### PR TITLE
[syntax-errors] PEP 701 f-strings before Python 3.12

### DIFF
--- a/crates/ruff_python_parser/resources/inline/err/pep701_f_string_py311.py
+++ b/crates/ruff_python_parser/resources/inline/err/pep701_f_string_py311.py
@@ -1,0 +1,7 @@
+# parse_options: {"target-version": "3.11"}
+f'Magic wand: { bag['wand'] }'     # nested quotes
+f"{'\n'.join(a)}"                  # escape sequence
+f'''A complex trick: {
+    bag['bag']                     # comment
+}'''
+f"{f"{f"{f"{f"{f"{1+1}"}"}"}"}"}"  # arbitrary nesting

--- a/crates/ruff_python_parser/resources/inline/ok/pep701_f_string_py312.py
+++ b/crates/ruff_python_parser/resources/inline/ok/pep701_f_string_py312.py
@@ -1,0 +1,7 @@
+# parse_options: {"target-version": "3.12"}
+f'Magic wand: { bag['wand'] }'     # nested quotes
+f"{'\n'.join(a)}"                  # escape sequence
+f'''A complex trick: {
+    bag['bag']                     # comment
+}'''
+f"{f"{f"{f"{f"{f"{1+1}"}"}"}"}"}"  # arbitrary nesting

