### PR TITLE
[`pycodestyle`] Auto-fix redundant boolean comparison (`E712`)

### DIFF
--- a/crates/ruff_linter/src/rules/pycodestyle/rules/literal_comparisons.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/literal_comparisons.rs
@@ -3,7 +3,7 @@ use rustc_hash::FxHashMap;
 
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, ViolationMetadata};
-use ruff_python_ast::helpers::{self, generate_comparison, is_redundant_boolean_comparison};
+use ruff_python_ast::helpers::{self, generate_comparison};
 use ruff_python_ast::{self as ast, CmpOp, Expr};
 use ruff_text_size::Ranged;
 
@@ -167,6 +167,15 @@ impl AlwaysFixableViolation for TrueFalseComparison {
             (false, EqCmpOp::Eq) => format!("Replace with `not {cond}`"),
             (false, EqCmpOp::NotEq) => format!("Replace with `{cond}`"),
         }
+    }
+}
+
+fn is_redundant_boolean_comparison(op: CmpOp, comparator: &Expr) -> Option<bool> {
+    let value = comparator.as_boolean_literal_expr()?.value;
+    match op {
+        CmpOp::Is | CmpOp::Eq => Some(value),
+        CmpOp::IsNot | CmpOp::NotEq => Some(!value),
+        _ => None,
     }
 }
 

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/literal_comparisons.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/literal_comparisons.rs
@@ -368,19 +368,15 @@ pub(crate) fn literal_comparisons(checker: &Checker, compare: &ast::ExprCompare)
                     let needs_wrap = compare.left.range().start() != compare.range().start();
                     maybe_wrap(result, needs_wrap)
                 } else if let Some(kind) = is_redundant_boolean_comparison(*op, comparator) {
-                    let left_range = parenthesized_range(
-                        ExprRef::from(compare.left.as_ref()),
-                        compare.into(),
+                    let needs_wrap = comparator.range().end() != compare.range().end();
+                    generate_redundant_comparison(
+                        compare,
                         comment_ranges,
                         source,
+                        &compare.left,
+                        kind,
+                        needs_wrap,
                     )
-                    .unwrap_or(compare.left.range());
-
-                    let left_str = &source[left_range];
-                    let result = build_conditional_string(left_str, kind);
-
-                    let needs_wrap = comparator.range().end() != compare.range().end();
-                    maybe_wrap(result, needs_wrap)
                 } else {
                     generate_comparison(
                         &compare.left,

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/literal_comparisons.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/literal_comparisons.rs
@@ -3,7 +3,7 @@ use rustc_hash::FxHashMap;
 
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, ViolationMetadata};
-use ruff_python_ast::helpers::{self, is_redundant_boolean_comparison, generate_comparison};
+use ruff_python_ast::helpers::{self, generate_comparison, is_redundant_boolean_comparison};
 use ruff_python_ast::{self as ast, CmpOp, Expr, ExprRef};
 use ruff_text_size::Ranged;
 
@@ -169,7 +169,6 @@ impl AlwaysFixableViolation for TrueFalseComparison {
         }
     }
 }
-
 
 fn build_conditional_string(source_slice: &str, kind: bool) -> String {
     if kind {
@@ -362,10 +361,10 @@ pub(crate) fn literal_comparisons(checker: &Checker, compare: &ast::ExprCompare)
                         source,
                     )
                     .unwrap_or(comparator.range());
-        
+
                     let comparator_str = &source[comparator_range];
                     let result = build_conditional_string(comparator_str, kind);
-        
+
                     let needs_wrap = compare.left.range().start() != compare.range().start();
                     maybe_wrap(result, needs_wrap)
                 } else if let Some(kind) = is_redundant_boolean_comparison(*op, comparator) {
@@ -376,10 +375,10 @@ pub(crate) fn literal_comparisons(checker: &Checker, compare: &ast::ExprCompare)
                         source,
                     )
                     .unwrap_or(compare.left.range());
