### PR TITLE
[ruff] Resolve type alias for annotations (RUF012)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF012.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF012.py
@@ -1,4 +1,5 @@
-from typing import ClassVar, Sequence, Final
+from typing import ClassVar, Sequence, Final, TypeAlias
+from collections.abc import Mapping
 
 
 class A:
@@ -118,3 +119,21 @@ class AWithQuotes:
     final_variable: 'Final[list[int]]' = []
     class_variable_without_subscript: 'ClassVar' = []
     final_variable_without_subscript: 'Final' = []
+
+
+Foo: TypeAlias = Mapping[str, str]
+
+
+class BaseFoo:
+    values: Foo
+
+
+class DerivedFoo(BaseFoo):
+    values: Foo = {"a": "b"}
+
+
+Bar: TypeAlias = dict[str, str]
+
+
+class DerivedBar(BaseFoo):
+    values: Bar = {"a": "b"}

--- a/crates/ruff_linter/src/rules/ruff/rules/helpers.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/helpers.rs
@@ -219,7 +219,7 @@ pub(super) fn map_annotation_binding<'a>(expr: &'a Expr, semantic: &'a SemanticM
     };
 
     match find_binding_value(binding, semantic) {
-        Some(value) => value,
+        Some(value) => map_annotation_binding(map_subscript(value), semantic),
         None => expr,
     }
 }

--- a/crates/ruff_linter/src/rules/ruff/rules/mutable_class_default.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/mutable_class_default.rs
@@ -8,7 +8,7 @@ use ruff_text_size::Ranged;
 use crate::checkers::ast::Checker;
 use crate::rules::ruff::rules::helpers::{
     dataclass_kind, has_default_copy_semantics, is_class_var_annotation, is_final_annotation,
-    is_special_attribute,
+    is_special_attribute, map_annotation_binding,
 };
 
 /// ## What it does
