### PR TITLE
[red-knot] Ignore surrounding whitespace when looking for `<!-- snapshot-diagnostics -->` directives in mdtests

### DIFF
--- a/crates/ruff_python_trivia/src/cursor.rs
+++ b/crates/ruff_python_trivia/src/cursor.rs
@@ -104,6 +104,20 @@ impl<'a> Cursor<'a> {
         }
     }
 
+    /// Eats the next two characters if they are `c1` and `c2`. Does not
+    /// consume any input otherwise, even if the first character matches.
+    pub fn eat_char3(&mut self, c1: char, c2: char, c3: char) -> bool {
+        let mut chars = self.chars.clone();
+        if chars.next() == Some(c1) && chars.next() == Some(c2) && chars.next() == Some(c3) {
+            self.bump();
+            self.bump();
+            self.bump();
+            true
+        } else {
+            false
+        }
+    }
+
     pub fn eat_char_back(&mut self, c: char) -> bool {
         if self.last() == c {
             self.bump_back();

--- a/crates/ruff_python_trivia/src/cursor.rs
+++ b/crates/ruff_python_trivia/src/cursor.rs
@@ -95,7 +95,8 @@ impl<'a> Cursor<'a> {
     /// Eats the next two characters if they are `c1` and `c2`. Does not
     /// consume any input otherwise, even if the first character matches.
     pub fn eat_char2(&mut self, c1: char, c2: char) -> bool {
-        if self.first() == c1 && self.second() == c2 {
+        let mut chars = self.chars.clone();
+        if chars.next() == Some(c1) && chars.next() == Some(c2) {
             self.bump();
             self.bump();
             true
@@ -104,8 +105,8 @@ impl<'a> Cursor<'a> {
         }
     }
 
-    /// Eats the next two characters if they are `c1` and `c2`. Does not
-    /// consume any input otherwise, even if the first character matches.
+    /// Eats the next three characters if they are `c1`, `c2` and `c3`
+    /// Does not consume any input otherwise, even if the first character matches.
     pub fn eat_char3(&mut self, c1: char, c2: char, c3: char) -> bool {
         let mut chars = self.chars.clone();
         if chars.next() == Some(c1) && chars.next() == Some(c2) && chars.next() == Some(c3) {


### PR DESCRIPTION
## Summary

Something unfortunate that happened while I was working on #16321 was that I initially added an HMTL comment like this:

```
<!--snapshot-diagnostics -->
```

...and I failed to notice for quite a while that there where no snapshots being tested for that specific test. (The directive was missing a whitespace between the `<!--` opener and the word "snapshot", meaning that mdtest wasn't recognising it as a directive.)

This PR changes the parsing of these directives so that whitespace surrounding the phrase "snapshot-diagnostics" is ignored inside HTML comments.

## Test Plan

I added a unit test to the `red_knot_test` crate. I also manually verified that if you apply this diff, running `cargo test -p red_knot_python_semantic` creates a new snapshot for you:

```diff
diff --git a/crates/red_knot_python_semantic/resources/mdtest/attributes.md b/crates/red_knot_python_semantic/resources/mdtest/attributes.md
index 6920bf18c..cd6171572 100644
--- a/crates/red_knot_python_semantic/resources/mdtest/attributes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/attributes.md
@@ -125,6 +125,8 @@ C.only_declared = "overwritten on class"
 
 #### Mixed declarations/bindings in class body and `__init__`
 
+<!--snapshot-diagnostics    -->
```
