### PR TITLE
[red-knot] Fix double hovers/inlays in playground

### DIFF
--- a/playground/knot/src/Editor/Editor.tsx
+++ b/playground/knot/src/Editor/Editor.tsx
@@ -94,6 +94,8 @@ export default function Editor({
 
   const handleMount: OnMount = useCallback(
     (editor, instance) => {
+      serverRef.current?.dispose();
+
       const server = new PlaygroundServer(instance, {
         workspace,
         files,


### PR DESCRIPTION
## Summary

I added a `key` to `Monaco` which means that `onMount` can now run more than once (in fact, it runs once on first initialization and then once everytime the user hits reset). 

This PR fixes the double (or triple!) hover and inlays by disposing the old server when `onMount` is executed again

Fixes https://github.com/astral-sh/ruff/issues/17329, https://github.com/astral-sh/ruff/issues/17330


