### PR TITLE
Add `ConfigurationPreference::FilesystemOnly`

### DIFF
--- a/crates/ruff_server/src/session/index/ruff_settings.rs
+++ b/crates/ruff_server/src/session/index/ruff_settings.rs
@@ -392,6 +392,7 @@ impl ConfigurationTransformer for EditorConfigurationTransformer<'_> {
                 filesystem_configuration.combine(editor_configuration)
             }
             ConfigurationPreference::EditorOnly => editor_configuration,
+            ConfigurationPreference::FilesystemOnly => filesystem_configuration,
         }
     }
 }

--- a/crates/ruff_server/src/session/settings.rs
+++ b/crates/ruff_server/src/session/settings.rs
@@ -55,6 +55,8 @@ pub(crate) enum ConfigurationPreference {
     FilesystemFirst,
     /// `.toml` files are ignored completely, and only the editor configuration is used.
     EditorOnly,
+    /// The editor configuration is ignored completely, and only `.toml` files are used.
+    FilesystemOnly,
 }
 
 /// This is a direct representation of the settings schema sent by the client.

--- a/docs/editors/settings.md
+++ b/docs/editors/settings.md
@@ -67,10 +67,11 @@ configuration is prioritized over `ruff.toml` and `pyproject.toml` files.
 - `"filesystemFirst"`: Configuration files present in the workspace takes priority over editor
     settings.
 - `"editorOnly"`: Ignore configuration files entirely i.e., only use editor settings.
+- `"filesystemOnly"`: Ignore editor settings entirely i.e., only use configuration files.
 
 **Default value**: `"editorFirst"`
 
-**Type**: `"editorFirst" | "filesystemFirst" | "editorOnly"`
+**Type**: `"editorFirst" | "filesystemFirst" | "editorOnly" | "filesystemOnly"`
 
 **Example usage**:
 


### PR DESCRIPTION
## Summary

Resolves #16209.

When `configurationPreference` is set to `filesystemOnly`, Ruff ignores all editor-level configurations. This is the same as `editorOnly`, but inverted.

## Test Plan

None.
