### PR TITLE
Update replacement paths for AIR302

### DIFF
--- a/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
@@ -613,25 +613,18 @@ fn check_name(checker: &Checker, expr: &Expr, range: TextRange) {
         }
 
         // airflow.datasets
-        ["airflow", "Dataset"] => Replacement::Name("airflow.sdk.definitions.asset.Asset"),
+        ["airflow", "Dataset"] | ["airflow", "datasets", "Dataset"] => {
+            Replacement::Name("airflow.sdk.Asset")
+        }
         ["airflow", "datasets", "DatasetAliasEvent"] => Replacement::None,
-        ["airflow", "datasets", "Dataset"] => {
-            Replacement::Name("airflow.sdk.definitions.asset.Asset")
-        }
-        ["airflow", "datasets", "DatasetAlias"] => {
-            Replacement::Name("airflow.sdk.definitions.asset.AssetAlias")
-        }
-        ["airflow", "datasets", "DatasetAll"] => {
-            Replacement::Name("airflow.sdk.definitions.asset.AssetAll")
-        }
-        ["airflow", "datasets", "DatasetAny"] => {
-            Replacement::Name("airflow.sdk.definitions.asset.AssetAny")
-        }
+        ["airflow", "datasets", "DatasetAlias"] => Replacement::Name("airflow.sdk.AssetAlias"),
+        ["airflow", "datasets", "DatasetAll"] => Replacement::Name("airflow.sdk.AssetAll"),
+        ["airflow", "datasets", "DatasetAny"] => Replacement::Name("airflow.sdk.AssetAny"),
         ["airflow", "datasets", "expand_alias_to_datasets"] => {
-            Replacement::Name("airflow.sdk.definitions.asset.expand_alias_to_assets")
+            Replacement::Name("airflow.sdk.expand_alias_to_assets")
         }
         ["airflow", "datasets", "metadata", "Metadata"] => {
-            Replacement::Name("airflow.sdk.definitions.asset.metadata.Metadata")
+            Replacement::Name("airflow.sdk.Metadata")
         }
 
         // airflow.datasets.manager

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_class_attribute.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_class_attribute.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_linter/src/rules/airflow/mod.rs
-snapshot_kind: text
 ---
 AIR302_class_attribute.py:24:21: AIR302 `airflow.Dataset` is removed in Airflow 3.0
    |
@@ -10,7 +9,7 @@ AIR302_class_attribute.py:24:21: AIR302 `airflow.Dataset` is removed in Airflow 
 25 | dataset_from_root.iter_datasets()
 26 | dataset_from_root.iter_dataset_aliases()
    |
-   = help: Use `airflow.sdk.definitions.asset.Asset` instead
+   = help: Use `airflow.sdk.Asset` instead
 
 AIR302_class_attribute.py:25:19: AIR302 `iter_datasets` is removed in Airflow 3.0
    |
@@ -41,7 +40,7 @@ AIR302_class_attribute.py:29:31: AIR302 `airflow.datasets.Dataset` is removed in
 30 | dataset_to_test_method_call.iter_datasets()
 31 | dataset_to_test_method_call.iter_dataset_aliases()
    |
-   = help: Use `airflow.sdk.definitions.asset.Asset` instead
+   = help: Use `airflow.sdk.Asset` instead
 
 AIR302_class_attribute.py:30:29: AIR302 `iter_datasets` is removed in Airflow 3.0
    |
@@ -73,7 +72,7 @@ AIR302_class_attribute.py:33:29: AIR302 `airflow.datasets.DatasetAlias` is remov
 34 | alias_to_test_method_call.iter_datasets()
 35 | alias_to_test_method_call.iter_dataset_aliases()
    |
-   = help: Use `airflow.sdk.definitions.asset.AssetAlias` instead
+   = help: Use `airflow.sdk.AssetAlias` instead
 
 AIR302_class_attribute.py:34:27: AIR302 `iter_datasets` is removed in Airflow 3.0
    |
@@ -104,7 +103,7 @@ AIR302_class_attribute.py:37:27: AIR302 `airflow.datasets.DatasetAny` is removed
 38 | any_to_test_method_call.iter_datasets()
 39 | any_to_test_method_call.iter_dataset_aliases()
    |
