### PR TITLE
[red-knot] detect non-deferred self-references in annotations

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/deferred.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/deferred.md
@@ -45,3 +45,40 @@ class Foo: ...
 
 reveal_type(get_foo())  # revealed: Foo
 ```
+
+## Deferred self-reference annotations in a class definition
+
+```py
+from __future__ import annotations
+
+class Bar:
+    this: Bar
+
+    def f(self: "Bar"):
+        reveal_type(self)  # revealed: Bar
+
+    def g(self: Bar):
+        reveal_type(self)  # revealed: Bar
+
+    def h(self) -> Bar:
+        _: Bar = self
+        return self
+```
+
+## Non-deferred self-reference annotations in a class definition
+
+```py
+class Bar:
+    # error: [unresolved-reference]
+    this: Bar
+
+    def f(self: "Bar"):
+        reveal_type(self)  # revealed: Bar
+    # error: [unresolved-reference]
+    def g(self: Bar):
+        reveal_type(self)  # revealed: Bar
+    # error: [unresolved-reference]
+    def h(self) -> Bar:
+        _: Bar = self
+        return self
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/binary/instances.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/binary/instances.md
@@ -13,6 +13,8 @@ We support inference for all Python's binary operators: `+`, `-`, `*`, `@`, `/`,
 `<<`, `>>`, `&`, `^`, and `|`.
 
 ```py
+from __future__ import annotations
+
 class A:
     def __add__(self, other) -> A:
         return self
@@ -75,6 +77,8 @@ reveal_type(A() | B())  # revealed: A
 We also support inference for reflected operations:
 
 ```py
+from __future__ import annotations
+
 class A:
     def __radd__(self, other) -> A:
         return self
@@ -156,6 +160,8 @@ In general, if the left-hand side defines `__add__` and the right-hand side defi
 the right-hand side is not a subtype of the left-hand side, `lhs.__add__` will take precedence:
 
 ```py
+from __future__ import annotations
+
 class A:
     def __add__(self, other: B) -> int:
         return 42
@@ -236,6 +242,8 @@ strictly-speaking "accepts" any other object without raising an exception -- it 
 well.
 
 ```py
+from __future__ import annotations
+
 class A:
     def __sub__(self, other: A) -> A:
         return A()
@@ -299,6 +307,8 @@ When we have a literal type for one operand, we're able to fall back to the inst
 its instance super-type.
 
 ```py
+from __future__ import annotations
+
 class A:
     def __add__(self, other) -> A:
         return self
@@ -432,6 +442,8 @@ the unreflected dunder of the left-hand operand. For context, see
 [this mailing list discussion](https://mail.python.org/archives/list/python-dev@python.org/thread/7NZUCODEAPQFMRFXYRMGJXDSIS3WJYIV/).
 
 ```py
+from __future__ import annotations
+
 class Foo:
     def __radd__(self, other: Foo) -> Foo:
         return self

--- a/crates/red_knot_python_semantic/src/semantic_index/symbol.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/symbol.rs
@@ -532,6 +532,13 @@ impl NodeWithScopeKind {
             _ => None,
         }
     }
+
+    pub const fn as_class(&self) -> Option<&ast::StmtClassDef> {
+        match self {
+            Self::Class(class) => Some(class.node()),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]

--- a/crates/red_knot_python_semantic/src/types/diagnostic.rs
+++ b/crates/red_knot_python_semantic/src/types/diagnostic.rs
@@ -1195,6 +1195,26 @@ pub(super) fn report_unresolved_reference(context: &InferContext, expr_name_node
     );
 }
 
+pub(super) fn report_non_deferred_self_reference(
+    context: &InferContext,
+    expr_name_node: &ast::ExprName,
+) {
+    let ast::ExprName { id, .. } = expr_name_node;
+
+    let name_span = Span::from(context.file()).with_range(expr_name_node.range());
+
+    context.report_lint_with_secondary_messages(
+        &UNRESOLVED_REFERENCE,
+        expr_name_node,
+        format_args!("Name `{id}` used when not defined"),
+        vec![OldSecondaryDiagnosticMessage::new(
+            name_span,
+            "In order to use a type annotation of the class itself in the scope of the class definition, \
+            escape it with a string or use `from __future__ import annotations`",
+        )],
+    );
+}
+
 pub(super) fn report_invalid_exception_caught(context: &InferContext, node: &ast::Expr, ty: Type) {
     context.report_lint(
         &INVALID_EXCEPTION_CAUGHT,


### PR DESCRIPTION
## Summary

This PR closes #16341.

## Test Plan

New test cases are added in `annotations/deferred.md`.
