### PR TITLE
[`flake8-return`] Fix false-positive for variables used inside nested functions in `RET504`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_return/RET504.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_return/RET504.py
@@ -421,3 +421,12 @@ def func(a: dict[str, int]) -> list[dict[str, int]]:
     if "services" in a:
         services = a["services"]
         return services
+
+# See: https://github.com/astral-sh/ruff/issues/14052
+def outer() -> list[object]:
+    @register
+    async def inner() -> None:
+        print(layout)
+
+    layout = [...]
+    return layout

--- a/crates/ruff_linter/resources/test/fixtures/flake8_return/RET504.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_return/RET504.py
@@ -430,3 +430,21 @@ def outer() -> list[object]:
 
     layout = [...]
     return layout
+
+def outer() -> list[object]:
+    with open("") as f:
+        async def inner() -> None:
+            print(layout)
+
+    layout = [...]
+    return layout
+
+
+def outer() -> list[object]:
+    def inner():
+        with open("") as f:
+            async def inner_inner() -> None:
+                print(layout)
+
+    layout = [...]
+    return layout

--- a/crates/ruff_linter/src/checkers/ast/analyze/bindings.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/bindings.rs
@@ -1,7 +1,7 @@
 use ruff_diagnostics::{Diagnostic, Fix};
 use ruff_text_size::Ranged;
 
