### PR TITLE
[`pylint`] Stabilize `len-test` (`PLC1802`)

### DIFF
--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -192,7 +192,7 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         (Pylint, "C0208") => (RuleGroup::Stable, rules::pylint::rules::IterationOverSet),
         (Pylint, "C0414") => (RuleGroup::Stable, rules::pylint::rules::UselessImportAlias),
         (Pylint, "C0415") => (RuleGroup::Preview, rules::pylint::rules::ImportOutsideTopLevel),
-        (Pylint, "C1802") => (RuleGroup::Preview, rules::pylint::rules::LenTest),
+        (Pylint, "C1802") => (RuleGroup::Stable, rules::pylint::rules::LenTest),
         (Pylint, "C1901") => (RuleGroup::Preview, rules::pylint::rules::CompareToEmptyString),
         (Pylint, "C2401") => (RuleGroup::Stable, rules::pylint::rules::NonAsciiName),
         (Pylint, "C2403") => (RuleGroup::Stable, rules::pylint::rules::NonAsciiImportName),

--- a/crates/ruff_linter/src/rules/pylint/rules/len_test.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/len_test.rs
@@ -9,12 +9,11 @@ use ruff_python_semantic::{BindingId, SemanticModel};
 use ruff_text_size::Ranged;
 
 /// ## What it does
-/// Checks for usage of call of 'len' on sequences
-/// in boolean test context.
+/// Checks for `len` calls on sequences in a boolean test context.
 ///
 /// ## Why is this bad?
 /// Empty sequences are considered false in a boolean context.
-/// You can either remove the call to 'len'
+/// You can either remove the call to `len`
 /// or compare the length against a scalar.
 ///
 /// ## Example


### PR DESCRIPTION
Summary
--

Stabilizes PLC1802. The tests were already in the right place, and I just tidied the docs a little bit.

Test Plan
--

1 issue closed 4 days after the rule was added, no other issues
