### PR TITLE
[`airflow`] Update oudated `AIR301`, `AIR302` rules

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR301_names.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR301_names.py
@@ -50,7 +50,7 @@ from airflow.notifications.basenotifier import BaseNotifier
 from airflow.operators import dummy_operator
 from airflow.operators.branch_operator import BaseBranchOperator
 from airflow.operators.dagrun_operator import TriggerDagRunLink, TriggerDagRunOperator
-from airflow.operators.dummy import DummyOperator, EmptyOperator
+
 from airflow.operators.email_operator import EmailOperator
 from airflow.operators.latest_only_operator import LatestOnlyOperator
 from airflow.operators.python_operator import (
@@ -173,13 +173,13 @@ BaseOperatorLink()
 # ariflow.notifications.basenotifier
 BaseNotifier()
 
-# airflow.operators.dummy
-EmptyOperator()
-DummyOperator()
 
-# airflow.operators.dummy_operator
-dummy_operator.EmptyOperator()
-dummy_operator.DummyOperator()
+
+
+
+
+
+
 
 # airflow.operators.branch_operator
 BaseBranchOperator()

--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR301_names.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR301_names.py
@@ -45,20 +45,16 @@ from airflow.lineage.hook import DatasetLineageInfo
 from airflow.listeners.spec.dataset import on_dataset_changed, on_dataset_created
 from airflow.metrics.validators import AllowListValidator, BlockListValidator
 from airflow.models.baseoperator import chain, chain_linear, cross_downstream
-from airflow.models.baseoperatorlink import BaseOperatorLink
-from airflow.notifications.basenotifier import BaseNotifier
-from airflow.operators import dummy_operator
-from airflow.operators.branch_operator import BaseBranchOperator
-from airflow.operators.dagrun_operator import TriggerDagRunLink, TriggerDagRunOperator
 
-from airflow.operators.email_operator import EmailOperator
-from airflow.operators.latest_only_operator import LatestOnlyOperator
-from airflow.operators.python_operator import (
-    BranchPythonOperator,
-    PythonOperator,
-    PythonVirtualenvOperator,
-    ShortCircuitOperator,
-)
+
+
+
+
+
+
+
+
+
 from airflow.operators.subdag import SubDagOperator
 from airflow.providers.amazon.aws.auth_manager.avp.entities import AvpEntities
 from airflow.providers.amazon.aws.datasets import s3
@@ -251,18 +247,18 @@ BaseSensorOperator()
 # airflow.sensors.date_time_sensor
 DateTimeSensor()
 
-# airflow.sensors.external_task
-ExternalTaskSensorLink()
-ExternalTaskMarker()
-ExternalTaskSensor()
 
-# airflow.sensors.external_task_sensor
-ExternalTaskMarkerFromExternalTaskSensor()
-ExternalTaskSensorFromExternalTaskSensor()
-ExternalTaskSensorLinkFromExternalTaskSensor()
 
-# airflow.sensors.time_delta_sensor
-TimeDeltaSensor()
+
+
+
+
+
+
+
+
+
+
 
 # airflow.timetables
 DatasetOrTimeSchedule()

--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR301_names.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR301_names.py
@@ -72,20 +72,20 @@ from airflow.secrets.local_filesystem import LocalFilesystemBackend, load_connec
 from airflow.security.permissions import RESOURCE_DATASET
 from airflow.sensors.base_sensor_operator import BaseSensorOperator
 
-from airflow.sensors.external_task import (
-    ExternalTaskMarker,
-    ExternalTaskSensor,
-    ExternalTaskSensorLink,
-)
-from airflow.sensors.external_task_sensor import (
-    ExternalTaskMarker as ExternalTaskMarkerFromExternalTaskSensor,
-)
-from airflow.sensors.external_task_sensor import (
-    ExternalTaskSensor as ExternalTaskSensorFromExternalTaskSensor,
-)
-from airflow.sensors.external_task_sensor import (
-    ExternalTaskSensorLink as ExternalTaskSensorLinkFromExternalTaskSensor,
-)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 from airflow.sensors.time_delta_sensor import TimeDeltaSensor
 from airflow.timetables.datasets import DatasetOrTimeSchedule
 from airflow.timetables.simple import DatasetTriggeredTimetable

--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR301_names.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR301_names.py
@@ -71,7 +71,7 @@ from airflow.providers.trino.datasets import trino
 from airflow.secrets.local_filesystem import LocalFilesystemBackend, load_connections
 from airflow.security.permissions import RESOURCE_DATASET
 from airflow.sensors.base_sensor_operator import BaseSensorOperator
-from airflow.sensors.date_time_sensor import DateTimeSensor
+
 from airflow.sensors.external_task import (
     ExternalTaskMarker,
     ExternalTaskSensor,
@@ -244,8 +244,8 @@ RESOURCE_DATASET
 # airflow.sensors.base_sensor_operator
 BaseSensorOperator()
 
-# airflow.sensors.date_time_sensor
-DateTimeSensor()
+
+
 
 
 

--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR301_names.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR301_names.py
@@ -71,22 +71,6 @@ from airflow.providers.trino.datasets import trino
 from airflow.secrets.local_filesystem import LocalFilesystemBackend, load_connections
 from airflow.security.permissions import RESOURCE_DATASET
 from airflow.sensors.base_sensor_operator import BaseSensorOperator
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-from airflow.sensors.time_delta_sensor import TimeDeltaSensor
 from airflow.timetables.datasets import DatasetOrTimeSchedule
 from airflow.timetables.simple import DatasetTriggeredTimetable
 from airflow.triggers.external_task import TaskStateTrigger
@@ -163,19 +147,6 @@ BlockListValidator()
 # airflow.models.baseoperator
 chain, chain_linear, cross_downstream
 
-# airflow.models.baseoperatorlink
-BaseOperatorLink()
-
-# ariflow.notifications.basenotifier
-BaseNotifier()
-
-
-
-
-
-
-
-
 
 # airflow.operators.branch_operator
 BaseBranchOperator()
@@ -243,21 +214,6 @@ RESOURCE_DATASET
 
 # airflow.sensors.base_sensor_operator
 BaseSensorOperator()
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 # airflow.timetables

--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR301_names.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR301_names.py
@@ -45,16 +45,6 @@ from airflow.lineage.hook import DatasetLineageInfo
 from airflow.listeners.spec.dataset import on_dataset_changed, on_dataset_created
 from airflow.metrics.validators import AllowListValidator, BlockListValidator
 from airflow.models.baseoperator import chain, chain_linear, cross_downstream
-
-
-
-
-
-
-
-
-
-
 from airflow.operators.subdag import SubDagOperator
 from airflow.providers.amazon.aws.auth_manager.avp.entities import AvpEntities
 from airflow.providers.amazon.aws.datasets import s3

--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR302.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR302.py
@@ -423,8 +423,10 @@ FileTrigger()
 DateTimeTrigger()
 
 from airflow.operators.dummy import DummyOperator, EmptyOperator
-from airflow.operators.email import EmailOperator
 
 DummyOperator()
 EmptyOperator()
+
+from airflow.operators.email import EmailOperator
+
 EmailOperator()

--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR302.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR302.py
@@ -421,3 +421,10 @@ SubprocessHook()
 WorkflowTrigger()
 FileTrigger()
 DateTimeTrigger()
+
+from airflow.operators.dummy import DummyOperator, EmptyOperator
+from airflow.operators.email import EmailOperator
+
+DummyOperator()
+EmptyOperator()
+EmailOperator()

--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR302.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR302.py
@@ -422,11 +422,58 @@ WorkflowTrigger()
 FileTrigger()
 DateTimeTrigger()
 
+from airflow.operators.email import EmailOperator
 from airflow.operators.dummy import DummyOperator, EmptyOperator
+from airflow.operators.trigger_dagrun import TriggerDagRunLink, TriggerDagRunOperator
+from airflow.operators.email_operator import EmailOperator
+from airflow.operators.python import (
+    BranchPythonOperator,
+    PythonOperator,
+    PythonVirtualenvOperator,
+    ShortCircuitOperator,
+)
+from airflow.sensors.date_time_sensor import DateTimeSensor
+from airflow.sensors.external_task import (
+    ExternalTaskMarker,
+    ExternalTaskSensor,
+    ExternalTaskSensorLink,
+)
+from airflow.sensors.external_task_sensor import (
+    ExternalTaskMarker as ExternalTaskMarkerFromExternalTaskSensor,
+)
+from airflow.sensors.external_task_sensor import (
+    ExternalTaskSensor as ExternalTaskSensorFromExternalTaskSensor,
+)
+from airflow.sensors.external_task_sensor import (
+    ExternalTaskSensorLink as ExternalTaskSensorLinkFromExternalTaskSensor,
+)
 
 DummyOperator()
 EmptyOperator()
-
-from airflow.operators.email import EmailOperator
-
 EmailOperator()
+
+# airflow.operators.trigger_dagrun
+TriggerDagRunLink()
+TriggerDagRunOperator()
+
+# airflow.sensors.date_time_sensor
+DateTimeSensor()
+
+# airflow.sensors.external_task
+ExternalTaskSensorLink()
+ExternalTaskMarker()
+ExternalTaskSensor()
+
+# airflow.sensors.external_task_sensor
+ExternalTaskMarkerFromExternalTaskSensor()
+ExternalTaskSensorFromExternalTaskSensor()
+ExternalTaskSensorLinkFromExternalTaskSensor()
+
+# airflow.sensors.time_delta_sensor
+TimeDeltaSensor()
+
+# airflow.operators.python
+BranchPythonOperator()
+PythonOperator()
+PythonVirtualenvOperator()
+ShortCircuitOperator()

--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR302.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR302.py
@@ -100,12 +100,6 @@ from airflow.kubernetes.secret import K8SModel2, Secret
 from airflow.kubernetes.volume import Volume
 from airflow.kubernetes.volume_mount import VolumeMount
 from airflow.macros.hive import closest_ds_partition, max_partition
-from airflow.operators import (
-    dagrun_operator,
-    dummy_operator,
-    email_operator,
-    python_operator,
-)
 from airflow.operators.bash import BashOperator
 from airflow.operators.bash_operator import BashOperator as LegacyBashOperator
 from airflow.operators.check_operator import (
@@ -204,7 +198,6 @@ from airflow.operators.sql import (
 from airflow.operators.sqlite_operator import SqliteOperator
 from airflow.operators.trigger_dagrun import TriggerDagRunOperator
 from airflow.operators.weekday import BranchDayOfWeekOperator
-from airflow.sensors import external_task_sensor
 from airflow.sensors.date_time import DateTimeSensor
 from airflow.sensors.date_time_sensor import DateTimeSensor
 from airflow.sensors.external_task import (

--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR302.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR302.py
@@ -100,6 +100,12 @@ from airflow.kubernetes.secret import K8SModel2, Secret
 from airflow.kubernetes.volume import Volume
 from airflow.kubernetes.volume_mount import VolumeMount
 from airflow.macros.hive import closest_ds_partition, max_partition
+from airflow.operators import (
+    dagrun_operator,
+    dummy_operator,
+    email_operator,
+    python_operator,
+)
 from airflow.operators.bash import BashOperator
 from airflow.operators.bash_operator import BashOperator as LegacyBashOperator
 from airflow.operators.check_operator import (
@@ -115,6 +121,9 @@ from airflow.operators.check_operator import (
 from airflow.operators.datetime import BranchDateTimeOperator
 from airflow.operators.docker_operator import DockerOperator
 from airflow.operators.druid_check_operator import DruidCheckOperator
+from airflow.operators.dummy import DummyOperator, EmptyOperator
+from airflow.operators.email import EmailOperator
+from airflow.operators.email_operator import EmailOperator
 from airflow.operators.gcs_to_s3 import GCSToS3Operator
 from airflow.operators.google_api_to_s3_transfer import (
     GoogleApiToS3Operator,
@@ -153,6 +162,12 @@ from airflow.operators.presto_to_mysql import (
     PrestoToMySqlOperator,
     PrestoToMySqlTransfer,
 )
+from airflow.operators.python import (
+    BranchPythonOperator,
+    PythonOperator,
+    PythonVirtualenvOperator,
+    ShortCircuitOperator,
+)
 from airflow.operators.redshift_to_s3_operator import (
     RedshiftToS3Operator,
     RedshiftToS3Transfer,
@@ -189,8 +204,14 @@ from airflow.operators.sql import (
 from airflow.operators.sqlite_operator import SqliteOperator
 from airflow.operators.trigger_dagrun import TriggerDagRunOperator
 from airflow.operators.weekday import BranchDayOfWeekOperator
+from airflow.sensors import external_task_sensor
 from airflow.sensors.date_time import DateTimeSensor
-from airflow.sensors.external_task import ExternalTaskMarker, ExternalTaskSensor
+from airflow.sensors.date_time_sensor import DateTimeSensor
+from airflow.sensors.external_task import (
+    ExternalTaskMarker,
+    ExternalTaskSensor,
+    ExternalTaskSensorLink,
+)
 from airflow.sensors.filesystem import FileSensor
 from airflow.sensors.hive_partition_sensor import HivePartitionSensor
 from airflow.sensors.http_sensor import HttpSensor
@@ -405,75 +426,30 @@ SqliteOperator()
 # apache-airflow-providers-zendesk
 ZendeskHook()
 
+# apache-airflow-providers-smtp
+EmailOperator()
+
 # apache-airflow-providers-standard
-FileSensor()
-TriggerDagRunOperator()
-ExternalTaskMarker(), ExternalTaskSensor()
 BranchDateTimeOperator()
 BranchDayOfWeekOperator()
+BranchPythonOperator()
 DateTimeSensor()
-TimeSensor()
-TimeDeltaSensor()
+DateTimeTrigger()
 DayOfWeekSensor()
+DummyOperator()
+EmptyOperator()
+ExternalTaskMarker()
+ExternalTaskSensor()
+ExternalTaskSensorLink()
+FileSensor()
+FileTrigger()
 FSHook()
 PackageIndexHook()
 SubprocessHook()
-WorkflowTrigger()
-FileTrigger()
-DateTimeTrigger()
-
-from airflow.operators.email import EmailOperator
-from airflow.operators.dummy import DummyOperator, EmptyOperator
-from airflow.operators.trigger_dagrun import TriggerDagRunLink, TriggerDagRunOperator
-from airflow.operators.email_operator import EmailOperator
-from airflow.operators.python import (
-    BranchPythonOperator,
-    PythonOperator,
-    PythonVirtualenvOperator,
-    ShortCircuitOperator,
-)
-from airflow.sensors.date_time_sensor import DateTimeSensor
-from airflow.sensors.external_task import (
-    ExternalTaskMarker,
-    ExternalTaskSensor,
-    ExternalTaskSensorLink,
-)
-from airflow.sensors.external_task_sensor import (
-    ExternalTaskMarker as ExternalTaskMarkerFromExternalTaskSensor,
-)
-from airflow.sensors.external_task_sensor import (
-    ExternalTaskSensor as ExternalTaskSensorFromExternalTaskSensor,
-)
-from airflow.sensors.external_task_sensor import (
-    ExternalTaskSensorLink as ExternalTaskSensorLinkFromExternalTaskSensor,
-)
-
-DummyOperator()
-EmptyOperator()
-EmailOperator()
-
-# airflow.operators.trigger_dagrun
-TriggerDagRunLink()
-TriggerDagRunOperator()
-
-# airflow.sensors.date_time_sensor
-DateTimeSensor()
-
-# airflow.sensors.external_task
-ExternalTaskSensorLink()
-ExternalTaskMarker()
-ExternalTaskSensor()
-
-# airflow.sensors.external_task_sensor
-ExternalTaskMarkerFromExternalTaskSensor()
-ExternalTaskSensorFromExternalTaskSensor()
-ExternalTaskSensorLinkFromExternalTaskSensor()
-
-# airflow.sensors.time_delta_sensor
+ShortCircuitOperator()
 TimeDeltaSensor()
-
-# airflow.operators.python
-BranchPythonOperator()
+TimeSensor()
+TriggerDagRunOperator()
+WorkflowTrigger()
 PythonOperator()
 PythonVirtualenvOperator()
-ShortCircuitOperator()

--- a/crates/ruff_linter/src/rules/airflow/rules/moved_to_provider_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/moved_to_provider_in_3.rs
@@ -874,6 +874,11 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
         },
 
         // apache-airflow-providers-standard
+        ["airflow", "operators", "dummy" | "dummy_operator", "EmptyOperator" | "DummyOperator"] => Replacement::ProviderName{
+            name: "airflow.providers.standard.operators.empty.EmptyOperator",
+            provider: "standard",
+            version: "0.1.0"
+        },
         ["airflow", "sensors", "filesystem", "FileSensor"] => Replacement::ProviderName{
             name: "airflow.providers.standard.sensors.filesystem.FileSensor",
             provider: "standard",

--- a/crates/ruff_linter/src/rules/airflow/rules/moved_to_provider_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/moved_to_provider_in_3.rs
@@ -171,7 +171,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             version: "1.0.0"
         },
         ["airflow", "sensors", "s3_key_sensor", "S3KeySensor"] => Replacement::ProviderName{
-            name: "S3KeySensor",
+            name: "airflow.providers.amazon.aws.sensors.s3.S3KeySensor",
             provider: "amazon",
             version: "1.0.0"
         },
@@ -407,7 +407,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             name: "airflow.providers.fab.auth_manager.security_manager.override.FabAirflowSecurityManagerOverride",
             provider: "fab",
             version: "1.0.0"
-            },
+        },
         ["airflow", "auth", "managers", "fab", "fab_auth_manager", "FabAuthManager"] => Replacement::ProviderName{
             name: "airflow.providers.fab.auth_manager.security_manager.FabAuthManager",
             provider: "fab",

--- a/crates/ruff_linter/src/rules/airflow/rules/moved_to_provider_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/moved_to_provider_in_3.rs
@@ -873,6 +873,14 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             version: "1.0.0"
         },
 
+        // apache-airflow-providers-smtp
+        ["airflow", "operators", "email_operator" | "email", "EmailOperator"] => Replacement::ProviderName{
+            name: "airflow.providers.smtp.operators.smtp.EmailOperator",
+            provider: "smtp",
+            version: "1.0.0",
+        },
+
+
         // apache-airflow-providers-standard
         ["airflow", "operators", "dummy" | "dummy_operator", "EmptyOperator" | "DummyOperator"] => Replacement::ProviderName{
             name: "airflow.providers.standard.operators.empty.EmptyOperator",

--- a/crates/ruff_linter/src/rules/airflow/rules/moved_to_provider_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/moved_to_provider_in_3.rs
@@ -987,14 +987,14 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
         ["airflow", "api", "auth", "backend", "basic_auth", ..] => Replacement::ImportPathMoved{
             original_path: "airflow.api.auth.backend.basic_auth",
             new_path: "airflow.providers.fab.auth_manager.api.auth.backend.basic_auth",
-            provider:"fab",
+            provider: "fab",
             version: "1.0.0"
         },
         ["airflow", "api", "auth", "backend", "kerberos_auth", ..] => Replacement::ImportPathMoved{
-            original_path:"airflow.api.auth.backend.kerberos_auth",
+            original_path: "airflow.api.auth.backend.kerberos_auth",
             new_path: "airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth",
             provider: "fab",
-            version:"1.0.0"
+            version: "1.0.0"
         },
         ["airflow", "auth", "managers", "fab", "api", "auth", "backend", "kerberos_auth", ..] => Replacement::ImportPathMoved{
             original_path: "airflow.auth_manager.api.auth.backend.kerberos_auth",

--- a/crates/ruff_linter/src/rules/airflow/rules/moved_to_provider_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/moved_to_provider_in_3.rs
@@ -882,30 +882,84 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
 
 
         // apache-airflow-providers-standard
+        ["airflow", "operators", "bash_operator", "BashOperator"] => Replacement::ProviderName{
+            name: "airflow.providers.standard.operators.bash.BashOperator",
+            provider: "standard",
+            version: "0.0.1"
+        },
+        ["airflow", "operators", "dagrun_operator" | "trigger_dagrun", rest @ ..        ] => match &rest {
+            ["TriggerDagRunLink"] => Replacement::ProviderName{
+                name: "airflow.providers.standard.operators.trigger_dagrun.TriggerDagRunLink",
+                provider: "standard",
+                version: "0.0.2"
+            },
+            ["TriggerDagRunOperator"] => Replacement::ProviderName{
+                name: "airflow.providers.standard.operators.trigger_dagrun.TriggerDagRunOperator",
+                provider: "standard",
+                version: "0.0.2"
+            },
+            _ => return
+        }
         ["airflow", "operators", "dummy" | "dummy_operator", "EmptyOperator" | "DummyOperator"] => Replacement::ProviderName{
             name: "airflow.providers.standard.operators.empty.EmptyOperator",
             provider: "standard",
-            version: "0.1.0"
+            version: "0.0.2"
         },
+        ["airflow", "operators", "latest_only_operator" | "latest_only", "LatestOnlyOperator"] => Replacement::ProviderName{
+            name: "airflow.providers.standard.operators.latest_only.LatestOnlyOperator",
+            provider: "standard",
+            version: "0.0.3"
+        },
+        ["airflow", "operators", "python_operator"| "python", rest @ ..] => match &rest {
+            ["BranchPythonOperator"] => Replacement::ProviderName{
+                name: "airflow.providers.standard.operators.python.BranchPythonOperator",
+                provider: "standard",
+                version: "0.0.1"
+            },
+            ["PythonOperator"] => Replacement::ProviderName{
+                name: "airflow.providers.standard.operators.python.PythonOperator",
+                provider: "standard",
+                version: "0.0.1"
+            },
+            ["PythonVirtualenvOperator"] => Replacement::ProviderName{
+                name: "airflow.providers.standard.operators.python.PythonVirtualenvOperator",
+                provider: "standard",
+                version: "0.0.1"
+            },
+            ["ShortCircuitOperator"] => Replacement::ProviderName{
+                name: "airflow.providers.standard.operators.python.ShortCircuitOperator",
+                provider: "standard",
+                version: "0.0.1"
+            },
+            _ => return
+        }
+        ["airflow", "sensors", "external_task_sensor" | "external_task", rest @..] => match &rest {
+            ["ExternalTaskSensor"] => Replacement::ProviderName{
+                name: "airflow.providers.standard.sensors.external_task.ExternalTaskSensor",
+                provider: "standard",
+                version: "0.0.3"
+            },
+            ["ExternalTaskSensorLink"] => Replacement::ProviderName{
+                name: "airflow.providers.standard.sensors.external_task.ExternalTaskSensorLink",
+                provider: "standard",
+                version: "0.0.3"
+            },
+            ["ExternalTaskMarker"] => Replacement::ProviderName{
+                name: "airflow.providers.standard.sensors.external_task.ExternalTaskMarker",
+                provider: "standard",
+                version: "0.0.3"
+            },
+            _ => return
+        }
         ["airflow", "sensors", "filesystem", "FileSensor"] => Replacement::ProviderName{
             name: "airflow.providers.standard.sensors.filesystem.FileSensor",
             provider: "standard",
             version: "0.0.2"
         },
-        ["airflow", "operators", "trigger_dagrun", "TriggerDagRunOperator"] => Replacement::ProviderName{
-            name: "airflow.providers.standard.operators.trigger_dagrun.TriggerDagRunOperator",
+        ["airflow", "sensors", "time_delta_sensor", "TimeDeltaSensor"] => Replacement::ProviderName{
+            name: "airflow.providers.standard.sensors.time_delta.TimeDeltaSensor",
             provider: "standard",
-            version: "0.0.2"
-        },
-        ["airflow", "sensors", "external_task", "ExternalTaskMarker"] => Replacement::ProviderName{
-            name: "airflow.providers.standard.sensors.external_task.ExternalTaskMarker",
-            provider: "standard",
-            version: "0.0.3"
-        },
-        ["airflow", "sensors", "external_task", "ExternalTaskSensor"] => Replacement::ProviderName{
-            name: "airflow.providers.standard.sensors.external_task.ExternalTaskSensor",
-            provider: "standard",
-            version: "0.0.3"
+            version: "0.1.0"
         },
 
         // apache-airflow-providers-sqlite

--- a/crates/ruff_linter/src/rules/airflow/rules/moved_to_provider_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/moved_to_provider_in_3.rs
@@ -887,13 +887,13 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             provider: "standard",
             version: "0.0.1"
         },
-        ["airflow", "operators", "dagrun_operator" | "trigger_dagrun", rest @ ..        ] => match &rest {
-            ["TriggerDagRunLink"] => Replacement::ProviderName{
+        ["airflow", "operators", "dagrun_operator" | "trigger_dagrun", rest] => match *rest {
+            "TriggerDagRunLink" => Replacement::ProviderName{
                 name: "airflow.providers.standard.operators.trigger_dagrun.TriggerDagRunLink",
                 provider: "standard",
                 version: "0.0.2"
             },
-            ["TriggerDagRunOperator"] => Replacement::ProviderName{
+            "TriggerDagRunOperator" => Replacement::ProviderName{
                 name: "airflow.providers.standard.operators.trigger_dagrun.TriggerDagRunOperator",
                 provider: "standard",
                 version: "0.0.2"
@@ -910,41 +910,41 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             provider: "standard",
             version: "0.0.3"
         },
-        ["airflow", "operators", "python_operator"| "python", rest @ ..] => match &rest {
-            ["BranchPythonOperator"] => Replacement::ProviderName{
+        ["airflow", "operators", "python_operator"| "python", rest ] => match *rest {
+            "BranchPythonOperator" => Replacement::ProviderName{
                 name: "airflow.providers.standard.operators.python.BranchPythonOperator",
                 provider: "standard",
                 version: "0.0.1"
             },
-            ["PythonOperator"] => Replacement::ProviderName{
+            "PythonOperator" => Replacement::ProviderName{
                 name: "airflow.providers.standard.operators.python.PythonOperator",
                 provider: "standard",
                 version: "0.0.1"
             },
-            ["PythonVirtualenvOperator"] => Replacement::ProviderName{
+            "PythonVirtualenvOperator" => Replacement::ProviderName{
                 name: "airflow.providers.standard.operators.python.PythonVirtualenvOperator",
                 provider: "standard",
                 version: "0.0.1"
             },
-            ["ShortCircuitOperator"] => Replacement::ProviderName{
+            "ShortCircuitOperator" => Replacement::ProviderName{
                 name: "airflow.providers.standard.operators.python.ShortCircuitOperator",
                 provider: "standard",
                 version: "0.0.1"
             },
             _ => return
         }
-        ["airflow", "sensors", "external_task_sensor" | "external_task", rest @..] => match &rest {
-            ["ExternalTaskSensor"] => Replacement::ProviderName{
+        ["airflow", "sensors", "external_task_sensor" | "external_task", rest] => match *rest {
+            "ExternalTaskSensor" => Replacement::ProviderName{
                 name: "airflow.providers.standard.sensors.external_task.ExternalTaskSensor",
                 provider: "standard",
                 version: "0.0.3"
             },
-            ["ExternalTaskSensorLink"] => Replacement::ProviderName{
+            "ExternalTaskSensorLink" => Replacement::ProviderName{
                 name: "airflow.providers.standard.sensors.external_task.ExternalTaskSensorLink",
                 provider: "standard",
                 version: "0.0.3"
             },
-            ["ExternalTaskMarker"] => Replacement::ProviderName{
+            "ExternalTaskMarker" => Replacement::ProviderName{
                 name: "airflow.providers.standard.sensors.external_task.ExternalTaskMarker",
                 provider: "standard",
                 version: "0.0.3"

--- a/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
@@ -689,12 +689,6 @@ fn check_name(checker: &Checker, expr: &Expr, range: TextRange) {
         ["airflow", "operators", "branch_operator", "BaseBranchOperator"] => {
             Replacement::Name("airflow.operators.branch.BaseBranchOperator")
         }
-        ["airflow", "operators", "dummy" | "dummy_operator", "EmptyOperator" | "DummyOperator"] => {
-            Replacement::Name("airflow.operators.empty.EmptyOperator")
-        }
-        ["airflow", "operators", "email_operator", "EmailOperator"] => {
-            Replacement::Name("airflow.operators.email.EmailOperator")
-        }
         ["airflow", "operators", "dagrun_operator", "TriggerDagRunLink"] => {
             Replacement::Name("airflow.operators.trigger_dagrun.TriggerDagRunLink")
         }

--- a/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
@@ -702,9 +702,6 @@ fn check_name(checker: &Checker, expr: &Expr, range: TextRange) {
         ["airflow", "sensors", "base_sensor_operator", "BaseSensorOperator"] => {
             Replacement::Name("airflow.sdk.bases.sensor.BaseSensorOperator")
         }
-        ["airflow", "sensors", "date_time_sensor", "DateTimeSensor"] => {
-            Replacement::Name("airflow.sensors.date_time.DateTimeSensor")
-        }
 
         // airflow.timetables
         ["airflow", "timetables", rest @ ..] => match &rest {

--- a/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
@@ -236,7 +236,6 @@ fn check_call_arguments(checker: &Checker, qualified_name: &QualifiedName, argum
                     Some("max_active_tis_per_dag"),
                 ));
                 match qualified_name.segments() {
-                    // TODO: consider also "dagrun_operator"
                     ["airflow", .., "operators", "trigger_dagrun", "TriggerDagRunOperator"] => {
                         checker.report_diagnostics(diagnostic_for_argument(
                             arguments,

--- a/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
@@ -236,6 +236,7 @@ fn check_call_arguments(checker: &Checker, qualified_name: &QualifiedName, argum
                     Some("max_active_tis_per_dag"),
                 ));
                 match qualified_name.segments() {
+                    // TODO: consider also "dagrun_operator"
                     ["airflow", .., "operators", "trigger_dagrun", "TriggerDagRunOperator"] => {
                         checker.report_diagnostics(diagnostic_for_argument(
                             arguments,
@@ -686,30 +687,6 @@ fn check_name(checker: &Checker, expr: &Expr, range: TextRange) {
         ["airflow", "operators", "subdag", ..] => {
             Replacement::Message("The whole `airflow.subdag` module has been removed.")
         }
-        ["airflow", "operators", "branch_operator", "BaseBranchOperator"] => {
-            Replacement::Name("airflow.operators.branch.BaseBranchOperator")
-        }
-        ["airflow", "operators", "dagrun_operator", "TriggerDagRunLink"] => {
-            Replacement::Name("airflow.operators.trigger_dagrun.TriggerDagRunLink")
-        }
-        ["airflow", "operators", "dagrun_operator", "TriggerDagRunOperator"] => {
-            Replacement::Name("airflow.operators.trigger_dagrun.TriggerDagRunOperator")
-        }
-        ["airflow", "operators", "python_operator", "BranchPythonOperator"] => {
-            Replacement::Name("airflow.operators.python.BranchPythonOperator")
-        }
-        ["airflow", "operators", "python_operator", "PythonOperator"] => {
-            Replacement::Name("airflow.operators.python.PythonOperator")
-        }
-        ["airflow", "operators", "python_operator", "PythonVirtualenvOperator"] => {
-            Replacement::Name("airflow.operators.python.PythonVirtualenvOperator")
-        }
-        ["airflow", "operators", "python_operator", "ShortCircuitOperator"] => {
-            Replacement::Name("airflow.operators.python.ShortCircuitOperator")
-        }
-        ["airflow", "operators", "latest_only_operator", "LatestOnlyOperator"] => {
-            Replacement::Name("airflow.operators.latest_only.LatestOnlyOperator")
-        }
 
         // airflow.secrets
         ["airflow", "secrets", "local_filesystem", "load_connections"] => {
@@ -727,18 +704,6 @@ fn check_name(checker: &Checker, expr: &Expr, range: TextRange) {
         }
         ["airflow", "sensors", "date_time_sensor", "DateTimeSensor"] => {
             Replacement::Name("airflow.sensors.date_time.DateTimeSensor")
-        }
-        ["airflow", "sensors", "external_task" | "external_task_sensor", "ExternalTaskMarker"] => {
-            Replacement::Name("airflow.sensors.external_task.ExternalTaskMarker")
-        }
-        ["airflow", "sensors", "external_task" | "external_task_sensor", "ExternalTaskSensorLink"] => {
-            Replacement::Name("airflow.sensors.external_task.ExternalDagLink")
-        }
-        ["airflow", "sensors", "external_task" | "external_task_sensor", "ExternalTaskSensor"] => {
-            Replacement::Name("airflow.sensors.external_task.ExternalTaskSensor")
-        }
-        ["airflow", "sensors", "time_delta_sensor", "TimeDeltaSensor"] => {
-            Replacement::Name("airflow.sensors.time_delta.TimeDeltaSensor")
         }
 
         // airflow.timetables

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR002_AIR002.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR002_AIR002.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_linter/src/rules/airflow/mod.rs
-snapshot_kind: text
 ---
 AIR002.py:4:1: AIR002 DAG should have an explicit `schedule` argument
   |

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR301_AIR301_context.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR301_AIR301_context.py.snap
@@ -316,17 +316,6 @@ AIR301_context.py:111:5: AIR301 [*] `schedule_interval` is removed in Airflow 3.
 113 113 |     template_searchpath=["/templates"],
 114 114 | ) as dag:
 
-AIR301_context.py:115:13: AIR301 `airflow.operators.dummy.DummyOperator` is removed in Airflow 3.0
-    |
-113 |     template_searchpath=["/templates"],
-114 | ) as dag:
-115 |     task1 = DummyOperator(
-    |             ^^^^^^^^^^^^^ AIR301
-116 |         task_id="task1",
-117 |         params={
-    |
-    = help: Use `airflow.operators.empty.EmptyOperator` instead
-
 AIR301_context.py:135:23: AIR301 `next_ds` is removed in Airflow 3.0
     |
 134 | class CustomOperator(BaseOperator):

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR301_AIR301_names.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR301_AIR301_names.py.snap
@@ -631,18 +631,8 @@ AIR301_names.py:245:1: AIR301 `airflow.sensors.base_sensor_operator.BaseSensorOp
 244 | # airflow.sensors.base_sensor_operator
 245 | BaseSensorOperator()
     | ^^^^^^^^^^^^^^^^^^ AIR301
-246 |
-247 | # airflow.sensors.date_time_sensor
     |
     = help: Use `airflow.sdk.bases.sensor.BaseSensorOperator` instead
-
-AIR301_names.py:248:1: AIR301 `airflow.sensors.date_time_sensor.DateTimeSensor` is removed in Airflow 3.0
-    |
-247 | # airflow.sensors.date_time_sensor
-248 | DateTimeSensor()
-    | ^^^^^^^^^^^^^^ AIR301
-    |
-    = help: Use `airflow.sensors.date_time.DateTimeSensor` instead
 
 AIR301_names.py:264:1: AIR301 `airflow.timetables.datasets.DatasetOrTimeSchedule` is removed in Airflow 3.0
     |

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR301_AIR301_names.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR301_AIR301_names.py.snap
@@ -447,8 +447,6 @@ AIR301_names.py:174:1: AIR301 `airflow.notifications.basenotifier.BaseNotifier` 
 173 | # ariflow.notifications.basenotifier
 174 | BaseNotifier()
     | ^^^^^^^^^^^^ AIR301
-175 |
-176 | # airflow.operators.dummy
     |
     = help: Use `airflow.sdk.BaseNotifier` instead
 

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR301_AIR301_names.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR301_AIR301_names.py.snap
@@ -1,111 +1,111 @@
 ---
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 ---
-AIR301_names.py:121:1: AIR301 `airflow.PY36` is removed in Airflow 3.0
+AIR301_names.py:117:1: AIR301 `airflow.PY36` is removed in Airflow 3.0
     |
-120 | # airflow root
-121 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+116 | # airflow root
+117 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
     | ^^^^ AIR301
-122 | DatasetFromRoot()
+118 | DatasetFromRoot()
     |
     = help: Use `sys.version_info` instead
 
-AIR301_names.py:121:7: AIR301 `airflow.PY37` is removed in Airflow 3.0
+AIR301_names.py:117:7: AIR301 `airflow.PY37` is removed in Airflow 3.0
     |
-120 | # airflow root
-121 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+116 | # airflow root
+117 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
     |       ^^^^ AIR301
-122 | DatasetFromRoot()
+118 | DatasetFromRoot()
     |
     = help: Use `sys.version_info` instead
 
-AIR301_names.py:121:13: AIR301 `airflow.PY38` is removed in Airflow 3.0
+AIR301_names.py:117:13: AIR301 `airflow.PY38` is removed in Airflow 3.0
     |
-120 | # airflow root
-121 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+116 | # airflow root
+117 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
     |             ^^^^ AIR301
-122 | DatasetFromRoot()
+118 | DatasetFromRoot()
     |
     = help: Use `sys.version_info` instead
 
-AIR301_names.py:121:19: AIR301 `airflow.PY39` is removed in Airflow 3.0
+AIR301_names.py:117:19: AIR301 `airflow.PY39` is removed in Airflow 3.0
     |
-120 | # airflow root
-121 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+116 | # airflow root
+117 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
     |                   ^^^^ AIR301
-122 | DatasetFromRoot()
+118 | DatasetFromRoot()
     |
     = help: Use `sys.version_info` instead
 
-AIR301_names.py:121:25: AIR301 `airflow.PY310` is removed in Airflow 3.0
+AIR301_names.py:117:25: AIR301 `airflow.PY310` is removed in Airflow 3.0
     |
-120 | # airflow root
-121 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+116 | # airflow root
+117 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
     |                         ^^^^^ AIR301
-122 | DatasetFromRoot()
+118 | DatasetFromRoot()
     |
     = help: Use `sys.version_info` instead
 
-AIR301_names.py:121:32: AIR301 `airflow.PY311` is removed in Airflow 3.0
+AIR301_names.py:117:32: AIR301 `airflow.PY311` is removed in Airflow 3.0
     |
-120 | # airflow root
-121 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+116 | # airflow root
+117 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
     |                                ^^^^^ AIR301
-122 | DatasetFromRoot()
+118 | DatasetFromRoot()
     |
     = help: Use `sys.version_info` instead
 
-AIR301_names.py:121:39: AIR301 `airflow.PY312` is removed in Airflow 3.0
+AIR301_names.py:117:39: AIR301 `airflow.PY312` is removed in Airflow 3.0
     |
-120 | # airflow root
-121 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+116 | # airflow root
+117 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
     |                                       ^^^^^ AIR301
-122 | DatasetFromRoot()
+118 | DatasetFromRoot()
     |
     = help: Use `sys.version_info` instead
 
-AIR301_names.py:122:1: AIR301 [*] `airflow.Dataset` is removed in Airflow 3.0
+AIR301_names.py:118:1: AIR301 [*] `airflow.Dataset` is removed in Airflow 3.0
     |
-120 | # airflow root
-121 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
-122 | DatasetFromRoot()
+116 | # airflow root
+117 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+118 | DatasetFromRoot()
     | ^^^^^^^^^^^^^^^ AIR301
-123 |
-124 | # airflow.api_connexion.security
+119 |
+120 | # airflow.api_connexion.security
     |
     = help: Use `airflow.sdk.Asset` instead
 
 ℹ Safe fix
-116 116 | from airflow.utils.trigger_rule import TriggerRule
-117 117 | from airflow.www.auth import has_access, has_access_dataset
-118 118 | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
-    119 |+from airflow.sdk import Asset
+112 112 | from airflow.utils.trigger_rule import TriggerRule
+113 113 | from airflow.www.auth import has_access, has_access_dataset
+114 114 | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
+    115 |+from airflow.sdk import Asset
+115 116 | 
+116 117 | # airflow root
+117 118 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+118     |-DatasetFromRoot()
+    119 |+Asset()
 119 120 | 
-120 121 | # airflow root
-121 122 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
-122     |-DatasetFromRoot()
-    123 |+Asset()
-123 124 | 
-124 125 | # airflow.api_connexion.security
-125 126 | requires_access, requires_access_dataset
+120 121 | # airflow.api_connexion.security
+121 122 | requires_access, requires_access_dataset
 
-AIR301_names.py:125:1: AIR301 `airflow.api_connexion.security.requires_access` is removed in Airflow 3.0
+AIR301_names.py:121:1: AIR301 `airflow.api_connexion.security.requires_access` is removed in Airflow 3.0
     |
-124 | # airflow.api_connexion.security
-125 | requires_access, requires_access_dataset
+120 | # airflow.api_connexion.security
+121 | requires_access, requires_access_dataset
     | ^^^^^^^^^^^^^^^ AIR301
-126 |
-127 | # airflow.auth.managers
+122 |
+123 | # airflow.auth.managers
     |
     = help: Use `airflow.api_connexion.security.requires_access_*` instead
 
-AIR301_names.py:125:18: AIR301 [*] `airflow.api_connexion.security.requires_access_dataset` is removed in Airflow 3.0
+AIR301_names.py:121:18: AIR301 [*] `airflow.api_connexion.security.requires_access_dataset` is removed in Airflow 3.0
     |
-124 | # airflow.api_connexion.security
-125 | requires_access, requires_access_dataset
+120 | # airflow.api_connexion.security
+121 | requires_access, requires_access_dataset
     |                  ^^^^^^^^^^^^^^^^^^^^^^^ AIR301
-126 |
-127 | # airflow.auth.managers
+122 |
+123 | # airflow.auth.managers
     |
     = help: Use `airflow.api_connexion.security.requires_access_asset` instead
 
@@ -119,969 +119,795 @@ AIR301_names.py:125:18: AIR301 [*] `airflow.api_connexion.security.requires_acce
 17  17  | from airflow.auth.managers.models.resource_details import DatasetDetails
 18  18  | from airflow.configuration import (
 --------------------------------------------------------------------------------
-122 122 | DatasetFromRoot()
-123 123 | 
-124 124 | # airflow.api_connexion.security
-125     |-requires_access, requires_access_dataset
-    125 |+requires_access, requires_access_asset
-126 126 | 
-127 127 | # airflow.auth.managers
-128 128 | is_authorized_dataset
+118 118 | DatasetFromRoot()
+119 119 | 
+120 120 | # airflow.api_connexion.security
+121     |-requires_access, requires_access_dataset
+    121 |+requires_access, requires_access_asset
+122 122 | 
+123 123 | # airflow.auth.managers
+124 124 | is_authorized_dataset
 
-AIR301_names.py:128:1: AIR301 `airflow.auth.managers.base_auth_manager.is_authorized_dataset` is removed in Airflow 3.0
+AIR301_names.py:124:1: AIR301 `airflow.auth.managers.base_auth_manager.is_authorized_dataset` is removed in Airflow 3.0
     |
-127 | # airflow.auth.managers
-128 | is_authorized_dataset
+123 | # airflow.auth.managers
+124 | is_authorized_dataset
     | ^^^^^^^^^^^^^^^^^^^^^ AIR301
-129 | DatasetDetails()
+125 | DatasetDetails()
     |
     = help: Use `airflow.api_fastapi.auth.managers.base_auth_manager.is_authorized_asset` instead
 
-AIR301_names.py:129:1: AIR301 `airflow.auth.managers.models.resource_details.DatasetDetails` is removed in Airflow 3.0
+AIR301_names.py:125:1: AIR301 `airflow.auth.managers.models.resource_details.DatasetDetails` is removed in Airflow 3.0
     |
-127 | # airflow.auth.managers
-128 | is_authorized_dataset
-129 | DatasetDetails()
+123 | # airflow.auth.managers
+124 | is_authorized_dataset
+125 | DatasetDetails()
     | ^^^^^^^^^^^^^^ AIR301
-130 |
-131 | # airflow.configuration
+126 |
+127 | # airflow.configuration
     |
     = help: Use `airflow.api_fastapi.auth.managers.models.resource_details.AssetDetails` instead
 
-AIR301_names.py:132:1: AIR301 `airflow.configuration.get` is removed in Airflow 3.0
+AIR301_names.py:128:1: AIR301 `airflow.configuration.get` is removed in Airflow 3.0
     |
-131 | # airflow.configuration
-132 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+127 | # airflow.configuration
+128 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     | ^^^ AIR301
     |
     = help: Use `airflow.configuration.conf.get` instead
 
-AIR301_names.py:132:6: AIR301 `airflow.configuration.getboolean` is removed in Airflow 3.0
+AIR301_names.py:128:6: AIR301 `airflow.configuration.getboolean` is removed in Airflow 3.0
     |
-131 | # airflow.configuration
-132 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+127 | # airflow.configuration
+128 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     |      ^^^^^^^^^^ AIR301
     |
     = help: Use `airflow.configuration.conf.getboolean` instead
 
-AIR301_names.py:132:18: AIR301 `airflow.configuration.getfloat` is removed in Airflow 3.0
+AIR301_names.py:128:18: AIR301 `airflow.configuration.getfloat` is removed in Airflow 3.0
     |
-131 | # airflow.configuration
-132 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+127 | # airflow.configuration
+128 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     |                  ^^^^^^^^ AIR301
     |
     = help: Use `airflow.configuration.conf.getfloat` instead
 
-AIR301_names.py:132:28: AIR301 `airflow.configuration.getint` is removed in Airflow 3.0
+AIR301_names.py:128:28: AIR301 `airflow.configuration.getint` is removed in Airflow 3.0
     |
-131 | # airflow.configuration
-132 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+127 | # airflow.configuration
+128 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     |                            ^^^^^^ AIR301
     |
     = help: Use `airflow.configuration.conf.getint` instead
 
-AIR301_names.py:132:36: AIR301 `airflow.configuration.has_option` is removed in Airflow 3.0
+AIR301_names.py:128:36: AIR301 `airflow.configuration.has_option` is removed in Airflow 3.0
     |
-131 | # airflow.configuration
-132 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+127 | # airflow.configuration
+128 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     |                                    ^^^^^^^^^^ AIR301
     |
     = help: Use `airflow.configuration.conf.has_option` instead
 
-AIR301_names.py:132:48: AIR301 `airflow.configuration.remove_option` is removed in Airflow 3.0
+AIR301_names.py:128:48: AIR301 `airflow.configuration.remove_option` is removed in Airflow 3.0
     |
-131 | # airflow.configuration
-132 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+127 | # airflow.configuration
+128 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     |                                                ^^^^^^^^^^^^^ AIR301
     |
     = help: Use `airflow.configuration.conf.remove_option` instead
 
-AIR301_names.py:132:63: AIR301 `airflow.configuration.as_dict` is removed in Airflow 3.0
+AIR301_names.py:128:63: AIR301 `airflow.configuration.as_dict` is removed in Airflow 3.0
     |
-131 | # airflow.configuration
-132 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+127 | # airflow.configuration
+128 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     |                                                               ^^^^^^^ AIR301
     |
     = help: Use `airflow.configuration.conf.as_dict` instead
 
-AIR301_names.py:132:72: AIR301 `airflow.configuration.set` is removed in Airflow 3.0
+AIR301_names.py:128:72: AIR301 `airflow.configuration.set` is removed in Airflow 3.0
     |
-131 | # airflow.configuration
-132 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+127 | # airflow.configuration
+128 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     |                                                                        ^^^ AIR301
     |
     = help: Use `airflow.configuration.conf.set` instead
 
-AIR301_names.py:136:1: AIR301 `airflow.contrib.aws_athena_hook.AWSAthenaHook` is removed in Airflow 3.0; The whole `airflow.contrib` module has been removed.
+AIR301_names.py:132:1: AIR301 `airflow.contrib.aws_athena_hook.AWSAthenaHook` is removed in Airflow 3.0; The whole `airflow.contrib` module has been removed.
     |
-135 | # airflow.contrib.*
-136 | AWSAthenaHook()
+131 | # airflow.contrib.*
+132 | AWSAthenaHook()
     | ^^^^^^^^^^^^^ AIR301
-137 |
-138 | # airflow.datasets
+133 |
+134 | # airflow.datasets
     |
 
-AIR301_names.py:139:1: AIR301 [*] `airflow.datasets.Dataset` is removed in Airflow 3.0
+AIR301_names.py:135:1: AIR301 [*] `airflow.datasets.Dataset` is removed in Airflow 3.0
     |
-138 | # airflow.datasets
-139 | Dataset()
+134 | # airflow.datasets
+135 | Dataset()
     | ^^^^^^^ AIR301
-140 | DatasetAlias()
-141 | DatasetAliasEvent()
+136 | DatasetAlias()
+137 | DatasetAliasEvent()
     |
     = help: Use `airflow.sdk.Asset` instead
 
 ℹ Safe fix
-116 116 | from airflow.utils.trigger_rule import TriggerRule
-117 117 | from airflow.www.auth import has_access, has_access_dataset
-118 118 | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
-    119 |+from airflow.sdk import Asset
-119 120 | 
-120 121 | # airflow root
-121 122 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+112 112 | from airflow.utils.trigger_rule import TriggerRule
+113 113 | from airflow.www.auth import has_access, has_access_dataset
+114 114 | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
+    115 |+from airflow.sdk import Asset
+115 116 | 
+116 117 | # airflow root
+117 118 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
 --------------------------------------------------------------------------------
-136 137 | AWSAthenaHook()
-137 138 | 
-138 139 | # airflow.datasets
-139     |-Dataset()
-    140 |+Asset()
-140 141 | DatasetAlias()
-141 142 | DatasetAliasEvent()
-142 143 | DatasetAll()
+132 133 | AWSAthenaHook()
+133 134 | 
+134 135 | # airflow.datasets
+135     |-Dataset()
+    136 |+Asset()
+136 137 | DatasetAlias()
+137 138 | DatasetAliasEvent()
+138 139 | DatasetAll()
 
-AIR301_names.py:140:1: AIR301 `airflow.datasets.DatasetAlias` is removed in Airflow 3.0
+AIR301_names.py:136:1: AIR301 `airflow.datasets.DatasetAlias` is removed in Airflow 3.0
     |
-138 | # airflow.datasets
-139 | Dataset()
-140 | DatasetAlias()
+134 | # airflow.datasets
+135 | Dataset()
+136 | DatasetAlias()
     | ^^^^^^^^^^^^ AIR301
-141 | DatasetAliasEvent()
-142 | DatasetAll()
+137 | DatasetAliasEvent()
+138 | DatasetAll()
     |
     = help: Use `airflow.sdk.AssetAlias` instead
 
-AIR301_names.py:141:1: AIR301 `airflow.datasets.DatasetAliasEvent` is removed in Airflow 3.0
+AIR301_names.py:137:1: AIR301 `airflow.datasets.DatasetAliasEvent` is removed in Airflow 3.0
     |
-139 | Dataset()
-140 | DatasetAlias()
-141 | DatasetAliasEvent()
+135 | Dataset()
+136 | DatasetAlias()
+137 | DatasetAliasEvent()
     | ^^^^^^^^^^^^^^^^^ AIR301
-142 | DatasetAll()
-143 | DatasetAny()
+138 | DatasetAll()
+139 | DatasetAny()
     |
 
-AIR301_names.py:142:1: AIR301 `airflow.datasets.DatasetAll` is removed in Airflow 3.0
+AIR301_names.py:138:1: AIR301 `airflow.datasets.DatasetAll` is removed in Airflow 3.0
     |
-140 | DatasetAlias()
-141 | DatasetAliasEvent()
-142 | DatasetAll()
+136 | DatasetAlias()
+137 | DatasetAliasEvent()
+138 | DatasetAll()
     | ^^^^^^^^^^ AIR301
-143 | DatasetAny()
-144 | Metadata()
+139 | DatasetAny()
+140 | Metadata()
     |
     = help: Use `airflow.sdk.AssetAll` instead
 
-AIR301_names.py:143:1: AIR301 `airflow.datasets.DatasetAny` is removed in Airflow 3.0
+AIR301_names.py:139:1: AIR301 `airflow.datasets.DatasetAny` is removed in Airflow 3.0
     |
-141 | DatasetAliasEvent()
-142 | DatasetAll()
-143 | DatasetAny()
+137 | DatasetAliasEvent()
+138 | DatasetAll()
+139 | DatasetAny()
     | ^^^^^^^^^^ AIR301
-144 | Metadata()
-145 | expand_alias_to_datasets
+140 | Metadata()
+141 | expand_alias_to_datasets
     |
     = help: Use `airflow.sdk.AssetAny` instead
 
-AIR301_names.py:144:1: AIR301 `airflow.datasets.metadata.Metadata` is removed in Airflow 3.0
+AIR301_names.py:140:1: AIR301 `airflow.datasets.metadata.Metadata` is removed in Airflow 3.0
     |
-142 | DatasetAll()
-143 | DatasetAny()
-144 | Metadata()
+138 | DatasetAll()
+139 | DatasetAny()
+140 | Metadata()
     | ^^^^^^^^ AIR301
-145 | expand_alias_to_datasets
+141 | expand_alias_to_datasets
     |
     = help: Use `airflow.sdk.Metadata` instead
 
-AIR301_names.py:145:1: AIR301 `airflow.datasets.expand_alias_to_datasets` is removed in Airflow 3.0
+AIR301_names.py:141:1: AIR301 `airflow.datasets.expand_alias_to_datasets` is removed in Airflow 3.0
     |
-143 | DatasetAny()
-144 | Metadata()
-145 | expand_alias_to_datasets
+139 | DatasetAny()
+140 | Metadata()
+141 | expand_alias_to_datasets
     | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR301
-146 |
-147 | # airflow.datasets.manager
+142 |
+143 | # airflow.datasets.manager
     |
     = help: Use `airflow.sdk.expand_alias_to_assets` instead
 
-AIR301_names.py:148:1: AIR301 `airflow.datasets.manager.DatasetManager` is removed in Airflow 3.0
+AIR301_names.py:144:1: AIR301 `airflow.datasets.manager.DatasetManager` is removed in Airflow 3.0
     |
-147 | # airflow.datasets.manager
-148 | DatasetManager()
+143 | # airflow.datasets.manager
+144 | DatasetManager()
     | ^^^^^^^^^^^^^^ AIR301
-149 | dataset_manager
-150 | resolve_dataset_manager
+145 | dataset_manager
+146 | resolve_dataset_manager
     |
     = help: Use `airflow.assets.AssetManager` instead
 
-AIR301_names.py:149:1: AIR301 `airflow.datasets.manager.dataset_manager` is removed in Airflow 3.0
+AIR301_names.py:145:1: AIR301 `airflow.datasets.manager.dataset_manager` is removed in Airflow 3.0
     |
-147 | # airflow.datasets.manager
-148 | DatasetManager()
-149 | dataset_manager
+143 | # airflow.datasets.manager
+144 | DatasetManager()
+145 | dataset_manager
     | ^^^^^^^^^^^^^^^ AIR301
-150 | resolve_dataset_manager
+146 | resolve_dataset_manager
     |
     = help: Use `airflow.assets.manager.asset_manager` instead
 
-AIR301_names.py:150:1: AIR301 `airflow.datasets.manager.resolve_dataset_manager` is removed in Airflow 3.0
+AIR301_names.py:146:1: AIR301 `airflow.datasets.manager.resolve_dataset_manager` is removed in Airflow 3.0
     |
-148 | DatasetManager()
-149 | dataset_manager
-150 | resolve_dataset_manager
+144 | DatasetManager()
+145 | dataset_manager
+146 | resolve_dataset_manager
     | ^^^^^^^^^^^^^^^^^^^^^^^ AIR301
-151 |
-152 | # airflow.hooks
+147 |
+148 | # airflow.hooks
     |
     = help: Use `airflow.assets.resolve_asset_manager` instead
 
-AIR301_names.py:153:1: AIR301 `airflow.hooks.base_hook.BaseHook` is removed in Airflow 3.0
+AIR301_names.py:149:1: AIR301 `airflow.hooks.base_hook.BaseHook` is removed in Airflow 3.0
     |
-152 | # airflow.hooks
-153 | BaseHook()
+148 | # airflow.hooks
+149 | BaseHook()
     | ^^^^^^^^ AIR301
-154 |
-155 | # airflow.lineage.hook
+150 |
+151 | # airflow.lineage.hook
     |
     = help: Use `airflow.hooks.base.BaseHook` instead
 
-AIR301_names.py:156:1: AIR301 `airflow.lineage.hook.DatasetLineageInfo` is removed in Airflow 3.0
+AIR301_names.py:152:1: AIR301 `airflow.lineage.hook.DatasetLineageInfo` is removed in Airflow 3.0
     |
-155 | # airflow.lineage.hook
-156 | DatasetLineageInfo()
+151 | # airflow.lineage.hook
+152 | DatasetLineageInfo()
     | ^^^^^^^^^^^^^^^^^^ AIR301
-157 |
-158 | # airflow.listeners.spec.dataset
+153 |
+154 | # airflow.listeners.spec.dataset
     |
     = help: Use `airflow.lineage.hook.AssetLineageInfo` instead
 
-AIR301_names.py:159:1: AIR301 `airflow.listeners.spec.dataset.on_dataset_changed` is removed in Airflow 3.0
+AIR301_names.py:155:1: AIR301 `airflow.listeners.spec.dataset.on_dataset_changed` is removed in Airflow 3.0
     |
-158 | # airflow.listeners.spec.dataset
-159 | on_dataset_changed
+154 | # airflow.listeners.spec.dataset
+155 | on_dataset_changed
     | ^^^^^^^^^^^^^^^^^^ AIR301
-160 | on_dataset_created
+156 | on_dataset_created
     |
     = help: Use `airflow.listeners.spec.asset.on_asset_changed` instead
 
-AIR301_names.py:160:1: AIR301 `airflow.listeners.spec.dataset.on_dataset_created` is removed in Airflow 3.0
+AIR301_names.py:156:1: AIR301 `airflow.listeners.spec.dataset.on_dataset_created` is removed in Airflow 3.0
     |
-158 | # airflow.listeners.spec.dataset
-159 | on_dataset_changed
-160 | on_dataset_created
+154 | # airflow.listeners.spec.dataset
+155 | on_dataset_changed
+156 | on_dataset_created
     | ^^^^^^^^^^^^^^^^^^ AIR301
-161 |
-162 | # airflow.metrics.validators
+157 |
+158 | # airflow.metrics.validators
     |
     = help: Use `airflow.listeners.spec.asset.on_asset_created` instead
 
-AIR301_names.py:163:1: AIR301 `airflow.metrics.validators.AllowListValidator` is removed in Airflow 3.0
+AIR301_names.py:159:1: AIR301 `airflow.metrics.validators.AllowListValidator` is removed in Airflow 3.0
     |
-162 | # airflow.metrics.validators
-163 | AllowListValidator()
+158 | # airflow.metrics.validators
+159 | AllowListValidator()
     | ^^^^^^^^^^^^^^^^^^ AIR301
-164 | BlockListValidator()
+160 | BlockListValidator()
     |
     = help: Use `airflow.metrics.validators.PatternAllowListValidator` instead
 
-AIR301_names.py:164:1: AIR301 `airflow.metrics.validators.BlockListValidator` is removed in Airflow 3.0
+AIR301_names.py:160:1: AIR301 `airflow.metrics.validators.BlockListValidator` is removed in Airflow 3.0
     |
-162 | # airflow.metrics.validators
-163 | AllowListValidator()
-164 | BlockListValidator()
+158 | # airflow.metrics.validators
+159 | AllowListValidator()
+160 | BlockListValidator()
     | ^^^^^^^^^^^^^^^^^^ AIR301
     |
     = help: Use `airflow.metrics.validators.PatternBlockListValidator` instead
 
-AIR301_names.py:168:1: AIR301 `airflow.models.baseoperator.chain` is removed in Airflow 3.0
+AIR301_names.py:164:1: AIR301 `airflow.models.baseoperator.chain` is removed in Airflow 3.0
     |
-167 | # airflow.models.baseoperator
-168 | chain, chain_linear, cross_downstream
+163 | # airflow.models.baseoperator
+164 | chain, chain_linear, cross_downstream
     | ^^^^^ AIR301
-169 |
-170 | # airflow.models.baseoperatorlink
+165 |
+166 | # airflow.models.baseoperatorlink
     |
     = help: Use `airflow.sdk.chain` instead
 
-AIR301_names.py:168:8: AIR301 `airflow.models.baseoperator.chain_linear` is removed in Airflow 3.0
+AIR301_names.py:164:8: AIR301 `airflow.models.baseoperator.chain_linear` is removed in Airflow 3.0
     |
-167 | # airflow.models.baseoperator
-168 | chain, chain_linear, cross_downstream
+163 | # airflow.models.baseoperator
+164 | chain, chain_linear, cross_downstream
     |        ^^^^^^^^^^^^ AIR301
-169 |
-170 | # airflow.models.baseoperatorlink
+165 |
+166 | # airflow.models.baseoperatorlink
     |
     = help: Use `airflow.sdk.chain_linear` instead
 
-AIR301_names.py:168:22: AIR301 `airflow.models.baseoperator.cross_downstream` is removed in Airflow 3.0
+AIR301_names.py:164:22: AIR301 `airflow.models.baseoperator.cross_downstream` is removed in Airflow 3.0
     |
-167 | # airflow.models.baseoperator
-168 | chain, chain_linear, cross_downstream
+163 | # airflow.models.baseoperator
+164 | chain, chain_linear, cross_downstream
     |                      ^^^^^^^^^^^^^^^^ AIR301
-169 |
-170 | # airflow.models.baseoperatorlink
+165 |
+166 | # airflow.models.baseoperatorlink
     |
     = help: Use `airflow.sdk.cross_downstream` instead
 
-AIR301_names.py:171:1: AIR301 `airflow.models.baseoperatorlink.BaseOperatorLink` is removed in Airflow 3.0
+AIR301_names.py:200:1: AIR301 `airflow.operators.subdag.SubDagOperator` is removed in Airflow 3.0; The whole `airflow.subdag` module has been removed.
     |
-170 | # airflow.models.baseoperatorlink
-171 | BaseOperatorLink()
-    | ^^^^^^^^^^^^^^^^ AIR301
-172 |
-173 | # ariflow.notifications.basenotifier
-    |
-    = help: Use `airflow.sdk.definitions.baseoperatorlink.BaseOperatorLink` instead
-
-AIR301_names.py:174:1: AIR301 `airflow.notifications.basenotifier.BaseNotifier` is removed in Airflow 3.0
-    |
-173 | # ariflow.notifications.basenotifier
-174 | BaseNotifier()
-    | ^^^^^^^^^^^^ AIR301
-    |
-    = help: Use `airflow.sdk.BaseNotifier` instead
-
-AIR301_names.py:185:1: AIR301 `airflow.operators.branch_operator.BaseBranchOperator` is removed in Airflow 3.0
-    |
-184 | # airflow.operators.branch_operator
-185 | BaseBranchOperator()
-    | ^^^^^^^^^^^^^^^^^^ AIR301
-186 |
-187 | # airflow.operators.dagrun_operator
-    |
-    = help: Use `airflow.operators.branch.BaseBranchOperator` instead
-
-AIR301_names.py:188:1: AIR301 `airflow.operators.dagrun_operator.TriggerDagRunLink` is removed in Airflow 3.0
-    |
-187 | # airflow.operators.dagrun_operator
-188 | TriggerDagRunLink()
-    | ^^^^^^^^^^^^^^^^^ AIR301
-189 | TriggerDagRunOperator()
-    |
-    = help: Use `airflow.operators.trigger_dagrun.TriggerDagRunLink` instead
-
-AIR301_names.py:189:1: AIR301 `airflow.operators.dagrun_operator.TriggerDagRunOperator` is removed in Airflow 3.0
-    |
-187 | # airflow.operators.dagrun_operator
-188 | TriggerDagRunLink()
-189 | TriggerDagRunOperator()
-    | ^^^^^^^^^^^^^^^^^^^^^ AIR301
-190 |
-191 | # airflow.operators.email_operator
-    |
-    = help: Use `airflow.operators.trigger_dagrun.TriggerDagRunOperator` instead
-
-AIR301_names.py:195:1: AIR301 `airflow.operators.latest_only_operator.LatestOnlyOperator` is removed in Airflow 3.0
-    |
-194 | # airflow.operators.latest_only_operator
-195 | LatestOnlyOperator()
-    | ^^^^^^^^^^^^^^^^^^ AIR301
-196 |
-197 | # airflow.operators.python_operator
-    |
-    = help: Use `airflow.operators.latest_only.LatestOnlyOperator` instead
-
-AIR301_names.py:198:1: AIR301 `airflow.operators.python_operator.BranchPythonOperator` is removed in Airflow 3.0
-    |
-197 | # airflow.operators.python_operator
-198 | BranchPythonOperator()
-    | ^^^^^^^^^^^^^^^^^^^^ AIR301
-199 | PythonOperator()
-200 | PythonVirtualenvOperator()
-    |
-    = help: Use `airflow.operators.python.BranchPythonOperator` instead
-
-AIR301_names.py:199:1: AIR301 `airflow.operators.python_operator.PythonOperator` is removed in Airflow 3.0
-    |
-197 | # airflow.operators.python_operator
-198 | BranchPythonOperator()
-199 | PythonOperator()
+199 | # airflow.operators.subdag.*
+200 | SubDagOperator()
     | ^^^^^^^^^^^^^^ AIR301
-200 | PythonVirtualenvOperator()
-201 | ShortCircuitOperator()
-    |
-    = help: Use `airflow.operators.python.PythonOperator` instead
-
-AIR301_names.py:200:1: AIR301 `airflow.operators.python_operator.PythonVirtualenvOperator` is removed in Airflow 3.0
-    |
-198 | BranchPythonOperator()
-199 | PythonOperator()
-200 | PythonVirtualenvOperator()
-    | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR301
-201 | ShortCircuitOperator()
-    |
-    = help: Use `airflow.operators.python.PythonVirtualenvOperator` instead
-
-AIR301_names.py:201:1: AIR301 `airflow.operators.python_operator.ShortCircuitOperator` is removed in Airflow 3.0
-    |
-199 | PythonOperator()
-200 | PythonVirtualenvOperator()
-201 | ShortCircuitOperator()
-    | ^^^^^^^^^^^^^^^^^^^^ AIR301
-202 |
-203 | # airflow.operators.subdag.*
-    |
-    = help: Use `airflow.operators.python.ShortCircuitOperator` instead
-
-AIR301_names.py:204:1: AIR301 `airflow.operators.subdag.SubDagOperator` is removed in Airflow 3.0; The whole `airflow.subdag` module has been removed.
-    |
-203 | # airflow.operators.subdag.*
-204 | SubDagOperator()
-    | ^^^^^^^^^^^^^^ AIR301
-205 |
-206 | # airflow.providers.amazon
+201 |
+202 | # airflow.providers.amazon
     |
 
-AIR301_names.py:207:13: AIR301 `airflow.providers.amazon.aws.auth_manager.avp.entities.AvpEntities.DATASET` is removed in Airflow 3.0
+AIR301_names.py:203:13: AIR301 `airflow.providers.amazon.aws.auth_manager.avp.entities.AvpEntities.DATASET` is removed in Airflow 3.0
     |
-206 | # airflow.providers.amazon
-207 | AvpEntities.DATASET
+202 | # airflow.providers.amazon
+203 | AvpEntities.DATASET
     |             ^^^^^^^ AIR301
-208 | s3.create_dataset
-209 | s3.convert_dataset_to_openlineage
+204 | s3.create_dataset
+205 | s3.convert_dataset_to_openlineage
     |
     = help: Use `airflow.providers.amazon.aws.auth_manager.avp.entities.AvpEntities.ASSET` instead
 
-AIR301_names.py:208:4: AIR301 `airflow.providers.amazon.aws.datasets.s3.create_dataset` is removed in Airflow 3.0
+AIR301_names.py:204:4: AIR301 `airflow.providers.amazon.aws.datasets.s3.create_dataset` is removed in Airflow 3.0
     |
-206 | # airflow.providers.amazon
-207 | AvpEntities.DATASET
-208 | s3.create_dataset
+202 | # airflow.providers.amazon
+203 | AvpEntities.DATASET
+204 | s3.create_dataset
     |    ^^^^^^^^^^^^^^ AIR301
-209 | s3.convert_dataset_to_openlineage
-210 | s3.sanitize_uri
+205 | s3.convert_dataset_to_openlineage
+206 | s3.sanitize_uri
     |
     = help: Use `airflow.providers.amazon.aws.assets.s3.create_asset` instead
 
-AIR301_names.py:209:4: AIR301 `airflow.providers.amazon.aws.datasets.s3.convert_dataset_to_openlineage` is removed in Airflow 3.0
+AIR301_names.py:205:4: AIR301 `airflow.providers.amazon.aws.datasets.s3.convert_dataset_to_openlineage` is removed in Airflow 3.0
     |
-207 | AvpEntities.DATASET
-208 | s3.create_dataset
-209 | s3.convert_dataset_to_openlineage
+203 | AvpEntities.DATASET
+204 | s3.create_dataset
+205 | s3.convert_dataset_to_openlineage
     |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR301
-210 | s3.sanitize_uri
+206 | s3.sanitize_uri
     |
     = help: Use `airflow.providers.amazon.aws.assets.s3.convert_asset_to_openlineage` instead
 
-AIR301_names.py:210:4: AIR301 `airflow.providers.amazon.aws.datasets.s3.sanitize_uri` is removed in Airflow 3.0
+AIR301_names.py:206:4: AIR301 `airflow.providers.amazon.aws.datasets.s3.sanitize_uri` is removed in Airflow 3.0
     |
-208 | s3.create_dataset
-209 | s3.convert_dataset_to_openlineage
-210 | s3.sanitize_uri
+204 | s3.create_dataset
+205 | s3.convert_dataset_to_openlineage
+206 | s3.sanitize_uri
     |    ^^^^^^^^^^^^ AIR301
-211 |
-212 | # airflow.providers.common.io
+207 |
+208 | # airflow.providers.common.io
     |
     = help: Use `airflow.providers.amazon.aws.assets.s3.sanitize_uri` instead
 
-AIR301_names.py:213:16: AIR301 `airflow.providers.common.io.datasets.file.convert_dataset_to_openlineage` is removed in Airflow 3.0
+AIR301_names.py:209:16: AIR301 `airflow.providers.common.io.datasets.file.convert_dataset_to_openlineage` is removed in Airflow 3.0
     |
-212 | # airflow.providers.common.io
-213 | common_io_file.convert_dataset_to_openlineage
+208 | # airflow.providers.common.io
+209 | common_io_file.convert_dataset_to_openlineage
     |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR301
-214 | common_io_file.create_dataset
-215 | common_io_file.sanitize_uri
+210 | common_io_file.create_dataset
+211 | common_io_file.sanitize_uri
     |
     = help: Use `airflow.providers.common.io.assets.file.convert_asset_to_openlineage` instead
 
-AIR301_names.py:214:16: AIR301 `airflow.providers.common.io.datasets.file.create_dataset` is removed in Airflow 3.0
+AIR301_names.py:210:16: AIR301 `airflow.providers.common.io.datasets.file.create_dataset` is removed in Airflow 3.0
     |
-212 | # airflow.providers.common.io
-213 | common_io_file.convert_dataset_to_openlineage
-214 | common_io_file.create_dataset
+208 | # airflow.providers.common.io
+209 | common_io_file.convert_dataset_to_openlineage
+210 | common_io_file.create_dataset
     |                ^^^^^^^^^^^^^^ AIR301
-215 | common_io_file.sanitize_uri
+211 | common_io_file.sanitize_uri
     |
     = help: Use `airflow.providers.common.io.assets.file.create_asset` instead
 
-AIR301_names.py:215:16: AIR301 `airflow.providers.common.io.datasets.file.sanitize_uri` is removed in Airflow 3.0
+AIR301_names.py:211:16: AIR301 `airflow.providers.common.io.datasets.file.sanitize_uri` is removed in Airflow 3.0
     |
-213 | common_io_file.convert_dataset_to_openlineage
-214 | common_io_file.create_dataset
-215 | common_io_file.sanitize_uri
+209 | common_io_file.convert_dataset_to_openlineage
+210 | common_io_file.create_dataset
+211 | common_io_file.sanitize_uri
     |                ^^^^^^^^^^^^ AIR301
-216 |
-217 | # airflow.providers.fab
+212 |
+213 | # airflow.providers.fab
     |
     = help: Use `airflow.providers.common.io.assets.file.sanitize_uri` instead
 
-AIR301_names.py:218:18: AIR301 `airflow.providers.fab.auth_manager.fab_auth_manager.is_authorized_dataset` is removed in Airflow 3.0
+AIR301_names.py:214:18: AIR301 `airflow.providers.fab.auth_manager.fab_auth_manager.is_authorized_dataset` is removed in Airflow 3.0
     |
-217 | # airflow.providers.fab
-218 | fab_auth_manager.is_authorized_dataset
+213 | # airflow.providers.fab
+214 | fab_auth_manager.is_authorized_dataset
     |                  ^^^^^^^^^^^^^^^^^^^^^ AIR301
-219 |
-220 | # airflow.providers.google
+215 |
+216 | # airflow.providers.google
     |
     = help: Use `airflow.providers.fab.auth_manager.fab_auth_manager.is_authorized_asset` instead
 
-AIR301_names.py:223:5: AIR301 `airflow.providers.google.datasets.gcs.create_dataset` is removed in Airflow 3.0
+AIR301_names.py:219:5: AIR301 `airflow.providers.google.datasets.gcs.create_dataset` is removed in Airflow 3.0
     |
-221 | bigquery.sanitize_uri
-222 |
-223 | gcs.create_dataset
+217 | bigquery.sanitize_uri
+218 |
+219 | gcs.create_dataset
     |     ^^^^^^^^^^^^^^ AIR301
-224 | gcs.sanitize_uri
-225 | gcs.convert_dataset_to_openlineage
+220 | gcs.sanitize_uri
+221 | gcs.convert_dataset_to_openlineage
     |
     = help: Use `airflow.providers.google.assets.gcs.create_asset` instead
 
-AIR301_names.py:224:5: AIR301 `airflow.providers.google.datasets.gcs.sanitize_uri` is removed in Airflow 3.0
+AIR301_names.py:220:5: AIR301 `airflow.providers.google.datasets.gcs.sanitize_uri` is removed in Airflow 3.0
     |
-223 | gcs.create_dataset
-224 | gcs.sanitize_uri
+219 | gcs.create_dataset
+220 | gcs.sanitize_uri
     |     ^^^^^^^^^^^^ AIR301
-225 | gcs.convert_dataset_to_openlineage
+221 | gcs.convert_dataset_to_openlineage
     |
     = help: Use `airflow.providers.google.assets.gcs.sanitize_uri` instead
 
-AIR301_names.py:225:5: AIR301 `airflow.providers.google.datasets.gcs.convert_dataset_to_openlineage` is removed in Airflow 3.0
+AIR301_names.py:221:5: AIR301 `airflow.providers.google.datasets.gcs.convert_dataset_to_openlineage` is removed in Airflow 3.0
     |
-223 | gcs.create_dataset
-224 | gcs.sanitize_uri
-225 | gcs.convert_dataset_to_openlineage
+219 | gcs.create_dataset
+220 | gcs.sanitize_uri
+221 | gcs.convert_dataset_to_openlineage
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR301
-226 |
-227 | # airflow.providers.mysql
+222 |
+223 | # airflow.providers.mysql
     |
     = help: Use `airflow.providers.google.assets.gcs.convert_asset_to_openlineage` instead
 
-AIR301_names.py:228:7: AIR301 `airflow.providers.mysql.datasets.mysql.sanitize_uri` is removed in Airflow 3.0
+AIR301_names.py:224:7: AIR301 `airflow.providers.mysql.datasets.mysql.sanitize_uri` is removed in Airflow 3.0
     |
-227 | # airflow.providers.mysql
-228 | mysql.sanitize_uri
+223 | # airflow.providers.mysql
+224 | mysql.sanitize_uri
     |       ^^^^^^^^^^^^ AIR301
-229 |
-230 | # airflow.providers.openlineage
+225 |
+226 | # airflow.providers.openlineage
     |
     = help: Use `airflow.providers.mysql.assets.mysql.sanitize_uri` instead
 
-AIR301_names.py:231:1: AIR301 `airflow.providers.openlineage.utils.utils.DatasetInfo` is removed in Airflow 3.0
+AIR301_names.py:227:1: AIR301 `airflow.providers.openlineage.utils.utils.DatasetInfo` is removed in Airflow 3.0
     |
-230 | # airflow.providers.openlineage
-231 | DatasetInfo()
+226 | # airflow.providers.openlineage
+227 | DatasetInfo()
     | ^^^^^^^^^^^ AIR301
-232 | translate_airflow_dataset
+228 | translate_airflow_dataset
     |
     = help: Use `airflow.providers.openlineage.utils.utils.AssetInfo` instead
 
-AIR301_names.py:232:1: AIR301 `airflow.providers.openlineage.utils.utils.translate_airflow_dataset` is removed in Airflow 3.0
+AIR301_names.py:228:1: AIR301 `airflow.providers.openlineage.utils.utils.translate_airflow_dataset` is removed in Airflow 3.0
     |
-230 | # airflow.providers.openlineage
-231 | DatasetInfo()
-232 | translate_airflow_dataset
+226 | # airflow.providers.openlineage
+227 | DatasetInfo()
+228 | translate_airflow_dataset
     | ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR301
-233 |
-234 | # airflow.providers.postgres
+229 |
+230 | # airflow.providers.postgres
     |
     = help: Use `airflow.providers.openlineage.utils.utils.translate_airflow_asset` instead
 
-AIR301_names.py:235:10: AIR301 `airflow.providers.postgres.datasets.postgres.sanitize_uri` is removed in Airflow 3.0
+AIR301_names.py:231:10: AIR301 `airflow.providers.postgres.datasets.postgres.sanitize_uri` is removed in Airflow 3.0
     |
-234 | # airflow.providers.postgres
-235 | postgres.sanitize_uri
+230 | # airflow.providers.postgres
+231 | postgres.sanitize_uri
     |          ^^^^^^^^^^^^ AIR301
-236 |
-237 | # airflow.providers.trino
+232 |
+233 | # airflow.providers.trino
     |
     = help: Use `airflow.providers.postgres.assets.postgres.sanitize_uri` instead
 
-AIR301_names.py:238:7: AIR301 `airflow.providers.trino.datasets.trino.sanitize_uri` is removed in Airflow 3.0
+AIR301_names.py:234:7: AIR301 `airflow.providers.trino.datasets.trino.sanitize_uri` is removed in Airflow 3.0
     |
-237 | # airflow.providers.trino
-238 | trino.sanitize_uri
+233 | # airflow.providers.trino
+234 | trino.sanitize_uri
     |       ^^^^^^^^^^^^ AIR301
-239 |
-240 | # airflow.secrets
+235 |
+236 | # airflow.secrets
     |
     = help: Use `airflow.providers.trino.assets.trino.sanitize_uri` instead
 
-AIR301_names.py:243:1: AIR301 `airflow.secrets.local_filesystem.load_connections` is removed in Airflow 3.0
+AIR301_names.py:239:1: AIR301 `airflow.secrets.local_filesystem.load_connections` is removed in Airflow 3.0
     |
-241 | # get_connection
-242 | LocalFilesystemBackend()
-243 | load_connections
+237 | # get_connection
+238 | LocalFilesystemBackend()
+239 | load_connections
     | ^^^^^^^^^^^^^^^^ AIR301
-244 |
-245 | # airflow.security.permissions
+240 |
+241 | # airflow.security.permissions
     |
     = help: Use `airflow.secrets.local_filesystem.load_connections_dict` instead
 
-AIR301_names.py:246:1: AIR301 `airflow.security.permissions.RESOURCE_DATASET` is removed in Airflow 3.0
+AIR301_names.py:242:1: AIR301 `airflow.security.permissions.RESOURCE_DATASET` is removed in Airflow 3.0
     |
-245 | # airflow.security.permissions
-246 | RESOURCE_DATASET
+241 | # airflow.security.permissions
+242 | RESOURCE_DATASET
     | ^^^^^^^^^^^^^^^^ AIR301
-247 |
-248 | # airflow.sensors.base_sensor_operator
+243 |
+244 | # airflow.sensors.base_sensor_operator
     |
     = help: Use `airflow.security.permissions.RESOURCE_ASSET` instead
 
-AIR301_names.py:249:1: AIR301 `airflow.sensors.base_sensor_operator.BaseSensorOperator` is removed in Airflow 3.0
+AIR301_names.py:245:1: AIR301 `airflow.sensors.base_sensor_operator.BaseSensorOperator` is removed in Airflow 3.0
     |
-248 | # airflow.sensors.base_sensor_operator
-249 | BaseSensorOperator()
+244 | # airflow.sensors.base_sensor_operator
+245 | BaseSensorOperator()
     | ^^^^^^^^^^^^^^^^^^ AIR301
-250 |
-251 | # airflow.sensors.date_time_sensor
+246 |
+247 | # airflow.sensors.date_time_sensor
     |
     = help: Use `airflow.sdk.bases.sensor.BaseSensorOperator` instead
 
-AIR301_names.py:252:1: AIR301 `airflow.sensors.date_time_sensor.DateTimeSensor` is removed in Airflow 3.0
+AIR301_names.py:248:1: AIR301 `airflow.sensors.date_time_sensor.DateTimeSensor` is removed in Airflow 3.0
     |
-251 | # airflow.sensors.date_time_sensor
-252 | DateTimeSensor()
+247 | # airflow.sensors.date_time_sensor
+248 | DateTimeSensor()
     | ^^^^^^^^^^^^^^ AIR301
-253 |
-254 | # airflow.sensors.external_task
     |
     = help: Use `airflow.sensors.date_time.DateTimeSensor` instead
 
-AIR301_names.py:255:1: AIR301 `airflow.sensors.external_task.ExternalTaskSensorLink` is removed in Airflow 3.0
+AIR301_names.py:264:1: AIR301 `airflow.timetables.datasets.DatasetOrTimeSchedule` is removed in Airflow 3.0
     |
-254 | # airflow.sensors.external_task
-255 | ExternalTaskSensorLink()
-    | ^^^^^^^^^^^^^^^^^^^^^^ AIR301
-256 | ExternalTaskMarker()
-257 | ExternalTaskSensor()
-    |
-    = help: Use `airflow.sensors.external_task.ExternalDagLink` instead
-
-AIR301_names.py:256:1: AIR301 `airflow.sensors.external_task.ExternalTaskMarker` is removed in Airflow 3.0
-    |
-254 | # airflow.sensors.external_task
-255 | ExternalTaskSensorLink()
-256 | ExternalTaskMarker()
-    | ^^^^^^^^^^^^^^^^^^ AIR301
-257 | ExternalTaskSensor()
-    |
-    = help: Use `airflow.sensors.external_task.ExternalTaskMarker` instead
-
-AIR301_names.py:257:1: AIR301 `airflow.sensors.external_task.ExternalTaskSensor` is removed in Airflow 3.0
-    |
-255 | ExternalTaskSensorLink()
-256 | ExternalTaskMarker()
-257 | ExternalTaskSensor()
-    | ^^^^^^^^^^^^^^^^^^ AIR301
-258 |
-259 | # airflow.sensors.external_task_sensor
-    |
-    = help: Use `airflow.sensors.external_task.ExternalTaskSensor` instead
-
-AIR301_names.py:260:1: AIR301 `airflow.sensors.external_task_sensor.ExternalTaskMarker` is removed in Airflow 3.0
-    |
-259 | # airflow.sensors.external_task_sensor
-260 | ExternalTaskMarkerFromExternalTaskSensor()
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR301
-261 | ExternalTaskSensorFromExternalTaskSensor()
-262 | ExternalTaskSensorLinkFromExternalTaskSensor()
-    |
-    = help: Use `airflow.sensors.external_task.ExternalTaskMarker` instead
-
-AIR301_names.py:261:1: AIR301 `airflow.sensors.external_task_sensor.ExternalTaskSensor` is removed in Airflow 3.0
-    |
-259 | # airflow.sensors.external_task_sensor
-260 | ExternalTaskMarkerFromExternalTaskSensor()
-261 | ExternalTaskSensorFromExternalTaskSensor()
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR301
-262 | ExternalTaskSensorLinkFromExternalTaskSensor()
-    |
-    = help: Use `airflow.sensors.external_task.ExternalTaskSensor` instead
-
-AIR301_names.py:262:1: AIR301 `airflow.sensors.external_task_sensor.ExternalTaskSensorLink` is removed in Airflow 3.0
-    |
-260 | ExternalTaskMarkerFromExternalTaskSensor()
-261 | ExternalTaskSensorFromExternalTaskSensor()
-262 | ExternalTaskSensorLinkFromExternalTaskSensor()
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR301
-263 |
-264 | # airflow.sensors.time_delta_sensor
-    |
-    = help: Use `airflow.sensors.external_task.ExternalDagLink` instead
-
-AIR301_names.py:265:1: AIR301 `airflow.sensors.time_delta_sensor.TimeDeltaSensor` is removed in Airflow 3.0
-    |
-264 | # airflow.sensors.time_delta_sensor
-265 | TimeDeltaSensor()
-    | ^^^^^^^^^^^^^^^ AIR301
-266 |
-267 | # airflow.timetables
-    |
-    = help: Use `airflow.sensors.time_delta.TimeDeltaSensor` instead
-
-AIR301_names.py:268:1: AIR301 `airflow.timetables.datasets.DatasetOrTimeSchedule` is removed in Airflow 3.0
-    |
-267 | # airflow.timetables
-268 | DatasetOrTimeSchedule()
+263 | # airflow.timetables
+264 | DatasetOrTimeSchedule()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR301
-269 | DatasetTriggeredTimetable()
+265 | DatasetTriggeredTimetable()
     |
     = help: Use `airflow.timetables.assets.AssetOrTimeSchedule` instead
 
-AIR301_names.py:269:1: AIR301 `airflow.timetables.simple.DatasetTriggeredTimetable` is removed in Airflow 3.0
+AIR301_names.py:265:1: AIR301 `airflow.timetables.simple.DatasetTriggeredTimetable` is removed in Airflow 3.0
     |
-267 | # airflow.timetables
-268 | DatasetOrTimeSchedule()
-269 | DatasetTriggeredTimetable()
+263 | # airflow.timetables
+264 | DatasetOrTimeSchedule()
+265 | DatasetTriggeredTimetable()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR301
-270 |
-271 | # airflow.triggers.external_task
+266 |
+267 | # airflow.triggers.external_task
     |
     = help: Use `airflow.timetables.simple.AssetTriggeredTimetable` instead
 
-AIR301_names.py:272:1: AIR301 `airflow.triggers.external_task.TaskStateTrigger` is removed in Airflow 3.0
+AIR301_names.py:268:1: AIR301 `airflow.triggers.external_task.TaskStateTrigger` is removed in Airflow 3.0
     |
-271 | # airflow.triggers.external_task
-272 | TaskStateTrigger()
+267 | # airflow.triggers.external_task
+268 | TaskStateTrigger()
     | ^^^^^^^^^^^^^^^^ AIR301
-273 |
-274 | # airflow.utils.date
+269 |
+270 | # airflow.utils.date
     |
 
-AIR301_names.py:275:7: AIR301 `airflow.utils.dates.date_range` is removed in Airflow 3.0
+AIR301_names.py:271:7: AIR301 `airflow.utils.dates.date_range` is removed in Airflow 3.0
     |
-274 | # airflow.utils.date
-275 | dates.date_range
+270 | # airflow.utils.date
+271 | dates.date_range
     |       ^^^^^^^^^^ AIR301
-276 | dates.days_ago
+272 | dates.days_ago
     |
 
-AIR301_names.py:276:7: AIR301 `airflow.utils.dates.days_ago` is removed in Airflow 3.0
+AIR301_names.py:272:7: AIR301 `airflow.utils.dates.days_ago` is removed in Airflow 3.0
     |
-274 | # airflow.utils.date
-275 | dates.date_range
-276 | dates.days_ago
+270 | # airflow.utils.date
+271 | dates.date_range
+272 | dates.days_ago
     |       ^^^^^^^^ AIR301
-277 |
-278 | date_range
+273 |
+274 | date_range
     |
     = help: Use `pendulum.today('UTC').add(days=-N, ...)` instead
 
-AIR301_names.py:278:1: AIR301 `airflow.utils.dates.date_range` is removed in Airflow 3.0
+AIR301_names.py:274:1: AIR301 `airflow.utils.dates.date_range` is removed in Airflow 3.0
     |
-276 | dates.days_ago
-277 |
-278 | date_range
+272 | dates.days_ago
+273 |
+274 | date_range
     | ^^^^^^^^^^ AIR301
-279 | days_ago
-280 | infer_time_unit
+275 | days_ago
+276 | infer_time_unit
     |
 
-AIR301_names.py:279:1: AIR301 `airflow.utils.dates.days_ago` is removed in Airflow 3.0
+AIR301_names.py:275:1: AIR301 `airflow.utils.dates.days_ago` is removed in Airflow 3.0
     |
-278 | date_range
-279 | days_ago
+274 | date_range
+275 | days_ago
     | ^^^^^^^^ AIR301
-280 | infer_time_unit
-281 | parse_execution_date
+276 | infer_time_unit
+277 | parse_execution_date
     |
     = help: Use `pendulum.today('UTC').add(days=-N, ...)` instead
 
-AIR301_names.py:280:1: AIR301 `airflow.utils.dates.infer_time_unit` is removed in Airflow 3.0
+AIR301_names.py:276:1: AIR301 `airflow.utils.dates.infer_time_unit` is removed in Airflow 3.0
     |
-278 | date_range
-279 | days_ago
-280 | infer_time_unit
+274 | date_range
+275 | days_ago
+276 | infer_time_unit
     | ^^^^^^^^^^^^^^^ AIR301
-281 | parse_execution_date
-282 | round_time
+277 | parse_execution_date
+278 | round_time
     |
 
-AIR301_names.py:281:1: AIR301 `airflow.utils.dates.parse_execution_date` is removed in Airflow 3.0
+AIR301_names.py:277:1: AIR301 `airflow.utils.dates.parse_execution_date` is removed in Airflow 3.0
     |
-279 | days_ago
-280 | infer_time_unit
-281 | parse_execution_date
+275 | days_ago
+276 | infer_time_unit
+277 | parse_execution_date
     | ^^^^^^^^^^^^^^^^^^^^ AIR301
-282 | round_time
-283 | scale_time_units
+278 | round_time
+279 | scale_time_units
     |
 
-AIR301_names.py:282:1: AIR301 `airflow.utils.dates.round_time` is removed in Airflow 3.0
+AIR301_names.py:278:1: AIR301 `airflow.utils.dates.round_time` is removed in Airflow 3.0
     |
-280 | infer_time_unit
-281 | parse_execution_date
-282 | round_time
+276 | infer_time_unit
+277 | parse_execution_date
+278 | round_time
     | ^^^^^^^^^^ AIR301
-283 | scale_time_units
+279 | scale_time_units
     |
 
-AIR301_names.py:283:1: AIR301 `airflow.utils.dates.scale_time_units` is removed in Airflow 3.0
+AIR301_names.py:279:1: AIR301 `airflow.utils.dates.scale_time_units` is removed in Airflow 3.0
     |
-281 | parse_execution_date
-282 | round_time
-283 | scale_time_units
+277 | parse_execution_date
+278 | round_time
+279 | scale_time_units
     | ^^^^^^^^^^^^^^^^ AIR301
-284 |
-285 | # This one was not deprecated.
+280 |
+281 | # This one was not deprecated.
     |
 
-AIR301_names.py:290:1: AIR301 `airflow.utils.dag_cycle_tester.test_cycle` is removed in Airflow 3.0
+AIR301_names.py:286:1: AIR301 `airflow.utils.dag_cycle_tester.test_cycle` is removed in Airflow 3.0
     |
-289 | # airflow.utils.dag_cycle_tester
-290 | test_cycle
+285 | # airflow.utils.dag_cycle_tester
+286 | test_cycle
     | ^^^^^^^^^^ AIR301
-291 |
-292 | # airflow.utils.dag_parsing_context
+287 |
+288 | # airflow.utils.dag_parsing_context
     |
 
-AIR301_names.py:293:1: AIR301 `airflow.utils.dag_parsing_context.get_parsing_context` is removed in Airflow 3.0
+AIR301_names.py:289:1: AIR301 `airflow.utils.dag_parsing_context.get_parsing_context` is removed in Airflow 3.0
     |
-292 | # airflow.utils.dag_parsing_context
-293 | get_parsing_context
+288 | # airflow.utils.dag_parsing_context
+289 | get_parsing_context
     | ^^^^^^^^^^^^^^^^^^^ AIR301
-294 |
-295 | # airflow.utils.db
+290 |
+291 | # airflow.utils.db
     |
     = help: Use `airflow.sdk.get_parsing_context` instead
 
-AIR301_names.py:296:1: AIR301 `airflow.utils.db.create_session` is removed in Airflow 3.0
+AIR301_names.py:292:1: AIR301 `airflow.utils.db.create_session` is removed in Airflow 3.0
     |
-295 | # airflow.utils.db
-296 | create_session
+291 | # airflow.utils.db
+292 | create_session
     | ^^^^^^^^^^^^^^ AIR301
-297 |
-298 | # airflow.utils.decorators
+293 |
+294 | # airflow.utils.decorators
     |
 
-AIR301_names.py:299:1: AIR301 `airflow.utils.decorators.apply_defaults` is removed in Airflow 3.0; `apply_defaults` is now unconditionally done and can be safely removed.
+AIR301_names.py:295:1: AIR301 `airflow.utils.decorators.apply_defaults` is removed in Airflow 3.0; `apply_defaults` is now unconditionally done and can be safely removed.
     |
-298 | # airflow.utils.decorators
-299 | apply_defaults
+294 | # airflow.utils.decorators
+295 | apply_defaults
     | ^^^^^^^^^^^^^^ AIR301
-300 |
-301 | # airflow.utils.file
+296 |
+297 | # airflow.utils.file
     |
 
-AIR301_names.py:302:1: AIR301 `airflow.utils.file.TemporaryDirectory` is removed in Airflow 3.0
+AIR301_names.py:298:1: AIR301 `airflow.utils.file.TemporaryDirectory` is removed in Airflow 3.0
     |
-301 | # airflow.utils.file
-302 | TemporaryDirectory()
+297 | # airflow.utils.file
+298 | TemporaryDirectory()
     | ^^^^^^^^^^^^^^^^^^ AIR301
-303 | mkdirs
+299 | mkdirs
     |
     = help: Use `tempfile.TemporaryDirectory` instead
 
-AIR301_names.py:303:1: AIR301 `airflow.utils.file.mkdirs` is removed in Airflow 3.0
+AIR301_names.py:299:1: AIR301 `airflow.utils.file.mkdirs` is removed in Airflow 3.0
     |
-301 | # airflow.utils.file
-302 | TemporaryDirectory()
-303 | mkdirs
+297 | # airflow.utils.file
+298 | TemporaryDirectory()
+299 | mkdirs
     | ^^^^^^ AIR301
-304 |
-305 | #  airflow.utils.helpers
+300 |
+301 | #  airflow.utils.helpers
     |
     = help: Use `pathlib.Path({path}).mkdir` instead
 
-AIR301_names.py:306:1: AIR301 `airflow.utils.helpers.chain` is removed in Airflow 3.0
+AIR301_names.py:302:1: AIR301 `airflow.utils.helpers.chain` is removed in Airflow 3.0
     |
-305 | #  airflow.utils.helpers
-306 | helper_chain
+301 | #  airflow.utils.helpers
+302 | helper_chain
     | ^^^^^^^^^^^^ AIR301
-307 | helper_cross_downstream
+303 | helper_cross_downstream
     |
     = help: Use `airflow.sdk.chain` instead
 
-AIR301_names.py:307:1: AIR301 `airflow.utils.helpers.cross_downstream` is removed in Airflow 3.0
+AIR301_names.py:303:1: AIR301 `airflow.utils.helpers.cross_downstream` is removed in Airflow 3.0
     |
-305 | #  airflow.utils.helpers
-306 | helper_chain
-307 | helper_cross_downstream
+301 | #  airflow.utils.helpers
+302 | helper_chain
+303 | helper_cross_downstream
     | ^^^^^^^^^^^^^^^^^^^^^^^ AIR301
-308 |
-309 | #  airflow.utils.log
+304 |
+305 | #  airflow.utils.log
     |
     = help: Use `airflow.sdk.cross_downstream` instead
 
-AIR301_names.py:310:1: AIR301 `airflow.utils.log.secrets_masker` is removed in Airflow 3.0
+AIR301_names.py:306:1: AIR301 `airflow.utils.log.secrets_masker` is removed in Airflow 3.0
     |
-309 | #  airflow.utils.log
-310 | secrets_masker
+305 | #  airflow.utils.log
+306 | secrets_masker
     | ^^^^^^^^^^^^^^ AIR301
-311 |
-312 | # airflow.utils.state
+307 |
+308 | # airflow.utils.state
     |
     = help: Use `airflow.sdk.execution_time.secrets_masker` instead
 
-AIR301_names.py:313:1: AIR301 `airflow.utils.state.SHUTDOWN` is removed in Airflow 3.0
+AIR301_names.py:309:1: AIR301 `airflow.utils.state.SHUTDOWN` is removed in Airflow 3.0
     |
-312 | # airflow.utils.state
-313 | SHUTDOWN
+308 | # airflow.utils.state
+309 | SHUTDOWN
     | ^^^^^^^^ AIR301
-314 | terminating_states
+310 | terminating_states
     |
 
-AIR301_names.py:314:1: AIR301 `airflow.utils.state.terminating_states` is removed in Airflow 3.0
+AIR301_names.py:310:1: AIR301 `airflow.utils.state.terminating_states` is removed in Airflow 3.0
     |
-312 | # airflow.utils.state
-313 | SHUTDOWN
-314 | terminating_states
+308 | # airflow.utils.state
+309 | SHUTDOWN
+310 | terminating_states
     | ^^^^^^^^^^^^^^^^^^ AIR301
-315 |
-316 | #  airflow.utils.trigger_rule
+311 |
+312 | #  airflow.utils.trigger_rule
     |
 
-AIR301_names.py:317:13: AIR301 `airflow.utils.trigger_rule.TriggerRule.DUMMY` is removed in Airflow 3.0
+AIR301_names.py:313:13: AIR301 `airflow.utils.trigger_rule.TriggerRule.DUMMY` is removed in Airflow 3.0
     |
-316 | #  airflow.utils.trigger_rule
-317 | TriggerRule.DUMMY
+312 | #  airflow.utils.trigger_rule
+313 | TriggerRule.DUMMY
     |             ^^^^^ AIR301
-318 | TriggerRule.NONE_FAILED_OR_SKIPPED
+314 | TriggerRule.NONE_FAILED_OR_SKIPPED
     |
 
-AIR301_names.py:318:13: AIR301 `airflow.utils.trigger_rule.TriggerRule.NONE_FAILED_OR_SKIPPED` is removed in Airflow 3.0
+AIR301_names.py:314:13: AIR301 `airflow.utils.trigger_rule.TriggerRule.NONE_FAILED_OR_SKIPPED` is removed in Airflow 3.0
     |
-316 | #  airflow.utils.trigger_rule
-317 | TriggerRule.DUMMY
-318 | TriggerRule.NONE_FAILED_OR_SKIPPED
+312 | #  airflow.utils.trigger_rule
+313 | TriggerRule.DUMMY
+314 | TriggerRule.NONE_FAILED_OR_SKIPPED
     |             ^^^^^^^^^^^^^^^^^^^^^^ AIR301
-319 |
-320 | # airflow.www.auth
+315 |
+316 | # airflow.www.auth
     |
 
-AIR301_names.py:321:1: AIR301 `airflow.www.auth.has_access` is removed in Airflow 3.0
+AIR301_names.py:317:1: AIR301 `airflow.www.auth.has_access` is removed in Airflow 3.0
     |
-320 | # airflow.www.auth
-321 | has_access
+316 | # airflow.www.auth
+317 | has_access
     | ^^^^^^^^^^ AIR301
-322 | has_access_dataset
+318 | has_access_dataset
     |
     = help: Use `airflow.www.auth.has_access_*` instead
 
-AIR301_names.py:322:1: AIR301 `airflow.www.auth.has_access_dataset` is removed in Airflow 3.0
+AIR301_names.py:318:1: AIR301 `airflow.www.auth.has_access_dataset` is removed in Airflow 3.0
     |
-320 | # airflow.www.auth
-321 | has_access
-322 | has_access_dataset
+316 | # airflow.www.auth
+317 | has_access
+318 | has_access_dataset
     | ^^^^^^^^^^^^^^^^^^ AIR301
-323 |
-324 | # airflow.www.utils
+319 |
+320 | # airflow.www.utils
     |
     = help: Use `airflow.www.auth.has_access_dataset.has_access_asset` instead
 
-AIR301_names.py:325:1: AIR301 `airflow.www.utils.get_sensitive_variables_fields` is removed in Airflow 3.0
+AIR301_names.py:321:1: AIR301 `airflow.www.utils.get_sensitive_variables_fields` is removed in Airflow 3.0
     |
-324 | # airflow.www.utils
-325 | get_sensitive_variables_fields
+320 | # airflow.www.utils
+321 | get_sensitive_variables_fields
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR301
-326 | should_hide_value_for_key
+322 | should_hide_value_for_key
     |
     = help: Use `airflow.utils.log.secrets_masker.get_sensitive_variables_fields` instead
 
-AIR301_names.py:326:1: AIR301 `airflow.www.utils.should_hide_value_for_key` is removed in Airflow 3.0
+AIR301_names.py:322:1: AIR301 `airflow.www.utils.should_hide_value_for_key` is removed in Airflow 3.0
     |
-324 | # airflow.www.utils
-325 | get_sensitive_variables_fields
-326 | should_hide_value_for_key
+320 | # airflow.www.utils
+321 | get_sensitive_variables_fields
+322 | should_hide_value_for_key
     | ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR301
     |
     = help: Use `airflow.utils.log.secrets_masker.should_hide_value_for_key` instead

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR301_AIR301_names.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR301_AIR301_names.py.snap
@@ -452,46 +452,6 @@ AIR301_names.py:174:1: AIR301 `airflow.notifications.basenotifier.BaseNotifier` 
     |
     = help: Use `airflow.sdk.BaseNotifier` instead
 
-AIR301_names.py:177:1: AIR301 `airflow.operators.dummy.EmptyOperator` is removed in Airflow 3.0
-    |
-176 | # airflow.operators.dummy
-177 | EmptyOperator()
-    | ^^^^^^^^^^^^^ AIR301
-178 | DummyOperator()
-    |
-    = help: Use `airflow.operators.empty.EmptyOperator` instead
-
-AIR301_names.py:178:1: AIR301 `airflow.operators.dummy.DummyOperator` is removed in Airflow 3.0
-    |
-176 | # airflow.operators.dummy
-177 | EmptyOperator()
-178 | DummyOperator()
-    | ^^^^^^^^^^^^^ AIR301
-179 |
-180 | # airflow.operators.dummy_operator
-    |
-    = help: Use `airflow.operators.empty.EmptyOperator` instead
-
-AIR301_names.py:181:16: AIR301 `airflow.operators.dummy_operator.EmptyOperator` is removed in Airflow 3.0
-    |
-180 | # airflow.operators.dummy_operator
-181 | dummy_operator.EmptyOperator()
-    |                ^^^^^^^^^^^^^ AIR301
-182 | dummy_operator.DummyOperator()
-    |
-    = help: Use `airflow.operators.empty.EmptyOperator` instead
-
-AIR301_names.py:182:16: AIR301 `airflow.operators.dummy_operator.DummyOperator` is removed in Airflow 3.0
-    |
-180 | # airflow.operators.dummy_operator
-181 | dummy_operator.EmptyOperator()
-182 | dummy_operator.DummyOperator()
-    |                ^^^^^^^^^^^^^ AIR301
-183 |
-184 | # airflow.operators.branch_operator
-    |
-    = help: Use `airflow.operators.empty.EmptyOperator` instead
-
 AIR301_names.py:185:1: AIR301 `airflow.operators.branch_operator.BaseBranchOperator` is removed in Airflow 3.0
     |
 184 | # airflow.operators.branch_operator
@@ -521,16 +481,6 @@ AIR301_names.py:189:1: AIR301 `airflow.operators.dagrun_operator.TriggerDagRunOp
 191 | # airflow.operators.email_operator
     |
     = help: Use `airflow.operators.trigger_dagrun.TriggerDagRunOperator` instead
-
-AIR301_names.py:192:1: AIR301 `airflow.operators.email_operator.EmailOperator` is removed in Airflow 3.0
-    |
-191 | # airflow.operators.email_operator
-192 | EmailOperator()
-    | ^^^^^^^^^^^^^ AIR301
-193 |
-194 | # airflow.operators.latest_only_operator
-    |
-    = help: Use `airflow.operators.email.EmailOperator` instead
 
 AIR301_names.py:195:1: AIR301 `airflow.operators.latest_only_operator.LatestOnlyOperator` is removed in Airflow 3.0
     |

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR301_AIR301_names.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR301_AIR301_names.py.snap
@@ -1,897 +1,897 @@
 ---
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 ---
-AIR301_names.py:101:1: AIR301 `airflow.PY36` is removed in Airflow 3.0
-    |
-100 | # airflow root
-101 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
-    | ^^^^ AIR301
-102 | DatasetFromRoot()
-    |
-    = help: Use `sys.version_info` instead
+AIR301_names.py:91:1: AIR301 `airflow.PY36` is removed in Airflow 3.0
+   |
+90 | # airflow root
+91 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+   | ^^^^ AIR301
+92 | DatasetFromRoot()
+   |
+   = help: Use `sys.version_info` instead
 
-AIR301_names.py:101:7: AIR301 `airflow.PY37` is removed in Airflow 3.0
-    |
-100 | # airflow root
-101 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
-    |       ^^^^ AIR301
-102 | DatasetFromRoot()
-    |
-    = help: Use `sys.version_info` instead
+AIR301_names.py:91:7: AIR301 `airflow.PY37` is removed in Airflow 3.0
+   |
+90 | # airflow root
+91 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+   |       ^^^^ AIR301
+92 | DatasetFromRoot()
+   |
+   = help: Use `sys.version_info` instead
 
-AIR301_names.py:101:13: AIR301 `airflow.PY38` is removed in Airflow 3.0
-    |
-100 | # airflow root
-101 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
-    |             ^^^^ AIR301
-102 | DatasetFromRoot()
-    |
-    = help: Use `sys.version_info` instead
+AIR301_names.py:91:13: AIR301 `airflow.PY38` is removed in Airflow 3.0
+   |
+90 | # airflow root
+91 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+   |             ^^^^ AIR301
+92 | DatasetFromRoot()
+   |
+   = help: Use `sys.version_info` instead
 
-AIR301_names.py:101:19: AIR301 `airflow.PY39` is removed in Airflow 3.0
-    |
-100 | # airflow root
-101 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
-    |                   ^^^^ AIR301
-102 | DatasetFromRoot()
-    |
-    = help: Use `sys.version_info` instead
+AIR301_names.py:91:19: AIR301 `airflow.PY39` is removed in Airflow 3.0
+   |
+90 | # airflow root
+91 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+   |                   ^^^^ AIR301
+92 | DatasetFromRoot()
+   |
+   = help: Use `sys.version_info` instead
 
-AIR301_names.py:101:25: AIR301 `airflow.PY310` is removed in Airflow 3.0
-    |
-100 | # airflow root
-101 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
-    |                         ^^^^^ AIR301
-102 | DatasetFromRoot()
-    |
-    = help: Use `sys.version_info` instead
+AIR301_names.py:91:25: AIR301 `airflow.PY310` is removed in Airflow 3.0
+   |
+90 | # airflow root
+91 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+   |                         ^^^^^ AIR301
+92 | DatasetFromRoot()
+   |
+   = help: Use `sys.version_info` instead
 
-AIR301_names.py:101:32: AIR301 `airflow.PY311` is removed in Airflow 3.0
-    |
-100 | # airflow root
-101 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
-    |                                ^^^^^ AIR301
-102 | DatasetFromRoot()
-    |
-    = help: Use `sys.version_info` instead
+AIR301_names.py:91:32: AIR301 `airflow.PY311` is removed in Airflow 3.0
+   |
+90 | # airflow root
+91 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+   |                                ^^^^^ AIR301
+92 | DatasetFromRoot()
+   |
+   = help: Use `sys.version_info` instead
 
-AIR301_names.py:101:39: AIR301 `airflow.PY312` is removed in Airflow 3.0
-    |
-100 | # airflow root
-101 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
-    |                                       ^^^^^ AIR301
-102 | DatasetFromRoot()
-    |
-    = help: Use `sys.version_info` instead
+AIR301_names.py:91:39: AIR301 `airflow.PY312` is removed in Airflow 3.0
+   |
+90 | # airflow root
+91 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+   |                                       ^^^^^ AIR301
+92 | DatasetFromRoot()
+   |
+   = help: Use `sys.version_info` instead
 
-AIR301_names.py:102:1: AIR301 [*] `airflow.Dataset` is removed in Airflow 3.0
-    |
-100 | # airflow root
-101 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
-102 | DatasetFromRoot()
-    | ^^^^^^^^^^^^^^^ AIR301
-103 |
-104 | # airflow.api_connexion.security
-    |
-    = help: Use `airflow.sdk.Asset` instead
-
-ℹ Safe fix
-96  96  | from airflow.utils.trigger_rule import TriggerRule
-97  97  | from airflow.www.auth import has_access, has_access_dataset
-98  98  | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
-    99  |+from airflow.sdk import Asset
-99  100 | 
-100 101 | # airflow root
-101 102 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
-102     |-DatasetFromRoot()
-    103 |+Asset()
-103 104 | 
-104 105 | # airflow.api_connexion.security
-105 106 | requires_access, requires_access_dataset
-
-AIR301_names.py:105:1: AIR301 `airflow.api_connexion.security.requires_access` is removed in Airflow 3.0
-    |
-104 | # airflow.api_connexion.security
-105 | requires_access, requires_access_dataset
-    | ^^^^^^^^^^^^^^^ AIR301
-106 |
-107 | # airflow.auth.managers
-    |
-    = help: Use `airflow.api_connexion.security.requires_access_*` instead
-
-AIR301_names.py:105:18: AIR301 [*] `airflow.api_connexion.security.requires_access_dataset` is removed in Airflow 3.0
-    |
-104 | # airflow.api_connexion.security
-105 | requires_access, requires_access_dataset
-    |                  ^^^^^^^^^^^^^^^^^^^^^^^ AIR301
-106 |
-107 | # airflow.auth.managers
-    |
-    = help: Use `airflow.api_connexion.security.requires_access_asset` instead
+AIR301_names.py:92:1: AIR301 [*] `airflow.Dataset` is removed in Airflow 3.0
+   |
+90 | # airflow root
+91 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+92 | DatasetFromRoot()
+   | ^^^^^^^^^^^^^^^ AIR301
+93 |
+94 | # airflow.api_connexion.security
+   |
+   = help: Use `airflow.sdk.Asset` instead
 
 ℹ Safe fix
-12  12  | from airflow import (
-13  13  |     Dataset as DatasetFromRoot,
-14  14  | )
-15      |-from airflow.api_connexion.security import requires_access, requires_access_dataset
-    15  |+from airflow.api_connexion.security import requires_access, requires_access_dataset, requires_access_asset
-16  16  | from airflow.auth.managers.base_auth_manager import is_authorized_dataset
-17  17  | from airflow.auth.managers.models.resource_details import DatasetDetails
-18  18  | from airflow.configuration import (
+86 86 | from airflow.utils.trigger_rule import TriggerRule
+87 87 | from airflow.www.auth import has_access, has_access_dataset
+88 88 | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
+   89 |+from airflow.sdk import Asset
+89 90 | 
+90 91 | # airflow root
+91 92 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+92    |-DatasetFromRoot()
+   93 |+Asset()
+93 94 | 
+94 95 | # airflow.api_connexion.security
+95 96 | requires_access, requires_access_dataset
+
+AIR301_names.py:95:1: AIR301 `airflow.api_connexion.security.requires_access` is removed in Airflow 3.0
+   |
+94 | # airflow.api_connexion.security
+95 | requires_access, requires_access_dataset
+   | ^^^^^^^^^^^^^^^ AIR301
+96 |
+97 | # airflow.auth.managers
+   |
+   = help: Use `airflow.api_connexion.security.requires_access_*` instead
+
+AIR301_names.py:95:18: AIR301 [*] `airflow.api_connexion.security.requires_access_dataset` is removed in Airflow 3.0
+   |
+94 | # airflow.api_connexion.security
+95 | requires_access, requires_access_dataset
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^ AIR301
+96 |
+97 | # airflow.auth.managers
+   |
+   = help: Use `airflow.api_connexion.security.requires_access_asset` instead
+
+ℹ Safe fix
+12 12 | from airflow import (
+13 13 |     Dataset as DatasetFromRoot,
+14 14 | )
+15    |-from airflow.api_connexion.security import requires_access, requires_access_dataset
+   15 |+from airflow.api_connexion.security import requires_access, requires_access_dataset, requires_access_asset
+16 16 | from airflow.auth.managers.base_auth_manager import is_authorized_dataset
+17 17 | from airflow.auth.managers.models.resource_details import DatasetDetails
+18 18 | from airflow.configuration import (
 --------------------------------------------------------------------------------
-102 102 | DatasetFromRoot()
-103 103 | 
-104 104 | # airflow.api_connexion.security
-105     |-requires_access, requires_access_dataset
-    105 |+requires_access, requires_access_asset
-106 106 | 
-107 107 | # airflow.auth.managers
-108 108 | is_authorized_dataset
+92 92 | DatasetFromRoot()
+93 93 | 
+94 94 | # airflow.api_connexion.security
+95    |-requires_access, requires_access_dataset
+   95 |+requires_access, requires_access_asset
+96 96 | 
+97 97 | # airflow.auth.managers
+98 98 | is_authorized_dataset
 
-AIR301_names.py:108:1: AIR301 `airflow.auth.managers.base_auth_manager.is_authorized_dataset` is removed in Airflow 3.0
-    |
-107 | # airflow.auth.managers
-108 | is_authorized_dataset
-    | ^^^^^^^^^^^^^^^^^^^^^ AIR301
-109 | DatasetDetails()
-    |
-    = help: Use `airflow.api_fastapi.auth.managers.base_auth_manager.is_authorized_asset` instead
+AIR301_names.py:98:1: AIR301 `airflow.auth.managers.base_auth_manager.is_authorized_dataset` is removed in Airflow 3.0
+   |
+97 | # airflow.auth.managers
+98 | is_authorized_dataset
+   | ^^^^^^^^^^^^^^^^^^^^^ AIR301
+99 | DatasetDetails()
+   |
+   = help: Use `airflow.api_fastapi.auth.managers.base_auth_manager.is_authorized_asset` instead
 
-AIR301_names.py:109:1: AIR301 `airflow.auth.managers.models.resource_details.DatasetDetails` is removed in Airflow 3.0
+AIR301_names.py:99:1: AIR301 `airflow.auth.managers.models.resource_details.DatasetDetails` is removed in Airflow 3.0
     |
-107 | # airflow.auth.managers
-108 | is_authorized_dataset
-109 | DatasetDetails()
+ 97 | # airflow.auth.managers
+ 98 | is_authorized_dataset
+ 99 | DatasetDetails()
     | ^^^^^^^^^^^^^^ AIR301
-110 |
-111 | # airflow.configuration
+100 |
+101 | # airflow.configuration
     |
     = help: Use `airflow.api_fastapi.auth.managers.models.resource_details.AssetDetails` instead
 
-AIR301_names.py:112:1: AIR301 `airflow.configuration.get` is removed in Airflow 3.0
+AIR301_names.py:102:1: AIR301 `airflow.configuration.get` is removed in Airflow 3.0
     |
-111 | # airflow.configuration
-112 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+101 | # airflow.configuration
+102 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     | ^^^ AIR301
     |
     = help: Use `airflow.configuration.conf.get` instead
 
-AIR301_names.py:112:6: AIR301 `airflow.configuration.getboolean` is removed in Airflow 3.0
+AIR301_names.py:102:6: AIR301 `airflow.configuration.getboolean` is removed in Airflow 3.0
     |
-111 | # airflow.configuration
-112 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+101 | # airflow.configuration
+102 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     |      ^^^^^^^^^^ AIR301
     |
     = help: Use `airflow.configuration.conf.getboolean` instead
 
-AIR301_names.py:112:18: AIR301 `airflow.configuration.getfloat` is removed in Airflow 3.0
+AIR301_names.py:102:18: AIR301 `airflow.configuration.getfloat` is removed in Airflow 3.0
     |
-111 | # airflow.configuration
-112 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+101 | # airflow.configuration
+102 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     |                  ^^^^^^^^ AIR301
     |
     = help: Use `airflow.configuration.conf.getfloat` instead
 
-AIR301_names.py:112:28: AIR301 `airflow.configuration.getint` is removed in Airflow 3.0
+AIR301_names.py:102:28: AIR301 `airflow.configuration.getint` is removed in Airflow 3.0
     |
-111 | # airflow.configuration
-112 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+101 | # airflow.configuration
+102 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     |                            ^^^^^^ AIR301
     |
     = help: Use `airflow.configuration.conf.getint` instead
 
-AIR301_names.py:112:36: AIR301 `airflow.configuration.has_option` is removed in Airflow 3.0
+AIR301_names.py:102:36: AIR301 `airflow.configuration.has_option` is removed in Airflow 3.0
     |
-111 | # airflow.configuration
-112 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+101 | # airflow.configuration
+102 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     |                                    ^^^^^^^^^^ AIR301
     |
     = help: Use `airflow.configuration.conf.has_option` instead
 
-AIR301_names.py:112:48: AIR301 `airflow.configuration.remove_option` is removed in Airflow 3.0
+AIR301_names.py:102:48: AIR301 `airflow.configuration.remove_option` is removed in Airflow 3.0
     |
-111 | # airflow.configuration
-112 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+101 | # airflow.configuration
+102 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     |                                                ^^^^^^^^^^^^^ AIR301
     |
     = help: Use `airflow.configuration.conf.remove_option` instead
 
-AIR301_names.py:112:63: AIR301 `airflow.configuration.as_dict` is removed in Airflow 3.0
+AIR301_names.py:102:63: AIR301 `airflow.configuration.as_dict` is removed in Airflow 3.0
     |
-111 | # airflow.configuration
-112 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+101 | # airflow.configuration
+102 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     |                                                               ^^^^^^^ AIR301
     |
     = help: Use `airflow.configuration.conf.as_dict` instead
 
-AIR301_names.py:112:72: AIR301 `airflow.configuration.set` is removed in Airflow 3.0
+AIR301_names.py:102:72: AIR301 `airflow.configuration.set` is removed in Airflow 3.0
     |
-111 | # airflow.configuration
-112 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+101 | # airflow.configuration
+102 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     |                                                                        ^^^ AIR301
     |
     = help: Use `airflow.configuration.conf.set` instead
 
-AIR301_names.py:116:1: AIR301 `airflow.contrib.aws_athena_hook.AWSAthenaHook` is removed in Airflow 3.0; The whole `airflow.contrib` module has been removed.
+AIR301_names.py:106:1: AIR301 `airflow.contrib.aws_athena_hook.AWSAthenaHook` is removed in Airflow 3.0; The whole `airflow.contrib` module has been removed.
     |
-115 | # airflow.contrib.*
-116 | AWSAthenaHook()
+105 | # airflow.contrib.*
+106 | AWSAthenaHook()
     | ^^^^^^^^^^^^^ AIR301
-117 |
-118 | # airflow.datasets
+107 |
+108 | # airflow.datasets
     |
 
-AIR301_names.py:119:1: AIR301 [*] `airflow.datasets.Dataset` is removed in Airflow 3.0
+AIR301_names.py:109:1: AIR301 [*] `airflow.datasets.Dataset` is removed in Airflow 3.0
     |
-118 | # airflow.datasets
-119 | Dataset()
+108 | # airflow.datasets
+109 | Dataset()
     | ^^^^^^^ AIR301
-120 | DatasetAlias()
-121 | DatasetAliasEvent()
+110 | DatasetAlias()
+111 | DatasetAliasEvent()
     |
     = help: Use `airflow.sdk.Asset` instead
 
 ℹ Safe fix
-96  96  | from airflow.utils.trigger_rule import TriggerRule
-97  97  | from airflow.www.auth import has_access, has_access_dataset
-98  98  | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
-    99  |+from airflow.sdk import Asset
-99  100 | 
-100 101 | # airflow root
-101 102 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+86  86  | from airflow.utils.trigger_rule import TriggerRule
+87  87  | from airflow.www.auth import has_access, has_access_dataset
+88  88  | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
+    89  |+from airflow.sdk import Asset
+89  90  | 
+90  91  | # airflow root
+91  92  | PY36, PY37, PY38, PY39, PY310, PY311, PY312
 --------------------------------------------------------------------------------
-116 117 | AWSAthenaHook()
-117 118 | 
-118 119 | # airflow.datasets
-119     |-Dataset()
-    120 |+Asset()
-120 121 | DatasetAlias()
-121 122 | DatasetAliasEvent()
-122 123 | DatasetAll()
+106 107 | AWSAthenaHook()
+107 108 | 
+108 109 | # airflow.datasets
+109     |-Dataset()
+    110 |+Asset()
+110 111 | DatasetAlias()
+111 112 | DatasetAliasEvent()
+112 113 | DatasetAll()
 
-AIR301_names.py:120:1: AIR301 `airflow.datasets.DatasetAlias` is removed in Airflow 3.0
+AIR301_names.py:110:1: AIR301 `airflow.datasets.DatasetAlias` is removed in Airflow 3.0
     |
-118 | # airflow.datasets
-119 | Dataset()
-120 | DatasetAlias()
+108 | # airflow.datasets
+109 | Dataset()
+110 | DatasetAlias()
     | ^^^^^^^^^^^^ AIR301
-121 | DatasetAliasEvent()
-122 | DatasetAll()
+111 | DatasetAliasEvent()
+112 | DatasetAll()
     |
     = help: Use `airflow.sdk.AssetAlias` instead
 
-AIR301_names.py:121:1: AIR301 `airflow.datasets.DatasetAliasEvent` is removed in Airflow 3.0
+AIR301_names.py:111:1: AIR301 `airflow.datasets.DatasetAliasEvent` is removed in Airflow 3.0
     |
-119 | Dataset()
-120 | DatasetAlias()
-121 | DatasetAliasEvent()
+109 | Dataset()
+110 | DatasetAlias()
+111 | DatasetAliasEvent()
     | ^^^^^^^^^^^^^^^^^ AIR301
-122 | DatasetAll()
-123 | DatasetAny()
+112 | DatasetAll()
+113 | DatasetAny()
     |
 
-AIR301_names.py:122:1: AIR301 `airflow.datasets.DatasetAll` is removed in Airflow 3.0
+AIR301_names.py:112:1: AIR301 `airflow.datasets.DatasetAll` is removed in Airflow 3.0
     |
-120 | DatasetAlias()
-121 | DatasetAliasEvent()
-122 | DatasetAll()
+110 | DatasetAlias()
+111 | DatasetAliasEvent()
+112 | DatasetAll()
     | ^^^^^^^^^^ AIR301
-123 | DatasetAny()
-124 | Metadata()
+113 | DatasetAny()
+114 | Metadata()
     |
     = help: Use `airflow.sdk.AssetAll` instead
 
-AIR301_names.py:123:1: AIR301 `airflow.datasets.DatasetAny` is removed in Airflow 3.0
+AIR301_names.py:113:1: AIR301 `airflow.datasets.DatasetAny` is removed in Airflow 3.0
     |
-121 | DatasetAliasEvent()
-122 | DatasetAll()
-123 | DatasetAny()
+111 | DatasetAliasEvent()
+112 | DatasetAll()
+113 | DatasetAny()
     | ^^^^^^^^^^ AIR301
-124 | Metadata()
-125 | expand_alias_to_datasets
+114 | Metadata()
+115 | expand_alias_to_datasets
     |
     = help: Use `airflow.sdk.AssetAny` instead
 
-AIR301_names.py:124:1: AIR301 `airflow.datasets.metadata.Metadata` is removed in Airflow 3.0
+AIR301_names.py:114:1: AIR301 `airflow.datasets.metadata.Metadata` is removed in Airflow 3.0
     |
-122 | DatasetAll()
-123 | DatasetAny()
-124 | Metadata()
+112 | DatasetAll()
+113 | DatasetAny()
+114 | Metadata()
     | ^^^^^^^^ AIR301
-125 | expand_alias_to_datasets
+115 | expand_alias_to_datasets
     |
     = help: Use `airflow.sdk.Metadata` instead
 
-AIR301_names.py:125:1: AIR301 `airflow.datasets.expand_alias_to_datasets` is removed in Airflow 3.0
+AIR301_names.py:115:1: AIR301 `airflow.datasets.expand_alias_to_datasets` is removed in Airflow 3.0
     |
-123 | DatasetAny()
-124 | Metadata()
-125 | expand_alias_to_datasets
+113 | DatasetAny()
+114 | Metadata()
+115 | expand_alias_to_datasets
     | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR301
-126 |
-127 | # airflow.datasets.manager
+116 |
+117 | # airflow.datasets.manager
     |
     = help: Use `airflow.sdk.expand_alias_to_assets` instead
 
-AIR301_names.py:128:1: AIR301 `airflow.datasets.manager.DatasetManager` is removed in Airflow 3.0
+AIR301_names.py:118:1: AIR301 `airflow.datasets.manager.DatasetManager` is removed in Airflow 3.0
     |
-127 | # airflow.datasets.manager
-128 | DatasetManager()
+117 | # airflow.datasets.manager
+118 | DatasetManager()
     | ^^^^^^^^^^^^^^ AIR301
-129 | dataset_manager
-130 | resolve_dataset_manager
+119 | dataset_manager
+120 | resolve_dataset_manager
     |
     = help: Use `airflow.assets.AssetManager` instead
 
-AIR301_names.py:129:1: AIR301 `airflow.datasets.manager.dataset_manager` is removed in Airflow 3.0
+AIR301_names.py:119:1: AIR301 `airflow.datasets.manager.dataset_manager` is removed in Airflow 3.0
     |
-127 | # airflow.datasets.manager
-128 | DatasetManager()
-129 | dataset_manager
+117 | # airflow.datasets.manager
+118 | DatasetManager()
+119 | dataset_manager
     | ^^^^^^^^^^^^^^^ AIR301
-130 | resolve_dataset_manager
+120 | resolve_dataset_manager
     |
     = help: Use `airflow.assets.manager.asset_manager` instead
 
-AIR301_names.py:130:1: AIR301 `airflow.datasets.manager.resolve_dataset_manager` is removed in Airflow 3.0
+AIR301_names.py:120:1: AIR301 `airflow.datasets.manager.resolve_dataset_manager` is removed in Airflow 3.0
     |
-128 | DatasetManager()
-129 | dataset_manager
-130 | resolve_dataset_manager
+118 | DatasetManager()
+119 | dataset_manager
+120 | resolve_dataset_manager
     | ^^^^^^^^^^^^^^^^^^^^^^^ AIR301
-131 |
-132 | # airflow.hooks
+121 |
+122 | # airflow.hooks
     |
     = help: Use `airflow.assets.resolve_asset_manager` instead
 
-AIR301_names.py:133:1: AIR301 `airflow.hooks.base_hook.BaseHook` is removed in Airflow 3.0
+AIR301_names.py:123:1: AIR301 `airflow.hooks.base_hook.BaseHook` is removed in Airflow 3.0
     |
-132 | # airflow.hooks
-133 | BaseHook()
+122 | # airflow.hooks
+123 | BaseHook()
     | ^^^^^^^^ AIR301
-134 |
-135 | # airflow.lineage.hook
+124 |
+125 | # airflow.lineage.hook
     |
     = help: Use `airflow.hooks.base.BaseHook` instead
 
-AIR301_names.py:136:1: AIR301 `airflow.lineage.hook.DatasetLineageInfo` is removed in Airflow 3.0
+AIR301_names.py:126:1: AIR301 `airflow.lineage.hook.DatasetLineageInfo` is removed in Airflow 3.0
     |
-135 | # airflow.lineage.hook
-136 | DatasetLineageInfo()
+125 | # airflow.lineage.hook
+126 | DatasetLineageInfo()
     | ^^^^^^^^^^^^^^^^^^ AIR301
-137 |
-138 | # airflow.listeners.spec.dataset
+127 |
+128 | # airflow.listeners.spec.dataset
     |
     = help: Use `airflow.lineage.hook.AssetLineageInfo` instead
 
-AIR301_names.py:139:1: AIR301 `airflow.listeners.spec.dataset.on_dataset_changed` is removed in Airflow 3.0
+AIR301_names.py:129:1: AIR301 `airflow.listeners.spec.dataset.on_dataset_changed` is removed in Airflow 3.0
     |
-138 | # airflow.listeners.spec.dataset
-139 | on_dataset_changed
+128 | # airflow.listeners.spec.dataset
+129 | on_dataset_changed
     | ^^^^^^^^^^^^^^^^^^ AIR301
-140 | on_dataset_created
+130 | on_dataset_created
     |
     = help: Use `airflow.listeners.spec.asset.on_asset_changed` instead
 
-AIR301_names.py:140:1: AIR301 `airflow.listeners.spec.dataset.on_dataset_created` is removed in Airflow 3.0
+AIR301_names.py:130:1: AIR301 `airflow.listeners.spec.dataset.on_dataset_created` is removed in Airflow 3.0
     |
-138 | # airflow.listeners.spec.dataset
-139 | on_dataset_changed
-140 | on_dataset_created
+128 | # airflow.listeners.spec.dataset
+129 | on_dataset_changed
+130 | on_dataset_created
     | ^^^^^^^^^^^^^^^^^^ AIR301
-141 |
-142 | # airflow.metrics.validators
+131 |
+132 | # airflow.metrics.validators
     |
     = help: Use `airflow.listeners.spec.asset.on_asset_created` instead
 
-AIR301_names.py:143:1: AIR301 `airflow.metrics.validators.AllowListValidator` is removed in Airflow 3.0
+AIR301_names.py:133:1: AIR301 `airflow.metrics.validators.AllowListValidator` is removed in Airflow 3.0
     |
-142 | # airflow.metrics.validators
-143 | AllowListValidator()
+132 | # airflow.metrics.validators
+133 | AllowListValidator()
     | ^^^^^^^^^^^^^^^^^^ AIR301
-144 | BlockListValidator()
+134 | BlockListValidator()
     |
     = help: Use `airflow.metrics.validators.PatternAllowListValidator` instead
 
-AIR301_names.py:144:1: AIR301 `airflow.metrics.validators.BlockListValidator` is removed in Airflow 3.0
+AIR301_names.py:134:1: AIR301 `airflow.metrics.validators.BlockListValidator` is removed in Airflow 3.0
     |
-142 | # airflow.metrics.validators
-143 | AllowListValidator()
-144 | BlockListValidator()
+132 | # airflow.metrics.validators
+133 | AllowListValidator()
+134 | BlockListValidator()
     | ^^^^^^^^^^^^^^^^^^ AIR301
     |
     = help: Use `airflow.metrics.validators.PatternBlockListValidator` instead
 
-AIR301_names.py:148:1: AIR301 `airflow.models.baseoperator.chain` is removed in Airflow 3.0
+AIR301_names.py:138:1: AIR301 `airflow.models.baseoperator.chain` is removed in Airflow 3.0
     |
-147 | # airflow.models.baseoperator
-148 | chain, chain_linear, cross_downstream
+137 | # airflow.models.baseoperator
+138 | chain, chain_linear, cross_downstream
     | ^^^^^ AIR301
     |
     = help: Use `airflow.sdk.chain` instead
 
-AIR301_names.py:148:8: AIR301 `airflow.models.baseoperator.chain_linear` is removed in Airflow 3.0
+AIR301_names.py:138:8: AIR301 `airflow.models.baseoperator.chain_linear` is removed in Airflow 3.0
     |
-147 | # airflow.models.baseoperator
-148 | chain, chain_linear, cross_downstream
+137 | # airflow.models.baseoperator
+138 | chain, chain_linear, cross_downstream
     |        ^^^^^^^^^^^^ AIR301
     |
     = help: Use `airflow.sdk.chain_linear` instead
 
-AIR301_names.py:148:22: AIR301 `airflow.models.baseoperator.cross_downstream` is removed in Airflow 3.0
+AIR301_names.py:138:22: AIR301 `airflow.models.baseoperator.cross_downstream` is removed in Airflow 3.0
     |
-147 | # airflow.models.baseoperator
-148 | chain, chain_linear, cross_downstream
+137 | # airflow.models.baseoperator
+138 | chain, chain_linear, cross_downstream
     |                      ^^^^^^^^^^^^^^^^ AIR301
     |
     = help: Use `airflow.sdk.cross_downstream` instead
 
-AIR301_names.py:171:1: AIR301 `airflow.operators.subdag.SubDagOperator` is removed in Airflow 3.0; The whole `airflow.subdag` module has been removed.
+AIR301_names.py:161:1: AIR301 `airflow.operators.subdag.SubDagOperator` is removed in Airflow 3.0; The whole `airflow.subdag` module has been removed.
     |
-170 | # airflow.operators.subdag.*
-171 | SubDagOperator()
+160 | # airflow.operators.subdag.*
+161 | SubDagOperator()
     | ^^^^^^^^^^^^^^ AIR301
-172 |
-173 | # airflow.providers.amazon
+162 |
+163 | # airflow.providers.amazon
     |
 
-AIR301_names.py:174:13: AIR301 `airflow.providers.amazon.aws.auth_manager.avp.entities.AvpEntities.DATASET` is removed in Airflow 3.0
+AIR301_names.py:164:13: AIR301 `airflow.providers.amazon.aws.auth_manager.avp.entities.AvpEntities.DATASET` is removed in Airflow 3.0
     |
-173 | # airflow.providers.amazon
-174 | AvpEntities.DATASET
+163 | # airflow.providers.amazon
+164 | AvpEntities.DATASET
     |             ^^^^^^^ AIR301
-175 | s3.create_dataset
-176 | s3.convert_dataset_to_openlineage
+165 | s3.create_dataset
+166 | s3.convert_dataset_to_openlineage
     |
     = help: Use `airflow.providers.amazon.aws.auth_manager.avp.entities.AvpEntities.ASSET` instead
 
-AIR301_names.py:175:4: AIR301 `airflow.providers.amazon.aws.datasets.s3.create_dataset` is removed in Airflow 3.0
+AIR301_names.py:165:4: AIR301 `airflow.providers.amazon.aws.datasets.s3.create_dataset` is removed in Airflow 3.0
     |
-173 | # airflow.providers.amazon
-174 | AvpEntities.DATASET
-175 | s3.create_dataset
+163 | # airflow.providers.amazon
+164 | AvpEntities.DATASET
+165 | s3.create_dataset
     |    ^^^^^^^^^^^^^^ AIR301
-176 | s3.convert_dataset_to_openlineage
-177 | s3.sanitize_uri
+166 | s3.convert_dataset_to_openlineage
+167 | s3.sanitize_uri
     |
     = help: Use `airflow.providers.amazon.aws.assets.s3.create_asset` instead
 
-AIR301_names.py:176:4: AIR301 `airflow.providers.amazon.aws.datasets.s3.convert_dataset_to_openlineage` is removed in Airflow 3.0
+AIR301_names.py:166:4: AIR301 `airflow.providers.amazon.aws.datasets.s3.convert_dataset_to_openlineage` is removed in Airflow 3.0
     |
-174 | AvpEntities.DATASET
-175 | s3.create_dataset
-176 | s3.convert_dataset_to_openlineage
+164 | AvpEntities.DATASET
+165 | s3.create_dataset
+166 | s3.convert_dataset_to_openlineage
     |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR301
-177 | s3.sanitize_uri
+167 | s3.sanitize_uri
     |
     = help: Use `airflow.providers.amazon.aws.assets.s3.convert_asset_to_openlineage` instead
 
-AIR301_names.py:177:4: AIR301 `airflow.providers.amazon.aws.datasets.s3.sanitize_uri` is removed in Airflow 3.0
+AIR301_names.py:167:4: AIR301 `airflow.providers.amazon.aws.datasets.s3.sanitize_uri` is removed in Airflow 3.0
     |
-175 | s3.create_dataset
-176 | s3.convert_dataset_to_openlineage
-177 | s3.sanitize_uri
+165 | s3.create_dataset
+166 | s3.convert_dataset_to_openlineage
+167 | s3.sanitize_uri
     |    ^^^^^^^^^^^^ AIR301
-178 |
-179 | # airflow.providers.common.io
+168 |
+169 | # airflow.providers.common.io
     |
     = help: Use `airflow.providers.amazon.aws.assets.s3.sanitize_uri` instead
 
-AIR301_names.py:180:16: AIR301 `airflow.providers.common.io.datasets.file.convert_dataset_to_openlineage` is removed in Airflow 3.0
+AIR301_names.py:170:16: AIR301 `airflow.providers.common.io.datasets.file.convert_dataset_to_openlineage` is removed in Airflow 3.0
     |
-179 | # airflow.providers.common.io
-180 | common_io_file.convert_dataset_to_openlineage
+169 | # airflow.providers.common.io
+170 | common_io_file.convert_dataset_to_openlineage
     |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR301
-181 | common_io_file.create_dataset
-182 | common_io_file.sanitize_uri
+171 | common_io_file.create_dataset
+172 | common_io_file.sanitize_uri
     |
     = help: Use `airflow.providers.common.io.assets.file.convert_asset_to_openlineage` instead
 
-AIR301_names.py:181:16: AIR301 `airflow.providers.common.io.datasets.file.create_dataset` is removed in Airflow 3.0
+AIR301_names.py:171:16: AIR301 `airflow.providers.common.io.datasets.file.create_dataset` is removed in Airflow 3.0
     |
-179 | # airflow.providers.common.io
-180 | common_io_file.convert_dataset_to_openlineage
-181 | common_io_file.create_dataset
+169 | # airflow.providers.common.io
+170 | common_io_file.convert_dataset_to_openlineage
+171 | common_io_file.create_dataset
     |                ^^^^^^^^^^^^^^ AIR301
-182 | common_io_file.sanitize_uri
+172 | common_io_file.sanitize_uri
     |
     = help: Use `airflow.providers.common.io.assets.file.create_asset` instead
 
-AIR301_names.py:182:16: AIR301 `airflow.providers.common.io.datasets.file.sanitize_uri` is removed in Airflow 3.0
+AIR301_names.py:172:16: AIR301 `airflow.providers.common.io.datasets.file.sanitize_uri` is removed in Airflow 3.0
     |
-180 | common_io_file.convert_dataset_to_openlineage
-181 | common_io_file.create_dataset
-182 | common_io_file.sanitize_uri
+170 | common_io_file.convert_dataset_to_openlineage
+171 | common_io_file.create_dataset
+172 | common_io_file.sanitize_uri
     |                ^^^^^^^^^^^^ AIR301
-183 |
-184 | # airflow.providers.fab
+173 |
+174 | # airflow.providers.fab
     |
     = help: Use `airflow.providers.common.io.assets.file.sanitize_uri` instead
 
-AIR301_names.py:185:18: AIR301 `airflow.providers.fab.auth_manager.fab_auth_manager.is_authorized_dataset` is removed in Airflow 3.0
+AIR301_names.py:175:18: AIR301 `airflow.providers.fab.auth_manager.fab_auth_manager.is_authorized_dataset` is removed in Airflow 3.0
     |
-184 | # airflow.providers.fab
-185 | fab_auth_manager.is_authorized_dataset
+174 | # airflow.providers.fab
+175 | fab_auth_manager.is_authorized_dataset
     |                  ^^^^^^^^^^^^^^^^^^^^^ AIR301
-186 |
-187 | # airflow.providers.google
+176 |
+177 | # airflow.providers.google
     |
     = help: Use `airflow.providers.fab.auth_manager.fab_auth_manager.is_authorized_asset` instead
 
-AIR301_names.py:190:5: AIR301 `airflow.providers.google.datasets.gcs.create_dataset` is removed in Airflow 3.0
+AIR301_names.py:180:5: AIR301 `airflow.providers.google.datasets.gcs.create_dataset` is removed in Airflow 3.0
     |
-188 | bigquery.sanitize_uri
-189 |
-190 | gcs.create_dataset
+178 | bigquery.sanitize_uri
+179 |
+180 | gcs.create_dataset
     |     ^^^^^^^^^^^^^^ AIR301
-191 | gcs.sanitize_uri
-192 | gcs.convert_dataset_to_openlineage
+181 | gcs.sanitize_uri
+182 | gcs.convert_dataset_to_openlineage
     |
     = help: Use `airflow.providers.google.assets.gcs.create_asset` instead
 
-AIR301_names.py:191:5: AIR301 `airflow.providers.google.datasets.gcs.sanitize_uri` is removed in Airflow 3.0
+AIR301_names.py:181:5: AIR301 `airflow.providers.google.datasets.gcs.sanitize_uri` is removed in Airflow 3.0
     |
-190 | gcs.create_dataset
-191 | gcs.sanitize_uri
+180 | gcs.create_dataset
+181 | gcs.sanitize_uri
     |     ^^^^^^^^^^^^ AIR301
-192 | gcs.convert_dataset_to_openlineage
+182 | gcs.convert_dataset_to_openlineage
     |
     = help: Use `airflow.providers.google.assets.gcs.sanitize_uri` instead
 
-AIR301_names.py:192:5: AIR301 `airflow.providers.google.datasets.gcs.convert_dataset_to_openlineage` is removed in Airflow 3.0
+AIR301_names.py:182:5: AIR301 `airflow.providers.google.datasets.gcs.convert_dataset_to_openlineage` is removed in Airflow 3.0
     |
-190 | gcs.create_dataset
-191 | gcs.sanitize_uri
-192 | gcs.convert_dataset_to_openlineage
+180 | gcs.create_dataset
+181 | gcs.sanitize_uri
+182 | gcs.convert_dataset_to_openlineage
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR301
-193 |
-194 | # airflow.providers.mysql
+183 |
+184 | # airflow.providers.mysql
     |
     = help: Use `airflow.providers.google.assets.gcs.convert_asset_to_openlineage` instead
 
-AIR301_names.py:195:7: AIR301 `airflow.providers.mysql.datasets.mysql.sanitize_uri` is removed in Airflow 3.0
+AIR301_names.py:185:7: AIR301 `airflow.providers.mysql.datasets.mysql.sanitize_uri` is removed in Airflow 3.0
     |
-194 | # airflow.providers.mysql
-195 | mysql.sanitize_uri
+184 | # airflow.providers.mysql
+185 | mysql.sanitize_uri
     |       ^^^^^^^^^^^^ AIR301
-196 |
-197 | # airflow.providers.openlineage
+186 |
+187 | # airflow.providers.openlineage
     |
     = help: Use `airflow.providers.mysql.assets.mysql.sanitize_uri` instead
 
-AIR301_names.py:198:1: AIR301 `airflow.providers.openlineage.utils.utils.DatasetInfo` is removed in Airflow 3.0
+AIR301_names.py:188:1: AIR301 `airflow.providers.openlineage.utils.utils.DatasetInfo` is removed in Airflow 3.0
     |
-197 | # airflow.providers.openlineage
-198 | DatasetInfo()
+187 | # airflow.providers.openlineage
+188 | DatasetInfo()
     | ^^^^^^^^^^^ AIR301
-199 | translate_airflow_dataset
+189 | translate_airflow_dataset
     |
     = help: Use `airflow.providers.openlineage.utils.utils.AssetInfo` instead
 
-AIR301_names.py:199:1: AIR301 `airflow.providers.openlineage.utils.utils.translate_airflow_dataset` is removed in Airflow 3.0
+AIR301_names.py:189:1: AIR301 `airflow.providers.openlineage.utils.utils.translate_airflow_dataset` is removed in Airflow 3.0
     |
-197 | # airflow.providers.openlineage
-198 | DatasetInfo()
-199 | translate_airflow_dataset
+187 | # airflow.providers.openlineage
+188 | DatasetInfo()
+189 | translate_airflow_dataset
     | ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR301
-200 |
-201 | # airflow.providers.postgres
+190 |
+191 | # airflow.providers.postgres
     |
     = help: Use `airflow.providers.openlineage.utils.utils.translate_airflow_asset` instead
 
-AIR301_names.py:202:10: AIR301 `airflow.providers.postgres.datasets.postgres.sanitize_uri` is removed in Airflow 3.0
+AIR301_names.py:192:10: AIR301 `airflow.providers.postgres.datasets.postgres.sanitize_uri` is removed in Airflow 3.0
     |
-201 | # airflow.providers.postgres
-202 | postgres.sanitize_uri
+191 | # airflow.providers.postgres
+192 | postgres.sanitize_uri
     |          ^^^^^^^^^^^^ AIR301
-203 |
-204 | # airflow.providers.trino
+193 |
+194 | # airflow.providers.trino
     |
     = help: Use `airflow.providers.postgres.assets.postgres.sanitize_uri` instead
 
-AIR301_names.py:205:7: AIR301 `airflow.providers.trino.datasets.trino.sanitize_uri` is removed in Airflow 3.0
+AIR301_names.py:195:7: AIR301 `airflow.providers.trino.datasets.trino.sanitize_uri` is removed in Airflow 3.0
     |
-204 | # airflow.providers.trino
-205 | trino.sanitize_uri
+194 | # airflow.providers.trino
+195 | trino.sanitize_uri
     |       ^^^^^^^^^^^^ AIR301
-206 |
-207 | # airflow.secrets
+196 |
+197 | # airflow.secrets
     |
     = help: Use `airflow.providers.trino.assets.trino.sanitize_uri` instead
 
-AIR301_names.py:210:1: AIR301 `airflow.secrets.local_filesystem.load_connections` is removed in Airflow 3.0
+AIR301_names.py:200:1: AIR301 `airflow.secrets.local_filesystem.load_connections` is removed in Airflow 3.0
     |
-208 | # get_connection
-209 | LocalFilesystemBackend()
-210 | load_connections
+198 | # get_connection
+199 | LocalFilesystemBackend()
+200 | load_connections
     | ^^^^^^^^^^^^^^^^ AIR301
-211 |
-212 | # airflow.security.permissions
+201 |
+202 | # airflow.security.permissions
     |
     = help: Use `airflow.secrets.local_filesystem.load_connections_dict` instead
 
-AIR301_names.py:213:1: AIR301 `airflow.security.permissions.RESOURCE_DATASET` is removed in Airflow 3.0
+AIR301_names.py:203:1: AIR301 `airflow.security.permissions.RESOURCE_DATASET` is removed in Airflow 3.0
     |
-212 | # airflow.security.permissions
-213 | RESOURCE_DATASET
+202 | # airflow.security.permissions
+203 | RESOURCE_DATASET
     | ^^^^^^^^^^^^^^^^ AIR301
-214 |
-215 | # airflow.sensors.base_sensor_operator
+204 |
+205 | # airflow.sensors.base_sensor_operator
     |
     = help: Use `airflow.security.permissions.RESOURCE_ASSET` instead
 
-AIR301_names.py:216:1: AIR301 `airflow.sensors.base_sensor_operator.BaseSensorOperator` is removed in Airflow 3.0
+AIR301_names.py:206:1: AIR301 `airflow.sensors.base_sensor_operator.BaseSensorOperator` is removed in Airflow 3.0
     |
-215 | # airflow.sensors.base_sensor_operator
-216 | BaseSensorOperator()
+205 | # airflow.sensors.base_sensor_operator
+206 | BaseSensorOperator()
     | ^^^^^^^^^^^^^^^^^^ AIR301
     |
     = help: Use `airflow.sdk.bases.sensor.BaseSensorOperator` instead
 
-AIR301_names.py:220:1: AIR301 `airflow.timetables.datasets.DatasetOrTimeSchedule` is removed in Airflow 3.0
+AIR301_names.py:210:1: AIR301 `airflow.timetables.datasets.DatasetOrTimeSchedule` is removed in Airflow 3.0
     |
-219 | # airflow.timetables
-220 | DatasetOrTimeSchedule()
+209 | # airflow.timetables
+210 | DatasetOrTimeSchedule()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR301
-221 | DatasetTriggeredTimetable()
+211 | DatasetTriggeredTimetable()
     |
     = help: Use `airflow.timetables.assets.AssetOrTimeSchedule` instead
 
-AIR301_names.py:221:1: AIR301 `airflow.timetables.simple.DatasetTriggeredTimetable` is removed in Airflow 3.0
+AIR301_names.py:211:1: AIR301 `airflow.timetables.simple.DatasetTriggeredTimetable` is removed in Airflow 3.0
     |
-219 | # airflow.timetables
-220 | DatasetOrTimeSchedule()
-221 | DatasetTriggeredTimetable()
+209 | # airflow.timetables
+210 | DatasetOrTimeSchedule()
+211 | DatasetTriggeredTimetable()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR301
-222 |
-223 | # airflow.triggers.external_task
+212 |
+213 | # airflow.triggers.external_task
     |
     = help: Use `airflow.timetables.simple.AssetTriggeredTimetable` instead
 
-AIR301_names.py:224:1: AIR301 `airflow.triggers.external_task.TaskStateTrigger` is removed in Airflow 3.0
+AIR301_names.py:214:1: AIR301 `airflow.triggers.external_task.TaskStateTrigger` is removed in Airflow 3.0
     |
-223 | # airflow.triggers.external_task
-224 | TaskStateTrigger()
+213 | # airflow.triggers.external_task
+214 | TaskStateTrigger()
     | ^^^^^^^^^^^^^^^^ AIR301
-225 |
-226 | # airflow.utils.date
+215 |
+216 | # airflow.utils.date
     |
 
-AIR301_names.py:227:7: AIR301 `airflow.utils.dates.date_range` is removed in Airflow 3.0
+AIR301_names.py:217:7: AIR301 `airflow.utils.dates.date_range` is removed in Airflow 3.0
     |
-226 | # airflow.utils.date
-227 | dates.date_range
+216 | # airflow.utils.date
+217 | dates.date_range
     |       ^^^^^^^^^^ AIR301
-228 | dates.days_ago
+218 | dates.days_ago
     |
 
-AIR301_names.py:228:7: AIR301 `airflow.utils.dates.days_ago` is removed in Airflow 3.0
+AIR301_names.py:218:7: AIR301 `airflow.utils.dates.days_ago` is removed in Airflow 3.0
     |
-226 | # airflow.utils.date
-227 | dates.date_range
-228 | dates.days_ago
+216 | # airflow.utils.date
+217 | dates.date_range
+218 | dates.days_ago
     |       ^^^^^^^^ AIR301
-229 |
-230 | date_range
+219 |
+220 | date_range
     |
     = help: Use `pendulum.today('UTC').add(days=-N, ...)` instead
 
-AIR301_names.py:230:1: AIR301 `airflow.utils.dates.date_range` is removed in Airflow 3.0
+AIR301_names.py:220:1: AIR301 `airflow.utils.dates.date_range` is removed in Airflow 3.0
     |
-228 | dates.days_ago
-229 |
-230 | date_range
+218 | dates.days_ago
+219 |
+220 | date_range
     | ^^^^^^^^^^ AIR301
-231 | days_ago
-232 | infer_time_unit
+221 | days_ago
+222 | infer_time_unit
     |
 
-AIR301_names.py:231:1: AIR301 `airflow.utils.dates.days_ago` is removed in Airflow 3.0
+AIR301_names.py:221:1: AIR301 `airflow.utils.dates.days_ago` is removed in Airflow 3.0
     |
-230 | date_range
-231 | days_ago
+220 | date_range
+221 | days_ago
     | ^^^^^^^^ AIR301
-232 | infer_time_unit
-233 | parse_execution_date
+222 | infer_time_unit
+223 | parse_execution_date
     |
     = help: Use `pendulum.today('UTC').add(days=-N, ...)` instead
 
-AIR301_names.py:232:1: AIR301 `airflow.utils.dates.infer_time_unit` is removed in Airflow 3.0
+AIR301_names.py:222:1: AIR301 `airflow.utils.dates.infer_time_unit` is removed in Airflow 3.0
     |
-230 | date_range
-231 | days_ago
-232 | infer_time_unit
+220 | date_range
+221 | days_ago
+222 | infer_time_unit
     | ^^^^^^^^^^^^^^^ AIR301
-233 | parse_execution_date
-234 | round_time
+223 | parse_execution_date
+224 | round_time
     |
 
-AIR301_names.py:233:1: AIR301 `airflow.utils.dates.parse_execution_date` is removed in Airflow 3.0
+AIR301_names.py:223:1: AIR301 `airflow.utils.dates.parse_execution_date` is removed in Airflow 3.0
     |
-231 | days_ago
-232 | infer_time_unit
-233 | parse_execution_date
+221 | days_ago
+222 | infer_time_unit
+223 | parse_execution_date
     | ^^^^^^^^^^^^^^^^^^^^ AIR301
-234 | round_time
-235 | scale_time_units
+224 | round_time
+225 | scale_time_units
     |
 
-AIR301_names.py:234:1: AIR301 `airflow.utils.dates.round_time` is removed in Airflow 3.0
+AIR301_names.py:224:1: AIR301 `airflow.utils.dates.round_time` is removed in Airflow 3.0
     |
-232 | infer_time_unit
-233 | parse_execution_date
-234 | round_time
+222 | infer_time_unit
+223 | parse_execution_date
+224 | round_time
     | ^^^^^^^^^^ AIR301
-235 | scale_time_units
+225 | scale_time_units
     |
 
-AIR301_names.py:235:1: AIR301 `airflow.utils.dates.scale_time_units` is removed in Airflow 3.0
+AIR301_names.py:225:1: AIR301 `airflow.utils.dates.scale_time_units` is removed in Airflow 3.0
     |
-233 | parse_execution_date
-234 | round_time
-235 | scale_time_units
+223 | parse_execution_date
+224 | round_time
+225 | scale_time_units
     | ^^^^^^^^^^^^^^^^ AIR301
-236 |
-237 | # This one was not deprecated.
+226 |
+227 | # This one was not deprecated.
     |
 
-AIR301_names.py:242:1: AIR301 `airflow.utils.dag_cycle_tester.test_cycle` is removed in Airflow 3.0
+AIR301_names.py:232:1: AIR301 `airflow.utils.dag_cycle_tester.test_cycle` is removed in Airflow 3.0
     |
-241 | # airflow.utils.dag_cycle_tester
-242 | test_cycle
+231 | # airflow.utils.dag_cycle_tester
+232 | test_cycle
     | ^^^^^^^^^^ AIR301
-243 |
-244 | # airflow.utils.dag_parsing_context
+233 |
+234 | # airflow.utils.dag_parsing_context
     |
 
-AIR301_names.py:245:1: AIR301 `airflow.utils.dag_parsing_context.get_parsing_context` is removed in Airflow 3.0
+AIR301_names.py:235:1: AIR301 `airflow.utils.dag_parsing_context.get_parsing_context` is removed in Airflow 3.0
     |
-244 | # airflow.utils.dag_parsing_context
-245 | get_parsing_context
+234 | # airflow.utils.dag_parsing_context
+235 | get_parsing_context
     | ^^^^^^^^^^^^^^^^^^^ AIR301
-246 |
-247 | # airflow.utils.db
+236 |
+237 | # airflow.utils.db
     |
     = help: Use `airflow.sdk.get_parsing_context` instead
 
-AIR301_names.py:248:1: AIR301 `airflow.utils.db.create_session` is removed in Airflow 3.0
+AIR301_names.py:238:1: AIR301 `airflow.utils.db.create_session` is removed in Airflow 3.0
     |
-247 | # airflow.utils.db
-248 | create_session
+237 | # airflow.utils.db
+238 | create_session
     | ^^^^^^^^^^^^^^ AIR301
-249 |
-250 | # airflow.utils.decorators
+239 |
+240 | # airflow.utils.decorators
     |
 
-AIR301_names.py:251:1: AIR301 `airflow.utils.decorators.apply_defaults` is removed in Airflow 3.0; `apply_defaults` is now unconditionally done and can be safely removed.
+AIR301_names.py:241:1: AIR301 `airflow.utils.decorators.apply_defaults` is removed in Airflow 3.0; `apply_defaults` is now unconditionally done and can be safely removed.
     |
-250 | # airflow.utils.decorators
-251 | apply_defaults
+240 | # airflow.utils.decorators
+241 | apply_defaults
     | ^^^^^^^^^^^^^^ AIR301
-252 |
-253 | # airflow.utils.file
+242 |
+243 | # airflow.utils.file
     |
 
-AIR301_names.py:254:1: AIR301 `airflow.utils.file.TemporaryDirectory` is removed in Airflow 3.0
+AIR301_names.py:244:1: AIR301 `airflow.utils.file.TemporaryDirectory` is removed in Airflow 3.0
     |
-253 | # airflow.utils.file
-254 | TemporaryDirectory()
+243 | # airflow.utils.file
+244 | TemporaryDirectory()
     | ^^^^^^^^^^^^^^^^^^ AIR301
-255 | mkdirs
+245 | mkdirs
     |
     = help: Use `tempfile.TemporaryDirectory` instead
 
-AIR301_names.py:255:1: AIR301 `airflow.utils.file.mkdirs` is removed in Airflow 3.0
+AIR301_names.py:245:1: AIR301 `airflow.utils.file.mkdirs` is removed in Airflow 3.0
     |
-253 | # airflow.utils.file
-254 | TemporaryDirectory()
-255 | mkdirs
+243 | # airflow.utils.file
+244 | TemporaryDirectory()
+245 | mkdirs
     | ^^^^^^ AIR301
-256 |
-257 | #  airflow.utils.helpers
+246 |
+247 | #  airflow.utils.helpers
     |
     = help: Use `pathlib.Path({path}).mkdir` instead
 
-AIR301_names.py:258:1: AIR301 `airflow.utils.helpers.chain` is removed in Airflow 3.0
+AIR301_names.py:248:1: AIR301 `airflow.utils.helpers.chain` is removed in Airflow 3.0
     |
-257 | #  airflow.utils.helpers
-258 | helper_chain
+247 | #  airflow.utils.helpers
+248 | helper_chain
     | ^^^^^^^^^^^^ AIR301
-259 | helper_cross_downstream
+249 | helper_cross_downstream
     |
     = help: Use `airflow.sdk.chain` instead
 
-AIR301_names.py:259:1: AIR301 `airflow.utils.helpers.cross_downstream` is removed in Airflow 3.0
+AIR301_names.py:249:1: AIR301 `airflow.utils.helpers.cross_downstream` is removed in Airflow 3.0
     |
-257 | #  airflow.utils.helpers
-258 | helper_chain
-259 | helper_cross_downstream
+247 | #  airflow.utils.helpers
+248 | helper_chain
+249 | helper_cross_downstream
     | ^^^^^^^^^^^^^^^^^^^^^^^ AIR301
-260 |
-261 | #  airflow.utils.log
+250 |
+251 | #  airflow.utils.log
     |
     = help: Use `airflow.sdk.cross_downstream` instead
 
-AIR301_names.py:262:1: AIR301 `airflow.utils.log.secrets_masker` is removed in Airflow 3.0
+AIR301_names.py:252:1: AIR301 `airflow.utils.log.secrets_masker` is removed in Airflow 3.0
     |
-261 | #  airflow.utils.log
-262 | secrets_masker
+251 | #  airflow.utils.log
+252 | secrets_masker
     | ^^^^^^^^^^^^^^ AIR301
-263 |
-264 | # airflow.utils.state
+253 |
+254 | # airflow.utils.state
     |
     = help: Use `airflow.sdk.execution_time.secrets_masker` instead
 
-AIR301_names.py:265:1: AIR301 `airflow.utils.state.SHUTDOWN` is removed in Airflow 3.0
+AIR301_names.py:255:1: AIR301 `airflow.utils.state.SHUTDOWN` is removed in Airflow 3.0
     |
-264 | # airflow.utils.state
-265 | SHUTDOWN
+254 | # airflow.utils.state
+255 | SHUTDOWN
     | ^^^^^^^^ AIR301
-266 | terminating_states
+256 | terminating_states
     |
 
-AIR301_names.py:266:1: AIR301 `airflow.utils.state.terminating_states` is removed in Airflow 3.0
+AIR301_names.py:256:1: AIR301 `airflow.utils.state.terminating_states` is removed in Airflow 3.0
     |
-264 | # airflow.utils.state
-265 | SHUTDOWN
-266 | terminating_states
+254 | # airflow.utils.state
+255 | SHUTDOWN
+256 | terminating_states
     | ^^^^^^^^^^^^^^^^^^ AIR301
-267 |
-268 | #  airflow.utils.trigger_rule
+257 |
+258 | #  airflow.utils.trigger_rule
     |
 
-AIR301_names.py:269:13: AIR301 `airflow.utils.trigger_rule.TriggerRule.DUMMY` is removed in Airflow 3.0
+AIR301_names.py:259:13: AIR301 `airflow.utils.trigger_rule.TriggerRule.DUMMY` is removed in Airflow 3.0
     |
-268 | #  airflow.utils.trigger_rule
-269 | TriggerRule.DUMMY
+258 | #  airflow.utils.trigger_rule
+259 | TriggerRule.DUMMY
     |             ^^^^^ AIR301
-270 | TriggerRule.NONE_FAILED_OR_SKIPPED
+260 | TriggerRule.NONE_FAILED_OR_SKIPPED
     |
 
-AIR301_names.py:270:13: AIR301 `airflow.utils.trigger_rule.TriggerRule.NONE_FAILED_OR_SKIPPED` is removed in Airflow 3.0
+AIR301_names.py:260:13: AIR301 `airflow.utils.trigger_rule.TriggerRule.NONE_FAILED_OR_SKIPPED` is removed in Airflow 3.0
     |
-268 | #  airflow.utils.trigger_rule
-269 | TriggerRule.DUMMY
-270 | TriggerRule.NONE_FAILED_OR_SKIPPED
+258 | #  airflow.utils.trigger_rule
+259 | TriggerRule.DUMMY
+260 | TriggerRule.NONE_FAILED_OR_SKIPPED
     |             ^^^^^^^^^^^^^^^^^^^^^^ AIR301
-271 |
-272 | # airflow.www.auth
+261 |
+262 | # airflow.www.auth
     |
 
-AIR301_names.py:273:1: AIR301 `airflow.www.auth.has_access` is removed in Airflow 3.0
+AIR301_names.py:263:1: AIR301 `airflow.www.auth.has_access` is removed in Airflow 3.0
     |
-272 | # airflow.www.auth
-273 | has_access
+262 | # airflow.www.auth
+263 | has_access
     | ^^^^^^^^^^ AIR301
-274 | has_access_dataset
+264 | has_access_dataset
     |
     = help: Use `airflow.www.auth.has_access_*` instead
 
-AIR301_names.py:274:1: AIR301 `airflow.www.auth.has_access_dataset` is removed in Airflow 3.0
+AIR301_names.py:264:1: AIR301 `airflow.www.auth.has_access_dataset` is removed in Airflow 3.0
     |
-272 | # airflow.www.auth
-273 | has_access
-274 | has_access_dataset
+262 | # airflow.www.auth
+263 | has_access
+264 | has_access_dataset
     | ^^^^^^^^^^^^^^^^^^ AIR301
-275 |
-276 | # airflow.www.utils
+265 |
+266 | # airflow.www.utils
     |
     = help: Use `airflow.www.auth.has_access_dataset.has_access_asset` instead
 
-AIR301_names.py:277:1: AIR301 `airflow.www.utils.get_sensitive_variables_fields` is removed in Airflow 3.0
+AIR301_names.py:267:1: AIR301 `airflow.www.utils.get_sensitive_variables_fields` is removed in Airflow 3.0
     |
-276 | # airflow.www.utils
-277 | get_sensitive_variables_fields
+266 | # airflow.www.utils
+267 | get_sensitive_variables_fields
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR301
-278 | should_hide_value_for_key
+268 | should_hide_value_for_key
     |
     = help: Use `airflow.utils.log.secrets_masker.get_sensitive_variables_fields` instead
 
-AIR301_names.py:278:1: AIR301 `airflow.www.utils.should_hide_value_for_key` is removed in Airflow 3.0
+AIR301_names.py:268:1: AIR301 `airflow.www.utils.should_hide_value_for_key` is removed in Airflow 3.0
     |
-276 | # airflow.www.utils
-277 | get_sensitive_variables_fields
-278 | should_hide_value_for_key
+266 | # airflow.www.utils
+267 | get_sensitive_variables_fields
+268 | should_hide_value_for_key
     | ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR301
     |
     = help: Use `airflow.utils.log.secrets_masker.should_hide_value_for_key` instead

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR301_AIR301_names.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR301_AIR301_names.py.snap
@@ -1,111 +1,111 @@
 ---
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 ---
-AIR301_names.py:117:1: AIR301 `airflow.PY36` is removed in Airflow 3.0
+AIR301_names.py:101:1: AIR301 `airflow.PY36` is removed in Airflow 3.0
     |
-116 | # airflow root
-117 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+100 | # airflow root
+101 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
     | ^^^^ AIR301
-118 | DatasetFromRoot()
+102 | DatasetFromRoot()
     |
     = help: Use `sys.version_info` instead
 
-AIR301_names.py:117:7: AIR301 `airflow.PY37` is removed in Airflow 3.0
+AIR301_names.py:101:7: AIR301 `airflow.PY37` is removed in Airflow 3.0
     |
-116 | # airflow root
-117 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+100 | # airflow root
+101 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
     |       ^^^^ AIR301
-118 | DatasetFromRoot()
+102 | DatasetFromRoot()
     |
     = help: Use `sys.version_info` instead
 
-AIR301_names.py:117:13: AIR301 `airflow.PY38` is removed in Airflow 3.0
+AIR301_names.py:101:13: AIR301 `airflow.PY38` is removed in Airflow 3.0
     |
-116 | # airflow root
-117 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+100 | # airflow root
+101 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
     |             ^^^^ AIR301
-118 | DatasetFromRoot()
+102 | DatasetFromRoot()
     |
     = help: Use `sys.version_info` instead
 
-AIR301_names.py:117:19: AIR301 `airflow.PY39` is removed in Airflow 3.0
+AIR301_names.py:101:19: AIR301 `airflow.PY39` is removed in Airflow 3.0
     |
-116 | # airflow root
-117 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+100 | # airflow root
+101 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
     |                   ^^^^ AIR301
-118 | DatasetFromRoot()
+102 | DatasetFromRoot()
     |
     = help: Use `sys.version_info` instead
 
-AIR301_names.py:117:25: AIR301 `airflow.PY310` is removed in Airflow 3.0
+AIR301_names.py:101:25: AIR301 `airflow.PY310` is removed in Airflow 3.0
     |
-116 | # airflow root
-117 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+100 | # airflow root
+101 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
     |                         ^^^^^ AIR301
-118 | DatasetFromRoot()
+102 | DatasetFromRoot()
     |
     = help: Use `sys.version_info` instead
 
-AIR301_names.py:117:32: AIR301 `airflow.PY311` is removed in Airflow 3.0
+AIR301_names.py:101:32: AIR301 `airflow.PY311` is removed in Airflow 3.0
     |
-116 | # airflow root
-117 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+100 | # airflow root
+101 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
     |                                ^^^^^ AIR301
-118 | DatasetFromRoot()
+102 | DatasetFromRoot()
     |
     = help: Use `sys.version_info` instead
 
-AIR301_names.py:117:39: AIR301 `airflow.PY312` is removed in Airflow 3.0
+AIR301_names.py:101:39: AIR301 `airflow.PY312` is removed in Airflow 3.0
     |
-116 | # airflow root
-117 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+100 | # airflow root
+101 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
     |                                       ^^^^^ AIR301
-118 | DatasetFromRoot()
+102 | DatasetFromRoot()
     |
     = help: Use `sys.version_info` instead
 
-AIR301_names.py:118:1: AIR301 [*] `airflow.Dataset` is removed in Airflow 3.0
+AIR301_names.py:102:1: AIR301 [*] `airflow.Dataset` is removed in Airflow 3.0
     |
-116 | # airflow root
-117 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
-118 | DatasetFromRoot()
+100 | # airflow root
+101 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+102 | DatasetFromRoot()
     | ^^^^^^^^^^^^^^^ AIR301
-119 |
-120 | # airflow.api_connexion.security
+103 |
+104 | # airflow.api_connexion.security
     |
     = help: Use `airflow.sdk.Asset` instead
 
 ℹ Safe fix
-112 112 | from airflow.utils.trigger_rule import TriggerRule
-113 113 | from airflow.www.auth import has_access, has_access_dataset
-114 114 | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
-    115 |+from airflow.sdk import Asset
-115 116 | 
-116 117 | # airflow root
-117 118 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
-118     |-DatasetFromRoot()
-    119 |+Asset()
-119 120 | 
-120 121 | # airflow.api_connexion.security
-121 122 | requires_access, requires_access_dataset
+96  96  | from airflow.utils.trigger_rule import TriggerRule
+97  97  | from airflow.www.auth import has_access, has_access_dataset
+98  98  | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
+    99  |+from airflow.sdk import Asset
+99  100 | 
+100 101 | # airflow root
+101 102 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+102     |-DatasetFromRoot()
+    103 |+Asset()
+103 104 | 
+104 105 | # airflow.api_connexion.security
+105 106 | requires_access, requires_access_dataset
 
-AIR301_names.py:121:1: AIR301 `airflow.api_connexion.security.requires_access` is removed in Airflow 3.0
+AIR301_names.py:105:1: AIR301 `airflow.api_connexion.security.requires_access` is removed in Airflow 3.0
     |
-120 | # airflow.api_connexion.security
-121 | requires_access, requires_access_dataset
+104 | # airflow.api_connexion.security
+105 | requires_access, requires_access_dataset
     | ^^^^^^^^^^^^^^^ AIR301
-122 |
-123 | # airflow.auth.managers
+106 |
+107 | # airflow.auth.managers
     |
     = help: Use `airflow.api_connexion.security.requires_access_*` instead
 
-AIR301_names.py:121:18: AIR301 [*] `airflow.api_connexion.security.requires_access_dataset` is removed in Airflow 3.0
+AIR301_names.py:105:18: AIR301 [*] `airflow.api_connexion.security.requires_access_dataset` is removed in Airflow 3.0
     |
-120 | # airflow.api_connexion.security
-121 | requires_access, requires_access_dataset
+104 | # airflow.api_connexion.security
+105 | requires_access, requires_access_dataset
     |                  ^^^^^^^^^^^^^^^^^^^^^^^ AIR301
-122 |
-123 | # airflow.auth.managers
+106 |
+107 | # airflow.auth.managers
     |
     = help: Use `airflow.api_connexion.security.requires_access_asset` instead
 
@@ -119,785 +119,779 @@ AIR301_names.py:121:18: AIR301 [*] `airflow.api_connexion.security.requires_acce
 17  17  | from airflow.auth.managers.models.resource_details import DatasetDetails
 18  18  | from airflow.configuration import (
 --------------------------------------------------------------------------------
-118 118 | DatasetFromRoot()
-119 119 | 
-120 120 | # airflow.api_connexion.security
-121     |-requires_access, requires_access_dataset
-    121 |+requires_access, requires_access_asset
-122 122 | 
-123 123 | # airflow.auth.managers
-124 124 | is_authorized_dataset
+102 102 | DatasetFromRoot()
+103 103 | 
+104 104 | # airflow.api_connexion.security
+105     |-requires_access, requires_access_dataset
+    105 |+requires_access, requires_access_asset
+106 106 | 
+107 107 | # airflow.auth.managers
+108 108 | is_authorized_dataset
 
-AIR301_names.py:124:1: AIR301 `airflow.auth.managers.base_auth_manager.is_authorized_dataset` is removed in Airflow 3.0
+AIR301_names.py:108:1: AIR301 `airflow.auth.managers.base_auth_manager.is_authorized_dataset` is removed in Airflow 3.0
     |
-123 | # airflow.auth.managers
-124 | is_authorized_dataset
+107 | # airflow.auth.managers
+108 | is_authorized_dataset
     | ^^^^^^^^^^^^^^^^^^^^^ AIR301
-125 | DatasetDetails()
+109 | DatasetDetails()
     |
     = help: Use `airflow.api_fastapi.auth.managers.base_auth_manager.is_authorized_asset` instead
 
-AIR301_names.py:125:1: AIR301 `airflow.auth.managers.models.resource_details.DatasetDetails` is removed in Airflow 3.0
+AIR301_names.py:109:1: AIR301 `airflow.auth.managers.models.resource_details.DatasetDetails` is removed in Airflow 3.0
     |
-123 | # airflow.auth.managers
-124 | is_authorized_dataset
-125 | DatasetDetails()
+107 | # airflow.auth.managers
+108 | is_authorized_dataset
+109 | DatasetDetails()
     | ^^^^^^^^^^^^^^ AIR301
-126 |
-127 | # airflow.configuration
+110 |
+111 | # airflow.configuration
     |
     = help: Use `airflow.api_fastapi.auth.managers.models.resource_details.AssetDetails` instead
 
-AIR301_names.py:128:1: AIR301 `airflow.configuration.get` is removed in Airflow 3.0
+AIR301_names.py:112:1: AIR301 `airflow.configuration.get` is removed in Airflow 3.0
     |
-127 | # airflow.configuration
-128 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+111 | # airflow.configuration
+112 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     | ^^^ AIR301
     |
     = help: Use `airflow.configuration.conf.get` instead
 
-AIR301_names.py:128:6: AIR301 `airflow.configuration.getboolean` is removed in Airflow 3.0
+AIR301_names.py:112:6: AIR301 `airflow.configuration.getboolean` is removed in Airflow 3.0
     |
-127 | # airflow.configuration
-128 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+111 | # airflow.configuration
+112 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     |      ^^^^^^^^^^ AIR301
     |
     = help: Use `airflow.configuration.conf.getboolean` instead
 
-AIR301_names.py:128:18: AIR301 `airflow.configuration.getfloat` is removed in Airflow 3.0
+AIR301_names.py:112:18: AIR301 `airflow.configuration.getfloat` is removed in Airflow 3.0
     |
-127 | # airflow.configuration
-128 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+111 | # airflow.configuration
+112 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     |                  ^^^^^^^^ AIR301
     |
     = help: Use `airflow.configuration.conf.getfloat` instead
 
-AIR301_names.py:128:28: AIR301 `airflow.configuration.getint` is removed in Airflow 3.0
+AIR301_names.py:112:28: AIR301 `airflow.configuration.getint` is removed in Airflow 3.0
     |
-127 | # airflow.configuration
-128 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+111 | # airflow.configuration
+112 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     |                            ^^^^^^ AIR301
     |
     = help: Use `airflow.configuration.conf.getint` instead
 
-AIR301_names.py:128:36: AIR301 `airflow.configuration.has_option` is removed in Airflow 3.0
+AIR301_names.py:112:36: AIR301 `airflow.configuration.has_option` is removed in Airflow 3.0
     |
-127 | # airflow.configuration
-128 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+111 | # airflow.configuration
+112 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     |                                    ^^^^^^^^^^ AIR301
     |
     = help: Use `airflow.configuration.conf.has_option` instead
 
-AIR301_names.py:128:48: AIR301 `airflow.configuration.remove_option` is removed in Airflow 3.0
+AIR301_names.py:112:48: AIR301 `airflow.configuration.remove_option` is removed in Airflow 3.0
     |
-127 | # airflow.configuration
-128 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+111 | # airflow.configuration
+112 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     |                                                ^^^^^^^^^^^^^ AIR301
     |
     = help: Use `airflow.configuration.conf.remove_option` instead
 
-AIR301_names.py:128:63: AIR301 `airflow.configuration.as_dict` is removed in Airflow 3.0
+AIR301_names.py:112:63: AIR301 `airflow.configuration.as_dict` is removed in Airflow 3.0
     |
-127 | # airflow.configuration
-128 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+111 | # airflow.configuration
+112 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     |                                                               ^^^^^^^ AIR301
     |
     = help: Use `airflow.configuration.conf.as_dict` instead
 
-AIR301_names.py:128:72: AIR301 `airflow.configuration.set` is removed in Airflow 3.0
+AIR301_names.py:112:72: AIR301 `airflow.configuration.set` is removed in Airflow 3.0
     |
-127 | # airflow.configuration
-128 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+111 | # airflow.configuration
+112 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     |                                                                        ^^^ AIR301
     |
     = help: Use `airflow.configuration.conf.set` instead
 
-AIR301_names.py:132:1: AIR301 `airflow.contrib.aws_athena_hook.AWSAthenaHook` is removed in Airflow 3.0; The whole `airflow.contrib` module has been removed.
+AIR301_names.py:116:1: AIR301 `airflow.contrib.aws_athena_hook.AWSAthenaHook` is removed in Airflow 3.0; The whole `airflow.contrib` module has been removed.
     |
-131 | # airflow.contrib.*
-132 | AWSAthenaHook()
+115 | # airflow.contrib.*
+116 | AWSAthenaHook()
     | ^^^^^^^^^^^^^ AIR301
-133 |
-134 | # airflow.datasets
+117 |
+118 | # airflow.datasets
     |
 
-AIR301_names.py:135:1: AIR301 [*] `airflow.datasets.Dataset` is removed in Airflow 3.0
+AIR301_names.py:119:1: AIR301 [*] `airflow.datasets.Dataset` is removed in Airflow 3.0
     |
-134 | # airflow.datasets
-135 | Dataset()
+118 | # airflow.datasets
+119 | Dataset()
     | ^^^^^^^ AIR301
-136 | DatasetAlias()
-137 | DatasetAliasEvent()
+120 | DatasetAlias()
+121 | DatasetAliasEvent()
     |
     = help: Use `airflow.sdk.Asset` instead
 
 ℹ Safe fix
-112 112 | from airflow.utils.trigger_rule import TriggerRule
-113 113 | from airflow.www.auth import has_access, has_access_dataset
-114 114 | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
-    115 |+from airflow.sdk import Asset
-115 116 | 
-116 117 | # airflow root
-117 118 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+96  96  | from airflow.utils.trigger_rule import TriggerRule
+97  97  | from airflow.www.auth import has_access, has_access_dataset
+98  98  | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
+    99  |+from airflow.sdk import Asset
+99  100 | 
+100 101 | # airflow root
+101 102 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
 --------------------------------------------------------------------------------
-132 133 | AWSAthenaHook()
-133 134 | 
-134 135 | # airflow.datasets
-135     |-Dataset()
-    136 |+Asset()
-136 137 | DatasetAlias()
-137 138 | DatasetAliasEvent()
-138 139 | DatasetAll()
+116 117 | AWSAthenaHook()
+117 118 | 
+118 119 | # airflow.datasets
+119     |-Dataset()
+    120 |+Asset()
+120 121 | DatasetAlias()
+121 122 | DatasetAliasEvent()
+122 123 | DatasetAll()
 
-AIR301_names.py:136:1: AIR301 `airflow.datasets.DatasetAlias` is removed in Airflow 3.0
+AIR301_names.py:120:1: AIR301 `airflow.datasets.DatasetAlias` is removed in Airflow 3.0
     |
-134 | # airflow.datasets
-135 | Dataset()
-136 | DatasetAlias()
+118 | # airflow.datasets
+119 | Dataset()
+120 | DatasetAlias()
     | ^^^^^^^^^^^^ AIR301
-137 | DatasetAliasEvent()
-138 | DatasetAll()
+121 | DatasetAliasEvent()
+122 | DatasetAll()
     |
     = help: Use `airflow.sdk.AssetAlias` instead
 
-AIR301_names.py:137:1: AIR301 `airflow.datasets.DatasetAliasEvent` is removed in Airflow 3.0
+AIR301_names.py:121:1: AIR301 `airflow.datasets.DatasetAliasEvent` is removed in Airflow 3.0
     |
-135 | Dataset()
-136 | DatasetAlias()
-137 | DatasetAliasEvent()
+119 | Dataset()
+120 | DatasetAlias()
+121 | DatasetAliasEvent()
     | ^^^^^^^^^^^^^^^^^ AIR301
-138 | DatasetAll()
-139 | DatasetAny()
+122 | DatasetAll()
+123 | DatasetAny()
     |
 
-AIR301_names.py:138:1: AIR301 `airflow.datasets.DatasetAll` is removed in Airflow 3.0
+AIR301_names.py:122:1: AIR301 `airflow.datasets.DatasetAll` is removed in Airflow 3.0
     |
-136 | DatasetAlias()
-137 | DatasetAliasEvent()
-138 | DatasetAll()
+120 | DatasetAlias()
+121 | DatasetAliasEvent()
+122 | DatasetAll()
     | ^^^^^^^^^^ AIR301
-139 | DatasetAny()
-140 | Metadata()
+123 | DatasetAny()
+124 | Metadata()
     |
     = help: Use `airflow.sdk.AssetAll` instead
 
-AIR301_names.py:139:1: AIR301 `airflow.datasets.DatasetAny` is removed in Airflow 3.0
+AIR301_names.py:123:1: AIR301 `airflow.datasets.DatasetAny` is removed in Airflow 3.0
     |
-137 | DatasetAliasEvent()
-138 | DatasetAll()
-139 | DatasetAny()
+121 | DatasetAliasEvent()
+122 | DatasetAll()
+123 | DatasetAny()
     | ^^^^^^^^^^ AIR301
-140 | Metadata()
-141 | expand_alias_to_datasets
+124 | Metadata()
+125 | expand_alias_to_datasets
     |
     = help: Use `airflow.sdk.AssetAny` instead
 
-AIR301_names.py:140:1: AIR301 `airflow.datasets.metadata.Metadata` is removed in Airflow 3.0
+AIR301_names.py:124:1: AIR301 `airflow.datasets.metadata.Metadata` is removed in Airflow 3.0
     |
-138 | DatasetAll()
-139 | DatasetAny()
-140 | Metadata()
+122 | DatasetAll()
+123 | DatasetAny()
+124 | Metadata()
     | ^^^^^^^^ AIR301
-141 | expand_alias_to_datasets
+125 | expand_alias_to_datasets
     |
     = help: Use `airflow.sdk.Metadata` instead
 
-AIR301_names.py:141:1: AIR301 `airflow.datasets.expand_alias_to_datasets` is removed in Airflow 3.0
+AIR301_names.py:125:1: AIR301 `airflow.datasets.expand_alias_to_datasets` is removed in Airflow 3.0
     |
-139 | DatasetAny()
-140 | Metadata()
-141 | expand_alias_to_datasets
+123 | DatasetAny()
+124 | Metadata()
+125 | expand_alias_to_datasets
     | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR301
-142 |
-143 | # airflow.datasets.manager
+126 |
+127 | # airflow.datasets.manager
     |
     = help: Use `airflow.sdk.expand_alias_to_assets` instead
 
-AIR301_names.py:144:1: AIR301 `airflow.datasets.manager.DatasetManager` is removed in Airflow 3.0
+AIR301_names.py:128:1: AIR301 `airflow.datasets.manager.DatasetManager` is removed in Airflow 3.0
     |
-143 | # airflow.datasets.manager
-144 | DatasetManager()
+127 | # airflow.datasets.manager
+128 | DatasetManager()
     | ^^^^^^^^^^^^^^ AIR301
-145 | dataset_manager
-146 | resolve_dataset_manager
+129 | dataset_manager
+130 | resolve_dataset_manager
     |
     = help: Use `airflow.assets.AssetManager` instead
 
-AIR301_names.py:145:1: AIR301 `airflow.datasets.manager.dataset_manager` is removed in Airflow 3.0
+AIR301_names.py:129:1: AIR301 `airflow.datasets.manager.dataset_manager` is removed in Airflow 3.0
     |
-143 | # airflow.datasets.manager
-144 | DatasetManager()
-145 | dataset_manager
+127 | # airflow.datasets.manager
+128 | DatasetManager()
+129 | dataset_manager
     | ^^^^^^^^^^^^^^^ AIR301
-146 | resolve_dataset_manager
+130 | resolve_dataset_manager
     |
     = help: Use `airflow.assets.manager.asset_manager` instead
 
-AIR301_names.py:146:1: AIR301 `airflow.datasets.manager.resolve_dataset_manager` is removed in Airflow 3.0
+AIR301_names.py:130:1: AIR301 `airflow.datasets.manager.resolve_dataset_manager` is removed in Airflow 3.0
     |
-144 | DatasetManager()
-145 | dataset_manager
-146 | resolve_dataset_manager
+128 | DatasetManager()
+129 | dataset_manager
+130 | resolve_dataset_manager
     | ^^^^^^^^^^^^^^^^^^^^^^^ AIR301
-147 |
-148 | # airflow.hooks
+131 |
+132 | # airflow.hooks
     |
     = help: Use `airflow.assets.resolve_asset_manager` instead
 
-AIR301_names.py:149:1: AIR301 `airflow.hooks.base_hook.BaseHook` is removed in Airflow 3.0
+AIR301_names.py:133:1: AIR301 `airflow.hooks.base_hook.BaseHook` is removed in Airflow 3.0
     |
-148 | # airflow.hooks
-149 | BaseHook()
+132 | # airflow.hooks
+133 | BaseHook()
     | ^^^^^^^^ AIR301
-150 |
-151 | # airflow.lineage.hook
+134 |
+135 | # airflow.lineage.hook
     |
     = help: Use `airflow.hooks.base.BaseHook` instead
 
-AIR301_names.py:152:1: AIR301 `airflow.lineage.hook.DatasetLineageInfo` is removed in Airflow 3.0
+AIR301_names.py:136:1: AIR301 `airflow.lineage.hook.DatasetLineageInfo` is removed in Airflow 3.0
     |
-151 | # airflow.lineage.hook
-152 | DatasetLineageInfo()
+135 | # airflow.lineage.hook
+136 | DatasetLineageInfo()
     | ^^^^^^^^^^^^^^^^^^ AIR301
-153 |
-154 | # airflow.listeners.spec.dataset
+137 |
+138 | # airflow.listeners.spec.dataset
     |
     = help: Use `airflow.lineage.hook.AssetLineageInfo` instead
 
-AIR301_names.py:155:1: AIR301 `airflow.listeners.spec.dataset.on_dataset_changed` is removed in Airflow 3.0
+AIR301_names.py:139:1: AIR301 `airflow.listeners.spec.dataset.on_dataset_changed` is removed in Airflow 3.0
     |
-154 | # airflow.listeners.spec.dataset
-155 | on_dataset_changed
+138 | # airflow.listeners.spec.dataset
+139 | on_dataset_changed
     | ^^^^^^^^^^^^^^^^^^ AIR301
-156 | on_dataset_created
+140 | on_dataset_created
     |
     = help: Use `airflow.listeners.spec.asset.on_asset_changed` instead
 
-AIR301_names.py:156:1: AIR301 `airflow.listeners.spec.dataset.on_dataset_created` is removed in Airflow 3.0
+AIR301_names.py:140:1: AIR301 `airflow.listeners.spec.dataset.on_dataset_created` is removed in Airflow 3.0
     |
-154 | # airflow.listeners.spec.dataset
-155 | on_dataset_changed
-156 | on_dataset_created
+138 | # airflow.listeners.spec.dataset
+139 | on_dataset_changed
+140 | on_dataset_created
     | ^^^^^^^^^^^^^^^^^^ AIR301
-157 |
-158 | # airflow.metrics.validators
+141 |
+142 | # airflow.metrics.validators
     |
     = help: Use `airflow.listeners.spec.asset.on_asset_created` instead
 
-AIR301_names.py:159:1: AIR301 `airflow.metrics.validators.AllowListValidator` is removed in Airflow 3.0
+AIR301_names.py:143:1: AIR301 `airflow.metrics.validators.AllowListValidator` is removed in Airflow 3.0
     |
-158 | # airflow.metrics.validators
-159 | AllowListValidator()
+142 | # airflow.metrics.validators
+143 | AllowListValidator()
     | ^^^^^^^^^^^^^^^^^^ AIR301
-160 | BlockListValidator()
+144 | BlockListValidator()
     |
     = help: Use `airflow.metrics.validators.PatternAllowListValidator` instead
 
-AIR301_names.py:160:1: AIR301 `airflow.metrics.validators.BlockListValidator` is removed in Airflow 3.0
+AIR301_names.py:144:1: AIR301 `airflow.metrics.validators.BlockListValidator` is removed in Airflow 3.0
     |
-158 | # airflow.metrics.validators
-159 | AllowListValidator()
-160 | BlockListValidator()
+142 | # airflow.metrics.validators
+143 | AllowListValidator()
+144 | BlockListValidator()
     | ^^^^^^^^^^^^^^^^^^ AIR301
     |
     = help: Use `airflow.metrics.validators.PatternBlockListValidator` instead
 
-AIR301_names.py:164:1: AIR301 `airflow.models.baseoperator.chain` is removed in Airflow 3.0
+AIR301_names.py:148:1: AIR301 `airflow.models.baseoperator.chain` is removed in Airflow 3.0
     |
-163 | # airflow.models.baseoperator
-164 | chain, chain_linear, cross_downstream
+147 | # airflow.models.baseoperator
+148 | chain, chain_linear, cross_downstream
     | ^^^^^ AIR301
-165 |
-166 | # airflow.models.baseoperatorlink
     |
     = help: Use `airflow.sdk.chain` instead
 
-AIR301_names.py:164:8: AIR301 `airflow.models.baseoperator.chain_linear` is removed in Airflow 3.0
+AIR301_names.py:148:8: AIR301 `airflow.models.baseoperator.chain_linear` is removed in Airflow 3.0
     |
-163 | # airflow.models.baseoperator
-164 | chain, chain_linear, cross_downstream
+147 | # airflow.models.baseoperator
+148 | chain, chain_linear, cross_downstream
     |        ^^^^^^^^^^^^ AIR301
-165 |
-166 | # airflow.models.baseoperatorlink
     |
     = help: Use `airflow.sdk.chain_linear` instead
 
-AIR301_names.py:164:22: AIR301 `airflow.models.baseoperator.cross_downstream` is removed in Airflow 3.0
+AIR301_names.py:148:22: AIR301 `airflow.models.baseoperator.cross_downstream` is removed in Airflow 3.0
     |
-163 | # airflow.models.baseoperator
-164 | chain, chain_linear, cross_downstream
+147 | # airflow.models.baseoperator
+148 | chain, chain_linear, cross_downstream
     |                      ^^^^^^^^^^^^^^^^ AIR301
-165 |
-166 | # airflow.models.baseoperatorlink
     |
     = help: Use `airflow.sdk.cross_downstream` instead
 
-AIR301_names.py:200:1: AIR301 `airflow.operators.subdag.SubDagOperator` is removed in Airflow 3.0; The whole `airflow.subdag` module has been removed.
+AIR301_names.py:171:1: AIR301 `airflow.operators.subdag.SubDagOperator` is removed in Airflow 3.0; The whole `airflow.subdag` module has been removed.
     |
-199 | # airflow.operators.subdag.*
-200 | SubDagOperator()
+170 | # airflow.operators.subdag.*
+171 | SubDagOperator()
     | ^^^^^^^^^^^^^^ AIR301
-201 |
-202 | # airflow.providers.amazon
+172 |
+173 | # airflow.providers.amazon
     |
 
-AIR301_names.py:203:13: AIR301 `airflow.providers.amazon.aws.auth_manager.avp.entities.AvpEntities.DATASET` is removed in Airflow 3.0
+AIR301_names.py:174:13: AIR301 `airflow.providers.amazon.aws.auth_manager.avp.entities.AvpEntities.DATASET` is removed in Airflow 3.0
     |
-202 | # airflow.providers.amazon
-203 | AvpEntities.DATASET
+173 | # airflow.providers.amazon
+174 | AvpEntities.DATASET
     |             ^^^^^^^ AIR301
-204 | s3.create_dataset
-205 | s3.convert_dataset_to_openlineage
+175 | s3.create_dataset
+176 | s3.convert_dataset_to_openlineage
     |
     = help: Use `airflow.providers.amazon.aws.auth_manager.avp.entities.AvpEntities.ASSET` instead
 
-AIR301_names.py:204:4: AIR301 `airflow.providers.amazon.aws.datasets.s3.create_dataset` is removed in Airflow 3.0
+AIR301_names.py:175:4: AIR301 `airflow.providers.amazon.aws.datasets.s3.create_dataset` is removed in Airflow 3.0
     |
-202 | # airflow.providers.amazon
-203 | AvpEntities.DATASET
-204 | s3.create_dataset
+173 | # airflow.providers.amazon
+174 | AvpEntities.DATASET
+175 | s3.create_dataset
     |    ^^^^^^^^^^^^^^ AIR301
-205 | s3.convert_dataset_to_openlineage
-206 | s3.sanitize_uri
+176 | s3.convert_dataset_to_openlineage
+177 | s3.sanitize_uri
     |
     = help: Use `airflow.providers.amazon.aws.assets.s3.create_asset` instead
 
-AIR301_names.py:205:4: AIR301 `airflow.providers.amazon.aws.datasets.s3.convert_dataset_to_openlineage` is removed in Airflow 3.0
+AIR301_names.py:176:4: AIR301 `airflow.providers.amazon.aws.datasets.s3.convert_dataset_to_openlineage` is removed in Airflow 3.0
     |
-203 | AvpEntities.DATASET
-204 | s3.create_dataset
-205 | s3.convert_dataset_to_openlineage
+174 | AvpEntities.DATASET
+175 | s3.create_dataset
+176 | s3.convert_dataset_to_openlineage
     |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR301
-206 | s3.sanitize_uri
+177 | s3.sanitize_uri
     |
     = help: Use `airflow.providers.amazon.aws.assets.s3.convert_asset_to_openlineage` instead
 
-AIR301_names.py:206:4: AIR301 `airflow.providers.amazon.aws.datasets.s3.sanitize_uri` is removed in Airflow 3.0
+AIR301_names.py:177:4: AIR301 `airflow.providers.amazon.aws.datasets.s3.sanitize_uri` is removed in Airflow 3.0
     |
-204 | s3.create_dataset
-205 | s3.convert_dataset_to_openlineage
-206 | s3.sanitize_uri
+175 | s3.create_dataset
+176 | s3.convert_dataset_to_openlineage
+177 | s3.sanitize_uri
     |    ^^^^^^^^^^^^ AIR301
-207 |
-208 | # airflow.providers.common.io
+178 |
+179 | # airflow.providers.common.io
     |
     = help: Use `airflow.providers.amazon.aws.assets.s3.sanitize_uri` instead
 
-AIR301_names.py:209:16: AIR301 `airflow.providers.common.io.datasets.file.convert_dataset_to_openlineage` is removed in Airflow 3.0
+AIR301_names.py:180:16: AIR301 `airflow.providers.common.io.datasets.file.convert_dataset_to_openlineage` is removed in Airflow 3.0
     |
-208 | # airflow.providers.common.io
-209 | common_io_file.convert_dataset_to_openlineage
+179 | # airflow.providers.common.io
+180 | common_io_file.convert_dataset_to_openlineage
     |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR301
-210 | common_io_file.create_dataset
-211 | common_io_file.sanitize_uri
+181 | common_io_file.create_dataset
+182 | common_io_file.sanitize_uri
     |
     = help: Use `airflow.providers.common.io.assets.file.convert_asset_to_openlineage` instead
 
-AIR301_names.py:210:16: AIR301 `airflow.providers.common.io.datasets.file.create_dataset` is removed in Airflow 3.0
+AIR301_names.py:181:16: AIR301 `airflow.providers.common.io.datasets.file.create_dataset` is removed in Airflow 3.0
     |
-208 | # airflow.providers.common.io
-209 | common_io_file.convert_dataset_to_openlineage
-210 | common_io_file.create_dataset
+179 | # airflow.providers.common.io
+180 | common_io_file.convert_dataset_to_openlineage
+181 | common_io_file.create_dataset
     |                ^^^^^^^^^^^^^^ AIR301
-211 | common_io_file.sanitize_uri
+182 | common_io_file.sanitize_uri
     |
     = help: Use `airflow.providers.common.io.assets.file.create_asset` instead
 
-AIR301_names.py:211:16: AIR301 `airflow.providers.common.io.datasets.file.sanitize_uri` is removed in Airflow 3.0
+AIR301_names.py:182:16: AIR301 `airflow.providers.common.io.datasets.file.sanitize_uri` is removed in Airflow 3.0
     |
-209 | common_io_file.convert_dataset_to_openlineage
-210 | common_io_file.create_dataset
-211 | common_io_file.sanitize_uri
+180 | common_io_file.convert_dataset_to_openlineage
+181 | common_io_file.create_dataset
+182 | common_io_file.sanitize_uri
     |                ^^^^^^^^^^^^ AIR301
-212 |
-213 | # airflow.providers.fab
+183 |
+184 | # airflow.providers.fab
     |
     = help: Use `airflow.providers.common.io.assets.file.sanitize_uri` instead
 
-AIR301_names.py:214:18: AIR301 `airflow.providers.fab.auth_manager.fab_auth_manager.is_authorized_dataset` is removed in Airflow 3.0
+AIR301_names.py:185:18: AIR301 `airflow.providers.fab.auth_manager.fab_auth_manager.is_authorized_dataset` is removed in Airflow 3.0
     |
-213 | # airflow.providers.fab
-214 | fab_auth_manager.is_authorized_dataset
+184 | # airflow.providers.fab
+185 | fab_auth_manager.is_authorized_dataset
     |                  ^^^^^^^^^^^^^^^^^^^^^ AIR301
-215 |
-216 | # airflow.providers.google
+186 |
+187 | # airflow.providers.google
     |
     = help: Use `airflow.providers.fab.auth_manager.fab_auth_manager.is_authorized_asset` instead
 
-AIR301_names.py:219:5: AIR301 `airflow.providers.google.datasets.gcs.create_dataset` is removed in Airflow 3.0
+AIR301_names.py:190:5: AIR301 `airflow.providers.google.datasets.gcs.create_dataset` is removed in Airflow 3.0
     |
-217 | bigquery.sanitize_uri
-218 |
-219 | gcs.create_dataset
+188 | bigquery.sanitize_uri
+189 |
+190 | gcs.create_dataset
     |     ^^^^^^^^^^^^^^ AIR301
-220 | gcs.sanitize_uri
-221 | gcs.convert_dataset_to_openlineage
+191 | gcs.sanitize_uri
+192 | gcs.convert_dataset_to_openlineage
     |
     = help: Use `airflow.providers.google.assets.gcs.create_asset` instead
 
-AIR301_names.py:220:5: AIR301 `airflow.providers.google.datasets.gcs.sanitize_uri` is removed in Airflow 3.0
+AIR301_names.py:191:5: AIR301 `airflow.providers.google.datasets.gcs.sanitize_uri` is removed in Airflow 3.0
     |
-219 | gcs.create_dataset
-220 | gcs.sanitize_uri
+190 | gcs.create_dataset
+191 | gcs.sanitize_uri
     |     ^^^^^^^^^^^^ AIR301
-221 | gcs.convert_dataset_to_openlineage
+192 | gcs.convert_dataset_to_openlineage
     |
     = help: Use `airflow.providers.google.assets.gcs.sanitize_uri` instead
 
-AIR301_names.py:221:5: AIR301 `airflow.providers.google.datasets.gcs.convert_dataset_to_openlineage` is removed in Airflow 3.0
+AIR301_names.py:192:5: AIR301 `airflow.providers.google.datasets.gcs.convert_dataset_to_openlineage` is removed in Airflow 3.0
     |
-219 | gcs.create_dataset
-220 | gcs.sanitize_uri
-221 | gcs.convert_dataset_to_openlineage
+190 | gcs.create_dataset
+191 | gcs.sanitize_uri
+192 | gcs.convert_dataset_to_openlineage
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR301
-222 |
-223 | # airflow.providers.mysql
+193 |
+194 | # airflow.providers.mysql
     |
     = help: Use `airflow.providers.google.assets.gcs.convert_asset_to_openlineage` instead
 
-AIR301_names.py:224:7: AIR301 `airflow.providers.mysql.datasets.mysql.sanitize_uri` is removed in Airflow 3.0
+AIR301_names.py:195:7: AIR301 `airflow.providers.mysql.datasets.mysql.sanitize_uri` is removed in Airflow 3.0
     |
-223 | # airflow.providers.mysql
-224 | mysql.sanitize_uri
+194 | # airflow.providers.mysql
+195 | mysql.sanitize_uri
     |       ^^^^^^^^^^^^ AIR301
-225 |
-226 | # airflow.providers.openlineage
+196 |
+197 | # airflow.providers.openlineage
     |
     = help: Use `airflow.providers.mysql.assets.mysql.sanitize_uri` instead
 
-AIR301_names.py:227:1: AIR301 `airflow.providers.openlineage.utils.utils.DatasetInfo` is removed in Airflow 3.0
+AIR301_names.py:198:1: AIR301 `airflow.providers.openlineage.utils.utils.DatasetInfo` is removed in Airflow 3.0
     |
-226 | # airflow.providers.openlineage
-227 | DatasetInfo()
+197 | # airflow.providers.openlineage
+198 | DatasetInfo()
     | ^^^^^^^^^^^ AIR301
-228 | translate_airflow_dataset
+199 | translate_airflow_dataset
     |
     = help: Use `airflow.providers.openlineage.utils.utils.AssetInfo` instead
 
-AIR301_names.py:228:1: AIR301 `airflow.providers.openlineage.utils.utils.translate_airflow_dataset` is removed in Airflow 3.0
+AIR301_names.py:199:1: AIR301 `airflow.providers.openlineage.utils.utils.translate_airflow_dataset` is removed in Airflow 3.0
     |
-226 | # airflow.providers.openlineage
-227 | DatasetInfo()
-228 | translate_airflow_dataset
+197 | # airflow.providers.openlineage
+198 | DatasetInfo()
+199 | translate_airflow_dataset
     | ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR301
-229 |
-230 | # airflow.providers.postgres
+200 |
+201 | # airflow.providers.postgres
     |
     = help: Use `airflow.providers.openlineage.utils.utils.translate_airflow_asset` instead
 
-AIR301_names.py:231:10: AIR301 `airflow.providers.postgres.datasets.postgres.sanitize_uri` is removed in Airflow 3.0
+AIR301_names.py:202:10: AIR301 `airflow.providers.postgres.datasets.postgres.sanitize_uri` is removed in Airflow 3.0
     |
-230 | # airflow.providers.postgres
-231 | postgres.sanitize_uri
+201 | # airflow.providers.postgres
+202 | postgres.sanitize_uri
     |          ^^^^^^^^^^^^ AIR301
-232 |
-233 | # airflow.providers.trino
+203 |
+204 | # airflow.providers.trino
     |
     = help: Use `airflow.providers.postgres.assets.postgres.sanitize_uri` instead
 
-AIR301_names.py:234:7: AIR301 `airflow.providers.trino.datasets.trino.sanitize_uri` is removed in Airflow 3.0
+AIR301_names.py:205:7: AIR301 `airflow.providers.trino.datasets.trino.sanitize_uri` is removed in Airflow 3.0
     |
-233 | # airflow.providers.trino
-234 | trino.sanitize_uri
+204 | # airflow.providers.trino
+205 | trino.sanitize_uri
     |       ^^^^^^^^^^^^ AIR301
-235 |
-236 | # airflow.secrets
+206 |
+207 | # airflow.secrets
     |
     = help: Use `airflow.providers.trino.assets.trino.sanitize_uri` instead
 
-AIR301_names.py:239:1: AIR301 `airflow.secrets.local_filesystem.load_connections` is removed in Airflow 3.0
+AIR301_names.py:210:1: AIR301 `airflow.secrets.local_filesystem.load_connections` is removed in Airflow 3.0
     |
-237 | # get_connection
-238 | LocalFilesystemBackend()
-239 | load_connections
+208 | # get_connection
+209 | LocalFilesystemBackend()
+210 | load_connections
     | ^^^^^^^^^^^^^^^^ AIR301
-240 |
-241 | # airflow.security.permissions
+211 |
+212 | # airflow.security.permissions
     |
     = help: Use `airflow.secrets.local_filesystem.load_connections_dict` instead
 
-AIR301_names.py:242:1: AIR301 `airflow.security.permissions.RESOURCE_DATASET` is removed in Airflow 3.0
+AIR301_names.py:213:1: AIR301 `airflow.security.permissions.RESOURCE_DATASET` is removed in Airflow 3.0
     |
-241 | # airflow.security.permissions
-242 | RESOURCE_DATASET
+212 | # airflow.security.permissions
+213 | RESOURCE_DATASET
     | ^^^^^^^^^^^^^^^^ AIR301
-243 |
-244 | # airflow.sensors.base_sensor_operator
+214 |
+215 | # airflow.sensors.base_sensor_operator
     |
     = help: Use `airflow.security.permissions.RESOURCE_ASSET` instead
 
-AIR301_names.py:245:1: AIR301 `airflow.sensors.base_sensor_operator.BaseSensorOperator` is removed in Airflow 3.0
+AIR301_names.py:216:1: AIR301 `airflow.sensors.base_sensor_operator.BaseSensorOperator` is removed in Airflow 3.0
     |
-244 | # airflow.sensors.base_sensor_operator
-245 | BaseSensorOperator()
+215 | # airflow.sensors.base_sensor_operator
+216 | BaseSensorOperator()
     | ^^^^^^^^^^^^^^^^^^ AIR301
     |
     = help: Use `airflow.sdk.bases.sensor.BaseSensorOperator` instead
 
-AIR301_names.py:264:1: AIR301 `airflow.timetables.datasets.DatasetOrTimeSchedule` is removed in Airflow 3.0
+AIR301_names.py:220:1: AIR301 `airflow.timetables.datasets.DatasetOrTimeSchedule` is removed in Airflow 3.0
     |
-263 | # airflow.timetables
-264 | DatasetOrTimeSchedule()
+219 | # airflow.timetables
+220 | DatasetOrTimeSchedule()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR301
-265 | DatasetTriggeredTimetable()
+221 | DatasetTriggeredTimetable()
     |
     = help: Use `airflow.timetables.assets.AssetOrTimeSchedule` instead
 
-AIR301_names.py:265:1: AIR301 `airflow.timetables.simple.DatasetTriggeredTimetable` is removed in Airflow 3.0
+AIR301_names.py:221:1: AIR301 `airflow.timetables.simple.DatasetTriggeredTimetable` is removed in Airflow 3.0
     |
-263 | # airflow.timetables
-264 | DatasetOrTimeSchedule()
-265 | DatasetTriggeredTimetable()
+219 | # airflow.timetables
+220 | DatasetOrTimeSchedule()
+221 | DatasetTriggeredTimetable()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR301
-266 |
-267 | # airflow.triggers.external_task
+222 |
+223 | # airflow.triggers.external_task
     |
     = help: Use `airflow.timetables.simple.AssetTriggeredTimetable` instead
 
-AIR301_names.py:268:1: AIR301 `airflow.triggers.external_task.TaskStateTrigger` is removed in Airflow 3.0
+AIR301_names.py:224:1: AIR301 `airflow.triggers.external_task.TaskStateTrigger` is removed in Airflow 3.0
     |
-267 | # airflow.triggers.external_task
-268 | TaskStateTrigger()
+223 | # airflow.triggers.external_task
+224 | TaskStateTrigger()
     | ^^^^^^^^^^^^^^^^ AIR301
-269 |
-270 | # airflow.utils.date
+225 |
+226 | # airflow.utils.date
     |
 
-AIR301_names.py:271:7: AIR301 `airflow.utils.dates.date_range` is removed in Airflow 3.0
+AIR301_names.py:227:7: AIR301 `airflow.utils.dates.date_range` is removed in Airflow 3.0
     |
-270 | # airflow.utils.date
-271 | dates.date_range
+226 | # airflow.utils.date
+227 | dates.date_range
     |       ^^^^^^^^^^ AIR301
-272 | dates.days_ago
+228 | dates.days_ago
     |
 
-AIR301_names.py:272:7: AIR301 `airflow.utils.dates.days_ago` is removed in Airflow 3.0
+AIR301_names.py:228:7: AIR301 `airflow.utils.dates.days_ago` is removed in Airflow 3.0
     |
-270 | # airflow.utils.date
-271 | dates.date_range
-272 | dates.days_ago
+226 | # airflow.utils.date
+227 | dates.date_range
+228 | dates.days_ago
     |       ^^^^^^^^ AIR301
-273 |
-274 | date_range
+229 |
+230 | date_range
     |
     = help: Use `pendulum.today('UTC').add(days=-N, ...)` instead
 
-AIR301_names.py:274:1: AIR301 `airflow.utils.dates.date_range` is removed in Airflow 3.0
+AIR301_names.py:230:1: AIR301 `airflow.utils.dates.date_range` is removed in Airflow 3.0
     |
-272 | dates.days_ago
-273 |
-274 | date_range
+228 | dates.days_ago
+229 |
+230 | date_range
     | ^^^^^^^^^^ AIR301
-275 | days_ago
-276 | infer_time_unit
+231 | days_ago
+232 | infer_time_unit
     |
 
-AIR301_names.py:275:1: AIR301 `airflow.utils.dates.days_ago` is removed in Airflow 3.0
+AIR301_names.py:231:1: AIR301 `airflow.utils.dates.days_ago` is removed in Airflow 3.0
     |
-274 | date_range
-275 | days_ago
+230 | date_range
+231 | days_ago
     | ^^^^^^^^ AIR301
-276 | infer_time_unit
-277 | parse_execution_date
+232 | infer_time_unit
+233 | parse_execution_date
     |
     = help: Use `pendulum.today('UTC').add(days=-N, ...)` instead
 
-AIR301_names.py:276:1: AIR301 `airflow.utils.dates.infer_time_unit` is removed in Airflow 3.0
+AIR301_names.py:232:1: AIR301 `airflow.utils.dates.infer_time_unit` is removed in Airflow 3.0
     |
-274 | date_range
-275 | days_ago
-276 | infer_time_unit
+230 | date_range
+231 | days_ago
+232 | infer_time_unit
     | ^^^^^^^^^^^^^^^ AIR301
-277 | parse_execution_date
-278 | round_time
+233 | parse_execution_date
+234 | round_time
     |
 
-AIR301_names.py:277:1: AIR301 `airflow.utils.dates.parse_execution_date` is removed in Airflow 3.0
+AIR301_names.py:233:1: AIR301 `airflow.utils.dates.parse_execution_date` is removed in Airflow 3.0
     |
-275 | days_ago
-276 | infer_time_unit
-277 | parse_execution_date
+231 | days_ago
+232 | infer_time_unit
+233 | parse_execution_date
     | ^^^^^^^^^^^^^^^^^^^^ AIR301
-278 | round_time
-279 | scale_time_units
+234 | round_time
+235 | scale_time_units
     |
 
-AIR301_names.py:278:1: AIR301 `airflow.utils.dates.round_time` is removed in Airflow 3.0
+AIR301_names.py:234:1: AIR301 `airflow.utils.dates.round_time` is removed in Airflow 3.0
     |
-276 | infer_time_unit
-277 | parse_execution_date
-278 | round_time
+232 | infer_time_unit
+233 | parse_execution_date
+234 | round_time
     | ^^^^^^^^^^ AIR301
-279 | scale_time_units
+235 | scale_time_units
     |
 
-AIR301_names.py:279:1: AIR301 `airflow.utils.dates.scale_time_units` is removed in Airflow 3.0
+AIR301_names.py:235:1: AIR301 `airflow.utils.dates.scale_time_units` is removed in Airflow 3.0
     |
-277 | parse_execution_date
-278 | round_time
-279 | scale_time_units
+233 | parse_execution_date
+234 | round_time
+235 | scale_time_units
     | ^^^^^^^^^^^^^^^^ AIR301
-280 |
-281 | # This one was not deprecated.
+236 |
+237 | # This one was not deprecated.
     |
 
-AIR301_names.py:286:1: AIR301 `airflow.utils.dag_cycle_tester.test_cycle` is removed in Airflow 3.0
+AIR301_names.py:242:1: AIR301 `airflow.utils.dag_cycle_tester.test_cycle` is removed in Airflow 3.0
     |
-285 | # airflow.utils.dag_cycle_tester
-286 | test_cycle
+241 | # airflow.utils.dag_cycle_tester
+242 | test_cycle
     | ^^^^^^^^^^ AIR301
-287 |
-288 | # airflow.utils.dag_parsing_context
+243 |
+244 | # airflow.utils.dag_parsing_context
     |
 
-AIR301_names.py:289:1: AIR301 `airflow.utils.dag_parsing_context.get_parsing_context` is removed in Airflow 3.0
+AIR301_names.py:245:1: AIR301 `airflow.utils.dag_parsing_context.get_parsing_context` is removed in Airflow 3.0
     |
-288 | # airflow.utils.dag_parsing_context
-289 | get_parsing_context
+244 | # airflow.utils.dag_parsing_context
+245 | get_parsing_context
     | ^^^^^^^^^^^^^^^^^^^ AIR301
-290 |
-291 | # airflow.utils.db
+246 |
+247 | # airflow.utils.db
     |
     = help: Use `airflow.sdk.get_parsing_context` instead
 
-AIR301_names.py:292:1: AIR301 `airflow.utils.db.create_session` is removed in Airflow 3.0
+AIR301_names.py:248:1: AIR301 `airflow.utils.db.create_session` is removed in Airflow 3.0
     |
-291 | # airflow.utils.db
-292 | create_session
+247 | # airflow.utils.db
+248 | create_session
     | ^^^^^^^^^^^^^^ AIR301
-293 |
-294 | # airflow.utils.decorators
+249 |
+250 | # airflow.utils.decorators
     |
 
-AIR301_names.py:295:1: AIR301 `airflow.utils.decorators.apply_defaults` is removed in Airflow 3.0; `apply_defaults` is now unconditionally done and can be safely removed.
+AIR301_names.py:251:1: AIR301 `airflow.utils.decorators.apply_defaults` is removed in Airflow 3.0; `apply_defaults` is now unconditionally done and can be safely removed.
     |
-294 | # airflow.utils.decorators
-295 | apply_defaults
+250 | # airflow.utils.decorators
+251 | apply_defaults
     | ^^^^^^^^^^^^^^ AIR301
-296 |
-297 | # airflow.utils.file
+252 |
+253 | # airflow.utils.file
     |
 
-AIR301_names.py:298:1: AIR301 `airflow.utils.file.TemporaryDirectory` is removed in Airflow 3.0
+AIR301_names.py:254:1: AIR301 `airflow.utils.file.TemporaryDirectory` is removed in Airflow 3.0
     |
-297 | # airflow.utils.file
-298 | TemporaryDirectory()
+253 | # airflow.utils.file
+254 | TemporaryDirectory()
     | ^^^^^^^^^^^^^^^^^^ AIR301
-299 | mkdirs
+255 | mkdirs
     |
     = help: Use `tempfile.TemporaryDirectory` instead
 
-AIR301_names.py:299:1: AIR301 `airflow.utils.file.mkdirs` is removed in Airflow 3.0
+AIR301_names.py:255:1: AIR301 `airflow.utils.file.mkdirs` is removed in Airflow 3.0
     |
-297 | # airflow.utils.file
-298 | TemporaryDirectory()
-299 | mkdirs
+253 | # airflow.utils.file
+254 | TemporaryDirectory()
+255 | mkdirs
     | ^^^^^^ AIR301
-300 |
-301 | #  airflow.utils.helpers
+256 |
+257 | #  airflow.utils.helpers
     |
     = help: Use `pathlib.Path({path}).mkdir` instead
 
-AIR301_names.py:302:1: AIR301 `airflow.utils.helpers.chain` is removed in Airflow 3.0
+AIR301_names.py:258:1: AIR301 `airflow.utils.helpers.chain` is removed in Airflow 3.0
     |
-301 | #  airflow.utils.helpers
-302 | helper_chain
+257 | #  airflow.utils.helpers
+258 | helper_chain
     | ^^^^^^^^^^^^ AIR301
-303 | helper_cross_downstream
+259 | helper_cross_downstream
     |
     = help: Use `airflow.sdk.chain` instead
 
-AIR301_names.py:303:1: AIR301 `airflow.utils.helpers.cross_downstream` is removed in Airflow 3.0
+AIR301_names.py:259:1: AIR301 `airflow.utils.helpers.cross_downstream` is removed in Airflow 3.0
     |
-301 | #  airflow.utils.helpers
-302 | helper_chain
-303 | helper_cross_downstream
+257 | #  airflow.utils.helpers
+258 | helper_chain
+259 | helper_cross_downstream
     | ^^^^^^^^^^^^^^^^^^^^^^^ AIR301
-304 |
-305 | #  airflow.utils.log
+260 |
+261 | #  airflow.utils.log
     |
     = help: Use `airflow.sdk.cross_downstream` instead
 
-AIR301_names.py:306:1: AIR301 `airflow.utils.log.secrets_masker` is removed in Airflow 3.0
+AIR301_names.py:262:1: AIR301 `airflow.utils.log.secrets_masker` is removed in Airflow 3.0
     |
-305 | #  airflow.utils.log
-306 | secrets_masker
+261 | #  airflow.utils.log
+262 | secrets_masker
     | ^^^^^^^^^^^^^^ AIR301
-307 |
-308 | # airflow.utils.state
+263 |
+264 | # airflow.utils.state
     |
     = help: Use `airflow.sdk.execution_time.secrets_masker` instead
 
-AIR301_names.py:309:1: AIR301 `airflow.utils.state.SHUTDOWN` is removed in Airflow 3.0
+AIR301_names.py:265:1: AIR301 `airflow.utils.state.SHUTDOWN` is removed in Airflow 3.0
     |
-308 | # airflow.utils.state
-309 | SHUTDOWN
+264 | # airflow.utils.state
+265 | SHUTDOWN
     | ^^^^^^^^ AIR301
-310 | terminating_states
+266 | terminating_states
     |
 
-AIR301_names.py:310:1: AIR301 `airflow.utils.state.terminating_states` is removed in Airflow 3.0
+AIR301_names.py:266:1: AIR301 `airflow.utils.state.terminating_states` is removed in Airflow 3.0
     |
-308 | # airflow.utils.state
-309 | SHUTDOWN
-310 | terminating_states
+264 | # airflow.utils.state
+265 | SHUTDOWN
+266 | terminating_states
     | ^^^^^^^^^^^^^^^^^^ AIR301
-311 |
-312 | #  airflow.utils.trigger_rule
+267 |
+268 | #  airflow.utils.trigger_rule
     |
 
-AIR301_names.py:313:13: AIR301 `airflow.utils.trigger_rule.TriggerRule.DUMMY` is removed in Airflow 3.0
+AIR301_names.py:269:13: AIR301 `airflow.utils.trigger_rule.TriggerRule.DUMMY` is removed in Airflow 3.0
     |
-312 | #  airflow.utils.trigger_rule
-313 | TriggerRule.DUMMY
+268 | #  airflow.utils.trigger_rule
+269 | TriggerRule.DUMMY
     |             ^^^^^ AIR301
-314 | TriggerRule.NONE_FAILED_OR_SKIPPED
+270 | TriggerRule.NONE_FAILED_OR_SKIPPED
     |
 
-AIR301_names.py:314:13: AIR301 `airflow.utils.trigger_rule.TriggerRule.NONE_FAILED_OR_SKIPPED` is removed in Airflow 3.0
+AIR301_names.py:270:13: AIR301 `airflow.utils.trigger_rule.TriggerRule.NONE_FAILED_OR_SKIPPED` is removed in Airflow 3.0
     |
-312 | #  airflow.utils.trigger_rule
-313 | TriggerRule.DUMMY
-314 | TriggerRule.NONE_FAILED_OR_SKIPPED
+268 | #  airflow.utils.trigger_rule
+269 | TriggerRule.DUMMY
+270 | TriggerRule.NONE_FAILED_OR_SKIPPED
     |             ^^^^^^^^^^^^^^^^^^^^^^ AIR301
-315 |
-316 | # airflow.www.auth
+271 |
+272 | # airflow.www.auth
     |
 
-AIR301_names.py:317:1: AIR301 `airflow.www.auth.has_access` is removed in Airflow 3.0
+AIR301_names.py:273:1: AIR301 `airflow.www.auth.has_access` is removed in Airflow 3.0
     |
-316 | # airflow.www.auth
-317 | has_access
+272 | # airflow.www.auth
+273 | has_access
     | ^^^^^^^^^^ AIR301
-318 | has_access_dataset
+274 | has_access_dataset
     |
     = help: Use `airflow.www.auth.has_access_*` instead
 
-AIR301_names.py:318:1: AIR301 `airflow.www.auth.has_access_dataset` is removed in Airflow 3.0
+AIR301_names.py:274:1: AIR301 `airflow.www.auth.has_access_dataset` is removed in Airflow 3.0
     |
-316 | # airflow.www.auth
-317 | has_access
-318 | has_access_dataset
+272 | # airflow.www.auth
+273 | has_access
+274 | has_access_dataset
     | ^^^^^^^^^^^^^^^^^^ AIR301
-319 |
-320 | # airflow.www.utils
+275 |
+276 | # airflow.www.utils
     |
     = help: Use `airflow.www.auth.has_access_dataset.has_access_asset` instead
 
-AIR301_names.py:321:1: AIR301 `airflow.www.utils.get_sensitive_variables_fields` is removed in Airflow 3.0
+AIR301_names.py:277:1: AIR301 `airflow.www.utils.get_sensitive_variables_fields` is removed in Airflow 3.0
     |
-320 | # airflow.www.utils
-321 | get_sensitive_variables_fields
+276 | # airflow.www.utils
+277 | get_sensitive_variables_fields
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR301
-322 | should_hide_value_for_key
+278 | should_hide_value_for_key
     |
     = help: Use `airflow.utils.log.secrets_masker.get_sensitive_variables_fields` instead
 
-AIR301_names.py:322:1: AIR301 `airflow.www.utils.should_hide_value_for_key` is removed in Airflow 3.0
+AIR301_names.py:278:1: AIR301 `airflow.www.utils.should_hide_value_for_key` is removed in Airflow 3.0
     |
-320 | # airflow.www.utils
-321 | get_sensitive_variables_fields
-322 | should_hide_value_for_key
+276 | # airflow.www.utils
+277 | get_sensitive_variables_fields
+278 | should_hide_value_for_key
     | ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR301
     |
     = help: Use `airflow.utils.log.secrets_masker.should_hide_value_for_key` instead

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302.py.snap
@@ -97,7 +97,7 @@ AIR302.py:241:1: AIR302 `airflow.sensors.s3_key_sensor.S3KeySensor` is moved int
 242 | S3ToRedshiftOperator()
 243 | S3ToRedshiftTransfer()
     |
-    = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `S3KeySensor` instead.
+    = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.sensors.s3.S3KeySensor` instead.
 
 AIR302.py:242:1: AIR302 `airflow.operators.s3_to_redshift_operator.S3ToRedshiftOperator` is moved into `amazon` provider in Airflow 3.0;
     |

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302.py.snap
@@ -205,7 +205,7 @@ AIR302.py:234:1: AIR302 Import path `airflow.operators.bash` is moved into `stan
     |
     = help: Install `apache-airflow-provider-standard>=0.0.1` and import from `airflow.providers.standard.operators.bash` instead.
 
-AIR302.py:235:1: AIR302 Import path `airflow.operators.bash_operator` is moved into `standard` provider in Airflow 3.0;
+AIR302.py:235:1: AIR302 `airflow.operators.bash_operator.BashOperator` is moved into `standard` provider in Airflow 3.0;
     |
 233 | BaseSQLOperator()
 234 | BashOperator()
@@ -214,7 +214,7 @@ AIR302.py:235:1: AIR302 Import path `airflow.operators.bash_operator` is moved i
 236 | BranchSQLOperator()
 237 | CheckOperator()
     |
-    = help: Install `apache-airflow-provider-standard>=0.0.1` and import from `airflow.providers.standard.operators.bash` instead.
+    = help: Install `apache-airflow-provider-standard>=0.0.1` and use `airflow.providers.standard.operators.bash.BashOperator` instead.
 
 AIR302.py:236:1: AIR302 `airflow.operators.sql.BranchSQLOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
@@ -1742,35 +1742,169 @@ AIR302.py:423:1: AIR302 Import path `airflow.triggers.temporal` is moved into `s
 423 | DateTimeTrigger()
     | ^^^^^^^^^^^^^^^ AIR302
 424 |
-425 | from airflow.operators.dummy import DummyOperator, EmptyOperator
+425 | from airflow.operators.email import EmailOperator
     |
     = help: Install `apache-airflow-provider-standard>=0.0.3` and import from `airflow.providers.standard.triggers.temporal` instead.
 
-AIR302.py:427:1: AIR302 `airflow.operators.dummy.DummyOperator` is moved into `standard` provider in Airflow 3.0;
+AIR302.py:451:1: AIR302 `airflow.operators.dummy.DummyOperator` is moved into `standard` provider in Airflow 3.0;
     |
-425 | from airflow.operators.dummy import DummyOperator, EmptyOperator
-426 |
-427 | DummyOperator()
+449 | )
+450 |
+451 | DummyOperator()
     | ^^^^^^^^^^^^^ AIR302
-428 | EmptyOperator()
+452 | EmptyOperator()
+453 | EmailOperator()
     |
-    = help: Install `apache-airflow-provider-standard>=0.1.0` and use `airflow.providers.standard.operators.empty.EmptyOperator` instead.
+    = help: Install `apache-airflow-provider-standard>=0.0.2` and use `airflow.providers.standard.operators.empty.EmptyOperator` instead.
 
-AIR302.py:428:1: AIR302 `airflow.operators.dummy.EmptyOperator` is moved into `standard` provider in Airflow 3.0;
+AIR302.py:452:1: AIR302 `airflow.operators.dummy.EmptyOperator` is moved into `standard` provider in Airflow 3.0;
     |
-427 | DummyOperator()
-428 | EmptyOperator()
+451 | DummyOperator()
+452 | EmptyOperator()
     | ^^^^^^^^^^^^^ AIR302
-429 |
-430 | from airflow.operators.email import EmailOperator
+453 | EmailOperator()
     |
-    = help: Install `apache-airflow-provider-standard>=0.1.0` and use `airflow.providers.standard.operators.empty.EmptyOperator` instead.
+    = help: Install `apache-airflow-provider-standard>=0.0.2` and use `airflow.providers.standard.operators.empty.EmptyOperator` instead.
 
-AIR302.py:432:1: AIR302 `airflow.operators.email.EmailOperator` is moved into `smtp` provider in Airflow 3.0;
+AIR302.py:453:1: AIR302 `airflow.operators.email_operator.EmailOperator` is moved into `smtp` provider in Airflow 3.0;
     |
-430 | from airflow.operators.email import EmailOperator
-431 |
-432 | EmailOperator()
+451 | DummyOperator()
+452 | EmptyOperator()
+453 | EmailOperator()
     | ^^^^^^^^^^^^^ AIR302
+454 |
+455 | # airflow.operators.trigger_dagrun
     |
     = help: Install `apache-airflow-provider-smtp>=1.0.0` and use `airflow.providers.smtp.operators.smtp.EmailOperator` instead.
+
+AIR302.py:456:1: AIR302 `airflow.operators.trigger_dagrun.TriggerDagRunLink` is moved into `standard` provider in Airflow 3.0;
+    |
+455 | # airflow.operators.trigger_dagrun
+456 | TriggerDagRunLink()
+    | ^^^^^^^^^^^^^^^^^ AIR302
+457 | TriggerDagRunOperator()
+    |
+    = help: Install `apache-airflow-provider-standard>=0.0.2` and use `airflow.providers.standard.operators.trigger_dagrun.TriggerDagRunLink` instead.
+
+AIR302.py:457:1: AIR302 `airflow.operators.trigger_dagrun.TriggerDagRunOperator` is moved into `standard` provider in Airflow 3.0;
+    |
+455 | # airflow.operators.trigger_dagrun
+456 | TriggerDagRunLink()
+457 | TriggerDagRunOperator()
+    | ^^^^^^^^^^^^^^^^^^^^^ AIR302
+458 |
+459 | # airflow.sensors.date_time_sensor
+    |
+    = help: Install `apache-airflow-provider-standard>=0.0.2` and use `airflow.providers.standard.operators.trigger_dagrun.TriggerDagRunOperator` instead.
+
+AIR302.py:463:1: AIR302 `airflow.sensors.external_task.ExternalTaskSensorLink` is moved into `standard` provider in Airflow 3.0;
+    |
+462 | # airflow.sensors.external_task
+463 | ExternalTaskSensorLink()
+    | ^^^^^^^^^^^^^^^^^^^^^^ AIR302
+464 | ExternalTaskMarker()
+465 | ExternalTaskSensor()
+    |
+    = help: Install `apache-airflow-provider-standard>=0.0.3` and use `airflow.providers.standard.sensors.external_task.ExternalTaskSensorLink` instead.
+
+AIR302.py:464:1: AIR302 `airflow.sensors.external_task.ExternalTaskMarker` is moved into `standard` provider in Airflow 3.0;
+    |
+462 | # airflow.sensors.external_task
+463 | ExternalTaskSensorLink()
+464 | ExternalTaskMarker()
+    | ^^^^^^^^^^^^^^^^^^ AIR302
+465 | ExternalTaskSensor()
+    |
+    = help: Install `apache-airflow-provider-standard>=0.0.3` and use `airflow.providers.standard.sensors.external_task.ExternalTaskMarker` instead.
+
+AIR302.py:465:1: AIR302 `airflow.sensors.external_task.ExternalTaskSensor` is moved into `standard` provider in Airflow 3.0;
+    |
+463 | ExternalTaskSensorLink()
+464 | ExternalTaskMarker()
+465 | ExternalTaskSensor()
+    | ^^^^^^^^^^^^^^^^^^ AIR302
+466 |
+467 | # airflow.sensors.external_task_sensor
+    |
+    = help: Install `apache-airflow-provider-standard>=0.0.3` and use `airflow.providers.standard.sensors.external_task.ExternalTaskSensor` instead.
+
+AIR302.py:468:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskMarker` is moved into `standard` provider in Airflow 3.0;
+    |
+467 | # airflow.sensors.external_task_sensor
+468 | ExternalTaskMarkerFromExternalTaskSensor()
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
+469 | ExternalTaskSensorFromExternalTaskSensor()
+470 | ExternalTaskSensorLinkFromExternalTaskSensor()
+    |
+    = help: Install `apache-airflow-provider-standard>=0.0.3` and use `airflow.providers.standard.sensors.external_task.ExternalTaskMarker` instead.
+
+AIR302.py:469:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensor` is moved into `standard` provider in Airflow 3.0;
+    |
+467 | # airflow.sensors.external_task_sensor
+468 | ExternalTaskMarkerFromExternalTaskSensor()
+469 | ExternalTaskSensorFromExternalTaskSensor()
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
+470 | ExternalTaskSensorLinkFromExternalTaskSensor()
+    |
+    = help: Install `apache-airflow-provider-standard>=0.0.3` and use `airflow.providers.standard.sensors.external_task.ExternalTaskSensor` instead.
+
+AIR302.py:470:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensorLink` is moved into `standard` provider in Airflow 3.0;
+    |
+468 | ExternalTaskMarkerFromExternalTaskSensor()
+469 | ExternalTaskSensorFromExternalTaskSensor()
+470 | ExternalTaskSensorLinkFromExternalTaskSensor()
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
+471 |
+472 | # airflow.sensors.time_delta_sensor
+    |
+    = help: Install `apache-airflow-provider-standard>=0.0.3` and use `airflow.providers.standard.sensors.external_task.ExternalTaskSensorLink` instead.
+
+AIR302.py:473:1: AIR302 Import path `airflow.sensors.time_delta` is moved into `standard` provider in Airflow 3.0;
+    |
+472 | # airflow.sensors.time_delta_sensor
+473 | TimeDeltaSensor()
+    | ^^^^^^^^^^^^^^^ AIR302
+474 |
+475 | # airflow.operators.python
+    |
+    = help: Install `apache-airflow-provider-standard>=0.0.1` and import from `airflow.providers.standard.time.sensors.time_delta` instead.
+
+AIR302.py:476:1: AIR302 `airflow.operators.python.BranchPythonOperator` is moved into `standard` provider in Airflow 3.0;
+    |
+475 | # airflow.operators.python
+476 | BranchPythonOperator()
+    | ^^^^^^^^^^^^^^^^^^^^ AIR302
+477 | PythonOperator()
+478 | PythonVirtualenvOperator()
+    |
+    = help: Install `apache-airflow-provider-standard>=0.0.1` and use `airflow.providers.standard.operators.python.BranchPythonOperator` instead.
+
+AIR302.py:477:1: AIR302 `airflow.operators.python.PythonOperator` is moved into `standard` provider in Airflow 3.0;
+    |
+475 | # airflow.operators.python
+476 | BranchPythonOperator()
+477 | PythonOperator()
+    | ^^^^^^^^^^^^^^ AIR302
+478 | PythonVirtualenvOperator()
+479 | ShortCircuitOperator()
+    |
+    = help: Install `apache-airflow-provider-standard>=0.0.1` and use `airflow.providers.standard.operators.python.PythonOperator` instead.
+
+AIR302.py:478:1: AIR302 `airflow.operators.python.PythonVirtualenvOperator` is moved into `standard` provider in Airflow 3.0;
+    |
+476 | BranchPythonOperator()
+477 | PythonOperator()
+478 | PythonVirtualenvOperator()
+    | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
+479 | ShortCircuitOperator()
+    |
+    = help: Install `apache-airflow-provider-standard>=0.0.1` and use `airflow.providers.standard.operators.python.PythonVirtualenvOperator` instead.
+
+AIR302.py:479:1: AIR302 `airflow.operators.python.ShortCircuitOperator` is moved into `standard` provider in Airflow 3.0;
+    |
+477 | PythonOperator()
+478 | PythonVirtualenvOperator()
+479 | ShortCircuitOperator()
+    | ^^^^^^^^^^^^^^^^^^^^ AIR302
+    |
+    = help: Install `apache-airflow-provider-standard>=0.0.1` and use `airflow.providers.standard.operators.python.ShortCircuitOperator` instead.

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302.py.snap
@@ -1,1821 +1,1821 @@
 ---
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 ---
-AIR302.py:233:1: AIR302 `airflow.hooks.S3_hook.provide_bucket_name` is moved into `amazon` provider in Airflow 3.0;
+AIR302.py:226:1: AIR302 `airflow.hooks.S3_hook.provide_bucket_name` is moved into `amazon` provider in Airflow 3.0;
     |
-232 | # apache-airflow-providers-amazon
-233 | provide_bucket_name()
+225 | # apache-airflow-providers-amazon
+226 | provide_bucket_name()
     | ^^^^^^^^^^^^^^^^^^^ AIR302
-234 | GCSToS3Operator()
-235 | GoogleApiToS3Operator()
+227 | GCSToS3Operator()
+228 | GoogleApiToS3Operator()
     |
     = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.hooks.s3.provide_bucket_name` instead.
 
-AIR302.py:234:1: AIR302 `airflow.operators.gcs_to_s3.GCSToS3Operator` is moved into `amazon` provider in Airflow 3.0;
+AIR302.py:227:1: AIR302 `airflow.operators.gcs_to_s3.GCSToS3Operator` is moved into `amazon` provider in Airflow 3.0;
     |
-232 | # apache-airflow-providers-amazon
-233 | provide_bucket_name()
-234 | GCSToS3Operator()
+225 | # apache-airflow-providers-amazon
+226 | provide_bucket_name()
+227 | GCSToS3Operator()
     | ^^^^^^^^^^^^^^^ AIR302
-235 | GoogleApiToS3Operator()
-236 | GoogleApiToS3Transfer()
+228 | GoogleApiToS3Operator()
+229 | GoogleApiToS3Transfer()
     |
     = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.transfers.gcs_to_s3.GCSToS3Operator` instead.
 
-AIR302.py:235:1: AIR302 `airflow.operators.google_api_to_s3_transfer.GoogleApiToS3Operator` is moved into `amazon` provider in Airflow 3.0;
+AIR302.py:228:1: AIR302 `airflow.operators.google_api_to_s3_transfer.GoogleApiToS3Operator` is moved into `amazon` provider in Airflow 3.0;
     |
-233 | provide_bucket_name()
-234 | GCSToS3Operator()
-235 | GoogleApiToS3Operator()
+226 | provide_bucket_name()
+227 | GCSToS3Operator()
+228 | GoogleApiToS3Operator()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-236 | GoogleApiToS3Transfer()
-237 | RedshiftToS3Operator()
+229 | GoogleApiToS3Transfer()
+230 | RedshiftToS3Operator()
     |
     = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.transfers.google_api_to_s3.GoogleApiToS3Operator` instead.
 
-AIR302.py:236:1: AIR302 `airflow.operators.google_api_to_s3_transfer.GoogleApiToS3Transfer` is moved into `amazon` provider in Airflow 3.0;
+AIR302.py:229:1: AIR302 `airflow.operators.google_api_to_s3_transfer.GoogleApiToS3Transfer` is moved into `amazon` provider in Airflow 3.0;
     |
-234 | GCSToS3Operator()
-235 | GoogleApiToS3Operator()
-236 | GoogleApiToS3Transfer()
+227 | GCSToS3Operator()
+228 | GoogleApiToS3Operator()
+229 | GoogleApiToS3Transfer()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-237 | RedshiftToS3Operator()
-238 | RedshiftToS3Transfer()
+230 | RedshiftToS3Operator()
+231 | RedshiftToS3Transfer()
     |
     = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.transfers.google_api_to_s3.GoogleApiToS3Operator` instead.
 
-AIR302.py:237:1: AIR302 `airflow.operators.redshift_to_s3_operator.RedshiftToS3Operator` is moved into `amazon` provider in Airflow 3.0;
+AIR302.py:230:1: AIR302 `airflow.operators.redshift_to_s3_operator.RedshiftToS3Operator` is moved into `amazon` provider in Airflow 3.0;
     |
-235 | GoogleApiToS3Operator()
-236 | GoogleApiToS3Transfer()
-237 | RedshiftToS3Operator()
+228 | GoogleApiToS3Operator()
+229 | GoogleApiToS3Transfer()
+230 | RedshiftToS3Operator()
     | ^^^^^^^^^^^^^^^^^^^^ AIR302
-238 | RedshiftToS3Transfer()
-239 | S3FileTransformOperator()
+231 | RedshiftToS3Transfer()
+232 | S3FileTransformOperator()
     |
     = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.transfers.redshift_to_s3.RedshiftToS3Operator` instead.
 
-AIR302.py:238:1: AIR302 `airflow.operators.redshift_to_s3_operator.RedshiftToS3Transfer` is moved into `amazon` provider in Airflow 3.0;
+AIR302.py:231:1: AIR302 `airflow.operators.redshift_to_s3_operator.RedshiftToS3Transfer` is moved into `amazon` provider in Airflow 3.0;
     |
-236 | GoogleApiToS3Transfer()
-237 | RedshiftToS3Operator()
-238 | RedshiftToS3Transfer()
+229 | GoogleApiToS3Transfer()
+230 | RedshiftToS3Operator()
+231 | RedshiftToS3Transfer()
     | ^^^^^^^^^^^^^^^^^^^^ AIR302
-239 | S3FileTransformOperator()
-240 | S3Hook()
+232 | S3FileTransformOperator()
+233 | S3Hook()
     |
     = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.transfers.redshift_to_s3.RedshiftToS3Operator` instead.
 
-AIR302.py:239:1: AIR302 `airflow.operators.s3_file_transform_operator.S3FileTransformOperator` is moved into `amazon` provider in Airflow 3.0;
+AIR302.py:232:1: AIR302 `airflow.operators.s3_file_transform_operator.S3FileTransformOperator` is moved into `amazon` provider in Airflow 3.0;
     |
-237 | RedshiftToS3Operator()
-238 | RedshiftToS3Transfer()
-239 | S3FileTransformOperator()
+230 | RedshiftToS3Operator()
+231 | RedshiftToS3Transfer()
+232 | S3FileTransformOperator()
     | ^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-240 | S3Hook()
-241 | S3KeySensor()
+233 | S3Hook()
+234 | S3KeySensor()
     |
     = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.operators.s3_file_transform.S3FileTransformOperator` instead.
 
-AIR302.py:240:1: AIR302 `airflow.hooks.S3_hook.S3Hook` is moved into `amazon` provider in Airflow 3.0;
+AIR302.py:233:1: AIR302 `airflow.hooks.S3_hook.S3Hook` is moved into `amazon` provider in Airflow 3.0;
     |
-238 | RedshiftToS3Transfer()
-239 | S3FileTransformOperator()
-240 | S3Hook()
+231 | RedshiftToS3Transfer()
+232 | S3FileTransformOperator()
+233 | S3Hook()
     | ^^^^^^ AIR302
-241 | S3KeySensor()
-242 | S3ToRedshiftOperator()
+234 | S3KeySensor()
+235 | S3ToRedshiftOperator()
     |
     = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.hooks.s3.S3Hook` instead.
 
-AIR302.py:241:1: AIR302 `airflow.sensors.s3_key_sensor.S3KeySensor` is moved into `amazon` provider in Airflow 3.0;
+AIR302.py:234:1: AIR302 `airflow.sensors.s3_key_sensor.S3KeySensor` is moved into `amazon` provider in Airflow 3.0;
     |
-239 | S3FileTransformOperator()
-240 | S3Hook()
-241 | S3KeySensor()
+232 | S3FileTransformOperator()
+233 | S3Hook()
+234 | S3KeySensor()
     | ^^^^^^^^^^^ AIR302
-242 | S3ToRedshiftOperator()
-243 | S3ToRedshiftTransfer()
+235 | S3ToRedshiftOperator()
+236 | S3ToRedshiftTransfer()
     |
     = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.sensors.s3.S3KeySensor` instead.
 
-AIR302.py:242:1: AIR302 `airflow.operators.s3_to_redshift_operator.S3ToRedshiftOperator` is moved into `amazon` provider in Airflow 3.0;
+AIR302.py:235:1: AIR302 `airflow.operators.s3_to_redshift_operator.S3ToRedshiftOperator` is moved into `amazon` provider in Airflow 3.0;
     |
-240 | S3Hook()
-241 | S3KeySensor()
-242 | S3ToRedshiftOperator()
+233 | S3Hook()
+234 | S3KeySensor()
+235 | S3ToRedshiftOperator()
     | ^^^^^^^^^^^^^^^^^^^^ AIR302
-243 | S3ToRedshiftTransfer()
+236 | S3ToRedshiftTransfer()
     |
     = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.transfers.s3_to_redshift.S3ToRedshiftOperator` instead.
 
-AIR302.py:243:1: AIR302 `airflow.operators.s3_to_redshift_operator.S3ToRedshiftTransfer` is moved into `amazon` provider in Airflow 3.0;
+AIR302.py:236:1: AIR302 `airflow.operators.s3_to_redshift_operator.S3ToRedshiftTransfer` is moved into `amazon` provider in Airflow 3.0;
     |
-241 | S3KeySensor()
-242 | S3ToRedshiftOperator()
-243 | S3ToRedshiftTransfer()
+234 | S3KeySensor()
+235 | S3ToRedshiftOperator()
+236 | S3ToRedshiftTransfer()
     | ^^^^^^^^^^^^^^^^^^^^ AIR302
-244 |
-245 | # apache-airflow-providers-celery
+237 |
+238 | # apache-airflow-providers-celery
     |
     = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.transfers.s3_to_redshift.S3ToRedshiftOperator` instead.
 
-AIR302.py:246:1: AIR302 `airflow.config_templates.default_celery.DEFAULT_CELERY_CONFIG` is moved into `celery` provider in Airflow 3.0;
+AIR302.py:239:1: AIR302 `airflow.config_templates.default_celery.DEFAULT_CELERY_CONFIG` is moved into `celery` provider in Airflow 3.0;
     |
-245 | # apache-airflow-providers-celery
-246 | DEFAULT_CELERY_CONFIG
+238 | # apache-airflow-providers-celery
+239 | DEFAULT_CELERY_CONFIG
     | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-247 | app
-248 | CeleryExecutor()
+240 | app
+241 | CeleryExecutor()
     |
     = help: Install `apache-airflow-provider-celery>=3.3.0` and use `airflow.providers.celery.executors.default_celery.DEFAULT_CELERY_CONFIG` instead.
 
-AIR302.py:247:1: AIR302 `airflow.executors.celery_executor.app` is moved into `celery` provider in Airflow 3.0;
+AIR302.py:240:1: AIR302 `airflow.executors.celery_executor.app` is moved into `celery` provider in Airflow 3.0;
     |
-245 | # apache-airflow-providers-celery
-246 | DEFAULT_CELERY_CONFIG
-247 | app
+238 | # apache-airflow-providers-celery
+239 | DEFAULT_CELERY_CONFIG
+240 | app
     | ^^^ AIR302
-248 | CeleryExecutor()
-249 | CeleryKubernetesExecutor()
+241 | CeleryExecutor()
+242 | CeleryKubernetesExecutor()
     |
     = help: Install `apache-airflow-provider-celery>=3.3.0` and use `airflow.providers.celery.executors.celery_executor_utils.app` instead.
 
-AIR302.py:248:1: AIR302 `airflow.executors.celery_executor.CeleryExecutor` is moved into `celery` provider in Airflow 3.0;
+AIR302.py:241:1: AIR302 `airflow.executors.celery_executor.CeleryExecutor` is moved into `celery` provider in Airflow 3.0;
     |
-246 | DEFAULT_CELERY_CONFIG
-247 | app
-248 | CeleryExecutor()
+239 | DEFAULT_CELERY_CONFIG
+240 | app
+241 | CeleryExecutor()
     | ^^^^^^^^^^^^^^ AIR302
-249 | CeleryKubernetesExecutor()
+242 | CeleryKubernetesExecutor()
     |
     = help: Install `apache-airflow-provider-celery>=3.3.0` and use `airflow.providers.celery.executors.celery_executor.CeleryExecutor` instead.
 
-AIR302.py:249:1: AIR302 `airflow.executors.celery_kubernetes_executor.CeleryKubernetesExecutor` is moved into `celery` provider in Airflow 3.0;
+AIR302.py:242:1: AIR302 `airflow.executors.celery_kubernetes_executor.CeleryKubernetesExecutor` is moved into `celery` provider in Airflow 3.0;
     |
-247 | app
-248 | CeleryExecutor()
-249 | CeleryKubernetesExecutor()
+240 | app
+241 | CeleryExecutor()
+242 | CeleryKubernetesExecutor()
     | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-250 |
-251 | # apache-airflow-providers-common-sql
+243 |
+244 | # apache-airflow-providers-common-sql
     |
     = help: Install `apache-airflow-provider-celery>=3.3.0` and use `airflow.providers.celery.executors.celery_kubernetes_executor.CeleryKubernetesExecutor` instead.
 
-AIR302.py:252:1: AIR302 `airflow.operators.sql._convert_to_float_if_possible` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:245:1: AIR302 `airflow.operators.sql._convert_to_float_if_possible` is moved into `common-sql` provider in Airflow 3.0;
     |
-251 | # apache-airflow-providers-common-sql
-252 | _convert_to_float_if_possible()
+244 | # apache-airflow-providers-common-sql
+245 | _convert_to_float_if_possible()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-253 | parse_boolean()
-254 | BaseSQLOperator()
+246 | parse_boolean()
+247 | BaseSQLOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.0.0` and use `airflow.providers.common.sql.operators.sql._convert_to_float_if_possible` instead.
 
-AIR302.py:253:1: AIR302 `airflow.operators.sql.parse_boolean` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:246:1: AIR302 `airflow.operators.sql.parse_boolean` is moved into `common-sql` provider in Airflow 3.0;
     |
-251 | # apache-airflow-providers-common-sql
-252 | _convert_to_float_if_possible()
-253 | parse_boolean()
+244 | # apache-airflow-providers-common-sql
+245 | _convert_to_float_if_possible()
+246 | parse_boolean()
     | ^^^^^^^^^^^^^ AIR302
-254 | BaseSQLOperator()
-255 | BashOperator()
+247 | BaseSQLOperator()
+248 | BashOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.0.0` and use `airflow.providers.common.sql.operators.sql.parse_boolean` instead.
 
-AIR302.py:254:1: AIR302 `airflow.operators.sql.BaseSQLOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:247:1: AIR302 `airflow.operators.sql.BaseSQLOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-252 | _convert_to_float_if_possible()
-253 | parse_boolean()
-254 | BaseSQLOperator()
+245 | _convert_to_float_if_possible()
+246 | parse_boolean()
+247 | BaseSQLOperator()
     | ^^^^^^^^^^^^^^^ AIR302
-255 | BashOperator()
-256 | LegacyBashOperator()
+248 | BashOperator()
+249 | LegacyBashOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.BaseSQLOperator` instead.
 
-AIR302.py:255:1: AIR302 Import path `airflow.operators.bash` is moved into `standard` provider in Airflow 3.0;
+AIR302.py:248:1: AIR302 Import path `airflow.operators.bash` is moved into `standard` provider in Airflow 3.0;
     |
-253 | parse_boolean()
-254 | BaseSQLOperator()
-255 | BashOperator()
+246 | parse_boolean()
+247 | BaseSQLOperator()
+248 | BashOperator()
     | ^^^^^^^^^^^^ AIR302
-256 | LegacyBashOperator()
-257 | BranchSQLOperator()
+249 | LegacyBashOperator()
+250 | BranchSQLOperator()
     |
     = help: Install `apache-airflow-provider-standard>=0.0.1` and import from `airflow.providers.standard.operators.bash` instead.
 
-AIR302.py:256:1: AIR302 `airflow.operators.bash_operator.BashOperator` is moved into `standard` provider in Airflow 3.0;
+AIR302.py:249:1: AIR302 `airflow.operators.bash_operator.BashOperator` is moved into `standard` provider in Airflow 3.0;
     |
-254 | BaseSQLOperator()
-255 | BashOperator()
-256 | LegacyBashOperator()
+247 | BaseSQLOperator()
+248 | BashOperator()
+249 | LegacyBashOperator()
     | ^^^^^^^^^^^^^^^^^^ AIR302
-257 | BranchSQLOperator()
-258 | CheckOperator()
+250 | BranchSQLOperator()
+251 | CheckOperator()
     |
     = help: Install `apache-airflow-provider-standard>=0.0.1` and use `airflow.providers.standard.operators.bash.BashOperator` instead.
 
-AIR302.py:257:1: AIR302 `airflow.operators.sql.BranchSQLOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:250:1: AIR302 `airflow.operators.sql.BranchSQLOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-255 | BashOperator()
-256 | LegacyBashOperator()
-257 | BranchSQLOperator()
+248 | BashOperator()
+249 | LegacyBashOperator()
+250 | BranchSQLOperator()
     | ^^^^^^^^^^^^^^^^^ AIR302
-258 | CheckOperator()
-259 | ConnectorProtocol()
+251 | CheckOperator()
+252 | ConnectorProtocol()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.BranchSQLOperator` instead.
 
-AIR302.py:258:1: AIR302 `airflow.operators.check_operator.CheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:251:1: AIR302 `airflow.operators.check_operator.CheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-256 | LegacyBashOperator()
-257 | BranchSQLOperator()
-258 | CheckOperator()
+249 | LegacyBashOperator()
+250 | BranchSQLOperator()
+251 | CheckOperator()
     | ^^^^^^^^^^^^^ AIR302
-259 | ConnectorProtocol()
-260 | DbApiHook()
+252 | ConnectorProtocol()
+253 | DbApiHook()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLCheckOperator` instead.
 
-AIR302.py:259:1: AIR302 `airflow.hooks.dbapi.ConnectorProtocol` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:252:1: AIR302 `airflow.hooks.dbapi.ConnectorProtocol` is moved into `common-sql` provider in Airflow 3.0;
     |
-257 | BranchSQLOperator()
-258 | CheckOperator()
-259 | ConnectorProtocol()
+250 | BranchSQLOperator()
+251 | CheckOperator()
+252 | ConnectorProtocol()
     | ^^^^^^^^^^^^^^^^^ AIR302
-260 | DbApiHook()
-261 | DbApiHook2()
+253 | DbApiHook()
+254 | DbApiHook2()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.0.0` and use `airflow.providers.common.sql.hooks.sql.ConnectorProtocol` instead.
 
-AIR302.py:260:1: AIR302 `airflow.hooks.dbapi.DbApiHook` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:253:1: AIR302 `airflow.hooks.dbapi.DbApiHook` is moved into `common-sql` provider in Airflow 3.0;
     |
-258 | CheckOperator()
-259 | ConnectorProtocol()
-260 | DbApiHook()
+251 | CheckOperator()
+252 | ConnectorProtocol()
+253 | DbApiHook()
     | ^^^^^^^^^ AIR302
-261 | DbApiHook2()
-262 | IntervalCheckOperator()
+254 | DbApiHook2()
+255 | IntervalCheckOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.0.0` and use `airflow.providers.common.sql.hooks.sql.DbApiHook` instead.
 
-AIR302.py:261:1: AIR302 `airflow.hooks.dbapi_hook.DbApiHook` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:254:1: AIR302 `airflow.hooks.dbapi_hook.DbApiHook` is moved into `common-sql` provider in Airflow 3.0;
     |
-259 | ConnectorProtocol()
-260 | DbApiHook()
-261 | DbApiHook2()
+252 | ConnectorProtocol()
+253 | DbApiHook()
+254 | DbApiHook2()
     | ^^^^^^^^^^ AIR302
-262 | IntervalCheckOperator()
-263 | PrestoCheckOperator()
+255 | IntervalCheckOperator()
+256 | PrestoCheckOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.0.0` and use `airflow.providers.common.sql.hooks.sql.DbApiHook` instead.
 
-AIR302.py:262:1: AIR302 `airflow.operators.check_operator.IntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:255:1: AIR302 `airflow.operators.check_operator.IntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-260 | DbApiHook()
-261 | DbApiHook2()
-262 | IntervalCheckOperator()
+253 | DbApiHook()
+254 | DbApiHook2()
+255 | IntervalCheckOperator()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-263 | PrestoCheckOperator()
-264 | PrestoIntervalCheckOperator()
+256 | PrestoCheckOperator()
+257 | PrestoIntervalCheckOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLIntervalCheckOperator` instead.
 
-AIR302.py:263:1: AIR302 `airflow.operators.presto_check_operator.PrestoCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:256:1: AIR302 `airflow.operators.presto_check_operator.PrestoCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-261 | DbApiHook2()
-262 | IntervalCheckOperator()
-263 | PrestoCheckOperator()
+254 | DbApiHook2()
+255 | IntervalCheckOperator()
+256 | PrestoCheckOperator()
     | ^^^^^^^^^^^^^^^^^^^ AIR302
-264 | PrestoIntervalCheckOperator()
-265 | PrestoValueCheckOperator()
+257 | PrestoIntervalCheckOperator()
+258 | PrestoValueCheckOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLCheckOperator` instead.
 
-AIR302.py:264:1: AIR302 `airflow.operators.presto_check_operator.PrestoIntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:257:1: AIR302 `airflow.operators.presto_check_operator.PrestoIntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-262 | IntervalCheckOperator()
-263 | PrestoCheckOperator()
-264 | PrestoIntervalCheckOperator()
+255 | IntervalCheckOperator()
+256 | PrestoCheckOperator()
+257 | PrestoIntervalCheckOperator()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-265 | PrestoValueCheckOperator()
-266 | SQLCheckOperator()
+258 | PrestoValueCheckOperator()
+259 | SQLCheckOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLIntervalCheckOperator` instead.
 
-AIR302.py:265:1: AIR302 `airflow.operators.presto_check_operator.PrestoValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:258:1: AIR302 `airflow.operators.presto_check_operator.PrestoValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-263 | PrestoCheckOperator()
-264 | PrestoIntervalCheckOperator()
-265 | PrestoValueCheckOperator()
+256 | PrestoCheckOperator()
+257 | PrestoIntervalCheckOperator()
+258 | PrestoValueCheckOperator()
     | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-266 | SQLCheckOperator()
-267 | SQLCheckOperator2()
+259 | SQLCheckOperator()
+260 | SQLCheckOperator2()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLValueCheckOperator` instead.
 
-AIR302.py:266:1: AIR302 `airflow.operators.check_operator.SQLCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:259:1: AIR302 `airflow.operators.check_operator.SQLCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-264 | PrestoIntervalCheckOperator()
-265 | PrestoValueCheckOperator()
-266 | SQLCheckOperator()
+257 | PrestoIntervalCheckOperator()
+258 | PrestoValueCheckOperator()
+259 | SQLCheckOperator()
     | ^^^^^^^^^^^^^^^^ AIR302
-267 | SQLCheckOperator2()
-268 | SQLCheckOperator3()
+260 | SQLCheckOperator2()
+261 | SQLCheckOperator3()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLCheckOperator` instead.
 
-AIR302.py:267:1: AIR302 `airflow.operators.presto_check_operator.SQLCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:260:1: AIR302 `airflow.operators.presto_check_operator.SQLCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-265 | PrestoValueCheckOperator()
-266 | SQLCheckOperator()
-267 | SQLCheckOperator2()
+258 | PrestoValueCheckOperator()
+259 | SQLCheckOperator()
+260 | SQLCheckOperator2()
     | ^^^^^^^^^^^^^^^^^ AIR302
-268 | SQLCheckOperator3()
-269 | SQLColumnCheckOperator2()
+261 | SQLCheckOperator3()
+262 | SQLColumnCheckOperator2()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLCheckOperator` instead.
 
-AIR302.py:268:1: AIR302 `airflow.operators.sql.SQLCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:261:1: AIR302 `airflow.operators.sql.SQLCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-266 | SQLCheckOperator()
-267 | SQLCheckOperator2()
-268 | SQLCheckOperator3()
+259 | SQLCheckOperator()
+260 | SQLCheckOperator2()
+261 | SQLCheckOperator3()
     | ^^^^^^^^^^^^^^^^^ AIR302
-269 | SQLColumnCheckOperator2()
-270 | SQLIntervalCheckOperator()
+262 | SQLColumnCheckOperator2()
+263 | SQLIntervalCheckOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLCheckOperator` instead.
 
-AIR302.py:269:1: AIR302 `airflow.operators.sql.SQLColumnCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:262:1: AIR302 `airflow.operators.sql.SQLColumnCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-267 | SQLCheckOperator2()
-268 | SQLCheckOperator3()
-269 | SQLColumnCheckOperator2()
+260 | SQLCheckOperator2()
+261 | SQLCheckOperator3()
+262 | SQLColumnCheckOperator2()
     | ^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-270 | SQLIntervalCheckOperator()
-271 | SQLIntervalCheckOperator2()
+263 | SQLIntervalCheckOperator()
+264 | SQLIntervalCheckOperator2()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.0.0` and use `airflow.providers.common.sql.operators.sql.SQLColumnCheckOperator` instead.
 
-AIR302.py:270:1: AIR302 `airflow.operators.check_operator.SQLIntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:263:1: AIR302 `airflow.operators.check_operator.SQLIntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-268 | SQLCheckOperator3()
-269 | SQLColumnCheckOperator2()
-270 | SQLIntervalCheckOperator()
+261 | SQLCheckOperator3()
+262 | SQLColumnCheckOperator2()
+263 | SQLIntervalCheckOperator()
     | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-271 | SQLIntervalCheckOperator2()
-272 | SQLIntervalCheckOperator3()
+264 | SQLIntervalCheckOperator2()
+265 | SQLIntervalCheckOperator3()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLIntervalCheckOperator` instead.
 
-AIR302.py:271:1: AIR302 `airflow.operators.presto_check_operator.SQLIntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:264:1: AIR302 `airflow.operators.presto_check_operator.SQLIntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-269 | SQLColumnCheckOperator2()
-270 | SQLIntervalCheckOperator()
-271 | SQLIntervalCheckOperator2()
+262 | SQLColumnCheckOperator2()
+263 | SQLIntervalCheckOperator()
+264 | SQLIntervalCheckOperator2()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-272 | SQLIntervalCheckOperator3()
-273 | SQLTableCheckOperator()
+265 | SQLIntervalCheckOperator3()
+266 | SQLTableCheckOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLIntervalCheckOperator` instead.
 
-AIR302.py:272:1: AIR302 `airflow.operators.sql.SQLIntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:265:1: AIR302 `airflow.operators.sql.SQLIntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-270 | SQLIntervalCheckOperator()
-271 | SQLIntervalCheckOperator2()
-272 | SQLIntervalCheckOperator3()
+263 | SQLIntervalCheckOperator()
+264 | SQLIntervalCheckOperator2()
+265 | SQLIntervalCheckOperator3()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-273 | SQLTableCheckOperator()
-274 | SQLThresholdCheckOperator()
+266 | SQLTableCheckOperator()
+267 | SQLThresholdCheckOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLIntervalCheckOperator` instead.
 
-AIR302.py:274:1: AIR302 `airflow.operators.check_operator.SQLThresholdCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:267:1: AIR302 `airflow.operators.check_operator.SQLThresholdCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-272 | SQLIntervalCheckOperator3()
-273 | SQLTableCheckOperator()
-274 | SQLThresholdCheckOperator()
+265 | SQLIntervalCheckOperator3()
+266 | SQLTableCheckOperator()
+267 | SQLThresholdCheckOperator()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-275 | SQLThresholdCheckOperator2()
-276 | SQLValueCheckOperator()
+268 | SQLThresholdCheckOperator2()
+269 | SQLValueCheckOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLThresholdCheckOperator` instead.
 
-AIR302.py:275:1: AIR302 `airflow.operators.sql.SQLThresholdCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:268:1: AIR302 `airflow.operators.sql.SQLThresholdCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-273 | SQLTableCheckOperator()
-274 | SQLThresholdCheckOperator()
-275 | SQLThresholdCheckOperator2()
+266 | SQLTableCheckOperator()
+267 | SQLThresholdCheckOperator()
+268 | SQLThresholdCheckOperator2()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-276 | SQLValueCheckOperator()
-277 | SQLValueCheckOperator2()
+269 | SQLValueCheckOperator()
+270 | SQLValueCheckOperator2()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.0.0` and use `airflow.providers.common.sql.operators.sql.SQLTableCheckOperator` instead.
 
-AIR302.py:276:1: AIR302 `airflow.operators.check_operator.SQLValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:269:1: AIR302 `airflow.operators.check_operator.SQLValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-274 | SQLThresholdCheckOperator()
-275 | SQLThresholdCheckOperator2()
-276 | SQLValueCheckOperator()
+267 | SQLThresholdCheckOperator()
+268 | SQLThresholdCheckOperator2()
+269 | SQLValueCheckOperator()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-277 | SQLValueCheckOperator2()
-278 | SQLValueCheckOperator3()
+270 | SQLValueCheckOperator2()
+271 | SQLValueCheckOperator3()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLValueCheckOperator` instead.
 
-AIR302.py:277:1: AIR302 `airflow.operators.presto_check_operator.SQLValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:270:1: AIR302 `airflow.operators.presto_check_operator.SQLValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-275 | SQLThresholdCheckOperator2()
-276 | SQLValueCheckOperator()
-277 | SQLValueCheckOperator2()
+268 | SQLThresholdCheckOperator2()
+269 | SQLValueCheckOperator()
+270 | SQLValueCheckOperator2()
     | ^^^^^^^^^^^^^^^^^^^^^^ AIR302
-278 | SQLValueCheckOperator3()
-279 | SqlSensor()
+271 | SQLValueCheckOperator3()
+272 | SqlSensor()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLValueCheckOperator` instead.
 
-AIR302.py:278:1: AIR302 `airflow.operators.sql.SQLValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:271:1: AIR302 `airflow.operators.sql.SQLValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-276 | SQLValueCheckOperator()
-277 | SQLValueCheckOperator2()
-278 | SQLValueCheckOperator3()
+269 | SQLValueCheckOperator()
+270 | SQLValueCheckOperator2()
+271 | SQLValueCheckOperator3()
     | ^^^^^^^^^^^^^^^^^^^^^^ AIR302
-279 | SqlSensor()
-280 | SqlSensor2()
+272 | SqlSensor()
+273 | SqlSensor2()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.0.0` and use `airflow.providers.common.sql.operators.sql.SQLValueCheckOperator` instead.
 
-AIR302.py:279:1: AIR302 `airflow.sensors.sql.SqlSensor` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:272:1: AIR302 `airflow.sensors.sql.SqlSensor` is moved into `common-sql` provider in Airflow 3.0;
     |
-277 | SQLValueCheckOperator2()
-278 | SQLValueCheckOperator3()
-279 | SqlSensor()
+270 | SQLValueCheckOperator2()
+271 | SQLValueCheckOperator3()
+272 | SqlSensor()
     | ^^^^^^^^^ AIR302
-280 | SqlSensor2()
-281 | ThresholdCheckOperator()
+273 | SqlSensor2()
+274 | ThresholdCheckOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.0.0` and use `airflow.providers.common.sql.sensors.sql.SqlSensor` instead.
 
-AIR302.py:281:1: AIR302 `airflow.operators.check_operator.ThresholdCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:274:1: AIR302 `airflow.operators.check_operator.ThresholdCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-279 | SqlSensor()
-280 | SqlSensor2()
-281 | ThresholdCheckOperator()
+272 | SqlSensor()
+273 | SqlSensor2()
+274 | ThresholdCheckOperator()
     | ^^^^^^^^^^^^^^^^^^^^^^ AIR302
-282 | ValueCheckOperator()
+275 | ValueCheckOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLThresholdCheckOperator` instead.
 
-AIR302.py:282:1: AIR302 `airflow.operators.check_operator.ValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:275:1: AIR302 `airflow.operators.check_operator.ValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-280 | SqlSensor2()
-281 | ThresholdCheckOperator()
-282 | ValueCheckOperator()
+273 | SqlSensor2()
+274 | ThresholdCheckOperator()
+275 | ValueCheckOperator()
     | ^^^^^^^^^^^^^^^^^^ AIR302
-283 |
-284 | # apache-airflow-providers-daskexecutor
+276 |
+277 | # apache-airflow-providers-daskexecutor
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLValueCheckOperator` instead.
 
-AIR302.py:285:1: AIR302 `airflow.executors.dask_executor.DaskExecutor` is moved into `daskexecutor` provider in Airflow 3.0;
+AIR302.py:278:1: AIR302 `airflow.executors.dask_executor.DaskExecutor` is moved into `daskexecutor` provider in Airflow 3.0;
     |
-284 | # apache-airflow-providers-daskexecutor
-285 | DaskExecutor()
+277 | # apache-airflow-providers-daskexecutor
+278 | DaskExecutor()
     | ^^^^^^^^^^^^ AIR302
-286 |
-287 | # apache-airflow-providers-docker
+279 |
+280 | # apache-airflow-providers-docker
     |
     = help: Install `apache-airflow-provider-daskexecutor>=1.0.0` and use `airflow.providers.daskexecutor.executors.dask_executor.DaskExecutor` instead.
 
-AIR302.py:288:1: AIR302 `airflow.hooks.docker_hook.DockerHook` is moved into `docker` provider in Airflow 3.0;
+AIR302.py:281:1: AIR302 `airflow.hooks.docker_hook.DockerHook` is moved into `docker` provider in Airflow 3.0;
     |
-287 | # apache-airflow-providers-docker
-288 | DockerHook()
+280 | # apache-airflow-providers-docker
+281 | DockerHook()
     | ^^^^^^^^^^ AIR302
-289 | DockerOperator()
+282 | DockerOperator()
     |
     = help: Install `apache-airflow-provider-docker>=1.0.0` and use `airflow.providers.docker.hooks.docker.DockerHook` instead.
 
-AIR302.py:289:1: AIR302 `airflow.operators.docker_operator.DockerOperator` is moved into `docker` provider in Airflow 3.0;
+AIR302.py:282:1: AIR302 `airflow.operators.docker_operator.DockerOperator` is moved into `docker` provider in Airflow 3.0;
     |
-287 | # apache-airflow-providers-docker
-288 | DockerHook()
-289 | DockerOperator()
+280 | # apache-airflow-providers-docker
+281 | DockerHook()
+282 | DockerOperator()
     | ^^^^^^^^^^^^^^ AIR302
-290 |
-291 | # apache-airflow-providers-apache-druid
+283 |
+284 | # apache-airflow-providers-apache-druid
     |
     = help: Install `apache-airflow-provider-docker>=1.0.0` and use `airflow.providers.docker.operators.docker.DockerOperator` instead.
 
-AIR302.py:292:1: AIR302 `airflow.hooks.druid_hook.DruidDbApiHook` is moved into `apache-druid` provider in Airflow 3.0;
+AIR302.py:285:1: AIR302 `airflow.hooks.druid_hook.DruidDbApiHook` is moved into `apache-druid` provider in Airflow 3.0;
     |
-291 | # apache-airflow-providers-apache-druid
-292 | DruidDbApiHook()
+284 | # apache-airflow-providers-apache-druid
+285 | DruidDbApiHook()
     | ^^^^^^^^^^^^^^ AIR302
-293 | DruidHook()
-294 | DruidCheckOperator()
+286 | DruidHook()
+287 | DruidCheckOperator()
     |
     = help: Install `apache-airflow-provider-apache-druid>=1.0.0` and use `DruidDbApiHook` instead.
 
-AIR302.py:293:1: AIR302 `airflow.hooks.druid_hook.DruidHook` is moved into `apache-druid` provider in Airflow 3.0;
+AIR302.py:286:1: AIR302 `airflow.hooks.druid_hook.DruidHook` is moved into `apache-druid` provider in Airflow 3.0;
     |
-291 | # apache-airflow-providers-apache-druid
-292 | DruidDbApiHook()
-293 | DruidHook()
+284 | # apache-airflow-providers-apache-druid
+285 | DruidDbApiHook()
+286 | DruidHook()
     | ^^^^^^^^^ AIR302
-294 | DruidCheckOperator()
+287 | DruidCheckOperator()
     |
     = help: Install `apache-airflow-provider-apache-druid>=1.0.0` and use `DruidHook` instead.
 
-AIR302.py:294:1: AIR302 `airflow.operators.druid_check_operator.DruidCheckOperator` is moved into `apache-druid` provider in Airflow 3.0;
+AIR302.py:287:1: AIR302 `airflow.operators.druid_check_operator.DruidCheckOperator` is moved into `apache-druid` provider in Airflow 3.0;
     |
-292 | DruidDbApiHook()
-293 | DruidHook()
-294 | DruidCheckOperator()
+285 | DruidDbApiHook()
+286 | DruidHook()
+287 | DruidCheckOperator()
     | ^^^^^^^^^^^^^^^^^^ AIR302
-295 |
-296 | # apache-airflow-providers-apache-hdfs
+288 |
+289 | # apache-airflow-providers-apache-hdfs
     |
     = help: Install `apache-airflow-provider-apache-druid>=1.0.0` and use `DruidCheckOperator` instead.
 
-AIR302.py:297:1: AIR302 `airflow.hooks.webhdfs_hook.WebHDFSHook` is moved into `apache-hdfs` provider in Airflow 3.0;
+AIR302.py:290:1: AIR302 `airflow.hooks.webhdfs_hook.WebHDFSHook` is moved into `apache-hdfs` provider in Airflow 3.0;
     |
-296 | # apache-airflow-providers-apache-hdfs
-297 | WebHDFSHook()
+289 | # apache-airflow-providers-apache-hdfs
+290 | WebHDFSHook()
     | ^^^^^^^^^^^ AIR302
-298 | WebHdfsSensor()
+291 | WebHdfsSensor()
     |
     = help: Install `apache-airflow-provider-apache-hdfs>=1.0.0` and use `airflow.providers.apache.hdfs.hooks.webhdfs.WebHDFSHook` instead.
 
-AIR302.py:298:1: AIR302 `airflow.sensors.web_hdfs_sensor.WebHdfsSensor` is moved into `apache-hdfs` provider in Airflow 3.0;
+AIR302.py:291:1: AIR302 `airflow.sensors.web_hdfs_sensor.WebHdfsSensor` is moved into `apache-hdfs` provider in Airflow 3.0;
     |
-296 | # apache-airflow-providers-apache-hdfs
-297 | WebHDFSHook()
-298 | WebHdfsSensor()
+289 | # apache-airflow-providers-apache-hdfs
+290 | WebHDFSHook()
+291 | WebHdfsSensor()
     | ^^^^^^^^^^^^^ AIR302
-299 |
-300 | # apache-airflow-providers-apache-hive
+292 |
+293 | # apache-airflow-providers-apache-hive
     |
     = help: Install `apache-airflow-provider-apache-hdfs>=1.0.0` and use `airflow.providers.apache.hdfs.sensors.web_hdfs.WebHdfsSensor` instead.
 
-AIR302.py:301:1: AIR302 `airflow.hooks.hive_hooks.HIVE_QUEUE_PRIORITIES` is moved into `apache-hive` provider in Airflow 3.0;
+AIR302.py:294:1: AIR302 `airflow.hooks.hive_hooks.HIVE_QUEUE_PRIORITIES` is moved into `apache-hive` provider in Airflow 3.0;
     |
-300 | # apache-airflow-providers-apache-hive
-301 | HIVE_QUEUE_PRIORITIES
+293 | # apache-airflow-providers-apache-hive
+294 | HIVE_QUEUE_PRIORITIES
     | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-302 | closest_ds_partition()
-303 | max_partition()
+295 | closest_ds_partition()
+296 | max_partition()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.hooks.hive.HIVE_QUEUE_PRIORITIES` instead.
 
-AIR302.py:302:1: AIR302 `airflow.macros.hive.closest_ds_partition` is moved into `apache-hive` provider in Airflow 3.0;
+AIR302.py:295:1: AIR302 `airflow.macros.hive.closest_ds_partition` is moved into `apache-hive` provider in Airflow 3.0;
     |
-300 | # apache-airflow-providers-apache-hive
-301 | HIVE_QUEUE_PRIORITIES
-302 | closest_ds_partition()
+293 | # apache-airflow-providers-apache-hive
+294 | HIVE_QUEUE_PRIORITIES
+295 | closest_ds_partition()
     | ^^^^^^^^^^^^^^^^^^^^ AIR302
-303 | max_partition()
-304 | HiveCliHook()
+296 | max_partition()
+297 | HiveCliHook()
     |
     = help: Install `apache-airflow-provider-apache-hive>=5.1.0` and use `airflow.providers.apache.hive.macros.hive.closest_ds_partition` instead.
 
-AIR302.py:303:1: AIR302 `airflow.macros.hive.max_partition` is moved into `apache-hive` provider in Airflow 3.0;
+AIR302.py:296:1: AIR302 `airflow.macros.hive.max_partition` is moved into `apache-hive` provider in Airflow 3.0;
     |
-301 | HIVE_QUEUE_PRIORITIES
-302 | closest_ds_partition()
-303 | max_partition()
+294 | HIVE_QUEUE_PRIORITIES
+295 | closest_ds_partition()
+296 | max_partition()
     | ^^^^^^^^^^^^^ AIR302
-304 | HiveCliHook()
-305 | HiveMetastoreHook()
+297 | HiveCliHook()
+298 | HiveMetastoreHook()
     |
     = help: Install `apache-airflow-provider-apache-hive>=5.1.0` and use `airflow.providers.apache.hive.macros.hive.max_partition` instead.
 
-AIR302.py:304:1: AIR302 `airflow.hooks.hive_hooks.HiveCliHook` is moved into `apache-hive` provider in Airflow 3.0;
+AIR302.py:297:1: AIR302 `airflow.hooks.hive_hooks.HiveCliHook` is moved into `apache-hive` provider in Airflow 3.0;
     |
-302 | closest_ds_partition()
-303 | max_partition()
-304 | HiveCliHook()
+295 | closest_ds_partition()
+296 | max_partition()
+297 | HiveCliHook()
     | ^^^^^^^^^^^ AIR302
-305 | HiveMetastoreHook()
-306 | HiveOperator()
+298 | HiveMetastoreHook()
+299 | HiveOperator()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.hooks.hive.HiveCliHook` instead.
 
-AIR302.py:305:1: AIR302 `airflow.hooks.hive_hooks.HiveMetastoreHook` is moved into `apache-hive` provider in Airflow 3.0;
+AIR302.py:298:1: AIR302 `airflow.hooks.hive_hooks.HiveMetastoreHook` is moved into `apache-hive` provider in Airflow 3.0;
     |
-303 | max_partition()
-304 | HiveCliHook()
-305 | HiveMetastoreHook()
+296 | max_partition()
+297 | HiveCliHook()
+298 | HiveMetastoreHook()
     | ^^^^^^^^^^^^^^^^^ AIR302
-306 | HiveOperator()
-307 | HivePartitionSensor()
+299 | HiveOperator()
+300 | HivePartitionSensor()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.hooks.hive.HiveMetastoreHook` instead.
 
-AIR302.py:306:1: AIR302 `airflow.operators.hive_operator.HiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
+AIR302.py:299:1: AIR302 `airflow.operators.hive_operator.HiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
     |
-304 | HiveCliHook()
-305 | HiveMetastoreHook()
-306 | HiveOperator()
+297 | HiveCliHook()
+298 | HiveMetastoreHook()
+299 | HiveOperator()
     | ^^^^^^^^^^^^ AIR302
-307 | HivePartitionSensor()
-308 | HiveServer2Hook()
+300 | HivePartitionSensor()
+301 | HiveServer2Hook()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.operators.hive.HiveOperator` instead.
 
-AIR302.py:307:1: AIR302 `airflow.sensors.hive_partition_sensor.HivePartitionSensor` is moved into `apache-hive` provider in Airflow 3.0;
+AIR302.py:300:1: AIR302 `airflow.sensors.hive_partition_sensor.HivePartitionSensor` is moved into `apache-hive` provider in Airflow 3.0;
     |
-305 | HiveMetastoreHook()
-306 | HiveOperator()
-307 | HivePartitionSensor()
+298 | HiveMetastoreHook()
+299 | HiveOperator()
+300 | HivePartitionSensor()
     | ^^^^^^^^^^^^^^^^^^^ AIR302
-308 | HiveServer2Hook()
-309 | HiveStatsCollectionOperator()
+301 | HiveServer2Hook()
+302 | HiveStatsCollectionOperator()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.sensors.hive_partition.HivePartitionSensor` instead.
 
-AIR302.py:308:1: AIR302 `airflow.hooks.hive_hooks.HiveServer2Hook` is moved into `apache-hive` provider in Airflow 3.0;
+AIR302.py:301:1: AIR302 `airflow.hooks.hive_hooks.HiveServer2Hook` is moved into `apache-hive` provider in Airflow 3.0;
     |
-306 | HiveOperator()
-307 | HivePartitionSensor()
-308 | HiveServer2Hook()
+299 | HiveOperator()
+300 | HivePartitionSensor()
+301 | HiveServer2Hook()
     | ^^^^^^^^^^^^^^^ AIR302
-309 | HiveStatsCollectionOperator()
-310 | HiveToDruidOperator()
+302 | HiveStatsCollectionOperator()
+303 | HiveToDruidOperator()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.hooks.hive.HiveServer2Hook` instead.
 
-AIR302.py:309:1: AIR302 `airflow.operators.hive_stats_operator.HiveStatsCollectionOperator` is moved into `apache-hive` provider in Airflow 3.0;
+AIR302.py:302:1: AIR302 `airflow.operators.hive_stats_operator.HiveStatsCollectionOperator` is moved into `apache-hive` provider in Airflow 3.0;
     |
-307 | HivePartitionSensor()
-308 | HiveServer2Hook()
-309 | HiveStatsCollectionOperator()
+300 | HivePartitionSensor()
+301 | HiveServer2Hook()
+302 | HiveStatsCollectionOperator()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-310 | HiveToDruidOperator()
-311 | HiveToDruidTransfer()
+303 | HiveToDruidOperator()
+304 | HiveToDruidTransfer()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.operators.hive_stats.HiveStatsCollectionOperator` instead.
 
-AIR302.py:310:1: AIR302 `airflow.operators.hive_to_druid.HiveToDruidOperator` is moved into `apache-druid` provider in Airflow 3.0;
+AIR302.py:303:1: AIR302 `airflow.operators.hive_to_druid.HiveToDruidOperator` is moved into `apache-druid` provider in Airflow 3.0;
     |
-308 | HiveServer2Hook()
-309 | HiveStatsCollectionOperator()
-310 | HiveToDruidOperator()
+301 | HiveServer2Hook()
+302 | HiveStatsCollectionOperator()
+303 | HiveToDruidOperator()
     | ^^^^^^^^^^^^^^^^^^^ AIR302
-311 | HiveToDruidTransfer()
-312 | HiveToSambaOperator()
+304 | HiveToDruidTransfer()
+305 | HiveToSambaOperator()
     |
     = help: Install `apache-airflow-provider-apache-druid>=1.0.0` and use `airflow.providers.apache.druid.transfers.hive_to_druid.HiveToDruidOperator` instead.
 
-AIR302.py:311:1: AIR302 `airflow.operators.hive_to_druid.HiveToDruidTransfer` is moved into `apache-druid` provider in Airflow 3.0;
+AIR302.py:304:1: AIR302 `airflow.operators.hive_to_druid.HiveToDruidTransfer` is moved into `apache-druid` provider in Airflow 3.0;
     |
-309 | HiveStatsCollectionOperator()
-310 | HiveToDruidOperator()
-311 | HiveToDruidTransfer()
+302 | HiveStatsCollectionOperator()
+303 | HiveToDruidOperator()
+304 | HiveToDruidTransfer()
     | ^^^^^^^^^^^^^^^^^^^ AIR302
-312 | HiveToSambaOperator()
-313 | S3ToHiveOperator()
+305 | HiveToSambaOperator()
+306 | S3ToHiveOperator()
     |
     = help: Install `apache-airflow-provider-apache-druid>=1.0.0` and use `airflow.providers.apache.druid.transfers.hive_to_druid.HiveToDruidOperator` instead.
 
-AIR302.py:312:1: AIR302 `airflow.operators.hive_to_samba_operator.HiveToSambaOperator` is moved into `apache-hive` provider in Airflow 3.0;
+AIR302.py:305:1: AIR302 `airflow.operators.hive_to_samba_operator.HiveToSambaOperator` is moved into `apache-hive` provider in Airflow 3.0;
     |
-310 | HiveToDruidOperator()
-311 | HiveToDruidTransfer()
-312 | HiveToSambaOperator()
+303 | HiveToDruidOperator()
+304 | HiveToDruidTransfer()
+305 | HiveToSambaOperator()
     | ^^^^^^^^^^^^^^^^^^^ AIR302
-313 | S3ToHiveOperator()
-314 | S3ToHiveTransfer()
+306 | S3ToHiveOperator()
+307 | S3ToHiveTransfer()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `HiveToSambaOperator` instead.
 
-AIR302.py:313:1: AIR302 `airflow.operators.s3_to_hive_operator.S3ToHiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
+AIR302.py:306:1: AIR302 `airflow.operators.s3_to_hive_operator.S3ToHiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
     |
-311 | HiveToDruidTransfer()
-312 | HiveToSambaOperator()
-313 | S3ToHiveOperator()
+304 | HiveToDruidTransfer()
+305 | HiveToSambaOperator()
+306 | S3ToHiveOperator()
     | ^^^^^^^^^^^^^^^^ AIR302
-314 | S3ToHiveTransfer()
-315 | MetastorePartitionSensor()
+307 | S3ToHiveTransfer()
+308 | MetastorePartitionSensor()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.transfers.s3_to_hive.S3ToHiveOperator` instead.
 
-AIR302.py:314:1: AIR302 `airflow.operators.s3_to_hive_operator.S3ToHiveTransfer` is moved into `apache-hive` provider in Airflow 3.0;
+AIR302.py:307:1: AIR302 `airflow.operators.s3_to_hive_operator.S3ToHiveTransfer` is moved into `apache-hive` provider in Airflow 3.0;
     |
-312 | HiveToSambaOperator()
-313 | S3ToHiveOperator()
-314 | S3ToHiveTransfer()
+305 | HiveToSambaOperator()
+306 | S3ToHiveOperator()
+307 | S3ToHiveTransfer()
     | ^^^^^^^^^^^^^^^^ AIR302
-315 | MetastorePartitionSensor()
-316 | NamedHivePartitionSensor()
+308 | MetastorePartitionSensor()
+309 | NamedHivePartitionSensor()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.transfers.s3_to_hive.S3ToHiveOperator` instead.
 
-AIR302.py:315:1: AIR302 `airflow.sensors.metastore_partition_sensor.MetastorePartitionSensor` is moved into `apache-hive` provider in Airflow 3.0;
+AIR302.py:308:1: AIR302 `airflow.sensors.metastore_partition_sensor.MetastorePartitionSensor` is moved into `apache-hive` provider in Airflow 3.0;
     |
-313 | S3ToHiveOperator()
-314 | S3ToHiveTransfer()
-315 | MetastorePartitionSensor()
+306 | S3ToHiveOperator()
+307 | S3ToHiveTransfer()
+308 | MetastorePartitionSensor()
     | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-316 | NamedHivePartitionSensor()
+309 | NamedHivePartitionSensor()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.sensors.metastore_partition.MetastorePartitionSensor` instead.
 
-AIR302.py:316:1: AIR302 `airflow.sensors.named_hive_partition_sensor.NamedHivePartitionSensor` is moved into `apache-hive` provider in Airflow 3.0;
+AIR302.py:309:1: AIR302 `airflow.sensors.named_hive_partition_sensor.NamedHivePartitionSensor` is moved into `apache-hive` provider in Airflow 3.0;
     |
-314 | S3ToHiveTransfer()
-315 | MetastorePartitionSensor()
-316 | NamedHivePartitionSensor()
+307 | S3ToHiveTransfer()
+308 | MetastorePartitionSensor()
+309 | NamedHivePartitionSensor()
     | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-317 |
-318 | # apache-airflow-providers-http
+310 |
+311 | # apache-airflow-providers-http
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.sensors.named_hive_partition.NamedHivePartitionSensor` instead.
 
-AIR302.py:319:1: AIR302 `airflow.hooks.http_hook.HttpHook` is moved into `http` provider in Airflow 3.0;
+AIR302.py:312:1: AIR302 `airflow.hooks.http_hook.HttpHook` is moved into `http` provider in Airflow 3.0;
     |
-318 | # apache-airflow-providers-http
-319 | HttpHook()
+311 | # apache-airflow-providers-http
+312 | HttpHook()
     | ^^^^^^^^ AIR302
-320 | HttpSensor()
-321 | SimpleHttpOperator()
+313 | HttpSensor()
+314 | SimpleHttpOperator()
     |
     = help: Install `apache-airflow-provider-http>=1.0.0` and use `airflow.providers.http.hooks.http.HttpHook` instead.
 
-AIR302.py:320:1: AIR302 `airflow.sensors.http_sensor.HttpSensor` is moved into `http` provider in Airflow 3.0;
+AIR302.py:313:1: AIR302 `airflow.sensors.http_sensor.HttpSensor` is moved into `http` provider in Airflow 3.0;
     |
-318 | # apache-airflow-providers-http
-319 | HttpHook()
-320 | HttpSensor()
+311 | # apache-airflow-providers-http
+312 | HttpHook()
+313 | HttpSensor()
     | ^^^^^^^^^^ AIR302
-321 | SimpleHttpOperator()
+314 | SimpleHttpOperator()
     |
     = help: Install `apache-airflow-provider-http>=1.0.0` and use `airflow.providers.http.sensors.http.HttpSensor` instead.
 
-AIR302.py:321:1: AIR302 `airflow.operators.http_operator.SimpleHttpOperator` is moved into `http` provider in Airflow 3.0;
+AIR302.py:314:1: AIR302 `airflow.operators.http_operator.SimpleHttpOperator` is moved into `http` provider in Airflow 3.0;
     |
-319 | HttpHook()
-320 | HttpSensor()
-321 | SimpleHttpOperator()
+312 | HttpHook()
+313 | HttpSensor()
+314 | SimpleHttpOperator()
     | ^^^^^^^^^^^^^^^^^^ AIR302
-322 |
-323 | # apache-airflow-providers-jdbc
+315 |
+316 | # apache-airflow-providers-jdbc
     |
     = help: Install `apache-airflow-provider-http>=1.0.0` and use `airflow.providers.http.operators.http.SimpleHttpOperator` instead.
 
-AIR302.py:324:1: AIR302 `airflow.hooks.jdbc_hook.jaydebeapi` is moved into `jdbc` provider in Airflow 3.0;
+AIR302.py:317:1: AIR302 `airflow.hooks.jdbc_hook.jaydebeapi` is moved into `jdbc` provider in Airflow 3.0;
     |
-323 | # apache-airflow-providers-jdbc
-324 | jaydebeapi
+316 | # apache-airflow-providers-jdbc
+317 | jaydebeapi
     | ^^^^^^^^^^ AIR302
-325 | JdbcHook()
-326 | JdbcOperator()
+318 | JdbcHook()
+319 | JdbcOperator()
     |
     = help: Install `apache-airflow-provider-jdbc>=1.0.0` and use `airflow.providers.jdbc.hooks.jdbc.jaydebeapi` instead.
 
-AIR302.py:325:1: AIR302 `airflow.hooks.jdbc_hook.JdbcHook` is moved into `jdbc` provider in Airflow 3.0;
+AIR302.py:318:1: AIR302 `airflow.hooks.jdbc_hook.JdbcHook` is moved into `jdbc` provider in Airflow 3.0;
     |
-323 | # apache-airflow-providers-jdbc
-324 | jaydebeapi
-325 | JdbcHook()
+316 | # apache-airflow-providers-jdbc
+317 | jaydebeapi
+318 | JdbcHook()
     | ^^^^^^^^ AIR302
-326 | JdbcOperator()
+319 | JdbcOperator()
     |
     = help: Install `apache-airflow-provider-jdbc>=1.0.0` and use `airflow.providers.jdbc.hooks.jdbc.JdbcHook` instead.
 
-AIR302.py:326:1: AIR302 `airflow.operators.jdbc_operator.JdbcOperator` is moved into `jdbc` provider in Airflow 3.0;
+AIR302.py:319:1: AIR302 `airflow.operators.jdbc_operator.JdbcOperator` is moved into `jdbc` provider in Airflow 3.0;
     |
-324 | jaydebeapi
-325 | JdbcHook()
-326 | JdbcOperator()
+317 | jaydebeapi
+318 | JdbcHook()
+319 | JdbcOperator()
     | ^^^^^^^^^^^^ AIR302
-327 |
-328 | # apache-airflow-providers-fab
+320 |
+321 | # apache-airflow-providers-fab
     |
     = help: Install `apache-airflow-provider-jdbc>=1.0.0` and use `airflow.providers.jdbc.operators.jdbc.JdbcOperator` instead.
 
-AIR302.py:329:1: AIR302 Import path `airflow.api.auth.backend.basic_auth` is moved into `fab` provider in Airflow 3.0;
+AIR302.py:322:1: AIR302 Import path `airflow.api.auth.backend.basic_auth` is moved into `fab` provider in Airflow 3.0;
     |
-328 | # apache-airflow-providers-fab
-329 | basic_auth, kerberos_auth
+321 | # apache-airflow-providers-fab
+322 | basic_auth, kerberos_auth
     | ^^^^^^^^^^ AIR302
-330 | auth_current_user
-331 | backend_kerberos_auth
+323 | auth_current_user
+324 | backend_kerberos_auth
     |
     = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.api.auth.backend.basic_auth` instead.
 
-AIR302.py:329:13: AIR302 Import path `airflow.api.auth.backend.kerberos_auth` is moved into `fab` provider in Airflow 3.0;
+AIR302.py:322:13: AIR302 Import path `airflow.api.auth.backend.kerberos_auth` is moved into `fab` provider in Airflow 3.0;
     |
-328 | # apache-airflow-providers-fab
-329 | basic_auth, kerberos_auth
+321 | # apache-airflow-providers-fab
+322 | basic_auth, kerberos_auth
     |             ^^^^^^^^^^^^^ AIR302
-330 | auth_current_user
-331 | backend_kerberos_auth
+323 | auth_current_user
+324 | backend_kerberos_auth
     |
     = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth` instead.
 
-AIR302.py:330:1: AIR302 Import path `airflow.api.auth.backend.basic_auth` is moved into `fab` provider in Airflow 3.0;
+AIR302.py:323:1: AIR302 Import path `airflow.api.auth.backend.basic_auth` is moved into `fab` provider in Airflow 3.0;
     |
-328 | # apache-airflow-providers-fab
-329 | basic_auth, kerberos_auth
-330 | auth_current_user
+321 | # apache-airflow-providers-fab
+322 | basic_auth, kerberos_auth
+323 | auth_current_user
     | ^^^^^^^^^^^^^^^^^ AIR302
-331 | backend_kerberos_auth
-332 | fab_override
+324 | backend_kerberos_auth
+325 | fab_override
     |
     = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.api.auth.backend.basic_auth` instead.
 
-AIR302.py:331:1: AIR302 Import path `airflow.auth_manager.api.auth.backend.kerberos_auth` is moved into `fab` provider in Airflow 3.0;
+AIR302.py:324:1: AIR302 Import path `airflow.auth_manager.api.auth.backend.kerberos_auth` is moved into `fab` provider in Airflow 3.0;
     |
-329 | basic_auth, kerberos_auth
-330 | auth_current_user
-331 | backend_kerberos_auth
+322 | basic_auth, kerberos_auth
+323 | auth_current_user
+324 | backend_kerberos_auth
     | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-332 | fab_override
-333 | FabAuthManager()
+325 | fab_override
+326 | FabAuthManager()
     |
     = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth` instead.
 
-AIR302.py:332:1: AIR302 Import path `airflow.auth.managers.fab.security_manager.override` is moved into `fab` provider in Airflow 3.0;
+AIR302.py:325:1: AIR302 Import path `airflow.auth.managers.fab.security_manager.override` is moved into `fab` provider in Airflow 3.0;
     |
-330 | auth_current_user
-331 | backend_kerberos_auth
-332 | fab_override
+323 | auth_current_user
+324 | backend_kerberos_auth
+325 | fab_override
     | ^^^^^^^^^^^^ AIR302
-333 | FabAuthManager()
-334 | FabAirflowSecurityManagerOverride()
+326 | FabAuthManager()
+327 | FabAirflowSecurityManagerOverride()
     |
     = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.security_manager.override` instead.
 
-AIR302.py:333:1: AIR302 `airflow.auth.managers.fab.fab_auth_manager.FabAuthManager` is moved into `fab` provider in Airflow 3.0;
+AIR302.py:326:1: AIR302 `airflow.auth.managers.fab.fab_auth_manager.FabAuthManager` is moved into `fab` provider in Airflow 3.0;
     |
-331 | backend_kerberos_auth
-332 | fab_override
-333 | FabAuthManager()
+324 | backend_kerberos_auth
+325 | fab_override
+326 | FabAuthManager()
     | ^^^^^^^^^^^^^^ AIR302
-334 | FabAirflowSecurityManagerOverride()
+327 | FabAirflowSecurityManagerOverride()
     |
     = help: Install `apache-airflow-provider-fab>=1.0.0` and use `airflow.providers.fab.auth_manager.security_manager.FabAuthManager` instead.
 
-AIR302.py:334:1: AIR302 `airflow.www.security.FabAirflowSecurityManagerOverride` is moved into `fab` provider in Airflow 3.0;
+AIR302.py:327:1: AIR302 `airflow.www.security.FabAirflowSecurityManagerOverride` is moved into `fab` provider in Airflow 3.0;
     |
-332 | fab_override
-333 | FabAuthManager()
-334 | FabAirflowSecurityManagerOverride()
+325 | fab_override
+326 | FabAuthManager()
+327 | FabAirflowSecurityManagerOverride()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-335 |
-336 | # apache-airflow-providers-cncf-kubernetes
+328 |
+329 | # apache-airflow-providers-cncf-kubernetes
     |
     = help: Install `apache-airflow-provider-fab>=1.0.0` and use `airflow.providers.fab.auth_manager.security_manager.override.FabAirflowSecurityManagerOverride` instead.
 
-AIR302.py:337:1: AIR302 `airflow.executors.kubernetes_executor_types.ALL_NAMESPACES` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:330:1: AIR302 `airflow.executors.kubernetes_executor_types.ALL_NAMESPACES` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-336 | # apache-airflow-providers-cncf-kubernetes
-337 | ALL_NAMESPACES
+329 | # apache-airflow-providers-cncf-kubernetes
+330 | ALL_NAMESPACES
     | ^^^^^^^^^^^^^^ AIR302
-338 | POD_EXECUTOR_DONE_KEY
-339 | _disable_verify_ssl()
+331 | POD_EXECUTOR_DONE_KEY
+332 | _disable_verify_ssl()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types.ALL_NAMESPACES` instead.
 
-AIR302.py:338:1: AIR302 `airflow.executors.kubernetes_executor_types.POD_EXECUTOR_DONE_KEY` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:331:1: AIR302 `airflow.executors.kubernetes_executor_types.POD_EXECUTOR_DONE_KEY` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-336 | # apache-airflow-providers-cncf-kubernetes
-337 | ALL_NAMESPACES
-338 | POD_EXECUTOR_DONE_KEY
+329 | # apache-airflow-providers-cncf-kubernetes
+330 | ALL_NAMESPACES
+331 | POD_EXECUTOR_DONE_KEY
     | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-339 | _disable_verify_ssl()
-340 | _enable_tcp_keepalive()
+332 | _disable_verify_ssl()
+333 | _enable_tcp_keepalive()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types.POD_EXECUTOR_DONE_KEY` instead.
 
-AIR302.py:339:1: AIR302 `airflow.kubernetes.kube_client._disable_verify_ssl` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:332:1: AIR302 `airflow.kubernetes.kube_client._disable_verify_ssl` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-337 | ALL_NAMESPACES
-338 | POD_EXECUTOR_DONE_KEY
-339 | _disable_verify_ssl()
+330 | ALL_NAMESPACES
+331 | POD_EXECUTOR_DONE_KEY
+332 | _disable_verify_ssl()
     | ^^^^^^^^^^^^^^^^^^^ AIR302
-340 | _enable_tcp_keepalive()
-341 | append_to_pod()
+333 | _enable_tcp_keepalive()
+334 | append_to_pod()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.kubernetes.airflow.providers.cncf.kubernetes.kube_client._disable_verify_ssl` instead.
 
-AIR302.py:340:1: AIR302 `airflow.kubernetes.kube_client._enable_tcp_keepalive` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:333:1: AIR302 `airflow.kubernetes.kube_client._enable_tcp_keepalive` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-338 | POD_EXECUTOR_DONE_KEY
-339 | _disable_verify_ssl()
-340 | _enable_tcp_keepalive()
+331 | POD_EXECUTOR_DONE_KEY
+332 | _disable_verify_ssl()
+333 | _enable_tcp_keepalive()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-341 | append_to_pod()
-342 | annotations_for_logging_task_metadata()
+334 | append_to_pod()
+335 | annotations_for_logging_task_metadata()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.kubernetes.airflow.providers.cncf.kubernetes.kube_client._enable_tcp_keepalive` instead.
 
-AIR302.py:341:1: AIR302 `airflow.kubernetes.k8s_model.append_to_pod` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:334:1: AIR302 `airflow.kubernetes.k8s_model.append_to_pod` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-339 | _disable_verify_ssl()
-340 | _enable_tcp_keepalive()
-341 | append_to_pod()
+332 | _disable_verify_ssl()
+333 | _enable_tcp_keepalive()
+334 | append_to_pod()
     | ^^^^^^^^^^^^^ AIR302
-342 | annotations_for_logging_task_metadata()
-343 | annotations_to_key()
+335 | annotations_for_logging_task_metadata()
+336 | annotations_to_key()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.k8s_model.append_to_pod` instead.
 
-AIR302.py:342:1: AIR302 `airflow.kubernetes.kubernetes_helper_functions.annotations_for_logging_task_metadata` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:335:1: AIR302 `airflow.kubernetes.kubernetes_helper_functions.annotations_for_logging_task_metadata` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-340 | _enable_tcp_keepalive()
-341 | append_to_pod()
-342 | annotations_for_logging_task_metadata()
+333 | _enable_tcp_keepalive()
+334 | append_to_pod()
+335 | annotations_for_logging_task_metadata()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-343 | annotations_to_key()
-344 | create_pod_id()
+336 | annotations_to_key()
+337 | create_pod_id()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.kubernetes_helper_functions.annotations_for_logging_task_metadata` instead.
 
-AIR302.py:343:1: AIR302 `airflow.kubernetes.kubernetes_helper_functions.annotations_to_key` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:336:1: AIR302 `airflow.kubernetes.kubernetes_helper_functions.annotations_to_key` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-341 | append_to_pod()
-342 | annotations_for_logging_task_metadata()
-343 | annotations_to_key()
+334 | append_to_pod()
+335 | annotations_for_logging_task_metadata()
+336 | annotations_to_key()
     | ^^^^^^^^^^^^^^^^^^ AIR302
-344 | create_pod_id()
-345 | datetime_to_label_safe_datestring()
+337 | create_pod_id()
+338 | datetime_to_label_safe_datestring()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.kubernetes_helper_functions.annotations_to_key` instead.
 
-AIR302.py:344:1: AIR302 `airflow.kubernetes.kubernetes_helper_functions.create_pod_id` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:337:1: AIR302 `airflow.kubernetes.kubernetes_helper_functions.create_pod_id` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-342 | annotations_for_logging_task_metadata()
-343 | annotations_to_key()
-344 | create_pod_id()
+335 | annotations_for_logging_task_metadata()
+336 | annotations_to_key()
+337 | create_pod_id()
     | ^^^^^^^^^^^^^ AIR302
-345 | datetime_to_label_safe_datestring()
-346 | extend_object_field()
+338 | datetime_to_label_safe_datestring()
+339 | extend_object_field()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.kubernetes_helper_functions.create_pod_id` instead.
 
-AIR302.py:345:1: AIR302 `airflow.kubernetes.pod_generator.datetime_to_label_safe_datestring` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:338:1: AIR302 `airflow.kubernetes.pod_generator.datetime_to_label_safe_datestring` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-343 | annotations_to_key()
-344 | create_pod_id()
-345 | datetime_to_label_safe_datestring()
+336 | annotations_to_key()
+337 | create_pod_id()
+338 | datetime_to_label_safe_datestring()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-346 | extend_object_field()
-347 | get_logs_task_metadata()
+339 | extend_object_field()
+340 | get_logs_task_metadata()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_generator.datetime_to_label_safe_datestring` instead.
 
-AIR302.py:346:1: AIR302 `airflow.kubernetes.pod_generator.extend_object_field` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:339:1: AIR302 `airflow.kubernetes.pod_generator.extend_object_field` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-344 | create_pod_id()
-345 | datetime_to_label_safe_datestring()
-346 | extend_object_field()
+337 | create_pod_id()
+338 | datetime_to_label_safe_datestring()
+339 | extend_object_field()
     | ^^^^^^^^^^^^^^^^^^^ AIR302
-347 | get_logs_task_metadata()
-348 | label_safe_datestring_to_datetime()
+340 | get_logs_task_metadata()
+341 | label_safe_datestring_to_datetime()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.kubernetes.airflow.providers.cncf.kubernetes.pod_generator.extend_object_field` instead.
 
-AIR302.py:347:1: AIR302 `airflow.kubernetes.kubernetes_helper_functions.get_logs_task_metadata` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:340:1: AIR302 `airflow.kubernetes.kubernetes_helper_functions.get_logs_task_metadata` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-345 | datetime_to_label_safe_datestring()
-346 | extend_object_field()
-347 | get_logs_task_metadata()
+338 | datetime_to_label_safe_datestring()
+339 | extend_object_field()
+340 | get_logs_task_metadata()
     | ^^^^^^^^^^^^^^^^^^^^^^ AIR302
-348 | label_safe_datestring_to_datetime()
-349 | merge_objects()
+341 | label_safe_datestring_to_datetime()
+342 | merge_objects()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.kubernetes_helper_functions.get_logs_task_metadata` instead.
 
-AIR302.py:348:1: AIR302 `airflow.kubernetes.pod_generator.label_safe_datestring_to_datetime` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:341:1: AIR302 `airflow.kubernetes.pod_generator.label_safe_datestring_to_datetime` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-346 | extend_object_field()
-347 | get_logs_task_metadata()
-348 | label_safe_datestring_to_datetime()
+339 | extend_object_field()
+340 | get_logs_task_metadata()
+341 | label_safe_datestring_to_datetime()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-349 | merge_objects()
-350 | Port()
+342 | merge_objects()
+343 | Port()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_generator.label_safe_datestring_to_datetime` instead.
 
-AIR302.py:349:1: AIR302 `airflow.kubernetes.pod_generator.merge_objects` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:342:1: AIR302 `airflow.kubernetes.pod_generator.merge_objects` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-347 | get_logs_task_metadata()
-348 | label_safe_datestring_to_datetime()
-349 | merge_objects()
+340 | get_logs_task_metadata()
+341 | label_safe_datestring_to_datetime()
+342 | merge_objects()
     | ^^^^^^^^^^^^^ AIR302
-350 | Port()
-351 | Resources()
+343 | Port()
+344 | Resources()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_generator.merge_objects` instead.
 
-AIR302.py:350:1: AIR302 `airflow.kubernetes.pod.Port` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:343:1: AIR302 `airflow.kubernetes.pod.Port` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-348 | label_safe_datestring_to_datetime()
-349 | merge_objects()
-350 | Port()
+341 | label_safe_datestring_to_datetime()
+342 | merge_objects()
+343 | Port()
     | ^^^^ AIR302
-351 | Resources()
-352 | PodRuntimeInfoEnv()
+344 | Resources()
+345 | PodRuntimeInfoEnv()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `kubernetes.client.models.V1ContainerPort` instead.
 
-AIR302.py:351:1: AIR302 `airflow.kubernetes.pod.Resources` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:344:1: AIR302 `airflow.kubernetes.pod.Resources` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-349 | merge_objects()
-350 | Port()
-351 | Resources()
+342 | merge_objects()
+343 | Port()
+344 | Resources()
     | ^^^^^^^^^ AIR302
-352 | PodRuntimeInfoEnv()
-353 | PodGeneratorDeprecated()
+345 | PodRuntimeInfoEnv()
+346 | PodGeneratorDeprecated()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `kubernetes.client.models.V1ResourceRequirements` instead.
 
-AIR302.py:352:1: AIR302 `airflow.kubernetes.pod_runtime_info_env.PodRuntimeInfoEnv` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:345:1: AIR302 `airflow.kubernetes.pod_runtime_info_env.PodRuntimeInfoEnv` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-350 | Port()
-351 | Resources()
-352 | PodRuntimeInfoEnv()
+343 | Port()
+344 | Resources()
+345 | PodRuntimeInfoEnv()
     | ^^^^^^^^^^^^^^^^^ AIR302
-353 | PodGeneratorDeprecated()
-354 | Volume()
+346 | PodGeneratorDeprecated()
+347 | Volume()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `kubernetes.client.models.V1EnvVar` instead.
 
-AIR302.py:353:1: AIR302 `airflow.kubernetes.pod_generator.PodGeneratorDeprecated` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:346:1: AIR302 `airflow.kubernetes.pod_generator.PodGeneratorDeprecated` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-351 | Resources()
-352 | PodRuntimeInfoEnv()
-353 | PodGeneratorDeprecated()
+344 | Resources()
+345 | PodRuntimeInfoEnv()
+346 | PodGeneratorDeprecated()
     | ^^^^^^^^^^^^^^^^^^^^^^ AIR302
-354 | Volume()
-355 | VolumeMount()
+347 | Volume()
+348 | VolumeMount()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_generator.PodGenerator` instead.
 
-AIR302.py:354:1: AIR302 `airflow.kubernetes.volume.Volume` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:347:1: AIR302 `airflow.kubernetes.volume.Volume` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-352 | PodRuntimeInfoEnv()
-353 | PodGeneratorDeprecated()
-354 | Volume()
+345 | PodRuntimeInfoEnv()
+346 | PodGeneratorDeprecated()
+347 | Volume()
     | ^^^^^^ AIR302
-355 | VolumeMount()
-356 | Secret()
+348 | VolumeMount()
+349 | Secret()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `kubernetes.client.models.V1Volume` instead.
 
-AIR302.py:355:1: AIR302 `airflow.kubernetes.volume_mount.VolumeMount` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:348:1: AIR302 `airflow.kubernetes.volume_mount.VolumeMount` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-353 | PodGeneratorDeprecated()
-354 | Volume()
-355 | VolumeMount()
+346 | PodGeneratorDeprecated()
+347 | Volume()
+348 | VolumeMount()
     | ^^^^^^^^^^^ AIR302
-356 | Secret()
+349 | Secret()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `kubernetes.client.models.V1VolumeMount` instead.
 
-AIR302.py:356:1: AIR302 `airflow.kubernetes.secret.Secret` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:349:1: AIR302 `airflow.kubernetes.secret.Secret` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-354 | Volume()
-355 | VolumeMount()
-356 | Secret()
+347 | Volume()
+348 | VolumeMount()
+349 | Secret()
     | ^^^^^^ AIR302
-357 |
-358 | add_pod_suffix()
+350 |
+351 | add_pod_suffix()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.secret.Secret` instead.
 
-AIR302.py:358:1: AIR302 `airflow.kubernetes.kubernetes_helper_functions.add_pod_suffix` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:351:1: AIR302 `airflow.kubernetes.kubernetes_helper_functions.add_pod_suffix` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-356 | Secret()
-357 |
-358 | add_pod_suffix()
+349 | Secret()
+350 |
+351 | add_pod_suffix()
     | ^^^^^^^^^^^^^^ AIR302
-359 | add_pod_suffix2()
-360 | get_kube_client()
+352 | add_pod_suffix2()
+353 | get_kube_client()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.kubernetes_helper_functions.add_pod_suffix` instead.
 
-AIR302.py:359:1: AIR302 `airflow.kubernetes.pod_generator.add_pod_suffix` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:352:1: AIR302 `airflow.kubernetes.pod_generator.add_pod_suffix` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-358 | add_pod_suffix()
-359 | add_pod_suffix2()
+351 | add_pod_suffix()
+352 | add_pod_suffix2()
     | ^^^^^^^^^^^^^^^ AIR302
-360 | get_kube_client()
-361 | get_kube_client2()
+353 | get_kube_client()
+354 | get_kube_client2()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.kubernetes_helper_functions.add_pod_suffix` instead.
 
-AIR302.py:360:1: AIR302 `airflow.kubernetes.kube_client.get_kube_client` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:353:1: AIR302 `airflow.kubernetes.kube_client.get_kube_client` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-358 | add_pod_suffix()
-359 | add_pod_suffix2()
-360 | get_kube_client()
+351 | add_pod_suffix()
+352 | add_pod_suffix2()
+353 | get_kube_client()
     | ^^^^^^^^^^^^^^^ AIR302
-361 | get_kube_client2()
-362 | make_safe_label_value()
+354 | get_kube_client2()
+355 | make_safe_label_value()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.kubernetes.airflow.providers.cncf.kubernetes.kube_client.get_kube_client` instead.
 
-AIR302.py:361:1: AIR302 `airflow.kubernetes.pod_launcher_deprecated.get_kube_client` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:354:1: AIR302 `airflow.kubernetes.pod_launcher_deprecated.get_kube_client` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-359 | add_pod_suffix2()
-360 | get_kube_client()
-361 | get_kube_client2()
+352 | add_pod_suffix2()
+353 | get_kube_client()
+354 | get_kube_client2()
     | ^^^^^^^^^^^^^^^^ AIR302
-362 | make_safe_label_value()
-363 | make_safe_label_value2()
+355 | make_safe_label_value()
+356 | make_safe_label_value2()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.kube_client.get_kube_client` instead.
 
-AIR302.py:362:1: AIR302 `airflow.kubernetes.pod_generator.make_safe_label_value` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:355:1: AIR302 `airflow.kubernetes.pod_generator.make_safe_label_value` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-360 | get_kube_client()
-361 | get_kube_client2()
-362 | make_safe_label_value()
+353 | get_kube_client()
+354 | get_kube_client2()
+355 | make_safe_label_value()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-363 | make_safe_label_value2()
-364 | rand_str()
+356 | make_safe_label_value2()
+357 | rand_str()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_generator.make_safe_label_value` instead.
 
-AIR302.py:363:1: AIR302 `airflow.kubernetes.pod_generator_deprecated.make_safe_label_value` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:356:1: AIR302 `airflow.kubernetes.pod_generator_deprecated.make_safe_label_value` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-361 | get_kube_client2()
-362 | make_safe_label_value()
-363 | make_safe_label_value2()
+354 | get_kube_client2()
+355 | make_safe_label_value()
+356 | make_safe_label_value2()
     | ^^^^^^^^^^^^^^^^^^^^^^ AIR302
-364 | rand_str()
-365 | rand_str2()
+357 | rand_str()
+358 | rand_str2()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_generator_deprecated.make_safe_label_value` instead.
 
-AIR302.py:364:1: AIR302 `airflow.kubernetes.kubernetes_helper_functions.rand_str` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:357:1: AIR302 `airflow.kubernetes.kubernetes_helper_functions.rand_str` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-362 | make_safe_label_value()
-363 | make_safe_label_value2()
-364 | rand_str()
+355 | make_safe_label_value()
+356 | make_safe_label_value2()
+357 | rand_str()
     | ^^^^^^^^ AIR302
-365 | rand_str2()
-366 | K8SModel()
+358 | rand_str2()
+359 | K8SModel()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.kubernetes_helper_functions.rand_str` instead.
 
-AIR302.py:365:1: AIR302 `airflow.kubernetes.pod_generator.rand_str` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:358:1: AIR302 `airflow.kubernetes.pod_generator.rand_str` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-363 | make_safe_label_value2()
-364 | rand_str()
-365 | rand_str2()
+356 | make_safe_label_value2()
+357 | rand_str()
+358 | rand_str2()
     | ^^^^^^^^^ AIR302
-366 | K8SModel()
-367 | K8SModel2()
+359 | K8SModel()
+360 | K8SModel2()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.kubernetes_helper_functions.rand_str` instead.
 
-AIR302.py:366:1: AIR302 `airflow.kubernetes.k8s_model.K8SModel` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:359:1: AIR302 `airflow.kubernetes.k8s_model.K8SModel` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-364 | rand_str()
-365 | rand_str2()
-366 | K8SModel()
+357 | rand_str()
+358 | rand_str2()
+359 | K8SModel()
     | ^^^^^^^^ AIR302
-367 | K8SModel2()
-368 | PodLauncher()
+360 | K8SModel2()
+361 | PodLauncher()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.k8s_model.K8SModel` instead.
 
-AIR302.py:368:1: AIR302 `airflow.kubernetes.pod_launcher.PodLauncher` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:361:1: AIR302 `airflow.kubernetes.pod_launcher.PodLauncher` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-366 | K8SModel()
-367 | K8SModel2()
-368 | PodLauncher()
+359 | K8SModel()
+360 | K8SModel2()
+361 | PodLauncher()
     | ^^^^^^^^^^^ AIR302
-369 | PodLauncher2()
-370 | PodStatus()
+362 | PodLauncher2()
+363 | PodStatus()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_launcher.PodLauncher` instead.
 
-AIR302.py:369:1: AIR302 `airflow.kubernetes.pod_launcher_deprecated.PodLauncher` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:362:1: AIR302 `airflow.kubernetes.pod_launcher_deprecated.PodLauncher` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-367 | K8SModel2()
-368 | PodLauncher()
-369 | PodLauncher2()
+360 | K8SModel2()
+361 | PodLauncher()
+362 | PodLauncher2()
     | ^^^^^^^^^^^^ AIR302
-370 | PodStatus()
-371 | PodStatus2()
+363 | PodStatus()
+364 | PodStatus2()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_launcher_deprecated.PodLauncher` instead.
 
-AIR302.py:370:1: AIR302 `airflow.kubernetes.pod_launcher.PodStatus` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:363:1: AIR302 `airflow.kubernetes.pod_launcher.PodStatus` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-368 | PodLauncher()
-369 | PodLauncher2()
-370 | PodStatus()
+361 | PodLauncher()
+362 | PodLauncher2()
+363 | PodStatus()
     | ^^^^^^^^^ AIR302
-371 | PodStatus2()
-372 | PodDefaults()
+364 | PodStatus2()
+365 | PodDefaults()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_launcher.PodStatus` instead.
 
-AIR302.py:371:1: AIR302 `airflow.kubernetes.pod_launcher_deprecated.PodStatus` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:364:1: AIR302 `airflow.kubernetes.pod_launcher_deprecated.PodStatus` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-369 | PodLauncher2()
-370 | PodStatus()
-371 | PodStatus2()
+362 | PodLauncher2()
+363 | PodStatus()
+364 | PodStatus2()
     | ^^^^^^^^^^ AIR302
-372 | PodDefaults()
-373 | PodDefaults2()
+365 | PodDefaults()
+366 | PodDefaults2()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_launcher_deprecated.PodStatus` instead.
 
-AIR302.py:372:1: AIR302 `airflow.kubernetes.pod_generator.PodDefaults` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:365:1: AIR302 `airflow.kubernetes.pod_generator.PodDefaults` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-370 | PodStatus()
-371 | PodStatus2()
-372 | PodDefaults()
+363 | PodStatus()
+364 | PodStatus2()
+365 | PodDefaults()
     | ^^^^^^^^^^^ AIR302
-373 | PodDefaults2()
-374 | PodDefaults3()
+366 | PodDefaults2()
+367 | PodDefaults3()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_generator_deprecated.PodDefaults` instead.
 
-AIR302.py:373:1: AIR302 `airflow.kubernetes.pod_launcher_deprecated.PodDefaults` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:366:1: AIR302 `airflow.kubernetes.pod_launcher_deprecated.PodDefaults` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-371 | PodStatus2()
-372 | PodDefaults()
-373 | PodDefaults2()
+364 | PodStatus2()
+365 | PodDefaults()
+366 | PodDefaults2()
     | ^^^^^^^^^^^^ AIR302
-374 | PodDefaults3()
-375 | PodGenerator()
+367 | PodDefaults3()
+368 | PodGenerator()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_generator_deprecated.PodDefaults` instead.
 
-AIR302.py:374:1: AIR302 `airflow.kubernetes.pod_generator_deprecated.PodDefaults` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:367:1: AIR302 `airflow.kubernetes.pod_generator_deprecated.PodDefaults` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-372 | PodDefaults()
-373 | PodDefaults2()
-374 | PodDefaults3()
+365 | PodDefaults()
+366 | PodDefaults2()
+367 | PodDefaults3()
     | ^^^^^^^^^^^^ AIR302
-375 | PodGenerator()
-376 | PodGenerator2()
+368 | PodGenerator()
+369 | PodGenerator2()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_generator_deprecated.PodDefaults` instead.
 
-AIR302.py:375:1: AIR302 `airflow.kubernetes.pod_generator.PodGenerator` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:368:1: AIR302 `airflow.kubernetes.pod_generator.PodGenerator` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-373 | PodDefaults2()
-374 | PodDefaults3()
-375 | PodGenerator()
+366 | PodDefaults2()
+367 | PodDefaults3()
+368 | PodGenerator()
     | ^^^^^^^^^^^^ AIR302
-376 | PodGenerator2()
+369 | PodGenerator2()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_generator.PodGenerator` instead.
 
-AIR302.py:376:1: AIR302 `airflow.kubernetes.pod_generator_deprecated.PodGenerator` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:369:1: AIR302 `airflow.kubernetes.pod_generator_deprecated.PodGenerator` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-374 | PodDefaults3()
-375 | PodGenerator()
-376 | PodGenerator2()
+367 | PodDefaults3()
+368 | PodGenerator()
+369 | PodGenerator2()
     | ^^^^^^^^^^^^^ AIR302
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_generator_deprecated.PodGenerator` instead.
 
-AIR302.py:380:1: AIR302 `airflow.hooks.mssql_hook.MsSqlHook` is moved into `microsoft-mssql` provider in Airflow 3.0;
+AIR302.py:373:1: AIR302 `airflow.hooks.mssql_hook.MsSqlHook` is moved into `microsoft-mssql` provider in Airflow 3.0;
     |
-379 | # apache-airflow-providers-microsoft-mssql
-380 | MsSqlHook()
+372 | # apache-airflow-providers-microsoft-mssql
+373 | MsSqlHook()
     | ^^^^^^^^^ AIR302
-381 | MsSqlOperator()
-382 | MsSqlToHiveOperator()
+374 | MsSqlOperator()
+375 | MsSqlToHiveOperator()
     |
     = help: Install `apache-airflow-provider-microsoft-mssql>=1.0.0` and use `airflow.providers.microsoft.mssql.hooks.mssql.MsSqlHook` instead.
 
-AIR302.py:381:1: AIR302 `airflow.operators.mssql_operator.MsSqlOperator` is moved into `microsoft-mssql` provider in Airflow 3.0;
+AIR302.py:374:1: AIR302 `airflow.operators.mssql_operator.MsSqlOperator` is moved into `microsoft-mssql` provider in Airflow 3.0;
     |
-379 | # apache-airflow-providers-microsoft-mssql
-380 | MsSqlHook()
-381 | MsSqlOperator()
+372 | # apache-airflow-providers-microsoft-mssql
+373 | MsSqlHook()
+374 | MsSqlOperator()
     | ^^^^^^^^^^^^^ AIR302
-382 | MsSqlToHiveOperator()
-383 | MsSqlToHiveTransfer()
+375 | MsSqlToHiveOperator()
+376 | MsSqlToHiveTransfer()
     |
     = help: Install `apache-airflow-provider-microsoft-mssql>=1.0.0` and use `airflow.providers.microsoft.mssql.operators.mssql.MsSqlOperator` instead.
 
-AIR302.py:382:1: AIR302 `airflow.operators.mssql_to_hive.MsSqlToHiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
+AIR302.py:375:1: AIR302 `airflow.operators.mssql_to_hive.MsSqlToHiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
     |
-380 | MsSqlHook()
-381 | MsSqlOperator()
-382 | MsSqlToHiveOperator()
+373 | MsSqlHook()
+374 | MsSqlOperator()
+375 | MsSqlToHiveOperator()
     | ^^^^^^^^^^^^^^^^^^^ AIR302
-383 | MsSqlToHiveTransfer()
+376 | MsSqlToHiveTransfer()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.transfers.mssql_to_hive.MsSqlToHiveOperator` instead.
 
-AIR302.py:383:1: AIR302 `airflow.operators.mssql_to_hive.MsSqlToHiveTransfer` is moved into `apache-hive` provider in Airflow 3.0;
+AIR302.py:376:1: AIR302 `airflow.operators.mssql_to_hive.MsSqlToHiveTransfer` is moved into `apache-hive` provider in Airflow 3.0;
     |
-381 | MsSqlOperator()
-382 | MsSqlToHiveOperator()
-383 | MsSqlToHiveTransfer()
+374 | MsSqlOperator()
+375 | MsSqlToHiveOperator()
+376 | MsSqlToHiveTransfer()
     | ^^^^^^^^^^^^^^^^^^^ AIR302
-384 |
-385 | # apache-airflow-providers-mysql
+377 |
+378 | # apache-airflow-providers-mysql
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.transfers.mssql_to_hive.MsSqlToHiveOperator` instead.
 
-AIR302.py:386:1: AIR302 `airflow.operators.hive_to_mysql.HiveToMySqlOperator` is moved into `apache-hive` provider in Airflow 3.0;
+AIR302.py:379:1: AIR302 `airflow.operators.hive_to_mysql.HiveToMySqlOperator` is moved into `apache-hive` provider in Airflow 3.0;
     |
-385 | # apache-airflow-providers-mysql
-386 | HiveToMySqlOperator()
+378 | # apache-airflow-providers-mysql
+379 | HiveToMySqlOperator()
     | ^^^^^^^^^^^^^^^^^^^ AIR302
-387 | HiveToMySqlTransfer()
-388 | MySqlHook()
+380 | HiveToMySqlTransfer()
+381 | MySqlHook()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.transfers.hive_to_mysql.HiveToMySqlOperator` instead.
 
-AIR302.py:387:1: AIR302 `airflow.operators.hive_to_mysql.HiveToMySqlTransfer` is moved into `apache-hive` provider in Airflow 3.0;
+AIR302.py:380:1: AIR302 `airflow.operators.hive_to_mysql.HiveToMySqlTransfer` is moved into `apache-hive` provider in Airflow 3.0;
     |
-385 | # apache-airflow-providers-mysql
-386 | HiveToMySqlOperator()
-387 | HiveToMySqlTransfer()
+378 | # apache-airflow-providers-mysql
+379 | HiveToMySqlOperator()
+380 | HiveToMySqlTransfer()
     | ^^^^^^^^^^^^^^^^^^^ AIR302
-388 | MySqlHook()
-389 | MySqlOperator()
+381 | MySqlHook()
+382 | MySqlOperator()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.transfers.hive_to_mysql.HiveToMySqlOperator` instead.
 
-AIR302.py:388:1: AIR302 `airflow.hooks.mysql_hook.MySqlHook` is moved into `mysql` provider in Airflow 3.0;
+AIR302.py:381:1: AIR302 `airflow.hooks.mysql_hook.MySqlHook` is moved into `mysql` provider in Airflow 3.0;
     |
-386 | HiveToMySqlOperator()
-387 | HiveToMySqlTransfer()
-388 | MySqlHook()
+379 | HiveToMySqlOperator()
+380 | HiveToMySqlTransfer()
+381 | MySqlHook()
     | ^^^^^^^^^ AIR302
-389 | MySqlOperator()
-390 | MySqlToHiveOperator()
+382 | MySqlOperator()
+383 | MySqlToHiveOperator()
     |
     = help: Install `apache-airflow-provider-mysql>=1.0.0` and use `airflow.providers.mysql.hooks.mysql.MySqlHook` instead.
 
-AIR302.py:389:1: AIR302 `airflow.operators.mysql_operator.MySqlOperator` is moved into `mysql` provider in Airflow 3.0;
+AIR302.py:382:1: AIR302 `airflow.operators.mysql_operator.MySqlOperator` is moved into `mysql` provider in Airflow 3.0;
     |
-387 | HiveToMySqlTransfer()
-388 | MySqlHook()
-389 | MySqlOperator()
+380 | HiveToMySqlTransfer()
+381 | MySqlHook()
+382 | MySqlOperator()
     | ^^^^^^^^^^^^^ AIR302
-390 | MySqlToHiveOperator()
-391 | MySqlToHiveTransfer()
+383 | MySqlToHiveOperator()
+384 | MySqlToHiveTransfer()
     |
     = help: Install `apache-airflow-provider-mysql>=1.0.0` and use `airflow.providers.mysql.operators.mysql.MySqlOperator` instead.
 
-AIR302.py:390:1: AIR302 `airflow.operators.mysql_to_hive.MySqlToHiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
+AIR302.py:383:1: AIR302 `airflow.operators.mysql_to_hive.MySqlToHiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
     |
-388 | MySqlHook()
-389 | MySqlOperator()
-390 | MySqlToHiveOperator()
+381 | MySqlHook()
+382 | MySqlOperator()
+383 | MySqlToHiveOperator()
     | ^^^^^^^^^^^^^^^^^^^ AIR302
-391 | MySqlToHiveTransfer()
-392 | PrestoToMySqlOperator()
+384 | MySqlToHiveTransfer()
+385 | PrestoToMySqlOperator()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.transfers.mysql_to_hive.MySqlToHiveOperator` instead.
 
-AIR302.py:391:1: AIR302 `airflow.operators.mysql_to_hive.MySqlToHiveTransfer` is moved into `apache-hive` provider in Airflow 3.0;
+AIR302.py:384:1: AIR302 `airflow.operators.mysql_to_hive.MySqlToHiveTransfer` is moved into `apache-hive` provider in Airflow 3.0;
     |
-389 | MySqlOperator()
-390 | MySqlToHiveOperator()
-391 | MySqlToHiveTransfer()
+382 | MySqlOperator()
+383 | MySqlToHiveOperator()
+384 | MySqlToHiveTransfer()
     | ^^^^^^^^^^^^^^^^^^^ AIR302
-392 | PrestoToMySqlOperator()
-393 | PrestoToMySqlTransfer()
+385 | PrestoToMySqlOperator()
+386 | PrestoToMySqlTransfer()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.transfers.mysql_to_hive.MySqlToHiveOperator` instead.
 
-AIR302.py:392:1: AIR302 `airflow.operators.presto_to_mysql.PrestoToMySqlOperator` is moved into `mysql` provider in Airflow 3.0;
+AIR302.py:385:1: AIR302 `airflow.operators.presto_to_mysql.PrestoToMySqlOperator` is moved into `mysql` provider in Airflow 3.0;
     |
-390 | MySqlToHiveOperator()
-391 | MySqlToHiveTransfer()
-392 | PrestoToMySqlOperator()
+383 | MySqlToHiveOperator()
+384 | MySqlToHiveTransfer()
+385 | PrestoToMySqlOperator()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-393 | PrestoToMySqlTransfer()
+386 | PrestoToMySqlTransfer()
     |
     = help: Install `apache-airflow-provider-mysql>=1.0.0` and use `airflow.providers.mysql.transfers.presto_to_mysql.PrestoToMySqlOperator` instead.
 
-AIR302.py:393:1: AIR302 `airflow.operators.presto_to_mysql.PrestoToMySqlTransfer` is moved into `mysql` provider in Airflow 3.0;
+AIR302.py:386:1: AIR302 `airflow.operators.presto_to_mysql.PrestoToMySqlTransfer` is moved into `mysql` provider in Airflow 3.0;
     |
-391 | MySqlToHiveTransfer()
-392 | PrestoToMySqlOperator()
-393 | PrestoToMySqlTransfer()
+384 | MySqlToHiveTransfer()
+385 | PrestoToMySqlOperator()
+386 | PrestoToMySqlTransfer()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-394 |
-395 | # apache-airflow-providers-oracle
+387 |
+388 | # apache-airflow-providers-oracle
     |
     = help: Install `apache-airflow-provider-mysql>=1.0.0` and use `airflow.providers.mysql.transfers.presto_to_mysql.PrestoToMySqlOperator` instead.
 
-AIR302.py:396:1: AIR302 `airflow.hooks.oracle_hook.OracleHook` is moved into `oracle` provider in Airflow 3.0;
+AIR302.py:389:1: AIR302 `airflow.hooks.oracle_hook.OracleHook` is moved into `oracle` provider in Airflow 3.0;
     |
-395 | # apache-airflow-providers-oracle
-396 | OracleHook()
+388 | # apache-airflow-providers-oracle
+389 | OracleHook()
     | ^^^^^^^^^^ AIR302
-397 | OracleOperator()
+390 | OracleOperator()
     |
     = help: Install `apache-airflow-provider-oracle>=1.0.0` and use `airflow.providers.oracle.hooks.oracle.OracleHook` instead.
 
-AIR302.py:397:1: AIR302 `airflow.operators.oracle_operator.OracleOperator` is moved into `oracle` provider in Airflow 3.0;
+AIR302.py:390:1: AIR302 `airflow.operators.oracle_operator.OracleOperator` is moved into `oracle` provider in Airflow 3.0;
     |
-395 | # apache-airflow-providers-oracle
-396 | OracleHook()
-397 | OracleOperator()
+388 | # apache-airflow-providers-oracle
+389 | OracleHook()
+390 | OracleOperator()
     | ^^^^^^^^^^^^^^ AIR302
-398 |
-399 | # apache-airflow-providers-papermill
+391 |
+392 | # apache-airflow-providers-papermill
     |
     = help: Install `apache-airflow-provider-oracle>=1.0.0` and use `airflow.providers.oracle.operators.oracle.OracleOperator` instead.
 
-AIR302.py:400:1: AIR302 `airflow.operators.papermill_operator.PapermillOperator` is moved into `papermill` provider in Airflow 3.0;
+AIR302.py:393:1: AIR302 `airflow.operators.papermill_operator.PapermillOperator` is moved into `papermill` provider in Airflow 3.0;
     |
-399 | # apache-airflow-providers-papermill
-400 | PapermillOperator()
+392 | # apache-airflow-providers-papermill
+393 | PapermillOperator()
     | ^^^^^^^^^^^^^^^^^ AIR302
-401 |
-402 | # apache-airflow-providers-apache-pig
+394 |
+395 | # apache-airflow-providers-apache-pig
     |
     = help: Install `apache-airflow-provider-papermill>=1.0.0` and use `airflow.providers.papermill.operators.papermill.PapermillOperator` instead.
 
-AIR302.py:403:1: AIR302 `airflow.hooks.pig_hook.PigCliHook` is moved into `apache-pig` provider in Airflow 3.0;
+AIR302.py:396:1: AIR302 `airflow.hooks.pig_hook.PigCliHook` is moved into `apache-pig` provider in Airflow 3.0;
     |
-402 | # apache-airflow-providers-apache-pig
-403 | PigCliHook()
+395 | # apache-airflow-providers-apache-pig
+396 | PigCliHook()
     | ^^^^^^^^^^ AIR302
-404 | PigOperator()
+397 | PigOperator()
     |
     = help: Install `apache-airflow-provider-apache-pig>=1.0.0` and use `airflow.providers.apache.pig.hooks.pig.PigCliHook` instead.
 
-AIR302.py:404:1: AIR302 `airflow.operators.pig_operator.PigOperator` is moved into `apache-pig` provider in Airflow 3.0;
+AIR302.py:397:1: AIR302 `airflow.operators.pig_operator.PigOperator` is moved into `apache-pig` provider in Airflow 3.0;
     |
-402 | # apache-airflow-providers-apache-pig
-403 | PigCliHook()
-404 | PigOperator()
+395 | # apache-airflow-providers-apache-pig
+396 | PigCliHook()
+397 | PigOperator()
     | ^^^^^^^^^^^ AIR302
-405 |
-406 | # apache-airflow-providers-postgres
+398 |
+399 | # apache-airflow-providers-postgres
     |
     = help: Install `apache-airflow-provider-apache-pig>=1.0.0` and use `airflow.providers.apache.pig.operators.pig.PigOperator` instead.
 
-AIR302.py:407:1: AIR302 `airflow.operators.postgres_operator.Mapping` is moved into `postgres` provider in Airflow 3.0;
+AIR302.py:400:1: AIR302 `airflow.operators.postgres_operator.Mapping` is moved into `postgres` provider in Airflow 3.0;
     |
-406 | # apache-airflow-providers-postgres
-407 | Mapping
+399 | # apache-airflow-providers-postgres
+400 | Mapping
     | ^^^^^^^ AIR302
-408 | PostgresHook()
-409 | PostgresOperator()
+401 | PostgresHook()
+402 | PostgresOperator()
     |
     = help: Install `apache-airflow-provider-postgres>=1.0.0` and use `airflow.providers.postgres.operators.postgres.Mapping` instead.
 
-AIR302.py:408:1: AIR302 `airflow.hooks.postgres_hook.PostgresHook` is moved into `postgres` provider in Airflow 3.0;
+AIR302.py:401:1: AIR302 `airflow.hooks.postgres_hook.PostgresHook` is moved into `postgres` provider in Airflow 3.0;
     |
-406 | # apache-airflow-providers-postgres
-407 | Mapping
-408 | PostgresHook()
+399 | # apache-airflow-providers-postgres
+400 | Mapping
+401 | PostgresHook()
     | ^^^^^^^^^^^^ AIR302
-409 | PostgresOperator()
+402 | PostgresOperator()
     |
     = help: Install `apache-airflow-provider-postgres>=1.0.0` and use `airflow.providers.postgres.hooks.postgres.PostgresHook` instead.
 
-AIR302.py:409:1: AIR302 `airflow.operators.postgres_operator.PostgresOperator` is moved into `postgres` provider in Airflow 3.0;
+AIR302.py:402:1: AIR302 `airflow.operators.postgres_operator.PostgresOperator` is moved into `postgres` provider in Airflow 3.0;
     |
-407 | Mapping
-408 | PostgresHook()
-409 | PostgresOperator()
+400 | Mapping
+401 | PostgresHook()
+402 | PostgresOperator()
     | ^^^^^^^^^^^^^^^^ AIR302
-410 |
-411 | # apache-airflow-providers-presto
+403 |
+404 | # apache-airflow-providers-presto
     |
     = help: Install `apache-airflow-provider-postgres>=1.0.0` and use `airflow.providers.postgres.operators.postgres.PostgresOperator` instead.
 
-AIR302.py:412:1: AIR302 `airflow.hooks.presto_hook.PrestoHook` is moved into `presto` provider in Airflow 3.0;
+AIR302.py:405:1: AIR302 `airflow.hooks.presto_hook.PrestoHook` is moved into `presto` provider in Airflow 3.0;
     |
-411 | # apache-airflow-providers-presto
-412 | PrestoHook()
+404 | # apache-airflow-providers-presto
+405 | PrestoHook()
     | ^^^^^^^^^^ AIR302
-413 |
-414 | # apache-airflow-providers-samba
+406 |
+407 | # apache-airflow-providers-samba
     |
     = help: Install `apache-airflow-provider-presto>=1.0.0` and use `airflow.providers.presto.hooks.presto.PrestoHook` instead.
 
-AIR302.py:415:1: AIR302 `airflow.hooks.samba_hook.SambaHook` is moved into `samba` provider in Airflow 3.0;
+AIR302.py:408:1: AIR302 `airflow.hooks.samba_hook.SambaHook` is moved into `samba` provider in Airflow 3.0;
     |
-414 | # apache-airflow-providers-samba
-415 | SambaHook()
+407 | # apache-airflow-providers-samba
+408 | SambaHook()
     | ^^^^^^^^^ AIR302
-416 |
-417 | # apache-airflow-providers-slack
+409 |
+410 | # apache-airflow-providers-slack
     |
     = help: Install `apache-airflow-provider-samba>=1.0.0` and use `airflow.providers.samba.hooks.samba.SambaHook` instead.
 
-AIR302.py:418:1: AIR302 `airflow.hooks.slack_hook.SlackHook` is moved into `slack` provider in Airflow 3.0;
+AIR302.py:411:1: AIR302 `airflow.hooks.slack_hook.SlackHook` is moved into `slack` provider in Airflow 3.0;
     |
-417 | # apache-airflow-providers-slack
-418 | SlackHook()
+410 | # apache-airflow-providers-slack
+411 | SlackHook()
     | ^^^^^^^^^ AIR302
-419 | SlackAPIOperator()
-420 | SlackAPIPostOperator()
+412 | SlackAPIOperator()
+413 | SlackAPIPostOperator()
     |
     = help: Install `apache-airflow-provider-slack>=1.0.0` and use `airflow.providers.slack.hooks.slack.SlackHook` instead.
 
-AIR302.py:419:1: AIR302 `airflow.operators.slack_operator.SlackAPIOperator` is moved into `slack` provider in Airflow 3.0;
+AIR302.py:412:1: AIR302 `airflow.operators.slack_operator.SlackAPIOperator` is moved into `slack` provider in Airflow 3.0;
     |
-417 | # apache-airflow-providers-slack
-418 | SlackHook()
-419 | SlackAPIOperator()
+410 | # apache-airflow-providers-slack
+411 | SlackHook()
+412 | SlackAPIOperator()
     | ^^^^^^^^^^^^^^^^ AIR302
-420 | SlackAPIPostOperator()
+413 | SlackAPIPostOperator()
     |
     = help: Install `apache-airflow-provider-slack>=1.0.0` and use `airflow.providers.slack.operators.slack.SlackAPIOperator` instead.
 
-AIR302.py:420:1: AIR302 `airflow.operators.slack_operator.SlackAPIPostOperator` is moved into `slack` provider in Airflow 3.0;
+AIR302.py:413:1: AIR302 `airflow.operators.slack_operator.SlackAPIPostOperator` is moved into `slack` provider in Airflow 3.0;
     |
-418 | SlackHook()
-419 | SlackAPIOperator()
-420 | SlackAPIPostOperator()
+411 | SlackHook()
+412 | SlackAPIOperator()
+413 | SlackAPIPostOperator()
     | ^^^^^^^^^^^^^^^^^^^^ AIR302
-421 |
-422 | # apache-airflow-providers-sqlite
+414 |
+415 | # apache-airflow-providers-sqlite
     |
     = help: Install `apache-airflow-provider-slack>=1.0.0` and use `airflow.providers.slack.operators.slack.SlackAPIPostOperator` instead.
 
-AIR302.py:423:1: AIR302 `airflow.hooks.sqlite_hook.SqliteHook` is moved into `sqlite` provider in Airflow 3.0;
+AIR302.py:416:1: AIR302 `airflow.hooks.sqlite_hook.SqliteHook` is moved into `sqlite` provider in Airflow 3.0;
     |
-422 | # apache-airflow-providers-sqlite
-423 | SqliteHook()
+415 | # apache-airflow-providers-sqlite
+416 | SqliteHook()
     | ^^^^^^^^^^ AIR302
-424 | SqliteOperator()
+417 | SqliteOperator()
     |
     = help: Install `apache-airflow-provider-sqlite>=1.0.0` and use `airflow.providers.sqlite.hooks.sqlite.SqliteHook` instead.
 
-AIR302.py:424:1: AIR302 `airflow.operators.sqlite_operator.SqliteOperator` is moved into `sqlite` provider in Airflow 3.0;
+AIR302.py:417:1: AIR302 `airflow.operators.sqlite_operator.SqliteOperator` is moved into `sqlite` provider in Airflow 3.0;
     |
-422 | # apache-airflow-providers-sqlite
-423 | SqliteHook()
-424 | SqliteOperator()
+415 | # apache-airflow-providers-sqlite
+416 | SqliteHook()
+417 | SqliteOperator()
     | ^^^^^^^^^^^^^^ AIR302
-425 |
-426 | # apache-airflow-providers-zendesk
+418 |
+419 | # apache-airflow-providers-zendesk
     |
     = help: Install `apache-airflow-provider-sqlite>=1.0.0` and use `airflow.providers.sqlite.operators.sqlite.SqliteOperator` instead.
 
-AIR302.py:427:1: AIR302 `airflow.hooks.zendesk_hook.ZendeskHook` is moved into `zendesk` provider in Airflow 3.0;
+AIR302.py:420:1: AIR302 `airflow.hooks.zendesk_hook.ZendeskHook` is moved into `zendesk` provider in Airflow 3.0;
     |
-426 | # apache-airflow-providers-zendesk
-427 | ZendeskHook()
+419 | # apache-airflow-providers-zendesk
+420 | ZendeskHook()
     | ^^^^^^^^^^^ AIR302
-428 |
-429 | # apache-airflow-providers-smtp
+421 |
+422 | # apache-airflow-providers-smtp
     |
     = help: Install `apache-airflow-provider-zendesk>=1.0.0` and use `airflow.providers.zendesk.hooks.zendesk.ZendeskHook` instead.
 
-AIR302.py:430:1: AIR302 `airflow.operators.email_operator.EmailOperator` is moved into `smtp` provider in Airflow 3.0;
+AIR302.py:423:1: AIR302 `airflow.operators.email_operator.EmailOperator` is moved into `smtp` provider in Airflow 3.0;
     |
-429 | # apache-airflow-providers-smtp
-430 | EmailOperator()
+422 | # apache-airflow-providers-smtp
+423 | EmailOperator()
     | ^^^^^^^^^^^^^ AIR302
-431 |
-432 | # apache-airflow-providers-standard
+424 |
+425 | # apache-airflow-providers-standard
     |
     = help: Install `apache-airflow-provider-smtp>=1.0.0` and use `airflow.providers.smtp.operators.smtp.EmailOperator` instead.
 
-AIR302.py:433:1: AIR302 Import path `airflow.operators.datetime` is moved into `standard` provider in Airflow 3.0;
+AIR302.py:426:1: AIR302 Import path `airflow.operators.datetime` is moved into `standard` provider in Airflow 3.0;
     |
-432 | # apache-airflow-providers-standard
-433 | BranchDateTimeOperator()
+425 | # apache-airflow-providers-standard
+426 | BranchDateTimeOperator()
     | ^^^^^^^^^^^^^^^^^^^^^^ AIR302
-434 | BranchDayOfWeekOperator()
-435 | BranchPythonOperator()
+427 | BranchDayOfWeekOperator()
+428 | BranchPythonOperator()
     |
     = help: Install `apache-airflow-provider-standard>=0.0.1` and import from `airflow.providers.standard.time.operators.datetime` instead.
 
-AIR302.py:434:1: AIR302 Import path `airflow.operators.weekday` is moved into `standard` provider in Airflow 3.0;
+AIR302.py:427:1: AIR302 Import path `airflow.operators.weekday` is moved into `standard` provider in Airflow 3.0;
     |
-432 | # apache-airflow-providers-standard
-433 | BranchDateTimeOperator()
-434 | BranchDayOfWeekOperator()
+425 | # apache-airflow-providers-standard
+426 | BranchDateTimeOperator()
+427 | BranchDayOfWeekOperator()
     | ^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-435 | BranchPythonOperator()
-436 | DateTimeSensor()
+428 | BranchPythonOperator()
+429 | DateTimeSensor()
     |
     = help: Install `apache-airflow-provider-standard>=0.0.1` and import from `airflow.providers.standard.time.operators.weekday` instead.
 
-AIR302.py:435:1: AIR302 `airflow.operators.python.BranchPythonOperator` is moved into `standard` provider in Airflow 3.0;
+AIR302.py:428:1: AIR302 `airflow.operators.python.BranchPythonOperator` is moved into `standard` provider in Airflow 3.0;
     |
-433 | BranchDateTimeOperator()
-434 | BranchDayOfWeekOperator()
-435 | BranchPythonOperator()
+426 | BranchDateTimeOperator()
+427 | BranchDayOfWeekOperator()
+428 | BranchPythonOperator()
     | ^^^^^^^^^^^^^^^^^^^^ AIR302
-436 | DateTimeSensor()
-437 | DateTimeTrigger()
+429 | DateTimeSensor()
+430 | DateTimeTrigger()
     |
     = help: Install `apache-airflow-provider-standard>=0.0.1` and use `airflow.providers.standard.operators.python.BranchPythonOperator` instead.
 
-AIR302.py:437:1: AIR302 Import path `airflow.triggers.temporal` is moved into `standard` provider in Airflow 3.0;
+AIR302.py:430:1: AIR302 Import path `airflow.triggers.temporal` is moved into `standard` provider in Airflow 3.0;
     |
-435 | BranchPythonOperator()
-436 | DateTimeSensor()
-437 | DateTimeTrigger()
+428 | BranchPythonOperator()
+429 | DateTimeSensor()
+430 | DateTimeTrigger()
     | ^^^^^^^^^^^^^^^ AIR302
-438 | DayOfWeekSensor()
-439 | DummyOperator()
+431 | DayOfWeekSensor()
+432 | DummyOperator()
     |
     = help: Install `apache-airflow-provider-standard>=0.0.3` and import from `airflow.providers.standard.triggers.temporal` instead.
 
-AIR302.py:438:1: AIR302 Import path `airflow.sensors.weekday` is moved into `standard` provider in Airflow 3.0;
+AIR302.py:431:1: AIR302 Import path `airflow.sensors.weekday` is moved into `standard` provider in Airflow 3.0;
     |
-436 | DateTimeSensor()
-437 | DateTimeTrigger()
-438 | DayOfWeekSensor()
+429 | DateTimeSensor()
+430 | DateTimeTrigger()
+431 | DayOfWeekSensor()
     | ^^^^^^^^^^^^^^^ AIR302
-439 | DummyOperator()
-440 | EmptyOperator()
+432 | DummyOperator()
+433 | EmptyOperator()
     |
     = help: Install `apache-airflow-provider-standard>=0.0.1` and import from `airflow.providers.standard.time.sensors.weekday` instead.
 
-AIR302.py:439:1: AIR302 `airflow.operators.dummy.DummyOperator` is moved into `standard` provider in Airflow 3.0;
+AIR302.py:432:1: AIR302 `airflow.operators.dummy.DummyOperator` is moved into `standard` provider in Airflow 3.0;
     |
-437 | DateTimeTrigger()
-438 | DayOfWeekSensor()
-439 | DummyOperator()
+430 | DateTimeTrigger()
+431 | DayOfWeekSensor()
+432 | DummyOperator()
     | ^^^^^^^^^^^^^ AIR302
-440 | EmptyOperator()
-441 | ExternalTaskMarker()
+433 | EmptyOperator()
+434 | ExternalTaskMarker()
     |
     = help: Install `apache-airflow-provider-standard>=0.0.2` and use `airflow.providers.standard.operators.empty.EmptyOperator` instead.
 
-AIR302.py:440:1: AIR302 `airflow.operators.dummy.EmptyOperator` is moved into `standard` provider in Airflow 3.0;
+AIR302.py:433:1: AIR302 `airflow.operators.dummy.EmptyOperator` is moved into `standard` provider in Airflow 3.0;
     |
-438 | DayOfWeekSensor()
-439 | DummyOperator()
-440 | EmptyOperator()
+431 | DayOfWeekSensor()
+432 | DummyOperator()
+433 | EmptyOperator()
     | ^^^^^^^^^^^^^ AIR302
-441 | ExternalTaskMarker()
-442 | ExternalTaskSensor()
+434 | ExternalTaskMarker()
+435 | ExternalTaskSensor()
     |
     = help: Install `apache-airflow-provider-standard>=0.0.2` and use `airflow.providers.standard.operators.empty.EmptyOperator` instead.
 
-AIR302.py:441:1: AIR302 `airflow.sensors.external_task.ExternalTaskMarker` is moved into `standard` provider in Airflow 3.0;
+AIR302.py:434:1: AIR302 `airflow.sensors.external_task.ExternalTaskMarker` is moved into `standard` provider in Airflow 3.0;
     |
-439 | DummyOperator()
-440 | EmptyOperator()
-441 | ExternalTaskMarker()
+432 | DummyOperator()
+433 | EmptyOperator()
+434 | ExternalTaskMarker()
     | ^^^^^^^^^^^^^^^^^^ AIR302
-442 | ExternalTaskSensor()
-443 | ExternalTaskSensorLink()
+435 | ExternalTaskSensor()
+436 | ExternalTaskSensorLink()
     |
     = help: Install `apache-airflow-provider-standard>=0.0.3` and use `airflow.providers.standard.sensors.external_task.ExternalTaskMarker` instead.
 
-AIR302.py:442:1: AIR302 `airflow.sensors.external_task.ExternalTaskSensor` is moved into `standard` provider in Airflow 3.0;
+AIR302.py:435:1: AIR302 `airflow.sensors.external_task.ExternalTaskSensor` is moved into `standard` provider in Airflow 3.0;
     |
-440 | EmptyOperator()
-441 | ExternalTaskMarker()
-442 | ExternalTaskSensor()
+433 | EmptyOperator()
+434 | ExternalTaskMarker()
+435 | ExternalTaskSensor()
     | ^^^^^^^^^^^^^^^^^^ AIR302
-443 | ExternalTaskSensorLink()
-444 | FileSensor()
+436 | ExternalTaskSensorLink()
+437 | FileSensor()
     |
     = help: Install `apache-airflow-provider-standard>=0.0.3` and use `airflow.providers.standard.sensors.external_task.ExternalTaskSensor` instead.
 
-AIR302.py:443:1: AIR302 `airflow.sensors.external_task.ExternalTaskSensorLink` is moved into `standard` provider in Airflow 3.0;
+AIR302.py:436:1: AIR302 `airflow.sensors.external_task.ExternalTaskSensorLink` is moved into `standard` provider in Airflow 3.0;
     |
-441 | ExternalTaskMarker()
-442 | ExternalTaskSensor()
-443 | ExternalTaskSensorLink()
+434 | ExternalTaskMarker()
+435 | ExternalTaskSensor()
+436 | ExternalTaskSensorLink()
     | ^^^^^^^^^^^^^^^^^^^^^^ AIR302
-444 | FileSensor()
-445 | FileTrigger()
+437 | FileSensor()
+438 | FileTrigger()
     |
     = help: Install `apache-airflow-provider-standard>=0.0.3` and use `airflow.providers.standard.sensors.external_task.ExternalTaskSensorLink` instead.
 
-AIR302.py:444:1: AIR302 `airflow.sensors.filesystem.FileSensor` is moved into `standard` provider in Airflow 3.0;
+AIR302.py:437:1: AIR302 `airflow.sensors.filesystem.FileSensor` is moved into `standard` provider in Airflow 3.0;
     |
-442 | ExternalTaskSensor()
-443 | ExternalTaskSensorLink()
-444 | FileSensor()
+435 | ExternalTaskSensor()
+436 | ExternalTaskSensorLink()
+437 | FileSensor()
     | ^^^^^^^^^^ AIR302
-445 | FileTrigger()
-446 | FSHook()
+438 | FileTrigger()
+439 | FSHook()
     |
     = help: Install `apache-airflow-provider-standard>=0.0.2` and use `airflow.providers.standard.sensors.filesystem.FileSensor` instead.
 
-AIR302.py:445:1: AIR302 Import path `airflow.triggers.file` is moved into `standard` provider in Airflow 3.0;
+AIR302.py:438:1: AIR302 Import path `airflow.triggers.file` is moved into `standard` provider in Airflow 3.0;
     |
-443 | ExternalTaskSensorLink()
-444 | FileSensor()
-445 | FileTrigger()
+436 | ExternalTaskSensorLink()
+437 | FileSensor()
+438 | FileTrigger()
     | ^^^^^^^^^^^ AIR302
-446 | FSHook()
-447 | PackageIndexHook()
+439 | FSHook()
+440 | PackageIndexHook()
     |
     = help: Install `apache-airflow-provider-standard>=0.0.3` and import from `airflow.providers.standard.triggers.file` instead.
 
-AIR302.py:446:1: AIR302 Import path `airflow.hooks.filesystem` is moved into `standard` provider in Airflow 3.0;
+AIR302.py:439:1: AIR302 Import path `airflow.hooks.filesystem` is moved into `standard` provider in Airflow 3.0;
     |
-444 | FileSensor()
-445 | FileTrigger()
-446 | FSHook()
+437 | FileSensor()
+438 | FileTrigger()
+439 | FSHook()
     | ^^^^^^ AIR302
-447 | PackageIndexHook()
-448 | SubprocessHook()
+440 | PackageIndexHook()
+441 | SubprocessHook()
     |
     = help: Install `apache-airflow-provider-standard>=0.0.1` and import from `airflow.providers.standard.hooks.filesystem` instead.
 
-AIR302.py:447:1: AIR302 Import path `airflow.hooks.package_index` is moved into `standard` provider in Airflow 3.0;
+AIR302.py:440:1: AIR302 Import path `airflow.hooks.package_index` is moved into `standard` provider in Airflow 3.0;
     |
-445 | FileTrigger()
-446 | FSHook()
-447 | PackageIndexHook()
+438 | FileTrigger()
+439 | FSHook()
+440 | PackageIndexHook()
     | ^^^^^^^^^^^^^^^^ AIR302
-448 | SubprocessHook()
-449 | ShortCircuitOperator()
+441 | SubprocessHook()
+442 | ShortCircuitOperator()
     |
     = help: Install `apache-airflow-provider-standard>=0.0.1` and import from `airflow.providers.standard.hooks.package_index` instead.
 
-AIR302.py:448:1: AIR302 Import path `airflow.hooks.subprocess` is moved into `standard` provider in Airflow 3.0;
+AIR302.py:441:1: AIR302 Import path `airflow.hooks.subprocess` is moved into `standard` provider in Airflow 3.0;
     |
-446 | FSHook()
-447 | PackageIndexHook()
-448 | SubprocessHook()
+439 | FSHook()
+440 | PackageIndexHook()
+441 | SubprocessHook()
     | ^^^^^^^^^^^^^^ AIR302
-449 | ShortCircuitOperator()
-450 | TimeDeltaSensor()
+442 | ShortCircuitOperator()
+443 | TimeDeltaSensor()
     |
     = help: Install `apache-airflow-provider-standard>=0.0.1` and import from `airflow.providers.standard.hooks.subprocess` instead.
 
-AIR302.py:449:1: AIR302 `airflow.operators.python.ShortCircuitOperator` is moved into `standard` provider in Airflow 3.0;
+AIR302.py:442:1: AIR302 `airflow.operators.python.ShortCircuitOperator` is moved into `standard` provider in Airflow 3.0;
     |
-447 | PackageIndexHook()
-448 | SubprocessHook()
-449 | ShortCircuitOperator()
+440 | PackageIndexHook()
+441 | SubprocessHook()
+442 | ShortCircuitOperator()
     | ^^^^^^^^^^^^^^^^^^^^ AIR302
-450 | TimeDeltaSensor()
-451 | TimeSensor()
+443 | TimeDeltaSensor()
+444 | TimeSensor()
     |
     = help: Install `apache-airflow-provider-standard>=0.0.1` and use `airflow.providers.standard.operators.python.ShortCircuitOperator` instead.
 
-AIR302.py:450:1: AIR302 Import path `airflow.sensors.time_delta` is moved into `standard` provider in Airflow 3.0;
+AIR302.py:443:1: AIR302 Import path `airflow.sensors.time_delta` is moved into `standard` provider in Airflow 3.0;
     |
-448 | SubprocessHook()
-449 | ShortCircuitOperator()
-450 | TimeDeltaSensor()
+441 | SubprocessHook()
+442 | ShortCircuitOperator()
+443 | TimeDeltaSensor()
     | ^^^^^^^^^^^^^^^ AIR302
-451 | TimeSensor()
-452 | TriggerDagRunOperator()
+444 | TimeSensor()
+445 | TriggerDagRunOperator()
     |
     = help: Install `apache-airflow-provider-standard>=0.0.1` and import from `airflow.providers.standard.time.sensors.time_delta` instead.
 
-AIR302.py:451:1: AIR302 Import path `airflow.sensors.time_sensor` is moved into `standard` provider in Airflow 3.0;
+AIR302.py:444:1: AIR302 Import path `airflow.sensors.time_sensor` is moved into `standard` provider in Airflow 3.0;
     |
-449 | ShortCircuitOperator()
-450 | TimeDeltaSensor()
-451 | TimeSensor()
+442 | ShortCircuitOperator()
+443 | TimeDeltaSensor()
+444 | TimeSensor()
     | ^^^^^^^^^^ AIR302
-452 | TriggerDagRunOperator()
-453 | WorkflowTrigger()
+445 | TriggerDagRunOperator()
+446 | WorkflowTrigger()
     |
     = help: Install `apache-airflow-provider-standard>=0.0.1` and import from `airflow.providers.standard.time.sensors.time` instead.
 
-AIR302.py:452:1: AIR302 `airflow.operators.trigger_dagrun.TriggerDagRunOperator` is moved into `standard` provider in Airflow 3.0;
+AIR302.py:445:1: AIR302 `airflow.operators.trigger_dagrun.TriggerDagRunOperator` is moved into `standard` provider in Airflow 3.0;
     |
-450 | TimeDeltaSensor()
-451 | TimeSensor()
-452 | TriggerDagRunOperator()
+443 | TimeDeltaSensor()
+444 | TimeSensor()
+445 | TriggerDagRunOperator()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-453 | WorkflowTrigger()
-454 | PythonOperator()
+446 | WorkflowTrigger()
+447 | PythonOperator()
     |
     = help: Install `apache-airflow-provider-standard>=0.0.2` and use `airflow.providers.standard.operators.trigger_dagrun.TriggerDagRunOperator` instead.
 
-AIR302.py:453:1: AIR302 Import path `airflow.triggers.external_task` is moved into `standard` provider in Airflow 3.0;
+AIR302.py:446:1: AIR302 Import path `airflow.triggers.external_task` is moved into `standard` provider in Airflow 3.0;
     |
-451 | TimeSensor()
-452 | TriggerDagRunOperator()
-453 | WorkflowTrigger()
+444 | TimeSensor()
+445 | TriggerDagRunOperator()
+446 | WorkflowTrigger()
     | ^^^^^^^^^^^^^^^ AIR302
-454 | PythonOperator()
-455 | PythonVirtualenvOperator()
+447 | PythonOperator()
+448 | PythonVirtualenvOperator()
     |
     = help: Install `apache-airflow-provider-standard>=0.0.3` and import from `airflow.providers.standard.triggers.external_task` instead.
 
-AIR302.py:454:1: AIR302 `airflow.operators.python.PythonOperator` is moved into `standard` provider in Airflow 3.0;
+AIR302.py:447:1: AIR302 `airflow.operators.python.PythonOperator` is moved into `standard` provider in Airflow 3.0;
     |
-452 | TriggerDagRunOperator()
-453 | WorkflowTrigger()
-454 | PythonOperator()
+445 | TriggerDagRunOperator()
+446 | WorkflowTrigger()
+447 | PythonOperator()
     | ^^^^^^^^^^^^^^ AIR302
-455 | PythonVirtualenvOperator()
+448 | PythonVirtualenvOperator()
     |
     = help: Install `apache-airflow-provider-standard>=0.0.1` and use `airflow.providers.standard.operators.python.PythonOperator` instead.
 
-AIR302.py:455:1: AIR302 `airflow.operators.python.PythonVirtualenvOperator` is moved into `standard` provider in Airflow 3.0;
+AIR302.py:448:1: AIR302 `airflow.operators.python.PythonVirtualenvOperator` is moved into `standard` provider in Airflow 3.0;
     |
-453 | WorkflowTrigger()
-454 | PythonOperator()
-455 | PythonVirtualenvOperator()
+446 | WorkflowTrigger()
+447 | PythonOperator()
+448 | PythonVirtualenvOperator()
     | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
     |
     = help: Install `apache-airflow-provider-standard>=0.0.1` and use `airflow.providers.standard.operators.python.PythonVirtualenvOperator` instead.

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302.py.snap
@@ -1,1910 +1,1821 @@
 ---
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 ---
-AIR302.py:212:1: AIR302 `airflow.hooks.S3_hook.provide_bucket_name` is moved into `amazon` provider in Airflow 3.0;
+AIR302.py:233:1: AIR302 `airflow.hooks.S3_hook.provide_bucket_name` is moved into `amazon` provider in Airflow 3.0;
     |
-211 | # apache-airflow-providers-amazon
-212 | provide_bucket_name()
+232 | # apache-airflow-providers-amazon
+233 | provide_bucket_name()
     | ^^^^^^^^^^^^^^^^^^^ AIR302
-213 | GCSToS3Operator()
-214 | GoogleApiToS3Operator()
+234 | GCSToS3Operator()
+235 | GoogleApiToS3Operator()
     |
     = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.hooks.s3.provide_bucket_name` instead.
 
-AIR302.py:213:1: AIR302 `airflow.operators.gcs_to_s3.GCSToS3Operator` is moved into `amazon` provider in Airflow 3.0;
+AIR302.py:234:1: AIR302 `airflow.operators.gcs_to_s3.GCSToS3Operator` is moved into `amazon` provider in Airflow 3.0;
     |
-211 | # apache-airflow-providers-amazon
-212 | provide_bucket_name()
-213 | GCSToS3Operator()
+232 | # apache-airflow-providers-amazon
+233 | provide_bucket_name()
+234 | GCSToS3Operator()
     | ^^^^^^^^^^^^^^^ AIR302
-214 | GoogleApiToS3Operator()
-215 | GoogleApiToS3Transfer()
+235 | GoogleApiToS3Operator()
+236 | GoogleApiToS3Transfer()
     |
     = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.transfers.gcs_to_s3.GCSToS3Operator` instead.
 
-AIR302.py:214:1: AIR302 `airflow.operators.google_api_to_s3_transfer.GoogleApiToS3Operator` is moved into `amazon` provider in Airflow 3.0;
+AIR302.py:235:1: AIR302 `airflow.operators.google_api_to_s3_transfer.GoogleApiToS3Operator` is moved into `amazon` provider in Airflow 3.0;
     |
-212 | provide_bucket_name()
-213 | GCSToS3Operator()
-214 | GoogleApiToS3Operator()
+233 | provide_bucket_name()
+234 | GCSToS3Operator()
+235 | GoogleApiToS3Operator()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-215 | GoogleApiToS3Transfer()
-216 | RedshiftToS3Operator()
+236 | GoogleApiToS3Transfer()
+237 | RedshiftToS3Operator()
     |
     = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.transfers.google_api_to_s3.GoogleApiToS3Operator` instead.
 
-AIR302.py:215:1: AIR302 `airflow.operators.google_api_to_s3_transfer.GoogleApiToS3Transfer` is moved into `amazon` provider in Airflow 3.0;
+AIR302.py:236:1: AIR302 `airflow.operators.google_api_to_s3_transfer.GoogleApiToS3Transfer` is moved into `amazon` provider in Airflow 3.0;
     |
-213 | GCSToS3Operator()
-214 | GoogleApiToS3Operator()
-215 | GoogleApiToS3Transfer()
+234 | GCSToS3Operator()
+235 | GoogleApiToS3Operator()
+236 | GoogleApiToS3Transfer()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-216 | RedshiftToS3Operator()
-217 | RedshiftToS3Transfer()
+237 | RedshiftToS3Operator()
+238 | RedshiftToS3Transfer()
     |
     = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.transfers.google_api_to_s3.GoogleApiToS3Operator` instead.
 
-AIR302.py:216:1: AIR302 `airflow.operators.redshift_to_s3_operator.RedshiftToS3Operator` is moved into `amazon` provider in Airflow 3.0;
+AIR302.py:237:1: AIR302 `airflow.operators.redshift_to_s3_operator.RedshiftToS3Operator` is moved into `amazon` provider in Airflow 3.0;
     |
-214 | GoogleApiToS3Operator()
-215 | GoogleApiToS3Transfer()
-216 | RedshiftToS3Operator()
+235 | GoogleApiToS3Operator()
+236 | GoogleApiToS3Transfer()
+237 | RedshiftToS3Operator()
     | ^^^^^^^^^^^^^^^^^^^^ AIR302
-217 | RedshiftToS3Transfer()
-218 | S3FileTransformOperator()
+238 | RedshiftToS3Transfer()
+239 | S3FileTransformOperator()
     |
     = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.transfers.redshift_to_s3.RedshiftToS3Operator` instead.
 
-AIR302.py:217:1: AIR302 `airflow.operators.redshift_to_s3_operator.RedshiftToS3Transfer` is moved into `amazon` provider in Airflow 3.0;
+AIR302.py:238:1: AIR302 `airflow.operators.redshift_to_s3_operator.RedshiftToS3Transfer` is moved into `amazon` provider in Airflow 3.0;
     |
-215 | GoogleApiToS3Transfer()
-216 | RedshiftToS3Operator()
-217 | RedshiftToS3Transfer()
+236 | GoogleApiToS3Transfer()
+237 | RedshiftToS3Operator()
+238 | RedshiftToS3Transfer()
     | ^^^^^^^^^^^^^^^^^^^^ AIR302
-218 | S3FileTransformOperator()
-219 | S3Hook()
+239 | S3FileTransformOperator()
+240 | S3Hook()
     |
     = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.transfers.redshift_to_s3.RedshiftToS3Operator` instead.
 
-AIR302.py:218:1: AIR302 `airflow.operators.s3_file_transform_operator.S3FileTransformOperator` is moved into `amazon` provider in Airflow 3.0;
+AIR302.py:239:1: AIR302 `airflow.operators.s3_file_transform_operator.S3FileTransformOperator` is moved into `amazon` provider in Airflow 3.0;
     |
-216 | RedshiftToS3Operator()
-217 | RedshiftToS3Transfer()
-218 | S3FileTransformOperator()
+237 | RedshiftToS3Operator()
+238 | RedshiftToS3Transfer()
+239 | S3FileTransformOperator()
     | ^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-219 | S3Hook()
-220 | S3KeySensor()
+240 | S3Hook()
+241 | S3KeySensor()
     |
     = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.operators.s3_file_transform.S3FileTransformOperator` instead.
 
-AIR302.py:219:1: AIR302 `airflow.hooks.S3_hook.S3Hook` is moved into `amazon` provider in Airflow 3.0;
+AIR302.py:240:1: AIR302 `airflow.hooks.S3_hook.S3Hook` is moved into `amazon` provider in Airflow 3.0;
     |
-217 | RedshiftToS3Transfer()
-218 | S3FileTransformOperator()
-219 | S3Hook()
+238 | RedshiftToS3Transfer()
+239 | S3FileTransformOperator()
+240 | S3Hook()
     | ^^^^^^ AIR302
-220 | S3KeySensor()
-221 | S3ToRedshiftOperator()
+241 | S3KeySensor()
+242 | S3ToRedshiftOperator()
     |
     = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.hooks.s3.S3Hook` instead.
 
-AIR302.py:220:1: AIR302 `airflow.sensors.s3_key_sensor.S3KeySensor` is moved into `amazon` provider in Airflow 3.0;
+AIR302.py:241:1: AIR302 `airflow.sensors.s3_key_sensor.S3KeySensor` is moved into `amazon` provider in Airflow 3.0;
     |
-218 | S3FileTransformOperator()
-219 | S3Hook()
-220 | S3KeySensor()
+239 | S3FileTransformOperator()
+240 | S3Hook()
+241 | S3KeySensor()
     | ^^^^^^^^^^^ AIR302
-221 | S3ToRedshiftOperator()
-222 | S3ToRedshiftTransfer()
+242 | S3ToRedshiftOperator()
+243 | S3ToRedshiftTransfer()
     |
     = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `S3KeySensor` instead.
 
-AIR302.py:221:1: AIR302 `airflow.operators.s3_to_redshift_operator.S3ToRedshiftOperator` is moved into `amazon` provider in Airflow 3.0;
+AIR302.py:242:1: AIR302 `airflow.operators.s3_to_redshift_operator.S3ToRedshiftOperator` is moved into `amazon` provider in Airflow 3.0;
     |
-219 | S3Hook()
-220 | S3KeySensor()
-221 | S3ToRedshiftOperator()
+240 | S3Hook()
+241 | S3KeySensor()
+242 | S3ToRedshiftOperator()
     | ^^^^^^^^^^^^^^^^^^^^ AIR302
-222 | S3ToRedshiftTransfer()
+243 | S3ToRedshiftTransfer()
     |
     = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.transfers.s3_to_redshift.S3ToRedshiftOperator` instead.
 
-AIR302.py:222:1: AIR302 `airflow.operators.s3_to_redshift_operator.S3ToRedshiftTransfer` is moved into `amazon` provider in Airflow 3.0;
+AIR302.py:243:1: AIR302 `airflow.operators.s3_to_redshift_operator.S3ToRedshiftTransfer` is moved into `amazon` provider in Airflow 3.0;
     |
-220 | S3KeySensor()
-221 | S3ToRedshiftOperator()
-222 | S3ToRedshiftTransfer()
+241 | S3KeySensor()
+242 | S3ToRedshiftOperator()
+243 | S3ToRedshiftTransfer()
     | ^^^^^^^^^^^^^^^^^^^^ AIR302
-223 |
-224 | # apache-airflow-providers-celery
+244 |
+245 | # apache-airflow-providers-celery
     |
     = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.transfers.s3_to_redshift.S3ToRedshiftOperator` instead.
 
-AIR302.py:225:1: AIR302 `airflow.config_templates.default_celery.DEFAULT_CELERY_CONFIG` is moved into `celery` provider in Airflow 3.0;
+AIR302.py:246:1: AIR302 `airflow.config_templates.default_celery.DEFAULT_CELERY_CONFIG` is moved into `celery` provider in Airflow 3.0;
     |
-224 | # apache-airflow-providers-celery
-225 | DEFAULT_CELERY_CONFIG
+245 | # apache-airflow-providers-celery
+246 | DEFAULT_CELERY_CONFIG
     | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-226 | app
-227 | CeleryExecutor()
+247 | app
+248 | CeleryExecutor()
     |
     = help: Install `apache-airflow-provider-celery>=3.3.0` and use `airflow.providers.celery.executors.default_celery.DEFAULT_CELERY_CONFIG` instead.
 
-AIR302.py:226:1: AIR302 `airflow.executors.celery_executor.app` is moved into `celery` provider in Airflow 3.0;
+AIR302.py:247:1: AIR302 `airflow.executors.celery_executor.app` is moved into `celery` provider in Airflow 3.0;
     |
-224 | # apache-airflow-providers-celery
-225 | DEFAULT_CELERY_CONFIG
-226 | app
+245 | # apache-airflow-providers-celery
+246 | DEFAULT_CELERY_CONFIG
+247 | app
     | ^^^ AIR302
-227 | CeleryExecutor()
-228 | CeleryKubernetesExecutor()
+248 | CeleryExecutor()
+249 | CeleryKubernetesExecutor()
     |
     = help: Install `apache-airflow-provider-celery>=3.3.0` and use `airflow.providers.celery.executors.celery_executor_utils.app` instead.
 
-AIR302.py:227:1: AIR302 `airflow.executors.celery_executor.CeleryExecutor` is moved into `celery` provider in Airflow 3.0;
+AIR302.py:248:1: AIR302 `airflow.executors.celery_executor.CeleryExecutor` is moved into `celery` provider in Airflow 3.0;
     |
-225 | DEFAULT_CELERY_CONFIG
-226 | app
-227 | CeleryExecutor()
+246 | DEFAULT_CELERY_CONFIG
+247 | app
+248 | CeleryExecutor()
     | ^^^^^^^^^^^^^^ AIR302
-228 | CeleryKubernetesExecutor()
+249 | CeleryKubernetesExecutor()
     |
     = help: Install `apache-airflow-provider-celery>=3.3.0` and use `airflow.providers.celery.executors.celery_executor.CeleryExecutor` instead.
 
-AIR302.py:228:1: AIR302 `airflow.executors.celery_kubernetes_executor.CeleryKubernetesExecutor` is moved into `celery` provider in Airflow 3.0;
+AIR302.py:249:1: AIR302 `airflow.executors.celery_kubernetes_executor.CeleryKubernetesExecutor` is moved into `celery` provider in Airflow 3.0;
     |
-226 | app
-227 | CeleryExecutor()
-228 | CeleryKubernetesExecutor()
+247 | app
+248 | CeleryExecutor()
+249 | CeleryKubernetesExecutor()
     | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-229 |
-230 | # apache-airflow-providers-common-sql
+250 |
+251 | # apache-airflow-providers-common-sql
     |
     = help: Install `apache-airflow-provider-celery>=3.3.0` and use `airflow.providers.celery.executors.celery_kubernetes_executor.CeleryKubernetesExecutor` instead.
 
-AIR302.py:231:1: AIR302 `airflow.operators.sql._convert_to_float_if_possible` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:252:1: AIR302 `airflow.operators.sql._convert_to_float_if_possible` is moved into `common-sql` provider in Airflow 3.0;
     |
-230 | # apache-airflow-providers-common-sql
-231 | _convert_to_float_if_possible()
+251 | # apache-airflow-providers-common-sql
+252 | _convert_to_float_if_possible()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-232 | parse_boolean()
-233 | BaseSQLOperator()
+253 | parse_boolean()
+254 | BaseSQLOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.0.0` and use `airflow.providers.common.sql.operators.sql._convert_to_float_if_possible` instead.
 
-AIR302.py:232:1: AIR302 `airflow.operators.sql.parse_boolean` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:253:1: AIR302 `airflow.operators.sql.parse_boolean` is moved into `common-sql` provider in Airflow 3.0;
     |
-230 | # apache-airflow-providers-common-sql
-231 | _convert_to_float_if_possible()
-232 | parse_boolean()
+251 | # apache-airflow-providers-common-sql
+252 | _convert_to_float_if_possible()
+253 | parse_boolean()
     | ^^^^^^^^^^^^^ AIR302
-233 | BaseSQLOperator()
-234 | BashOperator()
+254 | BaseSQLOperator()
+255 | BashOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.0.0` and use `airflow.providers.common.sql.operators.sql.parse_boolean` instead.
 
-AIR302.py:233:1: AIR302 `airflow.operators.sql.BaseSQLOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:254:1: AIR302 `airflow.operators.sql.BaseSQLOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-231 | _convert_to_float_if_possible()
-232 | parse_boolean()
-233 | BaseSQLOperator()
+252 | _convert_to_float_if_possible()
+253 | parse_boolean()
+254 | BaseSQLOperator()
     | ^^^^^^^^^^^^^^^ AIR302
-234 | BashOperator()
-235 | LegacyBashOperator()
+255 | BashOperator()
+256 | LegacyBashOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.BaseSQLOperator` instead.
 
-AIR302.py:234:1: AIR302 Import path `airflow.operators.bash` is moved into `standard` provider in Airflow 3.0;
+AIR302.py:255:1: AIR302 Import path `airflow.operators.bash` is moved into `standard` provider in Airflow 3.0;
     |
-232 | parse_boolean()
-233 | BaseSQLOperator()
-234 | BashOperator()
+253 | parse_boolean()
+254 | BaseSQLOperator()
+255 | BashOperator()
     | ^^^^^^^^^^^^ AIR302
-235 | LegacyBashOperator()
-236 | BranchSQLOperator()
+256 | LegacyBashOperator()
+257 | BranchSQLOperator()
     |
     = help: Install `apache-airflow-provider-standard>=0.0.1` and import from `airflow.providers.standard.operators.bash` instead.
 
-AIR302.py:235:1: AIR302 `airflow.operators.bash_operator.BashOperator` is moved into `standard` provider in Airflow 3.0;
+AIR302.py:256:1: AIR302 `airflow.operators.bash_operator.BashOperator` is moved into `standard` provider in Airflow 3.0;
     |
-233 | BaseSQLOperator()
-234 | BashOperator()
-235 | LegacyBashOperator()
+254 | BaseSQLOperator()
+255 | BashOperator()
+256 | LegacyBashOperator()
     | ^^^^^^^^^^^^^^^^^^ AIR302
-236 | BranchSQLOperator()
-237 | CheckOperator()
+257 | BranchSQLOperator()
+258 | CheckOperator()
     |
     = help: Install `apache-airflow-provider-standard>=0.0.1` and use `airflow.providers.standard.operators.bash.BashOperator` instead.
 
-AIR302.py:236:1: AIR302 `airflow.operators.sql.BranchSQLOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:257:1: AIR302 `airflow.operators.sql.BranchSQLOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-234 | BashOperator()
-235 | LegacyBashOperator()
-236 | BranchSQLOperator()
+255 | BashOperator()
+256 | LegacyBashOperator()
+257 | BranchSQLOperator()
     | ^^^^^^^^^^^^^^^^^ AIR302
-237 | CheckOperator()
-238 | ConnectorProtocol()
+258 | CheckOperator()
+259 | ConnectorProtocol()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.BranchSQLOperator` instead.
 
-AIR302.py:237:1: AIR302 `airflow.operators.check_operator.CheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:258:1: AIR302 `airflow.operators.check_operator.CheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-235 | LegacyBashOperator()
-236 | BranchSQLOperator()
-237 | CheckOperator()
+256 | LegacyBashOperator()
+257 | BranchSQLOperator()
+258 | CheckOperator()
     | ^^^^^^^^^^^^^ AIR302
-238 | ConnectorProtocol()
-239 | DbApiHook()
+259 | ConnectorProtocol()
+260 | DbApiHook()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLCheckOperator` instead.
 
-AIR302.py:238:1: AIR302 `airflow.hooks.dbapi.ConnectorProtocol` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:259:1: AIR302 `airflow.hooks.dbapi.ConnectorProtocol` is moved into `common-sql` provider in Airflow 3.0;
     |
-236 | BranchSQLOperator()
-237 | CheckOperator()
-238 | ConnectorProtocol()
+257 | BranchSQLOperator()
+258 | CheckOperator()
+259 | ConnectorProtocol()
     | ^^^^^^^^^^^^^^^^^ AIR302
-239 | DbApiHook()
-240 | DbApiHook2()
+260 | DbApiHook()
+261 | DbApiHook2()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.0.0` and use `airflow.providers.common.sql.hooks.sql.ConnectorProtocol` instead.
 
-AIR302.py:239:1: AIR302 `airflow.hooks.dbapi.DbApiHook` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:260:1: AIR302 `airflow.hooks.dbapi.DbApiHook` is moved into `common-sql` provider in Airflow 3.0;
     |
-237 | CheckOperator()
-238 | ConnectorProtocol()
-239 | DbApiHook()
+258 | CheckOperator()
+259 | ConnectorProtocol()
+260 | DbApiHook()
     | ^^^^^^^^^ AIR302
-240 | DbApiHook2()
-241 | IntervalCheckOperator()
+261 | DbApiHook2()
+262 | IntervalCheckOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.0.0` and use `airflow.providers.common.sql.hooks.sql.DbApiHook` instead.
 
-AIR302.py:240:1: AIR302 `airflow.hooks.dbapi_hook.DbApiHook` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:261:1: AIR302 `airflow.hooks.dbapi_hook.DbApiHook` is moved into `common-sql` provider in Airflow 3.0;
     |
-238 | ConnectorProtocol()
-239 | DbApiHook()
-240 | DbApiHook2()
+259 | ConnectorProtocol()
+260 | DbApiHook()
+261 | DbApiHook2()
     | ^^^^^^^^^^ AIR302
-241 | IntervalCheckOperator()
-242 | PrestoCheckOperator()
+262 | IntervalCheckOperator()
+263 | PrestoCheckOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.0.0` and use `airflow.providers.common.sql.hooks.sql.DbApiHook` instead.
 
-AIR302.py:241:1: AIR302 `airflow.operators.check_operator.IntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:262:1: AIR302 `airflow.operators.check_operator.IntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-239 | DbApiHook()
-240 | DbApiHook2()
-241 | IntervalCheckOperator()
+260 | DbApiHook()
+261 | DbApiHook2()
+262 | IntervalCheckOperator()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-242 | PrestoCheckOperator()
-243 | PrestoIntervalCheckOperator()
+263 | PrestoCheckOperator()
+264 | PrestoIntervalCheckOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLIntervalCheckOperator` instead.
 
-AIR302.py:242:1: AIR302 `airflow.operators.presto_check_operator.PrestoCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:263:1: AIR302 `airflow.operators.presto_check_operator.PrestoCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-240 | DbApiHook2()
-241 | IntervalCheckOperator()
-242 | PrestoCheckOperator()
+261 | DbApiHook2()
+262 | IntervalCheckOperator()
+263 | PrestoCheckOperator()
     | ^^^^^^^^^^^^^^^^^^^ AIR302
-243 | PrestoIntervalCheckOperator()
-244 | PrestoValueCheckOperator()
+264 | PrestoIntervalCheckOperator()
+265 | PrestoValueCheckOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLCheckOperator` instead.
 
-AIR302.py:243:1: AIR302 `airflow.operators.presto_check_operator.PrestoIntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:264:1: AIR302 `airflow.operators.presto_check_operator.PrestoIntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-241 | IntervalCheckOperator()
-242 | PrestoCheckOperator()
-243 | PrestoIntervalCheckOperator()
+262 | IntervalCheckOperator()
+263 | PrestoCheckOperator()
+264 | PrestoIntervalCheckOperator()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-244 | PrestoValueCheckOperator()
-245 | SQLCheckOperator()
+265 | PrestoValueCheckOperator()
+266 | SQLCheckOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLIntervalCheckOperator` instead.
 
-AIR302.py:244:1: AIR302 `airflow.operators.presto_check_operator.PrestoValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:265:1: AIR302 `airflow.operators.presto_check_operator.PrestoValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-242 | PrestoCheckOperator()
-243 | PrestoIntervalCheckOperator()
-244 | PrestoValueCheckOperator()
+263 | PrestoCheckOperator()
+264 | PrestoIntervalCheckOperator()
+265 | PrestoValueCheckOperator()
     | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-245 | SQLCheckOperator()
-246 | SQLCheckOperator2()
+266 | SQLCheckOperator()
+267 | SQLCheckOperator2()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLValueCheckOperator` instead.
 
-AIR302.py:245:1: AIR302 `airflow.operators.check_operator.SQLCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:266:1: AIR302 `airflow.operators.check_operator.SQLCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-243 | PrestoIntervalCheckOperator()
-244 | PrestoValueCheckOperator()
-245 | SQLCheckOperator()
+264 | PrestoIntervalCheckOperator()
+265 | PrestoValueCheckOperator()
+266 | SQLCheckOperator()
     | ^^^^^^^^^^^^^^^^ AIR302
-246 | SQLCheckOperator2()
-247 | SQLCheckOperator3()
+267 | SQLCheckOperator2()
+268 | SQLCheckOperator3()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLCheckOperator` instead.
 
-AIR302.py:246:1: AIR302 `airflow.operators.presto_check_operator.SQLCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:267:1: AIR302 `airflow.operators.presto_check_operator.SQLCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-244 | PrestoValueCheckOperator()
-245 | SQLCheckOperator()
-246 | SQLCheckOperator2()
+265 | PrestoValueCheckOperator()
+266 | SQLCheckOperator()
+267 | SQLCheckOperator2()
     | ^^^^^^^^^^^^^^^^^ AIR302
-247 | SQLCheckOperator3()
-248 | SQLColumnCheckOperator2()
+268 | SQLCheckOperator3()
+269 | SQLColumnCheckOperator2()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLCheckOperator` instead.
 
-AIR302.py:247:1: AIR302 `airflow.operators.sql.SQLCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:268:1: AIR302 `airflow.operators.sql.SQLCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-245 | SQLCheckOperator()
-246 | SQLCheckOperator2()
-247 | SQLCheckOperator3()
+266 | SQLCheckOperator()
+267 | SQLCheckOperator2()
+268 | SQLCheckOperator3()
     | ^^^^^^^^^^^^^^^^^ AIR302
-248 | SQLColumnCheckOperator2()
-249 | SQLIntervalCheckOperator()
+269 | SQLColumnCheckOperator2()
+270 | SQLIntervalCheckOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLCheckOperator` instead.
 
-AIR302.py:248:1: AIR302 `airflow.operators.sql.SQLColumnCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:269:1: AIR302 `airflow.operators.sql.SQLColumnCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-246 | SQLCheckOperator2()
-247 | SQLCheckOperator3()
-248 | SQLColumnCheckOperator2()
+267 | SQLCheckOperator2()
+268 | SQLCheckOperator3()
+269 | SQLColumnCheckOperator2()
     | ^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-249 | SQLIntervalCheckOperator()
-250 | SQLIntervalCheckOperator2()
+270 | SQLIntervalCheckOperator()
+271 | SQLIntervalCheckOperator2()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.0.0` and use `airflow.providers.common.sql.operators.sql.SQLColumnCheckOperator` instead.
 
-AIR302.py:249:1: AIR302 `airflow.operators.check_operator.SQLIntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:270:1: AIR302 `airflow.operators.check_operator.SQLIntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-247 | SQLCheckOperator3()
-248 | SQLColumnCheckOperator2()
-249 | SQLIntervalCheckOperator()
+268 | SQLCheckOperator3()
+269 | SQLColumnCheckOperator2()
+270 | SQLIntervalCheckOperator()
     | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-250 | SQLIntervalCheckOperator2()
-251 | SQLIntervalCheckOperator3()
+271 | SQLIntervalCheckOperator2()
+272 | SQLIntervalCheckOperator3()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLIntervalCheckOperator` instead.
 
-AIR302.py:250:1: AIR302 `airflow.operators.presto_check_operator.SQLIntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:271:1: AIR302 `airflow.operators.presto_check_operator.SQLIntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-248 | SQLColumnCheckOperator2()
-249 | SQLIntervalCheckOperator()
-250 | SQLIntervalCheckOperator2()
+269 | SQLColumnCheckOperator2()
+270 | SQLIntervalCheckOperator()
+271 | SQLIntervalCheckOperator2()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-251 | SQLIntervalCheckOperator3()
-252 | SQLTableCheckOperator()
+272 | SQLIntervalCheckOperator3()
+273 | SQLTableCheckOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLIntervalCheckOperator` instead.
 
-AIR302.py:251:1: AIR302 `airflow.operators.sql.SQLIntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:272:1: AIR302 `airflow.operators.sql.SQLIntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-249 | SQLIntervalCheckOperator()
-250 | SQLIntervalCheckOperator2()
-251 | SQLIntervalCheckOperator3()
+270 | SQLIntervalCheckOperator()
+271 | SQLIntervalCheckOperator2()
+272 | SQLIntervalCheckOperator3()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-252 | SQLTableCheckOperator()
-253 | SQLThresholdCheckOperator()
+273 | SQLTableCheckOperator()
+274 | SQLThresholdCheckOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLIntervalCheckOperator` instead.
 
-AIR302.py:253:1: AIR302 `airflow.operators.check_operator.SQLThresholdCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:274:1: AIR302 `airflow.operators.check_operator.SQLThresholdCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-251 | SQLIntervalCheckOperator3()
-252 | SQLTableCheckOperator()
-253 | SQLThresholdCheckOperator()
+272 | SQLIntervalCheckOperator3()
+273 | SQLTableCheckOperator()
+274 | SQLThresholdCheckOperator()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-254 | SQLThresholdCheckOperator2()
-255 | SQLValueCheckOperator()
+275 | SQLThresholdCheckOperator2()
+276 | SQLValueCheckOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLThresholdCheckOperator` instead.
 
-AIR302.py:254:1: AIR302 `airflow.operators.sql.SQLThresholdCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:275:1: AIR302 `airflow.operators.sql.SQLThresholdCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-252 | SQLTableCheckOperator()
-253 | SQLThresholdCheckOperator()
-254 | SQLThresholdCheckOperator2()
+273 | SQLTableCheckOperator()
+274 | SQLThresholdCheckOperator()
+275 | SQLThresholdCheckOperator2()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-255 | SQLValueCheckOperator()
-256 | SQLValueCheckOperator2()
+276 | SQLValueCheckOperator()
+277 | SQLValueCheckOperator2()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.0.0` and use `airflow.providers.common.sql.operators.sql.SQLTableCheckOperator` instead.
 
-AIR302.py:255:1: AIR302 `airflow.operators.check_operator.SQLValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:276:1: AIR302 `airflow.operators.check_operator.SQLValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-253 | SQLThresholdCheckOperator()
-254 | SQLThresholdCheckOperator2()
-255 | SQLValueCheckOperator()
+274 | SQLThresholdCheckOperator()
+275 | SQLThresholdCheckOperator2()
+276 | SQLValueCheckOperator()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-256 | SQLValueCheckOperator2()
-257 | SQLValueCheckOperator3()
+277 | SQLValueCheckOperator2()
+278 | SQLValueCheckOperator3()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLValueCheckOperator` instead.
 
-AIR302.py:256:1: AIR302 `airflow.operators.presto_check_operator.SQLValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:277:1: AIR302 `airflow.operators.presto_check_operator.SQLValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-254 | SQLThresholdCheckOperator2()
-255 | SQLValueCheckOperator()
-256 | SQLValueCheckOperator2()
+275 | SQLThresholdCheckOperator2()
+276 | SQLValueCheckOperator()
+277 | SQLValueCheckOperator2()
     | ^^^^^^^^^^^^^^^^^^^^^^ AIR302
-257 | SQLValueCheckOperator3()
-258 | SqlSensor()
+278 | SQLValueCheckOperator3()
+279 | SqlSensor()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLValueCheckOperator` instead.
 
-AIR302.py:257:1: AIR302 `airflow.operators.sql.SQLValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:278:1: AIR302 `airflow.operators.sql.SQLValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-255 | SQLValueCheckOperator()
-256 | SQLValueCheckOperator2()
-257 | SQLValueCheckOperator3()
+276 | SQLValueCheckOperator()
+277 | SQLValueCheckOperator2()
+278 | SQLValueCheckOperator3()
     | ^^^^^^^^^^^^^^^^^^^^^^ AIR302
-258 | SqlSensor()
-259 | SqlSensor2()
+279 | SqlSensor()
+280 | SqlSensor2()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.0.0` and use `airflow.providers.common.sql.operators.sql.SQLValueCheckOperator` instead.
 
-AIR302.py:258:1: AIR302 `airflow.sensors.sql.SqlSensor` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:279:1: AIR302 `airflow.sensors.sql.SqlSensor` is moved into `common-sql` provider in Airflow 3.0;
     |
-256 | SQLValueCheckOperator2()
-257 | SQLValueCheckOperator3()
-258 | SqlSensor()
+277 | SQLValueCheckOperator2()
+278 | SQLValueCheckOperator3()
+279 | SqlSensor()
     | ^^^^^^^^^ AIR302
-259 | SqlSensor2()
-260 | ThresholdCheckOperator()
+280 | SqlSensor2()
+281 | ThresholdCheckOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.0.0` and use `airflow.providers.common.sql.sensors.sql.SqlSensor` instead.
 
-AIR302.py:260:1: AIR302 `airflow.operators.check_operator.ThresholdCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:281:1: AIR302 `airflow.operators.check_operator.ThresholdCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-258 | SqlSensor()
-259 | SqlSensor2()
-260 | ThresholdCheckOperator()
+279 | SqlSensor()
+280 | SqlSensor2()
+281 | ThresholdCheckOperator()
     | ^^^^^^^^^^^^^^^^^^^^^^ AIR302
-261 | ValueCheckOperator()
+282 | ValueCheckOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLThresholdCheckOperator` instead.
 
-AIR302.py:261:1: AIR302 `airflow.operators.check_operator.ValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302.py:282:1: AIR302 `airflow.operators.check_operator.ValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-259 | SqlSensor2()
-260 | ThresholdCheckOperator()
-261 | ValueCheckOperator()
+280 | SqlSensor2()
+281 | ThresholdCheckOperator()
+282 | ValueCheckOperator()
     | ^^^^^^^^^^^^^^^^^^ AIR302
-262 |
-263 | # apache-airflow-providers-daskexecutor
+283 |
+284 | # apache-airflow-providers-daskexecutor
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLValueCheckOperator` instead.
 
-AIR302.py:264:1: AIR302 `airflow.executors.dask_executor.DaskExecutor` is moved into `daskexecutor` provider in Airflow 3.0;
+AIR302.py:285:1: AIR302 `airflow.executors.dask_executor.DaskExecutor` is moved into `daskexecutor` provider in Airflow 3.0;
     |
-263 | # apache-airflow-providers-daskexecutor
-264 | DaskExecutor()
+284 | # apache-airflow-providers-daskexecutor
+285 | DaskExecutor()
     | ^^^^^^^^^^^^ AIR302
-265 |
-266 | # apache-airflow-providers-docker
+286 |
+287 | # apache-airflow-providers-docker
     |
     = help: Install `apache-airflow-provider-daskexecutor>=1.0.0` and use `airflow.providers.daskexecutor.executors.dask_executor.DaskExecutor` instead.
 
-AIR302.py:267:1: AIR302 `airflow.hooks.docker_hook.DockerHook` is moved into `docker` provider in Airflow 3.0;
+AIR302.py:288:1: AIR302 `airflow.hooks.docker_hook.DockerHook` is moved into `docker` provider in Airflow 3.0;
     |
-266 | # apache-airflow-providers-docker
-267 | DockerHook()
+287 | # apache-airflow-providers-docker
+288 | DockerHook()
     | ^^^^^^^^^^ AIR302
-268 | DockerOperator()
+289 | DockerOperator()
     |
     = help: Install `apache-airflow-provider-docker>=1.0.0` and use `airflow.providers.docker.hooks.docker.DockerHook` instead.
 
-AIR302.py:268:1: AIR302 `airflow.operators.docker_operator.DockerOperator` is moved into `docker` provider in Airflow 3.0;
+AIR302.py:289:1: AIR302 `airflow.operators.docker_operator.DockerOperator` is moved into `docker` provider in Airflow 3.0;
     |
-266 | # apache-airflow-providers-docker
-267 | DockerHook()
-268 | DockerOperator()
+287 | # apache-airflow-providers-docker
+288 | DockerHook()
+289 | DockerOperator()
     | ^^^^^^^^^^^^^^ AIR302
-269 |
-270 | # apache-airflow-providers-apache-druid
+290 |
+291 | # apache-airflow-providers-apache-druid
     |
     = help: Install `apache-airflow-provider-docker>=1.0.0` and use `airflow.providers.docker.operators.docker.DockerOperator` instead.
 
-AIR302.py:271:1: AIR302 `airflow.hooks.druid_hook.DruidDbApiHook` is moved into `apache-druid` provider in Airflow 3.0;
+AIR302.py:292:1: AIR302 `airflow.hooks.druid_hook.DruidDbApiHook` is moved into `apache-druid` provider in Airflow 3.0;
     |
-270 | # apache-airflow-providers-apache-druid
-271 | DruidDbApiHook()
+291 | # apache-airflow-providers-apache-druid
+292 | DruidDbApiHook()
     | ^^^^^^^^^^^^^^ AIR302
-272 | DruidHook()
-273 | DruidCheckOperator()
+293 | DruidHook()
+294 | DruidCheckOperator()
     |
     = help: Install `apache-airflow-provider-apache-druid>=1.0.0` and use `DruidDbApiHook` instead.
 
-AIR302.py:272:1: AIR302 `airflow.hooks.druid_hook.DruidHook` is moved into `apache-druid` provider in Airflow 3.0;
+AIR302.py:293:1: AIR302 `airflow.hooks.druid_hook.DruidHook` is moved into `apache-druid` provider in Airflow 3.0;
     |
-270 | # apache-airflow-providers-apache-druid
-271 | DruidDbApiHook()
-272 | DruidHook()
+291 | # apache-airflow-providers-apache-druid
+292 | DruidDbApiHook()
+293 | DruidHook()
     | ^^^^^^^^^ AIR302
-273 | DruidCheckOperator()
+294 | DruidCheckOperator()
     |
     = help: Install `apache-airflow-provider-apache-druid>=1.0.0` and use `DruidHook` instead.
 
-AIR302.py:273:1: AIR302 `airflow.operators.druid_check_operator.DruidCheckOperator` is moved into `apache-druid` provider in Airflow 3.0;
+AIR302.py:294:1: AIR302 `airflow.operators.druid_check_operator.DruidCheckOperator` is moved into `apache-druid` provider in Airflow 3.0;
     |
-271 | DruidDbApiHook()
-272 | DruidHook()
-273 | DruidCheckOperator()
+292 | DruidDbApiHook()
+293 | DruidHook()
+294 | DruidCheckOperator()
     | ^^^^^^^^^^^^^^^^^^ AIR302
-274 |
-275 | # apache-airflow-providers-apache-hdfs
+295 |
+296 | # apache-airflow-providers-apache-hdfs
     |
     = help: Install `apache-airflow-provider-apache-druid>=1.0.0` and use `DruidCheckOperator` instead.
 
-AIR302.py:276:1: AIR302 `airflow.hooks.webhdfs_hook.WebHDFSHook` is moved into `apache-hdfs` provider in Airflow 3.0;
+AIR302.py:297:1: AIR302 `airflow.hooks.webhdfs_hook.WebHDFSHook` is moved into `apache-hdfs` provider in Airflow 3.0;
     |
-275 | # apache-airflow-providers-apache-hdfs
-276 | WebHDFSHook()
+296 | # apache-airflow-providers-apache-hdfs
+297 | WebHDFSHook()
     | ^^^^^^^^^^^ AIR302
-277 | WebHdfsSensor()
+298 | WebHdfsSensor()
     |
     = help: Install `apache-airflow-provider-apache-hdfs>=1.0.0` and use `airflow.providers.apache.hdfs.hooks.webhdfs.WebHDFSHook` instead.
 
-AIR302.py:277:1: AIR302 `airflow.sensors.web_hdfs_sensor.WebHdfsSensor` is moved into `apache-hdfs` provider in Airflow 3.0;
+AIR302.py:298:1: AIR302 `airflow.sensors.web_hdfs_sensor.WebHdfsSensor` is moved into `apache-hdfs` provider in Airflow 3.0;
     |
-275 | # apache-airflow-providers-apache-hdfs
-276 | WebHDFSHook()
-277 | WebHdfsSensor()
+296 | # apache-airflow-providers-apache-hdfs
+297 | WebHDFSHook()
+298 | WebHdfsSensor()
     | ^^^^^^^^^^^^^ AIR302
-278 |
-279 | # apache-airflow-providers-apache-hive
+299 |
+300 | # apache-airflow-providers-apache-hive
     |
     = help: Install `apache-airflow-provider-apache-hdfs>=1.0.0` and use `airflow.providers.apache.hdfs.sensors.web_hdfs.WebHdfsSensor` instead.
 
-AIR302.py:280:1: AIR302 `airflow.hooks.hive_hooks.HIVE_QUEUE_PRIORITIES` is moved into `apache-hive` provider in Airflow 3.0;
+AIR302.py:301:1: AIR302 `airflow.hooks.hive_hooks.HIVE_QUEUE_PRIORITIES` is moved into `apache-hive` provider in Airflow 3.0;
     |
-279 | # apache-airflow-providers-apache-hive
-280 | HIVE_QUEUE_PRIORITIES
+300 | # apache-airflow-providers-apache-hive
+301 | HIVE_QUEUE_PRIORITIES
     | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-281 | closest_ds_partition()
-282 | max_partition()
+302 | closest_ds_partition()
+303 | max_partition()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.hooks.hive.HIVE_QUEUE_PRIORITIES` instead.
 
-AIR302.py:281:1: AIR302 `airflow.macros.hive.closest_ds_partition` is moved into `apache-hive` provider in Airflow 3.0;
+AIR302.py:302:1: AIR302 `airflow.macros.hive.closest_ds_partition` is moved into `apache-hive` provider in Airflow 3.0;
     |
-279 | # apache-airflow-providers-apache-hive
-280 | HIVE_QUEUE_PRIORITIES
-281 | closest_ds_partition()
+300 | # apache-airflow-providers-apache-hive
+301 | HIVE_QUEUE_PRIORITIES
+302 | closest_ds_partition()
     | ^^^^^^^^^^^^^^^^^^^^ AIR302
-282 | max_partition()
-283 | HiveCliHook()
+303 | max_partition()
+304 | HiveCliHook()
     |
     = help: Install `apache-airflow-provider-apache-hive>=5.1.0` and use `airflow.providers.apache.hive.macros.hive.closest_ds_partition` instead.
 
-AIR302.py:282:1: AIR302 `airflow.macros.hive.max_partition` is moved into `apache-hive` provider in Airflow 3.0;
+AIR302.py:303:1: AIR302 `airflow.macros.hive.max_partition` is moved into `apache-hive` provider in Airflow 3.0;
     |
-280 | HIVE_QUEUE_PRIORITIES
-281 | closest_ds_partition()
-282 | max_partition()
+301 | HIVE_QUEUE_PRIORITIES
+302 | closest_ds_partition()
+303 | max_partition()
     | ^^^^^^^^^^^^^ AIR302
-283 | HiveCliHook()
-284 | HiveMetastoreHook()
+304 | HiveCliHook()
+305 | HiveMetastoreHook()
     |
     = help: Install `apache-airflow-provider-apache-hive>=5.1.0` and use `airflow.providers.apache.hive.macros.hive.max_partition` instead.
 
-AIR302.py:283:1: AIR302 `airflow.hooks.hive_hooks.HiveCliHook` is moved into `apache-hive` provider in Airflow 3.0;
+AIR302.py:304:1: AIR302 `airflow.hooks.hive_hooks.HiveCliHook` is moved into `apache-hive` provider in Airflow 3.0;
     |
-281 | closest_ds_partition()
-282 | max_partition()
-283 | HiveCliHook()
+302 | closest_ds_partition()
+303 | max_partition()
+304 | HiveCliHook()
     | ^^^^^^^^^^^ AIR302
-284 | HiveMetastoreHook()
-285 | HiveOperator()
+305 | HiveMetastoreHook()
+306 | HiveOperator()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.hooks.hive.HiveCliHook` instead.
 
-AIR302.py:284:1: AIR302 `airflow.hooks.hive_hooks.HiveMetastoreHook` is moved into `apache-hive` provider in Airflow 3.0;
+AIR302.py:305:1: AIR302 `airflow.hooks.hive_hooks.HiveMetastoreHook` is moved into `apache-hive` provider in Airflow 3.0;
     |
-282 | max_partition()
-283 | HiveCliHook()
-284 | HiveMetastoreHook()
+303 | max_partition()
+304 | HiveCliHook()
+305 | HiveMetastoreHook()
     | ^^^^^^^^^^^^^^^^^ AIR302
-285 | HiveOperator()
-286 | HivePartitionSensor()
+306 | HiveOperator()
+307 | HivePartitionSensor()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.hooks.hive.HiveMetastoreHook` instead.
 
-AIR302.py:285:1: AIR302 `airflow.operators.hive_operator.HiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
+AIR302.py:306:1: AIR302 `airflow.operators.hive_operator.HiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
     |
-283 | HiveCliHook()
-284 | HiveMetastoreHook()
-285 | HiveOperator()
+304 | HiveCliHook()
+305 | HiveMetastoreHook()
+306 | HiveOperator()
     | ^^^^^^^^^^^^ AIR302
-286 | HivePartitionSensor()
-287 | HiveServer2Hook()
+307 | HivePartitionSensor()
+308 | HiveServer2Hook()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.operators.hive.HiveOperator` instead.
 
-AIR302.py:286:1: AIR302 `airflow.sensors.hive_partition_sensor.HivePartitionSensor` is moved into `apache-hive` provider in Airflow 3.0;
+AIR302.py:307:1: AIR302 `airflow.sensors.hive_partition_sensor.HivePartitionSensor` is moved into `apache-hive` provider in Airflow 3.0;
     |
-284 | HiveMetastoreHook()
-285 | HiveOperator()
-286 | HivePartitionSensor()
+305 | HiveMetastoreHook()
+306 | HiveOperator()
+307 | HivePartitionSensor()
     | ^^^^^^^^^^^^^^^^^^^ AIR302
-287 | HiveServer2Hook()
-288 | HiveStatsCollectionOperator()
+308 | HiveServer2Hook()
+309 | HiveStatsCollectionOperator()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.sensors.hive_partition.HivePartitionSensor` instead.
 
-AIR302.py:287:1: AIR302 `airflow.hooks.hive_hooks.HiveServer2Hook` is moved into `apache-hive` provider in Airflow 3.0;
+AIR302.py:308:1: AIR302 `airflow.hooks.hive_hooks.HiveServer2Hook` is moved into `apache-hive` provider in Airflow 3.0;
     |
-285 | HiveOperator()
-286 | HivePartitionSensor()
-287 | HiveServer2Hook()
+306 | HiveOperator()
+307 | HivePartitionSensor()
+308 | HiveServer2Hook()
     | ^^^^^^^^^^^^^^^ AIR302
-288 | HiveStatsCollectionOperator()
-289 | HiveToDruidOperator()
+309 | HiveStatsCollectionOperator()
+310 | HiveToDruidOperator()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.hooks.hive.HiveServer2Hook` instead.
 
-AIR302.py:288:1: AIR302 `airflow.operators.hive_stats_operator.HiveStatsCollectionOperator` is moved into `apache-hive` provider in Airflow 3.0;
+AIR302.py:309:1: AIR302 `airflow.operators.hive_stats_operator.HiveStatsCollectionOperator` is moved into `apache-hive` provider in Airflow 3.0;
     |
-286 | HivePartitionSensor()
-287 | HiveServer2Hook()
-288 | HiveStatsCollectionOperator()
+307 | HivePartitionSensor()
+308 | HiveServer2Hook()
+309 | HiveStatsCollectionOperator()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-289 | HiveToDruidOperator()
-290 | HiveToDruidTransfer()
+310 | HiveToDruidOperator()
+311 | HiveToDruidTransfer()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.operators.hive_stats.HiveStatsCollectionOperator` instead.
 
-AIR302.py:289:1: AIR302 `airflow.operators.hive_to_druid.HiveToDruidOperator` is moved into `apache-druid` provider in Airflow 3.0;
+AIR302.py:310:1: AIR302 `airflow.operators.hive_to_druid.HiveToDruidOperator` is moved into `apache-druid` provider in Airflow 3.0;
     |
-287 | HiveServer2Hook()
-288 | HiveStatsCollectionOperator()
-289 | HiveToDruidOperator()
+308 | HiveServer2Hook()
+309 | HiveStatsCollectionOperator()
+310 | HiveToDruidOperator()
     | ^^^^^^^^^^^^^^^^^^^ AIR302
-290 | HiveToDruidTransfer()
-291 | HiveToSambaOperator()
+311 | HiveToDruidTransfer()
+312 | HiveToSambaOperator()
     |
     = help: Install `apache-airflow-provider-apache-druid>=1.0.0` and use `airflow.providers.apache.druid.transfers.hive_to_druid.HiveToDruidOperator` instead.
 
-AIR302.py:290:1: AIR302 `airflow.operators.hive_to_druid.HiveToDruidTransfer` is moved into `apache-druid` provider in Airflow 3.0;
+AIR302.py:311:1: AIR302 `airflow.operators.hive_to_druid.HiveToDruidTransfer` is moved into `apache-druid` provider in Airflow 3.0;
     |
-288 | HiveStatsCollectionOperator()
-289 | HiveToDruidOperator()
-290 | HiveToDruidTransfer()
+309 | HiveStatsCollectionOperator()
+310 | HiveToDruidOperator()
+311 | HiveToDruidTransfer()
     | ^^^^^^^^^^^^^^^^^^^ AIR302
-291 | HiveToSambaOperator()
-292 | S3ToHiveOperator()
+312 | HiveToSambaOperator()
+313 | S3ToHiveOperator()
     |
     = help: Install `apache-airflow-provider-apache-druid>=1.0.0` and use `airflow.providers.apache.druid.transfers.hive_to_druid.HiveToDruidOperator` instead.
 
-AIR302.py:291:1: AIR302 `airflow.operators.hive_to_samba_operator.HiveToSambaOperator` is moved into `apache-hive` provider in Airflow 3.0;
+AIR302.py:312:1: AIR302 `airflow.operators.hive_to_samba_operator.HiveToSambaOperator` is moved into `apache-hive` provider in Airflow 3.0;
     |
-289 | HiveToDruidOperator()
-290 | HiveToDruidTransfer()
-291 | HiveToSambaOperator()
+310 | HiveToDruidOperator()
+311 | HiveToDruidTransfer()
+312 | HiveToSambaOperator()
     | ^^^^^^^^^^^^^^^^^^^ AIR302
-292 | S3ToHiveOperator()
-293 | S3ToHiveTransfer()
+313 | S3ToHiveOperator()
+314 | S3ToHiveTransfer()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `HiveToSambaOperator` instead.
 
-AIR302.py:292:1: AIR302 `airflow.operators.s3_to_hive_operator.S3ToHiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
+AIR302.py:313:1: AIR302 `airflow.operators.s3_to_hive_operator.S3ToHiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
     |
-290 | HiveToDruidTransfer()
-291 | HiveToSambaOperator()
-292 | S3ToHiveOperator()
+311 | HiveToDruidTransfer()
+312 | HiveToSambaOperator()
+313 | S3ToHiveOperator()
     | ^^^^^^^^^^^^^^^^ AIR302
-293 | S3ToHiveTransfer()
-294 | MetastorePartitionSensor()
+314 | S3ToHiveTransfer()
+315 | MetastorePartitionSensor()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.transfers.s3_to_hive.S3ToHiveOperator` instead.
 
-AIR302.py:293:1: AIR302 `airflow.operators.s3_to_hive_operator.S3ToHiveTransfer` is moved into `apache-hive` provider in Airflow 3.0;
+AIR302.py:314:1: AIR302 `airflow.operators.s3_to_hive_operator.S3ToHiveTransfer` is moved into `apache-hive` provider in Airflow 3.0;
     |
-291 | HiveToSambaOperator()
-292 | S3ToHiveOperator()
-293 | S3ToHiveTransfer()
+312 | HiveToSambaOperator()
+313 | S3ToHiveOperator()
+314 | S3ToHiveTransfer()
     | ^^^^^^^^^^^^^^^^ AIR302
-294 | MetastorePartitionSensor()
-295 | NamedHivePartitionSensor()
+315 | MetastorePartitionSensor()
+316 | NamedHivePartitionSensor()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.transfers.s3_to_hive.S3ToHiveOperator` instead.
 
-AIR302.py:294:1: AIR302 `airflow.sensors.metastore_partition_sensor.MetastorePartitionSensor` is moved into `apache-hive` provider in Airflow 3.0;
+AIR302.py:315:1: AIR302 `airflow.sensors.metastore_partition_sensor.MetastorePartitionSensor` is moved into `apache-hive` provider in Airflow 3.0;
     |
-292 | S3ToHiveOperator()
-293 | S3ToHiveTransfer()
-294 | MetastorePartitionSensor()
+313 | S3ToHiveOperator()
+314 | S3ToHiveTransfer()
+315 | MetastorePartitionSensor()
     | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-295 | NamedHivePartitionSensor()
+316 | NamedHivePartitionSensor()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.sensors.metastore_partition.MetastorePartitionSensor` instead.
 
-AIR302.py:295:1: AIR302 `airflow.sensors.named_hive_partition_sensor.NamedHivePartitionSensor` is moved into `apache-hive` provider in Airflow 3.0;
+AIR302.py:316:1: AIR302 `airflow.sensors.named_hive_partition_sensor.NamedHivePartitionSensor` is moved into `apache-hive` provider in Airflow 3.0;
     |
-293 | S3ToHiveTransfer()
-294 | MetastorePartitionSensor()
-295 | NamedHivePartitionSensor()
+314 | S3ToHiveTransfer()
+315 | MetastorePartitionSensor()
+316 | NamedHivePartitionSensor()
     | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-296 |
-297 | # apache-airflow-providers-http
+317 |
+318 | # apache-airflow-providers-http
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.sensors.named_hive_partition.NamedHivePartitionSensor` instead.
 
-AIR302.py:298:1: AIR302 `airflow.hooks.http_hook.HttpHook` is moved into `http` provider in Airflow 3.0;
+AIR302.py:319:1: AIR302 `airflow.hooks.http_hook.HttpHook` is moved into `http` provider in Airflow 3.0;
     |
-297 | # apache-airflow-providers-http
-298 | HttpHook()
+318 | # apache-airflow-providers-http
+319 | HttpHook()
     | ^^^^^^^^ AIR302
-299 | HttpSensor()
-300 | SimpleHttpOperator()
+320 | HttpSensor()
+321 | SimpleHttpOperator()
     |
     = help: Install `apache-airflow-provider-http>=1.0.0` and use `airflow.providers.http.hooks.http.HttpHook` instead.
 
-AIR302.py:299:1: AIR302 `airflow.sensors.http_sensor.HttpSensor` is moved into `http` provider in Airflow 3.0;
+AIR302.py:320:1: AIR302 `airflow.sensors.http_sensor.HttpSensor` is moved into `http` provider in Airflow 3.0;
     |
-297 | # apache-airflow-providers-http
-298 | HttpHook()
-299 | HttpSensor()
+318 | # apache-airflow-providers-http
+319 | HttpHook()
+320 | HttpSensor()
     | ^^^^^^^^^^ AIR302
-300 | SimpleHttpOperator()
+321 | SimpleHttpOperator()
     |
     = help: Install `apache-airflow-provider-http>=1.0.0` and use `airflow.providers.http.sensors.http.HttpSensor` instead.
 
-AIR302.py:300:1: AIR302 `airflow.operators.http_operator.SimpleHttpOperator` is moved into `http` provider in Airflow 3.0;
+AIR302.py:321:1: AIR302 `airflow.operators.http_operator.SimpleHttpOperator` is moved into `http` provider in Airflow 3.0;
     |
-298 | HttpHook()
-299 | HttpSensor()
-300 | SimpleHttpOperator()
+319 | HttpHook()
+320 | HttpSensor()
+321 | SimpleHttpOperator()
     | ^^^^^^^^^^^^^^^^^^ AIR302
-301 |
-302 | # apache-airflow-providers-jdbc
+322 |
+323 | # apache-airflow-providers-jdbc
     |
     = help: Install `apache-airflow-provider-http>=1.0.0` and use `airflow.providers.http.operators.http.SimpleHttpOperator` instead.
 
-AIR302.py:303:1: AIR302 `airflow.hooks.jdbc_hook.jaydebeapi` is moved into `jdbc` provider in Airflow 3.0;
+AIR302.py:324:1: AIR302 `airflow.hooks.jdbc_hook.jaydebeapi` is moved into `jdbc` provider in Airflow 3.0;
     |
-302 | # apache-airflow-providers-jdbc
-303 | jaydebeapi
+323 | # apache-airflow-providers-jdbc
+324 | jaydebeapi
     | ^^^^^^^^^^ AIR302
-304 | JdbcHook()
-305 | JdbcOperator()
+325 | JdbcHook()
+326 | JdbcOperator()
     |
     = help: Install `apache-airflow-provider-jdbc>=1.0.0` and use `airflow.providers.jdbc.hooks.jdbc.jaydebeapi` instead.
 
-AIR302.py:304:1: AIR302 `airflow.hooks.jdbc_hook.JdbcHook` is moved into `jdbc` provider in Airflow 3.0;
+AIR302.py:325:1: AIR302 `airflow.hooks.jdbc_hook.JdbcHook` is moved into `jdbc` provider in Airflow 3.0;
     |
-302 | # apache-airflow-providers-jdbc
-303 | jaydebeapi
-304 | JdbcHook()
+323 | # apache-airflow-providers-jdbc
+324 | jaydebeapi
+325 | JdbcHook()
     | ^^^^^^^^ AIR302
-305 | JdbcOperator()
+326 | JdbcOperator()
     |
     = help: Install `apache-airflow-provider-jdbc>=1.0.0` and use `airflow.providers.jdbc.hooks.jdbc.JdbcHook` instead.
 
-AIR302.py:305:1: AIR302 `airflow.operators.jdbc_operator.JdbcOperator` is moved into `jdbc` provider in Airflow 3.0;
+AIR302.py:326:1: AIR302 `airflow.operators.jdbc_operator.JdbcOperator` is moved into `jdbc` provider in Airflow 3.0;
     |
-303 | jaydebeapi
-304 | JdbcHook()
-305 | JdbcOperator()
+324 | jaydebeapi
+325 | JdbcHook()
+326 | JdbcOperator()
     | ^^^^^^^^^^^^ AIR302
-306 |
-307 | # apache-airflow-providers-fab
+327 |
+328 | # apache-airflow-providers-fab
     |
     = help: Install `apache-airflow-provider-jdbc>=1.0.0` and use `airflow.providers.jdbc.operators.jdbc.JdbcOperator` instead.
 
-AIR302.py:308:1: AIR302 Import path `airflow.api.auth.backend.basic_auth` is moved into `fab` provider in Airflow 3.0;
+AIR302.py:329:1: AIR302 Import path `airflow.api.auth.backend.basic_auth` is moved into `fab` provider in Airflow 3.0;
     |
-307 | # apache-airflow-providers-fab
-308 | basic_auth, kerberos_auth
+328 | # apache-airflow-providers-fab
+329 | basic_auth, kerberos_auth
     | ^^^^^^^^^^ AIR302
-309 | auth_current_user
-310 | backend_kerberos_auth
+330 | auth_current_user
+331 | backend_kerberos_auth
     |
     = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.api.auth.backend.basic_auth` instead.
 
-AIR302.py:308:13: AIR302 Import path `airflow.api.auth.backend.kerberos_auth` is moved into `fab` provider in Airflow 3.0;
+AIR302.py:329:13: AIR302 Import path `airflow.api.auth.backend.kerberos_auth` is moved into `fab` provider in Airflow 3.0;
     |
-307 | # apache-airflow-providers-fab
-308 | basic_auth, kerberos_auth
+328 | # apache-airflow-providers-fab
+329 | basic_auth, kerberos_auth
     |             ^^^^^^^^^^^^^ AIR302
-309 | auth_current_user
-310 | backend_kerberos_auth
+330 | auth_current_user
+331 | backend_kerberos_auth
     |
     = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth` instead.
 
-AIR302.py:309:1: AIR302 Import path `airflow.api.auth.backend.basic_auth` is moved into `fab` provider in Airflow 3.0;
+AIR302.py:330:1: AIR302 Import path `airflow.api.auth.backend.basic_auth` is moved into `fab` provider in Airflow 3.0;
     |
-307 | # apache-airflow-providers-fab
-308 | basic_auth, kerberos_auth
-309 | auth_current_user
+328 | # apache-airflow-providers-fab
+329 | basic_auth, kerberos_auth
+330 | auth_current_user
     | ^^^^^^^^^^^^^^^^^ AIR302
-310 | backend_kerberos_auth
-311 | fab_override
+331 | backend_kerberos_auth
+332 | fab_override
     |
     = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.api.auth.backend.basic_auth` instead.
 
-AIR302.py:310:1: AIR302 Import path `airflow.auth_manager.api.auth.backend.kerberos_auth` is moved into `fab` provider in Airflow 3.0;
+AIR302.py:331:1: AIR302 Import path `airflow.auth_manager.api.auth.backend.kerberos_auth` is moved into `fab` provider in Airflow 3.0;
     |
-308 | basic_auth, kerberos_auth
-309 | auth_current_user
-310 | backend_kerberos_auth
+329 | basic_auth, kerberos_auth
+330 | auth_current_user
+331 | backend_kerberos_auth
     | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-311 | fab_override
-312 | FabAuthManager()
+332 | fab_override
+333 | FabAuthManager()
     |
     = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth` instead.
 
-AIR302.py:311:1: AIR302 Import path `airflow.auth.managers.fab.security_manager.override` is moved into `fab` provider in Airflow 3.0;
+AIR302.py:332:1: AIR302 Import path `airflow.auth.managers.fab.security_manager.override` is moved into `fab` provider in Airflow 3.0;
     |
-309 | auth_current_user
-310 | backend_kerberos_auth
-311 | fab_override
+330 | auth_current_user
+331 | backend_kerberos_auth
+332 | fab_override
     | ^^^^^^^^^^^^ AIR302
-312 | FabAuthManager()
-313 | FabAirflowSecurityManagerOverride()
+333 | FabAuthManager()
+334 | FabAirflowSecurityManagerOverride()
     |
     = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.security_manager.override` instead.
 
-AIR302.py:312:1: AIR302 `airflow.auth.managers.fab.fab_auth_manager.FabAuthManager` is moved into `fab` provider in Airflow 3.0;
+AIR302.py:333:1: AIR302 `airflow.auth.managers.fab.fab_auth_manager.FabAuthManager` is moved into `fab` provider in Airflow 3.0;
     |
-310 | backend_kerberos_auth
-311 | fab_override
-312 | FabAuthManager()
+331 | backend_kerberos_auth
+332 | fab_override
+333 | FabAuthManager()
     | ^^^^^^^^^^^^^^ AIR302
-313 | FabAirflowSecurityManagerOverride()
+334 | FabAirflowSecurityManagerOverride()
     |
     = help: Install `apache-airflow-provider-fab>=1.0.0` and use `airflow.providers.fab.auth_manager.security_manager.FabAuthManager` instead.
 
-AIR302.py:313:1: AIR302 `airflow.www.security.FabAirflowSecurityManagerOverride` is moved into `fab` provider in Airflow 3.0;
+AIR302.py:334:1: AIR302 `airflow.www.security.FabAirflowSecurityManagerOverride` is moved into `fab` provider in Airflow 3.0;
     |
-311 | fab_override
-312 | FabAuthManager()
-313 | FabAirflowSecurityManagerOverride()
+332 | fab_override
+333 | FabAuthManager()
+334 | FabAirflowSecurityManagerOverride()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-314 |
-315 | # apache-airflow-providers-cncf-kubernetes
+335 |
+336 | # apache-airflow-providers-cncf-kubernetes
     |
     = help: Install `apache-airflow-provider-fab>=1.0.0` and use `airflow.providers.fab.auth_manager.security_manager.override.FabAirflowSecurityManagerOverride` instead.
 
-AIR302.py:316:1: AIR302 `airflow.executors.kubernetes_executor_types.ALL_NAMESPACES` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:337:1: AIR302 `airflow.executors.kubernetes_executor_types.ALL_NAMESPACES` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-315 | # apache-airflow-providers-cncf-kubernetes
-316 | ALL_NAMESPACES
+336 | # apache-airflow-providers-cncf-kubernetes
+337 | ALL_NAMESPACES
     | ^^^^^^^^^^^^^^ AIR302
-317 | POD_EXECUTOR_DONE_KEY
-318 | _disable_verify_ssl()
+338 | POD_EXECUTOR_DONE_KEY
+339 | _disable_verify_ssl()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types.ALL_NAMESPACES` instead.
 
-AIR302.py:317:1: AIR302 `airflow.executors.kubernetes_executor_types.POD_EXECUTOR_DONE_KEY` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:338:1: AIR302 `airflow.executors.kubernetes_executor_types.POD_EXECUTOR_DONE_KEY` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-315 | # apache-airflow-providers-cncf-kubernetes
-316 | ALL_NAMESPACES
-317 | POD_EXECUTOR_DONE_KEY
+336 | # apache-airflow-providers-cncf-kubernetes
+337 | ALL_NAMESPACES
+338 | POD_EXECUTOR_DONE_KEY
     | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-318 | _disable_verify_ssl()
-319 | _enable_tcp_keepalive()
+339 | _disable_verify_ssl()
+340 | _enable_tcp_keepalive()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types.POD_EXECUTOR_DONE_KEY` instead.
 
-AIR302.py:318:1: AIR302 `airflow.kubernetes.kube_client._disable_verify_ssl` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:339:1: AIR302 `airflow.kubernetes.kube_client._disable_verify_ssl` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-316 | ALL_NAMESPACES
-317 | POD_EXECUTOR_DONE_KEY
-318 | _disable_verify_ssl()
+337 | ALL_NAMESPACES
+338 | POD_EXECUTOR_DONE_KEY
+339 | _disable_verify_ssl()
     | ^^^^^^^^^^^^^^^^^^^ AIR302
-319 | _enable_tcp_keepalive()
-320 | append_to_pod()
+340 | _enable_tcp_keepalive()
+341 | append_to_pod()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.kubernetes.airflow.providers.cncf.kubernetes.kube_client._disable_verify_ssl` instead.
 
-AIR302.py:319:1: AIR302 `airflow.kubernetes.kube_client._enable_tcp_keepalive` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:340:1: AIR302 `airflow.kubernetes.kube_client._enable_tcp_keepalive` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-317 | POD_EXECUTOR_DONE_KEY
-318 | _disable_verify_ssl()
-319 | _enable_tcp_keepalive()
+338 | POD_EXECUTOR_DONE_KEY
+339 | _disable_verify_ssl()
+340 | _enable_tcp_keepalive()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-320 | append_to_pod()
-321 | annotations_for_logging_task_metadata()
+341 | append_to_pod()
+342 | annotations_for_logging_task_metadata()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.kubernetes.airflow.providers.cncf.kubernetes.kube_client._enable_tcp_keepalive` instead.
 
-AIR302.py:320:1: AIR302 `airflow.kubernetes.k8s_model.append_to_pod` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:341:1: AIR302 `airflow.kubernetes.k8s_model.append_to_pod` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-318 | _disable_verify_ssl()
-319 | _enable_tcp_keepalive()
-320 | append_to_pod()
+339 | _disable_verify_ssl()
+340 | _enable_tcp_keepalive()
+341 | append_to_pod()
     | ^^^^^^^^^^^^^ AIR302
-321 | annotations_for_logging_task_metadata()
-322 | annotations_to_key()
+342 | annotations_for_logging_task_metadata()
+343 | annotations_to_key()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.k8s_model.append_to_pod` instead.
 
-AIR302.py:321:1: AIR302 `airflow.kubernetes.kubernetes_helper_functions.annotations_for_logging_task_metadata` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:342:1: AIR302 `airflow.kubernetes.kubernetes_helper_functions.annotations_for_logging_task_metadata` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-319 | _enable_tcp_keepalive()
-320 | append_to_pod()
-321 | annotations_for_logging_task_metadata()
+340 | _enable_tcp_keepalive()
+341 | append_to_pod()
+342 | annotations_for_logging_task_metadata()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-322 | annotations_to_key()
-323 | create_pod_id()
+343 | annotations_to_key()
+344 | create_pod_id()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.kubernetes_helper_functions.annotations_for_logging_task_metadata` instead.
 
-AIR302.py:322:1: AIR302 `airflow.kubernetes.kubernetes_helper_functions.annotations_to_key` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:343:1: AIR302 `airflow.kubernetes.kubernetes_helper_functions.annotations_to_key` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-320 | append_to_pod()
-321 | annotations_for_logging_task_metadata()
-322 | annotations_to_key()
+341 | append_to_pod()
+342 | annotations_for_logging_task_metadata()
+343 | annotations_to_key()
     | ^^^^^^^^^^^^^^^^^^ AIR302
-323 | create_pod_id()
-324 | datetime_to_label_safe_datestring()
+344 | create_pod_id()
+345 | datetime_to_label_safe_datestring()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.kubernetes_helper_functions.annotations_to_key` instead.
 
-AIR302.py:323:1: AIR302 `airflow.kubernetes.kubernetes_helper_functions.create_pod_id` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:344:1: AIR302 `airflow.kubernetes.kubernetes_helper_functions.create_pod_id` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-321 | annotations_for_logging_task_metadata()
-322 | annotations_to_key()
-323 | create_pod_id()
+342 | annotations_for_logging_task_metadata()
+343 | annotations_to_key()
+344 | create_pod_id()
     | ^^^^^^^^^^^^^ AIR302
-324 | datetime_to_label_safe_datestring()
-325 | extend_object_field()
+345 | datetime_to_label_safe_datestring()
+346 | extend_object_field()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.kubernetes_helper_functions.create_pod_id` instead.
 
-AIR302.py:324:1: AIR302 `airflow.kubernetes.pod_generator.datetime_to_label_safe_datestring` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:345:1: AIR302 `airflow.kubernetes.pod_generator.datetime_to_label_safe_datestring` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-322 | annotations_to_key()
-323 | create_pod_id()
-324 | datetime_to_label_safe_datestring()
+343 | annotations_to_key()
+344 | create_pod_id()
+345 | datetime_to_label_safe_datestring()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-325 | extend_object_field()
-326 | get_logs_task_metadata()
+346 | extend_object_field()
+347 | get_logs_task_metadata()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_generator.datetime_to_label_safe_datestring` instead.
 
-AIR302.py:325:1: AIR302 `airflow.kubernetes.pod_generator.extend_object_field` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:346:1: AIR302 `airflow.kubernetes.pod_generator.extend_object_field` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-323 | create_pod_id()
-324 | datetime_to_label_safe_datestring()
-325 | extend_object_field()
+344 | create_pod_id()
+345 | datetime_to_label_safe_datestring()
+346 | extend_object_field()
     | ^^^^^^^^^^^^^^^^^^^ AIR302
-326 | get_logs_task_metadata()
-327 | label_safe_datestring_to_datetime()
+347 | get_logs_task_metadata()
+348 | label_safe_datestring_to_datetime()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.kubernetes.airflow.providers.cncf.kubernetes.pod_generator.extend_object_field` instead.
 
-AIR302.py:326:1: AIR302 `airflow.kubernetes.kubernetes_helper_functions.get_logs_task_metadata` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:347:1: AIR302 `airflow.kubernetes.kubernetes_helper_functions.get_logs_task_metadata` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-324 | datetime_to_label_safe_datestring()
-325 | extend_object_field()
-326 | get_logs_task_metadata()
+345 | datetime_to_label_safe_datestring()
+346 | extend_object_field()
+347 | get_logs_task_metadata()
     | ^^^^^^^^^^^^^^^^^^^^^^ AIR302
-327 | label_safe_datestring_to_datetime()
-328 | merge_objects()
+348 | label_safe_datestring_to_datetime()
+349 | merge_objects()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.kubernetes_helper_functions.get_logs_task_metadata` instead.
 
-AIR302.py:327:1: AIR302 `airflow.kubernetes.pod_generator.label_safe_datestring_to_datetime` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:348:1: AIR302 `airflow.kubernetes.pod_generator.label_safe_datestring_to_datetime` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-325 | extend_object_field()
-326 | get_logs_task_metadata()
-327 | label_safe_datestring_to_datetime()
+346 | extend_object_field()
+347 | get_logs_task_metadata()
+348 | label_safe_datestring_to_datetime()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-328 | merge_objects()
-329 | Port()
+349 | merge_objects()
+350 | Port()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_generator.label_safe_datestring_to_datetime` instead.
 
-AIR302.py:328:1: AIR302 `airflow.kubernetes.pod_generator.merge_objects` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:349:1: AIR302 `airflow.kubernetes.pod_generator.merge_objects` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-326 | get_logs_task_metadata()
-327 | label_safe_datestring_to_datetime()
-328 | merge_objects()
+347 | get_logs_task_metadata()
+348 | label_safe_datestring_to_datetime()
+349 | merge_objects()
     | ^^^^^^^^^^^^^ AIR302
-329 | Port()
-330 | Resources()
+350 | Port()
+351 | Resources()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_generator.merge_objects` instead.
 
-AIR302.py:329:1: AIR302 `airflow.kubernetes.pod.Port` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:350:1: AIR302 `airflow.kubernetes.pod.Port` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-327 | label_safe_datestring_to_datetime()
-328 | merge_objects()
-329 | Port()
+348 | label_safe_datestring_to_datetime()
+349 | merge_objects()
+350 | Port()
     | ^^^^ AIR302
-330 | Resources()
-331 | PodRuntimeInfoEnv()
+351 | Resources()
+352 | PodRuntimeInfoEnv()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `kubernetes.client.models.V1ContainerPort` instead.
 
-AIR302.py:330:1: AIR302 `airflow.kubernetes.pod.Resources` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:351:1: AIR302 `airflow.kubernetes.pod.Resources` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-328 | merge_objects()
-329 | Port()
-330 | Resources()
+349 | merge_objects()
+350 | Port()
+351 | Resources()
     | ^^^^^^^^^ AIR302
-331 | PodRuntimeInfoEnv()
-332 | PodGeneratorDeprecated()
+352 | PodRuntimeInfoEnv()
+353 | PodGeneratorDeprecated()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `kubernetes.client.models.V1ResourceRequirements` instead.
 
-AIR302.py:331:1: AIR302 `airflow.kubernetes.pod_runtime_info_env.PodRuntimeInfoEnv` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:352:1: AIR302 `airflow.kubernetes.pod_runtime_info_env.PodRuntimeInfoEnv` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-329 | Port()
-330 | Resources()
-331 | PodRuntimeInfoEnv()
+350 | Port()
+351 | Resources()
+352 | PodRuntimeInfoEnv()
     | ^^^^^^^^^^^^^^^^^ AIR302
-332 | PodGeneratorDeprecated()
-333 | Volume()
+353 | PodGeneratorDeprecated()
+354 | Volume()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `kubernetes.client.models.V1EnvVar` instead.
 
-AIR302.py:332:1: AIR302 `airflow.kubernetes.pod_generator.PodGeneratorDeprecated` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:353:1: AIR302 `airflow.kubernetes.pod_generator.PodGeneratorDeprecated` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-330 | Resources()
-331 | PodRuntimeInfoEnv()
-332 | PodGeneratorDeprecated()
+351 | Resources()
+352 | PodRuntimeInfoEnv()
+353 | PodGeneratorDeprecated()
     | ^^^^^^^^^^^^^^^^^^^^^^ AIR302
-333 | Volume()
-334 | VolumeMount()
+354 | Volume()
+355 | VolumeMount()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_generator.PodGenerator` instead.
 
-AIR302.py:333:1: AIR302 `airflow.kubernetes.volume.Volume` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:354:1: AIR302 `airflow.kubernetes.volume.Volume` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-331 | PodRuntimeInfoEnv()
-332 | PodGeneratorDeprecated()
-333 | Volume()
+352 | PodRuntimeInfoEnv()
+353 | PodGeneratorDeprecated()
+354 | Volume()
     | ^^^^^^ AIR302
-334 | VolumeMount()
-335 | Secret()
+355 | VolumeMount()
+356 | Secret()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `kubernetes.client.models.V1Volume` instead.
 
-AIR302.py:334:1: AIR302 `airflow.kubernetes.volume_mount.VolumeMount` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:355:1: AIR302 `airflow.kubernetes.volume_mount.VolumeMount` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-332 | PodGeneratorDeprecated()
-333 | Volume()
-334 | VolumeMount()
+353 | PodGeneratorDeprecated()
+354 | Volume()
+355 | VolumeMount()
     | ^^^^^^^^^^^ AIR302
-335 | Secret()
+356 | Secret()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `kubernetes.client.models.V1VolumeMount` instead.
 
-AIR302.py:335:1: AIR302 `airflow.kubernetes.secret.Secret` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:356:1: AIR302 `airflow.kubernetes.secret.Secret` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-333 | Volume()
-334 | VolumeMount()
-335 | Secret()
+354 | Volume()
+355 | VolumeMount()
+356 | Secret()
     | ^^^^^^ AIR302
-336 |
-337 | add_pod_suffix()
+357 |
+358 | add_pod_suffix()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.secret.Secret` instead.
 
-AIR302.py:337:1: AIR302 `airflow.kubernetes.kubernetes_helper_functions.add_pod_suffix` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:358:1: AIR302 `airflow.kubernetes.kubernetes_helper_functions.add_pod_suffix` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-335 | Secret()
-336 |
-337 | add_pod_suffix()
+356 | Secret()
+357 |
+358 | add_pod_suffix()
     | ^^^^^^^^^^^^^^ AIR302
-338 | add_pod_suffix2()
-339 | get_kube_client()
+359 | add_pod_suffix2()
+360 | get_kube_client()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.kubernetes_helper_functions.add_pod_suffix` instead.
 
-AIR302.py:338:1: AIR302 `airflow.kubernetes.pod_generator.add_pod_suffix` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:359:1: AIR302 `airflow.kubernetes.pod_generator.add_pod_suffix` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-337 | add_pod_suffix()
-338 | add_pod_suffix2()
+358 | add_pod_suffix()
+359 | add_pod_suffix2()
     | ^^^^^^^^^^^^^^^ AIR302
-339 | get_kube_client()
-340 | get_kube_client2()
+360 | get_kube_client()
+361 | get_kube_client2()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.kubernetes_helper_functions.add_pod_suffix` instead.
 
-AIR302.py:339:1: AIR302 `airflow.kubernetes.kube_client.get_kube_client` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:360:1: AIR302 `airflow.kubernetes.kube_client.get_kube_client` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-337 | add_pod_suffix()
-338 | add_pod_suffix2()
-339 | get_kube_client()
+358 | add_pod_suffix()
+359 | add_pod_suffix2()
+360 | get_kube_client()
     | ^^^^^^^^^^^^^^^ AIR302
-340 | get_kube_client2()
-341 | make_safe_label_value()
+361 | get_kube_client2()
+362 | make_safe_label_value()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.kubernetes.airflow.providers.cncf.kubernetes.kube_client.get_kube_client` instead.
 
-AIR302.py:340:1: AIR302 `airflow.kubernetes.pod_launcher_deprecated.get_kube_client` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:361:1: AIR302 `airflow.kubernetes.pod_launcher_deprecated.get_kube_client` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-338 | add_pod_suffix2()
-339 | get_kube_client()
-340 | get_kube_client2()
+359 | add_pod_suffix2()
+360 | get_kube_client()
+361 | get_kube_client2()
     | ^^^^^^^^^^^^^^^^ AIR302
-341 | make_safe_label_value()
-342 | make_safe_label_value2()
+362 | make_safe_label_value()
+363 | make_safe_label_value2()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.kube_client.get_kube_client` instead.
 
-AIR302.py:341:1: AIR302 `airflow.kubernetes.pod_generator.make_safe_label_value` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:362:1: AIR302 `airflow.kubernetes.pod_generator.make_safe_label_value` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-339 | get_kube_client()
-340 | get_kube_client2()
-341 | make_safe_label_value()
+360 | get_kube_client()
+361 | get_kube_client2()
+362 | make_safe_label_value()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-342 | make_safe_label_value2()
-343 | rand_str()
+363 | make_safe_label_value2()
+364 | rand_str()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_generator.make_safe_label_value` instead.
 
-AIR302.py:342:1: AIR302 `airflow.kubernetes.pod_generator_deprecated.make_safe_label_value` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:363:1: AIR302 `airflow.kubernetes.pod_generator_deprecated.make_safe_label_value` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-340 | get_kube_client2()
-341 | make_safe_label_value()
-342 | make_safe_label_value2()
+361 | get_kube_client2()
+362 | make_safe_label_value()
+363 | make_safe_label_value2()
     | ^^^^^^^^^^^^^^^^^^^^^^ AIR302
-343 | rand_str()
-344 | rand_str2()
+364 | rand_str()
+365 | rand_str2()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_generator_deprecated.make_safe_label_value` instead.
 
-AIR302.py:343:1: AIR302 `airflow.kubernetes.kubernetes_helper_functions.rand_str` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:364:1: AIR302 `airflow.kubernetes.kubernetes_helper_functions.rand_str` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-341 | make_safe_label_value()
-342 | make_safe_label_value2()
-343 | rand_str()
+362 | make_safe_label_value()
+363 | make_safe_label_value2()
+364 | rand_str()
     | ^^^^^^^^ AIR302
-344 | rand_str2()
-345 | K8SModel()
+365 | rand_str2()
+366 | K8SModel()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.kubernetes_helper_functions.rand_str` instead.
 
-AIR302.py:344:1: AIR302 `airflow.kubernetes.pod_generator.rand_str` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:365:1: AIR302 `airflow.kubernetes.pod_generator.rand_str` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-342 | make_safe_label_value2()
-343 | rand_str()
-344 | rand_str2()
+363 | make_safe_label_value2()
+364 | rand_str()
+365 | rand_str2()
     | ^^^^^^^^^ AIR302
-345 | K8SModel()
-346 | K8SModel2()
+366 | K8SModel()
+367 | K8SModel2()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.kubernetes_helper_functions.rand_str` instead.
 
-AIR302.py:345:1: AIR302 `airflow.kubernetes.k8s_model.K8SModel` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:366:1: AIR302 `airflow.kubernetes.k8s_model.K8SModel` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-343 | rand_str()
-344 | rand_str2()
-345 | K8SModel()
+364 | rand_str()
+365 | rand_str2()
+366 | K8SModel()
     | ^^^^^^^^ AIR302
-346 | K8SModel2()
-347 | PodLauncher()
+367 | K8SModel2()
+368 | PodLauncher()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.k8s_model.K8SModel` instead.
 
-AIR302.py:347:1: AIR302 `airflow.kubernetes.pod_launcher.PodLauncher` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:368:1: AIR302 `airflow.kubernetes.pod_launcher.PodLauncher` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-345 | K8SModel()
-346 | K8SModel2()
-347 | PodLauncher()
+366 | K8SModel()
+367 | K8SModel2()
+368 | PodLauncher()
     | ^^^^^^^^^^^ AIR302
-348 | PodLauncher2()
-349 | PodStatus()
+369 | PodLauncher2()
+370 | PodStatus()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_launcher.PodLauncher` instead.
 
-AIR302.py:348:1: AIR302 `airflow.kubernetes.pod_launcher_deprecated.PodLauncher` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:369:1: AIR302 `airflow.kubernetes.pod_launcher_deprecated.PodLauncher` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-346 | K8SModel2()
-347 | PodLauncher()
-348 | PodLauncher2()
+367 | K8SModel2()
+368 | PodLauncher()
+369 | PodLauncher2()
     | ^^^^^^^^^^^^ AIR302
-349 | PodStatus()
-350 | PodStatus2()
+370 | PodStatus()
+371 | PodStatus2()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_launcher_deprecated.PodLauncher` instead.
 
-AIR302.py:349:1: AIR302 `airflow.kubernetes.pod_launcher.PodStatus` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:370:1: AIR302 `airflow.kubernetes.pod_launcher.PodStatus` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-347 | PodLauncher()
-348 | PodLauncher2()
-349 | PodStatus()
+368 | PodLauncher()
+369 | PodLauncher2()
+370 | PodStatus()
     | ^^^^^^^^^ AIR302
-350 | PodStatus2()
-351 | PodDefaults()
+371 | PodStatus2()
+372 | PodDefaults()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_launcher.PodStatus` instead.
 
-AIR302.py:350:1: AIR302 `airflow.kubernetes.pod_launcher_deprecated.PodStatus` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:371:1: AIR302 `airflow.kubernetes.pod_launcher_deprecated.PodStatus` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-348 | PodLauncher2()
-349 | PodStatus()
-350 | PodStatus2()
+369 | PodLauncher2()
+370 | PodStatus()
+371 | PodStatus2()
     | ^^^^^^^^^^ AIR302
-351 | PodDefaults()
-352 | PodDefaults2()
+372 | PodDefaults()
+373 | PodDefaults2()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_launcher_deprecated.PodStatus` instead.
 
-AIR302.py:351:1: AIR302 `airflow.kubernetes.pod_generator.PodDefaults` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:372:1: AIR302 `airflow.kubernetes.pod_generator.PodDefaults` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-349 | PodStatus()
-350 | PodStatus2()
-351 | PodDefaults()
+370 | PodStatus()
+371 | PodStatus2()
+372 | PodDefaults()
     | ^^^^^^^^^^^ AIR302
-352 | PodDefaults2()
-353 | PodDefaults3()
+373 | PodDefaults2()
+374 | PodDefaults3()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_generator_deprecated.PodDefaults` instead.
 
-AIR302.py:352:1: AIR302 `airflow.kubernetes.pod_launcher_deprecated.PodDefaults` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:373:1: AIR302 `airflow.kubernetes.pod_launcher_deprecated.PodDefaults` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-350 | PodStatus2()
-351 | PodDefaults()
-352 | PodDefaults2()
+371 | PodStatus2()
+372 | PodDefaults()
+373 | PodDefaults2()
     | ^^^^^^^^^^^^ AIR302
-353 | PodDefaults3()
-354 | PodGenerator()
+374 | PodDefaults3()
+375 | PodGenerator()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_generator_deprecated.PodDefaults` instead.
 
-AIR302.py:353:1: AIR302 `airflow.kubernetes.pod_generator_deprecated.PodDefaults` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:374:1: AIR302 `airflow.kubernetes.pod_generator_deprecated.PodDefaults` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-351 | PodDefaults()
-352 | PodDefaults2()
-353 | PodDefaults3()
+372 | PodDefaults()
+373 | PodDefaults2()
+374 | PodDefaults3()
     | ^^^^^^^^^^^^ AIR302
-354 | PodGenerator()
-355 | PodGenerator2()
+375 | PodGenerator()
+376 | PodGenerator2()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_generator_deprecated.PodDefaults` instead.
 
-AIR302.py:354:1: AIR302 `airflow.kubernetes.pod_generator.PodGenerator` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:375:1: AIR302 `airflow.kubernetes.pod_generator.PodGenerator` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-352 | PodDefaults2()
-353 | PodDefaults3()
-354 | PodGenerator()
+373 | PodDefaults2()
+374 | PodDefaults3()
+375 | PodGenerator()
     | ^^^^^^^^^^^^ AIR302
-355 | PodGenerator2()
+376 | PodGenerator2()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_generator.PodGenerator` instead.
 
-AIR302.py:355:1: AIR302 `airflow.kubernetes.pod_generator_deprecated.PodGenerator` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302.py:376:1: AIR302 `airflow.kubernetes.pod_generator_deprecated.PodGenerator` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-353 | PodDefaults3()
-354 | PodGenerator()
-355 | PodGenerator2()
+374 | PodDefaults3()
+375 | PodGenerator()
+376 | PodGenerator2()
     | ^^^^^^^^^^^^^ AIR302
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_generator_deprecated.PodGenerator` instead.
 
-AIR302.py:359:1: AIR302 `airflow.hooks.mssql_hook.MsSqlHook` is moved into `microsoft-mssql` provider in Airflow 3.0;
+AIR302.py:380:1: AIR302 `airflow.hooks.mssql_hook.MsSqlHook` is moved into `microsoft-mssql` provider in Airflow 3.0;
     |
-358 | # apache-airflow-providers-microsoft-mssql
-359 | MsSqlHook()
+379 | # apache-airflow-providers-microsoft-mssql
+380 | MsSqlHook()
     | ^^^^^^^^^ AIR302
-360 | MsSqlOperator()
-361 | MsSqlToHiveOperator()
+381 | MsSqlOperator()
+382 | MsSqlToHiveOperator()
     |
     = help: Install `apache-airflow-provider-microsoft-mssql>=1.0.0` and use `airflow.providers.microsoft.mssql.hooks.mssql.MsSqlHook` instead.
 
-AIR302.py:360:1: AIR302 `airflow.operators.mssql_operator.MsSqlOperator` is moved into `microsoft-mssql` provider in Airflow 3.0;
+AIR302.py:381:1: AIR302 `airflow.operators.mssql_operator.MsSqlOperator` is moved into `microsoft-mssql` provider in Airflow 3.0;
     |
-358 | # apache-airflow-providers-microsoft-mssql
-359 | MsSqlHook()
-360 | MsSqlOperator()
+379 | # apache-airflow-providers-microsoft-mssql
+380 | MsSqlHook()
+381 | MsSqlOperator()
     | ^^^^^^^^^^^^^ AIR302
-361 | MsSqlToHiveOperator()
-362 | MsSqlToHiveTransfer()
+382 | MsSqlToHiveOperator()
+383 | MsSqlToHiveTransfer()
     |
     = help: Install `apache-airflow-provider-microsoft-mssql>=1.0.0` and use `airflow.providers.microsoft.mssql.operators.mssql.MsSqlOperator` instead.
 
-AIR302.py:361:1: AIR302 `airflow.operators.mssql_to_hive.MsSqlToHiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
+AIR302.py:382:1: AIR302 `airflow.operators.mssql_to_hive.MsSqlToHiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
     |
-359 | MsSqlHook()
-360 | MsSqlOperator()
-361 | MsSqlToHiveOperator()
+380 | MsSqlHook()
+381 | MsSqlOperator()
+382 | MsSqlToHiveOperator()
     | ^^^^^^^^^^^^^^^^^^^ AIR302
-362 | MsSqlToHiveTransfer()
+383 | MsSqlToHiveTransfer()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.transfers.mssql_to_hive.MsSqlToHiveOperator` instead.
 
-AIR302.py:362:1: AIR302 `airflow.operators.mssql_to_hive.MsSqlToHiveTransfer` is moved into `apache-hive` provider in Airflow 3.0;
+AIR302.py:383:1: AIR302 `airflow.operators.mssql_to_hive.MsSqlToHiveTransfer` is moved into `apache-hive` provider in Airflow 3.0;
     |
-360 | MsSqlOperator()
-361 | MsSqlToHiveOperator()
-362 | MsSqlToHiveTransfer()
+381 | MsSqlOperator()
+382 | MsSqlToHiveOperator()
+383 | MsSqlToHiveTransfer()
     | ^^^^^^^^^^^^^^^^^^^ AIR302
-363 |
-364 | # apache-airflow-providers-mysql
+384 |
+385 | # apache-airflow-providers-mysql
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.transfers.mssql_to_hive.MsSqlToHiveOperator` instead.
 
-AIR302.py:365:1: AIR302 `airflow.operators.hive_to_mysql.HiveToMySqlOperator` is moved into `apache-hive` provider in Airflow 3.0;
+AIR302.py:386:1: AIR302 `airflow.operators.hive_to_mysql.HiveToMySqlOperator` is moved into `apache-hive` provider in Airflow 3.0;
     |
-364 | # apache-airflow-providers-mysql
-365 | HiveToMySqlOperator()
+385 | # apache-airflow-providers-mysql
+386 | HiveToMySqlOperator()
     | ^^^^^^^^^^^^^^^^^^^ AIR302
-366 | HiveToMySqlTransfer()
-367 | MySqlHook()
+387 | HiveToMySqlTransfer()
+388 | MySqlHook()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.transfers.hive_to_mysql.HiveToMySqlOperator` instead.
 
-AIR302.py:366:1: AIR302 `airflow.operators.hive_to_mysql.HiveToMySqlTransfer` is moved into `apache-hive` provider in Airflow 3.0;
+AIR302.py:387:1: AIR302 `airflow.operators.hive_to_mysql.HiveToMySqlTransfer` is moved into `apache-hive` provider in Airflow 3.0;
     |
-364 | # apache-airflow-providers-mysql
-365 | HiveToMySqlOperator()
-366 | HiveToMySqlTransfer()
+385 | # apache-airflow-providers-mysql
+386 | HiveToMySqlOperator()
+387 | HiveToMySqlTransfer()
     | ^^^^^^^^^^^^^^^^^^^ AIR302
-367 | MySqlHook()
-368 | MySqlOperator()
+388 | MySqlHook()
+389 | MySqlOperator()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.transfers.hive_to_mysql.HiveToMySqlOperator` instead.
 
-AIR302.py:367:1: AIR302 `airflow.hooks.mysql_hook.MySqlHook` is moved into `mysql` provider in Airflow 3.0;
+AIR302.py:388:1: AIR302 `airflow.hooks.mysql_hook.MySqlHook` is moved into `mysql` provider in Airflow 3.0;
     |
-365 | HiveToMySqlOperator()
-366 | HiveToMySqlTransfer()
-367 | MySqlHook()
+386 | HiveToMySqlOperator()
+387 | HiveToMySqlTransfer()
+388 | MySqlHook()
     | ^^^^^^^^^ AIR302
-368 | MySqlOperator()
-369 | MySqlToHiveOperator()
+389 | MySqlOperator()
+390 | MySqlToHiveOperator()
     |
     = help: Install `apache-airflow-provider-mysql>=1.0.0` and use `airflow.providers.mysql.hooks.mysql.MySqlHook` instead.
 
-AIR302.py:368:1: AIR302 `airflow.operators.mysql_operator.MySqlOperator` is moved into `mysql` provider in Airflow 3.0;
+AIR302.py:389:1: AIR302 `airflow.operators.mysql_operator.MySqlOperator` is moved into `mysql` provider in Airflow 3.0;
     |
-366 | HiveToMySqlTransfer()
-367 | MySqlHook()
-368 | MySqlOperator()
+387 | HiveToMySqlTransfer()
+388 | MySqlHook()
+389 | MySqlOperator()
     | ^^^^^^^^^^^^^ AIR302
-369 | MySqlToHiveOperator()
-370 | MySqlToHiveTransfer()
+390 | MySqlToHiveOperator()
+391 | MySqlToHiveTransfer()
     |
     = help: Install `apache-airflow-provider-mysql>=1.0.0` and use `airflow.providers.mysql.operators.mysql.MySqlOperator` instead.
 
-AIR302.py:369:1: AIR302 `airflow.operators.mysql_to_hive.MySqlToHiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
+AIR302.py:390:1: AIR302 `airflow.operators.mysql_to_hive.MySqlToHiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
     |
-367 | MySqlHook()
-368 | MySqlOperator()
-369 | MySqlToHiveOperator()
+388 | MySqlHook()
+389 | MySqlOperator()
+390 | MySqlToHiveOperator()
     | ^^^^^^^^^^^^^^^^^^^ AIR302
-370 | MySqlToHiveTransfer()
-371 | PrestoToMySqlOperator()
+391 | MySqlToHiveTransfer()
+392 | PrestoToMySqlOperator()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.transfers.mysql_to_hive.MySqlToHiveOperator` instead.
 
-AIR302.py:370:1: AIR302 `airflow.operators.mysql_to_hive.MySqlToHiveTransfer` is moved into `apache-hive` provider in Airflow 3.0;
+AIR302.py:391:1: AIR302 `airflow.operators.mysql_to_hive.MySqlToHiveTransfer` is moved into `apache-hive` provider in Airflow 3.0;
     |
-368 | MySqlOperator()
-369 | MySqlToHiveOperator()
-370 | MySqlToHiveTransfer()
+389 | MySqlOperator()
+390 | MySqlToHiveOperator()
+391 | MySqlToHiveTransfer()
     | ^^^^^^^^^^^^^^^^^^^ AIR302
-371 | PrestoToMySqlOperator()
-372 | PrestoToMySqlTransfer()
+392 | PrestoToMySqlOperator()
+393 | PrestoToMySqlTransfer()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.transfers.mysql_to_hive.MySqlToHiveOperator` instead.
 
-AIR302.py:371:1: AIR302 `airflow.operators.presto_to_mysql.PrestoToMySqlOperator` is moved into `mysql` provider in Airflow 3.0;
+AIR302.py:392:1: AIR302 `airflow.operators.presto_to_mysql.PrestoToMySqlOperator` is moved into `mysql` provider in Airflow 3.0;
     |
-369 | MySqlToHiveOperator()
-370 | MySqlToHiveTransfer()
-371 | PrestoToMySqlOperator()
+390 | MySqlToHiveOperator()
+391 | MySqlToHiveTransfer()
+392 | PrestoToMySqlOperator()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-372 | PrestoToMySqlTransfer()
+393 | PrestoToMySqlTransfer()
     |
     = help: Install `apache-airflow-provider-mysql>=1.0.0` and use `airflow.providers.mysql.transfers.presto_to_mysql.PrestoToMySqlOperator` instead.
 
-AIR302.py:372:1: AIR302 `airflow.operators.presto_to_mysql.PrestoToMySqlTransfer` is moved into `mysql` provider in Airflow 3.0;
+AIR302.py:393:1: AIR302 `airflow.operators.presto_to_mysql.PrestoToMySqlTransfer` is moved into `mysql` provider in Airflow 3.0;
     |
-370 | MySqlToHiveTransfer()
-371 | PrestoToMySqlOperator()
-372 | PrestoToMySqlTransfer()
+391 | MySqlToHiveTransfer()
+392 | PrestoToMySqlOperator()
+393 | PrestoToMySqlTransfer()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-373 |
-374 | # apache-airflow-providers-oracle
+394 |
+395 | # apache-airflow-providers-oracle
     |
     = help: Install `apache-airflow-provider-mysql>=1.0.0` and use `airflow.providers.mysql.transfers.presto_to_mysql.PrestoToMySqlOperator` instead.
 
-AIR302.py:375:1: AIR302 `airflow.hooks.oracle_hook.OracleHook` is moved into `oracle` provider in Airflow 3.0;
+AIR302.py:396:1: AIR302 `airflow.hooks.oracle_hook.OracleHook` is moved into `oracle` provider in Airflow 3.0;
     |
-374 | # apache-airflow-providers-oracle
-375 | OracleHook()
+395 | # apache-airflow-providers-oracle
+396 | OracleHook()
     | ^^^^^^^^^^ AIR302
-376 | OracleOperator()
+397 | OracleOperator()
     |
     = help: Install `apache-airflow-provider-oracle>=1.0.0` and use `airflow.providers.oracle.hooks.oracle.OracleHook` instead.
 
-AIR302.py:376:1: AIR302 `airflow.operators.oracle_operator.OracleOperator` is moved into `oracle` provider in Airflow 3.0;
+AIR302.py:397:1: AIR302 `airflow.operators.oracle_operator.OracleOperator` is moved into `oracle` provider in Airflow 3.0;
     |
-374 | # apache-airflow-providers-oracle
-375 | OracleHook()
-376 | OracleOperator()
+395 | # apache-airflow-providers-oracle
+396 | OracleHook()
+397 | OracleOperator()
     | ^^^^^^^^^^^^^^ AIR302
-377 |
-378 | # apache-airflow-providers-papermill
+398 |
+399 | # apache-airflow-providers-papermill
     |
     = help: Install `apache-airflow-provider-oracle>=1.0.0` and use `airflow.providers.oracle.operators.oracle.OracleOperator` instead.
 
-AIR302.py:379:1: AIR302 `airflow.operators.papermill_operator.PapermillOperator` is moved into `papermill` provider in Airflow 3.0;
+AIR302.py:400:1: AIR302 `airflow.operators.papermill_operator.PapermillOperator` is moved into `papermill` provider in Airflow 3.0;
     |
-378 | # apache-airflow-providers-papermill
-379 | PapermillOperator()
+399 | # apache-airflow-providers-papermill
+400 | PapermillOperator()
     | ^^^^^^^^^^^^^^^^^ AIR302
-380 |
-381 | # apache-airflow-providers-apache-pig
+401 |
+402 | # apache-airflow-providers-apache-pig
     |
     = help: Install `apache-airflow-provider-papermill>=1.0.0` and use `airflow.providers.papermill.operators.papermill.PapermillOperator` instead.
 
-AIR302.py:382:1: AIR302 `airflow.hooks.pig_hook.PigCliHook` is moved into `apache-pig` provider in Airflow 3.0;
+AIR302.py:403:1: AIR302 `airflow.hooks.pig_hook.PigCliHook` is moved into `apache-pig` provider in Airflow 3.0;
     |
-381 | # apache-airflow-providers-apache-pig
-382 | PigCliHook()
+402 | # apache-airflow-providers-apache-pig
+403 | PigCliHook()
     | ^^^^^^^^^^ AIR302
-383 | PigOperator()
+404 | PigOperator()
     |
     = help: Install `apache-airflow-provider-apache-pig>=1.0.0` and use `airflow.providers.apache.pig.hooks.pig.PigCliHook` instead.
 
-AIR302.py:383:1: AIR302 `airflow.operators.pig_operator.PigOperator` is moved into `apache-pig` provider in Airflow 3.0;
+AIR302.py:404:1: AIR302 `airflow.operators.pig_operator.PigOperator` is moved into `apache-pig` provider in Airflow 3.0;
     |
-381 | # apache-airflow-providers-apache-pig
-382 | PigCliHook()
-383 | PigOperator()
+402 | # apache-airflow-providers-apache-pig
+403 | PigCliHook()
+404 | PigOperator()
     | ^^^^^^^^^^^ AIR302
-384 |
-385 | # apache-airflow-providers-postgres
+405 |
+406 | # apache-airflow-providers-postgres
     |
     = help: Install `apache-airflow-provider-apache-pig>=1.0.0` and use `airflow.providers.apache.pig.operators.pig.PigOperator` instead.
 
-AIR302.py:386:1: AIR302 `airflow.operators.postgres_operator.Mapping` is moved into `postgres` provider in Airflow 3.0;
+AIR302.py:407:1: AIR302 `airflow.operators.postgres_operator.Mapping` is moved into `postgres` provider in Airflow 3.0;
     |
-385 | # apache-airflow-providers-postgres
-386 | Mapping
+406 | # apache-airflow-providers-postgres
+407 | Mapping
     | ^^^^^^^ AIR302
-387 | PostgresHook()
-388 | PostgresOperator()
+408 | PostgresHook()
+409 | PostgresOperator()
     |
     = help: Install `apache-airflow-provider-postgres>=1.0.0` and use `airflow.providers.postgres.operators.postgres.Mapping` instead.
 
-AIR302.py:387:1: AIR302 `airflow.hooks.postgres_hook.PostgresHook` is moved into `postgres` provider in Airflow 3.0;
+AIR302.py:408:1: AIR302 `airflow.hooks.postgres_hook.PostgresHook` is moved into `postgres` provider in Airflow 3.0;
     |
-385 | # apache-airflow-providers-postgres
-386 | Mapping
-387 | PostgresHook()
+406 | # apache-airflow-providers-postgres
+407 | Mapping
+408 | PostgresHook()
     | ^^^^^^^^^^^^ AIR302
-388 | PostgresOperator()
+409 | PostgresOperator()
     |
     = help: Install `apache-airflow-provider-postgres>=1.0.0` and use `airflow.providers.postgres.hooks.postgres.PostgresHook` instead.
 
-AIR302.py:388:1: AIR302 `airflow.operators.postgres_operator.PostgresOperator` is moved into `postgres` provider in Airflow 3.0;
+AIR302.py:409:1: AIR302 `airflow.operators.postgres_operator.PostgresOperator` is moved into `postgres` provider in Airflow 3.0;
     |
-386 | Mapping
-387 | PostgresHook()
-388 | PostgresOperator()
+407 | Mapping
+408 | PostgresHook()
+409 | PostgresOperator()
     | ^^^^^^^^^^^^^^^^ AIR302
-389 |
-390 | # apache-airflow-providers-presto
+410 |
+411 | # apache-airflow-providers-presto
     |
     = help: Install `apache-airflow-provider-postgres>=1.0.0` and use `airflow.providers.postgres.operators.postgres.PostgresOperator` instead.
 
-AIR302.py:391:1: AIR302 `airflow.hooks.presto_hook.PrestoHook` is moved into `presto` provider in Airflow 3.0;
+AIR302.py:412:1: AIR302 `airflow.hooks.presto_hook.PrestoHook` is moved into `presto` provider in Airflow 3.0;
     |
-390 | # apache-airflow-providers-presto
-391 | PrestoHook()
+411 | # apache-airflow-providers-presto
+412 | PrestoHook()
     | ^^^^^^^^^^ AIR302
-392 |
-393 | # apache-airflow-providers-samba
+413 |
+414 | # apache-airflow-providers-samba
     |
     = help: Install `apache-airflow-provider-presto>=1.0.0` and use `airflow.providers.presto.hooks.presto.PrestoHook` instead.
 
-AIR302.py:394:1: AIR302 `airflow.hooks.samba_hook.SambaHook` is moved into `samba` provider in Airflow 3.0;
+AIR302.py:415:1: AIR302 `airflow.hooks.samba_hook.SambaHook` is moved into `samba` provider in Airflow 3.0;
     |
-393 | # apache-airflow-providers-samba
-394 | SambaHook()
+414 | # apache-airflow-providers-samba
+415 | SambaHook()
     | ^^^^^^^^^ AIR302
-395 |
-396 | # apache-airflow-providers-slack
+416 |
+417 | # apache-airflow-providers-slack
     |
     = help: Install `apache-airflow-provider-samba>=1.0.0` and use `airflow.providers.samba.hooks.samba.SambaHook` instead.
 
-AIR302.py:397:1: AIR302 `airflow.hooks.slack_hook.SlackHook` is moved into `slack` provider in Airflow 3.0;
+AIR302.py:418:1: AIR302 `airflow.hooks.slack_hook.SlackHook` is moved into `slack` provider in Airflow 3.0;
     |
-396 | # apache-airflow-providers-slack
-397 | SlackHook()
+417 | # apache-airflow-providers-slack
+418 | SlackHook()
     | ^^^^^^^^^ AIR302
-398 | SlackAPIOperator()
-399 | SlackAPIPostOperator()
+419 | SlackAPIOperator()
+420 | SlackAPIPostOperator()
     |
     = help: Install `apache-airflow-provider-slack>=1.0.0` and use `airflow.providers.slack.hooks.slack.SlackHook` instead.
 
-AIR302.py:398:1: AIR302 `airflow.operators.slack_operator.SlackAPIOperator` is moved into `slack` provider in Airflow 3.0;
+AIR302.py:419:1: AIR302 `airflow.operators.slack_operator.SlackAPIOperator` is moved into `slack` provider in Airflow 3.0;
     |
-396 | # apache-airflow-providers-slack
-397 | SlackHook()
-398 | SlackAPIOperator()
+417 | # apache-airflow-providers-slack
+418 | SlackHook()
+419 | SlackAPIOperator()
     | ^^^^^^^^^^^^^^^^ AIR302
-399 | SlackAPIPostOperator()
+420 | SlackAPIPostOperator()
     |
     = help: Install `apache-airflow-provider-slack>=1.0.0` and use `airflow.providers.slack.operators.slack.SlackAPIOperator` instead.
 
-AIR302.py:399:1: AIR302 `airflow.operators.slack_operator.SlackAPIPostOperator` is moved into `slack` provider in Airflow 3.0;
+AIR302.py:420:1: AIR302 `airflow.operators.slack_operator.SlackAPIPostOperator` is moved into `slack` provider in Airflow 3.0;
     |
-397 | SlackHook()
-398 | SlackAPIOperator()
-399 | SlackAPIPostOperator()
+418 | SlackHook()
+419 | SlackAPIOperator()
+420 | SlackAPIPostOperator()
     | ^^^^^^^^^^^^^^^^^^^^ AIR302
-400 |
-401 | # apache-airflow-providers-sqlite
+421 |
+422 | # apache-airflow-providers-sqlite
     |
     = help: Install `apache-airflow-provider-slack>=1.0.0` and use `airflow.providers.slack.operators.slack.SlackAPIPostOperator` instead.
 
-AIR302.py:402:1: AIR302 `airflow.hooks.sqlite_hook.SqliteHook` is moved into `sqlite` provider in Airflow 3.0;
+AIR302.py:423:1: AIR302 `airflow.hooks.sqlite_hook.SqliteHook` is moved into `sqlite` provider in Airflow 3.0;
     |
-401 | # apache-airflow-providers-sqlite
-402 | SqliteHook()
+422 | # apache-airflow-providers-sqlite
+423 | SqliteHook()
     | ^^^^^^^^^^ AIR302
-403 | SqliteOperator()
+424 | SqliteOperator()
     |
     = help: Install `apache-airflow-provider-sqlite>=1.0.0` and use `airflow.providers.sqlite.hooks.sqlite.SqliteHook` instead.
 
-AIR302.py:403:1: AIR302 `airflow.operators.sqlite_operator.SqliteOperator` is moved into `sqlite` provider in Airflow 3.0;
+AIR302.py:424:1: AIR302 `airflow.operators.sqlite_operator.SqliteOperator` is moved into `sqlite` provider in Airflow 3.0;
     |
-401 | # apache-airflow-providers-sqlite
-402 | SqliteHook()
-403 | SqliteOperator()
+422 | # apache-airflow-providers-sqlite
+423 | SqliteHook()
+424 | SqliteOperator()
     | ^^^^^^^^^^^^^^ AIR302
-404 |
-405 | # apache-airflow-providers-zendesk
+425 |
+426 | # apache-airflow-providers-zendesk
     |
     = help: Install `apache-airflow-provider-sqlite>=1.0.0` and use `airflow.providers.sqlite.operators.sqlite.SqliteOperator` instead.
 
-AIR302.py:406:1: AIR302 `airflow.hooks.zendesk_hook.ZendeskHook` is moved into `zendesk` provider in Airflow 3.0;
+AIR302.py:427:1: AIR302 `airflow.hooks.zendesk_hook.ZendeskHook` is moved into `zendesk` provider in Airflow 3.0;
     |
-405 | # apache-airflow-providers-zendesk
-406 | ZendeskHook()
+426 | # apache-airflow-providers-zendesk
+427 | ZendeskHook()
     | ^^^^^^^^^^^ AIR302
-407 |
-408 | # apache-airflow-providers-standard
+428 |
+429 | # apache-airflow-providers-smtp
     |
     = help: Install `apache-airflow-provider-zendesk>=1.0.0` and use `airflow.providers.zendesk.hooks.zendesk.ZendeskHook` instead.
 
-AIR302.py:409:1: AIR302 `airflow.sensors.filesystem.FileSensor` is moved into `standard` provider in Airflow 3.0;
+AIR302.py:430:1: AIR302 `airflow.operators.email_operator.EmailOperator` is moved into `smtp` provider in Airflow 3.0;
     |
-408 | # apache-airflow-providers-standard
-409 | FileSensor()
-    | ^^^^^^^^^^ AIR302
-410 | TriggerDagRunOperator()
-411 | ExternalTaskMarker(), ExternalTaskSensor()
-    |
-    = help: Install `apache-airflow-provider-standard>=0.0.2` and use `airflow.providers.standard.sensors.filesystem.FileSensor` instead.
-
-AIR302.py:410:1: AIR302 `airflow.operators.trigger_dagrun.TriggerDagRunOperator` is moved into `standard` provider in Airflow 3.0;
-    |
-408 | # apache-airflow-providers-standard
-409 | FileSensor()
-410 | TriggerDagRunOperator()
-    | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-411 | ExternalTaskMarker(), ExternalTaskSensor()
-412 | BranchDateTimeOperator()
-    |
-    = help: Install `apache-airflow-provider-standard>=0.0.2` and use `airflow.providers.standard.operators.trigger_dagrun.TriggerDagRunOperator` instead.
-
-AIR302.py:411:1: AIR302 `airflow.sensors.external_task.ExternalTaskMarker` is moved into `standard` provider in Airflow 3.0;
-    |
-409 | FileSensor()
-410 | TriggerDagRunOperator()
-411 | ExternalTaskMarker(), ExternalTaskSensor()
-    | ^^^^^^^^^^^^^^^^^^ AIR302
-412 | BranchDateTimeOperator()
-413 | BranchDayOfWeekOperator()
-    |
-    = help: Install `apache-airflow-provider-standard>=0.0.3` and use `airflow.providers.standard.sensors.external_task.ExternalTaskMarker` instead.
-
-AIR302.py:411:23: AIR302 `airflow.sensors.external_task.ExternalTaskSensor` is moved into `standard` provider in Airflow 3.0;
-    |
-409 | FileSensor()
-410 | TriggerDagRunOperator()
-411 | ExternalTaskMarker(), ExternalTaskSensor()
-    |                       ^^^^^^^^^^^^^^^^^^ AIR302
-412 | BranchDateTimeOperator()
-413 | BranchDayOfWeekOperator()
-    |
-    = help: Install `apache-airflow-provider-standard>=0.0.3` and use `airflow.providers.standard.sensors.external_task.ExternalTaskSensor` instead.
-
-AIR302.py:412:1: AIR302 Import path `airflow.operators.datetime` is moved into `standard` provider in Airflow 3.0;
-    |
-410 | TriggerDagRunOperator()
-411 | ExternalTaskMarker(), ExternalTaskSensor()
-412 | BranchDateTimeOperator()
-    | ^^^^^^^^^^^^^^^^^^^^^^ AIR302
-413 | BranchDayOfWeekOperator()
-414 | DateTimeSensor()
-    |
-    = help: Install `apache-airflow-provider-standard>=0.0.1` and import from `airflow.providers.standard.time.operators.datetime` instead.
-
-AIR302.py:413:1: AIR302 Import path `airflow.operators.weekday` is moved into `standard` provider in Airflow 3.0;
-    |
-411 | ExternalTaskMarker(), ExternalTaskSensor()
-412 | BranchDateTimeOperator()
-413 | BranchDayOfWeekOperator()
-    | ^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-414 | DateTimeSensor()
-415 | TimeSensor()
-    |
-    = help: Install `apache-airflow-provider-standard>=0.0.1` and import from `airflow.providers.standard.time.operators.weekday` instead.
-
-AIR302.py:414:1: AIR302 Import path `airflow.sensors.date_time` is moved into `standard` provider in Airflow 3.0;
-    |
-412 | BranchDateTimeOperator()
-413 | BranchDayOfWeekOperator()
-414 | DateTimeSensor()
-    | ^^^^^^^^^^^^^^ AIR302
-415 | TimeSensor()
-416 | TimeDeltaSensor()
-    |
-    = help: Install `apache-airflow-provider-standard>=0.0.1` and import from `airflow.providers.standard.time.sensors.date_time` instead.
-
-AIR302.py:415:1: AIR302 Import path `airflow.sensors.time_sensor` is moved into `standard` provider in Airflow 3.0;
-    |
-413 | BranchDayOfWeekOperator()
-414 | DateTimeSensor()
-415 | TimeSensor()
-    | ^^^^^^^^^^ AIR302
-416 | TimeDeltaSensor()
-417 | DayOfWeekSensor()
-    |
-    = help: Install `apache-airflow-provider-standard>=0.0.1` and import from `airflow.providers.standard.time.sensors.time` instead.
-
-AIR302.py:416:1: AIR302 Import path `airflow.sensors.time_delta` is moved into `standard` provider in Airflow 3.0;
-    |
-414 | DateTimeSensor()
-415 | TimeSensor()
-416 | TimeDeltaSensor()
-    | ^^^^^^^^^^^^^^^ AIR302
-417 | DayOfWeekSensor()
-418 | FSHook()
-    |
-    = help: Install `apache-airflow-provider-standard>=0.0.1` and import from `airflow.providers.standard.time.sensors.time_delta` instead.
-
-AIR302.py:417:1: AIR302 Import path `airflow.sensors.weekday` is moved into `standard` provider in Airflow 3.0;
-    |
-415 | TimeSensor()
-416 | TimeDeltaSensor()
-417 | DayOfWeekSensor()
-    | ^^^^^^^^^^^^^^^ AIR302
-418 | FSHook()
-419 | PackageIndexHook()
-    |
-    = help: Install `apache-airflow-provider-standard>=0.0.1` and import from `airflow.providers.standard.time.sensors.weekday` instead.
-
-AIR302.py:418:1: AIR302 Import path `airflow.hooks.filesystem` is moved into `standard` provider in Airflow 3.0;
-    |
-416 | TimeDeltaSensor()
-417 | DayOfWeekSensor()
-418 | FSHook()
-    | ^^^^^^ AIR302
-419 | PackageIndexHook()
-420 | SubprocessHook()
-    |
-    = help: Install `apache-airflow-provider-standard>=0.0.1` and import from `airflow.providers.standard.hooks.filesystem` instead.
-
-AIR302.py:419:1: AIR302 Import path `airflow.hooks.package_index` is moved into `standard` provider in Airflow 3.0;
-    |
-417 | DayOfWeekSensor()
-418 | FSHook()
-419 | PackageIndexHook()
-    | ^^^^^^^^^^^^^^^^ AIR302
-420 | SubprocessHook()
-421 | WorkflowTrigger()
-    |
-    = help: Install `apache-airflow-provider-standard>=0.0.1` and import from `airflow.providers.standard.hooks.package_index` instead.
-
-AIR302.py:420:1: AIR302 Import path `airflow.hooks.subprocess` is moved into `standard` provider in Airflow 3.0;
-    |
-418 | FSHook()
-419 | PackageIndexHook()
-420 | SubprocessHook()
-    | ^^^^^^^^^^^^^^ AIR302
-421 | WorkflowTrigger()
-422 | FileTrigger()
-    |
-    = help: Install `apache-airflow-provider-standard>=0.0.1` and import from `airflow.providers.standard.hooks.subprocess` instead.
-
-AIR302.py:421:1: AIR302 Import path `airflow.triggers.external_task` is moved into `standard` provider in Airflow 3.0;
-    |
-419 | PackageIndexHook()
-420 | SubprocessHook()
-421 | WorkflowTrigger()
-    | ^^^^^^^^^^^^^^^ AIR302
-422 | FileTrigger()
-423 | DateTimeTrigger()
-    |
-    = help: Install `apache-airflow-provider-standard>=0.0.3` and import from `airflow.providers.standard.triggers.external_task` instead.
-
-AIR302.py:422:1: AIR302 Import path `airflow.triggers.file` is moved into `standard` provider in Airflow 3.0;
-    |
-420 | SubprocessHook()
-421 | WorkflowTrigger()
-422 | FileTrigger()
-    | ^^^^^^^^^^^ AIR302
-423 | DateTimeTrigger()
-    |
-    = help: Install `apache-airflow-provider-standard>=0.0.3` and import from `airflow.providers.standard.triggers.file` instead.
-
-AIR302.py:423:1: AIR302 Import path `airflow.triggers.temporal` is moved into `standard` provider in Airflow 3.0;
-    |
-421 | WorkflowTrigger()
-422 | FileTrigger()
-423 | DateTimeTrigger()
-    | ^^^^^^^^^^^^^^^ AIR302
-424 |
-425 | from airflow.operators.email import EmailOperator
-    |
-    = help: Install `apache-airflow-provider-standard>=0.0.3` and import from `airflow.providers.standard.triggers.temporal` instead.
-
-AIR302.py:451:1: AIR302 `airflow.operators.dummy.DummyOperator` is moved into `standard` provider in Airflow 3.0;
-    |
-449 | )
-450 |
-451 | DummyOperator()
+429 | # apache-airflow-providers-smtp
+430 | EmailOperator()
     | ^^^^^^^^^^^^^ AIR302
-452 | EmptyOperator()
-453 | EmailOperator()
-    |
-    = help: Install `apache-airflow-provider-standard>=0.0.2` and use `airflow.providers.standard.operators.empty.EmptyOperator` instead.
-
-AIR302.py:452:1: AIR302 `airflow.operators.dummy.EmptyOperator` is moved into `standard` provider in Airflow 3.0;
-    |
-451 | DummyOperator()
-452 | EmptyOperator()
-    | ^^^^^^^^^^^^^ AIR302
-453 | EmailOperator()
-    |
-    = help: Install `apache-airflow-provider-standard>=0.0.2` and use `airflow.providers.standard.operators.empty.EmptyOperator` instead.
-
-AIR302.py:453:1: AIR302 `airflow.operators.email_operator.EmailOperator` is moved into `smtp` provider in Airflow 3.0;
-    |
-451 | DummyOperator()
-452 | EmptyOperator()
-453 | EmailOperator()
-    | ^^^^^^^^^^^^^ AIR302
-454 |
-455 | # airflow.operators.trigger_dagrun
+431 |
+432 | # apache-airflow-providers-standard
     |
     = help: Install `apache-airflow-provider-smtp>=1.0.0` and use `airflow.providers.smtp.operators.smtp.EmailOperator` instead.
 
-AIR302.py:456:1: AIR302 `airflow.operators.trigger_dagrun.TriggerDagRunLink` is moved into `standard` provider in Airflow 3.0;
+AIR302.py:433:1: AIR302 Import path `airflow.operators.datetime` is moved into `standard` provider in Airflow 3.0;
     |
-455 | # airflow.operators.trigger_dagrun
-456 | TriggerDagRunLink()
-    | ^^^^^^^^^^^^^^^^^ AIR302
-457 | TriggerDagRunOperator()
-    |
-    = help: Install `apache-airflow-provider-standard>=0.0.2` and use `airflow.providers.standard.operators.trigger_dagrun.TriggerDagRunLink` instead.
-
-AIR302.py:457:1: AIR302 `airflow.operators.trigger_dagrun.TriggerDagRunOperator` is moved into `standard` provider in Airflow 3.0;
-    |
-455 | # airflow.operators.trigger_dagrun
-456 | TriggerDagRunLink()
-457 | TriggerDagRunOperator()
-    | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-458 |
-459 | # airflow.sensors.date_time_sensor
-    |
-    = help: Install `apache-airflow-provider-standard>=0.0.2` and use `airflow.providers.standard.operators.trigger_dagrun.TriggerDagRunOperator` instead.
-
-AIR302.py:463:1: AIR302 `airflow.sensors.external_task.ExternalTaskSensorLink` is moved into `standard` provider in Airflow 3.0;
-    |
-462 | # airflow.sensors.external_task
-463 | ExternalTaskSensorLink()
+432 | # apache-airflow-providers-standard
+433 | BranchDateTimeOperator()
     | ^^^^^^^^^^^^^^^^^^^^^^ AIR302
-464 | ExternalTaskMarker()
-465 | ExternalTaskSensor()
+434 | BranchDayOfWeekOperator()
+435 | BranchPythonOperator()
     |
-    = help: Install `apache-airflow-provider-standard>=0.0.3` and use `airflow.providers.standard.sensors.external_task.ExternalTaskSensorLink` instead.
+    = help: Install `apache-airflow-provider-standard>=0.0.1` and import from `airflow.providers.standard.time.operators.datetime` instead.
 
-AIR302.py:464:1: AIR302 `airflow.sensors.external_task.ExternalTaskMarker` is moved into `standard` provider in Airflow 3.0;
+AIR302.py:434:1: AIR302 Import path `airflow.operators.weekday` is moved into `standard` provider in Airflow 3.0;
     |
-462 | # airflow.sensors.external_task
-463 | ExternalTaskSensorLink()
-464 | ExternalTaskMarker()
-    | ^^^^^^^^^^^^^^^^^^ AIR302
-465 | ExternalTaskSensor()
+432 | # apache-airflow-providers-standard
+433 | BranchDateTimeOperator()
+434 | BranchDayOfWeekOperator()
+    | ^^^^^^^^^^^^^^^^^^^^^^^ AIR302
+435 | BranchPythonOperator()
+436 | DateTimeSensor()
     |
-    = help: Install `apache-airflow-provider-standard>=0.0.3` and use `airflow.providers.standard.sensors.external_task.ExternalTaskMarker` instead.
+    = help: Install `apache-airflow-provider-standard>=0.0.1` and import from `airflow.providers.standard.time.operators.weekday` instead.
 
-AIR302.py:465:1: AIR302 `airflow.sensors.external_task.ExternalTaskSensor` is moved into `standard` provider in Airflow 3.0;
+AIR302.py:435:1: AIR302 `airflow.operators.python.BranchPythonOperator` is moved into `standard` provider in Airflow 3.0;
     |
-463 | ExternalTaskSensorLink()
-464 | ExternalTaskMarker()
-465 | ExternalTaskSensor()
-    | ^^^^^^^^^^^^^^^^^^ AIR302
-466 |
-467 | # airflow.sensors.external_task_sensor
-    |
-    = help: Install `apache-airflow-provider-standard>=0.0.3` and use `airflow.providers.standard.sensors.external_task.ExternalTaskSensor` instead.
-
-AIR302.py:468:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskMarker` is moved into `standard` provider in Airflow 3.0;
-    |
-467 | # airflow.sensors.external_task_sensor
-468 | ExternalTaskMarkerFromExternalTaskSensor()
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-469 | ExternalTaskSensorFromExternalTaskSensor()
-470 | ExternalTaskSensorLinkFromExternalTaskSensor()
-    |
-    = help: Install `apache-airflow-provider-standard>=0.0.3` and use `airflow.providers.standard.sensors.external_task.ExternalTaskMarker` instead.
-
-AIR302.py:469:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensor` is moved into `standard` provider in Airflow 3.0;
-    |
-467 | # airflow.sensors.external_task_sensor
-468 | ExternalTaskMarkerFromExternalTaskSensor()
-469 | ExternalTaskSensorFromExternalTaskSensor()
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-470 | ExternalTaskSensorLinkFromExternalTaskSensor()
-    |
-    = help: Install `apache-airflow-provider-standard>=0.0.3` and use `airflow.providers.standard.sensors.external_task.ExternalTaskSensor` instead.
-
-AIR302.py:470:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensorLink` is moved into `standard` provider in Airflow 3.0;
-    |
-468 | ExternalTaskMarkerFromExternalTaskSensor()
-469 | ExternalTaskSensorFromExternalTaskSensor()
-470 | ExternalTaskSensorLinkFromExternalTaskSensor()
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-471 |
-472 | # airflow.sensors.time_delta_sensor
-    |
-    = help: Install `apache-airflow-provider-standard>=0.0.3` and use `airflow.providers.standard.sensors.external_task.ExternalTaskSensorLink` instead.
-
-AIR302.py:473:1: AIR302 Import path `airflow.sensors.time_delta` is moved into `standard` provider in Airflow 3.0;
-    |
-472 | # airflow.sensors.time_delta_sensor
-473 | TimeDeltaSensor()
-    | ^^^^^^^^^^^^^^^ AIR302
-474 |
-475 | # airflow.operators.python
-    |
-    = help: Install `apache-airflow-provider-standard>=0.0.1` and import from `airflow.providers.standard.time.sensors.time_delta` instead.
-
-AIR302.py:476:1: AIR302 `airflow.operators.python.BranchPythonOperator` is moved into `standard` provider in Airflow 3.0;
-    |
-475 | # airflow.operators.python
-476 | BranchPythonOperator()
+433 | BranchDateTimeOperator()
+434 | BranchDayOfWeekOperator()
+435 | BranchPythonOperator()
     | ^^^^^^^^^^^^^^^^^^^^ AIR302
-477 | PythonOperator()
-478 | PythonVirtualenvOperator()
+436 | DateTimeSensor()
+437 | DateTimeTrigger()
     |
     = help: Install `apache-airflow-provider-standard>=0.0.1` and use `airflow.providers.standard.operators.python.BranchPythonOperator` instead.
 
-AIR302.py:477:1: AIR302 `airflow.operators.python.PythonOperator` is moved into `standard` provider in Airflow 3.0;
+AIR302.py:437:1: AIR302 Import path `airflow.triggers.temporal` is moved into `standard` provider in Airflow 3.0;
     |
-475 | # airflow.operators.python
-476 | BranchPythonOperator()
-477 | PythonOperator()
+435 | BranchPythonOperator()
+436 | DateTimeSensor()
+437 | DateTimeTrigger()
+    | ^^^^^^^^^^^^^^^ AIR302
+438 | DayOfWeekSensor()
+439 | DummyOperator()
+    |
+    = help: Install `apache-airflow-provider-standard>=0.0.3` and import from `airflow.providers.standard.triggers.temporal` instead.
+
+AIR302.py:438:1: AIR302 Import path `airflow.sensors.weekday` is moved into `standard` provider in Airflow 3.0;
+    |
+436 | DateTimeSensor()
+437 | DateTimeTrigger()
+438 | DayOfWeekSensor()
+    | ^^^^^^^^^^^^^^^ AIR302
+439 | DummyOperator()
+440 | EmptyOperator()
+    |
+    = help: Install `apache-airflow-provider-standard>=0.0.1` and import from `airflow.providers.standard.time.sensors.weekday` instead.
+
+AIR302.py:439:1: AIR302 `airflow.operators.dummy.DummyOperator` is moved into `standard` provider in Airflow 3.0;
+    |
+437 | DateTimeTrigger()
+438 | DayOfWeekSensor()
+439 | DummyOperator()
+    | ^^^^^^^^^^^^^ AIR302
+440 | EmptyOperator()
+441 | ExternalTaskMarker()
+    |
+    = help: Install `apache-airflow-provider-standard>=0.0.2` and use `airflow.providers.standard.operators.empty.EmptyOperator` instead.
+
+AIR302.py:440:1: AIR302 `airflow.operators.dummy.EmptyOperator` is moved into `standard` provider in Airflow 3.0;
+    |
+438 | DayOfWeekSensor()
+439 | DummyOperator()
+440 | EmptyOperator()
+    | ^^^^^^^^^^^^^ AIR302
+441 | ExternalTaskMarker()
+442 | ExternalTaskSensor()
+    |
+    = help: Install `apache-airflow-provider-standard>=0.0.2` and use `airflow.providers.standard.operators.empty.EmptyOperator` instead.
+
+AIR302.py:441:1: AIR302 `airflow.sensors.external_task.ExternalTaskMarker` is moved into `standard` provider in Airflow 3.0;
+    |
+439 | DummyOperator()
+440 | EmptyOperator()
+441 | ExternalTaskMarker()
+    | ^^^^^^^^^^^^^^^^^^ AIR302
+442 | ExternalTaskSensor()
+443 | ExternalTaskSensorLink()
+    |
+    = help: Install `apache-airflow-provider-standard>=0.0.3` and use `airflow.providers.standard.sensors.external_task.ExternalTaskMarker` instead.
+
+AIR302.py:442:1: AIR302 `airflow.sensors.external_task.ExternalTaskSensor` is moved into `standard` provider in Airflow 3.0;
+    |
+440 | EmptyOperator()
+441 | ExternalTaskMarker()
+442 | ExternalTaskSensor()
+    | ^^^^^^^^^^^^^^^^^^ AIR302
+443 | ExternalTaskSensorLink()
+444 | FileSensor()
+    |
+    = help: Install `apache-airflow-provider-standard>=0.0.3` and use `airflow.providers.standard.sensors.external_task.ExternalTaskSensor` instead.
+
+AIR302.py:443:1: AIR302 `airflow.sensors.external_task.ExternalTaskSensorLink` is moved into `standard` provider in Airflow 3.0;
+    |
+441 | ExternalTaskMarker()
+442 | ExternalTaskSensor()
+443 | ExternalTaskSensorLink()
+    | ^^^^^^^^^^^^^^^^^^^^^^ AIR302
+444 | FileSensor()
+445 | FileTrigger()
+    |
+    = help: Install `apache-airflow-provider-standard>=0.0.3` and use `airflow.providers.standard.sensors.external_task.ExternalTaskSensorLink` instead.
+
+AIR302.py:444:1: AIR302 `airflow.sensors.filesystem.FileSensor` is moved into `standard` provider in Airflow 3.0;
+    |
+442 | ExternalTaskSensor()
+443 | ExternalTaskSensorLink()
+444 | FileSensor()
+    | ^^^^^^^^^^ AIR302
+445 | FileTrigger()
+446 | FSHook()
+    |
+    = help: Install `apache-airflow-provider-standard>=0.0.2` and use `airflow.providers.standard.sensors.filesystem.FileSensor` instead.
+
+AIR302.py:445:1: AIR302 Import path `airflow.triggers.file` is moved into `standard` provider in Airflow 3.0;
+    |
+443 | ExternalTaskSensorLink()
+444 | FileSensor()
+445 | FileTrigger()
+    | ^^^^^^^^^^^ AIR302
+446 | FSHook()
+447 | PackageIndexHook()
+    |
+    = help: Install `apache-airflow-provider-standard>=0.0.3` and import from `airflow.providers.standard.triggers.file` instead.
+
+AIR302.py:446:1: AIR302 Import path `airflow.hooks.filesystem` is moved into `standard` provider in Airflow 3.0;
+    |
+444 | FileSensor()
+445 | FileTrigger()
+446 | FSHook()
+    | ^^^^^^ AIR302
+447 | PackageIndexHook()
+448 | SubprocessHook()
+    |
+    = help: Install `apache-airflow-provider-standard>=0.0.1` and import from `airflow.providers.standard.hooks.filesystem` instead.
+
+AIR302.py:447:1: AIR302 Import path `airflow.hooks.package_index` is moved into `standard` provider in Airflow 3.0;
+    |
+445 | FileTrigger()
+446 | FSHook()
+447 | PackageIndexHook()
+    | ^^^^^^^^^^^^^^^^ AIR302
+448 | SubprocessHook()
+449 | ShortCircuitOperator()
+    |
+    = help: Install `apache-airflow-provider-standard>=0.0.1` and import from `airflow.providers.standard.hooks.package_index` instead.
+
+AIR302.py:448:1: AIR302 Import path `airflow.hooks.subprocess` is moved into `standard` provider in Airflow 3.0;
+    |
+446 | FSHook()
+447 | PackageIndexHook()
+448 | SubprocessHook()
     | ^^^^^^^^^^^^^^ AIR302
-478 | PythonVirtualenvOperator()
-479 | ShortCircuitOperator()
+449 | ShortCircuitOperator()
+450 | TimeDeltaSensor()
+    |
+    = help: Install `apache-airflow-provider-standard>=0.0.1` and import from `airflow.providers.standard.hooks.subprocess` instead.
+
+AIR302.py:449:1: AIR302 `airflow.operators.python.ShortCircuitOperator` is moved into `standard` provider in Airflow 3.0;
+    |
+447 | PackageIndexHook()
+448 | SubprocessHook()
+449 | ShortCircuitOperator()
+    | ^^^^^^^^^^^^^^^^^^^^ AIR302
+450 | TimeDeltaSensor()
+451 | TimeSensor()
+    |
+    = help: Install `apache-airflow-provider-standard>=0.0.1` and use `airflow.providers.standard.operators.python.ShortCircuitOperator` instead.
+
+AIR302.py:450:1: AIR302 Import path `airflow.sensors.time_delta` is moved into `standard` provider in Airflow 3.0;
+    |
+448 | SubprocessHook()
+449 | ShortCircuitOperator()
+450 | TimeDeltaSensor()
+    | ^^^^^^^^^^^^^^^ AIR302
+451 | TimeSensor()
+452 | TriggerDagRunOperator()
+    |
+    = help: Install `apache-airflow-provider-standard>=0.0.1` and import from `airflow.providers.standard.time.sensors.time_delta` instead.
+
+AIR302.py:451:1: AIR302 Import path `airflow.sensors.time_sensor` is moved into `standard` provider in Airflow 3.0;
+    |
+449 | ShortCircuitOperator()
+450 | TimeDeltaSensor()
+451 | TimeSensor()
+    | ^^^^^^^^^^ AIR302
+452 | TriggerDagRunOperator()
+453 | WorkflowTrigger()
+    |
+    = help: Install `apache-airflow-provider-standard>=0.0.1` and import from `airflow.providers.standard.time.sensors.time` instead.
+
+AIR302.py:452:1: AIR302 `airflow.operators.trigger_dagrun.TriggerDagRunOperator` is moved into `standard` provider in Airflow 3.0;
+    |
+450 | TimeDeltaSensor()
+451 | TimeSensor()
+452 | TriggerDagRunOperator()
+    | ^^^^^^^^^^^^^^^^^^^^^ AIR302
+453 | WorkflowTrigger()
+454 | PythonOperator()
+    |
+    = help: Install `apache-airflow-provider-standard>=0.0.2` and use `airflow.providers.standard.operators.trigger_dagrun.TriggerDagRunOperator` instead.
+
+AIR302.py:453:1: AIR302 Import path `airflow.triggers.external_task` is moved into `standard` provider in Airflow 3.0;
+    |
+451 | TimeSensor()
+452 | TriggerDagRunOperator()
+453 | WorkflowTrigger()
+    | ^^^^^^^^^^^^^^^ AIR302
+454 | PythonOperator()
+455 | PythonVirtualenvOperator()
+    |
+    = help: Install `apache-airflow-provider-standard>=0.0.3` and import from `airflow.providers.standard.triggers.external_task` instead.
+
+AIR302.py:454:1: AIR302 `airflow.operators.python.PythonOperator` is moved into `standard` provider in Airflow 3.0;
+    |
+452 | TriggerDagRunOperator()
+453 | WorkflowTrigger()
+454 | PythonOperator()
+    | ^^^^^^^^^^^^^^ AIR302
+455 | PythonVirtualenvOperator()
     |
     = help: Install `apache-airflow-provider-standard>=0.0.1` and use `airflow.providers.standard.operators.python.PythonOperator` instead.
 
-AIR302.py:478:1: AIR302 `airflow.operators.python.PythonVirtualenvOperator` is moved into `standard` provider in Airflow 3.0;
+AIR302.py:455:1: AIR302 `airflow.operators.python.PythonVirtualenvOperator` is moved into `standard` provider in Airflow 3.0;
     |
-476 | BranchPythonOperator()
-477 | PythonOperator()
-478 | PythonVirtualenvOperator()
+453 | WorkflowTrigger()
+454 | PythonOperator()
+455 | PythonVirtualenvOperator()
     | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-479 | ShortCircuitOperator()
     |
     = help: Install `apache-airflow-provider-standard>=0.0.1` and use `airflow.providers.standard.operators.python.PythonVirtualenvOperator` instead.
-
-AIR302.py:479:1: AIR302 `airflow.operators.python.ShortCircuitOperator` is moved into `standard` provider in Airflow 3.0;
-    |
-477 | PythonOperator()
-478 | PythonVirtualenvOperator()
-479 | ShortCircuitOperator()
-    | ^^^^^^^^^^^^^^^^^^^^ AIR302
-    |
-    = help: Install `apache-airflow-provider-standard>=0.0.1` and use `airflow.providers.standard.operators.python.ShortCircuitOperator` instead.

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302.py.snap
@@ -1746,22 +1746,31 @@ AIR302.py:423:1: AIR302 Import path `airflow.triggers.temporal` is moved into `s
     |
     = help: Install `apache-airflow-provider-standard>=0.0.3` and import from `airflow.providers.standard.triggers.temporal` instead.
 
-AIR302.py:428:1: AIR302 `airflow.operators.dummy.DummyOperator` is moved into `standard` provider in Airflow 3.0;
+AIR302.py:427:1: AIR302 `airflow.operators.dummy.DummyOperator` is moved into `standard` provider in Airflow 3.0;
     |
-426 | from airflow.operators.email import EmailOperator
-427 |
-428 | DummyOperator()
+425 | from airflow.operators.dummy import DummyOperator, EmptyOperator
+426 |
+427 | DummyOperator()
     | ^^^^^^^^^^^^^ AIR302
-429 | EmptyOperator()
-430 | EmailOperator()
+428 | EmptyOperator()
     |
     = help: Install `apache-airflow-provider-standard>=0.1.0` and use `airflow.providers.standard.operators.empty.EmptyOperator` instead.
 
-AIR302.py:429:1: AIR302 `airflow.operators.dummy.EmptyOperator` is moved into `standard` provider in Airflow 3.0;
+AIR302.py:428:1: AIR302 `airflow.operators.dummy.EmptyOperator` is moved into `standard` provider in Airflow 3.0;
     |
-428 | DummyOperator()
-429 | EmptyOperator()
+427 | DummyOperator()
+428 | EmptyOperator()
     | ^^^^^^^^^^^^^ AIR302
-430 | EmailOperator()
+429 |
+430 | from airflow.operators.email import EmailOperator
     |
     = help: Install `apache-airflow-provider-standard>=0.1.0` and use `airflow.providers.standard.operators.empty.EmptyOperator` instead.
+
+AIR302.py:432:1: AIR302 `airflow.operators.email.EmailOperator` is moved into `smtp` provider in Airflow 3.0;
+    |
+430 | from airflow.operators.email import EmailOperator
+431 |
+432 | EmailOperator()
+    | ^^^^^^^^^^^^^ AIR302
+    |
+    = help: Install `apache-airflow-provider-smtp>=1.0.0` and use `airflow.providers.smtp.operators.smtp.EmailOperator` instead.

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302.py.snap
@@ -1741,5 +1741,27 @@ AIR302.py:423:1: AIR302 Import path `airflow.triggers.temporal` is moved into `s
 422 | FileTrigger()
 423 | DateTimeTrigger()
     | ^^^^^^^^^^^^^^^ AIR302
+424 |
+425 | from airflow.operators.dummy import DummyOperator, EmptyOperator
     |
     = help: Install `apache-airflow-provider-standard>=0.0.3` and import from `airflow.providers.standard.triggers.temporal` instead.
+
+AIR302.py:428:1: AIR302 `airflow.operators.dummy.DummyOperator` is moved into `standard` provider in Airflow 3.0;
+    |
+426 | from airflow.operators.email import EmailOperator
+427 |
+428 | DummyOperator()
+    | ^^^^^^^^^^^^^ AIR302
+429 | EmptyOperator()
+430 | EmailOperator()
+    |
+    = help: Install `apache-airflow-provider-standard>=0.1.0` and use `airflow.providers.standard.operators.empty.EmptyOperator` instead.
+
+AIR302.py:429:1: AIR302 `airflow.operators.dummy.EmptyOperator` is moved into `standard` provider in Airflow 3.0;
+    |
+428 | DummyOperator()
+429 | EmptyOperator()
+    | ^^^^^^^^^^^^^ AIR302
+430 | EmailOperator()
+    |
+    = help: Install `apache-airflow-provider-standard>=0.1.0` and use `airflow.providers.standard.operators.empty.EmptyOperator` instead.


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Some of the migration rules has been changed during Airflow 3 development. The following are new AIR302 rules. Corresponding AIR301 has also been removed.

* airflow.sensors.external_task_sensor.ExternalTaskMarker → airflow.providers.standard.sensors.external_task.ExternalTaskMarker
* airflow.sensors.external_task_sensor.ExternalTaskSensor → airflow.providers.standard.sensors.external_task.ExternalTaskSensor
* airflow.sensors.external_task_sensor.ExternalTaskSensorLink → airflow.providers.standard.sensors.external_task.ExternalTaskSensorLink
* airflow.sensors.time_delta_sensor.TimeDeltaSensor → airflow.providers.standard.sensors.time_delta.TimeDeltaSensor
* airflow.operators.dagrun_operator.TriggerDagRunLink → airflow.providers.standard.operators.trigger_dagrun.TriggerDagRunLink
* airflow.operators.dagrun_operator.TriggerDagRunOperator → airflow.providers.standard.operators.trigger_dagrun.TriggerDagRunOperator
* airflow.operators.python_operator.BranchPythonOperator → airflow.providers.standard.operators.python.BranchPythonOperator
* airflow.operators.python_operator.PythonOperator → airflow.providers.standard.operators.python.PythonOperator
* airflow.operators.python_operator.PythonVirtualenvOperator → airflow.providers.standard.operators.python.PythonVirtualenvOperator
* airflow.operators.python_operator.ShortCircuitOperator → airflow.providers.standard.operators.python.ShortCircuitOperator
* airflow.operators.latest_only_operator.LatestOnlyOperator → airflow.providers.standard.operators.latest_only.LatestOnlyOperator
* airflow.sensors.date_time_sensor.DateTimeSensor → airflow.providers.standard.sensors.DateTimeSensor
* airflow.operators.email_operator.EmailOperator → airflow.providers.smtp.operators.smtp.EmailOperator
* airflow.operators.email.EmailOperator → airflow.providers.smtp.operators.smtp.EmailOperator
* airflow.operators.bash.BashOperator → airflow.providers.standard.operators.bash.BashOperator
* airflow.operators.EmptyOperator → airflow.providers.standard.operators.empty.EmptyOperator

closes: https://github.com/astral-sh/ruff/issues/17103

## Test Plan

<!-- How was it tested? -->

The test fixture has been updated and checked after each change and later reorganized in the latest commit
