### PR TITLE
[red-knot] Add support for overloaded functions

### DIFF
--- a/crates/red_knot/tests/cli.rs
+++ b/crates/red_knot/tests/cli.rs
@@ -252,7 +252,7 @@ fn configuration_rule_severity() -> anyhow::Result<()> {
         r#"
             y = 4 / 0
 
-            for a in range(0, y):
+            for a in range(0, int(y)):
                 x = a
 
             print(x)  # possibly-unresolved-reference
@@ -271,17 +271,7 @@ fn configuration_rule_severity() -> anyhow::Result<()> {
     2 | y = 4 / 0
       |     ^^^^^ Cannot divide object of type `Literal[4]` by zero
     3 |
-    4 | for a in range(0, y):
-      |
-
-    error: lint:no-matching-overload
-     --> <temp_dir>/test.py:4:10
-      |
-    2 | y = 4 / 0
-    3 |
-    4 | for a in range(0, y):
-      |          ^^^^^^^^^^^ No overload of function `__new__` matches arguments
-    5 |     x = a
+    4 | for a in range(0, int(y)):
       |
 
     warning: lint:possibly-unresolved-reference
@@ -293,7 +283,7 @@ fn configuration_rule_severity() -> anyhow::Result<()> {
       |       ^ Name `x` used when possibly not defined
       |
 
-    Found 3 diagnostics
+    Found 2 diagnostics
 
     ----- stderr -----
     ");
@@ -308,8 +298,8 @@ fn configuration_rule_severity() -> anyhow::Result<()> {
     )?;
 
     assert_cmd_snapshot!(case.command(), @r"
-    success: false
-    exit_code: 1
+    success: true
+    exit_code: 0
     ----- stdout -----
     warning: lint:division-by-zero
      --> <temp_dir>/test.py:2:5
@@ -317,20 +307,10 @@ fn configuration_rule_severity() -> anyhow::Result<()> {
     2 | y = 4 / 0
       |     ^^^^^ Cannot divide object of type `Literal[4]` by zero
     3 |
-    4 | for a in range(0, y):
+    4 | for a in range(0, int(y)):
       |
 
-    error: lint:no-matching-overload
-     --> <temp_dir>/test.py:4:10
-      |
-    2 | y = 4 / 0
-    3 |
-    4 | for a in range(0, y):
-      |          ^^^^^^^^^^^ No overload of function `__new__` matches arguments
-    5 |     x = a
-      |
-
-    Found 2 diagnostics
+    Found 1 diagnostic
 
     ----- stderr -----
     ");
@@ -348,7 +328,7 @@ fn cli_rule_severity() -> anyhow::Result<()> {
 
         y = 4 / 0
 
-        for a in range(0, y):
+        for a in range(0, int(y)):
             x = a
 
         print(x)  # possibly-unresolved-reference
@@ -378,17 +358,7 @@ fn cli_rule_severity() -> anyhow::Result<()> {
     4 | y = 4 / 0
       |     ^^^^^ Cannot divide object of type `Literal[4]` by zero
     5 |
-    6 | for a in range(0, y):
-      |
-
-    error: lint:no-matching-overload
-     --> <temp_dir>/test.py:6:10
-      |
-    4 | y = 4 / 0
-    5 |
-    6 | for a in range(0, y):
-      |          ^^^^^^^^^^^ No overload of function `__new__` matches arguments
-    7 |     x = a
+    6 | for a in range(0, int(y)):
       |
 
     warning: lint:possibly-unresolved-reference
@@ -400,7 +370,7 @@ fn cli_rule_severity() -> anyhow::Result<()> {
       |       ^ Name `x` used when possibly not defined
       |
 
-    Found 4 diagnostics
+    Found 3 diagnostics
 
     ----- stderr -----
     ");
@@ -415,8 +385,8 @@ fn cli_rule_severity() -> anyhow::Result<()> {
             .arg("--warn")
             .arg("unresolved-import"),
         @r"
-    success: false
-    exit_code: 1
+    success: true
+    exit_code: 0
     ----- stdout -----
     warning: lint:unresolved-import
      --> <temp_dir>/test.py:2:8
@@ -435,20 +405,10 @@ fn cli_rule_severity() -> anyhow::Result<()> {
     4 | y = 4 / 0
       |     ^^^^^ Cannot divide object of type `Literal[4]` by zero
     5 |
-    6 | for a in range(0, y):
+    6 | for a in range(0, int(y)):
       |
 
-    error: lint:no-matching-overload
-     --> <temp_dir>/test.py:6:10
-      |
-    4 | y = 4 / 0
-    5 |
-    6 | for a in range(0, y):
-      |          ^^^^^^^^^^^ No overload of function `__new__` matches arguments
-    7 |     x = a
-      |
-
-    Found 3 diagnostics
+    Found 2 diagnostics
 
     ----- stderr -----
     "
@@ -466,7 +426,7 @@ fn cli_rule_severity_precedence() -> anyhow::Result<()> {
         r#"
         y = 4 / 0
 
-        for a in range(0, y):
+        for a in range(0, int(y)):
             x = a
 
         print(x)  # possibly-unresolved-reference
@@ -485,17 +445,7 @@ fn cli_rule_severity_precedence() -> anyhow::Result<()> {
     2 | y = 4 / 0
       |     ^^^^^ Cannot divide object of type `Literal[4]` by zero
     3 |
-    4 | for a in range(0, y):
-      |
-
-    error: lint:no-matching-overload
-     --> <temp_dir>/test.py:4:10
-      |
-    2 | y = 4 / 0
-    3 |
-    4 | for a in range(0, y):
-      |          ^^^^^^^^^^^ No overload of function `__new__` matches arguments
-    5 |     x = a
+    4 | for a in range(0, int(y)):
       |
 
     warning: lint:possibly-unresolved-reference
@@ -507,7 +457,7 @@ fn cli_rule_severity_precedence() -> anyhow::Result<()> {
       |       ^ Name `x` used when possibly not defined
       |
 
-    Found 3 diagnostics
+    Found 2 diagnostics
 
     ----- stderr -----
     ");
@@ -523,8 +473,8 @@ fn cli_rule_severity_precedence() -> anyhow::Result<()> {
             .arg("--ignore")
             .arg("possibly-unresolved-reference"),
         @r"
-    success: false
-    exit_code: 1
+    success: true
+    exit_code: 0
     ----- stdout -----
     warning: lint:division-by-zero
      --> <temp_dir>/test.py:2:5
@@ -532,20 +482,10 @@ fn cli_rule_severity_precedence() -> anyhow::Result<()> {
     2 | y = 4 / 0
       |     ^^^^^ Cannot divide object of type `Literal[4]` by zero
     3 |
-    4 | for a in range(0, y):
+    4 | for a in range(0, int(y)):
       |
 
-    error: lint:no-matching-overload
-     --> <temp_dir>/test.py:4:10
-      |
-    2 | y = 4 / 0
-    3 |
-    4 | for a in range(0, y):
-      |          ^^^^^^^^^^^ No overload of function `__new__` matches arguments
-    5 |     x = a
-      |
-
-    Found 2 diagnostics
+    Found 1 diagnostic
 
     ----- stderr -----
     "
@@ -874,7 +814,7 @@ fn user_configuration() -> anyhow::Result<()> {
             r#"
             y = 4 / 0
 
-            for a in range(0, y):
+            for a in range(0, int(y)):
                 x = a
 
             print(x)
@@ -892,8 +832,8 @@ fn user_configuration() -> anyhow::Result<()> {
     assert_cmd_snapshot!(
         case.command().current_dir(case.root().join("project")).env(config_env_var, config_directory.as_os_str()),
         @r"
-    success: false
-    exit_code: 1
+    success: true
+    exit_code: 0
     ----- stdout -----
     warning: lint:division-by-zero
      --> <temp_dir>/project/main.py:2:5
@@ -901,17 +841,7 @@ fn user_configuration() -> anyhow::Result<()> {
     2 | y = 4 / 0
       |     ^^^^^ Cannot divide object of type `Literal[4]` by zero
     3 |
-    4 | for a in range(0, y):
-      |
-
-    error: lint:no-matching-overload
-     --> <temp_dir>/project/main.py:4:10
-      |
-    2 | y = 4 / 0
-    3 |
-    4 | for a in range(0, y):
-      |          ^^^^^^^^^^^ No overload of function `__new__` matches arguments
-    5 |     x = a
+    4 | for a in range(0, int(y)):
       |
 
     warning: lint:possibly-unresolved-reference
@@ -923,7 +853,7 @@ fn user_configuration() -> anyhow::Result<()> {
       |       ^ Name `x` used when possibly not defined
       |
 
-    Found 3 diagnostics
+    Found 2 diagnostics
 
     ----- stderr -----
     "
@@ -953,17 +883,7 @@ fn user_configuration() -> anyhow::Result<()> {
     2 | y = 4 / 0
       |     ^^^^^ Cannot divide object of type `Literal[4]` by zero
     3 |
-    4 | for a in range(0, y):
-      |
-
-    error: lint:no-matching-overload
-     --> <temp_dir>/project/main.py:4:10
-      |
-    2 | y = 4 / 0
-    3 |
-    4 | for a in range(0, y):
-      |          ^^^^^^^^^^^ No overload of function `__new__` matches arguments
-    5 |     x = a
+    4 | for a in range(0, int(y)):
       |
 
     error: lint:possibly-unresolved-reference
@@ -975,7 +895,7 @@ fn user_configuration() -> anyhow::Result<()> {
       |       ^ Name `x` used when possibly not defined
       |
 
-    Found 3 diagnostics
+    Found 2 diagnostics
 
     ----- stderr -----
     "

--- a/crates/red_knot/tests/cli.rs
+++ b/crates/red_knot/tests/cli.rs
@@ -274,6 +274,16 @@ fn configuration_rule_severity() -> anyhow::Result<()> {
     4 | for a in range(0, y):
       |
 
+    error: lint:no-matching-overload
+     --> <temp_dir>/test.py:4:10
+      |
+    2 | y = 4 / 0
+    3 |
+    4 | for a in range(0, y):
+      |          ^^^^^^^^^^^ No overload of function `__new__` matches arguments
+    5 |     x = a
+      |
+
     warning: lint:possibly-unresolved-reference
      --> <temp_dir>/test.py:7:7
       |
@@ -283,7 +293,7 @@ fn configuration_rule_severity() -> anyhow::Result<()> {
       |       ^ Name `x` used when possibly not defined
       |
 
-    Found 2 diagnostics
+    Found 3 diagnostics
 
     ----- stderr -----
     ");
@@ -298,8 +308,8 @@ fn configuration_rule_severity() -> anyhow::Result<()> {
     )?;
 
     assert_cmd_snapshot!(case.command(), @r"
-    success: true
-    exit_code: 0
+    success: false
+    exit_code: 1
     ----- stdout -----
     warning: lint:division-by-zero
      --> <temp_dir>/test.py:2:5
@@ -310,7 +320,17 @@ fn configuration_rule_severity() -> anyhow::Result<()> {
     4 | for a in range(0, y):
       |
 
-    Found 1 diagnostic
+    error: lint:no-matching-overload
+     --> <temp_dir>/test.py:4:10
+      |
+    2 | y = 4 / 0
+    3 |
+    4 | for a in range(0, y):
+      |          ^^^^^^^^^^^ No overload of function `__new__` matches arguments
+    5 |     x = a
+      |
+
+    Found 2 diagnostics
 
     ----- stderr -----
     ");
@@ -361,6 +381,16 @@ fn cli_rule_severity() -> anyhow::Result<()> {
     6 | for a in range(0, y):
       |
 
+    error: lint:no-matching-overload
+     --> <temp_dir>/test.py:6:10
+      |
+    4 | y = 4 / 0
+    5 |
+    6 | for a in range(0, y):
+      |          ^^^^^^^^^^^ No overload of function `__new__` matches arguments
+    7 |     x = a
+      |
+
     warning: lint:possibly-unresolved-reference
      --> <temp_dir>/test.py:9:7
       |
@@ -370,7 +400,7 @@ fn cli_rule_severity() -> anyhow::Result<()> {
       |       ^ Name `x` used when possibly not defined
       |
 
-    Found 3 diagnostics
+    Found 4 diagnostics
 
     ----- stderr -----
     ");
@@ -385,8 +415,8 @@ fn cli_rule_severity() -> anyhow::Result<()> {
             .arg("--warn")
             .arg("unresolved-import"),
         @r"
-    success: true
-    exit_code: 0
+    success: false
+    exit_code: 1
     ----- stdout -----
     warning: lint:unresolved-import
      --> <temp_dir>/test.py:2:8
@@ -408,7 +438,17 @@ fn cli_rule_severity() -> anyhow::Result<()> {
     6 | for a in range(0, y):
       |
 
-    Found 2 diagnostics
+    error: lint:no-matching-overload
+     --> <temp_dir>/test.py:6:10
+      |
+    4 | y = 4 / 0
+    5 |
+    6 | for a in range(0, y):
+      |          ^^^^^^^^^^^ No overload of function `__new__` matches arguments
+    7 |     x = a
+      |
+
+    Found 3 diagnostics
 
     ----- stderr -----
     "
@@ -448,6 +488,16 @@ fn cli_rule_severity_precedence() -> anyhow::Result<()> {
     4 | for a in range(0, y):
       |
 
+    error: lint:no-matching-overload
+     --> <temp_dir>/test.py:4:10
+      |
+    2 | y = 4 / 0
+    3 |
+    4 | for a in range(0, y):
+      |          ^^^^^^^^^^^ No overload of function `__new__` matches arguments
+    5 |     x = a
+      |
+
     warning: lint:possibly-unresolved-reference
      --> <temp_dir>/test.py:7:7
       |
@@ -457,7 +507,7 @@ fn cli_rule_severity_precedence() -> anyhow::Result<()> {
       |       ^ Name `x` used when possibly not defined
       |
 
-    Found 2 diagnostics
+    Found 3 diagnostics
 
     ----- stderr -----
     ");
@@ -473,8 +523,8 @@ fn cli_rule_severity_precedence() -> anyhow::Result<()> {
             .arg("--ignore")
             .arg("possibly-unresolved-reference"),
         @r"
-    success: true
-    exit_code: 0
+    success: false
+    exit_code: 1
     ----- stdout -----
     warning: lint:division-by-zero
      --> <temp_dir>/test.py:2:5
@@ -485,7 +535,17 @@ fn cli_rule_severity_precedence() -> anyhow::Result<()> {
     4 | for a in range(0, y):
       |
 
-    Found 1 diagnostic
+    error: lint:no-matching-overload
+     --> <temp_dir>/test.py:4:10
+      |
+    2 | y = 4 / 0
+    3 |
+    4 | for a in range(0, y):
+      |          ^^^^^^^^^^^ No overload of function `__new__` matches arguments
+    5 |     x = a
+      |
+
+    Found 2 diagnostics
 
     ----- stderr -----
     "
@@ -832,8 +892,8 @@ fn user_configuration() -> anyhow::Result<()> {
     assert_cmd_snapshot!(
         case.command().current_dir(case.root().join("project")).env(config_env_var, config_directory.as_os_str()),
         @r"
-    success: true
-    exit_code: 0
+    success: false
+    exit_code: 1
     ----- stdout -----
     warning: lint:division-by-zero
      --> <temp_dir>/project/main.py:2:5
@@ -842,6 +902,16 @@ fn user_configuration() -> anyhow::Result<()> {
       |     ^^^^^ Cannot divide object of type `Literal[4]` by zero
     3 |
     4 | for a in range(0, y):
+      |
+
+    error: lint:no-matching-overload
+     --> <temp_dir>/project/main.py:4:10
+      |
+    2 | y = 4 / 0
+    3 |
+    4 | for a in range(0, y):
+      |          ^^^^^^^^^^^ No overload of function `__new__` matches arguments
+    5 |     x = a
       |
 
     warning: lint:possibly-unresolved-reference
@@ -853,7 +923,7 @@ fn user_configuration() -> anyhow::Result<()> {
       |       ^ Name `x` used when possibly not defined
       |
 
-    Found 2 diagnostics
+    Found 3 diagnostics
 
     ----- stderr -----
     "
@@ -886,6 +956,16 @@ fn user_configuration() -> anyhow::Result<()> {
     4 | for a in range(0, y):
       |
 
+    error: lint:no-matching-overload
+     --> <temp_dir>/project/main.py:4:10
+      |
+    2 | y = 4 / 0
+    3 |
+    4 | for a in range(0, y):
+      |          ^^^^^^^^^^^ No overload of function `__new__` matches arguments
+    5 |     x = a
+      |
+
     error: lint:possibly-unresolved-reference
      --> <temp_dir>/project/main.py:7:7
       |
@@ -895,7 +975,7 @@ fn user_configuration() -> anyhow::Result<()> {
       |       ^ Name `x` used when possibly not defined
       |
 
-    Found 2 diagnostics
+    Found 3 diagnostics
 
     ----- stderr -----
     "

--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/literal_string.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/literal_string.md
@@ -72,13 +72,11 @@ reveal_type(baz)  # revealed: Literal["bazfoo"]
 qux = (foo, bar)
 reveal_type(qux)  # revealed: tuple[Literal["foo"], Literal["bar"]]
 
-# TODO: Infer "LiteralString"
-reveal_type(foo.join(qux))  # revealed: @Todo(return type of overloaded function)
+reveal_type(foo.join(qux))  # revealed: LiteralString
 
 template: LiteralString = "{}, {}"
 reveal_type(template)  # revealed: Literal["{}, {}"]
-# TODO: Infer `LiteralString`
-reveal_type(template.format(foo, bar))  # revealed: @Todo(return type of overloaded function)
+reveal_type(template.format(foo, bar))  # revealed: LiteralString
 ```
 
 ### Assignability

--- a/crates/red_knot_python_semantic/resources/mdtest/attributes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/attributes.md
@@ -1698,9 +1698,9 @@ Most attribute accesses on bool-literal types are delegated to `builtins.bool`, 
 bools are instances of that class:
 
 ```py
-# revealed: bound method Literal[True].__and__(**kwargs: @Todo(todo signature **kwargs)) -> @Todo(return type of overloaded function)
+# revealed: Overload((value: bool, /) -> bool, (value: int, /) -> int)
 reveal_type(True.__and__)
-# revealed: bound method Literal[False].__or__(**kwargs: @Todo(todo signature **kwargs)) -> @Todo(return type of overloaded function)
+# revealed: Overload((value: bool, /) -> bool, (value: int, /) -> int)
 reveal_type(False.__or__)
 ```
 

--- a/crates/red_knot_python_semantic/resources/mdtest/attributes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/attributes.md
@@ -1698,9 +1698,9 @@ Most attribute accesses on bool-literal types are delegated to `builtins.bool`, 
 bools are instances of that class:
 
 ```py
-# revealed: Overload((value: bool, /) -> bool, (value: int, /) -> int)
+# revealed: Overload[(value: bool, /) -> bool, (value: int, /) -> int]
 reveal_type(True.__and__)
-# revealed: Overload((value: bool, /) -> bool, (value: int, /) -> int)
+# revealed: Overload[(value: bool, /) -> bool, (value: int, /) -> int]
 reveal_type(False.__or__)
 ```
 

--- a/crates/red_knot_python_semantic/resources/mdtest/binary/instances.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/binary/instances.md
@@ -310,9 +310,7 @@ reveal_type(A() + 1)  # revealed: A
 reveal_type(1 + A())  # revealed: A
 
 reveal_type(A() + "foo")  # revealed: A
-# TODO should be `A` since `str.__add__` doesn't support `A` instances
-# TODO overloads
-reveal_type("foo" + A())  # revealed: @Todo(return type of overloaded function)
+reveal_type("foo" + A())  # revealed: A
 
 reveal_type(A() + b"foo")  # revealed: A
 # TODO should be `A` since `bytes.__add__` doesn't support `A` instances
@@ -320,16 +318,14 @@ reveal_type(b"foo" + A())  # revealed: bytes
 
 reveal_type(A() + ())  # revealed: A
 # TODO this should be `A`, since `tuple.__add__` doesn't support `A` instances
-reveal_type(() + A())  # revealed: @Todo(return type of overloaded function)
+reveal_type(() + A())  # revealed: @Todo(full tuple[...] support)
 
 literal_string_instance = "foo" * 1_000_000_000
 # the test is not testing what it's meant to be testing if this isn't a `LiteralString`:
 reveal_type(literal_string_instance)  # revealed: LiteralString
 
 reveal_type(A() + literal_string_instance)  # revealed: A
-# TODO should be `A` since `str.__add__` doesn't support `A` instances
-# TODO overloads
-reveal_type(literal_string_instance + A())  # revealed: @Todo(return type of overloaded function)
+reveal_type(literal_string_instance + A())  # revealed: A
 ```
 
 ## Operations involving instances of classes inheriting from `Any`

--- a/crates/red_knot_python_semantic/resources/mdtest/binary/integers.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/binary/integers.md
@@ -51,7 +51,9 @@ reveal_type(2**largest_u32)  # revealed: int
 
 def variable(x: int):
     reveal_type(x**2)  # revealed: int
+    # TODO: should be `Any` (overload 5 on `__pow__`), requires correct overload matching
     reveal_type(2**x)  # revealed: int
+    # TODO: should be `Any` (overload 5 on `__pow__`), requires correct overload matching
     reveal_type(x**x)  # revealed: int
 ```
 

--- a/crates/red_knot_python_semantic/resources/mdtest/binary/integers.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/binary/integers.md
@@ -50,9 +50,9 @@ reveal_type(1 ** (largest_u32 + 1))  # revealed: int
 reveal_type(2**largest_u32)  # revealed: int
 
 def variable(x: int):
-    reveal_type(x**2)  # revealed: @Todo(return type of overloaded function)
-    reveal_type(2**x)  # revealed: @Todo(return type of overloaded function)
-    reveal_type(x**x)  # revealed: @Todo(return type of overloaded function)
+    reveal_type(x**2)  # revealed: int
+    reveal_type(2**x)  # revealed: int
+    reveal_type(x**x)  # revealed: int
 ```
 
 If the second argument is \<0, a `float` is returned at runtime. If the first argument is \<0 but

--- a/crates/red_knot_python_semantic/resources/mdtest/dataclasses.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/dataclasses.md
@@ -547,14 +547,14 @@ the descriptor's `__get__` method as if it had been called on the class itself, 
 for the `instance` argument.
 
 ```py
-from typing import overload
+from typing import Literal, overload
 from dataclasses import dataclass
 
 class ConvertToLength:
     _len: int = 0
 
     @overload
-    def __get__(self, instance: None, owner: type) -> str: ...
+    def __get__(self, instance: None, owner: type) -> Literal[""]: ...
     @overload
     def __get__(self, instance: object, owner: type | None) -> int: ...
     def __get__(self, instance: object | None, owner: type | None) -> str | int:
@@ -570,7 +570,7 @@ class ConvertToLength:
 class C:
     converter: ConvertToLength = ConvertToLength()
 
-reveal_type(C.__init__)  # revealed: (converter: str = str) -> None
+reveal_type(C.__init__)  # revealed: (converter: str = Literal[""]) -> None
 
 c = C("abc")
 reveal_type(c.converter)  # revealed: int

--- a/crates/red_knot_python_semantic/resources/mdtest/dataclasses.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/dataclasses.md
@@ -570,12 +570,10 @@ class ConvertToLength:
 class C:
     converter: ConvertToLength = ConvertToLength()
 
-# TODO: Should be `(converter: str = Literal[""]) -> None` once we understand overloads
-reveal_type(C.__init__)  # revealed: (converter: str = str | int) -> None
+reveal_type(C.__init__)  # revealed: (converter: str = str) -> None
 
 c = C("abc")
-# TODO: Should be `int` once we understand overloads
-reveal_type(c.converter)  # revealed: str | int
+reveal_type(c.converter)  # revealed: int
 
 # This is also okay:
 C()
@@ -611,8 +609,7 @@ class AcceptsStrAndInt:
 class C:
     field: AcceptsStrAndInt = AcceptsStrAndInt()
 
-# TODO: Should be `field: str | int = int` once we understand overloads
-reveal_type(C.__init__)  # revealed: (field: Unknown = int) -> None
+reveal_type(C.__init__)  # revealed: (field: str | int = int) -> None
 ```
 
 ## `dataclasses.field`

--- a/crates/red_knot_python_semantic/resources/mdtest/descriptor_protocol.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/descriptor_protocol.md
@@ -459,11 +459,9 @@ class Descriptor:
 class C:
     d: Descriptor = Descriptor()
 
-# TODO: should be `Literal["called on class object"]
-reveal_type(C.d)  # revealed: LiteralString
+reveal_type(C.d)  # revealed: Literal["called on class object"]
 
-# TODO: should be `Literal["called on instance"]
-reveal_type(C().d)  # revealed: LiteralString
+reveal_type(C().d)  # revealed: Literal["called on instance"]
 ```
 
 ## Descriptor protocol for dunder methods

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/truthiness.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/truthiness.md
@@ -246,6 +246,7 @@ class MetaTruthy(type):
 
 class MetaDeferred(type):
     def __bool__(self) -> MetaAmbiguous:
+        # error: [no-matching-overload]
         return MetaAmbiguous()
 
 class AmbiguousClass(metaclass=MetaAmbiguous): ...

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/truthiness.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/truthiness.md
@@ -246,8 +246,7 @@ class MetaTruthy(type):
 
 class MetaDeferred(type):
     def __bool__(self) -> MetaAmbiguous:
-        # error: [no-matching-overload]
-        return MetaAmbiguous()
+        raise NotImplementedError
 
 class AmbiguousClass(metaclass=MetaAmbiguous): ...
 class FalsyClass(metaclass=MetaFalsy): ...

--- a/crates/red_knot_python_semantic/resources/mdtest/overloads.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/overloads.md
@@ -1,0 +1,335 @@
+# Overloads
+
+Reference: <https://typing.python.org/en/latest/spec/overload.html>
+
+## Invalid
+
+### At least two overloads
+
+At least two `@overload`-decorated definitions must be present.
+
+```py
+from typing import overload
+
+# TODO: error
+@overload
+def func(x: int) -> int: ...
+def func(x: int | str) -> int | str:
+    return x
+```
+
+### Overload without an implementation
+
+#### Regular modules
+
+In regular modules, a series of `@overload`-decorated definitions must be followed by exactly one
+non-`@overload`-decorated definition (for the same function/method).
+
+```py
+from typing import overload
+
+# TODO: error because implementation does not exists
+@overload
+def func(x: int) -> int: ...
+@overload
+def func(x: str) -> str: ...
+
+class Foo:
+    # TODO: error because implementation does not exists
+    @overload
+    def method(self, x: int) -> int: ...
+    @overload
+    def method(self, x: str) -> str: ...
+```
+
+#### Stub files
+
+Overload definitions within stub files are exempt from this check.
+
+```pyi
+from typing import overload
+
+@overload
+def func(x: int) -> int: ...
+@overload
+def func(x: str) -> str: ...
+```
+
+#### Protocols
+
+Overload definitions within protocols are exempt from this check.
+
+```py
+from typing import Protocol, overload
+
+class Foo(Protocol):
+    @overload
+    def f(self, x: int) -> int: ...
+    @overload
+    def f(self, x: str) -> str: ...
+```
+
+#### Abstract methods
+
+Overload definitions within abstract base classes are exempt from this check.
+
+```py
+from abc import ABC, abstractmethod
+from typing import overload
+
+class AbstractFoo(ABC):
+    @overload
+    @abstractmethod
+    def f(self, x: int) -> int: ...
+    @overload
+    @abstractmethod
+    def f(self, x: str) -> str: ...
+```
+
+Using the `@abstractmethod` decorator requires that the class's metaclass is `ABCMeta` or is derived
+from it.
+
+```py
+class Foo:
+    # TODO: Error because implementation does not exists
+    @overload
+    @abstractmethod
+    def f(self, x: int) -> int: ...
+    @overload
+    @abstractmethod
+    def f(self, x: str) -> str: ...
+```
+
+And, the `@abstractmethod` decorator must be present on all the `@overload`-ed methods.
+
+```py
+class PartialFoo1(ABC):
+    @overload
+    @abstractmethod
+    def f(self, x: int) -> int: ...
+    @overload
+    def f(self, x: str) -> str: ...
+
+class PartialFoo(ABC):
+    @overload
+    def f(self, x: int) -> int: ...
+    @overload
+    @abstractmethod
+    def f(self, x: str) -> str: ...
+```
+
+### Inconsistent decorators
+
+#### `@staticmethod` / `@classmethod`
+
+If one overload signature is decorated with `@staticmethod` or `@classmethod`, all overload
+signatures must be similarly decorated. The implementation, if present, must also have a consistent
+decorator.
+
+```py
+from __future__ import annotations
+
+from typing import overload
+
+class CheckStaticMethod:
+    # TODO: error because `@staticmethod` does not exist on all overloads
+    @overload
+    def method1(x: int) -> int: ...
+    @overload
+    def method1(x: str) -> str: ...
+    @staticmethod
+    def method1(x: int | str) -> int | str:
+        return x
+    # TODO: error because `@staticmethod` does not exist on all overloads
+    @overload
+    def method2(x: int) -> int: ...
+    @overload
+    @staticmethod
+    def method2(x: str) -> str: ...
+    @staticmethod
+    def method2(x: int | str) -> int | str:
+        return x
+    # TODO: error because `@staticmethod` does not exist on the implementation
+    @overload
+    @staticmethod
+    def method3(x: int) -> int: ...
+    @overload
+    @staticmethod
+    def method3(x: str) -> str: ...
+    def method3(x: int | str) -> int | str:
+        return x
+
+    @overload
+    @staticmethod
+    def method4(x: int) -> int: ...
+    @overload
+    @staticmethod
+    def method4(x: str) -> str: ...
+    @staticmethod
+    def method4(x: int | str) -> int | str:
+        return x
+
+class CheckClassMethod:
+    def __init__(self, x: int) -> None:
+        self.x = x
+    # TODO: error because `@classmethod` does not exist on all overloads
+    @overload
+    @classmethod
+    def try_from(cls, x: int) -> CheckClassMethod: ...
+    @overload
+    def try_from(cls, x: str) -> None: ...
+    @classmethod
+    def try_from(cls, x: int | str) -> CheckClassMethod | None:
+        if isinstance(x, int):
+            return cls(x)
+        return None
+    # TODO: error because `@classmethod` does not exist on all overloads
+    @overload
+    def try_from(cls, x: int) -> CheckClassMethod: ...
+    @overload
+    @classmethod
+    def try_from(cls, x: str) -> None: ...
+    @classmethod
+    def try_from(cls, x: int | str) -> CheckClassMethod | None:
+        if isinstance(x, int):
+            return cls(x)
+        return None
+    # TODO: error because `@classmethod` does not exist on the implementation
+    @overload
+    @classmethod
+    def try_from(cls, x: int) -> CheckClassMethod: ...
+    @overload
+    @classmethod
+    def try_from(cls, x: str) -> None: ...
+    def try_from(cls, x: int | str) -> CheckClassMethod | None:
+        if isinstance(x, int):
+            return cls(x)
+        return None
+
+    @overload
+    @classmethod
+    def try_from(cls, x: int) -> CheckClassMethod: ...
+    @overload
+    @classmethod
+    def try_from(cls, x: str) -> None: ...
+    @classmethod
+    def try_from(cls, x: int | str) -> CheckClassMethod | None:
+        if isinstance(x, int):
+            return cls(x)
+        return None
+```
+
+#### `@final` / `@override`
+
+If a `@final` or `@override` decorator is supplied for a function with overloads, the decorator
+should be applied only to the overload implementation if it is present.
+
+```py
+from typing_extensions import final, overload, override
+
+class Foo:
+    @overload
+    def method1(self, x: int) -> int: ...
+    @overload
+    def method1(self, x: str) -> str: ...
+    @final
+    def method1(self, x: int | str) -> int | str:
+        return x
+    # TODO: error because `@final` is not on the implementation
+    @overload
+    @final
+    def method2(self, x: int) -> int: ...
+    @overload
+    def method2(self, x: str) -> str: ...
+    def method2(self, x: int | str) -> int | str:
+        return x
+    # TODO: error because `@final` is not on the implementation
+    @overload
+    def method3(self, x: int) -> int: ...
+    @overload
+    @final
+    def method3(self, x: str) -> str: ...
+    def method3(self, x: int | str) -> int | str:
+        return x
+
+class Base:
+    @overload
+    def method(self, x: int) -> int: ...
+    @overload
+    def method(self, x: str) -> str: ...
+    def method(self, x: int | str) -> int | str:
+        return x
+
+class Sub1(Base):
+    @overload
+    def method(self, x: int) -> int: ...
+    @overload
+    def method(self, x: str) -> str: ...
+    @override
+    def method(self, x: int | str) -> int | str:
+        return x
+
+class Sub2(Base):
+    # TODO: error because `@override` is not on the implementation
+    @overload
+    def method(self, x: int) -> int: ...
+    @overload
+    @override
+    def method(self, x: str) -> str: ...
+    def method(self, x: int | str) -> int | str:
+        return x
+
+class Sub3(Base):
+    # TODO: error because `@override` is not on the implementation
+    @overload
+    @override
+    def method(self, x: int) -> int: ...
+    @overload
+    def method(self, x: str) -> str: ...
+    def method(self, x: int | str) -> int | str:
+        return x
+```
+
+#### `@final` / `@override` in stub files
+
+If an overload implementation isn’t present (for example, in a stub file), the `@final` or
+`@override` decorator should be applied only to the first overload.
+
+```pyi
+from typing_extensions import final, overload, override
+
+class Foo:
+    @overload
+    @final
+    def method1(self, x: int) -> int: ...
+    @overload
+    def method1(self, x: str) -> str: ...
+
+    # TODO: error because `@final` is not on the first overload
+    @overload
+    def method2(self, x: int) -> int: ...
+    @final
+    @overload
+    def method2(self, x: str) -> str: ...
+
+class Base:
+    @overload
+    def method(self, x: int) -> int: ...
+    @overload
+    def method(self, x: str) -> str: ...
+
+class Sub1(Base):
+    @overload
+    @override
+    def method(self, x: int) -> int: ...
+    @overload
+    def method(self, x: str) -> str: ...
+
+class Sub2(Base):
+    # TODO: error because `@override` is not on the first overload
+    @overload
+    def method(self, x: int) -> int: ...
+    @overload
+    @override
+    def method(self, x: str) -> str: ...
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/overloads.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/overloads.md
@@ -2,6 +2,21 @@
 
 Reference: <https://typing.python.org/en/latest/spec/overload.html>
 
+## `typing.overload`
+
+The definition of `typing.overload` in typeshed is an identity function.
+
+```py
+from typing import overload
+
+def foo(x: int) -> int:
+    return x
+
+reveal_type(foo)  # revealed: def foo(x: int) -> int
+bar = overload(foo)
+reveal_type(bar)  # revealed: def foo(x: int) -> int
+```
+
 ## Functions
 
 ```py
@@ -25,9 +40,9 @@ reveal_type(add(1, 2))  # revealed: int
 ## Overriding
 
 These scenarios are to verify that the overloaded and non-overloaded definitions are correctly
-overriden by each other.
+overridden by each other.
 
-An overloaded function is overridding another overloaded function:
+An overloaded function is overriding another overloaded function:
 
 ```py
 from typing import overload
@@ -55,7 +70,7 @@ reveal_type(foo())  # revealed: None
 reveal_type(foo(""))  # revealed: str
 ```
 
-A non-overloaded function is overridding an overloaded function:
+A non-overloaded function is overriding an overloaded function:
 
 ```py
 def foo(x: int) -> int:
@@ -64,9 +79,11 @@ def foo(x: int) -> int:
 reveal_type(foo)  # revealed: def foo(x: int) -> int
 ```
 
-An overloaded function is overridding a non-overloaded function:
+An overloaded function is overriding a non-overloaded function:
 
 ```py
+reveal_type(foo)  # revealed: def foo(x: int) -> int
+
 @overload
 def foo() -> None: ...
 @overload
@@ -265,6 +282,11 @@ reveal_type(func(""))  # revealed: str
 
 ## Generic
 
+```toml
+[environment]
+python-version = "3.12"
+```
+
 For an overloaded generic function, it's not necessary for all overloads to be generic.
 
 ```py
@@ -278,6 +300,7 @@ def func[T](x: T | None = None) -> T | None:
     return x
 
 reveal_type(func)  # revealed: Overload[() -> None, (x: T) -> T]
+reveal_type(func())  # revealed: None
 reveal_type(func(1))  # revealed: Literal[1]
 reveal_type(func(""))  # revealed: Literal[""]
 ```
@@ -455,45 +478,45 @@ class CheckClassMethod:
     # TODO: error because `@classmethod` does not exist on all overloads
     @overload
     @classmethod
-    def try_from(cls, x: int) -> CheckClassMethod: ...
+    def try_from1(cls, x: int) -> CheckClassMethod: ...
     @overload
-    def try_from(cls, x: str) -> None: ...
+    def try_from1(cls, x: str) -> None: ...
     @classmethod
-    def try_from(cls, x: int | str) -> CheckClassMethod | None:
+    def try_from1(cls, x: int | str) -> CheckClassMethod | None:
         if isinstance(x, int):
             return cls(x)
         return None
     # TODO: error because `@classmethod` does not exist on all overloads
     @overload
-    def try_from(cls, x: int) -> CheckClassMethod: ...
+    def try_from2(cls, x: int) -> CheckClassMethod: ...
     @overload
     @classmethod
-    def try_from(cls, x: str) -> None: ...
+    def try_from2(cls, x: str) -> None: ...
     @classmethod
-    def try_from(cls, x: int | str) -> CheckClassMethod | None:
+    def try_from2(cls, x: int | str) -> CheckClassMethod | None:
         if isinstance(x, int):
             return cls(x)
         return None
     # TODO: error because `@classmethod` does not exist on the implementation
     @overload
     @classmethod
-    def try_from(cls, x: int) -> CheckClassMethod: ...
+    def try_from3(cls, x: int) -> CheckClassMethod: ...
     @overload
     @classmethod
-    def try_from(cls, x: str) -> None: ...
-    def try_from(cls, x: int | str) -> CheckClassMethod | None:
+    def try_from3(cls, x: str) -> None: ...
+    def try_from3(cls, x: int | str) -> CheckClassMethod | None:
         if isinstance(x, int):
             return cls(x)
         return None
 
     @overload
     @classmethod
-    def try_from(cls, x: int) -> CheckClassMethod: ...
+    def try_from4(cls, x: int) -> CheckClassMethod: ...
     @overload
     @classmethod
-    def try_from(cls, x: str) -> None: ...
+    def try_from4(cls, x: str) -> None: ...
     @classmethod
-    def try_from(cls, x: int | str) -> CheckClassMethod | None:
+    def try_from4(cls, x: int | str) -> CheckClassMethod | None:
         if isinstance(x, int):
             return cls(x)
         return None

--- a/crates/red_knot_python_semantic/resources/mdtest/overloads.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/overloads.md
@@ -16,7 +16,6 @@ def add(x: int, y: int) -> int: ...
 def add(x: int | None = None, y: int | None = None) -> int | None:
     return (x or 0) + (y or 0)
 
-
 reveal_type(add)  # revealed: Overload[() -> None, (x: int) -> int, (x: int, y: int) -> int]
 reveal_type(add())  # revealed: None
 reveal_type(add(1))  # revealed: int
@@ -61,7 +60,6 @@ A non-overloaded function is overridding an overloaded function:
 ```py
 def foo(x: int) -> int:
     return x
-
 
 reveal_type(foo)  # revealed: def foo(x: int) -> int
 ```
@@ -155,6 +153,7 @@ from typing import overload
 if sys.version_info < (3, 10):
     def func(x: int) -> int:
         return x
+
 elif sys.version_info <= (3, 12):
     @overload
     def func() -> None: ...
@@ -162,7 +161,6 @@ elif sys.version_info <= (3, 12):
     def func(x: int) -> int: ...
     def func(x: int | None = None) -> int | None:
         return x
-
 
 reveal_type(func)  # revealed: def func(x: int) -> int
 func()  # error: [missing-argument]
@@ -182,6 +180,7 @@ from typing import overload
 if sys.version_info < (3, 10):
     def func(x: int) -> int:
         return x
+
 elif sys.version_info <= (3, 12):
     @overload
     def func() -> None: ...
@@ -189,7 +188,6 @@ elif sys.version_info <= (3, 12):
     def func(x: int) -> int: ...
     def func(x: int | None = None) -> int | None:
         return x
-
 
 reveal_type(func)  # revealed: Overload[() -> None, (x: int) -> int]
 reveal_type(func())  # revealed: None

--- a/crates/red_knot_python_semantic/resources/mdtest/overloads.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/overloads.md
@@ -278,14 +278,8 @@ def func[T](x: T | None = None) -> T | None:
     return x
 
 reveal_type(func)  # revealed: Overload[() -> None, (x: T) -> T]
-# TODO: requires generics; should be `int`
-# TODO: requires generics; should not error
-# error: [no-matching-overload]
-reveal_type(func(1))  # revealed: Unknown
-# TODO: requires generics; should be `str`
-# TODO: requires generics; should not error
-# error: [no-matching-overload]
-reveal_type(func(""))  # revealed: Unknown
+reveal_type(func(1))  # revealed: Literal[1]
+reveal_type(func(""))  # revealed: Literal[""]
 ```
 
 ## Invalid

--- a/crates/red_knot_python_semantic/resources/mdtest/subscript/bytes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/subscript/bytes.md
@@ -24,8 +24,7 @@ reveal_type(y)  # revealed: Unknown
 
 def _(n: int):
     a = b"abcde"[n]
-    # TODO: Support overloads... Should be `bytes`
-    reveal_type(a)  # revealed: @Todo(return type of overloaded function)
+    reveal_type(a)  # revealed: int
 ```
 
 ## Slices
@@ -43,11 +42,9 @@ b[::0]  # error: [zero-stepsize-in-slice]
 
 def _(m: int, n: int):
     byte_slice1 = b[m:n]
-    # TODO: Support overloads... Should be `bytes`
-    reveal_type(byte_slice1)  # revealed: @Todo(return type of overloaded function)
+    reveal_type(byte_slice1)  # revealed: bytes
 
 def _(s: bytes) -> bytes:
     byte_slice2 = s[0:5]
-    # TODO: Support overloads... Should be `bytes`
-    return reveal_type(byte_slice2)  # revealed: @Todo(return type of overloaded function)
+    return reveal_type(byte_slice2)  # revealed: bytes
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/subscript/lists.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/subscript/lists.md
@@ -17,7 +17,7 @@ reveal_type(x[0])  # revealed: Unknown | @Todo(Support for `typing.TypeVar` inst
 # TODO reveal list
 reveal_type(x[0:1])  # revealed: @Todo(generics)
 
-# error: [call-non-callable] "Method `__getitem__` of type `Overload[(i: SupportsIndex, /) -> Unknown | @Todo(Support for `typing.TypeVar` instances in type expressions), (s: slice, /) -> @Todo(generics)]` is not callable on object of type `list`"
+# error: [call-non-callable]
 reveal_type(x["a"])  # revealed: Unknown
 ```
 

--- a/crates/red_knot_python_semantic/resources/mdtest/subscript/lists.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/subscript/lists.md
@@ -29,9 +29,11 @@ In assignment, we might also have a named assignment. This should also get type 
 x = [1, 2, 3]
 x[0 if (y := 2) else 1] = 5
 
+# TODO: better error than "method `__getitem__` not callable on type `list`"
 # error: [call-non-callable]
 x["a" if (y := 2) else 1] = 6
 
+# TODO: better error than "method `__getitem__` not callable on type `list`"
 # error: [call-non-callable]
 x["a" if (y := 2) else "b"] = 6
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/subscript/lists.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/subscript/lists.md
@@ -12,13 +12,13 @@ x = [1, 2, 3]
 reveal_type(x)  # revealed: list
 
 # TODO reveal int
-reveal_type(x[0])  # revealed: @Todo(return type of overloaded function)
+reveal_type(x[0])  # revealed: Unknown | @Todo(Support for `typing.TypeVar` instances in type expressions)
 
 # TODO reveal list
-reveal_type(x[0:1])  # revealed: @Todo(return type of overloaded function)
+reveal_type(x[0:1])  # revealed: @Todo(generics)
 
-# TODO error
-reveal_type(x["a"])  # revealed: @Todo(return type of overloaded function)
+# error: [call-non-callable] "Method `__getitem__` of type `Overload((i: SupportsIndex, /) -> Unknown | @Todo(Support for `typing.TypeVar` instances in type expressions), (s: slice, /) -> @Todo(generics))` is not callable on object of type `list`"
+reveal_type(x["a"])  # revealed: Unknown
 ```
 
 ## Assignments within list assignment
@@ -29,9 +29,9 @@ In assignment, we might also have a named assignment. This should also get type 
 x = [1, 2, 3]
 x[0 if (y := 2) else 1] = 5
 
-# TODO error? (indeterminite index type)
+# error: [call-non-callable]
 x["a" if (y := 2) else 1] = 6
 
-# TODO error (can't index via string)
+# error: [call-non-callable]
 x["a" if (y := 2) else "b"] = 6
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/subscript/lists.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/subscript/lists.md
@@ -17,7 +17,7 @@ reveal_type(x[0])  # revealed: Unknown | @Todo(Support for `typing.TypeVar` inst
 # TODO reveal list
 reveal_type(x[0:1])  # revealed: @Todo(generics)
 
-# error: [call-non-callable] "Method `__getitem__` of type `Overload((i: SupportsIndex, /) -> Unknown | @Todo(Support for `typing.TypeVar` instances in type expressions), (s: slice, /) -> @Todo(generics))` is not callable on object of type `list`"
+# error: [call-non-callable] "Method `__getitem__` of type `Overload[(i: SupportsIndex, /) -> Unknown | @Todo(Support for `typing.TypeVar` instances in type expressions), (s: slice, /) -> @Todo(generics)]` is not callable on object of type `list`"
 reveal_type(x["a"])  # revealed: Unknown
 ```
 

--- a/crates/red_knot_python_semantic/resources/mdtest/subscript/string.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/subscript/string.md
@@ -21,8 +21,7 @@ reveal_type(b)  # revealed: Unknown
 
 def _(n: int):
     a = "abcde"[n]
-    # TODO: Support overloads... Should be `str`
-    reveal_type(a)  # revealed: @Todo(return type of overloaded function)
+    reveal_type(a)  # revealed: LiteralString
 ```
 
 ## Slices
@@ -75,12 +74,10 @@ def _(m: int, n: int, s2: str):
     s[::0]  # error: [zero-stepsize-in-slice]
 
     substring1 = s[m:n]
-    # TODO: Support overloads... Should be `LiteralString`
-    reveal_type(substring1)  # revealed: @Todo(return type of overloaded function)
+    reveal_type(substring1)  # revealed: LiteralString
 
     substring2 = s2[0:5]
-    # TODO: Support overloads... Should be `str`
-    reveal_type(substring2)  # revealed: @Todo(return type of overloaded function)
+    reveal_type(substring2)  # revealed: str
 ```
 
 ## Unsupported slice types

--- a/crates/red_knot_python_semantic/resources/mdtest/subscript/tuple.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/subscript/tuple.md
@@ -70,7 +70,7 @@ def _(m: int, n: int):
 
     tuple_slice = t[m:n]
     # TODO: Support overloads... Should be `tuple[Literal[1, 'a', b"b"] | None, ...]`
-    reveal_type(tuple_slice)  # revealed: @Todo(return type of overloaded function)
+    reveal_type(tuple_slice)  # revealed: @Todo(full tuple[...] support)
 ```
 
 ## Inheritance

--- a/crates/red_knot_python_semantic/resources/mdtest/subscript/tuple.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/subscript/tuple.md
@@ -69,7 +69,7 @@ def _(m: int, n: int):
     t[::0]  # error: [zero-stepsize-in-slice]
 
     tuple_slice = t[m:n]
-    # TODO: Support overloads... Should be `tuple[Literal[1, 'a', b"b"] | None, ...]`
+    # TODO: Should be `tuple[Literal[1, 'a', b"b"] | None, ...]`
     reveal_type(tuple_slice)  # revealed: @Todo(full tuple[...] support)
 ```
 

--- a/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
@@ -522,4 +522,35 @@ c: Callable[[Any], str] = A().f
 c: Callable[[Any], str] = A().g
 ```
 
+### Overloads
+
+`overloaded.pyi`:
+
+```pyi
+from typing import Any, overload
+
+@overload
+def overloaded() -> None: ...
+@overload
+def overloaded(a: str) -> str: ...
+@overload
+def overloaded(a: str, b: Any) -> str: ...
+```
+
+```py
+from overloaded import overloaded
+from typing import Any, Callable
+
+c: Callable[[], None] = overloaded
+c: Callable[[str], str] = overloaded
+c: Callable[[str, Any], Any] = overloaded
+c: Callable[..., str] = overloaded
+
+# error: [invalid-assignment]
+c: Callable[..., int] = overloaded
+
+# error: [invalid-assignment]
+c: Callable[[int], str] = overloaded
+```
+
 [typing documentation]: https://typing.python.org/en/latest/spec/concepts.html#the-assignable-to-or-consistent-subtyping-relation

--- a/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_equivalent_to.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_equivalent_to.md
@@ -254,4 +254,8 @@ from knot_extensions import is_equivalent_to, static_assert
 static_assert(is_equivalent_to(int | Callable[[int | str], None], Callable[[str | int], None] | int))
 ```
 
+### Overloads
+
+TODO
+
 [the equivalence relation]: https://typing.python.org/en/latest/spec/glossary.html#term-equivalent

--- a/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_fully_static.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_fully_static.md
@@ -99,3 +99,31 @@ static_assert(not is_fully_static(CallableTypeOf[f13]))
 static_assert(not is_fully_static(CallableTypeOf[f14]))
 static_assert(not is_fully_static(CallableTypeOf[f15]))
 ```
+
+## Overloads
+
+`overloaded.pyi`:
+
+```pyi
+from typing import Any, overload
+
+@overload
+def gradual() -> None: ...
+@overload
+def gradual(a: Any) -> None: ...
+
+@overload
+def static() -> None: ...
+@overload
+def static(x: int) -> None: ...
+@overload
+def static(x: str) -> str: ...
+```
+
+```py
+from knot_extensions import CallableTypeOf, is_fully_static, static_assert
+from overloaded import gradual, static
+
+static_assert(not is_fully_static(CallableTypeOf[gradual]))
+static_assert(is_fully_static(CallableTypeOf[static]))
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_fully_static.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_fully_static.md
@@ -121,8 +121,11 @@ def static(x: str) -> str: ...
 ```
 
 ```py
-from knot_extensions import CallableTypeOf, is_fully_static, static_assert
+from knot_extensions import CallableTypeOf, TypeOf, is_fully_static, static_assert
 from overloaded import gradual, static
+
+static_assert(is_fully_static(TypeOf[gradual]))
+static_assert(is_fully_static(TypeOf[static]))
 
 static_assert(not is_fully_static(CallableTypeOf[gradual]))
 static_assert(is_fully_static(CallableTypeOf[static]))

--- a/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_gradual_equivalent_to.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_gradual_equivalent_to.md
@@ -157,4 +157,6 @@ def f6(a, /): ...
 static_assert(not is_gradual_equivalent_to(CallableTypeOf[f1], CallableTypeOf[f6]))
 ```
 
+TODO: Overloads
+
 [materializations]: https://typing.python.org/en/latest/spec/glossary.html#term-materialize

--- a/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
@@ -1306,6 +1306,8 @@ static_assert(not is_subtype_of(CallableTypeOf[empty_cp], CallableTypeOf[empty_g
 
 #### Order of overloads
 
+Order of overloads is irrelevant for subtyping.
+
 `overloaded.pyi`:
 
 ```pyi

--- a/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
@@ -1153,5 +1153,156 @@ static_assert(not is_subtype_of(TypeOf[A.g], Callable[[], int]))
 static_assert(is_subtype_of(TypeOf[A.f], Callable[[A, int], int]))
 ```
 
+### Overload
+
+#### Subtype overloaded
+
+For `B <: A`, if a callable `B` is overloaded with two or more signatures, it is a subtype of
+callable `A` if _at least one_ of the overloaded signatures in `B` is a subtype of `A`.
+
+`overloaded.pyi`:
+
+```pyi
+from typing import overload
+
+class A: ...
+class B: ...
+class C: ...
+
+@overload
+def overloaded(x: A) -> None: ...
+@overload
+def overloaded(x: B) -> None: ...
+```
+
+```py
+from knot_extensions import CallableTypeOf, is_subtype_of, static_assert
+from overloaded import A, B, C, overloaded
+
+def accepts_a(x: A) -> None: ...
+def accepts_b(x: B) -> None: ...
+def accepts_c(x: C) -> None: ...
+
+static_assert(is_subtype_of(CallableTypeOf[overloaded], CallableTypeOf[accepts_a]))
+static_assert(is_subtype_of(CallableTypeOf[overloaded], CallableTypeOf[accepts_b]))
+static_assert(not is_subtype_of(CallableTypeOf[overloaded], CallableTypeOf[accepts_c]))
+```
+
+#### Supertype overloaded
+
+For `B <: A`, if a callable `A` is overloaded with two or more signatures, callable `B` is a subtype
+of `A` if `B` is a subtype of _all_ of the signatures in `A`.
+
+`overloaded.pyi`:
+
+```pyi
+from typing import overload
+
+class Grandparent: ...
+class Parent(Grandparent): ...
+class Child(Parent): ...
+
+@overload
+def overloaded(a: Child) -> None: ...
+@overload
+def overloaded(a: Parent) -> None: ...
+@overload
+def overloaded(a: Grandparent) -> None: ...
+```
+
+```py
+from knot_extensions import CallableTypeOf, is_subtype_of, static_assert
+from overloaded import Grandparent, Parent, Child, overloaded
+
+# This is a subtype of only the first overload
+def child(a: Child) -> None: ...
+
+# This is a subtype of the first and second overload
+def parent(a: Parent) -> None: ...
+
+# This is the only function that's a subtype of all overloads
+def grandparent(a: Grandparent) -> None: ...
+
+static_assert(not is_subtype_of(CallableTypeOf[child], CallableTypeOf[overloaded]))
+static_assert(not is_subtype_of(CallableTypeOf[parent], CallableTypeOf[overloaded]))
+static_assert(is_subtype_of(CallableTypeOf[grandparent], CallableTypeOf[overloaded]))
+```
+
+#### Both overloads
+
+For `B <: A`, if both `A` and `B` is a callable that's overloaded with two or more signatures, then
+`B` is a subtype of `A` if for _every_ signature in `A`, there is _at least one_ signature in `B`
+that is a subtype of it.
+
+`overloaded.pyi`:
+
+```pyi
+from typing import overload
+
+class Grandparent: ...
+class Parent(Grandparent): ...
+class Child(Parent): ...
+class Other: ...
+
+@overload
+def pg(a: Parent) -> None: ...
+@overload
+def pg(a: Grandparent) -> None: ...
+
+@overload
+def po(a: Parent) -> None: ...
+@overload
+def po(a: Other) -> None: ...
+
+@overload
+def go(a: Grandparent) -> None: ...
+@overload
+def go(a: Other) -> None: ...
+
+@overload
+def cpg(a: Child) -> None: ...
+@overload
+def cpg(a: Parent) -> None: ...
+@overload
+def cpg(a: Grandparent) -> None: ...
+
+@overload
+def empty_go() -> Child: ...
+@overload
+def empty_go(a: Grandparent) -> None: ...
+@overload
+def empty_go(a: Other) -> Other: ...
+
+@overload
+def empty_cp() -> Parent: ...
+@overload
+def empty_cp(a: Child) -> None: ...
+@overload
+def empty_cp(a: Parent) -> None: ...
+```
+
+```py
+from knot_extensions import CallableTypeOf, is_subtype_of, static_assert
+from overloaded import pg, po, go, cpg, empty_go, empty_cp
+
+static_assert(is_subtype_of(CallableTypeOf[pg], CallableTypeOf[cpg]))
+static_assert(is_subtype_of(CallableTypeOf[cpg], CallableTypeOf[pg]))
+
+static_assert(not is_subtype_of(CallableTypeOf[po], CallableTypeOf[pg]))
+static_assert(not is_subtype_of(CallableTypeOf[pg], CallableTypeOf[po]))
+
+static_assert(is_subtype_of(CallableTypeOf[go], CallableTypeOf[pg]))
+static_assert(not is_subtype_of(CallableTypeOf[pg], CallableTypeOf[go]))
+
+# Overload 1 in `empty_go` is a subtype of overload 1 in `empty_cp`
+# Overload 2 in `empty_go` is a subtype of overload 2 in `empty_cp`
+# Overload 2 in `empty_go` is a subtype of overload 3 in `empty_cp`
+#
+# All overloads in `empty_cp` has a subtype in `empty_go`
+static_assert(is_subtype_of(CallableTypeOf[empty_go], CallableTypeOf[empty_cp]))
+
+static_assert(not is_subtype_of(CallableTypeOf[empty_cp], CallableTypeOf[empty_go]))
+```
+
 [special case for float and complex]: https://typing.python.org/en/latest/spec/special-types.html#special-cases-for-float-and-complex
 [typing documentation]: https://typing.python.org/en/latest/spec/concepts.html#subtype-supertype-and-type-equivalence

--- a/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
@@ -1153,7 +1153,7 @@ static_assert(not is_subtype_of(TypeOf[A.g], Callable[[], int]))
 static_assert(is_subtype_of(TypeOf[A.f], Callable[[A, int], int]))
 ```
 
-### Overload
+### Overloads
 
 #### Subtype overloaded
 

--- a/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
@@ -1304,5 +1304,34 @@ static_assert(is_subtype_of(CallableTypeOf[empty_go], CallableTypeOf[empty_cp]))
 static_assert(not is_subtype_of(CallableTypeOf[empty_cp], CallableTypeOf[empty_go]))
 ```
 
+#### Order of overloads
+
+`overloaded.pyi`:
+
+```pyi
+from typing import overload
+
+class A: ...
+class B: ...
+
+@overload
+def overload_ab(x: A) -> None: ...
+@overload
+def overload_ab(x: B) -> None: ...
+
+@overload
+def overload_ba(x: B) -> None: ...
+@overload
+def overload_ba(x: A) -> None: ...
+```
+
+```py
+from overloaded import overload_ab, overload_ba
+from knot_extensions import CallableTypeOf, is_subtype_of, static_assert
+
+static_assert(is_subtype_of(CallableTypeOf[overload_ab], CallableTypeOf[overload_ba]))
+static_assert(is_subtype_of(CallableTypeOf[overload_ba], CallableTypeOf[overload_ab]))
+```
+
 [special case for float and complex]: https://typing.python.org/en/latest/spec/special-types.html#special-cases-for-float-and-complex
 [typing documentation]: https://typing.python.org/en/latest/spec/concepts.html#subtype-supertype-and-type-equivalence

--- a/crates/red_knot_python_semantic/src/semantic_index/ast_ids.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/ast_ids.rs
@@ -58,6 +58,13 @@ pub trait HasScopedUseId {
     fn scoped_use_id(&self, db: &dyn Db, scope: ScopeId) -> ScopedUseId;
 }
 
+impl HasScopedUseId for ast::Identifier {
+    fn scoped_use_id(&self, db: &dyn Db, scope: ScopeId) -> ScopedUseId {
+        let ast_ids = ast_ids(db, scope);
+        ast_ids.use_id(self)
+    }
+}
+
 impl HasScopedUseId for ast::ExprName {
     fn scoped_use_id(&self, db: &dyn Db, scope: ScopeId) -> ScopedUseId {
         let expression_ref = ExprRef::from(self);
@@ -157,7 +164,7 @@ impl AstIdsBuilder {
     }
 
     /// Adds `expr` to the use ids map and returns its id.
-    pub(super) fn record_use(&mut self, expr: &ast::Expr) -> ScopedUseId {
+    pub(super) fn record_use(&mut self, expr: impl Into<ExpressionNodeKey>) -> ScopedUseId {
         let use_id = self.uses_map.len().into();
 
         self.uses_map.insert(expr.into(), use_id);
@@ -193,6 +200,12 @@ pub(crate) mod node_key {
 
     impl From<&ast::Expr> for ExpressionNodeKey {
         fn from(value: &ast::Expr) -> Self {
+            Self(NodeKey::from_node(value))
+        }
+    }
+
+    impl From<&ast::Identifier> for ExpressionNodeKey {
+        fn from(value: &ast::Identifier) -> Self {
             Self(NodeKey::from_node(value))
         }
     }

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -1116,6 +1116,15 @@ where
                 // and return-type annotations.
                 let (symbol, _) = self.add_symbol(name.id.clone());
 
+                // Record a use of the function name in the scope that it is defined in, so that it
+                // can be used to find previously defined functions with the same name. This is
+                // used to collect all the overloaded definitions of a function. This needs to be
+                // done on the `Identifier` node as oppose to `ExprName` because that's what the
+                // AST uses.
+                //
+                // This could possibly be done only if there are decorators to avoid the extra
+                // work for non-overloaded functions, but that wouldn't work because the
+                // implementation function is not decorated with `@overload`.
                 self.mark_symbol_used(symbol);
                 let use_id = self.current_ast_ids().record_use(name);
                 self.current_use_def_map_mut()

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -1115,6 +1115,12 @@ where
                 // at the end to match the runtime evaluation of parameter defaults
                 // and return-type annotations.
                 let (symbol, _) = self.add_symbol(name.id.clone());
+
+                self.mark_symbol_used(symbol);
+                let use_id = self.current_ast_ids().record_use(name);
+                self.current_use_def_map_mut()
+                    .record_use(symbol, use_id, NodeKey::from_node(name));
+
                 self.add_definition(symbol, function_def);
             }
             ast::Stmt::ClassDef(class) => {

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -1119,12 +1119,8 @@ where
                 // Record a use of the function name in the scope that it is defined in, so that it
                 // can be used to find previously defined functions with the same name. This is
                 // used to collect all the overloaded definitions of a function. This needs to be
-                // done on the `Identifier` node as oppose to `ExprName` because that's what the
+                // done on the `Identifier` node as opposed to `ExprName` because that's what the
                 // AST uses.
-                //
-                // This could possibly be done only if there are decorators to avoid the extra
-                // work for non-overloaded functions, but that wouldn't work because the
-                // implementation function is not decorated with `@overload`.
                 self.mark_symbol_used(symbol);
                 let use_id = self.current_ast_ids().record_use(name);
                 self.current_use_def_map_mut()

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -5808,9 +5808,6 @@ pub struct FunctionType<'db> {
     /// Is this a function that we special-case somehow? If so, which one?
     known: Option<KnownFunction>,
 
-    /// The scope in which the function is defined.
-    scope: ScopeId<'db>,
-
     /// The scope that's created by the function, in which the function body is evaluated.
     body_scope: ScopeId<'db>,
 
@@ -5883,7 +5880,7 @@ impl<'db> FunctionType<'db> {
 
         // The semantic model records a use for each function on the name node. This is used here
         // to get the previous function definition with the same name.
-        let scope = self.scope(db);
+        let scope = self.definition(db).scope(db);
         let use_def = semantic_index(db, scope.file(db)).use_def_map(scope.file_scope_id(db));
         let use_id = self
             .body_scope(db)
@@ -5951,7 +5948,6 @@ impl<'db> FunctionType<'db> {
             db,
             self.name(db).clone(),
             self.known(db),
-            self.scope(db),
             self.body_scope(db),
             self.decorators(db),
             Some(generic_context),
@@ -5968,7 +5964,6 @@ impl<'db> FunctionType<'db> {
             db,
             self.name(db).clone(),
             self.known(db),
-            self.scope(db),
             self.body_scope(db),
             self.decorators(db),
             self.generic_context(db),

--- a/crates/red_knot_python_semantic/src/types/call/bind.rs
+++ b/crates/red_knot_python_semantic/src/types/call/bind.rs
@@ -19,7 +19,7 @@ use crate::types::diagnostic::{
 use crate::types::generics::{Specialization, SpecializationBuilder};
 use crate::types::signatures::{Parameter, ParameterForm};
 use crate::types::{
-    todo_type, BoundMethodType, DataclassMetadata, FunctionDecorators, KnownClass, KnownFunction,
+    BoundMethodType, DataclassMetadata, FunctionDecorators, KnownClass, KnownFunction,
     KnownInstanceType, MethodWrapperKind, PropertyInstanceType, UnionType, WrapperDescriptorKind,
 };
 use ruff_db::diagnostic::{Annotation, Severity, Span, SubDiagnostic};
@@ -536,7 +536,9 @@ impl<'db> Bindings<'db> {
                     }
 
                     Some(KnownFunction::Overload) => {
-                        overload.set_return_type(todo_type!("overload[..] return type"));
+                        if let [Some(ty)] = overload.parameter_types() {
+                            overload.set_return_type(*ty);
+                        }
                     }
 
                     Some(KnownFunction::GetattrStatic) => {

--- a/crates/red_knot_python_semantic/src/types/call/bind.rs
+++ b/crates/red_knot_python_semantic/src/types/call/bind.rs
@@ -536,6 +536,8 @@ impl<'db> Bindings<'db> {
                     }
 
                     Some(KnownFunction::Overload) => {
+                        // TODO: This can be removed once we understand legacy generics because the
+                        // typeshed definition for `typing.overload` is an identity function.
                         if let [Some(ty)] = overload.parameter_types() {
                             overload.set_return_type(*ty);
                         }

--- a/crates/red_knot_python_semantic/src/types/class.rs
+++ b/crates/red_knot_python_semantic/src/types/class.rs
@@ -931,7 +931,7 @@ impl<'db> ClassLiteralType<'db> {
 
             let init_signature = Signature::new(Parameters::new(parameters), Some(Type::none(db)));
 
-            return Some(Type::Callable(CallableType::new(db, init_signature)));
+            return Some(Type::Callable(CallableType::single(db, init_signature)));
         } else if matches!(name, "__lt__" | "__le__" | "__gt__" | "__ge__") {
             if metadata.contains(DataclassMetadata::ORDER) {
                 let signature = Signature::new(
@@ -943,7 +943,7 @@ impl<'db> ClassLiteralType<'db> {
                     Some(KnownClass::Bool.to_instance(db)),
                 );
 
-                return Some(Type::Callable(CallableType::new(db, signature)));
+                return Some(Type::Callable(CallableType::single(db, signature)));
             }
         }
 

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -388,7 +388,7 @@ impl Display for DisplaySpecialization<'_> {
 impl<'db> CallableType<'db> {
     pub(crate) fn display(&'db self, db: &'db dyn Db) -> DisplayCallableType<'db> {
         DisplayCallableType {
-            signatures: self.signature(db),
+            signatures: self.signatures(db),
             db,
         }
     }

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -405,13 +405,13 @@ impl Display for DisplayCallableType<'_> {
             [signature] => write!(f, "{}", signature.display(self.db)),
             signatures => {
                 // TODO: How to display overloads?
-                f.write_char('(')?;
+                f.write_str("Overload[")?;
                 let mut join = f.join(", ");
                 for signature in signatures {
                     join.entry(&signature.display(self.db));
                 }
                 join.finish()?;
-                f.write_char(')')
+                f.write_char(']')
             }
         }
     }

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -143,12 +143,12 @@ impl Display for DisplayRepresentation<'_> {
                     }
                     FunctionSignature::Overloaded(signatures, _) => {
                         // TODO: How to display overloads?
-                        f.write_str("Overload(")?;
+                        f.write_str("Overload[")?;
                         let mut join = f.join(", ");
                         for signature in signatures {
                             join.entry(&signature.bind_self().display(self.db));
                         }
-                        f.write_str(")")
+                        f.write_str("]")
                     }
                 }
             }

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -11,11 +11,14 @@ use crate::types::class_base::ClassBase;
 use crate::types::generics::{GenericContext, Specialization};
 use crate::types::signatures::{Parameter, Parameters, Signature};
 use crate::types::{
-    InstanceType, IntersectionType, KnownClass, MethodWrapperKind, StringLiteralType, Type,
-    TypeVarBoundOrConstraints, TypeVarInstance, UnionType, WrapperDescriptorKind,
+    FunctionSignature, InstanceType, IntersectionType, KnownClass, MethodWrapperKind,
+    StringLiteralType, Type, TypeVarBoundOrConstraints, TypeVarInstance, UnionType,
+    WrapperDescriptorKind,
 };
 use crate::Db;
 use rustc_hash::FxHashMap;
+
+use super::CallableType;
 
 impl<'db> Type<'db> {
     pub fn display(&self, db: &'db dyn Db) -> DisplayType {
@@ -95,32 +98,59 @@ impl Display for DisplayRepresentation<'_> {
             Type::KnownInstance(known_instance) => f.write_str(known_instance.repr(self.db)),
             Type::FunctionLiteral(function) => {
                 let signature = function.signature(self.db);
+
                 // TODO: when generic function types are supported, we should add
                 // the generic type parameters to the signature, i.e.
                 // show `def foo[T](x: T) -> T`.
 
-                write!(
-                    f,
-                    // "def {name}{specialization}{signature}",
-                    "def {name}{signature}",
-                    name = function.name(self.db),
-                    signature = signature.display(self.db)
-                )
+                match signature {
+                    FunctionSignature::Single(signature) => {
+                        write!(
+                            f,
+                            // "def {name}{specialization}{signature}",
+                            "def {name}{signature}",
+                            name = function.name(self.db),
+                            signature = signature.display(self.db)
+                        )
+                    }
+                    FunctionSignature::Overloaded(signatures, _) => {
+                        // TODO: How to display overloads?
+                        f.write_str("Overload(")?;
+                        let mut join = f.join(", ");
+                        for signature in signatures {
+                            join.entry(&signature.display(self.db));
+                        }
+                        f.write_str(")")
+                    }
+                }
             }
-            Type::Callable(callable) => callable.signature(self.db).display(self.db).fmt(f),
+            Type::Callable(callable) => callable.display(self.db).fmt(f),
             Type::BoundMethod(bound_method) => {
                 let function = bound_method.function(self.db);
 
                 // TODO: use the specialization from the method. Similar to the comment above
                 // about the function specialization,
 
-                write!(
-                    f,
-                    "bound method {instance}.{method}{signature}",
-                    method = function.name(self.db),
-                    instance = bound_method.self_instance(self.db).display(self.db),
-                    signature = function.signature(self.db).bind_self().display(self.db)
-                )
+                match function.signature(self.db) {
+                    FunctionSignature::Single(signature) => {
+                        write!(
+                            f,
+                            "bound method {instance}.{method}{signature}",
+                            method = function.name(self.db),
+                            instance = bound_method.self_instance(self.db).display(self.db),
+                            signature = signature.bind_self().display(self.db)
+                        )
+                    }
+                    FunctionSignature::Overloaded(signatures, _) => {
+                        // TODO: How to display overloads?
+                        f.write_str("Overload(")?;
+                        let mut join = f.join(", ");
+                        for signature in signatures {
+                            join.entry(&signature.bind_self().display(self.db));
+                        }
+                        f.write_str(")")
+                    }
+                }
             }
             Type::MethodWrapper(MethodWrapperKind::FunctionTypeDunderGet(function)) => {
                 write!(
@@ -355,8 +385,40 @@ impl Display for DisplaySpecialization<'_> {
     }
 }
 
+impl<'db> CallableType<'db> {
+    pub(crate) fn display(&'db self, db: &'db dyn Db) -> DisplayCallableType<'db> {
+        DisplayCallableType {
+            signatures: self.signature(db),
+            db,
+        }
+    }
+}
+
+pub(crate) struct DisplayCallableType<'db> {
+    signatures: &'db [Signature<'db>],
+    db: &'db dyn Db,
+}
+
+impl Display for DisplayCallableType<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self.signatures {
+            [signature] => write!(f, "{}", signature.display(self.db)),
+            signatures => {
+                // TODO: How to display overloads?
+                f.write_char('(')?;
+                let mut join = f.join(", ");
+                for signature in signatures {
+                    join.entry(&signature.display(self.db));
+                }
+                join.finish()?;
+                f.write_char(')')
+            }
+        }
+    }
+}
+
 impl<'db> Signature<'db> {
-    fn display(&'db self, db: &'db dyn Db) -> DisplaySignature<'db> {
+    pub(crate) fn display(&'db self, db: &'db dyn Db) -> DisplaySignature<'db> {
         DisplaySignature {
             parameters: self.parameters(),
             return_ty: self.return_ty,
@@ -365,7 +427,7 @@ impl<'db> Signature<'db> {
     }
 }
 
-struct DisplaySignature<'db> {
+pub(crate) struct DisplaySignature<'db> {
     parameters: &'db Parameters<'db>,
     return_ty: Option<Type<'db>>,
     db: &'db dyn Db,

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -115,12 +115,12 @@ impl Display for DisplayRepresentation<'_> {
                     }
                     FunctionSignature::Overloaded(signatures, _) => {
                         // TODO: How to display overloads?
-                        f.write_str("Overload(")?;
+                        f.write_str("Overload[")?;
                         let mut join = f.join(", ");
                         for signature in signatures {
                             join.entry(&signature.display(self.db));
                         }
-                        f.write_str(")")
+                        f.write_str("]")
                     }
                 }
             }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1496,7 +1496,6 @@ impl<'db> TypeInferenceBuilder<'db> {
             self.db(),
             &name.id,
             function_kind,
-            self.scope(),
             body_scope,
             function_decorators,
             generic_context,

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -895,28 +895,6 @@ impl<'db> TypeInferenceBuilder<'db> {
         }
     }
 
-    // fn check_overloaded_signatures(&self) {
-    //     // Raise diagnostics if
-    //     // 1. number of overloads < 2
-    //     // 2. in a runtime file, the implementation exists except for protocol, abstract methods in
-    //     //    abstract class
-    //     // 3. consistency between the overloads and implementation signature
-    //     let function_definitions = self
-    //         .types
-    //         .declarations
-    //         .iter()
-    //         .filter_map(|(definition, ty)| {
-    //             // Filter out function literals that result from imports
-    //             if let DefinitionKind::Function(function) = definition.kind(self.db()) {
-    //                 ty.inner_type()
-    //                     .into_function_literal()
-    //                     .map(|ty| (ty, function.node()))
-    //             } else {
-    //                 None
-    //             }
-    //         });
-    // }
-
     fn infer_region_definition(&mut self, definition: Definition<'db>) {
         match definition.kind(self.db()) {
             DefinitionKind::Function(function) => {

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -7409,11 +7409,12 @@ impl<'db> TypeInferenceBuilder<'db> {
                     let argument_type = self.infer_expression(arguments_slice);
                     let signatures = argument_type.signatures(db);
 
-                    // This is enforced by the constructor methods on `Signatures`.
+                    // SAFETY: This is enforced by the constructor methods on `Signatures` even in
+                    // the case of a non-callable union.
                     let callable_signature = signatures
                         .iter()
                         .next()
-                        .expect("Signatures to have at least one CallableSignature");
+                        .expect("`Signatures` should have at least one `CallableSignature`");
 
                     let mut signature_iter = callable_signature.iter().map(|signature| {
                         if argument_type.is_bound_method() {

--- a/crates/red_knot_python_semantic/src/types/property_tests/type_generation.rs
+++ b/crates/red_knot_python_semantic/src/types/property_tests/type_generation.rs
@@ -188,7 +188,7 @@ impl Ty {
 
                 create_bound_method(db, function, builtins_class)
             }
-            Ty::Callable { params, returns } => Type::Callable(CallableType::new(
+            Ty::Callable { params, returns } => Type::Callable(CallableType::single(
                 db,
                 Signature::new(
                     params.into_parameters(db),

--- a/crates/red_knot_python_semantic/src/types/signatures.rs
+++ b/crates/red_knot_python_semantic/src/types/signatures.rs
@@ -15,7 +15,7 @@ use std::{collections::HashMap, slice::Iter};
 use itertools::EitherOrBoth;
 use smallvec::{smallvec, SmallVec};
 
-use super::{definition_expression_type, DynamicType, Type};
+use super::{definition_expression_type, CallableType, DynamicType, Type};
 use crate::semantic_index::definition::Definition;
 use crate::types::generics::{GenericContext, Specialization};
 use crate::types::todo_type;
@@ -250,16 +250,6 @@ impl<'db> Signature<'db> {
         }
     }
 
-    /// Return a todo signature: (*args: Todo, **kwargs: Todo) -> Todo
-    #[allow(unused_variables)] // 'reason' only unused in debug builds
-    pub(crate) fn todo(reason: &'static str) -> Self {
-        Signature {
-            generic_context: None,
-            parameters: Parameters::todo(),
-            return_ty: Some(todo_type!(reason)),
-        }
-    }
-
     /// Return a typed signature from a function definition.
     pub(super) fn from_function(
         db: &'db dyn Db,
@@ -286,15 +276,34 @@ impl<'db> Signature<'db> {
         }
     }
 
+    pub(crate) fn to_callable_type(&self, db: &'db dyn Db) -> Type<'db> {
+        Type::Callable(CallableType::single(db, self.clone()))
+    }
+
+    pub(crate) fn normalized(&self, db: &'db dyn Db) -> Self {
+        Self {
+            generic_context: self.generic_context,
+            parameters: self
+                .parameters
+                .iter()
+                .map(|param| param.normalized(db))
+                .collect(),
+            return_ty: self.return_ty.map(|return_ty| return_ty.normalized(db)),
+        }
+    }
+
     pub(crate) fn apply_specialization(
-        &mut self,
+        &self,
         db: &'db dyn Db,
         specialization: Specialization<'db>,
-    ) {
-        self.parameters.apply_specialization(db, specialization);
-        self.return_ty = self
-            .return_ty
-            .map(|ty| ty.apply_specialization(db, specialization));
+    ) -> Self {
+        Self {
+            generic_context: self.generic_context,
+            parameters: self.parameters.apply_specialization(db, specialization),
+            return_ty: self
+                .return_ty
+                .map(|ty| ty.apply_specialization(db, specialization)),
+        }
     }
 
     /// Return the parameters in this signature.
@@ -995,10 +1004,15 @@ impl<'db> Parameters<'db> {
         )
     }
 
-    fn apply_specialization(&mut self, db: &'db dyn Db, specialization: Specialization<'db>) {
-        self.value
-            .iter_mut()
-            .for_each(|param| param.apply_specialization(db, specialization));
+    fn apply_specialization(&self, db: &'db dyn Db, specialization: Specialization<'db>) -> Self {
+        Self {
+            value: self
+                .value
+                .iter()
+                .map(|param| param.apply_specialization(db, specialization))
+                .collect(),
+            is_gradual: self.is_gradual,
+        }
     }
 
     pub(crate) fn len(&self) -> usize {
@@ -1162,11 +1176,14 @@ impl<'db> Parameter<'db> {
         self
     }
 
-    fn apply_specialization(&mut self, db: &'db dyn Db, specialization: Specialization<'db>) {
-        self.annotated_type = self
-            .annotated_type
-            .map(|ty| ty.apply_specialization(db, specialization));
-        self.kind.apply_specialization(db, specialization);
+    fn apply_specialization(&self, db: &'db dyn Db, specialization: Specialization<'db>) -> Self {
+        Self {
+            annotated_type: self
+                .annotated_type
+                .map(|ty| ty.apply_specialization(db, specialization)),
+            kind: self.kind.apply_specialization(db, specialization),
+            form: self.form,
+        }
     }
 
     /// Strip information from the parameter so that two equivalent parameters compare equal.
@@ -1356,14 +1373,27 @@ pub(crate) enum ParameterKind<'db> {
 }
 
 impl<'db> ParameterKind<'db> {
-    fn apply_specialization(&mut self, db: &'db dyn Db, specialization: Specialization<'db>) {
+    fn apply_specialization(&self, db: &'db dyn Db, specialization: Specialization<'db>) -> Self {
         match self {
-            Self::PositionalOnly { default_type, .. }
-            | Self::PositionalOrKeyword { default_type, .. }
-            | Self::KeywordOnly { default_type, .. } => {
-                *default_type = default_type.map(|ty| ty.apply_specialization(db, specialization));
-            }
-            Self::Variadic { .. } | Self::KeywordVariadic { .. } => {}
+            Self::PositionalOnly { default_type, name } => Self::PositionalOnly {
+                default_type: default_type
+                    .as_ref()
+                    .map(|ty| ty.apply_specialization(db, specialization)),
+                name: name.clone(),
+            },
+            Self::PositionalOrKeyword { default_type, name } => Self::PositionalOrKeyword {
+                default_type: default_type
+                    .as_ref()
+                    .map(|ty| ty.apply_specialization(db, specialization)),
+                name: name.clone(),
+            },
+            Self::KeywordOnly { default_type, name } => Self::KeywordOnly {
+                default_type: default_type
+                    .as_ref()
+                    .map(|ty| ty.apply_specialization(db, specialization)),
+                name: name.clone(),
+            },
+            Self::Variadic { .. } | Self::KeywordVariadic { .. } => self.clone(),
         }
     }
 }
@@ -1380,7 +1410,7 @@ mod tests {
     use super::*;
     use crate::db::tests::{setup_db, TestDb};
     use crate::symbol::global_symbol;
-    use crate::types::{FunctionType, KnownClass};
+    use crate::types::{FunctionSignature, FunctionType, KnownClass};
     use ruff_db::system::DbWithWritableSystem as _;
 
     #[track_caller]
@@ -1627,6 +1657,9 @@ mod tests {
         let expected_sig = func.internal_signature(&db);
 
         // With no decorators, internal and external signature are the same
-        assert_eq!(func.signature(&db), &expected_sig);
+        assert_eq!(
+            func.signature(&db),
+            &FunctionSignature::Single(expected_sig)
+        );
     }
 }

--- a/crates/red_knot_python_semantic/src/types/signatures.rs
+++ b/crates/red_knot_python_semantic/src/types/signatures.rs
@@ -15,7 +15,7 @@ use std::{collections::HashMap, slice::Iter};
 use itertools::EitherOrBoth;
 use smallvec::{smallvec, SmallVec};
 
-use super::{definition_expression_type, CallableType, DynamicType, Type};
+use super::{definition_expression_type, DynamicType, Type};
 use crate::semantic_index::definition::Definition;
 use crate::types::generics::{GenericContext, Specialization};
 use crate::types::todo_type;
@@ -274,10 +274,6 @@ impl<'db> Signature<'db> {
             ),
             return_ty,
         }
-    }
-
-    pub(crate) fn to_callable_type(&self, db: &'db dyn Db) -> Type<'db> {
-        Type::Callable(CallableType::single(db, self.clone()))
     }
 
     pub(crate) fn normalized(&self, db: &'db dyn Db) -> Self {


### PR DESCRIPTION
## Summary

Part of #15383, this PR adds support for overloaded callables.

Typing spec: https://typing.python.org/en/latest/spec/overload.html

Specifically, it does the following:
1. Update the `FunctionType::signature` method to return signatures from a possibly overloaded callable using a new `FunctionSignature` enum
2. Update `CallableType` to accommodate overloaded callable by updating the inner type to `Box<[Signature]>`
3. Update the relation methods on `CallableType` with logic specific to overloads
4. Update the display of callable type to display a list of signatures enclosed by parenthesis
5. Update `CallableTypeOf` special form to recognize overloaded callable
6. Update subtyping, assignability and fully static check to account for callables (equivalence is planned to be done as a follow-up)

For (2), it is required to be done in this PR because otherwise I'd need to add some workaround for `into_callable_type` and I though it would be best to include it in here.

For (2), another possible design would be convert `CallableType` in an enum with two variants `CallableType::Single` and `CallableType::Overload` but I decided to go with `Box<[Signature]>` for now to (a) mirror it to be equivalent to `overload` field on `CallableSignature` and (b) to avoid any refactor in this PR. This could be done in a follow-up to better split the two kind of callables.

### Design

There were two main candidates on how to represent the overloaded definition:
1. To include it in the existing infrastructure which is what this PR is doing by recognizing all the signatures within the `FunctionType::signature` method
2. To create a new `Overload` type variant

<details><summary>For context, this is what I had in mind with the new type variant:</summary>
<p>

```rs
pub enum Type {
	FunctionLiteral(FunctionType),
    Overload(OverloadType),
    BoundMethod(BoundMethodType),
    ...
}

pub struct OverloadType {
	// FunctionLiteral or BoundMethod
    overloads: Box<[Type]>,
	// FunctionLiteral or BoundMethod
    implementation: Option<Type>
}

pub struct BoundMethodType {
    kind: BoundMethodKind,
    self_instance: Type,
}

pub enum BoundMethodKind {
    Function(FunctionType),
    Overload(OverloadType),
}
```

</p>
</details> 

The main reasons to choose (1) are the simplicity in the implementation, reusing the existing infrastructure, avoiding any complications that the new type variant has specifically around the different variants between function and methods which would require the overload type to use `Type` instead.

### Implementation

The core logic is how to collect all the overloaded functions. The way this is done in this PR is by recording a **use** on the `Identifier` node that represents the function name in the use-def map. This is then used to fetch the previous symbol using the same name. This way the signatures are going to be propagated from top to bottom (from first overload to the final overload or the implementation) with each function / method. For example:

```py
from typing import overload

@overload
def foo(x: int) -> int: ...
@overload
def foo(x: str) -> str: ...
def foo(x: int | str) -> int | str:
	return x
```

Here, each definition of `foo` knows about all the signatures that comes before itself. So, the first overload would only see itself, the second would see the first and itself and so on until the implementation or the final overload.

This approach required some updates specifically recognizing `Identifier` node to record the function use because it doesn't use `ExprName`.

## Test Plan

Update existing test cases which were limited by the overload support and add test cases for the following cases:
* Valid overloads as functions, methods, generics, version specific
* Invalid overloads as stated in https://typing.python.org/en/latest/spec/overload.html#invalid-overload-definitions (implementation will be done in a follow-up)
* Various relation: fully static, subtyping, and assignability (others in a follow-up)

## Ecosystem changes

_WIP_

After going through the ecosystem changes (there are a lot!), here's what I've found:

We need assignability check between a callable type and a class literal because a lot of builtins are defined as classes in typeshed whose constructor method is overloaded e.g., `map`, `sorted`, `list.sort`, `max`, `min` with the `key` parameter, `collections.abc.defaultdict`, etc. (https://github.com/astral-sh/ruff/issues/17343). This makes up most of the ecosystem diff **roughly 70 diagnostics**. For example:

```py
from collections import defaultdict

# red-knot: No overload of bound method `__init__` matches arguments [lint:no-matching-overload]
defaultdict(int)
# red-knot: No overload of bound method `__init__` matches arguments [lint:no-matching-overload]
defaultdict(list)

class Foo:
    def __init__(self, x: int):
        self.x = x

# red-knot: No overload of function `__new__` matches arguments [lint:no-matching-overload]
map(Foo, ["a", "b", "c"])
```

Duplicate diagnostics in unpacking (https://github.com/astral-sh/ruff/issues/16514) has **~16 diagnostics**.

Support for the `callable` builtin which requires `TypeIs` support. This is **5 diagnostics**. For example:
```py
from typing import Any

def _(x: Any | None) -> None:
    if callable(x):
        # red-knot: `Any | None`
        # Pyright: `(...) -> object`
        # mypy: `Any`
        # pyrefly: `(...) -> object`
        reveal_type(x)
```

Narrowing on `assert` which has **11 diagnostics**. This is being worked on in https://github.com/astral-sh/ruff/pull/17345. For example:
```py
import re

match = re.search("", "")
assert match
match.group()  # error: [possibly-unbound-attribute]
```

Others:
* `Self`: 2
* Type aliases: 6
* Generics: 3
* Protocols: 13
* Unpacking in comprehension: 1 (https://github.com/astral-sh/ruff/pull/17396)

## Performance

Refer to https://github.com/astral-sh/ruff/pull/17366#issuecomment-2814053046.