### PR TITLE
Fix RUF100 to detect unused file-level noqa directives with specific codes (#17042)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF100_6.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF100_6.py
@@ -1,0 +1,1 @@
+# ruff: noqa: F841 -- intentional unused file directive; will be removed

--- a/crates/ruff_linter/src/checkers/noqa.rs
+++ b/crates/ruff_linter/src/checkers/noqa.rs
@@ -110,10 +110,20 @@ pub(crate) fn check_noqa(
         && !exemption.includes(Rule::UnusedNOQA)
         && !per_file_ignores.contains(Rule::UnusedNOQA)
     {
-        for line in noqa_directives.lines() {
-            match &line.directive {
+        let directives = noqa_directives
+            .lines()
+            .iter()
+            .map(|line| (&line.directive, &line.matches, false))
+            .chain(
+                file_noqa_directives
+                    .lines()
+                    .iter()
+                    .map(|line| (&line.parsed_file_exemption, &line.matches, true)),
+            );
+        for (directive, matches, is_file_level) in directives {
+            match directive {
                 Directive::All(directive) => {
-                    if line.matches.is_empty() {
+                    if matches.is_empty() {
                         let edit = delete_comment(directive.range(), locator);
                         let mut diagnostic =
                             Diagnostic::new(UnusedNOQA { codes: None }, directive.range());
@@ -139,15 +149,21 @@ pub(crate) fn check_noqa(
 
                         if !seen_codes.insert(original_code) {
                             duplicated_codes.push(original_code);
-                        } else if line.matches.iter().any(|match_| *match_ == code)
-                            || settings
+                        } else {
+                            let is_code_used = if is_file_level {
+                                diagnostics
+                                    .iter()
+                                    .any(|diag| diag.kind.rule().noqa_code() == code)
+                            } else {
+                                matches.iter().any(|match_| *match_ == code)
+                            } || settings
                                 .external
                                 .iter()
-                                .any(|external| code.starts_with(external))
-                        {
-                            valid_codes.push(original_code);
-                        } else {
-                            if let Ok(rule) = Rule::from_code(code) {
+                                .any(|external| code.starts_with(external));
+
+                            if is_code_used {
+                                valid_codes.push(original_code);
+                            } else if let Ok(rule) = Rule::from_code(code) {
                                 if settings.rules.enabled(rule) {
                                     unmatched_codes.push(original_code);
                                 } else {
@@ -171,8 +187,13 @@ pub(crate) fn check_noqa(
                         let edit = if valid_codes.is_empty() {
                             delete_comment(directive.range(), locator)
                         } else {
+                            let prefix = if is_file_level {
+                                "# ruff: noqa: "
+                            } else {
+                                "# noqa: "
+                            };
                             Edit::range_replacement(
-                                format!("# noqa: {}", valid_codes.join(", ")),
+                                format!("{}{}", prefix, valid_codes.join(", ")),
                                 directive.range(),
                             )
                         };

--- a/crates/ruff_linter/src/rules/ruff/mod.rs
+++ b/crates/ruff_linter/src/rules/ruff/mod.rs
@@ -315,6 +315,16 @@ mod tests {
     }
 
     #[test]
+    fn ruff_noqa_filedirective_unused() -> Result<()> {
+        let diagnostics = test_path(
+            Path::new("ruff/RUF100_6.py"),
+            &settings::LinterSettings::for_rules(vec![Rule::UnusedNOQA]),
+        )?;
+        assert_messages!(diagnostics);
+        Ok(())
+    }
+
+    #[test]
     fn ruff_per_file_ignores() -> Result<()> {
         let diagnostics = test_path(
             Path::new("ruff/ruff_per_file_ignores.py"),

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruff_noqa_filedirective_unused.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruff_noqa_filedirective_unused.snap
@@ -1,0 +1,13 @@
+---
+source: crates/ruff_linter/src/rules/ruff/mod.rs
+---
+RUF100_6.py:1:1: RUF100 [*] Unused `noqa` directive (non-enabled: `F841`)
+  |
+1 | # ruff: noqa: F841 -- intentional unused file directive; will be removed
+  | ^^^^^^^^^^^^^^^^^^ RUF100
+  |
+  = help: Remove unused `noqa` directive
+
+ℹ Safe fix
+1   |-# ruff: noqa: F841 -- intentional unused file directive; will be removed
+  1 |+


### PR DESCRIPTION
Closes #17042

## Summary
This PR fixes the issue outlined in #17042 where RUF100 (unused-noqa) fails to detect unused file-level noqa directives (`# ruff: noqa` or `# ruff: noqa: {code}`).

The issue stems from two underlying causes:

1. For blanket file-level directives (`# ruff: noqa`), there's a circular dependency: the directive exempts all rules including RUF100 itself, which prevents checking for usage. This isn't changed by this PR. I would argue it is intendend behavior - a blanket `# ruff: noqa` directive should exempt all rules including RUF100 itself.

2. For code-specific file-level directives (e.g. `# ruff: noqa: F841`), the handling was missing in the `check_noqa` function. This is added in this PR.

## Notes
- For file-level directives, he `matches` array is pre-populated with the specified codes during parsing, unlike line-level directives which only populate their `matches` array when actually suppressing diagnostics. This difference requires the somewhat clunky handling of both cases. I would appreciate guidance on a cleaner design :) 

- A more fundamental solution would be to change how file-level directives initialize the `matches` array in `FileNoqaDirectives::extract()`, but that requires more substantial changes as it breaks existing functionality. I suspect discussions in #16483 are relevant for this.

## Test Plan
- Local verification
- Added a test case and fixture