### PR TITLE
[red-knot] Attribute access and the descriptor protocol

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/literal_string.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/literal_string.md
@@ -73,12 +73,12 @@ qux = (foo, bar)
 reveal_type(qux)  # revealed: tuple[Literal["foo"], Literal["bar"]]
 
 # TODO: Infer "LiteralString"
-reveal_type(foo.join(qux))  # revealed: @Todo(overloaded method)
+reveal_type(foo.join(qux))  # revealed: @Todo(return type of decorated function)
 
 template: LiteralString = "{}, {}"
 reveal_type(template)  # revealed: Literal["{}, {}"]
 # TODO: Infer `LiteralString`
-reveal_type(template.format(foo, bar))  # revealed: @Todo(overloaded method)
+reveal_type(template.format(foo, bar))  # revealed: @Todo(return type of decorated function)
 ```
 
 ### Assignability

--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/stdlib_typing_aliases.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/stdlib_typing_aliases.md
@@ -70,7 +70,6 @@ import typing
 
 class ListSubclass(typing.List): ...
 
-# TODO: Reflect the runtime value in the MRO here? (ListSubclass, list, typing.Generic, object)
 # revealed: tuple[Literal[ListSubclass], Literal[list], Literal[MutableSequence], Literal[Sequence], Literal[Reversible], Literal[Collection], Literal[Iterable], Literal[Container], @Todo(protocol), Literal[object]]
 reveal_type(ListSubclass.__mro__)
 

--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/stdlib_typing_aliases.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/stdlib_typing_aliases.md
@@ -70,8 +70,8 @@ import typing
 
 class ListSubclass(typing.List): ...
 
-# TODO: should have `Generic`, should not have `Unknown`
-# revealed: tuple[Literal[ListSubclass], Literal[list], Unknown, Literal[object]]
+# TODO: Reflect the runtime value in the MRO here? (ListSubclass, list, typing.Generic, object)
+# revealed: tuple[Literal[ListSubclass], Literal[list], Literal[MutableSequence], Literal[Sequence], Literal[Reversible], Literal[Collection], Literal[Iterable], Literal[Container], @Todo(protocol), Literal[object]]
 reveal_type(ListSubclass.__mro__)
 
 class DictSubclass(typing.Dict): ...

--- a/crates/red_knot_python_semantic/resources/mdtest/assignment/augmented.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/assignment/augmented.md
@@ -75,8 +75,7 @@ def _(flag: bool):
 
     f = Foo()
 
-    # TODO: We should emit an `unsupported-operator` error here, possibly with the information
-    # that `Foo.__iadd__` may be unbound as additional context.
+    # error: [unsupported-operator] "Operator `+=` is unsupported between objects of type `Foo` and `Literal["Hello, world!"]`"
     f += "Hello, world!"
 
     reveal_type(f)  # revealed: int | Unknown

--- a/crates/red_knot_python_semantic/resources/mdtest/attributes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/attributes.md
@@ -155,7 +155,9 @@ reveal_type(c_instance.declared_in_body_and_init)  # revealed: str | None
 
 reveal_type(c_instance.declared_in_body_defined_in_init)  # revealed: str | None
 
-reveal_type(c_instance.bound_in_body_declared_in_init)  # revealed: str | None
+# TODO: This should be `str | None`. Fixing this requires an overhaul of the `Symbol` API,
+# which is planned in https://github.com/astral-sh/ruff/issues/14297
+reveal_type(c_instance.bound_in_body_declared_in_init)  # revealed: Unknown | str | None
 
 reveal_type(c_instance.bound_in_body_and_init)  # revealed: Unknown | None | Literal["a"]
 ```
@@ -704,7 +706,90 @@ reveal_type(Derived().declared_in_body)  # revealed: int | None
 reveal_type(Derived().defined_in_init)  # revealed: str | None
 ```
 
+## Accessing attributes on class objects
+
+When accessing attributes on class objects, they are always looked up on the type of the class
+object first, i.e. on the meta class:
+
+```py
+from typing import Literal
+
+class Meta1:
+    attr: Literal["meta class value"] = "meta class value"
+
+class C1(metaclass=Meta1): ...
+
+reveal_type(C1.attr)  # revealed: Literal["meta class value"]
+```
+
+However, the meta class attribute only takes precedence over a class-level attribute if it is a data
+descriptor. If it is a non-data descriptor or a normal attribute, the class-level attribute is used
+instead (see the [descriptor protocol tests] for data/non-data descriptor attributes):
+
+```py
+class Meta2:
+    attr: str = "meta class value"
+
+class C2(metaclass=Meta2):
+    attr: Literal["class value"] = "class value"
+
+reveal_type(C2.attr)  # revealed: Literal["class value"]
+```
+
+If the class-level attribute is only partially defined, we union the meta class attribute with the
+class-level attribute:
+
+```py
+def _(flag: bool):
+    class Meta3:
+        attr1 = "meta class value"
+        attr2: Literal["meta class value"] = "meta class value"
+
+    class C3(metaclass=Meta3):
+        if flag:
+            attr1 = "class value"
+            # TODO: Neither mypy nor pyright show an error here, but we could consider emitting a conflicting-declaration diagnostic here.
+            attr2: Literal["class value"] = "class value"
+
+    reveal_type(C3.attr1)  # revealed: Unknown | Literal["meta class value", "class value"]
+    reveal_type(C3.attr2)  # revealed: Literal["meta class value", "class value"]
+```
+
+If the *meta class* attribute is only partially defined, we emit a `possibly-unbound-attribute`
+diagnostic:
+
+```py
+def _(flag: bool):
+    class Meta4:
+        if flag:
+            attr1: str = "meta class value"
+
+    class C4(metaclass=Meta4): ...
+    # error: [possibly-unbound-attribute]
+    reveal_type(C4.attr1)  # revealed: str
+```
+
+Finally, if both the meta class attribute and the class-level attribute are only partially defined,
+we union them and emit a `possibly-unbound-attribute` diagnostic:
+
+```py
+def _(flag1: bool, flag2: bool):
+    class Meta5:
+        if flag1:
+            attr1 = "meta class value"
+
+    class C5(metaclass=Meta5):
+        if flag2:
+            attr1 = "class value"
+
+    # error: [possibly-unbound-attribute]
+    reveal_type(C5.attr1)  # revealed: Unknown | Literal["meta class value", "class value"]
+```
+
 ## Union of attributes
+
+If the (meta) class is a union type or if the attribute on the (meta) class has a union type, we
+infer those union types accordingly:
 
 ```py
 def _(flag: bool):
@@ -716,14 +801,35 @@ def _(flag: bool):
         class C1:
             x = 2
 
+    reveal_type(C1.x)  # revealed: Unknown | Literal[1, 2]
+
     class C2:
         if flag:
             x = 3
         else:
             x = 4
 
-    reveal_type(C1.x)  # revealed: Unknown | Literal[1, 2]
     reveal_type(C2.x)  # revealed: Unknown | Literal[3, 4]
+
+    if flag:
+        class Meta3(type):
+            x = 5
+
+    else:
+        class Meta3(type):
+            x = 6
+
+    class C3(metaclass=Meta3): ...
+    reveal_type(C3.x)  # revealed: Unknown | Literal[5, 6]
+
+    class Meta4(type):
+        if flag:
+            x = 7
+        else:
+            x = 8
+
+    class C4(metaclass=Meta4): ...
+    reveal_type(C4.x)  # revealed: Unknown | Literal[7, 8]
 ```
 
 ## Inherited class attributes
@@ -883,7 +989,7 @@ def _(flag: bool):
                 self.x = 1
 
     # error: [possibly-unbound-attribute]
-    reveal_type(Foo().x)  # revealed: int
+    reveal_type(Foo().x)  # revealed: int | Unknown
 ```
 
 #### Possibly unbound
@@ -1105,8 +1211,8 @@ Most attribute accesses on bool-literal types are delegated to `builtins.bool`, 
 bools are instances of that class:
 
 ```py
-reveal_type(True.__and__)  # revealed: @Todo(overloaded method)
-reveal_type(False.__or__)  # revealed: @Todo(overloaded method)
+reveal_type(True.__and__)  # revealed: <bound method `__and__` of `Literal[True]`>
+reveal_type(False.__or__)  # revealed: <bound method `__or__` of `Literal[False]`>
 ```
 
 Some attributes are special-cased, however:
