### PR TITLE
[red-knot] Use 101 exit code when there's at least one diagnostic with severity 'fatal'

### DIFF
--- a/crates/red_knot/src/main.rs
+++ b/crates/red_knot/src/main.rs
@@ -269,12 +269,6 @@ impl MainLoop {
                         .format(terminal_settings.output_format)
                         .color(colored::control::SHOULD_COLORIZE.should_colorize());
 
-                    let min_error_severity = if terminal_settings.error_on_warning {
-                        Severity::Warning
-                    } else {
-                        Severity::Error
-                    };
-
                     if check_revision == revision {
                         if db.project().files(db).is_empty() {
                             tracing::warn!("No python files found under the given path(s)");
@@ -289,13 +283,13 @@ impl MainLoop {
                                 return Ok(ExitStatus::Success);
                             }
                         } else {
-                            let mut failed = false;
+                            let mut max_severity = Severity::Info;
                             let diagnostics_count = result.len();
 
                             for diagnostic in result {
                                 write!(stdout, "{}", diagnostic.display(db, &display_config))?;
 
-                                failed |= diagnostic.severity() >= min_error_severity;
+                                max_severity = max_severity.max(diagnostic.severity());
                             }
 
                             writeln!(
@@ -306,10 +300,17 @@ impl MainLoop {
                             )?;
 
                             if self.watcher.is_none() {
-                                return Ok(if failed {
-                                    ExitStatus::Failure
-                                } else {
-                                    ExitStatus::Success
+                                return Ok(match max_severity {
+                                    Severity::Info => ExitStatus::Success,
+                                    Severity::Warning => {
+                                        if terminal_settings.error_on_warning {
+                                            ExitStatus::Failure
+                                        } else {
+                                            ExitStatus::Success
+                                        }
+                                    }
+                                    Severity::Error => ExitStatus::Failure,
+                                    Severity::Fatal => ExitStatus::Error,
                                 });
                             }
                         }

--- a/crates/red_knot/src/main.rs
+++ b/crates/red_knot/src/main.rs
@@ -169,8 +169,12 @@ pub enum ExitStatus {
     /// Checking was successful but there were errors.
     Failure = 1,
 
-    /// Checking failed.
+    /// Checking failed due to an invocation error (e.g. the current directory no longer exists, incorrect CLI arguments, ...)
     Error = 2,
+
+    /// Internal Red Knot error (panic, or any other error that isn't due to the user using the
+    /// program incorrectly or transient environment errors).
+    InternalError = 101,
 }
 
 impl Termination for ExitStatus {
@@ -310,7 +314,7 @@ impl MainLoop {
                                         }
                                     }
                                     Severity::Error => ExitStatus::Failure,
-                                    Severity::Fatal => ExitStatus::Error,
+                                    Severity::Fatal => ExitStatus::InternalError,
                                 });
                             }
                         }


### PR DESCRIPTION
## Summary

We now capture panics during checking and emit a diagnostic with severity `Fatal` but the CLI
still exits with `ExitStatus::Failure` (1) which makes it indistinguishable from a normal: there are diagnostics. 

This PR changes the implementation to return `ExitStatus::Eror` (which we code to 2)

## Test Plan

I ran red knot on a project where it panics and printed the exit code:

```bash
✦35 ❯ echo $status
2
```
