### PR TITLE
[red-knot] Track reachability of scopes

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/unreachable.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/unreachable.md
@@ -423,14 +423,10 @@ if False:
     x = 1
 
     def f():
-        # TODO
-        # error: [unresolved-reference]
         print(x)
 
     class C:
         def __init__(self):
-            # TODO
-            # error: [unresolved-reference]
             print(x)
 ```
 

--- a/crates/red_knot_python_semantic/src/semantic_index.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index.rs
@@ -241,9 +241,8 @@ impl<'db> SemanticIndex<'db> {
     }
 
     fn is_scope_reachable(&self, db: &'db dyn Db, scope_id: FileScopeId) -> bool {
-        match self.parent_scope_id(scope_id) {
-            None => true,
-            Some(parent_scope_id) => {
+        self.parent_scope_id(scope_id)
+            .is_none_or(|parent_scope_id| {
                 if !self.is_scope_reachable(db, parent_scope_id) {
                     return false;
                 }
@@ -252,8 +251,7 @@ impl<'db> SemanticIndex<'db> {
                 let reachability = self.scope(scope_id).reachability();
 
                 parent_use_def.is_reachable(db, reachability)
-            }
-        }
+            })
     }
 
     /// Returns true if a given 'use' of a symbol is reachable from the start of the scope.

--- a/crates/red_knot_python_semantic/src/semantic_index/symbol.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/symbol.rs
@@ -12,6 +12,7 @@ use rustc_hash::FxHasher;
 
 use crate::ast_node_ref::AstNodeRef;
 use crate::node_key::NodeKey;
+use crate::semantic_index::visibility_constraints::ScopedVisibilityConstraintId;
 use crate::semantic_index::{semantic_index, SymbolMap};
 use crate::Db;
 
@@ -176,6 +177,7 @@ pub struct Scope {
     parent: Option<FileScopeId>,
     node: NodeWithScopeKind,
     descendants: Range<FileScopeId>,
+    reachability: ScopedVisibilityConstraintId,
 }
 
 impl Scope {
@@ -183,11 +185,13 @@ impl Scope {
         parent: Option<FileScopeId>,
         node: NodeWithScopeKind,
         descendants: Range<FileScopeId>,
+        reachability: ScopedVisibilityConstraintId,
     ) -> Self {
         Scope {
             parent,
             node,
             descendants,
+            reachability,
         }
     }
 
@@ -213,6 +217,10 @@ impl Scope {
 
     pub(crate) fn is_eager(&self) -> bool {
         self.kind().is_eager()
+    }
+
+    pub(crate) fn reachability(&self) -> ScopedVisibilityConstraintId {
+        self.reachability
     }
 }
 

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -4302,7 +4302,9 @@ impl<'db> TypeInferenceBuilder<'db> {
         } else {
             let use_id = name_node.scoped_use_id(db, scope);
             let symbol = symbol_from_bindings(db, use_def.bindings_at_use(use_id));
-            let report_unresolved_usage = use_def.is_symbol_use_reachable(db, use_id);
+            let report_unresolved_usage =
+                self.index
+                    .is_symbol_use_reachable(db, file_scope_id, use_id);
             (symbol, report_unresolved_usage)
         };
 


### PR DESCRIPTION
## Summary

Track the reachability of nested scopes within their parent scopes. We use this as an additional requirement for emitting `unresolved-reference` diagnostics (and in the future, `unresolved-attribute` and `unresolved-import`). This means that we only emit `unresolved-reference` for a given use of a symbol if the use itself is reachable (within its own scope), *and if the scope itself is reachable*. For example, no diagnostic should be emitted for the use of `x` here:

```py
if False:
    x = 1

    def f():
        print(x)  # this use of `x` is reachable inside the `f` scope,
                  # but the whole `f` scope is not reachable.
```

There are probably more fine-grained ways of solving this problem, but they require a more sophisticated understanding of nested scopes (see #15777, in particular https://github.com/astral-sh/ruff/issues/15777#issuecomment-2788950267). But it doesn't seem completely unreasonable to silence *this specific kind of error* in unreachable scopes.

## Test Plan

Observed changes in reachability tests and ecosystem.