### PR TITLE
[red-knot] Add basic subtyping between class literal and callable

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
@@ -502,11 +502,9 @@ class MetaWithReturn(type):
 
 class A(metaclass=MetaWithReturn): ...
 
-def f(x: Callable[[], A]) -> None: ...
-
 # TODO: This should not error
-# error: [invalid-argument-type] "Argument to this function is incorrect: Expected `() -> A`, found `Literal[A]`"
-f(A)
+# error: [invalid-assignment] "Object of type `Literal[A]` is not assignable to `() -> A`"
+f: Callable[[], A] = A
 
 class MetaWithDifferentReturn(type):
     def __call__(cls) -> int:
@@ -514,9 +512,7 @@ class MetaWithDifferentReturn(type):
 
 class B(metaclass=MetaWithDifferentReturn): ...
 
-def g(x: Callable[[], int]) -> None: ...
-
-g(B)
+g: Callable[[], int] = B
 
 class MetaWithSelfReturn(type):
     def __call__(cls) -> Self:
@@ -524,11 +520,9 @@ class MetaWithSelfReturn(type):
 
 class C(metaclass=MetaWithSelfReturn): ...
 
-def h(x: Callable[[], C]) -> None: ...
-
 # TODO: This should not error
-# error: [invalid-argument-type] "Argument to this function is incorrect: Expected `() -> C`, found `Literal[C]`"
-h(C)
+# error: [invalid-assignment] "Object of type `Literal[C]` is not assignable to `() -> C`"
+h: Callable[[], C] = C
 ```
 
 ### Function types

--- a/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
@@ -487,6 +487,50 @@ static_assert(is_assignable_to(CallableTypeOf[keyword_variadic], Callable[..., N
 static_assert(is_assignable_to(CallableTypeOf[mixed], Callable[..., None]))
 ```
 
+### Class literals
+
+#### Classes with metaclasses
+
+```py
+from typing import Callable
+from typing_extensions import Self
+from knot_extensions import TypeOf, static_assert, is_subtype_of
+
+class MetaWithReturn(type):
+    def __call__(cls) -> "A":
+        return super().__call__()
+
+class A(metaclass=MetaWithReturn): ...
+
+def f(x: Callable[[], A]) -> None: ...
+
+# TODO: This should not error
+# error: [invalid-argument-type] "Argument to this function is incorrect: Expected `() -> A`, found `Literal[A]`"
+f(A)
+
+class MetaWithDifferentReturn(type):
+    def __call__(cls) -> int:
+        return super().__call__()
+
+class B(metaclass=MetaWithDifferentReturn): ...
+
+def g(x: Callable[[], int]) -> None: ...
+
+g(B)
+
+class MetaWithSelfReturn(type):
+    def __call__(cls) -> Self:
+        return super().__call__()
+
+class C(metaclass=MetaWithSelfReturn): ...
+
+def h(x: Callable[[], C]) -> None: ...
+
+# TODO: This should not error
+# error: [invalid-argument-type] "Argument to this function is incorrect: Expected `() -> C`, found `Literal[C]`"
+h(C)
+```
+
 ### Function types
 
 ```py

--- a/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
@@ -487,44 +487,6 @@ static_assert(is_assignable_to(CallableTypeOf[keyword_variadic], Callable[..., N
 static_assert(is_assignable_to(CallableTypeOf[mixed], Callable[..., None]))
 ```
 
