### PR TITLE
[red-knot] Add a test to ensure that `KnownClass::try_from_file_and_name()` is kept up to date

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2499,6 +2499,8 @@ dependencies = [
  "serde",
  "smallvec",
  "static_assertions",
+ "strum",
+ "strum_macros",
  "tempfile",
  "test-case",
  "thiserror 2.0.11",

--- a/crates/red_knot_python_semantic/Cargo.toml
+++ b/crates/red_knot_python_semantic/Cargo.toml
@@ -42,6 +42,8 @@ smallvec = { workspace = true }
 static_assertions = { workspace = true }
 test-case = { workspace = true }
 memchr = { workspace = true }
+strum = { workspace = true}
+strum_macros = { workspace = true}
 
 [dev-dependencies]
 ruff_db = { workspace = true, features = ["testing", "os"] }

--- a/crates/red_knot_python_semantic/src/module_resolver/module.rs
+++ b/crates/red_knot_python_semantic/src/module_resolver/module.rs
@@ -1,4 +1,5 @@
 use std::fmt::Formatter;
+use std::str::FromStr;
 use std::sync::Arc;
 
 use ruff_db::files::File;
@@ -98,10 +99,13 @@ impl ModuleKind {
 }
 
 /// Enumeration of various core stdlib modules in which important types are located
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, strum_macros::EnumString)]
+#[cfg_attr(test, derive(strum_macros::EnumIter))]
+#[strum(serialize_all = "snake_case")]
 pub enum KnownModule {
     Builtins,
     Types,
+    #[strum(serialize = "_typeshed")]
     Typeshed,
     TypingExtensions,
     Typing,
@@ -139,21 +143,10 @@ impl KnownModule {
         search_path: &SearchPath,
         name: &ModuleName,
     ) -> Option<Self> {
-        if !search_path.is_standard_library() {
-            return None;
-        }
-        match name.as_str() {
-            "builtins" => Some(Self::Builtins),
-            "types" => Some(Self::Types),
-            "typing" => Some(Self::Typing),
-            "_typeshed" => Some(Self::Typeshed),
-            "typing_extensions" => Some(Self::TypingExtensions),
-            "sys" => Some(Self::Sys),
-            "abc" => Some(Self::Abc),
-            "collections" => Some(Self::Collections),
-            "inspect" => Some(Self::Inspect),
-            "knot_extensions" => Some(Self::KnotExtensions),
-            _ => None,
+        if search_path.is_standard_library() {
+            Self::from_str(name.as_str()).ok()
+        } else {
+            None
         }
     }
 
@@ -167,5 +160,30 @@ impl KnownModule {
 
     pub const fn is_knot_extensions(self) -> bool {
         matches!(self, Self::KnotExtensions)
+    }
+
+    pub const fn is_inspect(self) -> bool {
+        matches!(self, Self::Inspect)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use strum::IntoEnumIterator;
+
+    #[test]
+    fn known_module_roundtrip_from_str() {
+        let stdlib_search_path = SearchPath::vendored_stdlib();
+
+        for module in KnownModule::iter() {
+            let module_name = module.name();
+
+            assert_eq!(
+                KnownModule::try_from_search_path_and_name(&stdlib_search_path, &module_name),
+                Some(module),
+                "The strum `EnumString` implementation appears to be incorrect for `{module_name}`"
+            );
+        }
     }
 }

--- a/crates/red_knot_python_semantic/src/types/narrow.rs
+++ b/crates/red_knot_python_semantic/src/types/narrow.rs
@@ -8,8 +8,8 @@ use crate::semantic_index::symbol::{ScopeId, ScopedSymbolId, SymbolTable};
 use crate::semantic_index::symbol_table;
 use crate::types::infer::infer_same_file_expression_type;
 use crate::types::{
-    infer_expression_types, IntersectionBuilder, KnownClass, KnownFunction, SubclassOfType,
-    Truthiness, Type, UnionBuilder,
+    infer_expression_types, IntersectionBuilder, KnownClass, SubclassOfType, Truthiness, Type,
+    UnionBuilder,
 };
 use crate::Db;
 use itertools::Itertools;
@@ -429,9 +429,7 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
         // and `issubclass`, for example `isinstance(x, str | (int | float))`.
         match callable_ty {
             Type::FunctionLiteral(function_type) if expr_call.arguments.keywords.is_empty() => {
-                let function = function_type
-                    .known(self.db)
-                    .and_then(KnownFunction::constraint_function)?;
+                let function = function_type.known(self.db)?.into_constraint_function()?;
 
                 let [ast::Expr::Name(ast::ExprName { id, .. }), class_info] =
                     &*expr_call.arguments.args


### PR DESCRIPTION
## Summary

We keep on adding new variants to the `KnownClass` enum but forgetting to update this method, because the Rust compiler only enforces exhaustiveness over enums when the enum variants appear on the left-hand side of the `match` statement:

https://github.com/astral-sh/ruff/blob/b312b53c2eafd97a084f9f2961a99fbfa257f21a/crates/red_knot_python_semantic/src/types.rs#L3183-L3231

That leads to subtle and confusing bugs that can be hard to debug, and that sometimes go unnoticed for several weeks.

This PR adds a test that will fail if we add a variant to the `KnownClass` enum and forget to add a case to `KnownClass::try_from_file_and_name()`. It also adds tests for the similar methods on the `KnownModule` and `KnownFunction` enums.

## How it works

~~`strum` and `strum_macros` are added as _test-only_ dependencies for red-knot (they are added to the `dev-dependencies` table in the `red_knot_python_semantic` crate's `Cargo.toml`). If the `test` feature is enabled, we derive the `EnumIter` trait for the `KnownClass` enum. In the tests for `KnownClass`, we then use the generated `iter()` method to iterate over all `KnownClass` variants and verify that each variant has its own branch in the `KnownClass::try_from_file_and_name()` function.~~

Following review, this has been changed:
- `strum` and `strum_macros` are now just regular dependencies for red-knot, in production as well as if the `test` feature is enabled.
- For `KnownFunction` and `KnownModule`, we use the `EnumString` macro from `strum_macros` to simplify the deserialization constructors and ensure that they are exhaustive over the right-hand side. (This unfortunately doesn't work for `KnownClass` because of the fact that the `EllipsisType` branch deserializes dynamically depending on the target Python version.)
- For all three enums, we add tests to ensure that the deserialization functions are both exhaustive and correct. This is done using strum's `EnumIter` macro.

## Limitations

Unfortunately, this approach doesn't work for the `KnownInstanceType` enum. `KnownInstanceType` is generic over a lifetime, and the `EnumIter` trait cannot be derived for enums generic over a lifetime. I therefore haven't touched that enum in this PR.

This approach also necessitated some small refactoring of the `KnownFunction` enum. `EnumIter` and `EnumString` couldn't be derived for the enum as-is because of the fact that the `ConstraintFunction` variant wrapped inner data. I solved this by replacing the `ConstraintFunction` variant (which wrapped an inner enum) with two variants (`KnownFunction::IsSubclass` and `KnownFunction::IsInstance`), and slightly reworking the `KnownFunction::constraint_function()` method (which is renamed to `KnownFunction::into_constraint_function()`)