### PR TITLE
[red-knot] class bases are not affected by __future__.annotations

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/deferred.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/deferred.md
@@ -156,3 +156,24 @@ def _():
         def f(self) -> C:
             return self
 ```
+
+## Base class references
+
+### Not deferred by __future__.annotations
+
+```py
+from __future__ import annotations
+
+class A(B):  # error: [unresolved-reference]
+    pass
+
+class B:
+    pass
+```
+
+### Deferred in stub files
+
+```pyi
+class A(B): ...
+class B: ...
+```


### PR DESCRIPTION
## Summary

We were over-conflating the conditions for deferred name resolution. `from __future__ import annotations` defers annotations, but not class bases. In stub files, class bases are also deferred. Modeling this correctly also reduces likelihood of cycles in Python files using `from __future__ import annotations` (since deferred resolution is inherently cycle-prone). The same cycles are still possible in `.pyi` files, but much less likely, since typically there isn't anything in a `pyi` file that would cause an early return from a scope, or otherwise cause visibility constraints to persist to end of scope. Usually there is only code at module global scope and class scope, which can't have `return` statements, and `raise` or `assert` statements in a stub file would be very strange. (Technically according to the spec we'd be within our rights to just forbid a whole bunch of syntax outright in a stub file, but  I kinda like minimizing unnecessary differences between the handling of Python files and stub files.)

## Test Plan

Added mdtests.