@@ -1262,6 +1368,7 @@ reveal_type(C.a_none)  # revealed: None
 Some of the tests in the *Class and instance variables* section draw inspiration from
 [pyright's documentation] on this topic.
 
+[descriptor protocol tests]: descriptor_protocol.md
 [pyright's documentation]: https://microsoft.github.io/pyright/#/type-concepts-advanced?id=class-and-instance-variables
 [typing spec on `classvar`]: https://typing.readthedocs.io/en/latest/spec/class-compat.html#classvar
 [`typing.classvar`]: https://docs.python.org/3/library/typing.html#typing.ClassVar

--- a/crates/red_knot_python_semantic/resources/mdtest/attributes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/attributes.md
@@ -709,7 +709,7 @@ reveal_type(Derived().defined_in_init)  # revealed: str | None
 ## Accessing attributes on class objects
 
 When accessing attributes on class objects, they are always looked up on the type of the class
-object first, i.e. on the meta class:
+object first, i.e. on the metaclass:
 
 ```py
 from typing import Literal
@@ -788,7 +788,7 @@ def _(flag1: bool, flag2: bool):
 
 ## Union of attributes
 
-If the (meta) class is a union type or if the attribute on the (meta) class has a union type, we
+If the (meta)class is a union type or if the attribute on the (meta) class has a union type, we
 infer those union types accordingly:
 
 ```py

--- a/crates/red_knot_python_semantic/resources/mdtest/binary/integers.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/binary/integers.md
@@ -10,8 +10,7 @@ reveal_type(-3 // 3)  # revealed: Literal[-1]
 reveal_type(-3 / 3)  # revealed: float
 reveal_type(5 % 3)  # revealed: Literal[2]
 
-# TODO: Should emit `unsupported-operator` but we don't understand the bases of `str`, so we think
-#       it inherits `Unknown`, so we think `str.__radd__` is `Unknown` instead of nonexistent.
+# error: [unsupported-operator] "Operator `+` is unsupported between objects of type `Literal[2]` and `Literal["f"]`"
 reveal_type(2 + "f")  # revealed: Unknown
 
 def lhs(x: int):

--- a/crates/red_knot_python_semantic/resources/mdtest/call/dunder.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/call/dunder.md
@@ -46,6 +46,17 @@ class DunderOnMetaClass(metaclass=Meta):
 reveal_type(DunderOnMetaClass[0])  # revealed: str
 ```
 
+If the dunder method is only present on the class itself, it will not be called:
+
+```py
+class ClassWithNormalDunder:
+    def __getitem__(self, key: int) -> str:
+        return str(key)
+
+# error: [non-subscriptable]
+ClassWithNormalDunder[0]
+```
+
 ## Operating on instances
 
 When invoking a dunder method on an instance of a class, it is looked up on the class:
@@ -79,11 +90,30 @@ reveal_type(this_fails[0])  # revealed: Unknown
 However, the attached dunder method *can* be called if accessed directly:
 
 ```py
-# TODO: `this_fails.__getitem__` is incorrectly treated as a bound method. This
-# should be fixed with https://github.com/astral-sh/ruff/issues/16367
-# error: [too-many-positional-arguments]
-# error: [invalid-argument-type]
 reveal_type(this_fails.__getitem__(this_fails, 0))  # revealed: Unknown | str
+```
+
+The instance-level method is also not called when the class-level method is present:
+
+```py
+def external_getitem1(instance, key) -> str:
+    return "a"
+
+def external_getitem2(key) -> int:
+    return 1
+
+def _(flag: bool):
+    class ThisFails:
+        if flag:
+            __getitem__ = external_getitem1
+
+        def __init__(self):
+            self.__getitem__ = external_getitem2
+
+    this_fails = ThisFails()
+
+    # error: [call-possibly-unbound-method]
+    reveal_type(this_fails[0])  # revealed: Unknown | str
 ```
 
 ## When the dunder is not a method
@@ -125,4 +155,65 @@ class ClassWithDescriptorDunder:
 class_with_descriptor_dunder = ClassWithDescriptorDunder()
 
 reveal_type(class_with_descriptor_dunder[0])  # revealed: str
+```
+
+## Dunders can not be overwritten on instances
+
+If we attempt to overwrite a dunder method on an instance, it does not affect the behavior of
+implicit dunder calls:
+
+```py
+class C:
+    def __getitem__(self, key: int) -> str:
+        return str(key)
+
+    def f(self):
+        # TODO: This should emit an `invalid-assignment` diagnostic once we understand the type of `self`
+        self.__getitem__ = None
+
+# This is still fine, and simply calls the `__getitem__` method on the class
+reveal_type(C()[0])  # revealed: str
+```
+
+## Calling a union of dunder methods
+
+```py
+def _(flag: bool):
+    class C:
+        if flag:
+            def __getitem__(self, key: int) -> str:
+                return str(key)
+        else:
+            def __getitem__(self, key: int) -> bytes:
+                return key
+
+    c = C()
+    reveal_type(c[0])  # revealed: str | bytes
+
+    if flag:
+        class D:
+            def __getitem__(self, key: int) -> str:
+                return str(key)
+
+    else:
+        class D:
+            def __getitem__(self, key: int) -> bytes:
+                return key
+
+    d = D()
+    reveal_type(d[0])  # revealed: str | bytes
+```
+
+## Calling a possibly-unbound dunder method
+
+```py
+def _(flag: bool):
+    class C:
+        if flag:
+            def __getitem__(self, key: int) -> str:
+                return str(key)
+
+    c = C()
+    # error: [call-possibly-unbound-method]
+    reveal_type(c[0])  # revealed: str
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/call/getattr_static.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/call/getattr_static.md
@@ -83,6 +83,12 @@ class E(metaclass=Meta): ...
 reveal_type(inspect.getattr_static(E, "attr"))  # revealed: int
 ```
 
+Metaclass attributes can not be added when probing an instance of the class:
+
+```py
+reveal_type(inspect.getattr_static(E(), "attr", "non_existent"))  # revealed: Literal["non_existent"]
+```
+
 ## Error cases
 
 We can only infer precise types if the attribute is a literal string. In all other cases, we fall

--- a/crates/red_knot_python_semantic/resources/mdtest/call/getattr_static.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/call/getattr_static.md
@@ -12,7 +12,7 @@ import inspect
 
 class Descriptor:
     def __get__(self, instance, owner) -> str:
-        return 1
+        return "a"
 
 class C:
     normal: int = 1
@@ -59,7 +59,7 @@ import sys
 reveal_type(inspect.getattr_static(sys, "platform"))  # revealed: LiteralString
 reveal_type(inspect.getattr_static(inspect, "getattr_static"))  # revealed: Literal[getattr_static]
 
-reveal_type(inspect.getattr_static(1, "real"))  # revealed: Literal[1]
+reveal_type(inspect.getattr_static(1, "real"))  # revealed: Literal[real]
 ```
 
 (Implicit) instance attributes can also be accessed through `inspect.getattr_static`:
@@ -70,6 +70,17 @@ class D:
         self.instance_attr: int = 1
 
 reveal_type(inspect.getattr_static(D(), "instance_attr"))  # revealed: int
+```
+
+And attributes on metaclasses can be accessed when probing the class:
+
+```py
+class Meta(type):
+    attr: int = 1
+
+class E(metaclass=Meta): ...
+
+reveal_type(inspect.getattr_static(E, "attr"))  # revealed: int
 ```
 
 ## Error cases

--- a/crates/red_knot_python_semantic/resources/mdtest/call/methods.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/call/methods.md
@@ -255,6 +255,58 @@ method_wrapper()
 method_wrapper(C(), C, "one too many")
 ```
 
+## Fallback to metaclass
+
+When a method is accessed on a class object, it is looked up on the metaclass if it is not found on
+the class itself. This also creates a bound method that is bound to the class object itself:
+
+```py
+from __future__ import annotations
+
+class Meta(type):
+    def f(cls: type[C | D | E], arg: int) -> str:
+        return "a"
+
+class C(metaclass=Meta):
+    pass
+
+reveal_type(C.f)  # revealed: <bound method `f` of `Literal[C]`>
+reveal_type(C.f(1))  # revealed: str
+```
+
+The method `f` can not be accessed from an instance of the class:
+
+```py
+# error: [unresolved-attribute] "Type `C` has no attribute `f`"
+C().f
+```
+
+A metaclass function can be shadowed by a class method:
+
+```py
+from typing import Any, Literal
+
+class D(metaclass=Meta):
+    def f(arg: int) -> Literal["a"]:
+        return "a"
+
+reveal_type(D.f(1))  # revealed: Literal["a"]
+```
+
+If the class method is possibly unbound, we union the return types:
+
+```py
+def flag() -> bool:
+    return True
+
+class E(metaclass=Meta):
+    if flag():
+        def f(arg: int) -> Any:
+            return "a"
+
+reveal_type(E.f(1))  # revealed: str | Any
+```
+
 ## `@classmethod`
 
 ### Basic
@@ -371,10 +423,10 @@ class C:
 # these should all return `str`:
 
 reveal_type(C.f1(1))  # revealed: @Todo(return type of decorated function)
-reveal_type(C().f1(1))  # revealed: @Todo(decorated method)
+reveal_type(C().f1(1))  # revealed: @Todo(return type of decorated function)
 
 reveal_type(C.f2(1))  # revealed: @Todo(return type of decorated function)
-reveal_type(C().f2(1))  # revealed: @Todo(decorated method)
+reveal_type(C().f2(1))  # revealed: @Todo(return type of decorated function)
 ```
 
 [functions and methods]: https://docs.python.org/3/howto/descriptor.html#functions-and-methods

--- a/crates/red_knot_python_semantic/resources/mdtest/call/methods.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/call/methods.md
@@ -264,7 +264,7 @@ the class itself. This also creates a bound method that is bound to the class ob
 from __future__ import annotations
 
 class Meta(type):
-    def f(cls: type[C | D | E], arg: int) -> str:
+    def f(cls, arg: int) -> str:
         return "a"
 
 class C(metaclass=Meta):
@@ -281,7 +281,7 @@ The method `f` can not be accessed from an instance of the class:
 C().f
 ```
 
-A metaclass function can be shadowed by a class method:
+A metaclass function can be shadowed by a method on the class:
 
 ```py
 from typing import Any, Literal

--- a/crates/red_knot_python_semantic/resources/mdtest/descriptor_protocol.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/descriptor_protocol.md
@@ -34,11 +34,9 @@ reveal_type(C.ten)  # revealed: Literal[10]
 c.ten = 10
 C.ten = 10
 
-# TODO: This should be an error (as the wrong type is being implicitly passed to `Ten.__set__`).
 # error: [invalid-assignment] "Object of type `Literal[11]` is not assignable to attribute `ten` of type `Literal[10]`"
 c.ten = 11
 
-# TODO: same as above
 # error: [invalid-assignment] "Object of type `Literal[11]` is not assignable to attribute `ten` of type `Literal[10]`"
 C.ten = 11
 ```
@@ -511,12 +509,12 @@ class TailoredForInstanceAccess:
     def __get__(self, instance: C, owner: type[C] | None = None) -> str:
         return "a"
 
-class TailoredForMetaClassAccess:
+class TailoredForMetaclassAccess:
     def __get__(self, instance: type[C], owner: type[Meta]) -> bytes:
         return b"a"
 
 class Meta(type):
-    meta_class_access: TailoredForMetaClassAccess = TailoredForMetaClassAccess()
+    metaclass_access: TailoredForMetaclassAccess = TailoredForMetaclassAccess()
 
 class C(metaclass=Meta):
     class_object_access: TailoredForClassObjectAccess = TailoredForClassObjectAccess()
@@ -524,7 +522,7 @@ class C(metaclass=Meta):
 
 reveal_type(C.class_object_access)  # revealed: int
 reveal_type(C().instance_access)  # revealed: str
-reveal_type(C.meta_class_access)  # revealed: bytes
+reveal_type(C.metaclass_access)  # revealed: bytes
 
 # TODO: These should emit a diagnostic
 reveal_type(C().class_object_access)  # revealed: TailoredForClassObjectAccess
@@ -602,7 +600,7 @@ def _(flag: bool):
 ## Descriptors with non-function `__get__` callables that are descriptors themselves
 
 The descriptor protocol is recursive, i.e. looking up `__get__` can involve triggering the
-descriptor protocol on the callables `__call__` method:
+descriptor protocol on the callable's `__call__` method:
 
 ```py
 from __future__ import annotations

--- a/crates/red_knot_python_semantic/resources/mdtest/descriptor_protocol.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/descriptor_protocol.md
@@ -31,13 +31,11 @@ reveal_type(c.ten)  # revealed: Literal[10]
 reveal_type(C.ten)  # revealed: Literal[10]
 
 # These are fine:
-# TODO: This should not be an error
-c.ten = 10  # error: [invalid-assignment]
+c.ten = 10
 C.ten = 10
 
-# TODO: This should be an error (as the wrong type is being implicitly passed to `Ten.__set__`),
-# but the error message is misleading.
-# error: [invalid-assignment] "Object of type `Literal[11]` is not assignable to attribute `ten` of type `Ten`"
+# TODO: This should be an error (as the wrong type is being implicitly passed to `Ten.__set__`).
+# error: [invalid-assignment] "Object of type `Literal[11]` is not assignable to attribute `ten` of type `Literal[10]`"
 c.ten = 11
 
 # TODO: same as above
@@ -67,16 +65,14 @@ c = C()
 
 reveal_type(c.flexible_int)  # revealed: int | None
 
-# TODO: These should not be errors
-# error: [invalid-assignment]
 c.flexible_int = 42  # okay
+# TODO: This should not be an error
 # error: [invalid-assignment]
 c.flexible_int = "42"  # also okay!
 
 reveal_type(c.flexible_int)  # revealed: int | None
 
-# TODO: This should be an error, but the message needs to be improved.
-# error: [invalid-assignment] "Object of type `None` is not assignable to attribute `flexible_int` of type `FlexibleInt`"
+# TODO: This should be an error
 c.flexible_int = None  # not okay
 
 reveal_type(c.flexible_int)  # revealed: int | None
@@ -84,11 +80,10 @@ reveal_type(c.flexible_int)  # revealed: int | None
 
 ## Data and non-data descriptors
 
-Descriptors that define `__set__` or `__delete__` are called *data descriptors*. An example\
-of a data descriptor is a `property` with a setter and/or a deleter.\
-Descriptors that only define `__get__`, meanwhile, are called *non-data descriptors*. Examples
-include\
-functions, `classmethod` or `staticmethod`).
+Descriptors that define `__set__` or `__delete__` are called *data descriptors*. An example of a
+data descriptor is a `property` with a setter and/or a deleter. Descriptors that only define
+`__get__`, meanwhile, are called *non-data descriptors*. Examples include functions, `classmethod`
+or `staticmethod`.
 
 The precedence chain for attribute access is (1) data descriptors, (2) instance attributes, and (3)
 non-data descriptors.
@@ -100,7 +95,7 @@ class DataDescriptor:
     def __get__(self, instance: object, owner: type | None = None) -> Literal["data"]:
         return "data"
 
-    def __set__(self, instance: int, value) -> None:
+    def __set__(self, instance: object, value: int) -> None:
         pass
 
 class NonDataDescriptor:
@@ -124,12 +119,7 @@ class C:
 
 c = C()
 
-# TODO: This should ideally be `Unknown | Literal["data"]`.
-#
-#     - Pyright also wrongly shows `int | Literal['data']` here
-#     - Mypy shows Literal["data"] here, but also shows Literal["non-data"] below.
-#
-reveal_type(c.data_descriptor)  # revealed: Unknown | Literal["data", 1]
+reveal_type(c.data_descriptor)  # revealed: Unknown | Literal["data"]
 
 reveal_type(c.non_data_descriptor)  # revealed: Unknown | Literal["non-data", 1]
 
@@ -141,6 +131,230 @@ reveal_type(C.non_data_descriptor)  # revealed: Unknown | Literal["non-data"]
 # assignment does not call `DataDescriptor.__set__`. For this reason, we infer
 # `Unknown | …` for all (descriptor) attributes.
 C.data_descriptor = "something else"  # This is okay
+```
+
+## Descriptor protocol for class objects
+
+When attributes are accessed on a class object, the following [precedence chain] is used:
+
+- Data descriptor on the metaclass
+- Data or non-data descriptor on the class
+- Class attribute
+- Non-data descriptor on the metaclass
+- Metaclass attribute
+
+To verify this, we define a data and a non-data descriptor:
+
+```py
+from typing import Literal, Any
+
+class DataDescriptor:
+    def __get__(self, instance: object, owner: type | None = None) -> Literal["data"]:
+        return "data"
+
+    def __set__(self, instance: object, value: str) -> None:
+        pass
+
+class NonDataDescriptor:
+    def __get__(self, instance: object, owner: type | None = None) -> Literal["non-data"]:
+        return "non-data"
+```
+
+First, we make sure that the descriptors are correctly accessed when defined on the metaclass or the
+class:
+
+```py
+class Meta1(type):
+    meta_data_descriptor: DataDescriptor = DataDescriptor()
+    meta_non_data_descriptor: NonDataDescriptor = NonDataDescriptor()
+
+class C1(metaclass=Meta1):
+    class_data_descriptor: DataDescriptor = DataDescriptor()
+    class_non_data_descriptor: NonDataDescriptor = NonDataDescriptor()
+
+reveal_type(C1.meta_data_descriptor)  # revealed: Literal["data"]
+reveal_type(C1.meta_non_data_descriptor)  # revealed: Literal["non-data"]
+
+reveal_type(C1.class_data_descriptor)  # revealed: Literal["data"]
+reveal_type(C1.class_non_data_descriptor)  # revealed: Literal["non-data"]
+```
+
+Next, we demonstrate that a *metaclass data descriptor* takes precedence over all class-level
+attributes:
+
+```py
+class Meta2(type):
+    meta_data_descriptor1: DataDescriptor = DataDescriptor()
+    meta_data_descriptor2: DataDescriptor = DataDescriptor()
+
+class ClassLevelDataDescriptor:
+    def __get__(self, instance: object, owner: type | None = None) -> Literal["class level data descriptor"]:
+        return "class level data descriptor"
+
+    def __set__(self, instance: object, value: str) -> None:
+        pass
+
+class C2(metaclass=Meta2):
+    meta_data_descriptor1: Literal["value on class"] = "value on class"
+    meta_data_descriptor2: ClassLevelDataDescriptor = ClassLevelDataDescriptor()
+
+reveal_type(C2.meta_data_descriptor1)  # revealed: Literal["data"]
+reveal_type(C2.meta_data_descriptor2)  # revealed: Literal["data"]
+```
+
+On the other hand, normal metaclass attributes and metaclass non-data descriptors are shadowed by
+class-level attributes (descriptor or not):
+
+```py
+class Meta3(type):
+    meta_attribute1: Literal["value on metaclass"] = "value on metaclass"
+    meta_attribute2: Literal["value on metaclass"] = "value on metaclass"
+    meta_non_data_descriptor1: NonDataDescriptor = NonDataDescriptor()
+    meta_non_data_descriptor2: NonDataDescriptor = NonDataDescriptor()
+
+class C3(metaclass=Meta3):
+    meta_attribute1: Literal["value on class"] = "value on class"
+    meta_attribute2: ClassLevelDataDescriptor = ClassLevelDataDescriptor()
+    meta_non_data_descriptor1: Literal["value on class"] = "value on class"
+    meta_non_data_descriptor2: ClassLevelDataDescriptor = ClassLevelDataDescriptor()
+
+reveal_type(C3.meta_attribute1)  # revealed: Literal["value on class"]
+reveal_type(C3.meta_attribute2)  # revealed: Literal["class level data descriptor"]
+reveal_type(C3.meta_non_data_descriptor1)  # revealed: Literal["value on class"]
+reveal_type(C3.meta_non_data_descriptor2)  # revealed: Literal["class level data descriptor"]
+```
+
+Finally, metaclass attributes and metaclass non-data descriptors are only accessible when they are
+not shadowed by class-level attributes:
+
+```py
+class Meta4(type):
+    meta_attribute: Literal["value on metaclass"] = "value on metaclass"
+    meta_non_data_descriptor: NonDataDescriptor = NonDataDescriptor()
+
+class C4(metaclass=Meta4): ...
+
+reveal_type(C4.meta_attribute)  # revealed: Literal["value on metaclass"]
+reveal_type(C4.meta_non_data_descriptor)  # revealed: Literal["non-data"]
+```
+
+When a metaclass data descriptor is possibly unbound, we union the result type of its `__get__`
+method with an underlying class level attribute, if present:
+
+```py
+def _(flag: bool):
+    class Meta5(type):
+        if flag:
+            meta_data_descriptor1: DataDescriptor = DataDescriptor()
+            meta_data_descriptor2: DataDescriptor = DataDescriptor()
+
+    class C5(metaclass=Meta5):
+        meta_data_descriptor1: Literal["value on class"] = "value on class"
+
+    reveal_type(C5.meta_data_descriptor1)  # revealed: Literal["data", "value on class"]
+    # error: [possibly-unbound-attribute]
+    reveal_type(C5.meta_data_descriptor2)  # revealed: Literal["data"]
+```
+
+When a class-level attribute is possibly unbound, we union its (descriptor protocol) type with the
+metaclass attribute (unless it's a data descriptor, which always takes precedence):
+
+```py
+from typing import Any
+
+def _(flag: bool):
+    class Meta6(type):
+        attribute1: DataDescriptor = DataDescriptor()
+        attribute2: NonDataDescriptor = NonDataDescriptor()
+        attribute3: Literal["value on metaclass"] = "value on metaclass"
+
+    class C6(metaclass=Meta6):
+        if flag:
+            attribute1: Literal["value on class"] = "value on class"
+            attribute2: Literal["value on class"] = "value on class"
+            attribute3: Literal["value on class"] = "value on class"
+            attribute4: Literal["value on class"] = "value on class"
+
+    reveal_type(C6.attribute1)  # revealed: Literal["data"]
+    reveal_type(C6.attribute2)  # revealed: Literal["non-data", "value on class"]
+    reveal_type(C6.attribute3)  # revealed: Literal["value on metaclass", "value on class"]
+    # error: [possibly-unbound-attribute]
+    reveal_type(C6.attribute4)  # revealed: Literal["value on class"]
+```
+
+Finally, we can also have unions of various types of attributes:
+
+```py
+def _(flag: bool):
+    class Meta7(type):
+        if flag:
+            union_of_metaclass_attributes: Literal[1] = 1
+            union_of_metaclass_data_descriptor_and_attribute: DataDescriptor = DataDescriptor()
+        else:
+            union_of_metaclass_attributes: Literal[2] = 2
+            union_of_metaclass_data_descriptor_and_attribute: Literal[2] = 2
+
+    class C7(metaclass=Meta7):
+        if flag:
+            union_of_class_attributes: Literal[1] = 1
+            union_of_class_data_descriptor_and_attribute: DataDescriptor = DataDescriptor()
+        else:
+            union_of_class_attributes: Literal[2] = 2
+            union_of_class_data_descriptor_and_attribute: Literal[2] = 2
+
+    reveal_type(C7.union_of_metaclass_attributes)  # revealed: Literal[1, 2]
+    reveal_type(C7.union_of_metaclass_data_descriptor_and_attribute)  # revealed: Literal["data", 2]
+    reveal_type(C7.union_of_class_attributes)  # revealed: Literal[1, 2]
+    reveal_type(C7.union_of_class_data_descriptor_and_attribute)  # revealed: Literal["data", 2]
+```
+
+## Partial fall back
+
+Our implementation of the descriptor protocol takes into account that symbols can be possibly
+unbound. In those cases, we fall back to lower precedence steps of the descriptor protocol and union
+all possible results accordingly. We start by defining a data and a non-data descriptor:
+
+```py
+from typing import Literal
+
+class DataDescriptor:
+    def __get__(self, instance: object, owner: type | None = None) -> Literal["data"]:
+        return "data"
+
+    def __set__(self, instance: object, value: int) -> None:
+        pass
+
+class NonDataDescriptor:
+    def __get__(self, instance: object, owner: type | None = None) -> Literal["non-data"]:
+        return "non-data"
+```
+
+Then, we demonstrate that we fall back to an instance attribute if a data descriptor is possibly
+unbound:
+
+```py
+def f1(flag: bool):
+    class C1:
+        if flag:
+            attr = DataDescriptor()
+
+        def f(self):
+            self.attr = "normal"
+
+    reveal_type(C1().attr)  # revealed: Unknown | Literal["data", "normal"]
+```
+
+We never treat implicit instance attributes as definitely bound, so we fall back to the non-data
+descriptor here:
+
+```py
+def f2(flag: bool):
+    class C2:
+        def f(self):
+            self.attr = "normal"
+        attr = NonDataDescriptor()
+
+    reveal_type(C2().attr)  # revealed: Unknown | Literal["non-data", "normal"]
 ```
 
 ## Built-in `property` descriptor
@@ -166,18 +380,21 @@ c = C()
 
 reveal_type(c._name)  # revealed: str | None
 
-# Should be `str`
-reveal_type(c.name)  # revealed: @Todo(decorated method)
+# TODO: Should be `str`
+reveal_type(c.name)  # revealed: <bound method `name` of `C`>
 
 # Should be `builtins.property`
 reveal_type(C.name)  # revealed: Literal[name]
 
-# This is fine:
+# TODO: These should not emit errors
+# error: [invalid-assignment]
 c.name = "new"
 
+# error: [invalid-assignment]
 c.name = None
 
-# TODO: this should be an error
+# TODO: this should be an error, but with a proper error message
+# error: [invalid-assignment] "Object of type `Literal[42]` is not assignable to attribute `name` of type `<bound method `name` of `C`>`"
 c.name = 42
 ```
 
@@ -225,8 +442,7 @@ class C:
     def __init__(self):
         self.ten: Ten = Ten()
 
-# TODO: Should be Ten
-reveal_type(C().ten)  # revealed: Literal[10]
+reveal_type(C().ten)  # revealed: Ten
 ```
 
 ## Descriptors distinguishing between class and instance access
@@ -295,12 +511,20 @@ class TailoredForInstanceAccess:
     def __get__(self, instance: C, owner: type[C] | None = None) -> str:
         return "a"
 
-class C:
+class TailoredForMetaClassAccess:
+    def __get__(self, instance: type[C], owner: type[Meta]) -> bytes:
+        return b"a"
+
+class Meta(type):
+    meta_class_access: TailoredForMetaClassAccess = TailoredForMetaClassAccess()
+
+class C(metaclass=Meta):
     class_object_access: TailoredForClassObjectAccess = TailoredForClassObjectAccess()
     instance_access: TailoredForInstanceAccess = TailoredForInstanceAccess()
 
 reveal_type(C.class_object_access)  # revealed: int
 reveal_type(C().instance_access)  # revealed: str
+reveal_type(C.meta_class_access)  # revealed: bytes
 
 # TODO: These should emit a diagnostic
 reveal_type(C().class_object_access)  # revealed: TailoredForClassObjectAccess
@@ -320,6 +544,42 @@ class C:
 
 # TODO: This should be an error
 reveal_type(C.descriptor)  # revealed: Descriptor
+
+# TODO: This should be an error
+reveal_type(C().descriptor)  # revealed: Descriptor
+```
+
+## Possibly unbound descriptor attributes
+
+```py
+class DataDescriptor:
+    def __get__(self, instance: object, owner: type | None = None) -> int:
+        return 1
+
+    def __set__(self, instance: int, value) -> None:
+        pass
+
+class NonDataDescriptor:
+    def __get__(self, instance: object, owner: type | None = None) -> int:
+        return 1
+
+def _(flag: bool):
+    class PossiblyUnbound:
+        if flag:
+            non_data: NonDataDescriptor = NonDataDescriptor()
+            data: DataDescriptor = DataDescriptor()
+
+    # error: [possibly-unbound-attribute] "Attribute `non_data` on type `Literal[PossiblyUnbound]` is possibly unbound"
+    reveal_type(PossiblyUnbound.non_data)  # revealed: int
+
+    # error: [possibly-unbound-attribute] "Attribute `non_data` on type `PossiblyUnbound` is possibly unbound"
+    reveal_type(PossiblyUnbound().non_data)  # revealed: int
+
+    # error: [possibly-unbound-attribute] "Attribute `data` on type `Literal[PossiblyUnbound]` is possibly unbound"
+    reveal_type(PossiblyUnbound.data)  # revealed: int
+
+    # error: [possibly-unbound-attribute] "Attribute `data` on type `PossiblyUnbound` is possibly unbound"
+    reveal_type(PossiblyUnbound().data)  # revealed: int
 ```
 
 ## Possibly-unbound `__get__` method
@@ -334,8 +594,50 @@ def _(flag: bool):
     class C:
         descriptor: MaybeDescriptor = MaybeDescriptor()
 
-    # TODO: This should be `MaybeDescriptor | int`
-    reveal_type(C.descriptor)  # revealed: int
+    reveal_type(C.descriptor)  # revealed: int | MaybeDescriptor
+
+    reveal_type(C().descriptor)  # revealed: int | MaybeDescriptor
+```
+
+## Descriptors with non-function `__get__` callables that are descriptors themselves
+
+The descriptor protocol is recursive, i.e. looking up `__get__` can involve triggering the
+descriptor protocol on the callables `__call__` method:
+
+```py
+from __future__ import annotations
+
+class ReturnedCallable2:
+    def __call__(self, descriptor: Descriptor1, instance: None, owner: type[C]) -> int:
+        return 1
+
+class ReturnedCallable1:
+    def __call__(self, descriptor: Descriptor2, instance: Callable1, owner: type[Callable1]) -> ReturnedCallable2:
+        return ReturnedCallable2()
+
+class Callable3:
+    def __call__(self, descriptor: Descriptor3, instance: Callable2, owner: type[Callable2]) -> ReturnedCallable1:
+        return ReturnedCallable1()
+
+class Descriptor3:
+    __get__: Callable3 = Callable3()
+
+class Callable2:
+    __call__: Descriptor3 = Descriptor3()
+
+class Descriptor2:
+    __get__: Callable2 = Callable2()
+
+class Callable1:
+    __call__: Descriptor2 = Descriptor2()
+
+class Descriptor1:
+    __get__: Callable1 = Callable1()
+
+class C:
+    d: Descriptor1 = Descriptor1()
+
+reveal_type(C.d)  # revealed: int
 ```
 
 ## Dunder methods
@@ -438,4 +740,5 @@ wrapper_descriptor(f, None, type(f), "one too many")
 ```
 
 [descriptors]: https://docs.python.org/3/howto/descriptor.html
+[precedence chain]: https://github.com/python/cpython/blob/3.13/Objects/typeobject.c#L5393-L5481
 [simple example]: https://docs.python.org/3/howto/descriptor.html#simple-example-a-descriptor-that-returns-a-constant

--- a/crates/red_knot_python_semantic/resources/mdtest/generics/classes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/generics/classes.md
@@ -68,7 +68,7 @@ class C[T]:
 # TODO: no error
 # TODO: revealed: C[int]
 # error: [non-subscriptable]
-reveal_type(C[int]())  # revealed: Unknown
+reveal_type(C[int]())  # revealed: C
 ```
 
 We can infer the type parameter from a type context:
@@ -129,18 +129,19 @@ propagate through:
 
 ```py
 class Base[T]:
-    x: T
+    x: T | None = None
 
 # TODO: no error
 # error: [non-subscriptable]
 class Sub[U](Base[U]): ...
 
 # TODO: no error
-# TODO: revealed: int
+# TODO: revealed: int | None
 # error: [non-subscriptable]
-reveal_type(Base[int].x)  # revealed: Unknown
-# TODO: revealed: int
-reveal_type(Sub[int].x)  # revealed: Unknown
+reveal_type(Base[int].x)  # revealed: T | None
+# TODO: revealed: int | None
+# error: [non-subscriptable]
+reveal_type(Sub[int].x)  # revealed: T | None
 ```
 
 ## Cyclic class definition

--- a/crates/red_knot_python_semantic/resources/mdtest/generics/scoping.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/generics/scoping.md
@@ -230,9 +230,9 @@ from typing import Iterable
 
 class C[T]:
     class Ok1[S]: ...
-    # TODO: error
+    # TODO: error for reuse of typevar
     class Bad1[T]: ...
-    # TODO: error
+    # TODO: no non-subscriptable error, error for reuse of typevar
     # error: [non-subscriptable]
     class Bad2(Iterable[T]): ...
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/generics/scoping.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/generics/scoping.md
@@ -216,9 +216,10 @@ from typing import Iterable
 
 def f[T](x: T, y: T) -> None:
     class Ok[S]: ...
-    # TODO: error
+    # TODO: error for reuse of typevar
     class Bad1[T]: ...
-    # TODO: error
+    # TODO: no non-subscriptable error, error for reuse of typevar
+    # error: [non-subscriptable]
     class Bad2(Iterable[T]): ...
 ```
 
@@ -232,6 +233,7 @@ class C[T]:
     # TODO: error
     class Bad1[T]: ...
     # TODO: error
+    # error: [non-subscriptable]
     class Bad2(Iterable[T]): ...
 ```
 

--- a/crates/red_knot_python_semantic/resources/mdtest/scopes/moduletype_attrs.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/scopes/moduletype_attrs.md
@@ -9,7 +9,7 @@ is unbound.
 ```py
 reveal_type(__name__)  # revealed: str
 reveal_type(__file__)  # revealed: str | None
-reveal_type(__loader__)  # revealed: @Todo(instance attribute on class with dynamic base) | None
+reveal_type(__loader__)  # revealed: LoaderProtocol | None
 reveal_type(__package__)  # revealed: str | None
 reveal_type(__doc__)  # revealed: str | None
 
@@ -151,6 +151,7 @@ typeshed = "/typeshed"
 `/typeshed/stdlib/builtins.pyi`:
 
 ```pyi
+class object: ...
 class int: ...
 class bytes: ...
 

--- a/crates/red_knot_python_semantic/resources/mdtest/stubs/class.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/stubs/class.md
@@ -13,7 +13,8 @@ class Foo[T]: ...
 class Bar(Foo[Bar]): ...
 
 reveal_type(Bar)  # revealed: Literal[Bar]
-reveal_type(Bar.__mro__)  # revealed: tuple[Literal[Bar], Unknown, Literal[object]]
+# TODO: Instead of `Literal[Foo]`, we might eventually want to show a type that involves the type parameter.
+reveal_type(Bar.__mro__)  # revealed: tuple[Literal[Bar], Literal[Foo], Literal[object]]
 ```
 
 ## Access to attributes declarated in stubs

--- a/crates/red_knot_python_semantic/resources/mdtest/subscript/tuple.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/subscript/tuple.md
@@ -118,6 +118,7 @@ from typing import Tuple
 class C(Tuple): ...
 
 # Runtime value: `(C, tuple, typing.Generic, object)`
-# TODO: Add `Generic` to the MRO
-reveal_type(C.__mro__)  # revealed: tuple[Literal[C], Literal[tuple], Unknown, Literal[object]]
+# TODO: Reflect the runtime value in the MRO here?
+# revealed: tuple[Literal[C], Literal[tuple], Literal[Sequence], Literal[Reversible], Literal[Collection], Literal[Iterable], Literal[Container], @Todo(protocol), Literal[object]]
+reveal_type(C.__mro__)
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/subscript/tuple.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/subscript/tuple.md
@@ -117,8 +117,6 @@ from typing import Tuple
 
 class C(Tuple): ...
 
-# Runtime value: `(C, tuple, typing.Generic, object)`
-# TODO: Reflect the runtime value in the MRO here?
 # revealed: tuple[Literal[C], Literal[tuple], Literal[Sequence], Literal[Reversible], Literal[Collection], Literal[Iterable], Literal[Container], @Todo(protocol), Literal[object]]
 reveal_type(C.__mro__)
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/suppressions/type_ignore.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/suppressions/type_ignore.md
@@ -38,16 +38,15 @@ For example, the `type: ignore` comment in this example suppresses the error of 
 `"test"` and adding `"other"` to the result of the cast.
 
 ```py
-# fmt: off
 from typing import cast
 
 y = (
-    cast(int, "test" +
-            # TODO: Remove the expected error after implementing `invalid-operator` for binary expressions
-            # error: [unused-ignore-comment]
-            2 # type: ignore
+    # error: [unsupported-operator]
+    cast(
+        int,
+        2 + "test",  # type: ignore
     )
-    + "other"  # TODO: expected-error[invalid-operator]
+    + "other"
 )
 ```
 

--- a/crates/red_knot_python_semantic/src/semantic_index/symbol.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/symbol.rs
@@ -6,8 +6,8 @@ use hashbrown::hash_map::RawEntryMut;
 use ruff_db::files::File;
 use ruff_db::parsed::ParsedModule;
 use ruff_index::{newtype_index, IndexVec};
+use ruff_python_ast as ast;
 use ruff_python_ast::name::Name;
-use ruff_python_ast::{self as ast};
 use rustc_hash::FxHasher;
 
 use crate::ast_node_ref::AstNodeRef;

--- a/crates/red_knot_python_semantic/src/symbol.rs
+++ b/crates/red_knot_python_semantic/src/symbol.rs
@@ -277,9 +277,7 @@ pub(crate) fn imported_symbol<'db>(
         if name == "__getattr__" {
             Symbol::Unbound.into()
         } else {
-            KnownClass::ModuleType
-                .to_instance(db)
-                .member(db, name.into())
+            KnownClass::ModuleType.to_instance(db).member(db, name)
         }
     })
 }
