### PR TITLE
[red-knot] Fix loading color in dark mode

### DIFF
--- a/playground/knot/src/Editor/SecondaryPanel.tsx
+++ b/playground/knot/src/Editor/SecondaryPanel.tsx
@@ -109,7 +109,9 @@ function Run({ files, theme }: { files: ReadonlyFiles; theme: Theme }) {
   }
 
   return (
-    <Suspense fallback={<div className="text-center">Loading</div>}>
+    <Suspense
+      fallback={<div className="text-center dark:text-white">Loading</div>}
+    >
       <RunWithPyiodide
         theme={theme}
         files={files}

--- a/playground/knot/src/Playground.tsx
+++ b/playground/knot/src/Playground.tsx
@@ -480,7 +480,11 @@ function updateFile(
 }
 
 function Loading() {
-  return <div className="align-middle  text-center my-2">Loading...</div>;
+  return (
+    <div className="align-middle text-current text-center my-2 dark:text-white">
+      Loading...
+    </div>
+  );
 }
 
 function restoreWorkspace(


### PR DESCRIPTION
## Summary

The loading indicator on dark mode isn't "visible" because it's black on black. Use white as text color instead.

