### PR TITLE
[playground] New default program

### DIFF
--- a/playground/knot/src/Playground.tsx
+++ b/playground/knot/src/Playground.tsx
@@ -205,9 +205,31 @@ export const DEFAULT_SETTINGS = JSON.stringify(
   4,
 );
 
+const DEFAULT_PROGRAM = `from typing import Literal
+
+type Style = Literal["italic", "bold", "underline"]
+
+# Add parameter annotations \`line: str, word: str, style: Style\` and a return
+# type annotation \`-> str\` to see if you can find the mistakes in this program.
+
+def with_style(line, word, style):
+    if style == "italic":
+        return line.replace(word, f"*{word}*")
+    elif style == "bold":
+        return line.replace(word, f"__{word}__")
+
+    position = line.find(word)
+    output = line + "\\n"
+    output += " " * position
+    output += "-" * len(word)
+
+
+print(with_style("Red Knot is a fast type checker for Python.", "fast", "underlined"))
+`;
+
 const DEFAULT_WORKSPACE = {
   files: {
-    "main.py": "import os",
+    "main.py": DEFAULT_PROGRAM,
     "knot.json": DEFAULT_SETTINGS,
   },
   current: "main.py",


### PR DESCRIPTION
## Summary

This PR proposes to change the default example program in the playground. I realize that this is somewhat underwhelming, but I found it rather difficult to come up with something that circumvented missing support for overloads/generics/self-type, while still looking like (easy!) code that someone might actually write, and demonstrating some Red Knot features. One thing that I wanted to capture was the experience of adding type constraints to an untyped program. And I wanted something that could be executed in the Playground once all errors are fixed.

Happy for any suggestions on what we could do instead. I had a lot of different ideas, but always ran into one or another limitation. So I guess we can also iterate on this as we add more features to Red Knot.

Try it here: https://playknot.ruff.rs/8e3a96af-f35d-4488-840a-2abee6c0512d
```py
from typing import Literal

type Style = Literal["italic", "bold", "underline"]

# Add parameter annotations `line: str, word: str, style: Style` and a return
# type annotation `-> str` to see if you can find the mistakes in this program.

def with_style(line, word, style):
    if style == "italic":
        return line.replace(word, f"*{word}*")
    elif style == "bold":
        return line.replace(word, f"__{word}__")

    position = line.find(word)
    output = line + "\n"
    output += " " * position
    output += "-" * len(word)


print(with_style("Red Knot is a fast type checker for Python.", "fast", "underlined"))
```

closes https://github.com/astral-sh/ruff/issues/17267

## Test Plan

<!-- How was it tested? -->
