### PR TITLE
[red-knot] remove fixpoint handling from try_mro query

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/generics/classes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/generics/classes.md
@@ -275,14 +275,16 @@ c: C[int] = C[int]()
 reveal_type(c.method("string"))  # revealed: Literal["string"]
 ```
 
-## Cyclic class definition
+## Cyclic class definitions
+
+### F-bounded quantification
 
 A class can use itself as the type parameter of one of its superclasses. (This is also known as the
 [curiously recurring template pattern][crtp] or [F-bounded quantification][f-bound].)
 
-Here, `Sub` is not a generic class, since it fills its superclass's type parameter (with itself).
+#### In a stub file
 
-`stub.pyi`:
+Here, `Sub` is not a generic class, since it fills its superclass's type parameter (with itself).
 
 ```pyi
 class Base[T]: ...
@@ -291,9 +293,9 @@ class Sub(Base[Sub]): ...
 reveal_type(Sub)  # revealed: Literal[Sub]
 ```
 
-A similar case can work in a non-stub file, if forward references are stringified:
+#### With string forward references
 
-`string_annotation.py`:
+A similar case can work in a non-stub file, if forward references are stringified:
 
 ```py
 class Base[T]: ...
@@ -302,9 +304,9 @@ class Sub(Base["Sub"]): ...
 reveal_type(Sub)  # revealed: Literal[Sub]
 ```
 
-In a non-stub file, without stringified forward references, this raises a `NameError`:
+#### Without string forward references
 
-`bare_annotation.py`:
+In a non-stub file, without stringified forward references, this raises a `NameError`:
 
 ```py
 class Base[T]: ...
@@ -313,10 +315,22 @@ class Base[T]: ...
 class Sub(Base[Sub]): ...
 ```
 
-## Another cyclic case
+### Cyclic inheritance as a generic parameter
 
 ```pyi
 class Derived[T](list[Derived[T]]): ...
+```
+
+### Direct cyclic inheritance
+
+Inheritance that would result in a cyclic MRO is detected as an error.
+
+```py
+# error: [cyclic-class-definition]
+class C[T](C): ...
+
+# error: [cyclic-class-definition]
+class D[T](D[int]): ...
 ```
 
 [crtp]: https://en.wikipedia.org/wiki/Curiously_recurring_template_pattern

--- a/crates/red_knot_python_semantic/resources/mdtest/metaclass.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/metaclass.md
@@ -53,6 +53,25 @@ class B(A): ...
 reveal_type(B.__class__)  # revealed: Literal[M]
 ```
 
+## Linear inheritance with PEP 695 generic class
+
+The same is true if the base with the metaclass is a generic class.
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+```py
+class M(type): ...
+class A[T](metaclass=M): ...
+class B(A): ...
+class C(A[int]): ...
+
+reveal_type(B.__class__)  # revealed: Literal[M]
+reveal_type(C.__class__)  # revealed: Literal[M]
+```
+
 ## Conflict (1)
 
 The metaclass of a derived class must be a (non-strict) subclass of the metaclasses of all its

--- a/crates/red_knot_python_semantic/src/types/class.rs
+++ b/crates/red_knot_python_semantic/src/types/class.rs
@@ -62,28 +62,6 @@ fn explicit_bases_cycle_initial<'db>(
     Box::default()
 }
 
-fn try_mro_cycle_recover<'db>(
-    _db: &'db dyn Db,
-    _value: &Result<Mro<'db>, MroError<'db>>,
-    _count: u32,
-    _self: ClassLiteralType<'db>,
-    _specialization: Option<Specialization<'db>>,
-) -> salsa::CycleRecoveryAction<Result<Mro<'db>, MroError<'db>>> {
-    salsa::CycleRecoveryAction::Iterate
-}
-
-#[allow(clippy::unnecessary_wraps)]
-fn try_mro_cycle_initial<'db>(
-    db: &'db dyn Db,
-    self_: ClassLiteralType<'db>,
-    specialization: Option<Specialization<'db>>,
-) -> Result<Mro<'db>, MroError<'db>> {
-    Ok(Mro::from_error(
-        db,
-        self_.apply_optional_specialization(db, specialization),
-    ))
-}
-
 #[allow(clippy::ref_option, clippy::trivially_copy_pass_by_ref)]
 fn inheritance_cycle_recover<'db>(
     _db: &'db dyn Db,
@@ -661,7 +639,7 @@ impl<'db> ClassLiteralType<'db> {
     /// attribute on a class at runtime.
     ///
     /// [method resolution order]: https://docs.python.org/3/glossary.html#term-method-resolution-order
-    #[salsa::tracked(return_ref, cycle_fn=try_mro_cycle_recover, cycle_initial=try_mro_cycle_initial)]
+    #[salsa::tracked(return_ref)]
     pub(super) fn try_mro(
         self,
         db: &'db dyn Db,

--- a/crates/red_knot_python_semantic/src/types/class_base.rs
+++ b/crates/red_knot_python_semantic/src/types/class_base.rs
@@ -62,7 +62,7 @@ impl<'db> ClassBase<'db> {
     pub(super) fn object(db: &'db dyn Db) -> Self {
         KnownClass::Object
             .to_class_literal(db)
-            .into_class_type()
+            .to_class_type(db)
             .map_or(Self::unknown(), Self::Class)
     }
 


### PR DESCRIPTION
## Summary

Fixpoint handling isn't really safe for the `try_mro` query, because if we actually hit a cycle, it can result in an ever-growing MRO that never converges.

No tests or ecosystem projects break from removing this -- I think other changes have improved our behavior here since I added this.

## Test Plan

Existing CI.