-### Class literals
-
-#### Classes with metaclasses
-
-```py
-from typing import Callable
-from typing_extensions import Self
-from knot_extensions import TypeOf, static_assert, is_subtype_of
-
-class MetaWithReturn(type):
-    def __call__(cls) -> "A":
-        return super().__call__()
-
-class A(metaclass=MetaWithReturn): ...
-
-# TODO: This should not error
-# error: [invalid-assignment] "Object of type `Literal[A]` is not assignable to `() -> A`"
-f: Callable[[], A] = A
-
-class MetaWithDifferentReturn(type):
-    def __call__(cls) -> int:
-        return super().__call__()
-
-class B(metaclass=MetaWithDifferentReturn): ...
-
-g: Callable[[], int] = B
-
-class MetaWithSelfReturn(type):
-    def __call__(cls) -> Self:
-        return super().__call__()
-
-class C(metaclass=MetaWithSelfReturn): ...
-
-# TODO: This should not error
-# error: [invalid-assignment] "Object of type `Literal[C]` is not assignable to `() -> C`"
-h: Callable[[], C] = C
-```
-
 ### Function types
 
 ```py

--- a/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
@@ -1130,7 +1130,7 @@ f(a)
 #### Classes with metaclasses
 
 ```py
-from typing import Callable
+from typing import Callable, overload
 from typing_extensions import Self
 from knot_extensions import TypeOf, static_assert, is_subtype_of
 
@@ -1166,6 +1166,19 @@ class C(metaclass=MetaWithSelfReturn): ...
 # error: [static-assert-error] "Static assertion error: argument evaluates to `False`"
 static_assert(is_subtype_of(TypeOf[C], Callable[[], C]))
 static_assert(not is_subtype_of(TypeOf[C], Callable[[object], C]))
+
+class MetaWithOverloadReturn(type):
+    @overload
+    def __call__(cls, x: int) -> int: ...
+    @overload
+    def __call__(cls) -> "str": ...
+    def __call__(cls, x: int | None = None) -> "str | int":
+        return super().__call__()
+
+class D(metaclass=MetaWithOverloadReturn): ...
+
+static_assert(is_subtype_of(TypeOf[D], Callable[[int], int]))
+static_assert(is_subtype_of(TypeOf[D], Callable[[], str]))
 ```
 
 ### Bound methods

--- a/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
@@ -1131,17 +1131,19 @@ f(a)
 from typing import Callable
 from knot_extensions import TypeOf, static_assert, is_subtype_of
 
-class A:
-    def __new__(cls) -> "A":
-        return object.__new__(cls)
+class Meta(type):
+    def __call__(cls) -> "A":
+        return super().__call__()
 
-class B: ...
+class A(metaclass=Meta): ...
 
 static_assert(is_subtype_of(TypeOf[A], Callable[[], A]))
 static_assert(not is_subtype_of(TypeOf[A], Callable[[object], A]))
 
-# TODO: This assertion should be true once we understand `Self`
-# error: [static-assert-error] "Static assertion error: argument evaluates to `False`"
+class B:
+    def __new__(cls) -> "B":
+        return super().__new__(cls)
+
 static_assert(is_subtype_of(TypeOf[B], Callable[[], B]))
 ```
 

--- a/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
@@ -1140,10 +1140,6 @@ class MetaWithReturn(type):
 
 class A(metaclass=MetaWithReturn): ...
 
-# TODO: This should not error
-# This errors because the metaclass `__call__` is not seen as overriding `type.__call__`
-# and we don't yet check `__new__` or `__init__`.
-# error: [static-assert-error] "Static assertion error: argument evaluates to `False`"
 static_assert(is_subtype_of(TypeOf[A], Callable[[], A]))
 static_assert(not is_subtype_of(TypeOf[A], Callable[[object], A]))
 
@@ -1156,29 +1152,18 @@ class B(metaclass=MetaWithDifferentReturn): ...
 static_assert(is_subtype_of(TypeOf[B], Callable[[], int]))
 static_assert(not is_subtype_of(TypeOf[B], Callable[[], B]))
 
-class MetaWithSelfReturn(type):
-    def __call__(cls) -> Self:
-        return super().__call__()
-
-class C(metaclass=MetaWithSelfReturn): ...
-
-# TODO: This should not error
-# error: [static-assert-error] "Static assertion error: argument evaluates to `False`"
-static_assert(is_subtype_of(TypeOf[C], Callable[[], C]))
-static_assert(not is_subtype_of(TypeOf[C], Callable[[object], C]))
-
 class MetaWithOverloadReturn(type):
     @overload
     def __call__(cls, x: int) -> int: ...
     @overload
