### PR TITLE
[red-knot] Attribute access on intersection types

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -5073,17 +5073,16 @@ impl<'db> IntersectionType<'db> {
 
         let mut builder = IntersectionBuilder::new(db);
 
-        let mut any_unbound = false;
-        let mut any_possibly_unbound = false;
+        let mut all_unbound = true;
+        let mut any_definitely_bound = false;
         for ty in self.positive(db) {
             let ty_member = transform_fn(ty);
             match ty_member {
-                Symbol::Unbound => {
-                    any_unbound = true;
-                }
+                Symbol::Unbound => {}
                 Symbol::Type(ty_member, member_boundness) => {
-                    if member_boundness == Boundness::PossiblyUnbound {
-                        any_possibly_unbound = true;
+                    all_unbound = false;
+                    if member_boundness == Boundness::Bound {
+                        any_definitely_bound = true;
                     }
 
                     builder = builder.add_positive(ty_member);
@@ -5091,15 +5090,15 @@ impl<'db> IntersectionType<'db> {
             }
         }
 
-        if any_unbound {
+        if all_unbound {
             Symbol::Unbound
         } else {
             Symbol::Type(
                 builder.build(),
-                if any_possibly_unbound {
-                    Boundness::PossiblyUnbound
-                } else {
+                if any_definitely_bound {
                     Boundness::Bound
+                } else {
+                    Boundness::PossiblyUnbound
                 },
             )
         }


### PR DESCRIPTION
## Summary

Implements attribute access on intersection types, which didn't previously work. For example:

```py
from typing import Any

class P: ...
class Q: ...

class A:
    x: P = P()

class B:
    x: Any = Q()

def _(obj: A):
    if isinstance(obj, B):
        reveal_type(obj.x)  # revealed: P & Any
```

Refers to [this comment].

[this comment]: https://github.com/astral-sh/ruff/pull/16416#discussion_r1985040363

## Test Plan

New Markdown tests