### PR TITLE
[`flake8-gettext`] Swap `format-` and `printf-in-get-text-func-call` examples (`INT002`, `INT003`)

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_gettext/rules/format_in_gettext_func_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_gettext/rules/format_in_gettext_func_call.rs
@@ -27,7 +27,7 @@ use crate::checkers::ast::Checker;
 /// from gettext import gettext as _
 ///
 /// name = "Maria"
-/// _("Hello, %s!" % name)  # Looks for "Hello, Maria!".
+/// _("Hello, {}!".format(name))  # Looks for "Hello, Maria!".
 /// ```
 ///
 /// Use instead:

--- a/crates/ruff_linter/src/rules/flake8_gettext/rules/printf_in_gettext_func_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_gettext/rules/printf_in_gettext_func_call.rs
@@ -26,7 +26,7 @@ use ruff_text_size::Ranged;
 /// from gettext import gettext as _
 ///
 /// name = "Maria"
-/// _("Hello, {}!".format(name))  # Looks for "Hello, Maria!".
+/// _("Hello, %s!" % name)  # Looks for "Hello, Maria!".
 /// ```
 ///
 /// Use instead:


### PR DESCRIPTION
Summary
--
Fixes #16735. I also checked `INT001`, and it correctly has an f-string example.

Test Plan
--
None
