### PR TITLE
[red-knot] Better diagnostics for method calls

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/call/methods.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/call/methods.md
@@ -239,11 +239,11 @@ method_wrapper(None, C)
 method_wrapper(None)
 
 # Passing something that is not assignable to `type` as the `owner` argument is an
-# error: [invalid-argument-type] "Object of type `Literal[1]` cannot be assigned to parameter 2 (`owner`); expected type `type`"
+# error: [invalid-argument-type] "Object of type `Literal[1]` cannot be assigned to parameter 2 (`owner`) of method wrapper `__get__` of function `f`; expected type `type`"
 method_wrapper(None, 1)
 
 # Passing `None` as the `owner` argument when `instance` is `None` is an
-# error: [invalid-argument-type] "Object of type `None` cannot be assigned to parameter 2 (`owner`); expected type `type`"
+# error: [invalid-argument-type] "Object of type `None` cannot be assigned to parameter 2 (`owner`) of method wrapper `__get__` of function `f`; expected type `type`"
 method_wrapper(None, None)
 
 # Calling `__get__` without any arguments is an
@@ -251,7 +251,7 @@ method_wrapper(None, None)
 method_wrapper()
 
 # Calling `__get__` with too many positional arguments is an
-# error: [too-many-positional-arguments] "Too many positional arguments: expected 2, got 3"
+# error: [too-many-positional-arguments] "Too many positional arguments to method wrapper `__get__` of function `f`: expected 2, got 3"
 method_wrapper(C(), C, "one too many")
 ```
 
@@ -298,7 +298,7 @@ class D:
         # This function is wrongly annotated, it should be `type[D]` instead of `D`
         pass
 
-# error: [invalid-argument-type] "Object of type `Literal[D]` cannot be assigned to parameter 1 (`cls`); expected type `D`"
+# error: [invalid-argument-type] "Object of type `Literal[D]` cannot be assigned to parameter 1 (`cls`) of bound method `f`; expected type `D`"
 D.f()
 ```
 

--- a/crates/red_knot_python_semantic/resources/mdtest/descriptor_protocol.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/descriptor_protocol.md
@@ -425,15 +425,15 @@ wrapper_descriptor(f, None)
 wrapper_descriptor(f, C())
 
 # Calling it with something that is not a `FunctionType` as the first argument is an
-# error: [invalid-argument-type] "Object of type `Literal[1]` cannot be assigned to parameter 1 (`self`); expected type `FunctionType`"
+# error: [invalid-argument-type] "Object of type `Literal[1]` cannot be assigned to parameter 1 (`self`) of wrapper descriptor `FunctionType.__get__`; expected type `FunctionType`"
 wrapper_descriptor(1, None, type(f))
 
 # Calling it with something that is not a `type` as the `owner` argument is an
-# error: [invalid-argument-type] "Object of type `Literal[f]` cannot be assigned to parameter 3 (`owner`); expected type `type`"
+# error: [invalid-argument-type] "Object of type `Literal[f]` cannot be assigned to parameter 3 (`owner`) of wrapper descriptor `FunctionType.__get__`; expected type `type`"
 wrapper_descriptor(f, None, f)
 
 # Calling it with too many positional arguments is an
-# error: [too-many-positional-arguments] "Too many positional arguments: expected 3, got 4"
+# error: [too-many-positional-arguments] "Too many positional arguments to wrapper descriptor `FunctionType.__get__`: expected 3, got 4"
 wrapper_descriptor(f, None, type(f), "one too many")
 ```
 

--- a/crates/red_knot_python_semantic/resources/mdtest/diagnostics/invalid_argument_type.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/diagnostics/invalid_argument_type.md
@@ -182,3 +182,16 @@ class C:
 c = C()
 c("wrong")  # error: [invalid-argument-type]
 ```
+
+## Calls to methods
+
+Tests that we also see a reference to a function if the callable is a bound method.
+
+```py
+class C:
+    def square(self, x: int) -> int:
+        return x * x
+
+c = C()
+c.square("hello")  # error: [invalid-argument-type]
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Calls_to_methods.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Calls_to_methods.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/red_knot_test/src/lib.rs
-assertion_line: 272
 expression: snapshot
 ---
 ---

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Calls_to_methods.snap.new
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Calls_to_methods.snap.new
@@ -31,5 +31,12 @@ error: lint:invalid-argument-type
 6 | c.square("hello")  # error: [invalid-argument-type]
   |          ^^^^^^^ Object of type `Literal["hello"]` cannot be assigned to parameter 2 (`x`) of bound method `square`; expected type `int`
   |
+ ::: /src/mdtest_snippet.py:2:22
+  |
+1 | class C:
+2 |     def square(self, x: int) -> int:
+  |                      ------ info: parameter declared in function definition here
+3 |         return x * x
+  |
 
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Calls_to_methods.snap.new
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Calls_to_methods.snap.new
@@ -29,7 +29,7 @@ error: lint:invalid-argument-type
   |
 5 | c = C()
 6 | c.square("hello")  # error: [invalid-argument-type]
-  |          ^^^^^^^ Object of type `Literal["hello"]` cannot be assigned to parameter 2 (`x`); expected type `int`
+  |          ^^^^^^^ Object of type `Literal["hello"]` cannot be assigned to parameter 2 (`x`) of bound method `square`; expected type `int`
   |
 
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Calls_to_methods.snap.new
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Calls_to_methods.snap.new
@@ -1,0 +1,35 @@
+---
+source: crates/red_knot_test/src/lib.rs
+assertion_line: 272
+expression: snapshot
+---
+---
+mdtest name: invalid_argument_type.md - Invalid argument type diagnostics - Calls to methods
+mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/invalid_argument_type.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+1 | class C:
+2 |     def square(self, x: int) -> int:
+3 |         return x * x
+4 | 
+5 | c = C()
+6 | c.square("hello")  # error: [invalid-argument-type]
+```
+
+# Diagnostics
+
+```
+error: lint:invalid-argument-type
+ --> /src/mdtest_snippet.py:6:10
+  |
+5 | c = C()
+6 | c.square("hello")  # error: [invalid-argument-type]
+  |          ^^^^^^^ Object of type `Literal["hello"]` cannot be assigned to parameter 2 (`x`); expected type `int`
+  |
+
+```


### PR DESCRIPTION
## Summary

Add better error messages and additional spans for method calls. Can be reviewed commit-by-commit.

before:

![image](https://github.com/user-attachments/assets/11108693-0eed-4932-954c-acdb544cb45b)


after:

![image](https://github.com/user-attachments/assets/e57f7cae-a930-436d-90da-d4ae6ec98a83)


## Test Plan

New snapshot test