@@ -103,11 +103,12 @@ pub(crate) fn mutable_class_default(checker: &Checker, class_def: &ast::StmtClas
                 value: Some(value),
                 ..
             }) => {
+                let annotation_type = map_annotation_binding(annotation, checker.semantic());
                 if !is_special_attribute(target)
                     && is_mutable_expr(value, checker.semantic())
-                    && !is_class_var_annotation(annotation, checker.semantic())
-                    && !is_final_annotation(annotation, checker.semantic())
-                    && !is_immutable_annotation(annotation, checker.semantic(), &[])
+                    && !is_class_var_annotation(annotation_type, checker.semantic())
+                    && !is_final_annotation(annotation_type, checker.semantic())
+                    && !is_immutable_annotation(annotation_type, checker.semantic(), &[])
                 {
                     if dataclass_kind(class_def, checker.semantic()).is_some() {
                         continue;

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF012_RUF012.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF012_RUF012.py.snap
@@ -1,108 +1,115 @@
 ---
 source: crates/ruff_linter/src/rules/ruff/mod.rs
 ---
-RUF012.py:9:34: RUF012 Mutable class attributes should be annotated with `typing.ClassVar`
+RUF012.py:10:34: RUF012 Mutable class attributes should be annotated with `typing.ClassVar`
    |
- 7 |     }
- 8 |
- 9 |     mutable_default: list[int] = []
+ 8 |     }
+ 9 |
+10 |     mutable_default: list[int] = []
    |                                  ^^ RUF012
-10 |     immutable_annotation: Sequence[int] = []
-11 |     without_annotation = []
+11 |     immutable_annotation: Sequence[int] = []
+12 |     without_annotation = []
    |
 
-RUF012.py:11:26: RUF012 Mutable class attributes should be annotated with `typing.ClassVar`
+RUF012.py:12:26: RUF012 Mutable class attributes should be annotated with `typing.ClassVar`
    |
- 9 |     mutable_default: list[int] = []
-10 |     immutable_annotation: Sequence[int] = []
-11 |     without_annotation = []
+10 |     mutable_default: list[int] = []
+11 |     immutable_annotation: Sequence[int] = []
+12 |     without_annotation = []
    |                          ^^ RUF012
-12 |     class_variable: ClassVar[list[int]] = []
-13 |     final_variable: Final[list[int]] = []
+13 |     class_variable: ClassVar[list[int]] = []
+14 |     final_variable: Final[list[int]] = []
    |
 
-RUF012.py:25:26: RUF012 Mutable class attributes should be annotated with `typing.ClassVar`
+RUF012.py:26:26: RUF012 Mutable class attributes should be annotated with `typing.ClassVar`
    |
-23 |     mutable_default: list[int] = []
-24 |     immutable_annotation: Sequence[int] = []
-25 |     without_annotation = []
+24 |     mutable_default: list[int] = []
+25 |     immutable_annotation: Sequence[int] = []
+26 |     without_annotation = []
    |                          ^^ RUF012
-26 |     perfectly_fine: list[int] = field(default_factory=list)
-27 |     class_variable: ClassVar[list[int]] = []
+27 |     perfectly_fine: list[int] = field(default_factory=list)
+28 |     class_variable: ClassVar[list[int]] = []
    |
 
-RUF012.py:89:38: RUF012 Mutable class attributes should be annotated with `typing.ClassVar`
+RUF012.py:90:38: RUF012 Mutable class attributes should be annotated with `typing.ClassVar`
    |
-87 |     class I(SQLModel):
-88 |         id: int
-89 |         mutable_default: list[int] = []
+88 |     class I(SQLModel):
+89 |         id: int
+90 |         mutable_default: list[int] = []
    |                                      ^^ RUF012
-90 |
-91 | from sqlmodel import SQLModel
+91 |
+92 | from sqlmodel import SQLModel
    |
 
-RUF012.py:114:36: RUF012 Mutable class attributes should be annotated with `typing.ClassVar`
+RUF012.py:115:36: RUF012 Mutable class attributes should be annotated with `typing.ClassVar`
     |
-112 |     }
-113 |
-114 |     mutable_default: 'list[int]' = []
+113 |     }
+114 |
+115 |     mutable_default: 'list[int]' = []
     |                                    ^^ RUF012
-115 |     immutable_annotation: 'Sequence[int]'= []
-116 |     without_annotation = []
+116 |     immutable_annotation: 'Sequence[int]'= []
+117 |     without_annotation = []
     |
 
-RUF012.py:115:44: RUF012 Mutable class attributes should be annotated with `typing.ClassVar`
+RUF012.py:116:44: RUF012 Mutable class attributes should be annotated with `typing.ClassVar`
     |
-114 |     mutable_default: 'list[int]' = []
-115 |     immutable_annotation: 'Sequence[int]'= []
+115 |     mutable_default: 'list[int]' = []
+116 |     immutable_annotation: 'Sequence[int]'= []
     |                                            ^^ RUF012
-116 |     without_annotation = []
-117 |     class_variable: 'ClassVar[list[int]]' = []
+117 |     without_annotation = []
+118 |     class_variable: 'ClassVar[list[int]]' = []
     |
 
-RUF012.py:116:26: RUF012 Mutable class attributes should be annotated with `typing.ClassVar`
+RUF012.py:117:26: RUF012 Mutable class attributes should be annotated with `typing.ClassVar`
     |
-114 |     mutable_default: 'list[int]' = []
-115 |     immutable_annotation: 'Sequence[int]'= []
-116 |     without_annotation = []
+115 |     mutable_default: 'list[int]' = []
+116 |     immutable_annotation: 'Sequence[int]'= []
+117 |     without_annotation = []
     |                          ^^ RUF012
-117 |     class_variable: 'ClassVar[list[int]]' = []
-118 |     final_variable: 'Final[list[int]]' = []
+118 |     class_variable: 'ClassVar[list[int]]' = []
+119 |     final_variable: 'Final[list[int]]' = []
     |
 
