### PR TITLE
Fix member lookup for unions & intersections ignoring policy

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/call/dunder.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/call/dunder.md
@@ -74,8 +74,7 @@ reveal_type(class_with_normal_dunder[0])  # revealed: str
 Which can be demonstrated by trying to attach a dunder method to an instance, which will not work:
 
 ```py
-from typing import Type, Callable, Any
-from knot_extensions import Intersection
+from typing import Type, Callable
 
 def external_getitem(instance, key: int) -> str:
     return str(key)
@@ -103,17 +102,6 @@ union_of_fail = foo(True)
 
 # error: [non-subscriptable] "Cannot subscript object of type `ThisFails | ThisFails2` with no `__getitem__` method"
 reveal_type(union_of_fail()[0])  # revealed: Unknown
-
-class InterFails(ThisFails, ThisFails2):
-    pass
-
-def bar() -> Intersection[Type[ThisFails], Type[ThisFails2]]:
-    return InterFails
-
-intersection_of_fail = bar()
-
-# TODO: should be an error, like the previous one
-reveal_type(intersection_of_fail()[0])  # revealed: @Todo(Type::Intersection.call())
 ```
 
 However, the attached dunder method *can* be called if accessed directly:

--- a/crates/red_knot_python_semantic/resources/mdtest/call/dunder.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/call/dunder.md
@@ -74,6 +74,9 @@ reveal_type(class_with_normal_dunder[0])  # revealed: str
 Which can be demonstrated by trying to attach a dunder method to an instance, which will not work:
 
 ```py
+from typing import Type, Callable, Any
+from knot_extensions import Intersection
+
 def external_getitem(instance, key: int) -> str:
     return str(key)
 
@@ -85,6 +88,32 @@ this_fails = ThisFails()
 
 # error: [non-subscriptable] "Cannot subscript object of type `ThisFails` with no `__getitem__` method"
 reveal_type(this_fails[0])  # revealed: Unknown
+
+class ThisFails2:
+    def __init__(self):
+        self.__getitem__: Callable[..., str] = external_getitem
+
+def foo(flag: bool) -> Type[ThisFails] | Type[ThisFails2]:
+    if flag:
+        return ThisFails
+    else:
+        return ThisFails2
+
+union_of_fail = foo(True)
+
+# error: [non-subscriptable] "Cannot subscript object of type `ThisFails | ThisFails2` with no `__getitem__` method"
+reveal_type(union_of_fail()[0])  # revealed: Unknown
+
+class InterFails(ThisFails, ThisFails2):
+    pass
+
+def bar() -> Intersection[Type[ThisFails], Type[ThisFails2]]:
+    return InterFails
+
+intersection_of_fail = bar()
+
+# TODO: should be an error, like the previous one
+reveal_type(intersection_of_fail()[0])  # revealed: @Todo(Type::Intersection.call())
 ```
 
 However, the attached dunder method *can* be called if accessed directly:

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1963,11 +1963,17 @@ impl<'db> Type<'db> {
 
         match self {
             Type::Union(union) => union
-                .map_with_boundness(db, |elem| elem.member(db, &name).symbol)
+                .map_with_boundness(db, |elem| {
+                    elem.member_lookup_with_policy(db, name_str.into(), policy)
+                        .symbol
+                })
                 .into(),
 
             Type::Intersection(intersection) => intersection
-                .map_with_boundness(db, |elem| elem.member(db, &name).symbol)
+                .map_with_boundness(db, |elem| {
+                    elem.member_lookup_with_policy(db, name_str.into(), policy)
+                        .symbol
+                })
                 .into(),
 
             Type::Dynamic(..) | Type::Never => Symbol::bound(self).into(),


### PR DESCRIPTION
## Summary

A quick fix for how union/intersection member search ins performed in Knot.

## Test Plan

* Added a dunder method call test for Union, which exhibits the error
* Also added an intersection error, but it is not triggering currently due to `call` logic not being fully implemented for intersections.
