### PR TITLE
Show version-related syntax errors in the playground

### DIFF
--- a/crates/ruff_wasm/src/lib.rs
+++ b/crates/ruff_wasm/src/lib.rs
@@ -238,6 +238,18 @@ impl Workspace {
                     fix: None,
                 }
             }))
+            .chain(parsed.unsupported_syntax_errors().iter().map(|error| {
+                let start_location = source_code.source_location(error.range.start());
+                let end_location = source_code.source_location(error.range.end());
+
+                ExpandedMessage {
+                    code: None,
+                    message: format!("SyntaxError: {error}"),
+                    location: start_location,
+                    end_location,
+                    fix: None,
+                }
+            }))
             .collect();
 
         serde_wasm_bindgen::to_value(&messages).map_err(into_error)

--- a/crates/ruff_wasm/tests/api.rs
+++ b/crates/ruff_wasm/tests/api.rs
@@ -68,7 +68,7 @@ fn unsupported_syntax_error() {
         r#"{}"#,
         [ExpandedMessage {
             code: None,
-            message: "SyntaxError: Cannot use `match` statement on Python 3.9 (syntax was added in Python {})".to_string(),
+            message: "SyntaxError: Cannot use `match` statement on Python 3.9 (syntax was added in Python 3.10)".to_string(),
             location: SourceLocation {
                 row: OneIndexed::from_zero_indexed(0),
                 column: OneIndexed::from_zero_indexed(0)

--- a/crates/ruff_wasm/tests/api.rs
+++ b/crates/ruff_wasm/tests/api.rs
@@ -62,6 +62,27 @@ fn syntax_error() {
 }
 
 #[wasm_bindgen_test]
+fn unsupported_syntax_error() {
+    check!(
+        "match 2:\n    case 1: ...",
+        r#"{}"#,
+        [ExpandedMessage {
+            code: None,
+            message: "SyntaxError: Cannot use `match` statement on Python 3.9 (syntax was added in Python {})".to_string(),
+            location: SourceLocation {
+                row: OneIndexed::from_zero_indexed(0),
+                column: OneIndexed::from_zero_indexed(0)
+            },
+            end_location: SourceLocation {
+                row: OneIndexed::from_zero_indexed(0),
+                column: OneIndexed::from_zero_indexed(5)
+            },
+            fix: None,
+        }]
+    );
+}
+
+#[wasm_bindgen_test]
 fn partial_config() {
     check!("if (1, 2):\n    pass", r#"{"ignore": ["F"]}"#, []);
 }


### PR DESCRIPTION
## Summary

Fixes part of https://github.com/astral-sh/ruff/issues/16417 by converting `unsupported_syntax_errors` into playground diagnostics.

## Test Plan

A new `ruff_wasm` test, plus trying out the playground locally:

Default settings:
![image](https://github.com/user-attachments/assets/94377ab5-4d4c-44d3-ae63-fe328a53e083)

`target-version = "py310"`:
![image](https://github.com/user-attachments/assets/51c312ce-70e7-43d3-b6ba-098f2750cb28)

