### PR TITLE
[red-knot] Use salsa query in `Class::own_instance_member`

### DIFF
--- a/crates/red_knot_python_semantic/src/symbol.rs
+++ b/crates/red_knot_python_semantic/src/symbol.rs
@@ -1,5 +1,6 @@
 use ruff_db::files::File;
 use ruff_python_ast as ast;
+use salsa::Update;
 
 use crate::module_resolver::file_to_module;
 use crate::semantic_index::definition::Definition;
@@ -333,7 +334,7 @@ pub(crate) type SymbolFromDeclarationsResult<'db> =
 /// that this comes with a [`CLASS_VAR`] type qualifier.
 ///
 /// [`CLASS_VAR`]: crate::types::TypeQualifiers::CLASS_VAR
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq, Clone, Update)]
 pub(crate) struct SymbolAndQualifiers<'db>(pub(crate) Symbol<'db>, pub(crate) TypeQualifiers);
 
 impl SymbolAndQualifiers<'_> {


### PR DESCRIPTION
## Summary
Fixes https://github.com/astral-sh/ruff/issues/16172

I considered making `member` a query but that has the downside that `name` needs to be a `String` (or at least a `Name`, it can't be a borrowed `&str` because Salsa has to intern the value). 

That's why I opted to make a local query around the specific `own_instance_member` branch that is problematic because it only requires interning `Class` and `ScopedSymbolId`, which should be cheap, considering that both are u32.


## Test Plan

I have to write one of those terrible salsa `did_run_query` tests, ugh
