### PR TITLE
[red-knot] Add diagnostic for class-object access to pure instance variables and class literal repr in diagnostics

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/annotated.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/annotated.md
@@ -77,8 +77,8 @@ from typing_extensions import Annotated
 # error: [invalid-base]
 class C(Annotated[int, "foo"]): ...
 
-# TODO: Should be `tuple[Literal[C], Literal[int], Literal[object]]`
-reveal_type(C.__mro__)  # revealed: tuple[Literal[C], Unknown, Literal[object]]
+# TODO: Should be `tuple[type[C], type[int], type[object]]`
+reveal_type(C.__mro__)  # revealed: tuple[type[C], Unknown, type[object]]
 ```
 
 ### Not parameterized
@@ -90,5 +90,5 @@ from typing_extensions import Annotated
 # error: [invalid-base]
 class C(Annotated): ...
 
-reveal_type(C.__mro__)  # revealed: tuple[Literal[C], Unknown, Literal[object]]
+reveal_type(C.__mro__)  # revealed: tuple[type[C], Unknown, type[object]]
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/any.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/any.md
@@ -60,7 +60,7 @@ from typing import Any
 
 class Subclass(Any): ...
 
-reveal_type(Subclass.__mro__)  # revealed: tuple[Literal[Subclass], Any, Literal[object]]
+reveal_type(Subclass.__mro__)  # revealed: tuple[type[Subclass], Any, type[object]]
 
 x: Subclass = 1  # error: [invalid-assignment]
 # TODO: no diagnostic

--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/stdlib_typing_aliases.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/stdlib_typing_aliases.md
@@ -71,25 +71,25 @@ import typing
 class ListSubclass(typing.List): ...
 
 # TODO: should have `Generic`, should not have `Unknown`
-# revealed: tuple[Literal[ListSubclass], Literal[list], Unknown, Literal[object]]
+# revealed: tuple[type[ListSubclass], type[list], Unknown, type[object]]
 reveal_type(ListSubclass.__mro__)
 
 class DictSubclass(typing.Dict): ...
 
 # TODO: should have `Generic`, should not have `Unknown`
-# revealed: tuple[Literal[DictSubclass], Literal[dict], Unknown, Literal[object]]
+# revealed: tuple[type[DictSubclass], type[dict], Unknown, type[object]]
 reveal_type(DictSubclass.__mro__)
 
 class SetSubclass(typing.Set): ...
 
 # TODO: should have `Generic`, should not have `Unknown`
-# revealed: tuple[Literal[SetSubclass], Literal[set], Unknown, Literal[object]]
+# revealed: tuple[type[SetSubclass], type[set], Unknown, type[object]]
 reveal_type(SetSubclass.__mro__)
 
 class FrozenSetSubclass(typing.FrozenSet): ...
 
 # TODO: should have `Generic`, should not have `Unknown`
-# revealed: tuple[Literal[FrozenSetSubclass], Literal[frozenset], Unknown, Literal[object]]
+# revealed: tuple[type[FrozenSetSubclass], type[frozenset], Unknown, type[object]]
 reveal_type(FrozenSetSubclass.__mro__)
 
 ####################
@@ -98,30 +98,30 @@ reveal_type(FrozenSetSubclass.__mro__)
 class ChainMapSubclass(typing.ChainMap): ...
 
 # TODO: Should be (ChainMapSubclass, ChainMap, MutableMapping, Mapping, Collection, Sized, Iterable, Container, Generic, object)
-# revealed: tuple[Literal[ChainMapSubclass], Literal[ChainMap], Unknown, Literal[object]]
+# revealed: tuple[type[ChainMapSubclass], type[ChainMap], Unknown, type[object]]
 reveal_type(ChainMapSubclass.__mro__)
 
 class CounterSubclass(typing.Counter): ...
 
 # TODO: Should be (CounterSubclass, Counter, dict, MutableMapping, Mapping, Collection, Sized, Iterable, Container, Generic, object)
-# revealed: tuple[Literal[CounterSubclass], Literal[Counter], Unknown, Literal[object]]
+# revealed: tuple[type[CounterSubclass], type[Counter], Unknown, type[object]]
 reveal_type(CounterSubclass.__mro__)
 
 class DefaultDictSubclass(typing.DefaultDict): ...
 
 # TODO: Should be (DefaultDictSubclass, defaultdict, dict, MutableMapping, Mapping, Collection, Sized, Iterable, Container, Generic, object)
-# revealed: tuple[Literal[DefaultDictSubclass], Literal[defaultdict], Unknown, Literal[object]]
+# revealed: tuple[type[DefaultDictSubclass], type[defaultdict], Unknown, type[object]]
 reveal_type(DefaultDictSubclass.__mro__)
 
 class DequeSubclass(typing.Deque): ...
 
 # TODO: Should be (DequeSubclass, deque, MutableSequence, Sequence, Reversible, Collection, Sized, Iterable, Container, Generic, object)
-# revealed: tuple[Literal[DequeSubclass], Literal[deque], Unknown, Literal[object]]
+# revealed: tuple[type[DequeSubclass], type[deque], Unknown, type[object]]
 reveal_type(DequeSubclass.__mro__)
 
 class OrderedDictSubclass(typing.OrderedDict): ...
 
 # TODO: Should be (OrderedDictSubclass, OrderedDict, dict, MutableMapping, Mapping, Collection, Sized, Iterable, Container, Generic, object)
-# revealed: tuple[Literal[OrderedDictSubclass], Literal[OrderedDict], Unknown, Literal[object]]
+# revealed: tuple[type[OrderedDictSubclass], type[OrderedDict], Unknown, type[object]]
 reveal_type(OrderedDictSubclass.__mro__)
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/string.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/string.md
@@ -116,8 +116,8 @@ MyType = int
 class Aliases:
     MyType = str
 
-    forward: "MyType"
-    not_forward: MyType
+    forward: "MyType" = "value"
+    not_forward: MyType = "value"
 
 reveal_type(Aliases.forward)  # revealed: str
 reveal_type(Aliases.not_forward)  # revealed: str

--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/unsupported_special_forms.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/unsupported_special_forms.md
@@ -51,7 +51,7 @@ class D(TypeIs): ...  # error: [invalid-base]
 class E(Concatenate): ...  # error: [invalid-base]
 class F(Callable): ...
 
-reveal_type(F.__mro__)  # revealed: tuple[Literal[F], @Todo(Support for Callable as a base class), Literal[object]]
+reveal_type(F.__mro__)  # revealed: tuple[type[F], @Todo(Support for Callable as a base class), type[object]]
 ```
 
 ## Subscriptability

--- a/crates/red_knot_python_semantic/resources/mdtest/attributes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/attributes.md
@@ -86,10 +86,8 @@ c_instance = C()
 
 reveal_type(c_instance.declared_and_bound)  # revealed: str | None
 
-# TODO: we currently plan to emit a diagnostic here. Note that both mypy
-# and pyright show no error in this case! So we may reconsider this in
-# the future, if it turns out to produce too many false positives.
-reveal_type(C.declared_and_bound)  # revealed: str | None
+# error: [unresolved-attribute] "Type `Literal[C]` has no attribute `declared_and_bound`"
+reveal_type(C.declared_and_bound)  # revealed: Unknown
 
 # TODO: same as above. We plan to emit a diagnostic here, even if both mypy
 # and pyright allow this.
@@ -112,9 +110,8 @@ c_instance = C()
 
 reveal_type(c_instance.only_declared)  # revealed: str
 
