### PR TITLE
[`airflow`] Refactor `AIR301` logic and fix typos (`AIR301`)

### DIFF
--- a/crates/ruff_linter/src/rules/airflow/helpers.rs
+++ b/crates/ruff_linter/src/rules/airflow/helpers.rs
@@ -10,12 +10,12 @@ pub(crate) enum Replacement {
     Name(&'static str),
     Message(&'static str),
     AutoImport {
-        path: &'static str,
+        module: &'static str,
         name: &'static str,
     },
     SourceModuleMoved {
-        name: String,
         module: &'static str,
+        name: String,
     },
 }
 
@@ -59,10 +59,10 @@ pub(crate) fn is_guarded_by_try_except(
 /// contain any [`ast::StmtImportFrom`] nodes that indicate the numpy
 /// member is being imported from the non-deprecated location?
 fn try_block_contains_undeprecated_import(try_node: &StmtTry, replacement: &Replacement) -> bool {
-    let Replacement::AutoImport { path, name } = replacement else {
+    let Replacement::AutoImport { module, name } = replacement else {
         return false;
     };
-    let mut import_searcher = ImportSearcher::new(path, name);
+    let mut import_searcher = ImportSearcher::new(module, name);
     import_searcher.visit_body(&try_node.body);
     import_searcher.found_import
 }

--- a/crates/ruff_linter/src/rules/airflow/helpers.rs
+++ b/crates/ruff_linter/src/rules/airflow/helpers.rs
@@ -13,6 +13,10 @@ pub(crate) enum Replacement {
         path: &'static str,
         name: &'static str,
     },
+    SourceModuleMoved {
+        name: String,
+        module: &'static str,
+    },
 }
 
 pub(crate) fn is_guarded_by_try_except(

--- a/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
@@ -593,15 +593,15 @@ fn check_name(checker: &Checker, expr: &Expr, range: TextRange) {
         }
 
         // airflow.configuration
-        ["airflow", "configuration", rest @ ..] => match &rest {
-            ["get"] => Replacement::Name("airflow.configuration.conf.get"),
-            ["getboolean"] => Replacement::Name("airflow.configuration.conf.getboolean"),
-            ["getfloat"] => Replacement::Name("airflow.configuration.conf.getfloat"),
-            ["getint"] => Replacement::Name("airflow.configuration.conf.getint"),
-            ["has_option"] => Replacement::Name("airflow.configuration.conf.has_option"),
-            ["remove_option"] => Replacement::Name("airflow.configuration.conf.remove_option"),
-            ["as_dict"] => Replacement::Name("airflow.configuration.conf.as_dict"),
-            ["set"] => Replacement::Name("airflow.configuration.conf.set"),
+        ["airflow", "configuration", rest] => match *rest {
+            "get" => Replacement::Name("airflow.configuration.conf.get"),
+            "getboolean" => Replacement::Name("airflow.configuration.conf.getboolean"),
+            "getfloat" => Replacement::Name("airflow.configuration.conf.getfloat"),
+            "getint" => Replacement::Name("airflow.configuration.conf.getint"),
+            "has_option" => Replacement::Name("airflow.configuration.conf.has_option"),
+            "remove_option" => Replacement::Name("airflow.configuration.conf.remove_option"),
+            "as_dict" => Replacement::Name("airflow.configuration.conf.as_dict"),
+            "set" => Replacement::Name("airflow.configuration.conf.set"),
             _ => return,
         },
 
@@ -644,6 +644,7 @@ fn check_name(checker: &Checker, expr: &Expr, range: TextRange) {
         }
 
         // airflow.listeners.spec
+        // TODO: this is removed
         ["airflow", "listeners", "spec", "dataset", rest @ ..] => match &rest {
             ["on_dataset_created"] => {
                 Replacement::Name("airflow.listeners.spec.asset.on_asset_created")
@@ -655,27 +656,26 @@ fn check_name(checker: &Checker, expr: &Expr, range: TextRange) {
         },
 
         // airflow.metrics.validators
-        ["airflow", "metrics", "validators", rest @ ..] => match &rest {
-            ["AllowListValidator"] => {
+        ["airflow", "metrics", "validators", rest] => match *rest {
+            "AllowListValidator" => {
                 Replacement::Name("airflow.metrics.validators.PatternAllowListValidator")
             }
-            ["BlockListValidator"] => {
+            "BlockListValidator" => {
                 Replacement::Name("airflow.metrics.validators.PatternBlockListValidator")
             }
             _ => return,
         },
 
         // airflow.models.baseoperator
-        ["airflow", "models", "baseoperator", "chain"] => Replacement::Name("airflow.sdk.chain"),
-        ["airflow", "models", "baseoperator", "chain_linear"] => {
-            Replacement::Name("airflow.sdk.chain_linear")
-        }
-        ["airflow", "models", "baseoperator", "cross_downstream"] => {
-            Replacement::Name("airflow.sdk.cross_downstream")
-        }
-        ["airflow", "models", "baseoperatorlink", "BaseOperatorLink"] => {
-            Replacement::Name("airflow.sdk.definitions.baseoperatorlink.BaseOperatorLink")
-        }
+        ["airflow", "models", "baseoperator", rest] => match *rest {
+            "chain" => Replacement::Name("airflow.sdk.chain"),
+            "chain_linear" => Replacement::Name("airflow.sdk.chain_linear"),
+            "cross_downstream" => Replacement::Name("airflow.sdk.cross_downstream"),
+            "BaseOperatorLink" => {
+                Replacement::Name("airflow.sdk.definitions.baseoperatorlink.BaseOperatorLink")
+            }
+            _ => return,
+        },
 
         // airflow.notifications
         ["airflow", "notifications", "basenotifier", "BaseNotifier"] => {
@@ -765,11 +765,12 @@ fn check_name(checker: &Checker, expr: &Expr, range: TextRange) {
         },
 
         // airflow.www
+        // TODO: www has been removed
         ["airflow", "www", "auth", "has_access"] => {
             Replacement::Name("airflow.www.auth.has_access_*")
         }
         ["airflow", "www", "auth", "has_access_dataset"] => {
-            Replacement::Name("airflow.www.auth.has_access_dataset.has_access_asset")
+            Replacement::Name("airflow.www.auth.has_access_dataset")
         }
         ["airflow", "www", "utils", "get_sensitive_variables_fields"] => {
             Replacement::Name("airflow.utils.log.secrets_masker.get_sensitive_variables_fields")

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR301_AIR301_class_attribute.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR301_AIR301_class_attribute.py.snap
@@ -244,7 +244,7 @@ AIR301_class_attribute.py:42:6: AIR301 `airflow.datasets.manager.DatasetManager`
 43 | dm.register_dataset_change()
 44 | dm.create_datasets()
    |
-   = help: Use `airflow.assets.AssetManager` instead
+   = help: Use `airflow.assets.manager.AssetManager` instead
 
 AIR301_class_attribute.py:43:4: AIR301 [*] `register_dataset_change` is removed in Airflow 3.0
    |

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR301_AIR301_names.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR301_AIR301_names.py.snap
@@ -876,7 +876,7 @@ AIR301_names.py:264:1: AIR301 `airflow.www.auth.has_access_dataset` is removed i
 265 |
 266 | # airflow.www.utils
     |
-    = help: Use `airflow.www.auth.has_access_dataset.has_access_asset` instead
+    = help: Use `airflow.www.auth.has_access_dataset` instead
 
 AIR301_names.py:267:1: AIR301 `airflow.www.utils.get_sensitive_variables_fields` is removed in Airflow 3.0
     |

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR301_AIR301_names.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR301_AIR301_names.py.snap
@@ -321,7 +321,7 @@ AIR301_names.py:118:1: AIR301 `airflow.datasets.manager.DatasetManager` is remov
 119 | dataset_manager
 120 | resolve_dataset_manager
     |
-    = help: Use `airflow.assets.AssetManager` instead
+    = help: Use `airflow.assets.manager.AssetManager` instead
 
 AIR301_names.py:119:1: AIR301 `airflow.datasets.manager.dataset_manager` is removed in Airflow 3.0
     |


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

* Simplify match conditions in AIR301
* Fix
    * `airflow.datasets.manager.DatasetManager` → `airflow.assets.manager.AssetManager`
    * `airflow.www.auth.has_access_dataset` → `airflow.www.auth.has_access_dataset` 

## Test Plan

<!-- How was it tested? -->
The test fixture has been updated accordingly