### PR TITLE
[`flake8-builtins`] Update documentation (`A005`)

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_builtins/rules/stdlib_module_shadowing.rs
+++ b/crates/ruff_linter/src/rules/flake8_builtins/rules/stdlib_module_shadowing.rs
@@ -27,7 +27,9 @@ use crate::settings::LinterSettings;
 /// `utils/logging.py`, and `utils/logging/__init__.py` would all clash with the builtin `logging`
 /// module. With the [`lint.flake8-builtins.builtins-strict-checking`] option set to `false`, the
 /// module path is considered, so only a top-level `logging.py` or `logging/__init__.py` will
-/// trigger the rule and `utils/logging.py`, for example, would not.
+/// trigger the rule and `utils/logging.py`, for example, would not. In preview mode, the default
+/// value of [`lint.flake8-builtins.builtins-strict-checking`] is `false` rather than `true` in
+/// stable mode.
 ///
 /// This rule is not applied to stub files, as the name of a stub module is out
 /// of the control of the author of the stub file. Instead, a stub should aim to

--- a/crates/ruff_linter/src/rules/flake8_builtins/rules/stdlib_module_shadowing.rs
+++ b/crates/ruff_linter/src/rules/flake8_builtins/rules/stdlib_module_shadowing.rs
@@ -24,10 +24,10 @@ use crate::settings::LinterSettings;
 /// [`lint.flake8-builtins.builtins-allowed-modules`] configuration option.
 ///
 /// By default, only the last component of the module name is considered, so `logging.py`,
-/// `a/logging.py`, `a/b/logging.py`, and so on would all clash with the builtin `logging` module.
-/// With the [`lint.flake8-builtins.builtins-strict-checking`] option set to `false`, the module
-/// path is considered, so only a top-level `logging.py` or `logging/__init__.py` will trigger the
-/// rule and `utils/logging.py`, for example, would not.
+/// `utils/logging.py`, and `utils/logging/__init__.py` would all clash with the builtin `logging`
+/// module. With the [`lint.flake8-builtins.builtins-strict-checking`] option set to `false`, the
+/// module path is considered, so only a top-level `logging.py` or `logging/__init__.py` will
+/// trigger the rule and `utils/logging.py`, for example, would not.
 ///
 /// This rule is not applied to stub files, as the name of a stub module is out
 /// of the control of the author of the stub file. Instead, a stub should aim to

--- a/crates/ruff_linter/src/rules/flake8_builtins/rules/stdlib_module_shadowing.rs
+++ b/crates/ruff_linter/src/rules/flake8_builtins/rules/stdlib_module_shadowing.rs
@@ -23,6 +23,12 @@ use crate::settings::LinterSettings;
 /// Standard-library modules can be marked as exceptions to this rule via the
 /// [`lint.flake8-builtins.builtins-allowed-modules`] configuration option.
 ///
+/// By default, only the last component of the module name is considered, so `logging.py`,
+/// `a/logging.py`, `a/b/logging.py`, and so on would all clash with the builtin `logging` module.
+/// With the [`lint.flake8-builtins.builtins-strict-checking`] option set to `false`, the module
+/// path is considered, so only a top-level `logging.py` or `logging/__init__.py` will trigger the
+/// rule and `utils/logging.py`, for example, would not.
+///
 /// This rule is not applied to stub files, as the name of a stub module is out
 /// of the control of the author of the stub file. Instead, a stub should aim to
 /// faithfully emulate the runtime module it is stubbing.
@@ -43,6 +49,7 @@ use crate::settings::LinterSettings;
 ///
 /// ## Options
 /// - `lint.flake8-builtins.builtins-allowed-modules`
+/// - `lint.flake8-builtins.builtins-strict-checking`
 #[derive(ViolationMetadata)]
 pub(crate) struct StdlibModuleShadowing {
     name: String,

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -1149,6 +1149,8 @@ pub struct Flake8BuiltinsOptions {
         example = "builtins-strict-checking = false"
     )]
     /// Compare module names instead of full module paths.
+    ///
+    /// Used by [`A005` - `stdlib-module-shadowing`](https://docs.astral.sh/ruff/rules/stdlib-module-shadowing/).
     pub builtins_strict_checking: Option<bool>,
 }
 

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -1151,6 +1151,8 @@ pub struct Flake8BuiltinsOptions {
     /// Compare module names instead of full module paths.
     ///
     /// Used by [`A005` - `stdlib-module-shadowing`](https://docs.astral.sh/ruff/rules/stdlib-module-shadowing/).
+    ///
+    /// In preview mode the default value is `false` rather than `true`.
     pub builtins_strict_checking: Option<bool>,
 }
 

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -1026,7 +1026,7 @@
           }
         },
         "builtins-strict-checking": {
-          "description": "Compare module names instead of full module paths.",
+          "description": "Compare module names instead of full module paths.\n\nUsed by [`A005` - `stdlib-module-shadowing`](https://docs.astral.sh/ruff/rules/stdlib-module-shadowing/).",
           "type": [
             "boolean",
             "null"

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -1026,7 +1026,7 @@
           }
         },
         "builtins-strict-checking": {
-          "description": "Compare module names instead of full module paths.\n\nUsed by [`A005` - `stdlib-module-shadowing`](https://docs.astral.sh/ruff/rules/stdlib-module-shadowing/).",
+          "description": "Compare module names instead of full module paths.\n\nUsed by [`A005` - `stdlib-module-shadowing`](https://docs.astral.sh/ruff/rules/stdlib-module-shadowing/).\n\nIn preview mode the default value is `false` rather than `true`.",
           "type": [
             "boolean",
             "null"


### PR DESCRIPTION
Follow-up to https://github.com/astral-sh/ruff/pull/15951 to update
* the options links in A005 to reference `lint.flake8-builtins.builtins-strict-checking`
* the description of the rule to explain strict vs non-strict checking
* the option documentation to point back to the rule