-# TODO: mypy and pyright do not show an error here, but we plan to emit a diagnostic.
-# The type could be changed to 'Unknown' if we decide to emit an error?
-reveal_type(C.only_declared)  # revealed: str
+# error: [unresolved-attribute] "Type `Literal[C]` has no attribute `only_declared`"
+reveal_type(C.only_declared)  # revealed: Unknown
 
 # TODO: mypy and pyright do not show an error here, but we plan to emit one.
 C.only_declared = "overwritten on class"

--- a/crates/red_knot_python_semantic/resources/mdtest/attributes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/attributes.md
@@ -52,7 +52,7 @@ c_instance.inferred_from_param = "incompatible"
 
 # TODO: we already show an error here but the message might be improved?
 # mypy shows no error here, but pyright raises "reportAttributeAccessIssue"
-# error: [unresolved-attribute] "Type `Literal[C]` has no attribute `inferred_from_value`"
+# error: [unresolved-attribute] "Type `type[C]` has no attribute `inferred_from_value`"
 reveal_type(C.inferred_from_value)  # revealed: Unknown
 
 # TODO: this should be an error (pure instance variables cannot be accessed on the class)
@@ -86,7 +86,7 @@ c_instance = C()
 
 reveal_type(c_instance.declared_and_bound)  # revealed: str | None
 
-# error: [unresolved-attribute] "Type `Literal[C]` has no attribute `declared_and_bound`"
+# error: [unresolved-attribute] "Type `type[C]` has no attribute `declared_and_bound`"
 reveal_type(C.declared_and_bound)  # revealed: Unknown
 
 # TODO: same as above. We plan to emit a diagnostic here, even if both mypy
@@ -110,7 +110,7 @@ c_instance = C()
 
 reveal_type(c_instance.only_declared)  # revealed: str
 
-# error: [unresolved-attribute] "Type `Literal[C]` has no attribute `only_declared`"
+# error: [unresolved-attribute] "Type `type[C]` has no attribute `only_declared`"
 reveal_type(C.only_declared)  # revealed: Unknown
 
 # TODO: mypy and pyright do not show an error here, but we plan to emit one.
@@ -749,7 +749,7 @@ class C(D, F): ...
 class B(E, D): ...
 class A(B, C): ...
 
-# revealed: tuple[Literal[A], Literal[B], Literal[E], Literal[C], Literal[D], Literal[F], Literal[O], Literal[object]]
+# revealed: tuple[type[A], type[B], type[E], type[C], type[D], type[F], type[O], type[object]]
 reveal_type(A.__mro__)
 
 # `E` is earlier in the MRO than `F`, so we should use the type of `E.X`
@@ -774,7 +774,7 @@ def _(flag1: bool, flag2: bool):
 
     C = C1 if flag1 else C2 if flag2 else C3
 
-    # error: [possibly-unbound-attribute] "Attribute `x` on type `Literal[C1, C2, C3]` is possibly unbound"
+    # error: [possibly-unbound-attribute] "Attribute `x` on type `types.UnionType[C1, C2, C3]` is possibly unbound"
     reveal_type(C.x)  # revealed: Unknown | Literal[1, 3]
 ```
 
@@ -797,7 +797,7 @@ def _(flag: bool, flag1: bool, flag2: bool):
 
     C = C1 if flag1 else C2 if flag2 else C3
 
-    # error: [possibly-unbound-attribute] "Attribute `x` on type `Literal[C1, C2, C3]` is possibly unbound"
+    # error: [possibly-unbound-attribute] "Attribute `x` on type `types.UnionType[C1, C2, C3]` is possibly unbound"
     reveal_type(C.x)  # revealed: Unknown | Literal[1, 2, 3]
 ```
 
@@ -811,7 +811,7 @@ def _(flag: bool):
     class C2: ...
     C = C1 if flag else C2
 
-    # error: [unresolved-attribute] "Type `Literal[C1, C2]` has no attribute `x`"
+    # error: [unresolved-attribute] "Type `types.UnionType[C1, C2]` has no attribute `x`"
     reveal_type(C.x)  # revealed: Unknown
 ```
 
@@ -820,39 +820,39 @@ def _(flag: bool):
 ```py
 import typing_extensions
 
-reveal_type(typing_extensions.__class__)  # revealed: Literal[ModuleType]
+reveal_type(typing_extensions.__class__)  # revealed: type[ModuleType]
 
 a = 42
-reveal_type(a.__class__)  # revealed: Literal[int]
+reveal_type(a.__class__)  # revealed: type[int]
 
 b = "42"
-reveal_type(b.__class__)  # revealed: Literal[str]
+reveal_type(b.__class__)  # revealed: type[str]
 
 c = b"42"
-reveal_type(c.__class__)  # revealed: Literal[bytes]
+reveal_type(c.__class__)  # revealed: type[bytes]
 
 d = True
-reveal_type(d.__class__)  # revealed: Literal[bool]
+reveal_type(d.__class__)  # revealed: type[bool]
 
 e = (42, 42)
-reveal_type(e.__class__)  # revealed: Literal[tuple]
+reveal_type(e.__class__)  # revealed: type[tuple]
 
 def f(a: int, b: typing_extensions.LiteralString, c: int | str, d: type[str]):
     reveal_type(a.__class__)  # revealed: type[int]
-    reveal_type(b.__class__)  # revealed: Literal[str]
+    reveal_type(b.__class__)  # revealed: type[str]
     reveal_type(c.__class__)  # revealed: type[int] | type[str]
 
     # `type[type]`, a.k.a., either the class `type` or some subclass of `type`.
-    # It would be incorrect to infer `Literal[type]` here,
+    # It would be incorrect to infer `type[type]` here,
     # as `c` could be some subclass of `str` with a custom metaclass.
     # All we know is that the metaclass must be a (non-strict) subclass of `type`.
     reveal_type(d.__class__)  # revealed: type[type]
 
-reveal_type(f.__class__)  # revealed: Literal[FunctionType]
+reveal_type(f.__class__)  # revealed: type[FunctionType]
 
 class Foo: ...
 
-reveal_type(Foo.__class__)  # revealed: Literal[type]
+reveal_type(Foo.__class__)  # revealed: type[type]
 ```
 
 ## Module attributes

--- a/crates/red_knot_python_semantic/resources/mdtest/binary/classes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/binary/classes.md
@@ -22,6 +22,6 @@ reveal_type(A | B)  # revealed: UnionType
 class A: ...
 class B: ...
 
-# error: "Operator `|` is unsupported between objects of type `Literal[A]` and `Literal[B]`"
+# error: "Operator `|` is unsupported between objects of type `type[A]` and `type[B]`"
 reveal_type(A | B)  # revealed: Unknown
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/binary/custom.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/binary/custom.md
@@ -307,11 +307,11 @@ class Yes:
 class Sub(Yes): ...
 class No: ...
 
-# error: [unsupported-operator] "Operator `+` is unsupported between objects of type `Literal[Yes]` and `Literal[Yes]`"
+# error: [unsupported-operator] "Operator `+` is unsupported between objects of type `type[Yes]` and `type[Yes]`"
 reveal_type(Yes + Yes)  # revealed: Unknown
-# error: [unsupported-operator] "Operator `+` is unsupported between objects of type `Literal[Sub]` and `Literal[Sub]`"
+# error: [unsupported-operator] "Operator `+` is unsupported between objects of type `type[Sub]` and `type[Sub]`"
 reveal_type(Sub + Sub)  # revealed: Unknown
-# error: [unsupported-operator] "Operator `+` is unsupported between objects of type `Literal[No]` and `Literal[No]`"
+# error: [unsupported-operator] "Operator `+` is unsupported between objects of type `type[No]` and `type[No]`"
 reveal_type(No + No)  # revealed: Unknown
 ```
 

