### PR TITLE
[red-knot] Protocols, but the only protocols in the world are the ones in the `typing` module

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/import/builtins.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/import/builtins.md
@@ -7,7 +7,7 @@ Builtin symbols can be explicitly imported:
 ```py
 import builtins
 
-reveal_type(builtins.chr)  # revealed: def chr(i: int | SupportsIndex, /) -> str
+reveal_type(builtins.chr)  # revealed: def chr(i: SupportsIndex, /) -> str
 ```
 
 ## Implicit use of builtin
@@ -15,7 +15,7 @@ reveal_type(builtins.chr)  # revealed: def chr(i: int | SupportsIndex, /) -> str
 Or used implicitly:
 
 ```py
-reveal_type(chr)  # revealed: def chr(i: int | SupportsIndex, /) -> str
+reveal_type(chr)  # revealed: def chr(i: SupportsIndex, /) -> str
 reveal_type(str)  # revealed: Literal[str]
 ```
 

--- a/crates/red_knot_python_semantic/resources/mdtest/protocols.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/protocols.md
@@ -230,7 +230,7 @@ And it is also an error to use `Protocol` in type expressions:
 def f(
     x: Protocol,  # error: [invalid-type-form] "`typing.Protocol` is not allowed in type expressions"
     y: type[Protocol],  # TODO: should emit `[invalid-type-form]` here too
-) -> None:
+):
     reveal_type(x)  # revealed: Unknown
 
     # TODO: should be `type[Unknown]`
@@ -266,9 +266,7 @@ class Bar(typing_extensions.Protocol):
 
 static_assert(typing_extensions.is_protocol(Foo))
 static_assert(typing_extensions.is_protocol(Bar))
-
-# TODO: should pass
-static_assert(is_equivalent_to(Foo, Bar))  # error: [static-assert-error]
+static_assert(is_equivalent_to(Foo, Bar))
 ```
 
 The same goes for `typing.runtime_checkable` and `typing_extensions.runtime_checkable`:
@@ -284,9 +282,7 @@ class RuntimeCheckableBar(typing_extensions.Protocol):
 
 static_assert(typing_extensions.is_protocol(RuntimeCheckableFoo))
 static_assert(typing_extensions.is_protocol(RuntimeCheckableBar))
-
-# TODO: should pass
-static_assert(is_equivalent_to(RuntimeCheckableFoo, RuntimeCheckableBar))  # error: [static-assert-error]
+static_assert(is_equivalent_to(RuntimeCheckableFoo, RuntimeCheckableBar))
 
 # These should not error because the protocols are decorated with `@runtime_checkable`
 isinstance(object(), RuntimeCheckableFoo)
@@ -488,21 +484,20 @@ class HasX(Protocol):
 class Foo:
     x: int
 
-# TODO: these should pass
-static_assert(is_subtype_of(Foo, HasX))  # error: [static-assert-error]
-static_assert(is_assignable_to(Foo, HasX))  # error: [static-assert-error]
+static_assert(is_subtype_of(Foo, HasX))
+static_assert(is_assignable_to(Foo, HasX))
 
 class FooSub(Foo): ...
 
-# TODO: these should pass
-static_assert(is_subtype_of(FooSub, HasX))  # error: [static-assert-error]
-static_assert(is_assignable_to(FooSub, HasX))  # error: [static-assert-error]
+static_assert(is_subtype_of(FooSub, HasX))
+static_assert(is_assignable_to(FooSub, HasX))
 
 class Bar:
     x: str
 
-static_assert(not is_subtype_of(Bar, HasX))
-static_assert(not is_assignable_to(Bar, HasX))
+# TODO: these should pass
+static_assert(not is_subtype_of(Bar, HasX))  # error: [static-assert-error]
+static_assert(not is_assignable_to(Bar, HasX))  # error: [static-assert-error]
 
 class Baz:
     y: int
@@ -524,14 +519,16 @@ class A:
     def x(self) -> int:
         return 42
 
-static_assert(not is_subtype_of(A, HasX))
-static_assert(not is_assignable_to(A, HasX))
+# TODO: these should pass
+static_assert(not is_subtype_of(A, HasX))  # error: [static-assert-error]
+static_assert(not is_assignable_to(A, HasX))  # error: [static-assert-error]
 
 class B:
     x: Final = 42
 
-static_assert(not is_subtype_of(A, HasX))
-static_assert(not is_assignable_to(A, HasX))
+# TODO: these should pass
+static_assert(not is_subtype_of(A, HasX))  # error: [static-assert-error]
+static_assert(not is_assignable_to(A, HasX))  # error: [static-assert-error]
 
 class IntSub(int): ...
 
@@ -541,8 +538,10 @@ class C:
 # due to invariance, a type is only a subtype of `HasX`
 # if its `x` attribute is of type *exactly* `int`:
 # a subclass of `int` does not satisfy the interface
-static_assert(not is_subtype_of(C, HasX))
-static_assert(not is_assignable_to(C, HasX))
+#
+# TODO: these should pass
+static_assert(not is_subtype_of(C, HasX))  # error: [static-assert-error]
+static_assert(not is_assignable_to(C, HasX))  # error: [static-assert-error]
 ```
 
 All attributes on frozen dataclasses and namedtuples are immutable, so instances of these classes
@@ -556,22 +555,23 @@ from typing import NamedTuple
 class MutableDataclass:
     x: int
 
-# TODO: these should pass
-static_assert(is_subtype_of(MutableDataclass, HasX))  # error: [static-assert-error]
-static_assert(is_assignable_to(MutableDataclass, HasX))  # error: [static-assert-error]
+static_assert(is_subtype_of(MutableDataclass, HasX))
+static_assert(is_assignable_to(MutableDataclass, HasX))
 
 @dataclass(frozen=True)
 class ImmutableDataclass:
     x: int
 
-static_assert(not is_subtype_of(ImmutableDataclass, HasX))
-static_assert(not is_assignable_to(ImmutableDataclass, HasX))
+# TODO: these should pass
+static_assert(not is_subtype_of(ImmutableDataclass, HasX))  # error: [static-assert-error]
+static_assert(not is_assignable_to(ImmutableDataclass, HasX))  # error: [static-assert-error]
 
 class NamedTupleWithX(NamedTuple):
     x: int
 
-static_assert(not is_subtype_of(NamedTupleWithX, HasX))
-static_assert(not is_assignable_to(NamedTupleWithX, HasX))
+# TODO: these should pass
+static_assert(not is_subtype_of(NamedTupleWithX, HasX))  # error: [static-assert-error]
+static_assert(not is_assignable_to(NamedTupleWithX, HasX))  # error: [static-assert-error]
 ```
 
 However, a type with a read-write property `x` *does* satisfy the `HasX` protocol. The `HasX`
@@ -590,9 +590,8 @@ class XProperty:
     def x(self, x: int) -> None:
         self._x = x**2
 
-# TODO: these should pass
-static_assert(is_subtype_of(XProperty, HasX))  # error: [static-assert-error]
-static_assert(is_assignable_to(XProperty, HasX))  # error: [static-assert-error]
+static_assert(is_subtype_of(XProperty, HasX))
+static_assert(is_assignable_to(XProperty, HasX))
 ```
 
 Attribute members on protocol classes are allowed to have default values, just like instance
@@ -717,9 +716,8 @@ from typing import Protocol
 
 class UniversalSet(Protocol): ...
 
-# TODO: these should pass
-static_assert(is_assignable_to(object, UniversalSet))  # error: [static-assert-error]
-static_assert(is_subtype_of(object, UniversalSet))  # error: [static-assert-error]
+static_assert(is_assignable_to(object, UniversalSet))
+static_assert(is_subtype_of(object, UniversalSet))
 ```
 
 Which means that `UniversalSet` here is in fact an equivalent type to `object`:
@@ -727,8 +725,7 @@ Which means that `UniversalSet` here is in fact an equivalent type to `object`:
 ```py
 from knot_extensions import is_equivalent_to
 
