### PR TITLE
Add missing unit tests for `# noqa: A`-like cases

### DIFF
--- a/crates/ruff_linter/src/noqa.rs
+++ b/crates/ruff_linter/src/noqa.rs
@@ -1275,6 +1275,30 @@ mod tests {
     }
 
     #[test]
+    fn malformed_code_1() {
+        let source = "# noqa: F";
+        let directive = lex_inline_noqa(TextRange::up_to(source.text_len()), source);
+        assert_debug_snapshot!(directive);
+        assert_lexed_ranges_match_slices(directive, source);
+    }
+
+    #[test]
+    fn malformed_code_2() {
+        let source = "# noqa: RUF001, F";
+        let directive = lex_inline_noqa(TextRange::up_to(source.text_len()), source);
+        assert_debug_snapshot!(directive);
+        assert_lexed_ranges_match_slices(directive, source);
+    }
+
+    #[test]
+    fn malformed_code_3() {
+        let source = "# noqa: RUF001F";
+        let directive = lex_inline_noqa(TextRange::up_to(source.text_len()), source);
+        assert_debug_snapshot!(directive);
+        assert_lexed_ranges_match_slices(directive, source);
+    }
+
+    #[test]
     fn noqa_code() {
         let source = "# noqa: F401";
         let directive = lex_inline_noqa(TextRange::up_to(source.text_len()), source);
@@ -1531,6 +1555,30 @@ mod tests {
     }
 
     #[test]
+    fn flake8_malformed_code_1() {
+        let source = "# flake8: noqa: F";
+        let directive = lex_file_exemption(TextRange::up_to(source.text_len()), source);
+        assert_debug_snapshot!(directive);
+        assert_lexed_ranges_match_slices(directive, source);
+    }
+
+    #[test]
+    fn flake8_malformed_code_2() {
+        let source = "# flake8: noqa: RUF001, F";
+        let directive = lex_file_exemption(TextRange::up_to(source.text_len()), source);
+        assert_debug_snapshot!(directive);
+        assert_lexed_ranges_match_slices(directive, source);
+    }
+
+    #[test]
+    fn flake8_malformed_code_3() {
+        let source = "# flake8: noqa: RUF001F";
+        let directive = lex_file_exemption(TextRange::up_to(source.text_len()), source);
+        assert_debug_snapshot!(directive);
+        assert_lexed_ranges_match_slices(directive, source);
+    }
+
+    #[test]
     fn ruff_exemption_all() {
         let source = "# ruff: noqa";
         let exemption = lex_file_exemption(TextRange::up_to(source.text_len()), source);
@@ -1560,6 +1608,30 @@ mod tests {
         let exemption = lex_file_exemption(TextRange::up_to(source.text_len()), source);
         assert_debug_snapshot!(exemption);
         assert_lexed_ranges_match_slices(exemption, source);
+    }
+
+    #[test]
+    fn ruff_malformed_code_1() {
+        let source = "# ruff: noqa: F";
+        let directive = lex_file_exemption(TextRange::up_to(source.text_len()), source);
+        assert_debug_snapshot!(directive);
+        assert_lexed_ranges_match_slices(directive, source);
+    }
+
+    #[test]
+    fn ruff_malformed_code_2() {
+        let source = "# ruff: noqa: RUF001, F";
+        let directive = lex_file_exemption(TextRange::up_to(source.text_len()), source);
+        assert_debug_snapshot!(directive);
+        assert_lexed_ranges_match_slices(directive, source);
+    }
+
+    #[test]
+    fn ruff_malformed_code_3() {
+        let source = "# ruff: noqa: RUF001F";
+        let directive = lex_file_exemption(TextRange::up_to(source.text_len()), source);
+        assert_debug_snapshot!(directive);
+        assert_lexed_ranges_match_slices(directive, source);
     }
 
     #[test]

--- a/crates/ruff_linter/src/snapshots/ruff_linter__noqa__tests__flake8_malformed_code_1.snap
+++ b/crates/ruff_linter/src/snapshots/ruff_linter__noqa__tests__flake8_malformed_code_1.snap
@@ -1,0 +1,7 @@
+---
+source: crates/ruff_linter/src/noqa.rs
+expression: directive
+---
+Err(
+    MissingCodes,
+)

--- a/crates/ruff_linter/src/snapshots/ruff_linter__noqa__tests__flake8_malformed_code_2.snap
+++ b/crates/ruff_linter/src/snapshots/ruff_linter__noqa__tests__flake8_malformed_code_2.snap
@@ -1,0 +1,22 @@
+---
+source: crates/ruff_linter/src/noqa.rs
+expression: directive
+---
+Ok(
+    Some(
+        NoqaLexerOutput {
+            warnings: [],
+            directive: Codes(
+                Codes {
+                    range: 0..22,
+                    codes: [
+                        Code {
+                            code: "RUF001",
+                            range: 16..22,
+                        },
+                    ],
+                },
+            ),
+        },
+    ),
+)

--- a/crates/ruff_linter/src/snapshots/ruff_linter__noqa__tests__flake8_malformed_code_3.snap
+++ b/crates/ruff_linter/src/snapshots/ruff_linter__noqa__tests__flake8_malformed_code_3.snap
@@ -1,0 +1,7 @@
+---
+source: crates/ruff_linter/src/noqa.rs
+expression: directive
+---
+Err(
+    InvalidCodeSuffix,
+)

--- a/crates/ruff_linter/src/snapshots/ruff_linter__noqa__tests__malformed_code_1.snap
+++ b/crates/ruff_linter/src/snapshots/ruff_linter__noqa__tests__malformed_code_1.snap
@@ -1,0 +1,7 @@
+---
+source: crates/ruff_linter/src/noqa.rs
+expression: directive
+---
+Err(
+    MissingCodes,
+)

--- a/crates/ruff_linter/src/snapshots/ruff_linter__noqa__tests__malformed_code_2.snap
+++ b/crates/ruff_linter/src/snapshots/ruff_linter__noqa__tests__malformed_code_2.snap
@@ -1,0 +1,22 @@
+---
+source: crates/ruff_linter/src/noqa.rs
+expression: directive
+---
+Ok(
+    Some(
+        NoqaLexerOutput {
+            warnings: [],
+            directive: Codes(
+                Codes {
+                    range: 0..14,
+                    codes: [
+                        Code {
+                            code: "RUF001",
+                            range: 8..14,
+                        },
+                    ],
+                },
+            ),
+        },
+    ),
+)

--- a/crates/ruff_linter/src/snapshots/ruff_linter__noqa__tests__malformed_code_3.snap
+++ b/crates/ruff_linter/src/snapshots/ruff_linter__noqa__tests__malformed_code_3.snap
@@ -1,0 +1,7 @@
+---
+source: crates/ruff_linter/src/noqa.rs
+expression: directive
+---
+Err(
+    InvalidCodeSuffix,
+)

--- a/crates/ruff_linter/src/snapshots/ruff_linter__noqa__tests__ruff_malformed_code_1.snap
+++ b/crates/ruff_linter/src/snapshots/ruff_linter__noqa__tests__ruff_malformed_code_1.snap
@@ -1,0 +1,7 @@
+---
+source: crates/ruff_linter/src/noqa.rs
+expression: directive
+---
+Err(
+    MissingCodes,
+)

--- a/crates/ruff_linter/src/snapshots/ruff_linter__noqa__tests__ruff_malformed_code_2.snap
+++ b/crates/ruff_linter/src/snapshots/ruff_linter__noqa__tests__ruff_malformed_code_2.snap
@@ -1,0 +1,22 @@
+---
+source: crates/ruff_linter/src/noqa.rs
+expression: directive
+---
+Ok(
+    Some(
+        NoqaLexerOutput {
+            warnings: [],
+            directive: Codes(
+                Codes {
+                    range: 0..20,
+                    codes: [
+                        Code {
+                            code: "RUF001",
+                            range: 14..20,
+                        },
+                    ],
+                },
+            ),
+        },
+    ),
+)

--- a/crates/ruff_linter/src/snapshots/ruff_linter__noqa__tests__ruff_malformed_code_3.snap
+++ b/crates/ruff_linter/src/snapshots/ruff_linter__noqa__tests__ruff_malformed_code_3.snap
@@ -1,0 +1,7 @@
+---
+source: crates/ruff_linter/src/noqa.rs
+expression: directive
+---
+Err(
+    InvalidCodeSuffix,
+)


### PR DESCRIPTION
## Summary

Follow-up to #16659.

This change adds tests for these three cases, which are (also) not covered by existing tests:

* `# noqa: A` (lone incomplete code)
* `# noqa: A123, B` (complete codes, last one incomplete)
* `# noqa: A123B` (squashed codes, last one incomplete)

The third case is mentioned in [the specification](https://github.com/astral-sh/ruff/pull/16483#issue-2892361457), but neither of the other two are:

> If an item does not consist entirely of codes (e.g. `F401abc`), parsing aborts with an error and the user is warned of an `InvalidCodeSuffix` [...]

## Test Plan

Unit tests.
