### PR TITLE
[red-knot] Add missing space between error message and lint code in playground

### DIFF
--- a/playground/knot/src/Editor/Diagnostics.tsx
+++ b/playground/knot/src/Editor/Diagnostics.tsx
@@ -88,7 +88,7 @@ function Items({
             >
               {diagnostic.message()}
               <span className="text-gray-500">
-                {id != null && `(${id})`} [Ln {startLine}, Col {startColumn}]
+                {id != null && ` (${id})`} [Ln {startLine}, Col {startColumn}]
               </span>
             </button>
           </li>


### PR DESCRIPTION
## Summary

Here's how an error message is currently displayed:

![](https://github.com/user-attachments/assets/b8953043-1208-4945-86a5-2e7013ed5b39)

Compare that with Ruff's:

![](https://github.com/user-attachments/assets/1b1ae24c-9671-4882-83a9-b34f5a4ade3a)

## Test Plan

None.
