### PR TITLE
[syntax-errors] `await` outside async functions

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/await_outside_async.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/await_outside_async.py
@@ -72,3 +72,15 @@ def await_generator_target():
 # See: https://github.com/astral-sh/ruff/issues/14167
 def async_for_list_comprehension_target():
     [x for x in await foo()]
+
+
+def async_for_dictionary_comprehension_key():
+    {await x: y for x, y in foo()}
+
+
+def async_for_dictionary_comprehension_value():
+    {y: await x for x, y in foo()}
+
+
+def async_for_dict_comprehension():
+    {x: y async for x, y in foo()}

--- a/crates/ruff_linter/src/checkers/ast/analyze/comprehension.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/comprehension.rs
@@ -2,7 +2,7 @@ use ruff_python_ast::Comprehension;
 
 use crate::checkers::ast::Checker;
 use crate::codes::Rule;
-use crate::rules::{flake8_simplify, pylint, refurb};
+use crate::rules::{flake8_simplify, refurb};
 
 /// Run lint rules over a [`Comprehension`] syntax nodes.
 pub(crate) fn comprehension(comprehension: &Comprehension, checker: &Checker) {
@@ -11,10 +11,5 @@ pub(crate) fn comprehension(comprehension: &Comprehension, checker: &Checker) {
     }
     if checker.enabled(Rule::ReadlinesInFor) {
         refurb::rules::readlines_in_comprehension(checker, comprehension);
-    }
-    if comprehension.is_async {
-        if checker.enabled(Rule::AwaitOutsideAsync) {
-            pylint::rules::await_outside_async(checker, comprehension);
-        }
     }
 }

--- a/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
@@ -1215,11 +1215,6 @@ pub(crate) fn expression(expr: &Expr, checker: &Checker) {
                 pylint::rules::yield_from_in_async_function(checker, yield_from);
             }
         }
-        Expr::Await(_) => {
-            if checker.enabled(Rule::AwaitOutsideAsync) {
-                pylint::rules::await_outside_async(checker, expr);
-            }
-        }
         Expr::FString(f_string_expr @ ast::ExprFString { value, .. }) => {
             if checker.enabled(Rule::FStringMissingPlaceholders) {
                 pyflakes::rules::f_string_missing_placeholders(checker, f_string_expr);

--- a/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
@@ -1242,14 +1242,7 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                 ruff::rules::invalid_assert_message_literal_argument(checker, assert_stmt);
             }
         }