-    def __call__(cls) -> "str": ...
-    def __call__(cls, x: int | None = None) -> "str | int":
+    def __call__(cls) -> str: ...
+    def __call__(cls, x: int | None = None) -> str | int:
         return super().__call__()
 
-class D(metaclass=MetaWithOverloadReturn): ...
+class C(metaclass=MetaWithOverloadReturn): ...
 
-static_assert(is_subtype_of(TypeOf[D], Callable[[int], int]))
-static_assert(is_subtype_of(TypeOf[D], Callable[[], str]))
+static_assert(is_subtype_of(TypeOf[C], Callable[[int], int]))
+static_assert(is_subtype_of(TypeOf[C], Callable[[], str]))
 ```
 
 ### Bound methods

--- a/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
@@ -1125,6 +1125,26 @@ def f(fn: Callable[[int], int]) -> None: ...
 f(a)
 ```
 
+### Class literals
+
+```py
+from typing import Callable
+from knot_extensions import TypeOf, static_assert, is_subtype_of
+
+class A:
+    def __new__(cls) -> "A":
+        return object.__new__(cls)
+
+class B: ...
+
+static_assert(is_subtype_of(TypeOf[A], Callable[[], A]))
+static_assert(not is_subtype_of(TypeOf[A], Callable[[object], A]))
+
+# TODO: This assertion should be true once we understand `Self`
+# error: [static-assert-error] "Static assertion error: argument evaluates to `False`"
+static_assert(is_subtype_of(TypeOf[B], Callable[[], B]))
+```
+
 ### Bound methods
 
 ```py

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1129,8 +1129,10 @@ impl<'db> Type<'db> {
                     .symbol;
 
                 if let Symbol::Type(Type::BoundMethod(new_function), _) = metaclass_call_symbol {
-                    // TODO: this intentionally diverges from step 1 in https://typing.python.org/en/latest/spec/constructors.html#converting-a-constructor-to-callable,
-                    // by always respecting the signature of the metaclass `__call__`, which makes unwarranted assumptions.
+                    // TODO: this intentionally diverges from step 1 in
+                    // https://typing.python.org/en/latest/spec/constructors.html#converting-a-constructor-to-callable
+                    // by always respecting the signature of the metaclass `__call__`, rather than
+                    // using a heuristic which makes unwarranted assumptions to sometimes ignore it.
                     let new_function = new_function.into_callable_type(db);
                     return new_function.is_subtype_of(db, target);
                 }

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1129,20 +1129,10 @@ impl<'db> Type<'db> {
                     .symbol;
 
                 if let Symbol::Type(Type::BoundMethod(new_function), _) = metaclass_call_symbol {
-                    let overrides_type_call = match new_function.function(db).signature(db) {
-                        FunctionSignature::Single(signature)
-                        | FunctionSignature::Overloaded(_, Some(signature)) => {
-                            match signature.return_ty {
-                                Some(ty) => !self.is_subtype_of(db, ty.to_meta_type(db)),
-                                _ => false,
-                            }
-                        }
-                        FunctionSignature::Overloaded(..) => false,
-                    };
-                    if overrides_type_call {
-                        let new_function = new_function.into_callable_type(db);
-                        return new_function.is_subtype_of(db, target);
-                    }
+                    // TODO: this intentionally diverges from step 1 in https://typing.python.org/en/latest/spec/constructors.html#converting-a-constructor-to-callable,
+                    // by always respecting the signature of the metaclass `__call__`, which makes unwarranted assumptions.
+                    let new_function = new_function.into_callable_type(db);
+                    return new_function.is_subtype_of(db, target);
                 }
                 false
             }


### PR DESCRIPTION
## Summary

This covers step 1 from https://typing.python.org/en/latest/spec/constructors.html#converting-a-constructor-to-callable

Part of #17343

## Test Plan

Update is_subtype_of.md and is_assignable_to.md