### PR TITLE
[`pyupgrade`] Add fix safety section to docs (`UP030`)

### DIFF
--- a/crates/ruff_linter/src/rules/pyupgrade/rules/format_literals.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/format_literals.rs
@@ -39,7 +39,7 @@ use crate::Locator;
 /// "{}, {}".format("Hello", "World")  # "Hello, World"
 /// ```
 ///
-/// This fix is unsafe because:
+/// This fix is marked as unsafe because:
 /// - Comments attached to arguments are not moved, which can cause comments to mismatch the actual arguments.
 /// - If arguments have side effects (e.g., print), reordering may change program behavior.
 ///

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/format_literals.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/format_literals.rs
@@ -40,7 +40,6 @@ use crate::Locator;
 /// ```
 ///
 /// This fix is unsafe because:
-
 /// - Comments attached to arguments are not moved, which can cause comments to mismatch the actual arguments.
 /// - If arguments have side effects (e.g., print), reordering may change program behavior.
 ///

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/format_literals.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/format_literals.rs
@@ -39,6 +39,10 @@ use crate::Locator;
 /// "{}, {}".format("Hello", "World")  # "Hello, World"
 /// ```
 ///
+/// ## Fix safety
+/// This fix is unsafe: it may remove comments when rewriting the call,
+/// and relies on the argument order matching the format string indices.
+///
 /// ## References
 /// - [Python documentation: Format String Syntax](https://docs.python.org/3/library/string.html#format-string-syntax)
 /// - [Python documentation: `str.format`](https://docs.python.org/3/library/stdtypes.html#str.format)

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/format_literals.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/format_literals.rs
@@ -39,9 +39,10 @@ use crate::Locator;
 /// "{}, {}".format("Hello", "World")  # "Hello, World"
 /// ```
 ///
-/// ## Fix safety
-/// This fix is unsafe: it may remove comments when rewriting the call,
-/// and relies on the argument order matching the format string indices.
+/// This fix is unsafe because:
+
+/// - Comments attached to arguments are not moved, which can cause comments to mismatch the actual arguments.
+/// - If arguments have side effects (e.g., print), reordering may change program behavior.
 ///
 /// ## References
 /// - [Python documentation: Format String Syntax](https://docs.python.org/3/library/string.html#format-string-syntax)


### PR DESCRIPTION


## Summary

add fix safety section to format_literals, for #15584 