### PR TITLE
Relativize path in github annotations

### DIFF
--- a/crates/ruff/src/printer.rs
+++ b/crates/ruff/src/printer.rs
@@ -308,7 +308,7 @@ impl Printer {
                 self.write_summary_text(writer, diagnostics)?;
             }
             OutputFormat::Github => {
-                GithubEmitter.emit(writer, &diagnostics.messages, &context)?;
+                GithubEmitter::default().emit(writer, &diagnostics.messages, &context)?;
             }
             OutputFormat::Gitlab => {
                 GitlabEmitter::default().emit(writer, &diagnostics.messages, &context)?;

--- a/crates/ruff_linter/src/message/github.rs
+++ b/crates/ruff_linter/src/message/github.rs
@@ -83,7 +83,17 @@ mod tests {
 
     #[test]
     fn output() {
-        let mut emitter = GithubEmitter::default();
+        let mut emitter = GithubEmitter {
+            project_dir: Some(String::from("/projects/project")),
+        };
+        let content = capture_emitter_output(&mut emitter, &create_messages());
+
+        assert_snapshot!(content);
+    }
+
+    #[test]
+    fn output_absolute_path() {
+        let mut emitter = GithubEmitter { project_dir: None };
         let content = capture_emitter_output(&mut emitter, &create_messages());
 
         assert_snapshot!(content);
@@ -91,7 +101,9 @@ mod tests {
 
     #[test]
     fn syntax_errors() {
-        let mut emitter = GithubEmitter::default();
+        let mut emitter = GithubEmitter {
+            project_dir: Some(String::from("/projects/project")),
+        };
         let content = capture_emitter_output(&mut emitter, &create_syntax_error_messages());
 
         assert_snapshot!(content);

--- a/crates/ruff_linter/src/message/mod.rs
+++ b/crates/ruff_linter/src/message/mod.rs
@@ -363,7 +363,8 @@ if call(foo
         pass
 ";
         let locator = Locator::new(source);
-        let source_file = SourceFileBuilder::new("syntax_errors.py", source).finish();
+        let source_file =
+            SourceFileBuilder::new("/projects/project/syntax_errors.py", source).finish();
         parse_unchecked(source, ParseOptions::from(Mode::Module))
             .errors()
             .iter()
@@ -401,7 +402,7 @@ def fibonacci(n):
             TextSize::from(10),
         ))));
 
-        let fib_source = SourceFileBuilder::new("fib.py", fib).finish();
+        let fib_source = SourceFileBuilder::new("/projects/project/fib.py", fib).finish();
 
         let unused_variable = Diagnostic::new(
             DiagnosticKind {
@@ -427,7 +428,7 @@ def fibonacci(n):
             TextRange::new(TextSize::from(3), TextSize::from(4)),
         );
 
-        let file_2_source = SourceFileBuilder::new("undef.py", file_2).finish();
+        let file_2_source = SourceFileBuilder::new("/projects/project/undef.py", file_2).finish();
 
         let unused_import_start = unused_import.start();
         let unused_variable_start = unused_variable.start();

--- a/crates/ruff_linter/src/message/snapshots/ruff_linter__message__azure__tests__output.snap
+++ b/crates/ruff_linter/src/message/snapshots/ruff_linter__message__azure__tests__output.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/ruff_linter/src/message/azure.rs
 expression: content
-snapshot_kind: text
 ---
-##vso[task.logissue type=error;sourcepath=fib.py;linenumber=1;columnnumber=8;code=F401;]`os` imported but unused
-##vso[task.logissue type=error;sourcepath=fib.py;linenumber=6;columnnumber=5;code=F841;]Local variable `x` is assigned to but never used
-##vso[task.logissue type=error;sourcepath=undef.py;linenumber=1;columnnumber=4;code=F821;]Undefined name `a`
+##vso[task.logissue type=error;sourcepath=/projects/project/fib.py;linenumber=1;columnnumber=8;code=F401;]`os` imported but unused
+##vso[task.logissue type=error;sourcepath=/projects/project/fib.py;linenumber=6;columnnumber=5;code=F841;]Local variable `x` is assigned to but never used
+##vso[task.logissue type=error;sourcepath=/projects/project/undef.py;linenumber=1;columnnumber=4;code=F821;]Undefined name `a`

--- a/crates/ruff_linter/src/message/snapshots/ruff_linter__message__azure__tests__syntax_errors.snap
+++ b/crates/ruff_linter/src/message/snapshots/ruff_linter__message__azure__tests__syntax_errors.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/ruff_linter/src/message/azure.rs
 expression: content
-snapshot_kind: text
 ---
-##vso[task.logissue type=error;sourcepath=syntax_errors.py;linenumber=1;columnnumber=15;]SyntaxError: Expected one or more symbol names after import
-##vso[task.logissue type=error;sourcepath=syntax_errors.py;linenumber=3;columnnumber=12;]SyntaxError: Expected ')', found newline
+##vso[task.logissue type=error;sourcepath=/projects/project/syntax_errors.py;linenumber=1;columnnumber=15;]SyntaxError: Expected one or more symbol names after import
+##vso[task.logissue type=error;sourcepath=/projects/project/syntax_errors.py;linenumber=3;columnnumber=12;]SyntaxError: Expected ')', found newline

--- a/crates/ruff_linter/src/message/snapshots/ruff_linter__message__github__tests__output_absolute_path.snap
+++ b/crates/ruff_linter/src/message/snapshots/ruff_linter__message__github__tests__output_absolute_path.snap
@@ -1,0 +1,7 @@
+---
+source: crates/ruff_linter/src/message/github.rs
+expression: content
+---
+::error title=Ruff (F401),file=/projects/project/fib.py,line=1,col=8,endLine=1,endColumn=10::/projects/project/fib.py:1:8: F401 `os` imported but unused
+::error title=Ruff (F841),file=/projects/project/fib.py,line=6,col=5,endLine=6,endColumn=6::/projects/project/fib.py:6:5: F841 Local variable `x` is assigned to but never used
+::error title=Ruff (F821),file=/projects/project/undef.py,line=1,col=4,endLine=1,endColumn=5::/projects/project/undef.py:1:4: F821 Undefined name `a`

--- a/crates/ruff_linter/src/message/snapshots/ruff_linter__message__gitlab__tests__output.snap
+++ b/crates/ruff_linter/src/message/snapshots/ruff_linter__message__gitlab__tests__output.snap
@@ -12,7 +12,7 @@ expression: redact_fingerprint(&content)
         "begin": 1,
         "end": 1
       },
-      "path": "fib.py"
+      "path": "/projects/project/fib.py"
     },
     "severity": "major"
   },
