### PR TITLE
Update Salsa

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3323,7 +3323,7 @@ checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 [[package]]
 name = "salsa"
 version = "0.18.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=97ea5581e1bdec72d5deb383d555e45928e54f9d#97ea5581e1bdec72d5deb383d555e45928e54f9d"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=687251fb50b4893dc373a7e2609ceaefb8accbe7#687251fb50b4893dc373a7e2609ceaefb8accbe7"
 dependencies = [
  "arc-swap",
  "boxcar",
@@ -3345,12 +3345,12 @@ dependencies = [
 [[package]]
 name = "salsa-macro-rules"
 version = "0.1.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=97ea5581e1bdec72d5deb383d555e45928e54f9d#97ea5581e1bdec72d5deb383d555e45928e54f9d"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=687251fb50b4893dc373a7e2609ceaefb8accbe7#687251fb50b4893dc373a7e2609ceaefb8accbe7"
 
 [[package]]
 name = "salsa-macros"
 version = "0.18.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=97ea5581e1bdec72d5deb383d555e45928e54f9d#97ea5581e1bdec72d5deb383d555e45928e54f9d"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=687251fb50b4893dc373a7e2609ceaefb8accbe7#687251fb50b4893dc373a7e2609ceaefb8accbe7"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ rayon = { version = "1.10.0" }
 regex = { version = "1.10.2" }
 rustc-hash = { version = "2.0.0" }
 # When updating salsa, make sure to also update the revision in `fuzz/Cargo.toml`
-salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "97ea5581e1bdec72d5deb383d555e45928e54f9d" }
+salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "687251fb50b4893dc373a7e2609ceaefb8accbe7" }
 schemars = { version = "0.8.16" }
 seahash = { version = "4.1.0" }
 serde = { version = "1.0.197", features = ["derive"] }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -29,7 +29,7 @@ ruff_python_formatter = { path = "../crates/ruff_python_formatter" }
 ruff_text_size = { path = "../crates/ruff_text_size" }
 
 libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer", default-features = false }
-salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "97ea5581e1bdec72d5deb383d555e45928e54f9d" }
+salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "687251fb50b4893dc373a7e2609ceaefb8accbe7" }
 similar = { version = "2.5.0" }
 tracing = { version = "0.1.40" }
 


### PR DESCRIPTION
Update Salsa to fix stale query results for multi-argument queries where one argument is a tracked struct. 

The performance regression isn't unexpected. https://github.com/astral-sh/ruff/pull/15763 introduced coarse grained dependencies and the version used in that branch removed adding dependencies for any tracked fields (not even to the tracked struct itself). It turned out, that this was incorrect in the case where tracked structs (and there IDs) get reused. The upstream fix now records a dependency on the tracked struct. This is still better than without coarse grained dependencies where salsa recorded a dependency for each tracked field but it isn't free (but required for correctness).

