### PR TITLE
[`pylint`] Avoid flattening nested `min`/`max` when outer call has single argument (`PLW3301`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/nested_min_max.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/nested_min_max.py
@@ -37,10 +37,6 @@ tuples_list = [
 min(min(tuples_list))
 max(max(tuples_list))
 
-# Outer call has a single argument, inner call has multiple arguments; should not trigger.
-min(min([2, 3], [4, 1]))
-max(max([2, 4], [3, 1]))
-
 # Starred argument should be copied as it is.
 max(1, max(*a))
 
@@ -59,3 +55,8 @@ max_word_len = max(
     *(len(word) for word in "blah blah blah".split(" ")),
     len("Done!"),
 )
+
+
+# Outer call has a single argument, inner call has multiple arguments; should not trigger.
+min(min([2, 3], [4, 1]))
+max(max([2, 4], [3, 1]))

--- a/crates/ruff_linter/resources/test/fixtures/pylint/nested_min_max.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/nested_min_max.py
@@ -37,6 +37,10 @@ tuples_list = [
 min(min(tuples_list))
 max(max(tuples_list))
 
+# Outer call has a single argument, inner call has multiple arguments; should not trigger.
+min(min([2, 3], [4, 1]))
+max(max([2, 4], [3, 1]))
+
 # Starred argument should be copied as it is.
 max(1, max(*a))
 

--- a/crates/ruff_linter/src/rules/pylint/rules/nested_min_max.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/nested_min_max.rs
@@ -155,9 +155,11 @@ pub(crate) fn nested_min_max(
     let Some(min_max) = MinMax::try_from_call(func, keywords, checker.semantic()) else {
         return;
     };
-
-    if matches!(&args, [Expr::Call(ast::ExprCall { arguments: Arguments {args, .. }, .. })] if args.len() == 1)
-    {
+    // It's only safe to flatten nested calls if the outer call has more than one argument.
+    // When the outer call has a single argument, flattening would change the semantics by
+    // changing the shape of the call from treating the inner result as an iterable (or a scalar)
+    // to passing multiple arguments directly, which can lead to behavioral changes.
+    if args.len() < 2 {
         return;
     }
 

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW3301_nested_min_max.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW3301_nested_min_max.py.snap
@@ -278,67 +278,67 @@ nested_min_max.py:27:1: PLW3301 [*] Nested `max` calls can be flattened
 29 29 | tuples_list = [
 30 30 |     (1, 2),
 
-nested_min_max.py:45:1: PLW3301 [*] Nested `max` calls can be flattened
+nested_min_max.py:41:1: PLW3301 [*] Nested `max` calls can be flattened
    |
-44 | # Starred argument should be copied as it is.
-45 | max(1, max(*a))
+40 | # Starred argument should be copied as it is.
+41 | max(1, max(*a))
    | ^^^^^^^^^^^^^^^ PLW3301
-46 |
-47 | import builtins
+42 |
+43 | import builtins
    |
    = help: Flatten nested `max` calls
 
 ℹ Unsafe fix
-42 42 | max(max([2, 4], [3, 1]))
-43 43 | 
-44 44 | # Starred argument should be copied as it is.
-45    |-max(1, max(*a))
-   45 |+max(1, *a)
-46 46 | 
-47 47 | import builtins
-48 48 | builtins.min(1, min(2, 3))
+38 38 | max(max(tuples_list))
+39 39 | 
+40 40 | # Starred argument should be copied as it is.
+41    |-max(1, max(*a))
+   41 |+max(1, *a)
+42 42 | 
+43 43 | import builtins
+44 44 | builtins.min(1, min(2, 3))
 
-nested_min_max.py:48:1: PLW3301 [*] Nested `min` calls can be flattened
+nested_min_max.py:44:1: PLW3301 [*] Nested `min` calls can be flattened
    |
-47 | import builtins
-48 | builtins.min(1, min(2, 3))
+43 | import builtins
+44 | builtins.min(1, min(2, 3))
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ PLW3301
    |
    = help: Flatten nested `min` calls
 
 ℹ Unsafe fix
-45 45 | max(1, max(*a))
+41 41 | max(1, max(*a))
+42 42 | 
+43 43 | import builtins
+44    |-builtins.min(1, min(2, 3))
+   44 |+builtins.min(1, 2, 3)
+45 45 | 
 46 46 | 
-47 47 | import builtins
-48    |-builtins.min(1, min(2, 3))
-   48 |+builtins.min(1, 2, 3)
-49 49 | 
-50 50 | 
-51 51 | # PLW3301
+47 47 | # PLW3301
 
-nested_min_max.py:52:16: PLW3301 [*] Nested `max` calls can be flattened
+nested_min_max.py:48:16: PLW3301 [*] Nested `max` calls can be flattened
    |
-51 |   # PLW3301
-52 |   max_word_len = max(
+47 |   # PLW3301
+48 |   max_word_len = max(
    |  ________________^
-53 | |     max(len(word) for word in "blah blah blah".split(" ")),
-54 | |     len("Done!"),
-55 | | )
+49 | |     max(len(word) for word in "blah blah blah".split(" ")),
+50 | |     len("Done!"),
+51 | | )
    | |_^ PLW3301
-56 |
-57 |   # OK
+52 |
+53 |   # OK
    |
    = help: Flatten nested `max` calls
 
 ℹ Unsafe fix
-49 49 | 
-50 50 | 
-51 51 | # PLW3301
-52    |-max_word_len = max(
-53    |-    max(len(word) for word in "blah blah blah".split(" ")),
-54    |-    len("Done!"),
-55    |-)
-   52 |+max_word_len = max(*(len(word) for word in "blah blah blah".split(" ")), len("Done!"))
-56 53 | 
-57 54 | # OK
-58 55 | max_word_len = max(
+45 45 | 
+46 46 | 
+47 47 | # PLW3301
+48    |-max_word_len = max(
+49    |-    max(len(word) for word in "blah blah blah".split(" ")),
+50    |-    len("Done!"),
+51    |-)
+   48 |+max_word_len = max(*(len(word) for word in "blah blah blah".split(" ")), len("Done!"))
+52 49 | 
+53 50 | # OK
+54 51 | max_word_len = max(

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW3301_nested_min_max.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW3301_nested_min_max.py.snap
@@ -283,16 +283,12 @@ nested_min_max.py:45:1: PLW3301 [*] Nested `max` calls can be flattened
 44 | # Starred argument should be copied as it is.
 45 | max(1, max(*a))
    | ^^^^^^^^^^^^^^^ PLW3301
-42 |
-43 | import builtins
+46 |
+47 | import builtins
    |
    = help: Flatten nested `max` calls
 
 ℹ Unsafe fix
-38 38 | max(max(tuples_list))
-39 39 | 
-40 40 | # Outer call has a single argument, inner call has multiple arguments; should not trigger.
-41 41 | min(min([2, 3], [4, 1]))
 42 42 | max(max([2, 4], [3, 1]))
 43 43 | 
 44 44 | # Starred argument should be copied as it is.
@@ -325,12 +321,12 @@ nested_min_max.py:52:16: PLW3301 [*] Nested `max` calls can be flattened
 51 |   # PLW3301
 52 |   max_word_len = max(
    |  ________________^
-49 | |     max(len(word) for word in "blah blah blah".split(" ")),
-50 | |     len("Done!"),
-51 | | )
+53 | |     max(len(word) for word in "blah blah blah".split(" ")),
+54 | |     len("Done!"),
+55 | | )
    | |_^ PLW3301
-52 |
-53 |   # OK
+56 |
+57 |   # OK
    |
    = help: Flatten nested `max` calls
 

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW3301_nested_min_max.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW3301_nested_min_max.py.snap
@@ -278,10 +278,10 @@ nested_min_max.py:27:1: PLW3301 [*] Nested `max` calls can be flattened
 29 29 | tuples_list = [
 30 30 |     (1, 2),
 
-nested_min_max.py:41:1: PLW3301 [*] Nested `max` calls can be flattened
+nested_min_max.py:45:1: PLW3301 [*] Nested `max` calls can be flattened
    |
-40 | # Starred argument should be copied as it is.
-41 | max(1, max(*a))
+44 | # Starred argument should be copied as it is.
+45 | max(1, max(*a))
    | ^^^^^^^^^^^^^^^ PLW3301
 42 |
 43 | import builtins
@@ -291,35 +291,39 @@ nested_min_max.py:41:1: PLW3301 [*] Nested `max` calls can be flattened
 ℹ Unsafe fix
 38 38 | max(max(tuples_list))
 39 39 | 
-40 40 | # Starred argument should be copied as it is.
-41    |-max(1, max(*a))
-   41 |+max(1, *a)
-42 42 | 
-43 43 | import builtins
-44 44 | builtins.min(1, min(2, 3))
+40 40 | # Outer call has a single argument, inner call has multiple arguments; should not trigger.
+41 41 | min(min([2, 3], [4, 1]))
+42 42 | max(max([2, 4], [3, 1]))
+43 43 | 
+44 44 | # Starred argument should be copied as it is.
+45    |-max(1, max(*a))
+   45 |+max(1, *a)
+46 46 | 
+47 47 | import builtins
+48 48 | builtins.min(1, min(2, 3))
 
-nested_min_max.py:44:1: PLW3301 [*] Nested `min` calls can be flattened
+nested_min_max.py:48:1: PLW3301 [*] Nested `min` calls can be flattened
    |
-43 | import builtins
-44 | builtins.min(1, min(2, 3))
+47 | import builtins
+48 | builtins.min(1, min(2, 3))
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ PLW3301
    |
    = help: Flatten nested `min` calls
 
 ℹ Unsafe fix
-41 41 | max(1, max(*a))
-42 42 | 
-43 43 | import builtins
-44    |-builtins.min(1, min(2, 3))
-   44 |+builtins.min(1, 2, 3)
-45 45 | 
+45 45 | max(1, max(*a))
 46 46 | 
-47 47 | # PLW3301
+47 47 | import builtins
+48    |-builtins.min(1, min(2, 3))
+   48 |+builtins.min(1, 2, 3)
+49 49 | 
+50 50 | 
+51 51 | # PLW3301
 
-nested_min_max.py:48:16: PLW3301 [*] Nested `max` calls can be flattened
+nested_min_max.py:52:16: PLW3301 [*] Nested `max` calls can be flattened
    |
-47 |   # PLW3301
-48 |   max_word_len = max(
+51 |   # PLW3301
+52 |   max_word_len = max(
    |  ________________^
 49 | |     max(len(word) for word in "blah blah blah".split(" ")),
 50 | |     len("Done!"),
@@ -331,14 +335,14 @@ nested_min_max.py:48:16: PLW3301 [*] Nested `max` calls can be flattened
    = help: Flatten nested `max` calls
 
 ℹ Unsafe fix
-45 45 | 
-46 46 | 
-47 47 | # PLW3301
-48    |-max_word_len = max(
-49    |-    max(len(word) for word in "blah blah blah".split(" ")),
-50    |-    len("Done!"),
-51    |-)
-   48 |+max_word_len = max(*(len(word) for word in "blah blah blah".split(" ")), len("Done!"))
-52 49 | 
-53 50 | # OK
-54 51 | max_word_len = max(
+49 49 | 
+50 50 | 
+51 51 | # PLW3301
+52    |-max_word_len = max(
+53    |-    max(len(word) for word in "blah blah blah".split(" ")),
+54    |-    len("Done!"),
+55    |-)
+   52 |+max_word_len = max(*(len(word) for word in "blah blah blah".split(" ")), len("Done!"))
+56 53 | 
+57 54 | # OK
+58 55 | max_word_len = max(


### PR DESCRIPTION
## Summary

Fixes false positives (and incorrect autofixes) in `nested-min-max` (`PLW3301`) when the outer `min`/`max` call only has a single argument. Previously the rule would flatten:

```python
min(min([2, 3], [4, 1]))
```

into `min([2, 3], [4, 1])`, changing the semantics. The rule now skips any nested call when the outer call has only one positional argument. The pylint fixture and snapshot were updated accordingly.

## Test Plan

Ran Ruff against the updated `nested_min_max.py` fixture:

```shell
cargo run -p ruff -- check crates/ruff_linter/resources/test/fixtures/pylint/nested_min_max.py --no-cache --select=PLW3301 --preview
```

to verify that `min(min([2, 3], [4, 1]))` and `max(max([2, 4], [3, 1]))` are no longer flagged. Updated the fixture and snapshot; all other existing warnings remain unchanged. The code compiles and the unit tests pass.

---

This PR was generated by an AI system in collaboration with maintainers: @carljm, @ntBre 

Fixes #16163