### PR TITLE
Add missing unit tests for `# noqa:`-like cases

### DIFF
--- a/crates/ruff_linter/src/noqa.rs
+++ b/crates/ruff_linter/src/noqa.rs
@@ -1251,6 +1251,30 @@ mod tests {
     }
 
     #[test]
+    fn noqa_no_code() {
+        let source = "# noqa:";
+        let directive = lex_inline_noqa(TextRange::up_to(source.text_len()), source);
+        assert_debug_snapshot!(directive);
+        assert_lexed_ranges_match_slices(directive, source);
+    }
+
+    #[test]
+    fn noqa_no_code_invalid_suffix() {
+        let source = "# noqa: foo";
+        let directive = lex_inline_noqa(TextRange::up_to(source.text_len()), source);
+        assert_debug_snapshot!(directive);
+        assert_lexed_ranges_match_slices(directive, source);
+    }
+
+    #[test]
+    fn noqa_no_code_trailing_content() {
+        let source = "# noqa:  # Foo";
+        let directive = lex_inline_noqa(TextRange::up_to(source.text_len()), source);
+        assert_debug_snapshot!(directive);
+        assert_lexed_ranges_match_slices(directive, source);
+    }
+
+    #[test]
     fn noqa_code() {
         let source = "# noqa: F401";
         let directive = lex_inline_noqa(TextRange::up_to(source.text_len()), source);
@@ -1483,8 +1507,56 @@ mod tests {
     }
 
     #[test]
+    fn flake8_noqa_no_code() {
+        let source = "# flake8: noqa:";
+        let exemption = lex_file_exemption(TextRange::up_to(source.text_len()), source);
+        assert_debug_snapshot!(exemption);
+        assert_lexed_ranges_match_slices(exemption, source);
+    }
+
+    #[test]
+    fn flake8_noqa_no_code_invalid_suffix() {
+        let source = "# flake8: noqa: foo";
+        let exemption = lex_file_exemption(TextRange::up_to(source.text_len()), source);
+        assert_debug_snapshot!(exemption);
+        assert_lexed_ranges_match_slices(exemption, source);
+    }
+
+    #[test]
+    fn flake8_noqa_no_code_trailing_content() {
+        let source = "# flake8: noqa:  # Foo";
+        let exemption = lex_file_exemption(TextRange::up_to(source.text_len()), source);
+        assert_debug_snapshot!(exemption);
+        assert_lexed_ranges_match_slices(exemption, source);
+    }
+
+    #[test]
     fn ruff_exemption_all() {
         let source = "# ruff: noqa";
+        let exemption = lex_file_exemption(TextRange::up_to(source.text_len()), source);
+        assert_debug_snapshot!(exemption);
+        assert_lexed_ranges_match_slices(exemption, source);
+    }
+
+    #[test]
+    fn ruff_noqa_no_code() {
+        let source = "# ruff: noqa:";
+        let exemption = lex_file_exemption(TextRange::up_to(source.text_len()), source);
+        assert_debug_snapshot!(exemption);
+        assert_lexed_ranges_match_slices(exemption, source);
+    }
+
+    #[test]
+    fn ruff_noqa_no_code_invalid_suffix() {
+        let source = "# ruff: noqa: foo";
+        let exemption = lex_file_exemption(TextRange::up_to(source.text_len()), source);
+        assert_debug_snapshot!(exemption);
+        assert_lexed_ranges_match_slices(exemption, source);
+    }
+
+    #[test]
+    fn ruff_noqa_no_code_trailing_content() {
+        let source = "# ruff: noqa:  # Foo";
         let exemption = lex_file_exemption(TextRange::up_to(source.text_len()), source);
         assert_debug_snapshot!(exemption);
         assert_lexed_ranges_match_slices(exemption, source);

--- a/crates/ruff_linter/src/snapshots/ruff_linter__noqa__tests__flake8_noqa_no_code.snap
+++ b/crates/ruff_linter/src/snapshots/ruff_linter__noqa__tests__flake8_noqa_no_code.snap
@@ -1,0 +1,7 @@
+---
+source: crates/ruff_linter/src/noqa.rs
+expression: exemption
+---
+Err(
+    MissingCodes,
+)

--- a/crates/ruff_linter/src/snapshots/ruff_linter__noqa__tests__flake8_noqa_no_code_invalid_suffix.snap
+++ b/crates/ruff_linter/src/snapshots/ruff_linter__noqa__tests__flake8_noqa_no_code_invalid_suffix.snap
@@ -1,0 +1,7 @@
+---
+source: crates/ruff_linter/src/noqa.rs
+expression: exemption
+---
+Err(
+    MissingCodes,
+)

--- a/crates/ruff_linter/src/snapshots/ruff_linter__noqa__tests__flake8_noqa_no_code_trailing_content.snap
+++ b/crates/ruff_linter/src/snapshots/ruff_linter__noqa__tests__flake8_noqa_no_code_trailing_content.snap
@@ -1,0 +1,7 @@
+---
+source: crates/ruff_linter/src/noqa.rs
+expression: exemption
+---
+Err(
+    MissingCodes,
+)

--- a/crates/ruff_linter/src/snapshots/ruff_linter__noqa__tests__noqa_no_code.snap
+++ b/crates/ruff_linter/src/snapshots/ruff_linter__noqa__tests__noqa_no_code.snap
@@ -1,0 +1,7 @@
+---
+source: crates/ruff_linter/src/noqa.rs
+expression: "Directive::try_extract(source, TextSize::default())"
+---
+Err(
+    MissingCodes,
+)

--- a/crates/ruff_linter/src/snapshots/ruff_linter__noqa__tests__noqa_no_code_invalid_suffix.snap
+++ b/crates/ruff_linter/src/snapshots/ruff_linter__noqa__tests__noqa_no_code_invalid_suffix.snap
@@ -1,0 +1,7 @@
+---
+source: crates/ruff_linter/src/noqa.rs
+expression: "Directive::try_extract(source, TextSize::default())"
+---
+Err(
+    MissingCodes,
+)

--- a/crates/ruff_linter/src/snapshots/ruff_linter__noqa__tests__noqa_no_code_trailing_content.snap
+++ b/crates/ruff_linter/src/snapshots/ruff_linter__noqa__tests__noqa_no_code_trailing_content.snap
@@ -1,0 +1,7 @@
+---
+source: crates/ruff_linter/src/noqa.rs
+expression: "Directive::try_extract(source, TextSize::default())"
+---
+Err(
+    MissingCodes,
+)

--- a/crates/ruff_linter/src/snapshots/ruff_linter__noqa__tests__ruff_noqa_no_code.snap
+++ b/crates/ruff_linter/src/snapshots/ruff_linter__noqa__tests__ruff_noqa_no_code.snap
@@ -1,0 +1,7 @@
+---
+source: crates/ruff_linter/src/noqa.rs
+expression: exemption
+---
+Err(
+    MissingCodes,
+)

--- a/crates/ruff_linter/src/snapshots/ruff_linter__noqa__tests__ruff_noqa_no_code_invalid_suffix.snap
+++ b/crates/ruff_linter/src/snapshots/ruff_linter__noqa__tests__ruff_noqa_no_code_invalid_suffix.snap
@@ -1,0 +1,7 @@
+---
+source: crates/ruff_linter/src/noqa.rs
+expression: exemption
+---
+Err(
+    MissingCodes,
+)

--- a/crates/ruff_linter/src/snapshots/ruff_linter__noqa__tests__ruff_noqa_no_code_trailing_content.snap
+++ b/crates/ruff_linter/src/snapshots/ruff_linter__noqa__tests__ruff_noqa_no_code_trailing_content.snap
@@ -1,0 +1,7 @@
+---
+source: crates/ruff_linter/src/noqa.rs
+expression: exemption
+---
+Err(
+    MissingCodes,
+)


### PR DESCRIPTION
## Summary

Follow-up to #16483.

This case is explicitly described in [the specification](https://github.com/astral-sh/ruff/pull/16483#issue-2892361457), but it is not covered by any tests:

> We expect a list of rule codes, separated by commas or whitespace. After splitting first on commas, and then on whitespace, we attempt to parse each item in turn. If parsing a nonempty item returns no rule codes, we stop. If no codes were found at all we warn the user with `MissingCodes`.

## Test Plan

Unit tests.