### PR TITLE
[`pycodestyle`] Fix duplicated diagnostic in `E712`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pycodestyle/E712.py
+++ b/crates/ruff_linter/resources/test/fixtures/pycodestyle/E712.py
@@ -53,3 +53,7 @@ if TrueElement.get_element(True) == TrueElement.get_element(False):
 assert (not foo) in bar
 assert {"x": not foo} in bar
 assert [42, not foo] in bar
+
+# https://github.com/astral-sh/ruff/issues/17582
+if True == True: # No duplicated diagnostic
+    pass

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/literal_comparisons.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/literal_comparisons.rs
@@ -311,6 +311,16 @@ pub(crate) fn literal_comparisons(checker: &Checker, compare: &ast::ExprCompare)
                 if let Expr::BooleanLiteral(ast::ExprBooleanLiteral { value, .. }) = next {
                     match op {
                         EqCmpOp::Eq => {
+                            if let Expr::BooleanLiteral(ast::ExprBooleanLiteral {
+                                value: comparator_value,
+                                ..
+                            }) = comparator
+                            {
+                                if value == comparator_value {
+                                    continue;
+                                }
+                            }
+
                             let cond = if compare.ops.len() == 1 {
                                 Some(SourceCodeSnippet::from_str(
                                     checker.locator().slice(comparator),

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E712_E712.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E712_E712.py.snap
@@ -265,3 +265,20 @@ E712.py:31:4: E712 [*] Avoid equality comparisons to `True`; use `if yield i:` f
 32 32 |       print("even")
 33 33 | 
 34 34 | #: Okay
+
+E712.py:58:4: E712 [*] Avoid equality comparisons to `True`; use `if True:` for truth checks
+   |
+57 | # https://github.com/astral-sh/ruff/issues/17582
+58 | if True == True: # No duplicate error
+   |    ^^^^^^^^^^^^ E712
+59 |     pass
+   |
+   = help: Replace with `True`
+
+ℹ Unsafe fix
+55 55 | assert [42, not foo] in bar
+56 56 | 
+57 57 | # https://github.com/astral-sh/ruff/issues/17582
+58    |-if True == True: # No duplicate error
+   58 |+if True: # No duplicate error
+59 59 |     pass

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E712_E712.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E712_E712.py.snap
@@ -269,7 +269,7 @@ E712.py:31:4: E712 [*] Avoid equality comparisons to `True`; use `if yield i:` f
 E712.py:58:4: E712 [*] Avoid equality comparisons to `True`; use `if True:` for truth checks
    |
 57 | # https://github.com/astral-sh/ruff/issues/17582
-58 | if True == True: # No duplicate error
+58 | if True == True: # No duplicated diagnostic
    |    ^^^^^^^^^^^^ E712
 59 |     pass
    |
@@ -279,6 +279,6 @@ E712.py:58:4: E712 [*] Avoid equality comparisons to `True`; use `if True:` for 
 55 55 | assert [42, not foo] in bar
 56 56 | 
 57 57 | # https://github.com/astral-sh/ruff/issues/17582
-58    |-if True == True: # No duplicate error
-   58 |+if True: # No duplicate error
+58    |-if True == True: # No duplicated diagnostic
+   58 |+if True: # No duplicated diagnostic
 59 59 |     pass


### PR DESCRIPTION


<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Fixes a duplicated diagnostic when both sides of the operator are `True`.
Example:
```python
if True == True:
    ...
```

Let me know if there is another case where this could happen, I couldn't think of any.

Fixes #17582.

## Test Plan

Snapshot tests.
