### PR TITLE
Split `SourceLocation` into `LineColumn` and `SourceLocation`

### DIFF
--- a/crates/red_knot_server/src/document.rs
+++ b/crates/red_knot_server/src/document.rs
@@ -27,6 +27,16 @@ pub enum PositionEncoding {
     UTF8,
 }
 
+impl From<PositionEncoding> for ruff_source_file::PositionEncoding {
+    fn from(value: PositionEncoding) -> Self {
+        match value {
+            PositionEncoding::UTF8 => Self::Utf8,
+            PositionEncoding::UTF16 => Self::Utf16,
+            PositionEncoding::UTF32 => Self::Utf32,
+        }
+    }
+}
+
 /// A unique document ID, derived from a URL passed as part of an LSP request.
 /// This document ID can point to either be a standalone Python file, a full notebook, or a cell within a notebook.
 #[derive(Clone, Debug)]

--- a/crates/red_knot_server/src/document/range.rs
+++ b/crates/red_knot_server/src/document/range.rs
@@ -9,8 +9,8 @@ use red_knot_python_semantic::Db;
 use ruff_db::files::FileRange;
 use ruff_db::source::{line_index, source_text};
 use ruff_notebook::NotebookIndex;
-use ruff_source_file::OneIndexed;
-use ruff_source_file::{LineIndex, SourceLocation};
+use ruff_source_file::LineIndex;
+use ruff_source_file::{OneIndexed, SourceLocation};
 use ruff_text_size::{Ranged, TextRange, TextSize};
 
 #[expect(dead_code)]
@@ -46,7 +46,7 @@ impl TextSizeExt for TextSize {
         index: &LineIndex,
         encoding: PositionEncoding,
     ) -> types::Position {
-        let source_location = offset_to_source_location(self, text, index, encoding);
+        let source_location = index.source_location(self, text, encoding.into());
         source_location_to_position(&source_location)
     }
 }
