### PR TITLE
[red-knot] Add `--python-platform` CLI option

### DIFF
--- a/crates/red_knot/src/args.rs
+++ b/crates/red_knot/src/args.rs
@@ -71,6 +71,14 @@ pub(crate) struct CheckCommand {
     #[arg(long, value_name = "VERSION", alias = "target-version")]
     pub(crate) python_version: Option<PythonVersion>,
 
+    /// Target platform to assume when resolving types.
+    ///
+    /// This is used to specialize the type of `sys.platform` and will affect the visibility
+    /// of platform-specific functions and attributes. If the value is set to `all`, no
+    /// assumptions are made about the target platform.
+    #[arg(long, value_name = "PLATFORM", alias = "platform")]
+    pub(crate) python_platform: Option<String>,
+
     #[clap(flatten)]
     pub(crate) verbosity: Verbosity,
 
@@ -116,6 +124,9 @@ impl CheckCommand {
                 python_version: self
                     .python_version
                     .map(|version| RangedValue::cli(version.into())),
+                python_platform: self
+                    .python_platform
+                    .map(|platform| RangedValue::cli(platform.into())),
                 python: self.python.map(RelativePathBuf::cli),
                 typeshed: self.typeshed.map(RelativePathBuf::cli),
                 extra_paths: self.extra_search_path.map(|extra_search_paths| {
@@ -124,7 +135,6 @@ impl CheckCommand {
                         .map(RelativePathBuf::cli)
                         .collect()
                 }),
-                ..EnvironmentOptions::default()
             }),
             terminal: Some(TerminalOptions {
                 output_format: self

--- a/crates/red_knot_project/src/metadata/options.rs
+++ b/crates/red_knot_project/src/metadata/options.rs
@@ -224,7 +224,7 @@ impl Options {
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct EnvironmentOptions {
-    /// Specifies the version of Python that will be used to execute the source code.
+    /// Specifies the version of Python that will be used to analyze the source code.
     /// The version should be specified as a string in the format `M.m` where `M` is the major version
     /// and `m` is the minor (e.g. "3.0" or "3.6").
     /// If a version is provided, knot will generate errors if the source code makes use of language features
@@ -233,7 +233,7 @@ pub struct EnvironmentOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub python_version: Option<RangedValue<PythonVersion>>,
 
-    /// Specifies the target platform that will be used to execute the source code.
+    /// Specifies the target platform that will be used to analyze the source code.
     /// If specified, Red Knot will tailor its use of type stub files,
     /// which conditionalize type definitions based on the platform.
     ///

--- a/crates/red_knot_python_semantic/src/python_platform.rs
+++ b/crates/red_knot_python_semantic/src/python_platform.rs
@@ -21,6 +21,15 @@ pub enum PythonPlatform {
     Identifier(String),
 }
 
+impl From<String> for PythonPlatform {
+    fn from(platform: String) -> Self {
+        match platform.as_str() {
+            "all" => PythonPlatform::All,
+            _ => PythonPlatform::Identifier(platform.to_string()),
+        }
+    }
+}
+
 impl Display for PythonPlatform {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/knot.schema.json
+++ b/knot.schema.json
@@ -89,7 +89,7 @@
           ]
         },
         "python-platform": {
-          "description": "Specifies the target platform that will be used to execute the source code. If specified, Red Knot will tailor its use of type stub files, which conditionalize type definitions based on the platform.\n\nIf no platform is specified, knot will use `all` or the current platform in the LSP use case.",
+          "description": "Specifies the target platform that will be used to analyze the source code. If specified, Red Knot will tailor its use of type stub files, which conditionalize type definitions based on the platform.\n\nIf no platform is specified, knot will use `all` or the current platform in the LSP use case.",
           "anyOf": [
             {
               "$ref": "#/definitions/PythonPlatform"
@@ -100,7 +100,7 @@
           ]
         },
         "python-version": {
-          "description": "Specifies the version of Python that will be used to execute the source code. The version should be specified as a string in the format `M.m` where `M` is the major version and `m` is the minor (e.g. \"3.0\" or \"3.6\"). If a version is provided, knot will generate errors if the source code makes use of language features that are not supported in that version. It will also tailor its use of type stub files, which conditionalizes type definitions based on the version.",
+          "description": "Specifies the version of Python that will be used to analyze the source code. The version should be specified as a string in the format `M.m` where `M` is the major version and `m` is the minor (e.g. \"3.0\" or \"3.6\"). If a version is provided, knot will generate errors if the source code makes use of language features that are not supported in that version. It will also tailor its use of type stub files, which conditionalizes type definitions based on the version.",
           "anyOf": [
             {
               "$ref": "#/definitions/PythonVersion"


### PR DESCRIPTION
## Summary

Add a new `--python-platform` command-line option, in analogy to `--python-version`.

## Test Plan

Added new integration test.
