### PR TITLE
[syntax-errors] Improve error message and range for pre-PEP-614 decorator syntax errors

### DIFF
--- a/crates/ruff_python_parser/resources/inline/err/decorator_await_expression_py38.py
+++ b/crates/ruff_python_parser/resources/inline/err/decorator_await_expression_py38.py
@@ -1,0 +1,4 @@
+# parse_options: { "target-version": "3.8" }
+async def foo():
+    @await bar
+    def baz(): ...

--- a/crates/ruff_python_parser/resources/inline/err/decorator_dict_literal_py38.py
+++ b/crates/ruff_python_parser/resources/inline/err/decorator_dict_literal_py38.py
@@ -1,0 +1,3 @@
+# parse_options: { "target-version": "3.8" }
+@{3: 3}
+def bar(): ...

--- a/crates/ruff_python_parser/resources/inline/err/decorator_float_literal_py38.py
+++ b/crates/ruff_python_parser/resources/inline/err/decorator_float_literal_py38.py
@@ -1,0 +1,3 @@
+# parse_options: { "target-version": "3.8" }
+@3.14
+def bar(): ...

--- a/crates/ruff_python_parser/resources/inline/err/decorator_non_toplevel_call_expression_py38.py
+++ b/crates/ruff_python_parser/resources/inline/err/decorator_non_toplevel_call_expression_py38.py
@@ -1,0 +1,3 @@
+# parse_options: { "target-version": "3.8" }
+@foo().bar()
+def baz(): ...

--- a/crates/ruff_python_parser/resources/inline/ok/decorator_await_expression_py39.py
+++ b/crates/ruff_python_parser/resources/inline/ok/decorator_await_expression_py39.py
@@ -1,0 +1,4 @@
+# parse_options: { "target-version": "3.9" }
+async def foo():
+    @await bar
+    def baz(): ...

