### PR TITLE
Replace dead link for rome tools playground

### DIFF
--- a/playground/README.md
+++ b/playground/README.md
@@ -27,4 +27,4 @@ a persistent datastore based on [Workers KV](https://developers.cloudflare.com/w
 and exposed via a [Cloudflare Worker](https://developers.cloudflare.com/workers/learning/how-workers-works/).
 
 The playground design is originally based on [Tailwind Play](https://play.tailwindcss.com/), with
-additional inspiration from the [Rome Tools Playground](https://docs.rome.tools/playground/).
+additional inspiration from the [Biome Playground](https://biomejs.dev/playground/).


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Rome Tools Playground was renamed to Biome Playground. The link was replaced to the new website. 

Resolves #16143


## Test Plan

- Checked the linked is accessible from the README
