### PR TITLE
[syntax-errors] Parenthesized context managers before Python 3.9

### DIFF
--- a/crates/ruff_python_parser/resources/inline/ok/parenthesized_context_manager_py38.py
+++ b/crates/ruff_python_parser/resources/inline/ok/parenthesized_context_manager_py38.py
@@ -1,0 +1,36 @@
+# parse_options: {"target-version": "3.8"}
+with (x, y) as foo:
+    pass
+
+with (x,
+    y) as foo:
+    pass
+
+with (x,
+y):
+    pass
+
+with (
+    x,
+):
+    pass
+
+with (
+    x,
+    y
+) as foo:
+    pass
+
+with x, (
+    y
+): pass
+
+with x as foo, (
+y
+) as bar:
+    pass
+
+with x() as foo, (
+    y()
+) as bar:
+    pass

--- a/crates/ruff_python_parser/src/error.rs
+++ b/crates/ruff_python_parser/src/error.rs
@@ -536,6 +536,7 @@ pub enum UnsupportedSyntaxErrorKind {
     TypeParameterList,
     TypeAliasStatement,
     TypeParamDefault,
+    ParenthesizedContextManager,
 }
 
 impl Display for UnsupportedSyntaxError {
@@ -552,6 +553,9 @@ impl Display for UnsupportedSyntaxError {
             UnsupportedSyntaxErrorKind::TypeAliasStatement => "Cannot use `type` alias statement",
             UnsupportedSyntaxErrorKind::TypeParamDefault => {
                 "Cannot set default type for a type parameter"
+            }
+            UnsupportedSyntaxErrorKind::ParenthesizedContextManager => {
+                "Invalid parentheses around context manager"
             }
         };
         write!(
@@ -575,6 +579,7 @@ impl UnsupportedSyntaxErrorKind {
             UnsupportedSyntaxErrorKind::TypeParameterList => PythonVersion::PY312,
             UnsupportedSyntaxErrorKind::TypeAliasStatement => PythonVersion::PY312,
             UnsupportedSyntaxErrorKind::TypeParamDefault => PythonVersion::PY313,
+            UnsupportedSyntaxErrorKind::ParenthesizedContextManager => PythonVersion::PY39,
         }
     }
 }

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -1967,6 +1967,43 @@ impl<'src> Parser<'src> {
     ///
     /// See: <https://docs.python.org/3/reference/compound_stmts.html#the-with-statement>
     fn parse_with_statement(&mut self, start: TextSize) -> ast::StmtWith {
+        // test_ok parenthesized_context_manager_py38
+        // # parse_options: {"target-version": "3.8"}
+        // with (x, y) as foo:
+        //     pass
+        //
+        // with (x,
+        //     y) as foo:
+        //     pass
+        //
+        // with (x,
+        // y):
+        //     pass
+        //
+        // with (
+        //     x,
+        // ):
+        //     pass
+        //
+        // with (
+        //     x,
+        //     y
+        // ) as foo:
+        //     pass
+        //
+        // with x, (
+        //     y
+        // ): pass
+        //
+        // with x as foo, (
+        // y
+        // ) as bar:
+        //     pass
+        //
+        // with x() as foo, (
+        //     y()
+        // ) as bar:
+        //     pass
         self.bump(TokenKind::With);
 
         let items = self.parse_with_items();

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@parenthesized_context_manager_py38.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@parenthesized_context_manager_py38.py.snap
@@ -1,0 +1,391 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/inline/ok/parenthesized_context_manager_py38.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..307,
+        body: [
+            With(
+                StmtWith {
+                    range: 43..71,
+                    is_async: false,
+                    items: [
+                        WithItem {
+                            range: 48..61,
+                            context_expr: Tuple(
+                                ExprTuple {
+                                    range: 48..54,
+                                    elts: [
+                                        Name(
+                                            ExprName {
+                                                range: 49..50,
+                                                id: Name("x"),
+                                                ctx: Load,
+                                            },
+                                        ),
+                                        Name(
+                                            ExprName {
+                                                range: 52..53,
+                                                id: Name("y"),
+                                                ctx: Load,
+                                            },
+                                        ),
+                                    ],
+                                    ctx: Load,
+                                    parenthesized: true,
+                                },
+                            ),
+                            optional_vars: Some(
+                                Name(
+                                    ExprName {
+                                        range: 58..61,
+                                        id: Name("foo"),
+                                        ctx: Store,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    body: [
+                        Pass(
+                            StmtPass {
+                                range: 67..71,
+                            },
+                        ),
+                    ],
+                },
+            ),
+            With(
+                StmtWith {
+                    range: 73..105,
+                    is_async: false,
+                    items: [
+                        WithItem {
+                            range: 78..95,
+                            context_expr: Tuple(
+                                ExprTuple {
+                                    range: 78..88,
+                                    elts: [
+                                        Name(
+                                            ExprName {
+                                                range: 79..80,
+                                                id: Name("x"),
+                                                ctx: Load,
+                                            },
+                                        ),
+                                        Name(
+                                            ExprName {
+                                                range: 86..87,
+                                                id: Name("y"),
+                                                ctx: Load,
+                                            },
+                                        ),
+                                    ],
+                                    ctx: Load,
+                                    parenthesized: true,
+                                },
+                            ),
+                            optional_vars: Some(
+                                Name(
+                                    ExprName {
+                                        range: 92..95,
+                                        id: Name("foo"),
+                                        ctx: Store,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    body: [
+                        Pass(
+                            StmtPass {
+                                range: 101..105,
+                            },
+                        ),
+                    ],
+                },
+            ),
+            With(
+                StmtWith {
+                    range: 107..128,
+                    is_async: false,
+                    items: [
+                        WithItem {
+                            range: 113..114,
+                            context_expr: Name(
+                                ExprName {
+                                    range: 113..114,
+                                    id: Name("x"),
+                                    ctx: Load,
+                                },
+                            ),
+                            optional_vars: None,
+                        },
+                        WithItem {
+                            range: 116..117,
+                            context_expr: Name(
+                                ExprName {
+                                    range: 116..117,
+                                    id: Name("y"),
+                                    ctx: Load,
+                                },
+                            ),
+                            optional_vars: None,
+                        },
+                    ],
+                    body: [
+                        Pass(
+                            StmtPass {
+                                range: 124..128,
+                            },
+                        ),
+                    ],
+                },
+            ),
+            With(
+                StmtWith {
+                    range: 130..155,
+                    is_async: false,
+                    items: [
+                        WithItem {
+                            range: 141..142,
+                            context_expr: Name(
+                                ExprName {
+                                    range: 141..142,
+                                    id: Name("x"),
+                                    ctx: Load,
+                                },
+                            ),
+                            optional_vars: None,
+                        },
+                    ],
+                    body: [
+                        Pass(
+                            StmtPass {
+                                range: 151..155,
+                            },
+                        ),
+                    ],
+                },
+            ),
+            With(
+                StmtWith {
+                    range: 157..195,
+                    is_async: false,
+                    items: [
+                        WithItem {
+                            range: 162..185,
+                            context_expr: Tuple(
+                                ExprTuple {
+                                    range: 162..178,
+                                    elts: [
+                                        Name(
+                                            ExprName {
+                                                range: 168..169,
+                                                id: Name("x"),
+                                                ctx: Load,
+                                            },
+                                        ),
+                                        Name(
+                                            ExprName {
+                                                range: 175..176,
+                                                id: Name("y"),
+                                                ctx: Load,
+                                            },
+                                        ),
+                                    ],
+                                    ctx: Load,
+                                    parenthesized: true,
+                                },
+                            ),
+                            optional_vars: Some(
+                                Name(
+                                    ExprName {
+                                        range: 182..185,
+                                        id: Name("foo"),
+                                        ctx: Store,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    body: [
+                        Pass(
+                            StmtPass {
+                                range: 191..195,
+                            },
+                        ),
+                    ],
+                },
+            ),
+            With(
+                StmtWith {
+                    range: 197..220,
+                    is_async: false,
+                    items: [
+                        WithItem {
+                            range: 202..203,
+                            context_expr: Name(
+                                ExprName {
+                                    range: 202..203,
+                                    id: Name("x"),
+                                    ctx: Load,
+                                },
+                            ),
+                            optional_vars: None,
+                        },
+                        WithItem {
+                            range: 205..214,
+                            context_expr: Name(
+                                ExprName {
+                                    range: 211..212,
+                                    id: Name("y"),
+                                    ctx: Load,
+                                },
+                            ),
+                            optional_vars: None,
+                        },
+                    ],
+                    body: [
+                        Pass(
+                            StmtPass {
+                                range: 216..220,
+                            },
+                        ),
+                    ],
+                },
+            ),
+            With(
+                StmtWith {
+                    range: 222..259,
+                    is_async: false,
+                    items: [
+                        WithItem {
+                            range: 227..235,
+                            context_expr: Name(
+                                ExprName {
+                                    range: 227..228,
+                                    id: Name("x"),
+                                    ctx: Load,
+                                },
+                            ),
+                            optional_vars: Some(
+                                Name(
+                                    ExprName {
+                                        range: 232..235,
+                                        id: Name("foo"),
+                                        ctx: Store,
+                                    },
+                                ),
+                            ),
+                        },
+                        WithItem {
+                            range: 237..249,
+                            context_expr: Name(
+                                ExprName {
+                                    range: 239..240,
+                                    id: Name("y"),
+                                    ctx: Load,
+                                },
+                            ),
+                            optional_vars: Some(
+                                Name(
+                                    ExprName {
+                                        range: 246..249,
+                                        id: Name("bar"),
+                                        ctx: Store,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    body: [
+                        Pass(
+                            StmtPass {
+                                range: 255..259,
+                            },
+                        ),
+                    ],
+                },
+            ),
+            With(
+                StmtWith {
+                    range: 261..306,
+                    is_async: false,
+                    items: [
+                        WithItem {
+                            range: 266..276,
+                            context_expr: Call(
+                                ExprCall {
+                                    range: 266..269,
+                                    func: Name(
+                                        ExprName {
+                                            range: 266..267,
+                                            id: Name("x"),
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    arguments: Arguments {
+                                        range: 267..269,
+                                        args: [],
+                                        keywords: [],
+                                    },
+                                },
+                            ),
+                            optional_vars: Some(
+                                Name(
+                                    ExprName {
+                                        range: 273..276,
+                                        id: Name("foo"),
+                                        ctx: Store,
+                                    },
+                                ),
+                            ),
+                        },
+                        WithItem {
+                            range: 278..296,
+                            context_expr: Call(
+                                ExprCall {
+                                    range: 284..287,
+                                    func: Name(
+                                        ExprName {
+                                            range: 284..285,
+                                            id: Name("y"),
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    arguments: Arguments {
+                                        range: 285..287,
+                                        args: [],
+                                        keywords: [],
+                                    },
+                                },
+                            ),
+                            optional_vars: Some(
+                                Name(
+                                    ExprName {
+                                        range: 293..296,
+                                        id: Name("bar"),
+                                        ctx: Store,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    body: [
+                        Pass(
+                            StmtPass {
+                                range: 302..306,
+                            },
+                        ),
+                    ],
+                },
+            ),
+        ],
+    },
+)
+```


### PR DESCRIPTION
Summary
--

WIP currently I just added all of the valid cases from Alex's comment here https://github.com/astral-sh/ruff/pull/16106#issuecomment-2653505671

Test Plan
--
Inline tests
