### PR TITLE
[red-knot] Check subtype relation between callable types

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
@@ -730,5 +730,20 @@ def mixed(a: int, /, b: int) -> None: ...
 static_assert(not is_subtype_of(CallableTypeFromFunction[variadic], CallableTypeFromFunction[mixed]))
 ```
 
+#### Empty
+
+When the supertype has an empty list of parameters, then the subtype can have any kind of parameters
+as long as they contain the default values for non-variadic parameters.
+
+```py
+from knot_extensions import CallableTypeFromFunction, is_subtype_of, static_assert
+
+def empty() -> None: ...
+def mixed(a: int = 1, /, b: int = 2, *args: int, c: int = 3, **kwargs: int) -> None: ...
+
+static_assert(is_subtype_of(CallableTypeFromFunction[mixed], CallableTypeFromFunction[empty]))
+static_assert(not is_subtype_of(CallableTypeFromFunction[empty], CallableTypeFromFunction[mixed]))
+```
+
 [special case for float and complex]: https://typing.readthedocs.io/en/latest/spec/special-types.html#special-cases-for-float-and-complex
 [typing documentation]: https://typing.readthedocs.io/en/latest/spec/concepts.html#subtype-supertype-and-type-equivalence

--- a/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
@@ -564,7 +564,8 @@ static_assert(not is_subtype_of(CallableTypeFromFunction[int_without_default], C
 static_assert(not is_subtype_of(CallableTypeFromFunction[empty], CallableTypeFromFunction[int_with_default]))
 ```
 
-The subtype can include as many positional-only parameters as long as they have the default value:
+The subtype can include any number of positional-only parameters as long as they have the default
+value:
 
 ```py
 def multi_param(a: float = 1, b: int = 2, c: str = "3", /) -> None: ...
@@ -736,7 +737,7 @@ static_assert(not is_subtype_of(CallableTypeFromFunction[multi_standard], Callab
 
 #### Standard with variadic
 
-A standard parameter in the supertype cannot be substituted with a variadic or keyword-variadic
+A variadic or keyword-variadic parameter in the supertype cannot be substituted with a standard
 parameter in the subtype.
 
 ```py