-        
+
                     let left_str = &source[left_range];
                     let result = build_conditional_string(left_str, kind);
-        
+
                     let needs_wrap = comparator.range().end() != compare.range().end();
                     maybe_wrap(result, needs_wrap)
                 } else {

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/literal_comparisons.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/literal_comparisons.rs
@@ -353,7 +353,7 @@ pub(crate) fn literal_comparisons(checker: &Checker, compare: &ast::ExprCompare)
                         format!("not {comparator_str}")
                     };
 
-                    // NOTE: Adding paranthesis if left is boolean and enclosed in parentheses
+                    // NOTE: Adding parenthesis if left is boolean and enclosed in parentheses
                     if compare.left.range().start() == compare.range().start() {
                         content
                     } else {

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E712_E712.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E712_E712.py.snap
@@ -14,7 +14,7 @@ E712.py:2:4: E712 [*] Avoid equality comparisons to `True`; use `if res:` for tr
 ℹ Unsafe fix
 1 1 | #: E712
 2   |-if res == True:
-  2 |+if res is True:
+  2 |+if res:
 3 3 |     pass
 4 4 | #: E712
 5 5 | if res != False:
@@ -35,7 +35,7 @@ E712.py:5:4: E712 [*] Avoid inequality comparisons to `False`; use `if res:` for
 3 3 |     pass
 4 4 | #: E712
 5   |-if res != False:
-  5 |+if res is not False:
+  5 |+if res:
 6 6 |     pass
 7 7 | #: E712
 8 8 | if True != res:
@@ -98,7 +98,7 @@ E712.py:14:4: E712 [*] Avoid equality comparisons to `True`; use `if res[1]:` fo
 12 12 |     pass
 13 13 | #: E712
 14    |-if res[1] == True:
-   14 |+if res[1] is True:
+   14 |+if res[1]:
 15 15 |     pass
 16 16 | #: E712
 17 17 | if res[1] != False:
@@ -119,7 +119,7 @@ E712.py:17:4: E712 [*] Avoid inequality comparisons to `False`; use `if res[1]:`
 15 15 |     pass
 16 16 | #: E712
 17    |-if res[1] != False:
-   17 |+if res[1] is not False:
+   17 |+if res[1]:
 18 18 |     pass
 19 19 | #: E712
 20 20 | var = 1 if cond == True else -1 if cond == False else cond
@@ -140,7 +140,7 @@ E712.py:20:12: E712 [*] Avoid equality comparisons to `True`; use `if cond:` for
 18 18 |     pass
 19 19 | #: E712
 20    |-var = 1 if cond == True else -1 if cond == False else cond
-   20 |+var = 1 if cond is True else -1 if cond == False else cond
+   20 |+var = 1 if cond else -1 if cond == False else cond
 21 21 | #: E712
 22 22 | if (True) == TrueElement or x == TrueElement:
 23 23 |     pass
@@ -161,7 +161,7 @@ E712.py:20:36: E712 [*] Avoid equality comparisons to `False`; use `if not cond:
 18 18 |     pass
 19 19 | #: E712
 20    |-var = 1 if cond == True else -1 if cond == False else cond
-   20 |+var = 1 if cond == True else -1 if cond is False else cond
+   20 |+var = 1 if cond == True else -1 if not cond else cond
 21 21 | #: E712
 22 22 | if (True) == TrueElement or x == TrueElement:
 23 23 |     pass
@@ -261,7 +261,7 @@ E712.py:31:4: E712 [*] Avoid equality comparisons to `True`; use `if yield i:` f
 29 29 |     pass
 30 30 | 
 31    |-if (yield i) == True:
-   31 |+if (yield i) is True:
+   31 |+if (yield i):
 32 32 |       print("even")
 33 33 | 
 34 34 | #: Okay

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E712_E712.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E712_E712.py.snap
@@ -56,7 +56,7 @@ E712.py:8:4: E712 [*] Avoid inequality comparisons to `True`; use `if not res:` 
 6 6 |     pass
 7 7 | #: E712
 8   |-if True != res:
-  8 |+if True is not res:
+  8 |+if not res:
 9 9 |     pass
 10 10 | #: E712
 11 11 | if False == res:
@@ -77,7 +77,7 @@ E712.py:11:4: E712 [*] Avoid equality comparisons to `False`; use `if not res:` 
 9  9  |     pass
 10 10 | #: E712
 11    |-if False == res:
-   11 |+if False is res:
+   11 |+if not res:
 12 12 |     pass
 13 13 | #: E712
 14 14 | if res[1] == True:
@@ -181,7 +181,7 @@ E712.py:22:4: E712 [*] Avoid equality comparisons to `True`; use `if TrueElement
 20 20 | var = 1 if cond == True else -1 if cond == False else cond
 21 21 | #: E712
 22    |-if (True) == TrueElement or x == TrueElement:
-   22 |+if (True) is TrueElement or x == TrueElement:
+   22 |+if (TrueElement) or x == TrueElement:
 23 23 |     pass
 24 24 | 
 25 25 | if res == True != False:
@@ -241,7 +241,7 @@ E712.py:28:3: E712 [*] Avoid equality comparisons to `True`; use `if TrueElement
 26 26 |     pass
 27 27 | 
 28    |-if(True) == TrueElement or x == TrueElement:
-   28 |+if(True) is TrueElement or x == TrueElement:
+   28 |+if(TrueElement) or x == TrueElement:
 29 29 |     pass
 30 30 | 
 31 31 | if (yield i) == True:

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__constant_literals.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__constant_literals.snap
@@ -122,7 +122,7 @@ constant_literals.py:14:4: E712 [*] Avoid equality comparisons to `False`; use `
 12 12 | if False is "abc":  # F632 (fix, but leaves behind unfixable E712)
 13 13 |     pass
 14    |-if False == None:  # E711, E712 (fix)
-   14 |+if False is None:  # E711, E712 (fix)
+   14 |+if not None:  # E711, E712 (fix)
 15 15 |     pass
 16 16 | if None == False:  # E711, E712 (fix)
 17 17 |     pass
@@ -143,7 +143,7 @@ constant_literals.py:14:13: E711 [*] Comparison to `None` should be `cond is Non
 12 12 | if False is "abc":  # F632 (fix, but leaves behind unfixable E712)
 13 13 |     pass
 14    |-if False == None:  # E711, E712 (fix)
-   14 |+if False is None:  # E711, E712 (fix)
+   14 |+if not None:  # E711, E712 (fix)
 15 15 |     pass
 16 16 | if None == False:  # E711, E712 (fix)
 17 17 |     pass

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__constant_literals.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__constant_literals.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
-snapshot_kind: text
 ---
 constant_literals.py:4:4: F632 [*] Use `==` to compare constant literals
   |
@@ -164,7 +163,7 @@ constant_literals.py:16:4: E711 [*] Comparison to `None` should be `cond is None
 14 14 | if False == None:  # E711, E712 (fix)
 15 15 |     pass
 16    |-if None == False:  # E711, E712 (fix)
-   16 |+if None is False:  # E711, E712 (fix)
+   16 |+if not None:  # E711, E712 (fix)
 17 17 |     pass
 18 18 | 
 19 19 | named_var = []
@@ -184,7 +183,7 @@ constant_literals.py:16:4: E712 [*] Avoid equality comparisons to `False`; use `
 14 14 | if False == None:  # E711, E712 (fix)
 15 15 |     pass
 16    |-if None == False:  # E711, E712 (fix)
-   16 |+if None is False:  # E711, E712 (fix)
+   16 |+if not None:  # E711, E712 (fix)
 17 17 |     pass
 18 18 | 
 19 19 | named_var = []

--- a/crates/ruff_python_ast/src/helpers.rs
+++ b/crates/ruff_python_ast/src/helpers.rs
@@ -1355,11 +1355,11 @@ fn is_empty_f_string(expr: &ast::ExprFString) -> bool {
     })
 }
 
-fn is_redundant_boolean_comparison(op: CmpOp, comparator: &Expr) -> Option<bool> {
+pub fn is_redundant_boolean_comparison(op: CmpOp, comparator: &Expr) -> Option<bool> {
     let value = comparator.as_boolean_literal_expr()?.value;
     match op {
-        CmpOp::Is => Some(value),
-        CmpOp::IsNot => Some(!value),
+        CmpOp::Is | CmpOp::Eq => Some(value),
+        CmpOp::IsNot | CmpOp::NotEq => Some(!value),
         _ => None,
     }
 }
@@ -1381,16 +1381,6 @@ pub fn generate_comparison(
         &source[parenthesized_range(left.into(), parent, comment_ranges, source)
             .unwrap_or(left.range())],
     );
-
-    if let ([op], [comparator]) = (ops, comparators) {
-        if let Some(kind) = is_redundant_boolean_comparison(*op, comparator) {
-            return if kind {
-                contents
-            } else {
-                format!("not {contents}")
-            };
-        }
-    }
 
     for (op, comparator) in ops.iter().zip(comparators) {
         // Add the operator.

--- a/crates/ruff_python_ast/src/helpers.rs
+++ b/crates/ruff_python_ast/src/helpers.rs
@@ -1355,15 +1355,6 @@ fn is_empty_f_string(expr: &ast::ExprFString) -> bool {
     })
 }
 
-pub fn is_redundant_boolean_comparison(op: CmpOp, comparator: &Expr) -> Option<bool> {
-    let value = comparator.as_boolean_literal_expr()?.value;
-    match op {
-        CmpOp::Is | CmpOp::Eq => Some(value),
-        CmpOp::IsNot | CmpOp::NotEq => Some(!value),
-        _ => None,
-    }
-}
-
 pub fn generate_comparison(
     left: &Expr,
     ops: &[CmpOp],


### PR DESCRIPTION
This pull request fixes https://github.com/astral-sh/ruff/issues/17014

changes this
```python
from __future__ import annotations

flag1 = True
flag2 = True

if flag1 == True or flag2 == True:
    pass

if flag1 == False and flag2 == False:
    pass

flag3 = True
if flag1 == flag3 and (flag2 == False or flag3 == True):  # Should become: if flag1==flag3 and (not flag2 or flag3)
    pass

if flag1 == True and (flag2 == False or not flag3 == True):  # Should become: if flag1 and (not flag2 or not flag3)
    pass

if flag1 != True and (flag2 != False or not flag3 == True):  # Should become: if not flag1 and (flag2 or not flag3)
    pass


flag = True
while flag == True:  # Should become: while flag
    flag = False

flag = True
x = 5
if flag == True and x > 0:  # Should become: if flag and x > 0
    print("ok")

flag = True
result = "yes" if flag == True else "no"  # Should become: result = "yes" if flag else "no"

x = flag == True < 5

x = (flag == True) == False < 5
```

to this 
```python
from __future__ import annotations

flag1 = True
flag2 = True

if flag1 or flag2:
    pass

if not flag1 and not flag2:
    pass

flag3 = True
if flag1 == flag3 and (not flag2 or flag3):  # Should become: if flag1 == flag3 and (not flag2 or flag3)
    pass

if flag1 and (not flag2 or not flag3):  # Should become: if flag1 and (not flag2 or not flag3)
    pass

if not flag1 and (flag2 or not flag3):  # Should become: if not flag1 and (flag2 or not flag3)
    pass


flag = True
while flag:  # Should become: while flag
    flag = False

flag = True
x = 5
if flag and x > 0:  # Should become: if flag and x > 0
    print("ok")

flag = True
result = "yes" if flag else "no"  # Should become: result = "yes" if flag else "no"

x = flag is True < 5

x = (flag) is False < 5
```
