### PR TITLE
[red-knot] resolve instance attributes bound in nested scopes

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/attributes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/attributes.md
@@ -402,9 +402,7 @@ class C:
 
 c_instance = C()
 
-# TODO: Should be `Unknown | int`
-# error: [unresolved-attribute]
-reveal_type(c_instance.a)  # revealed: Unknown
+reveal_type(c_instance.a)  # revealed: Unknown | int
 ```
 
 #### Conditionally declared / bound attributes
@@ -1656,9 +1654,37 @@ class C:
             self.x: str = value
         set_attribute("a")
 
-# TODO: ideally, this would be `str`. Mypy supports this, pyright does not.
+reveal_type(C().x)  # revealed: str
+```
+
+### Assignment to `self` from nested comprehension
+
+```py
+class C:
+    def __init__(self) -> None:
+        [... for self.x in [1]]
+
+reveal_type(C().x)  # revealed: Unknown | @Todo(generics)
+```
+
+### Assignment to `self` from nested class
+
+```py
+class C:
+    def __init__(self) -> None:
+        class D:
+            self.x: int = 1
+            def f(_):
+                self.y: int = 1
+
+    def g(self):
+        def h(self):
+            self.z: int = 1
+
+reveal_type(C().x)  # revealed: int
+reveal_type(C().y)  # revealed: int
 # error: [unresolved-attribute]
-reveal_type(C().x)  # revealed: Unknown
+C().z
 ```
 
 ### Accessing attributes on `Never`

--- a/crates/red_knot_python_semantic/src/semantic_index/attribute_assignment.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/attribute_assignment.rs
@@ -20,6 +20,7 @@ pub(crate) enum AttributeAssignment<'db> {
 
     /// An attribute assignment where the right-hand side is an iterable, for example
     /// `for self.x in <iterable>`.
+    /// This is also used for comprehensions, e.g. `[... for self.x in <iterable>]`.
     Iterable { iterable: Expression<'db> },
 
     /// An attribute assignment where the expression to be assigned is a context manager, for example


### PR DESCRIPTION
## Summary

This PR closes #17008.

Instance attributes bound in nested scopes are now accessible from the instance.

## Test Plan

New test cases are added to `mdtest/attributes.md`, and [this test case](https://github.com/astral-sh/ruff/blob/main/crates/red_knot_python_semantic/resources/mdtest/attributes.md#attributes-defined-in-comprehensions) now passes correctly.