### PR TITLE
[red-knot] Add `__init__` arguments check when doing `try_call` on a class literal

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/new_types.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/new_types.md
@@ -8,7 +8,11 @@ Currently, red-knot doesn't support `typing.NewType` in type annotations.
 from typing_extensions import NewType
 from types import GenericAlias
 
+X = GenericAlias(type, ())
 A = NewType("A", int)
+# TODO: typeshed for `typing.GenericAlias` uses `type` for the first argument. `NewType` should be special-cased
+# to be compatible with `type`
+# error: [invalid-argument-type] "Object of type `NewType` cannot be assigned to parameter 2 (`origin`) of function `__new__`; expected type `type`"
 B = GenericAlias(A, ())
 
 def _(

--- a/crates/red_knot_python_semantic/resources/mdtest/call/constructor.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/call/constructor.md
@@ -10,7 +10,7 @@ arguments.
 Both `__new__` and `__init__` are looked up using full descriptor protocol, but `__new__` is then
 called as an implicit static, rather than bound method with `cls` passed as the first argument.
 `__init__` has no special handling, it is fetched as bound method and is called just like any other
-method.
+dunder method.
 
 `type.__call__` does other things too, but this is not yet handled by us.
 

--- a/crates/red_knot_python_semantic/resources/mdtest/call/constructor.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/call/constructor.md
@@ -1,7 +1,236 @@
 # Constructor
 
+## No init or new
+
+Every class has `object` in it's MRO, so if no `__init__` method is provided, we fall back to
+`object.__init__`, which can only be called with zero arguments:
+
 ```py
 class Foo: ...
 
 reveal_type(Foo())  # revealed: Foo
+
+# error: [too-many-positional-arguments] "Too many positional arguments to bound method `__init__`: expected 0, got 1"
+reveal_type(Foo(1))  # revealed: Foo
+```
+
+## `__new__` present on the class itself
+
+If the class has an `__new__` method, we can infer the signature of the constructor from it.
+
+```py
+class Foo:
+    def __new__(cls, x: int) -> "Foo":
+        return object.__new__(cls)
+
+reveal_type(Foo(1))  # revealed: Foo
+
+# error: [missing-argument] "No argument provided for required parameter `x` of function `__new__`"
+reveal_type(Foo())  # revealed: Foo
+# error: [too-many-positional-arguments] "Too many positional arguments to function `__new__`: expected 1, got 2"
+reveal_type(Foo(1, 2))  # revealed: Foo
+```
+
+## `__new__` present on a superclass
+
+If the `__new__` method is defined on a superclass, we can still infer the signature of the
+constructor from it.
+
+```py
+from typing_extensions import Self
+
+class Base:
+    def __new__(cls, x: int) -> Self: ...
+
+class Foo(Base): ...
+
+reveal_type(Foo(1))  # revealed: Foo
+
+# error: [missing-argument] "No argument provided for required parameter `x` of function `__new__`"
+reveal_type(Foo())  # revealed: Foo
+# error: [too-many-positional-arguments] "Too many positional arguments to function `__new__`: expected 1, got 2"
+reveal_type(Foo(1, 2))  # revealed: Foo
+```
+
+## Conditional `__new__`
+
+```py
+def _(flag: bool) -> None:
+    class Foo:
+        if flag:
+            def __new__(cls, x: int): ...
+        else:
+            def __new__(cls, x: int, y: int = 1): ...
+
+    reveal_type(Foo(1))  # revealed: Foo
+    # error: [invalid-argument-type] "Object of type `Literal["1"]` cannot be assigned to parameter 2 (`x`) of function `__new__`; expected type `int`"
+    reveal_type(Foo("1"))  # revealed: Foo
+    # error: [missing-argument] "No argument provided for required parameter `x` of function `__new__`"
+    reveal_type(Foo())  # revealed: Foo
+```
+
+## A descriptor in place of `__new__`
+
+```py
+class SomeCallable:
+    def __call__(self, cls, x: int) -> "Foo":
+        obj = object.__new__(cls)
+        obj.x = x
+        return obj
+
+class Descriptor:
+    def __get__(self, instance, owner) -> SomeCallable:
+        return SomeCallable()
+
+class Foo:
+    __new__: Descriptor = Descriptor()
+
+reveal_type(Foo(1))  # revealed: Foo
+# error: [missing-argument] "No argument provided for required parameter `x` of bound method `__call__`"
+reveal_type(Foo())  # revealed: Foo
+```
+
+## A callable instance in place of `__new__`
+
+### Bound
+
+```py
+class Callable:
+    def __call__(self, cls, x: int) -> "Foo":
+        return object.__new__(cls)
+
+class Foo:
+    __new__ = Callable()
+
+reveal_type(Foo(1))  # revealed: Foo
+# error: [missing-argument] "No argument provided for required parameter `x` of bound method `__call__`"
+reveal_type(Foo())  # revealed: Foo
+```
+
+### Possibly Unbound
+
+```py
+def _(flag: bool) -> None:
+    class Callable:
+        if flag:
+            def __call__(self, cls, x: int) -> "Foo":
+                return object.__new__(cls)
+
+    class Foo:
+        __new__ = Callable()
+
+    # error: [call-non-callable] "Object of type `Callable` is not callable (possibly unbound `__call__` method)"
+    reveal_type(Foo(1))  # revealed: Foo
+    # error: [missing-argument] "No argument provided for required parameter `x` of bound method `__call__`"
+    reveal_type(Foo())  # revealed: Foo
+```
+
+## `__init__` present on the class itself
+
+If the class has an `__init__` method, we can infer the signature of the constructor from it.
+
+```py
+class Foo:
+    def __init__(self, x: int): ...
+
+reveal_type(Foo(1))  # revealed: Foo
+
+# error: [missing-argument] "No argument provided for required parameter `x` of bound method `__init__`"
+reveal_type(Foo())  # revealed: Foo
+# error: [too-many-positional-arguments] "Too many positional arguments to bound method `__init__`: expected 1, got 2"
+reveal_type(Foo(1, 2))  # revealed: Foo
+```
+
+## `__init__` present on a superclass
+
+If the `__init__` method is defined on a superclass, we can still infer the signature of the
+constructor from it.
+
+```py
+class Base:
+    def __init__(self, x: int): ...
+
+class Foo(Base): ...
+
+reveal_type(Foo(1))  # revealed: Foo
+
+# error: [missing-argument] "No argument provided for required parameter `x` of bound method `__init__`"
+reveal_type(Foo())  # revealed: Foo
+# error: [too-many-positional-arguments] "Too many positional arguments to bound method `__init__`: expected 1, got 2"
+reveal_type(Foo(1, 2))  # revealed: Foo
+```
+
+## Conditional `__init__`
+
+```py
+def _(flag: bool) -> None:
+    class Foo:
+        if flag:
+            def __init__(self, x: int): ...
+        else:
+            def __init__(self, x: int, y: int = 1): ...
+
+    reveal_type(Foo(1))  # revealed: Foo
+    # error: [invalid-argument-type] "Object of type `Literal["1"]` cannot be assigned to parameter 2 (`x`) of bound method `__init__`; expected type `int`"
+    reveal_type(Foo("1"))  # revealed: Foo
+    # error: [missing-argument] "No argument provided for required parameter `x` of bound method `__init__`"
+    reveal_type(Foo())  # revealed: Foo
+```
+
+## A descriptor in place of `__init__`
+
+```py
+class SomeCallable:
+    # TODO: at runtime `__init__` is checked to return `None` and
+    # a `TypeError` is raised if it doesn't. However, apparently
+    # this is not true when the descriptor is used as `__init__`.
+    # However, we may still want to check this.
+    def __call__(self, x: int) -> str:
+        return "a"
+
+class Descriptor:
+    def __get__(self, instance, owner) -> SomeCallable:
+        return SomeCallable()
+
+class Foo:
+    __init__: Descriptor = Descriptor()
+
+reveal_type(Foo(1))  # revealed: Foo
+# error: [missing-argument] "No argument provided for required parameter `x` of bound method `__call__`"
+reveal_type(Foo())  # revealed: Foo
+```
+
+## A callable instance in place of `__init__`
+
+### Bound
+
+```py
+class Callable:
+    def __call__(self, x: int) -> None:
+        pass
+
+class Foo:
+    __init__ = Callable()
+
+reveal_type(Foo(1))  # revealed: Foo
+# error: [missing-argument] "No argument provided for required parameter `x` of bound method `__call__`"
+reveal_type(Foo())  # revealed: Foo
+```
+
+### Possibly Unbound
+
+```py
+def _(flag: bool) -> None:
+    class Callable:
+        if flag:
+            def __call__(self, x: int) -> None:
+                pass
+
+    class Foo:
+        __init__ = Callable()
+
+    # error: [call-non-callable] "Object of type `Callable` is not callable (possibly unbound `__call__` method)"
+    reveal_type(Foo(1))  # revealed: Foo
+    # error: [missing-argument] "No argument provided for required parameter `x` of bound method `__call__`"
+    reveal_type(Foo())  # revealed: Foo
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/call/subclass_of.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/call/subclass_of.md
@@ -20,9 +20,11 @@ class C:
 def _(subclass_of_c: type[C]):
     reveal_type(subclass_of_c(1))  # revealed: C
 
-    # TODO: Those should all be errors
+    # error: [invalid-argument-type] "Object of type `Literal["a"]` cannot be assigned to parameter 2 (`x`) of bound method `__init__`; expected type `int`"
     reveal_type(subclass_of_c("a"))  # revealed: C
+    # error: [missing-argument] "No argument provided for required parameter `x` of bound method `__init__`"
     reveal_type(subclass_of_c())  # revealed: C
+    # error: [too-many-positional-arguments] "Too many positional arguments to bound method `__init__`: expected 1, got 2"
     reveal_type(subclass_of_c(1, 2))  # revealed: C
 ```
 

--- a/crates/red_knot_python_semantic/resources/mdtest/generics/classes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/generics/classes.md
@@ -111,6 +111,8 @@ class E[T]:
     def __init__(self, x: T) -> None: ...
 
 # TODO: revealed: E[int] or E[Literal[1]]
+# TODO should not emit an error
+# error: [invalid-argument-type] "Object of type `Literal[1]` cannot be assigned to parameter 2 (`x`) of bound method `__init__`; expected type `T`"
 reveal_type(E(1))  # revealed: E
 ```
 
@@ -118,7 +120,8 @@ The types inferred from a type context and from a constructor parameter must be 
 other:
 
 ```py
-# TODO: error
+# TODO: the error should not leak the `T` typevar and should mention `E[int]`
+# error: [invalid-argument-type] "Object of type `Literal["five"]` cannot be assigned to parameter 2 (`x`) of bound method `__init__`; expected type `T`"
 wrong_innards: E[int] = E("five")
 ```
 

--- a/crates/red_knot_python_semantic/resources/mdtest/unary/invert_add_usub.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/unary/invert_add_usub.md
@@ -18,7 +18,7 @@ class Number:
     def __invert__(self) -> Literal[True]:
         return True
 
-a = Number()
+a = Number(0)
 
 reveal_type(+a)  # revealed: int
 reveal_type(-a)  # revealed: int

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -3600,13 +3600,16 @@ impl<'db> Type<'db> {
         //    fallback to `object.__init__`, since it will indeed check that no arguments are
         //    passed.
         //
-        // Note that we currently ignore `__new__` return type, since we do not support `Self`
-        // and most builtin classes use it as return type annotation. We always return the instance type.
+        // Note that we currently ignore `__new__` return type, since we do not yet support `Self`
+        // and most builtin classes use it as return type annotation. We always return the instance
+        // type.
 
         // Lookup `__new__` method in the MRO up to, but not including, `object`. Also, we must
         // avoid `__new__` on `type` since per descriptor protocol, if `__new__` is not defined on
-        // a class, metaclass attribute would take precedence. But by avoiding `__new__` on `object`
-        // we would inadvertently unhide `__new__` on `type`, which is not what we want.
+        // a class, metaclass attribute would take precedence. But by avoiding `__new__` on
+        // `object` we would inadvertently unhide `__new__` on `type`, which is not what we want.
+        // An alternative might be to not skip `object.__new__` but instead mark it such that it's
+        // easy to check if that's the one we found?
         let new_call_outcome: Option<Result<Bindings<'db>, CallDunderError<'db>>> = match self
             .member_lookup_with_policy(
                 db,

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -2596,13 +2596,6 @@ impl<'db> Type<'db> {
             }
 
             Type::ClassLiteral(..) | Type::SubclassOf(..) => {
-                // Make sure `__mro__` is always searched all the way to object.
-                let policy = if name == "__mro__" {
-                    policy & !MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK
-                } else {
-                    policy
-                };
-
                 let class_attr_plain = self.find_name_in_mro(db, name_str, policy).expect(
                     "Calling `find_name_in_mro` on class literals and subclass-of types should always return `Some`",
                 );

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -3120,11 +3120,11 @@ impl<'db> Type<'db> {
             },
 
             Type::ClassLiteral(ClassLiteralType { class }) => match class.known(db) {
-                // TODO: currently we can't use typeshed to infer all calls using generic
-                // logic definedin `try_call_class_literal` (called from `infer_call_expression`).
-                // It has 3 main reasons: typeshed not 100% accurate, salsa queries and historical
-                // workarounds before `try_call_class_literal` was introduced.
-                // Some/most ofthe arms below should be removed eventually.
+                // TODO: currently we can't use typeshed to infer all calls using generic logic
+                // defined in `try_call_class_literal` (called from `infer_call_expression`). It
+                // has 3 main reasons: typeshed not 100% accurate, salsa queries and historical
+                // workarounds before `try_call_class_literal` was introduced. Some/most of the
+                // arms below should be removed eventually.
                 Some(KnownClass::Bool) => {
                     // ```py
                     // class bool(int):

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -3224,40 +3224,6 @@ impl<'db> Type<'db> {
                     );
                     Signatures::single(signature)
                 }
