### PR TITLE
[red-knot] Support multiple overloads when binding parameters at call sites

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/call/builtins.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/call/builtins.md
@@ -29,9 +29,15 @@ But a three-argument call to type creates a dynamic instance of the `type` class
 reveal_type(type("Foo", (), {}))  # revealed: type
 ```
 
-Other numbers of arguments are invalid (TODO -- these should emit a diagnostic)
+Other numbers of arguments are invalid
 
 ```py
+# error: [too-many-positional-arguments] "Too many positional arguments to overload 1 of class `type`: expected 1, got 2"
+# error: [missing-argument] "No argument provided for required parameter `dict` of overload 2 of class `type`"
 type("Foo", ())
+
+# error: [too-many-positional-arguments] "Too many positional arguments to overload 1 of class `type`: expected 1, got 3"
+# error: [unknown-argument] "Argument `weird_other_arg` does not match any known parameter of overload 1 of class `type`"
+# error: [unknown-argument] "Argument `weird_other_arg` does not match any known parameter of overload 2 of class `type`"
 type("Foo", (), {}, weird_other_arg=42)
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/call/builtins.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/call/builtins.md
@@ -6,7 +6,7 @@
 class NotBool:
     __bool__ = None
 
-# TODO: We should emit an `invalid-argument` error here for `2` because `bool` only takes one argument.
+# error: [too-many-positional-arguments] "Too many positional arguments to class `bool`: expected 1, got 2"
 bool(1, 2)
 
 # TODO: We should emit an `unsupported-bool-conversion` error here because the argument doesn't implement `__bool__` correctly.

--- a/crates/red_knot_python_semantic/resources/mdtest/call/methods.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/call/methods.md
@@ -235,30 +235,30 @@ method_wrapper(C(), None)
 method_wrapper(None, C)
 
 # Passing `None` without an `owner` argument is an
-# error: [missing-argument] "No argument provided for required parameter `owner` of method wrapper `__get__` of function `f`"
-# error: [invalid-argument-type] "Object of type `None` cannot be assigned to parameter 1 (`instance`) of method wrapper `__get__` of function `f`; expected type `~None`"
+# error: [missing-argument] "No argument provided for required parameter `owner` of overload 1 of method wrapper `__get__` of function `f`"
+# error: [invalid-argument-type] "Object of type `None` cannot be assigned to parameter 1 (`instance`) of overload 2 of method wrapper `__get__` of function `f`; expected type `~None`"
 method_wrapper(None)
 
 # Passing something that is not assignable to `type` as the `owner` argument is an
-# error: [invalid-argument-type] "Object of type `Literal[1]` cannot be assigned to parameter 2 (`owner`) of method wrapper `__get__` of function `f`; expected type `type`"
-# error: [invalid-argument-type] "Object of type `None` cannot be assigned to parameter 1 (`instance`) of method wrapper `__get__` of function `f`; expected type `~None`"
-# error: [invalid-argument-type] "Object of type `Literal[1]` cannot be assigned to parameter 2 (`owner`) of method wrapper `__get__` of function `f`; expected type `type | None`"
+# error: [invalid-argument-type] "Object of type `Literal[1]` cannot be assigned to parameter 2 (`owner`) of overload 1 of method wrapper `__get__` of function `f`; expected type `type`"
+# error: [invalid-argument-type] "Object of type `None` cannot be assigned to parameter 1 (`instance`) of overload 2 of method wrapper `__get__` of function `f`; expected type `~None`"
+# error: [invalid-argument-type] "Object of type `Literal[1]` cannot be assigned to parameter 2 (`owner`) of overload 2 of method wrapper `__get__` of function `f`; expected type `type | None`"
 method_wrapper(None, 1)
 
 # Passing `None` as the `owner` argument when `instance` is `None` is an
