### PR TITLE
[red-knot] mypy_primer: do not specify Python version

### DIFF
--- a/.github/workflows/mypy_primer.yaml
+++ b/.github/workflows/mypy_primer.yaml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Install mypy_primer
         run: |
-          uv tool install "git+https://github.com/astral-sh/mypy_primer.git@add-red-knot-support-v2"
+          uv tool install "git+https://github.com/astral-sh/mypy_primer.git@add-red-knot-support-v3"
 
       - name: Run mypy_primer
         shell: bash


### PR DESCRIPTION
## Summary

* Pull in latest changes from upstream (which includes an update to a `pyproject.toml` layout and a `uv.lock` file, which should make CI more deterministic)
* Do not specify `--python-version 3.13` in Red Knot runs

https://github.com/astral-sh/mypy_primer/compare/add-red-knot-support-v2...astral-sh:mypy_primer:add-red-knot-support-v3

## Test Plan

Tested locally
