### PR TITLE
[red-knot] Generalise special-casing for `KnownClass`es in `Type::bool`

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/type_properties/truthiness.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_properties/truthiness.md
@@ -91,3 +91,32 @@ class PossiblyUnboundTrue:
 
 reveal_type(bool(PossiblyUnboundTrue()))  # revealed: bool
 ```
+
+### Special-cased classes
+
+Some special-cased `@final` classes are known by red-knot to have instances that are either always
+truthy or always falsy.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+import types
+import typing
+import sys
+from knot_extensions import AlwaysTruthy, static_assert, is_subtype_of
+from typing_extensions import _NoDefaultType
+
+static_assert(is_subtype_of(sys.version_info.__class__, AlwaysTruthy))
+static_assert(is_subtype_of(types.EllipsisType, AlwaysTruthy))
+static_assert(is_subtype_of(_NoDefaultType, AlwaysTruthy))
+static_assert(is_subtype_of(slice, AlwaysTruthy))
+static_assert(is_subtype_of(types.FunctionType, AlwaysTruthy))
+static_assert(is_subtype_of(types.MethodType, AlwaysTruthy))
+static_assert(is_subtype_of(typing.TypeVar, AlwaysTruthy))
+static_assert(is_subtype_of(typing.TypeAliasType, AlwaysTruthy))
+static_assert(is_subtype_of(types.MethodWrapperType, AlwaysTruthy))
+static_assert(is_subtype_of(types.WrapperDescriptorType, AlwaysTruthy))
+```

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1699,8 +1699,9 @@ impl<'db> Type<'db> {
             },
             Type::AlwaysTruthy => Truthiness::AlwaysTrue,
             Type::AlwaysFalsy => Truthiness::AlwaysFalse,
-            Type::Instance(InstanceType { class }) => {
-                class.known(db).map(KnownClass::bool).unwrap_or_else(|| {
+            instance_ty @ Type::Instance(InstanceType { class }) => match class.known(db) {
+                Some(known_class) => known_class.bool(),
+                None => {
                     // We only check the `__bool__` method for truth testing, even though at
                     // runtime there is a fallback to `__len__`, since `__bool__` takes precedence
                     // and a subclass could add a `__bool__` method.
@@ -1777,8 +1778,8 @@ impl<'db> Type<'db> {
                             }
                         }
                     }
-                })
-            }
+                }
+            },
             Type::KnownInstance(known_instance) => known_instance.bool(),
             Type::Union(union) => {
                 let mut truthiness = None;

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -3198,6 +3198,7 @@ impl<'db> KnownClass {
             "MethodWrapperType" => Self::MethodWrapperType,
             "WrapperDescriptorType" => Self::WrapperDescriptorType,
             "TypeAliasType" => Self::TypeAliasType,
+            "TypeVar" => Self::TypeVar,
             "ChainMap" => Self::ChainMap,
             "Counter" => Self::Counter,
             "defaultdict" => Self::DefaultDict,

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -2886,6 +2886,12 @@ impl<'db> KnownClass {
     /// or have an ambiguous truthiness.
     const fn bool(self) -> Truthiness {
         match self {
+            // N.B. It's only generally safe to infer `Truthiness::AlwaysTrue` for a `KnownClass`
+            // variant if the class's `__bool__` method always returns the same thing *and* the
+            // class is `@final`.
+            //
+            // E.g. `ModuleType.__bool__` always returns `True`, but `ModuleType` is not `@final`.
+            // Equally, `range` is `@final`, but its `__bool__` method can return `False`.
             Self::EllipsisType
             | Self::NoDefaultType
             | Self::MethodType


### PR DESCRIPTION
## Summary

This generalises the special casing added in https://github.com/astral-sh/ruff/pull/16292 to a `match` statement on all `KnownClass` variants. Even if this doesn't actually result in a noticeable speedup, I kind-of prefer it over the current version on `main` because:
- It means we have more precise type inference: we now understand that `sys.version_info` and `builtins.Ellipsis` are always truthy
- It feels more extensible, and more maintainable (we won't forget to add special-casing for new `KnownClass` variants if we add any in the future)
- By doing one `class.known(db)` call in `Type::bool()` and then matching on the result (rather than doing two `class.is_known(db, KnownClass::Whatever)` calls), we now only do one Salsa db lookup instead of two

In addition to the change to `Type::bool()`, I also moved the `match` statement over `KnownClass` variants in `Type::is_single_valued()` to a new method on `KnownClass`.

## Test Plan

Added some new mdtests asserting that instance types for these known classes are understood to be subtypes of `AlwaysTruthy`.