### PR TITLE
Add playground workspace package-lock.json to gitignore

### DIFF
--- a/playground/.gitignore
+++ b/playground/.gitignore
@@ -131,3 +131,8 @@ dist
 
 # Wrangler
 api/.wrangler
+
+# Workspace lockfiles
+/shared/package-lock.json
+/knot/package-lock.json
+/ruff/package-lock.json


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Sometimes these lockfiles auto generate for me and i accidentally commit them. Seems like i should add them to the gitignore