### PR TITLE
Fix typos

### DIFF
--- a/crates/red_knot_python_semantic/src/semantic_index.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index.rs
@@ -235,8 +235,8 @@ impl<'db> SemanticIndex<'db> {
 
     /// Returns an iterator over the descendent scopes of `scope`.
     #[allow(unused)]
-    pub(crate) fn descendent_scopes(&self, scope: FileScopeId) -> DescendentsIter {
-        DescendentsIter::new(self, scope)
+    pub(crate) fn descendent_scopes(&self, scope: FileScopeId) -> DescendantsIter {
+        DescendantsIter::new(self, scope)
     }
 
     /// Returns an iterator over the direct child scopes of `scope`.
@@ -339,12 +339,12 @@ impl<'a> Iterator for AncestorsIter<'a> {
 
 impl FusedIterator for AncestorsIter<'_> {}
 
-pub struct DescendentsIter<'a> {
+pub struct DescendantsIter<'a> {
     next_id: FileScopeId,
     descendants: std::slice::Iter<'a, Scope>,
 }
 
-impl<'a> DescendentsIter<'a> {
+impl<'a> DescendantsIter<'a> {
     fn new(symbol_table: &'a SemanticIndex, scope_id: FileScopeId) -> Self {
         let scope = &symbol_table.scopes[scope_id];
         let scopes = &symbol_table.scopes[scope.descendants()];
@@ -356,15 +356,15 @@ impl<'a> DescendentsIter<'a> {
     }
 }
 
-impl<'a> Iterator for DescendentsIter<'a> {
+impl<'a> Iterator for DescendantsIter<'a> {
     type Item = (FileScopeId, &'a Scope);
 
     fn next(&mut self) -> Option<Self::Item> {
-        let descendent = self.descendants.next()?;
+        let descendant = self.descendants.next()?;
         let id = self.next_id;
         self.next_id = self.next_id + 1;
 
-        Some((id, descendent))
+        Some((id, descendant))
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -372,18 +372,18 @@ impl<'a> Iterator for DescendentsIter<'a> {
     }
 }
 
-impl FusedIterator for DescendentsIter<'_> {}
+impl FusedIterator for DescendantsIter<'_> {}
 
-impl ExactSizeIterator for DescendentsIter<'_> {}
+impl ExactSizeIterator for DescendantsIter<'_> {}
 
 pub struct ChildrenIter<'a> {
     parent: FileScopeId,
-    descendants: DescendentsIter<'a>,
+    descendants: DescendantsIter<'a>,
 }
 
 impl<'a> ChildrenIter<'a> {
     fn new(module_symbol_table: &'a SemanticIndex, parent: FileScopeId) -> Self {
-        let descendants = DescendentsIter::new(module_symbol_table, parent);
+        let descendants = DescendantsIter::new(module_symbol_table, parent);
 
         Self {
             parent,

--- a/crates/red_knot_python_semantic/src/semantic_index.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index.rs
@@ -341,17 +341,17 @@ impl FusedIterator for AncestorsIter<'_> {}
 
 pub struct DescendentsIter<'a> {
     next_id: FileScopeId,
-    descendents: std::slice::Iter<'a, Scope>,
+    descendants: std::slice::Iter<'a, Scope>,
 }
 
 impl<'a> DescendentsIter<'a> {
     fn new(symbol_table: &'a SemanticIndex, scope_id: FileScopeId) -> Self {
         let scope = &symbol_table.scopes[scope_id];
-        let scopes = &symbol_table.scopes[scope.descendents()];
+        let scopes = &symbol_table.scopes[scope.descendants()];
 
         Self {
             next_id: scope_id + 1,
-            descendents: scopes.iter(),
+            descendants: scopes.iter(),
         }
     }
 }
@@ -360,7 +360,7 @@ impl<'a> Iterator for DescendentsIter<'a> {
     type Item = (FileScopeId, &'a Scope);
 
     fn next(&mut self) -> Option<Self::Item> {
-        let descendent = self.descendents.next()?;
+        let descendent = self.descendants.next()?;
         let id = self.next_id;
         self.next_id = self.next_id + 1;
 
@@ -368,7 +368,7 @@ impl<'a> Iterator for DescendentsIter<'a> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        self.descendents.size_hint()
+        self.descendants.size_hint()
     }
 }
 
@@ -378,16 +378,16 @@ impl ExactSizeIterator for DescendentsIter<'_> {}
 
 pub struct ChildrenIter<'a> {
     parent: FileScopeId,
-    descendents: DescendentsIter<'a>,
+    descendants: DescendentsIter<'a>,
 }
 
 impl<'a> ChildrenIter<'a> {
     fn new(module_symbol_table: &'a SemanticIndex, parent: FileScopeId) -> Self {
-        let descendents = DescendentsIter::new(module_symbol_table, parent);
+        let descendants = DescendentsIter::new(module_symbol_table, parent);
 
         Self {
             parent,
-            descendents,
+            descendants,
         }
     }
 }
@@ -396,7 +396,7 @@ impl<'a> Iterator for ChildrenIter<'a> {
     type Item = (FileScopeId, &'a Scope);
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.descendents
+        self.descendants
             .find(|(_, scope)| scope.parent() == Some(self.parent))
     }
 }
@@ -1155,9 +1155,9 @@ def x():
 
         let index = semantic_index(&db, file);
 
-        let descendents = index.descendent_scopes(FileScopeId::global());
+        let descendants = index.descendent_scopes(FileScopeId::global());
         assert_eq!(
-            scope_names(descendents, &db, file),
+            scope_names(descendants, &db, file),
             vec!["Test", "foo", "bar", "baz", "x"]
         );
 

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -229,7 +229,7 @@ impl<'db> SemanticIndexBuilder<'db> {
 
         let children_end = self.scopes.next_index();
         let popped_scope = &mut self.scopes[popped_scope_id];
-        popped_scope.extend_descendents(children_end);
+        popped_scope.extend_descendants(children_end);
 
         if !popped_scope.is_eager() {
             return popped_scope_id;

--- a/crates/red_knot_python_semantic/src/semantic_index/symbol.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/symbol.rs
@@ -171,19 +171,19 @@ impl FileScopeId {
 pub struct Scope {
     parent: Option<FileScopeId>,
     node: NodeWithScopeKind,
-    descendents: Range<FileScopeId>,
+    descendants: Range<FileScopeId>,
 }
 
 impl Scope {
     pub(super) fn new(
         parent: Option<FileScopeId>,
         node: NodeWithScopeKind,
-        descendents: Range<FileScopeId>,
+        descendants: Range<FileScopeId>,
     ) -> Self {
         Scope {
             parent,
             node,
-            descendents,
+            descendants,
         }
     }
 
@@ -199,12 +199,12 @@ impl Scope {
         self.node().scope_kind()
     }
 
-    pub fn descendents(&self) -> Range<FileScopeId> {
-        self.descendents.clone()
+    pub fn descendants(&self) -> Range<FileScopeId> {
+        self.descendants.clone()
     }
 
-    pub(super) fn extend_descendents(&mut self, children_end: FileScopeId) {
-        self.descendents = self.descendents.start..children_end;
+    pub(super) fn extend_descendants(&mut self, children_end: FileScopeId) {
+        self.descendants = self.descendants.start..children_end;
     }
 
     pub(crate) fn is_eager(&self) -> bool {


### PR DESCRIPTION
## Summary

The noun is spelled "descend<strong><em>a</em></strong>nt" and the adjective "descend<strong><em>e</em></strong>nt".

## Test Plan

[From the English Wiktionary](https://en.wiktionary.org/wiki/descendent#Usage_notes):

> The adjective, "descending from a biological ancestor", may be spelt either with an <i>[a](https://en.wiktionary.org/wiki/-ant)</i> or with an <i>[e](https://en.wiktionary.org/wiki/-ent)</i> in the final syllable (see [descendant](https://en.wiktionary.org/wiki/descendant)). However, the noun <i>descendant</i>, "one who is the progeny of someone", may be spelt only with an <i>[a](https://en.wiktionary.org/wiki/-ant)</i>. Compare also <i>[dependent](https://en.wiktionary.org/wiki/dependent#English)</i> and <i>[dependant](https://en.wiktionary.org/wiki/dependant#English)</i>.
