### PR TITLE
Bump version to Ruff 0.9.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.9.9
+
+### Preview features
+
+- Fix caching of unsupported-syntax errors ([#16425](https://github.com/astral-sh/ruff/pull/16425))
+
+### Bug fixes
+
+- Only show unsupported-syntax errors in editors when preview mode is enabled ([#16429](https://github.com/astral-sh/ruff/pull/16429))
+
 ## 0.9.8
 
 ### Preview features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2656,7 +2656,7 @@ dependencies = [
 
 [[package]]
 name = "ruff"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "argfile",
@@ -2890,7 +2890,7 @@ dependencies = [
 
 [[package]]
 name = "ruff_linter"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -3212,7 +3212,7 @@ dependencies = [
 
 [[package]]
 name = "ruff_wasm"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "console_error_panic_hook",
  "console_log",

--- a/README.md
+++ b/README.md
@@ -149,8 +149,8 @@ curl -LsSf https://astral.sh/ruff/install.sh | sh
 powershell -c "irm https://astral.sh/ruff/install.ps1 | iex"
 
 # For a specific version.
-curl -LsSf https://astral.sh/ruff/0.9.8/install.sh | sh
-powershell -c "irm https://astral.sh/ruff/0.9.8/install.ps1 | iex"
+curl -LsSf https://astral.sh/ruff/0.9.9/install.sh | sh
+powershell -c "irm https://astral.sh/ruff/0.9.9/install.ps1 | iex"
 ```
 
 You can also install Ruff via [Homebrew](https://formulae.brew.sh/formula/ruff), [Conda](https://anaconda.org/conda-forge/ruff),
@@ -183,7 +183,7 @@ Ruff can also be used as a [pre-commit](https://pre-commit.com/) hook via [`ruff
 ```yaml
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.9.8
+  rev: v0.9.9
   hooks:
     # Run the linter.
     - id: ruff

--- a/crates/ruff/Cargo.toml
+++ b/crates/ruff/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff"
-version = "0.9.8"
+version = "0.9.9"
 publish = true
 authors = { workspace = true }
 edition = { workspace = true }

--- a/crates/ruff_linter/Cargo.toml
+++ b/crates/ruff_linter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff_linter"
-version = "0.9.8"
+version = "0.9.9"
 publish = false
 authors = { workspace = true }
 edition = { workspace = true }

--- a/crates/ruff_wasm/Cargo.toml
+++ b/crates/ruff_wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff_wasm"
-version = "0.9.8"
+version = "0.9.9"
 publish = false
 authors = { workspace = true }
 edition = { workspace = true }

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -80,7 +80,7 @@ You can add the following configuration to `.gitlab-ci.yml` to run a `ruff forma
   stage: build
   interruptible: true
   image:
-    name: ghcr.io/astral-sh/ruff:0.9.8-alpine
+    name: ghcr.io/astral-sh/ruff:0.9.9-alpine
   before_script:
     - cd $CI_PROJECT_DIR
     - ruff --version
@@ -106,7 +106,7 @@ Ruff can be used as a [pre-commit](https://pre-commit.com) hook via [`ruff-pre-c
 ```yaml
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.9.8
+  rev: v0.9.9
   hooks:
     # Run the linter.
     - id: ruff
@@ -119,7 +119,7 @@ To enable lint fixes, add the `--fix` argument to the lint hook:
 ```yaml
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.9.8
+  rev: v0.9.9
   hooks:
     # Run the linter.
     - id: ruff
@@ -133,7 +133,7 @@ To avoid running on Jupyter Notebooks, remove `jupyter` from the list of allowed
 ```yaml
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.9.8
+  rev: v0.9.9
   hooks:
     # Run the linter.
     - id: ruff

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -365,7 +365,7 @@ This tutorial has focused on Ruff's command-line interface, but Ruff can also be
 ```yaml
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.9.8
+  rev: v0.9.9
   hooks:
     # Run the linter.
     - id: ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "ruff"
-version = "0.9.8"
+version = "0.9.9"
 description = "An extremely fast Python linter and code formatter, written in Rust."
 authors = [{ name = "Astral Software Inc.", email = "hey@astral.sh" }]
 readme = "README.md"

--- a/scripts/benchmarks/pyproject.toml
+++ b/scripts/benchmarks/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scripts"
-version = "0.9.8"
+version = "0.9.9"
 description = ""
 authors = ["Charles Marsh <charlie.r.marsh@gmail.com>"]
 


### PR DESCRIPTION
## Summary

Bump Ruff's version to 0.9.9. 

This is a bugfix release to fix some issues around the new unsupported syntax handling.

## Test plan

I did test the unsupported syntax feature in the editor