### PR TITLE
[`pydocstyle`] Add fix safety section (`D200`) 

### DIFF
--- a/crates/ruff_linter/src/rules/pydocstyle/rules/one_liner.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/one_liner.rs
@@ -27,6 +27,11 @@ use crate::docstrings::Docstring;
 ///     """Return the mean of the given values."""
 /// ```
 ///
+/// ## Fix safety
+///
+/// This fix is marked as unsafe because it may produce a docstring
+/// that exceeds the project's maximum line length
+///
 /// ## References
 /// - [PEP 257 – Docstring Conventions](https://peps.python.org/pep-0257/)
 ///


### PR DESCRIPTION

## Summary

This PR add the `fix safety` section for rule `D200` in `one_liner.rs` for #15584 

I tested several cases, and the rule is generally safe, but there's a possibility that after merging, the length might exceed the project's current single-line length limit.
