### PR TITLE
[`flake8-tidy-imports`] Add fix safety section to docs (`TID252`) 

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_tidy_imports/rules/relative_imports.rs
+++ b/crates/ruff_linter/src/rules/flake8_tidy_imports/rules/relative_imports.rs
@@ -45,7 +45,7 @@ use crate::rules::flake8_tidy_imports::settings::Strictness;
 /// - `lint.flake8-tidy-imports.ban-relative-imports`
 ///
 /// ## Fix safety
-/// This rule's fix is marked as unsafe because it may remove comments associated
+/// This fix is marked as unsafe if it may remove comments associated
 /// with the import statement. The fix is only applied when the absolute module
 /// path can be reliably determined.
 ///

--- a/crates/ruff_linter/src/rules/flake8_tidy_imports/rules/relative_imports.rs
+++ b/crates/ruff_linter/src/rules/flake8_tidy_imports/rules/relative_imports.rs
@@ -44,6 +44,11 @@ use crate::rules::flake8_tidy_imports::settings::Strictness;
 /// ## Options
 /// - `lint.flake8-tidy-imports.ban-relative-imports`
 ///
+/// ## Fix safety
+/// This rule's fix is marked as unsafe because it may remove comments associated
+/// with the import statement. The fix is only applied when the absolute module
+/// path can be reliably determined.
+///
 /// [PEP 8]: https://peps.python.org/pep-0008/#imports
 #[derive(ViolationMetadata)]
 pub(crate) struct RelativeImports {

--- a/crates/ruff_linter/src/rules/flake8_tidy_imports/rules/relative_imports.rs
+++ b/crates/ruff_linter/src/rules/flake8_tidy_imports/rules/relative_imports.rs
@@ -45,9 +45,12 @@ use crate::rules::flake8_tidy_imports::settings::Strictness;
 /// - `lint.flake8-tidy-imports.ban-relative-imports`
 ///
 /// ## Fix safety
-/// This fix is marked as unsafe if it may remove comments associated
-/// with the import statement. The fix is only applied when the absolute module
-/// path can be reliably determined.
+/// When available, this rule's fix is always marked as unsafe because Ruff
+/// infers the absolute import path from the file's location and configured
+/// package roots, while Python resolves relative imports from the module's
+/// runtime package. If those differ, the rewritten import can fail or resolve
+/// to a different module. The fix may also remove comments attached to the
+/// import statement.
 ///
 /// [PEP 8]: https://peps.python.org/pep-0008/#imports
 #[derive(ViolationMetadata)]


### PR DESCRIPTION
## Summary

add `fix safety` section to `TID252: relative_imports.rs`, for #15584 

When there are multiple lines of quotes, the comments in between will be deleted after the fix, but everything else works fine.
Before:
![cbeddda57dcb4ebcf789623d92a3082](https://github.com/user-attachments/assets/db2122a1-6e0b-4349-b348-6c8d699549b9)


After:
![8168a4da225aea24256b8bc59569b1d](https://github.com/user-attachments/assets/cea0bc6b-5719-4c4e-8f59-bf306732ab2e)

