### PR TITLE
Test auto generated codes are up to date

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -302,7 +302,9 @@ jobs:
       - name: "Install Rust toolchain"
         env:
           MSRV: ${{ steps.msrv.outputs.value }}
-        run: rustup default "${MSRV}"
+        run: |
+          rustup default "${MSRV}"
+          rustup toolchain install "${MSRV}" --component rustfmt
       - name: "Install mold"
         uses: rui314/setup-mold@v1
       - name: "Install cargo nextest"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -292,6 +292,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+      - uses: astral-sh/setup-uv@v5
       - uses: SebRollen/toml-action@v1.2.0
         id: msrv
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -139,6 +139,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+      - uses: astral-sh/setup-uv@v5
       - uses: Swatinem/rust-cache@v2
       - name: "Install Rust toolchain"
         run: rustup show
@@ -185,6 +186,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+      - uses: astral-sh/setup-uv@v5
       - uses: Swatinem/rust-cache@v2
       - name: "Install Rust toolchain"
         run: rustup show
@@ -214,6 +216,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+      - uses: astral-sh/setup-uv@v5
       - uses: Swatinem/rust-cache@v2
       - name: "Install Rust toolchain"
         run: rustup show
@@ -241,6 +244,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+      - uses: astral-sh/setup-uv@v5
       - uses: Swatinem/rust-cache@v2
       - name: "Install Rust toolchain"
         run: rustup target add wasm32-unknown-unknown

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -392,7 +392,6 @@ jobs:
         run: rustup component add rustfmt
       # Run all code generation scripts, and verify that the current output is
       # already checked into git.
-      - run: python crates/ruff_python_ast/generate.py
       - run: python crates/ruff_python_formatter/generate.py
       - run: test -z "$(git status --porcelain)"
       # Verify that adding a plugin or rule produces clean code.

--- a/crates/ruff_python_ast/src/lib.rs
+++ b/crates/ruff_python_ast/src/lib.rs
@@ -149,7 +149,8 @@ mod tests {
         let original_content =
             fs::read_to_string(&generated_path).expect("Failed to read generated.rs");
         let generate_script = Path::new(env!("CARGO_MANIFEST_DIR")).join("generate.py");
-        let output = Command::new("python")
+        let output = Command::new("uv")
+            .arg("run")
             .arg(&generate_script)
             .output()
             .expect("Failed to run AST generator script");

--- a/crates/ruff_python_ast/src/lib.rs
+++ b/crates/ruff_python_ast/src/lib.rs
@@ -141,14 +141,19 @@ mod tests {
     use std::path::Path;
     use std::process::Command;
 
+    /// replaces all occurrences of "\r\n" with "\n" in the given string. Useful to make sure the file
+    /// content is same on all platforms.
+    fn normalize_newlines(s: &str) -> String {
+        s.replace("\r\n", "\n")
+    }
+
     #[test]
     fn test_astgen() {
-        let generated_path = Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("src")
-            .join("generated.rs");
+        let project_root = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let generated_path = project_root.join("src").join("generated.rs");
         let original_content =
             fs::read_to_string(&generated_path).expect("Failed to read generated.rs");
-        let generate_script = Path::new(env!("CARGO_MANIFEST_DIR")).join("generate.py");
+        let generate_script = project_root.join("generate.py");
         let output = Command::new("uv")
             .arg("run")
             .arg(&generate_script)
@@ -163,7 +168,7 @@ mod tests {
         let new_content = fs::read_to_string(&generated_path)
             .expect("Failed to read generated.rs after generation");
         assert!(
-            original_content == new_content,
+            normalize_newlines(&original_content) == normalize_newlines(&new_content),
             "{} has changed after running {}. Commit the changes.",
             generated_path.display(),
             generate_script.display()


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

This is just an idea feel free to close the PR if you don't see the benefit. I thought it would be quicker to discuss in the PR rather than issue.

## Summary

This PR replaces the check in the CI to ensure auto generated codes are up to date with a rust test. The benefit is that this will run along the tests and fails if the auto generated code is not up to date.

I was checking rust analyzer ast generator setup, and noticed [this test](https://github.com/rust-lang/rust-analyzer/blob/862693ff954660d169774c8ada4672fb96dabf36/crates/syntax/src/tests/sourcegen_ast.rs#L21) that checks for generate scripts to be up to date.
I think it's a nice improvement since the check we have now only runs in the CI, when I was working on the ast auto generation I forgot to update the generated file and found out in the CI.

Changes to make this work:

- Installing `uv` before running test in all steps. This is because we need to ensure we're running 3.11.
- line endings have different representation in different platforms on windows it's `\r\n` so we need to replace that with `\n` before checking. I have to admit this one was tricky for me to figure out why is it broken. Maybe it worth it to print a minimal diff in the CI?

The CI time does not seem to increase with this change.
[this branch](https://github.com/astral-sh/ruff/actions/runs/13475837412/job/37654902156) vs [main](https://github.com/astral-sh/ruff/actions/runs/13475837412/job/37654902156)

## Test Plan

Moved the CI check to a rust test. The failure looks like this:

```
ruff/crates/ruff_python_ast/src/generated.rs has changed after running ruff/crates/ruff_python_ast/generate.py. Commit the changes.
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

<!-- How was it tested? -->
