### PR TITLE
[red-knot] mypy_primer: switch to depot runners

### DIFF
--- a/.github/workflows/mypy_primer.yaml
+++ b/.github/workflows/mypy_primer.yaml
@@ -25,7 +25,7 @@ env:
 jobs:
   mypy_primer:
     name: Run mypy_primer
-    runs-on: ubuntu-24.04
+    runs-on: depot-ubuntu-22.04-16
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4


### PR DESCRIPTION
## Summary

Move the mypy_primer build to the depot runners to speed them up.

## Test Plan

Previous run of mypy_primer: 3m 49s
Run on this branch: 1m 38s
