### PR TITLE
[red-knot] Add list of failing/slow ecosystem projects

### DIFF
--- a/crates/red_knot_python_semantic/resources/primer/bad.txt
+++ b/crates/red_knot_python_semantic/resources/primer/bad.txt
@@ -25,7 +25,7 @@ schemathesis  # cycle panics (signature_)
 scikit-learn  # success, but mypy-primer hangs processing the output
 scipy  # missing expression ID
 spack  # success, but mypy-primer hangs processing the output
-spark  # missing expression ID
+spark  # cycle panics (try_metaclass_)
 sphinx  # missing expression ID
 steam.py  # missing expression ID
 streamlit  # cycle panic (signature)

--- a/crates/red_knot_python_semantic/resources/primer/bad.txt
+++ b/crates/red_knot_python_semantic/resources/primer/bad.txt
@@ -1,0 +1,33 @@
+Tanjun  # hangs?
+aiohttp  # missing expression ID
+alerta  # missing expression ID
+altair  # cycle panics (try_metaclass_)
+antidote  # hangs / slow
+artigraph  # cycle panics (value_type_)
+cpython  # missing expression ID, access to field whilst being initialized, too many cycle iterations
+colour  # cycle panics (try_metaclass_)
+core  # cycle panics (value_type_)
+discord.py  # some kind of hang, only when multi-threaded?
+dragonchain  # too many cycle iterations (member_lookup_with_policy)
+manticore  # stack overflow
+materialize  # stack overflow
+meson  # missing expression ID
+mypy  # cycle panic (signature_)
+pandas  # too many cycle iterations (member_lookup_with_policy)
+pandas-stubs  # cycle panics (try_metaclass)
+pip  # too many cycle iterations (infer_expression_types)
+poetry  # too many cycle iterations (member_lookup_with_policy, infer_expression_type)
+prefect # slow
+pytest  # cycle panics (signature_), missing expression ID
+pywin32  # bad use-def map (binding with definitely-visible unbound)
+schemathesis  # cycle panics (signature_)
+scikit-learn  # success, but mypy-primer hangs processing the output
+scipy  # missing expression ID
+setuptools  # too many cycle iterations (infer_definition_types)
+spack  # success, but mypy-primer hangs processing the output
+spark  # missing expression ID
+sphinx  # missing expression ID
+steam.py  # missing expression ID
+streamlit  # cycle panic (signature)
+sympy  # stack overflow
+trio  # missing expression ID

--- a/crates/red_knot_python_semantic/resources/primer/bad.txt
+++ b/crates/red_knot_python_semantic/resources/primer/bad.txt
@@ -8,7 +8,6 @@ colour  # cycle panics (try_metaclass_)
 core  # cycle panics (value_type_)
 cpython  # missing expression ID, access to field whilst being initialized, too many cycle iterations
 discord.py  # some kind of hang, only when multi-threaded?
-dragonchain  # too many cycle iterations (member_lookup_with_policy)
 freqtrade  # cycle panics (try_metaclass_)
 hydpy  # cycle panics (try_metaclass_)
 ibis  # cycle panics (try_metaclass_)

--- a/crates/red_knot_python_semantic/resources/primer/bad.txt
+++ b/crates/red_knot_python_semantic/resources/primer/bad.txt
@@ -18,7 +18,6 @@ mypy  # cycle panic (signature_)
 pandas  # slow
 pandas-stubs  # cycle panics (try_metaclass_)
 pandera  # cycle panics (try_metaclass_)
-pip  # too many cycle iterations (infer_expression_types)
 poetry  # too many cycle iterations (member_lookup_with_policy, infer_expression_type)
 prefect # slow
 pytest  # cycle panics (signature_), missing expression ID

--- a/crates/red_knot_python_semantic/resources/primer/bad.txt
+++ b/crates/red_knot_python_semantic/resources/primer/bad.txt
@@ -24,7 +24,6 @@ pywin32  # bad use-def map (binding with definitely-visible unbound)
 schemathesis  # cycle panics (signature_)
 scikit-learn  # success, but mypy-primer hangs processing the output
 scipy  # missing expression ID
-setuptools  # too many cycle iterations (infer_definition_types)
 spack  # success, but mypy-primer hangs processing the output
 spark  # missing expression ID
 sphinx  # missing expression ID

--- a/crates/red_knot_python_semantic/resources/primer/bad.txt
+++ b/crates/red_knot_python_semantic/resources/primer/bad.txt
@@ -28,7 +28,7 @@ spack  # success, but mypy-primer hangs processing the output
 spark  # cycle panics (try_metaclass_)
 sphinx  # missing expression ID
 steam.py  # missing expression ID
-streamlit  # cycle panic (signature)
+streamlit  # cycle panic (signature_)
 sympy  # stack overflow
 trio  # missing expression ID
 xarray  # cycle panics (try_metaclass_)

--- a/crates/red_knot_python_semantic/resources/primer/bad.txt
+++ b/crates/red_knot_python_semantic/resources/primer/bad.txt
@@ -4,17 +4,21 @@ alerta  # missing expression ID
 altair  # cycle panics (try_metaclass_)
 antidote  # hangs / slow
 artigraph  # cycle panics (value_type_)
