### PR TITLE
[red-knot] Infer the members of a protocol class

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/protocols.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/protocols.md
@@ -421,12 +421,16 @@ from typing_extensions import Protocol, get_protocol_members
 
 class Foo(Protocol):
     if sys.version_info >= (3, 10):
-        x: int
+        a: int
+        b = 42
+        def c(self) -> None: ...
     else:
-        y: str
+        d: int
+        e = 56
+        def f(self) -> None: ...
 
 # TODO: actually a frozenset
-reveal_type(get_protocol_members(Foo))  # revealed: tuple[Literal["y"]]
+reveal_type(get_protocol_members(Foo))  # revealed: tuple[Literal["d"], Literal["e"], Literal["f"]]
 ```
 
 ## Invalid calls to `get_protocol_members()`

--- a/crates/red_knot_python_semantic/src/semantic_index/use_def.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/use_def.rs
@@ -437,6 +437,15 @@ impl<'db> UseDefMap<'db> {
             .map(|symbol_id| (symbol_id, self.public_declarations(symbol_id)))
     }
 
+    pub(crate) fn all_public_bindings<'map>(
+        &'map self,
+    ) -> impl Iterator<Item = (ScopedSymbolId, BindingWithConstraintsIterator<'map, 'db>)> + 'map
+    {
+        (0..self.public_symbols.len())
+            .map(ScopedSymbolId::from_usize)
+            .map(|symbol_id| (symbol_id, self.public_bindings(symbol_id)))
+    }
+
     /// This function is intended to be called only once inside `TypeInferenceBuilder::infer_function_body`.
     pub(crate) fn can_implicit_return(&self, db: &dyn crate::Db) -> bool {
         !self

--- a/crates/red_knot_python_semantic/src/types/call/bind.rs
+++ b/crates/red_knot_python_semantic/src/types/call/bind.rs
@@ -564,10 +564,11 @@ impl<'db> Bindings<'db> {
                     Some(KnownFunction::GetProtocolMembers) => {
                         if let [Some(Type::ClassLiteral(class))] = overload.parameter_types() {
                             if let Some(protocol_class) = class.into_protocol_class(db) {
+                                // TODO: actually a frozenset at runtime (requires support for legacy generic classes)
                                 overload.set_return_type(Type::Tuple(TupleType::new(
                                     db,
                                     protocol_class
-                                        .members(db)
+                                        .protocol_members(db)
                                         .iter()
                                         .map(|member| Type::string_literal(db, member))
                                         .collect::<Box<[Type<'db>]>>(),

--- a/crates/red_knot_python_semantic/src/types/class.rs
+++ b/crates/red_knot_python_semantic/src/types/class.rs
@@ -1733,10 +1733,24 @@ impl<'db> From<ClassLiteralType<'db>> for Type<'db> {
 pub(super) struct ProtocolClassLiteral<'db>(ClassLiteralType<'db>);
 
 impl<'db> ProtocolClassLiteral<'db> {
-    pub(super) fn members(self, db: &'db dyn Db) -> &'db ordermap::set::Slice<Name> {
+    /// Returns the protocol members of this class.
+    ///
+    /// A protocol's members define the interface declared by the protocol.
+    /// They therefore determine how the protocol should behave with regards to
+    /// assignability and subtyping.
+    ///
+    /// The list of members consists of all bindings and declarations that take place
+    /// in the protocol's class body, except for a list of excluded attributes which should
+    /// not be taken into account. (This list includes `__init__` and `__new__`, which can
+    /// legally be defined on protocol classes but do not constitute protocol members.)
+    ///
+    /// It is illegal for a protocol class to have any instance attributes that are not declared
+    /// in the protocol's class body. If any are assigned to, they are not taken into account in
+    /// the protocol's list of members.
+    pub(super) fn protocol_members(self, db: &'db dyn Db) -> &'db ordermap::set::Slice<Name> {
         /// The list of excluded members is subject to change between Python versions,
         /// especially for dunders, but it probably doesn't matter *too* much if this
-        /// list goes out of date. It's up-to-date as of Python commit 87b1ea016b1454b1e83b9113fa9435849b7743aa
+        /// list goes out of date. It's up to date as of Python commit 87b1ea016b1454b1e83b9113fa9435849b7743aa
         /// (<https://github.com/python/cpython/blob/87b1ea016b1454b1e83b9113fa9435849b7743aa/Lib/typing.py#L1776-L1791>)
         fn excluded_from_proto_members(member: &str) -> bool {
             matches!(


### PR DESCRIPTION
## Summary

This PR adds the necessary machinery to infer the members of a protocol class, and uses that machinery to infer a precise return type for the `get_protocol_members` introspection function.

What this PR _doesn't_ do is infer what the _type_ of each protocol member is. We'll obviously have to do that in due course to properly implement protocol subtyping and assignability; when we add that functionality, I'm envisaging that `ProtocolClassLiteral::members()` would return a `HashMap` mapping from the member to its type rather than a boxed slice of `Name`s. I'm deliberately not doing that right now, however, as implementing all the subtyping rules around protocols is a somewhat large task, which I intend to approach incrementally over several PRs. The first stage will possibly not even consider the types of the protocol members at all.

## Test Plan

Existing mdtests updated.
