### PR TITLE
[red-knot] Add `Type.definition` method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2514,6 +2514,7 @@ dependencies = [
  "ruff_python_ast",
  "ruff_python_parser",
  "ruff_text_size",
+ "rustc-hash 2.1.1",
  "salsa",
  "smallvec",
  "tracing",

--- a/crates/red_knot_ide/Cargo.toml
+++ b/crates/red_knot_ide/Cargo.toml
@@ -17,6 +17,7 @@ ruff_python_parser = { workspace = true }
 ruff_text_size = { workspace = true }
 red_knot_python_semantic = { workspace = true }
 
+rustc-hash = { workspace = true }
 salsa = { workspace = true }
 smallvec = { workspace = true }
 tracing = { workspace = true }

--- a/crates/red_knot_ide/src/goto.rs
+++ b/crates/red_knot_ide/src/goto.rs
@@ -24,9 +24,11 @@ pub fn goto_type_definition(
         ty.display(db.upcast())
     );
 
+    let navigation_targets = ty.navigation_targets(db);
+
     Some(RangedValue {
         range: FileRange::new(file, goto_target.range()),
-        value: ty.navigation_targets(db),
+        value: navigation_targets,
     })
 }
 
@@ -391,12 +393,12 @@ mod tests {
 
         test.write_file("lib.py", "a = 10").unwrap();
 
-        assert_snapshot!(test.goto_type_definition(), @r###"
+        assert_snapshot!(test.goto_type_definition(), @r"
         info: lint:goto-type-definition: Type definition
          --> /lib.py:1:1
           |
         1 | a = 10
-          | ^
+          | ^^^^^^
           |
         info: Source
          --> /main.py:4:13
@@ -406,7 +408,7 @@ mod tests {
         4 |             lib
           |             ^^^
           |
-        "###);
+        ");
     }
 
     #[test]
@@ -756,14 +758,13 @@ f(**kwargs<CURSOR>)
 
         assert_snapshot!(test.goto_type_definition(), @r"
         info: lint:goto-type-definition: Type definition
-           --> stdlib/builtins.pyi:443:7
+           --> stdlib/types.pyi:677:11
             |
-        441 |     def __getitem__(self, key: int, /) -> str | int | None: ...
-        442 |
-        443 | class str(Sequence[str]):
-            |       ^^^
-        444 |     @overload
-        445 |     def __new__(cls, object: object = ...) -> Self: ...
+        675 | if sys.version_info >= (3, 10):
+        676 |     @final
+        677 |     class NoneType:
+            |           ^^^^^^^^
+        678 |         def __bool__(self) -> Literal[False]: ...
             |
         info: Source
          --> /main.py:3:17
@@ -774,13 +775,14 @@ f(**kwargs<CURSOR>)
           |
 
         info: lint:goto-type-definition: Type definition
-           --> stdlib/types.pyi:677:11
+           --> stdlib/builtins.pyi:443:7
             |
-        675 | if sys.version_info >= (3, 10):
-        676 |     @final
-        677 |     class NoneType:
-            |           ^^^^^^^^
-        678 |         def __bool__(self) -> Literal[False]: ...
+        441 |     def __getitem__(self, key: int, /) -> str | int | None: ...
+        442 |
+        443 | class str(Sequence[str]):
+            |       ^^^
+        444 |     @overload
+        445 |     def __new__(cls, object: object = ...) -> Self: ...
             |
         info: Source
          --> /main.py:3:17

--- a/crates/red_knot_python_semantic/src/semantic_index/definition.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/definition.rs
@@ -13,17 +13,13 @@ use crate::Db;
 
 /// A definition of a symbol.
 ///
-/// ## Module-local type
-/// This type should not be used as part of any cross-module API because
-/// it holds a reference to the AST node. Range-offset changes
-/// then propagate through all usages, and deserialization requires
-/// reparsing the entire module.
+/// ## ID stability
+/// The `Definition`'s ID is stable when the only field that change is its `kind` (AST node).
 ///
-/// E.g. don't use this type in:
-///
-/// * a return type of a cross-module query
-/// * a field of a type that is a return type of a cross-module query
-/// * an argument of a cross-module query
+/// The `Definition` changes when the `file`, `scope`, or `symbol` change. This can be
+/// because a new scope gets inserted before the `Definition` or a new symbol is inserted
+/// before this `Definition`. However, the ID can be considered stable and it is okay to use
+/// `Definition` in cross-module` salsa queries or as a field on other salsa tracked structs.
 #[salsa::tracked(debug)]
 pub struct Definition<'db> {
     /// The file in which the definition occurs.

--- a/crates/red_knot_python_semantic/src/types/class.rs
+++ b/crates/red_knot_python_semantic/src/types/class.rs
@@ -1,5 +1,11 @@
 use std::sync::{LazyLock, Mutex};
 
+use super::{
+    class_base::ClassBase, infer_expression_type, infer_unpack_types, IntersectionBuilder,
+    KnownFunction, Mro, MroError, MroIterator, SubclassOfType, Truthiness, Type, TypeAliasType,
+    TypeQualifiers, TypeVarInstance,
+};
+use crate::semantic_index::definition::Definition;
 use crate::{
     module_resolver::file_to_module,
     semantic_index::{
@@ -22,12 +28,6 @@ use ruff_db::files::{File, FileRange};
 use ruff_python_ast::{self as ast, PythonVersion};
 use rustc_hash::FxHashSet;
 
-use super::{
-    class_base::ClassBase, infer_expression_type, infer_unpack_types, IntersectionBuilder,
-    KnownFunction, Mro, MroError, MroIterator, SubclassOfType, Truthiness, Type, TypeAliasType,
-    TypeQualifiers, TypeVarInstance,
-};
-
 /// Representation of a runtime class object.
 ///
 /// Does not in itself represent a type,
@@ -43,52 +43,14 @@ pub struct Class<'db> {
     pub(crate) known: Option<KnownClass>,
 }
 
-fn explicit_bases_cycle_recover<'db>(
-    _db: &'db dyn Db,
-    _value: &[Type<'db>],
-    _count: u32,
-    _self: Class<'db>,
-) -> salsa::CycleRecoveryAction<Box<[Type<'db>]>> {
-    salsa::CycleRecoveryAction::Iterate
-}
-
-fn explicit_bases_cycle_initial<'db>(_db: &'db dyn Db, _self: Class<'db>) -> Box<[Type<'db>]> {
-    Box::default()
-}
-
-fn try_mro_cycle_recover<'db>(
-    _db: &'db dyn Db,
-    _value: &Result<Mro<'db>, MroError<'db>>,
-    _count: u32,
-    _self: Class<'db>,
-) -> salsa::CycleRecoveryAction<Result<Mro<'db>, MroError<'db>>> {
-    salsa::CycleRecoveryAction::Iterate
-}
-
-#[allow(clippy::unnecessary_wraps)]
-fn try_mro_cycle_initial<'db>(
-    db: &'db dyn Db,
-    self_: Class<'db>,
-) -> Result<Mro<'db>, MroError<'db>> {
-    Ok(Mro::from_error(db, self_))
-}
-
-#[allow(clippy::ref_option, clippy::trivially_copy_pass_by_ref)]
-fn inheritance_cycle_recover<'db>(
-    _db: &'db dyn Db,
-    _value: &Option<InheritanceCycle>,
-    _count: u32,
-    _self: Class<'db>,
-) -> salsa::CycleRecoveryAction<Option<InheritanceCycle>> {
-    salsa::CycleRecoveryAction::Iterate
-}
-
-fn inheritance_cycle_initial<'db>(_db: &'db dyn Db, _self: Class<'db>) -> Option<InheritanceCycle> {
-    None
-}
-
 #[salsa::tracked]
 impl<'db> Class<'db> {
+    pub(crate) fn definition(self, db: &'db dyn Db) -> Definition<'db> {
+        let scope = self.body_scope(db);
+        let index = semantic_index(db, scope.file(db));
+        index.expect_single_definition(scope.node(db).expect_class())
+    }
+
     /// Return `true` if this class represents `known_class`
     pub(crate) fn is_known(self, db: &'db dyn Db, known_class: KnownClass) -> bool {
         self.known(db) == Some(known_class)
@@ -239,8 +201,7 @@ impl<'db> Class<'db> {
             .find_keyword("metaclass")?
             .value;
 
-        let class_definition =
-            semantic_index(db, self.file(db)).expect_single_definition(class_stmt);
+        let class_definition = self.definition(db);
 
         Some(definition_expression_type(
             db,
@@ -740,6 +701,50 @@ impl<'db> Class<'db> {
     }
 }
 
+fn explicit_bases_cycle_recover<'db>(
+    _db: &'db dyn Db,
+    _value: &[Type<'db>],
+    _count: u32,
+    _self: Class<'db>,
+) -> salsa::CycleRecoveryAction<Box<[Type<'db>]>> {
+    salsa::CycleRecoveryAction::Iterate
+}
+
+fn explicit_bases_cycle_initial<'db>(_db: &'db dyn Db, _self: Class<'db>) -> Box<[Type<'db>]> {
+    Box::default()
+}
+
+fn try_mro_cycle_recover<'db>(
+    _db: &'db dyn Db,
+    _value: &Result<Mro<'db>, MroError<'db>>,
+    _count: u32,
+    _self: Class<'db>,
+) -> salsa::CycleRecoveryAction<Result<Mro<'db>, MroError<'db>>> {
+    salsa::CycleRecoveryAction::Iterate
+}
+
+#[allow(clippy::unnecessary_wraps)]
+fn try_mro_cycle_initial<'db>(
+    db: &'db dyn Db,
+    self_: Class<'db>,
+) -> Result<Mro<'db>, MroError<'db>> {
+    Ok(Mro::from_error(db, self_))
+}
+
+#[allow(clippy::ref_option, clippy::trivially_copy_pass_by_ref)]
+fn inheritance_cycle_recover<'db>(
+    _db: &'db dyn Db,
+    _value: &Option<InheritanceCycle>,
+    _count: u32,
+    _self: Class<'db>,
+) -> salsa::CycleRecoveryAction<Option<InheritanceCycle>> {
+    salsa::CycleRecoveryAction::Iterate
+}
+
+fn inheritance_cycle_initial<'db>(_db: &'db dyn Db, _self: Class<'db>) -> Option<InheritanceCycle> {
+    None
+}
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub(super) enum InheritanceCycle {
     /// The class is cyclically defined and is a participant in the cycle.
@@ -763,7 +768,7 @@ pub struct ClassLiteralType<'db> {
 }
 
 impl<'db> ClassLiteralType<'db> {
-    pub fn class(self) -> Class<'db> {
+    pub(super) fn class(self) -> Class<'db> {
         self.class
     }
 
