### PR TITLE
Expand `ruff.configuration` to allow inline config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3188,6 +3188,7 @@ dependencies = [
  "serde_json",
  "shellexpand",
  "thiserror 2.0.11",
+ "toml",
  "tracing",
  "tracing-subscriber",
 ]

--- a/crates/ruff/src/args.rs
+++ b/crates/ruff/src/args.rs
@@ -830,7 +830,7 @@ enum InvalidConfigFlagReason {
     ValidTomlButInvalidRuffSchema(toml::de::Error),
     /// It was a valid ruff config file, but the user tried to pass a
     /// value for `extend` as part of the config override.
-    // `extend` is special, because it affects which config files we look at
+    /// `extend` is special, because it affects which config files we look at
     /// in the first place. We currently only parse --config overrides *after*
     /// we've combined them with all the arguments from the various config files
     /// that we found, so trying to override `extend` as part of a --config

--- a/crates/ruff_server/Cargo.toml
+++ b/crates/ruff_server/Cargo.toml
@@ -38,6 +38,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 shellexpand = { workspace = true }
 thiserror = { workspace = true }
+toml = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 

--- a/crates/ruff_server/resources/test/fixtures/settings/inline_configuration.json
+++ b/crates/ruff_server/resources/test/fixtures/settings/inline_configuration.json
@@ -1,0 +1,16 @@
+{
+  "settings": {
+    "configuration": {
+      "line-length": 100,
+      "lint": {
+        "extend-select": ["I001"]
+      },
+      "format": {
+        "quote-style": "single"
+      }
+    },
+    "lint": {
+      "extendSelect": ["RUF001"]
+    }
+  }
+}

--- a/crates/ruff_server/src/session/index/ruff_settings.rs
+++ b/crates/ruff_server/src/session/index/ruff_settings.rs
@@ -391,11 +391,9 @@ impl ConfigurationTransformer for EditorConfigurationTransformer<'_> {
                     );
                     match Configuration::from_options(options, None, project_root) {
                         Ok(configuration) => editor_configuration.combine(configuration),
-                        err => {
+                        Err(err) => {
                             tracing::error!(
-                                "{:?}",
-                                err.context("Unable to load editor-specified inline configuration")
-                                    .unwrap_err()
+                                "Unable to load editor-specified inline configuration: {err:?}",
                             );
                             editor_configuration
                         }

--- a/crates/ruff_server/src/session/settings.rs
+++ b/crates/ruff_server/src/session/settings.rs
@@ -32,7 +32,7 @@ pub(crate) struct ResolvedClientSettings {
 /// LSP client settings. These fields are optional because we don't want to override file-based linter/formatting settings
 /// if these were un-set.
 #[derive(Clone, Debug)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[cfg_attr(test, derive(Default, PartialEq, Eq))]
 pub(crate) struct ResolvedEditorSettings {
     pub(super) configuration: Option<ResolvedConfiguration>,
     pub(super) lint_preview: Option<bool>,

--- a/crates/ruff_server/src/session/settings.rs
+++ b/crates/ruff_server/src/session/settings.rs
@@ -366,7 +366,9 @@ impl ResolvedClientSettings {
                         match ResolvedConfiguration::try_from(configuration) {
                             Ok(configuration) => Some(configuration),
                             Err(err) => {
-                                tracing::error!("Failed to resolve configuration: {err}");
+                                tracing::error!(
+                                    "Failed to load settings from `configuration`: {err}"
+                                );
                                 None
                             }
                         }

--- a/crates/ruff_server/src/session/settings.rs
+++ b/crates/ruff_server/src/session/settings.rs
@@ -485,6 +485,10 @@ impl Default for InitializationOptions {
 #[cfg(test)]
 mod tests {
     use insta::assert_debug_snapshot;
+    use ruff_python_formatter::QuoteStyle;
+    use ruff_workspace::options::{
+        FormatOptions as RuffFormatOptions, LintCommonOptions, LintOptions,
+    };
     use serde::de::DeserializeOwned;
 
     #[cfg(not(windows))]
@@ -931,187 +935,35 @@ mod tests {
             panic!("Expected global settings only");
         };
 
-        let settings = ResolvedClientSettings::global(&global_settings);
-
-        assert_debug_snapshot!(settings.editor_settings, @r"
-        ResolvedEditorSettings {
-            configuration: Some(
-                Inline(
-                    Options {
-                        cache_dir: None,
-                        extend: None,
-                        output_format: None,
-                        fix: None,
-                        unsafe_fixes: None,
-                        fix_only: None,
-                        show_fixes: None,
-                        required_version: None,
-                        preview: None,
-                        exclude: None,
-                        extend_exclude: None,
-                        extend_include: None,
-                        force_exclude: None,
-                        include: None,
-                        respect_gitignore: None,
-                        builtins: None,
-                        namespace_packages: None,
-                        target_version: None,
-                        src: None,
-                        line_length: Some(
-                            LineLength(
-                                100,
-                            ),
-                        ),
-                        indent_width: None,
-                        lint: Some(
-                            LintOptions {
-                                common: LintCommonOptions {
-                                    allowed_confusables: None,
-                                    dummy_variable_rgx: None,
-                                    extend_ignore: None,
-                                    extend_select: Some(
-                                        [
-                                            Rule {
-                                                prefix: Isort(
-                                                    _001,
-                                                ),
-                                                redirected_from: None,
-                                            },
-                                        ],
-                                    ),
-                                    extend_fixable: None,
-                                    extend_unfixable: None,
-                                    external: None,
-                                    fixable: None,
-                                    ignore: None,
-                                    extend_safe_fixes: None,
-                                    extend_unsafe_fixes: None,
-                                    ignore_init_module_imports: None,
-                                    logger_objects: None,
-                                    select: None,
-                                    explicit_preview_rules: None,
-                                    task_tags: None,
-                                    typing_modules: None,
-                                    unfixable: None,
-                                    flake8_annotations: None,
-                                    flake8_bandit: None,
-                                    flake8_boolean_trap: None,
-                                    flake8_bugbear: None,
-                                    flake8_builtins: None,
-                                    flake8_comprehensions: None,
-                                    flake8_copyright: None,
-                                    flake8_errmsg: None,
-                                    flake8_quotes: None,
-                                    flake8_self: None,
-                                    flake8_tidy_imports: None,
-                                    flake8_type_checking: None,
-                                    flake8_gettext: None,
-                                    flake8_implicit_str_concat: None,
-                                    flake8_import_conventions: None,
-                                    flake8_pytest_style: None,
-                                    flake8_unused_arguments: None,
-                                    isort: None,
-                                    mccabe: None,
-                                    pep8_naming: None,
-                                    pycodestyle: None,
-                                    pydocstyle: None,
-                                    pyflakes: None,
-                                    pylint: None,
-                                    pyupgrade: None,
-                                    per_file_ignores: None,
-                                    extend_per_file_ignores: None,
-                                },
-                                exclude: None,
-                                pydoclint: None,
-                                ruff: None,
-                                preview: None,
+        assert_eq!(
+            ResolvedClientSettings::global(&global_settings),
+            ResolvedClientSettings {
+                fix_all: true,
+                organize_imports: true,
+                lint_enable: true,
+                disable_rule_comment_enable: true,
+                fix_violation_enable: true,
+                show_syntax_errors: true,
+                editor_settings: ResolvedEditorSettings {
+                    configuration: Some(ResolvedConfiguration::Inline(Options {
+                        line_length: Some(LineLength::try_from(100).unwrap()),
+                        lint: Some(LintOptions {
+                            common: LintCommonOptions {
+                                extend_select: Some(vec![RuleSelector::from_str("I001").unwrap()]),
+                                ..Default::default()
                             },
-                        ),
-                        lint_top_level: DeprecatedTopLevelLintOptions(
-                            LintCommonOptions {
-                                allowed_confusables: None,
-                                dummy_variable_rgx: None,
-                                extend_ignore: None,
-                                extend_select: None,
-                                extend_fixable: None,
-                                extend_unfixable: None,
-                                external: None,
-                                fixable: None,
-                                ignore: None,
-                                extend_safe_fixes: None,
-                                extend_unsafe_fixes: None,
-                                ignore_init_module_imports: None,
-                                logger_objects: None,
-                                select: None,
-                                explicit_preview_rules: None,
-                                task_tags: None,
-                                typing_modules: None,
-                                unfixable: None,
-                                flake8_annotations: None,
-                                flake8_bandit: None,
-                                flake8_boolean_trap: None,
-                                flake8_bugbear: None,
-                                flake8_builtins: None,
-                                flake8_comprehensions: None,
-                                flake8_copyright: None,
-                                flake8_errmsg: None,
-                                flake8_quotes: None,
-                                flake8_self: None,
-                                flake8_tidy_imports: None,
-                                flake8_type_checking: None,
-                                flake8_gettext: None,
-                                flake8_implicit_str_concat: None,
-                                flake8_import_conventions: None,
-                                flake8_pytest_style: None,
-                                flake8_unused_arguments: None,
-                                isort: None,
-                                mccabe: None,
-                                pep8_naming: None,
-                                pycodestyle: None,
-                                pydocstyle: None,
-                                pyflakes: None,
-                                pylint: None,
-                                pyupgrade: None,
-                                per_file_ignores: None,
-                                extend_per_file_ignores: None,
-                            },
-                        ),
-                        format: Some(
-                            FormatOptions {
-                                exclude: None,
-                                preview: None,
-                                indent_style: None,
-                                quote_style: Some(
-                                    Single,
-                                ),
-                                skip_magic_trailing_comma: None,
-                                line_ending: None,
-                                docstring_code_format: None,
-                                docstring_code_line_length: None,
-                            },
-                        ),
-                        analyze: None,
-                    },
-                ),
-            ),
-            lint_preview: None,
-            format_preview: None,
-            select: None,
-            extend_select: Some(
-                [
-                    Rule {
-                        prefix: Ruff(
-                            _001,
-                        ),
-                        redirected_from: None,
-                    },
-                ],
-            ),
-            ignore: None,
-            exclude: None,
-            line_length: None,
-            configuration_preference: EditorFirst,
-        }
-        ");
+                            ..Default::default()
+                        }),
+                        format: Some(RuffFormatOptions {
+                            quote_style: Some(QuoteStyle::Single),
+                            ..Default::default()
+                        }),
+                        ..Default::default()
+                    })),
+                    extend_select: Some(vec![RuleSelector::from_str("RUF001").unwrap()]),
+                    ..Default::default()
+                }
+            }
+        );
     }
 }

--- a/docs/editors/settings.md
+++ b/docs/editors/settings.md
@@ -11,28 +11,25 @@ as per the editor.
 
 ### `configuration`
 
-The `configuration` setting allows you to configure Ruff's behavior directly from an editor. This
-can be done in one of the following ways:
+The `configuration` setting allows you to configure editor-specific Ruff behavior. This can be done
+in one of the following ways:
 
 1. **Configuration file path:** Specify the path to a `ruff.toml` or `pyproject.toml` file that
     contains the configuration. User home directory and environment variables will be expanded.
-1. **Inline JSON configuration:** Directly provide the configuration as a JSON object. This is
-    similar to how the configuration is specified in the settings tab on the
-    [playground](https://play.ruff.sh/).
+1. **Inline JSON configuration:** Directly provide the configuration as a JSON object.
 
 !!! note "Added in Ruff `0.9.8`"
 
-    The **Inline JSON configuration** option was introduced in Ruff `0.9.8`, allowing you to define
-    settings directly in your editor without relying on an external file.
+    The **Inline JSON configuration** option was introduced in Ruff `0.9.8`.
 
-By default, if no `configuration` is specified, Ruff will automatically detect and load settings
-from a configuration file in the project's filesystem, consistent with the behavior of the Ruff CLI.
+The default behavior, if `configuration` is unset, is to load the settings from the project's
+configuration (a `ruff.toml` or `pyproject.toml` in the project's directory), consistent with when
+running Ruff on the command-line.
 
-When both an editor-provided configuration and a local configuration file are present, you can
-control how Ruff resolves conflicts between them using the
-[`configurationPreference`](#configurationpreference) setting.
+The [`configurationPreference`](#configurationpreference) setting controls the precedence if both an
+editor-provided configuration (`configuration`) and a project level configuration file are present.
 
-#### Resolution order
+#### Resolution order {: #configuration_resolution_order }
 
 In an editor, Ruff supports three sources of configuration, prioritized as follows (from highest to
 lowest):
@@ -43,10 +40,10 @@ lowest):
     [`configuration`](#configuration) field (either a path to a configuration file or an inline
     configuration object)
 1. **Configuration file:** Settings defined in a `ruff.toml` or `pyproject.toml` file in the
-    project's filesystem (if present)
+    project's directory (if present)
 
 For example, if the line length is specified in all three sources, Ruff will use the value from the
-specific settings in the editor i.e., the [`lineLength`](#linelength) setting.
+[`lineLength`](#linelength) setting.
 
 **Default value**: `null`
 
@@ -54,120 +51,118 @@ specific settings in the editor i.e., the [`lineLength`](#linelength) setting.
 
 **Example usage**:
 
+_Using configuration file path:_
+
 === "VS Code"
 
-    === "Using a configuration file"
-
-        ```json
-        {
-            "ruff.configuration": "~/path/to/ruff.toml"
-        }
-        ```
-
-    === "Using inline configuration"
-
-        ```json
-        {
-            "ruff.configuration": {
-                "lint": {
-                    "unfixable": ["F401"],
-                    "extend-select": ["TID251"],
-                    "flake8-tidy-imports": {
-                        "banned-api": {
-                            "typing.TypedDict": {
-                                "msg": "Use `typing_extensions.TypedDict` instead",
-                            }
-                        }
-                    }
-                },
-                "format": {
-                    "quote-style": "single"
-                }
-            }
-        }
-        ```
+    ```json
+    {
+        "ruff.configuration": "~/path/to/ruff.toml"
+    }
+    ```
 
 === "Neovim"
 
-    === "Using a configuration file"
+    ```lua
+    require('lspconfig').ruff.setup {
+      init_options = {
+        configuration = "~/path/to/ruff.toml"
+      }
+    }
+    ```
 
-        ```lua
-        require('lspconfig').ruff.setup {
-          init_options = {
-            configuration = "~/path/to/ruff.toml"
+=== "Zed"
+
+    ```json
+    {
+      "lsp": {
+        "ruff": {
+          "initialization_options": {
+            "configuration": "~/path/to/ruff.toml"
           }
         }
-        ```
+      }
+    }
+    ```
 
-    === "Using inline configuration"
+_Using inline configuration:_
 
-        ```lua
-        require('lspconfig').ruff.setup {
-          init_options = {
-            configuration = {
-              lint = {
-                unfixable = {"F401"},
-                ["extend-select"] = {"TID251"},
-                ["flake8-tidy-imports"] = {
-                  ["banned-api"] = {
-                    ["typing.TypedDict"] = {
-                      msg = "Use `typing_extensions.TypedDict` instead"
+=== "VS Code"
+
+    ```json
+    {
+        "ruff.configuration": {
+            "lint": {
+                "unfixable": ["F401"],
+                "extend-select": ["TID251"],
+                "flake8-tidy-imports": {
+                    "banned-api": {
+                        "typing.TypedDict": {
+                            "msg": "Use `typing_extensions.TypedDict` instead",
+                        }
+                    }
+                }
+            },
+            "format": {
+                "quote-style": "single"
+            }
+        }
+    }
+    ```
+
+=== "Neovim"
+
+    ```lua
+    require('lspconfig').ruff.setup {
+      init_options = {
+        configuration = {
+          lint = {
+            unfixable = {"F401"},
+            ["extend-select"] = {"TID251"},
+            ["flake8-tidy-imports"] = {
+              ["banned-api"] = {
+                ["typing.TypedDict"] = {
+                  msg = "Use `typing_extensions.TypedDict` instead"
+                }
+              }
+            }
+          },
+          format = {
+            ["quote-style"] = "single"
+          }
+        }
+      }
+    }
+    ```
+
+=== "Zed"
+
+    ```json
+    {
+      "lsp": {
+        "ruff": {
+          "initialization_options": {
+            "configuration": {
+              "lint": {
+                "unfixable": ["F401"],
+                "extend-select": ["TID251"],
+                "flake8-tidy-imports": {
+                  "banned-api": {
+                    "typing.TypedDict": {
+                      "msg": "Use `typing_extensions.TypedDict` instead"
                     }
                   }
                 }
               },
-              format = {
-                ["quote-style"] = "single"
+              "format": {
+                "quote-style": "single"
               }
             }
           }
         }
-        ```
-
-=== "Zed"
-
-    === "Using a configuration file"
-
-        ```json
-        {
-          "lsp": {
-            "ruff": {
-              "initialization_options": {
-                "configuration": "~/path/to/ruff.toml"
-              }
-            }
-          }
-        }
-        ```
-
-    === "Using inline configuration"
-
-        ```json
-        {
-          "lsp": {
-            "ruff": {
-              "initialization_options": {
-                "configuration": {
-                  "lint": {
-                    "unfixable": ["F401"],
-                    "extend-select": ["TID251"],
-                    "flake8-tidy-imports": {
-                      "banned-api": {
-                        "typing.TypedDict": {
-                          "msg": "Use `typing_extensions.TypedDict` instead"
-                        }
-                      }
-                    }
-                  },
-                  "format": {
-                    "quote-style": "single"
-                  }
-                }
-              }
-            }
-          }
-        }
-        ```
+      }
+    }
+    ```
 
 ### `configurationPreference`
 

--- a/docs/editors/settings.md
+++ b/docs/editors/settings.md
@@ -78,7 +78,9 @@ _Using configuration file path:_
       "lsp": {
         "ruff": {
           "initialization_options": {
-            "configuration": "~/path/to/ruff.toml"
+            "settings": {
+              "configuration": "~/path/to/ruff.toml"
+            }
           }
         }
       }
@@ -142,20 +144,22 @@ _Using inline configuration:_
       "lsp": {
         "ruff": {
           "initialization_options": {
-            "configuration": {
-              "lint": {
-                "unfixable": ["F401"],
-                "extend-select": ["TID251"],
-                "flake8-tidy-imports": {
-                  "banned-api": {
-                    "typing.TypedDict": {
-                      "msg": "Use `typing_extensions.TypedDict` instead"
+            "settings": {
+              "configuration": {
+                "lint": {
+                  "unfixable": ["F401"],
+                  "extend-select": ["TID251"],
+                  "flake8-tidy-imports": {
+                    "banned-api": {
+                      "typing.TypedDict": {
+                        "msg": "Use `typing_extensions.TypedDict` instead"
+                      }
                     }
                   }
+                },
+                "format": {
+                  "quote-style": "single"
                 }
-              },
-              "format": {
-                "quote-style": "single"
               }
             }
           }
@@ -700,9 +704,7 @@ Whether to enable linting. Set to `false` to use Ruff exclusively as a formatter
           "initialization_options": {
             "settings": {
               "lint": {
-                "enable" = {
-                  "enable": false
-                }
+                "enable": false
               }
             }
           }

--- a/docs/editors/settings.md
+++ b/docs/editors/settings.md
@@ -15,12 +15,13 @@ The `configuration` setting allows you to configure Ruff's behavior directly fro
 can be done in one of the following ways:
 
 1. **Configuration file path:** Specify the path to a `ruff.toml` or `pyproject.toml` file that
-   contains the configuration. User home directory and environment variables will be expanded.
-2. **Inline JSON configuration:** Directly provide the configuration as a JSON object. This is
-   similar to how the configuration is specified in the settings tab on the
-   [playground](https://play.ruff.sh/).
+    contains the configuration. User home directory and environment variables will be expanded.
+1. **Inline JSON configuration:** Directly provide the configuration as a JSON object. This is
+    similar to how the configuration is specified in the settings tab on the
+    [playground](https://play.ruff.sh/).
 
 !!! note "Added in Ruff `0.9.8`"
+
     The **Inline JSON configuration** option was introduced in Ruff `0.9.8`, allowing you to define
     settings directly in your editor without relying on an external file.
 
@@ -37,12 +38,12 @@ In an editor, Ruff supports three sources of configuration, prioritized as follo
 lowest):
 
 1. **Specific settings:** Individual settings like [`lineLength`](#linelength) or
-   [`lint.select`](#select) defined in the editor
-2. [**`ruff.configuration`**](#configuration): Settings provided via the
-   [`configuration`](#configuration) field (either a path to a configuration file or an inline
-   configuration object)
-3. **Configuration file:** Settings defined in a `ruff.toml` or `pyproject.toml` file in the
-   project's filesystem (if present)
+    [`lint.select`](#select) defined in the editor
+1. [**`ruff.configuration`**](#configuration): Settings provided via the
+    [`configuration`](#configuration) field (either a path to a configuration file or an inline
+    configuration object)
+1. **Configuration file:** Settings defined in a `ruff.toml` or `pyproject.toml` file in the
+    project's filesystem (if present)
 
 For example, if the line length is specified in all three sources, Ruff will use the value from the
 specific settings in the editor i.e., the [`lineLength`](#linelength) setting.
@@ -86,7 +87,6 @@ specific settings in the editor i.e., the [`lineLength`](#linelength) setting.
         }
         ```
 
-
 === "Neovim"
 
     === "Using a configuration file"
@@ -123,7 +123,6 @@ specific settings in the editor i.e., the [`lineLength`](#linelength) setting.
           }
         }
         ```
-
 
 === "Zed"
 

--- a/docs/editors/settings.md
+++ b/docs/editors/settings.md
@@ -11,10 +11,41 @@ as per the editor.
 
 ### `configuration`
 
-Path to a `ruff.toml` or `pyproject.toml` file to use for configuration.
+The `configuration` setting allows you to configure Ruff's behavior directly from an editor. This
+can be done in one of the following ways:
 
-By default, Ruff will discover configuration for each project from the filesystem, mirroring the
-behavior of the Ruff CLI.
+1. **Configuration file path:** Specify the path to a `ruff.toml` or `pyproject.toml` file that
+   contains the configuration. User home directory and environment variables will be expanded.
+2. **Inline JSON configuration:** Directly provide the configuration as a JSON object. This is
+   similar to how the configuration is specified in the settings tab on the
+   [playground](https://play.ruff.sh/).
+
+!!! note "Added in Ruff `0.9.8`"
+    The **Inline JSON configuration** option was introduced in Ruff `0.9.8`, allowing you to define
+    settings directly in your editor without relying on an external file.
+
+By default, if no `configuration` is specified, Ruff will automatically detect and load settings
+from a configuration file in the project's filesystem, consistent with the behavior of the Ruff CLI.
+
+When both an editor-provided configuration and a local configuration file are present, you can
+control how Ruff resolves conflicts between them using the
+[`configurationPreference`](#configurationpreference) setting.
+
+#### Resolution order
+
+In an editor, Ruff supports three sources of configuration, prioritized as follows (from highest to
+lowest):
+
+1. **Specific settings:** Individual settings like [`lineLength`](#linelength) or
+   [`lint.select`](#select) defined in the editor
+2. [**`ruff.configuration`**](#configuration): Settings provided via the
+   [`configuration`](#configuration) field (either a path to a configuration file or an inline
+   configuration object)
+3. **Configuration file:** Settings defined in a `ruff.toml` or `pyproject.toml` file in the
+   project's filesystem (if present)
+
+For example, if the line length is specified in all three sources, Ruff will use the value from the
+specific settings in the editor i.e., the [`lineLength`](#linelength) setting.
 
 **Default value**: `null`
 
@@ -24,39 +55,120 @@ behavior of the Ruff CLI.
 
 === "VS Code"
 
-    ```json
-    {
-        "ruff.configuration": "~/path/to/ruff.toml"
-    }
-    ```
+    === "Using a configuration file"
+
+        ```json
+        {
+            "ruff.configuration": "~/path/to/ruff.toml"
+        }
+        ```
+
+    === "Using inline configuration"
+
+        ```json
+        {
+            "ruff.configuration": {
+                "lint": {
+                    "unfixable": ["F401"],
+                    "extend-select": ["TID251"],
+                    "flake8-tidy-imports": {
+                        "banned-api": {
+                            "typing.TypedDict": {
+                                "msg": "Use `typing_extensions.TypedDict` instead",
+                            }
+                        }
+                    }
+                },
+                "format": {
+                    "quote-style": "single"
+                }
+            }
+        }
+        ```
+
 
 === "Neovim"
 
-    ```lua
-    require('lspconfig').ruff.setup {
-      init_options = {
-        settings = {
-          configuration = "~/path/to/ruff.toml"
+    === "Using a configuration file"
+
+        ```lua
+        require('lspconfig').ruff.setup {
+          init_options = {
+            configuration = "~/path/to/ruff.toml"
+          }
         }
-      }
-    }
-    ```
+        ```
 
-=== "Zed"
+    === "Using inline configuration"
 
-    ```json
-    {
-      "lsp": {
-        "ruff": {
-          "initialization_options": {
-            "settings": {
-              "configuration": "~/path/to/ruff.toml"
+        ```lua
+        require('lspconfig').ruff.setup {
+          init_options = {
+            configuration = {
+              lint = {
+                unfixable = {"F401"},
+                ["extend-select"] = {"TID251"},
+                ["flake8-tidy-imports"] = {
+                  ["banned-api"] = {
+                    ["typing.TypedDict"] = {
+                      msg = "Use `typing_extensions.TypedDict` instead"
+                    }
+                  }
+                }
+              },
+              format = {
+                ["quote-style"] = "single"
+              }
             }
           }
         }
-      }
-    }
-    ```
+        ```
+
+
+=== "Zed"
+
+    === "Using a configuration file"
+
+        ```json
+        {
+          "lsp": {
+            "ruff": {
+              "initialization_options": {
+                "configuration": "~/path/to/ruff.toml"
+              }
+            }
+          }
+        }
+        ```
+
+    === "Using inline configuration"
+
+        ```json
+        {
+          "lsp": {
+            "ruff": {
+              "initialization_options": {
+                "configuration": {
+                  "lint": {
+                    "unfixable": ["F401"],
+                    "extend-select": ["TID251"],
+                    "flake8-tidy-imports": {
+                      "banned-api": {
+                        "typing.TypedDict": {
+                          "msg": "Use `typing_extensions.TypedDict` instead"
+                        }
+                      }
+                    }
+                  },
+                  "format": {
+                    "quote-style": "single"
+                  }
+                }
+              }
+            }
+          }
+        }
+        ```
 
 ### `configurationPreference`
 


### PR DESCRIPTION
## Summary

[Internal design document](https://www.notion.so/astral-sh/In-editor-settings-19e48797e1ca807fa8c2c91b689d9070?pvs=4)

This PR expands `ruff.configuration` to allow inline configuration directly in the editor. For example:

```json
{
	"ruff.configuration": {
		"line-length": 100,
		"lint": {
			"unfixable": ["F401"],
			"flake8-tidy-imports": {
				"banned-api": {
					"typing.TypedDict": {
						"msg": "Use `typing_extensions.TypedDict` instead"
					}
				}
			}
		},
		"format": {
			"quote-style": "single"
		}
	}
}
```

This means that now `ruff.configuration` accepts either a path to configuration file or the raw config itself. It's _mostly_ similar to `--config` with one difference that's highlighted in the following section. So, it can be said that the format of `ruff.configuration` when provided the config map is same as the one on the [playground] [^1].

## Limitations

<details><summary><b>Casing (<code>kebab-case</code> v/s/ <code>camelCase</code>)</b></summary>
<p>


The config keys needs to be in `kebab-case` instead of `camelCase` which is being used for other settings in the editor.

This could be a bit confusing. For example, the `line-length` option can be set directly via an editor setting or can be configured via `ruff.configuration`:

```json
{
	"ruff.configuration": {
        "line-length": 100
    },
    "ruff.lineLength": 120
}
```

#### Possible solution

We could use feature flag with [conditional compilation](https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute) to indicate that when used in `ruff_server`, we need the `Options` fields to be renamed as `camelCase` while for other crates it needs to be renamed as `kebab-case`. But, this might not work very easily because it will require wrapping the `Options` struct and create two structs in which we'll have to add `#[cfg_attr(...)]` because otherwise `serde` will complain:

```
error: duplicate serde attribute `rename_all`
  --> crates/ruff_workspace/src/options.rs:43:38
   |
43 | #[cfg_attr(feature = "editor", serde(rename_all = "camelCase"))]
   |                                      ^^^^^^^^^^
```

</p>
</details> 

<details><summary><b>Nesting (flat v/s nested keys)</b></summary>
<p>

This is the major difference between `--config` flag on the command-line v/s `ruff.configuration` and it makes it such that `ruff.configuration` has same value format as [playground] [^1].

The config keys needs to be split up into keys which can result in nested structure instead of flat structure:

So, the following **won't work**:

```json
{
	"ruff.configuration": {
		"format.quote-style": "single",
		"lint.flake8-tidy-imports.banned-api.\"typing.TypedDict\".msg": "Use `typing_extensions.TypedDict` instead"
	}
}
```

But, instead it would need to be split up like the following:
```json
{
	"ruff.configuration": {
		"format": {
			"quote-style": "single"
		},
		"lint": {
			"flake8-tidy-imports": {
				"banned-api": {
					"typing.TypedDict": {
						"msg": "Use `typing_extensions.TypedDict` instead"
					}
				}
			}
		}
	}
}
```

#### Possible solution (1)

The way we could solve this and make it same as `--config` would be to add a manual logic of converting the JSON map into an equivalent TOML string which would be then parsed into `Options`.

So, the following JSON map:
```json
{ "lint.flake8-tidy-imports": { "banned-api": {"\"typing.TypedDict\".msg": "Use typing_extensions.TypedDict instead"}}}
```

would need to be converted into the following TOML string:
```toml
lint.flake8-tidy-imports = { banned-api = { "typing.TypedDict".msg = "Use typing_extensions.TypedDict instead" } }
```

by recursively convering `"key": value` into `key = value` which is to remove the quotes from key and replacing `:` with `=`.

#### Possible solution (2)

Another would be to just accept `Map<String, String>` strictly and convert it into `key = value` and then parse it as a TOML string. This would also match `--config` but quotes might become a nuisance because JSON only allows double quotes and so it'll require escaping any inner quotes or use single quotes.

</p>
</details> 

## Test Plan

### VS Code

**Requires https://github.com/astral-sh/ruff-vscode/pull/702**

**`settings.json`**:
```json
{
  "ruff.lint.extendSelect": ["TID"],
  "ruff.configuration": {
    "line-length": 50,
    "format": {
      "quote-style": "single"
    },
    "lint": {
      "unfixable": ["F401"],
      "flake8-tidy-imports": {
        "banned-api": {
          "typing.TypedDict": {
            "msg": "Use `typing_extensions.TypedDict` instead"
          }
        }
      }
    }
  }
}
```

Following video showcases me doing the following:
1. Check diagnostics that it includes `TID`
2. Run `Ruff: Fix all auto-fixable problems` to test `unfixable`
3. Run `Format: Document` to test `line-length` and `quote-style`

https://github.com/user-attachments/assets/0a38176f-3fb0-4960-a213-73b2ea5b1180

### Neovim

**`init.lua`**:
```lua
require('lspconfig').ruff.setup {
  init_options = {
    settings = {
      lint = {
        extendSelect = { 'TID' },
      },
      configuration = {
        ['line-length'] = 50,
        format = {
          ['quote-style'] = 'single',
        },
        lint = {
          unfixable = { 'F401' },
          ['flake8-tidy-imports'] = {
            ['banned-api'] = {
              ['typing.TypedDict'] = {
                msg = 'Use typing_extensions.TypedDict instead',
              },
            },
          },
        },
      },
    },
  },
}
```

Same steps as in the VS Code test:


https://github.com/user-attachments/assets/cfe49a9b-9a89-43d7-94f2-7f565d6e3c9d

## Documentation Preview


https://github.com/user-attachments/assets/e0062f58-6ec8-4e01-889d-fac76fd8b3c7



[playground]: https://play.ruff.rs

[^1]: This has one advantage that the value can be copy-pasted directly into the playground