### PR TITLE
[`flake8-datetimez`] Stabilize `datetime-min-max` (`DTZ901`)

### DIFF
--- a/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
@@ -428,7 +428,7 @@ pub(crate) fn expression(expr: &Expr, checker: &Checker) {
                 flake8_2020::rules::name_or_attribute(checker, expr);
             }
             if checker.enabled(Rule::DatetimeMinMax) {
-                flake8_datetimez::rules::datetime_max_min(checker, expr);
+                flake8_datetimez::rules::datetime_min_max(checker, expr);
             }
             if checker.enabled(Rule::BannedApi) {
                 flake8_tidy_imports::rules::banned_attribute_access(checker, expr);

--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -719,7 +719,7 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         (Flake8Datetimez, "007") => (RuleGroup::Stable, rules::flake8_datetimez::rules::CallDatetimeStrptimeWithoutZone),
         (Flake8Datetimez, "011") => (RuleGroup::Stable, rules::flake8_datetimez::rules::CallDateToday),
         (Flake8Datetimez, "012") => (RuleGroup::Stable, rules::flake8_datetimez::rules::CallDateFromtimestamp),
-        (Flake8Datetimez, "901") => (RuleGroup::Preview, rules::flake8_datetimez::rules::DatetimeMinMax),
+        (Flake8Datetimez, "901") => (RuleGroup::Stable, rules::flake8_datetimez::rules::DatetimeMinMax),
 
         // pygrep-hooks
         (PygrepHooks, "001") => (RuleGroup::Removed, rules::pygrep_hooks::rules::Eval),

--- a/crates/ruff_linter/src/rules/flake8_datetimez/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/mod.rs
@@ -9,7 +9,6 @@ mod tests {
     use test_case::test_case;
 
     use crate::registry::Rule;
-    use crate::settings::types::PreviewMode;
     use crate::test::test_path;
     use crate::{assert_messages, settings};
 
@@ -22,25 +21,12 @@ mod tests {
     #[test_case(Rule::CallDatetimeStrptimeWithoutZone, Path::new("DTZ007.py"))]
     #[test_case(Rule::CallDateToday, Path::new("DTZ011.py"))]
     #[test_case(Rule::CallDateFromtimestamp, Path::new("DTZ012.py"))]
+    #[test_case(Rule::DatetimeMinMax, Path::new("DTZ901.py"))]
     fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.noqa_code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("flake8_datetimez").join(path).as_path(),
             &settings::LinterSettings::for_rule(rule_code),
-        )?;
-        assert_messages!(snapshot, diagnostics);
-        Ok(())
-    }
-
-    #[test_case(Rule::DatetimeMinMax, Path::new("DTZ901.py"))]
-    fn preview_rules(rule_code: Rule, path: &Path) -> Result<()> {
-        let snapshot = format!("{}_{}", rule_code.noqa_code(), path.to_string_lossy());
-        let diagnostics = test_path(
-            Path::new("flake8_datetimez").join(path).as_path(),
-            &settings::LinterSettings {
-                preview: PreviewMode::Enabled,
-                ..settings::LinterSettings::for_rule(rule_code)
-            },
         )?;
         assert_messages!(snapshot, diagnostics);
         Ok(())

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/datetime_min_max.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/datetime_min_max.rs
@@ -9,18 +9,18 @@ use ruff_text_size::Ranged;
 use crate::checkers::ast::Checker;
 
 /// ## What it does
-/// Checks for uses of `datetime.datetime.max` and `datetime.datetime.min`.
+/// Checks for uses of `datetime.datetime.min` and `datetime.datetime.max`.
 ///
 /// ## Why is this bad?
-/// `datetime.max` and `datetime.min` are non-timezone-aware datetime objects.
+/// `datetime.min` and `datetime.max` are non-timezone-aware datetime objects.
 ///
-/// As such, operations on `datetime.max` and `datetime.min` may behave
+/// As such, operations on `datetime.min` and `datetime.max` may behave
 /// unexpectedly, as in:
 ///
 /// ```python
 /// # Timezone: UTC-14
-/// datetime.max.timestamp()  # ValueError: year 10000 is out of range
 /// datetime.min.timestamp()  # ValueError: year 0 is out of range
+/// datetime.max.timestamp()  # ValueError: year 10000 is out of range
 /// ```
 ///
 /// ## Example
@@ -53,7 +53,7 @@ impl Violation for DatetimeMinMax {
 }
 
 /// DTZ901
-pub(crate) fn datetime_max_min(checker: &Checker, expr: &Expr) {
+pub(crate) fn datetime_min_max(checker: &Checker, expr: &Expr) {
     let semantic = checker.semantic();
 
     if !semantic.seen_module(Modules::DATETIME) {


### PR DESCRIPTION
Summary
--

Stabilizes DTZ901, renames the rule function to match the rule name, removes the `preview_rules` test, and handles some nits in the docs (mention `min` first to match the rule name too).

Test Plan
--

1 closed issue on 2024-11-12, 4 days after the rule was added. No issues since
