### PR TITLE
[red-knot] Use `web-time` instead of `FileTime::now`

### DIFF
--- a/crates/red_knot/tests/file_watching.rs
+++ b/crates/red_knot/tests/file_watching.rs
@@ -12,7 +12,7 @@ use red_knot_python_semantic::{resolve_module, ModuleName, PythonPlatform};
 use ruff_db::files::{system_path_to_file, File, FileError};
 use ruff_db::source::source_text;
 use ruff_db::system::{
-    OsSystem, System, SystemPath, SystemPathBuf, UserConfigDirectoryOverrideGuard,
+    file_time_now, OsSystem, System, SystemPath, SystemPathBuf, UserConfigDirectoryOverrideGuard,
 };
 use ruff_db::{Db as _, Upcast};
 use ruff_python_ast::PythonVersion;
@@ -462,7 +462,7 @@ fn update_file(path: impl AsRef<SystemPath>, content: &str) -> anyhow::Result<()
 
         std::thread::sleep(Duration::from_nanos(10));
 
-        filetime::set_file_handle_times(&file, None, Some(filetime::FileTime::now()))?;
+        filetime::set_file_handle_times(&file, None, Some(file_time_now()))?;
     }
 }
 

--- a/crates/ruff_db/src/file_revision.rs
+++ b/crates/ruff_db/src/file_revision.rs
@@ -1,3 +1,5 @@
+use crate::system::file_time_now;
+
 /// A number representing the revision of a file.
 ///
 /// Two revisions that don't compare equal signify that the file has been modified.
@@ -16,7 +18,7 @@ impl FileRevision {
     }
 
     pub fn now() -> Self {
-        Self::from(filetime::FileTime::now())
+        Self::from(file_time_now())
     }
 
     pub const fn zero() -> Self {
@@ -53,13 +55,12 @@ impl From<filetime::FileTime> for FileRevision {
 
 #[cfg(test)]
 mod tests {
-    use filetime::FileTime;
 
     use super::*;
 
     #[test]
     fn revision_from_file_time() {
-        let file_time = FileTime::now();
+        let file_time = file_time_now();
         let revision = FileRevision::from(file_time);
 
         let revision = revision.as_u128();


### PR DESCRIPTION
## Summary

`std::time::now` isn't available on `wasm32-unknown-unknown` but it is used by `FileTime::now`. 

This PR replaces the usages of `FileTime::now` with a target specific helper function that we already had in the memory file system.
Fixes https://github.com/astral-sh/ruff/issues/16966

## Test Plan

Tested that the playground no longer crash when adding an extra-path

