### PR TITLE
[red-knot] Handle special case returning `NotImplemented`

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/function/return_type.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/function/return_type.md
@@ -270,11 +270,10 @@ def f(cond: bool) -> int:
         return 2
 ```
 
-## NotImplement
+## NotImplemented
 
-`NotImplement` is a special symbol in Python. It is commonly used to control the fallback behavior
-of special dunder methods.\
-You can find more details in the
+`NotImplemented` is a special symbol in Python. It is commonly used to control the fallback behavior
+of special dunder methods. You can find more details in the
 [documentation](https://docs.python.org/3/library/numbers.html#implementing-the-arithmetic-operations).
 
 ```py

--- a/crates/red_knot_python_semantic/resources/mdtest/function/return_type.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/function/return_type.md
@@ -304,4 +304,11 @@ def f(x: int) -> int | str:
         return NotImplemented
     else:
         return "test"
+
+def f(cond: bool) -> str:
+    return "hello" if cond else NotImplemented
+
+def f(cond: bool) -> int:
+    # error: [invalid-return-type] "Object of type `Literal["hello"]` is not assignable to return type `int`"
+    return "hello" if cond else NotImplemented
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/function/return_type.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/function/return_type.md
@@ -269,3 +269,39 @@ def f(cond: bool) -> int:
     if cond:
         return 2
 ```
+
+## NotImplement
+
+`NotImplement` is a special symbol in Python. It is commonly used to control the fallback behavior
+of special dunder methods.\
+You can find more details in the
+[documentation](https://docs.python.org/3/library/numbers.html#implementing-the-arithmetic-operations).
+
+```py
+from __future__ import annotations
+
+class A:
+    def __add__(self, o: A) -> A:
+        return NotImplemented
+```
+
+However, as shown below, `NotImplemented` should not cause issues with the declared return type.
+
+```py
+def f() -> int:
+    return NotImplemented
+
+def f(cond: bool) -> int:
+    if cond:
+        return 1
+    else:
+        return NotImplemented
+
+def f(x: int) -> int | str:
+    if x < 0:
+        return -1
+    elif x == 0:
+        return NotImplemented
+    else:
+        return "test"
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_singleton.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_singleton.md
@@ -99,8 +99,8 @@ static_assert(is_singleton(types.EllipsisType))
 
 ### All Python versions
 
-Just like `Ellipsis`, the type of `NotImplemented` was not exposed on Python \<3.10.\
-However, we still recognize the type as a singleton in all Python versions.
+Just like `Ellipsis`, the type of `NotImplemented` was not exposed on Python \<3.10. However, we
+still recognize the type as a singleton in all Python versions.
 
 ```toml
 [environment]

--- a/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_singleton.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_singleton.md
@@ -115,7 +115,7 @@ static_assert(is_singleton(NotImplemented.__class__))
 
 ### Python 3.10+
 
-On Python 3.10+, the standard library exposes the type of `NotImplemented` as\
+On Python 3.10+, the standard library exposes the type of `NotImplemented` as
 `types.NotImplementedType`. We also recognize this as a singleton type when it is referenced
 directly:
 

--- a/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_singleton.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_singleton.md
@@ -72,7 +72,6 @@ python-version = "3.9"
 ```
 
 ```py
-import sys
 from knot_extensions import is_singleton, static_assert
 
 static_assert(is_singleton(Ellipsis.__class__))
@@ -94,4 +93,43 @@ import types
 from knot_extensions import static_assert, is_singleton
 
 static_assert(is_singleton(types.EllipsisType))
+```
+
+## `builtins.NotImplemented` / `types.NotImplementedType`
+
+### All Python versions
+
+Just like `Ellipsis`, the type of `NotImplemented` was not exposed on Python \<3.10.\
+However, we still recognize the type as a singleton in all Python versions.
+
+```toml
+[environment]
+python-version = "3.9"
+```
+
+```py
+from knot_extensions import is_singleton, static_assert
+
+static_assert(is_singleton(NotImplemented.__class__))
+```
+
+### Python 3.10+
+
+On Python 3.10+, the standard library exposes the type of `NotImplemented` as\
+`types.NotImplementedType`. We also recognize this as a singleton type when it is referenced
+directly:
+
+```toml
+[environment]
+python-version = "3.10"
+```
+
+```py
+import types
+from knot_extensions import static_assert, is_singleton
+
+# TODO: types.NotImplementedType is a TypeAlias of builtins._NotImplementedType
+# Once TypeAlias support is added, it should satisfy `is_singleton`
+reveal_type(types.NotImplementedType)  # revealed: Unknown | Literal[_NotImplementedType]
+static_assert(not is_singleton(types.NotImplementedType))
 ```

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -4983,6 +4983,10 @@ impl<'db> UnionType<'db> {
         Self::from_elements(db, self.elements(db).iter().map(transform_fn))
     }
 
