### PR TITLE
[`flake8-executable`] Add pytest and uv run to help message for `shebang-missing-python` (`EXE003`)

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_executable/rules/shebang_missing_python.rs
+++ b/crates/ruff_linter/src/rules/flake8_executable/rules/shebang_missing_python.rs
@@ -36,7 +36,7 @@ pub(crate) struct ShebangMissingPython;
 impl Violation for ShebangMissingPython {
     #[derive_message_formats]
     fn message(&self) -> String {
-        "Shebang should contain `python`".to_string()
+        "Shebang should contain `python`, `pytest`, or `uv run`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_executable/snapshots/ruff_linter__rules__flake8_executable__tests__EXE003.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_executable/snapshots/ruff_linter__rules__flake8_executable__tests__EXE003.py.snap
@@ -1,11 +1,9 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_executable/mod.rs
 ---
-EXE003.py:1:1: EXE003 Shebang should contain `python`
+EXE003.py:1:1: EXE003 Shebang should contain `python`, `pytest`, or `uv run`
   |
 1 | #!/usr/bin/bash
   | ^^^^^^^^^^^^^^^ EXE003
 2 | print("hello world")
   |
-
-


### PR DESCRIPTION
Followup to #16849 per https://github.com/astral-sh/ruff/pull/16849#issuecomment-2737316564
