### PR TITLE
Use ubuntu-24 to run benchmarks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -712,7 +712,7 @@ jobs:
           just test
 
   benchmarks:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: determine_changes
     if: ${{ github.repository == 'astral-sh/ruff' && !contains(github.event.pull_request.labels.*.name, 'no-test') && (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}
     timeout-minutes: 20

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -712,7 +712,7 @@ jobs:
           just test
 
   benchmarks:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: determine_changes
     if: ${{ github.repository == 'astral-sh/ruff' && !contains(github.event.pull_request.labels.*.name, 'no-test') && (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}
     timeout-minutes: 20


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

The CI benchmark step is broken with:
```
/home/runner/.cargo/bin/cargo-codspeed: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by /home/runner/.cargo/bin/cargo-codspeed)
```
[main CI](https://github.com/astral-sh/ruff/actions/runs/13314818925/job/37186139311)


It was also failing in my PR. I updated the ubuntu version in my PR and it succeeded:
https://github.com/astral-sh/ruff/pull/16144/commits/d335cef9ab334032f391120b280a832bd8447085

Since it fixed the issue I am changing this to benchmark to use `ubuntu-latest` (since their [actions repo](https://github.com/CodSpeedHQ/action) is using this version in the examples) I am sure between 22.04 and latest.

## Test Plan

<!-- How was it tested? -->