@@ -25,7 +25,7 @@ expression: redact_fingerprint(&content)
         "begin": 6,
         "end": 6
       },
-      "path": "fib.py"
+      "path": "/projects/project/fib.py"
     },
     "severity": "major"
   },
@@ -38,7 +38,7 @@ expression: redact_fingerprint(&content)
         "begin": 1,
         "end": 1
       },
-      "path": "undef.py"
+      "path": "/projects/project/undef.py"
     },
     "severity": "major"
   }

--- a/crates/ruff_linter/src/message/snapshots/ruff_linter__message__gitlab__tests__syntax_errors.snap
+++ b/crates/ruff_linter/src/message/snapshots/ruff_linter__message__gitlab__tests__syntax_errors.snap
@@ -12,7 +12,7 @@ expression: redact_fingerprint(&content)
         "begin": 1,
         "end": 2
       },
-      "path": "syntax_errors.py"
+      "path": "/projects/project/syntax_errors.py"
     },
     "severity": "major"
   },
@@ -25,7 +25,7 @@ expression: redact_fingerprint(&content)
         "begin": 3,
         "end": 4
       },
-      "path": "syntax_errors.py"
+      "path": "/projects/project/syntax_errors.py"
     },
     "severity": "major"
   }

--- a/crates/ruff_linter/src/message/snapshots/ruff_linter__message__grouped__tests__default.snap
+++ b/crates/ruff_linter/src/message/snapshots/ruff_linter__message__grouped__tests__default.snap
@@ -1,11 +1,10 @@
 ---
 source: crates/ruff_linter/src/message/grouped.rs
 expression: content
-snapshot_kind: text
 ---
