### PR TITLE
[red-knot] Check for invalid overload usages

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/overloads.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/overloads.md
@@ -317,15 +317,19 @@ At least two `@overload`-decorated definitions must be present.
 from typing import overload
 
 @overload
-def func1(x: int) -> int: ...
+def func(x: int) -> int: ...
 
 # error: [invalid-overload]
-def func1(x: int | str) -> int | str:
+def func(x: int | str) -> int | str:
     return x
+```
+
+```pyi
+from typing import overload
 
 @overload
 # error: [invalid-overload]
-def func2(x: int) -> int: ...
+def func(x: int) -> int: ...
 ```
 
 ### Overload without an implementation

--- a/crates/red_knot_python_semantic/resources/mdtest/overloads.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/overloads.md
@@ -318,6 +318,7 @@ from typing import overload
 
 @overload
 def func1(x: int) -> int: ...
+
 # error: [invalid-overload]
 def func1(x: int | str) -> int | str:
     return x

--- a/crates/red_knot_python_semantic/resources/mdtest/overloads.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/overloads.md
@@ -309,16 +309,22 @@ reveal_type(func(""))  # revealed: Literal[""]
 
 ### At least two overloads
 
+<!-- snapshot-diagnostics -->
+
 At least two `@overload`-decorated definitions must be present.
 
 ```py
 from typing import overload
 
-# TODO: error
 @overload
-def func(x: int) -> int: ...
-def func(x: int | str) -> int | str:
+def func1(x: int) -> int: ...
+# error: [invalid-overload]
+def func1(x: int | str) -> int | str:
     return x
+
+@overload
+# error: [invalid-overload]
+def func2(x: int) -> int: ...
 ```
 
 ### Overload without an implementation

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_At_least_two_overloads.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_At_least_two_overloads.snap
@@ -16,13 +16,14 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/overloads.md
  2 | 
  3 | @overload
  4 | def func1(x: int) -> int: ...
- 5 | # error: [invalid-overload]
- 6 | def func1(x: int | str) -> int | str:
- 7 |     return x
- 8 | 
- 9 | @overload
-10 | # error: [invalid-overload]
-11 | def func2(x: int) -> int: ...
+ 5 | 
+ 6 | # error: [invalid-overload]
+ 7 | def func1(x: int | str) -> int | str:
+ 8 |     return x
+ 9 | 
+10 | @overload
+11 | # error: [invalid-overload]
+12 | def func2(x: int) -> int: ...
 ```
 
 # Diagnostics
@@ -34,21 +35,22 @@ error: lint:invalid-overload: Function `func1` requires at least two overloads
 3 | @overload
 4 | def func1(x: int) -> int: ...
   |     ----- Only one overload defined here
-5 | # error: [invalid-overload]
-6 | def func1(x: int | str) -> int | str:
+5 |
+6 | # error: [invalid-overload]
+7 | def func1(x: int | str) -> int | str:
   |     ^^^^^
-7 |     return x
+8 |     return x
   |
 
 ```
 
 ```
 error: lint:invalid-overload: Function `func2` requires at least two overloads
-  --> /src/mdtest_snippet.py:11:5
+  --> /src/mdtest_snippet.py:12:5
    |