@@ -837,9 +835,7 @@ mod implicit_globals {
             .iter()
             .any(|module_type_member| &**module_type_member == name)
         {
-            KnownClass::ModuleType
-                .to_instance(db)
-                .member(db, name.into())
+            KnownClass::ModuleType.to_instance(db).member(db, name)
         } else {
             Symbol::Unbound.into()
         }

--- a/crates/red_knot_python_semantic/src/symbol.rs
+++ b/crates/red_knot_python_semantic/src/symbol.rs
@@ -211,7 +211,7 @@ pub(crate) fn class_symbol<'db>(
                 Symbol::Unbound.into()
             }
         })
-        .unwrap_or(Symbol::Unbound.into())
+        .unwrap_or_default()
 }
 
 /// Infers the public type of an explicit module-global symbol as seen from within the same file.
@@ -301,7 +301,7 @@ pub(crate) fn builtins_symbol<'db>(db: &'db dyn Db, symbol: &str) -> SymbolAndQu
                 module_type_implicit_global_symbol(db, symbol)
             })
         })
-        .unwrap_or(Symbol::Unbound.into())
+        .unwrap_or_default()
 }
 
 /// Lookup the type of `symbol` in a given known module.
@@ -314,7 +314,7 @@ pub(crate) fn known_module_symbol<'db>(
 ) -> SymbolAndQualifiers<'db> {
     resolve_module(db, &known_module.name())
         .map(|module| imported_symbol(db, &module, symbol))
