### PR TITLE
[`refurb`] Fix false positive for float and complex numbers in `FURB116`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/refurb/FURB116.py
+++ b/crates/ruff_linter/resources/test/fixtures/refurb/FURB116.py
@@ -17,3 +17,8 @@ print(bin(int(f"{num}"))[2:])  # FURB116 (no autofix)
 ## invalid
 print(oct(0o1337)[1:])
 print(hex(0x1337)[3:])
+
+# https://github.com/astral-sh/ruff/issues/16472
+# float and complex numbers should be ignored
+print(bin(1.0)[2:])
+print(bin(3.14j)[2:])

--- a/crates/ruff_linter/src/rules/refurb/rules/fstring_number_format.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/fstring_number_format.rs
@@ -1,6 +1,6 @@
 use ruff_diagnostics::{Diagnostic, Edit, Fix, FixAvailability, Violation};
 use ruff_macros::{derive_message_formats, ViolationMetadata};
-use ruff_python_ast::{self as ast, Expr, ExprCall};
+use ruff_python_ast::{self as ast, Expr, ExprCall, Number};
 use ruff_text_size::Ranged;
 
 use crate::checkers::ast::Checker;
@@ -109,6 +109,17 @@ pub(crate) fn fstring_number_format(checker: &Checker, subscript: &ast::ExprSubs
     let Some(base) = Base::from_str(id) else {
         return;
     };
+
+    // float and complex numbers are false positives, ignore them.
+    if matches!(
+        arg,
+        Expr::NumberLiteral(ast::ExprNumberLiteral {
+            value: Number::Float(_) | Number::Complex { .. },
+            ..
+        })
+    ) {
+        return;
+    }
 
     // Generate a replacement, if possible.
     let replacement = if matches!(


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Partially fixes #16472. Addresses the false positive for float and complex numbers.

I'm going to fix the other issues in another PR.
<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

Snapshot tests.
<!-- How was it tested? -->
