### PR TITLE
[ruff] Fix `last_tag`/`commits_since_last_tag` for `version` command

### DIFF
--- a/crates/ruff/build.rs
+++ b/crates/ruff/build.rs
@@ -49,7 +49,7 @@ fn commit_info(workspace_root: &Path) {
         .arg("-1")
         .arg("--date=short")
         .arg("--abbrev=9")
-        .arg("--format=%H %h %cd %(describe)")
+        .arg("--format=%H %h %cd %(describe:tags)")
         .output()
     {
         Ok(output) if output.status.success() => output,


### PR DESCRIPTION
## Summary

Since Ruff changed to GitHub releases, tags are no longer annotated and `git describe` no longer picks them up. Instead, it's necessary to also search lightweight tags.

This changes fixes the `version` command to give more accurate `last_tag`/`commits_since_last_tag` information. This only affects development builds, as this information is not present in releases.

## Test Plan

Testing is a little tricky because this information changes on every commit. Running manually on current `main` and my branch:

`main`:

```
# cargo run --bin ruff -- version --output-format=text
ruff 0.9.10+2547 (dd2313ab0 2025-03-12)

# cargo run --bin ruff -- version --output-format=json
{
  "version": "0.9.10",
  "commit_info": {
    "short_commit_hash": "dd2313ab0",
    "commit_hash": "dd2313ab0faea90abf66a75f1b5c388e728d9d0a",
    "commit_date": "2025-03-12",
    "last_tag": "v0.4.10",
    "commits_since_last_tag": 2547
  }
}
```

This PR:

```
# cargo run --bin ruff -- version --output-format=text
ruff 0.9.10+46 (11f39f616 2025-03-12)

# cargo run --bin ruff -- version --output-format=json
{
  "version": "0.9.10",
  "commit_info": {
    "short_commit_hash": "11f39f616",
    "commit_hash": "11f39f6166c3d7a521725b938a166659f64abb59",
    "commit_date": "2025-03-12",
    "last_tag": "0.9.10",
    "commits_since_last_tag": 46
  }
}
```