### PR TITLE
[flake8-bandit] Update insicure hash functions (S324)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_bandit/S324.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_bandit/S324.py
@@ -52,3 +52,12 @@ hashlib.new("Md5")
 
 # OK
 hashlib.new('Sha256')
+
+# From issue: https://github.com/astral-sh/ruff/issues/16572
+# Errors
+hashlib.new("md5  ")
+hashlib.new("sha-1")
+hashlib.new("ssl3-md5")
+hashlib.new("ssl3-sha1")
+hashlib.new("1.3.14.3.2.26")
+hashlib.new("1.2.840.113549.2.5")

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/hashlib_insecure_hash_functions.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/hashlib_insecure_hash_functions.rs
@@ -138,8 +138,16 @@ fn detect_insecure_hashlib_calls(
             // `hashlib.new` accepts mixed lowercase and uppercase names for hash
             // functions.
             if matches!(
-                hash_func_name.to_ascii_lowercase().as_str(),
-                "md4" | "md5" | "sha" | "sha1"
+                hash_func_name.to_ascii_lowercase().trim(),
+                "md4"
+                    | "md5"
+                    | "sha"
+                    | "sha1"
+                    | "sha-1"
+                    | "ssl3-md5"
+                    | "ssl3-sha1"
+                    | "1.3.14.3.2.26"
+                    | "1.2.840.113549.2.5"
             ) {
                 checker.report_diagnostic(Diagnostic::new(
                     HashlibInsecureHashFunction {

--- a/crates/ruff_linter/src/rules/flake8_bandit/snapshots/ruff_linter__rules__flake8_bandit__tests__S324_S324.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bandit/snapshots/ruff_linter__rules__flake8_bandit__tests__S324_S324.py.snap
@@ -205,3 +205,60 @@ S324.py:51:13: S324 Probable use of insecure hash functions in `hashlib`: `Md5`
 52 |
 53 | # OK
    |
+
+S324.py:58:13: S324 Probable use of insecure hash functions in `hashlib`: `md5  `
+   |
+56 | # From issue: https://github.com/astral-sh/ruff/issues/16572
+57 | # Errors
+58 | hashlib.new("md5  ")
+   |             ^^^^^^^ S324
+59 | hashlib.new("sha-1")
+60 | hashlib.new("ssl3-md5")
+   |
+
+S324.py:59:13: S324 Probable use of insecure hash functions in `hashlib`: `sha-1`
+   |
+57 | # Errors
+58 | hashlib.new("md5  ")
+59 | hashlib.new("sha-1")
+   |             ^^^^^^^ S324
+60 | hashlib.new("ssl3-md5")
+61 | hashlib.new("ssl3-sha1")
+   |
+
+S324.py:60:13: S324 Probable use of insecure hash functions in `hashlib`: `ssl3-md5`
+   |
+58 | hashlib.new("md5  ")
+59 | hashlib.new("sha-1")
+60 | hashlib.new("ssl3-md5")
+   |             ^^^^^^^^^^ S324
+61 | hashlib.new("ssl3-sha1")
+62 | hashlib.new("1.3.14.3.2.26")
+   |
+
+S324.py:61:13: S324 Probable use of insecure hash functions in `hashlib`: `ssl3-sha1`
+   |
+59 | hashlib.new("sha-1")
+60 | hashlib.new("ssl3-md5")
+61 | hashlib.new("ssl3-sha1")
+   |             ^^^^^^^^^^^ S324
+62 | hashlib.new("1.3.14.3.2.26")
+63 | hashlib.new("1.2.840.113549.2.5")
+   |
+
+S324.py:62:13: S324 Probable use of insecure hash functions in `hashlib`: `1.3.14.3.2.26`
+   |
+60 | hashlib.new("ssl3-md5")
+61 | hashlib.new("ssl3-sha1")
+62 | hashlib.new("1.3.14.3.2.26")
+   |             ^^^^^^^^^^^^^^^ S324
+63 | hashlib.new("1.2.840.113549.2.5")
+   |
+
+S324.py:63:13: S324 Probable use of insecure hash functions in `hashlib`: `1.2.840.113549.2.5`
+   |
+61 | hashlib.new("ssl3-sha1")
+62 | hashlib.new("1.3.14.3.2.26")
+63 | hashlib.new("1.2.840.113549.2.5")
+   |             ^^^^^^^^^^^^^^^^^^^^ S324
+   |


### PR DESCRIPTION
This PR solves issue #16572 

Could be an idea to define a HashSet containing the names of the insicure hash functions? In this way would be easier to update in case other insicure hash functions are added to the list.
