### PR TITLE
[red-knot] Fix subtle detail in where the `types.ModuleType` attribute lookup should happen in `TypeInferenceBuilder::infer_name_load()`

### DIFF
--- a/crates/red_knot_python_semantic/src/symbol.rs
+++ b/crates/red_knot_python_semantic/src/symbol.rs
@@ -846,4 +846,37 @@ mod tests {
         let property_symbol_name = ast::name::Name::new_static("property");
         assert!(!symbol_names.contains(&property_symbol_name));
     }
+
+    #[track_caller]
+    fn assert_bound_string_symbol<'db>(db: &'db dyn Db, symbol: Symbol<'db>) {
+        assert!(matches!(
+            symbol,
+            Symbol::Type(Type::Instance(_), Boundness::Bound)
+        ));
+        assert_eq!(symbol.expect_type(), KnownClass::Str.to_instance(db));
+    }
+
+    #[test]
+    fn implicit_builtin_globals() {
+        let db = setup_db();
+        assert_bound_string_symbol(&db, builtins_symbol(&db, "__name__"));
+    }
+
+    #[test]
+    fn implicit_typing_globals() {
+        let db = setup_db();
+        assert_bound_string_symbol(&db, typing_symbol(&db, "__name__"));
+    }
+
+    #[test]
+    fn implicit_typing_extensions_globals() {
+        let db = setup_db();
+        assert_bound_string_symbol(&db, typing_extensions_symbol(&db, "__name__"));
+    }
+
+    #[test]
+    fn implicit_sys_globals() {
+        let db = setup_db();
+        assert_bound_string_symbol(&db, known_module_symbol(&db, KnownModule::Sys, "__name__"));
+    }
 }

--- a/crates/red_knot_python_semantic/src/symbol.rs
+++ b/crates/red_knot_python_semantic/src/symbol.rs
@@ -234,14 +234,7 @@ pub(crate) fn imported_symbol<'db>(db: &'db dyn Db, module: &Module, name: &str)
 /// (e.g. `from builtins import int`).
 pub(crate) fn builtins_symbol<'db>(db: &'db dyn Db, symbol: &str) -> Symbol<'db> {
     resolve_module(db, &KnownModule::Builtins.name())
-        .map(|module| {
-            external_symbol_impl(db, module.file(), symbol).or_fall_back_to(db, || {
-                // We're looking up in the builtins namespace and not the module, so we should
-                // do the normal lookup in `types.ModuleType` and not the special one as in
-                // `imported_symbol`.
-                module_type_symbol(db, symbol)
-            })
-        })
+        .map(|module| external_symbol_impl(db, module.file(), symbol))
         .unwrap_or(Symbol::Unbound)
 }
 

--- a/crates/red_knot_python_semantic/src/symbol.rs
+++ b/crates/red_knot_python_semantic/src/symbol.rs
@@ -248,7 +248,14 @@ pub(crate) fn imported_symbol<'db>(db: &'db dyn Db, module: &Module, name: &str)
 /// (e.g. `from builtins import int`).
 pub(crate) fn builtins_symbol<'db>(db: &'db dyn Db, symbol: &str) -> Symbol<'db> {
     resolve_module(db, &KnownModule::Builtins.name())
-        .map(|module| external_symbol_impl(db, module.file(), symbol))
+        .map(|module| {
+            external_symbol_impl(db, module.file(), symbol).or_fall_back_to(db, || {
+                // We're looking up in the builtins namespace and not the module, so we should
+                // do the normal lookup in `types.ModuleType` and not the special one as in
+                // `imported_symbol`.
+                module_type_implicit_global_symbol(db, symbol)
+            })
+        })
         .unwrap_or(Symbol::Unbound)
 }
 

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -33,8 +33,8 @@ use crate::semantic_index::{
 };
 use crate::suppression::check_suppressions;
 use crate::symbol::{
-    global_symbol, imported_symbol, known_module_symbol, symbol, symbol_from_bindings,
-    symbol_from_declarations, Boundness, LookupError, LookupResult, Symbol, SymbolAndQualifiers,
+    imported_symbol, known_module_symbol, symbol, symbol_from_bindings, symbol_from_declarations,
+    Boundness, LookupError, LookupResult, Symbol, SymbolAndQualifiers,
 };
 use crate::types::call::{bind_call, CallArguments, CallBinding, CallOutcome};
 use crate::types::class_base::ClassBase;
