### PR TITLE
Improve API exposed on `ExprStringLiteral` nodes

### DIFF
--- a/crates/red_knot_python_semantic/src/types/string_annotation.rs
+++ b/crates/red_knot_python_semantic/src/types/string_annotation.rs
@@ -1,5 +1,4 @@
 use ruff_db::source::source_text;
-use ruff_python_ast::str::raw_contents;
 use ruff_python_ast::{self as ast, ModExpression};
 use ruff_python_parser::Parsed;
 use ruff_text_size::Ranged;
@@ -138,9 +137,8 @@ pub(crate) fn parse_string_annotation(
     let _span = tracing::trace_span!("parse_string_annotation", string=?string_expr.range(), file=%file.path(db)).entered();
 
     let source = source_text(db.upcast(), file);
-    let node_text = &source[string_expr.range()];
 
-    if let [string_literal] = string_expr.value.as_slice() {
+    if let Some(string_literal) = string_expr.as_unconcatenated_literal() {
         let prefix = string_literal.flags.prefix();
         if prefix.is_raw() {
             context.report_lint(
@@ -150,9 +148,7 @@ pub(crate) fn parse_string_annotation(
             );
         // Compare the raw contents (without quotes) of the expression with the parsed contents
         // contained in the string literal.
-        } else if raw_contents(node_text)
-            .is_some_and(|raw_contents| raw_contents == string_literal.as_str())
-        {
+        } else if &source[string_literal.content_range()] == string_literal.as_str() {
             match ruff_python_parser::parse_string_annotation(source.as_str(), string_literal) {
                 Ok(parsed) => return Some(parsed),
                 Err(parse_error) => context.report_lint(

--- a/crates/ruff_linter/src/checkers/ast/analyze/definitions.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/definitions.rs
@@ -182,9 +182,8 @@ pub(crate) fn definitions(checker: &mut Checker) {
                 continue;
             };
 
-            // If the `ExprStringLiteral` has multiple parts, it is implicitly concatenated.
-            // We don't support recognising such strings as docstrings in our model currently.
-            let [sole_string_part] = string_literal.value.as_slice() else {
+            // We don't recognise implicitly concatenated strings as valid docstrings in our model currently.
+            let Some(sole_string_part) = string_literal.as_unconcatenated_literal() else {
                 #[allow(deprecated)]
                 let location = checker
                     .locator

--- a/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
@@ -1537,7 +1537,7 @@ pub(crate) fn expression(expr: &Expr, checker: &Checker) {
                 }
             }
             if checker.enabled(Rule::MissingFStringSyntax) {
-                for string_literal in value.as_slice() {
+                for string_literal in value {
                     ruff::rules::missing_fstring_syntax(checker, string_literal);
                 }
             }

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/split_static_string.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/split_static_string.rs
@@ -159,11 +159,17 @@ fn split_default(str_value: &StringLiteralValue, max_split: i32) -> Option<Expr>
         }
         Ordering::Equal => {
             let list_items: Vec<&str> = vec![str_value.to_str()];
-            Some(construct_replacement(&list_items, str_value.flags()))
+            Some(construct_replacement(
+                &list_items,
+                str_value.first_literal_flags(),
+            ))
         }
         Ordering::Less => {
             let list_items: Vec<&str> = str_value.to_str().split_whitespace().collect();
-            Some(construct_replacement(&list_items, str_value.flags()))
+            Some(construct_replacement(
+                &list_items,
+                str_value.first_literal_flags(),
+            ))
         }
     }
 }
@@ -187,7 +193,7 @@ fn split_sep(
         }
     };
 
-    construct_replacement(&list_items, str_value.flags())
+    construct_replacement(&list_items, str_value.first_literal_flags())
 }
 
 /// Returns the value of the `maxsplit` argument as an `i32`, if it is a numeric value.

--- a/crates/ruff_linter/src/rules/flynt/rules/static_join_to_fstring.rs
+++ b/crates/ruff_linter/src/rules/flynt/rules/static_join_to_fstring.rs
@@ -72,7 +72,7 @@ fn build_fstring(joiner: &str, joinees: &[Expr], flags: FStringFlags) -> Option<
                     if let Expr::StringLiteral(ast::ExprStringLiteral { value, .. }) = expr {
                         if flags.is_none() {
                             // take the flags from the first Expr
-                            flags = Some(value.flags());
+                            flags = Some(value.first_literal_flags());
                         }
                         Some(value.to_str())
                     } else {

--- a/crates/ruff_python_formatter/src/expression/expr_string_literal.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_string_literal.rs
@@ -28,9 +28,7 @@ impl FormatRuleWithOptions<ExprStringLiteral, PyFormatContext<'_>> for FormatExp
 
 impl FormatNodeRule<ExprStringLiteral> for FormatExprStringLiteral {
     fn fmt_fields(&self, item: &ExprStringLiteral, f: &mut PyFormatter) -> FormatResult<()> {
-        let ExprStringLiteral { value, .. } = item;
-
-        if let [string_literal] = value.as_slice() {
+        if let Some(string_literal) = item.as_unconcatenated_literal() {
             string_literal.format().with_options(self.kind).fmt(f)
         } else {
             // Always join strings that aren't parenthesized and thus, always on a single line.

--- a/crates/ruff_python_parser/src/typing.rs
+++ b/crates/ruff_python_parser/src/typing.rs
@@ -1,7 +1,6 @@
 //! This module takes care of parsing a type annotation.
 
 use ruff_python_ast::relocate::relocate_expr;
-use ruff_python_ast::str::raw_contents;
 use ruff_python_ast::{Expr, ExprStringLiteral, ModExpression, StringLiteral};
 use ruff_text_size::Ranged;
 
@@ -57,14 +56,10 @@ pub fn parse_type_annotation(
     string_expr: &ExprStringLiteral,
     source: &str,
 ) -> AnnotationParseResult {
-    let expr_text = &source[string_expr.range()];
-
-    if let [string_literal] = string_expr.value.as_slice() {
+    if let Some(string_literal) = string_expr.as_unconcatenated_literal() {
         // Compare the raw contents (without quotes) of the expression with the parsed contents
         // contained in the string literal.
-        if raw_contents(expr_text)
-            .is_some_and(|raw_contents| raw_contents == string_literal.as_str())
-        {
+        if &source[string_literal.content_range()] == string_literal.as_str() {
             parse_simple_type_annotation(string_literal, source)
         } else {
             // The raw contents of the string doesn't match the parsed content. This could be the


### PR DESCRIPTION
## Summary

This PR makes the following changes:
- It adjusts various callsites to use the new `ast::StringLiteral::contents_range()` method that was introduced in https://github.com/astral-sh/ruff/pull/16183. This is less verbose and more type-safe than using the `ast::str::raw_contents()` helper function.
- It adds a new `ast::ExprStringLiteral::as_unconcatenated_literal()` helper method, and adjusts various callsites to use it. This addresses @MichaReiser's review comment at https://github.com/astral-sh/ruff/pull/16183#discussion_r1957334365. There is no functional change here, but it helps readability to make it clearer that we're differentiating between implicitly concatenated strings and unconcatenated strings at various points.
- It renames the `StringLiteralValue::flags()` method to `StringLiteralFlags::first_literal_flags()`. If you're dealing with an implicitly concatenated string `string_node`, `string_node.value.flags().closer_len()` could give an incorrect result; this renaming makes it clearer that the `StringLiteralFlags` instance returned by the method is only guaranteed to give accurate information for the first `StringLiteral` contained in the `ExprStringLiteral` node.
- It deletes the unused `BytesLiteralValue::flags()` method. This seems prone to misuse in the same way as `StringLiteralValue::flags()`: if it's an implicitly concatenated bytestring, the `BytesLiteralFlags` instance returned by the method would only give accurate information for the first `BytesLiteral` in the bytestring.

## Test Plan

`cargo test`
