### PR TITLE
[`flake8-bugbear `] Add fix safety section (`B006`) 

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
@@ -68,6 +68,10 @@ use crate::Locator;
 /// ## Options
 /// - `lint.flake8-bugbear.extend-immutable-calls`
 ///
+/// ## Fix safety
+///
+/// This fix is marked as unsafe as it changes program behavior.
+///
 /// ## References
 /// - [Python documentation: Default Argument Values](https://docs.python.org/3/tutorial/controlflow.html#default-argument-values)
 #[derive(ViolationMetadata)]


### PR DESCRIPTION

## Summary

This PR add the `fix safety` section for rule `B006` in `mutable_argument_default.rs` for #15584 

When applying this rule for fixes, certain changes may alter the original logical behavior. For example:

before:
```
def cache(x, storage=[]):
    storage.append(x)
    return storage

print(cache(1))  # [1]
print(cache(2))  # [1, 2]
```

after:
```
def cache(x, storage=[]):
    storage.append(x)
    return storage

print(cache(1))  # [1]
print(cache(2))  # [2]
```

