### PR TITLE
Fix missing serde feature for red_knot_python_semantic

### DIFF
--- a/crates/red_knot_python_semantic/Cargo.toml
+++ b/crates/red_knot_python_semantic/Cargo.toml
@@ -57,7 +57,7 @@ quickcheck = { version = "1.0.3", default-features = false }
 quickcheck_macros = { version = "1.0.0" }
 
 [features]
-serde = ["ruff_db/serde", "dep:serde"]
+serde = ["ruff_db/serde", "dep:serde", "ruff_python_ast/serde"]
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary

Running `cargo test -p red_knot_python_semantic` failed because of a missing serde feature. This PR enables the `ruff_python_ast`'`s `serde` if the crate's `serde` feature is enabled

Follow up to https://github.com/astral-sh/ruff/pull/16147

## Test Plan

`cargo test -p red_knot_python_semantic` compiles again
