### PR TITLE
[red-knot] add support for `--output-format={full,concise}`

### DIFF
--- a/crates/red_knot/src/main.rs
+++ b/crates/red_knot/src/main.rs
@@ -256,6 +256,7 @@ impl MainLoop {
                     revision: check_revision,
                 } => {
                     let display_config = DisplayDiagnosticConfig::default()
+                        .format(db.project().settings(db).terminal().output_format)
                         .color(colored::control::SHOULD_COLORIZE.should_colorize());
 
                     let min_error_severity =

--- a/crates/red_knot/tests/cli.rs
+++ b/crates/red_knot/tests/cli.rs
@@ -967,6 +967,30 @@ fn check_non_existing_path() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[test]
+fn concise_diagnostics() -> anyhow::Result<()> {
+    let case = TestCase::with_file(
+        "test.py",
+        r#"
+        print(x)     # [unresolved-reference]
+        print(4[1])  # [non-subscriptable]
+        "#,
+    )?;
+
+    assert_cmd_snapshot!(case.command().arg("--output-format=concise"), @r"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    warning[lint:unresolved-reference] <temp_dir>/test.py:2:7: Name `x` used when not defined
+    error[lint:non-subscriptable] <temp_dir>/test.py:3:7: Cannot subscript object of type `Literal[4]` with no `__getitem__` method
+    Found 2 diagnostics
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
 struct TestCase {
     _temp_dir: TempDir,
     _settings_scope: SettingsBindDropGuard,

--- a/crates/red_knot_project/src/metadata/options.rs
+++ b/crates/red_knot_project/src/metadata/options.rs
@@ -2,7 +2,7 @@ use crate::metadata::value::{RangedValue, RelativePathBuf, ValueSource, ValueSou
 use crate::Db;
 use red_knot_python_semantic::lint::{GetLintError, Level, LintSource, RuleSelection};
 use red_knot_python_semantic::{ProgramSettings, PythonPath, PythonPlatform, SearchPathSettings};
-use ruff_db::diagnostic::{DiagnosticId, OldDiagnosticTrait, Severity, Span};
+use ruff_db::diagnostic::{DiagnosticFormat, DiagnosticId, OldDiagnosticTrait, Severity, Span};
 use ruff_db::files::system_path_to_file;
 use ruff_db::system::{System, SystemPath};
 use ruff_macros::Combine;
@@ -120,6 +120,11 @@ impl Options {
 
         if let Some(terminal) = self.terminal.as_ref() {
             settings.set_terminal(TerminalSettings {
+                output_format: terminal
+                    .output_format
+                    .as_deref()
+                    .copied()
+                    .unwrap_or_default(),
                 error_on_warning: terminal.error_on_warning.unwrap_or_default(),
             });
         }
@@ -277,6 +282,11 @@ impl FromIterator<(RangedValue<String>, RangedValue<Level>)> for Rules {
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct TerminalOptions {
+    /// The format to use for printing diagnostic messages.
+    ///
+    /// Defaults to `full`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_format: Option<RangedValue<DiagnosticFormat>>,
     /// Use exit code 1 if there are any warning-level diagnostics.
     ///
     /// Defaults to `false`.

--- a/crates/red_knot_project/src/metadata/settings.rs
+++ b/crates/red_knot_project/src/metadata/settings.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use red_knot_python_semantic::lint::RuleSelection;
+use ruff_db::diagnostic::DiagnosticFormat;
 
 /// The resolved [`super::Options`] for the project.
 ///
@@ -49,5 +50,6 @@ impl Settings {
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct TerminalSettings {
+    pub output_format: DiagnosticFormat,
     pub error_on_warning: bool,
 }

--- a/crates/ruff_db/src/diagnostic/mod.rs
+++ b/crates/ruff_db/src/diagnostic/mod.rs
@@ -518,6 +518,10 @@ impl Severity {
 /// Configuration for rendering diagnostics.
 #[derive(Clone, Debug, Default)]
 pub struct DisplayDiagnosticConfig {
+    /// The format to use for diagnostic rendering.
+    ///
+    /// This uses the "full" format by default.
+    format: DiagnosticFormat,
     /// Whether to enable colors or not.
     ///
     /// Disabled by default.
@@ -525,8 +529,38 @@ pub struct DisplayDiagnosticConfig {
 }
 
 impl DisplayDiagnosticConfig {
+    /// Whether to enable concise diagnostic output or not.
+    pub fn format(self, format: DiagnosticFormat) -> DisplayDiagnosticConfig {
+        DisplayDiagnosticConfig { format, ..self }
+    }
+
     /// Whether to enable colors or not.
     pub fn color(self, yes: bool) -> DisplayDiagnosticConfig {
-        DisplayDiagnosticConfig { color: yes }
+        DisplayDiagnosticConfig { color: yes, ..self }
     }
+}
+
+/// The diagnostic output format.
+#[derive(Copy, Clone, Debug, Default, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub enum DiagnosticFormat {
+    /// The default full mode will print "pretty" diagnostics.
+    ///
+    /// That is, color will be used when printing to a `tty`.
+    /// Moreover, diagnostic messages may include additional
+    /// context and annotations on the input to help understand
+    /// the message.
+    #[default]
+    Full,
+    /// Print diagnostics in a concise mode.
+    ///
+    /// This will guarantee that each diagnostic is printed on
+    /// a single line. Only the most important or primary aspects
+    /// of the diagnostic are included. Contextual information is
+    /// dropped.
+    ///
+    /// This may use color when printing to a `tty`.
+    Concise,
 }

--- a/knot.schema.json
+++ b/knot.schema.json
@@ -49,6 +49,25 @@
   },
   "additionalProperties": false,
   "definitions": {
+    "DiagnosticFormat": {
+      "description": "The diagnostic output format.",
+      "oneOf": [
+        {
+          "description": "The default full mode will print \"pretty\" diagnostics.\n\nThat is, color will be used when printing to a `tty`. Moreover, diagnostic messages may include additional context and annotations on the input to help understand the message.",
+          "type": "string",
+          "enum": [
+            "full"
+          ]
+        },
+        {
+          "description": "Print diagnostics in a concise mode.\n\nThis will guarantee that each diagnostic is printed on a single line. Only the most important or primary aspects of the diagnostic are included. Contextual information is dropped.\n\nThis may use color when printing to a `tty`.",
+          "type": "string",
+          "enum": [
+            "concise"
+          ]
+        }
+      ]
+    },
     "EnvironmentOptions": {
       "type": "object",
       "properties": {
@@ -747,6 +766,17 @@
           "type": [
             "boolean",
             "null"
+          ]
+        },
+        "output-format": {
+          "description": "The format to use for printing diagnostic messages.\n\nDefaults to `full`.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DiagnosticFormat"
+            },
+            {
+              "type": "null"
+            }
           ]
         }
       },


### PR DESCRIPTION
This does pretty much what it says on the tin.

The concise format used in this PR was partially resurrected from
the diagnostic rendering used before #15856 landed. Specifically,
the concise format guarantees that every diagnostic uses exactly one
line of output. (This guarantee isn't technically enforced in every
conceivable way. For example, there's nothing stopping a diagnostic
message from containing multiple lines, but this seems like a bad idea
in general anyway.)

The motivation for this functionality is to provide a way to get
succinct diagnostics for whenever that is useful. For [example].

Many thanks to @MichaReiser for giving me the play-by-play on
how to plumb a new CLI option. Saved me a lot of time. :-)

[example]: https://github.com/astral-sh/ruff/issues/15697#issuecomment-2706477278
