### PR TITLE
[`airflow`] Extend `AIR302` with additional symbols

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_args.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_args.py
@@ -34,6 +34,9 @@ DAG(dag_id="class_default_view", default_view="dag_default_view")
 
 DAG(dag_id="class_orientation", orientation="BT")
 
+allow_future_exec_dates_dag = DAG(dag_id="class_allow_future_exec_dates")
+allow_future_exec_dates_dag.allow_future_exec_dates
+
 
 @dag(schedule="0 * * * *")
 def decorator_schedule():

--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_args.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_args.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import timedelta
 
 from airflow import DAG, dag
@@ -26,7 +28,11 @@ def sla_callback(*arg, **kwargs):
 
 DAG(dag_id="class_sla_callback", sla_miss_callback=sla_callback)
 
-DAG(dag_id="class_sla_callback", fail_stop=True)
+DAG(dag_id="class_fail_stop", fail_stop=True)
+
+DAG(dag_id="class_default_view", default_view="dag_default_view")
+
+DAG(dag_id="class_orientation", orientation="BT")
 
 
 @dag(schedule="0 * * * *")

--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_names.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_names.py
@@ -106,6 +106,7 @@ from airflow.utils.dates import (
     round_time,
     scale_time_units,
 )
+from airflow.utils.db import create_session
 from airflow.utils.decorators import apply_defaults
 from airflow.utils.file import TemporaryDirectory, mkdirs
 from airflow.utils.helpers import chain as helper_chain
@@ -290,6 +291,9 @@ test_cycle
 
 # airflow.utils.dag_parsing_context
 get_parsing_context
+
+# airflow.utils.db
+create_session
 
 # airflow.utils.decorators
 apply_defaults

--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_names.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_names.py
@@ -46,6 +46,7 @@ from airflow.listeners.spec.dataset import on_dataset_changed, on_dataset_create
 from airflow.metrics.validators import AllowListValidator, BlockListValidator
 from airflow.models.baseoperator import chain, chain_linear, cross_downstream
 from airflow.models.baseoperatorlink import BaseOperatorLink
+from airflow.notifications.basenotifier import BaseNotifier
 from airflow.operators import dummy_operator
 from airflow.operators.branch_operator import BaseBranchOperator
 from airflow.operators.dagrun_operator import TriggerDagRunLink, TriggerDagRunOperator
@@ -109,6 +110,7 @@ from airflow.utils.decorators import apply_defaults
 from airflow.utils.file import TemporaryDirectory, mkdirs
 from airflow.utils.helpers import chain as helper_chain
 from airflow.utils.helpers import cross_downstream as helper_cross_downstream
+from airflow.utils.log import secrets_masker
 from airflow.utils.state import SHUTDOWN, terminating_states
 from airflow.utils.trigger_rule import TriggerRule
 from airflow.www.auth import has_access, has_access_dataset
@@ -166,6 +168,9 @@ chain, chain_linear, cross_downstream
 
 # airflow.models.baseoperatorlink
 BaseOperatorLink()
+
+# ariflow.notifications.basenotifier
+BaseNotifier()
 
 # airflow.operators.dummy
 EmptyOperator()
@@ -296,6 +301,9 @@ mkdirs
 #  airflow.utils.helpers
 helper_chain
 helper_cross_downstream
+
+#  airflow.utils.log
+secrets_masker
 
 # airflow.utils.state
 SHUTDOWN

--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_names.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_names.py
@@ -45,6 +45,7 @@ from airflow.lineage.hook import DatasetLineageInfo
 from airflow.listeners.spec.dataset import on_dataset_changed, on_dataset_created
 from airflow.metrics.validators import AllowListValidator, BlockListValidator
 from airflow.models.baseoperator import chain, chain_linear, cross_downstream
+from airflow.models.baseoperatorlink import BaseOperatorLink
 from airflow.operators import dummy_operator
 from airflow.operators.branch_operator import BaseBranchOperator
 from airflow.operators.dagrun_operator import TriggerDagRunLink, TriggerDagRunOperator
@@ -162,6 +163,9 @@ BlockListValidator()
 
 # airflow.models.baseoperator
 chain, chain_linear, cross_downstream
+
+# airflow.models.baseoperatorlink
+BaseOperatorLink()
 
 # airflow.operators.dummy
 EmptyOperator()

