### PR TITLE
[red-knot] Fix MRO inference for protocol classes; allow inheritance from subscripted `Generic[]`; forbid subclassing unsubscripted `Generic`

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/stdlib_typing_aliases.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/stdlib_typing_aliases.md
@@ -75,8 +75,8 @@ reveal_type(ListSubclass.__mro__)
 
 class DictSubclass(typing.Dict): ...
 
-# TODO: should have `Generic`, should not have `Unknown`
-# revealed: tuple[Literal[DictSubclass], Literal[dict], Unknown, Literal[object]]
+# TODO
+# revealed: tuple[Literal[DictSubclass], Literal[dict], Literal[MutableMapping], Literal[Mapping], Literal[Collection], Literal[Iterable], Literal[Container], @Todo(`Protocol[]` subscript), @Todo(`Generic[]` subscript), Literal[object]]
 reveal_type(DictSubclass.__mro__)
 
 class SetSubclass(typing.Set): ...
@@ -95,8 +95,8 @@ reveal_type(FrozenSetSubclass.__mro__)
 
 class ChainMapSubclass(typing.ChainMap): ...
 
-# TODO: Should be (ChainMapSubclass, ChainMap, MutableMapping, Mapping, Collection, Sized, Iterable, Container, Generic, object)
-# revealed: tuple[Literal[ChainMapSubclass], Literal[ChainMap], Unknown, Literal[object]]
+# TODO
+# revealed: tuple[Literal[ChainMapSubclass], Literal[ChainMap], Literal[MutableMapping], Literal[Mapping], Literal[Collection], Literal[Iterable], Literal[Container], @Todo(`Protocol[]` subscript), @Todo(`Generic[]` subscript), Literal[object]]
 reveal_type(ChainMapSubclass.__mro__)
 
 class CounterSubclass(typing.Counter): ...

--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/stdlib_typing_aliases.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/stdlib_typing_aliases.md
@@ -70,7 +70,7 @@ import typing
 
 class ListSubclass(typing.List): ...
 
-# revealed: tuple[Literal[ListSubclass], Literal[list], Literal[MutableSequence], Literal[Sequence], Literal[Reversible], Literal[Collection], Literal[Iterable], Literal[Container], @Todo(protocol), Literal[object]]
+# revealed: tuple[Literal[ListSubclass], Literal[list], Literal[MutableSequence], Literal[Sequence], Literal[Reversible], Literal[Collection], Literal[Iterable], Literal[Container], @Todo(`Protocol[]` subscript), Literal[object]]
 reveal_type(ListSubclass.__mro__)
 
 class DictSubclass(typing.Dict): ...
@@ -81,7 +81,7 @@ reveal_type(DictSubclass.__mro__)
 
 class SetSubclass(typing.Set): ...
 
-# revealed: tuple[Literal[SetSubclass], Literal[set], Literal[MutableSet], Literal[AbstractSet], Literal[Collection], Literal[Iterable], Literal[Container], @Todo(protocol), Literal[object]]
+# revealed: tuple[Literal[SetSubclass], Literal[set], Literal[MutableSet], Literal[AbstractSet], Literal[Collection], Literal[Iterable], Literal[Container], @Todo(`Protocol[]` subscript), Literal[object]]
 reveal_type(SetSubclass.__mro__)
 
 class FrozenSetSubclass(typing.FrozenSet): ...
@@ -113,7 +113,7 @@ reveal_type(DefaultDictSubclass.__mro__)
 
 class DequeSubclass(typing.Deque): ...
 
-# revealed: tuple[Literal[DequeSubclass], Literal[deque], Literal[MutableSequence], Literal[Sequence], Literal[Reversible], Literal[Collection], Literal[Iterable], Literal[Container], @Todo(protocol), Literal[object]]
+# revealed: tuple[Literal[DequeSubclass], Literal[deque], Literal[MutableSequence], Literal[Sequence], Literal[Reversible], Literal[Collection], Literal[Iterable], Literal[Container], @Todo(`Protocol[]` subscript), Literal[object]]
 reveal_type(DequeSubclass.__mro__)
 
 class OrderedDictSubclass(typing.OrderedDict): ...

--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/stdlib_typing_aliases.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/stdlib_typing_aliases.md
@@ -67,21 +67,24 @@ import typing
 
 ####################
 ### Built-ins
+####################
 
 class ListSubclass(typing.List): ...
 
-# revealed: tuple[Literal[ListSubclass], Literal[list], Literal[MutableSequence], Literal[Sequence], Literal[Reversible], Literal[Collection], Literal[Iterable], Literal[Container], @Todo(`Protocol[]` subscript), Literal[object]]
+# TODO: generic protocols
+# revealed: tuple[Literal[ListSubclass], Literal[list], Literal[MutableSequence], Literal[Sequence], Literal[Reversible], Literal[Collection], Literal[Iterable], Literal[Container], @Todo(`Protocol[]` subscript), @Todo(`Generic[]` subscript), Literal[object]]
 reveal_type(ListSubclass.__mro__)
 
 class DictSubclass(typing.Dict): ...
 
-# TODO
+# TODO: generic protocols
 # revealed: tuple[Literal[DictSubclass], Literal[dict], Literal[MutableMapping], Literal[Mapping], Literal[Collection], Literal[Iterable], Literal[Container], @Todo(`Protocol[]` subscript), @Todo(`Generic[]` subscript), Literal[object]]
 reveal_type(DictSubclass.__mro__)
 
 class SetSubclass(typing.Set): ...
 
