### PR TITLE
[red-knot] Remove global `dead_code` from red-knot-server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2608,7 +2608,6 @@ dependencies = [
  "red_knot_python_semantic",
  "ruff_db",
  "ruff_notebook",
- "ruff_python_ast",
  "ruff_source_file",
  "ruff_text_size",
  "rustc-hash 2.1.1",

--- a/crates/red_knot_server/Cargo.toml
+++ b/crates/red_knot_server/Cargo.toml
@@ -17,7 +17,6 @@ red_knot_python_semantic = { workspace = true }
 
 ruff_db = { workspace = true, features = ["os"] }
 ruff_notebook = { workspace = true }
-ruff_python_ast = { workspace = true }
 ruff_source_file = { workspace = true }
 ruff_text_size = { workspace = true }
 

--- a/crates/red_knot_server/src/document/notebook.rs
+++ b/crates/red_knot_server/src/document/notebook.rs
@@ -199,6 +199,7 @@ impl NotebookDocument {
     }
 
     /// Get the URI for a cell by its index within the cell array.
+    #[expect(dead_code)]
     pub(crate) fn cell_uri_by_index(&self, index: CellId) -> Option<&lsp_types::Url> {
         self.cells.get(index).map(|cell| &cell.url)
     }

--- a/crates/red_knot_server/src/document/range.rs
+++ b/crates/red_knot_server/src/document/range.rs
@@ -13,6 +13,7 @@ use ruff_source_file::OneIndexed;
 use ruff_source_file::{LineIndex, SourceLocation};
 use ruff_text_size::{Ranged, TextRange, TextSize};
 
+#[expect(dead_code)]
 pub(crate) struct NotebookRange {
     pub(crate) cell: notebook::CellId,
     pub(crate) range: types::Range,
@@ -34,6 +35,8 @@ pub(crate) trait ToRangeExt {
         index: &LineIndex,
         encoding: PositionEncoding,
     ) -> types::Range;
+
+    #[expect(dead_code)]
     fn to_notebook_range(
         &self,
         text: &str,

--- a/crates/red_knot_server/src/lib.rs
+++ b/crates/red_knot_server/src/lib.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use crate::server::Server;
 use anyhow::Context;
 pub use document::{DocumentKey, NotebookDocument, PositionEncoding, TextDocument};

--- a/crates/red_knot_server/src/server/api/traits.rs
+++ b/crates/red_knot_server/src/server/api/traits.rs
@@ -17,6 +17,7 @@ pub(super) trait RequestHandler {
 /// This will block the main message receiver loop, meaning that no
 /// incoming requests or notifications will be handled while `run` is
 /// executing. Try to avoid doing any I/O or long-running computations.
+#[expect(dead_code)]
 pub(super) trait SyncRequestHandler: RequestHandler {
     fn run(
         session: &mut Session,

--- a/crates/red_knot_server/src/server/schedule.rs
+++ b/crates/red_knot_server/src/server/schedule.rs
@@ -57,6 +57,7 @@ impl<'s> Scheduler<'s> {
     /// Immediately sends a request of kind `R` to the client, with associated parameters.
     /// The task provided by `response_handler` will be dispatched as soon as the response
     /// comes back from the client.
+    #[expect(dead_code)]
     pub(super) fn request<R>(
         &mut self,
         params: R::Params,

--- a/crates/red_knot_server/src/server/schedule/task.rs
+++ b/crates/red_knot_server/src/server/schedule/task.rs
@@ -17,6 +17,7 @@ type BackgroundFnBuilder<'s> = Box<dyn FnOnce(&Session) -> BackgroundFn + 's>;
 pub(in crate::server) enum BackgroundSchedule {
     /// The task should be run on the background thread designated
     /// for formatting actions. This is a high priority thread.
+    #[expect(dead_code)]
     Fmt,
     /// The task should be run on the general high-priority background
     /// thread.

--- a/crates/red_knot_server/src/session/index.rs
+++ b/crates/red_knot_server/src/session/index.rs
@@ -1,5 +1,4 @@
-use std::borrow::Cow;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Arc;
 
 use lsp_types::Url;
@@ -22,6 +21,7 @@ pub(crate) struct Index {
     notebook_cells: FxHashMap<Url, Url>,
 
     /// Global settings provided by the client.
+    #[expect(dead_code)]
     global_settings: ClientSettings,
 }
 
@@ -34,12 +34,14 @@ impl Index {
         }
     }
 
+    #[expect(dead_code)]
     pub(super) fn text_document_urls(&self) -> impl Iterator<Item = &Url> + '_ {
         self.documents
             .iter()
             .filter_map(|(url, doc)| doc.as_text().and(Some(url)))
     }
 
+    #[expect(dead_code)]
     pub(super) fn notebook_document_urls(&self) -> impl Iterator<Item = &Url> + '_ {
         self.documents
             .iter()
@@ -82,6 +84,7 @@ impl Index {
         }
     }
 
+    #[expect(dead_code)]
     pub(super) fn update_notebook_document(
         &mut self,
         key: &DocumentKey,
@@ -114,10 +117,6 @@ impl Index {
 
         notebook.update(cells, metadata, new_version, encoding)?;
         Ok(())
-    }
-
-    pub(super) fn num_documents(&self) -> usize {
-        self.documents.len()
     }
 
     pub(crate) fn make_document_ref(&self, key: DocumentKey) -> Option<DocumentQuery> {
@@ -267,6 +266,7 @@ pub enum DocumentQuery {
 
 impl DocumentQuery {
     /// Retrieve the original key that describes this document query.
+    #[expect(dead_code)]
     pub(crate) fn make_key(&self) -> DocumentKey {
         match self {
             Self::Text { file_url, .. } => DocumentKey::Text(file_url.clone()),
@@ -286,14 +286,6 @@ impl DocumentQuery {
         }
     }
 
-    /// Get the source type of the document associated with this query.
-    pub(crate) fn source_type(&self) -> ruff_python_ast::PySourceType {
-        match self {
-            Self::Text { .. } => ruff_python_ast::PySourceType::from(self.virtual_file_path()),
-            Self::Notebook { .. } => ruff_python_ast::PySourceType::Ipynb,
-        }
-    }
-
     /// Get the version of document selected by this query.
     pub(crate) fn version(&self) -> DocumentVersion {
         match self {
@@ -309,27 +301,9 @@ impl DocumentQuery {
         }
     }
 
-    /// Get the path for the document selected by this query.
-    ///
-    /// Returns `None` if this is an unsaved (untitled) document.
-    ///
-    /// The path isn't guaranteed to point to a real path on the filesystem. This is the case
-    /// for unsaved (untitled) documents.
-    pub(crate) fn file_path(&self) -> Option<PathBuf> {
-        self.file_url().to_file_path().ok()
-    }
-
-    /// Get the path for the document selected by this query, ignoring whether the file exists on disk.
-    ///
-    /// Returns the URL's path if this is an unsaved (untitled) document.
-    pub(crate) fn virtual_file_path(&self) -> Cow<Path> {
-        self.file_path()
-            .map(Cow::Owned)
-            .unwrap_or_else(|| Cow::Borrowed(Path::new(self.file_url().path())))
-    }
-
     /// Attempt to access the single inner text document selected by the query.
     /// If this query is selecting an entire notebook document, this will return `None`.
+    #[expect(dead_code)]
     pub(crate) fn as_single_document(&self) -> Option<&TextDocument> {
         match self {
             Self::Text { document, .. } => Some(document),


### PR DESCRIPTION
## Summary

Use more local `expect(dead_code)` suppressions instead of a global `allow(dead_code)` in `lib.rs`. 

Remove some methods that are either easy to add later, are less likely to be needed for red knot, or it's unclear if we'd add it the same way as in ruff.

