### PR TITLE
[`pyupgrade`] Add spaces between tokens as necessary to avoid syntax errors in `UP018` autofix

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP018.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP018.py
@@ -84,3 +84,9 @@ str(
     '''Lorem
     ipsum'''  # Comment
 ).foo
+
+# https://github.com/astral-sh/ruff/issues/17606
+bool(True)and None
+int(1)and None
+float(1.)and None
+bool(True)and()

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/native_literals.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/native_literals.rs
@@ -250,14 +250,12 @@ pub(crate) fn native_literals(
             // next to it without any space separating them. Without this check, the fix for this
             // rule would create a syntax error.
             // Ex) `bool(True)and None` no space between `)` and the keyword `and`.
-            if let Ok(token_idx) =
-                tokens.binary_search_by(|token| token.range().end().cmp(&call_range.end()))
+            //
+            // Subtract 1 from the end of the range to include `Rpar` token in the slice.
+            if let [paren_token, next_token, ..] = tokens.after(call_range.sub_end(1.into()).end())
             {
-                let token = &tokens[token_idx];
-                needs_space = tokens.get(token_idx + 1).is_some_and(|next_token| {
-                    next_token.kind().is_keyword()
-                        && token.range().end() == next_token.range().start()
-                });
+                needs_space = next_token.kind().is_keyword()
+                    && paren_token.range().end() == next_token.range().start();
             }
 
             let mut content = match (parent_expr, literal_type, has_unary_op) {

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/native_literals.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/native_literals.rs
@@ -161,13 +161,14 @@ pub(crate) fn native_literals(
                 keywords,
                 range: _,
             },
-        range: _,
+        range: call_range,
     } = call;
 
     if !keywords.is_empty() || args.len() > 1 {
         return;
     }
 
+    let tokens = checker.tokens();
     let semantic = checker.semantic();
 
     let Some(builtin) = semantic.resolve_builtin_symbol(func) else {
@@ -244,7 +245,22 @@ pub(crate) fn native_literals(
 
             let arg_code = checker.locator().slice(arg);
 
-            let content = match (parent_expr, literal_type, has_unary_op) {
+            let mut needs_space = false;
+            // Look for the `Rpar` token of the call expression and check if there is a keyword token right
+            // next to it without any space separating them. Without this check, the fix for this
+            // rule would create a syntax error.
+            // Ex) `bool(True)and None` no space between `)` and the keyword `and`.
+            if let Ok(token_idx) =
+                tokens.binary_search_by(|token| token.range().end().cmp(&call_range.end()))
+            {
+                let token = tokens.get(token_idx).unwrap();
+                needs_space = tokens.get(token_idx + 1).is_some_and(|next_token| {
+                    next_token.kind().is_keyword()
+                        && token.range().end() == next_token.range().start()
+                });
+            }
+
+            let mut content = match (parent_expr, literal_type, has_unary_op) {
                 // Expressions including newlines must be parenthesised to be valid syntax
                 (_, _, true) if find_newline(arg_code).is_some() => format!("({arg_code})"),
 
@@ -264,6 +280,10 @@ pub(crate) fn native_literals(
 
                 _ => arg_code.to_string(),
             };
+
+            if needs_space {
+                content.push(' ');
+            }
 
             let applicability = if checker.comment_ranges().intersects(call.range) {
                 Applicability::Unsafe

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/native_literals.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/native_literals.rs
@@ -253,7 +253,7 @@ pub(crate) fn native_literals(
             if let Ok(token_idx) =
                 tokens.binary_search_by(|token| token.range().end().cmp(&call_range.end()))
             {
-                let token = tokens.get(token_idx).unwrap();
+                let token = &tokens[token_idx];
                 needs_space = tokens.get(token_idx + 1).is_some_and(|next_token| {
                     next_token.kind().is_keyword()
                         && token.range().end() == next_token.range().start()

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP018.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP018.py.snap
@@ -602,6 +602,8 @@ UP018.py:83:1: UP018 [*] Unnecessary `str` call (rewrite as a literal)
 85 | |     ipsum'''  # Comment
 86 | | ).foo
    | |_^ UP018
+87 |
+88 |   # https://github.com/astral-sh/ruff/issues/17606
    |
    = help: Replace with string literal
 
@@ -615,3 +617,80 @@ UP018.py:83:1: UP018 [*] Unnecessary `str` call (rewrite as a literal)
 86    |-).foo
    83 |+'''Lorem
    84 |+    ipsum'''.foo
+87 85 | 
+88 86 | # https://github.com/astral-sh/ruff/issues/17606
+89 87 | bool(True)and None
+
+UP018.py:89:1: UP018 [*] Unnecessary `bool` call (rewrite as a literal)
+   |
+88 | # https://github.com/astral-sh/ruff/issues/17606
+89 | bool(True)and None
+   | ^^^^^^^^^^ UP018
+90 | int(1)and None
+91 | float(1.)and None
+   |
+   = help: Replace with boolean literal
+
+ℹ Safe fix
+86 86 | ).foo
+87 87 | 
+88 88 | # https://github.com/astral-sh/ruff/issues/17606
+89    |-bool(True)and None
+   89 |+True and None
+90 90 | int(1)and None
+91 91 | float(1.)and None
+92 92 | bool(True)and()
+
+UP018.py:90:1: UP018 [*] Unnecessary `int` call (rewrite as a literal)
+   |
+88 | # https://github.com/astral-sh/ruff/issues/17606
+89 | bool(True)and None
+90 | int(1)and None
+   | ^^^^^^ UP018
+91 | float(1.)and None
+92 | bool(True)and()
+   |
+   = help: Replace with integer literal
+
+ℹ Safe fix
+87 87 | 
+88 88 | # https://github.com/astral-sh/ruff/issues/17606
+89 89 | bool(True)and None
+90    |-int(1)and None
+   90 |+1 and None
+91 91 | float(1.)and None
+92 92 | bool(True)and()
+
+UP018.py:91:1: UP018 [*] Unnecessary `float` call (rewrite as a literal)
+   |
+89 | bool(True)and None
+90 | int(1)and None
+91 | float(1.)and None
+   | ^^^^^^^^^ UP018
+92 | bool(True)and()
+   |
+   = help: Replace with float literal
+
+ℹ Safe fix
+88 88 | # https://github.com/astral-sh/ruff/issues/17606
+89 89 | bool(True)and None
+90 90 | int(1)and None
+91    |-float(1.)and None
+   91 |+1. and None
+92 92 | bool(True)and()
+
+UP018.py:92:1: UP018 [*] Unnecessary `bool` call (rewrite as a literal)
+   |
+90 | int(1)and None
+91 | float(1.)and None
+92 | bool(True)and()
+   | ^^^^^^^^^^ UP018
+   |
+   = help: Replace with boolean literal
+
+ℹ Safe fix
+89 89 | bool(True)and None
+90 90 | int(1)and None
+91 91 | float(1.)and None
+92    |-bool(True)and()
+   92 |+True and()


### PR DESCRIPTION
## Summary

Is it better to add another edit in the fix to add the space, or this is fine?
https://github.com/LaBatata101/ruff/blob/032bd2edcb7a3576ac0a69fd193a675639b5ea0e/crates/ruff_linter/src/rules/pyupgrade/rules/native_literals.rs#L284-L286

Fixes #17606

## Test Plan
Snapshot tests.