-# error: [invalid-argument-type] "Object of type `None` cannot be assigned to parameter 2 (`owner`) of method wrapper `__get__` of function `f`; expected type `type`"
-# error: [invalid-argument-type] "Object of type `None` cannot be assigned to parameter 1 (`instance`) of method wrapper `__get__` of function `f`; expected type `~None`"
+# error: [invalid-argument-type] "Object of type `None` cannot be assigned to parameter 2 (`owner`) of overload 1 of method wrapper `__get__` of function `f`; expected type `type`"
+# error: [invalid-argument-type] "Object of type `None` cannot be assigned to parameter 1 (`instance`) of overload 2 of method wrapper `__get__` of function `f`; expected type `~None`"
 method_wrapper(None, None)
 
 # Calling `__get__` without any arguments is an
-# error: [missing-argument] "No arguments provided for required parameters `instance`, `owner` of method wrapper `__get__` of function `f`"
-# error: [missing-argument] "No argument provided for required parameter `instance` of method wrapper `__get__` of function `f`"
+# error: [missing-argument] "No arguments provided for required parameters `instance`, `owner` of overload 1 of method wrapper `__get__` of function `f`"
+# error: [missing-argument] "No argument provided for required parameter `instance` of overload 2 of method wrapper `__get__` of function `f`"
 method_wrapper()
 
 # Calling `__get__` with too many positional arguments is an
-# error: [invalid-argument-type] "Object of type `C` cannot be assigned to parameter 1 (`instance`) of method wrapper `__get__` of function `f`; expected type `None`"
-# error: [too-many-positional-arguments] "Too many positional arguments to method wrapper `__get__` of function `f`: expected 2, got 3"
-# error: [too-many-positional-arguments] "Too many positional arguments to method wrapper `__get__` of function `f`: expected 2, got 3"
+# error: [invalid-argument-type] "Object of type `C` cannot be assigned to parameter 1 (`instance`) of overload 1 of method wrapper `__get__` of function `f`; expected type `None`"
+# error: [too-many-positional-arguments] "Too many positional arguments to overload 1 of method wrapper `__get__` of function `f`: expected 2, got 3"
+# error: [too-many-positional-arguments] "Too many positional arguments to overload 2 of method wrapper `__get__` of function `f`: expected 2, got 3"
 method_wrapper(C(), C, "one too many")
 ```
 

--- a/crates/red_knot_python_semantic/resources/mdtest/call/methods.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/call/methods.md
@@ -235,22 +235,29 @@ method_wrapper(C(), None)
 method_wrapper(None, C)
 
 # Passing `None` without an `owner` argument is an
-# error: [missing-argument] "No argument provided for required parameter `owner`"
+# error: [missing-argument] "No argument provided for required parameter `owner` of method wrapper `__get__` of function `f`"
+# error: [invalid-argument-type] "Object of type `None` cannot be assigned to parameter 1 (`instance`) of method wrapper `__get__` of function `f`; expected type `~None`"
 method_wrapper(None)
 
 # Passing something that is not assignable to `type` as the `owner` argument is an
 # error: [invalid-argument-type] "Object of type `Literal[1]` cannot be assigned to parameter 2 (`owner`) of method wrapper `__get__` of function `f`; expected type `type`"
+# error: [invalid-argument-type] "Object of type `None` cannot be assigned to parameter 1 (`instance`) of method wrapper `__get__` of function `f`; expected type `~None`"
+# error: [invalid-argument-type] "Object of type `Literal[1]` cannot be assigned to parameter 2 (`owner`) of method wrapper `__get__` of function `f`; expected type `type | None`"
 method_wrapper(None, 1)
 
 # Passing `None` as the `owner` argument when `instance` is `None` is an
 # error: [invalid-argument-type] "Object of type `None` cannot be assigned to parameter 2 (`owner`) of method wrapper `__get__` of function `f`; expected type `type`"
+# error: [invalid-argument-type] "Object of type `None` cannot be assigned to parameter 1 (`instance`) of method wrapper `__get__` of function `f`; expected type `~None`"
 method_wrapper(None, None)
 
 # Calling `__get__` without any arguments is an
-# error: [missing-argument] "No argument provided for required parameter `instance`"
+# error: [missing-argument] "No arguments provided for required parameters `instance`, `owner` of method wrapper `__get__` of function `f`"
+# error: [missing-argument] "No argument provided for required parameter `instance` of method wrapper `__get__` of function `f`"
 method_wrapper()
 
 # Calling `__get__` with too many positional arguments is an
+# error: [invalid-argument-type] "Object of type `C` cannot be assigned to parameter 1 (`instance`) of method wrapper `__get__` of function `f`; expected type `None`"
+# error: [too-many-positional-arguments] "Too many positional arguments to method wrapper `__get__` of function `f`: expected 2, got 3"
 # error: [too-many-positional-arguments] "Too many positional arguments to method wrapper `__get__` of function `f`: expected 2, got 3"
 method_wrapper(C(), C, "one too many")
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/descriptor_protocol.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/descriptor_protocol.md
@@ -410,15 +410,18 @@ Finally, we test some error cases for the call to the wrapper descriptor:
 
 ```py
 # Calling the wrapper descriptor without any arguments is an
