### PR TITLE
CI: Use a native version of Shellcheck instead of WASI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,7 @@ env:
   RUSTUP_MAX_RETRIES: 10
   PACKAGE_NAME: ruff
   PYTHON_VERSION: "3.13"
+  SHELLCHECK_VERSION: "0.10.0"
 
 jobs:
   determine_changes:
@@ -654,6 +655,21 @@ jobs:
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+      - name: "Cache shellcheck"
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        with:
+          path: /usr/local/bin/shellcheck
+          key: shellcheck-${{ env.SHELLCHECK_VERSION }}
+      - name: "Install shellcheck"
+        run: |
+          test -f /usr/local/bin/shellcheck && exit 0  # already installed (e.g. from cache)
+          cd "$(mktemp -d)"
+          gh release download -R koalaman/shellcheck "v${{ env.SHELLCHECK_VERSION }}" -p '*linux.x86_64*'
+          tar --strip-components=1 -xJf "shellcheck-v${{ env.SHELLCHECK_VERSION }}.linux.x86_64.tar.xz"
+          cp shellcheck /usr/local/bin/shellcheck
+          shellcheck --version
+        env:
+          GH_TOKEN: ${{ github.token }} # required to use `gh release download`
       - name: "Run pre-commit"
         run: |
           echo '```console' > "$GITHUB_STEP_SUMMARY"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -115,11 +115,13 @@ repos:
         args:
           - "-ignore=SC2129" # ignorable stylistic lint from shellcheck
           - "-ignore=SC2016" # another shellcheck lint: seems to have false positives?
-        additional_dependencies:
-          # actionlint has a shellcheck integration which extracts shell scripts in `run:` steps from GitHub Actions
-          # and checks these with shellcheck. This is arguably its most useful feature,
-          # but the integration only works if shellcheck is installed
-          - "github.com/wasilibs/go-shellcheck/cmd/shellcheck@v0.10.0"
+        # actionlint has a shellcheck integration which extracts shell scripts in `run:` steps from GitHub Actions
+        # and checks these with shellcheck. This is arguably its most useful feature,
+        # but the integration only works if shellcheck is installed.
+        # The CI pipeline installs the native version of shellcheck; for maximum local coverage, ensure you do too.
+        # If you can't, you can uncomment the below to install a slow, WASI-based version of shellcheck.
+        # additional_dependencies:
+        # - "github.com/wasilibs/go-shellcheck/cmd/shellcheck@v0.10.0"
 
 ci:
   skip: [cargo-fmt, dev-generate-all]


### PR DESCRIPTION
## Summary

Refs https://github.com/astral-sh/ruff/pull/17092#issuecomment-2768137890, this switches the CI pipeline to use a native version of Shellcheck pulled from GitHub Releases instead of the WASI compilation.

cc @AlexWaygood 

## Test Plan

I tried this out in my fork of `ruff` (where it made a cold-cache `pre-commit` CI step faster than a hot-cache run), and we're probably about to find out how it works here in upstream land.