### PR TITLE
[red-knot] Log sys-prefix origin for easier debugging

### DIFF
--- a/crates/red_knot_python_semantic/src/module_resolver/resolver.rs
+++ b/crates/red_knot_python_semantic/src/module_resolver/resolver.rs
@@ -224,6 +224,9 @@ impl SearchPaths {
 
         let site_packages_paths = match python_path {
             PythonPath::SysPrefix(sys_prefix, origin) => {
+                tracing::debug!(
+                    "Discovering site-packages paths from sys-prefix `{sys_prefix}` ({origin}')"
+                );
                 // TODO: We may want to warn here if the venv's python version is older
                 //  than the one resolved in the program settings because it indicates
                 //  that the `target-version` is incorrectly configured or that the


### PR DESCRIPTION
## Summary

Log the origin of the sys path prefix. This should help with debugging if someone doesn't understand
why Red Knot picks up a certain venv.

## Test Plan

Ran the CLI and tested that it logs the origin
