### PR TITLE
[red-knot] Case sensitive module resolver

### DIFF
--- a/crates/red_knot/src/main.rs
+++ b/crates/red_knot/src/main.rs
@@ -80,6 +80,8 @@ fn run_check(args: CheckCommand) -> anyhow::Result<ExitStatus> {
     countme::enable(verbosity.is_trace());
     let _guard = setup_tracing(verbosity)?;
 
+    tracing::debug!("Version: {}", version::version());
+
     // The base path to which all CLI arguments are relative to.
     let cwd = {
         let cwd = std::env::current_dir().context("Failed to get the current working directory")?;

--- a/crates/red_knot_python_semantic/resources/mdtest/import/basic.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/import/basic.md
@@ -140,3 +140,27 @@ import b.foo  # error: [unresolved-import] "Cannot resolve import `b.foo`"
 
 ```py
 ```
+
+## Long paths
+
+It's unlikely that a single module component is as long as in this example, but Windows treats paths
+that are longer than 200 and something specially. This test ensures that Red Knot can handle those
+paths gracefully.
+
+```toml
+system = "os"
+```
+
+`AveryLongPathAveryLongPathAveryLongPathAveryLongPathAveryLongPathAveryLongPathAveryLongPathAveryLongPathAveryLongPathAveryLongPathAveryLongPathAveryLongPathAveryLongPathAveryLongPathAveryLongPathAveryLongPathAveryLongPath/__init__.py`:
+
+```py
+class Foo: ...
+```
+
+```py
+from AveryLongPathAveryLongPathAveryLongPathAveryLongPathAveryLongPathAveryLongPathAveryLongPathAveryLongPathAveryLongPathAveryLongPathAveryLongPathAveryLongPathAveryLongPathAveryLongPathAveryLongPathAveryLongPathAveryLongPath import (
+    Foo,
+)
+
+reveal_type(Foo())  # revealed: Foo
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/import/case_sensitive.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/import/case_sensitive.md
@@ -4,7 +4,7 @@
 # TODO: This test should use the real file system instead of the memory file system.
 # but we can't change the file system yet because the tests would then start failing for 
 # case-insensitive file systems.
-#system = "os"
+system = "os"
 ```
 
 Python's import system is case-sensitive even on case-insensitive file system. This means, importing

--- a/crates/red_knot_python_semantic/resources/mdtest/import/case_sensitive.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/import/case_sensitive.md
@@ -1,9 +1,6 @@
 # Case Sensitive Imports
 
 ```toml
-# TODO: This test should use the real file system instead of the memory file system.
-# but we can't change the file system yet because the tests would then start failing for 
-# case-insensitive file systems.
 system = "os"
 ```
 

--- a/crates/red_knot_python_semantic/src/module_resolver/path.rs
+++ b/crates/red_knot_python_semantic/src/module_resolver/path.rs
@@ -63,6 +63,10 @@ impl ModulePath {
         self.relative_path.pop()
     }
 
+    pub(super) fn search_path(&self) -> &SearchPath {
+        &self.search_path
+    }
+
     #[must_use]
     pub(super) fn is_directory(&self, resolver: &ResolverContext) -> bool {
         let ModulePath {

--- a/crates/red_knot_python_semantic/src/module_resolver/resolver.rs
+++ b/crates/red_knot_python_semantic/src/module_resolver/resolver.rs
@@ -617,11 +617,11 @@ fn resolve_file_module(module: &ModulePath, resolver_state: &ResolverContext) ->
     // We can skip this step for vendored files or virtual files because
     // those file systems are case sensitive (we wouldn't get to this point).
     if let Some(path) = file.path(resolver_state.db).as_system_path() {
-        if !resolver_state
-            .db
-            .system()
-            .path_exists_case_sensitive(path, module.search_path().as_system_path().unwrap())
-            .unwrap_or(true)
+        let system = resolver_state.db.system();
+        if system.is_case_sensitive() != Some(true)
+            && !system
+                .path_exists_case_sensitive(path, module.search_path().as_system_path().unwrap())
+                .unwrap_or(true)
         {
             return None;
         }

--- a/crates/red_knot_python_semantic/src/module_resolver/resolver.rs
+++ b/crates/red_knot_python_semantic/src/module_resolver/resolver.rs
@@ -621,7 +621,6 @@ fn resolve_file_module(module: &ModulePath, resolver_state: &ResolverContext) ->
         if !system.case_sensitivity().is_case_sensitive()
             && !system
                 .path_exists_case_sensitive(path, module.search_path().as_system_path().unwrap())
-                .unwrap_or(true)
         {
             return None;
         }

--- a/crates/red_knot_python_semantic/src/module_resolver/resolver.rs
+++ b/crates/red_knot_python_semantic/src/module_resolver/resolver.rs
@@ -618,7 +618,7 @@ fn resolve_file_module(module: &ModulePath, resolver_state: &ResolverContext) ->
     // those file systems are case sensitive (we wouldn't get to this point).
     if let Some(path) = file.path(resolver_state.db).as_system_path() {
         let system = resolver_state.db.system();
-        if system.is_case_sensitive() != Some(true)
+        if !system.case_sensitivity().is_case_sensitive()
             && !system
                 .path_exists_case_sensitive(path, module.search_path().as_system_path().unwrap())
                 .unwrap_or(true)

--- a/crates/red_knot_python_semantic/src/module_resolver/resolver.rs
+++ b/crates/red_knot_python_semantic/src/module_resolver/resolver.rs
@@ -735,9 +735,8 @@ impl<'db> ResolverContext<'db> {
 
 #[cfg(test)]
 mod tests {
-    use anyhow::Context;
     use ruff_db::files::{system_path_to_file, File, FilePath};
-    use ruff_db::system::{DbWithTestSystem as _, DbWithWritableSystem as _, OsSystem};
+    use ruff_db::system::{DbWithTestSystem as _, DbWithWritableSystem as _};
     use ruff_db::testing::{
         assert_const_function_query_was_not_run, assert_function_query_was_not_run,
     };
@@ -1863,6 +1862,9 @@ not_a_directory
     #[test]
     #[cfg(unix)]
     fn case_sensitive_resolution_with_symlinked_directory() -> anyhow::Result<()> {
+        use anyhow::Context;
+        use ruff_db::system::OsSystem;
+
         let temp_dir = tempfile::TempDir::new()?;
         let root = SystemPathBuf::from_path_buf(
             temp_dir

--- a/crates/red_knot_server/src/system.rs
+++ b/crates/red_knot_server/src/system.rs
@@ -223,6 +223,10 @@ impl System for LSPSystem {
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }
+
+    fn is_case_sensitive(&self) -> Option<bool> {
+        self.os_system.is_case_sensitive()
+    }
 }
 
 fn not_a_text_document(path: impl Display) -> std::io::Error {

--- a/crates/red_knot_server/src/system.rs
+++ b/crates/red_knot_server/src/system.rs
@@ -136,7 +136,7 @@ impl System for LSPSystem {
         self.os_system.canonicalize_path(path)
     }
 
-    fn path_exists_case_sensitive(&self, path: &SystemPath, prefix: &SystemPath) -> Result<bool> {
+    fn path_exists_case_sensitive(&self, path: &SystemPath, prefix: &SystemPath) -> bool {
         self.os_system.path_exists_case_sensitive(path, prefix)
     }
 

--- a/crates/red_knot_server/src/system.rs
+++ b/crates/red_knot_server/src/system.rs
@@ -136,6 +136,10 @@ impl System for LSPSystem {
         self.os_system.canonicalize_path(path)
     }
 
+    fn path_exists_case_sensitive(&self, path: &SystemPath, prefix: &SystemPath) -> Result<bool> {
+        self.os_system.path_exists_case_sensitive(path, prefix)
+    }
+
     fn read_to_string(&self, path: &SystemPath) -> Result<String> {
         let document = self.system_path_to_document_ref(path)?;
 

--- a/crates/red_knot_server/src/system.rs
+++ b/crates/red_knot_server/src/system.rs
@@ -7,8 +7,8 @@ use lsp_types::Url;
 use ruff_db::file_revision::FileRevision;
 use ruff_db::system::walk_directory::WalkDirectoryBuilder;
 use ruff_db::system::{
-    DirectoryEntry, FileType, GlobError, Metadata, OsSystem, PatternError, Result, System,
-    SystemPath, SystemPathBuf, SystemVirtualPath, SystemVirtualPathBuf,
+    CaseSensitivity, DirectoryEntry, FileType, GlobError, Metadata, OsSystem, PatternError, Result,
+    System, SystemPath, SystemPathBuf, SystemVirtualPath, SystemVirtualPathBuf,
 };
 use ruff_notebook::{Notebook, NotebookError};
 
@@ -224,8 +224,8 @@ impl System for LSPSystem {
         self
     }
 
-    fn is_case_sensitive(&self) -> Option<bool> {
-        self.os_system.is_case_sensitive()
+    fn case_sensitivity(&self) -> CaseSensitivity {
+        self.os_system.case_sensitivity()
     }
 }
 

--- a/crates/red_knot_test/src/db.rs
+++ b/crates/red_knot_test/src/db.rs
@@ -220,6 +220,10 @@ impl System for MdtestSystem {
             .path_exists_case_sensitive(&self.normalize_path(path), &self.normalize_path(prefix))
     }
 
+    fn is_case_sensitive(&self) -> Option<bool> {
+        self.as_system().is_case_sensitive()
+    }
+
     fn current_directory(&self) -> &SystemPath {
         self.as_system().current_directory()
     }

--- a/crates/red_knot_test/src/db.rs
+++ b/crates/red_knot_test/src/db.rs
@@ -3,8 +3,8 @@ use red_knot_python_semantic::lint::{LintRegistry, RuleSelection};
 use red_knot_python_semantic::{default_lint_registry, Db as SemanticDb};
 use ruff_db::files::{File, Files};
 use ruff_db::system::{
-    DbWithWritableSystem, InMemorySystem, OsSystem, System, SystemPath, SystemPathBuf,
-    WritableSystem,
+    CaseSensitivity, DbWithWritableSystem, InMemorySystem, OsSystem, System, SystemPath,
+    SystemPathBuf, WritableSystem,
 };
 use ruff_db::vendored::VendoredFileSystem;
 use ruff_db::{Db as SourceDb, Upcast};
@@ -220,8 +220,8 @@ impl System for MdtestSystem {
             .path_exists_case_sensitive(&self.normalize_path(path), &self.normalize_path(prefix))
     }
 
-    fn is_case_sensitive(&self) -> Option<bool> {
-        self.as_system().is_case_sensitive()
+    fn case_sensitivity(&self) -> CaseSensitivity {
+        self.as_system().case_sensitivity()
     }
 
     fn current_directory(&self) -> &SystemPath {

--- a/crates/red_knot_test/src/db.rs
+++ b/crates/red_knot_test/src/db.rs
@@ -211,11 +211,7 @@ impl System for MdtestSystem {
         self.as_system().read_virtual_path_to_notebook(path)
     }
 
-    fn path_exists_case_sensitive(
-        &self,
-        path: &SystemPath,
-        prefix: &SystemPath,
-    ) -> ruff_db::system::Result<bool> {
+    fn path_exists_case_sensitive(&self, path: &SystemPath, prefix: &SystemPath) -> bool {
         self.as_system()
             .path_exists_case_sensitive(&self.normalize_path(path), &self.normalize_path(prefix))
     }

--- a/crates/red_knot_test/src/db.rs
+++ b/crates/red_knot_test/src/db.rs
@@ -211,6 +211,15 @@ impl System for MdtestSystem {
         self.as_system().read_virtual_path_to_notebook(path)
     }
 
+    fn path_exists_case_sensitive(
+        &self,
+        path: &SystemPath,
+        prefix: &SystemPath,
+    ) -> ruff_db::system::Result<bool> {
+        self.as_system()
+            .path_exists_case_sensitive(&self.normalize_path(path), &self.normalize_path(prefix))
+    }
+
     fn current_directory(&self) -> &SystemPath {
         self.as_system().current_directory()
     }

--- a/crates/red_knot_test/src/lib.rs
+++ b/crates/red_knot_test/src/lib.rs
@@ -113,7 +113,9 @@ fn run_test(
                 .canonicalize()
                 .expect("Canonicalizing to succeed");
             let root_path = SystemPathBuf::from_path_buf(root_path)
-                .expect("Temp directory to be a valid UTF8 path");
+                .expect("Temp directory to be a valid UTF8 path")
+                .simplified()
+                .to_path_buf();
 
             db.use_os_system_with_temp_dir(root_path, dir);
         }

--- a/crates/red_knot_wasm/src/lib.rs
+++ b/crates/red_knot_wasm/src/lib.rs
@@ -260,6 +260,14 @@ impl System for WasmSystem {
         Err(ruff_notebook::NotebookError::Io(not_found()))
     }
 
+    fn path_exists_case_sensitive(
+        &self,
+        path: &SystemPath,
+        _prefix: &SystemPath,
+    ) -> ruff_db::system::Result<bool> {
+        Ok(self.path_exists(path))
+    }
+
     fn current_directory(&self) -> &SystemPath {
         self.fs.current_directory()
     }

--- a/crates/red_knot_wasm/src/lib.rs
+++ b/crates/red_knot_wasm/src/lib.rs
@@ -268,6 +268,10 @@ impl System for WasmSystem {
         Ok(self.path_exists(path))
     }
 
+    fn is_case_sensitive(&self) -> Option<bool> {
+        Some(true)
+    }
+
     fn current_directory(&self) -> &SystemPath {
         self.fs.current_directory()
     }

--- a/crates/red_knot_wasm/src/lib.rs
+++ b/crates/red_knot_wasm/src/lib.rs
@@ -11,8 +11,8 @@ use ruff_db::diagnostic::{DisplayDiagnosticConfig, OldDiagnosticTrait};
 use ruff_db::files::{system_path_to_file, File};
 use ruff_db::system::walk_directory::WalkDirectoryBuilder;
 use ruff_db::system::{
-    DirectoryEntry, GlobError, MemoryFileSystem, Metadata, PatternError, System, SystemPath,
-    SystemPathBuf, SystemVirtualPath,
+    CaseSensitivity, DirectoryEntry, GlobError, MemoryFileSystem, Metadata, PatternError, System,
+    SystemPath, SystemPathBuf, SystemVirtualPath,
 };
 use ruff_notebook::Notebook;
 
@@ -268,8 +268,8 @@ impl System for WasmSystem {
         Ok(self.path_exists(path))
     }
 
-    fn is_case_sensitive(&self) -> Option<bool> {
-        Some(true)
+    fn case_sensitivity(&self) -> CaseSensitivity {
+        CaseSensitivity::CaseSensitive
     }
 
     fn current_directory(&self) -> &SystemPath {

--- a/crates/red_knot_wasm/src/lib.rs
+++ b/crates/red_knot_wasm/src/lib.rs
@@ -260,12 +260,8 @@ impl System for WasmSystem {
         Err(ruff_notebook::NotebookError::Io(not_found()))
     }
 
-    fn path_exists_case_sensitive(
-        &self,
-        path: &SystemPath,
-        _prefix: &SystemPath,
-    ) -> ruff_db::system::Result<bool> {
-        Ok(self.path_exists(path))
+    fn path_exists_case_sensitive(&self, path: &SystemPath, _prefix: &SystemPath) -> bool {
+        self.path_exists(path)
     }
 
     fn case_sensitivity(&self) -> CaseSensitivity {

--- a/crates/ruff_db/src/source.rs
+++ b/crates/ruff_db/src/source.rs
@@ -159,7 +159,7 @@ pub enum SourceTextError {
 /// Computes the [`LineIndex`] for `file`.
 #[salsa::tracked]
 pub fn line_index(db: &dyn Db, file: File) -> LineIndex {
-    let _span = tracing::trace_span!("line_index", file = ?file).entered();
+    let _span = tracing::trace_span!("line_index", file = ?file.path(db)).entered();
 
     let source = source_text(db, file);
 

--- a/crates/ruff_db/src/system.rs
+++ b/crates/ruff_db/src/system.rs
@@ -89,6 +89,15 @@ pub trait System: Debug {
         self.path_metadata(path).is_ok()
     }
 
+    /// Returns `true` if `path` exists on disk using the exact casing as specified in `path` for the parts after `prefix`.
+    ///
+    /// This is the same as [`Self::path_exists`] on case-sensitive systems.
+    ///
+    /// ## The use of prefix
+    ///
+    /// Prefix is only intended as an optimization for systems that can't efficiently check
+    /// if an entire path exists with the exact casing as specified in `path`. However,
+    /// implementations are allowed to check the casing of the entire path if they can do so efficiently.
     fn path_exists_case_sensitive(&self, path: &SystemPath, prefix: &SystemPath) -> Result<bool>;
 
     /// Returns `true` if `path` exists and is a directory.

--- a/crates/ruff_db/src/system.rs
+++ b/crates/ruff_db/src/system.rs
@@ -9,7 +9,7 @@ pub use os::OsSystem;
 
 use ruff_notebook::{Notebook, NotebookError};
 use std::error::Error;
-use std::fmt::Debug;
+use std::fmt::{Debug, Formatter};
 use std::path::{Path, PathBuf};
 use std::{fmt, io};
 pub use test::{DbWithTestSystem, DbWithWritableSystem, InMemorySystem, TestSystem};
@@ -100,9 +100,8 @@ pub trait System: Debug {
     /// implementations are allowed to check the casing of the entire path if they can do so efficiently.
     fn path_exists_case_sensitive(&self, path: &SystemPath, prefix: &SystemPath) -> Result<bool>;
 
-    /// Returns `Some(true)` if the system is case-sensitive, `Some(false)` if it is case-insensitive
-    /// and `None` if querying the information failed.
-    fn is_case_sensitive(&self) -> Option<bool>;
+    /// Returns the [`CaseSensitivity`] of the system's file system.
+    fn case_sensitivity(&self) -> CaseSensitivity;
 
     /// Returns `true` if `path` exists and is a directory.
     fn is_directory(&self, path: &SystemPath) -> bool {
@@ -174,6 +173,39 @@ pub trait System: Debug {
     fn as_any(&self) -> &dyn std::any::Any;
 
     fn as_any_mut(&mut self) -> &mut dyn std::any::Any;
+}
+
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
+pub enum CaseSensitivity {
+    /// The case sensitivity of the file system is unknown.
+    ///
+    /// The file system is either case-sensitive or case-insensitive. A caller
+    /// should not assume either case.
+    #[default]
+    Unknown,
+
+    /// The file system is case-sensitive.
+    CaseSensitive,
+
+    /// The file system is case-insensitive.
+    CaseInsensitive,
+}
+
+impl CaseSensitivity {
+    /// Returns `true` if the file system is known to be case-sensitive.
+    pub const fn is_case_sensitive(self) -> bool {
+        matches!(self, Self::CaseSensitive)
+    }
+}
+
+impl fmt::Display for CaseSensitivity {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            CaseSensitivity::Unknown => f.write_str("unknown"),
+            CaseSensitivity::CaseSensitive => f.write_str("case-sensitive"),
+            CaseSensitivity::CaseInsensitive => f.write_str("case-insensitive"),
+        }
+    }
 }
 
 /// System trait for non-readonly systems.

--- a/crates/ruff_db/src/system.rs
+++ b/crates/ruff_db/src/system.rs
@@ -89,6 +89,8 @@ pub trait System: Debug {
         self.path_metadata(path).is_ok()
     }
 
+    fn path_exists_case_sensitive(&self, path: &SystemPath, prefix: &SystemPath) -> Result<bool>;
+
     /// Returns `true` if `path` exists and is a directory.
     fn is_directory(&self, path: &SystemPath) -> bool {
         self.path_metadata(path)

--- a/crates/ruff_db/src/system.rs
+++ b/crates/ruff_db/src/system.rs
@@ -100,6 +100,10 @@ pub trait System: Debug {
     /// implementations are allowed to check the casing of the entire path if they can do so efficiently.
     fn path_exists_case_sensitive(&self, path: &SystemPath, prefix: &SystemPath) -> Result<bool>;
 
+    /// Returns `Some(true)` if the system is case-sensitive, `Some(false)` if it is case-insensitive
+    /// and `None` if querying the information failed.
+    fn is_case_sensitive(&self) -> Option<bool>;
+
     /// Returns `true` if `path` exists and is a directory.
     fn is_directory(&self, path: &SystemPath) -> bool {
         self.path_metadata(path)

--- a/crates/ruff_db/src/system.rs
+++ b/crates/ruff_db/src/system.rs
@@ -98,7 +98,7 @@ pub trait System: Debug {
     /// Prefix is only intended as an optimization for systems that can't efficiently check
     /// if an entire path exists with the exact casing as specified in `path`. However,
     /// implementations are allowed to check the casing of the entire path if they can do so efficiently.
-    fn path_exists_case_sensitive(&self, path: &SystemPath, prefix: &SystemPath) -> Result<bool>;
+    fn path_exists_case_sensitive(&self, path: &SystemPath, prefix: &SystemPath) -> bool;
 
     /// Returns the [`CaseSensitivity`] of the system's file system.
     fn case_sensitivity(&self) -> CaseSensitivity;

--- a/crates/ruff_db/src/system/test.rs
+++ b/crates/ruff_db/src/system/test.rs
@@ -5,8 +5,8 @@ use std::sync::{Arc, Mutex};
 
 use crate::files::File;
 use crate::system::{
-    DirectoryEntry, GlobError, MemoryFileSystem, Metadata, Result, System, SystemPath,
-    SystemPathBuf, SystemVirtualPath,
+    CaseSensitivity, DirectoryEntry, GlobError, MemoryFileSystem, Metadata, Result, System,
+    SystemPath, SystemPathBuf, SystemVirtualPath,
 };
 use crate::Db;
 
@@ -135,8 +135,8 @@ impl System for TestSystem {
         self.system().path_exists_case_sensitive(path, prefix)
     }
 
-    fn is_case_sensitive(&self) -> Option<bool> {
-        self.system().is_case_sensitive()
+    fn case_sensitivity(&self) -> CaseSensitivity {
+        self.system().case_sensitivity()
     }
 }
 
@@ -364,8 +364,8 @@ impl System for InMemorySystem {
         Ok(self.path_exists(path))
     }
 
-    fn is_case_sensitive(&self) -> Option<bool> {
-        Some(true)
+    fn case_sensitivity(&self) -> CaseSensitivity {
+        CaseSensitivity::CaseSensitive
     }
 }
 

--- a/crates/ruff_db/src/system/test.rs
+++ b/crates/ruff_db/src/system/test.rs
@@ -134,6 +134,10 @@ impl System for TestSystem {
     fn path_exists_case_sensitive(&self, path: &SystemPath, prefix: &SystemPath) -> Result<bool> {
         self.system().path_exists_case_sensitive(path, prefix)
     }
+
+    fn is_case_sensitive(&self) -> Option<bool> {
+        self.system().is_case_sensitive()
+    }
 }
 
 impl Default for TestSystem {
@@ -358,6 +362,10 @@ impl System for InMemorySystem {
     fn path_exists_case_sensitive(&self, path: &SystemPath, _prefix: &SystemPath) -> Result<bool> {
         // The memory file system is case-sensitive.
         Ok(self.path_exists(path))
+    }
+
+    fn is_case_sensitive(&self) -> Option<bool> {
+        Some(true)
     }
 }
 

--- a/crates/ruff_db/src/system/test.rs
+++ b/crates/ruff_db/src/system/test.rs
@@ -131,7 +131,7 @@ impl System for TestSystem {
         self
     }
 
-    fn path_exists_case_sensitive(&self, path: &SystemPath, prefix: &SystemPath) -> Result<bool> {
+    fn path_exists_case_sensitive(&self, path: &SystemPath, prefix: &SystemPath) -> bool {
         self.system().path_exists_case_sensitive(path, prefix)
     }
 
@@ -359,9 +359,9 @@ impl System for InMemorySystem {
     }
 
     #[inline]
-    fn path_exists_case_sensitive(&self, path: &SystemPath, _prefix: &SystemPath) -> Result<bool> {
+    fn path_exists_case_sensitive(&self, path: &SystemPath, _prefix: &SystemPath) -> bool {
         // The memory file system is case-sensitive.
-        Ok(self.path_exists(path))
+        self.path_exists(path)
     }
 
     fn case_sensitivity(&self) -> CaseSensitivity {

--- a/crates/ruff_db/src/system/test.rs
+++ b/crates/ruff_db/src/system/test.rs
@@ -130,6 +130,10 @@ impl System for TestSystem {
     fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
         self
     }
+
+    fn path_exists_case_sensitive(&self, path: &SystemPath, prefix: &SystemPath) -> Result<bool> {
+        self.system().path_exists_case_sensitive(path, prefix)
+    }
 }
 
 impl Default for TestSystem {
@@ -348,6 +352,12 @@ impl System for InMemorySystem {
 
     fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
         self
+    }
+
+    #[inline]
+    fn path_exists_case_sensitive(&self, path: &SystemPath, _prefix: &SystemPath) -> Result<bool> {
+        // The memory file system is case-sensitive.
+        Ok(self.path_exists(path))
     }
 }
 


### PR DESCRIPTION
## Summary

This PR implements the first part of https://github.com/astral-sh/ruff/discussions/16440. It ensures that Red Knot's module resolver is case sensitive on all systems. 

This PR combines a few approaches:

1. It uses `canonicalize` on non-case-sensitive systems to get the real casing of a path. This works for as long as no symlinks or mapped network drives (the windows `E:\` is mapped to `\\server\share` thingy). This is the same as what Pyright does
2. If 1. fails, fall back to recursively list the parent directory and test if the path's file name matches the casing exactly as listed in by list dir. This is the same approach as CPython takes in its module resolver. The main downside is that it requires more syscalls because, unlike CPython, we Red Knot needs to invalidate its caches if a file name gets renamed (CPython assumes that the folders are immutable). 

It's worth noting that the file watching test that I added that renames `lib.py` to `Lib.py` currently doesn't pass on case-insensitive systems. Making it pass requires some more involved changes to `Files`. I plan to work on this next. There's the argument that landing this PR on its own isn't worth it without this issue being addressed. I think it's still a good step in the right direction even when some of the details on how and where the path case sensitive comparison is implemented.

## Test plan

I added multiple integration tests (including a failing one). I tested that the `case-sensitivity` detection works as expected on Windows, MacOS and Linux and that the fast-paths are taken accordingly. 