### PR TITLE
[red-knot] Add a regression test for recent improvement to `TypeInferenceBuilder::infer_name_load()`

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/scopes/moduletype_attrs.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/scopes/moduletype_attrs.md
@@ -136,3 +136,42 @@ if returns_bool():
 reveal_type(__file__)  # revealed: Literal[42]
 reveal_type(__name__)  # revealed: Literal[1] | str
 ```
+
+## Implicit global attributes in the current module override implicit globals from builtins
+
+Here, we take the type of the implicit global symbol `__name__` from the `types.ModuleType` stub
+(which in this custom typeshed specifies the type as `bytes`). This is because the `main` module has
+an implicit `__name__` global that shadows the builtin `__name__` symbol.
+
+```toml
+[environment]
+typeshed = "/typeshed"
+```
+
+`/typeshed/stdlib/builtins.pyi`:
+
+```pyi
+class int: ...
+class bytes: ...
+
+__name__: int = 42
+```
+
+`/typeshed/stdlib/types.pyi`:
+
+```pyi
+class ModuleType:
+    __name__: bytes
+```
+
+`/typeshed/stdlib/typing_extensions.pyi`:
+
+```pyi
+def reveal_type(obj, /): ...
+```
+
+`main.py`:
+
+```py
+reveal_type(__name__)  # revealed: bytes
+```


### PR DESCRIPTION
## Summary

This PR adds a regression test for the subtle bug fixed in https://github.com/astral-sh/ruff/pull/16284

## Test Plan

I verified that this test fails if you check out https://github.com/astral-sh/ruff/commit/c2b9fa84f7ffffca0ab173751f5dc2943e8b052d and add the test.
