### PR TITLE
Sort linters alphabetically

### DIFF
--- a/crates/ruff_linter/src/registry.rs
+++ b/crates/ruff_linter/src/registry.rs
@@ -33,28 +33,15 @@ pub enum FromCodeError {
 
 #[derive(EnumIter, Debug, PartialEq, Eq, Clone, Hash, RuleNamespace)]
 pub enum Linter {
-    /// [Pyflakes](https://pypi.org/project/pyflakes/)
-    #[prefix = "F"]
-    Pyflakes,
-    /// [pycodestyle](https://pypi.org/project/pycodestyle/)
-    #[prefix = "E"]
-    #[prefix = "W"]
-    Pycodestyle,
-    /// [mccabe](https://pypi.org/project/mccabe/)
-    #[prefix = "C90"]
-    McCabe,
-    /// [isort](https://pypi.org/project/isort/)
-    #[prefix = "I"]
-    Isort,
-    /// [pep8-naming](https://pypi.org/project/pep8-naming/)
-    #[prefix = "N"]
-    PEP8Naming,
-    /// [pydocstyle](https://pypi.org/project/pydocstyle/)
-    #[prefix = "D"]
-    Pydocstyle,
-    /// [pyupgrade](https://pypi.org/project/pyupgrade/)
-    #[prefix = "UP"]
-    Pyupgrade,
+    /// [Airflow](https://pypi.org/project/apache-airflow/)
+    #[prefix = "AIR"]
+    Airflow,
+    /// [eradicate](https://pypi.org/project/eradicate/)
+    #[prefix = "ERA"]
+    Eradicate,
+    /// [FastAPI](https://pypi.org/project/fastapi/)
+    #[prefix = "FAST"]
+    FastApi,
     /// [flake8-2020](https://pypi.org/project/flake8-2020/)
     #[prefix = "YTT"]
     Flake82020,
@@ -172,45 +159,58 @@ pub enum Linter {
     /// [flake8-use-pathlib](https://pypi.org/project/flake8-use-pathlib/)
     #[prefix = "PTH"]
     Flake8UsePathlib,
-    /// [eradicate](https://pypi.org/project/eradicate/)
-    #[prefix = "ERA"]
-    Eradicate,
+    /// [flynt](https://pypi.org/project/flynt/)
+    #[prefix = "FLY"]
+    Flynt,
+    /// [isort](https://pypi.org/project/isort/)
+    #[prefix = "I"]
+    Isort,
+    /// [mccabe](https://pypi.org/project/mccabe/)
+    #[prefix = "C90"]
+    McCabe,
+    /// NumPy-specific rules
+    #[prefix = "NPY"]
+    Numpy,
     /// [pandas-vet](https://pypi.org/project/pandas-vet/)
     #[prefix = "PD"]
     PandasVet,
+    /// [pep8-naming](https://pypi.org/project/pep8-naming/)
+    #[prefix = "N"]
+    PEP8Naming,
+    /// [Perflint](https://pypi.org/project/perflint/)
+    #[prefix = "PERF"]
+    Perflint,
+    /// [pycodestyle](https://pypi.org/project/pycodestyle/)
+    #[prefix = "E"]
+    #[prefix = "W"]
+    Pycodestyle,
+    /// [pydoclint](https://pypi.org/project/pydoclint/)
+    #[prefix = "DOC"]
+    Pydoclint,
+    /// [pydocstyle](https://pypi.org/project/pydocstyle/)
+    #[prefix = "D"]
+    Pydocstyle,
+    /// [Pyflakes](https://pypi.org/project/pyflakes/)
+    #[prefix = "F"]
+    Pyflakes,
     /// [pygrep-hooks](https://github.com/pre-commit/pygrep-hooks)
     #[prefix = "PGH"]
     PygrepHooks,
     /// [Pylint](https://pypi.org/project/pylint/)
     #[prefix = "PL"]
     Pylint,
-    /// [tryceratops](https://pypi.org/project/tryceratops/)
-    #[prefix = "TRY"]
-    Tryceratops,
-    /// [flynt](https://pypi.org/project/flynt/)
-    #[prefix = "FLY"]
-    Flynt,
-    /// NumPy-specific rules
-    #[prefix = "NPY"]
-    Numpy,
-    /// [FastAPI](https://pypi.org/project/fastapi/)
-    #[prefix = "FAST"]
-    FastApi,
-    /// [Airflow](https://pypi.org/project/apache-airflow/)
-    #[prefix = "AIR"]
-    Airflow,
-    /// [Perflint](https://pypi.org/project/perflint/)
-    #[prefix = "PERF"]
-    Perflint,
+    /// [pyupgrade](https://pypi.org/project/pyupgrade/)
+    #[prefix = "UP"]
+    Pyupgrade,
     /// [refurb](https://pypi.org/project/refurb/)
     #[prefix = "FURB"]
     Refurb,
-    /// [pydoclint](https://pypi.org/project/pydoclint/)
-    #[prefix = "DOC"]
-    Pydoclint,
     /// Ruff-specific rules
     #[prefix = "RUF"]
     Ruff,
+    /// [tryceratops](https://pypi.org/project/tryceratops/)
+    #[prefix = "TRY"]
+    Tryceratops,
 }
 
 pub trait RuleNamespace: Sized {
@@ -430,6 +430,7 @@ pub mod clap_completion {
 
 #[cfg(test)]
 mod tests {
+    use itertools::Itertools;
     use std::mem::size_of;
 
     use strum::IntoEnumIterator;
@@ -492,5 +493,20 @@ mod tests {
     #[test]
     fn rule_size() {
         assert_eq!(2, size_of::<Rule>());
+    }
+
+    #[test]
+    fn linter_sorting() {
+        let names: Vec<_> = Linter::iter()
+            .map(|linter| linter.name().to_lowercase())
+            .collect();
+
+        let sorted: Vec<_> = names.iter().cloned().sorted().collect();
+
+        assert_eq!(
+            &names[..],
+            &sorted[..],
+            "Linters are not sorted alphabetically (case insensitive)"
+        );
     }
 }

--- a/crates/ruff_linter/src/registry.rs
+++ b/crates/ruff_linter/src/registry.rs
@@ -82,12 +82,12 @@ pub enum Linter {
     /// [flake8-commas](https://pypi.org/project/flake8-commas/)
     #[prefix = "COM"]
     Flake8Commas,
-    /// [flake8-copyright](https://pypi.org/project/flake8-copyright/)
-    #[prefix = "CPY"]
-    Flake8Copyright,
     /// [flake8-comprehensions](https://pypi.org/project/flake8-comprehensions/)
     #[prefix = "C4"]
     Flake8Comprehensions,
+    /// [flake8-copyright](https://pypi.org/project/flake8-copyright/)
+    #[prefix = "CPY"]
+    Flake8Copyright,
     /// [flake8-datetimez](https://pypi.org/project/flake8-datetimez/)
     #[prefix = "DTZ"]
     Flake8Datetimez,
@@ -103,9 +103,15 @@ pub enum Linter {
     /// [flake8-executable](https://pypi.org/project/flake8-executable/)
     #[prefix = "EXE"]
     Flake8Executable,
+    /// [flake8-fixme](https://github.com/tommilligan/flake8-fixme)
+    #[prefix = "FIX"]
+    Flake8Fixme,
     /// [flake8-future-annotations](https://pypi.org/project/flake8-future-annotations/)
     #[prefix = "FA"]
     Flake8FutureAnnotations,
+    /// [flake8-gettext](https://pypi.org/project/flake8-gettext/)
+    #[prefix = "INT"]
+    Flake8GetText,
     /// [flake8-implicit-str-concat](https://pypi.org/project/flake8-implicit-str-concat/)
     #[prefix = "ISC"]
     Flake8ImplicitStrConcat,
@@ -145,33 +151,27 @@ pub enum Linter {
     /// [flake8-self](https://pypi.org/project/flake8-self/)
     #[prefix = "SLF"]
     Flake8Self,
-    /// [flake8-slots](https://pypi.org/project/flake8-slots/)
-    #[prefix = "SLOT"]
-    Flake8Slots,
     /// [flake8-simplify](https://pypi.org/project/flake8-simplify/)
     #[prefix = "SIM"]
     Flake8Simplify,
+    /// [flake8-slots](https://pypi.org/project/flake8-slots/)
+    #[prefix = "SLOT"]
+    Flake8Slots,
     /// [flake8-tidy-imports](https://pypi.org/project/flake8-tidy-imports/)
     #[prefix = "TID"]
     Flake8TidyImports,
+    /// [flake8-todos](https://github.com/orsinium-labs/flake8-todos/)
+    #[prefix = "TD"]
+    Flake8Todos,
     /// [flake8-type-checking](https://pypi.org/project/flake8-type-checking/)
     #[prefix = "TC"]
     Flake8TypeChecking,
-    /// [flake8-gettext](https://pypi.org/project/flake8-gettext/)
-    #[prefix = "INT"]
-    Flake8GetText,
     /// [flake8-unused-arguments](https://pypi.org/project/flake8-unused-arguments/)
     #[prefix = "ARG"]
     Flake8UnusedArguments,
     /// [flake8-use-pathlib](https://pypi.org/project/flake8-use-pathlib/)
     #[prefix = "PTH"]
     Flake8UsePathlib,
-    /// [flake8-todos](https://github.com/orsinium-labs/flake8-todos/)
-    #[prefix = "TD"]
-    Flake8Todos,
-    /// [flake8-fixme](https://github.com/tommilligan/flake8-fixme)
-    #[prefix = "FIX"]
-    Flake8Fixme,
     /// [eradicate](https://pypi.org/project/eradicate/)
     #[prefix = "ERA"]
     Eradicate,


### PR DESCRIPTION
## Summary

Resolves #16164.

Linters are now sorted by their names case-insensitively.

## Test Plan

![](https://github.com/user-attachments/assets/87ffd4d8-1ba5-4a4b-8fed-dd21a020bd27)

Also unit tests.
