### PR TITLE
Use the Depot Ubuntu runners instead of GitHub for release workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ on:
 jobs:
   # Run 'dist plan' (or host) to determine what tasks we need to do
   plan:
-    runs-on: "ubuntu-20.04"
+    runs-on: "depot-ubuntu-latest-4"
     outputs:
       val: ${{ steps.plan.outputs.manifest }}
       tag: ${{ (inputs.tag != 'dry-run' && inputs.tag) || '' }}
@@ -116,7 +116,7 @@ jobs:
       - plan
       - custom-build-binaries
       - custom-build-docker
-    runs-on: "ubuntu-20.04"
+    runs-on: "depot-ubuntu-latest-4"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
@@ -167,7 +167,7 @@ jobs:
     if: ${{ always() && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.custom-build-binaries.result == 'skipped' || needs.custom-build-binaries.result == 'success') && (needs.custom-build-docker.result == 'skipped' || needs.custom-build-docker.result == 'success') }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    runs-on: "ubuntu-20.04"
+    runs-on: "depot-ubuntu-latest-4"
     outputs:
       val: ${{ steps.host.outputs.manifest }}
     steps:
@@ -242,7 +242,7 @@ jobs:
     # still allowing individual publish jobs to skip themselves (for prereleases).
     # "host" however must run to completion, no skipping allowed!
     if: ${{ always() && needs.host.result == 'success' && (needs.custom-publish-pypi.result == 'skipped' || needs.custom-publish-pypi.result == 'success') && (needs.custom-publish-wasm.result == 'skipped' || needs.custom-publish-wasm.result == 'success') }}
-    runs-on: "ubuntu-20.04"
+    runs-on: "depot-ubuntu-latest-4"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -330,3 +330,6 @@ install-path = ["$XDG_BIN_HOME/", "$XDG_DATA_HOME/../bin", "~/.local/bin"]
 # Temporarily allow changes to the `release` workflow, in which we pin actions
 # to a SHA instead of a tag (https://github.com/astral-sh/uv/issues/12253)
 allow-dirty = ["ci"]
+
+[workspace.metadata.dist.github-custom-runners]
+global = "depot-ubuntu-latest-4"


### PR DESCRIPTION
## Summary

This is same as https://github.com/astral-sh/uv/pull/11948 and is to prep for the upcoming Ruff release.

## Test Plan

<!-- How was it tested? -->
