### PR TITLE
[red-knot] fix collapsing literal and its negation to object

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/call/union.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/call/union.md
@@ -165,29 +165,39 @@ def _(flag: bool):
 ## Unions with literals and negations
 
 ```py
-from typing import Literal, Union
+from typing import Literal
 from knot_extensions import Not, AlwaysFalsy, static_assert, is_subtype_of, is_assignable_to
 
-static_assert(is_subtype_of(Literal["a", ""], Union[Literal["a", ""], Not[AlwaysFalsy]]))
-static_assert(is_subtype_of(Not[AlwaysFalsy], Union[Literal["", "a"], Not[AlwaysFalsy]]))
-static_assert(is_subtype_of(Literal["a", ""], Union[Not[AlwaysFalsy], Literal["a", ""]]))
-static_assert(is_subtype_of(Not[AlwaysFalsy], Union[Not[AlwaysFalsy], Literal["a", ""]]))
+static_assert(is_subtype_of(Literal["a", ""], Literal["a", ""] | Not[AlwaysFalsy]))
+static_assert(is_subtype_of(Not[AlwaysFalsy], Literal["", "a"] | Not[AlwaysFalsy]))
+static_assert(is_subtype_of(Literal["a", ""], Not[AlwaysFalsy] | Literal["a", ""]))
+static_assert(is_subtype_of(Not[AlwaysFalsy], Not[AlwaysFalsy] | Literal["a", ""]))
 
-static_assert(is_subtype_of(Literal["a", ""], Union[Literal["a", ""], Not[Literal[""]]]))
-static_assert(is_subtype_of(Not[Literal[""]], Union[Literal["a", ""], Not[Literal[""]]]))
-static_assert(is_subtype_of(Literal["a", ""], Union[Not[Literal[""]], Literal["a", ""]]))
-static_assert(is_subtype_of(Not[Literal[""]], Union[Not[Literal[""]], Literal["a", ""]]))
+static_assert(is_subtype_of(Literal["a", ""], Literal["a", ""] | Not[Literal[""]]))
+static_assert(is_subtype_of(Not[Literal[""]], Literal["a", ""] | Not[Literal[""]]))
+static_assert(is_subtype_of(Literal["a", ""], Not[Literal[""]] | Literal["a", ""]))
+static_assert(is_subtype_of(Not[Literal[""]], Not[Literal[""]] | Literal["a", ""]))
 
 def _(
-    a: Union[Literal["a", ""], Not[AlwaysFalsy]],
-    b: Union[Literal["a", ""], Not[Literal[""]]],
-    c: Union[Literal[""], Not[Literal[""]]],
-    d: Union[Not[Literal[""]], Literal[""]],
+    a: Literal["a", ""] | Not[AlwaysFalsy],
+    b: Literal["a", ""] | Not[Literal[""]],
+    c: Literal[""] | Not[Literal[""]],
+    d: Not[Literal[""]] | Literal[""],
+    e: Literal["a"] | Not[Literal["a"]],
+    f: Literal[b"b"] | Not[Literal[b"b"]],
+    g: Not[Literal[b"b"]] | Literal[b"b"],
+    h: Literal[42] | Not[Literal[42]],
+    i: Not[Literal[42]] | Literal[42],
 ):
     reveal_type(a)  # revealed: Literal[""] | ~AlwaysFalsy
     reveal_type(b)  # revealed: object
     reveal_type(c)  # revealed: object
     reveal_type(d)  # revealed: object
+    reveal_type(e)  # revealed: object
+    reveal_type(f)  # revealed: object
+    reveal_type(g)  # revealed: object
+    reveal_type(h)  # revealed: object
+    reveal_type(i)  # revealed: object
 ```
 
 ## Cannot use an argument as both a value and a type form

--- a/crates/red_knot_python_semantic/resources/mdtest/call/union.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/call/union.md
@@ -179,12 +179,15 @@ static_assert(is_subtype_of(Literal["a", ""], Union[Not[Literal[""]], Literal["a
 static_assert(is_subtype_of(Not[Literal[""]], Union[Not[Literal[""]], Literal["a", ""]]))
 
 def _(
-    x: Union[Literal["a", ""], Not[AlwaysFalsy]],
-    y: Union[Literal["a", ""], Not[Literal[""]]],
+    a: Union[Literal["a", ""], Not[AlwaysFalsy]],
+    b: Union[Literal["a", ""], Not[Literal[""]]],
+    c: Union[Literal[""], Not[Literal[""]]],
+    d: Union[Not[Literal[""]], Literal[""]],
 ):
-    reveal_type(x)  # revealed: Literal[""] | ~AlwaysFalsy
-    # TODO should be `object`
-    reveal_type(y)  # revealed: Literal[""] | ~Literal[""]
+    reveal_type(a)  # revealed: Literal[""] | ~AlwaysFalsy
+    reveal_type(b)  # revealed: object
+    reveal_type(c)  # revealed: object
+    reveal_type(d)  # revealed: object
 ```
 
 ## Cannot use an argument as both a value and a type form


### PR DESCRIPTION
## Summary

Another follow-up to the unions-of-large-literals optimization. Restore the behavior that e.g. `Literal[""] | ~Literal[""]` collapses to `object`.

## Test Plan

Added mdtests.
