### PR TITLE
Add dcreager as red-knot CODEOWNER

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,6 +18,6 @@
 /python/py-fuzzer/ @AlexWaygood
 
 # red-knot
-/crates/red_knot* @carljm @MichaReiser @AlexWaygood @sharkdp
-/crates/ruff_db/ @carljm @MichaReiser @AlexWaygood @sharkdp
-/scripts/knot_benchmark/ @carljm @MichaReiser @AlexWaygood @sharkdp
+/crates/red_knot* @carljm @MichaReiser @AlexWaygood @sharkdp @dcreager
+/crates/ruff_db/ @carljm @MichaReiser @AlexWaygood @sharkdp @dcreager
+/scripts/knot_benchmark/ @carljm @MichaReiser @AlexWaygood @sharkdp @dcreager


### PR DESCRIPTION
So that I can keep track of (and start help reviewing) red-knot PRs more easily