### PR TITLE
[red-knot] Correctly identify protocol classes

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/function/return_type.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/function/return_type.md
@@ -74,8 +74,6 @@ class Baz(Bar):
 T = TypeVar("T")
 
 class Qux(Protocol[T]):
-    # TODO: no error
-    # error: [invalid-return-type]
     def f(self) -> int: ...
 
 class Foo(Protocol):

--- a/crates/red_knot_python_semantic/src/types/call/bind.rs
+++ b/crates/red_knot_python_semantic/src/types/call/bind.rs
@@ -535,6 +535,15 @@ impl<'db> Bindings<'db> {
                         }
                     }
 
+                    Some(KnownFunction::IsProtocol) => {
+                        if let [Some(ty)] = overload.parameter_types() {
+                            overload.set_return_type(Type::BooleanLiteral(
+                                ty.into_class_literal()
+                                    .is_some_and(|class| class.is_protocol(db)),
+                            ));
+                        }
+                    }
+
                     Some(KnownFunction::Overload) => {
                         // TODO: This can be removed once we understand legacy generics because the
                         // typeshed definition for `typing.overload` is an identity function.

--- a/crates/red_knot_python_semantic/src/types/class.rs
+++ b/crates/red_knot_python_semantic/src/types/class.rs
@@ -582,6 +582,17 @@ impl<'db> ClassLiteralType<'db> {
             .collect()
     }
 
+    /// Determine if this class is a protocol.
+    pub(super) fn is_protocol(self, db: &'db dyn Db) -> bool {
+        self.explicit_bases(db).iter().any(|base| {
+            matches!(
+                base,
+                Type::KnownInstance(KnownInstanceType::Protocol)
+                    | Type::Dynamic(DynamicType::SubscriptedProtocol)
+            )
+        })
+    }
+
     /// Return the types of the decorators on this class
     #[salsa::tracked(return_ref)]
     fn decorators(self, db: &'db dyn Db) -> Box<[Type<'db>]> {


### PR DESCRIPTION
## Summary

A protocol class is one that has either `Protocol` or `Protocol[]` in its class bases. Fix our recognition of whether or not a class is a protocol class, and allow this to be introspected in mdtests via the helper function `typing(_extensions).is_protocol()`.

## Test Plan

mdtests added and updated.
