### PR TITLE
[red-knot] Disambiguate display for intersection types

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/callable.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/callable.md
@@ -167,6 +167,24 @@ def _(
     reveal_type(e)  # revealed: None | ((int | str, /) -> int) | int
 ```
 
+## Intersection
+
+```py
+from typing import Callable, Union
+from knot_extensions import Intersection, Not
+
+def _(
+    c: Intersection[Callable[[Union[int, str]], int], int],
+    d: Intersection[int, Callable[[Union[int, str]], int]],
+    e: Intersection[int, Callable[[Union[int, str]], int], str],
+    f: Intersection[Not[Callable[[int, str], Intersection[int, str]]]],
+):
+    reveal_type(c)  # revealed: ((int | str, /) -> int) & int
+    reveal_type(d)  # revealed: int & ((int | str, /) -> int)
+    reveal_type(e)  # revealed: int & ((int | str, /) -> int) & str
+    reveal_type(f)  # revealed: ~((int, str, /) -> int & str)
+```
+
 ## Nested
 
 A nested `Callable` as one of the parameter types:


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Fixes #16912 

Create a new type `DisplayMaybeParenthesizedType` that is now used in Union and Intersection display

## Test Plan

Update callable annotations
