### PR TITLE
ruff_db: add a vector for configuring diagnostic output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2755,7 +2755,6 @@ name = "ruff_db"
 version = "0.0.0"
 dependencies = [
  "camino",
- "colored 3.0.0",
  "countme",
  "dashmap 6.1.0",
  "dunce",

--- a/crates/red_knot/src/main.rs
+++ b/crates/red_knot/src/main.rs
@@ -15,7 +15,7 @@ use red_knot_project::watch::ProjectWatcher;
 use red_knot_project::{watch, Db};
 use red_knot_project::{ProjectDatabase, ProjectMetadata};
 use red_knot_server::run_server;
-use ruff_db::diagnostic::{Diagnostic, Severity};
+use ruff_db::diagnostic::{Diagnostic, DisplayDiagnosticConfig, Severity};
 use ruff_db::system::{OsSystem, System, SystemPath, SystemPathBuf};
 use salsa::plumbing::ZalsaDatabase;
 
@@ -231,6 +231,9 @@ impl MainLoop {
                     result,
                     revision: check_revision,
                 } => {
+                    let display_config = DisplayDiagnosticConfig::default()
+                        .color(colored::control::SHOULD_COLORIZE.should_colorize());
+
                     let min_error_severity =
                         if db.project().settings(db).terminal().error_on_warning {
                             Severity::Warning
@@ -245,7 +248,7 @@ impl MainLoop {
                     if check_revision == revision {
                         #[allow(clippy::print_stdout)]
                         for diagnostic in result {
-                            println!("{}", diagnostic.display(db));
+                            println!("{}", diagnostic.display(db, &display_config));
                         }
                     } else {
                         tracing::debug!(

--- a/crates/red_knot_test/src/lib.rs
+++ b/crates/red_knot_test/src/lib.rs
@@ -5,7 +5,7 @@ use colored::Colorize;
 use parser as test_parser;
 use red_knot_python_semantic::types::check_types;
 use red_knot_python_semantic::{Program, ProgramSettings, SearchPathSettings, SitePackages};
-use ruff_db::diagnostic::{Diagnostic, ParseDiagnostic};
+use ruff_db::diagnostic::{Diagnostic, DisplayDiagnosticConfig, ParseDiagnostic};
 use ruff_db::files::{system_path_to_file, File, Files};
 use ruff_db::panic::catch_unwind;
 use ruff_db::parsed::parsed_module;
@@ -300,9 +300,7 @@ fn create_diagnostic_snapshot<D: Diagnostic>(
     test: &parser::MarkdownTest,
     diagnostics: impl IntoIterator<Item = D>,
 ) -> String {
-    // TODO(ag): Do something better than requiring this
-    // global state to be twiddled everywhere.
-    colored::control::set_override(false);
+    let display_config = DisplayDiagnosticConfig::default().color(false);
 
     let mut snapshot = String::new();
     writeln!(snapshot).unwrap();
@@ -340,7 +338,7 @@ fn create_diagnostic_snapshot<D: Diagnostic>(
             writeln!(snapshot).unwrap();
         }
         writeln!(snapshot, "```").unwrap();
-        writeln!(snapshot, "{}", diag.display(db)).unwrap();
+        writeln!(snapshot, "{}", diag.display(db, &display_config)).unwrap();
         writeln!(snapshot, "```").unwrap();
     }
     snapshot

--- a/crates/red_knot_wasm/src/lib.rs
+++ b/crates/red_knot_wasm/src/lib.rs
@@ -7,7 +7,7 @@ use red_knot_project::metadata::options::{EnvironmentOptions, Options};
 use red_knot_project::metadata::value::RangedValue;
 use red_knot_project::ProjectMetadata;
 use red_knot_project::{Db, ProjectDatabase};
-use ruff_db::diagnostic::Diagnostic;
+use ruff_db::diagnostic::{Diagnostic, DisplayDiagnosticConfig};
 use ruff_db::files::{system_path_to_file, File};
 use ruff_db::system::walk_directory::WalkDirectoryBuilder;
 use ruff_db::system::{
@@ -114,9 +114,10 @@ impl Workspace {
     pub fn check_file(&self, file_id: &FileHandle) -> Result<Vec<String>, Error> {
         let result = self.db.check_file(file_id.file).map_err(into_error)?;
 
+        let display_config = DisplayDiagnosticConfig::default().color(false);
         Ok(result
             .into_iter()
-            .map(|diagnostic| diagnostic.display(&self.db).to_string())
+            .map(|diagnostic| diagnostic.display(&self.db, &display_config).to_string())
             .collect())
     }
 
@@ -124,9 +125,10 @@ impl Workspace {
     pub fn check(&self) -> Result<Vec<String>, Error> {
         let result = self.db.check().map_err(into_error)?;
 
+        let display_config = DisplayDiagnosticConfig::default().color(false);
         Ok(result
             .into_iter()
-            .map(|diagnostic| diagnostic.display(&self.db).to_string())
+            .map(|diagnostic| diagnostic.display(&self.db, &display_config).to_string())
             .collect())
     }
 

--- a/crates/ruff_db/Cargo.toml
+++ b/crates/ruff_db/Cargo.toml
@@ -21,7 +21,6 @@ ruff_source_file = { workspace = true }
 ruff_text_size = { workspace = true }
 
 camino = { workspace = true }
-colored = { workspace = true }
 countme = { workspace = true }
 dashmap = { workspace = true }
 dunce = { workspace = true }


### PR DESCRIPTION
For now, the only thing one can configure is whether color is enabled or
not. This avoids needing to ask the `colored` crate whether colors have
been globally enabled or disabled. And, more crucially, avoids the need
to _set_ this global flag for testing diagnostic output. Doing so can
have unintended consequences, as outlined in #16115.

Fixes #16115
