### PR TITLE
[`refurb`] Fix starred expressions fix (`FURB161`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/refurb/FURB161.py
+++ b/crates/ruff_linter/resources/test/fixtures/refurb/FURB161.py
@@ -12,7 +12,6 @@ count = bin(0x10 + 0x1000).count("1")  # FURB161
 count = bin(ten()).count("1")  # FURB161
 count = bin((10)).count("1")  # FURB161
 count = bin("10" "15").count("1")  # FURB161
-count = bin(*[123]).count("1")  # FURB161
 
 count = x.bit_count()  # OK
 count = (10).bit_count()  # OK
@@ -21,3 +20,5 @@ count = 0xA.bit_count()  # OK
 count = 0o12.bit_count()  # OK
 count = (0x10 + 0x1000).bit_count()  # OK
 count = ten().bit_count()  # OK
+count = bin(*[123]).count("1")  # OK
+count = bin(*(123)).count("1")  # OK

--- a/crates/ruff_linter/resources/test/fixtures/refurb/FURB161.py
+++ b/crates/ruff_linter/resources/test/fixtures/refurb/FURB161.py
@@ -12,6 +12,7 @@ count = bin(0x10 + 0x1000).count("1")  # FURB161
 count = bin(ten()).count("1")  # FURB161
 count = bin((10)).count("1")  # FURB161
 count = bin("10" "15").count("1")  # FURB161
+count = bin(*[123]).count("1")  # FURB161
 
 count = x.bit_count()  # OK
 count = (10).bit_count()  # OK

--- a/crates/ruff_linter/src/rules/refurb/rules/bit_count.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/bit_count.rs
@@ -111,22 +111,9 @@ pub(crate) fn bit_count(checker: &Checker, call: &ExprCall) {
     }
 
     // Extract, e.g., `x` in `bin(x)`.
-    // If is a starred expression extract just the value, e.g., `123` in `bin(*[123])`.
+    // If is a starred expression, it returns.
     let literal_text = match arg {
-        Expr::Starred(starred) => {
-            if let Expr::List(list) = &*starred.value {
-                if list.elts.len() == 1 {
-                    checker.locator().slice(&list.elts[0])
-                } else {
-                    // If the list is empty or has more than
-                    // one element, we cannot fix it as is a Python error.
-                    return;
-                }
-            } else {
-                // If it is not the unpacking of a list
-                return;
-            }
-        }
+        Expr::Starred(_) => return,
         _ => checker.locator().slice(arg),
     };
 

--- a/crates/ruff_linter/src/rules/refurb/rules/bit_count.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/bit_count.rs
@@ -124,7 +124,7 @@ pub(crate) fn bit_count(checker: &Checker, call: &ExprCall) {
                 }
             } else {
                 // If it is not the unpacking of a list
-                checker.locator().slice(arg)
+                return;
             }
         }
         _ => checker.locator().slice(arg),

--- a/crates/ruff_linter/src/rules/refurb/rules/bit_count.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/bit_count.rs
@@ -110,12 +110,12 @@ pub(crate) fn bit_count(checker: &Checker, call: &ExprCall) {
         return;
     }
 
-    // Extract, e.g., `x` in `bin(x)`.
     // If is a starred expression, it returns.
-    let literal_text = match arg {
-        Expr::Starred(_) => return,
-        _ => checker.locator().slice(arg),
-    };
+    if arg.is_starred_expr() {
+        return;
+    }
+    // Extract, e.g., `x` in `bin(x)`.
+    let literal_text = checker.locator().slice(arg);
 
     // If we're calling a method on an integer, or an expression with lower precedence, parenthesize
     // it.

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB161_FURB161.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB161_FURB161.py.snap
@@ -145,7 +145,7 @@ FURB161.py:12:9: FURB161 [*] Use of `bin(ten()).count('1')`
    12 |+count = ten().bit_count()  # FURB161
 13 13 | count = bin((10)).count("1")  # FURB161
 14 14 | count = bin("10" "15").count("1")  # FURB161
-15 15 | count = bin(*[123]).count("1")  # FURB161
+15 15 | 
 
 FURB161.py:13:9: FURB161 [*] Use of `bin(10).count('1')`
    |
@@ -154,7 +154,6 @@ FURB161.py:13:9: FURB161 [*] Use of `bin(10).count('1')`
 13 | count = bin((10)).count("1")  # FURB161
    |         ^^^^^^^^^^^^^^^^^^^^ FURB161
 14 | count = bin("10" "15").count("1")  # FURB161
-15 | count = bin(*[123]).count("1")  # FURB161
    |
    = help: Replace with `(10).bit_count()`
 
@@ -165,8 +164,8 @@ FURB161.py:13:9: FURB161 [*] Use of `bin(10).count('1')`
 13    |-count = bin((10)).count("1")  # FURB161
    13 |+count = (10).bit_count()  # FURB161
 14 14 | count = bin("10" "15").count("1")  # FURB161
-15 15 | count = bin(*[123]).count("1")  # FURB161
-16 16 | 
+15 15 | 
+16 16 | count = x.bit_count()  # OK
 
 FURB161.py:14:9: FURB161 [*] Use of `bin("10" "15").count('1')`
    |
@@ -174,7 +173,8 @@ FURB161.py:14:9: FURB161 [*] Use of `bin("10" "15").count('1')`
 13 | count = bin((10)).count("1")  # FURB161
 14 | count = bin("10" "15").count("1")  # FURB161
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^ FURB161
-15 | count = bin(*[123]).count("1")  # FURB161
+15 |
+16 | count = x.bit_count()  # OK
    |
    = help: Replace with `("10" "15").bit_count()`
 
