### PR TITLE
[`refurb`] Mark the `FURB161` fix unsafe except for integers and booleans

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/refurb/FURB161.py
+++ b/crates/ruff_linter/resources/test/fixtures/refurb/FURB161.py
@@ -12,6 +12,7 @@ count = bin(0x10 + 0x1000).count("1")  # FURB161
 count = bin(ten()).count("1")  # FURB161
 count = bin((10)).count("1")  # FURB161
 count = bin("10" "15").count("1")  # FURB161
+count = bin("123").count("1") # FURB161
 
 count = x.bit_count()  # OK
 count = (10).bit_count()  # OK

--- a/crates/ruff_linter/src/rules/refurb/rules/bit_count.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/bit_count.rs
@@ -30,7 +30,8 @@ use crate::fix::snippet::SourceCodeSnippet;
 ///
 /// ## Fix safety
 /// This rule's fix is marked as unsafe unless the argument to `bin` can be inferred as
-/// an instance of a type that implements the `__index__` and `bit_count` methods.
+/// an instance of a type that implements the `__index__` and `bit_count` methods because this can
+/// change the exception raised at runtime for an invalid argument.
 ///
 /// ## Options
 /// - `target-version`

--- a/crates/ruff_linter/src/rules/refurb/rules/bit_count.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/bit_count.rs
@@ -27,6 +27,10 @@ use crate::fix::snippet::SourceCodeSnippet;
 /// y = 0b1111011.bit_count()
 /// ```
 ///
+/// ## Fix safety
+/// This rule's fix is marked as unsafe, as the `bit_count()` method can be used when the argument
+/// to the `bin()` is an instance of a type that implements the `__index__` and `bit_count` methods.
+///
 /// ## Options
 /// - `target-version`
 ///
@@ -131,7 +135,7 @@ pub(crate) fn bit_count(checker: &Checker, call: &ExprCall) {
         }
 
         Expr::StringLiteral(inner) => (inner.value.is_implicit_concatenated(), false),
-        Expr::BytesLiteral(inner) => (inner.value.is_implicit_concatenated(), true),
+        Expr::BytesLiteral(inner) => (inner.value.is_implicit_concatenated(), false),
         Expr::FString(inner) => (inner.value.is_implicit_concatenated(), false),
 
         Expr::Await(_)
