### PR TITLE
[`ruff`] add fix safety section (`RUF057`)

### DIFF
--- a/crates/ruff_linter/src/rules/ruff/rules/unnecessary_round.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unnecessary_round.rs
@@ -27,6 +27,12 @@ use ruff_text_size::Ranged;
 /// ```python
 /// a = 1
 /// ```
+///
+/// ## Fix safety
+///
+/// The fix is marked unsafe if it is not possible to guarantee that the first argument of
+/// `round()` is of type `int`, or if the fix deletes comments.
+///
 #[derive(ViolationMetadata)]
 pub(crate) struct UnnecessaryRound;
 


### PR DESCRIPTION
As in the title, see issue #15584 