### PR TITLE
[ci] Test linter-only change

### DIFF
--- a/crates/ruff_linter/src/locator.rs
+++ b/crates/ruff_linter/src/locator.rs
@@ -27,7 +27,7 @@ impl<'a> Locator<'a> {
     }
 
     #[deprecated(
-        note = "This is expensive, avoid using outside of the diagnostic phase. Prefer the other `Locator` methods instead."
+        note = "This is expensive, avoid using outside of the diagnostic phase. Prefer the other `Locator` methods instead TEEEEST."
     )]
     pub fn compute_line_index(&self, offset: TextSize) -> OneIndexed {
         self.to_index().line_index(offset)


### PR DESCRIPTION
Tests the changes in https://github.com/astral-sh/ruff/pull/16796 by making a linter only change. 

It should skip the formatter specific pipelines but run the linter ecosystem checks.
