### PR TITLE
[red-knot] remove redundant sentence in test

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/function/return_type.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/function/return_type.md
@@ -1,8 +1,7 @@
 # Function return type
 
 When a function's return type is annotated, all return statements are checked to ensure that the
-type of the returned value is assignable to the annotated return type. A `raise` is equivalent to a
-return of `Never`, which is assignable to any annotated return type.
+type of the returned value is assignable to the annotated return type.
 
 ## Basic examples
 


### PR DESCRIPTION
Removes a redundant sentence I accidentally left in the test suite from in #16540 (my mistake).
