### PR TITLE
[red-knot] Change venv discovery

### DIFF
--- a/crates/red_knot_project/src/metadata/options.rs
+++ b/crates/red_knot_project/src/metadata/options.rs
@@ -121,7 +121,7 @@ impl Options {
                         .ok()
                         .map(PythonPath::from_virtual_env_var)
                 })
-                .unwrap_or(PythonPath::Discover),
+                .unwrap_or_else(|| PythonPath::Discover(project_root.to_path_buf())),
         }
     }
 

--- a/crates/red_knot_python_semantic/src/program.rs
+++ b/crates/red_knot_python_semantic/src/program.rs
@@ -145,7 +145,8 @@ pub enum PythonPath {
     /// [`sys.prefix`]: https://docs.python.org/3/library/sys.html#sys.prefix
     SysPrefix(SystemPathBuf, SysPrefixPathOrigin),
 
-    Discover,
+    /// Tries to discover a virtual environment in the given path.
+    Discover(SystemPathBuf),
 
     /// Resolved site packages paths.
     ///


### PR DESCRIPTION
## Summary

Rewrites the virtual env discovery to:

* Only use of `System` APIs, this ensures that the discovery will also work when using a memory file system (testing or WASM)
* Don't traverse ancestor directories. We're not convinced that this is necessary. Let's wait until someone shows us a use case where it is needed
* Start from the project root and not from the current working directory. This ensures that Red Knot picks up the right venv even when using `knot --project ../other-dir` 

## Test Plan

Existing tests, @ntBre tested that the `file_watching` tests no longer pick up his virtual env in a parent directory
