### PR TITLE
[pylint] Fix convert a code keyword argument to a positional argument (PLR1722)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/sys_exit_alias_13.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/sys_exit_alias_13.py
@@ -1,1 +1,2 @@
 exit(code=2)
+

--- a/crates/ruff_linter/resources/test/fixtures/pylint/sys_exit_alias_13.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/sys_exit_alias_13.py
@@ -1,0 +1,1 @@
+exit(code=2)

--- a/crates/ruff_linter/resources/test/fixtures/pylint/sys_exit_alias_14.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/sys_exit_alias_14.py
@@ -1,0 +1,2 @@
+code = {"code": 2}
+exit(**code)

--- a/crates/ruff_linter/resources/test/fixtures/pylint/sys_exit_alias_15.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/sys_exit_alias_15.py
@@ -1,0 +1,6 @@
+success = True
+if success:
+    code = 0
+else:
+    code = 1
+exit(code)

--- a/crates/ruff_linter/resources/test/fixtures/pylint/sys_exit_alias_16.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/sys_exit_alias_16.py
@@ -1,0 +1,23 @@
+def test_case_1():
+    # comments preserved with a positional argument
+    exit(  # comment
+        1,  # 2
+    )  # 3
+
+
+def test_case_2():
+    # comments preserved with a single keyword argument
+    exit(  # comment
+        code=1,  # 2
+    )  # 3
+
+
+def test_case_3():
+    # no diagnostic for multiple arguments
+    exit(2, 3, 4)
+
+
+def test_case_4():
+    # this should now be fixable
+    codes = [1]
+    exit(*codes)

