### PR TITLE
[red-knot] Switch to a handwritten parser for mdtest error assertions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2549,6 +2549,7 @@ dependencies = [
  "salsa",
  "serde",
  "smallvec",
+ "thiserror 2.0.11",
  "toml",
 ]
 

--- a/crates/red_knot_test/Cargo.toml
+++ b/crates/red_knot_test/Cargo.toml
@@ -31,6 +31,7 @@ salsa = { workspace = true }
 smallvec = { workspace = true }
 serde = { workspace = true }
 toml = { workspace = true }
+thiserror = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/red_knot_test/src/assertion.rs
+++ b/crates/red_knot_test/src/assertion.rs
@@ -91,7 +91,7 @@ impl<'a> IntoIterator for &'a InlineFileAssertions {
     }
 }
 
-/// An [`Assertion`] with the [`TextRange`] of its original inline comment.
+/// An [`UnparsedAssertion`] with the [`TextRange`] of its original inline comment.
 #[derive(Debug)]
 struct AssertionWithRange<'a>(UnparsedAssertion<'a>, TextRange);
 
@@ -138,7 +138,7 @@ impl<'a> Iterator for AssertionWithRangeIterator<'a> {
 
 impl std::iter::FusedIterator for AssertionWithRangeIterator<'_> {}
 
-/// A vector of [`Assertion`]s belonging to a single line.
+/// A vector of [`UnparsedAssertion`]s belonging to a single line.
 ///
 /// Most lines will have zero or one assertion, so we use a [`SmallVec`] optimized for a single
 /// element to avoid most heap vector allocations.

--- a/crates/red_knot_test/src/matcher.rs
+++ b/crates/red_knot_test/src/matcher.rs
@@ -139,6 +139,10 @@ trait UnmatchedWithColumn {
 // This is necessary since we only parse assertions lazily,
 // and sometimes we know before parsing any assertions that an assertion will be unmatched,
 // e.g. if we've exhausted all diagnostics but there are still assertions left.
+//
+// TODO: the lazy parsing means that we sometimes won't report malformed assertions as
+// being invalid if we detect that they'll be unmatched before parsing them.
+// That's perhaps not the best user experience.
 impl Unmatched for UnparsedAssertion<'_> {
     fn unmatched(&self) -> String {
         format!("{} {self}", "unmatched assertion:".red())

--- a/crates/red_knot_test/src/matcher.rs
+++ b/crates/red_knot_test/src/matcher.rs
@@ -651,6 +651,34 @@ mod tests {
     }
 
     #[test]
+    fn error_match_rule_no_whitespace() {
+        let result = get_result(
+            "x #error:[some-rule]",
+            vec![ExpectedDiagnostic::new(
+                DiagnosticId::lint("some-rule"),
+                "Any message",
+                0,
+            )],
+        );
+
+        assert_ok(&result);
+    }
+
+    #[test]
+    fn error_match_rule_lots_of_whitespace() {
+        let result = get_result(
+            "x   #  error  :  [ some-rule ]",
+            vec![ExpectedDiagnostic::new(
+                DiagnosticId::lint("some-rule"),
+                "Any message",
+                0,
+            )],
+        );
+
+        assert_ok(&result);
+    }
+
+    #[test]
     fn error_wrong_rule() {
         let result = get_result(
             "x # error: [some-rule]",

--- a/crates/red_knot_test/src/matcher.rs
+++ b/crates/red_knot_test/src/matcher.rs
@@ -1,4 +1,4 @@
-//! Match [`Diagnostic`]s against [`Assertion`]s and produce test failure messages for any
+//! Match [`Diagnostic`]s against assertions and produce test failure messages for any
 //! mismatches.
 use crate::assertion::{InlineFileAssertions, ParsedAssertion, UnparsedAssertion};
 use crate::db::Db;
@@ -222,7 +222,7 @@ impl Matcher {
         }
     }
 
-    /// Check a slice of [`Diagnostic`]s against a slice of [`Assertion`]s.
+    /// Check a slice of [`Diagnostic`]s against a slice of [`UnparsedAssertion`]s.
     ///
     /// Return vector of [`Unmatched`] for any unmatched diagnostics or assertions.
     fn match_line<'a, 'b, T: Diagnostic + 'a>(

--- a/crates/red_knot_test/src/matcher.rs
+++ b/crates/red_knot_test/src/matcher.rs
@@ -136,6 +136,9 @@ trait UnmatchedWithColumn {
     fn unmatched_with_column(&self, column: OneIndexed) -> String;
 }
 
+// This is necessary since we only parse assertions lazily,
+// and sometimes we know before parsing any assertions that an assertion will be unmatched,
+// e.g. if we've exhausted all diagnostics but there are still assertions left.
 impl Unmatched for UnparsedAssertion<'_> {
     fn unmatched(&self) -> String {
         format!("{} {self}", "unmatched assertion:".red())


### PR DESCRIPTION
## Summary

I keep on making mistakes when writing mdtests that the framework makes hard to debug. The latest iteration here was when I added a test that looked like this while working on https://github.com/astral-sh/ruff/pull/16321:

````md
```py
class TestIter:
    def __next__(self) -> int:
        return 42

class Test:
    def __iter__(self) -> TestIter | int:
        return TestIter()

# error: [not-iterable] "Object of type `Test` may not be iterable because its `__iter__` method returns an object of type `TestIter | int`, which may not have a `__next__` method
for x in Test():
    reveal_type(x)  # revealed: int
```
````

Notice the mistake there? It took me an annoying amount of time to figure it out. The error in the test is that the asserted error message is missing its closing `"` character. But mdtest doesn't tell you that if you apply this diff to `main`:

```diff
diff --git a/crates/red_knot_python_semantic/resources/mdtest/loops/for.md b/crates/red_knot_python_semantic/resources/mdtest/loops/for.md
index 394c104b9..c32cbda7e 100644
--- a/crates/red_knot_python_semantic/resources/mdtest/loops/for.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/loops/for.md
@@ -286,7 +286,7 @@ class Test:
     def __iter__(self) -> TestIter | int:
         return TestIter()
 
-# error: [not-iterable] "Object of type `Test` may not be iterable because its `__iter__` method returns an object of type `TestIter | int`, which may not have a `__next__` method"
+# error: [not-iterable] "Object of type `Test` may not be iterable because its `__iter__` method returns an object of type `TestIter | int`, which may not have a `__next__` method
 for x in Test():
     reveal_type(x)  # revealed: int
```

Instead it says:

```
failures:

---- mdtest__loops_for stdout ----

for.md - For loops - Union type as iterator where one union element has no `__next__` method

  crates/red_knot_python_semantic/resources/mdtest/loops/for.md:290 unexpected error: [not-iterable] "Object of type `Test` may not be iterable because its `__iter__` method returns an object of type `TestIter | int`, which may not have a `__next__` method"

To rerun this specific test, set the environment variable: MDTEST_TEST_FILTER="for.md - For loops - Union type as iterator where one union element has no `__next__` method"
MDTEST_TEST_FILTER="for.md - For loops - Union type as iterator where one union element has no `__next__` method" cargo test -p red_knot_python_semantic --test mdtest -- mdtest__loops_for
```

This PR switches our parsing of `# error:` assertion comments from regexes to a custom parser. This allows us to explicitly reject malformed assertion messages like this rather than misinterpreting them. Helpful messages are now given to the user in this and many other cases when a malformed assertion message is identified. Assertion messages are also now parsed lazily when matching assertion messages to the diagnostics that are emitted: this allows us to print tailored error messages to the terminal about the malformed assertion messages and recover from them, which would be harder if they were parsed eagerly.

## Test Plan

I added many unit tests to the `red_knot_test` crate. I also manually checked that if you apply the diff given above, mdtest now produces this error message:

```
failures:

---- mdtest__loops_for stdout ----

for.md - For loops - Union type as iterator where one union element has no `__next__` method

  crates/red_knot_python_semantic/resources/mdtest/loops/for.md:290 invalid assertion: expected '"' to be the final character in an assertion with an error message
  crates/red_knot_python_semantic/resources/mdtest/loops/for.md:290 unexpected error: 10 [not-iterable] "Object of type `Test` may not be iterable because its `__iter__` method returns an object of type `TestIter | int`, which may not have a `__next__` method"

To rerun this specific test, set the environment variable: MDTEST_TEST_FILTER="for.md - For loops - Union type as iterator where one union element has no `__next__` method"
MDTEST_TEST_FILTER="for.md - For loops - Union type as iterator where one union element has no `__next__` method" cargo test -p red_knot_python_semantic --test mdtest -- mdtest__loops_for
```