### PR TITLE
[red-knot] Allow any `Ranged` argument for `report_lint` and `report_diagnostic`

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -2264,11 +2264,7 @@ impl<'db> InvalidTypeExpressionError<'db> {
             invalid_expressions,
         } = self;
         for error in invalid_expressions {
-            context.report_lint(
-                &INVALID_TYPE_FORM,
-                node.into(),
-                format_args!("{}", error.reason()),
-            );
+            context.report_lint(&INVALID_TYPE_FORM, node, format_args!("{}", error.reason()));
         }
         fallback_type
     }

--- a/crates/red_knot_python_semantic/src/types/context.rs
+++ b/crates/red_knot_python_semantic/src/types/context.rs
@@ -5,8 +5,7 @@ use ruff_db::{
     diagnostic::{DiagnosticId, SecondaryDiagnosticMessage, Severity},
     files::File,
 };
-use ruff_python_ast::AnyNodeRef;
-use ruff_text_size::Ranged;
+use ruff_text_size::{Ranged, TextRange};
 
 use super::{binding_type, KnownFunction, TypeCheckDiagnostic, TypeCheckDiagnostics};
 
@@ -67,46 +66,60 @@ impl<'db> InferContext<'db> {
         self.diagnostics.get_mut().extend(other.diagnostics());
     }
 
