### PR TITLE
Specify the `wasm-pack` version for release workflows

### DIFF
--- a/.github/workflows/publish-playground.yml
+++ b/.github/workflows/publish-playground.yml
@@ -35,6 +35,8 @@ jobs:
           cache: "npm"
           cache-dependency-path: playground/package-lock.json
       - uses: jetli/wasm-pack-action@v0.4.0
+        with:
+          version: v0.13.1
       - uses: jetli/wasm-bindgen-action@v0.2.0
       - name: "Run wasm-pack"
         run: wasm-pack build --target web --out-dir ../../playground/src/pkg crates/ruff_wasm

--- a/.github/workflows/publish-wasm.yml
+++ b/.github/workflows/publish-wasm.yml
@@ -35,6 +35,8 @@ jobs:
       - name: "Install Rust toolchain"
         run: rustup target add wasm32-unknown-unknown
       - uses: jetli/wasm-pack-action@v0.4.0
+        with:
+          version: v0.13.1
       - uses: jetli/wasm-bindgen-action@v0.2.0
       - name: "Run wasm-pack build"
         run: wasm-pack build --target ${{ matrix.target }} crates/ruff_wasm


### PR DESCRIPTION
This PR uses the same version specified in https://github.com/astral-sh/ruff/pull/14465 for the CI workflow to prevent random versions from being pulled like in the 0.9.7 [release](https://github.com/astral-sh/ruff/actions/runs/13436100909/job/37539387595).
