### PR TITLE
Fixes how the checker visits `typing.cast`/`typing.NewType` arguments

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_type_checking/TC006.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_type_checking/TC006.py
@@ -89,3 +89,11 @@ def f():
         int  # TC006
         , 6.0
     )
+
+
+def f():
+    # Keyword arguments
+    from typing import cast
+
+    cast(typ=int, val=3.0)  # TC006
+    cast(val=3.0, typ=int)  # TC006

--- a/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__runtime-cast-value_TC006.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__runtime-cast-value_TC006.py.snap
@@ -212,3 +212,37 @@ TC006.py:89:9: TC006 [*] Add quotes to type expression in `typing.cast()`
    89 |+        "int"  # TC006
 90 90 |         , 6.0
 91 91 |     )
+92 92 | 
+
+TC006.py:98:14: TC006 [*] Add quotes to type expression in `typing.cast()`
+   |
+96 |     from typing import cast
+97 |
+98 |     cast(typ=int, val=3.0)  # TC006
+   |              ^^^ TC006
+99 |     cast(val=3.0, typ=int)  # TC006
+   |
+   = help: Add quotes
+
+ℹ Safe fix
+95 95 |     # Keyword arguments
+96 96 |     from typing import cast
+97 97 | 
+98    |-    cast(typ=int, val=3.0)  # TC006
+   98 |+    cast(typ="int", val=3.0)  # TC006
+99 99 |     cast(val=3.0, typ=int)  # TC006
+
+TC006.py:99:23: TC006 [*] Add quotes to type expression in `typing.cast()`
+   |
+98 |     cast(typ=int, val=3.0)  # TC006
+99 |     cast(val=3.0, typ=int)  # TC006
+   |                       ^^^ TC006
+   |
+   = help: Add quotes
+
+ℹ Safe fix
+96 96 |     from typing import cast
+97 97 | 
+98 98 |     cast(typ=int, val=3.0)  # TC006
+99    |-    cast(val=3.0, typ=int)  # TC006
+   99 |+    cast(val=3.0, typ="int")  # TC006


### PR DESCRIPTION
Closes: #17442

## Summary

This allows for their arguments to be passed by name, however uncommon that may be.

## Test Plan

`cargo nextest run`
