### PR TITLE
[red-knot] more type-narrowing in match statements

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/match.md
@@ -39,8 +39,7 @@ match x:
     case A():
         reveal_type(x)  # revealed: A
     case B():
-        # TODO could be `B & ~A`
-        reveal_type(x)  # revealed: B
+        reveal_type(x)  # revealed: B & ~A
 
 reveal_type(x)  # revealed: object
 ```
@@ -88,7 +87,7 @@ match x:
     case 6.0:
         reveal_type(x)  # revealed: float
     case 1j:
-        reveal_type(x)  # revealed: complex
+        reveal_type(x)  # revealed: complex & ~float
     case b"foo":
         reveal_type(x)  # revealed: Literal[b"foo"]
 
@@ -134,11 +133,11 @@ match x:
     case "foo" | 42 | None:
         reveal_type(x)  # revealed: Literal["foo", 42] | None
     case "foo" | tuple():
-        reveal_type(x)  # revealed: Literal["foo"] | tuple
+        reveal_type(x)  # revealed: tuple
     case True | False:
         reveal_type(x)  # revealed: bool
     case 3.14 | 2.718 | 1.414:
-        reveal_type(x)  # revealed: float
+        reveal_type(x)  # revealed: float & ~tuple
 
 reveal_type(x)  # revealed: object
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/match.md
@@ -165,3 +165,49 @@ match x:
 
 reveal_type(x)  # revealed: object
 ```
+
+## Narrowing due to guard
+
+```py
+def get_object() -> object:
+    return object()
+
+x = get_object()
+
+reveal_type(x)  # revealed: object
+
+match x:
+    case str() | float() if type(x) is str:
+        reveal_type(x)  #  revealed: str
+    case "foo" | 42 | None if isinstance(x, int):
+        reveal_type(x)  #  revealed: Literal[42]
+    case False if x:
+        reveal_type(x)  #  revealed: Never
+    case "foo" if x := "bar":
+        reveal_type(x)  # revealed: Literal["bar"]
+
+reveal_type(x)  # revealed: object
+```
+
+## Guard and reveal_type in guard
+
+```py
+def get_object() -> object:
+    return object()
+
+x = get_object()
+
+reveal_type(x)  # revealed: object
+
+match x:
+    case str() | float() if type(x) is str and reveal_type(x):  # revealed: str
+        pass
+    case "foo" | 42 | None if isinstance(x, int) and reveal_type(x):  #  revealed: Literal[42]
+        pass
+    case False if x and reveal_type(x):  #  revealed: Never
+        pass
+    case "foo" if (x := "bar") and reveal_type(x):  #  revealed: Literal["bar"]
+        pass
+
+reveal_type(x)  # revealed: object
+```

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -1572,50 +1572,65 @@ where
                     return;
                 }
 
-                let after_subject = self.flow_snapshot();
+                let has_catchall = cases
+                    .last()
+                    .is_some_and(|case| case.guard.is_none() && case.pattern.is_wildcard());
+
+                let mut no_case_matched = self.flow_snapshot();
                 let mut vis_constraints = vec![];
                 let mut post_case_snapshots = vec![];
