### PR TITLE
[red-knot] TypedDict: No errors for introspection dunder attributes

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/typed_dict.md
@@ -21,4 +21,7 @@ msg = Message(id=1, content="Hello")
 
 # No errors for yet-unsupported features (`closed`):
 OtherMessage = TypedDict("OtherMessage", {"id": int, "content": str}, closed=True)
+
+reveal_type(Person.__required_keys__)  # revealed: @Todo(TypedDict)
+reveal_type(Message.__required_keys__)  # revealed: @Todo(TypedDict)
 ```

--- a/crates/red_knot_python_semantic/src/types/class_base.rs
+++ b/crates/red_knot_python_semantic/src/types/class_base.rs
@@ -169,9 +169,7 @@ impl<'db> ClassBase<'db> {
                 KnownInstanceType::OrderedDict => {
                     Self::try_from_type(db, KnownClass::OrderedDict.to_class_literal(db))
                 }
-                KnownInstanceType::TypedDict => {
-                    Self::try_from_type(db, KnownClass::Dict.to_class_literal(db))
-                }
+                KnownInstanceType::TypedDict => Self::try_from_type(db, todo_type!("TypedDict")),
                 KnownInstanceType::Callable => {
                     Self::try_from_type(db, todo_type!("Support for Callable as a base class"))
                 }


### PR DESCRIPTION
## Summary

Do not emit errors when accessing introspection dunder attributes such as `__required_keys__` on `TypedDict`s.
