### PR TITLE
Recognize `SyntaxError:` as an error code for ecosystem checks

### DIFF
--- a/python/ruff-ecosystem/ruff_ecosystem/check.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/check.py
@@ -45,7 +45,7 @@ CHECK_DIFF_LINE_RE = re.compile(
 )
 
 CHECK_DIAGNOSTIC_LINE_RE = re.compile(
-    r"^(?P<diff>[+-])? ?(?P<location>.*): (?P<code>[A-Z]{1,4}[0-9]{3,4})(?P<fixable> \[\*\])? (?P<message>.*)"
+    r"^(?P<diff>[+-])? ?(?P<location>.*): (?P<code>[A-Z]{1,4}[0-9]{3,4}|SyntaxError:)(?P<fixable> \[\*\])? (?P<message>.*)"
 )
 
 CHECK_VIOLATION_FIX_INDICATOR = " [*]"


### PR DESCRIPTION
Summary
--

This updates the regex in `ruff-ecosystem` to catch syntax errors in an effort to prevent bugs like #16874. This should catch `ParseError`s, `UnsupportedSyntaxError`s, and the upcoming `SemanticSyntaxError`s.

Test Plan
--

I ran the ecosystem check locally comparing v0.11.0 and v0.11.1 and saw a large number (2757!) of new syntax errors. I also manually tested the regex on a few lines before that.

If we merge this before #16878, I'd expect to see that number decrease substantially in that PR too, as another test.