### PR TITLE
Separate `BitXorOr` into `BitXor` and `BitOr` precedence

### DIFF
--- a/crates/ruff_linter/src/rules/pylint/rules/unnecessary_dunder_call.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/unnecessary_dunder_call.rs
@@ -398,7 +398,7 @@ impl DunderReplacement {
             "__or__" => Some(Self::Operator(
                 "|",
                 "Use `|` operator",
-                OperatorPrecedence::BitXorOr,
+                OperatorPrecedence::BitOr,
             )),
             "__rshift__" => Some(Self::Operator(
                 ">>",
@@ -418,7 +418,7 @@ impl DunderReplacement {
             "__xor__" => Some(Self::Operator(
                 "^",
                 "Use `^` operator",
-                OperatorPrecedence::BitXorOr,
+                OperatorPrecedence::BitXor,
             )),
 
             "__radd__" => Some(Self::ROperator(
@@ -454,7 +454,7 @@ impl DunderReplacement {
             "__ror__" => Some(Self::ROperator(
                 "|",
                 "Use `|` operator",
-                OperatorPrecedence::BitXorOr,
+                OperatorPrecedence::BitOr,
             )),
             "__rrshift__" => Some(Self::ROperator(
                 ">>",
@@ -474,7 +474,7 @@ impl DunderReplacement {
             "__rxor__" => Some(Self::ROperator(
                 "^",
                 "Use `^` operator",
-                OperatorPrecedence::BitXorOr,
+                OperatorPrecedence::BitXor,
             )),
 
             "__aiter__" => Some(Self::Builtin("aiter", "Use `aiter()` builtin")),

--- a/crates/ruff_python_ast/src/operator_precedence.rs
+++ b/crates/ruff_python_ast/src/operator_precedence.rs
@@ -28,8 +28,10 @@ pub enum OperatorPrecedence {
     /// Precedence of comparisons (`<`, `<=`, `>`, `>=`, `!=`, `==`),
     /// memberships (`in`, `not in`) and identity tests (`is`, `is not`).
     ComparisonsMembershipIdentity,
-    /// Precedence of bitwise `|` and `^` operators.
-    BitXorOr,
+    /// Precedence of bitwise `|` operator.
+    BitOr,
+    /// Precedence of bitwise `^` operator.
+    BitXor,
     /// Precedence of bitwise `&` operator.
     BitAnd,
     /// Precedence of left and right shift expressions (`<<`, `>>`).
@@ -159,7 +161,8 @@ impl From<Operator> for OperatorPrecedence {
             Operator::LShift | Operator::RShift => Self::LeftRightShift,
             // Bitwise operations: &, ^, |
             Operator::BitAnd => Self::BitAnd,
-            Operator::BitXor | Operator::BitOr => Self::BitXorOr,
+            Operator::BitXor => Self::BitXor,
+            Operator::BitOr => Self::BitOr,
             // Exponentiation **
             Operator::Pow => Self::Exponent,
         }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

This change follows up on the bug-fix requested in #16747 -- `ruff_python_ast::OperatorPrecedence` had an enum variant, `BitXorOr`, which which gave the same precedence to the `|` and `^` operators. This goes against [Python's documentation for operator precedence](https://docs.python.org/3/reference/expressions.html#operator-precedence), so this PR changes the code so that it's correct.

This is part of the overall effort to unify redundant definitions of `OperatorPrecedence` throughout the codebase (#16071)

## Test Plan

<!-- How was it tested? -->

Because this is an internal change, I only ran existing tests to ensure nothing was broken.