### PR TITLE
[red-knot] fix detecting a metaclass on a not-explicitly-specialized generic base

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/generics/classes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/generics/classes.md
@@ -275,14 +275,16 @@ c: C[int] = C[int]()
 reveal_type(c.method("string"))  # revealed: Literal["string"]
 ```
 
-## Cyclic class definition
+## Cyclic class definitions
+
+### F-bounded quantification
 
 A class can use itself as the type parameter of one of its superclasses. (This is also known as the
 [curiously recurring template pattern][crtp] or [F-bounded quantification][f-bound].)
 
-Here, `Sub` is not a generic class, since it fills its superclass's type parameter (with itself).
+#### In a stub file
 
-`stub.pyi`:
+Here, `Sub` is not a generic class, since it fills its superclass's type parameter (with itself).
 
 ```pyi
 class Base[T]: ...
@@ -291,9 +293,9 @@ class Sub(Base[Sub]): ...
 reveal_type(Sub)  # revealed: Literal[Sub]
 ```
 
-A similar case can work in a non-stub file, if forward references are stringified:
+#### With string forward references
 
-`string_annotation.py`:
+A similar case can work in a non-stub file, if forward references are stringified:
 
 ```py
 class Base[T]: ...
@@ -302,9 +304,9 @@ class Sub(Base["Sub"]): ...
 reveal_type(Sub)  # revealed: Literal[Sub]
 ```
 
-In a non-stub file, without stringified forward references, this raises a `NameError`:
+#### Without string forward references
 
-`bare_annotation.py`:
+In a non-stub file, without stringified forward references, this raises a `NameError`:
 
 ```py
 class Base[T]: ...
@@ -313,10 +315,22 @@ class Base[T]: ...
 class Sub(Base[Sub]): ...
 ```
 
-## Another cyclic case
+### Cyclic inheritance as a generic parameter
 
 ```pyi
 class Derived[T](list[Derived[T]]): ...
+```
+
+### Direct cyclic inheritance
+
+Inheritance that would result in a cyclic MRO is detected as an error.
+
+```py
+# error: [cyclic-class-definition]
+class C[T](C): ...
+
+# error: [cyclic-class-definition]
+class D[T](D[int]): ...
 ```
 
 [crtp]: https://en.wikipedia.org/wiki/Curiously_recurring_template_pattern

--- a/crates/red_knot_python_semantic/resources/mdtest/metaclass.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/metaclass.md
@@ -53,6 +53,25 @@ class B(A): ...
 reveal_type(B.__class__)  # revealed: Literal[M]
 ```
 
+## Linear inheritance with PEP 695 generic class
+
+The same is true if the base with the metaclass is a generic class.
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+```py
+class M(type): ...
+class A[T](metaclass=M): ...
+class B(A): ...
+class C(A[int]): ...
+
+reveal_type(B.__class__)  # revealed: Literal[M]
+reveal_type(C.__class__)  # revealed: Literal[M]
+```
+
 ## Conflict (1)
 
 The metaclass of a derived class must be a (non-strict) subclass of the metaclasses of all its

--- a/crates/red_knot_python_semantic/src/types/class_base.rs
+++ b/crates/red_knot_python_semantic/src/types/class_base.rs
@@ -62,7 +62,7 @@ impl<'db> ClassBase<'db> {
     pub(super) fn object(db: &'db dyn Db) -> Self {
         KnownClass::Object
             .to_class_literal(db)
-            .into_class_type()
+            .to_class_type(db)
             .map_or(Self::unknown(), Self::Class)
     }
 


### PR DESCRIPTION
## Summary

After https://github.com/astral-sh/ruff/pull/17620 (which this PR is based on), I was looking at other call sites of `Type::into_class_type`, and I began to feel that _all_ of them were currently buggy due to silently skipping unspecialized generic class literal types (though in some cases the bug hadn't shown up yet because we don't understand legacy generic classes from typeshed), and in every case they would be better off if an unspecialized generic class literal were implicitly specialized with the default specialization (which is the usual Python typing semantics for an unspecialized reference to a generic class), instead of silently skipped.

So I changed the method to implicitly apply the default specialization, and added a test that previously failed for detecting metaclasses on an unspecialized generic base.

I also renamed the method to `to_class_type`, because I feel we have a strong naming convention where `Type::into_foo` is always a trivial `const fn` that simply returns `Some()` if the type is of variant `Foo` and `None` otherwise. Even the existing method (with it handling both `GenericAlias` and `ClassLiteral`, and distinguishing kinds of `ClassLiteral`) was stretching this convention, and the new version definitely breaks that envelope.

## Test Plan

Added a test that failed before this PR.
