### PR TITLE
[red-knot] Disallow more invalid type expressions

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/invalid.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/invalid.md
@@ -1,0 +1,45 @@
+# Tests for invalid types in type expressions
+
+## Invalid types are rejected
+
+Many types are illegal in the context of a type expression:
+
+```py
+import typing
+from knot_extensions import AlwaysTruthy, AlwaysFalsy
+from typing_extensions import Literal, Never
+
+def _(
+    a: type[int],
+    b: AlwaysTruthy,
+    c: AlwaysFalsy,
+    d: Literal[True],
+    e: Literal["bar"],
+    f: Literal[b"foo"],
+    g: tuple[int, str],
+    h: Never,
+):
+    def foo(): ...
+    def invalid(
+        i: a,  # error: [invalid-type-form] "Variable of type `type[int]` is not allowed in a type expression"
+        j: b,  # error: [invalid-type-form]
+        k: c,  # error: [invalid-type-form]
+        l: d,  # error: [invalid-type-form]
+        m: e,  # error: [invalid-type-form]
+        n: f,  # error: [invalid-type-form]
+        o: g,  # error: [invalid-type-form]
+        p: h,  # error: [invalid-type-form]
+        q: typing,  # error: [invalid-type-form]
+        r: foo,  # error: [invalid-type-form]
+    ):
+        reveal_type(i)  # revealed: Unknown
+        reveal_type(j)  # revealed: Unknown
+        reveal_type(k)  # revealed: Unknown
+        reveal_type(l)  # revealed: Unknown
+        reveal_type(m)  # revealed: Unknown
+        reveal_type(n)  # revealed: Unknown
+        reveal_type(o)  # revealed: Unknown
+        reveal_type(p)  # revealed: Unknown
+        reveal_type(q)  # revealed: Unknown
+        reveal_type(r)  # revealed: Unknown
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/unsupported_special_forms.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/unsupported_special_forms.md
@@ -18,7 +18,7 @@ def f(*args: Unpack[Ts]) -> tuple[Unpack[Ts]]:
     # TODO: should understand the annotation
     reveal_type(args)  # revealed: tuple
 
-    reveal_type(Alias)  # revealed: @Todo(Unsupported or invalid type in a type expression)
+    reveal_type(Alias)  # revealed: @Todo(Invalid or unsupported `KnownInstanceType` in `Type::to_type_expression`)
 
 def g() -> TypeGuard[int]: ...
 def h() -> TypeIs[int]: ...
@@ -33,7 +33,7 @@ def i(callback: Callable[Concatenate[int, P], R_co], *args: P.args, **kwargs: P.
 
 class Foo:
     def method(self, x: Self):
-        reveal_type(x)  # revealed: @Todo(Unsupported or invalid type in a type expression)
+        reveal_type(x)  # revealed: @Todo(Invalid or unsupported `KnownInstanceType` in `Type::to_type_expression`)
 ```
 
 ## Inheritance


### PR DESCRIPTION
## Summary

As part of working on https://github.com/astral-sh/ruff/issues/16302, I'm auditing all uses of `Type::to_instance()`. I noticed that one use in `Type::in_type_expression` has a pretty clear bug, in that it treats `Type::SubclassOf()` the same as `Type::ClassLiteral`. That's incorrect: an object can only have a `type[]` type if it's a dynamic variable of some kind, and we should reject such variables in type expressions. The practical effect of this is that on `main`, we have this incorrect behaviour, where we _should_ be reject `y`'s type annotation altogether, but instead we accept it:

```py
def _(x: type[int]):
    def f(y: x):
        reveal_type(y)  # revealed: int
```

This PR fixes the bug by making `Type::in_type_expression()` exhaustive over all `Type` variants and rejecting most of them when they appear in type expressions. (The method is not yet exhaustive over all `KnownInstanceType` variants; some of these would require special error messages, and it seemed out of the scope of this bugfix PR.)

## Test Plan

Added mdtests.
