### PR TITLE
[red-knot] `reveal-type` should return the revaled type

### DIFF
--- a/.github/workflows/publish-knot-playground.yml
+++ b/.github/workflows/publish-knot-playground.yml
@@ -8,10 +8,10 @@ on:
     branches: [main]
     paths:
       - "crates/red_knot*/**"
-      - "crates/ruff_db"
-      - "crates/ruff_python_ast"
-      - "crates/ruff_python_parser"
-      - "playground"
+      - "crates/ruff_db/**"
+      - "crates/ruff_python_ast/**"
+      - "crates/ruff_python_parser/**"
+      - "playground/**"
       - ".github/workflows/publish-knot-playground.yml"
 
 concurrency:

--- a/playground/knot/src/Editor/SecondaryPanel.tsx
+++ b/playground/knot/src/Editor/SecondaryPanel.tsx
@@ -144,20 +144,42 @@ function RunWithPyiodide({
 
       const main = files.selected == null ? "" : files.contents[files.selected];
 
+      let fileName = "main.py";
       for (const file of files.index) {
         pyodide.FS.writeFile(file.name, files.contents[file.id]);
+
+        if (file.id === files.selected) {
+          fileName = file.name;
+        }
       }
+
+      const dict = pyodide.globals.get("dict");
+      const globals = dict();
 
       try {
         // Patch up reveal types
         pyodide.runPython(`
         import builtins
-        builtins.reveal_type = print`);
 
-        pyodide.runPython(main);
+        def reveal_type(obj):
+          import typing
+          print(f"Runtime value is: \`{obj}\`")
+          return typing.reveal_type(obj)
+
+        builtins.reveal_type = reveal_type`);
+
+        pyodide.runPython(main, {
+          globals,
+          locals: globals,
+          filename: fileName,
+        });
+
         setOutput(stdout);
       } catch (e) {
         setOutput(`Failed to run Python script: ${e}`);
+      } finally {
+        globals.destroy();
+        dict.destroy();
       }
     };
     return (


### PR DESCRIPTION
## Summary

Return the revealed-type from the monkey-patched `revale_type` implementation to 
preserve the identity behavior.

This PR also isolates different script runs by assigning a different `globals` dict for each script-run. See https://github.com/pyodide/pyodide/issues/703
