### PR TITLE
[red-knot] replace old diagnostic renderer with the new

### DIFF
--- a/crates/red_knot/tests/cli.rs
+++ b/crates/red_knot/tests/cli.rs
@@ -219,7 +219,7 @@ fn configuration_rule_severity() -> anyhow::Result<()> {
     5 |     x = a
     6 |
     7 | print(x)  # possibly-unresolved-reference
-      |       - Name `x` used when possibly not defined
+      |       ^ Name `x` used when possibly not defined
       |
 
     Found 2 diagnostics
@@ -244,7 +244,7 @@ fn configuration_rule_severity() -> anyhow::Result<()> {
      --> <temp_dir>/test.py:2:5
       |
     2 | y = 4 / 0
-      |     ----- Cannot divide object of type `Literal[4]` by zero
+      |     ^^^^^ Cannot divide object of type `Literal[4]` by zero
     3 |
     4 | for a in range(0, y):
       |
@@ -306,7 +306,7 @@ fn cli_rule_severity() -> anyhow::Result<()> {
     7 |     x = a
     8 |
     9 | print(x)  # possibly-unresolved-reference
-      |       - Name `x` used when possibly not defined
+      |       ^ Name `x` used when possibly not defined
       |
 
     Found 3 diagnostics
@@ -331,7 +331,7 @@ fn cli_rule_severity() -> anyhow::Result<()> {
      --> <temp_dir>/test.py:2:8
       |
     2 | import does_not_exit
-      |        ------------- Cannot resolve import `does_not_exit`
+      |        ^^^^^^^^^^^^^ Cannot resolve import `does_not_exit`
     3 |
     4 | y = 4 / 0
       |
@@ -342,7 +342,7 @@ fn cli_rule_severity() -> anyhow::Result<()> {
     2 | import does_not_exit
     3 |
     4 | y = 4 / 0
-      |     ----- Cannot divide object of type `Literal[4]` by zero
+      |     ^^^^^ Cannot divide object of type `Literal[4]` by zero
     5 |
     6 | for a in range(0, y):
       |
@@ -393,7 +393,7 @@ fn cli_rule_severity_precedence() -> anyhow::Result<()> {
     5 |     x = a
     6 |
     7 | print(x)  # possibly-unresolved-reference
-      |       - Name `x` used when possibly not defined
+      |       ^ Name `x` used when possibly not defined
       |
 
     Found 2 diagnostics
@@ -419,7 +419,7 @@ fn cli_rule_severity_precedence() -> anyhow::Result<()> {
      --> <temp_dir>/test.py:2:5
       |
     2 | y = 4 / 0
-      |     ----- Cannot divide object of type `Literal[4]` by zero
+      |     ^^^^^ Cannot divide object of type `Literal[4]` by zero
     3 |
     4 | for a in range(0, y):
       |
@@ -456,7 +456,7 @@ fn configuration_unknown_rules() -> anyhow::Result<()> {
       |
     2 | [tool.knot.rules]
     3 | division-by-zer = "warn" # incorrect rule name
-      | --------------- Unknown lint rule `division-by-zer`
+      | ^^^^^^^^^^^^^^^ Unknown lint rule `division-by-zer`
       |
 
     Found 1 diagnostic
@@ -498,7 +498,7 @@ fn exit_code_only_warnings() -> anyhow::Result<()> {
      --> <temp_dir>/test.py:1:7
       |
     1 | print(x)  # [unresolved-reference]
-      |       - Name `x` used when not defined
+      |       ^ Name `x` used when not defined
       |
 
     Found 1 diagnostic
@@ -528,7 +528,7 @@ fn exit_code_only_info() -> anyhow::Result<()> {
       |
     2 | from typing_extensions import reveal_type
     3 | reveal_type(1)
-      | -------------- info: Revealed type is `Literal[1]`
+      | ^^^^^^^^^^^^^^ Revealed type is `Literal[1]`
       |
 
     Found 1 diagnostic
@@ -558,7 +558,7 @@ fn exit_code_only_info_and_error_on_warning_is_true() -> anyhow::Result<()> {
       |
     2 | from typing_extensions import reveal_type
     3 | reveal_type(1)
-      | -------------- info: Revealed type is `Literal[1]`
+      | ^^^^^^^^^^^^^^ Revealed type is `Literal[1]`
       |
 
     Found 1 diagnostic
@@ -581,7 +581,7 @@ fn exit_code_no_errors_but_error_on_warning_is_true() -> anyhow::Result<()> {
      --> <temp_dir>/test.py:1:7
       |
     1 | print(x)  # [unresolved-reference]
-      |       - Name `x` used when not defined
+      |       ^ Name `x` used when not defined
       |
 
     Found 1 diagnostic
@@ -613,7 +613,7 @@ fn exit_code_no_errors_but_error_on_warning_is_enabled_in_configuration() -> any
      --> <temp_dir>/test.py:1:7
       |
     1 | print(x)  # [unresolved-reference]
-      |       - Name `x` used when not defined
+      |       ^ Name `x` used when not defined
       |
 
     Found 1 diagnostic
@@ -642,7 +642,7 @@ fn exit_code_both_warnings_and_errors() -> anyhow::Result<()> {
      --> <temp_dir>/test.py:2:7
       |
     2 | print(x)     # [unresolved-reference]
-      |       - Name `x` used when not defined
+      |       ^ Name `x` used when not defined
     3 | print(4[1])  # [non-subscriptable]
       |
 
@@ -680,7 +680,7 @@ fn exit_code_both_warnings_and_errors_and_error_on_warning_is_true() -> anyhow::
      --> <temp_dir>/test.py:2:7
       |
     2 | print(x)     # [unresolved-reference]
-      |       - Name `x` used when not defined
+      |       ^ Name `x` used when not defined
     3 | print(4[1])  # [non-subscriptable]
       |
 
@@ -718,7 +718,7 @@ fn exit_code_exit_zero_is_true() -> anyhow::Result<()> {
      --> <temp_dir>/test.py:2:7
       |
     2 | print(x)     # [unresolved-reference]
-      |       - Name `x` used when not defined
+      |       ^ Name `x` used when not defined
     3 | print(4[1])  # [non-subscriptable]
       |
 
@@ -778,7 +778,7 @@ fn user_configuration() -> anyhow::Result<()> {
      --> <temp_dir>/project/main.py:2:5
       |
     2 | y = 4 / 0
-      |     ----- Cannot divide object of type `Literal[4]` by zero
+      |     ^^^^^ Cannot divide object of type `Literal[4]` by zero
     3 |
     4 | for a in range(0, y):
       |
@@ -789,7 +789,7 @@ fn user_configuration() -> anyhow::Result<()> {
     5 |     x = a
     6 |
     7 | print(x)
-      |       - Name `x` used when possibly not defined
+      |       ^ Name `x` used when possibly not defined
       |
 
     Found 2 diagnostics
@@ -820,7 +820,7 @@ fn user_configuration() -> anyhow::Result<()> {
      --> <temp_dir>/project/main.py:2:5
       |
     2 | y = 4 / 0
-      |     ----- Cannot divide object of type `Literal[4]` by zero
+      |     ^^^^^ Cannot divide object of type `Literal[4]` by zero
     3 |
     4 | for a in range(0, y):
       |

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Possibly-unbound_attributes.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Possibly-unbound_attributes.snap
@@ -32,7 +32,7 @@ warning: lint:possibly-unbound-attribute
 4 |             attr: int = 0
 5 |
 6 |     C.attr = 1  # error: [possibly-unbound-attribute]
-  |     ------ Attribute `attr` on type `Literal[C]` is possibly unbound
+  |     ^^^^^^ Attribute `attr` on type `Literal[C]` is possibly unbound
 7 |
 8 |     instance = C()
   |
@@ -45,7 +45,7 @@ warning: lint:possibly-unbound-attribute
   |
 8 |     instance = C()
 9 |     instance.attr = 1  # error: [possibly-unbound-attribute]
-  |     ------------- Attribute `attr` on type `C` is possibly unbound
+  |     ^^^^^^^^^^^^^ Attribute `attr` on type `C` is possibly unbound
   |
 
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Bad_`__getitem__`_method.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Bad_`__getitem__`_method.snap
@@ -46,7 +46,7 @@ info: revealed-type
  9 | # error: [not-iterable]
 10 | for x in Iterable():
 11 |     reveal_type(x)  # revealed: int
-   |     -------------- info: Revealed type is `int`
+   |     ^^^^^^^^^^^^^^ Revealed type is `int`
    |
 
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_No_`__iter__`_method_and_`__getitem__`_is_not_callable.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_No_`__iter__`_method_and_`__getitem__`_is_not_callable.snap
@@ -43,7 +43,7 @@ info: revealed-type
 6 | # error: [not-iterable]
 7 | for x in Bad():
 8 |     reveal_type(x)  # revealed: Unknown
-  |     -------------- info: Revealed type is `Unknown`
+  |     ^^^^^^^^^^^^^^ Revealed type is `Unknown`
   |
 
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly-not-callable_`__getitem__`_method.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly-not-callable_`__getitem__`_method.snap
@@ -65,7 +65,7 @@ info: revealed-type
 22 |     for x in Iterable1():
 23 |         # TODO... `int` might be ideal here?
 24 |         reveal_type(x)  # revealed: int | Unknown
-   |         -------------- info: Revealed type is `int | Unknown`
+   |         ^^^^^^^^^^^^^^ Revealed type is `int | Unknown`
 25 |
 26 |     # error: [not-iterable]
    |
@@ -92,7 +92,7 @@ info: revealed-type
 27 |     for y in Iterable2():
 28 |         # TODO... `int` might be ideal here?
 29 |         reveal_type(y)  # revealed: int | Unknown
-   |         -------------- info: Revealed type is `int | Unknown`
+   |         ^^^^^^^^^^^^^^ Revealed type is `int | Unknown`
    |
 
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__getitem__`_methods.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__getitem__`_methods.snap
@@ -62,7 +62,7 @@ info: revealed-type
 20 |     for x in Iterable1():
 21 |         # TODO: `str` might be better
 22 |         reveal_type(x)  # revealed: str | Unknown
-   |         -------------- info: Revealed type is `str | Unknown`
+   |         ^^^^^^^^^^^^^^ Revealed type is `str | Unknown`
 23 |
 24 |     # error: [not-iterable]
    |
@@ -88,7 +88,7 @@ info: revealed-type
 24 |     # error: [not-iterable]
 25 |     for y in Iterable2():
 26 |         reveal_type(y)  # revealed: str | int
-   |         -------------- info: Revealed type is `str | int`
+   |         ^^^^^^^^^^^^^^ Revealed type is `str | int`
    |
 
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__iter__`_methods.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__iter__`_methods.snap
@@ -65,7 +65,7 @@ info: revealed-type
 16 |     # error: [not-iterable]
 17 |     for x in Iterable1():
 18 |         reveal_type(x)  # revealed: int
-   |         -------------- info: Revealed type is `int`
+   |         ^^^^^^^^^^^^^^ Revealed type is `int`
 19 |
 20 |     class Iterable2:
    |
@@ -92,7 +92,7 @@ info: revealed-type
 28 |     for x in Iterable2():
 29 |         # TODO: `int` would probably be better here:
 30 |         reveal_type(x)  # revealed: int | Unknown
-   |         -------------- info: Revealed type is `int | Unknown`
+   |         ^^^^^^^^^^^^^^ Revealed type is `int | Unknown`
    |
 
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__next__`_method.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__next__`_method.snap
@@ -69,7 +69,7 @@ info: revealed-type
 27 |     # error: [not-iterable]
 28 |     for x in Iterable1():
 29 |         reveal_type(x)  # revealed: int | str
-   |         -------------- info: Revealed type is `int | str`
+   |         ^^^^^^^^^^^^^^ Revealed type is `int | str`
 30 |
 31 |     # error: [not-iterable]
    |
@@ -96,7 +96,7 @@ info: revealed-type
 32 |     for y in Iterable2():
 33 |         # TODO: `int` would probably be better here:
 34 |         reveal_type(y)  # revealed: int | Unknown
-   |         -------------- info: Revealed type is `int | Unknown`
+   |         ^^^^^^^^^^^^^^ Revealed type is `int | Unknown`
    |
 
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_bad_`__getitem__`_method.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_bad_`__getitem__`_method.snap
@@ -54,7 +54,7 @@ info: revealed-type
 17 |     # error: [not-iterable]
 18 |     for x in Iterable():
 19 |         reveal_type(x)  # revealed: int | bytes
-   |         -------------- info: Revealed type is `int | bytes`
+   |         ^^^^^^^^^^^^^^ Revealed type is `int | bytes`
    |
 
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_possibly_invalid_`__getitem__`.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_possibly_invalid_`__getitem__`.snap
@@ -73,7 +73,7 @@ info: revealed-type
 31 |     for x in Iterable1():
 32 |         # TODO: `bytes | str` might be better
 33 |         reveal_type(x)  # revealed: bytes | str | Unknown
-   |         -------------- info: Revealed type is `bytes | str | Unknown`
+   |         ^^^^^^^^^^^^^^ Revealed type is `bytes | str | Unknown`
 34 |
 35 |     # error: [not-iterable]
    |
@@ -100,7 +100,7 @@ info: revealed-type
 35 |     # error: [not-iterable]
 36 |     for y in Iterable2():
 37 |         reveal_type(y)  # revealed: bytes | str | int
-   |         -------------- info: Revealed type is `bytes | str | int`
+   |         ^^^^^^^^^^^^^^ Revealed type is `bytes | str | int`
    |
 
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_possibly_unbound_`__getitem__`.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_possibly_unbound_`__getitem__`.snap
@@ -53,7 +53,7 @@ info: revealed-type
 16 |     # error: [not-iterable]
 17 |     for x in Iterable():
 18 |         reveal_type(x)  # revealed: int | bytes
-   |         -------------- info: Revealed type is `int | bytes`
+   |         ^^^^^^^^^^^^^^ Revealed type is `int | bytes`
    |
 
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Union_type_as_iterable_where_one_union_element_has_invalid_`__iter__`_method.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Union_type_as_iterable_where_one_union_element_has_invalid_`__iter__`_method.snap
@@ -55,7 +55,7 @@ info: revealed-type
 17 |     # error: [not-iterable]
 18 |     for x in Test() if flag else Test2():
 19 |         reveal_type(x)  # revealed: int
-   |         -------------- info: Revealed type is `int`
+   |         ^^^^^^^^^^^^^^ Revealed type is `int`
    |
 
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Union_type_as_iterable_where_one_union_element_has_no_`__iter__`_method.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Union_type_as_iterable_where_one_union_element_has_no_`__iter__`_method.snap
@@ -50,7 +50,7 @@ info: revealed-type
 12 |     # error: [not-iterable]
 13 |     for x in Test() if flag else 42:
 14 |         reveal_type(x)  # revealed: int
-   |         -------------- info: Revealed type is `int`
+   |         ^^^^^^^^^^^^^^ Revealed type is `int`
    |
 
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_With_non-callable_iterator.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_With_non-callable_iterator.snap
@@ -51,7 +51,7 @@ warning: lint:possibly-unresolved-reference
 14 |     # revealed: Unknown
 15 |     # error: [possibly-unresolved-reference]
 16 |     reveal_type(x)
-   |                 - Name `x` used when possibly not defined
+   |                 ^ Name `x` used when possibly not defined
    |
 
 ```
@@ -63,7 +63,7 @@ info: revealed-type
 14 |     # revealed: Unknown
 15 |     # error: [possibly-unresolved-reference]
 16 |     reveal_type(x)
-   |     -------------- info: Revealed type is `Unknown`
+   |     ^^^^^^^^^^^^^^ Revealed type is `Unknown`
    |
 
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_does_not_return_an_iterator.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_does_not_return_an_iterator.snap
@@ -44,7 +44,7 @@ info: revealed-type
 7 | # error: [not-iterable]
 8 | for x in Bad():
 9 |     reveal_type(x)  # revealed: Unknown
-  |     -------------- info: Revealed type is `Unknown`
+  |     ^^^^^^^^^^^^^^ Revealed type is `Unknown`
   |
 
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_method_with_a_bad_signature.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_method_with_a_bad_signature.snap
@@ -48,7 +48,7 @@ info: revealed-type
 11 | # error: [not-iterable]
 12 | for x in Iterable():
 13 |     reveal_type(x)  # revealed: int
-   |     -------------- info: Revealed type is `int`
+   |     ^^^^^^^^^^^^^^ Revealed type is `int`
    |
 
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_returns_an_iterator_with_an_invalid_`__next__`_method.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_returns_an_iterator_with_an_invalid_`__next__`_method.snap
@@ -59,7 +59,7 @@ info: revealed-type
 18 | # error: [not-iterable]
 19 | for x in Iterable1():
 20 |     reveal_type(x)  # revealed: int
-   |     -------------- info: Revealed type is `int`
+   |     ^^^^^^^^^^^^^^ Revealed type is `int`
 21 |
 22 | # error: [not-iterable]
    |
@@ -85,7 +85,7 @@ info: revealed-type
 22 | # error: [not-iterable]
 23 | for y in Iterable2():
 24 |     reveal_type(y)  # revealed: Unknown
-   |     -------------- info: Revealed type is `Unknown`
+   |     ^^^^^^^^^^^^^^ Revealed type is `Unknown`
    |
 
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Basic.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Basic.snap
@@ -29,10 +29,11 @@ error: lint:invalid-argument-type
 4 | foo("hello")  # error: [invalid-argument-type]
   |     ^^^^^^^ Object of type `Literal["hello"]` cannot be assigned to parameter 1 (`x`) of function `foo`; expected type `int`
   |
- ::: /src/mdtest_snippet.py:1:9
+info
+ --> /src/mdtest_snippet.py:1:9
   |
 1 | def foo(x: int) -> int:
-  |         ------ info: parameter declared in function definition here
+  |         ------ parameter declared in function definition here
 2 |     return x * x
   |
 

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Calls_to_methods.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Calls_to_methods.snap
@@ -30,11 +30,12 @@ error: lint:invalid-argument-type
 6 | c.square("hello")  # error: [invalid-argument-type]
   |          ^^^^^^^ Object of type `Literal["hello"]` cannot be assigned to parameter 2 (`x`) of bound method `square`; expected type `int`
   |
- ::: /src/mdtest_snippet.py:2:22
+info
+ --> /src/mdtest_snippet.py:2:22
   |
 1 | class C:
 2 |     def square(self, x: int) -> int:
-  |                      ------ info: parameter declared in function definition here
+  |                      ------ parameter declared in function definition here
 3 |         return x * x
   |
 

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Different_files.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Different_files.snap
@@ -35,10 +35,11 @@ error: lint:invalid-argument-type
 3 | package.foo("hello")  # error: [invalid-argument-type]
   |             ^^^^^^^ Object of type `Literal["hello"]` cannot be assigned to parameter 1 (`x`) of function `foo`; expected type `int`
   |
- ::: /src/package.py:1:9
+info
+ --> /src/package.py:1:9
   |
 1 | def foo(x: int) -> int:
-  |         ------ info: parameter declared in function definition here
+  |         ------ parameter declared in function definition here
 2 |     return x * x
   |
 

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Different_source_order.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Different_source_order.snap
@@ -31,12 +31,13 @@ error: lint:invalid-argument-type
 3 |
 4 | def foo(x: int) -> int:
   |
- ::: /src/mdtest_snippet.py:4:9
+info
+ --> /src/mdtest_snippet.py:4:9
   |
 2 |     foo("hello")  # error: [invalid-argument-type]
 3 |
 4 | def foo(x: int) -> int:
-  |         ------ info: parameter declared in function definition here
+  |         ------ parameter declared in function definition here
 5 |     return x * x
   |
 

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters.snap
@@ -29,10 +29,11 @@ error: lint:invalid-argument-type
 4 | foo(1, "hello", 3)  # error: [invalid-argument-type]
   |        ^^^^^^^ Object of type `Literal["hello"]` cannot be assigned to parameter 2 (`y`) of function `foo`; expected type `int`
   |
- ::: /src/mdtest_snippet.py:1:17
+info
+ --> /src/mdtest_snippet.py:1:17
   |
 1 | def foo(x: int, y: int, z: int) -> int:
-  |                 ------ info: parameter declared in function definition here
+  |                 ------ parameter declared in function definition here
 2 |     return x * y * z
   |
 

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters_across_multiple_lines.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters_across_multiple_lines.snap
@@ -33,12 +33,13 @@ error: lint:invalid-argument-type
 8 | foo(1, "hello", 3)  # error: [invalid-argument-type]
   |        ^^^^^^^ Object of type `Literal["hello"]` cannot be assigned to parameter 2 (`y`) of function `foo`; expected type `int`
   |
- ::: /src/mdtest_snippet.py:3:5
+info
+ --> /src/mdtest_snippet.py:3:5
   |
 1 | def foo(
 2 |     x: int,
 3 |     y: int,
-  |     ------ info: parameter declared in function definition here
+  |     ------ parameter declared in function definition here
 4 |     z: int,
 5 | ) -> int:
   |

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters_with_multiple_invalid_arguments.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters_with_multiple_invalid_arguments.snap
@@ -32,10 +32,11 @@ error: lint:invalid-argument-type
 7 | foo("a", "b", "c")
   |     ^^^ Object of type `Literal["a"]` cannot be assigned to parameter 1 (`x`) of function `foo`; expected type `int`
   |
- ::: /src/mdtest_snippet.py:1:9
+info
+ --> /src/mdtest_snippet.py:1:9
   |
 1 | def foo(x: int, y: int, z: int) -> int:
-  |         ------ info: parameter declared in function definition here
+  |         ------ parameter declared in function definition here
 2 |     return x * y * z
   |
 
@@ -50,10 +51,11 @@ error: lint:invalid-argument-type
 7 | foo("a", "b", "c")
   |          ^^^ Object of type `Literal["b"]` cannot be assigned to parameter 2 (`y`) of function `foo`; expected type `int`
   |
- ::: /src/mdtest_snippet.py:1:17
+info
+ --> /src/mdtest_snippet.py:1:17
   |
 1 | def foo(x: int, y: int, z: int) -> int:
-  |                 ------ info: parameter declared in function definition here
+  |                 ------ parameter declared in function definition here
 2 |     return x * y * z
   |
 
@@ -68,10 +70,11 @@ error: lint:invalid-argument-type
 7 | foo("a", "b", "c")
   |               ^^^ Object of type `Literal["c"]` cannot be assigned to parameter 3 (`z`) of function `foo`; expected type `int`
   |
- ::: /src/mdtest_snippet.py:1:25
+info
+ --> /src/mdtest_snippet.py:1:25
   |
 1 | def foo(x: int, y: int, z: int) -> int:
-  |                         ------ info: parameter declared in function definition here
+  |                         ------ parameter declared in function definition here
 2 |     return x * y * z
   |
 

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Test_calling_a_function_whose_type_is_vendored_from_`typeshed`.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Test_calling_a_function_whose_type_is_vendored_from_`typeshed`.snap
@@ -21,19 +21,20 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/invali
 
 ```
 error: lint:invalid-argument-type
-  --> /src/mdtest_snippet.py:3:12
-   |
- 1 | import json
- 2 |
- 3 | json.loads(5)  # error: [invalid-argument-type]
-   |            ^ Object of type `Literal[5]` cannot be assigned to parameter 1 (`s`) of function `loads`; expected type `str | bytes | bytearray`
-   |
-  ::: vendored://stdlib/json/__init__.pyi:40:5
+ --> /src/mdtest_snippet.py:3:12
+  |
+1 | import json
+2 |
+3 | json.loads(5)  # error: [invalid-argument-type]
+  |            ^ Object of type `Literal[5]` cannot be assigned to parameter 1 (`s`) of function `loads`; expected type `str | bytes | bytearray`
+  |
+info
+  --> stdlib/json/__init__.pyi:40:5
    |
 38 | ) -> None: ...
 39 | def loads(
 40 |     s: str | bytes | bytearray,
-   |     -------------------------- info: parameter declared in function definition here
+   |     -------------------------- parameter declared in function definition here
 41 |     *,
 42 |     cls: type[JSONDecoder] | None = None,
    |

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Keyword_only_arguments.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Keyword_only_arguments.snap
@@ -29,10 +29,11 @@ error: lint:invalid-argument-type
 4 | foo(1, 2, z="hello")  # error: [invalid-argument-type]
   |           ^^^^^^^^^ Object of type `Literal["hello"]` cannot be assigned to parameter `z` of function `foo`; expected type `int`
   |
- ::: /src/mdtest_snippet.py:1:28
+info
+ --> /src/mdtest_snippet.py:1:28
   |
 1 | def foo(x: int, y: int, *, z: int = 0) -> int:
-  |                            ---------- info: parameter declared in function definition here
+  |                            ---------- parameter declared in function definition here
 2 |     return x * y * z
   |
 

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Mix_of_arguments.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Mix_of_arguments.snap
@@ -29,10 +29,11 @@ error: lint:invalid-argument-type
 4 | foo(1, 2, z="hello")  # error: [invalid-argument-type]
   |           ^^^^^^^^^ Object of type `Literal["hello"]` cannot be assigned to parameter `z` of function `foo`; expected type `int`
   |
- ::: /src/mdtest_snippet.py:1:31
+info
+ --> /src/mdtest_snippet.py:1:31
   |
 1 | def foo(x: int, /, y: int, *, z: int = 0) -> int:
-  |                               ---------- info: parameter declared in function definition here
+  |                               ---------- parameter declared in function definition here
 2 |     return x * y * z
   |
 

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_One_keyword_argument.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_One_keyword_argument.snap
@@ -29,10 +29,11 @@ error: lint:invalid-argument-type
 4 | foo(1, 2, "hello")  # error: [invalid-argument-type]
   |           ^^^^^^^ Object of type `Literal["hello"]` cannot be assigned to parameter 3 (`z`) of function `foo`; expected type `int`
   |
- ::: /src/mdtest_snippet.py:1:25
+info
+ --> /src/mdtest_snippet.py:1:25
   |
 1 | def foo(x: int, y: int, z: int = 0) -> int:
-  |                         ---------- info: parameter declared in function definition here
+  |                         ---------- parameter declared in function definition here
 2 |     return x * y * z
   |
 

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Only_positional.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Only_positional.snap
@@ -29,10 +29,11 @@ error: lint:invalid-argument-type
 4 | foo(1, "hello", 3)  # error: [invalid-argument-type]
   |        ^^^^^^^ Object of type `Literal["hello"]` cannot be assigned to parameter 2 (`y`) of function `foo`; expected type `int`
   |
- ::: /src/mdtest_snippet.py:1:17
+info
+ --> /src/mdtest_snippet.py:1:17
   |
 1 | def foo(x: int, y: int, z: int, /) -> int:
-  |                 ------ info: parameter declared in function definition here
+  |                 ------ parameter declared in function definition here
 2 |     return x * y * z
   |
 

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Synthetic_arguments.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Synthetic_arguments.snap
@@ -30,11 +30,12 @@ error: lint:invalid-argument-type
 6 | c("wrong")  # error: [invalid-argument-type]
   |   ^^^^^^^ Object of type `Literal["wrong"]` cannot be assigned to parameter 2 (`x`) of bound method `__call__`; expected type `int`
   |
- ::: /src/mdtest_snippet.py:2:24
+info
+ --> /src/mdtest_snippet.py:2:24
   |
 1 | class C:
 2 |     def __call__(self, x: int) -> int:
-  |                        ------ info: parameter declared in function definition here
+  |                        ------ parameter declared in function definition here
 3 |         return 1
   |
 

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Variadic_arguments.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Variadic_arguments.snap
@@ -29,10 +29,11 @@ error: lint:invalid-argument-type
 4 | foo(1, 2, 3, "hello", 5)  # error: [invalid-argument-type]
   |              ^^^^^^^ Object of type `Literal["hello"]` cannot be assigned to parameter `*numbers` of function `foo`; expected type `int`
   |
- ::: /src/mdtest_snippet.py:1:9
+info
+ --> /src/mdtest_snippet.py:1:9
   |
 1 | def foo(*numbers: int) -> int:
-  |         ------------- info: parameter declared in function definition here
+  |         ------------- parameter declared in function definition here
 2 |     return len(numbers)
   |
 

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Variadic_keyword_arguments.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Variadic_keyword_arguments.snap
@@ -29,10 +29,11 @@ error: lint:invalid-argument-type
 4 | foo(a=1, b=2, c=3, d="hello", e=5)  # error: [invalid-argument-type]
   |                    ^^^^^^^^^ Object of type `Literal["hello"]` cannot be assigned to parameter `**numbers` of function `foo`; expected type `int`
   |
- ::: /src/mdtest_snippet.py:1:9
+info
+ --> /src/mdtest_snippet.py:1:9
   |
 1 | def foo(**numbers: int) -> int:
-  |         -------------- info: parameter declared in function definition here
+  |         -------------- parameter declared in function definition here
 2 |     return len(numbers)
   |
 

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_conditional_return_type.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_conditional_return_type.snap
@@ -41,10 +41,11 @@ error: lint:invalid-return-type
 7 |
 8 | def f(cond: bool) -> str:
   |
- ::: /src/mdtest_snippet.py:1:22
+info
+ --> /src/mdtest_snippet.py:1:22
   |
 1 | def f(cond: bool) -> str:
-  |                      --- info: Return type is declared here as `str`
+  |                      --- Return type is declared here as `str`
 2 |     if cond:
 3 |         return "a"
   |
@@ -62,12 +63,13 @@ error: lint:invalid-return-type
 12 |     else:
 13 |         # error: [invalid-return-type]
    |
-  ::: /src/mdtest_snippet.py:8:22
+info
+  --> /src/mdtest_snippet.py:8:22
    |
  6 |         return 1
  7 |
  8 | def f(cond: bool) -> str:
-   |                      --- info: Return type is declared here as `str`
+   |                      --- Return type is declared here as `str`
  9 |     if cond:
 10 |         # error: [invalid-return-type]
    |
@@ -83,12 +85,13 @@ error: lint:invalid-return-type
 14 |         return 2
    |                ^ Object of type `Literal[2]` is not assignable to return type `str`
    |
-  ::: /src/mdtest_snippet.py:8:22
+info
+  --> /src/mdtest_snippet.py:8:22
    |
  6 |         return 1
  7 |
  8 | def f(cond: bool) -> str:
-   |                      --- info: Return type is declared here as `str`
+   |                      --- Return type is declared here as `str`
  9 |     if cond:
 10 |         # error: [invalid-return-type]
    |

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_implicit_return_type.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_implicit_return_type.snap
@@ -50,10 +50,11 @@ error: lint:invalid-return-type
 5 |
 6 | # error: [invalid-return-type]
   |
- ::: /src/mdtest_snippet.py:1:12
+info
+ --> /src/mdtest_snippet.py:1:12
   |
 1 | def f() -> None:
-  |            ---- info: Return type is declared here as `None`
+  |            ---- Return type is declared here as `None`
 2 |     if False:
 3 |         # error: [invalid-return-type]
   |

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type.snap
@@ -57,12 +57,13 @@ error: lint:invalid-return-type
 8 |
 9 | def f() -> int:
   |
- ::: /src/mdtest_snippet.py:5:12
+info
+ --> /src/mdtest_snippet.py:5:12
   |
 3 |     1
 4 |
 5 | def f() -> str:
-  |            --- info: Return type is declared here as `str`
+  |            --- Return type is declared here as `str`
 6 |     # error: [invalid-return-type]
 7 |     return 1
   |
@@ -80,12 +81,13 @@ error: lint:invalid-return-type
 12 |
 13 | from typing import TypeVar
    |
-  ::: /src/mdtest_snippet.py:9:12
+info
+  --> /src/mdtest_snippet.py:9:12
    |
  7 |     return 1
  8 |
  9 | def f() -> int:
-   |            --- info: Return type is declared here as `int`
+   |            --- Return type is declared here as `int`
 10 |     # error: [invalid-return-type]
 11 |     return
    |

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type_in_stub_file.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type_in_stub_file.snap
@@ -40,10 +40,11 @@ error: lint:invalid-return-type
 4 |
 5 | # error: [invalid-return-type]
   |
- ::: /src/mdtest_snippet.pyi:1:12
+info
+ --> /src/mdtest_snippet.pyi:1:12
   |
 1 | def f() -> int:
-  |            --- info: Return type is declared here as `int`
+  |            --- Return type is declared here as `int`
 2 |     # error: [invalid-return-type]
 3 |     return ...
   |

--- a/crates/ruff_db/src/diagnostic/mod.rs
+++ b/crates/ruff_db/src/diagnostic/mod.rs
@@ -109,6 +109,20 @@ impl Diagnostic {
     /// This also marks the diagnostic as having been printed. If a
     /// diagnostic is not rendered this way, then it will panic when
     /// it's dropped when `debug_assertions` is enabled.
+    ///
+    /// # Defuses panics
+    ///
+    /// When `debug_assertions` is enabled and a `Diagnostic` does
+    /// _not_ have this method called, then its `Drop` implementation
+    /// will panic. The intent of this panic is to avoid mistakes where
+    /// a diagnostic is created and then never printed. That is usually
+    /// indicative of a bug.
+    ///
+    /// # Errors
+    ///
+    /// This is guaranteed to only return an error if the underlying
+    /// writer given returns an error. Otherwise, the formatting of
+    /// diagnostics themselves is infallible.
     pub fn print(
         &mut self,
         db: &dyn Db,

--- a/crates/ruff_db/src/diagnostic/old.rs
+++ b/crates/ruff_db/src/diagnostic/old.rs
@@ -1,15 +1,12 @@
 use std::borrow::Cow;
 
-use ruff_annotate_snippets::{
-    Annotation as AnnotateAnnotation, Level as AnnotateLevel, Message as AnnotateMessage,
-    Renderer as AnnotateRenderer, Snippet as AnnotateSnippet,
-};
 use ruff_python_parser::ParseError;
-use ruff_source_file::{OneIndexed, SourceCode};
-use ruff_text_size::TextRange;
 
 use crate::{
-    diagnostic::{DiagnosticFormat, DiagnosticId, DisplayDiagnosticConfig, Severity, Span},
+    diagnostic::{
+        Annotation, Diagnostic, DiagnosticFormat, DiagnosticId, DisplayDiagnosticConfig, Severity,
+        Span, SubDiagnostic,
+    },
     files::File,
     source::{line_index, source_text},
     Db,
@@ -96,158 +93,59 @@ impl std::fmt::Display for OldDisplayDiagnostic<'_, '_, '_> {
             return write!(f, " {message}", message = self.diagnostic.message());
         }
 
-        let render = |f: &mut std::fmt::Formatter, message| {
-            let renderer = if self.config.color {
-                AnnotateRenderer::styled()
-            } else {
-                AnnotateRenderer::plain()
+        let mut diag = match self.diagnostic.span() {
+            None => {
+                // NOTE: This is pretty sub-optimal. It doesn't render well. We
+                // really want a snippet, but without a `File`, we can't really
+                // render anything. It looks like this case currently happens
+                // for configuration errors. It looks like we can probably
+                // produce a snippet for this if it comes from a file, but if
+                // it comes from the CLI, I'm not quite sure exactly what to
+                // do. ---AG
+                Diagnostic::new(
+                    self.diagnostic.id(),
+                    self.diagnostic.severity(),
+                    self.diagnostic.message(),
+                )
             }
-            .cut_indicator("…");
-            let rendered = renderer.render(message);
-            writeln!(f, "{rendered}")
+            Some(span) => {
+                let mut diag =
+                    Diagnostic::new(self.diagnostic.id(), self.diagnostic.severity(), "");
+                diag.annotate(Annotation::primary(span).message(self.diagnostic.message()));
+                diag
+            }
         };
-        let Some(span) = self.diagnostic.span() else {
-            // NOTE: This is pretty sub-optimal. It doesn't render well. We
-            // really want a snippet, but without a `File`, we can't really
-            // render anything. It looks like this case currently happens
-            // for configuration errors. It looks like we can probably
-            // produce a snippet for this if it comes from a file, but if
-            // it comes from the CLI, I'm not quite sure exactly what to
-            // do. ---AG
-            let msg = format!("{}: {}", self.diagnostic.id(), self.diagnostic.message());
-            return render(f, self.diagnostic.severity().to_annotate().title(&msg));
-        };
-
-        let mut message = Message::new(self.diagnostic.severity(), self.diagnostic.id());
-        message.add_snippet(Snippet::new(
-            self.db,
-            self.diagnostic.severity(),
-            &span,
-            &self.diagnostic.message(),
-        ));
         for secondary_msg in self.diagnostic.secondary_messages() {
-            message.add_snippet(Snippet::new(
-                self.db,
-                Severity::Info,
-                &secondary_msg.span,
-                &secondary_msg.message,
-            ));
-        }
-        render(f, message.to_annotate())
-    }
-}
-
-#[derive(Debug)]
-struct Message {
-    level: AnnotateLevel,
-    title: String,
-    snippets: Vec<Snippet>,
-}
-
-#[derive(Debug)]
-struct Snippet {
-    source: String,
-    origin: String,
-    line_start: usize,
-    annotation: Option<Annotation>,
-}
-
-#[derive(Debug)]
-struct Annotation {
-    level: AnnotateLevel,
-    span: TextRange,
-    label: String,
-}
-
-impl Message {
-    fn new(severity: Severity, id: DiagnosticId) -> Message {
-        Message {
-            level: severity.to_annotate(),
-            title: id.to_string(),
-            snippets: vec![],
-        }
-    }
-
-    fn add_snippet(&mut self, snippet: Snippet) {
-        self.snippets.push(snippet);
-    }
-
-    fn to_annotate(&self) -> AnnotateMessage<'_> {
-        self.level
-            .title(&self.title)
-            .snippets(self.snippets.iter().map(|snippet| snippet.to_annotate()))
-    }
-}
-
-impl Snippet {
-    fn new(db: &'_ dyn Db, severity: Severity, span: &Span, message: &str) -> Snippet {
-        let origin = span.file.path(db).to_string();
-        let source_text = source_text(db, span.file);
-        let Some(range) = span.range else {
-            return Snippet {
-                source: source_text.to_string(),
-                origin,
-                line_start: 1,
-                annotation: None,
-            };
-        };
-
-        // The bits below are a simplified copy from
-        // `crates/ruff_linter/src/message/text.rs`.
-        let index = line_index(db, span.file);
-        let source_code = SourceCode::new(source_text.as_str(), &index);
-
-        let content_start_index = source_code.line_index(range.start());
-        let mut start_index = content_start_index.saturating_sub(2);
-        // Trim leading empty lines.
-        while start_index < content_start_index {
-            if !source_code.line_text(start_index).trim().is_empty() {
-                break;
-            }
-            start_index = start_index.saturating_add(1);
+            // Secondary messages carry one span and a message
+            // attached to that span. Since we also want them to
+            // appear after the primary diagnostic, we encode them as
+            // sub-diagnostics.
+            //
+            // Moreover, since we only have one message, we attach it
+            // to the annotation and leave the sub-diagnostic message
+            // empty. This leads to somewhat awkward rendering, but
+            // the way to fix that is to migrate Red Knot to the more
+            // expressive `Diagnostic` API.
+            let mut sub = SubDiagnostic::new(Severity::Info, "");
+            sub.annotate(
+                Annotation::secondary(secondary_msg.span.clone()).message(&secondary_msg.message),
+            );
+            diag.sub(sub);
         }
 
-        let content_end_index = source_code.line_index(range.end());
-        let mut end_index = content_end_index
-            .saturating_add(2)
-            .min(OneIndexed::from_zero_indexed(index.line_count()));
-        // Trim trailing empty lines.
-        while end_index > content_end_index {
-            if !source_code.line_text(end_index).trim().is_empty() {
-                break;
-            }
-            end_index = end_index.saturating_sub(1);
-        }
-
-        // Slice up the code frame and adjust our range.
-        let start_offset = source_code.line_start(start_index);
-        let end_offset = source_code.line_end(end_index);
-        let frame = source_code.slice(TextRange::new(start_offset, end_offset));
-        let range = range - start_offset;
-
-        Snippet {
-            source: frame.to_string(),
-            origin,
-            line_start: start_index.get(),
-            annotation: Some(Annotation {
-                level: severity.to_annotate(),
-                span: range,
-                label: message.to_string(),
-            }),
-        }
-    }
-
-    fn to_annotate(&self) -> AnnotateSnippet<'_> {
-        AnnotateSnippet::source(&self.source)
-            .origin(&self.origin)
-            .line_start(self.line_start)
-            .annotations(self.annotation.as_ref().map(|a| a.to_annotate()))
-    }
-}
-
-impl Annotation {
-    fn to_annotate(&self) -> AnnotateAnnotation<'_> {
-        self.level.span(self.span.into()).label(&self.label)
+        // The main way to print a `Diagnostic` is via its `print`
+        // method, which specifically goes to a `std::io::Write` in
+        // order to strongly suggest that it is actually emitted
+        // somewhere. We should probably make callers use *that* API
+        // instead of this `Display` impl, but for now, we keep the API
+        // the same and write to a `Vec<u8>` under the covers.
+        let mut buf = vec![];
+        // OK because printing to a `Vec<u8>` will never return an error.
+        diag.print(self.db, self.config, &mut buf)
+            .map_err(|_| std::fmt::Error)?;
+        // OK because diagnostic rendering will always emit valid UTF-8.
+        let string = String::from_utf8(buf).map_err(|_| std::fmt::Error)?;
+        write!(f, "{string}")
     }
 }
 

--- a/crates/ruff_db/src/diagnostic/render.rs
+++ b/crates/ruff_db/src/diagnostic/render.rs
@@ -47,8 +47,11 @@ impl std::fmt::Display for DisplayDiagnostic<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let resolved = Resolved::new(self.resolver, self.diag);
         let renderable = resolved.to_renderable(self.config.context);
-        for diag in &renderable.diagnostics {
-            writeln!(f, "{}", self.annotate_renderer.render(diag.to_annotate()))?;
+        for (i, diag) in renderable.diagnostics.iter().enumerate() {
+            if i > 0 {
+                writeln!(f)?;
+            }
+            write!(f, "{}", self.annotate_renderer.render(diag.to_annotate()))?;
         }
         Ok(())
     }

--- a/crates/ruff_db/src/diagnostic/render.rs
+++ b/crates/ruff_db/src/diagnostic/render.rs
@@ -128,16 +128,21 @@ impl<'a> ResolvedDiagnostic<'a> {
                 ResolvedAnnotation::new(path, &input, ann)
             })
             .collect();
-        ResolvedDiagnostic {
-            severity: diag.inner.severity,
+        let message = if diag.inner.message.is_empty() {
+            diag.inner.id.to_string()
+        } else {
             // TODO: See the comment on `Renderable::id` for
             // a plausible better idea than smushing the ID
             // into the diagnostic message.
-            message: format!(
+            format!(
                 "{id}: {message}",
                 id = diag.inner.id,
                 message = diag.inner.message
-            ),
+            )
+        };
+        ResolvedDiagnostic {
+            severity: diag.inner.severity,
+            message,
             annotations,
         }
     }


### PR DESCRIPTION
This PR "rug pulls" the old renderer with the new.

The purpose here is to separate this change from a broader refactor
of moving Red Knot over to the new diagnostic data model. This also
enables us to actually start *using* the new renderer.

My initial goal here was to minimize the changes to the output format,
perhaps to no changes at all. While we *could* do that, I'm not sure
it's worth the effort. I think further customization of the output
should come in the form of making Red Knot use the more expressive
`Diagnostic` API. I tried to contextualize the changes that were made
to the output format in the last commit with all of the snapshot
changes.

Closes #16808
