### PR TITLE
[red-knot] mypy_primer: add strawberry, print compilation errors to stderr

### DIFF
--- a/.github/workflows/mypy_primer.yaml
+++ b/.github/workflows/mypy_primer.yaml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Install mypy_primer
         run: |
-          uv tool install "git+https://github.com/hauntsaninja/mypy_primer@ebaa9fd27b51a278873b63676fd25490cec6823b"
+          uv tool install "git+https://github.com/hauntsaninja/mypy_primer@4c22d192a456e27badf85b3ea0f830707375d2b7"
 
       - name: Run mypy_primer
         shell: bash

--- a/crates/red_knot_python_semantic/resources/primer/good.txt
+++ b/crates/red_knot_python_semantic/resources/primer/good.txt
@@ -96,6 +96,7 @@ speedrun.com_global_scoreboard_webapp
 starlette
 static-frame
 stone
+strawberry
 tornado
 twine
 typeshed-stats


### PR DESCRIPTION
## Summary

mypy_primer changes included here: https://github.com/hauntsaninja/mypy_primer/compare/ebaa9fd27b51a278873b63676fd25490cec6823b..4c22d192a456e27badf85b3ea0f830707375d2b7

- Add strawberry as a `good.txt` project (was previously included in our fork)
- Print Red Knot compilation errors to stderr (thanks @MichaReiser)