### PR TITLE
Refactor `CallOutcome` to `Result`

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/assignment/augmented.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/assignment/augmented.md
@@ -40,7 +40,7 @@ class C:
         return 42
 
 x = C()
-# error: [unsupported-operator]
+# error: [unsupported-operator] "Operator `-=` is unsupported between objects of type `C` and `Literal[1]`"
 x -= 1
 
 reveal_type(x)  # revealed: int

--- a/crates/red_knot_python_semantic/resources/mdtest/assignment/augmented.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/assignment/augmented.md
@@ -40,7 +40,7 @@ class C:
         return 42
 
 x = C()
-# error: [invalid-argument-type]
+# error: [unsupported-operator]
 x -= 1
 
 reveal_type(x)  # revealed: int

--- a/crates/red_knot_python_semantic/resources/mdtest/binary/instances.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/binary/instances.md
@@ -260,8 +260,8 @@ class B:
     __add__ = A()
 
 # TODO: this could be `int` if we declare `B.__add__` using a `Callable` type
-# TODO: This should not be an error but we currently fail to bind `self` in `A.__call__` as `B`
-#       and instead bind it to `A` which makes the `__add__` call fail.
+# TODO: Should not be an error: `A` instance is not a method descriptor, don't prepend `self` arg.
+#   Revealed type should be `Unknown | int`.
 # error: [unsupported-operator] "Operator `+` is unsupported between objects of type `B` and `B`"
 reveal_type(B() + B())  # revealed: Unknown
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/binary/instances.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/binary/instances.md
@@ -244,10 +244,7 @@ class B:
     def __rsub__(self, other: A) -> B:
         return B()
 
-# TODO: this should be `B` (the return annotation of `B.__rsub__`),
-# because `A.__sub__` is annotated as only accepting `A`,
-# but `B.__rsub__` will accept `A`.
-reveal_type(A() - B())  # revealed: A
+reveal_type(A() - B())  # revealed: B
 ```
 
 ## Callable instances as dunders
@@ -263,7 +260,10 @@ class B:
     __add__ = A()
 
 # TODO: this could be `int` if we declare `B.__add__` using a `Callable` type
-reveal_type(B() + B())  # revealed: Unknown | int
+# TODO: This should not be an error but we currently fail to bind `self` in `A.__call__` as `B`
+#       and instead bind it to `A` which makes the `__add__` call fail.
+# error: [unsupported-operator] "Operator `+` is unsupported between objects of type `B` and `B`"
+reveal_type(B() + B())  # revealed: Unknown
 ```
 
 ## Integration test: numbers from typeshed
@@ -277,22 +277,14 @@ return annotations from the widening, and preserve a bit more precision here?
 reveal_type(3j + 3.14)  # revealed: int | float | complex
 reveal_type(4.2 + 42)  # revealed: int | float
 reveal_type(3j + 3)  # revealed: int | float | complex
-
-# TODO should be int | float | complex, need to check arg type and fall back to `rhs.__radd__`
-reveal_type(3.14 + 3j)  # revealed: int | float
-
-# TODO should be int | float, need to check arg type and fall back to `rhs.__radd__`
-reveal_type(42 + 4.2)  # revealed: int
-
-# TODO should be int | float | complex, need to check arg type and fall back to `rhs.__radd__`
-reveal_type(3 + 3j)  # revealed: int
+reveal_type(3.14 + 3j)  # revealed: int | float | complex
+reveal_type(42 + 4.2)  # revealed: int | float
+reveal_type(3 + 3j)  # revealed: int | float | complex
 
 def _(x: bool, y: int):
     reveal_type(x + y)  # revealed: int
     reveal_type(4.2 + x)  # revealed: int | float
-
-    # TODO should be float, need to check arg type and fall back to `rhs.__radd__`
-    reveal_type(y + 4.12)  # revealed: int
+    reveal_type(y + 4.12)  # revealed: int | float
 ```
 
 ## With literal types
@@ -309,8 +301,7 @@ class A:
         return self
 
 reveal_type(A() + 1)  # revealed: A
-# TODO should be `A` since `int.__add__` doesn't support `A` instances
-reveal_type(1 + A())  # revealed: int
+reveal_type(1 + A())  # revealed: A
 
 reveal_type(A() + "foo")  # revealed: A
 # TODO should be `A` since `str.__add__` doesn't support `A` instances

--- a/crates/red_knot_python_semantic/resources/mdtest/binary/integers.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/binary/integers.md
@@ -12,7 +12,8 @@ reveal_type(5 % 3)  # revealed: Literal[2]
 
 # TODO: We don't currently verify that the actual parameter to int.__add__ matches the declared
 # formal parameter type.
-reveal_type(2 + "f")  # revealed: int
+# TODO: Should this emit an error?
+reveal_type(2 + "f")  # revealed: Unknown
 
 def lhs(x: int):
     reveal_type(x + 1)  # revealed: int

--- a/crates/red_knot_python_semantic/resources/mdtest/binary/integers.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/binary/integers.md
@@ -10,7 +10,7 @@ reveal_type(-3 // 3)  # revealed: Literal[-1]
 reveal_type(-3 / 3)  # revealed: float
 reveal_type(5 % 3)  # revealed: Literal[2]
 
-# TODO: This should emit an unsupported-operator error but we don't currently 
+# TODO: This should emit an unsupported-operator error but we don't currently
 #  verify that the actual parameter to `int.__add__` matches the declared
 #  formal parameter type.
 reveal_type(2 + "f")  # revealed: Unknown

--- a/crates/red_knot_python_semantic/resources/mdtest/binary/integers.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/binary/integers.md
@@ -10,9 +10,9 @@ reveal_type(-3 // 3)  # revealed: Literal[-1]
 reveal_type(-3 / 3)  # revealed: float
 reveal_type(5 % 3)  # revealed: Literal[2]
 
-# TODO: We don't currently verify that the actual parameter to int.__add__ matches the declared
-# formal parameter type.
-# TODO: Should this emit an error?
+# TODO: This should emit an unsupported-operator error but we don't currently 
+#  verify that the actual parameter to `int.__add__` matches the declared
+#  formal parameter type.
 reveal_type(2 + "f")  # revealed: Unknown
 
 def lhs(x: int):

--- a/crates/red_knot_python_semantic/resources/mdtest/call/callable_instance.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/call/callable_instance.md
@@ -99,3 +99,27 @@ c = C()
 # error: 13 [invalid-argument-type] "Object of type `C` cannot be assigned to parameter 1 (`self`) of function `__call__`; expected type `int`"
 reveal_type(c())  # revealed: int
 ```
+
+## Union over callables
+
+### Possibly unbound `__call__`
+
+```py
+def outer(cond1: bool):
+	class Test:
+		if cond1:
+			def __call__(self): ...
+	
+	class Other:
+		def __call__(self): ...
+	
+	def inner(cond2: bool): 
+		if cond2:
+			a = Test()
+		else:
+			a = Other()
+	
+        # TODO: Improve the error message to a) be more specific what `__call__` is and b) mention that it is possibly unbound.
+        # error: [call-non-callable] "Object of type `Test | Other` is not callable (due to union element `Literal[__call__]`)"
+		a()
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/call/callable_instance.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/call/callable_instance.md
@@ -68,7 +68,7 @@ def _(flag: bool):
 
     a = NonCallable()
     # error: "Object of type `Literal[1] | Literal[__call__]` is not callable (due to union element `Literal[1]`)"
-    reveal_type(a())  # revealed: Unknown | int
+    reveal_type(a())  # revealed: int | Unknown
 ```
 
 ## Call binding errors

--- a/crates/red_knot_python_semantic/resources/mdtest/call/callable_instance.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/call/callable_instance.md
@@ -52,7 +52,7 @@ class NonCallable:
     __call__ = 1
 
 a = NonCallable()
