### PR TITLE
[red-knot] Update `==` and `!=` narrowing

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/assert.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/assert.md
@@ -29,7 +29,7 @@ def _(x: Literal[1, 2, 3], y: Literal[1, 2, 3]):
     assert x is 2
     reveal_type(x)  # revealed: Literal[2]
     assert y == 2
-    reveal_type(y)  # revealed: Literal[1, 2, 3]
+    reveal_type(y)  # revealed: Literal[2]
 ```
 
 ## `assert` with `isinstance`

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals/elif_else.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals/elif_else.md
@@ -20,11 +20,9 @@ def _(flag1: bool, flag2: bool):
     x = 1 if flag1 else 2 if flag2 else 3
 
     if x == 1:
-        # TODO should be Literal[1]
-        reveal_type(x)  # revealed: Literal[1, 2, 3]
+        reveal_type(x)  # revealed: Literal[1]
     elif x == 2:
-        # TODO should be Literal[2]
-        reveal_type(x)  # revealed: Literal[2, 3]
+        reveal_type(x)  # revealed: Literal[2]
     else:
         reveal_type(x)  # revealed: Literal[3]
 ```
@@ -38,14 +36,11 @@ def _(flag1: bool, flag2: bool):
     if x != 1:
         reveal_type(x)  # revealed: Literal[2, 3]
     elif x != 2:
-        # TODO should be `Literal[1]`
-        reveal_type(x)  # revealed: Literal[1, 3]
+        reveal_type(x)  # revealed: Literal[1]
     elif x == 3:
-        # TODO should be Never
-        reveal_type(x)  # revealed: Literal[1, 2, 3]
+        reveal_type(x)  # revealed: Never
     else:
-        # TODO should be Never
-        reveal_type(x)  # revealed: Literal[1, 2]
+        reveal_type(x)  # revealed: Never
 ```
 
 ## Assignment expressions

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -121,8 +121,17 @@ def _(b: bool, i: Literal[1, 2]):
     if b == 1:
         reveal_type(b)  # revealed: Literal[True]
     else:
-        # TODO could be Literal[False]
+        reveal_type(b)  # revealed: Literal[False]
+
+    if b == 6:
+        reveal_type(b)  # revealed: Never
+    else:
         reveal_type(b)  # revealed: bool
+
+    if b == 0:
+        reveal_type(b)  # revealed: Literal[False]
+    else:
+        reveal_type(b)  # revealed: Literal[True]
 
     if i == True:
         reveal_type(i)  # revealed: Literal[1]

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -107,7 +107,7 @@ from typing import Any
 
 def _(x: Any | None, y: Any | None):
     if x != 1:
-        reveal_type(x)  # revealed: Any & ~Literal[1] | None
+        reveal_type(x)  # revealed: (Any & ~Literal[1]) | None
     if y == 1:
         reveal_type(y)  # revealed: Any & ~None
 ```
@@ -115,10 +115,35 @@ def _(x: Any | None, y: Any | None):
 ## Booleans and integers
 
 ```py
-def _(b: bool):
+from typing import Literal
+
+def _(b: bool, i: Literal[1, 2]):
     if b == 1:
         reveal_type(b)  # revealed: Literal[True]
     else:
         # TODO could be Literal[False]
         reveal_type(b)  # revealed: bool
+
+    if i == True:
+        reveal_type(i)  # revealed: Literal[1]
+    else:
+        # TODO could be Literal[2]
+        reveal_type(i)  # revealed: Literal[1, 2]
+```
+
+## Narrowing `LiteralString` in union
+
+```py
+from typing_extensions import Literal, LiteralString, Any
+
+def _(s: LiteralString | None, t: LiteralString | Any):
+    if s == "foo":
+        reveal_type(s)  # revealed: Literal["foo"]
+
+    if s == 1:
+        reveal_type(s)  # revealed: Never
+
+    if t == "foo":
+        # TODO could be `Literal["foo"] | Any`
+        reveal_type(t)  # revealed: LiteralString | Any
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -100,7 +100,7 @@ else:
     reveal_type(x)  # revealed: Literal[1]
 ```
 
