### PR TITLE
Add new `noqa` specification to the docs

### DIFF
--- a/docs/linter.md
+++ b/docs/linter.md
@@ -337,6 +337,27 @@ violations on a single line.
 Note that Ruff will also respect Flake8's `# flake8: noqa` directive, and will treat it as
 equivalent to `# ruff: noqa`.
 
+### Full suppression comment specification
+
+The full specification is as follows:
+
+- An inline blanket `noqa` comment is given by a case-insensitive match for
+  `#noqa` with optional whitespace after the `#` symbol, followed by either: the
+  end of the comment, the beginning of a new comment (`#`), or whitespace
+  followed by any character other than `:`.
+- An inline rule suppression is given by first finding a case-insensitive match
+  for `#noqa` with optional whitespace after the `#` symbol, optional whitespace
+  after `noqa`, and followed by the symbol `:`. After this we are expected to
+  have a list of rule codes which is given by sequences of uppercase ASCII
+  characters followed by ASCII digits, separated by whitespace or commas. The
+  list ends at the last valid code. We will attempt to interpret rules with a
+  missing delimiter (e.g. `F401F841`), though a warning will be emitted in this
+  case.
+- A file-level exemption comment is given by a case-sensitive match for `#ruff:`
+  or `#flake8:`, with optional whitespace after `#` and before `:`, followed by
+  optional whitespace and a case-insensitive match for `noqa`. After this, the
+  specification is as in the inline case.
+
 ### Detecting unused suppression comments
 
 Ruff implements a special rule, [`unused-noqa`](https://docs.astral.sh/ruff/rules/unused-noqa/),
@@ -352,26 +373,6 @@ unused `noqa` directives, run: `ruff check /path/to/file.py --extend-select RUF1
 Ruff can _automatically add_ `noqa` directives to all lines that contain violations, which is
 useful when migrating a new codebase to Ruff. To automatically add `noqa` directives to all
 relevant lines (with the appropriate rule codes), run: `ruff check /path/to/file.py --add-noqa`.
-
-### Full suppression comment specification
-
-The full specification is as follows:
-
-- An inline blanket `noqa` comment is given by a case-insensitive match for
-  `#noqa` with optional whitespace after the `#` symbol, followed by either: the
-  end of the comment, the beginning of a new comment (`#`), or whitespace
-  followed by any character other than `:`.
-- An inline rule suppression is given by first finding a case-insensitive match
-  for `#noqa` with optional whitespace after the `#` symbol, optional whitespace
-  after noqa, and followed by the symbol `:`. After this we are expected to have
-  a list of rule codes which is given by sequences of uppercase ascii characters
-  followed by ascii digits, separated by whitespace or commas. The list ends at
-  the last valid code. We will attempt to interpret rules with a missing
-  delimiter (e.g. `F401F841`), though a warning will be emitted in this case.
-- A file-level exemption comment is given by a case-sensitive match for `#ruff:`
-  or `#flake8:`, with optional whitespace after `#` and before `:`, followed by
-  optional whitespace and a case-insensitive match for `noqa`. After this, the
-  specification is as in the inline case.
 
 ### Action comments
 


### PR DESCRIPTION
## Summary

Adds @dylwil3's new `noqa` specification to the linter `Error suppression` page instead of the release blog post. Originally taken from his PR comment [here](https://github.com/astral-sh/ruff/pull/16483#issuecomment-2711985479).

## Test Plan

None
