### PR TITLE
Ignore source code actions for a notebook cell

### DIFF
--- a/crates/ruff_server/src/server/api/requests/code_action.rs
+++ b/crates/ruff_server/src/server/api/requests/code_action.rs
@@ -48,7 +48,11 @@ impl super::BackgroundDocumentRequestHandler for CodeActions {
 
         if snapshot.client_settings().fix_all() {
             if supported_code_actions.contains(&SupportedCodeAction::SourceFixAll) {
-                response.push(fix_all(&snapshot).with_failure_code(ErrorCode::InternalError)?);
+                if snapshot.is_notebook_cell() {
+                    tracing::debug!("Ignoring `source.fixAll` code action for a notebook cell");
+                } else {
+                    response.push(fix_all(&snapshot).with_failure_code(ErrorCode::InternalError)?);
+                }
             } else if supported_code_actions.contains(&SupportedCodeAction::NotebookSourceFixAll) {
                 response
                     .push(notebook_fix_all(&snapshot).with_failure_code(ErrorCode::InternalError)?);
@@ -57,8 +61,15 @@ impl super::BackgroundDocumentRequestHandler for CodeActions {
 
         if snapshot.client_settings().organize_imports() {
             if supported_code_actions.contains(&SupportedCodeAction::SourceOrganizeImports) {
-                response
-                    .push(organize_imports(&snapshot).with_failure_code(ErrorCode::InternalError)?);
+                if snapshot.is_notebook_cell() {
+                    tracing::debug!(
+                        "Ignoring `source.organizeImports` code action for a notebook cell"
+                    );
+                } else {
+                    response.push(
+                        organize_imports(&snapshot).with_failure_code(ErrorCode::InternalError)?,
+                    );
+                }
             } else if supported_code_actions
                 .contains(&SupportedCodeAction::NotebookSourceOrganizeImports)
             {

--- a/crates/ruff_server/src/server/api/requests/code_action.rs
+++ b/crates/ruff_server/src/server/api/requests/code_action.rs
@@ -49,6 +49,10 @@ impl super::BackgroundDocumentRequestHandler for CodeActions {
         if snapshot.client_settings().fix_all() {
             if supported_code_actions.contains(&SupportedCodeAction::SourceFixAll) {
                 if snapshot.is_notebook_cell() {
+                    // This is ignore here because the client requests this code action for each
+                    // cell in parallel and the server would send a workspace edit with the same
+                    // content which would result in applying the same edit multiple times
+                    // resulting in (possibly) duplicate code.
                     tracing::debug!("Ignoring `source.fixAll` code action for a notebook cell");
                 } else {
                     response.push(fix_all(&snapshot).with_failure_code(ErrorCode::InternalError)?);
@@ -62,6 +66,10 @@ impl super::BackgroundDocumentRequestHandler for CodeActions {
         if snapshot.client_settings().organize_imports() {
             if supported_code_actions.contains(&SupportedCodeAction::SourceOrganizeImports) {
                 if snapshot.is_notebook_cell() {
+                    // This is ignore here because the client requests this code action for each
+                    // cell in parallel and the server would send a workspace edit with the same
+                    // content which would result in applying the same edit multiple times
+                    // resulting in (possibly) duplicate code.
                     tracing::debug!(
                         "Ignoring `source.organizeImports` code action for a notebook cell"
                     );

--- a/crates/ruff_server/src/session.rs
+++ b/crates/ruff_server/src/session.rs
@@ -184,4 +184,15 @@ impl DocumentSnapshot {
     pub(crate) fn encoding(&self) -> PositionEncoding {
         self.position_encoding
     }
+
+    /// Returns `true` if this snapshot represents a notebook cell.
+    pub(crate) const fn is_notebook_cell(&self) -> bool {
+        matches!(
+            &self.document_ref,
+            index::DocumentQuery::Notebook {
+                cell_url: Some(_),
+                ..
+            }
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Related to https://github.com/astral-sh/ruff-vscode/pull/686, this PR ignores handling source code actions for notebooks which are not prefixed with `notebook`.

The main motivation is that the native server does not actually handle it well which results in gibberish code. There's some context about this in https://github.com/astral-sh/ruff-vscode/issues/680#issuecomment-2647490812 and the following comments.

closes: https://github.com/astral-sh/ruff-vscode/issues/680

## Test Plan

Running a notebook with the following does nothing except log the message:
```json
  "notebook.codeActionsOnSave": {
    "source.organizeImports.ruff": "explicit",
  },
```

while, including the `notebook` code actions does make the edit (as usual):
```json
  "notebook.codeActionsOnSave": {
    "notebook.source.organizeImports.ruff": "explicit"
  },
```
