### PR TITLE
Visit `Identifier` node as part of the `SourceOrderVisitor`

### DIFF
--- a/crates/ruff_linter/src/rules/ruff/rules/suppression_comment_visitor.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/suppression_comment_visitor.rs
@@ -195,6 +195,10 @@ where
             }
         }
     }
+
+    fn visit_identifier(&mut self, _identifier: &'ast ruff_python_ast::Identifier) {
+        // Skip identifiers, matching the formatter comment extraction
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/crates/ruff_python_ast/src/visitor/source_order.rs
+++ b/crates/ruff_python_ast/src/visitor/source_order.rs
@@ -1,10 +1,10 @@
-use crate::AnyNodeRef;
 use crate::{
     Alias, Arguments, BoolOp, BytesLiteral, CmpOp, Comprehension, Decorator, ElifElseClause,
     ExceptHandler, Expr, FString, FStringElement, Keyword, MatchCase, Mod, Operator, Parameter,
     ParameterWithDefault, Parameters, Pattern, PatternArguments, PatternKeyword, Singleton, Stmt,
     StringLiteral, TypeParam, TypeParams, UnaryOp, WithItem,
 };
+use crate::{AnyNodeRef, Identifier};
 
 /// Visitor that traverses all nodes recursively in the order they appear in the source.
 ///
@@ -169,6 +169,11 @@ pub trait SourceOrderVisitor<'a> {
     #[inline]
     fn visit_bytes_literal(&mut self, bytes_literal: &'a BytesLiteral) {
         walk_bytes_literal(self, bytes_literal);
+    }
+
+    #[inline]
+    fn visit_identifier(&mut self, identifier: &'a Identifier) {
+        walk_identifier(self, identifier);
     }
 }
 
@@ -577,6 +582,18 @@ where
     let node = AnyNodeRef::from(alias);
     if visitor.enter_node(node).is_traverse() {
         alias.visit_source_order(visitor);
+    }
+    visitor.leave_node(node);
+}
+
+#[inline]
+pub fn walk_identifier<'a, V: SourceOrderVisitor<'a> + ?Sized>(
+    visitor: &mut V,
+    identifier: &'a Identifier,
+) {
+    let node = AnyNodeRef::from(identifier);
+    if visitor.enter_node(node).is_traverse() {
+        identifier.visit_source_order(visitor);
     }
     visitor.leave_node(node);
 }

--- a/crates/ruff_python_ast_integration_tests/tests/snapshots/source_order__class_type_parameters.snap
+++ b/crates/ruff_python_ast_integration_tests/tests/snapshots/source_order__class_type_parameters.snap
@@ -1,15 +1,19 @@
 ---
 source: crates/ruff_python_ast_integration_tests/tests/source_order.rs
 expression: trace
-snapshot_kind: text
 ---
 - ModModule
   - StmtClassDef
+    - Identifier
     - TypeParams
       - TypeParamTypeVar
+        - Identifier
         - ExprName
       - TypeParamTypeVar
+        - Identifier
       - TypeParamTypeVarTuple
+        - Identifier
       - TypeParamParamSpec
+        - Identifier
     - StmtExpr
       - ExprEllipsisLiteral

--- a/crates/ruff_python_ast_integration_tests/tests/snapshots/source_order__decorators.snap
+++ b/crates/ruff_python_ast_integration_tests/tests/snapshots/source_order__decorators.snap
@@ -1,15 +1,16 @@
 ---
 source: crates/ruff_python_ast_integration_tests/tests/source_order.rs
 expression: trace
-snapshot_kind: text
 ---
 - ModModule
   - StmtFunctionDef
     - Decorator
       - ExprName
+    - Identifier
     - Parameters
     - StmtPass
   - StmtClassDef
     - Decorator
       - ExprName
+    - Identifier
     - StmtPass

--- a/crates/ruff_python_ast_integration_tests/tests/snapshots/source_order__function_arguments.snap
+++ b/crates/ruff_python_ast_integration_tests/tests/snapshots/source_order__function_arguments.snap
@@ -1,26 +1,34 @@
 ---
 source: crates/ruff_python_ast_integration_tests/tests/source_order.rs
 expression: trace
-snapshot_kind: text
 ---
 - ModModule
   - StmtFunctionDef
+    - Identifier
     - Parameters
       - ParameterWithDefault
         - Parameter
+          - Identifier
       - ParameterWithDefault
         - Parameter