-                for (i, case) in cases.iter().enumerate() {
-                    if i != 0 {
-                        post_case_snapshots.push(self.flow_snapshot());
-                        self.flow_restore(after_subject.clone());
-                    }
+                let mut match_predicate;
 
+                for (i, case) in cases.iter().enumerate() {
                     self.current_match_case = Some(CurrentMatchCase::new(&case.pattern));
                     self.visit_pattern(&case.pattern);
                     self.current_match_case = None;
-                    let predicate = self.add_pattern_narrowing_constraint(
+                    no_case_matched = self.flow_snapshot();
+                    match_predicate = self.add_pattern_narrowing_constraint(
                         subject_expr,
                         &case.pattern,
                         case.guard.as_deref(),
                     );
-                    self.record_reachability_constraint(predicate);
-                    if let Some(guard) = &case.guard {
+                    self.record_reachability_constraint(match_predicate);
+
+                    let match_success_guard_failure = case.guard.as_ref().map(|guard| {
                         let guard_expr = self.add_standalone_expression(guard);
                         self.visit_expr(guard);
+                        let post_match_success = self.flow_snapshot();
                         let predicate = Predicate {
                             node: PredicateNode::Expression(guard_expr),
                             is_positive: true,
                         };
+                        self.record_negated_narrowing_constraint(predicate);
+                        let match_success_guard_failure = self.flow_snapshot();
+                        self.flow_restore(post_match_success);
                         self.record_narrowing_constraint(predicate);
-                    }
+                        match_success_guard_failure
+                    });
+
                     self.visit_body(&case.body);
                     for id in &vis_constraints {
                         self.record_negated_visibility_constraint(*id);
                     }
-                    let vis_constraint_id = self.record_visibility_constraint(predicate);
+                    let vis_constraint_id = self.record_visibility_constraint(match_predicate);
                     vis_constraints.push(vis_constraint_id);
+
+                    post_case_snapshots.push(self.flow_snapshot());
+
+                    if i != cases.len() - 1 || !has_catchall {
+                        // We need to restore the state after each case, but not after the last one.
+                        // The last one will just become the state that we merge the other snapshots into
+                        self.flow_restore(no_case_matched.clone());
+                        self.record_negated_narrowing_constraint(match_predicate);
+                        if let Some(match_success_guard_failure) = match_success_guard_failure {
+                            self.flow_merge(match_success_guard_failure);
+                        }
+                    }
                 }
 
                 // If there is no final wildcard match case, pretend there is one. This is similar to how
                 // we add an implicit `else` block in if-elif chains, in case it's not present.
-                if !cases
-                    .last()
-                    .is_some_and(|case| case.guard.is_none() && case.pattern.is_wildcard())
-                {
-                    post_case_snapshots.push(self.flow_snapshot());
-                    self.flow_restore(after_subject.clone());
-
+                if !has_catchall {
                     for id in &vis_constraints {
                         self.record_negated_visibility_constraint(*id);
                     }
@@ -1625,7 +1640,7 @@ where
                     self.flow_merge(post_clause_state);
                 }
 
-                self.simplify_visibility_constraints(after_subject);
+                self.simplify_visibility_constraints(no_case_matched);
             }
             ast::Stmt::Try(ast::StmtTry {
                 body,

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -1618,8 +1618,10 @@ where
                     post_case_snapshots.push(self.flow_snapshot());
 
                     if i != cases.len() - 1 || !has_catchall {
-                        // We need to restore the state after each case, but not after the last one.
-                        // The last one will just become the state that we merge the other snapshots into
+                        // We need to restore the state after each case, but not after the last
+                        // one. The last one will just become the state that we merge the other
+                        // snapshots into. (If there's no catch-all, we'll add an implied one
+                        // below, so this can't be the last case.)
                         self.flow_restore(no_case_matched.clone());
                         self.record_negated_narrowing_constraint(match_predicate);
                         if let Some(match_success_guard_failure) = match_success_guard_failure {

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -568,23 +568,16 @@ impl<'db> SemanticIndexBuilder<'db> {
         id
     }
 
-    /// Constructs a visibility constraint id without recording it
-    fn visibility_constraint_id(
-        &mut self,
-        predicate: Predicate<'db>,
-    ) -> ScopedVisibilityConstraintId {
-        let predicate_id = self.current_use_def_map_mut().add_predicate(predicate);
-        self.current_visibility_constraints_mut()
-            .add_atom(predicate_id)
-    }
-
     /// Records a visibility constraint by applying it to all live bindings and declarations.
     #[must_use = "A visibility constraint must always be negated after it is added"]
     fn record_visibility_constraint(
         &mut self,
         predicate: Predicate<'db>,
     ) -> ScopedVisibilityConstraintId {
-        let id = self.visibility_constraint_id(predicate);
+        let predicate_id = self.current_use_def_map_mut().add_predicate(predicate);
+        let id = self
+            .current_visibility_constraints_mut()
+            .add_atom(predicate_id);
         self.record_visibility_constraint_id(id);
         id
     }

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -1578,7 +1578,6 @@ where
                     .last()
                     .is_some_and(|case| case.guard.is_none() && case.pattern.is_wildcard());
 
-                let mut vis_constraints = vec![];
                 let mut post_case_snapshots = vec![];
                 let mut match_predicate;
 
@@ -1615,7 +1614,6 @@ where
                     self.record_visibility_constraint_id(vis_constraint_id);
 
                     self.visit_body(&case.body);
-                    vis_constraints.push(vis_constraint_id);
 
                     post_case_snapshots.push(self.flow_snapshot());
 
@@ -1635,9 +1633,7 @@ where
                         debug_assert!(case.guard.is_none());
                     }
 
-                    for id in &vis_constraints {
-                        self.record_negated_visibility_constraint(*id);
-                    }
+                    self.record_negated_visibility_constraint(vis_constraint_id);
                     no_case_matched = self.flow_snapshot();
                 }
 

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -1590,8 +1590,14 @@ where
                         case.guard.as_deref(),
                     );
                     self.record_reachability_constraint(predicate);
-                    if let Some(expr) = &case.guard {
-                        self.visit_expr(expr);
+                    if let Some(guard) = &case.guard {
+                        let guard_expr = self.add_standalone_expression(guard);
+                        self.visit_expr(guard);
+                        let predicate = Predicate {
+                            node: PredicateNode::Expression(guard_expr),
+                            is_positive: true,
+                        };
+                        self.record_narrowing_constraint(predicate);
                     }
                     self.visit_body(&case.body);
                     for id in &vis_constraints {

--- a/crates/red_knot_python_semantic/src/types/narrow.rs
+++ b/crates/red_knot_python_semantic/src/types/narrow.rs
@@ -302,7 +302,6 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
         pattern: PatternPredicate<'db>,
     ) -> Option<NarrowingConstraints<'db>> {
         let subject = pattern.subject(self.db);
-
         self.evaluate_pattern_predicate_kind(pattern.kind(self.db), subject)
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Add more narrowing analysis for match statements:
* add narrowing constraints from guard expressions
* add negated constraints from previous predicates and guards to subsequent cases

This PR doesn't address that guards can mutate your subject, and so theoretically invalidate some of these narrowing constraints that you've previously accumulated. Some prior art on this issue [here][mutable guards].

[mutable guards]: https://www.irif.fr/~scherer/research/mutable-patterns/mutable-patterns-mlworkshop2024-abstract.pdf

## Test Plan

Add some new tests, and update some existing ones
<!-- How was it tested? -->
