### PR TITLE
[red-knot] Find conflicting declarations for attribute in class methods

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -3904,11 +3904,10 @@ impl<'db> Class<'db> {
                         let use_def = use_def_map(db, class_body_scope);
                         let declarations = use_def.public_declarations(symbol_id);
 
-                        match symbol_from_declarations(db, declarations) {
-                            Err((_, _conflicting_declarations)) => {
-                                // There are conflicting declarations for this attribute in the class body.
-                            }
-                            _ => {} // Ignore success cases
+                        if let Err((_, _conflicting_declarations)) =
+                            symbol_from_declarations(db, declarations)
+                        {
+                            // There are conflicting declarations for this attribute in the class body.
                         }
                     }
 

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -3899,6 +3899,19 @@ impl<'db> Class<'db> {
                     let annotation_ty = infer_expression_type(db, *annotation);
 
                     // TODO: check if there are conflicting declarations
+                    let table = symbol_table(db, class_body_scope);
+                    if let Some(symbol_id) = table.symbol_id_by_name(name) {
+                        let use_def = use_def_map(db, class_body_scope);
+                        let declarations = use_def.public_declarations(symbol_id);
+
+                        match symbol_from_declarations(db, declarations) {
+                            Err((_, _conflicting_declarations)) => {
+                                // There are conflicting declarations for this attribute in the class body.
+                            }
+                            _ => {} // Ignore success cases
+                        }
+                    }
+
                     return Symbol::bound(annotation_ty);
                 }
                 AttributeAssignment::Unannotated { value } => {


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary
Handling one more case for class attributes: checking for conflicting declarations for class attributes in methods.
part of astral-sh/ty#206
## Test Plan
No test for now
