### PR TITLE
Handle `PossiblyUndefinedDunder` as an error

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1927,11 +1927,11 @@ impl<'db> Type<'db> {
 
         let return_ty = match self.call_dunder(db, "__len__", &CallArguments::positional([*self])) {
             // TODO: emit a diagnostic
-            CallDunderResult::MethodNotAvailable => return None,
-
-            CallDunderResult::CallOutcome(outcome) | CallDunderResult::PossiblyUnbound(outcome) => {
-                outcome.return_type(db)?
+            CallDunderResult::MethodNotAvailable | CallDunderResult::PossiblyUnbound(_) => {
+                return None
             }
+
+            CallDunderResult::CallOutcome(outcome) => outcome.return_type(db)?,
         };
 
         non_negative_int_literal(db, return_ty)

--- a/crates/red_knot_python_semantic/src/types/call.rs
+++ b/crates/red_knot_python_semantic/src/types/call.rs
@@ -113,7 +113,7 @@ impl<'db> CallOutcome<'db> {
                     }
                 })
                 .map(UnionBuilder::build),
-            Self::PossiblyUnboundDunderCall { call_outcome, .. } => call_outcome.return_type(db),
+            Self::PossiblyUnboundDunderCall { .. } => None,
             Self::StaticAssertionError { .. } => Some(Type::none(db)),
             Self::AssertType {
                 binding,

--- a/crates/red_knot_python_semantic/src/types/call.rs
+++ b/crates/red_knot_python_semantic/src/types/call.rs
@@ -351,16 +351,16 @@ impl<'db> CallOutcome<'db> {
     }
 }
 
-pub(super) enum CallDunderResult<'db> {
-    CallOutcome(CallOutcome<'db>),
+pub(super) enum CallDunderOutcome<'db> {
+    Call(CallOutcome<'db>),
     PossiblyUnbound(CallOutcome<'db>),
     MethodNotAvailable,
 }
 
-impl<'db> CallDunderResult<'db> {
+impl<'db> CallDunderOutcome<'db> {
     pub(super) fn return_type(&self, db: &'db dyn Db) -> Option<Type<'db>> {
         match self {
-            Self::CallOutcome(outcome) => outcome.return_type(db),
+            Self::Call(outcome) => outcome.return_type(db),
             Self::PossiblyUnbound { .. } => None,
             Self::MethodNotAvailable => None,
         }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -64,7 +64,7 @@ use crate::types::mro::MroErrorKind;
 use crate::types::unpacker::{UnpackResult, Unpacker};
 use crate::types::{
     builtins_symbol, global_symbol, symbol, symbol_from_bindings, symbol_from_declarations,
-    todo_type, typing_extensions_symbol, Boundness, CallDunderResult, Class, ClassLiteralType,
+    todo_type, typing_extensions_symbol, Boundness, CallDunderOutcome, Class, ClassLiteralType,
     DynamicType, FunctionType, InstanceType, IntersectionBuilder, IntersectionType,
     IterationOutcome, KnownClass, KnownFunction, KnownInstanceType, MetaclassCandidate,
     MetaclassErrorKind, SliceLiteralType, SubclassOfType, Symbol, SymbolAndQualifiers, Truthiness,
@@ -3567,12 +3567,13 @@ impl<'db> TypeInferenceBuilder<'db> {
                     }
                 };
 
-                if let CallDunderResult::CallOutcome(call)
-                | CallDunderResult::PossiblyUnbound(call) = operand_type.call_dunder(
-                    self.db(),
-                    unary_dunder_method,
-                    &CallArguments::positional([operand_type]),
-                ) {
+                if let CallDunderOutcome::Call(call) | CallDunderOutcome::PossiblyUnbound(call) =
+                    operand_type.call_dunder(
+                        self.db(),
+                        unary_dunder_method,
+                        &CallArguments::positional([operand_type]),
+                    )
+                {
                     match call.return_type_result(&self.context, AnyNodeRef::ExprUnaryOp(unary)) {
                         Ok(t) => t,
                         Err(e) => {


### PR DESCRIPTION
## Summary

I won't pretend that I know what I'm doing here. 

However, I noticed that our handling of `PossiblyUnbound` for dunder methods is inconsistent:

* `CallDunderResult::return_type` returns `None` 
* `CallOutcome::return_type` might return `Some` for `PossiblyUnboundDunder` unlike all other variants taht return an `Err` in `return_type_result`.


To me, this seems wrong. The idea of those methods is to return the type if it is know but the possibly unbound suggests that the type is actually not known. 
Unfortunately, there are no tests... 


Edit: I included a small refactor in this PR that renames `CallDunderResult` to `CallDunderOutcome`. But it's a separate commit to ease reviewing.

## Test Plan

`cargo test`
