### PR TITLE
mypy_primer: add typeshed-stats

### DIFF
--- a/.github/workflows/mypy_primer.yaml
+++ b/.github/workflows/mypy_primer.yaml
@@ -68,7 +68,7 @@ jobs:
             --type-checker knot \
             --old base_commit \
             --new "$GITHUB_SHA" \
-            --project-selector '/(mypy_primer|black|pyp|git-revise|zipp|arrow|isort|itsdangerous|rich|packaging|pybind11|pyinstrument)$' \
+            --project-selector '/(mypy_primer|black|pyp|git-revise|zipp|arrow|isort|itsdangerous|rich|packaging|pybind11|pyinstrument|typeshed-stats)$' \
             --output concise \
             --debug > mypy_primer.diff || [ $? -eq 1 ]
 


### PR DESCRIPTION
This is a well-typed codebase on which we only emit 23 diagnostics right now, but which is highlighting some interesting issues. It uses some modern syntactic features such as `match` statements that aren't used much in other open-source projects in mypy_primer
