### PR TITLE
Fix relative import resolution in `site-packages` packages when the `site-packages` search path is a subdirectory of the first-party search path

### DIFF
--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -7367,7 +7367,7 @@ impl StringPartsCollector {
 
 #[cfg(test)]
 mod tests {
-    use crate::db::tests::{setup_db, TestDb};
+    use crate::db::tests::{setup_db, TestDb, TestDbBuilder};
     use crate::semantic_index::definition::Definition;
     use crate::semantic_index::symbol::FileScopeId;
     use crate::semantic_index::{global_scope, semantic_index, symbol_table, use_def_map};
@@ -7375,7 +7375,7 @@ mod tests {
     use crate::types::check_types;
     use ruff_db::diagnostic::Diagnostic;
     use ruff_db::files::{system_path_to_file, File};
-    use ruff_db::system::DbWithWritableSystem as _;
+    use ruff_db::system::{DbWithWritableSystem as _, SystemPath};
     use ruff_db::testing::{assert_function_query_was_not_run, assert_function_query_was_run};
 
     use super::*;
@@ -7529,6 +7529,26 @@ mod tests {
         assert_file_diagnostics(&db, "src/a.py", &[]);
 
         Ok(())
+    }
+
+    #[test]
+    fn relative_import_resolution_in_site_packages_when_site_packages_is_subdirectory_of_first_party_search_path(
+    ) {
+        let project_root = SystemPath::new("/src");
+        let foo_dot_py = project_root.join("foo.py");
+        let site_packages = project_root.join(".venv/lib/python3.13/site-packages");
+
+        let db = TestDbBuilder::new()
+            .with_site_packages_search_path(&site_packages)
+            .with_file(&foo_dot_py, "from bar import A")
+            .with_file(&site_packages.join("bar/__init__.py"), "from .a import *")
+            .with_file(&site_packages.join("bar/a.py"), "class A: ...")
+            .build()
+            .unwrap();
+
+        assert_file_diagnostics(&db, foo_dot_py.as_str(), &[]);
+        let a_symbol = get_symbol(&db, foo_dot_py.as_str(), &[], "A");
+        assert!(a_symbol.expect_type().is_class_literal());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

If a package in `site-packages` had this directory structure:

```py
# bar/__init__.py
from .a import A

# bar/a.py
class A: ...
```

then we would fail to resolve the `from .a import A` import _if_ (as is usually the case!) the `site-packages` search path was located inside a `.venv` directory that was a subdirectory of the project's first-party search path. The reason for this is a bug in `file_to_module` in the module resolver. In this loop, we would identify that `/project_root/.venv/lib/python3.13/site-packages/foo/__init__.py` can be turned into a path relative to the first-party search path (`/project_root`):

https://github.com/astral-sh/ruff/blob/6e2b8f9696e87d786cfed6304dc3baa0f029d341/crates/red_knot_python_semantic/src/module_resolver/resolver.rs#L101-L110

but we'd then try to turn the relative path (.venv/lib/python3.13/site-packages/foo/__init__.py`) into a module path, realise that it wasn't a valid module path... and therefore immediately `break` out of the loop before trying any other search paths (such as the `site-packages` search path).

This bug was originally reported on Discord by @MatthewMckee4.

## Test Plan

I added a unit test for `file_to_module` in `resolver.rs`, and an integration test that shows we can now resolve the import correctly in `infer.rs`.
