### PR TITLE
[`pylint`] Stabilize `shallow-copy-environ` (`PLW1507`)

### DIFF
--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -288,7 +288,7 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         (Pylint, "W0642") => (RuleGroup::Stable, rules::pylint::rules::SelfOrClsAssignment),
         (Pylint, "W0711") => (RuleGroup::Stable, rules::pylint::rules::BinaryOpException),
         (Pylint, "W1501") => (RuleGroup::Stable, rules::pylint::rules::BadOpenMode),
-        (Pylint, "W1507") => (RuleGroup::Preview, rules::pylint::rules::ShallowCopyEnviron),
+        (Pylint, "W1507") => (RuleGroup::Stable, rules::pylint::rules::ShallowCopyEnviron),
         (Pylint, "W1508") => (RuleGroup::Stable, rules::pylint::rules::InvalidEnvvarDefault),
         (Pylint, "W1509") => (RuleGroup::Stable, rules::pylint::rules::SubprocessPopenPreexecFn),
         (Pylint, "W1510") => (RuleGroup::Stable, rules::pylint::rules::SubprocessRunWithoutCheck),

--- a/crates/ruff_linter/src/rules/pylint/rules/shallow_copy_environ.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/shallow_copy_environ.rs
@@ -13,7 +13,7 @@ use crate::checkers::ast::Checker;
 /// `os.environ` is not a `dict` object, but rather, a proxy object. As such, mutating a shallow
 /// copy of `os.environ` will also mutate the original object.
 ///
-/// See: [#15373] for more information.
+/// See [BPO 15373] for more information.
 ///
 /// ## Example
 /// ```python
@@ -41,7 +41,7 @@ use crate::checkers::ast::Checker;
 /// - [Python documentation: `copy` — Shallow and deep copy operations](https://docs.python.org/3/library/copy.html)
 /// - [Python documentation: `os.environ`](https://docs.python.org/3/library/os.html#os.environ)
 ///
-/// [#15373]: https://bugs.python.org/issue15373
+/// [BPO 15373]: https://bugs.python.org/issue15373
 #[derive(ViolationMetadata)]
 pub(crate) struct ShallowCopyEnviron;
 


### PR DESCRIPTION
Summary
--

Stabilizes PLW1507. The tests were already in the right place, and I just tidied the docs a little bit.

Test Plan
--

1 issue from 2 weeks ago but just suggesting to mark the fix unsafe. The shallow vs deep copy *does* change the program behavior, just usually in a preferable way.