@@ -793,14 +794,27 @@ static_assert(is_subtype_of(CallableTypeFromFunction[variadic], CallableTypeFrom
 static_assert(is_subtype_of(CallableTypeFromFunction[variadic], CallableTypeFromFunction[positional_variadic]))
 ```
 
-This is valid only for positional-only parameters, not any other parameter kind:
+#### Variadic with other kinds
+
+Variadic parameter in a subtype can only be used to match against an unmatched positional-only
+parameters from the supertype, not any other parameter kind.
 
 ```py
-# Parameter 1 is matched with the one at the same position, parameter 2 is unmatched so uses the
-# variadic parameter but the standard parameter `c` remains and cannot be matched.
-def mixed(a: int, b: float, /, c: int) -> None: ...
+from knot_extensions import CallableTypeFromFunction, is_subtype_of, static_assert
 
-static_assert(not is_subtype_of(CallableTypeFromFunction[variadic], CallableTypeFromFunction[mixed]))
+def variadic(*args: int) -> None: ...
+
+# Both positional-only parameters are unmatched so uses the variadic parameter but the other
+# parameter `c` remains and cannot be matched.
+def standard(a: int, b: float, /, c: int) -> None: ...
+
+# Similarly, for other kinds
+def keyword_only(a: int, /, *, b: int) -> None: ...
+def keyword_variadic(a: int, /, **kwargs: int) -> None: ...
+
+static_assert(not is_subtype_of(CallableTypeFromFunction[variadic], CallableTypeFromFunction[standard]))
+static_assert(not is_subtype_of(CallableTypeFromFunction[variadic], CallableTypeFromFunction[keyword_only]))
+static_assert(not is_subtype_of(CallableTypeFromFunction[variadic], CallableTypeFromFunction[keyword_variadic]))
 ```
 
 #### Keyword-only

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -4936,7 +4936,7 @@ impl<'db> GeneralCallableType<'db> {
                             | ParameterKind::KeywordOnly {
                                 default_ty: self_default,
                             } => {
-                                if self_default.is_some() && other_default.is_none() {
+                                if self_default.is_none() && other_default.is_some() {
                                     return false;
                                 }
                                 if !is_subtype(

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -5064,10 +5064,9 @@ impl<'db> GeneralCallableType<'db> {
                         return false;
                     }
                 }
-                kind => {
-                    // TODO: Maybe we should just return `false` here instead of panicking in case
-                    // the AST is invalid?
-                    unreachable!("Unhandled parameter kind from `other`: {:?}", kind);
+                _ => {
+                    // This can only occur in case of a syntax error.
+                    return false;
                 }
             }
         }

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -662,7 +662,8 @@ impl<'db> Type<'db> {
             ) => self_callable.is_subtype_of(db, other_callable),
 
             (Type::Callable(CallableType::General(_)), _) => {
-                // TODO: Implement subtyping for general callable types
+                // TODO: Implement subtyping between general callable types and other types like
+                // function literals, bound methods, class literals, `type[]`, etc.)
                 false
             }
 

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -4981,9 +4981,8 @@ impl<'db> GeneralCallableType<'db> {
             }
         }
 
-        // At this point, the remaining parameters in `other` are keyword-only parameters or
-        // keyword variadic parameters. But, `self` could contain any unmatched positional
-        // parameters.
+        // At this point, the remaining parameters in `other` are keyword-only or keyword variadic.
+        // But, `self` could contain any unmatched positional parameters.
         let (self_parameters, other_parameters) = parameters.into_remaining();
 
         // Collect all the keyword-only parameters and the unmatched standard parameters.
@@ -5001,12 +5000,14 @@ impl<'db> GeneralCallableType<'db> {
                 ParameterKind::KeywordVariadic { .. } => {
                     self_keyword_variadic = self_parameter.annotated_type();
                 }
-                ParameterKind::PositionalOnly { .. } | ParameterKind::Variadic { .. } => {
-                    // These are the unmatched parameters in `self` from the above loop. They
-                    // cannot be matched against any parameter in `other` so the subtype relation
-                    // is invalid.
+                ParameterKind::PositionalOnly { .. } => {
+                    // These are the unmatched positional-only parameters in `self` from the
+                    // previous loop. They cannot be matched against any parameter in `other` which
+                    // only contains keyword-only and keyword-variadic parameters so the subtype
+                    // relation is invalid.
                     return false;
                 }
+                ParameterKind::Variadic { .. } => {}
             }
         }
 

--- a/crates/red_knot_python_semantic/src/types/signatures.rs
+++ b/crates/red_knot_python_semantic/src/types/signatures.rs
@@ -458,10 +458,6 @@ impl<'db> Parameters<'db> {
         self.value.len()
     }
 
-    pub(crate) fn is_empty(&self) -> bool {
-        self.value.is_empty()
-    }
-
     pub(crate) fn iter(&self) -> std::slice::Iter<Parameter<'db>> {
         self.value.iter()
     }

--- a/crates/red_knot_python_semantic/src/types/signatures.rs
+++ b/crates/red_knot_python_semantic/src/types/signatures.rs
@@ -458,6 +458,10 @@ impl<'db> Parameters<'db> {
         self.value.len()
     }
 
+    pub(crate) fn is_empty(&self) -> bool {
+        self.value.is_empty()
+    }
+
     pub(crate) fn iter(&self) -> std::slice::Iter<Parameter<'db>> {
         self.value.iter()
     }
@@ -615,6 +619,11 @@ impl<'db> Parameter<'db> {
             ParameterKind::KeywordOnly { name, .. } => Some(name),
             ParameterKind::KeywordVariadic { name } => Some(name),
         }
+    }
+
+    /// Returns the kind of the parameter which will contain the default type if any.
+    pub(crate) fn kind(&self) -> &ParameterKind<'db> {
+        &self.kind
     }
 
     /// Display name of the parameter, if it has one.

--- a/crates/red_knot_python_semantic/src/types/signatures.rs
+++ b/crates/red_knot_python_semantic/src/types/signatures.rs
@@ -617,11 +617,6 @@ impl<'db> Parameter<'db> {
         }
     }
 
-    /// Returns the kind of the parameter which will contain the default type if any.
-    pub(crate) fn kind(&self) -> &ParameterKind<'db> {
-        &self.kind
-    }
-
     /// Display name of the parameter, if it has one.
     pub(crate) fn display_name(&self) -> Option<ast::name::Name> {
         self.name().map(|name| match self.kind {


### PR DESCRIPTION
## Summary

Part of #15382

This PR adds support for checking the subtype relationship between the two callable types.

The main source of reference used for implementation is https://typing.python.org/en/latest/spec/callables.html#assignability-rules-for-callables.

The implementation is split into two phases:
1. Check all the positional parameters which includes positional-only, standard (positional or keyword) and variadic kind
2. Collect all the keywords in a `HashMap` to do the keyword parameters check via name lookup

For (1), there's a helper struct which is similar to `.zip_longest` (from `itertools`) except that it allows control over one of the iterator as that's required when processing a variadic parameter. This is required because positional parameters needs to be checked as per their position between the two callable types. The struct also keeps track of the current iteration element because when the loop is exited (to move on to the phase 2) the current iteration element would be carried over to the phase 2 check.

This struct is internal to the `is_subtype_of` method as I don't think it makes sense to expose it outside. It also allows me to use "self" and "other" suffixed field names as that's only relevant in that context.

## Test Plan

Add extensive tests in markdown.

Converted all of the code snippets from https://typing.python.org/en/latest/spec/callables.html#assignability-rules-for-callables to use `knot_extensions.is_subtype_of` and verified the result.
