### PR TITLE
 [`refurb`] Document why `UserDict`, `UserList`, `UserString` are preferred over `dict`, `list`, `str` (`FURB189`)

### DIFF
--- a/crates/ruff_linter/src/rules/refurb/rules/subclass_builtin.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/subclass_builtin.rs
@@ -9,21 +9,37 @@ use crate::{checkers::ast::Checker, importer::ImportRequest};
 /// Checks for subclasses of `dict`, `list` or `str`.
 ///
 /// ## Why is this bad?
-/// Subclassing `dict`, `list`, or `str` objects can be error prone, use the
-/// `UserDict`, `UserList`, and `UserString` objects from the `collections` module
+/// Built-in types don't consistently use their own dunder methods. For example,
+/// `dict.__init__` and `dict.update()` bypass `__setitem__`, making inheritance unreliable.
+///
+/// Use the `UserDict`, `UserList`, and `UserString` objects from the `collections` module
 /// instead.
 ///
 /// ## Example
+///
 /// ```python
-/// class CaseInsensitiveDict(dict): ...
+/// class UppercaseDict(dict):
+///     def __setitem__(self, key, value):
+///         super().__setitem__(key.upper(), value)
+///
+///
+/// d = UppercaseDict({"a": 1, "b": 2})  # Bypasses __setitem__
+/// print(d)  # {'a': 1, 'b': 2}
 /// ```
 ///
 /// Use instead:
+///
 /// ```python
 /// from collections import UserDict
 ///
 ///
-/// class CaseInsensitiveDict(UserDict): ...
+/// class UppercaseDict(UserDict):
+///     def __setitem__(self, key, value):
+///         super().__setitem__(key.upper(), value)
+///
+///
+/// d = UppercaseDict({"a": 1, "b": 2})  # Uses __setitem__
+/// print(d)  # {'A': 1, 'B': 2}
 /// ```
 ///
 /// ## Fix safety


### PR DESCRIPTION
## Summary

This PR addresses docs issue https://github.com/astral-sh/ruff/issues/14328.
