### PR TITLE
[red-knot] move everything to new diagnostics API

### DIFF
--- a/crates/red_knot/tests/cli.rs
+++ b/crates/red_knot/tests/cli.rs
@@ -32,12 +32,12 @@ fn config_override_python_version() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    error: lint:unresolved-attribute
+    error: lint:unresolved-attribute: Type `<module 'sys'>` has no attribute `last_exc`
      --> <temp_dir>/test.py:5:7
       |
     4 | # Access `sys.last_exc` that was only added in Python 3.12
     5 | print(sys.last_exc)
-      |       ^^^^^^^^^^^^ Type `<module 'sys'>` has no attribute `last_exc`
+      |       ^^^^^^^^^^^^
       |
 
     Found 1 diagnostic
@@ -165,11 +165,11 @@ fn cli_arguments_are_relative_to_the_current_directory() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    error: lint:unresolved-import
+    error: lint:unresolved-import: Cannot resolve import `utils`
      --> <temp_dir>/child/test.py:2:6
       |
     2 | from utils import add
-      |      ^^^^^ Cannot resolve import `utils`
+      |      ^^^^^
     3 |
     4 | stat = add(10, 15)
       |
@@ -265,11 +265,11 @@ fn configuration_rule_severity() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    error: lint:division-by-zero
+    error: lint:division-by-zero: Cannot divide object of type `Literal[4]` by zero
      --> <temp_dir>/test.py:2:5
       |
     2 | y = 4 / 0
-      |     ^^^^^ Cannot divide object of type `Literal[4]` by zero
+      |     ^^^^^
     3 |
     4 | for a in range(0, int(y)):
       |
