### PR TITLE
[red-knot] Simplify `IterationError` and `ContextManagerError`

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -2983,12 +2983,12 @@ impl<'db> Type<'db> {
             .try_call_dunder(db, "__iter__", &CallArguments::none())
             .map(|dunder_iter_outcome| dunder_iter_outcome.return_type(db));
 
-        let iteration_result = match dunder_iter_result {
+        match dunder_iter_result {
             Ok(iterator) => {
                 // `__iter__` is definitely bound and calling it succeeds.
                 // See what calling `__next__` on the object returned by `__iter__` gives us...
                 try_call_dunder_next_on_iterator(iterator).map_err(|dunder_next_error| {
-                    IterationErrorKind::IterReturnsInvalidIterator {
+                    IterationError::IterReturnsInvalidIterator {
                         iterator,
                         dunder_next_error,
                     }
@@ -3016,14 +3016,14 @@ impl<'db> Type<'db> {
                                 )
                             })
                             .map_err(|dunder_getitem_error| {
-                                IterationErrorKind::PossiblyUnboundIterAndGetitemError {
+                                IterationError::PossiblyUnboundIterAndGetitemError {
                                     dunder_next_return,
                                     dunder_getitem_error,
                                 }
                             })
                     }
 
-                    Err(dunder_next_error) => Err(IterationErrorKind::IterReturnsInvalidIterator {
+                    Err(dunder_next_error) => Err(IterationError::IterReturnsInvalidIterator {
                         iterator,
                         dunder_next_error,
                     }),
@@ -3032,23 +3032,18 @@ impl<'db> Type<'db> {
 
             // `__iter__` is definitely bound but it can't be called with the expected arguments
             Err(CallDunderError::CallError(kind, bindings)) => {
-                Err(IterationErrorKind::IterCallError(kind, bindings))
+                Err(IterationError::IterCallError(kind, bindings))
             }
 
             // There's no `__iter__` method. Try `__getitem__` instead...
             Err(CallDunderError::MethodNotAvailable) => {
                 try_call_dunder_getitem().map_err(|dunder_getitem_error| {
-                    IterationErrorKind::UnboundIterAndGetitemError {
+                    IterationError::UnboundIterAndGetitemError {
                         dunder_getitem_error,
                     }
                 })
             }
-        };
-
-        iteration_result.map_err(|error_kind| IterationError {
-            iterable_type: self,
-            error_kind,
-        })
+        }
     }
 
     /// Returns the type bound from a context manager with type `self`.
@@ -3771,34 +3766,7 @@ context_expression = context_expression_ty.display(db)
 
 /// Error returned if a type is not (or may not be) iterable.
 #[derive(Debug)]
-struct IterationError<'db> {
-    /// The type of the object that the analysed code attempted to iterate over.
-    iterable_type: Type<'db>,
-
-    /// The precise kind of error encountered when trying to iterate over the type.
-    error_kind: IterationErrorKind<'db>,
-}
-
-impl<'db> IterationError<'db> {
-    /// Returns the element type if it is known, or `None` if the type is never iterable.
-    fn element_type(&self, db: &'db dyn Db) -> Option<Type<'db>> {
-        self.error_kind.element_type(db)
-    }
-
-    /// Returns the element type if it is known, or `Type::unknown()` if it is not.
-    fn fallback_element_type(&self, db: &'db dyn Db) -> Type<'db> {
-        self.element_type(db).unwrap_or(Type::unknown())
-    }
-
-    /// Reports the diagnostic for this error.
-    fn report_diagnostic(&self, context: &InferContext<'db>, iterable_node: ast::AnyNodeRef) {
-        self.error_kind
-            .report_diagnostic(context, self.iterable_type, iterable_node);
-    }
-}
-
-#[derive(Debug)]
-enum IterationErrorKind<'db> {
+enum IterationError<'db> {
     /// The object being iterated over has a bound `__iter__` method,
     /// but calling it with the expected arguments results in an error.
     IterCallError(CallErrorKind, Box<Bindings<'db>>),
@@ -3833,7 +3801,11 @@ enum IterationErrorKind<'db> {
     },
 }
 
-impl<'db> IterationErrorKind<'db> {
+impl<'db> IterationError<'db> {
+    fn fallback_element_type(&self, db: &'db dyn Db) -> Type<'db> {
+        self.element_type(db).unwrap_or(Type::unknown())
+    }
+
     /// Returns the element type if it is known, or `None` if the type is never iterable.
     fn element_type(&self, db: &'db dyn Db) -> Option<Type<'db>> {
         match self {
@@ -3887,10 +3859,9 @@ impl<'db> IterationErrorKind<'db> {
             context.report_lint(&NOT_ITERABLE, iterable_node, arguments);
         };
 
-        // TODO: for all of these error variant, the "explanation" for the diagnostic
+        // TODO: for all of these error variants, the "explanation" for the diagnostic
         // (everything after the "because") should really be presented as a "help:", "note",
         // or similar, rather than as part of the same sentence as the error message.
-
         match self {
             Self::IterCallError(CallErrorKind::NotCallable, bindings) => report_not_iterable(format_args!(
                 "Object of type `{iterable_type}` is not iterable \

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1806,7 +1806,7 @@ impl<'db> TypeInferenceBuilder<'db> {
     fn infer_context_expression(
         &mut self,
         context_expression: &ast::Expr,
-        context_expression_ty: Type<'db>,
+        context_expression_type: Type<'db>,
         is_async: bool,
     ) -> Type<'db> {
         // TODO: Handle async with statements (they use `aenter` and `aexit`)
@@ -1814,10 +1814,14 @@ impl<'db> TypeInferenceBuilder<'db> {
             return todo_type!("async `with` statement");
         }
 
-        context_expression_ty
+        context_expression_type
             .try_enter(self.db())
             .unwrap_or_else(|err| {
-                err.report_diagnostic(&self.context, context_expression.into());
+                err.report_diagnostic(
+                    &self.context,
+                    context_expression_type,
+                    context_expression.into(),
+                );
                 err.fallback_enter_type(self.db())
             })
     }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2879,7 +2879,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                     unpacked.expression_type(name_ast_id)
                 }
                 TargetKind::Name => iterable_ty.try_iterate(self.db()).unwrap_or_else(|err| {
-                    err.report_diagnostic(&self.context, iterable.into());
+                    err.report_diagnostic(&self.context, iterable_ty, iterable.into());
                     err.fallback_element_type(self.db())
                 }),
             }
@@ -3682,7 +3682,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             todo_type!("async iterables/iterators")
         } else {
             iterable_ty.try_iterate(self.db()).unwrap_or_else(|err| {
-                err.report_diagnostic(&self.context, iterable.into());
+                err.report_diagnostic(&self.context, iterable_ty, iterable.into());
                 err.fallback_element_type(self.db())
             })
         };
@@ -3983,7 +3983,7 @@ impl<'db> TypeInferenceBuilder<'db> {
 
         let iterable_ty = self.infer_expression(value);
         iterable_ty.try_iterate(self.db()).unwrap_or_else(|err| {
-            err.report_diagnostic(&self.context, value.as_ref().into());
+            err.report_diagnostic(&self.context, iterable_ty, value.as_ref().into());
             err.fallback_element_type(self.db())
         });
 
@@ -4002,7 +4002,7 @@ impl<'db> TypeInferenceBuilder<'db> {
 
         let iterable_ty = self.infer_expression(value);
         iterable_ty.try_iterate(self.db()).unwrap_or_else(|err| {
-            err.report_diagnostic(&self.context, value.as_ref().into());
+            err.report_diagnostic(&self.context, iterable_ty, value.as_ref().into());
             err.fallback_element_type(self.db())
         });
 

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2868,9 +2868,9 @@ impl<'db> TypeInferenceBuilder<'db> {
         let iterable = for_stmt.iterable();
         let name = for_stmt.name();
 
-        let iterable_ty = self.infer_standalone_expression(iterable);
+        let iterable_type = self.infer_standalone_expression(iterable);
 
-        let loop_var_value_ty = if for_stmt.is_async() {
+        let loop_var_value_type = if for_stmt.is_async() {
             todo_type!("async iterables/iterators")
         } else {
             match for_stmt.target() {
@@ -2882,15 +2882,15 @@ impl<'db> TypeInferenceBuilder<'db> {
                     let name_ast_id = name.scoped_expression_id(self.db(), self.scope());
                     unpacked.expression_type(name_ast_id)
                 }
-                TargetKind::Name => iterable_ty.try_iterate(self.db()).unwrap_or_else(|err| {
-                    err.report_diagnostic(&self.context, iterable_ty, iterable.into());
+                TargetKind::Name => iterable_type.try_iterate(self.db()).unwrap_or_else(|err| {
+                    err.report_diagnostic(&self.context, iterable_type, iterable.into());
                     err.fallback_element_type(self.db())
                 }),
             }
         };
 
-        self.store_expression_type(name, loop_var_value_ty);
-        self.add_binding(name.into(), definition, loop_var_value_ty);
+        self.store_expression_type(name, loop_var_value_type);
+        self.add_binding(name.into(), definition, loop_var_value_type);
     }
 
     fn infer_while_statement(&mut self, while_statement: &ast::StmtWhile) {
@@ -3669,7 +3669,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         // (2) We must *not* call `self.extend()` on the result of the type inference,
         //     because `ScopedExpressionId`s are only meaningful within their own scope, so
         //     we'd add types for random wrong expressions in the current scope
-        let iterable_ty = if is_first {
+        let iterable_type = if is_first {
             let lookup_scope = self
                 .index
                 .parent_scope_id(self.scope().file_scope_id(self.db()))
@@ -3681,21 +3681,21 @@ impl<'db> TypeInferenceBuilder<'db> {
             result.expression_type(iterable.scoped_expression_id(self.db(), self.scope()))
         };
 
-        let target_ty = if is_async {
+        let target_type = if is_async {
             // TODO: async iterables/iterators! -- Alex
             todo_type!("async iterables/iterators")
         } else {
-            iterable_ty.try_iterate(self.db()).unwrap_or_else(|err| {
-                err.report_diagnostic(&self.context, iterable_ty, iterable.into());
+            iterable_type.try_iterate(self.db()).unwrap_or_else(|err| {
+                err.report_diagnostic(&self.context, iterable_type, iterable.into());
                 err.fallback_element_type(self.db())
             })
         };
 
         self.types.expressions.insert(
             target.scoped_expression_id(self.db(), self.scope()),
-            target_ty,
+            target_type,
         );
-        self.add_binding(target.into(), definition, target_ty);
+        self.add_binding(target.into(), definition, target_type);
     }
 
     fn infer_named_expression(&mut self, named: &ast::ExprNamed) -> Type<'db> {
@@ -3985,9 +3985,9 @@ impl<'db> TypeInferenceBuilder<'db> {
             ctx: _,
         } = starred;
 
-        let iterable_ty = self.infer_expression(value);
-        iterable_ty.try_iterate(self.db()).unwrap_or_else(|err| {
-            err.report_diagnostic(&self.context, iterable_ty, value.as_ref().into());
+        let iterable_type = self.infer_expression(value);
+        iterable_type.try_iterate(self.db()).unwrap_or_else(|err| {
+            err.report_diagnostic(&self.context, iterable_type, value.as_ref().into());
             err.fallback_element_type(self.db())
         });
 
@@ -4004,9 +4004,9 @@ impl<'db> TypeInferenceBuilder<'db> {
     fn infer_yield_from_expression(&mut self, yield_from: &ast::ExprYieldFrom) -> Type<'db> {
         let ast::ExprYieldFrom { range: _, value } = yield_from;
 
-        let iterable_ty = self.infer_expression(value);
-        iterable_ty.try_iterate(self.db()).unwrap_or_else(|err| {
-            err.report_diagnostic(&self.context, iterable_ty, value.as_ref().into());
+        let iterable_type = self.infer_expression(value);
+        iterable_type.try_iterate(self.db()).unwrap_or_else(|err| {
+            err.report_diagnostic(&self.context, iterable_type, value.as_ref().into());
             err.fallback_element_type(self.db())
         });
 

--- a/crates/red_knot_python_semantic/src/types/unpacker.rs
+++ b/crates/red_knot_python_semantic/src/types/unpacker.rs
@@ -42,30 +42,36 @@ impl<'db> Unpacker<'db> {
             "Unpacking target must be a list or tuple expression"
         );
 
-        let value_ty = infer_expression_types(self.db(), value.expression())
+        let value_type = infer_expression_types(self.db(), value.expression())
             .expression_type(value.scoped_expression_id(self.db(), self.scope));
 
-        let value_ty = match value {
+        let value_type = match value {
             UnpackValue::Assign(expression) => {
                 if self.context.in_stub()
                     && expression.node_ref(self.db()).is_ellipsis_literal_expr()
                 {
                     Type::unknown()
                 } else {
-                    value_ty
+                    value_type
                 }
             }
-            UnpackValue::Iterable(_) => value_ty.try_iterate(self.db()).unwrap_or_else(|err| {
-                err.report_diagnostic(&self.context, value_ty, value.as_any_node_ref(self.db()));
+            UnpackValue::Iterable(_) => value_type.try_iterate(self.db()).unwrap_or_else(|err| {
+                err.report_diagnostic(&self.context, value_type, value.as_any_node_ref(self.db()));
                 err.fallback_element_type(self.db())
             }),
-            UnpackValue::ContextManager(_) => value_ty.try_enter(self.db()).unwrap_or_else(|err| {
-                err.report_diagnostic(&self.context, value_ty, value.as_any_node_ref(self.db()));
-                err.fallback_enter_type(self.db())
-            }),
+            UnpackValue::ContextManager(_) => {
+                value_type.try_enter(self.db()).unwrap_or_else(|err| {
+                    err.report_diagnostic(
+                        &self.context,
+                        value_type,
+                        value.as_any_node_ref(self.db()),
+                    );
+                    err.fallback_enter_type(self.db())
+                })
+            }
         };
 
-        self.unpack_inner(target, value.as_any_node_ref(self.db()), value_ty);
+        self.unpack_inner(target, value.as_any_node_ref(self.db()), value_type);
     }
 
     fn unpack_inner(

--- a/crates/red_knot_python_semantic/src/types/unpacker.rs
+++ b/crates/red_knot_python_semantic/src/types/unpacker.rs
@@ -60,7 +60,7 @@ impl<'db> Unpacker<'db> {
                 err.fallback_element_type(self.db())
             }),
             UnpackValue::ContextManager(_) => value_ty.try_enter(self.db()).unwrap_or_else(|err| {
-                err.report_diagnostic(&self.context, value.as_any_node_ref(self.db()));
+                err.report_diagnostic(&self.context, value_ty, value.as_any_node_ref(self.db()));
                 err.fallback_enter_type(self.db())
             }),
         };

--- a/crates/red_knot_python_semantic/src/types/unpacker.rs
+++ b/crates/red_knot_python_semantic/src/types/unpacker.rs
@@ -56,7 +56,7 @@ impl<'db> Unpacker<'db> {
                 }
             }
             UnpackValue::Iterable(_) => value_ty.try_iterate(self.db()).unwrap_or_else(|err| {
-                err.report_diagnostic(&self.context, value.as_any_node_ref(self.db()));
+                err.report_diagnostic(&self.context, value_ty, value.as_any_node_ref(self.db()));
                 err.fallback_element_type(self.db())
             }),
             UnpackValue::ContextManager(_) => value_ty.try_enter(self.db()).unwrap_or_else(|err| {
@@ -165,7 +165,7 @@ impl<'db> Unpacker<'db> {
                             Type::LiteralString
                         } else {
                             ty.try_iterate(self.db()).unwrap_or_else(|err| {
-                                err.report_diagnostic(&self.context, value_expr);
+                                err.report_diagnostic(&self.context, ty, value_expr);
                                 err.fallback_element_type(self.db())
                             })
                         };


### PR DESCRIPTION
## Summary

This PR simplifies `IterationError` and `ContextManagerError` so that they no longer "remember" what type it was that was (respectively) not iterable or not valid as a context manager. Instead, the type that was iterated over (or was used as a context manager) is passed back in when calling the error struct's `report_diagnostic` method.

The motivations for this are:
- It significantly simplifies the code
- It reduces the size of these types on the stack

## Test Plan

`cargo test -p red_knot_python_semantic`
