### PR TITLE
[red-knot] simplify "removing" in UnionBuilder::add

### DIFF
--- a/crates/red_knot_python_semantic/src/types/builder.rs
+++ b/crates/red_knot_python_semantic/src/types/builder.rs
@@ -110,25 +110,14 @@ impl<'db> UnionBuilder<'db> {
                         return self.collapse_to_object();
                     }
                 }
-                match to_remove[..] {
-                    [] => self.elements.push(to_add),
-                    [index] => self.elements[index] = to_add,
-                    _ => {
-                        let mut current_index = 0;
-                        let mut to_remove = to_remove.into_iter();
-                        let mut next_to_remove_index = to_remove.next();
-                        self.elements.retain(|_| {
-                            let retain = if Some(current_index) == next_to_remove_index {
-                                next_to_remove_index = to_remove.next();
-                                false
-                            } else {
-                                true
-                            };
-                            current_index += 1;
-                            retain
-                        });
-                        self.elements.push(to_add);
+                if let Some((&first, rest)) = to_remove.split_first() {
+                    self.elements[first] = to_add;
+                    // We iterate in descending order to keep remaining indices valid after `swap_remove`.
+                    for &index in rest.iter().rev() {
+                        self.elements.swap_remove(index);
                     }
+                } else {
+                    self.elements.push(to_add);
                 }
             }
         }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Simplify "removing" in UnionBuilder::add
It's now O(m) instead of O(n + m) and easier to read.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
cargo test (incl. mdtest)