### PR TITLE
[playground] Fix `reveal_type`

### DIFF
--- a/playground/knot/src/Editor/SecondaryPanel.tsx
+++ b/playground/knot/src/Editor/SecondaryPanel.tsx
@@ -134,13 +134,14 @@ function RunWithPyiodide({
 
   if (output == null) {
     const handleRun = () => {
-      let stdout = "";
+      let combined_output = "";
 
-      pyodide.setStdout({
-        batched(output) {
-          stdout += output + "\n";
-        },
-      });
+      const outputHandler = (output: string) => {
+        combined_output += output + "\n";
+      };
+
+      pyodide.setStdout({ batched: outputHandler });
+      pyodide.setStderr({ batched: outputHandler });
 
       const main = files.selected == null ? "" : files.contents[files.selected];
 
@@ -163,7 +164,7 @@ function RunWithPyiodide({
 
         def reveal_type(obj):
           import typing
-          print(f"Runtime value is: \`{obj}\`")
+          print(f"Runtime value is '{obj}'")
           return typing.reveal_type(obj)
 
         builtins.reveal_type = reveal_type`);
@@ -174,7 +175,7 @@ function RunWithPyiodide({
           filename: fileName,
         });
 
-        setOutput(stdout);
+        setOutput(combined_output);
       } catch (e) {
         setOutput(`Failed to run Python script: ${e}`);
       } finally {


### PR DESCRIPTION
## Summary

Capture both `stdout` and `stderr` in a single stream. This fixes `reveal_type`, which prints to `stderr` by default.

## Test Plan

Tested with a simple `reveal_type(1)` example and got the output:
```
Runtime value is '1'
Runtime type is 'int'
```