### PR TITLE
Error instead of `panic!` when running Ruff from a deleted directory (#16903)

### DIFF
--- a/crates/ruff/src/lib.rs
+++ b/crates/ruff/src/lib.rs
@@ -112,7 +112,7 @@ fn is_stdin(files: &[PathBuf], stdin_filename: Option<&Path>) -> bool {
     file == Path::new("-")
 }
 
-/// Returns the default set of files if none are provided, otherwise returns `None`.
+/// Returns the default set of files if none are provided, otherwise returns provided files.
 fn resolve_default_files(files: Vec<PathBuf>, is_stdin: bool) -> Vec<PathBuf> {
     if files.is_empty() {
         if is_stdin {

--- a/crates/ruff/src/resolve.rs
+++ b/crates/ruff/src/resolve.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use log::debug;
 use path_absolutize::path_dedot;
 
@@ -21,6 +21,10 @@ pub fn resolve(
     config_arguments: &ConfigArguments,
     stdin_filename: Option<&Path>,
 ) -> Result<PyprojectConfig> {
+    // Ensure directory exists before proceeding
+    if std::env::current_dir().is_err() {
+        return Err(anyhow!("Working directory does not exist"));
+    }
     // First priority: if we're running in isolated mode, use the default settings.
     if config_arguments.isolated {
         let config = config_arguments.transform(Configuration::default());

--- a/crates/ruff/src/resolve.rs
+++ b/crates/ruff/src/resolve.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use anyhow::{bail, Result};
 use log::debug;
-use path_absolutize::path_dedot::{self, ParseDot};
+use path_absolutize::path_dedot;
 
 use ruff_workspace::configuration::Configuration;
 use ruff_workspace::pyproject::{self, find_fallback_target_version};
@@ -24,7 +24,6 @@ pub fn resolve(
     let Ok(cwd) = std::env::current_dir() else {
         bail!("Working directory does not exist")
     };
-    let cwd = cwd.parse_dot()?;
 
     // First priority: if we're running in isolated mode, use the default settings.
     if config_arguments.isolated {

--- a/crates/ruff/src/resolve.rs
+++ b/crates/ruff/src/resolve.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use anyhow::{anyhow, Result};
+use anyhow::{bail, Result};
 use log::debug;
 use path_absolutize::path_dedot;
 
@@ -21,10 +21,9 @@ pub fn resolve(
     config_arguments: &ConfigArguments,
     stdin_filename: Option<&Path>,
 ) -> Result<PyprojectConfig> {
-    // Ensure directory exists before proceeding
-    if std::env::current_dir().is_err() {
-        return Err(anyhow!("Working directory does not exist"));
-    }
+    let Ok(_cwd) = std::env::current_dir() else {
+        bail!("Working directory does not exist")
+    };
     // First priority: if we're running in isolated mode, use the default settings.
     if config_arguments.isolated {
         let config = config_arguments.transform(Configuration::default());

--- a/crates/ruff/src/resolve.rs
+++ b/crates/ruff/src/resolve.rs
@@ -62,9 +62,7 @@ pub fn resolve(
     // that directory. (With `Strategy::Hierarchical`, we'll end up finding
     // the "closest" `pyproject.toml` file for every Python file later on,
     // so these act as the "default" settings.)
-    if let Some(pyproject) =
-        pyproject::find_settings_toml(stdin_filename.as_ref().unwrap_or(&cwd.as_ref()))?
-    {
+    if let Some(pyproject) = pyproject::find_settings_toml(stdin_filename.unwrap_or(&cwd))? {
         debug!(
             "Using configuration file (via parent) at: {}",
             pyproject.display()
@@ -132,8 +130,7 @@ pub fn resolve(
         // `pyproject::find_settings_toml`.)
         // However, there may be a `pyproject.toml` with a `requires-python`
         // specified, and that is what we look for in this step.
-        let fallback =
-            find_fallback_target_version(stdin_filename.as_ref().unwrap_or(&cwd.as_ref()));
+        let fallback = find_fallback_target_version(stdin_filename.unwrap_or(&cwd));
         if let Some(version) = fallback {
             debug!("Derived `target-version` from found `requires-python`: {version:?}");
         }

--- a/crates/ruff/tests/direxist_guard.rs
+++ b/crates/ruff/tests/direxist_guard.rs
@@ -3,7 +3,7 @@
 //! Tests in the same module become flaky under `cargo test`s parallel execution
 //! due to in-test working directory manipulation.
 
-#![cfg(not(target_family = "wasm"))]
+#![cfg(target_family = "unix")]
 
 use std::env::set_current_dir;
 use std::process::Command;

--- a/crates/ruff/tests/direxist_guard.rs
+++ b/crates/ruff/tests/direxist_guard.rs
@@ -1,0 +1,28 @@
+#![cfg(not(target_family = "wasm"))]
+
+use std::env::{current_dir, set_current_dir};
+use std::process::Command;
+
+use insta_cmd::{assert_cmd_snapshot, get_cargo_bin};
+const BIN_NAME: &str = "ruff";
+
+#[test]
+fn check_in_deleted_directory_errors() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let temp_path = temp_dir.path().to_path_buf();
+    let original_dir = current_dir().unwrap();
+    set_current_dir(&temp_path).unwrap();
+    drop(temp_dir);
+
+    assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME)).arg("check"), @r###"
+            success: false
+            exit_code: 2
+            ----- stdout -----
+
+            ----- stderr -----
+            ruff failed
+              Cause: Working directory does not exist
+            "###);
+
+    set_current_dir(original_dir).unwrap();
+}

--- a/crates/ruff/tests/direxist_guard.rs
+++ b/crates/ruff/tests/direxist_guard.rs
@@ -1,6 +1,6 @@
 #![cfg(not(target_family = "wasm"))]
 
-use std::env::{current_dir, set_current_dir};
+use std::env::set_current_dir;
 use std::process::Command;
 
 use insta_cmd::{assert_cmd_snapshot, get_cargo_bin};
@@ -10,7 +10,6 @@ const BIN_NAME: &str = "ruff";
 fn check_in_deleted_directory_errors() {
     let temp_dir = tempfile::tempdir().unwrap();
     let temp_path = temp_dir.path().to_path_buf();
-    let original_dir = current_dir().unwrap();
     set_current_dir(&temp_path).unwrap();
     drop(temp_dir);
 
@@ -23,6 +22,4 @@ fn check_in_deleted_directory_errors() {
             ruff failed
               Cause: Working directory does not exist
             "###);
-
-    set_current_dir(original_dir).unwrap();
 }

--- a/crates/ruff/tests/direxist_guard.rs
+++ b/crates/ruff/tests/direxist_guard.rs
@@ -1,3 +1,8 @@
+//! Test to verify Ruff's behavior when run from deleted directory.
+//! It has to be isolated in a separate module.
+//! Tests in the same module become flaky under `cargo test`s parallel execution
+//! due to in-test working directory manipulation.
+
 #![cfg(not(target_family = "wasm"))]
 
 use std::env::set_current_dir;

--- a/crates/ruff/tests/resolve_files.rs
+++ b/crates/ruff/tests/resolve_files.rs
@@ -101,28 +101,3 @@ fn check_project_from_project_subdirectory_respects_includes() {
         ");
     });
 }
-
-#[test]
-fn check_in_deleted_directory_errors() {
-    let temp_dir = tempfile::tempdir().unwrap();
-    let temp_path = temp_dir.path().to_path_buf();
-    let original_dir = std::env::current_dir().unwrap();
-    std::env::set_current_dir(&temp_path).unwrap();
-    std::mem::drop(temp_dir);
-
-    insta::with_settings!({
-        filters => TEST_FILTERS.to_vec()
-    },
-    {
-        assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME)).args(["check", "--no-cache"]), @r###"
-            success: false
-            exit_code: 2
-            ----- stdout -----
-
-            ----- stderr -----
-            ruff failed
-              Cause: Working directory does not exist
-            "###);
-    });
-    std::env::set_current_dir(original_dir).unwrap();
-}

--- a/crates/ruff/tests/resolve_files.rs
+++ b/crates/ruff/tests/resolve_files.rs
@@ -101,3 +101,28 @@ fn check_project_from_project_subdirectory_respects_includes() {
         ");
     });
 }
+
+#[test]
+fn check_in_deleted_directory_errors() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let temp_path = temp_dir.path().to_path_buf();
+    let original_dir = std::env::current_dir().unwrap();
+    std::env::set_current_dir(&temp_path).unwrap();
+    std::mem::drop(temp_dir);
+
+    insta::with_settings!({
+        filters => TEST_FILTERS.to_vec()
+    },
+    {
+        assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME)).args(["check", "--no-cache"]), @r###"
+            success: false
+            exit_code: 2
+            ----- stdout -----
+
+            ----- stderr -----
+            ruff failed
+              Cause: Working directory does not exist
+            "###);
+    });
+    std::env::set_current_dir(original_dir).unwrap();
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->
Closes #16903

## Summary
Check if the current working directory exist. If not, provide an error instead of panicking.

Fixed a stale comment in `resolve_default_files`.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan
I added a test to the `resolve_files.rs`. 

Manual testing follows steps of #16903 :
- Terminal 1
```bash
mkdir tmp
cd tmp
```
- Terminal 2
```bash
rm -rf tmp
```
- Terminal 1
```bash
ruff check
```

## Open Issues / Questions to Reviewer
All tests pass when executed with `cargo nextest run`.

However, with `cargo test` the parallelization makes the other tests fail as we change the `pwd`.

Serial execution with `cargo test` seems to require [another dependency or some workarounds](https://stackoverflow.com/questions/51694017/how-can-i-avoid-running-some-tests-in-parallel).

Do you think an additional dependency or test complexity is worth testing this small edge case, do you have another implementation idea, or should i rather remove the test?
  
---
P.S.: I'm currently participating in a batch at the [Recurse Center](https://www.recurse.com/) and would love to contribute more for the next six weeks to improve my Rust. Let me know if you're open to mentoring/reviewing and/or if you have specific areas where help would be most valued.