### PR TITLE
removed the need for unpacking using partial ord derive

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_async/rules/long_sleep_not_forever.rs
+++ b/crates/ruff_linter/src/rules/flake8_async/rules/long_sleep_not_forever.rs
@@ -1,6 +1,6 @@
 use ruff_diagnostics::{Diagnostic, Edit, Fix, FixAvailability, Violation};
 use ruff_macros::{derive_message_formats, ViolationMetadata};
-use ruff_python_ast::{Expr, ExprCall, ExprNumberLiteral, Number};
+use ruff_python_ast::{Expr, ExprCall, ExprNumberLiteral, Int, Number};
 use ruff_python_semantic::Modules;
 use ruff_text_size::Ranged;
 
@@ -76,24 +76,9 @@ pub(crate) fn long_sleep_not_forever(checker: &Checker, call: &ExprCall) {
     };
 
     // TODO(ekohilas): Replace with Duration::from_days(1).as_secs(); when available.
-    let one_day_in_secs = 60 * 60 * 24;
-    match value {
-        Number::Int(int_value) => {
-            let Some(int_value) = int_value.as_u64() else {
-                return;
-            };
-            if int_value <= one_day_in_secs {
-                return;
-            }
-        }
-        Number::Float(float_value) =>
-        {
-            #[allow(clippy::cast_precision_loss)]
-            if *float_value <= one_day_in_secs as f64 {
-                return;
-            }
-        }
-        Number::Complex { .. } => return,
+    let one_day_in_secs: u32 = 60 * 60 * 24;
+    if value <= &Number::Int(Int::from(one_day_in_secs)) {
+        return;
     }
 
     let Some(qualified_name) = checker

--- a/crates/ruff_python_ast/src/int.rs
+++ b/crates/ruff_python_ast/src/int.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 use std::str::FromStr;
 
 /// A Python integer literal. Represents both small (fits in an `i64`) and large integers.
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialOrd, PartialEq, Eq, Hash)]
 pub struct Int(Number);
 
 impl FromStr for Int {
@@ -215,7 +215,7 @@ impl From<u64> for Int {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialOrd, PartialEq, Eq, Hash)]
 enum Number {
     /// A "small" number that can be represented as an `u64`.
     Small(u64),

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -1891,7 +1891,7 @@ impl From<FStringFlags> for AnyStringFlags {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, is_macro::Is)]
+#[derive(Clone, Debug, PartialOrd, PartialEq, is_macro::Is)]
 pub enum Number {
     Int(int::Int),
     Float(f64),


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Uses `PartialOrd` derive on Number to allow for cleaner comparisons in rules such as in `long_sleep_not_forever`

## Test Plan

Run on existing tests
