### PR TITLE
[`flake8-errmsg`] Add fix safety section to docs (`EM101`, `EM102`, `EM103`) 

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_errmsg/rules/string_in_exception.rs
+++ b/crates/ruff_linter/src/rules/flake8_errmsg/rules/string_in_exception.rs
@@ -47,6 +47,11 @@ use crate::Locator;
 ///     raise RuntimeError(msg)
 /// RuntimeError: 'Some value' is incorrect
 /// ```
+/// 
+/// ## Fix safety
+/// This rule's fix is marked as unsafe because comments associated with the
+/// exception argument may not be reliably matched to their original code
+/// positions after the fix is applied.
 #[derive(ViolationMetadata)]
 pub(crate) struct RawStringInException;
 
@@ -102,6 +107,11 @@ impl Violation for RawStringInException {
 ///     raise RuntimeError(msg)
 /// RuntimeError: 'Some value' is incorrect
 /// ```
+/// 
+/// ## Fix safety
+/// This rule's fix is marked as unsafe because comments associated with the
+/// exception argument may not be reliably matched to their original code
+/// positions after the fix is applied.
 #[derive(ViolationMetadata)]
 pub(crate) struct FStringInException;
 
@@ -158,6 +168,11 @@ impl Violation for FStringInException {
 ///     raise RuntimeError(msg)
 /// RuntimeError: 'Some value' is incorrect
 /// ```
+/// 
+/// ## Fix safety
+/// This rule's fix is marked as unsafe because comments associated with the
+/// exception argument may not be reliably matched to their original code
+/// positions after the fix is applied.
 #[derive(ViolationMetadata)]
 pub(crate) struct DotFormatInException;
 

--- a/crates/ruff_linter/src/rules/flake8_errmsg/rules/string_in_exception.rs
+++ b/crates/ruff_linter/src/rules/flake8_errmsg/rules/string_in_exception.rs
@@ -111,7 +111,7 @@ impl Violation for RawStringInException {
 /// ```
 ///
 /// ## Fix safety
-/// This rule's fix is marked as unsafe because:
+/// This fix is marked as unsafe because:
 /// - Comments associated with the exception argument may not be reliably matched
 ///   to their original code positions after the fix is applied.
 /// - The introduced `msg` variable may shadow an existing variable in the same

--- a/crates/ruff_linter/src/rules/flake8_errmsg/rules/string_in_exception.rs
+++ b/crates/ruff_linter/src/rules/flake8_errmsg/rules/string_in_exception.rs
@@ -47,7 +47,7 @@ use crate::Locator;
 ///     raise RuntimeError(msg)
 /// RuntimeError: 'Some value' is incorrect
 /// ```
-/// 
+///
 /// ## Fix safety
 /// This rule's fix is marked as unsafe because comments associated with the
 /// exception argument may not be reliably matched to their original code
@@ -107,7 +107,7 @@ impl Violation for RawStringInException {
 ///     raise RuntimeError(msg)
 /// RuntimeError: 'Some value' is incorrect
 /// ```
-/// 
+///
 /// ## Fix safety
 /// This rule's fix is marked as unsafe because comments associated with the
 /// exception argument may not be reliably matched to their original code
@@ -168,7 +168,7 @@ impl Violation for FStringInException {
 ///     raise RuntimeError(msg)
 /// RuntimeError: 'Some value' is incorrect
 /// ```
-/// 
+///
 /// ## Fix safety
 /// This rule's fix is marked as unsafe because comments associated with the
 /// exception argument may not be reliably matched to their original code

--- a/crates/ruff_linter/src/rules/flake8_errmsg/rules/string_in_exception.rs
+++ b/crates/ruff_linter/src/rules/flake8_errmsg/rules/string_in_exception.rs
@@ -49,7 +49,7 @@ use crate::Locator;
 /// ```
 ///
 /// ## Fix safety
-/// This rule's fix is marked as unsafe because:
+/// This fix is marked as unsafe because:
 /// - Comments associated with the exception argument may not be reliably matched
 ///   to their original code positions after the fix is applied.
 /// - The introduced `msg` variable may shadow an existing variable in the same
@@ -174,7 +174,7 @@ impl Violation for FStringInException {
 /// ```
 ///
 /// ## Fix safety
-/// This rule's fix is marked as unsafe because:
+/// This fix is marked as unsafe because:
 /// - Comments associated with the exception argument may not be reliably matched
 ///   to their original code positions after the fix is applied.
 /// - The introduced `msg` variable may shadow an existing variable in the same

--- a/crates/ruff_linter/src/rules/flake8_errmsg/rules/string_in_exception.rs
+++ b/crates/ruff_linter/src/rules/flake8_errmsg/rules/string_in_exception.rs
@@ -49,9 +49,11 @@ use crate::Locator;
 /// ```
 ///
 /// ## Fix safety
-/// This rule's fix is marked as unsafe because comments associated with the
-/// exception argument may not be reliably matched to their original code
-/// positions after the fix is applied.
+/// This rule's fix is marked as unsafe because:
+/// - Comments associated with the exception argument may not be reliably matched
+///   to their original code positions after the fix is applied.
+/// - The introduced `msg` variable may shadow an existing variable in the same
+///   scope, potentially changing program behavior.
 #[derive(ViolationMetadata)]
 pub(crate) struct RawStringInException;
 
@@ -109,9 +111,11 @@ impl Violation for RawStringInException {
 /// ```
 ///
 /// ## Fix safety
-/// This rule's fix is marked as unsafe because comments associated with the
-/// exception argument may not be reliably matched to their original code
-/// positions after the fix is applied.
+/// This rule's fix is marked as unsafe because:
+/// - Comments associated with the exception argument may not be reliably matched
+///   to their original code positions after the fix is applied.
+/// - The introduced `msg` variable may shadow an existing variable in the same
+///   scope, potentially changing program behavior.
 #[derive(ViolationMetadata)]
 pub(crate) struct FStringInException;
 
@@ -170,9 +174,11 @@ impl Violation for FStringInException {
 /// ```
 ///
 /// ## Fix safety
-/// This rule's fix is marked as unsafe because comments associated with the
-/// exception argument may not be reliably matched to their original code
-/// positions after the fix is applied.
+/// This rule's fix is marked as unsafe because:
+/// - Comments associated with the exception argument may not be reliably matched
+///   to their original code positions after the fix is applied.
+/// - The introduced `msg` variable may shadow an existing variable in the same
+///   scope, potentially changing program behavior.
 #[derive(ViolationMetadata)]
 pub(crate) struct DotFormatInException;
 


### PR DESCRIPTION
## Summary

add `fix safety` section to `EM101`, `EM102`, `EM103` in `string_in_exception.rs` for #15584 

This rule is only executed when the parameter is a character; if it's something else like a function, it will be skipped. I'm not sure if this point needs to be mentioned.

This rule modifies the original character content, such as inserting new variables, etc. If there are comments, they will remain in their original position. In the case of a single line, it doesn't seem problematic, but for multiple lines, the comments may end up in incorrect positions.

Before:

```python
raise RuntimeError("string") #comment 1

raise RuntimeError(
    "multi-line " # comment 1
    "string" # comment 2
) # comment 3


raise RuntimeError(
    f"{42} is "  # f-string comment1
    f"wrong"     # f-string comment2
)  # f-string comment3


raise RuntimeError(
    "value is {}".format(  # format comment1
        42                 # format comment2
    )
)  # format comment3


def side_effect():
    print("side effect!")
    return "danger"

raise RuntimeError(side_effect())
```


After:

```python
msg = "string"
raise RuntimeError(msg) #comment 1

msg = (
    "multi-line " # comment 1
    "string"
)
raise RuntimeError(
    msg # comment 2
) # comment 3


msg = (
    f"{42} is "  # f-string comment1
    f"wrong"
)
raise RuntimeError(
    msg     # f-string comment2
)  # f-string comment3


msg = (
    "value is {}".format(  # format comment1
        42                 # format comment2
    )
)
raise RuntimeError(
    msg
)  # format comment3


def side_effect():
    print("side effect!")
    return "danger"

raise RuntimeError(side_effect())
```