-RUF012.py:117:45: RUF012 Mutable class attributes should be annotated with `typing.ClassVar`
+RUF012.py:118:45: RUF012 Mutable class attributes should be annotated with `typing.ClassVar`
     |
-115 |     immutable_annotation: 'Sequence[int]'= []
-116 |     without_annotation = []
-117 |     class_variable: 'ClassVar[list[int]]' = []
+116 |     immutable_annotation: 'Sequence[int]'= []
+117 |     without_annotation = []
+118 |     class_variable: 'ClassVar[list[int]]' = []
     |                                             ^^ RUF012
-118 |     final_variable: 'Final[list[int]]' = []
-119 |     class_variable_without_subscript: 'ClassVar' = []
+119 |     final_variable: 'Final[list[int]]' = []
+120 |     class_variable_without_subscript: 'ClassVar' = []
     |
 
-RUF012.py:118:42: RUF012 Mutable class attributes should be annotated with `typing.ClassVar`
+RUF012.py:119:42: RUF012 Mutable class attributes should be annotated with `typing.ClassVar`
     |
-116 |     without_annotation = []
-117 |     class_variable: 'ClassVar[list[int]]' = []
-118 |     final_variable: 'Final[list[int]]' = []
+117 |     without_annotation = []
+118 |     class_variable: 'ClassVar[list[int]]' = []
+119 |     final_variable: 'Final[list[int]]' = []
     |                                          ^^ RUF012
-119 |     class_variable_without_subscript: 'ClassVar' = []
-120 |     final_variable_without_subscript: 'Final' = []
+120 |     class_variable_without_subscript: 'ClassVar' = []
+121 |     final_variable_without_subscript: 'Final' = []
     |
 
-RUF012.py:119:52: RUF012 Mutable class attributes should be annotated with `typing.ClassVar`
+RUF012.py:120:52: RUF012 Mutable class attributes should be annotated with `typing.ClassVar`
     |
-117 |     class_variable: 'ClassVar[list[int]]' = []
-118 |     final_variable: 'Final[list[int]]' = []
-119 |     class_variable_without_subscript: 'ClassVar' = []
+118 |     class_variable: 'ClassVar[list[int]]' = []
+119 |     final_variable: 'Final[list[int]]' = []
+120 |     class_variable_without_subscript: 'ClassVar' = []
     |                                                    ^^ RUF012
-120 |     final_variable_without_subscript: 'Final' = []
+121 |     final_variable_without_subscript: 'Final' = []
     |
 
-RUF012.py:120:49: RUF012 Mutable class attributes should be annotated with `typing.ClassVar`
+RUF012.py:121:49: RUF012 Mutable class attributes should be annotated with `typing.ClassVar`
     |
-118 |     final_variable: 'Final[list[int]]' = []
-119 |     class_variable_without_subscript: 'ClassVar' = []
-120 |     final_variable_without_subscript: 'Final' = []
+119 |     final_variable: 'Final[list[int]]' = []
+120 |     class_variable_without_subscript: 'ClassVar' = []
+121 |     final_variable_without_subscript: 'Final' = []
     |                                                 ^^ RUF012
+    |
+
+RUF012.py:139:19: RUF012 Mutable class attributes should be annotated with `typing.ClassVar`
+    |
+138 | class DerivedBar(BaseFoo):
+139 |     values: Bar = {"a": "b"}
+    |                   ^^^^^^^^^^ RUF012
     |


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
Check on mutable class default was not resolving the annotation that was a type alias thus the default values might have been flagged as mutable.

Added a helper function similar to `map_subscript` in order to check bindings on annotation to resolve to the final type.

Resolves #16174 

## Test Plan
- Checked with type aliases with both mutable and immutable 
- Checked the original behavior was intact.
<!-- How was it tested? -->
