### PR TITLE
Escape template filenames in glob patterns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1057,9 +1057,9 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "globset"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f1ce686646e7f1e19bf7d5533fe443a45dbfb990e00629110797578b42fb19"
+checksum = "54a1028dfc5f5df5da8a56a73e6c153c9a9708ec57232470703592a3f18e49f5"
 dependencies = [
  "aho-corasick",
  "bstr",

--- a/crates/ruff/tests/format.rs
+++ b/crates/ruff/tests/format.rs
@@ -2158,12 +2158,12 @@ fn cookiecutter_globbing() -> Result<()> {
     }, {
         assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
             .args(["format", "--no-cache", "--diff"])
-            .current_dir(tempdir.path()), @r#"
+            .current_dir(tempdir.path()), @r"
         success: false
         exit_code: 1
         ----- stdout -----
-        --- {{cookiecutter.repo_name}}/tests/maintest.py
-        +++ {{cookiecutter.repo_name}}/tests/maintest.py
+        --- tmp/{{cookiecutter.repo_name}}/tests/maintest.py
+        +++ tmp/{{cookiecutter.repo_name}}/tests/maintest.py
         @@ -1,3 +1,3 @@
          import foo
          import bar
@@ -2173,9 +2173,8 @@ fn cookiecutter_globbing() -> Result<()> {
 
 
         ----- stderr -----
-        warning: Error parsing original glob: `"[TMP]/{{cookiecutter.repo_name}}/tests/*"`, trying with escaped braces: `"[TMP]/[{][{]cookiecutter.repo_name[}][}]/tests/*"`
         1 file would be reformatted
-        "#);
+        ");
     });
 
     Ok(())

--- a/crates/ruff/tests/format.rs
+++ b/crates/ruff/tests/format.rs
@@ -2152,28 +2152,18 @@ fn cookiecutter_globbing() -> Result<()> {
         r#"tool.ruff.lint.per-file-ignores = { "tests/*" = ["F811"] }"#,
     )?;
     let maintest = tests.join("maintest.py");
-    fs::write(maintest, "import foo\nimport bar\nimport foo")?;
-    insta::with_settings!({filters => vec![(r"\\", "/")]}, {
-        assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
-                .args(["format", "--no-cache", "--diff"])
-                .current_dir(tempdir.path()), @r"
-        success: false
-        exit_code: 1
-        ----- stdout -----
-        --- {{cookiecutter.repo_name}}/tests/maintest.py
-        +++ {{cookiecutter.repo_name}}/tests/maintest.py
-        @@ -1,3 +1,3 @@
-        import foo
-        import bar
-        -import foo
-        \ No newline at end of file
-        +import foo
+    fs::write(maintest, "import foo\nimport bar\nimport foo\n")?;
 
+    assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+            .args(["format", "--no-cache", "--diff"])
+            .current_dir(tempdir.path()), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
 
-        ----- stderr -----
-        1 file would be reformatted
-        ");
-    });
+    ----- stderr -----
+    1 file already formatted
+    ");
 
     Ok(())
 }

--- a/crates/ruff/tests/format.rs
+++ b/crates/ruff/tests/format.rs
@@ -2153,25 +2153,27 @@ fn cookiecutter_globbing() -> Result<()> {
     )?;
     let maintest = tests.join("maintest.py");
     fs::write(maintest, "import foo\nimport bar\nimport foo")?;
-    assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
-            .args(["format", "--no-cache", "--diff"])
-            .current_dir(tempdir.path()), @r"
-    success: false
-    exit_code: 1
-    ----- stdout -----
-    --- {{cookiecutter.repo_name}}/tests/maintest.py
-    +++ {{cookiecutter.repo_name}}/tests/maintest.py
-    @@ -1,3 +1,3 @@
-     import foo
-     import bar
-    -import foo
-    \ No newline at end of file
-    +import foo
+    insta::with_settings!({filters => vec![(r"\\", "/")]}, {
+        assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+                .args(["format", "--no-cache", "--diff"])
+                .current_dir(tempdir.path()), @r"
+        success: false
+        exit_code: 1
+        ----- stdout -----
+        --- {{cookiecutter.repo_name}}/tests/maintest.py
+        +++ {{cookiecutter.repo_name}}/tests/maintest.py
+        @@ -1,3 +1,3 @@
+        import foo
+        import bar
+        -import foo
+        \ No newline at end of file
+        +import foo
 
 
-    ----- stderr -----
-    1 file would be reformatted
-    ");
+        ----- stderr -----
+        1 file would be reformatted
+        ");
+    });
 
     Ok(())
 }

--- a/crates/ruff/tests/format.rs
+++ b/crates/ruff/tests/format.rs
@@ -2165,15 +2165,15 @@ fn cookiecutter_globbing() -> Result<()> {
         --- {{cookiecutter.repo_name}}/tests/maintest.py
         +++ {{cookiecutter.repo_name}}/tests/maintest.py
         @@ -1,3 +1,3 @@
-        import foo
-        import bar
+         import foo
+         import bar
         -import foo
         / No newline at end of file
         +import foo
 
 
         ----- stderr -----
-        warning: Error parsing original glob: `"[TMP]/{{cookiecutter.repo_name}}/tests/*"`, trying with escaped braces (`{}`)
+        warning: Error parsing original glob: `"[TMP]/{{cookiecutter.repo_name}}/tests/*"`, trying with escaped braces: `"[TMP]/[{][{]cookiecutter.repo_name[}][}]/tests/*"`
         1 file would be reformatted
         "#);
     });

--- a/crates/ruff/tests/format.rs
+++ b/crates/ruff/tests/format.rs
@@ -2133,3 +2133,50 @@ with open("a_really_long_foo") as foo, open("a_really_long_bar") as bar, open("a
     ----- stderr -----
     "#);
 }
+
+/// Regression test for <https://github.com/astral-sh/ruff/issues/9381> with very helpful
+/// reproduction repo here: <https://github.com/lucasfijen/example_ruff_glob_bug>
+#[test]
+fn cookiecutter_globbing() -> Result<()> {
+    // This is a simplified directory structure from the repo linked above. The essence of the
+    // problem is this `{{cookiecutter.repo_name}}` directory containing a config file with a glob.
+    // The absolute path of the glob contains the glob metacharacters `{{` and `}}` even though the
+    // user's glob does not.
+    let tempdir = TempDir::new()?;
+    let cookiecutter = tempdir.path().join("{{cookiecutter.repo_name}}");
+    let cookiecutter_toml = cookiecutter.join("pyproject.toml");
+    let tests = cookiecutter.join("tests");
+    fs::create_dir_all(&tests)?;
+    fs::write(
+        cookiecutter_toml,
+        r#"tool.ruff.lint.per-file-ignores = { "tests/*" = ["F811"] }"#,
+    )?;
+    let maintest = tests.join("maintest.py");
+    fs::write(maintest, "import foo\nimport bar\nimport foo")?;
+    insta::with_settings!({
+        filters => vec![(tempdir_filter(&tempdir).as_str(), "[TMP]/"), (r"\\", "/")]
+    }, {
+    assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+        .args(["format", "--no-cache", "--diff"])
+        .current_dir(tempdir.path()), @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    --- {{cookiecutter.repo_name}}/tests/maintest.py
+    +++ {{cookiecutter.repo_name}}/tests/maintest.py
+    @@ -1,3 +1,3 @@
+     import foo
+     import bar
+    -import foo
+    / No newline at end of file
+    +import foo
+
+
+    ----- stderr -----
+    warning: Error parsing original glob: `"[TMP]/{{cookiecutter.repo_name}}/tests/*"`, trying with escaped braces (`{}`)
+    1 file would be reformatted
+    "#);
+    });
+
+    Ok(())
+}