-## `Any` narrowing
+## Union with `Any`
 
 ```py
 from typing import Any
@@ -110,4 +110,15 @@ def _(x: Any | None, y: Any | None):
         reveal_type(x)  # revealed: Any & ~Literal[1] | None
     if y == 1:
         reveal_type(y)  # revealed: Any & ~None
+```
+
+## Booleans and integers
+
+```py
+def _(b: bool):
+    if b == 1:
+        reveal_type(b)  # revealed: Literal[True]
+    else:
+        # TODO could be Literal[False]
+        reveal_type(b)  # revealed: bool
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -136,8 +136,7 @@ def _(b: bool, i: Literal[1, 2]):
     if i == True:
         reveal_type(i)  # revealed: Literal[1]
     else:
-        # TODO could be Literal[2]
-        reveal_type(i)  # revealed: Literal[1, 2]
+        reveal_type(i)  # revealed: Literal[2]
 ```
 
 ## Narrowing `LiteralString` in union

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals/nested.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals/nested.md
@@ -31,17 +31,14 @@ def _(flag1: bool, flag2: bool):
     if x != 1:
         reveal_type(x)  # revealed: Literal[2, 3]
         if x == 2:
-            # TODO should be `Literal[2]`
-            reveal_type(x)  # revealed: Literal[2, 3]
+            reveal_type(x)  # revealed: Literal[2]
         elif x == 3:
             reveal_type(x)  # revealed: Literal[3]
         else:
             reveal_type(x)  # revealed: Never
 
     elif x != 2:
-        # TODO should be Literal[1]
-        reveal_type(x)  # revealed: Literal[1, 3]
+        reveal_type(x)  # revealed: Literal[1]
     else:
-        # TODO should be Never
-        reveal_type(x)  # revealed: Literal[1, 2, 3]
+        reveal_type(x)  # revealed: Never
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals/not_eq.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals/not_eq.md
@@ -9,8 +9,7 @@ def _(flag: bool):
     if x != None:
         reveal_type(x)  # revealed: Literal[1]
     else:
-        # TODO should be None
-        reveal_type(x)  # revealed: None | Literal[1]
+        reveal_type(x)  # revealed: None
 ```
 
 ## `!=` for other singleton types
@@ -22,8 +21,7 @@ def _(flag: bool):
     if x != False:
         reveal_type(x)  # revealed: Literal[True]
     else:
-        # TODO should be Literal[False]
-        reveal_type(x)  # revealed: bool
+        reveal_type(x)  # revealed: Literal[False]
 ```
 
 ## `x != y` where `y` is of literal type
@@ -47,8 +45,7 @@ def _(flag: bool):
     if C != A:
         reveal_type(C)  # revealed: Literal[B]
     else:
-        # TODO should be Literal[A]
-        reveal_type(C)  # revealed: Literal[A, B]
+        reveal_type(C)  # revealed: Literal[A]
 ```
 
 ## `x != y` where `y` has multiple single-valued options
@@ -61,8 +58,7 @@ def _(flag1: bool, flag2: bool):
     if x != y:
         reveal_type(x)  # revealed: Literal[1, 2]
     else:
-        # TODO should be Literal[2]
-        reveal_type(x)  # revealed: Literal[1, 2]
+        reveal_type(x)  # revealed: Literal[2]
 ```
 
 ## `!=` for non-single-valued types
@@ -101,6 +97,5 @@ def f() -> Literal[1, 2, 3]:
 if (x := f()) != 1:
     reveal_type(x)  # revealed: Literal[2, 3]
 else:
-    # TODO should be Literal[1]
-    reveal_type(x)  # revealed: Literal[1, 2, 3]
+    reveal_type(x)  # revealed: Literal[1]
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals/not_eq.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals/not_eq.md
@@ -56,7 +56,8 @@ def _(flag1: bool, flag2: bool):
     y = 2 if flag2 else 3
 
     if x != y:
-        reveal_type(x)  # revealed: Literal[1, 2]
+        # TODO: should be Literal[1, 2]
+        reveal_type(x)  # revealed: Literal[1]
     else:
         reveal_type(x)  # revealed: Literal[2]
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals/not_eq.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals/not_eq.md
@@ -56,8 +56,7 @@ def _(flag1: bool, flag2: bool):
     y = 2 if flag2 else 3
 
     if x != y:
