### PR TITLE
improve diagnostics for "invalid argument type"

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/diagnostics/invalid_argument_type.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/diagnostics/invalid_argument_type.md
@@ -1,0 +1,184 @@
+# Invalid argument type diagnostics
+
+<!-- snapshot-diagnostics -->
+
+## Basic
+
+This is a basic test demonstrating that a diagnostic points to the function definition corresponding
+to the invalid argument.
+
+```py
+def foo(x: int) -> int:
+    return x * x
+
+foo("hello")  # error: [invalid-argument-type]
+```
+
+## Different source order
+
+This is like the basic test, except we put the call site above the function definition.
+
+```py
+def bar():
+    foo("hello")  # error: [invalid-argument-type]
+
+def foo(x: int) -> int:
+    return x * x
+```
+
+## Different files
+
+This tests that a diagnostic can point to a function definition in a different file in which an
+invalid call site was found.
+
+`package.py`:
+
+```py
+def foo(x: int) -> int:
+    return x * x
+```
+
+```py
+import package
+
+package.foo("hello")  # error: [invalid-argument-type]
+```
+
+## Many parameters
+
+This checks that a diagnostic renders reasonably when there are multiple parameters.
+
+```py
+def foo(x: int, y: int, z: int) -> int:
+    return x * y * z
+
+foo(1, "hello", 3)  # error: [invalid-argument-type]
+```
+
+## Many parameters across multiple lines
+
+This checks that a diagnostic renders reasonably when there are multiple parameters spread out
+across multiple lines.
+
+```py
+def foo(
+    x: int,
+    y: int,
+    z: int,
+) -> int:
+    return x * y * z
+
+foo(1, "hello", 3)  # error: [invalid-argument-type]
+```
+
+## Many parameters with multiple invalid arguments
+
+This checks that a diagnostic renders reasonably when there are multiple parameters and multiple
+invalid argument types.
+
+```py
+def foo(x: int, y: int, z: int) -> int:
+    return x * y * z
+
+# error: [invalid-argument-type]
+# error: [invalid-argument-type]
+# error: [invalid-argument-type]
+foo("a", "b", "c")
+```
+
+At present (2025-02-18), this renders three different diagnostic messages. But arguably, these could
+all be folded into one diagnostic. Fixing this requires at least better support for multi-spans in
+the diagnostic model and possibly also how diagnostics are emitted by the type checker itself.
+
+## Test calling a function whose type is vendored from `typeshed`
+
+This tests that diagnostic rendering is reasonable when the function being called is from the
+standard library.
+
+```py
+import json
+
+json.loads(5)  # error: [invalid-argument-type]
+```
+
+## Tests for a variety of argument types
+
+These tests check that diagnostic output is reasonable regardless of the kinds of arguments used in
+a function definition.
+
+### Only positional
+
+Tests a function definition with only positional parameters.
+
+```py
+def foo(x: int, y: int, z: int, /) -> int:
+    return x * y * z
+
+foo(1, "hello", 3)  # error: [invalid-argument-type]
+```
+
+### Variadic arguments
+
+Tests a function definition with variadic arguments.
+
+```py
+def foo(*numbers: int) -> int:
+    return len(numbers)
+
+foo(1, 2, 3, "hello", 5)  # error: [invalid-argument-type]
+```
+
+### Keyword only arguments
+
+Tests a function definition with keyword-only arguments.
+
+```py
+def foo(x: int, y: int, *, z: int = 0) -> int:
+    return x * y * z
+
+foo(1, 2, z="hello")  # error: [invalid-argument-type]
+```
+
+### One keyword argument
+
+Tests a function definition with keyword-only arguments.
+
+```py
+def foo(x: int, y: int, z: int = 0) -> int:
+    return x * y * z
+
+foo(1, 2, "hello")  # error: [invalid-argument-type]
+```
+
+### Variadic keyword arguments
+
+```py
+def foo(**numbers: int) -> int:
+    return len(numbers)
+
+foo(a=1, b=2, c=3, d="hello", e=5)  # error: [invalid-argument-type]
+```
+
+### Mix of arguments
+
+Tests a function definition with multiple different kinds of arguments.
+
+```py
+def foo(x: int, /, y: int, *, z: int = 0) -> int:
+    return x * y * z
+
+foo(1, 2, z="hello")  # error: [invalid-argument-type]
+```
+
+### Synthetic arguments
+
+Tests a function call with synthetic arguments.
+
+```py
+class C:
+    def __call__(self, x: int) -> int:
+        return 1
+
+c = C()
+c("wrong")  # error: [invalid-argument-type]
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Basic.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Basic.snap
@@ -1,0 +1,39 @@
+---
+source: crates/red_knot_test/src/lib.rs
+expression: snapshot
+---
+---
+mdtest name: invalid_argument_type.md - Invalid argument type diagnostics - Basic
+mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/invalid_argument_type.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+1 | def foo(x: int) -> int:
+2 |     return x * x
+3 | 
+4 | foo("hello")  # error: [invalid-argument-type]
+```
+
+# Diagnostics
+
+```
+error: lint:invalid-argument-type
+ --> /src/mdtest_snippet.py:4:5
+  |
+2 |     return x * x
+3 |
+4 | foo("hello")  # error: [invalid-argument-type]
+  |     ^^^^^^^ Object of type `Literal["hello"]` cannot be assigned to parameter 1 (`x`) of function `foo`; expected type `int`
+  |
+ ::: /src/mdtest_snippet.py:1:9
+  |
+1 | def foo(x: int) -> int:
+  |         ------ info: parameter declared in function definition here
+2 |     return x * x
+  |
+
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Different_files.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Different_files.snap
@@ -1,0 +1,45 @@
+---
+source: crates/red_knot_test/src/lib.rs
+expression: snapshot
+---
+---
+mdtest name: invalid_argument_type.md - Invalid argument type diagnostics - Different files
+mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/invalid_argument_type.md
+---
+
+# Python source files
+
+## package.py
+
+```
+1 | def foo(x: int) -> int:
+2 |     return x * x
+```
+
+## mdtest_snippet.py
+
+```
+1 | import package
+2 | 
+3 | package.foo("hello")  # error: [invalid-argument-type]
+```
+
+# Diagnostics
+
+```
+error: lint:invalid-argument-type
+ --> /src/mdtest_snippet.py:3:13
+  |
+1 | import package
+2 |
+3 | package.foo("hello")  # error: [invalid-argument-type]
+  |             ^^^^^^^ Object of type `Literal["hello"]` cannot be assigned to parameter 1 (`x`) of function `foo`; expected type `int`
+  |
+ ::: /src/package.py:1:9
+  |
+1 | def foo(x: int) -> int:
+  |         ------ info: parameter declared in function definition here
+2 |     return x * x
+  |
+
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Different_source_order.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Different_source_order.snap
@@ -1,0 +1,43 @@
+---
+source: crates/red_knot_test/src/lib.rs
+expression: snapshot
+---
+---
+mdtest name: invalid_argument_type.md - Invalid argument type diagnostics - Different source order
+mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/invalid_argument_type.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+1 | def bar():
+2 |     foo("hello")  # error: [invalid-argument-type]
+3 | 
+4 | def foo(x: int) -> int:
+5 |     return x * x
+```
+
+# Diagnostics
+
+```
+error: lint:invalid-argument-type
+ --> /src/mdtest_snippet.py:2:9
+  |
+1 | def bar():
+2 |     foo("hello")  # error: [invalid-argument-type]
+  |         ^^^^^^^ Object of type `Literal["hello"]` cannot be assigned to parameter 1 (`x`) of function `foo`; expected type `int`
+3 |
+4 | def foo(x: int) -> int:
+  |
+ ::: /src/mdtest_snippet.py:4:9
+  |
+2 |     foo("hello")  # error: [invalid-argument-type]
+3 |
+4 | def foo(x: int) -> int:
+  |         ------ info: parameter declared in function definition here
+5 |     return x * x
+  |
+
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters.snap
@@ -1,0 +1,39 @@
+---
+source: crates/red_knot_test/src/lib.rs
+expression: snapshot
+---
+---
+mdtest name: invalid_argument_type.md - Invalid argument type diagnostics - Many parameters
+mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/invalid_argument_type.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+1 | def foo(x: int, y: int, z: int) -> int:
+2 |     return x * y * z
+3 | 
+4 | foo(1, "hello", 3)  # error: [invalid-argument-type]
+```
+
+# Diagnostics
+
+```
+error: lint:invalid-argument-type
+ --> /src/mdtest_snippet.py:4:8
+  |
+2 |     return x * y * z
+3 |
+4 | foo(1, "hello", 3)  # error: [invalid-argument-type]
+  |        ^^^^^^^ Object of type `Literal["hello"]` cannot be assigned to parameter 2 (`y`) of function `foo`; expected type `int`
+  |
+ ::: /src/mdtest_snippet.py:1:17
+  |
+1 | def foo(x: int, y: int, z: int) -> int:
+  |                 ------ info: parameter declared in function definition here
+2 |     return x * y * z
+  |
+
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters_across_multiple_lines.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters_across_multiple_lines.snap
@@ -1,0 +1,46 @@
+---
+source: crates/red_knot_test/src/lib.rs
+expression: snapshot
+---
+---
+mdtest name: invalid_argument_type.md - Invalid argument type diagnostics - Many parameters across multiple lines
+mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/invalid_argument_type.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+1 | def foo(
+2 |     x: int,
+3 |     y: int,
+4 |     z: int,
+5 | ) -> int:
+6 |     return x * y * z
+7 | 
+8 | foo(1, "hello", 3)  # error: [invalid-argument-type]
+```
+
+# Diagnostics
+
+```
+error: lint:invalid-argument-type
+ --> /src/mdtest_snippet.py:8:8
+  |
+6 |     return x * y * z
+7 |
+8 | foo(1, "hello", 3)  # error: [invalid-argument-type]
+  |        ^^^^^^^ Object of type `Literal["hello"]` cannot be assigned to parameter 2 (`y`) of function `foo`; expected type `int`
+  |
+ ::: /src/mdtest_snippet.py:3:5
+  |
+1 | def foo(
+2 |     x: int,
+3 |     y: int,
+  |     ------ info: parameter declared in function definition here
+4 |     z: int,
+5 | ) -> int:
+  |
+
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters_with_multiple_invalid_arguments.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters_with_multiple_invalid_arguments.snap
@@ -1,0 +1,78 @@
+---
+source: crates/red_knot_test/src/lib.rs
+expression: snapshot
+---
+---
+mdtest name: invalid_argument_type.md - Invalid argument type diagnostics - Many parameters with multiple invalid arguments
+mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/invalid_argument_type.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+1 | def foo(x: int, y: int, z: int) -> int:
+2 |     return x * y * z
+3 | 
+4 | # error: [invalid-argument-type]
+5 | # error: [invalid-argument-type]
+6 | # error: [invalid-argument-type]
+7 | foo("a", "b", "c")
+```
+
+# Diagnostics
+
+```
+error: lint:invalid-argument-type
+ --> /src/mdtest_snippet.py:7:5
+  |
+5 | # error: [invalid-argument-type]
+6 | # error: [invalid-argument-type]
+7 | foo("a", "b", "c")
+  |     ^^^ Object of type `Literal["a"]` cannot be assigned to parameter 1 (`x`) of function `foo`; expected type `int`
+  |
+ ::: /src/mdtest_snippet.py:1:9
+  |
+1 | def foo(x: int, y: int, z: int) -> int:
+  |         ------ info: parameter declared in function definition here
+2 |     return x * y * z
+  |
+
+```
+
+```
+error: lint:invalid-argument-type
+ --> /src/mdtest_snippet.py:7:10
+  |
+5 | # error: [invalid-argument-type]
+6 | # error: [invalid-argument-type]
+7 | foo("a", "b", "c")
+  |          ^^^ Object of type `Literal["b"]` cannot be assigned to parameter 2 (`y`) of function `foo`; expected type `int`
+  |
+ ::: /src/mdtest_snippet.py:1:17
+  |
+1 | def foo(x: int, y: int, z: int) -> int:
+  |                 ------ info: parameter declared in function definition here
+2 |     return x * y * z
+  |
+
+```
+
+```
+error: lint:invalid-argument-type
+ --> /src/mdtest_snippet.py:7:15
+  |
+5 | # error: [invalid-argument-type]
+6 | # error: [invalid-argument-type]
+7 | foo("a", "b", "c")
+  |               ^^^ Object of type `Literal["c"]` cannot be assigned to parameter 3 (`z`) of function `foo`; expected type `int`
+  |
+ ::: /src/mdtest_snippet.py:1:25
+  |
+1 | def foo(x: int, y: int, z: int) -> int:
+  |                         ------ info: parameter declared in function definition here
+2 |     return x * y * z
+  |
+
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Test_calling_a_function_whose_type_is_vendored_from_`typeshed`.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Test_calling_a_function_whose_type_is_vendored_from_`typeshed`.snap
@@ -1,0 +1,41 @@
+---
+source: crates/red_knot_test/src/lib.rs
+expression: snapshot
+---
+---
+mdtest name: invalid_argument_type.md - Invalid argument type diagnostics - Test calling a function whose type is vendored from `typeshed`
+mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/invalid_argument_type.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+1 | import json
+2 | 
+3 | json.loads(5)  # error: [invalid-argument-type]
+```
+
+# Diagnostics
+
+```
+error: lint:invalid-argument-type
+  --> /src/mdtest_snippet.py:3:12
+   |
+ 1 | import json
+ 2 |
+ 3 | json.loads(5)  # error: [invalid-argument-type]
+   |            ^ Object of type `Literal[5]` cannot be assigned to parameter 1 (`s`) of function `loads`; expected type `str | bytes | bytearray`
+   |
+  ::: vendored://stdlib/json/__init__.pyi:40:5
+   |
+38 | ) -> None: ...
+39 | def loads(
+40 |     s: str | bytes | bytearray,
+   |     -------------------------- info: parameter declared in function definition here
+41 |     *,
+42 |     cls: type[JSONDecoder] | None = None,
+   |
+
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Keyword_only_arguments.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Keyword_only_arguments.snap
@@ -1,0 +1,39 @@
+---
+source: crates/red_knot_test/src/lib.rs
+expression: snapshot
+---
+---
+mdtest name: invalid_argument_type.md - Invalid argument type diagnostics - Tests for a variety of argument types - Keyword only arguments
+mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/invalid_argument_type.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+1 | def foo(x: int, y: int, *, z: int = 0) -> int:
+2 |     return x * y * z
+3 | 
+4 | foo(1, 2, z="hello")  # error: [invalid-argument-type]
+```
+
+# Diagnostics
+
+```
+error: lint:invalid-argument-type
+ --> /src/mdtest_snippet.py:4:11
+  |
+2 |     return x * y * z
+3 |
+4 | foo(1, 2, z="hello")  # error: [invalid-argument-type]
+  |           ^^^^^^^^^ Object of type `Literal["hello"]` cannot be assigned to parameter `z` of function `foo`; expected type `int`
+  |
+ ::: /src/mdtest_snippet.py:1:28
+  |
+1 | def foo(x: int, y: int, *, z: int = 0) -> int:
+  |                            ---------- info: parameter declared in function definition here
+2 |     return x * y * z
+  |
+
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Mix_of_arguments.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Mix_of_arguments.snap
@@ -1,0 +1,39 @@
+---
+source: crates/red_knot_test/src/lib.rs
+expression: snapshot
+---
+---
+mdtest name: invalid_argument_type.md - Invalid argument type diagnostics - Tests for a variety of argument types - Mix of arguments
+mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/invalid_argument_type.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+1 | def foo(x: int, /, y: int, *, z: int = 0) -> int:
+2 |     return x * y * z
+3 | 
+4 | foo(1, 2, z="hello")  # error: [invalid-argument-type]
+```
+
+# Diagnostics
+
+```
+error: lint:invalid-argument-type
+ --> /src/mdtest_snippet.py:4:11
+  |
+2 |     return x * y * z
+3 |
+4 | foo(1, 2, z="hello")  # error: [invalid-argument-type]
+  |           ^^^^^^^^^ Object of type `Literal["hello"]` cannot be assigned to parameter `z` of function `foo`; expected type `int`
+  |
+ ::: /src/mdtest_snippet.py:1:31
+  |
+1 | def foo(x: int, /, y: int, *, z: int = 0) -> int:
+  |                               ---------- info: parameter declared in function definition here
+2 |     return x * y * z
+  |
+
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_One_keyword_argument.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_One_keyword_argument.snap
@@ -1,0 +1,39 @@
+---
+source: crates/red_knot_test/src/lib.rs
+expression: snapshot
+---
+---
+mdtest name: invalid_argument_type.md - Invalid argument type diagnostics - Tests for a variety of argument types - One keyword argument
+mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/invalid_argument_type.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+1 | def foo(x: int, y: int, z: int = 0) -> int:
+2 |     return x * y * z
+3 | 
+4 | foo(1, 2, "hello")  # error: [invalid-argument-type]
+```
+
+# Diagnostics
+
+```
+error: lint:invalid-argument-type
+ --> /src/mdtest_snippet.py:4:11
+  |
+2 |     return x * y * z
+3 |
+4 | foo(1, 2, "hello")  # error: [invalid-argument-type]
+  |           ^^^^^^^ Object of type `Literal["hello"]` cannot be assigned to parameter 3 (`z`) of function `foo`; expected type `int`
+  |
+ ::: /src/mdtest_snippet.py:1:25
+  |
+1 | def foo(x: int, y: int, z: int = 0) -> int:
+  |                         ---------- info: parameter declared in function definition here
+2 |     return x * y * z
+  |
+
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Only_positional.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Only_positional.snap
@@ -1,0 +1,39 @@
+---
+source: crates/red_knot_test/src/lib.rs
+expression: snapshot
+---
+---
+mdtest name: invalid_argument_type.md - Invalid argument type diagnostics - Tests for a variety of argument types - Only positional
+mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/invalid_argument_type.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+1 | def foo(x: int, y: int, z: int, /) -> int:
+2 |     return x * y * z
+3 | 
+4 | foo(1, "hello", 3)  # error: [invalid-argument-type]
+```
+
+# Diagnostics
+
+```
+error: lint:invalid-argument-type
+ --> /src/mdtest_snippet.py:4:8
+  |
+2 |     return x * y * z
+3 |
+4 | foo(1, "hello", 3)  # error: [invalid-argument-type]
+  |        ^^^^^^^ Object of type `Literal["hello"]` cannot be assigned to parameter 2 (`y`) of function `foo`; expected type `int`
+  |
+ ::: /src/mdtest_snippet.py:1:17
+  |
+1 | def foo(x: int, y: int, z: int, /) -> int:
+  |                 ------ info: parameter declared in function definition here
+2 |     return x * y * z
+  |
+
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Synthetic_arguments.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Synthetic_arguments.snap
@@ -1,0 +1,41 @@
+---
+source: crates/red_knot_test/src/lib.rs
+expression: snapshot
+---
+---
+mdtest name: invalid_argument_type.md - Invalid argument type diagnostics - Tests for a variety of argument types - Synthetic arguments
+mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/invalid_argument_type.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+1 | class C:
+2 |     def __call__(self, x: int) -> int:
+3 |         return 1
+4 | 
+5 | c = C()
+6 | c("wrong")  # error: [invalid-argument-type]
+```
+
+# Diagnostics
+
+```
+error: lint:invalid-argument-type
+ --> /src/mdtest_snippet.py:6:3
+  |
+5 | c = C()
+6 | c("wrong")  # error: [invalid-argument-type]
+  |   ^^^^^^^ Object of type `Literal["wrong"]` cannot be assigned to parameter 2 (`x`) of function `__call__`; expected type `int`
+  |
+ ::: /src/mdtest_snippet.py:2:24
+  |
+1 | class C:
+2 |     def __call__(self, x: int) -> int:
+  |                        ------ info: parameter declared in function definition here
+3 |         return 1
+  |
+
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Variadic_arguments.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Variadic_arguments.snap
@@ -1,0 +1,39 @@
+---
+source: crates/red_knot_test/src/lib.rs
+expression: snapshot
+---
+---
+mdtest name: invalid_argument_type.md - Invalid argument type diagnostics - Tests for a variety of argument types - Variadic arguments
+mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/invalid_argument_type.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+1 | def foo(*numbers: int) -> int:
+2 |     return len(numbers)
+3 | 
+4 | foo(1, 2, 3, "hello", 5)  # error: [invalid-argument-type]
+```
+
+# Diagnostics
+
+```
+error: lint:invalid-argument-type
+ --> /src/mdtest_snippet.py:4:14
+  |
+2 |     return len(numbers)
+3 |
+4 | foo(1, 2, 3, "hello", 5)  # error: [invalid-argument-type]
+  |              ^^^^^^^ Object of type `Literal["hello"]` cannot be assigned to parameter `*numbers` of function `foo`; expected type `int`
+  |
+ ::: /src/mdtest_snippet.py:1:9
+  |
+1 | def foo(*numbers: int) -> int:
+  |         ------------- info: parameter declared in function definition here
+2 |     return len(numbers)
+  |
+
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Variadic_keyword_arguments.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Variadic_keyword_arguments.snap
@@ -1,0 +1,39 @@
+---
+source: crates/red_knot_test/src/lib.rs
+expression: snapshot
+---
+---
+mdtest name: invalid_argument_type.md - Invalid argument type diagnostics - Tests for a variety of argument types - Variadic keyword arguments
+mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/invalid_argument_type.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+1 | def foo(**numbers: int) -> int:
+2 |     return len(numbers)
+3 | 
+4 | foo(a=1, b=2, c=3, d="hello", e=5)  # error: [invalid-argument-type]
+```
+
+# Diagnostics
+
+```
+error: lint:invalid-argument-type
+ --> /src/mdtest_snippet.py:4:20
+  |
+2 |     return len(numbers)
+3 |
+4 | foo(a=1, b=2, c=3, d="hello", e=5)  # error: [invalid-argument-type]
+  |                    ^^^^^^^^^ Object of type `Literal["hello"]` cannot be assigned to parameter `**numbers` of function `foo`; expected type `int`
+  |
+ ::: /src/mdtest_snippet.py:1:9
+  |
+1 | def foo(**numbers: int) -> int:
+  |         -------------- info: parameter declared in function definition here
+2 |     return len(numbers)
+  |
+
+```

--- a/crates/red_knot_python_semantic/src/suppression.rs
+++ b/crates/red_knot_python_semantic/src/suppression.rs
@@ -325,6 +325,7 @@ impl<'a> CheckSuppressionsContext<'a> {
             range,
             severity,
             file: self.file,
+            secondary_messages: vec![],
         });
     }
 }

--- a/crates/red_knot_python_semantic/src/types/diagnostic.rs
+++ b/crates/red_knot_python_semantic/src/types/diagnostic.rs
@@ -8,7 +8,7 @@ use crate::types::string_annotation::{
 };
 use crate::types::{ClassLiteralType, KnownInstanceType, Type};
 use crate::{declare_lint, Db};
-use ruff_db::diagnostic::{Diagnostic, DiagnosticId, Severity, Span};
+use ruff_db::diagnostic::{Diagnostic, DiagnosticId, SecondaryDiagnosticMessage, Severity, Span};
 use ruff_db::files::File;
 use ruff_python_ast::{self as ast, AnyNodeRef};
 use ruff_text_size::TextRange;
@@ -777,6 +777,7 @@ pub struct TypeCheckDiagnostic {
     pub(crate) range: TextRange,
     pub(crate) severity: Severity,
     pub(crate) file: File,
+    pub(crate) secondary_messages: Vec<SecondaryDiagnosticMessage>,
 }
 
 impl TypeCheckDiagnostic {
@@ -804,6 +805,10 @@ impl Diagnostic for TypeCheckDiagnostic {
 
     fn span(&self) -> Option<Span> {
         Some(Span::from(self.file).with_range(self.range))
+    }
+
+    fn secondary_messages(&self) -> &[SecondaryDiagnosticMessage] {
+        &self.secondary_messages
     }
 
     fn severity(&self) -> Severity {

--- a/crates/red_knot_python_semantic/src/types/diagnostic.rs
+++ b/crates/red_knot_python_semantic/src/types/diagnostic.rs
@@ -11,7 +11,7 @@ use crate::{declare_lint, Db};
 use ruff_db::diagnostic::{Diagnostic, DiagnosticId, Severity, Span};
 use ruff_db::files::File;
 use ruff_python_ast::{self as ast, AnyNodeRef};
-use ruff_text_size::{Ranged, TextRange};
+use ruff_text_size::TextRange;
 use rustc_hash::FxHashSet;
 use std::borrow::Cow;
 use std::fmt::Formatter;
@@ -808,12 +808,6 @@ impl Diagnostic for TypeCheckDiagnostic {
 
     fn severity(&self) -> Severity {
         self.severity
-    }
-}
-
-impl Ranged for TypeCheckDiagnostic {
-    fn range(&self) -> TextRange {
-        self.range
     }
 }
 

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -3272,6 +3272,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                                         "Revealed type is `{}`",
                                         revealed_type.display(self.db())
                                     ),
+                                    vec![],
                                 );
                             }
                         }


### PR DESCRIPTION
This PR takes a quick route toward prototyping multi-span diagnostics.
As one concrete improvement, the diagnostics for invalid argument types
are improved by adding a secondary span. Specifically, red-knot will
now show not just the call site (which remains as the primary span
in the diagnostic output), but also the function definition with the
corresponding parameter annotated.

The form and definition of secondary diagnostic spans in this PR
is _not_ meant to be where we end up. We will want something more
sophisticated pretty soon, and the version in this PR is very limited.
For example, it doesn't let you attach multiple annotations to the
same snippet of code. Every diagnostic message is one snippet with one
annotation. We obviously want things to be more flexible than that.
Still, this was a useful exericse to go through for myself, and also I
think comes with one concrete improvement.

One comparison point with `rustc` that I found interesting is how dense
`rustc` error messages can be. For example, given this Rust code:

```rust
fn main() {
    foo("a", "b", "c");
}

fn foo(x: i32, y: i32, z: i32) -> i32 {
    x * y * z
}
```

`rustc` will emit:

```
error[E0308]: arguments to this function are incorrect
 --> src/main.rs:2:5
  |
2 |     foo("a", "b", "c");
  |     ^^^ ---  ---  --- expected `i32`, found `&str`
  |         |    |
  |         |    expected `i32`, found `&str`
  |         expected `i32`, found `&str`
  |
note: function defined here
 --> src/main.rs:5:4
  |
5 | fn foo(x: i32, y: i32, z: i32) -> i32 {
  |    ^^^ ------  ------  ------
```

In contrast, in Red Knot presently, a similar program with similar
faults actually results in three different diagnostics being rendered:

```
error: lint:invalid-argument-type
 --> /home/andrew/astral/ruff/play/diags/play/test.py:4:11
  |
4 | other.foo("a", "b", "c")
  |           ^^^ Object of type `Literal["a"]` cannot be assigned to parameter 1 (`x`) of function `foo`; expected type `int`
  |
 ::: /home/andrew/astral/ruff/play/diags/play/other.py:1:9
  |
1 | def foo(x: int, y: int, z: int) -> int:
  |         ------ info: function defined here
2 |     return x * y * z
  |

error: lint:invalid-argument-type
 --> /home/andrew/astral/ruff/play/diags/play/test.py:4:16
  |
4 | other.foo("a", "b", "c")
  |                ^^^ Object of type `Literal["b"]` cannot be assigned to parameter 2 (`y`) of function `foo`; expected type `int`
  |
 ::: /home/andrew/astral/ruff/play/diags/play/other.py:1:17
  |
1 | def foo(x: int, y: int, z: int) -> int:
  |                 ------ info: function defined here
2 |     return x * y * z
  |

error: lint:invalid-argument-type
 --> /home/andrew/astral/ruff/play/diags/play/test.py:4:21
  |
4 | other.foo("a", "b", "c")
  |                     ^^^ Object of type `Literal["c"]` cannot be assigned to parameter 3 (`z`) of function `foo`; expected type `int`
  |
 ::: /home/andrew/astral/ruff/play/diags/play/other.py:1:25
  |
1 | def foo(x: int, y: int, z: int) -> int:
  |                         ------ info: function defined here
2 |     return x * y * z
  |
```

Assuming for the sake of argument that we all agree that `rustc`'s
diagnostic output is better in this case, this is the sort of thing
I'll be thinking about as I work on a proposal for a high level
diagnostic design. But it is definitely not something that is tackled
by this PR. (I considered it, but I think it requires a fair bit of
work, and I didn't want to spend a bunch of time on that during a
prototype.) While `rustc`'s output requires be able to attach multiple
annotations to the same snippet of code, it may also require deeper
changes to how diagnostics themselves are emitted. (For example,
should such things be merged by the diagnostic rendering, or should
the type checker somehow know to merge them?)
