### PR TITLE
Move `reveal_type`, `assert_type` handling out of `CallOutcome`

### DIFF
--- a/crates/red_knot_python_semantic/src/types/call.rs
+++ b/crates/red_knot_python_semantic/src/types/call.rs
@@ -1,9 +1,7 @@
 use super::context::InferContext;
-use super::diagnostic::{CALL_NON_CALLABLE, TYPE_ASSERTION_FAILURE};
-use super::{Severity, Signature, Type, TypeArrayDisplay, UnionBuilder};
-use crate::types::diagnostic::STATIC_ASSERT_ERROR;
+use super::diagnostic::CALL_NON_CALLABLE;
+use super::{Signature, Type, TypeArrayDisplay, UnionBuilder};
 use crate::Db;
-use ruff_db::diagnostic::DiagnosticId;
 use ruff_python_ast as ast;
 
 mod arguments;
@@ -13,21 +11,9 @@ pub(super) use arguments::{Argument, CallArguments};
 pub(super) use bind::{bind_call, CallBinding};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) enum StaticAssertionErrorKind<'db> {
-    ArgumentIsFalse,
-    ArgumentIsFalsy(Type<'db>),
-    ArgumentTruthinessIsAmbiguous(Type<'db>),
-    CustomError(&'db str),
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) enum CallOutcome<'db> {
+pub(crate) enum CallOutcome<'db> {
     Callable {
         binding: CallBinding<'db>,
-    },
-    RevealType {
-        binding: CallBinding<'db>,
-        revealed_ty: Type<'db>,
     },
     NotCallable {
         not_callable_ty: Type<'db>,
@@ -39,14 +25,6 @@ pub(super) enum CallOutcome<'db> {
     PossiblyUnboundDunderCall {
         called_ty: Type<'db>,
         call_outcome: Box<CallOutcome<'db>>,
-    },
-    StaticAssertionError {
-        binding: CallBinding<'db>,
-        error_kind: StaticAssertionErrorKind<'db>,
-    },
-    AssertType {
-        binding: CallBinding<'db>,
-        asserted_ty: Type<'db>,
     },
 }
 
@@ -61,14 +39,6 @@ impl<'db> CallOutcome<'db> {
         CallOutcome::NotCallable { not_callable_ty }
     }
 
-    /// Create a new `CallOutcome::RevealType` with given revealed and return types.
-    pub(super) fn revealed(binding: CallBinding<'db>, revealed_ty: Type<'db>) -> CallOutcome<'db> {
-        CallOutcome::RevealType {
-            binding,
-            revealed_ty,
-        }
-    }
-
     /// Create a new `CallOutcome::Union` with given wrapped outcomes.
     pub(super) fn union(
         called_ty: Type<'db>,
@@ -80,22 +50,10 @@ impl<'db> CallOutcome<'db> {
         }
     }
 
-    /// Create a new `CallOutcome::AssertType` with given asserted and return types.
-    pub(super) fn asserted(binding: CallBinding<'db>, asserted_ty: Type<'db>) -> CallOutcome<'db> {
-        CallOutcome::AssertType {
-            binding,
-            asserted_ty,
-        }
-    }
-
     /// Get the return type of the call, or `None` if not callable.
     pub(super) fn return_type(&self, db: &'db dyn Db) -> Option<Type<'db>> {
         match self {
             Self::Callable { binding } => Some(binding.return_type()),
-            Self::RevealType {
-                binding,
-                revealed_ty: _,
-            } => Some(binding.return_type()),
             Self::NotCallable { not_callable_ty: _ } => None,
             Self::Union {
                 outcomes,
@@ -114,11 +72,6 @@ impl<'db> CallOutcome<'db> {
                 })
                 .map(UnionBuilder::build),
             Self::PossiblyUnboundDunderCall { call_outcome, .. } => call_outcome.return_type(db),
-            Self::StaticAssertionError { .. } => Some(Type::none(db)),
-            Self::AssertType {
-                binding,
-                asserted_ty: _,
-            } => Some(binding.return_type()),
         }
     }
 
@@ -204,20 +157,10 @@ impl<'db> CallOutcome<'db> {
         // only non-callable diagnostics in the union case, which is inconsistent.
         match self {
             Self::Callable { binding } => {
+                // TODO: Move this out of the `CallOutcome` and into `TypeInferenceBuilder`?
+                // This check is required everywhere where we call `return_type_result`
+                // from the TypeInferenceBuilder.
                 binding.report_diagnostics(context, node);
-                Ok(binding.return_type())
-            }
-            Self::RevealType {
-                binding,
-                revealed_ty,
-            } => {
-                binding.report_diagnostics(context, node);
-                context.report_diagnostic(
-                    node,
-                    DiagnosticId::RevealedType,
-                    Severity::Info,
-                    format_args!("Revealed type is `{}`", revealed_ty.display(context.db())),
-                );
                 Ok(binding.return_type())
             }
             Self::NotCallable { not_callable_ty } => Err(NotCallableError::Type {
@@ -239,23 +182,11 @@ impl<'db> CallOutcome<'db> {
             } => {
                 let mut not_callable = vec![];
                 let mut union_builder = UnionBuilder::new(context.db());
-                let mut revealed = false;
                 for outcome in outcomes {
                     let return_ty = match outcome {
                         Self::NotCallable { not_callable_ty } => {
                             not_callable.push(*not_callable_ty);
                             Type::unknown()
-                        }
-                        Self::RevealType {
-                            binding,
-                            revealed_ty: _,
-                        } => {
-                            if revealed {
-                                binding.return_type()
-                            } else {
-                                revealed = true;
-                                outcome.unwrap_with_diagnostic(context, node)
-                            }
                         }
                         _ => outcome.unwrap_with_diagnostic(context, node),
                     };
@@ -279,73 +210,6 @@ impl<'db> CallOutcome<'db> {
                         return_ty,
                     }),
                 }
-            }
-            Self::StaticAssertionError {
-                binding,
-                error_kind,
-            } => {
-                binding.report_diagnostics(context, node);
-
-                match error_kind {
-                    StaticAssertionErrorKind::ArgumentIsFalse => {
-                        context.report_lint(
-                            &STATIC_ASSERT_ERROR,
-                            node,
-                            format_args!("Static assertion error: argument evaluates to `False`"),
-                        );
-                    }
-                    StaticAssertionErrorKind::ArgumentIsFalsy(parameter_ty) => {
-                        context.report_lint(
-                            &STATIC_ASSERT_ERROR,
-                            node,
-                            format_args!(
-                                "Static assertion error: argument of type `{parameter_ty}` is statically known to be falsy",
-                                parameter_ty=parameter_ty.display(context.db())
-                            ),
-                        );
-                    }
-                    StaticAssertionErrorKind::ArgumentTruthinessIsAmbiguous(parameter_ty) => {
-                        context.report_lint(
-                            &STATIC_ASSERT_ERROR,
-                            node,
-                            format_args!(
-                                "Static assertion error: argument of type `{parameter_ty}` has an ambiguous static truthiness",
-                                parameter_ty=parameter_ty.display(context.db())
-                            ),
-                        );
-                    }
-                    StaticAssertionErrorKind::CustomError(message) => {
-                        context.report_lint(
-                            &STATIC_ASSERT_ERROR,
-                            node,
-                            format_args!("Static assertion error: {message}"),
-                        );
-                    }
-                }
-
-                Ok(Type::unknown())
-            }
-            Self::AssertType {
-                binding,
-                asserted_ty,
-            } => {
-                let [actual_ty, _asserted] = binding.parameter_types() else {
-                    return Ok(binding.return_type());
-                };
-
-                if !actual_ty.is_gradual_equivalent_to(context.db(), *asserted_ty) {
-                    context.report_lint(
-                        &TYPE_ASSERTION_FAILURE,
-                        node,
-                        format_args!(
-                            "Actual type `{}` is not the same as asserted type `{}`",
-                            actual_ty.display(context.db()),
-                            asserted_ty.display(context.db()),
-                        ),
-                    );
-                }
-
-                Ok(binding.return_type())
             }
         }
     }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -3250,83 +3250,98 @@ impl<'db> TypeInferenceBuilder<'db> {
 
         let call_outcome = function_type.call(self.db(), &call_arguments);
 
-        if let CallOutcome::Callable { binding } = &call_outcome {
-            if let Type::FunctionLiteral(function_type) = function_type {
-                match function_type.known(self.db()) {
-                    Some(KnownFunction::RevealType) => {
-                        let revealed_ty = binding.one_parameter_type().unwrap_or(Type::unknown());
-                        self.context.report_diagnostic(
-                            call_expression.into(),
-                            DiagnosticId::RevealedType,
-                            Severity::Info,
-                            format_args!("Revealed type is `{}`", revealed_ty.display(self.db())),
-                        );
-                    }
-                    Some(KnownFunction::AssertType) => {
-                        if let [actual_ty, asserted_ty] = binding.parameter_types() {
-                            if !actual_ty.is_gradual_equivalent_to(self.db(), *asserted_ty) {
-                                self.context.report_lint(
-                                    &TYPE_ASSERTION_FAILURE,
-                                    call_expression.into(),
-                                    format_args!(
-                                        "Actual type `{}` is not the same as asserted type `{}`",
-                                        actual_ty.display(self.db()),
-                                        asserted_ty.display(self.db()),
-                                    ),
-                                );
-                            }
-                        };
-                    }
-
-                    Some(KnownFunction::StaticAssert) => {
-                        if let Some((parameter_ty, message)) = binding.two_parameter_types() {
-                            let truthiness = parameter_ty.bool(self.db());
-
-                            if !truthiness.is_always_true() {
-                                if let Some(message) =
-                                    message.into_string_literal().map(|s| &**s.value(self.db()))
-                                {
-                                    self.context.report_lint(
-                                        &STATIC_ASSERT_ERROR,
-                                        call_expression.into(),
-                                        format_args!("Static assertion error: {message}"),
-                                    );
-                                } else if parameter_ty == Type::BooleanLiteral(false) {
-                                    self.context.report_lint(
-                                        &STATIC_ASSERT_ERROR,
-                                        call_expression.into(),
-                                        format_args!(
-                                            "Static assertion error: argument evaluates to `False`"
-                                        ),
-                                    );
-                                } else if truthiness.is_always_false() {
-                                    self.context.report_lint(
-                                        &STATIC_ASSERT_ERROR,
-                                        call_expression.into(),
-                                        format_args!(
-                                            "Static assertion error: argument of type `{parameter_ty}` is statically known to be falsy",
-                                            parameter_ty=parameter_ty.display(self.db())
-                                        ),
-                                    );
-                                } else {
-                                    self.context.report_lint(
-                                        &STATIC_ASSERT_ERROR,
-                                        call_expression.into(),
-                                        format_args!(
-                                            "Static assertion error: argument of type `{parameter_ty}` has an ambiguous static truthiness",
-                                            parameter_ty=parameter_ty.display(self.db())
-                                        ),
-                                    );
-                                };
-                            }
-                        }
-                    }
-                    _ => {}
-                }
-            }
-        }
+        self.check_call(call_expression, function_type, &call_outcome);
 
         call_outcome.unwrap_with_diagnostic(&self.context, call_expression.into())
+    }
+
+    fn check_call(
+        &self,
+        call_expression: &ast::ExprCall,
+        callee: Type<'db>,
+        outcome: &CallOutcome,
+    ) {
+        let Type::FunctionLiteral(function_type) = callee else {
+            return;
+        };
+
+        let CallOutcome::Callable { binding } = outcome else {
+            return;
+        };
+
+        match function_type.known(self.db()) {
+            Some(KnownFunction::RevealType) => {
+                let revealed_ty = binding.one_parameter_type().unwrap_or(Type::unknown());
+                self.context.report_diagnostic(
+                    call_expression.into(),
+                    DiagnosticId::RevealedType,
+                    Severity::Info,
+                    format_args!("Revealed type is `{}`", revealed_ty.display(self.db())),
+                );
+            }
+            Some(KnownFunction::AssertType) => {
+                let [actual_ty, asserted_ty] = binding.parameter_types() else {
+                    return;
+                };
+
+                if !actual_ty.is_gradual_equivalent_to(self.db(), *asserted_ty) {
+                    self.context.report_lint(
+                        &TYPE_ASSERTION_FAILURE,
+                        call_expression.into(),
+                        format_args!(
+                            "Actual type `{}` is not the same as asserted type `{}`",
+                            actual_ty.display(self.db()),
+                            asserted_ty.display(self.db()),
+                        ),
+                    );
+                }
+            }
+
+            Some(KnownFunction::StaticAssert) => {
+                let Some((parameter_ty, message)) = binding.two_parameter_types() else {
+                    return;
+                };
+
+                let truthiness = parameter_ty.bool(self.db());
+
+                if !truthiness.is_always_true() {
+                    if let Some(message) =
+                        message.into_string_literal().map(|s| &**s.value(self.db()))
+                    {
+                        self.context.report_lint(
+                            &STATIC_ASSERT_ERROR,
+                            call_expression.into(),
+                            format_args!("Static assertion error: {message}"),
+                        );
+                    } else if parameter_ty == Type::BooleanLiteral(false) {
+                        self.context.report_lint(
+                            &STATIC_ASSERT_ERROR,
+                            call_expression.into(),
+                            format_args!("Static assertion error: argument evaluates to `False`"),
+                        );
+                    } else if truthiness.is_always_false() {
+                        self.context.report_lint(
+                            &STATIC_ASSERT_ERROR,
+                            call_expression.into(),
+                            format_args!(
+                                "Static assertion error: argument of type `{parameter_ty}` is statically known to be falsy",
+                                parameter_ty=parameter_ty.display(self.db())
+                            ),
+                        );
+                    } else {
+                        self.context.report_lint(
+                            &STATIC_ASSERT_ERROR,
+                            call_expression.into(),
+                            format_args!(
+                                "Static assertion error: argument of type `{parameter_ty}` has an ambiguous static truthiness",
+                                parameter_ty=parameter_ty.display(self.db())
+                            ),
+                        );
+                    };
+                }
+            }
+            _ => {}
+        }
     }
 
     fn infer_starred_expression(&mut self, starred: &ast::ExprStarred) -> Type<'db> {


### PR DESCRIPTION
## Summary

Let's measure the temperture on how people feel about this ;) 

Something I noticed about `CallOutcome` or more generally about `Type::call` is that we have to differentiate between three use cases:

1. We want to type check a call expression
2. We want to type check a possibly implicit call (e.g. `a += 1` where this calls `__add__`)
3. We are only interested in what the function would return if called 


This PR moves the code only relevant to 1 out of `CallOutcome` and into `infer_call_expression` instead. 
It simplifies the `CallOutcome` struct overall and I, as a reader, find it easier to reason about which logic 
applies where. 

## Test Plan

`cargo test`
