### PR TITLE
[red-knot] Fix constructor calls on classes with metaclasses 

### DIFF
--- a/crates/red_knot_python_semantic/src/types/class.rs
+++ b/crates/red_knot_python_semantic/src/types/class.rs
@@ -879,12 +879,8 @@ impl<'db> ClassLiteral<'db> {
                         continue;
                     }
 
-                    // HACK: we should implement some more general logic here that supports arbitrary custom
-                    // metaclasses, not just `type` and `ABCMeta`.
-                    if matches!(
-                        class.known(db),
-                        Some(KnownClass::Type | KnownClass::ABCMeta)
-                    ) && policy.meta_class_no_type_fallback()
+                    if matches!(class.known(db), Some(KnownClass::Type))
+                        && policy.meta_class_no_type_fallback()
                     {
                         continue;
                     }

--- a/crates/red_knot_python_semantic/src/types/class.rs
+++ b/crates/red_knot_python_semantic/src/types/class.rs
@@ -879,6 +879,13 @@ impl<'db> ClassLiteral<'db> {
                         continue;
                     }
 
+                    // Some meta-class methods such as `__call__` need special treatment depending on
+                    // whether they are explicitly defined, or inherited from `type.__call__`.
+                    // We use `MemberLookupPolicy::META_CLASS_NO_TYPE_FALLBACK` flag and it's getter
+                    // `policy.meta_class_no_type_fallback` to allow downstream code to check whether
+                    // a custom implementation of such symbol exists on a type.
+                    // E.g. this is currently used in `ClassLiteral::into_callable` which passes this
+                    // policy here through a chain of calls.
                     if matches!(class.known(db), Some(KnownClass::Type))
                         && policy.meta_class_no_type_fallback()
                     {


### PR DESCRIPTION
## Summary

Fixes #17462

Notes:

* We can't get rid of META_CLASS_NO_TYPE_FALLBACK as it is necessary to figure out if a given meta-class has an explicit `__call__` method defined, not inherited from type. This is used in `into_callable` implementation
* I decided that it isn't worth it to create a separate `NO_META_CLASS_FALLBACK` policy flag, and instead hard-code the logic into descriptor protocol, that if `MRO_NO_OBJECT_FALLBACK` is used, we should assume that the lookup is being done for a symbol that is always present on `object` and hence we also assume that it can never be looked up on a meta-class

The last point is not 100% correct, since data-descriptors should theoretically override lookup even for attributes present on `object`. But as of today, `MRO_NO_OBJECT_FALLBACK` is only used for `__new__` which can't be overridden even by a data-descriptor on a meta-class (I've checked runtime behavior).

## Test Plan

Added the failing code example from #17462 to mdtest
