### PR TITLE
[ci]: Disable wheel testing on `ppc64le`

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -311,7 +311,7 @@ jobs:
           docker-options: ${{ matrix.platform.maturin_docker_options }}
           args: --release --locked --out dist
       - uses: uraimo/run-on-arch-action@ac33288c3728ca72563c97b8b88dda5a65a84448 # v2
-        if: matrix.platform.arch != 'ppc64'
+        if: ${{ matrix.platform.arch != 'ppc64' && matrix.platform.arch != 'ppc64le'}}
         name: Test wheel
         with:
           arch: ${{ matrix.platform.arch == 'arm' && 'armv6' || matrix.platform.arch }}


### PR DESCRIPTION
## Summary

The PPC64le wheel testing job spuriously failes due to some race when installing python dependencies. 
This is very annoying because it requires restarting the release process over and over again until you're lucky and it passes. 

This PR disables wheel testing on PPC64le

This is the same as we did in uv, see https://github.com/astral-sh/uv/issues/11231

## Test Plan

The wheel test step was skipped in CI, see https://github.com/astral-sh/ruff/actions/runs/13895143309/job/38874065160?pr=16793 but it still runs for other targets
