### PR TITLE
[pyupgrade] Add fix safety section to docs (UP029)

### DIFF
--- a/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_builtin_import.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_builtin_import.rs
@@ -27,6 +27,10 @@ use crate::fix;
 /// str(1)
 /// ```
 ///
+/// ## Fix safety
+/// This rule's fix is marked as unsafe because it may remove comments associated
+/// with the import statement.
+///
 /// ## References
 /// - [Python documentation: The Python Standard Library](https://docs.python.org/3/library/index.html)
 #[derive(ViolationMetadata)]


### PR DESCRIPTION


## Summary

add fix safety section to unnecessary_builtin_import, for  #15584 

I conducted some tests and found that the only side effect should be the removal of inline comments along with the code. However, during the deletion process, comments placed above the code are preserved. I'm not sure if this behavior needs to be explicitly described.
