### PR TITLE
[`ruff`] Skip RUF001 diagnostics when visiting string type definitions

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/confusables.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/confusables.py
@@ -56,3 +56,6 @@ assert getattr(Labware(), "µL") == 1.5
 
 # Implicit string concatenation
 x = "𝐁ad" f"𝐁ad string"
+
+from typing import Literal
+x: '''"""'Literal["ﮨ"]'"""'''

--- a/crates/ruff_linter/src/rules/ruff/rules/ambiguous_unicode_character.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/ambiguous_unicode_character.rs
@@ -186,7 +186,13 @@ pub(crate) fn ambiguous_unicode_character_comment(
 
 /// RUF001, RUF002
 pub(crate) fn ambiguous_unicode_character_string(checker: &Checker, string_like: StringLike) {
-    let context = if checker.semantic().in_pep_257_docstring() {
+    let semantic = checker.semantic();
+
+    if semantic.in_string_type_definition() {
+        return;
+    }
+
+    let context = if semantic.in_pep_257_docstring() {
         Context::Docstring
     } else {
         Context::String

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__confusables.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__confusables.snap
@@ -179,24 +179,3 @@ confusables.py:61:20: RUF001 String contains ambiguous `ﮨ` (ARABIC LETTER HEH 
 61 | x: '''"""'Literal["ﮨ"]'"""'''
    |                    ^ RUF001
    |
-
-confusables.py:61:20: RUF001 String contains ambiguous `ﮨ` (ARABIC LETTER HEH GOAL INITIAL FORM). Did you mean `o` (LATIN SMALL LETTER O)?
-   |
-60 | from typing import Literal
-61 | x: '''"""'Literal["ﮨ"]'"""'''
-   |                    ^ RUF001
-   |
-
-confusables.py:61:20: RUF001 String contains ambiguous `ﮨ` (ARABIC LETTER HEH GOAL INITIAL FORM). Did you mean `o` (LATIN SMALL LETTER O)?
-   |
-60 | from typing import Literal
-61 | x: '''"""'Literal["ﮨ"]'"""'''
-   |                    ^ RUF001
-   |
-
-confusables.py:61:20: RUF001 String contains ambiguous `ﮨ` (ARABIC LETTER HEH GOAL INITIAL FORM). Did you mean `o` (LATIN SMALL LETTER O)?
-   |
-60 | from typing import Literal
-61 | x: '''"""'Literal["ﮨ"]'"""'''
-   |                    ^ RUF001
-   |

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__confusables.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__confusables.snap
@@ -160,6 +160,8 @@ confusables.py:58:6: RUF001 String contains ambiguous `𝐁` (MATHEMATICAL BOLD 
 57 | # Implicit string concatenation
 58 | x = "𝐁ad" f"𝐁ad string"
    |      ^ RUF001
+59 |
+60 | from typing import Literal
    |
 
 confusables.py:58:13: RUF001 String contains ambiguous `𝐁` (MATHEMATICAL BOLD CAPITAL B). Did you mean `B` (LATIN CAPITAL LETTER B)?
@@ -167,4 +169,34 @@ confusables.py:58:13: RUF001 String contains ambiguous `𝐁` (MATHEMATICAL BOLD
 57 | # Implicit string concatenation
 58 | x = "𝐁ad" f"𝐁ad string"
    |             ^ RUF001
+59 |
+60 | from typing import Literal
+   |
+
+confusables.py:61:20: RUF001 String contains ambiguous `ﮨ` (ARABIC LETTER HEH GOAL INITIAL FORM). Did you mean `o` (LATIN SMALL LETTER O)?
+   |
+60 | from typing import Literal
+61 | x: '''"""'Literal["ﮨ"]'"""'''
+   |                    ^ RUF001
+   |
+
+confusables.py:61:20: RUF001 String contains ambiguous `ﮨ` (ARABIC LETTER HEH GOAL INITIAL FORM). Did you mean `o` (LATIN SMALL LETTER O)?
+   |
+60 | from typing import Literal
+61 | x: '''"""'Literal["ﮨ"]'"""'''
+   |                    ^ RUF001
+   |
+
+confusables.py:61:20: RUF001 String contains ambiguous `ﮨ` (ARABIC LETTER HEH GOAL INITIAL FORM). Did you mean `o` (LATIN SMALL LETTER O)?
+   |
+60 | from typing import Literal
+61 | x: '''"""'Literal["ﮨ"]'"""'''
+   |                    ^ RUF001
+   |
+
+confusables.py:61:20: RUF001 String contains ambiguous `ﮨ` (ARABIC LETTER HEH GOAL INITIAL FORM). Did you mean `o` (LATIN SMALL LETTER O)?
+   |
+60 | from typing import Literal
+61 | x: '''"""'Literal["ﮨ"]'"""'''
+   |                    ^ RUF001
    |

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__preview_confusables.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__preview_confusables.snap
@@ -168,6 +168,8 @@ confusables.py:58:6: RUF001 String contains ambiguous `𝐁` (MATHEMATICAL BOLD 
 57 | # Implicit string concatenation
 58 | x = "𝐁ad" f"𝐁ad string"
    |      ^ RUF001
+59 |
+60 | from typing import Literal
    |
 
 confusables.py:58:13: RUF001 String contains ambiguous `𝐁` (MATHEMATICAL BOLD CAPITAL B). Did you mean `B` (LATIN CAPITAL LETTER B)?
@@ -175,4 +177,34 @@ confusables.py:58:13: RUF001 String contains ambiguous `𝐁` (MATHEMATICAL BOLD
 57 | # Implicit string concatenation
 58 | x = "𝐁ad" f"𝐁ad string"
    |             ^ RUF001
+59 |
+60 | from typing import Literal
+   |
+
+confusables.py:61:20: RUF001 String contains ambiguous `ﮨ` (ARABIC LETTER HEH GOAL INITIAL FORM). Did you mean `o` (LATIN SMALL LETTER O)?
+   |
+60 | from typing import Literal
+61 | x: '''"""'Literal["ﮨ"]'"""'''
+   |                    ^ RUF001
+   |
+
+confusables.py:61:20: RUF001 String contains ambiguous `ﮨ` (ARABIC LETTER HEH GOAL INITIAL FORM). Did you mean `o` (LATIN SMALL LETTER O)?
+   |
+60 | from typing import Literal
+61 | x: '''"""'Literal["ﮨ"]'"""'''
+   |                    ^ RUF001
+   |
+
+confusables.py:61:20: RUF001 String contains ambiguous `ﮨ` (ARABIC LETTER HEH GOAL INITIAL FORM). Did you mean `o` (LATIN SMALL LETTER O)?
+   |
+60 | from typing import Literal
+61 | x: '''"""'Literal["ﮨ"]'"""'''
+   |                    ^ RUF001
+   |
+
+confusables.py:61:20: RUF001 String contains ambiguous `ﮨ` (ARABIC LETTER HEH GOAL INITIAL FORM). Did you mean `o` (LATIN SMALL LETTER O)?
+   |
+60 | from typing import Literal
+61 | x: '''"""'Literal["ﮨ"]'"""'''
+   |                    ^ RUF001
    |

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__preview_confusables.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__preview_confusables.snap
@@ -187,24 +187,3 @@ confusables.py:61:20: RUF001 String contains ambiguous `ﮨ` (ARABIC LETTER HEH 
 61 | x: '''"""'Literal["ﮨ"]'"""'''
    |                    ^ RUF001
    |
-
-confusables.py:61:20: RUF001 String contains ambiguous `ﮨ` (ARABIC LETTER HEH GOAL INITIAL FORM). Did you mean `o` (LATIN SMALL LETTER O)?
-   |
-60 | from typing import Literal
-61 | x: '''"""'Literal["ﮨ"]'"""'''
-   |                    ^ RUF001
-   |
-
-confusables.py:61:20: RUF001 String contains ambiguous `ﮨ` (ARABIC LETTER HEH GOAL INITIAL FORM). Did you mean `o` (LATIN SMALL LETTER O)?
-   |
-60 | from typing import Literal
-61 | x: '''"""'Literal["ﮨ"]'"""'''
-   |                    ^ RUF001
-   |
-
-confusables.py:61:20: RUF001 String contains ambiguous `ﮨ` (ARABIC LETTER HEH GOAL INITIAL FORM). Did you mean `o` (LATIN SMALL LETTER O)?
-   |
-60 | from typing import Literal
-61 | x: '''"""'Literal["ﮨ"]'"""'''
-   |                    ^ RUF001
-   |


### PR DESCRIPTION
## Summary

There's no need to check this rule again when we're visiting a parsed string type definition; all errors will have been caught in the first traversal of the tree. Fixes #16117

## Test Plan

Added a fixture that reproduces the error on `main`.
