### PR TITLE
[red-knot] Install mypy_primer from specific Git tag

### DIFF
--- a/.github/workflows/mypy_primer.yaml
+++ b/.github/workflows/mypy_primer.yaml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Install mypy_primer
         run: |
-          uv tool install "git+https://github.com/astral-sh/mypy_primer.git@add-red-knot-support"
+          uv tool install "git+https://github.com/astral-sh/mypy_primer.git@add-red-knot-support-v1"
 
       - name: Run mypy_primer
         shell: bash


### PR DESCRIPTION
## Summary

Instead of installing from a branch, install mypy_primer from a specific Git tag in order to make changes to the pipeline explicit.

