### PR TITLE
document MSRV policy

### DIFF
--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -48,6 +48,15 @@ Ruff uses a custom versioning scheme that uses the **minor** version number for 
     - A new server setting is added
     - A server setting is deprecated
 
+## Minimum supported Rust version
+
+The minimum supported Rust version required to compile Ruff is listed in the `rust-version` key of
+the `[workspace.package]` section in `Cargo.toml`. It may change in any release (minor or patch). It
+will never be newer than N-2 Rust versions, where N is the latest stable version. For example, if
+the latest stable Rust version is 1.85, Ruff's minimum supported Rust version will be at most 1.83.
+
+This is only relevant to users who build Ruff from source. Installing Ruff from the Python package
+index usually installs a pre-built binary and does not require Rust compilation.
 
 ## Preview mode
 


### PR DESCRIPTION
This documents our minimum supported Rust version policy. See https://github.com/astral-sh/ruff/issues/16370