### PR TITLE
[`flake8-pie`] Avoid false positive for multiple assignment with `auto()` (`PIE796`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_pie/PIE796.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pie/PIE796.py
@@ -78,3 +78,9 @@ class FakeEnum11(enum.Enum):
     A = cast(SomeType, ...)
     B = cast(SomeType, ...)  # PIE796
     C = cast(SomeType, ...)  # PIE796
+
+
+class FakeEnum12(enum.Enum):
+    A = enum.auto(), 0
+    B = enum.auto(), 1
+    C = enum.auto(), 0


### PR DESCRIPTION
This fix closes #16868 

I noticed the issue is assigned, but the assignee appears to be actively working on another pull request. I hope that’s okay!

<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

As of Python 3.11.1, `enum.auto()` can be used in multiple assignments. This pattern should not trigger non-unique-enums check.
Reference: [Python docs on enum.auto()](https://docs.python.org/3/library/enum.html#enum.auto)

This fix updates the check logic to skip enum variant statements where the right-hand side is a tuple containing a call to `enum.auto()`.

## Test Plan

<!-- How was it tested? -->

The added test case uses the example from the original issue. It previously triggered a false positive, but now passes successfully.
