### PR TITLE
[red-knot] make large-union benchmark more challenging

### DIFF
--- a/crates/ruff_benchmark/benches/red_knot.rs
+++ b/crates/ruff_benchmark/benches/red_knot.rs
@@ -280,6 +280,12 @@ fn benchmark_many_string_assignments(criterion: &mut Criterion) {
                             s += "attr7"
                         if x.attr8:
                             s += "attr8"
+                        if x.attr9:
+                            s += "attr9"
+                        if x.attr10:
+                            s += "attr10"
+                        if x.attr11:
+                            s += "attr11"
                         return s
                     "#,
                 )


### PR DESCRIPTION
## Summary

Now that we've fixed one large source of constant overhead in building large unions of literals, we can afford to make this benchmark a bit nastier, by letting the union get 8x as big (up to 2048 elements, as opposed to just 256 before). The motivation for doing this is so that the benchmark can more clearly show the distinction between constant-overhead optimizations and algorithmic-complexity improvements (which are relatively more important the larger the union in the benchmark gets.)

We expect the largest unions (from large code-generated enums) that we need to support may be around 4k or 5k elements, so ideally we'd increase the benchmark to that size, but at the moment that still makes the benchmark too slow.

## Test Plan

`cargo bench --bench red_knot`
