### PR TITLE
[red-knot] Update salsa (part 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3442,7 +3442,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 [[package]]
 name = "salsa"
 version = "0.19.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=296a8c78da1b54c76ff5795eb4c1e3fe2467e9fc#296a8c78da1b54c76ff5795eb4c1e3fe2467e9fc"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=c999c713d757b857b13f23fe38acc40ec5b4134c#c999c713d757b857b13f23fe38acc40ec5b4134c"
 dependencies = [
  "boxcar",
  "compact_str 0.8.1",
@@ -3465,12 +3465,12 @@ dependencies = [
 [[package]]
 name = "salsa-macro-rules"
 version = "0.19.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=296a8c78da1b54c76ff5795eb4c1e3fe2467e9fc#296a8c78da1b54c76ff5795eb4c1e3fe2467e9fc"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=c999c713d757b857b13f23fe38acc40ec5b4134c#c999c713d757b857b13f23fe38acc40ec5b4134c"
 
 [[package]]
 name = "salsa-macros"
 version = "0.19.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=296a8c78da1b54c76ff5795eb4c1e3fe2467e9fc#296a8c78da1b54c76ff5795eb4c1e3fe2467e9fc"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=c999c713d757b857b13f23fe38acc40ec5b4134c#c999c713d757b857b13f23fe38acc40ec5b4134c"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ rayon = { version = "1.10.0" }
 regex = { version = "1.10.2" }
 rustc-hash = { version = "2.0.0" }
 # When updating salsa, make sure to also update the revision in `fuzz/Cargo.toml`
-salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "296a8c78da1b54c76ff5795eb4c1e3fe2467e9fc" }
+salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "c999c713d757b857b13f23fe38acc40ec5b4134c" }
 schemars = { version = "0.8.16" }
 seahash = { version = "4.1.0" }
 serde = { version = "1.0.197", features = ["derive"] }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -29,7 +29,7 @@ ruff_python_formatter = { path = "../crates/ruff_python_formatter" }
 ruff_text_size = { path = "../crates/ruff_text_size" }
 
 libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer", default-features = false }
-salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "296a8c78da1b54c76ff5795eb4c1e3fe2467e9fc"}
+salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "c999c713d757b857b13f23fe38acc40ec5b4134c" }
 similar = { version = "2.5.0" }
 tracing = { version = "0.1.40" }
 


### PR DESCRIPTION
## Summary

Update salsa up to the commit before the fixpoint with tracked struct fix to narrow the perf regression.

## Test Plan

`cargo test`
