### PR TITLE
[red-knot] Add settings support to playground

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2641,11 +2641,12 @@ dependencies = [
  "js-sys",
  "log",
  "red_knot_project",
+ "red_knot_python_semantic",
  "ruff_db",
  "ruff_notebook",
- "ruff_python_ast",
  "ruff_source_file",
  "ruff_text_size",
+ "serde-wasm-bindgen",
  "wasm-bindgen",
  "wasm-bindgen-test",
 ]

--- a/crates/red_knot_project/src/metadata.rs
+++ b/crates/red_knot_project/src/metadata.rs
@@ -64,7 +64,7 @@ impl ProjectMetadata {
     }
 
     /// Loads a project from a set of options with an optional pyproject-project table.
-    pub(crate) fn from_options(
+    pub fn from_options(
         mut options: Options,
         root: SystemPathBuf,
         project: Option<&Project>,

--- a/crates/red_knot_project/src/metadata/options.rs
+++ b/crates/red_knot_project/src/metadata/options.rs
@@ -37,9 +37,17 @@ pub struct Options {
 
 impl Options {
     pub(crate) fn from_toml_str(content: &str, source: ValueSource) -> Result<Self, KnotTomlError> {
-        let _guard = ValueSourceGuard::new(source);
+        let _guard = ValueSourceGuard::new(source, true);
         let options = toml::from_str(content)?;
         Ok(options)
+    }
+
+    pub fn deserialize_with<'de, D>(source: ValueSource, deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let _guard = ValueSourceGuard::new(source, false);
+        Self::deserialize(deserializer)
     }
 
     pub(crate) fn to_program_settings(

--- a/crates/red_knot_project/src/metadata/pyproject.rs
+++ b/crates/red_knot_project/src/metadata/pyproject.rs
@@ -34,7 +34,7 @@ impl PyProject {
         content: &str,
         source: ValueSource,
     ) -> Result<Self, PyProjectError> {
-        let _guard = ValueSourceGuard::new(source);
+        let _guard = ValueSourceGuard::new(source, true);
         toml::from_str(content).map_err(PyProjectError::TomlSyntax)
     }
 }

--- a/crates/red_knot_wasm/Cargo.toml
+++ b/crates/red_knot_wasm/Cargo.toml
@@ -20,10 +20,10 @@ default = ["console_error_panic_hook"]
 
 [dependencies]
 red_knot_project = { workspace = true, default-features = false, features = ["deflate"] }
+red_knot_python_semantic = { workspace = true }
 
 ruff_db = { workspace = true, default-features = false, features = [] }
 ruff_notebook = { workspace = true }
-ruff_python_ast = { workspace = true }
 ruff_source_file = { workspace = true }
 ruff_text_size = { workspace = true }
 
@@ -34,6 +34,7 @@ log = { workspace = true }
 # Not a direct dependency but required to enable the `wasm_js` feature.
 # See https://docs.rs/getrandom/latest/getrandom/#webassembly-support
 getrandom = { workspace = true, features = ["wasm_js"] }
+serde-wasm-bindgen = { workspace = true }
 
 wasm-bindgen = { workspace = true }
 

--- a/crates/red_knot_wasm/tests/api.rs
+++ b/crates/red_knot_wasm/tests/api.rs
@@ -1,15 +1,12 @@
 #![cfg(target_arch = "wasm32")]
 
+use red_knot_wasm::{Position, Workspace};
 use wasm_bindgen_test::wasm_bindgen_test;
-
-use red_knot_wasm::{Position, PythonVersion, Settings, Workspace};
 
 #[wasm_bindgen_test]
 fn check() {
-    let settings = Settings {
-        python_version: PythonVersion::Py312,
-    };
-    let mut workspace = Workspace::new("/", &settings).expect("Workspace to be created");
+    let mut workspace =
+        Workspace::new("/", js_sys::JSON::parse("{}").unwrap()).expect("Workspace to be created");
 
     workspace
         .open_file("test.py", "import random22\n")

--- a/playground/knot/src/Editor/Chrome.tsx
+++ b/playground/knot/src/Editor/Chrome.tsx
@@ -15,13 +15,8 @@ import {
   HorizontalResizeHandle,
   VerticalResizeHandle,
 } from "shared";
-import initRedKnot, {
-  Diagnostic,
-  FileHandle,
-  Settings,
-  PythonVersion,
-  Workspace,
-} from "red_knot_wasm";
+import knotSchema from "../../../../knot.schema.json";
+import initRedKnot, { Diagnostic, FileHandle, Workspace } from "red_knot_wasm";
 import { loader } from "@monaco-editor/react";
 import { Panel, PanelGroup } from "react-resizable-panels";
 import { Files } from "./Files";
@@ -36,6 +31,8 @@ import Diagnostics from "./Diagnostics";
 import { editor } from "monaco-editor";
 import IStandaloneCodeEditor = editor.IStandaloneCodeEditor;
 
+const SETTINGS_FILE = "knot.json";
+
 interface CheckResult {
   diagnostics: Diagnostic[];
   error: string | null;
@@ -45,6 +42,7 @@ interface CheckResult {
 export default function Chrome() {
   const initPromise = useRef<null | Promise<void>>(null);
   const [workspace, setWorkspace] = useState<null | Workspace>(null);
+  const [updateError, setUpdateError] = useState<string | null>(null);
   const [files, dispatchFiles] = useReducer(filesReducer, {
     index: [],
     contents: Object.create(null),
@@ -60,6 +58,10 @@ export default function Chrome() {
   const editorRef = useRef<IStandaloneCodeEditor | null>(null);
   const [version, setVersion] = useState("");
   const [theme, setTheme] = useTheme();
+
+  const fileName = useMemo(() => {
+    return files.index.find((file) => file.id === files.selected)?.name ?? null;
+  }, [files.index, files.selected]);
 
   usePersistLocally(files);
 
@@ -77,13 +79,17 @@ export default function Chrome() {
   if (initPromise.current == null) {
     initPromise.current = startPlayground()
       .then(({ version, workspace: fetchedWorkspace }) => {
-        const settings = new Settings(PythonVersion.Py312);
-        const workspace = new Workspace("/", settings);
+        const workspace = new Workspace("/", {});
+
         setVersion(version);
         setWorkspace(workspace);
 
         for (const [name, content] of Object.entries(fetchedWorkspace.files)) {
-          const handle = workspace.openFile(name, content);
+          let handle = null;
+          if (name !== SETTINGS_FILE) {
+            handle = workspace.openFile(name, content);
+          }
+
           dispatchFiles({ type: "add", handle, name, content });
         }
 
@@ -109,23 +115,34 @@ export default function Chrome() {
         id: files.selected,
         content: source,
       });
-    },
-    [files.selected],
-  );
 
-  const handleFileClicked = useCallback(
-    (file: FileId) => {
-      if (workspace != null && files.selected != null) {
-        workspace.updateFile(
-          files.handles[files.selected],
-          files.contents[files.selected],
-        );
+      const handle = files.handles[files.selected];
+
+      if (handle != null) {
+        try {
+          workspace?.updateFile(handle, source);
+          setUpdateError(null);
+        } catch (error) {
+          setUpdateError(`Failed to update file: ${formatError(error)}`);
+        }
+      } else if (fileName === SETTINGS_FILE) {
+        try {
+          const settings = JSON.parse(source);
+          workspace?.updateOptions(settings);
+          setUpdateError(null);
+        } catch (error) {
+          setUpdateError(
+            `Failed to update 'knot.json' options: ${formatError(error)}`,
+          );
+        }
       }
-
-      dispatchFiles({ type: "selectFile", id: file });
     },
-    [workspace, files.contents, files.handles, files.selected],
+    [files.selected, workspace, files.handles, fileName],
   );
+
+  const handleFileClicked = useCallback((file: FileId) => {
+    dispatchFiles({ type: "selectFile", id: file });
+  }, []);
 
   const handleFileAdded = useCallback(
     (name: string) => {
@@ -133,23 +150,24 @@ export default function Chrome() {
         return;
       }
 
-      if (files.selected != null) {
-        workspace.updateFile(
-          files.handles[files.selected],
-          files.contents[files.selected],
-        );
+      let handle = null;
+
+      if (name !== SETTINGS_FILE) {
+        handle = workspace.openFile(name, "");
       }
 
-      const handle = workspace.openFile(name, "");
       dispatchFiles({ type: "add", name, handle, content: "" });
     },
-    [workspace, files.handles, files.contents, files.selected],
+    [workspace],
   );
 
   const handleFileRemoved = useCallback(
     (file: FileId) => {
       if (workspace != null) {
-        workspace.closeFile(files.handles[file]);
+        const handle = files.handles[file];
+        if (handle != null) {
+          workspace.closeFile(handle);
+        }
       }
 
       dispatchFiles({ type: "remove", id: file });
@@ -163,8 +181,15 @@ export default function Chrome() {
         return;
       }
 
-      workspace.closeFile(files.handles[file]);
-      const newHandle = workspace.openFile(newName, files.contents[file]);
+      const handle = files.handles[file];
+      let newHandle: FileHandle | null = null;
+      if (handle != null) {
+        workspace.closeFile(handle);
+      }
+
+      if (newName !== SETTINGS_FILE) {
+        newHandle = workspace.openFile(newName, files.contents[file]);
+      }
 
       editorRef.current?.focus();
 
@@ -208,6 +233,7 @@ export default function Chrome() {
   }, []);
 
   const checkResult = useCheckResult(files, workspace, secondaryTool);
+  const error = updateError ?? checkResult.error;
 
   return (
     <main className="flex flex-col h-full bg-ayu-background dark:bg-ayu-background-dark">
@@ -243,11 +269,12 @@ export default function Chrome() {
                   <Editor
                     theme={theme}
                     visible={true}
-                    onMount={handleEditorMount}
+                    fileName={fileName ?? "lib.py"}
                     source={files.contents[files.selected]}
-                    onChange={handleSourceChanged}
                     diagnostics={checkResult.diagnostics}
                     workspace={workspace}
+                    onMount={handleEditorMount}
+                    onChange={handleSourceChanged}
                   />
                   <VerticalResizeHandle />
                 </Panel>
@@ -291,7 +318,7 @@ export default function Chrome() {
         </>
       ) : null}
 
-      {checkResult.error ? (
+      {error ? (
         <div
           style={{
             position: "fixed",
@@ -300,12 +327,25 @@ export default function Chrome() {
             bottom: "10%",
           }}
         >
-          <ErrorMessage>{checkResult.error}</ErrorMessage>
+          <ErrorMessage>{error}</ErrorMessage>
         </div>
       ) : null}
     </main>
   );
 }
+
+const DEFAULT_SETTINGS = JSON.stringify(
+  {
+    environment: {
+      "python-version": "3.13",
+    },
+    rules: {
+      "division-by-zero": "error",
+    },
+  },
+  null,
+  4,
+);
 
 // Run once during startup. Initializes monaco, loads the wasm file, and restores the previous editor state.
 async function startPlayground(): Promise<{
@@ -315,12 +355,19 @@ async function startPlayground(): Promise<{
   await initRedKnot();
   const monaco = await loader.init();
 
-  setupMonaco(monaco);
+  setupMonaco(monaco, {
+    uri: "https://raw.githubusercontent.com/astral-sh/ruff/main/knot.schema.json",
+    fileMatch: ["knot.json"],
+    schema: knotSchema,
+  });
 
   const restored = await restore();
 
   const workspace = restored ?? {
-    files: { "main.py": "import os" },
+    files: {
+      "main.py": "import os",
+      "knot.json": DEFAULT_SETTINGS,
+    },
     current: "main.py",
   };
 
@@ -367,8 +414,14 @@ function useCheckResult(
     }
 
     const currentHandle = files.handles[files.selected];
-    // Update the workspace content but use the deferred value to avoid too frequent updates.
-    workspace.updateFile(currentHandle, deferredContent);
+
+    if (currentHandle == null) {
+      return {
+        diagnostics: [],
+        error: null,
+        secondary: null,
+      };
+    }
 
     try {
       const diagnostics = workspace.checkFile(currentHandle);
@@ -409,7 +462,7 @@ function useCheckResult(
 
       return {
         diagnostics: [],
-        error: (e as Error).message,
+        error: formatError(e),
         secondary: null,
       };
     }
@@ -437,8 +490,11 @@ interface FilesState {
 
   /**
    * The database file handles by file id.
+   *
+   * Files without a file handle are well-known files that are only handled by the
+   * playground (e.g. knot.json)
    */
-  handles: Readonly<{ [id: FileId]: FileHandle }>;
+  handles: Readonly<{ [id: FileId]: FileHandle | null }>;
 
   /**
    * The content per file indexed by file id.
@@ -455,7 +511,7 @@ interface FilesState {
 type FileAction =
   | {
       type: "add";
-      handle: FileHandle;
+      handle: FileHandle | null;
       /// The file name
       name: string;
       content: string;
@@ -465,7 +521,7 @@ type FileAction =
       id: FileId;
       content: string;
     }
-  | { type: "rename"; id: FileId; to: string; newHandle: FileHandle }
+  | { type: "rename"; id: FileId; to: string; newHandle: FileHandle | null }
   | {
       type: "remove";
       id: FileId;
@@ -584,4 +640,11 @@ function serializeFiles(files: FilesState): {
   }
 
   return { files: serializedFiles, current: selected };
+}
+
+function formatError(error: unknown): string {
+  const message = error instanceof Error ? error.message : `${error}`;
+  return message.startsWith("Error: ")
+    ? message.slice("Error: ".length)
+    : message;
 }

--- a/playground/knot/src/Editor/Editor.tsx
+++ b/playground/knot/src/Editor/Editor.tsx
@@ -12,6 +12,7 @@ import IStandaloneCodeEditor = editor.IStandaloneCodeEditor;
 
 type Props = {
   visible: boolean;
+  fileName: string;
   source: string;
   diagnostics: Diagnostic[];
   theme: Theme;
@@ -27,6 +28,7 @@ type MonacoEditorState = {
 export default function Editor({
   visible,
   source,
+  fileName,
   theme,
   diagnostics,
   workspace,
@@ -79,7 +81,7 @@ export default function Editor({
         scrollBeyondLastLine: false,
         contextmenu: false,
       }}
-      language={"python"}
+      path={fileName}
       wrapperProps={visible ? {} : { style: { display: "none" } }}
       theme={theme === "light" ? "Ayu-Light" : "Ayu-Dark"}
       value={source}

--- a/playground/knot/src/Editor/Files.tsx
+++ b/playground/knot/src/Editor/Files.tsx
@@ -138,6 +138,19 @@ function FileEntry({ name, onClicked, onRenamed, selected }: FileEntryProps) {
     }
   };
 
+  const extension = name.split(".").pop()?.toLowerCase();
+
+  const icon =
+    extension === "py" || extension === "pyi" ? (
+      <Icons.Python width={12} height={12} />
+    ) : extension === "json" ? (
+      <Icons.Json width={12} height={12} />
+    ) : extension === "ipynb" ? (
+      <Icons.Jupyter width={12} height={12} />
+    ) : (
+      <Icons.File width={12} height={12} />
+    );
+
   return (
     <button
       onClick={() => {
@@ -150,7 +163,7 @@ function FileEntry({ name, onClicked, onRenamed, selected }: FileEntryProps) {
       className="flex gap-2 items-center py-4 cursor-pointer"
     >
       <span className="inline-block flex-none" aria-hidden>
-        <Icons.Python width={12} height={12} />
+        {icon}
       </span>
       {newName == null ? (
         <span className="inline-block">{name}</span>
@@ -168,7 +181,7 @@ function FileEntry({ name, onClicked, onRenamed, selected }: FileEntryProps) {
 
             switch (event.key) {
               case "Enter":
-                handleRenamed(newName);
+                event.currentTarget.blur();
                 return;
               case "Escape":
                 setNewName(null);

--- a/playground/package-lock.json
+++ b/playground/package-lock.json
@@ -5885,7 +5885,7 @@
       }
     },
     "ruff/ruff_wasm": {
-      "version": "0.11.0",
+      "version": "0.11.2",
       "license": "MIT"
     },
     "shared": {

--- a/playground/ruff/src/Editor/Chrome.tsx
+++ b/playground/ruff/src/Editor/Chrome.tsx
@@ -1,3 +1,4 @@
+import ruffSchema from "../../../../ruff.schema.json";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { Header, useTheme, setupMonaco } from "shared";
 import { persist, persistLocal, restore, stringify } from "./settings";
@@ -106,7 +107,11 @@ async function startPlayground(): Promise<{
   await initRuff();
   const monaco = await loader.init();
 
-  setupMonaco(monaco);
+  setupMonaco(monaco, {
+    uri: "https://raw.githubusercontent.com/astral-sh/ruff/main/ruff.schema.json",
+    fileMatch: ["ruff.json"],
+    schema: ruffSchema,
+  });
 
   const response = await restore();
   const [settingsSource, pythonSource] = response ?? [

--- a/playground/ruff/src/Editor/SettingsEditor.tsx
+++ b/playground/ruff/src/Editor/SettingsEditor.tsx
@@ -115,6 +115,7 @@ export default function SettingsEditor({
       onMount={handleMount}
       wrapperProps={visible ? {} : { style: { display: "none" } }}
       language="json"
+      path="ruff.json"
       value={source}
       theme={theme === "light" ? "Ayu-Light" : "Ayu-Dark"}
       onChange={handleChange}

--- a/playground/shared/src/ErrorMessage.tsx
+++ b/playground/shared/src/ErrorMessage.tsx
@@ -1,11 +1,3 @@
-function truncate(str: string, length: number) {
-  if (str.length > length) {
-    return str.slice(0, length) + "...";
-  } else {
-    return str;
-  }
-}
-
 export function ErrorMessage({ children }: { children: string }) {
   return (
     <div
@@ -14,12 +6,9 @@ export function ErrorMessage({ children }: { children: string }) {
     >
       <p className="font-bold">Error</p>
       <p className="block sm:inline">
-        {truncate(
-          children.startsWith("Error: ")
-            ? children.slice("Error: ".length)
-            : children,
-          120,
-        )}
+        {children.startsWith("Error: ")
+          ? children.slice("Error: ".length)
+          : children}
       </p>
     </div>
   );

--- a/playground/shared/src/Header.tsx
+++ b/playground/shared/src/Header.tsx
@@ -5,8 +5,6 @@ import ShareButton from "./ShareButton";
 import { Theme } from "./theme";
 import VersionTag from "./VersionTag";
 
-export type Tab = "Source" | "Settings";
-
 export default function Header({
   edit,
   theme,
@@ -102,14 +100,14 @@ function Logo({
           className={className}
         >
           <path
-            fill-rule="evenodd"
-            clip-rule="evenodd"
+            fillRule="evenodd"
+            clipRule="evenodd"
             d="M431.998 9.98526C431.998 4.47055 436.469 0 441.984 0H522.013C527.528 0 531.998 4.47056 531.998 9.98526V100H485.998V70H477.998V100H431.998V9.98526ZM493.998 46V38H469.998V46H493.998Z"
             fill="#30173D"
           />
           <path
-            fill-rule="evenodd"
-            clip-rule="evenodd"
+            fillRule="evenodd"
+            clipRule="evenodd"
             d="M0 9.98526C0 4.47055 4.47055 0 9.98526 0H90.0147C95.5294 0 99.9999 4.47056 99.9999 9.98526V100H54V70H46V100H0V9.98526ZM62 46V38H38V46H62Z"
             fill="#30173D"
           />
@@ -122,8 +120,8 @@ function Logo({
             fill="#30173D"
           />
           <path
-            fill-rule="evenodd"
-            clip-rule="evenodd"
+            fillRule="evenodd"
+            clipRule="evenodd"
             d="M423.998 9.98526C423.998 4.47055 419.528 0 414.013 0H323.998V100H369.998V70H377.998V100H423.998V62H403.998V54H414.013C419.528 54 423.998 49.5294 423.998 44.0147V9.98526ZM385.998 38V46H361.998V38H385.998Z"
             fill="#30173D"
           />

--- a/playground/shared/src/Icons.tsx
+++ b/playground/shared/src/Icons.tsx
@@ -23,11 +23,17 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE
 
-export function File() {
+export function File({
+  width = 24,
+  height = 24,
+}: {
+  width?: number;
+  height?: number;
+}) {
   return (
     <svg
-      width="24"
-      height="24"
+      width={width}
+      height={height}
       viewBox="0 0 16 16"
       xmlns="http://www.w3.org/2000/svg"
     >
@@ -124,6 +130,7 @@ export function FormatterIR() {
     </svg>
   );
 }
+
 export function Comments() {
   return (
     <svg
@@ -174,7 +181,6 @@ export function Close() {
 }
 
 // https://github.com/material-extensions/vscode-material-icon-theme/blob/main/icons/python.svg
-// or use https://github.com/vscode-icons/vscode-icons/blob/master/icons/file_type_python.svg?short_path=677f216
 export function Python({
   height = 24,
   width = 24,
@@ -197,6 +203,55 @@ export function Python({
         fill="#fdd835"
         d="M17.959 7v2.68a2.85 2.85 0 0 1-2.85 2.859H9.86A2.85 2.85 0 0 0 7 15.389v3.75a2.86 2.86 0 0 0 2.86 2.86h4.28A2.86 2.86 0 0 0 17 19.14v-1.68h-4.291c-.39 0-.709-.57-.709-.96h7.14A2.86 2.86 0 0 0 22 13.64V9.86A2.86 2.86 0 0 0 19.14 7zM8.32 11.513l-.004.004c.012-.002.025-.001.038-.004zm6.54 7.276c.39 0 .71.3.71.89a.71.71 0 0 1-.71.71c-.4 0-.72-.12-.72-.71s.32-.89.72-.89z"
       />
+    </svg>
+  );
+}
+
+/** https://github.com/material-extensions/vscode-material-icon-theme/blob/main/icons/json.svg */
+export function Json({
+  height = 24,
+  width = 24,
+}: {
+  height?: number;
+  width?: number;
+}) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 -960 960 960"
+      width={width}
+      height={height}
+    >
+      <path
+        fill="#f9a825"
+        d="M560-160v-80h120q17 0 28.5-11.5T720-280v-80q0-38 22-69t58-44v-14q-36-13-58-44t-22-69v-80q0-17-11.5-28.5T680-720H560v-80h120q50 0 85 35t35 85v80q0 17 11.5 28.5T840-560h40v160h-40q-17 0-28.5 11.5T800-360v80q0 50-35 85t-85 35zm-280 0q-50 0-85-35t-35-85v-80q0-17-11.5-28.5T120-400H80v-160h40q17 0 28.5-11.5T160-600v-80q0-50 35-85t85-35h120v80H280q-17 0-28.5 11.5T240-680v80q0 38-22 69t-58 44v14q36 13 58 44t22 69v80q0 17 11.5 28.5T280-240h120v80z"
+      />
+    </svg>
+  );
+}
+
+/** https://github.com/material-extensions/vscode-material-icon-theme/blob/main/icons/jupyter.svg **/
+export function Jupyter({
+  height = 24,
+  width = 24,
+}: {
+  height?: number;
+  width?: number;
+}) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 32 32"
+      width={width}
+      height={height}
+    >
+      <path
+        fill="#f57c00"
+        d="M6.2 18a22.7 22.7 0 0 0 9.8 2 22.7 22.7 0 0 0 9.8-2 10.002 10.002 0 0 1-19.6 0m19.6-4a22.7 22.7 0 0 0-9.8-2 22.7 22.7 0 0 0-9.8 2 10.002 10.002 0 0 1 19.6 0"
+      />
+      <circle cx="27" cy="5" r="3" fill="#757575" />
+      <circle cx="5" cy="27" r="3" fill="#9e9e9e" />
+      <circle cx="5" cy="5" r="3" fill="#616161" />
     </svg>
   );
 }

--- a/playground/shared/src/setupMonaco.tsx
+++ b/playground/shared/src/setupMonaco.tsx
@@ -3,7 +3,6 @@
  */
 
 import { Monaco } from "@monaco-editor/react";
-import schema from "../../../ruff.schema.json";
 
 export const WHITE = "#ffffff";
 export const RADIATE = "#d7ff64";
@@ -26,7 +25,14 @@ export const LUNAR = "#fbf2fc";
 export const ASTEROID = "#e3cee3";
 export const CRATER = "#f0dfdf";
 
-export function setupMonaco(monaco: Monaco) {
+export function setupMonaco(
+  monaco: Monaco,
+  settingsSchema: {
+    fileMatch: [string];
+    uri: string;
+    schema: object;
+  },
+) {
   defineAyuThemes(monaco);
   defineFirLanguage(monaco);
   defineRustPythonTokensLanguage(monaco);
@@ -34,13 +40,7 @@ export function setupMonaco(monaco: Monaco) {
   defineCommentsLanguage(monaco);
 
   monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
-    schemas: [
-      {
-        uri: "https://raw.githubusercontent.com/astral-sh/ruff/main/ruff.schema.json",
-        fileMatch: ["*"],
-        schema,
-      },
-    ],
+    schemas: [settingsSchema],
   });
 }
 


### PR DESCRIPTION
## Summary

This PR extends the Red Knot playground by adding configuration support by adding a `knot.json` file.

<img width="1679" alt="Screenshot 2025-03-23 at 21 12 16" src="https://github.com/user-attachments/assets/81ff1588-a07a-4847-97d8-61250aa2feda" />


