### PR TITLE
Rename `visit_preorder` to `visit_source_order`

### DIFF
--- a/crates/ruff_python_ast/generate.py
+++ b/crates/ruff_python_ast/generate.py
@@ -481,7 +481,7 @@ def write_anynoderef(out: list[str], ast: Ast) -> None:
     - `impl<'a> From<&'a TypeParamTypeVarTuple> for AnyNodeRef<'a>`
     - `impl Ranged for AnyNodeRef<'_>`
     - `fn AnyNodeRef::as_ptr(&self) -> std::ptr::NonNull<()>`
-    - `fn AnyNodeRef::visit_preorder(self, visitor &mut impl SourceOrderVisitor)`
+    - `fn AnyNodeRef::visit_source_order(self, visitor &mut impl SourceOrderVisitor)`
     """
 
     out.append("""
@@ -564,7 +564,7 @@ def write_anynoderef(out: list[str], ast: Ast) -> None:
 
     out.append("""
         impl<'a> AnyNodeRef<'a> {
-            pub fn visit_preorder<'b, V>(self, visitor: &mut V)
+            pub fn visit_source_order<'b, V>(self, visitor: &mut V)
             where
                 V: crate::visitor::source_order::SourceOrderVisitor<'b> + ?Sized,
                 'a: 'b,

--- a/crates/ruff_python_ast/src/generated.rs
+++ b/crates/ruff_python_ast/src/generated.rs
@@ -6027,7 +6027,7 @@ impl AnyNodeRef<'_> {
 }
 
 impl<'a> AnyNodeRef<'a> {
-    pub fn visit_preorder<'b, V>(self, visitor: &mut V)
+    pub fn visit_source_order<'b, V>(self, visitor: &mut V)
     where
         V: crate::visitor::source_order::SourceOrderVisitor<'b> + ?Sized,
         'a: 'b,

--- a/crates/ruff_python_formatter/src/comments/mod.rs
+++ b/crates/ruff_python_formatter/src/comments/mod.rs
@@ -422,7 +422,7 @@ impl<'a> Comments<'a> {
             dangling.mark_formatted();
         }
 
-        node.visit_preorder(&mut MarkVerbatimCommentsAsFormattedVisitor(self));
+        node.visit_source_order(&mut MarkVerbatimCommentsAsFormattedVisitor(self));
     }
 
     /// Returns an object that implements [Debug] for nicely printing the [`Comments`].
@@ -460,7 +460,7 @@ impl<'a> Comments<'a> {
             comments: self,
             has_comment: false,
         };
-        node.visit_preorder(&mut visitor);
+        node.visit_source_order(&mut visitor);
 
         visitor.has_comment
     }

--- a/crates/ruff_python_formatter/src/comments/visitor.rs
+++ b/crates/ruff_python_formatter/src/comments/visitor.rs
@@ -53,7 +53,7 @@ impl<'a, 'builder> CommentsVisitor<'a, 'builder> {
 
     pub(super) fn visit(mut self, root: AnyNodeRef<'a>) {
         if self.enter_node(root).is_traverse() {
-            root.visit_preorder(&mut self);
+            root.visit_source_order(&mut self);
         }
 
         self.leave_node(root);

--- a/crates/ruff_python_formatter/src/range.rs
+++ b/crates/ruff_python_formatter/src/range.rs
@@ -154,7 +154,7 @@ fn find_enclosing_node<'ast>(
     let mut visitor = FindEnclosingNode::new(range, context);
 
     if visitor.enter_node(root).is_traverse() {
-        root.visit_preorder(&mut visitor);
+        root.visit_source_order(&mut visitor);
     }
     visitor.leave_node(root);
 
@@ -314,7 +314,7 @@ fn narrow_range(
     };
 
     if visitor.enter_node(enclosing_node).is_traverse() {
-        enclosing_node.visit_preorder(&mut visitor);
+        enclosing_node.visit_source_order(&mut visitor);
     }
 
     visitor.leave_node(enclosing_node);


### PR DESCRIPTION
## Summary

We renamed the `PreorderVisitor` to `SourceOrderVisitor` a long time ago but it seems that we missed to rename the `visit_preorder` functions to `visit_source_order`. 
This PR renames `visit_preorder` to `visit_source_order`

## Test Plan

`cargo test`
