### PR TITLE
[red-knot] Add `FunctionType::to_overloaded`

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -6126,11 +6126,7 @@ impl<'db> FunctionType<'db> {
             Some(specialization),
         )
     }
-}
 
-// This is a separate block for now to avoid making `to_overloaded` a salsa query. This is a
-// temporary workaround until salsa supports returning `Option<&T>` from a tracked query.
-impl<'db> FunctionType<'db> {
     /// Returns `self` as [`OverloadedFunction`] if it is overloaded, [`None`] otherwise.
     fn to_overloaded(self, db: &'db dyn Db) -> Option<&'db OverloadedFunction<'db>> {
         #[allow(clippy::ref_option)] // TODO: Remove once salsa supports deref (https://github.com/salsa-rs/salsa/pull/772)


### PR DESCRIPTION
## Summary

This PR adds a new method `FunctionType::to_overloaded` which converts a `FunctionType` into an `OverloadedFunction` which contains all the `@overload`-ed `FunctionType` and the implementation `FunctionType` if it exists.

There's a big caveat here (it's the way overloads work) which is that this method can only "see" all the overloads that comes _before_ itself. Consider the following example:

```py
from typing import overload

@overload
def foo() -> None: ...
@overload
def foo(x: int) -> int: ...
def foo(x: int | None) -> int | None:
	return x
```

Here, when the `to_overloaded` method is invoked on the
1. first `foo` definition, it would only contain a single overload which is itself and no implementation.
2. second `foo` definition, it would contain both overloads and still no implementation
3. third `foo` definition, it would contain both overloads and the implementation which is itself

### Usages

This method will be used in the logic for checking invalid overload usages. It can also be used for #17541.

## Test Plan

Make sure that existing tests pass.