-# error: "Object of type `Unknown | Literal[1]` is not callable (due to union element `Literal[1]`)"
+# error: [call-non-callable] "Object of type `Literal[1]` is not callable"
 reveal_type(a())  # revealed: Unknown
 ```
 
@@ -67,7 +67,7 @@ def _(flag: bool):
             def __call__(self) -> int: ...
 
     a = NonCallable()
-    # error: "Object of type `Literal[1] | Literal[__call__]` is not callable (due to union element `Literal[1]`)"
+    # error: [call-non-callable] "Object of type `Literal[1]` is not callable"
     reveal_type(a())  # revealed: int | Unknown
 ```
 
@@ -106,20 +106,19 @@ reveal_type(c())  # revealed: int
 
 ```py
 def outer(cond1: bool):
-	class Test:
-		if cond1:
-			def __call__(self): ...
-	
-	class Other:
-		def __call__(self): ...
-	
-	def inner(cond2: bool): 
-		if cond2:
-			a = Test()
-		else:
-			a = Other()
-	
-        # TODO: Improve the error message to a) be more specific what `__call__` is and b) mention that it is possibly unbound.
-        # error: [call-non-callable] "Object of type `Test | Other` is not callable (due to union element `Literal[__call__]`)"
-		a()
+    class Test:
+        if cond1:
+            def __call__(self): ...
+
+    class Other:
+        def __call__(self): ...
+
+    def inner(cond2: bool):
+        if cond2:
+            a = Test()
+        else:
+            a = Other()
+
+            # error: [call-non-callable] "Object of type `Test` is not callable (possibly unbound `__call__` method)"
+        a()
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/call/function.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/call/function.md
@@ -278,10 +278,10 @@ proper diagnostics in case of missing or superfluous arguments.
 from typing_extensions import reveal_type
 
 # error: [missing-argument] "No argument provided for required parameter `obj` of function `reveal_type`"
-reveal_type()  # revealed: Unknown
+reveal_type()
 
 # error: [too-many-positional-arguments] "Too many positional arguments to function `reveal_type`: expected 1, got 2"
-reveal_type(1, 2)  # revealed: Literal[1]
+reveal_type(1, 2)
 ```
 
 ### `static_assert`
@@ -290,7 +290,6 @@ reveal_type(1, 2)  # revealed: Literal[1]
 from knot_extensions import static_assert
 
 # error: [missing-argument] "No argument provided for required parameter `condition` of function `static_assert`"
-# error: [static-assert-error]
 static_assert()
 
 # error: [too-many-positional-arguments] "Too many positional arguments to function `static_assert`: expected 2, got 3"

--- a/crates/red_knot_python_semantic/resources/mdtest/call/union.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/call/union.md
@@ -81,8 +81,8 @@ def _(flag: bool):
 Calling a union where the arguments don't match the signature of all variants.
 
 ```py
-def f1(a: int): ...
-def f2(a: str): ...
+def f1(a: int) -> int: ...
+def f2(a: str) -> str: ...
 def _(flag: bool):
     if flag:
         f = f1
@@ -91,10 +91,10 @@ def _(flag: bool):
 
     # error: [call-non-callable] "Object of type `Literal[f1, f2]` is not callable (due to union element `Literal[f2]`)"
     x = f(3)
-    reveal_type(x)  # revealed: Unknown
+    reveal_type(x)  # revealed: int | str
 ```
 
-## Any non callable variant
+## Any non-callable variant
 
 ```py
 def f1(a: int): ...
@@ -102,9 +102,9 @@ def _(flag: bool):
     if flag:
         f = f1
     else:
-        f = "str"
+        f = "This is a string literal"
 
-    # error: [call-non-callable] "Object of type `Literal[f1] | Literal["str"]` is not callable (due to union element `Literal["str"]`)"
+    # error: [call-non-callable] "Object of type `Literal[f1] | Literal["This is a string literal"]` is not callable (due to union element `Literal["This is a string literal"]`)"
     x = f(3)
     reveal_type(x)  # revealed: Unknown
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/call/union.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/call/union.md
@@ -39,7 +39,7 @@ def _(flag: bool):
     else:
         def f() -> int:
             return 1
-    x = f()  # error: "Object of type `Literal[1] | Literal[f]` is not callable (due to union element `Literal[1]`)"
+    x = f()  # error: [call-non-callable] "Object of type `Literal[1]` is not callable"
     reveal_type(x)  # revealed: int | Unknown
 ```
 
@@ -56,7 +56,7 @@ def _(flag: bool, flag2: bool):
     else:
         def f() -> int:
             return 1
-    # error: "Object of type `Literal[1, "foo"] | Literal[f]` is not callable (due to union elements Literal[1], Literal["foo"])"
+    # error: [call-non-callable] "Object of type `Literal[1]` is not callable"
     # revealed: int | Unknown
     reveal_type(f())
 ```
@@ -72,7 +72,7 @@ def _(flag: bool):
     else:
         f = "foo"
 
-    x = f()  # error: "Object of type `Literal[1, "foo"]` is not callable"
+    x = f()  # error: [call-non-callable] "Object of type `Literal[1, "foo"]` is not callable"
     reveal_type(x)  # revealed: Unknown
 ```
 
@@ -89,7 +89,7 @@ def _(flag: bool):
     else:
         f = f2
 
-    # error: [call-non-callable] "Object of type `Literal[f1, f2]` is not callable (due to union element `Literal[f2]`)"
+    # error: [invalid-argument-type] "Object of type `Literal[3]` cannot be assigned to parameter 1 (`a`) of function `f2`; expected type `str`"
     x = f(3)
     reveal_type(x)  # revealed: int | str
 ```
@@ -104,7 +104,7 @@ def _(flag: bool):
     else:
         f = "This is a string literal"
 
-    # error: [call-non-callable] "Object of type `Literal[f1] | Literal["This is a string literal"]` is not callable (due to union element `Literal["This is a string literal"]`)"
+    # error: [call-non-callable] "Object of type `Literal["This is a string literal"]` is not callable"
     x = f(3)
     reveal_type(x)  # revealed: Unknown
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/call/union.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/call/union.md
@@ -40,7 +40,7 @@ def _(flag: bool):
         def f() -> int:
             return 1
     x = f()  # error: "Object of type `Literal[1] | Literal[f]` is not callable (due to union element `Literal[1]`)"
-    reveal_type(x)  # revealed: Unknown | int
+    reveal_type(x)  # revealed: int | Unknown
 ```
 
 ## Multiple non-callable elements in a union
@@ -57,7 +57,7 @@ def _(flag: bool, flag2: bool):
         def f() -> int:
             return 1
     # error: "Object of type `Literal[1, "foo"] | Literal[f]` is not callable (due to union elements Literal[1], Literal["foo"])"
-    # revealed: Unknown | int
+    # revealed: int | Unknown
     reveal_type(f())
 ```
 
@@ -76,7 +76,6 @@ def _(flag: bool):
     reveal_type(x)  # revealed: Unknown
 ```
 
-
 ## Mismatching signatures
 
 Calling a union where the arguments don't match the signature of all variants.
@@ -84,30 +83,28 @@ Calling a union where the arguments don't match the signature of all variants.
 ```py
 def f1(a: int): ...
 def f2(a: str): ...
-
 def _(flag: bool):
     if flag:
         f = f1
     else:
         f = f2
 
-    x = f(3)  # error: "Object of type `Literal[1, "foo"]` is not callable"
+    # error: [call-non-callable] "Object of type `Literal[f1, f2]` is not callable (due to union element `Literal[f2]`)"
+    x = f(3)
     reveal_type(x)  # revealed: Unknown
 ```
