### PR TITLE
Include document specific debug info

### DIFF
--- a/crates/ruff_server/src/server/api/requests/execute_command.rs
+++ b/crates/ruff_server/src/server/api/requests/execute_command.rs
@@ -160,14 +160,14 @@ version = {version}
 position_encoding = {encoding:?}
 workspace_root_folders = {workspace_folders:#?}
 indexed_configuration_files = {config_files:#?}
-open_documents = {open_documents}
+open_documents_len = {open_documents_len}
 client_capabilities = {client_capabilities:#?}
 ",
         version = crate::version(),
         encoding = session.encoding(),
         workspace_folders = session.workspace_root_folders().collect::<Vec<_>>(),
         config_files = session.config_file_paths().collect::<Vec<_>>(),
-        open_documents = session.open_documents(),
+        open_documents_len = session.open_documents_len(),
         client_capabilities = session.resolved_client_capabilities(),
     )?;
 
@@ -176,10 +176,11 @@ client_capabilities = {client_capabilities:#?}
             writeln!(buffer, "Unable to take a snapshot of the document at {uri}")?;
             return Ok(buffer);
         };
+        let query = snapshot.query();
 
         writeln!(
             buffer,
-            "Document:
+            "Open document:
 uri = {uri}
 kind = {kind}
 version = {version}
@@ -193,10 +194,10 @@ config_path = {config_path:?}
                 DocumentKey::NotebookCell(_) => "NotebookCell",
                 DocumentKey::Text(_) => "Text",
             },
-            version = snapshot.query().version(),
+            version = query.version(),
             client_settings = snapshot.client_settings(),
-            config_path = snapshot.query().settings().path(),
-            settings = snapshot.query().settings(),
+            config_path = query.settings().path(),
+            settings = query.settings(),
         )?;
     } else {
         writeln!(

--- a/crates/ruff_server/src/session.rs
+++ b/crates/ruff_server/src/session.rs
@@ -168,8 +168,8 @@ impl Session {
     }
 
     /// Returns the number of open documents in the session.
-    pub(crate) fn open_documents(&self) -> usize {
-        self.index.open_documents()
+    pub(crate) fn open_documents_len(&self) -> usize {
+        self.index.open_documents_len()
     }
 
     /// Returns an iterator over the workspace root folders in the session.

--- a/crates/ruff_server/src/session.rs
+++ b/crates/ruff_server/src/session.rs
@@ -1,8 +1,10 @@
 //! Data model, state management, and configuration resolution.
 
+use std::path::Path;
 use std::sync::Arc;
 
 use lsp_types::{ClientCapabilities, FileEvent, NotebookDocumentCellChange, Url};
+use settings::ResolvedClientSettings;
 
 use crate::edit::{DocumentKey, DocumentVersion, NotebookDocument};
 use crate::server::Workspaces;
@@ -147,24 +149,32 @@ impl Session {
         Ok(())
     }
 
-    pub(crate) fn num_documents(&self) -> usize {
-        self.index.num_documents()
-    }
-
-    pub(crate) fn num_workspaces(&self) -> usize {
-        self.index.num_workspaces()
-    }
-
-    pub(crate) fn list_config_files(&self) -> Vec<&std::path::Path> {
-        self.index.list_config_files()
-    }
-
     pub(crate) fn resolved_client_capabilities(&self) -> &ResolvedClientCapabilities {
         &self.resolved_client_capabilities
     }
 
     pub(crate) fn encoding(&self) -> PositionEncoding {
         self.position_encoding
+    }
+
+    /// Returns an iterator over the paths to the configuration files in the index.
+    pub(crate) fn config_file_paths(&self) -> impl Iterator<Item = &Path> {
+        self.index.config_file_paths()
+    }
+
+    /// Returns the resolved global client settings.
+    pub(crate) fn global_client_settings(&self) -> ResolvedClientSettings {
+        ResolvedClientSettings::global(&self.global_settings)
+    }
+
+    /// Returns the number of open documents in the session.
+    pub(crate) fn open_documents(&self) -> usize {
+        self.index.open_documents()
+    }
+
+    /// Returns an iterator over the workspace root folders in the session.
+    pub(crate) fn workspace_root_folders(&self) -> impl Iterator<Item = &Path> {
+        self.index.workspace_root_folders()
     }
 }
 

--- a/crates/ruff_server/src/session/index.rs
+++ b/crates/ruff_server/src/session/index.rs
@@ -177,21 +177,6 @@ impl Index {
             .register_workspace(&Workspace::new(url), global_settings)
     }
 
-    pub(super) fn num_documents(&self) -> usize {
-        self.documents.len()
-    }
-
-    pub(super) fn num_workspaces(&self) -> usize {
-        self.settings.len()
-    }
-
-    pub(super) fn list_config_files(&self) -> Vec<&Path> {
-        self.settings
-            .values()
-            .flat_map(|WorkspaceSettings { ruff_settings, .. }| ruff_settings.list_files())
-            .collect()
-    }
-
     pub(super) fn close_workspace_folder(&mut self, workspace_url: &Url) -> crate::Result<()> {
         let workspace_path = workspace_url.to_file_path().map_err(|()| {
             anyhow!("Failed to convert workspace URL to file path: {workspace_url}")
@@ -403,6 +388,23 @@ impl Index {
             .range(..path.to_path_buf())
             .next_back()
             .map(|(_, settings)| settings)
+    }
+
+    /// Returns an iterator over the workspace root folders contained in this index.
+    pub(super) fn workspace_root_folders(&self) -> impl Iterator<Item = &Path> {
+        self.settings.keys().map(PathBuf::as_path)
+    }
+
+    /// Returns the number of open documents.
+    pub(super) fn open_documents(&self) -> usize {
+        self.documents.len()
+    }
+
+    /// Returns an iterator over the paths to the configuration files in the index.
+    pub(super) fn config_file_paths(&self) -> impl Iterator<Item = &Path> {
+        self.settings
+            .values()
+            .flat_map(|WorkspaceSettings { ruff_settings, .. }| ruff_settings.config_file_paths())
     }
 }
 

--- a/crates/ruff_server/src/session/index.rs
+++ b/crates/ruff_server/src/session/index.rs
@@ -396,7 +396,7 @@ impl Index {
     }
 
     /// Returns the number of open documents.
-    pub(super) fn open_documents(&self) -> usize {
+    pub(super) fn open_documents_len(&self) -> usize {
         self.documents.len()
     }
 

--- a/crates/ruff_server/src/session/index/ruff_settings.rs
+++ b/crates/ruff_server/src/session/index/ruff_settings.rs
@@ -20,12 +20,19 @@ use ruff_workspace::{
 
 use crate::session::settings::{ConfigurationPreference, ResolvedEditorSettings};
 
+#[derive(Debug)]
 pub struct RuffSettings {
     /// The path to this configuration file, used for debugging.
     /// The default fallback configuration does not have a file path.
     path: Option<PathBuf>,
     /// The resolved settings.
     settings: Settings,
+}
+
+impl RuffSettings {
+    pub(crate) fn path(&self) -> Option<&Path> {
+        self.path.as_deref()
+    }
 }
 
 impl Deref for RuffSettings {
@@ -298,14 +305,15 @@ impl RuffSettingsIndex {
             .clone()
     }
 
-    pub(crate) fn list_files(&self) -> impl Iterator<Item = &Path> {
+    pub(super) fn fallback(&self) -> Arc<RuffSettings> {
+        self.fallback.clone()
+    }
+
+    /// Returns an iterator over the paths to the configuration files in the index.
+    pub(crate) fn config_file_paths(&self) -> impl Iterator<Item = &Path> {
         self.index
             .values()
             .filter_map(|settings| settings.path.as_deref())
-    }
-
-    pub(super) fn fallback(&self) -> Arc<RuffSettings> {
-        self.fallback.clone()
     }
 }
 


### PR DESCRIPTION
## Summary

Related https://github.com/astral-sh/ruff-vscode/pull/692.

## Test Plan

**When there's no active text document:**

```
[Info  - 10:57:03 PM] Global:
executable = /Users/dhruv/work/astral/ruff/target/debug/ruff
version = 0.9.6
position_encoding = UTF16
workspace_root_folders = [
    "/Users/dhruv/playground/ruff",
]
indexed_configuration_files = [
    "/Users/dhruv/playground/ruff/pyproject.toml",
    "/Users/dhruv/playground/ruff/formatter/ruff.toml",
]
open_documents = 0
client_capabilities = ResolvedClientCapabilities {
    code_action_deferred_edit_resolution: true,
    apply_edit: true,
    document_changes: true,
    workspace_refresh: true,
    pull_diagnostics: true,
}

global_client_settings = ResolvedClientSettings {
    fix_all: true,
    organize_imports: true,
    lint_enable: true,
    disable_rule_comment_enable: true,
    fix_violation_enable: true,
    show_syntax_errors: true,
    editor_settings: ResolvedEditorSettings {
        configuration: None,
        lint_preview: None,
        format_preview: None,
        select: None,
        extend_select: None,
        ignore: None,
        exclude: None,
        line_length: None,
        configuration_preference: EditorFirst,
    },
}
```

**When there's an active text document that's been passed as param:**

```
[Info  - 10:53:33 PM] Global:
executable = /Users/dhruv/work/astral/ruff/target/debug/ruff
version = 0.9.6
position_encoding = UTF16
workspace_root_folders = [
    "/Users/dhruv/playground/ruff",
]
indexed_configuration_files = [
    "/Users/dhruv/playground/ruff/pyproject.toml",
    "/Users/dhruv/playground/ruff/formatter/ruff.toml",
]
open_documents = 1
client_capabilities = ResolvedClientCapabilities {
    code_action_deferred_edit_resolution: true,
    apply_edit: true,
    document_changes: true,
    workspace_refresh: true,
    pull_diagnostics: true,
}

Document:
uri = file:///Users/dhruv/playground/ruff/lsp/play.py
kind = Text
version = 1
client_settings = ResolvedClientSettings {
    fix_all: true,
    organize_imports: true,
    lint_enable: true,
    disable_rule_comment_enable: true,
    fix_violation_enable: true,
    show_syntax_errors: true,
    editor_settings: ResolvedEditorSettings {
        configuration: None,
        lint_preview: None,
        format_preview: None,
        select: None,
        extend_select: None,
        ignore: None,
        exclude: None,
        line_length: None,
        configuration_preference: EditorFirst,
    },
}
config_path = Some("/Users/dhruv/playground/ruff/pyproject.toml")

...
```

Replace `...` at the end with the output of `ruff check --show-settings path.py`