### PR TITLE
[red-knot] Fix disambiguate display for union types

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/callable.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/callable.md
@@ -152,6 +152,21 @@ def _(c: Callable[[int, str], int]):
     reveal_type(c)  # revealed: (int, str, /) -> int
 ```
 
+## Union
+
+```py
+from typing import Callable, Union
+
+def _(
+    c: Callable[[Union[int, str]], int] | None,
+    d: None | Callable[[Union[int, str]], int],
+    e: None | Callable[[Union[int, str]], int] | int,
+):
+    reveal_type(c)  # revealed: ((int | str, /) -> int) | None
+    reveal_type(d)  # revealed: None | ((int | str, /) -> int)
+    reveal_type(e)  # revealed: None | ((int | str, /) -> int) | int
+```
+
 ## Nested
 
 A nested `Callable` as one of the parameter types:

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -412,10 +412,6 @@ impl<'db> Type<'db> {
         matches!(self, Type::FunctionLiteral(..))
     }
 
-    pub const fn is_callable(&self) -> bool {
-        matches!(self, Type::Callable(..))
-    }
-
     pub const fn into_int_literal(self) -> Option<i64> {
         match self {
             Type::IntLiteral(value) => Some(value),

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -412,6 +412,10 @@ impl<'db> Type<'db> {
         matches!(self, Type::FunctionLiteral(..))
     }
 
+    pub const fn is_callable(&self) -> bool {
+        matches!(self, Type::Callable(..))
+    }
+
     pub const fn into_int_literal(self) -> Option<i64> {
         match self {
             Type::IntLiteral(value) => Some(value),

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -292,7 +292,10 @@ impl Display for DisplayUnionType<'_> {
                     db: self.db,
                 });
             } else {
-                if element.is_callable() {
+                if let Type::Callable(
+                    CallableType::General(_) | CallableType::MethodWrapperDunderGet(_),
+                ) = element
+                {
                     join.entry(&format!("({})", element.display(self.db)));
                 } else {
                     join.entry(&element.display(self.db));

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -292,7 +292,11 @@ impl Display for DisplayUnionType<'_> {
                     db: self.db,
                 });
             } else {
-                join.entry(&element.display(self.db));
+                if element.is_callable() {
+                    join.entry(&format!("({})", element.display(self.db)));
+                } else {
+                    join.entry(&element.display(self.db));
+                }
             }
         }
 

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -296,7 +296,7 @@ impl Display for DisplayUnionType<'_> {
                     CallableType::General(_) | CallableType::MethodWrapperDunderGet(_),
                 ) = element
                 {
-                    join.entry(&format!("({})", element.display(self.db)));
+                    join.entry(&format_args!("({})", element.display(self.db)));
                 } else {
                     join.entry(&element.display(self.db));
                 }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

When callables are displayed in unions, like:
```py
from typing import Callable


def foo(x: Callable[[], int] | None):
    # red-knot: Revealed type is `() -> int | None` [revealed-type]
    reveal_type(x)
```

This leaves the type rather ambiguous, to fix this we can add parenthesis to callable type in union

Fixes #16893

## Test Plan

Update callable annotations tests
