### PR TITLE
[playground] Allow selecting the diagnostic message

### DIFF
--- a/playground/knot/src/Editor/Diagnostics.tsx
+++ b/playground/knot/src/Editor/Diagnostics.tsx
@@ -84,7 +84,7 @@ function Items({
           <li key={`${diagnostic.text_range()?.start ?? 0}-${id ?? index}`}>
             <button
               onClick={() => onGoTo(startLine, startColumn)}
-              className="w-full text-start cursor-pointer"
+              className="w-full text-start cursor-pointer select-text"
             >
               {diagnostic.message()}
               <span className="text-gray-500">

--- a/playground/ruff/src/Editor/Diagnostics.tsx
+++ b/playground/ruff/src/Editor/Diagnostics.tsx
@@ -6,6 +6,7 @@ import { useMemo } from "react";
 interface Props {
   diagnostics: Diagnostic[];
   theme: Theme;
+
   onGoTo(line: number, column: number): void;
 }
 
@@ -79,7 +80,7 @@ function Items({
                   diagnostic.start_location.column,
                 )
               }
-              className="w-full text-start"
+              className="w-full text-start cursor-pointer select-text"
             >
               {diagnostic.message}{" "}
               <span className="text-gray-500">


### PR DESCRIPTION
## Summary

Allow selecting the diagnostic message so that the message can be copied (e.g. into an issue)

## Test Plan

<img width="1679" alt="Screenshot 2025-03-28 at 16 52 45" src="https://github.com/user-attachments/assets/06674d87-6c88-45d4-b46c-0bcb3e151996" />

