### PR TITLE
[red-knot] Token system to avoid cross-module query dependencies

### DIFF
--- a/crates/red_knot_python_semantic/src/semantic_index.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index.rs
@@ -492,7 +492,7 @@ mod tests {
 
         let use_def = use_def_map(&db, scope);
         let binding = use_def.first_public_binding(foo).unwrap();
-        assert!(matches!(binding.kind(&db), DefinitionKind::Import(_)));
+        assert!(matches!(binding.kind(&db, file), DefinitionKind::Import(_)));
     }
 
     #[test]
@@ -533,7 +533,10 @@ mod tests {
                     .expect("symbol to exist"),
             )
             .unwrap();
-        assert!(matches!(binding.kind(&db), DefinitionKind::ImportFrom(_)));
+        assert!(matches!(
+            binding.kind(&db, file),
+            DefinitionKind::ImportFrom(_)
+        ));
     }
 
     #[test]
@@ -553,7 +556,10 @@ mod tests {
         let binding = use_def
             .first_public_binding(global_table.symbol_id_by_name("x").expect("symbol exists"))
             .unwrap();
-        assert!(matches!(binding.kind(&db), DefinitionKind::Assignment(_)));
+        assert!(matches!(
+            binding.kind(&db, file),
+            DefinitionKind::Assignment(_)
+        ));
     }
 
     #[test]
@@ -570,7 +576,7 @@ mod tests {
             .unwrap();
 
         assert!(matches!(
-            binding.kind(&db),
+            binding.kind(&db, file),
             DefinitionKind::AugmentedAssignment(_)
         ));
     }
@@ -606,7 +612,10 @@ y = 2
         let binding = use_def
             .first_public_binding(class_table.symbol_id_by_name("x").expect("symbol exists"))
             .unwrap();
-        assert!(matches!(binding.kind(&db), DefinitionKind::Assignment(_)));
+        assert!(matches!(
+            binding.kind(&db, file),
+            DefinitionKind::Assignment(_)
+        ));
     }
 
     #[test]
@@ -643,7 +652,10 @@ y = 2
                     .expect("symbol exists"),
             )
             .unwrap();
-        assert!(matches!(binding.kind(&db), DefinitionKind::Assignment(_)));
+        assert!(matches!(
+            binding.kind(&db, file),
+            DefinitionKind::Assignment(_)
+        ));
     }
 
     #[test]
@@ -682,7 +694,10 @@ def f(a: str, /, b: str, c: int = 1, *args, d: int = 2, **kwargs):
                         .expect("symbol exists"),
                 )
                 .unwrap();
-            assert!(matches!(binding.kind(&db), DefinitionKind::Parameter(_)));
+            assert!(matches!(
+                binding.kind(&db, file),
+                DefinitionKind::Parameter(_)
+            ));
         }
         let args_binding = use_def
             .first_public_binding(
@@ -692,7 +707,7 @@ def f(a: str, /, b: str, c: int = 1, *args, d: int = 2, **kwargs):
             )
             .unwrap();
         assert!(matches!(
-            args_binding.kind(&db),
+            args_binding.kind(&db, file),
             DefinitionKind::VariadicPositionalParameter(_)
         ));
         let kwargs_binding = use_def
@@ -703,7 +718,7 @@ def f(a: str, /, b: str, c: int = 1, *args, d: int = 2, **kwargs):
             )
             .unwrap();
         assert!(matches!(
-            kwargs_binding.kind(&db),
+            kwargs_binding.kind(&db, file),
             DefinitionKind::VariadicKeywordParameter(_)
         ));
     }
@@ -735,7 +750,10 @@ def f(a: str, /, b: str, c: int = 1, *args, d: int = 2, **kwargs):
             let binding = use_def
                 .first_public_binding(lambda_table.symbol_id_by_name(name).expect("symbol exists"))
                 .unwrap();
-            assert!(matches!(binding.kind(&db), DefinitionKind::Parameter(_)));
+            assert!(matches!(
+                binding.kind(&db, file),
+                DefinitionKind::Parameter(_)
+            ));
         }
         let args_binding = use_def
             .first_public_binding(
@@ -745,7 +763,7 @@ def f(a: str, /, b: str, c: int = 1, *args, d: int = 2, **kwargs):
             )
             .unwrap();
         assert!(matches!(
-            args_binding.kind(&db),
+            args_binding.kind(&db, file),
             DefinitionKind::VariadicPositionalParameter(_)
         ));
         let kwargs_binding = use_def
