### PR TITLE
add diagnostic `Span` (couples `File` and `TextRange`)

### DIFF
--- a/crates/red_knot_project/src/lib.rs
+++ b/crates/red_knot_project/src/lib.rs
@@ -8,7 +8,7 @@ pub use metadata::{ProjectDiscoveryError, ProjectMetadata};
 use red_knot_python_semantic::lint::{LintRegistry, LintRegistryBuilder, RuleSelection};
 use red_knot_python_semantic::register_lints;
 use red_knot_python_semantic::types::check_types;
-use ruff_db::diagnostic::{Diagnostic, DiagnosticId, ParseDiagnostic, Severity};
+use ruff_db::diagnostic::{Diagnostic, DiagnosticId, ParseDiagnostic, Severity, Span};
 use ruff_db::files::{system_path_to_file, File};
 use ruff_db::parsed::parsed_module;
 use ruff_db::source::{source_text, SourceTextError};
@@ -464,6 +464,10 @@ impl Diagnostic for IOErrorDiagnostic {
 
     fn range(&self) -> Option<TextRange> {
         None
+    }
+
+    fn span(&self) -> Option<Span> {
+        Some(Span::from(self.file))
     }
 
     fn severity(&self) -> Severity {

--- a/crates/red_knot_project/src/metadata/options.rs
+++ b/crates/red_knot_project/src/metadata/options.rs
@@ -383,7 +383,7 @@ impl Diagnostic for OptionDiagnostic {
     }
 
     fn span(&self) -> Option<Span> {
-        self.span
+        self.span.clone()
     }
 
     fn severity(&self) -> Severity {

--- a/crates/red_knot_project/src/metadata/options.rs
+++ b/crates/red_knot_project/src/metadata/options.rs
@@ -385,14 +385,6 @@ impl Diagnostic for OptionDiagnostic {
         Cow::Borrowed(&self.message)
     }
 
-    fn file(&self) -> Option<File> {
-        self.file
-    }
-
-    fn range(&self) -> Option<TextRange> {
-        self.range
-    }
-
     fn span(&self) -> Option<Span> {
         let mut span = self.file.map(Span::from)?;
         if let Some(range) = self.range {

--- a/crates/red_knot_project/src/metadata/options.rs
+++ b/crates/red_knot_project/src/metadata/options.rs
@@ -4,7 +4,7 @@ use red_knot_python_semantic::lint::{GetLintError, Level, LintSource, RuleSelect
 use red_knot_python_semantic::{
     ProgramSettings, PythonPlatform, PythonVersion, SearchPathSettings, SitePackages,
 };
-use ruff_db::diagnostic::{Diagnostic, DiagnosticId, Severity};
+use ruff_db::diagnostic::{Diagnostic, DiagnosticId, Severity, Span};
 use ruff_db::files::{system_path_to_file, File};
 use ruff_db::system::{System, SystemPath};
 use ruff_macros::Combine;
@@ -391,6 +391,14 @@ impl Diagnostic for OptionDiagnostic {
 
     fn range(&self) -> Option<TextRange> {
         self.range
+    }
+
+    fn span(&self) -> Option<Span> {
+        let mut span = self.file.map(Span::from)?;
+        if let Some(range) = self.range {
+            span = span.with_range(range);
+        }
+        Some(span)
     }
 
     fn severity(&self) -> Severity {

--- a/crates/red_knot_python_semantic/src/types/diagnostic.rs
+++ b/crates/red_knot_python_semantic/src/types/diagnostic.rs
@@ -8,7 +8,7 @@ use crate::types::string_annotation::{
 };
 use crate::types::{ClassLiteralType, KnownInstanceType, Type};
 use crate::{declare_lint, Db};
-use ruff_db::diagnostic::{Diagnostic, DiagnosticId, Severity};
+use ruff_db::diagnostic::{Diagnostic, DiagnosticId, Severity, Span};
 use ruff_db::files::File;
 use ruff_python_ast::{self as ast, AnyNodeRef};
 use ruff_text_size::{Ranged, TextRange};
@@ -808,6 +808,10 @@ impl Diagnostic for TypeCheckDiagnostic {
 
     fn range(&self) -> Option<TextRange> {
         Some(Ranged::range(self))
+    }
+
+    fn span(&self) -> Option<Span> {
+        Some(Span::from(self.file).with_range(self.range))
     }
 
     fn severity(&self) -> Severity {

--- a/crates/red_knot_python_semantic/src/types/diagnostic.rs
+++ b/crates/red_knot_python_semantic/src/types/diagnostic.rs
@@ -802,14 +802,6 @@ impl Diagnostic for TypeCheckDiagnostic {
         TypeCheckDiagnostic::message(self).into()
     }
 
-    fn file(&self) -> Option<File> {
-        Some(TypeCheckDiagnostic::file(self))
-    }
-
-    fn range(&self) -> Option<TextRange> {
-        Some(Ranged::range(self))
-    }
-
     fn span(&self) -> Option<Span> {
         Some(Span::from(self.file).with_range(self.range))
     }

--- a/crates/red_knot_server/src/server/api/requests/diagnostic.rs
+++ b/crates/red_knot_server/src/server/api/requests/diagnostic.rs
@@ -75,11 +75,13 @@ fn to_lsp_diagnostic(
     diagnostic: &dyn ruff_db::diagnostic::Diagnostic,
     encoding: crate::PositionEncoding,
 ) -> Diagnostic {
-    let range = if let (Some(file), Some(range)) = (diagnostic.file(), diagnostic.range()) {
-        let index = line_index(db.upcast(), file);
-        let source = source_text(db.upcast(), file);
+    let range = if let Some(span) = diagnostic.span() {
+        let index = line_index(db.upcast(), span.file());
+        let source = source_text(db.upcast(), span.file());
 
-        range.to_range(&source, &index, encoding)
+        span.range()
+            .map(|range| range.to_range(&source, &index, encoding))
+            .unwrap_or_default()
     } else {
         Range::default()
     };

--- a/crates/red_knot_test/src/diagnostic.rs
+++ b/crates/red_knot_test/src/diagnostic.rs
@@ -144,7 +144,7 @@ struct DiagnosticWithLine<T> {
 mod tests {
     use crate::db::Db;
     use crate::diagnostic::Diagnostic;
-    use ruff_db::diagnostic::{DiagnosticId, LintName, Severity};
+    use ruff_db::diagnostic::{DiagnosticId, LintName, Severity, Span};
     use ruff_db::files::{system_path_to_file, File};
     use ruff_db::source::line_index;
     use ruff_db::system::{DbWithTestSystem, SystemPathBuf};
@@ -204,6 +204,10 @@ mod tests {
 
         fn range(&self) -> Option<TextRange> {
             Some(self.range)
+        }
+
+        fn span(&self) -> Option<Span> {
+            Some(Span::from(self.file).with_range(self.range))
         }
 
         fn severity(&self) -> Severity {

--- a/crates/red_knot_test/src/diagnostic.rs
+++ b/crates/red_knot_test/src/diagnostic.rs
@@ -26,7 +26,8 @@ where
             .into_iter()
             .map(|diagnostic| DiagnosticWithLine {
                 line_number: diagnostic
-                    .range()
+                    .span()
+                    .and_then(|span| span.range())
                     .map_or(OneIndexed::from_zero_indexed(0), |range| {
                         line_index.line_index(range.start())
                     }),
@@ -196,14 +197,6 @@ mod tests {
 
         fn message(&self) -> Cow<str> {
             "dummy".into()
-        }
-
-        fn file(&self) -> Option<File> {
-            Some(self.file)
-        }
-
-        fn range(&self) -> Option<TextRange> {
-            Some(self.range)
         }
 
         fn span(&self) -> Option<Span> {

--- a/crates/red_knot_test/src/matcher.rs
+++ b/crates/red_knot_test/src/matcher.rs
@@ -334,7 +334,7 @@ impl Matcher {
 #[cfg(test)]
 mod tests {
     use super::FailuresByLine;
-    use ruff_db::diagnostic::{Diagnostic, DiagnosticId, Severity};
+    use ruff_db::diagnostic::{Diagnostic, DiagnosticId, Severity, Span};
     use ruff_db::files::{system_path_to_file, File};
     use ruff_db::system::{DbWithTestSystem, SystemPathBuf};
     use ruff_python_trivia::textwrap::dedent;
@@ -391,6 +391,10 @@ mod tests {
 
         fn range(&self) -> Option<TextRange> {
             Some(self.range)
+        }
+
+        fn span(&self) -> Option<Span> {
+            Some(Span::from(self.file).with_range(self.range))
         }
 
         fn severity(&self) -> Severity {

--- a/crates/red_knot_test/src/matcher.rs
+++ b/crates/red_knot_test/src/matcher.rs
@@ -257,7 +257,8 @@ impl Matcher {
 
     fn column<T: Diagnostic>(&self, diagnostic: &T) -> OneIndexed {
         diagnostic
-            .range()
+            .span()
+            .and_then(|span| span.range())
             .map(|range| {
                 self.line_index
                     .source_location(range.start(), &self.source)
@@ -383,14 +384,6 @@ mod tests {
 
         fn message(&self) -> Cow<str> {
             self.message.into()
-        }
-
-        fn file(&self) -> Option<File> {
-            Some(self.file)
-        }
-
-        fn range(&self) -> Option<TextRange> {
-            Some(self.range)
         }
 
         fn span(&self) -> Option<Span> {

--- a/crates/ruff_benchmark/benches/red_knot.rs
+++ b/crates/ruff_benchmark/benches/red_knot.rs
@@ -229,8 +229,14 @@ fn assert_diagnostics(db: &dyn Db, diagnostics: &[Box<dyn Diagnostic>]) {
         .map(|diagnostic| {
             (
                 diagnostic.id(),
-                diagnostic.file().map(|file| file.path(db).as_str()),
-                diagnostic.range().map(Range::<usize>::from),
+                diagnostic
+                    .span()
+                    .map(|span| span.file())
+                    .map(|file| file.path(db).as_str()),
+                diagnostic
+                    .span()
+                    .and_then(|span| span.range())
+                    .map(Range::<usize>::from),
                 diagnostic.message(),
                 diagnostic.severity(),
             )

--- a/crates/ruff_db/src/diagnostic.rs
+++ b/crates/ruff_db/src/diagnostic.rs
@@ -188,7 +188,7 @@ pub trait Diagnostic: Send + Sync + std::fmt::Debug {
 /// It consists of a `File` and an optional range into that file. When the
 /// range isn't present, it semantically implies that the diagnostic refers to
 /// the entire file. For example, when the file should be executable but isn't.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Span {
     file: File,
     range: Option<TextRange>,

--- a/crates/ruff_db/src/diagnostic.rs
+++ b/crates/ruff_db/src/diagnostic.rs
@@ -164,20 +164,6 @@ pub trait Diagnostic: Send + Sync + std::fmt::Debug {
 
     fn message(&self) -> Cow<str>;
 
-    /// The file this diagnostic is associated with.
-    ///
-    /// File can be `None` for diagnostics that don't originate from a file.
-    /// For example:
-    /// * A diagnostic indicating that a directory couldn't be read.
-    /// * A diagnostic related to a CLI argument
-    fn file(&self) -> Option<File>;
-
-    /// The primary range of the diagnostic in `file`.
-    ///
-    /// The range can be `None` if the diagnostic doesn't have a file
-    /// or it applies to the entire file (e.g. the file should be executable but isn't).
-    fn range(&self) -> Option<TextRange>;
-
     /// The primary span of the diagnostic.
     ///
     /// The range can be `None` if the diagnostic doesn't have a file
@@ -209,6 +195,21 @@ pub struct Span {
 }
 
 impl Span {
+    /// Returns the `File` attached to this `Span`.
+    pub fn file(&self) -> File {
+        self.file
+    }
+
+    /// Returns the range, if available, attached to this `Span`.
+    ///
+    /// When there is no range, it is convention to assume that this `Span`
+    /// refers to the corresponding `File` as a whole. In some cases, consumers
+    /// of this API may use the range `0..0` to represent this case.
+    pub fn range(&self) -> Option<TextRange> {
+        self.range
+    }
+
+    /// Returns a new `Span` with the given `range` attached to it.
     pub fn with_range(self, range: TextRange) -> Span {
         Span {
             range: Some(range),
@@ -347,14 +348,6 @@ where
         (**self).message()
     }
 
-    fn file(&self) -> Option<File> {
-        (**self).file()
-    }
-
-    fn range(&self) -> Option<TextRange> {
-        (**self).range()
-    }
-
     fn span(&self) -> Option<Span> {
         (**self).span()
     }
@@ -376,14 +369,6 @@ where
         (**self).message()
     }
 
-    fn file(&self) -> Option<File> {
-        (**self).file()
-    }
-
-    fn range(&self) -> Option<TextRange> {
-        (**self).range()
-    }
-
     fn span(&self) -> Option<Span> {
         (**self).span()
     }
@@ -400,14 +385,6 @@ impl Diagnostic for Box<dyn Diagnostic> {
 
     fn message(&self) -> Cow<str> {
         (**self).message()
-    }
-
-    fn file(&self) -> Option<File> {
-        (**self).file()
-    }
-
-    fn range(&self) -> Option<TextRange> {
-        (**self).range()
     }
 
     fn span(&self) -> Option<Span> {
@@ -428,14 +405,6 @@ impl Diagnostic for &'_ dyn Diagnostic {
         (**self).message()
     }
 
-    fn file(&self) -> Option<File> {
-        (**self).file()
-    }
-
-    fn range(&self) -> Option<TextRange> {
-        (**self).range()
-    }
-
     fn span(&self) -> Option<Span> {
         (**self).span()
     }
@@ -452,14 +421,6 @@ impl Diagnostic for std::sync::Arc<dyn Diagnostic> {
 
     fn message(&self) -> Cow<str> {
         (**self).message()
-    }
-
-    fn file(&self) -> Option<File> {
-        (**self).file()
-    }
-
-    fn range(&self) -> Option<TextRange> {
-        (**self).range()
     }
 
     fn span(&self) -> Option<Span> {
@@ -490,14 +451,6 @@ impl Diagnostic for ParseDiagnostic {
 
     fn message(&self) -> Cow<str> {
         self.error.error.to_string().into()
-    }
-
-    fn file(&self) -> Option<File> {
-        Some(self.file)
-    }
-
-    fn range(&self) -> Option<TextRange> {
-        Some(self.error.location)
     }
 
     fn span(&self) -> Option<Span> {

--- a/crates/ruff_db/src/diagnostic.rs
+++ b/crates/ruff_db/src/diagnostic.rs
@@ -182,17 +182,7 @@ pub trait Diagnostic: Send + Sync + std::fmt::Debug {
     ///
     /// The range can be `None` if the diagnostic doesn't have a file
     /// or it applies to the entire file (e.g. the file should be executable but isn't).
-    fn span(&self) -> Option<Span> {
-        // NOTE: This temporary implementation specifically rejects the
-        // possible case of a present `TextRange` but a missing `File`.
-        // During this re-factor, we'll specifically prevent this case
-        // from happening by construction.
-        let mut span = self.file().map(Span::from)?;
-        if let Some(range) = self.range() {
-            span = span.with_range(range);
-        }
-        Some(span)
-    }
+    fn span(&self) -> Option<Span>;
 
     fn severity(&self) -> Severity;
 
@@ -365,6 +355,10 @@ where
         (**self).range()
     }
 
+    fn span(&self) -> Option<Span> {
+        (**self).span()
+    }
+
     fn severity(&self) -> Severity {
         (**self).severity()
     }
@@ -390,6 +384,10 @@ where
         (**self).range()
     }
 
+    fn span(&self) -> Option<Span> {
+        (**self).span()
+    }
+
     fn severity(&self) -> Severity {
         (**self).severity()
     }
@@ -410,6 +408,10 @@ impl Diagnostic for Box<dyn Diagnostic> {
 
     fn range(&self) -> Option<TextRange> {
         (**self).range()
+    }
+
+    fn span(&self) -> Option<Span> {
+        (**self).span()
     }
 
     fn severity(&self) -> Severity {
@@ -434,6 +436,10 @@ impl Diagnostic for &'_ dyn Diagnostic {
         (**self).range()
     }
 
+    fn span(&self) -> Option<Span> {
+        (**self).span()
+    }
+
     fn severity(&self) -> Severity {
         (**self).severity()
     }
@@ -454,6 +460,10 @@ impl Diagnostic for std::sync::Arc<dyn Diagnostic> {
 
     fn range(&self) -> Option<TextRange> {
         (**self).range()
+    }
+
+    fn span(&self) -> Option<Span> {
+        (**self).span()
     }
 
     fn severity(&self) -> Severity {
@@ -488,6 +498,10 @@ impl Diagnostic for ParseDiagnostic {
 
     fn range(&self) -> Option<TextRange> {
         Some(self.error.location)
+    }
+
+    fn span(&self) -> Option<Span> {
+        Some(Span::from(self.file).with_range(self.error.location))
     }
 
     fn severity(&self) -> Severity {


### PR DESCRIPTION
This essentially makes it impossible to construct a `Diagnostic`
that has a `TextRange` but no `File`.

This is meant to be a precursor to multi-span support.

(Note that I consider this more of a prototyping-change and not
necessarily what this is going to look like longer term.)

Reviewers can probably review this PR as one big diff instead of
commit-by-commit.
