### PR TITLE
Fix `CallableTypeOf` display signature

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/type_api.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_api.md
@@ -453,6 +453,5 @@ def _(
     # TODO: should be `(x: int) -> Foo`
     reveal_type(c4)  # revealed: (...) -> Foo
 
-    # TODO: `self` is bound here; this should probably be `(x: int) -> str`?
-    reveal_type(c5)  #  revealed: (self, x: int) -> str
+    reveal_type(c5)  #  revealed: (x: int) -> str
 ```

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -519,6 +519,10 @@ impl<'db> Type<'db> {
         matches!(self, Type::FunctionLiteral(..))
     }
 
+    pub const fn is_bound_method(&self) -> bool {
+        matches!(self, Type::BoundMethod(..))
+    }
+
     pub fn is_union_of_single_valued(&self, db: &'db dyn Db) -> bool {
         self.into_union()
             .is_some_and(|union| union.elements(db).iter().all(|ty| ty.is_single_valued(db)))

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -6924,12 +6924,13 @@ impl<'db> TypeInferenceBuilder<'db> {
                         return Type::unknown();
                     };
 
-                    let bound_signature = signature.bind_self();
-                    if let Type::BoundMethod(_) = argument_type {
-                        signature = &bound_signature;
-                    }
+                    let revealed_signature = if argument_type.is_bound_method() {
+                        signature.bind_self()
+                    else {
+                        signature.clone()
+                    };
 
-                    Type::Callable(CallableType::new(db, signature.clone()))
+                    Type::Callable(CallableType::new(db, revealed_signature))
                 }
             },
 

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -6911,7 +6911,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                     let signatures = argument_type.signatures(db);
 
                     // TODO overloads
-                    let Some(signature) = signatures.iter().flatten().next() else {
+                    let Some(mut signature) = signatures.iter().flatten().next() else {
                         self.context.report_lint(
                             &INVALID_TYPE_FORM,
                             arguments_slice,
@@ -6923,6 +6923,11 @@ impl<'db> TypeInferenceBuilder<'db> {
                         );
                         return Type::unknown();
                     };
+
+                    let bound_signature = signature.bind_self();
+                    if let Type::BoundMethod(_) = argument_type {
+                        signature = &bound_signature;
+                    }
 
                     Type::Callable(CallableType::new(db, signature.clone()))
                 }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -6911,7 +6911,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                     let signatures = argument_type.signatures(db);
 
                     // TODO overloads
-                    let Some(mut signature) = signatures.iter().flatten().next() else {
+                    let Some(signature) = signatures.iter().flatten().next() else {
                         self.context.report_lint(
                             &INVALID_TYPE_FORM,
                             arguments_slice,
@@ -6926,7 +6926,7 @@ impl<'db> TypeInferenceBuilder<'db> {
 
                     let revealed_signature = if argument_type.is_bound_method() {
                         signature.bind_self()
-                    else {
+                    } else {
                         signature.clone()
                     };
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

If you reveal type of a variable annotated with `CallableTypeOf[<bound method>]` it includes the self parameter, it shouldnt do this

## Test Plan

update type_api.md
