### PR TITLE
Add Hex Format Option for Consistent Integer Representation

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,9 @@ skip-magic-trailing-comma = false
 
 # Like Black, automatically detect the appropriate line ending.
 line-ending = "auto"
+
+# Use uppercase or lowercase on hex expressions.
+format_hex = "upper"
 ```
 
 Note that, in a `pyproject.toml`, each section header should be prefixed with `tool.ruff`. For

--- a/crates/ruff_formatter/src/lib.rs
+++ b/crates/ruff_formatter/src/lib.rs
@@ -140,6 +140,15 @@ impl From<NonZeroU8> for IndentWidth {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct LineWidth(NonZeroU16);
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, CacheKey)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub enum HexFormat {
+    #[default]
+    Upper,
+    Lower,
+}
+
 impl LineWidth {
     /// Return the numeric value for this [`LineWidth`]
     pub const fn value(&self) -> u16 {

--- a/crates/ruff_formatter/src/lib.rs
+++ b/crates/ruff_formatter/src/lib.rs
@@ -141,7 +141,11 @@ impl From<NonZeroU8> for IndentWidth {
 pub struct LineWidth(NonZeroU16);
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, CacheKey)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "lowercase")
+)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum HexFormat {
     #[default]

--- a/crates/ruff_python_formatter/src/expression/expr_number_literal.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_number_literal.rs
@@ -94,8 +94,8 @@ fn normalize_integer(input: &str, hex_format: HexFormat) -> Cow<str> {
             if matches!(c, 'a'..='f') {
                 output.push_str(&input[last_index..index]);
                 output.push(match hex_format {
-                    HexFormat::Upper => c.to_ascii_uppercase()
-                    HexFormat::Lower => c.to_ascii_lowercase()
+                    HexFormat::Upper => c.to_ascii_uppercase(),
+                    HexFormat::Lower => c.to_ascii_lowercase(),
                 });
                 last_index = index + c.len_utf8();
             }

--- a/crates/ruff_python_formatter/src/options.rs
+++ b/crates/ruff_python_formatter/src/options.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use std::str::FromStr;
 
 use ruff_formatter::printer::{LineEnding, PrinterOptions, SourceMapGeneration};
-use ruff_formatter::{FormatOptions, IndentStyle, IndentWidth, LineWidth};
+use ruff_formatter::{FormatOptions, HexFormat, IndentStyle, IndentWidth, LineWidth};
 use ruff_macros::CacheKey;
 use ruff_python_ast::{self as ast, PySourceType};
 
@@ -62,6 +62,9 @@ pub struct PyFormatOptions {
 
     /// Whether preview style formatting is enabled or not
     preview: PreviewMode,
+
+    /// The preferred hex format for a given hex number.
+    hex_format: HexFormat,
 }
 
 fn default_line_width() -> LineWidth {
@@ -91,6 +94,7 @@ impl Default for PyFormatOptions {
             docstring_code: DocstringCode::default(),
             docstring_code_line_width: DocstringCodeLineWidth::default(),
             preview: PreviewMode::default(),
+            hex_format: HexFormat::default(),
         }
     }
 }
@@ -142,6 +146,10 @@ impl PyFormatOptions {
 
     pub const fn preview(&self) -> PreviewMode {
         self.preview
+    }
+
+    pub const fn hex_format(&self) -> HexFormat {
+        self.hex_format
     }
 
     #[must_use]
@@ -201,6 +209,12 @@ impl PyFormatOptions {
     #[must_use]
     pub fn with_preview(mut self, preview: PreviewMode) -> Self {
         self.preview = preview;
+        self
+    }
+
+    #[must_use]
+    pub fn with_hex_format(mut self, hex_format: HexFormat) -> Self {
+        self.hex_format = hex_format;
         self
     }
 

--- a/crates/ruff_python_formatter/tests/fixtures.rs
+++ b/crates/ruff_python_formatter/tests/fixtures.rs
@@ -516,7 +516,8 @@ docstring-code             = {docstring_code:?}
 docstring-code-line-width  = {docstring_code_line_width:?}
 preview                    = {preview:?}
 target_version             = {target_version}
-source_type                = {source_type:?}"#,
+source_type                = {source_type:?}
+hex_format                = {hex_format:?}"#,
             indent_style = self.0.indent_style(),
             indent_width = self.0.indent_width().value(),
             line_width = self.0.line_width().value(),
@@ -527,7 +528,8 @@ source_type                = {source_type:?}"#,
             docstring_code_line_width = self.0.docstring_code_line_width(),
             preview = self.0.preview(),
             target_version = self.0.target_version(),
-            source_type = self.0.source_type()
+            source_type = self.0.source_type(),
+            hex_format = self.0.hex_format()
         )
     }
 }

--- a/crates/ruff_python_formatter/tests/fixtures.rs
+++ b/crates/ruff_python_formatter/tests/fixtures.rs
@@ -277,6 +277,22 @@ fn format() {
     );
 }
 
+#[test]
+fn test_format_module_with_hex_format() {
+    use ruff_formatter::HexFormat;
+    use ruff_python_formatter::{format_module_source, PyFormatOptions};
+
+    let source = "x = 0x1a3f";
+
+    let options = PyFormatOptions::default().with_hex_format(HexFormat::Upper);
+    let formatted_upper = format_module_source(source, options).unwrap().into_code();
+    assert!(formatted_upper.contains("0x1A3F"));
+
+    let options = PyFormatOptions::default().with_hex_format(HexFormat::Lower);
+    let formatted_lower = format_module_source(source, options).unwrap().into_code();
+    assert!(formatted_lower.contains("0x1a3f"));
+}
+
 fn format_file(source: &str, options: &PyFormatOptions, input_path: &Path) -> String {
     let (unformatted, formatted_code) = if source.contains("<RANGE_START>") {
         let mut content = source.to_string();

--- a/crates/ruff_python_formatter/tests/snapshots/format@blank_line_before_class_docstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@blank_line_before_class_docstring.py.snap
@@ -58,6 +58,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Enabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python

--- a/crates/ruff_python_formatter/tests/snapshots/format@docstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@docstring.py.snap
@@ -177,6 +177,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python
@@ -353,6 +354,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python
@@ -529,6 +531,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python
@@ -705,6 +708,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python
@@ -881,6 +885,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python

--- a/crates/ruff_python_formatter/tests/snapshots/format@docstring_code_examples.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@docstring_code_examples.py.snap
@@ -1370,6 +1370,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python
@@ -2742,6 +2743,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python
@@ -4114,6 +4116,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python
@@ -5486,6 +5489,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python
@@ -6858,6 +6862,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python
@@ -8223,6 +8228,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python
@@ -9588,6 +9594,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python
@@ -10962,6 +10969,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python
@@ -12327,6 +12335,7 @@ docstring-code-line-width  = 60
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python
@@ -13701,6 +13710,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python

--- a/crates/ruff_python_formatter/tests/snapshots/format@docstring_code_examples_crlf.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@docstring_code_examples_crlf.py.snap
@@ -29,6 +29,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python

--- a/crates/ruff_python_formatter/tests/snapshots/format@docstring_code_examples_dynamic_line_width.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@docstring_code_examples_dynamic_line_width.py.snap
@@ -310,6 +310,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python
@@ -881,6 +882,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python
@@ -1427,6 +1429,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python
@@ -1998,6 +2001,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python

--- a/crates/ruff_python_formatter/tests/snapshots/format@docstring_tab_indentation.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@docstring_tab_indentation.py.snap
@@ -92,6 +92,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python
@@ -186,6 +187,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__bytes.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__bytes.py.snap
@@ -142,6 +142,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python
@@ -298,6 +299,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
@@ -753,6 +753,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Enabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python
@@ -1553,6 +1554,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring_preview.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring_preview.py.snap
@@ -40,6 +40,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Enabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__join_implicit_concatenated_string_preserve.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__join_implicit_concatenated_string_preserve.py.snap
@@ -42,6 +42,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python
@@ -83,6 +84,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.12
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__string.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__string.py.snap
@@ -234,6 +234,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python
@@ -484,6 +485,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python

--- a/crates/ruff_python_formatter/tests/snapshots/format@fmt_on_off__fmt_off_docstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@fmt_on_off__fmt_off_docstring.py.snap
@@ -39,6 +39,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python
@@ -77,6 +78,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python

--- a/crates/ruff_python_formatter/tests/snapshots/format@fmt_on_off__indent.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@fmt_on_off__indent.py.snap
@@ -20,6 +20,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python
@@ -39,6 +40,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python
@@ -58,6 +60,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python

--- a/crates/ruff_python_formatter/tests/snapshots/format@fmt_on_off__mixed_space_and_tab.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@fmt_on_off__mixed_space_and_tab.py.snap
@@ -35,6 +35,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python
@@ -70,6 +71,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python
@@ -105,6 +107,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python

--- a/crates/ruff_python_formatter/tests/snapshots/format@notebook_docstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@notebook_docstring.py.snap
@@ -26,6 +26,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Ipynb
+hex_format                = Upper
 ```
 
 ```python
@@ -50,6 +51,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python

--- a/crates/ruff_python_formatter/tests/snapshots/format@preview.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@preview.py.snap
@@ -86,6 +86,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python
@@ -169,6 +170,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Enabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python

--- a/crates/ruff_python_formatter/tests/snapshots/format@quote_style.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@quote_style.py.snap
@@ -70,6 +70,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python
@@ -144,6 +145,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python
@@ -218,6 +220,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python

--- a/crates/ruff_python_formatter/tests/snapshots/format@range_formatting__docstring_code_examples.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@range_formatting__docstring_code_examples.py.snap
@@ -123,6 +123,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python
@@ -275,6 +276,7 @@ docstring-code-line-width  = 88
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python

--- a/crates/ruff_python_formatter/tests/snapshots/format@range_formatting__indent.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@range_formatting__indent.py.snap
@@ -83,6 +83,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python
@@ -162,6 +163,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python
@@ -241,6 +243,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python

--- a/crates/ruff_python_formatter/tests/snapshots/format@range_formatting__stub.pyi.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@range_formatting__stub.pyi.snap
@@ -36,6 +36,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Stub
+hex_format                = Upper
 ```
 
 ```python

--- a/crates/ruff_python_formatter/tests/snapshots/format@skip_magic_trailing_comma.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@skip_magic_trailing_comma.py.snap
@@ -53,6 +53,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python
@@ -111,6 +112,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__with.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__with.py.snap
@@ -389,6 +389,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.8
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python
@@ -820,6 +821,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Enabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__with_39.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__with_39.py.snap
@@ -112,6 +112,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Enabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python

--- a/crates/ruff_python_formatter/tests/snapshots/format@stub_files__blank_line_after_nested_stub_class.pyi.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@stub_files__blank_line_after_nested_stub_class.pyi.snap
@@ -203,6 +203,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Enabled
 target_version             = 3.9
 source_type                = Stub
+hex_format                = Upper
 ```
 
 ```python

--- a/crates/ruff_python_formatter/tests/snapshots/format@stub_files__blank_line_after_nested_stub_class_eof.pyi.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@stub_files__blank_line_after_nested_stub_class_eof.pyi.snap
@@ -37,6 +37,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Enabled
 target_version             = 3.9
 source_type                = Stub
+hex_format                = Upper
 ```
 
 ```python

--- a/crates/ruff_python_formatter/tests/snapshots/format@tab_width.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@tab_width.py.snap
@@ -28,6 +28,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python
@@ -55,6 +56,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python
@@ -85,6 +87,7 @@ docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = 3.9
 source_type                = Python
+hex_format                = Upper
 ```
 
 ```python


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR introduces a new formatting option, `hex_format`, which allows users to specify whether hexadecimal numbers should be formatted in uppercase or lowercase. This enhances consistency in integer representation across a codebase already using hex in lowercase.

## Test Plan

- Added tests for hex numbers
- Updated snapshot tests to reflect the new behavior.
- Manually validated formatting results with different hex_format settings.
- The new setting does not break Black compatibility.