### PR TITLE
[red-knot] Ban list literals in most contexts in type expressions

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/callable.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/callable.md
@@ -63,7 +63,7 @@ from typing import Callable
 
 # error: [invalid-type-form] "Special form `typing.Callable` expected exactly two arguments (parameter types and return type)"
 def _(c: Callable[[int, str]]):
-    reveal_type(c)  # revealed: (int, str, /) -> Unknown
+    reveal_type(c)  # revealed: (...) -> Unknown
 ```
 
 Or, an ellipsis:
@@ -71,6 +71,18 @@ Or, an ellipsis:
 ```py
 # error: [invalid-type-form] "Special form `typing.Callable` expected exactly two arguments (parameter types and return type)"
 def _(c: Callable[...]):
+    reveal_type(c)  # revealed: (...) -> Unknown
+```
+
+Or something else that's invalid in a type expression generally:
+
+```py
+# fmt: off
+
+def _(c: Callable[  # error: [invalid-type-form] "Special form `typing.Callable` expected exactly two arguments (parameter types and return type)"
+            {1, 2}  # error: [invalid-type-form] "The first argument to `Callable` must be either a list of types, ParamSpec, Concatenate, or `...`"
+        ]
+    ):
     reveal_type(c)  # revealed: (...) -> Unknown
 ```
 
@@ -84,6 +96,48 @@ from typing import Callable
 
 # error: [invalid-type-form] "Special form `typing.Callable` expected exactly two arguments (parameter types and return type)"
 def _(c: Callable[[int], str, str]):
+    reveal_type(c)  # revealed: (...) -> Unknown
+```
+
+### List as the second argument
+
+```py
+from typing import Callable
+
+# fmt: off
+
+def _(c: Callable[
+            int,  # error: [invalid-type-form] "The first argument to `Callable` must be either a list of types, ParamSpec, Concatenate, or `...`"
+            [str]  # error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
+        ]
+    ):
+    reveal_type(c)  # revealed: (...) -> Unknown
+```
+
+### List as both arguments
+
+```py
+from typing import Callable
+
+# error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
+def _(c: Callable[[int], [str]]):
+    reveal_type(c)  # revealed: (int, /) -> Unknown
+```
+
+### Three list arguments
+
+```py
+from typing import Callable
+
+# fmt: off
+
+
+def _(c: Callable[  # error: [invalid-type-form] "Special form `typing.Callable` expected exactly two arguments (parameter types and return type)"
+            [int],
+            [str],  # error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
+            [bytes]  # error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
+        ]
+    ):
     reveal_type(c)  # revealed: (...) -> Unknown
 ```
 

--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/invalid.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/invalid.md
@@ -96,6 +96,7 @@ def _(
     d: [k for k in [1, 2]],  # error: [invalid-type-form] "List comprehensions are not allowed in type expressions"
     e: {k for k in [1, 2]},  # error: [invalid-type-form] "Set comprehensions are not allowed in type expressions"
     f: (k for k in [1, 2]),  # error: [invalid-type-form] "Generator expressions are not allowed in type expressions"
+    g: [int, str],  # error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
 ):
     reveal_type(a)  # revealed: Unknown
     reveal_type(b)  # revealed: Unknown
@@ -103,4 +104,5 @@ def _(
     reveal_type(d)  # revealed: Unknown
     reveal_type(e)  # revealed: Unknown
     reveal_type(f)  # revealed: Unknown
+    reveal_type(g)  # revealed: Unknown
 ```


### PR DESCRIPTION
## Summary

This PR reworks `TypeInferenceBuilder::infer_type_expression()` so that we emit diagnostics when encountering a list literal in a type expression. The only place where a list literal is allowed in a type expression is if it appears as the first argument to `Callable[]`, and `Callable` is already heavily special-cased in our type-expression parsing.

In order to ensure that list literals are _always_ allowed as the _first_ argument to `Callabler` (but never allowed as the second, third, etc. argument), I had to do some refactoring of our type-expression parsing for `Callable` annotations.

## Test Plan

New mdtests added, and existing ones updated
