### PR TITLE
Remove `Hash` and `Eq` from `AstNodeRef` for types not implementing `Eq` or `Hash`

### DIFF
--- a/crates/red_knot_python_semantic/src/ast_node_ref.rs
+++ b/crates/red_knot_python_semantic/src/ast_node_ref.rs
@@ -103,9 +103,26 @@ where
 
 impl<T> Eq for AstNodeRef<T> where T: Eq {}
 
-impl<T> Hash for AstNodeRef<T> {
+impl<T> Hash for AstNodeRef<T>
+where
+    T: Hash,
+{
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.node.hash(state);
+        self.node().hash(state);
+    }
+}
+
+#[allow(unsafe_code)]
+unsafe impl<T> salsa::Update for AstNodeRef<T> {
+    unsafe fn maybe_update(old_pointer: *mut Self, new_value: Self) -> bool {
+        let old_ref = &mut (*old_pointer);
+
+        if old_ref.parsed == new_value.parsed && old_ref.node.eq(&new_value.node) {
+            false
+        } else {
+            *old_ref = new_value;
+            true
+        }
     }
 }
 

--- a/crates/red_knot_python_semantic/src/ast_node_ref.rs
+++ b/crates/red_knot_python_semantic/src/ast_node_ref.rs
@@ -103,12 +103,9 @@ where
 
 impl<T> Eq for AstNodeRef<T> where T: Eq {}
 
-impl<T> Hash for AstNodeRef<T>
-where
-    T: Hash,
-{
+impl<T> Hash for AstNodeRef<T> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.node().hash(state);
+        self.node.hash(state);
     }
 }
 

--- a/crates/red_knot_python_semantic/src/semantic_index/definition.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/definition.rs
@@ -439,7 +439,7 @@ impl DefinitionCategory {
 /// [`DefinitionKind`] fields in salsa tracked structs should be tracked (attributed with `#[tracked]`)
 /// because the kind is a thin wrapper around [`AstNodeRef`]. See the [`AstNodeRef`] documentation
 /// for an in-depth explanation of why this is necessary.
-#[derive(Clone, Debug, Hash)]
+#[derive(Clone, Debug)]
 pub enum DefinitionKind<'db> {
     Import(AstNodeRef<ast::Alias>),
     ImportFrom(ImportFromDefinitionKind),
@@ -559,7 +559,7 @@ impl<'db> From<Option<Unpack<'db>>> for TargetKind<'db> {
     }
 }
 
-#[derive(Clone, Debug, Hash)]
+#[derive(Clone, Debug)]
 #[allow(dead_code)]
 pub struct MatchPatternDefinitionKind {
     pattern: AstNodeRef<ast::Pattern>,
@@ -577,7 +577,7 @@ impl MatchPatternDefinitionKind {
     }
 }
 
-#[derive(Clone, Debug, Hash)]
+#[derive(Clone, Debug)]
 pub struct ComprehensionDefinitionKind {
     iterable: AstNodeRef<ast::Expr>,
     target: AstNodeRef<ast::ExprName>,
@@ -603,7 +603,7 @@ impl ComprehensionDefinitionKind {
     }
 }
 
-#[derive(Clone, Debug, Hash)]
+#[derive(Clone, Debug)]
 pub struct ImportFromDefinitionKind {
     node: AstNodeRef<ast::StmtImportFrom>,
     alias_index: usize,
@@ -619,7 +619,7 @@ impl ImportFromDefinitionKind {
     }
 }
 
-#[derive(Clone, Debug, Hash)]
+#[derive(Clone, Debug)]
 pub struct AssignmentDefinitionKind<'db> {
     target: TargetKind<'db>,
     value: AstNodeRef<ast::Expr>,
@@ -645,7 +645,7 @@ impl<'db> AssignmentDefinitionKind<'db> {
     }
 }
 
-#[derive(Clone, Debug, Hash)]
+#[derive(Clone, Debug)]
 pub struct WithItemDefinitionKind {
     node: AstNodeRef<ast::WithItem>,
     target: AstNodeRef<ast::ExprName>,
@@ -666,7 +666,7 @@ impl WithItemDefinitionKind {
     }
 }
 
-#[derive(Clone, Debug, Hash)]
+#[derive(Clone, Debug)]
 pub struct ForStmtDefinitionKind<'db> {
     target: TargetKind<'db>,
     iterable: AstNodeRef<ast::Expr>,
@@ -697,7 +697,7 @@ impl<'db> ForStmtDefinitionKind<'db> {
     }
 }
 
-#[derive(Clone, Debug, Hash)]
+#[derive(Clone, Debug)]
 pub struct ExceptHandlerDefinitionKind {
     handler: AstNodeRef<ast::ExceptHandlerExceptHandler>,
     is_star: bool,

--- a/crates/red_knot_python_semantic/src/unpack.rs
+++ b/crates/red_knot_python_semantic/src/unpack.rs
@@ -36,7 +36,6 @@ pub(crate) struct Unpack<'db> {
     /// expression is `(a, b)`.
     #[no_eq]
     #[return_ref]
-    #[tracked]
     pub(crate) target: AstNodeRef<ast::Expr>,
 
     /// The ingredient representing the value expression of the unpacking. For example, in

--- a/crates/red_knot_python_semantic/src/unpack.rs
+++ b/crates/red_knot_python_semantic/src/unpack.rs
@@ -36,6 +36,7 @@ pub(crate) struct Unpack<'db> {
     /// expression is `(a, b)`.
     #[no_eq]
     #[return_ref]
+    #[tracked]
     pub(crate) target: AstNodeRef<ast::Expr>,
 
     /// The ingredient representing the value expression of the unpacking. For example, in


### PR DESCRIPTION
## Summary

This is a follow up to https://github.com/astral-sh/ruff/pull/15763#discussion_r1949681336

It reverts the change to using ptr equality for `AstNodeRef`s, which in turn removes the `Eq`, `PartialEq`, and `Hash` implementations for `AstNodeRef`s parametrized with AST nodes. 
Cheap comparisons shouldn't be needed because the node field is generally marked as `[#tracked]` and `#[no_eq]` and removing the implementations even enforces that those 
attributes are set on all `AstNodeRef` fields (which is good).

The only downside this has is that we technically wouldn't have to mark the `Unpack::target` as `#[tracked]` because 
the `target` field is accessed in every query accepting `Unpack` as an argument. 

Overall, enforcing the use of `#[tracked]` seems like a good trade off, espacially considering that it's very likely that
we'd probably forget to mark the `Unpack::target` field as tracked if we add a new `Unpack` query that doesn't access the target.

## Test Plan

`cargo test`
