### PR TITLE
[red-knot] treat annotated assignments without RHS in stubs as bindings

### DIFF
--- a/crates/red_knot_project/tests/check.rs
+++ b/crates/red_knot_project/tests/check.rs
@@ -283,4 +283,6 @@ const KNOWN_FAILURES: &[(&str, bool, bool)] = &[
     // related to circular references in f-string annotations (invalid syntax)
     ("crates/ruff_linter/resources/test/fixtures/pyflakes/F821_15.py", true, true),
     ("crates/ruff_linter/resources/test/fixtures/pyflakes/F821_14.py", false, true),
+    // related to circular references in stub type annotations (salsa cycle panic):
+    ("crates/ruff_linter/resources/test/fixtures/pycodestyle/E501_4.py", false, true),
 ];

--- a/crates/red_knot_project/tests/check.rs
+++ b/crates/red_knot_project/tests/check.rs
@@ -285,4 +285,7 @@ const KNOWN_FAILURES: &[(&str, bool, bool)] = &[
     ("crates/ruff_linter/resources/test/fixtures/pyflakes/F821_14.py", false, true),
     // related to circular references in stub type annotations (salsa cycle panic):
     ("crates/ruff_linter/resources/test/fixtures/pycodestyle/E501_4.py", false, true),
+    ("crates/ruff_linter/resources/test/fixtures/pyflakes/F401_0.py", false, true),
+    ("crates/ruff_linter/resources/test/fixtures/pyflakes/F401_12.py", false, true),
+    ("crates/ruff_linter/resources/test/fixtures/pyflakes/F401_14.py", false, true),
 ];

--- a/crates/red_knot_python_semantic/resources/mdtest/attributes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/attributes.md
@@ -577,43 +577,6 @@ class Subclass(C):
 reveal_type(Subclass.pure_class_variable1)  # revealed: str
 ```
 
-#### Declarations in stubs
-
-Unlike regular python modules, stub files often declare class variables without initializing them.
-But from the perspective of the type checker, we should treat something like `symbol: type` same as
-`symbol: type = ...`.
-
-`b.pyi`:
-
-```pyi
-from typing import ClassVar
-
-class C:
-    a_classvar: ClassVar[str]
-    instance_var: int
-```
-
-```py
-from typing import ClassVar, Literal
-
-from b import C
-
-reveal_type(C.a_classvar)  # revealed: str
-
-class Subclass(C):
-    declared: int
-    declared_and_bound: int = 42
-
-s_inst = Subclass()
-
-reveal_type(s_inst.instance_var)  # revealed: int
-
-# TODO: this should be an error showing possibly unbound.
-reveal_type(s_inst.declared)  # revealed: int
-
-reveal_type(s_inst.declared_and_bound)  # revealed: int
-```
-
 #### Variable only mentioned in a class method
 
 We also consider a class variable to be a pure class variable if it is only mentioned in a class
@@ -1034,6 +997,8 @@ reveal_type(Foo.__class__)  # revealed: Literal[type]
 
 ## Module attributes
 
+### Regular modules
+
 `mod.py`:
 
 ```py
@@ -1066,6 +1031,34 @@ class IntIterable:
 # error: [invalid-assignment] "Object of type `int` is not assignable to attribute `global_symbol` of type `str`"
 for mod.global_symbol in IntIterable():
     pass
+```
+
+### Declarations in stubs
+
+Unlike regular python modules, stub files often declare module-global and class variables without
+initializing them. But from the perspective of the type checker, we should treat something like
+`symbol: type` same as `symbol: type = ...`.
+
+`b.pyi`:
+
+```pyi
+from typing import Literal
+
+CONSTANT: Literal[42]
+
+# No error here, even though the variable is not initialized.
+uses_constant: int = CONSTANT
+
+class C:
+    instance_var: int
+```
+
+```py
+from typing import Literal
+
+from b import CONSTANT
+
+reveal_type(CONSTANT)  # revealed: Literal[42]
 ```
 
 ## Nested attributes

--- a/crates/red_knot_python_semantic/resources/mdtest/attributes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/attributes.md
@@ -577,6 +577,43 @@ class Subclass(C):
 reveal_type(Subclass.pure_class_variable1)  # revealed: str
 ```
 
+#### Declarations in stubs
+
+Unlike regular python modules, stub files often declare class variables without initializing them.
+But from the perspective of the type checker, we should treat something like `symbol: type` same as
+`symbol: type = ...`.
+
+`b.pyi`:
+
+```pyi
+from typing import ClassVar
+
+class C:
+    a_classvar: ClassVar[str]
+    instance_var: int
+```
+
+```py
+from typing import ClassVar, Literal
+
+from b import C
+
+reveal_type(C.a_classvar)  # revealed: str
+
+class Subclass(C):
+    declared: int
+    declared_and_bound: int = 42
+
+s_inst = Subclass()
+
+reveal_type(s_inst.instance_var)  # revealed: int
+
+# TODO: this should be an error showing possibly unbound.
+reveal_type(s_inst.declared)  # revealed: int
+
+reveal_type(s_inst.declared_and_bound)  # revealed: int
+```
+
 #### Variable only mentioned in a class method
 
 We also consider a class variable to be a pure class variable if it is only mentioned in a class

