### PR TITLE
[red-knot] Make every type a subtype of object

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
@@ -988,5 +988,29 @@ static_assert(is_subtype_of(CallableTypeFromFunction[mixed], CallableTypeFromFun
 static_assert(not is_subtype_of(CallableTypeFromFunction[empty], CallableTypeFromFunction[mixed]))
 ```
 
+#### Object
+
+```py
+from knot_extensions import CallableTypeFromFunction, is_subtype_of, static_assert, TypeOf
+from typing import Callable
+
+def f1(a: int, b: str, /, *c: float, d: int = 1, **e: float) -> None: ...
+
+static_assert(is_subtype_of(CallableTypeFromFunction[f1], object))
+static_assert(not is_subtype_of(object, CallableTypeFromFunction[f1]))
+
+def _(
+    f3: Callable[[int, str], None],
+) -> None:
+    static_assert(is_subtype_of(TypeOf[f3], object))
+    static_assert(not is_subtype_of(object, TypeOf[f3]))
+
+class C:
+    def foo(self) -> None: ...
+
+static_assert(is_subtype_of(TypeOf[C.foo], object))
+static_assert(not is_subtype_of(object, TypeOf[C.foo]))
+```
+
 [special case for float and complex]: https://typing.readthedocs.io/en/latest/spec/special-types.html#special-cases-for-float-and-complex
 [typing documentation]: https://typing.readthedocs.io/en/latest/spec/concepts.html#subtype-supertype-and-type-equivalence

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -554,7 +554,7 @@ impl<'db> Type<'db> {
 
         match (self, target) {
             // Everything is a subtype of `object`.
-            (_, ty) if ty.is_object(db) => true,
+            (_, Type::Instance(InstanceType { class })) if class.is_object(db) => true,
 
             // We should have handled these immediately above.
             (Type::Dynamic(_), _) | (_, Type::Dynamic(_)) => {
@@ -764,7 +764,7 @@ impl<'db> Type<'db> {
 
             // All types are assignable to `object`.
             // TODO this special case might be removable once the below cases are comprehensive
-            (_, ty) if ty.is_object(db) => true,
+            (_, Type::Instance(InstanceType { class })) if class.is_object(db) => true,
 
             // A union is assignable to a type T iff every element of the union is assignable to T.
             (Type::Union(union), ty) => union


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Mainly for partially fixing #16953

## Test Plan

Update is_subtype tests. And should maybe do these checks for many other types (is subtype of object but object is not subtype)
