### PR TITLE
docs: Correct collections-named-tuple example to use PascalCase assignment

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/collections_named_tuple.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/collections_named_tuple.rs
@@ -24,7 +24,7 @@ use crate::checkers::ast::Checker;
 /// ```pyi
 /// from collections import namedtuple
 ///
-/// person = namedtuple("Person", ["name", "age"])
+/// Person = namedtuple("Person", ["name", "age"])
 /// ```
 ///
 /// Use instead:


### PR DESCRIPTION
## Summary

The documentation for `collections-named-tuple` (`PYI024`) was using a lowercase variable in its example:

```py
from collections import namedtuple

person = namedtuple("Person", ["name", "age"])
```

while the recommended replacement used `class Person` – implying a name change that's not equivalent. This patch updates the docstring to use a more canonical example:

```py
from collections import namedtuple

Person = namedtuple("Person", ["name", "age"])
```

so that the “Use instead:” block aligns with the original name and doesn't suggest a breaking rename. No functional code changes were required.

## Test Plan

Only documentation comments were updated; the existing `flake8_pyi` tests still pass (`cargo test -p ruff_linter`). Running the full workspace tests yields a failure in an unrelated snapshot when run as root, but in a typical developer environment the existing tests and snapshots remain unaffected. All style and lint checks pass (`cargo clippy`, `cargo fmt`, etc.).

---

This PR was generated by an AI system in collaboration with maintainers: @carljm, @ntBre 