### PR TITLE
[red-knot] Avoid creating `UnionBuilder`s unnecessarily

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -4177,12 +4177,22 @@ impl<'db> UnionType<'db> {
         I: IntoIterator<Item = T>,
         T: Into<Type<'db>>,
     {
-        elements
-            .into_iter()
-            .fold(UnionBuilder::new(db), |builder, element| {
-                builder.add(element.into())
-            })
-            .build()
+        let mut elements = elements.into_iter();
+        let Some(first) = elements.next() else {
+            return Type::Never;
+        };
+
+        let Some(second) = elements.next() else {
+            return first.into();
+        };
+
+        let mut builder = UnionBuilder::new(db).add(first.into()).add(second.into());
+
+        for element in elements {
+            builder = builder.add(element.into());
+        }
+
+        builder.build()
     }
 
     /// Apply a transformation function to all elements of the union,

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -4186,11 +4186,11 @@ impl<'db> UnionType<'db> {
             return first;
         };
 
-        let (lower, _) = elements.size_hint();
-        let mut builder = UnionBuilder::new(db);
-        builder.reserve(lower + 2);
-
-        builder.add(first).add(second).extend(elements).build()
+        UnionBuilder::new(db)
+            .add(first)
+            .add(second)
+            .extend(elements)
+            .build()
     }
 
     /// Apply a transformation function to all elements of the union,

--- a/crates/red_knot_python_semantic/src/types/builder.rs
+++ b/crates/red_knot_python_semantic/src/types/builder.rs
@@ -43,11 +43,6 @@ impl<'db> UnionBuilder<'db> {
         }
     }
 
-    #[inline]
-    pub(crate) fn reserve(&mut self, additional: usize) {
-        self.elements.reserve(additional);
-    }
-
     /// Collapse the union to a single type: `object`.
     fn collapse_to_object(mut self) -> Self {
         self.elements.clear();
@@ -58,10 +53,6 @@ impl<'db> UnionBuilder<'db> {
     #[inline]
     pub(crate) fn extend(mut self, elements: impl IntoIterator<Item = Type<'db>>) -> Self {
         let elements = elements.into_iter();
-        let (lower, _) = elements.size_hint();
-
-        // Assume that most types will be unique
-        self.reserve(lower);
 
         for element in elements {
             self = self.add(element);

--- a/crates/red_knot_python_semantic/src/types/builder.rs
+++ b/crates/red_knot_python_semantic/src/types/builder.rs
@@ -43,10 +43,29 @@ impl<'db> UnionBuilder<'db> {
         }
     }
 
+    pub(crate) fn reserve(&mut self, additional: usize) {
+        self.elements.reserve(additional);
+    }
+
     /// Collapse the union to a single type: `object`.
     fn collapse_to_object(mut self) -> Self {
         self.elements.clear();
         self.elements.push(Type::object(self.db));
+        self
+    }
+
+    #[inline]
+    pub(crate) fn extend(mut self, elements: impl IntoIterator<Item = Type<'db>>) -> Self {
+        let elements = elements.into_iter();
+        let (lower, _) = elements.size_hint();
+
+        // Assume that most types will be unique
+        self.reserve(lower);
+
+        for element in elements {
+            self = self.add(element);
+        }
+
         self
     }
 

--- a/crates/red_knot_python_semantic/src/types/builder.rs
+++ b/crates/red_knot_python_semantic/src/types/builder.rs
@@ -43,6 +43,7 @@ impl<'db> UnionBuilder<'db> {
         }
     }
 
+    #[inline]
     pub(crate) fn reserve(&mut self, additional: usize) {
         self.elements.reserve(additional);
     }

--- a/crates/red_knot_python_semantic/src/types/unpacker.rs
+++ b/crates/red_knot_python_semantic/src/types/unpacker.rs
@@ -168,7 +168,7 @@ impl<'db> Unpacker<'db> {
                     // SAFETY: `target_types` is initialized with the same length as `elts`.
                     let element_ty = match target_types[index].as_slice() {
                         [] => Type::unknown(),
-                        types => UnionType::from_elements(self.db(), types),
+                        types => UnionType::from_elements(self.db(), types.iter().copied()),
                     };
                     self.unpack_inner(element, value_expr, element_ty);
                 }


### PR DESCRIPTION
## Summary
`UnionBuilder::from_elements` is called very frequently. Let's see if short-circuiting in the case where `elements` is zero or one elements
long helps improve perf.

## Test Plan

This should not change behavior.