- 9 | @overload
-10 | # error: [invalid-overload]
-11 | def func2(x: int) -> int: ...
+10 | @overload
+11 | # error: [invalid-overload]
+12 | def func2(x: int) -> int: ...
    |     -----
    |     |
    |     Only one overload defined here

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_At_least_two_overloads.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_At_least_two_overloads.snap
@@ -12,48 +12,54 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/overloads.md
 ## mdtest_snippet.py
 
 ```
- 1 | from typing import overload
- 2 | 
- 3 | @overload
- 4 | def func1(x: int) -> int: ...
- 5 | 
- 6 | # error: [invalid-overload]
- 7 | def func1(x: int | str) -> int | str:
- 8 |     return x
- 9 | 
-10 | @overload
-11 | # error: [invalid-overload]
-12 | def func2(x: int) -> int: ...
+1 | from typing import overload
+2 | 
+3 | @overload
+4 | def func(x: int) -> int: ...
+5 | 
+6 | # error: [invalid-overload]
+7 | def func(x: int | str) -> int | str:
+8 |     return x
+```
+
+## mdtest_snippet.pyi
+
+```
+1 | from typing import overload
+2 | 
+3 | @overload
+4 | # error: [invalid-overload]
+5 | def func(x: int) -> int: ...
 ```
 
 # Diagnostics
 
 ```
-error: lint:invalid-overload: Overloaded function `func1` requires at least two overloads
+error: lint:invalid-overload: Overloaded function `func` requires at least two overloads
  --> /src/mdtest_snippet.py:4:5
   |
 3 | @overload
-4 | def func1(x: int) -> int: ...
-  |     ----- Only one overload defined here
+4 | def func(x: int) -> int: ...
+  |     ---- Only one overload defined here
 5 |
 6 | # error: [invalid-overload]
-7 | def func1(x: int | str) -> int | str:
-  |     ^^^^^
+7 | def func(x: int | str) -> int | str:
+  |     ^^^^
 8 |     return x
   |
 
 ```
 
 ```
-error: lint:invalid-overload: Overloaded function `func2` requires at least two overloads
-  --> /src/mdtest_snippet.py:12:5
-   |
-10 | @overload
-11 | # error: [invalid-overload]
-12 | def func2(x: int) -> int: ...
-   |     -----
-   |     |
-   |     Only one overload defined here
-   |
+error: lint:invalid-overload: Overloaded function `func` requires at least two overloads
+ --> /src/mdtest_snippet.pyi:5:5
+  |
+3 | @overload
+4 | # error: [invalid-overload]
+5 | def func(x: int) -> int: ...
+  |     ----
+  |     |
+  |     Only one overload defined here
+  |
 
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_At_least_two_overloads.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_At_least_two_overloads.snap
@@ -36,7 +36,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/overloads.md
 
 ```
 error: lint:invalid-overload: Overloaded function `func` requires at least two overloads
- --> /src/mdtest_snippet.py:4:5
+ --> src/mdtest_snippet.py:4:5
   |
 3 | @overload
 4 | def func(x: int) -> int: ...
@@ -52,7 +52,7 @@ error: lint:invalid-overload: Overloaded function `func` requires at least two o
 
 ```
 error: lint:invalid-overload: Overloaded function `func` requires at least two overloads
- --> /src/mdtest_snippet.pyi:5:5
+ --> src/mdtest_snippet.pyi:5:5
   |
 3 | @overload
 4 | # error: [invalid-overload]

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_At_least_two_overloads.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_At_least_two_overloads.snap
@@ -1,0 +1,57 @@
+---
+source: crates/red_knot_test/src/lib.rs
+expression: snapshot
+---
+---
+mdtest name: overloads.md - Overloads - Invalid - At least two overloads
+mdtest path: crates/red_knot_python_semantic/resources/mdtest/overloads.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+ 1 | from typing import overload
+ 2 | 
+ 3 | @overload
+ 4 | def func1(x: int) -> int: ...
+ 5 | # error: [invalid-overload]
+ 6 | def func1(x: int | str) -> int | str:
+ 7 |     return x
+ 8 | 
+ 9 | @overload
+10 | # error: [invalid-overload]
+11 | def func2(x: int) -> int: ...
+```
+
+# Diagnostics
+
+```
+error: lint:invalid-overload: Function `func1` requires at least two overloads
+ --> /src/mdtest_snippet.py:4:5
+  |
+3 | @overload
+4 | def func1(x: int) -> int: ...
+  |     ----- Only one overload defined here
+5 | # error: [invalid-overload]
+6 | def func1(x: int | str) -> int | str:
+  |     ^^^^^
+7 |     return x
+  |
+
+```
+
+```
+error: lint:invalid-overload: Function `func2` requires at least two overloads
+  --> /src/mdtest_snippet.py:11:5
+   |
+ 9 | @overload
+10 | # error: [invalid-overload]
+11 | def func2(x: int) -> int: ...
+   |     -----
+   |     |
+   |     Only one overload defined here
+   |
+
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_At_least_two_overloads.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_At_least_two_overloads.snap
@@ -29,7 +29,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/overloads.md
 # Diagnostics
 
 ```
