### PR TITLE
ruff_db: simplify lifetimes on `DiagnosticDisplay`

### DIFF
--- a/crates/ruff_db/src/diagnostic/mod.rs
+++ b/crates/ruff_db/src/diagnostic/mod.rs
@@ -106,11 +106,11 @@ impl Diagnostic {
     ///
     /// Note that this `Display` impl includes a trailing line terminator, so
     /// callers should prefer using this with `write!` instead of `writeln!`.
-    pub fn display<'c, 'db, 'd>(
-        &'d self,
-        db: &'db dyn Db,
-        config: &'c DisplayDiagnosticConfig,
-    ) -> DisplayDiagnostic<'c, 'db, 'd> {
+    pub fn display<'a>(
+        &'a self,
+        db: &'a dyn Db,
+        config: &'a DisplayDiagnosticConfig,
+    ) -> DisplayDiagnostic<'a> {
         let resolver = FileResolver::new(db);
         DisplayDiagnostic::new(resolver, config, self)
     }

--- a/crates/ruff_db/src/diagnostic/render.rs
+++ b/crates/ruff_db/src/diagnostic/render.rs
@@ -21,27 +21,27 @@ use super::{
 ///
 /// It is created via [`Diagnostic::display`].
 ///
-/// The lifetime parameters are:
+/// The lifetime parameter, `'a`, refers to the shorter of:
 ///
-/// * `'c` is the lifetime of the rendering configuration.
-/// * `'r` is the lifetime of the resolver used to load the contents of `Span`
+/// * The lifetime of the rendering configuration.
+/// * The lifetime of the resolver used to load the contents of `Span`
 ///   values. When using Salsa, this most commonly corresponds to the lifetime
 ///   of a Salsa `Db`.
-/// * `'d` is the lifetime of the diagnostic being rendered.
+/// * The lifetime of the diagnostic being rendered.
 #[derive(Debug)]
-pub struct DisplayDiagnostic<'c, 'r, 'd> {
-    config: &'c DisplayDiagnosticConfig,
-    resolver: FileResolver<'r>,
+pub struct DisplayDiagnostic<'a> {
+    config: &'a DisplayDiagnosticConfig,
+    resolver: FileResolver<'a>,
     annotate_renderer: AnnotateRenderer,
-    diag: &'d Diagnostic,
+    diag: &'a Diagnostic,
 }
 
-impl<'c, 'r, 'd> DisplayDiagnostic<'c, 'r, 'd> {
+impl<'a> DisplayDiagnostic<'a> {
     pub(crate) fn new(
-        resolver: FileResolver<'r>,
-        config: &'c DisplayDiagnosticConfig,
-        diag: &'d Diagnostic,
-    ) -> DisplayDiagnostic<'c, 'r, 'd> {
+        resolver: FileResolver<'a>,
+        config: &'a DisplayDiagnosticConfig,
+        diag: &'a Diagnostic,
+    ) -> DisplayDiagnostic<'a> {
         let annotate_renderer = if config.color {
             AnnotateRenderer::styled()
         } else {
@@ -56,7 +56,7 @@ impl<'c, 'r, 'd> DisplayDiagnostic<'c, 'r, 'd> {
     }
 }
 
-impl std::fmt::Display for DisplayDiagnostic<'_, '_, '_> {
+impl std::fmt::Display for DisplayDiagnostic<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         if matches!(self.config.format, DiagnosticFormat::Concise) {
             match self.diag.severity() {


### PR DESCRIPTION
I initially split the lifetime out into three distinct lifetimes on
near-instinct because I moved the struct into the public API. But
because they are all shared borrows, and because there are no other APIs
on `DisplayDiagnostic` to access individual fields (and probably never
will be), it's probably fine to just specify one lifetime. Because of
subtyping, the one lifetime will be the shorter of the three.

There's also the point that `ruff_db` isn't _really_ a public API, since
it isn't a library that others depend on. So my instinct is probably a
bit off there.
