### PR TITLE
Add `text_len()` methods to more `*Prefix` enums in `ruff_python_ast`

### DIFF
--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -1029,7 +1029,7 @@ pub trait StringFlags: Copy {
     /// i.e., the length of the prefixes plus the length
     /// of the quotes used to open the string.
     fn opener_len(self) -> TextSize {
-        self.prefix().as_str().text_len() + self.quote_len()
+        self.prefix().text_len() + self.quote_len()
     }
 
     /// The total length of the string's closer.

--- a/crates/ruff_python_ast/src/str_prefix.rs
+++ b/crates/ruff_python_ast/src/str_prefix.rs
@@ -71,6 +71,13 @@ impl FStringPrefix {
         }
     }
 
+    pub const fn text_len(self) -> TextSize {
+        match self {
+            Self::Regular => TextSize::new(1),
+            Self::Raw { .. } => TextSize::new(2),
+        }
+    }
+
     /// Return true if this prefix indicates a "raw f-string",
     /// e.g. `rf"{bar}"` or `Rf"{bar}"`
     pub const fn is_raw(self) -> bool {
@@ -102,6 +109,13 @@ impl ByteStringPrefix {
             Self::Regular => "b",
             Self::Raw { uppercase_r: true } => "Rb",
             Self::Raw { uppercase_r: false } => "rb",
+        }
+    }
+
+    pub const fn text_len(self) -> TextSize {
+        match self {
+            Self::Regular => TextSize::new(1),
+            Self::Raw { .. } => TextSize::new(2),
         }
     }
 
@@ -147,6 +161,14 @@ impl AnyStringPrefix {
             Self::Regular(regular_prefix) => regular_prefix.as_str(),
             Self::Bytes(bytestring_prefix) => bytestring_prefix.as_str(),
             Self::Format(fstring_prefix) => fstring_prefix.as_str(),
+        }
+    }
+
+    pub const fn text_len(self) -> TextSize {
+        match self {
+            Self::Regular(regular_prefix) => regular_prefix.text_len(),
+            Self::Bytes(bytestring_prefix) => bytestring_prefix.text_len(),
+            Self::Format(fstring_prefix) => fstring_prefix.text_len(),
         }
     }
 


### PR DESCRIPTION
## Summary

https://github.com/astral-sh/ruff/pull/16183 added a `StringLiteralPrefix::text_len()` method. This PR adds similar methods to the other `*Prefix` methods, for a consistent API. This also allows us to remove a little bit of indirection from the `StringFlags::opener_len()` method.

## Test Plan

`cargo test`
