### PR TITLE
Assert that formatted code doesn't introduce any new unsupported syntax errors

### DIFF
--- a/crates/ruff_python_parser/src/error.rs
+++ b/crates/ruff_python_parser/src/error.rs
@@ -1,7 +1,7 @@
 use std::fmt::{self, Display};
 
 use ruff_python_ast::PythonVersion;
-use ruff_text_size::TextRange;
+use ruff_text_size::{Ranged, TextRange};
 
 use crate::TokenKind;
 
@@ -439,14 +439,20 @@ pub struct UnsupportedSyntaxError {
     pub target_version: PythonVersion,
 }
 
+impl Ranged for UnsupportedSyntaxError {
+    fn range(&self) -> TextRange {
+        self.range
+    }
+}
+
 /// The type of tuple unpacking for [`UnsupportedSyntaxErrorKind::StarTuple`].
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum StarTupleKind {
     Return,
     Yield,
 }
 
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum UnsupportedSyntaxErrorKind {
     Match,
     Walrus,


### PR DESCRIPTION
## Summary

This should give us better coverage for the unsupported syntax error features and 
increases our confidence that the formatter doesn't accidentially introduce new unsupported
syntax errors. 

A feature like this would have been very useful when working on f-string formatting
where it took a lot of iteration to find all Python 3.11 or older incompatibilities.

## Test Plan

I applied my changes on top of https://github.com/astral-sh/ruff/pull/16523 and
removed the target version check in the with-statement formatting code. As expected, 
the integration tests now failed
