### PR TITLE
[red-knot] Check if callable type is fully static

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_fully_static.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_fully_static.md
@@ -5,7 +5,7 @@ A type is fully static iff it does not contain any gradual forms.
 ## Fully-static
 
 ```py
-from typing_extensions import Literal, LiteralString, Never
+from typing_extensions import Literal, LiteralString, Never, Callable
 from knot_extensions import Intersection, Not, TypeOf, is_fully_static, static_assert
 
 static_assert(is_fully_static(Never))
@@ -38,7 +38,7 @@ static_assert(is_fully_static(type[object]))
 ## Non-fully-static
 
 ```py
-from typing_extensions import Any, Literal, LiteralString
+from typing_extensions import Any, Literal, LiteralString, Callable
 from knot_extensions import Intersection, Not, TypeOf, Unknown, is_fully_static, static_assert
 
 static_assert(not is_fully_static(Any))
@@ -51,4 +51,27 @@ static_assert(not is_fully_static(Intersection[Any, Not[LiteralString]]))
 static_assert(not is_fully_static(tuple[Any, ...]))
 static_assert(not is_fully_static(tuple[int, Any]))
 static_assert(not is_fully_static(type[Any]))
+```
+
+## Callable
+
+```py
+from typing_extensions import Callable, Any
+from knot_extensions import Unknown, is_fully_static, static_assert
+
+static_assert(is_fully_static(Callable[[], int]))
+static_assert(is_fully_static(Callable[[int, str], int]))
+
+static_assert(not is_fully_static(Callable[..., int]))
+static_assert(not is_fully_static(Callable[[], Any]))
+static_assert(not is_fully_static(Callable[[int, Unknown], int]))
+```
+
+The invalid forms of `Callable` annotation are never fully static because we represent them with the
+`(...) -> Unknown` signature.
+
+```py
+static_assert(not is_fully_static(Callable))
+# error: [invalid-type-form]
+static_assert(not is_fully_static(Callable[int, int]))
 ```


### PR DESCRIPTION
## Summary

Part of #15382 

This PR adds the check for whether a callable type is fully static or not.

A callable type is fully static if all of the parameter types are fully static _and_ the return type is fully static _and_ if it does not use the gradual form (`...`) for its parameters.

## Test Plan

Update `is_fully_static.md` with callable types.

It seems that currently this test is grouped into either fully static or not, I think it would be useful to split them up in groups like callable, etc. I intentionally avoided that in this PR but I'll put up a PR for an appropriate split.

Note: I've an explicit goal of updating the property tests with the new callable types once all relations are implemented.