--- a/crates/ruff_python_parser/src/error.rs
+++ b/crates/ruff_python_parser/src/error.rs
@@ -610,6 +610,34 @@ pub enum UnsupportedSyntaxErrorKind {
     TypeParameterList,
     TypeAliasStatement,
     TypeParamDefault,
+
+    /// Represents the use of a [PEP 701] f-string before Python 3.12.
+    ///
+    /// ## Examples
+    ///
+    /// As described in the PEP, each of these cases were invalid before Python 3.12:
+    ///
+    /// ```python
+    /// # nested quotes
+    /// f'Magic wand: { bag['wand'] }'
+    ///
+    /// # escape characters
+    /// f"{'\n'.join(a)}"
+    ///
+    /// # comments
+    /// f'''A complex trick: {
+    ///     bag['bag']  # recursive bags!
+    /// }'''
+    ///
+    /// # arbitrary nesting
+    /// f"{f"{f"{f"{f"{f"{1+1}"}"}"}"}"}"
+    /// ```
+    ///
+    /// These restrictions were lifted in Python 3.12, meaning that all of these examples are now
+    /// valid.
+    ///
+    /// [PEP 701]: https://peps.python.org/pep-0701/
+    Pep701FString,
 }
 
 impl Display for UnsupportedSyntaxError {
@@ -636,6 +664,9 @@ impl Display for UnsupportedSyntaxError {
             UnsupportedSyntaxErrorKind::TypeParamDefault => {
                 "Cannot set default type for a type parameter"
             }
+            // TODO(brent) pyright has special error messages for nested quotes and escape
+            // sequences but doesn't actually detect the issue with comments
+            UnsupportedSyntaxErrorKind::Pep701FString => "Cannot use PEP 701 f-strings",
         };
 
         write!(
@@ -681,6 +712,7 @@ impl UnsupportedSyntaxErrorKind {
             UnsupportedSyntaxErrorKind::TypeParameterList => Change::Added(PythonVersion::PY312),
             UnsupportedSyntaxErrorKind::TypeAliasStatement => Change::Added(PythonVersion::PY312),
             UnsupportedSyntaxErrorKind::TypeParamDefault => Change::Added(PythonVersion::PY313),
+            UnsupportedSyntaxErrorKind::Pep701FString => Change::Added(PythonVersion::PY312),
         }
     }
 

--- a/crates/ruff_python_parser/src/error.rs
+++ b/crates/ruff_python_parser/src/error.rs
@@ -446,6 +446,14 @@ pub enum StarTupleKind {
     Yield,
 }
 
+/// The type of PEP 701 f-string error for [`UnsupportedSyntaxErrorKind::Pep701FString`].
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum FStringKind {
+    Backslash,
+    Comment,
+    NestedQuote,
+}
+
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum UnsupportedSyntaxErrorKind {
     Match,
@@ -637,7 +645,7 @@ pub enum UnsupportedSyntaxErrorKind {
     /// valid.
     ///
     /// [PEP 701]: https://peps.python.org/pep-0701/
-    Pep701FString,
+    Pep701FString(FStringKind),
 }
 
 impl Display for UnsupportedSyntaxError {
@@ -664,9 +672,15 @@ impl Display for UnsupportedSyntaxError {
             UnsupportedSyntaxErrorKind::TypeParamDefault => {
                 "Cannot set default type for a type parameter"
             }
-            // TODO(brent) pyright has special error messages for nested quotes and escape
-            // sequences but doesn't actually detect the issue with comments
-            UnsupportedSyntaxErrorKind::Pep701FString => "Cannot use PEP 701 f-strings",
+            UnsupportedSyntaxErrorKind::Pep701FString(FStringKind::Backslash) => {
+                "Cannot use an escape sequence (backslash) in f-strings"
+            }
+            UnsupportedSyntaxErrorKind::Pep701FString(FStringKind::Comment) => {
+                "Cannot use comments in f-strings"
+            }
+            UnsupportedSyntaxErrorKind::Pep701FString(FStringKind::NestedQuote) => {
+                "Cannot reuse outer quote character in f-strings"
+            }
         };
 
         write!(
@@ -712,7 +726,7 @@ impl UnsupportedSyntaxErrorKind {
             UnsupportedSyntaxErrorKind::TypeParameterList => Change::Added(PythonVersion::PY312),
             UnsupportedSyntaxErrorKind::TypeAliasStatement => Change::Added(PythonVersion::PY312),
             UnsupportedSyntaxErrorKind::TypeParamDefault => Change::Added(PythonVersion::PY313),
-            UnsupportedSyntaxErrorKind::Pep701FString => Change::Added(PythonVersion::PY312),
+            UnsupportedSyntaxErrorKind::Pep701FString(_) => Change::Added(PythonVersion::PY312),
         }
     }
 

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -11,7 +11,7 @@ use ruff_python_ast::{
 };
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 
-use crate::error::StarTupleKind;
+use crate::error::{FStringKind, StarTupleKind};
 use crate::parser::progress::ParserProgress;
 use crate::parser::{helpers, FunctionKind, Parser};
 use crate::string::{parse_fstring_literal_element, parse_string_literal, StringType};
@@ -1356,7 +1356,7 @@ impl<'src> Parser<'src> {
                     continue;
                 };
                 self.add_unsupported_syntax_error(
-                    UnsupportedSyntaxErrorKind::Pep701FString,
+                    UnsupportedSyntaxErrorKind::Pep701FString(FStringKind::Backslash),
                     TextRange::at(expr.range.start() + slash_index, TextSize::from(1)),
                 )
             };
@@ -1366,7 +1366,7 @@ impl<'src> Parser<'src> {
                     continue;
                 };
                 self.add_unsupported_syntax_error(
-                    UnsupportedSyntaxErrorKind::Pep701FString,
+                    UnsupportedSyntaxErrorKind::Pep701FString(FStringKind::Comment),
                     TextRange::at(expr.range.start() + comment_index, TextSize::from(1)),
                 )
             };
@@ -1376,7 +1376,7 @@ impl<'src> Parser<'src> {
                     continue;
                 };
                 self.add_unsupported_syntax_error(
-                    UnsupportedSyntaxErrorKind::Pep701FString,
+                    UnsupportedSyntaxErrorKind::Pep701FString(FStringKind::NestedQuote),
                     TextRange::at(expr.range.start() + quote_index, TextSize::from(1)),
                 )
             };

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -1362,7 +1362,7 @@ impl<'src> Parser<'src> {
                     self.add_unsupported_syntax_error(
                         UnsupportedSyntaxErrorKind::Pep701FString(FStringKind::Backslash),
                         TextRange::at(expr.range.start() + slash_index, TextSize::from(1)),
-                    )
+                    );
                 };
 
                 if let Some(comment_index) = self.source[expr.range].find('#') {
@@ -1372,7 +1372,7 @@ impl<'src> Parser<'src> {
                     self.add_unsupported_syntax_error(
                         UnsupportedSyntaxErrorKind::Pep701FString(FStringKind::Comment),
                         TextRange::at(expr.range.start() + comment_index, TextSize::from(1)),
-                    )
+                    );
                 };
 
                 if let Some(quote_index) = self.source[expr.range].find(quote_str) {
@@ -1382,7 +1382,7 @@ impl<'src> Parser<'src> {
                     self.add_unsupported_syntax_error(
                         UnsupportedSyntaxErrorKind::Pep701FString(FStringKind::NestedQuote),
                         TextRange::at(expr.range.start() + quote_index, TextSize::from(1)),
-                    )
+                    );
                 };
             }
         }

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -1337,6 +1337,15 @@ impl<'src> Parser<'src> {
         // }'''
         // f"{f"{f"{f"{f"{f"{1+1}"}"}"}"}"}"  # arbitrary nesting
 
+        // test_err pep701_f_string_py311
+        // # parse_options: {"target-version": "3.11"}
+        // f'Magic wand: { bag['wand'] }'     # nested quotes
+        // f"{'\n'.join(a)}"                  # escape sequence
+        // f'''A complex trick: {
+        //     bag['bag']                     # comment
+        // }'''
+        // f"{f"{f"{f"{f"{f"{1+1}"}"}"}"}"}"  # arbitrary nesting
+
         self.bump(TokenKind::FStringStart);
         let elements = self.parse_fstring_elements(flags, FStringElementsKind::Regular);
 

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -1326,6 +1326,17 @@ impl<'src> Parser<'src> {
         let start = self.node_start();
         let flags = self.tokens.current_flags().as_any_string_flags();
 
+        // TODO(brent) move these to the right place
+
+        // test_ok pep701_f_string_py312
+        // # parse_options: {"target-version": "3.12"}
+        // f'Magic wand: { bag['wand'] }'     # nested quotes
+        // f"{'\n'.join(a)}"                  # escape sequence
+        // f'''A complex trick: {
+        //     bag['bag']                     # comment
+        // }'''
+        // f"{f"{f"{f"{f"{f"{1+1}"}"}"}"}"}"  # arbitrary nesting
+
         self.bump(TokenKind::FStringStart);
         let elements = self.parse_fstring_elements(flags, FStringElementsKind::Regular);
 

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@pep701_f_string_py311.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@pep701_f_string_py311.py.snap
@@ -441,7 +441,7 @@ Module(
   |
 1 | # parse_options: {"target-version": "3.11"}
 2 | f'Magic wand: { bag['wand'] }'     # nested quotes
-  |                     ^ Syntax Error: Cannot use PEP 701 f-strings on Python 3.11 (syntax was added in Python 3.12)
+  |                     ^ Syntax Error: Cannot reuse outer quote character in f-strings on Python 3.11 (syntax was added in Python 3.12)
 3 | f"{'\n'.join(a)}"                  # escape sequence
 4 | f'''A complex trick: {
   |
@@ -451,7 +451,7 @@ Module(
 1 | # parse_options: {"target-version": "3.11"}
 2 | f'Magic wand: { bag['wand'] }'     # nested quotes
 3 | f"{'\n'.join(a)}"                  # escape sequence
-  |     ^ Syntax Error: Cannot use PEP 701 f-strings on Python 3.11 (syntax was added in Python 3.12)
+  |     ^ Syntax Error: Cannot use an escape sequence (backslash) in f-strings on Python 3.11 (syntax was added in Python 3.12)
 4 | f'''A complex trick: {
 5 |     bag['bag']                     # comment
   |
@@ -461,7 +461,7 @@ Module(
 3 | f"{'\n'.join(a)}"                  # escape sequence
 4 | f'''A complex trick: {
 5 |     bag['bag']                     # comment
-  |                                    ^ Syntax Error: Cannot use PEP 701 f-strings on Python 3.11 (syntax was added in Python 3.12)
+  |                                    ^ Syntax Error: Cannot use comments in f-strings on Python 3.11 (syntax was added in Python 3.12)
 6 | }'''
 7 | f"{f"{f"{f"{f"{f"{1+1}"}"}"}"}"}"  # arbitrary nesting
   |
@@ -471,7 +471,7 @@ Module(
 5 |     bag['bag']                     # comment
 6 | }'''
 7 | f"{f"{f"{f"{f"{f"{1+1}"}"}"}"}"}"  # arbitrary nesting
-  |                 ^ Syntax Error: Cannot use PEP 701 f-strings on Python 3.11 (syntax was added in Python 3.12)
+  |                 ^ Syntax Error: Cannot reuse outer quote character in f-strings on Python 3.11 (syntax was added in Python 3.12)
   |
 
 
@@ -479,7 +479,7 @@ Module(
 5 |     bag['bag']                     # comment
 6 | }'''
 7 | f"{f"{f"{f"{f"{f"{1+1}"}"}"}"}"}"  # arbitrary nesting
-  |              ^ Syntax Error: Cannot use PEP 701 f-strings on Python 3.11 (syntax was added in Python 3.12)
+  |              ^ Syntax Error: Cannot reuse outer quote character in f-strings on Python 3.11 (syntax was added in Python 3.12)
   |
 
 
@@ -487,7 +487,7 @@ Module(
 5 |     bag['bag']                     # comment
 6 | }'''
 7 | f"{f"{f"{f"{f"{f"{1+1}"}"}"}"}"}"  # arbitrary nesting
-  |           ^ Syntax Error: Cannot use PEP 701 f-strings on Python 3.11 (syntax was added in Python 3.12)
+  |           ^ Syntax Error: Cannot reuse outer quote character in f-strings on Python 3.11 (syntax was added in Python 3.12)
   |
 
 
@@ -495,7 +495,7 @@ Module(
 5 |     bag['bag']                     # comment
 6 | }'''
 7 | f"{f"{f"{f"{f"{f"{1+1}"}"}"}"}"}"  # arbitrary nesting
-  |        ^ Syntax Error: Cannot use PEP 701 f-strings on Python 3.11 (syntax was added in Python 3.12)
+  |        ^ Syntax Error: Cannot reuse outer quote character in f-strings on Python 3.11 (syntax was added in Python 3.12)
   |
 
 
@@ -503,5 +503,5 @@ Module(
 5 |     bag['bag']                     # comment
 6 | }'''
 7 | f"{f"{f"{f"{f"{f"{1+1}"}"}"}"}"}"  # arbitrary nesting
-  |     ^ Syntax Error: Cannot use PEP 701 f-strings on Python 3.11 (syntax was added in Python 3.12)
+  |     ^ Syntax Error: Cannot reuse outer quote character in f-strings on Python 3.11 (syntax was added in Python 3.12)
   |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@pep701_f_string_py311.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@pep701_f_string_py311.py.snap
@@ -1,0 +1,507 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/inline/err/pep701_f_string_py311.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..276,
+        body: [
+            Expr(
+                StmtExpr {
+                    range: 44..74,
+                    value: FString(
+                        ExprFString {
+                            range: 44..74,
+                            value: FStringValue {
+                                inner: Single(
+                                    FString(
+                                        FString {
+                                            range: 44..74,
+                                            elements: [
+                                                Literal(
+                                                    FStringLiteralElement {
+                                                        range: 46..58,
+                                                        value: "Magic wand: ",
+                                                    },
+                                                ),
+                                                Expression(
+                                                    FStringExpressionElement {
+                                                        range: 58..73,
+                                                        expression: Subscript(
+                                                            ExprSubscript {
+                                                                range: 60..71,
+                                                                value: Name(
+                                                                    ExprName {
+                                                                        range: 60..63,
+                                                                        id: Name("bag"),
+                                                                        ctx: Load,
+                                                                    },
+                                                                ),
+                                                                slice: StringLiteral(
+                                                                    ExprStringLiteral {
+                                                                        range: 64..70,
+                                                                        value: StringLiteralValue {
+                                                                            inner: Single(
+                                                                                StringLiteral {
+                                                                                    range: 64..70,
+                                                                                    value: "wand",
+                                                                                    flags: StringLiteralFlags {
+                                                                                        quote_style: Single,
+                                                                                        prefix: Empty,
+                                                                                        triple_quoted: false,
+                                                                                    },
+                                                                                },
+                                                                            ),
+                                                                        },
+                                                                    },
+                                                                ),
+                                                                ctx: Load,
+                                                            },
+                                                        ),
+                                                        debug_text: None,
+                                                        conversion: None,
+                                                        format_spec: None,
+                                                    },
+                                                ),
+                                            ],
+                                            flags: FStringFlags {
+                                                quote_style: Single,
+                                                prefix: Regular,
+                                                triple_quoted: false,
+                                            },
+                                        },
+                                    ),
+                                ),
+                            },
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 95..112,
+                    value: FString(
+                        ExprFString {
+                            range: 95..112,
+                            value: FStringValue {
+                                inner: Single(
+                                    FString(
+                                        FString {
+                                            range: 95..112,
+                                            elements: [
+                                                Expression(
+                                                    FStringExpressionElement {
+                                                        range: 97..111,
+                                                        expression: Call(
+                                                            ExprCall {
+                                                                range: 98..110,
+                                                                func: Attribute(
+                                                                    ExprAttribute {
+                                                                        range: 98..107,
+                                                                        value: StringLiteral(
+                                                                            ExprStringLiteral {
+                                                                                range: 98..102,
+                                                                                value: StringLiteralValue {
+                                                                                    inner: Single(
+                                                                                        StringLiteral {
+                                                                                            range: 98..102,
+                                                                                            value: "\n",
+                                                                                            flags: StringLiteralFlags {
+                                                                                                quote_style: Single,
+                                                                                                prefix: Empty,
+                                                                                                triple_quoted: false,
+                                                                                            },
+                                                                                        },
+                                                                                    ),
+                                                                                },
+                                                                            },
+                                                                        ),
+                                                                        attr: Identifier {
+                                                                            id: Name("join"),
+                                                                            range: 103..107,
+                                                                        },
+                                                                        ctx: Load,
+                                                                    },
+                                                                ),
+                                                                arguments: Arguments {
+                                                                    range: 107..110,
+                                                                    args: [
+                                                                        Name(
+                                                                            ExprName {
+                                                                                range: 108..109,
+                                                                                id: Name("a"),
+                                                                                ctx: Load,
+                                                                            },
+                                                                        ),
+                                                                    ],
+                                                                    keywords: [],
+                                                                },
+                                                            },
+                                                        ),
+                                                        debug_text: None,
+                                                        conversion: None,
+                                                        format_spec: None,
+                                                    },
+                                                ),
+                                            ],
+                                            flags: FStringFlags {
+                                                quote_style: Double,
+                                                prefix: Regular,
+                                                triple_quoted: false,
+                                            },
+                                        },
+                                    ),
+                                ),
+                            },
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 148..220,
+                    value: FString(
+                        ExprFString {
+                            range: 148..220,
+                            value: FStringValue {
+                                inner: Single(
+                                    FString(
+                                        FString {
+                                            range: 148..220,
+                                            elements: [
+                                                Literal(
+                                                    FStringLiteralElement {
+                                                        range: 152..169,
+                                                        value: "A complex trick: ",
+                                                    },
+                                                ),
+                                                Expression(
+                                                    FStringExpressionElement {
+                                                        range: 169..217,
+                                                        expression: Subscript(
+                                                            ExprSubscript {
+                                                                range: 175..185,
+                                                                value: Name(
+                                                                    ExprName {
+                                                                        range: 175..178,
+                                                                        id: Name("bag"),
+                                                                        ctx: Load,
+                                                                    },
+                                                                ),
+                                                                slice: StringLiteral(
+                                                                    ExprStringLiteral {
+                                                                        range: 179..184,
+                                                                        value: StringLiteralValue {
+                                                                            inner: Single(
+                                                                                StringLiteral {
+                                                                                    range: 179..184,
+                                                                                    value: "bag",
+                                                                                    flags: StringLiteralFlags {
+                                                                                        quote_style: Single,
+                                                                                        prefix: Empty,
+                                                                                        triple_quoted: false,
+                                                                                    },
+                                                                                },
+                                                                            ),
+                                                                        },
+                                                                    },
+                                                                ),
+                                                                ctx: Load,
+                                                            },
+                                                        ),
+                                                        debug_text: None,
+                                                        conversion: None,
+                                                        format_spec: None,
+                                                    },
+                                                ),
+                                            ],
+                                            flags: FStringFlags {
+                                                quote_style: Single,
+                                                prefix: Regular,
+                                                triple_quoted: true,
+                                            },
+                                        },
+                                    ),
+                                ),
+                            },
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 221..254,
+                    value: FString(
+                        ExprFString {
+                            range: 221..254,
+                            value: FStringValue {
+                                inner: Single(
+                                    FString(
+                                        FString {
+                                            range: 221..254,
+                                            elements: [
+                                                Expression(
+                                                    FStringExpressionElement {
+                                                        range: 223..253,
+                                                        expression: FString(
+                                                            ExprFString {
+                                                                range: 224..252,
+                                                                value: FStringValue {
+                                                                    inner: Single(
+                                                                        FString(
+                                                                            FString {
+                                                                                range: 224..252,
+                                                                                elements: [
+                                                                                    Expression(
+                                                                                        FStringExpressionElement {
+                                                                                            range: 226..251,
+                                                                                            expression: FString(
+                                                                                                ExprFString {
+                                                                                                    range: 227..250,
+                                                                                                    value: FStringValue {
+                                                                                                        inner: Single(
+                                                                                                            FString(
+                                                                                                                FString {
+                                                                                                                    range: 227..250,
+                                                                                                                    elements: [
+                                                                                                                        Expression(
+                                                                                                                            FStringExpressionElement {
+                                                                                                                                range: 229..249,
+                                                                                                                                expression: FString(
+                                                                                                                                    ExprFString {
+                                                                                                                                        range: 230..248,
+                                                                                                                                        value: FStringValue {
+                                                                                                                                            inner: Single(
+                                                                                                                                                FString(
+                                                                                                                                                    FString {
+                                                                                                                                                        range: 230..248,
+                                                                                                                                                        elements: [
+                                                                                                                                                            Expression(
+                                                                                                                                                                FStringExpressionElement {
+                                                                                                                                                                    range: 232..247,
+                                                                                                                                                                    expression: FString(
+                                                                                                                                                                        ExprFString {
+                                                                                                                                                                            range: 233..246,
+                                                                                                                                                                            value: FStringValue {
+                                                                                                                                                                                inner: Single(
+                                                                                                                                                                                    FString(
+                                                                                                                                                                                        FString {
+                                                                                                                                                                                            range: 233..246,
+                                                                                                                                                                                            elements: [
+                                                                                                                                                                                                Expression(
+                                                                                                                                                                                                    FStringExpressionElement {
+                                                                                                                                                                                                        range: 235..245,
+                                                                                                                                                                                                        expression: FString(
+                                                                                                                                                                                                            ExprFString {
+                                                                                                                                                                                                                range: 236..244,
+                                                                                                                                                                                                                value: FStringValue {
+                                                                                                                                                                                                                    inner: Single(
+                                                                                                                                                                                                                        FString(
+                                                                                                                                                                                                                            FString {
+                                                                                                                                                                                                                                range: 236..244,
+                                                                                                                                                                                                                                elements: [
+                                                                                                                                                                                                                                    Expression(
+                                                                                                                                                                                                                                        FStringExpressionElement {
+                                                                                                                                                                                                                                            range: 238..243,
+                                                                                                                                                                                                                                            expression: BinOp(
+                                                                                                                                                                                                                                                ExprBinOp {
+                                                                                                                                                                                                                                                    range: 239..242,
+                                                                                                                                                                                                                                                    left: NumberLiteral(
+                                                                                                                                                                                                                                                        ExprNumberLiteral {
+                                                                                                                                                                                                                                                            range: 239..240,
+                                                                                                                                                                                                                                                            value: Int(
+                                                                                                                                                                                                                                                                1,
+                                                                                                                                                                                                                                                            ),
+                                                                                                                                                                                                                                                        },
+                                                                                                                                                                                                                                                    ),
+                                                                                                                                                                                                                                                    op: Add,
+                                                                                                                                                                                                                                                    right: NumberLiteral(
+                                                                                                                                                                                                                                                        ExprNumberLiteral {
+                                                                                                                                                                                                                                                            range: 241..242,
+                                                                                                                                                                                                                                                            value: Int(
+                                                                                                                                                                                                                                                                1,
+                                                                                                                                                                                                                                                            ),
+                                                                                                                                                                                                                                                        },
+                                                                                                                                                                                                                                                    ),
+                                                                                                                                                                                                                                                },
+                                                                                                                                                                                                                                            ),
+                                                                                                                                                                                                                                            debug_text: None,
+                                                                                                                                                                                                                                            conversion: None,
+                                                                                                                                                                                                                                            format_spec: None,
+                                                                                                                                                                                                                                        },
+                                                                                                                                                                                                                                    ),
+                                                                                                                                                                                                                                ],
+                                                                                                                                                                                                                                flags: FStringFlags {
+                                                                                                                                                                                                                                    quote_style: Double,
+                                                                                                                                                                                                                                    prefix: Regular,
+                                                                                                                                                                                                                                    triple_quoted: false,
+                                                                                                                                                                                                                                },
+                                                                                                                                                                                                                            },
+                                                                                                                                                                                                                        ),
+                                                                                                                                                                                                                    ),
+                                                                                                                                                                                                                },
+                                                                                                                                                                                                            },
+                                                                                                                                                                                                        ),
+                                                                                                                                                                                                        debug_text: None,
+                                                                                                                                                                                                        conversion: None,
+                                                                                                                                                                                                        format_spec: None,
+                                                                                                                                                                                                    },
+                                                                                                                                                                                                ),
+                                                                                                                                                                                            ],
+                                                                                                                                                                                            flags: FStringFlags {
+                                                                                                                                                                                                quote_style: Double,
+                                                                                                                                                                                                prefix: Regular,
+                                                                                                                                                                                                triple_quoted: false,
+                                                                                                                                                                                            },
+                                                                                                                                                                                        },
+                                                                                                                                                                                    ),
+                                                                                                                                                                                ),
+                                                                                                                                                                            },
+                                                                                                                                                                        },
+                                                                                                                                                                    ),
+                                                                                                                                                                    debug_text: None,
+                                                                                                                                                                    conversion: None,
+                                                                                                                                                                    format_spec: None,
+                                                                                                                                                                },
+                                                                                                                                                            ),
+                                                                                                                                                        ],
+                                                                                                                                                        flags: FStringFlags {
+                                                                                                                                                            quote_style: Double,
+                                                                                                                                                            prefix: Regular,
+                                                                                                                                                            triple_quoted: false,
+                                                                                                                                                        },
+                                                                                                                                                    },
+                                                                                                                                                ),
+                                                                                                                                            ),
+                                                                                                                                        },
+                                                                                                                                    },
+                                                                                                                                ),
+                                                                                                                                debug_text: None,
+                                                                                                                                conversion: None,
+                                                                                                                                format_spec: None,
+                                                                                                                            },
+                                                                                                                        ),
+                                                                                                                    ],
+                                                                                                                    flags: FStringFlags {
+                                                                                                                        quote_style: Double,
+                                                                                                                        prefix: Regular,
+                                                                                                                        triple_quoted: false,
+                                                                                                                    },
+                                                                                                                },
+                                                                                                            ),
+                                                                                                        ),
+                                                                                                    },
+                                                                                                },
+                                                                                            ),
+                                                                                            debug_text: None,
+                                                                                            conversion: None,
+                                                                                            format_spec: None,
+                                                                                        },
+                                                                                    ),
+                                                                                ],
+                                                                                flags: FStringFlags {
+                                                                                    quote_style: Double,
+                                                                                    prefix: Regular,
+                                                                                    triple_quoted: false,
+                                                                                },
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            },
+                                                        ),
+                                                        debug_text: None,
+                                                        conversion: None,
+                                                        format_spec: None,
+                                                    },
+                                                ),
+                                            ],
+                                            flags: FStringFlags {
+                                                quote_style: Double,
+                                                prefix: Regular,
+                                                triple_quoted: false,
+                                            },
+                                        },
+                                    ),
+                                ),
+                            },
+                        },
+                    ),
+                },
+            ),
+        ],
+    },
+)
+```
+## Unsupported Syntax Errors
+
+  |
+1 | # parse_options: {"target-version": "3.11"}
+2 | f'Magic wand: { bag['wand'] }'     # nested quotes
+  |                     ^ Syntax Error: Cannot use PEP 701 f-strings on Python 3.11 (syntax was added in Python 3.12)
+3 | f"{'\n'.join(a)}"                  # escape sequence
+4 | f'''A complex trick: {
+  |
+
+
+  |
+1 | # parse_options: {"target-version": "3.11"}
+2 | f'Magic wand: { bag['wand'] }'     # nested quotes
+3 | f"{'\n'.join(a)}"                  # escape sequence
+  |     ^ Syntax Error: Cannot use PEP 701 f-strings on Python 3.11 (syntax was added in Python 3.12)
+4 | f'''A complex trick: {
+5 |     bag['bag']                     # comment
+  |
+
+
+  |
+3 | f"{'\n'.join(a)}"                  # escape sequence
+4 | f'''A complex trick: {
+5 |     bag['bag']                     # comment
+  |                                    ^ Syntax Error: Cannot use PEP 701 f-strings on Python 3.11 (syntax was added in Python 3.12)
+6 | }'''
+7 | f"{f"{f"{f"{f"{f"{1+1}"}"}"}"}"}"  # arbitrary nesting
+  |
+
+
+  |
+5 |     bag['bag']                     # comment
+6 | }'''
+7 | f"{f"{f"{f"{f"{f"{1+1}"}"}"}"}"}"  # arbitrary nesting
+  |                 ^ Syntax Error: Cannot use PEP 701 f-strings on Python 3.11 (syntax was added in Python 3.12)
+  |
+
+
+  |
+5 |     bag['bag']                     # comment
+6 | }'''
+7 | f"{f"{f"{f"{f"{f"{1+1}"}"}"}"}"}"  # arbitrary nesting
+  |              ^ Syntax Error: Cannot use PEP 701 f-strings on Python 3.11 (syntax was added in Python 3.12)
+  |
+
+
+  |
+5 |     bag['bag']                     # comment
+6 | }'''
+7 | f"{f"{f"{f"{f"{f"{1+1}"}"}"}"}"}"  # arbitrary nesting
+  |           ^ Syntax Error: Cannot use PEP 701 f-strings on Python 3.11 (syntax was added in Python 3.12)
+  |
+
+
+  |
+5 |     bag['bag']                     # comment
+6 | }'''
+7 | f"{f"{f"{f"{f"{f"{1+1}"}"}"}"}"}"  # arbitrary nesting
+  |        ^ Syntax Error: Cannot use PEP 701 f-strings on Python 3.11 (syntax was added in Python 3.12)
+  |
+
+
+  |
+5 |     bag['bag']                     # comment
+6 | }'''
+7 | f"{f"{f"{f"{f"{f"{1+1}"}"}"}"}"}"  # arbitrary nesting
+  |     ^ Syntax Error: Cannot use PEP 701 f-strings on Python 3.11 (syntax was added in Python 3.12)
+  |

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@pep701_f_string_py312.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@pep701_f_string_py312.py.snap
@@ -1,0 +1,438 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/inline/ok/pep701_f_string_py312.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..276,
+        body: [
+            Expr(
+                StmtExpr {
+                    range: 44..74,
+                    value: FString(
+                        ExprFString {
+                            range: 44..74,
+                            value: FStringValue {
+                                inner: Single(
+                                    FString(
+                                        FString {
+                                            range: 44..74,
+                                            elements: [
+                                                Literal(
+                                                    FStringLiteralElement {
+                                                        range: 46..58,
+                                                        value: "Magic wand: ",
+                                                    },
+                                                ),
+                                                Expression(
+                                                    FStringExpressionElement {
+                                                        range: 58..73,
+                                                        expression: Subscript(
+                                                            ExprSubscript {
+                                                                range: 60..71,
+                                                                value: Name(
+                                                                    ExprName {
+                                                                        range: 60..63,
+                                                                        id: Name("bag"),
+                                                                        ctx: Load,
+                                                                    },
+                                                                ),
+                                                                slice: StringLiteral(
+                                                                    ExprStringLiteral {
+                                                                        range: 64..70,
+                                                                        value: StringLiteralValue {
+                                                                            inner: Single(
+                                                                                StringLiteral {
+                                                                                    range: 64..70,
+                                                                                    value: "wand",
+                                                                                    flags: StringLiteralFlags {
+                                                                                        quote_style: Single,
+                                                                                        prefix: Empty,
+                                                                                        triple_quoted: false,
+                                                                                    },
+                                                                                },
+                                                                            ),
+                                                                        },
+                                                                    },
+                                                                ),
+                                                                ctx: Load,
+                                                            },
+                                                        ),
+                                                        debug_text: None,
+                                                        conversion: None,
+                                                        format_spec: None,
+                                                    },
+                                                ),
+                                            ],
+                                            flags: FStringFlags {
+                                                quote_style: Single,
+                                                prefix: Regular,
+                                                triple_quoted: false,
+                                            },
+                                        },
+                                    ),
+                                ),
+                            },
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 95..112,
+                    value: FString(
+                        ExprFString {
+                            range: 95..112,
+                            value: FStringValue {
+                                inner: Single(
+                                    FString(
+                                        FString {
+                                            range: 95..112,
+                                            elements: [
+                                                Expression(
+                                                    FStringExpressionElement {
+                                                        range: 97..111,
+                                                        expression: Call(
+                                                            ExprCall {
+                                                                range: 98..110,
+                                                                func: Attribute(
+                                                                    ExprAttribute {
+                                                                        range: 98..107,
+                                                                        value: StringLiteral(
+                                                                            ExprStringLiteral {
+                                                                                range: 98..102,
+                                                                                value: StringLiteralValue {
+                                                                                    inner: Single(
+                                                                                        StringLiteral {
+                                                                                            range: 98..102,
+                                                                                            value: "\n",
+                                                                                            flags: StringLiteralFlags {
+                                                                                                quote_style: Single,
+                                                                                                prefix: Empty,
+                                                                                                triple_quoted: false,
+                                                                                            },
+                                                                                        },
+                                                                                    ),
+                                                                                },
+                                                                            },
+                                                                        ),
+                                                                        attr: Identifier {
+                                                                            id: Name("join"),
+                                                                            range: 103..107,
+                                                                        },
+                                                                        ctx: Load,
+                                                                    },
+                                                                ),
+                                                                arguments: Arguments {
+                                                                    range: 107..110,
+                                                                    args: [
+                                                                        Name(
+                                                                            ExprName {
+                                                                                range: 108..109,
+                                                                                id: Name("a"),
+                                                                                ctx: Load,
+                                                                            },
+                                                                        ),
+                                                                    ],
+                                                                    keywords: [],
+                                                                },
+                                                            },
+                                                        ),
+                                                        debug_text: None,
+                                                        conversion: None,
+                                                        format_spec: None,
+                                                    },
+                                                ),
+                                            ],
+                                            flags: FStringFlags {
+                                                quote_style: Double,
+                                                prefix: Regular,
+                                                triple_quoted: false,
+                                            },
+                                        },
+                                    ),
+                                ),
+                            },
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 148..220,
+                    value: FString(
+                        ExprFString {
+                            range: 148..220,
+                            value: FStringValue {
+                                inner: Single(
+                                    FString(
+                                        FString {
+                                            range: 148..220,
+                                            elements: [
+                                                Literal(
+                                                    FStringLiteralElement {
+                                                        range: 152..169,
+                                                        value: "A complex trick: ",
+                                                    },
+                                                ),
+                                                Expression(
+                                                    FStringExpressionElement {
+                                                        range: 169..217,
+                                                        expression: Subscript(
+                                                            ExprSubscript {
+                                                                range: 175..185,
+                                                                value: Name(
+                                                                    ExprName {
+                                                                        range: 175..178,
+                                                                        id: Name("bag"),
+                                                                        ctx: Load,
+                                                                    },
+                                                                ),
+                                                                slice: StringLiteral(
+                                                                    ExprStringLiteral {
+                                                                        range: 179..184,
+                                                                        value: StringLiteralValue {
+                                                                            inner: Single(
+                                                                                StringLiteral {
+                                                                                    range: 179..184,
+                                                                                    value: "bag",
+                                                                                    flags: StringLiteralFlags {
+                                                                                        quote_style: Single,
+                                                                                        prefix: Empty,
+                                                                                        triple_quoted: false,
+                                                                                    },
+                                                                                },
+                                                                            ),
+                                                                        },
+                                                                    },
+                                                                ),
+                                                                ctx: Load,
+                                                            },
+                                                        ),
+                                                        debug_text: None,
+                                                        conversion: None,
+                                                        format_spec: None,
+                                                    },
+                                                ),
+                                            ],
+                                            flags: FStringFlags {
+                                                quote_style: Single,
+                                                prefix: Regular,
+                                                triple_quoted: true,
+                                            },
+                                        },
+                                    ),
+                                ),
+                            },
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 221..254,
+                    value: FString(
+                        ExprFString {
+                            range: 221..254,
+                            value: FStringValue {
+                                inner: Single(
+                                    FString(
+                                        FString {
+                                            range: 221..254,
+                                            elements: [
+                                                Expression(
+                                                    FStringExpressionElement {
+                                                        range: 223..253,
+                                                        expression: FString(
+                                                            ExprFString {
+                                                                range: 224..252,
+                                                                value: FStringValue {
+                                                                    inner: Single(
+                                                                        FString(
+                                                                            FString {
+                                                                                range: 224..252,
+                                                                                elements: [
+                                                                                    Expression(
+                                                                                        FStringExpressionElement {
+                                                                                            range: 226..251,
+                                                                                            expression: FString(
+                                                                                                ExprFString {
+                                                                                                    range: 227..250,
+                                                                                                    value: FStringValue {
+                                                                                                        inner: Single(
+                                                                                                            FString(
+                                                                                                                FString {
+                                                                                                                    range: 227..250,
+                                                                                                                    elements: [
+                                                                                                                        Expression(
+                                                                                                                            FStringExpressionElement {
+                                                                                                                                range: 229..249,
+                                                                                                                                expression: FString(
+                                                                                                                                    ExprFString {
+                                                                                                                                        range: 230..248,
+                                                                                                                                        value: FStringValue {
+                                                                                                                                            inner: Single(
+                                                                                                                                                FString(
+                                                                                                                                                    FString {
+                                                                                                                                                        range: 230..248,
+                                                                                                                                                        elements: [
+                                                                                                                                                            Expression(
+                                                                                                                                                                FStringExpressionElement {
+                                                                                                                                                                    range: 232..247,
+                                                                                                                                                                    expression: FString(
+                                                                                                                                                                        ExprFString {
+                                                                                                                                                                            range: 233..246,
+                                                                                                                                                                            value: FStringValue {
+                                                                                                                                                                                inner: Single(
+                                                                                                                                                                                    FString(
+                                                                                                                                                                                        FString {
+                                                                                                                                                                                            range: 233..246,
+                                                                                                                                                                                            elements: [
+                                                                                                                                                                                                Expression(
+                                                                                                                                                                                                    FStringExpressionElement {
+                                                                                                                                                                                                        range: 235..245,
+                                                                                                                                                                                                        expression: FString(
+                                                                                                                                                                                                            ExprFString {
+                                                                                                                                                                                                                range: 236..244,
+                                                                                                                                                                                                                value: FStringValue {
+                                                                                                                                                                                                                    inner: Single(
+                                                                                                                                                                                                                        FString(
+                                                                                                                                                                                                                            FString {
+                                                                                                                                                                                                                                range: 236..244,
+                                                                                                                                                                                                                                elements: [
+                                                                                                                                                                                                                                    Expression(
+                                                                                                                                                                                                                                        FStringExpressionElement {
+                                                                                                                                                                                                                                            range: 238..243,
+                                                                                                                                                                                                                                            expression: BinOp(
+                                                                                                                                                                                                                                                ExprBinOp {
+                                                                                                                                                                                                                                                    range: 239..242,
+                                                                                                                                                                                                                                                    left: NumberLiteral(
+                                                                                                                                                                                                                                                        ExprNumberLiteral {
+                                                                                                                                                                                                                                                            range: 239..240,
+                                                                                                                                                                                                                                                            value: Int(
+                                                                                                                                                                                                                                                                1,
+                                                                                                                                                                                                                                                            ),
+                                                                                                                                                                                                                                                        },
+                                                                                                                                                                                                                                                    ),
+                                                                                                                                                                                                                                                    op: Add,
+                                                                                                                                                                                                                                                    right: NumberLiteral(
+                                                                                                                                                                                                                                                        ExprNumberLiteral {
+                                                                                                                                                                                                                                                            range: 241..242,
+                                                                                                                                                                                                                                                            value: Int(
+                                                                                                                                                                                                                                                                1,
+                                                                                                                                                                                                                                                            ),
+                                                                                                                                                                                                                                                        },
+                                                                                                                                                                                                                                                    ),
+                                                                                                                                                                                                                                                },
+                                                                                                                                                                                                                                            ),
+                                                                                                                                                                                                                                            debug_text: None,
+                                                                                                                                                                                                                                            conversion: None,
+                                                                                                                                                                                                                                            format_spec: None,
+                                                                                                                                                                                                                                        },
+                                                                                                                                                                                                                                    ),
+                                                                                                                                                                                                                                ],
+                                                                                                                                                                                                                                flags: FStringFlags {
+                                                                                                                                                                                                                                    quote_style: Double,
+                                                                                                                                                                                                                                    prefix: Regular,
+                                                                                                                                                                                                                                    triple_quoted: false,
+                                                                                                                                                                                                                                },
+                                                                                                                                                                                                                            },
+                                                                                                                                                                                                                        ),
+                                                                                                                                                                                                                    ),
+                                                                                                                                                                                                                },
+                                                                                                                                                                                                            },
+                                                                                                                                                                                                        ),
+                                                                                                                                                                                                        debug_text: None,
+                                                                                                                                                                                                        conversion: None,
+                                                                                                                                                                                                        format_spec: None,
+                                                                                                                                                                                                    },
+                                                                                                                                                                                                ),
+                                                                                                                                                                                            ],
+                                                                                                                                                                                            flags: FStringFlags {
+                                                                                                                                                                                                quote_style: Double,
+                                                                                                                                                                                                prefix: Regular,
+                                                                                                                                                                                                triple_quoted: false,
+                                                                                                                                                                                            },
+                                                                                                                                                                                        },
+                                                                                                                                                                                    ),
+                                                                                                                                                                                ),
+                                                                                                                                                                            },
+                                                                                                                                                                        },
+                                                                                                                                                                    ),
+                                                                                                                                                                    debug_text: None,
+                                                                                                                                                                    conversion: None,
+                                                                                                                                                                    format_spec: None,
+                                                                                                                                                                },
+                                                                                                                                                            ),
+                                                                                                                                                        ],
+                                                                                                                                                        flags: FStringFlags {
+                                                                                                                                                            quote_style: Double,
+                                                                                                                                                            prefix: Regular,
+                                                                                                                                                            triple_quoted: false,
+                                                                                                                                                        },
+                                                                                                                                                    },
+                                                                                                                                                ),
+                                                                                                                                            ),
+                                                                                                                                        },
+                                                                                                                                    },
+                                                                                                                                ),
+                                                                                                                                debug_text: None,
+                                                                                                                                conversion: None,
+                                                                                                                                format_spec: None,
+                                                                                                                            },
+                                                                                                                        ),
+                                                                                                                    ],
+                                                                                                                    flags: FStringFlags {
+                                                                                                                        quote_style: Double,
+                                                                                                                        prefix: Regular,
+                                                                                                                        triple_quoted: false,
+                                                                                                                    },
+                                                                                                                },
+                                                                                                            ),
+                                                                                                        ),
+                                                                                                    },
+                                                                                                },
+                                                                                            ),
+                                                                                            debug_text: None,
+                                                                                            conversion: None,
+                                                                                            format_spec: None,
+                                                                                        },
+                                                                                    ),
+                                                                                ],
+                                                                                flags: FStringFlags {
+                                                                                    quote_style: Double,
+                                                                                    prefix: Regular,
+                                                                                    triple_quoted: false,
+                                                                                },
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            },
+                                                        ),
+                                                        debug_text: None,
+                                                        conversion: None,
+                                                        format_spec: None,
+                                                    },
+                                                ),
+                                            ],
+                                            flags: FStringFlags {
+                                                quote_style: Double,
+                                                prefix: Regular,
+                                                triple_quoted: false,
+                                            },
+                                        },
+                                    ),
+                                ),
+                            },
+                        },
+                    ),
+                },
+            ),
+        ],
+    },
+)
+```


### PR DESCRIPTION
## Summary

This PR detects the use of PEP 701 f-strings before 3.12. This one sounded difficult and ended up being pretty easy, so I think there's a good chance I've over-simplified things. However, from experimenting in the Python REPL and checking with [pyright], I think this is correct. pyright actually doesn't even flag the comment case, but Python does.

I also checked pyright's implementation for [quotes](https://github.com/microsoft/pyright/blob/98dc4469cc5126bcdcbaf396a6c9d7e75dc1c4a0/packages/pyright-internal/src/analyzer/checker.ts#L1379-L1398) and [escapes](https://github.com/microsoft/pyright/blob/98dc4469cc5126bcdcbaf396a6c9d7e75dc1c4a0/packages/pyright-internal/src/analyzer/checker.ts#L1365-L1377) and think I've approximated how they do it.

Python's error messages also point to the simple approach of these characters simply not being allowed:

```pycon
Python 3.11.11 (main, Feb 12 2025, 14:51:05) [Clang 19.1.6 ] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> f'''multiline {
... expression # comment
... }'''
  File "<stdin>", line 3
    }'''
        ^
SyntaxError: f-string expression part cannot include '#'
>>> f'''{not a line \
... continuation}'''
  File "<stdin>", line 2
    continuation}'''
                    ^
SyntaxError: f-string expression part cannot include a backslash
>>> f'hello {'world'}'
  File "<stdin>", line 1
    f'hello {'world'}'
              ^^^^^
SyntaxError: f-string: expecting '}'
```

And since escapes aren't allowed, I don't think there are any tricky cases where nested quotes or comments can sneak in.

It's also slightly annoying that the error is repeated for every nested quote character, but that also mirrors pyright, although they highlight the whole nested string, which is a little nicer. However, their check is in the analysis phase, so I don't think we have such easy access to the quoted range, at least without adding another mini visitor.

## Test Plan

New inline tests

[pyright]: https://pyright-play.net/?pythonVersion=3.11&strict=true&code=EYQw5gBAvBAmCWBjALgCgO4gHaygRgEoAoEaCAIgBpyiiBiCLAUwGdknYIBHAVwHt2LIgDMA5AFlwSCJhwAuCAG8IoMAG1Rs2KIC6EAL6iIxosbPmLlq5foRWiEAAcmERAAsQAJxAomnltY2wuSKogA6WKIAdABWfPBYqCAE%2BuSBVqbpWVm2iHwAtvlMWMgB2ekiolUAgq4FjgA2TAAeEMieSADWCsoV5qoaqrrGDJ5MiDz%2B8ABuLqosAIREhlXlaybrmyYMXsDw7V4AnoysyAmQ5SIhwYo3d9cheADUeKlv5O%2BpQA