@@ -789,7 +794,7 @@ pub struct InstanceType<'db> {
 }
 
 impl<'db> InstanceType<'db> {
-    pub fn class(self) -> Class<'db> {
+    pub(super) fn class(self) -> Class<'db> {
         self.class
     }
 

--- a/crates/red_knot_python_semantic/src/types/class_base.rs
+++ b/crates/red_knot_python_semantic/src/types/class_base.rs
@@ -8,7 +8,7 @@ use itertools::Either;
 /// all types that would be invalid to have as a class base are
 /// transformed into [`ClassBase::unknown`]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, salsa::Update)]
-pub enum ClassBase<'db> {
+pub(crate) enum ClassBase<'db> {
     Dynamic(DynamicType),
     Class(Class<'db>),
 }
@@ -18,7 +18,7 @@ impl<'db> ClassBase<'db> {
         Self::Dynamic(DynamicType::Any)
     }
 
-    pub const fn unknown() -> Self {
+    pub(crate) const fn unknown() -> Self {
         Self::Dynamic(DynamicType::Unknown)
     }
 

--- a/crates/red_knot_python_semantic/src/types/definition.rs
+++ b/crates/red_knot_python_semantic/src/types/definition.rs
@@ -1,0 +1,39 @@
+use crate::semantic_index::definition::Definition;
+use crate::{Db, Module};
+use ruff_db::files::FileRange;
+use ruff_db::source::source_text;
+use ruff_text_size::{TextLen, TextRange};
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub enum TypeDefinition<'db> {
+    Module(Module),
+    Class(Definition<'db>),
+    Function(Definition<'db>),
+    TypeVar(Definition<'db>),
+    TypeAlias(Definition<'db>),
+}
+
+impl TypeDefinition<'_> {
+    pub fn focus_range(&self, db: &dyn Db) -> Option<FileRange> {
+        match self {
+            Self::Module(_) => None,
+            Self::Class(definition)
+            | Self::Function(definition)
+            | Self::TypeVar(definition)
+            | Self::TypeAlias(definition) => Some(definition.focus_range(db)),
+        }
+    }
+
+    pub fn full_range(&self, db: &dyn Db) -> FileRange {
+        match self {
+            Self::Module(module) => {
+                let source = source_text(db.upcast(), module.file());
+                FileRange::new(module.file(), TextRange::up_to(source.text_len()))
+            }
+            Self::Class(definition)
+            | Self::Function(definition)
+            | Self::TypeVar(definition)
+            | Self::TypeAlias(definition) => definition.full_range(db),
+        }
+    }
+}

--- a/crates/red_knot_python_semantic/src/types/subclass_of.rs
+++ b/crates/red_knot_python_semantic/src/types/subclass_of.rs
@@ -52,17 +52,17 @@ impl<'db> SubclassOfType<'db> {
     }
 
     /// Return the inner [`ClassBase`] value wrapped by this `SubclassOfType`.
-    pub const fn subclass_of(self) -> ClassBase<'db> {
+    pub(crate) const fn subclass_of(self) -> ClassBase<'db> {
         self.subclass_of
     }
 
-    pub const fn is_dynamic(self) -> bool {
+    pub(crate) const fn is_dynamic(self) -> bool {
         // Unpack `self` so that we're forced to update this method if any more fields are added in the future.
         let Self { subclass_of } = self;
         subclass_of.is_dynamic()
     }
 
-    pub const fn is_fully_static(self) -> bool {
+    pub(crate) const fn is_fully_static(self) -> bool {
         !self.is_dynamic()
     }
 


### PR DESCRIPTION
## Summary

This is a follow up to the goto type definition PR. Specifically, that we want to avoid exposing too many semantic model internals publicly. 

I want to get some feedback on the approach taken. I think it goes into the right direction but I'm not super happy with it. 
The basic idea is that we add a `Type::definition` method which does the "goto type definition". The parts that I think make it awkward:

* We can't directly return `Definition` because we don't create a `Definition` for modules (but we could?). Although I think it makes sense to possibly have a more public wrapper type anyway?
* It doesn't handle unions and intersections. Mainly because not all elements in an intersection may have a definition and we only want to show a navigation target for intersections if there's only a single positive element (besides maybe `Unknown`).


An alternative design or an addition to this design is to introduce a `SemanticAnalysis(Db)` struct that has methods like `type_definition(&self, type)` which explicitly exposes the methods we want. I don't feel comfortable design this API yet because it's unclear how fine granular it has to be (and if it is very fine granular, directly using `Type` might be better after all)


## Test Plan

`cargo test`
