### PR TITLE
[formatter] Stabilize fix for single-with-item formatting with trailing comment

### DIFF
--- a/crates/ruff_python_formatter/src/other/with_item.rs
+++ b/crates/ruff_python_formatter/src/other/with_item.rs
@@ -6,7 +6,6 @@ use crate::expression::parentheses::{
     is_expression_parenthesized, parenthesized, Parentheses, Parenthesize,
 };
 use crate::prelude::*;
-use crate::preview::is_with_single_target_parentheses_enabled;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum WithItemLayout {
@@ -118,11 +117,7 @@ impl FormatNodeRule<WithItem> for FormatWithItem {
                 // ...except if the with item is parenthesized and it's not the only with item or it has a target.
                 // Then use the context expression as a preferred breaking point.
                 let prefer_breaking_context_expression =
-                    if is_with_single_target_parentheses_enabled(f.context()) {
-                        (optional_vars.is_some() || !single) && is_parenthesized
-                    } else {
-                        is_parenthesized
-                    };
+                    (optional_vars.is_some() || !single) && is_parenthesized;
 
                 if prefer_breaking_context_expression {
                     maybe_parenthesize_expression(

--- a/crates/ruff_python_formatter/src/preview.rs
+++ b/crates/ruff_python_formatter/src/preview.rs
@@ -13,10 +13,3 @@ pub(crate) const fn is_hug_parens_with_braces_and_square_brackets_enabled(
 ) -> bool {
     context.is_preview()
 }
-
-/// Returns `true` if the bugfix for single-with items with a trailing comment targeting Python 3.9 or newer is enabled.
-///
-/// See [#14001](https://github.com/astral-sh/ruff/issues/14001)
-pub(crate) fn is_with_single_target_parentheses_enabled(context: &PyFormatContext) -> bool {
-    context.is_preview()
-}

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__with.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__with.py.snap
@@ -771,110 +771,39 @@ if True:
 
 # Regression test for https://github.com/astral-sh/ruff/issues/14001
 with (
-    (
-        open(
-            "some/path.txt",
-            "rb",
-        )
-        if True
-        else open("other/path.txt")
+    open(
+        "some/path.txt",
+        "rb",
     )
+    if True
+    else open("other/path.txt")
     # Bar
 ):
     pass
 
 
 with (  # trailing comment
-    (
-        open(
-            "some/path.txt",
-            "rb",
-        )
-        if True
-        else open("other/path.txt")
+    open(
+        "some/path.txt",
+        "rb",
     )
+    if True
+    else open("other/path.txt")
     # Bar
 ):
     pass
 
 
 with (
-    (
-        open(
-            "some/path.txt",
-            "rb",
-        )
-        if True
-        else open("other/path.txt")
+    open(
+        "some/path.txt",
+        "rb",
     )
+    if True
+    else open("other/path.txt")
     # Bar
 ):
     pass
-```
-
-
-#### Preview changes
-```diff
---- Stable
-+++ Preview
-@@ -377,42 +377,36 @@
- 
- # Regression test for https://github.com/astral-sh/ruff/issues/14001
- with (
--    (
--        open(
--            "some/path.txt",
--            "rb",
--        )
--        if True
--        else open("other/path.txt")
-+    open(
-+        "some/path.txt",
-+        "rb",
-     )
-+    if True
-+    else open("other/path.txt")
-     # Bar
- ):
-     pass
- 
- 
- with (  # trailing comment
--    (
--        open(
--            "some/path.txt",
--            "rb",
--        )
--        if True
--        else open("other/path.txt")
-+    open(
-+        "some/path.txt",
-+        "rb",
-     )
-+    if True
-+    else open("other/path.txt")
-     # Bar
- ):
-     pass
- 
- 
- with (
--    (
--        open(
--            "some/path.txt",
--            "rb",
--        )
--        if True
--        else open("other/path.txt")
-+    open(
-+        "some/path.txt",
-+        "rb",
-     )
-+    if True
-+    else open("other/path.txt")
-     # Bar
- ):
-     pass
 ```
 
 


### PR DESCRIPTION
## Summary

This PR stabilizies the fix for https://github.com/astral-sh/ruff/issues/14001

We try to only make breaking formatting changes once a year. However,
the plan was to release this fix as part of Ruff 0.9 but I somehow missed it when promoting all other formatter changes. 
I think it's worth making an exception here considering that this is a bug fix, it improves readability, and it should be rare
(very few files in a single project). Our version policy explicitly allows breaking formatter changes in any minor release and the idea of only making breaking formatter changes once a year is mainly to avoid multiple releases throughout the year that introduce large formatter changes

Closes https://github.com/astral-sh/ruff/issues/14001

## Test Plan

Updated snapshot
