### PR TITLE
Use pre-commit-uv in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -659,7 +659,7 @@ jobs:
           echo '```console' > "$GITHUB_STEP_SUMMARY"
           # Enable color output for pre-commit and remove it for the summary
           # Use --hook-stage=manual to enable slower pre-commit hooks that are skipped by default
-          SKIP=cargo-fmt,clippy,dev-generate-all uvx --python="${PYTHON_VERSION}" pre-commit run --all-files --show-diff-on-failure --color=always --hook-stage=manual | \
+          SKIP=cargo-fmt,clippy,dev-generate-all uvx --python="${PYTHON_VERSION}" --with=pre-commit-uv pre-commit run --all-files --show-diff-on-failure --color=always --hook-stage=manual | \
             tee >(sed -E 's/\x1B\[([0-9]{1,2}(;[0-9]{1,2})*)?[mGK]//g' >> "$GITHUB_STEP_SUMMARY") >&1
           exit_code="${PIPESTATUS[0]}"
           echo '```' >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Follows up on #17052 to add in [pre-commit-uv](https://pypi.org/project/pre-commit-uv/), which patches `pre-commit` to use `uv` for venv creation as well.

More dogfooding! More speed! 😄 

> [!NOTE]
> I suspect caching could be removed from the `pre-commit` CI step with this... 

## Test Plan

> How was it tested? 

We're about to find out...