### PR TITLE
ruff_db: switch diagnostic rendering over to `std::fmt::Display`

### DIFF
--- a/crates/red_knot/src/main.rs
+++ b/crates/red_knot/src/main.rs
@@ -288,7 +288,7 @@ impl MainLoop {
                             let diagnostics_count = result.len();
 
                             for diagnostic in result {
-                                diagnostic.print(db, &display_config, &mut stdout)?;
+                                write!(stdout, "{}", diagnostic.display(db, &display_config))?;
 
                                 failed |= diagnostic.severity() >= min_error_severity;
                             }

--- a/crates/red_knot_ide/src/goto.rs
+++ b/crates/red_knot_ide/src/goto.rs
@@ -241,6 +241,7 @@ pub(crate) fn find_goto_target(parsed: &ParsedModule, offset: TextSize) -> Optio
 
 #[cfg(test)]
 mod tests {
+    use std::fmt::Write;
 
     use crate::db::tests::TestDb;
     use crate::{goto_type_definition, NavigationTarget};
@@ -860,24 +861,19 @@ f(**kwargs<CURSOR>)
                 return "No type definitions found".to_string();
             }
 
-            let mut buf = vec![];
+            let mut buf = String::new();
 
             let source = targets.range;
 
+            let config = DisplayDiagnosticConfig::default()
+                .color(false)
+                .format(DiagnosticFormat::Full);
             for target in &*targets {
-                GotoTypeDefinitionDiagnostic::new(source, target)
-                    .into_diagnostic()
-                    .print(
-                        &self.db,
-                        &DisplayDiagnosticConfig::default()
-                            .color(false)
-                            .format(DiagnosticFormat::Full),
-                        &mut buf,
-                    )
-                    .unwrap();
+                let diag = GotoTypeDefinitionDiagnostic::new(source, target).into_diagnostic();
+                write!(buf, "{}", diag.display(&self.db, &config)).unwrap();
             }
 
-            String::from_utf8(buf).unwrap()
+            buf
         }
     }
 

--- a/crates/red_knot_test/src/lib.rs
+++ b/crates/red_knot_test/src/lib.rs
@@ -13,8 +13,7 @@ use ruff_db::parsed::parsed_module;
 use ruff_db::system::{DbWithWritableSystem as _, SystemPath, SystemPathBuf};
 use ruff_db::testing::{setup_logging, setup_logging_with_filter};
 use ruff_source_file::{LineIndex, OneIndexed};
-use std::fmt::Write as _;
-use std::io::Write as _;
+use std::fmt::Write;
 
 mod assertion;
 mod config;
@@ -324,7 +323,7 @@ fn create_diagnostic_snapshot(
 ) -> String {
     let display_config = DisplayDiagnosticConfig::default().color(false);
 
-    let mut snapshot = Vec::new();
+    let mut snapshot = String::new();
     writeln!(snapshot).unwrap();
     writeln!(snapshot, "---").unwrap();
     writeln!(snapshot, "mdtest name: {}", test.name()).unwrap();
@@ -360,8 +359,8 @@ fn create_diagnostic_snapshot(
             writeln!(snapshot).unwrap();
         }
         writeln!(snapshot, "```").unwrap();
-        diag.print(db, &display_config, &mut snapshot).unwrap();
+        write!(snapshot, "{}", diag.display(db, &display_config)).unwrap();
         writeln!(snapshot, "```").unwrap();
     }
-    String::from_utf8(snapshot).unwrap()
+    snapshot
 }

--- a/crates/red_knot_wasm/src/lib.rs
+++ b/crates/red_knot_wasm/src/lib.rs
@@ -273,11 +273,10 @@ impl Diagnostic {
     #[wasm_bindgen]
     pub fn display(&self, workspace: &Workspace) -> JsString {
         let config = DisplayDiagnosticConfig::default().color(false);
-        let mut buf = vec![];
         self.inner
-            .print(workspace.db.upcast(), &config, &mut buf)
-            .unwrap();
-        String::from_utf8(buf).unwrap().into()
+            .display(workspace.db.upcast(), &config)
+            .to_string()
+            .into()
     }
 }
 


### PR DESCRIPTION
It was already using this approach internally, so this is "just" a
matter of rejiggering the public API of `Diagnostic`.

We were previously writing directly to a `std::io::Write` since it was
thought that this worked better with the linear typing fakery. Namely,
it increased confidence that the diagnostic rendering was actually
written somewhere useful, instead of just being converted to a string
that could potentially get lost.

For reasons discussed in #17130, the linear type fakery was removed.
And so there is less of a reason to require a `std::io::Write`
implementation for diagnostic rendering. Indeed, this would sometimes
result in `unwrap()` calls when one wants to convert to a `String`.
