### PR TITLE
[`flake8-bandit`] Deprecate `suspicious-xmle-tree-usage` (`S320`)

### DIFF
--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -649,7 +649,7 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         (Flake8Bandit, "317") => (RuleGroup::Stable, rules::flake8_bandit::rules::SuspiciousXMLSaxUsage),
         (Flake8Bandit, "318") => (RuleGroup::Stable, rules::flake8_bandit::rules::SuspiciousXMLMiniDOMUsage),
         (Flake8Bandit, "319") => (RuleGroup::Stable, rules::flake8_bandit::rules::SuspiciousXMLPullDOMUsage),
-        (Flake8Bandit, "320") => (RuleGroup::Stable, rules::flake8_bandit::rules::SuspiciousXMLETreeUsage),
+        (Flake8Bandit, "320") => (RuleGroup::Deprecated, rules::flake8_bandit::rules::SuspiciousXMLETreeUsage),
         (Flake8Bandit, "321") => (RuleGroup::Stable, rules::flake8_bandit::rules::SuspiciousFTPLibUsage),
         (Flake8Bandit, "323") => (RuleGroup::Stable, rules::flake8_bandit::rules::SuspiciousUnverifiedContextUsage),
         (Flake8Bandit, "324") => (RuleGroup::Stable, rules::flake8_bandit::rules::HashlibInsecureHashFunction),

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/suspicious_function_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/suspicious_function_call.rs
@@ -779,6 +779,13 @@ impl Violation for SuspiciousXMLPullDOMUsage {
     }
 }
 
+/// ## Deprecation
+///
+/// This rule was deprecated as the `lxml` library has been modified to address
+/// known vulnerabilities and unsafe defaults. As such, the `defusedxml`
+/// library is no longer necessary, `defusedxml` has [deprecated] its `lxml`
+/// module.
+///
 /// ## What it does
 /// Checks for uses of insecure XML parsers.
 ///
@@ -802,6 +809,7 @@ impl Violation for SuspiciousXMLPullDOMUsage {
 /// - [Common Weakness Enumeration: CWE-776](https://cwe.mitre.org/data/definitions/776.html)
 ///
 /// [preview]: https://docs.astral.sh/ruff/preview/
+/// [deprecated]: https://pypi.org/project/defusedxml/0.8.0rc2/#defusedxml-lxml
 #[derive(ViolationMetadata)]
 pub(crate) struct SuspiciousXMLETreeUsage;
 

--- a/crates/ruff_linter/src/rules/flake8_builtins/rules/stdlib_module_shadowing.rs
+++ b/crates/ruff_linter/src/rules/flake8_builtins/rules/stdlib_module_shadowing.rs
@@ -26,7 +26,7 @@ use crate::settings::LinterSettings;
 /// By default, the module path relative to the project root or [`src`] directories is considered,
 /// so a top-level `logging.py` or `logging/__init__.py` will clash with the builtin `logging`
 /// module, but `utils/logging.py`, for example, will not. With the
-/// [`lint.flake8-builtins.builtins-strict-checking`] option set to `true`, only the last component
+/// [`lint.flake8-builtins.strict-checking`] option set to `true`, only the last component
 /// of the module name is considered, so `logging.py`, `utils/logging.py`, and
 /// `utils/logging/__init__.py` will all trigger the rule.
 ///


### PR DESCRIPTION
## Summary
Deprecate `S320` because defusedxml has deprecated there `lxml` module and `lxml` has been hardened since. 

flake8-bandit has removed their implementation as well (https://github.com/PyCQA/bandit/pull/1212).

Addresses https://github.com/astral-sh/ruff/issues/13707


## Test Plan

I verified that selecting `S320` prints a warning and fails if the preview mode is enabled. 
