### PR TITLE
Move rule code from `description` to `check_name` in GitLab output serializer

### DIFF
--- a/crates/ruff_linter/src/message/gitlab.rs
+++ b/crates/ruff_linter/src/message/gitlab.rs
@@ -90,13 +90,15 @@ impl Serialize for SerializedMessages<'_> {
             }
             fingerprints.insert(message_fingerprint);
 
-            let description = if let Some(rule) = message.rule() {
-                format!("({}) {}", rule.noqa_code(), message.body())
+            let description = message.body().to_string();
+            let check_name = if let Some(rule) = message.rule() {
+                rule.noqa_code().to_string()
             } else {
-                message.body().to_string()
+                "Syntax error".to_string()
             };
 
             let value = json!({
+                "check_name": check_name,
                 "description": description,
                 "severity": "major",
                 "fingerprint": format!("{:x}", message_fingerprint),

--- a/crates/ruff_linter/src/message/gitlab.rs
+++ b/crates/ruff_linter/src/message/gitlab.rs
@@ -90,11 +90,18 @@ impl Serialize for SerializedMessages<'_> {
             }
             fingerprints.insert(message_fingerprint);
 
-            let description = message.body().to_string();
-            let check_name = if let Some(rule) = message.rule() {
-                rule.noqa_code().to_string()
+            let (description, check_name) = if let Some(rule) = message.rule() {
+                (message.body().to_string(), rule.noqa_code().to_string())
             } else {
-                "Syntax error".to_string()
+                let description = message.body();
+                let description_without_prefix = description
+                    .strip_prefix("SyntaxError: ")
+                    .unwrap_or(description);
+
+                (
+                    description_without_prefix.to_string(),
+                    "Syntax error".to_string(),
+                )
             };
 
             let value = json!({

--- a/crates/ruff_linter/src/message/gitlab.rs
+++ b/crates/ruff_linter/src/message/gitlab.rs
@@ -100,7 +100,7 @@ impl Serialize for SerializedMessages<'_> {
 
                 (
                     description_without_prefix.to_string(),
-                    "Syntax error".to_string(),
+                    "syntax-error".to_string(),
                 )
             };
 

--- a/crates/ruff_linter/src/message/snapshots/ruff_linter__message__gitlab__tests__output.snap
+++ b/crates/ruff_linter/src/message/snapshots/ruff_linter__message__gitlab__tests__output.snap
@@ -1,11 +1,11 @@
 ---
 source: crates/ruff_linter/src/message/gitlab.rs
 expression: redact_fingerprint(&content)
-snapshot_kind: text
 ---
 [
   {
-    "description": "(F401) `os` imported but unused",
+    "check_name": "F401",
+    "description": "`os` imported but unused",
     "fingerprint": "<redacted>",
     "location": {
       "lines": {
@@ -17,7 +17,8 @@ snapshot_kind: text
     "severity": "major"
   },
   {
-    "description": "(F841) Local variable `x` is assigned to but never used",
+    "check_name": "F841",
+    "description": "Local variable `x` is assigned to but never used",
     "fingerprint": "<redacted>",
     "location": {
       "lines": {
@@ -29,7 +30,8 @@ snapshot_kind: text
     "severity": "major"
   },
   {
-    "description": "(F821) Undefined name `a`",
+    "check_name": "F821",
+    "description": "Undefined name `a`",
     "fingerprint": "<redacted>",
     "location": {
       "lines": {

--- a/crates/ruff_linter/src/message/snapshots/ruff_linter__message__gitlab__tests__syntax_errors.snap
+++ b/crates/ruff_linter/src/message/snapshots/ruff_linter__message__gitlab__tests__syntax_errors.snap
@@ -4,7 +4,7 @@ expression: redact_fingerprint(&content)
 ---
 [
   {
-    "check_name": "Syntax error",
+    "check_name": "syntax-error",
     "description": "Expected one or more symbol names after import",
     "fingerprint": "<redacted>",
     "location": {
@@ -17,7 +17,7 @@ expression: redact_fingerprint(&content)
     "severity": "major"
   },
   {
-    "check_name": "Syntax error",
+    "check_name": "syntax-error",
     "description": "Expected ')', found newline",
     "fingerprint": "<redacted>",
     "location": {

--- a/crates/ruff_linter/src/message/snapshots/ruff_linter__message__gitlab__tests__syntax_errors.snap
+++ b/crates/ruff_linter/src/message/snapshots/ruff_linter__message__gitlab__tests__syntax_errors.snap
@@ -5,7 +5,7 @@ expression: redact_fingerprint(&content)
 [
   {
     "check_name": "Syntax error",
-    "description": "SyntaxError: Expected one or more symbol names after import",
+    "description": "Expected one or more symbol names after import",
     "fingerprint": "<redacted>",
     "location": {
       "lines": {
@@ -18,7 +18,7 @@ expression: redact_fingerprint(&content)
   },
   {
     "check_name": "Syntax error",
-    "description": "SyntaxError: Expected ')', found newline",
+    "description": "Expected ')', found newline",
     "fingerprint": "<redacted>",
     "location": {
       "lines": {

--- a/crates/ruff_linter/src/message/snapshots/ruff_linter__message__gitlab__tests__syntax_errors.snap
+++ b/crates/ruff_linter/src/message/snapshots/ruff_linter__message__gitlab__tests__syntax_errors.snap
@@ -1,10 +1,10 @@
 ---
 source: crates/ruff_linter/src/message/gitlab.rs
 expression: redact_fingerprint(&content)
-snapshot_kind: text
 ---
 [
   {
+    "check_name": "Syntax error",
     "description": "SyntaxError: Expected one or more symbol names after import",
     "fingerprint": "<redacted>",
     "location": {
@@ -17,6 +17,7 @@ snapshot_kind: text
     "severity": "major"
   },
   {
+    "check_name": "Syntax error",
     "description": "SyntaxError: Expected ')', found newline",
     "fingerprint": "<redacted>",
     "location": {


### PR DESCRIPTION
## Summary

Resolves #16435.

The changes are summarized by the following table:

| Property      | Has rule? |             Before              |       After        |
|:--------------|:---------:|:-------------------------------:|:------------------:|
| `check_name`  |    Yes    |                -                |       `A123`       |
| `description` |    Yes    |    `A123: Some explanation`     | `Some explanation` |
| `check_name`  |    No     |                -                |   `Syntax error`   |
| `description` |    No     | `SyntaxError: Some explanation` | `Some explanation` |

## Test Plan

`cargo nextest run` and `cargo insta test`.