--- a/crates/red_knot_python_semantic/resources/mdtest/attributes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/attributes.md
@@ -997,8 +997,6 @@ reveal_type(Foo.__class__)  # revealed: Literal[type]
 
 ## Module attributes
 
-### Regular modules
-
 `mod.py`:
 
 ```py
@@ -1031,34 +1029,6 @@ class IntIterable:
 # error: [invalid-assignment] "Object of type `int` is not assignable to attribute `global_symbol` of type `str`"
 for mod.global_symbol in IntIterable():
     pass
-```
-
-### Declarations in stubs
-
-Unlike regular python modules, stub files often declare module-global and class variables without
-initializing them. But from the perspective of the type checker, we should treat something like
-`symbol: type` same as `symbol: type = ...`.
-
-`b.pyi`:
-
-```pyi
-from typing import Literal
-
-CONSTANT: Literal[42]
-
-# No error here, even though the variable is not initialized.
-uses_constant: int = CONSTANT
-
-class C:
-    instance_var: int
-```
-
-```py
-from typing import Literal
-
-from b import CONSTANT
-
-reveal_type(CONSTANT)  # revealed: Literal[42]
 ```
 
 ## Nested attributes

--- a/crates/red_knot_python_semantic/resources/mdtest/stubs/class.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/stubs/class.md
@@ -18,13 +18,13 @@ reveal_type(Bar.__mro__)  # revealed: tuple[Literal[Bar], Unknown, Literal[objec
 
 ## Access to attributes declarated in stubs
 
-Unlike regular Python modules, stub files often omit the RHS in declarations, including in class
+Unlike regular Python modules, stub files often omit the right-hand side in declarations, including in class
 scope. However, from the perspective of the type checker, we have to treat them as bindings too.
 That is, `symbol: type` is the same as `symbol: type = ...`.
 
-One implication of this is that we'll always treat symbols in class scope as either
-`class or instance` or `class only` (if `ClassVar` is used). We'll never infer a pure instance
-attribute from a stub.
+One implication of this is that we'll always treat symbols in class scope as safe to be
+accessed from the class object itself. We'll never infer a "pure instance attribute" from
+a stub.
 
 `b.pyi`:
 

--- a/crates/red_knot_python_semantic/resources/mdtest/stubs/class.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/stubs/class.md
@@ -15,3 +15,44 @@ class Bar(Foo[Bar]): ...
 reveal_type(Bar)  # revealed: Literal[Bar]
 reveal_type(Bar.__mro__)  # revealed: tuple[Literal[Bar], Unknown, Literal[object]]
 ```
+
+## Acces to attributes declarated in stubs
+
+Unlike regular python modules, stub files often declare module-global and class variables without
+initializing them. But from the perspective of the type checker, we should treat something like
+`symbol: type` same as `symbol: type = ...`.
+
+`b.pyi`:
+
+```pyi
+from typing import ClassVar
+
+class C:
+    a_classvar: ClassVar[str]
+    instance_var: int
+```
+
+```py
+from typing import ClassVar, Literal
+
+from b import C
+
+reveal_type(C.a_classvar)  # revealed: str
+
+class Subclass(C):
+    unbound_classvar: ClassVar[str]
+    declared: int
+    declared_and_bound: int = 42
+
+# TODO: this should be an error showing possibly unbound.
+reveal_type(Subclass.unbound_classvar)  # revealed: str
+
+s_inst = Subclass()
+
+reveal_type(s_inst.instance_var)  # revealed: int
+
+# TODO: this should be an error showing possibly unbound.
+reveal_type(s_inst.declared)  # revealed: int
+
+reveal_type(s_inst.declared_and_bound)  # revealed: int
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/stubs/class.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/stubs/class.md
@@ -18,13 +18,12 @@ reveal_type(Bar.__mro__)  # revealed: tuple[Literal[Bar], Unknown, Literal[objec
 
 ## Access to attributes declarated in stubs
 
-Unlike regular Python modules, stub files often omit the right-hand side in declarations, including in class
-scope. However, from the perspective of the type checker, we have to treat them as bindings too.
-That is, `symbol: type` is the same as `symbol: type = ...`.
+Unlike regular Python modules, stub files often omit the right-hand side in declarations, including
+in class scope. However, from the perspective of the type checker, we have to treat them as bindings
+too. That is, `symbol: type` is the same as `symbol: type = ...`.
 
-One implication of this is that we'll always treat symbols in class scope as safe to be
-accessed from the class object itself. We'll never infer a "pure instance attribute" from
-a stub.
+One implication of this is that we'll always treat symbols in class scope as safe to be accessed
+from the class object itself. We'll never infer a "pure instance attribute" from a stub.
 
 `b.pyi`:
 