-    /// Reports a lint located at `node`.
-    pub(super) fn report_lint(
+    /// Reports a lint located at `ranged`.
+    pub(super) fn report_lint<T>(
         &self,
         lint: &'static LintMetadata,
-        node: AnyNodeRef,
+        ranged: T,
         message: fmt::Arguments,
-    ) {
-        self.report_lint_with_secondary_messages(lint, node, message, vec![]);
+    ) where
+        T: Ranged,
+    {
+        self.report_lint_with_secondary_messages(lint, ranged, message, vec![]);
     }
 
-    /// Reports a lint located at `node`.
-    pub(super) fn report_lint_with_secondary_messages(
+    /// Reports a lint located at `ranged`.
+    pub(super) fn report_lint_with_secondary_messages<T>(
         &self,
         lint: &'static LintMetadata,
-        node: AnyNodeRef,
+        ranged: T,
         message: fmt::Arguments,
         secondary_messages: Vec<SecondaryDiagnosticMessage>,
-    ) {
-        if !self.db.is_file_open(self.file) {
-            return;
+    ) where
+        T: Ranged,
+    {
+        fn lint_severity(
+            context: &InferContext,
+            lint: &'static LintMetadata,
+            range: TextRange,
+        ) -> Option<Severity> {
+            if !context.db.is_file_open(context.file) {
+                return None;
+            }
+
+            // Skip over diagnostics if the rule is disabled.
+            let severity = context.db.rule_selection().severity(LintId::of(lint))?;
+
+            if context.is_in_no_type_check() {
+                return None;
+            }
+
+            let suppressions = suppressions(context.db, context.file);
+
+            if let Some(suppression) = suppressions.find_suppression(range, LintId::of(lint)) {
+                context.diagnostics.borrow_mut().mark_used(suppression.id());
+                return None;
+            }
+
+            Some(severity)
         }
 
-        // Skip over diagnostics if the rule is disabled.
-        let Some(severity) = self.db.rule_selection().severity(LintId::of(lint)) else {
+        let Some(severity) = lint_severity(self, lint, ranged.range()) else {
             return;
         };
 
-        if self.is_in_no_type_check() {
-            return;
-        }
-
-        let suppressions = suppressions(self.db, self.file);
-
-        if let Some(suppression) = suppressions.find_suppression(node.range(), LintId::of(lint)) {
-            self.diagnostics.borrow_mut().mark_used(suppression.id());
-            return;
-        }
-
         self.report_diagnostic(
-            node,
+            ranged,
             DiagnosticId::Lint(lint.name()),
             severity,
             message,
@@ -117,14 +130,16 @@ impl<'db> InferContext<'db> {
     /// Adds a new diagnostic.
     ///
     /// The diagnostic does not get added if the rule isn't enabled for this file.
-    pub(super) fn report_diagnostic(
+    pub(super) fn report_diagnostic<T>(
         &self,
-        node: AnyNodeRef,
+        ranged: T,
         id: DiagnosticId,
         severity: Severity,
         message: fmt::Arguments,
         secondary_messages: Vec<SecondaryDiagnosticMessage>,
-    ) {
+    ) where
+        T: Ranged,
+    {
         if !self.db.is_file_open(self.file) {
             return;
         }
@@ -139,7 +154,7 @@ impl<'db> InferContext<'db> {
             file: self.file,
             id,
             message: message.to_string(),
-            range: node.range(),
+            range: ranged.range(),
             severity,
             secondary_messages,
         });

--- a/crates/red_knot_python_semantic/src/types/diagnostic.rs
+++ b/crates/red_knot_python_semantic/src/types/diagnostic.rs
@@ -1047,7 +1047,7 @@ pub(super) fn report_possibly_unresolved_reference(
 
     context.report_lint(
         &POSSIBLY_UNRESOLVED_REFERENCE,
-        expr_name_node.into(),
+        expr_name_node,
         format_args!("Name `{id}` used when possibly not defined"),
     );
 }
@@ -1057,7 +1057,7 @@ pub(super) fn report_unresolved_reference(context: &InferContext, expr_name_node
 
     context.report_lint(
         &UNRESOLVED_REFERENCE,
-        expr_name_node.into(),
+        expr_name_node,
         format_args!("Name `{id}` used when not defined"),
     );
 }
@@ -1065,7 +1065,7 @@ pub(super) fn report_unresolved_reference(context: &InferContext, expr_name_node
 pub(super) fn report_invalid_exception_caught(context: &InferContext, node: &ast::Expr, ty: Type) {
     context.report_lint(
         &INVALID_EXCEPTION_CAUGHT,
-        node.into(),
+        node,
         format_args!(
             "Cannot catch object of type `{}` in an exception handler \
             (must be a `BaseException` subclass or a tuple of `BaseException` subclasses)",
@@ -1077,7 +1077,7 @@ pub(super) fn report_invalid_exception_caught(context: &InferContext, node: &ast
 pub(crate) fn report_invalid_exception_raised(context: &InferContext, node: &ast::Expr, ty: Type) {
     context.report_lint(
         &INVALID_RAISE,
-        node.into(),
+        node,
         format_args!(
             "Cannot raise object of type `{}` (must be a `BaseException` subclass or instance)",
             ty.display(context.db())
@@ -1088,7 +1088,7 @@ pub(crate) fn report_invalid_exception_raised(context: &InferContext, node: &ast
 pub(crate) fn report_invalid_exception_cause(context: &InferContext, node: &ast::Expr, ty: Type) {
     context.report_lint(
         &INVALID_RAISE,
-        node.into(),
+        node,
         format_args!(
             "Cannot use object of type `{}` as exception cause \
             (must be a `BaseException` subclass or instance or `None`)",
@@ -1100,7 +1100,7 @@ pub(crate) fn report_invalid_exception_cause(context: &InferContext, node: &ast:
 pub(crate) fn report_base_with_incompatible_slots(context: &InferContext, node: &ast::Expr) {
     context.report_lint(
         &INCOMPATIBLE_SLOTS,
-        node.into(),
+        node,
         format_args!("Class base has incompatible `__slots__`"),
     );
 }
@@ -1112,7 +1112,7 @@ pub(crate) fn report_invalid_arguments_to_annotated<'db>(
 ) {
     context.report_lint(
         &INVALID_TYPE_FORM,
-        subscript.into(),
+        subscript,
         format_args!(
             "Special form `{}` expected at least 2 arguments (one type and at least one metadata element)",
             KnownInstanceType::Annotated.repr(db)

--- a/crates/red_knot_python_semantic/src/types/string_annotation.rs
+++ b/crates/red_knot_python_semantic/src/types/string_annotation.rs
@@ -143,7 +143,7 @@ pub(crate) fn parse_string_annotation(
         if prefix.is_raw() {
             context.report_lint(
                 &RAW_STRING_TYPE_ANNOTATION,
-                string_literal.into(),
+                string_literal,
                 format_args!("Type expressions cannot use raw string literal"),
             );
         // Compare the raw contents (without quotes) of the expression with the parsed contents
@@ -153,7 +153,7 @@ pub(crate) fn parse_string_annotation(
                 Ok(parsed) => return Some(parsed),
                 Err(parse_error) => context.report_lint(
                     &INVALID_SYNTAX_IN_FORWARD_ANNOTATION,
-                    string_literal.into(),
+                    string_literal,
                     format_args!("Syntax error in forward annotation: {}", parse_error.error),
                 ),
             }
@@ -162,7 +162,7 @@ pub(crate) fn parse_string_annotation(
             // case for annotations that contain escape sequences.
             context.report_lint(
                 &ESCAPE_CHARACTER_IN_FORWARD_ANNOTATION,
-                string_expr.into(),
+                string_expr,
                 format_args!("Type expressions cannot contain escape characters"),
             );
         }
@@ -170,7 +170,7 @@ pub(crate) fn parse_string_annotation(
         // String is implicitly concatenated.
         context.report_lint(
             &IMPLICIT_CONCATENATED_STRING_TYPE_ANNOTATION,
-            string_expr.into(),
+            string_expr,
             format_args!("Type expressions cannot span multiple string literals"),
         );
     }

--- a/crates/red_knot_python_semantic/src/types/unpacker.rs
+++ b/crates/red_knot_python_semantic/src/types/unpacker.rs
@@ -124,7 +124,7 @@ impl<'db> Unpacker<'db> {
                             Ordering::Less => {
                                 self.context.report_lint(
                                     &INVALID_ASSIGNMENT,
-                                    target.into(),
+                                    target,
                                     format_args!(
                                         "Too many values to unpack (expected {}, got {})",
                                         elts.len(),
@@ -135,7 +135,7 @@ impl<'db> Unpacker<'db> {
                             Ordering::Greater => {
                                 self.context.report_lint(
                                     &INVALID_ASSIGNMENT,
-                                    target.into(),
+                                    target,
                                     format_args!(
                                         "Not enough values to unpack (expected {}, got {})",
                                         elts.len(),
@@ -232,7 +232,7 @@ impl<'db> Unpacker<'db> {
         } else {
             self.context.report_lint(
                 &INVALID_ASSIGNMENT,
-                expr.into(),
+                expr,
                 format_args!(
                     "Not enough values to unpack (expected {} or more, got {})",
                     targets.len() - 1,


### PR DESCRIPTION
## Summary

Restricting `report_lint` and `report_diagnostic` to only take ast nodes as arguments is too restrictive. 
E.g., we may want to highlight a comparision like `10 not in b` but there's no single node that represents just the `not in ...` comparision. 


This PR relaxes the argument representing the range to accept any `Ranged` type.

## Test Plan

`cargo test`
