### PR TITLE
 [red-knot] support narrowing on or patterns in matches

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/match.md
@@ -82,13 +82,8 @@ match x:
         reveal_type(x)  # revealed: Literal[42]
     case 6.0:
         reveal_type(x)  # revealed: float
-<<<<<<< HEAD
     case 1j:
         reveal_type(x)  # revealed: complex
-=======
-    case 1 + 1j:
-        reveal_type(x)  # revealed: int | float | complex
->>>>>>> bf3ccec66 (add narrowing for match value patterns)
     case b"foo":
         reveal_type(x)  # revealed: Literal[b"foo"]
 
@@ -115,6 +110,53 @@ match x:
     case 1j if reveal_type(x):  # revealed: complex
         pass
     case b"foo" if reveal_type(x):  # revealed: Literal[b"foo"]
+        pass
+
+reveal_type(x)  # revealed: object
+```
+
+## Or patterns
+
+```py
+def get_object() -> object:
+    return object()
+
+x = get_object()
+
+reveal_type(x)  # revealed: object
+
+match x:
+    case "foo" | 42 | None:
+        reveal_type(x)  # revealed: Literal["foo", 42] | None
+    case "foo" | tuple():
+        # kill lamumbo
+        reveal_type(x)  # revealed: Literal["foo"] | tuple
+    case True | False:
+        reveal_type(x)  # revealed: bool
+    case 3.14 | 2.718 | 1.414:
+        reveal_type(x)  # revealed: float
+
+reveal_type(x)  # revealed: object
+```
+
+## Or patterns with guard
+
+```py
+def get_object() -> object:
+    return object()
+
+x = get_object()
+
+reveal_type(x)  # revealed: object
+
+match x:
+    case "foo" | 42 | None if reveal_type(x):  # revealed: Literal["foo", 42] | None
+        pass
+    case "foo" | tuple() if reveal_type(x):  # revealed: Literal["foo"] | tuple
+        pass
+    case True | False if reveal_type(x):  # revealed: bool
+        pass
+    case 3.14 | 2.718 | 1.414 if reveal_type(x):  # revealed: float
         pass
 
 reveal_type(x)  # revealed: object

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/match.md
@@ -82,8 +82,13 @@ match x:
         reveal_type(x)  # revealed: Literal[42]
     case 6.0:
         reveal_type(x)  # revealed: float
+<<<<<<< HEAD
     case 1j:
         reveal_type(x)  # revealed: complex
+=======
+    case 1 + 1j:
+        reveal_type(x)  # revealed: int | float | complex
+>>>>>>> bf3ccec66 (add narrowing for match value patterns)
     case b"foo":
         reveal_type(x)  # revealed: Literal[b"foo"]
 

--- a/crates/red_knot_python_semantic/src/semantic_index/predicate.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/predicate.rs
@@ -59,6 +59,7 @@ pub(crate) enum PredicateNode<'db> {
 pub(crate) enum PatternPredicateKind<'db> {
     Singleton(Singleton, Option<Expression<'db>>),
     Value(Expression<'db>, Option<Expression<'db>>),
+    Or(Vec<PatternPredicateKind<'db>>, Option<Expression<'db>>),
     Class(Expression<'db>, Option<Expression<'db>>),
     Unsupported,
 }

--- a/crates/red_knot_python_semantic/src/semantic_index/visibility_constraints.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/visibility_constraints.rs
@@ -581,6 +581,7 @@ impl VisibilityConstraints {
                 }
                 PatternPredicateKind::Singleton(..)
                 | PatternPredicateKind::Class(..)
+                | PatternPredicateKind::Or(..)
                 | PatternPredicateKind::Unsupported => Truthiness::Ambiguous,
             },
         }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2119,6 +2119,11 @@ impl<'db> TypeInferenceBuilder<'db> {
                 }
                 self.infer_standalone_expression(cls);
             }
+            ast::Pattern::MatchOr(match_or) => {
+                for pattern in &match_or.patterns {
+                    self.infer_match_pattern(pattern);
+                }
+            }
             _ => {
                 self.infer_nested_match_pattern(pattern);
             }

--- a/crates/red_knot_python_semantic/src/types/narrow.rs
+++ b/crates/red_knot_python_semantic/src/types/narrow.rs
@@ -505,24 +505,6 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
         Some(NarrowingConstraints::from_iter([(symbol, ty)]))
     }
 
-    fn evaluate_match_pattern_value(
-        &mut self,
-        subject: Expression<'db>,
-        value: Expression<'db>,
-    ) -> Option<NarrowingConstraints<'db>> {
-        // TODO: DRY
-        let ast::ExprName { id, .. } = subject.node_ref(self.db).as_name_expr()?;
-        let symbol = self
-            .symbols()
-            .symbol_id_by_name(id)
-            .expect("We should always have a symbol for every `Name` node");
-        let ty = infer_same_file_expression_type(self.db, value);
-        let mut constraints = NarrowingConstraints::default();
-        constraints.insert(symbol, ty);
-
-        Some(constraints)
-    }
-
     fn evaluate_bool_op(
         &mut self,
         expr_bool_op: &ExprBoolOp,

--- a/crates/red_knot_python_semantic/src/types/narrow.rs
+++ b/crates/red_knot_python_semantic/src/types/narrow.rs
@@ -505,6 +505,24 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
         Some(NarrowingConstraints::from_iter([(symbol, ty)]))
     }
 
+    fn evaluate_match_pattern_value(
+        &mut self,
+        subject: Expression<'db>,
+        value: Expression<'db>,
+    ) -> Option<NarrowingConstraints<'db>> {
+        // TODO: DRY
+        let ast::ExprName { id, .. } = subject.node_ref(self.db).as_name_expr()?;
+        let symbol = self
+            .symbols()
+            .symbol_id_by_name(id)
+            .expect("We should always have a symbol for every `Name` node");
+        let ty = infer_same_file_expression_type(self.db, value);
+        let mut constraints = NarrowingConstraints::default();
+        constraints.insert(symbol, ty);
+
+        Some(constraints)
+    }
+
     fn evaluate_bool_op(
         &mut self,
         expr_bool_op: &ExprBoolOp,


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Part of #13694
<!-- What's the purpose of the change? What does it do, and why? -->
Narrow in or-patterns by taking the type union of the type constraints in each disjunct pattern.

## Test Plan

Add new tests to narrow/match.md
