### PR TITLE
[red-knot] Further optimize `*`-import visibility constraints

### DIFF
--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -1235,32 +1235,21 @@ where
                                 symbol_id,
                                 referenced_module,
                             );
-                            let pre_definition = self.flow_snapshot();
-                            self.push_additional_definition(symbol_id, node_ref);
 
                             // Fast path for if there were no previous definitions
                             // of the symbol defined through the `*` import:
                             // we can apply the visibility constraint to *only* the added definition,
                             // rather than all definitions
                             if newly_added {
-                                let constraint_id = self
-                                    .current_use_def_map_mut()
-                                    .record_star_import_visibility_constraint(
+                                self.push_additional_definition(symbol_id, node_ref);
+                                self.current_use_def_map_mut()
+                                    .record_and_negate_star_import_visibility_constraint(
                                         star_import,
                                         symbol_id,
                                     );
-
-                                let post_definition = self.flow_snapshot();
-                                self.flow_restore(pre_definition);
-
-                                self.current_use_def_map_mut()
-                                    .negate_star_import_visibility_constraint(
-                                        symbol_id,
-                                        constraint_id,
-                                    );
-
-                                self.flow_merge(post_definition);
                             } else {
+                                let pre_definition = self.flow_snapshot();
+                                self.push_additional_definition(symbol_id, node_ref);
                                 let constraint_id =
                                     self.record_visibility_constraint(star_import.into());
                                 let post_definition = self.flow_snapshot();


### PR DESCRIPTION
## Summary

Fixes #17322. Remove any need for snapshotting when applying visibility constraints to `*` imports. This also ends up simplifying the code!

## Test Plan

Existing tests all pass. I'd appreciate a careful review, though. Is it definitely safe to remove these calls, as I am doing currently in the PR?

E.g. the `UseDefMapBuilder::negate_star_import_visibility_constraint` method on `main` has this call:

```rs
        self.scope_start_visibility = self
            .visibility_constraints
            .add_and_constraint(self.scope_start_visibility, negated_constraint);
```

and `UseDefMapBuilder::merge` has this call:

```rs
        self.scope_start_visibility = self
            .visibility_constraints
            .add_or_constraint(self.scope_start_visibility, snapshot.scope_start_visibility);
```

Both calls are currently removed in this PR for the "fast path" for newly added `*`-import definitions, since `UseDefMapBuilder::negate_star_import_visibility_constraint` is removed as part of this PR, and `UseDefMapBuilder::merge` is no longer called in the fast path. If it's _not_ safe to remove these calls from the fast path, is there a test I could add that passes on `main`, but fails with them removed?
