### PR TITLE
Refactor symbol lookup APIs to hide re-export implementation details

### DIFF
--- a/crates/red_knot_python_semantic/src/semantic_index/definition.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/definition.rs
@@ -50,10 +50,6 @@ impl<'db> Definition<'db> {
         self.kind(db).category()
     }
 
-    pub(crate) fn in_stub(self, db: &'db dyn Db) -> bool {
-        self.file(db).is_stub(db.upcast())
-    }
-
     pub(crate) fn is_declaration(self, db: &'db dyn Db) -> bool {
         self.kind(db).category().is_declaration()
     }

--- a/crates/red_knot_python_semantic/src/stdlib.rs
+++ b/crates/red_knot_python_semantic/src/stdlib.rs
@@ -2,7 +2,7 @@ use crate::module_resolver::{resolve_module, KnownModule};
 use crate::semantic_index::global_scope;
 use crate::semantic_index::symbol::ScopeId;
 use crate::symbol::Symbol;
-use crate::types::{imported_symbol, module_type_symbol};
+use crate::types::imported_symbol;
 use crate::Db;
 
 /// Lookup the type of `symbol` in a given known module
@@ -14,19 +14,8 @@ pub(crate) fn known_module_symbol<'db>(
     symbol: &str,
 ) -> Symbol<'db> {
     resolve_module(db, &known_module.name())
-        .map(|module| {
-            imported_symbol(db, &module, symbol)
-                .or_fall_back_to(db, || module_type_symbol(db, symbol))
-        })
+        .map(|module| imported_symbol(db, &module, symbol))
         .unwrap_or(Symbol::Unbound)
-}
-
-/// Lookup the type of `symbol` in the builtins namespace.
-///
-/// Returns `Symbol::Unbound` if the `builtins` module isn't available for some reason.
-#[inline]
-pub(crate) fn builtins_symbol<'db>(db: &'db dyn Db, symbol: &str) -> Symbol<'db> {
-    known_module_symbol(db, KnownModule::Builtins, symbol)
 }
 
 /// Lookup the type of `symbol` in the `typing` module namespace.

--- a/crates/red_knot_python_semantic/src/stdlib.rs
+++ b/crates/red_knot_python_semantic/src/stdlib.rs
@@ -2,7 +2,7 @@ use crate::module_resolver::{resolve_module, KnownModule};
 use crate::semantic_index::global_scope;
 use crate::semantic_index::symbol::ScopeId;
 use crate::symbol::Symbol;
-use crate::types::{global_symbol, SymbolLookup};
+use crate::types::{imported_symbol, module_type_symbol};
 use crate::Db;
 
 /// Lookup the type of `symbol` in a given known module
@@ -14,7 +14,10 @@ pub(crate) fn known_module_symbol<'db>(
     symbol: &str,
 ) -> Symbol<'db> {
     resolve_module(db, &known_module.name())
-        .map(|module| global_symbol(db, SymbolLookup::External, module.file(), symbol))
+        .map(|module| {
+            imported_symbol(db, &module, symbol)
+                .or_fall_back_to(db, || module_type_symbol(db, symbol))
+        })
         .unwrap_or(Symbol::Unbound)
 }
 

--- a/crates/red_knot_python_semantic/src/types/signatures.rs
+++ b/crates/red_knot_python_semantic/src/types/signatures.rs
@@ -322,13 +322,13 @@ pub(crate) enum ParameterKind<'db> {
 mod tests {
     use super::*;
     use crate::db::tests::{setup_db, TestDb};
-    use crate::types::{global_symbol, FunctionType, KnownClass, SymbolLookup};
+    use crate::types::{global_symbol, FunctionType, KnownClass};
     use ruff_db::system::DbWithTestSystem;
 
     #[track_caller]
     fn get_function_f<'db>(db: &'db TestDb, file: &'static str) -> FunctionType<'db> {
         let module = ruff_db::files::system_path_to_file(db, file).unwrap();
-        global_symbol(db, SymbolLookup::Internal, module, "f")
+        global_symbol(db, module, "f")
             .expect_type()
             .expect_function_literal()
     }


### PR DESCRIPTION
## Summary

This PR refactors the symbol lookup APIs to better facilitate the re-export implementation. Specifically,
* Add `module_type_symbol` which returns the `Symbol` that's a member of `types.ModuleType`
* Rename `symbol` -> `symbol_impl`; add `symbol` which delegates to `symbol_impl` with `RequireExplicitReExport::No`
* Update `global_symbol` to do `symbol_impl` -> fall back to `module_type_symbol` and default to `RequireExplicitReExport::No`
* Add `imported_symbol` to do `symbol_impl` with `RequireExplicitReExport` as `Yes` if the module is in a stub file else `No`
* Update `known_module_symbol` to use `imported_symbol` with a fallback to `module_type_symbol`
* Update `ModuleLiteralType::member` to use `imported_symbol` with a custom fallback

We could potentially also update `symbol_from_declarations` and `symbol_from_bindings` to avoid passing in the `RequireExplicitReExport` as it would be always `No` if called directly. We could add `symbol_from_declarations_impl` and `symbol_from_bindings_impl`.

Looking at the `_impl` functions, I think we should move all of these symbol related logic into `symbol.rs` where `Symbol` is defined and the `_impl` could be private while we expose the public APIs at the crate level. This would also make the `RequireExplicitReExport` an implementation detail and the caller doesn't need to worry about it.

Happy to hear others thoughts on this.