--- a/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
@@ -279,6 +279,10 @@ fn check_class_attribute(checker: &Checker, attribute_expr: &ExprAttribute) {
     };
 
     let replacement = match *qualname.segments() {
+        ["airflow", .., "DAG" | "dag"] => match attr.as_str() {
+            "allow_future_exec_dates" => Replacement::None,
+            _ => return,
+        },
         ["airflow", "providers_manager", "ProvidersManager"] => match attr.as_str() {
             "dataset_factories" => Replacement::Name("asset_factories"),
             "dataset_uri_handlers" => Replacement::Name("asset_uri_handlers"),

--- a/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
@@ -634,6 +634,9 @@ fn check_name(checker: &Checker, expr: &Expr, range: TextRange) {
         ["airflow", "models", "baseoperator", "cross_downstream"] => {
             Replacement::Name("airflow.sdk.cross_downstream")
         }
+        ["airflow", "models", "baseoperatorlink", "BaseOperatorLink"] => {
+            Replacement::Name("airflow.sdk.definitions.baseoperatorlink.BaseOperatorLink")
+        }
 
         // airflow.operators
         ["airflow", "operators", "subdag", ..] => {

--- a/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
@@ -186,6 +186,12 @@ fn check_function_parameters(checker: &Checker, function_def: &StmtFunctionDef) 
 fn check_call_arguments(checker: &Checker, qualified_name: &QualifiedName, arguments: &Arguments) {
     match qualified_name.segments() {
         ["airflow", .., "DAG" | "dag"] => {
+            // with replacement
+            checker.report_diagnostics(diagnostic_for_argument(
+                arguments,
+                "fail_stop",
+                Some("fail_fast"),
+            ));
             checker.report_diagnostics(diagnostic_for_argument(
                 arguments,
                 "schedule_interval",
@@ -196,15 +202,13 @@ fn check_call_arguments(checker: &Checker, qualified_name: &QualifiedName, argum
                 "timetable",
                 Some("schedule"),
             ));
+            // without replacement
+            checker.report_diagnostics(diagnostic_for_argument(arguments, "default_view", None));
+            checker.report_diagnostics(diagnostic_for_argument(arguments, "orientation", None));
             checker.report_diagnostics(diagnostic_for_argument(
                 arguments,
                 "sla_miss_callback",
                 None,
-            ));
-            checker.report_diagnostics(diagnostic_for_argument(
-                arguments,
-                "fail_stop",
-                Some("fail_fast"),
             ));
         }
         _ => {
@@ -548,10 +552,14 @@ fn check_name(checker: &Checker, expr: &Expr, range: TextRange) {
 
         // airflow.auth.managers
         ["airflow", "auth", "managers", "models", "resource_details", "DatasetDetails"] => {
-            Replacement::Name("airflow.auth.managers.models.resource_details.AssetDetails")
+            Replacement::Name(
+                "airflow.api_fastapi.auth.managers.models.resource_details.AssetDetails",
+            )
         }
         ["airflow", "auth", "managers", "base_auth_manager", "is_authorized_dataset"] => {
-            Replacement::Name("airflow.auth.managers.base_auth_manager.is_authorized_asset")
+            Replacement::Name(
+                "airflow.api_fastapi.auth.managers.base_auth_manager.is_authorized_asset",
+            )
         }
 
         // airflow.configuration

--- a/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
@@ -698,7 +698,7 @@ fn check_name(checker: &Checker, expr: &Expr, range: TextRange) {
 
         // airflow.sensors
         ["airflow", "sensors", "base_sensor_operator", "BaseSensorOperator"] => {
-            Replacement::Name("airflow.sensors.base.BaseSensorOperator")
+            Replacement::Name("airflow.sdk.bases.sensor.BaseSensorOperator")
         }
         ["airflow", "sensors", "date_time_sensor", "DateTimeSensor"] => {
             Replacement::Name("airflow.sensors.date_time.DateTimeSensor")

--- a/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
@@ -646,6 +646,11 @@ fn check_name(checker: &Checker, expr: &Expr, range: TextRange) {
             Replacement::Name("airflow.sdk.definitions.baseoperatorlink.BaseOperatorLink")
         }
 
+        // airflow.notifications
+        ["airflow", "notifications", "basenotifier", "BaseNotifier"] => {
+            Replacement::Name("airflow.sdk.BaseNotifier")
+        }
+
         // airflow.operators
         ["airflow", "operators", "subdag", ..] => {
             Replacement::Message("The whole `airflow.subdag` module has been removed.")
@@ -754,6 +759,10 @@ fn check_name(checker: &Checker, expr: &Expr, range: TextRange) {
             // airflow.utils.helpers
             ["helpers", "chain"] => Replacement::Name("airflow.sdk.chain"),
             ["helpers", "cross_downstream"] => Replacement::Name("airflow.sdk.cross_downstream"),
+
+            ["log", "secrets_masker"] => {
+                Replacement::Name("airflow.sdk.execution_time.secrets_masker")
+            }
 
             // airflow.utils.state
             ["state", "SHUTDOWN" | "terminating_states"] => Replacement::None,

--- a/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
@@ -279,10 +279,6 @@ fn check_class_attribute(checker: &Checker, attribute_expr: &ExprAttribute) {
     };
 
     let replacement = match *qualname.segments() {
-        ["airflow", .., "DAG" | "dag"] => match attr.as_str() {
-            "allow_future_exec_dates" => Replacement::None,
-            _ => return,
-        },
         ["airflow", "providers_manager", "ProvidersManager"] => match attr.as_str() {
             "dataset_factories" => Replacement::Name("asset_factories"),
             "dataset_uri_handlers" => Replacement::Name("asset_uri_handlers"),
@@ -744,6 +740,9 @@ fn check_name(checker: &Checker, expr: &Expr, range: TextRange) {
                 Replacement::Name("airflow.sdk.get_parsing_context")
             }
 
+            // airflow.utils.db
+            ["db", "create_session"] => Replacement::None,
+
             // airflow.utils.decorators
             ["decorators", "apply_defaults"] => Replacement::Message(
                 "`apply_defaults` is now unconditionally done and can be safely removed.",
@@ -764,6 +763,7 @@ fn check_name(checker: &Checker, expr: &Expr, range: TextRange) {
             ["helpers", "chain"] => Replacement::Name("airflow.sdk.chain"),
             ["helpers", "cross_downstream"] => Replacement::Name("airflow.sdk.cross_downstream"),
 
+            // airflow.utils.log.secrets_masker
             ["log", "secrets_masker"] => {
                 Replacement::Name("airflow.sdk.execution_time.secrets_masker")
             }

--- a/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
@@ -756,8 +756,8 @@ fn check_name(checker: &Checker, expr: &Expr, range: TextRange) {
             }
 
             // airflow.utils.file
-            ["file", "TemporaryDirectory"] => Replacement::None,
-            ["file", "mkdirs"] => Replacement::Name("pendulum.today('UTC').add(days=-N, ...)"),
+            ["file", "TemporaryDirectory"] => Replacement::Name("tempfile.TemporaryDirectory"),
+            ["file", "mkdirs"] => Replacement::Name("pathlib.Path({path}).mkdir"),
 
             // airflow.utils.helpers
             ["helpers", "chain"] => Replacement::Name("airflow.sdk.chain"),

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_args.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_args.py.snap
@@ -2,272 +2,292 @@
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 snapshot_kind: text
 ---
-AIR302_args.py:18:39: AIR302 [*] `schedule_interval` is removed in Airflow 3.0
+AIR302_args.py:20:39: AIR302 [*] `schedule_interval` is removed in Airflow 3.0
    |
-16 | DAG(dag_id="class_schedule", schedule="@hourly")
-17 |
-18 | DAG(dag_id="class_schedule_interval", schedule_interval="@hourly")
-   |                                       ^^^^^^^^^^^^^^^^^ AIR302
+18 | DAG(dag_id="class_schedule", schedule="@hourly")
 19 |
-20 | DAG(dag_id="class_timetable", timetable=NullTimetable())
+20 | DAG(dag_id="class_schedule_interval", schedule_interval="@hourly")
+   |                                       ^^^^^^^^^^^^^^^^^ AIR302
+21 |
+22 | DAG(dag_id="class_timetable", timetable=NullTimetable())
    |
    = help: Use `schedule` instead
 
 ℹ Safe fix
-15 15 | 
-16 16 | DAG(dag_id="class_schedule", schedule="@hourly")
 17 17 | 
-18    |-DAG(dag_id="class_schedule_interval", schedule_interval="@hourly")
-   18 |+DAG(dag_id="class_schedule_interval", schedule="@hourly")
+18 18 | DAG(dag_id="class_schedule", schedule="@hourly")
 19 19 | 
-20 20 | DAG(dag_id="class_timetable", timetable=NullTimetable())
+20    |-DAG(dag_id="class_schedule_interval", schedule_interval="@hourly")
+   20 |+DAG(dag_id="class_schedule_interval", schedule="@hourly")
 21 21 | 
+22 22 | DAG(dag_id="class_timetable", timetable=NullTimetable())
+23 23 | 
 
-AIR302_args.py:20:31: AIR302 [*] `timetable` is removed in Airflow 3.0
+AIR302_args.py:22:31: AIR302 [*] `timetable` is removed in Airflow 3.0
    |
-18 | DAG(dag_id="class_schedule_interval", schedule_interval="@hourly")
-19 |
-20 | DAG(dag_id="class_timetable", timetable=NullTimetable())
+20 | DAG(dag_id="class_schedule_interval", schedule_interval="@hourly")
+21 |
+22 | DAG(dag_id="class_timetable", timetable=NullTimetable())
    |                               ^^^^^^^^^ AIR302
    |
    = help: Use `schedule` instead
 
 ℹ Safe fix
-17 17 | 
-18 18 | DAG(dag_id="class_schedule_interval", schedule_interval="@hourly")
 19 19 | 
-20    |-DAG(dag_id="class_timetable", timetable=NullTimetable())
-   20 |+DAG(dag_id="class_timetable", schedule=NullTimetable())
+20 20 | DAG(dag_id="class_schedule_interval", schedule_interval="@hourly")
 21 21 | 
-22 22 | 
-23 23 | def sla_callback(*arg, **kwargs):
+22    |-DAG(dag_id="class_timetable", timetable=NullTimetable())
+   22 |+DAG(dag_id="class_timetable", schedule=NullTimetable())
+23 23 | 
+24 24 | 
+25 25 | def sla_callback(*arg, **kwargs):
 
-AIR302_args.py:27:34: AIR302 `sla_miss_callback` is removed in Airflow 3.0
+AIR302_args.py:29:34: AIR302 `sla_miss_callback` is removed in Airflow 3.0
    |
-27 | DAG(dag_id="class_sla_callback", sla_miss_callback=sla_callback)
+29 | DAG(dag_id="class_sla_callback", sla_miss_callback=sla_callback)
    |                                  ^^^^^^^^^^^^^^^^^ AIR302
-28 |
-29 | DAG(dag_id="class_sla_callback", fail_stop=True)
+30 |
+31 | DAG(dag_id="class_fail_stop", fail_stop=True)
    |
 
-AIR302_args.py:29:34: AIR302 [*] `fail_stop` is removed in Airflow 3.0
+AIR302_args.py:31:31: AIR302 [*] `fail_stop` is removed in Airflow 3.0
    |
-27 | DAG(dag_id="class_sla_callback", sla_miss_callback=sla_callback)
-28 |
-29 | DAG(dag_id="class_sla_callback", fail_stop=True)
-   |                                  ^^^^^^^^^ AIR302
+29 | DAG(dag_id="class_sla_callback", sla_miss_callback=sla_callback)
+30 |
+31 | DAG(dag_id="class_fail_stop", fail_stop=True)
+   |                               ^^^^^^^^^ AIR302
+32 |
+33 | DAG(dag_id="class_default_view", default_view="dag_default_view")
    |
    = help: Use `fail_fast` instead
 
 ℹ Safe fix
-26 26 | 
-27 27 | DAG(dag_id="class_sla_callback", sla_miss_callback=sla_callback)
 28 28 | 
-29    |-DAG(dag_id="class_sla_callback", fail_stop=True)
-   29 |+DAG(dag_id="class_sla_callback", fail_fast=True)
+29 29 | DAG(dag_id="class_sla_callback", sla_miss_callback=sla_callback)
 30 30 | 
-31 31 | 
-32 32 | @dag(schedule="0 * * * *")
+31    |-DAG(dag_id="class_fail_stop", fail_stop=True)
+   31 |+DAG(dag_id="class_fail_stop", fail_fast=True)
+32 32 | 
+33 33 | DAG(dag_id="class_default_view", default_view="dag_default_view")
+34 34 | 
 
-AIR302_args.py:37:6: AIR302 [*] `schedule_interval` is removed in Airflow 3.0
+AIR302_args.py:33:34: AIR302 `default_view` is removed in Airflow 3.0
    |
-37 | @dag(schedule_interval="0 * * * *")
+31 | DAG(dag_id="class_fail_stop", fail_stop=True)
+32 |
+33 | DAG(dag_id="class_default_view", default_view="dag_default_view")
+   |                                  ^^^^^^^^^^^^ AIR302
+34 |
+35 | DAG(dag_id="class_orientation", orientation="BT")
+   |
+
+AIR302_args.py:35:33: AIR302 `orientation` is removed in Airflow 3.0
+   |
+33 | DAG(dag_id="class_default_view", default_view="dag_default_view")
+34 |
+35 | DAG(dag_id="class_orientation", orientation="BT")
+   |                                 ^^^^^^^^^^^ AIR302
+   |
+
+AIR302_args.py:43:6: AIR302 [*] `schedule_interval` is removed in Airflow 3.0
+   |
+43 | @dag(schedule_interval="0 * * * *")
    |      ^^^^^^^^^^^^^^^^^ AIR302
-38 | def decorator_schedule_interval():
-39 |     pass
+44 | def decorator_schedule_interval():
+45 |     pass
    |
    = help: Use `schedule` instead
 
 ℹ Safe fix
-34 34 |     pass
-35 35 | 
-36 36 | 
-37    |-@dag(schedule_interval="0 * * * *")
-   37 |+@dag(schedule="0 * * * *")
-38 38 | def decorator_schedule_interval():
-39 39 |     pass
-40 40 | 
-
-AIR302_args.py:42:6: AIR302 [*] `timetable` is removed in Airflow 3.0
-   |
-42 | @dag(timetable=NullTimetable())
-   |      ^^^^^^^^^ AIR302
-43 | def decorator_timetable():
-44 |     pass
-   |
-   = help: Use `schedule` instead
-
-ℹ Safe fix
-39 39 |     pass
-40 40 | 
+40 40 |     pass
 41 41 | 
-42    |-@dag(timetable=NullTimetable())
-   42 |+@dag(schedule=NullTimetable())
-43 43 | def decorator_timetable():
-44 44 |     pass
-45 45 | 
+42 42 | 
+43    |-@dag(schedule_interval="0 * * * *")
+   43 |+@dag(schedule="0 * * * *")
+44 44 | def decorator_schedule_interval():
+45 45 |     pass
+46 46 | 
 
-AIR302_args.py:47:6: AIR302 `sla_miss_callback` is removed in Airflow 3.0
+AIR302_args.py:48:6: AIR302 [*] `timetable` is removed in Airflow 3.0
    |
-47 | @dag(sla_miss_callback=sla_callback)
+48 | @dag(timetable=NullTimetable())
+   |      ^^^^^^^^^ AIR302
+49 | def decorator_timetable():
+50 |     pass
+   |
+   = help: Use `schedule` instead
+
+ℹ Safe fix
+45 45 |     pass
+46 46 | 
+47 47 | 
+48    |-@dag(timetable=NullTimetable())
+   48 |+@dag(schedule=NullTimetable())
+49 49 | def decorator_timetable():
+50 50 |     pass
+51 51 | 
+
+AIR302_args.py:53:6: AIR302 `sla_miss_callback` is removed in Airflow 3.0
+   |
+53 | @dag(sla_miss_callback=sla_callback)
    |      ^^^^^^^^^^^^^^^^^ AIR302
-48 | def decorator_sla_callback():
-49 |     pass
+54 | def decorator_sla_callback():
+55 |     pass
    |
 
-AIR302_args.py:55:39: AIR302 [*] `execution_date` is removed in Airflow 3.0
+AIR302_args.py:61:39: AIR302 [*] `execution_date` is removed in Airflow 3.0
    |
-53 | def decorator_deprecated_operator_args():
-54 |     trigger_dagrun_op = trigger_dagrun.TriggerDagRunOperator(
-55 |         task_id="trigger_dagrun_op1", execution_date="2024-12-04"
+59 | def decorator_deprecated_operator_args():
+60 |     trigger_dagrun_op = trigger_dagrun.TriggerDagRunOperator(
+61 |         task_id="trigger_dagrun_op1", execution_date="2024-12-04"
    |                                       ^^^^^^^^^^^^^^ AIR302
-56 |     )
-57 |     trigger_dagrun_op2 = TriggerDagRunOperator(
+62 |     )
+63 |     trigger_dagrun_op2 = TriggerDagRunOperator(
    |
    = help: Use `logical_date` instead
 
 ℹ Safe fix
-52 52 | @dag()
-53 53 | def decorator_deprecated_operator_args():
-54 54 |     trigger_dagrun_op = trigger_dagrun.TriggerDagRunOperator(
-55    |-        task_id="trigger_dagrun_op1", execution_date="2024-12-04"
-   55 |+        task_id="trigger_dagrun_op1", logical_date="2024-12-04"
-56 56 |     )
-57 57 |     trigger_dagrun_op2 = TriggerDagRunOperator(
-58 58 |         task_id="trigger_dagrun_op2", execution_date="2024-12-04"
+58 58 | @dag()
+59 59 | def decorator_deprecated_operator_args():
+60 60 |     trigger_dagrun_op = trigger_dagrun.TriggerDagRunOperator(
+61    |-        task_id="trigger_dagrun_op1", execution_date="2024-12-04"
+   61 |+        task_id="trigger_dagrun_op1", logical_date="2024-12-04"
+62 62 |     )
+63 63 |     trigger_dagrun_op2 = TriggerDagRunOperator(
+64 64 |         task_id="trigger_dagrun_op2", execution_date="2024-12-04"
 
-AIR302_args.py:58:39: AIR302 [*] `execution_date` is removed in Airflow 3.0
+AIR302_args.py:64:39: AIR302 [*] `execution_date` is removed in Airflow 3.0
    |
-56 |     )
-57 |     trigger_dagrun_op2 = TriggerDagRunOperator(
-58 |         task_id="trigger_dagrun_op2", execution_date="2024-12-04"
+62 |     )
+63 |     trigger_dagrun_op2 = TriggerDagRunOperator(
+64 |         task_id="trigger_dagrun_op2", execution_date="2024-12-04"
    |                                       ^^^^^^^^^^^^^^ AIR302
-59 |     )
+65 |     )
    |
    = help: Use `logical_date` instead
 
 ℹ Safe fix
-55 55 |         task_id="trigger_dagrun_op1", execution_date="2024-12-04"
-56 56 |     )
-57 57 |     trigger_dagrun_op2 = TriggerDagRunOperator(
-58    |-        task_id="trigger_dagrun_op2", execution_date="2024-12-04"
-   58 |+        task_id="trigger_dagrun_op2", logical_date="2024-12-04"
-59 59 |     )
-60 60 | 
-61 61 |     branch_dt_op = datetime.BranchDateTimeOperator(
+61 61 |         task_id="trigger_dagrun_op1", execution_date="2024-12-04"
+62 62 |     )
+63 63 |     trigger_dagrun_op2 = TriggerDagRunOperator(
+64    |-        task_id="trigger_dagrun_op2", execution_date="2024-12-04"
+   64 |+        task_id="trigger_dagrun_op2", logical_date="2024-12-04"
+65 65 |     )
+66 66 | 
+67 67 |     branch_dt_op = datetime.BranchDateTimeOperator(
 
-AIR302_args.py:62:33: AIR302 [*] `use_task_execution_day` is removed in Airflow 3.0
+AIR302_args.py:68:33: AIR302 [*] `use_task_execution_day` is removed in Airflow 3.0
    |
-61 |     branch_dt_op = datetime.BranchDateTimeOperator(
-62 |         task_id="branch_dt_op", use_task_execution_day=True, task_concurrency=5
+67 |     branch_dt_op = datetime.BranchDateTimeOperator(
+68 |         task_id="branch_dt_op", use_task_execution_day=True, task_concurrency=5
    |                                 ^^^^^^^^^^^^^^^^^^^^^^ AIR302
-63 |     )
-64 |     branch_dt_op2 = BranchDateTimeOperator(
+69 |     )
+70 |     branch_dt_op2 = BranchDateTimeOperator(
    |
    = help: Use `use_task_logical_date` instead
 
 ℹ Safe fix
-59 59 |     )
-60 60 | 
-61 61 |     branch_dt_op = datetime.BranchDateTimeOperator(
-62    |-        task_id="branch_dt_op", use_task_execution_day=True, task_concurrency=5
-   62 |+        task_id="branch_dt_op", use_task_logical_date=True, task_concurrency=5
-63 63 |     )
-64 64 |     branch_dt_op2 = BranchDateTimeOperator(
-65 65 |         task_id="branch_dt_op2",
+65 65 |     )
+66 66 | 
+67 67 |     branch_dt_op = datetime.BranchDateTimeOperator(
+68    |-        task_id="branch_dt_op", use_task_execution_day=True, task_concurrency=5
+   68 |+        task_id="branch_dt_op", use_task_logical_date=True, task_concurrency=5
+69 69 |     )
+70 70 |     branch_dt_op2 = BranchDateTimeOperator(
+71 71 |         task_id="branch_dt_op2",
 
-AIR302_args.py:62:62: AIR302 [*] `task_concurrency` is removed in Airflow 3.0
+AIR302_args.py:68:62: AIR302 [*] `task_concurrency` is removed in Airflow 3.0
    |
-61 |     branch_dt_op = datetime.BranchDateTimeOperator(
-62 |         task_id="branch_dt_op", use_task_execution_day=True, task_concurrency=5
+67 |     branch_dt_op = datetime.BranchDateTimeOperator(
+68 |         task_id="branch_dt_op", use_task_execution_day=True, task_concurrency=5
    |                                                              ^^^^^^^^^^^^^^^^ AIR302
-63 |     )
-64 |     branch_dt_op2 = BranchDateTimeOperator(
+69 |     )
+70 |     branch_dt_op2 = BranchDateTimeOperator(
    |
    = help: Use `max_active_tis_per_dag` instead
 
 ℹ Safe fix
-59 59 |     )
-60 60 | 
-61 61 |     branch_dt_op = datetime.BranchDateTimeOperator(
-62    |-        task_id="branch_dt_op", use_task_execution_day=True, task_concurrency=5
-   62 |+        task_id="branch_dt_op", use_task_execution_day=True, max_active_tis_per_dag=5
-63 63 |     )
-64 64 |     branch_dt_op2 = BranchDateTimeOperator(
-65 65 |         task_id="branch_dt_op2",
+65 65 |     )
+66 66 | 
+67 67 |     branch_dt_op = datetime.BranchDateTimeOperator(
+68    |-        task_id="branch_dt_op", use_task_execution_day=True, task_concurrency=5
+   68 |+        task_id="branch_dt_op", use_task_execution_day=True, max_active_tis_per_dag=5
+69 69 |     )
+70 70 |     branch_dt_op2 = BranchDateTimeOperator(
+71 71 |         task_id="branch_dt_op2",
 
-AIR302_args.py:66:9: AIR302 [*] `use_task_execution_day` is removed in Airflow 3.0
+AIR302_args.py:72:9: AIR302 [*] `use_task_execution_day` is removed in Airflow 3.0
    |
-64 |     branch_dt_op2 = BranchDateTimeOperator(
-65 |         task_id="branch_dt_op2",
-66 |         use_task_execution_day=True,
+70 |     branch_dt_op2 = BranchDateTimeOperator(
+71 |         task_id="branch_dt_op2",
+72 |         use_task_execution_day=True,
    |         ^^^^^^^^^^^^^^^^^^^^^^ AIR302
-67 |         sla=timedelta(seconds=10),
-68 |     )
+73 |         sla=timedelta(seconds=10),
+74 |     )
    |
    = help: Use `use_task_logical_date` instead
 
 ℹ Safe fix
-63 63 |     )
-64 64 |     branch_dt_op2 = BranchDateTimeOperator(
-65 65 |         task_id="branch_dt_op2",
-66    |-        use_task_execution_day=True,
-   66 |+        use_task_logical_date=True,
-67 67 |         sla=timedelta(seconds=10),
-68 68 |     )
-69 69 | 
+69 69 |     )
+70 70 |     branch_dt_op2 = BranchDateTimeOperator(
+71 71 |         task_id="branch_dt_op2",
+72    |-        use_task_execution_day=True,
+   72 |+        use_task_logical_date=True,
+73 73 |         sla=timedelta(seconds=10),
+74 74 |     )
+75 75 | 
 
-AIR302_args.py:67:9: AIR302 `sla` is removed in Airflow 3.0
+AIR302_args.py:73:9: AIR302 `sla` is removed in Airflow 3.0
    |
-65 |         task_id="branch_dt_op2",
-66 |         use_task_execution_day=True,
-67 |         sla=timedelta(seconds=10),
+71 |         task_id="branch_dt_op2",
+72 |         use_task_execution_day=True,
+73 |         sla=timedelta(seconds=10),
    |         ^^^ AIR302
-68 |     )
+74 |     )
    |
 
-AIR302_args.py:89:15: AIR302 `filename_template` is removed in Airflow 3.0
+AIR302_args.py:95:15: AIR302 `filename_template` is removed in Airflow 3.0
    |
-88 | # deprecated filename_template argument in FileTaskHandler
-89 | S3TaskHandler(filename_template="/tmp/test")
+94 | # deprecated filename_template argument in FileTaskHandler
+95 | S3TaskHandler(filename_template="/tmp/test")
    |               ^^^^^^^^^^^^^^^^^ AIR302
-90 | HdfsTaskHandler(filename_template="/tmp/test")
-91 | ElasticsearchTaskHandler(filename_template="/tmp/test")
+96 | HdfsTaskHandler(filename_template="/tmp/test")
+97 | ElasticsearchTaskHandler(filename_template="/tmp/test")
    |
 
-AIR302_args.py:90:17: AIR302 `filename_template` is removed in Airflow 3.0
+AIR302_args.py:96:17: AIR302 `filename_template` is removed in Airflow 3.0
    |
-88 | # deprecated filename_template argument in FileTaskHandler
-89 | S3TaskHandler(filename_template="/tmp/test")
-90 | HdfsTaskHandler(filename_template="/tmp/test")
+94 | # deprecated filename_template argument in FileTaskHandler
+95 | S3TaskHandler(filename_template="/tmp/test")
+96 | HdfsTaskHandler(filename_template="/tmp/test")
    |                 ^^^^^^^^^^^^^^^^^ AIR302
-91 | ElasticsearchTaskHandler(filename_template="/tmp/test")
-92 | GCSTaskHandler(filename_template="/tmp/test")
+97 | ElasticsearchTaskHandler(filename_template="/tmp/test")
+98 | GCSTaskHandler(filename_template="/tmp/test")
    |
 
-AIR302_args.py:91:26: AIR302 `filename_template` is removed in Airflow 3.0
+AIR302_args.py:97:26: AIR302 `filename_template` is removed in Airflow 3.0
    |
-89 | S3TaskHandler(filename_template="/tmp/test")
-90 | HdfsTaskHandler(filename_template="/tmp/test")
-91 | ElasticsearchTaskHandler(filename_template="/tmp/test")
+95 | S3TaskHandler(filename_template="/tmp/test")
+96 | HdfsTaskHandler(filename_template="/tmp/test")
+97 | ElasticsearchTaskHandler(filename_template="/tmp/test")
    |                          ^^^^^^^^^^^^^^^^^ AIR302
-92 | GCSTaskHandler(filename_template="/tmp/test")
+98 | GCSTaskHandler(filename_template="/tmp/test")
    |
 
-AIR302_args.py:92:16: AIR302 `filename_template` is removed in Airflow 3.0
-   |
-90 | HdfsTaskHandler(filename_template="/tmp/test")
-91 | ElasticsearchTaskHandler(filename_template="/tmp/test")
-92 | GCSTaskHandler(filename_template="/tmp/test")
-   |                ^^^^^^^^^^^^^^^^^ AIR302
-93 |
-94 | FabAuthManager(None)
-   |
+AIR302_args.py:98:16: AIR302 `filename_template` is removed in Airflow 3.0
+    |
+ 96 | HdfsTaskHandler(filename_template="/tmp/test")
+ 97 | ElasticsearchTaskHandler(filename_template="/tmp/test")
+ 98 | GCSTaskHandler(filename_template="/tmp/test")
+    |                ^^^^^^^^^^^^^^^^^ AIR302
+ 99 |
+100 | FabAuthManager(None)
+    |
 
-AIR302_args.py:94:15: AIR302 `appbuilder` is removed in Airflow 3.0; The constructor takes no parameter now
-   |
-92 | GCSTaskHandler(filename_template="/tmp/test")
-93 |
-94 | FabAuthManager(None)
-   |               ^^^^^^ AIR302
-   |
+AIR302_args.py:100:15: AIR302 `appbuilder` is removed in Airflow 3.0; The constructor takes no parameter now
+    |
+ 98 | GCSTaskHandler(filename_template="/tmp/test")
+ 99 |
+100 | FabAuthManager(None)
+    |               ^^^^^^ AIR302
+    |

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_args.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_args.py.snap
@@ -87,207 +87,216 @@ AIR302_args.py:35:33: AIR302 `orientation` is removed in Airflow 3.0
 34 |
 35 | DAG(dag_id="class_orientation", orientation="BT")
    |                                 ^^^^^^^^^^^ AIR302
+36 |
+37 | allow_future_exec_dates_dag = DAG(dag_id="class_allow_future_exec_dates")
    |
 
-AIR302_args.py:43:6: AIR302 [*] `schedule_interval` is removed in Airflow 3.0
+AIR302_args.py:38:29: AIR302 `allow_future_exec_dates` is removed in Airflow 3.0
    |
-43 | @dag(schedule_interval="0 * * * *")
+37 | allow_future_exec_dates_dag = DAG(dag_id="class_allow_future_exec_dates")
+38 | allow_future_exec_dates_dag.allow_future_exec_dates
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^ AIR302
+   |
+
+AIR302_args.py:46:6: AIR302 [*] `schedule_interval` is removed in Airflow 3.0
+   |
+46 | @dag(schedule_interval="0 * * * *")
    |      ^^^^^^^^^^^^^^^^^ AIR302
-44 | def decorator_schedule_interval():
-45 |     pass
+47 | def decorator_schedule_interval():
+48 |     pass
    |
    = help: Use `schedule` instead
 
 ℹ Safe fix
-40 40 |     pass
-41 41 | 
-42 42 | 
-43    |-@dag(schedule_interval="0 * * * *")
-   43 |+@dag(schedule="0 * * * *")
-44 44 | def decorator_schedule_interval():
-45 45 |     pass
-46 46 | 
+43 43 |     pass
+44 44 | 
+45 45 | 
+46    |-@dag(schedule_interval="0 * * * *")
+   46 |+@dag(schedule="0 * * * *")
+47 47 | def decorator_schedule_interval():
+48 48 |     pass
+49 49 | 
 
-AIR302_args.py:48:6: AIR302 [*] `timetable` is removed in Airflow 3.0
+AIR302_args.py:51:6: AIR302 [*] `timetable` is removed in Airflow 3.0
    |
-48 | @dag(timetable=NullTimetable())
+51 | @dag(timetable=NullTimetable())
    |      ^^^^^^^^^ AIR302
-49 | def decorator_timetable():
-50 |     pass
+52 | def decorator_timetable():
+53 |     pass
    |
    = help: Use `schedule` instead
 
 ℹ Safe fix
-45 45 |     pass
-46 46 | 
-47 47 | 
-48    |-@dag(timetable=NullTimetable())
-   48 |+@dag(schedule=NullTimetable())
-49 49 | def decorator_timetable():
-50 50 |     pass
-51 51 | 
+48 48 |     pass
+49 49 | 
+50 50 | 
+51    |-@dag(timetable=NullTimetable())
+   51 |+@dag(schedule=NullTimetable())
+52 52 | def decorator_timetable():
+53 53 |     pass
+54 54 | 
 
-AIR302_args.py:53:6: AIR302 `sla_miss_callback` is removed in Airflow 3.0
+AIR302_args.py:56:6: AIR302 `sla_miss_callback` is removed in Airflow 3.0
    |
-53 | @dag(sla_miss_callback=sla_callback)
+56 | @dag(sla_miss_callback=sla_callback)
    |      ^^^^^^^^^^^^^^^^^ AIR302
-54 | def decorator_sla_callback():
-55 |     pass
+57 | def decorator_sla_callback():
+58 |     pass
    |
-
-AIR302_args.py:61:39: AIR302 [*] `execution_date` is removed in Airflow 3.0
-   |
-59 | def decorator_deprecated_operator_args():
-60 |     trigger_dagrun_op = trigger_dagrun.TriggerDagRunOperator(
-61 |         task_id="trigger_dagrun_op1", execution_date="2024-12-04"
-   |                                       ^^^^^^^^^^^^^^ AIR302
-62 |     )
-63 |     trigger_dagrun_op2 = TriggerDagRunOperator(
-   |
-   = help: Use `logical_date` instead
-
-ℹ Safe fix
-58 58 | @dag()
-59 59 | def decorator_deprecated_operator_args():
-60 60 |     trigger_dagrun_op = trigger_dagrun.TriggerDagRunOperator(
-61    |-        task_id="trigger_dagrun_op1", execution_date="2024-12-04"
-   61 |+        task_id="trigger_dagrun_op1", logical_date="2024-12-04"
-62 62 |     )
-63 63 |     trigger_dagrun_op2 = TriggerDagRunOperator(
-64 64 |         task_id="trigger_dagrun_op2", execution_date="2024-12-04"
 
 AIR302_args.py:64:39: AIR302 [*] `execution_date` is removed in Airflow 3.0
    |
-62 |     )
-63 |     trigger_dagrun_op2 = TriggerDagRunOperator(
-64 |         task_id="trigger_dagrun_op2", execution_date="2024-12-04"
+62 | def decorator_deprecated_operator_args():
+63 |     trigger_dagrun_op = trigger_dagrun.TriggerDagRunOperator(
+64 |         task_id="trigger_dagrun_op1", execution_date="2024-12-04"
    |                                       ^^^^^^^^^^^^^^ AIR302
 65 |     )
+66 |     trigger_dagrun_op2 = TriggerDagRunOperator(
    |
    = help: Use `logical_date` instead
 
 ℹ Safe fix
-61 61 |         task_id="trigger_dagrun_op1", execution_date="2024-12-04"
-62 62 |     )
-63 63 |     trigger_dagrun_op2 = TriggerDagRunOperator(
-64    |-        task_id="trigger_dagrun_op2", execution_date="2024-12-04"
-   64 |+        task_id="trigger_dagrun_op2", logical_date="2024-12-04"
+61 61 | @dag()
+62 62 | def decorator_deprecated_operator_args():
+63 63 |     trigger_dagrun_op = trigger_dagrun.TriggerDagRunOperator(
+64    |-        task_id="trigger_dagrun_op1", execution_date="2024-12-04"
+   64 |+        task_id="trigger_dagrun_op1", logical_date="2024-12-04"
 65 65 |     )
-66 66 | 
-67 67 |     branch_dt_op = datetime.BranchDateTimeOperator(
+66 66 |     trigger_dagrun_op2 = TriggerDagRunOperator(
+67 67 |         task_id="trigger_dagrun_op2", execution_date="2024-12-04"
 
-AIR302_args.py:68:33: AIR302 [*] `use_task_execution_day` is removed in Airflow 3.0
+AIR302_args.py:67:39: AIR302 [*] `execution_date` is removed in Airflow 3.0
    |
-67 |     branch_dt_op = datetime.BranchDateTimeOperator(
-68 |         task_id="branch_dt_op", use_task_execution_day=True, task_concurrency=5
+65 |     )
+66 |     trigger_dagrun_op2 = TriggerDagRunOperator(
+67 |         task_id="trigger_dagrun_op2", execution_date="2024-12-04"
+   |                                       ^^^^^^^^^^^^^^ AIR302
+68 |     )
+   |
+   = help: Use `logical_date` instead
+
+ℹ Safe fix
+64 64 |         task_id="trigger_dagrun_op1", execution_date="2024-12-04"
+65 65 |     )
+66 66 |     trigger_dagrun_op2 = TriggerDagRunOperator(
+67    |-        task_id="trigger_dagrun_op2", execution_date="2024-12-04"
+   67 |+        task_id="trigger_dagrun_op2", logical_date="2024-12-04"
+68 68 |     )
+69 69 | 
+70 70 |     branch_dt_op = datetime.BranchDateTimeOperator(
+
+AIR302_args.py:71:33: AIR302 [*] `use_task_execution_day` is removed in Airflow 3.0
+   |
+70 |     branch_dt_op = datetime.BranchDateTimeOperator(
+71 |         task_id="branch_dt_op", use_task_execution_day=True, task_concurrency=5
    |                                 ^^^^^^^^^^^^^^^^^^^^^^ AIR302
-69 |     )
-70 |     branch_dt_op2 = BranchDateTimeOperator(
+72 |     )
+73 |     branch_dt_op2 = BranchDateTimeOperator(
    |
    = help: Use `use_task_logical_date` instead
 
 ℹ Safe fix
-65 65 |     )
-66 66 | 
-67 67 |     branch_dt_op = datetime.BranchDateTimeOperator(
-68    |-        task_id="branch_dt_op", use_task_execution_day=True, task_concurrency=5
-   68 |+        task_id="branch_dt_op", use_task_logical_date=True, task_concurrency=5
-69 69 |     )
-70 70 |     branch_dt_op2 = BranchDateTimeOperator(
-71 71 |         task_id="branch_dt_op2",
+68 68 |     )
+69 69 | 
+70 70 |     branch_dt_op = datetime.BranchDateTimeOperator(
+71    |-        task_id="branch_dt_op", use_task_execution_day=True, task_concurrency=5
+   71 |+        task_id="branch_dt_op", use_task_logical_date=True, task_concurrency=5
+72 72 |     )
+73 73 |     branch_dt_op2 = BranchDateTimeOperator(
+74 74 |         task_id="branch_dt_op2",
 
-AIR302_args.py:68:62: AIR302 [*] `task_concurrency` is removed in Airflow 3.0
+AIR302_args.py:71:62: AIR302 [*] `task_concurrency` is removed in Airflow 3.0
    |
-67 |     branch_dt_op = datetime.BranchDateTimeOperator(
-68 |         task_id="branch_dt_op", use_task_execution_day=True, task_concurrency=5
+70 |     branch_dt_op = datetime.BranchDateTimeOperator(
+71 |         task_id="branch_dt_op", use_task_execution_day=True, task_concurrency=5
    |                                                              ^^^^^^^^^^^^^^^^ AIR302
-69 |     )
-70 |     branch_dt_op2 = BranchDateTimeOperator(
+72 |     )
+73 |     branch_dt_op2 = BranchDateTimeOperator(
    |
    = help: Use `max_active_tis_per_dag` instead
 
 ℹ Safe fix
-65 65 |     )
-66 66 | 
-67 67 |     branch_dt_op = datetime.BranchDateTimeOperator(
-68    |-        task_id="branch_dt_op", use_task_execution_day=True, task_concurrency=5
-   68 |+        task_id="branch_dt_op", use_task_execution_day=True, max_active_tis_per_dag=5
-69 69 |     )
-70 70 |     branch_dt_op2 = BranchDateTimeOperator(
-71 71 |         task_id="branch_dt_op2",
+68 68 |     )
+69 69 | 
+70 70 |     branch_dt_op = datetime.BranchDateTimeOperator(
+71    |-        task_id="branch_dt_op", use_task_execution_day=True, task_concurrency=5
+   71 |+        task_id="branch_dt_op", use_task_execution_day=True, max_active_tis_per_dag=5
+72 72 |     )
+73 73 |     branch_dt_op2 = BranchDateTimeOperator(
+74 74 |         task_id="branch_dt_op2",
 
-AIR302_args.py:72:9: AIR302 [*] `use_task_execution_day` is removed in Airflow 3.0
+AIR302_args.py:75:9: AIR302 [*] `use_task_execution_day` is removed in Airflow 3.0
    |
-70 |     branch_dt_op2 = BranchDateTimeOperator(
-71 |         task_id="branch_dt_op2",
-72 |         use_task_execution_day=True,
+73 |     branch_dt_op2 = BranchDateTimeOperator(
+74 |         task_id="branch_dt_op2",
+75 |         use_task_execution_day=True,
    |         ^^^^^^^^^^^^^^^^^^^^^^ AIR302
-73 |         sla=timedelta(seconds=10),
-74 |     )
+76 |         sla=timedelta(seconds=10),
+77 |     )
    |
    = help: Use `use_task_logical_date` instead
 
 ℹ Safe fix
-69 69 |     )
-70 70 |     branch_dt_op2 = BranchDateTimeOperator(
-71 71 |         task_id="branch_dt_op2",
-72    |-        use_task_execution_day=True,
-   72 |+        use_task_logical_date=True,
-73 73 |         sla=timedelta(seconds=10),
-74 74 |     )
-75 75 | 
+72 72 |     )
+73 73 |     branch_dt_op2 = BranchDateTimeOperator(
+74 74 |         task_id="branch_dt_op2",
+75    |-        use_task_execution_day=True,
+   75 |+        use_task_logical_date=True,
+76 76 |         sla=timedelta(seconds=10),
+77 77 |     )
+78 78 | 
 
-AIR302_args.py:73:9: AIR302 `sla` is removed in Airflow 3.0
+AIR302_args.py:76:9: AIR302 `sla` is removed in Airflow 3.0
    |
-71 |         task_id="branch_dt_op2",
-72 |         use_task_execution_day=True,
-73 |         sla=timedelta(seconds=10),
+74 |         task_id="branch_dt_op2",
+75 |         use_task_execution_day=True,
+76 |         sla=timedelta(seconds=10),
    |         ^^^ AIR302
-74 |     )
+77 |     )
    |
 
-AIR302_args.py:95:15: AIR302 `filename_template` is removed in Airflow 3.0
-   |
-94 | # deprecated filename_template argument in FileTaskHandler
-95 | S3TaskHandler(filename_template="/tmp/test")
-   |               ^^^^^^^^^^^^^^^^^ AIR302
-96 | HdfsTaskHandler(filename_template="/tmp/test")
-97 | ElasticsearchTaskHandler(filename_template="/tmp/test")
-   |
-
-AIR302_args.py:96:17: AIR302 `filename_template` is removed in Airflow 3.0
-   |
-94 | # deprecated filename_template argument in FileTaskHandler
-95 | S3TaskHandler(filename_template="/tmp/test")
-96 | HdfsTaskHandler(filename_template="/tmp/test")
-   |                 ^^^^^^^^^^^^^^^^^ AIR302
-97 | ElasticsearchTaskHandler(filename_template="/tmp/test")
-98 | GCSTaskHandler(filename_template="/tmp/test")
-   |
-
-AIR302_args.py:97:26: AIR302 `filename_template` is removed in Airflow 3.0
-   |
-95 | S3TaskHandler(filename_template="/tmp/test")
-96 | HdfsTaskHandler(filename_template="/tmp/test")
-97 | ElasticsearchTaskHandler(filename_template="/tmp/test")
-   |                          ^^^^^^^^^^^^^^^^^ AIR302
-98 | GCSTaskHandler(filename_template="/tmp/test")
-   |
-
-AIR302_args.py:98:16: AIR302 `filename_template` is removed in Airflow 3.0
+AIR302_args.py:98:15: AIR302 `filename_template` is removed in Airflow 3.0
     |
- 96 | HdfsTaskHandler(filename_template="/tmp/test")
- 97 | ElasticsearchTaskHandler(filename_template="/tmp/test")
- 98 | GCSTaskHandler(filename_template="/tmp/test")
+ 97 | # deprecated filename_template argument in FileTaskHandler
+ 98 | S3TaskHandler(filename_template="/tmp/test")
+    |               ^^^^^^^^^^^^^^^^^ AIR302
+ 99 | HdfsTaskHandler(filename_template="/tmp/test")
+100 | ElasticsearchTaskHandler(filename_template="/tmp/test")
+    |
+
+AIR302_args.py:99:17: AIR302 `filename_template` is removed in Airflow 3.0
+    |
+ 97 | # deprecated filename_template argument in FileTaskHandler
+ 98 | S3TaskHandler(filename_template="/tmp/test")
+ 99 | HdfsTaskHandler(filename_template="/tmp/test")
+    |                 ^^^^^^^^^^^^^^^^^ AIR302
+100 | ElasticsearchTaskHandler(filename_template="/tmp/test")
+101 | GCSTaskHandler(filename_template="/tmp/test")
+    |
+
+AIR302_args.py:100:26: AIR302 `filename_template` is removed in Airflow 3.0
+    |
+ 98 | S3TaskHandler(filename_template="/tmp/test")
+ 99 | HdfsTaskHandler(filename_template="/tmp/test")
+100 | ElasticsearchTaskHandler(filename_template="/tmp/test")
+    |                          ^^^^^^^^^^^^^^^^^ AIR302
+101 | GCSTaskHandler(filename_template="/tmp/test")
+    |
+
+AIR302_args.py:101:16: AIR302 `filename_template` is removed in Airflow 3.0
+    |
+ 99 | HdfsTaskHandler(filename_template="/tmp/test")
+100 | ElasticsearchTaskHandler(filename_template="/tmp/test")
+101 | GCSTaskHandler(filename_template="/tmp/test")
     |                ^^^^^^^^^^^^^^^^^ AIR302
- 99 |
-100 | FabAuthManager(None)
+102 |
+103 | FabAuthManager(None)
     |
 
-AIR302_args.py:100:15: AIR302 `appbuilder` is removed in Airflow 3.0; The constructor takes no parameter now
+AIR302_args.py:103:15: AIR302 `appbuilder` is removed in Airflow 3.0; The constructor takes no parameter now
     |
- 98 | GCSTaskHandler(filename_template="/tmp/test")
- 99 |
-100 | FabAuthManager(None)
+101 | GCSTaskHandler(filename_template="/tmp/test")
+102 |
+103 | FabAuthManager(None)
     |               ^^^^^^ AIR302
     |

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_args.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_args.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_linter/src/rules/airflow/mod.rs
-snapshot_kind: text
 ---
 AIR302_args.py:20:39: AIR302 [*] `schedule_interval` is removed in Airflow 3.0
    |
@@ -89,13 +88,6 @@ AIR302_args.py:35:33: AIR302 `orientation` is removed in Airflow 3.0
    |                                 ^^^^^^^^^^^ AIR302
 36 |
 37 | allow_future_exec_dates_dag = DAG(dag_id="class_allow_future_exec_dates")
-   |
-
-AIR302_args.py:38:29: AIR302 `allow_future_exec_dates` is removed in Airflow 3.0
-   |
-37 | allow_future_exec_dates_dag = DAG(dag_id="class_allow_future_exec_dates")
-38 | allow_future_exec_dates_dag.allow_future_exec_dates
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^ AIR302
    |
 
 AIR302_args.py:46:6: AIR302 [*] `schedule_interval` is removed in Airflow 3.0

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
@@ -736,7 +736,7 @@ AIR302_names.py:249:1: AIR302 `airflow.sensors.base_sensor_operator.BaseSensorOp
 250 |
 251 | # airflow.sensors.date_time_sensor
     |
-    = help: Use `airflow.sensors.base.BaseSensorOperator` instead
+    = help: Use `airflow.sdk.bases.sensor.BaseSensorOperator` instead
 
 AIR302_names.py:252:1: AIR302 `airflow.sensors.date_time_sensor.DateTimeSensor` is removed in Airflow 3.0
     |

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
@@ -2,1058 +2,1078 @@
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 snapshot_kind: text
 ---
-AIR302_names.py:118:1: AIR302 `airflow.PY36` is removed in Airflow 3.0
+AIR302_names.py:120:1: AIR302 `airflow.PY36` is removed in Airflow 3.0
     |
-117 | # airflow root
-118 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+119 | # airflow root
+120 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
     | ^^^^ AIR302
-119 | DatasetFromRoot()
+121 | DatasetFromRoot()
     |
     = help: Use `sys.version_info` instead
 
-AIR302_names.py:118:7: AIR302 `airflow.PY37` is removed in Airflow 3.0
+AIR302_names.py:120:7: AIR302 `airflow.PY37` is removed in Airflow 3.0
     |
-117 | # airflow root
-118 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+119 | # airflow root
+120 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
     |       ^^^^ AIR302
-119 | DatasetFromRoot()
+121 | DatasetFromRoot()
     |
     = help: Use `sys.version_info` instead
 
-AIR302_names.py:118:13: AIR302 `airflow.PY38` is removed in Airflow 3.0
+AIR302_names.py:120:13: AIR302 `airflow.PY38` is removed in Airflow 3.0
     |
-117 | # airflow root
-118 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+119 | # airflow root
+120 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
     |             ^^^^ AIR302
-119 | DatasetFromRoot()
+121 | DatasetFromRoot()
     |
     = help: Use `sys.version_info` instead
 
-AIR302_names.py:118:19: AIR302 `airflow.PY39` is removed in Airflow 3.0
+AIR302_names.py:120:19: AIR302 `airflow.PY39` is removed in Airflow 3.0
     |
-117 | # airflow root
-118 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+119 | # airflow root
+120 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
     |                   ^^^^ AIR302
-119 | DatasetFromRoot()
+121 | DatasetFromRoot()
     |
     = help: Use `sys.version_info` instead
 
-AIR302_names.py:118:25: AIR302 `airflow.PY310` is removed in Airflow 3.0
+AIR302_names.py:120:25: AIR302 `airflow.PY310` is removed in Airflow 3.0
     |
-117 | # airflow root
-118 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+119 | # airflow root
+120 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
     |                         ^^^^^ AIR302
-119 | DatasetFromRoot()
+121 | DatasetFromRoot()
     |
     = help: Use `sys.version_info` instead
 
-AIR302_names.py:118:32: AIR302 `airflow.PY311` is removed in Airflow 3.0
+AIR302_names.py:120:32: AIR302 `airflow.PY311` is removed in Airflow 3.0
     |
-117 | # airflow root
-118 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+119 | # airflow root
+120 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
     |                                ^^^^^ AIR302
-119 | DatasetFromRoot()
+121 | DatasetFromRoot()
     |
     = help: Use `sys.version_info` instead
 
-AIR302_names.py:118:39: AIR302 `airflow.PY312` is removed in Airflow 3.0
+AIR302_names.py:120:39: AIR302 `airflow.PY312` is removed in Airflow 3.0
     |
-117 | # airflow root
-118 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+119 | # airflow root
+120 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
     |                                       ^^^^^ AIR302
-119 | DatasetFromRoot()
+121 | DatasetFromRoot()
     |
     = help: Use `sys.version_info` instead
 
-AIR302_names.py:119:1: AIR302 `airflow.Dataset` is removed in Airflow 3.0
+AIR302_names.py:121:1: AIR302 `airflow.Dataset` is removed in Airflow 3.0
     |
-117 | # airflow root
-118 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
-119 | DatasetFromRoot()
+119 | # airflow root
+120 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+121 | DatasetFromRoot()
     | ^^^^^^^^^^^^^^^ AIR302
-120 |
-121 | # airflow.api_connexion.security
+122 |
+123 | # airflow.api_connexion.security
     |
     = help: Use `airflow.sdk.Asset` instead
 
-AIR302_names.py:122:1: AIR302 `airflow.api_connexion.security.requires_access` is removed in Airflow 3.0
+AIR302_names.py:124:1: AIR302 `airflow.api_connexion.security.requires_access` is removed in Airflow 3.0
     |
-121 | # airflow.api_connexion.security
-122 | requires_access, requires_access_dataset
+123 | # airflow.api_connexion.security
+124 | requires_access, requires_access_dataset
     | ^^^^^^^^^^^^^^^ AIR302
-123 |
-124 | # airflow.auth.managers
+125 |
+126 | # airflow.auth.managers
     |
     = help: Use `airflow.api_connexion.security.requires_access_*` instead
 
-AIR302_names.py:122:18: AIR302 `airflow.api_connexion.security.requires_access_dataset` is removed in Airflow 3.0
+AIR302_names.py:124:18: AIR302 `airflow.api_connexion.security.requires_access_dataset` is removed in Airflow 3.0
     |
-121 | # airflow.api_connexion.security
-122 | requires_access, requires_access_dataset
+123 | # airflow.api_connexion.security
+124 | requires_access, requires_access_dataset
     |                  ^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-123 |
-124 | # airflow.auth.managers
+125 |
+126 | # airflow.auth.managers
     |
     = help: Use `airflow.api_connexion.security.requires_access_asset` instead
 
-AIR302_names.py:125:1: AIR302 `airflow.auth.managers.base_auth_manager.is_authorized_dataset` is removed in Airflow 3.0
+AIR302_names.py:127:1: AIR302 `airflow.auth.managers.base_auth_manager.is_authorized_dataset` is removed in Airflow 3.0
     |
-124 | # airflow.auth.managers
-125 | is_authorized_dataset
+126 | # airflow.auth.managers
+127 | is_authorized_dataset
     | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-126 | DatasetDetails()
+128 | DatasetDetails()
     |
     = help: Use `airflow.api_fastapi.auth.managers.base_auth_manager.is_authorized_asset` instead
 
-AIR302_names.py:126:1: AIR302 `airflow.auth.managers.models.resource_details.DatasetDetails` is removed in Airflow 3.0
+AIR302_names.py:128:1: AIR302 `airflow.auth.managers.models.resource_details.DatasetDetails` is removed in Airflow 3.0
     |
-124 | # airflow.auth.managers
-125 | is_authorized_dataset
-126 | DatasetDetails()
+126 | # airflow.auth.managers
+127 | is_authorized_dataset
+128 | DatasetDetails()
     | ^^^^^^^^^^^^^^ AIR302
-127 |
-128 | # airflow.configuration
+129 |
+130 | # airflow.configuration
     |
     = help: Use `airflow.api_fastapi.auth.managers.models.resource_details.AssetDetails` instead
 
-AIR302_names.py:129:1: AIR302 `airflow.configuration.get` is removed in Airflow 3.0
+AIR302_names.py:131:1: AIR302 `airflow.configuration.get` is removed in Airflow 3.0
     |
-128 | # airflow.configuration
-129 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+130 | # airflow.configuration
+131 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     | ^^^ AIR302
     |
     = help: Use `airflow.configuration.conf.get` instead
 
-AIR302_names.py:129:6: AIR302 `airflow.configuration.getboolean` is removed in Airflow 3.0
+AIR302_names.py:131:6: AIR302 `airflow.configuration.getboolean` is removed in Airflow 3.0
     |
-128 | # airflow.configuration
-129 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+130 | # airflow.configuration
+131 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     |      ^^^^^^^^^^ AIR302
     |
     = help: Use `airflow.configuration.conf.getboolean` instead
 
-AIR302_names.py:129:18: AIR302 `airflow.configuration.getfloat` is removed in Airflow 3.0
+AIR302_names.py:131:18: AIR302 `airflow.configuration.getfloat` is removed in Airflow 3.0
     |
-128 | # airflow.configuration
-129 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+130 | # airflow.configuration
+131 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     |                  ^^^^^^^^ AIR302
     |
     = help: Use `airflow.configuration.conf.getfloat` instead
 
-AIR302_names.py:129:28: AIR302 `airflow.configuration.getint` is removed in Airflow 3.0
+AIR302_names.py:131:28: AIR302 `airflow.configuration.getint` is removed in Airflow 3.0
     |
-128 | # airflow.configuration
-129 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+130 | # airflow.configuration
+131 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     |                            ^^^^^^ AIR302
     |
     = help: Use `airflow.configuration.conf.getint` instead
 
-AIR302_names.py:129:36: AIR302 `airflow.configuration.has_option` is removed in Airflow 3.0
+AIR302_names.py:131:36: AIR302 `airflow.configuration.has_option` is removed in Airflow 3.0
     |
-128 | # airflow.configuration
-129 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+130 | # airflow.configuration
+131 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     |                                    ^^^^^^^^^^ AIR302
     |
     = help: Use `airflow.configuration.conf.has_option` instead
 
-AIR302_names.py:129:48: AIR302 `airflow.configuration.remove_option` is removed in Airflow 3.0
+AIR302_names.py:131:48: AIR302 `airflow.configuration.remove_option` is removed in Airflow 3.0
     |
-128 | # airflow.configuration
-129 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+130 | # airflow.configuration
+131 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     |                                                ^^^^^^^^^^^^^ AIR302
     |
     = help: Use `airflow.configuration.conf.remove_option` instead
 
-AIR302_names.py:129:63: AIR302 `airflow.configuration.as_dict` is removed in Airflow 3.0
+AIR302_names.py:131:63: AIR302 `airflow.configuration.as_dict` is removed in Airflow 3.0
     |
-128 | # airflow.configuration
-129 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+130 | # airflow.configuration
+131 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     |                                                               ^^^^^^^ AIR302
     |
     = help: Use `airflow.configuration.conf.as_dict` instead
 
-AIR302_names.py:129:72: AIR302 `airflow.configuration.set` is removed in Airflow 3.0
+AIR302_names.py:131:72: AIR302 `airflow.configuration.set` is removed in Airflow 3.0
     |
-128 | # airflow.configuration
-129 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+130 | # airflow.configuration
+131 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     |                                                                        ^^^ AIR302
     |
     = help: Use `airflow.configuration.conf.set` instead
 
-AIR302_names.py:133:1: AIR302 `airflow.contrib.aws_athena_hook.AWSAthenaHook` is removed in Airflow 3.0; The whole `airflow.contrib` module has been removed.
+AIR302_names.py:135:1: AIR302 `airflow.contrib.aws_athena_hook.AWSAthenaHook` is removed in Airflow 3.0; The whole `airflow.contrib` module has been removed.
     |
-132 | # airflow.contrib.*
-133 | AWSAthenaHook()
+134 | # airflow.contrib.*
+135 | AWSAthenaHook()
     | ^^^^^^^^^^^^^ AIR302
-134 |
-135 | # airflow.datasets
+136 |
+137 | # airflow.datasets
     |
 
-AIR302_names.py:136:1: AIR302 `airflow.datasets.Dataset` is removed in Airflow 3.0
+AIR302_names.py:138:1: AIR302 `airflow.datasets.Dataset` is removed in Airflow 3.0
     |
-135 | # airflow.datasets
-136 | Dataset()
+137 | # airflow.datasets
+138 | Dataset()
     | ^^^^^^^ AIR302
-137 | DatasetAlias()
-138 | DatasetAliasEvent()
+139 | DatasetAlias()
+140 | DatasetAliasEvent()
     |
     = help: Use `airflow.sdk.Asset` instead
 
-AIR302_names.py:137:1: AIR302 `airflow.datasets.DatasetAlias` is removed in Airflow 3.0
+AIR302_names.py:139:1: AIR302 `airflow.datasets.DatasetAlias` is removed in Airflow 3.0
     |
-135 | # airflow.datasets
-136 | Dataset()
-137 | DatasetAlias()
+137 | # airflow.datasets
+138 | Dataset()
+139 | DatasetAlias()
     | ^^^^^^^^^^^^ AIR302
-138 | DatasetAliasEvent()
-139 | DatasetAll()
+140 | DatasetAliasEvent()
+141 | DatasetAll()
     |
     = help: Use `airflow.sdk.AssetAlias` instead
 
-AIR302_names.py:138:1: AIR302 `airflow.datasets.DatasetAliasEvent` is removed in Airflow 3.0
+AIR302_names.py:140:1: AIR302 `airflow.datasets.DatasetAliasEvent` is removed in Airflow 3.0
     |
-136 | Dataset()
-137 | DatasetAlias()
-138 | DatasetAliasEvent()
+138 | Dataset()
+139 | DatasetAlias()
+140 | DatasetAliasEvent()
     | ^^^^^^^^^^^^^^^^^ AIR302
-139 | DatasetAll()
-140 | DatasetAny()
+141 | DatasetAll()
+142 | DatasetAny()
     |
 
-AIR302_names.py:139:1: AIR302 `airflow.datasets.DatasetAll` is removed in Airflow 3.0
+AIR302_names.py:141:1: AIR302 `airflow.datasets.DatasetAll` is removed in Airflow 3.0
     |
-137 | DatasetAlias()
-138 | DatasetAliasEvent()
-139 | DatasetAll()
+139 | DatasetAlias()
+140 | DatasetAliasEvent()
+141 | DatasetAll()
     | ^^^^^^^^^^ AIR302
-140 | DatasetAny()
-141 | Metadata()
+142 | DatasetAny()
+143 | Metadata()
     |
     = help: Use `airflow.sdk.AssetAll` instead
 
-AIR302_names.py:140:1: AIR302 `airflow.datasets.DatasetAny` is removed in Airflow 3.0
+AIR302_names.py:142:1: AIR302 `airflow.datasets.DatasetAny` is removed in Airflow 3.0
     |
-138 | DatasetAliasEvent()
-139 | DatasetAll()
-140 | DatasetAny()
+140 | DatasetAliasEvent()
+141 | DatasetAll()
+142 | DatasetAny()
     | ^^^^^^^^^^ AIR302
-141 | Metadata()
-142 | expand_alias_to_datasets
+143 | Metadata()
+144 | expand_alias_to_datasets
     |
     = help: Use `airflow.sdk.AssetAny` instead
 
-AIR302_names.py:141:1: AIR302 `airflow.datasets.metadata.Metadata` is removed in Airflow 3.0
+AIR302_names.py:143:1: AIR302 `airflow.datasets.metadata.Metadata` is removed in Airflow 3.0
     |
-139 | DatasetAll()
-140 | DatasetAny()
-141 | Metadata()
+141 | DatasetAll()
+142 | DatasetAny()
+143 | Metadata()
     | ^^^^^^^^ AIR302
-142 | expand_alias_to_datasets
+144 | expand_alias_to_datasets
     |
     = help: Use `airflow.sdk.Metadata` instead
 
-AIR302_names.py:142:1: AIR302 `airflow.datasets.expand_alias_to_datasets` is removed in Airflow 3.0
+AIR302_names.py:144:1: AIR302 `airflow.datasets.expand_alias_to_datasets` is removed in Airflow 3.0
     |
-140 | DatasetAny()
-141 | Metadata()
-142 | expand_alias_to_datasets
+142 | DatasetAny()
+143 | Metadata()
+144 | expand_alias_to_datasets
     | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-143 |
-144 | # airflow.datasets.manager
+145 |
+146 | # airflow.datasets.manager
     |
     = help: Use `airflow.sdk.expand_alias_to_assets` instead
 
-AIR302_names.py:145:1: AIR302 `airflow.datasets.manager.DatasetManager` is removed in Airflow 3.0
+AIR302_names.py:147:1: AIR302 `airflow.datasets.manager.DatasetManager` is removed in Airflow 3.0
     |
-144 | # airflow.datasets.manager
-145 | DatasetManager()
+146 | # airflow.datasets.manager
+147 | DatasetManager()
     | ^^^^^^^^^^^^^^ AIR302
-146 | dataset_manager
-147 | resolve_dataset_manager
+148 | dataset_manager
+149 | resolve_dataset_manager
     |
     = help: Use `airflow.assets.AssetManager` instead
 
-AIR302_names.py:146:1: AIR302 `airflow.datasets.manager.dataset_manager` is removed in Airflow 3.0
+AIR302_names.py:148:1: AIR302 `airflow.datasets.manager.dataset_manager` is removed in Airflow 3.0
     |
-144 | # airflow.datasets.manager
-145 | DatasetManager()
-146 | dataset_manager
+146 | # airflow.datasets.manager
+147 | DatasetManager()
+148 | dataset_manager
     | ^^^^^^^^^^^^^^^ AIR302
-147 | resolve_dataset_manager
+149 | resolve_dataset_manager
     |
     = help: Use `airflow.assets.manager.asset_manager` instead
 
-AIR302_names.py:147:1: AIR302 `airflow.datasets.manager.resolve_dataset_manager` is removed in Airflow 3.0
+AIR302_names.py:149:1: AIR302 `airflow.datasets.manager.resolve_dataset_manager` is removed in Airflow 3.0
     |
-145 | DatasetManager()
-146 | dataset_manager
-147 | resolve_dataset_manager
+147 | DatasetManager()
+148 | dataset_manager
+149 | resolve_dataset_manager
     | ^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-148 |
-149 | # airflow.hooks
+150 |
+151 | # airflow.hooks
     |
     = help: Use `airflow.assets.resolve_asset_manager` instead
 
-AIR302_names.py:150:1: AIR302 `airflow.hooks.base_hook.BaseHook` is removed in Airflow 3.0
+AIR302_names.py:152:1: AIR302 `airflow.hooks.base_hook.BaseHook` is removed in Airflow 3.0
     |
-149 | # airflow.hooks
-150 | BaseHook()
+151 | # airflow.hooks
+152 | BaseHook()
     | ^^^^^^^^ AIR302
-151 |
-152 | # airflow.lineage.hook
+153 |
+154 | # airflow.lineage.hook
     |
     = help: Use `airflow.hooks.base.BaseHook` instead
 
-AIR302_names.py:153:1: AIR302 `airflow.lineage.hook.DatasetLineageInfo` is removed in Airflow 3.0
+AIR302_names.py:155:1: AIR302 `airflow.lineage.hook.DatasetLineageInfo` is removed in Airflow 3.0
     |
-152 | # airflow.lineage.hook
-153 | DatasetLineageInfo()
+154 | # airflow.lineage.hook
+155 | DatasetLineageInfo()
     | ^^^^^^^^^^^^^^^^^^ AIR302
-154 |
-155 | # airflow.listeners.spec.dataset
+156 |
+157 | # airflow.listeners.spec.dataset
     |
     = help: Use `airflow.lineage.hook.AssetLineageInfo` instead
 
-AIR302_names.py:156:1: AIR302 `airflow.listeners.spec.dataset.on_dataset_changed` is removed in Airflow 3.0
+AIR302_names.py:158:1: AIR302 `airflow.listeners.spec.dataset.on_dataset_changed` is removed in Airflow 3.0
     |
-155 | # airflow.listeners.spec.dataset
-156 | on_dataset_changed
+157 | # airflow.listeners.spec.dataset
+158 | on_dataset_changed
     | ^^^^^^^^^^^^^^^^^^ AIR302
-157 | on_dataset_created
+159 | on_dataset_created
     |
     = help: Use `airflow.listeners.spec.asset.on_asset_changed` instead
 
-AIR302_names.py:157:1: AIR302 `airflow.listeners.spec.dataset.on_dataset_created` is removed in Airflow 3.0
+AIR302_names.py:159:1: AIR302 `airflow.listeners.spec.dataset.on_dataset_created` is removed in Airflow 3.0
     |
-155 | # airflow.listeners.spec.dataset
-156 | on_dataset_changed
-157 | on_dataset_created
+157 | # airflow.listeners.spec.dataset
+158 | on_dataset_changed
+159 | on_dataset_created
     | ^^^^^^^^^^^^^^^^^^ AIR302
-158 |
-159 | # airflow.metrics.validators
+160 |
+161 | # airflow.metrics.validators
     |
     = help: Use `airflow.listeners.spec.asset.on_asset_created` instead
 
-AIR302_names.py:160:1: AIR302 `airflow.metrics.validators.AllowListValidator` is removed in Airflow 3.0
+AIR302_names.py:162:1: AIR302 `airflow.metrics.validators.AllowListValidator` is removed in Airflow 3.0
     |
-159 | # airflow.metrics.validators
-160 | AllowListValidator()
+161 | # airflow.metrics.validators
+162 | AllowListValidator()
     | ^^^^^^^^^^^^^^^^^^ AIR302
-161 | BlockListValidator()
+163 | BlockListValidator()
     |
     = help: Use `airflow.metrics.validators.PatternAllowListValidator` instead
 
-AIR302_names.py:161:1: AIR302 `airflow.metrics.validators.BlockListValidator` is removed in Airflow 3.0
+AIR302_names.py:163:1: AIR302 `airflow.metrics.validators.BlockListValidator` is removed in Airflow 3.0
     |
-159 | # airflow.metrics.validators
-160 | AllowListValidator()
-161 | BlockListValidator()
+161 | # airflow.metrics.validators
+162 | AllowListValidator()
+163 | BlockListValidator()
     | ^^^^^^^^^^^^^^^^^^ AIR302
     |
     = help: Use `airflow.metrics.validators.PatternBlockListValidator` instead
 
-AIR302_names.py:165:1: AIR302 `airflow.models.baseoperator.chain` is removed in Airflow 3.0
+AIR302_names.py:167:1: AIR302 `airflow.models.baseoperator.chain` is removed in Airflow 3.0
     |
-164 | # airflow.models.baseoperator
-165 | chain, chain_linear, cross_downstream
+166 | # airflow.models.baseoperator
+167 | chain, chain_linear, cross_downstream
     | ^^^^^ AIR302
-166 |
-167 | # airflow.models.baseoperatorlink
+168 |
+169 | # airflow.models.baseoperatorlink
     |
     = help: Use `airflow.sdk.chain` instead
 
-AIR302_names.py:165:8: AIR302 `airflow.models.baseoperator.chain_linear` is removed in Airflow 3.0
+AIR302_names.py:167:8: AIR302 `airflow.models.baseoperator.chain_linear` is removed in Airflow 3.0
     |
-164 | # airflow.models.baseoperator
-165 | chain, chain_linear, cross_downstream
+166 | # airflow.models.baseoperator
+167 | chain, chain_linear, cross_downstream
     |        ^^^^^^^^^^^^ AIR302
-166 |
-167 | # airflow.models.baseoperatorlink
+168 |
+169 | # airflow.models.baseoperatorlink
     |
     = help: Use `airflow.sdk.chain_linear` instead
 
-AIR302_names.py:165:22: AIR302 `airflow.models.baseoperator.cross_downstream` is removed in Airflow 3.0
+AIR302_names.py:167:22: AIR302 `airflow.models.baseoperator.cross_downstream` is removed in Airflow 3.0
     |
-164 | # airflow.models.baseoperator
-165 | chain, chain_linear, cross_downstream
+166 | # airflow.models.baseoperator
+167 | chain, chain_linear, cross_downstream
     |                      ^^^^^^^^^^^^^^^^ AIR302
-166 |
-167 | # airflow.models.baseoperatorlink
+168 |
+169 | # airflow.models.baseoperatorlink
     |
     = help: Use `airflow.sdk.cross_downstream` instead
 
-AIR302_names.py:168:1: AIR302 `airflow.models.baseoperatorlink.BaseOperatorLink` is removed in Airflow 3.0
+AIR302_names.py:170:1: AIR302 `airflow.models.baseoperatorlink.BaseOperatorLink` is removed in Airflow 3.0
     |
-167 | # airflow.models.baseoperatorlink
-168 | BaseOperatorLink()
+169 | # airflow.models.baseoperatorlink
+170 | BaseOperatorLink()
     | ^^^^^^^^^^^^^^^^ AIR302
-169 |
-170 | # airflow.operators.dummy
+171 |
+172 | # ariflow.notifications.basenotifier
     |
     = help: Use `airflow.sdk.definitions.baseoperatorlink.BaseOperatorLink` instead
 
-AIR302_names.py:171:1: AIR302 `airflow.operators.dummy.EmptyOperator` is removed in Airflow 3.0
+AIR302_names.py:173:1: AIR302 `airflow.notifications.basenotifier.BaseNotifier` is removed in Airflow 3.0
     |
-170 | # airflow.operators.dummy
-171 | EmptyOperator()
+172 | # ariflow.notifications.basenotifier
+173 | BaseNotifier()
+    | ^^^^^^^^^^^^ AIR302
+174 |
+175 | # airflow.operators.dummy
+    |
+    = help: Use `airflow.sdk.BaseNotifier` instead
+
+AIR302_names.py:176:1: AIR302 `airflow.operators.dummy.EmptyOperator` is removed in Airflow 3.0
+    |
+175 | # airflow.operators.dummy
+176 | EmptyOperator()
     | ^^^^^^^^^^^^^ AIR302
-172 | DummyOperator()
+177 | DummyOperator()
     |
     = help: Use `airflow.operators.empty.EmptyOperator` instead
 
-AIR302_names.py:172:1: AIR302 `airflow.operators.dummy.DummyOperator` is removed in Airflow 3.0
+AIR302_names.py:177:1: AIR302 `airflow.operators.dummy.DummyOperator` is removed in Airflow 3.0
     |
-170 | # airflow.operators.dummy
-171 | EmptyOperator()
-172 | DummyOperator()
+175 | # airflow.operators.dummy
+176 | EmptyOperator()
+177 | DummyOperator()
     | ^^^^^^^^^^^^^ AIR302
-173 |
-174 | # airflow.operators.dummy_operator
+178 |
+179 | # airflow.operators.dummy_operator
     |
     = help: Use `airflow.operators.empty.EmptyOperator` instead
 
-AIR302_names.py:175:16: AIR302 `airflow.operators.dummy_operator.EmptyOperator` is removed in Airflow 3.0
+AIR302_names.py:180:16: AIR302 `airflow.operators.dummy_operator.EmptyOperator` is removed in Airflow 3.0
     |
-174 | # airflow.operators.dummy_operator
-175 | dummy_operator.EmptyOperator()
+179 | # airflow.operators.dummy_operator
+180 | dummy_operator.EmptyOperator()
     |                ^^^^^^^^^^^^^ AIR302
-176 | dummy_operator.DummyOperator()
+181 | dummy_operator.DummyOperator()
     |
     = help: Use `airflow.operators.empty.EmptyOperator` instead
 
-AIR302_names.py:176:16: AIR302 `airflow.operators.dummy_operator.DummyOperator` is removed in Airflow 3.0
+AIR302_names.py:181:16: AIR302 `airflow.operators.dummy_operator.DummyOperator` is removed in Airflow 3.0
     |
-174 | # airflow.operators.dummy_operator
-175 | dummy_operator.EmptyOperator()
-176 | dummy_operator.DummyOperator()
+179 | # airflow.operators.dummy_operator
+180 | dummy_operator.EmptyOperator()
+181 | dummy_operator.DummyOperator()
     |                ^^^^^^^^^^^^^ AIR302
-177 |
-178 | # airflow.operators.branch_operator
+182 |
+183 | # airflow.operators.branch_operator
     |
     = help: Use `airflow.operators.empty.EmptyOperator` instead
 
-AIR302_names.py:179:1: AIR302 `airflow.operators.branch_operator.BaseBranchOperator` is removed in Airflow 3.0
+AIR302_names.py:184:1: AIR302 `airflow.operators.branch_operator.BaseBranchOperator` is removed in Airflow 3.0
     |
-178 | # airflow.operators.branch_operator
-179 | BaseBranchOperator()
+183 | # airflow.operators.branch_operator
+184 | BaseBranchOperator()
     | ^^^^^^^^^^^^^^^^^^ AIR302
-180 |
-181 | # airflow.operators.dagrun_operator
+185 |
+186 | # airflow.operators.dagrun_operator
     |
     = help: Use `airflow.operators.branch.BaseBranchOperator` instead
 
-AIR302_names.py:182:1: AIR302 `airflow.operators.dagrun_operator.TriggerDagRunLink` is removed in Airflow 3.0
+AIR302_names.py:187:1: AIR302 `airflow.operators.dagrun_operator.TriggerDagRunLink` is removed in Airflow 3.0
     |
-181 | # airflow.operators.dagrun_operator
-182 | TriggerDagRunLink()
+186 | # airflow.operators.dagrun_operator
+187 | TriggerDagRunLink()
     | ^^^^^^^^^^^^^^^^^ AIR302
-183 | TriggerDagRunOperator()
+188 | TriggerDagRunOperator()
     |
     = help: Use `airflow.operators.trigger_dagrun.TriggerDagRunLink` instead
 
-AIR302_names.py:183:1: AIR302 `airflow.operators.dagrun_operator.TriggerDagRunOperator` is removed in Airflow 3.0
+AIR302_names.py:188:1: AIR302 `airflow.operators.dagrun_operator.TriggerDagRunOperator` is removed in Airflow 3.0
     |
-181 | # airflow.operators.dagrun_operator
-182 | TriggerDagRunLink()
-183 | TriggerDagRunOperator()
+186 | # airflow.operators.dagrun_operator
+187 | TriggerDagRunLink()
+188 | TriggerDagRunOperator()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-184 |
-185 | # airflow.operators.email_operator
+189 |
+190 | # airflow.operators.email_operator
     |
     = help: Use `airflow.operators.trigger_dagrun.TriggerDagRunOperator` instead
 
-AIR302_names.py:186:1: AIR302 `airflow.operators.email_operator.EmailOperator` is removed in Airflow 3.0
+AIR302_names.py:191:1: AIR302 `airflow.operators.email_operator.EmailOperator` is removed in Airflow 3.0
     |
-185 | # airflow.operators.email_operator
-186 | EmailOperator()
+190 | # airflow.operators.email_operator
+191 | EmailOperator()
     | ^^^^^^^^^^^^^ AIR302
-187 |
-188 | # airflow.operators.latest_only_operator
+192 |
+193 | # airflow.operators.latest_only_operator
     |
     = help: Use `airflow.operators.email.EmailOperator` instead
 
-AIR302_names.py:189:1: AIR302 `airflow.operators.latest_only_operator.LatestOnlyOperator` is removed in Airflow 3.0
+AIR302_names.py:194:1: AIR302 `airflow.operators.latest_only_operator.LatestOnlyOperator` is removed in Airflow 3.0
     |
-188 | # airflow.operators.latest_only_operator
-189 | LatestOnlyOperator()
+193 | # airflow.operators.latest_only_operator
+194 | LatestOnlyOperator()
     | ^^^^^^^^^^^^^^^^^^ AIR302
-190 |
-191 | # airflow.operators.python_operator
+195 |
+196 | # airflow.operators.python_operator
     |
     = help: Use `airflow.operators.latest_only.LatestOnlyOperator` instead
 
-AIR302_names.py:192:1: AIR302 `airflow.operators.python_operator.BranchPythonOperator` is removed in Airflow 3.0
+AIR302_names.py:197:1: AIR302 `airflow.operators.python_operator.BranchPythonOperator` is removed in Airflow 3.0
     |
-191 | # airflow.operators.python_operator
-192 | BranchPythonOperator()
+196 | # airflow.operators.python_operator
+197 | BranchPythonOperator()
     | ^^^^^^^^^^^^^^^^^^^^ AIR302
-193 | PythonOperator()
-194 | PythonVirtualenvOperator()
+198 | PythonOperator()
+199 | PythonVirtualenvOperator()
     |
     = help: Use `airflow.operators.python.BranchPythonOperator` instead
 
-AIR302_names.py:193:1: AIR302 `airflow.operators.python_operator.PythonOperator` is removed in Airflow 3.0
+AIR302_names.py:198:1: AIR302 `airflow.operators.python_operator.PythonOperator` is removed in Airflow 3.0
     |
-191 | # airflow.operators.python_operator
-192 | BranchPythonOperator()
-193 | PythonOperator()
+196 | # airflow.operators.python_operator
+197 | BranchPythonOperator()
+198 | PythonOperator()
     | ^^^^^^^^^^^^^^ AIR302
-194 | PythonVirtualenvOperator()
-195 | ShortCircuitOperator()
+199 | PythonVirtualenvOperator()
+200 | ShortCircuitOperator()
     |
     = help: Use `airflow.operators.python.PythonOperator` instead
 
-AIR302_names.py:194:1: AIR302 `airflow.operators.python_operator.PythonVirtualenvOperator` is removed in Airflow 3.0
+AIR302_names.py:199:1: AIR302 `airflow.operators.python_operator.PythonVirtualenvOperator` is removed in Airflow 3.0
     |
-192 | BranchPythonOperator()
-193 | PythonOperator()
-194 | PythonVirtualenvOperator()
+197 | BranchPythonOperator()
+198 | PythonOperator()
+199 | PythonVirtualenvOperator()
     | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-195 | ShortCircuitOperator()
+200 | ShortCircuitOperator()
     |
     = help: Use `airflow.operators.python.PythonVirtualenvOperator` instead
 
-AIR302_names.py:195:1: AIR302 `airflow.operators.python_operator.ShortCircuitOperator` is removed in Airflow 3.0
+AIR302_names.py:200:1: AIR302 `airflow.operators.python_operator.ShortCircuitOperator` is removed in Airflow 3.0
     |
-193 | PythonOperator()
-194 | PythonVirtualenvOperator()
-195 | ShortCircuitOperator()
+198 | PythonOperator()
+199 | PythonVirtualenvOperator()
+200 | ShortCircuitOperator()
     | ^^^^^^^^^^^^^^^^^^^^ AIR302
-196 |
-197 | # airflow.operators.subdag.*
+201 |
+202 | # airflow.operators.subdag.*
     |
     = help: Use `airflow.operators.python.ShortCircuitOperator` instead
 
-AIR302_names.py:198:1: AIR302 `airflow.operators.subdag.SubDagOperator` is removed in Airflow 3.0; The whole `airflow.subdag` module has been removed.
+AIR302_names.py:203:1: AIR302 `airflow.operators.subdag.SubDagOperator` is removed in Airflow 3.0; The whole `airflow.subdag` module has been removed.
     |
-197 | # airflow.operators.subdag.*
-198 | SubDagOperator()
+202 | # airflow.operators.subdag.*
+203 | SubDagOperator()
     | ^^^^^^^^^^^^^^ AIR302
-199 |
-200 | # airflow.providers.amazon
+204 |
+205 | # airflow.providers.amazon
     |
 
-AIR302_names.py:201:13: AIR302 `airflow.providers.amazon.aws.auth_manager.avp.entities.AvpEntities.DATASET` is removed in Airflow 3.0
+AIR302_names.py:206:13: AIR302 `airflow.providers.amazon.aws.auth_manager.avp.entities.AvpEntities.DATASET` is removed in Airflow 3.0
     |
-200 | # airflow.providers.amazon
-201 | AvpEntities.DATASET
+205 | # airflow.providers.amazon
+206 | AvpEntities.DATASET
     |             ^^^^^^^ AIR302
-202 | s3.create_dataset
-203 | s3.convert_dataset_to_openlineage
+207 | s3.create_dataset
+208 | s3.convert_dataset_to_openlineage
     |
     = help: Use `airflow.providers.amazon.aws.auth_manager.avp.entities.AvpEntities.ASSET` instead
 
-AIR302_names.py:202:4: AIR302 `airflow.providers.amazon.aws.datasets.s3.create_dataset` is removed in Airflow 3.0
+AIR302_names.py:207:4: AIR302 `airflow.providers.amazon.aws.datasets.s3.create_dataset` is removed in Airflow 3.0
     |
-200 | # airflow.providers.amazon
-201 | AvpEntities.DATASET
-202 | s3.create_dataset
+205 | # airflow.providers.amazon
+206 | AvpEntities.DATASET
+207 | s3.create_dataset
     |    ^^^^^^^^^^^^^^ AIR302
-203 | s3.convert_dataset_to_openlineage
-204 | s3.sanitize_uri
+208 | s3.convert_dataset_to_openlineage
+209 | s3.sanitize_uri
     |
     = help: Use `airflow.providers.amazon.aws.assets.s3.create_asset` instead
 
-AIR302_names.py:203:4: AIR302 `airflow.providers.amazon.aws.datasets.s3.convert_dataset_to_openlineage` is removed in Airflow 3.0
+AIR302_names.py:208:4: AIR302 `airflow.providers.amazon.aws.datasets.s3.convert_dataset_to_openlineage` is removed in Airflow 3.0
     |
-201 | AvpEntities.DATASET
-202 | s3.create_dataset
-203 | s3.convert_dataset_to_openlineage
+206 | AvpEntities.DATASET
+207 | s3.create_dataset
+208 | s3.convert_dataset_to_openlineage
     |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-204 | s3.sanitize_uri
+209 | s3.sanitize_uri
     |
     = help: Use `airflow.providers.amazon.aws.assets.s3.convert_asset_to_openlineage` instead
 
-AIR302_names.py:204:4: AIR302 `airflow.providers.amazon.aws.datasets.s3.sanitize_uri` is removed in Airflow 3.0
+AIR302_names.py:209:4: AIR302 `airflow.providers.amazon.aws.datasets.s3.sanitize_uri` is removed in Airflow 3.0
     |
-202 | s3.create_dataset
-203 | s3.convert_dataset_to_openlineage
-204 | s3.sanitize_uri
+207 | s3.create_dataset
+208 | s3.convert_dataset_to_openlineage
+209 | s3.sanitize_uri
     |    ^^^^^^^^^^^^ AIR302
-205 |
-206 | # airflow.providers.common.io
+210 |
+211 | # airflow.providers.common.io
     |
     = help: Use `airflow.providers.amazon.aws.assets.s3.sanitize_uri` instead
 
-AIR302_names.py:207:16: AIR302 `airflow.providers.common.io.datasets.file.convert_dataset_to_openlineage` is removed in Airflow 3.0
+AIR302_names.py:212:16: AIR302 `airflow.providers.common.io.datasets.file.convert_dataset_to_openlineage` is removed in Airflow 3.0
     |
-206 | # airflow.providers.common.io
-207 | common_io_file.convert_dataset_to_openlineage
+211 | # airflow.providers.common.io
+212 | common_io_file.convert_dataset_to_openlineage
     |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-208 | common_io_file.create_dataset
-209 | common_io_file.sanitize_uri
+213 | common_io_file.create_dataset
+214 | common_io_file.sanitize_uri
     |
     = help: Use `airflow.providers.common.io.assets.file.convert_asset_to_openlineage` instead
 
-AIR302_names.py:208:16: AIR302 `airflow.providers.common.io.datasets.file.create_dataset` is removed in Airflow 3.0
+AIR302_names.py:213:16: AIR302 `airflow.providers.common.io.datasets.file.create_dataset` is removed in Airflow 3.0
     |
-206 | # airflow.providers.common.io
-207 | common_io_file.convert_dataset_to_openlineage
-208 | common_io_file.create_dataset
+211 | # airflow.providers.common.io
+212 | common_io_file.convert_dataset_to_openlineage
+213 | common_io_file.create_dataset
     |                ^^^^^^^^^^^^^^ AIR302
-209 | common_io_file.sanitize_uri
+214 | common_io_file.sanitize_uri
     |
     = help: Use `airflow.providers.common.io.assets.file.create_asset` instead
 
-AIR302_names.py:209:16: AIR302 `airflow.providers.common.io.datasets.file.sanitize_uri` is removed in Airflow 3.0
+AIR302_names.py:214:16: AIR302 `airflow.providers.common.io.datasets.file.sanitize_uri` is removed in Airflow 3.0
     |
-207 | common_io_file.convert_dataset_to_openlineage
-208 | common_io_file.create_dataset
-209 | common_io_file.sanitize_uri
+212 | common_io_file.convert_dataset_to_openlineage
+213 | common_io_file.create_dataset
+214 | common_io_file.sanitize_uri
     |                ^^^^^^^^^^^^ AIR302
-210 |
-211 | # airflow.providers.fab
+215 |
+216 | # airflow.providers.fab
     |
     = help: Use `airflow.providers.common.io.assets.file.sanitize_uri` instead
 
-AIR302_names.py:212:18: AIR302 `airflow.providers.fab.auth_manager.fab_auth_manager.is_authorized_dataset` is removed in Airflow 3.0
+AIR302_names.py:217:18: AIR302 `airflow.providers.fab.auth_manager.fab_auth_manager.is_authorized_dataset` is removed in Airflow 3.0
     |
-211 | # airflow.providers.fab
-212 | fab_auth_manager.is_authorized_dataset
+216 | # airflow.providers.fab
+217 | fab_auth_manager.is_authorized_dataset
     |                  ^^^^^^^^^^^^^^^^^^^^^ AIR302
-213 |
-214 | # airflow.providers.google
+218 |
+219 | # airflow.providers.google
     |
     = help: Use `airflow.providers.fab.auth_manager.fab_auth_manager.is_authorized_asset` instead
 
-AIR302_names.py:217:5: AIR302 `airflow.providers.google.datasets.gcs.create_dataset` is removed in Airflow 3.0
+AIR302_names.py:222:5: AIR302 `airflow.providers.google.datasets.gcs.create_dataset` is removed in Airflow 3.0
     |
-215 | bigquery.sanitize_uri
-216 |
-217 | gcs.create_dataset
+220 | bigquery.sanitize_uri
+221 |
+222 | gcs.create_dataset
     |     ^^^^^^^^^^^^^^ AIR302
-218 | gcs.sanitize_uri
-219 | gcs.convert_dataset_to_openlineage
+223 | gcs.sanitize_uri
+224 | gcs.convert_dataset_to_openlineage
     |
     = help: Use `airflow.providers.google.assets.gcs.create_asset` instead
 
-AIR302_names.py:218:5: AIR302 `airflow.providers.google.datasets.gcs.sanitize_uri` is removed in Airflow 3.0
+AIR302_names.py:223:5: AIR302 `airflow.providers.google.datasets.gcs.sanitize_uri` is removed in Airflow 3.0
     |
-217 | gcs.create_dataset
-218 | gcs.sanitize_uri
+222 | gcs.create_dataset
+223 | gcs.sanitize_uri
     |     ^^^^^^^^^^^^ AIR302
-219 | gcs.convert_dataset_to_openlineage
+224 | gcs.convert_dataset_to_openlineage
     |
     = help: Use `airflow.providers.google.assets.gcs.sanitize_uri` instead
 
-AIR302_names.py:219:5: AIR302 `airflow.providers.google.datasets.gcs.convert_dataset_to_openlineage` is removed in Airflow 3.0
+AIR302_names.py:224:5: AIR302 `airflow.providers.google.datasets.gcs.convert_dataset_to_openlineage` is removed in Airflow 3.0
     |
-217 | gcs.create_dataset
-218 | gcs.sanitize_uri
-219 | gcs.convert_dataset_to_openlineage
+222 | gcs.create_dataset
+223 | gcs.sanitize_uri
+224 | gcs.convert_dataset_to_openlineage
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-220 |
-221 | # airflow.providers.mysql
+225 |
+226 | # airflow.providers.mysql
     |
     = help: Use `airflow.providers.google.assets.gcs.convert_asset_to_openlineage` instead
 
-AIR302_names.py:222:7: AIR302 `airflow.providers.mysql.datasets.mysql.sanitize_uri` is removed in Airflow 3.0
+AIR302_names.py:227:7: AIR302 `airflow.providers.mysql.datasets.mysql.sanitize_uri` is removed in Airflow 3.0
     |
-221 | # airflow.providers.mysql
-222 | mysql.sanitize_uri
+226 | # airflow.providers.mysql
+227 | mysql.sanitize_uri
     |       ^^^^^^^^^^^^ AIR302
-223 |
-224 | # airflow.providers.openlineage
+228 |
+229 | # airflow.providers.openlineage
     |
     = help: Use `airflow.providers.mysql.assets.mysql.sanitize_uri` instead
 
-AIR302_names.py:225:1: AIR302 `airflow.providers.openlineage.utils.utils.DatasetInfo` is removed in Airflow 3.0
+AIR302_names.py:230:1: AIR302 `airflow.providers.openlineage.utils.utils.DatasetInfo` is removed in Airflow 3.0
     |
-224 | # airflow.providers.openlineage
-225 | DatasetInfo()
+229 | # airflow.providers.openlineage
+230 | DatasetInfo()
     | ^^^^^^^^^^^ AIR302
-226 | translate_airflow_dataset
+231 | translate_airflow_dataset
     |
     = help: Use `airflow.providers.openlineage.utils.utils.AssetInfo` instead
 
-AIR302_names.py:226:1: AIR302 `airflow.providers.openlineage.utils.utils.translate_airflow_dataset` is removed in Airflow 3.0
+AIR302_names.py:231:1: AIR302 `airflow.providers.openlineage.utils.utils.translate_airflow_dataset` is removed in Airflow 3.0
     |
-224 | # airflow.providers.openlineage
-225 | DatasetInfo()
-226 | translate_airflow_dataset
+229 | # airflow.providers.openlineage
+230 | DatasetInfo()
+231 | translate_airflow_dataset
     | ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-227 |
-228 | # airflow.providers.postgres
+232 |
+233 | # airflow.providers.postgres
     |
     = help: Use `airflow.providers.openlineage.utils.utils.translate_airflow_asset` instead
 
-AIR302_names.py:229:10: AIR302 `airflow.providers.postgres.datasets.postgres.sanitize_uri` is removed in Airflow 3.0
+AIR302_names.py:234:10: AIR302 `airflow.providers.postgres.datasets.postgres.sanitize_uri` is removed in Airflow 3.0
     |
-228 | # airflow.providers.postgres
-229 | postgres.sanitize_uri
+233 | # airflow.providers.postgres
+234 | postgres.sanitize_uri
     |          ^^^^^^^^^^^^ AIR302
-230 |
-231 | # airflow.providers.trino
+235 |
+236 | # airflow.providers.trino
     |
     = help: Use `airflow.providers.postgres.assets.postgres.sanitize_uri` instead
 
-AIR302_names.py:232:7: AIR302 `airflow.providers.trino.datasets.trino.sanitize_uri` is removed in Airflow 3.0
+AIR302_names.py:237:7: AIR302 `airflow.providers.trino.datasets.trino.sanitize_uri` is removed in Airflow 3.0
     |
-231 | # airflow.providers.trino
-232 | trino.sanitize_uri
+236 | # airflow.providers.trino
+237 | trino.sanitize_uri
     |       ^^^^^^^^^^^^ AIR302
-233 |
-234 | # airflow.secrets
+238 |
+239 | # airflow.secrets
     |
     = help: Use `airflow.providers.trino.assets.trino.sanitize_uri` instead
 
-AIR302_names.py:237:1: AIR302 `airflow.secrets.local_filesystem.load_connections` is removed in Airflow 3.0
+AIR302_names.py:242:1: AIR302 `airflow.secrets.local_filesystem.load_connections` is removed in Airflow 3.0
     |
-235 | # get_connection
-236 | LocalFilesystemBackend()
-237 | load_connections
+240 | # get_connection
+241 | LocalFilesystemBackend()
+242 | load_connections
     | ^^^^^^^^^^^^^^^^ AIR302
-238 |
-239 | # airflow.security.permissions
+243 |
+244 | # airflow.security.permissions
     |
     = help: Use `airflow.secrets.local_filesystem.load_connections_dict` instead
 
-AIR302_names.py:240:1: AIR302 `airflow.security.permissions.RESOURCE_DATASET` is removed in Airflow 3.0
+AIR302_names.py:245:1: AIR302 `airflow.security.permissions.RESOURCE_DATASET` is removed in Airflow 3.0
     |
-239 | # airflow.security.permissions
-240 | RESOURCE_DATASET
+244 | # airflow.security.permissions
+245 | RESOURCE_DATASET
     | ^^^^^^^^^^^^^^^^ AIR302
-241 |
-242 | # airflow.sensors.base_sensor_operator
+246 |
+247 | # airflow.sensors.base_sensor_operator
     |
     = help: Use `airflow.security.permissions.RESOURCE_ASSET` instead
 
-AIR302_names.py:243:1: AIR302 `airflow.sensors.base_sensor_operator.BaseSensorOperator` is removed in Airflow 3.0
+AIR302_names.py:248:1: AIR302 `airflow.sensors.base_sensor_operator.BaseSensorOperator` is removed in Airflow 3.0
     |
-242 | # airflow.sensors.base_sensor_operator
-243 | BaseSensorOperator()
+247 | # airflow.sensors.base_sensor_operator
+248 | BaseSensorOperator()
     | ^^^^^^^^^^^^^^^^^^ AIR302
-244 |
-245 | # airflow.sensors.date_time_sensor
+249 |
+250 | # airflow.sensors.date_time_sensor
     |
     = help: Use `airflow.sensors.base.BaseSensorOperator` instead
 
-AIR302_names.py:246:1: AIR302 `airflow.sensors.date_time_sensor.DateTimeSensor` is removed in Airflow 3.0
+AIR302_names.py:251:1: AIR302 `airflow.sensors.date_time_sensor.DateTimeSensor` is removed in Airflow 3.0
     |
-245 | # airflow.sensors.date_time_sensor
-246 | DateTimeSensor()
+250 | # airflow.sensors.date_time_sensor
+251 | DateTimeSensor()
     | ^^^^^^^^^^^^^^ AIR302
-247 |
-248 | # airflow.sensors.external_task
+252 |
+253 | # airflow.sensors.external_task
     |
     = help: Use `airflow.sensors.date_time.DateTimeSensor` instead
 
-AIR302_names.py:249:1: AIR302 `airflow.sensors.external_task.ExternalTaskSensorLink` is removed in Airflow 3.0
+AIR302_names.py:254:1: AIR302 `airflow.sensors.external_task.ExternalTaskSensorLink` is removed in Airflow 3.0
     |
-248 | # airflow.sensors.external_task
-249 | ExternalTaskSensorLink()
+253 | # airflow.sensors.external_task
+254 | ExternalTaskSensorLink()
     | ^^^^^^^^^^^^^^^^^^^^^^ AIR302
-250 | ExternalTaskMarker()
-251 | ExternalTaskSensor()
+255 | ExternalTaskMarker()
+256 | ExternalTaskSensor()
     |
     = help: Use `airflow.sensors.external_task.ExternalDagLink` instead
 
-AIR302_names.py:250:1: AIR302 `airflow.sensors.external_task.ExternalTaskMarker` is removed in Airflow 3.0
+AIR302_names.py:255:1: AIR302 `airflow.sensors.external_task.ExternalTaskMarker` is removed in Airflow 3.0
     |
-248 | # airflow.sensors.external_task
-249 | ExternalTaskSensorLink()
-250 | ExternalTaskMarker()
+253 | # airflow.sensors.external_task
+254 | ExternalTaskSensorLink()
+255 | ExternalTaskMarker()
     | ^^^^^^^^^^^^^^^^^^ AIR302
-251 | ExternalTaskSensor()
+256 | ExternalTaskSensor()
     |
     = help: Use `airflow.sensors.external_task.ExternalTaskMarker` instead
 
-AIR302_names.py:251:1: AIR302 `airflow.sensors.external_task.ExternalTaskSensor` is removed in Airflow 3.0
+AIR302_names.py:256:1: AIR302 `airflow.sensors.external_task.ExternalTaskSensor` is removed in Airflow 3.0
     |
-249 | ExternalTaskSensorLink()
-250 | ExternalTaskMarker()
-251 | ExternalTaskSensor()
+254 | ExternalTaskSensorLink()
+255 | ExternalTaskMarker()
+256 | ExternalTaskSensor()
     | ^^^^^^^^^^^^^^^^^^ AIR302
-252 |
-253 | # airflow.sensors.external_task_sensor
-    |
-    = help: Use `airflow.sensors.external_task.ExternalTaskSensor` instead
-
-AIR302_names.py:254:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskMarker` is removed in Airflow 3.0
-    |
-253 | # airflow.sensors.external_task_sensor
-254 | ExternalTaskMarkerFromExternalTaskSensor()
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-255 | ExternalTaskSensorFromExternalTaskSensor()
-256 | ExternalTaskSensorLinkFromExternalTaskSensor()
-    |
-    = help: Use `airflow.sensors.external_task.ExternalTaskMarker` instead
-
-AIR302_names.py:255:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensor` is removed in Airflow 3.0
-    |
-253 | # airflow.sensors.external_task_sensor
-254 | ExternalTaskMarkerFromExternalTaskSensor()
-255 | ExternalTaskSensorFromExternalTaskSensor()
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-256 | ExternalTaskSensorLinkFromExternalTaskSensor()
-    |
-    = help: Use `airflow.sensors.external_task.ExternalTaskSensor` instead
-
-AIR302_names.py:256:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensorLink` is removed in Airflow 3.0
-    |
-254 | ExternalTaskMarkerFromExternalTaskSensor()
-255 | ExternalTaskSensorFromExternalTaskSensor()
-256 | ExternalTaskSensorLinkFromExternalTaskSensor()
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
 257 |
-258 | # airflow.sensors.time_delta_sensor
+258 | # airflow.sensors.external_task_sensor
+    |
+    = help: Use `airflow.sensors.external_task.ExternalTaskSensor` instead
+
+AIR302_names.py:259:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskMarker` is removed in Airflow 3.0
+    |
+258 | # airflow.sensors.external_task_sensor
+259 | ExternalTaskMarkerFromExternalTaskSensor()
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
+260 | ExternalTaskSensorFromExternalTaskSensor()
+261 | ExternalTaskSensorLinkFromExternalTaskSensor()
+    |
+    = help: Use `airflow.sensors.external_task.ExternalTaskMarker` instead
+
+AIR302_names.py:260:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensor` is removed in Airflow 3.0
+    |
+258 | # airflow.sensors.external_task_sensor
+259 | ExternalTaskMarkerFromExternalTaskSensor()
+260 | ExternalTaskSensorFromExternalTaskSensor()
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
+261 | ExternalTaskSensorLinkFromExternalTaskSensor()
+    |
+    = help: Use `airflow.sensors.external_task.ExternalTaskSensor` instead
+
+AIR302_names.py:261:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensorLink` is removed in Airflow 3.0
+    |
+259 | ExternalTaskMarkerFromExternalTaskSensor()
+260 | ExternalTaskSensorFromExternalTaskSensor()
+261 | ExternalTaskSensorLinkFromExternalTaskSensor()
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
+262 |
+263 | # airflow.sensors.time_delta_sensor
     |
     = help: Use `airflow.sensors.external_task.ExternalDagLink` instead
 
-AIR302_names.py:259:1: AIR302 `airflow.sensors.time_delta_sensor.TimeDeltaSensor` is removed in Airflow 3.0
+AIR302_names.py:264:1: AIR302 `airflow.sensors.time_delta_sensor.TimeDeltaSensor` is removed in Airflow 3.0
     |
-258 | # airflow.sensors.time_delta_sensor
-259 | TimeDeltaSensor()
+263 | # airflow.sensors.time_delta_sensor
+264 | TimeDeltaSensor()
     | ^^^^^^^^^^^^^^^ AIR302
-260 |
-261 | # airflow.timetables
+265 |
+266 | # airflow.timetables
     |
     = help: Use `airflow.sensors.time_delta.TimeDeltaSensor` instead
 
-AIR302_names.py:262:1: AIR302 `airflow.timetables.datasets.DatasetOrTimeSchedule` is removed in Airflow 3.0
+AIR302_names.py:267:1: AIR302 `airflow.timetables.datasets.DatasetOrTimeSchedule` is removed in Airflow 3.0
     |
-261 | # airflow.timetables
-262 | DatasetOrTimeSchedule()
+266 | # airflow.timetables
+267 | DatasetOrTimeSchedule()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-263 | DatasetTriggeredTimetable()
+268 | DatasetTriggeredTimetable()
     |
     = help: Use `airflow.timetables.assets.AssetOrTimeSchedule` instead
 
-AIR302_names.py:263:1: AIR302 `airflow.timetables.simple.DatasetTriggeredTimetable` is removed in Airflow 3.0
+AIR302_names.py:268:1: AIR302 `airflow.timetables.simple.DatasetTriggeredTimetable` is removed in Airflow 3.0
     |
-261 | # airflow.timetables
-262 | DatasetOrTimeSchedule()
-263 | DatasetTriggeredTimetable()
+266 | # airflow.timetables
+267 | DatasetOrTimeSchedule()
+268 | DatasetTriggeredTimetable()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-264 |
-265 | # airflow.triggers.external_task
+269 |
+270 | # airflow.triggers.external_task
     |
     = help: Use `airflow.timetables.simple.AssetTriggeredTimetable` instead
 
-AIR302_names.py:266:1: AIR302 `airflow.triggers.external_task.TaskStateTrigger` is removed in Airflow 3.0
+AIR302_names.py:271:1: AIR302 `airflow.triggers.external_task.TaskStateTrigger` is removed in Airflow 3.0
     |
-265 | # airflow.triggers.external_task
-266 | TaskStateTrigger()
+270 | # airflow.triggers.external_task
+271 | TaskStateTrigger()
     | ^^^^^^^^^^^^^^^^ AIR302
-267 |
-268 | # airflow.utils.date
+272 |
+273 | # airflow.utils.date
     |
 
-AIR302_names.py:269:7: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0
+AIR302_names.py:274:7: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0
     |
-268 | # airflow.utils.date
-269 | dates.date_range
+273 | # airflow.utils.date
+274 | dates.date_range
     |       ^^^^^^^^^^ AIR302
-270 | dates.days_ago
+275 | dates.days_ago
     |
 
-AIR302_names.py:270:7: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0
+AIR302_names.py:275:7: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0
     |
-268 | # airflow.utils.date
-269 | dates.date_range
-270 | dates.days_ago
+273 | # airflow.utils.date
+274 | dates.date_range
+275 | dates.days_ago
     |       ^^^^^^^^ AIR302
-271 |
-272 | date_range
+276 |
+277 | date_range
     |
     = help: Use `pendulum.today('UTC').add(days=-N, ...)` instead
 
-AIR302_names.py:272:1: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0
+AIR302_names.py:277:1: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0
     |
-270 | dates.days_ago
-271 |
-272 | date_range
+275 | dates.days_ago
+276 |
+277 | date_range
     | ^^^^^^^^^^ AIR302
-273 | days_ago
-274 | infer_time_unit
+278 | days_ago
+279 | infer_time_unit
     |
 
-AIR302_names.py:273:1: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0
+AIR302_names.py:278:1: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0
     |
-272 | date_range
-273 | days_ago
+277 | date_range
+278 | days_ago
     | ^^^^^^^^ AIR302
-274 | infer_time_unit
-275 | parse_execution_date
+279 | infer_time_unit
+280 | parse_execution_date
     |
     = help: Use `pendulum.today('UTC').add(days=-N, ...)` instead
 
-AIR302_names.py:274:1: AIR302 `airflow.utils.dates.infer_time_unit` is removed in Airflow 3.0
+AIR302_names.py:279:1: AIR302 `airflow.utils.dates.infer_time_unit` is removed in Airflow 3.0
     |
-272 | date_range
-273 | days_ago
-274 | infer_time_unit
+277 | date_range
+278 | days_ago
+279 | infer_time_unit
     | ^^^^^^^^^^^^^^^ AIR302
-275 | parse_execution_date
-276 | round_time
+280 | parse_execution_date
+281 | round_time
     |
 
-AIR302_names.py:275:1: AIR302 `airflow.utils.dates.parse_execution_date` is removed in Airflow 3.0
+AIR302_names.py:280:1: AIR302 `airflow.utils.dates.parse_execution_date` is removed in Airflow 3.0
     |
-273 | days_ago
-274 | infer_time_unit
-275 | parse_execution_date
+278 | days_ago
+279 | infer_time_unit
+280 | parse_execution_date
     | ^^^^^^^^^^^^^^^^^^^^ AIR302
-276 | round_time
-277 | scale_time_units
+281 | round_time
+282 | scale_time_units
     |
 
-AIR302_names.py:276:1: AIR302 `airflow.utils.dates.round_time` is removed in Airflow 3.0
+AIR302_names.py:281:1: AIR302 `airflow.utils.dates.round_time` is removed in Airflow 3.0
     |
-274 | infer_time_unit
-275 | parse_execution_date
-276 | round_time
+279 | infer_time_unit
+280 | parse_execution_date
+281 | round_time
     | ^^^^^^^^^^ AIR302
-277 | scale_time_units
+282 | scale_time_units
     |
 
-AIR302_names.py:277:1: AIR302 `airflow.utils.dates.scale_time_units` is removed in Airflow 3.0
+AIR302_names.py:282:1: AIR302 `airflow.utils.dates.scale_time_units` is removed in Airflow 3.0
     |
-275 | parse_execution_date
-276 | round_time
-277 | scale_time_units
+280 | parse_execution_date
+281 | round_time
+282 | scale_time_units
     | ^^^^^^^^^^^^^^^^ AIR302
-278 |
-279 | # This one was not deprecated.
+283 |
+284 | # This one was not deprecated.
     |
 
-AIR302_names.py:284:1: AIR302 `airflow.utils.dag_cycle_tester.test_cycle` is removed in Airflow 3.0
+AIR302_names.py:289:1: AIR302 `airflow.utils.dag_cycle_tester.test_cycle` is removed in Airflow 3.0
     |
-283 | # airflow.utils.dag_cycle_tester
-284 | test_cycle
+288 | # airflow.utils.dag_cycle_tester
+289 | test_cycle
     | ^^^^^^^^^^ AIR302
-285 |
-286 | # airflow.utils.dag_parsing_context
+290 |
+291 | # airflow.utils.dag_parsing_context
     |
 
-AIR302_names.py:287:1: AIR302 `airflow.utils.dag_parsing_context.get_parsing_context` is removed in Airflow 3.0
+AIR302_names.py:292:1: AIR302 `airflow.utils.dag_parsing_context.get_parsing_context` is removed in Airflow 3.0
     |
-286 | # airflow.utils.dag_parsing_context
-287 | get_parsing_context
+291 | # airflow.utils.dag_parsing_context
+292 | get_parsing_context
     | ^^^^^^^^^^^^^^^^^^^ AIR302
-288 |
-289 | # airflow.utils.decorators
+293 |
+294 | # airflow.utils.decorators
     |
     = help: Use `airflow.sdk.get_parsing_context` instead
 
-AIR302_names.py:290:1: AIR302 `airflow.utils.decorators.apply_defaults` is removed in Airflow 3.0; `apply_defaults` is now unconditionally done and can be safely removed.
+AIR302_names.py:295:1: AIR302 `airflow.utils.decorators.apply_defaults` is removed in Airflow 3.0; `apply_defaults` is now unconditionally done and can be safely removed.
     |
-289 | # airflow.utils.decorators
-290 | apply_defaults
+294 | # airflow.utils.decorators
+295 | apply_defaults
     | ^^^^^^^^^^^^^^ AIR302
-291 |
-292 | # airflow.utils.file
+296 |
+297 | # airflow.utils.file
     |
 
-AIR302_names.py:293:1: AIR302 `airflow.utils.file.TemporaryDirectory` is removed in Airflow 3.0
+AIR302_names.py:298:1: AIR302 `airflow.utils.file.TemporaryDirectory` is removed in Airflow 3.0
     |
-292 | # airflow.utils.file
-293 | TemporaryDirectory()
+297 | # airflow.utils.file
+298 | TemporaryDirectory()
     | ^^^^^^^^^^^^^^^^^^ AIR302
-294 | mkdirs
+299 | mkdirs
     |
 
-AIR302_names.py:294:1: AIR302 `airflow.utils.file.mkdirs` is removed in Airflow 3.0
+AIR302_names.py:299:1: AIR302 `airflow.utils.file.mkdirs` is removed in Airflow 3.0
     |
-292 | # airflow.utils.file
-293 | TemporaryDirectory()
-294 | mkdirs
+297 | # airflow.utils.file
+298 | TemporaryDirectory()
+299 | mkdirs
     | ^^^^^^ AIR302
-295 |
-296 | #  airflow.utils.helpers
+300 |
+301 | #  airflow.utils.helpers
     |
     = help: Use `pendulum.today('UTC').add(days=-N, ...)` instead
 
-AIR302_names.py:297:1: AIR302 `airflow.utils.helpers.chain` is removed in Airflow 3.0
+AIR302_names.py:302:1: AIR302 `airflow.utils.helpers.chain` is removed in Airflow 3.0
     |
-296 | #  airflow.utils.helpers
-297 | helper_chain
+301 | #  airflow.utils.helpers
+302 | helper_chain
     | ^^^^^^^^^^^^ AIR302
-298 | helper_cross_downstream
+303 | helper_cross_downstream
     |
     = help: Use `airflow.sdk.chain` instead
 
-AIR302_names.py:298:1: AIR302 `airflow.utils.helpers.cross_downstream` is removed in Airflow 3.0
+AIR302_names.py:303:1: AIR302 `airflow.utils.helpers.cross_downstream` is removed in Airflow 3.0
     |
-296 | #  airflow.utils.helpers
-297 | helper_chain
-298 | helper_cross_downstream
+301 | #  airflow.utils.helpers
+302 | helper_chain
+303 | helper_cross_downstream
     | ^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-299 |
-300 | # airflow.utils.state
+304 |
+305 | #  airflow.utils.log
     |
     = help: Use `airflow.sdk.cross_downstream` instead
 
-AIR302_names.py:301:1: AIR302 `airflow.utils.state.SHUTDOWN` is removed in Airflow 3.0
+AIR302_names.py:306:1: AIR302 `airflow.utils.log.secrets_masker` is removed in Airflow 3.0
     |
-300 | # airflow.utils.state
-301 | SHUTDOWN
-    | ^^^^^^^^ AIR302
-302 | terminating_states
-    |
-
-AIR302_names.py:302:1: AIR302 `airflow.utils.state.terminating_states` is removed in Airflow 3.0
-    |
-300 | # airflow.utils.state
-301 | SHUTDOWN
-302 | terminating_states
-    | ^^^^^^^^^^^^^^^^^^ AIR302
-303 |
-304 | #  airflow.utils.trigger_rule
-    |
-
-AIR302_names.py:305:13: AIR302 `airflow.utils.trigger_rule.TriggerRule.DUMMY` is removed in Airflow 3.0
-    |
-304 | #  airflow.utils.trigger_rule
-305 | TriggerRule.DUMMY
-    |             ^^^^^ AIR302
-306 | TriggerRule.NONE_FAILED_OR_SKIPPED
-    |
-
-AIR302_names.py:306:13: AIR302 `airflow.utils.trigger_rule.TriggerRule.NONE_FAILED_OR_SKIPPED` is removed in Airflow 3.0
-    |
-304 | #  airflow.utils.trigger_rule
-305 | TriggerRule.DUMMY
-306 | TriggerRule.NONE_FAILED_OR_SKIPPED
-    |             ^^^^^^^^^^^^^^^^^^^^^^ AIR302
+305 | #  airflow.utils.log
+306 | secrets_masker
+    | ^^^^^^^^^^^^^^ AIR302
 307 |
-308 | # airflow.www.auth
+308 | # airflow.utils.state
+    |
+    = help: Use `airflow.sdk.execution_time.secrets_masker` instead
+
+AIR302_names.py:309:1: AIR302 `airflow.utils.state.SHUTDOWN` is removed in Airflow 3.0
+    |
+308 | # airflow.utils.state
+309 | SHUTDOWN
+    | ^^^^^^^^ AIR302
+310 | terminating_states
     |
 
-AIR302_names.py:309:1: AIR302 `airflow.www.auth.has_access` is removed in Airflow 3.0
+AIR302_names.py:310:1: AIR302 `airflow.utils.state.terminating_states` is removed in Airflow 3.0
     |
-308 | # airflow.www.auth
-309 | has_access
+308 | # airflow.utils.state
+309 | SHUTDOWN
+310 | terminating_states
+    | ^^^^^^^^^^^^^^^^^^ AIR302
+311 |
+312 | #  airflow.utils.trigger_rule
+    |
+
+AIR302_names.py:313:13: AIR302 `airflow.utils.trigger_rule.TriggerRule.DUMMY` is removed in Airflow 3.0
+    |
+312 | #  airflow.utils.trigger_rule
+313 | TriggerRule.DUMMY
+    |             ^^^^^ AIR302
+314 | TriggerRule.NONE_FAILED_OR_SKIPPED
+    |
+
+AIR302_names.py:314:13: AIR302 `airflow.utils.trigger_rule.TriggerRule.NONE_FAILED_OR_SKIPPED` is removed in Airflow 3.0
+    |
+312 | #  airflow.utils.trigger_rule
+313 | TriggerRule.DUMMY
+314 | TriggerRule.NONE_FAILED_OR_SKIPPED
+    |             ^^^^^^^^^^^^^^^^^^^^^^ AIR302
+315 |
+316 | # airflow.www.auth
+    |
+
+AIR302_names.py:317:1: AIR302 `airflow.www.auth.has_access` is removed in Airflow 3.0
+    |
+316 | # airflow.www.auth
+317 | has_access
     | ^^^^^^^^^^ AIR302
-310 | has_access_dataset
+318 | has_access_dataset
     |
     = help: Use `airflow.www.auth.has_access_*` instead
 
-AIR302_names.py:310:1: AIR302 `airflow.www.auth.has_access_dataset` is removed in Airflow 3.0
+AIR302_names.py:318:1: AIR302 `airflow.www.auth.has_access_dataset` is removed in Airflow 3.0
     |
-308 | # airflow.www.auth
-309 | has_access
-310 | has_access_dataset
+316 | # airflow.www.auth
+317 | has_access
+318 | has_access_dataset
     | ^^^^^^^^^^^^^^^^^^ AIR302
-311 |
-312 | # airflow.www.utils
+319 |
+320 | # airflow.www.utils
     |
     = help: Use `airflow.www.auth.has_access_dataset.has_access_asset` instead
 
-AIR302_names.py:313:1: AIR302 `airflow.www.utils.get_sensitive_variables_fields` is removed in Airflow 3.0
+AIR302_names.py:321:1: AIR302 `airflow.www.utils.get_sensitive_variables_fields` is removed in Airflow 3.0
     |
-312 | # airflow.www.utils
-313 | get_sensitive_variables_fields
+320 | # airflow.www.utils
+321 | get_sensitive_variables_fields
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-314 | should_hide_value_for_key
+322 | should_hide_value_for_key
     |
     = help: Use `airflow.utils.log.secrets_masker.get_sensitive_variables_fields` instead
 
-AIR302_names.py:314:1: AIR302 `airflow.www.utils.should_hide_value_for_key` is removed in Airflow 3.0
+AIR302_names.py:322:1: AIR302 `airflow.www.utils.should_hide_value_for_key` is removed in Airflow 3.0
     |
-312 | # airflow.www.utils
-313 | get_sensitive_variables_fields
-314 | should_hide_value_for_key
+320 | # airflow.www.utils
+321 | get_sensitive_variables_fields
+322 | should_hide_value_for_key
     | ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
     |
     = help: Use `airflow.utils.log.secrets_masker.should_hide_value_for_key` instead

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
@@ -103,7 +103,7 @@ AIR302_names.py:125:1: AIR302 `airflow.auth.managers.base_auth_manager.is_author
     | ^^^^^^^^^^^^^^^^^^^^^ AIR302
 126 | DatasetDetails()
     |
-    = help: Use `airflow.auth.managers.base_auth_manager.is_authorized_asset` instead
+    = help: Use `airflow.api_fastapi.auth.managers.base_auth_manager.is_authorized_asset` instead
 
 AIR302_names.py:126:1: AIR302 `airflow.auth.managers.models.resource_details.DatasetDetails` is removed in Airflow 3.0
     |
@@ -114,7 +114,7 @@ AIR302_names.py:126:1: AIR302 `airflow.auth.managers.models.resource_details.Dat
 127 |
 128 | # airflow.configuration
     |
-    = help: Use `airflow.auth.managers.models.resource_details.AssetDetails` instead
+    = help: Use `airflow.api_fastapi.auth.managers.models.resource_details.AssetDetails` instead
 
 AIR302_names.py:129:1: AIR302 `airflow.configuration.get` is removed in Airflow 3.0
     |

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
@@ -2,1048 +2,1058 @@
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 snapshot_kind: text
 ---
-AIR302_names.py:117:1: AIR302 `airflow.PY36` is removed in Airflow 3.0
+AIR302_names.py:118:1: AIR302 `airflow.PY36` is removed in Airflow 3.0
     |
-116 | # airflow root
-117 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+117 | # airflow root
+118 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
     | ^^^^ AIR302
-118 | DatasetFromRoot()
+119 | DatasetFromRoot()
     |
     = help: Use `sys.version_info` instead
 
-AIR302_names.py:117:7: AIR302 `airflow.PY37` is removed in Airflow 3.0
+AIR302_names.py:118:7: AIR302 `airflow.PY37` is removed in Airflow 3.0
     |
-116 | # airflow root
-117 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+117 | # airflow root
+118 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
     |       ^^^^ AIR302
-118 | DatasetFromRoot()
+119 | DatasetFromRoot()
     |
     = help: Use `sys.version_info` instead
 
-AIR302_names.py:117:13: AIR302 `airflow.PY38` is removed in Airflow 3.0
+AIR302_names.py:118:13: AIR302 `airflow.PY38` is removed in Airflow 3.0
     |
-116 | # airflow root
-117 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+117 | # airflow root
+118 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
     |             ^^^^ AIR302
-118 | DatasetFromRoot()
+119 | DatasetFromRoot()
     |
     = help: Use `sys.version_info` instead
 
-AIR302_names.py:117:19: AIR302 `airflow.PY39` is removed in Airflow 3.0
+AIR302_names.py:118:19: AIR302 `airflow.PY39` is removed in Airflow 3.0
     |
-116 | # airflow root
-117 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+117 | # airflow root
+118 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
     |                   ^^^^ AIR302
-118 | DatasetFromRoot()
+119 | DatasetFromRoot()
     |
     = help: Use `sys.version_info` instead
 
-AIR302_names.py:117:25: AIR302 `airflow.PY310` is removed in Airflow 3.0
+AIR302_names.py:118:25: AIR302 `airflow.PY310` is removed in Airflow 3.0
     |
-116 | # airflow root
-117 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+117 | # airflow root
+118 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
     |                         ^^^^^ AIR302
-118 | DatasetFromRoot()
+119 | DatasetFromRoot()
     |
     = help: Use `sys.version_info` instead
 
-AIR302_names.py:117:32: AIR302 `airflow.PY311` is removed in Airflow 3.0
+AIR302_names.py:118:32: AIR302 `airflow.PY311` is removed in Airflow 3.0
     |
-116 | # airflow root
-117 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+117 | # airflow root
+118 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
     |                                ^^^^^ AIR302
-118 | DatasetFromRoot()
+119 | DatasetFromRoot()
     |
     = help: Use `sys.version_info` instead
 
-AIR302_names.py:117:39: AIR302 `airflow.PY312` is removed in Airflow 3.0
+AIR302_names.py:118:39: AIR302 `airflow.PY312` is removed in Airflow 3.0
     |
-116 | # airflow root
-117 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+117 | # airflow root
+118 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
     |                                       ^^^^^ AIR302
-118 | DatasetFromRoot()
+119 | DatasetFromRoot()
     |
     = help: Use `sys.version_info` instead
 
-AIR302_names.py:118:1: AIR302 `airflow.Dataset` is removed in Airflow 3.0
+AIR302_names.py:119:1: AIR302 `airflow.Dataset` is removed in Airflow 3.0
     |
-116 | # airflow root
-117 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
-118 | DatasetFromRoot()
+117 | # airflow root
+118 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+119 | DatasetFromRoot()
     | ^^^^^^^^^^^^^^^ AIR302
-119 |
-120 | # airflow.api_connexion.security
+120 |
+121 | # airflow.api_connexion.security
     |
     = help: Use `airflow.sdk.Asset` instead
 
-AIR302_names.py:121:1: AIR302 `airflow.api_connexion.security.requires_access` is removed in Airflow 3.0
+AIR302_names.py:122:1: AIR302 `airflow.api_connexion.security.requires_access` is removed in Airflow 3.0
     |
-120 | # airflow.api_connexion.security
-121 | requires_access, requires_access_dataset
+121 | # airflow.api_connexion.security
+122 | requires_access, requires_access_dataset
     | ^^^^^^^^^^^^^^^ AIR302
-122 |
-123 | # airflow.auth.managers
+123 |
+124 | # airflow.auth.managers
     |
     = help: Use `airflow.api_connexion.security.requires_access_*` instead
 
-AIR302_names.py:121:18: AIR302 `airflow.api_connexion.security.requires_access_dataset` is removed in Airflow 3.0
+AIR302_names.py:122:18: AIR302 `airflow.api_connexion.security.requires_access_dataset` is removed in Airflow 3.0
     |
-120 | # airflow.api_connexion.security
-121 | requires_access, requires_access_dataset
+121 | # airflow.api_connexion.security
+122 | requires_access, requires_access_dataset
     |                  ^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-122 |
-123 | # airflow.auth.managers
+123 |
+124 | # airflow.auth.managers
     |
     = help: Use `airflow.api_connexion.security.requires_access_asset` instead
 
-AIR302_names.py:124:1: AIR302 `airflow.auth.managers.base_auth_manager.is_authorized_dataset` is removed in Airflow 3.0
+AIR302_names.py:125:1: AIR302 `airflow.auth.managers.base_auth_manager.is_authorized_dataset` is removed in Airflow 3.0
     |
-123 | # airflow.auth.managers
-124 | is_authorized_dataset
+124 | # airflow.auth.managers
+125 | is_authorized_dataset
     | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-125 | DatasetDetails()
+126 | DatasetDetails()
     |
     = help: Use `airflow.auth.managers.base_auth_manager.is_authorized_asset` instead
 
-AIR302_names.py:125:1: AIR302 `airflow.auth.managers.models.resource_details.DatasetDetails` is removed in Airflow 3.0
+AIR302_names.py:126:1: AIR302 `airflow.auth.managers.models.resource_details.DatasetDetails` is removed in Airflow 3.0
     |
-123 | # airflow.auth.managers
-124 | is_authorized_dataset
-125 | DatasetDetails()
+124 | # airflow.auth.managers
+125 | is_authorized_dataset
+126 | DatasetDetails()
     | ^^^^^^^^^^^^^^ AIR302
-126 |
-127 | # airflow.configuration
+127 |
+128 | # airflow.configuration
     |
     = help: Use `airflow.auth.managers.models.resource_details.AssetDetails` instead
 
-AIR302_names.py:128:1: AIR302 `airflow.configuration.get` is removed in Airflow 3.0
+AIR302_names.py:129:1: AIR302 `airflow.configuration.get` is removed in Airflow 3.0
     |
-127 | # airflow.configuration
-128 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+128 | # airflow.configuration
+129 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     | ^^^ AIR302
     |
     = help: Use `airflow.configuration.conf.get` instead
 
-AIR302_names.py:128:6: AIR302 `airflow.configuration.getboolean` is removed in Airflow 3.0
+AIR302_names.py:129:6: AIR302 `airflow.configuration.getboolean` is removed in Airflow 3.0
     |
-127 | # airflow.configuration
-128 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+128 | # airflow.configuration
+129 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     |      ^^^^^^^^^^ AIR302
     |
     = help: Use `airflow.configuration.conf.getboolean` instead
 
-AIR302_names.py:128:18: AIR302 `airflow.configuration.getfloat` is removed in Airflow 3.0
+AIR302_names.py:129:18: AIR302 `airflow.configuration.getfloat` is removed in Airflow 3.0
     |
-127 | # airflow.configuration
-128 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+128 | # airflow.configuration
+129 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     |                  ^^^^^^^^ AIR302
     |
     = help: Use `airflow.configuration.conf.getfloat` instead
 
-AIR302_names.py:128:28: AIR302 `airflow.configuration.getint` is removed in Airflow 3.0
+AIR302_names.py:129:28: AIR302 `airflow.configuration.getint` is removed in Airflow 3.0
     |
-127 | # airflow.configuration
-128 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+128 | # airflow.configuration
+129 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     |                            ^^^^^^ AIR302
     |
     = help: Use `airflow.configuration.conf.getint` instead
 
-AIR302_names.py:128:36: AIR302 `airflow.configuration.has_option` is removed in Airflow 3.0
+AIR302_names.py:129:36: AIR302 `airflow.configuration.has_option` is removed in Airflow 3.0
     |
-127 | # airflow.configuration
-128 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+128 | # airflow.configuration
+129 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     |                                    ^^^^^^^^^^ AIR302
     |
     = help: Use `airflow.configuration.conf.has_option` instead
 
-AIR302_names.py:128:48: AIR302 `airflow.configuration.remove_option` is removed in Airflow 3.0
+AIR302_names.py:129:48: AIR302 `airflow.configuration.remove_option` is removed in Airflow 3.0
     |
-127 | # airflow.configuration
-128 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+128 | # airflow.configuration
+129 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     |                                                ^^^^^^^^^^^^^ AIR302
     |
     = help: Use `airflow.configuration.conf.remove_option` instead
 
-AIR302_names.py:128:63: AIR302 `airflow.configuration.as_dict` is removed in Airflow 3.0
+AIR302_names.py:129:63: AIR302 `airflow.configuration.as_dict` is removed in Airflow 3.0
     |
-127 | # airflow.configuration
-128 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+128 | # airflow.configuration
+129 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     |                                                               ^^^^^^^ AIR302
     |
     = help: Use `airflow.configuration.conf.as_dict` instead
 
-AIR302_names.py:128:72: AIR302 `airflow.configuration.set` is removed in Airflow 3.0
+AIR302_names.py:129:72: AIR302 `airflow.configuration.set` is removed in Airflow 3.0
     |
-127 | # airflow.configuration
-128 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+128 | # airflow.configuration
+129 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     |                                                                        ^^^ AIR302
     |
     = help: Use `airflow.configuration.conf.set` instead
 
-AIR302_names.py:132:1: AIR302 `airflow.contrib.aws_athena_hook.AWSAthenaHook` is removed in Airflow 3.0; The whole `airflow.contrib` module has been removed.
+AIR302_names.py:133:1: AIR302 `airflow.contrib.aws_athena_hook.AWSAthenaHook` is removed in Airflow 3.0; The whole `airflow.contrib` module has been removed.
     |
-131 | # airflow.contrib.*
-132 | AWSAthenaHook()
+132 | # airflow.contrib.*
+133 | AWSAthenaHook()
     | ^^^^^^^^^^^^^ AIR302
-133 |
-134 | # airflow.datasets
+134 |
+135 | # airflow.datasets
     |
 
-AIR302_names.py:135:1: AIR302 `airflow.datasets.Dataset` is removed in Airflow 3.0
+AIR302_names.py:136:1: AIR302 `airflow.datasets.Dataset` is removed in Airflow 3.0
     |
-134 | # airflow.datasets
-135 | Dataset()
+135 | # airflow.datasets
+136 | Dataset()
     | ^^^^^^^ AIR302
-136 | DatasetAlias()
-137 | DatasetAliasEvent()
+137 | DatasetAlias()
+138 | DatasetAliasEvent()
     |
     = help: Use `airflow.sdk.Asset` instead
 
-AIR302_names.py:136:1: AIR302 `airflow.datasets.DatasetAlias` is removed in Airflow 3.0
+AIR302_names.py:137:1: AIR302 `airflow.datasets.DatasetAlias` is removed in Airflow 3.0
     |
-134 | # airflow.datasets
-135 | Dataset()
-136 | DatasetAlias()
+135 | # airflow.datasets
+136 | Dataset()
+137 | DatasetAlias()
     | ^^^^^^^^^^^^ AIR302
-137 | DatasetAliasEvent()
-138 | DatasetAll()
+138 | DatasetAliasEvent()
+139 | DatasetAll()
     |
     = help: Use `airflow.sdk.AssetAlias` instead
 
-AIR302_names.py:137:1: AIR302 `airflow.datasets.DatasetAliasEvent` is removed in Airflow 3.0
+AIR302_names.py:138:1: AIR302 `airflow.datasets.DatasetAliasEvent` is removed in Airflow 3.0
     |
-135 | Dataset()
-136 | DatasetAlias()
-137 | DatasetAliasEvent()
+136 | Dataset()
+137 | DatasetAlias()
+138 | DatasetAliasEvent()
     | ^^^^^^^^^^^^^^^^^ AIR302
-138 | DatasetAll()
-139 | DatasetAny()
+139 | DatasetAll()
+140 | DatasetAny()
     |
 
-AIR302_names.py:138:1: AIR302 `airflow.datasets.DatasetAll` is removed in Airflow 3.0
+AIR302_names.py:139:1: AIR302 `airflow.datasets.DatasetAll` is removed in Airflow 3.0
     |
-136 | DatasetAlias()
-137 | DatasetAliasEvent()
-138 | DatasetAll()
+137 | DatasetAlias()
+138 | DatasetAliasEvent()
+139 | DatasetAll()
     | ^^^^^^^^^^ AIR302
-139 | DatasetAny()
-140 | Metadata()
+140 | DatasetAny()
+141 | Metadata()
     |
     = help: Use `airflow.sdk.AssetAll` instead
 
-AIR302_names.py:139:1: AIR302 `airflow.datasets.DatasetAny` is removed in Airflow 3.0
+AIR302_names.py:140:1: AIR302 `airflow.datasets.DatasetAny` is removed in Airflow 3.0
     |
-137 | DatasetAliasEvent()
-138 | DatasetAll()
-139 | DatasetAny()
+138 | DatasetAliasEvent()
+139 | DatasetAll()
+140 | DatasetAny()
     | ^^^^^^^^^^ AIR302
-140 | Metadata()
-141 | expand_alias_to_datasets
+141 | Metadata()
+142 | expand_alias_to_datasets
     |
     = help: Use `airflow.sdk.AssetAny` instead
 
-AIR302_names.py:140:1: AIR302 `airflow.datasets.metadata.Metadata` is removed in Airflow 3.0
+AIR302_names.py:141:1: AIR302 `airflow.datasets.metadata.Metadata` is removed in Airflow 3.0
     |
-138 | DatasetAll()
-139 | DatasetAny()
-140 | Metadata()
+139 | DatasetAll()
+140 | DatasetAny()
+141 | Metadata()
     | ^^^^^^^^ AIR302
-141 | expand_alias_to_datasets
+142 | expand_alias_to_datasets
     |
     = help: Use `airflow.sdk.Metadata` instead
 
-AIR302_names.py:141:1: AIR302 `airflow.datasets.expand_alias_to_datasets` is removed in Airflow 3.0
+AIR302_names.py:142:1: AIR302 `airflow.datasets.expand_alias_to_datasets` is removed in Airflow 3.0
     |
-139 | DatasetAny()
-140 | Metadata()
-141 | expand_alias_to_datasets
+140 | DatasetAny()
+141 | Metadata()
+142 | expand_alias_to_datasets
     | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-142 |
-143 | # airflow.datasets.manager
+143 |
+144 | # airflow.datasets.manager
     |
     = help: Use `airflow.sdk.expand_alias_to_assets` instead
 
-AIR302_names.py:144:1: AIR302 `airflow.datasets.manager.DatasetManager` is removed in Airflow 3.0
+AIR302_names.py:145:1: AIR302 `airflow.datasets.manager.DatasetManager` is removed in Airflow 3.0
     |
-143 | # airflow.datasets.manager
-144 | DatasetManager()
+144 | # airflow.datasets.manager
+145 | DatasetManager()
     | ^^^^^^^^^^^^^^ AIR302
-145 | dataset_manager
-146 | resolve_dataset_manager
+146 | dataset_manager
+147 | resolve_dataset_manager
     |
     = help: Use `airflow.assets.AssetManager` instead
 
-AIR302_names.py:145:1: AIR302 `airflow.datasets.manager.dataset_manager` is removed in Airflow 3.0
+AIR302_names.py:146:1: AIR302 `airflow.datasets.manager.dataset_manager` is removed in Airflow 3.0
     |
-143 | # airflow.datasets.manager
-144 | DatasetManager()
-145 | dataset_manager
+144 | # airflow.datasets.manager
+145 | DatasetManager()
+146 | dataset_manager
     | ^^^^^^^^^^^^^^^ AIR302
-146 | resolve_dataset_manager
+147 | resolve_dataset_manager
     |
     = help: Use `airflow.assets.manager.asset_manager` instead
 
-AIR302_names.py:146:1: AIR302 `airflow.datasets.manager.resolve_dataset_manager` is removed in Airflow 3.0
+AIR302_names.py:147:1: AIR302 `airflow.datasets.manager.resolve_dataset_manager` is removed in Airflow 3.0
     |
-144 | DatasetManager()
-145 | dataset_manager
-146 | resolve_dataset_manager
+145 | DatasetManager()
+146 | dataset_manager
+147 | resolve_dataset_manager
     | ^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-147 |
-148 | # airflow.hooks
+148 |
+149 | # airflow.hooks
     |
     = help: Use `airflow.assets.resolve_asset_manager` instead
 
-AIR302_names.py:149:1: AIR302 `airflow.hooks.base_hook.BaseHook` is removed in Airflow 3.0
+AIR302_names.py:150:1: AIR302 `airflow.hooks.base_hook.BaseHook` is removed in Airflow 3.0
     |
-148 | # airflow.hooks
-149 | BaseHook()
+149 | # airflow.hooks
+150 | BaseHook()
     | ^^^^^^^^ AIR302
-150 |
-151 | # airflow.lineage.hook
+151 |
+152 | # airflow.lineage.hook
     |
     = help: Use `airflow.hooks.base.BaseHook` instead
 
-AIR302_names.py:152:1: AIR302 `airflow.lineage.hook.DatasetLineageInfo` is removed in Airflow 3.0
+AIR302_names.py:153:1: AIR302 `airflow.lineage.hook.DatasetLineageInfo` is removed in Airflow 3.0
     |
-151 | # airflow.lineage.hook
-152 | DatasetLineageInfo()
+152 | # airflow.lineage.hook
+153 | DatasetLineageInfo()
     | ^^^^^^^^^^^^^^^^^^ AIR302
-153 |
-154 | # airflow.listeners.spec.dataset
+154 |
+155 | # airflow.listeners.spec.dataset
     |
     = help: Use `airflow.lineage.hook.AssetLineageInfo` instead
 
-AIR302_names.py:155:1: AIR302 `airflow.listeners.spec.dataset.on_dataset_changed` is removed in Airflow 3.0
+AIR302_names.py:156:1: AIR302 `airflow.listeners.spec.dataset.on_dataset_changed` is removed in Airflow 3.0
     |
-154 | # airflow.listeners.spec.dataset
-155 | on_dataset_changed
+155 | # airflow.listeners.spec.dataset
+156 | on_dataset_changed
     | ^^^^^^^^^^^^^^^^^^ AIR302
-156 | on_dataset_created
+157 | on_dataset_created
     |
     = help: Use `airflow.listeners.spec.asset.on_asset_changed` instead
 
-AIR302_names.py:156:1: AIR302 `airflow.listeners.spec.dataset.on_dataset_created` is removed in Airflow 3.0
+AIR302_names.py:157:1: AIR302 `airflow.listeners.spec.dataset.on_dataset_created` is removed in Airflow 3.0
     |
-154 | # airflow.listeners.spec.dataset
-155 | on_dataset_changed
-156 | on_dataset_created
+155 | # airflow.listeners.spec.dataset
+156 | on_dataset_changed
+157 | on_dataset_created
     | ^^^^^^^^^^^^^^^^^^ AIR302
-157 |
-158 | # airflow.metrics.validators
+158 |
+159 | # airflow.metrics.validators
     |
     = help: Use `airflow.listeners.spec.asset.on_asset_created` instead
 
-AIR302_names.py:159:1: AIR302 `airflow.metrics.validators.AllowListValidator` is removed in Airflow 3.0
+AIR302_names.py:160:1: AIR302 `airflow.metrics.validators.AllowListValidator` is removed in Airflow 3.0
     |
-158 | # airflow.metrics.validators
-159 | AllowListValidator()
+159 | # airflow.metrics.validators
+160 | AllowListValidator()
     | ^^^^^^^^^^^^^^^^^^ AIR302
-160 | BlockListValidator()
+161 | BlockListValidator()
     |
     = help: Use `airflow.metrics.validators.PatternAllowListValidator` instead
 
-AIR302_names.py:160:1: AIR302 `airflow.metrics.validators.BlockListValidator` is removed in Airflow 3.0
+AIR302_names.py:161:1: AIR302 `airflow.metrics.validators.BlockListValidator` is removed in Airflow 3.0
     |
-158 | # airflow.metrics.validators
-159 | AllowListValidator()
-160 | BlockListValidator()
+159 | # airflow.metrics.validators
+160 | AllowListValidator()
+161 | BlockListValidator()
     | ^^^^^^^^^^^^^^^^^^ AIR302
     |
     = help: Use `airflow.metrics.validators.PatternBlockListValidator` instead
 
-AIR302_names.py:164:1: AIR302 `airflow.models.baseoperator.chain` is removed in Airflow 3.0
+AIR302_names.py:165:1: AIR302 `airflow.models.baseoperator.chain` is removed in Airflow 3.0
     |
-163 | # airflow.models.baseoperator
-164 | chain, chain_linear, cross_downstream
+164 | # airflow.models.baseoperator
+165 | chain, chain_linear, cross_downstream
     | ^^^^^ AIR302
-165 |
-166 | # airflow.operators.dummy
+166 |
+167 | # airflow.models.baseoperatorlink
     |
     = help: Use `airflow.sdk.chain` instead
 
-AIR302_names.py:164:8: AIR302 `airflow.models.baseoperator.chain_linear` is removed in Airflow 3.0
+AIR302_names.py:165:8: AIR302 `airflow.models.baseoperator.chain_linear` is removed in Airflow 3.0
     |
-163 | # airflow.models.baseoperator
-164 | chain, chain_linear, cross_downstream
+164 | # airflow.models.baseoperator
+165 | chain, chain_linear, cross_downstream
     |        ^^^^^^^^^^^^ AIR302
-165 |
-166 | # airflow.operators.dummy
+166 |
+167 | # airflow.models.baseoperatorlink
     |
     = help: Use `airflow.sdk.chain_linear` instead
 
-AIR302_names.py:164:22: AIR302 `airflow.models.baseoperator.cross_downstream` is removed in Airflow 3.0
+AIR302_names.py:165:22: AIR302 `airflow.models.baseoperator.cross_downstream` is removed in Airflow 3.0
     |
-163 | # airflow.models.baseoperator
-164 | chain, chain_linear, cross_downstream
+164 | # airflow.models.baseoperator
+165 | chain, chain_linear, cross_downstream
     |                      ^^^^^^^^^^^^^^^^ AIR302
-165 |
-166 | # airflow.operators.dummy
+166 |
+167 | # airflow.models.baseoperatorlink
     |
     = help: Use `airflow.sdk.cross_downstream` instead
 
-AIR302_names.py:167:1: AIR302 `airflow.operators.dummy.EmptyOperator` is removed in Airflow 3.0
+AIR302_names.py:168:1: AIR302 `airflow.models.baseoperatorlink.BaseOperatorLink` is removed in Airflow 3.0
     |
-166 | # airflow.operators.dummy
-167 | EmptyOperator()
-    | ^^^^^^^^^^^^^ AIR302
-168 | DummyOperator()
-    |
-    = help: Use `airflow.operators.empty.EmptyOperator` instead
-
-AIR302_names.py:168:1: AIR302 `airflow.operators.dummy.DummyOperator` is removed in Airflow 3.0
-    |
-166 | # airflow.operators.dummy
-167 | EmptyOperator()
-168 | DummyOperator()
-    | ^^^^^^^^^^^^^ AIR302
+167 | # airflow.models.baseoperatorlink
+168 | BaseOperatorLink()
+    | ^^^^^^^^^^^^^^^^ AIR302
 169 |
-170 | # airflow.operators.dummy_operator
+170 | # airflow.operators.dummy
+    |
+    = help: Use `airflow.sdk.definitions.baseoperatorlink.BaseOperatorLink` instead
+
+AIR302_names.py:171:1: AIR302 `airflow.operators.dummy.EmptyOperator` is removed in Airflow 3.0
+    |
+170 | # airflow.operators.dummy
+171 | EmptyOperator()
+    | ^^^^^^^^^^^^^ AIR302
+172 | DummyOperator()
     |
     = help: Use `airflow.operators.empty.EmptyOperator` instead
 
-AIR302_names.py:171:16: AIR302 `airflow.operators.dummy_operator.EmptyOperator` is removed in Airflow 3.0
+AIR302_names.py:172:1: AIR302 `airflow.operators.dummy.DummyOperator` is removed in Airflow 3.0
     |
-170 | # airflow.operators.dummy_operator
-171 | dummy_operator.EmptyOperator()
-    |                ^^^^^^^^^^^^^ AIR302
-172 | dummy_operator.DummyOperator()
-    |
-    = help: Use `airflow.operators.empty.EmptyOperator` instead
-
-AIR302_names.py:172:16: AIR302 `airflow.operators.dummy_operator.DummyOperator` is removed in Airflow 3.0
-    |
-170 | # airflow.operators.dummy_operator
-171 | dummy_operator.EmptyOperator()
-172 | dummy_operator.DummyOperator()
-    |                ^^^^^^^^^^^^^ AIR302
+170 | # airflow.operators.dummy
+171 | EmptyOperator()
+172 | DummyOperator()
+    | ^^^^^^^^^^^^^ AIR302
 173 |
-174 | # airflow.operators.branch_operator
+174 | # airflow.operators.dummy_operator
     |
     = help: Use `airflow.operators.empty.EmptyOperator` instead
 
-AIR302_names.py:175:1: AIR302 `airflow.operators.branch_operator.BaseBranchOperator` is removed in Airflow 3.0
+AIR302_names.py:175:16: AIR302 `airflow.operators.dummy_operator.EmptyOperator` is removed in Airflow 3.0
     |
-174 | # airflow.operators.branch_operator
-175 | BaseBranchOperator()
+174 | # airflow.operators.dummy_operator
+175 | dummy_operator.EmptyOperator()
+    |                ^^^^^^^^^^^^^ AIR302
+176 | dummy_operator.DummyOperator()
+    |
+    = help: Use `airflow.operators.empty.EmptyOperator` instead
+
+AIR302_names.py:176:16: AIR302 `airflow.operators.dummy_operator.DummyOperator` is removed in Airflow 3.0
+    |
+174 | # airflow.operators.dummy_operator
+175 | dummy_operator.EmptyOperator()
+176 | dummy_operator.DummyOperator()
+    |                ^^^^^^^^^^^^^ AIR302
+177 |
+178 | # airflow.operators.branch_operator
+    |
+    = help: Use `airflow.operators.empty.EmptyOperator` instead
+
+AIR302_names.py:179:1: AIR302 `airflow.operators.branch_operator.BaseBranchOperator` is removed in Airflow 3.0
+    |
+178 | # airflow.operators.branch_operator
+179 | BaseBranchOperator()
     | ^^^^^^^^^^^^^^^^^^ AIR302
-176 |
-177 | # airflow.operators.dagrun_operator
+180 |
+181 | # airflow.operators.dagrun_operator
     |
     = help: Use `airflow.operators.branch.BaseBranchOperator` instead
 
-AIR302_names.py:178:1: AIR302 `airflow.operators.dagrun_operator.TriggerDagRunLink` is removed in Airflow 3.0
+AIR302_names.py:182:1: AIR302 `airflow.operators.dagrun_operator.TriggerDagRunLink` is removed in Airflow 3.0
     |
-177 | # airflow.operators.dagrun_operator
-178 | TriggerDagRunLink()
+181 | # airflow.operators.dagrun_operator
+182 | TriggerDagRunLink()
     | ^^^^^^^^^^^^^^^^^ AIR302
-179 | TriggerDagRunOperator()
+183 | TriggerDagRunOperator()
     |
     = help: Use `airflow.operators.trigger_dagrun.TriggerDagRunLink` instead
 
-AIR302_names.py:179:1: AIR302 `airflow.operators.dagrun_operator.TriggerDagRunOperator` is removed in Airflow 3.0
+AIR302_names.py:183:1: AIR302 `airflow.operators.dagrun_operator.TriggerDagRunOperator` is removed in Airflow 3.0
     |
-177 | # airflow.operators.dagrun_operator
-178 | TriggerDagRunLink()
-179 | TriggerDagRunOperator()
+181 | # airflow.operators.dagrun_operator
+182 | TriggerDagRunLink()
+183 | TriggerDagRunOperator()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-180 |
-181 | # airflow.operators.email_operator
+184 |
+185 | # airflow.operators.email_operator
     |
     = help: Use `airflow.operators.trigger_dagrun.TriggerDagRunOperator` instead
 
-AIR302_names.py:182:1: AIR302 `airflow.operators.email_operator.EmailOperator` is removed in Airflow 3.0
+AIR302_names.py:186:1: AIR302 `airflow.operators.email_operator.EmailOperator` is removed in Airflow 3.0
     |
-181 | # airflow.operators.email_operator
-182 | EmailOperator()
+185 | # airflow.operators.email_operator
+186 | EmailOperator()
     | ^^^^^^^^^^^^^ AIR302
-183 |
-184 | # airflow.operators.latest_only_operator
+187 |
+188 | # airflow.operators.latest_only_operator
     |
     = help: Use `airflow.operators.email.EmailOperator` instead
 
-AIR302_names.py:185:1: AIR302 `airflow.operators.latest_only_operator.LatestOnlyOperator` is removed in Airflow 3.0
+AIR302_names.py:189:1: AIR302 `airflow.operators.latest_only_operator.LatestOnlyOperator` is removed in Airflow 3.0
     |
-184 | # airflow.operators.latest_only_operator
-185 | LatestOnlyOperator()
+188 | # airflow.operators.latest_only_operator
+189 | LatestOnlyOperator()
     | ^^^^^^^^^^^^^^^^^^ AIR302
-186 |
-187 | # airflow.operators.python_operator
+190 |
+191 | # airflow.operators.python_operator
     |
     = help: Use `airflow.operators.latest_only.LatestOnlyOperator` instead
 
-AIR302_names.py:188:1: AIR302 `airflow.operators.python_operator.BranchPythonOperator` is removed in Airflow 3.0
+AIR302_names.py:192:1: AIR302 `airflow.operators.python_operator.BranchPythonOperator` is removed in Airflow 3.0
     |
-187 | # airflow.operators.python_operator
-188 | BranchPythonOperator()
+191 | # airflow.operators.python_operator
+192 | BranchPythonOperator()
     | ^^^^^^^^^^^^^^^^^^^^ AIR302
-189 | PythonOperator()
-190 | PythonVirtualenvOperator()
+193 | PythonOperator()
+194 | PythonVirtualenvOperator()
     |
     = help: Use `airflow.operators.python.BranchPythonOperator` instead
 
-AIR302_names.py:189:1: AIR302 `airflow.operators.python_operator.PythonOperator` is removed in Airflow 3.0
+AIR302_names.py:193:1: AIR302 `airflow.operators.python_operator.PythonOperator` is removed in Airflow 3.0
     |
-187 | # airflow.operators.python_operator
-188 | BranchPythonOperator()
-189 | PythonOperator()
+191 | # airflow.operators.python_operator
+192 | BranchPythonOperator()
+193 | PythonOperator()
     | ^^^^^^^^^^^^^^ AIR302
-190 | PythonVirtualenvOperator()
-191 | ShortCircuitOperator()
+194 | PythonVirtualenvOperator()
+195 | ShortCircuitOperator()
     |
     = help: Use `airflow.operators.python.PythonOperator` instead
 
-AIR302_names.py:190:1: AIR302 `airflow.operators.python_operator.PythonVirtualenvOperator` is removed in Airflow 3.0
+AIR302_names.py:194:1: AIR302 `airflow.operators.python_operator.PythonVirtualenvOperator` is removed in Airflow 3.0
     |
-188 | BranchPythonOperator()
-189 | PythonOperator()
-190 | PythonVirtualenvOperator()
+192 | BranchPythonOperator()
+193 | PythonOperator()
+194 | PythonVirtualenvOperator()
     | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-191 | ShortCircuitOperator()
+195 | ShortCircuitOperator()
     |
     = help: Use `airflow.operators.python.PythonVirtualenvOperator` instead
 
-AIR302_names.py:191:1: AIR302 `airflow.operators.python_operator.ShortCircuitOperator` is removed in Airflow 3.0
+AIR302_names.py:195:1: AIR302 `airflow.operators.python_operator.ShortCircuitOperator` is removed in Airflow 3.0
     |
-189 | PythonOperator()
-190 | PythonVirtualenvOperator()
-191 | ShortCircuitOperator()
+193 | PythonOperator()
+194 | PythonVirtualenvOperator()
+195 | ShortCircuitOperator()
     | ^^^^^^^^^^^^^^^^^^^^ AIR302
-192 |
-193 | # airflow.operators.subdag.*
+196 |
+197 | # airflow.operators.subdag.*
     |
     = help: Use `airflow.operators.python.ShortCircuitOperator` instead
 
-AIR302_names.py:194:1: AIR302 `airflow.operators.subdag.SubDagOperator` is removed in Airflow 3.0; The whole `airflow.subdag` module has been removed.
+AIR302_names.py:198:1: AIR302 `airflow.operators.subdag.SubDagOperator` is removed in Airflow 3.0; The whole `airflow.subdag` module has been removed.
     |
-193 | # airflow.operators.subdag.*
-194 | SubDagOperator()
+197 | # airflow.operators.subdag.*
+198 | SubDagOperator()
     | ^^^^^^^^^^^^^^ AIR302
-195 |
-196 | # airflow.providers.amazon
+199 |
+200 | # airflow.providers.amazon
     |
 
-AIR302_names.py:197:13: AIR302 `airflow.providers.amazon.aws.auth_manager.avp.entities.AvpEntities.DATASET` is removed in Airflow 3.0
+AIR302_names.py:201:13: AIR302 `airflow.providers.amazon.aws.auth_manager.avp.entities.AvpEntities.DATASET` is removed in Airflow 3.0
     |
-196 | # airflow.providers.amazon
-197 | AvpEntities.DATASET
+200 | # airflow.providers.amazon
+201 | AvpEntities.DATASET
     |             ^^^^^^^ AIR302
-198 | s3.create_dataset
-199 | s3.convert_dataset_to_openlineage
+202 | s3.create_dataset
+203 | s3.convert_dataset_to_openlineage
     |
     = help: Use `airflow.providers.amazon.aws.auth_manager.avp.entities.AvpEntities.ASSET` instead
 
-AIR302_names.py:198:4: AIR302 `airflow.providers.amazon.aws.datasets.s3.create_dataset` is removed in Airflow 3.0
+AIR302_names.py:202:4: AIR302 `airflow.providers.amazon.aws.datasets.s3.create_dataset` is removed in Airflow 3.0
     |
-196 | # airflow.providers.amazon
-197 | AvpEntities.DATASET
-198 | s3.create_dataset
+200 | # airflow.providers.amazon
+201 | AvpEntities.DATASET
+202 | s3.create_dataset
     |    ^^^^^^^^^^^^^^ AIR302
-199 | s3.convert_dataset_to_openlineage
-200 | s3.sanitize_uri
+203 | s3.convert_dataset_to_openlineage
+204 | s3.sanitize_uri
     |
     = help: Use `airflow.providers.amazon.aws.assets.s3.create_asset` instead
 
-AIR302_names.py:199:4: AIR302 `airflow.providers.amazon.aws.datasets.s3.convert_dataset_to_openlineage` is removed in Airflow 3.0
+AIR302_names.py:203:4: AIR302 `airflow.providers.amazon.aws.datasets.s3.convert_dataset_to_openlineage` is removed in Airflow 3.0
     |
-197 | AvpEntities.DATASET
-198 | s3.create_dataset
-199 | s3.convert_dataset_to_openlineage
+201 | AvpEntities.DATASET
+202 | s3.create_dataset
+203 | s3.convert_dataset_to_openlineage
     |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-200 | s3.sanitize_uri
+204 | s3.sanitize_uri
     |
     = help: Use `airflow.providers.amazon.aws.assets.s3.convert_asset_to_openlineage` instead
 
-AIR302_names.py:200:4: AIR302 `airflow.providers.amazon.aws.datasets.s3.sanitize_uri` is removed in Airflow 3.0
+AIR302_names.py:204:4: AIR302 `airflow.providers.amazon.aws.datasets.s3.sanitize_uri` is removed in Airflow 3.0
     |
-198 | s3.create_dataset
-199 | s3.convert_dataset_to_openlineage
-200 | s3.sanitize_uri
+202 | s3.create_dataset
+203 | s3.convert_dataset_to_openlineage
+204 | s3.sanitize_uri
     |    ^^^^^^^^^^^^ AIR302
-201 |
-202 | # airflow.providers.common.io
+205 |
+206 | # airflow.providers.common.io
     |
     = help: Use `airflow.providers.amazon.aws.assets.s3.sanitize_uri` instead
 
-AIR302_names.py:203:16: AIR302 `airflow.providers.common.io.datasets.file.convert_dataset_to_openlineage` is removed in Airflow 3.0
+AIR302_names.py:207:16: AIR302 `airflow.providers.common.io.datasets.file.convert_dataset_to_openlineage` is removed in Airflow 3.0
     |
-202 | # airflow.providers.common.io
-203 | common_io_file.convert_dataset_to_openlineage
+206 | # airflow.providers.common.io
+207 | common_io_file.convert_dataset_to_openlineage
     |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-204 | common_io_file.create_dataset
-205 | common_io_file.sanitize_uri
+208 | common_io_file.create_dataset
+209 | common_io_file.sanitize_uri
     |
     = help: Use `airflow.providers.common.io.assets.file.convert_asset_to_openlineage` instead
 
-AIR302_names.py:204:16: AIR302 `airflow.providers.common.io.datasets.file.create_dataset` is removed in Airflow 3.0
+AIR302_names.py:208:16: AIR302 `airflow.providers.common.io.datasets.file.create_dataset` is removed in Airflow 3.0
     |
-202 | # airflow.providers.common.io
-203 | common_io_file.convert_dataset_to_openlineage
-204 | common_io_file.create_dataset
+206 | # airflow.providers.common.io
+207 | common_io_file.convert_dataset_to_openlineage
+208 | common_io_file.create_dataset
     |                ^^^^^^^^^^^^^^ AIR302
-205 | common_io_file.sanitize_uri
+209 | common_io_file.sanitize_uri
     |
     = help: Use `airflow.providers.common.io.assets.file.create_asset` instead
 
-AIR302_names.py:205:16: AIR302 `airflow.providers.common.io.datasets.file.sanitize_uri` is removed in Airflow 3.0
+AIR302_names.py:209:16: AIR302 `airflow.providers.common.io.datasets.file.sanitize_uri` is removed in Airflow 3.0
     |
-203 | common_io_file.convert_dataset_to_openlineage
-204 | common_io_file.create_dataset
-205 | common_io_file.sanitize_uri
+207 | common_io_file.convert_dataset_to_openlineage
+208 | common_io_file.create_dataset
+209 | common_io_file.sanitize_uri
     |                ^^^^^^^^^^^^ AIR302
-206 |
-207 | # airflow.providers.fab
+210 |
+211 | # airflow.providers.fab
     |
     = help: Use `airflow.providers.common.io.assets.file.sanitize_uri` instead
 
-AIR302_names.py:208:18: AIR302 `airflow.providers.fab.auth_manager.fab_auth_manager.is_authorized_dataset` is removed in Airflow 3.0
+AIR302_names.py:212:18: AIR302 `airflow.providers.fab.auth_manager.fab_auth_manager.is_authorized_dataset` is removed in Airflow 3.0
     |
-207 | # airflow.providers.fab
-208 | fab_auth_manager.is_authorized_dataset
+211 | # airflow.providers.fab
+212 | fab_auth_manager.is_authorized_dataset
     |                  ^^^^^^^^^^^^^^^^^^^^^ AIR302
-209 |
-210 | # airflow.providers.google
+213 |
+214 | # airflow.providers.google
     |
     = help: Use `airflow.providers.fab.auth_manager.fab_auth_manager.is_authorized_asset` instead
 
-AIR302_names.py:213:5: AIR302 `airflow.providers.google.datasets.gcs.create_dataset` is removed in Airflow 3.0
+AIR302_names.py:217:5: AIR302 `airflow.providers.google.datasets.gcs.create_dataset` is removed in Airflow 3.0
     |
-211 | bigquery.sanitize_uri
-212 |
-213 | gcs.create_dataset
+215 | bigquery.sanitize_uri
+216 |
+217 | gcs.create_dataset
     |     ^^^^^^^^^^^^^^ AIR302
-214 | gcs.sanitize_uri
-215 | gcs.convert_dataset_to_openlineage
+218 | gcs.sanitize_uri
+219 | gcs.convert_dataset_to_openlineage
     |
     = help: Use `airflow.providers.google.assets.gcs.create_asset` instead
 
-AIR302_names.py:214:5: AIR302 `airflow.providers.google.datasets.gcs.sanitize_uri` is removed in Airflow 3.0
+AIR302_names.py:218:5: AIR302 `airflow.providers.google.datasets.gcs.sanitize_uri` is removed in Airflow 3.0
     |
-213 | gcs.create_dataset
-214 | gcs.sanitize_uri
+217 | gcs.create_dataset
+218 | gcs.sanitize_uri
     |     ^^^^^^^^^^^^ AIR302
-215 | gcs.convert_dataset_to_openlineage
+219 | gcs.convert_dataset_to_openlineage
     |
     = help: Use `airflow.providers.google.assets.gcs.sanitize_uri` instead
 
-AIR302_names.py:215:5: AIR302 `airflow.providers.google.datasets.gcs.convert_dataset_to_openlineage` is removed in Airflow 3.0
+AIR302_names.py:219:5: AIR302 `airflow.providers.google.datasets.gcs.convert_dataset_to_openlineage` is removed in Airflow 3.0
     |
-213 | gcs.create_dataset
-214 | gcs.sanitize_uri
-215 | gcs.convert_dataset_to_openlineage
+217 | gcs.create_dataset
+218 | gcs.sanitize_uri
+219 | gcs.convert_dataset_to_openlineage
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-216 |
-217 | # airflow.providers.mysql
+220 |
+221 | # airflow.providers.mysql
     |
     = help: Use `airflow.providers.google.assets.gcs.convert_asset_to_openlineage` instead
 
-AIR302_names.py:218:7: AIR302 `airflow.providers.mysql.datasets.mysql.sanitize_uri` is removed in Airflow 3.0
+AIR302_names.py:222:7: AIR302 `airflow.providers.mysql.datasets.mysql.sanitize_uri` is removed in Airflow 3.0
     |
-217 | # airflow.providers.mysql
-218 | mysql.sanitize_uri
+221 | # airflow.providers.mysql
+222 | mysql.sanitize_uri
     |       ^^^^^^^^^^^^ AIR302
-219 |
-220 | # airflow.providers.openlineage
+223 |
+224 | # airflow.providers.openlineage
     |
     = help: Use `airflow.providers.mysql.assets.mysql.sanitize_uri` instead
 
-AIR302_names.py:221:1: AIR302 `airflow.providers.openlineage.utils.utils.DatasetInfo` is removed in Airflow 3.0
+AIR302_names.py:225:1: AIR302 `airflow.providers.openlineage.utils.utils.DatasetInfo` is removed in Airflow 3.0
     |
-220 | # airflow.providers.openlineage
-221 | DatasetInfo()
+224 | # airflow.providers.openlineage
+225 | DatasetInfo()
     | ^^^^^^^^^^^ AIR302
-222 | translate_airflow_dataset
+226 | translate_airflow_dataset
     |
     = help: Use `airflow.providers.openlineage.utils.utils.AssetInfo` instead
 
-AIR302_names.py:222:1: AIR302 `airflow.providers.openlineage.utils.utils.translate_airflow_dataset` is removed in Airflow 3.0
+AIR302_names.py:226:1: AIR302 `airflow.providers.openlineage.utils.utils.translate_airflow_dataset` is removed in Airflow 3.0
     |
-220 | # airflow.providers.openlineage
-221 | DatasetInfo()
-222 | translate_airflow_dataset
+224 | # airflow.providers.openlineage
+225 | DatasetInfo()
+226 | translate_airflow_dataset
     | ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-223 |
-224 | # airflow.providers.postgres
+227 |
+228 | # airflow.providers.postgres
     |
     = help: Use `airflow.providers.openlineage.utils.utils.translate_airflow_asset` instead
 
-AIR302_names.py:225:10: AIR302 `airflow.providers.postgres.datasets.postgres.sanitize_uri` is removed in Airflow 3.0
+AIR302_names.py:229:10: AIR302 `airflow.providers.postgres.datasets.postgres.sanitize_uri` is removed in Airflow 3.0
     |
-224 | # airflow.providers.postgres
-225 | postgres.sanitize_uri
+228 | # airflow.providers.postgres
+229 | postgres.sanitize_uri
     |          ^^^^^^^^^^^^ AIR302
-226 |
-227 | # airflow.providers.trino
+230 |
+231 | # airflow.providers.trino
     |
     = help: Use `airflow.providers.postgres.assets.postgres.sanitize_uri` instead
 
-AIR302_names.py:228:7: AIR302 `airflow.providers.trino.datasets.trino.sanitize_uri` is removed in Airflow 3.0
+AIR302_names.py:232:7: AIR302 `airflow.providers.trino.datasets.trino.sanitize_uri` is removed in Airflow 3.0
     |
-227 | # airflow.providers.trino
-228 | trino.sanitize_uri
+231 | # airflow.providers.trino
+232 | trino.sanitize_uri
     |       ^^^^^^^^^^^^ AIR302
-229 |
-230 | # airflow.secrets
+233 |
+234 | # airflow.secrets
     |
     = help: Use `airflow.providers.trino.assets.trino.sanitize_uri` instead
 
-AIR302_names.py:233:1: AIR302 `airflow.secrets.local_filesystem.load_connections` is removed in Airflow 3.0
+AIR302_names.py:237:1: AIR302 `airflow.secrets.local_filesystem.load_connections` is removed in Airflow 3.0
     |
-231 | # get_connection
-232 | LocalFilesystemBackend()
-233 | load_connections
+235 | # get_connection
+236 | LocalFilesystemBackend()
+237 | load_connections
     | ^^^^^^^^^^^^^^^^ AIR302
-234 |
-235 | # airflow.security.permissions
+238 |
+239 | # airflow.security.permissions
     |
     = help: Use `airflow.secrets.local_filesystem.load_connections_dict` instead
 
-AIR302_names.py:236:1: AIR302 `airflow.security.permissions.RESOURCE_DATASET` is removed in Airflow 3.0
+AIR302_names.py:240:1: AIR302 `airflow.security.permissions.RESOURCE_DATASET` is removed in Airflow 3.0
     |
-235 | # airflow.security.permissions
-236 | RESOURCE_DATASET
+239 | # airflow.security.permissions
+240 | RESOURCE_DATASET
     | ^^^^^^^^^^^^^^^^ AIR302
-237 |
-238 | # airflow.sensors.base_sensor_operator
+241 |
+242 | # airflow.sensors.base_sensor_operator
     |
     = help: Use `airflow.security.permissions.RESOURCE_ASSET` instead
 
-AIR302_names.py:239:1: AIR302 `airflow.sensors.base_sensor_operator.BaseSensorOperator` is removed in Airflow 3.0
+AIR302_names.py:243:1: AIR302 `airflow.sensors.base_sensor_operator.BaseSensorOperator` is removed in Airflow 3.0
     |
-238 | # airflow.sensors.base_sensor_operator
-239 | BaseSensorOperator()
+242 | # airflow.sensors.base_sensor_operator
+243 | BaseSensorOperator()
     | ^^^^^^^^^^^^^^^^^^ AIR302
-240 |
-241 | # airflow.sensors.date_time_sensor
+244 |
+245 | # airflow.sensors.date_time_sensor
     |
     = help: Use `airflow.sensors.base.BaseSensorOperator` instead
 
-AIR302_names.py:242:1: AIR302 `airflow.sensors.date_time_sensor.DateTimeSensor` is removed in Airflow 3.0
+AIR302_names.py:246:1: AIR302 `airflow.sensors.date_time_sensor.DateTimeSensor` is removed in Airflow 3.0
     |
-241 | # airflow.sensors.date_time_sensor
-242 | DateTimeSensor()
+245 | # airflow.sensors.date_time_sensor
+246 | DateTimeSensor()
     | ^^^^^^^^^^^^^^ AIR302
-243 |
-244 | # airflow.sensors.external_task
+247 |
+248 | # airflow.sensors.external_task
     |
     = help: Use `airflow.sensors.date_time.DateTimeSensor` instead
 
-AIR302_names.py:245:1: AIR302 `airflow.sensors.external_task.ExternalTaskSensorLink` is removed in Airflow 3.0
+AIR302_names.py:249:1: AIR302 `airflow.sensors.external_task.ExternalTaskSensorLink` is removed in Airflow 3.0
     |
-244 | # airflow.sensors.external_task
-245 | ExternalTaskSensorLink()
+248 | # airflow.sensors.external_task
+249 | ExternalTaskSensorLink()
     | ^^^^^^^^^^^^^^^^^^^^^^ AIR302
-246 | ExternalTaskMarker()
-247 | ExternalTaskSensor()
+250 | ExternalTaskMarker()
+251 | ExternalTaskSensor()
     |
     = help: Use `airflow.sensors.external_task.ExternalDagLink` instead
 
-AIR302_names.py:246:1: AIR302 `airflow.sensors.external_task.ExternalTaskMarker` is removed in Airflow 3.0
+AIR302_names.py:250:1: AIR302 `airflow.sensors.external_task.ExternalTaskMarker` is removed in Airflow 3.0
     |
-244 | # airflow.sensors.external_task
-245 | ExternalTaskSensorLink()
-246 | ExternalTaskMarker()
+248 | # airflow.sensors.external_task
+249 | ExternalTaskSensorLink()
+250 | ExternalTaskMarker()
     | ^^^^^^^^^^^^^^^^^^ AIR302
-247 | ExternalTaskSensor()
+251 | ExternalTaskSensor()
     |
     = help: Use `airflow.sensors.external_task.ExternalTaskMarker` instead
 
-AIR302_names.py:247:1: AIR302 `airflow.sensors.external_task.ExternalTaskSensor` is removed in Airflow 3.0
+AIR302_names.py:251:1: AIR302 `airflow.sensors.external_task.ExternalTaskSensor` is removed in Airflow 3.0
     |
-245 | ExternalTaskSensorLink()
-246 | ExternalTaskMarker()
-247 | ExternalTaskSensor()
+249 | ExternalTaskSensorLink()
+250 | ExternalTaskMarker()
+251 | ExternalTaskSensor()
     | ^^^^^^^^^^^^^^^^^^ AIR302
-248 |
-249 | # airflow.sensors.external_task_sensor
+252 |
+253 | # airflow.sensors.external_task_sensor
     |
     = help: Use `airflow.sensors.external_task.ExternalTaskSensor` instead
 
-AIR302_names.py:250:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskMarker` is removed in Airflow 3.0
+AIR302_names.py:254:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskMarker` is removed in Airflow 3.0
     |
-249 | # airflow.sensors.external_task_sensor
-250 | ExternalTaskMarkerFromExternalTaskSensor()
+253 | # airflow.sensors.external_task_sensor
+254 | ExternalTaskMarkerFromExternalTaskSensor()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-251 | ExternalTaskSensorFromExternalTaskSensor()
-252 | ExternalTaskSensorLinkFromExternalTaskSensor()
+255 | ExternalTaskSensorFromExternalTaskSensor()
+256 | ExternalTaskSensorLinkFromExternalTaskSensor()
     |
     = help: Use `airflow.sensors.external_task.ExternalTaskMarker` instead
 
-AIR302_names.py:251:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensor` is removed in Airflow 3.0
+AIR302_names.py:255:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensor` is removed in Airflow 3.0
     |
-249 | # airflow.sensors.external_task_sensor
-250 | ExternalTaskMarkerFromExternalTaskSensor()
-251 | ExternalTaskSensorFromExternalTaskSensor()
+253 | # airflow.sensors.external_task_sensor
+254 | ExternalTaskMarkerFromExternalTaskSensor()
+255 | ExternalTaskSensorFromExternalTaskSensor()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-252 | ExternalTaskSensorLinkFromExternalTaskSensor()
+256 | ExternalTaskSensorLinkFromExternalTaskSensor()
     |
     = help: Use `airflow.sensors.external_task.ExternalTaskSensor` instead
 
-AIR302_names.py:252:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensorLink` is removed in Airflow 3.0
+AIR302_names.py:256:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensorLink` is removed in Airflow 3.0
     |
-250 | ExternalTaskMarkerFromExternalTaskSensor()
-251 | ExternalTaskSensorFromExternalTaskSensor()
-252 | ExternalTaskSensorLinkFromExternalTaskSensor()
+254 | ExternalTaskMarkerFromExternalTaskSensor()
+255 | ExternalTaskSensorFromExternalTaskSensor()
+256 | ExternalTaskSensorLinkFromExternalTaskSensor()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-253 |
-254 | # airflow.sensors.time_delta_sensor
+257 |
+258 | # airflow.sensors.time_delta_sensor
     |
     = help: Use `airflow.sensors.external_task.ExternalDagLink` instead
 
-AIR302_names.py:255:1: AIR302 `airflow.sensors.time_delta_sensor.TimeDeltaSensor` is removed in Airflow 3.0
+AIR302_names.py:259:1: AIR302 `airflow.sensors.time_delta_sensor.TimeDeltaSensor` is removed in Airflow 3.0
     |
-254 | # airflow.sensors.time_delta_sensor
-255 | TimeDeltaSensor()
+258 | # airflow.sensors.time_delta_sensor
+259 | TimeDeltaSensor()
     | ^^^^^^^^^^^^^^^ AIR302
-256 |
-257 | # airflow.timetables
+260 |
+261 | # airflow.timetables
     |
     = help: Use `airflow.sensors.time_delta.TimeDeltaSensor` instead
 
-AIR302_names.py:258:1: AIR302 `airflow.timetables.datasets.DatasetOrTimeSchedule` is removed in Airflow 3.0
+AIR302_names.py:262:1: AIR302 `airflow.timetables.datasets.DatasetOrTimeSchedule` is removed in Airflow 3.0
     |
-257 | # airflow.timetables
-258 | DatasetOrTimeSchedule()
+261 | # airflow.timetables
+262 | DatasetOrTimeSchedule()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-259 | DatasetTriggeredTimetable()
+263 | DatasetTriggeredTimetable()
     |
     = help: Use `airflow.timetables.assets.AssetOrTimeSchedule` instead
 
-AIR302_names.py:259:1: AIR302 `airflow.timetables.simple.DatasetTriggeredTimetable` is removed in Airflow 3.0
+AIR302_names.py:263:1: AIR302 `airflow.timetables.simple.DatasetTriggeredTimetable` is removed in Airflow 3.0
     |
-257 | # airflow.timetables
-258 | DatasetOrTimeSchedule()
-259 | DatasetTriggeredTimetable()
+261 | # airflow.timetables
+262 | DatasetOrTimeSchedule()
+263 | DatasetTriggeredTimetable()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-260 |
-261 | # airflow.triggers.external_task
+264 |
+265 | # airflow.triggers.external_task
     |
     = help: Use `airflow.timetables.simple.AssetTriggeredTimetable` instead
 
-AIR302_names.py:262:1: AIR302 `airflow.triggers.external_task.TaskStateTrigger` is removed in Airflow 3.0
+AIR302_names.py:266:1: AIR302 `airflow.triggers.external_task.TaskStateTrigger` is removed in Airflow 3.0
     |
-261 | # airflow.triggers.external_task
-262 | TaskStateTrigger()
+265 | # airflow.triggers.external_task
+266 | TaskStateTrigger()
     | ^^^^^^^^^^^^^^^^ AIR302
-263 |
-264 | # airflow.utils.date
+267 |
+268 | # airflow.utils.date
     |
 
-AIR302_names.py:265:7: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0
+AIR302_names.py:269:7: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0
     |
-264 | # airflow.utils.date
-265 | dates.date_range
+268 | # airflow.utils.date
+269 | dates.date_range
     |       ^^^^^^^^^^ AIR302
-266 | dates.days_ago
+270 | dates.days_ago
     |
 
-AIR302_names.py:266:7: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0
+AIR302_names.py:270:7: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0
     |
-264 | # airflow.utils.date
-265 | dates.date_range
-266 | dates.days_ago
+268 | # airflow.utils.date
+269 | dates.date_range
+270 | dates.days_ago
     |       ^^^^^^^^ AIR302
-267 |
-268 | date_range
+271 |
+272 | date_range
     |
     = help: Use `pendulum.today('UTC').add(days=-N, ...)` instead
 
-AIR302_names.py:268:1: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0
+AIR302_names.py:272:1: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0
     |
-266 | dates.days_ago
-267 |
-268 | date_range
+270 | dates.days_ago
+271 |
+272 | date_range
     | ^^^^^^^^^^ AIR302
-269 | days_ago
-270 | infer_time_unit
+273 | days_ago
+274 | infer_time_unit
     |
 
-AIR302_names.py:269:1: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0
+AIR302_names.py:273:1: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0
     |
-268 | date_range
-269 | days_ago
+272 | date_range
+273 | days_ago
     | ^^^^^^^^ AIR302
-270 | infer_time_unit
-271 | parse_execution_date
+274 | infer_time_unit
+275 | parse_execution_date
     |
     = help: Use `pendulum.today('UTC').add(days=-N, ...)` instead
 
-AIR302_names.py:270:1: AIR302 `airflow.utils.dates.infer_time_unit` is removed in Airflow 3.0
+AIR302_names.py:274:1: AIR302 `airflow.utils.dates.infer_time_unit` is removed in Airflow 3.0
     |
-268 | date_range
-269 | days_ago
-270 | infer_time_unit
+272 | date_range
+273 | days_ago
+274 | infer_time_unit
     | ^^^^^^^^^^^^^^^ AIR302
-271 | parse_execution_date
-272 | round_time
+275 | parse_execution_date
+276 | round_time
     |
 
-AIR302_names.py:271:1: AIR302 `airflow.utils.dates.parse_execution_date` is removed in Airflow 3.0
+AIR302_names.py:275:1: AIR302 `airflow.utils.dates.parse_execution_date` is removed in Airflow 3.0
     |
-269 | days_ago
-270 | infer_time_unit
-271 | parse_execution_date
+273 | days_ago
+274 | infer_time_unit
+275 | parse_execution_date
     | ^^^^^^^^^^^^^^^^^^^^ AIR302
-272 | round_time
-273 | scale_time_units
+276 | round_time
+277 | scale_time_units
     |
 
-AIR302_names.py:272:1: AIR302 `airflow.utils.dates.round_time` is removed in Airflow 3.0
+AIR302_names.py:276:1: AIR302 `airflow.utils.dates.round_time` is removed in Airflow 3.0
     |
-270 | infer_time_unit
-271 | parse_execution_date
-272 | round_time
+274 | infer_time_unit
+275 | parse_execution_date
+276 | round_time
     | ^^^^^^^^^^ AIR302
-273 | scale_time_units
+277 | scale_time_units
     |
 
-AIR302_names.py:273:1: AIR302 `airflow.utils.dates.scale_time_units` is removed in Airflow 3.0
+AIR302_names.py:277:1: AIR302 `airflow.utils.dates.scale_time_units` is removed in Airflow 3.0
     |
-271 | parse_execution_date
-272 | round_time
-273 | scale_time_units
+275 | parse_execution_date
+276 | round_time
+277 | scale_time_units
     | ^^^^^^^^^^^^^^^^ AIR302
-274 |
-275 | # This one was not deprecated.
+278 |
+279 | # This one was not deprecated.
     |
 
-AIR302_names.py:280:1: AIR302 `airflow.utils.dag_cycle_tester.test_cycle` is removed in Airflow 3.0
+AIR302_names.py:284:1: AIR302 `airflow.utils.dag_cycle_tester.test_cycle` is removed in Airflow 3.0
     |
-279 | # airflow.utils.dag_cycle_tester
-280 | test_cycle
+283 | # airflow.utils.dag_cycle_tester
+284 | test_cycle
     | ^^^^^^^^^^ AIR302
-281 |
-282 | # airflow.utils.dag_parsing_context
+285 |
+286 | # airflow.utils.dag_parsing_context
     |
 
-AIR302_names.py:283:1: AIR302 `airflow.utils.dag_parsing_context.get_parsing_context` is removed in Airflow 3.0
+AIR302_names.py:287:1: AIR302 `airflow.utils.dag_parsing_context.get_parsing_context` is removed in Airflow 3.0
     |
-282 | # airflow.utils.dag_parsing_context
-283 | get_parsing_context
+286 | # airflow.utils.dag_parsing_context
+287 | get_parsing_context
     | ^^^^^^^^^^^^^^^^^^^ AIR302
-284 |
-285 | # airflow.utils.decorators
+288 |
+289 | # airflow.utils.decorators
     |
     = help: Use `airflow.sdk.get_parsing_context` instead
 
-AIR302_names.py:286:1: AIR302 `airflow.utils.decorators.apply_defaults` is removed in Airflow 3.0; `apply_defaults` is now unconditionally done and can be safely removed.
+AIR302_names.py:290:1: AIR302 `airflow.utils.decorators.apply_defaults` is removed in Airflow 3.0; `apply_defaults` is now unconditionally done and can be safely removed.
     |
-285 | # airflow.utils.decorators
-286 | apply_defaults
+289 | # airflow.utils.decorators
+290 | apply_defaults
     | ^^^^^^^^^^^^^^ AIR302
-287 |
-288 | # airflow.utils.file
-    |
-
-AIR302_names.py:289:1: AIR302 `airflow.utils.file.TemporaryDirectory` is removed in Airflow 3.0
-    |
-288 | # airflow.utils.file
-289 | TemporaryDirectory()
-    | ^^^^^^^^^^^^^^^^^^ AIR302
-290 | mkdirs
-    |
-
-AIR302_names.py:290:1: AIR302 `airflow.utils.file.mkdirs` is removed in Airflow 3.0
-    |
-288 | # airflow.utils.file
-289 | TemporaryDirectory()
-290 | mkdirs
-    | ^^^^^^ AIR302
 291 |
-292 | #  airflow.utils.helpers
+292 | # airflow.utils.file
+    |
+
+AIR302_names.py:293:1: AIR302 `airflow.utils.file.TemporaryDirectory` is removed in Airflow 3.0
+    |
+292 | # airflow.utils.file
+293 | TemporaryDirectory()
+    | ^^^^^^^^^^^^^^^^^^ AIR302
+294 | mkdirs
+    |
+
+AIR302_names.py:294:1: AIR302 `airflow.utils.file.mkdirs` is removed in Airflow 3.0
+    |
+292 | # airflow.utils.file
+293 | TemporaryDirectory()
+294 | mkdirs
+    | ^^^^^^ AIR302
+295 |
+296 | #  airflow.utils.helpers
     |
     = help: Use `pendulum.today('UTC').add(days=-N, ...)` instead
 
-AIR302_names.py:293:1: AIR302 `airflow.utils.helpers.chain` is removed in Airflow 3.0
+AIR302_names.py:297:1: AIR302 `airflow.utils.helpers.chain` is removed in Airflow 3.0
     |
-292 | #  airflow.utils.helpers
-293 | helper_chain
+296 | #  airflow.utils.helpers
+297 | helper_chain
     | ^^^^^^^^^^^^ AIR302
-294 | helper_cross_downstream
+298 | helper_cross_downstream
     |
     = help: Use `airflow.sdk.chain` instead
 
-AIR302_names.py:294:1: AIR302 `airflow.utils.helpers.cross_downstream` is removed in Airflow 3.0
+AIR302_names.py:298:1: AIR302 `airflow.utils.helpers.cross_downstream` is removed in Airflow 3.0
     |
-292 | #  airflow.utils.helpers
-293 | helper_chain
-294 | helper_cross_downstream
+296 | #  airflow.utils.helpers
+297 | helper_chain
+298 | helper_cross_downstream
     | ^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-295 |
-296 | # airflow.utils.state
+299 |
+300 | # airflow.utils.state
     |
     = help: Use `airflow.sdk.cross_downstream` instead
 
-AIR302_names.py:297:1: AIR302 `airflow.utils.state.SHUTDOWN` is removed in Airflow 3.0
+AIR302_names.py:301:1: AIR302 `airflow.utils.state.SHUTDOWN` is removed in Airflow 3.0
     |
-296 | # airflow.utils.state
-297 | SHUTDOWN
+300 | # airflow.utils.state
+301 | SHUTDOWN
     | ^^^^^^^^ AIR302
-298 | terminating_states
+302 | terminating_states
     |
 
-AIR302_names.py:298:1: AIR302 `airflow.utils.state.terminating_states` is removed in Airflow 3.0
+AIR302_names.py:302:1: AIR302 `airflow.utils.state.terminating_states` is removed in Airflow 3.0
     |
-296 | # airflow.utils.state
-297 | SHUTDOWN
-298 | terminating_states
+300 | # airflow.utils.state
+301 | SHUTDOWN
+302 | terminating_states
     | ^^^^^^^^^^^^^^^^^^ AIR302
-299 |
-300 | #  airflow.utils.trigger_rule
-    |
-
-AIR302_names.py:301:13: AIR302 `airflow.utils.trigger_rule.TriggerRule.DUMMY` is removed in Airflow 3.0
-    |
-300 | #  airflow.utils.trigger_rule
-301 | TriggerRule.DUMMY
-    |             ^^^^^ AIR302
-302 | TriggerRule.NONE_FAILED_OR_SKIPPED
-    |
-
-AIR302_names.py:302:13: AIR302 `airflow.utils.trigger_rule.TriggerRule.NONE_FAILED_OR_SKIPPED` is removed in Airflow 3.0
-    |
-300 | #  airflow.utils.trigger_rule
-301 | TriggerRule.DUMMY
-302 | TriggerRule.NONE_FAILED_OR_SKIPPED
-    |             ^^^^^^^^^^^^^^^^^^^^^^ AIR302
 303 |
-304 | # airflow.www.auth
+304 | #  airflow.utils.trigger_rule
     |
 
-AIR302_names.py:305:1: AIR302 `airflow.www.auth.has_access` is removed in Airflow 3.0
+AIR302_names.py:305:13: AIR302 `airflow.utils.trigger_rule.TriggerRule.DUMMY` is removed in Airflow 3.0
     |
-304 | # airflow.www.auth
-305 | has_access
+304 | #  airflow.utils.trigger_rule
+305 | TriggerRule.DUMMY
+    |             ^^^^^ AIR302
+306 | TriggerRule.NONE_FAILED_OR_SKIPPED
+    |
+
+AIR302_names.py:306:13: AIR302 `airflow.utils.trigger_rule.TriggerRule.NONE_FAILED_OR_SKIPPED` is removed in Airflow 3.0
+    |
+304 | #  airflow.utils.trigger_rule
+305 | TriggerRule.DUMMY
+306 | TriggerRule.NONE_FAILED_OR_SKIPPED
+    |             ^^^^^^^^^^^^^^^^^^^^^^ AIR302
+307 |
+308 | # airflow.www.auth
+    |
+
+AIR302_names.py:309:1: AIR302 `airflow.www.auth.has_access` is removed in Airflow 3.0
+    |
+308 | # airflow.www.auth
+309 | has_access
     | ^^^^^^^^^^ AIR302
-306 | has_access_dataset
+310 | has_access_dataset
     |
     = help: Use `airflow.www.auth.has_access_*` instead
 
-AIR302_names.py:306:1: AIR302 `airflow.www.auth.has_access_dataset` is removed in Airflow 3.0
+AIR302_names.py:310:1: AIR302 `airflow.www.auth.has_access_dataset` is removed in Airflow 3.0
     |
-304 | # airflow.www.auth
-305 | has_access
-306 | has_access_dataset
+308 | # airflow.www.auth
+309 | has_access
+310 | has_access_dataset
     | ^^^^^^^^^^^^^^^^^^ AIR302
-307 |
-308 | # airflow.www.utils
+311 |
+312 | # airflow.www.utils
     |
     = help: Use `airflow.www.auth.has_access_dataset.has_access_asset` instead
 
-AIR302_names.py:309:1: AIR302 `airflow.www.utils.get_sensitive_variables_fields` is removed in Airflow 3.0
+AIR302_names.py:313:1: AIR302 `airflow.www.utils.get_sensitive_variables_fields` is removed in Airflow 3.0
     |
-308 | # airflow.www.utils
-309 | get_sensitive_variables_fields
+312 | # airflow.www.utils
+313 | get_sensitive_variables_fields
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-310 | should_hide_value_for_key
+314 | should_hide_value_for_key
     |
     = help: Use `airflow.utils.log.secrets_masker.get_sensitive_variables_fields` instead
 
-AIR302_names.py:310:1: AIR302 `airflow.www.utils.should_hide_value_for_key` is removed in Airflow 3.0
+AIR302_names.py:314:1: AIR302 `airflow.www.utils.should_hide_value_for_key` is removed in Airflow 3.0
     |
-308 | # airflow.www.utils
-309 | get_sensitive_variables_fields
-310 | should_hide_value_for_key
+312 | # airflow.www.utils
+313 | get_sensitive_variables_fields
+314 | should_hide_value_for_key
     | ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
     |
     = help: Use `airflow.utils.log.secrets_masker.should_hide_value_for_key` instead

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
@@ -2,1078 +2,1087 @@
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 snapshot_kind: text
 ---
-AIR302_names.py:120:1: AIR302 `airflow.PY36` is removed in Airflow 3.0
+AIR302_names.py:121:1: AIR302 `airflow.PY36` is removed in Airflow 3.0
     |
-119 | # airflow root
-120 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+120 | # airflow root
+121 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
     | ^^^^ AIR302
-121 | DatasetFromRoot()
+122 | DatasetFromRoot()
     |
     = help: Use `sys.version_info` instead
 
-AIR302_names.py:120:7: AIR302 `airflow.PY37` is removed in Airflow 3.0
+AIR302_names.py:121:7: AIR302 `airflow.PY37` is removed in Airflow 3.0
     |
-119 | # airflow root
-120 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+120 | # airflow root
+121 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
     |       ^^^^ AIR302
-121 | DatasetFromRoot()
+122 | DatasetFromRoot()
     |
     = help: Use `sys.version_info` instead
 
-AIR302_names.py:120:13: AIR302 `airflow.PY38` is removed in Airflow 3.0
+AIR302_names.py:121:13: AIR302 `airflow.PY38` is removed in Airflow 3.0
     |
-119 | # airflow root
-120 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+120 | # airflow root
+121 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
     |             ^^^^ AIR302
-121 | DatasetFromRoot()
+122 | DatasetFromRoot()
     |
     = help: Use `sys.version_info` instead
 
-AIR302_names.py:120:19: AIR302 `airflow.PY39` is removed in Airflow 3.0
+AIR302_names.py:121:19: AIR302 `airflow.PY39` is removed in Airflow 3.0
     |
-119 | # airflow root
-120 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+120 | # airflow root
+121 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
     |                   ^^^^ AIR302
-121 | DatasetFromRoot()
+122 | DatasetFromRoot()
     |
     = help: Use `sys.version_info` instead
 
-AIR302_names.py:120:25: AIR302 `airflow.PY310` is removed in Airflow 3.0
+AIR302_names.py:121:25: AIR302 `airflow.PY310` is removed in Airflow 3.0
     |
-119 | # airflow root
-120 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+120 | # airflow root
+121 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
     |                         ^^^^^ AIR302
-121 | DatasetFromRoot()
+122 | DatasetFromRoot()
     |
     = help: Use `sys.version_info` instead
 
-AIR302_names.py:120:32: AIR302 `airflow.PY311` is removed in Airflow 3.0
+AIR302_names.py:121:32: AIR302 `airflow.PY311` is removed in Airflow 3.0
     |
-119 | # airflow root
-120 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+120 | # airflow root
+121 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
     |                                ^^^^^ AIR302
-121 | DatasetFromRoot()
+122 | DatasetFromRoot()
     |
     = help: Use `sys.version_info` instead
 
-AIR302_names.py:120:39: AIR302 `airflow.PY312` is removed in Airflow 3.0
+AIR302_names.py:121:39: AIR302 `airflow.PY312` is removed in Airflow 3.0
     |
-119 | # airflow root
-120 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+120 | # airflow root
+121 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
     |                                       ^^^^^ AIR302
-121 | DatasetFromRoot()
+122 | DatasetFromRoot()
     |
     = help: Use `sys.version_info` instead
 
-AIR302_names.py:121:1: AIR302 `airflow.Dataset` is removed in Airflow 3.0
+AIR302_names.py:122:1: AIR302 `airflow.Dataset` is removed in Airflow 3.0
     |
-119 | # airflow root
-120 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
-121 | DatasetFromRoot()
+120 | # airflow root
+121 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+122 | DatasetFromRoot()
     | ^^^^^^^^^^^^^^^ AIR302
-122 |
-123 | # airflow.api_connexion.security
+123 |
+124 | # airflow.api_connexion.security
     |
     = help: Use `airflow.sdk.Asset` instead
 
-AIR302_names.py:124:1: AIR302 `airflow.api_connexion.security.requires_access` is removed in Airflow 3.0
+AIR302_names.py:125:1: AIR302 `airflow.api_connexion.security.requires_access` is removed in Airflow 3.0
     |
-123 | # airflow.api_connexion.security
-124 | requires_access, requires_access_dataset
+124 | # airflow.api_connexion.security
+125 | requires_access, requires_access_dataset
     | ^^^^^^^^^^^^^^^ AIR302
-125 |
-126 | # airflow.auth.managers
+126 |
+127 | # airflow.auth.managers
     |
     = help: Use `airflow.api_connexion.security.requires_access_*` instead
 
-AIR302_names.py:124:18: AIR302 `airflow.api_connexion.security.requires_access_dataset` is removed in Airflow 3.0
+AIR302_names.py:125:18: AIR302 `airflow.api_connexion.security.requires_access_dataset` is removed in Airflow 3.0
     |
-123 | # airflow.api_connexion.security
-124 | requires_access, requires_access_dataset
+124 | # airflow.api_connexion.security
+125 | requires_access, requires_access_dataset
     |                  ^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-125 |
-126 | # airflow.auth.managers
+126 |
+127 | # airflow.auth.managers
     |
     = help: Use `airflow.api_connexion.security.requires_access_asset` instead
 
-AIR302_names.py:127:1: AIR302 `airflow.auth.managers.base_auth_manager.is_authorized_dataset` is removed in Airflow 3.0
+AIR302_names.py:128:1: AIR302 `airflow.auth.managers.base_auth_manager.is_authorized_dataset` is removed in Airflow 3.0
     |
-126 | # airflow.auth.managers
-127 | is_authorized_dataset
+127 | # airflow.auth.managers
+128 | is_authorized_dataset
     | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-128 | DatasetDetails()
+129 | DatasetDetails()
     |
     = help: Use `airflow.api_fastapi.auth.managers.base_auth_manager.is_authorized_asset` instead
 
-AIR302_names.py:128:1: AIR302 `airflow.auth.managers.models.resource_details.DatasetDetails` is removed in Airflow 3.0
+AIR302_names.py:129:1: AIR302 `airflow.auth.managers.models.resource_details.DatasetDetails` is removed in Airflow 3.0
     |
-126 | # airflow.auth.managers
-127 | is_authorized_dataset
-128 | DatasetDetails()
+127 | # airflow.auth.managers
+128 | is_authorized_dataset
+129 | DatasetDetails()
     | ^^^^^^^^^^^^^^ AIR302
-129 |
-130 | # airflow.configuration
+130 |
+131 | # airflow.configuration
     |
     = help: Use `airflow.api_fastapi.auth.managers.models.resource_details.AssetDetails` instead
 
-AIR302_names.py:131:1: AIR302 `airflow.configuration.get` is removed in Airflow 3.0
+AIR302_names.py:132:1: AIR302 `airflow.configuration.get` is removed in Airflow 3.0
     |
-130 | # airflow.configuration
-131 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+131 | # airflow.configuration
+132 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     | ^^^ AIR302
     |
     = help: Use `airflow.configuration.conf.get` instead
 
-AIR302_names.py:131:6: AIR302 `airflow.configuration.getboolean` is removed in Airflow 3.0
+AIR302_names.py:132:6: AIR302 `airflow.configuration.getboolean` is removed in Airflow 3.0
     |
-130 | # airflow.configuration
-131 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+131 | # airflow.configuration
+132 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     |      ^^^^^^^^^^ AIR302
     |
     = help: Use `airflow.configuration.conf.getboolean` instead
 
-AIR302_names.py:131:18: AIR302 `airflow.configuration.getfloat` is removed in Airflow 3.0
+AIR302_names.py:132:18: AIR302 `airflow.configuration.getfloat` is removed in Airflow 3.0
     |
-130 | # airflow.configuration
-131 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+131 | # airflow.configuration
+132 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     |                  ^^^^^^^^ AIR302
     |
     = help: Use `airflow.configuration.conf.getfloat` instead
 
-AIR302_names.py:131:28: AIR302 `airflow.configuration.getint` is removed in Airflow 3.0
+AIR302_names.py:132:28: AIR302 `airflow.configuration.getint` is removed in Airflow 3.0
     |
-130 | # airflow.configuration
-131 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+131 | # airflow.configuration
+132 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     |                            ^^^^^^ AIR302
     |
     = help: Use `airflow.configuration.conf.getint` instead
 
-AIR302_names.py:131:36: AIR302 `airflow.configuration.has_option` is removed in Airflow 3.0
+AIR302_names.py:132:36: AIR302 `airflow.configuration.has_option` is removed in Airflow 3.0
     |
-130 | # airflow.configuration
-131 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+131 | # airflow.configuration
+132 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     |                                    ^^^^^^^^^^ AIR302
     |
     = help: Use `airflow.configuration.conf.has_option` instead
 
-AIR302_names.py:131:48: AIR302 `airflow.configuration.remove_option` is removed in Airflow 3.0
+AIR302_names.py:132:48: AIR302 `airflow.configuration.remove_option` is removed in Airflow 3.0
     |
-130 | # airflow.configuration
-131 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+131 | # airflow.configuration
+132 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     |                                                ^^^^^^^^^^^^^ AIR302
     |
     = help: Use `airflow.configuration.conf.remove_option` instead
 
-AIR302_names.py:131:63: AIR302 `airflow.configuration.as_dict` is removed in Airflow 3.0
+AIR302_names.py:132:63: AIR302 `airflow.configuration.as_dict` is removed in Airflow 3.0
     |
-130 | # airflow.configuration
-131 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+131 | # airflow.configuration
+132 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     |                                                               ^^^^^^^ AIR302
     |
     = help: Use `airflow.configuration.conf.as_dict` instead
 
-AIR302_names.py:131:72: AIR302 `airflow.configuration.set` is removed in Airflow 3.0
+AIR302_names.py:132:72: AIR302 `airflow.configuration.set` is removed in Airflow 3.0
     |
-130 | # airflow.configuration
-131 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+131 | # airflow.configuration
+132 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     |                                                                        ^^^ AIR302
     |
     = help: Use `airflow.configuration.conf.set` instead
 
-AIR302_names.py:135:1: AIR302 `airflow.contrib.aws_athena_hook.AWSAthenaHook` is removed in Airflow 3.0; The whole `airflow.contrib` module has been removed.
+AIR302_names.py:136:1: AIR302 `airflow.contrib.aws_athena_hook.AWSAthenaHook` is removed in Airflow 3.0; The whole `airflow.contrib` module has been removed.
     |
-134 | # airflow.contrib.*
-135 | AWSAthenaHook()
+135 | # airflow.contrib.*
+136 | AWSAthenaHook()
     | ^^^^^^^^^^^^^ AIR302
-136 |
-137 | # airflow.datasets
+137 |
+138 | # airflow.datasets
     |
 
-AIR302_names.py:138:1: AIR302 `airflow.datasets.Dataset` is removed in Airflow 3.0
+AIR302_names.py:139:1: AIR302 `airflow.datasets.Dataset` is removed in Airflow 3.0
     |
-137 | # airflow.datasets
-138 | Dataset()
+138 | # airflow.datasets
+139 | Dataset()
     | ^^^^^^^ AIR302
-139 | DatasetAlias()
-140 | DatasetAliasEvent()
+140 | DatasetAlias()
+141 | DatasetAliasEvent()
     |
     = help: Use `airflow.sdk.Asset` instead
 
-AIR302_names.py:139:1: AIR302 `airflow.datasets.DatasetAlias` is removed in Airflow 3.0
+AIR302_names.py:140:1: AIR302 `airflow.datasets.DatasetAlias` is removed in Airflow 3.0
     |
-137 | # airflow.datasets
-138 | Dataset()
-139 | DatasetAlias()
+138 | # airflow.datasets
+139 | Dataset()
+140 | DatasetAlias()
     | ^^^^^^^^^^^^ AIR302
-140 | DatasetAliasEvent()
-141 | DatasetAll()
+141 | DatasetAliasEvent()
+142 | DatasetAll()
     |
     = help: Use `airflow.sdk.AssetAlias` instead
 
-AIR302_names.py:140:1: AIR302 `airflow.datasets.DatasetAliasEvent` is removed in Airflow 3.0
+AIR302_names.py:141:1: AIR302 `airflow.datasets.DatasetAliasEvent` is removed in Airflow 3.0
     |
-138 | Dataset()
-139 | DatasetAlias()
-140 | DatasetAliasEvent()
+139 | Dataset()
+140 | DatasetAlias()
+141 | DatasetAliasEvent()
     | ^^^^^^^^^^^^^^^^^ AIR302
-141 | DatasetAll()
-142 | DatasetAny()
+142 | DatasetAll()
+143 | DatasetAny()
     |
 
-AIR302_names.py:141:1: AIR302 `airflow.datasets.DatasetAll` is removed in Airflow 3.0
+AIR302_names.py:142:1: AIR302 `airflow.datasets.DatasetAll` is removed in Airflow 3.0
     |
-139 | DatasetAlias()
-140 | DatasetAliasEvent()
-141 | DatasetAll()
+140 | DatasetAlias()
+141 | DatasetAliasEvent()
+142 | DatasetAll()
     | ^^^^^^^^^^ AIR302
-142 | DatasetAny()
-143 | Metadata()
+143 | DatasetAny()
+144 | Metadata()
     |
     = help: Use `airflow.sdk.AssetAll` instead
 
-AIR302_names.py:142:1: AIR302 `airflow.datasets.DatasetAny` is removed in Airflow 3.0
+AIR302_names.py:143:1: AIR302 `airflow.datasets.DatasetAny` is removed in Airflow 3.0
     |
-140 | DatasetAliasEvent()
-141 | DatasetAll()
-142 | DatasetAny()
+141 | DatasetAliasEvent()
+142 | DatasetAll()
+143 | DatasetAny()
     | ^^^^^^^^^^ AIR302
-143 | Metadata()
-144 | expand_alias_to_datasets
+144 | Metadata()
+145 | expand_alias_to_datasets
     |
     = help: Use `airflow.sdk.AssetAny` instead
 
-AIR302_names.py:143:1: AIR302 `airflow.datasets.metadata.Metadata` is removed in Airflow 3.0
+AIR302_names.py:144:1: AIR302 `airflow.datasets.metadata.Metadata` is removed in Airflow 3.0
     |
-141 | DatasetAll()
-142 | DatasetAny()
-143 | Metadata()
+142 | DatasetAll()
+143 | DatasetAny()
+144 | Metadata()
     | ^^^^^^^^ AIR302
-144 | expand_alias_to_datasets
+145 | expand_alias_to_datasets
     |
     = help: Use `airflow.sdk.Metadata` instead
 
-AIR302_names.py:144:1: AIR302 `airflow.datasets.expand_alias_to_datasets` is removed in Airflow 3.0
+AIR302_names.py:145:1: AIR302 `airflow.datasets.expand_alias_to_datasets` is removed in Airflow 3.0
     |
-142 | DatasetAny()
-143 | Metadata()
-144 | expand_alias_to_datasets
+143 | DatasetAny()
+144 | Metadata()
+145 | expand_alias_to_datasets
     | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-145 |
-146 | # airflow.datasets.manager
+146 |
+147 | # airflow.datasets.manager
     |
     = help: Use `airflow.sdk.expand_alias_to_assets` instead
 
-AIR302_names.py:147:1: AIR302 `airflow.datasets.manager.DatasetManager` is removed in Airflow 3.0
+AIR302_names.py:148:1: AIR302 `airflow.datasets.manager.DatasetManager` is removed in Airflow 3.0
     |
-146 | # airflow.datasets.manager
-147 | DatasetManager()
+147 | # airflow.datasets.manager
+148 | DatasetManager()
     | ^^^^^^^^^^^^^^ AIR302
-148 | dataset_manager
-149 | resolve_dataset_manager
+149 | dataset_manager
+150 | resolve_dataset_manager
     |
     = help: Use `airflow.assets.AssetManager` instead
 
-AIR302_names.py:148:1: AIR302 `airflow.datasets.manager.dataset_manager` is removed in Airflow 3.0
+AIR302_names.py:149:1: AIR302 `airflow.datasets.manager.dataset_manager` is removed in Airflow 3.0
     |
-146 | # airflow.datasets.manager
-147 | DatasetManager()
-148 | dataset_manager
+147 | # airflow.datasets.manager
+148 | DatasetManager()
+149 | dataset_manager
     | ^^^^^^^^^^^^^^^ AIR302
-149 | resolve_dataset_manager
+150 | resolve_dataset_manager
     |
     = help: Use `airflow.assets.manager.asset_manager` instead
 
-AIR302_names.py:149:1: AIR302 `airflow.datasets.manager.resolve_dataset_manager` is removed in Airflow 3.0
+AIR302_names.py:150:1: AIR302 `airflow.datasets.manager.resolve_dataset_manager` is removed in Airflow 3.0
     |
-147 | DatasetManager()
-148 | dataset_manager
-149 | resolve_dataset_manager
+148 | DatasetManager()
+149 | dataset_manager
+150 | resolve_dataset_manager
     | ^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-150 |
-151 | # airflow.hooks
+151 |
+152 | # airflow.hooks
     |
     = help: Use `airflow.assets.resolve_asset_manager` instead
 
-AIR302_names.py:152:1: AIR302 `airflow.hooks.base_hook.BaseHook` is removed in Airflow 3.0
+AIR302_names.py:153:1: AIR302 `airflow.hooks.base_hook.BaseHook` is removed in Airflow 3.0
     |
-151 | # airflow.hooks
-152 | BaseHook()
+152 | # airflow.hooks
+153 | BaseHook()
     | ^^^^^^^^ AIR302
-153 |
-154 | # airflow.lineage.hook
+154 |
+155 | # airflow.lineage.hook
     |
     = help: Use `airflow.hooks.base.BaseHook` instead
 
-AIR302_names.py:155:1: AIR302 `airflow.lineage.hook.DatasetLineageInfo` is removed in Airflow 3.0
+AIR302_names.py:156:1: AIR302 `airflow.lineage.hook.DatasetLineageInfo` is removed in Airflow 3.0
     |
-154 | # airflow.lineage.hook
-155 | DatasetLineageInfo()
+155 | # airflow.lineage.hook
+156 | DatasetLineageInfo()
     | ^^^^^^^^^^^^^^^^^^ AIR302
-156 |
-157 | # airflow.listeners.spec.dataset
+157 |
+158 | # airflow.listeners.spec.dataset
     |
     = help: Use `airflow.lineage.hook.AssetLineageInfo` instead
 
-AIR302_names.py:158:1: AIR302 `airflow.listeners.spec.dataset.on_dataset_changed` is removed in Airflow 3.0
+AIR302_names.py:159:1: AIR302 `airflow.listeners.spec.dataset.on_dataset_changed` is removed in Airflow 3.0
     |
-157 | # airflow.listeners.spec.dataset
-158 | on_dataset_changed
+158 | # airflow.listeners.spec.dataset
+159 | on_dataset_changed
     | ^^^^^^^^^^^^^^^^^^ AIR302
-159 | on_dataset_created
+160 | on_dataset_created
     |
     = help: Use `airflow.listeners.spec.asset.on_asset_changed` instead
 
-AIR302_names.py:159:1: AIR302 `airflow.listeners.spec.dataset.on_dataset_created` is removed in Airflow 3.0
+AIR302_names.py:160:1: AIR302 `airflow.listeners.spec.dataset.on_dataset_created` is removed in Airflow 3.0
     |
-157 | # airflow.listeners.spec.dataset
-158 | on_dataset_changed
-159 | on_dataset_created
+158 | # airflow.listeners.spec.dataset
+159 | on_dataset_changed
+160 | on_dataset_created
     | ^^^^^^^^^^^^^^^^^^ AIR302
-160 |
-161 | # airflow.metrics.validators
+161 |
+162 | # airflow.metrics.validators
     |
     = help: Use `airflow.listeners.spec.asset.on_asset_created` instead
 
-AIR302_names.py:162:1: AIR302 `airflow.metrics.validators.AllowListValidator` is removed in Airflow 3.0
+AIR302_names.py:163:1: AIR302 `airflow.metrics.validators.AllowListValidator` is removed in Airflow 3.0
     |
-161 | # airflow.metrics.validators
-162 | AllowListValidator()
+162 | # airflow.metrics.validators
+163 | AllowListValidator()
     | ^^^^^^^^^^^^^^^^^^ AIR302
-163 | BlockListValidator()
+164 | BlockListValidator()
     |
     = help: Use `airflow.metrics.validators.PatternAllowListValidator` instead
 
-AIR302_names.py:163:1: AIR302 `airflow.metrics.validators.BlockListValidator` is removed in Airflow 3.0
+AIR302_names.py:164:1: AIR302 `airflow.metrics.validators.BlockListValidator` is removed in Airflow 3.0
     |
-161 | # airflow.metrics.validators
-162 | AllowListValidator()
-163 | BlockListValidator()
+162 | # airflow.metrics.validators
+163 | AllowListValidator()
+164 | BlockListValidator()
     | ^^^^^^^^^^^^^^^^^^ AIR302
     |
     = help: Use `airflow.metrics.validators.PatternBlockListValidator` instead
 
-AIR302_names.py:167:1: AIR302 `airflow.models.baseoperator.chain` is removed in Airflow 3.0
+AIR302_names.py:168:1: AIR302 `airflow.models.baseoperator.chain` is removed in Airflow 3.0
     |
-166 | # airflow.models.baseoperator
-167 | chain, chain_linear, cross_downstream
+167 | # airflow.models.baseoperator
+168 | chain, chain_linear, cross_downstream
     | ^^^^^ AIR302
-168 |
-169 | # airflow.models.baseoperatorlink
+169 |
+170 | # airflow.models.baseoperatorlink
     |
     = help: Use `airflow.sdk.chain` instead
 
-AIR302_names.py:167:8: AIR302 `airflow.models.baseoperator.chain_linear` is removed in Airflow 3.0
+AIR302_names.py:168:8: AIR302 `airflow.models.baseoperator.chain_linear` is removed in Airflow 3.0
     |
-166 | # airflow.models.baseoperator
-167 | chain, chain_linear, cross_downstream
+167 | # airflow.models.baseoperator
+168 | chain, chain_linear, cross_downstream
     |        ^^^^^^^^^^^^ AIR302
-168 |
-169 | # airflow.models.baseoperatorlink
+169 |
+170 | # airflow.models.baseoperatorlink
     |
     = help: Use `airflow.sdk.chain_linear` instead
 
-AIR302_names.py:167:22: AIR302 `airflow.models.baseoperator.cross_downstream` is removed in Airflow 3.0
+AIR302_names.py:168:22: AIR302 `airflow.models.baseoperator.cross_downstream` is removed in Airflow 3.0
     |
-166 | # airflow.models.baseoperator
-167 | chain, chain_linear, cross_downstream
+167 | # airflow.models.baseoperator
+168 | chain, chain_linear, cross_downstream
     |                      ^^^^^^^^^^^^^^^^ AIR302
-168 |
-169 | # airflow.models.baseoperatorlink
+169 |
+170 | # airflow.models.baseoperatorlink
     |
     = help: Use `airflow.sdk.cross_downstream` instead
 
-AIR302_names.py:170:1: AIR302 `airflow.models.baseoperatorlink.BaseOperatorLink` is removed in Airflow 3.0
+AIR302_names.py:171:1: AIR302 `airflow.models.baseoperatorlink.BaseOperatorLink` is removed in Airflow 3.0
     |
-169 | # airflow.models.baseoperatorlink
-170 | BaseOperatorLink()
+170 | # airflow.models.baseoperatorlink
+171 | BaseOperatorLink()
     | ^^^^^^^^^^^^^^^^ AIR302
-171 |
-172 | # ariflow.notifications.basenotifier
+172 |
+173 | # ariflow.notifications.basenotifier
     |
     = help: Use `airflow.sdk.definitions.baseoperatorlink.BaseOperatorLink` instead
 
-AIR302_names.py:173:1: AIR302 `airflow.notifications.basenotifier.BaseNotifier` is removed in Airflow 3.0
+AIR302_names.py:174:1: AIR302 `airflow.notifications.basenotifier.BaseNotifier` is removed in Airflow 3.0
     |
-172 | # ariflow.notifications.basenotifier
-173 | BaseNotifier()
+173 | # ariflow.notifications.basenotifier
+174 | BaseNotifier()
     | ^^^^^^^^^^^^ AIR302
-174 |
-175 | # airflow.operators.dummy
+175 |
+176 | # airflow.operators.dummy
     |
     = help: Use `airflow.sdk.BaseNotifier` instead
 
-AIR302_names.py:176:1: AIR302 `airflow.operators.dummy.EmptyOperator` is removed in Airflow 3.0
+AIR302_names.py:177:1: AIR302 `airflow.operators.dummy.EmptyOperator` is removed in Airflow 3.0
     |
-175 | # airflow.operators.dummy
-176 | EmptyOperator()
+176 | # airflow.operators.dummy
+177 | EmptyOperator()
     | ^^^^^^^^^^^^^ AIR302
-177 | DummyOperator()
+178 | DummyOperator()
     |
     = help: Use `airflow.operators.empty.EmptyOperator` instead
 
-AIR302_names.py:177:1: AIR302 `airflow.operators.dummy.DummyOperator` is removed in Airflow 3.0
+AIR302_names.py:178:1: AIR302 `airflow.operators.dummy.DummyOperator` is removed in Airflow 3.0
     |
-175 | # airflow.operators.dummy
-176 | EmptyOperator()
-177 | DummyOperator()
+176 | # airflow.operators.dummy
+177 | EmptyOperator()
+178 | DummyOperator()
     | ^^^^^^^^^^^^^ AIR302
-178 |
-179 | # airflow.operators.dummy_operator
+179 |
+180 | # airflow.operators.dummy_operator
     |
     = help: Use `airflow.operators.empty.EmptyOperator` instead
 
-AIR302_names.py:180:16: AIR302 `airflow.operators.dummy_operator.EmptyOperator` is removed in Airflow 3.0
+AIR302_names.py:181:16: AIR302 `airflow.operators.dummy_operator.EmptyOperator` is removed in Airflow 3.0
     |
-179 | # airflow.operators.dummy_operator
-180 | dummy_operator.EmptyOperator()
+180 | # airflow.operators.dummy_operator
+181 | dummy_operator.EmptyOperator()
     |                ^^^^^^^^^^^^^ AIR302
-181 | dummy_operator.DummyOperator()
+182 | dummy_operator.DummyOperator()
     |
     = help: Use `airflow.operators.empty.EmptyOperator` instead
 
-AIR302_names.py:181:16: AIR302 `airflow.operators.dummy_operator.DummyOperator` is removed in Airflow 3.0
+AIR302_names.py:182:16: AIR302 `airflow.operators.dummy_operator.DummyOperator` is removed in Airflow 3.0
     |
-179 | # airflow.operators.dummy_operator
-180 | dummy_operator.EmptyOperator()
-181 | dummy_operator.DummyOperator()
+180 | # airflow.operators.dummy_operator
+181 | dummy_operator.EmptyOperator()
+182 | dummy_operator.DummyOperator()
     |                ^^^^^^^^^^^^^ AIR302
-182 |
-183 | # airflow.operators.branch_operator
+183 |
+184 | # airflow.operators.branch_operator
     |
     = help: Use `airflow.operators.empty.EmptyOperator` instead
 
-AIR302_names.py:184:1: AIR302 `airflow.operators.branch_operator.BaseBranchOperator` is removed in Airflow 3.0
+AIR302_names.py:185:1: AIR302 `airflow.operators.branch_operator.BaseBranchOperator` is removed in Airflow 3.0
     |
-183 | # airflow.operators.branch_operator
-184 | BaseBranchOperator()
+184 | # airflow.operators.branch_operator
+185 | BaseBranchOperator()
     | ^^^^^^^^^^^^^^^^^^ AIR302
-185 |
-186 | # airflow.operators.dagrun_operator
+186 |
+187 | # airflow.operators.dagrun_operator
     |
     = help: Use `airflow.operators.branch.BaseBranchOperator` instead
 
-AIR302_names.py:187:1: AIR302 `airflow.operators.dagrun_operator.TriggerDagRunLink` is removed in Airflow 3.0
+AIR302_names.py:188:1: AIR302 `airflow.operators.dagrun_operator.TriggerDagRunLink` is removed in Airflow 3.0
     |
-186 | # airflow.operators.dagrun_operator
-187 | TriggerDagRunLink()
+187 | # airflow.operators.dagrun_operator
+188 | TriggerDagRunLink()
     | ^^^^^^^^^^^^^^^^^ AIR302
-188 | TriggerDagRunOperator()
+189 | TriggerDagRunOperator()
     |
     = help: Use `airflow.operators.trigger_dagrun.TriggerDagRunLink` instead
 
-AIR302_names.py:188:1: AIR302 `airflow.operators.dagrun_operator.TriggerDagRunOperator` is removed in Airflow 3.0
+AIR302_names.py:189:1: AIR302 `airflow.operators.dagrun_operator.TriggerDagRunOperator` is removed in Airflow 3.0
     |
-186 | # airflow.operators.dagrun_operator
-187 | TriggerDagRunLink()
-188 | TriggerDagRunOperator()
+187 | # airflow.operators.dagrun_operator
+188 | TriggerDagRunLink()
+189 | TriggerDagRunOperator()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-189 |
-190 | # airflow.operators.email_operator
+190 |
+191 | # airflow.operators.email_operator
     |
     = help: Use `airflow.operators.trigger_dagrun.TriggerDagRunOperator` instead
 
-AIR302_names.py:191:1: AIR302 `airflow.operators.email_operator.EmailOperator` is removed in Airflow 3.0
+AIR302_names.py:192:1: AIR302 `airflow.operators.email_operator.EmailOperator` is removed in Airflow 3.0
     |
-190 | # airflow.operators.email_operator
-191 | EmailOperator()
+191 | # airflow.operators.email_operator
+192 | EmailOperator()
     | ^^^^^^^^^^^^^ AIR302
-192 |
-193 | # airflow.operators.latest_only_operator
+193 |
+194 | # airflow.operators.latest_only_operator
     |
     = help: Use `airflow.operators.email.EmailOperator` instead
 
-AIR302_names.py:194:1: AIR302 `airflow.operators.latest_only_operator.LatestOnlyOperator` is removed in Airflow 3.0
+AIR302_names.py:195:1: AIR302 `airflow.operators.latest_only_operator.LatestOnlyOperator` is removed in Airflow 3.0
     |
-193 | # airflow.operators.latest_only_operator
-194 | LatestOnlyOperator()
+194 | # airflow.operators.latest_only_operator
+195 | LatestOnlyOperator()
     | ^^^^^^^^^^^^^^^^^^ AIR302
-195 |
-196 | # airflow.operators.python_operator
+196 |
+197 | # airflow.operators.python_operator
     |
     = help: Use `airflow.operators.latest_only.LatestOnlyOperator` instead
 
-AIR302_names.py:197:1: AIR302 `airflow.operators.python_operator.BranchPythonOperator` is removed in Airflow 3.0
+AIR302_names.py:198:1: AIR302 `airflow.operators.python_operator.BranchPythonOperator` is removed in Airflow 3.0
     |
-196 | # airflow.operators.python_operator
-197 | BranchPythonOperator()
+197 | # airflow.operators.python_operator
+198 | BranchPythonOperator()
     | ^^^^^^^^^^^^^^^^^^^^ AIR302
-198 | PythonOperator()
-199 | PythonVirtualenvOperator()
+199 | PythonOperator()
+200 | PythonVirtualenvOperator()
     |
     = help: Use `airflow.operators.python.BranchPythonOperator` instead
 
-AIR302_names.py:198:1: AIR302 `airflow.operators.python_operator.PythonOperator` is removed in Airflow 3.0
+AIR302_names.py:199:1: AIR302 `airflow.operators.python_operator.PythonOperator` is removed in Airflow 3.0
     |
-196 | # airflow.operators.python_operator
-197 | BranchPythonOperator()
-198 | PythonOperator()
+197 | # airflow.operators.python_operator
+198 | BranchPythonOperator()
+199 | PythonOperator()
     | ^^^^^^^^^^^^^^ AIR302
-199 | PythonVirtualenvOperator()
-200 | ShortCircuitOperator()
+200 | PythonVirtualenvOperator()
+201 | ShortCircuitOperator()
     |
     = help: Use `airflow.operators.python.PythonOperator` instead
 
-AIR302_names.py:199:1: AIR302 `airflow.operators.python_operator.PythonVirtualenvOperator` is removed in Airflow 3.0
+AIR302_names.py:200:1: AIR302 `airflow.operators.python_operator.PythonVirtualenvOperator` is removed in Airflow 3.0
     |
-197 | BranchPythonOperator()
-198 | PythonOperator()
-199 | PythonVirtualenvOperator()
+198 | BranchPythonOperator()
+199 | PythonOperator()
+200 | PythonVirtualenvOperator()
     | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-200 | ShortCircuitOperator()
+201 | ShortCircuitOperator()
     |
     = help: Use `airflow.operators.python.PythonVirtualenvOperator` instead
 
-AIR302_names.py:200:1: AIR302 `airflow.operators.python_operator.ShortCircuitOperator` is removed in Airflow 3.0
+AIR302_names.py:201:1: AIR302 `airflow.operators.python_operator.ShortCircuitOperator` is removed in Airflow 3.0
     |
-198 | PythonOperator()
-199 | PythonVirtualenvOperator()
-200 | ShortCircuitOperator()
+199 | PythonOperator()
+200 | PythonVirtualenvOperator()
+201 | ShortCircuitOperator()
     | ^^^^^^^^^^^^^^^^^^^^ AIR302
-201 |
-202 | # airflow.operators.subdag.*
+202 |
+203 | # airflow.operators.subdag.*
     |
     = help: Use `airflow.operators.python.ShortCircuitOperator` instead
 
-AIR302_names.py:203:1: AIR302 `airflow.operators.subdag.SubDagOperator` is removed in Airflow 3.0; The whole `airflow.subdag` module has been removed.
+AIR302_names.py:204:1: AIR302 `airflow.operators.subdag.SubDagOperator` is removed in Airflow 3.0; The whole `airflow.subdag` module has been removed.
     |
-202 | # airflow.operators.subdag.*
-203 | SubDagOperator()
+203 | # airflow.operators.subdag.*
+204 | SubDagOperator()
     | ^^^^^^^^^^^^^^ AIR302
-204 |
-205 | # airflow.providers.amazon
+205 |
+206 | # airflow.providers.amazon
     |
 
-AIR302_names.py:206:13: AIR302 `airflow.providers.amazon.aws.auth_manager.avp.entities.AvpEntities.DATASET` is removed in Airflow 3.0
+AIR302_names.py:207:13: AIR302 `airflow.providers.amazon.aws.auth_manager.avp.entities.AvpEntities.DATASET` is removed in Airflow 3.0
     |
-205 | # airflow.providers.amazon
-206 | AvpEntities.DATASET
+206 | # airflow.providers.amazon
+207 | AvpEntities.DATASET
     |             ^^^^^^^ AIR302
-207 | s3.create_dataset
-208 | s3.convert_dataset_to_openlineage
+208 | s3.create_dataset
+209 | s3.convert_dataset_to_openlineage
     |
     = help: Use `airflow.providers.amazon.aws.auth_manager.avp.entities.AvpEntities.ASSET` instead
 
-AIR302_names.py:207:4: AIR302 `airflow.providers.amazon.aws.datasets.s3.create_dataset` is removed in Airflow 3.0
+AIR302_names.py:208:4: AIR302 `airflow.providers.amazon.aws.datasets.s3.create_dataset` is removed in Airflow 3.0
     |
-205 | # airflow.providers.amazon
-206 | AvpEntities.DATASET
-207 | s3.create_dataset
+206 | # airflow.providers.amazon
+207 | AvpEntities.DATASET
+208 | s3.create_dataset
     |    ^^^^^^^^^^^^^^ AIR302
-208 | s3.convert_dataset_to_openlineage
-209 | s3.sanitize_uri
+209 | s3.convert_dataset_to_openlineage
+210 | s3.sanitize_uri
     |
     = help: Use `airflow.providers.amazon.aws.assets.s3.create_asset` instead
 
-AIR302_names.py:208:4: AIR302 `airflow.providers.amazon.aws.datasets.s3.convert_dataset_to_openlineage` is removed in Airflow 3.0
+AIR302_names.py:209:4: AIR302 `airflow.providers.amazon.aws.datasets.s3.convert_dataset_to_openlineage` is removed in Airflow 3.0
     |
-206 | AvpEntities.DATASET
-207 | s3.create_dataset
-208 | s3.convert_dataset_to_openlineage
+207 | AvpEntities.DATASET
+208 | s3.create_dataset
+209 | s3.convert_dataset_to_openlineage
     |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-209 | s3.sanitize_uri
+210 | s3.sanitize_uri
     |
     = help: Use `airflow.providers.amazon.aws.assets.s3.convert_asset_to_openlineage` instead
 
-AIR302_names.py:209:4: AIR302 `airflow.providers.amazon.aws.datasets.s3.sanitize_uri` is removed in Airflow 3.0
+AIR302_names.py:210:4: AIR302 `airflow.providers.amazon.aws.datasets.s3.sanitize_uri` is removed in Airflow 3.0
     |
-207 | s3.create_dataset
-208 | s3.convert_dataset_to_openlineage
-209 | s3.sanitize_uri
+208 | s3.create_dataset
+209 | s3.convert_dataset_to_openlineage
+210 | s3.sanitize_uri
     |    ^^^^^^^^^^^^ AIR302
-210 |
-211 | # airflow.providers.common.io
+211 |
+212 | # airflow.providers.common.io
     |
     = help: Use `airflow.providers.amazon.aws.assets.s3.sanitize_uri` instead
 
-AIR302_names.py:212:16: AIR302 `airflow.providers.common.io.datasets.file.convert_dataset_to_openlineage` is removed in Airflow 3.0
+AIR302_names.py:213:16: AIR302 `airflow.providers.common.io.datasets.file.convert_dataset_to_openlineage` is removed in Airflow 3.0
     |
-211 | # airflow.providers.common.io
-212 | common_io_file.convert_dataset_to_openlineage
+212 | # airflow.providers.common.io
+213 | common_io_file.convert_dataset_to_openlineage
     |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-213 | common_io_file.create_dataset
-214 | common_io_file.sanitize_uri
+214 | common_io_file.create_dataset
+215 | common_io_file.sanitize_uri
     |
     = help: Use `airflow.providers.common.io.assets.file.convert_asset_to_openlineage` instead
 
-AIR302_names.py:213:16: AIR302 `airflow.providers.common.io.datasets.file.create_dataset` is removed in Airflow 3.0
+AIR302_names.py:214:16: AIR302 `airflow.providers.common.io.datasets.file.create_dataset` is removed in Airflow 3.0
     |
-211 | # airflow.providers.common.io
-212 | common_io_file.convert_dataset_to_openlineage
-213 | common_io_file.create_dataset
+212 | # airflow.providers.common.io
+213 | common_io_file.convert_dataset_to_openlineage
+214 | common_io_file.create_dataset
     |                ^^^^^^^^^^^^^^ AIR302
-214 | common_io_file.sanitize_uri
+215 | common_io_file.sanitize_uri
     |
     = help: Use `airflow.providers.common.io.assets.file.create_asset` instead
 
-AIR302_names.py:214:16: AIR302 `airflow.providers.common.io.datasets.file.sanitize_uri` is removed in Airflow 3.0
+AIR302_names.py:215:16: AIR302 `airflow.providers.common.io.datasets.file.sanitize_uri` is removed in Airflow 3.0
     |
-212 | common_io_file.convert_dataset_to_openlineage
-213 | common_io_file.create_dataset
-214 | common_io_file.sanitize_uri
+213 | common_io_file.convert_dataset_to_openlineage
+214 | common_io_file.create_dataset
+215 | common_io_file.sanitize_uri
     |                ^^^^^^^^^^^^ AIR302
-215 |
-216 | # airflow.providers.fab
+216 |
+217 | # airflow.providers.fab
     |
     = help: Use `airflow.providers.common.io.assets.file.sanitize_uri` instead
 
-AIR302_names.py:217:18: AIR302 `airflow.providers.fab.auth_manager.fab_auth_manager.is_authorized_dataset` is removed in Airflow 3.0
+AIR302_names.py:218:18: AIR302 `airflow.providers.fab.auth_manager.fab_auth_manager.is_authorized_dataset` is removed in Airflow 3.0
     |
-216 | # airflow.providers.fab
-217 | fab_auth_manager.is_authorized_dataset
+217 | # airflow.providers.fab
+218 | fab_auth_manager.is_authorized_dataset
     |                  ^^^^^^^^^^^^^^^^^^^^^ AIR302
-218 |
-219 | # airflow.providers.google
+219 |
+220 | # airflow.providers.google
     |
     = help: Use `airflow.providers.fab.auth_manager.fab_auth_manager.is_authorized_asset` instead
 
-AIR302_names.py:222:5: AIR302 `airflow.providers.google.datasets.gcs.create_dataset` is removed in Airflow 3.0
+AIR302_names.py:223:5: AIR302 `airflow.providers.google.datasets.gcs.create_dataset` is removed in Airflow 3.0
     |
-220 | bigquery.sanitize_uri
-221 |
-222 | gcs.create_dataset
+221 | bigquery.sanitize_uri
+222 |
+223 | gcs.create_dataset
     |     ^^^^^^^^^^^^^^ AIR302
-223 | gcs.sanitize_uri
-224 | gcs.convert_dataset_to_openlineage
+224 | gcs.sanitize_uri
+225 | gcs.convert_dataset_to_openlineage
     |
     = help: Use `airflow.providers.google.assets.gcs.create_asset` instead
 
-AIR302_names.py:223:5: AIR302 `airflow.providers.google.datasets.gcs.sanitize_uri` is removed in Airflow 3.0
+AIR302_names.py:224:5: AIR302 `airflow.providers.google.datasets.gcs.sanitize_uri` is removed in Airflow 3.0
     |
-222 | gcs.create_dataset
-223 | gcs.sanitize_uri
+223 | gcs.create_dataset
+224 | gcs.sanitize_uri
     |     ^^^^^^^^^^^^ AIR302
-224 | gcs.convert_dataset_to_openlineage
+225 | gcs.convert_dataset_to_openlineage
     |
     = help: Use `airflow.providers.google.assets.gcs.sanitize_uri` instead
 
-AIR302_names.py:224:5: AIR302 `airflow.providers.google.datasets.gcs.convert_dataset_to_openlineage` is removed in Airflow 3.0
+AIR302_names.py:225:5: AIR302 `airflow.providers.google.datasets.gcs.convert_dataset_to_openlineage` is removed in Airflow 3.0
     |
-222 | gcs.create_dataset
-223 | gcs.sanitize_uri
-224 | gcs.convert_dataset_to_openlineage
+223 | gcs.create_dataset
+224 | gcs.sanitize_uri
+225 | gcs.convert_dataset_to_openlineage
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-225 |
-226 | # airflow.providers.mysql
+226 |
+227 | # airflow.providers.mysql
     |
     = help: Use `airflow.providers.google.assets.gcs.convert_asset_to_openlineage` instead
 
-AIR302_names.py:227:7: AIR302 `airflow.providers.mysql.datasets.mysql.sanitize_uri` is removed in Airflow 3.0
+AIR302_names.py:228:7: AIR302 `airflow.providers.mysql.datasets.mysql.sanitize_uri` is removed in Airflow 3.0
     |
-226 | # airflow.providers.mysql
-227 | mysql.sanitize_uri
+227 | # airflow.providers.mysql
+228 | mysql.sanitize_uri
     |       ^^^^^^^^^^^^ AIR302
-228 |
-229 | # airflow.providers.openlineage
+229 |
+230 | # airflow.providers.openlineage
     |
     = help: Use `airflow.providers.mysql.assets.mysql.sanitize_uri` instead
 
-AIR302_names.py:230:1: AIR302 `airflow.providers.openlineage.utils.utils.DatasetInfo` is removed in Airflow 3.0
+AIR302_names.py:231:1: AIR302 `airflow.providers.openlineage.utils.utils.DatasetInfo` is removed in Airflow 3.0
     |
-229 | # airflow.providers.openlineage
-230 | DatasetInfo()
+230 | # airflow.providers.openlineage
+231 | DatasetInfo()
     | ^^^^^^^^^^^ AIR302
-231 | translate_airflow_dataset
+232 | translate_airflow_dataset
     |
     = help: Use `airflow.providers.openlineage.utils.utils.AssetInfo` instead
 
-AIR302_names.py:231:1: AIR302 `airflow.providers.openlineage.utils.utils.translate_airflow_dataset` is removed in Airflow 3.0
+AIR302_names.py:232:1: AIR302 `airflow.providers.openlineage.utils.utils.translate_airflow_dataset` is removed in Airflow 3.0
     |
-229 | # airflow.providers.openlineage
-230 | DatasetInfo()
-231 | translate_airflow_dataset
+230 | # airflow.providers.openlineage
+231 | DatasetInfo()
+232 | translate_airflow_dataset
     | ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-232 |
-233 | # airflow.providers.postgres
+233 |
+234 | # airflow.providers.postgres
     |
     = help: Use `airflow.providers.openlineage.utils.utils.translate_airflow_asset` instead
 
-AIR302_names.py:234:10: AIR302 `airflow.providers.postgres.datasets.postgres.sanitize_uri` is removed in Airflow 3.0
+AIR302_names.py:235:10: AIR302 `airflow.providers.postgres.datasets.postgres.sanitize_uri` is removed in Airflow 3.0
     |
-233 | # airflow.providers.postgres
-234 | postgres.sanitize_uri
+234 | # airflow.providers.postgres
+235 | postgres.sanitize_uri
     |          ^^^^^^^^^^^^ AIR302
-235 |
-236 | # airflow.providers.trino
+236 |
+237 | # airflow.providers.trino
     |
     = help: Use `airflow.providers.postgres.assets.postgres.sanitize_uri` instead
 
-AIR302_names.py:237:7: AIR302 `airflow.providers.trino.datasets.trino.sanitize_uri` is removed in Airflow 3.0
+AIR302_names.py:238:7: AIR302 `airflow.providers.trino.datasets.trino.sanitize_uri` is removed in Airflow 3.0
     |
-236 | # airflow.providers.trino
-237 | trino.sanitize_uri
+237 | # airflow.providers.trino
+238 | trino.sanitize_uri
     |       ^^^^^^^^^^^^ AIR302
-238 |
-239 | # airflow.secrets
+239 |
+240 | # airflow.secrets
     |
     = help: Use `airflow.providers.trino.assets.trino.sanitize_uri` instead
 
-AIR302_names.py:242:1: AIR302 `airflow.secrets.local_filesystem.load_connections` is removed in Airflow 3.0
+AIR302_names.py:243:1: AIR302 `airflow.secrets.local_filesystem.load_connections` is removed in Airflow 3.0
     |
-240 | # get_connection
-241 | LocalFilesystemBackend()
-242 | load_connections
+241 | # get_connection
+242 | LocalFilesystemBackend()
+243 | load_connections
     | ^^^^^^^^^^^^^^^^ AIR302
-243 |
-244 | # airflow.security.permissions
+244 |
+245 | # airflow.security.permissions
     |
     = help: Use `airflow.secrets.local_filesystem.load_connections_dict` instead
 
-AIR302_names.py:245:1: AIR302 `airflow.security.permissions.RESOURCE_DATASET` is removed in Airflow 3.0
+AIR302_names.py:246:1: AIR302 `airflow.security.permissions.RESOURCE_DATASET` is removed in Airflow 3.0
     |
-244 | # airflow.security.permissions
-245 | RESOURCE_DATASET
+245 | # airflow.security.permissions
+246 | RESOURCE_DATASET
     | ^^^^^^^^^^^^^^^^ AIR302
-246 |
-247 | # airflow.sensors.base_sensor_operator
+247 |
+248 | # airflow.sensors.base_sensor_operator
     |
     = help: Use `airflow.security.permissions.RESOURCE_ASSET` instead
 
-AIR302_names.py:248:1: AIR302 `airflow.sensors.base_sensor_operator.BaseSensorOperator` is removed in Airflow 3.0
+AIR302_names.py:249:1: AIR302 `airflow.sensors.base_sensor_operator.BaseSensorOperator` is removed in Airflow 3.0
     |
-247 | # airflow.sensors.base_sensor_operator
-248 | BaseSensorOperator()
+248 | # airflow.sensors.base_sensor_operator
+249 | BaseSensorOperator()
     | ^^^^^^^^^^^^^^^^^^ AIR302
-249 |
-250 | # airflow.sensors.date_time_sensor
+250 |
+251 | # airflow.sensors.date_time_sensor
     |
     = help: Use `airflow.sensors.base.BaseSensorOperator` instead
 
-AIR302_names.py:251:1: AIR302 `airflow.sensors.date_time_sensor.DateTimeSensor` is removed in Airflow 3.0
+AIR302_names.py:252:1: AIR302 `airflow.sensors.date_time_sensor.DateTimeSensor` is removed in Airflow 3.0
     |
-250 | # airflow.sensors.date_time_sensor
-251 | DateTimeSensor()
+251 | # airflow.sensors.date_time_sensor
+252 | DateTimeSensor()
     | ^^^^^^^^^^^^^^ AIR302
-252 |
-253 | # airflow.sensors.external_task
+253 |
+254 | # airflow.sensors.external_task
     |
     = help: Use `airflow.sensors.date_time.DateTimeSensor` instead
 
-AIR302_names.py:254:1: AIR302 `airflow.sensors.external_task.ExternalTaskSensorLink` is removed in Airflow 3.0
+AIR302_names.py:255:1: AIR302 `airflow.sensors.external_task.ExternalTaskSensorLink` is removed in Airflow 3.0
     |
-253 | # airflow.sensors.external_task
-254 | ExternalTaskSensorLink()
+254 | # airflow.sensors.external_task
+255 | ExternalTaskSensorLink()
     | ^^^^^^^^^^^^^^^^^^^^^^ AIR302
-255 | ExternalTaskMarker()
-256 | ExternalTaskSensor()
+256 | ExternalTaskMarker()
+257 | ExternalTaskSensor()
     |
     = help: Use `airflow.sensors.external_task.ExternalDagLink` instead
 
-AIR302_names.py:255:1: AIR302 `airflow.sensors.external_task.ExternalTaskMarker` is removed in Airflow 3.0
+AIR302_names.py:256:1: AIR302 `airflow.sensors.external_task.ExternalTaskMarker` is removed in Airflow 3.0
     |
-253 | # airflow.sensors.external_task
-254 | ExternalTaskSensorLink()
-255 | ExternalTaskMarker()
+254 | # airflow.sensors.external_task
+255 | ExternalTaskSensorLink()
+256 | ExternalTaskMarker()
     | ^^^^^^^^^^^^^^^^^^ AIR302
-256 | ExternalTaskSensor()
+257 | ExternalTaskSensor()
     |
     = help: Use `airflow.sensors.external_task.ExternalTaskMarker` instead
 
-AIR302_names.py:256:1: AIR302 `airflow.sensors.external_task.ExternalTaskSensor` is removed in Airflow 3.0
+AIR302_names.py:257:1: AIR302 `airflow.sensors.external_task.ExternalTaskSensor` is removed in Airflow 3.0
     |
-254 | ExternalTaskSensorLink()
-255 | ExternalTaskMarker()
-256 | ExternalTaskSensor()
+255 | ExternalTaskSensorLink()
+256 | ExternalTaskMarker()
+257 | ExternalTaskSensor()
     | ^^^^^^^^^^^^^^^^^^ AIR302
-257 |
-258 | # airflow.sensors.external_task_sensor
+258 |
+259 | # airflow.sensors.external_task_sensor
     |
     = help: Use `airflow.sensors.external_task.ExternalTaskSensor` instead
 
-AIR302_names.py:259:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskMarker` is removed in Airflow 3.0
+AIR302_names.py:260:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskMarker` is removed in Airflow 3.0
     |
-258 | # airflow.sensors.external_task_sensor
-259 | ExternalTaskMarkerFromExternalTaskSensor()
+259 | # airflow.sensors.external_task_sensor
+260 | ExternalTaskMarkerFromExternalTaskSensor()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-260 | ExternalTaskSensorFromExternalTaskSensor()
-261 | ExternalTaskSensorLinkFromExternalTaskSensor()
+261 | ExternalTaskSensorFromExternalTaskSensor()
+262 | ExternalTaskSensorLinkFromExternalTaskSensor()
     |
     = help: Use `airflow.sensors.external_task.ExternalTaskMarker` instead
 
-AIR302_names.py:260:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensor` is removed in Airflow 3.0
+AIR302_names.py:261:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensor` is removed in Airflow 3.0
     |
-258 | # airflow.sensors.external_task_sensor
-259 | ExternalTaskMarkerFromExternalTaskSensor()
-260 | ExternalTaskSensorFromExternalTaskSensor()
+259 | # airflow.sensors.external_task_sensor
+260 | ExternalTaskMarkerFromExternalTaskSensor()
+261 | ExternalTaskSensorFromExternalTaskSensor()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-261 | ExternalTaskSensorLinkFromExternalTaskSensor()
+262 | ExternalTaskSensorLinkFromExternalTaskSensor()
     |
     = help: Use `airflow.sensors.external_task.ExternalTaskSensor` instead
 
-AIR302_names.py:261:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensorLink` is removed in Airflow 3.0
+AIR302_names.py:262:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensorLink` is removed in Airflow 3.0
     |
-259 | ExternalTaskMarkerFromExternalTaskSensor()
-260 | ExternalTaskSensorFromExternalTaskSensor()
-261 | ExternalTaskSensorLinkFromExternalTaskSensor()
+260 | ExternalTaskMarkerFromExternalTaskSensor()
+261 | ExternalTaskSensorFromExternalTaskSensor()
+262 | ExternalTaskSensorLinkFromExternalTaskSensor()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-262 |
-263 | # airflow.sensors.time_delta_sensor
+263 |
+264 | # airflow.sensors.time_delta_sensor
     |
     = help: Use `airflow.sensors.external_task.ExternalDagLink` instead
 
-AIR302_names.py:264:1: AIR302 `airflow.sensors.time_delta_sensor.TimeDeltaSensor` is removed in Airflow 3.0
+AIR302_names.py:265:1: AIR302 `airflow.sensors.time_delta_sensor.TimeDeltaSensor` is removed in Airflow 3.0
     |
-263 | # airflow.sensors.time_delta_sensor
-264 | TimeDeltaSensor()
+264 | # airflow.sensors.time_delta_sensor
+265 | TimeDeltaSensor()
     | ^^^^^^^^^^^^^^^ AIR302
-265 |
-266 | # airflow.timetables
+266 |
+267 | # airflow.timetables
     |
     = help: Use `airflow.sensors.time_delta.TimeDeltaSensor` instead
 
-AIR302_names.py:267:1: AIR302 `airflow.timetables.datasets.DatasetOrTimeSchedule` is removed in Airflow 3.0
+AIR302_names.py:268:1: AIR302 `airflow.timetables.datasets.DatasetOrTimeSchedule` is removed in Airflow 3.0
     |
-266 | # airflow.timetables
-267 | DatasetOrTimeSchedule()
+267 | # airflow.timetables
+268 | DatasetOrTimeSchedule()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-268 | DatasetTriggeredTimetable()
+269 | DatasetTriggeredTimetable()
     |
     = help: Use `airflow.timetables.assets.AssetOrTimeSchedule` instead
 
-AIR302_names.py:268:1: AIR302 `airflow.timetables.simple.DatasetTriggeredTimetable` is removed in Airflow 3.0
+AIR302_names.py:269:1: AIR302 `airflow.timetables.simple.DatasetTriggeredTimetable` is removed in Airflow 3.0
     |
-266 | # airflow.timetables
-267 | DatasetOrTimeSchedule()
-268 | DatasetTriggeredTimetable()
+267 | # airflow.timetables
+268 | DatasetOrTimeSchedule()
+269 | DatasetTriggeredTimetable()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-269 |
-270 | # airflow.triggers.external_task
+270 |
+271 | # airflow.triggers.external_task
     |
     = help: Use `airflow.timetables.simple.AssetTriggeredTimetable` instead
 
-AIR302_names.py:271:1: AIR302 `airflow.triggers.external_task.TaskStateTrigger` is removed in Airflow 3.0
+AIR302_names.py:272:1: AIR302 `airflow.triggers.external_task.TaskStateTrigger` is removed in Airflow 3.0
     |
-270 | # airflow.triggers.external_task
-271 | TaskStateTrigger()
+271 | # airflow.triggers.external_task
+272 | TaskStateTrigger()
     | ^^^^^^^^^^^^^^^^ AIR302
-272 |
-273 | # airflow.utils.date
+273 |
+274 | # airflow.utils.date
     |
 
-AIR302_names.py:274:7: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0
+AIR302_names.py:275:7: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0
     |
-273 | # airflow.utils.date
-274 | dates.date_range
+274 | # airflow.utils.date
+275 | dates.date_range
     |       ^^^^^^^^^^ AIR302
-275 | dates.days_ago
+276 | dates.days_ago
     |
 
-AIR302_names.py:275:7: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0
+AIR302_names.py:276:7: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0
     |
-273 | # airflow.utils.date
-274 | dates.date_range
-275 | dates.days_ago
+274 | # airflow.utils.date
+275 | dates.date_range
+276 | dates.days_ago
     |       ^^^^^^^^ AIR302
-276 |
-277 | date_range
+277 |
+278 | date_range
     |
     = help: Use `pendulum.today('UTC').add(days=-N, ...)` instead
 
-AIR302_names.py:277:1: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0
+AIR302_names.py:278:1: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0
     |
-275 | dates.days_ago
-276 |
-277 | date_range
+276 | dates.days_ago
+277 |
+278 | date_range
     | ^^^^^^^^^^ AIR302
-278 | days_ago
-279 | infer_time_unit
+279 | days_ago
+280 | infer_time_unit
     |
 
-AIR302_names.py:278:1: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0
+AIR302_names.py:279:1: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0
     |
-277 | date_range
-278 | days_ago
+278 | date_range
+279 | days_ago
     | ^^^^^^^^ AIR302
-279 | infer_time_unit
-280 | parse_execution_date
+280 | infer_time_unit
+281 | parse_execution_date
     |
     = help: Use `pendulum.today('UTC').add(days=-N, ...)` instead
 
-AIR302_names.py:279:1: AIR302 `airflow.utils.dates.infer_time_unit` is removed in Airflow 3.0
+AIR302_names.py:280:1: AIR302 `airflow.utils.dates.infer_time_unit` is removed in Airflow 3.0
     |
-277 | date_range
-278 | days_ago
-279 | infer_time_unit
+278 | date_range
+279 | days_ago
+280 | infer_time_unit
     | ^^^^^^^^^^^^^^^ AIR302
-280 | parse_execution_date
-281 | round_time
+281 | parse_execution_date
+282 | round_time
     |
 
-AIR302_names.py:280:1: AIR302 `airflow.utils.dates.parse_execution_date` is removed in Airflow 3.0
+AIR302_names.py:281:1: AIR302 `airflow.utils.dates.parse_execution_date` is removed in Airflow 3.0
     |
-278 | days_ago
-279 | infer_time_unit
-280 | parse_execution_date
+279 | days_ago
+280 | infer_time_unit
+281 | parse_execution_date
     | ^^^^^^^^^^^^^^^^^^^^ AIR302
-281 | round_time
-282 | scale_time_units
+282 | round_time
+283 | scale_time_units
     |
 
-AIR302_names.py:281:1: AIR302 `airflow.utils.dates.round_time` is removed in Airflow 3.0
+AIR302_names.py:282:1: AIR302 `airflow.utils.dates.round_time` is removed in Airflow 3.0
     |
-279 | infer_time_unit
-280 | parse_execution_date
-281 | round_time
+280 | infer_time_unit
+281 | parse_execution_date
+282 | round_time
     | ^^^^^^^^^^ AIR302
-282 | scale_time_units
+283 | scale_time_units
     |
 
-AIR302_names.py:282:1: AIR302 `airflow.utils.dates.scale_time_units` is removed in Airflow 3.0
+AIR302_names.py:283:1: AIR302 `airflow.utils.dates.scale_time_units` is removed in Airflow 3.0
     |
-280 | parse_execution_date
-281 | round_time
-282 | scale_time_units
+281 | parse_execution_date
+282 | round_time
+283 | scale_time_units
     | ^^^^^^^^^^^^^^^^ AIR302
-283 |
-284 | # This one was not deprecated.
+284 |
+285 | # This one was not deprecated.
     |
 
-AIR302_names.py:289:1: AIR302 `airflow.utils.dag_cycle_tester.test_cycle` is removed in Airflow 3.0
+AIR302_names.py:290:1: AIR302 `airflow.utils.dag_cycle_tester.test_cycle` is removed in Airflow 3.0
     |
-288 | # airflow.utils.dag_cycle_tester
-289 | test_cycle
+289 | # airflow.utils.dag_cycle_tester
+290 | test_cycle
     | ^^^^^^^^^^ AIR302
-290 |
-291 | # airflow.utils.dag_parsing_context
+291 |
+292 | # airflow.utils.dag_parsing_context
     |
 
-AIR302_names.py:292:1: AIR302 `airflow.utils.dag_parsing_context.get_parsing_context` is removed in Airflow 3.0
+AIR302_names.py:293:1: AIR302 `airflow.utils.dag_parsing_context.get_parsing_context` is removed in Airflow 3.0
     |
-291 | # airflow.utils.dag_parsing_context
-292 | get_parsing_context
+292 | # airflow.utils.dag_parsing_context
+293 | get_parsing_context
     | ^^^^^^^^^^^^^^^^^^^ AIR302
-293 |
-294 | # airflow.utils.decorators
+294 |
+295 | # airflow.utils.db
     |
     = help: Use `airflow.sdk.get_parsing_context` instead
 
-AIR302_names.py:295:1: AIR302 `airflow.utils.decorators.apply_defaults` is removed in Airflow 3.0; `apply_defaults` is now unconditionally done and can be safely removed.
+AIR302_names.py:296:1: AIR302 `airflow.utils.db.create_session` is removed in Airflow 3.0
     |
-294 | # airflow.utils.decorators
-295 | apply_defaults
+295 | # airflow.utils.db
+296 | create_session
     | ^^^^^^^^^^^^^^ AIR302
-296 |
-297 | # airflow.utils.file
+297 |
+298 | # airflow.utils.decorators
     |
 
-AIR302_names.py:298:1: AIR302 `airflow.utils.file.TemporaryDirectory` is removed in Airflow 3.0
+AIR302_names.py:299:1: AIR302 `airflow.utils.decorators.apply_defaults` is removed in Airflow 3.0; `apply_defaults` is now unconditionally done and can be safely removed.
     |
-297 | # airflow.utils.file
-298 | TemporaryDirectory()
-    | ^^^^^^^^^^^^^^^^^^ AIR302
-299 | mkdirs
-    |
-
-AIR302_names.py:299:1: AIR302 `airflow.utils.file.mkdirs` is removed in Airflow 3.0
-    |
-297 | # airflow.utils.file
-298 | TemporaryDirectory()
-299 | mkdirs
-    | ^^^^^^ AIR302
+298 | # airflow.utils.decorators
+299 | apply_defaults
+    | ^^^^^^^^^^^^^^ AIR302
 300 |
-301 | #  airflow.utils.helpers
+301 | # airflow.utils.file
+    |
+
+AIR302_names.py:302:1: AIR302 `airflow.utils.file.TemporaryDirectory` is removed in Airflow 3.0
+    |
+301 | # airflow.utils.file
+302 | TemporaryDirectory()
+    | ^^^^^^^^^^^^^^^^^^ AIR302
+303 | mkdirs
+    |
+
+AIR302_names.py:303:1: AIR302 `airflow.utils.file.mkdirs` is removed in Airflow 3.0
+    |
+301 | # airflow.utils.file
+302 | TemporaryDirectory()
+303 | mkdirs
+    | ^^^^^^ AIR302
+304 |
+305 | #  airflow.utils.helpers
     |
     = help: Use `pendulum.today('UTC').add(days=-N, ...)` instead
 
-AIR302_names.py:302:1: AIR302 `airflow.utils.helpers.chain` is removed in Airflow 3.0
+AIR302_names.py:306:1: AIR302 `airflow.utils.helpers.chain` is removed in Airflow 3.0
     |
-301 | #  airflow.utils.helpers
-302 | helper_chain
+305 | #  airflow.utils.helpers
+306 | helper_chain
     | ^^^^^^^^^^^^ AIR302
-303 | helper_cross_downstream
+307 | helper_cross_downstream
     |
     = help: Use `airflow.sdk.chain` instead
 
-AIR302_names.py:303:1: AIR302 `airflow.utils.helpers.cross_downstream` is removed in Airflow 3.0
+AIR302_names.py:307:1: AIR302 `airflow.utils.helpers.cross_downstream` is removed in Airflow 3.0
     |
-301 | #  airflow.utils.helpers
-302 | helper_chain
-303 | helper_cross_downstream
+305 | #  airflow.utils.helpers
+306 | helper_chain
+307 | helper_cross_downstream
     | ^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-304 |
-305 | #  airflow.utils.log
+308 |
+309 | #  airflow.utils.log
     |
     = help: Use `airflow.sdk.cross_downstream` instead
 
-AIR302_names.py:306:1: AIR302 `airflow.utils.log.secrets_masker` is removed in Airflow 3.0
+AIR302_names.py:310:1: AIR302 `airflow.utils.log.secrets_masker` is removed in Airflow 3.0
     |
-305 | #  airflow.utils.log
-306 | secrets_masker
+309 | #  airflow.utils.log
+310 | secrets_masker
     | ^^^^^^^^^^^^^^ AIR302
-307 |
-308 | # airflow.utils.state
+311 |
+312 | # airflow.utils.state
     |
     = help: Use `airflow.sdk.execution_time.secrets_masker` instead
 
-AIR302_names.py:309:1: AIR302 `airflow.utils.state.SHUTDOWN` is removed in Airflow 3.0
+AIR302_names.py:313:1: AIR302 `airflow.utils.state.SHUTDOWN` is removed in Airflow 3.0
     |
-308 | # airflow.utils.state
-309 | SHUTDOWN
+312 | # airflow.utils.state
+313 | SHUTDOWN
     | ^^^^^^^^ AIR302
-310 | terminating_states
+314 | terminating_states
     |
 
-AIR302_names.py:310:1: AIR302 `airflow.utils.state.terminating_states` is removed in Airflow 3.0
+AIR302_names.py:314:1: AIR302 `airflow.utils.state.terminating_states` is removed in Airflow 3.0
     |
-308 | # airflow.utils.state
-309 | SHUTDOWN
-310 | terminating_states
+312 | # airflow.utils.state
+313 | SHUTDOWN
+314 | terminating_states
     | ^^^^^^^^^^^^^^^^^^ AIR302
-311 |
-312 | #  airflow.utils.trigger_rule
-    |
-
-AIR302_names.py:313:13: AIR302 `airflow.utils.trigger_rule.TriggerRule.DUMMY` is removed in Airflow 3.0
-    |
-312 | #  airflow.utils.trigger_rule
-313 | TriggerRule.DUMMY
-    |             ^^^^^ AIR302
-314 | TriggerRule.NONE_FAILED_OR_SKIPPED
-    |
-
-AIR302_names.py:314:13: AIR302 `airflow.utils.trigger_rule.TriggerRule.NONE_FAILED_OR_SKIPPED` is removed in Airflow 3.0
-    |
-312 | #  airflow.utils.trigger_rule
-313 | TriggerRule.DUMMY
-314 | TriggerRule.NONE_FAILED_OR_SKIPPED
-    |             ^^^^^^^^^^^^^^^^^^^^^^ AIR302
 315 |
-316 | # airflow.www.auth
+316 | #  airflow.utils.trigger_rule
     |
 
-AIR302_names.py:317:1: AIR302 `airflow.www.auth.has_access` is removed in Airflow 3.0
+AIR302_names.py:317:13: AIR302 `airflow.utils.trigger_rule.TriggerRule.DUMMY` is removed in Airflow 3.0
     |
-316 | # airflow.www.auth
-317 | has_access
+316 | #  airflow.utils.trigger_rule
+317 | TriggerRule.DUMMY
+    |             ^^^^^ AIR302
+318 | TriggerRule.NONE_FAILED_OR_SKIPPED
+    |
+
+AIR302_names.py:318:13: AIR302 `airflow.utils.trigger_rule.TriggerRule.NONE_FAILED_OR_SKIPPED` is removed in Airflow 3.0
+    |
+316 | #  airflow.utils.trigger_rule
+317 | TriggerRule.DUMMY
+318 | TriggerRule.NONE_FAILED_OR_SKIPPED
+    |             ^^^^^^^^^^^^^^^^^^^^^^ AIR302
+319 |
+320 | # airflow.www.auth
+    |
+
+AIR302_names.py:321:1: AIR302 `airflow.www.auth.has_access` is removed in Airflow 3.0
+    |
+320 | # airflow.www.auth
+321 | has_access
     | ^^^^^^^^^^ AIR302
-318 | has_access_dataset
+322 | has_access_dataset
     |
     = help: Use `airflow.www.auth.has_access_*` instead
 
-AIR302_names.py:318:1: AIR302 `airflow.www.auth.has_access_dataset` is removed in Airflow 3.0
+AIR302_names.py:322:1: AIR302 `airflow.www.auth.has_access_dataset` is removed in Airflow 3.0
     |
-316 | # airflow.www.auth
-317 | has_access
-318 | has_access_dataset
+320 | # airflow.www.auth
+321 | has_access
+322 | has_access_dataset
     | ^^^^^^^^^^^^^^^^^^ AIR302
-319 |
-320 | # airflow.www.utils
+323 |
+324 | # airflow.www.utils
     |
     = help: Use `airflow.www.auth.has_access_dataset.has_access_asset` instead
 
-AIR302_names.py:321:1: AIR302 `airflow.www.utils.get_sensitive_variables_fields` is removed in Airflow 3.0
+AIR302_names.py:325:1: AIR302 `airflow.www.utils.get_sensitive_variables_fields` is removed in Airflow 3.0
     |
-320 | # airflow.www.utils
-321 | get_sensitive_variables_fields
+324 | # airflow.www.utils
+325 | get_sensitive_variables_fields
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-322 | should_hide_value_for_key
+326 | should_hide_value_for_key
     |
     = help: Use `airflow.utils.log.secrets_masker.get_sensitive_variables_fields` instead
 
-AIR302_names.py:322:1: AIR302 `airflow.www.utils.should_hide_value_for_key` is removed in Airflow 3.0
+AIR302_names.py:326:1: AIR302 `airflow.www.utils.should_hide_value_for_key` is removed in Airflow 3.0
     |
-320 | # airflow.www.utils
-321 | get_sensitive_variables_fields
-322 | should_hide_value_for_key
+324 | # airflow.www.utils
+325 | get_sensitive_variables_fields
+326 | should_hide_value_for_key
     | ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
     |
     = help: Use `airflow.utils.log.secrets_masker.should_hide_value_for_key` instead

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
@@ -970,6 +970,7 @@ AIR302_names.py:302:1: AIR302 `airflow.utils.file.TemporaryDirectory` is removed
     | ^^^^^^^^^^^^^^^^^^ AIR302
 303 | mkdirs
     |
+    = help: Use `tempfile.TemporaryDirectory` instead
 
 AIR302_names.py:303:1: AIR302 `airflow.utils.file.mkdirs` is removed in Airflow 3.0
     |
@@ -980,7 +981,7 @@ AIR302_names.py:303:1: AIR302 `airflow.utils.file.mkdirs` is removed in Airflow 
 304 |
 305 | #  airflow.utils.helpers
     |
-    = help: Use `pendulum.today('UTC').add(days=-N, ...)` instead
+    = help: Use `pathlib.Path({path}).mkdir` instead
 
 AIR302_names.py:306:1: AIR302 `airflow.utils.helpers.chain` is removed in Airflow 3.0
     |

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_linter/src/rules/airflow/mod.rs
-snapshot_kind: text
 ---
 AIR302_names.py:121:1: AIR302 `airflow.PY36` is removed in Airflow 3.0
     |


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

* ``airflow.auth.managers.base_auth_manager.is_authorized_dataset`` has been moved to ``airflow.api_fastapi.auth.managers.base_auth_manager.is_authorized_asset`` in Airflow 3.0
* ``airflow.auth.managers.models.resource_details.DatasetDetails`` has been moved to ``airflow.api_fastapi.auth.managers.models.resource_details.AssetDetails`` in Airflow 3.0
* Dag arguments `default_view` and `orientation` has been removed in Airflow 3.0
* `airflow.models.baseoperatorlink.BaseOperatorLink` has been moved to `airflow.sdk.definitions.baseoperatorlink.BaseOperatorLink` in Airflow 3.0
* ``airflow.notifications.basenotifier.BaseNotifier`` has been moved to ``airflow.sdk.BaseNotifier``  in Airflow 3.0
* ``airflow.utils.log.secrets_masker`` has been moved to ``airflow.sdk.execution_time.secrets_masker`` in Airflow 3.0
* ``airflow...DAG.allow_future_exec_dates`` has been removed in Airflow 3.0
* `airflow.utils.db.create_session` has een removed in Airflow 3.0
* `airflow.sensors.base_sensor_operator.BaseSensorOperator` has been moved to `airflow.sdk.bases.sensor.BaseSensorOperator` removed Airflow 3.0
* `airflow.utils.file.TemporaryDirectory` has been removed in Airflow 3.0 and can be replaced by `tempfile.TemporaryDirectory`
*  `airflow.utils.file.mkdirs` has been removed in Airflow 3.0 and can be replaced by `pathlib.Path({path}).mkdir`

## Test Plan

<!-- How was it tested? -->
Test fixture has been added for these changes