@@ -150,7 +154,7 @@ pub(crate) fn bit_count(checker: &Checker, call: &ExprCall) {
         | Expr::Compare(_)
         | Expr::Tuple(_)
         | Expr::Generator(_)
-        | Expr::IpyEscapeCommand(_) => (true, true),
+        | Expr::IpyEscapeCommand(_) => (true, false),
 
         Expr::Call(_)
         | Expr::Dict(_)
@@ -162,7 +166,7 @@ pub(crate) fn bit_count(checker: &Checker, call: &ExprCall) {
         | Expr::NoneLiteral(_)
         | Expr::EllipsisLiteral(_)
         | Expr::Attribute(_)
-        | Expr::Subscript(_) => (false, true),
+        | Expr::Subscript(_) => (false, false),
     };
 
     let replacement = if parenthesize {

--- a/crates/ruff_linter/src/rules/refurb/rules/bit_count.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/bit_count.rs
@@ -28,8 +28,8 @@ use crate::fix::snippet::SourceCodeSnippet;
 /// ```
 ///
 /// ## Fix safety
-/// This rule's fix is marked as unsafe, as the `bit_count()` method can be used when the argument
-/// to the `bin()` is an instance of a type that implements the `__index__` and `bit_count` methods.
+/// This rule's fix is marked as unsafe unless the argument to `bin` can be inferred as
+/// an instance of a type that implements the `__index__` and `bit_count` methods.
 ///
 /// ## Options
 /// - `target-version`

--- a/crates/ruff_linter/src/rules/refurb/rules/bit_count.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/bit_count.rs
@@ -121,9 +121,10 @@ pub(crate) fn bit_count(checker: &Checker, call: &ExprCall) {
     }
     // Extract, e.g., `x` in `bin(x)`.
     let literal_text = checker.locator().slice(arg);
+
     // If we're calling a method on an integer, or an expression with lower precedence, parenthesize
     // it.
-    let parenthesize: bool = match arg {
+    let parenthesize = match arg {
         Expr::NumberLiteral(ast::ExprNumberLiteral { .. }) => {
             let mut chars = literal_text.chars();
             !matches!(
@@ -160,9 +161,9 @@ pub(crate) fn bit_count(checker: &Checker, call: &ExprCall) {
         | Expr::ListComp(_)
         | Expr::SetComp(_)
         | Expr::DictComp(_)
+        | Expr::BooleanLiteral(_)
         | Expr::NoneLiteral(_)
         | Expr::EllipsisLiteral(_)
-        | Expr::BooleanLiteral(_)
         | Expr::Attribute(_)
         | Expr::Subscript(_) => false,
     };

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB161_FURB161.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB161_FURB161.py.snap
@@ -145,7 +145,7 @@ FURB161.py:12:9: FURB161 [*] Use of `bin(ten()).count('1')`
    12 |+count = ten().bit_count()  # FURB161
 13 13 | count = bin((10)).count("1")  # FURB161
 14 14 | count = bin("10" "15").count("1")  # FURB161
-15 15 | 
+15 15 | count = bin("123").count("1") # FURB161
 
 FURB161.py:13:9: FURB161 [*] Use of `bin(10).count('1')`
    |
@@ -154,6 +154,7 @@ FURB161.py:13:9: FURB161 [*] Use of `bin(10).count('1')`
 13 | count = bin((10)).count("1")  # FURB161
    |         ^^^^^^^^^^^^^^^^^^^^ FURB161
 14 | count = bin("10" "15").count("1")  # FURB161
+15 | count = bin("123").count("1") # FURB161
    |
    = help: Replace with `(10).bit_count()`
 
@@ -164,8 +165,8 @@ FURB161.py:13:9: FURB161 [*] Use of `bin(10).count('1')`
 13    |-count = bin((10)).count("1")  # FURB161
    13 |+count = (10).bit_count()  # FURB161
 14 14 | count = bin("10" "15").count("1")  # FURB161
-15 15 | 
-16 16 | count = x.bit_count()  # OK
+15 15 | count = bin("123").count("1") # FURB161
+16 16 | 
 
 FURB161.py:14:9: FURB161 [*] Use of `bin("10" "15").count('1')`
    |
@@ -173,17 +174,37 @@ FURB161.py:14:9: FURB161 [*] Use of `bin("10" "15").count('1')`
 13 | count = bin((10)).count("1")  # FURB161
 14 | count = bin("10" "15").count("1")  # FURB161
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^ FURB161
-15 |
-16 | count = x.bit_count()  # OK
+15 | count = bin("123").count("1") # FURB161
    |
    = help: Replace with `("10" "15").bit_count()`
 
-ℹ Safe fix
+ℹ Unsafe fix
 11 11 | count = bin(0x10 + 0x1000).count("1")  # FURB161
 12 12 | count = bin(ten()).count("1")  # FURB161
 13 13 | count = bin((10)).count("1")  # FURB161
 14    |-count = bin("10" "15").count("1")  # FURB161
    14 |+count = ("10" "15").bit_count()  # FURB161
-15 15 | 
-16 16 | count = x.bit_count()  # OK
-17 17 | count = (10).bit_count()  # OK
+15 15 | count = bin("123").count("1") # FURB161
+16 16 | 
+17 17 | count = x.bit_count()  # OK
+
+FURB161.py:15:9: FURB161 [*] Use of `bin("123").count('1')`
+   |
+13 | count = bin((10)).count("1")  # FURB161
+14 | count = bin("10" "15").count("1")  # FURB161
+15 | count = bin("123").count("1") # FURB161
+   |         ^^^^^^^^^^^^^^^^^^^^^ FURB161
+16 |
+17 | count = x.bit_count()  # OK
+   |
+   = help: Replace with `"123".bit_count()`
+
+ℹ Unsafe fix
+12 12 | count = bin(ten()).count("1")  # FURB161
+13 13 | count = bin((10)).count("1")  # FURB161
+14 14 | count = bin("10" "15").count("1")  # FURB161
+15    |-count = bin("123").count("1") # FURB161
+   15 |+count = "123".bit_count() # FURB161
+16 16 | 
+17 17 | count = x.bit_count()  # OK
+18 18 | count = (10).bit_count()  # OK

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB161_FURB161.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB161_FURB161.py.snap
@@ -116,7 +116,7 @@ FURB161.py:11:9: FURB161 [*] Use of `bin(0x10 + 0x1000).count('1')`
    |
    = help: Replace with `(0x10 + 0x1000).bit_count()`
 
-ℹ Unsafe fix
+ℹ Safe fix
 8  8  | count = bin(0b1010).count("1")  # FURB161
 9  9  | count = bin(0xA).count("1")  # FURB161
 10 10 | count = bin(0o12).count("1")  # FURB161

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB161_FURB161.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB161_FURB161.py.snap
@@ -12,7 +12,7 @@ FURB161.py:6:9: FURB161 [*] Use of `bin(x).count('1')`
   |
   = help: Replace with `(x).bit_count()`
 
-ℹ Safe fix
+ℹ Unsafe fix
 3 3 | def ten() -> int:
 4 4 |     return 10
 5 5 | 
@@ -116,7 +116,7 @@ FURB161.py:11:9: FURB161 [*] Use of `bin(0x10 + 0x1000).count('1')`
    |
    = help: Replace with `(0x10 + 0x1000).bit_count()`
 
-ℹ Safe fix
+ℹ Unsafe fix
 8  8  | count = bin(0b1010).count("1")  # FURB161
 9  9  | count = bin(0xA).count("1")  # FURB161
 10 10 | count = bin(0o12).count("1")  # FURB161
@@ -137,7 +137,7 @@ FURB161.py:12:9: FURB161 [*] Use of `bin(ten()).count('1')`
    |
    = help: Replace with `ten().bit_count()`
 
-ℹ Safe fix
+ℹ Unsafe fix
 9  9  | count = bin(0xA).count("1")  # FURB161
 10 10 | count = bin(0o12).count("1")  # FURB161
 11 11 | count = bin(0x10 + 0x1000).count("1")  # FURB161


### PR DESCRIPTION
The PR fixes #16457 .

Specifically, `FURB161` is marked safe, but the rule generates safe fixes only in specific cases. Therefore, we attempt to mark the fix as unsafe when we are not in one of these cases. 

For instances, the fix is marked as aunsafe just in case of strings (as pointed out in the issue). Let me know if I should change something.
 