-# revealed: tuple[Literal[SetSubclass], Literal[set], Literal[MutableSet], Literal[AbstractSet], Literal[Collection], Literal[Iterable], Literal[Container], @Todo(`Protocol[]` subscript), Literal[object]]
+# TODO: generic protocols
+# revealed: tuple[Literal[SetSubclass], Literal[set], Literal[MutableSet], Literal[AbstractSet], Literal[Collection], Literal[Iterable], Literal[Container], @Todo(`Protocol[]` subscript), @Todo(`Generic[]` subscript), Literal[object]]
 reveal_type(SetSubclass.__mro__)
 
 class FrozenSetSubclass(typing.FrozenSet): ...
@@ -92,10 +95,11 @@ reveal_type(FrozenSetSubclass.__mro__)
 
 ####################
 ### `collections`
+####################
 
 class ChainMapSubclass(typing.ChainMap): ...
 
-# TODO
+# TODO: generic protocols
 # revealed: tuple[Literal[ChainMapSubclass], Literal[ChainMap], Literal[MutableMapping], Literal[Mapping], Literal[Collection], Literal[Iterable], Literal[Container], @Todo(`Protocol[]` subscript), @Todo(`Generic[]` subscript), Literal[object]]
 reveal_type(ChainMapSubclass.__mro__)
 
@@ -113,7 +117,8 @@ reveal_type(DefaultDictSubclass.__mro__)
 
 class DequeSubclass(typing.Deque): ...
 
-# revealed: tuple[Literal[DequeSubclass], Literal[deque], Literal[MutableSequence], Literal[Sequence], Literal[Reversible], Literal[Collection], Literal[Iterable], Literal[Container], @Todo(`Protocol[]` subscript), Literal[object]]
+# TODO: generic protocols
+# revealed: tuple[Literal[DequeSubclass], Literal[deque], Literal[MutableSequence], Literal[Sequence], Literal[Reversible], Literal[Collection], Literal[Iterable], Literal[Container], @Todo(`Protocol[]` subscript), @Todo(`Generic[]` subscript), Literal[object]]
 reveal_type(DequeSubclass.__mro__)
 
 class OrderedDictSubclass(typing.OrderedDict): ...

--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/unsupported_special_forms.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/unsupported_special_forms.md
@@ -74,7 +74,7 @@ class C(TypeGuard): ...  # error: [invalid-base]
 class D(TypeIs): ...  # error: [invalid-base]
 class E(Concatenate): ...  # error: [invalid-base]
 class F(Callable): ...
-class G(Generic): ...  # TODO should emit an error here
+class G(Generic): ...  # error: [invalid-base] "Cannot inherit from plain `Generic`"
 
 reveal_type(F.__mro__)  # revealed: tuple[Literal[F], @Todo(Support for Callable as a base class), Literal[object]]
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/unsupported_special_forms.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/unsupported_special_forms.md
@@ -49,7 +49,7 @@ def _(
     c: TypeIs,  # error: [invalid-type-form] "`typing.TypeIs` requires exactly one argument when used in a type expression"
     d: Concatenate,  # error: [invalid-type-form] "`typing.Concatenate` requires at least two arguments when used in a type expression"
     e: ParamSpec,
-    f: Generic  # error: [invalid-type-form] "`typing.Generic` is not allowed in type expressions"
+    f: Generic,  # error: [invalid-type-form] "`typing.Generic` is not allowed in type expressions"
 ) -> None:
     reveal_type(a)  # revealed: Unknown
     reveal_type(b)  # revealed: Unknown

--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/unsupported_special_forms.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/unsupported_special_forms.md
@@ -41,7 +41,7 @@ class Foo:
 One thing that is supported is error messages for using special forms in type expressions.
 
 ```py
-from typing_extensions import Unpack, TypeGuard, TypeIs, Concatenate, ParamSpec
+from typing_extensions import Unpack, TypeGuard, TypeIs, Concatenate, ParamSpec, Generic
 
 def _(
     a: Unpack,  # error: [invalid-type-form] "`typing.Unpack` requires exactly one argument when used in a type expression"
@@ -49,6 +49,7 @@ def _(
     c: TypeIs,  # error: [invalid-type-form] "`typing.TypeIs` requires exactly one argument when used in a type expression"
     d: Concatenate,  # error: [invalid-type-form] "`typing.Concatenate` requires at least two arguments when used in a type expression"
     e: ParamSpec,
+    f: Generic  # error: [invalid-type-form] "`typing.Generic` is not allowed in type expressions"
 ) -> None:
     reveal_type(a)  # revealed: Unknown
     reveal_type(b)  # revealed: Unknown
@@ -65,7 +66,7 @@ You can't inherit from most of these. `typing.Callable` is an exception.
 
 ```py
 from typing import Callable
-from typing_extensions import Self, Unpack, TypeGuard, TypeIs, Concatenate
+from typing_extensions import Self, Unpack, TypeGuard, TypeIs, Concatenate, Generic
 
 class A(Self): ...  # error: [invalid-base]
 class B(Unpack): ...  # error: [invalid-base]
@@ -73,6 +74,7 @@ class C(TypeGuard): ...  # error: [invalid-base]
 class D(TypeIs): ...  # error: [invalid-base]
 class E(Concatenate): ...  # error: [invalid-base]
 class F(Callable): ...
+class G(Generic): ...  # TODO should emit an error here
 
 reveal_type(F.__mro__)  # revealed: tuple[Literal[F], @Todo(Support for Callable as a base class), Literal[object]]
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/generics/classes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/generics/classes.md
@@ -51,8 +51,7 @@ class C(Generic[T]): ...
 A class that inherits from a generic class, and fills its type parameters with typevars, is generic.
 
 ```py
-# TODO: no error
-class D(C[T]): ...  # error: [non-subscriptable]
+class D(C[T]): ...
 ```
 
 (Examples `E` and `F` from above do not have analogues in the legacy syntax.)

