### PR TITLE
[red-knot] Fix more `redundant-cast` false positives

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/directives/cast.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/directives/cast.md
@@ -45,6 +45,7 @@ diagnostics.
 ```py
 from typing import Callable
 
-def f(x: Callable[[dict[str, int]], None]):
-    y = cast(Callable[[list[bytes]], None], x)
+def f(x: Callable[[dict[str, int]], None], y: tuple[dict[str, int]]):
+    a = cast(Callable[[list[bytes]], None], x)
+    b = cast(tuple[list[bytes]], y)
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/directives/cast.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/directives/cast.md
@@ -39,7 +39,8 @@ def function_returning_any() -> Any:
 cast(Any, function_returning_any())
 ```
 
-Complex type expressions (which may be unsupported) do not lead to spurious `[redundant-cast]` diagnostics.
+Complex type expressions (which may be unsupported) do not lead to spurious `[redundant-cast]`
+diagnostics.
 
 ```py
 from typing import Callable

--- a/crates/red_knot_python_semantic/resources/mdtest/directives/cast.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/directives/cast.md
@@ -38,3 +38,12 @@ def function_returning_any() -> Any:
 # error: [redundant-cast] "Value is already of type `Any`"
 cast(Any, function_returning_any())
 ```
+
+Complex type expressions (which may be unsupported) do not lead to spurious `[redundant-cast]` diagnostics.
+
+```py
+from typing import Callable
+
+def f(x: Callable[[dict[str, int]], None]):
+    y = cast(Callable[[list[bytes]], None], x)
+```


### PR DESCRIPTION
## Summary

There are quite a few places we infer `Todo` types currently, and some of them are nested somewhat deeply in type expressions. These can cause spurious issues for the new `redundant-cast` diagnostics. We fixed all the false positives we saw in the mypy_primer report before merging https://github.com/astral-sh/ruff/pull/17100, but I think there are still lots of places where we'd emit false positives due to this check -- we currently don't run on that many projects at all in our mypy_primer check:

https://github.com/astral-sh/ruff/blob/d0c8eaa0923352ccc4ec30c9fac1f573f20998b3/.github/workflows/mypy_primer.yaml#L71

This PR fixes some more false positives from this diagnostic by making the `Type::contains_todo()` method more expansive.

## Test Plan

I added a regression test which causes us to emit a spurious diagnostic on `main`, but does not with this PR.
