### PR TITLE
[red-knot] Detect (some) invalid protocols

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/protocols.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/protocols.md
@@ -136,13 +136,13 @@ If `Protocol` is present in the bases tuple, all other bases in the tuple must b
 or `TypeError` is raised at runtime when the class is created.
 
 ```py
-# TODO: should emit `[invalid-protocol]`
+# error: [invalid-protocol] "Protocol class `Invalid` cannot inherit from non-protocol class `NotAProtocol`"
 class Invalid(NotAProtocol, Protocol): ...
 
 # revealed: tuple[Literal[Invalid], Literal[NotAProtocol], typing.Protocol, typing.Generic, Literal[object]]
 reveal_type(Invalid.__mro__)
 
-# TODO: should emit an `[invalid-protocol`] error
+# error: [invalid-protocol] "Protocol class `AlsoInvalid` cannot inherit from non-protocol class `NotAProtocol`"
 class AlsoInvalid(MyProtocol, OtherProtocol, NotAProtocol, Protocol): ...
 
 # revealed: tuple[Literal[AlsoInvalid], Literal[MyProtocol], Literal[OtherProtocol], Literal[NotAProtocol], typing.Protocol, typing.Generic, Literal[object]]

--- a/crates/red_knot_python_semantic/src/types/diagnostic.rs
+++ b/crates/red_knot_python_semantic/src/types/diagnostic.rs
@@ -36,6 +36,7 @@ pub(crate) fn register_lints(registry: &mut LintRegistryBuilder) {
     registry.register_lint(&INVALID_EXCEPTION_CAUGHT);
     registry.register_lint(&INVALID_METACLASS);
     registry.register_lint(&INVALID_PARAMETER_DEFAULT);
+    registry.register_lint(&INVALID_PROTOCOL);
     registry.register_lint(&INVALID_RAISE);
     registry.register_lint(&INVALID_SUPER_ARGUMENT);
     registry.register_lint(&INVALID_TYPE_CHECKING_CONSTANT);
@@ -225,6 +226,34 @@ declare_lint! {
     /// ```
     pub(crate) static INCOMPATIBLE_SLOTS = {
         summary: "detects class definitions whose MRO has conflicting `__slots__`",
+        status: LintStatus::preview("1.0.0"),
+        default_level: Level::Error,
+    }
+}
+
+declare_lint! {
+    /// ## What it does
+    /// Checks for invalidly defined protocol classes.
+    ///
+    /// ## Why is this bad?
+    /// An invalidly defined protocol class may lead to the type checker inferring
+    /// unexpected things. It may also lead to `TypeError`s at runtime.
+    ///
+    /// ## Examples
+    /// A `Protocol` class cannot inherit from a non-`Protocol` class;
+    /// this raises a `TypeError` at runtime:
+    ///
+    /// ```pycon
+    /// >>> from typing import Protocol
+    /// >>> class Foo(int, Protocol): ...
+    /// ...
+    /// Traceback (most recent call last):
+    ///   File "<python-input-1>", line 1, in <module>
+    ///     class Foo(int, Protocol): ...
+    /// TypeError: Protocols can only inherit from other protocols, got <class 'int'>
+    /// ```
+    pub(crate) static INVALID_PROTOCOL = {
+        summary: "detects invalid protocol class definitions",
         status: LintStatus::preview("1.0.0"),
         default_level: Level::Error,
     }

--- a/knot.schema.json
+++ b/knot.schema.json
@@ -460,6 +460,16 @@
             }
           ]
         },
+        "invalid-protocol": {
+          "title": "detects invalid protocol class definitions",
+          "description": "## What it does\nChecks for invalidly defined protocol classes.\n\n## Why is this bad?\nAn invalidly defined protocol class may lead to the type checker inferring\nunexpected things. It may also lead to `TypeError`s at runtime.\n\n## Examples\nA `Protocol` class cannot inherit from a non-`Protocol` class;\nthis raises a `TypeError` at runtime:\n\n```pycon\n>>> from typing import Protocol\n>>> class Foo(int, Protocol): ...\n...\nTraceback (most recent call last):\n  File \"<python-input-1>\", line 1, in <module>\n    class Foo(int, Protocol): ...\nTypeError: Protocols can only inherit from other protocols, got <class 'int'>\n```",
+          "default": "error",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Level"
+            }
+          ]
+        },
         "invalid-raise": {
           "title": "detects `raise` statements that raise invalid exceptions or use invalid causes",
           "description": "Checks for `raise` statements that raise non-exceptions or use invalid\ncauses for their raised exceptions.\n\n## Why is this bad?\nOnly subclasses or instances of `BaseException` can be raised.\nFor an exception's cause, the same rules apply, except that `None` is also\npermitted. Violating these rules results in a `TypeError` at runtime.\n\n## Examples\n```python\ndef f():\n    try:\n        something()\n    except NameError:\n        raise \"oops!\" from f\n\ndef g():\n    raise NotImplemented from 42\n```\n\nUse instead:\n```python\ndef f():\n    try:\n        something()\n    except NameError as e:\n        raise RuntimeError(\"oops!\") from e\n\ndef g():\n    raise NotImplementedError from None\n```\n\n## References\n- [Python documentation: The `raise` statement](https://docs.python.org/3/reference/simple_stmts.html#raise)\n- [Python documentation: Built-in Exceptions](https://docs.python.org/3/library/exceptions.html#built-in-exceptions)",


### PR DESCRIPTION
## Summary

Stacked on top of #17487.

If a class includes `Protocol` or `Protocol[]` in its bases, it cannot also include any non-protocol classes in its bases, or `TypeError` is raised at runtime. This PR adds the logic to detect this error by adding a new lint, `invalid-protocol`.

## Test Plan

existing mdtests updated
