### PR TITLE
[`ruff`] add fix safety section (`RUF027`)

### DIFF
--- a/crates/ruff_linter/src/rules/ruff/rules/missing_fstring_syntax.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/missing_fstring_syntax.rs
@@ -53,6 +53,11 @@ use crate::Locator;
 /// print(f"Hello {name}! It is {day_of_week} today!")
 /// ```
 ///
+/// ## Fix safety
+///
+/// The fix is always marked as unsafe, because it is possible to find a string literal which
+/// doesn't fall in one of the cases listed in the `details` section.
+///
 /// [logging]: https://docs.python.org/3/howto/logging-cookbook.html#using-particular-formatting-styles-throughout-your-application
 /// [gettext]: https://docs.python.org/3/library/gettext.html
 /// [FastAPI path]: https://fastapi.tiangolo.com/tutorial/path-params/


### PR DESCRIPTION
The PR add the `fix safety` section for rule `RUF027` (#15584 ).

Actually, I have an example of a false positive. Should I include it in the` fix safety` section?