-
 
 ## Any non callable variant
 
 ```py
 def f1(a: int): ...
-def f2(a: str): ...
-
 def _(flag: bool):
     if flag:
         f = f1
     else:
         f = "str"
 
-    x = f(3)  # error: "Object of type `Literal[1, "foo"]` is not callable"
+    # error: [call-non-callable] "Object of type `Literal[f1] | Literal["str"]` is not callable (due to union element `Literal["str"]`)"
+    x = f(3)
     reveal_type(x)  # revealed: Unknown
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/call/union.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/call/union.md
@@ -75,3 +75,39 @@ def _(flag: bool):
     x = f()  # error: "Object of type `Literal[1, "foo"]` is not callable"
     reveal_type(x)  # revealed: Unknown
 ```
+
+
+## Mismatching signatures
+
+Calling a union where the arguments don't match the signature of all variants.
+
+```py
+def f1(a: int): ...
+def f2(a: str): ...
+
+def _(flag: bool):
+    if flag:
+        f = f1
+    else:
+        f = f2
+
+    x = f(3)  # error: "Object of type `Literal[1, "foo"]` is not callable"
+    reveal_type(x)  # revealed: Unknown
+```
+
+
+## Any non callable variant
+
+```py
+def f1(a: int): ...
+def f2(a: str): ...
+
+def _(flag: bool):
+    if flag:
+        f = f1
+    else:
+        f = "str"
+
+    x = f(3)  # error: "Object of type `Literal[1, "foo"]` is not callable"
+    reveal_type(x)  # revealed: Unknown
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/comparison/instances/membership_test.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/comparison/instances/membership_test.md
@@ -21,8 +21,9 @@ class A:
 
 reveal_type("hello" in A())  # revealed: bool
 reveal_type("hello" not in A())  # revealed: bool
-# TODO: should emit diagnostic, need to check arg type, will fail
+# error: [unsupported-operator] "Operator `in` is not supported for types `int` and `A`, in comparing `Literal[42]` with `A`"
 reveal_type(42 in A())  # revealed: bool
+# error: [unsupported-operator] "Operator `not in` is not supported for types `int` and `A`, in comparing `Literal[42]` with `A`"
 reveal_type(42 not in A())  # revealed: bool
 ```
 
@@ -126,9 +127,9 @@ class A:
 
 reveal_type(CheckContains() in A())  # revealed: bool
 
-# TODO: should emit diagnostic, need to check arg type,
-# should not fall back to __iter__ or __getitem__
+# error: [unsupported-operator] "Operator `in` is not supported for types `CheckIter` and `A`"
 reveal_type(CheckIter() in A())  # revealed: bool
+# error: [unsupported-operator] "Operator `in` is not supported for types `CheckGetItem` and `A`"
 reveal_type(CheckGetItem() in A())  # revealed: bool
 
 class B:
@@ -154,7 +155,8 @@ class A:
     def __getitem__(self, key: str) -> str:
         return "foo"
 
-# TODO should emit a diagnostic
+# error: [unsupported-operator] "Operator `in` is not supported for types `int` and `A`, in comparing `Literal[42]` with `A`"
 reveal_type(42 in A())  # revealed: bool
+# error: [unsupported-operator] "Operator `in` is not supported for types `str` and `A`, in comparing `Literal["hello"]` with `A`"
 reveal_type("hello" in A())  # revealed: bool
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/comparison/instances/rich_comparison.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/comparison/instances/rich_comparison.md
@@ -117,14 +117,11 @@ class B:
     def __ne__(self, other: str) -> B:
         return B()
 
-# TODO: should be `int` and `bytearray`.
-# Need to check arg type and fall back to `rhs.__eq__` and `rhs.__ne__`.
-#
 # Because `object.__eq__` and `object.__ne__` accept `object` in typeshed,
 # this can only happen with an invalid override of these methods,
 # but we still support it.
-reveal_type(B() == A())  # revealed: B
-reveal_type(B() != A())  # revealed: B
+reveal_type(B() == A())  # revealed: int
+reveal_type(B() != A())  # revealed: bytearray
 
 reveal_type(B() < A())  # revealed: list
 reveal_type(B() <= A())  # revealed: set
@@ -222,9 +219,8 @@ class B(A):
     def __gt__(self, other: int) -> B:
         return B()
 
-# TODO: should be `A`, need to check argument type and fall back to LHS method
-reveal_type(A() < B())  # revealed: B
-reveal_type(A() > B())  # revealed: B
+reveal_type(A() < B())  # revealed: A
+reveal_type(A() > B())  # revealed: A
 ```
 
 ## Operations involving instances of classes inheriting from `Any`
@@ -272,9 +268,8 @@ class A:
     def __ne__(self, other: int) -> A:
         return A()
 
-# TODO: it should be `bool`, need to check arg type and fall back to `is` and `is not`
-reveal_type(A() == A())  # revealed: A
-reveal_type(A() != A())  # revealed: A
+reveal_type(A() == A())  # revealed: bool
+reveal_type(A() != A())  # revealed: bool
 ```
 
 ## Object Comparisons with Typeshed
@@ -305,12 +300,14 @@ reveal_type(1 >= 1.0)  # revealed: bool
 reveal_type(1 == 2j)  # revealed: bool
 reveal_type(1 != 2j)  # revealed: bool
 
-# TODO: should be Unknown and emit diagnostic,
-# need to check arg type and should be failed
-reveal_type(1 < 2j)  # revealed: bool
-reveal_type(1 <= 2j)  # revealed: bool
-reveal_type(1 > 2j)  # revealed: bool
-reveal_type(1 >= 2j)  # revealed: bool
+# error: [unsupported-operator] "Operator `<` is not supported for types `int` and `complex`, in comparing `Literal[1]` with `complex`"
+reveal_type(1 < 2j)  # revealed: Unknown
+# error: [unsupported-operator] "Operator `<=` is not supported for types `int` and `complex`, in comparing `Literal[1]` with `complex`"
+reveal_type(1 <= 2j)  # revealed: Unknown
+# error: [unsupported-operator] "Operator `>` is not supported for types `int` and `complex`, in comparing `Literal[1]` with `complex`"
+reveal_type(1 > 2j)  # revealed: Unknown
+# error: [unsupported-operator] "Operator `>=` is not supported for types `int` and `complex`, in comparing `Literal[1]` with `complex`"
+reveal_type(1 >= 2j)  # revealed: Unknown
 
 def f(x: bool, y: int):
     reveal_type(x < y)  # revealed: bool

--- a/crates/red_knot_python_semantic/resources/mdtest/comparison/integers.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/comparison/integers.md
@@ -12,8 +12,8 @@ reveal_type(1 is 1)  # revealed: bool
 reveal_type(1 is not 1)  # revealed: bool
 reveal_type(1 is 2)  # revealed: Literal[False]
 reveal_type(1 is not 7)  # revealed: Literal[True]
-# TODO: should be Unknown, and emit diagnostic, once we check call argument types
-reveal_type(1 <= "" and 0 < 1)  # revealed: bool
+# error: [unsupported-operator] "Operator `<=` is not supported for types `int` and `str`, in comparing `Literal[1]` with `Literal[""]`"
+reveal_type(1 <= "" and 0 < 1)  # revealed: Unknown & ~AlwaysTruthy | Literal[True]
 ```
 
 ## Integer instance

--- a/crates/red_knot_python_semantic/resources/mdtest/comparison/intersections.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/comparison/intersections.md
@@ -8,18 +8,15 @@ types, we can infer that the result for the intersection type is also true/false
 ```py
 from typing import Literal
 
-class Base: ...
+class Base:
+    def __gt__(self, other) -> bool:
+        return False
 
 class Child1(Base):
     def __eq__(self, other) -> Literal[True]:
         return True
 
-    def __gt__(self, other) -> bool:
-        return False
-
-class Child2(Base):
-    def __gt__(self, other) -> bool:
-        return False
+class Child2(Base): ...
 
 def _(x: Base):
     c1 = Child1()