-fib.py:
+/projects/project/fib.py:
   1:8 F401 `os` imported but unused
   6:5 F841 Local variable `x` is assigned to but never used
 
-undef.py:
+/projects/project/undef.py:
   1:4 F821 Undefined name `a`

--- a/crates/ruff_linter/src/message/snapshots/ruff_linter__message__grouped__tests__fix_status.snap
+++ b/crates/ruff_linter/src/message/snapshots/ruff_linter__message__grouped__tests__fix_status.snap
@@ -1,9 +1,8 @@
 ---
 source: crates/ruff_linter/src/message/grouped.rs
 expression: content
-snapshot_kind: text
 ---
-fib.py:
+/projects/project/fib.py:
   1:8 F401 `os` imported but unused
     |
   1 | import os
@@ -22,7 +21,7 @@ fib.py:
     |
     = help: Remove assignment to unused variable `x`
   
-undef.py:
+/projects/project/undef.py:
   1:4 F821 Undefined name `a`
     |
   1 | if a == 1: pass

--- a/crates/ruff_linter/src/message/snapshots/ruff_linter__message__grouped__tests__fix_status_unsafe.snap
+++ b/crates/ruff_linter/src/message/snapshots/ruff_linter__message__grouped__tests__fix_status_unsafe.snap
@@ -1,9 +1,8 @@
 ---
 source: crates/ruff_linter/src/message/grouped.rs
 expression: content
-snapshot_kind: text
 ---
-fib.py:
+/projects/project/fib.py:
   1:8 F401 [*] `os` imported but unused
     |
   1 | import os
@@ -22,7 +21,7 @@ fib.py:
     |
     = help: Remove assignment to unused variable `x`
   
-undef.py:
+/projects/project/undef.py:
   1:4 F821 Undefined name `a`
     |
   1 | if a == 1: pass

--- a/crates/ruff_linter/src/message/snapshots/ruff_linter__message__grouped__tests__show_source.snap
+++ b/crates/ruff_linter/src/message/snapshots/ruff_linter__message__grouped__tests__show_source.snap
@@ -1,9 +1,8 @@
 ---
 source: crates/ruff_linter/src/message/grouped.rs
 expression: content
-snapshot_kind: text
 ---
-fib.py:
+/projects/project/fib.py:
   1:8 F401 `os` imported but unused
     |
   1 | import os
@@ -22,7 +21,7 @@ fib.py:
     |
     = help: Remove assignment to unused variable `x`
   
-undef.py:
+/projects/project/undef.py:
   1:4 F821 Undefined name `a`
     |
   1 | if a == 1: pass

--- a/crates/ruff_linter/src/message/snapshots/ruff_linter__message__grouped__tests__syntax_errors.snap
+++ b/crates/ruff_linter/src/message/snapshots/ruff_linter__message__grouped__tests__syntax_errors.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/ruff_linter/src/message/grouped.rs
 expression: content
-snapshot_kind: text
 ---
-syntax_errors.py:
+/projects/project/syntax_errors.py:
   1:15 SyntaxError: Expected one or more symbol names after import
   3:12 SyntaxError: Expected ')', found newline

--- a/crates/ruff_linter/src/message/snapshots/ruff_linter__message__json__tests__output.snap
+++ b/crates/ruff_linter/src/message/snapshots/ruff_linter__message__json__tests__output.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/ruff_linter/src/message/json.rs
 expression: content
