### PR TITLE
[red-knot] Silence `unresolved-import` in unreachable code

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/unreachable.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/unreachable.md
@@ -117,8 +117,6 @@ python-version = "3.10"
 import sys
 
 if sys.version_info >= (3, 11):
-    # TODO: we should not emit an error here
-    # error: [unresolved-import]
     from typing import Self
 ```
 
@@ -391,22 +389,14 @@ diagnostics:
 import sys
 
 if sys.version_info >= (3, 11):
-    # TODO
-    # error: [unresolved-import]
     from builtins import ExceptionGroup
 
-    # TODO
-    # error: [unresolved-import]
     import builtins.ExceptionGroup
 
     # See https://docs.python.org/3/whatsnew/3.11.html#new-modules
 
-    # TODO
-    # error: [unresolved-import]
     import tomllib
 
-    # TODO
-    # error: [unresolved-import]
     import wsgiref.types
 ```
 
@@ -435,8 +425,6 @@ import sys
 import typing
 
 if sys.version_info >= (3, 11):
-    # TODO (silence diagnostics for imports, see above)
-    # error: [unresolved-import]
     from typing import Self
 
     class C:

--- a/crates/red_knot_python_semantic/src/semantic_index.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index.rs
@@ -10,8 +10,9 @@ use salsa::plumbing::AsId;
 use salsa::Update;
 
 use crate::module_name::ModuleName;
+use crate::node_key::NodeKey;
 use crate::semantic_index::ast_ids::node_key::ExpressionNodeKey;
-use crate::semantic_index::ast_ids::{AstIds, ScopedExpressionId};
+use crate::semantic_index::ast_ids::AstIds;
 use crate::semantic_index::attribute_assignment::AttributeAssignments;
 use crate::semantic_index::builder::SemanticIndexBuilder;
 use crate::semantic_index::definition::{Definition, DefinitionNodeKey, Definitions};
@@ -254,7 +255,7 @@ impl<'db> SemanticIndex<'db> {
             })
     }
 
-    /// Returns true if a given expression is reachable from the start of the scope. For example,
+    /// Returns true if a given AST node is reachable from the start of the scope. For example,
     /// in the following code, expression `2` is reachable, but expressions `1` and `3` are not:
     /// ```py
     /// def f():
@@ -265,16 +266,14 @@ impl<'db> SemanticIndex<'db> {
     ///     return
     ///     x  # 3
     /// ```
-    pub(crate) fn is_expression_reachable(
+    pub(crate) fn is_node_reachable(
         &self,
         db: &'db dyn crate::Db,
         scope_id: FileScopeId,
-        expression_id: ScopedExpressionId,
+        node_key: NodeKey,
     ) -> bool {
         self.is_scope_reachable(db, scope_id)
-            && self
-                .use_def_map(scope_id)
-                .is_expression_reachable(db, expression_id)
+            && self.use_def_map(scope_id).is_node_reachable(db, node_key)
     }
 
     /// Returns an iterator over the descendent scopes of `scope`.

--- a/crates/red_knot_python_semantic/src/types/diagnostic.rs
+++ b/crates/red_knot_python_semantic/src/types/diagnostic.rs
@@ -993,23 +993,6 @@ pub(super) fn report_non_subscriptable(
     );
 }
 
-pub(super) fn report_unresolved_module<'db>(
-    context: &InferContext,
-    import_node: impl Into<AnyNodeRef<'db>>,
-    level: u32,
-    module: Option<&str>,
-) {
-    context.report_lint_old(
-        &UNRESOLVED_IMPORT,
-        import_node.into(),
-        format_args!(
-            "Cannot resolve import `{}{}`",
-            ".".repeat(level as usize),
-            module.unwrap_or_default()
-        ),
-    );
-}
-
 pub(super) fn report_slice_step_size_zero(context: &InferContext, node: AnyNodeRef) {
     context.report_lint_old(
         &ZERO_STEPSIZE_IN_SLICE,


### PR DESCRIPTION
## Summary

Similar to what we did for `unresolved-reference` and `unresolved-attribute`, we now also silence `unresolved-import` diagnostics if the corresponding `import` statement is unreachable.

This addresses the (already closed) issue #17049.

## Test Plan

Adapted Markdown tests.