--- a/crates/red_knot_python_semantic/resources/mdtest/comparison/intersections.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/comparison/intersections.md
@@ -14,7 +14,12 @@ class Child1(Base):
     def __eq__(self, other) -> Literal[True]:
         return True
 
-class Child2(Base): ...
+    def __gt__(self, other) -> bool:
+        return False
+
+class Child2(Base):
+    def __gt__(self, other) -> bool:
+        return False
 
 def _(x: Base):
     c1 = Child1()

--- a/crates/red_knot_python_semantic/resources/mdtest/comparison/non_bool_returns.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/comparison/non_bool_returns.md
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 class A:
     def __lt__(self, other) -> A: ...
-    def __gt__(self, other) -> A: ...
+    def __gt__(self, other) -> bool: ...
 
 class B:
     def __lt__(self, other) -> B: ...
@@ -35,7 +35,7 @@ x = A() < B() < C()
 reveal_type(x)  # revealed: A & ~AlwaysTruthy | B
 
 y = 0 < 1 < A() < 3
-reveal_type(y)  # revealed: A
+reveal_type(y)  # revealed: Literal[False] | A
 
 z = 10 < 0 < A() < B() < C()
 reveal_type(z)  # revealed: Literal[False]

--- a/crates/red_knot_python_semantic/resources/mdtest/comparison/non_bool_returns.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/comparison/non_bool_returns.md
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 class A:
     def __lt__(self, other) -> A: ...
+    def __gt__(self, other) -> A: ...
 
 class B:
     def __lt__(self, other) -> B: ...
@@ -34,7 +35,7 @@ x = A() < B() < C()
 reveal_type(x)  # revealed: A & ~AlwaysTruthy | B
 
 y = 0 < 1 < A() < 3
-reveal_type(y)  # revealed: Literal[False] | A
+reveal_type(y)  # revealed: A
 
 z = 10 < 0 < A() < B() < C()
 reveal_type(z)  # revealed: Literal[False]

--- a/crates/red_knot_python_semantic/resources/mdtest/comparison/tuples.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/comparison/tuples.md
@@ -92,11 +92,14 @@ reveal_type(a == b)  # revealed: bool
 # TODO: should be Literal[True], once we implement (in)equality for mismatched literals
 reveal_type(a != b)  # revealed: bool
 
-# TODO: should be Unknown and add more informative diagnostics
-reveal_type(a < b)  # revealed: bool
-reveal_type(a <= b)  # revealed: bool
-reveal_type(a > b)  # revealed: bool
-reveal_type(a >= b)  # revealed: bool
+# error: [unsupported-operator] "Operator `<` is not supported for types `int` and `str`, in comparing `tuple[Literal[1], Literal[2]]` with `tuple[Literal[1], Literal["hello"]]`"
+reveal_type(a < b)  # revealed: Unknown
+# error: [unsupported-operator] "Operator `<=` is not supported for types `int` and `str`, in comparing `tuple[Literal[1], Literal[2]]` with `tuple[Literal[1], Literal["hello"]]`"
+reveal_type(a <= b)  # revealed: Unknown
+# error: [unsupported-operator] "Operator `>` is not supported for types `int` and `str`, in comparing `tuple[Literal[1], Literal[2]]` with `tuple[Literal[1], Literal["hello"]]`"
+reveal_type(a > b)  # revealed: Unknown
+# error: [unsupported-operator] "Operator `>=` is not supported for types `int` and `str`, in comparing `tuple[Literal[1], Literal[2]]` with `tuple[Literal[1], Literal["hello"]]`"
+reveal_type(a >= b)  # revealed: Unknown
 ```
 
 However, if the lexicographic comparison completes without reaching a point where str and int are

--- a/crates/red_knot_python_semantic/resources/mdtest/comparison/unsupported.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/comparison/unsupported.md
@@ -9,28 +9,22 @@ def _(flag: bool, flag1: bool, flag2: bool):
     b = 0 not in 10  # error: "Operator `not in` is not supported for types `Literal[0]` and `Literal[10]`"
     reveal_type(b)  # revealed: bool
 
-    # TODO: should error, once operand type check is implemented
-    # ("Operator `<` is not supported for types `object` and `int`")
+    # error: [unsupported-operator] "Operator `<` is not supported for types `object` and `int`, in comparing `object` with `Literal[5]`"
     c = object() < 5
-    # TODO: should be Unknown, once operand type check is implemented
-    reveal_type(c)  # revealed: bool
+    reveal_type(c)  # revealed: Unknown
 
-    # TODO: should error, once operand type check is implemented
-    # ("Operator `<` is not supported for types `int` and `object`")
+    # error: [unsupported-operator] "Operator `<` is not supported for types `int` and `object`, in comparing `Literal[5]` with `object`"
     d = 5 < object()
-    # TODO: should be Unknown, once operand type check is implemented
-    reveal_type(d)  # revealed: bool
+    reveal_type(d)  # revealed: Unknown
 
     int_literal_or_str_literal = 1 if flag else "foo"
     # error: "Operator `in` is not supported for types `Literal[42]` and `Literal[1]`, in comparing `Literal[42]` with `Literal[1, "foo"]`"
     e = 42 in int_literal_or_str_literal
     reveal_type(e)  # revealed: bool
 
-    # TODO: should error, need to check if __lt__ signature is valid for right operand
-    # error may be "Operator `<` is not supported for types `int` and `str`, in comparing `tuple[Literal[1], Literal[2]]` with `tuple[Literal[1], Literal["hello"]]`
+    # error: [unsupported-operator] "Operator `<` is not supported for types `int` and `str`, in comparing `tuple[Literal[1], Literal[2]]` with `tuple[Literal[1], Literal["hello"]]`"
     f = (1, 2) < (1, "hello")
-    # TODO: should be Unknown, once operand type check is implemented
-    reveal_type(f)  # revealed: bool
+    reveal_type(f)  # revealed: Unknown
 
     # error: [unsupported-operator] "Operator `<` is not supported for types `A` and `A`, in comparing `tuple[bool, A]` with `tuple[bool, A]`"
     g = (flag1, A()) < (flag2, A())

--- a/crates/red_knot_python_semantic/resources/mdtest/loops/for.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/loops/for.md
@@ -247,7 +247,7 @@ class Test2:
 def _(flag: bool):
     # error: "Object of type `Test | Test2` is not iterable"
     for x in Test() if flag else Test2():
-        reveal_type(x)  # revealed: Unknown
+        reveal_type(x)  # revealed: int
 ```
 
 ## Union type as iterator where one union element has no `__next__` method
@@ -263,5 +263,5 @@ class Test:
 
 # error: [not-iterable] "Object of type `Test` is not iterable"
 for x in Test():
-    reveal_type(x)  # revealed: Unknown
+    reveal_type(x)  # revealed: int
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/loops/for.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/loops/for.md
@@ -245,6 +245,7 @@ class Test2:
         return 42
 
 def _(flag: bool):
+    # TODO: Improve error message to state which union variant isn't iterable (https://github.com/astral-sh/ruff/issues/13989)
     # error: "Object of type `Test | Test2` is not iterable"
     for x in Test() if flag else Test2():
         reveal_type(x)  # revealed: int

--- a/crates/red_knot_python_semantic/resources/mdtest/with/sync.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/with/sync.md
@@ -134,3 +134,20 @@ def _(flag: bool):
     with Manager() as f:
         reveal_type(f)  # revealed: str
 ```
+
+## Invalid `__enter__` signature
+
+```py
+class Manager:
+    def __enter__() -> str:
+        return "foo"
+
+    def __exit__(self, exc_type, exc_value, traceback): ...
+
+context_expr = Manager()
+
+# error: [invalid-context-manager] "Object of type `Manager` cannot be used with `with` because the method `__enter__` of type `Literal[__enter__]` is not callable"
+with context_expr as f:
+    # TODO: Should this be Unknown?
+    reveal_type(f)  # revealed: str
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/with/sync.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/with/sync.md
@@ -80,7 +80,7 @@ class Manager:
 
     def __exit__(self, exc_tpe, exc_value, traceback): ...
 
