### PR TITLE
[red-knot] Consider two instance types disjoint if the underlying classes have disjoint metaclasses

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
@@ -56,6 +56,19 @@ static_assert(not is_disjoint_from(FinalSubclass, A))
 # ... which makes it disjoint from B1, B2:
 static_assert(is_disjoint_from(B1, FinalSubclass))
 static_assert(is_disjoint_from(B2, FinalSubclass))
+
+# Instance types can also be disjoint if they have disjoint metaclasses.
+# No possible subclass of `Meta1` and `Meta2` could exist, therefore
+# no possible subclass of `UsesMeta1` and `UsesMeta2` can exist:
+class Meta1(type): ...
+class UsesMeta1(metaclass=Meta1): ...
+
+@final
+class Meta2(type): ...
+
+class UsesMeta2(metaclass=Meta2): ...
+
+static_assert(is_disjoint_from(UsesMeta1, UsesMeta2))
 ```
 
 ## Tuple types
@@ -342,8 +355,8 @@ static_assert(is_disjoint_from(Meta1, type[UsesMeta2]))
 
 ### `type[T]` versus `type[S]`
 
-By the same token, `type[T]` is disjoint from `type[S]` if the metaclass of `T` is disjoint from the
-metaclass of `S`.
+By the same token, `type[T]` is disjoint from `type[S]` if `T` is `@final`, `S` is `@final`, or the
+metaclass of `T` is disjoint from the metaclass of `S`.
 
 ```py
 from typing import final
@@ -353,6 +366,9 @@ from knot_extensions import static_assert, is_disjoint_from
 class Meta1(type): ...
 
 class Meta2(type): ...
+
+static_assert(is_disjoint_from(type[Meta1], type[Meta2]))
+
 class UsesMeta1(metaclass=Meta1): ...
 class UsesMeta2(metaclass=Meta2): ...
 


### PR DESCRIPTION
## Summary

I noticed we were being inconsistent between `type[]` types and instance types when it came to whether we considered disjointness of the metaclasses when determining the disjointness of two types. Consider the following example:

```py
from typing import final, reveal_type
from knot_extensions import Intersection

@final
class Final1: ...

@final
class Final2: ...

@final
class Meta1(type): ...

@final
class Meta2(type): ...

class UsesMeta1(metaclass=Meta1): ...
class UsesMeta2(metaclass=Meta2): ...

def f(
    a: Intersection[Final1, Final2],
    b: Intersection[type[Final1], type[Final2]],
    c: Intersection[UsesMeta1, UsesMeta2],
    d: Intersection[type[UsesMeta1], type[UsesMeta2]]
):
    reveal_type(a)  # `Never`
    reveal_type(b)  # `Never`
    reveal_type(c)  # `UsesMeta1 & UsesMeta2` on `main`, but should also be `Never`
    reveal_type(d)  # `Never`
```

https://playknot.ruff.rs/d422556b-bce6-407d-80cd-31b602fec12b

If two instance types have disjoint metaclasses, the instance types must themselves be disjoint, as a class that simultaneously subclasses `A` and `B` can only exist if there could exist a metaclass that is a simultaneous subclass of `A`'s metaclass and `B`'s metaclass.

## Test Plan

New mdtests added.