@@ -4479,7 +4479,7 @@ static_assertions::assert_eq_size!(Type, [u8; 16]);
 pub(crate) mod tests {
     use super::*;
     use crate::db::tests::{setup_db, TestDbBuilder};
-    use crate::symbol::{typing_extensions_symbol, typing_symbol};
+    use crate::symbol::{global_symbol, typing_extensions_symbol, typing_symbol};
     use ruff_db::files::system_path_to_file;
     use ruff_db::parsed::parsed_module;
     use ruff_db::system::DbWithTestSystem;

--- a/crates/red_knot_python_semantic/src/types/signatures.rs
+++ b/crates/red_knot_python_semantic/src/types/signatures.rs
@@ -322,7 +322,8 @@ pub(crate) enum ParameterKind<'db> {
 mod tests {
     use super::*;
     use crate::db::tests::{setup_db, TestDb};
-    use crate::types::{global_symbol, FunctionType, KnownClass};
+    use crate::symbol::global_symbol;
+    use crate::types::{FunctionType, KnownClass};
     use ruff_db::system::DbWithTestSystem;
 
     #[track_caller]


### PR DESCRIPTION
## Summary

This PR fixes a "bug" where we got to the right answer... but for the wrong reasons 😄

It is best reviewed commit by commit.:
1. The first commit "breaks" things by removing the code that was allowing us to achieve the right answer for the wrong reasons.
2. The second commit fixes things again by making us get to the right answer for the right reasons
3. The third commit adds more unit tests
4. The fourth commit makes the new unit tests pass by reverting the first commit

## Description of the bug

In code like this, we were correctly inferring that the `__name__` symbol was bound:

```py
print(__name__)
```

However, we were only considering it bound because of the fact that the call `builtins_symbol(db, "__name__")` (the _last_ fallback in the chain of fallbacks in `TypeInferenceBuilder::infer_name_load()`) returns a bound symbol -- in other words, we were considering that `__name__` here was a builtin symbol. That's incorrect: every module has its own `__name__` symbol, meaning that although there _is_ a `__name__` symbol in Python's builtins scope, it is almost always shadowed by the `__name__` symbol in other modules' global scopes. The reason why we were not understanding that there was a global-scope `__name__` symbol here is that although we have a `ModuleType`-attribute fallback in the `global_symbol` call at the last line here, we fail to get there if we exit early due to the `if file_scope_id.is_global()` early return at the start of the closure:

https://github.com/astral-sh/ruff/blob/470f852f04f0e4284c78d15ce81637540e127558/crates/red_knot_python_semantic/src/types/infer.rs#L3576-L3592

In other words, we only did the `ModuleType`-attribute fallback if we doing name lookup from an inner scope -- we were skipping it if we were doing name lookup from the global scope itself. 

(This bug has existed for a while -- it was already there in https://github.com/astral-sh/ruff/blob/4941975e744309972a03f7ee5a9a7b9083362c3c/crates/red_knot_python_semantic/src/types/infer.rs, for example.)

## Does this matter?

Right now? Maybe not... but it might do later. For example, we don't yet model the effect of `del` statements on bindings. For a normal symbol in a global scope, once it's been deleted, you can't access it:

```pycon
>>> FOO = 42
>>> del FOO
>>> FOO
Traceback (most recent call last):
  File "<python-input-2>", line 1, in <module>
    FOO
NameError: name 'FOO' is not defined
```

But that's not true for `__name__`, because it exists as both a symbol in the current global scope and a symbol in the builtins scope:

```pycon
>>> __name__
'__main__'
>>> del __name__
>>> __name__
'builtins'
```

I'd also just prefer to _get this right_. It's quite confusing to me that we currently only recognise these symbols as being bound because we erroneously consider them builtins even when they're shadowed by implicit globals. This PR fixes things so that we accurately model the semantics.

## Implementation

The semantics are now modeled correctly by splitting the `global_symbol` function into two functions: `explicit_global_symbol` (which does _not_ consider implicit globals such as `__name__`, `__doc__`, etc.) and `global_symbol`, which wraps `explicit_global_symbol` but adds the fallback to the implicit globals.

`global_symbol()` actually becomes test-only, because it is now unused in production code. `TypeInferenceBuilder::infer_name_load()` uses `explicit_global_symbol()` in the location it currently uses `global_symbol`, and we now, er, _explicitly_ fallback to the _implicit_ globals as a standalone step in `TypeInferenceBuilder::infer_name_load()`. 

## Test Plan

- All existing tests pass
- New unit tests added to `symbol.rs`
