### PR TITLE
[red-knot] Understand `typing.Protocol` and `typing_extensions.Protocol` as equivalent

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/protocols.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/protocols.md
@@ -227,8 +227,7 @@ from knot_extensions import static_assert, is_equivalent_to
 class Foo(typing.Protocol):
     x: int
 
-# TODO: should not error
-class Bar(typing_extensions.Protocol):  # error: [invalid-base]
+class Bar(typing_extensions.Protocol):
     x: int
 
 # TODO: these should pass
@@ -244,9 +243,8 @@ The same goes for `typing.runtime_checkable` and `typing_extensions.runtime_chec
 class RuntimeCheckableFoo(typing.Protocol):
     x: int
 
-# TODO: should not error
 @typing.runtime_checkable
-class RuntimeCheckableBar(typing_extensions.Protocol):  # error: [invalid-base]
+class RuntimeCheckableBar(typing_extensions.Protocol):
     x: int
 
 # TODO: these should pass
@@ -257,6 +255,12 @@ static_assert(is_equivalent_to(RuntimeCheckableFoo, RuntimeCheckableBar))  # err
 # These should not error because the protocols are decorated with `@runtime_checkable`
 isinstance(object(), RuntimeCheckableFoo)
 isinstance(object(), RuntimeCheckableBar)
+```
+
+However, we understand that they are distinct symbols:
+
+```py
+static_assert(typing.Protocol is not typing_extensions.Protocol)
 ```
 
 ## Calls to protocol classes
@@ -304,8 +308,7 @@ via `typing_extensions`.
 ```py
 from typing_extensions import Protocol, get_protocol_members
 
-# TODO: should not error
-class Foo(Protocol):  # error: [invalid-base]
+class Foo(Protocol):
     x: int
 
     @property
@@ -346,8 +349,7 @@ Certain special attributes and methods are not considered protocol members at ru
 not be considered protocol members by type checkers either:
 
 ```py
-# TODO: should not error
-class Lumberjack(Protocol):  # error: [invalid-base]
+class Lumberjack(Protocol):
     __slots__ = ()
     __match_args__ = ()
     x: int

--- a/crates/red_knot_python_semantic/src/module_resolver/module.rs
+++ b/crates/red_knot_python_semantic/src/module_resolver/module.rs
@@ -164,6 +164,10 @@ impl KnownModule {
         matches!(self, Self::Typing)
     }
 
+    pub const fn is_typing_extensions(self) -> bool {
+        matches!(self, Self::TypingExtensions)
+    }
+
     pub const fn is_knot_extensions(self) -> bool {
         matches!(self, Self::KnotExtensions)
     }

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -4316,7 +4316,7 @@ impl<'db> Type<'db> {
                 KnownInstanceType::TypingSelf => Ok(todo_type!("Support for `typing.Self`")),
                 KnownInstanceType::TypeAlias => Ok(todo_type!("Support for `typing.TypeAlias`")),
 
-                KnownInstanceType::Protocol => Err(InvalidTypeExpressionError {
+                KnownInstanceType::Protocol(_) => Err(InvalidTypeExpressionError {
                     invalid_expressions: smallvec::smallvec![InvalidTypeExpression::Protocol],
                     fallback_type: Type::unknown(),
                 }),

--- a/crates/red_knot_python_semantic/src/types/class_base.rs
+++ b/crates/red_knot_python_semantic/src/types/class_base.rs
@@ -165,7 +165,9 @@ impl<'db> ClassBase<'db> {
                 KnownInstanceType::Callable => {
                     Self::try_from_type(db, todo_type!("Support for Callable as a base class"))
                 }
-                KnownInstanceType::Protocol => Some(ClassBase::Dynamic(DynamicType::TodoProtocol)),
+                KnownInstanceType::Protocol(_) => {
+                    Some(ClassBase::Dynamic(DynamicType::TodoProtocol))
+                }
             },
         }
     }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1249,7 +1249,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         node_ref.bases().iter().any(|base| {
             matches!(
                 self.file_expression_type(base),
-                Type::KnownInstance(KnownInstanceType::Protocol)
+                Type::KnownInstance(KnownInstanceType::Protocol(_))
             )
         })
     }
@@ -6230,7 +6230,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 value_ty,
                 Type::IntLiteral(i64::from(bool)),
             ),
-            (Type::KnownInstance(KnownInstanceType::Protocol), _) => {
+            (Type::KnownInstance(KnownInstanceType::Protocol(_)), _) => {
                 Type::Dynamic(DynamicType::TodoProtocol)
             }
             (Type::KnownInstance(known_instance), _)
@@ -7487,7 +7487,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 self.infer_type_expression(arguments_slice);
                 todo_type!("`Unpack[]` special form")
             }
-            KnownInstanceType::Protocol => {
+            KnownInstanceType::Protocol(_) => {
                 self.infer_type_expression(arguments_slice);
                 Type::Dynamic(DynamicType::TodoProtocol)
             }

--- a/crates/red_knot_python_semantic/src/types/type_ordering.rs
+++ b/crates/red_knot_python_semantic/src/types/type_ordering.rs
@@ -3,8 +3,8 @@ use std::cmp::Ordering;
 use crate::db::Db;
 
 use super::{
-    class_base::ClassBase, DynamicType, InstanceType, KnownInstanceType, SuperOwnerKind, TodoType,
-    Type,
+    class::ProtocolOrigin, class_base::ClassBase, DynamicType, InstanceType, KnownInstanceType,
+    SuperOwnerKind, TodoType, Type,
 };
 
 /// Return an [`Ordering`] that describes the canonical order in which two types should appear
@@ -230,8 +230,15 @@ pub(super) fn union_or_intersection_elements_ordering<'db>(
                 (KnownInstanceType::OrderedDict, _) => Ordering::Less,
                 (_, KnownInstanceType::OrderedDict) => Ordering::Greater,
 
-                (KnownInstanceType::Protocol, _) => Ordering::Less,
-                (_, KnownInstanceType::Protocol) => Ordering::Greater,
+                (KnownInstanceType::Protocol(ProtocolOrigin::Typing), _) => Ordering::Less,
+                (_, KnownInstanceType::Protocol(ProtocolOrigin::Typing)) => Ordering::Greater,
+
+                (KnownInstanceType::Protocol(ProtocolOrigin::TypingExtensions), _) => {
+                    Ordering::Less
+                }
+                (_, KnownInstanceType::Protocol(ProtocolOrigin::TypingExtensions)) => {
+                    Ordering::Greater
+                }
 
                 (KnownInstanceType::NoReturn, _) => Ordering::Less,
                 (_, KnownInstanceType::NoReturn) => Ordering::Greater,


### PR DESCRIPTION
## Summary

We currently have special-casing that avoids false positives for `typing.Protocol`, but the special-casing doesn't currently recognise `typing_extensions.Protocol` as also being a valid class base, etc. Due to various bugfixes and performance optimisations having been backported via typing_extensions, `typing_extensions.Protocol` is a different symbol to `typing.Protocol` on most Python versions: it would be wrong for us to infer `Literal[True]` as the result of the expression `typing_extensions.Protocol is typing.Protocol`, for example. Nonetheless, they should be treated identically by a type checker in terms of their semantics. This PR implements that.

## Test Plan

Existing mdtests have been updated to reflect that we no longer issue false-positive diagnostics on classes inheriting from `typing_extensions.Protocol`.
