### PR TITLE
Workspace versioning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3150,7 +3150,7 @@ dependencies = [
 
 [[package]]
 name = "ruff_server"
-version = "0.2.2"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "crossbeam",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2707,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "ruff_annotate_snippets"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2856,7 +2856,7 @@ dependencies = [
 
 [[package]]
 name = "ruff_graph"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 rust-version = "1.80"
+version = "0.0.0"
 homepage = "https://docs.astral.sh/ruff"
 documentation = "https://docs.astral.sh/ruff"
 repository = "https://github.com/astral-sh/ruff"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ resolver = "2"
 edition = "2021"
 rust-version = "1.80"
 version = "0.0.0"
+publish = false
 homepage = "https://docs.astral.sh/ruff"
 documentation = "https://docs.astral.sh/ruff"
 repository = "https://github.com/astral-sh/ruff"

--- a/crates/red_knot/Cargo.toml
+++ b/crates/red_knot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "red_knot"
-version = "0.0.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 homepage.workspace = true

--- a/crates/red_knot_project/Cargo.toml
+++ b/crates/red_knot_project/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "red_knot_project"
-version = "0.0.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 homepage.workspace = true

--- a/crates/red_knot_python_semantic/Cargo.toml
+++ b/crates/red_knot_python_semantic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "red_knot_python_semantic"
-version = "0.0.0"
+version.workspace = true
 publish = false
 authors = { workspace = true }
 edition = { workspace = true }

--- a/crates/red_knot_python_semantic/Cargo.toml
+++ b/crates/red_knot_python_semantic/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "red_knot_python_semantic"
 version.workspace = true
-publish = false
+publish.workspace = true
 authors = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/red_knot_server/Cargo.toml
+++ b/crates/red_knot_server/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "red_knot_server"
 version.workspace = true
-publish = false
+publish.workspace = true
 authors = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/red_knot_server/Cargo.toml
+++ b/crates/red_knot_server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "red_knot_server"
-version = "0.0.0"
+version.workspace = true
 publish = false
 authors = { workspace = true }
 edition = { workspace = true }

--- a/crates/red_knot_test/Cargo.toml
+++ b/crates/red_knot_test/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "red_knot_test"
 version.workspace = true
-publish = false
+publish.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 homepage.workspace = true

--- a/crates/red_knot_test/Cargo.toml
+++ b/crates/red_knot_test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "red_knot_test"
-version = "0.0.0"
+version.workspace = true
 publish = false
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/red_knot_vendored/Cargo.toml
+++ b/crates/red_knot_vendored/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "red_knot_vendored"
 version.workspace = true
-publish = false
+publish.workspace = true
 authors = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/red_knot_vendored/Cargo.toml
+++ b/crates/red_knot_vendored/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "red_knot_vendored"
-version = "0.0.0"
+version.workspace = true
 publish = false
 authors = { workspace = true }
 edition = { workspace = true }
@@ -28,4 +28,3 @@ deflate = ["zip/deflate"]
 
 [lints]
 workspace = true
-

--- a/crates/red_knot_wasm/Cargo.toml
+++ b/crates/red_knot_wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "red_knot_wasm"
-version = "0.0.0"
+version.workspace = true
 publish = false
 authors = { workspace = true }
 edition = { workspace = true }
@@ -40,4 +40,3 @@ wasm-bindgen-test = { workspace = true }
 
 [lints]
 workspace = true
-

--- a/crates/red_knot_wasm/Cargo.toml
+++ b/crates/red_knot_wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "red_knot_wasm"
 version.workspace = true
-publish = false
+publish.workspace = true
 authors = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/ruff_annotate_snippets/Cargo.toml
+++ b/crates/ruff_annotate_snippets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff_annotate_snippets"
-version = "0.1.0"
+version.workspace = true
 publish.workspace = true
 authors = { workspace = true }
 edition = { workspace = true }

--- a/crates/ruff_annotate_snippets/Cargo.toml
+++ b/crates/ruff_annotate_snippets/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ruff_annotate_snippets"
 version = "0.1.0"
-publish = false
+publish.workspace = true
 authors = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/ruff_benchmark/Cargo.toml
+++ b/crates/ruff_benchmark/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff_benchmark"
-version = "0.0.0"
+version.workspace = true
 description = "Ruff Micro-benchmarks"
 publish = false
 authors = { workspace = true }

--- a/crates/ruff_benchmark/Cargo.toml
+++ b/crates/ruff_benchmark/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ruff_benchmark"
 version.workspace = true
 description = "Ruff Micro-benchmarks"
-publish = false
+publish.workspace = true
 authors = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/ruff_cache/Cargo.toml
+++ b/crates/ruff_cache/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ruff_cache"
 version.workspace = true
-publish = false
+publish.workspace = true
 authors = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/ruff_cache/Cargo.toml
+++ b/crates/ruff_cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff_cache"
-version = "0.0.0"
+version.workspace = true
 publish = false
 authors = { workspace = true }
 edition = { workspace = true }

--- a/crates/ruff_db/Cargo.toml
+++ b/crates/ruff_db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff_db"
-version = "0.0.0"
+version.workspace = true
 publish = false
 authors = { workspace = true }
 edition = { workspace = true }

--- a/crates/ruff_db/Cargo.toml
+++ b/crates/ruff_db/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ruff_db"
 version.workspace = true
-publish = false
+publish.workspace = true
 authors = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/ruff_dev/Cargo.toml
+++ b/crates/ruff_dev/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff_dev"
-version = "0.0.0"
+version.workspace = true
 publish = false
 authors = { workspace = true }
 edition = { workspace = true }

--- a/crates/ruff_dev/Cargo.toml
+++ b/crates/ruff_dev/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ruff_dev"
 version.workspace = true
-publish = false
+publish.workspace = true
 authors = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/ruff_diagnostics/Cargo.toml
+++ b/crates/ruff_diagnostics/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ruff_diagnostics"
 version.workspace = true
-publish = false
+publish.workspace = true
 authors = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/ruff_diagnostics/Cargo.toml
+++ b/crates/ruff_diagnostics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff_diagnostics"
-version = "0.0.0"
+version.workspace = true
 publish = false
 authors = { workspace = true }
 edition = { workspace = true }

--- a/crates/ruff_formatter/Cargo.toml
+++ b/crates/ruff_formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff_formatter"
-version = "0.0.0"
+version.workspace = true
 publish = false
 authors = { workspace = true }
 edition = { workspace = true }

--- a/crates/ruff_formatter/Cargo.toml
+++ b/crates/ruff_formatter/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ruff_formatter"
 version.workspace = true
-publish = false
+publish.workspace = true
 authors = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/ruff_graph/Cargo.toml
+++ b/crates/ruff_graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff_graph"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 homepage.workspace = true

--- a/crates/ruff_index/Cargo.toml
+++ b/crates/ruff_index/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ruff_index"
 version.workspace = true
-publish = false
+publish.workspace = true
 authors = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/ruff_index/Cargo.toml
+++ b/crates/ruff_index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff_index"
-version = "0.0.0"
+version.workspace = true
 publish = false
 authors = { workspace = true }
 edition = { workspace = true }

--- a/crates/ruff_linter/Cargo.toml
+++ b/crates/ruff_linter/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ruff_linter"
 version = "0.9.6"
-publish = false
+publish.workspace = true
 authors = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/ruff_macros/Cargo.toml
+++ b/crates/ruff_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff_macros"
-version = "0.0.0"
+version.workspace = true
 publish = false
 authors = { workspace = true }
 edition = { workspace = true }

--- a/crates/ruff_macros/Cargo.toml
+++ b/crates/ruff_macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ruff_macros"
 version.workspace = true
-publish = false
+publish.workspace = true
 authors = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/ruff_notebook/Cargo.toml
+++ b/crates/ruff_notebook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff_notebook"
-version = "0.0.0"
+version.workspace = true
 publish = false
 authors = { workspace = true }
 edition = { workspace = true }

--- a/crates/ruff_notebook/Cargo.toml
+++ b/crates/ruff_notebook/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ruff_notebook"
 version.workspace = true
-publish = false
+publish.workspace = true
 authors = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/ruff_python_ast/Cargo.toml
+++ b/crates/ruff_python_ast/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ruff_python_ast"
 version.workspace = true
-publish = false
+publish.workspace = true
 authors = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/ruff_python_ast/Cargo.toml
+++ b/crates/ruff_python_ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff_python_ast"
-version = "0.0.0"
+version.workspace = true
 publish = false
 authors = { workspace = true }
 edition = { workspace = true }

--- a/crates/ruff_python_ast_integration_tests/Cargo.toml
+++ b/crates/ruff_python_ast_integration_tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff_python_ast_integration_tests"
-version = "0.0.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 homepage.workspace = true

--- a/crates/ruff_python_codegen/Cargo.toml
+++ b/crates/ruff_python_codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff_python_codegen"
-version = "0.0.0"
+version.workspace = true
 publish = false
 authors = { workspace = true }
 edition = { workspace = true }
@@ -25,4 +25,3 @@ test-case = { workspace = true }
 
 [lints]
 workspace = true
-

--- a/crates/ruff_python_codegen/Cargo.toml
+++ b/crates/ruff_python_codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ruff_python_codegen"
 version.workspace = true
-publish = false
+publish.workspace = true
 authors = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/ruff_python_formatter/Cargo.toml
+++ b/crates/ruff_python_formatter/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ruff_python_formatter"
 version.workspace = true
-publish = false
+publish.workspace = true
 authors = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/ruff_python_formatter/Cargo.toml
+++ b/crates/ruff_python_formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff_python_formatter"
-version = "0.0.0"
+version.workspace = true
 publish = false
 authors = { workspace = true }
 edition = { workspace = true }

--- a/crates/ruff_python_index/Cargo.toml
+++ b/crates/ruff_python_index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff_python_index"
-version = "0.0.0"
+version.workspace = true
 publish = false
 authors = { workspace = true }
 edition = { workspace = true }

--- a/crates/ruff_python_index/Cargo.toml
+++ b/crates/ruff_python_index/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ruff_python_index"
 version.workspace = true
-publish = false
+publish.workspace = true
 authors = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/ruff_python_literal/Cargo.toml
+++ b/crates/ruff_python_literal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff_python_literal"
-version = "0.0.0"
+version.workspace = true
 publish = false
 description = "Common literal handling utilities mostly useful for unparse and repr."
 authors = ["Charlie Marsh <charlie.r.marsh@gmail.com>", "RustPython Team"]

--- a/crates/ruff_python_literal/Cargo.toml
+++ b/crates/ruff_python_literal/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ruff_python_literal"
 version.workspace = true
-publish = false
+publish.workspace = true
 description = "Common literal handling utilities mostly useful for unparse and repr."
 authors = ["Charlie Marsh <charlie.r.marsh@gmail.com>", "RustPython Team"]
 edition = { workspace = true }

--- a/crates/ruff_python_parser/Cargo.toml
+++ b/crates/ruff_python_parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff_python_parser"
-version = "0.0.0"
+version.workspace = true
 publish = false
 authors = ["Charlie Marsh <charlie.r.marsh@gmail.com>", "RustPython Team"]
 edition = { workspace = true }

--- a/crates/ruff_python_parser/Cargo.toml
+++ b/crates/ruff_python_parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ruff_python_parser"
 version.workspace = true
-publish = false
+publish.workspace = true
 authors = ["Charlie Marsh <charlie.r.marsh@gmail.com>", "RustPython Team"]
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/ruff_python_resolver/Cargo.toml
+++ b/crates/ruff_python_resolver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff_python_resolver"
-version = "0.0.0"
+version.workspace = true
 description = "A Python module resolver for Ruff"
 publish = false
 authors = { workspace = true }

--- a/crates/ruff_python_resolver/Cargo.toml
+++ b/crates/ruff_python_resolver/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ruff_python_resolver"
 version.workspace = true
 description = "A Python module resolver for Ruff"
-publish = false
+publish.workspace = true
 authors = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/ruff_python_semantic/Cargo.toml
+++ b/crates/ruff_python_semantic/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ruff_python_semantic"
 version.workspace = true
-publish = false
+publish.workspace = true
 authors = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/ruff_python_semantic/Cargo.toml
+++ b/crates/ruff_python_semantic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff_python_semantic"
-version = "0.0.0"
+version.workspace = true
 publish = false
 authors = { workspace = true }
 edition = { workspace = true }

--- a/crates/ruff_python_stdlib/Cargo.toml
+++ b/crates/ruff_python_stdlib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ruff_python_stdlib"
 version.workspace = true
-publish = false
+publish.workspace = true
 authors = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/ruff_python_stdlib/Cargo.toml
+++ b/crates/ruff_python_stdlib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff_python_stdlib"
-version = "0.0.0"
+version.workspace = true
 publish = false
 authors = { workspace = true }
 edition = { workspace = true }

--- a/crates/ruff_python_trivia/Cargo.toml
+++ b/crates/ruff_python_trivia/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ruff_python_trivia"
 version.workspace = true
-publish = false
+publish.workspace = true
 authors = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/ruff_python_trivia/Cargo.toml
+++ b/crates/ruff_python_trivia/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff_python_trivia"
-version = "0.0.0"
+version.workspace = true
 publish = false
 authors = { workspace = true }
 edition = { workspace = true }

--- a/crates/ruff_python_trivia_integration_tests/Cargo.toml
+++ b/crates/ruff_python_trivia_integration_tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff_python_trivia_integration_tests"
-version = "0.0.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 homepage.workspace = true

--- a/crates/ruff_server/Cargo.toml
+++ b/crates/ruff_server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff_server"
-version = "0.2.2"
+version.workspace = true
 publish.workspace = true
 authors = { workspace = true }
 edition = { workspace = true }

--- a/crates/ruff_server/Cargo.toml
+++ b/crates/ruff_server/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ruff_server"
 version = "0.2.2"
-publish = false
+publish.workspace = true
 authors = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/ruff_source_file/Cargo.toml
+++ b/crates/ruff_source_file/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff_source_file"
-version = "0.0.0"
+version.workspace = true
 publish = false
 authors = { workspace = true }
 edition = { workspace = true }

--- a/crates/ruff_source_file/Cargo.toml
+++ b/crates/ruff_source_file/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ruff_source_file"
 version.workspace = true
-publish = false
+publish.workspace = true
 authors = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/ruff_text_size/Cargo.toml
+++ b/crates/ruff_text_size/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ruff_text_size"
 version.workspace = true
-publish = false
+publish.workspace = true
 edition = "2021"
 rust-version = "1.67.1"
 

--- a/crates/ruff_text_size/Cargo.toml
+++ b/crates/ruff_text_size/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff_text_size"
-version = "0.0.0"
+version.workspace = true
 publish = false
 edition = "2021"
 rust-version = "1.67.1"

--- a/crates/ruff_wasm/Cargo.toml
+++ b/crates/ruff_wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ruff_wasm"
 version = "0.9.6"
-publish = false
+publish.workspace = true
 authors = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/ruff_workspace/Cargo.toml
+++ b/crates/ruff_workspace/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ruff_workspace"
 version.workspace = true
-publish = false
+publish.workspace = true
 authors = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/ruff_workspace/Cargo.toml
+++ b/crates/ruff_workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff_workspace"
-version = "0.0.0"
+version.workspace = true
 publish = false
 authors = { workspace = true }
 edition = { workspace = true }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff-fuzz"
-version.workspace = true
+version = "0.0.0"
 authors = [
     "Charlie Marsh <charlie.r.marsh@gmail.com>",
     "Addison Crump <research@addisoncrump.info>",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff-fuzz"
-version = "0.0.0"
+version.workspace = true
 authors = [
     "Charlie Marsh <charlie.r.marsh@gmail.com>",
     "Addison Crump <research@addisoncrump.info>",


### PR DESCRIPTION
Move "0.0.0" versions and "publish = false" to top level Cargo.toml and inherit from there - steps towards #43 (see https://github.com/astral-sh/ruff/issues/43#issuecomment-2628873363 - as means all the ruff internal packages can be versioned together)
