### PR TITLE
[red-knot] avoid inferring types if unpacking fails

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/unpacking.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/unpacking.md
@@ -1,5 +1,9 @@
 # Unpacking
 
+If there are not enough or too many values ​​when unpacking, an error will occur and the types of
+all variables (if nested tuple unpacking fails, only the variables within the failed tuples) is
+inferred to be `Unknown`.
+
 ## Tuple
 
 ### Simple tuple
@@ -60,9 +64,6 @@ reveal_type(c)  # revealed: Literal[4]
 
 ### Uneven unpacking (1)
 
-If there are not enough or too many values ​​when unpacking, the type of all variables is inferred
-to be `Unknown`. This is a different behavior from pyright, but the same as mypy.
-
 ```py
 # error: [invalid-assignment] "Not enough values to unpack (expected 3, got 2)"
 (a, b, c) = (1, 2)
@@ -109,7 +110,7 @@ reveal_type(d)  # revealed: Literal[5]
 [a, *b, c, d] = (1, 2)
 reveal_type(a)  # revealed: Unknown
 # TODO: Should be list[Any] once support for assigning to starred expression is added
-reveal_type(b)  # revealed: @Todo(starred unpacking)
+reveal_type(b)  # revealed: Unknown
 reveal_type(c)  # revealed: Unknown
 reveal_type(d)  # revealed: Unknown
 ```
@@ -163,7 +164,7 @@ reveal_type(c)  # revealed: @Todo(starred unpacking)
 reveal_type(a)  # revealed: Unknown
 reveal_type(b)  # revealed: Unknown
 reveal_type(c)  # revealed: Unknown
-reveal_type(d)  # revealed: @Todo(starred unpacking)
+reveal_type(d)  # revealed: Unknown
 reveal_type(e)  # revealed: Unknown
 reveal_type(f)  # revealed: Unknown
 ```
@@ -247,7 +248,7 @@ reveal_type(b)  # revealed: Unknown
 (a, *b, c, d) = "ab"
 reveal_type(a)  # revealed: Unknown
 # TODO: Should be list[LiteralString] once support for assigning to starred expression is added
-reveal_type(b)  # revealed: @Todo(starred unpacking)
+reveal_type(b)  # revealed: Unknown
 reveal_type(c)  # revealed: Unknown
 reveal_type(d)  # revealed: Unknown
 ```
@@ -257,7 +258,7 @@ reveal_type(d)  # revealed: Unknown
 (a, b, *c, d) = "a"
 reveal_type(a)  # revealed: Unknown
 reveal_type(b)  # revealed: Unknown
-reveal_type(c)  # revealed: @Todo(starred unpacking)
+reveal_type(c)  # revealed: Unknown
 reveal_type(d)  # revealed: Unknown
 ```
 

--- a/crates/red_knot_python_semantic/src/types/unpacker.rs
+++ b/crates/red_knot_python_semantic/src/types/unpacker.rs
@@ -121,7 +121,7 @@ impl<'db> Unpacker<'db> {
                     if let Some(tuple_ty) = ty.into_tuple() {
                         let tuple_ty_elements = self.tuple_ty_elements(target, elts, tuple_ty);
 
-                        let invalid_unpacking = match elts.len().cmp(&tuple_ty_elements.len()) {
+                        let length_mismatch = match elts.len().cmp(&tuple_ty_elements.len()) {
                             Ordering::Less => {
                                 self.context.report_lint(
                                     &INVALID_ASSIGNMENT,
@@ -151,7 +151,7 @@ impl<'db> Unpacker<'db> {
 
                         for (index, ty) in tuple_ty_elements.iter().enumerate() {
                             if let Some(element_types) = target_types.get_mut(index) {
-                                if invalid_unpacking {
+                                if length_mismatch {
                                     element_types.push(Type::unknown());
                                 } else {
                                     element_types.push(*ty);
@@ -249,18 +249,7 @@ impl<'db> Unpacker<'db> {
                 ),
             );
 
-            let mut element_types = tuple_ty.elements(self.db()).to_vec();
-
-            // Subtract 1 to insert the starred expression type at the correct
-            // index.
-            element_types.resize(targets.len() - 1, Type::unknown());
-            for element_type in &mut element_types {
-                *element_type = Type::unknown();
-            }
-            // TODO: This should be `list[Unknown]`
-            element_types.insert(starred_index, todo_type!("starred unpacking"));
-
-            Cow::Owned(element_types)
+            Cow::Owned(vec![Type::unknown(); targets.len()])
         }
     }
 


### PR DESCRIPTION
## Summary

This PR closes #15199.

The change I just made is to set all variables to type `Unknown` if unpacking fails, but in some cases this may be excessive.
For example:

```py
a, b, c = "ab"
reveal_type(a)  # Unknown, but it would be reasonable to think of it as LiteralString
reveal_type(c)  # Unknown
```

```py
# Failed to unpack before the starred expression
(a, b, *c, d, e) = (1,)
reveal_type(a)  # Unknown
reveal_type(b)  # Unknown
...
# Failed to unpack after the starred expression
(a, b, *c, d, e) = (1, 2, 3)
reveal_type(a)  # Unknown, but should it be Literal[1]?
reveal_type(b)  # Unknown, but should it be Literal[2]?
reveal_type(c)  # Todo
reveal_type(d)  # Unknown
reveal_type(e)  # Unknown
```

I will modify it if you think it would be better to make it a different type than just `Unknown`.

## Test Plan

I have made appropriate modifications to the test cases affected by this change, and also added some more test cases.