-                Some(KnownClass::TypeVar) => {
-                    // Added here to avoid salsa query cycle in typeshed definition
-                    // TODO: signature depends on Python version, using 3.11 for now
-                    // ```py
-                    // class TypeVar:
-                    //     elif sys.version_info >= (3, 11):
-                    //        def __new__(
-                    //            cls, name: str, *constraints: Any, bound: Any | None = None, covariant: bool = False,
-                    //            contravariant: bool = False
-                    //        ) -> Self: ...None: ...
-                    // ```
-                    let signature = CallableSignature::from_overloads(
-                        self,
-                        [Signature::new(
-                            Parameters::new([
-                                Parameter::positional_only(Some(Name::new_static("name")))
-                                    .with_annotated_type(KnownClass::Str.to_instance(db)),
-                                Parameter::variadic(Name::new_static("constraints"))
-                                    .with_annotated_type(Type::any()),
-                                Parameter::keyword_only(Name::new_static("bound"))
-                                    .with_annotated_type(Type::any())
-                                    .with_default_type(Type::none(db)),
-                                Parameter::keyword_only(Name::new_static("covariant"))
-                                    .with_annotated_type(KnownClass::Bool.to_instance(db))
-                                    .with_default_type(Type::BooleanLiteral(false)),
-                                Parameter::keyword_only(Name::new_static("contravariant"))
-                                    .with_annotated_type(KnownClass::Bool.to_instance(db))
-                                    .with_default_type(Type::BooleanLiteral(false)),
-                            ]),
-                            Some(KnownClass::TypeVar.to_instance(db)),
-                        )],
-                    );
-                    Signatures::single(signature)
-                }
                 Some(KnownClass::Object) => {
                     // // Added here to avoid salsa query cycle in typeshed definition
                     // ```py

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -3225,7 +3225,6 @@ impl<'db> Type<'db> {
                     Signatures::single(signature)
                 }
                 Some(KnownClass::Object) => {
-                    // // Added here to avoid salsa query cycle in typeshed definition
                     // ```py
                     // class object:
                     //    def __init__(self) -> None: ...

--- a/crates/red_knot_python_semantic/src/types/call/arguments.rs
+++ b/crates/red_knot_python_semantic/src/types/call/arguments.rs
@@ -109,6 +109,21 @@ impl<'a, 'db> CallArgumentTypes<'a, 'db> {
         result
     }
 
+    /// Create a new [`CallArgumentTypes`] by prepending a synthetic argument to the front of this
+    /// argument list.
+    pub(crate) fn prepend_synthetic(&self, synthetic: Type<'db>) -> Self {
+        Self {
+            arguments: CallArguments(
+                std::iter::once(Argument::Synthetic)
+                    .chain(self.arguments.iter())
+                    .collect(),
+            ),
+            types: std::iter::once(synthetic)
+                .chain(self.types.iter().copied())
+                .collect(),
+        }
+    }
+
     pub(crate) fn iter(&self) -> impl Iterator<Item = (Argument<'a>, Type<'db>)> + '_ {
         self.arguments.iter().zip(self.types.iter().copied())
     }

--- a/crates/red_knot_python_semantic/src/types/call/bind.rs
+++ b/crates/red_knot_python_semantic/src/types/call/bind.rs
@@ -929,7 +929,9 @@ impl<'db> Binding<'db> {
                     .count()
                     // using saturating_sub to avoid negative values due to invalid syntax in source code
                     .saturating_sub(num_synthetic_args),
-                provided_positional_count: next_positional,
+                provided_positional_count: next_positional
+                    // using saturating_sub to avoid negative values due to invalid syntax in source code
+                    .saturating_sub(num_synthetic_args),
             });
         }
         let mut missing = vec![];

