### PR TITLE
Directly include `Settings` struct for the server

### DIFF
--- a/crates/ruff_server/src/fix.rs
+++ b/crates/ruff_server/src/fix.rs
@@ -27,15 +27,14 @@ pub(crate) fn fix_all(
     encoding: PositionEncoding,
 ) -> crate::Result<Fixes> {
     let source_kind = query.make_source_kind();
-
-    let file_resolver_settings = query.settings().file_resolver();
+    let settings = query.settings();
     let document_path = query.file_path();
 
     // If the document is excluded, return an empty list of fixes.
     let package = if let Some(document_path) = document_path.as_ref() {
         if is_document_excluded_for_linting(
             document_path,
-            file_resolver_settings,
+            &settings.file_resolver,
             linter_settings,
             query.text_document_language_id(),
         ) {
@@ -71,7 +70,7 @@ pub(crate) fn fix_all(
         &query.virtual_file_path(),
         package,
         flags::Noqa::Enabled,
-        query.settings().unsafe_fixes(),
+        settings.unsafe_fixes,
         linter_settings,
         &source_kind,
         source_type,

--- a/crates/ruff_server/src/lint.rs
+++ b/crates/ruff_server/src/lint.rs
@@ -67,16 +67,15 @@ pub(crate) fn check(
     show_syntax_errors: bool,
 ) -> DiagnosticsMap {
     let source_kind = query.make_source_kind();
-    let file_resolver_settings = query.settings().file_resolver();
-    let linter_settings = query.settings().linter();
+    let settings = query.settings();
     let document_path = query.file_path();
 
     // If the document is excluded, return an empty list of diagnostics.
     let package = if let Some(document_path) = document_path.as_ref() {
         if is_document_excluded_for_linting(
             document_path,
-            file_resolver_settings,
-            linter_settings,
+            &settings.file_resolver,
+            &settings.linter,
             query.text_document_language_id(),
         ) {
             return DiagnosticsMap::default();
@@ -86,7 +85,7 @@ pub(crate) fn check(
             document_path
                 .parent()
                 .expect("a path to a document should have a parent path"),
-            &linter_settings.namespace_packages,
+            &settings.linter.namespace_packages,
         )
         .map(PackageRoot::root)
     } else {
@@ -118,7 +117,7 @@ pub(crate) fn check(
         &stylist,
         &indexer,
         &directives,
-        linter_settings,
+        &settings.linter,
         flags::Noqa::Enabled,
         &source_kind,
         source_type,
@@ -130,7 +129,7 @@ pub(crate) fn check(
         &diagnostics,
         &locator,
         indexer.comment_ranges(),
-        &linter_settings.external,
+        &settings.linter.external,
         &directives.noqa_line_for,
         stylist.line_ending(),
     );

--- a/crates/ruff_server/src/server/api/requests/code_action_resolve.rs
+++ b/crates/ruff_server/src/server/api/requests/code_action_resolve.rs
@@ -93,7 +93,7 @@ pub(super) fn fix_all_edit(
     query: &DocumentQuery,
     encoding: PositionEncoding,
 ) -> crate::Result<Fixes> {
-    crate::fix::fix_all(query, query.settings().linter(), encoding)
+    crate::fix::fix_all(query, &query.settings().linter, encoding)
 }
 
 pub(super) fn resolve_edit_for_organize_imports(
@@ -110,7 +110,7 @@ pub(super) fn organize_imports_edit(
     query: &DocumentQuery,
     encoding: PositionEncoding,
 ) -> crate::Result<Fixes> {
-    let mut linter_settings = query.settings().linter().clone();
+    let mut linter_settings = query.settings().linter.clone();
     linter_settings.rules = [
         Rule::UnsortedImports,       // I001
         Rule::MissingRequiredImport, // I002

--- a/crates/ruff_server/src/server/api/requests/format.rs
+++ b/crates/ruff_server/src/server/api/requests/format.rs
@@ -82,15 +82,14 @@ fn format_text_document(
     encoding: PositionEncoding,
     is_notebook: bool,
 ) -> Result<super::FormatResponse> {
-    let file_resolver_settings = query.settings().file_resolver();
-    let formatter_settings = query.settings().formatter();
+    let settings = query.settings();
 
     // If the document is excluded, return early.
     if let Some(file_path) = query.file_path() {
         if is_document_excluded_for_formatting(
             &file_path,
-            file_resolver_settings,
-            formatter_settings,
+            &settings.file_resolver,
+            &settings.formatter,
             text_document.language_id(),
         ) {
             return Ok(None);
@@ -98,7 +97,7 @@ fn format_text_document(
     }
 
     let source = text_document.contents();
-    let formatted = crate::format::format(text_document, query.source_type(), formatter_settings)
+    let formatted = crate::format::format(text_document, query.source_type(), &settings.formatter)
         .with_failure_code(lsp_server::ErrorCode::InternalError)?;
     let Some(mut formatted) = formatted else {
         return Ok(None);

--- a/crates/ruff_server/src/server/api/requests/format_range.rs
+++ b/crates/ruff_server/src/server/api/requests/format_range.rs
@@ -46,15 +46,14 @@ fn format_text_document_range(
     query: &DocumentQuery,
     encoding: PositionEncoding,
 ) -> Result<super::FormatResponse> {
-    let file_resolver_settings = query.settings().file_resolver();
-    let formatter_settings = query.settings().formatter();
+    let settings = query.settings();
 
     // If the document is excluded, return early.
     if let Some(file_path) = query.file_path() {
         if is_document_excluded_for_formatting(
             &file_path,
-            file_resolver_settings,
-            formatter_settings,
+            &settings.file_resolver,
+            &settings.formatter,
             text_document.language_id(),
         ) {
             return Ok(None);
@@ -67,7 +66,7 @@ fn format_text_document_range(
     let formatted_range = crate::format::format_range(
         text_document,
         query.source_type(),
-        formatter_settings,
+        &settings.formatter,
         range,
     )
     .with_failure_code(lsp_server::ErrorCode::InternalError)?;


### PR DESCRIPTION
## Summary

This PR refactors the `RuffSettings` struct to directly include the resolved `Settings` instead of including the specific fields from it. The server utilizes a lot of it already, so it makes sense to just include the entire struct for simplicity.

### `Deref`

I implemented `Deref` on `RuffSettings` to return the `Settings` because `RuffSettings` is now basically a wrapper around it with the config path as the other field. This path field is only used for debugging ("printDebugInformation" command).
