### PR TITLE
[red-knot] Add initial support for `*` imports

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/import/star.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/import/star.md
@@ -17,10 +17,7 @@ X: bool = True
 ```py
 from a import *
 
-# TODO: should not error, should be `bool`
-# error: [unresolved-reference]
-reveal_type(X)  # revealed: Unknown
-
+reveal_type(X)  # revealed: bool
 print(Y)  # error: [unresolved-reference]
 ```
 
@@ -40,8 +37,7 @@ reveal_type(X)  # revealed: Literal[42]
 
 from a import *
 
-# TODO: should reveal `bool`
-reveal_type(X)  # revealed: Literal[42]
+reveal_type(X)  # revealed: bool
 ```
 
 ### Overridden by later definition
@@ -57,12 +53,9 @@ X: bool = True
 ```py
 from a import *
 
-# TODO: should not error, should reveal `bool`
-# error: [unresolved-reference]
-reveal_type(X)  # revealed: Unknown
-
-X = 42
-reveal_type(X)  # revealed: Literal[42]
+reveal_type(X)  # revealed: bool
+X = False
+reveal_type(X)  # revealed: Literal[False]
 ```
 
 ### Reaching across many modules
@@ -90,9 +83,7 @@ from b import *
 ```py
 from c import *
 
-# TODO: should not error, should reveal `bool`
-# error: [unresolved-reference]
-reveal_type(X)  # revealed: Unknown
+reveal_type(X)  # revealed: bool
 ```
 
 ### A wildcard import constitutes a re-export
@@ -120,8 +111,7 @@ from b import Y
 
 ```py
 # `X` is accessible because the `*` import in `c` re-exports it from `c`
-# TODO: should not error
-from c import X  # error: [unresolved-import]
+from c import X
 
 # but `Y` is not because the `from b import Y` import does *not* constitute a re-export
 from c import Y  # error: [unresolved-import]
@@ -140,12 +130,8 @@ X = (Y := 3) + 4
 ```py
 from a import *
 
-# TODO should not error, should reveal `Literal[7] | Unknown`
-# error: [unresolved-reference]
-reveal_type(X)  # revealed: Unknown
-# TODO should not error, should reveal `Literal[3] | Unknown`
-# error: [unresolved-reference]
-reveal_type(Y)  # revealed: Unknown
+reveal_type(X)  # revealed: Unknown | Literal[7]
+reveal_type(Y)  # revealed: Unknown | Literal[3]
 ```
 
 ### Global-scope names starting with underscores
@@ -169,8 +155,6 @@ Y: bool = True
 ```py
 from a import *
 
-# These errors are correct:
-#
 # error: [unresolved-reference]
 reveal_type(_private)  # revealed: Unknown
 # error: [unresolved-reference]
@@ -180,10 +164,7 @@ reveal_type(__dunder__)  # revealed: Unknown
 # error: [unresolved-reference]
 reveal_type(___thunder___)  # revealed: Unknown
 
-# TODO: this error is incorrect (should reveal `bool`):
-#
-# error: [unresolved-reference]
-reveal_type(Y)  # revealed: Unknown
+reveal_type(Y)  # revealed: bool
 ```
 
 ### All public symbols are considered re-exported from `.py` files
@@ -212,11 +193,8 @@ from a import X
 ```py
 from b import *
 
-# TODO: this is a false positive, but we could consider a different opt-in diagnostic
-# (see prose commentary above)
-#
-# error: [unresolved-reference]
-reveal_type(X)  # revealed: Unknown
+# TODO: we could consider an opt-in diagnostic (see prose commentary above)
+reveal_type(X)  # revealed: bool
 ```
 
 ### Only explicit re-exports are considered re-exported from `.pyi` files
@@ -270,11 +248,9 @@ else:
 ```py
 from a import *
 
-# TODO should not error, should reveal `bool`
-# error: [unresolved-reference]
-reveal_type(X)  # revealed: Unknown
+reveal_type(X)  # revealed: bool
 
-# error: [unresolved-reference]
+# TODO: should emit error: [unresolved-reference]
 reveal_type(Y)  # revealed: Unknown
 ```
 
@@ -298,9 +274,7 @@ X: bool = True
 ```py
 from .foo import *
 
-# TODO should not error, should reveal `bool`
-# error: [unresolved-reference]
-reveal_type(X)  # revealed: Unknown
+reveal_type(X)  # revealed: bool
 ```
 
 ## Star imports with `__all__`
@@ -329,9 +303,9 @@ Y: bool = False
 ```py
 from a import *
 
+reveal_type(X)  # revealed: bool
+
 # TODO none of these should error, should all reveal `bool`
-# error: [unresolved-reference]
-reveal_type(X)  # revealed: Unknown
 # error: [unresolved-reference]
 reveal_type(_private)  # revealed: Unknown
 # error: [unresolved-reference]
@@ -341,10 +315,8 @@ reveal_type(__dunder__)  # revealed: Unknown
 # error: [unresolved-reference]
 reveal_type(___thunder___)  # revealed: Unknown
 
-# but this diagnostic is accurate!
-#
-# error: [unresolved-reference]
-reveal_type(Y)  # revealed: Unknown
+# TODO: should emit [unresolved-reference] diagnostic & reveal `Unknown`
+reveal_type(Y)  # revealed: bool
 ```
 
 ### Simple list `__all__`