--- a/crates/red_knot_python_semantic/resources/mdtest/generics/classes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/generics/classes.md
@@ -45,15 +45,14 @@ from typing import Generic, TypeVar
 
 T = TypeVar("T")
 
-# TODO: no error
-# error: [invalid-base]
 class C(Generic[T]): ...
 ```
 
 A class that inherits from a generic class, and fills its type parameters with typevars, is generic.
 
 ```py
-class D(C[T]): ...
+# TODO: no error
+class D(C[T]): ...  # error: [non-subscriptable]
 ```
 
 (Examples `E` and `F` from above do not have analogues in the legacy syntax.)

--- a/crates/red_knot_python_semantic/resources/mdtest/generics/scoping.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/generics/scoping.md
@@ -137,8 +137,6 @@ from typing import TypeVar, Generic
 T = TypeVar("T")
 S = TypeVar("S")
 
-# TODO: no error
-# error: [invalid-base]
 class Legacy(Generic[T]):
     def m(self, x: T, y: S) -> S:
         return y
@@ -177,8 +175,6 @@ def f(x: T) -> None:
     # TODO: error
     y: list[S] = []
 
-# TODO: no error
-# error: [invalid-base]
 class C(Generic[T]):
     # TODO: error
     x: list[S] = []

--- a/crates/red_knot_python_semantic/resources/mdtest/generics/scoping.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/generics/scoping.md
@@ -255,8 +255,7 @@ def f[T](x: T, y: T) -> None:
     class Ok[S]: ...
     # TODO: error for reuse of typevar
     class Bad1[T]: ...
-    # TODO: no non-subscriptable error, error for reuse of typevar
-    # error: [non-subscriptable]
+    # TODO: error for reuse of typevar
     class Bad2(Iterable[T]): ...
 ```
 
@@ -269,8 +268,7 @@ class C[T]:
     class Ok1[S]: ...
     # TODO: error for reuse of typevar
     class Bad1[T]: ...
-    # TODO: no non-subscriptable error, error for reuse of typevar
-    # error: [non-subscriptable]
+    # TODO: error for reuse of typevar
     class Bad2(Iterable[T]): ...
 ```
 

--- a/crates/red_knot_python_semantic/resources/mdtest/protocols.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/protocols.md
@@ -132,8 +132,7 @@ class Fine(Protocol, object): ...
 
 reveal_type(Fine.__mro__)  # revealed: tuple[Literal[Fine], typing.Protocol, typing.Generic, Literal[object]]
 
-# TODO: should not error
-class StillFine(Protocol, Generic[T], object): ...  # error: [invalid-base]
+class StillFine(Protocol, Generic[T], object): ...
 class EvenThis[T](Protocol, object): ...
 ```
 

--- a/crates/red_knot_python_semantic/resources/mdtest/protocols.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/protocols.md
@@ -28,8 +28,7 @@ from typing import Protocol
 
 class MyProtocol(Protocol): ...
 
-# TODO: at runtime this is `(<class '__main__.MyProtocol'>, <class 'typing.Protocol'>, <class 'typing.Generic'>, <class 'object'>)`
-reveal_type(MyProtocol.__mro__)  # revealed: tuple[Literal[MyProtocol], @Todo(protocol), Literal[object]]
+reveal_type(MyProtocol.__mro__)  # revealed: tuple[Literal[MyProtocol], typing.Protocol, typing.Generic, Literal[object]]
 ```
 
 Just like for any other class base, it is an error for `Protocol` to appear multiple times in a
@@ -72,8 +71,7 @@ it is not sufficient for it to have `Protocol` in its MRO.
 ```py
 class SubclassOfMyProtocol(MyProtocol): ...
 
-# TODO
-# revealed: tuple[Literal[SubclassOfMyProtocol], Literal[MyProtocol], @Todo(protocol), Literal[object]]
+# revealed: tuple[Literal[SubclassOfMyProtocol], Literal[MyProtocol], typing.Protocol, typing.Generic, Literal[object]]
 reveal_type(SubclassOfMyProtocol.__mro__)
 
 # TODO: should be `Literal[False]`
@@ -94,8 +92,7 @@ class OtherProtocol(Protocol):
 
 class ComplexInheritance(SubProtocol, OtherProtocol, Protocol): ...
 
-# TODO
-# revealed: tuple[Literal[ComplexInheritance], Literal[SubProtocol], Literal[MyProtocol], Literal[OtherProtocol], @Todo(protocol), Literal[object]]
+# revealed: tuple[Literal[ComplexInheritance], Literal[SubProtocol], Literal[MyProtocol], Literal[OtherProtocol], typing.Protocol, typing.Generic, Literal[object]]
 reveal_type(ComplexInheritance.__mro__)
 
 # TODO: should be `Literal[True]`
@@ -109,15 +106,13 @@ or `TypeError` is raised at runtime when the class is created.
 # TODO: should emit `[invalid-protocol]`
 class Invalid(NotAProtocol, Protocol): ...
 
-# TODO
-# revealed: tuple[Literal[Invalid], Literal[NotAProtocol], @Todo(protocol), Literal[object]]
+# revealed: tuple[Literal[Invalid], Literal[NotAProtocol], typing.Protocol, typing.Generic, Literal[object]]
 reveal_type(Invalid.__mro__)
 
 # TODO: should emit an `[invalid-protocol`] error
 class AlsoInvalid(MyProtocol, OtherProtocol, NotAProtocol, Protocol): ...
 
