### PR TITLE
Don't install Rust before running pre-commit in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -651,9 +651,6 @@ jobs:
       - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
-      - name: "Install Rust toolchain"
-        run: rustup show
       - name: "Install pre-commit"
         run: pip install pre-commit
       - name: "Cache pre-commit"


### PR DESCRIPTION
Following https://github.com/astral-sh/ruff/commit/29573daef5a7587b7903095a8c6be03739cb1ccb, it doesn't look to me like any of the pre-commit hooks run in CI here are Rust-based:

- `cargo fmt` is Rust-based but it's explicitly skipped as part of this job and run as a separate CI job: https://github.com/astral-sh/ruff/blob/93052331b07e8cbc84660340019db4f582fb4ad1/.pre-commit-config.yaml#L124-L125
- The `typos` hook is Rust-based, but according to https://github.com/crate-ci/typos/blob/master/docs/pre-commit.md pre-commit should install a built binary rather than building the binary from source

As such, I think this step in the workflow is just taking up 15s of CI time and not actually speeding up pre-commit at all