-# TODO: this should pass
-static_assert(is_equivalent_to(UniversalSet, object))  # error: [static-assert-error]
+static_assert(is_equivalent_to(UniversalSet, object))
 ```
 
 `object` is a subtype of certain other protocols too. Since all fully static types (whether nominal
@@ -739,17 +736,16 @@ means that these protocols are also equivalent to `UniversalSet` and `object`:
 class SupportsStr(Protocol):
     def __str__(self) -> str: ...
 
-# TODO: these should pass
-static_assert(is_equivalent_to(SupportsStr, UniversalSet))  # error: [static-assert-error]
-static_assert(is_equivalent_to(SupportsStr, object))  # error: [static-assert-error]
+static_assert(is_equivalent_to(SupportsStr, UniversalSet))
+static_assert(is_equivalent_to(SupportsStr, object))
 
 class SupportsClass(Protocol):
-    __class__: type
+    @property
+    def __class__(self) -> type: ...
 
-# TODO: these should pass
-static_assert(is_equivalent_to(SupportsClass, UniversalSet))  # error: [static-assert-error]
-static_assert(is_equivalent_to(SupportsClass, SupportsStr))  # error: [static-assert-error]
-static_assert(is_equivalent_to(SupportsClass, object))  # error: [static-assert-error]
+static_assert(is_equivalent_to(SupportsClass, UniversalSet))
+static_assert(is_equivalent_to(SupportsClass, SupportsStr))
+static_assert(is_equivalent_to(SupportsClass, object))
 ```
 
 If a protocol contains members that are not defined on `object`, then that protocol will (like all
@@ -786,8 +782,7 @@ class HasX(Protocol):
 class AlsoHasX(Protocol):
     x: int
 
-# TODO: this should pass
-static_assert(is_equivalent_to(HasX, AlsoHasX))  # error: [static-assert-error]
+static_assert(is_equivalent_to(HasX, AlsoHasX))
 ```
 
 And unions containing equivalent protocols are recognised as equivalent, even when the order is not
@@ -803,8 +798,7 @@ class AlsoHasY(Protocol):
 class A: ...
 class B: ...
 
-# TODO: this should pass
-static_assert(is_equivalent_to(A | HasX | B | HasY, B | AlsoHasY | AlsoHasX | A))  # error: [static-assert-error]
+static_assert(is_equivalent_to(A | HasX | B | HasY, B | AlsoHasY | AlsoHasX | A))
 ```
 
 ## Intersections of protocols
@@ -882,9 +876,9 @@ from knot_extensions import is_subtype_of, is_assignable_to, static_assert, Type
 class HasX(Protocol):
     x: int
 
-# TODO: these should pass
+# TODO: this should pass
 static_assert(is_subtype_of(TypeOf[module], HasX))  # error: [static-assert-error]
-static_assert(is_assignable_to(TypeOf[module], HasX))  # error: [static-assert-error]
+static_assert(is_assignable_to(TypeOf[module], HasX))
 
 class ExplicitProtocolSubtype(HasX, Protocol):
     y: int
@@ -896,9 +890,8 @@ class ImplicitProtocolSubtype(Protocol):
     x: int
     y: str
 
-# TODO: these should pass
-static_assert(is_subtype_of(ImplicitProtocolSubtype, HasX))  # error: [static-assert-error]
-static_assert(is_assignable_to(ImplicitProtocolSubtype, HasX))  # error: [static-assert-error]
+static_assert(is_subtype_of(ImplicitProtocolSubtype, HasX))
+static_assert(is_assignable_to(ImplicitProtocolSubtype, HasX))
 
 class Meta(type):
     x: int
@@ -933,23 +926,24 @@ def f(obj: ClassVarXProto):
 class InstanceAttrX:
     x: int
 
-static_assert(not is_assignable_to(InstanceAttrX, ClassVarXProto))
-static_assert(not is_subtype_of(InstanceAttrX, ClassVarXProto))
+# TODO: these should pass
+static_assert(not is_assignable_to(InstanceAttrX, ClassVarXProto))  # error: [static-assert-error]
+static_assert(not is_subtype_of(InstanceAttrX, ClassVarXProto))  # error: [static-assert-error]
 
 class PropertyX:
     @property
     def x(self) -> int:
         return 42
 
-static_assert(not is_assignable_to(PropertyX, ClassVarXProto))
-static_assert(not is_subtype_of(PropertyX, ClassVarXProto))
+# TODO: these should pass
+static_assert(not is_assignable_to(PropertyX, ClassVarXProto))  # error: [static-assert-error]
+static_assert(not is_subtype_of(PropertyX, ClassVarXProto))  # error: [static-assert-error]
 
 class ClassVarX:
     x: ClassVar[int] = 42
 
-# TODO: these should pass
-static_assert(is_assignable_to(ClassVarX, ClassVarXProto))  # error: [static-assert-error]
-static_assert(is_subtype_of(ClassVarX, ClassVarXProto))  # error: [static-assert-error]
+static_assert(is_assignable_to(ClassVarX, ClassVarXProto))
+static_assert(is_subtype_of(ClassVarX, ClassVarXProto))
 ```
 
 This is mentioned by the
@@ -976,18 +970,16 @@ class HasXProperty(Protocol):
 class XAttr:
     x: int
 
-# TODO: these should pass
-static_assert(is_subtype_of(XAttr, HasXProperty))  # error: [static-assert-error]
-static_assert(is_assignable_to(XAttr, HasXProperty))  # error: [static-assert-error]
+static_assert(is_subtype_of(XAttr, HasXProperty))
+static_assert(is_assignable_to(XAttr, HasXProperty))
 
 class XReadProperty:
     @property
     def x(self) -> int:
         return 42
 
-# TODO: these should pass
-static_assert(is_subtype_of(XReadProperty, HasXProperty))  # error: [static-assert-error]
-static_assert(is_assignable_to(XReadProperty, HasXProperty))  # error: [static-assert-error]
+static_assert(is_subtype_of(XReadProperty, HasXProperty))
+static_assert(is_assignable_to(XReadProperty, HasXProperty))
 
 class XReadWriteProperty:
     @property
@@ -997,22 +989,20 @@ class XReadWriteProperty:
     @x.setter
     def x(self, val: int) -> None: ...
 
-# TODO: these should pass
-static_assert(is_subtype_of(XReadWriteProperty, HasXProperty))  # error: [static-assert-error]
-static_assert(is_assignable_to(XReadWriteProperty, HasXProperty))  # error: [static-assert-error]
+static_assert(is_subtype_of(XReadWriteProperty, HasXProperty))
+static_assert(is_assignable_to(XReadWriteProperty, HasXProperty))
 
 class XClassVar:
     x: ClassVar[int] = 42
 
-static_assert(is_subtype_of(XClassVar, HasXProperty))  # error: [static-assert-error]
-static_assert(is_assignable_to(XClassVar, HasXProperty))  # error: [static-assert-error]
+static_assert(is_subtype_of(XClassVar, HasXProperty))
+static_assert(is_assignable_to(XClassVar, HasXProperty))
 
 class XFinal:
     x: Final = 42
 
-# TODO: these should pass
-static_assert(is_subtype_of(XFinal, HasXProperty))  # error: [static-assert-error]
-static_assert(is_assignable_to(XFinal, HasXProperty))  # error: [static-assert-error]
+static_assert(is_subtype_of(XFinal, HasXProperty))
+static_assert(is_assignable_to(XFinal, HasXProperty))
 ```
 
 A read-only property on a protocol, unlike a mutable attribute, is covariant: `XSub` in the below
@@ -1025,9 +1015,8 @@ class MyInt(int): ...
 class XSub:
     x: MyInt
 
-# TODO: these should pass
-static_assert(is_subtype_of(XSub, HasXProperty))  # error: [static-assert-error]
-static_assert(is_assignable_to(XSub, HasXProperty))  # error: [static-assert-error]
+static_assert(is_subtype_of(XSub, HasXProperty))
+static_assert(is_assignable_to(XSub, HasXProperty))
 ```
 
 A read/write property on a protocol, where the getter returns the same type that the setter takes,
@@ -1043,17 +1032,17 @@ class HasMutableXProperty(Protocol):
 class XAttr:
     x: int
 
-# TODO: these should pass
-static_assert(is_subtype_of(XAttr, HasXProperty))  # error: [static-assert-error]
-static_assert(is_assignable_to(XAttr, HasXProperty))  # error: [static-assert-error]
+static_assert(is_subtype_of(XAttr, HasXProperty))
+static_assert(is_assignable_to(XAttr, HasXProperty))
 
 class XReadProperty:
     @property
     def x(self) -> int:
         return 42
 
-static_assert(not is_subtype_of(XReadProperty, HasXProperty))
-static_assert(not is_assignable_to(XReadProperty, HasXProperty))
+# TODO: these should pass
+static_assert(not is_subtype_of(XReadProperty, HasXProperty))  # error: [static-assert-error]
+static_assert(not is_assignable_to(XReadProperty, HasXProperty))  # error: [static-assert-error]
 
 class XReadWriteProperty:
     @property
@@ -1063,15 +1052,15 @@ class XReadWriteProperty:
     @x.setter
     def x(self, val: int) -> None: ...
 
-# TODO: these should pass
-static_assert(is_subtype_of(XReadWriteProperty, HasXProperty))  # error: [static-assert-error]
-static_assert(is_assignable_to(XReadWriteProperty, HasXProperty))  # error: [static-assert-error]
+static_assert(is_subtype_of(XReadWriteProperty, HasXProperty))
+static_assert(is_assignable_to(XReadWriteProperty, HasXProperty))
 
 class XSub:
     x: MyInt
 
-static_assert(not is_subtype_of(XSub, HasXProperty))
-static_assert(not is_assignable_to(XSub, HasXProperty))
+# TODO: should pass
+static_assert(not is_subtype_of(XSub, HasXProperty))  # error: [static-assert-error]
+static_assert(not is_assignable_to(XSub, HasXProperty))  # error: [static-assert-error]
 ```
 
 A protocol with a read/write property `x` is exactly equivalent to a protocol with a mutable
@@ -1083,16 +1072,13 @@ from knot_extensions import is_equivalent_to
 class HasMutableXAttr(Protocol):
     x: int
 
-# TODO: this should pass
-static_assert(is_equivalent_to(HasMutableXAttr, HasMutableXProperty))  # error: [static-assert-error]
+static_assert(is_equivalent_to(HasMutableXAttr, HasMutableXProperty))
 
-# TODO: these should pass
-static_assert(is_subtype_of(HasMutableXAttr, HasXProperty))  # error: [static-assert-error]
-static_assert(is_assignable_to(HasMutableXAttr, HasXProperty))  # error: [static-assert-error]
+static_assert(is_subtype_of(HasMutableXAttr, HasXProperty))
+static_assert(is_assignable_to(HasMutableXAttr, HasXProperty))
 
-# TODO: these should pass
-static_assert(is_subtype_of(HasMutableXProperty, HasXProperty))  # error: [static-assert-error]
-static_assert(is_assignable_to(HasMutableXProperty, HasXProperty))  # error: [static-assert-error]
+static_assert(is_subtype_of(HasMutableXProperty, HasXProperty))
+static_assert(is_assignable_to(HasMutableXProperty, HasXProperty))
 ```
 
 A read/write property on a protocol, where the setter accepts a subtype of the type returned by the
@@ -1119,9 +1105,8 @@ class HasAsymmetricXProperty(Protocol):
 class XAttr:
     x: int
 
-# TODO: these should pass
-static_assert(is_subtype_of(XAttr, HasAsymmetricXProperty))  # error: [static-assert-error]
-static_assert(is_assignable_to(XAttr, HasAsymmetricXProperty))  # error: [static-assert-error]
+static_assert(is_subtype_of(XAttr, HasAsymmetricXProperty))
+static_assert(is_assignable_to(XAttr, HasAsymmetricXProperty))
 ```
 
 The end conclusion of this is that the getter-returned type of a property is always covariant and
@@ -1132,9 +1117,8 @@ regular mutable attribute, where the implied getter-returned and setter-accepted
 class XAttrSub:
     x: MyInt
 
-# TODO: these should pass
-static_assert(is_subtype_of(XAttrSub, HasAsymmetricXProperty))  # error: [static-assert-error]
-static_assert(is_assignable_to(XAttrSub, HasAsymmetricXProperty))  # error: [static-assert-error]
+static_assert(is_subtype_of(XAttrSub, HasAsymmetricXProperty))
+static_assert(is_assignable_to(XAttrSub, HasAsymmetricXProperty))
 
 class MyIntSub(MyInt):
     pass
@@ -1142,8 +1126,9 @@ class MyIntSub(MyInt):
 class XAttrSubSub:
     x: MyIntSub
 
-static_assert(not is_subtype_of(XAttrSubSub, HasAsymmetricXProperty))
-static_assert(not is_assignable_to(XAttrSubSub, HasAsymmetricXProperty))
+# TODO: should pass
+static_assert(not is_subtype_of(XAttrSubSub, HasAsymmetricXProperty))  # error: [static-assert-error]
+static_assert(not is_assignable_to(XAttrSubSub, HasAsymmetricXProperty))  # error: [static-assert-error]
 ```
 
 An asymmetric property on a protocol can also be satisfied by an asymmetric property on a nominal
@@ -1159,9 +1144,8 @@ class XAsymmetricProperty:
     @x.setter
     def x(self, x: int) -> None: ...
 
-# TODO: these should pass
-static_assert(is_subtype_of(XAsymmetricProperty, HasAsymmetricXProperty))  # error: [static-assert-error]
-static_assert(is_assignable_to(XAsymmetricProperty, HasAsymmetricXProperty))  # error: [static-assert-error]
+static_assert(is_subtype_of(XAsymmetricProperty, HasAsymmetricXProperty))
+static_assert(is_assignable_to(XAsymmetricProperty, HasAsymmetricXProperty))
 ```
 
 A custom descriptor attribute on the nominal class will also suffice:
@@ -1176,9 +1160,8 @@ class Descriptor:
 class XCustomDescriptor:
     x: Descriptor = Descriptor()
 
-# TODO: these should pass
-static_assert(is_subtype_of(XCustomDescriptor, HasAsymmetricXProperty))  # error: [static-assert-error]
-static_assert(is_assignable_to(XCustomDescriptor, HasAsymmetricXProperty))  # error: [static-assert-error]
+static_assert(is_subtype_of(XCustomDescriptor, HasAsymmetricXProperty))
+static_assert(is_assignable_to(XCustomDescriptor, HasAsymmetricXProperty))
 ```
 
 Moreover, a read-only property on a protocol can be satisfied by a nominal class that defines a
@@ -1191,19 +1174,20 @@ class HasGetAttr:
     def __getattr__(self, attr: str) -> int:
         return 42
 
-# TODO: these should pass
-static_assert(is_subtype_of(HasGetAttr, HasXProperty))  # error: [static-assert-error]
-static_assert(is_assignable_to(HasGetAttr, HasXProperty))  # error: [static-assert-error]
+static_assert(is_subtype_of(HasGetAttr, HasXProperty))
+static_assert(is_assignable_to(HasGetAttr, HasXProperty))
 
-static_assert(not is_subtype_of(HasGetAttr, HasMutableXAttr))
-static_assert(not is_subtype_of(HasGetAttr, HasMutableXAttr))
+# TODO: these should pass
+static_assert(not is_subtype_of(HasGetAttr, HasMutableXAttr))  # error: [static-assert-error]
+static_assert(not is_subtype_of(HasGetAttr, HasMutableXAttr))  # error: [static-assert-error]
 
 class HasGetAttrWithUnsuitableReturn:
     def __getattr__(self, attr: str) -> tuple[int, int]:
         return (1, 2)
 
-static_assert(not is_subtype_of(HasGetAttrWithUnsuitableReturn, HasXProperty))
-static_assert(not is_assignable_to(HasGetAttrWithUnsuitableReturn, HasXProperty))
+# TODO: these should pass
+static_assert(not is_subtype_of(HasGetAttrWithUnsuitableReturn, HasXProperty))  # error: [static-assert-error]
+static_assert(not is_assignable_to(HasGetAttrWithUnsuitableReturn, HasXProperty))  # error: [static-assert-error]
 
 class HasGetAttrAndSetAttr:
     def __getattr__(self, attr: str) -> MyInt:
@@ -1211,9 +1195,10 @@ class HasGetAttrAndSetAttr:
 
     def __setattr__(self, attr: str, value: int) -> None: ...
 
+static_assert(is_subtype_of(HasGetAttrAndSetAttr, HasXProperty))
+static_assert(is_assignable_to(HasGetAttrAndSetAttr, HasXProperty))
+
 # TODO: these should pass
-static_assert(is_subtype_of(HasGetAttrAndSetAttr, HasXProperty))  # error: [static-assert-error]
-static_assert(is_assignable_to(HasGetAttrAndSetAttr, HasXProperty))  # error: [static-assert-error]
 static_assert(is_subtype_of(HasGetAttrAndSetAttr, XAsymmetricProperty))  # error: [static-assert-error]
 static_assert(is_assignable_to(HasGetAttrAndSetAttr, XAsymmetricProperty))  # error: [static-assert-error]
 ```
@@ -1314,9 +1299,12 @@ class FalsyFooSubclass(FalsyFoo, Protocol):
     y: str
 
 def g(a: Truthy, b: FalsyFoo, c: FalsyFooSubclass):
-    reveal_type(bool(a))  # revealed: Literal[True]
-    reveal_type(bool(b))  # revealed: Literal[False]
-    reveal_type(bool(c))  # revealed: Literal[False]
+    # TODO should be `Literal[True]
+    reveal_type(bool(a))  # revealed: bool
+    # TODO should be `Literal[False]
+    reveal_type(bool(b))  # revealed: bool
+    # TODO should be `Literal[False]
+    reveal_type(bool(c))  # revealed: bool
 ```
 
 It is not sufficient for a protocol to have a callable `__bool__` instance member that returns
@@ -1363,12 +1351,12 @@ from knot_extensions import is_subtype_of, is_assignable_to
 class NominalWithX:
     x: int = 42
 
-# TODO: these should pass
-static_assert(is_assignable_to(NominalWithX, FullyStatic))  # error: [static-assert-error]
-static_assert(is_assignable_to(NominalWithX, NotFullyStatic))  # error: [static-assert-error]
-static_assert(is_subtype_of(NominalWithX, FullyStatic))  # error: [static-assert-error]
+static_assert(is_assignable_to(NominalWithX, FullyStatic))
+static_assert(is_assignable_to(NominalWithX, NotFullyStatic))
+static_assert(is_subtype_of(NominalWithX, FullyStatic))
 
-static_assert(not is_subtype_of(NominalWithX, NotFullyStatic))
+# TODO: this should pass
+static_assert(not is_subtype_of(NominalWithX, NotFullyStatic))  # error: [static-assert-error]
 ```
 
 Empty protocols are fully static; this follows from the fact that an empty protocol is equivalent to

--- a/crates/red_knot_python_semantic/resources/mdtest/scopes/builtin.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/scopes/builtin.md
@@ -13,7 +13,7 @@ if returns_bool():
     chr: int = 1
 
 def f():
-    reveal_type(chr)  # revealed: int | (def chr(i: int | SupportsIndex, /) -> str)
+    reveal_type(chr)  # revealed: int | (def chr(i: SupportsIndex, /) -> str)
 ```
 
 ## Conditionally global or builtin, with annotation
@@ -28,5 +28,5 @@ if returns_bool():
     chr: int = 1
 
 def f():
-    reveal_type(chr)  # revealed: int | (def chr(i: int | SupportsIndex, /) -> str)
+    reveal_type(chr)  # revealed: int | (def chr(i: SupportsIndex, /) -> str)
 ```

--- a/crates/red_knot_python_semantic/src/symbol.rs
+++ b/crates/red_knot_python_semantic/src/symbol.rs
@@ -1114,7 +1114,7 @@ mod tests {
     fn assert_bound_string_symbol<'db>(db: &'db dyn Db, symbol: Symbol<'db>) {
         assert!(matches!(
             symbol,
-            Symbol::Type(Type::Instance(_), Boundness::Bound)
+            Symbol::Type(Type::NominalInstance(_), Boundness::Bound)
         ));
         assert_eq!(symbol.expect_type(), KnownClass::Str.to_instance(db));
     }

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -50,7 +50,7 @@ pub(crate) use crate::types::narrow::infer_narrowing_constraint;
 use crate::types::signatures::{Parameter, ParameterForm, Parameters};
 use crate::{Db, FxOrderSet, Module, Program};
 pub(crate) use class::{ClassLiteral, ClassType, GenericAlias, KnownClass};
-pub(crate) use instance::InstanceType;
+pub(crate) use instance::NominalInstanceType;
 pub(crate) use known_instance::KnownInstanceType;
 
 mod builder;
@@ -475,7 +475,7 @@ pub enum Type<'db> {
     SubclassOf(SubclassOfType<'db>),
     /// The set of Python objects with the given class in their __class__'s method resolution order.
     /// Construct this variant using the `Type::instance` constructor function.
-    Instance(InstanceType<'db>),
+    NominalInstance(NominalInstanceType<'db>),
     /// A single Python object that requires special treatment in the type system
     KnownInstance(KnownInstanceType<'db>),
     /// An instance of `builtins.property`
@@ -510,7 +510,7 @@ pub enum Type<'db> {
     TypeVar(TypeVarInstance<'db>),
     // A bound super object like `super()` or `super(A, A())`
     // This type doesn't handle an unbound super object like `super(A)`; for that we just use
-    // a `Type::Instance` of `builtins.super`.
+    // a `Type::NominalInstance` of `builtins.super`.
     BoundSuper(BoundSuperType<'db>),
     // TODO protocols, overloads, generics
 }
@@ -583,7 +583,7 @@ impl<'db> Type<'db> {
             | Self::BooleanLiteral(_)
             | Self::BytesLiteral(_)
             | Self::FunctionLiteral(_)
-            | Self::Instance(_)
+            | Self::NominalInstance(_)
             | Self::ModuleLiteral(_)
             | Self::ClassLiteral(_)
             | Self::KnownInstance(_)
@@ -888,7 +888,7 @@ impl<'db> Type<'db> {
             Type::Tuple(tuple) => Type::Tuple(tuple.normalized(db)),
             Type::Callable(callable) => Type::Callable(callable.normalized(db)),
             Type::LiteralString
-            | Type::Instance(_)
+            | Type::NominalInstance(_)
             | Type::PropertyInstance(_)
             | Type::AlwaysFalsy
             | Type::AlwaysTruthy
@@ -980,7 +980,7 @@ impl<'db> Type<'db> {
             (_, Type::Never) => false,
 
             // Everything is a subtype of `object`.
-            (_, Type::Instance(instance)) if instance.class().is_object(db) => true,
+            (_, Type::NominalInstance(instance)) if instance.class().is_object(db) => true,
 
             // A fully static typevar is always a subtype of itself, and is never a subtype of any
             // other typevar, since there is no guarantee that they will be specialized to the same
@@ -1232,7 +1232,7 @@ impl<'db> Type<'db> {
                     metaclass_instance_type.is_subtype_of(db, target)
                 }),
 
-            // For example: `Type::KnownInstance(KnownInstanceType::Type)` is a subtype of `Type::Instance(_SpecialForm)`,
+            // For example: `Type::KnownInstance(KnownInstanceType::Type)` is a subtype of `Type::NominalInstance(_SpecialForm)`,
             // because `Type::KnownInstance(KnownInstanceType::Type)` is a set with exactly one runtime value in it
             // (the symbol `typing.Type`), and that symbol is known to be an instance of `typing._SpecialForm` at runtime.
             (Type::KnownInstance(left), right) => {
@@ -1241,11 +1241,11 @@ impl<'db> Type<'db> {
 
             // `bool` is a subtype of `int`, because `bool` subclasses `int`,
             // which means that all instances of `bool` are also instances of `int`
-            (Type::Instance(self_instance), Type::Instance(target_instance)) => {
+            (Type::NominalInstance(self_instance), Type::NominalInstance(target_instance)) => {
                 self_instance.is_subtype_of(db, target_instance)
             }
 
-            (Type::Instance(_), Type::Callable(_)) => {
+            (Type::NominalInstance(_), Type::Callable(_)) => {
                 let call_symbol = self.member(db, "__call__").symbol;
                 match call_symbol {
                     Symbol::Type(Type::BoundMethod(call_function), _) => call_function
@@ -1264,7 +1264,7 @@ impl<'db> Type<'db> {
 
             // Other than the special cases enumerated above, `Instance` types and typevars are
             // never subtypes of any other variants
-            (Type::Instance(_) | Type::TypeVar(_), _) => false,
+            (Type::NominalInstance(_) | Type::TypeVar(_), _) => false,
         }
     }
 
@@ -1286,7 +1286,7 @@ impl<'db> Type<'db> {
 
             // All types are assignable to `object`.
             // TODO this special case might be removable once the below cases are comprehensive
-            (_, Type::Instance(instance)) if instance.class().is_object(db) => true,
+            (_, Type::NominalInstance(instance)) if instance.class().is_object(db) => true,
 
             // A typevar is always assignable to itself, and is never assignable to any other
             // typevar, since there is no guarantee that they will be specialized to the same
@@ -1420,7 +1420,7 @@ impl<'db> Type<'db> {
             // subtypes of `type[object]` are `type[...]` types (or `Never`), and `type[Any]` can
             // materialize to any `type[...]` type (or to `type[Never]`, which is equivalent to
             // `Never`.)
-            (Type::SubclassOf(subclass_of_ty), Type::Instance(_))
+            (Type::SubclassOf(subclass_of_ty), Type::NominalInstance(_))
                 if subclass_of_ty.is_dynamic()
                     && (KnownClass::Type
                         .to_instance(db)
@@ -1432,7 +1432,7 @@ impl<'db> Type<'db> {
 
             // Any type that is assignable to `type[object]` is also assignable to `type[Any]`,
             // because `type[Any]` can materialize to `type[object]`.
-            (Type::Instance(_), Type::SubclassOf(subclass_of_ty))
+            (Type::NominalInstance(_), Type::SubclassOf(subclass_of_ty))
                 if subclass_of_ty.is_dynamic()
                     && self.is_assignable_to(db, KnownClass::Type.to_instance(db)) =>
             {
@@ -1441,11 +1441,11 @@ impl<'db> Type<'db> {
 
             // TODO: This is a workaround to avoid false positives (e.g. when checking function calls
             // with `SupportsIndex` parameters), which should be removed when we understand protocols.
-            (lhs, Type::Instance(instance))
+            (lhs, Type::NominalInstance(instance))
                 if instance.class().is_known(db, KnownClass::SupportsIndex) =>
             {
                 match lhs {
-                    Type::Instance(instance)
+                    Type::NominalInstance(instance)
                         if matches!(
                             instance.class().known(db),
                             Some(KnownClass::Int | KnownClass::SupportsIndex)
@@ -1459,7 +1459,9 @@ impl<'db> Type<'db> {
             }
 
             // TODO: ditto for avoiding false positives when checking function calls with `Sized` parameters.
-            (lhs, Type::Instance(instance)) if instance.class().is_known(db, KnownClass::Sized) => {
+            (lhs, Type::NominalInstance(instance))
+                if instance.class().is_known(db, KnownClass::Sized) =>
+            {
                 matches!(
                     lhs.to_meta_type(db).member(db, "__len__"),
                     SymbolAndQualifiers {
@@ -1469,7 +1471,7 @@ impl<'db> Type<'db> {
                 )
             }
 
-            (Type::Instance(self_instance), Type::Instance(target_instance)) => {
+            (Type::NominalInstance(self_instance), Type::NominalInstance(target_instance)) => {
                 self_instance.is_assignable_to(db, target_instance)
             }
 
@@ -1477,7 +1479,7 @@ impl<'db> Type<'db> {
                 self_callable.is_assignable_to(db, target_callable)
             }
 
-            (Type::Instance(_), Type::Callable(_)) => {
+            (Type::NominalInstance(_), Type::Callable(_)) => {
                 let call_symbol = self.member(db, "__call__").symbol;
                 match call_symbol {
                     Symbol::Type(Type::BoundMethod(call_function), _) => call_function
@@ -1517,7 +1519,9 @@ impl<'db> Type<'db> {
             }
             (Type::Tuple(left), Type::Tuple(right)) => left.is_equivalent_to(db, right),
             (Type::Callable(left), Type::Callable(right)) => left.is_equivalent_to(db, right),
-            (Type::Instance(left), Type::Instance(right)) => left.is_equivalent_to(db, right),
+            (Type::NominalInstance(left), Type::NominalInstance(right)) => {
+                left.is_equivalent_to(db, right)
+            }
             _ => self == other && self.is_fully_static(db) && other.is_fully_static(db),
         }
     }
@@ -1552,7 +1556,7 @@ impl<'db> Type<'db> {
 
             (Type::TypeVar(first), Type::TypeVar(second)) => first == second,
 
-            (Type::Instance(first), Type::Instance(second)) => {
+            (Type::NominalInstance(first), Type::NominalInstance(second)) => {
                 first.is_gradual_equivalent_to(db, second)
             }
 
@@ -1780,8 +1784,8 @@ impl<'db> Type<'db> {
                     .is_disjoint_from(db, other),
             },
 
-            (Type::KnownInstance(known_instance), Type::Instance(instance))
-            | (Type::Instance(instance), Type::KnownInstance(known_instance)) => {
+            (Type::KnownInstance(known_instance), Type::NominalInstance(instance))
+            | (Type::NominalInstance(instance), Type::KnownInstance(known_instance)) => {
                 !known_instance.is_instance_of(db, instance.class())
             }
 
@@ -1790,8 +1794,8 @@ impl<'db> Type<'db> {
                 known_instance_ty.is_disjoint_from(db, KnownClass::Tuple.to_instance(db))
             }
 
-            (Type::BooleanLiteral(..), Type::Instance(instance))
-            | (Type::Instance(instance), Type::BooleanLiteral(..)) => {
+            (Type::BooleanLiteral(..), Type::NominalInstance(instance))
+            | (Type::NominalInstance(instance), Type::BooleanLiteral(..)) => {
                 // A `Type::BooleanLiteral()` must be an instance of exactly `bool`
                 // (it cannot be an instance of a `bool` subclass)
                 !KnownClass::Bool.is_subclass_of(db, instance.class())
@@ -1799,8 +1803,8 @@ impl<'db> Type<'db> {
 
             (Type::BooleanLiteral(..), _) | (_, Type::BooleanLiteral(..)) => true,
 
-            (Type::IntLiteral(..), Type::Instance(instance))
-            | (Type::Instance(instance), Type::IntLiteral(..)) => {
+            (Type::IntLiteral(..), Type::NominalInstance(instance))
+            | (Type::NominalInstance(instance), Type::IntLiteral(..)) => {
                 // A `Type::IntLiteral()` must be an instance of exactly `int`
                 // (it cannot be an instance of an `int` subclass)
                 !KnownClass::Int.is_subclass_of(db, instance.class())
@@ -1811,8 +1815,8 @@ impl<'db> Type<'db> {
             (Type::StringLiteral(..), Type::LiteralString)
             | (Type::LiteralString, Type::StringLiteral(..)) => false,
 
-            (Type::StringLiteral(..) | Type::LiteralString, Type::Instance(instance))
-            | (Type::Instance(instance), Type::StringLiteral(..) | Type::LiteralString) => {
+            (Type::StringLiteral(..) | Type::LiteralString, Type::NominalInstance(instance))
+            | (Type::NominalInstance(instance), Type::StringLiteral(..) | Type::LiteralString) => {
                 // A `Type::StringLiteral()` or a `Type::LiteralString` must be an instance of exactly `str`
                 // (it cannot be an instance of a `str` subclass)
                 !KnownClass::Str.is_subclass_of(db, instance.class())
@@ -1821,15 +1825,15 @@ impl<'db> Type<'db> {
             (Type::LiteralString, Type::LiteralString) => false,
             (Type::LiteralString, _) | (_, Type::LiteralString) => true,
 
-            (Type::BytesLiteral(..), Type::Instance(instance))
-            | (Type::Instance(instance), Type::BytesLiteral(..)) => {
+            (Type::BytesLiteral(..), Type::NominalInstance(instance))
+            | (Type::NominalInstance(instance), Type::BytesLiteral(..)) => {
                 // A `Type::BytesLiteral()` must be an instance of exactly `bytes`
                 // (it cannot be an instance of a `bytes` subclass)
                 !KnownClass::Bytes.is_subclass_of(db, instance.class())
             }
 
-            (Type::SliceLiteral(..), Type::Instance(instance))
-            | (Type::Instance(instance), Type::SliceLiteral(..)) => {
+            (Type::SliceLiteral(..), Type::NominalInstance(instance))
+            | (Type::NominalInstance(instance), Type::SliceLiteral(..)) => {
                 // A `Type::SliceLiteral` must be an instance of exactly `slice`
                 // (it cannot be an instance of a `slice` subclass)
                 !KnownClass::Slice.is_subclass_of(db, instance.class())
@@ -1838,17 +1842,19 @@ impl<'db> Type<'db> {
             // A class-literal type `X` is always disjoint from an instance type `Y`,
             // unless the type expressing "all instances of `Z`" is a subtype of of `Y`,
             // where `Z` is `X`'s metaclass.
-            (Type::ClassLiteral(class), instance @ Type::Instance(_))
-            | (instance @ Type::Instance(_), Type::ClassLiteral(class)) => !class
+            (Type::ClassLiteral(class), instance @ Type::NominalInstance(_))
+            | (instance @ Type::NominalInstance(_), Type::ClassLiteral(class)) => !class
                 .metaclass_instance_type(db)
                 .is_subtype_of(db, instance),
-            (Type::GenericAlias(alias), instance @ Type::Instance(_))
-            | (instance @ Type::Instance(_), Type::GenericAlias(alias)) => !ClassType::from(alias)
-                .metaclass_instance_type(db)
-                .is_subtype_of(db, instance),
+            (Type::GenericAlias(alias), instance @ Type::NominalInstance(_))
+            | (instance @ Type::NominalInstance(_), Type::GenericAlias(alias)) => {
+                !ClassType::from(alias)
+                    .metaclass_instance_type(db)
+                    .is_subtype_of(db, instance)
+            }
 
-            (Type::FunctionLiteral(..), Type::Instance(instance))
-            | (Type::Instance(instance), Type::FunctionLiteral(..)) => {
+            (Type::FunctionLiteral(..), Type::NominalInstance(instance))
+            | (Type::NominalInstance(instance), Type::FunctionLiteral(..)) => {
                 // A `Type::FunctionLiteral()` must be an instance of exactly `types.FunctionType`
                 // (it cannot be an instance of a `types.FunctionType` subclass)
                 !KnownClass::FunctionType.is_subclass_of(db, instance.class())
@@ -1904,13 +1910,15 @@ impl<'db> Type<'db> {
                 false
             }
 
-            (Type::ModuleLiteral(..), other @ Type::Instance(..))
-            | (other @ Type::Instance(..), Type::ModuleLiteral(..)) => {
+            (Type::ModuleLiteral(..), other @ Type::NominalInstance(..))
+            | (other @ Type::NominalInstance(..), Type::ModuleLiteral(..)) => {
                 // Modules *can* actually be instances of `ModuleType` subclasses
                 other.is_disjoint_from(db, KnownClass::ModuleType.to_instance(db))
             }
 
-            (Type::Instance(left), Type::Instance(right)) => left.is_disjoint_from(db, right),
+            (Type::NominalInstance(left), Type::NominalInstance(right)) => {
+                left.is_disjoint_from(db, right)
+            }
 
             (Type::Tuple(tuple), Type::Tuple(other_tuple)) => {
                 let self_elements = tuple.elements(db);
@@ -1922,8 +1930,8 @@ impl<'db> Type<'db> {
                         .any(|(e1, e2)| e1.is_disjoint_from(db, *e2))
             }
 
-            (Type::Tuple(..), instance @ Type::Instance(_))
-            | (instance @ Type::Instance(_), Type::Tuple(..)) => {
+            (Type::Tuple(..), instance @ Type::NominalInstance(_))
+            | (instance @ Type::NominalInstance(_), Type::Tuple(..)) => {
                 // We cannot be sure if the tuple is disjoint from the instance because:
                 //   - 'other' might be the homogeneous arbitrary-length tuple type
                 //     tuple[T, ...] (which we don't have support for yet); if all of
@@ -1983,7 +1991,7 @@ impl<'db> Type<'db> {
                 !matches!(bound_super.pivot_class(db), ClassBase::Dynamic(_))
                     && !matches!(bound_super.owner(db), SuperOwnerKind::Dynamic(_))
             }
-            Type::ClassLiteral(_) | Type::GenericAlias(_) | Type::Instance(_) => {
+            Type::ClassLiteral(_) | Type::GenericAlias(_) | Type::NominalInstance(_) => {
                 // TODO: Ideally, we would iterate over the MRO of the class, check if all
                 // bases are fully static, and only return `true` if that is the case.
                 //
@@ -2089,7 +2097,7 @@ impl<'db> Type<'db> {
                 false
             }
             Type::DataclassDecorator(_) | Type::DataclassTransformer(_) => false,
-            Type::Instance(instance) => instance.is_singleton(db),
+            Type::NominalInstance(instance) => instance.is_singleton(db),
             Type::PropertyInstance(_) => false,
             Type::Tuple(..) => {
                 // The empty tuple is a singleton on CPython and PyPy, but not on other Python
@@ -2161,7 +2169,7 @@ impl<'db> Type<'db> {
                 .iter()
                 .all(|elem| elem.is_single_valued(db)),
 
-            Type::Instance(instance) => instance.is_single_valued(db),
+            Type::NominalInstance(instance) => instance.is_single_valued(db),
 
             Type::BoundSuper(_) => {
                 // At runtime two super instances never compare equal, even if their arguments are identical.
@@ -2299,10 +2307,11 @@ impl<'db> Type<'db> {
                 .to_class_literal(db)
                 .find_name_in_mro_with_policy(db, name, policy),
 
-            // We eagerly normalize type[object], i.e. Type::SubclassOf(object) to `type`, i.e. Type::Instance(type).
-            // So looking up a name in the MRO of `Type::Instance(type)` is equivalent to looking up the name in the
+            // We eagerly normalize type[object], i.e. Type::SubclassOf(object) to `type`,
+            // i.e. Type::NominalInstance(type). So looking up a name in the MRO of
+            // `Type::NominalInstance(type)` is equivalent to looking up the name in the
             // MRO of the class `object`.
-            Type::Instance(instance) if instance.class().is_known(db, KnownClass::Type) => {
+            Type::NominalInstance(instance) if instance.class().is_known(db, KnownClass::Type) => {
                 KnownClass::Object
                     .to_class_literal(db)
                     .find_name_in_mro_with_policy(db, name, policy)
@@ -2327,7 +2336,7 @@ impl<'db> Type<'db> {
             | Type::SliceLiteral(_)
             | Type::Tuple(_)
             | Type::TypeVar(_)
-            | Type::Instance(_)
+            | Type::NominalInstance(_)
             | Type::PropertyInstance(_) => None,
         }
     }
@@ -2392,7 +2401,7 @@ impl<'db> Type<'db> {
 
             Type::Dynamic(_) | Type::Never => Symbol::bound(self).into(),
 
-            Type::Instance(instance) => instance.class().instance_member(db, name),
+            Type::NominalInstance(instance) => instance.class().instance_member(db, name),
 
             Type::FunctionLiteral(_) => KnownClass::FunctionType
                 .to_instance(db)
@@ -2833,7 +2842,7 @@ impl<'db> Type<'db> {
                 .to_instance(db)
                 .member_lookup_with_policy(db, name, policy),
 
-            Type::Instance(instance)
+            Type::NominalInstance(instance)
                 if matches!(name.as_str(), "major" | "minor")
                     && instance.class().is_known(db, KnownClass::VersionInfo) =>
             {
@@ -2875,7 +2884,7 @@ impl<'db> Type<'db> {
                 policy,
             ),
 
-            Type::Instance(..)
+            Type::NominalInstance(..)
             | Type::BooleanLiteral(..)
             | Type::IntLiteral(..)
             | Type::StringLiteral(..)
@@ -3167,7 +3176,7 @@ impl<'db> Type<'db> {
                 }
             },
 
-            Type::Instance(instance) => match instance.class().known(db) {
+            Type::NominalInstance(instance) => match instance.class().known(db) {
                 Some(known_class) => known_class.bool(),
                 None => try_dunder_bool()?,
             },
@@ -3911,7 +3920,7 @@ impl<'db> Type<'db> {
                 SubclassOfInner::Class(class) => Type::from(class).signatures(db),
             },
 
-            Type::Instance(_) => {
+            Type::NominalInstance(_) => {
                 // Note that for objects that have a (possibly not callable!) `__call__` attribute,
                 // we will get the signature of the `__call__` attribute, but will pass in the type
                 // of the original object as the "callable type". That ensures that we get errors
@@ -4361,7 +4370,7 @@ impl<'db> Type<'db> {
             | Type::WrapperDescriptor(_)
             | Type::DataclassDecorator(_)
             | Type::DataclassTransformer(_)
-            | Type::Instance(_)
+            | Type::NominalInstance(_)
             | Type::KnownInstance(_)
             | Type::PropertyInstance(_)
             | Type::ModuleLiteral(_)
@@ -4381,7 +4390,7 @@ impl<'db> Type<'db> {
     ///
     /// For example, the builtin `int` as a value expression is of type
     /// `Type::ClassLiteral(builtins.int)`, that is, it is the `int` class itself. As a type
-    /// expression, it names the type `Type::Instance(builtins.int)`, that is, all objects whose
+    /// expression, it names the type `Type::NominalInstance(builtins.int)`, that is, all objects whose
     /// `__class__` is `int`.
     pub fn in_type_expression(
         &self,
@@ -4558,7 +4567,7 @@ impl<'db> Type<'db> {
 
             Type::Dynamic(_) => Ok(*self),
 
-            Type::Instance(instance) => match instance.class().known(db) {
+            Type::NominalInstance(instance) => match instance.class().known(db) {
                 Some(KnownClass::TypeVar) => Ok(todo_type!(
                     "Support for `typing.TypeVar` instances in type expressions"
                 )),
@@ -4634,7 +4643,7 @@ impl<'db> Type<'db> {
     pub fn to_meta_type(&self, db: &'db dyn Db) -> Type<'db> {
         match self {
             Type::Never => Type::Never,
-            Type::Instance(instance) => instance.to_meta_type(db),
+            Type::NominalInstance(instance) => instance.to_meta_type(db),
             Type::KnownInstance(known_instance) => known_instance.to_meta_type(db),
             Type::PropertyInstance(_) => KnownClass::Property.to_class_literal(db),
             Type::Union(union) => union.map(db, |ty| ty.to_meta_type(db)),
@@ -4805,7 +4814,7 @@ impl<'db> Type<'db> {
             | Type::BoundSuper(_)
             // Instance contains a ClassType, which has already been specialized if needed, like
             // above with BoundMethod's self_instance.
-            | Type::Instance(_)
+            | Type::NominalInstance(_)
             | Type::KnownInstance(_) => self,
         }
     }
@@ -4869,7 +4878,7 @@ impl<'db> Type<'db> {
                 Some(TypeDefinition::Class(class_literal.definition(db)))
             }
             Self::GenericAlias(alias) => Some(TypeDefinition::Class(alias.definition(db))),
-            Self::Instance(instance) => {
+            Self::NominalInstance(instance) => {
                 Some(TypeDefinition::Class(instance.class().definition(db)))
             }
             Self::KnownInstance(instance) => match instance {
@@ -7457,7 +7466,7 @@ impl BoundSuperError<'_> {
 pub enum SuperOwnerKind<'db> {
     Dynamic(DynamicType),
     Class(ClassType<'db>),
-    Instance(InstanceType<'db>),
+    Instance(NominalInstanceType<'db>),
 }
 
 impl<'db> SuperOwnerKind<'db> {
@@ -7491,7 +7500,7 @@ impl<'db> SuperOwnerKind<'db> {
             Type::ClassLiteral(class_literal) => Some(SuperOwnerKind::Class(
                 class_literal.apply_optional_specialization(db, None),
             )),
-            Type::Instance(instance) => Some(SuperOwnerKind::Instance(instance)),
+            Type::NominalInstance(instance) => Some(SuperOwnerKind::Instance(instance)),
             Type::BooleanLiteral(_) => {
                 SuperOwnerKind::try_from_type(db, KnownClass::Bool.to_instance(db))
             }

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1,3 +1,4 @@
+use instance::{Protocol, ProtocolInstanceType};
 use itertools::Either;
 
 use std::slice::Iter;
@@ -476,6 +477,8 @@ pub enum Type<'db> {
     /// The set of Python objects with the given class in their __class__'s method resolution order.
     /// Construct this variant using the `Type::instance` constructor function.
     NominalInstance(NominalInstanceType<'db>),
+    /// The set of Python objects that conform to the interface described by a given protocol.
+    ProtocolInstance(ProtocolInstanceType<'db>),
     /// A single Python object that requires special treatment in the type system
     KnownInstance(KnownInstanceType<'db>),
     /// An instance of `builtins.property`
@@ -543,17 +546,17 @@ impl<'db> Type<'db> {
     }
 
     fn is_none(&self, db: &'db dyn Db) -> bool {
-        self.into_instance()
+        self.into_nominal_instance()
             .is_some_and(|instance| instance.class().is_known(db, KnownClass::NoneType))
     }
 
     fn is_bool(&self, db: &'db dyn Db) -> bool {
-        self.into_instance()
+        self.into_nominal_instance()
             .is_some_and(|instance| instance.class().is_known(db, KnownClass::Bool))
     }
 
     pub fn is_notimplemented(&self, db: &'db dyn Db) -> bool {
-        self.into_instance().is_some_and(|instance| {
+        self.into_nominal_instance().is_some_and(|instance| {
             instance
                 .class()
                 .is_known(db, KnownClass::NotImplementedType)
@@ -561,7 +564,7 @@ impl<'db> Type<'db> {
     }
 
     pub fn is_object(&self, db: &'db dyn Db) -> bool {
-        self.into_instance()
+        self.into_nominal_instance()
             .is_some_and(|instance| instance.class().is_object(db))
     }
 
@@ -667,6 +670,8 @@ impl<'db> Type<'db> {
                         .iter()
                         .any(|ty| ty.contains_todo(db))
             }
+
+            Self::ProtocolInstance(protocol) => protocol.contains_todo(),
         }
     }
 
@@ -887,6 +892,7 @@ impl<'db> Type<'db> {
             Type::Intersection(intersection) => Type::Intersection(intersection.normalized(db)),
             Type::Tuple(tuple) => Type::Tuple(tuple.normalized(db)),
             Type::Callable(callable) => Type::Callable(callable.normalized(db)),
+            Type::ProtocolInstance(protocol) => protocol.normalized(db),
             Type::LiteralString
             | Type::NominalInstance(_)
             | Type::PropertyInstance(_)
@@ -1149,6 +1155,14 @@ impl<'db> Type<'db> {
                 // function literals, bound methods, class literals, `type[]`, etc.)
                 false
             }
+
+            (Type::ProtocolInstance(left), Type::ProtocolInstance(right)) => {
+                left.is_subtype_of(db, right)
+            }
+            // A protocol instance can never be a subtype of a nominal type, with the *sole* exception of `object`.
+            // TODO: `Callable` types are also structural types.
+            (Type::ProtocolInstance(_), _) => false,
+            (_, Type::ProtocolInstance(protocol)) => self.satisfies_protocol(db, protocol),
 
             // A fully static heterogeneous tuple type `A` is a subtype of a fully static heterogeneous tuple type `B`
             // iff the two tuple types have the same number of elements and each element-type in `A` is a subtype
@@ -1499,6 +1513,16 @@ impl<'db> Type<'db> {
                 .into_callable_type(db)
                 .is_assignable_to(db, target),
 
+            (Type::ProtocolInstance(left), Type::ProtocolInstance(right)) => {
+                left.is_assignable_to(db, right)
+            }
+            // Other than the dynamic types such as `Any`/`Unknown`/`Todo` handled above,
+            // a protocol instance can never be assignable to a nominal type,
+            // with the *sole* exception of `object`.
+            // TODO: `Callable` types are also structural types.
+            (Type::ProtocolInstance(_), _) => false,
+            (_, Type::ProtocolInstance(protocol)) => self.satisfies_protocol(db, protocol),
+
             // TODO other types containing gradual forms
             _ => self.is_subtype_of(db, target),
         }
@@ -1521,6 +1545,13 @@ impl<'db> Type<'db> {
             (Type::Callable(left), Type::Callable(right)) => left.is_equivalent_to(db, right),
             (Type::NominalInstance(left), Type::NominalInstance(right)) => {
                 left.is_equivalent_to(db, right)
+            }
+            (Type::ProtocolInstance(first), Type::ProtocolInstance(right)) => {
+                first.is_equivalent_to(db, right)
+            }
+            (Type::ProtocolInstance(protocol), nominal @ Type::NominalInstance(n))
+            | (nominal @ Type::NominalInstance(n), Type::ProtocolInstance(protocol)) => {
+                n.class().is_object(db) && protocol.normalized(db) == nominal
             }
             _ => self == other && self.is_fully_static(db) && other.is_fully_static(db),
         }
@@ -1572,8 +1603,22 @@ impl<'db> Type<'db> {
                 first.is_gradual_equivalent_to(db, second)
             }
 
+            (Type::ProtocolInstance(first), Type::ProtocolInstance(right)) => {
+                first.is_gradual_equivalent_to(db, right)
+            }
+            (Type::ProtocolInstance(protocol), nominal @ Type::NominalInstance(n))
+            | (nominal @ Type::NominalInstance(n), Type::ProtocolInstance(protocol)) => {
+                n.class().is_object(db) && protocol.normalized(db) == nominal
+            }
             _ => false,
         }
+    }
+
+    fn satisfies_protocol(self, db: &'db dyn Db, protocol: ProtocolInstanceType<'db>) -> bool {
+        protocol
+            .protocol_members(db)
+            .iter()
+            .all(|member| !self.member(db, member).symbol.is_unbound())
     }
 
     /// Return true if this type and `other` have no common elements.
@@ -1770,6 +1815,68 @@ impl<'db> Type<'db> {
             (Type::AlwaysFalsy, ty) | (ty, Type::AlwaysFalsy) => {
                 // Similarly, they are only disjoint if `ty.bool() == AlwaysTrue`.
                 ty.bool(db).is_always_true()
+            }
+
+            (Type::ProtocolInstance(left), Type::ProtocolInstance(right)) => {
+                left.is_disjoint_from(db, right)
+            }
+
+            // TODO: we could also consider `protocol` to be disjoint from `nominal` if `nominal`
+            // has the right member but the type of its member is disjoint from the type of the
+            // member on `protocol`.
+            (Type::ProtocolInstance(protocol), nominal @ Type::NominalInstance(n))
+            | (nominal @ Type::NominalInstance(n), Type::ProtocolInstance(protocol)) => {
+                n.class().is_final(db) && !nominal.satisfies_protocol(db, protocol)
+            }
+
+            (
+                ty @ (Type::LiteralString
+                | Type::StringLiteral(..)
+                | Type::BytesLiteral(..)
+                | Type::BooleanLiteral(..)
+                | Type::SliceLiteral(..)
+                | Type::ClassLiteral(..)
+                | Type::FunctionLiteral(..)
+                | Type::ModuleLiteral(..)
+                | Type::GenericAlias(..)
+                | Type::IntLiteral(..)),
+                Type::ProtocolInstance(protocol),
+            )
+            | (
+                Type::ProtocolInstance(protocol),
+                ty @ (Type::LiteralString
+                | Type::StringLiteral(..)
+                | Type::BytesLiteral(..)
+                | Type::BooleanLiteral(..)
+                | Type::SliceLiteral(..)
+                | Type::ClassLiteral(..)
+                | Type::FunctionLiteral(..)
+                | Type::ModuleLiteral(..)
+                | Type::GenericAlias(..)
+                | Type::IntLiteral(..)),
+            ) => !ty.satisfies_protocol(db, protocol),
+
+            (Type::ProtocolInstance(protocol), Type::KnownInstance(known_instance))
+            | (Type::KnownInstance(known_instance), Type::ProtocolInstance(protocol)) => {
+                !known_instance
+                    .instance_fallback(db)
+                    .satisfies_protocol(db, protocol)
+            }
+
+            (Type::Callable(_), Type::ProtocolInstance(_))
+            | (Type::ProtocolInstance(_), Type::Callable(_)) => {
+                // TODO disjointness between `Callable` and `ProtocolInstance`
+                false
+            }
+
+            (Type::Tuple(..), Type::ProtocolInstance(..))
+            | (Type::ProtocolInstance(..), Type::Tuple(..)) => {
+                // Currently we do not make any general assumptions about the disjointness of a `Tuple` type
+                // and a `ProtocolInstance` type because a `Tuple` type can be an instance of a tuple
+                // subclass.
+                //
+                // TODO when we capture the types of the protocol members, we can improve on this.
+                false
             }
 
             // for `type[Any]`/`type[Unknown]`/`type[Todo]`, we know the type cannot be any larger than `type`,
@@ -1977,6 +2084,8 @@ impl<'db> Type<'db> {
             | Type::AlwaysTruthy
             | Type::PropertyInstance(_) => true,
 
+            Type::ProtocolInstance(protocol) => protocol.is_fully_static(),
+
             Type::TypeVar(typevar) => match typevar.bound_or_constraints(db) {
                 None => true,
                 Some(TypeVarBoundOrConstraints::UpperBound(bound)) => bound.is_fully_static(db),
@@ -2039,6 +2148,26 @@ impl<'db> Type<'db> {
                 // Note: The literal types included in this pattern are not true singletons.
                 // There can be multiple Python objects (at different memory locations) that
                 // are both of type Literal[345], for example.
+                false
+            }
+
+            Type::ProtocolInstance(..) => {
+                // It *might* be possible to have a singleton protocol-instance type...?
+                //
+                // E.g.:
+                //
+                // ```py
+                // from typing import Protocol, Callable
+                //
+                // class WeirdAndWacky(Protocol):
+                //     @property
+                //     def __class__(self) -> Callable[[], None]: ...
+                // ```
+                //
+                // `WeirdAndWacky` only has a single possible inhabitant: `None`!
+                // It is thus a singleton type.
+                // However, going out of our way to recognise it as such is probably not worth it.
+                // Such cases should anyway be exceedingly rare and/or contrived.
                 false
             }
 
@@ -2143,6 +2272,11 @@ impl<'db> Type<'db> {
             | Type::BytesLiteral(..)
             | Type::SliceLiteral(..)
             | Type::KnownInstance(..) => true,
+
+            Type::ProtocolInstance(..) => {
+                // See comment in the `Type::ProtocolInstance` branch for `Type::is_singleton`.
+                false
+            }
 
             // An unbounded, unconstrained typevar is not single-valued, because it can be
             // specialized to a multiple-valued type. A bounded typevar is not single-valued, even
@@ -2337,6 +2471,7 @@ impl<'db> Type<'db> {
             | Type::Tuple(_)
             | Type::TypeVar(_)
             | Type::NominalInstance(_)
+            | Type::ProtocolInstance(_)
             | Type::PropertyInstance(_) => None,
         }
     }
@@ -2402,6 +2537,17 @@ impl<'db> Type<'db> {
             Type::Dynamic(_) | Type::Never => Symbol::bound(self).into(),
 
             Type::NominalInstance(instance) => instance.class().instance_member(db, name),
+
+            Type::ProtocolInstance(protocol) => match protocol.inner() {
+                Protocol::FromClass(class) => class.instance_member(db, name),
+                Protocol::Synthesized(synthesized) => {
+                    if synthesized.members(db).contains(name) {
+                        SymbolAndQualifiers::todo("Capture type of synthesized protocol members")
+                    } else {
+                        Symbol::Unbound.into()
+                    }
+                }
+            },
 
             Type::FunctionLiteral(_) => KnownClass::FunctionType
                 .to_instance(db)
@@ -2885,6 +3031,7 @@ impl<'db> Type<'db> {
             ),
 
             Type::NominalInstance(..)
+            | Type::ProtocolInstance(..)
             | Type::BooleanLiteral(..)
             | Type::IntLiteral(..)
             | Type::StringLiteral(..)
@@ -2915,7 +3062,7 @@ impl<'db> Type<'db> {
                     // It will need a special handling, so it remember the origin type to properly
                     // resolve the attribute.
                     if matches!(
-                        self.into_instance()
+                        self.into_nominal_instance()
                             .and_then(|instance| instance.class().known(db)),
                         Some(KnownClass::ModuleType | KnownClass::GenericAlias)
                     ) {
@@ -3180,6 +3327,8 @@ impl<'db> Type<'db> {
                 Some(known_class) => known_class.bool(),
                 None => try_dunder_bool()?,
             },
+
+            Type::ProtocolInstance(_) => try_dunder_bool()?,
 
             Type::KnownInstance(known_instance) => known_instance.bool(),
 
@@ -4315,11 +4464,14 @@ impl<'db> Type<'db> {
                 };
                 let specialized = specialization
                     .map(|specialization| {
-                        Type::instance(ClassType::Generic(GenericAlias::new(
+                        Type::instance(
                             db,
-                            generic_origin,
-                            specialization,
-                        )))
+                            ClassType::Generic(GenericAlias::new(
+                                db,
+                                generic_origin,
+                                specialization,
+                            )),
+                        )
                     })
                     .unwrap_or(instance_ty);
                 Ok(specialized)
@@ -4350,9 +4502,9 @@ impl<'db> Type<'db> {
     pub fn to_instance(&self, db: &'db dyn Db) -> Option<Type<'db>> {
         match self {
             Type::Dynamic(_) | Type::Never => Some(*self),
-            Type::ClassLiteral(class) => Some(Type::instance(class.default_specialization(db))),
-            Type::GenericAlias(alias) => Some(Type::instance(ClassType::from(*alias))),
-            Type::SubclassOf(subclass_of_ty) => Some(subclass_of_ty.to_instance()),
+            Type::ClassLiteral(class) => Some(Type::instance(db, class.default_specialization(db))),
+            Type::GenericAlias(alias) => Some(Type::instance(db, ClassType::from(*alias))),
+            Type::SubclassOf(subclass_of_ty) => Some(subclass_of_ty.to_instance(db)),
             Type::Union(union) => {
                 let mut builder = UnionBuilder::new(db);
                 for element in union.elements(db) {
@@ -4371,6 +4523,7 @@ impl<'db> Type<'db> {
             | Type::DataclassDecorator(_)
             | Type::DataclassTransformer(_)
             | Type::NominalInstance(_)
+            | Type::ProtocolInstance(_)
             | Type::KnownInstance(_)
             | Type::PropertyInstance(_)
             | Type::ModuleLiteral(_)
@@ -4417,11 +4570,11 @@ impl<'db> Type<'db> {
                             KnownClass::Float.to_instance(db),
                         ],
                     ),
-                    _ => Type::instance(class.default_specialization(db)),
+                    _ => Type::instance(db, class.default_specialization(db)),
                 };
                 Ok(ty)
             }
-            Type::GenericAlias(alias) => Ok(Type::instance(ClassType::from(*alias))),
+            Type::GenericAlias(alias) => Ok(Type::instance(db, ClassType::from(*alias))),
 
             Type::SubclassOf(_)
             | Type::BooleanLiteral(_)
@@ -4444,6 +4597,7 @@ impl<'db> Type<'db> {
             | Type::Never
             | Type::FunctionLiteral(_)
             | Type::BoundSuper(_)
+            | Type::ProtocolInstance(_)
             | Type::PropertyInstance(_) => Err(InvalidTypeExpressionError {
                 invalid_expressions: smallvec::smallvec![InvalidTypeExpression::InvalidType(*self)],
                 fallback_type: Type::unknown(),
@@ -4691,6 +4845,7 @@ impl<'db> Type<'db> {
             ),
             Type::AlwaysTruthy | Type::AlwaysFalsy => KnownClass::Type.to_instance(db),
             Type::BoundSuper(_) => KnownClass::Super.to_class_literal(db),
+            Type::ProtocolInstance(protocol) => protocol.to_meta_type(db),
         }
     }
 
@@ -4812,9 +4967,11 @@ impl<'db> Type<'db> {
             | Type::BytesLiteral(_)
             | Type::SliceLiteral(_)
             | Type::BoundSuper(_)
-            // Instance contains a ClassType, which has already been specialized if needed, like
-            // above with BoundMethod's self_instance.
+            // `NominalInstance` contains a ClassType, which has already been specialized if needed,
+            // like above with BoundMethod's self_instance.
             | Type::NominalInstance(_)
+            // Same for `ProtocolInstance`
+            | Type::ProtocolInstance(_)
             | Type::KnownInstance(_) => self,
         }
     }
@@ -4911,6 +5068,11 @@ impl<'db> Type<'db> {
             | Self::Tuple(_) => self.to_meta_type(db).definition(db),
 
             Self::TypeVar(var) => Some(TypeDefinition::TypeVar(var.definition(db))),
+
+            Self::ProtocolInstance(protocol) => match protocol.inner() {
+                Protocol::FromClass(class) => Some(TypeDefinition::Class(class.definition(db))),
+                Protocol::Synthesized(_) => None,
+            },
 
             Self::Union(_) | Self::Intersection(_) => None,
 

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1453,38 +1453,6 @@ impl<'db> Type<'db> {
                 true
             }
 
-            // TODO: This is a workaround to avoid false positives (e.g. when checking function calls
-            // with `SupportsIndex` parameters), which should be removed when we understand protocols.
-            (lhs, Type::NominalInstance(instance))
-                if instance.class().is_known(db, KnownClass::SupportsIndex) =>
-            {
-                match lhs {
-                    Type::NominalInstance(instance)
-                        if matches!(
-                            instance.class().known(db),
-                            Some(KnownClass::Int | KnownClass::SupportsIndex)
-                        ) =>
-                    {
-                        true
-                    }
-                    Type::IntLiteral(_) => true,
-                    _ => false,
-                }
-            }
-
-            // TODO: ditto for avoiding false positives when checking function calls with `Sized` parameters.
-            (lhs, Type::NominalInstance(instance))
-                if instance.class().is_known(db, KnownClass::Sized) =>
-            {
-                matches!(
-                    lhs.to_meta_type(db).member(db, "__len__"),
-                    SymbolAndQualifiers {
-                        symbol: Symbol::Type(..),
-                        ..
-                    }
-                )
-            }
-
             (Type::NominalInstance(self_instance), Type::NominalInstance(target_instance)) => {
                 self_instance.is_assignable_to(db, target_instance)
             }

--- a/crates/red_knot_python_semantic/src/types/builder.rs
+++ b/crates/red_knot_python_semantic/src/types/builder.rs
@@ -591,7 +591,7 @@ impl<'db> InnerIntersectionBuilder<'db> {
             }
             _ => {
                 let known_instance = new_positive
-                    .into_instance()
+                    .into_nominal_instance()
                     .and_then(|instance| instance.class().known(db));
 
                 if known_instance == Some(KnownClass::Object) {
@@ -705,7 +705,7 @@ impl<'db> InnerIntersectionBuilder<'db> {
         let contains_bool = || {
             self.positive
                 .iter()
-                .filter_map(|ty| ty.into_instance())
+                .filter_map(|ty| ty.into_nominal_instance())
                 .filter_map(|instance| instance.class().known(db))
                 .any(KnownClass::is_bool)
         };

--- a/crates/red_knot_python_semantic/src/types/builder.rs
+++ b/crates/red_knot_python_semantic/src/types/builder.rs
@@ -611,7 +611,7 @@ impl<'db> InnerIntersectionBuilder<'db> {
                         Type::AlwaysFalsy if addition_is_bool_instance => {
                             new_positive = Type::BooleanLiteral(false);
                         }
-                        Type::Instance(instance)
+                        Type::NominalInstance(instance)
                             if instance.class().is_known(db, KnownClass::Bool) =>
                         {
                             match new_positive {
@@ -722,7 +722,7 @@ impl<'db> InnerIntersectionBuilder<'db> {
             Type::Never => {
                 // Adding ~Never to an intersection is a no-op.
             }
-            Type::Instance(instance) if instance.class().is_object(db) => {
+            Type::NominalInstance(instance) if instance.class().is_object(db) => {
                 // Adding ~object to an intersection results in Never.
                 *self = Self::default();
                 self.positive.insert(Type::Never);

--- a/crates/red_knot_python_semantic/src/types/class.rs
+++ b/crates/red_knot_python_semantic/src/types/class.rs
@@ -144,6 +144,10 @@ impl<'db> ClassType<'db> {
         }
     }
 
+    pub(super) fn is_protocol(self, db: &'db dyn Db) -> bool {
+        self.class_literal(db).0.is_protocol(db)
+    }
+
     pub(crate) fn name(self, db: &'db dyn Db) -> &'db ast::name::Name {
         let (class_literal, _) = self.class_literal(db);
         class_literal.name(db)
@@ -1076,6 +1080,7 @@ impl<'db> ClassLiteral<'db> {
                     Parameters::new([Parameter::positional_or_keyword(Name::new_static("other"))
                         // TODO: could be `Self`.
                         .with_annotated_type(Type::instance(
+                            db,
                             self.apply_optional_specialization(db, specialization),
                         ))]),
                     Some(KnownClass::Bool.to_instance(db)),
@@ -2084,7 +2089,7 @@ impl<'db> KnownClass {
     pub(crate) fn to_instance(self, db: &'db dyn Db) -> Type<'db> {
         self.to_class_literal(db)
             .to_class_type(db)
-            .map(Type::instance)
+            .map(|class| Type::instance(db, class))
             .unwrap_or_else(Type::unknown)
     }
 

--- a/crates/red_knot_python_semantic/src/types/class.rs
+++ b/crates/red_knot_python_semantic/src/types/class.rs
@@ -144,9 +144,9 @@ impl<'db> ClassType<'db> {
         }
     }
 
-    pub(super) fn is_protocol(self, db: &'db dyn Db) -> bool {
-        self.class_literal(db).0.is_protocol(db)
-    }
+    // pub(super) fn is_protocol(self, db: &'db dyn Db) -> bool {
+    //     self.class_literal(db).0.is_protocol(db)
+    // }
 
     pub(crate) fn name(self, db: &'db dyn Db) -> &'db ast::name::Name {
         let (class_literal, _) = self.class_literal(db);
@@ -1891,9 +1891,26 @@ pub enum KnownClass {
     TypeAliasType,
     NoDefaultType,
     NewType,
-    Sized,
-    // TODO: This can probably be removed when we have support for protocols
+    // TODO: These can probably be removed when we have support for protocols
     SupportsIndex,
+    Sized,
+    SupportsInt,
+    SupportsFloat,
+    SupportsComplex,
+    SupportsBytes,
+    Hashable,
+    SupportsAbs,
+    SupportsRound,
+    Awaitable,
+    Iterable,
+    Iterator,
+    Generator,
+    Reversible,
+    AsyncIterable,
+    AsyncIterator,
+    AsyncGenerator,
+    Container,
+    Collection,
     // Collections
     ChainMap,
     Counter,
@@ -1957,7 +1974,27 @@ impl<'db> KnownClass {
             | Self::GenericAlias
             | Self::NewType
             | Self::StdlibAlias
+
             | Self::SupportsIndex
+            | Self::SupportsInt
+            | Self::SupportsFloat
+            | Self::SupportsComplex
+            | Self::SupportsBytes
+            | Self::Hashable
+            | Self::Sized
+            | Self::SupportsAbs
+            | Self::SupportsRound
+            | Self::Awaitable
+            | Self::Iterable
+            | Self::Iterator
+            | Self::Generator
+            | Self::Reversible
+            | Self::AsyncIterable
+            | Self::AsyncIterator
+            | Self::AsyncGenerator
+            | Self::Container
+            | Self::Collection
+
             | Self::Set
             | Self::Tuple
             | Self::Int
@@ -1976,7 +2013,6 @@ impl<'db> KnownClass {
             | Self::DefaultDict
             | Self::Deque
             | Self::Float
-            | Self::Sized
             | Self::Enum
             | Self::ABCMeta
             // Evaluating `NotImplementedType` in a boolean context was deprecated in Python 3.9
@@ -2027,12 +2063,31 @@ impl<'db> KnownClass {
             Self::TypeAliasType => "TypeAliasType",
             Self::NoDefaultType => "_NoDefaultType",
             Self::NewType => "NewType",
+
             Self::SupportsIndex => "SupportsIndex",
+            Self::SupportsInt => "SupportsInt",
+            Self::SupportsFloat => "SupportsFloat",
+            Self::SupportsComplex => "SupportsComplex",
+            Self::SupportsBytes => "SupportsBytes",
+            Self::Hashable => "Hashable",
+            Self::Sized => "Sized",
+            Self::SupportsAbs => "SupportsAbs",
+            Self::SupportsRound => "SupportsRound",
+            Self::Awaitable => "Awaitable",
+            Self::Iterable => "Iterable",
+            Self::Iterator => "Iterator",
+            Self::Generator => "Generator",
+            Self::Reversible => "Reversible",
+            Self::AsyncIterable => "AsyncIterable",
+            Self::AsyncIterator => "AsyncIterator",
+            Self::AsyncGenerator => "AsyncGenerator",
+            Self::Container => "Container",
+            Self::Collection => "Collection",
+
             Self::ChainMap => "ChainMap",
             Self::Counter => "Counter",
             Self::DefaultDict => "defaultdict",
             Self::Deque => "deque",
-            Self::Sized => "Sized",
             Self::OrderedDict => "OrderedDict",
             Self::Enum => "Enum",
             Self::ABCMeta => "ABCMeta",
@@ -2207,6 +2262,23 @@ impl<'db> KnownClass {
             | Self::TypeVar
             | Self::StdlibAlias
             | Self::SupportsIndex
+            | Self::SupportsInt
+            | Self::SupportsFloat
+            | Self::SupportsComplex
+            | Self::SupportsBytes
+            | Self::Hashable
+            | Self::SupportsAbs
+            | Self::SupportsRound
+            | Self::Awaitable
+            | Self::Iterable
+            | Self::Iterator
+            | Self::Generator
+            | Self::Reversible
+            | Self::AsyncIterable
+            | Self::AsyncIterator
+            | Self::AsyncGenerator
+            | Self::Container
+            | Self::Collection
             | Self::Sized => KnownModule::Typing,
             Self::TypeAliasType
             | Self::TypeVarTuple
@@ -2289,13 +2361,30 @@ impl<'db> KnownClass {
             | Self::Deque
             | Self::OrderedDict
             | Self::SupportsIndex
+            | Self::SupportsInt
+            | Self::SupportsFloat
+            | Self::SupportsComplex
+            | Self::SupportsBytes
+            | Self::Hashable
+            | Self::Sized
+            | Self::SupportsAbs
+            | Self::SupportsRound
+            | Self::Awaitable
+            | Self::Iterable
+            | Self::Iterator
+            | Self::Generator
+            | Self::Reversible
+            | Self::AsyncIterable
+            | Self::AsyncIterator
+            | Self::AsyncGenerator
+            | Self::Container
+            | Self::Collection
             | Self::StdlibAlias
             | Self::TypeVar
             | Self::ParamSpec
             | Self::ParamSpecArgs
             | Self::ParamSpecKwargs
             | Self::TypeVarTuple
-            | Self::Sized
             | Self::Enum
             | Self::ABCMeta
             | Self::Super
@@ -2347,6 +2436,24 @@ impl<'db> KnownClass {
             | Self::OrderedDict
             | Self::StdlibAlias
             | Self::SupportsIndex
+            | Self::SupportsInt
+            | Self::SupportsFloat
+            | Self::SupportsComplex
+            | Self::SupportsBytes
+            | Self::Hashable
+            | Self::Sized
+            | Self::SupportsAbs
+            | Self::SupportsRound
+            | Self::Awaitable
+            | Self::Iterable
+            | Self::Iterator
+            | Self::Generator
+            | Self::Reversible
+            | Self::AsyncIterable
+            | Self::AsyncIterator
+            | Self::AsyncGenerator
+            | Self::Container
+            | Self::Collection
             | Self::BaseException
             | Self::BaseExceptionGroup
             | Self::Classmethod
@@ -2355,7 +2462,6 @@ impl<'db> KnownClass {
             | Self::ParamSpecArgs
             | Self::ParamSpecKwargs
             | Self::TypeVarTuple
-            | Self::Sized
             | Self::Enum
             | Self::ABCMeta
             | Self::Super
@@ -2416,8 +2522,27 @@ impl<'db> KnownClass {
             "_Alias" => Self::StdlibAlias,
             "_SpecialForm" => Self::SpecialForm,
             "_NoDefaultType" => Self::NoDefaultType,
+
             "SupportsIndex" => Self::SupportsIndex,
             "Sized" => Self::Sized,
+            "SupportsInt" => Self::SupportsInt,
+            "SupportsFloat" => Self::SupportsFloat,
+            "SupportsComplex" => Self::SupportsComplex,
+            "SupportsBytes" => Self::SupportsBytes,
+            "Hashable" => Self::Hashable,
+            "SupportsAbs" => Self::SupportsAbs,
+            "SupportsRound" => Self::SupportsRound,
+            "Awaitable" => Self::Awaitable,
+            "Iterable" => Self::Iterable,
+            "Iterator" => Self::Iterator,
+            "Generator" => Self::Generator,
+            "Reversible" => Self::Reversible,
+            "AsyncIterable" => Self::AsyncIterable,
+            "AsyncIterator" => Self::AsyncIterator,
+            "AsyncGenerator" => Self::AsyncGenerator,
+            "Container" => Self::Container,
+            "Collection" => Self::Collection,
+
             "Enum" => Self::Enum,
             "ABCMeta" => Self::ABCMeta,
             "super" => Self::Super,
@@ -2485,13 +2610,107 @@ impl<'db> KnownClass {
             | Self::TypeVar
             | Self::TypeAliasType
             | Self::NoDefaultType
+
             | Self::SupportsIndex
+            | Self::SupportsInt
+            | Self::SupportsFloat
+            | Self::SupportsComplex
+            | Self::SupportsBytes
+            | Self::Hashable
+            | Self::Sized
+            | Self::SupportsAbs
+            | Self::SupportsRound
+            | Self::Awaitable
+            | Self::Iterable
+            | Self::Iterator
+            | Self::Generator
+            | Self::Reversible
+            | Self::AsyncIterable
+            | Self::AsyncIterator
+            | Self::AsyncGenerator
+            | Self::Container
+            | Self::Collection
+
             | Self::ParamSpec
             | Self::ParamSpecArgs
             | Self::ParamSpecKwargs
             | Self::TypeVarTuple
-            | Self::Sized
             | Self::NewType => matches!(module, KnownModule::Typing | KnownModule::TypingExtensions),
+        }
+    }
+
+    pub(super) const fn is_protocol(self) -> bool {
+        match self {
+            Self::SupportsBytes
+            | Self::SupportsIndex
+            | Self::SupportsInt
+            | Self::SupportsFloat
+            | Self::SupportsComplex
+            | Self::Hashable
+            | Self::SupportsAbs
+            | Self::SupportsRound
+            | Self::Awaitable
+            | Self::Iterable
+            | Self::Iterator
+            | Self::Generator
+            | Self::Reversible
+            | Self::AsyncIterable
+            | Self::AsyncIterator
+            | Self::AsyncGenerator
+            | Self::Container
+            | Self::Collection
+            | Self::Sized => true,
+
+            Self::Any
+            | Self::Bool
+            | Self::Object
+            | Self::Bytes
+            | Self::Bytearray
+            | Self::Type
+            | Self::Int
+            | Self::Float
+            | Self::Complex
+            | Self::Str
+            | Self::List
+            | Self::Tuple
+            | Self::Set
+            | Self::FrozenSet
+            | Self::Dict
+            | Self::Slice
+            | Self::Range
+            | Self::Property
+            | Self::GenericAlias
+            | Self::ModuleType
+            | Self::FunctionType
+            | Self::MethodType
+            | Self::MethodWrapperType
+            | Self::UnionType
+            | Self::BaseException
+            | Self::BaseExceptionGroup
+            | Self::Classmethod
+            | Self::SpecialForm
+            | Self::TypeVar
+            | Self::ParamSpec
+            | Self::ParamSpecArgs
+            | Self::ParamSpecKwargs
+            | Self::TypeVarTuple
+            | Self::TypeAliasType
+            | Self::NoDefaultType
+            | Self::NewType
+            | Self::Enum
+            | Self::ABCMeta
+            | Self::Super
+            | Self::StdlibAlias
+            | Self::VersionInfo
+            | Self::ChainMap
+            | Self::Counter
+            | Self::DefaultDict
+            | Self::Deque
+            | Self::OrderedDict
+            | Self::NoneType
+            | Self::EllipsisType
+            | Self::NotImplementedType
+            | Self::WrapperDescriptorType => false,
         }
     }
 }

--- a/crates/red_knot_python_semantic/src/types/class_base.rs
+++ b/crates/red_knot_python_semantic/src/types/class_base.rs
@@ -106,6 +106,7 @@ impl<'db> ClassBase<'db> {
             | Type::SubclassOf(_)
             | Type::TypeVar(_)
             | Type::BoundSuper(_)
+            | Type::ProtocolInstance(_)
             | Type::AlwaysFalsy
             | Type::AlwaysTruthy => None,
             Type::KnownInstance(known_instance) => match known_instance {

--- a/crates/red_knot_python_semantic/src/types/class_base.rs
+++ b/crates/red_knot_python_semantic/src/types/class_base.rs
@@ -78,12 +78,14 @@ impl<'db> ClassBase<'db> {
                 Self::Class(literal.default_specialization(db))
             }),
             Type::GenericAlias(generic) => Some(Self::Class(ClassType::Generic(generic))),
-            Type::Instance(instance) if instance.class().is_known(db, KnownClass::GenericAlias) => {
+            Type::NominalInstance(instance)
+                if instance.class().is_known(db, KnownClass::GenericAlias) =>
+            {
                 Self::try_from_type(db, todo_type!("GenericAlias instance"))
             }
             Type::Union(_) => None, // TODO -- forces consideration of multiple possible MROs?
             Type::Intersection(_) => None, // TODO -- probably incorrect?
-            Type::Instance(_) => None, // TODO -- handle `__mro_entries__`?
+            Type::NominalInstance(_) => None, // TODO -- handle `__mro_entries__`?
             Type::PropertyInstance(_) => None,
             Type::Never
             | Type::BooleanLiteral(_)

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -73,12 +73,14 @@ impl Display for DisplayRepresentation<'_> {
         match self.ty {
             Type::Dynamic(dynamic) => dynamic.fmt(f),
             Type::Never => f.write_str("Never"),
-            Type::Instance(instance) => match (instance.class(), instance.class().known(self.db)) {
-                (_, Some(KnownClass::NoneType)) => f.write_str("None"),
-                (_, Some(KnownClass::NoDefaultType)) => f.write_str("NoDefault"),
-                (ClassType::NonGeneric(class), _) => f.write_str(class.name(self.db)),
-                (ClassType::Generic(alias), _) => write!(f, "{}", alias.display(self.db)),
-            },
+            Type::NominalInstance(instance) => {
+                match (instance.class(), instance.class().known(self.db)) {
+                    (_, Some(KnownClass::NoneType)) => f.write_str("None"),
+                    (_, Some(KnownClass::NoDefaultType)) => f.write_str("NoDefault"),
+                    (ClassType::NonGeneric(class), _) => f.write_str(class.name(self.db)),
+                    (ClassType::Generic(alias), _) => write!(f, "{}", alias.display(self.db)),
+                }
+            }
             Type::PropertyInstance(_) => f.write_str("property"),
             Type::ModuleLiteral(module) => {
                 write!(f, "<module '{}'>", module.module(self.db).name())

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1064,7 +1064,7 @@ impl<'db> TypeInferenceBuilder<'db> {
     ) -> bool {
         match left {
             Type::BooleanLiteral(_) | Type::IntLiteral(_) => {}
-            Type::Instance(instance)
+            Type::NominalInstance(instance)
                 if matches!(
                     instance.class().known(self.db()),
                     Some(KnownClass::Float | KnownClass::Int | KnownClass::Bool)
@@ -2515,7 +2515,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             }
 
             // Super instances do not allow attribute assignment
-            Type::Instance(instance) if instance.class().is_known(db, KnownClass::Super) => {
+            Type::NominalInstance(instance) if instance.class().is_known(db, KnownClass::Super) => {
                 if emit_diagnostics {
                     if let Some(builder) = self.context.report_lint(&INVALID_ASSIGNMENT, target) {
                         builder.into_diagnostic(format_args!(
@@ -2540,7 +2540,7 @@ impl<'db> TypeInferenceBuilder<'db> {
 
             Type::Dynamic(..) | Type::Never => true,
 
-            Type::Instance(..)
+            Type::NominalInstance(..)
             | Type::BooleanLiteral(..)
             | Type::IntLiteral(..)
             | Type::StringLiteral(..)
@@ -3031,7 +3031,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         }
 
         // Handle various singletons.
-        if let Type::Instance(instance) = declared_ty.inner_type() {
+        if let Type::NominalInstance(instance) = declared_ty.inner_type() {
             if instance
                 .class()
                 .is_known(self.db(), KnownClass::SpecialForm)
@@ -5007,7 +5007,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 | Type::ClassLiteral(_)
                 | Type::GenericAlias(_)
                 | Type::SubclassOf(_)
-                | Type::Instance(_)
+                | Type::NominalInstance(_)
                 | Type::KnownInstance(_)
                 | Type::PropertyInstance(_)
                 | Type::Union(_)
@@ -5287,7 +5287,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 | Type::ClassLiteral(_)
                 | Type::GenericAlias(_)
                 | Type::SubclassOf(_)
-                | Type::Instance(_)
+                | Type::NominalInstance(_)
                 | Type::KnownInstance(_)
                 | Type::PropertyInstance(_)
                 | Type::Intersection(_)
@@ -5312,7 +5312,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 | Type::ClassLiteral(_)
                 | Type::GenericAlias(_)
                 | Type::SubclassOf(_)
-                | Type::Instance(_)
+                | Type::NominalInstance(_)
                 | Type::KnownInstance(_)
                 | Type::PropertyInstance(_)
                 | Type::Intersection(_)
@@ -5745,13 +5745,13 @@ impl<'db> TypeInferenceBuilder<'db> {
                     right_ty: right,
                 }),
             },
-            (Type::IntLiteral(_), Type::Instance(_)) => self.infer_binary_type_comparison(
+            (Type::IntLiteral(_), Type::NominalInstance(_)) => self.infer_binary_type_comparison(
                 KnownClass::Int.to_instance(self.db()),
                 op,
                 right,
                 range,
             ),
-            (Type::Instance(_), Type::IntLiteral(_)) => self.infer_binary_type_comparison(
+            (Type::NominalInstance(_), Type::IntLiteral(_)) => self.infer_binary_type_comparison(
                 left,
                 op,
                 KnownClass::Int.to_instance(self.db()),
@@ -5877,7 +5877,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 KnownClass::Bytes.to_instance(self.db()),
                 range,
             ),
-            (Type::Tuple(_), Type::Instance(instance))
+            (Type::Tuple(_), Type::NominalInstance(instance))
                 if instance
                     .class()
                     .is_known(self.db(), KnownClass::VersionInfo) =>
@@ -5889,7 +5889,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                     range,
                 )
             }
-            (Type::Instance(instance), Type::Tuple(_))
+            (Type::NominalInstance(instance), Type::Tuple(_))
                 if instance
                     .class()
                     .is_known(self.db(), KnownClass::VersionInfo) =>
@@ -6275,7 +6275,7 @@ impl<'db> TypeInferenceBuilder<'db> {
     ) -> Type<'db> {
         match (value_ty, slice_ty) {
             (
-                Type::Instance(instance),
+                Type::NominalInstance(instance),
                 Type::IntLiteral(_) | Type::BooleanLiteral(_) | Type::SliceLiteral(_),
             ) if instance
                 .class()
@@ -6576,7 +6576,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 Err(_) => SliceArg::Unsupported,
             },
             Some(Type::BooleanLiteral(b)) => SliceArg::Arg(Some(i32::from(b))),
-            Some(Type::Instance(instance))
+            Some(Type::NominalInstance(instance))
                 if instance.class().is_known(self.db(), KnownClass::NoneType) =>
             {
                 SliceArg::Arg(None)

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2541,6 +2541,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             Type::Dynamic(..) | Type::Never => true,
 
             Type::NominalInstance(..)
+            | Type::ProtocolInstance(_)
             | Type::BooleanLiteral(..)
             | Type::IntLiteral(..)
             | Type::StringLiteral(..)
@@ -5008,6 +5009,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 | Type::GenericAlias(_)
                 | Type::SubclassOf(_)
                 | Type::NominalInstance(_)
+                | Type::ProtocolInstance(_)
                 | Type::KnownInstance(_)
                 | Type::PropertyInstance(_)
                 | Type::Union(_)
@@ -5288,6 +5290,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 | Type::GenericAlias(_)
                 | Type::SubclassOf(_)
                 | Type::NominalInstance(_)
+                | Type::ProtocolInstance(_)
                 | Type::KnownInstance(_)
                 | Type::PropertyInstance(_)
                 | Type::Intersection(_)
@@ -5313,6 +5316,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 | Type::GenericAlias(_)
                 | Type::SubclassOf(_)
                 | Type::NominalInstance(_)
+                | Type::ProtocolInstance(_)
                 | Type::KnownInstance(_)
                 | Type::PropertyInstance(_)
                 | Type::Intersection(_)

--- a/crates/red_knot_python_semantic/src/types/instance.rs
+++ b/crates/red_knot_python_semantic/src/types/instance.rs
@@ -5,12 +5,12 @@ use crate::Db;
 
 impl<'db> Type<'db> {
     pub(crate) const fn instance(class: ClassType<'db>) -> Self {
-        Self::Instance(InstanceType { class })
+        Self::NominalInstance(NominalInstanceType { class })
     }
 
-    pub(crate) const fn into_instance(self) -> Option<InstanceType<'db>> {
+    pub(crate) const fn into_instance(self) -> Option<NominalInstanceType<'db>> {
         match self {
-            Type::Instance(instance_type) => Some(instance_type),
+            Type::NominalInstance(instance_type) => Some(instance_type),
             _ => None,
         }
     }
@@ -18,13 +18,13 @@ impl<'db> Type<'db> {
 
 /// A type representing the set of runtime objects which are instances of a certain nominal class.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, salsa::Update)]
-pub struct InstanceType<'db> {
-    // Keep this field private, so that the only way of constructing `InstanceType` instances
+pub struct NominalInstanceType<'db> {
+    // Keep this field private, so that the only way of constructing `NominalInstanceType` instances
     // is through the `Type::instance` constructor function.
     class: ClassType<'db>,
 }
 
-impl<'db> InstanceType<'db> {
+impl<'db> NominalInstanceType<'db> {
     pub(super) fn class(self) -> ClassType<'db> {
         self.class
     }
@@ -87,8 +87,8 @@ impl<'db> InstanceType<'db> {
     }
 }
 
-impl<'db> From<InstanceType<'db>> for Type<'db> {
-    fn from(value: InstanceType<'db>) -> Self {
-        Self::Instance(value)
+impl<'db> From<NominalInstanceType<'db>> for Type<'db> {
+    fn from(value: NominalInstanceType<'db>) -> Self {
+        Self::NominalInstance(value)
     }
 }

--- a/crates/red_knot_python_semantic/src/types/instance.rs
+++ b/crates/red_knot_python_semantic/src/types/instance.rs
@@ -170,7 +170,7 @@ impl<'db> ProtocolInstanceType<'db> {
     /// TODO: consider the types of the members as well as their existence
     pub(super) fn is_subtype_of(self, db: &'db dyn Db, other: Self) -> bool {
         self.protocol_members(db)
-            .is_subset(other.protocol_members(db))
+            .is_superset(other.protocol_members(db))
     }
 
     /// TODO: consider the types of the members as well as their existence

--- a/crates/red_knot_python_semantic/src/types/instance.rs
+++ b/crates/red_knot_python_semantic/src/types/instance.rs
@@ -138,12 +138,8 @@ impl<'db> ProtocolInstanceType<'db> {
     }
 
     pub(super) fn normalized(self, db: &'db dyn Db) -> Type<'db> {
-        let members = self.protocol_members(db);
         let object = KnownClass::Object.to_instance(db);
-        if members
-            .iter()
-            .all(|member| !object.member(db, member).symbol.is_unbound())
-        {
+        if object.satisfies_protocol(db, self) {
             return object;
         }
         match self.0 {
@@ -180,7 +176,7 @@ impl<'db> ProtocolInstanceType<'db> {
 
     /// TODO: consider the types of the members as well as their existence
     pub(super) fn is_equivalent_to(self, db: &'db dyn Db, other: Self) -> bool {
-        self.protocol_members(db).set_eq(other.protocol_members(db))
+        self.normalized(db) == other.normalized(db)
     }
 
     /// TODO: consider the types of the members as well as their existence

--- a/crates/red_knot_python_semantic/src/types/instance.rs
+++ b/crates/red_knot_python_semantic/src/types/instance.rs
@@ -7,7 +7,7 @@ use crate::{Db, FxOrderSet};
 
 impl<'db> Type<'db> {
     pub(crate) fn instance(db: &'db dyn Db, class: ClassType<'db>) -> Self {
-        if class.is_protocol(db) {
+        if class.known(db).is_some_and(KnownClass::is_protocol) {
             Self::ProtocolInstance(ProtocolInstanceType(Protocol::FromClass(class)))
         } else {
             Self::NominalInstance(NominalInstanceType { class })

--- a/crates/red_knot_python_semantic/src/types/known_instance.rs
+++ b/crates/red_knot_python_semantic/src/types/known_instance.rs
@@ -1,6 +1,6 @@
 //! The `KnownInstance` type.
 //!
-//! Despite its name, this is quite a different type from [`super::InstanceType`].
+//! Despite its name, this is quite a different type from [`super::NominalInstanceType`].
 //! For the vast majority of instance-types in Python, we cannot say how many possible
 //! inhabitants there are or could be of that type at runtime. Each variant of the
 //! [`KnownInstanceType`] enum, however, represents a specific runtime symbol
@@ -249,7 +249,7 @@ impl<'db> KnownInstanceType<'db> {
     ///
     /// For example, the symbol `typing.Literal` is an instance of `typing._SpecialForm`,
     /// so `KnownInstanceType::Literal.instance_fallback(db)`
-    /// returns `Type::Instance(InstanceType { class: <typing._SpecialForm> })`.
+    /// returns `Type::NominalInstance(NominalInstanceType { class: <typing._SpecialForm> })`.
     pub(super) fn instance_fallback(self, db: &dyn Db) -> Type {
         self.class().to_instance(db)
     }

--- a/crates/red_knot_python_semantic/src/types/narrow.rs
+++ b/crates/red_knot_python_semantic/src/types/narrow.rs
@@ -472,7 +472,7 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
                         union.map(db, |ty| filter_to_cannot_be_equal(db, *ty, rhs_ty))
                     }
                     // Treat `bool` as `Literal[True, False]`.
-                    Type::Instance(instance) if instance.class().is_known(db, KnownClass::Bool) => {
+                    Type::NominalInstance(instance) if instance.class().is_known(db, KnownClass::Bool) => {
                         UnionType::from_elements(
                             db,
                             [Type::BooleanLiteral(true), Type::BooleanLiteral(false)]
@@ -501,7 +501,7 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
 
     fn evaluate_expr_ne(&mut self, lhs_ty: Type<'db>, rhs_ty: Type<'db>) -> Option<Type<'db>> {
         match (lhs_ty, rhs_ty) {
-            (Type::Instance(instance), Type::IntLiteral(i))
+            (Type::NominalInstance(instance), Type::IntLiteral(i))
                 if instance.class().is_known(self.db, KnownClass::Bool) =>
             {
                 if i == 0 {

--- a/crates/red_knot_python_semantic/src/types/narrow.rs
+++ b/crates/red_knot_python_semantic/src/types/narrow.rs
@@ -159,7 +159,7 @@ impl KnownConstraintFunction {
     /// union types are not yet supported. Returns `None` if the `classinfo` argument has a wrong type.
     fn generate_constraint<'db>(self, db: &'db dyn Db, classinfo: Type<'db>) -> Option<Type<'db>> {
         let constraint_fn = |class| match self {
-            KnownConstraintFunction::IsInstance => Type::instance(class),
+            KnownConstraintFunction::IsInstance => Type::instance(db, class),
             KnownConstraintFunction::IsSubclass => SubclassOfType::from(db, class),
         };
 
@@ -682,7 +682,7 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
                         let symbol = self.expect_expr_name_symbol(id);
                         constraints.insert(
                             symbol,
-                            Type::instance(rhs_class.unknown_specialization(self.db)),
+                            Type::instance(self.db, rhs_class.unknown_specialization(self.db)),
                         );
                     }
                 }

--- a/crates/red_knot_python_semantic/src/types/narrow.rs
+++ b/crates/red_knot_python_semantic/src/types/narrow.rs
@@ -472,7 +472,9 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
                         union.map(db, |ty| filter_to_cannot_be_equal(db, *ty, rhs_ty))
                     }
                     // Treat `bool` as `Literal[True, False]`.
-                    Type::NominalInstance(instance) if instance.class().is_known(db, KnownClass::Bool) => {
+                    Type::NominalInstance(instance)
+                        if instance.class().is_known(db, KnownClass::Bool) =>
+                    {
                         UnionType::from_elements(
                             db,
                             [Type::BooleanLiteral(true), Type::BooleanLiteral(false)]

--- a/crates/red_knot_python_semantic/src/types/subclass_of.rs
+++ b/crates/red_knot_python_semantic/src/types/subclass_of.rs
@@ -16,8 +16,8 @@ impl<'db> SubclassOfType<'db> {
     /// This method does not always return a [`Type::SubclassOf`] variant.
     /// If the class object is known to be a final class,
     /// this method will return a [`Type::ClassLiteral`] variant; this is a more precise type.
-    /// If the class object is `builtins.object`, `Type::Instance(<builtins.type>)` will be returned;
-    /// this is no more precise, but it is exactly equivalent to `type[object]`.
+    /// If the class object is `builtins.object`, `Type::NominalInstance(<builtins.type>)`
+    /// will be returned; this is no more precise, but it is exactly equivalent to `type[object]`.
     ///
     /// The eager normalization here means that we do not need to worry elsewhere about distinguishing
     /// between `@final` classes and other classes when dealing with [`Type::SubclassOf`] variants.

--- a/crates/red_knot_python_semantic/src/types/subclass_of.rs
+++ b/crates/red_knot_python_semantic/src/types/subclass_of.rs
@@ -94,9 +94,9 @@ impl<'db> SubclassOfType<'db> {
         }
     }
 
-    pub(crate) fn to_instance(self) -> Type<'db> {
+    pub(crate) fn to_instance(self, db: &'db dyn Db) -> Type<'db> {
         match self.subclass_of {
-            SubclassOfInner::Class(class) => Type::instance(class),
+            SubclassOfInner::Class(class) => Type::instance(db, class),
             SubclassOfInner::Dynamic(dynamic_type) => Type::Dynamic(dynamic_type),
         }
     }

--- a/crates/red_knot_python_semantic/src/types/type_ordering.rs
+++ b/crates/red_knot_python_semantic/src/types/type_ordering.rs
@@ -126,10 +126,12 @@ pub(super) fn union_or_intersection_elements_ordering<'db>(
 
         (Type::SubclassOf(_), _) => Ordering::Less,
         (_, Type::SubclassOf(_)) => Ordering::Greater,
-        (Type::Instance(left), Type::Instance(right)) => left.class().cmp(&right.class()),
+        (Type::NominalInstance(left), Type::NominalInstance(right)) => {
+            left.class().cmp(&right.class())
+        }
 
-        (Type::Instance(_), _) => Ordering::Less,
-        (_, Type::Instance(_)) => Ordering::Greater,
+        (Type::NominalInstance(_), _) => Ordering::Less,
+        (_, Type::NominalInstance(_)) => Ordering::Greater,
 
         (Type::TypeVar(left), Type::TypeVar(right)) => left.cmp(right),
         (Type::TypeVar(_), _) => Ordering::Less,

--- a/crates/red_knot_python_semantic/src/types/type_ordering.rs
+++ b/crates/red_knot_python_semantic/src/types/type_ordering.rs
@@ -126,12 +126,20 @@ pub(super) fn union_or_intersection_elements_ordering<'db>(
 
         (Type::SubclassOf(_), _) => Ordering::Less,
         (_, Type::SubclassOf(_)) => Ordering::Greater,
+
         (Type::NominalInstance(left), Type::NominalInstance(right)) => {
             left.class().cmp(&right.class())
         }
-
         (Type::NominalInstance(_), _) => Ordering::Less,
         (_, Type::NominalInstance(_)) => Ordering::Greater,
+
+        (Type::ProtocolInstance(left_proto), Type::ProtocolInstance(right_proto)) => {
+            debug_assert_eq!(*left, left_proto.normalized(db));
+            debug_assert_eq!(*right, right_proto.normalized(db));
+            left_proto.cmp(right_proto)
+        }
+        (Type::ProtocolInstance(_), _) => Ordering::Less,
+        (_, Type::ProtocolInstance(_)) => Ordering::Greater,
 
         (Type::TypeVar(left), Type::TypeVar(right)) => left.cmp(right),
         (Type::TypeVar(_), _) => Ordering::Less,


### PR DESCRIPTION
## Summary

This is a somewhat silly version of https://github.com/astral-sh/ruff/pull/17614 where we pretend that the only protocols in the world are the ones that are defined in the typing module. I'm not intending for this to be merged; I'm mainly interested in seeing if this has any impact on mypy_primer or not.

## Test Plan

`cargo test -p red_knot_python_semantic`