--- a/crates/red_knot_python_semantic/src/types/call/bind.rs
+++ b/crates/red_knot_python_semantic/src/types/call/bind.rs
@@ -924,7 +924,11 @@ impl<'db> Binding<'db> {
                     first_excess_argument_index,
                     num_synthetic_args,
                 ),
-                expected_positional_count: parameters.positional().count(),
+                expected_positional_count: parameters
+                    .positional()
+                    .count()
+                    // using saturating_sub to avoid negative values due to invalid syntax in source code
+                    .saturating_sub(num_synthetic_args),
                 provided_positional_count: next_positional,
             });
         }

--- a/crates/red_knot_python_semantic/src/types/class.rs
+++ b/crates/red_knot_python_semantic/src/types/class.rs
@@ -2,8 +2,8 @@ use std::sync::{LazyLock, Mutex};
 
 use super::{
     class_base::ClassBase, infer_expression_type, infer_unpack_types, IntersectionBuilder,
-    KnownFunction, Mro, MroError, MroIterator, SubclassOfType, Truthiness, Type, TypeAliasType,
-    TypeQualifiers, TypeVarInstance,
+    KnownFunction, MemberLookupPolicy, Mro, MroError, MroIterator, SubclassOfType, Truthiness,
+    Type, TypeAliasType, TypeQualifiers, TypeVarInstance,
 };
 use crate::semantic_index::definition::Definition;
 use crate::{
@@ -323,7 +323,12 @@ impl<'db> Class<'db> {
     /// The member resolves to a member on the class itself or any of its proper superclasses.
     ///
     /// TODO: Should this be made private...?
-    pub(super) fn class_member(self, db: &'db dyn Db, name: &str) -> SymbolAndQualifiers<'db> {
+    pub(super) fn class_member(
+        self,
+        db: &'db dyn Db,
+        name: &str,
+        policy: MemberLookupPolicy,
+    ) -> SymbolAndQualifiers<'db> {
         if name == "__mro__" {
             let tuple_elements = self.iter_mro(db).map(Type::from);
             return Symbol::bound(TupleType::from_elements(db, tuple_elements)).into();
@@ -354,6 +359,13 @@ impl<'db> Class<'db> {
                     dynamic_type_to_intersect_with.get_or_insert(Type::from(superclass));
                 }
                 ClassBase::Class(class) => {
+                    if class.is_known(db, KnownClass::Object)
+                        // Only exclude `object` members if this is not an `object` class itself
+                        && (policy.mro_no_object_fallback() && !self.is_known(db, KnownClass::Object))
+                    {
+                        continue;
+                    }
+
                     lookup_result = lookup_result.or_else(|lookup_error| {
                         lookup_error.or_fall_back_to(db, class.own_class_member(db, name))
                     });
@@ -776,8 +788,13 @@ impl<'db> ClassLiteralType<'db> {
         self.class.body_scope(db)
     }
 
-    pub(super) fn class_member(self, db: &'db dyn Db, name: &str) -> SymbolAndQualifiers<'db> {
-        self.class.class_member(db, name)
+    pub(super) fn class_member(
+        self,
+        db: &'db dyn Db,
+        name: &str,
+        policy: MemberLookupPolicy,
+    ) -> SymbolAndQualifiers<'db> {
+        self.class.class_member(db, name, policy)
     }
 }
 

--- a/crates/red_knot_python_semantic/src/types/class.rs
+++ b/crates/red_knot_python_semantic/src/types/class.rs
@@ -366,6 +366,11 @@ impl<'db> Class<'db> {
                         continue;
                     }
 
+                    if class.is_known(db, KnownClass::Type) && policy.meta_class_no_type_fallback()
+                    {
+                        continue;
+                    }
+
                     lookup_result = lookup_result.or_else(|lookup_error| {
                         lookup_error.or_fall_back_to(db, class.own_class_member(db, name))
                     });

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -3995,9 +3995,10 @@ impl<'db> TypeInferenceBuilder<'db> {
         };
 
         if class.is_some_and(|class| {
-            // For some known classes we have manual signatures defined and use the
-            // following logic. Mostly due to salsa cycles or historical reasons.
-            // TODO: remove special cases and start relying on typeshed signatures
+            // For some known classes we have manual signatures defined and use the `try_call` path
+            // below. TODO: it should be possible to move these special cases into the
+            // `try_call_class_literal` path instead, or even remove some entirely once we support
+            // overloads fully.
             class.known(self.db()).is_none_or(|class| {
                 !matches!(
                     class,

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -4004,7 +4004,6 @@ impl<'db> TypeInferenceBuilder<'db> {
                     KnownClass::Bool
                         | KnownClass::Str
                         | KnownClass::Type
-                        | KnownClass::TypeVar
                         | KnownClass::Object
                         | KnownClass::Property
                 )

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -3997,7 +3997,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         if class.is_some_and(|class| {
             // For some known classes we have manual signatures defined and use the `try_call` path
             // below. TODO: it should be possible to move these special cases into the
-            // `try_call_class_literal` path instead, or even remove some entirely once we support
+            // `try_call_constructor` path instead, or even remove some entirely once we support
             // overloads fully.
             class.known(self.db()).is_none_or(|class| {
                 !matches!(
@@ -4015,7 +4015,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 self.infer_argument_types(arguments, call_arguments, &argument_forms);
 
             return callable_type
-                .try_call_class_literal(self.db(), call_argument_types)
+                .try_call_constructor(self.db(), call_argument_types)
                 .unwrap_or_else(|err| {
                     err.report_diagnostic(&self.context, callable_type, call_expression.into());
                     err.return_type()

--- a/crates/red_knot_python_semantic/src/types/subclass_of.rs
+++ b/crates/red_knot_python_semantic/src/types/subclass_of.rs
@@ -1,6 +1,6 @@
 use crate::symbol::SymbolAndQualifiers;
 
-use super::{ClassBase, ClassLiteralType, Db, KnownClass, Type};
+use super::{ClassBase, ClassLiteralType, Db, KnownClass, MemberLookupPolicy, Type};
 
 /// A type that represents `type[C]`, i.e. the class object `C` and class objects that are subclasses of `C`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, salsa::Update)]
@@ -70,8 +70,9 @@ impl<'db> SubclassOfType<'db> {
         self,
         db: &'db dyn Db,
         name: &str,
+        policy: MemberLookupPolicy,
     ) -> Option<SymbolAndQualifiers<'db>> {
-        Type::from(self.subclass_of).find_name_in_mro(db, name)
+        Type::from(self.subclass_of).find_name_in_mro(db, name, policy)
     }
 
     /// Return `true` if `self` is a subtype of `other`.

--- a/crates/red_knot_python_semantic/src/types/subclass_of.rs
+++ b/crates/red_knot_python_semantic/src/types/subclass_of.rs
@@ -66,13 +66,13 @@ impl<'db> SubclassOfType<'db> {
         !self.is_dynamic()
     }
 
-    pub(crate) fn find_name_in_mro(
+    pub(crate) fn find_name_in_mro_with_policy(
         self,
         db: &'db dyn Db,
         name: &str,
         policy: MemberLookupPolicy,
     ) -> Option<SymbolAndQualifiers<'db>> {
-        Type::from(self.subclass_of).find_name_in_mro(db, name, policy)
+        Type::from(self.subclass_of).find_name_in_mro_with_policy(db, name, policy)
     }
 
     /// Return `true` if `self` is a subtype of `other`.


### PR DESCRIPTION
## Summary

* Addresses #16511 for simple cases where only `__init__` method is bound on class or doesn't exist at all.
* fixes a bug with argument counting in bound method diagnostics

Caveats:
* No handling of `__new__` or modified `__call__` on metaclass.
* This leads to a couple of false positive errors in tests

## Test Plan

- A couple new cases in mdtests
- cargo nextest run -p red_knot_python_semantic --no-fail-fast

