### PR TITLE
[red-knot] Improve handling of inherited class attributes

### DIFF
--- a/crates/red_knot_python_semantic/src/symbol.rs
+++ b/crates/red_knot_python_semantic/src/symbol.rs
@@ -161,6 +161,9 @@ impl<'db> LookupError<'db> {
 
 /// A [`Result`] type in which the `Ok` variant represents a definitely bound symbol
 /// and the `Err` variant represents a symbol that is either definitely or possibly unbound.
+///
+/// Note that this type is exactly isomorphic to [`Symbol`].
+/// In the future, we could possibly consider removing `Symbol` and using this type everywhere instead.
 pub(crate) type LookupResult<'db> = Result<Type<'db>, LookupError<'db>>;
 
 #[cfg(test)]

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -4232,6 +4232,9 @@ impl<'db> Class<'db> {
         for superclass in self.iter_mro(db) {
             match superclass {
                 ClassBase::Dynamic(_) => {
+                    // Note: calling `Type::from(superclass).member()` would be incorrect here.
+                    // What we'd really want is a `Type::Any.own_class_member()` method,
+                    // but adding such a method wouldn't make much sense -- it would always return `Any`!
                     dynamic_type_to_intersect_with.get_or_insert(Type::from(superclass));
                 }
                 ClassBase::Class(class) => {


### PR DESCRIPTION
## Summary

This PR fixes a number of issues to do with inherited class attributes.

On `main`, if you run red-knot on this file, you get these results:

```py
from typing_extensions import reveal_type, ClassVar, Any, Literal

def _(flag: bool):
    class Foo:
        x = 1

    class Bar(Foo):
        if flag:
            x = 2

    # error: Attribute `x` on type `Literal[Bar]` is possibly unbound
    reveal_type(Bar.x)  # revealed: `Unknown | Literal[2]`

def _2(flag: bool):
    class Foo2:
        if flag:
            x = 1

    class Bar2(Foo2):
        if flag:
            x = 2

     # error: Attribute `x` on type `Literal[Bar]` is possibly unbound
    reveal_type(Bar2.x)  # revealed: `Unknown | Literal[2]`

class Foo3(Any): ...
reveal_type(Foo3.__repr__)  # revealed: Any

class A:
    x: ClassVar[Literal[1]] = 1

class B(Any): ...
class C(B, A): ...

reveal_type(C.x)  # revealed: `Any`
```

There are the following issues here:
1. The first "possibly unbound" diagnostic is a false positive, and the type is incorrect. Although the attribute is possibly unbound on the subclass, it is definitely bound on the superclass. We should union the two types together and understand the attribute as definitely bound.
2. The second "possibly unbound" diagnostic is correct, but the reported type is incorrect. Since the attribute is possibly unbound on the subclass, we should continue iterating up through the class's MRO until we find a definitely bound attribute on a superclass, and we should union all types we find in the process.
3. The revealed type for `Foo3.__repr__` is not incorrect, but it could be more precise. All classes -- even non-fully-static classes that have `Any` in their MRO -- inherit from `object`, and `object` has a `__repr__` method. We therefore know that whatever the type of `Foo3.__repr__` is, it must be a consistent subtype of the type of `object.__repr__`; `Literal[object.__repr__] & Any` is therefore a better type for `Foo3.__repr__` than `Any`.
4. A similar principle applies for the final revealed type, for `C.x`. `C` is not a fully static type (it has `Any` in its MRO), but it inherits from a fully static type `A` that has an `x` attribute. We therefore know that whatever type the `Any` in its MRO materialises to, the type of `C.x` must be a consistent subtype of the type of `A.x`; `Literal[1] & Any` is therefore a better type here than simply `Any`.

This PR fixes these issues by reworking `types::Class::class_member`. The PR is best reviewed one commit at a time:
1. The first commit is pure refactoring: it adds some new APIs to `Symbol` that moves the `Symbol` closer to our other `Outcome` enums. This refactoring makes commit 2 much easier.
2. Commit 2 fixes the bugs described above.

## Test Plan

New mdtests added, which all fail on `main`.
