### PR TITLE
[red-knot] Initial support for `dataclass`es

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/dataclasses.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/dataclasses.md
@@ -93,7 +93,60 @@ C() == C()
 
 ## Inheritance
 
-To do
+### Normal class inheriting from a dataclass
+
+```py
+from dataclasses import dataclass
+
+@dataclass
+class Base:
+    x: int
+
+class Derived(Base): ...
+
+d = Derived(1)  # OK
+reveal_type(d.x)  # revealed: int
+```
+
+### Dataclass inheriting from normal class
+
+```py
+from dataclasses import dataclass
+
+class Base:
+    x: int = 1
+
+@dataclass
+class Derived(Base):
+    y: str
+
+d = Derived("a")
+
+# TODO: should be an error:
+Derived(1, "a")
+```
+
+### Dataclass inheriting from another dataclass
+
+```py
+from dataclasses import dataclass
+
+@dataclass
+class Base:
+    x: int
+
+@dataclass
+class Derived(Base):
+    y: str
+
+d = Derived(1, "a")  # OK
+
+reveal_type(d.x)  # revealed: int
+reveal_type(d.y)  # revealed: str
+
+# TODO: should be an error:
+Derived("a")
+```
 
 ## Generic dataclasses
 

--- a/crates/red_knot_python_semantic/resources/mdtest/dataclasses.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/dataclasses.md
@@ -1,0 +1,189 @@
+# Dataclasses
+
+## Basic
+
+Decorating a class with `@dataclass` is a convenient way to add special methods such as `__init__`,
+`__repr__`, and `__eq__` to a class. The following example shows the basic usage of the `@dataclass`
+decorator. By default, only the three mentioned methods are generated.
+
+```py
+from dataclasses import dataclass
+
+@dataclass
+class Person:
+    name: str
+    age: int | None = None
+
+alice1 = Person("Alice", 30)
+alice2 = Person(name="Alice", age=30)
+alice3 = Person(age=30, name="Alice")
+alice4 = Person("Alice", age=30)
+
+reveal_type(alice1)  # revealed: Person
+reveal_type(type(alice1))  # revealed: type[Person]
+
+reveal_type(alice1.name)  # revealed: str
+reveal_type(alice1.age)  # revealed: int | None
+
+reveal_type(repr(alice1))  # revealed: str
+
+reveal_type(alice1 == alice2)  # revealed: bool
+reveal_type(alice1 == "Alice")  # revealed: bool
+
+bob = Person("Bob")
+bob2 = Person("Bob", None)
+bob3 = Person(name="Bob")
+bob4 = Person(name="Bob", age=None)
+```
+
+The signature of the `__init__` method is generated based on the classes attributes. The following
+calls are not valid:
+
+```py
+# TODO: should be an error: too few arguments
+Person()
+
+# TODO: should be an error: too many arguments
+Person("Eve", 20, "too many arguments")
+
+# TODO: should be an error: wrong argument type
+Person("Eve", "string instead of int")
+
+# TODO: should be an error: wrong argument types
+Person(20, "Eve")
+```
+
+## `@dataclass` calls with arguments
+
+The `@dataclass` decorator can take several arguments to customize the existence of the generated
+methods. The following test makes sure that we still treat the class as a dataclass if (the default)
+arguments are passed in:
+
+```py
+from dataclasses import dataclass
+
+@dataclass(init=True, repr=True, eq=True)
+class Person:
+    name: str
+    age: int | None = None
+
+alice = Person("Alice", 30)
+reveal_type(repr(alice))  # revealed: str
+reveal_type(alice == alice)  # revealed: bool
+```
+
+If `init` is set to `False`, no `__init__` method is generated:
+
+```py
+from dataclasses import dataclass
+
+@dataclass(init=False)
+class C:
+    x: int
+
+C()  # Okay
+
+# error: [too-many-positional-arguments]
+C(1)
+
+repr(C())
+
+C() == C()
+```
+
+## Inheritance
+
+To do
+
+## Generic dataclasses
+
+```py
+from dataclasses import dataclass
+
+@dataclass
+class DataWithDescription[T]:
+    data: T
+    description: str
+
+reveal_type(DataWithDescription[int])  # revealed: Literal[DataWithDescription[int]]
+
+d_int = DataWithDescription[int](1, "description")  # OK
+reveal_type(d_int.data)  # revealed: int
+reveal_type(d_int.description)  # revealed: str
+
+# TODO: should be an error: wrong argument type
+DataWithDescription[int](None, "description")
+```
+
+## Frozen instances
+
+To do
+
+## Descriptor-typed fields
+
+To do
+
+## `dataclasses.field`
+
+To do
+
+## Other special cases
+
+### `dataclasses.dataclass`
+
+We also understand dataclasses if they are decorated with the fully qualified name:
+
+```py
+import dataclasses
+
+@dataclasses.dataclass
+class C:
+    x: str
+
+# TODO: should show the proper signature
+reveal_type(C.__init__)  # revealed: (*args: Any, **kwargs: Any) -> None
+```
+
+### Dataclass with `init=False`
+
+To do
+
+### Dataclass with custom `__init__` method
+
+To do
+
+### Dataclass with `ClassVar`s
+
+To do
+
+### Using `dataclass` as a function
+
+To do
+
+## Internals
+
+The `dataclass` decorator returns the class itself. This means that the type of `Person` is `type`,
+and attributes like the MRO are unchanged:
+
+```py
+from dataclasses import dataclass
+
+@dataclass
+class Person:
+    name: str
+    age: int | None = None
+
+reveal_type(type(Person))  # revealed: Literal[type]
+reveal_type(Person.__mro__)  # revealed: tuple[Literal[Person], Literal[object]]
+```
+
+The generated methods have the following signatures:
+
+```py
+# TODO: proper signature
+reveal_type(Person.__init__)  # revealed: (*args: Any, **kwargs: Any) -> None
+
+reveal_type(Person.__repr__)  # revealed: def __repr__(self) -> str
+
+reveal_type(Person.__eq__)  # revealed: def __eq__(self, value: object, /) -> bool
+```