@@ -184,27 +184,6 @@ FURB161.py:14:9: FURB161 [*] Use of `bin("10" "15").count('1')`
 13 13 | count = bin((10)).count("1")  # FURB161
 14    |-count = bin("10" "15").count("1")  # FURB161
    14 |+count = ("10" "15").bit_count()  # FURB161
-15 15 | count = bin(*[123]).count("1")  # FURB161
-16 16 | 
-17 17 | count = x.bit_count()  # OK
-
-FURB161.py:15:9: FURB161 [*] Use of `bin(123).count('1')`
-   |
-13 | count = bin((10)).count("1")  # FURB161
-14 | count = bin("10" "15").count("1")  # FURB161
-15 | count = bin(*[123]).count("1")  # FURB161
-   |         ^^^^^^^^^^^^^^^^^^^^^^ FURB161
-16 |
-17 | count = x.bit_count()  # OK
-   |
-   = help: Replace with `(123).bit_count()`
-
-ℹ Safe fix
-12 12 | count = bin(ten()).count("1")  # FURB161
-13 13 | count = bin((10)).count("1")  # FURB161
-14 14 | count = bin("10" "15").count("1")  # FURB161
-15    |-count = bin(*[123]).count("1")  # FURB161
-   15 |+count = (123).bit_count()  # FURB161
-16 16 | 
-17 17 | count = x.bit_count()  # OK
-18 18 | count = (10).bit_count()  # OK
+15 15 | 
+16 16 | count = x.bit_count()  # OK
+17 17 | count = (10).bit_count()  # OK

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB161_FURB161.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB161_FURB161.py.snap
@@ -145,7 +145,7 @@ FURB161.py:12:9: FURB161 [*] Use of `bin(ten()).count('1')`
    12 |+count = ten().bit_count()  # FURB161
 13 13 | count = bin((10)).count("1")  # FURB161
 14 14 | count = bin("10" "15").count("1")  # FURB161
-15 15 | 
+15 15 | count = bin(*[123]).count("1")  # FURB161
 
 FURB161.py:13:9: FURB161 [*] Use of `bin(10).count('1')`
    |
@@ -154,6 +154,7 @@ FURB161.py:13:9: FURB161 [*] Use of `bin(10).count('1')`
 13 | count = bin((10)).count("1")  # FURB161
    |         ^^^^^^^^^^^^^^^^^^^^ FURB161
 14 | count = bin("10" "15").count("1")  # FURB161
+15 | count = bin(*[123]).count("1")  # FURB161
    |
    = help: Replace with `(10).bit_count()`
 
@@ -164,8 +165,8 @@ FURB161.py:13:9: FURB161 [*] Use of `bin(10).count('1')`
 13    |-count = bin((10)).count("1")  # FURB161
    13 |+count = (10).bit_count()  # FURB161
 14 14 | count = bin("10" "15").count("1")  # FURB161
-15 15 | 
-16 16 | count = x.bit_count()  # OK
+15 15 | count = bin(*[123]).count("1")  # FURB161
+16 16 | 
 
 FURB161.py:14:9: FURB161 [*] Use of `bin("10" "15").count('1')`
    |
@@ -173,8 +174,7 @@ FURB161.py:14:9: FURB161 [*] Use of `bin("10" "15").count('1')`
 13 | count = bin((10)).count("1")  # FURB161
 14 | count = bin("10" "15").count("1")  # FURB161
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^ FURB161
-15 |
-16 | count = x.bit_count()  # OK
+15 | count = bin(*[123]).count("1")  # FURB161
    |
    = help: Replace with `("10" "15").bit_count()`
 
@@ -184,6 +184,27 @@ FURB161.py:14:9: FURB161 [*] Use of `bin("10" "15").count('1')`
 13 13 | count = bin((10)).count("1")  # FURB161
 14    |-count = bin("10" "15").count("1")  # FURB161
    14 |+count = ("10" "15").bit_count()  # FURB161
-15 15 | 
-16 16 | count = x.bit_count()  # OK
-17 17 | count = (10).bit_count()  # OK
+15 15 | count = bin(*[123]).count("1")  # FURB161
+16 16 | 
+17 17 | count = x.bit_count()  # OK
+
+FURB161.py:15:9: FURB161 [*] Use of `bin(123).count('1')`
+   |
+13 | count = bin((10)).count("1")  # FURB161
+14 | count = bin("10" "15").count("1")  # FURB161
+15 | count = bin(*[123]).count("1")  # FURB161
+   |         ^^^^^^^^^^^^^^^^^^^^^^ FURB161
+16 |
+17 | count = x.bit_count()  # OK
+   |
+   = help: Replace with `(123).bit_count()`
+
+ℹ Safe fix
+12 12 | count = bin(ten()).count("1")  # FURB161
+13 13 | count = bin((10)).count("1")  # FURB161
+14 14 | count = bin("10" "15").count("1")  # FURB161
+15    |-count = bin(*[123]).count("1")  # FURB161
+   15 |+count = (123).bit_count()  # FURB161
+16 16 | 
+17 17 | count = x.bit_count()  # OK
+18 18 | count = (10).bit_count()  # OK


### PR DESCRIPTION
The PR partially solves issue #16457

Specifically, it solves the following problem:

```text
$ cat >furb161_1.py <<'# EOF'
print(bin(*[123]).count("1"))
# EOF

$ python furb161_1.py
6

$ ruff --isolated check --target-version py310 --preview --select FURB161 furb161_1.py --diff 2>&1 | grep error:
error: Fix introduced a syntax error. Reverting all changes.
```

Now starred expressions are corrected handled.