### PR TITLE
Server: Use `min` instead of `max` to limit the number of threads

### DIFF
--- a/crates/red_knot_server/src/lib.rs
+++ b/crates/red_knot_server/src/lib.rs
@@ -30,7 +30,7 @@ pub fn run_server() -> anyhow::Result<()> {
     // by default, we set the number of worker threads to `num_cpus`, with a maximum of 4.
     let worker_threads = std::thread::available_parallelism()
         .unwrap_or(four)
-        .max(four);
+        .min(four);
 
     Server::new(worker_threads)
         .context("Failed to start server")?

--- a/crates/ruff/src/lib.rs
+++ b/crates/ruff/src/lib.rs
@@ -228,7 +228,7 @@ fn server(args: ServerCommand) -> Result<ExitStatus> {
     // by default, we set the number of worker threads to `num_cpus`, with a maximum of 4.
     let worker_threads = std::thread::available_parallelism()
         .unwrap_or(four)
-        .max(four);
+        .min(four);
     commands::server::run_server(worker_threads, args.resolve_preview())
 }
 


### PR DESCRIPTION
## Summary

Prevent overcommit by using max 4 threads as intended.

Unintuitively, `.max()` returns the maximum value of `self` and the argument (not limiting to the argument). To limit the value to 4, one needs to use `.min()`.

https://doc.rust-lang.org/std/cmp/trait.Ord.html#method.max