--- a/crates/red_knot_python_semantic/src/module_resolver/module.rs
+++ b/crates/red_knot_python_semantic/src/module_resolver/module.rs
@@ -116,6 +116,7 @@ pub enum KnownModule {
     Sys,
     #[allow(dead_code)]
     Abc, // currently only used in tests
+    Dataclasses,
     Collections,
     Inspect,
     KnotExtensions,
@@ -132,6 +133,7 @@ impl KnownModule {
             Self::TypingExtensions => "typing_extensions",
             Self::Sys => "sys",
             Self::Abc => "abc",
+            Self::Dataclasses => "dataclasses",
             Self::Collections => "collections",
             Self::Inspect => "inspect",
             Self::KnotExtensions => "knot_extensions",

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1733,8 +1733,6 @@ impl<'db> Type<'db> {
                     .is_disjoint_from(db, other)
             }
 
-            (Type::DataclassDecorator(_), _) | (_, Type::DataclassDecorator(_)) => false,
-
             (Type::Callable(_) | Type::FunctionLiteral(_), Type::Callable(_))
             | (Type::Callable(_), Type::FunctionLiteral(_)) => {
                 // No two callable types are ever disjoint because
@@ -1757,7 +1755,8 @@ impl<'db> Type<'db> {
                 true
             }
 
-            (Type::Callable(_), _) | (_, Type::Callable(_)) => {
+            (Type::Callable(_) | Type::DataclassDecorator(_), _)
+            | (_, Type::Callable(_) | Type::DataclassDecorator(_)) => {
                 // TODO: Implement disjointness for general callable type with other types
                 false
             }

--- a/crates/red_knot_python_semantic/src/types/class.rs
+++ b/crates/red_knot_python_semantic/src/types/class.rs
@@ -707,26 +707,6 @@ impl<'db> ClassLiteralType<'db> {
             return Symbol::bound(TupleType::from_elements(db, tuple_elements)).into();
         }
 
-        if let Some(metadata) = self.dataclass_metadata(db) {
-            if name == "__init__" {
-                if metadata.contains(DataclassMetadata::INIT) {
-                    // TODO: Generate the signature from the attributes on the class
-                    let init_signature = Signature::new(
-                        Parameters::new([
-                            Parameter::variadic(Name::new_static("args"))
-                                .with_annotated_type(Type::any()),
-                            Parameter::keyword_variadic(Name::new_static("kwargs"))
-                                .with_annotated_type(Type::any()),
-                        ]),
-                        Some(Type::none(db)),
-                    );
-
-                    return Symbol::bound(Type::Callable(CallableType::new(db, init_signature)))
-                        .into();
-                }
-            }
-        }
-
         // If we encounter a dynamic type in this class's MRO, we'll save that dynamic type
         // in this variable. After we've traversed the MRO, we'll either:
         // (1) Use that dynamic type as the type for this attribute,
@@ -811,6 +791,26 @@ impl<'db> ClassLiteralType<'db> {
     /// directly. Use [`ClassLiteralType::class_member`] if you require a method that will
     /// traverse through the MRO until it finds the member.
     pub(super) fn own_class_member(self, db: &'db dyn Db, name: &str) -> SymbolAndQualifiers<'db> {
+        if let Some(metadata) = self.dataclass_metadata(db) {
+            if name == "__init__" {
+                if metadata.contains(DataclassMetadata::INIT) {
+                    // TODO: Generate the signature from the attributes on the class
+                    let init_signature = Signature::new(
+                        Parameters::new([
+                            Parameter::variadic(Name::new_static("args"))
+                                .with_annotated_type(Type::any()),
+                            Parameter::keyword_variadic(Name::new_static("kwargs"))
+                                .with_annotated_type(Type::any()),
+                        ]),
+                        Some(Type::none(db)),
+                    );
+
+                    return Symbol::bound(Type::Callable(CallableType::new(db, init_signature)))
+                        .into();
+                }
+            }
+        }
+
         let body_scope = self.body_scope(db);
         class_symbol(db, body_scope, name)
     }

--- a/crates/red_knot_python_semantic/src/types/class.rs
+++ b/crates/red_knot_python_semantic/src/types/class.rs
@@ -7,6 +7,8 @@ use super::{
 };
 use crate::semantic_index::definition::Definition;
 use crate::types::generics::{GenericContext, Specialization};
+use crate::types::signatures::{Parameter, Parameters};
+use crate::types::{CallableType, DataclassMetadata, Signature};
 use crate::{
     module_resolver::file_to_module,
     semantic_index::{
@@ -30,6 +32,7 @@ use crate::{
 use indexmap::IndexSet;
 use itertools::Itertools as _;
 use ruff_db::files::File;
+use ruff_python_ast::name::Name;
 use ruff_python_ast::{self as ast, PythonVersion};
 use rustc_hash::FxHashSet;
 
@@ -98,6 +101,8 @@ pub struct Class<'db> {
     pub(crate) body_scope: ScopeId<'db>,
 
     pub(crate) known: Option<KnownClass>,
+
+    pub(crate) dataclass_metadata: Option<DataclassMetadata>,
 }
 
 impl<'db> Class<'db> {
@@ -362,6 +367,10 @@ impl<'db> ClassLiteralType<'db> {
 
     pub(crate) fn known(self, db: &'db dyn Db) -> Option<KnownClass> {
         self.class(db).known
+    }
+
+    pub(crate) fn dataclass_metadata(self, db: &'db dyn Db) -> Option<DataclassMetadata> {
+        self.class(db).dataclass_metadata
     }
 
     /// Return `true` if this class represents `known_class`
@@ -696,6 +705,26 @@ impl<'db> ClassLiteralType<'db> {
         if name == "__mro__" {
             let tuple_elements = self.iter_mro(db, specialization).map(Type::from);
             return Symbol::bound(TupleType::from_elements(db, tuple_elements)).into();
+        }
+
+        if let Some(metadata) = self.dataclass_metadata(db) {
+            if name == "__init__" {
+                if metadata.contains(DataclassMetadata::INIT) {
+                    // TODO: Generate the signature from the attributes on the class
+                    let init_signature = Signature::new(
+                        Parameters::new([
+                            Parameter::variadic(Name::new_static("args"))
+                                .with_annotated_type(Type::any()),
+                            Parameter::keyword_variadic(Name::new_static("kwargs"))
+                                .with_annotated_type(Type::any()),
+                        ]),
+                        Some(Type::none(db)),
+                    );
+
+                    return Symbol::bound(Type::Callable(CallableType::new(db, init_signature)))
+                        .into();
+                }
+            }
         }
 
         // If we encounter a dynamic type in this class's MRO, we'll save that dynamic type

--- a/crates/red_knot_python_semantic/src/types/class_base.rs
+++ b/crates/red_knot_python_semantic/src/types/class_base.rs
@@ -86,6 +86,7 @@ impl<'db> ClassBase<'db> {
             | Type::BoundMethod(_)
             | Type::MethodWrapper(_)
             | Type::WrapperDescriptor(_)
+            | Type::DataclassDecorator(_)
             | Type::BytesLiteral(_)
             | Type::IntLiteral(_)
             | Type::StringLiteral(_)

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -165,7 +165,9 @@ impl Display for DisplayRepresentation<'_> {
                 };
                 write!(f, "<wrapper-descriptor `{method}` of `{object}` objects>")
             }
-            Type::DataclassDecorator(_) => f.write_str("<function dataclasses.dataclass>"),
+            Type::DataclassDecorator(_) => {
+                f.write_str("<decorator produced by dataclasses.dataclass>")
+            }
             Type::Union(union) => union.display(self.db).fmt(f),
             Type::Intersection(intersection) => intersection.display(self.db).fmt(f),
             Type::IntLiteral(n) => n.fmt(f),

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -165,6 +165,7 @@ impl Display for DisplayRepresentation<'_> {
                 };
                 write!(f, "<wrapper-descriptor `{method}` of `{object}` objects>")
             }
+            Type::DataclassDecorator(_) => f.write_str("<function dataclasses.dataclass>"),
             Type::Union(union) => union.display(self.db).fmt(f),
             Type::Intersection(intersection) => intersection.display(self.db).fmt(f),
             Type::IntLiteral(n) => n.fmt(f),

--- a/crates/red_knot_python_semantic/src/types/type_ordering.rs
+++ b/crates/red_knot_python_semantic/src/types/type_ordering.rs
@@ -70,6 +70,12 @@ pub(super) fn union_or_intersection_elements_ordering<'db>(
         (Type::WrapperDescriptor(_), _) => Ordering::Less,
         (_, Type::WrapperDescriptor(_)) => Ordering::Greater,
 
+        (Type::DataclassDecorator(left), Type::DataclassDecorator(right)) => {
+            left.bits().cmp(&right.bits())
+        }
+        (Type::DataclassDecorator(_), _) => Ordering::Less,
+        (_, Type::DataclassDecorator(_)) => Ordering::Greater,
+
         (Type::Callable(left), Type::Callable(right)) => {
             debug_assert_eq!(*left, left.normalized(db));
             debug_assert_eq!(*right, right.normalized(db));


### PR DESCRIPTION
## Summary

Add very early support for dataclasses. This is mostly to make sure that we do not emit false positives on dataclass construction, but it also lies some foundations for future extensions.

This seems like a good initial step to merge to me, as it basically removes all false positives on dataclass constructor calls. This allows us to use the ecosystem checks for making sure we don't introduce new false positives as we continue to work on dataclasses.

## Ecosystem analysis

I re-ran the mypy_primer evaluation of [the  `__init__` PR](https://github.com/astral-sh/ruff/pull/16512) locally with our current mypy_primer version and project selection. It introduced 1597 new diagnostics. Filtering those by searching for `__init__` and rejecting those that contain `invalid-argument-type` (those could not possibly be solved by this PR) leaves 1281 diagnostics. The current version of this PR removes 1171 diagnostics, which leaves 110 unaccounted for. I extracted the lint + file path for all of these diagnostics and generated a diff (of diffs), to see which `__init__`-diagnostics remain. I looked at a subset of these: There are a lot of `SomeClass(*args)` calls where we don't understand the unpacking yet (this is not even related to `__init__`). Some others are related to `NamedTuple`, which we also don't support yet. And then there are some errors related to `@attrs.define`-decorated classes, which would probably require support for `dataclass_transform`, which I made no attempt to include in this PR.

## Test Plan

New Markdown tests.