### PR TITLE
ruff_annotate_snippets: address unused code warnings

### DIFF
--- a/crates/ruff_annotate_snippets/tests/fixtures/main.rs
+++ b/crates/ruff_annotate_snippets/tests/fixtures/main.rs
@@ -7,7 +7,6 @@ use snapbox::Data;
 use std::error::Error;
 
 fn main() {
-    #[cfg(not(windows))]
     tryfn::Harness::new("tests/fixtures/", setup, test)
         .select(["*/*.toml"])
         .test();


### PR DESCRIPTION
Fixes #17230