--- a/crates/ruff/tests/format.rs
+++ b/crates/ruff/tests/format.rs
@@ -2153,14 +2153,9 @@ fn cookiecutter_globbing() -> Result<()> {
     )?;
     let maintest = tests.join("maintest.py");
     fs::write(maintest, "import foo\nimport bar\nimport foo")?;
-
-    let tmp_filter = tempdir_filter(&tempdir);
-    let filters = vec![
-        (tmp_filter.as_str(), "[TMP]/"),
-        (r#"\\(\w\w|\s|\.|")"#, "/$1"),
-    ];
-
-    insta::with_settings!({filters => filters}, {
+    insta::with_settings!({
+        filters => vec![(tempdir_filter(&tempdir).as_str(), "[TMP]/"), (r"\\", "/")]
+    }, {
         assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
             .args(["format", "--no-cache", "--diff"])
             .current_dir(tempdir.path()), @r#"

--- a/crates/ruff/tests/format.rs
+++ b/crates/ruff/tests/format.rs
@@ -2143,7 +2143,12 @@ fn cookiecutter_globbing() -> Result<()> {
     // The absolute path of the glob contains the glob metacharacters `{{` and `}}` even though the
     // user's glob does not.
     let tempdir = TempDir::new()?;
-    let cookiecutter = tempdir.path().join("{{cookiecutter.repo_name}}");
+    // add an extra layer here to prevent the regex escapes on `{` from conflicting with the tempdir
+    // filter for insta
+    let cookiecutter = tempdir
+        .path()
+        .join("tmp")
+        .join("{{cookiecutter.repo_name}}");
     let cookiecutter_toml = cookiecutter.join("pyproject.toml");
     let tests = cookiecutter.join("tests");
     fs::create_dir_all(&tests)?;
@@ -2167,8 +2172,8 @@ fn cookiecutter_globbing() -> Result<()> {
         success: false
         exit_code: 1
         ----- stdout -----
-        --- {{cookiecutter.repo_name}}/tests/maintest.py
-        +++ {{cookiecutter.repo_name}}/tests/maintest.py
+        --- tmp/{{cookiecutter.repo_name}}/tests/maintest.py
+        +++ tmp/{{cookiecutter.repo_name}}/tests/maintest.py
         @@ -1,3 +1,3 @@
          import foo
          import bar
@@ -2178,7 +2183,7 @@ fn cookiecutter_globbing() -> Result<()> {
 
 
         ----- stderr -----
-        warning: Error parsing original glob: `"[TMP]/{{cookiecutter.repo_name}}/tests/*"`, trying with escaped braces: `"[TMP]/[{][{]cookiecutter.repo_name[}][}]/tests/*"`
+        warning: Error parsing original glob: `"[TMP]/tmp/{{cookiecutter.repo_name}}/tests/*"`, trying with escaped braces: `"[TMP]/tmp/[{][{]cookiecutter.repo_name[}][}]/tests/*"`
         1 file would be reformatted
         "#);
     });

--- a/crates/ruff/tests/format.rs
+++ b/crates/ruff/tests/format.rs
@@ -2143,12 +2143,7 @@ fn cookiecutter_globbing() -> Result<()> {
     // The absolute path of the glob contains the glob metacharacters `{{` and `}}` even though the
     // user's glob does not.
     let tempdir = TempDir::new()?;
-    // add an extra layer here to prevent the regex escapes on `{` from conflicting with the tempdir
-    // filter for insta
-    let cookiecutter = tempdir
-        .path()
-        .join("tmp")
-        .join("{{cookiecutter.repo_name}}");
+    let cookiecutter = tempdir.path().join("{{cookiecutter.repo_name}}");
     let cookiecutter_toml = cookiecutter.join("pyproject.toml");
     let tests = cookiecutter.join("tests");
     fs::create_dir_all(&tests)?;
@@ -2172,8 +2167,8 @@ fn cookiecutter_globbing() -> Result<()> {
         success: false
         exit_code: 1
         ----- stdout -----
-        --- tmp/{{cookiecutter.repo_name}}/tests/maintest.py
-        +++ tmp/{{cookiecutter.repo_name}}/tests/maintest.py
+        --- {{cookiecutter.repo_name}}/tests/maintest.py
+        +++ {{cookiecutter.repo_name}}/tests/maintest.py
         @@ -1,3 +1,3 @@
          import foo
          import bar
@@ -2183,7 +2178,7 @@ fn cookiecutter_globbing() -> Result<()> {
 
 
         ----- stderr -----
-        warning: Error parsing original glob: `"[TMP]/tmp/{{cookiecutter.repo_name}}/tests/*"`, trying with escaped braces: `"[TMP]/tmp/[{][{]cookiecutter.repo_name[}][}]/tests/*"`
+        warning: Error parsing original glob: `"[TMP]/{{cookiecutter.repo_name}}/tests/*"`, trying with escaped braces: `"[TMP]/[{][{]cookiecutter.repo_name[}][}]/tests/*"`
         1 file would be reformatted
         "#);
     });

--- a/crates/ruff/tests/format.rs
+++ b/crates/ruff/tests/format.rs
@@ -2156,26 +2156,26 @@ fn cookiecutter_globbing() -> Result<()> {
     insta::with_settings!({
         filters => vec![(tempdir_filter(&tempdir).as_str(), "[TMP]/"), (r"\\", "/")]
     }, {
-    assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
-        .args(["format", "--no-cache", "--diff"])
-        .current_dir(tempdir.path()), @r#"
-    success: false
-    exit_code: 1
-    ----- stdout -----
-    --- {{cookiecutter.repo_name}}/tests/maintest.py
-    +++ {{cookiecutter.repo_name}}/tests/maintest.py
-    @@ -1,3 +1,3 @@
-     import foo
-     import bar
-    -import foo
-    / No newline at end of file
-    +import foo
+        assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+            .args(["format", "--no-cache", "--diff"])
+            .current_dir(tempdir.path()), @r#"
+        success: false
+        exit_code: 1
+        ----- stdout -----
+        --- {{cookiecutter.repo_name}}/tests/maintest.py
+        +++ {{cookiecutter.repo_name}}/tests/maintest.py
+        @@ -1,3 +1,3 @@
+        import foo
+        import bar
+        -import foo
+        / No newline at end of file
+        +import foo
 
 
-    ----- stderr -----
-    warning: Error parsing original glob: `"[TMP]/{{cookiecutter.repo_name}}/tests/*"`, trying with escaped braces (`{}`)
-    1 file would be reformatted
-    "#);
+        ----- stderr -----
+        warning: Error parsing original glob: `"[TMP]/{{cookiecutter.repo_name}}/tests/*"`, trying with escaped braces (`{}`)
+        1 file would be reformatted
+        "#);
     });
 
     Ok(())

--- a/crates/ruff/tests/format.rs
+++ b/crates/ruff/tests/format.rs
@@ -2153,9 +2153,14 @@ fn cookiecutter_globbing() -> Result<()> {
     )?;
     let maintest = tests.join("maintest.py");
     fs::write(maintest, "import foo\nimport bar\nimport foo")?;
-    insta::with_settings!({
-        filters => vec![(tempdir_filter(&tempdir).as_str(), "[TMP]/"), (r"\\", "/")]
-    }, {
+
+    let tmp_filter = tempdir_filter(&tempdir);
+    let filters = vec![
+        (tmp_filter.as_str(), "[TMP]/"),
+        (r#"\\(\w\w|\s|\.|")"#, "/$1"),
+    ];
+
+    insta::with_settings!({filters => filters}, {
         assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
             .args(["format", "--no-cache", "--diff"])
             .current_dir(tempdir.path()), @r#"

--- a/crates/ruff/tests/format.rs
+++ b/crates/ruff/tests/format.rs
@@ -2153,29 +2153,25 @@ fn cookiecutter_globbing() -> Result<()> {
     )?;
     let maintest = tests.join("maintest.py");
     fs::write(maintest, "import foo\nimport bar\nimport foo")?;
-    insta::with_settings!({
-        filters => vec![(tempdir_filter(&tempdir).as_str(), "[TMP]/"), (r"\\", "/")]
-    }, {
-        assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+    assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
             .args(["format", "--no-cache", "--diff"])
             .current_dir(tempdir.path()), @r"
-        success: false
-        exit_code: 1
-        ----- stdout -----
-        --- tmp/{{cookiecutter.repo_name}}/tests/maintest.py
-        +++ tmp/{{cookiecutter.repo_name}}/tests/maintest.py
-        @@ -1,3 +1,3 @@
-         import foo
-         import bar
-        -import foo
-        / No newline at end of file
-        +import foo
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    --- {{cookiecutter.repo_name}}/tests/maintest.py
+    +++ {{cookiecutter.repo_name}}/tests/maintest.py
+    @@ -1,3 +1,3 @@
+     import foo
+     import bar
+    -import foo
+    \ No newline at end of file
+    +import foo
 
 
-        ----- stderr -----
-        1 file would be reformatted
-        ");
-    });
+    ----- stderr -----
+    1 file would be reformatted
+    ");
 
     Ok(())
 }

--- a/crates/ruff/tests/lint.rs
+++ b/crates/ruff/tests/lint.rs
@@ -2724,14 +2724,13 @@ fn cookiecutter_globbing() -> Result<()> {
     assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
         .args(STDIN_BASE_OPTIONS)
         .current_dir(tempdir.path()), @r#"
-    success: false
-    exit_code: 2
+    success: true
+    exit_code: 0
     ----- stdout -----
+    All checks passed!
 
     ----- stderr -----
-    ruff failed
-      Cause: invalid glob "[TMP]/{{cookiecutter.repo_name}}/tests/*"
-      Cause: error parsing glob '[TMP]/{{cookiecutter.repo_name}}/tests/*': nested alternate groups are not allowed
+    warning: Error parsing original glob: `"[TMP]/{{cookiecutter.repo_name}}/tests/*"`, trying with escaped braces (`{}`)
     "#);
     });
 

--- a/crates/ruff/tests/lint.rs
+++ b/crates/ruff/tests/lint.rs
@@ -2725,18 +2725,18 @@ fn cookiecutter_globbing() -> Result<()> {
     insta::with_settings!({
         filters => vec![(tempdir_filter(&tempdir).as_str(), "[TMP]/"), (r"\\", "/")]
     }, {
-    assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
-        .args(STDIN_BASE_OPTIONS)
-        .arg("--select=F811")
-        .current_dir(tempdir.path()), @r#"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-    All checks passed!
+        assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+            .args(STDIN_BASE_OPTIONS)
+            .arg("--select=F811")
+            .current_dir(tempdir.path()), @r#"
+		success: true
+		exit_code: 0
+		----- stdout -----
+		All checks passed!
 
-    ----- stderr -----
-    warning: Error parsing original glob: `"[TMP]/{{cookiecutter.repo_name}}/tests/*"`, trying with escaped braces (`{}`)
-    "#);
+		----- stderr -----
+		warning: Error parsing original glob: `"[TMP]/{{cookiecutter.repo_name}}/tests/*"`, trying with escaped braces (`{}`)
+		"#);
     });
 
     // after removing the config file with the ignore, F811 applies, so the glob worked above
@@ -2745,19 +2745,19 @@ fn cookiecutter_globbing() -> Result<()> {
     insta::with_settings!({
         filters => vec![(tempdir_filter(&tempdir).as_str(), "[TMP]/"), (r"\\", "/")]
     }, {
-    assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
-        .args(STDIN_BASE_OPTIONS)
-        .arg("--select=F811")
-        .current_dir(tempdir.path()), @r"
-    success: false
-    exit_code: 1
-    ----- stdout -----
-    {{cookiecutter.repo_name}}/tests/maintest.py:3:8: F811 [*] Redefinition of unused `foo` from line 1
-    Found 1 error.
-    [*] 1 fixable with the `--fix` option.
+        assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+            .args(STDIN_BASE_OPTIONS)
+            .arg("--select=F811")
+            .current_dir(tempdir.path()), @r"
+		success: false
+		exit_code: 1
+		----- stdout -----
+		{{cookiecutter.repo_name}}/tests/maintest.py:3:8: F811 [*] Redefinition of unused `foo` from line 1
+		Found 1 error.
+		[*] 1 fixable with the `--fix` option.
 
-    ----- stderr -----
-    ");
+		----- stderr -----
+		");
     });
 
     Ok(())

--- a/crates/ruff/tests/lint.rs
+++ b/crates/ruff/tests/lint.rs
@@ -2728,15 +2728,14 @@ fn cookiecutter_globbing() -> Result<()> {
         assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
             .args(STDIN_BASE_OPTIONS)
             .arg("--select=F811")
-            .current_dir(tempdir.path()), @r#"
+            .current_dir(tempdir.path()), @r"
         success: true
         exit_code: 0
         ----- stdout -----
         All checks passed!
 
         ----- stderr -----
-        warning: Error parsing original glob: `"[TMP]/{{cookiecutter.repo_name}}/tests/*"`, trying with escaped braces: `"[TMP]/[{][{]cookiecutter.repo_name[}][}]/tests/*"`
-        "#);
+        ");
     });
 
     // after removing the config file with the ignore, F811 applies, so the glob worked above

--- a/crates/ruff/tests/lint.rs
+++ b/crates/ruff/tests/lint.rs
@@ -2729,14 +2729,14 @@ fn cookiecutter_globbing() -> Result<()> {
             .args(STDIN_BASE_OPTIONS)
             .arg("--select=F811")
             .current_dir(tempdir.path()), @r#"
-		success: true
-		exit_code: 0
-		----- stdout -----
-		All checks passed!
+        success: true
+        exit_code: 0
+        ----- stdout -----
+        All checks passed!
 
-		----- stderr -----
-		warning: Error parsing original glob: `"[TMP]/{{cookiecutter.repo_name}}/tests/*"`, trying with escaped braces (`{}`)
-		"#);
+        ----- stderr -----
+        warning: Error parsing original glob: `"[TMP]/{{cookiecutter.repo_name}}/tests/*"`, trying with escaped braces: `"[TMP]/[{][{]cookiecutter.repo_name[}][}]/tests/*"`
+        "#);
     });
 
     // after removing the config file with the ignore, F811 applies, so the glob worked above

--- a/crates/ruff/tests/lint.rs
+++ b/crates/ruff/tests/lint.rs
@@ -2722,34 +2722,39 @@ fn cookiecutter_globbing() -> Result<()> {
     // F811 example from the docs to ensure the glob still works
     let maintest = tests.join("maintest.py");
     fs::write(maintest, "import foo\nimport bar\nimport foo")?;
-    assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
-            .args(STDIN_BASE_OPTIONS)
-            .arg("--select=F811")
-            .current_dir(tempdir.path()), @r"
-        success: true
-        exit_code: 0
-        ----- stdout -----
-        All checks passed!
 
-        ----- stderr -----
-        ");
+    insta::with_settings!({filters => vec![(r"\\", "/")]}, {
+        assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+                .args(STDIN_BASE_OPTIONS)
+                .arg("--select=F811")
+                .current_dir(tempdir.path()), @r"
+			success: true
+			exit_code: 0
+			----- stdout -----
+			All checks passed!
+
+			----- stderr -----
+			");
+    });
 
     // after removing the config file with the ignore, F811 applies, so the glob worked above
     fs::remove_file(cookiecutter_toml)?;
 
-    assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
-            .args(STDIN_BASE_OPTIONS)
-            .arg("--select=F811")
-            .current_dir(tempdir.path()), @r"
-		success: false
-		exit_code: 1
-		----- stdout -----
-		{{cookiecutter.repo_name}}/tests/maintest.py:3:8: F811 [*] Redefinition of unused `foo` from line 1
-		Found 1 error.
-		[*] 1 fixable with the `--fix` option.
+    insta::with_settings!({filters => vec![(r"\\", "/")]}, {
+        assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+                .args(STDIN_BASE_OPTIONS)
+                .arg("--select=F811")
+                .current_dir(tempdir.path()), @r"
+			success: false
+			exit_code: 1
+			----- stdout -----
+			{{cookiecutter.repo_name}}/tests/maintest.py:3:8: F811 [*] Redefinition of unused `foo` from line 1
+			Found 1 error.
+			[*] 1 fixable with the `--fix` option.
 
-		----- stderr -----
-	");
+			----- stderr -----
+		");
+    });
 
     Ok(())
 }
@@ -2761,18 +2766,20 @@ fn cookiecutter_globbing_no_project_root() -> Result<()> {
     let tempdir = tempdir.path().join("{{cookiecutter.repo_name}}");
     fs::create_dir(&tempdir)?;
 
-    assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
-        .current_dir(&tempdir)
-        .args(STDIN_BASE_OPTIONS)
-        .args(["--extend-per-file-ignores", "generated.py:Q"]), @r"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-    All checks passed!
+    insta::with_settings!({filters => vec![(r"\\", "/")]}, {
+        assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+            .current_dir(&tempdir)
+            .args(STDIN_BASE_OPTIONS)
+            .args(["--extend-per-file-ignores", "generated.py:Q"]), @r"
+		success: true
+		exit_code: 0
+		----- stdout -----
+		All checks passed!
 
-    ----- stderr -----
-    warning: No Python files found under the given path(s)
-    ");
+		----- stderr -----
+		warning: No Python files found under the given path(s)
+		");
+    });
 
     Ok(())
 }

--- a/crates/ruff/tests/lint.rs
+++ b/crates/ruff/tests/lint.rs
@@ -2767,17 +2767,15 @@ fn cookiecutter_globbing_no_project_root() -> Result<()> {
     assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
         .current_dir(&tempdir)
         .args(STDIN_BASE_OPTIONS)
-        .args(["--extend-per-file-ignores", "generated.py:Q"]), @r#"
-    success: false
-    exit_code: 2
+        .args(["--extend-per-file-ignores", "generated.py:Q"]), @r"
+    success: true
+    exit_code: 0
     ----- stdout -----
+    All checks passed!
 
     ----- stderr -----
-    [crates/ruff_linter/src/settings/types.rs:308:21] fs::normalize_path(path) = "/tmp/.tmpEibace/{{cookiecutter.repo_name}}/generated.py"
-    ruff failed
-      Cause: invalid glob "/tmp/.tmpEibace/{{cookiecutter.repo_name}}/generated.py"
-      Cause: error parsing glob '/tmp/.tmpEibace/{{cookiecutter.repo_name}}/generated.py': nested alternate groups are not allowed
-    "#);
+    warning: No Python files found under the given path(s)
+    ");
 
     Ok(())
 }

--- a/crates/ruff/tests/lint.rs
+++ b/crates/ruff/tests/lint.rs
@@ -2722,10 +2722,7 @@ fn cookiecutter_globbing() -> Result<()> {
     // F811 example from the docs to ensure the glob still works
     let maintest = tests.join("maintest.py");
     fs::write(maintest, "import foo\nimport bar\nimport foo")?;
-    insta::with_settings!({
-        filters => vec![(tempdir_filter(&tempdir).as_str(), "[TMP]/"), (r"\\", "/")]
-    }, {
-        assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+    assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
             .args(STDIN_BASE_OPTIONS)
             .arg("--select=F811")
             .current_dir(tempdir.path()), @r"
@@ -2736,15 +2733,11 @@ fn cookiecutter_globbing() -> Result<()> {
 
         ----- stderr -----
         ");
-    });
 
     // after removing the config file with the ignore, F811 applies, so the glob worked above
     fs::remove_file(cookiecutter_toml)?;
 
-    insta::with_settings!({
-        filters => vec![(tempdir_filter(&tempdir).as_str(), "[TMP]/"), (r"\\", "/")]
-    }, {
-        assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+    assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
             .args(STDIN_BASE_OPTIONS)
             .arg("--select=F811")
             .current_dir(tempdir.path()), @r"
@@ -2756,8 +2749,7 @@ fn cookiecutter_globbing() -> Result<()> {
 		[*] 1 fixable with the `--fix` option.
 
 		----- stderr -----
-		");
-    });
+	");
 
     Ok(())
 }

--- a/crates/ruff/tests/lint.rs
+++ b/crates/ruff/tests/lint.rs
@@ -2754,10 +2754,7 @@ fn cookiecutter_globbing() -> Result<()> {
     Ok(())
 }
 
-/// Like the test above but exercises the non-absolute path case. I think this will be much more
-/// rare in practice but still worth considering. This is adapted from
-/// `extend_per_file_ignores_stdin`. I think reading from stdin might be one of the only ways to
-/// trigger the case where `project_root` is `None` when the globs are being loaded.
+/// Like the test above but exercises the non-absolute path case in `PerFile::new`
 #[test]
 fn cookiecutter_globbing_no_project_root() -> Result<()> {
     let tempdir = TempDir::new()?;

--- a/crates/ruff/tests/lint.rs
+++ b/crates/ruff/tests/lint.rs
@@ -2711,12 +2711,7 @@ fn cookiecutter_globbing() -> Result<()> {
     // The absolute path of the glob contains the glob metacharacters `{{` and `}}` even though the
     // user's glob does not.
     let tempdir = TempDir::new()?;
-    // add an extra layer here to prevent the regex escapes on `{` from conflicting with the tempdir
-    // filter for insta
-    let cookiecutter = tempdir
-        .path()
-        .join("tmp")
-        .join("{{cookiecutter.repo_name}}");
+    let cookiecutter = tempdir.path().join("{{cookiecutter.repo_name}}");
     let cookiecutter_toml = cookiecutter.join("pyproject.toml");
     let tests = cookiecutter.join("tests");
     fs::create_dir_all(&tests)?;
@@ -2745,7 +2740,7 @@ fn cookiecutter_globbing() -> Result<()> {
         All checks passed!
 
         ----- stderr -----
-        warning: Error parsing original glob: `"[TMP]/tmp/{{cookiecutter.repo_name}}/tests/*"`, trying with escaped braces: `"[TMP]/tmp/[{][{]cookiecutter.repo_name[}][}]/tests/*"`
+        warning: Error parsing original glob: `"[TMP]/{{cookiecutter.repo_name}}/tests/*"`, trying with escaped braces: `"[TMP]/[{][{]cookiecutter.repo_name[}][}]/tests/*"`
         "#);
     });
 
@@ -2757,15 +2752,15 @@ fn cookiecutter_globbing() -> Result<()> {
             .args(STDIN_BASE_OPTIONS)
             .arg("--select=F811")
             .current_dir(tempdir.path()), @r"
-        success: false
-        exit_code: 1
-        ----- stdout -----
-        tmp/{{cookiecutter.repo_name}}/tests/maintest.py:3:8: F811 [*] Redefinition of unused `foo` from line 1
-        Found 1 error.
-        [*] 1 fixable with the `--fix` option.
+		success: false
+		exit_code: 1
+		----- stdout -----
+		{{cookiecutter.repo_name}}/tests/maintest.py:3:8: F811 [*] Redefinition of unused `foo` from line 1
+		Found 1 error.
+		[*] 1 fixable with the `--fix` option.
 
-        ----- stderr -----
-        ");
+		----- stderr -----
+		");
     });
 
     Ok(())

--- a/crates/ruff/tests/lint.rs
+++ b/crates/ruff/tests/lint.rs
@@ -2722,14 +2722,9 @@ fn cookiecutter_globbing() -> Result<()> {
     // F811 example from the docs to ensure the glob still works
     let maintest = tests.join("maintest.py");
     fs::write(maintest, "import foo\nimport bar\nimport foo")?;
-
-    let tmp_filter = tempdir_filter(&tempdir);
-    let filters = vec![
-        (tmp_filter.as_str(), "[TMP]/"),
-        (r#"\\(\w\w|\s|\.|")"#, "/$1"),
-    ];
-
-    insta::with_settings!({filters => filters.clone()}, {
+    insta::with_settings!({
+        filters => vec![(tempdir_filter(&tempdir).as_str(), "[TMP]/"), (r"\\", "/")]
+    }, {
         assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
             .args(STDIN_BASE_OPTIONS)
             .arg("--select=F811")
@@ -2747,7 +2742,9 @@ fn cookiecutter_globbing() -> Result<()> {
     // after removing the config file with the ignore, F811 applies, so the glob worked above
     fs::remove_file(cookiecutter_toml)?;
 
-    insta::with_settings!({filters => filters}, {
+    insta::with_settings!({
+        filters => vec![(tempdir_filter(&tempdir).as_str(), "[TMP]/"), (r"\\", "/")]
+    }, {
         assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
             .args(STDIN_BASE_OPTIONS)
             .arg("--select=F811")

--- a/crates/ruff/tests/lint.rs
+++ b/crates/ruff/tests/lint.rs
@@ -2711,7 +2711,12 @@ fn cookiecutter_globbing() -> Result<()> {
     // The absolute path of the glob contains the glob metacharacters `{{` and `}}` even though the
     // user's glob does not.
     let tempdir = TempDir::new()?;
-    let cookiecutter = tempdir.path().join("{{cookiecutter.repo_name}}");
+    // add an extra layer here to prevent the regex escapes on `{` from conflicting with the tempdir
+    // filter for insta
+    let cookiecutter = tempdir
+        .path()
+        .join("tmp")
+        .join("{{cookiecutter.repo_name}}");
     let cookiecutter_toml = cookiecutter.join("pyproject.toml");
     let tests = cookiecutter.join("tests");
     fs::create_dir_all(&tests)?;
@@ -2740,7 +2745,7 @@ fn cookiecutter_globbing() -> Result<()> {
         All checks passed!
 
         ----- stderr -----
-        warning: Error parsing original glob: `"[TMP]/{{cookiecutter.repo_name}}/tests/*"`, trying with escaped braces: `"[TMP]/[{][{]cookiecutter.repo_name[}][}]/tests/*"`
+        warning: Error parsing original glob: `"[TMP]/tmp/{{cookiecutter.repo_name}}/tests/*"`, trying with escaped braces: `"[TMP]/tmp/[{][{]cookiecutter.repo_name[}][}]/tests/*"`
         "#);
     });
 
@@ -2752,15 +2757,15 @@ fn cookiecutter_globbing() -> Result<()> {
             .args(STDIN_BASE_OPTIONS)
             .arg("--select=F811")
             .current_dir(tempdir.path()), @r"
-		success: false
-		exit_code: 1
-		----- stdout -----
-		{{cookiecutter.repo_name}}/tests/maintest.py:3:8: F811 [*] Redefinition of unused `foo` from line 1
-		Found 1 error.
-		[*] 1 fixable with the `--fix` option.
+        success: false
+        exit_code: 1
+        ----- stdout -----
+        tmp/{{cookiecutter.repo_name}}/tests/maintest.py:3:8: F811 [*] Redefinition of unused `foo` from line 1
+        Found 1 error.
+        [*] 1 fixable with the `--fix` option.
 
-		----- stderr -----
-		");
+        ----- stderr -----
+        ");
     });
 
     Ok(())

--- a/crates/ruff_linter/src/settings/mod.rs
+++ b/crates/ruff_linter/src/settings/mod.rs
@@ -2,7 +2,6 @@
 //! command-line options. Structure is optimized for internal usage, as opposed
 //! to external visibility or parsing.
 
-use path_absolutize::path_dedot;
 use regex::Regex;
 use rustc_hash::FxHashSet;
 use std::fmt::{Display, Formatter};
@@ -24,7 +23,7 @@ use crate::rules::{
     pep8_naming, pycodestyle, pydoclint, pydocstyle, pyflakes, pylint, pyupgrade, ruff,
 };
 use crate::settings::types::{CompiledPerFileIgnoreList, ExtensionMapping, FilePatternSet};
-use crate::{codes, RuleSelector};
+use crate::{codes, fs, RuleSelector};
 
 use super::line_width::IndentWidth;
 
@@ -414,7 +413,7 @@ impl LinterSettings {
             per_file_ignores: CompiledPerFileIgnoreList::default(),
             fix_safety: FixSafetyTable::default(),
 
-            src: vec![path_dedot::CWD.clone(), path_dedot::CWD.join("src")],
+            src: vec![fs::get_cwd().to_path_buf(), fs::get_cwd().join("src")],
             // Needs duplicating
             tab_size: IndentWidth::default(),
             line_length: LineLength::default(),
@@ -474,6 +473,6 @@ impl LinterSettings {
 
 impl Default for LinterSettings {
     fn default() -> Self {
-        Self::new(path_dedot::CWD.as_path())
+        Self::new(fs::get_cwd())
     }
 }

--- a/crates/ruff_linter/src/settings/types.rs
+++ b/crates/ruff_linter/src/settings/types.rs
@@ -8,7 +8,6 @@ use std::string::ToString;
 use anyhow::{bail, Context, Result};
 use globset::{Glob, GlobMatcher, GlobSet, GlobSetBuilder};
 use log::debug;
-use path_absolutize::path_dedot;
 use pep440_rs::{VersionSpecifier, VersionSpecifiers};
 use rustc_hash::FxHashMap;
 use serde::{de, Deserialize, Deserializer, Serialize};

--- a/crates/ruff_linter/src/settings/types.rs
+++ b/crates/ruff_linter/src/settings/types.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::string::ToString;
 
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use globset::{Glob, GlobMatcher, GlobSet, GlobSetBuilder};
 use log::debug;
 use pep440_rs::{VersionSpecifier, VersionSpecifiers};
@@ -305,7 +305,7 @@ impl<T> PerFile<T> {
                 let escaped = globset::escape(&project_root.to_string_lossy());
                 fs::normalize_path_to(path, escaped)
             }
-            None => fs::normalize_path(path),
+            None => dbg!(fs::normalize_path(path)),
         };
 
         Self {
@@ -660,11 +660,14 @@ impl<T> CompiledPerFileList<T> {
             .into_iter()
             .map(|per_file_ignore| {
                 // Construct absolute path matcher.
-                let absolute_matcher =
-                    Glob::new(&per_file_ignore.absolute.to_string_lossy())?.compile_matcher();
+                let absolute_matcher = Glob::new(&per_file_ignore.absolute.to_string_lossy())
+                    .with_context(|| format!("invalid glob {:?}", per_file_ignore.absolute))?
+                    .compile_matcher();
 
                 // Construct basename matcher.
-                let basename_matcher = Glob::new(&per_file_ignore.basename)?.compile_matcher();
+                let basename_matcher = Glob::new(&per_file_ignore.basename)
+                    .with_context(|| format!("invalid glob {:?}", per_file_ignore.basename))?
+                    .compile_matcher();
 
                 Ok(CompiledPerFile::new(
                     absolute_matcher,

--- a/crates/ruff_linter/src/settings/types.rs
+++ b/crates/ruff_linter/src/settings/types.rs
@@ -236,7 +236,7 @@ impl FromStr for FilePattern {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(Self::User(
             s.to_string(),
-            GlobPath::normalize(s, &*path_dedot::CWD),
+            GlobPath::normalize(s, fs::get_cwd()),
         ))
     }
 }
@@ -332,7 +332,7 @@ impl<T> PerFile<T> {
             pattern.drain(..1);
         }
 
-        let project_root = project_root.unwrap_or(&path_dedot::CWD);
+        let project_root = project_root.unwrap_or(fs::get_cwd());
 
         Self {
             absolute: GlobPath::normalize(&pattern, project_root),

--- a/crates/ruff_linter/src/settings/types.rs
+++ b/crates/ruff_linter/src/settings/types.rs
@@ -656,9 +656,11 @@ where
 pub fn try_glob_new(s: &str) -> Result<Glob> {
     match Glob::new(s) {
         Err(e) if *e.kind() == globset::ErrorKind::NestedAlternates => {
-            log::warn!("Error parsing original glob: `{s:?}`, trying with escaped braces (`{{}}`)");
-            let s = s.replace("{{", "[{][{]").replace("}}", "[}][}]");
-            Ok(Glob::new(&s)?)
+            let new = s.replace("{{", "[{][{]").replace("}}", "[}][}]");
+            log::warn!(
+                "Error parsing original glob: `{s:?}`, trying with escaped braces: `{new:?}`"
+            );
+            Ok(Glob::new(&new)?)
         }
         glob => Ok(glob?),
     }

--- a/crates/ruff_linter/src/settings/types.rs
+++ b/crates/ruff_linter/src/settings/types.rs
@@ -169,15 +169,15 @@ impl FilePattern {
     pub fn add_to(self, builder: &mut GlobSetBuilder) -> Result<()> {
         match self {
             FilePattern::Builtin(pattern) => {
-                builder.add(Glob::from_str(pattern)?);
+                builder.add(try_glob_new(pattern)?);
             }
             FilePattern::User(pattern, absolute) => {
                 // Add the absolute path.
-                builder.add(Glob::new(&absolute.to_string_lossy())?);
+                builder.add(try_glob_new(&absolute.to_string_lossy())?);
 
                 // Add basename path.
                 if !pattern.contains(std::path::MAIN_SEPARATOR) {
-                    builder.add(Glob::new(&pattern)?);
+                    builder.add(try_glob_new(&pattern)?);
                 }
             }
         }
@@ -653,7 +653,7 @@ where
 /// For example, the `cookiecutter` package generates paths like `{{cookiecutter.repo_name}}`, which
 /// look like nested glob alternate expressions like `{foo,bar}`. The nested version is not
 /// supported by `globset`, causing an error.
-fn try_glob_new(s: &str) -> Result<Glob> {
+pub fn try_glob_new(s: &str) -> Result<Glob> {
     match Glob::new(s) {
         Err(e) if *e.kind() == globset::ErrorKind::NestedAlternates => {
             log::warn!("Error parsing original glob: `{s:?}`, trying with escaped braces (`{{}}`)");

--- a/crates/ruff_linter/src/settings/types.rs
+++ b/crates/ruff_linter/src/settings/types.rs
@@ -204,7 +204,8 @@ impl FromStr for FilePattern {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let pattern = s.to_string();
-        let absolute = fs::normalize_path(&pattern);
+        let cwd = globset::escape(&path_dedot::CWD.to_string_lossy());
+        let absolute = fs::normalize_path_to(&pattern, cwd);
         Ok(Self::User(pattern, absolute))
     }
 }

--- a/crates/ruff_linter/src/settings/types.rs
+++ b/crates/ruff_linter/src/settings/types.rs
@@ -169,15 +169,15 @@ impl FilePattern {
     pub fn add_to(self, builder: &mut GlobSetBuilder) -> Result<()> {
         match self {
             FilePattern::Builtin(pattern) => {
-                builder.add(try_glob_new(pattern)?);
+                builder.add(Glob::from_str(pattern)?);
             }
             FilePattern::User(pattern, absolute) => {
                 // Add the absolute path.
-                builder.add(try_glob_new(&absolute.to_string_lossy())?);
+                builder.add(Glob::new(&absolute.to_string_lossy())?);
 
                 // Add basename path.
                 if !pattern.contains(std::path::MAIN_SEPARATOR) {
-                    builder.add(try_glob_new(&pattern)?);
+                    builder.add(Glob::new(&pattern)?);
                 }
             }
         }
@@ -653,7 +653,7 @@ where
 /// For example, the `cookiecutter` package generates paths like `{{cookiecutter.repo_name}}`, which
 /// look like nested glob alternate expressions like `{foo,bar}`. The nested version is not
 /// supported by `globset`, causing an error.
-pub fn try_glob_new(s: &str) -> Result<Glob> {
+fn try_glob_new(s: &str) -> Result<Glob> {
     match Glob::new(s) {
         Err(e) if *e.kind() == globset::ErrorKind::NestedAlternates => {
             let new = s.replace("{{", "[{][{]").replace("}}", "[}][}]");

--- a/crates/ruff_server/src/session/index/ruff_settings.rs
+++ b/crates/ruff_server/src/session/index/ruff_settings.rs
@@ -356,7 +356,10 @@ impl ConfigurationTransformer for EditorConfigurationTransformer<'_> {
                 exclude
                     .into_iter()
                     .map(|pattern| {
-                        let absolute = normalize_path_to(&pattern, project_root);
+                        let absolute = normalize_path_to(
+                            &pattern,
+                            globset::escape(&project_root.to_string_lossy()),
+                        );
                         FilePattern::User(pattern, absolute)
                     })
                     .collect()

--- a/crates/ruff_server/src/session/index/ruff_settings.rs
+++ b/crates/ruff_server/src/session/index/ruff_settings.rs
@@ -7,9 +7,8 @@ use std::sync::Arc;
 use anyhow::Context;
 use ignore::{WalkBuilder, WalkState};
 
-use ruff_linter::{
-    fs::normalize_path_to, settings::types::FilePattern, settings::types::PreviewMode,
-};
+use ruff_linter::settings::types::GlobPath;
+use ruff_linter::{settings::types::FilePattern, settings::types::PreviewMode};
 use ruff_workspace::resolver::match_exclusion;
 use ruff_workspace::Settings;
 use ruff_workspace::{
@@ -356,10 +355,7 @@ impl ConfigurationTransformer for EditorConfigurationTransformer<'_> {
                 exclude
                     .into_iter()
                     .map(|pattern| {
-                        let absolute = normalize_path_to(
-                            &pattern,
-                            globset::escape(&project_root.to_string_lossy()),
-                        );
+                        let absolute = GlobPath::normalize(&pattern, project_root);
                         FilePattern::User(pattern, absolute)
                     })
                     .collect()

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -476,7 +476,10 @@ impl Configuration {
                 paths
                     .into_iter()
                     .map(|pattern| {
-                        let absolute = fs::normalize_path_to(&pattern, project_root);
+                        let absolute = fs::normalize_path_to(
+                            &pattern,
+                            globset::escape(&project_root.to_string_lossy()),
+                        );
                         FilePattern::User(pattern, absolute)
                     })
                     .collect()
@@ -495,7 +498,10 @@ impl Configuration {
                     paths
                         .into_iter()
                         .map(|pattern| {
-                            let absolute = fs::normalize_path_to(&pattern, project_root);
+                            let absolute = fs::normalize_path_to(
+                                &pattern,
+                                globset::escape(&project_root.to_string_lossy()),
+                            );
                             FilePattern::User(pattern, absolute)
                         })
                         .collect()
@@ -507,7 +513,10 @@ impl Configuration {
                     paths
                         .into_iter()
                         .map(|pattern| {
-                            let absolute = fs::normalize_path_to(&pattern, project_root);
+                            let absolute = fs::normalize_path_to(
+                                &pattern,
+                                globset::escape(&project_root.to_string_lossy()),
+                            );
                             FilePattern::User(pattern, absolute)
                         })
                         .collect()
@@ -517,7 +526,10 @@ impl Configuration {
                 paths
                     .into_iter()
                     .map(|pattern| {
-                        let absolute = fs::normalize_path_to(&pattern, project_root);
+                        let absolute = fs::normalize_path_to(
+                            &pattern,
+                            globset::escape(&project_root.to_string_lossy()),
+                        );
                         FilePattern::User(pattern, absolute)
                     })
                     .collect()
@@ -700,7 +712,10 @@ impl LintConfiguration {
                 paths
                     .into_iter()
                     .map(|pattern| {
-                        let absolute = fs::normalize_path_to(&pattern, project_root);
+                        let absolute = fs::normalize_path_to(
+                            &pattern,
+                            globset::escape(&project_root.to_string_lossy()),
+                        );
                         FilePattern::User(pattern, absolute)
                     })
                     .collect()
@@ -1203,7 +1218,10 @@ impl FormatConfiguration {
                 paths
                     .into_iter()
                     .map(|pattern| {
-                        let absolute = fs::normalize_path_to(&pattern, project_root);
+                        let absolute = fs::normalize_path_to(
+                            &pattern,
+                            globset::escape(&project_root.to_string_lossy()),
+                        );
                         FilePattern::User(pattern, absolute)
                     })
                     .collect()
@@ -1267,7 +1285,10 @@ impl AnalyzeConfiguration {
                 paths
                     .into_iter()
                     .map(|pattern| {
-                        let absolute = fs::normalize_path_to(&pattern, project_root);
+                        let absolute = fs::normalize_path_to(
+                            &pattern,
+                            globset::escape(&project_root.to_string_lossy()),
+                        );
                         FilePattern::User(pattern, absolute)
                     })
                     .collect()

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -30,7 +30,7 @@ use ruff_linter::settings::fix_safety_table::FixSafetyTable;
 use ruff_linter::settings::rule_table::RuleTable;
 use ruff_linter::settings::types::{
     CompiledPerFileIgnoreList, CompiledPerFileTargetVersionList, ExtensionMapping, FilePattern,
-    FilePatternSet, OutputFormat, PerFileIgnore, PerFileTargetVersion, PreviewMode,
+    FilePatternSet, GlobPath, OutputFormat, PerFileIgnore, PerFileTargetVersion, PreviewMode,
     RequiredVersion, UnsafeFixes,
 };
 use ruff_linter::settings::{LinterSettings, DEFAULT_SELECTORS, DUMMY_VARIABLE_RGX, TASK_TAGS};
@@ -476,10 +476,7 @@ impl Configuration {
                 paths
                     .into_iter()
                     .map(|pattern| {
-                        let absolute = fs::normalize_path_to(
-                            &pattern,
-                            globset::escape(&project_root.to_string_lossy()),
-                        );
+                        let absolute = GlobPath::normalize(&pattern, project_root);
                         FilePattern::User(pattern, absolute)
                     })
                     .collect()
@@ -498,10 +495,7 @@ impl Configuration {
                     paths
                         .into_iter()
                         .map(|pattern| {
-                            let absolute = fs::normalize_path_to(
-                                &pattern,
-                                globset::escape(&project_root.to_string_lossy()),
-                            );
+                            let absolute = GlobPath::normalize(&pattern, project_root);
                             FilePattern::User(pattern, absolute)
                         })
                         .collect()
@@ -513,10 +507,7 @@ impl Configuration {
                     paths
                         .into_iter()
                         .map(|pattern| {
-                            let absolute = fs::normalize_path_to(
-                                &pattern,
-                                globset::escape(&project_root.to_string_lossy()),
-                            );
+                            let absolute = GlobPath::normalize(&pattern, project_root);
                             FilePattern::User(pattern, absolute)
                         })
                         .collect()
@@ -526,10 +517,7 @@ impl Configuration {
                 paths
                     .into_iter()
                     .map(|pattern| {
-                        let absolute = fs::normalize_path_to(
-                            &pattern,
-                            globset::escape(&project_root.to_string_lossy()),
-                        );
+                        let absolute = GlobPath::normalize(&pattern, project_root);
                         FilePattern::User(pattern, absolute)
                     })
                     .collect()
@@ -712,10 +700,7 @@ impl LintConfiguration {
                 paths
                     .into_iter()
                     .map(|pattern| {
-                        let absolute = fs::normalize_path_to(
-                            &pattern,
-                            globset::escape(&project_root.to_string_lossy()),
-                        );
+                        let absolute = GlobPath::normalize(&pattern, project_root);
                         FilePattern::User(pattern, absolute)
                     })
                     .collect()
@@ -1218,10 +1203,7 @@ impl FormatConfiguration {
                 paths
                     .into_iter()
                     .map(|pattern| {
-                        let absolute = fs::normalize_path_to(
-                            &pattern,
-                            globset::escape(&project_root.to_string_lossy()),
-                        );
+                        let absolute = GlobPath::normalize(&pattern, project_root);
                         FilePattern::User(pattern, absolute)
                     })
                     .collect()
@@ -1285,10 +1267,7 @@ impl AnalyzeConfiguration {
                 paths
                     .into_iter()
                     .map(|pattern| {
-                        let absolute = fs::normalize_path_to(
-                            &pattern,
-                            globset::escape(&project_root.to_string_lossy()),
-                        );
+                        let absolute = GlobPath::normalize(&pattern, project_root);
                         FilePattern::User(pattern, absolute)
                     })
                     .collect()

--- a/crates/ruff_workspace/src/resolver.rs
+++ b/crates/ruff_workspace/src/resolver.rs
@@ -877,7 +877,7 @@ mod tests {
     use path_absolutize::Absolutize;
     use tempfile::TempDir;
 
-    use ruff_linter::settings::types::FilePattern;
+    use ruff_linter::settings::types::{FilePattern, GlobPath};
 
     use crate::configuration::Configuration;
     use crate::pyproject::find_settings_toml;
@@ -972,13 +972,8 @@ mod tests {
         let project_root = Path::new("/tmp/");
 
         let path = Path::new("foo").absolutize_from(project_root).unwrap();
-        let exclude = FilePattern::User(
-            "foo".to_string(),
-            Path::new("foo")
-                .absolutize_from(project_root)
-                .unwrap()
-                .to_path_buf(),
-        );
+        let exclude =
+            FilePattern::User("foo".to_string(), GlobPath::normalize("foo", project_root));
         let file_path = &path;
         let file_basename = path.file_name().unwrap();
         assert!(match_exclusion(
@@ -988,13 +983,8 @@ mod tests {
         ));
 
         let path = Path::new("foo/bar").absolutize_from(project_root).unwrap();
-        let exclude = FilePattern::User(
-            "bar".to_string(),
-            Path::new("bar")
-                .absolutize_from(project_root)
-                .unwrap()
-                .to_path_buf(),
-        );
+        let exclude =
+            FilePattern::User("bar".to_string(), GlobPath::normalize("bar", project_root));
         let file_path = &path;
         let file_basename = path.file_name().unwrap();
         assert!(match_exclusion(
@@ -1008,10 +998,7 @@ mod tests {
             .unwrap();
         let exclude = FilePattern::User(
             "baz.py".to_string(),
-            Path::new("baz.py")
-                .absolutize_from(project_root)
-                .unwrap()
-                .to_path_buf(),
+            GlobPath::normalize("baz.py", project_root),
         );
         let file_path = &path;
         let file_basename = path.file_name().unwrap();
@@ -1024,10 +1011,7 @@ mod tests {
         let path = Path::new("foo/bar").absolutize_from(project_root).unwrap();
         let exclude = FilePattern::User(
             "foo/bar".to_string(),
-            Path::new("foo/bar")
-                .absolutize_from(project_root)
-                .unwrap()
-                .to_path_buf(),
+            GlobPath::normalize("foo/bar", project_root),
         );
         let file_path = &path;
         let file_basename = path.file_name().unwrap();
@@ -1042,10 +1026,7 @@ mod tests {
             .unwrap();
         let exclude = FilePattern::User(
             "foo/bar/baz.py".to_string(),
-            Path::new("foo/bar/baz.py")
-                .absolutize_from(project_root)
-                .unwrap()
-                .to_path_buf(),
+            GlobPath::normalize("foo/bar/baz.py", project_root),
         );
         let file_path = &path;
         let file_basename = path.file_name().unwrap();
@@ -1060,10 +1041,7 @@ mod tests {
             .unwrap();
         let exclude = FilePattern::User(
             "foo/bar/*.py".to_string(),
-            Path::new("foo/bar/*.py")
-                .absolutize_from(project_root)
-                .unwrap()
-                .to_path_buf(),
+            GlobPath::normalize("foo/bar/*.py", project_root),
         );
         let file_path = &path;
         let file_basename = path.file_name().unwrap();
@@ -1076,13 +1054,8 @@ mod tests {
         let path = Path::new("foo/bar/baz.py")
             .absolutize_from(project_root)
             .unwrap();
-        let exclude = FilePattern::User(
-            "baz".to_string(),
-            Path::new("baz")
-                .absolutize_from(project_root)
-                .unwrap()
-                .to_path_buf(),
-        );
+        let exclude =
+            FilePattern::User("baz".to_string(), GlobPath::normalize("baz", project_root));
         let file_path = &path;
         let file_basename = path.file_name().unwrap();
         assert!(!match_exclusion(


### PR DESCRIPTION
## Summary

Fixes #9381. This PR fixes errors like 

```
Cause: error parsing glob '/Users/me/project/{{cookiecutter.project_dirname}}/__pycache__': nested alternate groups are not allowed
```

caused by glob special characters in filenames like `{{cookiecutter.project_dirname}}`. When the user is matching that directory exactly, they can use the workaround given by https://github.com/astral-sh/ruff/issues/7959#issuecomment-1764751734, but that doesn't work for a nested config file with relative paths. For example, the directory tree in the reproduction repo linked [here](https://github.com/astral-sh/ruff/issues/9381#issuecomment-2677696408):

```
.
├── README.md
├── hello.py
├── pyproject.toml
├── uv.lock
└── {{cookiecutter.repo_name}}
    ├── main.py
    ├── pyproject.toml
    └── tests
        └── maintest.py
```

where the inner `pyproject.toml` contains a relative glob:

```toml
[tool.ruff.lint.per-file-ignores]
"tests/*" = ["F811"]
```

## Test Plan

A new CLI test in both the linter and formatter. The formatter test may not be necessary because I didn't have to modify any additional code to pass it, but the original report mentioned both `check` and `format`, so I wanted to be sure both were fixed.
