### PR TITLE
[red-knot] mypy_primer: use debug builds of red_knot

### DIFF
--- a/.github/workflows/mypy_primer.yaml
+++ b/.github/workflows/mypy_primer.yaml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Install mypy_primer
         run: |
-          uv tool install "git+https://github.com/astral-sh/mypy_primer.git@add-red-knot-support-v1"
+          uv tool install "git+https://github.com/astral-sh/mypy_primer.git@add-red-knot-support-v2"
 
       - name: Run mypy_primer
         shell: bash


### PR DESCRIPTION
## Summary

Use a debug build instead of a release build in order to speed up mypy_primer runs.

## Test Plan

Previous mypy_primer run: 5m 45s
mypy_primer run on this branch: 3m 49s
