### PR TITLE
Run fuzzer with `--preview`

### DIFF
--- a/python/py-fuzzer/fuzz.py
+++ b/python/py-fuzzer/fuzz.py
@@ -71,6 +71,7 @@ def ruff_contains_bug(code: str, *, ruff_executable: Path) -> bool:
             "--no-cache",
             "--target-version",
             "py313",
+            "--preview",
             "-",
         ],
         capture_output=True,


### PR DESCRIPTION
Summary
--

Updates `fuzz.py` to run with `--preview`, which should allow it to catch semantic syntax errors.

Test Plan
--

@AlexWaygood and I temporarily made any named expression a semantic syntax error and checked that this led to fuzzing errors. We also tested that reverting the `--preview` addition did not show any errors.

We also ran the fuzzer on 500 seeds on `main` but didn't find any issues, (un)fortunately.
