### PR TITLE
[red-knot] Default `python-platform` to current platform

### DIFF
--- a/crates/red_knot/src/args.rs
+++ b/crates/red_knot/src/args.rs
@@ -75,7 +75,8 @@ pub(crate) struct CheckCommand {
     ///
     /// This is used to specialize the type of `sys.platform` and will affect the visibility
     /// of platform-specific functions and attributes. If the value is set to `all`, no
-    /// assumptions are made about the target platform.
+    /// assumptions are made about the target platform. If unspecified, the current system's
+    /// platform will be used.
     #[arg(long, value_name = "PLATFORM", alias = "platform")]
     pub(crate) python_platform: Option<String>,
 

--- a/crates/red_knot_project/src/metadata/options.rs
+++ b/crates/red_knot_project/src/metadata/options.rs
@@ -242,7 +242,7 @@ pub struct EnvironmentOptions {
     /// If specified, Red Knot will tailor its use of type stub files,
     /// which conditionalize type definitions based on the platform.
     ///
-    /// If no platform is specified, knot will use current platform:
+    /// If no platform is specified, knot will use the current platform:
     /// - `win32` for Windows
     /// - `darwin` for macOS
     /// - `android` for Android

--- a/crates/red_knot_python_semantic/resources/mdtest/call/getattr_static.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/call/getattr_static.md
@@ -2,6 +2,11 @@
 
 ## Basic usage
 
+```toml
+[environment]
+python-platform = "all"
+```
+
 `inspect.getattr_static` is a function that returns attributes of an object without invoking the
 descriptor protocol (for caveats, see the [official documentation]).
 

--- a/crates/red_knot_python_semantic/resources/mdtest/call/getattr_static.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/call/getattr_static.md
@@ -2,11 +2,6 @@
 
 ## Basic usage
 
-```toml
-[environment]
-python-platform = "all"
-```
-
 `inspect.getattr_static` is a function that returns attributes of an object without invoking the
 descriptor protocol (for caveats, see the [official documentation]).
 
@@ -61,7 +56,7 @@ We can access attributes on objects of all kinds:
 ```py
 import sys
 
-reveal_type(inspect.getattr_static(sys, "platform"))  # revealed: LiteralString
+reveal_type(inspect.getattr_static(sys, "dont_write_bytecode"))  # revealed: bool
 reveal_type(inspect.getattr_static(inspect, "getattr_static"))  # revealed: Literal[getattr_static]
 
 reveal_type(inspect.getattr_static(1, "real"))  # revealed: property

--- a/crates/red_knot_python_semantic/resources/mdtest/sys_platform.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/sys_platform.md
@@ -1,22 +1,9 @@
 # `sys.platform`
 
-## Default value
-
-When no target platform is specified, we fall back to the type of `sys.platform` declared in
-typeshed:
-
-```toml
-[environment]
-# No python-platform entry
-```
-
-```py
-import sys
-
-reveal_type(sys.platform)  # revealed: LiteralString
-```
-
 ## Explicit selection of `all` platforms
+
+When `python-platform="all"` is specified, we fall back to the type of `sys.platform` declared in
+typeshed:
 
 ```toml
 [environment]

--- a/crates/red_knot_python_semantic/resources/mdtest/unreachable.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/unreachable.md
@@ -201,7 +201,7 @@ If `python-platform` is not specified, we currently default to `all`:
 
 ```toml
 [environment]
-# python-platform not specified
+python-platform = "all"
 ```
 
 ```py

--- a/crates/red_knot_python_semantic/resources/mdtest/unreachable.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/unreachable.md
@@ -195,24 +195,6 @@ if sys.platform == "win32":
     sys.getwindowsversion()
 ```
 
-##### Checking without a specified platform
-
-If `python-platform` is not specified, we currently default to `all`:
-
-```toml
-[environment]
-python-platform = "all"
-```
-
-```py
-import sys
-
-if sys.platform == "win32":
-    # TODO: we should not emit an error here
-    # error: [possibly-unbound-attribute]
-    sys.getwindowsversion()
-```
-
 ## No (incorrect) diagnostics in unreachable code
 
 ```toml

--- a/crates/red_knot_python_semantic/src/python_platform.rs
+++ b/crates/red_knot_python_semantic/src/python_platform.rs
@@ -1,7 +1,7 @@
 use std::fmt::{Display, Formatter};
 
 /// The target platform to assume when resolving types.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(
     feature = "serde",
     derive(serde::Serialize, serde::Deserialize),
@@ -9,7 +9,6 @@ use std::fmt::{Display, Formatter};
 )]
 pub enum PythonPlatform {
     /// Do not make any assumptions about the target platform.
-    #[default]
     All,
 
     /// Assume a specific target platform like `linux`, `darwin` or `win32`.
@@ -35,6 +34,22 @@ impl Display for PythonPlatform {
         match self {
             PythonPlatform::All => f.write_str("all"),
             PythonPlatform::Identifier(name) => f.write_str(name),
+        }
+    }
+}
+
+impl Default for PythonPlatform {
+    fn default() -> Self {
+        if cfg!(target_os = "windows") {
+            PythonPlatform::Identifier("win32".to_string())
+        } else if cfg!(target_os = "macos") {
+            PythonPlatform::Identifier("darwin".to_string())
+        } else if cfg!(target_os = "android") {
+            PythonPlatform::Identifier("android".to_string())
+        } else if cfg!(target_os = "ios") {
+            PythonPlatform::Identifier("ios".to_string())
+        } else {
+            PythonPlatform::Identifier("linux".to_string())
         }
     }
 }

--- a/crates/red_knot_test/src/lib.rs
+++ b/crates/red_knot_test/src/lib.rs
@@ -6,7 +6,7 @@ use config::SystemKind;
 use parser as test_parser;
 use red_knot_python_semantic::types::check_types;
 use red_knot_python_semantic::{
-    Program, ProgramSettings, PythonPath, SearchPathSettings, SysPrefixPathOrigin,
+    Program, ProgramSettings, PythonPath, PythonPlatform, SearchPathSettings, SysPrefixPathOrigin,
 };
 use ruff_db::diagnostic::{create_parse_diagnostic, Diagnostic, DisplayDiagnosticConfig};
 use ruff_db::files::{system_path_to_file, File};
@@ -265,7 +265,9 @@ fn run_test(
 
     let settings = ProgramSettings {
         python_version,
-        python_platform: configuration.python_platform().unwrap_or_default(),
+        python_platform: configuration
+            .python_platform()
+            .unwrap_or(PythonPlatform::Identifier("linux".to_string())),
         search_paths: SearchPathSettings {
             src_roots: vec![src_path],
             extra_paths: configuration.extra_paths().unwrap_or_default().to_vec(),

--- a/knot.schema.json
+++ b/knot.schema.json
@@ -89,7 +89,7 @@
           ]
         },
         "python-platform": {
-          "description": "Specifies the target platform that will be used to analyze the source code. If specified, Red Knot will tailor its use of type stub files, which conditionalize type definitions based on the platform.\n\nIf no platform is specified, knot will use `all` or the current platform in the LSP use case.",
+          "description": "Specifies the target platform that will be used to analyze the source code. If specified, Red Knot will tailor its use of type stub files, which conditionalize type definitions based on the platform.\n\nIf no platform is specified, knot will use current platform: - `win32` for Windows - `darwin` for macOS - `android` for Android - `ios` for iOS - `linux` for everything else",
           "anyOf": [
             {
               "$ref": "#/definitions/PythonPlatform"

--- a/knot.schema.json
+++ b/knot.schema.json
@@ -89,7 +89,7 @@
           ]
         },
         "python-platform": {
-          "description": "Specifies the target platform that will be used to analyze the source code. If specified, Red Knot will tailor its use of type stub files, which conditionalize type definitions based on the platform.\n\nIf no platform is specified, knot will use current platform: - `win32` for Windows - `darwin` for macOS - `android` for Android - `ios` for iOS - `linux` for everything else",
+          "description": "Specifies the target platform that will be used to analyze the source code. If specified, Red Knot will tailor its use of type stub files, which conditionalize type definitions based on the platform.\n\nIf no platform is specified, knot will use the current platform: - `win32` for Windows - `darwin` for macOS - `android` for Android - `ios` for iOS - `linux` for everything else",
           "anyOf": [
             {
               "$ref": "#/definitions/PythonPlatform"


### PR DESCRIPTION
## Summary

As discussed in https://github.com/astral-sh/ruff/issues/16983 and "mitigate" said issue for the alpha. 

This PR changes the default for `PythonPlatform` to be the current platform rather than `all`. 

I'm not sure if we should be as sophisticated as supporting `ios` and `android` as defaults but it was easy... 

## Test Plan

Some mdtests started failing because they now defaulted to `darwin`. 
