### PR TITLE
Add doc about usedforsecurity flag for S324

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/hashlib_insecure_hash_functions.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/hashlib_insecure_hash_functions.rs
@@ -43,7 +43,8 @@ use super::super::helpers::string_literal;
 ///     return hash == known_hash
 /// ```
 ///
-/// or add `usedforsecurity=False` to suppress for FIPS build of Python
+/// or add `usedforsecurity=False` if the hashing algorithm is not used in a security context, e.g.
+/// as a non-cryptographic one-way compression function:
 /// ```python
 /// import hashlib
 ///

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/hashlib_insecure_hash_functions.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/hashlib_insecure_hash_functions.rs
@@ -43,9 +43,21 @@ use super::super::helpers::string_literal;
 ///     return hash == known_hash
 /// ```
 ///
+/// or add `usedforsecurity=False` to suppress for FIPS build of Python
+/// ```python
+/// import hashlib
+///
+///
+/// def certificate_is_valid(certificate: bytes, known_hash: str) -> bool:
+///     hash = hashlib.md5(certificate, usedforsecurity=False).hexdigest()
+///     return hash == known_hash
+/// ```
+///
+///
 /// ## References
 /// - [Python documentation: `hashlib` — Secure hashes and message digests](https://docs.python.org/3/library/hashlib.html)
 /// - [Python documentation: `crypt` — Function to check Unix passwords](https://docs.python.org/3/library/crypt.html)
+/// - [Python documentation: `FIPS` - FIPS compliant hashlib implementation](https://docs.python.org/3/library/hashlib.html#hashlib.algorithms_guaranteed)
 /// - [Common Weakness Enumeration: CWE-327](https://cwe.mitre.org/data/definitions/327.html)
 /// - [Common Weakness Enumeration: CWE-328](https://cwe.mitre.org/data/definitions/328.html)
 /// - [Common Weakness Enumeration: CWE-916](https://cwe.mitre.org/data/definitions/916.html)


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
Provides documentation about the FIPS compliant flag for Python hashlib `usedforsecurity`
Fixes #16188 

## Test Plan

<!-- How was it tested? -->
* pre-commit hooks