### PR TITLE
[red-knot] Never is callable and iterable. Arbitrary attributes can be accessed.

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/attributes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/attributes.md
@@ -1218,6 +1218,9 @@ from typing_extensions import Never
 
 def f(never: Never):
     reveal_type(never.arbitrary_attribute)  # revealed: Never
+
+    # Assigning `Never` to an attribute on `Never` is also allowed:
+    never.another_attribute = never
 ```
 
 ### Builtin types attributes

--- a/crates/red_knot_python_semantic/resources/mdtest/attributes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/attributes.md
@@ -1209,6 +1209,17 @@ class C:
 reveal_type(C().x)  # revealed: Unknown
 ```
 
+### Accessing attributes on `Never`
+
+Arbitrary attributes can be accessed on `Never` without emitting any errors:
+
+```py
+from typing_extensions import Never
+
+def f(never: Never):
+    reveal_type(never.arbitrary_attribute)  # revealed: Never
+```
+
 ### Builtin types attributes
 
 This test can probably be removed eventually, but we currently include it because we do not yet

--- a/crates/red_knot_python_semantic/resources/mdtest/call/never.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/call/never.md
@@ -1,0 +1,12 @@
+# Never is callable
+
+The type `Never` is callable with an arbitrary set of arguments. The result is always `Never`.
+
+```py
+from typing_extensions import Never
+
+def f(never: Never):
+    reveal_type(never())  # revealed: Never
+    reveal_type(never(1))  # revealed: Never
+    reveal_type(never(1, "a", never, x=None))  # revealed: Never
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/loops/for.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/loops/for.md
@@ -737,3 +737,13 @@ def _(flag: bool, flag2: bool):
     for y in Iterable2():
         reveal_type(y)  # revealed: bytes | str | int
 ```
+
+## Never is iterable
+
+```py
+from typing_extensions import Never
+
+def f(never: Never):
+    for x in never:
+        reveal_type(x)  # revealed: Never
+```


### PR DESCRIPTION
## Summary

- `Never` is callable
- `Never` is iterable
- Arbitrary attributes can be accessed on `Never`

Split out from #16416 that is going to be required.

## Test Plan

Tests for all properties above.
