### PR TITLE
Add pre-commit hook to check for merge conflicts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,11 @@ exclude: |
   )$
 
 repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-merge-conflict
+
   - repo: https://github.com/abravalheri/validate-pyproject
     rev: v0.24.1
     hooks:


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.) Yes
- Does this pull request include a descriptive title? Yes
- Does this pull request include references to any relevant issues? Yes
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
* Adds a pre-commit check for merge conflict inspired by reviewing #17278. This will flag any commits that contain merge-conflict strings before they are pushed to branches.

## Test Plan
* Checks that it flags merge conflict like in #17278 . This is one of the builtin standard hooks and I have used it in many repos.
<!-- How was it tested? -->