-# error: [missing-argument] "No arguments provided for required parameters `self`, `instance`"
+# error: [missing-argument] "No arguments provided for required parameters `self`, `instance`, `owner` of wrapper descriptor `FunctionType.__get__`"
+# error: [missing-argument] "No arguments provided for required parameters `self`, `instance` of wrapper descriptor `FunctionType.__get__`"
 wrapper_descriptor()
 
 # Calling it without the `instance` argument is an also an
-# error: [missing-argument] "No argument provided for required parameter `instance`"
+# error: [missing-argument] "No arguments provided for required parameters `instance`, `owner` of wrapper descriptor `FunctionType.__get__`"
+# error: [missing-argument] "No argument provided for required parameter `instance` of wrapper descriptor `FunctionType.__get__`"
 wrapper_descriptor(f)
 
 # Calling it without the `owner` argument if `instance` is not `None` is an
-# error: [missing-argument] "No argument provided for required parameter `owner`"
+# error: [missing-argument] "No argument provided for required parameter `owner` of wrapper descriptor `FunctionType.__get__`"
+# error: [invalid-argument-type] "Object of type `None` cannot be assigned to parameter 2 (`instance`) of wrapper descriptor `FunctionType.__get__`; expected type `~None`"
 wrapper_descriptor(f, None)
 
 # But calling it with an instance is fine (in this case, the `owner` argument is optional):
@@ -426,13 +429,19 @@ wrapper_descriptor(f, C())
 
 # Calling it with something that is not a `FunctionType` as the first argument is an
 # error: [invalid-argument-type] "Object of type `Literal[1]` cannot be assigned to parameter 1 (`self`) of wrapper descriptor `FunctionType.__get__`; expected type `FunctionType`"
+# error: [invalid-argument-type] "Object of type `Literal[1]` cannot be assigned to parameter 1 (`self`) of wrapper descriptor `FunctionType.__get__`; expected type `FunctionType`"
+# error: [invalid-argument-type] "Object of type `None` cannot be assigned to parameter 2 (`instance`) of wrapper descriptor `FunctionType.__get__`; expected type `~None`"
 wrapper_descriptor(1, None, type(f))
 
 # Calling it with something that is not a `type` as the `owner` argument is an
 # error: [invalid-argument-type] "Object of type `Literal[f]` cannot be assigned to parameter 3 (`owner`) of wrapper descriptor `FunctionType.__get__`; expected type `type`"
+# error: [invalid-argument-type] "Object of type `None` cannot be assigned to parameter 2 (`instance`) of wrapper descriptor `FunctionType.__get__`; expected type `~None`"
+# error: [invalid-argument-type] "Object of type `Literal[f]` cannot be assigned to parameter 3 (`owner`) of wrapper descriptor `FunctionType.__get__`; expected type `type | None`"
 wrapper_descriptor(f, None, f)
 
 # Calling it with too many positional arguments is an
