### PR TITLE
[red-knot] Disjointness for callable types

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/tuple.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/tuple.md
@@ -8,7 +8,6 @@ that a tuple type containing `Never` is disjoint from any other tuple type.
 ```py
 from typing_extensions import Never
 
-
 def _(x: tuple[Never], y: tuple[int, Never], z: tuple[Never, int]):
     reveal_type(x)  # revealed: Never
     reveal_type(y)  # revealed: Never

--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/tuple.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/tuple.md
@@ -1,0 +1,16 @@
+# Tuple
+
+## `Never`
+
+If a tuple type contains a `Never` element, then it is eagerly simplified to `Never` which means
+that a tuple type containing `Never` is disjoint from any other tuple type.
+
+```py
+from typing_extensions import Never
+
+
+def _(x: tuple[Never], y: tuple[int, Never], z: tuple[Never, int]):
+    reveal_type(x)  # revealed: Never
+    reveal_type(y)  # revealed: Never
+    reveal_type(z)  # revealed: Never
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
@@ -358,8 +358,8 @@ static_assert(is_disjoint_from(type[UsesMeta1], type[UsesMeta2]))
 
 No two callable types are disjoint because there exists a non-empty callable type
 `(*args: object, **kwargs: object) -> Never` that is a subtype of all fully static callable types.
-As such, for any two callable types, it is possible to conceive of a runtime callable object that would
-inhabit both types simultaneously.
+As such, for any two callable types, it is possible to conceive of a runtime callable object that
+would inhabit both types simultaneously.
 
 ```py
 from knot_extensions import CallableTypeOf, is_disjoint_from, static_assert


### PR DESCRIPTION
## Summary

Part of #15382, this PR adds support for disjointness between two callable types. They are never disjoint because there exists a callable type that's a subtype of all other callable types:
```py
(*args: object, **kwargs: object) -> Never
```

The `Never` is a subtype of every fully static type thus a callable type that has the return type of `Never` means that it is a subtype of every return type.

## Test Plan

Add test cases related to mixed parameter kinds, gradual form (`...`) and `Never` type.
