### PR TITLE
[red-knot] infer attribute assignments bound in comprehensions

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/attributes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/attributes.md
@@ -397,15 +397,27 @@ class IntIterable:
     def __iter__(self) -> IntIterator:
         return IntIterator()
 
+class TupleIterator:
+    def __next__(self) -> tuple[int, str]:
+        return (1, "a")
+
+class TupleIterable:
+    def __iter__(self) -> TupleIterator:
+        return TupleIterator()
+
 class C:
     def __init__(self) -> None:
         [... for self.a in IntIterable()]
+        [... for (self.b, self.c) in TupleIterable()]
+        [... for self.d in IntIterable() for self.e in IntIterable()]
 
 c_instance = C()
 
-# TODO: Should be `Unknown | int`
-# error: [unresolved-attribute]
-reveal_type(c_instance.a)  # revealed: Unknown
+reveal_type(c_instance.a)  # revealed: Unknown | int
+reveal_type(c_instance.b)  # revealed: Unknown | int
+reveal_type(c_instance.c)  # revealed: Unknown | str
+reveal_type(c_instance.d)  # revealed: Unknown | int
+reveal_type(c_instance.e)  # revealed: Unknown | int
 ```
 
 #### Conditionally declared / bound attributes

--- a/crates/red_knot_python_semantic/resources/mdtest/comprehensions/basic.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/comprehensions/basic.md
@@ -47,6 +47,23 @@ class IntIterable:
 [[reveal_type((x, y)) for x in IntIterable()] for y in IntIterable()]
 ```
 
+## Unpacking in comprehension
+
+```py
+class TupleIterator:
+    def __next__(self) -> tuple[int, int]:
+        return (42, 42)
+
+class TupleIterable:
+    def __iter__(self) -> TupleIterator:
+        return TupleIterator()
+
+# revealed: tuple[int, int]
+[(reveal_type((x, y)) for x, y in TupleIterable())]
+# revealed: tuple[int, int]
+[(reveal_type((x, y)) for [x, y] in TupleIterable())]
+```
+
 ## Comprehension referencing outer comprehension
 
 ```py

--- a/crates/red_knot_python_semantic/resources/mdtest/comprehensions/basic.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/comprehensions/basic.md
@@ -47,23 +47,6 @@ class IntIterable:
 [[reveal_type((x, y)) for x in IntIterable()] for y in IntIterable()]
 ```
 
