### PR TITLE
[red-knot] Emit a diagnostic if a non-protocol is passed to `get_protocol_members`

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Invalid_calls_to_`get_protocol_members()`.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Invalid_calls_to_`get_protocol_members()`.snap
@@ -1,0 +1,82 @@
+---
+source: crates/red_knot_test/src/lib.rs
+expression: snapshot
+---
+---
+mdtest name: protocols.md - Protocols - Invalid calls to `get_protocol_members()`
+mdtest path: crates/red_knot_python_semantic/resources/mdtest/protocols.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+ 1 | from typing_extensions import Protocol, get_protocol_members
+ 2 | 
+ 3 | class NotAProtocol: ...
+ 4 | 
+ 5 | get_protocol_members(NotAProtocol)  # error: [invalid-argument-type]
+ 6 | 
+ 7 | class AlsoNotAProtocol(NotAProtocol, object): ...
+ 8 | 
+ 9 | get_protocol_members(AlsoNotAProtocol)  # error: [invalid-argument-type]
+10 | class GenericProtocol[T](Protocol): ...
+11 | 
+12 | get_protocol_members(GenericProtocol[int])  # TODO: should emit a diagnostic here (https://github.com/astral-sh/ruff/issues/17549)
+```
+
+# Diagnostics
+
+```
+error: lint:invalid-argument-type: Invalid argument to `get_protocol_members`
+ --> /src/mdtest_snippet.py:5:1
+  |
+3 | class NotAProtocol: ...
+4 |
+5 | get_protocol_members(NotAProtocol)  # error: [invalid-argument-type]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This call will raise `TypeError` at runtime
+6 |
+7 | class AlsoNotAProtocol(NotAProtocol, object): ...
+  |
+info: Only protocol classes can be passed to `get_protocol_members`
+info: `NotAProtocol` is declared here, but it is not a protocol class:
+ --> /src/mdtest_snippet.py:3:7
+  |
+1 | from typing_extensions import Protocol, get_protocol_members
+2 |
+3 | class NotAProtocol: ...
+  |       ^^^^^^^^^^^^
+4 |
+5 | get_protocol_members(NotAProtocol)  # error: [invalid-argument-type]
+  |
+info: A class is only a protocol class if it directly inherits from `typing.Protocol` or `typing_extensions.Protocol`
+info: See https://typing.python.org/en/latest/spec/protocol.html#
+
+```
+
+```
+error: lint:invalid-argument-type: Invalid argument to `get_protocol_members`
+  --> /src/mdtest_snippet.py:9:1
+   |
+ 7 | class AlsoNotAProtocol(NotAProtocol, object): ...
+ 8 |
+ 9 | get_protocol_members(AlsoNotAProtocol)  # error: [invalid-argument-type]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This call will raise `TypeError` at runtime
+10 | class GenericProtocol[T](Protocol): ...
+   |
+info: Only protocol classes can be passed to `get_protocol_members`
+info: `AlsoNotAProtocol` is declared here, but it is not a protocol class:
+ --> /src/mdtest_snippet.py:7:7
+  |
+5 | get_protocol_members(NotAProtocol)  # error: [invalid-argument-type]
+6 |
+7 | class AlsoNotAProtocol(NotAProtocol, object): ...
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+8 |
+9 | get_protocol_members(AlsoNotAProtocol)  # error: [invalid-argument-type]
+  |
+info: A class is only a protocol class if it directly inherits from `typing.Protocol` or `typing_extensions.Protocol`
+info: See https://typing.python.org/en/latest/spec/protocol.html#
+
+```

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -96,7 +96,8 @@ use crate::Db;
 
 use super::context::{InNoTypeCheck, InferContext};
 use super::diagnostic::{
-    report_index_out_of_bounds, report_invalid_exception_caught, report_invalid_exception_cause,
+    report_bad_argument_to_get_protocol_members, report_index_out_of_bounds,
+    report_invalid_exception_caught, report_invalid_exception_cause,
     report_invalid_exception_raised, report_invalid_type_checking_constant,
     report_non_subscriptable, report_possibly_unresolved_reference, report_slice_step_size_zero,
     report_unresolved_reference, INVALID_METACLASS, INVALID_PROTOCOL, REDUNDANT_CAST,
@@ -4483,6 +4484,19 @@ impl<'db> TypeInferenceBuilder<'db> {
                                                     casted_type.display(db),
                                                 ));
                                             }
+                                        }
+                                    }
+                                }
+                                KnownFunction::GetProtocolMembers => {
+                                    if let [Some(Type::ClassLiteral(class))] =
+                                        overload.parameter_types()
+                                    {
+                                        if !class.is_protocol(self.db()) {
+                                            report_bad_argument_to_get_protocol_members(
+                                                &self.context,
+                                                call_expression,
+                                                *class,
+                                            );
                                         }
                                     }
                                 }


### PR DESCRIPTION
## Summary

Passing a non-protocol class to `get_protocol_members` fails at runtime. This PR adds logic to red-knot so that we detect that error and warn the user about it.

Stacked on top of #17550

## Test Plan

Existing mdtests updated and extended. Snapshots added!

Screenshot of what the diagnostics look like in the terminal: 
![image](https://github.com/user-attachments/assets/3298df31-f612-4215-a1f4-55f264056328)