-        Stmt::With(
-            with_stmt @ ast::StmtWith {
-                items,
-                body,
-                is_async,
-                ..
-            },
-        ) => {
+        Stmt::With(with_stmt @ ast::StmtWith { items, body, .. }) => {
             if checker.enabled(Rule::TooManyNestedBlocks) {
                 pylint::rules::too_many_nested_blocks(checker, stmt);
             }
@@ -1283,11 +1276,6 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
             }
             if checker.enabled(Rule::CancelScopeNoCheckpoint) {
                 flake8_async::rules::cancel_scope_no_checkpoint(checker, with_stmt, items);
-            }
-            if *is_async {
-                if checker.enabled(Rule::AwaitOutsideAsync) {
-                    pylint::rules::await_outside_async(checker, stmt);
-                }
             }
         }
         Stmt::While(while_stmt @ ast::StmtWhile { body, orelse, .. }) => {
@@ -1377,11 +1365,7 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
             if checker.enabled(Rule::ReadlinesInFor) {
                 refurb::rules::readlines_in_for(checker, for_stmt);
             }
-            if *is_async {
-                if checker.enabled(Rule::AwaitOutsideAsync) {
-                    pylint::rules::await_outside_async(checker, stmt);
-                }
-            } else {
+            if !*is_async {
                 if checker.enabled(Rule::ReimplementedBuiltin) {
                     flake8_simplify::rules::convert_for_loop_to_any_all(checker, stmt);
                 }

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -604,7 +604,7 @@ impl SemanticSyntaxContext for Checker<'_> {
                     self.report_diagnostic(Diagnostic::new(ReturnOutsideFunction, error.range));
                 }
             }
-            SemanticSyntaxErrorKind::AwaitOutsideAsyncFunction => {
+            SemanticSyntaxErrorKind::AwaitOutsideAsyncFunction(_) => {
                 if self.settings.rules.enabled(Rule::AwaitOutsideAsync) {
                     self.report_diagnostic(Diagnostic::new(AwaitOutsideAsync, error.range));
                 }

--- a/crates/ruff_linter/src/rules/pylint/rules/await_outside_async.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/await_outside_async.rs
@@ -1,9 +1,5 @@
-use ruff_diagnostics::{Diagnostic, Violation};
+use ruff_diagnostics::Violation;
 use ruff_macros::{derive_message_formats, ViolationMetadata};
-use ruff_python_semantic::{GeneratorKind, ScopeKind};
-use ruff_text_size::Ranged;
-
-use crate::checkers::ast::Checker;
 
 /// ## What it does
 /// Checks for uses of `await` outside `async` functions.
@@ -46,40 +42,4 @@ impl Violation for AwaitOutsideAsync {
     fn message(&self) -> String {
         "`await` should be used within an async function".to_string()
     }
-}
-
-/// PLE1142
-pub(crate) fn await_outside_async<T: Ranged>(checker: &Checker, node: T) {
-    // If we're in an `async` function, we're good.
-    if checker.semantic().in_async_context() {
-        return;
-    }
-
-    // `await` is allowed at the top level of a Jupyter notebook.
-    // See: https://ipython.readthedocs.io/en/stable/interactive/autoawait.html.
-    if checker.semantic().current_scope().kind.is_module() && checker.source_type.is_ipynb() {
-        return;
-    }
-
-    // Generators are evaluated lazily, so you can use `await` in them. For example:
-    // ```python
-    // # This is valid
-    // (await x for x in y)
-    // (x async for x in y)
-    //
-    // # This is invalid
-    // (x for x in async y)
-    // [await x for x in y]
-    // ```
-    if matches!(
-        checker.semantic().current_scope().kind,
-        ScopeKind::Generator {
-            kind: GeneratorKind::Generator,
-            ..
-        }
-    ) {
-        return;
-    }
-
-    checker.report_diagnostic(Diagnostic::new(AwaitOutsideAsync, node.range()));
 }

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLE1142_await_outside_async.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLE1142_await_outside_async.py.snap
@@ -63,3 +63,24 @@ await_outside_async.py:74:17: PLE1142 `await` should be used within an async fun
 74 |     [x for x in await foo()]
    |                 ^^^^^^^^^^^ PLE1142
    |
+
+await_outside_async.py:78:6: PLE1142 `await` should be used within an async function
+   |
+77 | def async_for_dictionary_comprehension_key():
+78 |     {await x: y for x, y in foo()}
+   |      ^^^^^^^ PLE1142
+   |
+
+await_outside_async.py:82:9: PLE1142 `await` should be used within an async function
+   |
+81 | def async_for_dictionary_comprehension_value():
+82 |     {y: await x for x, y in foo()}
+   |         ^^^^^^^ PLE1142
+   |
+
+await_outside_async.py:86:11: PLE1142 `await` should be used within an async function
+   |
+85 | def async_for_dict_comprehension():
+86 |     {x: y async for x, y in foo()}
+   |           ^^^^^^^^^^^^^^^^^^^^^^^ PLE1142
+   |


### PR DESCRIPTION
Summary
--

This PR implements detecting the use of `await` expressions outside of async functions. This is a reimplementation of
[await-outside-async (PLE1142)](https://docs.astral.sh/ruff/rules/await-outside-async/) as a semantic syntax error.

Despite the rule name, PLE1142 also applies to `async for` and `async with`, so these are covered here too.

Test Plan
--

Existing PLE1142 tests.

I also deleted more code from the `SemanticSyntaxCheckerVisitor` to avoid changes in other parser tests.