@@ -756,7 +774,7 @@ def f(a: str, /, b: str, c: int = 1, *args, d: int = 2, **kwargs):
             )
             .unwrap();
         assert!(matches!(
-            kwargs_binding.kind(&db),
+            kwargs_binding.kind(&db, file),
             DefinitionKind::VariadicKeywordParameter(_)
         ));
     }
@@ -803,7 +821,7 @@ def f(a: str, /, b: str, c: int = 1, *args, d: int = 2, **kwargs):
                 )
                 .unwrap();
             assert!(matches!(
-                binding.kind(&db),
+                binding.kind(&db, file),
                 DefinitionKind::Comprehension(_)
             ));
         }
@@ -843,7 +861,7 @@ def f(a: str, /, b: str, c: int = 1, *args, d: int = 2, **kwargs):
             element.scoped_use_id(&db, comprehension_scope_id.to_scope_id(&db, file));
 
         let binding = use_def.first_binding_at_use(element_use_id).unwrap();
-        let DefinitionKind::Comprehension(comprehension) = binding.kind(&db) else {
+        let DefinitionKind::Comprehension(comprehension) = binding.kind(&db, file) else {
             panic!("expected generator definition")
         };
         let target = comprehension.target();
@@ -925,7 +943,10 @@ with item1 as x, item2 as y:
             let binding = use_def
                 .first_public_binding(global_table.symbol_id_by_name(name).expect("symbol exists"))
                 .expect("Expected with item definition for {name}");
-            assert!(matches!(binding.kind(&db), DefinitionKind::WithItem(_)));
+            assert!(matches!(
+                binding.kind(&db, file),
+                DefinitionKind::WithItem(_)
+            ));
         }
     }
 
@@ -948,7 +969,10 @@ with context() as (x, y):
             let binding = use_def
                 .first_public_binding(global_table.symbol_id_by_name(name).expect("symbol exists"))
                 .expect("Expected with item definition for {name}");
-            assert!(matches!(binding.kind(&db), DefinitionKind::WithItem(_)));
+            assert!(matches!(
+                binding.kind(&db, file),
+                DefinitionKind::WithItem(_)
+            ));
         }
     }
 
@@ -992,7 +1016,10 @@ def func():
                     .expect("symbol exists"),
             )
             .unwrap();
-        assert!(matches!(binding.kind(&db), DefinitionKind::Function(_)));
+        assert!(matches!(
+            binding.kind(&db, file),
+            DefinitionKind::Function(_)
+        ));
     }
 
     #[test]
@@ -1093,7 +1120,7 @@ class C[T]:
         let x_use_id = x_use_expr_name.scoped_use_id(&db, scope);
         let use_def = use_def_map(&db, scope);
         let binding = use_def.first_binding_at_use(x_use_id).unwrap();
