### PR TITLE
Clarify that D417 only checks docstrings with an arguments section

### DIFF
--- a/crates/ruff_linter/src/rules/pydocstyle/rules/sections.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/sections.rs
@@ -1167,10 +1167,10 @@ impl AlwaysFixableViolation for MissingSectionNameColon {
 /// a blank line, followed by a series of sections, each with a section header
 /// and a section body. Function docstrings often include a section for
 /// function arguments; this rule is concerned with that section only.
-/// This rule does not check functions without any arguments sections (e.g. `Args`).
-///
 /// Note that this rule only checks docstrings with an arguments (e.g. `Args`) section.
-/// Docstrings without any arguments sections
+///
+/// This rule is enabled when using the `google` convention, and disabled when
+/// using the `pep257` and `numpy` conventions.
 ///
 /// ## Example
 /// ```python

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/sections.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/sections.rs
@@ -1167,9 +1167,10 @@ impl AlwaysFixableViolation for MissingSectionNameColon {
 /// a blank line, followed by a series of sections, each with a section header
 /// and a section body. Function docstrings often include a section for
 /// function arguments; this rule is concerned with that section only.
+/// This rule does not check functions without any arguments sections (e.g. `Args`).
 ///
-/// This rule is enabled when using the `google` convention, and disabled when
-/// using the `pep257` and `numpy` conventions.
+/// Note that this rule only checks docstrings with an arguments (e.g. `Args`) section.
+/// Docstrings without any arguments sections
 ///
 /// ## Example
 /// ```python


### PR DESCRIPTION
## Summary

This came up in https://github.com/astral-sh/ruff/issues/16477

It's not obvious from the D417 rule's documentation that it only checks docstrings
with an arguments section. Functions without such a section aren't checked. 

This PR tries to make this clearer in the documentation.

