### PR TITLE
[flake8-async] add fix safety section (ASYNC116) 

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_async/rules/long_sleep_not_forever.rs
+++ b/crates/ruff_linter/src/rules/flake8_async/rules/long_sleep_not_forever.rs
@@ -34,6 +34,12 @@ use crate::rules::flake8_async::helpers::AsyncModule;
 /// async def func():
 ///     await trio.sleep_forever()
 /// ```
+/// 
+/// ## Fix safety
+///
+/// This fix is unsafe because it changes a finite sleep to an indefinite one.
+/// If the original code intended to eventually resume execution, this fix may
+/// introduce unintended permanent suspension.
 #[derive(ViolationMetadata)]
 pub(crate) struct LongSleepNotForever {
     module: AsyncModule,


### PR DESCRIPTION

## Summary

This PR add the `fix safety` section for rule `ASYNC116` for #15584 