-## Unpacking in comprehension
-
-```py
-class TupleIterator:
-    def __next__(self) -> tuple[int, int]:
-        return (42, 42)
-
-class TupleIterable:
-    def __iter__(self) -> TupleIterator:
-        return TupleIterator()
-
-# revealed: tuple[int, int]
-[(reveal_type((x, y)) for x, y in TupleIterable())]
-# revealed: tuple[int, int]
-[(reveal_type((x, y)) for [x, y] in TupleIterable())]
-```
-
 ## Comprehension referencing outer comprehension
 
 ```py

--- a/crates/red_knot_python_semantic/src/semantic_index.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index.rs
@@ -937,7 +937,7 @@ def f(a: str, /, b: str, c: int = 1, *args, d: int = 2, **kwargs):
             panic!("expected generator definition")
         };
         let target = comprehension.target();
-        let name = target.id().as_str();
+        let name = target.as_name_expr().unwrap().id().as_str();
 
         assert_eq!(name, "x");
         assert_eq!(target.range(), TextRange::new(23.into(), 24.into()));

--- a/crates/red_knot_python_semantic/src/semantic_index/definition.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/definition.rs
@@ -755,30 +755,14 @@ impl MatchPatternDefinitionKind {
 
 #[derive(Clone, Debug)]
 pub struct ComprehensionDefinitionKind<'db> {
-    target_kind: TargetKind<'db>,
-    iterable: AstNodeRef<ast::Expr>,
-    target: AstNodeRef<ast::Expr>,
-    first: bool,
-    is_async: bool,
+    pub(super) target_kind: TargetKind<'db>,
+    pub(super) iterable: AstNodeRef<ast::Expr>,
+    pub(super) target: AstNodeRef<ast::Expr>,
+    pub(super) first: bool,
+    pub(super) is_async: bool,
 }
 
 impl<'db> ComprehensionDefinitionKind<'db> {
-    pub(crate) fn new(
-        target_kind: TargetKind<'db>,
-        iterable: AstNodeRef<ast::Expr>,
-        target: AstNodeRef<ast::Expr>,
-        is_first: bool,
-        is_async: bool,
-    ) -> Self {
-        Self {
-            target_kind,
-            iterable,
-            target,
-            first: is_first,
-            is_async,
-        }
-    }
-
     pub(crate) fn iterable(&self) -> &ast::Expr {
         self.iterable.node()
     }

--- a/crates/red_knot_python_semantic/src/semantic_index/definition.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/definition.rs
@@ -281,8 +281,9 @@ pub(crate) struct ExceptHandlerDefinitionNodeRef<'a> {
 
 #[derive(Copy, Clone, Debug)]
 pub(crate) struct ComprehensionDefinitionNodeRef<'a> {
+    pub(crate) unpack: Option<(UnpackPosition, Unpack<'a>)>,
     pub(crate) iterable: &'a ast::Expr,
-    pub(crate) target: &'a ast::ExprName,
+    pub(crate) target: &'a ast::Expr,
     pub(crate) first: bool,
     pub(crate) is_async: bool,
 }
@@ -374,11 +375,13 @@ impl<'db> DefinitionNodeRef<'db> {
                 is_async,
             }),
             DefinitionNodeRef::Comprehension(ComprehensionDefinitionNodeRef {
+                unpack,
                 iterable,
                 target,
                 first,
                 is_async,
             }) => DefinitionKind::Comprehension(ComprehensionDefinitionKind {
+                target_kind: TargetKind::from(unpack),
                 iterable: AstNodeRef::new(parsed.clone(), iterable),
                 target: AstNodeRef::new(parsed, target),
                 first,
@@ -474,7 +477,9 @@ impl<'db> DefinitionNodeRef<'db> {
                 unpack: _,
                 is_async: _,
             }) => DefinitionNodeKey(NodeKey::from_node(target)),
-            Self::Comprehension(ComprehensionDefinitionNodeRef { target, .. }) => target.into(),
+            Self::Comprehension(ComprehensionDefinitionNodeRef { target, .. }) => {
+                DefinitionNodeKey(NodeKey::from_node(target))
+            }
             Self::VariadicPositionalParameter(node) => node.into(),
             Self::VariadicKeywordParameter(node) => node.into(),
             Self::Parameter(node) => node.into(),
@@ -550,7 +555,7 @@ pub enum DefinitionKind<'db> {
     AnnotatedAssignment(AnnotatedAssignmentDefinitionKind),
     AugmentedAssignment(AstNodeRef<ast::StmtAugAssign>),
     For(ForStmtDefinitionKind<'db>),
-    Comprehension(ComprehensionDefinitionKind),
+    Comprehension(ComprehensionDefinitionKind<'db>),
     VariadicPositionalParameter(AstNodeRef<ast::Parameter>),
     VariadicKeywordParameter(AstNodeRef<ast::Parameter>),
     Parameter(AstNodeRef<ast::ParameterWithDefault>),
@@ -749,19 +754,40 @@ impl MatchPatternDefinitionKind {
 }
 
 #[derive(Clone, Debug)]
-pub struct ComprehensionDefinitionKind {
+pub struct ComprehensionDefinitionKind<'db> {
+    target_kind: TargetKind<'db>,
     iterable: AstNodeRef<ast::Expr>,
-    target: AstNodeRef<ast::ExprName>,
+    target: AstNodeRef<ast::Expr>,
     first: bool,
     is_async: bool,
 }
 
-impl ComprehensionDefinitionKind {
+impl<'db> ComprehensionDefinitionKind<'db> {
+    pub(crate) fn new(
+        target_kind: TargetKind<'db>,
+        iterable: AstNodeRef<ast::Expr>,
+        target: AstNodeRef<ast::Expr>,
+        is_first: bool,
+        is_async: bool,
+    ) -> Self {
+        Self {
+            target_kind,
+            iterable,
+            target,
+            first: is_first,
+            is_async,
+        }
+    }
+
     pub(crate) fn iterable(&self) -> &ast::Expr {
         self.iterable.node()
     }
 
-    pub(crate) fn target(&self) -> &ast::ExprName {
+    pub(crate) fn target_kind(&self) -> TargetKind<'db> {
+        self.target_kind
+    }
+
+    pub(crate) fn target(&self) -> &ast::Expr {
         self.target.node()
     }
 

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -3906,13 +3906,9 @@ impl<'db> TypeInferenceBuilder<'db> {
             ast::Expr::Name(name) => {
                 self.infer_definition(name);
             }
-            ast::Expr::Tuple(tuple) => {
-                for elt in &tuple.elts {
-                    self.infer_comprehension_target(elt);
-                }
-            }
-            ast::Expr::List(list) => {
-                for elt in &list.elts {
+            ast::Expr::Tuple(ast::ExprTuple { elts, .. })
+            | ast::Expr::List(ast::ExprList { elts, .. }) => {
+                for elt in elts {
                     self.infer_comprehension_target(elt);
                 }
             }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -3894,27 +3894,9 @@ impl<'db> TypeInferenceBuilder<'db> {
         if !is_first {
             self.infer_standalone_expression(iter);
         }
-        self.infer_comprehension_target(target);
+        self.infer_target_impl(target, None);
         for expr in ifs {
             self.infer_expression(expr);
-        }
-    }
-
-    // TODO: support attribute, subscription
-    fn infer_comprehension_target(&mut self, target: &ast::Expr) {
-        match target {
-            ast::Expr::Name(name) => {
-                self.infer_definition(name);
-            }
-            ast::Expr::Tuple(ast::ExprTuple { elts, .. })
-            | ast::Expr::List(ast::ExprList { elts, .. }) => {
-                for elt in elts {
-                    self.infer_comprehension_target(elt);
-                }
-            }
-            _ => {
-                self.infer_expression(target);
-            }
         }
     }
 

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -304,7 +304,7 @@ pub(super) fn infer_unpack_types<'db>(db: &'db dyn Db, unpack: Unpack<'db>) -> U
     let _span =
         tracing::trace_span!("infer_unpack_types", range=?unpack.range(db), ?file).entered();
 
-    let mut unpacker = Unpacker::new(db, unpack.scope(db));
+    let mut unpacker = Unpacker::new(db, unpack.target_scope(db), unpack.value_scope(db));
     unpacker.unpack(unpack.target(db), unpack.value(db));
     unpacker.finish()
 }
@@ -3914,7 +3914,7 @@ impl<'db> TypeInferenceBuilder<'db> {
     fn infer_comprehension_definition(
         &mut self,
         iterable: &ast::Expr,
-        target: &ast::ExprName,
+        target: &ast::Expr,
         is_first: bool,
         is_async: bool,
         definition: Definition<'db>,

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1899,11 +1899,13 @@ impl<'db> TypeInferenceBuilder<'db> {
         for item in items {
             let target = item.optional_vars.as_deref();
             if let Some(target) = target {
-                self.infer_target(target, &item.context_expr, |db, ctx_manager_ty| {
+                self.infer_target(target, &item.context_expr, |builder, context_expr| {
                     // TODO: `infer_with_statement_definition` reports a diagnostic if `ctx_manager_ty` isn't a context manager
                     //  but only if the target is a name. We should report a diagnostic here if the target isn't a name:
                     //  `with not_context_manager as a.x: ...
