### PR TITLE
Allow discovery of venv in VIRTUAL_ENV env variable

### DIFF
--- a/crates/red_knot/src/args.rs
+++ b/crates/red_knot/src/args.rs
@@ -50,6 +50,8 @@ pub(crate) struct CheckCommand {
 
     /// Path to the Python installation from which Red Knot resolves type information and third-party dependencies.
     ///
+    /// If not specified, Red Knot will look at the `VIRTUAL_ENV` environment variable.
+    ///
     /// Red Knot will search in the path's `site-packages` directories for type information and
     /// third-party imports.
     ///

--- a/crates/red_knot_project/src/metadata/options.rs
+++ b/crates/red_knot_project/src/metadata/options.rs
@@ -108,6 +108,7 @@ impl Options {
                 .map(|python_path| {
                     PythonPath::SysPrefix(python_path.absolute(project_root, system))
                 })
+                .or(PythonPath::find_virtual_env())
                 .unwrap_or(PythonPath::KnownSitePackages(vec![])),
         }
     }

--- a/crates/red_knot_python_semantic/src/module_resolver/resolver.rs
+++ b/crates/red_knot_python_semantic/src/module_resolver/resolver.rs
@@ -223,7 +223,7 @@ impl SearchPaths {
         static_paths.push(stdlib_path);
 
         let site_packages_paths = match python_path {
-            PythonPath::SysPrefix(sys_prefix) => {
+            PythonPath::SysPrefix(sys_prefix) | PythonPath::ActiveEnvironment(sys_prefix) => {
                 // TODO: We may want to warn here if the venv's python version is older
                 //  than the one resolved in the program settings because it indicates
                 //  that the `target-version` is incorrectly configured or that the

--- a/crates/red_knot_python_semantic/src/program.rs
+++ b/crates/red_knot_python_semantic/src/program.rs
@@ -144,9 +144,23 @@ pub enum PythonPath {
     /// [`sys.prefix`]: https://docs.python.org/3/library/sys.html#sys.prefix
     SysPrefix(SystemPathBuf),
 
+    /// An environment was active e.g. via `VIRTUAL_ENV`
+    ActiveEnvironment(SystemPathBuf),
+
     /// Resolved site packages paths.
     ///
     /// This variant is mainly intended for testing where we want to skip resolving `site-packages`
     /// because it would unnecessarily complicate the test setup.
     KnownSitePackages(Vec<SystemPathBuf>),
+}
+
+impl PythonPath {
+    pub fn find_virtual_env() -> Option<Self> {
+        let virtual_env = std::env::var("VIRTUAL_ENV").ok();
+        if let Some(virtual_env) = virtual_env {
+            tracing::debug!("Found virtual environment at {:?}", virtual_env);
+            return Some(Self::ActiveEnvironment(SystemPathBuf::from(virtual_env)));
+        }
+        None
+    }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Fixes #16744 

Allows the cli to find a virtual environment from the VIRTUAL_ENV environment variable if no --python is set

## Test Plan

Unsure how to mock a venv to test that this works