### PR TITLE
Add Semantic Error Test for LateFutureImport

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/syntax_errors/late_future_import.py
+++ b/crates/ruff_linter/resources/test/fixtures/syntax_errors/late_future_import.py
@@ -1,0 +1,2 @@
+import random
+from __future__ import annotations  # Error; not at top of file

--- a/crates/ruff_linter/src/linter.rs
+++ b/crates/ruff_linter/src/linter.rs
@@ -1061,6 +1061,7 @@ mod tests {
         Ok(())
     }
 
+    #[test_case(Rule::LateFutureImport, Path::new("late_future_import.py"))]
     #[test_case(Rule::YieldOutsideFunction, Path::new("yield_scope.py"))]
     #[test_case(Rule::ReturnOutsideFunction, Path::new("return_outside_function.py"))]
     fn test_syntax_errors(rule: Rule, path: &Path) -> Result<()> {

--- a/crates/ruff_linter/src/snapshots/ruff_linter__linter__tests__late_future_import.py.snap
+++ b/crates/ruff_linter/src/snapshots/ruff_linter__linter__tests__late_future_import.py.snap
@@ -1,0 +1,9 @@
+---
+source: crates/ruff_linter/src/linter.rs
+---
+resources/test/fixtures/syntax_errors/late_future_import.py:2:1: F404 `from __future__` imports must occur at the beginning of the file
+  |
+1 | import random
+2 | from __future__ import annotations  # Error; not at top of file
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ F404
+  |


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->
Adresses a question in #17526.

## Summary
Adds a syntax error test for `__future__` import not at top of file. 

## Question: 
Is this a redundant with https://github.com/astral-sh/ruff/blob/8d2c79276d167fcfcf9143a2bc1b328bb9d0f876/crates/ruff_linter/resources/test/fixtures/pyflakes/F404_0.py#L1-L8 and https://github.com/astral-sh/ruff/blob/8d2c79276d167fcfcf9143a2bc1b328bb9d0f876/crates/ruff_linter/resources/test/fixtures/pyflakes/F404_1.py#L1-L5

which test pyflake `F404`?
<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan
This is a test
<!-- How was it tested? -->