-snapshot_kind: text
 ---
 [
   {
@@ -11,7 +10,7 @@ snapshot_kind: text
       "column": 10,
       "row": 1
     },
-    "filename": "fib.py",
+    "filename": "/projects/project/fib.py",
     "fix": {
       "applicability": "unsafe",
       "edits": [
@@ -44,7 +43,7 @@ snapshot_kind: text
       "column": 6,
       "row": 6
     },
-    "filename": "fib.py",
+    "filename": "/projects/project/fib.py",
     "fix": {
       "applicability": "unsafe",
       "edits": [
@@ -77,7 +76,7 @@ snapshot_kind: text
       "column": 5,
       "row": 1
     },
-    "filename": "undef.py",
+    "filename": "/projects/project/undef.py",
     "fix": null,
     "location": {
       "column": 4,

--- a/crates/ruff_linter/src/message/snapshots/ruff_linter__message__json__tests__syntax_errors.snap
+++ b/crates/ruff_linter/src/message/snapshots/ruff_linter__message__json__tests__syntax_errors.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/ruff_linter/src/message/json.rs
 expression: content
-snapshot_kind: text
 ---
 [
   {
@@ -11,7 +10,7 @@ snapshot_kind: text
       "column": 1,
       "row": 2
     },
-    "filename": "syntax_errors.py",
+    "filename": "/projects/project/syntax_errors.py",
     "fix": null,
     "location": {
       "column": 15,
@@ -28,7 +27,7 @@ snapshot_kind: text
       "column": 1,
       "row": 4
     },
-    "filename": "syntax_errors.py",
+    "filename": "/projects/project/syntax_errors.py",
     "fix": null,
     "location": {
       "column": 12,

--- a/crates/ruff_linter/src/message/snapshots/ruff_linter__message__json_lines__tests__output.snap
+++ b/crates/ruff_linter/src/message/snapshots/ruff_linter__message__json_lines__tests__output.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/ruff_linter/src/message/json_lines.rs
 expression: content
-snapshot_kind: text
 ---
-{"cell":null,"code":"F401","end_location":{"column":10,"row":1},"filename":"fib.py","fix":{"applicability":"unsafe","edits":[{"content":"","end_location":{"column":1,"row":2},"location":{"column":1,"row":1}}],"message":"Remove unused import: `os`"},"location":{"column":8,"row":1},"message":"`os` imported but unused","noqa_row":1,"url":"https://docs.astral.sh/ruff/rules/unused-import"}
-{"cell":null,"code":"F841","end_location":{"column":6,"row":6},"filename":"fib.py","fix":{"applicability":"unsafe","edits":[{"content":"","end_location":{"column":10,"row":6},"location":{"column":5,"row":6}}],"message":"Remove assignment to unused variable `x`"},"location":{"column":5,"row":6},"message":"Local variable `x` is assigned to but never used","noqa_row":6,"url":"https://docs.astral.sh/ruff/rules/unused-variable"}
-{"cell":null,"code":"F821","end_location":{"column":5,"row":1},"filename":"undef.py","fix":null,"location":{"column":4,"row":1},"message":"Undefined name `a`","noqa_row":1,"url":"https://docs.astral.sh/ruff/rules/undefined-name"}
+{"cell":null,"code":"F401","end_location":{"column":10,"row":1},"filename":"/projects/project/fib.py","fix":{"applicability":"unsafe","edits":[{"content":"","end_location":{"column":1,"row":2},"location":{"column":1,"row":1}}],"message":"Remove unused import: `os`"},"location":{"column":8,"row":1},"message":"`os` imported but unused","noqa_row":1,"url":"https://docs.astral.sh/ruff/rules/unused-import"}
+{"cell":null,"code":"F841","end_location":{"column":6,"row":6},"filename":"/projects/project/fib.py","fix":{"applicability":"unsafe","edits":[{"content":"","end_location":{"column":10,"row":6},"location":{"column":5,"row":6}}],"message":"Remove assignment to unused variable `x`"},"location":{"column":5,"row":6},"message":"Local variable `x` is assigned to but never used","noqa_row":6,"url":"https://docs.astral.sh/ruff/rules/unused-variable"}
+{"cell":null,"code":"F821","end_location":{"column":5,"row":1},"filename":"/projects/project/undef.py","fix":null,"location":{"column":4,"row":1},"message":"Undefined name `a`","noqa_row":1,"url":"https://docs.astral.sh/ruff/rules/undefined-name"}

--- a/crates/ruff_linter/src/message/snapshots/ruff_linter__message__json_lines__tests__syntax_errors.snap
+++ b/crates/ruff_linter/src/message/snapshots/ruff_linter__message__json_lines__tests__syntax_errors.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/ruff_linter/src/message/json_lines.rs
 expression: content
-snapshot_kind: text
 ---
-{"cell":null,"code":null,"end_location":{"column":1,"row":2},"filename":"syntax_errors.py","fix":null,"location":{"column":15,"row":1},"message":"SyntaxError: Expected one or more symbol names after import","noqa_row":null,"url":null}
-{"cell":null,"code":null,"end_location":{"column":1,"row":4},"filename":"syntax_errors.py","fix":null,"location":{"column":12,"row":3},"message":"SyntaxError: Expected ')', found newline","noqa_row":null,"url":null}
+{"cell":null,"code":null,"end_location":{"column":1,"row":2},"filename":"/projects/project/syntax_errors.py","fix":null,"location":{"column":15,"row":1},"message":"SyntaxError: Expected one or more symbol names after import","noqa_row":null,"url":null}
+{"cell":null,"code":null,"end_location":{"column":1,"row":4},"filename":"/projects/project/syntax_errors.py","fix":null,"location":{"column":12,"row":3},"message":"SyntaxError: Expected ')', found newline","noqa_row":null,"url":null}

--- a/crates/ruff_linter/src/message/snapshots/ruff_linter__message__junit__tests__output.snap
+++ b/crates/ruff_linter/src/message/snapshots/ruff_linter__message__junit__tests__output.snap
@@ -1,20 +1,19 @@
 ---
 source: crates/ruff_linter/src/message/junit.rs
 expression: content
-snapshot_kind: text
 ---
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites name="ruff" tests="3" failures="3" errors="0">
-    <testsuite name="fib.py" tests="2" disabled="0" errors="0" failures="2" package="org.ruff">
-        <testcase name="org.ruff.F401" classname="fib" line="1" column="8">
+    <testsuite name="/projects/project/fib.py" tests="2" disabled="0" errors="0" failures="2" package="org.ruff">
+        <testcase name="org.ruff.F401" classname="/projects/project/fib" line="1" column="8">
             <failure message="`os` imported but unused">line 1, col 8, `os` imported but unused</failure>
         </testcase>
-        <testcase name="org.ruff.F841" classname="fib" line="6" column="5">
+        <testcase name="org.ruff.F841" classname="/projects/project/fib" line="6" column="5">
             <failure message="Local variable `x` is assigned to but never used">line 6, col 5, Local variable `x` is assigned to but never used</failure>
         </testcase>
     </testsuite>
-    <testsuite name="undef.py" tests="1" disabled="0" errors="0" failures="1" package="org.ruff">
-        <testcase name="org.ruff.F821" classname="undef" line="1" column="4">
+    <testsuite name="/projects/project/undef.py" tests="1" disabled="0" errors="0" failures="1" package="org.ruff">
+        <testcase name="org.ruff.F821" classname="/projects/project/undef" line="1" column="4">
             <failure message="Undefined name `a`">line 1, col 4, Undefined name `a`</failure>
         </testcase>
     </testsuite>

--- a/crates/ruff_linter/src/message/snapshots/ruff_linter__message__junit__tests__syntax_errors.snap
+++ b/crates/ruff_linter/src/message/snapshots/ruff_linter__message__junit__tests__syntax_errors.snap
@@ -1,15 +1,14 @@
 ---
 source: crates/ruff_linter/src/message/junit.rs
 expression: content
-snapshot_kind: text
 ---
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites name="ruff" tests="2" failures="2" errors="0">
-    <testsuite name="syntax_errors.py" tests="2" disabled="0" errors="0" failures="2" package="org.ruff">
-        <testcase name="org.ruff" classname="syntax_errors" line="1" column="15">
+    <testsuite name="/projects/project/syntax_errors.py" tests="2" disabled="0" errors="0" failures="2" package="org.ruff">
+        <testcase name="org.ruff" classname="/projects/project/syntax_errors" line="1" column="15">
             <failure message="SyntaxError: Expected one or more symbol names after import">line 1, col 15, SyntaxError: Expected one or more symbol names after import</failure>
         </testcase>
-        <testcase name="org.ruff" classname="syntax_errors" line="3" column="12">
+        <testcase name="org.ruff" classname="/projects/project/syntax_errors" line="3" column="12">
             <failure message="SyntaxError: Expected &apos;)&apos;, found newline">line 3, col 12, SyntaxError: Expected &apos;)&apos;, found newline</failure>
         </testcase>
     </testsuite>

--- a/crates/ruff_linter/src/message/snapshots/ruff_linter__message__pylint__tests__output.snap
+++ b/crates/ruff_linter/src/message/snapshots/ruff_linter__message__pylint__tests__output.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/ruff_linter/src/message/pylint.rs
 expression: content
-snapshot_kind: text
 ---
-fib.py:1: [F401] `os` imported but unused
-fib.py:6: [F841] Local variable `x` is assigned to but never used
-undef.py:1: [F821] Undefined name `a`
+/projects/project/fib.py:1: [F401] `os` imported but unused
+/projects/project/fib.py:6: [F841] Local variable `x` is assigned to but never used
+/projects/project/undef.py:1: [F821] Undefined name `a`

--- a/crates/ruff_linter/src/message/snapshots/ruff_linter__message__pylint__tests__syntax_errors.snap
+++ b/crates/ruff_linter/src/message/snapshots/ruff_linter__message__pylint__tests__syntax_errors.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/ruff_linter/src/message/pylint.rs
 expression: content
-snapshot_kind: text
 ---
-syntax_errors.py:1: SyntaxError: Expected one or more symbol names after import
-syntax_errors.py:3: SyntaxError: Expected ')', found newline
+/projects/project/syntax_errors.py:1: SyntaxError: Expected one or more symbol names after import
+/projects/project/syntax_errors.py:3: SyntaxError: Expected ')', found newline

--- a/crates/ruff_linter/src/message/snapshots/ruff_linter__message__rdjson__tests__output.snap
+++ b/crates/ruff_linter/src/message/snapshots/ruff_linter__message__rdjson__tests__output.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/ruff_linter/src/message/rdjson.rs
 expression: content
-snapshot_kind: text
 ---
 {
   "diagnostics": [
@@ -11,7 +10,7 @@ snapshot_kind: text
         "value": "F401"
       },
       "location": {
-        "path": "fib.py",
+        "path": "/projects/project/fib.py",
         "range": {
           "end": {
             "column": 10,
@@ -46,7 +45,7 @@ snapshot_kind: text
         "value": "F841"
       },
       "location": {
-        "path": "fib.py",
+        "path": "/projects/project/fib.py",
         "range": {
           "end": {
             "column": 6,
@@ -81,7 +80,7 @@ snapshot_kind: text
         "value": "F821"
       },
       "location": {
-        "path": "undef.py",
+        "path": "/projects/project/undef.py",
         "range": {
           "end": {
             "column": 5,

--- a/crates/ruff_linter/src/message/snapshots/ruff_linter__message__rdjson__tests__syntax_errors.snap
+++ b/crates/ruff_linter/src/message/snapshots/ruff_linter__message__rdjson__tests__syntax_errors.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/ruff_linter/src/message/rdjson.rs
 expression: content
-snapshot_kind: text
 ---
 {
   "diagnostics": [
@@ -11,7 +10,7 @@ snapshot_kind: text
         "value": null
       },
       "location": {
-        "path": "syntax_errors.py",
+        "path": "/projects/project/syntax_errors.py",
         "range": {
           "end": {
             "column": 1,
@@ -31,7 +30,7 @@ snapshot_kind: text
         "value": null
       },
       "location": {
-        "path": "syntax_errors.py",
+        "path": "/projects/project/syntax_errors.py",
         "range": {
           "end": {
             "column": 1,

--- a/crates/ruff_linter/src/message/snapshots/ruff_linter__message__text__tests__default.snap
+++ b/crates/ruff_linter/src/message/snapshots/ruff_linter__message__text__tests__default.snap
@@ -1,16 +1,15 @@
 ---
 source: crates/ruff_linter/src/message/text.rs
 expression: content
-snapshot_kind: text
 ---
-fib.py:1:8: F401 `os` imported but unused
+/projects/project/fib.py:1:8: F401 `os` imported but unused
   |
 1 | import os
   |        ^^ F401
   |
   = help: Remove unused import: `os`
 
-fib.py:6:5: F841 Local variable `x` is assigned to but never used
+/projects/project/fib.py:6:5: F841 Local variable `x` is assigned to but never used
   |
 4 | def fibonacci(n):
 5 |     """Compute the nth number in the Fibonacci sequence."""
@@ -21,7 +20,7 @@ fib.py:6:5: F841 Local variable `x` is assigned to but never used
   |
   = help: Remove assignment to unused variable `x`
 
-undef.py:1:4: F821 Undefined name `a`
+/projects/project/undef.py:1:4: F821 Undefined name `a`
   |
 1 | if a == 1: pass
   |    ^ F821

--- a/crates/ruff_linter/src/message/snapshots/ruff_linter__message__text__tests__fix_status.snap
+++ b/crates/ruff_linter/src/message/snapshots/ruff_linter__message__text__tests__fix_status.snap
@@ -1,16 +1,15 @@
 ---
 source: crates/ruff_linter/src/message/text.rs
 expression: content
-snapshot_kind: text
 ---
-fib.py:1:8: F401 `os` imported but unused
+/projects/project/fib.py:1:8: F401 `os` imported but unused
   |
 1 | import os
   |        ^^ F401
   |
   = help: Remove unused import: `os`
 
-fib.py:6:5: F841 Local variable `x` is assigned to but never used
+/projects/project/fib.py:6:5: F841 Local variable `x` is assigned to but never used
   |
 4 | def fibonacci(n):
 5 |     """Compute the nth number in the Fibonacci sequence."""
@@ -21,7 +20,7 @@ fib.py:6:5: F841 Local variable `x` is assigned to but never used
   |
   = help: Remove assignment to unused variable `x`
 
-undef.py:1:4: F821 Undefined name `a`
+/projects/project/undef.py:1:4: F821 Undefined name `a`
   |
 1 | if a == 1: pass
   |    ^ F821

--- a/crates/ruff_linter/src/message/snapshots/ruff_linter__message__text__tests__fix_status_unsafe.snap
+++ b/crates/ruff_linter/src/message/snapshots/ruff_linter__message__text__tests__fix_status_unsafe.snap
@@ -1,16 +1,15 @@
 ---
 source: crates/ruff_linter/src/message/text.rs
 expression: content
-snapshot_kind: text
 ---
-fib.py:1:8: F401 [*] `os` imported but unused
+/projects/project/fib.py:1:8: F401 [*] `os` imported but unused
   |
 1 | import os
   |        ^^ F401
   |
   = help: Remove unused import: `os`
 
-fib.py:6:5: F841 [*] Local variable `x` is assigned to but never used
+/projects/project/fib.py:6:5: F841 [*] Local variable `x` is assigned to but never used
   |
 4 | def fibonacci(n):
 5 |     """Compute the nth number in the Fibonacci sequence."""
@@ -21,7 +20,7 @@ fib.py:6:5: F841 [*] Local variable `x` is assigned to but never used
   |
   = help: Remove assignment to unused variable `x`
 
-undef.py:1:4: F821 Undefined name `a`
+/projects/project/undef.py:1:4: F821 Undefined name `a`
   |
 1 | if a == 1: pass
   |    ^ F821

--- a/crates/ruff_linter/src/message/snapshots/ruff_linter__message__text__tests__syntax_errors.snap
+++ b/crates/ruff_linter/src/message/snapshots/ruff_linter__message__text__tests__syntax_errors.snap
@@ -2,7 +2,7 @@
 source: crates/ruff_linter/src/message/text.rs
 expression: content
 ---
-syntax_errors.py:1:15: SyntaxError: Expected one or more symbol names after import
+/projects/project/syntax_errors.py:1:15: SyntaxError: Expected one or more symbol names after import
   |
 1 | from os import
   |               ^
@@ -11,7 +11,7 @@ syntax_errors.py:1:15: SyntaxError: Expected one or more symbol names after impo
 4 |     def bar():
   |
 
-syntax_errors.py:3:12: SyntaxError: Expected ')', found newline
+/projects/project/syntax_errors.py:3:12: SyntaxError: Expected ')', found newline
   |
 1 | from os import
 2 |


### PR DESCRIPTION
-------

<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Without relative paths GH actions will not correctly display inline
comments in the right place.

It's possible this is only affecting GitHub enterprise or self-hosted
runners.

See #17433

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->

`ruff check --output-format=github` should show annotations with paths relative to root of the project instead of absolute paths in the filesystem.