### PR TITLE
[red-knot] add fixpoint iteration for Type::member_lookup_with_policy

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/attributes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/attributes.md
@@ -1820,6 +1820,21 @@ def f(never: Never):
     never.another_attribute = never
 ```
 
+### Cyclic implicit attributes
+
+Inferring types for undeclared implicit attributes can be cyclic:
+
+```py
+class C:
+    def __init__(self):
+        self.x = 1
+
+    def copy(self, other: "C"):
+        self.x = other.x
+
+reveal_type(C().x)  # revealed: Unknown | Literal[1]
+```
+
 ### Builtin types attributes
 
 This test can probably be removed eventually, but we currently include it because we do not yet


### PR DESCRIPTION
## Summary

Member lookup can be cyclic, with type inference of implicit members. A sample case is shown in the added mdtest.

There's no clear way to handle such cases other than to fixpoint-iterate the cycle.

Fixes #17457.

## Test Plan

Added test.