-cpython  # missing expression ID, access to field whilst being initialized, too many cycle iterations
 colour  # cycle panics (try_metaclass_)
 core  # cycle panics (value_type_)
+cpython  # missing expression ID, access to field whilst being initialized, too many cycle iterations
 discord.py  # some kind of hang, only when multi-threaded?
 dragonchain  # too many cycle iterations (member_lookup_with_policy)
+freqtrade  # cycle panics (try_metaclass_)
+hydpy  # cycle panics (try_metaclass_)
+ibis  # cycle panics (try_metaclass_)
 manticore  # stack overflow
 materialize  # stack overflow
 meson  # missing expression ID
 mypy  # cycle panic (signature_)
 pandas  # too many cycle iterations (member_lookup_with_policy)
-pandas-stubs  # cycle panics (try_metaclass)
+pandas-stubs  # cycle panics (try_metaclass_)
+pandera  # cycle panics (try_metaclass_)
 pip  # too many cycle iterations (infer_expression_types)
 poetry  # too many cycle iterations (member_lookup_with_policy, infer_expression_type)
 prefect # slow
@@ -31,3 +35,4 @@ steam.py  # missing expression ID
 streamlit  # cycle panic (signature)
 sympy  # stack overflow
 trio  # missing expression ID
+xarray  # cycle panics (try_metaclass_)

--- a/crates/red_knot_python_semantic/resources/primer/bad.txt
+++ b/crates/red_knot_python_semantic/resources/primer/bad.txt
@@ -18,7 +18,6 @@ mypy  # cycle panic (signature_)
 pandas  # slow
 pandas-stubs  # cycle panics (try_metaclass_)
 pandera  # cycle panics (try_metaclass_)
-poetry  # too many cycle iterations (member_lookup_with_policy, infer_expression_type)
 prefect # slow
 pytest  # cycle panics (signature_), missing expression ID
 pywin32  # bad use-def map (binding with definitely-visible unbound)

--- a/crates/red_knot_python_semantic/resources/primer/bad.txt
+++ b/crates/red_knot_python_semantic/resources/primer/bad.txt
@@ -1,4 +1,4 @@
-Tanjun  # hangs?
+Tanjun  # cycle panic (signature_)
 aiohttp  # missing expression ID
 alerta  # missing expression ID
 altair  # cycle panics (try_metaclass_)

--- a/crates/red_knot_python_semantic/resources/primer/bad.txt
+++ b/crates/red_knot_python_semantic/resources/primer/bad.txt
@@ -15,7 +15,7 @@ manticore  # stack overflow
 materialize  # stack overflow
 meson  # missing expression ID
 mypy  # cycle panic (signature_)
-pandas  # too many cycle iterations (member_lookup_with_policy)
+pandas  # slow
 pandas-stubs  # cycle panics (try_metaclass_)
 pandera  # cycle panics (try_metaclass_)
 pip  # too many cycle iterations (infer_expression_types)

--- a/crates/red_knot_python_semantic/resources/primer/good.txt
+++ b/crates/red_knot_python_semantic/resources/primer/good.txt
@@ -30,6 +30,7 @@ dd-trace-py
 dedupe
 django-stubs
 downforeveryone
+dragonchain
 dulwich
 flake8
 flake8-pyi

--- a/crates/red_knot_python_semantic/resources/primer/good.txt
+++ b/crates/red_knot_python_semantic/resources/primer/good.txt
@@ -65,6 +65,7 @@ packaging
 paroxython
 parso
 pegen
+pip
 porcupine
 ppb-vector
 psycopg

--- a/crates/red_knot_python_semantic/resources/primer/good.txt
+++ b/crates/red_knot_python_semantic/resources/primer/good.txt
@@ -90,6 +90,7 @@ rich
 rotki
 schema_salad
 scrapy
+setuptools
 sockeye
 speedrun.com_global_scoreboard_webapp
 starlette

--- a/crates/red_knot_python_semantic/resources/primer/good.txt
+++ b/crates/red_knot_python_semantic/resources/primer/good.txt
@@ -66,6 +66,7 @@ paroxython
 parso
 pegen
 pip
+poetry
 porcupine
 ppb-vector
 psycopg


### PR DESCRIPTION
## Summary

I ran red-knot on every project in mypy-primer. I moved every project where red-knot ran to completion (fast enough, and mypy-primer could handle its output) into `good.txt`, so it will run in our CI.

The remaining projects I left listed in `bad.txt`, with a comment summarizing the failure mode (a few don't fail, they are just slow -- on a debug build, at least -- or output too many diagnostics for mypy-primer to handle.)

We will now run CI on 109 projects; 34 are left in `bad.txt`.

The main question about this PR is whether running mypy-primer on 111 projects is too much for CI: does it take too long? does it make the mypy-primer output overwhelming? If it is too much, I can split `good.txt` into `run-in-ci.txt` and `good.txt`, and we can pick some subset to run in CI.

## Test Plan

CI on this PR!