@@ -75,36 +75,14 @@ fn u32_index_to_usize(index: u32) -> usize {
 
 impl PositionExt for lsp_types::Position {
     fn to_text_size(&self, text: &str, index: &LineIndex, encoding: PositionEncoding) -> TextSize {
-        let start_line = index.line_range(
-            OneIndexed::from_zero_indexed(u32_index_to_usize(self.line)),
+        index.offset(
+            SourceLocation {
+                line: OneIndexed::from_zero_indexed(u32_index_to_usize(self.line)),
+                character_offset: OneIndexed::from_zero_indexed(u32_index_to_usize(self.character)),
+            },
             text,
-        );
-
-        let start_column_offset = match encoding {
-            PositionEncoding::UTF8 => TextSize::new(self.character),
-
-            PositionEncoding::UTF16 => {
-                // Fast path for ASCII only documents
-                if index.is_ascii() {
-                    TextSize::new(self.character)
-                } else {
-                    // UTF16 encodes characters either as one or two 16 bit words.
-                    // The position in `range` is the 16-bit word offset from the start of the line (and not the character offset)
-                    // UTF-16 with a text that may use variable-length characters.
-                    utf8_column_offset(self.character, &text[start_line])
-                }
-            }
-            PositionEncoding::UTF32 => {
-                // UTF-32 uses 4 bytes for each character. Meaning, the position in range is a character offset.
-                return index.offset(
-                    OneIndexed::from_zero_indexed(u32_index_to_usize(self.line)),
-                    OneIndexed::from_zero_indexed(u32_index_to_usize(self.character)),
-                    text,
-                );
-            }
-        };
-
-        start_line.start() + start_column_offset.clamp(TextSize::new(0), start_line.end())
+            encoding.into(),
+        )
     }
 }
 
@@ -142,26 +120,23 @@ impl ToRangeExt for TextRange {
         notebook_index: &NotebookIndex,
         encoding: PositionEncoding,
     ) -> NotebookRange {
-        let start = offset_to_source_location(self.start(), text, source_index, encoding);
-        let mut end = offset_to_source_location(self.end(), text, source_index, encoding);
-        let starting_cell = notebook_index.cell(start.row);
+        let start = source_index.source_location(self.start(), text, encoding.into());
+        let mut end = source_index.source_location(self.end(), text, encoding.into());
+        let starting_cell = notebook_index.cell(start.line);
 
         // weird edge case here - if the end of the range is where the newline after the cell got added (making it 'out of bounds')
         // we need to move it one character back (which should place it at the end of the last line).
         // we test this by checking if the ending offset is in a different (or nonexistent) cell compared to the cell of the starting offset.
-        if notebook_index.cell(end.row) != starting_cell {
-            end.row = end.row.saturating_sub(1);
-            end.column = offset_to_source_location(
-                self.end().checked_sub(1.into()).unwrap_or_default(),
-                text,
-                source_index,
-                encoding,
-            )
-            .column;
+        if notebook_index.cell(end.line) != starting_cell {
+            end.line = end.line.saturating_sub(1);
+            let offset = self.end().checked_sub(1.into()).unwrap_or_default();
+            end.character_offset = source_index
+                .source_location(offset, text, encoding.into())
+                .character_offset;
         }
 
-        let start = source_location_to_position(&notebook_index.translate_location(&start));
-        let end = source_location_to_position(&notebook_index.translate_location(&end));
+        let start = source_location_to_position(&notebook_index.translate_source_location(&start));
+        let end = source_location_to_position(&notebook_index.translate_source_location(&end));
 
         NotebookRange {
             cell: starting_cell
@@ -172,67 +147,10 @@ impl ToRangeExt for TextRange {
     }
 }
 
-/// Converts a UTF-16 code unit offset for a given line into a UTF-8 column number.
-fn utf8_column_offset(utf16_code_unit_offset: u32, line: &str) -> TextSize {
-    let mut utf8_code_unit_offset = TextSize::new(0);
-
-    let mut i = 0u32;
-
-    for c in line.chars() {
-        if i >= utf16_code_unit_offset {
-            break;
-        }
-
-        // Count characters encoded as two 16 bit words as 2 characters.
-        {
-            utf8_code_unit_offset +=
-                TextSize::new(u32::try_from(c.len_utf8()).expect("utf8 len always <=4"));
-            i += u32::try_from(c.len_utf16()).expect("utf16 len always <=2");
-        }
-    }
-
-    utf8_code_unit_offset
-}
-
-fn offset_to_source_location(
-    offset: TextSize,
-    text: &str,
-    index: &LineIndex,
-    encoding: PositionEncoding,
-) -> SourceLocation {
-    match encoding {
-        PositionEncoding::UTF8 => {
-            let row = index.line_index(offset);
-            let column = offset - index.line_start(row, text);
-
-            SourceLocation {
-                column: OneIndexed::from_zero_indexed(column.to_usize()),
-                row,
-            }
-        }
-        PositionEncoding::UTF16 => {
-            let row = index.line_index(offset);
-
-            let column = if index.is_ascii() {
-                (offset - index.line_start(row, text)).to_usize()
-            } else {
-                let up_to_line = &text[TextRange::new(index.line_start(row, text), offset)];
-                up_to_line.encode_utf16().count()
-            };
-
-            SourceLocation {
-                column: OneIndexed::from_zero_indexed(column),
-                row,
-            }
-        }
-        PositionEncoding::UTF32 => index.source_location(offset, text),
-    }
-}
-
 fn source_location_to_position(location: &SourceLocation) -> types::Position {
     types::Position {
-        line: u32::try_from(location.row.to_zero_indexed()).expect("row usize fits in u32"),
-        character: u32::try_from(location.column.to_zero_indexed())
+        line: u32::try_from(location.line.to_zero_indexed()).expect("line usize fits in u32"),
+        character: u32::try_from(location.character_offset.to_zero_indexed())
             .expect("character usize fits in u32"),
     }
 }

--- a/crates/red_knot_test/src/matcher.rs
+++ b/crates/red_knot_test/src/matcher.rs
@@ -263,7 +263,7 @@ impl Matcher {
             .and_then(|span| span.range())
             .map(|range| {
                 self.line_index
-                    .source_location(range.start(), &self.source)
+                    .line_column(range.start(), &self.source)
                     .column
             })
             .unwrap_or(OneIndexed::from_zero_indexed(0))

--- a/crates/ruff_db/src/diagnostic/render.rs
+++ b/crates/ruff_db/src/diagnostic/render.rs
@@ -71,8 +71,8 @@ impl std::fmt::Display for DisplayDiagnostic<'_> {
                 write!(f, " {path}", path = self.resolver.path(span.file()))?;
                 if let Some(range) = span.range() {
                     let input = self.resolver.input(span.file());
-                    let start = input.as_source_code().source_location(range.start());
-                    write!(f, ":{line}:{col}", line = start.row, col = start.column)?;
+                    let start = input.as_source_code().line_column(range.start());
+                    write!(f, ":{line}:{col}", line = start.line, col = start.column)?;
                 }
                 write!(f, ":")?;
             }

--- a/crates/ruff_linter/src/checkers/ast/analyze/definitions.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/definitions.rs
@@ -191,7 +191,7 @@ pub(crate) fn definitions(checker: &mut Checker) {
                 warn_user!(
                     "Docstring at {}:{}:{} contains implicit string concatenation; ignoring...",
                     relativize_path(checker.path),
-                    location.row,
+                    location.line,
                     location.column
                 );
                 continue;

--- a/crates/ruff_linter/src/locator.rs
+++ b/crates/ruff_linter/src/locator.rs
@@ -2,7 +2,7 @@
 
 use std::cell::OnceCell;
 
-use ruff_source_file::{LineIndex, LineRanges, OneIndexed, SourceCode, SourceLocation};
+use ruff_source_file::{LineColumn, LineIndex, LineRanges, OneIndexed, SourceCode};
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 
 #[derive(Debug)]
@@ -36,8 +36,8 @@ impl<'a> Locator<'a> {
     #[deprecated(
         note = "This is expensive, avoid using outside of the diagnostic phase. Prefer the other `Locator` methods instead."
     )]
-    pub fn compute_source_location(&self, offset: TextSize) -> SourceLocation {
-        self.to_source_code().source_location(offset)
+    pub fn compute_source_location(&self, offset: TextSize) -> LineColumn {
+        self.to_source_code().line_column(offset)
     }
 
     pub fn to_index(&self) -> &LineIndex {

--- a/crates/ruff_linter/src/message/azure.rs
+++ b/crates/ruff_linter/src/message/azure.rs
@@ -1,6 +1,6 @@
 use std::io::Write;
 
-use ruff_source_file::SourceLocation;
+use ruff_source_file::LineColumn;
 
 use crate::message::{Emitter, EmitterContext, Message};
 
@@ -20,7 +20,7 @@ impl Emitter for AzureEmitter {
             let location = if context.is_notebook(message.filename()) {
                 // We can't give a reasonable location for the structured formats,
                 // so we show one that's clearly a fallback
-                SourceLocation::default()
+                LineColumn::default()
             } else {
                 message.compute_start_location()
             };
@@ -30,7 +30,7 @@ impl Emitter for AzureEmitter {
                 "##vso[task.logissue type=error\
                         ;sourcepath={filename};linenumber={line};columnnumber={col};{code}]{body}",
                 filename = message.filename(),
-                line = location.row,
+                line = location.line,
                 col = location.column,
                 code = message
                     .rule()

--- a/crates/ruff_linter/src/message/github.rs
+++ b/crates/ruff_linter/src/message/github.rs
@@ -1,6 +1,6 @@
 use std::io::Write;
 
-use ruff_source_file::SourceLocation;
+use ruff_source_file::LineColumn;
 
 use crate::fs::relativize_path;
 use crate::message::{Emitter, EmitterContext, Message};
@@ -22,9 +22,9 @@ impl Emitter for GithubEmitter {
             let location = if context.is_notebook(message.filename()) {
                 // We can't give a reasonable location for the structured formats,
                 // so we show one that's clearly a fallback
-                SourceLocation::default()
+                LineColumn::default()
             } else {
-                source_location.clone()
+                source_location
             };
 
             let end_location = message.compute_end_location();
@@ -34,9 +34,9 @@ impl Emitter for GithubEmitter {
                 "::error title=Ruff{code},file={file},line={row},col={column},endLine={end_row},endColumn={end_column}::",
                 code = message.rule().map_or_else(String::new, |rule| format!(" ({})", rule.noqa_code())),
                 file = message.filename(),
-                row = source_location.row,
+                row = source_location.line,
                 column = source_location.column,
-                end_row = end_location.row,
+                end_row = end_location.line,
                 end_column = end_location.column,
             )?;
 
@@ -44,7 +44,7 @@ impl Emitter for GithubEmitter {
                 writer,
                 "{path}:{row}:{column}:",
                 path = relativize_path(message.filename()),
-                row = location.row,
+                row = location.line,
                 column = location.column,
             )?;
 

--- a/crates/ruff_linter/src/message/gitlab.rs
+++ b/crates/ruff_linter/src/message/gitlab.rs
@@ -71,8 +71,8 @@ impl Serialize for SerializedMessages<'_> {
                 })
             } else {
                 json!({
-                    "begin": start_location.row,
-                    "end": end_location.row
+                    "begin": start_location.line,
+                    "end": end_location.line
                 })
             };
 

--- a/crates/ruff_linter/src/message/grouped.rs
+++ b/crates/ruff_linter/src/message/grouped.rs
@@ -57,7 +57,7 @@ impl Emitter for GroupedEmitter {
             let mut max_column_length = OneIndexed::MIN;
 
             for message in &messages {
-                max_row_length = max_row_length.max(message.start_location.row);
+                max_row_length = max_row_length.max(message.start_location.line);
                 max_column_length = max_column_length.max(message.start_location.column);
             }
 
@@ -115,8 +115,8 @@ impl Display for DisplayGroupedMessage<'_> {
         write!(
             f,
             "  {row_padding}",
-            row_padding =
-                " ".repeat(self.row_length.get() - calculate_print_width(start_location.row).get())
+            row_padding = " "
+                .repeat(self.row_length.get() - calculate_print_width(start_location.line).get())
         )?;
 
         // Check if we're working on a jupyter notebook and translate positions with cell accordingly
@@ -125,18 +125,18 @@ impl Display for DisplayGroupedMessage<'_> {
                 f,
                 "cell {cell}{sep}",
                 cell = jupyter_index
-                    .cell(start_location.row)
+                    .cell(start_location.line)
                     .unwrap_or(OneIndexed::MIN),
                 sep = ":".cyan()
             )?;
             (
                 jupyter_index
-                    .cell_row(start_location.row)
+                    .cell_row(start_location.line)
                     .unwrap_or(OneIndexed::MIN),
                 start_location.column,
             )
         } else {
-            (start_location.row, start_location.column)
+            (start_location.line, start_location.column)
         };
 
         writeln!(

--- a/crates/ruff_linter/src/message/junit.rs
+++ b/crates/ruff_linter/src/message/junit.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use quick_junit::{NonSuccessKind, Report, TestCase, TestCaseStatus, TestSuite, XmlString};
 
-use ruff_source_file::SourceLocation;
+use ruff_source_file::LineColumn;
 
 use crate::message::{
     group_messages_by_filename, Emitter, EmitterContext, Message, MessageWithLocation,
@@ -47,14 +47,14 @@ impl Emitter for JunitEmitter {
                     let location = if context.is_notebook(message.filename()) {
                         // We can't give a reasonable location for the structured formats,
                         // so we show one that's clearly a fallback
-                        SourceLocation::default()
+                        LineColumn::default()
                     } else {
                         start_location
                     };
 
                     status.set_description(format!(
                         "line {row}, col {col}, {body}",
-                        row = location.row,
+                        row = location.line,
                         col = location.column,
                         body = message.body()
                     ));
@@ -72,7 +72,7 @@ impl Emitter for JunitEmitter {
                     case.set_classname(classname.to_str().unwrap());
                     case.extra.insert(
                         XmlString::new("line"),
-                        XmlString::new(location.row.to_string()),
+                        XmlString::new(location.line.to_string()),
                     );
                     case.extra.insert(
                         XmlString::new("column"),

--- a/crates/ruff_linter/src/message/mod.rs
+++ b/crates/ruff_linter/src/message/mod.rs
@@ -18,7 +18,7 @@ pub use rdjson::RdjsonEmitter;
 use ruff_diagnostics::{Diagnostic, DiagnosticKind, Fix};
 use ruff_notebook::NotebookIndex;
 use ruff_python_parser::{ParseError, UnsupportedSyntaxError};
-use ruff_source_file::{SourceFile, SourceLocation};
+use ruff_source_file::{LineColumn, SourceFile};
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 pub use sarif::SarifEmitter;
 pub use text::TextEmitter;
@@ -239,17 +239,15 @@ impl Message {
     }
 
     /// Computes the start source location for the message.
-    pub fn compute_start_location(&self) -> SourceLocation {
+    pub fn compute_start_location(&self) -> LineColumn {
         self.source_file()
             .to_source_code()
-            .source_location(self.start())
+            .line_column(self.start())
     }
 
     /// Computes the end source location for the message.
-    pub fn compute_end_location(&self) -> SourceLocation {
-        self.source_file()
-            .to_source_code()
-            .source_location(self.end())
+    pub fn compute_end_location(&self) -> LineColumn {
+        self.source_file().to_source_code().line_column(self.end())
     }
 
     /// Returns the [`SourceFile`] which the message belongs to.
@@ -284,7 +282,7 @@ impl Ranged for Message {
 
 struct MessageWithLocation<'a> {
     message: &'a Message,
-    start_location: SourceLocation,
+    start_location: LineColumn,
 }
 
 impl Deref for MessageWithLocation<'_> {

--- a/crates/ruff_linter/src/message/pylint.rs
+++ b/crates/ruff_linter/src/message/pylint.rs
@@ -23,7 +23,7 @@ impl Emitter for PylintEmitter {
                 // so we show one that's clearly a fallback
                 OneIndexed::from_zero_indexed(0)
             } else {
-                message.compute_start_location().row
+                message.compute_start_location().line
             };
 
             let body = if let Some(rule) = message.rule() {

--- a/crates/ruff_linter/src/message/sarif.rs
+++ b/crates/ruff_linter/src/message/sarif.rs
@@ -129,9 +129,9 @@ impl SarifResult {
             uri: url::Url::from_file_path(&path)
                 .map_err(|()| anyhow::anyhow!("Failed to convert path to URL: {}", path.display()))?
                 .to_string(),
-            start_line: start_location.row,
+            start_line: start_location.line,
             start_column: start_location.column,
-            end_line: end_location.row,
+            end_line: end_location.line,
             end_column: end_location.column,
         })
     }
@@ -147,9 +147,9 @@ impl SarifResult {
             level: "error".to_string(),
             message: message.body().to_string(),
             uri: path.display().to_string(),
-            start_line: start_location.row,
+            start_line: start_location.line,
             start_column: start_location.column,
-            end_line: end_location.row,
+            end_line: end_location.line,
             end_column: end_location.column,
         })
     }

--- a/crates/ruff_linter/src/message/text.rs
+++ b/crates/ruff_linter/src/message/text.rs
@@ -7,7 +7,7 @@ use colored::Colorize;
 use ruff_annotate_snippets::{Level, Renderer, Snippet};
 
 use ruff_notebook::NotebookIndex;
-use ruff_source_file::{OneIndexed, SourceLocation};
+use ruff_source_file::{LineColumn, OneIndexed};
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 
 use crate::fs::relativize_path;
@@ -86,14 +86,14 @@ impl Emitter for TextEmitter {
                     writer,
                     "cell {cell}{sep}",
                     cell = notebook_index
-                        .cell(start_location.row)
+                        .cell(start_location.line)
                         .unwrap_or(OneIndexed::MIN),
                     sep = ":".cyan(),
                 )?;
 
-                SourceLocation {
-                    row: notebook_index
-                        .cell_row(start_location.row)
+                LineColumn {
+                    line: notebook_index
+                        .cell_row(start_location.line)
                         .unwrap_or(OneIndexed::MIN),
                     column: start_location.column,
                 }
@@ -104,7 +104,7 @@ impl Emitter for TextEmitter {
             writeln!(
                 writer,
                 "{row}{sep}{col}{sep} {code_and_body}",
-                row = diagnostic_location.row,
+                row = diagnostic_location.line,
                 col = diagnostic_location.column,
                 sep = ":".cyan(),
                 code_and_body = RuleCodeAndBody {

--- a/crates/ruff_notebook/src/index.rs
+++ b/crates/ruff_notebook/src/index.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use ruff_source_file::{OneIndexed, SourceLocation};
+use ruff_source_file::{LineColumn, OneIndexed, SourceLocation};
 
 /// Jupyter Notebook indexing table
 ///
@@ -33,16 +33,29 @@ impl NotebookIndex {
         self.row_to_row_in_cell.get(row.to_zero_indexed()).copied()
     }
 
-    /// Translates the given source location based on the indexing table.
+    /// Translates the given [`LineColumn`] based on the indexing table.
     ///
     /// This will translate the row/column in the concatenated source code
     /// to the row/column in the Jupyter Notebook.
-    pub fn translate_location(&self, source_location: &SourceLocation) -> SourceLocation {
-        SourceLocation {
-            row: self
-                .cell_row(source_location.row)
+    pub fn translate_line_column(&self, source_location: &LineColumn) -> LineColumn {
+        LineColumn {
+            line: self
+                .cell_row(source_location.line)
                 .unwrap_or(OneIndexed::MIN),
             column: source_location.column,
+        }
+    }
+
+    /// Translates the given [`SourceLocation`] based on the indexing table.
+    ///
+    /// This will translate the line/character in the concatenated source code
+    /// to the line/character in the Jupyter Notebook.
+    pub fn translate_source_location(&self, source_location: &SourceLocation) -> SourceLocation {
+        SourceLocation {
+            line: self
+                .cell_row(source_location.line)
+                .unwrap_or(OneIndexed::MIN),
+            character_offset: source_location.character_offset,
         }
     }
 }

--- a/crates/ruff_python_formatter/tests/fixtures.rs
+++ b/crates/ruff_python_formatter/tests/fixtures.rs
@@ -430,10 +430,10 @@ fn ensure_unchanged_ast(
             formatted_unsupported_syntax_errors
                 .into_values()
                 .map(|error| {
-                    let location = index.source_location(error.start(), formatted_code);
+                    let location = index.line_column(error.start(), formatted_code);
                     format!(
                         "{row}:{col} {error}",
-                        row = location.row,
+                        row = location.line,
                         col = location.column
                     )
                 })

--- a/crates/ruff_server/src/edit.rs
+++ b/crates/ruff_server/src/edit.rs
@@ -31,6 +31,16 @@ pub enum PositionEncoding {
     UTF8,
 }
 
+impl From<PositionEncoding> for ruff_source_file::PositionEncoding {
+    fn from(value: PositionEncoding) -> Self {
+        match value {
+            PositionEncoding::UTF8 => Self::Utf8,
+            PositionEncoding::UTF16 => Self::Utf16,
+            PositionEncoding::UTF32 => Self::Utf32,
+        }
+    }
+}
+
 /// A unique document ID, derived from a URL passed as part of an LSP request.
 /// This document ID can point to either be a standalone Python file, a full notebook, or a cell within a notebook.
 #[derive(Clone, Debug)]

--- a/crates/ruff_server/src/edit/range.rs
+++ b/crates/ruff_server/src/edit/range.rs
@@ -2,9 +2,9 @@ use super::notebook;
 use super::PositionEncoding;
 use lsp_types as types;
 use ruff_notebook::NotebookIndex;
-use ruff_source_file::OneIndexed;
-use ruff_source_file::{LineIndex, SourceLocation};
-use ruff_text_size::{TextRange, TextSize};
+use ruff_source_file::LineIndex;
+use ruff_source_file::{OneIndexed, SourceLocation};
+use ruff_text_size::TextRange;
 
 pub(crate) struct NotebookRange {
     pub(crate) cell: notebook::CellId,
@@ -38,76 +38,43 @@ impl RangeExt for lsp_types::Range {
         index: &LineIndex,
         encoding: PositionEncoding,
     ) -> TextRange {
-        let start_line = index.line_range(
-            OneIndexed::from_zero_indexed(u32_index_to_usize(self.start.line)),
+        let start = index.offset(
+            SourceLocation {
+                line: OneIndexed::from_zero_indexed(u32_index_to_usize(self.start.line)),
+                character_offset: OneIndexed::from_zero_indexed(u32_index_to_usize(
+                    self.start.character,
+                )),
+            },
             text,
+            encoding.into(),
         );
-        let end_line = index.line_range(
-            OneIndexed::from_zero_indexed(u32_index_to_usize(self.end.line)),
+        let end = index.offset(
+            SourceLocation {
+                line: OneIndexed::from_zero_indexed(u32_index_to_usize(self.end.line)),
+                character_offset: OneIndexed::from_zero_indexed(u32_index_to_usize(
+                    self.end.character,
+                )),
+            },
             text,
+            encoding.into(),
         );
 
-        let (start_column_offset, end_column_offset) = match encoding {
-            PositionEncoding::UTF8 => (
-                TextSize::new(self.start.character),
-                TextSize::new(self.end.character),
-            ),
-
-            PositionEncoding::UTF16 => {
-                // Fast path for ASCII only documents
-                if index.is_ascii() {
-                    (
-                        TextSize::new(self.start.character),
-                        TextSize::new(self.end.character),
-                    )
-                } else {
-                    // UTF16 encodes characters either as one or two 16 bit words.
-                    // The position in `range` is the 16-bit word offset from the start of the line (and not the character offset)
-                    // UTF-16 with a text that may use variable-length characters.
-                    (
-                        utf8_column_offset(self.start.character, &text[start_line]),
-                        utf8_column_offset(self.end.character, &text[end_line]),
-                    )
-                }
-            }
-            PositionEncoding::UTF32 => {
-                // UTF-32 uses 4 bytes for each character. Meaning, the position in range is a character offset.
-                return TextRange::new(
-                    index.offset(
-                        OneIndexed::from_zero_indexed(u32_index_to_usize(self.start.line)),
-                        OneIndexed::from_zero_indexed(u32_index_to_usize(self.start.character)),
-                        text,
-                    ),
-                    index.offset(
-                        OneIndexed::from_zero_indexed(u32_index_to_usize(self.end.line)),
-                        OneIndexed::from_zero_indexed(u32_index_to_usize(self.end.character)),
-                        text,
-                    ),
-                );
-            }
-        };
-
-        TextRange::new(
-            start_line.start() + start_column_offset.clamp(TextSize::new(0), start_line.end()),
-            end_line.start() + end_column_offset.clamp(TextSize::new(0), end_line.end()),
-        )
+        TextRange::new(start, end)
     }
 }
 
 impl ToRangeExt for TextRange {
     fn to_range(&self, text: &str, index: &LineIndex, encoding: PositionEncoding) -> types::Range {
         types::Range {
-            start: source_location_to_position(&offset_to_source_location(
+            start: source_location_to_position(&index.source_location(
                 self.start(),
                 text,
-                index,
-                encoding,
+                encoding.into(),
             )),
-            end: source_location_to_position(&offset_to_source_location(
+            end: source_location_to_position(&index.source_location(
                 self.end(),
                 text,
-                index,
-                encoding,
+                encoding.into(),
             )),
         }
     }
@@ -119,26 +86,26 @@ impl ToRangeExt for TextRange {
         notebook_index: &NotebookIndex,
         encoding: PositionEncoding,
     ) -> NotebookRange {
-        let start = offset_to_source_location(self.start(), text, source_index, encoding);
-        let mut end = offset_to_source_location(self.end(), text, source_index, encoding);
-        let starting_cell = notebook_index.cell(start.row);
+        let start = source_index.source_location(self.start(), text, encoding.into());
+        let mut end = source_index.source_location(self.end(), text, encoding.into());
+        let starting_cell = notebook_index.cell(start.line);
 
         // weird edge case here - if the end of the range is where the newline after the cell got added (making it 'out of bounds')
         // we need to move it one character back (which should place it at the end of the last line).
         // we test this by checking if the ending offset is in a different (or nonexistent) cell compared to the cell of the starting offset.
-        if notebook_index.cell(end.row) != starting_cell {
-            end.row = end.row.saturating_sub(1);
-            end.column = offset_to_source_location(
-                self.end().checked_sub(1.into()).unwrap_or_default(),
-                text,
-                source_index,
-                encoding,
-            )
-            .column;
+        if notebook_index.cell(end.line) != starting_cell {
+            end.line = end.line.saturating_sub(1);
+            end.character_offset = source_index
+                .source_location(
+                    self.end().checked_sub(1.into()).unwrap_or_default(),
+                    text,
+                    encoding.into(),
+                )
+                .character_offset;
         }
 
-        let start = source_location_to_position(&notebook_index.translate_location(&start));
-        let end = source_location_to_position(&notebook_index.translate_location(&end));
+        let start = source_location_to_position(&notebook_index.translate_source_location(&start));
+        let end = source_location_to_position(&notebook_index.translate_source_location(&end));
 
         NotebookRange {
             cell: starting_cell
@@ -149,67 +116,10 @@ impl ToRangeExt for TextRange {
     }
 }
 
-/// Converts a UTF-16 code unit offset for a given line into a UTF-8 column number.
-fn utf8_column_offset(utf16_code_unit_offset: u32, line: &str) -> TextSize {
-    let mut utf8_code_unit_offset = TextSize::new(0);
-
-    let mut i = 0u32;
-
-    for c in line.chars() {
-        if i >= utf16_code_unit_offset {
-            break;
-        }
-
-        // Count characters encoded as two 16 bit words as 2 characters.
-        {
-            utf8_code_unit_offset +=
-                TextSize::new(u32::try_from(c.len_utf8()).expect("utf8 len always <=4"));
-            i += u32::try_from(c.len_utf16()).expect("utf16 len always <=2");
-        }
-    }
-
-    utf8_code_unit_offset
-}
-
-fn offset_to_source_location(
-    offset: TextSize,
-    text: &str,
-    index: &LineIndex,
-    encoding: PositionEncoding,
-) -> SourceLocation {
-    match encoding {
-        PositionEncoding::UTF8 => {
-            let row = index.line_index(offset);
-            let column = offset - index.line_start(row, text);
-
-            SourceLocation {
-                column: OneIndexed::from_zero_indexed(column.to_usize()),
-                row,
-            }
-        }
-        PositionEncoding::UTF16 => {
-            let row = index.line_index(offset);
-
-            let column = if index.is_ascii() {
-                (offset - index.line_start(row, text)).to_usize()
-            } else {
-                let up_to_line = &text[TextRange::new(index.line_start(row, text), offset)];
-                up_to_line.encode_utf16().count()
-            };
-
-            SourceLocation {
-                column: OneIndexed::from_zero_indexed(column),
-                row,
-            }
-        }
-        PositionEncoding::UTF32 => index.source_location(offset, text),
-    }
-}
-
 fn source_location_to_position(location: &SourceLocation) -> types::Position {
     types::Position {
-        line: u32::try_from(location.row.to_zero_indexed()).expect("row usize fits in u32"),
-        character: u32::try_from(location.column.to_zero_indexed())
+        line: u32::try_from(location.line.to_zero_indexed()).expect("row usize fits in u32"),
+        character: u32::try_from(location.character_offset.to_zero_indexed())
             .expect("character usize fits in u32"),
     }
 }

--- a/crates/ruff_server/src/server.rs
+++ b/crates/ruff_server/src/server.rs
@@ -59,6 +59,7 @@ impl Server {
 
         let client_capabilities = init_params.capabilities;
         let position_encoding = Self::find_best_position_encoding(&client_capabilities);
+
         let server_capabilities = Self::server_capabilities(position_encoding);
 
         let connection = connection.initialize_finish(
@@ -97,6 +98,8 @@ impl Server {
             workspace_folders,
             workspace_settings.unwrap_or_default(),
         )?;
+
+        tracing::debug!("Negotiated position encoding: {position_encoding:?}");
 
         Ok(Self {
             connection,

--- a/crates/ruff_source_file/src/line_index.rs
+++ b/crates/ruff_source_file/src/line_index.rs
@@ -5,13 +5,12 @@ use std::ops::Deref;
 use std::str::FromStr;
 use std::sync::Arc;
 
+use crate::{LineColumn, SourceLocation};
 use ruff_text_size::{TextLen, TextRange, TextSize};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use crate::SourceLocation;
-
-/// Index for fast [byte offset](TextSize) to [`SourceLocation`] conversions.
+/// Index for fast [byte offset](TextSize) to [`LineColumn`] conversions.
 ///
 /// Cloning a [`LineIndex`] is cheap because it only requires bumping a reference count.
 #[derive(Clone, Eq, PartialEq)]
@@ -66,39 +65,53 @@ impl LineIndex {
         self.inner.kind
     }
 
-    /// Returns the row and column index for an offset.
+    /// Returns the line and column number for an offset, skipping the BOM character (if any) because
+    /// it's uncommon for editors and other tools to count it as a column.
+    ///
+    /// ### BOM handling
+    ///
+    /// Offsets before the end of the BOM character are all mapped to the first line and column. This means,
+    /// that converting the position back to an offset always returns the offset AFTER the BOM character.
+    /// The operation isn't reversible, but it is consistent.
     ///
     /// ## Examples
     ///
     /// ```
     /// # use ruff_text_size::TextSize;
-    /// # use ruff_source_file::{LineIndex, OneIndexed, SourceLocation};
-    /// let source = "def a():\n    pass";
-    /// let index = LineIndex::from_source_text(source);
+    /// # use ruff_source_file::{LineIndex, OneIndexed, LineColumn};
+    /// let source = format!("\u{FEFF}{}", "def a():\n    pass");
+    /// let index = LineIndex::from_source_text(&source);
     ///
+    /// // Before BOM, maps to after BOM
     /// assert_eq!(
-    ///     index.source_location(TextSize::from(0), source),
-    ///     SourceLocation { row: OneIndexed::from_zero_indexed(0), column: OneIndexed::from_zero_indexed(0) }
+    ///     index.line_column(TextSize::from(0), &source),
+    ///     LineColumn { line: OneIndexed::from_zero_indexed(0), column: OneIndexed::from_zero_indexed(0) }
+    /// );
+    ///
+    /// // After BOM, maps to after BOM
+    /// assert_eq!(
+    ///     index.line_column(TextSize::from(3), &source),
+    ///     LineColumn { line: OneIndexed::from_zero_indexed(0), column: OneIndexed::from_zero_indexed(0) }
     /// );
     ///
     /// assert_eq!(
-    ///     index.source_location(TextSize::from(4), source),
-    ///     SourceLocation { row: OneIndexed::from_zero_indexed(0), column: OneIndexed::from_zero_indexed(4) }
+    ///     index.line_column(TextSize::from(7), &source),
+    ///     LineColumn { line: OneIndexed::from_zero_indexed(0), column: OneIndexed::from_zero_indexed(4) }
     /// );
     /// assert_eq!(
-    ///     index.source_location(TextSize::from(13), source),
-    ///     SourceLocation { row: OneIndexed::from_zero_indexed(1), column: OneIndexed::from_zero_indexed(4) }
+    ///     index.line_column(TextSize::from(16), &source),
+    ///     LineColumn { line: OneIndexed::from_zero_indexed(1), column: OneIndexed::from_zero_indexed(4) }
     /// );
     /// ```
     ///
     /// ## Panics
     ///
     /// If the offset is out of bounds.
-    pub fn source_location(&self, offset: TextSize, content: &str) -> SourceLocation {
+    pub fn line_column(&self, offset: TextSize, content: &str) -> LineColumn {
         match self.line_starts().binary_search(&offset) {
             // Offset is at the start of a line
-            Ok(row) => SourceLocation {
-                row: OneIndexed::from_zero_indexed(row),
+            Ok(line) => LineColumn {
+                line: OneIndexed::from_zero_indexed(line),
                 column: OneIndexed::from_zero_indexed(0),
             },
             Err(next_row) => {
@@ -117,9 +130,94 @@ impl LineIndex {
                     content[TextRange::new(line_start, offset)].chars().count()
                 };
 
-                SourceLocation {
-                    row: OneIndexed::from_zero_indexed(row),
+                LineColumn {
+                    line: OneIndexed::from_zero_indexed(row),
                     column: OneIndexed::from_zero_indexed(column),
+                }
+            }
+        }
+    }
+
+    /// Returns the line and character offset according to the given encoding.
+    ///
+    /// ### BOM handling
+    ///
+    /// Unlike [`Self::line_column`], this method does not skip the BOM character. This allows for
+    /// bidirectional mapping between `LineCharacter` and `TextSize`.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// # use ruff_text_size::TextSize;
+    /// # use ruff_source_file::{LineIndex, OneIndexed, LineColumn, SourceLocation, PositionEncoding, Line};
+    /// let source = format!("\u{FEFF}{}", "def a():\n    pass");
+    /// let index = LineIndex::from_source_text(&source);
+    ///
+    /// // Before BOM, maps to character 0
+    /// assert_eq!(
+    ///     index.source_location(TextSize::from(0), &source, PositionEncoding::Utf32),
+    ///     SourceLocation { line: OneIndexed::from_zero_indexed(0), character_offset: OneIndexed::from_zero_indexed(0) }
+    /// );
+    ///
+    /// // After BOM, maps to after BOM
+    /// assert_eq!(
+    ///     index.source_location(TextSize::from(3), &source, PositionEncoding::Utf32),
+    ///     SourceLocation { line: OneIndexed::from_zero_indexed(0), character_offset: OneIndexed::from_zero_indexed(1) }
+    /// );
+    ///
+    /// assert_eq!(
+    ///     index.source_location(TextSize::from(7), &source, PositionEncoding::Utf32),
+    ///     SourceLocation { line: OneIndexed::from_zero_indexed(0), character_offset: OneIndexed::from_zero_indexed(5) }
+    /// );
+    /// assert_eq!(
+    ///     index.source_location(TextSize::from(16), &source, PositionEncoding::Utf32),
+    ///     SourceLocation { line: OneIndexed::from_zero_indexed(1), character_offset: OneIndexed::from_zero_indexed(4) }
+    /// );
+    /// ```
+    ///
+    /// ## Panics
+    ///
+    /// If the offset is out of bounds.
+    pub fn source_location(
+        &self,
+        offset: TextSize,
+        text: &str,
+        encoding: PositionEncoding,
+    ) -> SourceLocation {
+        let line = self.line_index(offset);
+        let line_start = self.line_start(line, text);
+
+        if self.is_ascii() {
+            return SourceLocation {
+                line,
+                character_offset: OneIndexed::from_zero_indexed((offset - line_start).to_usize()),
+            };
+        }
+
+        match encoding {
+            PositionEncoding::Utf8 => {
+                let character_offset = offset - line_start;
+                SourceLocation {
+                    line,
+                    character_offset: OneIndexed::from_zero_indexed(character_offset.to_usize()),
+                }
+            }
+            PositionEncoding::Utf16 => {
+                let up_to_character = &text[TextRange::new(line_start, offset)];
+                let character = up_to_character.encode_utf16().count();
+
+                SourceLocation {
+                    line,
+                    character_offset: OneIndexed::from_zero_indexed(character),
+                }
+            }
+            PositionEncoding::Utf32 => {
+                let up_to_character = &text[TextRange::new(line_start, offset)];
+                let character = up_to_character.chars().count();
+
+                SourceLocation {
+                    line,
+                    character_offset: OneIndexed::from_zero_indexed(character),
                 }
             }
         }
@@ -141,7 +239,7 @@ impl LineIndex {
     ///
     /// ```
     /// # use ruff_text_size::TextSize;
-    /// # use ruff_source_file::{LineIndex, OneIndexed, SourceLocation};
+    /// # use ruff_source_file::{LineIndex, OneIndexed, LineColumn};
     /// let source = "def a():\n    pass";
     /// let index = LineIndex::from_source_text(source);
     ///
@@ -221,83 +319,211 @@ impl LineIndex {
         }
     }
 
-    /// Returns the [byte offset](TextSize) at `line` and `column`.
+    /// Returns the [byte offset](TextSize) at `line` and `character` where character is counted using the given encoding.
     ///
     /// ## Examples
     ///
     /// ### ASCII
     ///
     /// ```
-    /// use ruff_source_file::{LineIndex, OneIndexed};
-    /// use ruff_text_size::TextSize;
+    /// # use ruff_source_file::{SourceLocation, LineIndex, OneIndexed, PositionEncoding};
+    /// # use ruff_text_size::TextSize;
     /// let source = r#"a = 4
     /// c = "some string"
     /// x = b"#;
     ///
     /// let index = LineIndex::from_source_text(source);
     ///
-    /// // First line, first column
-    /// assert_eq!(index.offset(OneIndexed::from_zero_indexed(0), OneIndexed::from_zero_indexed(0), source), TextSize::new(0));
+    /// // First line, first character
+    /// assert_eq!(
+    ///     index.offset(
+    ///         SourceLocation {
+    ///             line: OneIndexed::from_zero_indexed(0),
+    ///             character_offset: OneIndexed::from_zero_indexed(0)
+    ///         },
+    ///         source,
+    ///         PositionEncoding::Utf32,
+    ///     ),
+    ///     TextSize::new(0)
+    ///  );
     ///
-    /// // Second line, 4th column
-    /// assert_eq!(index.offset(OneIndexed::from_zero_indexed(1), OneIndexed::from_zero_indexed(4), source), TextSize::new(10));
+    /// assert_eq!(
+    ///     index.offset(
+    ///         SourceLocation {
+    ///             line: OneIndexed::from_zero_indexed(1),
+    ///             character_offset: OneIndexed::from_zero_indexed(4)
+    ///         },
+    ///         source,
+    ///         PositionEncoding::Utf32,
+    ///     ),
+    ///     TextSize::new(10)
+    ///  );
     ///
     /// // Offset past the end of the first line
-    /// assert_eq!(index.offset(OneIndexed::from_zero_indexed(0), OneIndexed::from_zero_indexed(10), source), TextSize::new(6));
+    /// assert_eq!(
+    ///     index.offset(
+    ///         SourceLocation {
+    ///             line: OneIndexed::from_zero_indexed(0),
+    ///             character_offset: OneIndexed::from_zero_indexed(10)
+    ///         },
+    ///         source,
+    ///         PositionEncoding::Utf32,
+    ///     ),
+    ///     TextSize::new(6)
+    ///  );
     ///
     /// // Offset past the end of the file
-    /// assert_eq!(index.offset(OneIndexed::from_zero_indexed(3), OneIndexed::from_zero_indexed(0), source), TextSize::new(29));
+    /// assert_eq!(
+    ///     index.offset(
+    ///         SourceLocation {
+    ///             line: OneIndexed::from_zero_indexed(3),
+    ///             character_offset: OneIndexed::from_zero_indexed(0)
+    ///         },
+    ///         source,
+    ///         PositionEncoding::Utf32,
+    ///     ),
+    ///     TextSize::new(29)
+    ///  );
     /// ```
     ///
     /// ### UTF8
     ///
     /// ```
-    /// use ruff_source_file::{LineIndex, OneIndexed};
+    /// use ruff_source_file::{LineIndex, OneIndexed, SourceLocation, PositionEncoding};
     /// use ruff_text_size::TextSize;
-    /// let source = r#"a = 4
+    /// let source = format!("\u{FEFF}{}", r#"a = 4
     /// c = "❤️"
-    /// x = b"#;
+    /// x = b"#);
     ///
-    /// let index = LineIndex::from_source_text(source);
+    /// let index = LineIndex::from_source_text(&source);
     ///
-    /// // First line, first column
-    /// assert_eq!(index.offset(OneIndexed::from_zero_indexed(0), OneIndexed::from_zero_indexed(0), source), TextSize::new(0));
+    /// // First line, first character, points at the BOM
+    /// assert_eq!(
+    ///     index.offset(
+    ///         SourceLocation {
+    ///             line: OneIndexed::from_zero_indexed(0),
+    ///             character_offset: OneIndexed::from_zero_indexed(0)
+    ///         },
+    ///         &source,
+    ///         PositionEncoding::Utf32,
+    ///     ),
+    ///     TextSize::new(0)
+    ///  );
     ///
-    /// // Third line, 2nd column, after emoji
-    /// assert_eq!(index.offset(OneIndexed::from_zero_indexed(2), OneIndexed::from_zero_indexed(1), source), TextSize::new(20));
+    /// // First line, after the BOM
+    /// assert_eq!(
+    ///     index.offset(
+    ///         SourceLocation {
+    ///             line: OneIndexed::from_zero_indexed(0),
+    ///             character_offset: OneIndexed::from_zero_indexed(1)
+    ///         },
+    ///         &source,
+    ///         PositionEncoding::Utf32,
+    ///     ),
+    ///     TextSize::new(3)
+    ///  );
+    ///
+    /// // second line, 7th character, after emoji, UTF32
+    /// assert_eq!(
+    ///     index.offset(
+    ///         SourceLocation {
+    ///             line: OneIndexed::from_zero_indexed(1),
+    ///             character_offset: OneIndexed::from_zero_indexed(7)
+    ///         },
+    ///         &source,
+    ///         PositionEncoding::Utf32,
+    ///     ),
+    ///     TextSize::new(20)
+    ///  );
+    ///
+    /// // Second line, 7th character, after emoji, UTF 16
+    /// assert_eq!(
+    ///     index.offset(
+    ///         SourceLocation {
+    ///             line: OneIndexed::from_zero_indexed(1),
+    ///             character_offset: OneIndexed::from_zero_indexed(7)
+    ///         },
+    ///         &source,
+    ///         PositionEncoding::Utf16,
+    ///     ),
+    ///     TextSize::new(20)
+    ///  );
+    ///
     ///
     /// // Offset past the end of the second line
-    /// assert_eq!(index.offset(OneIndexed::from_zero_indexed(1), OneIndexed::from_zero_indexed(10), source), TextSize::new(19));
+    /// assert_eq!(
+    ///     index.offset(
+    ///         SourceLocation {
+    ///             line: OneIndexed::from_zero_indexed(1),
+    ///             character_offset: OneIndexed::from_zero_indexed(10)
+    ///         },
+    ///         &source,
+    ///         PositionEncoding::Utf32,
+    ///     ),
+    ///     TextSize::new(22)
+    ///  );
     ///
     /// // Offset past the end of the file
-    /// assert_eq!(index.offset(OneIndexed::from_zero_indexed(3), OneIndexed::from_zero_indexed(0), source), TextSize::new(24));
+    /// assert_eq!(
+    ///     index.offset(
+    ///         SourceLocation {
+    ///             line: OneIndexed::from_zero_indexed(3),
+    ///             character_offset: OneIndexed::from_zero_indexed(0)
+    ///         },
+    ///         &source,
+    ///         PositionEncoding::Utf32,
+    ///     ),
+    ///     TextSize::new(27)
+    ///  );
     /// ```
-    ///
-    pub fn offset(&self, line: OneIndexed, column: OneIndexed, contents: &str) -> TextSize {
+    pub fn offset(
+        &self,
+        position: SourceLocation,
+        text: &str,
+        position_encoding: PositionEncoding,
+    ) -> TextSize {
         // If start-of-line position after last line
-        if line.to_zero_indexed() > self.line_starts().len() {
-            return contents.text_len();
+        if position.line.to_zero_indexed() > self.line_starts().len() {
+            return text.text_len();
         }
 
-        let line_range = self.line_range(line, contents);
+        let line_range = self.line_range(position.line, text);
 
-        match self.kind() {
-            IndexKind::Ascii => {
-                line_range.start()
-                    + TextSize::try_from(column.to_zero_indexed())
-                        .unwrap_or(line_range.len())
-                        .clamp(TextSize::new(0), line_range.len())
-            }
-            IndexKind::Utf8 => {
-                let rest = &contents[line_range];
-                let column_offset: TextSize = rest
+        let character_offset = if self.is_ascii() {
+            TextSize::try_from(position.character_offset.to_zero_indexed()).unwrap()
+        } else {
+            let line = &text[line_range];
+
+            match position_encoding {
+                PositionEncoding::Utf8 => {
+                    TextSize::try_from(position.character_offset.to_zero_indexed()).unwrap()
+                }
+                PositionEncoding::Utf16 => {
+                    let mut utf8_code_unit_offset = TextSize::new(0);
+
+                    let mut i = 0;
+
+                    for c in line.chars() {
+                        if i >= position.character_offset.to_zero_indexed() {
+                            break;
+                        }
+
+                        // Count characters encoded as two 16 bit words as 2 characters.
+                        utf8_code_unit_offset += c.text_len();
+                        i += c.len_utf16();
+                    }
+
+                    utf8_code_unit_offset
+                }
+                PositionEncoding::Utf32 => line
                     .chars()
-                    .take(column.to_zero_indexed())
+                    .take(position.character_offset.to_zero_indexed())
                     .map(ruff_text_size::TextLen::text_len)
-                    .sum();
-                line_range.start() + column_offset
+                    .sum(),
             }
-        }
+        };
+
+        line_range.start() + character_offset.clamp(TextSize::new(0), line_range.len())
     }
 
     /// Returns the [byte offsets](TextSize) for every line
@@ -430,12 +656,26 @@ impl FromStr for OneIndexed {
     }
 }
 
+#[derive(Default, Copy, Clone, Debug)]
+pub enum PositionEncoding {
+    /// Character offsets count the number of bytes from the start of the line.
+    #[default]
+    Utf8,
+
+    /// Character offsets count the number of UTF-16 code units from the start of the line.
+    Utf16,
+
+    /// Character offsets count the number of UTF-32 code points units (the same as number of characters in Rust)
+    /// from the start of the line.
+    Utf32,
+}
+
 #[cfg(test)]
 mod tests {
     use ruff_text_size::TextSize;
 
     use crate::line_index::LineIndex;
-    use crate::{OneIndexed, SourceLocation};
+    use crate::{LineColumn, OneIndexed};
 
     #[test]
     fn ascii_index() {
@@ -466,30 +706,30 @@ mod tests {
         let index = LineIndex::from_source_text(contents);
 
         // First row.
-        let loc = index.source_location(TextSize::from(2), contents);
+        let loc = index.line_column(TextSize::from(2), contents);
         assert_eq!(
             loc,
-            SourceLocation {
-                row: OneIndexed::from_zero_indexed(0),
+            LineColumn {
+                line: OneIndexed::from_zero_indexed(0),
                 column: OneIndexed::from_zero_indexed(2)
             }
         );
 
         // Second row.
-        let loc = index.source_location(TextSize::from(6), contents);
+        let loc = index.line_column(TextSize::from(6), contents);
         assert_eq!(
             loc,
-            SourceLocation {
-                row: OneIndexed::from_zero_indexed(1),
+            LineColumn {
+                line: OneIndexed::from_zero_indexed(1),
                 column: OneIndexed::from_zero_indexed(0)
             }
         );
 
-        let loc = index.source_location(TextSize::from(11), contents);
+        let loc = index.line_column(TextSize::from(11), contents);
         assert_eq!(
             loc,
-            SourceLocation {
-                row: OneIndexed::from_zero_indexed(1),
+            LineColumn {
+                line: OneIndexed::from_zero_indexed(1),
                 column: OneIndexed::from_zero_indexed(5)
             }
         );
@@ -502,23 +742,23 @@ mod tests {
         assert_eq!(index.line_starts(), &[TextSize::from(0), TextSize::from(6)]);
 
         assert_eq!(
-            index.source_location(TextSize::from(4), contents),
-            SourceLocation {
-                row: OneIndexed::from_zero_indexed(0),
+            index.line_column(TextSize::from(4), contents),
+            LineColumn {
+                line: OneIndexed::from_zero_indexed(0),
                 column: OneIndexed::from_zero_indexed(4)
             }
         );
         assert_eq!(
-            index.source_location(TextSize::from(6), contents),
-            SourceLocation {
-                row: OneIndexed::from_zero_indexed(1),
+            index.line_column(TextSize::from(6), contents),
+            LineColumn {
+                line: OneIndexed::from_zero_indexed(1),
                 column: OneIndexed::from_zero_indexed(0)
             }
         );
         assert_eq!(
-            index.source_location(TextSize::from(7), contents),
-            SourceLocation {
-                row: OneIndexed::from_zero_indexed(1),
+            index.line_column(TextSize::from(7), contents),
+            LineColumn {
+                line: OneIndexed::from_zero_indexed(1),
                 column: OneIndexed::from_zero_indexed(1)
             }
         );
@@ -531,23 +771,23 @@ mod tests {
         assert_eq!(index.line_starts(), &[TextSize::from(0), TextSize::from(7)]);
 
         assert_eq!(
-            index.source_location(TextSize::from(4), contents),
-            SourceLocation {
-                row: OneIndexed::from_zero_indexed(0),
+            index.line_column(TextSize::from(4), contents),
+            LineColumn {
+                line: OneIndexed::from_zero_indexed(0),
                 column: OneIndexed::from_zero_indexed(4)
             }
         );
         assert_eq!(
-            index.source_location(TextSize::from(7), contents),
-            SourceLocation {
-                row: OneIndexed::from_zero_indexed(1),
+            index.line_column(TextSize::from(7), contents),
+            LineColumn {
+                line: OneIndexed::from_zero_indexed(1),
                 column: OneIndexed::from_zero_indexed(0)
             }
         );
         assert_eq!(
-            index.source_location(TextSize::from(8), contents),
-            SourceLocation {
-                row: OneIndexed::from_zero_indexed(1),
+            index.line_column(TextSize::from(8), contents),
+            LineColumn {
+                line: OneIndexed::from_zero_indexed(1),
                 column: OneIndexed::from_zero_indexed(1)
             }
         );
@@ -598,23 +838,23 @@ mod tests {
 
         // Second '
         assert_eq!(
-            index.source_location(TextSize::from(9), contents),
-            SourceLocation {
-                row: OneIndexed::from_zero_indexed(0),
+            index.line_column(TextSize::from(9), contents),
+            LineColumn {
+                line: OneIndexed::from_zero_indexed(0),
                 column: OneIndexed::from_zero_indexed(6)
             }
         );
         assert_eq!(
-            index.source_location(TextSize::from(11), contents),
-            SourceLocation {
-                row: OneIndexed::from_zero_indexed(1),
+            index.line_column(TextSize::from(11), contents),
+            LineColumn {
+                line: OneIndexed::from_zero_indexed(1),
                 column: OneIndexed::from_zero_indexed(0)
             }
         );
         assert_eq!(
-            index.source_location(TextSize::from(12), contents),
-            SourceLocation {
-                row: OneIndexed::from_zero_indexed(1),
+            index.line_column(TextSize::from(12), contents),
+            LineColumn {
+                line: OneIndexed::from_zero_indexed(1),
                 column: OneIndexed::from_zero_indexed(1)
             }
         );
@@ -632,23 +872,23 @@ mod tests {
 
         // Second '
         assert_eq!(
-            index.source_location(TextSize::from(9), contents),
-            SourceLocation {
-                row: OneIndexed::from_zero_indexed(0),
+            index.line_column(TextSize::from(9), contents),
+            LineColumn {
+                line: OneIndexed::from_zero_indexed(0),
                 column: OneIndexed::from_zero_indexed(6)
             }
         );
         assert_eq!(
-            index.source_location(TextSize::from(12), contents),
-            SourceLocation {
-                row: OneIndexed::from_zero_indexed(1),
+            index.line_column(TextSize::from(12), contents),
+            LineColumn {
+                line: OneIndexed::from_zero_indexed(1),
                 column: OneIndexed::from_zero_indexed(0)
             }
         );
         assert_eq!(
-            index.source_location(TextSize::from(13), contents),
-            SourceLocation {
-                row: OneIndexed::from_zero_indexed(1),
+            index.line_column(TextSize::from(13), contents),
+            LineColumn {
+                line: OneIndexed::from_zero_indexed(1),
                 column: OneIndexed::from_zero_indexed(1)
             }
         );
@@ -664,49 +904,49 @@ mod tests {
         );
 
         // First row.
-        let loc = index.source_location(TextSize::from(0), contents);
+        let loc = index.line_column(TextSize::from(0), contents);
         assert_eq!(
             loc,
-            SourceLocation {
-                row: OneIndexed::from_zero_indexed(0),
+            LineColumn {
+                line: OneIndexed::from_zero_indexed(0),
                 column: OneIndexed::from_zero_indexed(0)
             }
         );
 
-        let loc = index.source_location(TextSize::from(5), contents);
+        let loc = index.line_column(TextSize::from(5), contents);
         assert_eq!(
             loc,
-            SourceLocation {
-                row: OneIndexed::from_zero_indexed(0),
+            LineColumn {
+                line: OneIndexed::from_zero_indexed(0),
                 column: OneIndexed::from_zero_indexed(5)
             }
         );
 
-        let loc = index.source_location(TextSize::from(8), contents);
+        let loc = index.line_column(TextSize::from(8), contents);
         assert_eq!(
             loc,
-            SourceLocation {
-                row: OneIndexed::from_zero_indexed(0),
+            LineColumn {
+                line: OneIndexed::from_zero_indexed(0),
                 column: OneIndexed::from_zero_indexed(6)
             }
         );
 
         // Second row.
-        let loc = index.source_location(TextSize::from(10), contents);
+        let loc = index.line_column(TextSize::from(10), contents);
         assert_eq!(
             loc,
-            SourceLocation {
-                row: OneIndexed::from_zero_indexed(1),
+            LineColumn {
+                line: OneIndexed::from_zero_indexed(1),
                 column: OneIndexed::from_zero_indexed(0)
             }
         );
 
         // One-past-the-end.
-        let loc = index.source_location(TextSize::from(15), contents);
+        let loc = index.line_column(TextSize::from(15), contents);
         assert_eq!(
             loc,
-            SourceLocation {
-                row: OneIndexed::from_zero_indexed(1),
+            LineColumn {
+                line: OneIndexed::from_zero_indexed(1),
                 column: OneIndexed::from_zero_indexed(5)
             }
         );

--- a/crates/ruff_wasm/src/lib.rs
+++ b/crates/ruff_wasm/src/lib.rs
@@ -21,7 +21,7 @@ use ruff_python_formatter::{format_module_ast, pretty_comments, PyFormatContext,
 use ruff_python_index::Indexer;
 use ruff_python_parser::{parse, parse_unchecked, Mode, ParseOptions, Parsed};
 use ruff_python_trivia::CommentRanges;
-use ruff_source_file::SourceLocation;
+use ruff_source_file::{LineColumn, OneIndexed};
 use ruff_text_size::Ranged;
 use ruff_workspace::configuration::Configuration;
 use ruff_workspace::options::{FormatOptions, LintCommonOptions, LintOptions, Options};
@@ -61,8 +61,8 @@ export interface Diagnostic {
 pub struct ExpandedMessage {
     pub code: Option<String>,
     pub message: String,
-    pub start_location: SourceLocation,
-    pub end_location: SourceLocation,
+    pub start_location: Location,
+    pub end_location: Location,
     pub fix: Option<ExpandedFix>,
 }
 
@@ -74,8 +74,8 @@ pub struct ExpandedFix {
 
 #[derive(Serialize, Deserialize, Eq, PartialEq, Debug)]
 struct ExpandedEdit {
-    location: SourceLocation,
-    end_location: SourceLocation,
+    location: Location,
+    end_location: Location,
     content: Option<String>,
 }
 
@@ -214,16 +214,16 @@ impl Workspace {
                 }) => ExpandedMessage {
                     code: Some(kind.rule().noqa_code().to_string()),
                     message: kind.body,
-                    start_location: source_code.source_location(range.start()),
-                    end_location: source_code.source_location(range.end()),
+                    start_location: source_code.line_column(range.start()).into(),
+                    end_location: source_code.line_column(range.end()).into(),
                     fix: fix.map(|fix| ExpandedFix {
                         message: kind.suggestion,
                         edits: fix
                             .edits()
                             .iter()
                             .map(|edit| ExpandedEdit {
-                                location: source_code.source_location(edit.start()),
-                                end_location: source_code.source_location(edit.end()),
+                                location: source_code.line_column(edit.start()).into(),
+                                end_location: source_code.line_column(edit.end()).into(),
                                 content: edit.content().map(ToString::to_string),
                             })
                             .collect(),
@@ -233,8 +233,8 @@ impl Workspace {
                     ExpandedMessage {
                         code: None,
                         message,
-                        start_location: source_code.source_location(range.start()),
-                        end_location: source_code.source_location(range.end()),
+                        start_location: source_code.line_column(range.start()).into(),
+                        end_location: source_code.line_column(range.end()).into(),
                         fix: None,
                     }
                 }
@@ -314,5 +314,20 @@ impl<'a> ParsedModule<'a> {
             self.source_code,
             options,
         )
+    }
+}
+
+#[derive(Serialize, Deserialize, Eq, PartialEq, Debug)]
+pub struct Location {
+    pub row: OneIndexed,
+    pub column: OneIndexed,
+}
+
+impl From<LineColumn> for Location {
+    fn from(value: LineColumn) -> Self {
+        Self {
+            row: value.line,
+            column: value.column,
+        }
     }
 }

--- a/crates/ruff_wasm/tests/api.rs
+++ b/crates/ruff_wasm/tests/api.rs
@@ -3,8 +3,8 @@
 use wasm_bindgen_test::wasm_bindgen_test;
 
 use ruff_linter::registry::Rule;
-use ruff_source_file::{OneIndexed, SourceLocation};
-use ruff_wasm::{ExpandedMessage, Workspace};
+use ruff_source_file::OneIndexed;
+use ruff_wasm::{ExpandedMessage, Location, Workspace};
 
 macro_rules! check {
     ($source:expr, $config:expr, $expected:expr) => {{
@@ -27,11 +27,11 @@ fn empty_config() {
         [ExpandedMessage {
             code: Some(Rule::IfTuple.noqa_code().to_string()),
             message: "If test is a tuple, which is always `True`".to_string(),
-            start_location: SourceLocation {
+            start_location: Location {
                 row: OneIndexed::from_zero_indexed(0),
                 column: OneIndexed::from_zero_indexed(3)
             },
-            end_location: SourceLocation {
+            end_location: Location {
                 row: OneIndexed::from_zero_indexed(0),
                 column: OneIndexed::from_zero_indexed(9)
             },
@@ -48,11 +48,11 @@ fn syntax_error() {
         [ExpandedMessage {
             code: None,
             message: "SyntaxError: Expected an expression".to_string(),
-            start_location: SourceLocation {
+            start_location: Location {
                 row: OneIndexed::from_zero_indexed(0),
                 column: OneIndexed::from_zero_indexed(3)
             },
-            end_location: SourceLocation {
+            end_location: Location {
                 row: OneIndexed::from_zero_indexed(1),
                 column: OneIndexed::from_zero_indexed(0)
             },
@@ -69,11 +69,11 @@ fn unsupported_syntax_error() {
         [ExpandedMessage {
             code: None,
             message: "SyntaxError: Cannot use `match` statement on Python 3.9 (syntax was added in Python 3.10)".to_string(),
-            start_location: SourceLocation {
+            start_location: Location {
                 row: OneIndexed::from_zero_indexed(0),
                 column: OneIndexed::from_zero_indexed(0)
             },
-            end_location: SourceLocation {
+            end_location: Location {
                 row: OneIndexed::from_zero_indexed(0),
                 column: OneIndexed::from_zero_indexed(5)
             },


### PR DESCRIPTION
## Summary

This PR splits `SourceLocation` into `LineColumn` and `SourceLocation` and moves the `TextSize` to LSP position conversion logic into `LineIndex`.

`LineIndex` as it is before this PR had two methods:

* `source_location`: Converts a `TextSize` to a `SourceLocation`
* `offset: `Converts a `SourceLocation` back to a `TextSize`


The problem with the current implementation is that `source_location` trims a leading BOM offset, whereas `offset` doesn't have any custom BOM handling. 
That means, mapping the first character right after a BOM to the old `source_location` would give `row: 0`, `column: 0`, but mapping that position back to an offset would point **before** instead of **after** the BOM. 

This PR fixes this inconsistency by removing the `offset` for the old `SourceLocation` (now `LineColumn)` because the only case where we need to map back a column is in the formatter but the special BOM handling doesn't matter.

However, we don't want to skip the BOM for LSP operations because LSP operations don't return line/column information; instead, they map a position to a line and the `nth` character on that line. 
This is why this PR introduces a new pair of `source_location` and `offset` methods to map between `TextSize` and a `line` and `character_offset` where `character_offset` is an `UTF8`, `UTF16` or `UTF32` offset (bytes, code units, Unicode scalar values). 

The reason I dove into all this is because the playground needs to convert the ranges to UTF16 and I wanted to avoid copying the whole conversion logic a third time (ruff server, red knot server, wasm)

## Test Plan

* Tested the Ruff and VS code extension with unicode content
* Tested that the line numbers in the CLI are correct
* Tested notebooks
* `cargo test`
