### PR TITLE
[internal] Return `Message`s from `check_path`

### DIFF
--- a/crates/ruff/src/cache.rs
+++ b/crates/ruff/src/cache.rs
@@ -353,6 +353,7 @@ impl FileCache {
                             fix: msg.fix.clone(),
                             file: file.clone(),
                             noqa_offset: msg.noqa_offset,
+                            parent: msg.parent,
                         })
                     })
                     .collect()
@@ -445,6 +446,7 @@ impl LintCacheData {
                 CacheMessage {
                     kind: msg.kind.clone(),
                     range: msg.range,
+                    parent: msg.parent,
                     fix: msg.fix.clone(),
                     noqa_offset: msg.noqa_offset,
                 }
@@ -465,6 +467,7 @@ pub(super) struct CacheMessage {
     kind: DiagnosticKind,
     /// Range into the message's [`FileCache::source`].
     range: TextRange,
+    parent: Option<TextSize>,
     fix: Option<Fix>,
     noqa_offset: TextSize,
 }
@@ -702,7 +705,10 @@ mod tests {
             .unwrap();
         }
 
-        assert_eq!(expected_diagnostics, got_diagnostics);
+        assert_eq!(
+            expected_diagnostics, got_diagnostics,
+            "left == {expected_diagnostics:#?}, right == {got_diagnostics:#?}",
+        );
     }
 
     #[test]