-# error: [invalid-context-manager] "Object of type `Manager` cannot be used with `with` because the method `__enter__` of type `int` is not callable"
+# error: [invalid-context-manager] "Object of type `Manager` cannot be used with `with` because it does not correctly implement `__enter__`"
 with Manager():
     ...
 ```
@@ -95,7 +95,7 @@ class Manager:
 
     __exit__: int = 32
 
-# error: [invalid-context-manager] "Object of type `Manager` cannot be used with `with` because the method `__exit__` of type `int` is not callable"
+# error: [invalid-context-manager] "Object of type `Manager` cannot be used with `with` because it does not correctly implement `__exit__`"
 with Manager():
     ...
 ```
@@ -146,8 +146,7 @@ class Manager:
 
 context_expr = Manager()
 
-# error: [invalid-context-manager] "Object of type `Manager` cannot be used with `with` because the method `__enter__` of type `Literal[__enter__]` is not callable"
+# error: [invalid-context-manager] "Object of type `Manager` cannot be used with `with` because it does not correctly implement `__enter__`"
 with context_expr as f:
-    # TODO: Should this be Unknown?
     reveal_type(f)  # revealed: str
 ```

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1,11 +1,11 @@
 use std::hash::Hash;
 
 use bitflags::bitflags;
+use call::{CallDunderError, CallError, NotCallableVariant};
 use context::InferContext;
 use diagnostic::{report_not_iterable, report_not_iterable_possibly_unbound};
 use indexmap::IndexSet;
 use itertools::Itertools;
-use ruff_db::diagnostic::Severity;
 use ruff_db::files::File;
 use ruff_python_ast as ast;
 use ruff_python_ast::python_version::PythonVersion;
@@ -36,7 +36,7 @@ use crate::symbol::{
     global_symbol, imported_symbol, known_module_symbol, symbol, symbol_from_bindings,
     symbol_from_declarations, Boundness, LookupError, LookupResult, Symbol, SymbolAndQualifiers,
 };
-use crate::types::call::{bind_call, CallArguments, CallBinding, CallDunderResult, CallOutcome};
+use crate::types::call::{bind_call, CallArguments, CallBinding, CallOutcome};
 use crate::types::class_base::ClassBase;
 use crate::types::diagnostic::INVALID_TYPE_FORM;
 use crate::types::infer::infer_unpack_types;
@@ -1467,9 +1467,9 @@ impl<'db> Type<'db> {
                         return Truthiness::Ambiguous;
                     };
 
-                    if let Some(Type::BooleanLiteral(bool_val)) = bool_method
+                    if let Ok(Type::BooleanLiteral(bool_val)) = bool_method
                         .call_bound(db, instance_ty, &CallArguments::positional([]))
-                        .return_type(db)
+                        .map(|outcome| outcome.return_type(db))
                     {
                         bool_val.into()
                     } else {
@@ -1542,20 +1542,23 @@ impl<'db> Type<'db> {
         }
 
         let return_ty = match self.call_dunder(db, "__len__", &CallArguments::positional([*self])) {
-            // TODO: emit a diagnostic
-            CallDunderResult::MethodNotAvailable => return None,
+            Ok(outcome) | Err(CallDunderError::PossiblyUnbound(outcome)) => outcome.return_type(db),
 
-            CallDunderResult::CallOutcome(outcome) | CallDunderResult::PossiblyUnbound(outcome) => {
-                outcome.return_type(db)?
-            }
+            // TODO: emit a diagnostic
+            Err(err) => err.return_type(db)?,
         };
 
         non_negative_int_literal(db, return_ty)
     }
 
-    /// Return the outcome of calling an object of this type.
-    #[must_use]
-    fn call(self, db: &'db dyn Db, arguments: &CallArguments<'_, 'db>) -> CallOutcome<'db> {
+    /// Calls `self`
+    ///
+    /// Returns `Ok` if the call with the given arguments is successful and `Err` otherwise.
+    fn call(
+        self,
+        db: &'db dyn Db,
+        arguments: &CallArguments<'_, 'db>,
+    ) -> Result<CallOutcome<'db>, CallError<'db>> {
         match self {
             Type::FunctionLiteral(function_type) => {
                 let mut binding = bind_call(db, arguments, function_type.signature(db), self);
@@ -1566,14 +1569,12 @@ impl<'db> Type<'db> {
                             .unwrap_or((Type::unknown(), Type::unknown()));
                         binding
                             .set_return_type(Type::BooleanLiteral(ty_a.is_equivalent_to(db, ty_b)));
-                        CallOutcome::callable(binding)
                     }
                     Some(KnownFunction::IsSubtypeOf) => {
                         let (ty_a, ty_b) = binding
                             .two_parameter_types()
                             .unwrap_or((Type::unknown(), Type::unknown()));
                         binding.set_return_type(Type::BooleanLiteral(ty_a.is_subtype_of(db, ty_b)));
-                        CallOutcome::callable(binding)
                     }
                     Some(KnownFunction::IsAssignableTo) => {
                         let (ty_a, ty_b) = binding
@@ -1581,7 +1582,6 @@ impl<'db> Type<'db> {
                             .unwrap_or((Type::unknown(), Type::unknown()));
                         binding
                             .set_return_type(Type::BooleanLiteral(ty_a.is_assignable_to(db, ty_b)));
-                        CallOutcome::callable(binding)
                     }
                     Some(KnownFunction::IsDisjointFrom) => {
                         let (ty_a, ty_b) = binding
@@ -1589,7 +1589,6 @@ impl<'db> Type<'db> {
                             .unwrap_or((Type::unknown(), Type::unknown()));
                         binding
                             .set_return_type(Type::BooleanLiteral(ty_a.is_disjoint_from(db, ty_b)));
-                        CallOutcome::callable(binding)
                     }
                     Some(KnownFunction::IsGradualEquivalentTo) => {
                         let (ty_a, ty_b) = binding
@@ -1598,22 +1597,18 @@ impl<'db> Type<'db> {
                         binding.set_return_type(Type::BooleanLiteral(
                             ty_a.is_gradual_equivalent_to(db, ty_b),
                         ));
-                        CallOutcome::callable(binding)
                     }
                     Some(KnownFunction::IsFullyStatic) => {
                         let ty = binding.one_parameter_type().unwrap_or(Type::unknown());
                         binding.set_return_type(Type::BooleanLiteral(ty.is_fully_static(db)));
-                        CallOutcome::callable(binding)
                     }
                     Some(KnownFunction::IsSingleton) => {
                         let ty = binding.one_parameter_type().unwrap_or(Type::unknown());
                         binding.set_return_type(Type::BooleanLiteral(ty.is_singleton(db)));
-                        CallOutcome::callable(binding)
                     }
                     Some(KnownFunction::IsSingleValued) => {
                         let ty = binding.one_parameter_type().unwrap_or(Type::unknown());
                         binding.set_return_type(Type::BooleanLiteral(ty.is_single_valued(db)));
-                        CallOutcome::callable(binding)
                     }
 
                     Some(KnownFunction::Len) => {
@@ -1622,100 +1617,100 @@ impl<'db> Type<'db> {
                                 binding.set_return_type(len_ty);
                             }
                         };
-
-                        CallOutcome::callable(binding)
                     }
 
                     Some(KnownFunction::Repr) => {
                         if let Some(first_arg) = binding.one_parameter_type() {
                             binding.set_return_type(first_arg.repr(db));
                         };
-
-                        CallOutcome::callable(binding)
                     }
 
                     Some(KnownFunction::Cast) => {
                         // TODO: Use `.two_parameter_tys()` exclusively
                         // when overloads are supported.
-                        if binding.two_parameter_types().is_none() {
-                            return CallOutcome::callable(binding);
-                        };
-
                         if let Some(casted_ty) = arguments.first_argument() {
-                            binding.set_return_type(casted_ty);
+                            if binding.two_parameter_types().is_some() {
+                                binding.set_return_type(casted_ty);
+                            }
                         };
-
-                        CallOutcome::callable(binding)
                     }
 
-                    _ => CallOutcome::callable(binding),
+                    _ => {}
+                };
+
+                if binding.has_binding_errors() {
+                    Err(CallError::BindingError { binding })
+                } else {
+                    Ok(CallOutcome::Single(binding))
                 }
             }
 
             // TODO annotated return type on `__new__` or metaclass `__call__`
             // TODO check call vs signatures of `__new__` and/or `__init__`
             Type::ClassLiteral(ClassLiteralType { class }) => {
-                CallOutcome::callable(CallBinding::from_return_type(match class.known(db) {
-                    // If the class is the builtin-bool class (for example `bool(1)`), we try to
-                    // return the specific truthiness value of the input arg, `Literal[True]` for
-                    // the example above.
-                    Some(KnownClass::Bool) => arguments
-                        .first_argument()
-                        .map(|arg| arg.bool(db).into_type(db))
-                        .unwrap_or(Type::BooleanLiteral(false)),
+                Ok(CallOutcome::Single(CallBinding::from_return_type(
+                    match class.known(db) {
+                        // If the class is the builtin-bool class (for example `bool(1)`), we try to
+                        // return the specific truthiness value of the input arg, `Literal[True]` for
+                        // the example above.
+                        Some(KnownClass::Bool) => arguments
+                            .first_argument()
+                            .map(|arg| arg.bool(db).into_type(db))
+                            .unwrap_or(Type::BooleanLiteral(false)),
 
-                    Some(KnownClass::Str) => arguments
-                        .first_argument()
-                        .map(|arg| arg.str(db))
-                        .unwrap_or(Type::string_literal(db, "")),
+                        Some(KnownClass::Str) => arguments
+                            .first_argument()
+                            .map(|arg| arg.str(db))
+                            .unwrap_or(Type::string_literal(db, "")),
 
-                    _ => Type::Instance(InstanceType { class }),
-                }))
+                        _ => Type::Instance(InstanceType { class }),
+                    },
+                )))
             }
 
             instance_ty @ Type::Instance(_) => {
-                match instance_ty.call_dunder(db, "__call__", &arguments.with_self(instance_ty)) {
-                    CallDunderResult::CallOutcome(CallOutcome::NotCallable { .. }) => {
-                        // Turn "`<type of illegal '__call__'>` not callable" into
-                        // "`X` not callable"
-                        CallOutcome::NotCallable {
-                            not_callable_ty: self,
+                instance_ty
+                    .call_dunder(db, "__call__", &arguments.with_self(instance_ty))
+                    .map_err(|err| match err {
+                        CallDunderError::Call(CallError::NotCallable { .. }) => {
+                            // Turn "`<type of illegal '__call__'>` not callable" into
+                            // "`X` not callable"
+                            CallError::NotCallable {
+                                not_callable_ty: self,
+                            }
                         }
-                    }
-                    CallDunderResult::CallOutcome(outcome) => outcome,
-                    CallDunderResult::PossiblyUnbound(call_outcome) => {
+                        CallDunderError::Call(error) => error,
                         // Turn "possibly unbound object of type `Literal['__call__']`"
                         // into "`X` not callable (possibly unbound `__call__` method)"
-                        CallOutcome::PossiblyUnboundDunderCall {
-                            called_ty: self,
-                            call_outcome: Box::new(call_outcome),
+                        CallDunderError::PossiblyUnbound(outcome) => {
+                            CallError::PossiblyUnboundDunderCall {
+                                called_type: self,
+                                outcome: Box::new(outcome),
+                            }
                         }
-                    }
-                    CallDunderResult::MethodNotAvailable => {
-                        // Turn "`X.__call__` unbound" into "`X` not callable"
-                        CallOutcome::NotCallable {
-                            not_callable_ty: self,
+                        CallDunderError::MethodNotAvailable => {
+                            // Turn "`X.__call__` unbound" into "`X` not callable"
+                            CallError::NotCallable {
+                                not_callable_ty: self,
+                            }
                         }
-                    }
-                }
+                    })
             }
 
             // Dynamic types are callable, and the return type is the same dynamic type
-            Type::Dynamic(_) => CallOutcome::callable(CallBinding::from_return_type(self)),
+            Type::Dynamic(_) => Ok(CallOutcome::Single(CallBinding::from_return_type(self))),
 
-            Type::Union(union) => CallOutcome::union(
-                self,
-                union
-                    .elements(db)
-                    .iter()
-                    .map(|elem| elem.call(db, arguments)),
-            ),
+            Type::Union(union) => {
+                CallOutcome::try_call(db, union, |element| element.call(db, arguments))
+            }
 
-            Type::Intersection(_) => CallOutcome::callable(CallBinding::from_return_type(
+            Type::Intersection(_) => Ok(CallOutcome::Single(CallBinding::from_return_type(
                 todo_type!("Type::Intersection.call()"),
-            )),
+            ))),
 
-            _ => CallOutcome::not_callable(self),
+            _ => Err(CallError::NotCallable {
+                not_callable_ty: self,
+            }),
         }
     }
 
@@ -1725,13 +1720,12 @@ impl<'db> Type<'db> {
     /// `receiver_ty` must be `Type::Instance(_)` or `Type::ClassLiteral`.
     ///
     /// TODO: handle `super()` objects properly
-    #[must_use]
     fn call_bound(
         self,
         db: &'db dyn Db,
         receiver_ty: &Type<'db>,
         arguments: &CallArguments<'_, 'db>,
-    ) -> CallOutcome<'db> {
+    ) -> Result<CallOutcome<'db>, CallError<'db>> {
         debug_assert!(receiver_ty.is_instance() || receiver_ty.is_class_literal());
 
         match self {
@@ -1746,22 +1740,20 @@ impl<'db> Type<'db> {
                 self.call(db, arguments)
             }
 
-            Type::Union(union) => CallOutcome::union(
-                self,
-                union
-                    .elements(db)
-                    .iter()
-                    .map(|elem| elem.call_bound(db, receiver_ty, arguments)),
-            ),
+            Type::Union(union) => CallOutcome::try_call(db, union, |element| {
+                element.call_bound(db, receiver_ty, arguments)
+            }),
 
-            Type::Intersection(_) => CallOutcome::callable(CallBinding::from_return_type(
+            Type::Intersection(_) => Ok(CallOutcome::Single(CallBinding::from_return_type(
                 todo_type!("Type::Intersection.call_bound()"),
-            )),
+            ))),
 
             // Cases that duplicate, and thus must be kept in sync with, `Type::call()`
-            Type::Dynamic(_) => CallOutcome::callable(CallBinding::from_return_type(self)),
+            Type::Dynamic(_) => Ok(CallOutcome::Single(CallBinding::from_return_type(self))),
 
-            _ => CallOutcome::not_callable(self),
+            _ => Err(CallError::NotCallable {
+                not_callable_ty: self,
+            }),
         }
     }
 
@@ -1771,15 +1763,14 @@ impl<'db> Type<'db> {
         db: &'db dyn Db,
         name: &str,
         arguments: &CallArguments<'_, 'db>,
-    ) -> CallDunderResult<'db> {
+    ) -> Result<CallOutcome<'db>, CallDunderError<'db>> {
         match self.to_meta_type(db).member(db, name) {
-            Symbol::Type(callable_ty, Boundness::Bound) => {
-                CallDunderResult::CallOutcome(callable_ty.call(db, arguments))
-            }
+            Symbol::Type(callable_ty, Boundness::Bound) => Ok(callable_ty.call(db, arguments)?),
             Symbol::Type(callable_ty, Boundness::PossiblyUnbound) => {
-                CallDunderResult::PossiblyUnbound(callable_ty.call(db, arguments))
+                let call = callable_ty.call(db, arguments)?;
+                Err(CallDunderError::PossiblyUnbound(call))
             }
-            Symbol::Unbound => CallDunderResult::MethodNotAvailable,
+            Symbol::Unbound => Err(CallDunderError::MethodNotAvailable),
         }
     }
 
@@ -1800,34 +1791,50 @@ impl<'db> Type<'db> {
 
         let dunder_iter_result =
             self.call_dunder(db, "__iter__", &CallArguments::positional([self]));
-        match dunder_iter_result {
-            CallDunderResult::CallOutcome(ref call_outcome)
-            | CallDunderResult::PossiblyUnbound(ref call_outcome) => {
-                let Some(iterator_ty) = call_outcome.return_type(db) else {
-                    return IterationOutcome::NotIterable {
-                        not_iterable_ty: self,
-                    };
-                };
+        match &dunder_iter_result {
+            Ok(outcome) | Err(CallDunderError::PossiblyUnbound(outcome)) => {
+                let iterator_ty = outcome.return_type(db);
 
-                return if let Some(element_ty) = iterator_ty
-                    .call_dunder(db, "__next__", &CallArguments::positional([iterator_ty]))
-                    .return_type(db)
-                {
-                    if matches!(dunder_iter_result, CallDunderResult::PossiblyUnbound(..)) {
+                return match iterator_ty.call_dunder(
+                    db,
+                    "__next__",
+                    &CallArguments::positional([iterator_ty]),
+                ) {
+                    Ok(outcome) => {
+                        if matches!(
+                            dunder_iter_result,
+                            Err(CallDunderError::PossiblyUnbound { .. })
+                        ) {
+                            IterationOutcome::PossiblyUnboundDunderIter {
+                                iterable_ty: self,
+                                element_ty: outcome.return_type(db),
+                            }
+                        } else {
+                            IterationOutcome::Iterable {
+                                element_ty: outcome.return_type(db),
+                            }
+                        }
+                    }
+                    Err(CallDunderError::PossiblyUnbound(outcome)) => {
                         IterationOutcome::PossiblyUnboundDunderIter {
                             iterable_ty: self,
-                            element_ty,
+                            element_ty: outcome.return_type(db),
                         }
-                    } else {
-                        IterationOutcome::Iterable { element_ty }
                     }
-                } else {
-                    IterationOutcome::NotIterable {
+                    Err(_) => IterationOutcome::NotIterable {
                         not_iterable_ty: self,
-                    }
+                    },
                 };
             }
-            CallDunderResult::MethodNotAvailable => {}
+            // If the attribute exists but can't be called, return not iterable over falling back to `__get__item`.
+            Err(CallDunderError::Call(_)) => {
+                return IterationOutcome::NotIterable {
+                    not_iterable_ty: self,
+                }
+            }
+            Err(CallDunderError::MethodNotAvailable) => {
+                // No `__iter__` attribute, try `__getitem__` next.
+            }
         }
 
         // Although it's not considered great practice,
@@ -1836,19 +1843,23 @@ impl<'db> Type<'db> {
         //
         // TODO(Alex) this is only valid if the `__getitem__` method is annotated as
         // accepting `int` or `SupportsIndex`
-        if let Some(element_ty) = self
-            .call_dunder(
-                db,
-                "__getitem__",
-                &CallArguments::positional([self, KnownClass::Int.to_instance(db)]),
-            )
-            .return_type(db)
-        {
-            IterationOutcome::Iterable { element_ty }
-        } else {
-            IterationOutcome::NotIterable {
-                not_iterable_ty: self,
+        match self.call_dunder(
+            db,
+            "__getitem__",
+            &CallArguments::positional([self, KnownClass::Int.to_instance(db)]),
+        ) {
+            Ok(outcome) => IterationOutcome::Iterable {
+                element_ty: outcome.return_type(db),
+            },
+            Err(CallDunderError::PossiblyUnbound(outcome)) => {
+                IterationOutcome::PossiblyUnboundDunderIter {
+                    iterable_ty: self,
+                    element_ty: outcome.return_type(db),
+                }
             }
+            Err(_) => IterationOutcome::NotIterable {
+                not_iterable_ty: self,
+            },
         }
     }
 
@@ -3650,20 +3661,23 @@ impl<'db> Class<'db> {
             let arguments = CallArguments::positional([name, bases, namespace]);
 
             let return_ty_result = match metaclass.call(db, &arguments) {
-                CallOutcome::NotCallable { not_callable_ty } => Err(MetaclassError {
+                Ok(outcome) => Ok(outcome.return_type(db)),
+
+                Err(CallError::NotCallable { not_callable_ty }) => Err(MetaclassError {
                     kind: MetaclassErrorKind::NotCallable(not_callable_ty),
                 }),
 
-                CallOutcome::Union {
-                    outcomes,
+                Err(CallError::NotCallableVariants {
                     called_ty,
-                } => {
+                    not_callable,
+                    callable,
+                }) => {
                     let mut partly_not_callable = false;
 
-                    let return_ty = outcomes
+                    let return_ty = not_callable
                         .iter()
-                        .fold(None, |acc, outcome| {
-                            let ty = outcome.return_type(db);
+                        .fold(None, |acc, not_callable| {
+                            let ty = not_callable.return_type();
 
                             match (acc, ty) {
                                 (acc, None) => {
@@ -3674,24 +3688,30 @@ impl<'db> Class<'db> {
                                 (Some(builder), Some(ty)) => Some(builder.add(ty)),
                             }
                         })
-                        .map(UnionBuilder::build);
+                        .map(|mut builder| {
+                            for callable in callable {
+                                builder = builder.add(callable.return_type());
+                            }
+
+                            builder.build()
+                        });
 
                     if partly_not_callable {
                         Err(MetaclassError {
-                            kind: MetaclassErrorKind::PartlyNotCallable(called_ty),
+                            kind: MetaclassErrorKind::PartlyNotCallable(Type::Union(called_ty)),
                         })
                     } else {
                         Ok(return_ty.unwrap_or(Type::unknown()))
                     }
                 }
 
-                CallOutcome::PossiblyUnboundDunderCall { called_ty, .. } => Err(MetaclassError {
-                    kind: MetaclassErrorKind::PartlyNotCallable(called_ty),
+                Err(CallError::PossiblyUnboundDunderCall { .. }) => Err(MetaclassError {
+                    kind: MetaclassErrorKind::PartlyNotCallable(metaclass),
                 }),
 
                 // TODO we should also check for binding errors that would indicate the metaclass
                 // does not accept the right arguments
-                CallOutcome::Callable { binding } => Ok(binding.return_type()),
+                Err(CallError::BindingError { binding }) => Ok(binding.return_type()),
             };
 
             return return_ty_result.map(|ty| ty.to_meta_type(db));

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -36,9 +36,7 @@ use crate::symbol::{
     global_symbol, imported_symbol, known_module_symbol, symbol, symbol_from_bindings,
     symbol_from_declarations, Boundness, LookupError, LookupResult, Symbol, SymbolAndQualifiers,
 };
-use crate::types::call::{
-    bind_call, CallArguments, CallBinding, CallDunderResult, CallOutcome, StaticAssertionErrorKind,
-};
+use crate::types::call::{bind_call, CallArguments, CallBinding, CallDunderResult, CallOutcome};
 use crate::types::class_base::ClassBase;
 use crate::types::diagnostic::INVALID_TYPE_FORM;
 use crate::types::infer::infer_unpack_types;
@@ -1562,40 +1560,6 @@ impl<'db> Type<'db> {
             Type::FunctionLiteral(function_type) => {
                 let mut binding = bind_call(db, arguments, function_type.signature(db), self);
                 match function_type.known(db) {
-                    Some(KnownFunction::RevealType) => {
-                        let revealed_ty = binding.one_parameter_type().unwrap_or(Type::unknown());
-                        CallOutcome::revealed(binding, revealed_ty)
-                    }
-                    Some(KnownFunction::StaticAssert) => {
-                        if let Some((parameter_ty, message)) = binding.two_parameter_types() {
-                            let truthiness = parameter_ty.bool(db);
-
-                            if truthiness.is_always_true() {
-                                CallOutcome::callable(binding)
-                            } else {
-                                let error_kind = if let Some(message) =
-                                    message.into_string_literal().map(|s| &**s.value(db))
-                                {
-                                    StaticAssertionErrorKind::CustomError(message)
-                                } else if parameter_ty == Type::BooleanLiteral(false) {
-                                    StaticAssertionErrorKind::ArgumentIsFalse
-                                } else if truthiness.is_always_false() {
-                                    StaticAssertionErrorKind::ArgumentIsFalsy(parameter_ty)
-                                } else {
-                                    StaticAssertionErrorKind::ArgumentTruthinessIsAmbiguous(
-                                        parameter_ty,
-                                    )
-                                };
-
-                                CallOutcome::StaticAssertionError {
-                                    binding,
-                                    error_kind,
-                                }
-                            }
-                        } else {
-                            CallOutcome::callable(binding)
-                        }
-                    }
                     Some(KnownFunction::IsEquivalentTo) => {
                         let (ty_a, ty_b) = binding
                             .two_parameter_types()
@@ -1668,14 +1632,6 @@ impl<'db> Type<'db> {
                         };
 
                         CallOutcome::callable(binding)
-                    }
-
-                    Some(KnownFunction::AssertType) => {
-                        let Some((_, asserted_ty)) = binding.two_parameter_types() else {
-                            return CallOutcome::callable(binding);
-                        };
-
-                        CallOutcome::asserted(binding, asserted_ty)
                     }
 
                     Some(KnownFunction::Cast) => {
@@ -3735,10 +3691,7 @@ impl<'db> Class<'db> {
 
                 // TODO we should also check for binding errors that would indicate the metaclass
                 // does not accept the right arguments
-                CallOutcome::Callable { binding }
-                | CallOutcome::RevealType { binding, .. }
-                | CallOutcome::StaticAssertionError { binding, .. }
-                | CallOutcome::AssertType { binding, .. } => Ok(binding.return_type()),
+                CallOutcome::Callable { binding } => Ok(binding.return_type()),
             };
 
             return return_ty_result.map(|ty| ty.to_meta_type(db));

--- a/crates/red_knot_python_semantic/src/types/call/bind.rs
+++ b/crates/red_knot_python_semantic/src/types/call/bind.rs
@@ -161,6 +161,10 @@ impl<'db> CallBinding<'db> {
         }
     }
 
+    pub(super) fn callable_type(&self) -> Type<'db> {
+        self.callable_ty
+    }
+
     pub(crate) fn set_return_type(&mut self, return_ty: Type<'db>) {
         self.return_ty = return_ty;
     }
@@ -200,6 +204,10 @@ impl<'db> CallBinding<'db> {
         for error in &self.errors {
             error.report_diagnostic(context, node, callable_name);
         }
+    }
+
+    pub(super) fn has_binding_errors(&self) -> bool {
+        !self.errors.is_empty()
     }
 }
 

--- a/crates/red_knot_python_semantic/src/types/call/bind.rs
+++ b/crates/red_knot_python_semantic/src/types/call/bind.rs
@@ -161,7 +161,7 @@ impl<'db> CallBinding<'db> {
         }
     }
 
-    pub(super) fn callable_type(&self) -> Type<'db> {
+    pub(crate) fn callable_type(&self) -> Type<'db> {
         self.callable_ty
     }
 
@@ -199,14 +199,14 @@ impl<'db> CallBinding<'db> {
         }
     }
 
-    pub(super) fn report_diagnostics(&self, context: &InferContext<'db>, node: ast::AnyNodeRef) {
+    pub(crate) fn report_diagnostics(&self, context: &InferContext<'db>, node: ast::AnyNodeRef) {
         let callable_name = self.callable_name(context.db());
         for error in &self.errors {
             error.report_diagnostic(context, node, callable_name);
         }
     }
 
-    pub(super) fn has_binding_errors(&self) -> bool {
+    pub(crate) fn has_binding_errors(&self) -> bool {
         !self.errors.is_empty()
     }
 }


### PR DESCRIPTION
## Summary

This PR refactors `Type::call` to better support the three main use cases:

* To check an **explicit call**, e.g. `a(1, 2)`: We want to warn about incorrect arguments.
* To check an **implicit call**, e.g. `a += 1`, `with a:`, `if a` (`__bool__`), `len(a)`: We want to test if the operation is supported or use a specific error message if the operation is not supported because the type doesn’t implement the expected Protocol or convention (“protocol”) but we don’t want to emit errors about missing or incorrect arguments
* To **query** the “best known” return type. This is, indirectly, used when evaluating visibility constraints (`__bool__`) but may also be used to test if a type implements a specific “protocol” or Protocol. We don’t want to emit any errors.


The existing implementation already supported checking explicit calls well. However, it did emit diagnostics for implicit calls when the arguments didn't match the expected signature. 

```py
class Manager:
    def __enter__() -> str:
        return "foo"

    def __exit__(self, exc_type, exc_value, traceback): ...

