### PR TITLE
Auto generate ast expression nodes

### DIFF
--- a/crates/ruff_python_ast/ast.toml
+++ b/crates/ruff_python_ast/ast.toml
@@ -112,7 +112,7 @@ fields = [
 [Expr.nodes.ExprLambda]
 doc = "See also [Lambda](https://docs.python.org/3/library/ast.html#ast.Lambda)"
 fields = [
-  { name = "parameters", type = "Parameters?" },
+  { name = "parameters", type = "Box<crate::Parameters>?" },
   { name = "body", type = "Expr" }
 ]
 

--- a/crates/ruff_python_ast/ast.toml
+++ b/crates/ruff_python_ast/ast.toml
@@ -80,130 +80,314 @@ add_suffix_to_is_methods = true
 anynode_is_label = "expression"
 rustdoc = "/// See also [expr](https://docs.python.org/3/library/ast.html#ast.expr)"
 
-[Expr.nodes]
-ExprBoolOp = { fields = [
-    { name = "op", type = "BoolOp" },
-    { name = "values", type = "Expr", seq = true }
-]}
-ExprNamed = { fields = [
-    { name = "target", type = "Expr" },
-    { name = "value", type = "Expr" }
-]}
-ExprBinOp = { fields = [
-    { name = "left", type = "Expr" },
-    { name = "op", type = "Operator" },
-    { name = "right", type = "Expr" }
-]}
-ExprUnaryOp = { fields = [
-    { name = "op", type = "UnaryOp" },
-    { name = "operand", type = "Expr" }
-]}
-ExprLambda = { fields = [
-    { name = "parameters", type = "Box<crate::Parameters>", optional = true },
-    { name = "body", type = "Expr" }
-]}
-ExprIf = { fields = [
-    { name = "test", type = "Expr" },
-    { name = "body", type = "Expr" },
-    { name = "orelse", type = "Expr" }
-]}
-ExprDict = { fields = [
-    { name = "items", type = "DictItem", seq = true },
-]}
-ExprSet = { fields = [
-    { name = "elts", type = "Expr", seq = true }
-]}
-ExprListComp = { fields = [
-    { name = "elt", type = "Expr" },
-    { name = "generators", type = "Comprehension", seq = true }
-]}
-ExprSetComp = { fields = [
-    { name = "elt", type = "Expr" },
-    { name = "generators", type = "Comprehension", seq = true }
-]}
-ExprDictComp = { fields = [
-    { name = "key", type = "Expr" },
-    { name = "value", type = "Expr" },
-    { name = "generators", type = "Comprehension", seq = true }
-]}
-ExprGenerator = { fields = [
-    { name = "elt", type = "Expr" },
-    { name = "generators", type = "Comprehension", seq = true },
-    { name = "parenthesized", type = "bool" }
-]}
-ExprAwait = { fields = [
-    { name = "value", type = "Expr" }
-]}
-ExprYield = { fields = [
-    { name = "value", type = "Expr", optional = true }
-]}
-ExprYieldFrom = { fields = [
-    { name = "value", type = "Expr" }
-]}
-ExprCompare = { fields = [
-    { name = "left", type = "Expr" },
-    # TODO: We don't want this field to be a vec hence the seq is not enabled.
-    { name = "ops", type = "Box<[crate::CmpOp]>"},
-    { name = "comparators", type = "Box<[Expr]>"}
-]}
-ExprCall = { fields = [
-    { name = "func", type = "Expr" },
-    { name = "arguments", type = "Arguments"}
-]}
-ExprFString = { fields = [
-    { name = "value", type = "FStringValue" }
-]}
-ExprStringLiteral = { fields = [
-    { name = "value", type = "StringLiteralValue" }
-]}
-ExprBytesLiteral = { fields = [
-    { name = "value", type = "BytesLiteralValue" }
-]}
-ExprNumberLiteral = { fields = [
-    { name = "value", type = "Number" }
-]}
-ExprBooleanLiteral = { fields = [
-    { name = "value", type = "bool" }
-], derives = ["Default"]}
-ExprNoneLiteral = { fields = [], derives = ["Default"]}
-ExprEllipsisLiteral = { fields = [], derives = ["Default"]}
-ExprAttribute = { fields = [
-    { name = "value", type = "Expr" },
-    { name = "attr", type = "Identifier" },
-    { name = "ctx", type = "ExprContext" }
-]}
-ExprSubscript = { fields = [
-    { name = "value", type = "Expr" },
-    { name = "slice", type = "Expr" },
-    { name = "ctx", type = "ExprContext" }
-]}
-ExprStarred = { fields = [
-    { name = "value", type = "Expr" },
-    { name = "ctx", type = "ExprContext" }
-]}
-ExprName = { fields = [
-    { name = "id", type = "name::Name" },
-    { name = "ctx", type = "ExprContext" }
-]}
-ExprList = { fields = [
-    { name = "elts", type = "Expr", seq = true },
-    { name = "ctx", type = "ExprContext" }
-]}
-ExprTuple = { fields = [
-    { name = "elts", type = "Expr", seq = true },
-    { name = "ctx", type = "ExprContext" },
-    { name = "parenthesized", type = "bool" }
-]}
-ExprSlice = { fields = [
-    { name = "lower", type = "Expr", optional = true },
-    { name = "upper", type = "Expr", optional = true },
-    { name = "step", type = "Expr", optional = true }
-]}
-ExprIpyEscapeCommand = { fields = [
-    { name = "kind", type = "IpyEscapeKind" },
-    { name = "value", type = "Box<str>" }
+# See also [BoolOp](https://docs.python.org/3/library/ast.html#ast.BoolOp)
+[[Expr.nodes.ExprBoolOp.fields]]
+name = "op"
+type = "BoolOp"
 
-]}
+[[Expr.nodes.ExprBoolOp.fields]]
+name = "values"
+type = "Expr"
+seq = true
+
+# See also [NamedExpr](https://docs.python.org/3/library/ast.html#ast.NamedExpr)
+[[Expr.nodes.ExprNamed.fields]]
+name = "target"
+type = "Expr"
+
+[[Expr.nodes.ExprNamed.fields]]
+name = "value"
+type = "Expr"
+
+# See also [BinOp](https://docs.python.org/3/library/ast.html#ast.BinOp)
+[[Expr.nodes.ExprBinOp.fields]]
+name = "left"
+type = "Expr"
+
+[[Expr.nodes.ExprBinOp.fields]]
+name = "op"
+type = "Operator"
+
+[[Expr.nodes.ExprBinOp.fields]]
+name = "right"
+type = "Expr"
+
+# See also [UnaryOp](https://docs.python.org/3/library/ast.html#ast.UnaryOp)
+[[Expr.nodes.ExprUnaryOp.fields]]
+name = "op"
+type = "UnaryOp"
+
+[[Expr.nodes.ExprUnaryOp.fields]]
+name = "operand"
+type = "Expr"
+
+# See also [Lambda](https://docs.python.org/3/library/ast.html#ast.Lambda)
+[[Expr.nodes.ExprLambda.fields]]
+name = "parameters"
+type = "Box<crate::Parameters>"
+optional = true
+
+[[Expr.nodes.ExprLambda.fields]]
+name = "body"
+type = "Expr"
+
+# See also [IfExp](https://docs.python.org/3/library/ast.html#ast.IfExp)
+[[Expr.nodes.ExprIf.fields]]
+name = "test"
+type = "Expr"
+
+[[Expr.nodes.ExprIf.fields]]
+name = "body"
+type = "Expr"
+
+[[Expr.nodes.ExprIf.fields]]
+name = "orelse"
+type = "Expr"
+
+# See also [Dict](https://docs.python.org/3/library/ast.html#ast.Dict)
+[[Expr.nodes.ExprDict.fields]]
+name = "items"
+type = "DictItem"
+seq = true
+
+# See also [Set](https://docs.python.org/3/library/ast.html#ast.Set)
+[[Expr.nodes.ExprSet.fields]]
+name = "elts"
+type = "Expr"
+seq = true
+
+# See also [ListComp](https://docs.python.org/3/library/ast.html#ast.ListComp)
+[[Expr.nodes.ExprListComp.fields]]
+name = "elt"
+type = "Expr"
+
+[[Expr.nodes.ExprListComp.fields]]
+name = "generators"
+type = "Comprehension"
+seq = true
+
+# See also [SetComp](https://docs.python.org/3/library/ast.html#ast.SetComp)
+[[Expr.nodes.ExprSetComp.fields]]
+name = "elt"
+type = "Expr"
+
+[[Expr.nodes.ExprSetComp.fields]]
+name = "generators"
+type = "Comprehension"
+seq = true
+
+# See also [DictComp](https://docs.python.org/3/library/ast.html#ast.DictComp)
+[[Expr.nodes.ExprDictComp.fields]]
+name = "key"
+type = "Expr"
+
+[[Expr.nodes.ExprDictComp.fields]]
+name = "value"
+type = "Expr"
+
+[[Expr.nodes.ExprDictComp.fields]]
+name = "generators"
+type = "Comprehension"
+seq = true
+
+# See also [GeneratorExp](https://docs.python.org/3/library/ast.html#ast.GeneratorExp)
+[[Expr.nodes.ExprGenerator.fields]]
+name = "elt"
+type = "Expr"
+
+[[Expr.nodes.ExprGenerator.fields]]
+name = "generators"
+type = "Comprehension"
+seq = true
+
+[[Expr.nodes.ExprGenerator.fields]]
+name = "parenthesized"
+type = "bool"
+
+# See also [Await](https://docs.python.org/3/library/ast.html#ast.Await)
+[[Expr.nodes.ExprAwait.fields]]
+name = "value"
+type = "Expr"
+
+# See also [Yield](https://docs.python.org/3/library/ast.html#ast.Yield)
+[[Expr.nodes.ExprYield.fields]]
+name = "value"
+type = "Expr"
+optional = true
+
+# See also [YieldFrom](https://docs.python.org/3/library/ast.html#ast.YieldFrom)
+[[Expr.nodes.ExprYieldFrom.fields]]
+name = "value"
+type = "Expr"
+
+# See also [Compare](https://docs.python.org/3/library/ast.html#ast.Compare)
+[[Expr.nodes.ExprCompare.fields]]
+name = "left"
+type = "Expr"
+
+[[Expr.nodes.ExprCompare.fields]]
+name = "ops"
+type = "Box<[crate::CmpOp]>"
+
+[[Expr.nodes.ExprCompare.fields]]
+name = "comparators"
+type = "Box<[Expr]>"
+
+# See also [Call](https://docs.python.org/3/library/ast.html#ast.Call)
+[[Expr.nodes.ExprCall.fields]]
+name = "func"
+type = "Expr"
+
+[[Expr.nodes.ExprCall.fields]]
+name = "arguments"
+type = "Arguments"
+
+# An AST node that represents either a single-part f-string literal
+# or an implicitly concatenated f-string literal.
+#
+# This type differs from the original Python AST ([JoinedStr]) in that it
+# doesn't join the implicitly concatenated parts into a single string. Instead,
+# it keeps them separate and provide various methods to access the parts.
+#
+# [JoinedStr]: https://docs.python.org/3/library/ast.html#ast.JoinedStr
+[[Expr.nodes.ExprFString.fields]]
+name = "value"
+type = "FStringValue"
+
+# An AST node that represents either a single-part string literal
+# or an implicitly concatenated string literal.
+[[Expr.nodes.ExprStringLiteral.fields]]
+name = "value"
+type = "StringLiteralValue"
+
+# An AST node that represents either a single-part bytestring literal
+# or an implicitly concatenated bytestring literal.
+[[Expr.nodes.ExprBytesLiteral.fields]]
+name = "value"
+type = "BytesLiteralValue"
+
+[[Expr.nodes.ExprNumberLiteral.fields]]
+name = "value"
+type = "Number"
+
+[[Expr.nodes.ExprBooleanLiteral.fields]]
+name = "value"
+type = "bool"
+
+[Expr.nodes.ExprBooleanLiteral]
+derives = ["Default"]
+
+[Expr.nodes.ExprNoneLiteral]
+fields = []
+derives = ["Default"]
+
+[Expr.nodes.ExprEllipsisLiteral]
+fields = []
+derives = ["Default"]
+
+# See also [Attribute](https://docs.python.org/3/library/ast.html#ast.Attribute)
+[[Expr.nodes.ExprAttribute.fields]]
+name = "value"
+type = "Expr"
+
+[[Expr.nodes.ExprAttribute.fields]]
+name = "attr"
+type = "Identifier"
+
+[[Expr.nodes.ExprAttribute.fields]]
+name = "ctx"
+type = "ExprContext"
+
+# See also [Subscript](https://docs.python.org/3/library/ast.html#ast.Subscript)
+[[Expr.nodes.ExprSubscript.fields]]
+name = "value"
+type = "Expr"
+
+[[Expr.nodes.ExprSubscript.fields]]
+name = "slice"
+type = "Expr"
+
+[[Expr.nodes.ExprSubscript.fields]]
+name = "ctx"
+type = "ExprContext"
+
+# See also [Starred](https://docs.python.org/3/library/ast.html#ast.Starred)
+[[Expr.nodes.ExprStarred.fields]]
+name = "value"
+type = "Expr"
+
+[[Expr.nodes.ExprStarred.fields]]
+name = "ctx"
+type = "ExprContext"
+
+# See also [Name](https://docs.python.org/3/library/ast.html#ast.Name)
+[[Expr.nodes.ExprName.fields]]
+name = "id"
+type = "Name"
+
+[[Expr.nodes.ExprName.fields]]
+name = "ctx"
+type = "ExprContext"
+
+# See also [List](https://docs.python.org/3/library/ast.html#ast.List)
+[[Expr.nodes.ExprList.fields]]
+name = "elts"
+type = "Expr"
+seq = true
+
+[[Expr.nodes.ExprList.fields]]
+name = "ctx"
+type = "ExprContext"
+
+# See also [Tuple](https://docs.python.org/3/library/ast.html#ast.Tuple)
+[[Expr.nodes.ExprTuple.fields]]
+name = "elts"
+type = "Expr"
+seq = true
+
+[[Expr.nodes.ExprTuple.fields]]
+name = "ctx"
+type = "ExprContext"
+
+[[Expr.nodes.ExprTuple.fields]]
+name = "parenthesized"
+type = "bool"
+
+# See also [Slice](https://docs.python.org/3/library/ast.html#ast.Slice)
+[[Expr.nodes.ExprSlice.fields]]
+name = "lower"
+type = "Expr"
+optional = true
+
+[[Expr.nodes.ExprSlice.fields]]
+name = "upper"
+type = "Expr"
+optional = true
+
+[[Expr.nodes.ExprSlice.fields]]
+name = "step"
+type = "Expr"
+optional = true
+
+#  An AST node used to represent a IPython escape command at the expression level.
+#
+#  For example,
+#  ```python
+#  dir = !pwd
+#  ```
+#
+#  Here, the escape kind can only be `!` or `%` otherwise it is a syntax error.
+#
+#  For more information related to terminology and syntax of escape commands,
+#  see [`StmtIpyEscapeCommand`].
+[[Expr.nodes.ExprIpyEscapeCommand.fields]]
+name = "kind"
+type = "IpyEscapeKind"
+
+[[Expr.nodes.ExprIpyEscapeCommand.fields]]
+name = "value"
+type = "Box<str>"
+
 
 [ExceptHandler]
 rustdoc = "/// See also [excepthandler](https://docs.python.org/3/library/ast.html#ast.excepthandler)"

--- a/crates/ruff_python_ast/ast.toml
+++ b/crates/ruff_python_ast/ast.toml
@@ -82,239 +82,159 @@ doc = "See also [expr](https://docs.python.org/3/library/ast.html#ast.expr)"
 
 [Expr.nodes.ExprBoolOp]
 doc = "See also [BoolOp](https://docs.python.org/3/library/ast.html#ast.BoolOp)"
-
-[[Expr.nodes.ExprBoolOp.fields]]
-name = "op"
-type = "BoolOp"
-
-[[Expr.nodes.ExprBoolOp.fields]]
-name = "values"
-type = "Expr"
-seq = true
+fields = [
+  { name = "op", type = "BoolOp" },
+  { name = "values", type = "Expr*" }
+]
 
 [Expr.nodes.ExprNamed]
 doc = "See also [NamedExpr](https://docs.python.org/3/library/ast.html#ast.NamedExpr)"
-
-[[Expr.nodes.ExprNamed.fields]]
-name = "target"
-type = "Expr"
-
-[[Expr.nodes.ExprNamed.fields]]
-name = "value"
-type = "Expr"
+fields = [
+  { name = "target", type = "Expr" },
+  { name = "value", type = "Expr" }
+]
 
 [Expr.nodes.ExprBinOp]
 doc = "See also [BinOp](https://docs.python.org/3/library/ast.html#ast.BinOp)"
-
-[[Expr.nodes.ExprBinOp.fields]]
-name = "left"
-type = "Expr"
-
-[[Expr.nodes.ExprBinOp.fields]]
-name = "op"
-type = "Operator"
-
-[[Expr.nodes.ExprBinOp.fields]]
-name = "right"
-type = "Expr"
+fields = [
+  { name = "left", type = "Expr" },
+  { name = "op", type = "Operator" },
+  { name = "right", type = "Expr" }
+]
 
 [Expr.nodes.ExprUnaryOp]
 doc = "See also [UnaryOp](https://docs.python.org/3/library/ast.html#ast.UnaryOp)"
-
-[[Expr.nodes.ExprUnaryOp.fields]]
-name = "op"
-type = "UnaryOp"
-
-[[Expr.nodes.ExprUnaryOp.fields]]
-name = "operand"
-type = "Expr"
+fields = [
+  { name = "op", type = "UnaryOp" },
+  { name = "operand", type = "Expr" }
+]
 
 [Expr.nodes.ExprLambda]
 doc = "See also [Lambda](https://docs.python.org/3/library/ast.html#ast.Lambda)"
-
-[[Expr.nodes.ExprLambda.fields]]
-name = "parameters"
-type = "Box<crate::Parameters>"
-optional = true
-
-[[Expr.nodes.ExprLambda.fields]]
-name = "body"
-type = "Expr"
+fields = [
+  { name = "parameters", type = "Parameters?" },
+  { name = "body", type = "Expr" }
+]
 
 [Expr.nodes.ExprIf]
 doc = "See also [IfExp](https://docs.python.org/3/library/ast.html#ast.IfExp)"
-
-[[Expr.nodes.ExprIf.fields]]
-name = "test"
-type = "Expr"
-
-[[Expr.nodes.ExprIf.fields]]
-name = "body"
-type = "Expr"
-
-[[Expr.nodes.ExprIf.fields]]
-name = "orelse"
-type = "Expr"
+fields = [
+  { name = "test", type = "Expr" },
+  { name = "body", type = "Expr" },
+  { name = "orelse", type = "Expr" }
+]
 
 [Expr.nodes.ExprDict]
 doc = "See also [Dict](https://docs.python.org/3/library/ast.html#ast.Dict)"
-
-[[Expr.nodes.ExprDict.fields]]
-name = "items"
-type = "DictItem"
-seq = true
+fields = [
+  { name = "items", type = "DictItem*" }
+]
 
 [Expr.nodes.ExprSet]
 doc = "See also [Set](https://docs.python.org/3/library/ast.html#ast.Set)"
-
-[[Expr.nodes.ExprSet.fields]]
-name = "elts"
-type = "Expr"
-seq = true
+fields = [
+  { name = "elts", type = "Expr*" }
+]
 
 [Expr.nodes.ExprListComp]
 doc = "See also [ListComp](https://docs.python.org/3/library/ast.html#ast.ListComp)"
-
-[[Expr.nodes.ExprListComp.fields]]
-name = "elt"
-type = "Expr"
-
-[[Expr.nodes.ExprListComp.fields]]
-name = "generators"
-type = "Comprehension"
-seq = true
+fields = [
+  { name = "elt", type = "Expr" },
+  { name = "generators", type = "Comprehension*" }
+]
 
 [Expr.nodes.ExprSetComp]
 doc = "See also [SetComp](https://docs.python.org/3/library/ast.html#ast.SetComp)"
-
-[[Expr.nodes.ExprSetComp.fields]]
-name = "elt"
-type = "Expr"
-
-[[Expr.nodes.ExprSetComp.fields]]
-name = "generators"
-type = "Comprehension"
-seq = true
+fields = [
+  { name = "elt", type = "Expr" },
+  { name = "generators", type = "Comprehension*" }
+]
 
 [Expr.nodes.ExprDictComp]
 doc = "See also [DictComp](https://docs.python.org/3/library/ast.html#ast.DictComp)"
-
-[[Expr.nodes.ExprDictComp.fields]]
-name = "key"
-type = "Expr"
-
-[[Expr.nodes.ExprDictComp.fields]]
-name = "value"
-type = "Expr"
-
-[[Expr.nodes.ExprDictComp.fields]]
-name = "generators"
-type = "Comprehension"
-seq = true
+fields = [
+  { name = "key", type = "Expr" },
+  { name = "value", type = "Expr" },
+  { name = "generators", type = "Comprehension*" }
+]
 
 [Expr.nodes.ExprGenerator]
 doc = "See also [GeneratorExp](https://docs.python.org/3/library/ast.html#ast.GeneratorExp)"
-
-[[Expr.nodes.ExprGenerator.fields]]
-name = "elt"
-type = "Expr"
-
-[[Expr.nodes.ExprGenerator.fields]]
-name = "generators"
-type = "Comprehension"
-seq = true
-
-[[Expr.nodes.ExprGenerator.fields]]
-name = "parenthesized"
-type = "bool"
+fields = [
+  { name = "elt", type = "Expr" },
+  { name = "generators", type = "Comprehension*" },
+  { name = "parenthesized", type = "bool" }
+]
 
 [Expr.nodes.ExprAwait]
 doc = "See also [Await](https://docs.python.org/3/library/ast.html#ast.Await)"
-
-[[Expr.nodes.ExprAwait.fields]]
-name = "value"
-type = "Expr"
+fields = [
+  { name = "value", type = "Expr" }
+]
 
 [Expr.nodes.ExprYield]
 doc = "See also [Yield](https://docs.python.org/3/library/ast.html#ast.Yield)"
-
-[[Expr.nodes.ExprYield.fields]]
-name = "value"
-type = "Expr"
-optional = true
+fields = [
+  { name = "value", type = "Expr?" }
+]
 
 [Expr.nodes.ExprYieldFrom]
 doc = "See also [YieldFrom](https://docs.python.org/3/library/ast.html#ast.YieldFrom)"
-
-[[Expr.nodes.ExprYieldFrom.fields]]
-name = "value"
-type = "Expr"
+fields = [
+  { name = "value", type = "Expr" }
+]
 
 [Expr.nodes.ExprCompare]
 doc = "See also [Compare](https://docs.python.org/3/library/ast.html#ast.Compare)"
-
-[[Expr.nodes.ExprCompare.fields]]
-name = "left"
-type = "Expr"
-
-[[Expr.nodes.ExprCompare.fields]]
-name = "ops"
-type = "Box<[crate::CmpOp]>"
-
-[[Expr.nodes.ExprCompare.fields]]
-name = "comparators"
-type = "Box<[Expr]>"
+fields = [
+  { name = "left", type = "Expr" },
+  { name = "ops", type = "&CmpOp*" },
+  { name = "comparators", type = "&Expr*" }
+]
 
 [Expr.nodes.ExprCall]
 doc = "See also [Call](https://docs.python.org/3/library/ast.html#ast.Call)"
-
-[[Expr.nodes.ExprCall.fields]]
-name = "func"
-type = "Expr"
-
-[[Expr.nodes.ExprCall.fields]]
-name = "arguments"
-type = "Arguments"
+fields = [
+  { name = "func", type = "Expr" },
+  { name = "arguments", type = "Arguments" }
+]
 
 [Expr.nodes.ExprFString]
 doc = """An AST node that represents either a single-part f-string literal
 or an implicitly concatenated f-string literal.
 
-This type differs from the original Python AST ([`JoinedStr`]) in that it
+This type differs from the original Python AST `JoinedStr` in that it
 doesn't join the implicitly concatenated parts into a single string. Instead,
 it keeps them separate and provide various methods to access the parts.
 
 See also [JoinedStr](https://docs.python.org/3/library/ast.html#ast.JoinedStr)"""
-
-[[Expr.nodes.ExprFString.fields]]
-name = "value"
-type = "FStringValue"
+fields = [
+  { name = "value", type = "FStringValue" }
+]
 
 [Expr.nodes.ExprStringLiteral]
 doc = """An AST node that represents either a single-part string literal
 or an implicitly concatenated string literal."""
-
-[[Expr.nodes.ExprStringLiteral.fields]]
-name = "value"
-type = "StringLiteralValue"
+fields = [
+  { name = "value", type = "StringLiteralValue" }
+]
 
 [Expr.nodes.ExprBytesLiteral]
 doc = """An AST node that represents either a single-part bytestring literal
 or an implicitly concatenated bytestring literal."""
+fields = [
+  { name = "value", type = "BytesLiteralValue" }
+]
 
-[[Expr.nodes.ExprBytesLiteral.fields]]
-name = "value"
-type = "BytesLiteralValue"
-
-[[Expr.nodes.ExprNumberLiteral.fields]]
-name = "value"
-type = "Number"
-
-[[Expr.nodes.ExprBooleanLiteral.fields]]
-name = "value"
-type = "bool"
+[Expr.nodes.ExprNumberLiteral]
+fields = [
+  { name = "value", type = "Number" }
+]
 
 [Expr.nodes.ExprBooleanLiteral]
+fields = [
+  { name = "value", type = "bool" }
+]
 derives = ["Default"]
 
 [Expr.nodes.ExprNoneLiteral]
@@ -327,103 +247,59 @@ derives = ["Default"]
 
 [Expr.nodes.ExprAttribute]
 doc = "See also [Attribute](https://docs.python.org/3/library/ast.html#ast.Attribute)"
-
-[[Expr.nodes.ExprAttribute.fields]]
-name = "value"
-type = "Expr"
-
-[[Expr.nodes.ExprAttribute.fields]]
-name = "attr"
-type = "Identifier"
-
-[[Expr.nodes.ExprAttribute.fields]]
-name = "ctx"
-type = "ExprContext"
+fields = [
+  { name = "value", type = "Expr" },
+  { name = "attr", type = "Identifier" },
+  { name = "ctx", type = "ExprContext" }
+]
 
 [Expr.nodes.ExprSubscript]
 doc = "See also [Subscript](https://docs.python.org/3/library/ast.html#ast.Subscript)"
-
-[[Expr.nodes.ExprSubscript.fields]]
-name = "value"
-type = "Expr"
-
-[[Expr.nodes.ExprSubscript.fields]]
-name = "slice"
-type = "Expr"
-
-[[Expr.nodes.ExprSubscript.fields]]
-name = "ctx"
-type = "ExprContext"
+fields = [
+  { name = "value", type = "Expr" },
+  { name = "slice", type = "Expr" },
+  { name = "ctx", type = "ExprContext" }
+]
 
 [Expr.nodes.ExprStarred]
 doc = "See also [Starred](https://docs.python.org/3/library/ast.html#ast.Starred)"
-
-[[Expr.nodes.ExprStarred.fields]]
-name = "value"
-type = "Expr"
-
-[[Expr.nodes.ExprStarred.fields]]
-name = "ctx"
-type = "ExprContext"
+fields = [
+  { name = "value", type = "Expr" },
+  { name = "ctx", type = "ExprContext" }
+]
 
 [Expr.nodes.ExprName]
 doc = "See also [Name](https://docs.python.org/3/library/ast.html#ast.Name)"
-
-[[Expr.nodes.ExprName.fields]]
-name = "id"
-type = "Name"
-
-[[Expr.nodes.ExprName.fields]]
-name = "ctx"
-type = "ExprContext"
+fields = [
+  { name = "id", type = "Name" },
+  { name = "ctx", type = "ExprContext" }
+]
 
 [Expr.nodes.ExprList]
 doc = "See also [List](https://docs.python.org/3/library/ast.html#ast.List)"
-
-[[Expr.nodes.ExprList.fields]]
-name = "elts"
-type = "Expr"
-seq = true
-
-[[Expr.nodes.ExprList.fields]]
-name = "ctx"
-type = "ExprContext"
+fields = [
+  { name = "elts", type = "Expr*" },
+  { name = "ctx", type = "ExprContext" }
+]
 
 [Expr.nodes.ExprTuple]
 doc = "See also [Tuple](https://docs.python.org/3/library/ast.html#ast.Tuple)"
-
-[[Expr.nodes.ExprTuple.fields]]
-name = "elts"
-type = "Expr"
-seq = true
-
-[[Expr.nodes.ExprTuple.fields]]
-name = "ctx"
-type = "ExprContext"
-
-[[Expr.nodes.ExprTuple.fields]]
-name = "parenthesized"
-type = "bool"
+fields = [
+  { name = "elts", type = "Expr*" },
+  { name = "ctx", type = "ExprContext" },
+  { name = "parenthesized", type = "bool" }
+]
 
 [Expr.nodes.ExprSlice]
 doc = "See also [Slice](https://docs.python.org/3/library/ast.html#ast.Slice)"
-
-[[Expr.nodes.ExprSlice.fields]]
-name = "lower"
-type = "Expr"
-optional = true
-
-[[Expr.nodes.ExprSlice.fields]]
-name = "upper"
-type = "Expr"
-optional = true
-
-[[Expr.nodes.ExprSlice.fields]]
-name = "step"
-type = "Expr"
-optional = true
+fields = [
+  { name = "lower", type = "Expr?" },
+  { name = "upper", type = "Expr?" },
+  { name = "step", type = "Expr?" }
+]
 
 [Expr.nodes.ExprIpyEscapeCommand]
+# TODO: Remove the crate:: prefix once StmtIpyEscapeCommand is moved to generated.rs
 doc = """An AST node used to represent a IPython escape command at the expression level.
 
 For example,
@@ -434,16 +310,12 @@ dir = !pwd
 Here, the escape kind can only be `!` or `%` otherwise it is a syntax error.
 
 For more information related to terminology and syntax of escape commands,
-see [`StmtIpyEscapeCommand`]."""
+see [`crate::StmtIpyEscapeCommand`]."""
 
-[[Expr.nodes.ExprIpyEscapeCommand.fields]]
-name = "kind"
-type = "IpyEscapeKind"
-
-[[Expr.nodes.ExprIpyEscapeCommand.fields]]
-name = "value"
-type = "Box<str>"
-
+fields = [
+  { name = "kind", type = "IpyEscapeKind" },
+  { name = "value", type = "Box<str>" }
+]
 
 [ExceptHandler]
 doc = "See also [excepthandler](https://docs.python.org/3/library/ast.html#ast.excepthandler)"

--- a/crates/ruff_python_ast/ast.toml
+++ b/crates/ruff_python_ast/ast.toml
@@ -277,14 +277,15 @@ name = "arguments"
 type = "Arguments"
 
 [Expr.nodes.ExprFString]
-rustdoc = """/// An AST node that represents either a single-part f-string literal
-/// or an implicitly concatenated f-string literal.
-///
-/// This type differs from the original Python AST ([JoinedStr]) in that it
-/// doesn't join the implicitly concatenated parts into a single string. Instead,
-/// it keeps them separate and provide various methods to access the parts.
-///
-/// [JoinedStr]: https://docs.python.org/3/library/ast.html#ast.JoinedStr"""
+rustdoc = """
+An AST node that represents either a single-part f-string literal
+or an implicitly concatenated f-string literal.
+
+This type differs from the original Python AST ([JoinedStr]) in that it
+doesn't join the implicitly concatenated parts into a single string. Instead,
+it keeps them separate and provide various methods to access the parts.
+
+[JoinedStr]: https://docs.python.org/3/library/ast.html#ast.JoinedStr"""
 
 [[Expr.nodes.ExprFString.fields]]
 name = "value"

--- a/crates/ruff_python_ast/ast.toml
+++ b/crates/ruff_python_ast/ast.toml
@@ -142,7 +142,7 @@ ExprYieldFrom = { fields = [
 ]}
 ExprCompare = { fields = [
     { name = "left", type = "Expr" },
-    # We don't want this field to be a vec hence the seq is not enabled.
+    # TODO: We don't want this field to be a vec hence the seq is not enabled.
     { name = "ops", type = "Box<[crate::CmpOp]>"},
     { name = "comparators", type = "Box<[Expr]>"}
 ]}

--- a/crates/ruff_python_ast/ast.toml
+++ b/crates/ruff_python_ast/ast.toml
@@ -37,7 +37,7 @@
 
 [Mod]
 anynode_is_label = "module"
-rustdoc = "/// See also [mod](https://docs.python.org/3/library/ast.html#ast.mod)"
+doc = "See also [mod](https://docs.python.org/3/library/ast.html#ast.mod)"
 
 [Mod.nodes]
 ModModule = {}
@@ -46,7 +46,7 @@ ModExpression = {}
 [Stmt]
 add_suffix_to_is_methods = true
 anynode_is_label = "statement"
-rustdoc = "/// See also [stmt](https://docs.python.org/3/library/ast.html#ast.stmt)"
+doc = "See also [stmt](https://docs.python.org/3/library/ast.html#ast.stmt)"
 
 [Stmt.nodes]
 StmtFunctionDef = {}
@@ -78,10 +78,10 @@ StmtIpyEscapeCommand = {}
 [Expr]
 add_suffix_to_is_methods = true
 anynode_is_label = "expression"
-rustdoc = "/// See also [expr](https://docs.python.org/3/library/ast.html#ast.expr)"
+doc = "See also [expr](https://docs.python.org/3/library/ast.html#ast.expr)"
 
 [Expr.nodes.ExprBoolOp]
-rustdoc = "/// See also [BoolOp](https://docs.python.org/3/library/ast.html#ast.BoolOp)"
+doc = "See also [BoolOp](https://docs.python.org/3/library/ast.html#ast.BoolOp)"
 
 [[Expr.nodes.ExprBoolOp.fields]]
 name = "op"
@@ -93,7 +93,7 @@ type = "Expr"
 seq = true
 
 [Expr.nodes.ExprNamed]
-rustdoc = "/// See also [NamedExpr](https://docs.python.org/3/library/ast.html#ast.NamedExpr)"
+doc = "See also [NamedExpr](https://docs.python.org/3/library/ast.html#ast.NamedExpr)"
 
 [[Expr.nodes.ExprNamed.fields]]
 name = "target"
@@ -104,7 +104,7 @@ name = "value"
 type = "Expr"
 
 [Expr.nodes.ExprBinOp]
-rustdoc = "/// See also [BinOp](https://docs.python.org/3/library/ast.html#ast.BinOp)"
+doc = "See also [BinOp](https://docs.python.org/3/library/ast.html#ast.BinOp)"
 
 [[Expr.nodes.ExprBinOp.fields]]
 name = "left"
@@ -119,7 +119,7 @@ name = "right"
 type = "Expr"
 
 [Expr.nodes.ExprUnaryOp]
-rustdoc = "/// See also [UnaryOp](https://docs.python.org/3/library/ast.html#ast.UnaryOp)"
+doc = "See also [UnaryOp](https://docs.python.org/3/library/ast.html#ast.UnaryOp)"
 
 [[Expr.nodes.ExprUnaryOp.fields]]
 name = "op"
@@ -130,7 +130,7 @@ name = "operand"
 type = "Expr"
 
 [Expr.nodes.ExprLambda]
-rustdoc = "/// See also [Lambda](https://docs.python.org/3/library/ast.html#ast.Lambda)"
+doc = "See also [Lambda](https://docs.python.org/3/library/ast.html#ast.Lambda)"
 
 [[Expr.nodes.ExprLambda.fields]]
 name = "parameters"
@@ -142,7 +142,7 @@ name = "body"
 type = "Expr"
 
 [Expr.nodes.ExprIf]
-rustdoc = "/// See also [IfExp](https://docs.python.org/3/library/ast.html#ast.IfExp)"
+doc = "See also [IfExp](https://docs.python.org/3/library/ast.html#ast.IfExp)"
 
 [[Expr.nodes.ExprIf.fields]]
 name = "test"
@@ -157,7 +157,7 @@ name = "orelse"
 type = "Expr"
 
 [Expr.nodes.ExprDict]
-rustdoc = "/// See also [Dict](https://docs.python.org/3/library/ast.html#ast.Dict)"
+doc = "See also [Dict](https://docs.python.org/3/library/ast.html#ast.Dict)"
 
 [[Expr.nodes.ExprDict.fields]]
 name = "items"
@@ -165,7 +165,7 @@ type = "DictItem"
 seq = true
 
 [Expr.nodes.ExprSet]
-rustdoc = "/// See also [Set](https://docs.python.org/3/library/ast.html#ast.Set)"
+doc = "See also [Set](https://docs.python.org/3/library/ast.html#ast.Set)"
 
 [[Expr.nodes.ExprSet.fields]]
 name = "elts"
@@ -173,7 +173,7 @@ type = "Expr"
 seq = true
 
 [Expr.nodes.ExprListComp]
-rustdoc = "/// See also [ListComp](https://docs.python.org/3/library/ast.html#ast.ListComp)"
+doc = "See also [ListComp](https://docs.python.org/3/library/ast.html#ast.ListComp)"
 
 [[Expr.nodes.ExprListComp.fields]]
 name = "elt"
@@ -185,7 +185,7 @@ type = "Comprehension"
 seq = true
 
 [Expr.nodes.ExprSetComp]
-rustdoc = "/// See also [SetComp](https://docs.python.org/3/library/ast.html#ast.SetComp)"
+doc = "See also [SetComp](https://docs.python.org/3/library/ast.html#ast.SetComp)"
 
 [[Expr.nodes.ExprSetComp.fields]]
 name = "elt"
@@ -197,7 +197,7 @@ type = "Comprehension"
 seq = true
 
 [Expr.nodes.ExprDictComp]
-rustdoc = "/// See also [DictComp](https://docs.python.org/3/library/ast.html#ast.DictComp)"
+doc = "See also [DictComp](https://docs.python.org/3/library/ast.html#ast.DictComp)"
 
 [[Expr.nodes.ExprDictComp.fields]]
 name = "key"
@@ -213,7 +213,7 @@ type = "Comprehension"
 seq = true
 
 [Expr.nodes.ExprGenerator]
-rustdoc = "/// See also [GeneratorExp](https://docs.python.org/3/library/ast.html#ast.GeneratorExp)"
+doc = "See also [GeneratorExp](https://docs.python.org/3/library/ast.html#ast.GeneratorExp)"
 
 [[Expr.nodes.ExprGenerator.fields]]
 name = "elt"
@@ -229,14 +229,14 @@ name = "parenthesized"
 type = "bool"
 
 [Expr.nodes.ExprAwait]
-rustdoc = "/// See also [Await](https://docs.python.org/3/library/ast.html#ast.Await)"
+doc = "See also [Await](https://docs.python.org/3/library/ast.html#ast.Await)"
 
 [[Expr.nodes.ExprAwait.fields]]
 name = "value"
 type = "Expr"
 
 [Expr.nodes.ExprYield]
-rustdoc = "/// See also [Yield](https://docs.python.org/3/library/ast.html#ast.Yield)"
+doc = "See also [Yield](https://docs.python.org/3/library/ast.html#ast.Yield)"
 
 [[Expr.nodes.ExprYield.fields]]
 name = "value"
@@ -244,14 +244,14 @@ type = "Expr"
 optional = true
 
 [Expr.nodes.ExprYieldFrom]
-rustdoc = "/// See also [YieldFrom](https://docs.python.org/3/library/ast.html#ast.YieldFrom)"
+doc = "See also [YieldFrom](https://docs.python.org/3/library/ast.html#ast.YieldFrom)"
 
 [[Expr.nodes.ExprYieldFrom.fields]]
 name = "value"
 type = "Expr"
 
 [Expr.nodes.ExprCompare]
-rustdoc = "/// See also [Compare](https://docs.python.org/3/library/ast.html#ast.Compare)"
+doc = "See also [Compare](https://docs.python.org/3/library/ast.html#ast.Compare)"
 
 [[Expr.nodes.ExprCompare.fields]]
 name = "left"
@@ -266,7 +266,7 @@ name = "comparators"
 type = "Box<[Expr]>"
 
 [Expr.nodes.ExprCall]
-rustdoc = "/// See also [Call](https://docs.python.org/3/library/ast.html#ast.Call)"
+doc = "See also [Call](https://docs.python.org/3/library/ast.html#ast.Call)"
 
 [[Expr.nodes.ExprCall.fields]]
 name = "func"
@@ -277,31 +277,30 @@ name = "arguments"
 type = "Arguments"
 
 [Expr.nodes.ExprFString]
-rustdoc = """
-An AST node that represents either a single-part f-string literal
+doc = """An AST node that represents either a single-part f-string literal
 or an implicitly concatenated f-string literal.
 
 This type differs from the original Python AST ([JoinedStr]) in that it
 doesn't join the implicitly concatenated parts into a single string. Instead,
 it keeps them separate and provide various methods to access the parts.
 
-[JoinedStr]: https://docs.python.org/3/library/ast.html#ast.JoinedStr"""
+See also [JoinedStr](https://docs.python.org/3/library/ast.html#ast.JoinedStr)"""
 
 [[Expr.nodes.ExprFString.fields]]
 name = "value"
 type = "FStringValue"
 
 [Expr.nodes.ExprStringLiteral]
-rustdoc = """/// An AST node that represents either a single-part string literal
-/// or an implicitly concatenated string literal."""
+doc = """An AST node that represents either a single-part string literal
+or an implicitly concatenated string literal."""
 
 [[Expr.nodes.ExprStringLiteral.fields]]
 name = "value"
 type = "StringLiteralValue"
 
 [Expr.nodes.ExprBytesLiteral]
-rustdoc = """/// An AST node that represents either a single-part bytestring literal
-/// or an implicitly concatenated bytestring literal."""
+doc = """An AST node that represents either a single-part bytestring literal
+or an implicitly concatenated bytestring literal."""
 
 [[Expr.nodes.ExprBytesLiteral.fields]]
 name = "value"
@@ -327,7 +326,7 @@ fields = []
 derives = ["Default"]
 
 [Expr.nodes.ExprAttribute]
-rustdoc = "/// See also [Attribute](https://docs.python.org/3/library/ast.html#ast.Attribute)"
+doc = "See also [Attribute](https://docs.python.org/3/library/ast.html#ast.Attribute)"
 
 [[Expr.nodes.ExprAttribute.fields]]
 name = "value"
@@ -342,7 +341,7 @@ name = "ctx"
 type = "ExprContext"
 
 [Expr.nodes.ExprSubscript]
-rustdoc = "/// See also [Subscript](https://docs.python.org/3/library/ast.html#ast.Subscript)"
+doc = "See also [Subscript](https://docs.python.org/3/library/ast.html#ast.Subscript)"
 
 [[Expr.nodes.ExprSubscript.fields]]
 name = "value"
@@ -357,7 +356,7 @@ name = "ctx"
 type = "ExprContext"
 
 [Expr.nodes.ExprStarred]
-rustdoc = "/// See also [Starred](https://docs.python.org/3/library/ast.html#ast.Starred)"
+doc = "See also [Starred](https://docs.python.org/3/library/ast.html#ast.Starred)"
 
 [[Expr.nodes.ExprStarred.fields]]
 name = "value"
@@ -368,7 +367,7 @@ name = "ctx"
 type = "ExprContext"
 
 [Expr.nodes.ExprName]
-rustdoc = "/// See also [Name](https://docs.python.org/3/library/ast.html#ast.Name)"
+doc = "See also [Name](https://docs.python.org/3/library/ast.html#ast.Name)"
 
 [[Expr.nodes.ExprName.fields]]
 name = "id"
@@ -379,7 +378,7 @@ name = "ctx"
 type = "ExprContext"
 
 [Expr.nodes.ExprList]
-rustdoc = "/// See also [List](https://docs.python.org/3/library/ast.html#ast.List)"
+doc = "See also [List](https://docs.python.org/3/library/ast.html#ast.List)"
 
 [[Expr.nodes.ExprList.fields]]
 name = "elts"
@@ -391,7 +390,7 @@ name = "ctx"
 type = "ExprContext"
 
 [Expr.nodes.ExprTuple]
-rustdoc = "/// See also [Tuple](https://docs.python.org/3/library/ast.html#ast.Tuple)"
+doc = "See also [Tuple](https://docs.python.org/3/library/ast.html#ast.Tuple)"
 
 [[Expr.nodes.ExprTuple.fields]]
 name = "elts"
@@ -407,7 +406,7 @@ name = "parenthesized"
 type = "bool"
 
 [Expr.nodes.ExprSlice]
-rustdoc = "/// See also [Slice](https://docs.python.org/3/library/ast.html#ast.Slice)"
+doc = "See also [Slice](https://docs.python.org/3/library/ast.html#ast.Slice)"
 
 [[Expr.nodes.ExprSlice.fields]]
 name = "lower"
@@ -425,14 +424,17 @@ type = "Expr"
 optional = true
 
 [Expr.nodes.ExprIpyEscapeCommand]
-rustdoc = """/// An AST node used to represent a IPython escape command at the expression level.
-///
-/// For example,
-/// ```python
-/// dir = !pwd
-///
-/// For more information related to terminology and syntax of escape commands,
-///  see [`StmtIpyEscapeCommand`]."""
+doc = """An AST node used to represent a IPython escape command at the expression level.
+
+For example,
+```python
+dir = !pwd
+```
+
+Here, the escape kind can only be `!` or `%` otherwise it is a syntax error.
+
+For more information related to terminology and syntax of escape commands,
+see [`StmtIpyEscapeCommand`]."""
 
 [[Expr.nodes.ExprIpyEscapeCommand.fields]]
 name = "kind"
@@ -444,7 +446,7 @@ type = "Box<str>"
 
 
 [ExceptHandler]
-rustdoc = "/// See also [excepthandler](https://docs.python.org/3/library/ast.html#ast.excepthandler)"
+doc = "See also [excepthandler](https://docs.python.org/3/library/ast.html#ast.excepthandler)"
 
 [ExceptHandler.nodes]
 ExceptHandlerExceptHandler = {}
@@ -454,7 +456,7 @@ FStringExpressionElement = {variant = "Expression"}
 FStringLiteralElement = {variant = "Literal"}
 
 [Pattern]
-rustdoc = "/// See also [pattern](https://docs.python.org/3/library/ast.html#ast.pattern)"
+doc = "See also [pattern](https://docs.python.org/3/library/ast.html#ast.pattern)"
 
 [Pattern.nodes]
 PatternMatchValue = {}
@@ -467,7 +469,7 @@ PatternMatchAs = {}
 PatternMatchOr = {}
 
 [TypeParam]
-rustdoc = "/// See also [type_param](https://docs.python.org/3/library/ast.html#ast.type_param)"
+doc = "See also [type_param](https://docs.python.org/3/library/ast.html#ast.type_param)"
 
 [TypeParam.nodes]
 TypeParamTypeVar = {}

--- a/crates/ruff_python_ast/ast.toml
+++ b/crates/ruff_python_ast/ast.toml
@@ -81,31 +81,6 @@ anynode_is_label = "expression"
 rustdoc = "/// See also [expr](https://docs.python.org/3/library/ast.html#ast.expr)"
 
 [Expr.nodes]
-ExprSet = {}
-ExprListComp = {}
-ExprSetComp = {}
-ExprDictComp = {}
-ExprGenerator = {}
-ExprAwait = {}
-ExprYield = {}
-ExprYieldFrom = {}
-ExprCompare = {}
-ExprCall = {}
-ExprFString = {}
-ExprStringLiteral = {}
-ExprBytesLiteral = {}
-ExprNumberLiteral = {}
-ExprBooleanLiteral = {}
-ExprNoneLiteral = {}
-ExprEllipsisLiteral = {}
-ExprAttribute = {}
-ExprSubscript = {}
-ExprStarred = {}
-ExprName = {}
-ExprList = {}
-ExprTuple = {}
-ExprSlice = {}
-ExprIpyEscapeCommand = {}
 ExprBoolOp = { fields = [
     { name = "op", type = "BoolOp" },
     { name = "values", type = "Expr", seq = true }
@@ -124,7 +99,7 @@ ExprUnaryOp = { fields = [
     { name = "operand", type = "Expr" }
 ]}
 ExprLambda = { fields = [
-    { name = "parameters", type = "Parameters", optional = true },
+    { name = "parameters", type = "Box<crate::Parameters>", optional = true },
     { name = "body", type = "Expr" }
 ]}
 ExprIf = { fields = [
@@ -134,6 +109,100 @@ ExprIf = { fields = [
 ]}
 ExprDict = { fields = [
     { name = "items", type = "DictItem", seq = true },
+]}
+ExprSet = { fields = [
+    { name = "elts", type = "Expr", seq = true }
+]}
+ExprListComp = { fields = [
+    { name = "elt", type = "Expr" },
+    { name = "generators", type = "Comprehension", seq = true }
+]}
+ExprSetComp = { fields = [
+    { name = "elt", type = "Expr" },
+    { name = "generators", type = "Comprehension", seq = true }
+]}
+ExprDictComp = { fields = [
+    { name = "key", type = "Expr" },
+    { name = "value", type = "Expr" },
+    { name = "generators", type = "Comprehension", seq = true }
+]}
+ExprGenerator = { fields = [
+    { name = "elt", type = "Expr" },
+    { name = "generators", type = "Comprehension", seq = true },
+    { name = "parenthesized", type = "bool" }
+]}
+ExprAwait = { fields = [
+    { name = "value", type = "Expr" }
+]}
+ExprYield = { fields = [
+    { name = "value", type = "Expr", optional = true }
+]}
+ExprYieldFrom = { fields = [
+    { name = "value", type = "Expr" }
+]}
+ExprCompare = { fields = [
+    { name = "left", type = "Expr" },
+    # We don't want this field to be a vec hence the seq is not enabled.
+    { name = "ops", type = "Box<[crate::CmpOp]>"},
+    { name = "comparators", type = "Box<[Expr]>"}
+]}
+ExprCall = { fields = [
+    { name = "func", type = "Expr" },
+    { name = "arguments", type = "Arguments"}
+]}
+ExprFString = { fields = [
+    { name = "value", type = "FStringValue" }
+]}
+ExprStringLiteral = { fields = [
+    { name = "value", type = "StringLiteralValue" }
+]}
+ExprBytesLiteral = { fields = [
+    { name = "value", type = "BytesLiteralValue" }
+]}
+ExprNumberLiteral = { fields = [
+    { name = "value", type = "Number" }
+]}
+ExprBooleanLiteral = { fields = [
+    { name = "value", type = "bool" }
+], derives = ["Default"]}
+ExprNoneLiteral = { fields = [], derives = ["Default"]}
+ExprEllipsisLiteral = { fields = [], derives = ["Default"]}
+ExprAttribute = { fields = [
+    { name = "value", type = "Expr" },
+    { name = "attr", type = "Identifier" },
+    { name = "ctx", type = "ExprContext" }
+]}
+ExprSubscript = { fields = [
+    { name = "value", type = "Expr" },
+    { name = "slice", type = "Expr" },
+    { name = "ctx", type = "ExprContext" }
+]}
+ExprStarred = { fields = [
+    { name = "value", type = "Expr" },
+    { name = "ctx", type = "ExprContext" }
+]}
+ExprName = { fields = [
+    { name = "id", type = "name::Name" },
+    { name = "ctx", type = "ExprContext" }
+]}
+ExprList = { fields = [
+    { name = "elts", type = "Expr", seq = true },
+    { name = "ctx", type = "ExprContext" }
+]}
+ExprTuple = { fields = [
+    { name = "elts", type = "Expr", seq = true },
+    { name = "ctx", type = "ExprContext" },
+    { name = "parenthesized", type = "bool" }
+]}
+ExprSlice = { fields = [
+    { name = "lower", type = "Expr", optional = true },
+    { name = "upper", type = "Expr", optional = true },
+    { name = "step", type = "Expr", optional = true }
+]}
+ExprIpyEscapeCommand = { fields = [
+    { name = "kind", type = "IpyEscapeKind" },
+    { name = "value", type = "Box<str>" }
+
 ]}
 
 [ExceptHandler]

--- a/crates/ruff_python_ast/ast.toml
+++ b/crates/ruff_python_ast/ast.toml
@@ -80,7 +80,9 @@ add_suffix_to_is_methods = true
 anynode_is_label = "expression"
 rustdoc = "/// See also [expr](https://docs.python.org/3/library/ast.html#ast.expr)"
 
-# See also [BoolOp](https://docs.python.org/3/library/ast.html#ast.BoolOp)
+[Expr.nodes.ExprBoolOp]
+rustdoc = "/// See also [BoolOp](https://docs.python.org/3/library/ast.html#ast.BoolOp)"
+
 [[Expr.nodes.ExprBoolOp.fields]]
 name = "op"
 type = "BoolOp"
@@ -90,7 +92,9 @@ name = "values"
 type = "Expr"
 seq = true
 
-# See also [NamedExpr](https://docs.python.org/3/library/ast.html#ast.NamedExpr)
+[Expr.nodes.ExprNamed]
+rustdoc = "/// See also [NamedExpr](https://docs.python.org/3/library/ast.html#ast.NamedExpr)"
+
 [[Expr.nodes.ExprNamed.fields]]
 name = "target"
 type = "Expr"
@@ -99,7 +103,9 @@ type = "Expr"
 name = "value"
 type = "Expr"
 
-# See also [BinOp](https://docs.python.org/3/library/ast.html#ast.BinOp)
+[Expr.nodes.ExprBinOp]
+rustdoc = "/// See also [BinOp](https://docs.python.org/3/library/ast.html#ast.BinOp)"
+
 [[Expr.nodes.ExprBinOp.fields]]
 name = "left"
 type = "Expr"
@@ -112,7 +118,9 @@ type = "Operator"
 name = "right"
 type = "Expr"
 
-# See also [UnaryOp](https://docs.python.org/3/library/ast.html#ast.UnaryOp)
+[Expr.nodes.ExprUnaryOp]
+rustdoc = "/// See also [UnaryOp](https://docs.python.org/3/library/ast.html#ast.UnaryOp)"
+
 [[Expr.nodes.ExprUnaryOp.fields]]
 name = "op"
 type = "UnaryOp"
@@ -121,7 +129,9 @@ type = "UnaryOp"
 name = "operand"
 type = "Expr"
 
-# See also [Lambda](https://docs.python.org/3/library/ast.html#ast.Lambda)
+[Expr.nodes.ExprLambda]
+rustdoc = "/// See also [Lambda](https://docs.python.org/3/library/ast.html#ast.Lambda)"
+
 [[Expr.nodes.ExprLambda.fields]]
 name = "parameters"
 type = "Box<crate::Parameters>"
@@ -131,7 +141,9 @@ optional = true
 name = "body"
 type = "Expr"
 
-# See also [IfExp](https://docs.python.org/3/library/ast.html#ast.IfExp)
+[Expr.nodes.ExprIf]
+rustdoc = "/// See also [IfExp](https://docs.python.org/3/library/ast.html#ast.IfExp)"
+
 [[Expr.nodes.ExprIf.fields]]
 name = "test"
 type = "Expr"
@@ -144,19 +156,25 @@ type = "Expr"
 name = "orelse"
 type = "Expr"
 
-# See also [Dict](https://docs.python.org/3/library/ast.html#ast.Dict)
+[Expr.nodes.ExprDict]
+rustdoc = "/// See also [Dict](https://docs.python.org/3/library/ast.html#ast.Dict)"
+
 [[Expr.nodes.ExprDict.fields]]
 name = "items"
 type = "DictItem"
 seq = true
 
-# See also [Set](https://docs.python.org/3/library/ast.html#ast.Set)
+[Expr.nodes.ExprSet]
+rustdoc = "/// See also [Set](https://docs.python.org/3/library/ast.html#ast.Set)"
+
 [[Expr.nodes.ExprSet.fields]]
 name = "elts"
 type = "Expr"
 seq = true
 
-# See also [ListComp](https://docs.python.org/3/library/ast.html#ast.ListComp)
+[Expr.nodes.ExprListComp]
+rustdoc = "/// See also [ListComp](https://docs.python.org/3/library/ast.html#ast.ListComp)"
+
 [[Expr.nodes.ExprListComp.fields]]
 name = "elt"
 type = "Expr"
@@ -166,7 +184,9 @@ name = "generators"
 type = "Comprehension"
 seq = true
 
-# See also [SetComp](https://docs.python.org/3/library/ast.html#ast.SetComp)
+[Expr.nodes.ExprSetComp]
+rustdoc = "/// See also [SetComp](https://docs.python.org/3/library/ast.html#ast.SetComp)"
+
 [[Expr.nodes.ExprSetComp.fields]]
 name = "elt"
 type = "Expr"
@@ -176,7 +196,9 @@ name = "generators"
 type = "Comprehension"
 seq = true
 
-# See also [DictComp](https://docs.python.org/3/library/ast.html#ast.DictComp)
+[Expr.nodes.ExprDictComp]
+rustdoc = "/// See also [DictComp](https://docs.python.org/3/library/ast.html#ast.DictComp)"
+
 [[Expr.nodes.ExprDictComp.fields]]
 name = "key"
 type = "Expr"
@@ -190,7 +212,9 @@ name = "generators"
 type = "Comprehension"
 seq = true
 
-# See also [GeneratorExp](https://docs.python.org/3/library/ast.html#ast.GeneratorExp)
+[Expr.nodes.ExprGenerator]
+rustdoc = "/// See also [GeneratorExp](https://docs.python.org/3/library/ast.html#ast.GeneratorExp)"
+
 [[Expr.nodes.ExprGenerator.fields]]
 name = "elt"
 type = "Expr"
@@ -204,23 +228,31 @@ seq = true
 name = "parenthesized"
 type = "bool"
 
-# See also [Await](https://docs.python.org/3/library/ast.html#ast.Await)
+[Expr.nodes.ExprAwait]
+rustdoc = "/// See also [Await](https://docs.python.org/3/library/ast.html#ast.Await)"
+
 [[Expr.nodes.ExprAwait.fields]]
 name = "value"
 type = "Expr"
 
-# See also [Yield](https://docs.python.org/3/library/ast.html#ast.Yield)
+[Expr.nodes.ExprYield]
+rustdoc = "/// See also [Yield](https://docs.python.org/3/library/ast.html#ast.Yield)"
+
 [[Expr.nodes.ExprYield.fields]]
 name = "value"
 type = "Expr"
 optional = true
 
-# See also [YieldFrom](https://docs.python.org/3/library/ast.html#ast.YieldFrom)
+[Expr.nodes.ExprYieldFrom]
+rustdoc = "/// See also [YieldFrom](https://docs.python.org/3/library/ast.html#ast.YieldFrom)"
+
 [[Expr.nodes.ExprYieldFrom.fields]]
 name = "value"
 type = "Expr"
 
-# See also [Compare](https://docs.python.org/3/library/ast.html#ast.Compare)
+[Expr.nodes.ExprCompare]
+rustdoc = "/// See also [Compare](https://docs.python.org/3/library/ast.html#ast.Compare)"
+
 [[Expr.nodes.ExprCompare.fields]]
 name = "left"
 type = "Expr"
@@ -233,7 +265,9 @@ type = "Box<[crate::CmpOp]>"
 name = "comparators"
 type = "Box<[Expr]>"
 
-# See also [Call](https://docs.python.org/3/library/ast.html#ast.Call)
+[Expr.nodes.ExprCall]
+rustdoc = "/// See also [Call](https://docs.python.org/3/library/ast.html#ast.Call)"
+
 [[Expr.nodes.ExprCall.fields]]
 name = "func"
 type = "Expr"
@@ -242,26 +276,32 @@ type = "Expr"
 name = "arguments"
 type = "Arguments"
 
-# An AST node that represents either a single-part f-string literal
-# or an implicitly concatenated f-string literal.
-#
-# This type differs from the original Python AST ([JoinedStr]) in that it
-# doesn't join the implicitly concatenated parts into a single string. Instead,
-# it keeps them separate and provide various methods to access the parts.
-#
-# [JoinedStr]: https://docs.python.org/3/library/ast.html#ast.JoinedStr
+[Expr.nodes.ExprFString]
+rustdoc = """/// An AST node that represents either a single-part f-string literal
+/// or an implicitly concatenated f-string literal.
+///
+/// This type differs from the original Python AST ([JoinedStr]) in that it
+/// doesn't join the implicitly concatenated parts into a single string. Instead,
+/// it keeps them separate and provide various methods to access the parts.
+///
+/// [JoinedStr]: https://docs.python.org/3/library/ast.html#ast.JoinedStr"""
+
 [[Expr.nodes.ExprFString.fields]]
 name = "value"
 type = "FStringValue"
 
-# An AST node that represents either a single-part string literal
-# or an implicitly concatenated string literal.
+[Expr.nodes.ExprStringLiteral]
+rustdoc = """/// An AST node that represents either a single-part string literal
+/// or an implicitly concatenated string literal."""
+
 [[Expr.nodes.ExprStringLiteral.fields]]
 name = "value"
 type = "StringLiteralValue"
 
-# An AST node that represents either a single-part bytestring literal
-# or an implicitly concatenated bytestring literal.
+[Expr.nodes.ExprBytesLiteral]
+rustdoc = """/// An AST node that represents either a single-part bytestring literal
+/// or an implicitly concatenated bytestring literal."""
+
 [[Expr.nodes.ExprBytesLiteral.fields]]
 name = "value"
 type = "BytesLiteralValue"
@@ -285,7 +325,9 @@ derives = ["Default"]
 fields = []
 derives = ["Default"]
 
-# See also [Attribute](https://docs.python.org/3/library/ast.html#ast.Attribute)
+[Expr.nodes.ExprAttribute]
+rustdoc = "/// See also [Attribute](https://docs.python.org/3/library/ast.html#ast.Attribute)"
+
 [[Expr.nodes.ExprAttribute.fields]]
 name = "value"
 type = "Expr"
@@ -298,7 +340,9 @@ type = "Identifier"
 name = "ctx"
 type = "ExprContext"
 
-# See also [Subscript](https://docs.python.org/3/library/ast.html#ast.Subscript)
+[Expr.nodes.ExprSubscript]
+rustdoc = "/// See also [Subscript](https://docs.python.org/3/library/ast.html#ast.Subscript)"
+
 [[Expr.nodes.ExprSubscript.fields]]
 name = "value"
 type = "Expr"
@@ -311,7 +355,9 @@ type = "Expr"
 name = "ctx"
 type = "ExprContext"
 
-# See also [Starred](https://docs.python.org/3/library/ast.html#ast.Starred)
+[Expr.nodes.ExprStarred]
+rustdoc = "/// See also [Starred](https://docs.python.org/3/library/ast.html#ast.Starred)"
+
 [[Expr.nodes.ExprStarred.fields]]
 name = "value"
 type = "Expr"
@@ -320,7 +366,9 @@ type = "Expr"
 name = "ctx"
 type = "ExprContext"
 
-# See also [Name](https://docs.python.org/3/library/ast.html#ast.Name)
+[Expr.nodes.ExprName]
+rustdoc = "/// See also [Name](https://docs.python.org/3/library/ast.html#ast.Name)"
+
 [[Expr.nodes.ExprName.fields]]
 name = "id"
 type = "Name"
@@ -329,7 +377,9 @@ type = "Name"
 name = "ctx"
 type = "ExprContext"
 
-# See also [List](https://docs.python.org/3/library/ast.html#ast.List)
+[Expr.nodes.ExprList]
+rustdoc = "/// See also [List](https://docs.python.org/3/library/ast.html#ast.List)"
+
 [[Expr.nodes.ExprList.fields]]
 name = "elts"
 type = "Expr"
@@ -339,7 +389,9 @@ seq = true
 name = "ctx"
 type = "ExprContext"
 
-# See also [Tuple](https://docs.python.org/3/library/ast.html#ast.Tuple)
+[Expr.nodes.ExprTuple]
+rustdoc = "/// See also [Tuple](https://docs.python.org/3/library/ast.html#ast.Tuple)"
+
 [[Expr.nodes.ExprTuple.fields]]
 name = "elts"
 type = "Expr"
@@ -353,7 +405,9 @@ type = "ExprContext"
 name = "parenthesized"
 type = "bool"
 
-# See also [Slice](https://docs.python.org/3/library/ast.html#ast.Slice)
+[Expr.nodes.ExprSlice]
+rustdoc = "/// See also [Slice](https://docs.python.org/3/library/ast.html#ast.Slice)"
+
 [[Expr.nodes.ExprSlice.fields]]
 name = "lower"
 type = "Expr"
@@ -369,17 +423,16 @@ name = "step"
 type = "Expr"
 optional = true
 
-#  An AST node used to represent a IPython escape command at the expression level.
-#
-#  For example,
-#  ```python
-#  dir = !pwd
-#  ```
-#
-#  Here, the escape kind can only be `!` or `%` otherwise it is a syntax error.
-#
-#  For more information related to terminology and syntax of escape commands,
-#  see [`StmtIpyEscapeCommand`].
+[Expr.nodes.ExprIpyEscapeCommand]
+rustdoc = """/// An AST node used to represent a IPython escape command at the expression level.
+///
+/// For example,
+/// ```python
+/// dir = !pwd
+///
+/// For more information related to terminology and syntax of escape commands,
+///  see [`StmtIpyEscapeCommand`]."""
+
 [[Expr.nodes.ExprIpyEscapeCommand.fields]]
 name = "kind"
 type = "IpyEscapeKind"

--- a/crates/ruff_python_ast/ast.toml
+++ b/crates/ruff_python_ast/ast.toml
@@ -81,13 +81,6 @@ anynode_is_label = "expression"
 rustdoc = "/// See also [expr](https://docs.python.org/3/library/ast.html#ast.expr)"
 
 [Expr.nodes]
-ExprBoolOp = {}
-ExprNamed = {}
-ExprBinOp = {}
-ExprUnaryOp = {}
-ExprLambda = {}
-ExprIf = {}
-ExprDict = {}
 ExprSet = {}
 ExprListComp = {}
 ExprSetComp = {}
@@ -113,6 +106,35 @@ ExprList = {}
 ExprTuple = {}
 ExprSlice = {}
 ExprIpyEscapeCommand = {}
+ExprBoolOp = { fields = [
+    { name = "op", type = "BoolOp" },
+    { name = "values", type = "Expr", seq = true }
+]}
+ExprNamed = { fields = [
+    { name = "target", type = "Expr" },
+    { name = "value", type = "Expr" }
+]}
+ExprBinOp = { fields = [
+    { name = "left", type = "Expr" },
+    { name = "op", type = "Operator" },
+    { name = "right", type = "Expr" }
+]}
+ExprUnaryOp = { fields = [
+    { name = "op", type = "UnaryOp" },
+    { name = "operand", type = "Expr" }
+]}
+ExprLambda = { fields = [
+    { name = "parameters", type = "Parameters", optional = true },
+    { name = "body", type = "Expr" }
+]}
+ExprIf = { fields = [
+    { name = "test", type = "Expr" },
+    { name = "body", type = "Expr" },
+    { name = "orelse", type = "Expr" }
+]}
+ExprDict = { fields = [
+    { name = "items", type = "DictItem", seq = true },
+]}
 
 [ExceptHandler]
 rustdoc = "/// See also [excepthandler](https://docs.python.org/3/library/ast.html#ast.excepthandler)"

--- a/crates/ruff_python_ast/ast.toml
+++ b/crates/ruff_python_ast/ast.toml
@@ -26,10 +26,28 @@
 #   Controls the name of the AnyNodeRef::is_foo_bar method.  The default is the
 #   group name in snake_case.
 #
-# rustdoc:
-#   A rustdoc comment that is added to the group's enums.
+# doc:
+#   A doc comment that is added to the group's enums.
 #
 # The following syntax node options are available:
+#
+# doc:
+#  A doc comment that is added to the syntax node struct.
+#
+# derives:
+# List of derives to add to the syntax node struct. Clone, Debug, PartialEq are added by default.
+#
+# fields:
+# List of fields in the syntax node struct. Each field is a table with the
+# following keys:
+# * name - The name of the field.
+# * type - The type of the field.  This can be a simple type name, or a type
+#   type field uses a special syntax to describe the rust type:
+#    * `Expr` - A single expression.
+#    * `Expr?` - Option type.
+#    * `Expr*` - A vector of Expr.
+#    * `&Expr*` - A boxed slice of Expr.
+#    These properties cannot be nested, for example we cannot create a vector of option types.
 #
 # variant:
 #   The name of the enum variant for this syntax node.  Defaults to the node

--- a/crates/ruff_python_ast/ast.toml
+++ b/crates/ruff_python_ast/ast.toml
@@ -280,7 +280,7 @@ type = "Arguments"
 doc = """An AST node that represents either a single-part f-string literal
 or an implicitly concatenated f-string literal.
 
-This type differs from the original Python AST ([JoinedStr]) in that it
+This type differs from the original Python AST ([`JoinedStr`]) in that it
 doesn't join the implicitly concatenated parts into a single string. Instead,
 it keeps them separate and provide various methods to access the parts.
 

--- a/crates/ruff_python_ast/generate.py
+++ b/crates/ruff_python_ast/generate.py
@@ -577,8 +577,8 @@ def write_node(out: list[str], ast: Ast) -> None:
             if node.fields is None:
                 continue
             out.append(
-                "#[derive(Clone, Debug, PartialEq, "
-                + ", ".join(node.derives or [])
+                "#[derive(Clone, Debug, PartialEq"
+                + "".join(f", {derive}" for derive in node.derives)
                 + ")]"
             )
             name = node.name

--- a/crates/ruff_python_ast/generate.py
+++ b/crates/ruff_python_ast/generate.py
@@ -100,6 +100,7 @@ class Node:
     name: str
     variant: str
     ty: str
+    rustdoc: str | None
     fields: list[Field] | None
     derives: list[str]
 
@@ -112,6 +113,7 @@ class Node:
         if fields is not None:
             self.fields = [Field(f) for f in fields]
         self.derives = node.get("derives", [])
+        self.rustdoc = node.get("rustdoc")
 
 
 @dataclass
@@ -138,7 +140,7 @@ def write_preamble(out: list[str]) -> None:
     // This is a generated file. Don't modify it by hand!
     // Run `crates/ruff_python_ast/generate.py` to re-generate the file.
 
-    { import_section }
+    {import_section}
     """)
 
 
@@ -591,6 +593,8 @@ def write_node(out: list[str], ast: Ast) -> None:
         for node in group.nodes:
             if node.fields is None:
                 continue
+            if node.rustdoc is not None:
+                out.append(node.rustdoc)
             out.append(
                 "#[derive(Clone, Debug, PartialEq"
                 + "".join(f", {derive}" for derive in node.derives)

--- a/crates/ruff_python_ast/generate.py
+++ b/crates/ruff_python_ast/generate.py
@@ -572,8 +572,6 @@ def write_nodekind(out: list[str], ast: Ast) -> None:
 
 
 def write_node(out: list[str], ast: Ast) -> None:
-    group_names = [group.name for group in ast.groups]
-    node_names = [node.name for node in ast.all_nodes]
     for group in ast.groups:
         for node in group.nodes:
             if node.fields is None:
@@ -589,12 +587,10 @@ def write_node(out: list[str], ast: Ast) -> None:
             for field in node.fields:
                 field_str = f"pub {field.name}: "
                 inner = f"crate::{field.ty}"
-                if (field.ty == "Expr" or (field.ty in group_names)) and (
-                    field.seq is False
-                ):
-                    inner = f"Box<{inner}>"
                 if field.ty == "bool" or field.ty.startswith("Box"):
                     inner = field.ty
+                if field.ty == group.name and field.seq is False:
+                    inner = f"Box<{inner}>"
 
                 if field.seq:
                     field_str += f"Vec<{inner}>,"

--- a/crates/ruff_python_ast/generate.py
+++ b/crates/ruff_python_ast/generate.py
@@ -27,7 +27,6 @@ types_requiring_create_prefix = [
     "CmpOp",
     "Comprehension",
     "DictItem",
-    "Parameters",
     "UnaryOp",
     "BoolOp",
     "Operator",
@@ -665,9 +664,7 @@ def write_node(out: list[str], ast: Ast) -> None:
                     rust_ty = f"crate::{rust_ty}"
                 if ty.slice_:
                     rust_ty = f"[{rust_ty}]"
-                if (
-                    ty.name in group_names or ty.name == "Parameters" or ty.slice_
-                ) and ty.seq is False:
+                if (ty.name in group_names or ty.slice_) and ty.seq is False:
                     rust_ty = f"Box<{rust_ty}>"
 
                 if ty.seq:

--- a/crates/ruff_python_ast/src/generated.rs
+++ b/crates/ruff_python_ast/src/generated.rs
@@ -1,6 +1,8 @@
 // This is a generated file. Don't modify it by hand!
 // Run `crates/ruff_python_ast/generate.py` to re-generate the file.
 
+use crate::name::Name;
+
 /// See also [mod](https://docs.python.org/3/library/ast.html#ast.mod)
 #[derive(Clone, Debug, PartialEq)]
 pub enum Mod {
@@ -6631,7 +6633,7 @@ pub struct ExprStarred {
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprName {
     pub range: ruff_text_size::TextRange,
-    pub id: crate::name::Name,
+    pub id: Name,
     pub ctx: crate::ExprContext,
 }
 

--- a/crates/ruff_python_ast/src/generated.rs
+++ b/crates/ruff_python_ast/src/generated.rs
@@ -1249,6 +1249,13 @@ impl Stmt {
 /// See also [expr](https://docs.python.org/3/library/ast.html#ast.expr)
 #[derive(Clone, Debug, PartialEq)]
 pub enum Expr {
+    BoolOp(crate::ExprBoolOp),
+    Named(crate::ExprNamed),
+    BinOp(crate::ExprBinOp),
+    UnaryOp(crate::ExprUnaryOp),
+    Lambda(crate::ExprLambda),
+    If(crate::ExprIf),
+    Dict(crate::ExprDict),
     Set(crate::ExprSet),
     ListComp(crate::ExprListComp),
     SetComp(crate::ExprSetComp),
@@ -1274,13 +1281,48 @@ pub enum Expr {
     Tuple(crate::ExprTuple),
     Slice(crate::ExprSlice),
     IpyEscapeCommand(crate::ExprIpyEscapeCommand),
-    BoolOp(crate::ExprBoolOp),
-    Named(crate::ExprNamed),
-    BinOp(crate::ExprBinOp),
-    UnaryOp(crate::ExprUnaryOp),
-    Lambda(crate::ExprLambda),
-    If(crate::ExprIf),
-    Dict(crate::ExprDict),
+}
+
+impl From<crate::ExprBoolOp> for Expr {
+    fn from(node: crate::ExprBoolOp) -> Self {
+        Self::BoolOp(node)
+    }
+}
+
+impl From<crate::ExprNamed> for Expr {
+    fn from(node: crate::ExprNamed) -> Self {
+        Self::Named(node)
+    }
+}
+
+impl From<crate::ExprBinOp> for Expr {
+    fn from(node: crate::ExprBinOp) -> Self {
+        Self::BinOp(node)
+    }
+}
+
+impl From<crate::ExprUnaryOp> for Expr {
+    fn from(node: crate::ExprUnaryOp) -> Self {
+        Self::UnaryOp(node)
+    }
+}
+
+impl From<crate::ExprLambda> for Expr {
+    fn from(node: crate::ExprLambda) -> Self {
+        Self::Lambda(node)
+    }
+}
+
+impl From<crate::ExprIf> for Expr {
+    fn from(node: crate::ExprIf) -> Self {
+        Self::If(node)
+    }
+}
+
+impl From<crate::ExprDict> for Expr {
+    fn from(node: crate::ExprDict) -> Self {
+        Self::Dict(node)
+    }
 }
 
 impl From<crate::ExprSet> for Expr {
@@ -1433,51 +1475,16 @@ impl From<crate::ExprIpyEscapeCommand> for Expr {
     }
 }
 
-impl From<crate::ExprBoolOp> for Expr {
-    fn from(node: crate::ExprBoolOp) -> Self {
-        Self::BoolOp(node)
-    }
-}
-
-impl From<crate::ExprNamed> for Expr {
-    fn from(node: crate::ExprNamed) -> Self {
-        Self::Named(node)
-    }
-}
-
-impl From<crate::ExprBinOp> for Expr {
-    fn from(node: crate::ExprBinOp) -> Self {
-        Self::BinOp(node)
-    }
-}
-
-impl From<crate::ExprUnaryOp> for Expr {
-    fn from(node: crate::ExprUnaryOp) -> Self {
-        Self::UnaryOp(node)
-    }
-}
-
-impl From<crate::ExprLambda> for Expr {
-    fn from(node: crate::ExprLambda) -> Self {
-        Self::Lambda(node)
-    }
-}
-
-impl From<crate::ExprIf> for Expr {
-    fn from(node: crate::ExprIf) -> Self {
-        Self::If(node)
-    }
-}
-
-impl From<crate::ExprDict> for Expr {
-    fn from(node: crate::ExprDict) -> Self {
-        Self::Dict(node)
-    }
-}
-
 impl ruff_text_size::Ranged for Expr {
     fn range(&self) -> ruff_text_size::TextRange {
         match self {
+            Self::BoolOp(node) => node.range(),
+            Self::Named(node) => node.range(),
+            Self::BinOp(node) => node.range(),
+            Self::UnaryOp(node) => node.range(),
+            Self::Lambda(node) => node.range(),
+            Self::If(node) => node.range(),
+            Self::Dict(node) => node.range(),
             Self::Set(node) => node.range(),
             Self::ListComp(node) => node.range(),
             Self::SetComp(node) => node.range(),
@@ -1503,19 +1510,271 @@ impl ruff_text_size::Ranged for Expr {
             Self::Tuple(node) => node.range(),
             Self::Slice(node) => node.range(),
             Self::IpyEscapeCommand(node) => node.range(),
-            Self::BoolOp(node) => node.range(),
-            Self::Named(node) => node.range(),
-            Self::BinOp(node) => node.range(),
-            Self::UnaryOp(node) => node.range(),
-            Self::Lambda(node) => node.range(),
-            Self::If(node) => node.range(),
-            Self::Dict(node) => node.range(),
         }
     }
 }
 
 #[allow(dead_code, clippy::match_wildcard_for_single_variants)]
 impl Expr {
+    #[inline]
+    pub const fn is_bool_op_expr(&self) -> bool {
+        matches!(self, Self::BoolOp(_))
+    }
+
+    #[inline]
+    pub fn bool_op_expr(self) -> Option<crate::ExprBoolOp> {
+        match self {
+            Self::BoolOp(val) => Some(val),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn expect_bool_op_expr(self) -> crate::ExprBoolOp {
+        match self {
+            Self::BoolOp(val) => val,
+            _ => panic!("called expect on {self:?}"),
+        }
+    }
+
+    #[inline]
+    pub fn as_bool_op_expr_mut(&mut self) -> Option<&mut crate::ExprBoolOp> {
+        match self {
+            Self::BoolOp(val) => Some(val),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn as_bool_op_expr(&self) -> Option<&crate::ExprBoolOp> {
+        match self {
+            Self::BoolOp(val) => Some(val),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub const fn is_named_expr(&self) -> bool {
+        matches!(self, Self::Named(_))
+    }
+
+    #[inline]
+    pub fn named_expr(self) -> Option<crate::ExprNamed> {
+        match self {
+            Self::Named(val) => Some(val),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn expect_named_expr(self) -> crate::ExprNamed {
+        match self {
+            Self::Named(val) => val,
+            _ => panic!("called expect on {self:?}"),
+        }
+    }
+
+    #[inline]
+    pub fn as_named_expr_mut(&mut self) -> Option<&mut crate::ExprNamed> {
+        match self {
+            Self::Named(val) => Some(val),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn as_named_expr(&self) -> Option<&crate::ExprNamed> {
+        match self {
+            Self::Named(val) => Some(val),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub const fn is_bin_op_expr(&self) -> bool {
+        matches!(self, Self::BinOp(_))
+    }
+
+    #[inline]
+    pub fn bin_op_expr(self) -> Option<crate::ExprBinOp> {
+        match self {
+            Self::BinOp(val) => Some(val),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn expect_bin_op_expr(self) -> crate::ExprBinOp {
+        match self {
+            Self::BinOp(val) => val,
+            _ => panic!("called expect on {self:?}"),
+        }
+    }
+
+    #[inline]
+    pub fn as_bin_op_expr_mut(&mut self) -> Option<&mut crate::ExprBinOp> {
+        match self {
+            Self::BinOp(val) => Some(val),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn as_bin_op_expr(&self) -> Option<&crate::ExprBinOp> {
+        match self {
+            Self::BinOp(val) => Some(val),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub const fn is_unary_op_expr(&self) -> bool {
+        matches!(self, Self::UnaryOp(_))
+    }
+
+    #[inline]
+    pub fn unary_op_expr(self) -> Option<crate::ExprUnaryOp> {
+        match self {
+            Self::UnaryOp(val) => Some(val),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn expect_unary_op_expr(self) -> crate::ExprUnaryOp {
+        match self {
+            Self::UnaryOp(val) => val,
+            _ => panic!("called expect on {self:?}"),
+        }
+    }
+
+    #[inline]
+    pub fn as_unary_op_expr_mut(&mut self) -> Option<&mut crate::ExprUnaryOp> {
+        match self {
+            Self::UnaryOp(val) => Some(val),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn as_unary_op_expr(&self) -> Option<&crate::ExprUnaryOp> {
+        match self {
+            Self::UnaryOp(val) => Some(val),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub const fn is_lambda_expr(&self) -> bool {
+        matches!(self, Self::Lambda(_))
+    }
+
+    #[inline]
+    pub fn lambda_expr(self) -> Option<crate::ExprLambda> {
+        match self {
+            Self::Lambda(val) => Some(val),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn expect_lambda_expr(self) -> crate::ExprLambda {
+        match self {
+            Self::Lambda(val) => val,
+            _ => panic!("called expect on {self:?}"),
+        }
+    }
+
+    #[inline]
+    pub fn as_lambda_expr_mut(&mut self) -> Option<&mut crate::ExprLambda> {
+        match self {
+            Self::Lambda(val) => Some(val),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn as_lambda_expr(&self) -> Option<&crate::ExprLambda> {
+        match self {
+            Self::Lambda(val) => Some(val),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub const fn is_if_expr(&self) -> bool {
+        matches!(self, Self::If(_))
+    }
+
+    #[inline]
+    pub fn if_expr(self) -> Option<crate::ExprIf> {
+        match self {
+            Self::If(val) => Some(val),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn expect_if_expr(self) -> crate::ExprIf {
+        match self {
+            Self::If(val) => val,
+            _ => panic!("called expect on {self:?}"),
+        }
+    }
+
+    #[inline]
+    pub fn as_if_expr_mut(&mut self) -> Option<&mut crate::ExprIf> {
+        match self {
+            Self::If(val) => Some(val),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn as_if_expr(&self) -> Option<&crate::ExprIf> {
+        match self {
+            Self::If(val) => Some(val),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub const fn is_dict_expr(&self) -> bool {
+        matches!(self, Self::Dict(_))
+    }
+
+    #[inline]
+    pub fn dict_expr(self) -> Option<crate::ExprDict> {
+        match self {
+            Self::Dict(val) => Some(val),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn expect_dict_expr(self) -> crate::ExprDict {
+        match self {
+            Self::Dict(val) => val,
+            _ => panic!("called expect on {self:?}"),
+        }
+    }
+
+    #[inline]
+    pub fn as_dict_expr_mut(&mut self) -> Option<&mut crate::ExprDict> {
+        match self {
+            Self::Dict(val) => Some(val),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn as_dict_expr(&self) -> Option<&crate::ExprDict> {
+        match self {
+            Self::Dict(val) => Some(val),
+            _ => None,
+        }
+    }
+
     #[inline]
     pub const fn is_set_expr(&self) -> bool {
         matches!(self, Self::Set(_))
@@ -2440,265 +2699,6 @@ impl Expr {
             _ => None,
         }
     }
-
-    #[inline]
-    pub const fn is_bool_op_expr(&self) -> bool {
-        matches!(self, Self::BoolOp(_))
-    }
-
-    #[inline]
-    pub fn bool_op_expr(self) -> Option<crate::ExprBoolOp> {
-        match self {
-            Self::BoolOp(val) => Some(val),
-            _ => None,
-        }
-    }
-
-    #[inline]
-    pub fn expect_bool_op_expr(self) -> crate::ExprBoolOp {
-        match self {
-            Self::BoolOp(val) => val,
-            _ => panic!("called expect on {self:?}"),
-        }
-    }
-
-    #[inline]
-    pub fn as_bool_op_expr_mut(&mut self) -> Option<&mut crate::ExprBoolOp> {
-        match self {
-            Self::BoolOp(val) => Some(val),
-            _ => None,
-        }
-    }
-
-    #[inline]
-    pub fn as_bool_op_expr(&self) -> Option<&crate::ExprBoolOp> {
-        match self {
-            Self::BoolOp(val) => Some(val),
-            _ => None,
-        }
-    }
-
-    #[inline]
-    pub const fn is_named_expr(&self) -> bool {
-        matches!(self, Self::Named(_))
-    }
-
-    #[inline]
-    pub fn named_expr(self) -> Option<crate::ExprNamed> {
-        match self {
-            Self::Named(val) => Some(val),
-            _ => None,
-        }
-    }
-
-    #[inline]
-    pub fn expect_named_expr(self) -> crate::ExprNamed {
-        match self {
-            Self::Named(val) => val,
-            _ => panic!("called expect on {self:?}"),
-        }
-    }
-
-    #[inline]
-    pub fn as_named_expr_mut(&mut self) -> Option<&mut crate::ExprNamed> {
-        match self {
-            Self::Named(val) => Some(val),
-            _ => None,
-        }
-    }
-
-    #[inline]
-    pub fn as_named_expr(&self) -> Option<&crate::ExprNamed> {
-        match self {
-            Self::Named(val) => Some(val),
-            _ => None,
-        }
-    }
-
-    #[inline]
-    pub const fn is_bin_op_expr(&self) -> bool {
-        matches!(self, Self::BinOp(_))
-    }
-
-    #[inline]
-    pub fn bin_op_expr(self) -> Option<crate::ExprBinOp> {
-        match self {
-            Self::BinOp(val) => Some(val),
-            _ => None,
-        }
-    }
-
-    #[inline]
-    pub fn expect_bin_op_expr(self) -> crate::ExprBinOp {
-        match self {
-            Self::BinOp(val) => val,
-            _ => panic!("called expect on {self:?}"),
-        }
-    }
-
-    #[inline]
-    pub fn as_bin_op_expr_mut(&mut self) -> Option<&mut crate::ExprBinOp> {
-        match self {
-            Self::BinOp(val) => Some(val),
-            _ => None,
-        }
-    }
-
-    #[inline]
-    pub fn as_bin_op_expr(&self) -> Option<&crate::ExprBinOp> {
-        match self {
-            Self::BinOp(val) => Some(val),
-            _ => None,
-        }
-    }
-
-    #[inline]
-    pub const fn is_unary_op_expr(&self) -> bool {
-        matches!(self, Self::UnaryOp(_))
-    }
-
-    #[inline]
-    pub fn unary_op_expr(self) -> Option<crate::ExprUnaryOp> {
-        match self {
-            Self::UnaryOp(val) => Some(val),
-            _ => None,
-        }
-    }
-
-    #[inline]
-    pub fn expect_unary_op_expr(self) -> crate::ExprUnaryOp {
-        match self {
-            Self::UnaryOp(val) => val,
-            _ => panic!("called expect on {self:?}"),
-        }
-    }
-
-    #[inline]
-    pub fn as_unary_op_expr_mut(&mut self) -> Option<&mut crate::ExprUnaryOp> {
-        match self {
-            Self::UnaryOp(val) => Some(val),
-            _ => None,
-        }
-    }
-
-    #[inline]
-    pub fn as_unary_op_expr(&self) -> Option<&crate::ExprUnaryOp> {
-        match self {
-            Self::UnaryOp(val) => Some(val),
-            _ => None,
-        }
-    }
-
-    #[inline]
-    pub const fn is_lambda_expr(&self) -> bool {
-        matches!(self, Self::Lambda(_))
-    }
-
-    #[inline]
-    pub fn lambda_expr(self) -> Option<crate::ExprLambda> {
-        match self {
-            Self::Lambda(val) => Some(val),
-            _ => None,
-        }
-    }
-
-    #[inline]
-    pub fn expect_lambda_expr(self) -> crate::ExprLambda {
-        match self {
-            Self::Lambda(val) => val,
-            _ => panic!("called expect on {self:?}"),
-        }
-    }
-
-    #[inline]
-    pub fn as_lambda_expr_mut(&mut self) -> Option<&mut crate::ExprLambda> {
-        match self {
-            Self::Lambda(val) => Some(val),
-            _ => None,
-        }
-    }
-
-    #[inline]
-    pub fn as_lambda_expr(&self) -> Option<&crate::ExprLambda> {
-        match self {
-            Self::Lambda(val) => Some(val),
-            _ => None,
-        }
-    }
-
-    #[inline]
-    pub const fn is_if_expr(&self) -> bool {
-        matches!(self, Self::If(_))
-    }
-
-    #[inline]
-    pub fn if_expr(self) -> Option<crate::ExprIf> {
-        match self {
-            Self::If(val) => Some(val),
-            _ => None,
-        }
-    }
-
-    #[inline]
-    pub fn expect_if_expr(self) -> crate::ExprIf {
-        match self {
-            Self::If(val) => val,
-            _ => panic!("called expect on {self:?}"),
-        }
-    }
-
-    #[inline]
-    pub fn as_if_expr_mut(&mut self) -> Option<&mut crate::ExprIf> {
-        match self {
-            Self::If(val) => Some(val),
-            _ => None,
-        }
-    }
-
-    #[inline]
-    pub fn as_if_expr(&self) -> Option<&crate::ExprIf> {
-        match self {
-            Self::If(val) => Some(val),
-            _ => None,
-        }
-    }
-
-    #[inline]
-    pub const fn is_dict_expr(&self) -> bool {
-        matches!(self, Self::Dict(_))
-    }
-
-    #[inline]
-    pub fn dict_expr(self) -> Option<crate::ExprDict> {
-        match self {
-            Self::Dict(val) => Some(val),
-            _ => None,
-        }
-    }
-
-    #[inline]
-    pub fn expect_dict_expr(self) -> crate::ExprDict {
-        match self {
-            Self::Dict(val) => val,
-            _ => panic!("called expect on {self:?}"),
-        }
-    }
-
-    #[inline]
-    pub fn as_dict_expr_mut(&mut self) -> Option<&mut crate::ExprDict> {
-        match self {
-            Self::Dict(val) => Some(val),
-            _ => None,
-        }
-    }
-
-    #[inline]
-    pub fn as_dict_expr(&self) -> Option<&crate::ExprDict> {
-        match self {
-            Self::Dict(val) => Some(val),
-            _ => None,
-        }
-    }
 }
 
 /// See also [excepthandler](https://docs.python.org/3/library/ast.html#ast.excepthandler)
@@ -3548,6 +3548,48 @@ impl ruff_text_size::Ranged for crate::StmtIpyEscapeCommand {
     }
 }
 
+impl ruff_text_size::Ranged for crate::ExprBoolOp {
+    fn range(&self) -> ruff_text_size::TextRange {
+        self.range
+    }
+}
+
+impl ruff_text_size::Ranged for crate::ExprNamed {
+    fn range(&self) -> ruff_text_size::TextRange {
+        self.range
+    }
+}
+
+impl ruff_text_size::Ranged for crate::ExprBinOp {
+    fn range(&self) -> ruff_text_size::TextRange {
+        self.range
+    }
+}
+
+impl ruff_text_size::Ranged for crate::ExprUnaryOp {
+    fn range(&self) -> ruff_text_size::TextRange {
+        self.range
+    }
+}
+
+impl ruff_text_size::Ranged for crate::ExprLambda {
+    fn range(&self) -> ruff_text_size::TextRange {
+        self.range
+    }
+}
+
+impl ruff_text_size::Ranged for crate::ExprIf {
+    fn range(&self) -> ruff_text_size::TextRange {
+        self.range
+    }
+}
+
+impl ruff_text_size::Ranged for crate::ExprDict {
+    fn range(&self) -> ruff_text_size::TextRange {
+        self.range
+    }
+}
+
 impl ruff_text_size::Ranged for crate::ExprSet {
     fn range(&self) -> ruff_text_size::TextRange {
         self.range
@@ -3693,48 +3735,6 @@ impl ruff_text_size::Ranged for crate::ExprSlice {
 }
 
 impl ruff_text_size::Ranged for crate::ExprIpyEscapeCommand {
-    fn range(&self) -> ruff_text_size::TextRange {
-        self.range
-    }
-}
-
-impl ruff_text_size::Ranged for crate::ExprBoolOp {
-    fn range(&self) -> ruff_text_size::TextRange {
-        self.range
-    }
-}
-
-impl ruff_text_size::Ranged for crate::ExprNamed {
-    fn range(&self) -> ruff_text_size::TextRange {
-        self.range
-    }
-}
-
-impl ruff_text_size::Ranged for crate::ExprBinOp {
-    fn range(&self) -> ruff_text_size::TextRange {
-        self.range
-    }
-}
-
-impl ruff_text_size::Ranged for crate::ExprUnaryOp {
-    fn range(&self) -> ruff_text_size::TextRange {
-        self.range
-    }
-}
-
-impl ruff_text_size::Ranged for crate::ExprLambda {
-    fn range(&self) -> ruff_text_size::TextRange {
-        self.range
-    }
-}
-
-impl ruff_text_size::Ranged for crate::ExprIf {
-    fn range(&self) -> ruff_text_size::TextRange {
-        self.range
-    }
-}
-
-impl ruff_text_size::Ranged for crate::ExprDict {
     fn range(&self) -> ruff_text_size::TextRange {
         self.range
     }
@@ -3994,6 +3994,13 @@ impl Expr {
         V: crate::visitor::source_order::SourceOrderVisitor<'a> + ?Sized,
     {
         match self {
+            Expr::BoolOp(node) => node.visit_source_order(visitor),
+            Expr::Named(node) => node.visit_source_order(visitor),
+            Expr::BinOp(node) => node.visit_source_order(visitor),
+            Expr::UnaryOp(node) => node.visit_source_order(visitor),
+            Expr::Lambda(node) => node.visit_source_order(visitor),
+            Expr::If(node) => node.visit_source_order(visitor),
+            Expr::Dict(node) => node.visit_source_order(visitor),
             Expr::Set(node) => node.visit_source_order(visitor),
             Expr::ListComp(node) => node.visit_source_order(visitor),
             Expr::SetComp(node) => node.visit_source_order(visitor),
@@ -4019,13 +4026,6 @@ impl Expr {
             Expr::Tuple(node) => node.visit_source_order(visitor),
             Expr::Slice(node) => node.visit_source_order(visitor),
             Expr::IpyEscapeCommand(node) => node.visit_source_order(visitor),
-            Expr::BoolOp(node) => node.visit_source_order(visitor),
-            Expr::Named(node) => node.visit_source_order(visitor),
-            Expr::BinOp(node) => node.visit_source_order(visitor),
-            Expr::UnaryOp(node) => node.visit_source_order(visitor),
-            Expr::Lambda(node) => node.visit_source_order(visitor),
-            Expr::If(node) => node.visit_source_order(visitor),
-            Expr::Dict(node) => node.visit_source_order(visitor),
         }
     }
 }
@@ -4397,6 +4397,20 @@ impl ruff_text_size::Ranged for StmtRef<'_> {
 /// See also [expr](https://docs.python.org/3/library/ast.html#ast.expr)
 #[derive(Clone, Copy, Debug, PartialEq, is_macro::Is)]
 pub enum ExprRef<'a> {
+    #[is(name = "bool_op_expr")]
+    BoolOp(&'a crate::ExprBoolOp),
+    #[is(name = "named_expr")]
+    Named(&'a crate::ExprNamed),
+    #[is(name = "bin_op_expr")]
+    BinOp(&'a crate::ExprBinOp),
+    #[is(name = "unary_op_expr")]
+    UnaryOp(&'a crate::ExprUnaryOp),
+    #[is(name = "lambda_expr")]
+    Lambda(&'a crate::ExprLambda),
+    #[is(name = "if_expr")]
+    If(&'a crate::ExprIf),
+    #[is(name = "dict_expr")]
+    Dict(&'a crate::ExprDict),
     #[is(name = "set_expr")]
     Set(&'a crate::ExprSet),
     #[is(name = "list_comp_expr")]
@@ -4447,25 +4461,18 @@ pub enum ExprRef<'a> {
     Slice(&'a crate::ExprSlice),
     #[is(name = "ipy_escape_command_expr")]
     IpyEscapeCommand(&'a crate::ExprIpyEscapeCommand),
-    #[is(name = "bool_op_expr")]
-    BoolOp(&'a crate::ExprBoolOp),
-    #[is(name = "named_expr")]
-    Named(&'a crate::ExprNamed),
-    #[is(name = "bin_op_expr")]
-    BinOp(&'a crate::ExprBinOp),
-    #[is(name = "unary_op_expr")]
-    UnaryOp(&'a crate::ExprUnaryOp),
-    #[is(name = "lambda_expr")]
-    Lambda(&'a crate::ExprLambda),
-    #[is(name = "if_expr")]
-    If(&'a crate::ExprIf),
-    #[is(name = "dict_expr")]
-    Dict(&'a crate::ExprDict),
 }
 
 impl<'a> From<&'a Expr> for ExprRef<'a> {
     fn from(node: &'a Expr) -> Self {
         match node {
+            Expr::BoolOp(node) => ExprRef::BoolOp(node),
+            Expr::Named(node) => ExprRef::Named(node),
+            Expr::BinOp(node) => ExprRef::BinOp(node),
+            Expr::UnaryOp(node) => ExprRef::UnaryOp(node),
+            Expr::Lambda(node) => ExprRef::Lambda(node),
+            Expr::If(node) => ExprRef::If(node),
+            Expr::Dict(node) => ExprRef::Dict(node),
             Expr::Set(node) => ExprRef::Set(node),
             Expr::ListComp(node) => ExprRef::ListComp(node),
             Expr::SetComp(node) => ExprRef::SetComp(node),
@@ -4491,14 +4498,49 @@ impl<'a> From<&'a Expr> for ExprRef<'a> {
             Expr::Tuple(node) => ExprRef::Tuple(node),
             Expr::Slice(node) => ExprRef::Slice(node),
             Expr::IpyEscapeCommand(node) => ExprRef::IpyEscapeCommand(node),
-            Expr::BoolOp(node) => ExprRef::BoolOp(node),
-            Expr::Named(node) => ExprRef::Named(node),
-            Expr::BinOp(node) => ExprRef::BinOp(node),
-            Expr::UnaryOp(node) => ExprRef::UnaryOp(node),
-            Expr::Lambda(node) => ExprRef::Lambda(node),
-            Expr::If(node) => ExprRef::If(node),
-            Expr::Dict(node) => ExprRef::Dict(node),
         }
+    }
+}
+
+impl<'a> From<&'a crate::ExprBoolOp> for ExprRef<'a> {
+    fn from(node: &'a crate::ExprBoolOp) -> Self {
+        Self::BoolOp(node)
+    }
+}
+
+impl<'a> From<&'a crate::ExprNamed> for ExprRef<'a> {
+    fn from(node: &'a crate::ExprNamed) -> Self {
+        Self::Named(node)
+    }
+}
+
+impl<'a> From<&'a crate::ExprBinOp> for ExprRef<'a> {
+    fn from(node: &'a crate::ExprBinOp) -> Self {
+        Self::BinOp(node)
+    }
+}
+
+impl<'a> From<&'a crate::ExprUnaryOp> for ExprRef<'a> {
+    fn from(node: &'a crate::ExprUnaryOp) -> Self {
+        Self::UnaryOp(node)
+    }
+}
+
+impl<'a> From<&'a crate::ExprLambda> for ExprRef<'a> {
+    fn from(node: &'a crate::ExprLambda) -> Self {
+        Self::Lambda(node)
+    }
+}
+
+impl<'a> From<&'a crate::ExprIf> for ExprRef<'a> {
+    fn from(node: &'a crate::ExprIf) -> Self {
+        Self::If(node)
+    }
+}
+
+impl<'a> From<&'a crate::ExprDict> for ExprRef<'a> {
+    fn from(node: &'a crate::ExprDict) -> Self {
+        Self::Dict(node)
     }
 }
 
@@ -4652,51 +4694,16 @@ impl<'a> From<&'a crate::ExprIpyEscapeCommand> for ExprRef<'a> {
     }
 }
 
-impl<'a> From<&'a crate::ExprBoolOp> for ExprRef<'a> {
-    fn from(node: &'a crate::ExprBoolOp) -> Self {
-        Self::BoolOp(node)
-    }
-}
-
-impl<'a> From<&'a crate::ExprNamed> for ExprRef<'a> {
-    fn from(node: &'a crate::ExprNamed) -> Self {
-        Self::Named(node)
-    }
-}
-
-impl<'a> From<&'a crate::ExprBinOp> for ExprRef<'a> {
-    fn from(node: &'a crate::ExprBinOp) -> Self {
-        Self::BinOp(node)
-    }
-}
-
-impl<'a> From<&'a crate::ExprUnaryOp> for ExprRef<'a> {
-    fn from(node: &'a crate::ExprUnaryOp) -> Self {
-        Self::UnaryOp(node)
-    }
-}
-
-impl<'a> From<&'a crate::ExprLambda> for ExprRef<'a> {
-    fn from(node: &'a crate::ExprLambda) -> Self {
-        Self::Lambda(node)
-    }
-}
-
-impl<'a> From<&'a crate::ExprIf> for ExprRef<'a> {
-    fn from(node: &'a crate::ExprIf) -> Self {
-        Self::If(node)
-    }
-}
-
-impl<'a> From<&'a crate::ExprDict> for ExprRef<'a> {
-    fn from(node: &'a crate::ExprDict) -> Self {
-        Self::Dict(node)
-    }
-}
-
 impl ruff_text_size::Ranged for ExprRef<'_> {
     fn range(&self) -> ruff_text_size::TextRange {
         match self {
+            Self::BoolOp(node) => node.range(),
+            Self::Named(node) => node.range(),
+            Self::BinOp(node) => node.range(),
+            Self::UnaryOp(node) => node.range(),
+            Self::Lambda(node) => node.range(),
+            Self::If(node) => node.range(),
+            Self::Dict(node) => node.range(),
             Self::Set(node) => node.range(),
             Self::ListComp(node) => node.range(),
             Self::SetComp(node) => node.range(),
@@ -4722,13 +4729,6 @@ impl ruff_text_size::Ranged for ExprRef<'_> {
             Self::Tuple(node) => node.range(),
             Self::Slice(node) => node.range(),
             Self::IpyEscapeCommand(node) => node.range(),
-            Self::BoolOp(node) => node.range(),
-            Self::Named(node) => node.range(),
-            Self::BinOp(node) => node.range(),
-            Self::UnaryOp(node) => node.range(),
-            Self::Lambda(node) => node.range(),
-            Self::If(node) => node.range(),
-            Self::Dict(node) => node.range(),
         }
     }
 }
@@ -4963,6 +4963,13 @@ pub enum AnyNodeRef<'a> {
     StmtBreak(&'a crate::StmtBreak),
     StmtContinue(&'a crate::StmtContinue),
     StmtIpyEscapeCommand(&'a crate::StmtIpyEscapeCommand),
+    ExprBoolOp(&'a crate::ExprBoolOp),
+    ExprNamed(&'a crate::ExprNamed),
+    ExprBinOp(&'a crate::ExprBinOp),
+    ExprUnaryOp(&'a crate::ExprUnaryOp),
+    ExprLambda(&'a crate::ExprLambda),
+    ExprIf(&'a crate::ExprIf),
+    ExprDict(&'a crate::ExprDict),
     ExprSet(&'a crate::ExprSet),
     ExprListComp(&'a crate::ExprListComp),
     ExprSetComp(&'a crate::ExprSetComp),
@@ -4988,13 +4995,6 @@ pub enum AnyNodeRef<'a> {
     ExprTuple(&'a crate::ExprTuple),
     ExprSlice(&'a crate::ExprSlice),
     ExprIpyEscapeCommand(&'a crate::ExprIpyEscapeCommand),
-    ExprBoolOp(&'a crate::ExprBoolOp),
-    ExprNamed(&'a crate::ExprNamed),
-    ExprBinOp(&'a crate::ExprBinOp),
-    ExprUnaryOp(&'a crate::ExprUnaryOp),
-    ExprLambda(&'a crate::ExprLambda),
-    ExprIf(&'a crate::ExprIf),
-    ExprDict(&'a crate::ExprDict),
     ExceptHandlerExceptHandler(&'a crate::ExceptHandlerExceptHandler),
     FStringExpressionElement(&'a crate::FStringExpressionElement),
     FStringLiteralElement(&'a crate::FStringLiteralElement),
@@ -5115,6 +5115,13 @@ impl<'a> From<StmtRef<'a>> for AnyNodeRef<'a> {
 impl<'a> From<&'a Expr> for AnyNodeRef<'a> {
     fn from(node: &'a Expr) -> AnyNodeRef<'a> {
         match node {
+            Expr::BoolOp(node) => AnyNodeRef::ExprBoolOp(node),
+            Expr::Named(node) => AnyNodeRef::ExprNamed(node),
+            Expr::BinOp(node) => AnyNodeRef::ExprBinOp(node),
+            Expr::UnaryOp(node) => AnyNodeRef::ExprUnaryOp(node),
+            Expr::Lambda(node) => AnyNodeRef::ExprLambda(node),
+            Expr::If(node) => AnyNodeRef::ExprIf(node),
+            Expr::Dict(node) => AnyNodeRef::ExprDict(node),
             Expr::Set(node) => AnyNodeRef::ExprSet(node),
             Expr::ListComp(node) => AnyNodeRef::ExprListComp(node),
             Expr::SetComp(node) => AnyNodeRef::ExprSetComp(node),
@@ -5140,13 +5147,6 @@ impl<'a> From<&'a Expr> for AnyNodeRef<'a> {
             Expr::Tuple(node) => AnyNodeRef::ExprTuple(node),
             Expr::Slice(node) => AnyNodeRef::ExprSlice(node),
             Expr::IpyEscapeCommand(node) => AnyNodeRef::ExprIpyEscapeCommand(node),
-            Expr::BoolOp(node) => AnyNodeRef::ExprBoolOp(node),
-            Expr::Named(node) => AnyNodeRef::ExprNamed(node),
-            Expr::BinOp(node) => AnyNodeRef::ExprBinOp(node),
-            Expr::UnaryOp(node) => AnyNodeRef::ExprUnaryOp(node),
-            Expr::Lambda(node) => AnyNodeRef::ExprLambda(node),
-            Expr::If(node) => AnyNodeRef::ExprIf(node),
-            Expr::Dict(node) => AnyNodeRef::ExprDict(node),
         }
     }
 }
@@ -5154,6 +5154,13 @@ impl<'a> From<&'a Expr> for AnyNodeRef<'a> {
 impl<'a> From<ExprRef<'a>> for AnyNodeRef<'a> {
     fn from(node: ExprRef<'a>) -> AnyNodeRef<'a> {
         match node {
+            ExprRef::BoolOp(node) => AnyNodeRef::ExprBoolOp(node),
+            ExprRef::Named(node) => AnyNodeRef::ExprNamed(node),
+            ExprRef::BinOp(node) => AnyNodeRef::ExprBinOp(node),
+            ExprRef::UnaryOp(node) => AnyNodeRef::ExprUnaryOp(node),
+            ExprRef::Lambda(node) => AnyNodeRef::ExprLambda(node),
+            ExprRef::If(node) => AnyNodeRef::ExprIf(node),
+            ExprRef::Dict(node) => AnyNodeRef::ExprDict(node),
             ExprRef::Set(node) => AnyNodeRef::ExprSet(node),
             ExprRef::ListComp(node) => AnyNodeRef::ExprListComp(node),
             ExprRef::SetComp(node) => AnyNodeRef::ExprSetComp(node),
@@ -5179,13 +5186,6 @@ impl<'a> From<ExprRef<'a>> for AnyNodeRef<'a> {
             ExprRef::Tuple(node) => AnyNodeRef::ExprTuple(node),
             ExprRef::Slice(node) => AnyNodeRef::ExprSlice(node),
             ExprRef::IpyEscapeCommand(node) => AnyNodeRef::ExprIpyEscapeCommand(node),
-            ExprRef::BoolOp(node) => AnyNodeRef::ExprBoolOp(node),
-            ExprRef::Named(node) => AnyNodeRef::ExprNamed(node),
-            ExprRef::BinOp(node) => AnyNodeRef::ExprBinOp(node),
-            ExprRef::UnaryOp(node) => AnyNodeRef::ExprUnaryOp(node),
-            ExprRef::Lambda(node) => AnyNodeRef::ExprLambda(node),
-            ExprRef::If(node) => AnyNodeRef::ExprIf(node),
-            ExprRef::Dict(node) => AnyNodeRef::ExprDict(node),
         }
     }
 }
@@ -5436,6 +5436,48 @@ impl<'a> From<&'a crate::StmtIpyEscapeCommand> for AnyNodeRef<'a> {
     }
 }
 
+impl<'a> From<&'a crate::ExprBoolOp> for AnyNodeRef<'a> {
+    fn from(node: &'a crate::ExprBoolOp) -> AnyNodeRef<'a> {
+        AnyNodeRef::ExprBoolOp(node)
+    }
+}
+
+impl<'a> From<&'a crate::ExprNamed> for AnyNodeRef<'a> {
+    fn from(node: &'a crate::ExprNamed) -> AnyNodeRef<'a> {
+        AnyNodeRef::ExprNamed(node)
+    }
+}
+
+impl<'a> From<&'a crate::ExprBinOp> for AnyNodeRef<'a> {
+    fn from(node: &'a crate::ExprBinOp) -> AnyNodeRef<'a> {
+        AnyNodeRef::ExprBinOp(node)
+    }
+}
+
+impl<'a> From<&'a crate::ExprUnaryOp> for AnyNodeRef<'a> {
+    fn from(node: &'a crate::ExprUnaryOp) -> AnyNodeRef<'a> {
+        AnyNodeRef::ExprUnaryOp(node)
+    }
+}
+
+impl<'a> From<&'a crate::ExprLambda> for AnyNodeRef<'a> {
+    fn from(node: &'a crate::ExprLambda) -> AnyNodeRef<'a> {
+        AnyNodeRef::ExprLambda(node)
+    }
+}
+
+impl<'a> From<&'a crate::ExprIf> for AnyNodeRef<'a> {
+    fn from(node: &'a crate::ExprIf) -> AnyNodeRef<'a> {
+        AnyNodeRef::ExprIf(node)
+    }
+}
+
+impl<'a> From<&'a crate::ExprDict> for AnyNodeRef<'a> {
+    fn from(node: &'a crate::ExprDict) -> AnyNodeRef<'a> {
+        AnyNodeRef::ExprDict(node)
+    }
+}
+
 impl<'a> From<&'a crate::ExprSet> for AnyNodeRef<'a> {
     fn from(node: &'a crate::ExprSet) -> AnyNodeRef<'a> {
         AnyNodeRef::ExprSet(node)
@@ -5583,48 +5625,6 @@ impl<'a> From<&'a crate::ExprSlice> for AnyNodeRef<'a> {
 impl<'a> From<&'a crate::ExprIpyEscapeCommand> for AnyNodeRef<'a> {
     fn from(node: &'a crate::ExprIpyEscapeCommand) -> AnyNodeRef<'a> {
         AnyNodeRef::ExprIpyEscapeCommand(node)
-    }
-}
-
-impl<'a> From<&'a crate::ExprBoolOp> for AnyNodeRef<'a> {
-    fn from(node: &'a crate::ExprBoolOp) -> AnyNodeRef<'a> {
-        AnyNodeRef::ExprBoolOp(node)
-    }
-}
-
-impl<'a> From<&'a crate::ExprNamed> for AnyNodeRef<'a> {
-    fn from(node: &'a crate::ExprNamed) -> AnyNodeRef<'a> {
-        AnyNodeRef::ExprNamed(node)
-    }
-}
-
-impl<'a> From<&'a crate::ExprBinOp> for AnyNodeRef<'a> {
-    fn from(node: &'a crate::ExprBinOp) -> AnyNodeRef<'a> {
-        AnyNodeRef::ExprBinOp(node)
-    }
-}
-
-impl<'a> From<&'a crate::ExprUnaryOp> for AnyNodeRef<'a> {
-    fn from(node: &'a crate::ExprUnaryOp) -> AnyNodeRef<'a> {
-        AnyNodeRef::ExprUnaryOp(node)
-    }
-}
-
-impl<'a> From<&'a crate::ExprLambda> for AnyNodeRef<'a> {
-    fn from(node: &'a crate::ExprLambda) -> AnyNodeRef<'a> {
-        AnyNodeRef::ExprLambda(node)
-    }
-}
-
-impl<'a> From<&'a crate::ExprIf> for AnyNodeRef<'a> {
-    fn from(node: &'a crate::ExprIf) -> AnyNodeRef<'a> {
-        AnyNodeRef::ExprIf(node)
-    }
-}
-
-impl<'a> From<&'a crate::ExprDict> for AnyNodeRef<'a> {
-    fn from(node: &'a crate::ExprDict) -> AnyNodeRef<'a> {
-        AnyNodeRef::ExprDict(node)
     }
 }
 
@@ -5856,6 +5856,13 @@ impl ruff_text_size::Ranged for AnyNodeRef<'_> {
             AnyNodeRef::StmtBreak(node) => node.range(),
             AnyNodeRef::StmtContinue(node) => node.range(),
             AnyNodeRef::StmtIpyEscapeCommand(node) => node.range(),
+            AnyNodeRef::ExprBoolOp(node) => node.range(),
+            AnyNodeRef::ExprNamed(node) => node.range(),
+            AnyNodeRef::ExprBinOp(node) => node.range(),
+            AnyNodeRef::ExprUnaryOp(node) => node.range(),
+            AnyNodeRef::ExprLambda(node) => node.range(),
+            AnyNodeRef::ExprIf(node) => node.range(),
+            AnyNodeRef::ExprDict(node) => node.range(),
             AnyNodeRef::ExprSet(node) => node.range(),
             AnyNodeRef::ExprListComp(node) => node.range(),
             AnyNodeRef::ExprSetComp(node) => node.range(),
@@ -5881,13 +5888,6 @@ impl ruff_text_size::Ranged for AnyNodeRef<'_> {
             AnyNodeRef::ExprTuple(node) => node.range(),
             AnyNodeRef::ExprSlice(node) => node.range(),
             AnyNodeRef::ExprIpyEscapeCommand(node) => node.range(),
-            AnyNodeRef::ExprBoolOp(node) => node.range(),
-            AnyNodeRef::ExprNamed(node) => node.range(),
-            AnyNodeRef::ExprBinOp(node) => node.range(),
-            AnyNodeRef::ExprUnaryOp(node) => node.range(),
-            AnyNodeRef::ExprLambda(node) => node.range(),
-            AnyNodeRef::ExprIf(node) => node.range(),
-            AnyNodeRef::ExprDict(node) => node.range(),
             AnyNodeRef::ExceptHandlerExceptHandler(node) => node.range(),
             AnyNodeRef::FStringExpressionElement(node) => node.range(),
             AnyNodeRef::FStringLiteralElement(node) => node.range(),
@@ -5955,6 +5955,13 @@ impl AnyNodeRef<'_> {
             AnyNodeRef::StmtBreak(node) => std::ptr::NonNull::from(*node).cast(),
             AnyNodeRef::StmtContinue(node) => std::ptr::NonNull::from(*node).cast(),
             AnyNodeRef::StmtIpyEscapeCommand(node) => std::ptr::NonNull::from(*node).cast(),
+            AnyNodeRef::ExprBoolOp(node) => std::ptr::NonNull::from(*node).cast(),
+            AnyNodeRef::ExprNamed(node) => std::ptr::NonNull::from(*node).cast(),
+            AnyNodeRef::ExprBinOp(node) => std::ptr::NonNull::from(*node).cast(),
+            AnyNodeRef::ExprUnaryOp(node) => std::ptr::NonNull::from(*node).cast(),
+            AnyNodeRef::ExprLambda(node) => std::ptr::NonNull::from(*node).cast(),
+            AnyNodeRef::ExprIf(node) => std::ptr::NonNull::from(*node).cast(),
+            AnyNodeRef::ExprDict(node) => std::ptr::NonNull::from(*node).cast(),
             AnyNodeRef::ExprSet(node) => std::ptr::NonNull::from(*node).cast(),
             AnyNodeRef::ExprListComp(node) => std::ptr::NonNull::from(*node).cast(),
             AnyNodeRef::ExprSetComp(node) => std::ptr::NonNull::from(*node).cast(),
@@ -5980,13 +5987,6 @@ impl AnyNodeRef<'_> {
             AnyNodeRef::ExprTuple(node) => std::ptr::NonNull::from(*node).cast(),
             AnyNodeRef::ExprSlice(node) => std::ptr::NonNull::from(*node).cast(),
             AnyNodeRef::ExprIpyEscapeCommand(node) => std::ptr::NonNull::from(*node).cast(),
-            AnyNodeRef::ExprBoolOp(node) => std::ptr::NonNull::from(*node).cast(),
-            AnyNodeRef::ExprNamed(node) => std::ptr::NonNull::from(*node).cast(),
-            AnyNodeRef::ExprBinOp(node) => std::ptr::NonNull::from(*node).cast(),
-            AnyNodeRef::ExprUnaryOp(node) => std::ptr::NonNull::from(*node).cast(),
-            AnyNodeRef::ExprLambda(node) => std::ptr::NonNull::from(*node).cast(),
-            AnyNodeRef::ExprIf(node) => std::ptr::NonNull::from(*node).cast(),
-            AnyNodeRef::ExprDict(node) => std::ptr::NonNull::from(*node).cast(),
             AnyNodeRef::ExceptHandlerExceptHandler(node) => std::ptr::NonNull::from(*node).cast(),
             AnyNodeRef::FStringExpressionElement(node) => std::ptr::NonNull::from(*node).cast(),
             AnyNodeRef::FStringLiteralElement(node) => std::ptr::NonNull::from(*node).cast(),
@@ -6058,6 +6058,13 @@ impl<'a> AnyNodeRef<'a> {
             AnyNodeRef::StmtBreak(node) => node.visit_source_order(visitor),
             AnyNodeRef::StmtContinue(node) => node.visit_source_order(visitor),
             AnyNodeRef::StmtIpyEscapeCommand(node) => node.visit_source_order(visitor),
+            AnyNodeRef::ExprBoolOp(node) => node.visit_source_order(visitor),
+            AnyNodeRef::ExprNamed(node) => node.visit_source_order(visitor),
+            AnyNodeRef::ExprBinOp(node) => node.visit_source_order(visitor),
+            AnyNodeRef::ExprUnaryOp(node) => node.visit_source_order(visitor),
+            AnyNodeRef::ExprLambda(node) => node.visit_source_order(visitor),
+            AnyNodeRef::ExprIf(node) => node.visit_source_order(visitor),
+            AnyNodeRef::ExprDict(node) => node.visit_source_order(visitor),
             AnyNodeRef::ExprSet(node) => node.visit_source_order(visitor),
             AnyNodeRef::ExprListComp(node) => node.visit_source_order(visitor),
             AnyNodeRef::ExprSetComp(node) => node.visit_source_order(visitor),
@@ -6083,13 +6090,6 @@ impl<'a> AnyNodeRef<'a> {
             AnyNodeRef::ExprTuple(node) => node.visit_source_order(visitor),
             AnyNodeRef::ExprSlice(node) => node.visit_source_order(visitor),
             AnyNodeRef::ExprIpyEscapeCommand(node) => node.visit_source_order(visitor),
-            AnyNodeRef::ExprBoolOp(node) => node.visit_source_order(visitor),
-            AnyNodeRef::ExprNamed(node) => node.visit_source_order(visitor),
-            AnyNodeRef::ExprBinOp(node) => node.visit_source_order(visitor),
-            AnyNodeRef::ExprUnaryOp(node) => node.visit_source_order(visitor),
-            AnyNodeRef::ExprLambda(node) => node.visit_source_order(visitor),
-            AnyNodeRef::ExprIf(node) => node.visit_source_order(visitor),
-            AnyNodeRef::ExprDict(node) => node.visit_source_order(visitor),
             AnyNodeRef::ExceptHandlerExceptHandler(node) => node.visit_source_order(visitor),
             AnyNodeRef::FStringExpressionElement(node) => node.visit_source_order(visitor),
             AnyNodeRef::FStringLiteralElement(node) => node.visit_source_order(visitor),
@@ -6173,7 +6173,14 @@ impl AnyNodeRef<'_> {
     pub const fn is_expression(self) -> bool {
         matches!(
             self,
-            AnyNodeRef::ExprSet(_)
+            AnyNodeRef::ExprBoolOp(_)
+                | AnyNodeRef::ExprNamed(_)
+                | AnyNodeRef::ExprBinOp(_)
+                | AnyNodeRef::ExprUnaryOp(_)
+                | AnyNodeRef::ExprLambda(_)
+                | AnyNodeRef::ExprIf(_)
+                | AnyNodeRef::ExprDict(_)
+                | AnyNodeRef::ExprSet(_)
                 | AnyNodeRef::ExprListComp(_)
                 | AnyNodeRef::ExprSetComp(_)
                 | AnyNodeRef::ExprDictComp(_)
@@ -6198,13 +6205,6 @@ impl AnyNodeRef<'_> {
                 | AnyNodeRef::ExprTuple(_)
                 | AnyNodeRef::ExprSlice(_)
                 | AnyNodeRef::ExprIpyEscapeCommand(_)
-                | AnyNodeRef::ExprBoolOp(_)
-                | AnyNodeRef::ExprNamed(_)
-                | AnyNodeRef::ExprBinOp(_)
-                | AnyNodeRef::ExprUnaryOp(_)
-                | AnyNodeRef::ExprLambda(_)
-                | AnyNodeRef::ExprIf(_)
-                | AnyNodeRef::ExprDict(_)
         )
     }
 }
@@ -6280,6 +6280,13 @@ pub enum NodeKind {
     StmtBreak,
     StmtContinue,
     StmtIpyEscapeCommand,
+    ExprBoolOp,
+    ExprNamed,
+    ExprBinOp,
+    ExprUnaryOp,
+    ExprLambda,
+    ExprIf,
+    ExprDict,
     ExprSet,
     ExprListComp,
     ExprSetComp,
@@ -6305,13 +6312,6 @@ pub enum NodeKind {
     ExprTuple,
     ExprSlice,
     ExprIpyEscapeCommand,
-    ExprBoolOp,
-    ExprNamed,
-    ExprBinOp,
-    ExprUnaryOp,
-    ExprLambda,
-    ExprIf,
-    ExprDict,
     ExceptHandlerExceptHandler,
     FStringExpressionElement,
     FStringLiteralElement,
@@ -6377,6 +6377,13 @@ impl AnyNodeRef<'_> {
             AnyNodeRef::StmtBreak(_) => NodeKind::StmtBreak,
             AnyNodeRef::StmtContinue(_) => NodeKind::StmtContinue,
             AnyNodeRef::StmtIpyEscapeCommand(_) => NodeKind::StmtIpyEscapeCommand,
+            AnyNodeRef::ExprBoolOp(_) => NodeKind::ExprBoolOp,
+            AnyNodeRef::ExprNamed(_) => NodeKind::ExprNamed,
+            AnyNodeRef::ExprBinOp(_) => NodeKind::ExprBinOp,
+            AnyNodeRef::ExprUnaryOp(_) => NodeKind::ExprUnaryOp,
+            AnyNodeRef::ExprLambda(_) => NodeKind::ExprLambda,
+            AnyNodeRef::ExprIf(_) => NodeKind::ExprIf,
+            AnyNodeRef::ExprDict(_) => NodeKind::ExprDict,
             AnyNodeRef::ExprSet(_) => NodeKind::ExprSet,
             AnyNodeRef::ExprListComp(_) => NodeKind::ExprListComp,
             AnyNodeRef::ExprSetComp(_) => NodeKind::ExprSetComp,
@@ -6402,13 +6409,6 @@ impl AnyNodeRef<'_> {
             AnyNodeRef::ExprTuple(_) => NodeKind::ExprTuple,
             AnyNodeRef::ExprSlice(_) => NodeKind::ExprSlice,
             AnyNodeRef::ExprIpyEscapeCommand(_) => NodeKind::ExprIpyEscapeCommand,
-            AnyNodeRef::ExprBoolOp(_) => NodeKind::ExprBoolOp,
-            AnyNodeRef::ExprNamed(_) => NodeKind::ExprNamed,
-            AnyNodeRef::ExprBinOp(_) => NodeKind::ExprBinOp,
-            AnyNodeRef::ExprUnaryOp(_) => NodeKind::ExprUnaryOp,
-            AnyNodeRef::ExprLambda(_) => NodeKind::ExprLambda,
-            AnyNodeRef::ExprIf(_) => NodeKind::ExprIf,
-            AnyNodeRef::ExprDict(_) => NodeKind::ExprDict,
             AnyNodeRef::ExceptHandlerExceptHandler(_) => NodeKind::ExceptHandlerExceptHandler,
             AnyNodeRef::FStringExpressionElement(_) => NodeKind::FStringExpressionElement,
             AnyNodeRef::FStringLiteralElement(_) => NodeKind::FStringLiteralElement,
@@ -6494,4 +6494,173 @@ pub struct ExprIf {
 pub struct ExprDict {
     pub range: ruff_text_size::TextRange,
     pub items: Vec<crate::DictItem>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExprSet {
+    pub range: ruff_text_size::TextRange,
+    pub elts: Vec<crate::Expr>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExprListComp {
+    pub range: ruff_text_size::TextRange,
+    pub elt: Box<crate::Expr>,
+    pub generators: Vec<crate::Comprehension>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExprSetComp {
+    pub range: ruff_text_size::TextRange,
+    pub elt: Box<crate::Expr>,
+    pub generators: Vec<crate::Comprehension>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExprDictComp {
+    pub range: ruff_text_size::TextRange,
+    pub key: Box<crate::Expr>,
+    pub value: Box<crate::Expr>,
+    pub generators: Vec<crate::Comprehension>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExprGenerator {
+    pub range: ruff_text_size::TextRange,
+    pub elt: Box<crate::Expr>,
+    pub generators: Vec<crate::Comprehension>,
+    pub parenthesized: bool,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExprAwait {
+    pub range: ruff_text_size::TextRange,
+    pub value: Box<crate::Expr>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExprYield {
+    pub range: ruff_text_size::TextRange,
+    pub value: Option<Box<crate::Expr>>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExprYieldFrom {
+    pub range: ruff_text_size::TextRange,
+    pub value: Box<crate::Expr>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExprCompare {
+    pub range: ruff_text_size::TextRange,
+    pub left: Box<crate::Expr>,
+    pub ops: Box<[crate::CmpOp]>,
+    pub comparators: Box<[Expr]>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExprCall {
+    pub range: ruff_text_size::TextRange,
+    pub func: Box<crate::Expr>,
+    pub arguments: crate::Arguments,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExprFString {
+    pub range: ruff_text_size::TextRange,
+    pub value: crate::FStringValue,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExprStringLiteral {
+    pub range: ruff_text_size::TextRange,
+    pub value: crate::StringLiteralValue,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExprBytesLiteral {
+    pub range: ruff_text_size::TextRange,
+    pub value: crate::BytesLiteralValue,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExprNumberLiteral {
+    pub range: ruff_text_size::TextRange,
+    pub value: crate::Number,
+}
+
+#[derive(Clone, Debug, PartialEq, Default)]
+pub struct ExprBooleanLiteral {
+    pub range: ruff_text_size::TextRange,
+    pub value: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Default)]
+pub struct ExprNoneLiteral {
+    pub range: ruff_text_size::TextRange,
+}
+
+#[derive(Clone, Debug, PartialEq, Default)]
+pub struct ExprEllipsisLiteral {
+    pub range: ruff_text_size::TextRange,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExprAttribute {
+    pub range: ruff_text_size::TextRange,
+    pub value: Box<crate::Expr>,
+    pub attr: crate::Identifier,
+    pub ctx: crate::ExprContext,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExprSubscript {
+    pub range: ruff_text_size::TextRange,
+    pub value: Box<crate::Expr>,
+    pub slice: Box<crate::Expr>,
+    pub ctx: crate::ExprContext,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExprStarred {
+    pub range: ruff_text_size::TextRange,
+    pub value: Box<crate::Expr>,
+    pub ctx: crate::ExprContext,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExprName {
+    pub range: ruff_text_size::TextRange,
+    pub id: crate::name::Name,
+    pub ctx: crate::ExprContext,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExprList {
+    pub range: ruff_text_size::TextRange,
+    pub elts: Vec<crate::Expr>,
+    pub ctx: crate::ExprContext,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExprTuple {
+    pub range: ruff_text_size::TextRange,
+    pub elts: Vec<crate::Expr>,
+    pub ctx: crate::ExprContext,
+    pub parenthesized: bool,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExprSlice {
+    pub range: ruff_text_size::TextRange,
+    pub lower: Option<Box<crate::Expr>>,
+    pub upper: Option<Box<crate::Expr>>,
+    pub step: Option<Box<crate::Expr>>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExprIpyEscapeCommand {
+    pub range: ruff_text_size::TextRange,
+    pub kind: crate::IpyEscapeKind,
+    pub value: Box<str>,
 }

--- a/crates/ruff_python_ast/src/generated.rs
+++ b/crates/ruff_python_ast/src/generated.rs
@@ -6591,7 +6591,7 @@ pub struct ExprCall {
 /// doesn't join the implicitly concatenated parts into a single string. Instead,
 /// it keeps them separate and provide various methods to access the parts.
 ///
-/// [JoinedStr]: https://docs.python.org/3/library/ast.html#ast.JoinedStr
+/// See also [JoinedStr](https://docs.python.org/3/library/ast.html#ast.JoinedStr)
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprFString {
     pub range: ruff_text_size::TextRange,
@@ -6674,7 +6674,7 @@ pub struct ExprName {
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprList {
     pub range: ruff_text_size::TextRange,
-    pub elts: Vec<crate::Expr>,
+    pub elts: Option<Vec<crate::Expr>>,
     pub ctx: crate::ExprContext,
 }
 
@@ -6701,9 +6701,12 @@ pub struct ExprSlice {
 /// For example,
 /// ```python
 /// dir = !pwd
+/// ```
+///
+/// Here, the escape kind can only be `!` or `%` otherwise it is a syntax error.
 ///
 /// For more information related to terminology and syntax of escape commands,
-///  see [`StmtIpyEscapeCommand`].
+/// see [`StmtIpyEscapeCommand`].
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprIpyEscapeCommand {
     pub range: ruff_text_size::TextRange,

--- a/crates/ruff_python_ast/src/generated.rs
+++ b/crates/ruff_python_ast/src/generated.rs
@@ -6587,7 +6587,7 @@ pub struct ExprCall {
 /// An AST node that represents either a single-part f-string literal
 /// or an implicitly concatenated f-string literal.
 ///
-/// This type differs from the original Python AST ([`JoinedStr`]) in that it
+/// This type differs from the original Python AST `JoinedStr` in that it
 /// doesn't join the implicitly concatenated parts into a single string. Instead,
 /// it keeps them separate and provide various methods to access the parts.
 ///
@@ -6706,7 +6706,7 @@ pub struct ExprSlice {
 /// Here, the escape kind can only be `!` or `%` otherwise it is a syntax error.
 ///
 /// For more information related to terminology and syntax of escape commands,
-/// see [`StmtIpyEscapeCommand`].
+/// see [`crate::StmtIpyEscapeCommand`].
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprIpyEscapeCommand {
     pub range: ruff_text_size::TextRange,

--- a/crates/ruff_python_ast/src/generated.rs
+++ b/crates/ruff_python_ast/src/generated.rs
@@ -6448,6 +6448,7 @@ impl AnyNodeRef<'_> {
     }
 }
 
+/// See also [BoolOp](https://docs.python.org/3/library/ast.html#ast.BoolOp)
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprBoolOp {
     pub range: ruff_text_size::TextRange,
@@ -6455,6 +6456,7 @@ pub struct ExprBoolOp {
     pub values: Vec<crate::Expr>,
 }
 
+/// See also [NamedExpr](https://docs.python.org/3/library/ast.html#ast.NamedExpr)
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprNamed {
     pub range: ruff_text_size::TextRange,
@@ -6462,6 +6464,7 @@ pub struct ExprNamed {
     pub value: Box<crate::Expr>,
 }
 
+/// See also [BinOp](https://docs.python.org/3/library/ast.html#ast.BinOp)
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprBinOp {
     pub range: ruff_text_size::TextRange,
@@ -6470,6 +6473,7 @@ pub struct ExprBinOp {
     pub right: Box<crate::Expr>,
 }
 
+/// See also [UnaryOp](https://docs.python.org/3/library/ast.html#ast.UnaryOp)
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprUnaryOp {
     pub range: ruff_text_size::TextRange,
@@ -6477,6 +6481,7 @@ pub struct ExprUnaryOp {
     pub operand: Box<crate::Expr>,
 }
 
+/// See also [Lambda](https://docs.python.org/3/library/ast.html#ast.Lambda)
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprLambda {
     pub range: ruff_text_size::TextRange,
@@ -6484,6 +6489,7 @@ pub struct ExprLambda {
     pub body: Box<crate::Expr>,
 }
 
+/// See also [IfExp](https://docs.python.org/3/library/ast.html#ast.IfExp)
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprIf {
     pub range: ruff_text_size::TextRange,
@@ -6492,18 +6498,21 @@ pub struct ExprIf {
     pub orelse: Box<crate::Expr>,
 }
 
+/// See also [Dict](https://docs.python.org/3/library/ast.html#ast.Dict)
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprDict {
     pub range: ruff_text_size::TextRange,
     pub items: Vec<crate::DictItem>,
 }
 
+/// See also [Set](https://docs.python.org/3/library/ast.html#ast.Set)
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprSet {
     pub range: ruff_text_size::TextRange,
     pub elts: Vec<crate::Expr>,
 }
 
+/// See also [ListComp](https://docs.python.org/3/library/ast.html#ast.ListComp)
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprListComp {
     pub range: ruff_text_size::TextRange,
@@ -6511,6 +6520,7 @@ pub struct ExprListComp {
     pub generators: Vec<crate::Comprehension>,
 }
 
+/// See also [SetComp](https://docs.python.org/3/library/ast.html#ast.SetComp)
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprSetComp {
     pub range: ruff_text_size::TextRange,
@@ -6518,6 +6528,7 @@ pub struct ExprSetComp {
     pub generators: Vec<crate::Comprehension>,
 }
 
+/// See also [DictComp](https://docs.python.org/3/library/ast.html#ast.DictComp)
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprDictComp {
     pub range: ruff_text_size::TextRange,
@@ -6526,6 +6537,7 @@ pub struct ExprDictComp {
     pub generators: Vec<crate::Comprehension>,
 }
 
+/// See also [GeneratorExp](https://docs.python.org/3/library/ast.html#ast.GeneratorExp)
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprGenerator {
     pub range: ruff_text_size::TextRange,
@@ -6534,24 +6546,28 @@ pub struct ExprGenerator {
     pub parenthesized: bool,
 }
 
+/// See also [Await](https://docs.python.org/3/library/ast.html#ast.Await)
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprAwait {
     pub range: ruff_text_size::TextRange,
     pub value: Box<crate::Expr>,
 }
 
+/// See also [Yield](https://docs.python.org/3/library/ast.html#ast.Yield)
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprYield {
     pub range: ruff_text_size::TextRange,
     pub value: Option<Box<crate::Expr>>,
 }
 
+/// See also [YieldFrom](https://docs.python.org/3/library/ast.html#ast.YieldFrom)
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprYieldFrom {
     pub range: ruff_text_size::TextRange,
     pub value: Box<crate::Expr>,
 }
 
+/// See also [Compare](https://docs.python.org/3/library/ast.html#ast.Compare)
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprCompare {
     pub range: ruff_text_size::TextRange,
@@ -6560,6 +6576,7 @@ pub struct ExprCompare {
     pub comparators: Box<[Expr]>,
 }
 
+/// See also [Call](https://docs.python.org/3/library/ast.html#ast.Call)
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprCall {
     pub range: ruff_text_size::TextRange,
@@ -6567,18 +6584,30 @@ pub struct ExprCall {
     pub arguments: crate::Arguments,
 }
 
+/// An AST node that represents either a single-part f-string literal
+/// or an implicitly concatenated f-string literal.
+///
+/// This type differs from the original Python AST ([JoinedStr]) in that it
+/// doesn't join the implicitly concatenated parts into a single string. Instead,
+/// it keeps them separate and provide various methods to access the parts.
+///
+/// [JoinedStr]: https://docs.python.org/3/library/ast.html#ast.JoinedStr
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprFString {
     pub range: ruff_text_size::TextRange,
     pub value: crate::FStringValue,
 }
 
+/// An AST node that represents either a single-part string literal
+/// or an implicitly concatenated string literal.
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprStringLiteral {
     pub range: ruff_text_size::TextRange,
     pub value: crate::StringLiteralValue,
 }
 
+/// An AST node that represents either a single-part bytestring literal
+/// or an implicitly concatenated bytestring literal.
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprBytesLiteral {
     pub range: ruff_text_size::TextRange,
@@ -6607,6 +6636,7 @@ pub struct ExprEllipsisLiteral {
     pub range: ruff_text_size::TextRange,
 }
 
+/// See also [Attribute](https://docs.python.org/3/library/ast.html#ast.Attribute)
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprAttribute {
     pub range: ruff_text_size::TextRange,
@@ -6615,6 +6645,7 @@ pub struct ExprAttribute {
     pub ctx: crate::ExprContext,
 }
 
+/// See also [Subscript](https://docs.python.org/3/library/ast.html#ast.Subscript)
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprSubscript {
     pub range: ruff_text_size::TextRange,
@@ -6623,6 +6654,7 @@ pub struct ExprSubscript {
     pub ctx: crate::ExprContext,
 }
 
+/// See also [Starred](https://docs.python.org/3/library/ast.html#ast.Starred)
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprStarred {
     pub range: ruff_text_size::TextRange,
@@ -6630,6 +6662,7 @@ pub struct ExprStarred {
     pub ctx: crate::ExprContext,
 }
 
+/// See also [Name](https://docs.python.org/3/library/ast.html#ast.Name)
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprName {
     pub range: ruff_text_size::TextRange,
@@ -6637,6 +6670,7 @@ pub struct ExprName {
     pub ctx: crate::ExprContext,
 }
 
+/// See also [List](https://docs.python.org/3/library/ast.html#ast.List)
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprList {
     pub range: ruff_text_size::TextRange,
@@ -6644,6 +6678,7 @@ pub struct ExprList {
     pub ctx: crate::ExprContext,
 }
 
+/// See also [Tuple](https://docs.python.org/3/library/ast.html#ast.Tuple)
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprTuple {
     pub range: ruff_text_size::TextRange,
@@ -6652,6 +6687,7 @@ pub struct ExprTuple {
     pub parenthesized: bool,
 }
 
+/// See also [Slice](https://docs.python.org/3/library/ast.html#ast.Slice)
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprSlice {
     pub range: ruff_text_size::TextRange,
@@ -6660,6 +6696,14 @@ pub struct ExprSlice {
     pub step: Option<Box<crate::Expr>>,
 }
 
+/// An AST node used to represent a IPython escape command at the expression level.
+///
+/// For example,
+/// ```python
+/// dir = !pwd
+///
+/// For more information related to terminology and syntax of escape commands,
+///  see [`StmtIpyEscapeCommand`].
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprIpyEscapeCommand {
     pub range: ruff_text_size::TextRange,

--- a/crates/ruff_python_ast/src/generated.rs
+++ b/crates/ruff_python_ast/src/generated.rs
@@ -6453,24 +6453,24 @@ impl AnyNodeRef<'_> {
 pub struct ExprBoolOp {
     pub range: ruff_text_size::TextRange,
     pub op: crate::BoolOp,
-    pub values: Vec<crate::Expr>,
+    pub values: Vec<Expr>,
 }
 
 /// See also [NamedExpr](https://docs.python.org/3/library/ast.html#ast.NamedExpr)
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprNamed {
     pub range: ruff_text_size::TextRange,
-    pub target: Box<crate::Expr>,
-    pub value: Box<crate::Expr>,
+    pub target: Box<Expr>,
+    pub value: Box<Expr>,
 }
 
 /// See also [BinOp](https://docs.python.org/3/library/ast.html#ast.BinOp)
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprBinOp {
     pub range: ruff_text_size::TextRange,
-    pub left: Box<crate::Expr>,
+    pub left: Box<Expr>,
     pub op: crate::Operator,
-    pub right: Box<crate::Expr>,
+    pub right: Box<Expr>,
 }
 
 /// See also [UnaryOp](https://docs.python.org/3/library/ast.html#ast.UnaryOp)
@@ -6478,7 +6478,7 @@ pub struct ExprBinOp {
 pub struct ExprUnaryOp {
     pub range: ruff_text_size::TextRange,
     pub op: crate::UnaryOp,
-    pub operand: Box<crate::Expr>,
+    pub operand: Box<Expr>,
 }
 
 /// See also [Lambda](https://docs.python.org/3/library/ast.html#ast.Lambda)
@@ -6486,16 +6486,16 @@ pub struct ExprUnaryOp {
 pub struct ExprLambda {
     pub range: ruff_text_size::TextRange,
     pub parameters: Option<Box<crate::Parameters>>,
-    pub body: Box<crate::Expr>,
+    pub body: Box<Expr>,
 }
 
 /// See also [IfExp](https://docs.python.org/3/library/ast.html#ast.IfExp)
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprIf {
     pub range: ruff_text_size::TextRange,
-    pub test: Box<crate::Expr>,
-    pub body: Box<crate::Expr>,
-    pub orelse: Box<crate::Expr>,
+    pub test: Box<Expr>,
+    pub body: Box<Expr>,
+    pub orelse: Box<Expr>,
 }
 
 /// See also [Dict](https://docs.python.org/3/library/ast.html#ast.Dict)
@@ -6509,14 +6509,14 @@ pub struct ExprDict {
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprSet {
     pub range: ruff_text_size::TextRange,
-    pub elts: Vec<crate::Expr>,
+    pub elts: Vec<Expr>,
 }
 
 /// See also [ListComp](https://docs.python.org/3/library/ast.html#ast.ListComp)
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprListComp {
     pub range: ruff_text_size::TextRange,
-    pub elt: Box<crate::Expr>,
+    pub elt: Box<Expr>,
     pub generators: Vec<crate::Comprehension>,
 }
 
@@ -6524,7 +6524,7 @@ pub struct ExprListComp {
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprSetComp {
     pub range: ruff_text_size::TextRange,
-    pub elt: Box<crate::Expr>,
+    pub elt: Box<Expr>,
     pub generators: Vec<crate::Comprehension>,
 }
 
@@ -6532,8 +6532,8 @@ pub struct ExprSetComp {
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprDictComp {
     pub range: ruff_text_size::TextRange,
-    pub key: Box<crate::Expr>,
-    pub value: Box<crate::Expr>,
+    pub key: Box<Expr>,
+    pub value: Box<Expr>,
     pub generators: Vec<crate::Comprehension>,
 }
 
@@ -6541,7 +6541,7 @@ pub struct ExprDictComp {
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprGenerator {
     pub range: ruff_text_size::TextRange,
-    pub elt: Box<crate::Expr>,
+    pub elt: Box<Expr>,
     pub generators: Vec<crate::Comprehension>,
     pub parenthesized: bool,
 }
@@ -6550,28 +6550,28 @@ pub struct ExprGenerator {
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprAwait {
     pub range: ruff_text_size::TextRange,
-    pub value: Box<crate::Expr>,
+    pub value: Box<Expr>,
 }
 
 /// See also [Yield](https://docs.python.org/3/library/ast.html#ast.Yield)
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprYield {
     pub range: ruff_text_size::TextRange,
-    pub value: Option<Box<crate::Expr>>,
+    pub value: Option<Box<Expr>>,
 }
 
 /// See also [YieldFrom](https://docs.python.org/3/library/ast.html#ast.YieldFrom)
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprYieldFrom {
     pub range: ruff_text_size::TextRange,
-    pub value: Box<crate::Expr>,
+    pub value: Box<Expr>,
 }
 
 /// See also [Compare](https://docs.python.org/3/library/ast.html#ast.Compare)
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprCompare {
     pub range: ruff_text_size::TextRange,
-    pub left: Box<crate::Expr>,
+    pub left: Box<Expr>,
     pub ops: Box<[crate::CmpOp]>,
     pub comparators: Box<[Expr]>,
 }
@@ -6580,7 +6580,7 @@ pub struct ExprCompare {
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprCall {
     pub range: ruff_text_size::TextRange,
-    pub func: Box<crate::Expr>,
+    pub func: Box<Expr>,
     pub arguments: crate::Arguments,
 }
 
@@ -6640,7 +6640,7 @@ pub struct ExprEllipsisLiteral {
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprAttribute {
     pub range: ruff_text_size::TextRange,
-    pub value: Box<crate::Expr>,
+    pub value: Box<Expr>,
     pub attr: crate::Identifier,
     pub ctx: crate::ExprContext,
 }
@@ -6649,8 +6649,8 @@ pub struct ExprAttribute {
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprSubscript {
     pub range: ruff_text_size::TextRange,
-    pub value: Box<crate::Expr>,
-    pub slice: Box<crate::Expr>,
+    pub value: Box<Expr>,
+    pub slice: Box<Expr>,
     pub ctx: crate::ExprContext,
 }
 
@@ -6658,7 +6658,7 @@ pub struct ExprSubscript {
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprStarred {
     pub range: ruff_text_size::TextRange,
-    pub value: Box<crate::Expr>,
+    pub value: Box<Expr>,
     pub ctx: crate::ExprContext,
 }
 
@@ -6674,7 +6674,7 @@ pub struct ExprName {
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprList {
     pub range: ruff_text_size::TextRange,
-    pub elts: Option<Vec<crate::Expr>>,
+    pub elts: Vec<Expr>,
     pub ctx: crate::ExprContext,
 }
 
@@ -6682,7 +6682,7 @@ pub struct ExprList {
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprTuple {
     pub range: ruff_text_size::TextRange,
-    pub elts: Vec<crate::Expr>,
+    pub elts: Vec<Expr>,
     pub ctx: crate::ExprContext,
     pub parenthesized: bool,
 }
@@ -6691,9 +6691,9 @@ pub struct ExprTuple {
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprSlice {
     pub range: ruff_text_size::TextRange,
-    pub lower: Option<Box<crate::Expr>>,
-    pub upper: Option<Box<crate::Expr>>,
-    pub step: Option<Box<crate::Expr>>,
+    pub lower: Option<Box<Expr>>,
+    pub upper: Option<Box<Expr>>,
+    pub step: Option<Box<Expr>>,
 }
 
 /// An AST node used to represent a IPython escape command at the expression level.

--- a/crates/ruff_python_ast/src/generated.rs
+++ b/crates/ruff_python_ast/src/generated.rs
@@ -6587,7 +6587,7 @@ pub struct ExprCall {
 /// An AST node that represents either a single-part f-string literal
 /// or an implicitly concatenated f-string literal.
 ///
-/// This type differs from the original Python AST ([JoinedStr]) in that it
+/// This type differs from the original Python AST ([`JoinedStr`]) in that it
 /// doesn't join the implicitly concatenated parts into a single string. Instead,
 /// it keeps them separate and provide various methods to access the parts.
 ///

--- a/crates/ruff_python_ast/src/generated.rs
+++ b/crates/ruff_python_ast/src/generated.rs
@@ -1249,13 +1249,6 @@ impl Stmt {
 /// See also [expr](https://docs.python.org/3/library/ast.html#ast.expr)
 #[derive(Clone, Debug, PartialEq)]
 pub enum Expr {
-    BoolOp(crate::ExprBoolOp),
-    Named(crate::ExprNamed),
-    BinOp(crate::ExprBinOp),
-    UnaryOp(crate::ExprUnaryOp),
-    Lambda(crate::ExprLambda),
-    If(crate::ExprIf),
-    Dict(crate::ExprDict),
     Set(crate::ExprSet),
     ListComp(crate::ExprListComp),
     SetComp(crate::ExprSetComp),
@@ -1281,48 +1274,13 @@ pub enum Expr {
     Tuple(crate::ExprTuple),
     Slice(crate::ExprSlice),
     IpyEscapeCommand(crate::ExprIpyEscapeCommand),
-}
-
-impl From<crate::ExprBoolOp> for Expr {
-    fn from(node: crate::ExprBoolOp) -> Self {
-        Self::BoolOp(node)
-    }
-}
-
-impl From<crate::ExprNamed> for Expr {
-    fn from(node: crate::ExprNamed) -> Self {
-        Self::Named(node)
-    }
-}
-
-impl From<crate::ExprBinOp> for Expr {
-    fn from(node: crate::ExprBinOp) -> Self {
-        Self::BinOp(node)
-    }
-}
-
-impl From<crate::ExprUnaryOp> for Expr {
-    fn from(node: crate::ExprUnaryOp) -> Self {
-        Self::UnaryOp(node)
-    }
-}
-
-impl From<crate::ExprLambda> for Expr {
-    fn from(node: crate::ExprLambda) -> Self {
-        Self::Lambda(node)
-    }
-}
-
-impl From<crate::ExprIf> for Expr {
-    fn from(node: crate::ExprIf) -> Self {
-        Self::If(node)
-    }
-}
-
-impl From<crate::ExprDict> for Expr {
-    fn from(node: crate::ExprDict) -> Self {
-        Self::Dict(node)
-    }
+    BoolOp(crate::ExprBoolOp),
+    Named(crate::ExprNamed),
+    BinOp(crate::ExprBinOp),
+    UnaryOp(crate::ExprUnaryOp),
+    Lambda(crate::ExprLambda),
+    If(crate::ExprIf),
+    Dict(crate::ExprDict),
 }
 
 impl From<crate::ExprSet> for Expr {
@@ -1475,16 +1433,51 @@ impl From<crate::ExprIpyEscapeCommand> for Expr {
     }
 }
 
+impl From<crate::ExprBoolOp> for Expr {
+    fn from(node: crate::ExprBoolOp) -> Self {
+        Self::BoolOp(node)
+    }
+}
+
+impl From<crate::ExprNamed> for Expr {
+    fn from(node: crate::ExprNamed) -> Self {
+        Self::Named(node)
+    }
+}
+
+impl From<crate::ExprBinOp> for Expr {
+    fn from(node: crate::ExprBinOp) -> Self {
+        Self::BinOp(node)
+    }
+}
+
+impl From<crate::ExprUnaryOp> for Expr {
+    fn from(node: crate::ExprUnaryOp) -> Self {
+        Self::UnaryOp(node)
+    }
+}
+
+impl From<crate::ExprLambda> for Expr {
+    fn from(node: crate::ExprLambda) -> Self {
+        Self::Lambda(node)
+    }
+}
+
+impl From<crate::ExprIf> for Expr {
+    fn from(node: crate::ExprIf) -> Self {
+        Self::If(node)
+    }
+}
+
+impl From<crate::ExprDict> for Expr {
+    fn from(node: crate::ExprDict) -> Self {
+        Self::Dict(node)
+    }
+}
+
 impl ruff_text_size::Ranged for Expr {
     fn range(&self) -> ruff_text_size::TextRange {
         match self {
-            Self::BoolOp(node) => node.range(),
-            Self::Named(node) => node.range(),
-            Self::BinOp(node) => node.range(),
-            Self::UnaryOp(node) => node.range(),
-            Self::Lambda(node) => node.range(),
-            Self::If(node) => node.range(),
-            Self::Dict(node) => node.range(),
             Self::Set(node) => node.range(),
             Self::ListComp(node) => node.range(),
             Self::SetComp(node) => node.range(),
@@ -1510,271 +1503,19 @@ impl ruff_text_size::Ranged for Expr {
             Self::Tuple(node) => node.range(),
             Self::Slice(node) => node.range(),
             Self::IpyEscapeCommand(node) => node.range(),
+            Self::BoolOp(node) => node.range(),
+            Self::Named(node) => node.range(),
+            Self::BinOp(node) => node.range(),
+            Self::UnaryOp(node) => node.range(),
+            Self::Lambda(node) => node.range(),
+            Self::If(node) => node.range(),
+            Self::Dict(node) => node.range(),
         }
     }
 }
 
 #[allow(dead_code, clippy::match_wildcard_for_single_variants)]
 impl Expr {
-    #[inline]
-    pub const fn is_bool_op_expr(&self) -> bool {
-        matches!(self, Self::BoolOp(_))
-    }
-
-    #[inline]
-    pub fn bool_op_expr(self) -> Option<crate::ExprBoolOp> {
-        match self {
-            Self::BoolOp(val) => Some(val),
-            _ => None,
-        }
-    }
-
-    #[inline]
-    pub fn expect_bool_op_expr(self) -> crate::ExprBoolOp {
-        match self {
-            Self::BoolOp(val) => val,
-            _ => panic!("called expect on {self:?}"),
-        }
-    }
-
-    #[inline]
-    pub fn as_bool_op_expr_mut(&mut self) -> Option<&mut crate::ExprBoolOp> {
-        match self {
-            Self::BoolOp(val) => Some(val),
-            _ => None,
-        }
-    }
-
-    #[inline]
-    pub fn as_bool_op_expr(&self) -> Option<&crate::ExprBoolOp> {
-        match self {
-            Self::BoolOp(val) => Some(val),
-            _ => None,
-        }
-    }
-
-    #[inline]
-    pub const fn is_named_expr(&self) -> bool {
-        matches!(self, Self::Named(_))
-    }
-
-    #[inline]
-    pub fn named_expr(self) -> Option<crate::ExprNamed> {
-        match self {
-            Self::Named(val) => Some(val),
-            _ => None,
-        }
-    }
-
-    #[inline]
-    pub fn expect_named_expr(self) -> crate::ExprNamed {
-        match self {
-            Self::Named(val) => val,
-            _ => panic!("called expect on {self:?}"),
-        }
-    }
-
-    #[inline]
-    pub fn as_named_expr_mut(&mut self) -> Option<&mut crate::ExprNamed> {
-        match self {
-            Self::Named(val) => Some(val),
-            _ => None,
-        }
-    }
-
-    #[inline]
-    pub fn as_named_expr(&self) -> Option<&crate::ExprNamed> {
-        match self {
-            Self::Named(val) => Some(val),
-            _ => None,
-        }
-    }
-
-    #[inline]
-    pub const fn is_bin_op_expr(&self) -> bool {
-        matches!(self, Self::BinOp(_))
-    }
-
-    #[inline]
-    pub fn bin_op_expr(self) -> Option<crate::ExprBinOp> {
-        match self {
-            Self::BinOp(val) => Some(val),
-            _ => None,
-        }
-    }
-
-    #[inline]
-    pub fn expect_bin_op_expr(self) -> crate::ExprBinOp {
-        match self {
-            Self::BinOp(val) => val,
-            _ => panic!("called expect on {self:?}"),
-        }
-    }
-
-    #[inline]
-    pub fn as_bin_op_expr_mut(&mut self) -> Option<&mut crate::ExprBinOp> {
-        match self {
-            Self::BinOp(val) => Some(val),
-            _ => None,
-        }
-    }
-
-    #[inline]
-    pub fn as_bin_op_expr(&self) -> Option<&crate::ExprBinOp> {
-        match self {
-            Self::BinOp(val) => Some(val),
-            _ => None,
-        }
-    }
-
-    #[inline]
-    pub const fn is_unary_op_expr(&self) -> bool {
-        matches!(self, Self::UnaryOp(_))
-    }
-
-    #[inline]
-    pub fn unary_op_expr(self) -> Option<crate::ExprUnaryOp> {
-        match self {
-            Self::UnaryOp(val) => Some(val),
-            _ => None,
-        }
-    }
-
-    #[inline]
-    pub fn expect_unary_op_expr(self) -> crate::ExprUnaryOp {
-        match self {
-            Self::UnaryOp(val) => val,
-            _ => panic!("called expect on {self:?}"),
-        }
-    }
-
-    #[inline]
-    pub fn as_unary_op_expr_mut(&mut self) -> Option<&mut crate::ExprUnaryOp> {
-        match self {
-            Self::UnaryOp(val) => Some(val),
-            _ => None,
-        }
-    }
-
-    #[inline]
-    pub fn as_unary_op_expr(&self) -> Option<&crate::ExprUnaryOp> {
-        match self {
-            Self::UnaryOp(val) => Some(val),
-            _ => None,
-        }
-    }
-
-    #[inline]
-    pub const fn is_lambda_expr(&self) -> bool {
-        matches!(self, Self::Lambda(_))
-    }
-
-    #[inline]
-    pub fn lambda_expr(self) -> Option<crate::ExprLambda> {
-        match self {
-            Self::Lambda(val) => Some(val),
-            _ => None,
-        }
-    }
-
-    #[inline]
-    pub fn expect_lambda_expr(self) -> crate::ExprLambda {
-        match self {
-            Self::Lambda(val) => val,
-            _ => panic!("called expect on {self:?}"),
-        }
-    }
-
-    #[inline]
-    pub fn as_lambda_expr_mut(&mut self) -> Option<&mut crate::ExprLambda> {
-        match self {
-            Self::Lambda(val) => Some(val),
-            _ => None,
-        }
-    }
-
-    #[inline]
-    pub fn as_lambda_expr(&self) -> Option<&crate::ExprLambda> {
-        match self {
-            Self::Lambda(val) => Some(val),
-            _ => None,
-        }
-    }
-
-    #[inline]
-    pub const fn is_if_expr(&self) -> bool {
-        matches!(self, Self::If(_))
-    }
-
-    #[inline]
-    pub fn if_expr(self) -> Option<crate::ExprIf> {
-        match self {
-            Self::If(val) => Some(val),
-            _ => None,
-        }
-    }
-
-    #[inline]
-    pub fn expect_if_expr(self) -> crate::ExprIf {
-        match self {
-            Self::If(val) => val,
-            _ => panic!("called expect on {self:?}"),
-        }
-    }
-
-    #[inline]
-    pub fn as_if_expr_mut(&mut self) -> Option<&mut crate::ExprIf> {
-        match self {
-            Self::If(val) => Some(val),
-            _ => None,
-        }
-    }
-
-    #[inline]
-    pub fn as_if_expr(&self) -> Option<&crate::ExprIf> {
-        match self {
-            Self::If(val) => Some(val),
-            _ => None,
-        }
-    }
-
-    #[inline]
-    pub const fn is_dict_expr(&self) -> bool {
-        matches!(self, Self::Dict(_))
-    }
-
-    #[inline]
-    pub fn dict_expr(self) -> Option<crate::ExprDict> {
-        match self {
-            Self::Dict(val) => Some(val),
-            _ => None,
-        }
-    }
-
-    #[inline]
-    pub fn expect_dict_expr(self) -> crate::ExprDict {
-        match self {
-            Self::Dict(val) => val,
-            _ => panic!("called expect on {self:?}"),
-        }
-    }
-
-    #[inline]
-    pub fn as_dict_expr_mut(&mut self) -> Option<&mut crate::ExprDict> {
-        match self {
-            Self::Dict(val) => Some(val),
-            _ => None,
-        }
-    }
-
-    #[inline]
-    pub fn as_dict_expr(&self) -> Option<&crate::ExprDict> {
-        match self {
-            Self::Dict(val) => Some(val),
-            _ => None,
-        }
-    }
-
     #[inline]
     pub const fn is_set_expr(&self) -> bool {
         matches!(self, Self::Set(_))
@@ -2699,6 +2440,265 @@ impl Expr {
             _ => None,
         }
     }
+
+    #[inline]
+    pub const fn is_bool_op_expr(&self) -> bool {
+        matches!(self, Self::BoolOp(_))
+    }
+
+    #[inline]
+    pub fn bool_op_expr(self) -> Option<crate::ExprBoolOp> {
+        match self {
+            Self::BoolOp(val) => Some(val),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn expect_bool_op_expr(self) -> crate::ExprBoolOp {
+        match self {
+            Self::BoolOp(val) => val,
+            _ => panic!("called expect on {self:?}"),
+        }
+    }
+
+    #[inline]
+    pub fn as_bool_op_expr_mut(&mut self) -> Option<&mut crate::ExprBoolOp> {
+        match self {
+            Self::BoolOp(val) => Some(val),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn as_bool_op_expr(&self) -> Option<&crate::ExprBoolOp> {
+        match self {
+            Self::BoolOp(val) => Some(val),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub const fn is_named_expr(&self) -> bool {
+        matches!(self, Self::Named(_))
+    }
+
+    #[inline]
+    pub fn named_expr(self) -> Option<crate::ExprNamed> {
+        match self {
+            Self::Named(val) => Some(val),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn expect_named_expr(self) -> crate::ExprNamed {
+        match self {
+            Self::Named(val) => val,
+            _ => panic!("called expect on {self:?}"),
+        }
+    }
+
+    #[inline]
+    pub fn as_named_expr_mut(&mut self) -> Option<&mut crate::ExprNamed> {
+        match self {
+            Self::Named(val) => Some(val),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn as_named_expr(&self) -> Option<&crate::ExprNamed> {
+        match self {
+            Self::Named(val) => Some(val),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub const fn is_bin_op_expr(&self) -> bool {
+        matches!(self, Self::BinOp(_))
+    }
+
+    #[inline]
+    pub fn bin_op_expr(self) -> Option<crate::ExprBinOp> {
+        match self {
+            Self::BinOp(val) => Some(val),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn expect_bin_op_expr(self) -> crate::ExprBinOp {
+        match self {
+            Self::BinOp(val) => val,
+            _ => panic!("called expect on {self:?}"),
+        }
+    }
+
+    #[inline]
+    pub fn as_bin_op_expr_mut(&mut self) -> Option<&mut crate::ExprBinOp> {
+        match self {
+            Self::BinOp(val) => Some(val),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn as_bin_op_expr(&self) -> Option<&crate::ExprBinOp> {
+        match self {
+            Self::BinOp(val) => Some(val),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub const fn is_unary_op_expr(&self) -> bool {
+        matches!(self, Self::UnaryOp(_))
+    }
+
+    #[inline]
+    pub fn unary_op_expr(self) -> Option<crate::ExprUnaryOp> {
+        match self {
+            Self::UnaryOp(val) => Some(val),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn expect_unary_op_expr(self) -> crate::ExprUnaryOp {
+        match self {
+            Self::UnaryOp(val) => val,
+            _ => panic!("called expect on {self:?}"),
+        }
+    }
+
+    #[inline]
+    pub fn as_unary_op_expr_mut(&mut self) -> Option<&mut crate::ExprUnaryOp> {
+        match self {
+            Self::UnaryOp(val) => Some(val),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn as_unary_op_expr(&self) -> Option<&crate::ExprUnaryOp> {
+        match self {
+            Self::UnaryOp(val) => Some(val),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub const fn is_lambda_expr(&self) -> bool {
+        matches!(self, Self::Lambda(_))
+    }
+
+    #[inline]
+    pub fn lambda_expr(self) -> Option<crate::ExprLambda> {
+        match self {
+            Self::Lambda(val) => Some(val),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn expect_lambda_expr(self) -> crate::ExprLambda {
+        match self {
+            Self::Lambda(val) => val,
+            _ => panic!("called expect on {self:?}"),
+        }
+    }
+
+    #[inline]
+    pub fn as_lambda_expr_mut(&mut self) -> Option<&mut crate::ExprLambda> {
+        match self {
+            Self::Lambda(val) => Some(val),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn as_lambda_expr(&self) -> Option<&crate::ExprLambda> {
+        match self {
+            Self::Lambda(val) => Some(val),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub const fn is_if_expr(&self) -> bool {
+        matches!(self, Self::If(_))
+    }
+
+    #[inline]
+    pub fn if_expr(self) -> Option<crate::ExprIf> {
+        match self {
+            Self::If(val) => Some(val),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn expect_if_expr(self) -> crate::ExprIf {
+        match self {
+            Self::If(val) => val,
+            _ => panic!("called expect on {self:?}"),
+        }
+    }
+
+    #[inline]
+    pub fn as_if_expr_mut(&mut self) -> Option<&mut crate::ExprIf> {
+        match self {
+            Self::If(val) => Some(val),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn as_if_expr(&self) -> Option<&crate::ExprIf> {
+        match self {
+            Self::If(val) => Some(val),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub const fn is_dict_expr(&self) -> bool {
+        matches!(self, Self::Dict(_))
+    }
+
+    #[inline]
+    pub fn dict_expr(self) -> Option<crate::ExprDict> {
+        match self {
+            Self::Dict(val) => Some(val),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn expect_dict_expr(self) -> crate::ExprDict {
+        match self {
+            Self::Dict(val) => val,
+            _ => panic!("called expect on {self:?}"),
+        }
+    }
+
+    #[inline]
+    pub fn as_dict_expr_mut(&mut self) -> Option<&mut crate::ExprDict> {
+        match self {
+            Self::Dict(val) => Some(val),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn as_dict_expr(&self) -> Option<&crate::ExprDict> {
+        match self {
+            Self::Dict(val) => Some(val),
+            _ => None,
+        }
+    }
 }
 
 /// See also [excepthandler](https://docs.python.org/3/library/ast.html#ast.excepthandler)
@@ -3548,48 +3548,6 @@ impl ruff_text_size::Ranged for crate::StmtIpyEscapeCommand {
     }
 }
 
-impl ruff_text_size::Ranged for crate::ExprBoolOp {
-    fn range(&self) -> ruff_text_size::TextRange {
-        self.range
-    }
-}
-
-impl ruff_text_size::Ranged for crate::ExprNamed {
-    fn range(&self) -> ruff_text_size::TextRange {
-        self.range
-    }
-}
-
-impl ruff_text_size::Ranged for crate::ExprBinOp {
-    fn range(&self) -> ruff_text_size::TextRange {
-        self.range
-    }
-}
-
-impl ruff_text_size::Ranged for crate::ExprUnaryOp {
-    fn range(&self) -> ruff_text_size::TextRange {
-        self.range
-    }
-}
-
-impl ruff_text_size::Ranged for crate::ExprLambda {
-    fn range(&self) -> ruff_text_size::TextRange {
-        self.range
-    }
-}
-
-impl ruff_text_size::Ranged for crate::ExprIf {
-    fn range(&self) -> ruff_text_size::TextRange {
-        self.range
-    }
-}
-
-impl ruff_text_size::Ranged for crate::ExprDict {
-    fn range(&self) -> ruff_text_size::TextRange {
-        self.range
-    }
-}
-
 impl ruff_text_size::Ranged for crate::ExprSet {
     fn range(&self) -> ruff_text_size::TextRange {
         self.range
@@ -3735,6 +3693,48 @@ impl ruff_text_size::Ranged for crate::ExprSlice {
 }
 
 impl ruff_text_size::Ranged for crate::ExprIpyEscapeCommand {
+    fn range(&self) -> ruff_text_size::TextRange {
+        self.range
+    }
+}
+
+impl ruff_text_size::Ranged for crate::ExprBoolOp {
+    fn range(&self) -> ruff_text_size::TextRange {
+        self.range
+    }
+}
+
+impl ruff_text_size::Ranged for crate::ExprNamed {
+    fn range(&self) -> ruff_text_size::TextRange {
+        self.range
+    }
+}
+
+impl ruff_text_size::Ranged for crate::ExprBinOp {
+    fn range(&self) -> ruff_text_size::TextRange {
+        self.range
+    }
+}
+
+impl ruff_text_size::Ranged for crate::ExprUnaryOp {
+    fn range(&self) -> ruff_text_size::TextRange {
+        self.range
+    }
+}
+
+impl ruff_text_size::Ranged for crate::ExprLambda {
+    fn range(&self) -> ruff_text_size::TextRange {
+        self.range
+    }
+}
+
+impl ruff_text_size::Ranged for crate::ExprIf {
+    fn range(&self) -> ruff_text_size::TextRange {
+        self.range
+    }
+}
+
+impl ruff_text_size::Ranged for crate::ExprDict {
     fn range(&self) -> ruff_text_size::TextRange {
         self.range
     }
@@ -3994,13 +3994,6 @@ impl Expr {
         V: crate::visitor::source_order::SourceOrderVisitor<'a> + ?Sized,
     {
         match self {
-            Expr::BoolOp(node) => node.visit_source_order(visitor),
-            Expr::Named(node) => node.visit_source_order(visitor),
-            Expr::BinOp(node) => node.visit_source_order(visitor),
-            Expr::UnaryOp(node) => node.visit_source_order(visitor),
-            Expr::Lambda(node) => node.visit_source_order(visitor),
-            Expr::If(node) => node.visit_source_order(visitor),
-            Expr::Dict(node) => node.visit_source_order(visitor),
             Expr::Set(node) => node.visit_source_order(visitor),
             Expr::ListComp(node) => node.visit_source_order(visitor),
             Expr::SetComp(node) => node.visit_source_order(visitor),
@@ -4026,6 +4019,13 @@ impl Expr {
             Expr::Tuple(node) => node.visit_source_order(visitor),
             Expr::Slice(node) => node.visit_source_order(visitor),
             Expr::IpyEscapeCommand(node) => node.visit_source_order(visitor),
+            Expr::BoolOp(node) => node.visit_source_order(visitor),
+            Expr::Named(node) => node.visit_source_order(visitor),
+            Expr::BinOp(node) => node.visit_source_order(visitor),
+            Expr::UnaryOp(node) => node.visit_source_order(visitor),
+            Expr::Lambda(node) => node.visit_source_order(visitor),
+            Expr::If(node) => node.visit_source_order(visitor),
+            Expr::Dict(node) => node.visit_source_order(visitor),
         }
     }
 }
@@ -4397,20 +4397,6 @@ impl ruff_text_size::Ranged for StmtRef<'_> {
 /// See also [expr](https://docs.python.org/3/library/ast.html#ast.expr)
 #[derive(Clone, Copy, Debug, PartialEq, is_macro::Is)]
 pub enum ExprRef<'a> {
-    #[is(name = "bool_op_expr")]
-    BoolOp(&'a crate::ExprBoolOp),
-    #[is(name = "named_expr")]
-    Named(&'a crate::ExprNamed),
-    #[is(name = "bin_op_expr")]
-    BinOp(&'a crate::ExprBinOp),
-    #[is(name = "unary_op_expr")]
-    UnaryOp(&'a crate::ExprUnaryOp),
-    #[is(name = "lambda_expr")]
-    Lambda(&'a crate::ExprLambda),
-    #[is(name = "if_expr")]
-    If(&'a crate::ExprIf),
-    #[is(name = "dict_expr")]
-    Dict(&'a crate::ExprDict),
     #[is(name = "set_expr")]
     Set(&'a crate::ExprSet),
     #[is(name = "list_comp_expr")]
@@ -4461,18 +4447,25 @@ pub enum ExprRef<'a> {
     Slice(&'a crate::ExprSlice),
     #[is(name = "ipy_escape_command_expr")]
     IpyEscapeCommand(&'a crate::ExprIpyEscapeCommand),
+    #[is(name = "bool_op_expr")]
+    BoolOp(&'a crate::ExprBoolOp),
+    #[is(name = "named_expr")]
+    Named(&'a crate::ExprNamed),
+    #[is(name = "bin_op_expr")]
+    BinOp(&'a crate::ExprBinOp),
+    #[is(name = "unary_op_expr")]
+    UnaryOp(&'a crate::ExprUnaryOp),
+    #[is(name = "lambda_expr")]
+    Lambda(&'a crate::ExprLambda),
+    #[is(name = "if_expr")]
+    If(&'a crate::ExprIf),
+    #[is(name = "dict_expr")]
+    Dict(&'a crate::ExprDict),
 }
 
 impl<'a> From<&'a Expr> for ExprRef<'a> {
     fn from(node: &'a Expr) -> Self {
         match node {
-            Expr::BoolOp(node) => ExprRef::BoolOp(node),
-            Expr::Named(node) => ExprRef::Named(node),
-            Expr::BinOp(node) => ExprRef::BinOp(node),
-            Expr::UnaryOp(node) => ExprRef::UnaryOp(node),
-            Expr::Lambda(node) => ExprRef::Lambda(node),
-            Expr::If(node) => ExprRef::If(node),
-            Expr::Dict(node) => ExprRef::Dict(node),
             Expr::Set(node) => ExprRef::Set(node),
             Expr::ListComp(node) => ExprRef::ListComp(node),
             Expr::SetComp(node) => ExprRef::SetComp(node),
@@ -4498,49 +4491,14 @@ impl<'a> From<&'a Expr> for ExprRef<'a> {
             Expr::Tuple(node) => ExprRef::Tuple(node),
             Expr::Slice(node) => ExprRef::Slice(node),
             Expr::IpyEscapeCommand(node) => ExprRef::IpyEscapeCommand(node),
+            Expr::BoolOp(node) => ExprRef::BoolOp(node),
+            Expr::Named(node) => ExprRef::Named(node),
+            Expr::BinOp(node) => ExprRef::BinOp(node),
+            Expr::UnaryOp(node) => ExprRef::UnaryOp(node),
+            Expr::Lambda(node) => ExprRef::Lambda(node),
+            Expr::If(node) => ExprRef::If(node),
+            Expr::Dict(node) => ExprRef::Dict(node),
         }
-    }
-}
-
-impl<'a> From<&'a crate::ExprBoolOp> for ExprRef<'a> {
-    fn from(node: &'a crate::ExprBoolOp) -> Self {
-        Self::BoolOp(node)
-    }
-}
-
-impl<'a> From<&'a crate::ExprNamed> for ExprRef<'a> {
-    fn from(node: &'a crate::ExprNamed) -> Self {
-        Self::Named(node)
-    }
-}
-
-impl<'a> From<&'a crate::ExprBinOp> for ExprRef<'a> {
-    fn from(node: &'a crate::ExprBinOp) -> Self {
-        Self::BinOp(node)
-    }
-}
-
-impl<'a> From<&'a crate::ExprUnaryOp> for ExprRef<'a> {
-    fn from(node: &'a crate::ExprUnaryOp) -> Self {
-        Self::UnaryOp(node)
-    }
-}
-
-impl<'a> From<&'a crate::ExprLambda> for ExprRef<'a> {
-    fn from(node: &'a crate::ExprLambda) -> Self {
-        Self::Lambda(node)
-    }
-}
-
-impl<'a> From<&'a crate::ExprIf> for ExprRef<'a> {
-    fn from(node: &'a crate::ExprIf) -> Self {
-        Self::If(node)
-    }
-}
-
-impl<'a> From<&'a crate::ExprDict> for ExprRef<'a> {
-    fn from(node: &'a crate::ExprDict) -> Self {
-        Self::Dict(node)
     }
 }
 
@@ -4694,16 +4652,51 @@ impl<'a> From<&'a crate::ExprIpyEscapeCommand> for ExprRef<'a> {
     }
 }
 
+impl<'a> From<&'a crate::ExprBoolOp> for ExprRef<'a> {
+    fn from(node: &'a crate::ExprBoolOp) -> Self {
+        Self::BoolOp(node)
+    }
+}
+
+impl<'a> From<&'a crate::ExprNamed> for ExprRef<'a> {
+    fn from(node: &'a crate::ExprNamed) -> Self {
+        Self::Named(node)
+    }
+}
+
+impl<'a> From<&'a crate::ExprBinOp> for ExprRef<'a> {
+    fn from(node: &'a crate::ExprBinOp) -> Self {
+        Self::BinOp(node)
+    }
+}
+
+impl<'a> From<&'a crate::ExprUnaryOp> for ExprRef<'a> {
+    fn from(node: &'a crate::ExprUnaryOp) -> Self {
+        Self::UnaryOp(node)
+    }
+}
+
+impl<'a> From<&'a crate::ExprLambda> for ExprRef<'a> {
+    fn from(node: &'a crate::ExprLambda) -> Self {
+        Self::Lambda(node)
+    }
+}
+
+impl<'a> From<&'a crate::ExprIf> for ExprRef<'a> {
+    fn from(node: &'a crate::ExprIf) -> Self {
+        Self::If(node)
+    }
+}
+
+impl<'a> From<&'a crate::ExprDict> for ExprRef<'a> {
+    fn from(node: &'a crate::ExprDict) -> Self {
+        Self::Dict(node)
+    }
+}
+
 impl ruff_text_size::Ranged for ExprRef<'_> {
     fn range(&self) -> ruff_text_size::TextRange {
         match self {
-            Self::BoolOp(node) => node.range(),
-            Self::Named(node) => node.range(),
-            Self::BinOp(node) => node.range(),
-            Self::UnaryOp(node) => node.range(),
-            Self::Lambda(node) => node.range(),
-            Self::If(node) => node.range(),
-            Self::Dict(node) => node.range(),
             Self::Set(node) => node.range(),
             Self::ListComp(node) => node.range(),
             Self::SetComp(node) => node.range(),
@@ -4729,6 +4722,13 @@ impl ruff_text_size::Ranged for ExprRef<'_> {
             Self::Tuple(node) => node.range(),
             Self::Slice(node) => node.range(),
             Self::IpyEscapeCommand(node) => node.range(),
+            Self::BoolOp(node) => node.range(),
+            Self::Named(node) => node.range(),
+            Self::BinOp(node) => node.range(),
+            Self::UnaryOp(node) => node.range(),
+            Self::Lambda(node) => node.range(),
+            Self::If(node) => node.range(),
+            Self::Dict(node) => node.range(),
         }
     }
 }
@@ -4963,13 +4963,6 @@ pub enum AnyNodeRef<'a> {
     StmtBreak(&'a crate::StmtBreak),
     StmtContinue(&'a crate::StmtContinue),
     StmtIpyEscapeCommand(&'a crate::StmtIpyEscapeCommand),
-    ExprBoolOp(&'a crate::ExprBoolOp),
-    ExprNamed(&'a crate::ExprNamed),
-    ExprBinOp(&'a crate::ExprBinOp),
-    ExprUnaryOp(&'a crate::ExprUnaryOp),
-    ExprLambda(&'a crate::ExprLambda),
-    ExprIf(&'a crate::ExprIf),
-    ExprDict(&'a crate::ExprDict),
     ExprSet(&'a crate::ExprSet),
     ExprListComp(&'a crate::ExprListComp),
     ExprSetComp(&'a crate::ExprSetComp),
@@ -4995,6 +4988,13 @@ pub enum AnyNodeRef<'a> {
     ExprTuple(&'a crate::ExprTuple),
     ExprSlice(&'a crate::ExprSlice),
     ExprIpyEscapeCommand(&'a crate::ExprIpyEscapeCommand),
+    ExprBoolOp(&'a crate::ExprBoolOp),
+    ExprNamed(&'a crate::ExprNamed),
+    ExprBinOp(&'a crate::ExprBinOp),
+    ExprUnaryOp(&'a crate::ExprUnaryOp),
+    ExprLambda(&'a crate::ExprLambda),
+    ExprIf(&'a crate::ExprIf),
+    ExprDict(&'a crate::ExprDict),
     ExceptHandlerExceptHandler(&'a crate::ExceptHandlerExceptHandler),
     FStringExpressionElement(&'a crate::FStringExpressionElement),
     FStringLiteralElement(&'a crate::FStringLiteralElement),
@@ -5115,13 +5115,6 @@ impl<'a> From<StmtRef<'a>> for AnyNodeRef<'a> {
 impl<'a> From<&'a Expr> for AnyNodeRef<'a> {
     fn from(node: &'a Expr) -> AnyNodeRef<'a> {
         match node {
-            Expr::BoolOp(node) => AnyNodeRef::ExprBoolOp(node),
-            Expr::Named(node) => AnyNodeRef::ExprNamed(node),
-            Expr::BinOp(node) => AnyNodeRef::ExprBinOp(node),
-            Expr::UnaryOp(node) => AnyNodeRef::ExprUnaryOp(node),
-            Expr::Lambda(node) => AnyNodeRef::ExprLambda(node),
-            Expr::If(node) => AnyNodeRef::ExprIf(node),
-            Expr::Dict(node) => AnyNodeRef::ExprDict(node),
             Expr::Set(node) => AnyNodeRef::ExprSet(node),
             Expr::ListComp(node) => AnyNodeRef::ExprListComp(node),
             Expr::SetComp(node) => AnyNodeRef::ExprSetComp(node),
@@ -5147,6 +5140,13 @@ impl<'a> From<&'a Expr> for AnyNodeRef<'a> {
             Expr::Tuple(node) => AnyNodeRef::ExprTuple(node),
             Expr::Slice(node) => AnyNodeRef::ExprSlice(node),
             Expr::IpyEscapeCommand(node) => AnyNodeRef::ExprIpyEscapeCommand(node),
+            Expr::BoolOp(node) => AnyNodeRef::ExprBoolOp(node),
+            Expr::Named(node) => AnyNodeRef::ExprNamed(node),
+            Expr::BinOp(node) => AnyNodeRef::ExprBinOp(node),
+            Expr::UnaryOp(node) => AnyNodeRef::ExprUnaryOp(node),
+            Expr::Lambda(node) => AnyNodeRef::ExprLambda(node),
+            Expr::If(node) => AnyNodeRef::ExprIf(node),
+            Expr::Dict(node) => AnyNodeRef::ExprDict(node),
         }
     }
 }
@@ -5154,13 +5154,6 @@ impl<'a> From<&'a Expr> for AnyNodeRef<'a> {
 impl<'a> From<ExprRef<'a>> for AnyNodeRef<'a> {
     fn from(node: ExprRef<'a>) -> AnyNodeRef<'a> {
         match node {
-            ExprRef::BoolOp(node) => AnyNodeRef::ExprBoolOp(node),
-            ExprRef::Named(node) => AnyNodeRef::ExprNamed(node),
-            ExprRef::BinOp(node) => AnyNodeRef::ExprBinOp(node),
-            ExprRef::UnaryOp(node) => AnyNodeRef::ExprUnaryOp(node),
-            ExprRef::Lambda(node) => AnyNodeRef::ExprLambda(node),
-            ExprRef::If(node) => AnyNodeRef::ExprIf(node),
-            ExprRef::Dict(node) => AnyNodeRef::ExprDict(node),
             ExprRef::Set(node) => AnyNodeRef::ExprSet(node),
             ExprRef::ListComp(node) => AnyNodeRef::ExprListComp(node),
             ExprRef::SetComp(node) => AnyNodeRef::ExprSetComp(node),
@@ -5186,6 +5179,13 @@ impl<'a> From<ExprRef<'a>> for AnyNodeRef<'a> {
             ExprRef::Tuple(node) => AnyNodeRef::ExprTuple(node),
             ExprRef::Slice(node) => AnyNodeRef::ExprSlice(node),
             ExprRef::IpyEscapeCommand(node) => AnyNodeRef::ExprIpyEscapeCommand(node),
+            ExprRef::BoolOp(node) => AnyNodeRef::ExprBoolOp(node),
+            ExprRef::Named(node) => AnyNodeRef::ExprNamed(node),
+            ExprRef::BinOp(node) => AnyNodeRef::ExprBinOp(node),
+            ExprRef::UnaryOp(node) => AnyNodeRef::ExprUnaryOp(node),
+            ExprRef::Lambda(node) => AnyNodeRef::ExprLambda(node),
+            ExprRef::If(node) => AnyNodeRef::ExprIf(node),
+            ExprRef::Dict(node) => AnyNodeRef::ExprDict(node),
         }
     }
 }
@@ -5436,48 +5436,6 @@ impl<'a> From<&'a crate::StmtIpyEscapeCommand> for AnyNodeRef<'a> {
     }
 }
 
-impl<'a> From<&'a crate::ExprBoolOp> for AnyNodeRef<'a> {
-    fn from(node: &'a crate::ExprBoolOp) -> AnyNodeRef<'a> {
-        AnyNodeRef::ExprBoolOp(node)
-    }
-}
-
-impl<'a> From<&'a crate::ExprNamed> for AnyNodeRef<'a> {
-    fn from(node: &'a crate::ExprNamed) -> AnyNodeRef<'a> {
-        AnyNodeRef::ExprNamed(node)
-    }
-}
-
-impl<'a> From<&'a crate::ExprBinOp> for AnyNodeRef<'a> {
-    fn from(node: &'a crate::ExprBinOp) -> AnyNodeRef<'a> {
-        AnyNodeRef::ExprBinOp(node)
-    }
-}
-
-impl<'a> From<&'a crate::ExprUnaryOp> for AnyNodeRef<'a> {
-    fn from(node: &'a crate::ExprUnaryOp) -> AnyNodeRef<'a> {
-        AnyNodeRef::ExprUnaryOp(node)
-    }
-}
-
-impl<'a> From<&'a crate::ExprLambda> for AnyNodeRef<'a> {
-    fn from(node: &'a crate::ExprLambda) -> AnyNodeRef<'a> {
-        AnyNodeRef::ExprLambda(node)
-    }
-}
-
-impl<'a> From<&'a crate::ExprIf> for AnyNodeRef<'a> {
-    fn from(node: &'a crate::ExprIf) -> AnyNodeRef<'a> {
-        AnyNodeRef::ExprIf(node)
-    }
-}
-
-impl<'a> From<&'a crate::ExprDict> for AnyNodeRef<'a> {
-    fn from(node: &'a crate::ExprDict) -> AnyNodeRef<'a> {
-        AnyNodeRef::ExprDict(node)
-    }
-}
-
 impl<'a> From<&'a crate::ExprSet> for AnyNodeRef<'a> {
     fn from(node: &'a crate::ExprSet) -> AnyNodeRef<'a> {
         AnyNodeRef::ExprSet(node)
@@ -5625,6 +5583,48 @@ impl<'a> From<&'a crate::ExprSlice> for AnyNodeRef<'a> {
 impl<'a> From<&'a crate::ExprIpyEscapeCommand> for AnyNodeRef<'a> {
     fn from(node: &'a crate::ExprIpyEscapeCommand) -> AnyNodeRef<'a> {
         AnyNodeRef::ExprIpyEscapeCommand(node)
+    }
+}
+
+impl<'a> From<&'a crate::ExprBoolOp> for AnyNodeRef<'a> {
+    fn from(node: &'a crate::ExprBoolOp) -> AnyNodeRef<'a> {
+        AnyNodeRef::ExprBoolOp(node)
+    }
+}
+
+impl<'a> From<&'a crate::ExprNamed> for AnyNodeRef<'a> {
+    fn from(node: &'a crate::ExprNamed) -> AnyNodeRef<'a> {
+        AnyNodeRef::ExprNamed(node)
+    }
+}
+
+impl<'a> From<&'a crate::ExprBinOp> for AnyNodeRef<'a> {
+    fn from(node: &'a crate::ExprBinOp) -> AnyNodeRef<'a> {
+        AnyNodeRef::ExprBinOp(node)
+    }
+}
+
+impl<'a> From<&'a crate::ExprUnaryOp> for AnyNodeRef<'a> {
+    fn from(node: &'a crate::ExprUnaryOp) -> AnyNodeRef<'a> {
+        AnyNodeRef::ExprUnaryOp(node)
+    }
+}
+
+impl<'a> From<&'a crate::ExprLambda> for AnyNodeRef<'a> {
+    fn from(node: &'a crate::ExprLambda) -> AnyNodeRef<'a> {
+        AnyNodeRef::ExprLambda(node)
+    }
+}
+
+impl<'a> From<&'a crate::ExprIf> for AnyNodeRef<'a> {
+    fn from(node: &'a crate::ExprIf) -> AnyNodeRef<'a> {
+        AnyNodeRef::ExprIf(node)
+    }
+}
+
+impl<'a> From<&'a crate::ExprDict> for AnyNodeRef<'a> {
+    fn from(node: &'a crate::ExprDict) -> AnyNodeRef<'a> {
+        AnyNodeRef::ExprDict(node)
     }
 }
 
@@ -5856,13 +5856,6 @@ impl ruff_text_size::Ranged for AnyNodeRef<'_> {
             AnyNodeRef::StmtBreak(node) => node.range(),
             AnyNodeRef::StmtContinue(node) => node.range(),
             AnyNodeRef::StmtIpyEscapeCommand(node) => node.range(),
-            AnyNodeRef::ExprBoolOp(node) => node.range(),
-            AnyNodeRef::ExprNamed(node) => node.range(),
-            AnyNodeRef::ExprBinOp(node) => node.range(),
-            AnyNodeRef::ExprUnaryOp(node) => node.range(),
-            AnyNodeRef::ExprLambda(node) => node.range(),
-            AnyNodeRef::ExprIf(node) => node.range(),
-            AnyNodeRef::ExprDict(node) => node.range(),
             AnyNodeRef::ExprSet(node) => node.range(),
             AnyNodeRef::ExprListComp(node) => node.range(),
             AnyNodeRef::ExprSetComp(node) => node.range(),
@@ -5888,6 +5881,13 @@ impl ruff_text_size::Ranged for AnyNodeRef<'_> {
             AnyNodeRef::ExprTuple(node) => node.range(),
             AnyNodeRef::ExprSlice(node) => node.range(),
             AnyNodeRef::ExprIpyEscapeCommand(node) => node.range(),
+            AnyNodeRef::ExprBoolOp(node) => node.range(),
+            AnyNodeRef::ExprNamed(node) => node.range(),
+            AnyNodeRef::ExprBinOp(node) => node.range(),
+            AnyNodeRef::ExprUnaryOp(node) => node.range(),
+            AnyNodeRef::ExprLambda(node) => node.range(),
+            AnyNodeRef::ExprIf(node) => node.range(),
+            AnyNodeRef::ExprDict(node) => node.range(),
             AnyNodeRef::ExceptHandlerExceptHandler(node) => node.range(),
             AnyNodeRef::FStringExpressionElement(node) => node.range(),
             AnyNodeRef::FStringLiteralElement(node) => node.range(),
@@ -5955,13 +5955,6 @@ impl AnyNodeRef<'_> {
             AnyNodeRef::StmtBreak(node) => std::ptr::NonNull::from(*node).cast(),
             AnyNodeRef::StmtContinue(node) => std::ptr::NonNull::from(*node).cast(),
             AnyNodeRef::StmtIpyEscapeCommand(node) => std::ptr::NonNull::from(*node).cast(),
-            AnyNodeRef::ExprBoolOp(node) => std::ptr::NonNull::from(*node).cast(),
-            AnyNodeRef::ExprNamed(node) => std::ptr::NonNull::from(*node).cast(),
-            AnyNodeRef::ExprBinOp(node) => std::ptr::NonNull::from(*node).cast(),
-            AnyNodeRef::ExprUnaryOp(node) => std::ptr::NonNull::from(*node).cast(),
-            AnyNodeRef::ExprLambda(node) => std::ptr::NonNull::from(*node).cast(),
-            AnyNodeRef::ExprIf(node) => std::ptr::NonNull::from(*node).cast(),
-            AnyNodeRef::ExprDict(node) => std::ptr::NonNull::from(*node).cast(),
             AnyNodeRef::ExprSet(node) => std::ptr::NonNull::from(*node).cast(),
             AnyNodeRef::ExprListComp(node) => std::ptr::NonNull::from(*node).cast(),
             AnyNodeRef::ExprSetComp(node) => std::ptr::NonNull::from(*node).cast(),
@@ -5987,6 +5980,13 @@ impl AnyNodeRef<'_> {
             AnyNodeRef::ExprTuple(node) => std::ptr::NonNull::from(*node).cast(),
             AnyNodeRef::ExprSlice(node) => std::ptr::NonNull::from(*node).cast(),
             AnyNodeRef::ExprIpyEscapeCommand(node) => std::ptr::NonNull::from(*node).cast(),
+            AnyNodeRef::ExprBoolOp(node) => std::ptr::NonNull::from(*node).cast(),
+            AnyNodeRef::ExprNamed(node) => std::ptr::NonNull::from(*node).cast(),
+            AnyNodeRef::ExprBinOp(node) => std::ptr::NonNull::from(*node).cast(),
+            AnyNodeRef::ExprUnaryOp(node) => std::ptr::NonNull::from(*node).cast(),
+            AnyNodeRef::ExprLambda(node) => std::ptr::NonNull::from(*node).cast(),
+            AnyNodeRef::ExprIf(node) => std::ptr::NonNull::from(*node).cast(),
+            AnyNodeRef::ExprDict(node) => std::ptr::NonNull::from(*node).cast(),
             AnyNodeRef::ExceptHandlerExceptHandler(node) => std::ptr::NonNull::from(*node).cast(),
             AnyNodeRef::FStringExpressionElement(node) => std::ptr::NonNull::from(*node).cast(),
             AnyNodeRef::FStringLiteralElement(node) => std::ptr::NonNull::from(*node).cast(),
@@ -6058,13 +6058,6 @@ impl<'a> AnyNodeRef<'a> {
             AnyNodeRef::StmtBreak(node) => node.visit_source_order(visitor),
             AnyNodeRef::StmtContinue(node) => node.visit_source_order(visitor),
             AnyNodeRef::StmtIpyEscapeCommand(node) => node.visit_source_order(visitor),
-            AnyNodeRef::ExprBoolOp(node) => node.visit_source_order(visitor),
-            AnyNodeRef::ExprNamed(node) => node.visit_source_order(visitor),
-            AnyNodeRef::ExprBinOp(node) => node.visit_source_order(visitor),
-            AnyNodeRef::ExprUnaryOp(node) => node.visit_source_order(visitor),
-            AnyNodeRef::ExprLambda(node) => node.visit_source_order(visitor),
-            AnyNodeRef::ExprIf(node) => node.visit_source_order(visitor),
-            AnyNodeRef::ExprDict(node) => node.visit_source_order(visitor),
             AnyNodeRef::ExprSet(node) => node.visit_source_order(visitor),
             AnyNodeRef::ExprListComp(node) => node.visit_source_order(visitor),
             AnyNodeRef::ExprSetComp(node) => node.visit_source_order(visitor),
@@ -6090,6 +6083,13 @@ impl<'a> AnyNodeRef<'a> {
             AnyNodeRef::ExprTuple(node) => node.visit_source_order(visitor),
             AnyNodeRef::ExprSlice(node) => node.visit_source_order(visitor),
             AnyNodeRef::ExprIpyEscapeCommand(node) => node.visit_source_order(visitor),
+            AnyNodeRef::ExprBoolOp(node) => node.visit_source_order(visitor),
+            AnyNodeRef::ExprNamed(node) => node.visit_source_order(visitor),
+            AnyNodeRef::ExprBinOp(node) => node.visit_source_order(visitor),
+            AnyNodeRef::ExprUnaryOp(node) => node.visit_source_order(visitor),
+            AnyNodeRef::ExprLambda(node) => node.visit_source_order(visitor),
+            AnyNodeRef::ExprIf(node) => node.visit_source_order(visitor),
+            AnyNodeRef::ExprDict(node) => node.visit_source_order(visitor),
             AnyNodeRef::ExceptHandlerExceptHandler(node) => node.visit_source_order(visitor),
             AnyNodeRef::FStringExpressionElement(node) => node.visit_source_order(visitor),
             AnyNodeRef::FStringLiteralElement(node) => node.visit_source_order(visitor),
@@ -6173,14 +6173,7 @@ impl AnyNodeRef<'_> {
     pub const fn is_expression(self) -> bool {
         matches!(
             self,
-            AnyNodeRef::ExprBoolOp(_)
-                | AnyNodeRef::ExprNamed(_)
-                | AnyNodeRef::ExprBinOp(_)
-                | AnyNodeRef::ExprUnaryOp(_)
-                | AnyNodeRef::ExprLambda(_)
-                | AnyNodeRef::ExprIf(_)
-                | AnyNodeRef::ExprDict(_)
-                | AnyNodeRef::ExprSet(_)
+            AnyNodeRef::ExprSet(_)
                 | AnyNodeRef::ExprListComp(_)
                 | AnyNodeRef::ExprSetComp(_)
                 | AnyNodeRef::ExprDictComp(_)
@@ -6205,6 +6198,13 @@ impl AnyNodeRef<'_> {
                 | AnyNodeRef::ExprTuple(_)
                 | AnyNodeRef::ExprSlice(_)
                 | AnyNodeRef::ExprIpyEscapeCommand(_)
+                | AnyNodeRef::ExprBoolOp(_)
+                | AnyNodeRef::ExprNamed(_)
+                | AnyNodeRef::ExprBinOp(_)
+                | AnyNodeRef::ExprUnaryOp(_)
+                | AnyNodeRef::ExprLambda(_)
+                | AnyNodeRef::ExprIf(_)
+                | AnyNodeRef::ExprDict(_)
         )
     }
 }
@@ -6280,13 +6280,6 @@ pub enum NodeKind {
     StmtBreak,
     StmtContinue,
     StmtIpyEscapeCommand,
-    ExprBoolOp,
-    ExprNamed,
-    ExprBinOp,
-    ExprUnaryOp,
-    ExprLambda,
-    ExprIf,
-    ExprDict,
     ExprSet,
     ExprListComp,
     ExprSetComp,
@@ -6312,6 +6305,13 @@ pub enum NodeKind {
     ExprTuple,
     ExprSlice,
     ExprIpyEscapeCommand,
+    ExprBoolOp,
+    ExprNamed,
+    ExprBinOp,
+    ExprUnaryOp,
+    ExprLambda,
+    ExprIf,
+    ExprDict,
     ExceptHandlerExceptHandler,
     FStringExpressionElement,
     FStringLiteralElement,
@@ -6377,13 +6377,6 @@ impl AnyNodeRef<'_> {
             AnyNodeRef::StmtBreak(_) => NodeKind::StmtBreak,
             AnyNodeRef::StmtContinue(_) => NodeKind::StmtContinue,
             AnyNodeRef::StmtIpyEscapeCommand(_) => NodeKind::StmtIpyEscapeCommand,
-            AnyNodeRef::ExprBoolOp(_) => NodeKind::ExprBoolOp,
-            AnyNodeRef::ExprNamed(_) => NodeKind::ExprNamed,
-            AnyNodeRef::ExprBinOp(_) => NodeKind::ExprBinOp,
-            AnyNodeRef::ExprUnaryOp(_) => NodeKind::ExprUnaryOp,
-            AnyNodeRef::ExprLambda(_) => NodeKind::ExprLambda,
-            AnyNodeRef::ExprIf(_) => NodeKind::ExprIf,
-            AnyNodeRef::ExprDict(_) => NodeKind::ExprDict,
             AnyNodeRef::ExprSet(_) => NodeKind::ExprSet,
             AnyNodeRef::ExprListComp(_) => NodeKind::ExprListComp,
             AnyNodeRef::ExprSetComp(_) => NodeKind::ExprSetComp,
@@ -6409,6 +6402,13 @@ impl AnyNodeRef<'_> {
             AnyNodeRef::ExprTuple(_) => NodeKind::ExprTuple,
             AnyNodeRef::ExprSlice(_) => NodeKind::ExprSlice,
             AnyNodeRef::ExprIpyEscapeCommand(_) => NodeKind::ExprIpyEscapeCommand,
+            AnyNodeRef::ExprBoolOp(_) => NodeKind::ExprBoolOp,
+            AnyNodeRef::ExprNamed(_) => NodeKind::ExprNamed,
+            AnyNodeRef::ExprBinOp(_) => NodeKind::ExprBinOp,
+            AnyNodeRef::ExprUnaryOp(_) => NodeKind::ExprUnaryOp,
+            AnyNodeRef::ExprLambda(_) => NodeKind::ExprLambda,
+            AnyNodeRef::ExprIf(_) => NodeKind::ExprIf,
+            AnyNodeRef::ExprDict(_) => NodeKind::ExprDict,
             AnyNodeRef::ExceptHandlerExceptHandler(_) => NodeKind::ExceptHandlerExceptHandler,
             AnyNodeRef::FStringExpressionElement(_) => NodeKind::FStringExpressionElement,
             AnyNodeRef::FStringLiteralElement(_) => NodeKind::FStringLiteralElement,
@@ -6444,4 +6444,54 @@ impl AnyNodeRef<'_> {
             AnyNodeRef::Identifier(_) => NodeKind::Identifier,
         }
     }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExprBoolOp {
+    pub range: ruff_text_size::TextRange,
+    pub op: crate::BoolOp,
+    pub values: Vec<crate::Expr>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExprNamed {
+    pub range: ruff_text_size::TextRange,
+    pub target: Box<crate::Expr>,
+    pub value: Box<crate::Expr>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExprBinOp {
+    pub range: ruff_text_size::TextRange,
+    pub left: Box<crate::Expr>,
+    pub op: crate::Operator,
+    pub right: Box<crate::Expr>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExprUnaryOp {
+    pub range: ruff_text_size::TextRange,
+    pub op: crate::UnaryOp,
+    pub operand: Box<crate::Expr>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExprLambda {
+    pub range: ruff_text_size::TextRange,
+    pub parameters: Option<Box<crate::Parameters>>,
+    pub body: Box<crate::Expr>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExprIf {
+    pub range: ruff_text_size::TextRange,
+    pub test: Box<crate::Expr>,
+    pub body: Box<crate::Expr>,
+    pub orelse: Box<crate::Expr>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExprDict {
+    pub range: ruff_text_size::TextRange,
+    pub items: Vec<crate::DictItem>,
 }

--- a/crates/ruff_python_ast/src/name.rs
+++ b/crates/ruff_python_ast/src/name.rs
@@ -3,7 +3,8 @@ use std::fmt::{Debug, Display, Formatter, Write};
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
 
-use crate::{nodes, Expr};
+use crate::generated::ExprName;
+use crate::Expr;
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -387,16 +388,14 @@ impl<'a> UnqualifiedName<'a> {
         let attr1 = match expr {
             Expr::Attribute(attr1) => attr1,
             // Ex) `foo`
-            Expr::Name(nodes::ExprName { id, .. }) => {
-                return Some(Self::from_slice(&[id.as_str()]))
-            }
+            Expr::Name(ExprName { id, .. }) => return Some(Self::from_slice(&[id.as_str()])),
             _ => return None,
         };
 
         let attr2 = match attr1.value.as_ref() {
             Expr::Attribute(attr2) => attr2,
             // Ex) `foo.bar`
-            Expr::Name(nodes::ExprName { id, .. }) => {
+            Expr::Name(ExprName { id, .. }) => {
                 return Some(Self::from_slice(&[id.as_str(), attr1.attr.as_str()]))
             }
             _ => return None,
@@ -405,7 +404,7 @@ impl<'a> UnqualifiedName<'a> {
         let attr3 = match attr2.value.as_ref() {
             Expr::Attribute(attr3) => attr3,
             // Ex) `foo.bar.baz`
-            Expr::Name(nodes::ExprName { id, .. }) => {
+            Expr::Name(ExprName { id, .. }) => {
                 return Some(Self::from_slice(&[
                     id.as_str(),
                     attr2.attr.as_str(),
@@ -418,7 +417,7 @@ impl<'a> UnqualifiedName<'a> {
         let attr4 = match attr3.value.as_ref() {
             Expr::Attribute(attr4) => attr4,
             // Ex) `foo.bar.baz.bop`
-            Expr::Name(nodes::ExprName { id, .. }) => {
+            Expr::Name(ExprName { id, .. }) => {
                 return Some(Self::from_slice(&[
                     id.as_str(),
                     attr3.attr.as_str(),
@@ -432,7 +431,7 @@ impl<'a> UnqualifiedName<'a> {
         let attr5 = match attr4.value.as_ref() {
             Expr::Attribute(attr5) => attr5,
             // Ex) `foo.bar.baz.bop.bap`
-            Expr::Name(nodes::ExprName { id, .. }) => {
+            Expr::Name(ExprName { id, .. }) => {
                 return Some(Self::from_slice(&[
                     id.as_str(),
                     attr4.attr.as_str(),
@@ -447,7 +446,7 @@ impl<'a> UnqualifiedName<'a> {
         let attr6 = match attr5.value.as_ref() {
             Expr::Attribute(attr6) => attr6,
             // Ex) `foo.bar.baz.bop.bap.bab`
-            Expr::Name(nodes::ExprName { id, .. }) => {
+            Expr::Name(ExprName { id, .. }) => {
                 return Some(Self::from_slice(&[
                     id.as_str(),
                     attr5.attr.as_str(),
@@ -463,7 +462,7 @@ impl<'a> UnqualifiedName<'a> {
         let attr7 = match attr6.value.as_ref() {
             Expr::Attribute(attr7) => attr7,
             // Ex) `foo.bar.baz.bop.bap.bab.bob`
-            Expr::Name(nodes::ExprName { id, .. }) => {
+            Expr::Name(ExprName { id, .. }) => {
                 return Some(Self::from_slice(&[
                     id.as_str(),
                     attr6.attr.as_str(),
@@ -480,7 +479,7 @@ impl<'a> UnqualifiedName<'a> {
         let attr8 = match attr7.value.as_ref() {
             Expr::Attribute(attr8) => attr8,
             // Ex) `foo.bar.baz.bop.bap.bab.bob.bib`
-            Expr::Name(nodes::ExprName { id, .. }) => {
+            Expr::Name(ExprName { id, .. }) => {
                 return Some(Self(SegmentsVec::from([
                     id.as_str(),
                     attr7.attr.as_str(),
@@ -505,7 +504,7 @@ impl<'a> UnqualifiedName<'a> {
                     segments.push(attr.attr.as_str());
                     &*attr.value
                 }
-                Expr::Name(nodes::ExprName { id, .. }) => {
+                Expr::Name(ExprName { id, .. }) => {
                     segments.push(id.as_str());
                     break;
                 }

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -1,6 +1,9 @@
 #![allow(clippy::derive_partial_eq_without_eq)]
 
-use crate::generated::*;
+use crate::generated::{
+    ExprBytesLiteral, ExprDict, ExprFString, ExprList, ExprName, ExprSet, ExprStringLiteral,
+    ExprTuple,
+};
 use std::borrow::Cow;
 use std::fmt;
 use std::fmt::Debug;
@@ -639,7 +642,7 @@ impl DoubleEndedIterator for DictValueIterator<'_> {
 impl FusedIterator for DictValueIterator<'_> {}
 impl ExactSizeIterator for DictValueIterator<'_> {}
 
-/// See also [Set](https://docs.python.org/3/library/ast.html#ast.Set)
+// /// See also [Set](https://docs.python.org/3/library/ast.html#ast.Set)
 // #[derive(Clone, Debug, PartialEq)]
 // pub struct ExprSet {
 //     pub range: TextRange,

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -397,55 +397,55 @@ pub struct ExprIpyEscapeCommand {
     pub value: Box<str>,
 }
 
-/// See also [BoolOp](https://docs.python.org/3/library/ast.html#ast.BoolOp)
-#[derive(Clone, Debug, PartialEq)]
-pub struct ExprBoolOp {
-    pub range: TextRange,
-    pub op: BoolOp,
-    pub values: Vec<Expr>,
-}
+// /// See also [BoolOp](https://docs.python.org/3/library/ast.html#ast.BoolOp)
+// #[derive(Clone, Debug, PartialEq)]
+// pub struct ExprBoolOp {
+//     pub range: TextRange,
+//     pub op: BoolOp,
+//     pub values: Vec<Expr>,
+// }
 
-/// See also [NamedExpr](https://docs.python.org/3/library/ast.html#ast.NamedExpr)
-#[derive(Clone, Debug, PartialEq)]
-pub struct ExprNamed {
-    pub range: TextRange,
-    pub target: Box<Expr>,
-    pub value: Box<Expr>,
-}
+// /// See also [NamedExpr](https://docs.python.org/3/library/ast.html#ast.NamedExpr)
+// #[derive(Clone, Debug, PartialEq)]
+// pub struct ExprNamed {
+//     pub range: TextRange,
+//     pub target: Box<Expr>,
+//     pub value: Box<Expr>,
+// }
 
-/// See also [BinOp](https://docs.python.org/3/library/ast.html#ast.BinOp)
-#[derive(Clone, Debug, PartialEq)]
-pub struct ExprBinOp {
-    pub range: TextRange,
-    pub left: Box<Expr>,
-    pub op: Operator,
-    pub right: Box<Expr>,
-}
+// /// See also [BinOp](https://docs.python.org/3/library/ast.html#ast.BinOp)
+// #[derive(Clone, Debug, PartialEq)]
+// pub struct ExprBinOp {
+//     pub range: TextRange,
+//     pub left: Box<Expr>,
+//     pub op: Operator,
+//     pub right: Box<Expr>,
+// }
 
-/// See also [UnaryOp](https://docs.python.org/3/library/ast.html#ast.UnaryOp)
-#[derive(Clone, Debug, PartialEq)]
-pub struct ExprUnaryOp {
-    pub range: TextRange,
-    pub op: UnaryOp,
-    pub operand: Box<Expr>,
-}
+// /// See also [UnaryOp](https://docs.python.org/3/library/ast.html#ast.UnaryOp)
+// #[derive(Clone, Debug, PartialEq)]
+// pub struct ExprUnaryOp {
+//     pub range: TextRange,
+//     pub op: UnaryOp,
+//     pub operand: Box<Expr>,
+// }
 
-/// See also [Lambda](https://docs.python.org/3/library/ast.html#ast.Lambda)
-#[derive(Clone, Debug, PartialEq)]
-pub struct ExprLambda {
-    pub range: TextRange,
-    pub parameters: Option<Box<Parameters>>,
-    pub body: Box<Expr>,
-}
+// /// See also [Lambda](https://docs.python.org/3/library/ast.html#ast.Lambda)
+// #[derive(Clone, Debug, PartialEq)]
+// pub struct ExprLambda {
+//     pub range: TextRange,
+//     pub parameters: Option<Box<Parameters>>,
+//     pub body: Box<Expr>,
+// }
 
-/// See also [IfExp](https://docs.python.org/3/library/ast.html#ast.IfExp)
-#[derive(Clone, Debug, PartialEq)]
-pub struct ExprIf {
-    pub range: TextRange,
-    pub test: Box<Expr>,
-    pub body: Box<Expr>,
-    pub orelse: Box<Expr>,
-}
+// /// See also [IfExp](https://docs.python.org/3/library/ast.html#ast.IfExp)
+// #[derive(Clone, Debug, PartialEq)]
+// pub struct ExprIf {
+//     pub range: TextRange,
+//     pub test: Box<Expr>,
+//     pub body: Box<Expr>,
+//     pub orelse: Box<Expr>,
+// }
 
 /// Represents an item in a [dictionary literal display][1].
 ///
@@ -495,14 +495,14 @@ impl Ranged for DictItem {
     }
 }
 
-/// See also [Dict](https://docs.python.org/3/library/ast.html#ast.Dict)
-#[derive(Clone, Debug, PartialEq)]
-pub struct ExprDict {
-    pub range: TextRange,
-    pub items: Vec<DictItem>,
-}
+// /// See also [Dict](https://docs.python.org/3/library/ast.html#ast.Dict)
+// #[derive(Clone, Debug, PartialEq)]
+// pub struct ExprDict {
+//     pub range: TextRange,
+//     pub items: Vec<DictItem>,
+// }
 
-impl ExprDict {
+impl crate::ExprDict {
     /// Returns an `Iterator` over the AST nodes representing the
     /// dictionary's keys.
     pub fn iter_keys(&self) -> DictKeyIterator {
@@ -544,7 +544,7 @@ impl ExprDict {
     }
 }
 
-impl<'a> IntoIterator for &'a ExprDict {
+impl<'a> IntoIterator for &'a crate::ExprDict {
     type IntoIter = std::slice::Iter<'a, DictItem>;
     type Item = &'a DictItem;
 
@@ -3641,25 +3641,25 @@ mod tests {
         assert_eq!(std::mem::size_of::<Expr>(), 64);
         assert_eq!(std::mem::size_of::<ExprAttribute>(), 56);
         assert_eq!(std::mem::size_of::<ExprAwait>(), 16);
-        assert_eq!(std::mem::size_of::<ExprBinOp>(), 32);
-        assert_eq!(std::mem::size_of::<ExprBoolOp>(), 40);
+        assert_eq!(std::mem::size_of::<crate::ExprBinOp>(), 32);
+        assert_eq!(std::mem::size_of::<crate::ExprBoolOp>(), 40);
         assert_eq!(std::mem::size_of::<ExprBooleanLiteral>(), 12);
         assert_eq!(std::mem::size_of::<ExprBytesLiteral>(), 40);
         assert_eq!(std::mem::size_of::<ExprCall>(), 56);
         assert_eq!(std::mem::size_of::<ExprCompare>(), 48);
-        assert_eq!(std::mem::size_of::<ExprDict>(), 32);
+        assert_eq!(std::mem::size_of::<crate::ExprDict>(), 32);
         assert_eq!(std::mem::size_of::<ExprDictComp>(), 48);
         assert_eq!(std::mem::size_of::<ExprEllipsisLiteral>(), 8);
         // 56 for Rustc < 1.76
         assert!(matches!(std::mem::size_of::<ExprFString>(), 48 | 56));
         assert_eq!(std::mem::size_of::<ExprGenerator>(), 48);
-        assert_eq!(std::mem::size_of::<ExprIf>(), 32);
+        assert_eq!(std::mem::size_of::<crate::ExprIf>(), 32);
         assert_eq!(std::mem::size_of::<ExprIpyEscapeCommand>(), 32);
-        assert_eq!(std::mem::size_of::<ExprLambda>(), 24);
+        assert_eq!(std::mem::size_of::<crate::ExprLambda>(), 24);
         assert_eq!(std::mem::size_of::<ExprList>(), 40);
         assert_eq!(std::mem::size_of::<ExprListComp>(), 40);
         assert_eq!(std::mem::size_of::<ExprName>(), 40);
-        assert_eq!(std::mem::size_of::<ExprNamed>(), 24);
+        assert_eq!(std::mem::size_of::<crate::ExprNamed>(), 24);
         assert_eq!(std::mem::size_of::<ExprNoneLiteral>(), 8);
         assert_eq!(std::mem::size_of::<ExprNumberLiteral>(), 32);
         assert_eq!(std::mem::size_of::<ExprSet>(), 32);
@@ -3669,7 +3669,7 @@ mod tests {
         assert_eq!(std::mem::size_of::<ExprStringLiteral>(), 56);
         assert_eq!(std::mem::size_of::<ExprSubscript>(), 32);
         assert_eq!(std::mem::size_of::<ExprTuple>(), 40);
-        assert_eq!(std::mem::size_of::<ExprUnaryOp>(), 24);
+        assert_eq!(std::mem::size_of::<crate::ExprUnaryOp>(), 24);
         assert_eq!(std::mem::size_of::<ExprYield>(), 16);
         assert_eq!(std::mem::size_of::<ExprYieldFrom>(), 16);
     }

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -384,74 +384,6 @@ impl ExprRef<'_> {
     }
 }
 
-// /// An AST node used to represent a IPython escape command at the expression level.
-// ///
-// /// For example,
-// /// ```python
-// /// dir = !pwd
-// /// ```
-// ///
-// /// Here, the escape kind can only be `!` or `%` otherwise it is a syntax error.
-// ///
-// /// For more information related to terminology and syntax of escape commands,
-// /// see [`StmtIpyEscapeCommand`].
-// #[derive(Clone, Debug, PartialEq)]
-// pub struct ExprIpyEscapeCommand {
-//     pub range: TextRange,
-//     pub kind: IpyEscapeKind,
-//     pub value: Box<str>,
-// }
-
-// /// See also [BoolOp](https://docs.python.org/3/library/ast.html#ast.BoolOp)
-// #[derive(Clone, Debug, PartialEq)]
-// pub struct ExprBoolOp {
-//     pub range: TextRange,
-//     pub op: BoolOp,
-//     pub values: Vec<Expr>,
-// }
-
-// /// See also [NamedExpr](https://docs.python.org/3/library/ast.html#ast.NamedExpr)
-// #[derive(Clone, Debug, PartialEq)]
-// pub struct ExprNamed {
-//     pub range: TextRange,
-//     pub target: Box<Expr>,
-//     pub value: Box<Expr>,
-// }
-
-// /// See also [BinOp](https://docs.python.org/3/library/ast.html#ast.BinOp)
-// #[derive(Clone, Debug, PartialEq)]
-// pub struct ExprBinOp {
-//     pub range: TextRange,
-//     pub left: Box<Expr>,
-//     pub op: Operator,
-//     pub right: Box<Expr>,
-// }
-
-// /// See also [UnaryOp](https://docs.python.org/3/library/ast.html#ast.UnaryOp)
-// #[derive(Clone, Debug, PartialEq)]
-// pub struct ExprUnaryOp {
-//     pub range: TextRange,
-//     pub op: UnaryOp,
-//     pub operand: Box<Expr>,
-// }
-
-// /// See also [Lambda](https://docs.python.org/3/library/ast.html#ast.Lambda)
-// #[derive(Clone, Debug, PartialEq)]
-// pub struct ExprLambda {
-//     pub range: TextRange,
-//     pub parameters: Option<Box<Parameters>>,
-//     pub body: Box<Expr>,
-// }
-
-// /// See also [IfExp](https://docs.python.org/3/library/ast.html#ast.IfExp)
-// #[derive(Clone, Debug, PartialEq)]
-// pub struct ExprIf {
-//     pub range: TextRange,
-//     pub test: Box<Expr>,
-//     pub body: Box<Expr>,
-//     pub orelse: Box<Expr>,
-// }
-
 /// Represents an item in a [dictionary literal display][1].
 ///
 /// Consider the following Python dictionary literal:
@@ -499,13 +431,6 @@ impl Ranged for DictItem {
         )
     }
 }
-
-// /// See also [Dict](https://docs.python.org/3/library/ast.html#ast.Dict)
-// #[derive(Clone, Debug, PartialEq)]
-// pub struct ExprDict {
-//     pub range: TextRange,
-//     pub items: Vec<DictItem>,
-// }
 
 impl ExprDict {
     /// Returns an `Iterator` over the AST nodes representing the
@@ -642,13 +567,6 @@ impl DoubleEndedIterator for DictValueIterator<'_> {
 impl FusedIterator for DictValueIterator<'_> {}
 impl ExactSizeIterator for DictValueIterator<'_> {}
 
-// /// See also [Set](https://docs.python.org/3/library/ast.html#ast.Set)
-// #[derive(Clone, Debug, PartialEq)]
-// pub struct ExprSet {
-//     pub range: TextRange,
-//     pub elts: Vec<Expr>,
-// }
-
 impl ExprSet {
     pub fn iter(&self) -> std::slice::Iter<'_, Expr> {
         self.elts.iter()
@@ -671,78 +589,6 @@ impl<'a> IntoIterator for &'a ExprSet {
         self.iter()
     }
 }
-
-// /// See also [ListComp](https://docs.python.org/3/library/ast.html#ast.ListComp)
-// #[derive(Clone, Debug, PartialEq)]
-// pub struct ExprListComp {
-//     pub range: TextRange,
-//     pub elt: Box<Expr>,
-//     pub generators: Vec<Comprehension>,
-// }
-
-// /// See also [SetComp](https://docs.python.org/3/library/ast.html#ast.SetComp)
-// #[derive(Clone, Debug, PartialEq)]
-// pub struct ExprSetComp {
-//     pub range: TextRange,
-//     pub elt: Box<Expr>,
-//     pub generators: Vec<Comprehension>,
-// }
-
-// /// See also [DictComp](https://docs.python.org/3/library/ast.html#ast.DictComp)
-// #[derive(Clone, Debug, PartialEq)]
-// pub struct ExprDictComp {
-//     pub range: TextRange,
-//     pub key: Box<Expr>,
-//     pub value: Box<Expr>,
-//     pub generators: Vec<Comprehension>,
-// }
-
-// /// See also [GeneratorExp](https://docs.python.org/3/library/ast.html#ast.GeneratorExp)
-// #[derive(Clone, Debug, PartialEq)]
-// pub struct ExprGenerator {
-//     pub range: TextRange,
-//     pub elt: Box<Expr>,
-//     pub generators: Vec<Comprehension>,
-//     pub parenthesized: bool,
-// }
-
-// /// See also [Await](https://docs.python.org/3/library/ast.html#ast.Await)
-// #[derive(Clone, Debug, PartialEq)]
-// pub struct ExprAwait {
-//     pub range: TextRange,
-//     pub value: Box<Expr>,
-// }
-
-// /// See also [Yield](https://docs.python.org/3/library/ast.html#ast.Yield)
-// #[derive(Clone, Debug, PartialEq)]
-// pub struct ExprYield {
-//     pub range: TextRange,
-//     pub value: Option<Box<Expr>>,
-// }
-
-// /// See also [YieldFrom](https://docs.python.org/3/library/ast.html#ast.YieldFrom)
-// #[derive(Clone, Debug, PartialEq)]
-// pub struct ExprYieldFrom {
-//     pub range: TextRange,
-//     pub value: Box<Expr>,
-// }
-
-// /// See also [Compare](https://docs.python.org/3/library/ast.html#ast.Compare)
-// #[derive(Clone, Debug, PartialEq)]
-// pub struct ExprCompare {
-//     pub range: TextRange,
-//     pub left: Box<Expr>,
-//     pub ops: Box<[CmpOp]>,
-//     pub comparators: Box<[Expr]>,
-// }
-
-// /// See also [Call](https://docs.python.org/3/library/ast.html#ast.Call)
-// #[derive(Clone, Debug, PartialEq)]
-// pub struct ExprCall {
-//     pub range: TextRange,
-//     pub func: Box<Expr>,
-//     pub arguments: Arguments,
-// }
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct FStringFormatSpec {
@@ -815,20 +661,6 @@ pub struct DebugText {
     /// The text between the expression and the conversion, the `format_spec`, or the `}`, depending on what's present in the source
     pub trailing: String,
 }
-
-// /// An AST node that represents either a single-part f-string literal
-// /// or an implicitly concatenated f-string literal.
-// ///
-// /// This type differs from the original Python AST ([JoinedStr]) in that it
-// /// doesn't join the implicitly concatenated parts into a single string. Instead,
-// /// it keeps them separate and provide various methods to access the parts.
-// ///
-// /// [JoinedStr]: https://docs.python.org/3/library/ast.html#ast.JoinedStr
-// #[derive(Clone, Debug, PartialEq)]
-// pub struct ExprFString {
-//     pub range: TextRange,
-//     pub value: FStringValue,
-// }
 
 impl ExprFString {
     /// Returns the single [`FString`] if the f-string isn't implicitly concatenated, [`None`]
@@ -1291,14 +1123,6 @@ impl fmt::Debug for FStringElements {
     }
 }
 
-// /// An AST node that represents either a single-part string literal
-// /// or an implicitly concatenated string literal.
-// #[derive(Clone, Debug, PartialEq)]
-// pub struct ExprStringLiteral {
-//     pub range: TextRange,
-//     pub value: StringLiteralValue,
-// }
-
 impl ExprStringLiteral {
     /// Return `Some(literal)` if the string only consists of a single `StringLiteral` part
     /// (indicating that it is not implicitly concatenated). Otherwise, return `None`.
@@ -1742,14 +1566,6 @@ impl Debug for ConcatenatedStringLiteral {
             .finish()
     }
 }
-
-// /// An AST node that represents either a single-part bytestring literal
-// /// or an implicitly concatenated bytestring literal.
-// #[derive(Clone, Debug, PartialEq)]
-// pub struct ExprBytesLiteral {
-//     pub range: TextRange,
-//     pub value: BytesLiteralValue,
-// }
 
 impl ExprBytesLiteral {
     /// Return `Some(literal)` if the bytestring only consists of a single `BytesLiteral` part
@@ -2352,12 +2168,6 @@ impl From<FStringFlags> for AnyStringFlags {
     }
 }
 
-// #[derive(Clone, Debug, PartialEq)]
-// pub struct ExprNumberLiteral {
-//     pub range: TextRange,
-//     pub value: Number,
-// }
-
 #[derive(Clone, Debug, PartialEq, is_macro::Is)]
 pub enum Number {
     Int(int::Int),
@@ -2365,69 +2175,11 @@ pub enum Number {
     Complex { real: f64, imag: f64 },
 }
 
-// #[derive(Clone, Debug, Default, PartialEq)]
-// pub struct ExprBooleanLiteral {
-//     pub range: TextRange,
-//     pub value: bool,
-// }
-
-// #[derive(Clone, Debug, Default, PartialEq)]
-// pub struct ExprNoneLiteral {
-//     pub range: TextRange,
-// }
-
-// #[derive(Clone, Debug, Default, PartialEq)]
-// pub struct ExprEllipsisLiteral {
-//     pub range: TextRange,
-// }
-
-// /// See also [Attribute](https://docs.python.org/3/library/ast.html#ast.Attribute)
-// #[derive(Clone, Debug, PartialEq)]
-// pub struct ExprAttribute {
-//     pub range: TextRange,
-//     pub value: Box<Expr>,
-//     pub attr: Identifier,
-//     pub ctx: ExprContext,
-// }
-
-// /// See also [Subscript](https://docs.python.org/3/library/ast.html#ast.Subscript)
-// #[derive(Clone, Debug, PartialEq)]
-// pub struct ExprSubscript {
-//     pub range: TextRange,
-//     pub value: Box<Expr>,
-//     pub slice: Box<Expr>,
-//     pub ctx: ExprContext,
-// }
-
-// /// See also [Starred](https://docs.python.org/3/library/ast.html#ast.Starred)
-// #[derive(Clone, Debug, PartialEq)]
-// pub struct ExprStarred {
-//     pub range: TextRange,
-//     pub value: Box<Expr>,
-//     pub ctx: ExprContext,
-// }
-
-// /// See also [Name](https://docs.python.org/3/library/ast.html#ast.Name)
-// #[derive(Clone, Debug, PartialEq)]
-// pub struct ExprName {
-//     pub range: TextRange,
-//     pub id: Name,
-//     pub ctx: ExprContext,
-// }
-
 impl ExprName {
     pub fn id(&self) -> &Name {
         &self.id
     }
 }
-
-// /// See also [List](https://docs.python.org/3/library/ast.html#ast.List)
-// #[derive(Clone, Debug, PartialEq)]
-// pub struct ExprList {
-//     pub range: TextRange,
-//     pub elts: Vec<Expr>,
-//     pub ctx: ExprContext,
-// }
 
 impl ExprList {
     pub fn iter(&self) -> std::slice::Iter<'_, Expr> {
@@ -2452,17 +2204,6 @@ impl<'a> IntoIterator for &'a ExprList {
     }
 }
 
-// /// See also [Tuple](https://docs.python.org/3/library/ast.html#ast.Tuple)
-// #[derive(Clone, Debug, PartialEq)]
-// pub struct ExprTuple {
-//     pub range: TextRange,
-//     pub elts: Vec<Expr>,
-//     pub ctx: ExprContext,
-//
-//     /// Whether the tuple is parenthesized in the source code.
-//     pub parenthesized: bool,
-// }
-
 impl ExprTuple {
     pub fn iter(&self) -> std::slice::Iter<'_, Expr> {
         self.elts.iter()
@@ -2485,15 +2226,6 @@ impl<'a> IntoIterator for &'a ExprTuple {
         self.iter()
     }
 }
-
-// /// See also [Slice](https://docs.python.org/3/library/ast.html#ast.Slice)
-// #[derive(Clone, Debug, PartialEq)]
-// pub struct ExprSlice {
-//     pub range: TextRange,
-//     pub lower: Option<Box<Expr>>,
-//     pub upper: Option<Box<Expr>>,
-//     pub step: Option<Box<Expr>>,
-// }
 
 /// See also [expr_context](https://docs.python.org/3/library/ast.html#ast.expr_context)
 #[derive(Clone, Debug, PartialEq, is_macro::Is, Copy, Hash, Eq)]

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::derive_partial_eq_without_eq)]
 
+use crate::generated::*;
 use std::borrow::Cow;
 use std::fmt;
 use std::fmt::Debug;
@@ -120,6 +121,7 @@ pub struct StmtClassDef {
     pub decorator_list: Vec<Decorator>,
     pub name: Identifier,
     pub type_params: Option<Box<TypeParams>>,
+    // TODO: can remove?
     pub arguments: Option<Box<Arguments>>,
     pub body: Vec<Stmt>,
 }
@@ -379,23 +381,23 @@ impl ExprRef<'_> {
     }
 }
 
-/// An AST node used to represent a IPython escape command at the expression level.
-///
-/// For example,
-/// ```python
-/// dir = !pwd
-/// ```
-///
-/// Here, the escape kind can only be `!` or `%` otherwise it is a syntax error.
-///
-/// For more information related to terminology and syntax of escape commands,
-/// see [`StmtIpyEscapeCommand`].
-#[derive(Clone, Debug, PartialEq)]
-pub struct ExprIpyEscapeCommand {
-    pub range: TextRange,
-    pub kind: IpyEscapeKind,
-    pub value: Box<str>,
-}
+// /// An AST node used to represent a IPython escape command at the expression level.
+// ///
+// /// For example,
+// /// ```python
+// /// dir = !pwd
+// /// ```
+// ///
+// /// Here, the escape kind can only be `!` or `%` otherwise it is a syntax error.
+// ///
+// /// For more information related to terminology and syntax of escape commands,
+// /// see [`StmtIpyEscapeCommand`].
+// #[derive(Clone, Debug, PartialEq)]
+// pub struct ExprIpyEscapeCommand {
+//     pub range: TextRange,
+//     pub kind: IpyEscapeKind,
+//     pub value: Box<str>,
+// }
 
 // /// See also [BoolOp](https://docs.python.org/3/library/ast.html#ast.BoolOp)
 // #[derive(Clone, Debug, PartialEq)]
@@ -502,7 +504,7 @@ impl Ranged for DictItem {
 //     pub items: Vec<DictItem>,
 // }
 
-impl crate::ExprDict {
+impl ExprDict {
     /// Returns an `Iterator` over the AST nodes representing the
     /// dictionary's keys.
     pub fn iter_keys(&self) -> DictKeyIterator {
@@ -544,7 +546,7 @@ impl crate::ExprDict {
     }
 }
 
-impl<'a> IntoIterator for &'a crate::ExprDict {
+impl<'a> IntoIterator for &'a ExprDict {
     type IntoIter = std::slice::Iter<'a, DictItem>;
     type Item = &'a DictItem;
 
@@ -638,11 +640,11 @@ impl FusedIterator for DictValueIterator<'_> {}
 impl ExactSizeIterator for DictValueIterator<'_> {}
 
 /// See also [Set](https://docs.python.org/3/library/ast.html#ast.Set)
-#[derive(Clone, Debug, PartialEq)]
-pub struct ExprSet {
-    pub range: TextRange,
-    pub elts: Vec<Expr>,
-}
+// #[derive(Clone, Debug, PartialEq)]
+// pub struct ExprSet {
+//     pub range: TextRange,
+//     pub elts: Vec<Expr>,
+// }
 
 impl ExprSet {
     pub fn iter(&self) -> std::slice::Iter<'_, Expr> {
@@ -667,77 +669,77 @@ impl<'a> IntoIterator for &'a ExprSet {
     }
 }
 
-/// See also [ListComp](https://docs.python.org/3/library/ast.html#ast.ListComp)
-#[derive(Clone, Debug, PartialEq)]
-pub struct ExprListComp {
-    pub range: TextRange,
-    pub elt: Box<Expr>,
-    pub generators: Vec<Comprehension>,
-}
+// /// See also [ListComp](https://docs.python.org/3/library/ast.html#ast.ListComp)
+// #[derive(Clone, Debug, PartialEq)]
+// pub struct ExprListComp {
+//     pub range: TextRange,
+//     pub elt: Box<Expr>,
+//     pub generators: Vec<Comprehension>,
+// }
 
-/// See also [SetComp](https://docs.python.org/3/library/ast.html#ast.SetComp)
-#[derive(Clone, Debug, PartialEq)]
-pub struct ExprSetComp {
-    pub range: TextRange,
-    pub elt: Box<Expr>,
-    pub generators: Vec<Comprehension>,
-}
+// /// See also [SetComp](https://docs.python.org/3/library/ast.html#ast.SetComp)
+// #[derive(Clone, Debug, PartialEq)]
+// pub struct ExprSetComp {
+//     pub range: TextRange,
+//     pub elt: Box<Expr>,
+//     pub generators: Vec<Comprehension>,
+// }
 
-/// See also [DictComp](https://docs.python.org/3/library/ast.html#ast.DictComp)
-#[derive(Clone, Debug, PartialEq)]
-pub struct ExprDictComp {
-    pub range: TextRange,
-    pub key: Box<Expr>,
-    pub value: Box<Expr>,
-    pub generators: Vec<Comprehension>,
-}
+// /// See also [DictComp](https://docs.python.org/3/library/ast.html#ast.DictComp)
+// #[derive(Clone, Debug, PartialEq)]
+// pub struct ExprDictComp {
+//     pub range: TextRange,
+//     pub key: Box<Expr>,
+//     pub value: Box<Expr>,
+//     pub generators: Vec<Comprehension>,
+// }
 
-/// See also [GeneratorExp](https://docs.python.org/3/library/ast.html#ast.GeneratorExp)
-#[derive(Clone, Debug, PartialEq)]
-pub struct ExprGenerator {
-    pub range: TextRange,
-    pub elt: Box<Expr>,
-    pub generators: Vec<Comprehension>,
-    pub parenthesized: bool,
-}
+// /// See also [GeneratorExp](https://docs.python.org/3/library/ast.html#ast.GeneratorExp)
+// #[derive(Clone, Debug, PartialEq)]
+// pub struct ExprGenerator {
+//     pub range: TextRange,
+//     pub elt: Box<Expr>,
+//     pub generators: Vec<Comprehension>,
+//     pub parenthesized: bool,
+// }
 
-/// See also [Await](https://docs.python.org/3/library/ast.html#ast.Await)
-#[derive(Clone, Debug, PartialEq)]
-pub struct ExprAwait {
-    pub range: TextRange,
-    pub value: Box<Expr>,
-}
+// /// See also [Await](https://docs.python.org/3/library/ast.html#ast.Await)
+// #[derive(Clone, Debug, PartialEq)]
+// pub struct ExprAwait {
+//     pub range: TextRange,
+//     pub value: Box<Expr>,
+// }
 
-/// See also [Yield](https://docs.python.org/3/library/ast.html#ast.Yield)
-#[derive(Clone, Debug, PartialEq)]
-pub struct ExprYield {
-    pub range: TextRange,
-    pub value: Option<Box<Expr>>,
-}
+// /// See also [Yield](https://docs.python.org/3/library/ast.html#ast.Yield)
+// #[derive(Clone, Debug, PartialEq)]
+// pub struct ExprYield {
+//     pub range: TextRange,
+//     pub value: Option<Box<Expr>>,
+// }
 
-/// See also [YieldFrom](https://docs.python.org/3/library/ast.html#ast.YieldFrom)
-#[derive(Clone, Debug, PartialEq)]
-pub struct ExprYieldFrom {
-    pub range: TextRange,
-    pub value: Box<Expr>,
-}
+// /// See also [YieldFrom](https://docs.python.org/3/library/ast.html#ast.YieldFrom)
+// #[derive(Clone, Debug, PartialEq)]
+// pub struct ExprYieldFrom {
+//     pub range: TextRange,
+//     pub value: Box<Expr>,
+// }
 
-/// See also [Compare](https://docs.python.org/3/library/ast.html#ast.Compare)
-#[derive(Clone, Debug, PartialEq)]
-pub struct ExprCompare {
-    pub range: TextRange,
-    pub left: Box<Expr>,
-    pub ops: Box<[CmpOp]>,
-    pub comparators: Box<[Expr]>,
-}
+// /// See also [Compare](https://docs.python.org/3/library/ast.html#ast.Compare)
+// #[derive(Clone, Debug, PartialEq)]
+// pub struct ExprCompare {
+//     pub range: TextRange,
+//     pub left: Box<Expr>,
+//     pub ops: Box<[CmpOp]>,
+//     pub comparators: Box<[Expr]>,
+// }
 
-/// See also [Call](https://docs.python.org/3/library/ast.html#ast.Call)
-#[derive(Clone, Debug, PartialEq)]
-pub struct ExprCall {
-    pub range: TextRange,
-    pub func: Box<Expr>,
-    pub arguments: Arguments,
-}
+// /// See also [Call](https://docs.python.org/3/library/ast.html#ast.Call)
+// #[derive(Clone, Debug, PartialEq)]
+// pub struct ExprCall {
+//     pub range: TextRange,
+//     pub func: Box<Expr>,
+//     pub arguments: Arguments,
+// }
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct FStringFormatSpec {
@@ -811,19 +813,19 @@ pub struct DebugText {
     pub trailing: String,
 }
 
-/// An AST node that represents either a single-part f-string literal
-/// or an implicitly concatenated f-string literal.
-///
-/// This type differs from the original Python AST ([JoinedStr]) in that it
-/// doesn't join the implicitly concatenated parts into a single string. Instead,
-/// it keeps them separate and provide various methods to access the parts.
-///
-/// [JoinedStr]: https://docs.python.org/3/library/ast.html#ast.JoinedStr
-#[derive(Clone, Debug, PartialEq)]
-pub struct ExprFString {
-    pub range: TextRange,
-    pub value: FStringValue,
-}
+// /// An AST node that represents either a single-part f-string literal
+// /// or an implicitly concatenated f-string literal.
+// ///
+// /// This type differs from the original Python AST ([JoinedStr]) in that it
+// /// doesn't join the implicitly concatenated parts into a single string. Instead,
+// /// it keeps them separate and provide various methods to access the parts.
+// ///
+// /// [JoinedStr]: https://docs.python.org/3/library/ast.html#ast.JoinedStr
+// #[derive(Clone, Debug, PartialEq)]
+// pub struct ExprFString {
+//     pub range: TextRange,
+//     pub value: FStringValue,
+// }
 
 impl ExprFString {
     /// Returns the single [`FString`] if the f-string isn't implicitly concatenated, [`None`]
@@ -1286,13 +1288,13 @@ impl fmt::Debug for FStringElements {
     }
 }
 
-/// An AST node that represents either a single-part string literal
-/// or an implicitly concatenated string literal.
-#[derive(Clone, Debug, PartialEq)]
-pub struct ExprStringLiteral {
-    pub range: TextRange,
-    pub value: StringLiteralValue,
-}
+// /// An AST node that represents either a single-part string literal
+// /// or an implicitly concatenated string literal.
+// #[derive(Clone, Debug, PartialEq)]
+// pub struct ExprStringLiteral {
+//     pub range: TextRange,
+//     pub value: StringLiteralValue,
+// }
 
 impl ExprStringLiteral {
     /// Return `Some(literal)` if the string only consists of a single `StringLiteral` part
@@ -1738,13 +1740,13 @@ impl Debug for ConcatenatedStringLiteral {
     }
 }
 
-/// An AST node that represents either a single-part bytestring literal
-/// or an implicitly concatenated bytestring literal.
-#[derive(Clone, Debug, PartialEq)]
-pub struct ExprBytesLiteral {
-    pub range: TextRange,
-    pub value: BytesLiteralValue,
-}
+// /// An AST node that represents either a single-part bytestring literal
+// /// or an implicitly concatenated bytestring literal.
+// #[derive(Clone, Debug, PartialEq)]
+// pub struct ExprBytesLiteral {
+//     pub range: TextRange,
+//     pub value: BytesLiteralValue,
+// }
 
 impl ExprBytesLiteral {
     /// Return `Some(literal)` if the bytestring only consists of a single `BytesLiteral` part
@@ -2347,11 +2349,11 @@ impl From<FStringFlags> for AnyStringFlags {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
-pub struct ExprNumberLiteral {
-    pub range: TextRange,
-    pub value: Number,
-}
+// #[derive(Clone, Debug, PartialEq)]
+// pub struct ExprNumberLiteral {
+//     pub range: TextRange,
+//     pub value: Number,
+// }
 
 #[derive(Clone, Debug, PartialEq, is_macro::Is)]
 pub enum Number {
@@ -2360,55 +2362,55 @@ pub enum Number {
     Complex { real: f64, imag: f64 },
 }
 
-#[derive(Clone, Debug, Default, PartialEq)]
-pub struct ExprBooleanLiteral {
-    pub range: TextRange,
-    pub value: bool,
-}
+// #[derive(Clone, Debug, Default, PartialEq)]
+// pub struct ExprBooleanLiteral {
+//     pub range: TextRange,
+//     pub value: bool,
+// }
 
-#[derive(Clone, Debug, Default, PartialEq)]
-pub struct ExprNoneLiteral {
-    pub range: TextRange,
-}
+// #[derive(Clone, Debug, Default, PartialEq)]
+// pub struct ExprNoneLiteral {
+//     pub range: TextRange,
+// }
 
-#[derive(Clone, Debug, Default, PartialEq)]
-pub struct ExprEllipsisLiteral {
-    pub range: TextRange,
-}
+// #[derive(Clone, Debug, Default, PartialEq)]
+// pub struct ExprEllipsisLiteral {
+//     pub range: TextRange,
+// }
 
-/// See also [Attribute](https://docs.python.org/3/library/ast.html#ast.Attribute)
-#[derive(Clone, Debug, PartialEq)]
-pub struct ExprAttribute {
-    pub range: TextRange,
-    pub value: Box<Expr>,
-    pub attr: Identifier,
-    pub ctx: ExprContext,
-}
+// /// See also [Attribute](https://docs.python.org/3/library/ast.html#ast.Attribute)
+// #[derive(Clone, Debug, PartialEq)]
+// pub struct ExprAttribute {
+//     pub range: TextRange,
+//     pub value: Box<Expr>,
+//     pub attr: Identifier,
+//     pub ctx: ExprContext,
+// }
 
-/// See also [Subscript](https://docs.python.org/3/library/ast.html#ast.Subscript)
-#[derive(Clone, Debug, PartialEq)]
-pub struct ExprSubscript {
-    pub range: TextRange,
-    pub value: Box<Expr>,
-    pub slice: Box<Expr>,
-    pub ctx: ExprContext,
-}
+// /// See also [Subscript](https://docs.python.org/3/library/ast.html#ast.Subscript)
+// #[derive(Clone, Debug, PartialEq)]
+// pub struct ExprSubscript {
+//     pub range: TextRange,
+//     pub value: Box<Expr>,
+//     pub slice: Box<Expr>,
+//     pub ctx: ExprContext,
+// }
 
-/// See also [Starred](https://docs.python.org/3/library/ast.html#ast.Starred)
-#[derive(Clone, Debug, PartialEq)]
-pub struct ExprStarred {
-    pub range: TextRange,
-    pub value: Box<Expr>,
-    pub ctx: ExprContext,
-}
+// /// See also [Starred](https://docs.python.org/3/library/ast.html#ast.Starred)
+// #[derive(Clone, Debug, PartialEq)]
+// pub struct ExprStarred {
+//     pub range: TextRange,
+//     pub value: Box<Expr>,
+//     pub ctx: ExprContext,
+// }
 
-/// See also [Name](https://docs.python.org/3/library/ast.html#ast.Name)
-#[derive(Clone, Debug, PartialEq)]
-pub struct ExprName {
-    pub range: TextRange,
-    pub id: Name,
-    pub ctx: ExprContext,
-}
+// /// See also [Name](https://docs.python.org/3/library/ast.html#ast.Name)
+// #[derive(Clone, Debug, PartialEq)]
+// pub struct ExprName {
+//     pub range: TextRange,
+//     pub id: Name,
+//     pub ctx: ExprContext,
+// }
 
 impl ExprName {
     pub fn id(&self) -> &Name {
@@ -2416,13 +2418,13 @@ impl ExprName {
     }
 }
 
-/// See also [List](https://docs.python.org/3/library/ast.html#ast.List)
-#[derive(Clone, Debug, PartialEq)]
-pub struct ExprList {
-    pub range: TextRange,
-    pub elts: Vec<Expr>,
-    pub ctx: ExprContext,
-}
+// /// See also [List](https://docs.python.org/3/library/ast.html#ast.List)
+// #[derive(Clone, Debug, PartialEq)]
+// pub struct ExprList {
+//     pub range: TextRange,
+//     pub elts: Vec<Expr>,
+//     pub ctx: ExprContext,
+// }
 
 impl ExprList {
     pub fn iter(&self) -> std::slice::Iter<'_, Expr> {
@@ -2447,16 +2449,16 @@ impl<'a> IntoIterator for &'a ExprList {
     }
 }
 
-/// See also [Tuple](https://docs.python.org/3/library/ast.html#ast.Tuple)
-#[derive(Clone, Debug, PartialEq)]
-pub struct ExprTuple {
-    pub range: TextRange,
-    pub elts: Vec<Expr>,
-    pub ctx: ExprContext,
-
-    /// Whether the tuple is parenthesized in the source code.
-    pub parenthesized: bool,
-}
+// /// See also [Tuple](https://docs.python.org/3/library/ast.html#ast.Tuple)
+// #[derive(Clone, Debug, PartialEq)]
+// pub struct ExprTuple {
+//     pub range: TextRange,
+//     pub elts: Vec<Expr>,
+//     pub ctx: ExprContext,
+//
+//     /// Whether the tuple is parenthesized in the source code.
+//     pub parenthesized: bool,
+// }
 
 impl ExprTuple {
     pub fn iter(&self) -> std::slice::Iter<'_, Expr> {
@@ -2481,14 +2483,14 @@ impl<'a> IntoIterator for &'a ExprTuple {
     }
 }
 
-/// See also [Slice](https://docs.python.org/3/library/ast.html#ast.Slice)
-#[derive(Clone, Debug, PartialEq)]
-pub struct ExprSlice {
-    pub range: TextRange,
-    pub lower: Option<Box<Expr>>,
-    pub upper: Option<Box<Expr>>,
-    pub step: Option<Box<Expr>>,
-}
+// /// See also [Slice](https://docs.python.org/3/library/ast.html#ast.Slice)
+// #[derive(Clone, Debug, PartialEq)]
+// pub struct ExprSlice {
+//     pub range: TextRange,
+//     pub lower: Option<Box<Expr>>,
+//     pub upper: Option<Box<Expr>>,
+//     pub step: Option<Box<Expr>>,
+// }
 
 /// See also [expr_context](https://docs.python.org/3/library/ast.html#ast.expr_context)
 #[derive(Clone, Debug, PartialEq, is_macro::Is, Copy, Hash, Eq)]
@@ -3625,6 +3627,7 @@ mod tests {
     #[allow(clippy::wildcard_imports)]
     use super::*;
 
+    use crate::generated::*;
     use crate::Mod;
 
     #[test]
@@ -3641,25 +3644,25 @@ mod tests {
         assert_eq!(std::mem::size_of::<Expr>(), 64);
         assert_eq!(std::mem::size_of::<ExprAttribute>(), 56);
         assert_eq!(std::mem::size_of::<ExprAwait>(), 16);
-        assert_eq!(std::mem::size_of::<crate::ExprBinOp>(), 32);
-        assert_eq!(std::mem::size_of::<crate::ExprBoolOp>(), 40);
+        assert_eq!(std::mem::size_of::<ExprBinOp>(), 32);
+        assert_eq!(std::mem::size_of::<ExprBoolOp>(), 40);
         assert_eq!(std::mem::size_of::<ExprBooleanLiteral>(), 12);
         assert_eq!(std::mem::size_of::<ExprBytesLiteral>(), 40);
         assert_eq!(std::mem::size_of::<ExprCall>(), 56);
         assert_eq!(std::mem::size_of::<ExprCompare>(), 48);
-        assert_eq!(std::mem::size_of::<crate::ExprDict>(), 32);
+        assert_eq!(std::mem::size_of::<ExprDict>(), 32);
         assert_eq!(std::mem::size_of::<ExprDictComp>(), 48);
         assert_eq!(std::mem::size_of::<ExprEllipsisLiteral>(), 8);
         // 56 for Rustc < 1.76
         assert!(matches!(std::mem::size_of::<ExprFString>(), 48 | 56));
         assert_eq!(std::mem::size_of::<ExprGenerator>(), 48);
-        assert_eq!(std::mem::size_of::<crate::ExprIf>(), 32);
+        assert_eq!(std::mem::size_of::<ExprIf>(), 32);
         assert_eq!(std::mem::size_of::<ExprIpyEscapeCommand>(), 32);
-        assert_eq!(std::mem::size_of::<crate::ExprLambda>(), 24);
+        assert_eq!(std::mem::size_of::<ExprLambda>(), 24);
         assert_eq!(std::mem::size_of::<ExprList>(), 40);
         assert_eq!(std::mem::size_of::<ExprListComp>(), 40);
         assert_eq!(std::mem::size_of::<ExprName>(), 40);
-        assert_eq!(std::mem::size_of::<crate::ExprNamed>(), 24);
+        assert_eq!(std::mem::size_of::<ExprNamed>(), 24);
         assert_eq!(std::mem::size_of::<ExprNoneLiteral>(), 8);
         assert_eq!(std::mem::size_of::<ExprNumberLiteral>(), 32);
         assert_eq!(std::mem::size_of::<ExprSet>(), 32);
@@ -3669,7 +3672,7 @@ mod tests {
         assert_eq!(std::mem::size_of::<ExprStringLiteral>(), 56);
         assert_eq!(std::mem::size_of::<ExprSubscript>(), 32);
         assert_eq!(std::mem::size_of::<ExprTuple>(), 40);
-        assert_eq!(std::mem::size_of::<crate::ExprUnaryOp>(), 24);
+        assert_eq!(std::mem::size_of::<ExprUnaryOp>(), 24);
         assert_eq!(std::mem::size_of::<ExprYield>(), 16);
         assert_eq!(std::mem::size_of::<ExprYieldFrom>(), 16);
     }

--- a/crates/ruff_python_ast/src/relocate.rs
+++ b/crates/ruff_python_ast/src/relocate.rs
@@ -1,7 +1,7 @@
 use ruff_text_size::TextRange;
 
 use crate::visitor::transformer::{walk_expr, walk_keyword, Transformer};
-use crate::{nodes, Expr, Keyword};
+use crate::{Expr, Keyword};
 
 /// Change an expression's location (recursively) to match a desired, fixed
 /// range.
@@ -17,100 +17,100 @@ struct Relocator {
 impl Transformer for Relocator {
     fn visit_expr(&self, expr: &mut Expr) {
         match expr {
-            Expr::BoolOp(nodes::ExprBoolOp { range, .. }) => {
+            Expr::BoolOp(crate::ExprBoolOp { range, .. }) => {
                 *range = self.range;
             }
-            Expr::Named(nodes::ExprNamed { range, .. }) => {
+            Expr::Named(crate::ExprNamed { range, .. }) => {
                 *range = self.range;
             }
-            Expr::BinOp(nodes::ExprBinOp { range, .. }) => {
+            Expr::BinOp(crate::ExprBinOp { range, .. }) => {
                 *range = self.range;
             }
-            Expr::UnaryOp(nodes::ExprUnaryOp { range, .. }) => {
+            Expr::UnaryOp(crate::ExprUnaryOp { range, .. }) => {
                 *range = self.range;
             }
-            Expr::Lambda(nodes::ExprLambda { range, .. }) => {
+            Expr::Lambda(crate::ExprLambda { range, .. }) => {
                 *range = self.range;
             }
-            Expr::If(nodes::ExprIf { range, .. }) => {
+            Expr::If(crate::ExprIf { range, .. }) => {
                 *range = self.range;
             }
-            Expr::Dict(nodes::ExprDict { range, .. }) => {
+            Expr::Dict(crate::ExprDict { range, .. }) => {
                 *range = self.range;
             }
-            Expr::Set(nodes::ExprSet { range, .. }) => {
+            Expr::Set(crate::ExprSet { range, .. }) => {
                 *range = self.range;
             }
-            Expr::ListComp(nodes::ExprListComp { range, .. }) => {
+            Expr::ListComp(crate::ExprListComp { range, .. }) => {
                 *range = self.range;
             }
-            Expr::SetComp(nodes::ExprSetComp { range, .. }) => {
+            Expr::SetComp(crate::ExprSetComp { range, .. }) => {
                 *range = self.range;
             }
-            Expr::DictComp(nodes::ExprDictComp { range, .. }) => {
+            Expr::DictComp(crate::ExprDictComp { range, .. }) => {
                 *range = self.range;
             }
-            Expr::Generator(nodes::ExprGenerator { range, .. }) => {
+            Expr::Generator(crate::ExprGenerator { range, .. }) => {
                 *range = self.range;
             }
-            Expr::Await(nodes::ExprAwait { range, .. }) => {
+            Expr::Await(crate::ExprAwait { range, .. }) => {
                 *range = self.range;
             }
-            Expr::Yield(nodes::ExprYield { range, .. }) => {
+            Expr::Yield(crate::ExprYield { range, .. }) => {
                 *range = self.range;
             }
-            Expr::YieldFrom(nodes::ExprYieldFrom { range, .. }) => {
+            Expr::YieldFrom(crate::ExprYieldFrom { range, .. }) => {
                 *range = self.range;
             }
-            Expr::Compare(nodes::ExprCompare { range, .. }) => {
+            Expr::Compare(crate::ExprCompare { range, .. }) => {
                 *range = self.range;
             }
-            Expr::Call(nodes::ExprCall { range, .. }) => {
+            Expr::Call(crate::ExprCall { range, .. }) => {
                 *range = self.range;
             }
-            Expr::FString(nodes::ExprFString { range, .. }) => {
+            Expr::FString(crate::ExprFString { range, .. }) => {
                 *range = self.range;
             }
-            Expr::StringLiteral(nodes::ExprStringLiteral { range, .. }) => {
+            Expr::StringLiteral(crate::ExprStringLiteral { range, .. }) => {
                 *range = self.range;
             }
-            Expr::BytesLiteral(nodes::ExprBytesLiteral { range, .. }) => {
+            Expr::BytesLiteral(crate::ExprBytesLiteral { range, .. }) => {
                 *range = self.range;
             }
-            Expr::NumberLiteral(nodes::ExprNumberLiteral { range, .. }) => {
+            Expr::NumberLiteral(crate::ExprNumberLiteral { range, .. }) => {
                 *range = self.range;
             }
-            Expr::BooleanLiteral(nodes::ExprBooleanLiteral { range, .. }) => {
+            Expr::BooleanLiteral(crate::ExprBooleanLiteral { range, .. }) => {
                 *range = self.range;
             }
-            Expr::NoneLiteral(nodes::ExprNoneLiteral { range }) => {
+            Expr::NoneLiteral(crate::ExprNoneLiteral { range }) => {
                 *range = self.range;
             }
-            Expr::EllipsisLiteral(nodes::ExprEllipsisLiteral { range }) => {
+            Expr::EllipsisLiteral(crate::ExprEllipsisLiteral { range }) => {
                 *range = self.range;
             }
-            Expr::Attribute(nodes::ExprAttribute { range, .. }) => {
+            Expr::Attribute(crate::ExprAttribute { range, .. }) => {
                 *range = self.range;
             }
-            Expr::Subscript(nodes::ExprSubscript { range, .. }) => {
+            Expr::Subscript(crate::ExprSubscript { range, .. }) => {
                 *range = self.range;
             }
-            Expr::Starred(nodes::ExprStarred { range, .. }) => {
+            Expr::Starred(crate::ExprStarred { range, .. }) => {
                 *range = self.range;
             }
-            Expr::Name(nodes::ExprName { range, .. }) => {
+            Expr::Name(crate::ExprName { range, .. }) => {
                 *range = self.range;
             }
-            Expr::List(nodes::ExprList { range, .. }) => {
+            Expr::List(crate::ExprList { range, .. }) => {
                 *range = self.range;
             }
-            Expr::Tuple(nodes::ExprTuple { range, .. }) => {
+            Expr::Tuple(crate::ExprTuple { range, .. }) => {
                 *range = self.range;
             }
-            Expr::Slice(nodes::ExprSlice { range, .. }) => {
+            Expr::Slice(crate::ExprSlice { range, .. }) => {
                 *range = self.range;
             }
-            Expr::IpyEscapeCommand(nodes::ExprIpyEscapeCommand { range, .. }) => {
+            Expr::IpyEscapeCommand(crate::ExprIpyEscapeCommand { range, .. }) => {
                 *range = self.range;
             }
         }

--- a/crates/ruff_python_ast/src/relocate.rs
+++ b/crates/ruff_python_ast/src/relocate.rs
@@ -1,6 +1,7 @@
 use ruff_text_size::TextRange;
 
 use crate::visitor::transformer::{walk_expr, walk_keyword, Transformer};
+use crate::{self as ast};
 use crate::{Expr, Keyword};
 
 /// Change an expression's location (recursively) to match a desired, fixed
@@ -17,100 +18,100 @@ struct Relocator {
 impl Transformer for Relocator {
     fn visit_expr(&self, expr: &mut Expr) {
         match expr {
-            Expr::BoolOp(crate::ExprBoolOp { range, .. }) => {
+            Expr::BoolOp(ast::ExprBoolOp { range, .. }) => {
                 *range = self.range;
             }
-            Expr::Named(crate::ExprNamed { range, .. }) => {
+            Expr::Named(ast::ExprNamed { range, .. }) => {
                 *range = self.range;
             }
-            Expr::BinOp(crate::ExprBinOp { range, .. }) => {
+            Expr::BinOp(ast::ExprBinOp { range, .. }) => {
                 *range = self.range;
             }
-            Expr::UnaryOp(crate::ExprUnaryOp { range, .. }) => {
+            Expr::UnaryOp(ast::ExprUnaryOp { range, .. }) => {
                 *range = self.range;
             }
-            Expr::Lambda(crate::ExprLambda { range, .. }) => {
+            Expr::Lambda(ast::ExprLambda { range, .. }) => {
                 *range = self.range;
             }
-            Expr::If(crate::ExprIf { range, .. }) => {
+            Expr::If(ast::ExprIf { range, .. }) => {
                 *range = self.range;
             }
-            Expr::Dict(crate::ExprDict { range, .. }) => {
+            Expr::Dict(ast::ExprDict { range, .. }) => {
                 *range = self.range;
             }
-            Expr::Set(crate::ExprSet { range, .. }) => {
+            Expr::Set(ast::ExprSet { range, .. }) => {
                 *range = self.range;
             }
-            Expr::ListComp(crate::ExprListComp { range, .. }) => {
+            Expr::ListComp(ast::ExprListComp { range, .. }) => {
                 *range = self.range;
             }
-            Expr::SetComp(crate::ExprSetComp { range, .. }) => {
+            Expr::SetComp(ast::ExprSetComp { range, .. }) => {
                 *range = self.range;
             }
-            Expr::DictComp(crate::ExprDictComp { range, .. }) => {
+            Expr::DictComp(ast::ExprDictComp { range, .. }) => {
                 *range = self.range;
             }
-            Expr::Generator(crate::ExprGenerator { range, .. }) => {
+            Expr::Generator(ast::ExprGenerator { range, .. }) => {
                 *range = self.range;
             }
-            Expr::Await(crate::ExprAwait { range, .. }) => {
+            Expr::Await(ast::ExprAwait { range, .. }) => {
                 *range = self.range;
             }
-            Expr::Yield(crate::ExprYield { range, .. }) => {
+            Expr::Yield(ast::ExprYield { range, .. }) => {
                 *range = self.range;
             }
-            Expr::YieldFrom(crate::ExprYieldFrom { range, .. }) => {
+            Expr::YieldFrom(ast::ExprYieldFrom { range, .. }) => {
                 *range = self.range;
             }
-            Expr::Compare(crate::ExprCompare { range, .. }) => {
+            Expr::Compare(ast::ExprCompare { range, .. }) => {
                 *range = self.range;
             }
-            Expr::Call(crate::ExprCall { range, .. }) => {
+            Expr::Call(ast::ExprCall { range, .. }) => {
                 *range = self.range;
             }
-            Expr::FString(crate::ExprFString { range, .. }) => {
+            Expr::FString(ast::ExprFString { range, .. }) => {
                 *range = self.range;
             }
-            Expr::StringLiteral(crate::ExprStringLiteral { range, .. }) => {
+            Expr::StringLiteral(ast::ExprStringLiteral { range, .. }) => {
                 *range = self.range;
             }
-            Expr::BytesLiteral(crate::ExprBytesLiteral { range, .. }) => {
+            Expr::BytesLiteral(ast::ExprBytesLiteral { range, .. }) => {
                 *range = self.range;
             }
-            Expr::NumberLiteral(crate::ExprNumberLiteral { range, .. }) => {
+            Expr::NumberLiteral(ast::ExprNumberLiteral { range, .. }) => {
                 *range = self.range;
             }
-            Expr::BooleanLiteral(crate::ExprBooleanLiteral { range, .. }) => {
+            Expr::BooleanLiteral(ast::ExprBooleanLiteral { range, .. }) => {
                 *range = self.range;
             }
-            Expr::NoneLiteral(crate::ExprNoneLiteral { range }) => {
+            Expr::NoneLiteral(ast::ExprNoneLiteral { range }) => {
                 *range = self.range;
             }
-            Expr::EllipsisLiteral(crate::ExprEllipsisLiteral { range }) => {
+            Expr::EllipsisLiteral(ast::ExprEllipsisLiteral { range }) => {
                 *range = self.range;
             }
-            Expr::Attribute(crate::ExprAttribute { range, .. }) => {
+            Expr::Attribute(ast::ExprAttribute { range, .. }) => {
                 *range = self.range;
             }
-            Expr::Subscript(crate::ExprSubscript { range, .. }) => {
+            Expr::Subscript(ast::ExprSubscript { range, .. }) => {
                 *range = self.range;
             }
-            Expr::Starred(crate::ExprStarred { range, .. }) => {
+            Expr::Starred(ast::ExprStarred { range, .. }) => {
                 *range = self.range;
             }
-            Expr::Name(crate::ExprName { range, .. }) => {
+            Expr::Name(ast::ExprName { range, .. }) => {
                 *range = self.range;
             }
-            Expr::List(crate::ExprList { range, .. }) => {
+            Expr::List(ast::ExprList { range, .. }) => {
                 *range = self.range;
             }
-            Expr::Tuple(crate::ExprTuple { range, .. }) => {
+            Expr::Tuple(ast::ExprTuple { range, .. }) => {
                 *range = self.range;
             }
-            Expr::Slice(crate::ExprSlice { range, .. }) => {
+            Expr::Slice(ast::ExprSlice { range, .. }) => {
                 *range = self.range;
             }
-            Expr::IpyEscapeCommand(crate::ExprIpyEscapeCommand { range, .. }) => {
+            Expr::IpyEscapeCommand(ast::ExprIpyEscapeCommand { range, .. }) => {
                 *range = self.range;
             }
         }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Part of https://github.com/astral-sh/ruff/issues/15655

- Auto generate AST nodes using definitions in `ast.toml`. I added attributes similar to [`Field`](https://github.com/python/cpython/blob/main/Parser/asdl.py#L67) in ASDL to hold field information

## Test Plan

<!-- How was it tested? -->

Nothing outside the `ruff_python_ast` package should change.