### PR TITLE
[`flake8-copyright`] Add links to applicable options (`CPY001`)

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_copyright/rules/missing_copyright_notice.rs
+++ b/crates/ruff_linter/src/rules/flake8_copyright/rules/missing_copyright_notice.rs
@@ -13,6 +13,11 @@ use crate::Locator;
 /// ## Why is this bad?
 /// In some codebases, it's common to have a license header at the top of every
 /// file. This rule ensures that the license header is present.
+///
+/// ## Options
+/// - `lint.flake8-copyright.author`
+/// - `lint.flake8-copyright.min-file-size`
+/// - `lint.flake8-copyright.notice-rgx`
 #[derive(ViolationMetadata)]
 pub(crate) struct MissingCopyrightNotice;
 


### PR DESCRIPTION
## Summary

Resolves #16420.

`CPY001`'s documentation now links to all three options in the [`lint.flake8-copyright`](https://docs.astral.sh/ruff/settings/#lintflake8-copyright) section.

## Test Plan

`cargo nextest run` and `cargo insta test`.