+# error: [too-many-positional-arguments] "Too many positional arguments to wrapper descriptor `FunctionType.__get__`: expected 3, got 4"
+# error: [invalid-argument-type] "Object of type `None` cannot be assigned to parameter 2 (`instance`) of wrapper descriptor `FunctionType.__get__`; expected type `~None`"
 # error: [too-many-positional-arguments] "Too many positional arguments to wrapper descriptor `FunctionType.__get__`: expected 3, got 4"
 wrapper_descriptor(f, None, type(f), "one too many")
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/descriptor_protocol.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/descriptor_protocol.md
@@ -410,39 +410,39 @@ Finally, we test some error cases for the call to the wrapper descriptor:
 
 ```py
 # Calling the wrapper descriptor without any arguments is an
-# error: [missing-argument] "No arguments provided for required parameters `self`, `instance`, `owner` of wrapper descriptor `FunctionType.__get__`"
-# error: [missing-argument] "No arguments provided for required parameters `self`, `instance` of wrapper descriptor `FunctionType.__get__`"
+# error: [missing-argument] "No arguments provided for required parameters `self`, `instance`, `owner` of overload 1 of wrapper descriptor `FunctionType.__get__`"
+# error: [missing-argument] "No arguments provided for required parameters `self`, `instance` of overload 2 of wrapper descriptor `FunctionType.__get__`"
 wrapper_descriptor()
 
 # Calling it without the `instance` argument is an also an
-# error: [missing-argument] "No arguments provided for required parameters `instance`, `owner` of wrapper descriptor `FunctionType.__get__`"
-# error: [missing-argument] "No argument provided for required parameter `instance` of wrapper descriptor `FunctionType.__get__`"
+# error: [missing-argument] "No arguments provided for required parameters `instance`, `owner` of overload 1 of wrapper descriptor `FunctionType.__get__`"
+# error: [missing-argument] "No argument provided for required parameter `instance` of overload 2 of wrapper descriptor `FunctionType.__get__`"
 wrapper_descriptor(f)
 
 # Calling it without the `owner` argument if `instance` is not `None` is an
-# error: [missing-argument] "No argument provided for required parameter `owner` of wrapper descriptor `FunctionType.__get__`"
-# error: [invalid-argument-type] "Object of type `None` cannot be assigned to parameter 2 (`instance`) of wrapper descriptor `FunctionType.__get__`; expected type `~None`"
+# error: [missing-argument] "No argument provided for required parameter `owner` of overload 1 of wrapper descriptor `FunctionType.__get__`"
+# error: [invalid-argument-type] "Object of type `None` cannot be assigned to parameter 2 (`instance`) of overload 2 of wrapper descriptor `FunctionType.__get__`; expected type `~None`"
 wrapper_descriptor(f, None)
 
 # But calling it with an instance is fine (in this case, the `owner` argument is optional):
 wrapper_descriptor(f, C())
 
 # Calling it with something that is not a `FunctionType` as the first argument is an
-# error: [invalid-argument-type] "Object of type `Literal[1]` cannot be assigned to parameter 1 (`self`) of wrapper descriptor `FunctionType.__get__`; expected type `FunctionType`"
-# error: [invalid-argument-type] "Object of type `Literal[1]` cannot be assigned to parameter 1 (`self`) of wrapper descriptor `FunctionType.__get__`; expected type `FunctionType`"
-# error: [invalid-argument-type] "Object of type `None` cannot be assigned to parameter 2 (`instance`) of wrapper descriptor `FunctionType.__get__`; expected type `~None`"
+# error: [invalid-argument-type] "Object of type `Literal[1]` cannot be assigned to parameter 1 (`self`) of overload 1 of wrapper descriptor `FunctionType.__get__`; expected type `FunctionType`"
+# error: [invalid-argument-type] "Object of type `Literal[1]` cannot be assigned to parameter 1 (`self`) of overload 2 of wrapper descriptor `FunctionType.__get__`; expected type `FunctionType`"
+# error: [invalid-argument-type] "Object of type `None` cannot be assigned to parameter 2 (`instance`) of overload 2 of wrapper descriptor `FunctionType.__get__`; expected type `~None`"
 wrapper_descriptor(1, None, type(f))
 
 # Calling it with something that is not a `type` as the `owner` argument is an
-# error: [invalid-argument-type] "Object of type `Literal[f]` cannot be assigned to parameter 3 (`owner`) of wrapper descriptor `FunctionType.__get__`; expected type `type`"
-# error: [invalid-argument-type] "Object of type `None` cannot be assigned to parameter 2 (`instance`) of wrapper descriptor `FunctionType.__get__`; expected type `~None`"
-# error: [invalid-argument-type] "Object of type `Literal[f]` cannot be assigned to parameter 3 (`owner`) of wrapper descriptor `FunctionType.__get__`; expected type `type | None`"
+# error: [invalid-argument-type] "Object of type `Literal[f]` cannot be assigned to parameter 3 (`owner`) of overload 1 of wrapper descriptor `FunctionType.__get__`; expected type `type`"
+# error: [invalid-argument-type] "Object of type `None` cannot be assigned to parameter 2 (`instance`) of overload 2 of wrapper descriptor `FunctionType.__get__`; expected type `~None`"
+# error: [invalid-argument-type] "Object of type `Literal[f]` cannot be assigned to parameter 3 (`owner`) of overload 2 of wrapper descriptor `FunctionType.__get__`; expected type `type | None`"
 wrapper_descriptor(f, None, f)
 
 # Calling it with too many positional arguments is an
-# error: [too-many-positional-arguments] "Too many positional arguments to wrapper descriptor `FunctionType.__get__`: expected 3, got 4"
-# error: [invalid-argument-type] "Object of type `None` cannot be assigned to parameter 2 (`instance`) of wrapper descriptor `FunctionType.__get__`; expected type `~None`"
-# error: [too-many-positional-arguments] "Too many positional arguments to wrapper descriptor `FunctionType.__get__`: expected 3, got 4"
+# error: [too-many-positional-arguments] "Too many positional arguments to overload 1 of wrapper descriptor `FunctionType.__get__`: expected 3, got 4"
+# error: [invalid-argument-type] "Object of type `None` cannot be assigned to parameter 2 (`instance`) of overload 2 of wrapper descriptor `FunctionType.__get__`; expected type `~None`"
+# error: [too-many-positional-arguments] "Too many positional arguments to overload 2 of wrapper descriptor `FunctionType.__get__`: expected 3, got 4"
 wrapper_descriptor(f, None, type(f), "one too many")
 ```
 

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/bool-call.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/bool-call.md
@@ -22,11 +22,13 @@ def _(flag: bool):
 
     # invalid invocation, too many positional args
     reveal_type(x)  # revealed: Literal[1] | None