-                    ctx_manager_ty.enter(db)
+                    builder
+                        .infer_standalone_expression(context_expr)
+                        .enter(builder.db())
                 });
             } else {
                 // Call into the context expression inference to validate that it evaluates
@@ -2309,7 +2311,9 @@ impl<'db> TypeInferenceBuilder<'db> {
         } = assignment;
 
         for target in targets {
-            self.infer_target(target, value, |_, ty| ty);
+            self.infer_target(target, value, |builder, value_expr| {
+                builder.infer_standalone_expression(value_expr)
+            });
         }
     }
 
@@ -2319,30 +2323,16 @@ impl<'db> TypeInferenceBuilder<'db> {
     /// targets (unpacking). If `target` is an attribute expression, we check that the assignment
     /// is valid. For 'target's that are definitions, this check happens elsewhere.
     ///
-    /// The `to_assigned_ty` function is used to convert the inferred type of the `value` expression
-    /// to the type that is eventually assigned to the `target`.
-    ///
-    /// # Panics
-    ///
-    /// If the `value` is not a standalone expression.
-    fn infer_target<F>(&mut self, target: &ast::Expr, value: &ast::Expr, to_assigned_ty: F)
+    /// The `infer_value_expr` function is used to infer the type of the `value` expression which
+    /// are not `Name` expressions. The returned type is the one that is eventually assigned to the
+    /// `target`.
+    fn infer_target<F>(&mut self, target: &ast::Expr, value: &ast::Expr, infer_value_expr: F)
     where
-        F: Fn(&'db dyn Db, Type<'db>) -> Type<'db>,
+        F: Fn(&mut TypeInferenceBuilder<'db>, &ast::Expr) -> Type<'db>,
     {
         let assigned_ty = match target {
             ast::Expr::Name(_) => None,
-            _ => {
-                // The scope of the comprehension and the value (= iter) are different.
-                let value_ty =
-                    if self.types.scope.scope(self.db()).kind() == ScopeKind::Comprehension {
-                        let standalone_expression = self.index.expression(value);
-                        infer_same_file_expression_type(self.db(), standalone_expression)
-                    } else {
-                        self.infer_standalone_expression(value)
-                    };
-
-                Some(to_assigned_ty(self.db(), value_ty))
-            }
+            _ => Some(infer_value_expr(self, value)),
         };
         self.infer_target_impl(target, assigned_ty);
     }
@@ -3065,11 +3055,13 @@ impl<'db> TypeInferenceBuilder<'db> {
             is_async: _,
         } = for_statement;
 
-        self.infer_target(target, iter, |db, iter_ty| {
+        self.infer_target(target, iter, |builder, iter_expr| {
             // TODO: `infer_for_statement_definition` reports a diagnostic if `iter_ty` isn't iterable
             //  but only if the target is a name. We should report a diagnostic here if the target isn't a name:
             //  `for a.x in not_iterable: ...
-            iter_ty.iterate(db)
+            builder
+                .infer_standalone_expression(iter_expr)
+                .iterate(builder.db())
         });
 
         self.infer_body(body);
@@ -3898,14 +3890,16 @@ impl<'db> TypeInferenceBuilder<'db> {
             is_async: _,
         } = comprehension;
 
-        if !is_first {
-            self.infer_standalone_expression(iter);
-        }
-        self.infer_target(target, iter, |db, iter_ty| {
+        self.infer_target(target, iter, |builder, iter_expr| {
             // TODO: `infer_comprehension_definition` reports a diagnostic if `iter_ty` isn't iterable
             //  but only if the target is a name. We should report a diagnostic here if the target isn't a name:
             //  `[... for a.x in not_iterable]
-            iter_ty.iterate(db)
+            if is_first {
+                infer_same_file_expression_type(builder.db(), builder.index.expression(iter_expr))
+            } else {
+                builder.infer_standalone_expression(iter_expr)
+            }
+            .iterate(builder.db())
         });
         for expr in ifs {
             self.infer_expression(expr);

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -3894,14 +3894,31 @@ impl<'db> TypeInferenceBuilder<'db> {
         if !is_first {
             self.infer_standalone_expression(iter);
         }
-        // TODO more complex assignment targets
-        if let ast::Expr::Name(name) = target {
-            self.infer_definition(name);
-        } else {
-            self.infer_expression(target);
-        }
+        self.infer_comprehension_target(target);
         for expr in ifs {
             self.infer_expression(expr);
+        }
+    }
+
+    // TODO: support attribute, subscription
+    fn infer_comprehension_target(&mut self, target: &ast::Expr) {
+        match target {
+            ast::Expr::Name(name) => {
+                self.infer_definition(name);
+            }
+            ast::Expr::Tuple(tuple) => {
+                for elt in &tuple.elts {
+                    self.infer_comprehension_target(elt);
+                }
+            }
+            ast::Expr::List(list) => {
+                for elt in &list.elts {
+                    self.infer_comprehension_target(elt);
+                }
+            }
+            _ => {
+                self.infer_expression(target);
+            }
         }
     }
 

--- a/crates/red_knot_python_semantic/src/unpack.rs
+++ b/crates/red_knot_python_semantic/src/unpack.rs
@@ -30,7 +30,9 @@ use crate::Db;
 pub(crate) struct Unpack<'db> {
     pub(crate) file: File,
 
-    pub(crate) file_scope: FileScopeId,
+    pub(crate) value_file_scope: FileScopeId,
+
+    pub(crate) target_file_scope: FileScopeId,
 
     /// The target expression that is being unpacked. For example, in `(a, b) = (1, 2)`, the target
     /// expression is `(a, b)`.
@@ -47,9 +49,15 @@ pub(crate) struct Unpack<'db> {
 }
 
 impl<'db> Unpack<'db> {
-    /// Returns the scope where the unpacking is happening.
-    pub(crate) fn scope(self, db: &'db dyn Db) -> ScopeId<'db> {
-        self.file_scope(db).to_scope_id(db, self.file(db))
+    /// Returns the scope where the unpacked value is appeared.
+    /// In comprehension, the scope of the value and the target may be different.
+    pub(crate) fn value_scope(self, db: &'db dyn Db) -> ScopeId<'db> {
+        self.value_file_scope(db).to_scope_id(db, self.file(db))
+    }
+
+    /// Returns the scope where the unpack target is appeared.
+    pub(crate) fn target_scope(self, db: &'db dyn Db) -> ScopeId<'db> {
+        self.target_file_scope(db).to_scope_id(db, self.file(db))
     }
 
     /// Returns the range of the unpack target expression.

--- a/crates/red_knot_python_semantic/src/unpack.rs
+++ b/crates/red_knot_python_semantic/src/unpack.rs
@@ -49,15 +49,17 @@ pub(crate) struct Unpack<'db> {
 }
 
 impl<'db> Unpack<'db> {
-    /// Returns the scope where the unpacked value is appeared.
-    /// The value scope and the target scope are not always the same;
-    /// the first generator in a generator expression or list/dict/set comprehension is evaluated in the outer scope, while all subsequent
-    /// nodes are evaluated in the inner scope.
+    /// Returns the scope in which the unpack value expression belongs.
+    ///
+    /// The scope in which the target and value expression belongs to are usually the same
+    /// except in generator expressions and comprehensions (list/dict/set), where the value
+    /// expression of the first generator is evaluated in the outer scope, while the ones in the subsequent
+    /// generators are evaluated in the comprehension scope.
     pub(crate) fn value_scope(self, db: &'db dyn Db) -> ScopeId<'db> {
         self.value_file_scope(db).to_scope_id(db, self.file(db))
     }
 
-    /// Returns the scope where the unpack target is appeared.
+    /// Returns the scope where the unpack target expression belongs to.
     pub(crate) fn target_scope(self, db: &'db dyn Db) -> ScopeId<'db> {
         self.target_file_scope(db).to_scope_id(db, self.file(db))
     }

--- a/crates/red_knot_python_semantic/src/unpack.rs
+++ b/crates/red_knot_python_semantic/src/unpack.rs
@@ -50,7 +50,9 @@ pub(crate) struct Unpack<'db> {
 
 impl<'db> Unpack<'db> {
     /// Returns the scope where the unpacked value is appeared.
-    /// In comprehension, the scope of the value and the target may be different.
+    /// The value scope and the target scope are not always the same;
+    /// the first generator in a generator expression or list/dict/set comprehension is evaluated in the outer scope, while all subsequent
+    /// nodes are evaluated in the inner scope.
     pub(crate) fn value_scope(self, db: &'db dyn Db) -> ScopeId<'db> {
         self.value_file_scope(db).to_scope_id(db, self.file(db))
     }


### PR DESCRIPTION
## Summary

This PR is a follow-up to #16852.

Instance variables bound in comprehensions are recorded, allowing type inference to work correctly.

This required adding support for unpacking in comprehension which resolves https://github.com/astral-sh/ruff/issues/15369.

## Test Plan

One TODO in `mdtest/attributes.md` is now resolved, and some new test cases are added.