-use crate::checkers::ast::{self, Checker};
+use crate::checkers::ast::Checker;
 use crate::codes::Rule;
 use crate::rules::{
     flake8_import_conventions, flake8_pyi, flake8_pytest_style, flake8_return,
@@ -32,10 +32,11 @@ pub(crate) fn bindings(checker: &Checker) {
 
     for (binding_id, binding) in checker.semantic.bindings.iter_enumerated() {
         if checker.enabled(Rule::UnnecessaryAssign) {
-            if let Some(ast::Stmt::FunctionDef(function_def)) =
-                binding.statement(checker.semantic())
-            {
-                flake8_return::rules::unnecessary_assign(checker, function_def);
+            if binding.kind.is_function_definition() {
+                flake8_return::rules::unnecessary_assign(
+                    checker,
+                    binding.statement(checker.semantic()).unwrap(),
+                );
             }
         }
         if checker.enabled(Rule::UnusedVariable) {

--- a/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
@@ -214,7 +214,6 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                 Rule::UnnecessaryReturnNone,
                 Rule::ImplicitReturnValue,
                 Rule::ImplicitReturn,
-                Rule::UnnecessaryAssign,
                 Rule::SuperfluousElseReturn,
                 Rule::SuperfluousElseRaise,
                 Rule::SuperfluousElseContinue,

--- a/crates/ruff_linter/src/rules/flake8_return/rules/function.rs
+++ b/crates/ruff_linter/src/rules/flake8_return/rules/function.rs
@@ -857,10 +857,6 @@ pub(crate) fn function(checker: &Checker, function_def: &ast::StmtFunctionDef) {
         if checker.enabled(Rule::ImplicitReturn) {
             implicit_return(checker, function_def, last_stmt);
         }
-
-        // if checker.enabled(Rule::UnnecessaryAssign) {
-        //     unnecessary_assign(checker, &stack);
-        // }
     } else {
         if checker.enabled(Rule::UnnecessaryReturnNone) {
             // Skip functions that have a return annotation that is not `None`.

--- a/crates/ruff_linter/src/rules/flake8_return/rules/function.rs
+++ b/crates/ruff_linter/src/rules/flake8_return/rules/function.rs
@@ -562,7 +562,10 @@ fn implicit_return(checker: &Checker, function_def: &ast::StmtFunctionDef, stmt:
 }
 
 /// RET504
-pub(crate) fn unnecessary_assign(checker: &Checker, function_def: &ast::StmtFunctionDef) {
+pub(crate) fn unnecessary_assign(checker: &Checker, function_stmt: &Stmt) {
+    let Stmt::FunctionDef(function_def) = function_stmt else {
+        unreachable!();
+    };
     let Some(stack) = create_stack(checker, function_def) else {
         return;
     };

--- a/crates/ruff_linter/src/rules/flake8_return/snapshots/ruff_linter__rules__flake8_return__tests__RET504_RET504.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_return/snapshots/ruff_linter__rules__flake8_return__tests__RET504_RET504.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_return/mod.rs
-snapshot_kind: text
 ---
 RET504.py:6:12: RET504 [*] Unnecessary assignment to `a` before `return` statement
   |
@@ -248,6 +247,8 @@ RET504.py:423:16: RET504 [*] Unnecessary assignment to `services` before `return
 422 |         services = a["services"]
 423 |         return services
     |                ^^^^^^^^ RET504
+424 |
+425 | # See: https://github.com/astral-sh/ruff/issues/14052
     |
     = help: Remove unnecessary assignment
 
@@ -258,3 +259,6 @@ RET504.py:423:16: RET504 [*] Unnecessary assignment to `services` before `return
 422     |-        services = a["services"]
 423     |-        return services
     422 |+        return a["services"]
+424 423 | 
+425 424 | # See: https://github.com/astral-sh/ruff/issues/14052
+426 425 | def outer() -> list[object]:

--- a/crates/ruff_linter/src/rules/flake8_return/snapshots/ruff_linter__rules__flake8_return__tests__RET504_RET504.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_return/snapshots/ruff_linter__rules__flake8_return__tests__RET504_RET504.py.snap
@@ -101,26 +101,6 @@ RET504.py:269:12: RET504 [*] Unnecessary assignment to `val` before `return` sta
 271 270 | 
 272 271 | def str_to_bool(val):
 
-RET504.py:269:12: RET504 [*] Unnecessary assignment to `val` before `return` statement
-    |
-267 |         return val
-268 |     val = 1
-269 |     return val  # RET504
-    |            ^^^ RET504
-    |
-    = help: Remove unnecessary assignment
-
-ℹ Unsafe fix
-265 265 | def str_to_bool(val):
-266 266 |     if isinstance(val, bool):
-267 267 |         return val
-268     |-    val = 1
-269     |-    return val  # RET504
-    268 |+    return 1
-270 269 | 
-271 270 | 
-272 271 | def str_to_bool(val):
-
 RET504.py:321:12: RET504 [*] Unnecessary assignment to `x` before `return` statement
     |
 319 |     with open("foo.txt", "r") as f:
@@ -241,26 +221,6 @@ RET504.py:365:12: RET504 [*] Unnecessary assignment to `D` before `return` state
 367 366 | 
 368 367 | # contextlib suppress in with statement
 
-RET504.py:365:12: RET504 [*] Unnecessary assignment to `D` before `return` statement
-    |
-363 | def mavko_debari(P_kbar):
-364 |     D=0.4853881 + 3.6006116*P - 0.0117368*(P-1.3822)**2
-365 |     return D
-    |            ^ RET504
-    |
-    = help: Remove unnecessary assignment
-
-ℹ Unsafe fix
-361 361 | 
-362 362 | # Regression test for: https://github.com/astral-sh/ruff/issues/7098
-363 363 | def mavko_debari(P_kbar):
-364     |-    D=0.4853881 + 3.6006116*P - 0.0117368*(P-1.3822)**2
-365     |-    return D
-    364 |+    return 0.4853881 + 3.6006116*P - 0.0117368*(P-1.3822)**2
-366 365 | 
-367 366 | 
-368 367 | # contextlib suppress in with statement
-
 RET504.py:400:12: RET504 [*] Unnecessary assignment to `y` before `return` statement
     |
 398 |         x = 1
@@ -280,28 +240,6 @@ RET504.py:400:12: RET504 [*] Unnecessary assignment to `y` before `return` state
 401 400 | 
 402 401 | 
 403 402 | def foo():
-
-RET504.py:423:16: RET504 [*] Unnecessary assignment to `services` before `return` statement
-    |
-421 |     if "services" in a:
-422 |         services = a["services"]
-423 |         return services
-    |                ^^^^^^^^ RET504
-424 |
-425 | # See: https://github.com/astral-sh/ruff/issues/14052
-    |
-    = help: Remove unnecessary assignment
-
-ℹ Unsafe fix
-419 419 | # See: https://github.com/astral-sh/ruff/issues/10732
-420 420 | def func(a: dict[str, int]) -> list[dict[str, int]]:
-421 421 |     if "services" in a:
-422     |-        services = a["services"]
-423     |-        return services
-    422 |+        return a["services"]
-424 423 | 
-425 424 | # See: https://github.com/astral-sh/ruff/issues/14052
-426 425 | def outer() -> list[object]:
 
 RET504.py:423:16: RET504 [*] Unnecessary assignment to `services` before `return` statement
     |

--- a/crates/ruff_linter/src/rules/flake8_return/snapshots/ruff_linter__rules__flake8_return__tests__RET504_RET504.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_return/snapshots/ruff_linter__rules__flake8_return__tests__RET504_RET504.py.snap
@@ -101,6 +101,26 @@ RET504.py:269:12: RET504 [*] Unnecessary assignment to `val` before `return` sta
 271 270 | 
 272 271 | def str_to_bool(val):
 
+RET504.py:269:12: RET504 [*] Unnecessary assignment to `val` before `return` statement
+    |
+267 |         return val
+268 |     val = 1
+269 |     return val  # RET504
+    |            ^^^ RET504
+    |
+    = help: Remove unnecessary assignment
+
+ℹ Unsafe fix
+265 265 | def str_to_bool(val):
+266 266 |     if isinstance(val, bool):
+267 267 |         return val
+268     |-    val = 1
+269     |-    return val  # RET504
+    268 |+    return 1
+270 269 | 
+271 270 | 
+272 271 | def str_to_bool(val):
+
 RET504.py:321:12: RET504 [*] Unnecessary assignment to `x` before `return` statement
     |
 319 |     with open("foo.txt", "r") as f:
@@ -221,6 +241,26 @@ RET504.py:365:12: RET504 [*] Unnecessary assignment to `D` before `return` state
 367 366 | 
 368 367 | # contextlib suppress in with statement
 
+RET504.py:365:12: RET504 [*] Unnecessary assignment to `D` before `return` statement
+    |
+363 | def mavko_debari(P_kbar):
+364 |     D=0.4853881 + 3.6006116*P - 0.0117368*(P-1.3822)**2
+365 |     return D
+    |            ^ RET504
+    |
+    = help: Remove unnecessary assignment
+
+ℹ Unsafe fix
+361 361 | 
+362 362 | # Regression test for: https://github.com/astral-sh/ruff/issues/7098
+363 363 | def mavko_debari(P_kbar):
+364     |-    D=0.4853881 + 3.6006116*P - 0.0117368*(P-1.3822)**2
+365     |-    return D
+    364 |+    return 0.4853881 + 3.6006116*P - 0.0117368*(P-1.3822)**2
+366 365 | 
+367 366 | 
+368 367 | # contextlib suppress in with statement
+
 RET504.py:400:12: RET504 [*] Unnecessary assignment to `y` before `return` statement
     |
 398 |         x = 1
@@ -240,6 +280,28 @@ RET504.py:400:12: RET504 [*] Unnecessary assignment to `y` before `return` state
 401 400 | 
 402 401 | 
 403 402 | def foo():
+
+RET504.py:423:16: RET504 [*] Unnecessary assignment to `services` before `return` statement
+    |
+421 |     if "services" in a:
+422 |         services = a["services"]
+423 |         return services
+    |                ^^^^^^^^ RET504
+424 |
+425 | # See: https://github.com/astral-sh/ruff/issues/14052
+    |
+    = help: Remove unnecessary assignment
+
+ℹ Unsafe fix
+419 419 | # See: https://github.com/astral-sh/ruff/issues/10732
+420 420 | def func(a: dict[str, int]) -> list[dict[str, int]]:
+421 421 |     if "services" in a:
+422     |-        services = a["services"]
+423     |-        return services
+    422 |+        return a["services"]
+424 423 | 
+425 424 | # See: https://github.com/astral-sh/ruff/issues/14052
+426 425 | def outer() -> list[object]:
 
 RET504.py:423:16: RET504 [*] Unnecessary assignment to `services` before `return` statement
     |

--- a/crates/ruff_linter/src/rules/flake8_return/visitor.rs
+++ b/crates/ruff_linter/src/rules/flake8_return/visitor.rs
@@ -186,42 +186,6 @@ impl<'a> Visitor<'a> for ReturnVisitor<'_, 'a> {
     }
 }
 
-pub(super) struct NestedFunctionVisitor<'data> {
-    /// Identifiers used inside nested functions.
-    pub(super) nested_ids: FxHashSet<&'data str>,
-}
-
-impl NestedFunctionVisitor<'_> {
-    pub(super) fn new() -> Self {
-        Self {
-            nested_ids: FxHashSet::default(),
-        }
-    }
-}
-
-impl<'a> Visitor<'a> for NestedFunctionVisitor<'a> {
-    fn visit_stmt(&mut self, stmt: &'a Stmt) {
-        if let Stmt::FunctionDef(ast::StmtFunctionDef { body, .. }) = stmt {
-            for stmt in body {
-                visitor::walk_stmt(self, stmt);
-            }
-        }
-    }
-
-    fn visit_expr(&mut self, expr: &'a Expr) {
-        match expr {
-            Expr::Name(ast::ExprName {
-                ctx: ast::ExprContext::Load,
-                id,
-                ..
-            }) => {
-                self.nested_ids.insert(id.as_str());
-            }
-            _ => visitor::walk_expr(self, expr),
-        }
-    }
-}
-
 /// Returns `true` if the [`With`] statement is known to have a conditional body. In other words:
 /// if the [`With`] statement's body may or may not run.
 ///

--- a/crates/ruff_linter/src/rules/flake8_return/visitor.rs
+++ b/crates/ruff_linter/src/rules/flake8_return/visitor.rs
@@ -186,6 +186,45 @@ impl<'a> Visitor<'a> for ReturnVisitor<'_, 'a> {
     }
 }
 
+pub(super) struct NestedFunctionVisitor<'data> {
+    /// Identifiers used inside nested functions.
+    pub(super) nested_ids: FxHashSet<&'data str>,
+}
+
+impl NestedFunctionVisitor<'_> {
+    pub(super) fn new() -> Self {
+        Self {
+            nested_ids: FxHashSet::default(),
+        }
+    }
+}
+
+impl<'a> Visitor<'a> for NestedFunctionVisitor<'a> {
+    fn visit_stmt(&mut self, stmt: &'a Stmt) {
+        match stmt {
+            Stmt::FunctionDef(ast::StmtFunctionDef { body, .. }) => {
+                for stmt in body {
+                    visitor::walk_stmt(self, stmt);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn visit_expr(&mut self, expr: &'a Expr) {
+        match expr {
+            Expr::Name(ast::ExprName {
+                ctx: ast::ExprContext::Load,
+                id,
+                ..
+            }) => {
+                self.nested_ids.insert(id.as_str());
+            }
+            _ => visitor::walk_expr(self, expr),
+        }
+    }
+}
+
 /// Returns `true` if the [`With`] statement is known to have a conditional body. In other words:
 /// if the [`With`] statement's body may or may not run.
 ///

--- a/crates/ruff_linter/src/rules/flake8_return/visitor.rs
+++ b/crates/ruff_linter/src/rules/flake8_return/visitor.rs
@@ -201,13 +201,10 @@ impl NestedFunctionVisitor<'_> {
 
 impl<'a> Visitor<'a> for NestedFunctionVisitor<'a> {
     fn visit_stmt(&mut self, stmt: &'a Stmt) {
-        match stmt {
-            Stmt::FunctionDef(ast::StmtFunctionDef { body, .. }) => {
-                for stmt in body {
-                    visitor::walk_stmt(self, stmt);
-                }
+        if let Stmt::FunctionDef(ast::StmtFunctionDef { body, .. }) = stmt {
+            for stmt in body {
+                visitor::walk_stmt(self, stmt);
             }
-            _ => {}
         }
     }
 


### PR DESCRIPTION

<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
Fixes #14052.

## Test Plan

<!-- How was it tested? -->
Snapshot tests.