### PR TITLE
[red-knot] Allow setting `python` in mdtests

### DIFF
--- a/crates/red_knot_test/src/config.rs
+++ b/crates/red_knot_test/src/config.rs
@@ -33,25 +33,23 @@ impl MarkdownTestConfig {
     }
 
     pub(crate) fn python_version(&self) -> Option<PythonVersion> {
-        self.environment.as_ref().and_then(|env| env.python_version)
+        self.environment.as_ref()?.python_version
     }
 
     pub(crate) fn python_platform(&self) -> Option<PythonPlatform> {
-        self.environment
-            .as_ref()
-            .and_then(|env| env.python_platform.clone())
+        self.environment.as_ref()?.python_platform.clone()
     }
 
     pub(crate) fn typeshed(&self) -> Option<&SystemPath> {
-        self.environment
-            .as_ref()
-            .and_then(|env| env.typeshed.as_deref())
+        self.environment.as_ref()?.typeshed.as_deref()
     }
 
     pub(crate) fn extra_paths(&self) -> Option<&[SystemPathBuf]> {
-        self.environment
-            .as_ref()
-            .and_then(|env| env.extra_paths.as_deref())
+        self.environment.as_ref()?.extra_paths.as_deref()
+    }
+
+    pub(crate) fn python(&self) -> Option<&SystemPath> {
+        self.environment.as_ref()?.python.as_deref()
     }
 }
 
@@ -69,6 +67,15 @@ pub(crate) struct Environment {
 
     /// Additional search paths to consider when resolving modules.
     pub(crate) extra_paths: Option<Vec<SystemPathBuf>>,
+
+    /// Path to the Python installation from which Red Knot resolves type information and third-party dependencies.
+    ///
+    /// Red Knot will search in the path's `site-packages` directories for type information and
+    /// third-party imports.
+    ///
+    /// This option is commonly used to specify the path to a virtual environment.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub python: Option<SystemPathBuf>,
 }
 
 #[derive(Deserialize, Debug, Clone)]

--- a/crates/red_knot_test/src/lib.rs
+++ b/crates/red_knot_test/src/lib.rs
@@ -221,18 +221,22 @@ fn run_test(
         }
     }
 
+    let configuration = test.configuration();
+
     let settings = ProgramSettings {
-        python_version: test.configuration().python_version().unwrap_or_default(),
-        python_platform: test.configuration().python_platform().unwrap_or_default(),
+        python_version: configuration.python_version().unwrap_or_default(),
+        python_platform: configuration.python_platform().unwrap_or_default(),
         search_paths: SearchPathSettings {
             src_roots: vec![src_path],
-            extra_paths: test
-                .configuration()
-                .extra_paths()
-                .unwrap_or_default()
-                .to_vec(),
+            extra_paths: configuration.extra_paths().unwrap_or_default().to_vec(),
             custom_typeshed: custom_typeshed_path.map(SystemPath::to_path_buf),
-            python_path: PythonPath::KnownSitePackages(vec![]),
+            python_path: PythonPath::KnownSitePackages(
+                configuration
+                    .python()
+                    .into_iter()
+                    .map(SystemPath::to_path_buf)
+                    .collect(),
+            ),
         },
     };
 


### PR DESCRIPTION
## Summary

This PR extends the mdtest options to allow setting the `environment.python` option.

## Test Plan

I let @AlexWaygood write a test and he'll tell me if it works 😆 
