### PR TITLE
[red-knot] Fix callable subtyping for standard parameters

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -4582,6 +4582,14 @@ impl<'db> GeneralCallableType<'db> {
 
             match next_parameter {
                 EitherOrBoth::Left(self_parameter) => match self_parameter.kind() {
+                    ParameterKind::KeywordOnly { .. } | ParameterKind::KeywordVariadic { .. }
+                        if !other_keywords.is_empty() =>
+                    {
+                        // If there are any unmatched keyword parameters in `other`, they need to
+                        // be checked against the keyword-only / keyword-variadic parameters that
+                        // will be done after this loop.
+                        break;
+                    }
                     ParameterKind::PositionalOnly { default_type, .. }
                     | ParameterKind::PositionalOrKeyword { default_type, .. }
                     | ParameterKind::KeywordOnly { default_type, .. } => {


### PR DESCRIPTION
## Summary

This PR fixes a bug in callable subtyping to consider both the positional and keyword form of the standard parameter in the supertype when matching against variadic, keyword-only and keyword-variadic parameter in the subtype.

This is done by collecting the unmatched standard parameters and then checking them against the keyword-only / keyword-variadic parameters after the positional loop.

## Test Plan

Add test cases.