-# TODO
-# revealed: tuple[Literal[AlsoInvalid], Literal[MyProtocol], Literal[OtherProtocol], Literal[NotAProtocol], @Todo(protocol), Literal[object]]
+# revealed: tuple[Literal[AlsoInvalid], Literal[MyProtocol], Literal[OtherProtocol], Literal[NotAProtocol], typing.Protocol, typing.Generic, Literal[object]]
 reveal_type(AlsoInvalid.__mro__)
 ```
 
@@ -135,8 +130,7 @@ T = TypeVar("T")
 # type checkers.
 class Fine(Protocol, object): ...
 
-# TODO
-reveal_type(Fine.__mro__)  # revealed: tuple[Literal[Fine], @Todo(protocol), Literal[object]]
+reveal_type(Fine.__mro__)  # revealed: tuple[Literal[Fine], typing.Protocol, typing.Generic, Literal[object]]
 
 # TODO: should not error
 class StillFine(Protocol, Generic[T], object): ...  # error: [invalid-base]
@@ -149,8 +143,7 @@ And multiple inheritance from a mix of protocol and non-protocol classes is fine
 ```py
 class FineAndDandy(MyProtocol, OtherProtocol, NotAProtocol): ...
 
-# TODO
-# revealed: tuple[Literal[FineAndDandy], Literal[MyProtocol], Literal[OtherProtocol], @Todo(protocol), Literal[NotAProtocol], Literal[object]]
+# revealed: tuple[Literal[FineAndDandy], Literal[MyProtocol], Literal[OtherProtocol], typing.Protocol, typing.Generic, Literal[NotAProtocol], Literal[object]]
 reveal_type(FineAndDandy.__mro__)
 ```
 

--- a/crates/red_knot_python_semantic/resources/mdtest/subscript/tuple.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/subscript/tuple.md
@@ -117,6 +117,6 @@ from typing import Tuple
 
 class C(Tuple): ...
 
-# revealed: tuple[Literal[C], Literal[tuple], Literal[Sequence], Literal[Reversible], Literal[Collection], Literal[Iterable], Literal[Container], @Todo(protocol), Literal[object]]
+# revealed: tuple[Literal[C], Literal[tuple], Literal[Sequence], Literal[Reversible], Literal[Collection], Literal[Iterable], Literal[Container], @Todo(`Protocol[]` subscript), Literal[object]]
 reveal_type(C.__mro__)
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/subscript/tuple.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/subscript/tuple.md
@@ -117,6 +117,7 @@ from typing import Tuple
 
 class C(Tuple): ...
 
-# revealed: tuple[Literal[C], Literal[tuple], Literal[Sequence], Literal[Reversible], Literal[Collection], Literal[Iterable], Literal[Container], @Todo(`Protocol[]` subscript), Literal[object]]
+# TODO: generic protocols
+# revealed: tuple[Literal[C], Literal[tuple], Literal[Sequence], Literal[Reversible], Literal[Collection], Literal[Iterable], Literal[Container], @Todo(`Protocol[]` subscript), @Todo(`Generic[]` subscript), Literal[object]]
 reveal_type(C.__mro__)
 ```

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1,5 +1,4 @@
 use itertools::Either;
-use subclass_of::SubclassOfInner;
 
 use std::slice::Iter;
 use std::str::FromStr;
@@ -27,7 +26,7 @@ pub(crate) use self::infer::{
 };
 pub(crate) use self::narrow::KnownConstraintFunction;
 pub(crate) use self::signatures::{CallableSignature, Signature, Signatures};
-pub(crate) use self::subclass_of::SubclassOfType;
+pub(crate) use self::subclass_of::{SubclassOfInner, SubclassOfType};
 use crate::module_name::ModuleName;
 use crate::module_resolver::{file_to_module, resolve_module, KnownModule};
 use crate::semantic_index::ast_ids::HasScopedExpressionId;