-        # TODO: should be Literal[1, 2]
-        reveal_type(x)  # revealed: Literal[1]
+        reveal_type(x)  # revealed: Literal[1, 2]
     else:
         reveal_type(x)  # revealed: Literal[2]
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals/not_eq.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals/not_eq.md
@@ -99,3 +99,15 @@ if (x := f()) != 1:
 else:
     reveal_type(x)  # revealed: Literal[1]
 ```
+
+## `Any` narrowing
+
+```py
+from typing import Any
+
+def _(x: Any | None, y: Any | None):
+    if x != 1:
+        reveal_type(x)  # revealed: Any & ~Literal[1] | None
+    if y == 1:
+        reveal_type(y)  # revealed: Any & ~None
+```

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -2172,28 +2172,6 @@ impl<'db> Type<'db> {
         }
     }
 
-    // Get the part of the type that is positively narrowable and are not a subtype of the other type.
-    fn positively_narrowable_with(self, db: &'db dyn Db, target: Type<'db>) -> Type<'db> {
-        if self.is_single_valued(db) || self.is_union_of_single_valued(db) {
-            if self.is_subtype_of(db, target) {
-                Type::Never
-            } else {
-                self
-            }
-        } else {
-            match self {
-                Type::Union(union) => {
-                    let elements = union
-                        .elements(db)
-                        .iter()
-                        .map(|elem| elem.positively_narrowable_with(db, target));
-                    UnionType::from_elements(db, elements)
-                }
-                _ => Type::Never,
-            }
-        }
-    }
-
     /// This function is roughly equivalent to `find_name_in_mro` as defined in the [descriptor guide] or
     /// [`_PyType_Lookup`] in CPython's `Objects/typeobject.c`. It should typically be called through
     /// [Type::class_member], unless it is known that `self` is a class-like type. This function returns

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -2174,10 +2174,6 @@ impl<'db> Type<'db> {
                 .is_some_and(|instance| instance.class().is_known(db, KnownClass::Bool))
     }
 
-    fn is_negatively_narrowable(self, db: &'db dyn Db) -> bool {
-        self.is_single_valued(db)
-    }
-
     /// This function is roughly equivalent to `find_name_in_mro` as defined in the [descriptor guide] or
     /// [`_PyType_Lookup`] in CPython's `Objects/typeobject.c`. It should typically be called through
     /// [Type::class_member], unless it is known that `self` is a class-like type. This function returns

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -2165,6 +2165,19 @@ impl<'db> Type<'db> {
         }
     }
 
+    fn is_positively_narrowable(self, db: &'db dyn Db) -> bool {
+        self.is_single_valued(db)
+            || self.is_union_of_single_valued(db)
+            || self.is_literal_string()
+            || self
+                .into_instance()
+                .is_some_and(|instance| instance.class().is_known(db, KnownClass::Bool))
+    }
+
+    fn is_negatively_narrowable(self, db: &'db dyn Db) -> bool {
+        self.is_single_valued(db)
+    }
+
     /// This function is roughly equivalent to `find_name_in_mro` as defined in the [descriptor guide] or
     /// [`_PyType_Lookup`] in CPython's `Objects/typeobject.c`. It should typically be called through
     /// [Type::class_member], unless it is known that `self` is a class-like type. This function returns

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -781,10 +781,13 @@ impl<'db> Type<'db> {
     }
 
     pub fn is_union_of_single_valued(&self, db: &'db dyn Db) -> bool {
-        self.into_union()
-            .is_some_and(|union| union.elements(db).iter().all(|ty| ty.is_single_valued(db)))
+        self.into_union().is_some_and(|union| {
+            union
+                .elements(db)
+                .iter()
+                .all(|ty| ty.is_single_valued(db) || ty.is_bool(db) || ty.is_literal_string())
+        }) || self.is_bool(db)
             || self.is_literal_string()
-            || self.is_bool(db)
     }
 
     pub const fn into_int_literal(self) -> Option<i64> {

--- a/crates/red_knot_python_semantic/src/types/narrow.rs
+++ b/crates/red_knot_python_semantic/src/types/narrow.rs
@@ -411,7 +411,7 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
     }
 
     fn evaluate_expr_ne(&mut self, rhs_ty: Type<'db>) -> Option<Type<'db>> {
-        if rhs_ty.is_single_valued(self.db) || rhs_ty.is_union_of_single_valued(self.db) {
+        if rhs_ty.is_single_valued(self.db) {
             Some(rhs_ty.negate(self.db))
         } else {
             None

--- a/crates/red_knot_python_semantic/src/types/narrow.rs
+++ b/crates/red_knot_python_semantic/src/types/narrow.rs
@@ -405,7 +405,7 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
     }
 
     fn evaluate_expr_ne(&mut self, rhs_ty: Type<'db>) -> Option<Type<'db>> {
-        if rhs_ty.is_negatively_narrowable(self.db) {
+        if rhs_ty.is_single_valued(self.db) {
             Some(rhs_ty.negate(self.db))
         } else {
             None

--- a/crates/red_knot_python_semantic/src/types/narrow.rs
+++ b/crates/red_knot_python_semantic/src/types/narrow.rs
@@ -395,13 +395,7 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
     }
 
     fn evaluate_expr_eq(&mut self, lhs_ty: Type<'db>, rhs_ty: Type<'db>) -> Option<Type<'db>> {
-        // TODO: move this to a `Type` function
-        if (lhs_ty.is_single_valued(self.db)
-            || lhs_ty.is_union_of_single_valued(self.db)
-            || lhs_ty.is_literal_string()
-            || lhs_ty
-                .into_instance()
-                .is_some_and(|instance| instance.class().is_known(self.db, KnownClass::Bool)))
+        if lhs_ty.is_positively_narrowable(self.db)
             && (rhs_ty.is_single_valued(self.db) || rhs_ty.is_union_of_single_valued(self.db))
         {
             Some(rhs_ty)
@@ -411,7 +405,7 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
     }
 
     fn evaluate_expr_ne(&mut self, rhs_ty: Type<'db>) -> Option<Type<'db>> {
-        if rhs_ty.is_single_valued(self.db) {
+        if rhs_ty.is_negatively_narrowable(self.db) {
             Some(rhs_ty.negate(self.db))
         } else {
             None

--- a/crates/red_knot_python_semantic/src/types/narrow.rs
+++ b/crates/red_knot_python_semantic/src/types/narrow.rs
@@ -395,10 +395,16 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
     }
 
     fn evaluate_expr_eq(&mut self, lhs_ty: Type<'db>, rhs_ty: Type<'db>) -> Option<Type<'db>> {
-        if lhs_ty.is_positively_narrowable(self.db)
-            && (rhs_ty.is_single_valued(self.db) || rhs_ty.is_union_of_single_valued(self.db))
-        {
-            Some(rhs_ty)
+        if rhs_ty.is_single_valued(self.db) || rhs_ty.is_union_of_single_valued(self.db) {
+            let union = UnionBuilder::new(self.db)
+                .add(
+                    lhs_ty
+                        .positively_narrowable_with(self.db, rhs_ty)
+                        .negate(self.db),
+                )
+                .add(rhs_ty)
+                .build();
+            Some(union)
         } else {
             None
         }

--- a/crates/red_knot_python_semantic/src/types/narrow.rs
+++ b/crates/red_knot_python_semantic/src/types/narrow.rs
@@ -410,7 +410,7 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
         }
     }
 
-    fn evaluate_expr_ne(&mut self, lhs_ty: Type<'db>, rhs_ty: Type<'db>) -> Option<Type<'db>> {
+    fn evaluate_expr_ne(&mut self, rhs_ty: Type<'db>) -> Option<Type<'db>> {
         if rhs_ty.is_single_valued(self.db) || rhs_ty.is_union_of_single_valued(self.db) {
             Some(rhs_ty.negate(self.db))
         } else {
@@ -460,7 +460,7 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
             }
             ast::CmpOp::Is => Some(rhs_ty),
             ast::CmpOp::Eq => self.evaluate_expr_eq(lhs_ty, rhs_ty),
-            ast::CmpOp::NotEq => self.evaluate_expr_ne(lhs_ty, rhs_ty),
+            ast::CmpOp::NotEq => self.evaluate_expr_ne(rhs_ty),
             ast::CmpOp::In => self.evaluate_expr_in(lhs_ty, rhs_ty),
             ast::CmpOp::NotIn => self
                 .evaluate_expr_in(lhs_ty, rhs_ty)

--- a/crates/red_knot_python_semantic/src/types/narrow.rs
+++ b/crates/red_knot_python_semantic/src/types/narrow.rs
@@ -433,9 +433,7 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
                     // Boolean literals and int literals are disjoint, and single valued, and yet
                     // `True == 1` and `False == 0`.
                     (Type::BooleanLiteral(b), Type::IntLiteral(i))
-                    | (Type::IntLiteral(i), Type::BooleanLiteral(b)) => {
-                        (b && (i == 1)) || (!b && (i == 0))
-                    }
+                    | (Type::IntLiteral(i), Type::BooleanLiteral(b)) => i64::from(b) == i,
                     // Other than the above cases, two single-valued disjoint types cannot compare
                     // equal.
                     _ => !(left_ty.is_single_valued(db) && right_ty.is_single_valued(db)),


### PR DESCRIPTION
## Summary

Historically we have avoided narrowing on `==` tests because in many cases it's unsound, since subclasses of a type could compare equal to who-knows-what. But there are a lot of types (literals and unions of them, as well as some known instances like `None` -- single-valued types) whose `__eq__` behavior we know, and which we can safely narrow away based on equality comparisons.

This PR implements equality narrowing in the cases where it is sound. The most elegant way to do this (and the way that is most in-line with our approach up until now) would be to introduce new Type variants `NeverEqualTo[...]` and `AlwaysEqualTo[...]`, and then implement all type relations for those variants, narrow by intersection, and let union and intersection simplification sort it all out. This is analogous to our existing handling for `AlwaysFalse` and `AlwaysTrue`.

But I'm reluctant to add new `Type` variants for this, mostly because they could end up un-simplified in some types and make types even more complex. So let's try this approach, where we handle more of the narrowing logic as a special case.

## Test Plan

Updated and added tests.