--- a/crates/red_knot_python_semantic/resources/mdtest/stubs/locals.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/stubs/locals.md
@@ -1,0 +1,17 @@
+# Declarations in stubs
+
+Unlike regular Python modules, stub files often declare module-global variables without initializing
+them. If these symbols are then used in the same stub, applying regular logic would lead to an
+undefined variable access error.
+
+However, from the perspective of the type checker, we should treat something like `symbol: type` the
+same as `symbol: type = ...`. In other words, assume these are bindings too.
+
+```pyi
+from typing import Literal
+
+CONSTANT: Literal[42]
+
+# No error here, even though the variable is not initialized.
+uses_constant: int = CONSTANT
+```

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -353,7 +353,7 @@ impl<'db> SemanticIndexBuilder<'db> {
         #[allow(unsafe_code)]
         // SAFETY: `definition_node` is guaranteed to be a child of `self.module`
         let kind = unsafe { definition_node.into_owned(self.module.clone()) };
-        let category = kind.category();
+        let category = kind.category(self.file.is_stub(self.db.upcast()));
         let is_reexported = kind.is_reexported();
         let definition = Definition::new(
             self.db,
@@ -370,7 +370,7 @@ impl<'db> SemanticIndexBuilder<'db> {
             .insert(definition_node.key(), definition);
         debug_assert_eq!(existing_definition, None);
 
-        if category.is_binding() || self.file.is_stub(self.db.upcast()) {
+        if category.is_binding() {
             self.mark_symbol_bound(symbol);
         }
         if category.is_declaration() {

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -370,7 +370,7 @@ impl<'db> SemanticIndexBuilder<'db> {
             .insert(definition_node.key(), definition);
         debug_assert_eq!(existing_definition, None);
 
-        if category.is_binding() {
+        if category.is_binding() || self.file.is_stub(self.db.upcast()) {
             self.mark_symbol_bound(symbol);
         }
         if category.is_declaration() {

--- a/crates/red_knot_python_semantic/src/semantic_index/definition.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/definition.rs
@@ -515,7 +515,7 @@ impl DefinitionKind<'_> {
         }
     }
 
-    pub(crate) fn category(&self) -> DefinitionCategory {
+    pub(crate) fn category(&self, in_stub: bool) -> DefinitionCategory {
         match self {
             // functions, classes, and imports always bind, and we consider them declarations
             DefinitionKind::Function(_)
@@ -545,7 +545,7 @@ impl DefinitionKind<'_> {
             }
             // annotated assignment is always a declaration, only a binding if there is a RHS
             DefinitionKind::AnnotatedAssignment(ann_assign) => {
-                if ann_assign.value.is_some() {
+                if in_stub || ann_assign.value.is_some() {
                     DefinitionCategory::DeclarationAndBinding
                 } else {
                     DefinitionCategory::Declaration

--- a/crates/red_knot_python_semantic/src/semantic_index/definition.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/definition.rs
@@ -543,7 +543,8 @@ impl DefinitionKind<'_> {
                     DefinitionCategory::Binding
                 }
             }
-            // annotated assignment is always a declaration, only a binding if there is a RHS
+            // Annotated assignment is always a declaration. It is also a binding if there is a RHS
+            // or if we are in a stub file. Unfortunately, it is common for stubs to omit even an `...` value placeholder.
             DefinitionKind::AnnotatedAssignment(ann_assign) => {
                 if in_stub || ann_assign.value.is_some() {
                     DefinitionCategory::DeclarationAndBinding

--- a/crates/ruff_benchmark/benches/red_knot.rs
+++ b/crates/ruff_benchmark/benches/red_knot.rs
@@ -96,13 +96,6 @@ static EXPECTED_DIAGNOSTICS: &[KeyDiagnosticFields] = &[
         Cow::Borrowed("Unused blanket `type: ignore` directive"),
         Severity::Warning,
     ),
-    (
-        DiagnosticId::lint("invalid-attribute-access"),
-        Some("/src/tomllib/__init__.py"),
-        Some(270..296),
-        Cow::Borrowed("Cannot assign to instance attribute `__module__` from the class object `Literal[TOMLDecodeError]`"),
-        Severity::Error,
-    ),
 ];
 
 fn tomllib_path(file: &TestFile) -> SystemPathBuf {


### PR DESCRIPTION
## Summary

Make a small-ish change, marking all declarations in stubs from annotated assignments as bound, even if there is no RHS. This is done by changing the implementation of `category`, that now takes whether it is in a stub context as an argument. I think this reflects logic encapsulation better then checking for stub context in downstream code, combining the category return with the stub flag.

However, current state of red knot would only reveal one behavior change: avoid a very rare (maybe even non-existent) false negative when a stub uses a global variable defined without a default value in the same stub.

With the current symbol boundness inference logic is not changed, unbound class and instance attributes do not emit diagnostics => there is no apparent difference between stubs & regular modules.

Fixes #16264 

## Test Plan

A couple of new mdtest sections.