-        .unwrap_or(Symbol::Unbound.into())
+        .unwrap_or_default()
 }
 
 /// Lookup the type of `symbol` in the `typing` module namespace.
@@ -399,6 +399,15 @@ pub(crate) type SymbolFromDeclarationsResult<'db> =
 pub(crate) struct SymbolAndQualifiers<'db> {
     pub(crate) symbol: Symbol<'db>,
     pub(crate) qualifiers: TypeQualifiers,
+}
+
+impl Default for SymbolAndQualifiers<'_> {
+    fn default() -> Self {
+        SymbolAndQualifiers {
+            symbol: Symbol::Unbound,
+            qualifiers: TypeQualifiers::empty(),
+        }
+    }
 }
 
 impl<'db> SymbolAndQualifiers<'db> {
@@ -604,7 +613,7 @@ fn symbol_impl<'db>(
     symbol_table(db, scope)
         .symbol_id_by_name(name)
         .map(|symbol| symbol_by_id(db, scope, symbol, requires_explicit_reexport))
-        .unwrap_or(Symbol::Unbound.into())
+        .unwrap_or_default()
 }
 
 /// Implementation of [`symbol_from_bindings`].

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1492,12 +1492,14 @@ impl<'db> Type<'db> {
             }
             Type::SubclassOf(subclass_of_ty) => subclass_of_ty.find_name_in_mro(db, name),
 
+            // We eagerly normalize type[object], i.e. Type::SubclassOf(object) to `type`, i.e. Type::Instance(type).
+            // So looking up a name in the MRO of `Type::Instance(type)` is equivalent to looking up the name in the
+            // MRO of the class `object`.
             Type::Instance(InstanceType { class }) if class.is_known(db, KnownClass::Type) => {
                 KnownClass::Object
                     .to_class_literal(db)
                     .find_name_in_mro(db, name)
             }
-
             Type::FunctionLiteral(_)
             | Type::Callable(_)
             | Type::ModuleLiteral(_)

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1737,15 +1737,12 @@ impl<'db> Type<'db> {
 
             SymbolAndQualifiers {
                 symbol: Symbol::Type(attribute_ty, boundness),
-                qualifiers,
+                qualifiers: _,
             } => {
                 if let Some((return_ty, attribute_kind)) =
                     attribute_ty.try_call_dunder_get(db, instance, owner)
                 {
-                    (
-                        Symbol::Type(return_ty, boundness).with_qualifiers(qualifiers),
-                        attribute_kind,
-                    )
+                    (Symbol::Type(return_ty, boundness).into(), attribute_kind)
                 } else {
                     (attribute, AttributeKind::NormalOrNonDataDescriptor)
                 }

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -6,7 +6,8 @@ use call::{CallDunderError, CallError};
 use context::InferContext;
 use diagnostic::NOT_ITERABLE;
 use ruff_db::files::File;
-use ruff_python_ast as ast;
+use ruff_python_ast::name::Name;
+use ruff_python_ast::{self as ast};
 use ruff_text_size::{Ranged, TextRange};
 use type_ordering::union_elements_ordering;
 
@@ -120,6 +121,52 @@ fn definition_expression_type<'db>(
     } else {
         // expression is in a type-params sub-scope
         infer_scope_types(db, scope).expression_type(expr_id)
+    }
+}
+
+/// The descriptor protocol distiguishes two kinds of descriptors. Non-data descriptors
+/// define a `__get__` method, while data descriptors additionally define a `__set__`
+/// method or a `__delete__` method. This enum is used to categorize attributes into two
+/// groups: (1) data descriptors and (2) normal attributes or non-data descriptors.
+#[derive(Clone, Debug, Copy, PartialEq, Eq, Hash, salsa::Update)]
+enum AttributeKind {
+    DataDescriptor,
+    NormalOrNonDataDescriptor,
+}
+
+/// This enum is used to control the behavior of the descriptor protocol implementation.
+/// When invoked on a class object, the fallback type (a class attribute) can shadow a
+/// non-data descriptor of the meta type (the class's metaclass). However, this is not
+/// true for instances. When invoked on an instance, the fallback type (an attribute on
+/// the instance) can not completely shadow a non-data descriptor of the meta type (the
+/// class), because we do not currently attempt to statically infer if an instance
+/// attribute is definitely defined (i.e. to check whether a particular method has been
+/// called).
+#[derive(Clone, Debug, Copy, PartialEq)]
+enum InstanceFallbackShadowsNonDataDescriptor {
+    Yes,
+    No,
+}
+
+/// Dunder methods are looked up on the meta type of a type without potentially falling
+/// back on attributes on the type itself. For example, when implicitly invoked on an
+/// instance, dunder methods are not looked up as instance attributes. And when invoked
+/// on a class, dunder methods are only looked up on the meta class, not the class itself.
+///
+/// All other attributes use the `WithInstanceFallback` policy.
+#[derive(Clone, Debug, Copy, PartialEq)]
+enum MemberLookupPolicy {
+    /// Only look up the attribute on the meta type.
+    NoInstanceFallback,
+    /// Look up the attribute on the meta type, but fall back to attributes on the instance
+    /// if the meta-type attribute is not found or if the meta-type attribute is not a data
+    /// descriptor.
+    WithInstanceFallback,
+}
+
+impl AttributeKind {
+    const fn is_data(self) -> bool {
+        matches!(self, Self::DataDescriptor)
     }
 }
 
@@ -239,6 +286,7 @@ pub enum Type<'db> {
     // TODO protocols, callable types, overloads, generics, type vars
 }
 
