### PR TITLE
[`perflint`] Allow list function calls to be replaced with a comprehension (`PERF401`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/perflint/PERF401.py
+++ b/crates/ruff_linter/resources/test/fixtures/perflint/PERF401.py
@@ -260,3 +260,9 @@ def f():
     for i in range(5):
         if j := i:
             items.append(j)
+
+def f():
+    values = [1, 2, 3]
+    result = list()  # this should be replaced with a comprehension
+    for i in values:
+        result.append(i + 1)  # PERF401

--- a/crates/ruff_linter/src/rules/perflint/rules/manual_list_comprehension.rs
+++ b/crates/ruff_linter/src/rules/perflint/rules/manual_list_comprehension.rs
@@ -270,6 +270,15 @@ pub(crate) fn manual_list_comprehension(checker: &Checker, for_stmt: &ast::StmtF
         list_binding_value.is_some_and(|binding_value| match binding_value {
             // `value = []`
             Expr::List(list_expr) => list_expr.is_empty(),
+            // `value = list()`
+            // This might be linted against, but turning it into a list comprehension will also remove it
+            Expr::Call(call) => {
+                checker
+                    .semantic()
+                    .resolve_builtin_symbol(&call.func)
+                    .is_some_and(|name| name == "list")
+                    && call.arguments.is_empty()
+            }
             _ => false,
         });
 

--- a/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__PERF401_PERF401.py.snap
+++ b/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__PERF401_PERF401.py.snap
@@ -208,5 +208,16 @@ PERF401.py:262:13: PERF401 Use a list comprehension to create a transformed list
 261 |         if j := i:
 262 |             items.append(j)
     |             ^^^^^^^^^^^^^^^ PERF401
+263 |
+264 | def f():
+    |
+    = help: Replace for loop with list comprehension
+
+PERF401.py:268:9: PERF401 Use a list comprehension to create a transformed list
+    |
+266 |     result = list()  # this should be replaced with a comprehension
+267 |     for i in values:
+268 |         result.append(i + 1)  # PERF401
+    |         ^^^^^^^^^^^^^^^^^^^^ PERF401
     |
     = help: Replace for loop with list comprehension

--- a/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__preview__PERF401_PERF401.py.snap
+++ b/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__preview__PERF401_PERF401.py.snap
@@ -492,6 +492,8 @@ PERF401.py:262:13: PERF401 [*] Use a list comprehension to create a transformed 
 261 |         if j := i:
 262 |             items.append(j)
     |             ^^^^^^^^^^^^^^^ PERF401
+263 |
+264 | def f():
     |
     = help: Replace for loop with list comprehension
 
@@ -505,3 +507,25 @@ PERF401.py:262:13: PERF401 [*] Use a list comprehension to create a transformed 
 261     |-        if j := i:
 262     |-            items.append(j)
     259 |+    items = [j for i in range(5) if (j := i)]
+263 260 | 
+264 261 | def f():
+265 262 |     values = [1, 2, 3]
+
+PERF401.py:268:9: PERF401 [*] Use a list comprehension to create a transformed list
+    |
+266 |     result = list()  # this should be replaced with a comprehension
+267 |     for i in values:
+268 |         result.append(i + 1)  # PERF401
+    |         ^^^^^^^^^^^^^^^^^^^^ PERF401
+    |
+    = help: Replace for loop with list comprehension
+
+ℹ Unsafe fix
+263 263 | 
+264 264 | def f():
+265 265 |     values = [1, 2, 3]
+266     |-    result = list()  # this should be replaced with a comprehension
+267     |-    for i in values:
+268     |-        result.append(i + 1)  # PERF401
+    266 |+    # this should be replaced with a comprehension
+    267 |+    result = [i + 1 for i in values]  # PERF401


### PR DESCRIPTION
This is an implementation of the discussion from #16719. 

This change will allow list function calls to be replaced with comprehensions:

```python
result = list()
for i in range(3):
    result.append(i + 1)
# becomes
result = [i + 1 for i in range(3)]
```

I added a new test to `PERF401.py` to verify that this fix will now work for `list()`. 