### PR TITLE
Update Ruff tutorial to avoid non-existent fix in `__init__.py`

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -23,7 +23,8 @@ numbers
           └── py.typed
 ```
 
-We'll then replace the contents of `src/numbers/__init__.py` with the following code:
+We'll then clear out the auto-generated content in `src/numbers/__init__.py`
+and create `src/numbers/calculate.py` with the following code:
 
 ```python
 from typing import Iterable
@@ -49,7 +50,7 @@ We can then run the Ruff linter over our project via `uv run ruff check`:
 
 ```console
 $ uv run ruff check
-src/numbers/__init__.py:3:8: F401 [*] `os` imported but unused
+src/numbers/calculate.py:3:8: F401 [*] `os` imported but unused
 Found 1 error.
 [*] 1 fixable with the `--fix` option.
 ```
@@ -71,8 +72,8 @@ Found 1 error (1 fixed, 0 remaining).
 Running `git diff` shows the following:
 
 ```diff
---- a/src/numbers/__init__.py
-+++ b/src/numbers/__init__.py
+--- a/src/numbers/calculate.py
++++ b/src/numbers/calculate.py
 @@ -1,7 +1,5 @@
  from typing import Iterable
 
@@ -90,7 +91,7 @@ def sum_even_numbers(numbers: Iterable[int]) -> int:
 Note Ruff runs in the current directory by default, but you can pass specific paths to check:
 
 ```console
-$ uv run ruff check src/numbers/__init__.py
+$ uv run ruff check src/numbers/calculate.py
 ```
 
 Now that our project is passing `ruff check`, we can run the Ruff formatter via `ruff format`:
@@ -104,8 +105,8 @@ Running `git diff` shows that the `sum` call was reformatted to fit within the d
 line length limit:
 
 ```diff
---- a/numbers.py
-+++ b/numbers.py
+--- a/src/numbers/calculate.py
++++ b/src/numbers/calculate.py
 @@ -3,7 +3,4 @@ from typing import Iterable
 
  def sum_even_numbers(numbers: Iterable[int]) -> int:
@@ -158,7 +159,7 @@ Running Ruff again, we see that it now enforces a maximum line width, with a lim
 
 ```console
 $ uv run ruff check
-src/numbers/__init__.py:5:80: E501 Line too long (90 > 79)
+src/numbers/calculate.py:5:80: E501 Line too long (90 > 79)
 Found 1 error.
 ```
 
@@ -240,7 +241,7 @@ the use of the deprecated `typing.Iterable` instead of `collections.abc.Iterable
 
 ```console
 $ uv run ruff check
-src/numbers/__init__.py:1:1: UP035 [*] Import from `collections.abc` instead: `Iterable`
+src/numbers/calculate.py:1:1: UP035 [*] Import from `collections.abc` instead: `Iterable`
 Found 1 error.
 [*] 1 fixable with the `--fix` option.
 ```
@@ -283,9 +284,15 @@ If we run Ruff again, we'll see that it now enforces the pydocstyle rules:
 
 ```console
 $ uv run ruff check
-numbers/__init__.py:1:1: D104 Missing docstring in public package
-src/numbers/__init__.py:1:1: UP035 [*] Import from `collections.abc` instead: `Iterable`
-src/numbers/__init__.py:1:1: D100 Missing docstring in public module
+src/numbers/__init__.py:1:1: D104 Missing docstring in public package
+src/numbers/calculate.py:1:1: UP035 [*] Import from `collections.abc` instead: `Iterable`
+  |
+1 | from typing import Iterable
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP035
+  |
+  = help: Import from `collections.abc`
+
+src/numbers/calculate.py:1:1: D100 Missing docstring in public module
 Found 3 errors.
 [*] 1 fixable with the `--fix` option.
 ```
@@ -308,9 +315,9 @@ Running `ruff check` again, we'll see that it no longer flags the `Iterable` imp
 
 ```console
 $ uv run ruff check
-numbers/__init__.py:1:1: D104 Missing docstring in public package
-src/numbers/__init__.py:1:1: D100 Missing docstring in public module
-Found 3 errors.
+src/numbers/__init__.py:1:1: D104 Missing docstring in public package
+src/numbers/calculate.py:1:1: D100 Missing docstring in public module
+Found 2 errors.
 ```
 
 If we want to ignore a rule for an entire file, we can add the line `# ruff: noqa: {code}` anywhere
@@ -345,16 +352,13 @@ Added 1 noqa directive.
 Running `git diff` shows the following:
 
 ```diff
-diff --git a/tutorial/src/main.py b/tutorial/src/main.py
-index b9291c5ca..b9f15b8c1 100644
---- a/src/numbers/__init__.py
-+++ b/src/numbers/__init__.py
+diff --git a/numbers/src/numbers/calculate.py b/numbers/src/numbers/calculate.py
+index 71fca60c8d..e92d839f1b 100644
+--- a/numbers/src/numbers/calculate.py
++++ b/numbers/src/numbers/calculate.py
 @@ -1,4 +1,4 @@
 -from typing import Iterable
 +from typing import Iterable  # noqa: UP035
-
-
- def sum_even_numbers(numbers: Iterable[int]) -> int:
 ```
 
 ## Integrations


### PR DESCRIPTION
## Summary

There were some other stale references too.

Closes https://github.com/astral-sh/ruff/issues/16805.
