### PR TITLE
Root exclusions in the server to project root

### DIFF
--- a/crates/ruff_server/src/resolve.rs
+++ b/crates/ruff_server/src/resolve.rs
@@ -59,9 +59,7 @@ fn is_document_excluded(
 ) -> bool {
     if let Some(exclusion) = match_any_exclusion(
         path,
-        &resolver_settings.project_root,
-        &resolver_settings.exclude,
-        &resolver_settings.extend_exclude,
+        resolver_settings,
         linter_settings.map(|s| &*s.exclude),
         formatter_settings.map(|s| &*s.exclude),
     ) {
@@ -69,11 +67,7 @@ fn is_document_excluded(
         return true;
     }
 
-    if let Some(inclusion) = match_any_inclusion(
-        path,
-        &resolver_settings.include,
-        &resolver_settings.extend_include,
-    ) {
+    if let Some(inclusion) = match_any_inclusion(path, resolver_settings) {
         tracing::debug!("Included path via `{}`: {}", inclusion, path.display());
         false
     } else if let Some(LanguageId::Python) = language_id {

--- a/crates/ruff_server/src/resolve.rs
+++ b/crates/ruff_server/src/resolve.rs
@@ -59,6 +59,7 @@ fn is_document_excluded(
 ) -> bool {
     if let Some(exclusion) = match_any_exclusion(
         path,
+        &resolver_settings.project_root,
         &resolver_settings.exclude,
         &resolver_settings.extend_exclude,
         linter_settings.map(|s| &*s.exclude),

--- a/crates/ruff_workspace/src/resolver.rs
+++ b/crates/ruff_workspace/src/resolver.rs
@@ -778,6 +778,7 @@ impl std::fmt::Display for ExclusionKind {
 /// any of the exclusion criteria.
 pub fn match_any_exclusion(
     path: &Path,
+    project_root: &Path,
     exclude: &GlobSet,
     extend_exclude: &GlobSet,
     lint_exclude: Option<&GlobSet>,
@@ -803,6 +804,11 @@ pub fn match_any_exclusion(
                     return Some(ExclusionKind::FormatExclude);
                 }
             }
+        }
+        if path == project_root {
+            // Bail out; we'd end up past the project root on the next iteration
+            // (excludes etc. are thus "rooted" to the project).
+            break;
         }
     }
     None

--- a/crates/ruff_workspace/src/resolver.rs
+++ b/crates/ruff_workspace/src/resolver.rs
@@ -23,9 +23,9 @@ use ruff_linter::package::PackageRoot;
 use ruff_linter::packaging::is_package;
 
 use crate::configuration::Configuration;
-use crate::pyproject;
 use crate::pyproject::settings_toml;
 use crate::settings::Settings;
+use crate::{pyproject, FileResolverSettings};
 
 /// The configuration information from a `pyproject.toml` file.
 #[derive(Debug)]
@@ -778,9 +778,7 @@ impl std::fmt::Display for ExclusionKind {
 /// any of the exclusion criteria.
 pub fn match_any_exclusion(
     path: &Path,
-    project_root: &Path,
-    exclude: &GlobSet,
-    extend_exclude: &GlobSet,
+    resolver_settings: &FileResolverSettings,
     lint_exclude: Option<&GlobSet>,
     format_exclude: Option<&GlobSet>,
 ) -> Option<ExclusionKind> {
@@ -788,10 +786,10 @@ pub fn match_any_exclusion(
         if let Some(basename) = path.file_name() {
             let path = Candidate::new(path);
             let basename = Candidate::new(basename);
-            if match_candidate_exclusion(&path, &basename, exclude) {
+            if match_candidate_exclusion(&path, &basename, &resolver_settings.exclude) {
                 return Some(ExclusionKind::Exclude);
             }
-            if match_candidate_exclusion(&path, &basename, extend_exclude) {
+            if match_candidate_exclusion(&path, &basename, &resolver_settings.extend_exclude) {
                 return Some(ExclusionKind::ExtendExclude);
             }
             if let Some(lint_exclude) = lint_exclude {
@@ -805,7 +803,7 @@ pub fn match_any_exclusion(
                 }
             }
         }
-        if path == project_root {
+        if path == resolver_settings.project_root {
             // Bail out; we'd end up past the project root on the next iteration
             // (excludes etc. are thus "rooted" to the project).
             break;
@@ -835,12 +833,11 @@ impl std::fmt::Display for InclusionKind {
 /// criteria.
 pub fn match_any_inclusion(
     path: &Path,
-    include: &GlobSet,
-    extend_include: &GlobSet,
+    resolver_settings: &FileResolverSettings,
 ) -> Option<InclusionKind> {
-    if include.is_match(path) {
+    if resolver_settings.include.is_match(path) {
         Some(InclusionKind::Include)
-    } else if extend_include.is_match(path) {
+    } else if resolver_settings.extend_include.is_match(path) {
         Some(InclusionKind::ExtendInclude)
     } else {
         None


### PR DESCRIPTION
## Summary

fixes: #16041 

## Test Plan

Using the [project](https://github.com/bwcc-clan/polebot) in the linked issue:

Notice how the project "polebot" is in the "play" directory which is included in the `exclude` setting as:

```toml
exclude = ["play"]
```

**Before this fix**

```
DEBUG ruff:worker:0 ruff_server::resolve: Ignored path via `exclude`: /private/tmp/ruff-test/play/polebot/src/utils/log_tools.py
```

**After this fix**

```
DEBUG ruff:worker:2 ruff_server::resolve: Included path via `include`: /private/tmp/ruff-test/play/polebot/src/utils/log_tools.py
```

I also updated the same project to remove the "play" directory from the `exclude` setting and made sure that anything under the `polebot/play` directory is included:

```
DEBUG  ruff:worker:4 ruff_server::resolve: Included path via `include`: /private/tmp/ruff-test/play/polebot/play/test.py
```

And, excluded when I add the directory back:

```
DEBUG  ruff:worker:2 ruff_server::resolve: Ignored path via `exclude`: /private/tmp/ruff-test/play/polebot/play/test.py
```