--- a/crates/ruff_python_parser/src/error.rs
+++ b/crates/ruff_python_parser/src/error.rs
@@ -557,7 +557,9 @@ pub enum UnsupportedSyntaxErrorKind {
     /// [PEP 614]: https://peps.python.org/pep-0614/
     /// [`dotted_name`]: https://docs.python.org/3.8/reference/compound_stmts.html#grammar-token-dotted-name
     /// [decorator grammar]: https://docs.python.org/3/reference/compound_stmts.html#grammar-token-python-grammar-decorator
-    RelaxedDecorator,
+    RelaxedDecorator {
+        invalid_node_name: &'static str,
+    },
 
     /// Represents the use of a [PEP 570] positional-only parameter before Python 3.8.
     ///
@@ -633,7 +635,14 @@ impl Display for UnsupportedSyntaxError {
             UnsupportedSyntaxErrorKind::StarTuple(StarTupleKind::Yield) => {
                 "Cannot use iterable unpacking in yield expressions"
             }
-            UnsupportedSyntaxErrorKind::RelaxedDecorator => "Unsupported expression in decorators",
+            UnsupportedSyntaxErrorKind::RelaxedDecorator { invalid_node_name } => {
+                return write!(
+                    f,
+                    "Cannot use {invalid_node_name} outside function-call arguments in a decorator \
+                    on Python {target_version} (syntax was added in Python 3.9)",
+                    target_version = self.target_version,
+                );
+            }
             UnsupportedSyntaxErrorKind::PositionalOnlyParameter => {
                 "Cannot use positional-only parameter separator"
             }
@@ -677,7 +686,9 @@ impl UnsupportedSyntaxErrorKind {
             UnsupportedSyntaxErrorKind::Walrus => Change::Added(PythonVersion::PY38),
             UnsupportedSyntaxErrorKind::ExceptStar => Change::Added(PythonVersion::PY311),
             UnsupportedSyntaxErrorKind::StarTuple(_) => Change::Added(PythonVersion::PY38),
-            UnsupportedSyntaxErrorKind::RelaxedDecorator => Change::Added(PythonVersion::PY39),
+            UnsupportedSyntaxErrorKind::RelaxedDecorator { .. } => {
+                Change::Added(PythonVersion::PY39)
+            }
             UnsupportedSyntaxErrorKind::PositionalOnlyParameter => {
                 Change::Added(PythonVersion::PY38)
             }

--- a/crates/ruff_python_parser/src/error.rs
+++ b/crates/ruff_python_parser/src/error.rs
@@ -638,9 +638,10 @@ impl Display for UnsupportedSyntaxError {
             UnsupportedSyntaxErrorKind::RelaxedDecorator { invalid_node_name } => {
                 return write!(
                     f,
-                    "Cannot use {invalid_node_name} outside function-call arguments in a decorator \
-                    on Python {target_version} (syntax was added in Python 3.9)",
+                    "Can only use {invalid_node_name} inside call expressions in a decorator \
+                    on Python {target_version} (relaxed decorator syntax was {changed})",
                     target_version = self.target_version,
+                    changed = self.kind.changed_version(),
                 );
             }
             UnsupportedSyntaxErrorKind::PositionalOnlyParameter => {

--- a/crates/ruff_python_parser/src/parser/helpers.rs
+++ b/crates/ruff_python_parser/src/parser/helpers.rs
@@ -1,7 +1,7 @@
 use ruff_python_ast::{self as ast, CmpOp, Expr, ExprContext, Number};
 use ruff_text_size::{Ranged, TextRange};
 
-use crate::TokenKind;
+use crate::{error::RelaxedDecoratorError, TokenKind};
 
 /// Set the `ctx` for `Expr::Id`, `Expr::Attribute`, `Expr::Subscript`, `Expr::Starred`,
 /// `Expr::Tuple` and `Expr::List`. If `expr` is either `Expr::Tuple` or `Expr::List`,
@@ -48,56 +48,56 @@ pub(super) const fn token_kind_to_cmp_op(tokens: [TokenKind; 2]) -> Option<CmpOp
 /// Helper for `parse_decorators` to determine if `expr` is a [`dotted_name`] from the decorator
 /// grammar before Python 3.9.
 ///
-/// Returns `None` if `expr` is a `dotted_name`. Returns `Some((description, range))` if it is not,
-/// where `description` is a string describing the invalid node and `range` is the node's range.
+/// Returns `Some((error, range))` if `expr` is not a `dotted_name`, or `None` if it is a `dotted_name`.
 ///
 /// [`dotted_name`]: https://docs.python.org/3.8/reference/compound_stmts.html#grammar-token-dotted-name
-pub(super) fn invalid_pre_py39_decorator_description_and_range(
+pub(super) fn detect_invalid_pre_py39_decorator_node(
     expr: &Expr,
-) -> Option<(&'static str, TextRange)> {
+) -> Option<(RelaxedDecoratorError, TextRange)> {
     let description = match expr {
-        Expr::Attribute(attr) => {
-            return invalid_pre_py39_decorator_description_and_range(&attr.value)
-        }
-
         Expr::Name(_) => return None,
 
+        Expr::Attribute(attribute) => {
+            return detect_invalid_pre_py39_decorator_node(&attribute.value)
+        }
+
+        Expr::Call(_) => return Some((RelaxedDecoratorError::CallExpression, expr.range())),
+
         Expr::NumberLiteral(number) => match &number.value {
-            Number::Int(_) => "int literals",
-            Number::Float(_) => "float literals",
-            Number::Complex { .. } => "complex literals",
+            Number::Int(_) => "an int literal",
+            Number::Float(_) => "a float literal",
+            Number::Complex { .. } => "a complex literal",
         },
 
-        Expr::BoolOp(_) => "boolean expressions",
-        Expr::BinOp(_) => "binary-operation expressions",
-        Expr::UnaryOp(_) => "unary-operation expressions",
-        Expr::Await(_) => "`await` expressions",
-        Expr::Lambda(_) => "lambda expressions",
-        Expr::If(_) => "conditional expressions",
-        Expr::Dict(_) => "dict literals",
-        Expr::Set(_) => "set literals",
-        Expr::List(_) => "list literals",
-        Expr::Tuple(_) => "tuple literals",
-        Expr::Starred(_) => "starred expressions",
-        Expr::Slice(_) => "slice expressions",
-        Expr::BytesLiteral(_) => "bytes literals",
-        Expr::StringLiteral(_) => "string literals",
-        Expr::EllipsisLiteral(_) => "ellipsis literals",
-        Expr::NoneLiteral(_) => "`None` literals",
-        Expr::BooleanLiteral(_) => "boolean literals",
-        Expr::ListComp(_) => "list comprehensions",
-        Expr::SetComp(_) => "set comprehensions",
-        Expr::DictComp(_) => "dict comprehensions",
-        Expr::Generator(_) => "generator expressions",
-        Expr::Yield(_) => "`yield` expressions",
-        Expr::YieldFrom(_) => "`yield from` expressions",
-        Expr::Compare(_) => "comparison expressions",
-        Expr::Call(_) => "function calls",
-        Expr::FString(_) => "f-strings",
-        Expr::Named(_) => "assignment expressions",
-        Expr::Subscript(_) => "subscript expressions",
-        Expr::IpyEscapeCommand(_) => "IPython escape commands",
+        Expr::BoolOp(_) => "boolean expression",
+        Expr::BinOp(_) => "binary-operation expression",
+        Expr::UnaryOp(_) => "unary-operation expression",
+        Expr::Await(_) => "`await` expression",
+        Expr::Lambda(_) => "lambda expression",
+        Expr::If(_) => "conditional expression",
+        Expr::Dict(_) => "a dict literal",
+        Expr::Set(_) => "a set literal",
+        Expr::List(_) => "a list literal",
+        Expr::Tuple(_) => "a tuple literal",
+        Expr::Starred(_) => "starred expression",
+        Expr::Slice(_) => "slice expression",
+        Expr::BytesLiteral(_) => "a bytes literal",
+        Expr::StringLiteral(_) => "a string literal",
+        Expr::EllipsisLiteral(_) => "an ellipsis literal",
+        Expr::NoneLiteral(_) => "a `None` literal",
+        Expr::BooleanLiteral(_) => "a boolean literal",
+        Expr::ListComp(_) => "a list comprehension",
+        Expr::SetComp(_) => "a set comprehension",
+        Expr::DictComp(_) => "a dict comprehension",
+        Expr::Generator(_) => "generator expression",
+        Expr::Yield(_) => "`yield` expression",
+        Expr::YieldFrom(_) => "`yield from` expression",
+        Expr::Compare(_) => "comparison expression",
+        Expr::FString(_) => "f-string",
+        Expr::Named(_) => "assignment expression",
+        Expr::Subscript(_) => "subscript expression",
+        Expr::IpyEscapeCommand(_) => "IPython escape command",
     };
 
-    Some((description, expr.range()))
+    Some((RelaxedDecoratorError::Other(description), expr.range()))
 }

--- a/crates/ruff_python_parser/src/parser/helpers.rs
+++ b/crates/ruff_python_parser/src/parser/helpers.rs
@@ -52,48 +52,52 @@ pub(super) const fn token_kind_to_cmp_op(tokens: [TokenKind; 2]) -> Option<CmpOp
 /// where `description` is a string describing the invalid node and `range` is the node's range.
 ///
 /// [`dotted_name`]: https://docs.python.org/3.8/reference/compound_stmts.html#grammar-token-dotted-name
-pub(super) fn invalid_pre_py39_decorator_node(expr: &Expr) -> Option<(&'static str, TextRange)> {
+pub(super) fn invalid_pre_py39_decorator_description_and_range(
+    expr: &Expr,
+) -> Option<(&'static str, TextRange)> {
     let description = match expr {
-        Expr::Attribute(attr) => return invalid_pre_py39_decorator_node(&attr.value),
+        Expr::Attribute(attr) => {
+            return invalid_pre_py39_decorator_description_and_range(&attr.value)
+        }
 
-        Expr::Name(_) => None,
+        Expr::Name(_) => return None,
 
         Expr::NumberLiteral(number) => match &number.value {
-            Number::Int(_) => Some("an int literal"),
-            Number::Float(_) => Some("a float literal"),
-            Number::Complex { .. } => Some("a complex literal"),
+            Number::Int(_) => "int literals",
+            Number::Float(_) => "float literals",
+            Number::Complex { .. } => "complex literals",
         },
 
-        Expr::BoolOp(_) => Some("boolean expression"),
-        Expr::BinOp(_) => Some("binary-operation expression"),
-        Expr::UnaryOp(_) => Some("unary-operation expression"),
-        Expr::Await(_) => Some("`await` expression"),
-        Expr::Lambda(_) => Some("lambda expression"),
-        Expr::If(_) => Some("conditional expression"),
-        Expr::Dict(_) => Some("a dict literal"),
-        Expr::Set(_) => Some("a set literal"),
-        Expr::List(_) => Some("a list literal"),
-        Expr::Tuple(_) => Some("a tuple literal"),
-        Expr::Starred(_) => Some("starred expression"),
-        Expr::Slice(_) => Some("slice expression"),
-        Expr::BytesLiteral(_) => Some("bytes literal"),
-        Expr::StringLiteral(_) => Some("string literal"),
-        Expr::EllipsisLiteral(_) => Some("ellipsis literal"),
-        Expr::NoneLiteral(_) => Some("`None` literal"),
-        Expr::BooleanLiteral(_) => Some("boolean literal"),
-        Expr::ListComp(_) => Some("list comprehension"),
-        Expr::SetComp(_) => Some("set comprehension"),
-        Expr::DictComp(_) => Some("dict comprehension"),
-        Expr::Generator(_) => Some("generator expression"),
-        Expr::Yield(_) => Some("`yield` expression"),
-        Expr::YieldFrom(_) => Some("`yield from` expression"),
-        Expr::Compare(_) => Some("comparison expression"),
-        Expr::Call(_) => Some("function call"),
-        Expr::FString(_) => Some("f-string"),
-        Expr::Named(_) => Some("assignment expression"),
-        Expr::Subscript(_) => Some("subscript expression"),
-        Expr::IpyEscapeCommand(_) => Some("IPython escape command"),
+        Expr::BoolOp(_) => "boolean expressions",
+        Expr::BinOp(_) => "binary-operation expressions",
+        Expr::UnaryOp(_) => "unary-operation expressions",
+        Expr::Await(_) => "`await` expressions",
+        Expr::Lambda(_) => "lambda expressions",
+        Expr::If(_) => "conditional expressions",
+        Expr::Dict(_) => "dict literals",
+        Expr::Set(_) => "set literals",
+        Expr::List(_) => "list literals",
+        Expr::Tuple(_) => "tuple literals",
+        Expr::Starred(_) => "starred expressions",
+        Expr::Slice(_) => "slice expressions",
+        Expr::BytesLiteral(_) => "bytes literals",
+        Expr::StringLiteral(_) => "string literals",
+        Expr::EllipsisLiteral(_) => "ellipsis literals",
+        Expr::NoneLiteral(_) => "`None` literals",
+        Expr::BooleanLiteral(_) => "boolean literals",
+        Expr::ListComp(_) => "list comprehensions",
+        Expr::SetComp(_) => "set comprehensions",
+        Expr::DictComp(_) => "dict comprehensions",
+        Expr::Generator(_) => "generator expressions",
+        Expr::Yield(_) => "`yield` expressions",
+        Expr::YieldFrom(_) => "`yield from` expressions",
+        Expr::Compare(_) => "comparison expressions",
+        Expr::Call(_) => "function calls",
+        Expr::FString(_) => "f-strings",
+        Expr::Named(_) => "assignment expressions",
+        Expr::Subscript(_) => "subscript expressions",
+        Expr::IpyEscapeCommand(_) => "IPython escape commands",
     };
 
-    description.map(|description| (description, expr.range()))
+    Some((description, expr.range()))
 }

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -2678,17 +2678,42 @@ impl<'src> Parser<'src> {
                 // # parse_options: { "target-version": "3.7" }
                 // @(x := lambda x: x)(foo)
                 // def bar(): ...
-                let allowed_decorator = match &parsed_expr.expr {
+
+                // test_err decorator_dict_literal_py38
+                // # parse_options: { "target-version": "3.8" }
+                // @{3: 3}
+                // def bar(): ...
+
+                // test_err decorator_float_literal_py38
+                // # parse_options: { "target-version": "3.8" }
+                // @3.14
+                // def bar(): ...
+
+                // test_ok decorator_await_expression_py39
+                // # parse_options: { "target-version": "3.9" }
+                // async def foo():
+                //     @await bar
+                //     def baz(): ...
+
+                // test_err decorator_await_expression_py38
+                // # parse_options: { "target-version": "3.8" }
+                // async def foo():
+                //     @await bar
+                //     def baz(): ...
+
+                let disallowed_expression = match &parsed_expr.expr {
                     Expr::Call(expr_call) => {
-                        helpers::is_name_or_attribute_expression(&expr_call.func)
+                        helpers::invalid_pre_py39_decorator_node(&expr_call.func)
                     }
-                    expr => helpers::is_name_or_attribute_expression(expr),
+                    expr => helpers::invalid_pre_py39_decorator_node(expr),
                 };
 
-                if !allowed_decorator {
+                if let Some((description, range)) = disallowed_expression {
                     self.add_unsupported_syntax_error(
-                        UnsupportedSyntaxErrorKind::RelaxedDecorator,
-                        parsed_expr.range(),
+                        UnsupportedSyntaxErrorKind::RelaxedDecorator {
+                            invalid_node_name: description,
+                        },
+                        range,
                     );
                 }
             }

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -2701,18 +2701,21 @@ impl<'src> Parser<'src> {
                 //     @await bar
                 //     def baz(): ...
 
-                let disallowed_expression = match &parsed_expr.expr {
+                // test_err decorator_non_toplevel_call_expression_py38
+                // # parse_options: { "target-version": "3.8" }
+                // @foo().bar()
+                // def baz(): ...
+
+                let relaxed_decorator_error = match &parsed_expr.expr {
                     Expr::Call(expr_call) => {
-                        helpers::invalid_pre_py39_decorator_description_and_range(&expr_call.func)
+                        helpers::detect_invalid_pre_py39_decorator_node(&expr_call.func)
                     }
-                    expr => helpers::invalid_pre_py39_decorator_description_and_range(expr),
+                    expr => helpers::detect_invalid_pre_py39_decorator_node(expr),
                 };
 
-                if let Some((description, range)) = disallowed_expression {
+                if let Some((error, range)) = relaxed_decorator_error {
                     self.add_unsupported_syntax_error(
-                        UnsupportedSyntaxErrorKind::RelaxedDecorator {
-                            invalid_node_name: description,
-                        },
+                        UnsupportedSyntaxErrorKind::RelaxedDecorator(error),
                         range,
                     );
                 }

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -2703,9 +2703,9 @@ impl<'src> Parser<'src> {
 
                 let disallowed_expression = match &parsed_expr.expr {
                     Expr::Call(expr_call) => {
-                        helpers::invalid_pre_py39_decorator_node(&expr_call.func)
+                        helpers::invalid_pre_py39_decorator_description_and_range(&expr_call.func)
                     }
-                    expr => helpers::invalid_pre_py39_decorator_node(expr),
+                    expr => helpers::invalid_pre_py39_decorator_description_and_range(expr),
                 };
 
                 if let Some((description, range)) = disallowed_expression {

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@decorator_await_expression_py38.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@decorator_await_expression_py38.py.snap
@@ -91,6 +91,6 @@ Module(
 1 | # parse_options: { "target-version": "3.8" }
 2 | async def foo():
 3 |     @await bar
-  |      ^^^^^^^^^ Syntax Error: Cannot use `await` expression outside function-call arguments in a decorator on Python 3.8 (syntax was added in Python 3.9)
+  |      ^^^^^^^^^ Syntax Error: Cannot use `await` expression outside function call arguments in a decorator on Python 3.8 (syntax was added in Python 3.9)
 4 |     def baz(): ...
   |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@decorator_await_expression_py38.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@decorator_await_expression_py38.py.snap
@@ -1,0 +1,96 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/inline/err/decorator_await_expression_py38.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..96,
+        body: [
+            FunctionDef(
+                StmtFunctionDef {
+                    range: 45..95,
+                    is_async: true,
+                    decorator_list: [],
+                    name: Identifier {
+                        id: Name("foo"),
+                        range: 55..58,
+                    },
+                    type_params: None,
+                    parameters: Parameters {
+                        range: 58..60,
+                        posonlyargs: [],
+                        args: [],
+                        vararg: None,
+                        kwonlyargs: [],
+                        kwarg: None,
+                    },
+                    returns: None,
+                    body: [
+                        FunctionDef(
+                            StmtFunctionDef {
+                                range: 66..95,
+                                is_async: false,
+                                decorator_list: [
+                                    Decorator {
+                                        range: 66..76,
+                                        expression: Await(
+                                            ExprAwait {
+                                                range: 67..76,
+                                                value: Name(
+                                                    ExprName {
+                                                        range: 73..76,
+                                                        id: Name("bar"),
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                ],
+                                name: Identifier {
+                                    id: Name("baz"),
+                                    range: 85..88,
+                                },
+                                type_params: None,
+                                parameters: Parameters {
+                                    range: 88..90,
+                                    posonlyargs: [],
+                                    args: [],
+                                    vararg: None,
+                                    kwonlyargs: [],
+                                    kwarg: None,
+                                },
+                                returns: None,
+                                body: [
+                                    Expr(
+                                        StmtExpr {
+                                            range: 92..95,
+                                            value: EllipsisLiteral(
+                                                ExprEllipsisLiteral {
+                                                    range: 92..95,
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    ],
+                },
+            ),
+        ],
+    },
+)
+```
+## Unsupported Syntax Errors
+
+  |
+1 | # parse_options: { "target-version": "3.8" }
+2 | async def foo():
+3 |     @await bar
+  |      ^^^^^^^^^ Syntax Error: Cannot use `await` expression outside function-call arguments in a decorator on Python 3.8 (syntax was added in Python 3.9)
+4 |     def baz(): ...
+  |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@decorator_dict_literal_py38.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@decorator_dict_literal_py38.py.snap
@@ -1,0 +1,87 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/inline/err/decorator_dict_literal_py38.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..68,
+        body: [
+            FunctionDef(
+                StmtFunctionDef {
+                    range: 45..67,
+                    is_async: false,
+                    decorator_list: [
+                        Decorator {
+                            range: 45..52,
+                            expression: Dict(
+                                ExprDict {
+                                    range: 46..52,
+                                    items: [
+                                        DictItem {
+                                            key: Some(
+                                                NumberLiteral(
+                                                    ExprNumberLiteral {
+                                                        range: 47..48,
+                                                        value: Int(
+                                                            3,
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                            value: NumberLiteral(
+                                                ExprNumberLiteral {
+                                                    range: 50..51,
+                                                    value: Int(
+                                                        3,
+                                                    ),
+                                                },
+                                            ),
+                                        },
+                                    ],
+                                },
+                            ),
+                        },
+                    ],
+                    name: Identifier {
+                        id: Name("bar"),
+                        range: 57..60,
+                    },
+                    type_params: None,
+                    parameters: Parameters {
+                        range: 60..62,
+                        posonlyargs: [],
+                        args: [],
+                        vararg: None,
+                        kwonlyargs: [],
+                        kwarg: None,
+                    },
+                    returns: None,
+                    body: [
+                        Expr(
+                            StmtExpr {
+                                range: 64..67,
+                                value: EllipsisLiteral(
+                                    ExprEllipsisLiteral {
+                                        range: 64..67,
+                                    },
+                                ),
+                            },
+                        ),
+                    ],
+                },
+            ),
+        ],
+    },
+)
+```
+## Unsupported Syntax Errors
+
+  |
+1 | # parse_options: { "target-version": "3.8" }
+2 | @{3: 3}
+  |  ^^^^^^ Syntax Error: Cannot use a dict literal outside function-call arguments in a decorator on Python 3.8 (syntax was added in Python 3.9)
+3 | def bar(): ...
+  |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@decorator_dict_literal_py38.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@decorator_dict_literal_py38.py.snap
@@ -82,6 +82,6 @@ Module(
   |
 1 | # parse_options: { "target-version": "3.8" }
 2 | @{3: 3}
-  |  ^^^^^^ Syntax Error: Cannot use a dict literal outside function-call arguments in a decorator on Python 3.8 (syntax was added in Python 3.9)
+  |  ^^^^^^ Syntax Error: Cannot use a dict literal outside function call arguments in a decorator on Python 3.8 (syntax was added in Python 3.9)
 3 | def bar(): ...
   |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@decorator_expression_py38.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@decorator_expression_py38.py.snap
@@ -96,6 +96,6 @@ Module(
   |
 1 | # parse_options: { "target-version": "3.8" }
 2 | @buttons[0].clicked.connect
-  |  ^^^^^^^^^^ Syntax Error: Cannot use subscript expression outside function-call arguments in a decorator on Python 3.8 (syntax was added in Python 3.9)
+  |  ^^^^^^^^^^ Syntax Error: Cannot use subscript expression outside function call arguments in a decorator on Python 3.8 (syntax was added in Python 3.9)
 3 | def spam(): ...
   |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@decorator_expression_py38.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@decorator_expression_py38.py.snap
@@ -96,6 +96,6 @@ Module(
   |
 1 | # parse_options: { "target-version": "3.8" }
 2 | @buttons[0].clicked.connect
-  |  ^^^^^^^^^^^^^^^^^^^^^^^^^^ Syntax Error: Unsupported expression in decorators on Python 3.8 (syntax was added in Python 3.9)
+  |  ^^^^^^^^^^ Syntax Error: Cannot use subscript expression outside function-call arguments in a decorator on Python 3.8 (syntax was added in Python 3.9)
 3 | def spam(): ...
   |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@decorator_float_literal_py38.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@decorator_float_literal_py38.py.snap
@@ -63,6 +63,6 @@ Module(
   |
 1 | # parse_options: { "target-version": "3.8" }
 2 | @3.14
-  |  ^^^^ Syntax Error: Cannot use a float literal outside function-call arguments in a decorator on Python 3.8 (syntax was added in Python 3.9)
+  |  ^^^^ Syntax Error: Cannot use a float literal outside function call arguments in a decorator on Python 3.8 (syntax was added in Python 3.9)
 3 | def bar(): ...
   |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@decorator_float_literal_py38.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@decorator_float_literal_py38.py.snap
@@ -1,0 +1,68 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/inline/err/decorator_float_literal_py38.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..66,
+        body: [
+            FunctionDef(
+                StmtFunctionDef {
+                    range: 45..65,
+                    is_async: false,
+                    decorator_list: [
+                        Decorator {
+                            range: 45..50,
+                            expression: NumberLiteral(
+                                ExprNumberLiteral {
+                                    range: 46..50,
+                                    value: Float(
+                                        3.14,
+                                    ),
+                                },
+                            ),
+                        },
+                    ],
+                    name: Identifier {
+                        id: Name("bar"),
+                        range: 55..58,
+                    },
+                    type_params: None,
+                    parameters: Parameters {
+                        range: 58..60,
+                        posonlyargs: [],
+                        args: [],
+                        vararg: None,
+                        kwonlyargs: [],
+                        kwarg: None,
+                    },
+                    returns: None,
+                    body: [
+                        Expr(
+                            StmtExpr {
+                                range: 62..65,
+                                value: EllipsisLiteral(
+                                    ExprEllipsisLiteral {
+                                        range: 62..65,
+                                    },
+                                ),
+                            },
+                        ),
+                    ],
+                },
+            ),
+        ],
+    },
+)
+```
+## Unsupported Syntax Errors
+
+  |
+1 | # parse_options: { "target-version": "3.8" }
+2 | @3.14
+  |  ^^^^ Syntax Error: Cannot use a float literal outside function-call arguments in a decorator on Python 3.8 (syntax was added in Python 3.9)
+3 | def bar(): ...
+  |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@decorator_named_expression_py37.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@decorator_named_expression_py37.py.snap
@@ -128,6 +128,6 @@ Module(
   |
 1 | # parse_options: { "target-version": "3.7" }
 2 | @(x := lambda x: x)(foo)
-  |  ^^^^^^^^^^^^^^^^^^^^^^^ Syntax Error: Unsupported expression in decorators on Python 3.7 (syntax was added in Python 3.9)
+  |   ^^^^^^^^^^^^^^^^ Syntax Error: Cannot use assignment expression outside function-call arguments in a decorator on Python 3.7 (syntax was added in Python 3.9)
 3 | def bar(): ...
   |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@decorator_named_expression_py37.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@decorator_named_expression_py37.py.snap
@@ -128,6 +128,6 @@ Module(
   |
 1 | # parse_options: { "target-version": "3.7" }
 2 | @(x := lambda x: x)(foo)
-  |   ^^^^^^^^^^^^^^^^ Syntax Error: Cannot use assignment expression outside function-call arguments in a decorator on Python 3.7 (syntax was added in Python 3.9)
+  |   ^^^^^^^^^^^^^^^^ Syntax Error: Cannot use assignment expression outside function call arguments in a decorator on Python 3.7 (syntax was added in Python 3.9)
 3 | def bar(): ...
   |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@decorator_non_toplevel_call_expression_py38.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@decorator_non_toplevel_call_expression_py38.py.snap
@@ -1,0 +1,97 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/inline/err/decorator_non_toplevel_call_expression_py38.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..73,
+        body: [
+            FunctionDef(
+                StmtFunctionDef {
+                    range: 45..72,
+                    is_async: false,
+                    decorator_list: [
+                        Decorator {
+                            range: 45..57,
+                            expression: Call(
+                                ExprCall {
+                                    range: 46..57,
+                                    func: Attribute(
+                                        ExprAttribute {
+                                            range: 46..55,
+                                            value: Call(
+                                                ExprCall {
+                                                    range: 46..51,
+                                                    func: Name(
+                                                        ExprName {
+                                                            range: 46..49,
+                                                            id: Name("foo"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    arguments: Arguments {
+                                                        range: 49..51,
+                                                        args: [],
+                                                        keywords: [],
+                                                    },
+                                                },
+                                            ),
+                                            attr: Identifier {
+                                                id: Name("bar"),
+                                                range: 52..55,
+                                            },
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    arguments: Arguments {
+                                        range: 55..57,
+                                        args: [],
+                                        keywords: [],
+                                    },
+                                },
+                            ),
+                        },
+                    ],
+                    name: Identifier {
+                        id: Name("baz"),
+                        range: 62..65,
+                    },
+                    type_params: None,
+                    parameters: Parameters {
+                        range: 65..67,
+                        posonlyargs: [],
+                        args: [],
+                        vararg: None,
+                        kwonlyargs: [],
+                        kwarg: None,
+                    },
+                    returns: None,
+                    body: [
+                        Expr(
+                            StmtExpr {
+                                range: 69..72,
+                                value: EllipsisLiteral(
+                                    ExprEllipsisLiteral {
+                                        range: 69..72,
+                                    },
+                                ),
+                            },
+                        ),
+                    ],
+                },
+            ),
+        ],
+    },
+)
+```
+## Unsupported Syntax Errors
+
+  |
+1 | # parse_options: { "target-version": "3.8" }
+2 | @foo().bar()
+  |  ^^^^^ Syntax Error: Cannot use a call expression in a decorator on Python 3.8 unless it is the top-level expression or it occurs in the argument list of a top-level call expression (relaxed decorator syntax was added in Python 3.9)
+3 | def baz(): ...
+  |

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@decorator_await_expression_py39.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@decorator_await_expression_py39.py.snap
@@ -1,0 +1,87 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/inline/ok/decorator_await_expression_py39.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..96,
+        body: [
+            FunctionDef(
+                StmtFunctionDef {
+                    range: 45..95,
+                    is_async: true,
+                    decorator_list: [],
+                    name: Identifier {
+                        id: Name("foo"),
+                        range: 55..58,
+                    },
+                    type_params: None,
+                    parameters: Parameters {
+                        range: 58..60,
+                        posonlyargs: [],
+                        args: [],
+                        vararg: None,
+                        kwonlyargs: [],
+                        kwarg: None,
+                    },
+                    returns: None,
+                    body: [
+                        FunctionDef(
+                            StmtFunctionDef {
+                                range: 66..95,
+                                is_async: false,
+                                decorator_list: [
+                                    Decorator {
+                                        range: 66..76,
+                                        expression: Await(
+                                            ExprAwait {
+                                                range: 67..76,
+                                                value: Name(
+                                                    ExprName {
+                                                        range: 73..76,
+                                                        id: Name("bar"),
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                ],
+                                name: Identifier {
+                                    id: Name("baz"),
+                                    range: 85..88,
+                                },
+                                type_params: None,
+                                parameters: Parameters {
+                                    range: 88..90,
+                                    posonlyargs: [],
+                                    args: [],
+                                    vararg: None,
+                                    kwonlyargs: [],
+                                    kwarg: None,
+                                },
+                                returns: None,
+                                body: [
+                                    Expr(
+                                        StmtExpr {
+                                            range: 92..95,
+                                            value: EllipsisLiteral(
+                                                ExprEllipsisLiteral {
+                                                    range: 92..95,
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    ],
+                },
+            ),
+        ],
+    },
+)
+```


### PR DESCRIPTION
## Summary

A small followup to https://github.com/astral-sh/ruff/pull/16386. We now tell the user exactly what it was about their decorator that constituted invalid syntax on Python <3.9, and the range now highlights the specific sub-expression that is invalid rather than highlighting the whole decorator

## Test Plan

Inline snapshots are updated, and new ones are added.