-   = help: Use `airflow.sdk.definitions.asset.AssetAny` instead
+   = help: Use `airflow.sdk.AssetAny` instead
 
 AIR302_class_attribute.py:38:25: AIR302 `iter_datasets` is removed in Airflow 3.0
    |

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_linter/src/rules/airflow/mod.rs
-assertion_line: 29
 ---
 AIR302_names.py:107:1: AIR302 `airflow.PY36` is removed in Airflow 3.0
     |
@@ -74,7 +73,7 @@ AIR302_names.py:108:1: AIR302 `airflow.Dataset` is removed in Airflow 3.0
 109 |
 110 | # airflow.api_connexion.security
     |
-    = help: Use `airflow.sdk.definitions.asset.Asset` instead
+    = help: Use `airflow.sdk.Asset` instead
 
 AIR302_names.py:111:1: AIR302 `airflow.api_connexion.security.requires_access` is removed in Airflow 3.0
     |
@@ -197,7 +196,7 @@ AIR302_names.py:125:1: AIR302 `airflow.datasets.Dataset` is removed in Airflow 3
 126 | DatasetAlias()
 127 | DatasetAliasEvent()
     |
-    = help: Use `airflow.sdk.definitions.asset.Asset` instead
+    = help: Use `airflow.sdk.Asset` instead
 
 AIR302_names.py:126:1: AIR302 `airflow.datasets.DatasetAlias` is removed in Airflow 3.0
     |
@@ -208,7 +207,7 @@ AIR302_names.py:126:1: AIR302 `airflow.datasets.DatasetAlias` is removed in Airf
 127 | DatasetAliasEvent()
 128 | DatasetAll()
     |
-    = help: Use `airflow.sdk.definitions.asset.AssetAlias` instead
+    = help: Use `airflow.sdk.AssetAlias` instead
 
 AIR302_names.py:127:1: AIR302 `airflow.datasets.DatasetAliasEvent` is removed in Airflow 3.0
     |
@@ -229,7 +228,7 @@ AIR302_names.py:128:1: AIR302 `airflow.datasets.DatasetAll` is removed in Airflo
 129 | DatasetAny()
 130 | Metadata()
     |
-    = help: Use `airflow.sdk.definitions.asset.AssetAll` instead
+    = help: Use `airflow.sdk.AssetAll` instead
 
 AIR302_names.py:129:1: AIR302 `airflow.datasets.DatasetAny` is removed in Airflow 3.0
     |
@@ -240,7 +239,7 @@ AIR302_names.py:129:1: AIR302 `airflow.datasets.DatasetAny` is removed in Airflo
 130 | Metadata()
 131 | expand_alias_to_datasets
     |
-    = help: Use `airflow.sdk.definitions.asset.AssetAny` instead
+    = help: Use `airflow.sdk.AssetAny` instead
 
 AIR302_names.py:130:1: AIR302 `airflow.datasets.metadata.Metadata` is removed in Airflow 3.0
     |
@@ -250,7 +249,7 @@ AIR302_names.py:130:1: AIR302 `airflow.datasets.metadata.Metadata` is removed in
     | ^^^^^^^^ AIR302
 131 | expand_alias_to_datasets
     |
-    = help: Use `airflow.sdk.definitions.asset.metadata.Metadata` instead
+    = help: Use `airflow.sdk.Metadata` instead
 
 AIR302_names.py:131:1: AIR302 `airflow.datasets.expand_alias_to_datasets` is removed in Airflow 3.0
     |
@@ -261,7 +260,7 @@ AIR302_names.py:131:1: AIR302 `airflow.datasets.expand_alias_to_datasets` is rem
 132 |
 133 | # airflow.datasets.manager
     |
-    = help: Use `airflow.sdk.definitions.asset.expand_alias_to_assets` instead
+    = help: Use `airflow.sdk.expand_alias_to_assets` instead
 
 AIR302_names.py:135:1: AIR302 `airflow.datasets.manager.dataset_manager` is removed in Airflow 3.0
     |


### PR DESCRIPTION
I am one of the core developers of Airflow and working on the "airflow.sdk"
package, and this updates the recommended replacments to the correct
user-facing imports.[^1]

cc @Lee-W @uranusjr 

[^1]: https://github.com/apache/airflow/blob/33f0f1d639b53d4221757c8493b819684bd26d21/task-sdk/src/airflow/sdk/__init__.py#L68-L93

<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

Hope and pray? 😉 

I'm sure there are some snapshot files I'm supposed to fix first.


<!-- How was it tested? -->
