### PR TITLE
Check `LinterSettings::preview` for version-related syntax errors

### DIFF
--- a/crates/ruff_server/src/lint.rs
+++ b/crates/ruff_server/src/lint.rs
@@ -172,6 +172,12 @@ pub(crate) fn check(
             )
         });
 
+    let unsupported_syntax_errors = if settings.linter.preview.is_enabled() {
+        parsed.unsupported_syntax_errors()
+    } else {
+        &[]
+    };
+
     let lsp_diagnostics = lsp_diagnostics.chain(
         show_syntax_errors
             .then(|| {
@@ -186,7 +192,7 @@ pub(crate) fn check(
                             encoding,
                         )
                     })
-                    .chain(parsed.unsupported_syntax_errors().iter().map(|error| {
+                    .chain(unsupported_syntax_errors.iter().map(|error| {
                         unsupported_syntax_error_to_lsp_diagnostic(
                             error,
                             &source_kind,

--- a/crates/ruff_wasm/src/lib.rs
+++ b/crates/ruff_wasm/src/lib.rs
@@ -205,6 +205,12 @@ impl Workspace {
 
         let source_code = locator.to_source_code();
 
+        let unsupported_syntax_errors = if self.settings.linter.preview.is_enabled() {
+            parsed.unsupported_syntax_errors()
+        } else {
+            &[]
+        };
+
         let messages: Vec<ExpandedMessage> = diagnostics
             .into_iter()
             .map(|diagnostic| {
@@ -242,7 +248,7 @@ impl Workspace {
                     fix: None,
                 }
             }))
-            .chain(parsed.unsupported_syntax_errors().iter().map(|error| {
+            .chain(unsupported_syntax_errors.iter().map(|error| {
                 let start_location = source_code.source_location(error.range.start());
                 let end_location = source_code.source_location(error.range.end());
 

--- a/crates/ruff_wasm/tests/api.rs
+++ b/crates/ruff_wasm/tests/api.rs
@@ -44,7 +44,7 @@ fn empty_config() {
 fn syntax_error() {
     check!(
         "x =\ny = 1\n",
-        r#"{"preview": true}"#,
+        r#"{}"#,
         [ExpandedMessage {
             code: None,
             message: "SyntaxError: Expected an expression".to_string(),
@@ -65,7 +65,7 @@ fn syntax_error() {
 fn unsupported_syntax_error() {
     check!(
         "match 2:\n    case 1: ...",
-        r#"{}"#,
+        r#"{"preview": true}"#,
         [ExpandedMessage {
             code: None,
             message: "SyntaxError: Cannot use `match` statement on Python 3.9 (syntax was added in Python 3.10)".to_string(),

--- a/crates/ruff_wasm/tests/api.rs
+++ b/crates/ruff_wasm/tests/api.rs
@@ -44,7 +44,7 @@ fn empty_config() {
 fn syntax_error() {
     check!(
         "x =\ny = 1\n",
-        r#"{"preview" = true}"#,
+        r#"{"preview": true}"#,
         [ExpandedMessage {
             code: None,
             message: "SyntaxError: Expected an expression".to_string(),

--- a/crates/ruff_wasm/tests/api.rs
+++ b/crates/ruff_wasm/tests/api.rs
@@ -44,7 +44,7 @@ fn empty_config() {
 fn syntax_error() {
     check!(
         "x =\ny = 1\n",
-        r#"{}"#,
+        r#"{"preview" = true}"#,
         [ExpandedMessage {
             code: None,
             message: "SyntaxError: Expected an expression".to_string(),


### PR DESCRIPTION
Summary
--
Fixes part of the report in https://github.com/astral-sh/ruff/issues/16417#issuecomment-2689600543 by checking `LinterSettings::preview` in both the language server and in the playground. That now covers all calls of `Parsed::unsupported_syntax_errors`.

Test Plan
--
Manual tests in both VS Code and the playground. I also added `preview = true` to the WASM test I added earlier.
