### PR TITLE
[red-knot] Extend ecosystem checks

### DIFF
--- a/.github/workflows/mypy_primer.yaml
+++ b/.github/workflows/mypy_primer.yaml
@@ -68,7 +68,7 @@ jobs:
             --type-checker knot \
             --old base_commit \
             --new "$GITHUB_SHA" \
-            --project-selector '/(mypy_primer|black|pyp|git-revise|zipp|arrow)$' \
+            --project-selector '/(mypy_primer|black|pyp|git-revise|zipp|arrow|isort|itsdangerous|rich|packaging|pybind11|pyinstrument)$' \
             --output concise \
             --debug > mypy_primer.diff || [ $? -eq 1 ]
 


### PR DESCRIPTION
## Summary

The ecosystem checks have proven useful so far, so I'm extending the list a bit. My main selection criteria are:

- Few dependencies (we don't understand -stubs/-types packages yet)
- Fewer than 1000 diagnostics
- No panics

## Test Plan

Ran it locally. We now have ~2k diagnostics in total, across 12 projects
