### PR TITLE
Avoid caching files with unsupported syntax errors

### DIFF
--- a/crates/ruff/tests/lint.rs
+++ b/crates/ruff/tests/lint.rs
@@ -2733,10 +2733,11 @@ fn cache_syntax_errors() -> Result<()> {
     assert_cmd_snapshot!(
         cmd,
         @r"
-    success: true
-    exit_code: 0
+    success: false
+    exit_code: 1
     ----- stdout -----
-    All checks passed!
+    main.py:1:1: SyntaxError: Cannot use `match` statement on Python 3.9 (syntax was added in Python 3.10)
+    Found 1 error.
 
     ----- stderr -----
     warning: Detected debug build without --no-cache.

--- a/crates/ruff/tests/lint.rs
+++ b/crates/ruff/tests/lint.rs
@@ -2713,6 +2713,7 @@ fn cache_syntax_errors() -> Result<()> {
     cmd.args(["check", "--output-format", "concise"])
         .arg("--target-version=py39")
         .arg("--preview")
+        .arg("--quiet") // suppress `debug build without --no-cache` warnings
         .current_dir(&tempdir);
 
     assert_cmd_snapshot!(
@@ -2722,10 +2723,8 @@ fn cache_syntax_errors() -> Result<()> {
     exit_code: 1
     ----- stdout -----
     main.py:1:1: SyntaxError: Cannot use `match` statement on Python 3.9 (syntax was added in Python 3.10)
-    Found 1 error.
 
     ----- stderr -----
-    warning: Detected debug build without --no-cache.
     "
     );
 
@@ -2737,10 +2736,8 @@ fn cache_syntax_errors() -> Result<()> {
     exit_code: 1
     ----- stdout -----
     main.py:1:1: SyntaxError: Cannot use `match` statement on Python 3.9 (syntax was added in Python 3.10)
-    Found 1 error.
 
     ----- stderr -----
-    warning: Detected debug build without --no-cache.
     "
     );
 

--- a/crates/ruff_linter/src/linter.rs
+++ b/crates/ruff_linter/src/linter.rs
@@ -445,7 +445,7 @@ pub fn lint_only(
             &locator,
             &directives,
         ),
-        has_syntax_error: !parsed.is_valid(),
+        has_syntax_error: !parsed.is_valid() || !parsed.unsupported_syntax_errors().is_empty(),
     }
 }
 
@@ -546,7 +546,7 @@ pub fn lint_fix<'a>(
         );
 
         if iterations == 0 {
-            is_valid_syntax = parsed.is_valid();
+            is_valid_syntax = parsed.is_valid() && parsed.unsupported_syntax_errors().is_empty();
         } else {
             // If the source code was parseable on the first pass, but is no
             // longer parseable on a subsequent pass, then we've introduced a


### PR DESCRIPTION
## Summary

This PR includes the new `Parsed::unsupported_syntax_errors` field when determining if a `LinterResult` has a syntax error. This prevents caching files with version-related syntax errors, which led to these errors only being reported on the first ruff run.

Fixes https://github.com/astral-sh/ruff/issues/16417 in combination with https://github.com/astral-sh/ruff/pull/16419, modulo the discussion split off into https://github.com/astral-sh/ruff/issues/16418.

## Test Plan

New CLI test that reported no errors in the second case on `main` (see the first commit).
