### PR TITLE
[red-knot] Detect division-by-zero in unions and intersections

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/binary/unions.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/binary/unions.md
@@ -49,3 +49,11 @@ def f4(x: float, y: float):
     reveal_type(x // y)  # revealed: int | float
     reveal_type(x % y)  # revealed: int | float
 ```
+
+If any of the union elements leads to a division by zero, we will report an error:
+
+```py
+def f5(m: int, n: Literal[-1, 0, 1]):
+    # error: [division-by-zero] "Cannot divide object of type `int` by zero"
+    return m / n
+```


### PR DESCRIPTION
## Summary

Yet another instance of "we should have handled unions and intersections correctly". With this PR, we emit a diagnostic for this case where previously didn't:
```py
from typing import Literal

def f(m: int, n: Literal[-1, 0, 1]):
    # error: [division-by-zero] "Cannot divide object of type `int` by zero"
    return m / n
```

The new Boolean flag is not pretty, but without it, we emit multiple diagnostics for a single expression in some cases. Let me know if you have better ways to address this.

## Test Plan

New Markdown test