+    pub fn filter(&self, db: &'db dyn Db, filter_fn: impl FnMut(&&Type<'db>) -> bool) -> Type<'db> {
+        Self::from_elements(db, self.elements(db).iter().filter(filter_fn))
+    }
+
     pub(crate) fn map_with_boundness(
         self,
         db: &'db dyn Db,

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -315,6 +315,14 @@ impl<'db> Type<'db> {
             .is_some_and(|instance| instance.class().is_known(db, KnownClass::NoneType))
     }
 
+    pub fn is_notimplemented(&self, db: &'db dyn Db) -> bool {
+        self.into_instance().is_some_and(|instance| {
+            instance
+                .class()
+                .is_known(db, KnownClass::NotImplementedType)
+        })
+    }
+
     pub fn is_object(&self, db: &'db dyn Db) -> bool {
         self.into_instance()
             .is_some_and(|instance| instance.class().is_object(db))

--- a/crates/red_knot_python_semantic/src/types/class.rs
+++ b/crates/red_knot_python_semantic/src/types/class.rs
@@ -862,8 +862,6 @@ pub enum KnownClass {
     // Exposed as `types.EllipsisType` on Python >=3.10;
     // backported as `builtins.ellipsis` by typeshed on Python <=3.9
     EllipsisType,
-    // Exposed as `types.NotImplementedType` on Python >=3.10;
-    // backported as `builtins._NotImplementedType` by typeshed on Python <=3.9
     NotImplementedType,
 }
 
@@ -1001,13 +999,7 @@ impl<'db> KnownClass {
                     "ellipsis"
                 }
             }
-            Self::NotImplementedType => {
-                // Exposed as `types.NotImplementedType` on Python >=3.10;
-                // backported as `builtins._NotImplementedType` by typeshed on Python <=3.9
-                // TODO: Currently, types.NotImplementedType is a type alias of `builtins._NotImplementedType`
-                // TypeAlias is not fully supported yet, so we use `_NotImplementedType` here for now
-                "_NotImplementedType"
-            }
+            Self::NotImplementedType => "_NotImplementedType",
         }
     }
 
@@ -1181,11 +1173,7 @@ impl<'db> KnownClass {
                     KnownModule::Builtins
                 }
             }
-            Self::NotImplementedType => {
-                // TODO: Currently, types.NotImplementedType is a type alias of `builtins._NotImplementedType`
-                // TypeAlias is not fully supported yet, so we use `_NotImplementedType` here for now
-                KnownModule::Builtins
-            }
+            Self::NotImplementedType => KnownModule::Builtins,
             Self::ChainMap
             | Self::Counter
             | Self::DefaultDict
@@ -1361,12 +1349,6 @@ impl<'db> KnownClass {
                 Self::EllipsisType
             }
             "_NotImplementedType" if Program::get(db).python_version(db) <= PythonVersion::PY39 => {
-                Self::NotImplementedType
-            }
-            // TODO: It should be changed to `NotImplementedType` when we have support for TypeAlias
-            "_NotImplementedType"
-                if Program::get(db).python_version(db) >= PythonVersion::PY310 =>
-            {
                 Self::NotImplementedType
             }
             _ => return None,

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1266,11 +1266,10 @@ impl<'db> TypeInferenceBuilder<'db> {
             {
                 return;
             }
-            for invalid in self
-                .return_types_and_ranges
-                .iter()
-                .filter(|ty_range| !ty_range.ty.is_assignable_to(self.db(), declared_ty))
-            {
+            for invalid in self.return_types_and_ranges.iter().filter(|ty_range| {
+                !ty_range.ty.is_assignable_to(self.db(), declared_ty)
+                    && !ty_range.ty.is_notimplemented(self.db())
+            }) {
                 report_invalid_return_type(
                     &self.context,
                     invalid.range,


### PR DESCRIPTION
## Summary

Closes #16661

This PR includes two changes:

- `NotImplementedType` is now a member of `KnownClass`
- We skip `is_assignable_to` checks for `NotImplemented` when checking return types

### Limitation

```py
def f(cond: bool) -> int:
    return 1 if cond else NotImplemented
```

The implementation covers cases where `NotImplemented` appears inside a `Union`.
However, for more complex types (ex. `Intersection`) it will not worked. In my opinion, supporting such complexity is unnecessary at this point.

## Test Plan

Two `mdtest` files were updated:

- `mdtest/function/return_type.md`
- `mdtest/type_properties/is_singleton.md`

To test `KnownClass`, run:
```bash
cargo test -p red_knot_python_semantic -- types::class::
```