### PR TITLE
Check `pyproject.toml` correctly when it is passed via stdin

### DIFF
--- a/crates/ruff/src/diagnostics.rs
+++ b/crates/ruff/src/diagnostics.rs
@@ -381,6 +381,15 @@ pub(crate) fn lint_stdin(
             SourceType::Python(source_type) => source_type,
 
             SourceType::Toml(source_type) if source_type.is_pyproject() => {
+                if !settings
+                    .linter
+                    .rules
+                    .iter_enabled()
+                    .any(|rule_code| rule_code.lint_source().is_pyproject_toml())
+                {
+                    return Ok(Diagnostics::default());
+                }
+
                 let path = path.unwrap();
                 let source_file =
                     SourceFileBuilder::new(path.to_string_lossy(), contents.clone()).finish();

--- a/crates/ruff/src/diagnostics.rs
+++ b/crates/ruff/src/diagnostics.rs
@@ -398,7 +398,7 @@ pub(crate) fn lint_stdin(
                 });
             }
 
-            _ => return Ok(Diagnostics::default()),
+            SourceType::Toml(_) => return Ok(Diagnostics::default()),
         },
         Some(language) => PySourceType::from(language),
     };

--- a/crates/ruff/src/diagnostics.rs
+++ b/crates/ruff/src/diagnostics.rs
@@ -387,7 +387,7 @@ pub(crate) fn lint_stdin(
 
                 match fix_mode {
                     flags::FixMode::Diff | flags::FixMode::Generate => {}
-                    flags::FixMode::Apply => write!(&mut io::stdout().lock(), "{}", contents)?,
+                    flags::FixMode::Apply => write!(&mut io::stdout().lock(), "{contents}")?,
                 }
 
                 return Ok(Diagnostics {

--- a/crates/ruff/tests/integration_test.rs
+++ b/crates/ruff/tests/integration_test.rs
@@ -2235,7 +2235,7 @@ unfixable = ["RUF"]
 }
 
 #[test]
-fn pyproject_toml_stdin_syntax_error() -> Result<()> {
+fn pyproject_toml_stdin_syntax_error() {
     let mut cmd = RuffCheck::default()
         .args(["--stdin-filename", "pyproject.toml", "--select", "RUF200"])
         .build();
@@ -2258,12 +2258,10 @@ fn pyproject_toml_stdin_syntax_error() -> Result<()> {
     ----- stderr -----
     "
     );
-
-    Ok(())
 }
 
 #[test]
-fn pyproject_toml_stdin_schema_error() -> Result<()> {
+fn pyproject_toml_stdin_schema_error() {
     let mut cmd = RuffCheck::default()
         .args(["--stdin-filename", "pyproject.toml", "--select", "RUF200"])
         .build();
@@ -2286,12 +2284,10 @@ fn pyproject_toml_stdin_schema_error() -> Result<()> {
     ----- stderr -----
     "
     );
-
-    Ok(())
 }
 
 #[test]
-fn pyproject_toml_stdin_no_applicable_rules_selected() -> Result<()> {
+fn pyproject_toml_stdin_no_applicable_rules_selected() {
     let mut cmd = RuffCheck::default()
         .args(["--stdin-filename", "pyproject.toml"])
         .build();
@@ -2307,12 +2303,10 @@ fn pyproject_toml_stdin_no_applicable_rules_selected() -> Result<()> {
     ----- stderr -----
     "
     );
-
-    Ok(())
 }
 
 #[test]
-fn pyproject_toml_stdin_no_errors() -> Result<()> {
+fn pyproject_toml_stdin_no_errors() {
     let mut cmd = RuffCheck::default()
         .args(["--stdin-filename", "pyproject.toml"])
         .build();
@@ -2328,12 +2322,10 @@ fn pyproject_toml_stdin_no_errors() -> Result<()> {
     ----- stderr -----
     "
     );
-
-    Ok(())
 }
 
 #[test]
-fn pyproject_toml_stdin_schema_error_fix() -> Result<()> {
+fn pyproject_toml_stdin_schema_error_fix() {
     let mut cmd = RuffCheck::default()
         .args([
             "--stdin-filename",
@@ -2362,12 +2354,10 @@ fn pyproject_toml_stdin_schema_error_fix() -> Result<()> {
     Found 1 error.
     "
     );
-
-    Ok(())
 }
 
 #[test]
-fn pyproject_toml_stdin_schema_error_fix_diff() -> Result<()> {
+fn pyproject_toml_stdin_schema_error_fix_diff() {
     let mut cmd = RuffCheck::default()
         .args([
             "--stdin-filename",
@@ -2389,6 +2379,4 @@ fn pyproject_toml_stdin_schema_error_fix_diff() -> Result<()> {
     ----- stderr -----
     "
     );
-
-    Ok(())
 }

--- a/crates/ruff/tests/integration_test.rs
+++ b/crates/ruff/tests/integration_test.rs
@@ -2342,7 +2342,8 @@ fn pyproject_toml_stdin_schema_error_fix() {
     success: false
     exit_code: 1
     ----- stdout -----
-
+    [project]
+    name = 1
     ----- stderr -----
     pyproject.toml:2:8: RUF200 Failed to parse pyproject.toml: invalid type: integer `1`, expected a string
       |
@@ -2352,6 +2353,31 @@ fn pyproject_toml_stdin_schema_error_fix() {
       |
 
     Found 1 error.
+    "
+    );
+}
+
+#[test]
+fn pyproject_toml_stdin_schema_error_fix_only() {
+    let mut cmd = RuffCheck::default()
+        .args([
+            "--stdin-filename",
+            "pyproject.toml",
+            "--select",
+            "RUF200",
+            "--fix-only",
+        ])
+        .build();
+
+    assert_cmd_snapshot!(
+        cmd.pass_stdin("[project]\nname = 1"),
+        @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    [project]
+    name = 1
+    ----- stderr -----
     "
     );
 }

--- a/crates/ruff/tests/integration_test.rs
+++ b/crates/ruff/tests/integration_test.rs
@@ -2306,6 +2306,25 @@ fn pyproject_toml_stdin_no_applicable_rules_selected() {
 }
 
 #[test]
+fn pyproject_toml_stdin_no_applicable_rules_selected_2() {
+    let mut cmd = RuffCheck::default()
+        .args(["--stdin-filename", "pyproject.toml", "--select", "F401"])
+        .build();
+
+    assert_cmd_snapshot!(
+        cmd.pass_stdin("[project"),
+        @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    All checks passed!
+
+    ----- stderr -----
+    "
+    );
+}
+
+#[test]
 fn pyproject_toml_stdin_no_errors() {
     let mut cmd = RuffCheck::default()
         .args(["--stdin-filename", "pyproject.toml"])

--- a/crates/ruff/tests/integration_test.rs
+++ b/crates/ruff/tests/integration_test.rs
@@ -2233,3 +2233,162 @@ unfixable = ["RUF"]
 
     Ok(())
 }
+
+#[test]
+fn pyproject_toml_stdin_syntax_error() -> Result<()> {
+    let mut cmd = RuffCheck::default()
+        .args(["--stdin-filename", "pyproject.toml", "--select", "RUF200"])
+        .build();
+
+    assert_cmd_snapshot!(
+        cmd.pass_stdin("[project"),
+        @r"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    pyproject.toml:1:9: RUF200 Failed to parse pyproject.toml: invalid table header
+    expected `.`, `]`
+      |
+    1 | [project
+      |         ^ RUF200
+      |
+
+    Found 1 error.
+
+    ----- stderr -----
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn pyproject_toml_stdin_schema_error() -> Result<()> {
+    let mut cmd = RuffCheck::default()
+        .args(["--stdin-filename", "pyproject.toml", "--select", "RUF200"])
+        .build();
+
+    assert_cmd_snapshot!(
+        cmd.pass_stdin("[project]\nname = 1"),
+        @r"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    pyproject.toml:2:8: RUF200 Failed to parse pyproject.toml: invalid type: integer `1`, expected a string
+      |
+    1 | [project]
+    2 | name = 1
+      |        ^ RUF200
+      |
+
+    Found 1 error.
+
+    ----- stderr -----
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn pyproject_toml_stdin_no_applicable_rules_selected() -> Result<()> {
+    let mut cmd = RuffCheck::default()
+        .args(["--stdin-filename", "pyproject.toml"])
+        .build();
+
+    assert_cmd_snapshot!(
+        cmd.pass_stdin("[project"),
+        @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    All checks passed!
+
+    ----- stderr -----
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn pyproject_toml_stdin_no_errors() -> Result<()> {
+    let mut cmd = RuffCheck::default()
+        .args(["--stdin-filename", "pyproject.toml"])
+        .build();
+
+    assert_cmd_snapshot!(
+        cmd.pass_stdin(r#"[project]\nname = "ruff"\nversion = "0.0.0""#),
+        @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    All checks passed!
+
+    ----- stderr -----
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn pyproject_toml_stdin_schema_error_fix() -> Result<()> {
+    let mut cmd = RuffCheck::default()
+        .args([
+            "--stdin-filename",
+            "pyproject.toml",
+            "--select",
+            "RUF200",
+            "--fix",
+        ])
+        .build();
+
+    assert_cmd_snapshot!(
+        cmd.pass_stdin("[project]\nname = 1"),
+        @r"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    pyproject.toml:2:8: RUF200 Failed to parse pyproject.toml: invalid type: integer `1`, expected a string
+      |
+    1 | [project]
+    2 | name = 1
+      |        ^ RUF200
+      |
+
+    Found 1 error.
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn pyproject_toml_stdin_schema_error_fix_diff() -> Result<()> {
+    let mut cmd = RuffCheck::default()
+        .args([
+            "--stdin-filename",
+            "pyproject.toml",
+            "--select",
+            "RUF200",
+            "--fix",
+            "--diff",
+        ])
+        .build();
+
+    assert_cmd_snapshot!(
+        cmd.pass_stdin("[project]\nname = 1"),
+        @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    "
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Resolves #16950 and [a 1.5-year-old TODO comment](https://github.com/astral-sh/ruff/blame/8d16a5c8c98089b0d1be3e3fd68954be62dd2598/crates/ruff/src/diagnostics.rs#L380).

After this change, a `pyproject.toml` will be linted the same as any Python files would when passed via stdin.

## Test Plan

Integration tests.
