### PR TITLE
CI: Run pre-commit on depot machine

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -642,7 +642,7 @@ jobs:
 
   pre-commit:
     name: "pre-commit"
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-22.04-16
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4


### PR DESCRIPTION
## Summary

Sibling/alternate of #17108 (see https://github.com/astral-sh/ruff/pull/17108#issuecomment-2769200896).

See if running the pre-commit CI step on Depot machines makes WASM-compiled shellcheck faster.

## Test Plan

> How was it tested?

We're doing it live!