### PR TITLE
[`pyupgrade`] Add fix safety section to docs (`UP008`, `UP022`)

### DIFF
--- a/crates/ruff_linter/src/rules/pyupgrade/rules/replace_stdout_stderr.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/replace_stdout_stderr.rs
@@ -33,6 +33,12 @@ use crate::fix::edits::{remove_argument, Parentheses};
 /// subprocess.run(["foo"], capture_output=True)
 /// ```
 ///
+/// ## Fix safety
+///
+/// This rule's fix is marked as unsafe because replacing `stdout=subprocess.PIPE` and
+/// `stderr=subprocess.PIPE` with `capture_output=True` may delete comments attached
+/// to the original arguments.
+///
 /// ## References
 /// - [Python 3.7 release notes](https://docs.python.org/3/whatsnew/3.7.html#subprocess)
 /// - [Python documentation: `subprocess.run`](https://docs.python.org/3/library/subprocess.html#subprocess.run)

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/super_call_with_parameters.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/super_call_with_parameters.rs
@@ -40,6 +40,11 @@ use crate::checkers::ast::Checker;
 ///         super().foo()
 /// ```
 ///
+/// ## Fix safety
+///
+/// This rule's fix is marked as unsafe because removing the arguments from a call
+/// may delete comments that are attached to the arguments.
+///
 /// ## References
 /// - [Python documentation: `super`](https://docs.python.org/3/library/functions.html#super)
 /// - [super/MRO, Python's most misunderstood feature.](https://www.youtube.com/watch?v=X1PQ7zzltz4)


### PR DESCRIPTION
## Summary

add fix safety section to replace_stdout_stderr and super_call_with_parameters, for #15584 
I checked the behavior and found that these two files could only potentially delete the appended comments, so I submitted them as a PR.


