### PR TITLE
ERA001: Allow Jira and gitlab references

### DIFF
--- a/crates/ruff_linter/src/rules/eradicate/detection.rs
+++ b/crates/ruff_linter/src/rules/eradicate/detection.rs
@@ -105,7 +105,7 @@ pub(crate) fn comment_contains_code(line: &str, task_tags: &[String]) -> bool {
         return false;
     }
 
-    // Ignore lines with references to issues.
+    // Ignore lines with references to github/gitlab/jira (#999, PROJ-123, !54).
     if ISSUE_REFERENCE.is_match(line) {
         return false;
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This extends the [ERA001](https://docs.astral.sh/ruff/rules/commented-out-code/) check to allow references to Jira issues and GitLab merge requests. Currently, only GitHub-style issue references are excluded from being flagged as commented-out code.

Previously, lines like the following were incorrectly flagged:

Jira issue reference
```
See: PROJ-1234
See: !15
```

GitLab MR reference
```
See: !15
```

These are now correctly treated as comments, not code.


<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->

Added unit tests to verify the behavior.
