### PR TITLE
Add object to intersection if positive is empty

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -6580,10 +6580,20 @@ impl<'db> IntersectionType<'db> {
             elements
         }
 
+        let normalised_negative = normalized_set(db, self.negative(db));
+
+        if self.positive(db).is_empty() {
+            return IntersectionType::new(
+                db,
+                FxOrderSet::from_iter([Type::object(db)]),
+                normalised_negative,
+            );
+        }
+
         IntersectionType::new(
             db,
             normalized_set(db, self.positive(db)),
-            normalized_set(db, self.negative(db)),
+            normalised_negative,
         )
     }
 

--- a/crates/red_knot_python_semantic/src/types/builder.rs
+++ b/crates/red_knot_python_semantic/src/types/builder.rs
@@ -586,6 +586,9 @@ impl<'db> InnerIntersectionBuilder<'db> {
             _ => {
                 self.positive.shrink_to_fit();
                 self.negative.shrink_to_fit();
+                if self.positive.is_empty() {
+                    self.positive.insert(Type::object(db));
+                }
                 Type::Intersection(IntersectionType::new(db, self.positive, self.negative))
             }
         }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -5237,6 +5237,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         // If a comparison yields a definitive true/false answer on a (positive) part
         // of an intersection type, it will also yield a definitive answer on the full
         // intersection type, which is even more specific.
+        let mut builder = IntersectionBuilder::new(self.db());
         for pos in intersection.positive(self.db()) {
             let result = match intersection_on {
                 IntersectionOn::Left => {
@@ -5249,6 +5250,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             if let Type::BooleanLiteral(b) = result {
                 return Ok(Type::BooleanLiteral(b));
             }
+            builder = builder.add_positive(result);
         }
 
         // For negative contributions to the intersection type, there are only a few
@@ -5318,19 +5320,6 @@ impl<'db> TypeInferenceBuilder<'db> {
         //
         // we would get a result type `Literal[True]` which is too narrow.
         //
-        let mut builder = IntersectionBuilder::new(self.db());
-        for pos in intersection.positive(self.db()) {
-            let result = match intersection_on {
-                IntersectionOn::Left => {
-                    self.infer_binary_type_comparison(*pos, op, other, range)?
-                }
-                IntersectionOn::Right => {
-                    self.infer_binary_type_comparison(other, op, *pos, range)?
-                }
-            };
-            builder = builder.add_positive(result);
-        }
-
         Ok(builder.build())
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Empty positive can cause some unwanted effects

## Test Plan

Will have to update some regressions