@@ -363,12 +335,10 @@ Y: bool = False
 ```py
 from a import *
 
-# TODO should not error, should reveal `bool`
-# error: [unresolved-reference]
-reveal_type(X)  # revealed: Unknown
+reveal_type(X)  # revealed: bool
 
-# error: [unresolved-reference]
-reveal_type(Y)  # revealed: Unknown
+# TODO: should emit [unresolved-reference] diagnostic & reveal `Unknown`
+reveal_type(Y)  # revealed: bool
 ```
 
 ### `__all__` with additions later on in the global scope
@@ -409,22 +379,15 @@ F: bool = False
 ```py
 from b import *
 
-# TODO none of these should error, they should all reveal `bool`
-# error: [unresolved-reference]
-reveal_type(A)  # revealed: Unknown
-# error: [unresolved-reference]
-reveal_type(B)  # revealed: Unknown
-# error: [unresolved-reference]
-reveal_type(C)  # revealed: Unknown
-# error: [unresolved-reference]
-reveal_type(D)  # revealed: Unknown
-# error: [unresolved-reference]
-reveal_type(E)  # revealed: Unknown
-# error: [unresolved-reference]
-reveal_type(FOO)  # revealed: Unknown
+reveal_type(A)  # revealed: bool
+reveal_type(B)  # revealed: bool
+reveal_type(C)  # revealed: bool
+reveal_type(D)  # revealed: bool
+reveal_type(E)  # revealed: bool
+reveal_type(FOO)  # revealed: bool
 
-# error: [unresolved-reference]
-reveal_type(F)  # revealed: Unknown
+# TODO should error with [unresolved-reference] & reveal `Unknown`
+reveal_type(F)  # revealed: bool
 ```
 
 ### `__all__` with subtractions later on in the global scope
@@ -447,12 +410,10 @@ B: bool = True
 ```py
 from a import *
 
-# TODO should not error, should reveal `bool`
-# error: [unresolved-reference]
-reveal_type(A)  # revealed: Unknown
+reveal_type(A)  # revealed: bool
 
-# error: [unresolved-reference]
-reveal_type(B)  # revealed: Unknown
+# TODO should emit an [unresolved-reference] diagnostic & reveal `Unknown`
+reveal_type(B)  # revealed: bool
 ```
 
 ### Invalid `__all__`
@@ -508,16 +469,11 @@ __all__ = [f()]
 ```py
 from a import *
 
-# TODO: we should avoid both errors here.
-#
 # At runtime, `f` is imported but `g` is not; to avoid false positives, however,
-# we should treat `a` as though it does not have `__all__` at all,
+# we treat `a` as though it does not have `__all__` at all,
 # which would imply that both symbols would be present.
-#
-# error: [unresolved-reference]
-reveal_type(f)  # revealed: Unknown
-# error: [unresolved-reference]
-reveal_type(g)  # revealed: Unknown
+reveal_type(f)  # revealed: Literal[f]
+reveal_type(g)  # revealed: Literal[g]
 ```
 
 ### `__all__` conditionally defined in a statically known branch
@@ -547,13 +503,10 @@ else:
 ```py
 from a import *
 
-# TODO neither should error, both should be `bool`
-# error: [unresolved-reference]
-reveal_type(X)  # revealed: Unknown
-# error: [unresolved-reference]
-reveal_type(Y)  # revealed: Unknown
+reveal_type(X)  # revealed: bool
+reveal_type(Y)  # revealed: bool
 
-# error: [unresolved-reference]
+# TODO: should error with [unresolved-reference]
 reveal_type(Z)  # revealed: Unknown
 ```
 
@@ -585,13 +538,10 @@ else:
 ```py
 from a import *
 
-# TODO neither should error, both should be `bool`
-# error: [unresolved-reference]
-reveal_type(X)  # revealed: Unknown
-# error: [unresolved-reference]
-reveal_type(Y)  # revealed: Unknown
+reveal_type(X)  # revealed: bool
+reveal_type(Y)  # revealed: bool
 
-# error: [unresolved-reference]
+# TODO should have an [unresolved-reference] diagnostic
 reveal_type(Z)  # revealed: Unknown
 ```
 
@@ -622,10 +572,9 @@ __all__ = []
 from a import *
 from b import *
 
-# error: [unresolved-reference]
-reveal_type(X)  # revealed: Unknown
-# error: [unresolved-reference]
-reveal_type(Y)  # revealed: Unknown
+# TODO: both of these should have [unresolved-reference] diagnostics and reveal `Unknown`
+reveal_type(X)  # revealed: bool
+reveal_type(Y)  # revealed: bool
 ```
 
 ### `__all__` in a stub file
@@ -653,13 +602,10 @@ __all__ = ["X"]
 ```py
 from b import *
 
-# TODO: should not error, should reveal `bool`
-# error: [unresolved-reference]
-reveal_type(X)  # revealed: Unknown
+reveal_type(X)  # revealed: bool
 
