### PR TITLE
[syntax-errors] `type` statements before Python 3.12

### DIFF
--- a/crates/ruff_python_parser/resources/inline/err/type_stmt_py311.py
+++ b/crates/ruff_python_parser/resources/inline/err/type_stmt_py311.py
@@ -1,0 +1,2 @@
+# parse_options: {"target-version": "3.11"}
+type x = int

--- a/crates/ruff_python_parser/resources/inline/ok/type_stmt_py312.py
+++ b/crates/ruff_python_parser/resources/inline/ok/type_stmt_py312.py
@@ -1,0 +1,2 @@
+# parse_options: {"target-version": "3.12"}
+type x = int

--- a/crates/ruff_python_parser/src/error.rs
+++ b/crates/ruff_python_parser/src/error.rs
@@ -449,6 +449,7 @@ pub enum UnsupportedSyntaxErrorKind {
     Match,
     Walrus,
     ExceptStar,
+    TypeStmt,
 }
 
 impl Display for UnsupportedSyntaxError {
@@ -457,6 +458,7 @@ impl Display for UnsupportedSyntaxError {
             UnsupportedSyntaxErrorKind::Match => "`match` statement",
             UnsupportedSyntaxErrorKind::Walrus => "named assignment expression (`:=`)",
             UnsupportedSyntaxErrorKind::ExceptStar => "`except*`",
+            UnsupportedSyntaxErrorKind::TypeStmt => "`type` statement",
         };
         write!(
             f,
@@ -474,6 +476,7 @@ impl UnsupportedSyntaxErrorKind {
             UnsupportedSyntaxErrorKind::Match => PythonVersion::PY310,
             UnsupportedSyntaxErrorKind::Walrus => PythonVersion::PY38,
             UnsupportedSyntaxErrorKind::ExceptStar => PythonVersion::PY311,
+            UnsupportedSyntaxErrorKind::TypeStmt => PythonVersion::PY312,
         }
     }
 }

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -890,6 +890,8 @@ impl<'src> Parser<'src> {
         let start = self.node_start();
         self.bump(TokenKind::Type);
 
+        let type_range = self.node_range(start);
+
         let mut name = Expr::Name(self.parse_name());
         helpers::set_expr_ctx(&mut name, ExprContext::Store);
 
@@ -908,6 +910,16 @@ impl<'src> Parser<'src> {
         // type x = yield from y
         // type x = x := 1
         let value = self.parse_conditional_expression_or_higher();
+
+        // test_ok type_stmt_py312
+        // # parse_options: {"target-version": "3.12"}
+        // type x = int
+
+        // test_err type_stmt_py311
+        // # parse_options: {"target-version": "3.11"}
+        // type x = int
+
+        self.add_unsupported_syntax_error(UnsupportedSyntaxErrorKind::TypeStmt, type_range);
 
         ast::StmtTypeAlias {
             name: Box::new(name),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@type_stmt_py311.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@type_stmt_py311.py.snap
@@ -1,0 +1,42 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/inline/err/type_stmt_py311.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..57,
+        body: [
+            TypeAlias(
+                StmtTypeAlias {
+                    range: 44..56,
+                    name: Name(
+                        ExprName {
+                            range: 49..50,
+                            id: Name("x"),
+                            ctx: Store,
+                        },
+                    ),
+                    type_params: None,
+                    value: Name(
+                        ExprName {
+                            range: 53..56,
+                            id: Name("int"),
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+        ],
+    },
+)
+```
+## Unsupported Syntax Errors
+
+  |
+1 | # parse_options: {"target-version": "3.11"}
+2 | type x = int
+  | ^^^^ Syntax Error: Cannot use `type` statement on Python 3.11 (syntax was added in Python 3.12)
+  |

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@type_stmt_py312.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@type_stmt_py312.py.snap
@@ -1,0 +1,35 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/inline/ok/type_stmt_py312.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..57,
+        body: [
+            TypeAlias(
+                StmtTypeAlias {
+                    range: 44..56,
+                    name: Name(
+                        ExprName {
+                            range: 49..50,
+                            id: Name("x"),
+                            ctx: Store,
+                        },
+                    ),
+                    type_params: None,
+                    value: Name(
+                        ExprName {
+                            range: 53..56,
+                            id: Name("int"),
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+        ],
+    },
+)
+```


### PR DESCRIPTION
Summary
--
Another simple one, just detect standalone `type` statements. I limited the diagnostic to `type` itself like [pyright]. That probably makes the most sense for more complicated examples.

Test Plan
--
Inline tests.

[pyright]: https://pyright-play.net/?pythonVersion=3.8&strict=true&code=C4TwDgpgBAHlC8UCWA7YQ