### PR TITLE
[red-knot] Make `BoundMethodType` a salsa interned

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -6223,7 +6223,7 @@ impl KnownFunction {
 /// on an instance of a class. For example, the expression `Path("a.txt").touch` creates
 /// a bound method object that represents the `Path.touch` method which is bound to the
 /// instance `Path("a.txt")`.
-#[salsa::tracked(debug)]
+#[salsa::interned(debug)]
 pub struct BoundMethodType<'db> {
     /// The function that is being bound. Corresponds to the `__func__` attribute on a
     /// bound method object


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ruff/issues/17579

Use a salsa-interned instead of a salsa-tracked because we want that two `BoundMethodType`'s compare equal if they belong to the same function and self instance.

This fixes the property tests because salsa-trackeds can't be created outside of queries because their "instance" is owned by the creating query. 
The property tests started creating `BoundMethodType` instances in https://github.com/astral-sh/ruff/commit/e45f23b0ec1efd093c6588f9b7d56bf87c4eebae because
`is_subtype_of` now calls `Class::into_callable` which calls `into_bound_method_type`.

## Test Plan

I ran the property tests locally