+#[salsa::tracked]
 impl<'db> Type<'db> {
     pub const fn any() -> Self {
         Self::Dynamic(DynamicType::Any)
@@ -1359,193 +1407,449 @@ impl<'db> Type<'db> {
         }
     }
 
-    /// Access an attribute of this type without invoking the descriptor protocol. This
-    /// method corresponds to `inspect.getattr_static(<object of type 'self'>, name)`.
+    /// This function is roughly equivalent to `find_name_in_mro` as defined in the [descriptor guide] or
+    /// [`_PyType_Lookup`] in CPython's `Objects/typeobject.c`. It should typically be called through
+    /// [Type::class_member], unless it is known that `self` is a class-like type. This function returns
+    /// `None` if called on an instance-like type.
     ///
-    /// See also: [`Type::member`]
-    #[must_use]
-    fn static_member(&self, db: &'db dyn Db, name: &str) -> Symbol<'db> {
+    /// [descriptor guide]: https://docs.python.org/3/howto/descriptor.html#invocation-from-an-instance
+    /// [`_PyType_Lookup`]: https://github.com/python/cpython/blob/e285232c76606e3be7bf216efb1be1e742423e4b/Objects/typeobject.c#L5223
+    fn find_name_in_mro(&self, db: &'db dyn Db, name: &str) -> Option<SymbolAndQualifiers<'db>> {
         match self {
-            Type::Dynamic(_) | Type::Never => Symbol::bound(self),
+            Type::Union(union) => Some(union.map_with_boundness_and_qualifiers(db, |elem| {
+                elem.find_name_in_mro(db, name)
+                    // If some elements are classes, and some are not, we simply fall back to Unbound for the non-class
+                    // elements instead of short-circuiting the whole result to `None`. We would need a more detailed
+                    // return type otherwise, and since `find_name_in_mro` is usualled via `class_member`, this is not
+                    // a problem.
+                    .unwrap_or(Symbol::Unbound.into())
+            })),
+            Type::Intersection(inter) => {
+                Some(inter.map_with_boundness_and_qualifiers(db, |elem| {
+                    elem.find_name_in_mro(db, name)
+                        // Fall back to Unbound, similar to the union case (see above).
+                        .unwrap_or(Symbol::Unbound.into())
+                }))
+            }
+
+            Type::Dynamic(_) | Type::Never => Some(Symbol::bound(self).into()),
+
+            Type::ClassLiteral(ClassLiteralType { class })
+                if class.is_known(db, KnownClass::FunctionType) && name == "__get__" =>
+            {
+                Some(Symbol::bound(Type::Callable(CallableType::WrapperDescriptorDunderGet)).into())
+            }
+            Type::ClassLiteral(ClassLiteralType { class })
+                if class.is_known(db, KnownClass::FunctionType)
+                    && matches!(name, "__set__" | "__delete__") =>
+            {
+                // Hard code this knowledge, as we look up `__set__` and `__delete__` on `FunctionType` often.
+                Some(Symbol::Unbound.into())
+            }
+            // TODO:
+            // We currently hard-code the knowledge that the following known classes are not
+            // descriptors, i.e. that they have no `__get__` method. This is not wrong and
+            // potentially even beneficial for performance, but it's not very principled.
+            // This case can probably be removed eventually, but we include it at the moment
+            // because we make extensive use of these types in our test suite. Note that some
+            // builtin types are not included here, since they do not have generic bases and
+            // are correctly handled by the `find_name_in_mro` method.
+            Type::ClassLiteral(class)
+                if matches!(
+                    class.class.known(db),
+                    Some(
+                        KnownClass::Int
+                            | KnownClass::Str
+                            | KnownClass::Bytes
+                            | KnownClass::Tuple
+                            | KnownClass::Slice
+                            | KnownClass::Range,
+                    )
+                ) && matches!(name, "__get__" | "__set__" | "__delete__") =>
+            {
+                Some(Symbol::Unbound.into())
+            }
+            Type::ClassLiteral(class_literal) => Some(class_literal.class_member(db, name)),
+
+            Type::SubclassOf(subclass_of)
+                if name == "__get__"
+                    && matches!(
+                        subclass_of
+                            .subclass_of()
+                            .into_class()
+                            .and_then(|c| c.known(db)),
+                        Some(
+                            KnownClass::Int
+                                | KnownClass::Str
+                                | KnownClass::Bytes
+                                | KnownClass::Tuple
+                                | KnownClass::Slice
+                                | KnownClass::Range,
+                        )
+                    ) =>
+            {
+                Some(Symbol::Unbound.into())
+            }
+            Type::SubclassOf(subclass_of_ty) => subclass_of_ty.find_name_in_mro(db, name),
+
+            Type::Instance(InstanceType { class }) if class.is_known(db, KnownClass::Type) => {
+                KnownClass::Object
+                    .to_class_literal(db)
+                    .find_name_in_mro(db, name)
+            }
+
+            Type::FunctionLiteral(_)
+            | Type::Callable(_)
+            | Type::ModuleLiteral(_)
+            | Type::KnownInstance(_)
+            | Type::AlwaysTruthy
+            | Type::AlwaysFalsy
+            | Type::IntLiteral(_)
+            | Type::BooleanLiteral(_)
+            | Type::StringLiteral(_)
+            | Type::LiteralString
+            | Type::BytesLiteral(_)
+            | Type::SliceLiteral(_)
+            | Type::Tuple(_)
+            | Type::Instance(_) => None,
+        }
+    }
+
+    /// Look up an attribute in the MRO of the meta type of `self`. This returns class-level attributes
+    /// when called on an instance-like type, and metaclass attributes when called on a class-like type.
+    ///
+    /// Basically corresponds to `self.to_meta_type().find_name_in_mro(name)`, except for the handling
+    /// of union and intersection types.
+    #[salsa::tracked]
+    fn class_member(self, db: &'db dyn Db, name: Name) -> SymbolAndQualifiers<'db> {
+        match self {
+            Type::Union(union) => union
+                .map_with_boundness_and_qualifiers(db, |elem| elem.class_member(db, name.clone())),
+            Type::Intersection(inter) => inter
+                .map_with_boundness_and_qualifiers(db, |elem| elem.class_member(db, name.clone())),
+            _ => self
+                .to_meta_type(db)
+                .find_name_in_mro(db, name.as_str())
+                .expect("was called on meta type"),
+        }
+    }
+
+    /// This function roughly corresponds to looking up an attribute in the `__dict__` of an object.
+    /// For instance-like types, this goes through the classes MRO and discovers attribute assignments
+    /// in methods, as well as class-body declarations that we consider to be evidence for the presence
+    /// of an instance attribute.
+    ///
+    /// For example, an instance of the following class has instance members `a` and `b`, but `c` is
+    /// just a class attribute that would not be discovered by this method:
+    /// ```py
+    /// class C:
+    ///     a: int
+    ///
+    ///     c = 1
+    ///
+    ///     def __init__(self):
+    ///         self.b: str = "a"
+    /// ```
+    fn instance_member(&self, db: &'db dyn Db, name: &str) -> SymbolAndQualifiers<'db> {
+        match self {
+            Type::Union(union) => {
+                union.map_with_boundness_and_qualifiers(db, |elem| elem.instance_member(db, name))
+            }
+
+            Type::Intersection(intersection) => intersection
+                .map_with_boundness_and_qualifiers(db, |elem| elem.instance_member(db, name)),
+
+            Type::Dynamic(_) | Type::Never => Symbol::bound(self).into(),
+
+            Type::Instance(InstanceType { class }) => class.instance_member(db, name),
 
             Type::FunctionLiteral(_) => KnownClass::FunctionType
                 .to_instance(db)
-                .static_member(db, name),
+                .instance_member(db, name),
 
             Type::Callable(CallableType::BoundMethod(_)) => KnownClass::MethodType
                 .to_instance(db)
-                .static_member(db, name),
+                .instance_member(db, name),
             Type::Callable(CallableType::MethodWrapperDunderGet(_)) => {
                 KnownClass::MethodWrapperType
                     .to_instance(db)
-                    .static_member(db, name)
+                    .instance_member(db, name)
             }
             Type::Callable(CallableType::WrapperDescriptorDunderGet) => {
                 KnownClass::WrapperDescriptorType
                     .to_instance(db)
-                    .static_member(db, name)
+                    .instance_member(db, name)
             }
 
-            Type::ModuleLiteral(module) => module.static_member(db, name),
-
-            Type::ClassLiteral(class_ty) => class_ty.static_member(db, name),
-
-            Type::SubclassOf(subclass_of_ty) => subclass_of_ty.static_member(db, name),
-
-            Type::KnownInstance(known_instance) => known_instance.static_member(db, name),
-
-            Type::Instance(InstanceType { class }) => match (class.known(db), name) {
-                (Some(KnownClass::VersionInfo), "major") => Symbol::bound(Type::IntLiteral(
-                    Program::get(db).python_version(db).major.into(),
-                )),
-                (Some(KnownClass::VersionInfo), "minor") => Symbol::bound(Type::IntLiteral(
-                    Program::get(db).python_version(db).minor.into(),
-                )),
-                (Some(KnownClass::FunctionType), "__get__") => {
-                    Symbol::bound(Type::Callable(CallableType::WrapperDescriptorDunderGet))
-                }
-
-                // TODO:
-                // We currently hard-code the knowledge that the following known classes are not
-                // descriptors, i.e. that they have no `__get__` method. This is not wrong and
-                // potentially even beneficial for performance, but it's not very principled.
-                // This case can probably be removed eventually, but we include it at the moment
-                // because we make extensive use of these types in our test suite. Note that some
-                // builtin types are not included here, since they do not have generic bases and
-                // are correctly handled by the `instance_member` method.
-                (
-                    Some(
-                        KnownClass::Str
-                        | KnownClass::Bytes
-                        | KnownClass::Tuple
-                        | KnownClass::Slice
-                        | KnownClass::Range,
-                    ),
-                    "__get__",
-                ) => Symbol::Unbound,
-
-                _ => {
-                    let SymbolAndQualifiers(symbol, _) = class.instance_member(db, name);
-                    symbol
-                }
-            },
-
-            Type::Union(union) => union.map_with_boundness(db, |elem| elem.static_member(db, name)),
-
-            Type::Intersection(intersection) => {
-                intersection.map_with_boundness(db, |elem| elem.static_member(db, name))
-            }
-
-            Type::IntLiteral(_) => match name {
-                "real" | "numerator" => Symbol::bound(self),
-                // TODO more attributes could probably be usefully special-cased
-                _ => KnownClass::Int.to_instance(db).static_member(db, name),
-            },
-
-            Type::BooleanLiteral(bool_value) => match name {
-                "real" | "numerator" => Symbol::bound(Type::IntLiteral(i64::from(*bool_value))),
-                _ => KnownClass::Bool.to_instance(db).static_member(db, name),
-            },
-
+            Type::IntLiteral(_) => KnownClass::Int.to_instance(db).instance_member(db, name),
+            Type::BooleanLiteral(_) => KnownClass::Bool.to_instance(db).instance_member(db, name),
             Type::StringLiteral(_) | Type::LiteralString => {
-                KnownClass::Str.to_instance(db).static_member(db, name)
+                KnownClass::Str.to_instance(db).instance_member(db, name)
             }
+            Type::BytesLiteral(_) => KnownClass::Bytes.to_instance(db).instance_member(db, name),
+            Type::SliceLiteral(_) => KnownClass::Slice.to_instance(db).instance_member(db, name),
+            Type::Tuple(_) => KnownClass::Tuple.to_instance(db).instance_member(db, name),
 
-            Type::BytesLiteral(_) => KnownClass::Bytes.to_instance(db).static_member(db, name),
+            Type::AlwaysTruthy | Type::AlwaysFalsy => Type::object(db).instance_member(db, name),
+            Type::ModuleLiteral(_) => KnownClass::ModuleType
+                .to_instance(db)
+                .instance_member(db, name),
 
-            // We could plausibly special-case `start`, `step`, and `stop` here,
-            // but it doesn't seem worth the complexity given the very narrow range of places
-            // where we infer `SliceLiteral` types.
-            Type::SliceLiteral(_) => KnownClass::Slice.to_instance(db).static_member(db, name),
+            Type::KnownInstance(_) => Symbol::Unbound.into(),
 
-            Type::Tuple(_) => {
-                // TODO: We might want to special case some attributes here, as the stubs
-                // for `builtins.tuple` assume that `self` is a homogeneous tuple, while
-                // we're explicitly modeling heterogeneous tuples using `Type::Tuple`.
-                KnownClass::Tuple.to_instance(db).static_member(db, name)
-            }
-
-            Type::AlwaysTruthy | Type::AlwaysFalsy => match name {
-                "__bool__" => {
-                    // TODO should be `Callable[[], Literal[True/False]]`
-                    Symbol::todo("`__bool__` for `AlwaysTruthy`/`AlwaysFalsy` Type variants")
-                }
-                _ => Type::object(db).static_member(db, name),
-            },
+            // TODO: we currently don't model the fact that class literals and subclass-of types have
+            // a `__dict__` that is filled with class level attributes. Modeling this is currently not
+            // required, as `instance_member` is only called for instance-like types through `member`,
+            // but we might want to add this in the future.
+            Type::ClassLiteral(_) | Type::SubclassOf(_) => Symbol::Unbound.into(),
         }
     }
 
-    /// Call the `__get__(instance, owner)` method on a type, and get the return
-    /// type of the call.
+    /// Access an attribute of this type without invoking the descriptor protocol. This
+    /// method corresponds to `inspect.getattr_static(<object of type 'self'>, name)`.
     ///
-    /// If `__get__` is not defined on the type, this method returns `Ok(None)`.
-    /// If the call to `__get__` fails, this method returns an error.
+    /// See also: [`Type::member`]
+    fn static_member(&self, db: &'db dyn Db, name: &str) -> Symbol<'db> {
+        if let Type::ModuleLiteral(module) = self {
+            module.static_member(db, name)
+        } else if let symbol @ Symbol::Type(_, _) = self.class_member(db, name.into()).symbol {
+            symbol
+        } else if let Some(symbol @ Symbol::Type(_, _)) =
+            self.find_name_in_mro(db, name).map(|inner| inner.symbol)
+        {
+            symbol
+        } else {
+            self.instance_member(db, name).symbol
+        }
+    }
+
+    /// Look up `__get__` on the meta type of self, and call it with the arguments `self`, `instance`,
+    /// and `owner`. `__get__` is different than other dunder methods in that it is not looked up using
+    /// the descriptor protocol itself.
+    ///
+    /// In addition to the return type of `__get__`, this method also returns the *kind* of attribute
+    /// that `self` represents: (1) a data descriptor or (2) a non-data descriptor / normal attribute.
+    ///
+    /// If `__get__` is not defined on the meta type, this method returns `None`.
+    #[salsa::tracked]
     fn try_call_dunder_get(
         self,
         db: &'db dyn Db,
-        instance: Option<Type<'db>>,
+        instance: Type<'db>,
         owner: Type<'db>,
-    ) -> Option<Type<'db>> {
-        #[salsa::tracked]
-        fn try_call_dunder_get_query<'db>(
-            db: &'db dyn Db,
-            ty_self: Type<'db>,
-            instance: Option<Type<'db>>,
-            owner: Type<'db>,
-        ) -> Option<Type<'db>> {
-            // TODO: Handle possible-unboundness and errors from `__get__` calls.
+    ) -> Option<(Type<'db>, AttributeKind)> {
+        let descr_get = self.class_member(db, "__get__".into()).symbol;
 
-            match ty_self {
-                Type::Union(union) => {
-                    let mut builder = UnionBuilder::new(db);
-                    for elem in union.elements(db) {
-                        let ty = if let Some(result) = elem.try_call_dunder_get(db, instance, owner)
-                        {
-                            result
-                        } else {
-                            *elem
-                        };
-                        builder = builder.add(ty);
+        if let Symbol::Type(descr_get, descr_get_boundness) = descr_get {
+            let return_ty = descr_get
+                .try_call(db, &CallArguments::positional([self, instance, owner]))
+                .map(|outcome| {
+                    if descr_get_boundness == Boundness::Bound {
+                        outcome.return_type(db)
+                    } else {
+                        UnionType::from_elements(db, [outcome.return_type(db), self])
                     }
-                    Some(builder.build())
-                }
-                Type::Intersection(intersection) => {
-                    if !intersection.negative(db).is_empty() {
-                        return Some(todo_type!(
-                            "try_call_dunder_get: intersections with negative contributions"
-                        ));
-                    }
+                })
+                .ok()?;
 
-                    let mut builder = IntersectionBuilder::new(db);
-                    for elem in intersection.positive(db) {
-                        let ty = if let Some(result) = elem.try_call_dunder_get(db, instance, owner)
-                        {
-                            result
-                        } else {
-                            *elem
-                        };
-                        builder = builder.add_positive(ty);
-                    }
-                    Some(builder.build())
-                }
-                _ => {
-                    // TODO: Handle possible-unboundness of `__get__` method
-                    // There is an existing test case for this in `descriptor_protocol.md`.
+            let descriptor_kind = if self.class_member(db, "__set__".into()).symbol.is_unbound()
+                && self
+                    .class_member(db, "__delete__".into())
+                    .symbol
+                    .is_unbound()
+            {
+                AttributeKind::NormalOrNonDataDescriptor
+            } else {
+                AttributeKind::DataDescriptor
+            };
 
-                    ty_self
-                        .member(db, "__get__")
-                        .ignore_possibly_unbound()?
-                        .try_call(
-                            db,
-                            &CallArguments::positional([instance.unwrap_or(Type::none(db)), owner]),
+            Some((return_ty, descriptor_kind))
+        } else {
+            None
+        }
+    }
+
+    /// Look up `__get__` on the meta type of `attribute`, and call it with `attribute`, `instance`,
+    /// and `owner` as arguments. This method exists as a separate step as we need to handle unions
+    /// and intersections explicitly.
+    fn try_call_dunder_get_on_attribute(
+        db: &'db dyn Db,
+        attribute: SymbolAndQualifiers<'db>,
+        instance: Type<'db>,
+        owner: Type<'db>,
+    ) -> (SymbolAndQualifiers<'db>, AttributeKind) {
+        match attribute {
+            // This branch is not strictly needed, but it short-circuits the lookup of various dunder
+            // methods and calls that would otherwise be made.
+            //
+            // Note that attribute accesses on dynamic types always succeed. For this reason, they also
+            // have `__get__`, `__set__`, and `__delete__` methods and are therefore considered to be
+            // data descriptors.
+            //
+            // The same is true for `Never`.
+            SymbolAndQualifiers {
+                symbol: Symbol::Type(Type::Dynamic(_) | Type::Never, _),
+                qualifiers: _,
+            } => (attribute, AttributeKind::DataDescriptor),
+
+            SymbolAndQualifiers {
+                symbol: Symbol::Type(Type::Union(union), boundness),
+                qualifiers,
+            } => (
+                union
+                    .map_with_boundness(db, |elem| {
+                        Symbol::Type(
+                            elem.try_call_dunder_get(db, instance, owner)
+                                .map_or(*elem, |(ty, _)| ty),
+                            boundness,
                         )
-                        .map(|outcome| Some(outcome.return_type(db)))
-                        .unwrap_or(None)
+                    })
+                    .with_qualifiers(qualifiers),
+                // TODO: avoid the duplication here:
+                if union.elements(db).iter().all(|elem| {
+                    elem.try_call_dunder_get(db, instance, owner)
+                        .is_some_and(|(_, kind)| kind.is_data())
+                }) {
+                    AttributeKind::DataDescriptor
+                } else {
+                    AttributeKind::NormalOrNonDataDescriptor
+                },
+            ),
+
+            SymbolAndQualifiers {
+                symbol: Symbol::Type(Type::Intersection(intersection), boundness),
+                qualifiers,
+            } => (
+                intersection
+                    .map_with_boundness(db, |elem| {
+                        Symbol::Type(
+                            elem.try_call_dunder_get(db, instance, owner)
+                                .map_or(*elem, |(ty, _)| ty),
+                            boundness,
+                        )
+                    })
+                    .with_qualifiers(qualifiers),
+                // TODO: Discover data descriptors in intersections.
+                AttributeKind::NormalOrNonDataDescriptor,
+            ),
+
+            SymbolAndQualifiers {
+                symbol: Symbol::Type(attribute_ty, boundness),
+                qualifiers,
+            } => {
+                if let Some((return_ty, attribute_kind)) =
+                    attribute_ty.try_call_dunder_get(db, instance, owner)
+                {
+                    (
+                        Symbol::Type(return_ty, boundness).with_qualifiers(qualifiers),
+                        attribute_kind,
+                    )
+                } else {
+                    (attribute, AttributeKind::NormalOrNonDataDescriptor)
                 }
             }
-        }
 
-        try_call_dunder_get_query(db, self, instance, owner)
+            _ => (attribute, AttributeKind::NormalOrNonDataDescriptor),
+        }
+    }
+
+    /// Implementation of the descriptor protocol.
+    ///
+    /// This method roughly performs the following steps:
+    ///
+    /// - Look up the attribute `name` on the meta type of `self`. Call the result `meta_attr`.
+    /// - Call `__get__` on the meta-type of `meta_attr`, if it exists. If the call succeeds,
+    ///   replace `meta_attr` with the result of the call. Also check if `meta_attr` is a *data*
+    ///   descriptor by testing if `__set__` or `__delete__` exist.
+    /// - If `meta_attr` is a data descriptor, return it.
+    /// - Otherwise, if `fallback` is bound, return `fallback`.
+    /// - Otherwise, return `meta_attr`.
+    ///
+    /// In addition to that, we also handle various cases of possibly-unbound symbols and fall
+    /// back to lower-precedence stages of the descriptor protocol by building union types.
+    fn invoke_descriptor_protocol(
+        self,
+        db: &'db dyn Db,
+        name: &str,
+        fallback: SymbolAndQualifiers<'db>,
+        policy: InstanceFallbackShadowsNonDataDescriptor,
+    ) -> SymbolAndQualifiers<'db> {
+        let (
+            SymbolAndQualifiers {
+                symbol: meta_attr,
+                qualifiers: meta_attr_qualifiers,
+            },
+            meta_attr_kind,
+        ) = Self::try_call_dunder_get_on_attribute(
+            db,
+            self.class_member(db, name.into()),
+            self,
+            self.to_meta_type(db),
+        );
+
+        let SymbolAndQualifiers {
+            symbol: fallback,
+            qualifiers: fallback_qualifiers,
+        } = fallback;
+
+        match (meta_attr, meta_attr_kind, fallback) {
+            // The fallback type is unbound, so we can just return `meta_attr` unconditionally,
+            // no matter if it's data descriptor, a non-data descriptor, or a normal attribute.
+            (meta_attr @ Symbol::Type(_, _), _, Symbol::Unbound) => {
+                meta_attr.with_qualifiers(meta_attr_qualifiers)
+            }
+
+            // `meta_attr` is the return type of a data descriptor and definitely bound, so we
+            // return it.
+            (meta_attr @ Symbol::Type(_, Boundness::Bound), AttributeKind::DataDescriptor, _) => {
+                meta_attr.with_qualifiers(meta_attr_qualifiers)
+            }
+
+            // `meta_attr` is the return type of a data descriptor, but the attribute on the
+            // meta type is possibly-unbound. This means that we "fall through" to the next
+            // stage of the descriptor protocol and union with the fallback type.
+            (
+                Symbol::Type(meta_attr_ty, Boundness::PossiblyUnbound),
+                AttributeKind::DataDescriptor,
+                Symbol::Type(fallback_ty, fallback_boundness),
+            ) => Symbol::Type(
+                UnionType::from_elements(db, [meta_attr_ty, fallback_ty]),
+                fallback_boundness,
+            )
+            .with_qualifiers(meta_attr_qualifiers.union(fallback_qualifiers)),
+
+            // `meta_attr` is *not* a data descriptor. This means that the `fallback` type has
+            // now the highest priority. However, we only return the pure `fallback` type if the
+            // policy allows it. When invoked on class objects, the policy is set to `Yes`, which
+            // means that class-level attributes (the fallback) can shadow non-data descriptors
+            // on metaclasses. However, for instances, the policy is set to `No`, because we do
+            // allow instance-level attributes to shadow class-level non-data descriptors. This
+            // would require us to statically infer if an instance attribute is always set, which
+            // is something we currently don't attempt to do.
+            (
+                Symbol::Type(_, _),
+                AttributeKind::NormalOrNonDataDescriptor,
+                fallback @ Symbol::Type(_, Boundness::Bound),
+            ) if policy == InstanceFallbackShadowsNonDataDescriptor::Yes => {
+                fallback.with_qualifiers(fallback_qualifiers)
+            }
+
+            // `meta_attr` is *not* a data descriptor. The `fallback` symbol is either possibly
+            // unbound or the policy argument is `No`. In both cases, the `fallback` type does
+            // not completely shadow the non-data descriptor, so we build a union of the two.
+            (
+                Symbol::Type(meta_attr_ty, meta_attr_boundness),
+                AttributeKind::NormalOrNonDataDescriptor,
+                Symbol::Type(fallback_ty, fallback_boundness),
+            ) => Symbol::Type(
+                UnionType::from_elements(db, [meta_attr_ty, fallback_ty]),
+                meta_attr_boundness.max(fallback_boundness),
+            )
+            .with_qualifiers(meta_attr_qualifiers.union(fallback_qualifiers)),
+
+            // If the attribute is not found on the meta type, we simply return the fallback.
+            (Symbol::Unbound, _, fallback) => fallback.with_qualifiers(fallback_qualifiers),
+        }
     }
 
     /// Access an attribute of this type, potentially invoking the descriptor protocol.
@@ -1556,27 +1860,61 @@ impl<'db> Type<'db> {
     /// TODO: We should return a `Result` here to handle errors that can appear during attribute
     /// lookup, like a failed `__get__` call on a descriptor.
     #[must_use]
-    pub(crate) fn member(&self, db: &'db dyn Db, name: &str) -> Symbol<'db> {
+    #[salsa::tracked]
+    pub(crate) fn member(self, db: &'db dyn Db, name: Name) -> SymbolAndQualifiers<'db> {
+        self.member_lookup_with_policy(db, name, MemberLookupPolicy::WithInstanceFallback)
+    }
+
+    /// Similar to [`Type::member`], but allows the caller to specify what policy should be used
+    /// when looking up attributes. See [`MemberLookupPolicy`] for more information.
+    fn member_lookup_with_policy(
+        &self,
+        db: &'db dyn Db,
+        name: Name,
+        policy: MemberLookupPolicy,
+    ) -> SymbolAndQualifiers<'db> {
         if name == "__class__" {
-            return Symbol::bound(self.to_meta_type(db));
+            return Symbol::bound(self.to_meta_type(db)).into();
         }
 
+        let name_str = name.as_str();
+
         match self {
+            Type::Union(union) => union
+                .map_with_boundness(db, |elem| elem.member(db, name.clone()).symbol)
+                .into(),
+
+            Type::Intersection(intersection) => intersection
+                .map_with_boundness(db, |elem| elem.member(db, name.clone()).symbol)
+                .into(),
+
+            Type::Dynamic(..) | Type::Never => Symbol::bound(self).into(),
+
             Type::FunctionLiteral(function) if name == "__get__" => Symbol::bound(Type::Callable(
                 CallableType::MethodWrapperDunderGet(*function),
-            )),
+            ))
+            .into(),
 
-            Type::Callable(CallableType::BoundMethod(bound_method)) => match name {
-                "__self__" => Symbol::bound(bound_method.self_instance(db)),
-                "__func__" => Symbol::bound(Type::FunctionLiteral(bound_method.function(db))),
+            Type::ClassLiteral(ClassLiteralType { class })
+                if class.is_known(db, KnownClass::FunctionType) && name == "__get__" =>
+            {
+                Symbol::bound(Type::Callable(CallableType::WrapperDescriptorDunderGet)).into()
+            }
+
+            Type::Callable(CallableType::BoundMethod(bound_method)) => match name_str {
+                "__self__" => Symbol::bound(bound_method.self_instance(db)).into(),
+                "__func__" => {
+                    Symbol::bound(Type::FunctionLiteral(bound_method.function(db))).into()
+                }
                 _ => {
                     KnownClass::MethodType
                         .to_instance(db)
-                        .member(db, name)
+                        .member(db, name.clone())
                         .or_fall_back_to(db, || {
                             // If an attribute is not available on the bound method object,
                             // it will be looked up on the underlying function object:
-                            Type::FunctionLiteral(bound_method.function(db)).member(db, name)
+                            Type::FunctionLiteral(bound_method.function(db))
+                                .member(db, name.clone())
                         })
                 }
             },
@@ -1591,6 +1929,43 @@ impl<'db> Type<'db> {
                     .member(db, name)
             }
 
+            Type::Instance(InstanceType { class })
+                if class.is_known(db, KnownClass::VersionInfo) && name == "major" =>
+            {
+                Symbol::bound(Type::IntLiteral(
+                    Program::get(db).python_version(db).major.into(),
+                ))
+                .into()
+            }
+            Type::Instance(InstanceType { class })
+                if class.is_known(db, KnownClass::VersionInfo) && name == "minor" =>
+            {
+                Symbol::bound(Type::IntLiteral(
+                    Program::get(db).python_version(db).minor.into(),
+                ))
+                .into()
+            }
+
+            Type::IntLiteral(_) if matches!(name_str, "real" | "numerator") => {
+                Symbol::bound(self).into()
+            }
+
+            Type::BooleanLiteral(bool_value) if matches!(name_str, "real" | "numerator") => {
+                Symbol::bound(Type::IntLiteral(i64::from(*bool_value))).into()
+            }
+
+            Type::ModuleLiteral(module) => module.static_member(db, name_str).into(),
+
+            Type::AlwaysFalsy | Type::AlwaysTruthy => self.class_member(db, name),
+
+            _ if policy == MemberLookupPolicy::NoInstanceFallback => self
+                .invoke_descriptor_protocol(
+                    db,
+                    name_str,
+                    Symbol::Unbound.into(),
+                    InstanceFallbackShadowsNonDataDescriptor::No,
+                ),
+
             Type::Instance(..)
             | Type::BooleanLiteral(..)
             | Type::IntLiteral(..)
@@ -1601,34 +1976,40 @@ impl<'db> Type<'db> {
             | Type::Tuple(..)
             | Type::KnownInstance(..)
             | Type::FunctionLiteral(..) => {
-                let member = self.static_member(db, name);
+                let fallback = self.instance_member(db, name_str);
 
-                let instance = Some(*self);
-                let owner = self.to_meta_type(db);
-
-                // TODO: Handle `__get__` call errors instead of using `.unwrap_or(None)`.
-                // There is an existing test case for this in `descriptor_protocol.md`.
-                member.map_type(|ty| ty.try_call_dunder_get(db, instance, owner).unwrap_or(ty))
+                self.invoke_descriptor_protocol(
+                    db,
+                    name_str,
+                    fallback,
+                    InstanceFallbackShadowsNonDataDescriptor::No,
+                )
             }
+
             Type::ClassLiteral(..) | Type::SubclassOf(..) => {
-                let member = self.static_member(db, name);
+                let class_attr_plain = self.find_name_in_mro(db, name_str).expect(
+                    "Calling `find_name_in_mro` on class literals and subclass-of types returns `Some` result",
+                );
 
-                let instance = None;
-                let owner = *self;
+                if name == "__mro__" {
+                    return class_attr_plain;
+                }
 
-                // TODO: Handle `__get__` call errors (see above).
-                member.map_type(|ty| ty.try_call_dunder_get(db, instance, owner).unwrap_or(ty))
+                let class_attr_fallback = Self::try_call_dunder_get_on_attribute(
+                    db,
+                    class_attr_plain,
+                    Type::none(db),
+                    *self,
+                )
+                .0;
+
+                self.invoke_descriptor_protocol(
+                    db,
+                    name_str,
+                    class_attr_fallback,
+                    InstanceFallbackShadowsNonDataDescriptor::Yes,
+                )
             }
-            Type::Union(union) => union.map_with_boundness(db, |elem| elem.member(db, name)),
-            Type::Intersection(intersection) => {
-                intersection.map_with_boundness(db, |elem| elem.member(db, name))
-            }
-
-            Type::Dynamic(..)
-            | Type::Never
-            | Type::AlwaysFalsy
-            | Type::AlwaysTruthy
-            | Type::ModuleLiteral(..) => self.static_member(db, name),
         }
     }
 
@@ -2036,9 +2417,50 @@ impl<'db> Type<'db> {
                                     if instance.is_none(db) {
                                         function_ty
                                     } else {
-                                        Type::Callable(CallableType::BoundMethod(
-                                            BoundMethodType::new(db, function, instance),
-                                        ))
+                                        match instance {
+                                            Type::KnownInstance(
+                                                KnownInstanceType::TypeAliasType(type_alias),
+                                            ) if arguments
+                                                .third_argument()
+                                                .and_then(Type::into_class_literal)
+                                                .is_some_and(|class_literal| {
+                                                    class_literal
+                                                        .class
+                                                        .is_known(db, KnownClass::TypeAliasType)
+                                                })
+                                                && function.name(db) == "__name__" =>
+                                            {
+                                                Type::string_literal(db, type_alias.name(db))
+                                            }
+                                            Type::KnownInstance(KnownInstanceType::TypeVar(
+                                                typevar,
+                                            )) if arguments
+                                                .third_argument()
+                                                .and_then(Type::into_class_literal)
+                                                .is_some_and(|class_literal| {
+                                                    class_literal
+                                                        .class
+                                                        .is_known(db, KnownClass::TypeVar)
+                                                })
+                                                && function.name(db) == "__name__" =>
+                                            {
+                                                Type::string_literal(db, typevar.name(db))
+                                            }
+                                            _ => {
+                                                if function.has_known_class_decorator(
+                                                    db,
+                                                    KnownClass::Property,
+                                                ) {
+                                                    todo_type!("@property")
+                                                } else {
+                                                    Type::Callable(CallableType::BoundMethod(
+                                                        BoundMethodType::new(
+                                                            db, function, instance,
+                                                        ),
+                                                    ))
+                                                }
+                                            }
+                                        }
                                     }
                                 } else {
                                     Type::unknown()
@@ -2295,18 +2717,12 @@ impl<'db> Type<'db> {
         name: &str,
         arguments: &CallArguments<'_, 'db>,
     ) -> Result<CallOutcome<'db>, CallDunderError<'db>> {
-        let meta_type = self.to_meta_type(db);
-
-        match meta_type.static_member(db, name) {
-            Symbol::Type(callable_ty, boundness) => {
-                // Dunder methods are looked up on the meta type, but they invoke the descriptor
-                // protocol *as if they had been called on the instance itself*. This is why we
-                // pass `Some(self)` for the `instance` argument here.
-                let callable_ty = callable_ty
-                    .try_call_dunder_get(db, Some(self), meta_type)
-                    .unwrap_or(callable_ty);
-
-                let result = callable_ty.try_call(db, arguments)?;
+        match self
+            .member_lookup_with_policy(db, name.into(), MemberLookupPolicy::NoInstanceFallback)
+            .symbol
+        {
+            Symbol::Type(dunder_callbable, boundness) => {
+                let result = dunder_callbable.try_call(db, arguments)?;
 
                 if boundness == Boundness::Bound {
                     Ok(result)
@@ -2750,6 +3166,9 @@ pub enum DynamicType {
     ///
     /// This variant should be created with the `todo_type!` macro.
     Todo(TodoType),
+    /// Temporary type until we support protocols. We use a separate variant (instead of `Todo(…)`)
+    /// in order to be able to match on them explicitly.
+    TodoProtocol,
 }
 
 impl std::fmt::Display for DynamicType {
@@ -2760,6 +3179,11 @@ impl std::fmt::Display for DynamicType {
             // `DynamicType::Todo`'s display should be explicit that is not a valid display of
             // any other type
             DynamicType::Todo(todo) => write!(f, "@Todo{todo}"),
+            DynamicType::TodoProtocol => f.write_str(if cfg!(debug_assertions) {
+                "@Todo(protocol)"
+            } else {
+                "@Todo"
+            }),
         }
     }
 }
@@ -3835,7 +4259,8 @@ impl<'db> ModuleLiteralType<'db> {
         if name == "__dict__" {
             return KnownClass::ModuleType
                 .to_instance(db)
-                .static_member(db, "__dict__");
+                .member(db, "__dict__".into())
+                .symbol;
         }
 
         // If the file that originally imported the module has also imported a submodule
@@ -3859,7 +4284,7 @@ impl<'db> ModuleLiteralType<'db> {
             }
         }
 
-        imported_symbol(db, &self.module(db), name)
+        imported_symbol(db, &self.module(db), name).symbol
     }
 }
 
@@ -3965,6 +4390,53 @@ impl<'db> UnionType<'db> {
                     Boundness::Bound
                 },
             )
+        }
+    }
+
+    pub(crate) fn map_with_boundness_and_qualifiers(
+        self,
+        db: &'db dyn Db,
+        mut transform_fn: impl FnMut(&Type<'db>) -> SymbolAndQualifiers<'db>,
+    ) -> SymbolAndQualifiers<'db> {
+        let mut builder = UnionBuilder::new(db);
+        let mut qualifiers = TypeQualifiers::empty();
+
+        let mut all_unbound = true;
+        let mut possibly_unbound = false;
+        for ty in self.elements(db) {
+            let SymbolAndQualifiers {
+                symbol: ty_member,
+                qualifiers: new_qualifiers,
+            } = transform_fn(ty);
+            qualifiers |= new_qualifiers;
+            match ty_member {
+                Symbol::Unbound => {
+                    possibly_unbound = true;
+                }
+                Symbol::Type(ty_member, member_boundness) => {
+                    if member_boundness == Boundness::PossiblyUnbound {
+                        possibly_unbound = true;
+                    }
+
+                    all_unbound = false;
+                    builder = builder.add(ty_member);
+                }
+            }
+        }
+        SymbolAndQualifiers {
+            symbol: if all_unbound {
+                Symbol::Unbound
+            } else {
+                Symbol::Type(
+                    builder.build(),
+                    if possibly_unbound {
+                        Boundness::PossiblyUnbound
+                    } else {
+                        Boundness::Bound
+                    },
+                )
+            },
+            qualifiers,
         }
     }
 
@@ -4233,6 +4705,58 @@ impl<'db> IntersectionType<'db> {
             )
         }
     }
+
+    pub(crate) fn map_with_boundness_and_qualifiers(
+        self,
+        db: &'db dyn Db,
+        mut transform_fn: impl FnMut(&Type<'db>) -> SymbolAndQualifiers<'db>,
+    ) -> SymbolAndQualifiers<'db> {
+        if !self.negative(db).is_empty() {
+            return Symbol::todo("map_with_boundness: intersections with negative contributions")
+                .into();
+        }
+
+        let mut builder = IntersectionBuilder::new(db);
+        let mut qualifiers = TypeQualifiers::empty();
+
+        let mut any_unbound = false;
+        let mut any_possibly_unbound = false;
+        for ty in self.positive(db) {
+            let SymbolAndQualifiers {
+                symbol: member,
+                qualifiers: new_qualifiers,
+            } = transform_fn(ty);
+            qualifiers |= new_qualifiers;
+            match member {
+                Symbol::Unbound => {
+                    any_unbound = true;
+                }
+                Symbol::Type(ty_member, member_boundness) => {
+                    if member_boundness == Boundness::PossiblyUnbound {
+                        any_possibly_unbound = true;
+                    }
+
+                    builder = builder.add_positive(ty_member);
+                }
+            }
+        }
+
+        SymbolAndQualifiers {
+            symbol: if any_unbound {
+                Symbol::Unbound
+            } else {
+                Symbol::Type(
+                    builder.build(),
+                    if any_possibly_unbound {
+                        Boundness::PossiblyUnbound
+                    } else {
+                        Boundness::Bound
+                    },
+                )
+            },
+            qualifiers,
+        }
+    }
 }
 
 #[salsa::interned]
@@ -4380,8 +4904,10 @@ pub(crate) mod tests {
             .build()
             .unwrap();
 
-        let typing_no_default = typing_symbol(&db, "NoDefault").expect_type();
-        let typing_extensions_no_default = typing_extensions_symbol(&db, "NoDefault").expect_type();
+        let typing_no_default = typing_symbol(&db, "NoDefault").symbol.expect_type();
+        let typing_extensions_no_default = typing_extensions_symbol(&db, "NoDefault")
+            .symbol
+            .expect_type();
 
         assert_eq!(typing_no_default.display(&db).to_string(), "NoDefault");
         assert_eq!(
@@ -4413,7 +4939,7 @@ pub(crate) mod tests {
         )?;
 
         let bar = system_path_to_file(&db, "src/bar.py")?;
-        let a = global_symbol(&db, bar, "a");
+        let a = global_symbol(&db, bar, "a").symbol;
 
         assert_eq!(
             a.expect_type(),
@@ -4432,7 +4958,7 @@ pub(crate) mod tests {
         )?;
         db.clear_salsa_events();
 
-        let a = global_symbol(&db, bar, "a");
+        let a = global_symbol(&db, bar, "a").symbol;
 
         assert_eq!(
             a.expect_type(),
@@ -4534,6 +5060,7 @@ pub(crate) mod tests {
             };
 
             let function_body_scope = known_module_symbol(&db, module, function_name)
+                .symbol
                 .expect_type()
                 .expect_function_literal()
                 .body_scope(&db);

--- a/crates/red_knot_python_semantic/src/types/class.rs
+++ b/crates/red_knot_python_semantic/src/types/class.rs
@@ -338,7 +338,7 @@ impl<'db> Class<'db> {
         for superclass in self.iter_mro(db) {
             match superclass {
                 ClassBase::Dynamic(DynamicType::TodoProtocol) => {
-                    // TODO: We currently skip protocols when looking up class members, in order to
+                    // TODO: We currently skip `Protocol` when looking up class members, in order to
                     // avoid creating many dynamic types in our test suite that would otherwise
                     // result from looking up attributes on builtin types like `str`, `list`, `tuple`
                 }
@@ -413,7 +413,7 @@ impl<'db> Class<'db> {
         for superclass in self.iter_mro(db) {
             match superclass {
                 ClassBase::Dynamic(DynamicType::TodoProtocol) => {
-                    // TODO: We currently skip protocols when looking up instance members, in order to
+                    // TODO: We currently skip `Protocol` when looking up instance members, in order to
                     // avoid creating many dynamic types in our test suite that would otherwise
                     // result from looking up attributes on builtin types like `str`, `list`, `tuple`
                 }

--- a/crates/red_knot_python_semantic/src/types/class.rs
+++ b/crates/red_knot_python_semantic/src/types/class.rs
@@ -9,8 +9,8 @@ use crate::{
         Boundness, LookupError, LookupResult, Symbol, SymbolAndQualifiers,
     },
     types::{
-        definition_expression_type, CallArguments, CallError, MetaclassCandidate, TupleType,
-        UnionBuilder, UnionCallError,
+        definition_expression_type, CallArguments, CallError, DynamicType, MetaclassCandidate,
+        TupleType, UnionBuilder, UnionCallError, UnionType,
     },
     Db, KnownModule, Program,
 };
@@ -318,10 +318,10 @@ impl<'db> Class<'db> {
     /// The member resolves to a member on the class itself or any of its proper superclasses.
     ///
     /// TODO: Should this be made private...?
-    pub(super) fn class_member(self, db: &'db dyn Db, name: &str) -> Symbol<'db> {
+    pub(super) fn class_member(self, db: &'db dyn Db, name: &str) -> SymbolAndQualifiers<'db> {
         if name == "__mro__" {
             let tuple_elements = self.iter_mro(db).map(Type::from);
-            return Symbol::bound(TupleType::from_elements(db, tuple_elements));
+            return Symbol::bound(TupleType::from_elements(db, tuple_elements)).into();
         }
 
         // If we encounter a dynamic type in this class's MRO, we'll save that dynamic type
@@ -332,10 +332,16 @@ impl<'db> Class<'db> {
         //     from the non-dynamic members of the class's MRO.
         let mut dynamic_type_to_intersect_with: Option<Type<'db>> = None;
 
-        let mut lookup_result: LookupResult<'db> = Err(LookupError::Unbound);
+        let mut lookup_result: LookupResult<'db> =
+            Err(LookupError::Unbound(TypeQualifiers::empty()));
 
         for superclass in self.iter_mro(db) {
             match superclass {
+                ClassBase::Dynamic(DynamicType::TodoProtocol) => {
+                    // TODO: We currently skip protocols when looking up class members, in order to
+                    // avoid creating many dynamic types in our test suite that would otherwise
+                    // result from looking up attributes on builtin types like `str`, `list`, `tuple`
+                }
                 ClassBase::Dynamic(_) => {
                     // Note: calling `Type::from(superclass).member()` would be incorrect here.
                     // What we'd really want is a `Type::Any.own_class_member()` method,
@@ -353,15 +359,33 @@ impl<'db> Class<'db> {
             }
         }
 
-        match (Symbol::from(lookup_result), dynamic_type_to_intersect_with) {
-            (symbol, None) => symbol,
-            (Symbol::Type(ty, _), Some(dynamic_type)) => Symbol::bound(
+        match (
+            SymbolAndQualifiers::from(lookup_result),
+            dynamic_type_to_intersect_with,
+        ) {
+            (symbol_and_qualifiers, None) => symbol_and_qualifiers,
+
+            (
+                SymbolAndQualifiers {
+                    symbol: Symbol::Type(ty, _),
+                    qualifiers,
+                },
+                Some(dynamic_type),
+            ) => Symbol::bound(
                 IntersectionBuilder::new(db)
                     .add_positive(ty)
                     .add_positive(dynamic_type)
                     .build(),
-            ),
-            (Symbol::Unbound, Some(dynamic_type)) => Symbol::bound(dynamic_type),
+            )
+            .with_qualifiers(qualifiers),
+
+            (
+                SymbolAndQualifiers {
+                    symbol: Symbol::Unbound,
+                    qualifiers,
+                },
+                Some(dynamic_type),
+            ) => Symbol::bound(dynamic_type).with_qualifiers(qualifiers),
         }
     }
 
@@ -371,7 +395,7 @@ impl<'db> Class<'db> {
     /// Returns [`Symbol::Unbound`] if `name` cannot be found in this class's scope
     /// directly. Use [`Class::class_member`] if you require a method that will
     /// traverse through the MRO until it finds the member.
-    pub(super) fn own_class_member(self, db: &'db dyn Db, name: &str) -> Symbol<'db> {
+    pub(super) fn own_class_member(self, db: &'db dyn Db, name: &str) -> SymbolAndQualifiers<'db> {
         let body_scope = self.body_scope(db);
         class_symbol(db, body_scope, name)
     }
@@ -388,17 +412,24 @@ impl<'db> Class<'db> {
 
         for superclass in self.iter_mro(db) {
             match superclass {
+                ClassBase::Dynamic(DynamicType::TodoProtocol) => {
+                    // TODO: We currently skip protocols when looking up instance members, in order to
+                    // avoid creating many dynamic types in our test suite that would otherwise
+                    // result from looking up attributes on builtin types like `str`, `list`, `tuple`
+                }
                 ClassBase::Dynamic(_) => {
                     return SymbolAndQualifiers::todo(
                         "instance attribute on class with dynamic base",
                     );
                 }
                 ClassBase::Class(class) => {
-                    if let member @ SymbolAndQualifiers(Symbol::Type(ty, boundness), qualifiers) =
-                        class.own_instance_member(db, name)
+                    if let member @ SymbolAndQualifiers {
+                        symbol: Symbol::Type(ty, boundness),
+                        qualifiers,
+                    } = class.own_instance_member(db, name)
                     {
                         // TODO: We could raise a diagnostic here if there are conflicting type qualifiers
-                        union_qualifiers = union_qualifiers.union(qualifiers);
+                        union_qualifiers |= qualifiers;
 
                         if boundness == Boundness::Bound {
                             if union.is_empty() {
@@ -406,10 +437,8 @@ impl<'db> Class<'db> {
                                 return member;
                             }
 
-                            return SymbolAndQualifiers(
-                                Symbol::bound(union.add(ty).build()),
-                                union_qualifiers,
-                            );
+                            return Symbol::bound(union.add(ty).build())
+                                .with_qualifiers(union_qualifiers);
                         }
 
                         // If we see a possibly-unbound symbol, we need to keep looking
@@ -421,15 +450,13 @@ impl<'db> Class<'db> {
         }
 
         if union.is_empty() {
-            SymbolAndQualifiers(Symbol::Unbound, TypeQualifiers::empty())
+            Symbol::Unbound.with_qualifiers(TypeQualifiers::empty())
         } else {
             // If we have reached this point, we know that we have only seen possibly-unbound symbols.
             // This means that the final result is still possibly-unbound.
 
-            SymbolAndQualifiers(
-                Symbol::Type(union.build(), Boundness::PossiblyUnbound),
-                union_qualifiers,
-            )
+            Symbol::Type(union.build(), Boundness::PossiblyUnbound)
+                .with_qualifiers(union_qualifiers)
         }
     }
 
@@ -439,31 +466,18 @@ impl<'db> Class<'db> {
         db: &'db dyn Db,
         class_body_scope: ScopeId<'db>,
         name: &str,
-        inferred_from_class_body: &Symbol<'db>,
-    ) -> Symbol<'db> {
+    ) -> Option<Type<'db>> {
         // If we do not see any declarations of an attribute, neither in the class body nor in
         // any method, we build a union of `Unknown` with the inferred types of all bindings of
         // that attribute. We include `Unknown` in that union to account for the fact that the
         // attribute might be externally modified.
         let mut union_of_inferred_types = UnionBuilder::new(db).add(Type::unknown());
-        let mut union_boundness = Boundness::Bound;
-
-        if let Symbol::Type(ty, boundness) = inferred_from_class_body {
-            union_of_inferred_types = union_of_inferred_types.add(*ty);
-            union_boundness = *boundness;
-        }
 
         let attribute_assignments = attribute_assignments(db, class_body_scope);
 
-        let Some(attribute_assignments) = attribute_assignments
+        let attribute_assignments = attribute_assignments
             .as_deref()
-            .and_then(|assignments| assignments.get(name))
-        else {
-            if inferred_from_class_body.is_unbound() {
-                return Symbol::Unbound;
-            }
-            return Symbol::Type(union_of_inferred_types.build(), union_boundness);
-        };
+            .and_then(|assignments| assignments.get(name))?;
 
         for attribute_assignment in attribute_assignments {
             match attribute_assignment {
@@ -477,7 +491,7 @@ impl<'db> Class<'db> {
                     let annotation_ty = infer_expression_type(db, *annotation);
 
                     // TODO: check if there are conflicting declarations
-                    return Symbol::bound(annotation_ty);
+                    return Some(annotation_ty);
                 }
                 AttributeAssignment::Unannotated { value } => {
                     // We found an un-annotated attribute assignment of the form:
@@ -516,7 +530,7 @@ impl<'db> Class<'db> {
             }
         }
 
-        Symbol::Type(union_of_inferred_types.build(), union_boundness)
+        Some(union_of_inferred_types.build())
     }
 
     /// A helper function for `instance_member` that looks up the `name` attribute only on
@@ -533,55 +547,93 @@ impl<'db> Class<'db> {
             let use_def = use_def_map(db, body_scope);
 
             let declarations = use_def.public_declarations(symbol_id);
-
-            match symbol_from_declarations(db, declarations) {
-                Ok(SymbolAndQualifiers(declared @ Symbol::Type(declared_ty, _), qualifiers)) => {
+            let declared_and_qualifiers = symbol_from_declarations(db, declarations);
+            match declared_and_qualifiers {
+                Ok(SymbolAndQualifiers {
+                    symbol: declared @ Symbol::Type(declared_ty, declaredness),
+                    qualifiers,
+                }) => {
                     // The attribute is declared in the class body.
-
-                    if let Some(function) = declared_ty.into_function_literal() {
-                        // TODO: Eventually, we are going to process all decorators correctly. This is
-                        // just a temporary heuristic to provide a broad categorization
-
-                        if function.has_known_class_decorator(db, KnownClass::Classmethod)
-                            && function.decorators(db).len() == 1
-                        {
-                            SymbolAndQualifiers(declared, qualifiers)
-                        } else if function.has_known_class_decorator(db, KnownClass::Property) {
-                            SymbolAndQualifiers::todo("@property")
-                        } else if function.has_known_function_decorator(db, KnownFunction::Overload)
-                        {
-                            SymbolAndQualifiers::todo("overloaded method")
-                        } else if !function.decorators(db).is_empty() {
-                            SymbolAndQualifiers::todo("decorated method")
-                        } else {
-                            SymbolAndQualifiers(declared, qualifiers)
-                        }
-                    } else {
-                        SymbolAndQualifiers(declared, qualifiers)
-                    }
-                }
-                Ok(SymbolAndQualifiers(Symbol::Unbound, _)) => {
-                    // The attribute is not *declared* in the class body. It could still be declared
-                    // in a method, and it could also be *bound* in the class body (and/or in a method).
 
                     let bindings = use_def.public_bindings(symbol_id);
                     let inferred = symbol_from_bindings(db, bindings);
+                    let has_binding = !inferred.is_unbound();
 
-                    Self::implicit_instance_attribute(db, body_scope, name, &inferred).into()
+                    if has_binding {
+                        // The attribute is declared and bound in the class body.
+
+                        if let Some(implicit_ty) =
+                            Self::implicit_instance_attribute(db, body_scope, name)
+                        {
+                            if declaredness == Boundness::Bound {
+                                // If a symbol is definitely declared, and we see
+                                // attribute assignments in methods of the class,
+                                // we trust the declared type.
+                                declared.with_qualifiers(qualifiers)
+                            } else {
+                                Symbol::Type(
+                                    UnionType::from_elements(db, [declared_ty, implicit_ty]),
+                                    declaredness,
+                                )
+                                .with_qualifiers(qualifiers)
+                            }
+                        } else {
+                            // The symbol is declared and bound in the class body,
+                            // but we did not find any attribute assignments in
+                            // methods of the class. This means that the attribute
+                            // has a class-level default value, but it would not be
+                            // found in a `__dict__` lookup.
+
+                            Symbol::Unbound.into()
+                        }
+                    } else {
+                        // The attribute is declared but not bound in the class body.
+                        // We take this as a sign that this is intended to be a pure
+                        // instance attribute, and we trust the declared type, unless
+                        // it is possibly-undeclared. In the latter case, we also
+                        // union with the inferred type from attribute assignments.
+
+                        if declaredness == Boundness::Bound {
+                            declared.with_qualifiers(qualifiers)
+                        } else {
+                            if let Some(implicit_ty) =
+                                Self::implicit_instance_attribute(db, body_scope, name)
+                            {
+                                Symbol::Type(
+                                    UnionType::from_elements(db, [declared_ty, implicit_ty]),
+                                    declaredness,
+                                )
+                                .with_qualifiers(qualifiers)
+                            } else {
+                                declared.with_qualifiers(qualifiers)
+                            }
+                        }
+                    }
                 }
-                Err((declared_ty, _conflicting_declarations)) => {
+
+                Ok(SymbolAndQualifiers {
+                    symbol: Symbol::Unbound,
+                    qualifiers: _,
+                }) => {
+                    // The attribute is not *declared* in the class body. It could still be declared/bound
+                    // in a method.
+
+                    Self::implicit_instance_attribute(db, body_scope, name)
+                        .map_or(Symbol::Unbound, Symbol::bound)
+                        .into()
+                }
+                Err((declared, _conflicting_declarations)) => {
                     // There are conflicting declarations for this attribute in the class body.
-                    SymbolAndQualifiers(
-                        Symbol::bound(declared_ty.inner_type()),
-                        declared_ty.qualifiers(),
-                    )
+                    Symbol::bound(declared.inner_type()).with_qualifiers(declared.qualifiers())
                 }
             }
         } else {
             // This attribute is neither declared nor bound in the class body.
             // It could still be implicitly defined in a method.
 
-            Self::implicit_instance_attribute(db, body_scope, name, &Symbol::Unbound).into()
+            Self::implicit_instance_attribute(db, body_scope, name)
+                .map_or(Symbol::Unbound, Symbol::bound)
+                .into()
         }
     }
 
@@ -663,7 +715,7 @@ impl<'db> ClassLiteralType<'db> {
         self.class.body_scope(db)
     }
 
-    pub(super) fn static_member(self, db: &'db dyn Db, name: &str) -> Symbol<'db> {
+    pub(super) fn class_member(self, db: &'db dyn Db, name: &str) -> SymbolAndQualifiers<'db> {
         self.class.class_member(db, name)
     }
 }
@@ -881,6 +933,7 @@ impl<'db> KnownClass {
 
     pub(crate) fn to_class_literal(self, db: &'db dyn Db) -> Type<'db> {
         known_module_symbol(db, self.canonical_module(db), self.as_str(db))
+            .symbol
             .ignore_possibly_unbound()
             .unwrap_or(Type::unknown())
     }
@@ -896,6 +949,7 @@ impl<'db> KnownClass {
     /// *and* `class` is a subclass of `other`.
     pub(super) fn is_subclass_of(self, db: &'db dyn Db, other: Class<'db>) -> bool {
         known_module_symbol(db, self.canonical_module(db), self.as_str(db))
+            .symbol
             .ignore_possibly_unbound()
             .and_then(Type::into_class_literal)
             .is_some_and(|ClassLiteralType { class }| class.is_subclass_of(db, other))
@@ -1203,6 +1257,8 @@ pub enum KnownInstanceType<'db> {
     Deque,
     /// The symbol `typing.OrderedDict` (which can also be found as `typing_extensions.OrderedDict`)
     OrderedDict,
+    /// The symbol `typing.Protocol` (which can also be found as `typing_extensions.Protocol`)
+    Protocol,
     /// The symbol `typing.Type` (which can also be found as `typing_extensions.Type`)
     Type,
     /// A single instance of `typing.TypeVar`
@@ -1274,6 +1330,7 @@ impl<'db> KnownInstanceType<'db> {
             | Self::Deque
             | Self::ChainMap
             | Self::OrderedDict
+            | Self::Protocol
             | Self::ReadOnly
             | Self::TypeAliasType(_)
             | Self::Unknown
@@ -1318,6 +1375,7 @@ impl<'db> KnownInstanceType<'db> {
             Self::Deque => "typing.Deque",
             Self::ChainMap => "typing.ChainMap",
             Self::OrderedDict => "typing.OrderedDict",
+            Self::Protocol => "typing.Protocol",
             Self::ReadOnly => "typing.ReadOnly",
             Self::TypeVar(typevar) => typevar.name(db),
             Self::TypeAliasType(_) => "typing.TypeAliasType",
@@ -1364,6 +1422,7 @@ impl<'db> KnownInstanceType<'db> {
             Self::Deque => KnownClass::StdlibAlias,
             Self::ChainMap => KnownClass::StdlibAlias,
             Self::OrderedDict => KnownClass::StdlibAlias,
+            Self::Protocol => KnownClass::SpecialForm,
             Self::TypeVar(_) => KnownClass::TypeVar,
             Self::TypeAliasType(_) => KnownClass::TypeAliasType,
             Self::TypeOf => KnownClass::SpecialForm,
@@ -1406,6 +1465,7 @@ impl<'db> KnownInstanceType<'db> {
             "Counter" => Self::Counter,
             "ChainMap" => Self::ChainMap,
             "OrderedDict" => Self::OrderedDict,
+            "Protocol" => Self::Protocol,
             "Optional" => Self::Optional,
             "Union" => Self::Union,
             "NoReturn" => Self::NoReturn,
@@ -1457,6 +1517,7 @@ impl<'db> KnownInstanceType<'db> {
             | Self::Counter
             | Self::ChainMap
             | Self::OrderedDict
+            | Self::Protocol
             | Self::Optional
             | Self::Union
             | Self::NoReturn
@@ -1488,15 +1549,6 @@ impl<'db> KnownInstanceType<'db> {
             | Self::Intersection
             | Self::TypeOf => module.is_knot_extensions(),
         }
-    }
-
-    pub(super) fn static_member(self, db: &'db dyn Db, name: &str) -> Symbol<'db> {
-        let ty = match (self, name) {
-            (Self::TypeVar(typevar), "__name__") => Type::string_literal(db, typevar.name(db)),
-            (Self::TypeAliasType(alias), "__name__") => Type::string_literal(db, alias.name(db)),
-            _ => return self.instance_fallback(db).static_member(db, name),
-        };
-        Symbol::bound(ty)
     }
 }
 

--- a/crates/red_knot_python_semantic/src/types/class_base.rs
+++ b/crates/red_knot_python_semantic/src/types/class_base.rs
@@ -144,6 +144,7 @@ impl<'db> ClassBase<'db> {
                 KnownInstanceType::Callable => {
                     Self::try_from_type(db, todo_type!("Support for Callable as a base class"))
                 }
+                KnownInstanceType::Protocol => Some(ClassBase::Dynamic(DynamicType::TodoProtocol)),
             },
         }
     }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -6755,7 +6755,7 @@ mod tests {
             assert_eq!(var_ty.display(&db).to_string(), var);
 
             let expected_name_ty = format!(r#"Literal["{var}"]"#);
-            let name_ty = var_ty.member(&db, "__name__".into()).symbol.expect_type();
+            let name_ty = var_ty.member(&db, "__name__").symbol.expect_type();
             assert_eq!(name_ty.display(&db).to_string(), expected_name_ty);
 
             let KnownInstanceType::TypeVar(typevar) = var_ty.expect_known_instance() else {

--- a/crates/red_knot_python_semantic/src/types/property_tests.rs
+++ b/crates/red_knot_python_semantic/src/types/property_tests.rs
@@ -100,13 +100,16 @@ impl Ty {
             Ty::BooleanLiteral(b) => Type::BooleanLiteral(b),
             Ty::LiteralString => Type::LiteralString,
             Ty::BytesLiteral(s) => Type::bytes_literal(db, s.as_bytes()),
-            Ty::BuiltinInstance(s) => builtins_symbol(db, s).expect_type().to_instance(db),
+            Ty::BuiltinInstance(s) => builtins_symbol(db, s).symbol.expect_type().to_instance(db),
             Ty::AbcInstance(s) => known_module_symbol(db, KnownModule::Abc, s)
+                .symbol
                 .expect_type()
                 .to_instance(db),
-            Ty::AbcClassLiteral(s) => known_module_symbol(db, KnownModule::Abc, s).expect_type(),
+            Ty::AbcClassLiteral(s) => known_module_symbol(db, KnownModule::Abc, s)
+                .symbol
+                .expect_type(),
             Ty::TypingLiteral => Type::KnownInstance(KnownInstanceType::Literal),
-            Ty::BuiltinClassLiteral(s) => builtins_symbol(db, s).expect_type(),
+            Ty::BuiltinClassLiteral(s) => builtins_symbol(db, s).symbol.expect_type(),
             Ty::KnownClassInstance(known_class) => known_class.to_instance(db),
             Ty::Union(tys) => {
                 UnionType::from_elements(db, tys.into_iter().map(|ty| ty.into_type(db)))
@@ -129,6 +132,7 @@ impl Ty {
             Ty::SubclassOfBuiltinClass(s) => SubclassOfType::from(
                 db,
                 builtins_symbol(db, s)
+                    .symbol
                     .expect_type()
                     .expect_class_literal()
                     .class,
@@ -136,16 +140,20 @@ impl Ty {
             Ty::SubclassOfAbcClass(s) => SubclassOfType::from(
                 db,
                 known_module_symbol(db, KnownModule::Abc, s)
+                    .symbol
                     .expect_type()
                     .expect_class_literal()
                     .class,
             ),
             Ty::AlwaysTruthy => Type::AlwaysTruthy,
             Ty::AlwaysFalsy => Type::AlwaysFalsy,
-            Ty::BuiltinsFunction(name) => builtins_symbol(db, name).expect_type(),
+            Ty::BuiltinsFunction(name) => builtins_symbol(db, name).symbol.expect_type(),
             Ty::BuiltinsBoundMethod { class, method } => {
-                let builtins_class = builtins_symbol(db, class).expect_type();
-                let function = builtins_class.static_member(db, method).expect_type();
+                let builtins_class = builtins_symbol(db, class).symbol.expect_type();
+                let function = builtins_class
+                    .class_member(db, method.into())
+                    .symbol
+                    .expect_type();
 
                 create_bound_method(db, function, builtins_class)
             }

--- a/crates/red_knot_python_semantic/src/types/signatures.rs
+++ b/crates/red_knot_python_semantic/src/types/signatures.rs
@@ -354,6 +354,7 @@ mod tests {
     fn get_function_f<'db>(db: &'db TestDb, file: &'static str) -> FunctionType<'db> {
         let module = ruff_db::files::system_path_to_file(db, file).unwrap();
         global_symbol(db, module, "f")
+            .symbol
             .expect_type()
             .expect_function_literal()
     }

--- a/crates/red_knot_python_semantic/src/types/slots.rs
+++ b/crates/red_knot_python_semantic/src/types/slots.rs
@@ -24,7 +24,7 @@ enum SlotsKind {
 
 impl SlotsKind {
     fn from(db: &dyn Db, base: Class) -> Self {
-        let Symbol::Type(slots_ty, bound) = base.own_class_member(db, "__slots__") else {
+        let Symbol::Type(slots_ty, bound) = base.own_class_member(db, "__slots__").symbol else {
             return Self::NotSpecified;
         };
 

--- a/crates/red_knot_python_semantic/src/types/subclass_of.rs
+++ b/crates/red_knot_python_semantic/src/types/subclass_of.rs
@@ -1,4 +1,6 @@
-use super::{ClassBase, ClassLiteralType, Db, KnownClass, Symbol, Type};
+use crate::symbol::SymbolAndQualifiers;
+
+use super::{ClassBase, ClassLiteralType, Db, KnownClass, Type};
 
 /// A type that represents `type[C]`, i.e. the class object `C` and class objects that are subclasses of `C`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, salsa::Update)]
@@ -64,8 +66,12 @@ impl<'db> SubclassOfType<'db> {
         !self.is_dynamic()
     }
 
-    pub(crate) fn static_member(self, db: &'db dyn Db, name: &str) -> Symbol<'db> {
-        Type::from(self.subclass_of).static_member(db, name)
+    pub(crate) fn find_name_in_mro(
+        self,
+        db: &'db dyn Db,
+        name: &str,
+    ) -> Option<SymbolAndQualifiers<'db>> {
+        Type::from(self.subclass_of).find_name_in_mro(db, name)
     }
 
     /// Return `true` if `self` is a subtype of `other`.

--- a/crates/red_knot_python_semantic/src/types/type_ordering.rs
+++ b/crates/red_knot_python_semantic/src/types/type_ordering.rs
@@ -184,6 +184,9 @@ pub(super) fn union_elements_ordering<'db>(left: &Type<'db>, right: &Type<'db>) 
                 (KnownInstanceType::OrderedDict, _) => Ordering::Less,
                 (_, KnownInstanceType::OrderedDict) => Ordering::Greater,
 
+                (KnownInstanceType::Protocol, _) => Ordering::Less,
+                (_, KnownInstanceType::Protocol) => Ordering::Greater,
+
                 (KnownInstanceType::NoReturn, _) => Ordering::Less,
                 (_, KnownInstanceType::NoReturn) => Ordering::Greater,
 
@@ -285,5 +288,8 @@ fn dynamic_elements_ordering(left: DynamicType, right: DynamicType) -> Ordering 
 
         #[cfg(not(debug_assertions))]
         (DynamicType::Todo(TodoType), DynamicType::Todo(TodoType)) => Ordering::Equal,
+
+        (DynamicType::TodoProtocol, _) => Ordering::Less,
+        (_, DynamicType::TodoProtocol) => Ordering::Greater,
     }
 }


### PR DESCRIPTION
## Summary

* Attributes/method are now properly looked up on metaclasses, when called on class objects
* We properly distinguish between data descriptors and non-data descriptors (but we do not yet support them in store-context, i.e. `obj.data_descr = …`)
* The descriptor protocol is now implemented in a single unified place for instances, classes and dunder-calls. Unions and possibly-unbound symbols are supported in all possible stages of the process by creating union types as results.
* In general, the handling of "possibly-unbound" symbols has been improved in a lot of places: meta-class attributes, attributes, descriptors with possibly-unbound `__get__` methods, instance attributes, …
* We keep track of type qualifiers in a lot more places. I anticipate that this will be useful if we import e.g. `Final` symbols from other modules (see relevant change to typing spec: https://github.com/python/typing/pull/1937).
* Detection and special-casing of the `typing.Protocol` special form in order to avoid lots of changes in the test suite due to new `@Todo` types when looking up attributes on builtin types which have `Protocol` in their MRO. We previously 
looked up attributes in a wrong way, which is why this didn't come up before.

closes #16367
closes #15966

## Context

The way attribute lookup in `Type::member` worked before was simply wrong (mostly my own fault). The whole instance-attribute lookup should probably never have been integrated into `Type::member`. And the `Type::static_member` function that I introduced in my last descriptor PR was the wrong abstraction. It's kind of fascinating how far this approach took us, but I am pretty confident that the new approach proposed here is what we need to model this correctly.

There are three key pieces that are required to implement attribute lookups:

- **`Type::class_member`**/**`Type::find_in_mro`**: The `Type::find_in_mro` method that can look up attributes on class bodies (and corresponding bases). This is a partial function on types, as it can not be called on instance types like`Type::Instance(…)` or `Type::IntLiteral(…)`. For this reason, we usually call it through `Type::class_member`, which is essentially just `type.to_meta_type().find_in_mro(…)` plus union/intersection handling.
- **`Type::instance_member`**: This new function is basically the type-level equivalent to `obj.__dict__[name]` when called on `Type::Instance(…)`. We use this to discover instance attributes such as those that we see as declarations on class bodies or as (annotated) assignments to `self.attr` in methods of a class.
- The implementation of the descriptor protocol. It works slightly different for instances and for class objects, but it can be described by the general framework:
  - Call `type.class_member("attribute")` to look up "attribute" in the MRO of the meta type of `type`. Call the resulting `Symbol` `meta_attr` (even if it's unbound).
  - Use `meta_attr.class_member("__get__")` to look up `__get__` on the *meta type* of `meta_attr`. Call it with `__get__(meta_attr, self, self.to_meta_type())`. If this fails (either the lookup or the call), just proceed with `meta_attr`. Otherwise, replace `meta_attr` in the following with the return type of `__get__`. In this step, we also probe if a `__set__` or `__delete__` method exists and store it in `meta_attr_kind` (can be either "data descriptor" or "normal attribute or non-data descriptor").
  - Compute a `fallback` type.
    - For instances, we use `self.instance_member("attribute")`
    - For class objects, we use `class_attr = self.find_in_mro("attribute")`, and then try to invoke the descriptor protocol on `class_attr`, i.e. we look up `__get__` on the meta type of `class_attr` and call it with `__get__(class_attr, None, self)`. This additional invocation of the descriptor protocol on the fallback type is one major asymmetry in the otherwise universal descriptor protocol implementation.
  - Finally, we look at `meta_attr`, `meta_attr_kind` and `fallback`, and handle various cases of (possible) unboundness of these symbols.
    - If `meta_attr` is bound and a data descriptor, just return `meta_attr`
    - If `meta_attr` is not a data descriptor, and `fallback` is bound, just return `fallback`
    - If `meta_attr` is not a data descriptor, and `fallback` is unbound, return `meta_attr`
    - Return unions of these three possibilities for partially-bound symbols.

This allows us to handle class objects and instances within the same framework. There is a minor additional detail where for instances, we do not allow the fallback type (the instance attribute) to completely shadow the non-data descriptor. We do this because we (currently) don't want to pretend that we can statically infer that an instance attribute is always set.

Dunder method calls can also be embedded into this framework. The only thing that changes is that *there is no fallback type*. If a dunder method is called on an instance, we do not fall back to instance variables. If a dunder method is called on a class object, we only look it up on the meta class, never on the class itself.

## Test Plan

New Markdown tests.