### PR TITLE
dependencies: switch from `chrono` to `jiff`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1558,10 +1558,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d699bc6dfc879fb1bf9bdff0d4c56f0884fc6f0d0eb0fba397a6d00cd9a6b85e"
 dependencies = [
  "jiff-static",
+ "jiff-tzdb-platform",
  "log",
  "portable-atomic",
  "portable-atomic-util",
  "serde",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1573,6 +1575,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1283705eb0a21404d2bfd6eef2a7593d240bc42a0bdb39db0ad6fa2ec026524"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
 ]
 
 [[package]]
@@ -2476,7 +2493,6 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "argfile",
- "chrono",
  "clap",
  "colored 3.0.0",
  "countme",
@@ -2485,6 +2501,7 @@ dependencies = [
  "filetime",
  "insta",
  "insta-cmd",
+ "jiff",
  "rayon",
  "red_knot_project",
  "red_knot_python_semantic",
@@ -2764,7 +2781,6 @@ dependencies = [
  "bincode",
  "bitflags 2.9.0",
  "cachedir",
- "chrono",
  "clap",
  "clap_complete_command",
  "clearscreen",
@@ -2777,6 +2793,7 @@ dependencies = [
  "insta-cmd",
  "is-macro",
  "itertools 0.14.0",
+ "jiff",
  "log",
  "mimalloc",
  "notify",
@@ -2996,7 +3013,6 @@ dependencies = [
  "aho-corasick",
  "anyhow",
  "bitflags 2.9.0",
- "chrono",
  "clap",
  "colored 3.0.0",
  "fern",
@@ -3007,6 +3023,7 @@ dependencies = [
  "is-macro",
  "is-wsl",
  "itertools 0.14.0",
+ "jiff",
  "libcst",
  "log",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,6 @@ bitflags = { version = "2.5.0" }
 bstr = { version = "1.9.1" }
 cachedir = { version = "0.3.1" }
 camino = { version = "1.1.7" }
-chrono = { version = "0.4.35", default-features = false, features = ["clock"] }
 clap = { version = "4.5.3", features = ["derive"] }
 clap_complete_command = { version = "0.6.0" }
 clearscreen = { version = "4.0.0" }
@@ -95,6 +94,7 @@ insta-cmd = { version = "0.6.0" }
 is-macro = { version = "0.3.5" }
 is-wsl = { version = "0.4.0" }
 itertools = { version = "0.14.0" }
+jiff = { version = "0.2.0" }
 js-sys = { version = "0.3.69" }
 jod-thread = { version = "0.1.2" }
 libc = { version = "0.2.153" }

--- a/crates/red_knot/Cargo.toml
+++ b/crates/red_knot/Cargo.toml
@@ -20,12 +20,12 @@ ruff_python_ast = { workspace = true }
 
 anyhow = { workspace = true }
 argfile = { workspace = true }
-chrono = { workspace = true }
 clap = { workspace = true, features = ["wrap_help"] }
 colored = { workspace = true }
 countme = { workspace = true, features = ["enable"] }
 crossbeam = { workspace = true }
 ctrlc = { version = "3.4.4" }
+jiff = { workspace = true }
 rayon = { workspace = true }
 salsa = { workspace = true }
 tracing = { workspace = true, features = ["release_max_level_debug"] }

--- a/crates/red_knot/src/logging.rs
+++ b/crates/red_knot/src/logging.rs
@@ -190,8 +190,8 @@ where
         let ansi = writer.has_ansi_escapes();
 
         if self.display_timestamp {
-            let timestamp = chrono::Local::now()
-                .format("%Y-%m-%d %H:%M:%S.%f")
+            let timestamp = jiff::Zoned::now()
+                .strftime("%Y-%m-%d %H:%M:%S.%f")
                 .to_string();
             if ansi {
                 write!(writer, "{} ", timestamp.dimmed())?;
@@ -199,7 +199,7 @@ where
                 write!(
                     writer,
                     "{} ",
-                    chrono::Local::now().format("%Y-%m-%d %H:%M:%S.%f")
+                    jiff::Zoned::now().strftime("%Y-%m-%d %H:%M:%S.%f")
                 )?;
             }
         }

--- a/crates/ruff/Cargo.toml
+++ b/crates/ruff/Cargo.toml
@@ -33,7 +33,6 @@ argfile = { workspace = true }
 bincode = { workspace = true }
 bitflags = { workspace = true }
 cachedir = { workspace = true }
-chrono = { workspace = true }
 clap = { workspace = true, features = ["derive", "env", "wrap_help"] }
 clap_complete_command = { workspace = true }
 clearscreen = { workspace = true }
@@ -43,6 +42,7 @@ globwalk = { workspace = true }
 ignore = { workspace = true }
 is-macro = { workspace = true }
 itertools = { workspace = true }
+jiff = { workspace = true }
 log = { workspace = true }
 notify = { workspace = true }
 path-absolutize = { workspace = true, features = ["once_cell_cache"] }
@@ -75,7 +75,7 @@ test-case = { workspace = true }
 
 [package.metadata.cargo-shear]
 # Used via macro expansion.
-ignored = ["chrono"]
+ignored = ["jiff"]
 
 [target.'cfg(target_os = "windows")'.dependencies]
 mimalloc = { workspace = true }

--- a/crates/ruff_linter/Cargo.toml
+++ b/crates/ruff_linter/Cargo.toml
@@ -32,7 +32,6 @@ ruff_text_size = { workspace = true }
 aho-corasick = { workspace = true }
 anyhow = { workspace = true }
 bitflags = { workspace = true }
-chrono = { workspace = true }
 clap = { workspace = true, features = ["derive", "string"], optional = true }
 colored = { workspace = true }
 fern = { workspace = true }
@@ -43,6 +42,7 @@ is-macro = { workspace = true }
 is-wsl = { workspace = true }
 itertools = { workspace = true }
 libcst = { workspace = true }
+jiff = { workspace = true }
 log = { workspace = true }
 memchr = { workspace = true }
 natord = { workspace = true }

--- a/crates/ruff_linter/src/logging.rs
+++ b/crates/ruff_linter/src/logging.rs
@@ -85,8 +85,8 @@ macro_rules! notify_user {
     ($($arg:tt)*) => {
         println!(
             "[{}] {}",
-            chrono::Local::now()
-                .format("%H:%M:%S %p")
+            jiff::Zoned::now()
+                .strftime("%H:%M:%S %p")
                 .to_string()
                 .dimmed(),
             format_args!($($arg)*)
@@ -142,7 +142,7 @@ pub fn set_up_logging(level: LogLevel) -> Result<()> {
             Level::Info | Level::Debug | Level::Trace => {
                 out.finish(format_args!(
                     "{}[{}][{}] {}",
-                    chrono::Local::now().format("[%Y-%m-%d][%H:%M:%S]"),
+                    jiff::Zoned::now().strftime("[%Y-%m-%d][%H:%M:%S]"),
                     record.target(),
                     record.level(),
                     message


### PR DESCRIPTION
We weren't really using `chrono` for anything other than getting the
current time and formatting it for logs. So the switch to Jiff here
is pretty uninteresting.

Unfortunately, this doesn't quite get us to a point where `chrono`
can be removed. From what I can tell, we're still bringing it via
[`tracing-subscriber`](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/)
and
[`quick-junit`](https://docs.rs/quick-junit/latest/quick_junit/).
`tracing-subscriber` does have an
[issue open about Jiff](https://github.com/tokio-rs/tracing/discussions/3128),
but there's no movement on it.

Normally I'd suggest holding off on this since it doesn't get us all of
the way there and it would be better to avoid bringing in two datetime
libraries, but we are, it appears, already there. In particular,
`env_logger` brings in Jiff. So this PR doesn't really make anything
worse, but it does bring us closer to an all-Jiff world.
