### PR TITLE
Ruff 0.11.0

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -2,7 +2,7 @@
 
 ## 0.11.0
 
-This is largely a follow-up release to Ruff 0.10.0 because we accidentally didn't include the new `requires-python` inference changes. Ruff 0.11.0 now includes this change as well as the stabilization of `PGH004`'s preview behavior
+This is a follow-up to release 0.10.0. Because of a mistake in the release process, the `requires-python` inference changes were not included in that release. Ruff 0.11.0 now includes this change as well as the stabilization of the preview behavior for `PGH004`.
 
 - **Changes to how the Python version is inferred when a `target-version` is not specified** ([#16319](https://github.com/astral-sh/ruff/pull/16319))
 
@@ -29,26 +29,8 @@ This is largely a follow-up release to Ruff 0.10.0 because we accidentally didn'
 
 - **Changes to how the Python version is inferred when a `target-version` is not specified** ([#16319](https://github.com/astral-sh/ruff/pull/16319))
 
-    > Note: Because of a mistake in the release process, the `requires-python` inference changes are not included in this release and instead shipped as part of 0.11.0.
-
-    In previous versions of Ruff, you could specify your Python version with:
-
-    - The `target-version` option in a `ruff.toml` file or the `[tool.ruff]` section of a pyproject.toml file.
-    - The `project.requires-python` field in a `pyproject.toml` file with a `[tool.ruff]` section.
-
-    These options worked well in most cases, and are still recommended for fine control of the Python version. However, because of the way Ruff discovers config files, `pyproject.toml` files without a `[tool.ruff]` section would be ignored, including the `requires-python` setting. Ruff would then use the default Python version (3.9 as of this writing) instead, which is surprising when you've attempted to request another version.
-
-    In v0.10, config discovery has been updated to address this issue:
-
-    - If Ruff finds a `ruff.toml` file without a `target-version`, it will check
-        for a `pyproject.toml` file in the same directory and respect its
-        `requires-python` version, even if it does not contain a `[tool.ruff]`
-        section.
-    - If Ruff finds a user-level configuration, the `requires-python` field of the closest `pyproject.toml` in a parent directory will take precedence.
-    - If there is no config file (`ruff.toml`or `pyproject.toml` with a
-        `[tool.ruff]` section) in the directory of the file being checked, Ruff will
-        search for the closest `pyproject.toml` in the parent directories and use its
-        `requires-python` setting.
+    Because of a mistake in the release process, the `requires-python` inference changes are not included in this release and instead shipped as part of 0.11.0.
+    You can find a description of this change in the 0.11.0 section.
 
 - **Updated `TYPE_CHECKING` behavior** ([#16669](https://github.com/astral-sh/ruff/pull/16669))
 

--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -29,6 +29,8 @@ This is largely a follow-up release to Ruff 0.10.0 because we accidentally didn'
 
 - **Changes to how the Python version is inferred when a `target-version` is not specified** ([#16319](https://github.com/astral-sh/ruff/pull/16319))
 
+    > Note: Because of a mistake in the release process, the `requires-python` inference changes are not included in this release and instead shipped as part of 0.11.0.
+
     In previous versions of Ruff, you could specify your Python version with:
 
     - The `target-version` option in a `ruff.toml` file or the `[tool.ruff]` section of a pyproject.toml file.

--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -1,5 +1,30 @@
 # Breaking Changes
 
+## 0.11.0
+
+This is largely a follow-up release to Ruff 0.10.0 because we accidentally didn't include the new `requires-python` inference changes. Ruff 0.11.0 now includes this change as well as the stabilization of `PGH004`'s preview behavior
+
+- **Changes to how the Python version is inferred when a `target-version` is not specified** ([#16319](https://github.com/astral-sh/ruff/pull/16319))
+
+    In previous versions of Ruff, you could specify your Python version with:
+
+    - The `target-version` option in a `ruff.toml` file or the `[tool.ruff]` section of a pyproject.toml file.
+    - The `project.requires-python` field in a `pyproject.toml` file with a `[tool.ruff]` section.
+
+    These options worked well in most cases, and are still recommended for fine control of the Python version. However, because of the way Ruff discovers config files, `pyproject.toml` files without a `[tool.ruff]` section would be ignored, including the `requires-python` setting. Ruff would then use the default Python version (3.9 as of this writing) instead, which is surprising when you've attempted to request another version.
+
+    In v0.10, config discovery has been updated to address this issue:
+
+    - If Ruff finds a `ruff.toml` file without a `target-version`, it will check
+        for a `pyproject.toml` file in the same directory and respect its
+        `requires-python` version, even if it does not contain a `[tool.ruff]`
+        section.
+    - If Ruff finds a user-level configuration, the `requires-python` field of the closest `pyproject.toml` in a parent directory will take precedence.
+    - If there is no config file (`ruff.toml`or `pyproject.toml` with a
+        `[tool.ruff]` section) in the directory of the file being checked, Ruff will
+        search for the closest `pyproject.toml` in the parent directories and use its
+        `requires-python` setting.
+
 ## 0.10.0
 
 - **Changes to how the Python version is inferred when a `target-version` is not specified** ([#16319](https://github.com/astral-sh/ruff/pull/16319))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## 0.11.0
+
+This is largely a follow-up release to Ruff 0.10.0 because we accidentally didn't include the new `requires-python` inference changes. Ruff 0.11.0 now includes this change as well as the stabilization of `PGH004`'s preview behavior
+
+### Breaking changes
+
+- **Changes to how the Python version is inferred when a `target-version` is not specified** ([#16319](https://github.com/astral-sh/ruff/pull/16319))
+
+    In previous versions of Ruff, you could specify your Python version with:
+
+    - The `target-version` option in a `ruff.toml` file or the `[tool.ruff]` section of a pyproject.toml file.
+    - The `project.requires-python` field in a `pyproject.toml` file with a `[tool.ruff]` section.
+
+    These options worked well in most cases, and are still recommended for fine control of the Python version. However, because of the way Ruff discovers config files, `pyproject.toml` files without a `[tool.ruff]` section would be ignored, including the `requires-python` setting. Ruff would then use the default Python version (3.9 as of this writing) instead, which is surprising when you've attempted to request another version.
+
+    In v0.10, config discovery has been updated to address this issue:
+
+    - If Ruff finds a `ruff.toml` file without a `target-version`, it will check
+        for a `pyproject.toml` file in the same directory and respect its
+        `requires-python` version, even if it does not contain a `[tool.ruff]`
+        section.
+    - If Ruff finds a user-level configuration, the `requires-python` field of the closest `pyproject.toml` in a parent directory will take precedence.
+    - If there is no config file (`ruff.toml`or `pyproject.toml` with a
+        `[tool.ruff]` section) in the directory of the file being checked, Ruff will
+        search for the closest `pyproject.toml` in the parent directories and use its
+        `requires-python` setting.
+
+### Stabilization
+
+The following behaviors have been stabilized:
+
+- [`blanket-noqa`](https://docs.astral.sh/ruff/rules/blanket-noqa/) (`PGH004`): Also detect blanked file-level noqa comments (and not just line level comments).
+
+### Preview features
+
+- [syntax-errors] Tuple unpacking in `for` statement iterator clause before Python 3.9 ([#16558](https://github.com/astral-sh/ruff/pull/16558))
+
 ## 0.10.0
 
 Check out the [blog post](https://astral.sh/blog/ruff-v0.10.0) for a migration guide and overview of the changes!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ See also, the "Remapped rules" section which may result in disabled rules.
 
 - **Changes to how the Python version is inferred when a `target-version` is not specified** ([#16319](https://github.com/astral-sh/ruff/pull/16319))
 
+    > Note: Because of a mistake in the release process, the `requires-python` inference changes are not included in this release and instead shipped as part of 0.11.0.
+
     In previous versions of Ruff, you could specify your Python version with:
 
     - The `target-version` option in a `ruff.toml` file or the `[tool.ruff]` section of a pyproject.toml file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.11.0
 
-This is largely a follow-up release to Ruff 0.10.0 because we accidentally didn't include the new `requires-python` inference changes. Ruff 0.11.0 now includes this change as well as the stabilization of `PGH004`'s preview behavior
+This is a follow-up to release 0.10.0. Because of a mistake in the release process, the `requires-python` inference changes were not included in that release. Ruff 0.11.0 now includes this change as well as the stabilization of the preview behavior for `PGH004`.
 
 ### Breaking changes
 
@@ -47,26 +47,8 @@ See also, the "Remapped rules" section which may result in disabled rules.
 
 - **Changes to how the Python version is inferred when a `target-version` is not specified** ([#16319](https://github.com/astral-sh/ruff/pull/16319))
 
-    > Note: Because of a mistake in the release process, the `requires-python` inference changes are not included in this release and instead shipped as part of 0.11.0.
-
-    In previous versions of Ruff, you could specify your Python version with:
-
-    - The `target-version` option in a `ruff.toml` file or the `[tool.ruff]` section of a pyproject.toml file.
-    - The `project.requires-python` field in a `pyproject.toml` file with a `[tool.ruff]` section.
-
-    These options worked well in most cases, and are still recommended for fine control of the Python version. However, because of the way Ruff discovers config files, `pyproject.toml` files without a `[tool.ruff]` section would be ignored, including the `requires-python` setting. Ruff would then use the default Python version (3.9 as of this writing) instead, which is surprising when you've attempted to request another version.
-
-    In v0.10, config discovery has been updated to address this issue:
-
-    - If Ruff finds a `ruff.toml` file without a `target-version`, it will check
-        for a `pyproject.toml` file in the same directory and respect its
-        `requires-python` version, even if it does not contain a `[tool.ruff]`
-        section.
-    - If Ruff finds a user-level configuration, the `requires-python` field of the closest `pyproject.toml` in a parent directory will take precedence.
-    - If there is no config file (`ruff.toml`or `pyproject.toml` with a
-        `[tool.ruff]` section) in the directory of the file being checked, Ruff will
-        search for the closest `pyproject.toml` in the parent directories and use its
-        `requires-python` setting.
+    Because of a mistake in the release process, the `requires-python` inference changes are not included in this release and instead shipped as part of 0.11.0.
+    You can find a description of this change in the 0.11.0 section.
 
 - **Updated `TYPE_CHECKING` behavior** ([#16669](https://github.com/astral-sh/ruff/pull/16669))
 
@@ -125,7 +107,6 @@ The following behaviors have been stabilized:
 
 - [`bad-staticmethod-argument`](https://docs.astral.sh/ruff/rules/bad-staticmethod-argument/) (`PLW0211`) [`invalid-first-argument-name-for-class-method`](https://docs.astral.sh/ruff/rules/invalid-first-argument-name-for-class-method/) (`N804`): `__new__` methods are now no longer flagged by `invalid-first-argument-name-for-class-method` (`N804`) but instead by `bad-staticmethod-argument` (`PLW0211`)
 - [`bad-str-strip-call`](https://docs.astral.sh/ruff/rules/bad-str-strip-call/) (`PLE1310`): The rule now applies to objects which are known to have type `str` or `bytes`.
-- [`blanket-noqa`](https://docs.astral.sh/ruff/rules/blanket-noqa/) (`PGH004`): Also detect blanked file-level noqa comments (and not just line level comments).
 - [`custom-type-var-for-self`](https://docs.astral.sh/ruff/rules/custom-type-var-for-self/) (`PYI019`): More accurate detection of custom `TypeVars` replaceable by `Self`. The range of the diagnostic is now the full function header rather than just the return annotation.
 - [`invalid-argument-name`](https://docs.astral.sh/ruff/rules/invalid-argument-name/) (`N803`): Ignore argument names of functions decorated with `typing.override`
 - [`invalid-envvar-default`](https://docs.astral.sh/ruff/rules/invalid-envvar-default/) (`PLW1508`): Detect default value arguments to `os.environ.get` with invalid type.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2659,7 +2659,7 @@ dependencies = [
 
 [[package]]
 name = "ruff"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "argfile",
@@ -2894,7 +2894,7 @@ dependencies = [
 
 [[package]]
 name = "ruff_linter"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -3217,7 +3217,7 @@ dependencies = [
 
 [[package]]
 name = "ruff_wasm"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "console_error_panic_hook",
  "console_log",

--- a/README.md
+++ b/README.md
@@ -149,8 +149,8 @@ curl -LsSf https://astral.sh/ruff/install.sh | sh
 powershell -c "irm https://astral.sh/ruff/install.ps1 | iex"
 
 # For a specific version.
-curl -LsSf https://astral.sh/ruff/0.10.0/install.sh | sh
-powershell -c "irm https://astral.sh/ruff/0.10.0/install.ps1 | iex"
+curl -LsSf https://astral.sh/ruff/0.11.0/install.sh | sh
+powershell -c "irm https://astral.sh/ruff/0.11.0/install.ps1 | iex"
 ```
 
 You can also install Ruff via [Homebrew](https://formulae.brew.sh/formula/ruff), [Conda](https://anaconda.org/conda-forge/ruff),
@@ -183,7 +183,7 @@ Ruff can also be used as a [pre-commit](https://pre-commit.com/) hook via [`ruff
 ```yaml
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.10.0
+  rev: v0.11.0
   hooks:
     # Run the linter.
     - id: ruff

--- a/crates/ruff/Cargo.toml
+++ b/crates/ruff/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff"
-version = "0.10.0"
+version = "0.11.0"
 publish = true
 authors = { workspace = true }
 edition = { workspace = true }

--- a/crates/ruff_linter/Cargo.toml
+++ b/crates/ruff_linter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff_linter"
-version = "0.10.0"
+version = "0.11.0"
 publish = false
 authors = { workspace = true }
 edition = { workspace = true }

--- a/crates/ruff_wasm/Cargo.toml
+++ b/crates/ruff_wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff_wasm"
-version = "0.10.0"
+version = "0.11.0"
 publish = false
 authors = { workspace = true }
 edition = { workspace = true }

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -80,7 +80,7 @@ You can add the following configuration to `.gitlab-ci.yml` to run a `ruff forma
   stage: build
   interruptible: true
   image:
-    name: ghcr.io/astral-sh/ruff:0.10.0-alpine
+    name: ghcr.io/astral-sh/ruff:0.11.0-alpine
   before_script:
     - cd $CI_PROJECT_DIR
     - ruff --version
@@ -106,7 +106,7 @@ Ruff can be used as a [pre-commit](https://pre-commit.com) hook via [`ruff-pre-c
 ```yaml
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.10.0
+  rev: v0.11.0
   hooks:
     # Run the linter.
     - id: ruff
@@ -119,7 +119,7 @@ To enable lint fixes, add the `--fix` argument to the lint hook:
 ```yaml
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.10.0
+  rev: v0.11.0
   hooks:
     # Run the linter.
     - id: ruff
@@ -133,7 +133,7 @@ To avoid running on Jupyter Notebooks, remove `jupyter` from the list of allowed
 ```yaml
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.10.0
+  rev: v0.11.0
   hooks:
     # Run the linter.
     - id: ruff

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -365,7 +365,7 @@ This tutorial has focused on Ruff's command-line interface, but Ruff can also be
 ```yaml
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.10.0
+  rev: v0.11.0
   hooks:
     # Run the linter.
     - id: ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "ruff"
-version = "0.10.0"
+version = "0.11.0"
 description = "An extremely fast Python linter and code formatter, written in Rust."
 authors = [{ name = "Astral Software Inc.", email = "hey@astral.sh" }]
 readme = "README.md"

--- a/scripts/benchmarks/pyproject.toml
+++ b/scripts/benchmarks/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scripts"
-version = "0.10.0"
+version = "0.11.0"
 description = ""
 authors = ["Charles Marsh <charlie.r.marsh@gmail.com>"]
 


### PR DESCRIPTION
## Summary

Follow-up release for Ruff v0.10 that now includes the following two changes that we intended to ship but slipped:

* Changes to how the Python version is inferred when a `target-version` is not specified (#16319)
* `blanket-noqa` (`PGH004`): Also detect blanked file-level noqa comments (and not just line level comments).

## Test plan

I verified that the binary built on this branch respects the `requires-python` setting ([logs](https://www.diffchecker.com/qyJWYi6W/), left: v0.10, right: v0.11)
