### PR TITLE
[red-knot] LSP: only emit WARN logs from non-red-knot sources

### DIFF
--- a/crates/red_knot_server/src/logging.rs
+++ b/crates/red_knot_server/src/logging.rs
@@ -102,7 +102,7 @@ impl<S> tracing_subscriber::layer::Filter<S> for LogLevelFilter {
         let filter = if meta.target().starts_with("red_knot") {
             self.filter.trace_level()
         } else {
-            tracing::Level::INFO
+            tracing::Level::WARN
         };
 
         meta.level() <= &filter


### PR DESCRIPTION
Currently the red-knot LSP server emits any log messages of level `INFO` or higher from non-red-knot crates. This makes its output quite verbose, because Salsa emits an `INFO` level message every time it executes a query. I use red-knot as LSP with neovim, and this spams the log file quite a lot.

It seems like a better default to only emit `WARN` or higher messages from non-red-knot sources.

I confirmed that this fixes the nvim LSP log spam.
