### PR TITLE
[`pylint`] Fix typo in documentation of PLC1802

### DIFF
--- a/crates/ruff_linter/src/rules/pylint/rules/len_test.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/len_test.rs
@@ -31,6 +31,7 @@ use ruff_text_size::Ranged;
 /// Use instead:
 /// ```python
 /// fruits = ["orange", "apple"]
+/// vegetables = []
 ///
 /// if fruits:
 ///     print(fruits)


### PR DESCRIPTION
The PR adresses issue #16797 
