### PR TITLE
[red-knot] Fix `_NotImplementedType` check for Python >=3.10

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/function/return_type.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/function/return_type.md
@@ -272,7 +272,7 @@ def f(cond: bool) -> int:
 
 ## NotImplemented
 
-### All Python versions
+### Default Python version
 
 `NotImplemented` is a special symbol in Python. It is commonly used to control the fallback behavior
 of special dunder methods. You can find more details in the

--- a/crates/red_knot_python_semantic/resources/mdtest/function/return_type.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/function/return_type.md
@@ -272,6 +272,8 @@ def f(cond: bool) -> int:
 
 ## NotImplemented
 
+### All Python version
+
 `NotImplemented` is a special symbol in Python. It is commonly used to control the fallback behavior
 of special dunder methods. You can find more details in the
 [documentation](https://docs.python.org/3/library/numbers.html#implementing-the-arithmetic-operations).
@@ -309,5 +311,24 @@ def f(cond: bool) -> str:
 
 def f(cond: bool) -> int:
     # error: [invalid-return-type] "Object of type `Literal["hello"]` is not assignable to return type `int`"
+    return "hello" if cond else NotImplemented
+```
+
+### Python 3.10+
+
+Unlike Ellipsis, `_NotImplementedType` remains in `builtins.pyi` regardless of the Python version.
+Even if `builtins._NotImplementedType` is fully replaced by `types.NotImplementedType` in the
+future, it should still work as expected.
+
+```toml
+[environment]
+python-version = "3.10"
+```
+
+```py
+def f() -> int:
+    return NotImplemented
+
+def f(cond: bool) -> str:
     return "hello" if cond else NotImplemented
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/function/return_type.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/function/return_type.md
@@ -272,7 +272,7 @@ def f(cond: bool) -> int:
 
 ## NotImplemented
 
-### All Python version
+### All Python versions
 
 `NotImplemented` is a special symbol in Python. It is commonly used to control the fallback behavior
 of special dunder methods. You can find more details in the

--- a/crates/red_knot_python_semantic/src/types/class.rs
+++ b/crates/red_knot_python_semantic/src/types/class.rs
@@ -1370,9 +1370,7 @@ impl<'db> KnownClass {
             "EllipsisType" if Program::get(db).python_version(db) >= PythonVersion::PY310 => {
                 Self::EllipsisType
             }
-            "_NotImplementedType" if Program::get(db).python_version(db) <= PythonVersion::PY39 => {
-                Self::NotImplementedType
-            }
+            "_NotImplementedType" => Self::NotImplementedType,
             _ => return None,
         };
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

from https://github.com/astral-sh/ruff/pull/17034#discussion_r2024222525

This is a simple PR to fix the invalid behavior of `NotImplemented` on Python >=3.10.


## Test Plan

I think it would be better if we could run mdtest across multiple Python versions in GitHub Actions.

<!-- How was it tested? -->