--- a/crates/red_knot_python_semantic/resources/mdtest/exception/control_flow.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/exception/control_flow.md
@@ -569,12 +569,12 @@ except:
         reveal_type(x)  # revealed: range
 
     x = Bar
-    reveal_type(x)  # revealed: Literal[Bar]
+    reveal_type(x)  # revealed: type[Bar]
 finally:
-    # TODO: should be `Literal[1] | Literal[foo] | Literal[Bar]`
-    reveal_type(x)  # revealed: Literal[foo] | Literal[Bar]
+    # TODO: should be `Literal[1] | Literal[foo] | type[Bar]`
+    reveal_type(x)  # revealed: Literal[foo] | type[Bar]
 
-reveal_type(x)  # revealed: Literal[foo] | Literal[Bar]
+reveal_type(x)  # revealed: Literal[foo] | type[Bar]
 ```
 
 [1]: https://astral-sh.notion.site/Exception-handler-control-flow-11348797e1ca80bb8ce1e9aedbbe439d

--- a/crates/red_knot_python_semantic/resources/mdtest/expression/attribute.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/expression/attribute.md
@@ -26,9 +26,9 @@ def _(flag: bool):
 
     reveal_type(A.union_declared)  # revealed: int | str
 
-    # error: [possibly-unbound-attribute] "Attribute `possibly_unbound` on type `Literal[A]` is possibly unbound"
+    # error: [possibly-unbound-attribute] "Attribute `possibly_unbound` on type `type[A]` is possibly unbound"
     reveal_type(A.possibly_unbound)  # revealed: str
 
-    # error: [unresolved-attribute] "Type `Literal[A]` has no attribute `non_existent`"
+    # error: [unresolved-attribute] "Type `type[A]` has no attribute `non_existent`"
     reveal_type(A.non_existent)  # revealed: Unknown
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/generics.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/generics.md
@@ -57,7 +57,7 @@ class Seq[T]: ...
 # TODO not error on the subscripting
 class S[T](Seq[S]): ...  # error: [non-subscriptable]
 
-reveal_type(S)  # revealed: Literal[S]
+reveal_type(S)  # revealed: type[S]
 ```
 
 ## Type params

--- a/crates/red_knot_python_semantic/resources/mdtest/import/basic.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/import/basic.md
@@ -6,7 +6,7 @@
 from b import C as D
 
 E = D
-reveal_type(E)  # revealed: Literal[C]
+reveal_type(E)  # revealed: type[C]
 ```
 
 `b.py`:
@@ -21,7 +21,7 @@ class C: ...
 import b
 
 D = b.C
-reveal_type(D)  # revealed: Literal[C]
+reveal_type(D)  # revealed: type[C]
 ```
 
 `b.py`:
@@ -35,7 +35,7 @@ class C: ...
 ```py
 import a.b
 
-reveal_type(a.b.C)  # revealed: Literal[C]
+reveal_type(a.b.C)  # revealed: type[C]
 ```
 
 `a/__init__.py`:
@@ -54,7 +54,7 @@ class C: ...
 ```py
 import a.b.c
 
-reveal_type(a.b.c.C)  # revealed: Literal[C]
+reveal_type(a.b.c.C)  # revealed: type[C]
 ```
 
 `a/__init__.py`:
@@ -78,7 +78,7 @@ class C: ...
 ```py
 import a.b as b
 
-reveal_type(b.C)  # revealed: Literal[C]
+reveal_type(b.C)  # revealed: type[C]
 ```
 
 `a/__init__.py`:
@@ -97,7 +97,7 @@ class C: ...
 ```py
 import a.b.c as c
 
-reveal_type(c.C)  # revealed: Literal[C]
+reveal_type(c.C)  # revealed: type[C]
 ```
 
 `a/__init__.py`:

--- a/crates/red_knot_python_semantic/resources/mdtest/import/builtins.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/import/builtins.md
@@ -16,7 +16,7 @@ Or used implicitly:
 
 ```py
 reveal_type(chr)  # revealed: Literal[chr]
-reveal_type(str)  # revealed: Literal[str]
+reveal_type(str)  # revealed: type[str]
 ```
 
 ## Builtin symbol from custom typeshed

--- a/crates/red_knot_python_semantic/resources/mdtest/import/errors.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/import/errors.md
@@ -69,12 +69,12 @@ x = "foo"  # error: [invalid-assignment] "Object of type `Literal["foo"]"
 ```py
 class A: ...
 
-reveal_type(A.__mro__)  # revealed: tuple[Literal[A], Literal[object]]
+reveal_type(A.__mro__)  # revealed: tuple[type[A], type[object]]
 import b
 
 class C(b.B): ...
 
-reveal_type(C.__mro__)  # revealed: tuple[Literal[C], Literal[B], Literal[A], Literal[object]]
+reveal_type(C.__mro__)  # revealed: tuple[type[C], type[B], type[A], type[object]]
 ```
 
 `b.py`:
@@ -84,5 +84,5 @@ from a import A
 
 class B(A): ...
 
-reveal_type(B.__mro__)  # revealed: tuple[Literal[B], Literal[A], Literal[object]]
+reveal_type(B.__mro__)  # revealed: tuple[type[B], type[A], type[object]]
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/import/tracking.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/import/tracking.md
@@ -27,7 +27,7 @@ has been imported.
 import a
 
 # Would be an error with flow-sensitive tracking
-reveal_type(a.b.C)  # revealed: Literal[C]
+reveal_type(a.b.C)  # revealed: type[C]
 
 import a.b
 ```
@@ -53,10 +53,10 @@ submodule `b`, even though `a.b` is never imported in the main module.
 from q import a, b
 
 reveal_type(b)  # revealed: <module 'a.b'>
-reveal_type(b.C)  # revealed: Literal[C]
+reveal_type(b.C)  # revealed: type[C]
 
 reveal_type(a.b)  # revealed: <module 'a.b'>
-reveal_type(a.b.C)  # revealed: Literal[C]
+reveal_type(a.b.C)  # revealed: type[C]
 ```
 
 `a/__init__.py`:

