### PR TITLE
[red-knot] Add redundant-cast error

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/directives/cast.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/directives/cast.md
@@ -25,4 +25,8 @@ reveal_type(cast(1, True))  # revealed: Unknown
 cast(str)
 # error: [too-many-positional-arguments] "Too many positional arguments to function `cast`: expected 2, got 3"
 cast(str, b"ar", "foo")
+
+a: int = 10
+# error: [redundant-cast] "Value is already of type `int`"
+cast(int, a)
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/directives/cast.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/directives/cast.md
@@ -5,7 +5,7 @@
 The (inferred) type of the value and the given type do not need to have any correlation.
 
 ```py
-from typing import Literal, cast
+from typing import Literal, cast, Any
 
 reveal_type(True)  # revealed: Literal[True]
 reveal_type(cast(str, True))  # revealed: str
@@ -31,4 +31,10 @@ def f() -> int:
   return 10
 # error: [redundant-cast] "Value is already of type `int`"
 cast(int, f())
+
+def function_returning_any() -> Any:
+  return 10
+
+# error: [redundant-cast] "Value is already of type `Any`"
+cast(Any, function_returning_any())
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/directives/cast.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/directives/cast.md
@@ -27,11 +27,15 @@ cast(str)
 cast(str, b"ar", "foo")
 
 
-def function_returning_int() -> int: return 10
+def function_returning_int() -> int:
+    return 10
+
 # error: [redundant-cast] "Value is already of type `int`"
 cast(int, function_returning_int())
 
-def function_returning_any() -> Any: return "blah"
+def function_returning_any() -> Any:
+    return "blah"
+
 # error: [redundant-cast] "Value is already of type `Any`"
 cast(Any, function_returning_any())
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/directives/cast.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/directives/cast.md
@@ -26,7 +26,6 @@ cast(str)
 # error: [too-many-positional-arguments] "Too many positional arguments to function `cast`: expected 2, got 3"
 cast(str, b"ar", "foo")
 
-
 def function_returning_int() -> int:
     return 10
 

--- a/crates/red_knot_python_semantic/resources/mdtest/directives/cast.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/directives/cast.md
@@ -26,7 +26,9 @@ cast(str)
 # error: [too-many-positional-arguments] "Too many positional arguments to function `cast`: expected 2, got 3"
 cast(str, b"ar", "foo")
 
-a: int = 10
+
+def f() -> int:
+  return 10
 # error: [redundant-cast] "Value is already of type `int`"
-cast(int, a)
+cast(int, f())
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/directives/cast.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/directives/cast.md
@@ -27,14 +27,11 @@ cast(str)
 cast(str, b"ar", "foo")
 
 
-def f() -> int:
-  return 10
+def function_returning_int() -> int: return 10
 # error: [redundant-cast] "Value is already of type `int`"
-cast(int, f())
+cast(int, function_returning_int())
 
-def function_returning_any() -> Any:
-  return 10
-
+def function_returning_any() -> Any: return "blah"
 # error: [redundant-cast] "Value is already of type `Any`"
 cast(Any, function_returning_any())
 ```

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -320,6 +320,14 @@ impl<'db> Type<'db> {
         matches!(self, Type::Dynamic(DynamicType::Todo(_)))
     }
 
