### PR TITLE
[red-knot] Add tests asserting that `KnownClass::to_instance()` doesn't unexpectedly fallback to `Type::Unknown` with full typeshed stubs

### DIFF
--- a/crates/red_knot_python_semantic/src/types/class.rs
+++ b/crates/red_knot_python_semantic/src/types/class.rs
@@ -1641,24 +1641,16 @@ mod tests {
     fn known_class_doesnt_fallback_to_unknown_unexpectedly_on_low_python_version() {
         let mut db = setup_db();
 
-        Program::get(&db)
-            .set_python_version(&mut db)
-            .to(PythonVersion::PY37);
-
         for class in KnownClass::iter() {
-            let current_version = Program::get(&db).python_version(&db);
-
             let version_added = match class {
                 KnownClass::BaseExceptionGroup => PythonVersion::PY311,
                 KnownClass::GenericAlias => PythonVersion::PY39,
                 _ => PythonVersion::PY37,
             };
 
-            if current_version != version_added {
-                Program::get(&db)
-                    .set_python_version(&mut db)
-                    .to(version_added);
-            }
+            Program::get(&db)
+                .set_python_version(&mut db)
+                .to(version_added);
 
             assert_ne!(
                 class.to_instance(&db),


### PR DESCRIPTION
## Summary

One of the motivations in https://github.com/astral-sh/ruff/pull/16428 for panicking when the `test` or `debug_assertions` features are enabled and a lookup of a `KnownClass` fails is that we've had some latent bugs in our code where certain variants have been silently falling back to `Unknown` in every typeshed lookup without us realising. But that in itself isn't a great motivation for panicking in `KnownClass::to_instance()`, since we can fairly easily add some tests that assert that we don't unexpectedly fallback to `Unknown` for any `KnownClass` variant. This PR adds those tests. 

## Test Plan

`cargo test -p red_knot_python_semantic`
