### PR TITLE
[red-knot] Do not ignore typeshed stubs for 'venv' module

### DIFF
--- a/crates/red_knot_vendored/.gitignore
+++ b/crates/red_knot_vendored/.gitignore
@@ -1,0 +1,4 @@
+# Do not ignore any of the vendored files. If this pattern is not present,
+# we will gitignore the `venv/` stubs in typeshed, as there is a general
+# rule to ignore `venv/` directories in the root `.gitignore`.
+!/vendor/typeshed/**/*

--- a/crates/red_knot_vendored/vendor/typeshed/stdlib/venv/__init__.pyi
+++ b/crates/red_knot_vendored/vendor/typeshed/stdlib/venv/__init__.pyi
@@ -1,0 +1,107 @@
+import logging
+import sys
+from _typeshed import StrOrBytesPath
+from collections.abc import Iterable, Sequence
+from types import SimpleNamespace
+
+logger: logging.Logger
+
+if sys.version_info >= (3, 9):
+    CORE_VENV_DEPS: tuple[str, ...]
+
+class EnvBuilder:
+    system_site_packages: bool
+    clear: bool
+    symlinks: bool
+    upgrade: bool
+    with_pip: bool
+    prompt: str | None
+
+    if sys.version_info >= (3, 13):
+        def __init__(
+            self,
+            system_site_packages: bool = False,
+            clear: bool = False,
+            symlinks: bool = False,
+            upgrade: bool = False,
+            with_pip: bool = False,
+            prompt: str | None = None,
+            upgrade_deps: bool = False,
+            *,
+            scm_ignore_files: Iterable[str] = ...,
+        ) -> None: ...
+    elif sys.version_info >= (3, 9):
+        def __init__(
+            self,
+            system_site_packages: bool = False,
+            clear: bool = False,
+            symlinks: bool = False,
+            upgrade: bool = False,
+            with_pip: bool = False,
+            prompt: str | None = None,
+            upgrade_deps: bool = False,
+        ) -> None: ...
+    else:
+        def __init__(
+            self,
+            system_site_packages: bool = False,
+            clear: bool = False,
+            symlinks: bool = False,
+            upgrade: bool = False,
+            with_pip: bool = False,
+            prompt: str | None = None,
+        ) -> None: ...
+
+    def create(self, env_dir: StrOrBytesPath) -> None: ...
+    def clear_directory(self, path: StrOrBytesPath) -> None: ...  # undocumented
+    def ensure_directories(self, env_dir: StrOrBytesPath) -> SimpleNamespace: ...
+    def create_configuration(self, context: SimpleNamespace) -> None: ...
+    def symlink_or_copy(
+        self, src: StrOrBytesPath, dst: StrOrBytesPath, relative_symlinks_ok: bool = False
+    ) -> None: ...  # undocumented
+    def setup_python(self, context: SimpleNamespace) -> None: ...
+    def _setup_pip(self, context: SimpleNamespace) -> None: ...  # undocumented
+    def setup_scripts(self, context: SimpleNamespace) -> None: ...
+    def post_setup(self, context: SimpleNamespace) -> None: ...
+    def replace_variables(self, text: str, context: SimpleNamespace) -> str: ...  # undocumented
+    def install_scripts(self, context: SimpleNamespace, path: str) -> None: ...
+    if sys.version_info >= (3, 9):
+        def upgrade_dependencies(self, context: SimpleNamespace) -> None: ...
+    if sys.version_info >= (3, 13):
+        def create_git_ignore_file(self, context: SimpleNamespace) -> None: ...
+
+if sys.version_info >= (3, 13):
+    def create(
+        env_dir: StrOrBytesPath,
+        system_site_packages: bool = False,
+        clear: bool = False,
+        symlinks: bool = False,
+        with_pip: bool = False,
+        prompt: str | None = None,
+        upgrade_deps: bool = False,
+        *,
+        scm_ignore_files: Iterable[str] = ...,
+    ) -> None: ...
+
+elif sys.version_info >= (3, 9):
+    def create(
+        env_dir: StrOrBytesPath,
+        system_site_packages: bool = False,
+        clear: bool = False,
+        symlinks: bool = False,
+        with_pip: bool = False,
+        prompt: str | None = None,
+        upgrade_deps: bool = False,
+    ) -> None: ...
+
+else:
+    def create(
+        env_dir: StrOrBytesPath,
+        system_site_packages: bool = False,
+        clear: bool = False,
+        symlinks: bool = False,
+        with_pip: bool = False,
+        prompt: str | None = None,
+    ) -> None: ...
+
+def main(args: Sequence[str] | None = None) -> None: ...


### PR DESCRIPTION
## Summary

We currently fail to add the stubs for the [`venv` stdlib module](https://github.com/python/typeshed/blob/main/stdlib/venv/__init__.pyi) because there is a [`venv/` ignore pattern](https://github.com/astral-sh/ruff/blob/b6c7ba4f8ee53fa5831ed5f94fc3ebf441353800/.gitignore#L181) in the top-level `.gitignore` file.

Another solution would be to remove the top-level `.gitignore` pattern. I'm personally not a big fan of such tool-specific ignore patterns, and I am even less of a fan of broad patterns like "venv", ["dist", "build", "downloads", "lib" or "parts"](https://github.com/astral-sh/ruff/blob/b6c7ba4f8ee53fa5831ed5f94fc3ebf441353800/.gitignore#L63-L81). I have seen them cause annoying-to-debug problems way too often. But I wasn't sure if anyone relied on these.

## Test Plan

Ran the typeshed sync workflow manually once to see if the `venv/` folder is now correctly added.
