### PR TITLE
[red-knot] Use `try_call_dunder` for augmented assignment

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/assignment/augmented.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/assignment/augmented.md
@@ -10,6 +10,10 @@ reveal_type(x)  # revealed: Literal[2]
 x = 1.0
 x /= 2
 reveal_type(x)  # revealed: int | float
+
+x = (1, 2)
+x += (3, 4)
+reveal_type(x)  # revealed: tuple[Literal[1], Literal[2], Literal[3], Literal[4]]
 ```
 
 ## Dunder methods
@@ -160,4 +164,19 @@ def f(flag: bool, flag2: bool):
     f += 12
 
     reveal_type(f)  # revealed: int | str | float
+```
+
+## Implicit dunder calls on class objects
+
+```py
+class Meta(type):
+    def __iadd__(cls, other: int) -> str:
+        return ""
+
+class C(metaclass=Meta): ...
+
+cls = C
+cls += 1
+
+reveal_type(cls)  # revealed: str
 ```


### PR DESCRIPTION
## Summary

Uses the `try_call_dunder` infrastructure for augmented assignment and fixes the logic to work for types other than `Type::Instance(…)`. This allows us to infer the correct type here:
```py
x = (1, 2)
x += (3, 4)
reveal_type(x)  # revealed: tuple[Literal[1], Literal[2], Literal[3], Literal[4]]
```
Or in this (extremely weird) scenario:
```py
class Meta(type):
    def __iadd__(cls, other: int) -> str:
        return ""

class C(metaclass=Meta): ...

cls = C
cls += 1

reveal_type(cls)  # revealed: str
```

Union and intersection handling could also be improved here, but I made no attempt to do so in this PR.

## Test Plan

New MD tests