### PR TITLE
[`refurb`] Add fix safety section (`FURB105`)

### DIFF
--- a/crates/ruff_linter/src/rules/refurb/rules/print_empty_string.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/print_empty_string.rs
@@ -30,6 +30,11 @@ use crate::checkers::ast::Checker;
 /// print()
 /// ```
 ///
+/// ## Fix safety
+/// This fix is unsafe because if the removed argument or keyword is an
+/// expression with side effects. Removing such arguments may
+/// skip the execution of those side effects.
+/// 
 /// ## References
 /// - [Python documentation: `print`](https://docs.python.org/3/library/functions.html#print)
 #[derive(ViolationMetadata)]


### PR DESCRIPTION
## Summary

This PR add the `fix safety` section for rule `FURB105` in `print_empty_string.rs` for #15584

Before:
```
def get_sep():
    print("side effect")
    return ""
    
print("", sep=get_sep())
```

After:
```
def get_sep():
    print("side effect")
    return ""
    
print()
```