### PR TITLE
[red-knot] change TypeVarInstance to be interned, not tracked

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -5230,11 +5230,7 @@ impl<'db> InvalidTypeExpression<'db> {
 /// typevar represents as an annotation: that is, an unknown set of objects, constrained by the
 /// upper-bound/constraints on this type var, defaulting to the default type of this type var when
 /// not otherwise bound to a type.
-///
-/// This must be a tracked struct, not an interned one, because typevar equivalence is by identity,
-/// not by value. Two typevars that have the same name, bound/constraints, and default, are still
-/// different typevars: if used in the same scope, they may be bound to different types.
-#[salsa::tracked(debug)]
+#[salsa::interned(debug)]
 pub struct TypeVarInstance<'db> {
     /// The name of this TypeVar (e.g. `T`)
     #[return_ref]


### PR DESCRIPTION
## Summary

Tracked structs have some issues with fixpoint iteration in Salsa, and there's not actually any need for this to be tracked, it should be interned like most of our type structs.

The removed comment was probably never correct (in that we could have disambiguated sufficiently), and is definitely not relevant now that `TypeVarInstance` also holds its `Definition`.

## Test Plan

Existing tests.
