### PR TITLE
[`pep8-naming`] Add links to `ignore-names` options in various rules' documentation

### DIFF
--- a/crates/ruff_linter/src/rules/pep8_naming/rules/camelcase_imported_as_acronym.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/rules/camelcase_imported_as_acronym.rs
@@ -37,6 +37,8 @@ use crate::rules::pep8_naming::helpers;
 ///
 /// ## Options
 /// - `lint.flake8-import-conventions.aliases`
+/// - `lint.pep8-naming.ignore-names`
+/// - `lint.pep8-naming.extend-ignore-names`
 ///
 /// [PEP 8]: https://peps.python.org/pep-0008/
 #[derive(ViolationMetadata)]

--- a/crates/ruff_linter/src/rules/pep8_naming/rules/camelcase_imported_as_constant.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/rules/camelcase_imported_as_constant.rs
@@ -44,6 +44,10 @@ use crate::rules::pep8_naming::settings::IgnoreNames;
 /// A common example of a single uppercase character being used for a class
 /// name can be found in Django's `django.db.models.Q` class.
 ///
+/// ## Options
+/// - `lint.pep8-naming.ignore-names`
+/// - `lint.pep8-naming.extend-ignore-names`
+///
 /// [PEP 8]: https://peps.python.org/pep-0008/
 #[derive(ViolationMetadata)]
 pub(crate) struct CamelcaseImportedAsConstant {

--- a/crates/ruff_linter/src/rules/pep8_naming/rules/camelcase_imported_as_lowercase.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/rules/camelcase_imported_as_lowercase.rs
@@ -29,6 +29,10 @@ use crate::rules::pep8_naming::settings::IgnoreNames;
 /// from example import MyClassName
 /// ```
 ///
+/// ## Options
+/// - `lint.pep8-naming.ignore-names`
+/// - `lint.pep8-naming.extend-ignore-names`
+///
 /// [PEP 8]: https://peps.python.org/pep-0008/
 #[derive(ViolationMetadata)]
 pub(crate) struct CamelcaseImportedAsLowercase {

--- a/crates/ruff_linter/src/rules/pep8_naming/rules/constant_imported_as_non_constant.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/rules/constant_imported_as_non_constant.rs
@@ -42,6 +42,10 @@ use crate::rules::pep8_naming::{helpers, settings::IgnoreNames};
 /// A common example of a single uppercase character being used for a class
 /// name can be found in Django's `django.db.models.Q` class.
 ///
+/// ## Options
+/// - `lint.pep8-naming.ignore-names`
+/// - `lint.pep8-naming.extend-ignore-names`
+///
 /// [PEP 8]: https://peps.python.org/pep-0008/
 #[derive(ViolationMetadata)]
 pub(crate) struct ConstantImportedAsNonConstant {

--- a/crates/ruff_linter/src/rules/pep8_naming/rules/dunder_function_name.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/rules/dunder_function_name.rs
@@ -31,6 +31,10 @@ use crate::rules::pep8_naming::settings::IgnoreNames;
 ///     pass
 /// ```
 ///
+/// ## Options
+/// - `lint.pep8-naming.ignore-names`
+/// - `lint.pep8-naming.extend-ignore-names`
+///
 /// [PEP 8]: https://peps.python.org/pep-0008/
 #[derive(ViolationMetadata)]
 pub(crate) struct DunderFunctionName;

--- a/crates/ruff_linter/src/rules/pep8_naming/rules/error_suffix_on_exception_name.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/rules/error_suffix_on_exception_name.rs
@@ -28,6 +28,10 @@ use crate::rules::pep8_naming::settings::IgnoreNames;
 /// class ValidationError(Exception): ...
 /// ```
 ///
+/// ## Options
+/// - `lint.pep8-naming.ignore-names`
+/// - `lint.pep8-naming.extend-ignore-names`
+///
 /// [PEP 8]: https://peps.python.org/pep-0008/#exception-names
 #[derive(ViolationMetadata)]
 pub(crate) struct ErrorSuffixOnExceptionName {

--- a/crates/ruff_linter/src/rules/pep8_naming/rules/invalid_argument_name.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/rules/invalid_argument_name.rs
@@ -37,6 +37,10 @@ use crate::checkers::ast::Checker;
 ///     pass
 /// ```
 ///
+/// ## Options
+/// - `lint.pep8-naming.ignore-names`
+/// - `lint.pep8-naming.extend-ignore-names`
+///
 /// [PEP 8]: https://peps.python.org/pep-0008/#function-and-method-arguments
 /// [preview]: https://docs.astral.sh/ruff/preview/
 #[derive(ViolationMetadata)]

--- a/crates/ruff_linter/src/rules/pep8_naming/rules/invalid_class_name.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/rules/invalid_class_name.rs
@@ -34,6 +34,10 @@ use crate::rules::pep8_naming::settings::IgnoreNames;
 ///     pass
 /// ```
 ///
+/// ## Options
+/// - `lint.pep8-naming.ignore-names`
+/// - `lint.pep8-naming.extend-ignore-names`
+///
 /// [PEP 8]: https://peps.python.org/pep-0008/#class-names
 #[derive(ViolationMetadata)]
 pub(crate) struct InvalidClassName {

--- a/crates/ruff_linter/src/rules/pep8_naming/rules/lowercase_imported_as_non_lowercase.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/rules/lowercase_imported_as_non_lowercase.rs
@@ -28,6 +28,10 @@ use crate::rules::pep8_naming::settings::IgnoreNames;
 /// from example import myclassname
 /// ```
 ///
+/// ## Options
+/// - `lint.pep8-naming.ignore-names`
+/// - `lint.pep8-naming.extend-ignore-names`
+///
 /// [PEP 8]: https://peps.python.org/pep-0008/
 #[derive(ViolationMetadata)]
 pub(crate) struct LowercaseImportedAsNonLowercase {

--- a/crates/ruff_linter/src/rules/pep8_naming/rules/mixed_case_variable_in_class_scope.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/rules/mixed_case_variable_in_class_scope.rs
@@ -35,6 +35,10 @@ use crate::rules::pep8_naming::helpers;
 ///     another_variable = "world"
 /// ```
 ///
+/// ## Options
+/// - `lint.pep8-naming.ignore-names`
+/// - `lint.pep8-naming.extend-ignore-names`
+///
 /// [PEP 8]: https://peps.python.org/pep-0008/#function-and-method-arguments
 #[derive(ViolationMetadata)]
 pub(crate) struct MixedCaseVariableInClassScope {

--- a/crates/ruff_linter/src/rules/pep8_naming/rules/mixed_case_variable_in_global_scope.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/rules/mixed_case_variable_in_global_scope.rs
@@ -46,6 +46,10 @@ use crate::rules::pep8_naming::helpers;
 /// yet_another_variable = "foo"
 /// ```
 ///
+/// ## Options
+/// - `lint.pep8-naming.ignore-names`
+/// - `lint.pep8-naming.extend-ignore-names`
+///
 /// [PEP 8]: https://peps.python.org/pep-0008/#global-variable-names
 #[derive(ViolationMetadata)]
 pub(crate) struct MixedCaseVariableInGlobalScope {


### PR DESCRIPTION
## Summary

Resolves #16551.

All rules using [`lint.pep8-naming.ignore-names`](https://docs.astral.sh/ruff/settings/#lint_pep8-naming_ignore-names) and [`lint.pep8-naming.extend-ignore-names`](https://docs.astral.sh/ruff/settings/#lint_pep8-naming_extend-ignore-names) now have their documentation linked to these two options.

## Test Plan

None.
