### PR TITLE
[red-knot] Use concise message for the server

### DIFF
--- a/crates/red_knot_server/src/server/api/requests/diagnostic.rs
+++ b/crates/red_knot_server/src/server/api/requests/diagnostic.rs
@@ -99,7 +99,7 @@ fn to_lsp_diagnostic(
         code: Some(NumberOrString::String(diagnostic.id().to_string())),
         code_description: None,
         source: Some("red-knot".into()),
-        message: diagnostic.primary_message().to_string(),
+        message: diagnostic.concise_message().to_string(),
         related_information: None,
         data: None,
     }


### PR DESCRIPTION
## Summary

This is mainly a follow-up from https://github.com/astral-sh/ruff/pull/17357 to use the `concise_message` method for the red-knot server which I noticed recently while testing the overload implementation.
