### PR TITLE
[red-knot] Recognize `...` as a singleton

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals/is.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals/is.md
@@ -82,7 +82,7 @@ def _(x: int | EllipsisType):
         reveal_type(x)  # revealed: int
 ```
 
-## `is` for `EllipsisType` (Python <=3.9)
+## `is` for `EllipsisType` (Python \<=3.9)
 
 ```toml
 [environment]

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals/is.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals/is.md
@@ -82,7 +82,7 @@ def _(x: int | EllipsisType):
         reveal_type(x)  # revealed: int
 ```
 
-## `is` for `EllipsisType` (Python \<=3.9)
+## `is` for `EllipsisType` (Python 3.9 and below)
 
 ```toml
 [environment]

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals/is.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals/is.md
@@ -98,5 +98,5 @@ def _(flag: bool):
     if x is ...:
         reveal_type(x)  # revealed: ellipsis
     else:
-        reveal_type(x)  # revealed: int
+        reveal_type(x)  # revealed: Literal[42]
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals/is.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals/is.md
@@ -64,3 +64,39 @@ def _(flag1: bool, flag2: bool):
     else:
         reveal_type(x)  # revealed: Literal[1]
 ```
+
+## `is` for `EllipsisType` (Python 3.10+)
+
+```toml
+[environment]
+python-version = "3.10"
+```
+
+```py
+from types import EllipsisType
+
+def _(x: int | EllipsisType):
+    if x is ...:
+        reveal_type(x)  # revealed: EllipsisType
+    else:
+        reveal_type(x)  # revealed: int
+```
+
+## `is` for `EllipsisType` (Python <=3.9)
+
+```toml
+[environment]
+python-version = "3.9"
+```
+
+```py
+def _(flag: bool):
+    x = ... if flag else 42
+
+    reveal_type(x)  # revealed: ellipsis | Literal[42]
+
+    if x is ...:
+        reveal_type(x)  # revealed: ellipsis
+    else:
+        reveal_type(x)  # revealed: int
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_singleton.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_singleton.md
@@ -54,3 +54,41 @@ from knot_extensions import is_singleton, static_assert
 
 static_assert(is_singleton(_NoDefaultType))
 ```
+
+## `builtins.ellipsis`/`types.EllipsisType`
+
+### All Python versions
+
+The type of the builtin symbol `Ellipsis` is the same as the type of an ellipsis literal (`...`).
+The type is not actually exposed from the standard library on Python \<3.10, but we still recognise
+the type as a singleton on any Python version.
+
+```toml
+[environment]
+python-version = "3.9"
+```
+
+```py
+import sys
+from knot_extensions import is_singleton, static_assert
+
+static_assert(is_singleton(Ellipsis.__class__))
+static_assert(is_singleton((...).__class__))
+```
+
+### Python 3.10+
+
+On Python 3.10+, the standard library exposes the type of `...` as `types.EllipsisType`, and we also
+recognise this as a singleton type when it is referenced directly:
+
+```toml
+[environment]
+python-version = "3.10"
+```
+
+```py
+import types
+from knot_extensions import static_assert, is_singleton
+
+static_assert(is_singleton(types.EllipsisType))
+```

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2814,17 +2814,15 @@ impl<'db> TypeInferenceBuilder<'db> {
 
     fn infer_number_literal_expression(&mut self, literal: &ast::ExprNumberLiteral) -> Type<'db> {
         let ast::ExprNumberLiteral { range: _, value } = literal;
+        let db = self.db();
 
         match value {
             ast::Number::Int(n) => n
                 .as_i64()
                 .map(Type::IntLiteral)
-                .unwrap_or_else(|| KnownClass::Int.to_instance(self.db())),
-            ast::Number::Float(_) => KnownClass::Float.to_instance(self.db()),
-            ast::Number::Complex { .. } => builtins_symbol(self.db(), "complex")
-                .ignore_possibly_unbound()
-                .unwrap_or(Type::unknown())
-                .to_instance(self.db()),
+                .unwrap_or_else(|| KnownClass::Int.to_instance(db)),
+            ast::Number::Float(_) => KnownClass::Float.to_instance(db),
+            ast::Number::Complex { .. } => KnownClass::Complex.to_instance(db),
         }
     }
 
@@ -2908,9 +2906,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         &mut self,
         _literal: &ast::ExprEllipsisLiteral,
     ) -> Type<'db> {
-        builtins_symbol(self.db(), "Ellipsis")
-            .ignore_possibly_unbound()
-            .unwrap_or(Type::unknown())
+        KnownClass::EllipsisType.to_instance(self.db())
     }
 
     fn infer_tuple_expression(&mut self, tuple: &ast::ExprTuple) -> Type<'db> {


### PR DESCRIPTION
## Summary

This PR adds some special-casing for `types.EllipsisType` (and, on Python <=3.9, the fictional `builtins.ellipsis` class) so that red-knot recognises it as a singleton class. Once this is recognised, we are able to narrow unions involving `EllipsisType` using `if x is ...`, which is a pattern supported by both [mypy](https://mypy-play.net/?mypy=latest&python=3.12&gist=7cc5f1f77f16a34e4dabcb9fc74fb0c6) and [pyright](https://pyright-play.net/?code=GYJw9gtgBALgngBwKYGcoEsILCGUCiANoegiuigCqJIBQtAJksFMABQAeAXAcaeVRpQAPhgB2MAJRdaUORhYcMaAHRqZ8zVBBIAbkgCGhAPrxknSbPlJCKJBq1yd%2Bo6ZoXaQA).

I hoped to add support for `NotImplementedType` as part of the same PR, but this is requires a little more thought due to the fact that, according to typeshed, [`NotImplemented` is not an instance of `types.NotImplementedType` even on Python 3.10+](https://github.com/python/typeshed/blob/654d8c245766663379b69e89631d8ae665b63e48/stdlib/builtins.pyi#L1285-L1289).

## Test Plan

Mdtests added that fail on `main`