-        let DefinitionKind::Assignment(assignment) = binding.kind(&db) else {
+        let DefinitionKind::Assignment(assignment) = binding.kind(&db, file) else {
             panic!("should be an assignment definition")
         };
         let ast::Expr::NumberLiteral(ast::ExprNumberLiteral {
@@ -1226,7 +1253,7 @@ match subject:
             let binding = use_def
                 .first_public_binding(global_table.symbol_id_by_name(name).expect("symbol exists"))
                 .expect("Expected with item definition for {name}");
-            if let DefinitionKind::MatchPattern(pattern) = binding.kind(&db) {
+            if let DefinitionKind::MatchPattern(pattern) = binding.kind(&db, file) {
                 assert_eq!(pattern.index(), expected_index);
             } else {
                 panic!("Expected match pattern definition for {name}");
@@ -1256,7 +1283,7 @@ match 1:
             let binding = use_def
                 .first_public_binding(global_table.symbol_id_by_name(name).expect("symbol exists"))
                 .expect("Expected with item definition for {name}");
-            if let DefinitionKind::MatchPattern(pattern) = binding.kind(&db) {
+            if let DefinitionKind::MatchPattern(pattern) = binding.kind(&db, file) {
                 assert_eq!(pattern.index(), expected_index);
             } else {
                 panic!("Expected match pattern definition for {name}");
@@ -1277,7 +1304,7 @@ match 1:
             .first_public_binding(global_table.symbol_id_by_name("x").unwrap())
             .unwrap();
 
-        assert!(matches!(binding.kind(&db), DefinitionKind::For(_)));
+        assert!(matches!(binding.kind(&db, file), DefinitionKind::For(_)));
     }
 
     #[test]
@@ -1296,8 +1323,8 @@ match 1:
             .first_public_binding(global_table.symbol_id_by_name("y").unwrap())
             .unwrap();
 
-        assert!(matches!(x_binding.kind(&db), DefinitionKind::For(_)));
-        assert!(matches!(y_binding.kind(&db), DefinitionKind::For(_)));
+        assert!(matches!(x_binding.kind(&db, file), DefinitionKind::For(_)));
+        assert!(matches!(y_binding.kind(&db, file), DefinitionKind::For(_)));
     }
 
     #[test]
@@ -1313,6 +1340,6 @@ match 1:
             .first_public_binding(global_table.symbol_id_by_name("a").unwrap())
             .unwrap();
 
-        assert!(matches!(binding.kind(&db), DefinitionKind::For(_)));
+        assert!(matches!(binding.kind(&db, file), DefinitionKind::For(_)));
     }
 }

--- a/crates/red_knot_python_semantic/src/types/call/bind.rs
+++ b/crates/red_knot_python_semantic/src/types/call/bind.rs
@@ -315,7 +315,7 @@ impl<'db> CallBindingError<'db> {
                 if let Some(func_lit) = callable_ty.into_function_literal() {
                     let func_lit_scope = func_lit.body_scope(context.db());
                     let mut span = Span::from(func_lit_scope.file(context.db()));
-                    let node = func_lit_scope.node(context.db());
+                    let node = func_lit_scope.node_unchecked(context.db());
                     if let Some(func_def) = node.as_function() {
                         let range = func_def
                             .parameters

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -547,7 +547,7 @@ impl<'db> TypeInferenceBuilder<'db> {
     }
 
     fn infer_region_scope(&mut self, scope: ScopeId<'db>) {
-        let node = scope.node(self.db());
+        let node = scope.node(self.db(), self.file());
         match node {
             NodeWithScopeKind::Module => {
                 let parsed = parsed_module(self.db().upcast(), self.file());
@@ -3539,7 +3539,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             // a local variable or not in function-like scopes. If a variable has any bindings in a
             // function-like scope, it is considered a local variable; it never references another
             // scope. (At runtime, it would use the `LOAD_FAST` opcode.)
-            if has_bindings_in_this_scope && scope.is_function_like(db) {
+            if has_bindings_in_this_scope && scope.is_function_like(db, self.file()) {
                 return Symbol::Unbound;
             }
 
@@ -3554,7 +3554,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 // scope differently (because an unbound name there falls back to builtins), so
                 // check only function-like scopes.
                 let enclosing_scope_id = enclosing_scope_file_id.to_scope_id(db, current_file);
-                if !enclosing_scope_id.is_function_like(db) {
+                if !enclosing_scope_id.is_function_like(db, self.file()) {
                     continue;
                 }
 

--- a/crates/red_knot_python_semantic/src/types/narrow.rs
+++ b/crates/red_knot_python_semantic/src/types/narrow.rs
@@ -248,6 +248,9 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
         symbol_table(self.db, self.scope())
     }
 
+    /// Returns the `constraint`'s scope.
+    ///
+    /// This is also the scope of the enclosing salsa query.
     fn scope(&self) -> ScopeId<'db> {
         match self.constraint {
             ConstraintNode::Expression(expression) => expression.scope(self.db),

--- a/crates/red_knot_python_semantic/src/types/narrow.rs
+++ b/crates/red_knot_python_semantic/src/types/narrow.rs
@@ -199,7 +199,9 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
         expression: Expression<'db>,
         is_positive: bool,
     ) -> Option<NarrowingConstraints<'db>> {
-        let expression_node = expression.node_ref(self.db).node();
+        let expression_node = expression
+            .node_ref(self.db, self.scope().file(self.db))
+            .node();
         self.evaluate_expression_node_constraint(expression_node, expression, is_positive)
     }
 
@@ -473,7 +475,10 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
         subject: Expression<'db>,
         singleton: ast::Singleton,
     ) -> Option<NarrowingConstraints<'db>> {
-        if let Some(ast::ExprName { id, .. }) = subject.node_ref(self.db).as_name_expr() {
+        if let Some(ast::ExprName { id, .. }) = subject
+            .node_ref(self.db, self.scope().file(self.db))
+            .as_name_expr()
+        {
             // SAFETY: we should always have a symbol for every Name node.
             let symbol = self.symbols().symbol_id_by_name(id).unwrap();
 
@@ -495,10 +500,14 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
         subject: Expression<'db>,
         cls: Expression<'db>,
     ) -> Option<NarrowingConstraints<'db>> {
-        if let Some(ast::ExprName { id, .. }) = subject.node_ref(self.db).as_name_expr() {
+        if let Some(ast::ExprName { id, .. }) = subject
+            .node_ref(self.db, self.scope().file(self.db))
+            .as_name_expr()
+        {
             // SAFETY: we should always have a symbol for every Name node.
             let symbol = self.symbols().symbol_id_by_name(id).unwrap();
-            let ty = infer_same_file_expression_type(self.db, cls).to_instance(self.db);
+            let ty = infer_same_file_expression_type(self.db, cls, self.scope().file(self.db))
+                .to_instance(self.db);
 
             let mut constraints = NarrowingConstraints::default();
             constraints.insert(symbol, ty);

--- a/crates/red_knot_python_semantic/src/types/unpacker.rs
+++ b/crates/red_knot_python_semantic/src/types/unpacker.rs
@@ -49,7 +49,7 @@ impl<'db> Unpacker<'db> {
             && self.context.in_stub()
             && value
                 .expression()
-                .node_ref(self.db())
+                .node_ref(self.db(), self.scope.file(self.db()))
                 .is_ellipsis_literal_expr()
         {
             value_ty = Type::unknown();
@@ -57,12 +57,17 @@ impl<'db> Unpacker<'db> {
         if value.is_iterable() {
             // If the value is an iterable, then the type that needs to be unpacked is the iterator
             // type.
-            value_ty = value_ty
-                .iterate(self.db())
-                .unwrap_with_diagnostic(&self.context, value.as_any_node_ref(self.db()));
+            value_ty = value_ty.iterate(self.db()).unwrap_with_diagnostic(
+                &self.context,
+                value.as_any_node_ref(self.db(), self.scope.file(self.db())),
+            );
         }
 
-        self.unpack_inner(target, value.as_any_node_ref(self.db()), value_ty);
+        self.unpack_inner(
+            target,
+            value.as_any_node_ref(self.db(), self.scope.file(self.db())),
+            value_ty,
+        );
     }
 
     fn unpack_inner(


### PR DESCRIPTION
## Summary

This PR introduces a token based system to reduce accidental cross-module query dependencies. 

The basic idea is that we create a custom accessor for tracked struct fields that return an `AstNodeRef` and require an extra `query_file: File` argument. 
The `query_file` is the file of the enclosing query and we compare it against the tracked struct's scope to ensure it is the same. 

The basic idea here is: You should probably not access the node if don't know in which context your query runs or wrap your code in an extra query. 


Getting the file should generally be easy. E.g. `TypeInferenceBuilder` has a `file` method. 

This system doesn't prevent abuse. It's normally easy to get the correct file. E.g. you can call `definition.scope(db).file(db)` to get the file
but let's not do that ;). 

The main downside of this approach is that it's sort of annoying. But I take that for extra peace of mind.


This should mitigate/fix https://github.com/astral-sh/ty/issues/208


## Alternative approach

I considered changing `AstNodeRef::node` to take a `File` instead. But that quickly became annoying because we'd lose the `Deref` and `Debug` would also need a workaround. It also isn't `AstNodeRef::node` that's the problem, it's accessing the field on the tracked struct. That's why I opted for the custom-accessor on the tracked struct approach.

The ideal solution is to solve this problem by restructuring our modules and enforce it with visibility constraints but that's a bit more work.