### PR TITLE
[red-knot] Fix syntax highlighting for pyi files

### DIFF
--- a/playground/knot/src/Editor/Editor.tsx
+++ b/playground/knot/src/Editor/Editor.tsx
@@ -81,6 +81,7 @@ export default function Editor({
         scrollBeyondLastLine: false,
         contextmenu: false,
       }}
+      language={fileName.endsWith(".pyi") ? "python" : undefined}
       path={fileName}
       wrapperProps={visible ? {} : { style: { display: "none" } }}
       theme={theme === "light" ? "Ayu-Light" : "Ayu-Dark"}


### PR DESCRIPTION
Monaco supports inferring the language based on the file's extension but it doesn't seem to support `pyi`. I tried to patch up the python language definition by adding `.pyi` to the language's `extension` array but that didn't work. That's why I decided to patch up the language in React.