### PR TITLE
Use `visit_annotation` for type alias value

### DIFF
--- a/crates/ruff_python_ast/ast.toml
+++ b/crates/ruff_python_ast/ast.toml
@@ -116,7 +116,7 @@ doc = "See also [TypeAlias](https://docs.python.org/3/library/ast.html#ast.TypeA
 fields = [
   { name = "name", type = "Expr" },
   { name = "type_params", type = "Box<crate::TypeParams>?" },
-  { name = "value", type = "Expr" },
+  { name = "value", type = "Expr", is_annotation = true },
 ]
 
 [Stmt.nodes.StmtAssign]

--- a/crates/ruff_python_ast/src/generated.rs
+++ b/crates/ruff_python_ast/src/generated.rs
@@ -7268,7 +7268,7 @@ impl StmtTypeAlias {
             visitor.visit_type_params(type_params);
         }
 
-        visitor.visit_expr(value);
+        visitor.visit_annotation(value);
     }
 }
 

--- a/crates/ruff_python_ast_integration_tests/tests/snapshots/source_order__type_aliases.snap
+++ b/crates/ruff_python_ast_integration_tests/tests/snapshots/source_order__type_aliases.snap
@@ -16,5 +16,6 @@ expression: trace
       - TypeParamParamSpec
         - Identifier
     - ExprSubscript
-      - ExprName
-      - ExprName
+      - ExprSubscript
+        - ExprName
+        - ExprName


### PR DESCRIPTION
This was a follow up task from https://github.com/astral-sh/ruff/pull/17180#discussion_r2037973858 separated into this PR.

<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
