### PR TITLE
[red-knot] Dataclasses: synthesize `__init__` with proper signature

### DIFF
--- a/crates/red_knot_python_semantic/src/semantic_index/use_def.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/use_def.rs
@@ -429,6 +429,14 @@ impl<'db> UseDefMap<'db> {
         self.declarations_iterator(declarations)
     }
 
+    pub(crate) fn all_public_declarations<'map>(
+        &'map self,
+    ) -> impl Iterator<Item = (ScopedSymbolId, DeclarationsIterator<'map, 'db>)> + 'map {
+        (0..self.public_symbols.len())
+            .map(ScopedSymbolId::from_usize)
+            .map(|symbol_id| (symbol_id, self.public_declarations(symbol_id)))
+    }
+
     /// This function is intended to be called only once inside `TypeInferenceBuilder::infer_function_body`.
     pub(crate) fn can_implicit_return(&self, db: &dyn crate::Db) -> bool {
         !self
@@ -551,6 +559,7 @@ impl<'db> Iterator for ConstraintsIterator<'_, 'db> {
 
 impl std::iter::FusedIterator for ConstraintsIterator<'_, '_> {}
 
+#[derive(Clone)]
 pub(crate) struct DeclarationsIterator<'map, 'db> {
     all_definitions: &'map IndexVec<ScopedDefinitionId, Option<Definition<'db>>>,
     pub(crate) predicates: &'map Predicates<'db>,


### PR DESCRIPTION
## Summary

This changeset allows us to generate the signature of synthesized `__init__` functions in dataclasses by analyzing the fields on the class (and its superclasses). There are certain things that I have not yet attempted to model in this PR, like `kw_only`, [`dataclasses.KW_ONLY`](https://docs.python.org/3/library/dataclasses.html#dataclasses.KW_ONLY) or functionality around [`dataclasses.field`](https://docs.python.org/3/library/dataclasses.html#dataclasses.field).

depends on https://github.com/astral-sh/ruff/pull/17406

ticket: https://github.com/astral-sh/ruff/issues/16651

## Ecosystem analysis

These two seem to depend on missing features in generics (see [relevant code here](https://github.com/konradhalas/dacite/blob/9898ccbb783e7e6a35ae165e7deb9fa84edfe21c/tests/core/test_generics.py#L54)):

> ```diff
> + error[lint:unknown-argument] /tmp/mypy_primer/projects/dacite/tests/core/test_generics.py:54:24: Argument `x` does not match any known parameter
> + error[lint:unknown-argument] /tmp/mypy_primer/projects/dacite/tests/core/test_generics.py:54:38: Argument `y` does not match any known parameter
> ```



These two are true positives :partying_face:. See [relevant code here](https://github.com/konradhalas/dacite/blob/9898ccbb783e7e6a35ae165e7deb9fa84edfe21c/tests/core/test_config.py#L154-L161).

> ```diff
> + error[lint:invalid-argument-type] /tmp/mypy_primer/projects/dacite/tests/core/test_config.py:161:24: Argument to this function is incorrect: Expected `int`, found `Literal["test"]`
> + error[lint:invalid-argument-type] /tmp/mypy_primer/projects/dacite/tests/core/test_config.py:172:24: Argument to this function is incorrect: Expected `int | float`, found `Literal["test"]`
> ```


This one depends on `**` unpacking of dictionaries, which we don't support yet:

> ```diff
> + error[lint:missing-argument] /tmp/mypy_primer/projects/mypy_primer/mypy_primer/globals.py:218:11: No arguments provided for required parameters `new`, `old`, `repo`, `type_checker`, `mypyc_compile_level`, `custom_typeshed_repo`, `new_typeshed`, `old_typeshed`, `new_prepend_path`, `old_prepend_path`, `additional_flags`, `project_selector`, `known_dependency_selector`, `local_project`, `expected_success`, `project_date`, `shard_index`, `num_shards`, `output`, `old_success`, `coverage`, `bisect`, `bisect_output`, `validate_expected_success`, `measure_project_runtimes`, `concurrency`, `base_dir`, `debug`, `clear`
> ```



## Test Plan

New Markdown tests.