### PR TITLE
[red-knot] add cycle handling to FunctionType::signature query

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/cycle.md
+++ b/crates/ty_python_semantic/resources/mdtest/cycle.md
@@ -1,0 +1,15 @@
+# Cycles
+
+## Function signature
+
+Deferred annotations can result in cycles in resolving a function signature:
+
+```py
+from __future__ import annotations
+
+# error: [invalid-type-form]
+def f(x: f):
+    pass
+
+reveal_type(f)  # revealed: def f(x: Unknown) -> Unknown
+```

--- a/crates/ty_python_semantic/resources/primer/bad.txt
+++ b/crates/ty_python_semantic/resources/primer/bad.txt
@@ -1,4 +1,3 @@
-Expression  # cycle panic (signature_)
 Tanjun  # cycle panic (signature_)
 altair  # cycle panics (try_metaclass_)
 antidote  # hangs / slow
@@ -12,21 +11,16 @@ hydpy  # cycle panics (try_metaclass_)
 ibis  # cycle panics (try_metaclass_)
 manticore  # stack overflow
 materialize  # stack overflow
-mypy  # cycle panic (signature_)
 pandas  # slow
 pandas-stubs  # cycle panics (try_metaclass_)
 pandera  # cycle panics (try_metaclass_)
 prefect # slow
 pylint  # cycle panics (self-recursive type alias)
-pytest  # cycle panics (signature_)
 pywin32  # bad use-def map (binding with definitely-visible unbound)
-schemathesis  # cycle panics (signature_)
 scikit-learn  # success, but mypy-primer hangs processing the output
 scipy  # missing expression type ("expression should belong to this TypeInference region")
 spack  # success, but mypy-primer hangs processing the output
 spark  # cycle panics (try_metaclass_)
 steam.py  # cycle panics (try_metaclass_), often hangs when multi-threaded
-streamlit  # cycle panic (signature_)
 sympy  # stack overflow
-trio  # cycle panics (deferred annotatation resolving in wrong scope)
 xarray  # cycle panics (try_metaclass_)

--- a/crates/ty_python_semantic/resources/primer/good.txt
+++ b/crates/ty_python_semantic/resources/primer/good.txt
@@ -1,4 +1,5 @@
 AutoSplit
+Expression
 PyGithub
 PyWinCtl
 SinbadCogs
@@ -55,6 +56,7 @@ mkdocs
 mkosi
 mongo-python-driver
 more-itertools
+mypy
 mypy-protobuf
 mypy_primer
 nionutils
@@ -82,6 +84,7 @@ pylox
 pyodide
 pyp
 pyppeteer
+pytest
 pytest-robotframework
 python-chess
 python-htmlgen
@@ -90,6 +93,7 @@ rclip
 rich
 rotki
 schema_salad
+schemathesis
 scrapy
 setuptools
 sockeye
@@ -99,7 +103,9 @@ starlette
 static-frame
 stone
 strawberry
+streamlit
 tornado
+trio
 twine
 typeshed-stats
 urllib3

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -291,6 +291,16 @@ impl<'db> Signature<'db> {
         }
     }
 
+    /// Return the "bottom" signature, subtype of all other fully-static signatures.
+    pub(crate) fn bottom(db: &'db dyn Db) -> Self {
+        Self {
+            generic_context: None,
+            inherited_generic_context: None,
+            parameters: Parameters::object(db),
+            return_ty: Some(Type::Never),
+        }
+    }
+
     pub(crate) fn normalized(&self, db: &'db dyn Db) -> Self {
         Self {
             generic_context: self.generic_context,
@@ -957,7 +967,6 @@ impl<'db> Parameters<'db> {
     }
 
     /// Return parameters that represents `(*args: object, **kwargs: object)`.
-    #[cfg(test)]
     pub(crate) fn object(db: &'db dyn Db) -> Self {
         Self {
             value: vec![


### PR DESCRIPTION
This fixes cycle panics in several ecosystem projects (moved to `good.txt` here), as well as in the minimal case in the added mdtest. It also fixes a number of panicking fuzzer seeds. It doesn't appear to cause any regression in any ecosystem project or any fuzzer seed.