--- a/crates/red_knot_python_semantic/src/types/class.rs
+++ b/crates/red_knot_python_semantic/src/types/class.rs
@@ -246,7 +246,7 @@ impl<'db> ClassType<'db> {
     /// cases rather than simply iterating over the inferred resolution order for the class.
     ///
     /// [method resolution order]: https://docs.python.org/3/glossary.html#term-method-resolution-order
-    pub(super) fn iter_mro(self, db: &'db dyn Db) -> impl Iterator<Item = ClassBase<'db>> {
+    pub(super) fn iter_mro(self, db: &'db dyn Db) -> MroIterator<'db> {
         let (class_literal, specialization) = self.class_literal(db);
         class_literal.iter_mro(db, specialization)
     }
@@ -549,7 +549,7 @@ impl<'db> ClassLiteralType<'db> {
         self,
         db: &'db dyn Db,
         specialization: Option<Specialization<'db>>,
-    ) -> impl Iterator<Item = ClassBase<'db>> {
+    ) -> MroIterator<'db> {
         MroIterator::new(db, self, specialization)
     }
 

--- a/crates/red_knot_python_semantic/src/types/class.rs
+++ b/crates/red_knot_python_semantic/src/types/class.rs
@@ -2505,6 +2505,7 @@ impl<'db> KnownInstanceType<'db> {
             "Counter" => Self::Counter,
             "ChainMap" => Self::ChainMap,
             "OrderedDict" => Self::OrderedDict,
+            "Generic" => Self::Generic,
             "Protocol" => Self::Protocol,
             "Optional" => Self::Optional,
             "Union" => Self::Union,

--- a/crates/red_knot_python_semantic/src/types/class_base.rs
+++ b/crates/red_knot_python_semantic/src/types/class_base.rs
@@ -25,13 +25,6 @@ impl<'db> ClassBase<'db> {
         Self::Dynamic(DynamicType::Unknown)
     }
 
-    pub(crate) const fn is_dynamic(self) -> bool {
-        match self {
-            ClassBase::Dynamic(_) => true,
-            ClassBase::Class(_) => false,
-        }
-    }
-
     pub(crate) fn display(self, db: &'db dyn Db) -> impl std::fmt::Display + 'db {
         struct Display<'db> {
             base: ClassBase<'db>,

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -7,7 +7,6 @@ use ruff_python_ast::str::{Quote, TripleQuotes};
 use ruff_python_literal::escape::AsciiEscape;
 
 use crate::types::class::{ClassType, GenericAlias, GenericClass};
-use crate::types::class_base::ClassBase;
 use crate::types::generics::{GenericContext, Specialization};
 use crate::types::signatures::{Parameter, Parameters, Signature};
 use crate::types::{
@@ -16,6 +15,8 @@ use crate::types::{
 };
 use crate::Db;
 use rustc_hash::FxHashMap;
+
+use super::subclass_of::SubclassOfInner;
 
 impl<'db> Type<'db> {
     pub fn display(&self, db: &'db dyn Db) -> DisplayType {
@@ -89,8 +90,8 @@ impl Display for DisplayRepresentation<'_> {
             Type::SubclassOf(subclass_of_ty) => match subclass_of_ty.subclass_of() {
                 // Only show the bare class name here; ClassBase::display would render this as
                 // type[<class 'Foo'>] instead of type[Foo].
-                ClassBase::Class(class) => write!(f, "type[{}]", class.name(self.db)),
-                ClassBase::Dynamic(dynamic) => write!(f, "type[{dynamic}]"),
+                SubclassOfInner::Class(class) => write!(f, "type[{}]", class.name(self.db)),
+                SubclassOfInner::Dynamic(dynamic) => write!(f, "type[{dynamic}]"),
             },
             Type::KnownInstance(known_instance) => f.write_str(known_instance.repr(self.db)),
             Type::FunctionLiteral(function) => {

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -10,13 +10,12 @@ use crate::types::class::{ClassType, GenericAlias, GenericClass};
 use crate::types::generics::{GenericContext, Specialization};
 use crate::types::signatures::{Parameter, Parameters, Signature};
 use crate::types::{
-    InstanceType, IntersectionType, KnownClass, MethodWrapperKind, StringLiteralType, Type,
-    TypeVarBoundOrConstraints, TypeVarInstance, UnionType, WrapperDescriptorKind,
+    InstanceType, IntersectionType, KnownClass, MethodWrapperKind, StringLiteralType,
+    SubclassOfInner, Type, TypeVarBoundOrConstraints, TypeVarInstance, UnionType,
+    WrapperDescriptorKind,
 };
 use crate::Db;
 use rustc_hash::FxHashMap;
-
-use super::subclass_of::SubclassOfInner;
 
 impl<'db> Type<'db> {
     pub fn display(&self, db: &'db dyn Db) -> DisplayType {

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -94,7 +94,6 @@ use crate::unpack::{Unpack, UnpackPosition};
 use crate::util::subscript::{PyIndex, PySlice};
 use crate::Db;
 
-use super::class_base::ClassBase;
 use super::context::{InNoTypeCheck, InferContext};
 use super::diagnostic::{
     report_index_out_of_bounds, report_invalid_exception_caught, report_invalid_exception_cause,
@@ -107,6 +106,7 @@ use super::slots::check_class_slots;
 use super::string_annotation::{
     parse_string_annotation, BYTE_STRING_TYPE_ANNOTATION, FSTRING_TYPE_ANNOTATION,
 };
+use super::subclass_of::SubclassOfInner;
 use super::{BoundSuperError, BoundSuperType};
 
 /// Infer all types for a [`ScopeId`], including all definitions and expressions in that scope.
@@ -4738,10 +4738,10 @@ impl<'db> TypeInferenceBuilder<'db> {
                             }
                             Type::SubclassOf(subclass_of @ SubclassOfType { .. }) => {
                                 match subclass_of.subclass_of() {
-                                    ClassBase::Class(class) => {
+                                    SubclassOfInner::Class(class) => {
                                         !class.instance_member(db, attr).symbol.is_unbound()
                                     }
-                                    ClassBase::Dynamic(_) => unreachable!(
+                                    SubclassOfInner::Dynamic(_) => unreachable!(
                                         "Attribute lookup on a dynamic `SubclassOf` type should always return a bound symbol"
                                     ),
                                 }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -4983,8 +4983,10 @@ impl<'db> TypeInferenceBuilder<'db> {
             | (_, unknown @ Type::Dynamic(DynamicType::Unknown), _) => Some(unknown),
             (todo @ Type::Dynamic(DynamicType::Todo(_)), _, _)
             | (_, todo @ Type::Dynamic(DynamicType::Todo(_)), _) => Some(todo),
-            (todo @ Type::Dynamic(DynamicType::TodoProtocol), _, _)
-            | (_, todo @ Type::Dynamic(DynamicType::TodoProtocol), _) => Some(todo),
+            (todo @ Type::Dynamic(DynamicType::SubscriptedProtocol), _, _)
+            | (_, todo @ Type::Dynamic(DynamicType::SubscriptedProtocol), _) => Some(todo),
+            (todo @ Type::Dynamic(DynamicType::SubscriptedGeneric), _, _)
+            | (_, todo @ Type::Dynamic(DynamicType::SubscriptedGeneric), _) => Some(todo),
             (Type::Never, _, _) | (_, Type::Never, _) => Some(Type::Never),
 
             (Type::IntLiteral(n), Type::IntLiteral(m), ast::Operator::Add) => Some(
@@ -6231,7 +6233,10 @@ impl<'db> TypeInferenceBuilder<'db> {
                 Type::IntLiteral(i64::from(bool)),
             ),
             (Type::KnownInstance(KnownInstanceType::Protocol), _) => {
-                Type::Dynamic(DynamicType::TodoProtocol)
+                Type::Dynamic(DynamicType::SubscriptedProtocol)
+            }
+            (Type::KnownInstance(KnownInstanceType::Generic), _) => {
+                Type::Dynamic(DynamicType::SubscriptedGeneric)
             }
             (Type::KnownInstance(known_instance), _)
                 if known_instance.class().is_special_form() =>
@@ -7489,7 +7494,11 @@ impl<'db> TypeInferenceBuilder<'db> {
             }
             KnownInstanceType::Protocol => {
                 self.infer_type_expression(arguments_slice);
-                Type::Dynamic(DynamicType::TodoProtocol)
+                Type::Dynamic(DynamicType::SubscriptedProtocol)
+            }
+            KnownInstanceType::Generic => {
+                self.infer_type_expression(arguments_slice);
+                Type::Dynamic(DynamicType::SubscriptedGeneric)
             }
             KnownInstanceType::NoReturn
             | KnownInstanceType::Never

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -6360,7 +6360,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                     if !value_ty.into_class_literal().is_some_and(|class| {
                         class
                             .iter_mro(self.db(), None)
-                            .any(|base| base == ClassBase::Dynamic(DynamicType::SubscriptedGeneric))
+                            .contains(&ClassBase::Dynamic(DynamicType::SubscriptedGeneric))
                     }) {
                         report_non_subscriptable(
                             &self.context,

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -777,8 +777,8 @@ impl<'db> TypeInferenceBuilder<'db> {
                         );
                         continue;
                     }
-                    // dynamic/unknown bases are never `@final`
                     Type::ClassLiteral(class) => class,
+                    // dynamic/unknown bases are never `@final`
                     _ => continue,
                 };
 
@@ -6358,15 +6358,9 @@ impl<'db> TypeInferenceBuilder<'db> {
 
                     // TODO: properly handle old-style generics; get rid of this temporary hack
                     if !value_ty.into_class_literal().is_some_and(|class| {
-                        class.iter_mro(self.db(), None).any(|base| {
-                            matches!(
-                                base,
-                                ClassBase::Dynamic(
-                                    DynamicType::SubscriptedGeneric
-                                        | DynamicType::SubscriptedProtocol,
-                                )
-                            )
-                        })
+                        class
+                            .iter_mro(self.db(), None)
+                            .any(|base| base == ClassBase::Dynamic(DynamicType::SubscriptedGeneric))
                     }) {
                         report_non_subscriptable(
                             &self.context,

--- a/crates/red_knot_python_semantic/src/types/subclass_of.rs
+++ b/crates/red_knot_python_semantic/src/types/subclass_of.rs
@@ -102,6 +102,20 @@ impl<'db> SubclassOfType<'db> {
     }
 }
 
+/// An enumeration of the different kinds of `type[]` types that a [`SubclassOfType`] can represent:
+///
+/// 1. A "subclass of a class": `type[C]` for any class object `C`
+/// 2. A "subclass of a dynamic type": `type[Any]`, `type[Unknown]` and `type[@Todo]`
+///
+/// In the long term, we may want to implement <https://github.com/astral-sh/ruff/issues/15381>.
+/// Doing this would allow us to get rid of this enum,
+/// since `type[Any]` would be represented as `type & Any`
+/// rather than using the [`Type::SubclassOf`] variant at all;
+/// [`SubclassOfType`] would then be a simple wrapper around [`ClassType`].
+///
+/// Note that this enum is similar to the [`super::ClassBase`] enum,
+/// but does not include the `ClassBase::Protocol` and `ClassBase::Generic` variants
+/// (`type[Protocol]` and `type[Generic]` are not valid types).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, salsa::Update)]
 pub(crate) enum SubclassOfInner<'db> {
     Class(ClassType<'db>),

--- a/crates/red_knot_python_semantic/src/types/subclass_of.rs
+++ b/crates/red_knot_python_semantic/src/types/subclass_of.rs
@@ -51,7 +51,7 @@ impl<'db> SubclassOfType<'db> {
         })
     }
 
-    /// Return the inner [`ClassBase`] value wrapped by this `SubclassOfType`.
+    /// Return the inner [`SubclassOfInner`] value wrapped by this `SubclassOfType`.
     pub(crate) const fn subclass_of(self) -> SubclassOfInner<'db> {
         self.subclass_of
     }
@@ -77,7 +77,7 @@ impl<'db> SubclassOfType<'db> {
 
     /// Return `true` if `self` is a subtype of `other`.
     ///
-    /// This can only return `true` if `self.subclass_of` is a [`ClassBase::Class`] variant;
+    /// This can only return `true` if `self.subclass_of` is a [`SubclassOfInner::Class`] variant;
     /// only fully static types participate in subtyping.
     pub(crate) fn is_subtype_of(self, db: &'db dyn Db, other: SubclassOfType<'db>) -> bool {
         match (self.subclass_of, other.subclass_of) {

--- a/crates/red_knot_python_semantic/src/types/subclass_of.rs
+++ b/crates/red_knot_python_semantic/src/types/subclass_of.rs
@@ -1,12 +1,12 @@
 use crate::symbol::SymbolAndQualifiers;
 
-use super::{ClassBase, Db, KnownClass, MemberLookupPolicy, Type};
+use super::{ClassType, Db, DynamicType, KnownClass, MemberLookupPolicy, Type};
 
 /// A type that represents `type[C]`, i.e. the class object `C` and class objects that are subclasses of `C`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, salsa::Update)]
 pub struct SubclassOfType<'db> {
     // Keep this field private, so that the only way of constructing the struct is through the `from` method.
-    subclass_of: ClassBase<'db>,
+    subclass_of: SubclassOfInner<'db>,
 }
 
 impl<'db> SubclassOfType<'db> {
@@ -21,11 +21,11 @@ impl<'db> SubclassOfType<'db> {
     ///
     /// The eager normalization here means that we do not need to worry elsewhere about distinguishing
     /// between `@final` classes and other classes when dealing with [`Type::SubclassOf`] variants.
-    pub(crate) fn from(db: &'db dyn Db, subclass_of: impl Into<ClassBase<'db>>) -> Type<'db> {
+    pub(crate) fn from(db: &'db dyn Db, subclass_of: impl Into<SubclassOfInner<'db>>) -> Type<'db> {
         let subclass_of = subclass_of.into();
         match subclass_of {
-            ClassBase::Dynamic(_) => Type::SubclassOf(Self { subclass_of }),
-            ClassBase::Class(class) => {
+            SubclassOfInner::Dynamic(_) => Type::SubclassOf(Self { subclass_of }),
+            SubclassOfInner::Class(class) => {
                 if class.is_final(db) {
                     Type::from(class)
                 } else if class.is_object(db) {
@@ -40,19 +40,19 @@ impl<'db> SubclassOfType<'db> {
     /// Return a [`Type`] instance representing the type `type[Unknown]`.
     pub(crate) const fn subclass_of_unknown() -> Type<'db> {
         Type::SubclassOf(SubclassOfType {
-            subclass_of: ClassBase::unknown(),
+            subclass_of: SubclassOfInner::unknown(),
         })
     }
 
     /// Return a [`Type`] instance representing the type `type[Any]`.
     pub(crate) const fn subclass_of_any() -> Type<'db> {
         Type::SubclassOf(SubclassOfType {
-            subclass_of: ClassBase::any(),
+            subclass_of: SubclassOfInner::Dynamic(DynamicType::Any),
         })
     }
 
     /// Return the inner [`ClassBase`] value wrapped by this `SubclassOfType`.
-    pub(crate) const fn subclass_of(self) -> ClassBase<'db> {
+    pub(crate) const fn subclass_of(self) -> SubclassOfInner<'db> {
         self.subclass_of
     }
 
@@ -82,12 +82,12 @@ impl<'db> SubclassOfType<'db> {
     pub(crate) fn is_subtype_of(self, db: &'db dyn Db, other: SubclassOfType<'db>) -> bool {
         match (self.subclass_of, other.subclass_of) {
             // Non-fully-static types do not participate in subtyping
-            (ClassBase::Dynamic(_), _) | (_, ClassBase::Dynamic(_)) => false,
+            (SubclassOfInner::Dynamic(_), _) | (_, SubclassOfInner::Dynamic(_)) => false,
 
             // For example, `type[bool]` describes all possible runtime subclasses of the class `bool`,
             // and `type[int]` describes all possible runtime subclasses of the class `int`.
             // The first set is a subset of the second set, because `bool` is itself a subclass of `int`.
-            (ClassBase::Class(self_class), ClassBase::Class(other_class)) => {
+            (SubclassOfInner::Class(self_class), SubclassOfInner::Class(other_class)) => {
                 // N.B. The subclass relation is fully static
                 self_class.is_subclass_of(db, other_class)
             }
@@ -96,8 +96,59 @@ impl<'db> SubclassOfType<'db> {
 
     pub(crate) fn to_instance(self) -> Type<'db> {
         match self.subclass_of {
-            ClassBase::Class(class) => Type::instance(class),
-            ClassBase::Dynamic(dynamic_type) => Type::Dynamic(dynamic_type),
+            SubclassOfInner::Class(class) => Type::instance(class),
+            SubclassOfInner::Dynamic(dynamic_type) => Type::Dynamic(dynamic_type),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, salsa::Update)]
+pub(crate) enum SubclassOfInner<'db> {
+    Class(ClassType<'db>),
+    Dynamic(DynamicType),
+}
+
+impl<'db> SubclassOfInner<'db> {
+    pub(crate) const fn unknown() -> Self {
+        Self::Dynamic(DynamicType::Unknown)
+    }
+
+    pub(crate) const fn is_dynamic(self) -> bool {
+        matches!(self, Self::Dynamic(_))
+    }
+
+    pub(crate) const fn into_class(self) -> Option<ClassType<'db>> {
+        match self {
+            Self::Class(class) => Some(class),
+            Self::Dynamic(_) => None,
+        }
+    }
+
+    pub(crate) fn try_from_type(db: &'db dyn Db, ty: Type<'db>) -> Option<Self> {
+        match ty {
+            Type::Dynamic(dynamic) => Some(Self::Dynamic(dynamic)),
+            Type::ClassLiteral(literal) => Some(if literal.is_known(db, KnownClass::Any) {
+                Self::Dynamic(DynamicType::Any)
+            } else {
+                Self::Class(literal.default_specialization(db))
+            }),
+            Type::GenericAlias(generic) => Some(Self::Class(ClassType::Generic(generic))),
+            _ => None,
+        }
+    }
+}
+
+impl<'db> From<ClassType<'db>> for SubclassOfInner<'db> {
+    fn from(value: ClassType<'db>) -> Self {
+        SubclassOfInner::Class(value)
+    }
+}
+
+impl<'db> From<SubclassOfInner<'db>> for Type<'db> {
+    fn from(value: SubclassOfInner<'db>) -> Self {
+        match value {
+            SubclassOfInner::Dynamic(dynamic) => Type::Dynamic(dynamic),
+            SubclassOfInner::Class(class) => class.into(),
         }
     }
 }

--- a/crates/red_knot_python_semantic/src/types/type_ordering.rs
+++ b/crates/red_knot_python_semantic/src/types/type_ordering.rs
@@ -3,7 +3,8 @@ use std::cmp::Ordering;
 use crate::db::Db;
 
 use super::{
-    class_base::ClassBase, subclass_of::SubclassOfInner, DynamicType, InstanceType, KnownInstanceType, SuperOwnerKind, TodoType, Type
+    class_base::ClassBase, subclass_of::SubclassOfInner, DynamicType, InstanceType,
+    KnownInstanceType, SuperOwnerKind, TodoType, Type,
 };
 
 /// Return an [`Ordering`] that describes the canonical order in which two types should appear
@@ -142,6 +143,10 @@ pub(super) fn union_or_intersection_elements_ordering<'db>(
                 (ClassBase::Class(left), ClassBase::Class(right)) => left.cmp(right),
                 (ClassBase::Class(_), _) => Ordering::Less,
                 (_, ClassBase::Class(_)) => Ordering::Greater,
+                (ClassBase::Protocol, _) => Ordering::Less,
+                (_, ClassBase::Protocol) => Ordering::Greater,
+                (ClassBase::Generic, _) => Ordering::Less,
+                (_, ClassBase::Generic) => Ordering::Greater,
                 (ClassBase::Dynamic(left), ClassBase::Dynamic(right)) => {
                     dynamic_elements_ordering(*left, *right)
                 }
@@ -228,6 +233,9 @@ pub(super) fn union_or_intersection_elements_ordering<'db>(
 
                 (KnownInstanceType::OrderedDict, _) => Ordering::Less,
                 (_, KnownInstanceType::OrderedDict) => Ordering::Greater,
+
+                (KnownInstanceType::Generic, _) => Ordering::Less,
+                (_, KnownInstanceType::Generic) => Ordering::Greater,
 
                 (KnownInstanceType::Protocol, _) => Ordering::Less,
                 (_, KnownInstanceType::Protocol) => Ordering::Greater,
@@ -363,7 +371,10 @@ fn dynamic_elements_ordering(left: DynamicType, right: DynamicType) -> Ordering 
         #[cfg(not(debug_assertions))]
         (DynamicType::Todo(TodoType), DynamicType::Todo(TodoType)) => Ordering::Equal,
 
-        (DynamicType::TodoProtocol, _) => Ordering::Less,
-        (_, DynamicType::TodoProtocol) => Ordering::Greater,
+        (DynamicType::SubscriptedGeneric, _) => Ordering::Less,
+        (_, DynamicType::SubscriptedGeneric) => Ordering::Greater,
+
+        (DynamicType::SubscriptedProtocol, _) => Ordering::Less,
+        (_, DynamicType::SubscriptedProtocol) => Ordering::Greater,
     }
 }

--- a/crates/red_knot_python_semantic/src/types/type_ordering.rs
+++ b/crates/red_knot_python_semantic/src/types/type_ordering.rs
@@ -3,8 +3,7 @@ use std::cmp::Ordering;
 use crate::db::Db;
 
 use super::{
-    class_base::ClassBase, DynamicType, InstanceType, KnownInstanceType, SuperOwnerKind, TodoType,
-    Type,
+    class_base::ClassBase, subclass_of::SubclassOfInner, DynamicType, InstanceType, KnownInstanceType, SuperOwnerKind, TodoType, Type
 };
 
 /// Return an [`Ordering`] that describes the canonical order in which two types should appear
@@ -109,10 +108,10 @@ pub(super) fn union_or_intersection_elements_ordering<'db>(
 
         (Type::SubclassOf(left), Type::SubclassOf(right)) => {
             match (left.subclass_of(), right.subclass_of()) {
-                (ClassBase::Class(left), ClassBase::Class(right)) => left.cmp(&right),
-                (ClassBase::Class(_), _) => Ordering::Less,
-                (_, ClassBase::Class(_)) => Ordering::Greater,
-                (ClassBase::Dynamic(left), ClassBase::Dynamic(right)) => {
+                (SubclassOfInner::Class(left), SubclassOfInner::Class(right)) => left.cmp(&right),
+                (SubclassOfInner::Class(_), _) => Ordering::Less,
+                (_, SubclassOfInner::Class(_)) => Ordering::Greater,
+                (SubclassOfInner::Dynamic(left), SubclassOfInner::Dynamic(right)) => {
                     dynamic_elements_ordering(left, right)
                 }
             }


### PR DESCRIPTION
## Summary

- Add a new `KnownInstanceType::Generic` variant to represent the type of the symbol `typing(_extensions).Generic`
- Add new `ClassBase::Protocol` and `ClassBase::Generic` variants, to represent the fact that classes can have these symbols in their MRO at runtime, even though these are not represented as classes in typeshed.
- Introduce a separate `SubclassOfInner` variant to represent the inner data that a `type[]` type holds. With the introduction of the new `ClassBase::Protocol` and `ClassBase::Generic` variants, the `ClassBase` enum is no longer suitable for this purpose, since `type[Protocol]` and `type[Generic]` are both meaningless.
- Remove false-positive diagnostics when inheriting from `Generic[]`
- Remove false-positive diagnostics when subscripting an old-style generic class
- Ensure that diagnostics are still emitted if a class inherits from bare `Generic`
- Correctly infer the MROs of protocol classes!

This appears to get rid of a lot of `invalid-base` false-positive errors and greatly improves the accuracy of our MRO inference for classes that inherit from `Generic` and/or `Protocol`... unfortunately it seems to be introducing many new false positives regarding `__new__` in the mypy_primer report, which isn't something I expected. Possibly these were latent bugs that are now exposed due to the fact that we understand a lot of MROs a lot more precisely...?

## Test Plan

Mdtests updated and added.
