### PR TITLE
[airflow] fix typos `AIR312`

### DIFF
--- a/crates/ruff_linter/src/rules/airflow/rules/suggested_to_move_to_provider_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/suggested_to_move_to_provider_in_3.rs
@@ -137,7 +137,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
         ["airflow", "operators", "datetime", rest @ ("BranchDateTimeOperator" | "target_times_as_dates")] => {
             ProviderReplacement::SourceModuleMovedToProvider {
                 name: (*rest).to_string(),
-                module: "airflow.providers.standard.time.operators.datetime",
+                module: "airflow.providers.standard.operators.datetime",
                 provider: "standard",
                 version: "0.0.1",
             }
@@ -173,7 +173,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
         },
         ["airflow", "operators", "weekday", "BranchDayOfWeekOperator"] => {
             ProviderReplacement::ProviderName {
-                name: "airflow.providers.standard.time.operators.weekday.BranchDayOfWeekOperator",
+                name: "airflow.providers.standard.operators.weekday.BranchDayOfWeekOperator",
                 provider: "standard",
                 version: "0.0.1",
             }
@@ -181,7 +181,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
         ["airflow", "sensors", "date_time", rest @ ("DateTimeSensor" | "DateTimeSensorAsync")] => {
             ProviderReplacement::SourceModuleMovedToProvider {
                 name: (*rest).to_string(),
-                module: "airflow.providers.standard.time.sensors.date_time",
+                module: "airflow.providers.standard.sensors.date_time",
                 provider: "standard",
                 version: "0.0.1",
             }
@@ -202,7 +202,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
         ["airflow", "sensors", "time_sensor", rest @ ("TimeSensor" | "TimeSensorAsync")] => {
             ProviderReplacement::SourceModuleMovedToProvider {
                 name: (*rest).to_string(),
-                module: "airflow.providers.standard.time.sensors.time",
+                module: "airflow.providers.standard.sensors.time",
                 provider: "standard",
                 version: "0.0.1",
             }
@@ -210,13 +210,13 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
         ["airflow", "sensors", "time_delta", rest @ ("TimeDeltaSensor" | "TimeDeltaSensorAsync" | "WaitSensor")] => {
             ProviderReplacement::SourceModuleMovedToProvider {
                 name: (*rest).to_string(),
-                module: "airflow.providers.standard.time.sensors.time_delta",
+                module: "airflow.providers.standard.sensors.time_delta",
                 provider: "standard",
                 version: "0.0.1",
             }
         }
         ["airflow", "sensors", "weekday", "DayOfWeekSensor"] => ProviderReplacement::ProviderName {
-            name: "airflow.providers.standard.time.sensors.weekday.DayOfWeekSensor",
+            name: "airflow.providers.standard.sensors.weekday.DayOfWeekSensor",
             provider: "standard",
             version: "0.0.1",
         },

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR312_AIR312.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR312_AIR312.py.snap
@@ -75,7 +75,7 @@ AIR312.py:36:1: AIR312 `airflow.operators.datetime.BranchDateTimeOperator` is de
 37 | TriggerDagRunLink(), TriggerDagRunOperator()
 38 | EmptyOperator()
    |
-   = help: Install `apache-airflow-providers-standard>=0.0.1` and use `airflow.providers.standard.time.operators.datetime.BranchDateTimeOperator` instead.
+   = help: Install `apache-airflow-providers-standard>=0.0.1` and use `airflow.providers.standard.operators.datetime.BranchDateTimeOperator` instead.
 
 AIR312.py:36:27: AIR312 `airflow.operators.datetime.target_times_as_dates` is deprecated and moved into `standard` provider in Airflow 3.0; It still works in Airflow 3.0 but is expected to be removed in a future version.
    |
@@ -86,7 +86,7 @@ AIR312.py:36:27: AIR312 `airflow.operators.datetime.target_times_as_dates` is de
 37 | TriggerDagRunLink(), TriggerDagRunOperator()
 38 | EmptyOperator()
    |
-   = help: Install `apache-airflow-providers-standard>=0.0.1` and use `airflow.providers.standard.time.operators.datetime.target_times_as_dates` instead.
+   = help: Install `apache-airflow-providers-standard>=0.0.1` and use `airflow.providers.standard.operators.datetime.target_times_as_dates` instead.
 
 AIR312.py:37:1: AIR312 `airflow.operators.trigger_dagrun.TriggerDagRunLink` is deprecated and moved into `standard` provider in Airflow 3.0; It still works in Airflow 3.0 but is expected to be removed in a future version.
    |
@@ -185,7 +185,7 @@ AIR312.py:46:1: AIR312 `airflow.operators.weekday.BranchDayOfWeekOperator` is de
 47 | DateTimeSensor(), DateTimeSensorAsync()
 48 | ExternalTaskMarker(), ExternalTaskSensor(), ExternalTaskSensorLink()
    |
-   = help: Install `apache-airflow-providers-standard>=0.0.1` and use `airflow.providers.standard.time.operators.weekday.BranchDayOfWeekOperator` instead.
+   = help: Install `apache-airflow-providers-standard>=0.0.1` and use `airflow.providers.standard.operators.weekday.BranchDayOfWeekOperator` instead.
 
 AIR312.py:47:1: AIR312 `airflow.sensors.date_time.DateTimeSensor` is deprecated and moved into `standard` provider in Airflow 3.0; It still works in Airflow 3.0 but is expected to be removed in a future version.
    |
@@ -196,7 +196,7 @@ AIR312.py:47:1: AIR312 `airflow.sensors.date_time.DateTimeSensor` is deprecated 
 48 | ExternalTaskMarker(), ExternalTaskSensor(), ExternalTaskSensorLink()
 49 | FileSensor()
    |
-   = help: Install `apache-airflow-providers-standard>=0.0.1` and use `airflow.providers.standard.time.sensors.date_time.DateTimeSensor` instead.
+   = help: Install `apache-airflow-providers-standard>=0.0.1` and use `airflow.providers.standard.sensors.date_time.DateTimeSensor` instead.
 
 AIR312.py:47:19: AIR312 `airflow.sensors.date_time.DateTimeSensorAsync` is deprecated and moved into `standard` provider in Airflow 3.0; It still works in Airflow 3.0 but is expected to be removed in a future version.
    |
@@ -207,7 +207,7 @@ AIR312.py:47:19: AIR312 `airflow.sensors.date_time.DateTimeSensorAsync` is depre
 48 | ExternalTaskMarker(), ExternalTaskSensor(), ExternalTaskSensorLink()
 49 | FileSensor()
    |
-   = help: Install `apache-airflow-providers-standard>=0.0.1` and use `airflow.providers.standard.time.sensors.date_time.DateTimeSensorAsync` instead.
+   = help: Install `apache-airflow-providers-standard>=0.0.1` and use `airflow.providers.standard.sensors.date_time.DateTimeSensorAsync` instead.
 
 AIR312.py:48:1: AIR312 `airflow.sensors.external_task.ExternalTaskMarker` is deprecated and moved into `standard` provider in Airflow 3.0; It still works in Airflow 3.0 but is expected to be removed in a future version.
    |
@@ -262,7 +262,7 @@ AIR312.py:50:1: AIR312 `airflow.sensors.time_sensor.TimeSensor` is deprecated an
 51 | TimeDeltaSensor(), TimeDeltaSensorAsync(), WaitSensor()
 52 | DayOfWeekSensor()
    |
-   = help: Install `apache-airflow-providers-standard>=0.0.1` and use `airflow.providers.standard.time.sensors.time.TimeSensor` instead.
+   = help: Install `apache-airflow-providers-standard>=0.0.1` and use `airflow.providers.standard.sensors.time.TimeSensor` instead.
 
 AIR312.py:50:15: AIR312 `airflow.sensors.time_sensor.TimeSensorAsync` is deprecated and moved into `standard` provider in Airflow 3.0; It still works in Airflow 3.0 but is expected to be removed in a future version.
    |
@@ -273,7 +273,7 @@ AIR312.py:50:15: AIR312 `airflow.sensors.time_sensor.TimeSensorAsync` is depreca
 51 | TimeDeltaSensor(), TimeDeltaSensorAsync(), WaitSensor()
 52 | DayOfWeekSensor()
    |
-   = help: Install `apache-airflow-providers-standard>=0.0.1` and use `airflow.providers.standard.time.sensors.time.TimeSensorAsync` instead.
+   = help: Install `apache-airflow-providers-standard>=0.0.1` and use `airflow.providers.standard.sensors.time.TimeSensorAsync` instead.
 
 AIR312.py:51:1: AIR312 `airflow.sensors.time_delta.TimeDeltaSensor` is deprecated and moved into `standard` provider in Airflow 3.0; It still works in Airflow 3.0 but is expected to be removed in a future version.
    |
@@ -284,7 +284,7 @@ AIR312.py:51:1: AIR312 `airflow.sensors.time_delta.TimeDeltaSensor` is deprecate
 52 | DayOfWeekSensor()
 53 | DagStateTrigger(), WorkflowTrigger()
    |
-   = help: Install `apache-airflow-providers-standard>=0.0.1` and use `airflow.providers.standard.time.sensors.time_delta.TimeDeltaSensor` instead.
+   = help: Install `apache-airflow-providers-standard>=0.0.1` and use `airflow.providers.standard.sensors.time_delta.TimeDeltaSensor` instead.
 
 AIR312.py:51:20: AIR312 `airflow.sensors.time_delta.TimeDeltaSensorAsync` is deprecated and moved into `standard` provider in Airflow 3.0; It still works in Airflow 3.0 but is expected to be removed in a future version.
    |
@@ -295,7 +295,7 @@ AIR312.py:51:20: AIR312 `airflow.sensors.time_delta.TimeDeltaSensorAsync` is dep
 52 | DayOfWeekSensor()
 53 | DagStateTrigger(), WorkflowTrigger()
    |
-   = help: Install `apache-airflow-providers-standard>=0.0.1` and use `airflow.providers.standard.time.sensors.time_delta.TimeDeltaSensorAsync` instead.
+   = help: Install `apache-airflow-providers-standard>=0.0.1` and use `airflow.providers.standard.sensors.time_delta.TimeDeltaSensorAsync` instead.
 
 AIR312.py:51:44: AIR312 `airflow.sensors.time_delta.WaitSensor` is deprecated and moved into `standard` provider in Airflow 3.0; It still works in Airflow 3.0 but is expected to be removed in a future version.
    |
@@ -306,7 +306,7 @@ AIR312.py:51:44: AIR312 `airflow.sensors.time_delta.WaitSensor` is deprecated an
 52 | DayOfWeekSensor()
 53 | DagStateTrigger(), WorkflowTrigger()
    |
-   = help: Install `apache-airflow-providers-standard>=0.0.1` and use `airflow.providers.standard.time.sensors.time_delta.WaitSensor` instead.
+   = help: Install `apache-airflow-providers-standard>=0.0.1` and use `airflow.providers.standard.sensors.time_delta.WaitSensor` instead.
 
 AIR312.py:52:1: AIR312 `airflow.sensors.weekday.DayOfWeekSensor` is deprecated and moved into `standard` provider in Airflow 3.0; It still works in Airflow 3.0 but is expected to be removed in a future version.
    |
@@ -317,7 +317,7 @@ AIR312.py:52:1: AIR312 `airflow.sensors.weekday.DayOfWeekSensor` is deprecated a
 53 | DagStateTrigger(), WorkflowTrigger()
 54 | FileTrigger()
    |
-   = help: Install `apache-airflow-providers-standard>=0.0.1` and use `airflow.providers.standard.time.sensors.weekday.DayOfWeekSensor` instead.
+   = help: Install `apache-airflow-providers-standard>=0.0.1` and use `airflow.providers.standard.sensors.weekday.DayOfWeekSensor` instead.
 
 AIR312.py:53:1: AIR312 `airflow.triggers.external_task.DagStateTrigger` is deprecated and moved into `standard` provider in Airflow 3.0; It still works in Airflow 3.0 but is expected to be removed in a future version.
    |


### PR DESCRIPTION
## Summary

Fix incorrect package path in apache-airflow-providers-standard:
There is no time directory in the package structure.

Before:
```
airflow.providers.standard.time.operators.datetime.BranchDateTimeOperator
```

After:
```
airflow.providers.standard.operators.datetime.BranchDateTimeOperator
```

This change aligns with the actual source code structure in apache-airflow-providers-standard==1.0.0:
https://github.com/apache/airflow/tree/providers-standard/1.0.0/providers/standard/src/airflow/providers/standard


<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

test fixture has been updated
