### PR TITLE
[`pyupgrade`]: Deprecate `non-pep604-isinstance` (`UP038`)

### DIFF
--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -532,7 +532,7 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         (Pyupgrade, "035") => (RuleGroup::Stable, rules::pyupgrade::rules::DeprecatedImport),
         (Pyupgrade, "036") => (RuleGroup::Stable, rules::pyupgrade::rules::OutdatedVersionBlock),
         (Pyupgrade, "037") => (RuleGroup::Stable, rules::pyupgrade::rules::QuotedAnnotation),
-        (Pyupgrade, "038") => (RuleGroup::Stable, rules::pyupgrade::rules::NonPEP604Isinstance),
+        (Pyupgrade, "038") => (RuleGroup::Deprecated, rules::pyupgrade::rules::NonPEP604Isinstance),
         (Pyupgrade, "039") => (RuleGroup::Stable, rules::pyupgrade::rules::UnnecessaryClassParentheses),
         (Pyupgrade, "040") => (RuleGroup::Stable, rules::pyupgrade::rules::NonPEP695TypeAlias),
         (Pyupgrade, "041") => (RuleGroup::Stable, rules::pyupgrade::rules::TimeoutErrorAlias),

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep604_isinstance.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep604_isinstance.rs
@@ -33,6 +33,12 @@ impl CallKind {
     }
 }
 
+/// ## Deprecation
+/// This rule was deprecated as using [PEP 604] syntax in `isinstance` and `issubclass` calls
+/// isn't recommended practice, and it incorrectly suggests that other typing syntaxes like [PEP 695]
+/// would be supported by `isinstance` and `issubclass`. Using the [PEP 604] syntax
+/// is also slightly slower.
+///
 /// ## What it does
 /// Checks for uses of `isinstance` and `issubclass` that take a tuple
 /// of types for comparison.
@@ -64,6 +70,7 @@ impl CallKind {
 /// - [Python documentation: `issubclass`](https://docs.python.org/3/library/functions.html#issubclass)
 ///
 /// [PEP 604]: https://peps.python.org/pep-0604/
+/// [PEP 695]: https://peps.python.org/pep-0695/
 #[derive(ViolationMetadata)]
 pub(crate) struct NonPEP604Isinstance {
     kind: CallKind,


### PR DESCRIPTION
## Summary

This PR deprecates UP038. Using PEP 604 syntax in `isinstance` and `issubclass` calls isn't a recommended pattern (or community agreed best practice) 
and it negatively impacts performance. 

Resolves https://github.com/astral-sh/ruff/issues/7871

## Test Plan

I tested that selecting `UP038` results in a warning in no-preview mode and an error in preview mode
