### PR TITLE
[red-knot] Remove `CallDunderResult::PossiblyUnbound` variant

### DIFF
--- a/crates/red_knot_python_semantic/src/types/call.rs
+++ b/crates/red_knot_python_semantic/src/types/call.rs
@@ -355,15 +355,15 @@ impl<'db> CallOutcome<'db> {
     }
 }
 
-pub(super) enum CallDunderResult<'db> {
-    CallOutcome(CallOutcome<'db>),
+pub(super) enum CallDunderOutcome<'db> {
+    Call(CallOutcome<'db>),
     MethodNotAvailable,
 }
 
-impl<'db> CallDunderResult<'db> {
+impl<'db> CallDunderOutcome<'db> {
     pub(super) fn return_type(&self, db: &'db dyn Db) -> Option<Type<'db>> {
         match self {
-            Self::CallOutcome(outcome) => {
+            Self::Call(outcome) => {
                 // TODO: Always call `outcome.return_type`, see https://github.com/astral-sh/ruff/issues/16123
                 if outcome.is_possibly_unbound_dunder() {
                     None

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -64,7 +64,7 @@ use crate::types::mro::MroErrorKind;
 use crate::types::unpacker::{UnpackResult, Unpacker};
 use crate::types::{
     builtins_symbol, global_symbol, symbol, symbol_from_bindings, symbol_from_declarations,
-    todo_type, typing_extensions_symbol, Boundness, CallDunderResult, Class, ClassLiteralType,
+    todo_type, typing_extensions_symbol, Boundness, CallDunderOutcome, Class, ClassLiteralType,
     DynamicType, FunctionType, InstanceType, IntersectionBuilder, IntersectionType,
     IterationOutcome, KnownClass, KnownFunction, KnownInstanceType, MetaclassCandidate,
     MetaclassErrorKind, SliceLiteralType, SubclassOfType, Symbol, SymbolAndQualifiers, Truthiness,
@@ -3567,7 +3567,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                     }
                 };
 
-                if let CallDunderResult::CallOutcome(call) = operand_type.call_dunder(
+                if let CallDunderOutcome::Call(call) = operand_type.call_dunder(
                     self.db(),
                     unary_dunder_method,
                     &CallArguments::positional([operand_type]),

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -3567,8 +3567,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                     }
                 };
 
-                if let CallDunderResult::CallOutcome(call)
-                | CallDunderResult::PossiblyUnbound(call) = operand_type.call_dunder(
+                if let CallDunderResult::CallOutcome(call) = operand_type.call_dunder(
                     self.db(),
                     unary_dunder_method,
                     &CallArguments::positional([operand_type]),


### PR DESCRIPTION
## Summary

This PR removes the `CallDunderResult::PossiblyUnbound` variant and instead uses the `CallOutcome` 
variant instead.

The motivation for this change is that a possibly unbound dunder could be represented in two ways before this change:

* `CallDunderResult::PossiblyUnbound`
* `CallDunderResult::CallOutcome(CallOutcome::PossiblyUnboundDunder)` 

We only ever created the first variant (to my knowledge) but this is hard to tell by just reading the downstream code. 

We can't remove `CallOutcome::PossiblyUnboundDunder` because it is used to emit a diagnostic in `CallOutcome::return_type_result`. That's why `CallDunderResult::PossiblyUnbound` had to go ;)

There's a second commit that renames `CallDunderResult` to `CallDunderOutcome`

## Test Plan

`cargo test`
