### PR TITLE
[red-knot] Refresh diagnostics when changing related files

### DIFF
--- a/crates/red_knot_server/src/server.rs
+++ b/crates/red_knot_server/src/server.rs
@@ -212,6 +212,7 @@ impl Server {
             position_encoding: Some(position_encoding.into()),
             diagnostic_provider: Some(DiagnosticServerCapabilities::Options(DiagnosticOptions {
                 identifier: Some(crate::DIAGNOSTIC_NAME.into()),
+                inter_file_dependencies: true,
                 ..Default::default()
             })),
             text_document_sync: Some(TextDocumentSyncCapability::Options(


### PR DESCRIPTION
## Summary

Given:

`main.py`:

```py
from foo import Foo
```

`foo.py`

```py
class Fo: ...
```

Red Knot reports an unresolved import diagnostic in `main.py` because `foo` doesn't export `Foo`. 
Renaming the class `Fo` in `foo.py` to `Foo` should refresh the diagnsotics in `main.py`.


It turns out, that this is a fairly easy change. All that was necessary is to set `inter_file_dependencies` in the server registration options to true.

We'll need a different solution for publish diagnostics but Red Knot doesn't yet support publish diagnostics (https://github.com/astral-sh/ruff/issues/16743)

## Test Plan


https://github.com/user-attachments/assets/7f54e675-919d-421d-b646-85fc96504ad2


