### PR TITLE
[red-knot] Add argfile and windows glob path support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2409,6 +2409,7 @@ name = "red_knot"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "argfile",
  "chrono",
  "clap",
  "colored 3.0.0",
@@ -2433,6 +2434,7 @@ dependencies = [
  "tracing-flame",
  "tracing-subscriber",
  "tracing-tree",
+ "wild",
 ]
 
 [[package]]

--- a/crates/red_knot/Cargo.toml
+++ b/crates/red_knot/Cargo.toml
@@ -19,6 +19,7 @@ ruff_db = { workspace = true, features = ["os", "cache"] }
 ruff_python_ast = { workspace = true }
 
 anyhow = { workspace = true }
+argfile = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true, features = ["wrap_help"] }
 colored = { workspace = true }
@@ -31,6 +32,7 @@ tracing = { workspace = true, features = ["release_max_level_debug"] }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 tracing-flame = { workspace = true }
 tracing-tree = { workspace = true }
+wild = { workspace = true }
 
 [dev-dependencies]
 ruff_db = { workspace = true, features = ["testing"] }

--- a/crates/red_knot/src/main.rs
+++ b/crates/red_knot/src/main.rs
@@ -47,7 +47,10 @@ pub fn main() -> ExitStatus {
 }
 
 fn run() -> anyhow::Result<ExitStatus> {
-    let args = Args::parse_from(std::env::args());
+    let args = wild::args_os();
+    let args = argfile::expand_args_from(args, argfile::parse_fromfile, argfile::PREFIX)
+        .context("Failed to read CLI arguments from file")?;
+    let args = Args::parse_from(args);
 
     match args.command {
         Command::Server => run_server().map(|()| ExitStatus::Success),


### PR DESCRIPTION
## Summary

This is mostly copy pasta from Ruff:

* Adds support for argument files using `argfile` (passing CLI arguments from a file, e.g `@knot.args`). This can be useful for buck integrations or other cases where one has to pass more arguments than the shell allows 
* Adds support for glob patterns on windows (using `wild`)

## Test Plan

```
cargo run --bin red_knot -- check @knot.args
```

Where `knot.args` contains

```
--project
../test
-vv
```

runs red knot with verbose mode enabled and it checks the `../test` directory
