### PR TITLE
[red-knot] Default playground to Python 3.13 for real

### DIFF
--- a/playground/knot/src/Editor/Chrome.tsx
+++ b/playground/knot/src/Editor/Chrome.tsx
@@ -99,7 +99,7 @@ export default function Chrome() {
         }
 
         if (!hasSettings) {
-          workspace.updateOptions(null);
+          updateOptions(workspace, null, setUpdateError);
         }
 
         dispatchFiles({


### PR DESCRIPTION
## Summary

Default to 3.13 for good. 

I incorrectly used `workspace.updateOptions` instead of `updateOptions` where the latter has a fallback.

## Test Plan

```py
import os

import sys

reveal_type(sys.version_info.minor)
```

reveals 13 on initial page load