context_expr = Manager()

with context_expr as f:
    reveal_type(f) 
```

Red Knot emitted a rather confusing error about incorrect arguments before:

```
crates/red_knot_python_semantic/resources/mdtest/with/sync.md:55 unexpected error: [too-many-positional-arguments] "Too many positional arguments to function `__enter__`: expected 0, got 1"
```

My main finding is that `Type::call` should consider the call as failed if there are any errors, including binding errors. This is important for implicit call checking as demonstrated by the error above or when probing if a `Class` implements a specific dunder method. 

`Type::call` should return an `Err` if the call fails for any reason and leave the proper handling to the caller. However, it should retain enough information for the call site to create a useful diagnostic. There's a tension here because including very accurate information is expensive to collect and the work is wasted if the caller doesn't care about it (because it only wants to know if the call succeeded). I also think that collecting the appropriate information probably requires knowing the context in which the method was called. I don't have a concrete example but we may want to implement custom diagnostics for when an operator failed and I suspect that collecting the necessary information will be its own side-adventure (@BurntSushi told me that this is at least the case for Rustc). 

The main work of this PR is to change `Type::call`, `Type::dunder_call` and `Type::bound_call` to now return a `Result` and dealing with the fallout from downstream usages. I also had to implement a few workarounds where the new behavior is too accurate. E.g. I had to explicitly ignore binding errors in a few cases where we also did so before. We should tackle those TODOs in separate PRs (my goal was to preserve existing behavior in most places).

Returning a `Result` is now often less ergonomic on the call site than the old `outcome.return_type`. This is intentional because using `return_type` is often wrong. I want to make the decision about what should happen if the call fails explicit: Do we have to emit a diagnostic? Can we ignore certain errors? What's the best recovery logic for this specific inference? That's why it's now necessary to match the variants and call `Ok(outcome) => outcome.return_type(db)`,  `Err(err) => err.unwrap_return_type(db)`, or `Err(err) => err.return_type(db)` to get the return type best suited for this call site. 

## What's next

We should refactor our other `Outcome` types to use `Result`. We should explore whether we can move some methods that take a `context` and node into `infer.rs`. We should also consider whether `bool`, `len`, and `member` (and even `to_instance`) should return a `Result`,.