### PR TITLE
[red-knot] mypy_primer: Fail job on panic or internal errors

### DIFF
--- a/.github/workflows/mypy_primer.yaml
+++ b/.github/workflows/mypy_primer.yaml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Install mypy_primer
         run: |
-          uv tool install "git+https://github.com/astral-sh/mypy_primer.git@add-red-knot-support-v4"
+          uv tool install "git+https://github.com/astral-sh/mypy_primer.git@add-red-knot-support-v5"
 
       - name: Run mypy_primer
         shell: bash


### PR DESCRIPTION
## Summary

Let the mypy_primer job fail if Red Knot panics or exits with code 2 (indicating an internal error).

Corresponding mypy_primer commit: https://github.com/astral-sh/mypy_primer/commit/90808f4656fa45106b65ad80afe70db0713e26b7

In addition, we may also want to make a successful mypy_primer run required for merging?

## Test Plan

Made sure that mypy_primer exits with code 70 locally on panics, which should result in a pipeline failure, since we only allow code 0 and 1 in the pipeline here: https://github.com/astral-sh/ruff/blob/a4d7c6669bb356eb40e6e7069b11dffbfc27f483/.github/workflows/mypy_primer.yaml#L73