### PR TITLE
[red-knot] Add `ParamSpecArgs` and `ParamSpecKwargs` as `KnownClass`

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -3104,6 +3104,12 @@ impl<'db> Type<'db> {
                 Some(KnownClass::ParamSpec) => Ok(todo_type!(
                     "Support for `typing.ParamSpec` instances in type expressions"
                 )),
+                Some(KnownClass::ParamSpecArgs) => Ok(todo_type!(
+                    "Support for `typing.ParamSpecArgs` instances in type expressions"
+                )),
+                Some(KnownClass::ParamSpecKwargs) => Ok(todo_type!(
+                    "Support for `typing.ParamSpecKwargs` instances in type expressions"
+                )),
                 Some(KnownClass::TypeVarTuple) => Ok(todo_type!(
                     "Support for `typing.TypeVarTuple` instances in type expressions"
                 )),

--- a/crates/red_knot_python_semantic/src/types/class.rs
+++ b/crates/red_knot_python_semantic/src/types/class.rs
@@ -844,6 +844,8 @@ pub enum KnownClass {
     SpecialForm,
     TypeVar,
     ParamSpec,
+    ParamSpecArgs,
+    ParamSpecKwargs,
     TypeVarTuple,
     TypeAliasType,
     NoDefaultType,
@@ -893,6 +895,8 @@ impl<'db> KnownClass {
             | Self::TypeAliasType
             | Self::TypeVar
             | Self::ParamSpec
+            | Self::ParamSpecArgs
+            | Self::ParamSpecKwargs
             | Self::TypeVarTuple
             | Self::WrapperDescriptorType
             | Self::MethodWrapperType => Truthiness::AlwaysTrue,
@@ -969,6 +973,8 @@ impl<'db> KnownClass {
             Self::SpecialForm => "_SpecialForm",
             Self::TypeVar => "TypeVar",
             Self::ParamSpec => "ParamSpec",
+            Self::ParamSpecArgs => "ParamSpecArgs",
+            Self::ParamSpecKwargs => "ParamSpecKwargs",
             Self::TypeVarTuple => "TypeVarTuple",
             Self::TypeAliasType => "TypeAliasType",
             Self::NoDefaultType => "_NoDefaultType",
@@ -1149,9 +1155,12 @@ impl<'db> KnownClass {
             | Self::StdlibAlias
             | Self::SupportsIndex
             | Self::Sized => KnownModule::Typing,
-            Self::TypeAliasType | Self::TypeVarTuple | Self::ParamSpec | Self::NewType => {
-                KnownModule::TypingExtensions
-            }
+            Self::TypeAliasType
+            | Self::TypeVarTuple
+            | Self::ParamSpec
+            | Self::ParamSpecArgs
+            | Self::ParamSpecKwargs
+            | Self::NewType => KnownModule::TypingExtensions,
             Self::NoDefaultType => {
                 let python_version = Program::get(db).python_version(db);
 
@@ -1227,6 +1236,8 @@ impl<'db> KnownClass {
             | Self::StdlibAlias
             | Self::TypeVar
             | Self::ParamSpec
+            | Self::ParamSpecArgs
+            | Self::ParamSpecKwargs
             | Self::TypeVarTuple
             | Self::Sized
             | Self::Enum
@@ -1282,6 +1293,8 @@ impl<'db> KnownClass {
             | Self::Classmethod
             | Self::TypeVar
             | Self::ParamSpec
+            | Self::ParamSpecArgs
+            | Self::ParamSpecKwargs
             | Self::TypeVarTuple
             | Self::Sized
             | Self::Enum
@@ -1328,6 +1341,8 @@ impl<'db> KnownClass {
             "TypeAliasType" => Self::TypeAliasType,
             "TypeVar" => Self::TypeVar,
             "ParamSpec" => Self::ParamSpec,
+            "ParamSpecArgs" => Self::ParamSpecArgs,
+            "ParamSpecKwargs" => Self::ParamSpecKwargs,
             "TypeVarTuple" => Self::TypeVarTuple,
             "ChainMap" => Self::ChainMap,
             "Counter" => Self::Counter,
@@ -1405,6 +1420,8 @@ impl<'db> KnownClass {
             | Self::NoDefaultType
             | Self::SupportsIndex
             | Self::ParamSpec
+            | Self::ParamSpecArgs
+            | Self::ParamSpecKwargs
             | Self::TypeVarTuple
             | Self::Sized
             | Self::NewType => matches!(module, KnownModule::Typing | KnownModule::TypingExtensions),


### PR DESCRIPTION
## Summary

In preparation for #17017, where we will need them to suppress new false positives (once we understand the `ParamSpec.args`/`ParamSpec.kwargs` properties).

## Test Plan

Tested on branch #17017