### PR TITLE
[red-knot] allow assignment expression in call compare narrowing

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/type.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/type.md
@@ -144,3 +144,13 @@ def _(x: Base):
         # express a constraint like `Base & ~ProperSubtypeOf[Base]`.
         reveal_type(x)  # revealed: Base
 ```
+
+## Assignment expressions
+
+```py
+def _(x: object):
+    if (y := type(x)) is bool:
+        reveal_type(y)  # revealed: Literal[bool]
+    if (type(y := x)) is bool:
+        reveal_type(y)  # revealed: bool
+```


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

There was some narrowing constraints not covered from the previous PR

```py
def _(x: object):
    if (type(y := x)) is bool:
        reveal_type(y)  # revealed: bool
```

Also, refactored a bit

## Test Plan

Update type_api.md 