+    pub fn contains_todo(&self, db: &'db dyn Db) -> bool {
+        if let Type::Union(union) = self {
+            union.elements(db).iter().any(Type::is_todo)
+        } else {
+            false
+        }
+    }
+
     pub const fn class_literal(class: Class<'db>) -> Self {
         Self::ClassLiteral(ClassLiteralType { class })
     }

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -321,11 +321,8 @@ impl<'db> Type<'db> {
     }
 
     pub fn contains_todo(&self, db: &'db dyn Db) -> bool {
-        if let Type::Union(union) = self {
-            union.elements(db).iter().any(Type::is_todo)
-        } else {
-            false
-        }
+        self.is_todo()
+            || matches!(self, Type::Union(union) if union.elements(db).iter().any(Type::is_todo))
     }
 
     pub const fn class_literal(class: Class<'db>) -> Self {

--- a/crates/red_knot_python_semantic/src/types/call/bind.rs
+++ b/crates/red_knot_python_semantic/src/types/call/bind.rs
@@ -398,7 +398,7 @@ impl<'db> Bindings<'db> {
                         let mut redundant_cast_error = None;
 
                         if let [Some(casted_ty), Some(source_ty)] = overload.parameter_types() {
-                            if source_ty.is_equivalent_to(db, *casted_ty) {
+                            if source_ty.is_gradual_equivalent_to(db, *casted_ty) {
                                 redundant_cast_error =
                                     Some(BindingError::RedundantCast { ty: *casted_ty });
                             }

--- a/crates/red_knot_python_semantic/src/types/call/bind.rs
+++ b/crates/red_knot_python_semantic/src/types/call/bind.rs
@@ -13,8 +13,8 @@ use crate::db::Db;
 use crate::symbol::{Boundness, Symbol};
 use crate::types::diagnostic::{
     CALL_NON_CALLABLE, CONFLICTING_ARGUMENT_FORMS, INVALID_ARGUMENT_TYPE, MISSING_ARGUMENT,
-    NO_MATCHING_OVERLOAD, PARAMETER_ALREADY_ASSIGNED, REDUNDANT_CAST,
-    TOO_MANY_POSITIONAL_ARGUMENTS, UNKNOWN_ARGUMENT,
+    NO_MATCHING_OVERLOAD, PARAMETER_ALREADY_ASSIGNED, TOO_MANY_POSITIONAL_ARGUMENTS,
+    UNKNOWN_ARGUMENT,
 };
 use crate::types::signatures::{Parameter, ParameterForm};
 use crate::types::{
@@ -395,18 +395,8 @@ impl<'db> Bindings<'db> {
                     }
 
                     Some(KnownFunction::Cast) => {
-                        let mut redundant_cast_error = None;
-
-                        if let [Some(casted_ty), Some(source_ty)] = overload.parameter_types() {
-                            if source_ty.is_gradual_equivalent_to(db, *casted_ty) {
-                                redundant_cast_error =
-                                    Some(BindingError::RedundantCast { ty: *casted_ty });
-                            }
+                        if let [Some(casted_ty), Some(_)] = overload.parameter_types() {
                             overload.set_return_type(*casted_ty);
-                        }
-
-                        if let Some(error) = redundant_cast_error {
-                            overload.errors.push(error);
                         }
                     }
 
@@ -1045,8 +1035,6 @@ pub(crate) enum BindingError<'db> {
         argument_index: Option<usize>,
         parameter: ParameterContext,
     },
-    /// A `cast` to this type is redundant because the argument already has this type.
-    RedundantCast { ty: Type<'db> },
 }
 
 impl<'db> BindingError<'db> {
@@ -1195,14 +1183,6 @@ impl<'db> BindingError<'db> {
                             String::new()
                         }
                     ),
-                );
-            }
-
-            Self::RedundantCast { ty } => {
-                context.report_lint(
-                    &REDUNDANT_CAST,
-                    Self::get_node(node, Some(1)),
-                    format_args!("Value is already of type `{}`", ty.display(context.db()),),
                 );
             }
         }

--- a/crates/red_knot_python_semantic/src/types/diagnostic.rs
+++ b/crates/red_knot_python_semantic/src/types/diagnostic.rs
@@ -888,12 +888,15 @@ declare_lint! {
     ///
     /// ## Example
     /// ```python
-    /// cast(int, 1)  # Redundant
+    /// def f() -> int:
+    ///     return 10
+    ///
+    /// cast(int, f())  # Redundant
     /// ```
     pub(crate) static REDUNDANT_CAST = {
         summary: "detects redundant `cast` calls",
         status: LintStatus::preview("1.0.0"),
-        default_level: Level::Error,
+        default_level: Level::Warn,
     }
 }
 

--- a/crates/red_knot_python_semantic/src/types/diagnostic.rs
+++ b/crates/red_knot_python_semantic/src/types/diagnostic.rs
@@ -67,6 +67,7 @@ pub(crate) fn register_lints(registry: &mut LintRegistryBuilder) {
     registry.register_lint(&ZERO_STEPSIZE_IN_SLICE);
     registry.register_lint(&STATIC_ASSERT_ERROR);
     registry.register_lint(&INVALID_ATTRIBUTE_ACCESS);
+    registry.register_lint(&REDUNDANT_CAST);
 
     // String annotations
     registry.register_lint(&BYTE_STRING_TYPE_ANNOTATION);
@@ -873,6 +874,24 @@ declare_lint! {
     /// ```
     pub(crate) static INVALID_ATTRIBUTE_ACCESS = {
         summary: "Invalid attribute access",
+        status: LintStatus::preview("1.0.0"),
+        default_level: Level::Error,
+    }
+}
+
+declare_lint! {
+    /// ## What it does
+    /// Detects redundant `cast` calls where the value already has the target type.
+    ///
+    /// ## Why is this bad?
+    /// These casts have no effect and can be removed.
+    ///
+    /// ## Example
+    /// ```python
+    /// cast(int, 1)  # Redundant
+    /// ```
+    pub(crate) static REDUNDANT_CAST = {
+        summary: "detects redundant `cast` calls",
         status: LintStatus::preview("1.0.0"),
         default_level: Level::Error,
     }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -4019,7 +4019,8 @@ impl<'db> TypeInferenceBuilder<'db> {
                         }
                         KnownFunction::Cast => {
                             if let [Some(casted_ty), Some(source_ty)] = overload.parameter_types() {
-                                if source_ty.is_gradual_equivalent_to(self.context.db(), *casted_ty) {
+                                if source_ty.is_gradual_equivalent_to(self.context.db(), *casted_ty)
+                                {
                                     self.context.report_lint(
                                         &REDUNDANT_CAST,
                                         call_expression,

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -4020,7 +4020,6 @@ impl<'db> TypeInferenceBuilder<'db> {
                         KnownFunction::Cast => {
                             if let [Some(casted_ty), Some(source_ty)] = overload.parameter_types() {
                                 if source_ty.is_gradual_equivalent_to(self.context.db(), *casted_ty)
-                                    && !source_ty.is_todo()
                                     && !source_ty.contains_todo(self.context.db())
                                 {
                                     self.context.report_lint(

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -4020,6 +4020,8 @@ impl<'db> TypeInferenceBuilder<'db> {
                         KnownFunction::Cast => {
                             if let [Some(casted_ty), Some(source_ty)] = overload.parameter_types() {
                                 if source_ty.is_gradual_equivalent_to(self.context.db(), *casted_ty)
+                                    && !source_ty.is_todo()
+                                    && !source_ty.contains_todo(self.context.db())
                                 {
                                     self.context.report_lint(
                                         &REDUNDANT_CAST,

--- a/knot.schema.json
+++ b/knot.schema.json
@@ -610,6 +610,16 @@
             }
           ]
         },
+        "redundant-cast": {
+          "title": "detects redundant `cast` calls",
+          "description": "## What it does\nDetects redundant `cast` calls where the value already has the target type.\n\n## Why is this bad?\nThese casts have no effect and can be removed.\n\n## Example\n```python\ncast(int, 1)  # Redundant\n```",
+          "default": "error",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Level"
+            }
+          ]
+        },
         "static-assert-error": {
           "title": "Failed static assertion",
           "description": "## What it does\nMakes sure that the argument of `static_assert` is statically known to be true.\n\n## Examples\n```python\nfrom knot_extensions import static_assert\n\nstatic_assert(1 + 1 == 3)  # error: evaluates to `False`\n\nstatic_assert(int(2.0 * 3.0) == 6)  # error: does not have a statically known truthiness\n```",

--- a/knot.schema.json
+++ b/knot.schema.json
@@ -612,8 +612,8 @@
         },
         "redundant-cast": {
           "title": "detects redundant `cast` calls",
-          "description": "## What it does\nDetects redundant `cast` calls where the value already has the target type.\n\n## Why is this bad?\nThese casts have no effect and can be removed.\n\n## Example\n```python\ncast(int, 1)  # Redundant\n```",
-          "default": "error",
+          "description": "## What it does\nDetects redundant `cast` calls where the value already has the target type.\n\n## Why is this bad?\nThese casts have no effect and can be removed.\n\n## Example\n```python\ndef f() -> int:\n    return 10\n\ncast(int, f())  # Redundant\n```",
+          "default": "warn",
           "oneOf": [
             {
               "$ref": "#/definitions/Level"


### PR DESCRIPTION
## Summary

Following up from earlier discussion on Discord, this PR adds logic to flag casts as redundant when the inferred type of the expression is the same as the target type. It should follow the semantics from [mypy](https://github.com/python/mypy/pull/1705).

Example:

```python
def f() -> int:
    return 10

# error: [redundant-cast] "Value is already of type `int`"
cast(int, f())
```

~However, I don't think the comparison is quite right yet...there's probably some type comparison behavior I'm misunderstanding. Hopefully it's close enough that the fix is straightforward.~
