### PR TITLE
[DO NOT LAND] bump Salsa version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,9 +207,9 @@ dependencies = [
 
 [[package]]
 name = "boxcar"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225450ee9328e1e828319b48a89726cffc1b0ad26fd9211ad435de9fa376acae"
+checksum = "6740c6e2fc6360fa57c35214c7493826aee95993926092606f27c983b40837be"
 dependencies = [
  "loom",
 ]
@@ -3438,7 +3438,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 [[package]]
 name = "salsa"
 version = "0.19.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=d758691ba17ee1a60c5356ea90888d529e1782ad#d758691ba17ee1a60c5356ea90888d529e1782ad"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=395b29d08ad1de0f4f3ac057057219f40e2f6388#395b29d08ad1de0f4f3ac057057219f40e2f6388"
 dependencies = [
  "boxcar",
  "compact_str 0.8.1",
@@ -3454,18 +3454,19 @@ dependencies = [
  "salsa-macro-rules",
  "salsa-macros",
  "smallvec",
+ "thin-vec",
  "tracing",
 ]
 
 [[package]]
 name = "salsa-macro-rules"
 version = "0.19.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=d758691ba17ee1a60c5356ea90888d529e1782ad#d758691ba17ee1a60c5356ea90888d529e1782ad"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=395b29d08ad1de0f4f3ac057057219f40e2f6388#395b29d08ad1de0f4f3ac057057219f40e2f6388"
 
 [[package]]
 name = "salsa-macros"
 version = "0.19.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=d758691ba17ee1a60c5356ea90888d529e1782ad#d758691ba17ee1a60c5356ea90888d529e1782ad"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=395b29d08ad1de0f4f3ac057057219f40e2f6388#395b29d08ad1de0f4f3ac057057219f40e2f6388"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3877,6 +3878,12 @@ dependencies = [
  "syn 2.0.100",
  "test-case-core",
 ]
+
+[[package]]
+name = "thin-vec"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "144f754d318415ac792f9d69fc87abbbfc043ce2ef041c60f16ad828f638717d"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ rayon = { version = "1.10.0" }
 regex = { version = "1.10.2" }
 rustc-hash = { version = "2.0.0" }
 # When updating salsa, make sure to also update the revision in `fuzz/Cargo.toml`
-salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "d758691ba17ee1a60c5356ea90888d529e1782ad" }
+salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "395b29d08ad1de0f4f3ac057057219f40e2f6388"}
 schemars = { version = "0.8.16" }
 seahash = { version = "4.1.0" }
 serde = { version = "1.0.197", features = ["derive"] }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -29,7 +29,7 @@ ruff_python_formatter = { path = "../crates/ruff_python_formatter" }
 ruff_text_size = { path = "../crates/ruff_text_size" }
 
 libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer", default-features = false }
-salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "d758691ba17ee1a60c5356ea90888d529e1782ad" }
+salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "395b29d08ad1de0f4f3ac057057219f40e2f6388"}
 similar = { version = "2.5.0" }
 tracing = { version = "0.1.40" }
 


### PR DESCRIPTION
Update to latest Salsa main branch, so as to get a baseline for measuring the perf effect of https://github.com/salsa-rs/salsa/pull/786 on red-knot in isolation from other recent changes in Salsa main branch.