--- a/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
@@ -900,7 +900,7 @@ pub(crate) fn expression(expr: &Expr, checker: &Checker) {
                 pylint::rules::unnecessary_direct_lambda_call(checker, expr, func);
             }
             if checker.enabled(Rule::SysExitAlias) {
-                pylint::rules::sys_exit_alias(checker, func, call);
+                pylint::rules::sys_exit_alias(checker, call);
             }
             if checker.enabled(Rule::BadOpenMode) {
                 pylint::rules::bad_open_mode(checker, call);

--- a/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
@@ -900,7 +900,7 @@ pub(crate) fn expression(expr: &Expr, checker: &Checker) {
                 pylint::rules::unnecessary_direct_lambda_call(checker, expr, func);
             }
             if checker.enabled(Rule::SysExitAlias) {
-                pylint::rules::sys_exit_alias(checker, func);
+                pylint::rules::sys_exit_alias(checker, func, call);
             }
             if checker.enabled(Rule::BadOpenMode) {
                 pylint::rules::bad_open_mode(checker, call);

--- a/crates/ruff_linter/src/rules/pylint/mod.rs
+++ b/crates/ruff_linter/src/rules/pylint/mod.rs
@@ -65,6 +65,7 @@ mod tests {
     #[test_case(Rule::SysExitAlias, Path::new("sys_exit_alias_11.py"))]
     #[test_case(Rule::SysExitAlias, Path::new("sys_exit_alias_12.py"))]
     #[test_case(Rule::SysExitAlias, Path::new("sys_exit_alias_13.py"))]
+    #[test_case(Rule::SysExitAlias, Path::new("sys_exit_alias_14.py"))]
     #[test_case(Rule::ContinueInFinally, Path::new("continue_in_finally.py"))]
     #[test_case(Rule::GlobalStatement, Path::new("global_statement.py"))]
     #[test_case(

--- a/crates/ruff_linter/src/rules/pylint/mod.rs
+++ b/crates/ruff_linter/src/rules/pylint/mod.rs
@@ -67,6 +67,7 @@ mod tests {
     #[test_case(Rule::SysExitAlias, Path::new("sys_exit_alias_13.py"))]
     #[test_case(Rule::SysExitAlias, Path::new("sys_exit_alias_14.py"))]
     #[test_case(Rule::SysExitAlias, Path::new("sys_exit_alias_15.py"))]
+    #[test_case(Rule::SysExitAlias, Path::new("sys_exit_alias_16.py"))]
     #[test_case(Rule::ContinueInFinally, Path::new("continue_in_finally.py"))]
     #[test_case(Rule::GlobalStatement, Path::new("global_statement.py"))]
     #[test_case(

--- a/crates/ruff_linter/src/rules/pylint/mod.rs
+++ b/crates/ruff_linter/src/rules/pylint/mod.rs
@@ -64,6 +64,7 @@ mod tests {
     #[test_case(Rule::SysExitAlias, Path::new("sys_exit_alias_10.py"))]
     #[test_case(Rule::SysExitAlias, Path::new("sys_exit_alias_11.py"))]
     #[test_case(Rule::SysExitAlias, Path::new("sys_exit_alias_12.py"))]
+    #[test_case(Rule::SysExitAlias, Path::new("sys_exit_alias_13.py"))]
     #[test_case(Rule::ContinueInFinally, Path::new("continue_in_finally.py"))]
     #[test_case(Rule::GlobalStatement, Path::new("global_statement.py"))]
     #[test_case(

--- a/crates/ruff_linter/src/rules/pylint/mod.rs
+++ b/crates/ruff_linter/src/rules/pylint/mod.rs
@@ -66,6 +66,7 @@ mod tests {
     #[test_case(Rule::SysExitAlias, Path::new("sys_exit_alias_12.py"))]
     #[test_case(Rule::SysExitAlias, Path::new("sys_exit_alias_13.py"))]
     #[test_case(Rule::SysExitAlias, Path::new("sys_exit_alias_14.py"))]
+    #[test_case(Rule::SysExitAlias, Path::new("sys_exit_alias_15.py"))]
     #[test_case(Rule::ContinueInFinally, Path::new("continue_in_finally.py"))]
     #[test_case(Rule::GlobalStatement, Path::new("global_statement.py"))]
     #[test_case(

--- a/crates/ruff_linter/src/rules/pylint/rules/sys_exit_alias.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/sys_exit_alias.rs
@@ -70,26 +70,10 @@ pub(crate) fn sys_exit_alias(checker: &Checker, call: &ExprCall) {
         call.func.range(),
     );
 
-    let num_str = call
-        .arguments
-        .args
-        .first()
-        .and_then(|arg| arg.as_number_literal_expr())
-        .map(|lit| format!("{:?}", lit.value))
-        .or_else(|| {
-            call.arguments
-                .keywords
-                .first()
-                .filter(|kwr| kwr.value.is_number_literal_expr())
-                .map(|kwr| format!("{:?}", kwr.value.as_number_literal_expr().unwrap().value))
-        });
+    let arg = call.arguments.find_argument_value("code", 0);
 
-    let code = if let Some(value) = num_str {
-        value
-            .strip_prefix("Int(")
-            .and_then(|s| s.strip_suffix(")"))
-            .and_then(|num_str| num_str.parse::<i32>().ok())
-            .unwrap()
+    let code = if let Some(arg) = arg {
+        &checker.source()[arg.range()]
     } else {
         // if it is not possible to retrieve the code, just a violation is raised
         checker.report_diagnostic(diagnostic);

--- a/crates/ruff_linter/src/rules/pylint/rules/sys_exit_alias.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/sys_exit_alias.rs
@@ -71,7 +71,6 @@ pub(crate) fn sys_exit_alias(checker: &Checker, call: &ExprCall) {
     );
 
     let arg = call.arguments.find_argument_value("code", 0);
-
     let code = if let Some(arg) = arg {
         &checker.source()[arg.range()]
     } else {
@@ -86,7 +85,7 @@ pub(crate) fn sys_exit_alias(checker: &Checker, call: &ExprCall) {
             call.func.start(),
             checker.semantic(),
         )?;
-        let reference_edit = Edit::range_replacement(format!("{binding}({code:?})"), call.range);
+        let reference_edit = Edit::range_replacement(format!("{binding}({code})"), call.range);
         Ok(Fix::unsafe_edits(import_edit, [reference_edit]))
     });
     checker.report_diagnostic(diagnostic);

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR1722_sys_exit_alias_13.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR1722_sys_exit_alias_13.py.snap
@@ -1,0 +1,15 @@
+---
+source: crates/ruff_linter/src/rules/pylint/mod.rs
+---
+sys_exit_alias_13.py:1:1: PLR1722 [*] Use `sys.exit()` instead of `exit`
+  |
+1 | exit(code=2)
+  | ^^^^ PLR1722
+  |
+  = help: Replace `exit` with `sys.exit()`
+
+ℹ Unsafe fix
+1   |-exit(code=2)
+  1 |+import sys
+  2 |+sys.exit(2)
+2 3 |

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR1722_sys_exit_alias_14.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR1722_sys_exit_alias_14.py.snap
@@ -1,0 +1,10 @@
+---
+source: crates/ruff_linter/src/rules/pylint/mod.rs
+---
+sys_exit_alias_14.py:2:1: PLR1722 Use `sys.exit()` instead of `exit`
+  |
+1 | code = {"code": 2}
+2 | exit(**code)
+  | ^^^^ PLR1722
+  |
+  = help: Replace `exit` with `sys.exit()`

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR1722_sys_exit_alias_15.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR1722_sys_exit_alias_15.py.snap
@@ -1,0 +1,21 @@
+---
+source: crates/ruff_linter/src/rules/pylint/mod.rs
+---
+sys_exit_alias_15.py:6:1: PLR1722 [*] Use `sys.exit()` instead of `exit`
+  |
+4 | else:
+5 |     code = 1
+6 | exit(code)
+  | ^^^^ PLR1722
+  |
+  = help: Replace `exit` with `sys.exit()`
+
+ℹ Unsafe fix
+  1 |+import sys
+1 2 | success = True
+2 3 | if success:
+3 4 |     code = 0
+4 5 | else:
+5 6 |     code = 1
+6   |-exit(code)
+  7 |+sys.exit(code)

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR1722_sys_exit_alias_16.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR1722_sys_exit_alias_16.py.snap
@@ -1,0 +1,81 @@
+---
+source: crates/ruff_linter/src/rules/pylint/mod.rs
+---
+sys_exit_alias_16.py:3:5: PLR1722 [*] Use `sys.exit()` instead of `exit`
+  |
+1 | def test_case_1():
+2 |     # comments preserved with a positional argument
+3 |     exit(  # comment
+  |     ^^^^ PLR1722
+4 |         1,  # 2
+5 |     )  # 3
+  |
+  = help: Replace `exit` with `sys.exit()`
+
+ℹ Unsafe fix
+  1 |+import sys
+1 2 | def test_case_1():
+2 3 |     # comments preserved with a positional argument
+3   |-    exit(  # comment
+  4 |+    sys.exit(  # comment
+4 5 |         1,  # 2
+5 6 |     )  # 3
+6 7 | 
+
+sys_exit_alias_16.py:10:5: PLR1722 [*] Use `sys.exit()` instead of `exit`
+   |
+ 8 | def test_case_2():
+ 9 |     # comments preserved with a single keyword argument
+10 |     exit(  # comment
+   |     ^^^^ PLR1722
+11 |         code=1,  # 2
+12 |     )  # 3
+   |
+   = help: Replace `exit` with `sys.exit()`
+
+ℹ Unsafe fix
+   1  |+import sys
+1  2  | def test_case_1():
+2  3  |     # comments preserved with a positional argument
+3  4  |     exit(  # comment
+--------------------------------------------------------------------------------
+7  8  | 
+8  9  | def test_case_2():
+9  10 |     # comments preserved with a single keyword argument
+10    |-    exit(  # comment
+11    |-        code=1,  # 2
+   11 |+    sys.exit(  # comment
+   12 |+        1,  # 2
+12 13 |     )  # 3
+13 14 | 
+14 15 | 
+
+sys_exit_alias_16.py:17:5: PLR1722 Use `sys.exit()` instead of `exit`
+   |
+15 | def test_case_3():
+16 |     # no diagnostic for multiple arguments
+17 |     exit(2, 3, 4)
+   |     ^^^^ PLR1722
+   |
+   = help: Replace `exit` with `sys.exit()`
+
+sys_exit_alias_16.py:23:5: PLR1722 [*] Use `sys.exit()` instead of `exit`
+   |
+21 |     # this should now be fixable
+22 |     codes = [1]
+23 |     exit(*codes)
+   |     ^^^^ PLR1722
+   |
+   = help: Replace `exit` with `sys.exit()`
+
+ℹ Unsafe fix
+   1  |+import sys
+1  2  | def test_case_1():
+2  3  |     # comments preserved with a positional argument
+3  4  |     exit(  # comment
+--------------------------------------------------------------------------------
+20 21 | def test_case_4():
+21 22 |     # this should now be fixable
+22 23 |     codes = [1]
+23    |-    exit(*codes)
+   24 |+    sys.exit(*codes)


### PR DESCRIPTION
The PR addresses issue #16396 .

Specifically:

- If the exit statement contains a code keyword argument, it is converted into a positional argument.
- If retrieving the code from the exit statement is not possible, a violation is raised without suggesting a fix.