### PR TITLE
[red-knot] Eliminate `None` in equality-comparison narrowing

### DIFF
--- a/crates/red_knot_python_semantic/src/types/narrow.rs
+++ b/crates/red_knot_python_semantic/src/types/narrow.rs
@@ -446,6 +446,11 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
                 }
             }
             ast::CmpOp::Eq if lhs_ty.is_literal_string() => Some(rhs_ty),
+            ast::CmpOp::Eq if !rhs_ty.is_none(self.db) => Some(
+                IntersectionBuilder::new(self.db)
+                    .add_negative(Type::none(self.db))
+                    .build(),
+            ),
             ast::CmpOp::In => self.evaluate_expr_in(lhs_ty, rhs_ty),
             ast::CmpOp::NotIn => self
                 .evaluate_expr_in(lhs_ty, rhs_ty)


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