--- a/crates/red_knot_python_semantic/resources/mdtest/intersection_types.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/intersection_types.md
@@ -429,7 +429,7 @@ def _(
     reveal_type(i07)  # revealed: Never
     reveal_type(i08)  # revealed: Never
 
-# `bool` is final and can not be subclassed, so `type[bool]` is equivalent to `Literal[bool]`, which
+# `bool` is final and can not be subclassed, so `type[bool]` is equivalent to `type[bool]`, which
 # is disjoint from `type[str]`:
 def example_type_bool_type_str(
     i: Intersection[type[bool], type[str]],

--- a/crates/red_knot_python_semantic/resources/mdtest/metaclass.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/metaclass.md
@@ -3,19 +3,19 @@
 ```py
 class M(type): ...
 
-reveal_type(M.__class__)  # revealed: Literal[type]
+reveal_type(M.__class__)  # revealed: type[type]
 ```
 
 ## `object`
 
 ```py
-reveal_type(object.__class__)  # revealed: Literal[type]
+reveal_type(object.__class__)  # revealed: type[type]
 ```
 
 ## `type`
 
 ```py
-reveal_type(type.__class__)  # revealed: Literal[type]
+reveal_type(type.__class__)  # revealed: type[type]
 ```
 
 ## Basic
@@ -24,7 +24,7 @@ reveal_type(type.__class__)  # revealed: Literal[type]
 class M(type): ...
 class B(metaclass=M): ...
 
-reveal_type(B.__class__)  # revealed: Literal[M]
+reveal_type(B.__class__)  # revealed: type[M]
 ```
 
 ## Invalid metaclass
@@ -37,7 +37,7 @@ class M: ...
 class A(metaclass=M): ...
 
 # TODO: emit a diagnostic for the invalid metaclass
-reveal_type(A.__class__)  # revealed: Literal[M]
+reveal_type(A.__class__)  # revealed: type[M]
 ```
 
 ## Linear inheritance
@@ -50,7 +50,7 @@ class M(type): ...
 class A(metaclass=M): ...
 class B(A): ...
 
-reveal_type(B.__class__)  # revealed: Literal[M]
+reveal_type(B.__class__)  # revealed: type[M]
 ```
 
 ## Conflict (1)
@@ -98,7 +98,7 @@ class A(metaclass=M): ...
 class B(metaclass=M): ...
 class C(A, B): ...
 
-reveal_type(C.__class__)  # revealed: Literal[M]
+reveal_type(C.__class__)  # revealed: type[M]
 ```
 
 ## Metaclass metaclass
@@ -112,7 +112,7 @@ class M3(M2): ...
 class A(metaclass=M3): ...
 class B(A): ...
 
-reveal_type(A.__class__)  # revealed: Literal[M3]
+reveal_type(A.__class__)  # revealed: type[M3]
 ```
 
 ## Diamond inheritance
@@ -140,14 +140,14 @@ from nonexistent_module import UnknownClass  # error: [unresolved-import]
 class C(UnknownClass): ...
 
 # TODO: should be `type[type] & Unknown`
-reveal_type(C.__class__)  # revealed: Literal[type]
+reveal_type(C.__class__)  # revealed: type[type]
 
 class M(type): ...
 class A(metaclass=M): ...
 class B(A, UnknownClass): ...
 
 # TODO: should be `type[M] & Unknown`
-reveal_type(B.__class__)  # revealed: Literal[M]
+reveal_type(B.__class__)  # revealed: type[M]
 ```
 
 ## Duplicate
@@ -157,7 +157,7 @@ class M(type): ...
 class A(metaclass=M): ...
 class B(A, A): ...  # error: [duplicate-base] "Duplicate base class `A`"
 
-reveal_type(B.__class__)  # revealed: Literal[M]
+reveal_type(B.__class__)  # revealed: type[M]
 ```
 
 ## Non-class
@@ -171,14 +171,14 @@ def f(*args, **kwargs) -> int: ...
 class A(metaclass=f): ...
 
 # TODO: Should be `int`
-reveal_type(A)  # revealed: Literal[A]
+reveal_type(A)  # revealed: type[A]
 reveal_type(A.__class__)  # revealed: type[int]
 
 def _(n: int):
     # error: [invalid-metaclass]
     class B(metaclass=n): ...
     # TODO: Should be `Unknown`
-    reveal_type(B)  # revealed: Literal[B]
+    reveal_type(B)  # revealed: type[B]
     reveal_type(B.__class__)  # revealed: type[Unknown]
 
 def _(flag: bool):
@@ -187,7 +187,7 @@ def _(flag: bool):
     # error: [invalid-metaclass]
     class C(metaclass=m): ...
     # TODO: Should be `int | Unknown`
-    reveal_type(C)  # revealed: Literal[C]
+    reveal_type(C)  # revealed: type[C]
     reveal_type(C.__class__)  # revealed: type[Unknown]
 
 class SignatureMismatch: ...
@@ -196,9 +196,9 @@ class SignatureMismatch: ...
 class D(metaclass=SignatureMismatch): ...
 
 # TODO: Should be `Unknown`
-reveal_type(D)  # revealed: Literal[D]
+reveal_type(D)  # revealed: type[D]
 # TODO: Should be `type[Unknown]`
-reveal_type(D.__class__)  # revealed: Literal[SignatureMismatch]
+reveal_type(D.__class__)  # revealed: type[SignatureMismatch]
 ```
 
 ## Cyclic
@@ -219,7 +219,7 @@ reveal_type(A.__class__)  # revealed: type[Unknown]
 class M(type): ...
 class A[T: str](metaclass=M): ...
 
-reveal_type(A.__class__)  # revealed: Literal[M]
+reveal_type(A.__class__)  # revealed: type[M]
 ```
 
 ## Metaclasses of metaclasses
@@ -230,9 +230,9 @@ class Bar(type, metaclass=Foo): ...
 class Baz(type, metaclass=Bar): ...
 class Spam(metaclass=Baz): ...
 
-reveal_type(Spam.__class__)  # revealed: Literal[Baz]
-reveal_type(Spam.__class__.__class__)  # revealed: Literal[Bar]
-reveal_type(Spam.__class__.__class__.__class__)  # revealed: Literal[Foo]
+reveal_type(Spam.__class__)  # revealed: type[Baz]
+reveal_type(Spam.__class__.__class__)  # revealed: type[Bar]
+reveal_type(Spam.__class__.__class__.__class__)  # revealed: type[Foo]
 
 def test(x: Spam):
     reveal_type(x.__class__)  # revealed: type[Spam]

--- a/crates/red_knot_python_semantic/resources/mdtest/mro.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/mro.md
@@ -16,13 +16,13 @@ For documentation on method resolution orders, see:
 ```py
 class C: ...
 
-reveal_type(C.__mro__)  # revealed: tuple[Literal[C], Literal[object]]
+reveal_type(C.__mro__)  # revealed: tuple[type[C], type[object]]
 ```
 
 ## The special case: `object` itself
 
 ```py
-reveal_type(object.__mro__)  # revealed: tuple[Literal[object]]
+reveal_type(object.__mro__)  # revealed: tuple[type[object]]
 ```
 
 ## Explicit inheritance from `object`
@@ -30,7 +30,7 @@ reveal_type(object.__mro__)  # revealed: tuple[Literal[object]]
 ```py
 class C(object): ...
 
-reveal_type(C.__mro__)  # revealed: tuple[Literal[C], Literal[object]]
+reveal_type(C.__mro__)  # revealed: tuple[type[C], type[object]]
 ```
 
 ## Explicit inheritance from non-`object` single base
@@ -39,7 +39,7 @@ reveal_type(C.__mro__)  # revealed: tuple[Literal[C], Literal[object]]
 class A: ...
 class B(A): ...
 
-reveal_type(B.__mro__)  # revealed: tuple[Literal[B], Literal[A], Literal[object]]
+reveal_type(B.__mro__)  # revealed: tuple[type[B], type[A], type[object]]
 ```
 
 ## Linearization of multiple bases
@@ -49,7 +49,7 @@ class A: ...
 class B: ...
 class C(A, B): ...
 
-reveal_type(C.__mro__)  # revealed: tuple[Literal[C], Literal[A], Literal[B], Literal[object]]
+reveal_type(C.__mro__)  # revealed: tuple[type[C], type[A], type[B], type[object]]
 ```
 
 ## Complex diamond inheritance (1)
@@ -63,8 +63,8 @@ class Y(O): ...
 class A(X, Y): ...
 class B(Y, X): ...
 
-reveal_type(A.__mro__)  # revealed: tuple[Literal[A], Literal[X], Literal[Y], Literal[O], Literal[object]]
-reveal_type(B.__mro__)  # revealed: tuple[Literal[B], Literal[Y], Literal[X], Literal[O], Literal[object]]
+reveal_type(A.__mro__)  # revealed: tuple[type[A], type[X], type[Y], type[O], type[object]]
+reveal_type(B.__mro__)  # revealed: tuple[type[B], type[Y], type[X], type[O], type[object]]
 ```
 
 ## Complex diamond inheritance (2)
@@ -80,11 +80,11 @@ class C(D, F): ...
 class B(D, E): ...
 class A(B, C): ...
 
-# revealed: tuple[Literal[C], Literal[D], Literal[F], Literal[O], Literal[object]]
+# revealed: tuple[type[C], type[D], type[F], type[O], type[object]]
 reveal_type(C.__mro__)
-# revealed: tuple[Literal[B], Literal[D], Literal[E], Literal[O], Literal[object]]
+# revealed: tuple[type[B], type[D], type[E], type[O], type[object]]
 reveal_type(B.__mro__)
-# revealed: tuple[Literal[A], Literal[B], Literal[C], Literal[D], Literal[E], Literal[F], Literal[O], Literal[object]]
+# revealed: tuple[type[A], type[B], type[C], type[D], type[E], type[F], type[O], type[object]]
 reveal_type(A.__mro__)
 ```
 
@@ -101,11 +101,11 @@ class C(D, F): ...
 class B(E, D): ...
 class A(B, C): ...
 
-# revealed: tuple[Literal[C], Literal[D], Literal[F], Literal[O], Literal[object]]
+# revealed: tuple[type[C], type[D], type[F], type[O], type[object]]
 reveal_type(C.__mro__)
-# revealed: tuple[Literal[B], Literal[E], Literal[D], Literal[O], Literal[object]]
+# revealed: tuple[type[B], type[E], type[D], type[O], type[object]]
 reveal_type(B.__mro__)
-# revealed: tuple[Literal[A], Literal[B], Literal[E], Literal[C], Literal[D], Literal[F], Literal[O], Literal[object]]
+# revealed: tuple[type[A], type[B], type[E], type[C], type[D], type[F], type[O], type[object]]
 reveal_type(A.__mro__)
 ```
 
@@ -125,13 +125,13 @@ class K2(D, B, E): ...
 class K3(D, A): ...
 class Z(K1, K2, K3): ...
 
-# revealed: tuple[Literal[K1], Literal[A], Literal[B], Literal[C], Literal[O], Literal[object]]
+# revealed: tuple[type[K1], type[A], type[B], type[C], type[O], type[object]]
 reveal_type(K1.__mro__)
-# revealed: tuple[Literal[K2], Literal[D], Literal[B], Literal[E], Literal[O], Literal[object]]
+# revealed: tuple[type[K2], type[D], type[B], type[E], type[O], type[object]]
 reveal_type(K2.__mro__)
-# revealed: tuple[Literal[K3], Literal[D], Literal[A], Literal[O], Literal[object]]
+# revealed: tuple[type[K3], type[D], type[A], type[O], type[object]]
 reveal_type(K3.__mro__)
-# revealed: tuple[Literal[Z], Literal[K1], Literal[K2], Literal[K3], Literal[D], Literal[A], Literal[B], Literal[C], Literal[E], Literal[O], Literal[object]]
+# revealed: tuple[type[Z], type[K1], type[K2], type[K3], type[D], type[A], type[B], type[C], type[E], type[O], type[object]]
 reveal_type(Z.__mro__)
 ```
 
@@ -147,10 +147,10 @@ class D(A, B, C): ...
 class E(B, C): ...
 class F(E, A): ...
 
-reveal_type(A.__mro__)  # revealed: tuple[Literal[A], Unknown, Literal[object]]
-reveal_type(D.__mro__)  # revealed: tuple[Literal[D], Literal[A], Unknown, Literal[B], Literal[C], Literal[object]]
-reveal_type(E.__mro__)  # revealed: tuple[Literal[E], Literal[B], Literal[C], Literal[object]]
-reveal_type(F.__mro__)  # revealed: tuple[Literal[F], Literal[E], Literal[B], Literal[C], Literal[A], Unknown, Literal[object]]
+reveal_type(A.__mro__)  # revealed: tuple[type[A], Unknown, type[object]]
+reveal_type(D.__mro__)  # revealed: tuple[type[D], type[A], Unknown, type[B], type[C], type[object]]
+reveal_type(E.__mro__)  # revealed: tuple[type[E], type[B], type[C], type[object]]
+reveal_type(F.__mro__)  # revealed: tuple[type[F], type[E], type[B], type[C], type[A], Unknown, type[object]]
 ```
 
 ## `__bases__` lists that cause errors at runtime
@@ -162,11 +162,11 @@ creation to fail, we infer the class's `__mro__` as being `[<class>, Unknown, ob
 # error: [inconsistent-mro] "Cannot create a consistent method resolution order (MRO) for class `Foo` with bases list `[<class 'object'>, <class 'int'>]`"
 class Foo(object, int): ...
 
-reveal_type(Foo.__mro__)  # revealed: tuple[Literal[Foo], Unknown, Literal[object]]
+reveal_type(Foo.__mro__)  # revealed: tuple[type[Foo], Unknown, type[object]]
 
 class Bar(Foo): ...
 
-reveal_type(Bar.__mro__)  # revealed: tuple[Literal[Bar], Literal[Foo], Unknown, Literal[object]]
+reveal_type(Bar.__mro__)  # revealed: tuple[type[Bar], type[Foo], Unknown, type[object]]
 
 # This is the `TypeError` at the bottom of "ex_2"
 # in the examples at <https://docs.python.org/3/howto/mro.html#the-end>
@@ -176,17 +176,17 @@ class Y(O): ...
 class A(X, Y): ...
 class B(Y, X): ...
 
-reveal_type(A.__mro__)  # revealed: tuple[Literal[A], Literal[X], Literal[Y], Literal[O], Literal[object]]
-reveal_type(B.__mro__)  # revealed: tuple[Literal[B], Literal[Y], Literal[X], Literal[O], Literal[object]]
+reveal_type(A.__mro__)  # revealed: tuple[type[A], type[X], type[Y], type[O], type[object]]
+reveal_type(B.__mro__)  # revealed: tuple[type[B], type[Y], type[X], type[O], type[object]]
 
 # error: [inconsistent-mro] "Cannot create a consistent method resolution order (MRO) for class `Z` with bases list `[<class 'A'>, <class 'B'>]`"
 class Z(A, B): ...
 
-reveal_type(Z.__mro__)  # revealed: tuple[Literal[Z], Unknown, Literal[object]]
+reveal_type(Z.__mro__)  # revealed: tuple[type[Z], Unknown, type[object]]
 
 class AA(Z): ...
 
-reveal_type(AA.__mro__)  # revealed: tuple[Literal[AA], Literal[Z], Unknown, Literal[object]]
+reveal_type(AA.__mro__)  # revealed: tuple[type[AA], type[Z], Unknown, type[object]]
 ```
 
 ## `__bases__` includes a `Union`
@@ -207,12 +207,12 @@ if returns_bool():
 else:
     x = B
 
-reveal_type(x)  # revealed: Literal[A, B]
+reveal_type(x)  # revealed: types.UnionType[A, B]
 
-# error: 11 [invalid-base] "Invalid class base with type `Literal[A, B]` (all bases must be a class, `Any`, `Unknown` or `Todo`)"
+# error: 11 [invalid-base] "Invalid class base with type `types.UnionType[A, B]` (all bases must be a class, `Any`, `Unknown` or `Todo`)"
 class Foo(x): ...
 
-reveal_type(Foo.__mro__)  # revealed: tuple[Literal[Foo], Unknown, Literal[object]]
+reveal_type(Foo.__mro__)  # revealed: tuple[type[Foo], Unknown, type[object]]
 ```
 
 ## `__bases__` includes multiple `Union`s
@@ -236,14 +236,14 @@ if returns_bool():
 else:
     y = D
 
-reveal_type(x)  # revealed: Literal[A, B]
-reveal_type(y)  # revealed: Literal[C, D]
+reveal_type(x)  # revealed: types.UnionType[A, B]
+reveal_type(y)  # revealed: types.UnionType[C, D]
 
-# error: 11 [invalid-base] "Invalid class base with type `Literal[A, B]` (all bases must be a class, `Any`, `Unknown` or `Todo`)"
-# error: 14 [invalid-base] "Invalid class base with type `Literal[C, D]` (all bases must be a class, `Any`, `Unknown` or `Todo`)"
+# error: 11 [invalid-base] "Invalid class base with type `types.UnionType[A, B]` (all bases must be a class, `Any`, `Unknown` or `Todo`)"
+# error: 14 [invalid-base] "Invalid class base with type `types.UnionType[C, D]` (all bases must be a class, `Any`, `Unknown` or `Todo`)"
 class Foo(x, y): ...
 
-reveal_type(Foo.__mro__)  # revealed: tuple[Literal[Foo], Unknown, Literal[object]]
+reveal_type(Foo.__mro__)  # revealed: tuple[type[Foo], Unknown, type[object]]
 ```
 
 ## `__bases__` lists that cause errors... now with `Union`s
@@ -261,14 +261,14 @@ if returns_bool():
 else:
     foo = object
 
-# error: 21 [invalid-base] "Invalid class base with type `Literal[Y, object]` (all bases must be a class, `Any`, `Unknown` or `Todo`)"
+# error: 21 [invalid-base] "Invalid class base with type `types.UnionType[Y, object]` (all bases must be a class, `Any`, `Unknown` or `Todo`)"
 class PossibleError(foo, X): ...
 
-reveal_type(PossibleError.__mro__)  # revealed: tuple[Literal[PossibleError], Unknown, Literal[object]]
+reveal_type(PossibleError.__mro__)  # revealed: tuple[type[PossibleError], Unknown, type[object]]
 
 class A(X, Y): ...
 
-reveal_type(A.__mro__)  # revealed: tuple[Literal[A], Literal[X], Literal[Y], Literal[O], Literal[object]]
+reveal_type(A.__mro__)  # revealed: tuple[type[A], type[X], type[Y], type[O], type[object]]
 
 if returns_bool():
     class B(X, Y): ...
@@ -276,13 +276,13 @@ if returns_bool():
 else:
     class B(Y, X): ...
 
-# revealed: tuple[Literal[B], Literal[X], Literal[Y], Literal[O], Literal[object]] | tuple[Literal[B], Literal[Y], Literal[X], Literal[O], Literal[object]]
+# revealed: tuple[type[B], type[X], type[Y], type[O], type[object]] | tuple[type[B], type[Y], type[X], type[O], type[object]]
 reveal_type(B.__mro__)
 
-# error: 12 [invalid-base] "Invalid class base with type `Literal[B, B]` (all bases must be a class, `Any`, `Unknown` or `Todo`)"
+# error: 12 [invalid-base] "Invalid class base with type `types.UnionType[B, B]` (all bases must be a class, `Any`, `Unknown` or `Todo`)"
 class Z(A, B): ...
 
-reveal_type(Z.__mro__)  # revealed: tuple[Literal[Z], Unknown, Literal[object]]
+reveal_type(Z.__mro__)  # revealed: tuple[type[Z], Unknown, type[object]]
 ```
 
 ## `__bases__` lists with duplicate bases
@@ -290,7 +290,7 @@ reveal_type(Z.__mro__)  # revealed: tuple[Literal[Z], Unknown, Literal[object]]
 ```py
 class Foo(str, str): ...  # error: 16 [duplicate-base] "Duplicate base class `str`"
 
-reveal_type(Foo.__mro__)  # revealed: tuple[Literal[Foo], Unknown, Literal[object]]
+reveal_type(Foo.__mro__)  # revealed: tuple[type[Foo], Unknown, type[object]]
 
 class Spam: ...
 class Eggs: ...
@@ -301,12 +301,12 @@ class Ham(
     Eggs,  # error: [duplicate-base] "Duplicate base class `Eggs`"
 ): ...
 
-reveal_type(Ham.__mro__)  # revealed: tuple[Literal[Ham], Unknown, Literal[object]]
+reveal_type(Ham.__mro__)  # revealed: tuple[type[Ham], Unknown, type[object]]
 
 class Mushrooms: ...
 class Omelette(Spam, Eggs, Mushrooms, Mushrooms): ...  # error: [duplicate-base]
 
-reveal_type(Omelette.__mro__)  # revealed: tuple[Literal[Omelette], Unknown, Literal[object]]
+reveal_type(Omelette.__mro__)  # revealed: tuple[type[Omelette], Unknown, type[object]]
 ```
 
 ## `__bases__` lists with duplicate `Unknown` bases
@@ -331,7 +331,7 @@ reveal_type(unknown_object_2)  # revealed: Unknown
 # error: [inconsistent-mro] "Cannot create a consistent method resolution order (MRO) for class `Foo` with bases list `[Unknown, Unknown]`"
 class Foo(unknown_object_1, unknown_object_2): ...
 
-reveal_type(Foo.__mro__)  # revealed: tuple[Literal[Foo], Unknown, Literal[object]]
+reveal_type(Foo.__mro__)  # revealed: tuple[type[Foo], Unknown, type[object]]
 ```
 
 ## Unrelated objects inferred as `Any`/`Unknown` do not have special `__mro__` attributes
@@ -350,15 +350,15 @@ These are invalid, but we need to be able to handle them gracefully without pani
 ```pyi
 class Foo(Foo): ...  # error: [cyclic-class-definition]
 
-reveal_type(Foo)  # revealed: Literal[Foo]
-reveal_type(Foo.__mro__)  # revealed: tuple[Literal[Foo], Unknown, Literal[object]]
+reveal_type(Foo)  # revealed: type[Foo]
+reveal_type(Foo.__mro__)  # revealed: tuple[type[Foo], Unknown, type[object]]
 
 class Bar: ...
 class Baz: ...
 class Boz(Bar, Baz, Boz): ...  # error: [cyclic-class-definition]
 
-reveal_type(Boz)  # revealed: Literal[Boz]
-reveal_type(Boz.__mro__)  # revealed: tuple[Literal[Boz], Unknown, Literal[object]]
+reveal_type(Boz)  # revealed: type[Boz]
+reveal_type(Boz.__mro__)  # revealed: tuple[type[Boz], Unknown, type[object]]
 ```
 
 ## Classes with indirect cycles in their MROs
@@ -370,9 +370,9 @@ class Foo(Bar): ...  # error: [cyclic-class-definition]
 class Bar(Baz): ...  # error: [cyclic-class-definition]
 class Baz(Foo): ...  # error: [cyclic-class-definition]
 
-reveal_type(Foo.__mro__)  # revealed: tuple[Literal[Foo], Unknown, Literal[object]]
-reveal_type(Bar.__mro__)  # revealed: tuple[Literal[Bar], Unknown, Literal[object]]
-reveal_type(Baz.__mro__)  # revealed: tuple[Literal[Baz], Unknown, Literal[object]]
+reveal_type(Foo.__mro__)  # revealed: tuple[type[Foo], Unknown, type[object]]
+reveal_type(Bar.__mro__)  # revealed: tuple[type[Bar], Unknown, type[object]]
+reveal_type(Baz.__mro__)  # revealed: tuple[type[Baz], Unknown, type[object]]
 ```
 
 ## Classes with cycles in their MROs, and multiple inheritance
@@ -383,9 +383,9 @@ class Foo(Bar): ...  # error: [cyclic-class-definition]
 class Bar(Baz): ...  # error: [cyclic-class-definition]
 class Baz(Foo, Spam): ...  # error: [cyclic-class-definition]
 
-reveal_type(Foo.__mro__)  # revealed: tuple[Literal[Foo], Unknown, Literal[object]]
-reveal_type(Bar.__mro__)  # revealed: tuple[Literal[Bar], Unknown, Literal[object]]
-reveal_type(Baz.__mro__)  # revealed: tuple[Literal[Baz], Unknown, Literal[object]]
+reveal_type(Foo.__mro__)  # revealed: tuple[type[Foo], Unknown, type[object]]
+reveal_type(Bar.__mro__)  # revealed: tuple[type[Bar], Unknown, type[object]]
+reveal_type(Baz.__mro__)  # revealed: tuple[type[Baz], Unknown, type[object]]
 ```
 
 ## Classes with cycles in their MRO, and a sub-graph
@@ -401,8 +401,8 @@ class Bar(Foo): ...
 class Baz(Bar, BarCycle): ...
 class Spam(Baz): ...
 
-reveal_type(FooCycle.__mro__)  # revealed: tuple[Literal[FooCycle], Unknown, Literal[object]]
-reveal_type(BarCycle.__mro__)  # revealed: tuple[Literal[BarCycle], Unknown, Literal[object]]
-reveal_type(Baz.__mro__)  # revealed: tuple[Literal[Baz], Unknown, Literal[object]]
-reveal_type(Spam.__mro__)  # revealed: tuple[Literal[Spam], Unknown, Literal[object]]
+reveal_type(FooCycle.__mro__)  # revealed: tuple[type[FooCycle], Unknown, type[object]]
+reveal_type(BarCycle.__mro__)  # revealed: tuple[type[BarCycle], Unknown, type[object]]
+reveal_type(Baz.__mro__)  # revealed: tuple[type[Baz], Unknown, type[object]]
+reveal_type(Spam.__mro__)  # revealed: tuple[type[Spam], Unknown, type[object]]
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals/not_eq.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals/not_eq.md
@@ -45,10 +45,10 @@ def _(flag: bool):
     C = A if flag else B
 
     if C != A:
-        reveal_type(C)  # revealed: Literal[B]
+        reveal_type(C)  # revealed: type[B]
     else:
-        # TODO should be Literal[A]
-        reveal_type(C)  # revealed: Literal[A, B]
+        # TODO should be type[A]
+        reveal_type(C)  # revealed: types.UnionType[A, B]
 ```
 
 ## `x != y` where `y` has multiple single-valued options

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/truthiness.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/truthiness.md
@@ -108,12 +108,12 @@ def flag() -> bool:
     return True
 
 x = int if flag() else str
-reveal_type(x)  # revealed: Literal[int, str]
+reveal_type(x)  # revealed: types.UnionType[int, str]
 
 if x:
-    reveal_type(x)  # revealed: Literal[int] & ~AlwaysFalsy | Literal[str] & ~AlwaysFalsy
+    reveal_type(x)  # revealed: type[int] & ~AlwaysFalsy | type[str] & ~AlwaysFalsy
 else:
-    reveal_type(x)  # revealed: Literal[int] & ~AlwaysTruthy | Literal[str] & ~AlwaysTruthy
+    reveal_type(x)  # revealed: type[int] & ~AlwaysTruthy | type[str] & ~AlwaysTruthy
 ```
 
 ## Determined Truthiness
@@ -272,12 +272,12 @@ def _(
         reveal_type(d)  # revealed: type[DeferredClass] & ~AlwaysFalsy
 
     tf = TruthyClass if flag else FalsyClass
-    reveal_type(tf)  # revealed: Literal[TruthyClass, FalsyClass]
+    reveal_type(tf)  # revealed: types.UnionType[TruthyClass, FalsyClass]
 
     if tf:
-        reveal_type(tf)  # revealed: Literal[TruthyClass]
+        reveal_type(tf)  # revealed: type[TruthyClass]
     else:
-        reveal_type(tf)  # revealed: Literal[FalsyClass]
+        reveal_type(tf)  # revealed: type[FalsyClass]
 ```
 
 ## Narrowing in chained boolean expressions

--- a/crates/red_knot_python_semantic/resources/mdtest/scopes/moduletype_attrs.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/scopes/moduletype_attrs.md
@@ -59,7 +59,7 @@ reveal_type(typing.__init__)  # revealed: @Todo(bound method)
 # These come from `builtins.object`, not `types.ModuleType`:
 reveal_type(typing.__eq__)  # revealed: @Todo(bound method)
 
-reveal_type(typing.__class__)  # revealed: Literal[ModuleType]
+reveal_type(typing.__class__)  # revealed: type[ModuleType]
 
 # TODO: needs support for attribute access on instances, properties and generics;
 # should be `dict[str, Any]`

--- a/crates/red_knot_python_semantic/resources/mdtest/scopes/unbound.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/scopes/unbound.md
@@ -16,7 +16,7 @@ class C:
     if flag:
         x = 2
 
-# error: [possibly-unbound-attribute] "Attribute `x` on type `Literal[C]` is possibly unbound"
+# error: [possibly-unbound-attribute] "Attribute `x` on type `type[C]` is possibly unbound"
 reveal_type(C.x)  # revealed: Unknown | Literal[2]
 reveal_type(C.y)  # revealed: Unknown | Literal[1]
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/stubs/class.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/stubs/class.md
@@ -12,6 +12,6 @@ class Foo[T]: ...
 # error: [non-subscriptable]
 class Bar(Foo[Bar]): ...
 
-reveal_type(Bar)  # revealed: Literal[Bar]
-reveal_type(Bar.__mro__)  # revealed: tuple[Literal[Bar], Unknown, Literal[object]]
+reveal_type(Bar)  # revealed: type[Bar]
+reveal_type(Bar.__mro__)  # revealed: tuple[type[Bar], Unknown, type[object]]
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/subscript/class.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/subscript/class.md
@@ -5,7 +5,7 @@
 ```py
 class NotSubscriptable: ...
 
-a = NotSubscriptable[0]  # error: "Cannot subscript object of type `Literal[NotSubscriptable]` with no `__class_getitem__` method"
+a = NotSubscriptable[0]  # error: "Cannot subscript object of type `type[NotSubscriptable]` with no `__class_getitem__` method"
 ```
 
 ## Class getitem
@@ -47,7 +47,7 @@ def _(flag: bool):
 
     x = A if flag else B
 
-    reveal_type(x)  # revealed: Literal[A, B]
+    reveal_type(x)  # revealed: types.UnionType[A, B]
     reveal_type(x[0])  # revealed: str | int
 ```
 
@@ -62,7 +62,7 @@ def _(flag: bool):
 
     else:
         class Spam: ...
-    # error: [call-possibly-unbound-method] "Method `__class_getitem__` of type `Literal[Spam, Spam]` is possibly unbound"
+    # error: [call-possibly-unbound-method] "Method `__class_getitem__` of type `types.UnionType[Spam, Spam]` is possibly unbound"
     # revealed: str
     reveal_type(Spam[42])
 ```
@@ -79,7 +79,7 @@ def _(flag: bool):
     else:
         Eggs = 1
 
-    a = Eggs[42]  # error: "Cannot subscript object of type `Literal[Eggs] | Literal[1]` with no `__getitem__` method"
+    a = Eggs[42]  # error: "Cannot subscript object of type `type[Eggs] | Literal[1]` with no `__getitem__` method"
 
     # TODO: should _probably_ emit `str | Unknown`
     reveal_type(a)  # revealed: Unknown

--- a/crates/red_knot_python_semantic/resources/mdtest/subscript/tuple.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/subscript/tuple.md
@@ -87,7 +87,7 @@ class A(tuple[int, str]): ...
 
 # Runtime value: `(A, tuple, object)`
 # TODO: Generics
-reveal_type(A.__mro__)  # revealed: tuple[Literal[A], Unknown, Literal[object]]
+reveal_type(A.__mro__)  # revealed: tuple[type[A], Unknown, type[object]]
 ```
 
 ## `typing.Tuple`
@@ -119,5 +119,5 @@ class C(Tuple): ...
 
 # Runtime value: `(C, tuple, typing.Generic, object)`
 # TODO: Add `Generic` to the MRO
-reveal_type(C.__mro__)  # revealed: tuple[Literal[C], Literal[tuple], Unknown, Literal[object]]
+reveal_type(C.__mro__)  # revealed: tuple[type[C], type[tuple], Unknown, type[object]]
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/type_api.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_api.md
@@ -91,7 +91,7 @@ def explicit_unknown(x: Unknown, y: tuple[str, Unknown], z: Unknown = 1) -> None
 ```py
 class C(Unknown): ...
 
-# revealed: tuple[Literal[C], Unknown, Literal[object]]
+# revealed: tuple[type[C], Unknown, type[object]]
 reveal_type(C.__mro__)
 
 # error: "Special form `knot_extensions.Unknown` expected no type parameter"

--- a/crates/red_knot_python_semantic/resources/mdtest/type_of/basic.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_of/basic.md
@@ -149,8 +149,8 @@ _: type[A, B]
 # error: [invalid-base] "Invalid class base with type `GenericAlias` (all bases must be a class, `Any`, `Unknown` or `Todo`)"
 class Foo(type[int]): ...
 
-# TODO: should be `tuple[Literal[Foo], Literal[type], Literal[object]]
-reveal_type(Foo.__mro__)  # revealed: tuple[Literal[Foo], Unknown, Literal[object]]
+# TODO: should be `tuple[type[Foo], type[type], type[object]]
+reveal_type(Foo.__mro__)  # revealed: tuple[type[Foo], Unknown, type[object]]
 ```
 
 ## `@final` classes
@@ -171,6 +171,6 @@ from typing import final
 class Foo: ...
 
 def _(x: type[Foo], y: type[EllipsisType]):
-    reveal_type(x)  # revealed: Literal[Foo]
-    reveal_type(y)  # revealed: Literal[EllipsisType]
+    reveal_type(x)  # revealed: type[Foo]
+    reveal_type(y)  # revealed: type[EllipsisType]
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/type_of/typing_dot_Type.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_of/typing_dot_Type.md
@@ -28,5 +28,5 @@ class C(Type): ...
 
 # Runtime value: `(C, type, typing.Generic, object)`
 # TODO: Add `Generic` to the MRO
-reveal_type(C.__mro__)  # revealed: tuple[Literal[C], Literal[type], Literal[object]]
+reveal_type(C.__mro__)  # revealed: tuple[type[C], type[type], type[object]]
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/unary/custom.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/unary/custom.md
@@ -52,25 +52,25 @@ class Yes:
 class Sub(Yes): ...
 class No: ...
 
-# error: [unsupported-operator] "Unary operator `+` is unsupported for type `Literal[Yes]`"
+# error: [unsupported-operator] "Unary operator `+` is unsupported for type `type[Yes]`"
 reveal_type(+Yes)  # revealed: Unknown
-# error: [unsupported-operator] "Unary operator `-` is unsupported for type `Literal[Yes]`"
+# error: [unsupported-operator] "Unary operator `-` is unsupported for type `type[Yes]`"
 reveal_type(-Yes)  # revealed: Unknown
-# error: [unsupported-operator] "Unary operator `~` is unsupported for type `Literal[Yes]`"
+# error: [unsupported-operator] "Unary operator `~` is unsupported for type `type[Yes]`"
 reveal_type(~Yes)  # revealed: Unknown
 
-# error: [unsupported-operator] "Unary operator `+` is unsupported for type `Literal[Sub]`"
+# error: [unsupported-operator] "Unary operator `+` is unsupported for type `type[Sub]`"
 reveal_type(+Sub)  # revealed: Unknown
-# error: [unsupported-operator] "Unary operator `-` is unsupported for type `Literal[Sub]`"
+# error: [unsupported-operator] "Unary operator `-` is unsupported for type `type[Sub]`"
 reveal_type(-Sub)  # revealed: Unknown
-# error: [unsupported-operator] "Unary operator `~` is unsupported for type `Literal[Sub]`"
+# error: [unsupported-operator] "Unary operator `~` is unsupported for type `type[Sub]`"
 reveal_type(~Sub)  # revealed: Unknown
 
-# error: [unsupported-operator] "Unary operator `+` is unsupported for type `Literal[No]`"
+# error: [unsupported-operator] "Unary operator `+` is unsupported for type `type[No]`"
 reveal_type(+No)  # revealed: Unknown
-# error: [unsupported-operator] "Unary operator `-` is unsupported for type `Literal[No]`"
+# error: [unsupported-operator] "Unary operator `-` is unsupported for type `type[No]`"
 reveal_type(-No)  # revealed: Unknown
-# error: [unsupported-operator] "Unary operator `~` is unsupported for type `Literal[No]`"
+# error: [unsupported-operator] "Unary operator `~` is unsupported for type `type[No]`"
 reveal_type(~No)  # revealed: Unknown
 ```
 
@@ -160,10 +160,10 @@ reveal_type(+Sub)  # revealed: bool
 reveal_type(-Sub)  # revealed: str
 reveal_type(~Sub)  # revealed: int
 
-# error: [unsupported-operator] "Unary operator `+` is unsupported for type `Literal[No]`"
+# error: [unsupported-operator] "Unary operator `+` is unsupported for type `type[No]`"
 reveal_type(+No)  # revealed: Unknown
-# error: [unsupported-operator] "Unary operator `-` is unsupported for type `Literal[No]`"
+# error: [unsupported-operator] "Unary operator `-` is unsupported for type `type[No]`"
 reveal_type(-No)  # revealed: Unknown
-# error: [unsupported-operator] "Unary operator `~` is unsupported for type `Literal[No]`"
+# error: [unsupported-operator] "Unary operator `~` is unsupported for type `type[No]`"
 reveal_type(~No)  # revealed: Unknown
 ```

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -4140,8 +4140,18 @@ impl<'db> Class<'db> {
     /// directly. Use [`Class::class_member`] if you require a method that will
     /// traverse through the MRO until it finds the member.
     pub(crate) fn own_class_member(self, db: &'db dyn Db, name: &str) -> Symbol<'db> {
-        let scope = self.body_scope(db);
-        symbol(db, scope, name)
+        let body_scope = self.body_scope(db);
+        let table = symbol_table(db, body_scope);
+
+        if let Some(sym) = table.symbol_by_name(name) {
+            if !sym.is_bound() {
+                return Symbol::Unbound;
+            }
+
+            symbol(db, body_scope, name)
+        } else {
+            Symbol::Unbound
+        }
     }
 
     /// Returns the `name` attribute of an instance of this class.


### PR DESCRIPTION
## Summary

This is at best a band-aid solution for #15963 . See my first comment below for discussion.

As of time of writing:

* Fixes unbound class attribute access. Doesn't return a bound symbol anymore and thus causes a `[unresolved-attribute]` diagnostic
* Intentionally as a separate commit:
  * Changes`Type::ClassLiteral` representation to `type[ClassName]` matching mypy (this was already the case for `Type::SubclassOf`)
  * Changes representation of a union of 2+ types to `types.UnionType[TypeOne, TypeTwo, ...]` also matching mypy

I didn't not add a separate new lint, despite the issue description. I am not sure why `[unresolved-attribute]` is not appropriate. Unbound attributes indeed do not exist at runtime, so the language seems perfectly appropriate.

## Test Plan

cargo nextest run -p red_knot_python_semantic --no-fail-fast
