### PR TITLE
Add --respect-ignore-files flag

### DIFF
--- a/crates/red_knot/src/args.rs
+++ b/crates/red_knot/src/args.rs
@@ -105,6 +105,19 @@ pub(crate) struct CheckCommand {
     /// Watch files for changes and recheck files related to the changed files.
     #[arg(long, short = 'W')]
     pub(crate) watch: bool,
+
+    /// Respect file exclusions via `.gitignore` and other standard ignore files.
+    /// Use `--no-respect-gitignore` to disable.
+    #[arg(
+        long,
+        overrides_with("no_respect_ignore_files"),
+        help_heading = "File selection",
+        default_missing_value = "true",
+        num_args = 0..1
+    )]
+    respect_ignore_files: Option<bool>,
+    #[clap(long, overrides_with("respect_ignore_files"), hide = true)]
+    no_respect_ignore_files: bool,
 }
 
 impl CheckCommand {
@@ -120,6 +133,13 @@ impl CheckCommand {
             )
         };
 
+        // --no-respect-gitignore defaults to false and is set true by CLI flag. If passed, override config file
+        // Otherwise, only pass this through if explicitly set (don't default to anything here to
+        // make sure that doesn't take precedence over an explicitly-set config file value)
+        let respect_ignore_files = self
+            .no_respect_ignore_files
+            .then_some(false)
+            .or(self.respect_ignore_files);
         Options {
             environment: Some(EnvironmentOptions {
                 python_version: self
@@ -144,6 +164,7 @@ impl CheckCommand {
                 error_on_warning: self.error_on_warning,
             }),
             rules,
+            respect_ignore_files,
             ..Default::default()
         }
     }

--- a/crates/red_knot_project/src/metadata/options.rs
+++ b/crates/red_knot_project/src/metadata/options.rs
@@ -32,6 +32,9 @@ pub struct Options {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub terminal: Option<TerminalOptions>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub respect_ignore_files: Option<bool>,
 }
 
 impl Options {
@@ -133,7 +136,7 @@ impl Options {
     pub(crate) fn to_settings(&self, db: &dyn Db) -> (Settings, Vec<OptionDiagnostic>) {
         let (rules, diagnostics) = self.to_rule_selection(db);
 
-        let mut settings = Settings::new(rules);
+        let mut settings = Settings::new(rules, self.respect_ignore_files);
 
         if let Some(terminal) = self.terminal.as_ref() {
             settings.set_terminal(TerminalSettings {

--- a/crates/red_knot_project/src/metadata/settings.rs
+++ b/crates/red_knot_project/src/metadata/settings.rs
@@ -21,18 +21,25 @@ pub struct Settings {
     rules: Arc<RuleSelection>,
 
     terminal: TerminalSettings,
+
+    respect_ignore_files: bool,
 }
 
 impl Settings {
-    pub fn new(rules: RuleSelection) -> Self {
+    pub fn new(rules: RuleSelection, respect_ignore_files: Option<bool>) -> Self {
         Self {
             rules: Arc::new(rules),
             terminal: TerminalSettings::default(),
+            respect_ignore_files: respect_ignore_files.unwrap_or(true),
         }
     }
 
     pub fn rules(&self) -> &RuleSelection {
         &self.rules
+    }
+
+    pub fn respect_ignore_files(&self) -> bool {
+        self.respect_ignore_files
     }
 
     pub fn to_rules(&self) -> Arc<RuleSelection> {

--- a/crates/red_knot_project/src/walk.rs
+++ b/crates/red_knot_project/src/walk.rs
@@ -129,7 +129,10 @@ impl<'a> ProjectFilesWalker<'a> {
     {
         let mut paths = paths.into_iter();
 
-        let mut walker = db.system().walk_directory(paths.next()?.as_ref());
+        let mut walker = db
+            .system()
+            .walk_directory(paths.next()?.as_ref())
+            .standard_filters(db.project().settings(db).respect_ignore_files());
 
         for path in paths {
             walker = walker.add(path);

--- a/knot.schema.json
+++ b/knot.schema.json
@@ -15,6 +15,12 @@
         }
       ]
     },
+    "respect-ignore-files": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
     "rules": {
       "description": "Configures the enabled lints and their severity.",
       "anyOf": [


### PR DESCRIPTION
## Summary
#15491

this PR adds a `--respect-ignore-files`, `--no-respect-ignore-files`, and `[knot.respect-ignore-files]` CLI/config file options that drive whether standard ignore files are respected when doing file discovery. Borrowed the CLI flag pattern (positive/negative CLI flags) from Ruff

## Test Plan
Added snapshot tests