### PR TITLE
[airflow] fix typos in AIR302 implementation and test cases

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_names.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_names.py
@@ -58,7 +58,7 @@ from airflow.operators.python_operator import (
     ShortCircuitOperator,
 )
 from airflow.operators.subdag import SubDagOperator
-from airflow.providers.amazon.auth_manager.avp.entities import AvpEntities
+from airflow.providers.amazon.aws.auth_manager.avp.entities import AvpEntities
 from airflow.providers.amazon.aws.datasets import s3
 from airflow.providers.common.io.datasets import file as common_io_file
 from airflow.providers.fab.auth_manager import fab_auth_manager

--- a/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
@@ -613,12 +613,12 @@ fn check_name(checker: &Checker, expr: &Expr, range: TextRange) {
 
         // airflow.datasets.manager
         ["airflow", "datasets", "manager", "dataset_manager"] => {
-            Replacement::Name("airflow.assets.manager")
+            Replacement::Name("airflow.assets.manager.asset_manager")
         }
         ["airflow", "datasets", "manager", "resolve_dataset_manager"] => {
             Replacement::Name("airflow.assets.resolve_asset_manager")
         }
-        ["airflow", "datasets.manager", "DatasetManager"] => {
+        ["airflow", "datasets", "manager", "DatasetManager"] => {
             Replacement::Name("airflow.assets.AssetManager")
         }
 
@@ -782,7 +782,7 @@ fn check_name(checker: &Checker, expr: &Expr, range: TextRange) {
             Replacement::Name("airflow.providers.amazon.aws.assets.s3.sanitize_uri")
         }
 
-        ["airflow", "providers", "amazon", "auth_manager", "avp", "entities", "AvpEntities", "DATASET"] => {
+        ["airflow", "providers", "amazon", "aws", "auth_manager", "avp", "entities", "AvpEntities", "DATASET"] => {
             Replacement::Name(
                 "airflow.providers.amazon.auth_manager.avp.entities.AvpEntities.ASSET",
             )

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_class_attribute.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_class_attribute.py.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ruff_linter/src/rules/airflow/mod.rs
+snapshot_kind: text
 ---
 AIR302_class_attribute.py:24:21: AIR302 `airflow.Dataset` is removed in Airflow 3.0
    |
@@ -124,6 +125,16 @@ AIR302_class_attribute.py:39:25: AIR302 `iter_dataset_aliases` is removed in Air
 41 | # airflow.datasets.manager
    |
    = help: Use `iter_asset_aliases` instead
+
+AIR302_class_attribute.py:42:6: AIR302 `airflow.datasets.manager.DatasetManager` is removed in Airflow 3.0
+   |
+41 | # airflow.datasets.manager
+42 | dm = DatasetManager()
+   |      ^^^^^^^^^^^^^^ AIR302
+43 | dm.register_dataset_change()
+44 | dm.create_datasets()
+   |
+   = help: Use `airflow.assets.AssetManager` instead
 
 AIR302_class_attribute.py:43:4: AIR302 `register_dataset_change` is removed in Airflow 3.0
    |

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
@@ -263,6 +263,16 @@ AIR302_names.py:141:1: AIR302 `airflow.datasets.expand_alias_to_datasets` is rem
     |
     = help: Use `airflow.sdk.expand_alias_to_assets` instead
 
+AIR302_names.py:144:1: AIR302 `airflow.datasets.manager.DatasetManager` is removed in Airflow 3.0
+    |
+143 | # airflow.datasets.manager
+144 | DatasetManager()
+    | ^^^^^^^^^^^^^^ AIR302
+145 | dataset_manager
+146 | resolve_dataset_manager
+    |
+    = help: Use `airflow.assets.AssetManager` instead
+
 AIR302_names.py:145:1: AIR302 `airflow.datasets.manager.dataset_manager` is removed in Airflow 3.0
     |
 143 | # airflow.datasets.manager
@@ -271,7 +281,7 @@ AIR302_names.py:145:1: AIR302 `airflow.datasets.manager.dataset_manager` is remo
     | ^^^^^^^^^^^^^^^ AIR302
 146 | resolve_dataset_manager
     |
-    = help: Use `airflow.assets.manager` instead
+    = help: Use `airflow.assets.manager.asset_manager` instead
 
 AIR302_names.py:146:1: AIR302 `airflow.datasets.manager.resolve_dataset_manager` is removed in Airflow 3.0
     |
@@ -513,7 +523,7 @@ AIR302_names.py:194:1: AIR302 `airflow.operators.subdag.SubDagOperator` is remov
 196 | # airflow.providers.amazon
     |
 
-AIR302_names.py:197:13: AIR302 `airflow.providers.amazon.auth_manager.avp.entities.AvpEntities.DATASET` is removed in Airflow 3.0
+AIR302_names.py:197:13: AIR302 `airflow.providers.amazon.aws.auth_manager.avp.entities.AvpEntities.DATASET` is removed in Airflow 3.0
     |
 196 | # airflow.providers.amazon
 197 | AvpEntities.DATASET


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

* The following paths are wrong 
    * `airflow.providers.amazon.auth_manager.avp.entities` should be `airflow.providers.amazon.aws.auth_manager.avp.entities`
    * `["airflow", "datasets", "manager", "dataset_manager"]` should be fixed as `airflow.assets.manager` but not `airflow.assets.manager.asset_manager`
   * `["airflow", "datasets.manager", "DatasetManager"]` should be ` ["airflow", "datasets", "manager", "DatasetManager"]` instead

## Test Plan

<!-- How was it tested? -->

the test fixture is updated accordingly