-error: lint:invalid-overload: Function `func1` requires at least two overloads
+error: lint:invalid-overload: Overloaded function `func1` requires at least two overloads
  --> /src/mdtest_snippet.py:4:5
   |
 3 | @overload
@@ -45,7 +45,7 @@ error: lint:invalid-overload: Function `func1` requires at least two overloads
 ```
 
 ```
-error: lint:invalid-overload: Function `func2` requires at least two overloads
+error: lint:invalid-overload: Overloaded function `func2` requires at least two overloads
   --> /src/mdtest_snippet.py:12:5
    |
 10 | @overload

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -6396,6 +6396,10 @@ impl<'db> FunctionType<'db> {
         Type::BoundMethod(BoundMethodType::new(db, self, self_instance))
     }
 
+    pub(crate) fn node(self, db: &'db dyn Db) -> &'db ast::StmtFunctionDef {
+        self.body_scope(db).node(db).expect_function()
+    }
+
     /// Returns the [`FileRange`] of the function's name.
     pub fn focus_range(self, db: &dyn Db) -> FileRange {
         FileRange::new(

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -6396,8 +6396,22 @@ impl<'db> FunctionType<'db> {
         Type::BoundMethod(BoundMethodType::new(db, self, self_instance))
     }
 
-    pub(crate) fn node(self, db: &'db dyn Db) -> &'db ast::StmtFunctionDef {
-        self.body_scope(db).node(db).expect_function()
+    /// Returns the AST node for this function.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the file passed in does not match the one where this function is defined.
+    pub(crate) fn node(self, db: &'db dyn Db, file: File) -> &'db ast::StmtFunctionDef {
+        let body_scope = self.body_scope(db);
+
+        assert_eq!(
+            file,
+            body_scope.file(db),
+            "FunctionType::node() must be called with the same file as the one where \
+            the function is defined."
+        );
+
+        body_scope.node(db).expect_function()
     }
 
     /// Returns the [`FileRange`] of the function's name.
@@ -6415,6 +6429,13 @@ impl<'db> FunctionType<'db> {
         )
     }
 
+    /// Returns the [`Definition`] of this function.
+    ///
+    /// ## Warning
+    ///
+    /// This uses the semantic index to find the definition of the function. This means that if the
+    /// calling query is not in the same file as this function is defined in, then this will create
+    /// a cross-module dependency which might lead to cache invalidation.
     pub(crate) fn definition(self, db: &'db dyn Db) -> Definition<'db> {
         let body_scope = self.body_scope(db);
         let index = semantic_index(db, body_scope.file(db));

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -6397,14 +6397,10 @@ impl<'db> FunctionType<'db> {
     }
 
     /// Returns the AST node for this function.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the file passed in does not match the one where this function is defined.
     pub(crate) fn node(self, db: &'db dyn Db, file: File) -> &'db ast::StmtFunctionDef {
         let body_scope = self.body_scope(db);
 
-        assert_eq!(
+        debug_assert_eq!(
             file,
             body_scope.file(db),
             "FunctionType::node() must be called with the same file as the one where \
@@ -6435,7 +6431,8 @@ impl<'db> FunctionType<'db> {
     ///
     /// This uses the semantic index to find the definition of the function. This means that if the
     /// calling query is not in the same file as this function is defined in, then this will create
-    /// a cross-module dependency which might lead to cache invalidation.
+    /// a cross-module dependency directly on the full AST which will lead to cache
+    /// over-invalidation.
     pub(crate) fn definition(self, db: &'db dyn Db) -> Definition<'db> {
         let body_scope = self.body_scope(db);
         let index = semantic_index(db, body_scope.file(db));

--- a/crates/red_knot_python_semantic/src/types/diagnostic.rs
+++ b/crates/red_knot_python_semantic/src/types/diagnostic.rs
@@ -37,6 +37,7 @@ pub(crate) fn register_lints(registry: &mut LintRegistryBuilder) {
     registry.register_lint(&INVALID_EXCEPTION_CAUGHT);
     registry.register_lint(&INVALID_LEGACY_TYPE_VARIABLE);
     registry.register_lint(&INVALID_METACLASS);
+    registry.register_lint(&INVALID_OVERLOAD);
     registry.register_lint(&INVALID_PARAMETER_DEFAULT);
     registry.register_lint(&INVALID_PROTOCOL);
     registry.register_lint(&INVALID_RAISE);
@@ -442,6 +443,49 @@ declare_lint! {
     /// - [Python documentation: Metaclasses](https://docs.python.org/3/reference/datamodel.html#metaclasses)
     pub(crate) static INVALID_METACLASS = {
         summary: "detects invalid `metaclass=` arguments",
+        status: LintStatus::preview("1.0.0"),
+        default_level: Level::Error,
+    }
+}
+
+declare_lint! {
+    /// ## What it does
+    /// Checks for various invalid `@overload` usages.
+    ///
+    /// ## Why is this bad?
+    /// The `@overload` decorator is used to define functions and methods that accepts different
+    /// combinations of arguments and return different types based on the arguments passed. This is
+    /// mainly beneficial for type checkers. But, if the `@overload` usage is invalid, the type
+    /// checker may not be able to provide correct type information.
+    ///
+    /// ## Example
+    ///
+    /// Defining only one overload:
+    ///
+    /// ```py
+    /// from typing import overload
+    ///
+    /// @overload
+    /// def foo(x: int) -> int: ...
+    /// def foo(x: int | None) -> int | None:
+    ///     return x
+    /// ```
+    ///
+    /// Or, not providing an implementation for the overloaded definition:
+    ///
+    /// ```py
+    /// from typing import overload
+    ///
+    /// @overload
+    /// def foo() -> None: ...
+    /// @overload
+    /// def foo(x: int) -> int: ...
+    /// ```
+    ///
+    /// ## References
+    /// - [Python documentation: `@overload`](https://docs.python.org/3/library/typing.html#typing.overload)
+    pub(crate) static INVALID_OVERLOAD = {
+        summary: "detects invalid `@overload` usages",
         status: LintStatus::preview("1.0.0"),
         default_level: Level::Error,
     }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1032,7 +1032,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 continue;
             };
 
-            if overloaded.overloads.len() < 2 {
+            if let [single_overload] = overloaded.overloads.as_slice() {
                 let function_node = function.node(self.db(), self.file());
                 if let Some(builder) = self
                     .context
@@ -1042,13 +1042,11 @@ impl<'db> TypeInferenceBuilder<'db> {
                         "Overloaded function `{}` requires at least two overloads",
                         &function_node.name
                     ));
-                    if let Some(first_overload) = overloaded.overloads.first() {
-                        diagnostic.annotate(
-                            self.context
-                                .secondary(first_overload.focus_range(self.db()))
-                                .message(format_args!("Only one overload defined here")),
-                        );
-                    }
+                    diagnostic.annotate(
+                        self.context
+                            .secondary(single_overload.focus_range(self.db()))
+                            .message(format_args!("Only one overload defined here")),
+                    );
                 }
             }
         }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -545,6 +545,8 @@ pub(super) struct TypeInferenceBuilder<'db> {
     /// def foo(x: int) -> int:
     ///     return x
     /// ```
+    ///
+    /// [`check_overloaded_functions`]: TypeInferenceBuilder::check_overloaded_functions
     called_functions: FxHashSet<FunctionType<'db>>,
 
     /// The deferred state of inferring types of certain expressions within the region.

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1020,6 +1020,12 @@ impl<'db> TypeInferenceBuilder<'db> {
             if let Symbol::Type(Type::FunctionLiteral(function), Boundness::Bound) =
                 symbol_from_bindings(self.db(), use_def.public_bindings(symbol))
             {
+                if function.file(self.db()) != self.file() {
+                    // If the function is not in this file, we don't need to check it.
+                    // https://github.com/astral-sh/ruff/pull/17609#issuecomment-2839445740
+                    continue;
+                }
+
                 // Extend the functions that we need to check with the publicly visible overloaded
                 // function. This is always going to be either the implementation or the last
                 // overload if the implementation doesn't exists.

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -418,7 +418,7 @@ impl<'db> TypeInference<'db> {
             .copied()
             .or(self.cycle_fallback_type)
             .expect(
-                "definition should belong to this TypeInference region and
+                "definition should belong to this TypeInference region and \
                 TypeInferenceBuilder should have inferred a type for it",
             )
     }
@@ -430,7 +430,7 @@ impl<'db> TypeInference<'db> {
             .copied()
             .or(self.cycle_fallback_type.map(Into::into))
             .expect(
-                "definition should belong to this TypeInference region and
+                "definition should belong to this TypeInference region and \
                 TypeInferenceBuilder should have inferred a type for it",
             )
     }
@@ -1032,6 +1032,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 continue;
             };
 
+            // Check that the overloaded function has at least two overloads
             if let [single_overload] = overloaded.overloads.as_slice() {
                 let function_node = function.node(self.db(), self.file());
                 if let Some(builder) = self

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1039,7 +1039,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                     .report_lint(&INVALID_OVERLOAD, &function_node.name)
                 {
                     let mut diagnostic = builder.into_diagnostic(format_args!(
-                        "Function `{}` requires at least two overloads",
+                        "Overloaded function `{}` requires at least two overloads",
                         &function_node.name
                     ));
                     if let Some(first_overload) = overloaded.overloads.first() {

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -4404,7 +4404,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             // in the same file as the one we're currently inferring the types for. This is because
             // the `definition` method accesses the semantic index, which could create a
             // cross-module AST dependency.
-            if function.body_scope(self.db()).file(self.db()) == self.file()
+            if function.file(self.db()) == self.file()
                 && function.definition(self.db()).scope(self.db()) == self.scope()
             {
                 self.called_functions.insert(function);

--- a/knot.schema.json
+++ b/knot.schema.json
@@ -470,6 +470,16 @@
             }
           ]
         },
+        "invalid-overload": {
+          "title": "detects invalid `@overload` usages",
+          "description": "## What it does\nChecks for various invalid `@overload` usages.\n\n## Why is this bad?\nThe `@overload` decorator is used to define functions and methods that accepts different\ncombinations of arguments and return different types based on the arguments passed. This is\nmainly beneficial for type checkers. But, if the `@overload` usage is invalid, the type\nchecker may not be able to provide correct type information.\n\n## Example\n\nDefining only one overload:\n\n```py\nfrom typing import overload\n\n@overload\ndef foo(x: int) -> int: ...\ndef foo(x: int | None) -> int | None:\n    return x\n```\n\nOr, not providing an implementation for the overloaded definition:\n\n```py\nfrom typing import overload\n\n@overload\ndef foo() -> None: ...\n@overload\ndef foo(x: int) -> int: ...\n```\n\n## References\n- [Python documentation: `@overload`](https://docs.python.org/3/library/typing.html#typing.overload)",
+          "default": "error",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Level"
+            }
+          ]
+        },
         "invalid-parameter-default": {
           "title": "detects default values that can't be assigned to the parameter's annotated type",
           "description": "## What it does\nChecks for default values that can't be assigned to the parameter's annotated type.\n\n## Why is this bad?\nTODO #14889",


### PR DESCRIPTION
## Summary

Part of #15383, this PR adds the core infrastructure to check for invalid overloads and adds a diagnostic to raise if there are < 2 overloads for a given definition.

### Design notes

The requirements to check the overloads are:
* Requires `FunctionType` which has the `to_overloaded` method
* The `FunctionType` **should** be for the function that is either the implementation or the last overload if the implementation doesn't exists
* Avoid checking any `FunctionType` that are part of an overload chain
* Consider visibility constraints

This required a couple of iteration to make sure all of the above requirements are fulfilled.

#### 1. Use a set to deduplicate

The logic would first collect all the `FunctionType` that are part of the overload chain except for the implementation or the last overload if the implementation doesn't exists. Then, when iterating over all the function declarations within the scope, we'd avoid checking these functions. But, this approach would fail to consider visibility constraints as certain overloads _can_ be behind a version check. Those aren't part of the overload chain but those aren't a separate overload chain either.

<details><summary>Implementation:</summary>
<p>

```rs
fn check_overloaded_functions(&mut self) {
    let function_definitions = || {
        self.types
            .declarations
            .iter()
            .filter_map(|(definition, ty)| {
                // Filter out function literals that result from anything other than a function
                // definition e.g., imports.
                if let DefinitionKind::Function(function) = definition.kind(self.db()) {
                    ty.inner_type()
                        .into_function_literal()
                        .map(|ty| (ty, definition.symbol(self.db()), function.node()))
                } else {
                    None
                }
            })
    };

    // A set of all the functions that are part of an overloaded function definition except for
    // the implementation function and the last overload in case the implementation doesn't
    // exists. This allows us to collect all the function definitions that needs to be skipped
    // when checking for invalid overload usages.
    let mut overloads: HashSet<FunctionType<'db>> = HashSet::default();

    for (function, _) in function_definitions() {
        let Some(overloaded) = function.to_overloaded(self.db()) else {
            continue;
        };
        if overloaded.implementation.is_some() {
            overloads.extend(overloaded.overloads.iter().copied());
        } else if let Some((_, previous_overloads)) = overloaded.overloads.split_last() {
            overloads.extend(previous_overloads.iter().copied());
        }
    }

    for (function, function_node) in function_definitions() {
        let Some(overloaded) = function.to_overloaded(self.db()) else {
            continue;
        };
        if overloads.contains(&function) {
            continue;
        }

        // At this point, the `function` variable is either the implementation function or the
        // last overloaded function if the implementation doesn't exists.

        if overloaded.overloads.len() < 2 {
            if let Some(builder) = self
                .context
                .report_lint(&INVALID_OVERLOAD, &function_node.name)
            {
                let mut diagnostic = builder.into_diagnostic(format_args!(
                    "Function `{}` requires at least two overloads",
                    &function_node.name
                ));
                if let Some(first_overload) = overloaded.overloads.first() {
                    diagnostic.annotate(
                        self.context
                            .secondary(first_overload.focus_range(self.db()))
                            .message(format_args!("Only one overload defined here")),
                    );
                }
            }
        }
    }
 }
```

</p>
</details> 

#### 2. Define a `predecessor` query

The `predecessor` query would return the previous `FunctionType` for the given `FunctionType` i.e., the current logic would be extracted to be a query instead. This could then be used to make sure that we're checking the entire overload chain once. The way this would've been implemented is to have a `to_overloaded` implementation which would take the root of the overload chain instead of the leaf. But, this would require updates to the use-def map to somehow be able to return the _following_ functions for a given definition.

#### 3. Create a successor link

This is what Pyrefly uses, we'd create a forward link between two functions that are involved in an overload chain. This means that for a given function, we can get the successor function. This could be used to find the _leaf_ of the overload chain which can then be used with the `to_overloaded` method to get the entire overload chain. But, this would also require updating the use-def map to be able to "see" the _following_ function.

### Implementation 

This leads us to the final implementation that this PR implements which is to consider the overloaded functions using:
* Collect all the **function symbols** that are defined **and** called within the same file. This could potentially be an overloaded function
* Use the public bindings to get the leaf of the overload chain and use that to get the entire overload chain via `to_overloaded` and perform the check

This has a limitation that in case a function redefines an overload, then that overload will not be checked. For example:

```py
from typing import overload

@overload
def f() -> None: ...
@overload
def f(x: int) -> int: ...

# The above overload will not be checked as the below function with the same name
# shadows it

def f(*args: int) -> int: ...
```

## Test Plan

Update existing mdtest and add snapshot diagnostics.
