### PR TITLE
Bump alpine default tag to 3.21

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -163,7 +163,7 @@ jobs:
         # Mapping of base image followed by a comma followed by one or more base tags (comma separated)
         # Note, org.opencontainers.image.version label will use the first base tag (use the most specific tag first)
         image-mapping:
-          - alpine:3.20,alpine3.20,alpine
+          - alpine:3.21,alpine3.21,alpine
           - debian:bookworm-slim,bookworm-slim,debian-slim
           - buildpack-deps:bookworm,bookworm,debian
     steps:


### PR DESCRIPTION
## Summary

Alpine 3.21 has been released for a few months and `uv` has already migrated in https://github.com/astral-sh/uv/pull/11157
