### PR TITLE
[red-knot] Create generic context for generic classes lazily

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/mro.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/mro.md
@@ -191,7 +191,7 @@ reveal_type(AA.__mro__)  # revealed: tuple[Literal[AA], Literal[Z], Unknown, Lit
 
 ## `__bases__` includes a `Union`
 
-We don't support union types in a class's bases; a base must resolve to a single `ClassLiteralType`.
+We don't support union types in a class's bases; a base must resolve to a single `ClassType`.
 If we find a union type in a class's bases, we infer the class's `__mro__` as being
 `[<class>, Unknown, object]`, the same as for MROs that cause errors at runtime.
 

--- a/crates/red_knot_python_semantic/resources/mdtest/mro.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/mro.md
@@ -191,8 +191,8 @@ reveal_type(AA.__mro__)  # revealed: tuple[Literal[AA], Literal[Z], Unknown, Lit
 
 ## `__bases__` includes a `Union`
 
-We don't support union types in a class's bases; a base must resolve to a single `ClassType`.
-If we find a union type in a class's bases, we infer the class's `__mro__` as being
+We don't support union types in a class's bases; a base must resolve to a single `ClassType`. If we
+find a union type in a class's bases, we infer the class's `__mro__` as being
 `[<class>, Unknown, object]`, the same as for MROs that cause errors at runtime.
 
 ```py

--- a/crates/red_knot_python_semantic/src/types/class_base.rs
+++ b/crates/red_knot_python_semantic/src/types/class_base.rs
@@ -62,7 +62,7 @@ impl<'db> ClassBase<'db> {
     pub(super) fn object(db: &'db dyn Db) -> Self {
         KnownClass::Object
             .to_class_literal(db)
-            .into_class_type()
+            .into_class_type(db)
             .map_or(Self::unknown(), Self::Class)
     }
 

--- a/crates/red_knot_python_semantic/src/types/diagnostic.rs
+++ b/crates/red_knot_python_semantic/src/types/diagnostic.rs
@@ -1,5 +1,5 @@
 use super::context::InferContext;
-use super::ClassLiteralType;
+use super::ClassLiteral;
 use crate::declare_lint;
 use crate::lint::{Level, LintRegistryBuilder, LintStatus};
 use crate::suppression::FileSuppressionId;
@@ -1321,7 +1321,7 @@ pub(crate) fn report_invalid_arguments_to_annotated(
 pub(crate) fn report_bad_argument_to_get_protocol_members(
     context: &InferContext,
     call: &ast::ExprCall,
-    class: ClassLiteralType,
+    class: ClassLiteral,
 ) {
     let Some(builder) = context.report_lint(&INVALID_ARGUMENT_TYPE, call) else {
         return;

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -6,7 +6,7 @@ use ruff_db::display::FormatterJoinExtension;
 use ruff_python_ast::str::{Quote, TripleQuotes};
 use ruff_python_literal::escape::AsciiEscape;
 
-use crate::types::class::{ClassType, GenericAlias, GenericClass};
+use crate::types::class::{ClassLiteral, ClassType, GenericAlias};
 use crate::types::generics::{GenericContext, Specialization};
 use crate::types::signatures::{Parameter, Parameters, Signature};
 use crate::types::{
@@ -76,7 +76,7 @@ impl Display for DisplayRepresentation<'_> {
             Type::Instance(instance) => match (instance.class(), instance.class().known(self.db)) {
                 (_, Some(KnownClass::NoneType)) => f.write_str("None"),
                 (_, Some(KnownClass::NoDefaultType)) => f.write_str("NoDefault"),
-                (ClassType::NonGeneric(class), _) => f.write_str(&class.class(self.db).name),
+                (ClassType::NonGeneric(class), _) => f.write_str(class.name(self.db)),
                 (ClassType::Generic(alias), _) => write!(f, "{}", alias.display(self.db)),
             },
             Type::PropertyInstance(_) => f.write_str("property"),
@@ -272,7 +272,7 @@ impl<'db> GenericAlias<'db> {
 }
 
 pub(crate) struct DisplayGenericAlias<'db> {
-    origin: GenericClass<'db>,
+    origin: ClassLiteral<'db>,
     specialization: Specialization<'db>,
     db: &'db dyn Db,
 }
@@ -282,7 +282,7 @@ impl Display for DisplayGenericAlias<'_> {
         write!(
             f,
             "{origin}{specialization}",
-            origin = self.origin.class(self.db).name,
+            origin = self.origin.name(self.db),
             specialization = self.specialization.display_short(self.db),
         )
     }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -77,7 +77,6 @@ use crate::types::diagnostic::{
     POSSIBLY_UNBOUND_IMPORT, UNDEFINED_REVEAL, UNRESOLVED_ATTRIBUTE, UNRESOLVED_IMPORT,
     UNSUPPORTED_OPERATOR,
 };
-use crate::types::generics::GenericContext;
 use crate::types::mro::MroErrorKind;
 use crate::types::unpacker::{UnpackResult, Unpacker};
 use crate::types::{
@@ -1825,10 +1824,6 @@ impl<'db> TypeInferenceBuilder<'db> {
             }
         }
 
-        let generic_context = type_params.as_ref().map(|type_params| {
-            GenericContext::from_type_params(self.db(), self.index, type_params)
-        });
-
         let body_scope = self
             .index
             .node_scope(NodeWithScopeRef::Class(class_node))
@@ -1843,10 +1838,8 @@ impl<'db> TypeInferenceBuilder<'db> {
             dataclass_params,
             dataclass_transformer_params,
         };
-        let class_literal = match generic_context {
-            Some(generic_context) => {
-                ClassLiteralType::Generic(GenericClass::new(self.db(), class, generic_context))
-            }
+        let class_literal = match type_params.as_ref() {
+            Some(_) => ClassLiteralType::Generic(GenericClass::new(self.db(), class)),
             None => ClassLiteralType::NonGeneric(NonGenericClass::new(self.db(), class)),
         };
         let class_ty = Type::from(class_literal);

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -77,17 +77,17 @@ use crate::types::diagnostic::{
     POSSIBLY_UNBOUND_IMPORT, UNDEFINED_REVEAL, UNRESOLVED_ATTRIBUTE, UNRESOLVED_IMPORT,
     UNSUPPORTED_OPERATOR,
 };
+use crate::types::generics::GenericContext;
 use crate::types::mro::MroErrorKind;
 use crate::types::unpacker::{UnpackResult, Unpacker};
 use crate::types::{
-    binding_type, todo_type, CallDunderError, CallableSignature, CallableType, Class,
-    ClassLiteralType, ClassType, DataclassParams, DynamicType, FunctionDecorators, FunctionType,
-    GenericAlias, GenericClass, IntersectionBuilder, IntersectionType, KnownClass, KnownFunction,
-    KnownInstanceType, MemberLookupPolicy, MetaclassCandidate, NonGenericClass, Parameter,
-    ParameterForm, Parameters, Signature, Signatures, SliceLiteralType, StringLiteralType,
-    SubclassOfType, Symbol, SymbolAndQualifiers, Truthiness, TupleType, Type, TypeAliasType,
-    TypeAndQualifiers, TypeArrayDisplay, TypeQualifiers, TypeVarBoundOrConstraints,
-    TypeVarInstance, UnionBuilder, UnionType,
+    binding_type, todo_type, CallDunderError, CallableSignature, CallableType, ClassLiteral,
+    ClassType, DataclassParams, DynamicType, FunctionDecorators, FunctionType, GenericAlias,
+    IntersectionBuilder, IntersectionType, KnownClass, KnownFunction, KnownInstanceType,
+    MemberLookupPolicy, MetaclassCandidate, Parameter, ParameterForm, Parameters, Signature,
+    Signatures, SliceLiteralType, StringLiteralType, SubclassOfType, Symbol, SymbolAndQualifiers,
+    Truthiness, TupleType, Type, TypeAliasType, TypeAndQualifiers, TypeArrayDisplay,
+    TypeQualifiers, TypeVarBoundOrConstraints, TypeVarInstance, UnionBuilder, UnionType,
 };
 use crate::unpack::{Unpack, UnpackPosition};
 use crate::util::subscript::{PyIndex, PySlice};
@@ -1831,18 +1831,14 @@ impl<'db> TypeInferenceBuilder<'db> {
 
         let maybe_known_class = KnownClass::try_from_file_and_name(self.db(), self.file(), name);
 
-        let class = Class {
-            name: name.id.clone(),
+        let class_ty = Type::from(ClassLiteral::new(
+            self.db(),
+            name.id.clone(),
             body_scope,
-            known: maybe_known_class,
+            maybe_known_class,
             dataclass_params,
             dataclass_transformer_params,
-        };
-        let class_literal = match type_params.as_ref() {
-            Some(_) => ClassLiteralType::Generic(GenericClass::new(self.db(), class)),
-            None => ClassLiteralType::NonGeneric(NonGenericClass::new(self.db(), class)),
-        };
-        let class_ty = Type::from(class_literal);
+        ));
 
         self.add_declaration_with_binding(
             class_node.into(),
@@ -6203,8 +6199,15 @@ impl<'db> TypeInferenceBuilder<'db> {
         // updating all of the subscript logic below to use custom callables for all of the _other_
         // special cases, too.
         let value_ty = self.infer_expression(value);
-        if let Type::ClassLiteral(ClassLiteralType::Generic(generic_class)) = value_ty {
-            return self.infer_explicit_class_specialization(subscript, value_ty, generic_class);
+        if let Type::ClassLiteral(class) = value_ty {
+            if let Some(generic_context) = class.generic_context(self.db()) {
+                return self.infer_explicit_class_specialization(
+                    subscript,
+                    value_ty,
+                    class,
+                    generic_context,
+                );
+            }
         }
 
         let slice_ty = self.infer_expression(slice);
@@ -6215,7 +6218,8 @@ impl<'db> TypeInferenceBuilder<'db> {
         &mut self,
         subscript: &ast::ExprSubscript,
         value_ty: Type<'db>,
-        generic_class: GenericClass<'db>,
+        generic_class: ClassLiteral<'db>,
+        generic_context: GenericContext<'db>,
     ) -> Type<'db> {
         let slice_node = subscript.slice.as_ref();
         let mut call_argument_types = match slice_node {
@@ -6224,7 +6228,6 @@ impl<'db> TypeInferenceBuilder<'db> {
             ),
             _ => CallArgumentTypes::positional([self.infer_type_expression(slice_node)]),
         };
-        let generic_context = generic_class.generic_context(self.db());
         let signatures = Signatures::single(CallableSignature::single(
             value_ty,
             generic_context.signature(self.db()),
@@ -6496,7 +6499,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                             return KnownClass::GenericAlias.to_instance(self.db());
                         }
 
-                        if let ClassLiteralType::Generic(_) = class {
+                        if class.generic_context(self.db()).is_some() {
                             // TODO: specialize the generic class using these explicit type
                             // variable assignments
                             return value_ty;
@@ -7354,18 +7357,26 @@ impl<'db> TypeInferenceBuilder<'db> {
                 self.infer_type_expression(slice);
                 value_ty
             }
-            Type::ClassLiteral(ClassLiteralType::Generic(generic_class)) => {
-                let specialized_class =
-                    self.infer_explicit_class_specialization(subscript, value_ty, generic_class);
-                specialized_class
-                    .in_type_expression(self.db())
-                    .unwrap_or(Type::unknown())
-            }
-            Type::ClassLiteral(ClassLiteralType::NonGeneric(_)) => {
-                // TODO: Once we know that e.g. `list` is generic, emit a diagnostic if you try to
-                // specialize a non-generic class.
-                self.infer_type_expression(slice);
-                todo_type!("specialized non-generic class")
+            Type::ClassLiteral(class) => {
+                match class.generic_context(self.db()) {
+                    Some(generic_context) => {
+                        let specialized_class = self.infer_explicit_class_specialization(
+                            subscript,
+                            value_ty,
+                            class,
+                            generic_context,
+                        );
+                        specialized_class
+                            .in_type_expression(self.db())
+                            .unwrap_or(Type::unknown())
+                    }
+                    None => {
+                        // TODO: Once we know that e.g. `list` is generic, emit a diagnostic if you try to
+                        // specialize a non-generic class.
+                        self.infer_type_expression(slice);
+                        todo_type!("specialized non-generic class")
+                    }
+                }
             }
             _ => {
                 // TODO: Emit a diagnostic once we've implemented all valid subscript type

--- a/crates/red_knot_python_semantic/src/types/narrow.rs
+++ b/crates/red_knot_python_semantic/src/types/narrow.rs
@@ -8,8 +8,8 @@ use crate::semantic_index::symbol::{ScopeId, ScopedSymbolId, SymbolTable};
 use crate::semantic_index::symbol_table;
 use crate::types::infer::infer_same_file_expression_type;
 use crate::types::{
-    infer_expression_types, ClassLiteralType, IntersectionBuilder, KnownClass, SubclassOfType,
-    Truthiness, Type, UnionBuilder,
+    infer_expression_types, IntersectionBuilder, KnownClass, SubclassOfType, Truthiness, Type,
+    UnionBuilder,
 };
 use crate::Db;
 use itertools::Itertools;
@@ -530,9 +530,7 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
                 }) if keywords.is_empty() => {
                     let rhs_class = match rhs_ty {
                         Type::ClassLiteral(class) => class,
-                        Type::GenericAlias(alias) => {
-                            ClassLiteralType::Generic(alias.origin(self.db))
-                        }
+                        Type::GenericAlias(alias) => alias.origin(self.db),
                         _ => {
                             continue;
                         }

--- a/crates/red_knot_python_semantic/src/types/slots.rs
+++ b/crates/red_knot_python_semantic/src/types/slots.rs
@@ -4,7 +4,7 @@ use crate::db::Db;
 use crate::symbol::{Boundness, Symbol};
 use crate::types::class_base::ClassBase;
 use crate::types::diagnostic::report_base_with_incompatible_slots;
-use crate::types::{ClassLiteralType, Type};
+use crate::types::{ClassLiteral, Type};
 
 use super::InferContext;
 
@@ -23,7 +23,7 @@ enum SlotsKind {
 }
 
 impl SlotsKind {
-    fn from(db: &dyn Db, base: ClassLiteralType) -> Self {
+    fn from(db: &dyn Db, base: ClassLiteral) -> Self {
         let Symbol::Type(slots_ty, bound) = base.own_class_member(db, None, "__slots__").symbol
         else {
             return Self::NotSpecified;
@@ -53,7 +53,7 @@ impl SlotsKind {
 
 pub(super) fn check_class_slots(
     context: &InferContext,
-    class: ClassLiteralType,
+    class: ClassLiteral,
     node: &ast::StmtClassDef,
 ) {
     let db = context.db();


### PR DESCRIPTION
As discussed today, this is needed to handle legacy generic classes without having to infer the types of the class's explicit bases eagerly at class construction time. Pulling this out into a separate PR so there's a smaller diff to review.

This also makes our representation of generic classes and functions more consistent — before, we had separate Rust types and enum variants for generic/non-generic classes, but a single type for generic functions. Now we each a single (respective) type for each.

There were very few places we were differentiation between generic and non-generic _class literals_, and these are handled now by calling the (salsa cached) `generic_context` _accessor function_.

Note that _`ClassType`_ is still an enum with distinct variants for non-generic classes and specialized generic classes.