### PR TITLE
Fix file permission issues when running Ruff through Docker

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -91,11 +91,11 @@ On **Docker**, it is published as `ghcr.io/astral-sh/ruff`, tagged for each rele
 the latest release.
 
 ```console
-$ docker run -v .:/io --rm ghcr.io/astral-sh/ruff check
-$ docker run -v .:/io --rm ghcr.io/astral-sh/ruff:0.3.0 check
+$ docker run -v .:/io -u "$(id -u):$(id -g)" --rm ghcr.io/astral-sh/ruff check
+$ docker run -v .:/io -u "$(id -u):$(id -g)" --rm ghcr.io/astral-sh/ruff:0.3.0 check
 
 $ # Or, for Podman on SELinux.
-$ docker run -v .:/io:Z --rm ghcr.io/astral-sh/ruff check
+$ docker run -v .:/io:Z -u "$(id -u):$(id -g)" --rm ghcr.io/astral-sh/ruff check
 ```
 
 [![Packaging status](https://repology.org/badge/vertical-allrepos/ruff-python-linter.svg?exclude_unsupported=1)](https://repology.org/project/ruff-python-linter/versions)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -92,7 +92,7 @@ the latest release.
 
 ```console
 $ docker run -v .:/io -u "$(id -u):$(id -g)" --rm ghcr.io/astral-sh/ruff check
-$ docker run -v .:/io -u "$(id -u):$(id -g)" --rm ghcr.io/astral-sh/ruff:0.3.0 check
+$ docker run -v .:/io -u "$(id -u):$(id -g)" --rm ghcr.io/astral-sh/ruff:0.11.2 check
 
 $ # Or, for Podman on SELinux.
 $ docker run -v .:/io:Z -u "$(id -u):$(id -g)" --rm ghcr.io/astral-sh/ruff check


### PR DESCRIPTION
## Summary

The current documentation suggests running:

``` sh
docker run -v .:/io --rm ghcr.io/astral-sh/ruff:0.3.0 check
```

There are 2 issues here:

- If Ruff modifies a file, the file will be written to the Docker host as `root:root` causing all sorts of permission issues, such as not being able to save the file anymore in your normal code editor
    - If using Docker Desktop, there are mechanisms to make it not be root but on native Linux (including WSL 2) it will be root
- The docs reference `0.3.0` which is a bit old
    - I used the most recent release but maybe a long term plan in another PR (above my paygrade) would be to auto-generate this when cutting a new release so it's always using the latest release?

This PR addresses both issues:

- For the first one, I added `-u "$(id -u):$(id -g)"` which will use the current user's UID / GID to ensure files get written back to the host as the same user who ran the Docker command
    - I have been using this locally for days now, it works on both native Linux without Docker Desktop as well as Docker Desktop on macOS, I did not directly test other machines but I imagine it will be ok with Docker Desktop on Windows too as long as you run the command from WSL 2
        - I do not use SELinux or Podman so I'm not sure if it will work there
- For the second one, I found the latest release and referenced it

## Test Plan

I didn't run any tests, I found the documentation file and patched it.