### PR TITLE
[red-knot] Short-circuit bool calls on bool

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1452,7 +1452,9 @@ impl<'db> Type<'db> {
             Type::AlwaysTruthy => Truthiness::AlwaysTrue,
             Type::AlwaysFalsy => Truthiness::AlwaysFalse,
             instance_ty @ Type::Instance(InstanceType { class }) => {
-                if class.is_known(db, KnownClass::NoneType) {
+                if class.is_known(db, KnownClass::Bool) {
+                    Truthiness::Ambiguous
+                } else if class.is_known(db, KnownClass::NoneType) {
                     Truthiness::AlwaysFalse
                 } else {
                     // We only check the `__bool__` method for truth testing, even though at


### PR DESCRIPTION
## Summary

This avoids looking up `__bool__` on class `bool` for every `Type::Instance(bool).bool()` call. 1% performance win on cold cache, 4% win on incremental performance.