### PR TITLE
Update server to return the debug info as string

### DIFF
--- a/crates/ruff_server/src/server/api/requests/execute_command.rs
+++ b/crates/ruff_server/src/server/api/requests/execute_command.rs
@@ -37,11 +37,11 @@ impl super::SyncRequestHandler for ExecuteCommand {
             let output = debug_information(session);
             notifier
                 .notify::<types::notification::LogMessage>(types::LogMessageParams {
-                    message: output,
+                    message: output.clone(),
                     typ: types::MessageType::INFO,
                 })
                 .with_failure_code(ErrorCode::InternalError)?;
-            return Ok(None);
+            return Ok(Some(serde_json::Value::String(output)));
         }
 
         // check if we can apply a workspace edit


### PR DESCRIPTION
## Summary

This PR updates the `ruff.printDebugInformation` command to return the info as string in the response. Currently, we send a `window/logMessage` request with the info but that has the disadvantage that it's not visible to the user directly.

What `rust-analyzer` does with it's `rust-analyzer/status` request which returns it as a string which then the client can just display it in a separate window. This is what I'm thinking of doing as well.

Other editors can also benefit from it by directly opening a temporary file with this information that the user can see directly.

There are couple of options here:
1. Keep using the command, keep the log request and return the string
2. Keep using the command, remove the log request and return the string
3. Create a new request similar to `rust-analyzer/status` which returns a string

This PR implements (1) but I'd want to move towards (2) and remove the log request completely. We haven't advertised it as such so this would only require updating the VS Code extension to handle it by opening a new document with the debug content.

## Test plan

For VS Code, refer to https://github.com/astral-sh/ruff-vscode/pull/694.

For Neovim, one could do:
```lua
local function execute_ruff_command(command)
  local client = vim.lsp.get_clients({ 
    bufnr = vim.api.nvim_get_current_buf(), 
    name = name,
    method = 'workspace/executeCommand',
  })[1]
  if not client then
    return
  end
  client.request('workspace/executeCommand', {
    command = command,
    arguments = {
      { uri = vim.uri_from_bufnr(0) }
    },
    function(err, result)
      if err then
        -- log error
        return
      end
      vim.print(result)
      -- Or, open a new window with the `result` content
    end
  }
```