-    if bool(x is not None, 5):  # TODO diagnostic
+    # error: [too-many-positional-arguments] "Too many positional arguments to class `bool`: expected 1, got 2"
+    if bool(x is not None, 5):
         reveal_type(x)  # revealed: Literal[1] | None
 
     # invalid invocation, too many kwargs
     reveal_type(x)  # revealed: Literal[1] | None
-    if bool(x is not None, y=5):  # TODO diagnostic
+    # error: [unknown-argument] "Argument `y` does not match any known parameter of class `bool`"
+    if bool(x is not None, y=5):
         reveal_type(x)  # revealed: Literal[1] | None
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/type.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/type.md
@@ -88,7 +88,10 @@ def _(x: str | int):
 
 ```py
 def _(x: str | int):
-    # TODO: we could issue a diagnostic here
+    # error: [unknown-argument] "Argument `object` does not match any known parameter of overload 1 of class `type`"
+    # error: [missing-argument] "No argument provided for required parameter `o` of overload 1 of class `type`"
+    # error: [unknown-argument] "Argument `object` does not match any known parameter of overload 2 of class `type`"
+    # error: [missing-argument] "No arguments provided for required parameters `o`, `bases`, `dict` of overload 2 of class `type`"
     if type(object=x) is str:
         reveal_type(x)  # revealed: str | int
 ```

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -2279,9 +2279,9 @@ impl<'db> Type<'db> {
             }
 
             Type::Intersection(_) => {
-                OverloadBinding::from_return_type(todo_type!("Type::Intersection.call()"))
-                    .into_binding()
-                    .into_outcome()
+                let overloads = Overloads::todo("Type::Intersection.call()");
+                let binding = bind_call(db, &arguments, &overloads, self);
+                binding.into_outcome()
             }
 
             _ => Err(CallError::NotCallable {
@@ -3549,7 +3549,7 @@ impl<'db> FunctionType<'db> {
             {
                 internal_signature
             } else {
-                Signature::todo("return type of decorated function").into()
+                Overloads::todo("return type of decorated function")
             }
         } else {
             internal_signature

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -2397,7 +2397,7 @@ impl<'db> Type<'db> {
 
             Type::Intersection(_) => {
                 let overloads = Overloads::todo("Type::Intersection.call()");
-                let binding = bind_call(db, &arguments, &overloads, self);
+                let binding = bind_call(db, arguments, &overloads, self);
                 binding.into_outcome()
             }
 

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -2341,10 +2341,9 @@ impl<'db> Type<'db> {
 
             // TODO annotated return type on `__new__` or metaclass `__call__`
             // TODO check call vs signatures of `__new__` and/or `__init__`
-            Type::ClassLiteral(ClassLiteralType { class }) => {
-                let overload =
-                    OverloadBinding::from_return_type(Type::Instance(InstanceType { class }));
-                let binding = overload.into_binding();
+            Type::ClassLiteral(ClassLiteralType { .. }) => {
+                let signature = Signature::new(Parameters::any(), Some(self.to_instance(db)));
+                let binding = bind_call(db, arguments, &signature.into(), self);
                 binding.into_outcome()
             }
 

--- a/crates/red_knot_python_semantic/src/types/call.rs
+++ b/crates/red_knot_python_semantic/src/types/call.rs
@@ -1,5 +1,5 @@
 use super::context::InferContext;
-use super::{Signature, Type};
+use super::{Overloads, Signature, Type};
 use crate::types::UnionType;
 use crate::Db;
 

--- a/crates/red_knot_python_semantic/src/types/call/arguments.rs
+++ b/crates/red_knot_python_semantic/src/types/call/arguments.rs
@@ -36,14 +36,6 @@ impl<'a, 'db> CallArguments<'a, 'db> {
     }
 
     // TODO this should be eliminated in favor of [`bind_call`]
-    pub(crate) fn exactly_one_argument(&self) -> Option<Type<'db>> {
-        match &*self.0 {
-            [arg] => Some(arg.ty()),
-            _ => None,
-        }
-    }
-
-    // TODO this should be eliminated in favor of [`bind_call`]
     pub(crate) fn second_argument(&self) -> Option<Type<'db>> {
         self.0.get(1).map(Argument::ty)
     }

--- a/crates/red_knot_python_semantic/src/types/call/bind.rs
+++ b/crates/red_knot_python_semantic/src/types/call/bind.rs
@@ -242,13 +242,11 @@ impl<'db> CallBinding<'db> {
     }
 
     /// Report diagnostics for all of the errors that occurred when trying to match actual
-    /// arguments to formal parameters. If the callable has multiple overloads, we only report
-    /// diagnostics for the first overload.
+    /// arguments to formal parameters. If the callable has multiple overloads, we report
+    /// diagnostics for all of them.
     pub(crate) fn report_diagnostics(&self, context: &InferContext<'db>, node: ast::AnyNodeRef) {
-        // TODO: We currently only report the errors from the first overload. Consider reporting
-        // errors from all of them.
-        if let Some(overload) = self.overloads.first() {
-            let callable_descriptor = self.callable_descriptor(context.db());
+        let callable_descriptor = self.callable_descriptor(context.db());
+        for overload in &self.overloads {
             overload.report_diagnostics(
                 context,
                 node,

--- a/crates/red_knot_python_semantic/src/types/call/bind.rs
+++ b/crates/red_knot_python_semantic/src/types/call/bind.rs
@@ -22,6 +22,8 @@ pub(crate) fn bind_call<'db>(
     overloads: &Overloads<'db>,
     callable_ty: Type<'db>,
 ) -> CallBinding<'db> {
+    // TODO: This checks every overload. Consider short-circuiting this loop once we find the first
+    // overload that is a successful match against the argument list.
     let overloads = overloads
         .iter()
         .map(|signature| bind_overload(db, arguments, signature))

--- a/crates/red_knot_python_semantic/src/types/call/bind.rs
+++ b/crates/red_knot_python_semantic/src/types/call/bind.rs
@@ -200,24 +200,26 @@ impl<'db> CallBinding<'db> {
 
     /// Returns the overload that matched for this call binding. Returns `None` if none of the
     /// overloads matched.
-    pub(crate) fn matching_overload(&self) -> Option<&OverloadBinding<'db>> {
+    pub(crate) fn matching_overload(&self) -> Option<(usize, &OverloadBinding<'db>)> {
         self.overloads
             .iter()
-            .find(|overload| !overload.has_binding_errors())
+            .enumerate()
+            .find(|(_, overload)| !overload.has_binding_errors())
     }
 
     /// Returns the overload that matched for this call binding. Returns `None` if none of the
     /// overloads matched.
-    pub(crate) fn matching_overload_mut(&mut self) -> Option<&mut OverloadBinding<'db>> {
+    pub(crate) fn matching_overload_mut(&mut self) -> Option<(usize, &mut OverloadBinding<'db>)> {
         self.overloads
             .iter_mut()
-            .find(|overload| !overload.has_binding_errors())
+            .enumerate()
+            .find(|(_, overload)| !overload.has_binding_errors())
     }
 
     /// Returns the return type of the matching overload for this binding. If none of the overloads
     /// matched, returns a union of the return types of each overload.
     pub(crate) fn return_type(&self, db: &'db dyn Db) -> Type<'db> {
-        if let Some(overload) = self.matching_overload() {
+        if let Some((_, overload)) = self.matching_overload() {
             return overload.return_type();
         }
         if let [overload] = self.overloads.as_ref() {

--- a/crates/red_knot_python_semantic/src/types/call/bind.rs
+++ b/crates/red_knot_python_semantic/src/types/call/bind.rs
@@ -1,4 +1,4 @@
-use super::{Argument, CallArguments, InferContext, Signature, Type};
+use super::{Argument, CallArguments, CallError, CallOutcome, InferContext, Signature, Type};
 use crate::db::Db;
 use crate::types::diagnostic::{
     INVALID_ARGUMENT_TYPE, MISSING_ARGUMENT, PARAMETER_ALREADY_ASSIGNED,
@@ -168,6 +168,13 @@ impl<'db> CallBinding<'db> {
             parameter_tys: Box::default(),
             errors: vec![],
         }
+    }
+
+    pub(crate) fn into_outcome(self) -> Result<CallOutcome<'db>, CallError<'db>> {
+        if self.has_binding_errors() {
+            return Err(CallError::BindingError { binding: self });
+        }
+        Ok(CallOutcome::Single(self))
     }
 
     pub(crate) fn callable_type(&self) -> Type<'db> {

--- a/crates/red_knot_python_semantic/src/types/class.rs
+++ b/crates/red_knot_python_semantic/src/types/class.rs
@@ -251,7 +251,7 @@ impl<'db> Class<'db> {
                         })
                         .map(|mut builder| {
                             for binding in bindings {
-                                builder = builder.add(binding.return_type());
+                                builder = builder.add(binding.return_type(db));
                             }
 
                             builder.build()
@@ -272,7 +272,7 @@ impl<'db> Class<'db> {
 
                 // TODO we should also check for binding errors that would indicate the metaclass
                 // does not accept the right arguments
-                Err(CallError::BindingError { binding }) => Ok(binding.return_type()),
+                Err(CallError::BindingError { binding }) => Ok(binding.return_type(db)),
             };
 
             return return_ty_result.map(|ty| ty.to_meta_type(db));

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -3423,9 +3423,13 @@ impl<'db> TypeInferenceBuilder<'db> {
                         continue;
                     };
 
+                    let Some(overload) = binding.matching_overload() else {
+                        continue;
+                    };
+
                     match known_function {
                         KnownFunction::RevealType => {
-                            if let Some(revealed_type) = binding.one_parameter_type() {
+                            if let Some(revealed_type) = overload.one_parameter_type() {
                                 self.context.report_diagnostic(
                                     call_expression,
                                     DiagnosticId::RevealedType,
@@ -3439,7 +3443,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                             }
                         }
                         KnownFunction::AssertType => {
-                            if let [actual_ty, asserted_ty] = binding.parameter_types() {
+                            if let [actual_ty, asserted_ty] = overload.parameter_types() {
                                 if !actual_ty.is_gradual_equivalent_to(self.db(), *asserted_ty) {
                                     self.context.report_lint(
                                             &TYPE_ASSERTION_FAILURE,
@@ -3454,7 +3458,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                             }
                         }
                         KnownFunction::StaticAssert => {
-                            if let Some((parameter_ty, message)) = binding.two_parameter_types() {
+                            if let Some((parameter_ty, message)) = overload.two_parameter_types() {
                                 let truthiness = match parameter_ty.try_bool(self.db()) {
                                     Ok(truthiness) => truthiness,
                                     Err(err) => {

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -3423,7 +3423,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                         continue;
                     };
 
-                    let Some(overload) = binding.matching_overload() else {
+                    let Some((_, overload)) = binding.matching_overload() else {
                         continue;
                     };
 

--- a/crates/red_knot_python_semantic/src/types/signatures.rs
+++ b/crates/red_knot_python_semantic/src/types/signatures.rs
@@ -32,6 +32,16 @@ impl<'db> Overloads<'db> {
             Overloads::Overloaded(signatures) => signatures.iter(),
         }
     }
+
+    /// Return a todo signature: (*args: Todo, **kwargs: Todo) -> Todo
+    #[allow(unused_variables)] // 'reason' only unused in debug builds
+    pub(crate) fn todo(reason: &'static str) -> Self {
+        let signature = Signature {
+            parameters: Parameters::todo(),
+            return_ty: Some(todo_type!(reason)),
+        };
+        signature.into()
+    }
 }
 
 impl<'db> From<Signature<'db>> for Overloads<'db> {
@@ -63,15 +73,6 @@ impl<'db> Signature<'db> {
         Self {
             parameters,
             return_ty,
-        }
-    }
-
-    /// Return a todo signature: (*args: Todo, **kwargs: Todo) -> Todo
-    #[allow(unused_variables)] // 'reason' only unused in debug builds
-    pub(crate) fn todo(reason: &'static str) -> Self {
-        Self {
-            parameters: Parameters::todo(),
-            return_ty: Some(todo_type!(reason)),
         }
     }
 
@@ -689,7 +690,7 @@ mod tests {
         .unwrap();
         let func = get_function_f(&db, "/src/a.py");
 
-        let expected_sig = Signature::todo("return type of decorated function").into();
+        let expected_sig = Overloads::todo("return type of decorated function");
 
         // With no decorators, internal and external signature are the same
         assert_eq!(func.signature(&db), &expected_sig);

--- a/crates/red_knot_python_semantic/src/types/signatures.rs
+++ b/crates/red_knot_python_semantic/src/types/signatures.rs
@@ -115,6 +115,22 @@ impl<'db> Parameters<'db> {
         Self(parameters.into_iter().collect())
     }
 
+    /// Return dynamic parameters: (*args: Any, **kwargs: Any)
+    pub(crate) fn any() -> Self {
+        Self(vec![
+            Parameter {
+                name: Some(Name::new_static("args")),
+                annotated_ty: Some(Type::any()),
+                kind: ParameterKind::Variadic,
+            },
+            Parameter {
+                name: Some(Name::new_static("kwargs")),
+                annotated_ty: Some(Type::any()),
+                kind: ParameterKind::KeywordVariadic,
+            },
+        ])
+    }
+
     /// Return todo parameters: (*args: Todo, **kwargs: Todo)
     fn todo() -> Self {
         Self(vec![


### PR DESCRIPTION
This updates the `Signature` and `CallBinding` machinery to support multiple overloads for a callable.  This is currently only used for `KnownFunction`s that we special-case in our type inference code.  It does **_not_** yet update the semantic index builder to handle `@overload` decorators and construct a multi-signature `Overloads` instance for real Python functions.

While I was here, I updated many of the `try_call` special cases to use signatures (possibly overloaded ones now) and `bind_call` to check parameter lists.  We still need some of the mutator methods on `OverloadBinding` for the special cases where we need to update return types based on some Rust code.