--- a/crates/ruff_linter/src/fix/mod.rs
+++ b/crates/ruff_linter/src/fix/mod.rs
@@ -27,17 +27,17 @@ pub(crate) struct FixResult {
 
 /// Fix errors in a file, and write the fixed source code to disk.
 pub(crate) fn fix_file(
-    diagnostics: &[Message],
+    messages: &[Message],
     locator: &Locator,
     unsafe_fixes: UnsafeFixes,
 ) -> Option<FixResult> {
     let required_applicability = unsafe_fixes.required_applicability();
 
-    let mut with_fixes = diagnostics
+    let mut with_fixes = messages
         .iter()
         .filter_map(Message::as_diagnostic_message)
-        .filter(|diagnostic| {
-            diagnostic
+        .filter(|message| {
+            message
                 .fix
                 .as_ref()
                 .is_some_and(|fix| fix.applies(required_applicability))

--- a/crates/ruff_linter/src/linter.rs
+++ b/crates/ruff_linter/src/linter.rs
@@ -58,8 +58,7 @@ pub struct FixerResult<'a> {
     pub fixed: FixTable,
 }
 
-/// Generate `Diagnostic`s from the source code contents at the
-/// given `Path`.
+/// Generate [`Message`]s from the source code contents at the given `Path`.
 #[allow(clippy::too_many_arguments)]
 pub fn check_path(
     path: &Path,
@@ -74,7 +73,7 @@ pub fn check_path(
     source_type: PySourceType,
     parsed: &Parsed<ModModule>,
     target_version: PythonVersion,
-) -> Vec<Diagnostic> {
+) -> Vec<Message> {
     // Aggregate all diagnostics.
     let mut diagnostics = vec![];
 
@@ -322,7 +321,20 @@ pub fn check_path(
         }
     }
 
-    diagnostics
+    let syntax_errors = if settings.preview.is_enabled() {
+        parsed.unsupported_syntax_errors()
+    } else {
+        &[]
+    };
+
+    diagnostics_to_messages(
+        diagnostics,
+        parsed.errors(),
+        syntax_errors,
+        path,
+        locator,
+        directives,
+    )
 }
 
 const MAX_ITERATIONS: usize = 100;
@@ -417,7 +429,7 @@ pub fn lint_only(
     );
 
     // Generate diagnostics.
-    let diagnostics = check_path(
+    let messages = check_path(
         path,
         package,
         &locator,
@@ -432,21 +444,8 @@ pub fn lint_only(
         target_version,
     );
 
-    let syntax_errors = if settings.preview.is_enabled() {
-        parsed.unsupported_syntax_errors()
-    } else {
-        &[]
-    };
-
     LinterResult {
-        messages: diagnostics_to_messages(
-            diagnostics,
-            parsed.errors(),
-            syntax_errors,
-            path,
-            &locator,
-            &directives,
-        ),
+        messages,
         has_syntax_error: parsed.has_syntax_errors(),
     }
 }
@@ -591,22 +590,9 @@ pub fn lint_fix<'a>(
             report_failed_to_converge_error(path, transformed.source_code(), &diagnostics);
         }
 
-        let syntax_errors = if settings.preview.is_enabled() {
-            parsed.unsupported_syntax_errors()
-        } else {
-            &[]
-        };
-
         return Ok(FixerResult {
             result: LinterResult {
-                messages: diagnostics_to_messages(
-                    diagnostics,
-                    parsed.errors(),
-                    syntax_errors,
-                    path,
-                    &locator,
-                    &directives,
-                ),
+                messages: diagnostics,
                 has_syntax_error: !is_valid_syntax,
             },
             transformed,
@@ -625,8 +611,8 @@ fn collect_rule_codes(rules: impl IntoIterator<Item = Rule>) -> String {
 }
 
 #[allow(clippy::print_stderr)]
-fn report_failed_to_converge_error(path: &Path, transformed: &str, diagnostics: &[Diagnostic]) {
-    let codes = collect_rule_codes(diagnostics.iter().map(|diagnostic| diagnostic.kind.rule()));
+fn report_failed_to_converge_error(path: &Path, transformed: &str, diagnostics: &[Message]) {
+    let codes = collect_rule_codes(diagnostics.iter().filter_map(Message::rule));
     if cfg!(debug_assertions) {
         eprintln!(
             "{}{} Failed to converge after {} iterations in `{}` with rule codes {}:---\n{}\n---",

--- a/crates/ruff_linter/src/linter.rs
+++ b/crates/ruff_linter/src/linter.rs
@@ -369,7 +369,7 @@ pub fn add_noqa_to_path(
     );
 
     // Generate diagnostics, ignoring any existing `noqa` directives.
-    let diagnostics = check_path(
+    let messages = check_path(
         path,
         package,
         &locator,
@@ -388,7 +388,7 @@ pub fn add_noqa_to_path(
     // TODO(dhruvmanila): Add support for Jupyter Notebooks
     add_noqa(
         path,
-        &diagnostics,
+        &messages,
         &locator,
         indexer.comment_ranges(),
         &settings.external,
@@ -531,7 +531,7 @@ pub fn lint_fix<'a>(
         );
 
         // Generate diagnostics.
-        let diagnostics = check_path(
+        let messages = check_path(
             path,
             package,
             &locator,
@@ -570,7 +570,7 @@ pub fn lint_fix<'a>(
             code: fixed_contents,
             fixes: applied,
             source_map,
-        }) = fix_file(&diagnostics, &locator, unsafe_fixes)
+        }) = fix_file(&messages, &locator, unsafe_fixes)
         {
             if iterations < MAX_ITERATIONS {
                 // Count the number of fixed errors.
@@ -587,12 +587,12 @@ pub fn lint_fix<'a>(
                 continue;
             }
 
-            report_failed_to_converge_error(path, transformed.source_code(), &diagnostics);
+            report_failed_to_converge_error(path, transformed.source_code(), &messages);
         }
 
         return Ok(FixerResult {
             result: LinterResult {
-                messages: diagnostics,
+                messages,
                 has_syntax_error: !is_valid_syntax,
             },
             transformed,
@@ -611,8 +611,8 @@ fn collect_rule_codes(rules: impl IntoIterator<Item = Rule>) -> String {
 }
 
 #[allow(clippy::print_stderr)]
-fn report_failed_to_converge_error(path: &Path, transformed: &str, diagnostics: &[Message]) {
-    let codes = collect_rule_codes(diagnostics.iter().filter_map(Message::rule));
+fn report_failed_to_converge_error(path: &Path, transformed: &str, messages: &[Message]) {
+    let codes = collect_rule_codes(messages.iter().filter_map(Message::rule));
     if cfg!(debug_assertions) {
         eprintln!(
             "{}{} Failed to converge after {} iterations in `{}` with rule codes {}:---\n{}\n---",

--- a/crates/ruff_linter/src/message/mod.rs
+++ b/crates/ruff_linter/src/message/mod.rs
@@ -41,24 +41,25 @@ mod text;
 
 /// Message represents either a diagnostic message corresponding to a rule violation or a syntax
 /// error message raised by the parser.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Message {
     Diagnostic(DiagnosticMessage),
     SyntaxError(SyntaxErrorMessage),
 }
 
 /// A diagnostic message corresponding to a rule violation.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DiagnosticMessage {
     pub kind: DiagnosticKind,
     pub range: TextRange,
     pub fix: Option<Fix>,
+    pub parent: Option<TextSize>,
     pub file: SourceFile,
     pub noqa_offset: TextSize,
 }
 
 /// A syntax error message raised by the parser.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SyntaxErrorMessage {
     pub message: String,
     pub range: TextRange,
@@ -91,6 +92,7 @@ impl Message {
             range: diagnostic.range(),
             kind: diagnostic.kind,
             fix: diagnostic.fix,
+            parent: diagnostic.parent,
             file,
             noqa_offset,
         })
@@ -134,6 +136,13 @@ impl Message {
     }
 
     pub const fn as_diagnostic_message(&self) -> Option<&DiagnosticMessage> {
+        match self {
+            Message::Diagnostic(m) => Some(m),
+            Message::SyntaxError(_) => None,
+        }
+    }
+
+    pub fn into_diagnostic_message(self) -> Option<DiagnosticMessage> {
         match self {
             Message::Diagnostic(m) => Some(m),
             Message::SyntaxError(_) => None,

--- a/crates/ruff_linter/src/rules/pyflakes/mod.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/mod.rs
@@ -758,7 +758,7 @@ mod tests {
             &locator,
             &indexer,
         );
-        let mut diagnostics = check_path(
+        let mut messages = check_path(
             Path::new("<filename>"),
             None,
             &locator,
@@ -772,8 +772,8 @@ mod tests {
             &parsed,
             settings.unresolved_target_version,
         );
-        diagnostics.sort_by_key(Ranged::start);
-        let actual = diagnostics
+        messages.sort_by_key(Ranged::start);
+        let actual = messages
             .iter()
             .filter_map(Message::as_diagnostic_message)
             .map(|diagnostic| diagnostic.kind.rule())

--- a/crates/ruff_linter/src/rules/pyflakes/mod.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/mod.rs
@@ -22,6 +22,7 @@ mod tests {
     use ruff_text_size::Ranged;
 
     use crate::linter::check_path;
+    use crate::message::Message;
     use crate::registry::{AsRule, Linter, Rule};
     use crate::rules::isort;
     use crate::rules::pyflakes;
@@ -774,6 +775,7 @@ mod tests {
         diagnostics.sort_by_key(Ranged::start);
         let actual = diagnostics
             .iter()
+            .filter_map(Message::as_diagnostic_message)
             .map(|diagnostic| diagnostic.kind.rule())
             .collect::<Vec<_>>();
         assert_eq!(actual, expected);

--- a/crates/ruff_server/src/lint.rs
+++ b/crates/ruff_server/src/lint.rs
@@ -13,14 +13,15 @@ use ruff_diagnostics::{Applicability, DiagnosticKind, Edit, Fix};
 use ruff_linter::{
     directives::{extract_directives, Flags},
     generate_noqa_edits,
+    linter::check_path,
     message::{DiagnosticMessage, Message, SyntaxErrorMessage},
+    package::PackageRoot,
     packaging::detect_package_root,
     registry::AsRule,
     settings::flags,
     source_kind::SourceKind,
     Locator,
 };
-use ruff_linter::{linter::check_path, package::PackageRoot};
 use ruff_notebook::Notebook;
 use ruff_python_codegen::Stylist;
 use ruff_python_index::Indexer;

--- a/crates/ruff_server/src/lint.rs
+++ b/crates/ruff_server/src/lint.rs
@@ -120,7 +120,7 @@ pub(crate) fn check(
     let directives = extract_directives(parsed.tokens(), Flags::all(), &locator, &indexer);
 
     // Generate checks.
-    let diagnostics = check_path(
+    let messages = check_path(
         &query.virtual_file_path(),
         package,
         &locator,
@@ -137,7 +137,7 @@ pub(crate) fn check(
 
     let noqa_edits = generate_noqa_edits(
         &query.virtual_file_path(),
-        &diagnostics,
+        &messages,
         &locator,
         indexer.comment_ranges(),
         &settings.linter.external,
@@ -160,10 +160,10 @@ pub(crate) fn check(
     }
 
     let lsp_diagnostics =
-        diagnostics
+        messages
             .into_iter()
             .zip(noqa_edits)
-            .filter_map(|(diagnostic, noqa_edit)| match diagnostic {
+            .filter_map(|(message, noqa_edit)| match message {
                 Message::Diagnostic(diagnostic_message) => Some(to_lsp_diagnostic(
                     diagnostic_message,
                     noqa_edit,

--- a/crates/ruff_server/src/lint.rs
+++ b/crates/ruff_server/src/lint.rs
@@ -9,22 +9,22 @@ use crate::{
     session::DocumentQuery,
     PositionEncoding, DIAGNOSTIC_NAME,
 };
-use ruff_diagnostics::{Applicability, Diagnostic, DiagnosticKind, Edit, Fix};
-use ruff_linter::package::PackageRoot;
+use ruff_diagnostics::{Applicability, DiagnosticKind, Edit, Fix};
 use ruff_linter::{
     directives::{extract_directives, Flags},
     generate_noqa_edits,
-    linter::check_path,
+    message::{DiagnosticMessage, Message, SyntaxErrorMessage},
     packaging::detect_package_root,
     registry::AsRule,
     settings::flags,
     source_kind::SourceKind,
     Locator,
 };
+use ruff_linter::{linter::check_path, package::PackageRoot};
 use ruff_notebook::Notebook;
 use ruff_python_codegen::Stylist;
 use ruff_python_index::Indexer;
-use ruff_python_parser::{ParseError, ParseOptions, UnsupportedSyntaxError};
+use ruff_python_parser::ParseOptions;
 use ruff_source_file::LineIndex;
 use ruff_text_size::{Ranged, TextRange};
 
@@ -159,51 +159,27 @@ pub(crate) fn check(
             .or_default();
     }
 
-    let lsp_diagnostics = diagnostics
-        .into_iter()
-        .zip(noqa_edits)
-        .map(|(diagnostic, noqa_edit)| {
-            to_lsp_diagnostic(
-                diagnostic,
-                noqa_edit,
-                &source_kind,
-                locator.to_index(),
-                encoding,
-            )
-        });
-
-    let unsupported_syntax_errors = if settings.linter.preview.is_enabled() {
-        parsed.unsupported_syntax_errors()
-    } else {
-        &[]
-    };
-
-    let lsp_diagnostics = lsp_diagnostics.chain(
-        show_syntax_errors
-            .then(|| {
-                parsed
-                    .errors()
-                    .iter()
-                    .map(|parse_error| {
-                        parse_error_to_lsp_diagnostic(
-                            parse_error,
-                            &source_kind,
-                            locator.to_index(),
-                            encoding,
-                        )
-                    })
-                    .chain(unsupported_syntax_errors.iter().map(|error| {
-                        unsupported_syntax_error_to_lsp_diagnostic(
-                            error,
-                            &source_kind,
-                            locator.to_index(),
-                            encoding,
-                        )
-                    }))
-            })
+    let lsp_diagnostics =
+        diagnostics
             .into_iter()
-            .flatten(),
-    );
+            .zip(noqa_edits)
+            .filter_map(|(diagnostic, noqa_edit)| match diagnostic {
+                Message::Diagnostic(diagnostic_message) => Some(to_lsp_diagnostic(
+                    diagnostic_message,
+                    noqa_edit,
+                    &source_kind,
+                    locator.to_index(),
+                    encoding,
+                )),
+                Message::SyntaxError(syntax_error_message) => show_syntax_errors.then(|| {
+                    syntax_error_to_lsp_diagnostic(
+                        syntax_error_message,
+                        &source_kind,
+                        locator.to_index(),
+                        encoding,
+                    )
+                }),
+            });
 
     if let Some(notebook) = query.as_notebook() {
         for (index, diagnostic) in lsp_diagnostics {
@@ -260,13 +236,13 @@ pub(crate) fn fixes_for_diagnostics(
 /// Generates an LSP diagnostic with an associated cell index for the diagnostic to go in.
 /// If the source kind is a text document, the cell index will always be `0`.
 fn to_lsp_diagnostic(
-    diagnostic: Diagnostic,
+    diagnostic: DiagnosticMessage,
     noqa_edit: Option<Edit>,
     source_kind: &SourceKind,
     index: &LineIndex,
     encoding: PositionEncoding,
 ) -> (usize, lsp_types::Diagnostic) {
-    let Diagnostic {
+    let DiagnosticMessage {
         kind,
         range: diagnostic_range,
         fix,
@@ -339,8 +315,8 @@ fn to_lsp_diagnostic(
     )
 }
 
-fn parse_error_to_lsp_diagnostic(
-    parse_error: &ParseError,
+fn syntax_error_to_lsp_diagnostic(
+    syntax_error: SyntaxErrorMessage,
     source_kind: &SourceKind,
     index: &LineIndex,
     encoding: PositionEncoding,
@@ -349,7 +325,7 @@ fn parse_error_to_lsp_diagnostic(
     let cell: usize;
 
     if let Some(notebook_index) = source_kind.as_ipy_notebook().map(Notebook::index) {
-        NotebookRange { cell, range } = parse_error.location.to_notebook_range(
+        NotebookRange { cell, range } = syntax_error.range.to_notebook_range(
             source_kind.source_code(),
             index,
             notebook_index,
@@ -357,46 +333,7 @@ fn parse_error_to_lsp_diagnostic(
         );
     } else {
         cell = usize::default();
-        range = parse_error
-            .location
-            .to_range(source_kind.source_code(), index, encoding);
-    }
-
-    (
-        cell,
-        lsp_types::Diagnostic {
-            range,
-            severity: Some(lsp_types::DiagnosticSeverity::ERROR),
-            tags: None,
-            code: None,
-            code_description: None,
-            source: Some(DIAGNOSTIC_NAME.into()),
-            message: format!("SyntaxError: {}", &parse_error.error),
-            related_information: None,
-            data: None,
-        },
-    )
-}
-
-fn unsupported_syntax_error_to_lsp_diagnostic(
-    unsupported_syntax_error: &UnsupportedSyntaxError,
-    source_kind: &SourceKind,
-    index: &LineIndex,
-    encoding: PositionEncoding,
-) -> (usize, lsp_types::Diagnostic) {
-    let range: lsp_types::Range;
-    let cell: usize;
-
-    if let Some(notebook_index) = source_kind.as_ipy_notebook().map(Notebook::index) {
-        NotebookRange { cell, range } = unsupported_syntax_error.range.to_notebook_range(
-            source_kind.source_code(),
-            index,
-            notebook_index,
-            encoding,
-        );
-    } else {
-        cell = usize::default();
-        range = unsupported_syntax_error
+        range = syntax_error
             .range
             .to_range(source_kind.source_code(), index, encoding);
     }
@@ -410,7 +347,7 @@ fn unsupported_syntax_error_to_lsp_diagnostic(
             code: None,
             code_description: None,
             source: Some(DIAGNOSTIC_NAME.into()),
-            message: format!("SyntaxError: {unsupported_syntax_error}"),
+            message: syntax_error.message,
             related_information: None,
             data: None,
         },

--- a/crates/ruff_wasm/src/lib.rs
+++ b/crates/ruff_wasm/src/lib.rs
@@ -189,7 +189,7 @@ impl Workspace {
         );
 
         // Generate checks.
-        let diagnostics = check_path(
+        let messages = check_path(
             Path::new("<filename>"),
             None,
             &locator,
@@ -206,9 +206,9 @@ impl Workspace {
 
         let source_code = locator.to_source_code();
 
-        let messages: Vec<ExpandedMessage> = diagnostics
+        let messages: Vec<ExpandedMessage> = messages
             .into_iter()
-            .map(|diagnostic| match diagnostic {
+            .map(|message| match message {
                 Message::Diagnostic(DiagnosticMessage {
                     kind, range, fix, ..
                 }) => ExpandedMessage {

--- a/crates/ruff_wasm/tests/api.rs
+++ b/crates/ruff_wasm/tests/api.rs
@@ -27,7 +27,7 @@ fn empty_config() {
         [ExpandedMessage {
             code: Some(Rule::IfTuple.noqa_code().to_string()),
             message: "If test is a tuple, which is always `True`".to_string(),
-            location: SourceLocation {
+            start_location: SourceLocation {
                 row: OneIndexed::from_zero_indexed(0),
                 column: OneIndexed::from_zero_indexed(3)
             },
@@ -48,7 +48,7 @@ fn syntax_error() {
         [ExpandedMessage {
             code: None,
             message: "SyntaxError: Expected an expression".to_string(),
-            location: SourceLocation {
+            start_location: SourceLocation {
                 row: OneIndexed::from_zero_indexed(0),
                 column: OneIndexed::from_zero_indexed(3)
             },
@@ -69,7 +69,7 @@ fn unsupported_syntax_error() {
         [ExpandedMessage {
             code: None,
             message: "SyntaxError: Cannot use `match` statement on Python 3.9 (syntax was added in Python 3.10)".to_string(),
-            location: SourceLocation {
+            start_location: SourceLocation {
                 row: OneIndexed::from_zero_indexed(0),
                 column: OneIndexed::from_zero_indexed(0)
             },


### PR DESCRIPTION
Summary
--

This PR updates `check_path` in the `ruff_linter` crate to return a `Vec<Message>` instead of a `Vec<Diagnostic>`. The main motivation for this is to make it easier to convert semantic syntax errors directly into `Message`s rather than `Diagnostic`s in #16106. However, this also has the benefit of keeping the preview check on unsupported syntax errors in `check_path`, as suggested in https://github.com/astral-sh/ruff/pull/16429#discussion_r1974748024.

All of the interesting changes are in the first commit. The second commit just renames variables like `diagnostics` to `messages`, and the third commit is a tiny import fix.

Test Plan
--

Existing tests. I also tested the playground and server manually.