### PR TITLE
[ci] Fix pattern for code changes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -143,7 +143,7 @@ jobs:
         env:
           MERGE_BASE: ${{ steps.merge_base.outputs.sha }}
         run: |
-          if git diff --quiet "${MERGE_BASE}...HEAD" -- ':**/*' \
+          if git diff --quiet "${MERGE_BASE}...HEAD" -- ':**' \
             ':!**/*.md' \
             ':crates/red_knot_python_semantic/resources/mdtest/**/*.md' \
             ':!docs/**' \


### PR DESCRIPTION

## Summary

`**/*` only matches files in a subdirectory whereas `**` matches any file at an arbitrary depth

> A trailing "/**" matches everything inside. For example, "abc/**" matches all files inside directory "abc", relative to the location of the .gitignore file, with infinite depth.

> A leading "**" followed by a slash means match in all directories. For example, "**/foo" matches file or directory "foo" anywhere, the same as pattern "foo". "**/foo/bar" matches file or directory "bar" anywhere that is directly under directory "foo".


