### PR TITLE
Upgrade Rust toolchain to 1.85.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.84"
+channel = "1.85"


### PR DESCRIPTION
## Summary
This PR upgrades the local Rust toolchain from 1.84 to 1.85. This PR does not bump the MSRV.

## Test Plan

`cargo test`, `cargo clippy`
