### PR TITLE
[docs] fix formatting of "See Style Guide" link

### DIFF
--- a/docs/formatter.md
+++ b/docs/formatter.md
@@ -33,7 +33,7 @@ adoption is minimally disruptive for the vast majority of projects.
 
 Specifically, the formatter is intended to emit near-identical output when run over existing
 Black-formatted code. When run over extensive Black-formatted projects like Django and Zulip, > 99.9%
-of lines are formatted identically. (See: [_Style Guide](#style-guide).)
+of lines are formatted identically. (See: [_Style Guide_](#style-guide).)
 
 Given this focus on Black compatibility, the formatter thus adheres to [Black's (stable) code style](https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html),
 which aims for "consistency, generality, readability and reducing git diffs". To give you a sense


### PR DESCRIPTION


<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Minor formatting tweak in the docs. Looks like the link is meant to be italic (others "See XXXX" are), but the opening underscore isn't closed so it's displayed in the rendered version: https://docs.astral.sh/ruff/formatter/#philosophy

![image](https://github.com/user-attachments/assets/e5984a90-3ea6-4afc-a561-2c681519c78d)


## Test Plan

<!-- How was it tested? -->
