### PR TITLE
Use the common `OperatorPrecedence` for the parser

### DIFF
--- a/crates/ruff_python_ast/src/operator_precedence.rs
+++ b/crates/ruff_python_ast/src/operator_precedence.rs
@@ -131,6 +131,12 @@ impl OperatorPrecedence {
     pub fn from_expr(expr: &Expr) -> Self {
         Self::from(&ExprRef::from(expr))
     }
+
+    /// Returns `true` if the precedence is right-associative i.e., the operations are evaluated
+    /// from right to left.
+    pub fn is_right_associative(self) -> bool {
+        matches!(self, OperatorPrecedence::Exponent)
+    }
 }
 
 impl From<&Expr> for OperatorPrecedence {
@@ -177,3 +183,13 @@ impl From<BoolOp> for OperatorPrecedence {
         }
     }
 }
+
+impl From<UnaryOp> for OperatorPrecedence {
+    fn from(unary_op: UnaryOp) -> Self {
+        match unary_op{
+            UnaryOp::UAdd | UnaryOp::USub | UnaryOp::Invert => Self::PosNegBitNot,
+            UnaryOp::Not => Self::Not,
+        }
+    }
+}
+

--- a/crates/ruff_python_ast/src/operator_precedence.rs
+++ b/crates/ruff_python_ast/src/operator_precedence.rs
@@ -186,10 +186,9 @@ impl From<BoolOp> for OperatorPrecedence {
 
 impl From<UnaryOp> for OperatorPrecedence {
     fn from(unary_op: UnaryOp) -> Self {
-        match unary_op{
+        match unary_op {
             UnaryOp::UAdd | UnaryOp::USub | UnaryOp::Invert => Self::PosNegBitNot,
             UnaryOp::Not => Self::Not,
         }
     }
 }
-

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -272,13 +272,6 @@ impl<'src> Parser<'src> {
 
             let new_precedence = operator.precedence();
 
-            // NOTE TO SELF (todo: delete this comment before merging):
-            // At this point in the code, if we ever compare a BitXor to a BitOr, the result will
-            // be wrong (when we're using ast's OperatorPrecedence) bc of ast has BitXorOr and
-            // OldOperatorPrecedence has BitOr *and* BitXor
-            //
-            // So we need to change this logic to work if there's a single BitXorOr variant of
-            // OperatorPrecedence. I think that might fix the problem!
             let stop_at_current_operator = if new_precedence.is_right_associative() {
                 new_precedence < left_precedence
             } else {
@@ -2603,59 +2596,6 @@ impl Ranged for ParsedExpr {
     }
 }
 
-/*
-/// Represents the precedence levels for various operators and expressions of Python.
-/// Variants at the top have lower precedence and variants at the bottom have
-/// higher precedence.
-///
-/// Note: Some expressions like if-else, named expression (`:=`), lambda, subscription,
-/// slicing, call and attribute reference expressions, that are mentioned in the link
-/// below are better handled in other parts of the parser.
-///
-/// See: <https://docs.python.org/3/reference/expressions.html#operator-precedence>
-#[derive(Debug, Ord, Eq, PartialEq, PartialOrd, Copy, Clone)]
-pub(super) enum OldOperatorPrecedence {
-    /// The initial precedence when parsing an expression.
-    Initial,
-    /// Precedence of boolean `or` operator.
-    Or,
-    /// Precedence of boolean `and` operator.
-    And,
-    /// Precedence of boolean `not` unary operator.
-    Not,
-    /// Precedence of comparisons operators (`<`, `<=`, `>`, `>=`, `!=`, `==`),
-    /// memberships tests (`in`, `not in`) and identity tests (`is` `is not`).
-    ComparisonsMembershipIdentity,
-    /// Precedence of `Bitwise OR` (`|`) operator.
-    BitOr,
-    /// Precedence of `Bitwise XOR` (`^`) operator.
-    BitXor,
-    /// Precedence of `Bitwise AND` (`&`) operator.
-    BitAnd,
-    /// Precedence of left and right shift operators (`<<`, `>>`).
-    LeftRightShift,
-    /// Precedence of addition (`+`) and subtraction (`-`) operators.
-    AddSub,
-    /// Precedence of multiplication (`*`), matrix multiplication (`@`), division (`/`), floor
-    /// division (`//`) and remainder operators (`%`).
-    MulDivRemain,
-    /// Precedence of positive (`+`), negative (`-`), `Bitwise NOT` (`~`) unary operators.
-    PosNegBitNot,
-    /// Precedence of exponentiation operator (`**`).
-    Exponent,
-    /// Precedence of `await` expression.
-    Await,
-}
-
-impl OldOperatorPrecedence {
-    /// Returns `true` if the precedence is right-associative i.e., the operations are evaluated
-    /// from right to left.
-    fn is_right_associative(self) -> bool {
-        matches!(self, OldOperatorPrecedence::Exponent)
-    }
-}
-*/
-
 #[derive(Debug)]
 enum BinaryLikeOperator {
     Boolean(BoolOp),
@@ -2686,47 +2626,6 @@ impl BinaryLikeOperator {
         }
     }
 }
-
-/*
-impl From<BoolOp> for OldOperatorPrecedence {
-    #[inline]
-    fn from(op: BoolOp) -> Self {
-        match op {
-            BoolOp::And => OldOperatorPrecedence::And,
-            BoolOp::Or => OldOperatorPrecedence::Or,
-        }
-    }
-}
-
-impl From<UnaryOp> for OldOperatorPrecedence {
-    #[inline]
-    fn from(op: UnaryOp) -> Self {
-        match op {
-            UnaryOp::Not => OldOperatorPrecedence::Not,
-            _ => OldOperatorPrecedence::PosNegBitNot,
-        }
-    }
-}
-
-impl From<Operator> for OldOperatorPrecedence {
-    #[inline]
-    fn from(op: Operator) -> Self {
-        match op {
-            Operator::Add | Operator::Sub => OldOperatorPrecedence::AddSub,
-            Operator::Mult
-            | Operator::Div
-            | Operator::FloorDiv
-            | Operator::Mod
-            | Operator::MatMult => OldOperatorPrecedence::MulDivRemain,
-            Operator::BitAnd => OldOperatorPrecedence::BitAnd,
-            Operator::BitOr => OldOperatorPrecedence::BitOr,
-            Operator::BitXor => OldOperatorPrecedence::BitXor,
-            Operator::LShift | Operator::RShift => OldOperatorPrecedence::LeftRightShift,
-            Operator::Pow => OldOperatorPrecedence::Exponent,
-        }
-    }
-}
-*/
 
 /// Represents the precedence used for parsing the value part of a starred expression.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/ruff_python_parser/tests/fixtures.rs
+++ b/crates/ruff_python_parser/tests/fixtures.rs
@@ -13,7 +13,6 @@ use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 #[test]
 fn valid_syntax() {
     insta::glob!("../resources", "valid/**/*.py", test_valid_syntax);
-    // insta::glob!("../resources", "valid/expressions/bool_op.py", test_valid_syntax); // remove
 }
 
 #[test]

--- a/crates/ruff_python_parser/tests/fixtures.rs
+++ b/crates/ruff_python_parser/tests/fixtures.rs
@@ -13,6 +13,7 @@ use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 #[test]
 fn valid_syntax() {
     insta::glob!("../resources", "valid/**/*.py", test_valid_syntax);
+    // insta::glob!("../resources", "valid/expressions/bool_op.py", test_valid_syntax); // remove
 }
 
 #[test]

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__bin_op.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__bin_op.py.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/ruff_python_parser/tests/fixtures.rs
 input_file: crates/ruff_python_parser/resources/valid/expressions/bin_op.py
-snapshot_kind: text
 ---
 ## AST
 
@@ -767,19 +766,19 @@ Module(
                     value: BinOp(
                         ExprBinOp {
                             range: 270..306,
-                            left: NumberLiteral(
-                                ExprNumberLiteral {
-                                    range: 270..271,
-                                    value: Int(
-                                        1,
-                                    ),
-                                },
-                            ),
-                            op: BitOr,
-                            right: BinOp(
+                            left: BinOp(
                                 ExprBinOp {
-                                    range: 274..306,
-                                    left: BinOp(
+                                    range: 270..279,
+                                    left: NumberLiteral(
+                                        ExprNumberLiteral {
+                                            range: 270..271,
+                                            value: Int(
+                                                1,
+                                            ),
+                                        },
+                                    ),
+                                    op: BitOr,
+                                    right: BinOp(
                                         ExprBinOp {
                                             range: 274..279,
                                             left: NumberLiteral(
@@ -801,67 +800,44 @@ Module(
                                             ),
                                         },
                                     ),
-                                    op: BitXor,
-                                    right: BinOp(
+                                },
+                            ),
+                            op: BitXor,
+                            right: BinOp(
+                                ExprBinOp {
+                                    range: 282..306,
+                                    left: BinOp(
                                         ExprBinOp {
-                                            range: 282..306,
+                                            range: 282..301,
                                             left: BinOp(
                                                 ExprBinOp {
-                                                    range: 282..301,
-                                                    left: BinOp(
-                                                        ExprBinOp {
-                                                            range: 282..291,
-                                                            left: NumberLiteral(
-                                                                ExprNumberLiteral {
-                                                                    range: 282..283,
-                                                                    value: Int(
-                                                                        4,
-                                                                    ),
-                                                                },
-                                                            ),
-                                                            op: Add,
-                                                            right: BinOp(
-                                                                ExprBinOp {
-                                                                    range: 286..291,
-                                                                    left: NumberLiteral(
-                                                                        ExprNumberLiteral {
-                                                                            range: 286..287,
-                                                                            value: Int(
-                                                                                5,
-                                                                            ),
-                                                                        },
-                                                                    ),
-                                                                    op: MatMult,
-                                                                    right: NumberLiteral(
-                                                                        ExprNumberLiteral {
-                                                                            range: 290..291,
-                                                                            value: Int(
-                                                                                6,
-                                                                            ),
-                                                                        },
-                                                                    ),
-                                                                },
+                                                    range: 282..291,
+                                                    left: NumberLiteral(
+                                                        ExprNumberLiteral {
+                                                            range: 282..283,
+                                                            value: Int(
+                                                                4,
                                                             ),
                                                         },
                                                     ),
-                                                    op: LShift,
+                                                    op: Add,
                                                     right: BinOp(
                                                         ExprBinOp {
-                                                            range: 295..301,
+                                                            range: 286..291,
                                                             left: NumberLiteral(
                                                                 ExprNumberLiteral {
-                                                                    range: 295..296,
+                                                                    range: 286..287,
                                                                     value: Int(
-                                                                        7,
+                                                                        5,
                                                                     ),
                                                                 },
                                                             ),
-                                                            op: FloorDiv,
+                                                            op: MatMult,
                                                             right: NumberLiteral(
                                                                 ExprNumberLiteral {
-                                                                    range: 300..301,
+                                                                    range: 290..291,
                                                                     value: Int(
-                                                                        8,
+                                                                        6,
                                                                     ),
                                                                 },
                                                             ),
@@ -869,14 +845,37 @@ Module(
                                                     ),
                                                 },
                                             ),
-                                            op: RShift,
-                                            right: NumberLiteral(
-                                                ExprNumberLiteral {
-                                                    range: 305..306,
-                                                    value: Int(
-                                                        9,
+                                            op: LShift,
+                                            right: BinOp(
+                                                ExprBinOp {
+                                                    range: 295..301,
+                                                    left: NumberLiteral(
+                                                        ExprNumberLiteral {
+                                                            range: 295..296,
+                                                            value: Int(
+                                                                7,
+                                                            ),
+                                                        },
+                                                    ),
+                                                    op: FloorDiv,
+                                                    right: NumberLiteral(
+                                                        ExprNumberLiteral {
+                                                            range: 300..301,
+                                                            value: Int(
+                                                                8,
+                                                            ),
+                                                        },
                                                     ),
                                                 },
+                                            ),
+                                        },
+                                    ),
+                                    op: RShift,
+                                    right: NumberLiteral(
+                                        ExprNumberLiteral {
+                                            range: 305..306,
+                                            value: Int(
+                                                9,
                                             ),
                                         },
                                     ),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__bin_op.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__bin_op.py.snap
@@ -766,19 +766,19 @@ Module(
                     value: BinOp(
                         ExprBinOp {
                             range: 270..306,
-                            left: BinOp(
-                                ExprBinOp {
-                                    range: 270..279,
-                                    left: NumberLiteral(
-                                        ExprNumberLiteral {
-                                            range: 270..271,
-                                            value: Int(
-                                                1,
-                                            ),
-                                        },
+                            left: NumberLiteral(
+                                ExprNumberLiteral {
+                                    range: 270..271,
+                                    value: Int(
+                                        1,
                                     ),
-                                    op: BitOr,
-                                    right: BinOp(
+                                },
+                            ),
+                            op: BitOr,
+                            right: BinOp(
+                                ExprBinOp {
+                                    range: 274..306,
+                                    left: BinOp(
                                         ExprBinOp {
                                             range: 274..279,
                                             left: NumberLiteral(
@@ -800,44 +800,67 @@ Module(
                                             ),
                                         },
                                     ),
-                                },
-                            ),
-                            op: BitXor,
-                            right: BinOp(
-                                ExprBinOp {
-                                    range: 282..306,
-                                    left: BinOp(
+                                    op: BitXor,
+                                    right: BinOp(
                                         ExprBinOp {
-                                            range: 282..301,
+                                            range: 282..306,
                                             left: BinOp(
                                                 ExprBinOp {
-                                                    range: 282..291,
-                                                    left: NumberLiteral(
-                                                        ExprNumberLiteral {
-                                                            range: 282..283,
-                                                            value: Int(
-                                                                4,
-                                                            ),
-                                                        },
-                                                    ),
-                                                    op: Add,
-                                                    right: BinOp(
+                                                    range: 282..301,
+                                                    left: BinOp(
                                                         ExprBinOp {
-                                                            range: 286..291,
+                                                            range: 282..291,
                                                             left: NumberLiteral(
                                                                 ExprNumberLiteral {
-                                                                    range: 286..287,
+                                                                    range: 282..283,
                                                                     value: Int(
-                                                                        5,
+                                                                        4,
                                                                     ),
                                                                 },
                                                             ),
-                                                            op: MatMult,
+                                                            op: Add,
+                                                            right: BinOp(
+                                                                ExprBinOp {
+                                                                    range: 286..291,
+                                                                    left: NumberLiteral(
+                                                                        ExprNumberLiteral {
+                                                                            range: 286..287,
+                                                                            value: Int(
+                                                                                5,
+                                                                            ),
+                                                                        },
+                                                                    ),
+                                                                    op: MatMult,
+                                                                    right: NumberLiteral(
+                                                                        ExprNumberLiteral {
+                                                                            range: 290..291,
+                                                                            value: Int(
+                                                                                6,
+                                                                            ),
+                                                                        },
+                                                                    ),
+                                                                },
+                                                            ),
+                                                        },
+                                                    ),
+                                                    op: LShift,
+                                                    right: BinOp(
+                                                        ExprBinOp {
+                                                            range: 295..301,
+                                                            left: NumberLiteral(
+                                                                ExprNumberLiteral {
+                                                                    range: 295..296,
+                                                                    value: Int(
+                                                                        7,
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            op: FloorDiv,
                                                             right: NumberLiteral(
                                                                 ExprNumberLiteral {
-                                                                    range: 290..291,
+                                                                    range: 300..301,
                                                                     value: Int(
-                                                                        6,
+                                                                        8,
                                                                     ),
                                                                 },
                                                             ),
@@ -845,37 +868,14 @@ Module(
                                                     ),
                                                 },
                                             ),
-                                            op: LShift,
-                                            right: BinOp(
-                                                ExprBinOp {
-                                                    range: 295..301,
-                                                    left: NumberLiteral(
-                                                        ExprNumberLiteral {
-                                                            range: 295..296,
-                                                            value: Int(
-                                                                7,
-                                                            ),
-                                                        },
-                                                    ),
-                                                    op: FloorDiv,
-                                                    right: NumberLiteral(
-                                                        ExprNumberLiteral {
-                                                            range: 300..301,
-                                                            value: Int(
-                                                                8,
-                                                            ),
-                                                        },
+                                            op: RShift,
+                                            right: NumberLiteral(
+                                                ExprNumberLiteral {
+                                                    range: 305..306,
+                                                    value: Int(
+                                                        9,
                                                     ),
                                                 },
-                                            ),
-                                        },
-                                    ),
-                                    op: RShift,
-                                    right: NumberLiteral(
-                                        ExprNumberLiteral {
-                                            range: 305..306,
-                                            value: Int(
-                                                9,
                                             ),
                                         },
                                     ),


### PR DESCRIPTION
## Summary

This change continues to resolve #16071 (and continues the work started in #16162). Specifically, this PR changes the code in the parser so that it uses the `OperatorPrecedence` struct from `ruff_python_ast` instead of its own version. This is part of an effort to get rid of the redundant definitions of `OperatorPrecedence` throughout the codebase. 

Note that this PR only makes this change for `ruff_python_parser` -- we still want to make a similar change for the formatter (namely the `OperatorPrecedence` defined in the expression part of the formatter, the pattern one is different). I separated the work to keep the PRs small and easily reviewable.

## Test Plan

Because this is an internal change, I didn't add any additional tests. Existing tests do pass.
