### PR TITLE
Allow dirty files in `cargo-dist` for action pins

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -327,3 +327,6 @@ github-custom-job-permissions = { "build-docker" = { packages = "write", content
 install-updater = false
 # Path that installers should place binaries in
 install-path = ["$XDG_BIN_HOME/", "$XDG_DATA_HOME/../bin", "~/.local/bin"]
+# Temporarily allow changes to the `release` workflow, in which we pin actions
+# to a SHA instead of a tag (https://github.com/astral-sh/uv/issues/12253)
+allow-dirty = ["ci"]


### PR DESCRIPTION
## Summary

This is same as https://github.com/astral-sh/uv/pull/12252 and is to prepare for the upcoming Ruff release.

Upstream issue: https://github.com/axodotdev/cargo-dist/issues/1800
