### PR TITLE
[red-knot] Add `KnownFunction` variants for `is_protocol`, `get_protocol_members` and `runtime_checkable`

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -5896,6 +5896,12 @@ pub enum KnownFunction {
     Cast,
     /// `typing(_extensions).overload`
     Overload,
+    /// `typing(_extensions).is_protocol`
+    IsProtocol,
+    /// `typing(_extensions).get_protocol_members`
+    GetProtocolMembers,
+    /// `typing(_extensions).runtime_checkable`
+    RuntimeCheckable,
 
     /// `abc.abstractmethod`
     #[strum(serialize = "abstractmethod")]
@@ -5957,6 +5963,9 @@ impl KnownFunction {
             | Self::Overload
             | Self::RevealType
             | Self::Final
+            | Self::IsProtocol
+            | Self::GetProtocolMembers
+            | Self::RuntimeCheckable
             | Self::NoTypeCheck => {
                 matches!(module, KnownModule::Typing | KnownModule::TypingExtensions)
             }
@@ -7195,6 +7204,9 @@ pub(crate) mod tests {
                 | KnownFunction::RevealType
                 | KnownFunction::AssertType
                 | KnownFunction::AssertNever
+                | KnownFunction::IsProtocol
+                | KnownFunction::GetProtocolMembers
+                | KnownFunction::RuntimeCheckable
                 | KnownFunction::NoTypeCheck => KnownModule::TypingExtensions,
 
                 KnownFunction::IsSingleton


### PR DESCRIPTION
## Summary

We want to special-case these functions to allow us to introspect red-knot's inference of protocol types (see tests at https://github.com/astral-sh/ruff/blob/main/crates/red_knot_python_semantic/resources/mdtest/protocols.md). Doing this is a necessary precondition for adding the special casing.

## Test Plan

I updated the `known_function_roundtrip_from_str` unit test. This PR doesn't actually add the special casing yet, so no new mdtests for now.
