### PR TITLE
[`ruff`] add fix safety section (`RUFF017`)

### DIFF
--- a/crates/ruff_linter/src/rules/ruff/rules/quadratic_list_summation.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/quadratic_list_summation.rs
@@ -46,6 +46,11 @@ use crate::importer::ImportRequest;
 /// functools.reduce(operator.iadd, lists, [])
 /// ```
 ///
+/// ## Fix safety
+///
+/// The rule's fix is marked as unsafe because it could convert lists into iterators, and it can
+/// delete comments in case of a multiline expression.
+///
 /// ## References
 /// - [_How Not to Flatten a List of Lists in Python_](https://mathieularose.com/how-not-to-flatten-a-list-of-lists-in-python)
 /// - [_How do I make a flat list out of a list of lists?_](https://stackoverflow.com/questions/952914/how-do-i-make-a-flat-list-out-of-a-list-of-lists/953097#953097)


### PR DESCRIPTION
The PR add the `fix safety` section for rule `RUF017` (#15584 )

The rule create always an unsafe fix. The reason I found are:
- it can convert a list into an iterator (see [comment](https://github.com/astral-sh/ruff/pull/16131#issuecomment-2657403910) in PR #16131 )
- it can delete comments in case we have a multiline expression.
