### PR TITLE
Avoid indexing the project if `configurationPreference` is `editorOnly`

### DIFF
--- a/crates/ruff_server/src/session/index/ruff_settings.rs
+++ b/crates/ruff_server/src/session/index/ruff_settings.rs
@@ -56,32 +56,45 @@ impl std::fmt::Display for RuffSettings {
 }
 
 impl RuffSettings {
+    /// Constructs [`RuffSettings`] by attempting to resolve settings from a user-provided
+    /// configuration file, such as `pyproject.toml` or `ruff.toml`, within the
+    /// user's workspace.
+    ///
+    /// In the absence of a valid configuration file, it gracefully falls back to
+    /// editor-only settings.
     pub(crate) fn fallback(editor_settings: &ResolvedEditorSettings, root: &Path) -> RuffSettings {
-        let mut path = None;
-        let fallback = find_user_settings_toml()
+        find_user_settings_toml()
             .and_then(|user_settings| {
                 let settings = ruff_workspace::resolver::resolve_root_settings(
                     &user_settings,
                     Relativity::Cwd,
                     &EditorConfigurationTransformer(editor_settings, root),
-                )
-                .ok();
-                path = Some(user_settings);
-                settings
+                );
+                match settings {
+                    Ok(settings) => Some(RuffSettings {
+                        path: Some(user_settings),
+                        settings,
+                    }),
+                    Err(..) => None,
+                }
             })
-            .unwrap_or_else(|| {
-                let default_configuration = Configuration::default();
-                EditorConfigurationTransformer(editor_settings, root)
-                    .transform(default_configuration)
-                    .into_settings(root)
-                    .expect(
-                        "editor configuration should merge successfully with default configuration",
-                    )
-            });
+            .unwrap_or_else(|| Self::editor_only(editor_settings, root))
+    }
+
+    /// Constructs [`RuffSettings`] by merging the editor-defined settings with the
+    /// default configuration.
+    pub(crate) fn editor_only(
+        editor_settings: &ResolvedEditorSettings,
+        root: &Path,
+    ) -> RuffSettings {
+        let settings = EditorConfigurationTransformer(editor_settings, root)
+            .transform(Configuration::default())
+            .into_settings(root)
+            .expect("editor configuration should merge successfully with default configuration");
 
         RuffSettings {
-            path,
-            settings: fallback,
+            path: None,
+            settings,
         }
     }
 }
@@ -102,19 +115,22 @@ impl RuffSettingsIndex {
         editor_settings: &ResolvedEditorSettings,
         is_default_workspace: bool,
     ) -> Self {
-        let mut has_error = false;
-        let mut index = BTreeMap::default();
-        let mut respect_gitignore = None;
-        let fallback = Arc::new(RuffSettings::fallback(editor_settings, root));
-
         if editor_settings.configuration_preference == ConfigurationPreference::EditorOnly {
             tracing::debug!(
                 "Skipping indexing settings due to editorOnly configuration preference."
             );
-            return RuffSettingsIndex { index, fallback };
+            return RuffSettingsIndex {
+                index: BTreeMap::default(),
+                fallback: Arc::new(RuffSettings::editor_only(editor_settings, root)),
+            };
         }
 
         tracing::debug!("Indexing settings for workspace: {}", root.display());
+        let mut has_error = false;
+        let mut respect_gitignore = None;
+        let mut index = BTreeMap::default();
+        let fallback = Arc::new(RuffSettings::fallback(editor_settings, root));
+
         // If this is *not* the default workspace, then we should skip the workspace root itself
         // because it will be resolved when walking the workspace directory tree. This is done by
         // the `WalkBuilder` below.


### PR DESCRIPTION
## Summary

Closes: https://github.com/astral-sh/ruff/issues/16267

This change skips building the `index` in RuffSettingsIndex when the configuration preference, in the editor settings, is set to `editorOnly`. This is appropriate due to the fact that the indexes will go unused as long as the configuration preference persists.

## Test Plan

I have tested this in VSCode and can confirm that we skip indexing when `editorOnly` is set. Upon switching back to `editorFirst` or `filesystemFirst` we index the settings as normal.

I don't seen any unit tests for setting indexing at the moment, but I am happy to give it a shot if that is something we want.