+          - Identifier
       - ParameterWithDefault
         - Parameter
+          - Identifier
       - ParameterWithDefault
         - Parameter
+          - Identifier
         - ExprNumberLiteral
       - Parameter
+        - Identifier
       - ParameterWithDefault
         - Parameter
+          - Identifier
         - ExprNumberLiteral
       - ParameterWithDefault
         - Parameter
+          - Identifier
         - ExprNumberLiteral
       - Parameter
+        - Identifier
     - StmtPass

--- a/crates/ruff_python_ast_integration_tests/tests/snapshots/source_order__function_positional_only_with_default.snap
+++ b/crates/ruff_python_ast_integration_tests/tests/snapshots/source_order__function_positional_only_with_default.snap
@@ -1,18 +1,22 @@
 ---
 source: crates/ruff_python_ast_integration_tests/tests/source_order.rs
 expression: trace
-snapshot_kind: text
 ---
 - ModModule
   - StmtFunctionDef
+    - Identifier
     - Parameters
       - ParameterWithDefault
         - Parameter
+          - Identifier
       - ParameterWithDefault
         - Parameter
+          - Identifier
         - ExprNumberLiteral
       - ParameterWithDefault
         - Parameter
+          - Identifier
         - ExprNumberLiteral
       - Parameter
+        - Identifier
     - StmtPass

--- a/crates/ruff_python_ast_integration_tests/tests/snapshots/source_order__function_type_parameters.snap
+++ b/crates/ruff_python_ast_integration_tests/tests/snapshots/source_order__function_type_parameters.snap
@@ -1,16 +1,20 @@
 ---
 source: crates/ruff_python_ast_integration_tests/tests/source_order.rs
 expression: trace
-snapshot_kind: text
 ---
 - ModModule
   - StmtFunctionDef
+    - Identifier
     - TypeParams
       - TypeParamTypeVar
+        - Identifier
         - ExprName
       - TypeParamTypeVar
+        - Identifier
       - TypeParamTypeVarTuple
+        - Identifier
       - TypeParamParamSpec
+        - Identifier
     - Parameters
     - StmtExpr
       - ExprEllipsisLiteral

--- a/crates/ruff_python_ast_integration_tests/tests/snapshots/source_order__type_aliases.snap
+++ b/crates/ruff_python_ast_integration_tests/tests/snapshots/source_order__type_aliases.snap
@@ -1,17 +1,20 @@
 ---
 source: crates/ruff_python_ast_integration_tests/tests/source_order.rs
 expression: trace
-snapshot_kind: text
 ---
 - ModModule
   - StmtTypeAlias
     - ExprName
     - TypeParams
       - TypeParamTypeVar
+        - Identifier
         - ExprName
       - TypeParamTypeVar
+        - Identifier
       - TypeParamTypeVarTuple
+        - Identifier
       - TypeParamParamSpec
+        - Identifier
     - ExprSubscript
       - ExprName
       - ExprName

--- a/crates/ruff_python_formatter/src/comments/visitor.rs
+++ b/crates/ruff_python_formatter/src/comments/visitor.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 use std::iter::Peekable;
 
 use ruff_formatter::{SourceCode, SourceCodeSlice};
-use ruff_python_ast::AnyNodeRef;
+use ruff_python_ast::{AnyNodeRef, Identifier};
 use ruff_python_ast::{Mod, Stmt};
 // The interface is designed to only export the members relevant for iterating nodes in
 // pre-order.
@@ -165,6 +165,10 @@ impl<'ast> SourceOrderVisitor<'ast> for CommentsVisitor<'ast, '_> {
                 }
             }
         }
+    }
+
+    fn visit_identifier(&mut self, _identifier: &'ast Identifier) {
+        // TODO: Visit and associate comments with identifiers
     }
 }
 


### PR DESCRIPTION
## Summary

I don't remember exactly when we made `Identifier` a node but it is now considered a node (it implements `AnyNodeRef`, it has a range). However, we never updated
the `SourceOrderVisitor` to visit identifiers because we never had a use case for it and visiting new nodes can change how the formatter associates comments (breaking change!). 
This PR updates the `SourceOrderVisitor` to visit identifiers and changes the formatter comment visitor to skip identifiers (updating the visitor might be desired because it could help simplifying some comment placement logic but this is out of scope for this PR). 

## Test Plan

Tests, updated snapshot tests
