### PR TITLE
[red-knot] Move `name` field on parameter kind

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -2351,14 +2351,18 @@ impl<'db> Type<'db> {
                         Signature::new(
                             Parameters::new([
                                 Parameter::new(
-                                    Some(Name::new_static("instance")),
                                     Some(Type::none(db)),
-                                    ParameterKind::PositionalOnly { default_ty: None },
+                                    ParameterKind::PositionalOnly {
+                                        name: Some(Name::new_static("instance")),
+                                        default_ty: None,
+                                    },
                                 ),
                                 Parameter::new(
-                                    Some(Name::new_static("owner")),
                                     Some(KnownClass::Type.to_instance(db)),
-                                    ParameterKind::PositionalOnly { default_ty: None },
+                                    ParameterKind::PositionalOnly {
+                                        name: Some(Name::new_static("owner")),
+                                        default_ty: None,
+                                    },
                                 ),
                             ]),
                             None,
@@ -2366,17 +2370,19 @@ impl<'db> Type<'db> {
                         Signature::new(
                             Parameters::new([
                                 Parameter::new(
-                                    Some(Name::new_static("instance")),
                                     Some(not_none),
-                                    ParameterKind::PositionalOnly { default_ty: None },
+                                    ParameterKind::PositionalOnly {
+                                        name: Some(Name::new_static("instance")),
+                                        default_ty: None,
+                                    },
                                 ),
                                 Parameter::new(
-                                    Some(Name::new_static("owner")),
                                     Some(UnionType::from_elements(
                                         db,
                                         [KnownClass::Type.to_instance(db), Type::none(db)],
                                     )),
                                     ParameterKind::PositionalOnly {
+                                        name: Some(Name::new_static("owner")),
                                         default_ty: Some(Type::none(db)),
                                     },
                                 ),
@@ -2402,19 +2408,25 @@ impl<'db> Type<'db> {
                         Signature::new(
                             Parameters::new([
                                 Parameter::new(
-                                    Some(Name::new_static("self")),
                                     Some(KnownClass::FunctionType.to_instance(db)),
-                                    ParameterKind::PositionalOnly { default_ty: None },
+                                    ParameterKind::PositionalOnly {
+                                        name: Some(Name::new_static("self")),
+                                        default_ty: None,
+                                    },
                                 ),
                                 Parameter::new(
-                                    Some(Name::new_static("instance")),
                                     Some(Type::none(db)),
-                                    ParameterKind::PositionalOnly { default_ty: None },
+                                    ParameterKind::PositionalOnly {
+                                        name: Some(Name::new_static("instance")),
+                                        default_ty: None,
+                                    },
                                 ),
                                 Parameter::new(
-                                    Some(Name::new_static("owner")),
                                     Some(KnownClass::Type.to_instance(db)),
-                                    ParameterKind::PositionalOnly { default_ty: None },
+                                    ParameterKind::PositionalOnly {
+                                        name: Some(Name::new_static("owner")),
+                                        default_ty: None,
+                                    },
                                 ),
                             ]),
                             None,
@@ -2422,22 +2434,26 @@ impl<'db> Type<'db> {
                         Signature::new(
                             Parameters::new([
                                 Parameter::new(
-                                    Some(Name::new_static("self")),
                                     Some(KnownClass::FunctionType.to_instance(db)),
-                                    ParameterKind::PositionalOnly { default_ty: None },
+                                    ParameterKind::PositionalOnly {
+                                        name: Some(Name::new_static("self")),
+                                        default_ty: None,
+                                    },
                                 ),
                                 Parameter::new(
-                                    Some(Name::new_static("instance")),
                                     Some(not_none),
-                                    ParameterKind::PositionalOnly { default_ty: None },
+                                    ParameterKind::PositionalOnly {
+                                        name: Some(Name::new_static("instance")),
+                                        default_ty: None,
+                                    },
                                 ),
                                 Parameter::new(
-                                    Some(Name::new_static("owner")),
                                     Some(UnionType::from_elements(
                                         db,
                                         [KnownClass::Type.to_instance(db), Type::none(db)],
                                     )),
                                     ParameterKind::PositionalOnly {
+                                        name: Some(Name::new_static("owner")),
                                         default_ty: Some(Type::none(db)),
                                     },
                                 ),
@@ -2464,9 +2480,9 @@ impl<'db> Type<'db> {
                         self,
                         Signature::new(
                             Parameters::new([Parameter::new(
-                                Some(Name::new_static("o")),
                                 Some(Type::any()),
                                 ParameterKind::PositionalOnly {
+                                    name: Some(Name::new_static("o")),
                                     default_ty: Some(Type::BooleanLiteral(false)),
                                 },
                             )]),
@@ -2489,9 +2505,9 @@ impl<'db> Type<'db> {
                         [
                             Signature::new(
                                 Parameters::new([Parameter::new(
-                                    Some(Name::new_static("o")),
                                     Some(Type::any()),
                                     ParameterKind::PositionalOnly {
+                                        name: Some(Name::new_static("o")),
                                         default_ty: Some(Type::string_literal(db, "")),
                                     },
                                 )]),
@@ -2500,19 +2516,25 @@ impl<'db> Type<'db> {
                             Signature::new(
                                 Parameters::new([
                                     Parameter::new(
-                                        Some(Name::new_static("o")),
                                         Some(Type::any()), // TODO: ReadableBuffer
-                                        ParameterKind::PositionalOnly { default_ty: None },
+                                        ParameterKind::PositionalOnly {
+                                            name: Some(Name::new_static("o")),
+                                            default_ty: None,
+                                        },
                                     ),
                                     Parameter::new(
-                                        Some(Name::new_static("encoding")),
                                         Some(KnownClass::Str.to_instance(db)),
-                                        ParameterKind::PositionalOnly { default_ty: None },
+                                        ParameterKind::PositionalOnly {
+                                            name: Some(Name::new_static("encoding")),
+                                            default_ty: None,
+                                        },
                                     ),
                                     Parameter::new(
-                                        Some(Name::new_static("errors")),
                                         Some(KnownClass::Str.to_instance(db)),
-                                        ParameterKind::PositionalOnly { default_ty: None },
+                                        ParameterKind::PositionalOnly {
+                                            name: Some(Name::new_static("errors")),
+                                            default_ty: None,
+                                        },
                                     ),
                                 ]),
                                 Some(KnownClass::Str.to_instance(db)),
@@ -2535,28 +2557,36 @@ impl<'db> Type<'db> {
                         [
                             Signature::new(
                                 Parameters::new([Parameter::new(
-                                    Some(Name::new_static("o")),
                                     Some(Type::any()),
-                                    ParameterKind::PositionalOnly { default_ty: None },
+                                    ParameterKind::PositionalOnly {
+                                        name: Some(Name::new_static("o")),
+                                        default_ty: None,
+                                    },
                                 )]),
                                 Some(KnownClass::Type.to_instance(db)),
                             ),
                             Signature::new(
                                 Parameters::new([
                                     Parameter::new(
-                                        Some(Name::new_static("o")),
                                         Some(Type::any()),
-                                        ParameterKind::PositionalOnly { default_ty: None },
+                                        ParameterKind::PositionalOnly {
+                                            name: Some(Name::new_static("o")),
+                                            default_ty: None,
+                                        },
                                     ),
                                     Parameter::new(
-                                        Some(Name::new_static("bases")),
                                         Some(Type::any()),
-                                        ParameterKind::PositionalOnly { default_ty: None },
+                                        ParameterKind::PositionalOnly {
+                                            name: Some(Name::new_static("bases")),
+                                            default_ty: None,
+                                        },
                                     ),
                                     Parameter::new(
-                                        Some(Name::new_static("dict")),
                                         Some(Type::any()),
-                                        ParameterKind::PositionalOnly { default_ty: None },
+                                        ParameterKind::PositionalOnly {
+                                            name: Some(Name::new_static("dict")),
+                                            default_ty: None,
+                                        },
                                     ),
                                 ]),
                                 Some(KnownClass::Type.to_instance(db)),

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -575,13 +575,15 @@ mod tests {
             display_signature(
                 &db,
                 [Parameter::new(
-                    None,
                     Some(Type::none(&db)),
-                    ParameterKind::PositionalOrKeyword { default_ty: None }
+                    ParameterKind::PositionalOnly {
+                        name: None,
+                        default_ty: None
+                    }
                 )],
                 Some(Type::none(&db))
             ),
-            "(None) -> None"
+            "(None, /) -> None"
         );
 
         // Two parameters where one has annotation and the other doesn't.
@@ -590,16 +592,16 @@ mod tests {
                 &db,
                 [
                     Parameter::new(
-                        Some(Name::new_static("x")),
                         None,
                         ParameterKind::PositionalOrKeyword {
+                            name: Name::new_static("x"),
                             default_ty: Some(KnownClass::Int.to_instance(&db))
                         }
                     ),
                     Parameter::new(
-                        Some(Name::new_static("y")),
                         Some(KnownClass::Str.to_instance(&db)),
                         ParameterKind::PositionalOrKeyword {
+                            name: Name::new_static("y"),
                             default_ty: Some(KnownClass::Str.to_instance(&db))
                         }
                     )
@@ -615,14 +617,18 @@ mod tests {
                 &db,
                 [
                     Parameter::new(
-                        Some(Name::new_static("x")),
                         None,
-                        ParameterKind::PositionalOnly { default_ty: None }
+                        ParameterKind::PositionalOnly {
+                            name: Some(Name::new_static("x")),
+                            default_ty: None
+                        }
                     ),
                     Parameter::new(
-                        Some(Name::new_static("y")),
                         None,
-                        ParameterKind::PositionalOnly { default_ty: None }
+                        ParameterKind::PositionalOnly {
+                            name: Some(Name::new_static("y")),
+                            default_ty: None
+                        }
                     )
                 ],
                 Some(Type::none(&db))
@@ -636,14 +642,18 @@ mod tests {
                 &db,
                 [
                     Parameter::new(
-                        Some(Name::new_static("x")),
                         None,
-                        ParameterKind::PositionalOnly { default_ty: None }
+                        ParameterKind::PositionalOnly {
+                            name: Some(Name::new_static("x")),
+                            default_ty: None
+                        }
                     ),
                     Parameter::new(
-                        Some(Name::new_static("y")),
                         None,
-                        ParameterKind::PositionalOrKeyword { default_ty: None }
+                        ParameterKind::PositionalOrKeyword {
+                            name: Name::new_static("y"),
+                            default_ty: None
+                        }
                     )
                 ],
                 Some(Type::none(&db))
@@ -657,14 +667,18 @@ mod tests {
                 &db,
                 [
                     Parameter::new(
-                        Some(Name::new_static("x")),
                         None,
-                        ParameterKind::KeywordOnly { default_ty: None }
+                        ParameterKind::KeywordOnly {
+                            name: Name::new_static("x"),
+                            default_ty: None
+                        }
                     ),
                     Parameter::new(
-                        Some(Name::new_static("y")),
                         None,
-                        ParameterKind::KeywordOnly { default_ty: None }
+                        ParameterKind::KeywordOnly {
+                            name: Name::new_static("y"),
+                            default_ty: None
+                        }
                     )
                 ],
                 Some(Type::none(&db))
@@ -678,14 +692,18 @@ mod tests {
                 &db,
                 [
                     Parameter::new(
-                        Some(Name::new_static("x")),
                         None,
-                        ParameterKind::PositionalOrKeyword { default_ty: None }
+                        ParameterKind::PositionalOrKeyword {
+                            name: Name::new_static("x"),
+                            default_ty: None
+                        }
                     ),
                     Parameter::new(
-                        Some(Name::new_static("y")),
                         None,
-                        ParameterKind::KeywordOnly { default_ty: None }
+                        ParameterKind::KeywordOnly {
+                            name: Name::new_static("y"),
+                            default_ty: None
+                        }
                     )
                 ],
                 Some(Type::none(&db))
@@ -699,66 +717,72 @@ mod tests {
                 &db,
                 [
                     Parameter::new(
-                        Some(Name::new_static("a")),
-                        None,
-                        ParameterKind::PositionalOnly { default_ty: None },
-                    ),
-                    Parameter::new(
-                        Some(Name::new_static("b")),
-                        Some(KnownClass::Int.to_instance(&db)),
-                        ParameterKind::PositionalOnly { default_ty: None },
-                    ),
-                    Parameter::new(
-                        Some(Name::new_static("c")),
                         None,
                         ParameterKind::PositionalOnly {
+                            name: Some(Name::new_static("a")),
+                            default_ty: None
+                        },
+                    ),
+                    Parameter::new(
+                        Some(KnownClass::Int.to_instance(&db)),
+                        ParameterKind::PositionalOnly {
+                            name: Some(Name::new_static("b")),
+                            default_ty: None
+                        },
+                    ),
+                    Parameter::new(
+                        None,
+                        ParameterKind::PositionalOnly {
+                            name: Some(Name::new_static("c")),
                             default_ty: Some(Type::IntLiteral(1)),
                         },
                     ),
                     Parameter::new(
-                        Some(Name::new_static("d")),
                         Some(KnownClass::Int.to_instance(&db)),
                         ParameterKind::PositionalOnly {
+                            name: Some(Name::new_static("d")),
                             default_ty: Some(Type::IntLiteral(2)),
                         },
                     ),
                     Parameter::new(
-                        Some(Name::new_static("e")),
                         None,
                         ParameterKind::PositionalOrKeyword {
+                            name: Name::new_static("e"),
                             default_ty: Some(Type::IntLiteral(3)),
                         },
                     ),
                     Parameter::new(
-                        Some(Name::new_static("f")),
                         Some(KnownClass::Int.to_instance(&db)),
                         ParameterKind::PositionalOrKeyword {
+                            name: Name::new_static("f"),
                             default_ty: Some(Type::IntLiteral(4)),
                         },
                     ),
                     Parameter::new(
-                        Some(Name::new_static("args")),
                         Some(Type::object(&db)),
-                        ParameterKind::Variadic,
+                        ParameterKind::Variadic {
+                            name: Name::new_static("args")
+                        },
                     ),
                     Parameter::new(
-                        Some(Name::new_static("g")),
                         None,
                         ParameterKind::KeywordOnly {
+                            name: Name::new_static("g"),
                             default_ty: Some(Type::IntLiteral(5)),
                         },
                     ),
                     Parameter::new(
-                        Some(Name::new_static("h")),
                         Some(KnownClass::Int.to_instance(&db)),
                         ParameterKind::KeywordOnly {
+                            name: Name::new_static("h"),
                             default_ty: Some(Type::IntLiteral(6)),
                         },
                     ),
                     Parameter::new(
-                        Some(Name::new_static("kwargs")),
                         Some(KnownClass::Str.to_instance(&db)),
-                        ParameterKind::KeywordVariadic,
+                        ParameterKind::KeywordVariadic {
+                            name: Name::new_static("kwargs")
+                        },
                     ),
                 ],
                 Some(KnownClass::Bytes.to_instance(&db))

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -3767,9 +3767,9 @@ impl<'db> TypeInferenceBuilder<'db> {
                 .iter()
                 .map(|parameter| {
                     Parameter::new(
-                        Some(parameter.name().id.clone()),
                         None,
                         ParameterKind::PositionalOnly {
+                            name: Some(parameter.name().id.clone()),
                             default_ty: parameter
                                 .default()
                                 .map(|default| self.infer_expression(default)),
@@ -3782,9 +3782,9 @@ impl<'db> TypeInferenceBuilder<'db> {
                 .iter()
                 .map(|parameter| {
                     Parameter::new(
-                        Some(parameter.name().id.clone()),
                         None,
                         ParameterKind::PositionalOrKeyword {
+                            name: parameter.name().id.clone(),
                             default_ty: parameter
                                 .default()
                                 .map(|default| self.infer_expression(default)),
@@ -3794,9 +3794,10 @@ impl<'db> TypeInferenceBuilder<'db> {
                 .collect::<Vec<_>>();
             let variadic = parameters.vararg.as_ref().map(|parameter| {
                 Parameter::new(
-                    Some(parameter.name.id.clone()),
                     None,
-                    ParameterKind::Variadic,
+                    ParameterKind::Variadic {
+                        name: parameter.name.id.clone(),
+                    },
                 )
             });
             let keyword_only = parameters
@@ -3804,9 +3805,9 @@ impl<'db> TypeInferenceBuilder<'db> {
                 .iter()
                 .map(|parameter| {
                     Parameter::new(
-                        Some(parameter.name().id.clone()),
                         None,
                         ParameterKind::KeywordOnly {
+                            name: parameter.name().id.clone(),
                             default_ty: parameter
                                 .default()
                                 .map(|default| self.infer_expression(default)),
@@ -3816,9 +3817,10 @@ impl<'db> TypeInferenceBuilder<'db> {
                 .collect::<Vec<_>>();
             let keyword_variadic = parameters.kwarg.as_ref().map(|parameter| {
                 Parameter::new(
-                    Some(parameter.name.id.clone()),
                     None,
-                    ParameterKind::KeywordVariadic,
+                    ParameterKind::KeywordVariadic {
+                        name: parameter.name.id.clone(),
+                    },
                 )
             });
 
@@ -6882,9 +6884,11 @@ impl<'db> TypeInferenceBuilder<'db> {
                 } else {
                     Parameters::new(parameter_types.iter().map(|param_type| {
                         Parameter::new(
-                            None,
                             Some(*param_type),
-                            ParameterKind::PositionalOnly { default_ty: None },
+                            ParameterKind::PositionalOnly {
+                                name: None,
+                                default_ty: None,
+                            },
                         )
                     }))
                 }


### PR DESCRIPTION
## Summary

Previously, the `name` field was on `Parameter` which required it to be always optional regardless of the parameter kind because a `typing.Callable` signature does not have name for the parameters. This is the case for positional-only parameters. This wasn't enforced at the type level which meant that downstream usages would have to unwrap on `name` even though it's guaranteed to be present.

This commit moves the `name` field from `Parameter` to the `ParameterKind` variants and makes it optional only for `ParameterKind::PositionalOnly` variant while required for all other variants.

One change that's now required is that a `Callable` form using a gradual form for parameter types (`...`) would have a default `args` and `kwargs` name used for variadic and keyword-variadic parameter kind respectively. This is also the case for invalid `Callable` type forms. I think this is fine as names are not relevant in this context but happy to make it optional even in variadic variants.

## Test Plan

No new tests; make sure existing tests are passing.
