### PR TITLE
[red-knot] mypy_primer: larger depot runner

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -6,5 +6,6 @@ self-hosted-runner:
   labels:
     - depot-ubuntu-latest-8
     - depot-ubuntu-22.04-16
+    - depot-ubuntu-22.04-32
     - github-windows-2025-x86_64-8
     - github-windows-2025-x86_64-16

--- a/.github/workflows/mypy_primer.yaml
+++ b/.github/workflows/mypy_primer.yaml
@@ -26,7 +26,7 @@ env:
 jobs:
   mypy_primer:
     name: Run mypy_primer
-    runs-on: depot-ubuntu-22.04-16
+    runs-on: depot-ubuntu-22.04-32
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
## Summary

A switch from 16 to 32 cores reduces the `mypy_primer` CI time from 3.5-4 min to 2.5-3 min. There's also a 64-core runner, but the 4 min -> 3 min change when doubling the cores once does suggest that it doesn't parallelize *this* well.