### PR TITLE
[red-knot] mypy_primer: capture backtraces

### DIFF
--- a/.github/workflows/mypy_primer.yaml
+++ b/.github/workflows/mypy_primer.yaml
@@ -21,6 +21,7 @@ env:
   CARGO_NET_RETRY: 10
   CARGO_TERM_COLOR: always
   RUSTUP_MAX_RETRIES: 10
+  RUST_BACKTRACE: 1
 
 jobs:
   mypy_primer:


### PR DESCRIPTION
## Summary

`mypy_primer` is not deterministic (we pin `mypy_primer` itself, but projects change over time and we just pull in the latest version). We've also seen occasional panics being caught in `mypy_primer` runs, so this is trying to make these CI failures more helpful.
