### PR TITLE
[red-knot] Reject obvious `snapshot-diagnostics` typos in mdtests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,7 +458,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -467,7 +467,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2545,6 +2545,7 @@ dependencies = [
  "ruff_python_trivia",
  "ruff_source_file",
  "ruff_text_size",
+ "rust-fuzzy-search",
  "rustc-hash 2.1.1",
  "salsa",
  "serde",
@@ -3273,6 +3274,12 @@ dependencies = [
  "tempfile",
  "toml",
 ]
+
+[[package]]
+name = "rust-fuzzy-search"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a157657054ffe556d8858504af8a672a054a6e0bd9e8ee531059100c0fa11bb2"
 
 [[package]]
 name = "rust-stemmers"
@@ -4457,7 +4464,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,6 +122,7 @@ rand = { version = "0.9.0" }
 rayon = { version = "1.10.0" }
 regex = { version = "1.10.2" }
 rustc-hash = { version = "2.0.0" }
+rust-fuzzy-search = { version = "0.1.1" }
 # When updating salsa, make sure to also update the revision in `fuzz/Cargo.toml`
 salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "99be5d9917c3dd88e19735a82ef6bf39ba84bd7e" }
 schemars = { version = "0.8.16" }

--- a/crates/red_knot_test/Cargo.toml
+++ b/crates/red_knot_test/Cargo.toml
@@ -27,6 +27,7 @@ insta = { workspace = true, features = ["filters"] }
 memchr = { workspace = true }
 regex = { workspace = true }
 rustc-hash = { workspace = true }
+rust-fuzzy-search = { workspace = true}
 salsa = { workspace = true }
 smallvec = { workspace = true }
 serde = { workspace = true }


### PR DESCRIPTION
## Summary

This PR adds some heuristics to the mdtest framework so that obvious typos such as `<!-- snpashot-diagnostics` or `<!-- snpshot-dignosstics -->` are rejected. The heuristics are that if the HTML comment is not equal to `snapshot-diagnostics`, but has a high fuzzy similarity score and is similar in length, we deduce that it's probably a typo.

I'm not sure at all this is the way to go, but I figured I'd put it up to see what people think of the idea. The pros of this PR are that it's an easy mistake to make to have a typo in a `snapshot-diagnostics` HTML comment, and that this PR doesn't add much complexity to mdtest. The cons are that we add some dissatisfying heuristics to mdtest, and add a new (admittedly very small) third-party dependency.

Note that the `looks_like_snapshot_directive_typo()` function introduced in this PR also has _some_ false positives. It rejects HTML comments such as `<!-- snapdragon-diagnostics -->` as being too similar to `<!-- snapshot-diagnostics -->`. It _does_ seem pretty unlikely that anybody is going to actually add a `<!-- snapdragon-diagnostics -->` HTML comment to an mdtest, however; we have the luxury of knowing that this framework is only for internal use.

Fixes https://github.com/astral-sh/ruff/issues/16352

## Test Plan

Added unit tests
