### PR TITLE
[red-knot] fix red-knot fuzzing

### DIFF
--- a/python/py-fuzzer/fuzz.py
+++ b/python/py-fuzzer/fuzz.py
@@ -17,6 +17,11 @@ Example invocations of the script using `uv`:
   using a random selection of seeds, and only print a summary at the end
   (the `shuf` command is Unix-specific):
   `uvx --from ./python/py-fuzzer fuzz --bin ruff $(shuf -i 0-1000000 -n 10000) --quiet
+
+If you make local modifications to this script, you'll need to run the above
+with `--reinstall` to get your changes reflected in the uv-cached installed
+package. Alternatively, if iterating quickly on changes, you can add
+`--with-editable ./python/py-fuzzer`.
 """
 
 from __future__ import annotations
@@ -48,7 +53,7 @@ def redknot_contains_bug(code: str, *, red_knot_executable: Path) -> bool:
         Path(tempdir, "pyproject.toml").write_text('[project]\n\tname = "fuzz-input"')
         Path(tempdir, "input.py").write_text(code)
         completed_process = subprocess.run(
-            [red_knot_executable, "--current-directory", tempdir],
+            [red_knot_executable, "check", "--project", tempdir],
             capture_output=True,
             text=True,
         )


### PR DESCRIPTION
The red-knot CLI changed since the fuzzer script was added; update it to work with current red-knot CLI.

Also add some notes on how to ensure local changes to the fuzzer script are picked up.