@@ -301,11 +301,11 @@ fn configuration_rule_severity() -> anyhow::Result<()> {
     success: true
     exit_code: 0
     ----- stdout -----
-    warning: lint:division-by-zero
+    warning: lint:division-by-zero: Cannot divide object of type `Literal[4]` by zero
      --> <temp_dir>/test.py:2:5
       |
     2 | y = 4 / 0
-      |     ^^^^^ Cannot divide object of type `Literal[4]` by zero
+      |     ^^^^^
     3 |
     4 | for a in range(0, int(y)):
       |
@@ -341,22 +341,22 @@ fn cli_rule_severity() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    error: lint:unresolved-import
+    error: lint:unresolved-import: Cannot resolve import `does_not_exit`
      --> <temp_dir>/test.py:2:8
       |
     2 | import does_not_exit
-      |        ^^^^^^^^^^^^^ Cannot resolve import `does_not_exit`
+      |        ^^^^^^^^^^^^^
     3 |
     4 | y = 4 / 0
       |
 
-    error: lint:division-by-zero
+    error: lint:division-by-zero: Cannot divide object of type `Literal[4]` by zero
      --> <temp_dir>/test.py:4:5
       |
     2 | import does_not_exit
     3 |
     4 | y = 4 / 0
-      |     ^^^^^ Cannot divide object of type `Literal[4]` by zero
+      |     ^^^^^
     5 |
     6 | for a in range(0, int(y)):
       |
@@ -388,22 +388,22 @@ fn cli_rule_severity() -> anyhow::Result<()> {
     success: true
     exit_code: 0
     ----- stdout -----
-    warning: lint:unresolved-import
+    warning: lint:unresolved-import: Cannot resolve import `does_not_exit`
      --> <temp_dir>/test.py:2:8
       |
     2 | import does_not_exit
-      |        ^^^^^^^^^^^^^ Cannot resolve import `does_not_exit`
+      |        ^^^^^^^^^^^^^
     3 |
     4 | y = 4 / 0
       |
 
-    warning: lint:division-by-zero
+    warning: lint:division-by-zero: Cannot divide object of type `Literal[4]` by zero
      --> <temp_dir>/test.py:4:5
       |
     2 | import does_not_exit
     3 |
     4 | y = 4 / 0
-      |     ^^^^^ Cannot divide object of type `Literal[4]` by zero
+      |     ^^^^^
     5 |
     6 | for a in range(0, int(y)):
       |
@@ -439,11 +439,11 @@ fn cli_rule_severity_precedence() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    error: lint:division-by-zero
+    error: lint:division-by-zero: Cannot divide object of type `Literal[4]` by zero
      --> <temp_dir>/test.py:2:5
       |
     2 | y = 4 / 0
-      |     ^^^^^ Cannot divide object of type `Literal[4]` by zero
+      |     ^^^^^
     3 |
     4 | for a in range(0, int(y)):
       |
@@ -476,11 +476,11 @@ fn cli_rule_severity_precedence() -> anyhow::Result<()> {
     success: true
     exit_code: 0
     ----- stdout -----
-    warning: lint:division-by-zero
+    warning: lint:division-by-zero: Cannot divide object of type `Literal[4]` by zero
      --> <temp_dir>/test.py:2:5
       |
     2 | y = 4 / 0
-      |     ^^^^^ Cannot divide object of type `Literal[4]` by zero
+      |     ^^^^^
     3 |
     4 | for a in range(0, int(y)):
       |
@@ -835,11 +835,11 @@ fn user_configuration() -> anyhow::Result<()> {
     success: true
     exit_code: 0
     ----- stdout -----
-    warning: lint:division-by-zero
+    warning: lint:division-by-zero: Cannot divide object of type `Literal[4]` by zero
      --> <temp_dir>/project/main.py:2:5
       |
     2 | y = 4 / 0
-      |     ^^^^^ Cannot divide object of type `Literal[4]` by zero
+      |     ^^^^^
     3 |
     4 | for a in range(0, int(y)):
       |
@@ -877,11 +877,11 @@ fn user_configuration() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    warning: lint:division-by-zero
+    warning: lint:division-by-zero: Cannot divide object of type `Literal[4]` by zero
      --> <temp_dir>/project/main.py:2:5
       |
     2 | y = 4 / 0
-      |     ^^^^^ Cannot divide object of type `Literal[4]` by zero
+      |     ^^^^^
     3 |
     4 | for a in range(0, int(y)):
       |
@@ -935,25 +935,25 @@ fn check_specific_paths() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    error: lint:unresolved-import
+    error: lint:unresolved-import: Cannot resolve import `does_not_exist`
      --> <temp_dir>/project/tests/test_main.py:2:8
       |
     2 | import does_not_exist  # error: unresolved-import
-      |        ^^^^^^^^^^^^^^ Cannot resolve import `does_not_exist`
+      |        ^^^^^^^^^^^^^^
       |
 
-    error: lint:division-by-zero
+    error: lint:division-by-zero: Cannot divide object of type `Literal[4]` by zero
      --> <temp_dir>/project/main.py:2:5
       |
     2 | y = 4 / 0  # error: division-by-zero
-      |     ^^^^^ Cannot divide object of type `Literal[4]` by zero
+      |     ^^^^^
       |
 
-    error: lint:unresolved-import
+    error: lint:unresolved-import: Cannot resolve import `main2`
      --> <temp_dir>/project/other.py:2:6
       |
     2 | from main2 import z  # error: unresolved-import
-      |      ^^^^^ Cannot resolve import `main2`
+      |      ^^^^^
     3 |
     4 | print(z)
       |
@@ -972,18 +972,18 @@ fn check_specific_paths() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    error: lint:unresolved-import
+    error: lint:unresolved-import: Cannot resolve import `does_not_exist`
      --> <temp_dir>/project/tests/test_main.py:2:8
       |
     2 | import does_not_exist  # error: unresolved-import
-      |        ^^^^^^^^^^^^^^ Cannot resolve import `does_not_exist`
+      |        ^^^^^^^^^^^^^^
       |
 
-    error: lint:unresolved-import
+    error: lint:unresolved-import: Cannot resolve import `main2`
      --> <temp_dir>/project/other.py:2:6
       |
     2 | from main2 import z  # error: unresolved-import
-      |      ^^^^^ Cannot resolve import `main2`
+      |      ^^^^^
     3 |
     4 | print(z)
       |

--- a/crates/red_knot/tests/cli.rs
+++ b/crates/red_knot/tests/cli.rs
@@ -274,13 +274,13 @@ fn configuration_rule_severity() -> anyhow::Result<()> {
     4 | for a in range(0, int(y)):
       |
 
-    warning: lint:possibly-unresolved-reference
+    warning: lint:possibly-unresolved-reference: Name `x` used when possibly not defined
      --> <temp_dir>/test.py:7:7
       |
     5 |     x = a
     6 |
     7 | print(x)  # possibly-unresolved-reference
-      |       ^ Name `x` used when possibly not defined
+      |       ^
       |
 
     Found 2 diagnostics
@@ -361,13 +361,13 @@ fn cli_rule_severity() -> anyhow::Result<()> {
     6 | for a in range(0, int(y)):
       |
 
-    warning: lint:possibly-unresolved-reference
+    warning: lint:possibly-unresolved-reference: Name `x` used when possibly not defined
      --> <temp_dir>/test.py:9:7
       |
     7 |     x = a
     8 |
     9 | print(x)  # possibly-unresolved-reference
-      |       ^ Name `x` used when possibly not defined
+      |       ^
       |
 
     Found 3 diagnostics
@@ -448,13 +448,13 @@ fn cli_rule_severity_precedence() -> anyhow::Result<()> {
     4 | for a in range(0, int(y)):
       |
 
-    warning: lint:possibly-unresolved-reference
+    warning: lint:possibly-unresolved-reference: Name `x` used when possibly not defined
      --> <temp_dir>/test.py:7:7
       |
     5 |     x = a
     6 |
     7 | print(x)  # possibly-unresolved-reference
-      |       ^ Name `x` used when possibly not defined
+      |       ^
       |
 
     Found 2 diagnostics
@@ -555,11 +555,11 @@ fn exit_code_only_warnings() -> anyhow::Result<()> {
     success: true
     exit_code: 0
     ----- stdout -----
-    warning: lint:unresolved-reference
+    warning: lint:unresolved-reference: Name `x` used when not defined
      --> <temp_dir>/test.py:1:7
       |
     1 | print(x)  # [unresolved-reference]
-      |       ^ Name `x` used when not defined
+      |       ^
       |
 
     Found 1 diagnostic
@@ -638,11 +638,11 @@ fn exit_code_no_errors_but_error_on_warning_is_true() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    warning: lint:unresolved-reference
+    warning: lint:unresolved-reference: Name `x` used when not defined
      --> <temp_dir>/test.py:1:7
       |
     1 | print(x)  # [unresolved-reference]
-      |       ^ Name `x` used when not defined
+      |       ^
       |
 
     Found 1 diagnostic
@@ -670,11 +670,11 @@ fn exit_code_no_errors_but_error_on_warning_is_enabled_in_configuration() -> any
     success: false
     exit_code: 1
     ----- stdout -----
-    warning: lint:unresolved-reference
+    warning: lint:unresolved-reference: Name `x` used when not defined
      --> <temp_dir>/test.py:1:7
       |
     1 | print(x)  # [unresolved-reference]
-      |       ^ Name `x` used when not defined
+      |       ^
       |
 
     Found 1 diagnostic
@@ -699,20 +699,20 @@ fn exit_code_both_warnings_and_errors() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    warning: lint:unresolved-reference
+    warning: lint:unresolved-reference: Name `x` used when not defined
      --> <temp_dir>/test.py:2:7
       |
     2 | print(x)     # [unresolved-reference]
-      |       ^ Name `x` used when not defined
+      |       ^
     3 | print(4[1])  # [non-subscriptable]
       |
 
-    error: lint:non-subscriptable
+    error: lint:non-subscriptable: Cannot subscript object of type `Literal[4]` with no `__getitem__` method
      --> <temp_dir>/test.py:3:7
       |
     2 | print(x)     # [unresolved-reference]
     3 | print(4[1])  # [non-subscriptable]
-      |       ^ Cannot subscript object of type `Literal[4]` with no `__getitem__` method
+      |       ^
       |
 
     Found 2 diagnostics
@@ -737,20 +737,20 @@ fn exit_code_both_warnings_and_errors_and_error_on_warning_is_true() -> anyhow::
     success: false
     exit_code: 1
     ----- stdout -----
-    warning: lint:unresolved-reference
+    warning: lint:unresolved-reference: Name `x` used when not defined
      --> <temp_dir>/test.py:2:7
       |
     2 | print(x)     # [unresolved-reference]
-      |       ^ Name `x` used when not defined
+      |       ^
     3 | print(4[1])  # [non-subscriptable]
       |
 
-    error: lint:non-subscriptable
+    error: lint:non-subscriptable: Cannot subscript object of type `Literal[4]` with no `__getitem__` method
      --> <temp_dir>/test.py:3:7
       |
     2 | print(x)     # [unresolved-reference]
     3 | print(4[1])  # [non-subscriptable]
-      |       ^ Cannot subscript object of type `Literal[4]` with no `__getitem__` method
+      |       ^
       |
 
     Found 2 diagnostics
@@ -775,20 +775,20 @@ fn exit_code_exit_zero_is_true() -> anyhow::Result<()> {
     success: true
     exit_code: 0
     ----- stdout -----
-    warning: lint:unresolved-reference
+    warning: lint:unresolved-reference: Name `x` used when not defined
      --> <temp_dir>/test.py:2:7
       |
     2 | print(x)     # [unresolved-reference]
-      |       ^ Name `x` used when not defined
+      |       ^
     3 | print(4[1])  # [non-subscriptable]
       |
 
-    error: lint:non-subscriptable
+    error: lint:non-subscriptable: Cannot subscript object of type `Literal[4]` with no `__getitem__` method
      --> <temp_dir>/test.py:3:7
       |
     2 | print(x)     # [unresolved-reference]
     3 | print(4[1])  # [non-subscriptable]
-      |       ^ Cannot subscript object of type `Literal[4]` with no `__getitem__` method
+      |       ^
       |
 
     Found 2 diagnostics
@@ -844,13 +844,13 @@ fn user_configuration() -> anyhow::Result<()> {
     4 | for a in range(0, int(y)):
       |
 
-    warning: lint:possibly-unresolved-reference
+    warning: lint:possibly-unresolved-reference: Name `x` used when possibly not defined
      --> <temp_dir>/project/main.py:7:7
       |
     5 |     x = a
     6 |
     7 | print(x)
-      |       ^ Name `x` used when possibly not defined
+      |       ^
       |
 
     Found 2 diagnostics
@@ -886,13 +886,13 @@ fn user_configuration() -> anyhow::Result<()> {
     4 | for a in range(0, int(y)):
       |
 
-    error: lint:possibly-unresolved-reference
+    error: lint:possibly-unresolved-reference: Name `x` used when possibly not defined
      --> <temp_dir>/project/main.py:7:7
       |
     5 |     x = a
     6 |
     7 | print(x)
-      |       ^ Name `x` used when possibly not defined
+      |       ^
       |
 
     Found 2 diagnostics

--- a/crates/red_knot_python_semantic/resources/mdtest/diagnostics/shadowing.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/diagnostics/shadowing.md
@@ -1,0 +1,19 @@
+# Shadowing
+
+<!-- snapshot-diagnostics -->
+
+## Implicit class shadowing
+
+```py
+class C: ...
+
+C = 1  # error: [invalid-assignment]
+```
+
+## Implicit function shadowing
+
+```py
+def f(): ...
+
+f = 1  # error: [invalid-assignment]
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/diagnostics/unpacking.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/diagnostics/unpacking.md
@@ -8,14 +8,20 @@
 a, b = 1  # error: [not-iterable]
 ```
 
-## Too many values to unpack
+## Exactly too many values to unpack
 
 ```py
 a, b = (1, 2, 3)  # error: [invalid-assignment]
 ```
 
-## Too few values to unpack
+## Exactly too few values to unpack
 
 ```py
 a, b = (1,)  # error: [invalid-assignment]
+```
+
+## Too few values to unpack
+
+```py
+[a, *b, c, d] = (1, 2)  # error: [invalid-assignment]
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/shadowing/class.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/shadowing/class.md
@@ -5,7 +5,7 @@
 ```py
 class C: ...
 
-C = 1  # error: "Implicit shadowing of class `C`; annotate to make it explicit if this is intentional"
+C = 1  # error: "Implicit shadowing of class `C`"
 ```
 
 ## Explicit

--- a/crates/red_knot_python_semantic/resources/mdtest/shadowing/function.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/shadowing/function.md
@@ -15,7 +15,7 @@ def f(x: str):
 ```py
 def f(): ...
 
-f = 1  # error: "Implicit shadowing of function `f`; annotate to make it explicit if this is intentional"
+f = 1  # error: "Implicit shadowing of function `f`"
 ```
 
 ## Explicit shadowing

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Data_descriptors_-_Invalid_`__set__`_method_signature.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Data_descriptors_-_Invalid_`__set__`_method_signature.snap
@@ -28,12 +28,12 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/attrib
 # Diagnostics
 
 ```
-error: lint:invalid-assignment
+error: lint:invalid-assignment: Invalid assignment to data descriptor attribute `attr` on type `C` with custom `__set__` method
   --> /src/mdtest_snippet.py:11:1
    |
 10 | # TODO: ideally, we would mention why this is an invalid assignment (wrong number of arguments for `__set__`)
 11 | instance.attr = 1  # error: [invalid-assignment]
-   | ^^^^^^^^^^^^^ Invalid assignment to data descriptor attribute `attr` on type `C` with custom `__set__` method
+   | ^^^^^^^^^^^^^
    |
 
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Data_descriptors_-_Invalid_argument_type.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Data_descriptors_-_Invalid_argument_type.snap
@@ -29,12 +29,12 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/attrib
 # Diagnostics
 
 ```
-error: lint:invalid-assignment
+error: lint:invalid-assignment: Invalid assignment to data descriptor attribute `attr` on type `C` with custom `__set__` method
   --> /src/mdtest_snippet.py:12:1
    |
 11 | # TODO: ideally, we would mention why this is an invalid assignment (wrong argument type for `value` parameter)
 12 | instance.attr = "wrong"  # error: [invalid-assignment]
-   | ^^^^^^^^^^^^^ Invalid assignment to data descriptor attribute `attr` on type `C` with custom `__set__` method
+   | ^^^^^^^^^^^^^
    |
 
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Instance_attributes_with_class-level_defaults.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Instance_attributes_with_class-level_defaults.snap
@@ -26,13 +26,13 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/attrib
 # Diagnostics
 
 ```
-error: lint:invalid-assignment
+error: lint:invalid-assignment: Object of type `Literal["wrong"]` is not assignable to attribute `attr` of type `int`
  --> /src/mdtest_snippet.py:6:1
   |
 4 | instance = C()
 5 | instance.attr = 1  # fine
 6 | instance.attr = "wrong"  # error: [invalid-assignment]
-  | ^^^^^^^^^^^^^ Object of type `Literal["wrong"]` is not assignable to attribute `attr` of type `int`
+  | ^^^^^^^^^^^^^
 7 |
 8 | C.attr = 1  # fine
   |
@@ -40,12 +40,12 @@ error: lint:invalid-assignment
 ```
 
 ```
-error: lint:invalid-assignment
+error: lint:invalid-assignment: Object of type `Literal["wrong"]` is not assignable to attribute `attr` of type `int`
  --> /src/mdtest_snippet.py:9:1
   |
 8 | C.attr = 1  # fine
 9 | C.attr = "wrong"  # error: [invalid-assignment]
-  | ^^^^^^ Object of type `Literal["wrong"]` is not assignable to attribute `attr` of type `int`
+  | ^^^^^^
   |
 
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Possibly-unbound_attributes.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Possibly-unbound_attributes.snap
@@ -26,13 +26,13 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/attrib
 # Diagnostics
 
 ```
-warning: lint:possibly-unbound-attribute
+warning: lint:possibly-unbound-attribute: Attribute `attr` on type `Literal[C]` is possibly unbound
  --> /src/mdtest_snippet.py:6:5
   |
 4 |             attr: int = 0
 5 |
 6 |     C.attr = 1  # error: [possibly-unbound-attribute]
-  |     ^^^^^^ Attribute `attr` on type `Literal[C]` is possibly unbound
+  |     ^^^^^^
 7 |
 8 |     instance = C()
   |
@@ -40,12 +40,12 @@ warning: lint:possibly-unbound-attribute
 ```
 
 ```
-warning: lint:possibly-unbound-attribute
+warning: lint:possibly-unbound-attribute: Attribute `attr` on type `C` is possibly unbound
  --> /src/mdtest_snippet.py:9:5
   |
 8 |     instance = C()
 9 |     instance.attr = 1  # error: [possibly-unbound-attribute]
-  |     ^^^^^^^^^^^^^ Attribute `attr` on type `C` is possibly unbound
+  |     ^^^^^^^^^^^^^
   |
 
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Pure_instance_attributes.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Pure_instance_attributes.snap
@@ -26,13 +26,13 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/attrib
 # Diagnostics
 
 ```
-error: lint:invalid-assignment
+error: lint:invalid-assignment: Object of type `Literal["wrong"]` is not assignable to attribute `attr` of type `int`
  --> /src/mdtest_snippet.py:7:1
   |
 5 | instance = C()
 6 | instance.attr = 1  # fine
 7 | instance.attr = "wrong"  # error: [invalid-assignment]
-  | ^^^^^^^^^^^^^ Object of type `Literal["wrong"]` is not assignable to attribute `attr` of type `int`
+  | ^^^^^^^^^^^^^
 8 |
 9 | C.attr = 1  # error: [invalid-attribute-access]
   |

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Pure_instance_attributes.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Pure_instance_attributes.snap
@@ -40,13 +40,13 @@ error: lint:invalid-assignment: Object of type `Literal["wrong"]` is not assigna
 ```
 
 ```
-error: lint:invalid-attribute-access
+error: lint:invalid-attribute-access: Cannot assign to instance attribute `attr` from the class object `Literal[C]`
  --> /src/mdtest_snippet.py:9:1
   |
 7 | instance.attr = "wrong"  # error: [invalid-assignment]
 8 |
 9 | C.attr = 1  # error: [invalid-attribute-access]
-  | ^^^^^^ Cannot assign to instance attribute `attr` from the class object `Literal[C]`
+  | ^^^^^^
   |
 
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Setting_attributes_on_union_types.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Setting_attributes_on_union_types.snap
@@ -37,12 +37,12 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/attrib
 # Diagnostics
 
 ```
-error: lint:invalid-assignment
+error: lint:invalid-assignment: Object of type `Literal[1]` is not assignable to attribute `attr` on type `Literal[C1, C1]`
   --> /src/mdtest_snippet.py:11:5
    |
 10 |     # TODO: The error message here could be improved to explain why the assignment fails.
 11 |     C1.attr = 1  # error: [invalid-assignment]
-   |     ^^^^^^^ Object of type `Literal[1]` is not assignable to attribute `attr` on type `Literal[C1, C1]`
+   |     ^^^^^^^
 12 |
 13 |     class C2:
    |

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Unknown_attributes.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Unknown_attributes.snap
@@ -23,13 +23,13 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/attrib
 # Diagnostics
 
 ```
-error: lint:unresolved-attribute
+error: lint:unresolved-attribute: Unresolved attribute `non_existent` on type `Literal[C]`.
  --> /src/mdtest_snippet.py:3:1
   |
 1 | class C: ...
 2 |
 3 | C.non_existent = 1  # error: [unresolved-attribute]
-  | ^^^^^^^^^^^^^^ Unresolved attribute `non_existent` on type `Literal[C]`.
+  | ^^^^^^^^^^^^^^
 4 |
 5 | instance = C()
   |
@@ -37,12 +37,12 @@ error: lint:unresolved-attribute
 ```
 
 ```
-error: lint:unresolved-attribute
+error: lint:unresolved-attribute: Unresolved attribute `non_existent` on type `C`.
  --> /src/mdtest_snippet.py:6:1
   |
 5 | instance = C()
 6 | instance.non_existent = 1  # error: [unresolved-attribute]
-  | ^^^^^^^^^^^^^^^^^^^^^ Unresolved attribute `non_existent` on type `C`.
+  | ^^^^^^^^^^^^^^^^^^^^^
   |
 
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_`ClassVar`s.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_`ClassVar`s.snap
@@ -27,12 +27,12 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/attrib
 # Diagnostics
 
 ```
-error: lint:invalid-assignment
+error: lint:invalid-assignment: Object of type `Literal["wrong"]` is not assignable to attribute `attr` of type `int`
  --> /src/mdtest_snippet.py:7:1
   |
 6 | C.attr = 1  # fine
 7 | C.attr = "wrong"  # error: [invalid-assignment]
-  | ^^^^^^ Object of type `Literal["wrong"]` is not assignable to attribute `attr` of type `int`
+  | ^^^^^^
 8 |
 9 | instance = C()
   |

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_`ClassVar`s.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_`ClassVar`s.snap
@@ -40,12 +40,12 @@ error: lint:invalid-assignment: Object of type `Literal["wrong"]` is not assigna
 ```
 
 ```
-error: lint:invalid-attribute-access
+error: lint:invalid-attribute-access: Cannot assign to ClassVar `attr` from an instance of type `C`
   --> /src/mdtest_snippet.py:10:1
    |
  9 | instance = C()
 10 | instance.attr = 1  # error: [invalid-attribute-access]
-   | ^^^^^^^^^^^^^ Cannot assign to ClassVar `attr` from an instance of type `C`
+   | ^^^^^^^^^^^^^
    |
 
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Unresolvable_module_import.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Unresolvable_module_import.snap
@@ -18,11 +18,11 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/import/basic.md
 # Diagnostics
 
 ```
-error: lint:unresolved-import
+error: lint:unresolved-import: Cannot resolve import `zqzqzqzqzqzqzq`
  --> /src/mdtest_snippet.py:1:8
   |
 1 | import zqzqzqzqzqzqzq  # error: [unresolved-import] "Cannot resolve import `zqzqzqzqzqzqzq`"
-  |        ^^^^^^^^^^^^^^ Cannot resolve import `zqzqzqzqzqzqzq`
+  |        ^^^^^^^^^^^^^^
   |
 
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Unresolvable_submodule_imports.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Unresolvable_submodule_imports.snap
@@ -27,12 +27,12 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/import/basic.md
 # Diagnostics
 
 ```
-error: lint:unresolved-import
+error: lint:unresolved-import: Cannot resolve import `a.foo`
  --> /src/mdtest_snippet.py:2:8
   |
 1 | # Topmost component resolvable, submodule not resolvable:
 2 | import a.foo  # error: [unresolved-import] "Cannot resolve import `a.foo`"
-  |        ^^^^^ Cannot resolve import `a.foo`
+  |        ^^^^^
 3 |
 4 | # Topmost component unresolvable:
   |
@@ -40,12 +40,12 @@ error: lint:unresolved-import
 ```
 
 ```
-error: lint:unresolved-import
+error: lint:unresolved-import: Cannot resolve import `b.foo`
  --> /src/mdtest_snippet.py:5:8
   |
 4 | # Topmost component unresolvable:
 5 | import b.foo  # error: [unresolved-import] "Cannot resolve import `b.foo`"
-  |        ^^^^^ Cannot resolve import `b.foo`
+  |        ^^^^^
   |
 
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Bad_`__getitem__`_method.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Bad_`__getitem__`_method.snap
@@ -28,12 +28,12 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/loops/for.md
 # Diagnostics
 
 ```
-error: lint:not-iterable
+error: lint:not-iterable: Object of type `Iterable` is not iterable because it has no `__iter__` method and its `__getitem__` method has an incorrect signature for the old-style iteration protocol (expected a signature at least as permissive as `def __getitem__(self, key: int): ...`)
   --> /src/mdtest_snippet.py:10:10
    |
  9 | # error: [not-iterable]
 10 | for x in Iterable():
-   |          ^^^^^^^^^^ Object of type `Iterable` is not iterable because it has no `__iter__` method and its `__getitem__` method has an incorrect signature for the old-style iteration protocol (expected a signature at least as permissive as `def __getitem__(self, key: int): ...`)
+   |          ^^^^^^^^^^
 11 |     reveal_type(x)  # revealed: int
    |
 

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Invalid_iterable.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Invalid_iterable.snap
@@ -20,12 +20,12 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/loops/for.md
 # Diagnostics
 
 ```
-error: lint:not-iterable
+error: lint:not-iterable: Object of type `Literal[123]` is not iterable because it doesn't have an `__iter__` method or a `__getitem__` method
  --> /src/mdtest_snippet.py:2:10
   |
 1 | nonsense = 123
 2 | for x in nonsense:  # error: [not-iterable]
-  |          ^^^^^^^^ Object of type `Literal[123]` is not iterable because it doesn't have an `__iter__` method or a `__getitem__` method
+  |          ^^^^^^^^
 3 |     pass
   |
 

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_New_over_old_style_iteration_protocol.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_New_over_old_style_iteration_protocol.snap
@@ -24,13 +24,13 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/loops/for.md
 # Diagnostics
 
 ```
-error: lint:not-iterable
+error: lint:not-iterable: Object of type `NotIterable` is not iterable because its `__iter__` attribute has type `None`, which is not callable
  --> /src/mdtest_snippet.py:6:10
   |
 4 |     __iter__: None = None
 5 |
 6 | for x in NotIterable():  # error: [not-iterable]
-  |          ^^^^^^^^^^^^^ Object of type `NotIterable` is not iterable because its `__iter__` attribute has type `None`, which is not callable
+  |          ^^^^^^^^^^^^^
 7 |     pass
   |
 

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_No_`__iter__`_method_and_`__getitem__`_is_not_callable.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_No_`__iter__`_method_and_`__getitem__`_is_not_callable.snap
@@ -25,12 +25,12 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/loops/for.md
 # Diagnostics
 
 ```
-error: lint:not-iterable
+error: lint:not-iterable: Object of type `Bad` is not iterable because it has no `__iter__` method and its `__getitem__` attribute has type `None`, which is not callable
  --> /src/mdtest_snippet.py:7:10
   |
 6 | # error: [not-iterable]
 7 | for x in Bad():
-  |          ^^^^^ Object of type `Bad` is not iterable because it has no `__iter__` method and its `__getitem__` attribute has type `None`, which is not callable
+  |          ^^^^^
 8 |     reveal_type(x)  # revealed: Unknown
   |
 

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly-not-callable_`__getitem__`_method.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly-not-callable_`__getitem__`_method.snap
@@ -46,12 +46,12 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/loops/for.md
 # Diagnostics
 
 ```
-error: lint:not-iterable
+error: lint:not-iterable: Object of type `Iterable1` may not be iterable because it has no `__iter__` method and its `__getitem__` attribute (with type `CustomCallable`) may not be callable
   --> /src/mdtest_snippet.py:22:14
    |
 21 |     # error: [not-iterable]
 22 |     for x in Iterable1():
-   |              ^^^^^^^^^^^ Object of type `Iterable1` may not be iterable because it has no `__iter__` method and its `__getitem__` attribute (with type `CustomCallable`) may not be callable
+   |              ^^^^^^^^^^^
 23 |         # TODO... `int` might be ideal here?
 24 |         reveal_type(x)  # revealed: int | Unknown
    |
@@ -73,12 +73,12 @@ info: revealed-type: Revealed type
 ```
 
 ```
-error: lint:not-iterable
+error: lint:not-iterable: Object of type `Iterable2` may not be iterable because it has no `__iter__` method and its `__getitem__` attribute (with type `(bound method Iterable2.__getitem__(key: int) -> int) | None`) may not be callable
   --> /src/mdtest_snippet.py:27:14
    |
 26 |     # error: [not-iterable]
 27 |     for y in Iterable2():
-   |              ^^^^^^^^^^^ Object of type `Iterable2` may not be iterable because it has no `__iter__` method and its `__getitem__` attribute (with type `(bound method Iterable2.__getitem__(key: int) -> int) | None`) may not be callable
+   |              ^^^^^^^^^^^
 28 |         # TODO... `int` might be ideal here?
 29 |         reveal_type(y)  # revealed: int | Unknown
    |

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__getitem__`_methods.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__getitem__`_methods.snap
@@ -43,12 +43,12 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/loops/for.md
 # Diagnostics
 
 ```
-error: lint:not-iterable
+error: lint:not-iterable: Object of type `Iterable1` may not be iterable because it has no `__iter__` method and its `__getitem__` attribute (with type `(bound method Iterable1.__getitem__(item: int) -> str) | None`) may not be callable
   --> /src/mdtest_snippet.py:20:14
    |
 19 |     # error: [not-iterable]
 20 |     for x in Iterable1():
-   |              ^^^^^^^^^^^ Object of type `Iterable1` may not be iterable because it has no `__iter__` method and its `__getitem__` attribute (with type `(bound method Iterable1.__getitem__(item: int) -> str) | None`) may not be callable
+   |              ^^^^^^^^^^^
 21 |         # TODO: `str` might be better
 22 |         reveal_type(x)  # revealed: str | Unknown
    |
@@ -70,12 +70,12 @@ info: revealed-type: Revealed type
 ```
 
 ```
-error: lint:not-iterable
+error: lint:not-iterable: Object of type `Iterable2` may not be iterable because it has no `__iter__` method and its `__getitem__` method (with type `(bound method Iterable2.__getitem__(item: int) -> str) | (bound method Iterable2.__getitem__(item: str) -> int)`) may have an incorrect signature for the old-style iteration protocol (expected a signature at least as permissive as `def __getitem__(self, key: int): ...`)
   --> /src/mdtest_snippet.py:25:14
    |
 24 |     # error: [not-iterable]
 25 |     for y in Iterable2():
-   |              ^^^^^^^^^^^ Object of type `Iterable2` may not be iterable because it has no `__iter__` method and its `__getitem__` method (with type `(bound method Iterable2.__getitem__(item: int) -> str) | (bound method Iterable2.__getitem__(item: str) -> int)`) may have an incorrect signature for the old-style iteration protocol (expected a signature at least as permissive as `def __getitem__(self, key: int): ...`)
+   |              ^^^^^^^^^^^
 26 |         reveal_type(y)  # revealed: str | int
    |
 

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__iter__`_methods.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__iter__`_methods.snap
@@ -47,12 +47,12 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/loops/for.md
 # Diagnostics
 
 ```
-error: lint:not-iterable
+error: lint:not-iterable: Object of type `Iterable1` may not be iterable because its `__iter__` method (with type `(bound method Iterable1.__iter__() -> Iterator) | (bound method Iterable1.__iter__(invalid_extra_arg) -> Iterator)`) may have an invalid signature (expected `def __iter__(self): ...`)
   --> /src/mdtest_snippet.py:17:14
    |
 16 |     # error: [not-iterable]
 17 |     for x in Iterable1():
-   |              ^^^^^^^^^^^ Object of type `Iterable1` may not be iterable because its `__iter__` method (with type `(bound method Iterable1.__iter__() -> Iterator) | (bound method Iterable1.__iter__(invalid_extra_arg) -> Iterator)`) may have an invalid signature (expected `def __iter__(self): ...`)
+   |              ^^^^^^^^^^^
 18 |         reveal_type(x)  # revealed: int
    |
 
@@ -73,12 +73,12 @@ info: revealed-type: Revealed type
 ```
 
 ```
-error: lint:not-iterable
+error: lint:not-iterable: Object of type `Iterable2` may not be iterable because its `__iter__` attribute (with type `(bound method Iterable2.__iter__() -> Iterator) | None`) may not be callable
   --> /src/mdtest_snippet.py:28:14
    |
 27 |     # error: [not-iterable]
 28 |     for x in Iterable2():
-   |              ^^^^^^^^^^^ Object of type `Iterable2` may not be iterable because its `__iter__` attribute (with type `(bound method Iterable2.__iter__() -> Iterator) | None`) may not be callable
+   |              ^^^^^^^^^^^
 29 |         # TODO: `int` would probably be better here:
 30 |         reveal_type(x)  # revealed: int | Unknown
    |

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__next__`_method.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__next__`_method.snap
@@ -51,12 +51,12 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/loops/for.md
 # Diagnostics
 
 ```
-error: lint:not-iterable
+error: lint:not-iterable: Object of type `Iterable1` may not be iterable because its `__iter__` method returns an object of type `Iterator1`, which may have an invalid `__next__` method (expected `def __next__(self): ...`)
   --> /src/mdtest_snippet.py:28:14
    |
 27 |     # error: [not-iterable]
 28 |     for x in Iterable1():
-   |              ^^^^^^^^^^^ Object of type `Iterable1` may not be iterable because its `__iter__` method returns an object of type `Iterator1`, which may have an invalid `__next__` method (expected `def __next__(self): ...`)
+   |              ^^^^^^^^^^^
 29 |         reveal_type(x)  # revealed: int | str
    |
 
@@ -77,12 +77,12 @@ info: revealed-type: Revealed type
 ```
 
 ```
-error: lint:not-iterable
+error: lint:not-iterable: Object of type `Iterable2` may not be iterable because its `__iter__` method returns an object of type `Iterator2`, which has a `__next__` attribute that may not be callable
   --> /src/mdtest_snippet.py:32:14
    |
 31 |     # error: [not-iterable]
 32 |     for y in Iterable2():
-   |              ^^^^^^^^^^^ Object of type `Iterable2` may not be iterable because its `__iter__` method returns an object of type `Iterator2`, which has a `__next__` attribute that may not be callable
+   |              ^^^^^^^^^^^
 33 |         # TODO: `int` would probably be better here:
 34 |         reveal_type(y)  # revealed: int | Unknown
    |

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_bad_`__getitem__`_method.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_bad_`__getitem__`_method.snap
@@ -36,12 +36,12 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/loops/for.md
 # Diagnostics
 
 ```
-error: lint:not-iterable
+error: lint:not-iterable: Object of type `Iterable` may not be iterable because it may not have an `__iter__` method and its `__getitem__` method has an incorrect signature for the old-style iteration protocol (expected a signature at least as permissive as `def __getitem__(self, key: int): ...`)
   --> /src/mdtest_snippet.py:18:14
    |
 17 |     # error: [not-iterable]
 18 |     for x in Iterable():
-   |              ^^^^^^^^^^ Object of type `Iterable` may not be iterable because it may not have an `__iter__` method and its `__getitem__` method has an incorrect signature for the old-style iteration protocol (expected a signature at least as permissive as `def __getitem__(self, key: int): ...`)
+   |              ^^^^^^^^^^
 19 |         reveal_type(x)  # revealed: int | bytes
    |
 

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_possibly_invalid_`__getitem__`.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_possibly_invalid_`__getitem__`.snap
@@ -54,12 +54,12 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/loops/for.md
 # Diagnostics
 
 ```
-error: lint:not-iterable
+error: lint:not-iterable: Object of type `Iterable1` may not be iterable because it may not have an `__iter__` method and its `__getitem__` attribute (with type `(bound method Iterable1.__getitem__(item: int) -> str) | None`) may not be callable
   --> /src/mdtest_snippet.py:31:14
    |
 30 |     # error: [not-iterable]
 31 |     for x in Iterable1():
-   |              ^^^^^^^^^^^ Object of type `Iterable1` may not be iterable because it may not have an `__iter__` method and its `__getitem__` attribute (with type `(bound method Iterable1.__getitem__(item: int) -> str) | None`) may not be callable
+   |              ^^^^^^^^^^^
 32 |         # TODO: `bytes | str` might be better
 33 |         reveal_type(x)  # revealed: bytes | str | Unknown
    |
@@ -81,12 +81,12 @@ info: revealed-type: Revealed type
 ```
 
 ```
-error: lint:not-iterable
+error: lint:not-iterable: Object of type `Iterable2` may not be iterable because it may not have an `__iter__` method and its `__getitem__` method (with type `(bound method Iterable2.__getitem__(item: int) -> str) | (bound method Iterable2.__getitem__(item: str) -> int)`) may have an incorrect signature for the old-style iteration protocol (expected a signature at least as permissive as `def __getitem__(self, key: int): ...`)
   --> /src/mdtest_snippet.py:36:14
    |
 35 |     # error: [not-iterable]
 36 |     for y in Iterable2():
-   |              ^^^^^^^^^^^ Object of type `Iterable2` may not be iterable because it may not have an `__iter__` method and its `__getitem__` method (with type `(bound method Iterable2.__getitem__(item: int) -> str) | (bound method Iterable2.__getitem__(item: str) -> int)`) may have an incorrect signature for the old-style iteration protocol (expected a signature at least as permissive as `def __getitem__(self, key: int): ...`)
+   |              ^^^^^^^^^^^
 37 |         reveal_type(y)  # revealed: bytes | str | int
    |
 

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_possibly_unbound_`__getitem__`.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_possibly_unbound_`__getitem__`.snap
@@ -35,12 +35,12 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/loops/for.md
 # Diagnostics
 
 ```
-error: lint:not-iterable
+error: lint:not-iterable: Object of type `Iterable` may not be iterable because it may not have an `__iter__` method or a `__getitem__` method
   --> /src/mdtest_snippet.py:17:14
    |
 16 |     # error: [not-iterable]
 17 |     for x in Iterable():
-   |              ^^^^^^^^^^ Object of type `Iterable` may not be iterable because it may not have an `__iter__` method or a `__getitem__` method
+   |              ^^^^^^^^^^
 18 |         reveal_type(x)  # revealed: int | bytes
    |
 

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Union_type_as_iterable_where_one_union_element_has_invalid_`__iter__`_method.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Union_type_as_iterable_where_one_union_element_has_invalid_`__iter__`_method.snap
@@ -36,13 +36,13 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/loops/for.md
 # Diagnostics
 
 ```
-error: lint:not-iterable
+error: lint:not-iterable: Object of type `Test | Test2` may not be iterable because its `__iter__` method returns an object of type `TestIter | int`, which may not have a `__next__` method
   --> /src/mdtest_snippet.py:18:14
    |
 16 |     # TODO: Improve error message to state which union variant isn't iterable (https://github.com/astral-sh/ruff/issues/13989)
 17 |     # error: [not-iterable]
 18 |     for x in Test() if flag else Test2():
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Object of type `Test | Test2` may not be iterable because its `__iter__` method returns an object of type `TestIter | int`, which may not have a `__next__` method
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 19 |         reveal_type(x)  # revealed: int
    |
 

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Union_type_as_iterable_where_one_union_element_has_no_`__iter__`_method.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Union_type_as_iterable_where_one_union_element_has_no_`__iter__`_method.snap
@@ -31,13 +31,13 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/loops/for.md
 # Diagnostics
 
 ```
-error: lint:not-iterable
+error: lint:not-iterable: Object of type `Test | Literal[42]` may not be iterable because it may not have an `__iter__` method and it doesn't have a `__getitem__` method
   --> /src/mdtest_snippet.py:13:14
    |
 11 | def _(flag: bool):
 12 |     # error: [not-iterable]
 13 |     for x in Test() if flag else 42:
-   |              ^^^^^^^^^^^^^^^^^^^^^^ Object of type `Test | Literal[42]` may not be iterable because it may not have an `__iter__` method and it doesn't have a `__getitem__` method
+   |              ^^^^^^^^^^^^^^^^^^^^^^
 14 |         reveal_type(x)  # revealed: int
    |
 

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_With_non-callable_iterator.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_With_non-callable_iterator.snap
@@ -45,13 +45,13 @@ error: lint:not-iterable
 ```
 
 ```
-warning: lint:possibly-unresolved-reference
+warning: lint:possibly-unresolved-reference: Name `x` used when possibly not defined
   --> /src/mdtest_snippet.py:16:17
    |
 14 |     # revealed: Unknown
 15 |     # error: [possibly-unresolved-reference]
 16 |     reveal_type(x)
-   |                 ^ Name `x` used when possibly not defined
+   |                 ^
    |
 
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_With_non-callable_iterator.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_With_non-callable_iterator.snap
@@ -33,12 +33,12 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/loops/for.md
 # Diagnostics
 
 ```
-error: lint:not-iterable
+error: lint:not-iterable: Object of type `NotIterable` is not iterable because its `__iter__` attribute has type `int | None`, which is not callable
   --> /src/mdtest_snippet.py:11:14
    |
 10 |     # error: [not-iterable]
 11 |     for x in NotIterable():
-   |              ^^^^^^^^^^^^^ Object of type `NotIterable` is not iterable because its `__iter__` attribute has type `int | None`, which is not callable
+   |              ^^^^^^^^^^^^^
 12 |         pass
    |
 

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_does_not_return_an_iterator.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_does_not_return_an_iterator.snap
@@ -26,12 +26,12 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/loops/for.md
 # Diagnostics
 
 ```
-error: lint:not-iterable
+error: lint:not-iterable: Object of type `Bad` is not iterable because its `__iter__` method returns an object of type `int`, which has no `__next__` method
  --> /src/mdtest_snippet.py:8:10
   |
 7 | # error: [not-iterable]
 8 | for x in Bad():
-  |          ^^^^^ Object of type `Bad` is not iterable because its `__iter__` method returns an object of type `int`, which has no `__next__` method
+  |          ^^^^^
 9 |     reveal_type(x)  # revealed: Unknown
   |
 

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_method_with_a_bad_signature.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_method_with_a_bad_signature.snap
@@ -30,12 +30,12 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/loops/for.md
 # Diagnostics
 
 ```
-error: lint:not-iterable
+error: lint:not-iterable: Object of type `Iterable` is not iterable because its `__iter__` method has an invalid signature (expected `def __iter__(self): ...`)
   --> /src/mdtest_snippet.py:12:10
    |
 11 | # error: [not-iterable]
 12 | for x in Iterable():
-   |          ^^^^^^^^^^ Object of type `Iterable` is not iterable because its `__iter__` method has an invalid signature (expected `def __iter__(self): ...`)
+   |          ^^^^^^^^^^
 13 |     reveal_type(x)  # revealed: int
    |
 

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_returns_an_iterator_with_an_invalid_`__next__`_method.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_returns_an_iterator_with_an_invalid_`__next__`_method.snap
@@ -41,12 +41,12 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/loops/for.md
 # Diagnostics
 
 ```
-error: lint:not-iterable
+error: lint:not-iterable: Object of type `Iterable1` is not iterable because its `__iter__` method returns an object of type `Iterator1`, which has an invalid `__next__` method (expected `def __next__(self): ...`)
   --> /src/mdtest_snippet.py:19:10
    |
 18 | # error: [not-iterable]
 19 | for x in Iterable1():
-   |          ^^^^^^^^^^^ Object of type `Iterable1` is not iterable because its `__iter__` method returns an object of type `Iterator1`, which has an invalid `__next__` method (expected `def __next__(self): ...`)
+   |          ^^^^^^^^^^^
 20 |     reveal_type(x)  # revealed: int
    |
 
@@ -67,12 +67,12 @@ info: revealed-type: Revealed type
 ```
 
 ```
-error: lint:not-iterable
+error: lint:not-iterable: Object of type `Iterable2` is not iterable because its `__iter__` method returns an object of type `Iterator2`, which has a `__next__` attribute that is not callable
   --> /src/mdtest_snippet.py:23:10
    |
 22 | # error: [not-iterable]
 23 | for y in Iterable2():
-   |          ^^^^^^^^^^^ Object of type `Iterable2` is not iterable because its `__iter__` method returns an object of type `Iterator2`, which has a `__next__` attribute that is not callable
+   |          ^^^^^^^^^^^
 24 |     reveal_type(y)  # revealed: Unknown
    |
 

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/instances.md_-_Binary_operations_on_instances_-_Operations_involving_types_with_invalid_`__bool__`_methods.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/instances.md_-_Binary_operations_on_instances_-_Operations_involving_types_with_invalid_`__bool__`_methods.snap
@@ -24,12 +24,12 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/binary/instances.m
 # Diagnostics
 
 ```
-error: lint:unsupported-bool-conversion
+error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable`; its `__bool__` method isn't callable
  --> /src/mdtest_snippet.py:7:8
   |
 6 | # error: [unsupported-bool-conversion]
 7 | 10 and a and True
-  |        ^ Boolean conversion is unsupported for type `NotBoolable`; its `__bool__` method isn't callable
+  |        ^
   |
 
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/membership_test.md_-_Comparison___Membership_Test_-_Return_type_that_doesn't_implement_`__bool__`_correctly.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/membership_test.md_-_Comparison___Membership_Test_-_Return_type_that_doesn't_implement_`__bool__`_correctly.snap
@@ -28,12 +28,12 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/comparison/instanc
 # Diagnostics
 
 ```
-error: lint:unsupported-bool-conversion
+error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable`; its `__bool__` method isn't callable
   --> /src/mdtest_snippet.py:9:1
    |
  8 | # error: [unsupported-bool-conversion]
  9 | 10 in WithContains()
-   | ^^^^^^^^^^^^^^^^^^^^ Boolean conversion is unsupported for type `NotBoolable`; its `__bool__` method isn't callable
+   | ^^^^^^^^^^^^^^^^^^^^
 10 | # error: [unsupported-bool-conversion]
 11 | 10 not in WithContains()
    |
@@ -41,13 +41,13 @@ error: lint:unsupported-bool-conversion
 ```
 
 ```
-error: lint:unsupported-bool-conversion
+error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable`; its `__bool__` method isn't callable
   --> /src/mdtest_snippet.py:11:1
    |
  9 | 10 in WithContains()
 10 | # error: [unsupported-bool-conversion]
 11 | 10 not in WithContains()
-   | ^^^^^^^^^^^^^^^^^^^^^^^^ Boolean conversion is unsupported for type `NotBoolable`; its `__bool__` method isn't callable
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
    |
 
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/no_matching_overload.md_-_No_matching_overload_diagnostics_-_Calls_to_overloaded_functions.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/no_matching_overload.md_-_No_matching_overload_diagnostics_-_Calls_to_overloaded_functions.snap
@@ -18,11 +18,11 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/no_mat
 # Diagnostics
 
 ```
-error: lint:no-matching-overload
+error: lint:no-matching-overload: No overload of class `type` matches arguments
  --> /src/mdtest_snippet.py:1:1
   |
 1 | type("Foo", ())  # error: [no-matching-overload]
-  | ^^^^^^^^^^^^^^^ No overload of class `type` matches arguments
+  | ^^^^^^^^^^^^^^^
   |
 
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/not.md_-_Unary_not_-_Object_that_implements_`__bool__`_incorrectly.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/not.md_-_Unary_not_-_Object_that_implements_`__bool__`_incorrectly.snap
@@ -22,12 +22,12 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/unary/not.md
 # Diagnostics
 
 ```
-error: lint:unsupported-bool-conversion
+error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable`; its `__bool__` method isn't callable
  --> /src/mdtest_snippet.py:5:1
   |
 4 | # error: [unsupported-bool-conversion]
 5 | not NotBoolable()
-  | ^^^^^^^^^^^^^^^^^ Boolean conversion is unsupported for type `NotBoolable`; its `__bool__` method isn't callable
+  | ^^^^^^^^^^^^^^^^^
   |
 
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_implicit_return_type.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_implicit_return_type.snap
@@ -56,12 +56,12 @@ error: lint:invalid-return-type: Return type does not match returned value
 ```
 
 ```
-error: lint:invalid-return-type
+error: lint:invalid-return-type: Function can implicitly return `None`, which is not assignable to return type `int`
  --> /src/mdtest_snippet.py:7:22
   |
 6 | # error: [invalid-return-type]
 7 | def f(cond: bool) -> int:
-  |                      ^^^ Function can implicitly return `None`, which is not assignable to return type `int`
+  |                      ^^^
 8 |     if cond:
 9 |         return 1
   |
@@ -69,12 +69,12 @@ error: lint:invalid-return-type
 ```
 
 ```
-error: lint:invalid-return-type
+error: lint:invalid-return-type: Function can implicitly return `None`, which is not assignable to return type `int`
   --> /src/mdtest_snippet.py:12:22
    |
 11 | # error: [invalid-return-type]
 12 | def f(cond: bool) -> int:
-   |                      ^^^ Function can implicitly return `None`, which is not assignable to return type `int`
+   |                      ^^^
 13 |     if cond:
 14 |         raise ValueError()
    |
@@ -82,12 +82,12 @@ error: lint:invalid-return-type
 ```
 
 ```
-error: lint:invalid-return-type
+error: lint:invalid-return-type: Function can implicitly return `None`, which is not assignable to return type `int`
   --> /src/mdtest_snippet.py:17:22
    |
 16 | # error: [invalid-return-type]
 17 | def f(cond: bool) -> int:
-   |                      ^^^ Function can implicitly return `None`, which is not assignable to return type `int`
+   |                      ^^^
 18 |     if cond:
 19 |         cond = False
    |

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type.snap
@@ -35,12 +35,12 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/function/return_ty
 # Diagnostics
 
 ```
-error: lint:invalid-return-type
+error: lint:invalid-return-type: Function can implicitly return `None`, which is not assignable to return type `int`
  --> /src/mdtest_snippet.py:2:12
   |
 1 | # error: [invalid-return-type]
 2 | def f() -> int:
-  |            ^^^ Function can implicitly return `None`, which is not assignable to return type `int`
+  |            ^^^
 3 |     1
   |
 

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type_in_stub_file.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type_in_stub_file.snap
@@ -45,12 +45,12 @@ error: lint:invalid-return-type: Return type does not match returned value
 ```
 
 ```
-error: lint:invalid-return-type
+error: lint:invalid-return-type: Function can implicitly return `None`, which is not assignable to return type `int`
  --> /src/mdtest_snippet.pyi:6:14
   |
 5 | # error: [invalid-return-type]
 6 | def foo() -> int:
-  |              ^^^ Function can implicitly return `None`, which is not assignable to return type `int`
+  |              ^^^
 7 |     print("...")
 8 |     ...
   |
@@ -58,12 +58,12 @@ error: lint:invalid-return-type
 ```
 
 ```
-error: lint:invalid-return-type
+error: lint:invalid-return-type: Function can implicitly return `None`, which is not assignable to return type `int`
   --> /src/mdtest_snippet.pyi:11:14
    |
 10 | # error: [invalid-return-type]
 11 | def foo() -> int:
-   |              ^^^ Function can implicitly return `None`, which is not assignable to return type `int`
+   |              ^^^
 12 |     f"""{foo} is a function that ..."""
 13 |     ...
    |

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/rich_comparison.md_-_Comparison___Rich_Comparison_-_Chained_comparisons_with_objects_that_don't_implement_`__bool__`_correctly.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/rich_comparison.md_-_Comparison___Rich_Comparison_-_Chained_comparisons_with_objects_that_don't_implement_`__bool__`_correctly.snap
@@ -33,12 +33,12 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/comparison/instanc
 # Diagnostics
 
 ```
-error: lint:unsupported-bool-conversion
+error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable`; its `__bool__` method isn't callable
   --> /src/mdtest_snippet.py:12:1
    |
 11 | # error: [unsupported-bool-conversion]
 12 | 10 < Comparable() < 20
-   | ^^^^^^^^^^^^^^^^^ Boolean conversion is unsupported for type `NotBoolable`; its `__bool__` method isn't callable
+   | ^^^^^^^^^^^^^^^^^
 13 | # error: [unsupported-bool-conversion]
 14 | 10 < Comparable() < Comparable()
    |
@@ -46,13 +46,13 @@ error: lint:unsupported-bool-conversion
 ```
 
 ```
-error: lint:unsupported-bool-conversion
+error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable`; its `__bool__` method isn't callable
   --> /src/mdtest_snippet.py:14:1
    |
 12 | 10 < Comparable() < 20
 13 | # error: [unsupported-bool-conversion]
 14 | 10 < Comparable() < Comparable()
-   | ^^^^^^^^^^^^^^^^^ Boolean conversion is unsupported for type `NotBoolable`; its `__bool__` method isn't callable
+   | ^^^^^^^^^^^^^^^^^
 15 |
 16 | Comparable() < Comparable()  # fine
    |

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/shadowing.md_-_Shadowing_-_Implicit_class_shadowing.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/shadowing.md_-_Shadowing_-_Implicit_class_shadowing.snap
@@ -1,0 +1,33 @@
+---
+source: crates/red_knot_test/src/lib.rs
+expression: snapshot
+---
+---
+mdtest name: shadowing.md - Shadowing - Implicit class shadowing
+mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/shadowing.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+1 | class C: ...
+2 | 
+3 | C = 1  # error: [invalid-assignment]
+```
+
+# Diagnostics
+
+```
+error: lint:invalid-assignment: Implicit shadowing of class `C`
+ --> /src/mdtest_snippet.py:3:1
+  |
+1 | class C: ...
+2 |
+3 | C = 1  # error: [invalid-assignment]
+  | ^
+  |
+info: Annotate to make it explicit if this is intentional
+
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/shadowing.md_-_Shadowing_-_Implicit_function_shadowing.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/shadowing.md_-_Shadowing_-_Implicit_function_shadowing.snap
@@ -1,0 +1,33 @@
+---
+source: crates/red_knot_test/src/lib.rs
+expression: snapshot
+---
+---
+mdtest name: shadowing.md - Shadowing - Implicit function shadowing
+mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/shadowing.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+1 | def f(): ...
+2 | 
+3 | f = 1  # error: [invalid-assignment]
+```
+
+# Diagnostics
+
+```
+error: lint:invalid-assignment: Implicit shadowing of function `f`
+ --> /src/mdtest_snippet.py:3:1
+  |
+1 | def f(): ...
+2 |
+3 | f = 1  # error: [invalid-assignment]
+  | ^
+  |
+info: Annotate to make it explicit if this is intentional
+
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/tuples.md_-_Comparison___Tuples_-_Chained_comparisons_with_elements_that_incorrectly_implement_`__bool__`.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/tuples.md_-_Comparison___Tuples_-_Chained_comparisons_with_elements_that_incorrectly_implement_`__bool__`.snap
@@ -34,12 +34,12 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/comparison/tuples.
 # Diagnostics
 
 ```
-error: lint:unsupported-bool-conversion
+error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable | Literal[False]`; its `__bool__` method isn't callable
   --> /src/mdtest_snippet.py:15:1
    |
 14 | # error: [unsupported-bool-conversion]
 15 | a < b < b
-   | ^^^^^ Boolean conversion is unsupported for type `NotBoolable | Literal[False]`; its `__bool__` method isn't callable
+   | ^^^^^
 16 |
 17 | a < b  # fine
    |

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/tuples.md_-_Comparison___Tuples_-_Equality_with_elements_that_incorrectly_implement_`__bool__`.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/tuples.md_-_Comparison___Tuples_-_Equality_with_elements_that_incorrectly_implement_`__bool__`.snap
@@ -26,12 +26,12 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/comparison/tuples.
 # Diagnostics
 
 ```
-error: lint:unsupported-bool-conversion
+error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable`; its `__bool__` method isn't callable
  --> /src/mdtest_snippet.py:9:1
   |
 8 | # error: [unsupported-bool-conversion]
 9 | (A(),) == (A(),)
-  | ^^^^^^^^^^^^^^^^ Boolean conversion is unsupported for type `NotBoolable`; its `__bool__` method isn't callable
+  | ^^^^^^^^^^^^^^^^
   |
 
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Exactly_too_few_values_to_unpack.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Exactly_too_few_values_to_unpack.snap
@@ -18,11 +18,13 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/unpack
 # Diagnostics
 
 ```
-error: lint:invalid-assignment
+error: lint:invalid-assignment: Not enough values to unpack
  --> /src/mdtest_snippet.py:1:1
   |
 1 | a, b = (1,)  # error: [invalid-assignment]
-  | ^^^^ Not enough values to unpack (expected 2, got 1)
+  | ^^^^   ---- Got 1
+  | |
+  | Expected 2
   |
 
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Exactly_too_few_values_to_unpack.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Exactly_too_few_values_to_unpack.snap
@@ -3,7 +3,7 @@ source: crates/red_knot_test/src/lib.rs
 expression: snapshot
 ---
 ---
-mdtest name: unpacking.md - Unpacking - Too few values to unpack
+mdtest name: unpacking.md - Unpacking - Exactly too few values to unpack
 mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/unpacking.md
 ---
 
@@ -12,7 +12,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/unpack
 ## mdtest_snippet.py
 
 ```
-1 | [a, *b, c, d] = (1, 2)
+1 | a, b = (1,)  # error: [invalid-assignment]
 ```
 
 # Diagnostics
@@ -21,8 +21,8 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/unpack
 error: lint:invalid-assignment
  --> /src/mdtest_snippet.py:1:1
   |
-1 | [a, *b, c, d] = (1, 2)
-  | ^^^^^^^^^^^^^ Not enough values to unpack (expected 3 or more, got 2)
+1 | a, b = (1,)  # error: [invalid-assignment]
+  | ^^^^ Not enough values to unpack (expected 2, got 1)
   |
 
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Exactly_too_many_values_to_unpack.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Exactly_too_many_values_to_unpack.snap
@@ -3,7 +3,7 @@ source: crates/red_knot_test/src/lib.rs
 expression: snapshot
 ---
 ---
-mdtest name: unpacking.md - Unpacking - Too many values to unpack
+mdtest name: unpacking.md - Unpacking - Exactly too many values to unpack
 mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/unpacking.md
 ---
 

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Exactly_too_many_values_to_unpack.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Exactly_too_many_values_to_unpack.snap
@@ -18,11 +18,13 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/unpack
 # Diagnostics
 
 ```
-error: lint:invalid-assignment
+error: lint:invalid-assignment: Too many values to unpack
  --> /src/mdtest_snippet.py:1:1
   |
 1 | a, b = (1, 2, 3)  # error: [invalid-assignment]
-  | ^^^^ Too many values to unpack (expected 2, got 3)
+  | ^^^^   --------- Got 3
+  | |
+  | Expected 2
   |
 
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Right_hand_side_not_iterable.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Right_hand_side_not_iterable.snap
@@ -18,11 +18,11 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/unpack
 # Diagnostics
 
 ```
-error: lint:not-iterable
+error: lint:not-iterable: Object of type `Literal[1]` is not iterable because it doesn't have an `__iter__` method or a `__getitem__` method
  --> /src/mdtest_snippet.py:1:8
   |
 1 | a, b = 1  # error: [not-iterable]
-  |        ^ Object of type `Literal[1]` is not iterable because it doesn't have an `__iter__` method or a `__getitem__` method
+  |        ^
   |
 
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Too_few_values_to_unpack.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Too_few_values_to_unpack.snap
@@ -12,17 +12,19 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/unpack
 ## mdtest_snippet.py
 
 ```
-1 | [a, *b, c, d] = (1, 2)
+1 | [a, *b, c, d] = (1, 2)  # error: [invalid-assignment]
 ```
 
 # Diagnostics
 
 ```
-error: lint:invalid-assignment
+error: lint:invalid-assignment: Not enough values to unpack
  --> /src/mdtest_snippet.py:1:1
   |
-1 | [a, *b, c, d] = (1, 2)
-  | ^^^^^^^^^^^^^ Not enough values to unpack (expected 3 or more, got 2)
+1 | [a, *b, c, d] = (1, 2)  # error: [invalid-assignment]
+  | ^^^^^^^^^^^^^   ------ Got 2
+  | |
+  | Expected 3 or more
   |
 
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_An_unresolvable_import_that_does_not_use_`from`.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_An_unresolvable_import_that_does_not_use_`from`.snap
@@ -20,11 +20,11 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/unreso
 # Diagnostics
 
 ```
-error: lint:unresolved-import
+error: lint:unresolved-import: Cannot resolve import `does_not_exist`
  --> /src/mdtest_snippet.py:1:8
   |
 1 | import does_not_exist  # error: [unresolved-import]
-  |        ^^^^^^^^^^^^^^ Cannot resolve import `does_not_exist`
+  |        ^^^^^^^^^^^^^^
 2 |
 3 | x = does_not_exist.foo
   |

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_a_resolvable_module_but_unresolvable_item.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_a_resolvable_module_but_unresolvable_item.snap
@@ -25,11 +25,11 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/unreso
 # Diagnostics
 
 ```
-error: lint:unresolved-import
+error: lint:unresolved-import: Module `a` has no member `does_not_exist`
  --> /src/mdtest_snippet.py:1:28
   |
 1 | from a import does_exist1, does_not_exist, does_exist2  # error: [unresolved-import]
-  |                            ^^^^^^^^^^^^^^ Module `a` has no member `does_not_exist`
+  |                            ^^^^^^^^^^^^^^
   |
 
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_an_unknown_current_module.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_an_unknown_current_module.snap
@@ -20,11 +20,11 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/unreso
 # Diagnostics
 
 ```
-error: lint:unresolved-import
+error: lint:unresolved-import: Cannot resolve import `.does_not_exist`
  --> /src/mdtest_snippet.py:1:7
   |
 1 | from .does_not_exist import add  # error: [unresolved-import]
-  |       ^^^^^^^^^^^^^^ Cannot resolve import `.does_not_exist`
+  |       ^^^^^^^^^^^^^^
 2 |
 3 | stat = add(10, 15)
   |

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_an_unknown_nested_module.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_an_unknown_nested_module.snap
@@ -20,11 +20,11 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/unreso
 # Diagnostics
 
 ```
-error: lint:unresolved-import
+error: lint:unresolved-import: Cannot resolve import `.does_not_exist.foo.bar`
  --> /src/mdtest_snippet.py:1:7
   |
 1 | from .does_not_exist.foo.bar import add  # error: [unresolved-import]
-  |       ^^^^^^^^^^^^^^^^^^^^^^ Cannot resolve import `.does_not_exist.foo.bar`
+  |       ^^^^^^^^^^^^^^^^^^^^^^
 2 |
 3 | stat = add(10, 15)
   |

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_an_unresolvable_module.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_an_unresolvable_module.snap
@@ -20,11 +20,11 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/unreso
 # Diagnostics
 
 ```
-error: lint:unresolved-import
+error: lint:unresolved-import: Cannot resolve import `does_not_exist`
  --> /src/mdtest_snippet.py:1:6
   |
 1 | from does_not_exist import add  # error: [unresolved-import]
-  |      ^^^^^^^^^^^^^^ Cannot resolve import `does_not_exist`
+  |      ^^^^^^^^^^^^^^
 2 |
 3 | stat = add(10, 15)
   |

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_too_many_leading_dots.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_too_many_leading_dots.snap
@@ -32,11 +32,11 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/unreso
 # Diagnostics
 
 ```
-error: lint:unresolved-import
+error: lint:unresolved-import: Cannot resolve import `....foo`
  --> /src/package/subpackage/subsubpackage/__init__.py:1:10
   |
 1 | from ....foo import add  # error: [unresolved-import]
-  |          ^^^ Cannot resolve import `....foo`
+  |          ^^^
 2 |
 3 | stat = add(10, 15)
   |

--- a/crates/red_knot_python_semantic/resources/mdtest/unpacking.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/unpacking.md
@@ -65,7 +65,7 @@ reveal_type(c)  # revealed: Literal[4]
 ### Uneven unpacking (1)
 
 ```py
-# error: [invalid-assignment] "Not enough values to unpack (expected 3, got 2)"
+# error: [invalid-assignment] "Not enough values to unpack: Expected 3"
 (a, b, c) = (1, 2)
 reveal_type(a)  # revealed: Unknown
 reveal_type(b)  # revealed: Unknown
@@ -75,7 +75,7 @@ reveal_type(c)  # revealed: Unknown
 ### Uneven unpacking (2)
 
 ```py
-# error: [invalid-assignment] "Too many values to unpack (expected 2, got 3)"
+# error: [invalid-assignment] "Too many values to unpack: Expected 2"
 (a, b) = (1, 2, 3)
 reveal_type(a)  # revealed: Unknown
 reveal_type(b)  # revealed: Unknown
@@ -84,7 +84,7 @@ reveal_type(b)  # revealed: Unknown
 ### Nested uneven unpacking (1)
 
 ```py
-# error: [invalid-assignment] "Not enough values to unpack (expected 2, got 1)"
+# error: [invalid-assignment] "Not enough values to unpack: Expected 2"
 (a, (b, c), d) = (1, (2,), 3)
 reveal_type(a)  # revealed: Literal[1]
 reveal_type(b)  # revealed: Unknown
@@ -95,7 +95,7 @@ reveal_type(d)  # revealed: Literal[3]
 ### Nested uneven unpacking (2)
 
 ```py
-# error: [invalid-assignment] "Too many values to unpack (expected 2, got 3)"
+# error: [invalid-assignment] "Too many values to unpack: Expected 2"
 (a, (b, c), d) = (1, (2, 3, 4), 5)
 reveal_type(a)  # revealed: Literal[1]
 reveal_type(b)  # revealed: Unknown
@@ -106,7 +106,7 @@ reveal_type(d)  # revealed: Literal[5]
 ### Starred expression (1)
 
 ```py
-# error: [invalid-assignment] "Not enough values to unpack (expected 3 or more, got 2)"
+# error: [invalid-assignment] "Not enough values to unpack: Expected 3 or more"
 [a, *b, c, d] = (1, 2)
 reveal_type(a)  # revealed: Unknown
 # TODO: Should be list[Any] once support for assigning to starred expression is added
@@ -159,7 +159,7 @@ reveal_type(c)  # revealed: @Todo(starred unpacking)
 ### Starred expression (6)
 
 ```py
-# error: [invalid-assignment] "Not enough values to unpack (expected 5 or more, got 1)"
+# error: [invalid-assignment] "Not enough values to unpack: Expected 5 or more"
 (a, b, c, *d, e, f) = (1,)
 reveal_type(a)  # revealed: Unknown
 reveal_type(b)  # revealed: Unknown
@@ -225,7 +225,7 @@ reveal_type(b)  # revealed: LiteralString
 ### Uneven unpacking (1)
 
 ```py
-# error: [invalid-assignment] "Not enough values to unpack (expected 3, got 2)"
+# error: [invalid-assignment] "Not enough values to unpack: Expected 3"
 a, b, c = "ab"
 reveal_type(a)  # revealed: Unknown
 reveal_type(b)  # revealed: Unknown
@@ -235,7 +235,7 @@ reveal_type(c)  # revealed: Unknown
 ### Uneven unpacking (2)
 
 ```py
-# error: [invalid-assignment] "Too many values to unpack (expected 2, got 3)"
+# error: [invalid-assignment] "Too many values to unpack: Expected 2"
 a, b = "abc"
 reveal_type(a)  # revealed: Unknown
 reveal_type(b)  # revealed: Unknown
@@ -244,7 +244,7 @@ reveal_type(b)  # revealed: Unknown
 ### Starred expression (1)
 
 ```py
-# error: [invalid-assignment] "Not enough values to unpack (expected 3 or more, got 2)"
+# error: [invalid-assignment] "Not enough values to unpack: Expected 3 or more"
 (a, *b, c, d) = "ab"
 reveal_type(a)  # revealed: Unknown
 # TODO: Should be list[LiteralString] once support for assigning to starred expression is added
@@ -254,7 +254,7 @@ reveal_type(d)  # revealed: Unknown
 ```
 
 ```py
-# error: [invalid-assignment] "Not enough values to unpack (expected 3 or more, got 1)"
+# error: [invalid-assignment] "Not enough values to unpack: Expected 3 or more"
 (a, b, *c, d) = "a"
 reveal_type(a)  # revealed: Unknown
 reveal_type(b)  # revealed: Unknown
@@ -306,7 +306,7 @@ reveal_type(c)  # revealed: @Todo(starred unpacking)
 ### Unicode
 
 ```py
-# error: [invalid-assignment] "Not enough values to unpack (expected 2, got 1)"
+# error: [invalid-assignment] "Not enough values to unpack: Expected 2"
 (a, b) = "é"
 
 reveal_type(a)  # revealed: Unknown
@@ -316,7 +316,7 @@ reveal_type(b)  # revealed: Unknown
 ### Unicode escape (1)
 
 ```py
-# error: [invalid-assignment] "Not enough values to unpack (expected 2, got 1)"
+# error: [invalid-assignment] "Not enough values to unpack: Expected 2"
 (a, b) = "\u9e6c"
 
 reveal_type(a)  # revealed: Unknown
@@ -326,7 +326,7 @@ reveal_type(b)  # revealed: Unknown
 ### Unicode escape (2)
 
 ```py
-# error: [invalid-assignment] "Not enough values to unpack (expected 2, got 1)"
+# error: [invalid-assignment] "Not enough values to unpack: Expected 2"
 (a, b) = "\U0010ffff"
 
 reveal_type(a)  # revealed: Unknown
@@ -420,8 +420,8 @@ def _(arg: tuple[int, bytes, int] | tuple[int, int, str, int, bytes]):
 
 ```py
 def _(arg: tuple[int, bytes, int] | tuple[int, int, str, int, bytes]):
-    # error: [invalid-assignment] "Too many values to unpack (expected 2, got 3)"
-    # error: [invalid-assignment] "Too many values to unpack (expected 2, got 5)"
+    # error: [invalid-assignment] "Too many values to unpack: Expected 2"
+    # error: [invalid-assignment] "Too many values to unpack: Expected 2"
     a, b = arg
     reveal_type(a)  # revealed: Unknown
     reveal_type(b)  # revealed: Unknown
@@ -431,8 +431,8 @@ def _(arg: tuple[int, bytes, int] | tuple[int, int, str, int, bytes]):
 
 ```py
 def _(arg: tuple[int, bytes] | tuple[int, str]):
-    # error: [invalid-assignment] "Not enough values to unpack (expected 3, got 2)"
-    # error: [invalid-assignment] "Not enough values to unpack (expected 3, got 2)"
+    # error: [invalid-assignment] "Not enough values to unpack: Expected 3"
+    # error: [invalid-assignment] "Not enough values to unpack: Expected 3"
     a, b, c = arg
     reveal_type(a)  # revealed: Unknown
     reveal_type(b)  # revealed: Unknown
@@ -575,7 +575,7 @@ for a, b in ((1, 2), ("a", "b")):
 # error: "Object of type `Literal[1]` is not iterable"
 # error: "Object of type `Literal[2]` is not iterable"
 # error: "Object of type `Literal[4]` is not iterable"
-# error: [invalid-assignment] "Not enough values to unpack (expected 2, got 1)"
+# error: [invalid-assignment] "Not enough values to unpack: Expected 2"
 for a, b in (1, 2, (3, "a"), 4, (5, "b"), "c"):
     reveal_type(a)  # revealed: Unknown | Literal[3, 5]
     reveal_type(b)  # revealed: Unknown | Literal["a", "b"]
@@ -702,7 +702,7 @@ class ContextManager:
     def __exit__(self, *args) -> None:
         pass
 
-# error: [invalid-assignment] "Not enough values to unpack (expected 3, got 2)"
+# error: [invalid-assignment] "Not enough values to unpack: Expected 3"
 with ContextManager() as (a, b, c):
     reveal_type(a)  # revealed: Unknown
     reveal_type(b)  # revealed: Unknown
@@ -765,7 +765,7 @@ def _(arg: tuple[tuple[int, int, int], tuple[int, str, bytes], tuple[int, int, s
 # error: "Object of type `Literal[1]` is not iterable"
 # error: "Object of type `Literal[2]` is not iterable"
 # error: "Object of type `Literal[4]` is not iterable"
-# error: [invalid-assignment] "Not enough values to unpack (expected 2, got 1)"
+# error: [invalid-assignment] "Not enough values to unpack: Expected 2"
 # revealed: tuple[Unknown | Literal[3, 5], Unknown | Literal["a", "b"]]
 [reveal_type((a, b)) for a, b in (1, 2, (3, "a"), 4, (5, "b"), "c")]
 ```

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -5029,11 +5029,10 @@ impl<'db> InvalidTypeExpressionError<'db> {
         } = self;
         if is_reachable {
             for error in invalid_expressions {
-                context.report_lint_old(
-                    &INVALID_TYPE_FORM,
-                    node,
-                    format_args!("{}", error.reason(context.db())),
-                );
+                let Some(builder) = context.report_lint(&INVALID_TYPE_FORM, node) else {
+                    continue;
+                };
+                builder.into_diagnostic(error.reason(context.db()));
             }
         }
         fallback_type
@@ -5218,6 +5217,11 @@ impl<'db> ContextManagerError<'db> {
         context_expression_type: Type<'db>,
         context_expression_node: ast::AnyNodeRef,
     ) {
+        let Some(builder) = context.report_lint(&INVALID_CONTEXT_MANAGER, context_expression_node)
+        else {
+            return;
+        };
+
         let format_call_dunder_error = |call_dunder_error: &CallDunderError<'db>, name: &str| {
             match call_dunder_error {
                 CallDunderError::MethodNotAvailable => format!("it does not implement `{name}`"),
@@ -5269,9 +5273,7 @@ impl<'db> ContextManagerError<'db> {
             } => format_call_dunder_errors(enter_error, "__enter__", exit_error, "__exit__"),
         };
 
-        context.report_lint_old(
-            &INVALID_CONTEXT_MANAGER,
-            context_expression_node,
+        builder.into_diagnostic(
             format_args!(
                 "Object of type `{context_expression}` cannot be used with `with` because {formatted_errors}",
                 context_expression = context_expression_type.display(db)
@@ -5369,10 +5371,13 @@ impl<'db> IterationError<'db> {
         iterable_type: Type<'db>,
         iterable_node: ast::AnyNodeRef,
     ) {
+        let Some(builder) = context.report_lint(&NOT_ITERABLE, iterable_node) else {
+            return;
+        };
         let db = context.db();
 
         let report_not_iterable = |arguments: std::fmt::Arguments| {
-            context.report_lint_old(&NOT_ITERABLE, iterable_node, arguments);
+            builder.into_diagnostic(arguments);
         };
 
         // TODO: for all of these error variants, the "explanation" for the diagnostic
@@ -5646,13 +5651,14 @@ impl<'db> BoolError<'db> {
     }
 
     fn report_diagnostic_impl(&self, context: &InferContext, condition: TextRange) {
+        let Some(builder) = context.report_lint(&UNSUPPORTED_BOOL_CONVERSION, condition) else {
+            return;
+        };
         match self {
             Self::IncorrectArguments {
                 not_boolable_type, ..
             } => {
-                context.report_lint_old(
-                    &UNSUPPORTED_BOOL_CONVERSION,
-                    condition,
+                builder.into_diagnostic(
                     format_args!(
                         "Boolean conversion is unsupported for type `{}`; it incorrectly implements `__bool__`",
                         not_boolable_type.display(context.db())
@@ -5663,25 +5669,20 @@ impl<'db> BoolError<'db> {
                 not_boolable_type,
                 return_type,
             } => {
-                context.report_lint_old(
-                    &UNSUPPORTED_BOOL_CONVERSION,
-                    condition,
-                    format_args!(
-                        "Boolean conversion is unsupported for type `{not_boolable}`; the return type of its bool method (`{return_type}`) isn't assignable to `bool",
-                        not_boolable = not_boolable_type.display(context.db()),
-                        return_type = return_type.display(context.db())
-                    ),
-                );
+                builder.into_diagnostic(format_args!(
+                    "Boolean conversion is unsupported for type `{not_boolable}`; \
+                     the return type of its bool method (`{return_type}`) \
+                     isn't assignable to `bool",
+                    not_boolable = not_boolable_type.display(context.db()),
+                    return_type = return_type.display(context.db())
+                ));
             }
             Self::NotCallable { not_boolable_type } => {
-                context.report_lint_old(
-                    &UNSUPPORTED_BOOL_CONVERSION,
-                    condition,
-                    format_args!(
-                        "Boolean conversion is unsupported for type `{}`; its `__bool__` method isn't callable",
-                        not_boolable_type.display(context.db())
-                    ),
-                );
+                builder.into_diagnostic(format_args!(
+                    "Boolean conversion is unsupported for type `{}`; \
+                     its `__bool__` method isn't callable",
+                    not_boolable_type.display(context.db())
+                ));
             }
             Self::Union { union, .. } => {
                 let first_error = union
@@ -5690,26 +5691,20 @@ impl<'db> BoolError<'db> {
                     .find_map(|element| element.try_bool(context.db()).err())
                     .unwrap();
 
-                context.report_lint_old(
-                        &UNSUPPORTED_BOOL_CONVERSION,
-                        condition,
-                        format_args!(
-                            "Boolean conversion is unsupported for union `{}` because `{}` doesn't implement `__bool__` correctly",
-                            Type::Union(*union).display(context.db()),
-                            first_error.not_boolable_type().display(context.db()),
-                        ),
-                    );
+                builder.into_diagnostic(format_args!(
+                    "Boolean conversion is unsupported for union `{}` \
+                     because `{}` doesn't implement `__bool__` correctly",
+                    Type::Union(*union).display(context.db()),
+                    first_error.not_boolable_type().display(context.db()),
+                ));
             }
 
             Self::Other { not_boolable_type } => {
-                context.report_lint_old(
-                    &UNSUPPORTED_BOOL_CONVERSION,
-                    condition,
-                    format_args!(
-                        "Boolean conversion is unsupported for type `{}`; it incorrectly implements `__bool__`",
-                        not_boolable_type.display(context.db())
-                    ),
-                );
+                builder.into_diagnostic(format_args!(
+                    "Boolean conversion is unsupported for type `{}`; \
+                     it incorrectly implements `__bool__`",
+                    not_boolable_type.display(context.db())
+                ));
             }
         }
     }
@@ -5740,27 +5735,28 @@ impl<'db> ConstructorCallError<'db> {
     ) {
         let report_init_error = |call_dunder_error: &CallDunderError<'db>| match call_dunder_error {
             CallDunderError::MethodNotAvailable => {
-                // If we are using vendored typeshed, it should be impossible to have missing
-                // or unbound `__init__` method on a class, as all classes have `object` in MRO.
-                // Thus the following may only trigger if a custom typeshed is used.
-                context.report_lint_old(
-                    &CALL_POSSIBLY_UNBOUND_METHOD,
-                    context_expression_node,
-                    format_args!(
-                        "`__init__` method is missing on type `{}`. Make sure your `object` in typeshed has its definition.",
+                if let Some(builder) =
+                    context.report_lint(&CALL_POSSIBLY_UNBOUND_METHOD, context_expression_node)
+                {
+                    // If we are using vendored typeshed, it should be impossible to have missing
+                    // or unbound `__init__` method on a class, as all classes have `object` in MRO.
+                    // Thus the following may only trigger if a custom typeshed is used.
+                    builder.into_diagnostic(format_args!(
+                        "`__init__` method is missing on type `{}`. \
+                         Make sure your `object` in typeshed has its definition.",
                         context_expression_type.display(context.db()),
-                    ),
-                );
+                    ));
+                }
             }
             CallDunderError::PossiblyUnbound(bindings) => {
-                context.report_lint_old(
-                    &CALL_POSSIBLY_UNBOUND_METHOD,
-                    context_expression_node,
-                    format_args!(
+                if let Some(builder) =
+                    context.report_lint(&CALL_POSSIBLY_UNBOUND_METHOD, context_expression_node)
+                {
+                    builder.into_diagnostic(format_args!(
                         "Method `__init__` on type `{}` is possibly unbound.",
                         context_expression_type.display(context.db()),
-                    ),
-                );
+                    ));
+                }
 
                 bindings.report_diagnostics(context, context_expression_node);
             }
@@ -5776,14 +5772,14 @@ impl<'db> ConstructorCallError<'db> {
                 unreachable!("`__new__` method may not be called if missing");
             }
             CallDunderError::PossiblyUnbound(bindings) => {
-                context.report_lint_old(
-                    &CALL_POSSIBLY_UNBOUND_METHOD,
-                    context_expression_node,
-                    format_args!(
+                if let Some(builder) =
+                    context.report_lint(&CALL_POSSIBLY_UNBOUND_METHOD, context_expression_node)
+                {
+                    builder.into_diagnostic(format_args!(
                         "Method `__new__` on type `{}` is possibly unbound.",
                         context_expression_type.display(context.db()),
-                    ),
-                );
+                    ));
+                }
 
                 bindings.report_diagnostics(context, context_expression_node);
             }
@@ -7130,34 +7126,31 @@ impl BoundSuperError<'_> {
     pub(super) fn report_diagnostic(&self, context: &InferContext, node: AnyNodeRef) {
         match self {
             BoundSuperError::InvalidPivotClassType { pivot_class } => {
-                context.report_lint_old(
-                    &INVALID_SUPER_ARGUMENT,
-                    node,
-                    format_args!(
+                if let Some(builder) = context.report_lint(&INVALID_SUPER_ARGUMENT, node) {
+                    builder.into_diagnostic(format_args!(
                         "`{pivot_class}` is not a valid class",
                         pivot_class = pivot_class.display(context.db()),
-                    ),
-                );
+                    ));
+                }
             }
             BoundSuperError::FailingConditionCheck { pivot_class, owner } => {
-                context.report_lint_old(
-                    &INVALID_SUPER_ARGUMENT,
-                    node,
-                    format_args!(
-                        "`{owner}` is not an instance or subclass of `{pivot_class}` in `super({pivot_class}, {owner})` call",
+                if let Some(builder) = context.report_lint(&INVALID_SUPER_ARGUMENT, node) {
+                    builder.into_diagnostic(format_args!(
+                        "`{owner}` is not an instance or subclass of \
+                         `{pivot_class}` in `super({pivot_class}, {owner})` call",
                         pivot_class = pivot_class.display(context.db()),
                         owner = owner.display(context.db()),
-                    ),
-                );
+                    ));
+                }
             }
             BoundSuperError::UnavailableImplicitArguments => {
-                context.report_lint_old(
-                    &UNAVAILABLE_IMPLICIT_SUPER_ARGUMENTS,
-                    node,
-                    format_args!(
+                if let Some(builder) =
+                    context.report_lint(&UNAVAILABLE_IMPLICIT_SUPER_ARGUMENTS, node)
+                {
+                    builder.into_diagnostic(format_args!(
                         "Cannot determine implicit arguments for 'super()' in this context",
-                    ),
-                );
+                    ));
+                }
             }
         }
     }

--- a/crates/red_knot_python_semantic/src/types/call/bind.rs
+++ b/crates/red_knot_python_semantic/src/types/call/bind.rs
@@ -179,24 +179,23 @@ impl<'db> Bindings<'db> {
         // If all union elements are not callable, report that the union as a whole is not
         // callable.
         if self.into_iter().all(|b| !b.is_callable()) {
-            context.report_lint_old(
-                &CALL_NON_CALLABLE,
-                node,
-                format_args!(
+            if let Some(builder) = context.report_lint(&CALL_NON_CALLABLE, node) {
+                builder.into_diagnostic(format_args!(
                     "Object of type `{}` is not callable",
                     self.callable_type().display(context.db())
-                ),
-            );
+                ));
+            }
             return;
         }
 
         for (index, conflicting_form) in self.conflicting_forms.iter().enumerate() {
             if *conflicting_form {
-                context.report_lint_old(
-                    &CONFLICTING_ARGUMENT_FORMS,
-                    BindingError::get_node(node, Some(index)),
-                    format_args!("Argument is used as both a value and a type form in call"),
-                );
+                let node = BindingError::get_node(node, Some(index));
+                if let Some(builder) = context.report_lint(&CONFLICTING_ARGUMENT_FORMS, node) {
+                    builder.into_diagnostic(
+                        "Argument is used as both a value and a type form in call",
+                    );
+                }
             }
         }
 
@@ -907,43 +906,37 @@ impl<'db> CallableBinding<'db> {
 
     fn report_diagnostics(&self, context: &InferContext<'db>, node: ast::AnyNodeRef) {
         if !self.is_callable() {
-            context.report_lint_old(
-                &CALL_NON_CALLABLE,
-                node,
-                format_args!(
+            if let Some(builder) = context.report_lint(&CALL_NON_CALLABLE, node) {
+                builder.into_diagnostic(format_args!(
                     "Object of type `{}` is not callable",
                     self.callable_type.display(context.db()),
-                ),
-            );
+                ));
+            }
             return;
         }
 
         if self.dunder_call_is_possibly_unbound {
-            context.report_lint_old(
-                &CALL_NON_CALLABLE,
-                node,
-                format_args!(
+            if let Some(builder) = context.report_lint(&CALL_NON_CALLABLE, node) {
+                builder.into_diagnostic(format_args!(
                     "Object of type `{}` is not callable (possibly unbound `__call__` method)",
                     self.callable_type.display(context.db()),
-                ),
-            );
+                ));
+            }
             return;
         }
 
         let callable_description = CallableDescription::new(context.db(), self.callable_type);
         if self.overloads.len() > 1 {
-            context.report_lint_old(
-                &NO_MATCHING_OVERLOAD,
-                node,
-                format_args!(
+            if let Some(builder) = context.report_lint(&NO_MATCHING_OVERLOAD, node) {
+                builder.into_diagnostic(format_args!(
                     "No overload{} matches arguments",
                     if let Some(CallableDescription { kind, name }) = callable_description {
                         format!(" of {kind} `{name}`")
                     } else {
                         String::new()
                     }
-                ),
-            );
+                ));
+            }
             return;
         }
 
@@ -1444,10 +1437,9 @@ impl<'db> BindingError<'db> {
                 expected_positional_count,
                 provided_positional_count,
             } => {
-                context.report_lint_old(
-                    &TOO_MANY_POSITIONAL_ARGUMENTS,
-                    Self::get_node(node, *first_excess_argument_index),
-                    format_args!(
+                let node = Self::get_node(node, *first_excess_argument_index);
+                if let Some(builder) = context.report_lint(&TOO_MANY_POSITIONAL_ARGUMENTS, node) {
+                    builder.into_diagnostic(format_args!(
                         "Too many positional arguments{}: expected \
                         {expected_positional_count}, got {provided_positional_count}",
                         if let Some(CallableDescription { kind, name }) = callable_description {
@@ -1455,75 +1447,70 @@ impl<'db> BindingError<'db> {
                         } else {
                             String::new()
                         }
-                    ),
-                );
+                    ));
+                }
             }
 
             Self::MissingArguments { parameters } => {
-                let s = if parameters.0.len() == 1 { "" } else { "s" };
-                context.report_lint_old(
-                    &MISSING_ARGUMENT,
-                    node,
-                    format_args!(
+                if let Some(builder) = context.report_lint(&MISSING_ARGUMENT, node) {
+                    let s = if parameters.0.len() == 1 { "" } else { "s" };
+                    builder.into_diagnostic(format_args!(
                         "No argument{s} provided for required parameter{s} {parameters}{}",
                         if let Some(CallableDescription { kind, name }) = callable_description {
                             format!(" of {kind} `{name}`")
                         } else {
                             String::new()
                         }
-                    ),
-                );
+                    ));
+                }
             }
 
             Self::UnknownArgument {
                 argument_name,
                 argument_index,
             } => {
-                context.report_lint_old(
-                    &UNKNOWN_ARGUMENT,
-                    Self::get_node(node, *argument_index),
-                    format_args!(
+                let node = Self::get_node(node, *argument_index);
+                if let Some(builder) = context.report_lint(&UNKNOWN_ARGUMENT, node) {
+                    builder.into_diagnostic(format_args!(
                         "Argument `{argument_name}` does not match any known parameter{}",
                         if let Some(CallableDescription { kind, name }) = callable_description {
                             format!(" of {kind} `{name}`")
                         } else {
                             String::new()
                         }
-                    ),
-                );
+                    ));
+                }
             }
 
             Self::ParameterAlreadyAssigned {
                 argument_index,
                 parameter,
             } => {
-                context.report_lint_old(
-                    &PARAMETER_ALREADY_ASSIGNED,
-                    Self::get_node(node, *argument_index),
-                    format_args!(
+                let node = Self::get_node(node, *argument_index);
+                if let Some(builder) = context.report_lint(&PARAMETER_ALREADY_ASSIGNED, node) {
+                    builder.into_diagnostic(format_args!(
                         "Multiple values provided for parameter {parameter}{}",
                         if let Some(CallableDescription { kind, name }) = callable_description {
                             format!(" of {kind} `{name}`")
                         } else {
                             String::new()
                         }
-                    ),
-                );
+                    ));
+                }
             }
 
             Self::InternalCallError(reason) => {
-                context.report_lint_old(
-                    &CALL_NON_CALLABLE,
-                    Self::get_node(node, None),
-                    format_args!(
+                let node = Self::get_node(node, None);
+                if let Some(builder) = context.report_lint(&CALL_NON_CALLABLE, node) {
+                    builder.into_diagnostic(format_args!(
                         "Call{} failed: {reason}",
                         if let Some(CallableDescription { kind, name }) = callable_description {
                             format!(" of {kind} `{name}`")
                         } else {
                             String::new()
                         }
-                    ),
-                );
+                    ));
+                }
             }
         }
     }

--- a/crates/red_knot_python_semantic/src/types/context.rs
+++ b/crates/red_knot_python_semantic/src/types/context.rs
@@ -404,7 +404,6 @@ impl<'db, 'ctx> LintDiagnosticGuardBuilder<'db, 'ctx> {
     ///
     /// The diagnostic can be further mutated on the guard via its `DerefMut`
     /// impl to `Diagnostic`.
-    #[must_use]
     pub(super) fn into_diagnostic(
         self,
         message: impl std::fmt::Display,
@@ -541,7 +540,6 @@ impl<'db, 'ctx> DiagnosticGuardBuilder<'db, 'ctx> {
     ///
     /// The diagnostic can be further mutated on the guard via its `DerefMut`
     /// impl to `Diagnostic`.
-    #[must_use]
     pub(super) fn into_diagnostic(
         self,
         message: impl std::fmt::Display,

--- a/crates/red_knot_python_semantic/src/types/context.rs
+++ b/crates/red_knot_python_semantic/src/types/context.rs
@@ -81,22 +81,6 @@ impl<'db> InferContext<'db> {
         self.diagnostics.get_mut().extend(other);
     }
 
-    /// Reports a lint located at `ranged`.
-    pub(super) fn report_lint_old<T>(
-        &self,
-        lint: &'static LintMetadata,
-        ranged: T,
-        message: fmt::Arguments,
-    ) where
-        T: Ranged,
-    {
-        let Some(builder) = self.report_lint(lint, ranged) else {
-            return;
-        };
-        let mut diag = builder.into_diagnostic("");
-        diag.set_primary_message(message);
-    }
-
     /// Optionally return a builder for a lint diagnostic guard.
     ///
     /// If the current context believes a diagnostic should be reported for

--- a/crates/red_knot_python_semantic/src/types/context.rs
+++ b/crates/red_knot_python_semantic/src/types/context.rs
@@ -65,6 +65,14 @@ impl<'db> InferContext<'db> {
         Span::from(self.file()).with_range(ranged.range())
     }
 
+    /// Create a secondary annotation attached to the range of the given value in
+    /// the file currently being type checked.
+    ///
+    /// The annotation returned has no message attached to it.
+    pub(crate) fn secondary<T: Ranged>(&self, ranged: T) -> Annotation {
+        Annotation::secondary(self.span(ranged))
+    }
+
     pub(crate) fn db(&self) -> &'db dyn Db {
         self.db
     }

--- a/crates/red_knot_python_semantic/src/types/diagnostic.rs
+++ b/crates/red_knot_python_semantic/src/types/diagnostic.rs
@@ -1075,14 +1075,13 @@ pub(super) fn report_index_out_of_bounds(
     length: usize,
     index: i64,
 ) {
-    context.report_lint_old(
-        &INDEX_OUT_OF_BOUNDS,
-        node,
-        format_args!(
-            "Index {index} is out of bounds for {kind} `{}` with length {length}",
-            tuple_ty.display(context.db())
-        ),
-    );
+    let Some(builder) = context.report_lint(&INDEX_OUT_OF_BOUNDS, node) else {
+        return;
+    };
+    builder.into_diagnostic(format_args!(
+        "Index {index} is out of bounds for {kind} `{}` with length {length}",
+        tuple_ty.display(context.db())
+    ));
 }
 
 /// Emit a diagnostic declaring that a type does not support subscripting.
@@ -1092,22 +1091,20 @@ pub(super) fn report_non_subscriptable(
     non_subscriptable_ty: Type,
     method: &str,
 ) {
-    context.report_lint_old(
-        &NON_SUBSCRIPTABLE,
-        node,
-        format_args!(
-            "Cannot subscript object of type `{}` with no `{method}` method",
-            non_subscriptable_ty.display(context.db())
-        ),
-    );
+    let Some(builder) = context.report_lint(&NON_SUBSCRIPTABLE, node) else {
+        return;
+    };
+    builder.into_diagnostic(format_args!(
+        "Cannot subscript object of type `{}` with no `{method}` method",
+        non_subscriptable_ty.display(context.db())
+    ));
 }
 
 pub(super) fn report_slice_step_size_zero(context: &InferContext, node: AnyNodeRef) {
-    context.report_lint_old(
-        &ZERO_STEPSIZE_IN_SLICE,
-        node,
-        format_args!("Slice step size can not be zero"),
-    );
+    let Some(builder) = context.report_lint(&ZERO_STEPSIZE_IN_SLICE, node) else {
+        return;
+    };
+    builder.into_diagnostic("Slice step size can not be zero");
 }
 
 fn report_invalid_assignment_with_message(
@@ -1209,21 +1206,21 @@ pub(super) fn report_implicit_return_type(
     range: impl Ranged,
     expected_ty: Type,
 ) {
-    context.report_lint_old(
-        &INVALID_RETURN_TYPE,
-        range,
-        format_args!(
-            "Function can implicitly return `None`, which is not assignable to return type `{}`",
-            expected_ty.display(context.db())
-        ),
-    );
+    let Some(builder) = context.report_lint(&INVALID_RETURN_TYPE, range) else {
+        return;
+    };
+    builder.into_diagnostic(format_args!(
+        "Function can implicitly return `None`, which is not assignable to return type `{}`",
+        expected_ty.display(context.db())
+    ));
 }
 
 pub(super) fn report_invalid_type_checking_constant(context: &InferContext, node: AnyNodeRef) {
-    context.report_lint_old(
-        &INVALID_TYPE_CHECKING_CONSTANT,
-        node,
-        format_args!("The name TYPE_CHECKING is reserved for use as a flag; only False can be assigned to it.",),
+    let Some(builder) = context.report_lint(&INVALID_TYPE_CHECKING_CONSTANT, node) else {
+        return;
+    };
+    builder.into_diagnostic(
+        "The name TYPE_CHECKING is reserved for use as a flag; only False can be assigned to it",
     );
 }
 
@@ -1231,13 +1228,12 @@ pub(super) fn report_possibly_unresolved_reference(
     context: &InferContext,
     expr_name_node: &ast::ExprName,
 ) {
-    let ast::ExprName { id, .. } = expr_name_node;
+    let Some(builder) = context.report_lint(&POSSIBLY_UNRESOLVED_REFERENCE, expr_name_node) else {
+        return;
+    };
 
-    context.report_lint_old(
-        &POSSIBLY_UNRESOLVED_REFERENCE,
-        expr_name_node,
-        format_args!("Name `{id}` used when possibly not defined"),
-    );
+    let ast::ExprName { id, .. } = expr_name_node;
+    builder.into_diagnostic(format_args!("Name `{id}` used when possibly not defined"));
 }
 
 pub(super) fn report_possibly_unbound_attribute(
@@ -1246,93 +1242,86 @@ pub(super) fn report_possibly_unbound_attribute(
     attribute: &str,
     object_ty: Type,
 ) {
-    context.report_lint_old(
-        &POSSIBLY_UNBOUND_ATTRIBUTE,
-        target,
-        format_args!(
-            "Attribute `{attribute}` on type `{}` is possibly unbound",
-            object_ty.display(context.db()),
-        ),
-    );
+    let Some(builder) = context.report_lint(&POSSIBLY_UNBOUND_ATTRIBUTE, target) else {
+        return;
+    };
+    builder.into_diagnostic(format_args!(
+        "Attribute `{attribute}` on type `{}` is possibly unbound",
+        object_ty.display(context.db()),
+    ));
 }
 
 pub(super) fn report_unresolved_reference(context: &InferContext, expr_name_node: &ast::ExprName) {
-    let ast::ExprName { id, .. } = expr_name_node;
+    let Some(builder) = context.report_lint(&UNRESOLVED_REFERENCE, expr_name_node) else {
+        return;
+    };
 
-    context.report_lint_old(
-        &UNRESOLVED_REFERENCE,
-        expr_name_node,
-        format_args!("Name `{id}` used when not defined"),
-    );
+    let ast::ExprName { id, .. } = expr_name_node;
+    builder.into_diagnostic(format_args!("Name `{id}` used when not defined"));
 }
 
 pub(super) fn report_invalid_exception_caught(context: &InferContext, node: &ast::Expr, ty: Type) {
-    context.report_lint_old(
-        &INVALID_EXCEPTION_CAUGHT,
-        node,
-        format_args!(
-            "Cannot catch object of type `{}` in an exception handler \
+    let Some(builder) = context.report_lint(&INVALID_EXCEPTION_CAUGHT, node) else {
+        return;
+    };
+    builder.into_diagnostic(format_args!(
+        "Cannot catch object of type `{}` in an exception handler \
             (must be a `BaseException` subclass or a tuple of `BaseException` subclasses)",
-            ty.display(context.db())
-        ),
-    );
+        ty.display(context.db())
+    ));
 }
 
 pub(crate) fn report_invalid_exception_raised(context: &InferContext, node: &ast::Expr, ty: Type) {
-    context.report_lint_old(
-        &INVALID_RAISE,
-        node,
-        format_args!(
-            "Cannot raise object of type `{}` (must be a `BaseException` subclass or instance)",
-            ty.display(context.db())
-        ),
-    );
+    let Some(builder) = context.report_lint(&INVALID_RAISE, node) else {
+        return;
+    };
+    builder.into_diagnostic(format_args!(
+        "Cannot raise object of type `{}` (must be a `BaseException` subclass or instance)",
+        ty.display(context.db())
+    ));
 }
 
 pub(crate) fn report_invalid_exception_cause(context: &InferContext, node: &ast::Expr, ty: Type) {
-    context.report_lint_old(
-        &INVALID_RAISE,
-        node,
-        format_args!(
-            "Cannot use object of type `{}` as exception cause \
-            (must be a `BaseException` subclass or instance or `None`)",
-            ty.display(context.db())
-        ),
-    );
+    let Some(builder) = context.report_lint(&INVALID_RAISE, node) else {
+        return;
+    };
+    builder.into_diagnostic(format_args!(
+        "Cannot use object of type `{}` as exception cause \
+         (must be a `BaseException` subclass or instance or `None`)",
+        ty.display(context.db())
+    ));
 }
 
 pub(crate) fn report_base_with_incompatible_slots(context: &InferContext, node: &ast::Expr) {
-    context.report_lint_old(
-        &INCOMPATIBLE_SLOTS,
-        node,
-        format_args!("Class base has incompatible `__slots__`"),
-    );
+    let Some(builder) = context.report_lint(&INCOMPATIBLE_SLOTS, node) else {
+        return;
+    };
+    builder.into_diagnostic("Class base has incompatible `__slots__`");
 }
 
 pub(crate) fn report_invalid_arguments_to_annotated(
     context: &InferContext,
     subscript: &ast::ExprSubscript,
 ) {
-    context.report_lint_old(
-        &INVALID_TYPE_FORM,
-        subscript,
-        format_args!(
-            "Special form `{}` expected at least 2 arguments (one type and at least one metadata element)",
-            KnownInstanceType::Annotated.repr(context.db())
-        ),
-    );
+    let Some(builder) = context.report_lint(&INVALID_TYPE_FORM, subscript) else {
+        return;
+    };
+    builder.into_diagnostic(format_args!(
+        "Special form `{}` expected at least 2 arguments \
+         (one type and at least one metadata element)",
+        KnownInstanceType::Annotated.repr(context.db())
+    ));
 }
 
 pub(crate) fn report_invalid_arguments_to_callable(
     context: &InferContext,
     subscript: &ast::ExprSubscript,
 ) {
-    context.report_lint_old(
-        &INVALID_TYPE_FORM,
-        subscript,
-        format_args!(
-            "Special form `{}` expected exactly two arguments (parameter types and return type)",
-            KnownInstanceType::Callable.repr(context.db())
-        ),
-    );
+    let Some(builder) = context.report_lint(&INVALID_TYPE_FORM, subscript) else {
+        return;
+    };
+    builder.into_diagnostic(format_args!(
+        "Special form `{}` expected exactly two arguments (parameter types and return type)",
+        KnownInstanceType::Callable.repr(context.db())
+    ));
 }

--- a/crates/red_knot_python_semantic/src/types/diagnostic.rs
+++ b/crates/red_knot_python_semantic/src/types/diagnostic.rs
@@ -1116,19 +1116,26 @@ fn report_invalid_assignment_with_message(
     target_ty: Type,
     message: std::fmt::Arguments,
 ) {
+    let Some(builder) = context.report_lint(&INVALID_ASSIGNMENT, node) else {
+        return;
+    };
     match target_ty {
         Type::ClassLiteral(class) => {
-            context.report_lint_old(&INVALID_ASSIGNMENT, node, format_args!(
-                    "Implicit shadowing of class `{}`; annotate to make it explicit if this is intentional",
-                    class.name(context.db())));
+            let mut diag = builder.into_diagnostic(format_args!(
+                "Implicit shadowing of class `{}`",
+                class.name(context.db()),
+            ));
+            diag.info("Annotate to make it explicit if this is intentional");
         }
         Type::FunctionLiteral(function) => {
-            context.report_lint_old(&INVALID_ASSIGNMENT, node, format_args!(
-                    "Implicit shadowing of function `{}`; annotate to make it explicit if this is intentional",
-                    function.name(context.db())));
+            let mut diag = builder.into_diagnostic(format_args!(
+                "Implicit shadowing of function `{}`",
+                function.name(context.db()),
+            ));
+            diag.info("Annotate to make it explicit if this is intentional");
         }
         _ => {
-            context.report_lint_old(&INVALID_ASSIGNMENT, node, message);
+            builder.into_diagnostic(message);
         }
     }
 }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -749,14 +749,15 @@ impl<'db> TypeInferenceBuilder<'db> {
             // (1) Check that the class does not have a cyclic definition
             if let Some(inheritance_cycle) = class.inheritance_cycle(self.db()) {
                 if inheritance_cycle.is_participant() {
-                    self.context.report_lint_old(
-                        &CYCLIC_CLASS_DEFINITION,
-                        class_node,
-                        format_args!(
+                    if let Some(builder) = self
+                        .context
+                        .report_lint(&CYCLIC_CLASS_DEFINITION, class_node)
+                    {
+                        builder.into_diagnostic(format_args!(
                             "Cyclic definition of `{}` (class cannot inherit from itself)",
                             class.name(self.db())
-                        ),
-                    );
+                        ));
+                    }
                 }
                 // Attempting to determine the MRO of a class or if the class has a metaclass conflict
                 // is impossible if the class is cyclically defined; there's nothing more to do here.
@@ -772,13 +773,14 @@ impl<'db> TypeInferenceBuilder<'db> {
             for (i, base_class) in class.explicit_bases(self.db()).iter().enumerate() {
                 let base_class = match base_class {
                     Type::KnownInstance(KnownInstanceType::Generic) => {
-                        // Unsubscripted `Generic` can appear in the MRO of many classes,
-                        // but it is never valid as an explicit base class in user code.
-                        self.context.report_lint_old(
-                            &INVALID_BASE,
-                            &class_node.bases()[i],
-                            format_args!("Cannot inherit from plain `Generic`"),
-                        );
+                        if let Some(builder) = self
+                            .context
+                            .report_lint(&INVALID_BASE, &class_node.bases()[i])
+                        {
+                            // Unsubscripted `Generic` can appear in the MRO of many classes,
+                            // but it is never valid as an explicit base class in user code.
+                            builder.into_diagnostic("Cannot inherit from plain `Generic`");
+                        }
                         continue;
                     }
                     Type::ClassLiteral(class) => class,
@@ -790,27 +792,29 @@ impl<'db> TypeInferenceBuilder<'db> {
                     && !(base_class.is_protocol(self.db())
                         || base_class.is_known(self.db(), KnownClass::Object))
                 {
-                    self.context.report_lint_old(
-                        &INVALID_PROTOCOL,
-                        &class_node.bases()[i],
-                        format_args!(
+                    if let Some(builder) = self
+                        .context
+                        .report_lint(&INVALID_PROTOCOL, &class_node.bases()[i])
+                    {
+                        builder.into_diagnostic(format_args!(
                             "Protocol class `{}` cannot inherit from non-protocol class `{}`",
                             class.name(self.db()),
                             base_class.name(self.db()),
-                        ),
-                    );
+                        ));
+                    }
                 }
 
                 if base_class.is_final(self.db()) {
-                    self.context.report_lint_old(
-                        &SUBCLASS_OF_FINAL_CLASS,
-                        &class_node.bases()[i],
-                        format_args!(
+                    if let Some(builder) = self
+                        .context
+                        .report_lint(&SUBCLASS_OF_FINAL_CLASS, &class_node.bases()[i])
+                    {
+                        builder.into_diagnostic(format_args!(
                             "Class `{}` cannot inherit from final class `{}`",
                             class.name(self.db()),
                             base_class.name(self.db()),
-                        ),
-                    );
+                        ));
+                    }
                 }
             }
 
@@ -821,11 +825,16 @@ impl<'db> TypeInferenceBuilder<'db> {
                         MroErrorKind::DuplicateBases(duplicates) => {
                             let base_nodes = class_node.bases();
                             for (index, duplicate) in duplicates {
-                                self.context.report_lint_old(
-                                    &DUPLICATE_BASE,
-                                    &base_nodes[*index],
-                                    format_args!("Duplicate base class `{}`", duplicate.name(self.db())),
-                                );
+                                let Some(builder) = self
+                                    .context
+                                    .report_lint(&DUPLICATE_BASE, &base_nodes[*index])
+                                else {
+                                    continue;
+                                };
+                                builder.into_diagnostic(format_args!(
+                                    "Duplicate base class `{}`",
+                                    duplicate.name(self.db())
+                                ));
                             }
                         }
                         MroErrorKind::InvalidBases(bases) => {
@@ -837,25 +846,33 @@ impl<'db> TypeInferenceBuilder<'db> {
                                     // class will never happen.
                                     continue;
                                 }
-                                self.context.report_lint_old(
-                                    &INVALID_BASE,
-                                    &base_nodes[*index],
-                                    format_args!(
-                                        "Invalid class base with type `{}` (all bases must be a class, `Any`, `Unknown` or `Todo`)",
-                                        base_ty.display(self.db())
-                                    ),
-                                );
+                                let Some(builder) =
+                                    self.context.report_lint(&INVALID_BASE, &base_nodes[*index])
+                                else {
+                                    continue;
+                                };
+                                builder.into_diagnostic(format_args!(
+                                    "Invalid class base with type `{}` \
+                                     (all bases must be a class, `Any`, `Unknown` or `Todo`)",
+                                    base_ty.display(self.db())
+                                ));
                             }
                         }
-                        MroErrorKind::UnresolvableMro { bases_list } => self.context.report_lint_old(
-                            &INCONSISTENT_MRO,
-                            class_node,
-                            format_args!(
-                                "Cannot create a consistent method resolution order (MRO) for class `{}` with bases list `[{}]`",
-                                class.name(self.db()),
-                                bases_list.iter().map(|base| base.display(self.db())).join(", ")
-                            ),
-                        )
+                        MroErrorKind::UnresolvableMro { bases_list } => {
+                            if let Some(builder) =
+                                self.context.report_lint(&INCONSISTENT_MRO, class_node)
+                            {
+                                builder.into_diagnostic(format_args!(
+                                    "Cannot create a consistent method resolution order (MRO) \
+                                     for class `{}` with bases list `[{}]`",
+                                    class.name(self.db()),
+                                    bases_list
+                                        .iter()
+                                        .map(|base| base.display(self.db()))
+                                        .join(", ")
+                                ));
+                            }
+                        }
                     }
                 }
                 Ok(_) => check_class_slots(&self.context, class, class_node),
@@ -864,19 +881,26 @@ impl<'db> TypeInferenceBuilder<'db> {
             // (4) Check that the class's metaclass can be determined without error.
             if let Err(metaclass_error) = class.try_metaclass(self.db()) {
                 match metaclass_error.reason() {
-                    MetaclassErrorKind::NotCallable(ty) => self.context.report_lint_old(
-                        &INVALID_METACLASS,
-                        class_node,
-                        format_args!("Metaclass type `{}` is not callable", ty.display(self.db())),
-                    ),
-                    MetaclassErrorKind::PartlyNotCallable(ty) => self.context.report_lint_old(
-                        &INVALID_METACLASS,
-                        class_node,
-                        format_args!(
-                            "Metaclass type `{}` is partly not callable",
-                            ty.display(self.db())
-                        ),
-                    ),
+                    MetaclassErrorKind::NotCallable(ty) => {
+                        if let Some(builder) =
+                            self.context.report_lint(&INVALID_METACLASS, class_node)
+                        {
+                            builder.into_diagnostic(format_args!(
+                                "Metaclass type `{}` is not callable",
+                                ty.display(self.db())
+                            ));
+                        }
+                    }
+                    MetaclassErrorKind::PartlyNotCallable(ty) => {
+                        if let Some(builder) =
+                            self.context.report_lint(&INVALID_METACLASS, class_node)
+                        {
+                            builder.into_diagnostic(format_args!(
+                                "Metaclass type `{}` is partly not callable",
+                                ty.display(self.db())
+                            ));
+                        }
+                    }
                     MetaclassErrorKind::Conflict {
                         candidate1:
                             MetaclassCandidate {
@@ -890,35 +914,35 @@ impl<'db> TypeInferenceBuilder<'db> {
                             },
                         candidate1_is_base_class,
                     } => {
-                        if *candidate1_is_base_class {
-                            self.context.report_lint_old(
-                                &CONFLICTING_METACLASS,
-                                class_node,
-                                format_args!(
-                                    "The metaclass of a derived class (`{class}`) must be a subclass of the metaclasses of all its bases, \
-                                    but `{metaclass1}` (metaclass of base class `{base1}`) and `{metaclass2}` (metaclass of base class `{base2}`) \
-                                    have no subclass relationship",
+                        if let Some(builder) =
+                            self.context.report_lint(&CONFLICTING_METACLASS, class_node)
+                        {
+                            if *candidate1_is_base_class {
+                                builder.into_diagnostic(format_args!(
+                                    "The metaclass of a derived class (`{class}`) \
+                                     must be a subclass of the metaclasses of all its bases, \
+                                     but `{metaclass1}` (metaclass of base class `{base1}`) \
+                                     and `{metaclass2}` (metaclass of base class `{base2}`) \
+                                     have no subclass relationship",
                                     class = class.name(self.db()),
                                     metaclass1 = metaclass1.name(self.db()),
                                     base1 = class1.name(self.db()),
                                     metaclass2 = metaclass2.name(self.db()),
                                     base2 = class2.name(self.db()),
-                                ),
-                            );
-                        } else {
-                            self.context.report_lint_old(
-                                &CONFLICTING_METACLASS,
-                                class_node,
-                                format_args!(
-                                    "The metaclass of a derived class (`{class}`) must be a subclass of the metaclasses of all its bases, \
-                                    but `{metaclass_of_class}` (metaclass of `{class}`) and `{metaclass_of_base}` (metaclass of base class `{base}`) \
-                                    have no subclass relationship",
+                                ));
+                            } else {
+                                builder.into_diagnostic(format_args!(
+                                    "The metaclass of a derived class (`{class}`) \
+                                     must be a subclass of the metaclasses of all its bases, \
+                                     but `{metaclass_of_class}` (metaclass of `{class}`) \
+                                     and `{metaclass_of_base}` (metaclass of base class `{base}`) \
+                                     have no subclass relationship",
                                     class = class.name(self.db()),
                                     metaclass_of_class = metaclass1.name(self.db()),
                                     metaclass_of_base = metaclass2.name(self.db()),
                                     base = class2.name(self.db()),
-                                ),
-                            );
+                                ));
+                            }
                         }
                     }
                 }
@@ -1054,14 +1078,12 @@ impl<'db> TypeInferenceBuilder<'db> {
             _ => return false,
         };
 
-        self.context.report_lint_old(
-            &DIVISION_BY_ZERO,
-            node,
-            format_args!(
+        if let Some(builder) = self.context.report_lint(&DIVISION_BY_ZERO, node) {
+            builder.into_diagnostic(format_args!(
                 "Cannot {op} object of type `{}` {by_zero}",
                 left.display(self.db())
-            ),
-        );
+            ));
+        }
 
         true
     }
@@ -1082,14 +1104,12 @@ impl<'db> TypeInferenceBuilder<'db> {
                 // TODO point out the conflicting declarations in the diagnostic?
                 let symbol_table = self.index.symbol_table(binding.file_scope(self.db()));
                 let symbol_name = symbol_table.symbol(binding.symbol(self.db())).name();
-                self.context.report_lint_old(
-                    &CONFLICTING_DECLARATIONS,
-                    node,
-                    format_args!(
+                if let Some(builder) = self.context.report_lint(&CONFLICTING_DECLARATIONS, node) {
+                    builder.into_diagnostic(format_args!(
                         "Conflicting declared types for `{symbol_name}`: {}",
                         conflicting.display(self.db())
-                    ),
-                );
+                    ));
+                }
                 ty.inner_type()
             });
         if !bound_ty.is_assignable_to(self.db(), declared_ty) {
@@ -1120,15 +1140,13 @@ impl<'db> TypeInferenceBuilder<'db> {
         let ty = if inferred_ty.is_assignable_to(self.db(), ty.inner_type()) {
             ty
         } else {
-            self.context.report_lint_old(
-                &INVALID_DECLARATION,
-                node,
-                format_args!(
+            if let Some(builder) = self.context.report_lint(&INVALID_DECLARATION, node) {
+                builder.into_diagnostic(format_args!(
                     "Cannot declare type `{}` for inferred type `{}`",
                     ty.inner_type().display(self.db()),
                     inferred_ty.display(self.db())
-                ),
-            );
+                ));
+            }
             TypeAndQualifiers::unknown()
         };
         self.types.declarations.insert(declaration, ty);
@@ -1654,13 +1672,17 @@ impl<'db> TypeInferenceBuilder<'db> {
                 {
                     DeclaredAndInferredType::AreTheSame(declared_ty)
                 } else {
-                    self.context.report_lint_old(
-                        &INVALID_PARAMETER_DEFAULT,
-                        parameter_with_default,
-                        format_args!(
-                            "Default value of type `{}` is not assignable to annotated parameter type `{}`",
-                            default_ty.display(self.db()), declared_ty.display(self.db())),
-                    );
+                    if let Some(builder) = self
+                        .context
+                        .report_lint(&INVALID_PARAMETER_DEFAULT, parameter_with_default)
+                    {
+                        builder.into_diagnostic(format_args!(
+                            "Default value of type `{}` is not assignable \
+                             to annotated parameter type `{}`",
+                            default_ty.display(self.db()),
+                            declared_ty.display(self.db())
+                        ));
+                    }
                     DeclaredAndInferredType::AreTheSame(declared_ty)
                 }
             } else {
@@ -2130,11 +2152,12 @@ impl<'db> TypeInferenceBuilder<'db> {
         let bound_or_constraint = match bound.as_deref() {
             Some(expr @ ast::Expr::Tuple(ast::ExprTuple { elts, .. })) => {
                 if elts.len() < 2 {
-                    self.context.report_lint_old(
-                        &INVALID_TYPE_VARIABLE_CONSTRAINTS,
-                        expr,
-                        format_args!("TypeVar must have at least two constrained types"),
-                    );
+                    if let Some(builder) = self
+                        .context
+                        .report_lint(&INVALID_TYPE_VARIABLE_CONSTRAINTS, expr)
+                    {
+                        builder.into_diagnostic("TypeVar must have at least two constrained types");
+                    }
                     self.infer_expression(expr);
                     None
                 } else {
@@ -2485,27 +2508,23 @@ impl<'db> TypeInferenceBuilder<'db> {
             // Super instances do not allow attribute assignment
             Type::Instance(instance) if instance.class().is_known(db, KnownClass::Super) => {
                 if emit_diagnostics {
-                    self.context.report_lint_old(
-                        &INVALID_ASSIGNMENT,
-                        target,
-                        format_args!(
+                    if let Some(builder) = self.context.report_lint(&INVALID_ASSIGNMENT, target) {
+                        builder.into_diagnostic(format_args!(
                             "Cannot assign to attribute `{attribute}` on type `{}`",
                             object_ty.display(self.db()),
-                        ),
-                    );
+                        ));
+                    }
                 }
                 false
             }
             Type::BoundSuper(_) => {
                 if emit_diagnostics {
-                    self.context.report_lint_old(
-                        &INVALID_ASSIGNMENT,
-                        target,
-                        format_args!(
+                    if let Some(builder) = self.context.report_lint(&INVALID_ASSIGNMENT, target) {
+                        builder.into_diagnostic(format_args!(
                             "Cannot assign to attribute `{attribute}` on type `{}`",
                             object_ty.display(self.db()),
-                        ),
-                    );
+                        ));
+                    }
                 }
                 false
             }
@@ -2535,14 +2554,15 @@ impl<'db> TypeInferenceBuilder<'db> {
                 match object_ty.class_member(db, attribute.into()) {
                     meta_attr @ SymbolAndQualifiers { .. } if meta_attr.is_class_var() => {
                         if emit_diagnostics {
-                            self.context.report_lint_old(
-                                &INVALID_ATTRIBUTE_ACCESS,
-                                target,
-                                format_args!(
-                                    "Cannot assign to ClassVar `{attribute}` from an instance of type `{ty}`",
+                            if let Some(builder) =
+                                self.context.report_lint(&INVALID_ATTRIBUTE_ACCESS, target)
+                            {
+                                builder.into_diagnostic(format_args!(
+                                    "Cannot assign to ClassVar `{attribute}` \
+                                     from an instance of type `{ty}`",
                                     ty = object_ty.display(self.db()),
-                                ),
-                            );
+                                ));
+                            }
                         }
                         false
                     }
@@ -2650,29 +2670,31 @@ impl<'db> TypeInferenceBuilder<'db> {
                                 Ok(_) | Err(CallDunderError::PossiblyUnbound(_)) => true,
                                 Err(CallDunderError::CallError(..)) => {
                                     if emit_diagnostics {
-                                        self.context.report_lint_old(
-                                        &UNRESOLVED_ATTRIBUTE,
-                                        target,
-                                        format_args!(
-                                            "Can not assign object of `{}` to attribute `{attribute}` on type `{}` with custom `__setattr__` method.",
-                                            value_ty.display(db),
-                                            object_ty.display(db)
-                                        ),
-                                    );
+                                        if let Some(builder) =
+                                            self.context.report_lint(&UNRESOLVED_ATTRIBUTE, target)
+                                        {
+                                            builder.into_diagnostic(format_args!(
+                                                "Can not assign object of `{}` to attribute \
+                                                 `{attribute}` on type `{}` with \
+                                                 custom `__setattr__` method.",
+                                                value_ty.display(db),
+                                                object_ty.display(db)
+                                            ));
+                                        }
                                     }
                                     false
                                 }
                                 Err(CallDunderError::MethodNotAvailable) => {
                                     if emit_diagnostics {
-                                        self.context.report_lint_old(
-                                            &UNRESOLVED_ATTRIBUTE,
-                                            target,
-                                            format_args!(
+                                        if let Some(builder) =
+                                            self.context.report_lint(&UNRESOLVED_ATTRIBUTE, target)
+                                        {
+                                            builder.into_diagnostic(format_args!(
                                                 "Unresolved attribute `{}` on type `{}`.",
                                                 attribute,
                                                 object_ty.display(db)
-                                            ),
-                                        );
+                                            ));
+                                        }
                                     }
 
                                     false
@@ -2784,23 +2806,25 @@ impl<'db> TypeInferenceBuilder<'db> {
                             // Attribute is declared or bound on instance. Forbid access from the class object
                             if emit_diagnostics {
                                 if attribute_is_bound_on_instance {
-                                    self.context.report_lint_old(
-                                    &INVALID_ATTRIBUTE_ACCESS,
-                                    target,
-                                    format_args!(
-                                        "Cannot assign to instance attribute `{attribute}` from the class object `{ty}`",
-                                        ty = object_ty.display(self.db()),
-                                ));
+                                    if let Some(builder) =
+                                        self.context.report_lint(&INVALID_ATTRIBUTE_ACCESS, target)
+                                    {
+                                        builder.into_diagnostic(format_args!(
+                                            "Cannot assign to instance attribute \
+                                             `{attribute}` from the class object `{ty}`",
+                                            ty = object_ty.display(self.db()),
+                                        ));
+                                    }
                                 } else {
-                                    self.context.report_lint_old(
-                                        &UNRESOLVED_ATTRIBUTE,
-                                        target,
-                                        format_args!(
+                                    if let Some(builder) =
+                                        self.context.report_lint(&UNRESOLVED_ATTRIBUTE, target)
+                                    {
+                                        builder.into_diagnostic(format_args!(
                                             "Unresolved attribute `{}` on type `{}`.",
                                             attribute,
                                             object_ty.display(db)
-                                        ),
-                                    );
+                                        ));
+                                    }
                                 }
                             }
 
@@ -2825,15 +2849,13 @@ impl<'db> TypeInferenceBuilder<'db> {
 
                     false
                 } else {
-                    self.context.report_lint_old(
-                        &UNRESOLVED_ATTRIBUTE,
-                        target,
-                        format_args!(
+                    if let Some(builder) = self.context.report_lint(&UNRESOLVED_ATTRIBUTE, target) {
+                        builder.into_diagnostic(format_args!(
                             "Unresolved attribute `{}` on type `{}`.",
                             attribute,
                             object_ty.display(db)
-                        ),
-                    );
+                        ));
+                    }
 
                     false
                 }
@@ -3073,15 +3095,14 @@ impl<'db> TypeInferenceBuilder<'db> {
         let db = self.db();
 
         let report_unsupported_augmented_op = |ctx: &mut InferContext| {
-            ctx.report_lint_old(
-                &UNSUPPORTED_OPERATOR,
-                assignment,
-                format_args!(
-                    "Operator `{op}=` is unsupported between objects of type `{}` and `{}`",
-                    target_type.display(db),
-                    value_type.display(db)
-                ),
-            );
+            let Some(builder) = ctx.report_lint(&UNSUPPORTED_OPERATOR, assignment) else {
+                return;
+            };
+            builder.into_diagnostic(format_args!(
+                "Operator `{op}=` is unsupported between objects of type `{}` and `{}`",
+                target_type.display(db),
+                value_type.display(db)
+            ));
         };
 
         // Fall back to non-augmented binary operator inference.
@@ -3254,15 +3275,14 @@ impl<'db> TypeInferenceBuilder<'db> {
             return;
         }
 
-        self.context.report_lint_old(
-            &UNRESOLVED_IMPORT,
-            range,
-            format_args!(
-                "Cannot resolve import `{}{}`",
-                ".".repeat(level as usize),
-                module.unwrap_or_default()
-            ),
-        );
+        let Some(builder) = self.context.report_lint(&UNRESOLVED_IMPORT, range) else {
+            return;
+        };
+        builder.into_diagnostic(format_args!(
+            "Cannot resolve import `{}{}`",
+            ".".repeat(level as usize),
+            module.unwrap_or_default()
+        ));
     }
 
     fn infer_import_definition(
@@ -3495,11 +3515,14 @@ impl<'db> TypeInferenceBuilder<'db> {
             if &alias.name != "*" && boundness == Boundness::PossiblyUnbound {
                 // TODO: Consider loading _both_ the attribute and any submodule and unioning them
                 // together if the attribute exists but is possibly-unbound.
-                self.context.report_lint_old(
-                    &POSSIBLY_UNBOUND_IMPORT,
-                    AnyNodeRef::Alias(alias),
-                    format_args!("Member `{name}` of module `{module_name}` is possibly unbound",),
-                );
+                if let Some(builder) = self
+                    .context
+                    .report_lint(&POSSIBLY_UNBOUND_IMPORT, AnyNodeRef::Alias(alias))
+                {
+                    builder.into_diagnostic(format_args!(
+                        "Member `{name}` of module `{module_name}` is possibly unbound",
+                    ));
+                }
             }
             self.add_declaration_with_binding(
                 alias.into(),
@@ -3541,11 +3564,14 @@ impl<'db> TypeInferenceBuilder<'db> {
             let is_import_reachable = self.is_reachable(import_from);
 
             if is_import_reachable {
-                self.context.report_lint_old(
-                    &UNRESOLVED_IMPORT,
-                    AnyNodeRef::Alias(alias),
-                    format_args!("Module `{module_name}` has no member `{name}`",),
-                );
+                if let Some(builder) = self
+                    .context
+                    .report_lint(&UNRESOLVED_IMPORT, AnyNodeRef::Alias(alias))
+                {
+                    builder.into_diagnostic(format_args!(
+                        "Module `{module_name}` has no member `{name}`"
+                    ));
+                }
             }
         }
 
@@ -4342,29 +4368,32 @@ impl<'db> TypeInferenceBuilder<'db> {
                                         if !actual_ty
                                             .is_gradual_equivalent_to(self.db(), *asserted_ty)
                                         {
-                                            self.context.report_lint_old(
-                                                    &TYPE_ASSERTION_FAILURE,
-                                                    call_expression,
-                                                    format_args!(
-                                                        "Actual type `{}` is not the same as asserted type `{}`",
-                                                        actual_ty.display(self.db()),
-                                                        asserted_ty.display(self.db()),
-                                                    ),
-                                                );
+                                            if let Some(builder) = self.context.report_lint(
+                                                &TYPE_ASSERTION_FAILURE,
+                                                call_expression,
+                                            ) {
+                                                builder.into_diagnostic(format_args!(
+                                                    "Actual type `{}` is not the same \
+                                                         as asserted type `{}`",
+                                                    actual_ty.display(self.db()),
+                                                    asserted_ty.display(self.db()),
+                                                ));
+                                            }
                                         }
                                     }
                                 }
                                 KnownFunction::AssertNever => {
                                     if let [Some(actual_ty)] = overload.parameter_types() {
                                         if !actual_ty.is_equivalent_to(self.db(), Type::Never) {
-                                            self.context.report_lint_old(
+                                            if let Some(builder) = self.context.report_lint(
                                                 &TYPE_ASSERTION_FAILURE,
                                                 call_expression,
-                                                format_args!(
+                                            ) {
+                                                builder.into_diagnostic(format_args!(
                                                     "Expected type `Never`, got `{}` instead",
                                                     actual_ty.display(self.db()),
-                                                ),
-                                            );
+                                                ));
+                                            }
                                         }
                                     }
                                 }
@@ -4395,42 +4424,42 @@ impl<'db> TypeInferenceBuilder<'db> {
                                             }
                                         };
 
-                                        if !truthiness.is_always_true() {
-                                            if let Some(message) = message
-                                                .and_then(Type::into_string_literal)
-                                                .map(|s| &**s.value(self.db()))
-                                            {
-                                                self.context.report_lint_old(
-                                                    &STATIC_ASSERT_ERROR,
-                                                    call_expression,
-                                                    format_args!(
+                                        if let Some(builder) = self
+                                            .context
+                                            .report_lint(&STATIC_ASSERT_ERROR, call_expression)
+                                        {
+                                            if !truthiness.is_always_true() {
+                                                if let Some(message) = message
+                                                    .and_then(Type::into_string_literal)
+                                                    .map(|s| &**s.value(self.db()))
+                                                {
+                                                    builder.into_diagnostic(format_args!(
                                                         "Static assertion error: {message}"
-                                                    ),
-                                                );
-                                            } else if *parameter_ty == Type::BooleanLiteral(false) {
-                                                self.context.report_lint_old(
-                                                    &STATIC_ASSERT_ERROR,
-                                                    call_expression,
-                                                    format_args!("Static assertion error: argument evaluates to `False`"),
-                                                );
-                                            } else if truthiness.is_always_false() {
-                                                self.context.report_lint_old(
-                                                    &STATIC_ASSERT_ERROR,
-                                                    call_expression,
-                                                    format_args!(
-                                                        "Static assertion error: argument of type `{parameter_ty}` is statically known to be falsy",
-                                                        parameter_ty=parameter_ty.display(self.db())
-                                                    ),
-                                                );
-                                            } else {
-                                                self.context.report_lint_old(
-                                                    &STATIC_ASSERT_ERROR,
-                                                    call_expression,
-                                                    format_args!(
-                                                        "Static assertion error: argument of type `{parameter_ty}` has an ambiguous static truthiness",
-                                                        parameter_ty=parameter_ty.display(self.db())
-                                                    ),
-                                                );
+                                                    ));
+                                                } else if *parameter_ty
+                                                    == Type::BooleanLiteral(false)
+                                                {
+                                                    builder.into_diagnostic(
+                                                        "Static assertion error: \
+                                                        argument evaluates to `False`",
+                                                    );
+                                                } else if truthiness.is_always_false() {
+                                                    builder.into_diagnostic(format_args!(
+                                                        "Static assertion error: \
+                                                        argument of type `{parameter_ty}` \
+                                                        is statically known to be falsy",
+                                                        parameter_ty =
+                                                            parameter_ty.display(self.db())
+                                                    ));
+                                                } else {
+                                                    builder.into_diagnostic(format_args!(
+                                                        "Static assertion error: \
+                                                         argument of type `{parameter_ty}` \
+                                                         has an ambiguous static truthiness",
+                                                        parameter_ty =
+                                                            parameter_ty.display(self.db())
+                                                    ));
+                                                }
                                             }
                                         }
                                     }
@@ -4445,14 +4474,15 @@ impl<'db> TypeInferenceBuilder<'db> {
                                                 == casted_type.normalized(db))
                                             && !source_type.contains_todo(db)
                                         {
-                                            self.context.report_lint_old(
-                                                &REDUNDANT_CAST,
-                                                call_expression,
-                                                format_args!(
+                                            if let Some(builder) = self
+                                                .context
+                                                .report_lint(&REDUNDANT_CAST, call_expression)
+                                            {
+                                                builder.into_diagnostic(format_args!(
                                                     "Value is already of type `{}`",
                                                     casted_type.display(db),
-                                                ),
-                                            );
+                                                ));
+                                            }
                                         }
                                     }
                                 }
@@ -4740,14 +4770,15 @@ impl<'db> TypeInferenceBuilder<'db> {
                 // Still not found? It might be `reveal_type`...
                 .or_fall_back_to(db, || {
                     if symbol_name == "reveal_type" {
-                        self.context.report_lint_old(
-                            &UNDEFINED_REVEAL,
-                            name_node,
-                            format_args!(
-                                "`reveal_type` used without importing it; \
-                            this is allowed for debugging convenience but will fail at runtime"
-                            ),
-                        );
+                        if let Some(builder) =
+                            self.context.report_lint(&UNDEFINED_REVEAL, name_node)
+                        {
+                            let mut diag =
+                                builder.into_diagnostic("`reveal_type` used without importing it");
+                            diag.info(
+                                "This is allowed for debugging convenience but will fail at runtime"
+                            );
+                        }
                         typing_extensions_symbol(db, symbol_name)
                     } else {
                         Symbol::Unbound.into()
@@ -4817,26 +4848,28 @@ impl<'db> TypeInferenceBuilder<'db> {
                             _ => false,
                         };
 
+                        if let Some(builder) = self
+                            .context
+                            .report_lint(&UNRESOLVED_ATTRIBUTE, attribute)
+                        {
                         if bound_on_instance {
-                            self.context.report_lint_old(
-                                &UNRESOLVED_ATTRIBUTE,
-                                attribute,
+                            builder.into_diagnostic(
                                 format_args!(
-                                    "Attribute `{}` can only be accessed on instances, not on the class object `{}` itself.",
+                                    "Attribute `{}` can only be accessed on instances, \
+                                     not on the class object `{}` itself.",
                                     attr.id,
                                     value_type.display(db)
                                 ),
                             );
                         } else {
-                            self.context.report_lint_old(
-                                &UNRESOLVED_ATTRIBUTE,
-                                attribute,
+                            builder.into_diagnostic(
                                 format_args!(
                                     "Type `{}` has no attribute `{}`",
                                     value_type.display(db),
                                     attr.id
                                 ),
                             );
+                        }
                         }
                     }
 
@@ -4951,14 +4984,14 @@ impl<'db> TypeInferenceBuilder<'db> {
                 ) {
                     Ok(outcome) => outcome.return_type(self.db()),
                     Err(e) => {
-                        self.context.report_lint_old(
-                            &UNSUPPORTED_OPERATOR,
-                            unary,
-                            format_args!(
+                        if let Some(builder) =
+                            self.context.report_lint(&UNSUPPORTED_OPERATOR, unary)
+                        {
+                            builder.into_diagnostic(format_args!(
                                 "Unary operator `{op}` is unsupported for type `{}`",
                                 operand_type.display(self.db()),
-                            ),
-                        );
+                            ));
+                        }
                         e.fallback_return_type(self.db())
                     }
                 }
@@ -4979,15 +5012,13 @@ impl<'db> TypeInferenceBuilder<'db> {
 
         self.infer_binary_expression_type(binary.into(), false, left_ty, right_ty, *op)
             .unwrap_or_else(|| {
-                self.context.report_lint_old(
-                    &UNSUPPORTED_OPERATOR,
-                    binary,
-                    format_args!(
+                if let Some(builder) = self.context.report_lint(&UNSUPPORTED_OPERATOR, binary) {
+                    builder.into_diagnostic(format_args!(
                         "Operator `{op}` is unsupported between objects of type `{}` and `{}`",
                         left_ty.display(self.db()),
                         right_ty.display(self.db())
-                    ),
-                );
+                    ));
+                }
                 Type::unknown()
             })
     }
@@ -5436,11 +5467,11 @@ impl<'db> TypeInferenceBuilder<'db> {
                 let ty = builder
                     .infer_binary_type_comparison(left_ty, *op, right_ty, range)
                     .unwrap_or_else(|error| {
-                        // Handle unsupported operators (diagnostic, `bool`/`Unknown` outcome)
-                        builder.context.report_lint_old(
-                            &UNSUPPORTED_OPERATOR,
-                            range,
-                            format_args!(
+                        if let Some(diagnostic_builder) =
+                            builder.context.report_lint(&UNSUPPORTED_OPERATOR, range)
+                        {
+                            // Handle unsupported operators (diagnostic, `bool`/`Unknown` outcome)
+                            diagnostic_builder.into_diagnostic(format_args!(
                                 "Operator `{}` is not supported for types `{}` and `{}`{}",
                                 error.op,
                                 error.left_ty.display(builder.db()),
@@ -5454,8 +5485,8 @@ impl<'db> TypeInferenceBuilder<'db> {
                                         right_ty.display(builder.db())
                                     )
                                 }
-                            ),
-                        );
+                            ));
+                        }
 
                         match op {
                             // `in, not in, is, is not` always return bool instances
@@ -6328,27 +6359,29 @@ impl<'db> TypeInferenceBuilder<'db> {
                 ) {
                     Ok(outcome) => return outcome.return_type(self.db()),
                     Err(err @ CallDunderError::PossiblyUnbound { .. }) => {
-                        self.context.report_lint_old(
-                            &CALL_POSSIBLY_UNBOUND_METHOD,
-                            value_node,
-                            format_args!(
+                        if let Some(builder) = self
+                            .context
+                            .report_lint(&CALL_POSSIBLY_UNBOUND_METHOD, value_node)
+                        {
+                            builder.into_diagnostic(format_args!(
                                 "Method `__getitem__` of type `{}` is possibly unbound",
                                 value_ty.display(self.db()),
-                            ),
-                        );
+                            ));
+                        }
 
                         return err.fallback_return_type(self.db());
                     }
                     Err(CallDunderError::CallError(_, bindings)) => {
-                        self.context.report_lint_old(
-                            &CALL_NON_CALLABLE,
-                            value_node,
-                            format_args!(
-                                "Method `__getitem__` of type `{}` is not callable on object of type `{}`",
+                        if let Some(builder) =
+                            self.context.report_lint(&CALL_NON_CALLABLE, value_node)
+                        {
+                            builder.into_diagnostic(format_args!(
+                                "Method `__getitem__` of type `{}` \
+                                 is not callable on object of type `{}`",
                                 bindings.callable_type().display(self.db()),
                                 value_ty.display(self.db()),
-                            ),
-                        );
+                            ));
+                        }
 
                         return bindings.return_type(self.db());
                     }
@@ -6374,14 +6407,16 @@ impl<'db> TypeInferenceBuilder<'db> {
                         Symbol::Unbound => {}
                         Symbol::Type(ty, boundness) => {
                             if boundness == Boundness::PossiblyUnbound {
-                                self.context.report_lint_old(
-                                    &CALL_POSSIBLY_UNBOUND_METHOD,
-                                    value_node,
-                                    format_args!(
-                                        "Method `__class_getitem__` of type `{}` is possibly unbound",
+                                if let Some(builder) = self
+                                    .context
+                                    .report_lint(&CALL_POSSIBLY_UNBOUND_METHOD, value_node)
+                                {
+                                    builder.into_diagnostic(format_args!(
+                                        "Method `__class_getitem__` of type `{}` \
+                                        is possibly unbound",
                                         value_ty.display(self.db()),
-                                    ),
-                                );
+                                    ));
+                                }
                             }
 
                             match ty.try_call(
@@ -6390,15 +6425,16 @@ impl<'db> TypeInferenceBuilder<'db> {
                             ) {
                                 Ok(bindings) => return bindings.return_type(self.db()),
                                 Err(CallError(_, bindings)) => {
-                                    self.context.report_lint_old(
-                                        &CALL_NON_CALLABLE,
-                                        value_node,
-                                        format_args!(
-                                            "Method `__class_getitem__` of type `{}` is not callable on object of type `{}`",
+                                    if let Some(builder) =
+                                        self.context.report_lint(&CALL_NON_CALLABLE, value_node)
+                                    {
+                                        builder.into_diagnostic(format_args!(
+                                            "Method `__class_getitem__` of type `{}` \
+                                             is not callable on object of type `{}`",
                                             bindings.callable_type().display(self.db()),
                                             value_ty.display(self.db()),
-                                        ),
-                                    );
+                                        ));
+                                    }
                                     return bindings.return_type(self.db());
                                 }
                             }
@@ -6564,20 +6600,19 @@ impl<'db> TypeInferenceBuilder<'db> {
             ast::Expr::Starred(starred) => self.infer_starred_expression(starred).into(),
 
             ast::Expr::BytesLiteral(bytes) => {
-                self.context.report_lint_old(
-                    &BYTE_STRING_TYPE_ANNOTATION,
-                    bytes,
-                    format_args!("Type expressions cannot use bytes literal"),
-                );
+                if let Some(builder) = self
+                    .context
+                    .report_lint(&BYTE_STRING_TYPE_ANNOTATION, bytes)
+                {
+                    builder.into_diagnostic("Type expressions cannot use bytes literal");
+                }
                 TypeAndQualifiers::unknown()
             }
 
             ast::Expr::FString(fstring) => {
-                self.context.report_lint_old(
-                    &FSTRING_TYPE_ANNOTATION,
-                    fstring,
-                    format_args!("Type expressions cannot use f-strings"),
-                );
+                if let Some(builder) = self.context.report_lint(&FSTRING_TYPE_ANNOTATION, fstring) {
+                    builder.into_diagnostic("Type expressions cannot use f-strings");
+                }
                 self.infer_fstring_expression(fstring);
                 TypeAndQualifiers::unknown()
             }
@@ -6651,14 +6686,15 @@ impl<'db> TypeInferenceBuilder<'db> {
                         known_instance @ (KnownInstanceType::ClassVar | KnownInstanceType::Final),
                     ) => match slice {
                         ast::Expr::Tuple(..) => {
-                            self.context.report_lint_old(
-                                &INVALID_TYPE_FORM,
-                                subscript,
-                                format_args!(
-                                    "Type qualifier `{type_qualifier}` expects exactly one type parameter",
+                            if let Some(builder) =
+                                self.context.report_lint(&INVALID_TYPE_FORM, subscript)
+                            {
+                                builder.into_diagnostic(format_args!(
+                                    "Type qualifier `{type_qualifier}` \
+                                     expects exactly one type parameter",
                                     type_qualifier = known_instance.repr(self.db()),
-                                ),
-                            );
+                                ));
+                            }
                             Type::unknown().into()
                         }
                         _ => {
@@ -6751,8 +6787,9 @@ impl<'db> TypeInferenceBuilder<'db> {
         expression: &ast::Expr,
         message: std::fmt::Arguments,
     ) -> Type<'db> {
-        self.context
-            .report_lint_old(&INVALID_TYPE_FORM, expression, message);
+        if let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, expression) {
+            builder.into_diagnostic(message);
+        }
         Type::unknown()
     }
 
@@ -7201,11 +7238,9 @@ impl<'db> TypeInferenceBuilder<'db> {
             }
             ast::Expr::Tuple(_) => {
                 self.infer_type_expression(slice);
-                self.context.report_lint_old(
-                    &INVALID_TYPE_FORM,
-                    slice,
-                    format_args!("type[...] must have exactly one type argument"),
-                );
+                if let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, slice) {
+                    builder.into_diagnostic("type[...] must have exactly one type argument");
+                }
                 Type::unknown()
             }
             ast::Expr::Subscript(ast::ExprSubscript {
@@ -7257,11 +7292,9 @@ impl<'db> TypeInferenceBuilder<'db> {
 
         match value_ty {
             Type::ClassLiteral(literal) if literal.is_known(self.db(), KnownClass::Any) => {
-                self.context.report_lint_old(
-                    &INVALID_TYPE_FORM,
-                    subscript,
-                    format_args!("Type `typing.Any` expected no type parameter",),
-                );
+                if let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, subscript) {
+                    builder.into_diagnostic("Type `typing.Any` expected no type parameter");
+                }
                 Type::unknown()
             }
             Type::KnownInstance(known_instance) => {
@@ -7337,14 +7370,14 @@ impl<'db> TypeInferenceBuilder<'db> {
                     Ok(ty) => ty,
                     Err(nodes) => {
                         for node in nodes {
-                            self.context.report_lint_old(
-                                &INVALID_TYPE_FORM,
-                                node,
-                                format_args!(
+                            if let Some(builder) =
+                                self.context.report_lint(&INVALID_TYPE_FORM, node)
+                            {
+                                builder.into_diagnostic(
                                     "Type arguments for `Literal` must be `None`, \
-                                    a literal value (int, bool, str, or bytes), or an enum value"
-                                ),
-                            );
+                                     a literal value (int, bool, str, or bytes), or an enum value",
+                                );
+                            }
                         }
                         Type::unknown()
                     }
@@ -7426,14 +7459,12 @@ impl<'db> TypeInferenceBuilder<'db> {
             // Type API special forms
             KnownInstanceType::Not => match arguments_slice {
                 ast::Expr::Tuple(_) => {
-                    self.context.report_lint_old(
-                        &INVALID_TYPE_FORM,
-                        subscript,
-                        format_args!(
+                    if let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, subscript) {
+                        builder.into_diagnostic(format_args!(
                             "Special form `{}` expected exactly one type parameter",
                             known_instance.repr(db)
-                        ),
-                    );
+                        ));
+                    }
                     Type::unknown()
                 }
                 _ => {
@@ -7455,14 +7486,12 @@ impl<'db> TypeInferenceBuilder<'db> {
             }
             KnownInstanceType::TypeOf => match arguments_slice {
                 ast::Expr::Tuple(_) => {
-                    self.context.report_lint_old(
-                        &INVALID_TYPE_FORM,
-                        subscript,
-                        format_args!(
+                    if let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, subscript) {
+                        builder.into_diagnostic(format_args!(
                             "Special form `{}` expected exactly one type parameter",
                             known_instance.repr(db)
-                        ),
-                    );
+                        ));
+                    }
                     Type::unknown()
                 }
                 _ => {
@@ -7473,14 +7502,12 @@ impl<'db> TypeInferenceBuilder<'db> {
             },
             KnownInstanceType::CallableTypeOf => match arguments_slice {
                 ast::Expr::Tuple(_) => {
-                    self.context.report_lint_old(
-                        &INVALID_TYPE_FORM,
-                        subscript,
-                        format_args!(
+                    if let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, subscript) {
+                        builder.into_diagnostic(format_args!(
                             "Special form `{}` expected exactly one type parameter",
                             known_instance.repr(db)
-                        ),
-                    );
+                        ));
+                    }
                     Type::unknown()
                 }
                 _ => {
@@ -7503,15 +7530,18 @@ impl<'db> TypeInferenceBuilder<'db> {
                     });
 
                     let Some(signature) = signature_iter.next() else {
-                        self.context.report_lint_old(
-                            &INVALID_TYPE_FORM,
-                            arguments_slice,
-                            format_args!(
-                                "Expected the first argument to `{}` to be a callable object, but got an object of type `{}`",
+                        if let Some(builder) = self
+                            .context
+                            .report_lint(&INVALID_TYPE_FORM, arguments_slice)
+                        {
+                            builder.into_diagnostic(format_args!(
+                                "Expected the first argument to `{}` \
+                                 to be a callable object, \
+                                 but got an object of type `{}`",
                                 known_instance.repr(db),
                                 argument_type.display(db)
-                            ),
-                        );
+                            ));
+                        }
                         return Type::unknown();
                     };
 
@@ -7569,14 +7599,13 @@ impl<'db> TypeInferenceBuilder<'db> {
                 todo_type!("`NotRequired[]` type qualifier")
             }
             KnownInstanceType::ClassVar | KnownInstanceType::Final => {
-                self.context.report_lint_old(
-                    &INVALID_TYPE_FORM,
-                    subscript,
-                    format_args!(
-                        "Type qualifier `{}` is not allowed in type expressions (only in annotation expressions)",
+                if let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, subscript) {
+                    builder.into_diagnostic(format_args!(
+                        "Type qualifier `{}` is not allowed in type expressions \
+                         (only in annotation expressions)",
                         known_instance.repr(db)
-                    ),
-                );
+                    ));
+                }
                 self.infer_type_expression(arguments_slice)
             }
             KnownInstanceType::Required => {
@@ -7612,38 +7641,33 @@ impl<'db> TypeInferenceBuilder<'db> {
             | KnownInstanceType::Any
             | KnownInstanceType::AlwaysTruthy
             | KnownInstanceType::AlwaysFalsy => {
-                self.context.report_lint_old(
-                    &INVALID_TYPE_FORM,
-                    subscript,
-                    format_args!(
+                if let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, subscript) {
+                    builder.into_diagnostic(format_args!(
                         "Type `{}` expected no type parameter",
                         known_instance.repr(db)
-                    ),
-                );
+                    ));
+                }
                 Type::unknown()
             }
             KnownInstanceType::TypingSelf
             | KnownInstanceType::TypeAlias
             | KnownInstanceType::Unknown => {
-                self.context.report_lint_old(
-                    &INVALID_TYPE_FORM,
-                    subscript,
-                    format_args!(
+                if let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, subscript) {
+                    builder.into_diagnostic(format_args!(
                         "Special form `{}` expected no type parameter",
                         known_instance.repr(db)
-                    ),
-                );
+                    ));
+                }
                 Type::unknown()
             }
             KnownInstanceType::LiteralString => {
-                self.context.report_lint_old(
-                    &INVALID_TYPE_FORM,
-                    subscript,
-                    format_args!(
-                        "Type `{}` expected no type parameter. Did you mean to use `Literal[...]` instead?",
+                if let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, subscript) {
+                    let mut diag = builder.into_diagnostic(format_args!(
+                        "Type `{}` expected no type parameter",
                         known_instance.repr(db)
-                    ),
-                );
+                    ));
+                    diag.info("Did you mean to use `Literal[...]` instead?");
+                }
                 Type::unknown()
             }
             KnownInstanceType::Type => self.infer_subclass_of_type_expression(arguments_slice),
@@ -7781,14 +7805,14 @@ impl<'db> TypeInferenceBuilder<'db> {
                 return None;
             }
             _ => {
-                // TODO: Check whether `Expr::Name` is a ParamSpec
-                self.context.report_lint_old(
-                    &INVALID_TYPE_FORM,
-                    parameters,
-                    format_args!(
-                        "The first argument to `Callable` must be either a list of types, ParamSpec, Concatenate, or `...`",
-                    ),
-                );
+                if let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, parameters) {
+                    // TODO: Check whether `Expr::Name` is a ParamSpec
+                    builder.into_diagnostic(format_args!(
+                        "The first argument to `Callable` \
+                         must be either a list of types, \
+                         ParamSpec, Concatenate, or `...`",
+                    ));
+                }
                 return None;
             }
         })

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2442,13 +2442,17 @@ impl<'db> TypeInferenceBuilder<'db> {
                     true
                 } else {
                     // TODO: This is not a very helpful error message, as it does not include the underlying reason
-                    // why the assignment is invalid. This would be a good use case for nested diagnostics.
+                    // why the assignment is invalid. This would be a good use case for sub-diagnostics.
                     if emit_diagnostics {
-                        self.context.report_lint_old(&INVALID_ASSIGNMENT, target, format_args!(
-                            "Object of type `{}` is not assignable to attribute `{attribute}` on type `{}`",
-                            value_ty.display(self.db()),
-                            object_ty.display(self.db()),
-                        ));
+                        if let Some(builder) = self.context.report_lint(&INVALID_ASSIGNMENT, target)
+                        {
+                            builder.into_diagnostic(format_args!(
+                                "Object of type `{}` is not assignable \
+                                 to attribute `{attribute}` on type `{}`",
+                                value_ty.display(self.db()),
+                                object_ty.display(self.db()),
+                            ));
+                        }
                     }
 
                     false
@@ -2463,12 +2467,16 @@ impl<'db> TypeInferenceBuilder<'db> {
                     true
                 } else {
                     if emit_diagnostics {
-                        // TODO: same here, see above
-                        self.context.report_lint_old(&INVALID_ASSIGNMENT, target, format_args!(
-                            "Object of type `{}` is not assignable to attribute `{attribute}` on type `{}`",
-                            value_ty.display(self.db()),
-                            object_ty.display(self.db()),
-                        ));
+                        if let Some(builder) = self.context.report_lint(&INVALID_ASSIGNMENT, target)
+                        {
+                            // TODO: same here, see above
+                            builder.into_diagnostic(format_args!(
+                                "Object of type `{}` is not assignable \
+                                 to attribute `{attribute}` on type `{}`",
+                                value_ty.display(self.db()),
+                                object_ty.display(self.db()),
+                            ));
+                        }
                     }
                     false
                 }
@@ -2557,15 +2565,16 @@ impl<'db> TypeInferenceBuilder<'db> {
                                 .is_ok();
 
                             if !successful_call && emit_diagnostics {
-                                // TODO: Here, it would be nice to emit an additional diagnostic that explains why the call failed
-                                self.context.report_lint_old(
-                                &INVALID_ASSIGNMENT,
-                                target,
-                                format_args!(
-                                    "Invalid assignment to data descriptor attribute `{attribute}` on type `{}` with custom `__set__` method",
-                                    object_ty.display(db)
-                                ),
-                            );
+                                if let Some(builder) =
+                                    self.context.report_lint(&INVALID_ASSIGNMENT, target)
+                                {
+                                    // TODO: Here, it would be nice to emit an additional diagnostic that explains why the call failed
+                                    builder.into_diagnostic(format_args!(
+                                        "Invalid assignment to data descriptor attribute \
+                                         `{attribute}` on type `{}` with custom `__set__` method",
+                                        object_ty.display(db)
+                                    ));
+                                }
                             }
 
                             successful_call
@@ -2695,15 +2704,16 @@ impl<'db> TypeInferenceBuilder<'db> {
                                 .is_ok();
 
                             if !successful_call && emit_diagnostics {
-                                // TODO: Here, it would be nice to emit an additional diagnostic that explains why the call failed
-                                self.context.report_lint_old(
-                                    &INVALID_ASSIGNMENT,
-                                    target,
-                                    format_args!(
-                                        "Invalid assignment to data descriptor attribute `{attribute}` on type `{}` with custom `__set__` method",
+                                if let Some(builder) =
+                                    self.context.report_lint(&INVALID_ASSIGNMENT, target)
+                                {
+                                    // TODO: Here, it would be nice to emit an additional diagnostic that explains why the call failed
+                                    builder.into_diagnostic(format_args!(
+                                        "Invalid assignment to data descriptor attribute \
+                                         `{attribute}` on type `{}` with custom `__set__` method",
                                         object_ty.display(db)
-                                    ),
-                                );
+                                    ));
+                                }
                             }
 
                             successful_call

--- a/crates/red_knot_python_semantic/src/types/unpacker.rs
+++ b/crates/red_knot_python_semantic/src/types/unpacker.rs
@@ -134,35 +134,45 @@ impl<'db> Unpacker<'db> {
                     };
 
                     if let Some(tuple_ty) = ty.into_tuple() {
-                        let tuple_ty_elements = self.tuple_ty_elements(target, elts, tuple_ty);
+                        let tuple_ty_elements =
+                            self.tuple_ty_elements(target, elts, tuple_ty, value_expr);
 
-                        let length_mismatch = match elts.len().cmp(&tuple_ty_elements.len()) {
-                            Ordering::Less => {
-                                self.context.report_lint_old(
-                                    &INVALID_ASSIGNMENT,
-                                    target,
-                                    format_args!(
-                                        "Too many values to unpack (expected {}, got {})",
-                                        elts.len(),
-                                        tuple_ty_elements.len()
-                                    ),
-                                );
-                                true
-                            }
-                            Ordering::Greater => {
-                                self.context.report_lint_old(
-                                    &INVALID_ASSIGNMENT,
-                                    target,
-                                    format_args!(
-                                        "Not enough values to unpack (expected {}, got {})",
-                                        elts.len(),
-                                        tuple_ty_elements.len()
-                                    ),
-                                );
-                                true
-                            }
-                            Ordering::Equal => false,
-                        };
+                        let length_mismatch =
+                            match elts.len().cmp(&tuple_ty_elements.len()) {
+                                Ordering::Less => {
+                                    if let Some(builder) =
+                                        self.context.report_lint(&INVALID_ASSIGNMENT, target)
+                                    {
+                                        let mut diag =
+                                            builder.into_diagnostic("Too many values to unpack");
+                                        diag.set_primary_message(format_args!(
+                                            "Expected {}",
+                                            elts.len(),
+                                        ));
+                                        diag.annotate(self.context.secondary(value_expr).message(
+                                            format_args!("Got {}", tuple_ty_elements.len()),
+                                        ));
+                                    }
+                                    true
+                                }
+                                Ordering::Greater => {
+                                    if let Some(builder) =
+                                        self.context.report_lint(&INVALID_ASSIGNMENT, target)
+                                    {
+                                        let mut diag =
+                                            builder.into_diagnostic("Not enough values to unpack");
+                                        diag.set_primary_message(format_args!(
+                                            "Expected {}",
+                                            elts.len(),
+                                        ));
+                                        diag.annotate(self.context.secondary(value_expr).message(
+                                            format_args!("Got {}", tuple_ty_elements.len()),
+                                        ));
+                                    }
+                                    true
+                                }
+                                Ordering::Equal => false,
+                            };
 
                         for (index, ty) in tuple_ty_elements.iter().enumerate() {
                             if let Some(element_types) = target_types.get_mut(index) {
@@ -203,11 +213,15 @@ impl<'db> Unpacker<'db> {
 
     /// Returns the [`Type`] elements inside the given [`TupleType`] taking into account that there
     /// can be a starred expression in the `elements`.
+    ///
+    /// `value_expr` is an AST reference to the value being unpacked. It is
+    /// only used for diagnostics.
     fn tuple_ty_elements(
         &self,
         expr: &ast::Expr,
         targets: &[ast::Expr],
         tuple_ty: TupleType<'db>,
+        value_expr: AnyNodeRef<'_>,
     ) -> Cow<'_, [Type<'db>]> {
         // If there is a starred expression, it will consume all of the types at that location.
         let Some(starred_index) = targets.iter().position(ast::Expr::is_starred_expr) else {
@@ -254,15 +268,15 @@ impl<'db> Unpacker<'db> {
 
             Cow::Owned(element_types)
         } else {
-            self.context.report_lint_old(
-                &INVALID_ASSIGNMENT,
-                expr,
-                format_args!(
-                    "Not enough values to unpack (expected {} or more, got {})",
-                    targets.len() - 1,
-                    tuple_ty.len(self.db())
-                ),
-            );
+            if let Some(builder) = self.context.report_lint(&INVALID_ASSIGNMENT, expr) {
+                let mut diag = builder.into_diagnostic("Not enough values to unpack");
+                diag.set_primary_message(format_args!("Expected {} or more", targets.len() - 1));
+                diag.annotate(
+                    self.context
+                        .secondary(value_expr)
+                        .message(format_args!("Got {}", tuple_ty.len(self.db()))),
+                );
+            }
 
             Cow::Owned(vec![Type::unknown(); targets.len()])
         }


### PR DESCRIPTION
This removes the last vestiges of the old diagnostics system. So everything in Red Knot should now have easy access to attaching sub-diagnostics, extra annotations and so on.

I started out initially trying to holistically improve diagnostics as I went. But that turned out to be quite slow given the sheer volume here. So I pretty quickly switched to a more mechanical approach where I just swapped out the old API with the new API.

Because the old diagnostics didn't distinguish between a message attached the diagnostic itself and a message attached to its primary annotation, and since this was a mechanical change, I had to make a choice of where to put that message: either on the main diagnostic or on the annotation. I ended up going with the former, which is a change to how diagnostics are rendered. This means that many diagnostics don't have a message attached to their primary annotation. I actually think this is okay in a lot of cases. But in some cases, there is clear room for improvement.

Closes #16809 