-# this error is correct:
-# error: [unresolved-reference]
-reveal_type(Y)  # revealed: Unknown
+# TODO this should have an [unresolved-reference] diagnostic and reveal `Unknown`
+reveal_type(Y)  # revealed: bool
 ```
 
 ## Integration test: `collections.abc`

--- a/crates/red_knot_python_semantic/resources/mdtest/scopes/moduletype_attrs.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/scopes/moduletype_attrs.md
@@ -12,10 +12,7 @@ reveal_type(__file__)  # revealed: str | None
 reveal_type(__loader__)  # revealed: LoaderProtocol | None
 reveal_type(__package__)  # revealed: str | None
 reveal_type(__doc__)  # revealed: str | None
-
-# TODO: Should be `ModuleSpec | None`
-# (needs support for `*` imports)
-reveal_type(__spec__)  # revealed: Unknown | None
+reveal_type(__spec__)  # revealed: ModuleSpec | None
 
 reveal_type(__path__)  # revealed: @Todo(generics)
 

--- a/crates/red_knot_python_semantic/src/semantic_index.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index.rs
@@ -137,7 +137,7 @@ pub(crate) struct SemanticIndex<'db> {
     scopes_by_expression: FxHashMap<ExpressionNodeKey, FileScopeId>,
 
     /// Map from a node creating a definition to its definition.
-    definitions_by_node: FxHashMap<DefinitionNodeKey, Definition<'db>>,
+    definitions_by_node: FxHashMap<DefinitionNodeKey, smallvec::SmallVec<[Definition<'db>; 1]>>,
 
     /// Map from a standalone expression to its [`Expression`] ingredient.
     expressions_by_node: FxHashMap<ExpressionNodeKey, Expression<'db>>,
@@ -256,8 +256,8 @@ impl<'db> SemanticIndex<'db> {
     pub(crate) fn definition(
         &self,
         definition_key: impl Into<DefinitionNodeKey>,
-    ) -> Definition<'db> {
-        self.definitions_by_node[&definition_key.into()]
+    ) -> &smallvec::SmallVec<[Definition<'db>; 1]> {
+        &self.definitions_by_node[&definition_key.into()]
     }
 
     /// Returns the [`Expression`] ingredient for an expression node.

--- a/crates/red_knot_python_semantic/src/semantic_index.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index.rs
@@ -1,7 +1,6 @@
 use std::iter::FusedIterator;
 use std::sync::Arc;
 
-use definition::Definitions;
 use ruff_db::files::File;
 use ruff_db::parsed::parsed_module;
 use ruff_index::{IndexSlice, IndexVec};
@@ -15,7 +14,7 @@ use crate::semantic_index::ast_ids::node_key::ExpressionNodeKey;
 use crate::semantic_index::ast_ids::AstIds;
 use crate::semantic_index::attribute_assignment::AttributeAssignments;
 use crate::semantic_index::builder::SemanticIndexBuilder;
-use crate::semantic_index::definition::DefinitionNodeKey;
+use crate::semantic_index::definition::{DefinitionNodeKey, Definitions};
 use crate::semantic_index::expression::Expression;
 use crate::semantic_index::symbol::{
     FileScopeId, NodeWithScopeKey, NodeWithScopeRef, Scope, ScopeId, ScopedSymbolId, SymbolTable,
@@ -252,7 +251,10 @@ impl<'db> SemanticIndex<'db> {
         AncestorsIter::new(self, scope)
     }
 
-    /// Returns the [`Definition`] salsa ingredients for `definition_key`.
+    /// Returns the [`Definition`] salsa ingredient(s) for `definition_key`.
+    ///
+    /// There will only ever be >1 `Definition` associated with a `definition_key`
+    /// if the definition is created by a wildcard (`*`) import.
     #[track_caller]
     pub(crate) fn definitions(
         &self,

--- a/crates/red_knot_python_semantic/src/semantic_index.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index.rs
@@ -29,6 +29,7 @@ pub mod definition;
 pub mod expression;
 mod narrowing_constraints;
 pub(crate) mod predicate;
+mod re_exports;
 pub mod symbol;
 mod use_def;
 mod visibility_constraints;

--- a/crates/red_knot_python_semantic/src/semantic_index.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index.rs
@@ -1,6 +1,7 @@
 use std::iter::FusedIterator;
 use std::sync::Arc;
 
+use definition::Definitions;
 use ruff_db::files::File;
 use ruff_db::parsed::parsed_module;
 use ruff_index::{IndexSlice, IndexVec};
@@ -14,7 +15,7 @@ use crate::semantic_index::ast_ids::node_key::ExpressionNodeKey;
 use crate::semantic_index::ast_ids::AstIds;
 use crate::semantic_index::attribute_assignment::AttributeAssignments;
 use crate::semantic_index::builder::SemanticIndexBuilder;
-use crate::semantic_index::definition::{Definition, DefinitionNodeKey};
+use crate::semantic_index::definition::DefinitionNodeKey;
 use crate::semantic_index::expression::Expression;
 use crate::semantic_index::symbol::{
     FileScopeId, NodeWithScopeKey, NodeWithScopeRef, Scope, ScopeId, ScopedSymbolId, SymbolTable,
@@ -137,7 +138,7 @@ pub(crate) struct SemanticIndex<'db> {
     scopes_by_expression: FxHashMap<ExpressionNodeKey, FileScopeId>,
 
     /// Map from a node creating a definition to its definition.
-    definitions_by_node: FxHashMap<DefinitionNodeKey, smallvec::SmallVec<[Definition<'db>; 1]>>,
+    definitions_by_node: FxHashMap<DefinitionNodeKey, Definitions<'db>>,
 
     /// Map from a standalone expression to its [`Expression`] ingredient.
     expressions_by_node: FxHashMap<ExpressionNodeKey, Expression<'db>>,
@@ -251,12 +252,12 @@ impl<'db> SemanticIndex<'db> {
         AncestorsIter::new(self, scope)
     }
 
-    /// Returns the [`Definition`] salsa ingredient for `definition_key`.
+    /// Returns the [`Definition`] salsa ingredients for `definition_key`.
     #[track_caller]
-    pub(crate) fn definition(
+    pub(crate) fn definitions(
         &self,
         definition_key: impl Into<DefinitionNodeKey>,
-    ) -> &smallvec::SmallVec<[Definition<'db>; 1]> {
+    ) -> &Definitions<'db> {
         &self.definitions_by_node[&definition_key.into()]
     }
 

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -39,7 +39,7 @@ use crate::semantic_index::SemanticIndex;
 use crate::unpack::{Unpack, UnpackValue};
 use crate::{resolve_module, Db};
 
-use super::definition::{DefinitionKind, StarImportDefinitionNodeRef};
+use super::definition::{DefinitionKind, Definitions, StarImportDefinitionNodeRef};
 use super::re_exports::find_exports;
 
 mod except_handlers;
@@ -90,7 +90,7 @@ pub(super) struct SemanticIndexBuilder<'db> {
     use_def_maps: IndexVec<FileScopeId, UseDefMapBuilder<'db>>,
     scopes_by_node: FxHashMap<NodeWithScopeKey, FileScopeId>,
     scopes_by_expression: FxHashMap<ExpressionNodeKey, FileScopeId>,
-    definitions_by_node: FxHashMap<DefinitionNodeKey, smallvec::SmallVec<[Definition<'db>; 1]>>,
+    definitions_by_node: FxHashMap<DefinitionNodeKey, Definitions<'db>>,
     expressions_by_node: FxHashMap<ExpressionNodeKey, Expression<'db>>,
     imported_modules: FxHashSet<ModuleName>,
     attribute_assignments: FxHashMap<FileScopeId, AttributeAssignments<'db>>,
@@ -776,7 +776,7 @@ impl<'db> SemanticIndexBuilder<'db> {
         // a valid type (and doesn't panic)
         let existing_definition = self.definitions_by_node.insert(
             (&parameter.parameter).into(),
-            smallvec::smallvec![definition],
+            Definitions::single(definition),
         );
         debug_assert_eq!(existing_definition, None);
     }

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -12,19 +12,22 @@ use ruff_python_ast::{self as ast, ExprContext};
 
 use crate::ast_node_ref::AstNodeRef;
 use crate::module_name::{module_name_from_import_statement, ModuleName};
+use crate::module_resolver::resolve_module;
 use crate::semantic_index::ast_ids::node_key::ExpressionNodeKey;
 use crate::semantic_index::ast_ids::AstIdsBuilder;
 use crate::semantic_index::attribute_assignment::{AttributeAssignment, AttributeAssignments};
 use crate::semantic_index::definition::{
     AssignmentDefinitionNodeRef, ComprehensionDefinitionNodeRef, Definition, DefinitionCategory,
-    DefinitionNodeKey, DefinitionNodeRef, ExceptHandlerDefinitionNodeRef, ForStmtDefinitionNodeRef,
-    ImportDefinitionNodeRef, ImportFromDefinitionNodeRef, MatchPatternDefinitionNodeRef,
+    DefinitionKind, DefinitionNodeKey, DefinitionNodeRef, Definitions,
+    ExceptHandlerDefinitionNodeRef, ForStmtDefinitionNodeRef, ImportDefinitionNodeRef,
+    ImportFromDefinitionNodeRef, MatchPatternDefinitionNodeRef, StarImportDefinitionNodeRef,
     WithItemDefinitionNodeRef,
 };
 use crate::semantic_index::expression::{Expression, ExpressionKind};
 use crate::semantic_index::predicate::{
     PatternPredicate, PatternPredicateKind, Predicate, PredicateNode, ScopedPredicateId,
 };
+use crate::semantic_index::re_exports::find_exports;
 use crate::semantic_index::symbol::{
     FileScopeId, NodeWithScopeKey, NodeWithScopeRef, Scope, ScopeId, ScopeKind, ScopedSymbolId,
     SymbolTableBuilder,
@@ -37,10 +40,7 @@ use crate::semantic_index::visibility_constraints::{
 };
 use crate::semantic_index::SemanticIndex;
 use crate::unpack::{Unpack, UnpackValue};
-use crate::{resolve_module, Db};
-
-use super::definition::{DefinitionKind, Definitions, StarImportDefinitionNodeRef};
-use super::re_exports::find_exports;
+use crate::Db;
 
 mod except_handlers;
 

--- a/crates/red_knot_python_semantic/src/semantic_index/definition.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/definition.rs
@@ -430,10 +430,7 @@ impl<'db> DefinitionNodeRef<'db> {
                 alias_index,
                 is_reexported: _,
             }) => (&node.names[alias_index]).into(),
-            Self::ImportStar(StarImportDefinitionNodeRef { node, .. }) => {
-                debug_assert_eq!(node.names.len(), 1);
-                (&node.names[0]).into()
-            }
+            Self::ImportStar(StarImportDefinitionNodeRef { node, .. }) => (&node.names[0]).into(),
             Self::Function(node) => node.into(),
             Self::Class(node) => node.into(),
             Self::TypeAlias(node) => node.into(),

--- a/crates/red_knot_python_semantic/src/semantic_index/re_exports.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/re_exports.rs
@@ -1,0 +1,293 @@
+//! A visitor and query to find all global-scope symbols that are exported from a module
+//! when a wildcard import is used.
+//!
+//! For example, if a module `foo` contains `from bar import *`, which symbols from the global
+//! scope of `bar` are imported into the global namespace of `foo`?
+
+use ruff_db::{files::File, parsed::parsed_module};
+use ruff_python_ast::{
+    self as ast,
+    name::Name,
+    visitor::{walk_expr, walk_stmt, Visitor},
+};
+use rustc_hash::FxHashSet;
+
+use crate::Db;
+
+#[salsa::tracked(return_ref)]
+fn find_exports(db: &dyn Db, file: File) -> FxHashSet<Name> {
+    let module = parsed_module(db.upcast(), file);
+
+    let mut finder = ExportFinder {
+        exports: FxHashSet::default(),
+        is_stub: file.is_stub(db.upcast()),
+    };
+
+    finder.visit_body(module.suite());
+    finder.exports
+}
+
+struct ExportFinder {
+    exports: FxHashSet<Name>,
+    is_stub: bool,
+}
+
+impl ExportFinder {
+    fn possibly_add_export(&mut self, name: &Name) {
+        if name.starts_with('_') {
+            return;
+        }
+        if !self.exports.contains(name) {
+            self.exports.insert(name.clone());
+        }
+    }
+}
+
+impl<'db> Visitor<'db> for ExportFinder {
+    fn visit_alias(&mut self, alias: &'db ast::Alias) {
+        let ast::Alias { name, asname, .. } = alias;
+        if self.is_stub {
+            // If the source is a stub, names defined by imports are only exported
+            // if they use the explicit `foo as foo` syntax:
+            if asname.as_ref() == Some(name) {
+                self.possibly_add_export(&name.id);
+            }
+        } else {
+            self.possibly_add_export(&name.id);
+        }
+    }
+
+    fn visit_with_item(&mut self, with_item: &'db ast::WithItem) {
+        let ast::WithItem {
+            context_expr,
+            optional_vars,
+            range: _,
+        } = with_item;
+
+        if let Some(var) = optional_vars.as_deref() {
+            if let ast::Expr::Name(ast::ExprName { id, .. }) = var {
+                self.possibly_add_export(id);
+            } else {
+                self.visit_expr(var);
+            }
+        }
+        self.visit_expr(context_expr);
+    }
+
+    fn visit_pattern(&mut self, pattern: &'db ast::Pattern) {
+        match pattern {
+            ast::Pattern::MatchAs(ast::PatternMatchAs {
+                pattern,
+                name,
+                range: _,
+            }) => {
+                if let Some(pattern) = pattern {
+                    self.visit_pattern(pattern);
+                }
+                if let Some(name) = name {
+                    // Wildcard patterns (`case _:`) do not bind names.
+                    // Currently `self.possibly_add_export()` just ignores
+                    // all names with leading underscores, but this will not always be the case
+                    // (in the future we will want to support modules with `__all__ = ['_']`).
+                    if name != "_" {
+                        self.possibly_add_export(&name.id);
+                    }
+                }
+            }
+            ast::Pattern::MatchClass(ast::PatternMatchClass {
+                arguments,
+                cls: _,
+                range: _,
+            }) => {
+                let ast::PatternArguments {
+                    patterns,
+                    keywords,
+                    range: _,
+                } = arguments;
+                for pattern in patterns {
+                    self.visit_pattern(pattern);
+                }
+                for ast::PatternKeyword {
+                    pattern,
+                    attr: _,
+                    range: _,
+                } in keywords
+                {
+                    self.visit_pattern(pattern);
+                }
+            }
+            ast::Pattern::MatchMapping(ast::PatternMatchMapping {
+                patterns,
+                rest,
+                keys: _,
+                range: _,
+            }) => {
+                for pattern in patterns {
+                    self.visit_pattern(pattern);
+                }
+                if let Some(rest) = rest {
+                    self.possibly_add_export(&rest.id);
+                }
+            }
+            ast::Pattern::MatchStar(ast::PatternMatchStar { name, range: _ }) => {
+                if let Some(name) = name {
+                    self.possibly_add_export(&name.id);
+                }
+            }
+            ast::Pattern::MatchSequence(ast::PatternMatchSequence { patterns, range: _ })
+            | ast::Pattern::MatchOr(ast::PatternMatchOr { patterns, range: _ }) => {
+                for pattern in patterns {
+                    self.visit_pattern(pattern);
+                }
+            }
+            ast::Pattern::MatchSingleton(_) | ast::Pattern::MatchValue(_) => {}
+        }
+    }
+
+    fn visit_stmt(&mut self, stmt: &'db ruff_python_ast::Stmt) {
+        match stmt {
+            ast::Stmt::ClassDef(ast::StmtClassDef {
+                name,
+                decorator_list,
+                type_params,
+                arguments,
+                body: _, // We don't want to visit the body of the class
+                range: _,
+            }) => {
+                self.possibly_add_export(&name.id);
+                for decorator in decorator_list {
+                    self.visit_decorator(decorator);
+                }
+                if let Some(type_params) = type_params {
+                    self.visit_type_params(type_params);
+                }
+                if let Some(arguments) = arguments {
+                    self.visit_arguments(arguments);
+                }
+            }
+            ast::Stmt::FunctionDef(ast::StmtFunctionDef {
+                name,
+                decorator_list,
+                parameters,
+                returns,
+                type_params,
+                body: _, // We don't want to visit the body of the function
+                range: _,
+                is_async: _,
+            }) => {
+                self.possibly_add_export(&name.id);
+                for decorator in decorator_list {
+                    self.visit_decorator(decorator);
+                }
+                self.visit_parameters(parameters);
+                if let Some(returns) = returns {
+                    self.visit_expr(returns);
+                }
+                if let Some(type_params) = type_params {
+                    self.visit_type_params(type_params);
+                }
+            }
+            ast::Stmt::Assign(ast::StmtAssign {
+                targets,
+                value,
+                range: _,
+            }) => {
+                for target in targets {
+                    if let ast::Expr::Name(ast::ExprName { id, .. }) = target {
+                        self.possibly_add_export(id);
+                    } else {
+                        self.visit_expr(target);
+                    }
+                }
+                self.visit_expr(value);
+            }
+            ast::Stmt::AnnAssign(ast::StmtAnnAssign {
+                target,
+                value,
+                annotation,
+                simple: _,
+                range: _,
+            }) => {
+                if let ast::Expr::Name(ast::ExprName { id, .. }) = &**target {
+                    self.possibly_add_export(id);
+                } else {
+                    self.visit_expr(target);
+                }
+                self.visit_expr(annotation);
+                if let Some(value) = value {
+                    self.visit_expr(value);
+                }
+            }
+            ast::Stmt::TypeAlias(ast::StmtTypeAlias {
+                name,
+                type_params: _,
+                value: _,
+                range: _,
+            }) => {
+                if let ast::Expr::Name(ast::ExprName { id, .. }) = &**name {
+                    self.possibly_add_export(id);
+                }
+                // Neither walrus expressions nor statements cannot appear in type aliases;
+                // no need to recursively visit the `value` or `type_params`
+            }
+            ast::Stmt::For(ast::StmtFor {
+                target,
+                iter,
+                body,
+                orelse,
+                range: _,
+                is_async: _,
+            }) => {
+                if let ast::Expr::Name(ast::ExprName { id, .. }) = &**target {
+                    self.possibly_add_export(id);
+                }
+                self.visit_expr(iter);
+                for child in body {
+                    self.visit_stmt(child);
+                }
+                for child in orelse {
+                    self.visit_stmt(child);
+                }
+            }
+
+            ast::Stmt::Import(_)
+            | ast::Stmt::AugAssign(_)
+            | ast::Stmt::ImportFrom(_)
+            | ast::Stmt::While(_)
+            | ast::Stmt::If(_)
+            | ast::Stmt::With(_)
+            | ast::Stmt::Assert(_)
+            | ast::Stmt::Try(_)
+            | ast::Stmt::Expr(_)
+            | ast::Stmt::Match(_) => walk_stmt(self, stmt),
+
+            ast::Stmt::Global(_)
+            | ast::Stmt::Raise(_)
+            | ast::Stmt::Return(_)
+            | ast::Stmt::Break(_)
+            | ast::Stmt::Continue(_)
+            | ast::Stmt::IpyEscapeCommand(_)
+            | ast::Stmt::Delete(_)
+            | ast::Stmt::Nonlocal(_)
+            | ast::Stmt::Pass(_) => {}
+        }
+    }
+
+    fn visit_expr(&mut self, expr: &'db ast::Expr) {
+        if let ast::Expr::Named(ast::ExprNamed {
+            target,
+            value,
+            range: _,
+        }) = expr
+        {
+            if let ast::Expr::Name(ast::ExprName { id, .. }) = &**target {
+                self.possibly_add_export(id);
+            } else {
+                self.visit_expr(target);
+            }
+            self.visit_expr(value);
+        } else {
+            walk_expr(self, expr);
+        }
+    }
+}

--- a/crates/red_knot_python_semantic/src/semantic_model.rs
+++ b/crates/red_knot_python_semantic/src/semantic_model.rs
@@ -149,7 +149,7 @@ macro_rules! impl_binding_has_ty {
             #[inline]
             fn inferred_type<'db>(&self, model: &SemanticModel<'db>) -> Type<'db> {
                 let index = semantic_index(model.db, model.file);
-                let definitions = index.definition(self);
+                let definitions = index.definitions(self);
                 debug_assert_eq!(definitions.len(), 1);
                 binding_type(model.db, definitions[0])
             }
@@ -168,7 +168,7 @@ impl HasType for ast::Alias {
             return Type::Never;
         }
         let index = semantic_index(model.db, model.file);
-        let definitions = index.definition(self);
+        let definitions = index.definitions(self);
         debug_assert_eq!(definitions.len(), 1);
         binding_type(model.db, definitions[0])
     }

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -4152,7 +4152,7 @@ impl<'db> FunctionType<'db> {
     fn internal_signature(self, db: &'db dyn Db) -> Signature<'db> {
         let scope = self.body_scope(db);
         let function_stmt_node = scope.node(db).expect_function();
-        let definitions = semantic_index(db, scope.file(db)).definition(function_stmt_node);
+        let definitions = semantic_index(db, scope.file(db)).definitions(function_stmt_node);
         debug_assert_eq!(definitions.len(), 1);
         Signature::from_function(db, definitions[0], function_stmt_node)
     }
@@ -4883,7 +4883,7 @@ impl<'db> TypeAliasType<'db> {
         let scope = self.rhs_scope(db);
 
         let type_alias_stmt_node = scope.node(db).expect_type_alias();
-        let definitions = semantic_index(db, scope.file(db)).definition(type_alias_stmt_node);
+        let definitions = semantic_index(db, scope.file(db)).definitions(type_alias_stmt_node);
         debug_assert_eq!(definitions.len(), 1);
 
         definition_expression_type(db, definitions[0], &type_alias_stmt_node.value)
@@ -5648,7 +5648,7 @@ pub(crate) mod tests {
             let function_node = function_body_scope.node(&db).expect_function();
 
             let definitions =
-                semantic_index(&db, function_body_scope.file(&db)).definition(function_node);
+                semantic_index(&db, function_body_scope.file(&db)).definitions(function_node);
             assert_eq!(definitions.len(), 1);
 
             assert_eq!(

--- a/crates/red_knot_python_semantic/src/types/class.rs
+++ b/crates/red_knot_python_semantic/src/types/class.rs
@@ -130,7 +130,11 @@ impl<'db> Class<'db> {
         tracing::trace!("Class::explicit_bases_query: {}", self.name(db));
         let class_stmt = self.node(db);
 
-        let class_definition = semantic_index(db, self.file(db)).definition(class_stmt);
+        let class_definitions = semantic_index(db, self.file(db)).definition(class_stmt);
+
+        debug_assert_eq!(class_definitions.len(), 1);
+
+        let class_definition = class_definitions[0];
 
         class_stmt
             .bases()
@@ -160,12 +164,13 @@ impl<'db> Class<'db> {
         if class_stmt.decorator_list.is_empty() {
             return Box::new([]);
         }
-        let class_definition = semantic_index(db, self.file(db)).definition(class_stmt);
+        let class_definitions = semantic_index(db, self.file(db)).definition(class_stmt);
+        debug_assert_eq!(class_definitions.len(), 1);
         class_stmt
             .decorator_list
             .iter()
             .map(|decorator_node| {
-                definition_expression_type(db, class_definition, &decorator_node.expression)
+                definition_expression_type(db, class_definitions[0], &decorator_node.expression)
             })
             .collect()
     }
@@ -224,8 +229,9 @@ impl<'db> Class<'db> {
             .as_ref()?
             .find_keyword("metaclass")?
             .value;
-        let class_definition = semantic_index(db, self.file(db)).definition(class_stmt);
-        let metaclass_ty = definition_expression_type(db, class_definition, metaclass_node);
+        let definitions = semantic_index(db, self.file(db)).definition(class_stmt);
+        debug_assert_eq!(definitions.len(), 1);
+        let metaclass_ty = definition_expression_type(db, definitions[0], metaclass_node);
         Some(metaclass_ty)
     }
 

--- a/crates/red_knot_python_semantic/src/types/class.rs
+++ b/crates/red_knot_python_semantic/src/types/class.rs
@@ -130,7 +130,7 @@ impl<'db> Class<'db> {
         tracing::trace!("Class::explicit_bases_query: {}", self.name(db));
         let class_stmt = self.node(db);
 
-        let class_definitions = semantic_index(db, self.file(db)).definition(class_stmt);
+        let class_definitions = semantic_index(db, self.file(db)).definitions(class_stmt);
 
         debug_assert_eq!(class_definitions.len(), 1);
 
@@ -164,7 +164,7 @@ impl<'db> Class<'db> {
         if class_stmt.decorator_list.is_empty() {
             return Box::new([]);
         }
-        let class_definitions = semantic_index(db, self.file(db)).definition(class_stmt);
+        let class_definitions = semantic_index(db, self.file(db)).definitions(class_stmt);
         debug_assert_eq!(class_definitions.len(), 1);
         class_stmt
             .decorator_list
@@ -229,7 +229,7 @@ impl<'db> Class<'db> {
             .as_ref()?
             .find_keyword("metaclass")?
             .value;
-        let definitions = semantic_index(db, self.file(db)).definition(class_stmt);
+        let definitions = semantic_index(db, self.file(db)).definitions(class_stmt);
         debug_assert_eq!(definitions.len(), 1);
         let metaclass_ty = definition_expression_type(db, definitions[0], metaclass_node);
         Some(metaclass_ty)

--- a/crates/red_knot_python_semantic/src/types/context.rs
+++ b/crates/red_knot_python_semantic/src/types/context.rs
@@ -178,7 +178,9 @@ impl<'db> InferContext<'db> {
                     .ancestor_scopes(scope_id)
                     .filter_map(|(_, scope)| scope.node().as_function())
                     .filter_map(|function| {
-                        binding_type(self.db, index.definition(function)).into_function_literal()
+                        let definitions = index.definition(function);
+                        debug_assert_eq!(definitions.len(), 1);
+                        binding_type(self.db, definitions[0]).into_function_literal()
                     });
 
                 // Iterate over all functions and test if any is decorated with `@no_type_check`.

--- a/crates/red_knot_python_semantic/src/types/context.rs
+++ b/crates/red_knot_python_semantic/src/types/context.rs
@@ -178,7 +178,7 @@ impl<'db> InferContext<'db> {
                     .ancestor_scopes(scope_id)
                     .filter_map(|(_, scope)| scope.node().as_function())
                     .filter_map(|function| {
-                        let definitions = index.definition(function);
+                        let definitions = index.definitions(function);
                         debug_assert_eq!(definitions.len(), 1);
                         binding_type(self.db, definitions[0]).into_function_literal()
                     });

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -3118,7 +3118,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             &alias.name.id
         };
 
-        if import_from.is_wildcard_import() && !is_meaningful_star_import {
+        if &alias.name == "*" && !is_meaningful_star_import {
             self.add_declaration_with_binding(
                 alias.into(),
                 definition,
@@ -3129,7 +3129,7 @@ impl<'db> TypeInferenceBuilder<'db> {
 
         // First try loading the requested attribute from the module.
         if let Symbol::Type(ty, boundness) = module_ty.member(self.db(), name).symbol {
-            if boundness == Boundness::PossiblyUnbound {
+            if &alias.name != "*" && boundness == Boundness::PossiblyUnbound {
                 // TODO: Consider loading _both_ the attribute and any submodule and unioning them
                 // together if the attribute exists but is possibly-unbound.
                 self.context.report_lint(
@@ -3174,7 +3174,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             }
         }
 
-        if !is_meaningful_star_import {
+        if &alias.name != "*" {
             self.context.report_lint(
                 &UNRESOLVED_IMPORT,
                 AnyNodeRef::Alias(alias),

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1300,7 +1300,7 @@ impl<'db> TypeInferenceBuilder<'db> {
     }
 
     fn infer_definition(&mut self, node: impl Into<DefinitionNodeKey>) {
-        for definition in self.index.definition(node) {
+        for definition in self.index.definitions(node) {
             self.extend(infer_definition_types(self.db(), *definition));
         }
     }
@@ -3702,7 +3702,7 @@ impl<'db> TypeInferenceBuilder<'db> {
     fn infer_named_expression(&mut self, named: &ast::ExprNamed) -> Type<'db> {
         // See https://peps.python.org/pep-0572/#differences-between-assignment-expressions-and-assignment-statements
         if named.target.is_name_expr() {
-            let definitions = self.index.definition(named);
+            let definitions = self.index.definitions(named);
             debug_assert_eq!(definitions.len(), 1);
             let result = infer_definition_types(self.db(), definitions[0]);
             self.extend(result);

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -4,6 +4,7 @@ use crate::generated::{
     ExprBytesLiteral, ExprDict, ExprFString, ExprList, ExprName, ExprSet, ExprStringLiteral,
     ExprTuple, StmtClassDef,
 };
+use crate::StmtImportFrom;
 use std::borrow::Cow;
 use std::fmt;
 use std::fmt::Debug;
@@ -55,6 +56,12 @@ impl StmtClassDef {
             Some(arguments) => &arguments.keywords,
             None => &[],
         }
+    }
+}
+
+impl StmtImportFrom {
+    pub fn is_wildcard_import(&self) -> bool {
+        matches!(&self.names[..], [Alias { range: _, name, asname: None }] if name == "*")
     }
 }
 

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -2,9 +2,8 @@
 
 use crate::generated::{
     ExprBytesLiteral, ExprDict, ExprFString, ExprList, ExprName, ExprSet, ExprStringLiteral,
-    ExprTuple, StmtClassDef,
+    ExprTuple, StmtClassDef, StmtImportFrom,
 };
-use crate::StmtImportFrom;
 use std::borrow::Cow;
 use std::fmt;
 use std::fmt::Debug;

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -2,7 +2,7 @@
 
 use crate::generated::{
     ExprBytesLiteral, ExprDict, ExprFString, ExprList, ExprName, ExprSet, ExprStringLiteral,
-    ExprTuple, StmtClassDef, StmtImportFrom,
+    ExprTuple, StmtClassDef,
 };
 use std::borrow::Cow;
 use std::fmt;
@@ -55,12 +55,6 @@ impl StmtClassDef {
             Some(arguments) => &arguments.keywords,
             None => &[],
         }
-    }
-}
-
-impl StmtImportFrom {
-    pub fn is_wildcard_import(&self) -> bool {
-        matches!(&self.names[..], [Alias { range: _, name, asname: None }] if name == "*")
     }
 }
 


### PR DESCRIPTION
## Summary

This PR adds initial support for `*` imports to red-knot. The approach is to implement a standalone query, called from semantic indexing, that visits the module referenced by the `*` import and collects all global-scope public names that will be imported by the `*` import. The `SemanticIndexBuilder` then adds separate definitions for each of these names, all keyed to the same `ast::Alias` node that represents the `*` import.

There are many pieces of `*`-import semantics that are still yet to be done, even with this PR:
- This PR does not attempt to implement any of the semantics to do with `__all__`. (If a module defines `__all__`, then only the symbols included in `__all__` are imported, _not_ all public global-scope symbols.
- With the logic implemented in this PR as it currently stands, we sometimes incorrectly consider a symbol bound even though it is defined in a branch that is statically known to be dead code, e.g. (assuming the target Python version is set to 3.11):

  ```py
  # a.py

  import sys

  if sys.version_info < (3, 10):
      class Foo: ...

  ```

  ```py
  # b.py

  from a import *

  print(Foo)  # this is unbound at runtime on 3.11,
              # but we currently consider it bound with the logic in this PR
  ```

Implementing these features is important, but is for now deferred to followup PRs.

## Test Plan

Assertions in existing mdtests are adjusted, and several new ones are added.

TODO: the `collections.abc` integration test at the bottom of `star.md` is still failing. Not sure why...