### PR TITLE
[red-knot] Fix false positives on `types.UnionType` instances in type expressions

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/union.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/union.md
@@ -2,7 +2,7 @@
 
 ## Annotation
 
-`typing.Union` can be used to construct union types same as `|` operator.
+`typing.Union` can be used to construct union types in the same way as the `|` operator.
 
 ```py
 from typing import Union
@@ -68,4 +68,21 @@ from typing import Union
 # error: [invalid-type-form] "`typing.Union` requires at least one argument when used in a type expression"
 def f(x: Union) -> None:
     reveal_type(x)  # revealed: Unknown
+```
+
+## Implicit type aliases using new-style unions
+
+We don't recognise these as type aliases yet, but we also don't emit false-positive diagnostics if
+you use them in type expressions:
+
+```toml
+[environment]
+python-version = "3.10"
+```
+
+```py
+X = int | str
+
+def f(y: X):
+    reveal_type(y)  # revealed: @Todo(Support for `types.UnionType` instances in type expressions)
 ```

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -3710,6 +3710,9 @@ impl<'db> Type<'db> {
                 Some(KnownClass::GenericAlias) => Ok(todo_type!(
                     "Support for `typing.GenericAlias` instances in type expressions"
                 )),
+                Some(KnownClass::UnionType) => Ok(todo_type!(
+                    "Support for `types.UnionType` instances in type expressions"
+                )),
                 _ => Err(InvalidTypeExpressionError {
                     invalid_expressions: smallvec::smallvec![InvalidTypeExpression::InvalidType(
                         *self

--- a/crates/red_knot_python_semantic/src/types/class.rs
+++ b/crates/red_knot_python_semantic/src/types/class.rs
@@ -852,6 +852,7 @@ pub enum KnownClass {
     MethodType,
     MethodWrapperType,
     WrapperDescriptorType,
+    UnionType,
     // Typeshed
     NoneType, // Part of `types` for Python >= 3.10
     // Typing
@@ -915,6 +916,7 @@ impl<'db> KnownClass {
             | Self::ParamSpecKwargs
             | Self::TypeVarTuple
             | Self::WrapperDescriptorType
+            | Self::UnionType
             | Self::MethodWrapperType => Truthiness::AlwaysTrue,
 
             Self::NoneType => Truthiness::AlwaysFalse,
@@ -987,6 +989,7 @@ impl<'db> KnownClass {
             Self::ModuleType => "ModuleType",
             Self::FunctionType => "FunctionType",
             Self::MethodType => "MethodType",
+            Self::UnionType => "UnionType",
             Self::MethodWrapperType => "MethodWrapperType",
             Self::WrapperDescriptorType => "WrapperDescriptorType",
             Self::NoneType => "NoneType",
@@ -1169,6 +1172,7 @@ impl<'db> KnownClass {
             | Self::FunctionType
             | Self::MethodType
             | Self::MethodWrapperType
+            | Self::UnionType
             | Self::WrapperDescriptorType => KnownModule::Types,
             Self::NoneType => KnownModule::Typeshed,
             Self::Any
@@ -1221,6 +1225,7 @@ impl<'db> KnownClass {
             | Self::VersionInfo
             | Self::EllipsisType
             | Self::TypeAliasType
+            | Self::UnionType
             | Self::NotImplementedType => true,
 
             Self::Any
@@ -1325,6 +1330,7 @@ impl<'db> KnownClass {
             | Self::Sized
             | Self::Enum
             | Self::Super
+            | Self::UnionType
             | Self::NewType => false,
         }
     }
@@ -1363,6 +1369,7 @@ impl<'db> KnownClass {
             "ModuleType" => Self::ModuleType,
             "FunctionType" => Self::FunctionType,
             "MethodType" => Self::MethodType,
+            "UnionType" => Self::UnionType,
             "MethodWrapperType" => Self::MethodWrapperType,
             "WrapperDescriptorType" => Self::WrapperDescriptorType,
             "NewType" => Self::NewType,
@@ -1440,6 +1447,7 @@ impl<'db> KnownClass {
             | Self::Enum
             | Self::Super
             | Self::NotImplementedType
+            | Self::UnionType
             | Self::WrapperDescriptorType => module == self.canonical_module(db),
             Self::NoneType => matches!(module, KnownModule::Typeshed | KnownModule::Types),
             Self::SpecialForm
@@ -1939,6 +1947,7 @@ mod tests {
 
         for class in KnownClass::iter() {
             let version_added = match class {
+                KnownClass::UnionType => PythonVersion::PY310,
                 KnownClass::BaseExceptionGroup => PythonVersion::PY311,
                 KnownClass::GenericAlias => PythonVersion::PY39,
                 _ => PythonVersion::PY37,


### PR DESCRIPTION
## Summary

For an implicit type alias like `X = int | str`, don't emit a false positive if `X` is then used in a type annotation.

## Test Plan

Added a test
