### PR TITLE
Add `per-file-target-version` option

### DIFF
--- a/crates/ruff/src/commands/format.rs
+++ b/crates/ruff/src/commands/format.rs
@@ -342,7 +342,7 @@ pub(crate) fn format_source(
     let target_version = if let Some(path) = path {
         settings.resolve_target_version(path)
     } else {
-        settings.target_version
+        settings.unresolved_target_version
     };
 
     match &source_kind {

--- a/crates/ruff/src/commands/format.rs
+++ b/crates/ruff/src/commands/format.rs
@@ -339,9 +339,17 @@ pub(crate) fn format_source(
     settings: &FormatterSettings,
     range: Option<FormatRange>,
 ) -> Result<FormattedSource, FormatCommandError> {
+    let target_version = if let Some(path) = path {
+        settings.resolve_target_version(path)
+    } else {
+        settings.target_version
+    };
+
     match &source_kind {
         SourceKind::Python(unformatted) => {
-            let options = settings.to_format_options(source_type, unformatted);
+            let options = settings
+                .to_format_options(source_type, unformatted)
+                .with_target_version(target_version);
 
             let formatted = if let Some(range) = range {
                 let line_index = LineIndex::from_source_text(unformatted);
@@ -391,7 +399,9 @@ pub(crate) fn format_source(
                 ));
             }
 
-            let options = settings.to_format_options(source_type, notebook.source_code());
+            let options = settings
+                .to_format_options(source_type, notebook.source_code())
+                .with_target_version(target_version);
 
             let mut output: Option<String> = None;
             let mut last: Option<TextSize> = None;

--- a/crates/ruff/src/commands/format.rs
+++ b/crates/ruff/src/commands/format.rs
@@ -339,17 +339,9 @@ pub(crate) fn format_source(
     settings: &FormatterSettings,
     range: Option<FormatRange>,
 ) -> Result<FormattedSource, FormatCommandError> {
-    let target_version = if let Some(path) = path {
-        settings.resolve_target_version(path)
-    } else {
-        settings.unresolved_target_version
-    };
-
     match &source_kind {
         SourceKind::Python(unformatted) => {
-            let options = settings
-                .to_format_options(source_type, unformatted)
-                .with_target_version(target_version);
+            let options = settings.to_format_options(source_type, unformatted, path);
 
             let formatted = if let Some(range) = range {
                 let line_index = LineIndex::from_source_text(unformatted);
@@ -399,9 +391,7 @@ pub(crate) fn format_source(
                 ));
             }
 
-            let options = settings
-                .to_format_options(source_type, notebook.source_code())
-                .with_target_version(target_version);
+            let options = settings.to_format_options(source_type, notebook.source_code(), path);
 
             let mut output: Option<String> = None;
             let mut last: Option<TextSize> = None;

--- a/crates/ruff/tests/format.rs
+++ b/crates/ruff/tests/format.rs
@@ -2086,3 +2086,31 @@ fn range_formatting_notebook() {
     error: Failed to format main.ipynb: Range formatting isn't supported for notebooks.
     ");
 }
+
+/// Test that the formatter respects `per-file-target-version`. Context managers can't be
+/// parenthesized like this before Python 3.10.
+///
+/// Adapted from <https://github.com/python/cpython/issues/56991#issuecomment-1093555135>
+#[test]
+fn per_file_target_version_formatter() {
+    assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+        .args(["format", "--isolated", "--stdin-filename", "test.py", "--target-version=py38"])
+        .args(["--config", r#"per-file-target-version = {"test.py" = "py311"}"#])
+        .arg("-")
+        .pass_stdin(r#"
+with open("a_really_long_foo") as foo, open("a_really_long_bar") as bar, open("a_really_long_baz") as baz:
+    pass
+"#), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    with (
+        open("a_really_long_foo") as foo,
+        open("a_really_long_bar") as bar,
+        open("a_really_long_baz") as baz,
+    ):
+        pass
+
+    ----- stderr -----
+    "#);
+}

--- a/crates/ruff/tests/format.rs
+++ b/crates/ruff/tests/format.rs
@@ -2093,6 +2093,25 @@ fn range_formatting_notebook() {
 /// Adapted from <https://github.com/python/cpython/issues/56991#issuecomment-1093555135>
 #[test]
 fn per_file_target_version_formatter() {
+    // without `per-file-target-version` this should not be reformatted in the same way
+    assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+        .args(["format", "--isolated", "--stdin-filename", "test.py", "--target-version=py38"])
+        .arg("-")
+        .pass_stdin(r#"
+with open("a_really_long_foo") as foo, open("a_really_long_bar") as bar, open("a_really_long_baz") as baz:
+    pass
+"#), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    with open("a_really_long_foo") as foo, open("a_really_long_bar") as bar, open(
+        "a_really_long_baz"
+    ) as baz:
+        pass
+
+    ----- stderr -----
+    "#);
+
     assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
         .args(["format", "--isolated", "--stdin-filename", "test.py", "--target-version=py38"])
         .args(["--config", r#"per-file-target-version = {"test.py" = "py311"}"#])

--- a/crates/ruff/tests/lint.rs
+++ b/crates/ruff/tests/lint.rs
@@ -2568,14 +2568,25 @@ fn a005_module_shadowing_strict_default() -> Result<()> {
     Ok(())
 }
 
+/// Test that the linter respects per-file-target-version.
 #[test]
-fn per_file_target_version_exists() {
+fn per_file_target_version_linter() {
     assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
         .args(STDIN_BASE_OPTIONS)
+        .args(["--target-version", "py312"])
         .args(["--config", r#"per-file-target-version = {"test.py" = "py311"}"#])
-        .args(["--select", "A005"]) // something that won't trigger
+        .args(["--select", "UP046"]) // only triggers on 3.12+
+        .args(["--stdin-filename", "test.py"])
+        .arg("--preview")
         .arg("-")
-        .pass_stdin("1"),
+        .pass_stdin(r#"
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+class A(Generic[T]):
+    var: T
+"#),
         @r"
     success: true
     exit_code: 0

--- a/crates/ruff/tests/lint.rs
+++ b/crates/ruff/tests/lint.rs
@@ -2567,3 +2567,22 @@ fn a005_module_shadowing_strict_default() -> Result<()> {
     });
     Ok(())
 }
+
+#[test]
+fn per_file_target_version_exists() {
+    assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+        .args(STDIN_BASE_OPTIONS)
+        .args(["--config", r#"per-file-target-version = {"test.py" = "py311"}"#])
+        .args(["--select", "A005"]) // something that won't trigger
+        .arg("-")
+        .pass_stdin("1"),
+        @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    All checks passed!
+
+    ----- stderr -----
+    "
+    );
+}

--- a/crates/ruff/tests/snapshots/show_settings__display_default_settings.snap
+++ b/crates/ruff/tests/snapshots/show_settings__display_default_settings.snap
@@ -189,7 +189,7 @@ linter.rules.should_fix = [
 linter.per_file_ignores = {}
 linter.safety_table.forced_safe = []
 linter.safety_table.forced_unsafe = []
-linter.target_version = 3.7
+linter.unresolved_target_version = 3.7
 linter.per_file_target_version = {}
 linter.preview = disabled
 linter.explicit_preview_rules = false
@@ -374,7 +374,7 @@ linter.ruff.allowed_markup_calls = []
 
 # Formatter Settings
 formatter.exclude = []
-formatter.target_version = 3.7
+formatter.unresolved_target_version = 3.7
 formatter.per_file_target_version = {}
 formatter.preview = disabled
 formatter.line_width = 100

--- a/crates/ruff/tests/snapshots/show_settings__display_default_settings.snap
+++ b/crates/ruff/tests/snapshots/show_settings__display_default_settings.snap
@@ -190,6 +190,7 @@ linter.per_file_ignores = {}
 linter.safety_table.forced_safe = []
 linter.safety_table.forced_unsafe = []
 linter.target_version = 3.7
+linter.per_file_target_version = {}
 linter.preview = disabled
 linter.explicit_preview_rules = false
 linter.extension = ExtensionMapping({})
@@ -374,6 +375,7 @@ linter.ruff.allowed_markup_calls = []
 # Formatter Settings
 formatter.exclude = []
 formatter.target_version = 3.7
+formatter.per_file_target_version = {}
 formatter.preview = disabled
 formatter.line_width = 100
 formatter.line_ending = auto

--- a/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
@@ -34,8 +34,8 @@ pub(crate) fn expression(expr: &Expr, checker: &Checker) {
                 {
                     if checker.enabled(Rule::FutureRewritableTypeAnnotation) {
                         if !checker.semantic.future_annotations_or_stub()
-                            && checker.settings.target_version < PythonVersion::PY310
-                            && checker.settings.target_version >= PythonVersion::PY37
+                            && checker.target_version() < PythonVersion::PY310
+                            && checker.target_version() >= PythonVersion::PY37
                             && checker.semantic.in_annotation()
                             && !checker.settings.pyupgrade.keep_runtime_typing
                         {
@@ -49,8 +49,8 @@ pub(crate) fn expression(expr: &Expr, checker: &Checker) {
                         Rule::NonPEP604AnnotationOptional,
                     ]) {
                         if checker.source_type.is_stub()
-                            || checker.settings.target_version >= PythonVersion::PY310
-                            || (checker.settings.target_version >= PythonVersion::PY37
+                            || checker.target_version() >= PythonVersion::PY310
+                            || (checker.target_version() >= PythonVersion::PY37
                                 && checker.semantic.future_annotations_or_stub()
                                 && checker.semantic.in_annotation()
                                 && !checker.settings.pyupgrade.keep_runtime_typing)
@@ -64,7 +64,7 @@ pub(crate) fn expression(expr: &Expr, checker: &Checker) {
             // Ex) list[...]
             if checker.enabled(Rule::FutureRequiredTypeAnnotation) {
                 if !checker.semantic.future_annotations_or_stub()
-                    && checker.settings.target_version < PythonVersion::PY39
+                    && checker.target_version() < PythonVersion::PY39
                     && checker.semantic.in_annotation()
                     && checker.semantic.in_runtime_evaluated_annotation()
                     && !checker.semantic.in_string_type_definition()
@@ -135,7 +135,7 @@ pub(crate) fn expression(expr: &Expr, checker: &Checker) {
             }
 
             if checker.enabled(Rule::UnnecessaryDefaultTypeArgs) {
-                if checker.settings.target_version >= PythonVersion::PY313 {
+                if checker.target_version() >= PythonVersion::PY313 {
                     pyupgrade::rules::unnecessary_default_type_args(checker, expr);
                 }
             }
@@ -268,8 +268,8 @@ pub(crate) fn expression(expr: &Expr, checker: &Checker) {
                         {
                             if checker.enabled(Rule::FutureRewritableTypeAnnotation) {
                                 if !checker.semantic.future_annotations_or_stub()
-                                    && checker.settings.target_version < PythonVersion::PY39
-                                    && checker.settings.target_version >= PythonVersion::PY37
+                                    && checker.target_version() < PythonVersion::PY39
+                                    && checker.target_version() >= PythonVersion::PY37
                                     && checker.semantic.in_annotation()
                                     && !checker.settings.pyupgrade.keep_runtime_typing
                                 {
@@ -278,8 +278,8 @@ pub(crate) fn expression(expr: &Expr, checker: &Checker) {
                             }
                             if checker.enabled(Rule::NonPEP585Annotation) {
                                 if checker.source_type.is_stub()
-                                    || checker.settings.target_version >= PythonVersion::PY39
-                                    || (checker.settings.target_version >= PythonVersion::PY37
+                                    || checker.target_version() >= PythonVersion::PY39
+                                    || (checker.target_version() >= PythonVersion::PY37
                                         && checker.semantic.future_annotations_or_stub()
                                         && checker.semantic.in_annotation()
                                         && !checker.settings.pyupgrade.keep_runtime_typing)
@@ -378,8 +378,8 @@ pub(crate) fn expression(expr: &Expr, checker: &Checker) {
                 if let Some(replacement) = typing::to_pep585_generic(expr, &checker.semantic) {
                     if checker.enabled(Rule::FutureRewritableTypeAnnotation) {
                         if !checker.semantic.future_annotations_or_stub()
-                            && checker.settings.target_version < PythonVersion::PY39
-                            && checker.settings.target_version >= PythonVersion::PY37
+                            && checker.target_version() < PythonVersion::PY39
+                            && checker.target_version() >= PythonVersion::PY37
                             && checker.semantic.in_annotation()
                             && !checker.settings.pyupgrade.keep_runtime_typing
                         {
@@ -390,8 +390,8 @@ pub(crate) fn expression(expr: &Expr, checker: &Checker) {
                     }
                     if checker.enabled(Rule::NonPEP585Annotation) {
                         if checker.source_type.is_stub()
-                            || checker.settings.target_version >= PythonVersion::PY39
-                            || (checker.settings.target_version >= PythonVersion::PY37
+                            || checker.target_version() >= PythonVersion::PY39
+                            || (checker.target_version() >= PythonVersion::PY37
                                 && checker.semantic.future_annotations_or_stub()
                                 && checker.semantic.in_annotation()
                                 && !checker.settings.pyupgrade.keep_runtime_typing)
@@ -405,7 +405,7 @@ pub(crate) fn expression(expr: &Expr, checker: &Checker) {
                 refurb::rules::regex_flag_alias(checker, expr);
             }
             if checker.enabled(Rule::DatetimeTimezoneUTC) {
-                if checker.settings.target_version >= PythonVersion::PY311 {
+                if checker.target_version() >= PythonVersion::PY311 {
                     pyupgrade::rules::datetime_utc_alias(checker, expr);
                 }
             }
@@ -610,12 +610,12 @@ pub(crate) fn expression(expr: &Expr, checker: &Checker) {
                 pyupgrade::rules::os_error_alias_call(checker, func);
             }
             if checker.enabled(Rule::TimeoutErrorAlias) {
-                if checker.settings.target_version >= PythonVersion::PY310 {
+                if checker.target_version() >= PythonVersion::PY310 {
                     pyupgrade::rules::timeout_error_alias_call(checker, func);
                 }
             }
             if checker.enabled(Rule::NonPEP604Isinstance) {
-                if checker.settings.target_version >= PythonVersion::PY310 {
+                if checker.target_version() >= PythonVersion::PY310 {
                     pyupgrade::rules::use_pep604_isinstance(checker, expr, func, args);
                 }
             }
@@ -690,7 +690,7 @@ pub(crate) fn expression(expr: &Expr, checker: &Checker) {
                 );
             }
             if checker.enabled(Rule::ZipWithoutExplicitStrict) {
-                if checker.settings.target_version >= PythonVersion::PY310 {
+                if checker.target_version() >= PythonVersion::PY310 {
                     flake8_bugbear::rules::zip_without_explicit_strict(checker, call);
                 }
             }
@@ -963,7 +963,7 @@ pub(crate) fn expression(expr: &Expr, checker: &Checker) {
                 flake8_pytest_style::rules::fail_call(checker, call);
             }
             if checker.enabled(Rule::ZipInsteadOfPairwise) {
-                if checker.settings.target_version >= PythonVersion::PY310 {
+                if checker.target_version() >= PythonVersion::PY310 {
                     ruff::rules::zip_instead_of_pairwise(checker, call);
                 }
             }
@@ -1385,7 +1385,7 @@ pub(crate) fn expression(expr: &Expr, checker: &Checker) {
             // Ex) `str | None`
             if checker.enabled(Rule::FutureRequiredTypeAnnotation) {
                 if !checker.semantic.future_annotations_or_stub()
-                    && checker.settings.target_version < PythonVersion::PY310
+                    && checker.target_version() < PythonVersion::PY310
                     && checker.semantic.in_annotation()
                     && checker.semantic.in_runtime_evaluated_annotation()
                     && !checker.semantic.in_string_type_definition()

--- a/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
@@ -164,9 +164,7 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                     flake8_pyi::rules::str_or_repr_defined_in_stub(checker, stmt);
                 }
             }
-            if checker.source_type.is_stub()
-                || checker.settings.target_version >= PythonVersion::PY311
-            {
+            if checker.source_type.is_stub() || checker.target_version() >= PythonVersion::PY311 {
                 if checker.enabled(Rule::NoReturnArgumentAnnotationInStub) {
                     flake8_pyi::rules::no_return_argument_annotation(checker, parameters);
                 }
@@ -194,12 +192,12 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                 pylint::rules::global_statement(checker, name);
             }
             if checker.enabled(Rule::LRUCacheWithoutParameters) {
-                if checker.settings.target_version >= PythonVersion::PY38 {
+                if checker.target_version() >= PythonVersion::PY38 {
                     pyupgrade::rules::lru_cache_without_parameters(checker, decorator_list);
                 }
             }
             if checker.enabled(Rule::LRUCacheWithMaxsizeNone) {
-                if checker.settings.target_version >= PythonVersion::PY39 {
+                if checker.target_version() >= PythonVersion::PY39 {
                     pyupgrade::rules::lru_cache_with_maxsize_none(checker, decorator_list);
                 }
             }
@@ -445,7 +443,7 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                 pyupgrade::rules::useless_object_inheritance(checker, class_def);
             }
             if checker.enabled(Rule::ReplaceStrEnum) {
-                if checker.settings.target_version >= PythonVersion::PY311 {
+                if checker.target_version() >= PythonVersion::PY311 {
                     pyupgrade::rules::replace_str_enum(checker, class_def);
                 }
             }
@@ -765,7 +763,7 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                 }
             }
             if checker.enabled(Rule::UnnecessaryFutureImport) {
-                if checker.settings.target_version >= PythonVersion::PY37 {
+                if checker.target_version() >= PythonVersion::PY37 {
                     if let Some("__future__") = module {
                         pyupgrade::rules::unnecessary_future_import(checker, stmt, names);
                     }
@@ -1039,7 +1037,7 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                 }
             }
             if checker.enabled(Rule::TimeoutErrorAlias) {
-                if checker.settings.target_version >= PythonVersion::PY310 {
+                if checker.target_version() >= PythonVersion::PY310 {
                     if let Some(item) = exc {
                         pyupgrade::rules::timeout_error_alias_raise(checker, item);
                     }
@@ -1431,7 +1429,7 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                 flake8_bugbear::rules::jump_statement_in_finally(checker, finalbody);
             }
             if checker.enabled(Rule::ContinueInFinally) {
-                if checker.settings.target_version <= PythonVersion::PY38 {
+                if checker.target_version() <= PythonVersion::PY38 {
                     pylint::rules::continue_in_finally(checker, finalbody);
                 }
             }
@@ -1455,7 +1453,7 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                 pyupgrade::rules::os_error_alias_handlers(checker, handlers);
             }
             if checker.enabled(Rule::TimeoutErrorAlias) {
-                if checker.settings.target_version >= PythonVersion::PY310 {
+                if checker.target_version() >= PythonVersion::PY310 {
                     pyupgrade::rules::timeout_error_alias_handlers(checker, handlers);
                 }
             }

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -223,6 +223,8 @@ pub(crate) struct Checker<'a> {
     last_stmt_end: TextSize,
     /// A state describing if a docstring is expected or not.
     docstring_state: DocstringState,
+    /// The target [`PythonVersion`] for version-dependent checks
+    target_version: PythonVersion,
 }
 
 impl<'a> Checker<'a> {
@@ -273,6 +275,7 @@ impl<'a> Checker<'a> {
             notebook_index,
             last_stmt_end: TextSize::default(),
             docstring_state: DocstringState::default(),
+            target_version,
         }
     }
 }
@@ -502,8 +505,9 @@ impl<'a> Checker<'a> {
         }
     }
 
-    pub(crate) fn target_version(&self) -> PythonVersion {
-        self.settings.resolve_target_version(self.path)
+    /// Return the [`PythonVersion`] to use for version-related checks.
+    pub(crate) const fn target_version(&self) -> PythonVersion {
+        self.target_version
     }
 }
 

--- a/crates/ruff_linter/src/checkers/filesystem.rs
+++ b/crates/ruff_linter/src/checkers/filesystem.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use ruff_diagnostics::Diagnostic;
+use ruff_python_ast::PythonVersion;
 use ruff_python_trivia::CommentRanges;
 
 use crate::package::PackageRoot;
@@ -17,6 +18,7 @@ pub(crate) fn check_file_path(
     locator: &Locator,
     comment_ranges: &CommentRanges,
     settings: &LinterSettings,
+    target_version: PythonVersion,
 ) -> Vec<Diagnostic> {
     let mut diagnostics: Vec<Diagnostic> = vec![];
 
@@ -46,7 +48,7 @@ pub(crate) fn check_file_path(
 
     // flake8-builtins
     if settings.rules.enabled(Rule::StdlibModuleShadowing) {
-        if let Some(diagnostic) = stdlib_module_shadowing(path, settings) {
+        if let Some(diagnostic) = stdlib_module_shadowing(path, settings, target_version) {
             diagnostics.push(diagnostic);
         }
     }

--- a/crates/ruff_linter/src/checkers/imports.rs
+++ b/crates/ruff_linter/src/checkers/imports.rs
@@ -3,7 +3,7 @@
 use ruff_diagnostics::Diagnostic;
 use ruff_notebook::CellOffsets;
 use ruff_python_ast::statement_visitor::StatementVisitor;
-use ruff_python_ast::{ModModule, PySourceType};
+use ruff_python_ast::{ModModule, PySourceType, PythonVersion};
 use ruff_python_codegen::Stylist;
 use ruff_python_index::Indexer;
 use ruff_python_parser::Parsed;
@@ -27,6 +27,7 @@ pub(crate) fn check_imports(
     package: Option<PackageRoot<'_>>,
     source_type: PySourceType,
     cell_offsets: Option<&CellOffsets>,
+    target_version: PythonVersion,
 ) -> Vec<Diagnostic> {
     // Extract all import blocks from the AST.
     let tracker = {
@@ -52,6 +53,7 @@ pub(crate) fn check_imports(
                     package,
                     source_type,
                     parsed.tokens(),
+                    target_version,
                 ) {
                     diagnostics.push(diagnostic);
                 }

--- a/crates/ruff_linter/src/fs.rs
+++ b/crates/ruff_linter/src/fs.rs
@@ -18,9 +18,9 @@ pub(crate) fn ignores_from_path(path: &Path, ignore_list: &CompiledPerFileIgnore
                         "Adding per-file ignores for {:?} due to basename match on {:?}: {:?}",
                         path,
                         entry.basename_matcher.glob().regex(),
-                        entry.rules
+                        entry.data
                     );
-                    Some(&entry.rules)
+                    Some(&entry.data)
                 }
             } else if entry.absolute_matcher.is_match(path) {
                 if entry.negated { None } else {
@@ -28,9 +28,9 @@ pub(crate) fn ignores_from_path(path: &Path, ignore_list: &CompiledPerFileIgnore
                         "Adding per-file ignores for {:?} due to absolute match on {:?}: {:?}",
                         path,
                         entry.absolute_matcher.glob().regex(),
-                        entry.rules
+                        entry.data
                     );
-                    Some(&entry.rules)
+                    Some(&entry.data)
                 }
             } else if entry.negated {
                 debug!(
@@ -38,9 +38,9 @@ pub(crate) fn ignores_from_path(path: &Path, ignore_list: &CompiledPerFileIgnore
                     path,
                     entry.basename_matcher.glob().regex(),
                     entry.absolute_matcher.glob().regex(),
-                    entry.rules
+                    entry.data
                 );
-                Some(&entry.rules)
+                Some(&entry.data)
             } else {
                 None
             }

--- a/crates/ruff_linter/src/fs.rs
+++ b/crates/ruff_linter/src/fs.rs
@@ -7,7 +7,10 @@ use crate::settings::types::CompiledPerFileIgnoreList;
 
 /// Create a set with codes matching the pattern/code pairs.
 pub(crate) fn ignores_from_path(path: &Path, ignore_list: &CompiledPerFileIgnoreList) -> RuleSet {
-    ignore_list.iter_matches(path).flatten().collect()
+    ignore_list
+        .iter_matches(path, "Adding per-file ignores")
+        .flatten()
+        .collect()
 }
 
 /// Convert any path to an absolute path (based on the current working

--- a/crates/ruff_linter/src/fs.rs
+++ b/crates/ruff_linter/src/fs.rs
@@ -1,6 +1,5 @@
 use std::path::{Path, PathBuf};
 
-use log::debug;
 use path_absolutize::Absolutize;
 
 use crate::registry::RuleSet;
@@ -8,45 +7,7 @@ use crate::settings::types::CompiledPerFileIgnoreList;
 
 /// Create a set with codes matching the pattern/code pairs.
 pub(crate) fn ignores_from_path(path: &Path, ignore_list: &CompiledPerFileIgnoreList) -> RuleSet {
-    let file_name = path.file_name().expect("Unable to parse filename");
-    ignore_list
-        .iter()
-        .filter_map(|entry| {
-            if entry.basename_matcher.is_match(file_name) {
-                if entry.negated { None } else {
-                    debug!(
-                        "Adding per-file ignores for {:?} due to basename match on {:?}: {:?}",
-                        path,
-                        entry.basename_matcher.glob().regex(),
-                        entry.data
-                    );
-                    Some(&entry.data)
-                }
-            } else if entry.absolute_matcher.is_match(path) {
-                if entry.negated { None } else {
-                    debug!(
-                        "Adding per-file ignores for {:?} due to absolute match on {:?}: {:?}",
-                        path,
-                        entry.absolute_matcher.glob().regex(),
-                        entry.data
-                    );
-                    Some(&entry.data)
-                }
-            } else if entry.negated {
-                debug!(
-                    "Adding per-file ignores for {:?} due to negated pattern matching neither {:?} nor {:?}: {:?}",
-                    path,
-                    entry.basename_matcher.glob().regex(),
-                    entry.absolute_matcher.glob().regex(),
-                    entry.data
-                );
-                Some(&entry.data)
-            } else {
-                None
-            }
-        })
-        .flatten()
-        .collect()
+    ignore_list.iter_matches(path).flatten().collect()
 }
 
 /// Convert any path to an absolute path (based on the current working

--- a/crates/ruff_linter/src/linter.rs
+++ b/crates/ruff_linter/src/linter.rs
@@ -104,6 +104,8 @@ pub fn check_path(
         ));
     }
 
+    let target_version = settings.resolve_target_version(path);
+
     // Run the filesystem-based rules.
     if settings
         .rules
@@ -116,6 +118,7 @@ pub fn check_path(
             locator,
             comment_ranges,
             settings,
+            target_version,
         ));
     }
 
@@ -144,7 +147,6 @@ pub fn check_path(
         if use_ast || use_imports || use_doc_lines {
             let cell_offsets = source_kind.as_ipy_notebook().map(Notebook::cell_offsets);
             let notebook_index = source_kind.as_ipy_notebook().map(Notebook::index);
-            let target_version = settings.resolve_target_version(path);
             if use_ast {
                 diagnostics.extend(check_ast(
                     parsed,

--- a/crates/ruff_linter/src/linter.rs
+++ b/crates/ruff_linter/src/linter.rs
@@ -144,6 +144,7 @@ pub fn check_path(
         if use_ast || use_imports || use_doc_lines {
             let cell_offsets = source_kind.as_ipy_notebook().map(Notebook::cell_offsets);
             let notebook_index = source_kind.as_ipy_notebook().map(Notebook::index);
+            let target_version = settings.resolve_target_version(path);
             if use_ast {
                 diagnostics.extend(check_ast(
                     parsed,
@@ -158,6 +159,7 @@ pub fn check_path(
                     source_type,
                     cell_offsets,
                     notebook_index,
+                    target_version,
                 ));
             }
             if use_imports {
@@ -171,6 +173,7 @@ pub fn check_path(
                     package,
                     source_type,
                     cell_offsets,
+                    target_version,
                 );
 
                 diagnostics.extend(import_diagnostics);

--- a/crates/ruff_linter/src/renamer.rs
+++ b/crates/ruff_linter/src/renamer.rs
@@ -399,7 +399,7 @@ impl ShadowedKind {
 
         if is_python_builtin(
             new_name,
-            checker.settings.target_version.minor,
+            checker.target_version().minor,
             checker.source_type.is_ipynb(),
         ) {
             return ShadowedKind::BuiltIn;

--- a/crates/ruff_linter/src/rules/fastapi/mod.rs
+++ b/crates/ruff_linter/src/rules/fastapi/mod.rs
@@ -36,7 +36,7 @@ mod tests {
         let diagnostics = test_path(
             Path::new("fastapi").join(path).as_path(),
             &settings::LinterSettings {
-                target_version: ruff_python_ast::PythonVersion::PY38,
+                unresolved_target_version: ruff_python_ast::PythonVersion::PY38,
                 ..settings::LinterSettings::for_rule(rule_code)
             },
         )?;

--- a/crates/ruff_linter/src/rules/fastapi/rules/fastapi_non_annotated_dependency.rs
+++ b/crates/ruff_linter/src/rules/fastapi/rules/fastapi_non_annotated_dependency.rs
@@ -226,13 +226,13 @@ fn create_diagnostic(
 ) -> bool {
     let mut diagnostic = Diagnostic::new(
         FastApiNonAnnotatedDependency {
-            py_version: checker.settings.target_version,
+            py_version: checker.target_version(),
         },
         parameter.range,
     );
 
     let try_generate_fix = || {
-        let module = if checker.settings.target_version >= PythonVersion::PY39 {
+        let module = if checker.target_version() >= PythonVersion::PY39 {
             "typing"
         } else {
             "typing_extensions"

--- a/crates/ruff_linter/src/rules/flake8_annotations/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_annotations/mod.rs
@@ -128,7 +128,7 @@ mod tests {
         let diagnostics = test_path(
             Path::new("flake8_annotations/auto_return_type.py"),
             &LinterSettings {
-                target_version: PythonVersion::PY38,
+                unresolved_target_version: PythonVersion::PY38,
                 ..LinterSettings::for_rules(vec![
                     Rule::MissingReturnTypeUndocumentedPublicFunction,
                     Rule::MissingReturnTypePrivateFunction,

--- a/crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs
+++ b/crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs
@@ -523,7 +523,7 @@ fn check_dynamically_typed<F>(
             if type_hint_resolves_to_any(
                 parsed_annotation.expression(),
                 checker,
-                checker.settings.target_version,
+                checker.target_version(),
             ) {
                 diagnostics.push(Diagnostic::new(
                     AnyType { name: func() },
@@ -532,7 +532,7 @@ fn check_dynamically_typed<F>(
             }
         }
     } else {
-        if type_hint_resolves_to_any(annotation, checker, checker.settings.target_version) {
+        if type_hint_resolves_to_any(annotation, checker, checker.target_version()) {
             diagnostics.push(Diagnostic::new(
                 AnyType { name: func() },
                 annotation.range(),
@@ -725,7 +725,7 @@ pub(crate) fn definition(
                                 checker.importer(),
                                 function.parameters.start(),
                                 checker.semantic(),
-                                checker.settings.target_version,
+                                checker.target_version(),
                             )
                         })
                         .map(|(return_type, edits)| (checker.generator().expr(&return_type), edits))
@@ -756,7 +756,7 @@ pub(crate) fn definition(
                                 checker.importer(),
                                 function.parameters.start(),
                                 checker.semantic(),
-                                checker.settings.target_version,
+                                checker.target_version(),
                             )
                         })
                         .map(|(return_type, edits)| (checker.generator().expr(&return_type), edits))
@@ -826,7 +826,7 @@ pub(crate) fn definition(
                                         checker.importer(),
                                         function.parameters.start(),
                                         checker.semantic(),
-                                        checker.settings.target_version,
+                                        checker.target_version(),
                                     )
                                 })
                                 .map(|(return_type, edits)| {
@@ -865,7 +865,7 @@ pub(crate) fn definition(
                                         checker.importer(),
                                         function.parameters.start(),
                                         checker.semantic(),
-                                        checker.settings.target_version,
+                                        checker.target_version(),
                                     )
                                 })
                                 .map(|(return_type, edits)| {

--- a/crates/ruff_linter/src/rules/flake8_async/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_async/mod.rs
@@ -44,7 +44,7 @@ mod tests {
         let diagnostics = test_path(
             Path::new("flake8_async").join(path),
             &LinterSettings {
-                target_version: PythonVersion::PY310,
+                unresolved_target_version: PythonVersion::PY310,
                 ..LinterSettings::for_rule(Rule::AsyncFunctionWithTimeout)
             },
         )?;

--- a/crates/ruff_linter/src/rules/flake8_async/rules/async_function_with_timeout.rs
+++ b/crates/ruff_linter/src/rules/flake8_async/rules/async_function_with_timeout.rs
@@ -108,7 +108,7 @@ pub(crate) fn async_function_with_timeout(checker: &Checker, function_def: &ast:
     };
 
     // asyncio.timeout feature was first introduced in Python 3.11
-    if module == AsyncModule::AsyncIo && checker.settings.target_version < PythonVersion::PY311 {
+    if module == AsyncModule::AsyncIo && checker.target_version() < PythonVersion::PY311 {
         return;
     }
 

--- a/crates/ruff_linter/src/rules/flake8_bugbear/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/mod.rs
@@ -100,7 +100,7 @@ mod tests {
         let diagnostics = test_path(
             Path::new("flake8_bugbear").join(path).as_path(),
             &LinterSettings {
-                target_version,
+                unresolved_target_version,
                 ..LinterSettings::for_rule(rule_code)
             },
         )?;

--- a/crates/ruff_linter/src/rules/flake8_bugbear/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/mod.rs
@@ -100,7 +100,7 @@ mod tests {
         let diagnostics = test_path(
             Path::new("flake8_bugbear").join(path).as_path(),
             &LinterSettings {
-                unresolved_target_version,
+                unresolved_target_version: target_version,
                 ..LinterSettings::for_rule(rule_code)
             },
         )?;

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/batched_without_explicit_strict.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/batched_without_explicit_strict.rs
@@ -59,7 +59,7 @@ impl Violation for BatchedWithoutExplicitStrict {
 
 /// B911
 pub(crate) fn batched_without_explicit_strict(checker: &Checker, call: &ExprCall) {
-    if checker.settings.target_version < PythonVersion::PY313 {
+    if checker.target_version() < PythonVersion::PY313 {
         return;
     }
 

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/class_as_data_structure.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/class_as_data_structure.rs
@@ -78,7 +78,7 @@ pub(crate) fn class_as_data_structure(checker: &Checker, class_def: &ast::StmtCl
                         // skip `self`
                         .skip(1)
                         .all(|param| param.annotation().is_some() && !param.is_variadic())
-                    && (func_def.parameters.kwonlyargs.is_empty() || checker.settings.target_version >= PythonVersion::PY310)
+                    && (func_def.parameters.kwonlyargs.is_empty() || checker.target_version() >= PythonVersion::PY310)
                     // `__init__` should not have complicated logic in it
                     // only assignments
                     && func_def

--- a/crates/ruff_linter/src/rules/flake8_builtins/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_builtins/mod.rs
@@ -217,7 +217,7 @@ mod tests {
         let diagnostics = test_path(
             Path::new("flake8_builtins").join(path).as_path(),
             &LinterSettings {
-                target_version: PythonVersion::PY38,
+                unresolved_target_version: PythonVersion::PY38,
                 ..LinterSettings::for_rule(rule_code)
             },
         )?;

--- a/crates/ruff_linter/src/rules/flake8_builtins/rules/builtin_argument_shadowing.rs
+++ b/crates/ruff_linter/src/rules/flake8_builtins/rules/builtin_argument_shadowing.rs
@@ -68,7 +68,7 @@ pub(crate) fn builtin_argument_shadowing(checker: &Checker, parameter: &Paramete
         parameter.name(),
         checker.source_type,
         &checker.settings.flake8_builtins.builtins_ignorelist,
-        checker.settings.target_version,
+        checker.target_version(),
     ) {
         // Ignore parameters in lambda expressions.
         // (That is the domain of A006.)

--- a/crates/ruff_linter/src/rules/flake8_builtins/rules/builtin_attribute_shadowing.rs
+++ b/crates/ruff_linter/src/rules/flake8_builtins/rules/builtin_attribute_shadowing.rs
@@ -99,7 +99,7 @@ pub(crate) fn builtin_attribute_shadowing(
             name,
             checker.source_type,
             &checker.settings.flake8_builtins.builtins_ignorelist,
-            checker.settings.target_version,
+            checker.target_version(),
         ) {
             // Ignore explicit overrides.
             if class_def.decorator_list.iter().any(|decorator| {

--- a/crates/ruff_linter/src/rules/flake8_builtins/rules/builtin_import_shadowing.rs
+++ b/crates/ruff_linter/src/rules/flake8_builtins/rules/builtin_import_shadowing.rs
@@ -61,7 +61,7 @@ pub(crate) fn builtin_import_shadowing(checker: &Checker, alias: &Alias) {
         name.as_str(),
         checker.source_type,
         &checker.settings.flake8_builtins.builtins_ignorelist,
-        checker.settings.target_version,
+        checker.target_version(),
     ) {
         checker.report_diagnostic(Diagnostic::new(
             BuiltinImportShadowing {

--- a/crates/ruff_linter/src/rules/flake8_builtins/rules/builtin_lambda_argument_shadowing.rs
+++ b/crates/ruff_linter/src/rules/flake8_builtins/rules/builtin_lambda_argument_shadowing.rs
@@ -44,7 +44,7 @@ pub(crate) fn builtin_lambda_argument_shadowing(checker: &Checker, lambda: &Expr
             name,
             checker.source_type,
             &checker.settings.flake8_builtins.builtins_ignorelist,
-            checker.settings.target_version,
+            checker.target_version(),
         ) {
             checker.report_diagnostic(Diagnostic::new(
                 BuiltinLambdaArgumentShadowing {

--- a/crates/ruff_linter/src/rules/flake8_builtins/rules/builtin_variable_shadowing.rs
+++ b/crates/ruff_linter/src/rules/flake8_builtins/rules/builtin_variable_shadowing.rs
@@ -63,7 +63,7 @@ pub(crate) fn builtin_variable_shadowing(checker: &Checker, name: &str, range: T
         name,
         checker.source_type,
         &checker.settings.flake8_builtins.builtins_ignorelist,
-        checker.settings.target_version,
+        checker.target_version(),
     ) {
         checker.report_diagnostic(Diagnostic::new(
             BuiltinVariableShadowing {

--- a/crates/ruff_linter/src/rules/flake8_builtins/rules/stdlib_module_shadowing.rs
+++ b/crates/ruff_linter/src/rules/flake8_builtins/rules/stdlib_module_shadowing.rs
@@ -69,6 +69,7 @@ impl Violation for StdlibModuleShadowing {
 pub(crate) fn stdlib_module_shadowing(
     mut path: &Path,
     settings: &LinterSettings,
+    target_version: PythonVersion,
 ) -> Option<Diagnostic> {
     if !PySourceType::try_from_path(path).is_some_and(PySourceType::is_py_file) {
         return None;
@@ -98,11 +99,7 @@ pub(crate) fn stdlib_module_shadowing(
 
     let module_name = components.next()?;
 
-    if is_allowed_module(
-        settings,
-        settings.resolve_target_version(&path),
-        &module_name,
-    ) {
+    if is_allowed_module(settings, target_version, &module_name) {
         return None;
     }
 

--- a/crates/ruff_linter/src/rules/flake8_builtins/rules/stdlib_module_shadowing.rs
+++ b/crates/ruff_linter/src/rules/flake8_builtins/rules/stdlib_module_shadowing.rs
@@ -3,7 +3,7 @@ use std::path::{Component, Path, PathBuf};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, ViolationMetadata};
-use ruff_python_ast::PySourceType;
+use ruff_python_ast::{PySourceType, PythonVersion};
 use ruff_python_stdlib::path::is_module_file;
 use ruff_python_stdlib::sys::is_known_standard_library;
 use ruff_text_size::TextRange;
@@ -100,7 +100,7 @@ pub(crate) fn stdlib_module_shadowing(
 
     if is_allowed_module(
         settings,
-        settings.resolve_target_version(&path).minor,
+        settings.resolve_target_version(&path),
         &module_name,
     ) {
         return None;
@@ -133,7 +133,7 @@ fn get_prefix<'a>(settings: &'a LinterSettings, path: &Path) -> Option<&'a PathB
     prefix
 }
 
-fn is_allowed_module(settings: &LinterSettings, minor_version: u8, module: &str) -> bool {
+fn is_allowed_module(settings: &LinterSettings, version: PythonVersion, module: &str) -> bool {
     // Shadowing private stdlib modules is okay.
     // https://github.com/astral-sh/ruff/issues/12949
     if module.starts_with('_') && !module.starts_with("__") {
@@ -149,5 +149,5 @@ fn is_allowed_module(settings: &LinterSettings, minor_version: u8, module: &str)
         return true;
     }
 
-    !is_known_standard_library(minor_version, module)
+    !is_known_standard_library(version.minor, module)
 }

--- a/crates/ruff_linter/src/rules/flake8_builtins/rules/stdlib_module_shadowing.rs
+++ b/crates/ruff_linter/src/rules/flake8_builtins/rules/stdlib_module_shadowing.rs
@@ -98,7 +98,11 @@ pub(crate) fn stdlib_module_shadowing(
 
     let module_name = components.next()?;
 
-    if is_allowed_module(settings, &module_name) {
+    if is_allowed_module(
+        settings,
+        settings.resolve_target_version(&path).minor,
+        &module_name,
+    ) {
         return None;
     }
 
@@ -129,7 +133,7 @@ fn get_prefix<'a>(settings: &'a LinterSettings, path: &Path) -> Option<&'a PathB
     prefix
 }
 
-fn is_allowed_module(settings: &LinterSettings, module: &str) -> bool {
+fn is_allowed_module(settings: &LinterSettings, minor_version: u8, module: &str) -> bool {
     // Shadowing private stdlib modules is okay.
     // https://github.com/astral-sh/ruff/issues/12949
     if module.starts_with('_') && !module.starts_with("__") {
@@ -145,5 +149,5 @@ fn is_allowed_module(settings: &LinterSettings, module: &str) -> bool {
         return true;
     }
 
-    !is_known_standard_library(settings.target_version.minor, module)
+    !is_known_standard_library(minor_version, module)
 }

--- a/crates/ruff_linter/src/rules/flake8_future_annotations/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_future_annotations/mod.rs
@@ -30,7 +30,7 @@ mod tests {
         let diagnostics = test_path(
             Path::new("flake8_future_annotations").join(path).as_path(),
             &settings::LinterSettings {
-                target_version: PythonVersion::PY37,
+                unresolved_target_version: PythonVersion::PY37,
                 ..settings::LinterSettings::for_rule(Rule::FutureRewritableTypeAnnotation)
             },
         )?;
@@ -49,7 +49,7 @@ mod tests {
         let diagnostics = test_path(
             Path::new("flake8_future_annotations").join(path).as_path(),
             &settings::LinterSettings {
-                target_version: PythonVersion::PY37,
+                unresolved_target_version: PythonVersion::PY37,
                 ..settings::LinterSettings::for_rule(Rule::FutureRequiredTypeAnnotation)
             },
         )?;

--- a/crates/ruff_linter/src/rules/flake8_pyi/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/mod.rs
@@ -189,7 +189,7 @@ mod tests {
         let diagnostics = test_path(
             Path::new("flake8_pyi").join(path).as_path(),
             &settings::LinterSettings {
-                target_version: PythonVersion::PY38,
+                unresolved_target_version: PythonVersion::PY38,
                 ..settings::LinterSettings::for_rule(rule_code)
             },
         )?;

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/custom_type_var_for_self.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/custom_type_var_for_self.rs
@@ -560,7 +560,7 @@ fn replace_custom_typevar_with_self(
 /// This is because it was added to the `typing` module on Python 3.11,
 /// but is available from the backport package `typing_extensions` on all versions.
 fn import_self(checker: &Checker, position: TextSize) -> Result<(Edit, String), ResolutionError> {
-    let source_module = if checker.settings.target_version >= PythonVersion::PY311 {
+    let source_module = if checker.target_version() >= PythonVersion::PY311 {
         "typing"
     } else {
         "typing_extensions"

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/no_return_argument_annotation.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/no_return_argument_annotation.rs
@@ -67,7 +67,7 @@ pub(crate) fn no_return_argument_annotation(checker: &Checker, parameters: &ast:
         if is_no_return(annotation, checker) {
             checker.report_diagnostic(Diagnostic::new(
                 NoReturnArgumentAnnotationInStub {
-                    module: if checker.settings.target_version >= PythonVersion::PY311 {
+                    module: if checker.target_version() >= PythonVersion::PY311 {
                         TypingModule::Typing
                     } else {
                         TypingModule::TypingExtensions

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/non_self_return_type.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/non_self_return_type.rs
@@ -215,7 +215,7 @@ fn replace_with_self_fix(
     let semantic = checker.semantic();
 
     let (self_import, self_binding) = {
-        let source_module = if checker.settings.target_version >= PythonVersion::PY311 {
+        let source_module = if checker.target_version() >= PythonVersion::PY311 {
             "typing"
         } else {
             "typing_extensions"

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/pre_pep570_positional_argument.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/pre_pep570_positional_argument.rs
@@ -56,7 +56,7 @@ impl Violation for Pep484StylePositionalOnlyParameter {
 /// PYI063
 pub(crate) fn pep_484_positional_parameter(checker: &Checker, function_def: &ast::StmtFunctionDef) {
     // PEP 570 was introduced in Python 3.8.
-    if checker.settings.target_version < PythonVersion::PY38 {
+    if checker.target_version() < PythonVersion::PY38 {
         return;
     }
 

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/redundant_none_literal.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/redundant_none_literal.rs
@@ -112,9 +112,7 @@ pub(crate) fn redundant_none_literal<'a>(checker: &Checker, literal_expr: &'a Ex
 
     let union_kind = if literal_elements.is_empty() {
         UnionKind::NoUnion
-    } else if (checker.settings.target_version >= PythonVersion::PY310)
-        || checker.source_type.is_stub()
-    {
+    } else if (checker.target_version() >= PythonVersion::PY310) || checker.source_type.is_stub() {
         UnionKind::BitOr
     } else {
         UnionKind::TypingOptional

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/simple_defaults.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/simple_defaults.rs
@@ -667,7 +667,7 @@ pub(crate) fn type_alias_without_annotation(checker: &Checker, value: &Expr, tar
         return;
     }
 
-    let module = if checker.settings.target_version >= PythonVersion::PY310 {
+    let module = if checker.target_version() >= PythonVersion::PY310 {
         TypingModule::Typing
     } else {
         TypingModule::TypingExtensions

--- a/crates/ruff_linter/src/rules/flake8_quotes/rules/avoidable_escaped_quote.rs
+++ b/crates/ruff_linter/src/rules/flake8_quotes/rules/avoidable_escaped_quote.rs
@@ -3,7 +3,7 @@ use flake8_quotes::settings::Quote;
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_python_ast::visitor::{walk_f_string, Visitor};
-use ruff_python_ast::{self as ast, AnyStringFlags, StringFlags, StringLike};
+use ruff_python_ast::{self as ast, AnyStringFlags, PythonVersion, StringFlags, StringLike};
 use ruff_text_size::{Ranged, TextRange, TextSize};
 
 use crate::checkers::ast::Checker;
@@ -61,7 +61,11 @@ pub(crate) fn avoidable_escaped_quote(checker: &Checker, string_like: StringLike
         return;
     }
 
-    let mut rule_checker = AvoidableEscapedQuoteChecker::new(checker.locator(), checker.settings);
+    let mut rule_checker = AvoidableEscapedQuoteChecker::new(
+        checker.locator(),
+        checker.settings,
+        checker.target_version(),
+    );
 
     for part in string_like.parts() {
         match part {
@@ -88,11 +92,15 @@ struct AvoidableEscapedQuoteChecker<'a> {
 }
 
 impl<'a> AvoidableEscapedQuoteChecker<'a> {
-    fn new(locator: &'a Locator<'a>, settings: &'a LinterSettings) -> Self {
+    fn new(
+        locator: &'a Locator<'a>,
+        settings: &'a LinterSettings,
+        target_version: PythonVersion,
+    ) -> Self {
         Self {
             locator,
             quotes_settings: &settings.flake8_quotes,
-            supports_pep701: settings.target_version.supports_pep_701(),
+            supports_pep701: target_version.supports_pep_701(),
             diagnostics: vec![],
         }
     }

--- a/crates/ruff_linter/src/rules/flake8_type_checking/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/mod.rs
@@ -92,7 +92,7 @@ mod tests {
         let diagnostics = test_path(
             Path::new("flake8_type_checking").join(path).as_path(),
             &settings::LinterSettings {
-                target_version: PythonVersion::PY39,
+                unresolved_target_version: PythonVersion::PY39,
                 ..settings::LinterSettings::for_rule(rule_code)
             },
         )?;

--- a/crates/ruff_linter/src/rules/flake8_type_checking/rules/type_alias_quotes.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/rules/type_alias_quotes.rs
@@ -10,7 +10,6 @@ use ruff_text_size::Ranged;
 use crate::checkers::ast::Checker;
 use crate::registry::Rule;
 use crate::rules::flake8_type_checking::helpers::quote_type_expression;
-use crate::settings::LinterSettings;
 use ruff_python_ast::PythonVersion;
 
 /// ## What it does
@@ -284,7 +283,7 @@ pub(crate) fn quoted_type_alias(
 
     // explicit type aliases require some additional checks to avoid false positives
     if checker.semantic().in_annotated_type_alias_value()
-        && quotes_are_unremovable(checker.semantic(), expr, checker.settings)
+        && quotes_are_unremovable(checker.semantic(), expr, checker.target_version())
     {
         return;
     }
@@ -305,7 +304,7 @@ pub(crate) fn quoted_type_alias(
 fn quotes_are_unremovable(
     semantic: &SemanticModel,
     expr: &Expr,
-    settings: &LinterSettings,
+    target_version: PythonVersion,
 ) -> bool {
     match expr {
         Expr::BinOp(ast::ExprBinOp {
@@ -313,11 +312,11 @@ fn quotes_are_unremovable(
         }) => {
             match op {
                 Operator::BitOr => {
-                    if settings.target_version < PythonVersion::PY310 {
+                    if target_version < PythonVersion::PY310 {
                         return true;
                     }
-                    quotes_are_unremovable(semantic, left, settings)
-                        || quotes_are_unremovable(semantic, right, settings)
+                    quotes_are_unremovable(semantic, left, target_version)
+                        || quotes_are_unremovable(semantic, right, target_version)
                 }
                 // for now we'll treat uses of other operators as unremovable quotes
                 // since that would make it an invalid type expression anyways. We skip
@@ -330,7 +329,7 @@ fn quotes_are_unremovable(
             value,
             ctx: ExprContext::Load,
             ..
-        }) => quotes_are_unremovable(semantic, value, settings),
+        }) => quotes_are_unremovable(semantic, value, target_version),
         Expr::Subscript(ast::ExprSubscript { value, slice, .. }) => {
             // for subscripts we don't know whether it's safe to do at runtime
             // since the operation may only be available at type checking time.
@@ -338,7 +337,7 @@ fn quotes_are_unremovable(
             if !semantic.in_type_checking_block() {
                 return true;
             }
-            if quotes_are_unremovable(semantic, value, settings) {
+            if quotes_are_unremovable(semantic, value, target_version) {
                 return true;
             }
             // for `typing.Annotated`, only analyze the first argument, since the rest may
@@ -347,23 +346,23 @@ fn quotes_are_unremovable(
                 if semantic.match_typing_qualified_name(&qualified_name, "Annotated") {
                     if let Expr::Tuple(ast::ExprTuple { elts, .. }) = slice.as_ref() {
                         return !elts.is_empty()
-                            && quotes_are_unremovable(semantic, &elts[0], settings);
+                            && quotes_are_unremovable(semantic, &elts[0], target_version);
                     }
                     return false;
                 }
             }
-            quotes_are_unremovable(semantic, slice, settings)
+            quotes_are_unremovable(semantic, slice, target_version)
         }
         Expr::Attribute(ast::ExprAttribute { value, .. }) => {
             // for attributes we also don't know whether it's safe
             if !semantic.in_type_checking_block() {
                 return true;
             }
-            quotes_are_unremovable(semantic, value, settings)
+            quotes_are_unremovable(semantic, value, target_version)
         }
         Expr::List(ast::ExprList { elts, .. }) | Expr::Tuple(ast::ExprTuple { elts, .. }) => {
             for elt in elts {
-                if quotes_are_unremovable(semantic, elt, settings) {
+                if quotes_are_unremovable(semantic, elt, target_version) {
                     return true;
                 }
             }

--- a/crates/ruff_linter/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
@@ -307,7 +307,7 @@ pub(crate) fn typing_only_runtime_import(
                 checker.package(),
                 checker.settings.isort.detect_same_package,
                 &checker.settings.isort.known_modules,
-                checker.settings.target_version,
+                checker.target_version(),
                 checker.settings.isort.no_sections,
                 &checker.settings.isort.section_order,
                 &checker.settings.isort.default_section,

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/replaceable_by_pathlib.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/replaceable_by_pathlib.rs
@@ -152,7 +152,7 @@ pub(crate) fn replaceable_by_pathlib(checker: &Checker, call: &ExprCall) {
             ),
             // PTH115
             // Python 3.9+
-            ["os", "readlink"] if checker.settings.target_version >= PythonVersion::PY39 => {
+            ["os", "readlink"] if checker.target_version() >= PythonVersion::PY39 => {
                 Some(OsReadlink.into())
             }
             // PTH208,

--- a/crates/ruff_linter/src/rules/isort/rules/organize_imports.rs
+++ b/crates/ruff_linter/src/rules/isort/rules/organize_imports.rs
@@ -3,7 +3,7 @@ use itertools::{EitherOrBoth, Itertools};
 use ruff_diagnostics::{Diagnostic, Edit, Fix, FixAvailability, Violation};
 use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_python_ast::whitespace::trailing_lines_end;
-use ruff_python_ast::{PySourceType, Stmt};
+use ruff_python_ast::{PySourceType, PythonVersion, Stmt};
 use ruff_python_codegen::Stylist;
 use ruff_python_index::Indexer;
 use ruff_python_parser::Tokens;
@@ -88,6 +88,7 @@ pub(crate) fn organize_imports(
     package: Option<PackageRoot<'_>>,
     source_type: PySourceType,
     tokens: &Tokens,
+    target_version: PythonVersion,
 ) -> Option<Diagnostic> {
     let indentation = locator.slice(extract_indentation_range(&block.imports, locator));
     let indentation = leading_indentation(indentation);
@@ -127,7 +128,7 @@ pub(crate) fn organize_imports(
         &settings.src,
         package,
         source_type,
-        settings.target_version,
+        target_version,
         &settings.isort,
         tokens,
     );

--- a/crates/ruff_linter/src/rules/perflint/mod.rs
+++ b/crates/ruff_linter/src/rules/perflint/mod.rs
@@ -43,7 +43,7 @@ mod tests {
             Path::new("perflint").join(path).as_path(),
             &LinterSettings {
                 preview: PreviewMode::Enabled,
-                target_version: PythonVersion::PY310,
+                unresolved_target_version: PythonVersion::PY310,
                 ..LinterSettings::for_rule(rule_code)
             },
         )?;

--- a/crates/ruff_linter/src/rules/perflint/rules/try_except_in_loop.rs
+++ b/crates/ruff_linter/src/rules/perflint/rules/try_except_in_loop.rs
@@ -89,7 +89,7 @@ impl Violation for TryExceptInLoop {
 
 /// PERF203
 pub(crate) fn try_except_in_loop(checker: &Checker, body: &[Stmt]) {
-    if checker.settings.target_version >= PythonVersion::PY311 {
+    if checker.target_version() >= PythonVersion::PY311 {
         return;
     }
 

--- a/crates/ruff_linter/src/rules/pyflakes/mod.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/mod.rs
@@ -218,7 +218,7 @@ mod tests {
         let diagnostics = test_snippet(
             "PythonFinalizationError",
             &LinterSettings {
-                target_version: ruff_python_ast::PythonVersion::PY312,
+                unresolved_target_version: ruff_python_ast::PythonVersion::PY312,
                 ..LinterSettings::for_rule(Rule::UndefinedName)
             },
         );

--- a/crates/ruff_linter/src/rules/pyflakes/rules/unused_import.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/unused_import.rs
@@ -229,7 +229,7 @@ fn is_first_party(import: &AnyImport, checker: &Checker) -> bool {
         checker.package(),
         checker.settings.isort.detect_same_package,
         &checker.settings.isort.known_modules,
-        checker.settings.target_version,
+        checker.target_version(),
         checker.settings.isort.no_sections,
         &checker.settings.isort.section_order,
         &checker.settings.isort.default_section,

--- a/crates/ruff_linter/src/rules/pylint/rules/bad_str_strip_call.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/bad_str_strip_call.rs
@@ -211,7 +211,7 @@ pub(crate) fn bad_str_strip_call(checker: &Checker, call: &ast::ExprCall) {
         return;
     }
 
-    let removal = if checker.settings.target_version >= PythonVersion::PY39 {
+    let removal = if checker.target_version() >= PythonVersion::PY39 {
         RemovalKind::for_strip(strip)
     } else {
         None

--- a/crates/ruff_linter/src/rules/pylint/rules/unnecessary_dunder_call.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/unnecessary_dunder_call.rs
@@ -76,7 +76,7 @@ pub(crate) fn unnecessary_dunder_call(checker: &Checker, call: &ast::ExprCall) {
     }
 
     // If this is an allowed dunder method, abort.
-    if allowed_dunder_constants(attr, checker.settings.target_version) {
+    if allowed_dunder_constants(attr, checker.target_version()) {
         return;
     }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/useless_exception_statement.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/useless_exception_statement.rs
@@ -55,7 +55,7 @@ pub(crate) fn useless_exception_statement(checker: &Checker, expr: &ast::StmtExp
         return;
     };
 
-    if is_builtin_exception(func, checker.semantic(), checker.settings.target_version) {
+    if is_builtin_exception(func, checker.semantic(), checker.target_version()) {
         let mut diagnostic = Diagnostic::new(UselessExceptionStatement, expr.range());
         diagnostic.set_fix(Fix::unsafe_edit(Edit::insertion(
             "raise ".to_string(),

--- a/crates/ruff_linter/src/rules/pyupgrade/mod.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/mod.rs
@@ -156,7 +156,7 @@ mod tests {
         let diagnostics = test_path(
             Path::new("pyupgrade/UP041.py"),
             &settings::LinterSettings {
-                target_version: PythonVersion::PY310,
+                unresolved_target_version: PythonVersion::PY310,
                 ..settings::LinterSettings::for_rule(Rule::TimeoutErrorAlias)
             },
         )?;
@@ -169,7 +169,7 @@ mod tests {
         let diagnostics = test_path(
             Path::new("pyupgrade/UP040.py"),
             &settings::LinterSettings {
-                target_version: PythonVersion::PY311,
+                unresolved_target_version: PythonVersion::PY311,
                 ..settings::LinterSettings::for_rule(Rule::NonPEP695TypeAlias)
             },
         )?;
@@ -185,7 +185,7 @@ mod tests {
                 pyupgrade: pyupgrade::settings::Settings {
                     keep_runtime_typing: true,
                 },
-                target_version: PythonVersion::PY37,
+                unresolved_target_version: PythonVersion::PY37,
                 ..settings::LinterSettings::for_rule(Rule::NonPEP585Annotation)
             },
         )?;
@@ -201,7 +201,7 @@ mod tests {
                 pyupgrade: pyupgrade::settings::Settings {
                     keep_runtime_typing: true,
                 },
-                target_version: PythonVersion::PY310,
+                unresolved_target_version: PythonVersion::PY310,
                 ..settings::LinterSettings::for_rule(Rule::NonPEP585Annotation)
             },
         )?;
@@ -214,7 +214,7 @@ mod tests {
         let diagnostics = test_path(
             Path::new("pyupgrade/future_annotations.py"),
             &settings::LinterSettings {
-                target_version: PythonVersion::PY37,
+                unresolved_target_version: PythonVersion::PY37,
                 ..settings::LinterSettings::for_rule(Rule::NonPEP585Annotation)
             },
         )?;
@@ -227,7 +227,7 @@ mod tests {
         let diagnostics = test_path(
             Path::new("pyupgrade/future_annotations.py"),
             &settings::LinterSettings {
-                target_version: PythonVersion::PY310,
+                unresolved_target_version: PythonVersion::PY310,
                 ..settings::LinterSettings::for_rule(Rule::NonPEP585Annotation)
             },
         )?;
@@ -240,7 +240,7 @@ mod tests {
         let diagnostics = test_path(
             Path::new("pyupgrade/future_annotations.py"),
             &settings::LinterSettings {
-                target_version: PythonVersion::PY37,
+                unresolved_target_version: PythonVersion::PY37,
                 ..settings::LinterSettings::for_rules([
                     Rule::NonPEP604AnnotationUnion,
                     Rule::NonPEP604AnnotationOptional,
@@ -256,7 +256,7 @@ mod tests {
         let diagnostics = test_path(
             Path::new("pyupgrade/future_annotations.py"),
             &settings::LinterSettings {
-                target_version: PythonVersion::PY310,
+                unresolved_target_version: PythonVersion::PY310,
                 ..settings::LinterSettings::for_rules([
                     Rule::NonPEP604AnnotationUnion,
                     Rule::NonPEP604AnnotationOptional,
@@ -272,7 +272,7 @@ mod tests {
         let diagnostics = test_path(
             Path::new("pyupgrade/UP017.py"),
             &settings::LinterSettings {
-                target_version: PythonVersion::PY311,
+                unresolved_target_version: PythonVersion::PY311,
                 ..settings::LinterSettings::for_rule(Rule::DatetimeTimezoneUTC)
             },
         )?;
@@ -286,7 +286,7 @@ mod tests {
             Path::new("pyupgrade/UP044.py"),
             &settings::LinterSettings {
                 preview: PreviewMode::Enabled,
-                target_version: PythonVersion::PY311,
+                unresolved_target_version: PythonVersion::PY311,
                 ..settings::LinterSettings::for_rule(Rule::NonPEP646Unpack)
             },
         )?;

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_import.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_import.rs
@@ -722,7 +722,7 @@ pub(crate) fn deprecated_import(checker: &Checker, import_from_stmt: &StmtImport
         checker.locator(),
         checker.stylist(),
         checker.tokens(),
-        checker.settings.target_version,
+        checker.target_version(),
     );
 
     for (operation, fix) in fixer.without_renames() {

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/outdated_version_block.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/outdated_version_block.rs
@@ -115,7 +115,7 @@ pub(crate) fn outdated_version_block(checker: &Checker, stmt_if: &StmtIf) {
                     let Some(version) = extract_version(elts) else {
                         return;
                     };
-                    let target = checker.settings.target_version;
+                    let target = checker.target_version();
                     match version_always_less_than(
                         &version,
                         target,

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_generic_class.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_generic_class.rs
@@ -106,7 +106,7 @@ impl Violation for NonPEP695GenericClass {
 /// UP046
 pub(crate) fn non_pep695_generic_class(checker: &Checker, class_def: &StmtClassDef) {
     // PEP-695 syntax is only available on Python 3.12+
-    if checker.settings.target_version < PythonVersion::PY312 {
+    if checker.target_version() < PythonVersion::PY312 {
         return;
     }
 

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_generic_function.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_generic_function.rs
@@ -98,7 +98,7 @@ impl Violation for NonPEP695GenericFunction {
 /// UP047
 pub(crate) fn non_pep695_generic_function(checker: &Checker, function_def: &StmtFunctionDef) {
     // PEP-695 syntax is only available on Python 3.12+
-    if checker.settings.target_version < PythonVersion::PY312 {
+    if checker.target_version() < PythonVersion::PY312 {
         return;
     }
 

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_type_alias.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_type_alias.rs
@@ -111,7 +111,7 @@ impl Violation for NonPEP695TypeAlias {
 
 /// UP040
 pub(crate) fn non_pep695_type_alias_type(checker: &Checker, stmt: &StmtAssign) {
-    if checker.settings.target_version < PythonVersion::PY312 {
+    if checker.target_version() < PythonVersion::PY312 {
         return;
     }
 
@@ -182,7 +182,7 @@ pub(crate) fn non_pep695_type_alias_type(checker: &Checker, stmt: &StmtAssign) {
 
 /// UP040
 pub(crate) fn non_pep695_type_alias(checker: &Checker, stmt: &StmtAnnAssign) {
-    if checker.settings.target_version < PythonVersion::PY312 {
+    if checker.target_version() < PythonVersion::PY312 {
         return;
     }
 

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/timeout_error_alias.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/timeout_error_alias.rs
@@ -162,7 +162,7 @@ pub(crate) fn timeout_error_alias_handlers(checker: &Checker, handlers: &[Except
         };
         match expr.as_ref() {
             Expr::Name(_) | Expr::Attribute(_) => {
-                if is_alias(expr, checker.semantic(), checker.settings.target_version) {
+                if is_alias(expr, checker.semantic(), checker.target_version()) {
                     atom_diagnostic(checker, expr);
                 }
             }
@@ -170,7 +170,7 @@ pub(crate) fn timeout_error_alias_handlers(checker: &Checker, handlers: &[Except
                 // List of aliases to replace with `TimeoutError`.
                 let mut aliases: Vec<&Expr> = vec![];
                 for element in tuple {
-                    if is_alias(element, checker.semantic(), checker.settings.target_version) {
+                    if is_alias(element, checker.semantic(), checker.target_version()) {
                         aliases.push(element);
                     }
                 }
@@ -185,7 +185,7 @@ pub(crate) fn timeout_error_alias_handlers(checker: &Checker, handlers: &[Except
 
 /// UP041
 pub(crate) fn timeout_error_alias_call(checker: &Checker, func: &Expr) {
-    if is_alias(func, checker.semantic(), checker.settings.target_version) {
+    if is_alias(func, checker.semantic(), checker.target_version()) {
         atom_diagnostic(checker, func);
     }
 }
@@ -193,7 +193,7 @@ pub(crate) fn timeout_error_alias_call(checker: &Checker, func: &Expr) {
 /// UP041
 pub(crate) fn timeout_error_alias_raise(checker: &Checker, expr: &Expr) {
     if matches!(expr, Expr::Name(_) | Expr::Attribute(_)) {
-        if is_alias(expr, checker.semantic(), checker.settings.target_version) {
+        if is_alias(expr, checker.semantic(), checker.target_version()) {
             atom_diagnostic(checker, expr);
         }
     }

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep585_annotation.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep585_annotation.rs
@@ -98,7 +98,7 @@ pub(crate) fn use_pep585_annotation(checker: &Checker, expr: &Expr, replacement:
                         checker.semantic(),
                     )?;
                     let binding_edit = Edit::range_replacement(binding, expr.range());
-                    let applicability = if checker.settings.target_version >= PythonVersion::PY310 {
+                    let applicability = if checker.target_version() >= PythonVersion::PY310 {
                         Applicability::Safe
                     } else {
                         Applicability::Unsafe
@@ -122,7 +122,7 @@ pub(crate) fn use_pep585_annotation(checker: &Checker, expr: &Expr, replacement:
                     Ok(Fix::applicable_edits(
                         import_edit,
                         [reference_edit],
-                        if checker.settings.target_version >= PythonVersion::PY310 {
+                        if checker.target_version() >= PythonVersion::PY310 {
                             Applicability::Safe
                         } else {
                             Applicability::Unsafe

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep604_annotation.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep604_annotation.rs
@@ -142,7 +142,7 @@ pub(crate) fn non_pep604_annotation(
         && !checker.semantic().in_complex_string_type_definition()
         && is_allowed_value(slice);
 
-    let applicability = if checker.settings.target_version >= PythonVersion::PY310 {
+    let applicability = if checker.target_version() >= PythonVersion::PY310 {
         Applicability::Safe
     } else {
         Applicability::Unsafe

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep646_unpack.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep646_unpack.rs
@@ -53,7 +53,7 @@ impl Violation for NonPEP646Unpack {
 
 /// UP044
 pub(crate) fn use_pep646_unpack(checker: &Checker, expr: &ExprSubscript) {
-    if checker.settings.target_version < PythonVersion::PY311 {
+    if checker.target_version() < PythonVersion::PY311 {
         return;
     }
 

--- a/crates/ruff_linter/src/rules/refurb/rules/bit_count.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/bit_count.rs
@@ -59,7 +59,7 @@ impl AlwaysFixableViolation for BitCount {
 /// FURB161
 pub(crate) fn bit_count(checker: &Checker, call: &ExprCall) {
     // `int.bit_count()` was added in Python 3.10
-    if checker.settings.target_version < PythonVersion::PY310 {
+    if checker.target_version() < PythonVersion::PY310 {
         return;
     }
 

--- a/crates/ruff_linter/src/rules/refurb/rules/fromisoformat_replace_z.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/fromisoformat_replace_z.rs
@@ -82,7 +82,7 @@ impl AlwaysFixableViolation for FromisoformatReplaceZ {
 
 /// FURB162
 pub(crate) fn fromisoformat_replace_z(checker: &Checker, call: &ExprCall) {
-    if checker.settings.target_version < PythonVersion::PY311 {
+    if checker.target_version() < PythonVersion::PY311 {
         return;
     }
 

--- a/crates/ruff_linter/src/rules/refurb/rules/read_whole_file.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/read_whole_file.rs
@@ -58,12 +58,7 @@ pub(crate) fn read_whole_file(checker: &Checker, with: &ast::StmtWith) {
     }
 
     // First we go through all the items in the statement and find all `open` operations.
-    let candidates = find_file_opens(
-        with,
-        checker.semantic(),
-        true,
-        checker.settings.target_version,
-    );
+    let candidates = find_file_opens(with, checker.semantic(), true, checker.target_version());
     if candidates.is_empty() {
         return;
     }

--- a/crates/ruff_linter/src/rules/refurb/rules/slice_to_remove_prefix_or_suffix.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/slice_to_remove_prefix_or_suffix.rs
@@ -69,7 +69,7 @@ impl AlwaysFixableViolation for SliceToRemovePrefixOrSuffix {
 
 /// FURB188
 pub(crate) fn slice_to_remove_affix_expr(checker: &Checker, if_expr: &ast::ExprIf) {
-    if checker.settings.target_version < PythonVersion::PY39 {
+    if checker.target_version() < PythonVersion::PY39 {
         return;
     }
 
@@ -100,7 +100,7 @@ pub(crate) fn slice_to_remove_affix_expr(checker: &Checker, if_expr: &ast::ExprI
 
 /// FURB188
 pub(crate) fn slice_to_remove_affix_stmt(checker: &Checker, if_stmt: &ast::StmtIf) {
-    if checker.settings.target_version < PythonVersion::PY39 {
+    if checker.target_version() < PythonVersion::PY39 {
         return;
     }
     if let Some(removal_data) = affix_removal_data_stmt(if_stmt) {

--- a/crates/ruff_linter/src/rules/refurb/rules/write_whole_file.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/write_whole_file.rs
@@ -59,12 +59,7 @@ pub(crate) fn write_whole_file(checker: &Checker, with: &ast::StmtWith) {
     }
 
     // First we go through all the items in the statement and find all `open` operations.
-    let candidates = find_file_opens(
-        with,
-        checker.semantic(),
-        false,
-        checker.settings.target_version,
-    );
+    let candidates = find_file_opens(with, checker.semantic(), false, checker.target_version());
     if candidates.is_empty() {
         return;
     }

--- a/crates/ruff_linter/src/rules/ruff/mod.rs
+++ b/crates/ruff_linter/src/rules/ruff/mod.rs
@@ -129,7 +129,7 @@ mod tests {
                     extend_markup_names: vec![],
                     allowed_markup_calls: vec![],
                 },
-                target_version: PythonVersion::PY310,
+                unresolved_target_version: PythonVersion::PY310,
                 ..LinterSettings::for_rule(Rule::IncorrectlyParenthesizedTupleInSubscript)
             },
         )?;

--- a/crates/ruff_linter/src/rules/ruff/rules/class_with_mixed_type_vars.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/class_with_mixed_type_vars.rs
@@ -79,7 +79,7 @@ impl Violation for ClassWithMixedTypeVars {
 
 /// RUF053
 pub(crate) fn class_with_mixed_type_vars(checker: &Checker, class_def: &StmtClassDef) {
-    if checker.settings.target_version < PythonVersion::PY312 {
+    if checker.target_version() < PythonVersion::PY312 {
         return;
     }
 

--- a/crates/ruff_linter/src/rules/ruff/rules/implicit_optional.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/implicit_optional.rs
@@ -177,11 +177,11 @@ pub(crate) fn implicit_optional(checker: &Checker, parameters: &Parameters) {
                 let Some(expr) = type_hint_explicitly_allows_none(
                     parsed_annotation.expression(),
                     checker,
-                    checker.settings.target_version,
+                    checker.target_version(),
                 ) else {
                     continue;
                 };
-                let conversion_type = checker.settings.target_version.into();
+                let conversion_type = checker.target_version().into();
 
                 let mut diagnostic =
                     Diagnostic::new(ImplicitOptional { conversion_type }, expr.range());
@@ -192,14 +192,12 @@ pub(crate) fn implicit_optional(checker: &Checker, parameters: &Parameters) {
             }
         } else {
             // Unquoted annotation.
-            let Some(expr) = type_hint_explicitly_allows_none(
-                annotation,
-                checker,
-                checker.settings.target_version,
-            ) else {
+            let Some(expr) =
+                type_hint_explicitly_allows_none(annotation, checker, checker.target_version())
+            else {
                 continue;
             };
-            let conversion_type = checker.settings.target_version.into();
+            let conversion_type = checker.target_version().into();
 
             let mut diagnostic =
                 Diagnostic::new(ImplicitOptional { conversion_type }, expr.range());

--- a/crates/ruff_linter/src/rules/ruff/rules/incorrectly_parenthesized_tuple_in_subscript.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/incorrectly_parenthesized_tuple_in_subscript.rs
@@ -88,7 +88,7 @@ pub(crate) fn subscript_with_parenthesized_tuple(checker: &Checker, subscript: &
     // to a syntax error in Python 3.10.
     // This is no longer a syntax error starting in Python 3.11
     // see https://peps.python.org/pep-0646/#change-1-star-expressions-in-indexes
-    if checker.settings.target_version <= PythonVersion::PY310
+    if checker.target_version() <= PythonVersion::PY310
         && !prefer_parentheses
         && tuple_subscript.iter().any(Expr::is_starred_expr)
     {

--- a/crates/ruff_linter/src/settings/mod.rs
+++ b/crates/ruff_linter/src/settings/mod.rs
@@ -222,14 +222,18 @@ pub struct LinterSettings {
 
     /// The non-path-resolved Python version specified by the `target-version` input option.
     ///
-    /// See [`LinterSettings::resolve_target_version`] for a way to obtain the Python version for a
-    /// given file, while respecting the overrides in `per_file_target_version`.
+    /// If you have a `Checker` available, see its `target_version` method instead.
+    ///
+    /// Otherwise, see [`LinterSettings::resolve_target_version`] for a way to obtain the Python
+    /// version for a given file, while respecting the overrides in `per_file_target_version`.
     pub unresolved_target_version: PythonVersion,
     /// Path-specific overrides to `unresolved_target_version`.
     ///
-    /// See [`LinterSettings::resolve_target_version`] for a way to check a given [`Path`]
-    /// against these patterns, while falling back to `unresolved_target_version` if none of them
-    /// match.
+    /// If you have a `Checker` available, see its `target_version` method instead.
+    ///
+    /// Otherwise, see [`LinterSettings::resolve_target_version`] for a way to check a given
+    /// [`Path`] against these patterns, while falling back to `unresolved_target_version` if none
+    /// of them match.
     pub per_file_target_version: CompiledPerFileTargetVersionList,
     pub preview: PreviewMode,
     pub explicit_preview_rules: bool,

--- a/crates/ruff_linter/src/settings/mod.rs
+++ b/crates/ruff_linter/src/settings/mod.rs
@@ -284,6 +284,7 @@ impl Display for LinterSettings {
                 self.fix_safety | nested,
 
                 self.target_version,
+                self.per_file_target_version,
                 self.preview,
                 self.explicit_preview_rules,
                 self.extension | debug,

--- a/crates/ruff_linter/src/settings/mod.rs
+++ b/crates/ruff_linter/src/settings/mod.rs
@@ -8,7 +8,7 @@ use rustc_hash::FxHashSet;
 use std::fmt::{Display, Formatter};
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
-use types::{CompiledPerFileVersion, CompiledPerFileVersionList};
+use types::CompiledPerFileVersionList;
 
 use crate::codes::RuleCodePrefix;
 use ruff_macros::CacheKey;
@@ -452,12 +452,9 @@ impl LinterSettings {
     /// [`LinterSettings::per_file_target_version`] and falls back on
     /// [`LinterSettings::unresolved_target_version`] if none of the override patterns match.
     pub fn resolve_target_version(&self, path: &Path) -> PythonVersion {
-        for CompiledPerFileVersion { matcher, version } in &*self.per_file_target_version {
-            if matcher.is_match(path) {
-                return *version;
-            }
-        }
-        self.target_version
+        self.per_file_target_version
+            .is_match(path)
+            .unwrap_or(self.target_version)
     }
 }
 

--- a/crates/ruff_linter/src/settings/mod.rs
+++ b/crates/ruff_linter/src/settings/mod.rs
@@ -8,7 +8,7 @@ use rustc_hash::FxHashSet;
 use std::fmt::{Display, Formatter};
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
-use types::CompiledPerFileVersionList;
+use types::CompiledPerFileTargetVersionList;
 
 use crate::codes::RuleCodePrefix;
 use ruff_macros::CacheKey;
@@ -230,7 +230,7 @@ pub struct LinterSettings {
     /// See [`LinterSettings::resolve_target_version`] for a way to check a given [`Path`]
     /// against these patterns, while falling back to `unresolved_target_version` if none of them
     /// match.
-    pub per_file_target_version: CompiledPerFileVersionList,
+    pub per_file_target_version: CompiledPerFileTargetVersionList,
     pub preview: PreviewMode,
     pub explicit_preview_rules: bool,
 
@@ -390,7 +390,7 @@ impl LinterSettings {
         Self {
             exclude: FilePatternSet::default(),
             unresolved_target_version: PythonVersion::default(),
-            per_file_target_version: CompiledPerFileVersionList::default(),
+            per_file_target_version: CompiledPerFileTargetVersionList::default(),
             project_root: project_root.to_path_buf(),
             rules: DEFAULT_SELECTORS
                 .iter()

--- a/crates/ruff_linter/src/settings/mod.rs
+++ b/crates/ruff_linter/src/settings/mod.rs
@@ -4,7 +4,7 @@
 
 use path_absolutize::path_dedot;
 use regex::Regex;
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 use std::fmt::{Display, Formatter};
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
@@ -220,6 +220,7 @@ pub struct LinterSettings {
     pub fix_safety: FixSafetyTable,
 
     pub target_version: PythonVersion,
+    pub per_file_target_version: FxHashMap<String, PythonVersion>,
     pub preview: PreviewMode,
     pub explicit_preview_rules: bool,
 
@@ -378,6 +379,7 @@ impl LinterSettings {
         Self {
             exclude: FilePatternSet::default(),
             target_version: PythonVersion::default(),
+            per_file_target_version: FxHashMap::default(),
             project_root: project_root.to_path_buf(),
             rules: DEFAULT_SELECTORS
                 .iter()

--- a/crates/ruff_linter/src/settings/types.rs
+++ b/crates/ruff_linter/src/settings/types.rs
@@ -707,14 +707,6 @@ impl CompiledPerFileVersionList {
     }
 }
 
-impl Deref for CompiledPerFileVersionList {
-    type Target = Vec<CompiledPerFileVersion>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.versions
-    }
-}
-
 #[cfg(test)]
 mod tests {
     #[test]

--- a/crates/ruff_linter/src/settings/types.rs
+++ b/crates/ruff_linter/src/settings/types.rs
@@ -314,6 +314,8 @@ impl<T> PerFile<T> {
 }
 
 /// Per-file ignored linting rules.
+///
+/// See [`PerFile`] for details of the representation.
 #[derive(Debug, Clone)]
 pub struct PerFileIgnore(PerFile<RuleSet>);
 
@@ -780,15 +782,15 @@ impl PerFileTargetVersion {
 }
 
 #[derive(CacheKey, Clone, Debug, Default)]
-pub struct CompiledPerFileVersionList(CompiledPerFileList<ast::PythonVersion>);
+pub struct CompiledPerFileTargetVersionList(CompiledPerFileList<ast::PythonVersion>);
 
-impl CompiledPerFileVersionList {
+impl CompiledPerFileTargetVersionList {
     /// Given a list of [`PerFileTargetVersion`] patterns, create a compiled set of globs.
     ///
     /// Returns an error if either of the glob patterns cannot be parsed.
-    pub fn resolve(per_file_ignores: Vec<PerFileTargetVersion>) -> Result<Self> {
+    pub fn resolve(per_file_versions: Vec<PerFileTargetVersion>) -> Result<Self> {
         Ok(Self(CompiledPerFileList::resolve(
-            per_file_ignores.into_iter().map(|version| version.0),
+            per_file_versions.into_iter().map(|version| version.0),
         )?))
     }
 
@@ -797,7 +799,7 @@ impl CompiledPerFileVersionList {
     }
 }
 
-impl Display for CompiledPerFileVersionList {
+impl Display for CompiledPerFileTargetVersionList {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         self.0.fmt(f)
     }

--- a/crates/ruff_linter/src/settings/types.rs
+++ b/crates/ruff_linter/src/settings/types.rs
@@ -274,15 +274,24 @@ impl CacheKey for FilePatternSet {
     }
 }
 
+/// A glob pattern and associated data for matching file paths.
 #[derive(Debug, Clone)]
-struct PerFile<T> {
+pub struct PerFile<T> {
+    /// The glob pattern used to construct the [`PerFile`].
     basename: String,
+    /// The same pattern as `basename` but normalized to the project root directory.
     absolute: PathBuf,
+    /// Whether the glob pattern should be negated (e.g. `!*.ipynb`)
     negated: bool,
+    /// The per-file data associated with these glob patterns.
     data: T,
 }
 
 impl<T> PerFile<T> {
+    /// Construct a new [`PerFile`] from the given glob `pattern` and containing `data`.
+    ///
+    /// If provided, `project_root` is used to construct a second glob pattern normalized to the
+    /// project root directory. See [`fs::normalize_path_to`] for more details.
     fn new(mut pattern: String, project_root: Option<&Path>, data: T) -> Self {
         let negated = pattern.starts_with('!');
         if negated {
@@ -303,6 +312,7 @@ impl<T> PerFile<T> {
     }
 }
 
+/// Per-file ignored linting rules.
 #[derive(Debug, Clone)]
 pub struct PerFileIgnore(PerFile<RuleSet>);
 
@@ -564,6 +574,7 @@ impl Display for RequiredVersion {
 /// pattern matching.
 pub type IdentifierPattern = glob::Pattern;
 
+/// Like [`PerFile`] but with string globs compiled to [`GlobMatcher`]s for more efficient usage.
 #[derive(Debug, Clone, CacheKey)]
 pub struct CompiledPerFileIgnore {
     pub absolute_matcher: GlobMatcher,
@@ -641,8 +652,9 @@ impl Deref for CompiledPerFileIgnoreList {
     }
 }
 
-// This struct and its `new` implementation are adapted directly from `PerFileIgnore`, minus the
-// `negated` field
+/// Contains the target Python version for a given glob pattern.
+///
+/// See [`PerFile`] for details of the representation.
 #[derive(Debug, Clone)]
 pub struct PerFileVersion(PerFile<ast::PythonVersion>);
 

--- a/crates/ruff_linter/src/settings/types.rs
+++ b/crates/ruff_linter/src/settings/types.rs
@@ -628,15 +628,15 @@ pub struct CompiledPerFileList<T: CacheKey> {
 
 /// Helper trait for debug labels on [`PerFile<T>`] types.
 pub trait PerFileKind {
-    const LABEL: &str;
+    const LABEL: &'static str;
 }
 
 impl PerFileKind for RuleSet {
-    const LABEL: &str = "Adding per-file ignores";
+    const LABEL: &'static str = "Adding per-file ignores";
 }
 
 impl PerFileKind for ast::PythonVersion {
-    const LABEL: &str = "Setting Python version";
+    const LABEL: &'static str = "Setting Python version";
 }
 
 impl<T: CacheKey> CompiledPerFileList<T> {

--- a/crates/ruff_linter/src/settings/types.rs
+++ b/crates/ruff_linter/src/settings/types.rs
@@ -662,6 +662,12 @@ impl CompiledPerFileVersionList {
             versions: versions?,
         })
     }
+
+    pub fn is_match(&self, path: &Path) -> Option<ast::PythonVersion> {
+        self.versions
+            .iter()
+            .find_map(|v| v.matcher.is_match(path).then_some(v.version))
+    }
 }
 
 impl Deref for CompiledPerFileVersionList {

--- a/crates/ruff_linter/src/settings/types.rs
+++ b/crates/ruff_linter/src/settings/types.rs
@@ -766,9 +766,9 @@ impl Display for CompiledPerFileIgnoreList {
 ///
 /// See [`PerFile`] for details of the representation.
 #[derive(Debug, Clone)]
-pub struct PerFileVersion(PerFile<ast::PythonVersion>);
+pub struct PerFileTargetVersion(PerFile<ast::PythonVersion>);
 
-impl PerFileVersion {
+impl PerFileTargetVersion {
     pub fn new(pattern: String, version: ast::PythonVersion, project_root: Option<&Path>) -> Self {
         Self(PerFile::new(pattern, project_root, version))
     }
@@ -778,8 +778,10 @@ impl PerFileVersion {
 pub struct CompiledPerFileVersionList(CompiledPerFileList<ast::PythonVersion>);
 
 impl CompiledPerFileVersionList {
-    /// Given a list of patterns, create a `GlobSet`.
-    pub fn resolve(per_file_ignores: Vec<PerFileVersion>) -> Result<Self> {
+    /// Given a list of [`PerFileTargetVersion`] patterns, create a compiled set of globs.
+    ///
+    /// Returns an error if either of the glob patterns cannot be parsed.
+    pub fn resolve(per_file_ignores: Vec<PerFileTargetVersion>) -> Result<Self> {
         Ok(Self(CompiledPerFileList::resolve(
             per_file_ignores.into_iter().map(|version| version.0),
         )?))

--- a/crates/ruff_linter/src/settings/types.rs
+++ b/crates/ruff_linter/src/settings/types.rs
@@ -666,6 +666,22 @@ pub struct CompiledPerFileVersion {
     pub version: ast::PythonVersion,
 }
 
+impl Display for CompiledPerFileVersion {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        display_settings! {
+            formatter = f,
+            fields = [
+                self.absolute_matcher | globmatcher,
+                self.basename_matcher | globmatcher,
+                // TODO
+                // self.negated,
+                self.version,
+            ]
+        }
+        Ok(())
+    }
+}
+
 #[derive(CacheKey, Clone, Debug, Default)]
 pub struct CompiledPerFileVersionList {
     versions: Vec<CompiledPerFileVersion>,
@@ -704,6 +720,21 @@ impl CompiledPerFileVersionList {
                 None
             }
         })
+    }
+}
+
+impl Display for CompiledPerFileVersionList {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        if self.versions.is_empty() {
+            write!(f, "{{}}")?;
+        } else {
+            writeln!(f, "{{")?;
+            for version in &self.versions {
+                writeln!(f, "\t{version}")?;
+            }
+            write!(f, "}}")?;
+        }
+        Ok(())
     }
 }
 

--- a/crates/ruff_linter/src/settings/types.rs
+++ b/crates/ruff_linter/src/settings/types.rs
@@ -618,17 +618,7 @@ where
     }
 }
 
-#[derive(Debug, Clone, CacheKey)]
-pub struct CompiledPerFileIgnore(CompiledPerFile<RuleSet>);
-
-impl Deref for CompiledPerFileIgnore {
-    type Target = CompiledPerFile<RuleSet>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
+/// A sequence of [`CompiledPerFile<T>`].
 #[derive(Debug, Clone, CacheKey, Default)]
 pub struct CompiledPerFileList<T: CacheKey> {
     inner: Vec<CompiledPerFile<T>>,
@@ -764,10 +754,6 @@ impl PerFileVersion {
         Self(PerFile::new(pattern, project_root, version))
     }
 }
-
-#[derive(Debug, Clone, CacheKey)]
-pub struct CompiledPerFileVersion(CompiledPerFile<ast::PythonVersion>);
-
 #[derive(CacheKey, Clone, Debug, Default)]
 pub struct CompiledPerFileVersionList(CompiledPerFileList<ast::PythonVersion>);
 

--- a/crates/ruff_server/src/format.rs
+++ b/crates/ruff_server/src/format.rs
@@ -62,3 +62,146 @@ pub(crate) fn format_range(
         Err(err) => Err(err.into()),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use insta::assert_snapshot;
+    use ruff_linter::settings::types::{CompiledPerFileTargetVersionList, PerFileTargetVersion};
+    use ruff_python_ast::{PySourceType, PythonVersion};
+    use ruff_text_size::{TextRange, TextSize};
+    use ruff_workspace::FormatterSettings;
+
+    use crate::format::{format, format_range};
+    use crate::TextDocument;
+
+    #[test]
+    fn format_per_file_version() {
+        let document = TextDocument::new(r#"
+with open("a_really_long_foo") as foo, open("a_really_long_bar") as bar, open("a_really_long_baz") as baz:
+    pass
+"#.to_string(), 0);
+        let per_file_target_version =
+            CompiledPerFileTargetVersionList::resolve(vec![PerFileTargetVersion::new(
+                "test.py".to_string(),
+                PythonVersion::PY310,
+                Some(Path::new(".")),
+            )])
+            .unwrap();
+        let result = format(
+            &document,
+            PySourceType::Python,
+            &FormatterSettings {
+                unresolved_target_version: PythonVersion::PY38,
+                per_file_target_version,
+                ..Default::default()
+            },
+            Some(Path::new("test.py")),
+        )
+        .expect("Expected no errors when formatting")
+        .expect("Expected formatting changes");
+
+        assert_snapshot!(result, @r#"
+        with (
+            open("a_really_long_foo") as foo,
+            open("a_really_long_bar") as bar,
+            open("a_really_long_baz") as baz,
+        ):
+            pass
+        "#);
+
+        // same as above but without the per_file_target_version override
+        let result = format(
+            &document,
+            PySourceType::Python,
+            &FormatterSettings {
+                unresolved_target_version: PythonVersion::PY38,
+                ..Default::default()
+            },
+            Some(Path::new("test.py")),
+        )
+        .expect("Expected no errors when formatting")
+        .expect("Expected formatting changes");
+
+        assert_snapshot!(result, @r#"
+        with open("a_really_long_foo") as foo, open("a_really_long_bar") as bar, open(
+            "a_really_long_baz"
+        ) as baz:
+            pass
+        "#);
+    }
+
+    #[test]
+    fn format_per_file_version_range() -> anyhow::Result<()> {
+        // prepare a document with formatting changes before and after the intended range (the
+        // context manager)
+        let document = TextDocument::new(r#"
+def fn(x: str) -> Foo | Bar: return foobar(x)
+
+with open("a_really_long_foo") as foo, open("a_really_long_bar") as bar, open("a_really_long_baz") as baz:
+    pass
+
+sys.exit(
+1
+)
+"#.to_string(), 0);
+
+        let start = document.contents().find("with").unwrap();
+        let end = document.contents().find("pass").unwrap() + "pass".len();
+        let range = TextRange::new(TextSize::try_from(start)?, TextSize::try_from(end)?);
+
+        let per_file_target_version =
+            CompiledPerFileTargetVersionList::resolve(vec![PerFileTargetVersion::new(
+                "test.py".to_string(),
+                PythonVersion::PY310,
+                Some(Path::new(".")),
+            )])
+            .unwrap();
+        let result = format_range(
+            &document,
+            PySourceType::Python,
+            &FormatterSettings {
+                unresolved_target_version: PythonVersion::PY38,
+                per_file_target_version,
+                ..Default::default()
+            },
+            range,
+            Some(Path::new("test.py")),
+        )
+        .expect("Expected no errors when formatting")
+        .expect("Expected formatting changes");
+
+        assert_snapshot!(result.as_code(), @r#"
+        with (
+            open("a_really_long_foo") as foo,
+            open("a_really_long_bar") as bar,
+            open("a_really_long_baz") as baz,
+        ):
+            pass
+        "#);
+
+        // same as above but without the per_file_target_version override
+        let result = format_range(
+            &document,
+            PySourceType::Python,
+            &FormatterSettings {
+                unresolved_target_version: PythonVersion::PY38,
+                ..Default::default()
+            },
+            range,
+            Some(Path::new("test.py")),
+        )
+        .expect("Expected no errors when formatting")
+        .expect("Expected formatting changes");
+
+        assert_snapshot!(result.as_code(), @r#"
+        with open("a_really_long_foo") as foo, open("a_really_long_bar") as bar, open(
+            "a_really_long_baz"
+        ) as baz:
+            pass
+        "#);
+
+        Ok(())
+    }
+}

--- a/crates/ruff_server/src/format.rs
+++ b/crates/ruff_server/src/format.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use ruff_formatter::PrintedRange;
 use ruff_python_ast::PySourceType;
 use ruff_python_formatter::{format_module_source, FormatModuleError};
@@ -10,8 +12,10 @@ pub(crate) fn format(
     document: &TextDocument,
     source_type: PySourceType,
     formatter_settings: &FormatterSettings,
+    path: Option<&Path>,
 ) -> crate::Result<Option<String>> {
-    let format_options = formatter_settings.to_format_options(source_type, document.contents());
+    let format_options =
+        formatter_settings.to_format_options(source_type, document.contents(), path);
     match format_module_source(document.contents(), format_options) {
         Ok(formatted) => {
             let formatted = formatted.into_code();
@@ -36,8 +40,10 @@ pub(crate) fn format_range(
     source_type: PySourceType,
     formatter_settings: &FormatterSettings,
     range: TextRange,
+    path: Option<&Path>,
 ) -> crate::Result<Option<PrintedRange>> {
-    let format_options = formatter_settings.to_format_options(source_type, document.contents());
+    let format_options =
+        formatter_settings.to_format_options(source_type, document.contents(), path);
 
     match ruff_python_formatter::format_range(document.contents(), range, format_options) {
         Ok(formatted) => {

--- a/crates/ruff_server/src/server/api/requests/format.rs
+++ b/crates/ruff_server/src/server/api/requests/format.rs
@@ -85,9 +85,10 @@ fn format_text_document(
     let settings = query.settings();
 
     // If the document is excluded, return early.
-    if let Some(file_path) = query.file_path() {
+    let file_path = query.file_path();
+    if let Some(file_path) = &file_path {
         if is_document_excluded_for_formatting(
-            &file_path,
+            file_path,
             &settings.file_resolver,
             &settings.formatter,
             text_document.language_id(),
@@ -97,8 +98,13 @@ fn format_text_document(
     }
 
     let source = text_document.contents();
-    let formatted = crate::format::format(text_document, query.source_type(), &settings.formatter)
-        .with_failure_code(lsp_server::ErrorCode::InternalError)?;
+    let formatted = crate::format::format(
+        text_document,
+        query.source_type(),
+        &settings.formatter,
+        file_path.as_deref(),
+    )
+    .with_failure_code(lsp_server::ErrorCode::InternalError)?;
     let Some(mut formatted) = formatted else {
         return Ok(None);
     };

--- a/crates/ruff_server/src/server/api/requests/format_range.rs
+++ b/crates/ruff_server/src/server/api/requests/format_range.rs
@@ -49,9 +49,10 @@ fn format_text_document_range(
     let settings = query.settings();
 
     // If the document is excluded, return early.
-    if let Some(file_path) = query.file_path() {
+    let file_path = query.file_path();
+    if let Some(file_path) = &file_path {
         if is_document_excluded_for_formatting(
-            &file_path,
+            file_path,
             &settings.file_resolver,
             &settings.formatter,
             text_document.language_id(),
@@ -68,6 +69,7 @@ fn format_text_document_range(
         query.source_type(),
         &settings.formatter,
         range,
+        file_path.as_deref(),
     )
     .with_failure_code(lsp_server::ErrorCode::InternalError)?;
 

--- a/crates/ruff_wasm/src/lib.rs
+++ b/crates/ruff_wasm/src/lib.rs
@@ -303,7 +303,7 @@ impl<'a> ParsedModule<'a> {
         // TODO(konstin): Add an options for py/pyi to the UI (2/2)
         let options = settings
             .formatter
-            .to_format_options(PySourceType::default(), self.source_code)
+            .to_format_options(PySourceType::default(), self.source_code, None)
             .with_source_map_generation(SourceMapGeneration::Enabled);
 
         format_module_ast(

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -29,8 +29,8 @@ use ruff_linter::rules::{flake8_import_conventions, isort, pycodestyle};
 use ruff_linter::settings::fix_safety_table::FixSafetyTable;
 use ruff_linter::settings::rule_table::RuleTable;
 use ruff_linter::settings::types::{
-    CompiledPerFileIgnoreList, ExtensionMapping, FilePattern, FilePatternSet, OutputFormat,
-    PerFileIgnore, PreviewMode, RequiredVersion, UnsafeFixes,
+    CompiledPerFileIgnoreList, CompiledPerFileVersionList, ExtensionMapping, FilePattern,
+    FilePatternSet, OutputFormat, PerFileIgnore, PreviewMode, RequiredVersion, UnsafeFixes,
 };
 use ruff_linter::settings::{LinterSettings, DEFAULT_SELECTORS, DUMMY_VARIABLE_RGX, TASK_TAGS};
 use ruff_linter::{
@@ -280,7 +280,9 @@ impl Configuration {
                 extension: self.extension.unwrap_or_default(),
                 preview: lint_preview,
                 target_version,
-                per_file_target_version: self.per_file_target_version.unwrap_or_default(),
+                per_file_target_version: CompiledPerFileVersionList::resolve(
+                    self.per_file_target_version.unwrap_or_default(),
+                )?,
                 project_root: project_root.to_path_buf(),
                 allowed_confusables: lint
                     .allowed_confusables

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -175,11 +175,15 @@ impl Configuration {
             PreviewMode::Enabled => ruff_python_formatter::PreviewMode::Enabled,
         };
 
+        let per_file_target_version =
+            CompiledPerFileVersionList::resolve(self.per_file_target_version.unwrap_or_default())?;
+
         let formatter = FormatterSettings {
             exclude: FilePatternSet::try_from_iter(format.exclude.unwrap_or_default())?,
             extension: self.extension.clone().unwrap_or_default(),
             preview: format_preview,
             target_version,
+            per_file_target_version: per_file_target_version.clone(),
             line_width: self
                 .line_length
                 .map_or(format_defaults.line_width, |length| {
@@ -280,9 +284,7 @@ impl Configuration {
                 extension: self.extension.unwrap_or_default(),
                 preview: lint_preview,
                 target_version,
-                per_file_target_version: CompiledPerFileVersionList::resolve(
-                    self.per_file_target_version.unwrap_or_default(),
-                )?,
+                per_file_target_version,
                 project_root: project_root.to_path_buf(),
                 allowed_confusables: lint
                     .allowed_confusables

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -30,8 +30,8 @@ use ruff_linter::settings::fix_safety_table::FixSafetyTable;
 use ruff_linter::settings::rule_table::RuleTable;
 use ruff_linter::settings::types::{
     CompiledPerFileIgnoreList, CompiledPerFileVersionList, ExtensionMapping, FilePattern,
-    FilePatternSet, OutputFormat, PerFileIgnore, PerFileVersion, PreviewMode, RequiredVersion,
-    UnsafeFixes,
+    FilePatternSet, OutputFormat, PerFileIgnore, PerFileTargetVersion, PreviewMode,
+    RequiredVersion, UnsafeFixes,
 };
 use ruff_linter::settings::{LinterSettings, DEFAULT_SELECTORS, DUMMY_VARIABLE_RGX, TASK_TAGS};
 use ruff_linter::{
@@ -139,7 +139,7 @@ pub struct Configuration {
     pub namespace_packages: Option<Vec<PathBuf>>,
     pub src: Option<Vec<PathBuf>>,
     pub target_version: Option<ast::PythonVersion>,
-    pub per_file_target_version: Option<Vec<PerFileVersion>>,
+    pub per_file_target_version: Option<Vec<PerFileTargetVersion>>,
 
     // Global formatting options
     pub line_length: Option<LineLength>,
@@ -544,7 +544,7 @@ impl Configuration {
                 versions
                     .into_iter()
                     .map(|(pattern, version)| {
-                        PerFileVersion::new(
+                        PerFileTargetVersion::new(
                             pattern,
                             ast::PythonVersion::from(version),
                             Some(project_root),

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -9,7 +9,7 @@ use std::num::{NonZeroU16, NonZeroU8};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use glob::{glob, GlobError, Paths, PatternError};
 use itertools::Itertools;
 use regex::Regex;
@@ -177,7 +177,8 @@ impl Configuration {
         };
 
         let per_file_target_version =
-            CompiledPerFileVersionList::resolve(self.per_file_target_version.unwrap_or_default())?;
+            CompiledPerFileVersionList::resolve(self.per_file_target_version.unwrap_or_default())
+                .context("failed to resolve `per-file-target-version` table")?;
 
         let formatter = FormatterSettings {
             exclude: FilePatternSet::try_from_iter(format.exclude.unwrap_or_default())?,

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -184,7 +184,7 @@ impl Configuration {
             exclude: FilePatternSet::try_from_iter(format.exclude.unwrap_or_default())?,
             extension: self.extension.clone().unwrap_or_default(),
             preview: format_preview,
-            target_version,
+            unresolved_target_version: target_version,
             per_file_target_version: per_file_target_version.clone(),
             line_width: self
                 .line_length
@@ -285,7 +285,7 @@ impl Configuration {
                 exclude: FilePatternSet::try_from_iter(lint.exclude.unwrap_or_default())?,
                 extension: self.extension.unwrap_or_default(),
                 preview: lint_preview,
-                target_version,
+                unresolved_target_version: target_version,
                 per_file_target_version,
                 project_root: project_root.to_path_buf(),
                 allowed_confusables: lint

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -29,7 +29,7 @@ use ruff_linter::rules::{flake8_import_conventions, isort, pycodestyle};
 use ruff_linter::settings::fix_safety_table::FixSafetyTable;
 use ruff_linter::settings::rule_table::RuleTable;
 use ruff_linter::settings::types::{
-    CompiledPerFileIgnoreList, CompiledPerFileVersionList, ExtensionMapping, FilePattern,
+    CompiledPerFileIgnoreList, CompiledPerFileTargetVersionList, ExtensionMapping, FilePattern,
     FilePatternSet, OutputFormat, PerFileIgnore, PerFileTargetVersion, PreviewMode,
     RequiredVersion, UnsafeFixes,
 };
@@ -176,9 +176,10 @@ impl Configuration {
             PreviewMode::Enabled => ruff_python_formatter::PreviewMode::Enabled,
         };
 
-        let per_file_target_version =
-            CompiledPerFileVersionList::resolve(self.per_file_target_version.unwrap_or_default())
-                .context("failed to resolve `per-file-target-version` table")?;
+        let per_file_target_version = CompiledPerFileTargetVersionList::resolve(
+            self.per_file_target_version.unwrap_or_default(),
+        )
+        .context("failed to resolve `per-file-target-version` table")?;
 
         let formatter = FormatterSettings {
             exclude: FilePatternSet::try_from_iter(format.exclude.unwrap_or_default())?,

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -333,6 +333,19 @@ pub struct Options {
     )]
     pub target_version: Option<PythonVersion>,
 
+    /// A list of mappings from file pattern to Python version to use when checking the
+    /// corresponding file(s).
+    #[option(
+        default = "{}",
+        value_type = "dict[str, PythonVersion]",
+        scope = "per-file-target-version",
+        example = r#"
+            # Override the project-wide Python version for a developer scripts directory:
+            "scripts/**.py" = "py312"
+        "#
+    )]
+    pub per_file_target_version: Option<FxHashMap<String, PythonVersion>>,
+
     /// The directories to consider when resolving first- vs. third-party
     /// imports.
     ///

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -333,8 +333,18 @@ pub struct Options {
     )]
     pub target_version: Option<PythonVersion>,
 
-    /// A list of mappings from file pattern to Python version to use when checking the
+    /// A list of mappings from glob-style file pattern to Python version to use when checking the
     /// corresponding file(s).
+    ///
+    /// This may be useful for overriding the global Python version settings in `target-version` or
+    /// `requires-python` for a subset of files. For example, if you have a project with a minimum
+    /// supported Python version of 3.9 but a subdirectory of developer scripts that want to use a
+    /// newer feature like the `match` statement from Python 3.10, you can use
+    /// `per-file-target-version` to specify `"developer_scripts/*.py" = "py310"`.
+    ///
+    /// This setting is used by the linter to enforce any enabled version-specific lint rules, as
+    /// well as by the formatter for any version-specific formatting options, such as parenthesizing
+    /// context managers on Python 3.10+.
     #[option(
         default = "{}",
         value_type = "dict[str, PythonVersion]",

--- a/crates/ruff_workspace/src/settings.rs
+++ b/crates/ruff_workspace/src/settings.rs
@@ -262,6 +262,7 @@ impl fmt::Display for FormatterSettings {
             fields = [
                 self.exclude,
                 self.target_version,
+                self.per_file_target_version,
                 self.preview,
                 self.line_width,
                 self.line_ending,

--- a/crates/ruff_workspace/src/settings.rs
+++ b/crates/ruff_workspace/src/settings.rs
@@ -4,7 +4,7 @@ use ruff_formatter::{FormatOptions, IndentStyle, IndentWidth, LineWidth};
 use ruff_graph::AnalyzeSettings;
 use ruff_linter::display_settings;
 use ruff_linter::settings::types::{
-    CompiledPerFileVersionList, ExtensionMapping, FilePattern, FilePatternSet, OutputFormat,
+    CompiledPerFileTargetVersionList, ExtensionMapping, FilePattern, FilePatternSet, OutputFormat,
     UnsafeFixes,
 };
 use ruff_linter::settings::LinterSettings;
@@ -175,7 +175,7 @@ pub struct FormatterSettings {
     /// See [`FormatterSettings::resolve_target_version`] for a way to check a given [`Path`]
     /// against these patterns, while falling back to `unresolved_target_version` if none of them
     /// match.
-    pub per_file_target_version: CompiledPerFileVersionList,
+    pub per_file_target_version: CompiledPerFileTargetVersionList,
 
     pub line_width: LineWidth,
 
@@ -257,7 +257,7 @@ impl Default for FormatterSettings {
             exclude: FilePatternSet::default(),
             extension: ExtensionMapping::default(),
             unresolved_target_version: default_options.target_version(),
-            per_file_target_version: CompiledPerFileVersionList::default(),
+            per_file_target_version: CompiledPerFileTargetVersionList::default(),
             preview: PreviewMode::Disabled,
             line_width: default_options.line_width(),
             line_ending: LineEnding::Auto,

--- a/crates/ruff_workspace/src/settings.rs
+++ b/crates/ruff_workspace/src/settings.rs
@@ -193,7 +193,16 @@ pub struct FormatterSettings {
 }
 
 impl FormatterSettings {
-    pub fn to_format_options(&self, source_type: PySourceType, source: &str) -> PyFormatOptions {
+    pub fn to_format_options(
+        &self,
+        source_type: PySourceType,
+        source: &str,
+        path: Option<&Path>,
+    ) -> PyFormatOptions {
+        let target_version = path
+            .map(|path| self.resolve_target_version(path))
+            .unwrap_or(self.unresolved_target_version);
+
         let line_ending = match self.line_ending {
             LineEnding::Lf => ruff_formatter::printer::LineEnding::LineFeed,
             LineEnding::CrLf => ruff_formatter::printer::LineEnding::CarriageReturnLineFeed,
@@ -216,7 +225,7 @@ impl FormatterSettings {
         };
 
         PyFormatOptions::from_source_type(source_type)
-            .with_target_version(self.unresolved_target_version)
+            .with_target_version(target_version)
             .with_indent_style(self.indent_style)
             .with_indent_width(self.indent_width)
             .with_quote_style(self.quote_style)

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -578,6 +578,16 @@
         }
       }
     },
+    "per-file-target-version": {
+      "description": "A list of mappings from glob-style file pattern to Python version to use when checking the corresponding file(s).\n\nThis may be useful for overriding the global Python version settings in `target-version` or `requires-python` for a subset of files. For example, if you have a project with a minimum supported Python version of 3.9 but a subdirectory of developer scripts that want to use a newer feature like the `match` statement from Python 3.10, you can use `per-file-target-version` to specify `\"developer_scripts/*.py\" = \"py310\"`.\n\nThis setting is used by the linter to enforce any enabled version-specific lint rules, as well as by the formatter for any version-specific formatting options, such as parenthesizing context managers on Python 3.10+.",
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": {
+        "$ref": "#/definitions/PythonVersion"
+      }
+    },
     "preview": {
       "description": "Whether to enable preview mode. When preview mode is enabled, Ruff will use unstable rules, fixes, and formatting.",
       "type": [


### PR DESCRIPTION
## Summary

This PR is another step in preparing to detect syntax errors in the parser. It introduces the new `per-file-target-version` top-level configuration option, which holds a mapping of compiled glob patterns to Python versions. I intend to use the `LinterSettings::resolve_target_version` method here to pass to the parser:

https://github.com/astral-sh/ruff/blob/f50849aeef51a381af6c27df8595ac0e1ef5a891/crates/ruff_linter/src/linter.rs#L491-L493

## Test Plan

I added two new CLI tests to show that the `per-file-target-version` is respected in both the formatter and the linter.