### PR TITLE
[red-knot] fix non-callable reporting for unions

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/call/union.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/call/union.md
@@ -126,3 +126,21 @@ def _(flag: bool):
     x = f(3)
     reveal_type(x)  # revealed: Unknown
 ```
+
+## One not-callable, one wrong argument
+
+```py
+class C: ...
+
+def f1(): ...
+def _(flag: bool):
+    if flag:
+        f = f1
+    else:
+        f = C()
+
+    # TODO: we should either show all union errors here, or prioritize the not-callable error
+    # error: [too-many-positional-arguments] "Too many positional arguments to function `f1`: expected 0, got 1"
+    x = f(3)
+    reveal_type(x)  # revealed: Unknown
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/call/union.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/call/union.md
@@ -56,6 +56,7 @@ def _(flag: bool, flag2: bool):
     else:
         def f() -> int:
             return 1
+    # TODO we should mention all non-callable elements of the union
     # error: [call-non-callable] "Object of type `Literal[1]` is not callable"
     # revealed: int | Unknown
     reveal_type(f())
@@ -105,6 +106,23 @@ def _(flag: bool):
         f = "This is a string literal"
 
     # error: [call-non-callable] "Object of type `Literal["This is a string literal"]` is not callable"
+    x = f(3)
+    reveal_type(x)  # revealed: Unknown
+```
+
+## Union of binding errors
+
+```py
+def f1(): ...
+def f2(): ...
+def _(flag: bool):
+    if flag:
+        f = f1
+    else:
+        f = f2
+
+    # TODO: we should show all errors from the union, not arbitrarily pick one union element
+    # error: [too-many-positional-arguments] "Too many positional arguments to function `f1`: expected 0, got 1"
     x = f(3)
     reveal_type(x)  # revealed: Unknown
 ```

--- a/crates/red_knot_python_semantic/src/types/call.rs
+++ b/crates/red_knot_python_semantic/src/types/call.rs
@@ -35,7 +35,7 @@ impl<'db> CallOutcome<'db> {
         let elements = union.elements(db);
         let mut bindings = Vec::with_capacity(elements.len());
         let mut errors = Vec::new();
-        let mut not_callable = true;
+        let mut not_callable = false;
 
         for element in elements {
             match call(*element) {

--- a/crates/red_knot_python_semantic/src/types/call.rs
+++ b/crates/red_knot_python_semantic/src/types/call.rs
@@ -35,7 +35,7 @@ impl<'db> CallOutcome<'db> {
         let elements = union.elements(db);
         let mut bindings = Vec::with_capacity(elements.len());
         let mut errors = Vec::new();
-        let mut not_callable = false;
+        let mut all_errors_not_callable = true;
 
         for element in elements {
             match call(*element) {
@@ -44,7 +44,7 @@ impl<'db> CallOutcome<'db> {
                     bindings.extend(inner_bindings);
                 }
                 Err(error) => {
-                    not_callable |= error.is_not_callable();
+                    all_errors_not_callable &= error.is_not_callable();
                     errors.push(error);
                 }
             }
@@ -52,7 +52,7 @@ impl<'db> CallOutcome<'db> {
 
         if errors.is_empty() {
             Ok(CallOutcome::Union(bindings.into()))
-        } else if bindings.is_empty() && not_callable {
+        } else if bindings.is_empty() && all_errors_not_callable {
             Err(CallError::NotCallable {
                 not_callable_type: Type::Union(union),
             })


### PR DESCRIPTION
Minor follow-up to https://github.com/astral-sh/ruff/pull/16161

This `not_callable` flag wasn't functional, because it could never be `false`. It was initialized to `true` and then only ever updated with `|=`, which can never make it `false`.

Add a test that exercises the case where it _should_ be `false` (all of the union elements are callable) but `bindings` is also empty (all union elements have binding errors). Before this PR, the added test wrongly emits a diagnostic that the union `Literal[f1] | Literal[f2]` is not callable.

And add a test where a union call results in one binding error and one not-callable error, where we currently give the wrong result (we show only the binding error), with a TODO.

Also add TODO comments in a couple other tests where ideally we'd report more than just one error out of a union call.

Also update the flag name to `all_errors_not_callable` to more clearly indicate the semantics of the flag.
