### PR TITLE
[red-knot] Don't check non-python files

### DIFF
--- a/crates/red_knot_wasm/src/lib.rs
+++ b/crates/red_knot_wasm/src/lib.rs
@@ -214,6 +214,10 @@ impl FileHandle {
     pub fn js_to_string(&self) -> String {
         format!("file(id: {:?}, path: {})", self.file, self.path)
     }
+
+    pub fn path(&self) -> String {
+        self.path.to_string()
+    }
 }
 
 #[wasm_bindgen]

--- a/playground/knot/src/Editor/Chrome.tsx
+++ b/playground/knot/src/Editor/Chrome.tsx
@@ -220,7 +220,9 @@ function useCheckResult(
 
     const currentHandle = files.handles[files.selected];
 
-    if (currentHandle == null) {
+    const extension =
+      currentHandle?.path()?.toLowerCase().split(".").pop() ?? "";
+    if (currentHandle == null || !["py", "pyi", "pyw"].includes(extension)) {
       return {
         diagnostics: [],
         error: null,


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ruff/issues/17018

## Test Plan

I renamed a python file to `knot.toml` and verified that there are no diagnostics. Renaming back the file to `*.py` brings back the diagnostics
