### PR TITLE
[red-knot] Add 'mypy_primer' workflow

### DIFF
--- a/.github/workflows/mypy_primer.yaml
+++ b/.github/workflows/mypy_primer.yaml
@@ -59,7 +59,7 @@ jobs:
 
           echo "Running mypy_primer"
 
-          uvx --from "git+https://github.com/sharkdp/mypy_primer.git@add-red-knot-support" mypy_primer \
+          uvx --from "git+https://github.com/astral-sh/mypy_primer.git@add-red-knot-support" mypy_primer \
             --repo ruff \
             --type-checker knot \
             --old base_commit \

--- a/.github/workflows/mypy_primer.yaml
+++ b/.github/workflows/mypy_primer.yaml
@@ -1,0 +1,68 @@
+name: Run mypy_primer
+
+permissions: {}
+
+on:
+  pull_request:
+    paths:
+      - "crates/red_knot*/**"
+      - "crates/ruff_python_ast"
+      - "crates/ruff_python_parser"
+      - ".github/workflows/mypy_primer.yaml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  CARGO_TERM_COLOR: always
+  RUSTUP_MAX_RETRIES: 10
+
+jobs:
+  mypy_primer:
+    name: Run mypy_primer
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: ruff
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v5
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "ruff"
+      - name: Install Rust toolchain
+        run: rustup show
+
+      - name: Run mypy_primer
+        shell: bash
+        run: |
+          cd ruff
+
+          echo "new commit"
+          git rev-list --format=%s --max-count=1 "$GITHUB_SHA"
+
+          MERGE_BASE="$(git merge-base "$GITHUB_SHA" "origin/$GITHUB_BASE_REF")"
+          git checkout -b base_commit "$MERGE_BASE"
+          echo "base commit"
+          git rev-list --format=%s --max-count=1 base_commit
+
+          cd ..
+
+          echo "Running mypy_primer"
+
+          uvx --from "git+https://github.com/sharkdp/mypy_primer.git@add-red-knot-support" mypy_primer \
+            --repo ruff \
+            --type-checker knot \
+            --old base_commit \
+            --new "$GITHUB_SHA" \
+            --project-selector '/(mypy_primer|black|pyp|git-revise|zipp|arrow)$' \
+            --output concise \
+            --debug

--- a/.github/workflows/mypy_primer.yaml
+++ b/.github/workflows/mypy_primer.yaml
@@ -6,6 +6,7 @@ on:
   pull_request:
     paths:
       - "crates/red_knot*/**"
+      - "crates/ruff_db"
       - "crates/ruff_python_ast"
       - "crates/ruff_python_parser"
       - ".github/workflows/mypy_primer.yaml"

--- a/.github/workflows/mypy_primer.yaml
+++ b/.github/workflows/mypy_primer.yaml
@@ -24,7 +24,7 @@ env:
 jobs:
   mypy_primer:
     name: Run mypy_primer
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Run Red Knot on a small selection of ecosystem projects via a [forked version of `mypy_primer`](https://github.com/astral-sh/mypy_primer/tree/add-red-knot-support). I think it's probably fine to run this from a fork as long as the red knot CLI is not stable, and as long as we're still experimenting with this?

There's probably a lot still to do both on the `mypy_primer` side as well as on the pipeline side here (we might want to have it comment on PRs, for example), but maybe this is a good first step to have this as a non-blocking pipeline that simply runs on red knot PRs? For you to look at, if you're interested...

Example output with a negative diff for a dummy change (commented out `unresolved-attribute` diagnostics):

![image](https://github.com/user-attachments/assets/c6940d77-843f-4664-83af-5664436bbb77)

## TODO

- Only run for PRs that touch red-knot source code

## Test Plan

* Successful run: https://github.com/astral-sh/ruff/actions/runs/13725319641/job/38390245552?pr=16554
* Intentially failed run where I commented out `unresolved-attribute` diagnostics reporting: https://github.com/astral-sh/ruff/actions/runs/13723777105/job/38385224144

<!-- How was it tested? -->
