### PR TITLE
[red-knot] Add regression tests for narrowing constraints cycles

### DIFF
--- a/crates/red_knot_project/resources/test/corpus/cycle_narrowing_constraints.py
+++ b/crates/red_knot_project/resources/test/corpus/cycle_narrowing_constraints.py
@@ -1,5 +1,5 @@
 # Regression test for https://github.com/astral-sh/ruff/issues/17215
-# panicked on commit 1a6a10b30
+# panicked in commit 1a6a10b30
 # error message:
 # dependency graph cycle querying all_narrowing_constraints_for_expression(Id(8591))
 

--- a/crates/red_knot_project/resources/test/corpus/cycle_narrowing_constraints.py
+++ b/crates/red_knot_project/resources/test/corpus/cycle_narrowing_constraints.py
@@ -1,0 +1,15 @@
+# Regression test for https://github.com/astral-sh/ruff/issues/17215
+# panicked on commit 1a6a10b30
+# error message:
+# dependency graph cycle querying all_narrowing_constraints_for_expression(Id(8591))
+
+def f(a: A, b: B, c: C):
+    unknown_a: UA = make_unknown()
+    unknown_b: UB = make_unknown()
+    unknown_c: UC = make_unknown()
+    unknown_d: UD = make_unknown()
+
+    if unknown_a and unknown_b:
+        if unknown_c:
+            if unknown_d:
+                return a, b, c

--- a/crates/red_knot_project/resources/test/corpus/cycle_negative_narrowing_constraints.py
+++ b/crates/red_knot_project/resources/test/corpus/cycle_negative_narrowing_constraints.py
@@ -1,5 +1,5 @@
 # Regression test for https://github.com/astral-sh/ruff/issues/17215
-# panicked on commit 1a6a10b30
+# panicked in commit 1a6a10b30
 # error message:
 # dependency graph cycle querying all_negative_narrowing_constraints_for_expression(Id(859f))
 

--- a/crates/red_knot_project/resources/test/corpus/cycle_negative_narrowing_constraints.py
+++ b/crates/red_knot_project/resources/test/corpus/cycle_negative_narrowing_constraints.py
@@ -1,0 +1,22 @@
+# Regression test for https://github.com/astral-sh/ruff/issues/17215
+# panicked on commit 1a6a10b30
+# error message:
+# dependency graph cycle querying all_negative_narrowing_constraints_for_expression(Id(859f))
+
+def f(f1: bool, f2: bool, f3: bool, f4: bool):
+    o1: UnknownClass = make_o()
+    o2: UnknownClass = make_o()
+    o3: UnknownClass = make_o()
+    o4: UnknownClass = make_o()
+
+    if f1 and f2 and f3 and f4:
+        if o1 == o2:
+            return None
+        if o2 == o3:
+            return None
+        if o3 == o4:
+            return None
+        if o4 == o1:
+            return None
+
+    return o1, o2, o3, o4


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

closes #17215 

This PR adds regression tests for the following cycled queries:
- all_narrowing_constraints_for_expression
- all_negative_narrowing_constraints_for_expression

The following test files are included:
- `red_knot_project/resources/test/corpus/cycle_narrowing_constraints.py`
- `red_knot_project/resources/test/corpus/cycle_negative_narrowing_constraints.py`

These test names don't follow the existing naming convention based on Cinder.
However, I’ve chosen these names to clearly reflect the regression cases.
Let me know if you’d prefer to align more closely with the existing Cinder-based style.

## Test Plan

```sh
git checkout 1a6a10b30
cargo test --package red_knot_project  -- corpus
```
