### PR TITLE
[red-knot] Add a new `Type::ProtocolInstance` variant (take 2!)

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/import/builtins.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/import/builtins.md
@@ -7,7 +7,7 @@ Builtin symbols can be explicitly imported:
 ```py
 import builtins
 
-reveal_type(builtins.chr)  # revealed: def chr(i: int | SupportsIndex, /) -> str
+reveal_type(builtins.chr)  # revealed: def chr(i: SupportsIndex, /) -> str
 ```
 
 ## Implicit use of builtin
@@ -15,7 +15,7 @@ reveal_type(builtins.chr)  # revealed: def chr(i: int | SupportsIndex, /) -> str
 Or used implicitly:
 
 ```py
-reveal_type(chr)  # revealed: def chr(i: int | SupportsIndex, /) -> str
+reveal_type(chr)  # revealed: def chr(i: SupportsIndex, /) -> str
 reveal_type(str)  # revealed: Literal[str]
 ```
 

--- a/crates/red_knot_python_semantic/resources/mdtest/protocols.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/protocols.md
@@ -1299,12 +1299,9 @@ class FalsyFooSubclass(FalsyFoo, Protocol):
     y: str
 
 def g(a: Truthy, b: FalsyFoo, c: FalsyFooSubclass):
-    # TODO should be `Literal[True]
-    reveal_type(bool(a))  # revealed: bool
-    # TODO should be `Literal[False]
-    reveal_type(bool(b))  # revealed: bool
-    # TODO should be `Literal[False]
-    reveal_type(bool(c))  # revealed: bool
+    reveal_type(bool(a))  # revealed: Literal[True]
+    reveal_type(bool(b))  # revealed: Literal[False]
+    reveal_type(bool(c))  # revealed: Literal[False]
 ```
 
 It is not sufficient for a protocol to have a callable `__bool__` instance member that returns

--- a/crates/red_knot_python_semantic/resources/mdtest/protocols.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/protocols.md
@@ -1437,6 +1437,26 @@ def g(obj: Callable[[int], str], obj2: CallMeMaybe, obj3: Callable[[str], str]):
     obj3 = obj2  # error: [invalid-assignment]
 ```
 
+## Protocols are never singleton types, and are never single-valued types
+
+It *might* be possible to have a singleton protocol-instance type...?
+
+For example, `WeirdAndWacky` in the following snippet only has a single possible inhabitant: `None`!
+It is thus a singleton type. However, going out of our way to recognise it as such is probably not
+worth it. Such cases should anyway be exceedingly rare and/or contrived.
+
+```py
+from typing import Protocol, Callable
+from knot_extensions import is_singleton, is_single_valued
+
+class WeirdAndWacky(Protocol):
+    @property
+    def __class__(self) -> Callable[[], None]: ...
+
+reveal_type(is_singleton(WeirdAndWacky))  # revealed: Literal[False]
+reveal_type(is_single_valued(WeirdAndWacky))  # revealed: Literal[False]
+```
+
 ## Integration test: `typing.SupportsIndex` and `typing.Sized`
 
 `typing.SupportsIndex` and `typing.Sized` are two protocols that are very commonly used in the wild.

--- a/crates/red_knot_python_semantic/resources/mdtest/protocols.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/protocols.md
@@ -1436,6 +1436,25 @@ def two(some_list: list, some_tuple: tuple[int, str], some_sized: Sized):
     c: Sized = some_sized
 ```
 
+## Regression test: narrowing with self-referential protocols
+
+This snippet caused us to panic on an early version of the implementation for protocols.
+
+```py
+from typing import Protocol
+
+class A(Protocol):
+    def x(self) -> "B | A": ...
+
+class B(Protocol):
+    def y(self): ...
+
+obj = something_unresolvable  # error: [unresolved-reference]
+reveal_type(obj)  # revealed: Unknown
+if isinstance(obj, (B, A)):
+    reveal_type(obj)  # revealed: (Unknown & B) | (Unknown & A)
+```
+
 ## TODO
 
 Add tests for:

--- a/crates/red_knot_python_semantic/resources/mdtest/protocols.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/protocols.md
@@ -1403,25 +1403,34 @@ static_assert(not is_fully_static(NoParameterAnnotation))  # error: [static-asse
 static_assert(not is_fully_static(NoReturnAnnotation))  # error: [static-assert-error]
 ```
 
-## `typing.SupportsIndex` and `typing.Sized`
+## Callable protocols
 
-`typing.SupportsIndex` is already somewhat supported through some special-casing in red-knot.
+An instance of a protocol type is callable if the protocol defines a `__call__` method:
 
 ```py
-from typing import SupportsIndex, Literal
+from typing import Protocol
 
-def _(some_int: int, some_literal_int: Literal[1], some_indexable: SupportsIndex):
+class CallMeMaybe(Protocol):
+    def __call__(self, x: int) -> str: ...
+
+def _(obj: CallMeMaybe):
+    reveal_type(obj(42))  # revealed: str
+    obj("bar")  # error: [invalid-argument-type]
+```
+
+## Integration test: `typing.SupportsIndex` and `typing.Sized`
+
+`typing.SupportsIndex` and `typing.Sized` are two protocols that are very commonly used in the wild.
+
+```py
+from typing import SupportsIndex, Sized, Literal
+
+def one(some_int: int, some_literal_int: Literal[1], some_indexable: SupportsIndex):
     a: SupportsIndex = some_int
     b: SupportsIndex = some_literal_int
     c: SupportsIndex = some_indexable
-```
 
-The same goes for `typing.Sized`:
-
-```py
-from typing import Sized
-
-def _(some_list: list, some_tuple: tuple[int, str], some_sized: Sized):
+def two(some_list: list, some_tuple: tuple[int, str], some_sized: Sized):
     a: Sized = some_list
     b: Sized = some_tuple
     c: Sized = some_sized

--- a/crates/red_knot_python_semantic/resources/mdtest/protocols.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/protocols.md
@@ -1413,9 +1413,28 @@ from typing import Protocol
 class CallMeMaybe(Protocol):
     def __call__(self, x: int) -> str: ...
 
-def _(obj: CallMeMaybe):
+def f(obj: CallMeMaybe):
     reveal_type(obj(42))  # revealed: str
     obj("bar")  # error: [invalid-argument-type]
+```
+
+An instance of a protocol like this can be assignable to a `Callable` type, but only if it has the
+right signature:
+
+```py
+from typing import Callable
+from knot_extensions import is_subtype_of, is_assignable_to, static_assert
+
+static_assert(is_subtype_of(CallMeMaybe, Callable[[int], str]))
+static_assert(is_assignable_to(CallMeMaybe, Callable[[int], str]))
+static_assert(not is_subtype_of(CallMeMaybe, Callable[[str], str]))
+static_assert(not is_assignable_to(CallMeMaybe, Callable[[str], str]))
+static_assert(not is_subtype_of(CallMeMaybe, Callable[[CallMeMaybe, int], str]))
+static_assert(not is_assignable_to(CallMeMaybe, Callable[[CallMeMaybe, int], str]))
+
+def g(obj: Callable[[int], str], obj2: CallMeMaybe, obj3: Callable[[str], str]):
+    obj = obj2
+    obj3 = obj2  # error: [invalid-assignment]
 ```
 
 ## Integration test: `typing.SupportsIndex` and `typing.Sized`

--- a/crates/red_knot_python_semantic/resources/mdtest/protocols.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/protocols.md
@@ -230,7 +230,7 @@ And it is also an error to use `Protocol` in type expressions:
 def f(
     x: Protocol,  # error: [invalid-type-form] "`typing.Protocol` is not allowed in type expressions"
     y: type[Protocol],  # TODO: should emit `[invalid-type-form]` here too
-) -> None:
+):
     reveal_type(x)  # revealed: Unknown
 
     # TODO: should be `type[Unknown]`
@@ -266,9 +266,7 @@ class Bar(typing_extensions.Protocol):
 
 static_assert(typing_extensions.is_protocol(Foo))
 static_assert(typing_extensions.is_protocol(Bar))
-
-# TODO: should pass
-static_assert(is_equivalent_to(Foo, Bar))  # error: [static-assert-error]
+static_assert(is_equivalent_to(Foo, Bar))
 ```
 
 The same goes for `typing.runtime_checkable` and `typing_extensions.runtime_checkable`:
@@ -284,9 +282,7 @@ class RuntimeCheckableBar(typing_extensions.Protocol):
 
 static_assert(typing_extensions.is_protocol(RuntimeCheckableFoo))
 static_assert(typing_extensions.is_protocol(RuntimeCheckableBar))
-
-# TODO: should pass
-static_assert(is_equivalent_to(RuntimeCheckableFoo, RuntimeCheckableBar))  # error: [static-assert-error]
+static_assert(is_equivalent_to(RuntimeCheckableFoo, RuntimeCheckableBar))
 
 # These should not error because the protocols are decorated with `@runtime_checkable`
 isinstance(object(), RuntimeCheckableFoo)
@@ -488,21 +484,20 @@ class HasX(Protocol):
 class Foo:
     x: int
 
-# TODO: these should pass
-static_assert(is_subtype_of(Foo, HasX))  # error: [static-assert-error]
-static_assert(is_assignable_to(Foo, HasX))  # error: [static-assert-error]
+static_assert(is_subtype_of(Foo, HasX))
+static_assert(is_assignable_to(Foo, HasX))
 
 class FooSub(Foo): ...
 
-# TODO: these should pass
-static_assert(is_subtype_of(FooSub, HasX))  # error: [static-assert-error]
-static_assert(is_assignable_to(FooSub, HasX))  # error: [static-assert-error]
+static_assert(is_subtype_of(FooSub, HasX))
+static_assert(is_assignable_to(FooSub, HasX))
 
 class Bar:
     x: str
 
-static_assert(not is_subtype_of(Bar, HasX))
-static_assert(not is_assignable_to(Bar, HasX))
+# TODO: these should pass
+static_assert(not is_subtype_of(Bar, HasX))  # error: [static-assert-error]
+static_assert(not is_assignable_to(Bar, HasX))  # error: [static-assert-error]
 
 class Baz:
     y: int
@@ -524,14 +519,16 @@ class A:
     def x(self) -> int:
         return 42
 
-static_assert(not is_subtype_of(A, HasX))
-static_assert(not is_assignable_to(A, HasX))
+# TODO: these should pass
+static_assert(not is_subtype_of(A, HasX))  # error: [static-assert-error]
+static_assert(not is_assignable_to(A, HasX))  # error: [static-assert-error]
 
 class B:
     x: Final = 42
 
-static_assert(not is_subtype_of(A, HasX))
-static_assert(not is_assignable_to(A, HasX))
+# TODO: these should pass
+static_assert(not is_subtype_of(A, HasX))  # error: [static-assert-error]
+static_assert(not is_assignable_to(A, HasX))  # error: [static-assert-error]
 
 class IntSub(int): ...
 
@@ -541,8 +538,10 @@ class C:
 # due to invariance, a type is only a subtype of `HasX`
 # if its `x` attribute is of type *exactly* `int`:
 # a subclass of `int` does not satisfy the interface
-static_assert(not is_subtype_of(C, HasX))
-static_assert(not is_assignable_to(C, HasX))
+#
+# TODO: these should pass
+static_assert(not is_subtype_of(C, HasX))  # error: [static-assert-error]
+static_assert(not is_assignable_to(C, HasX))  # error: [static-assert-error]
 ```
 
 All attributes on frozen dataclasses and namedtuples are immutable, so instances of these classes
@@ -556,22 +555,23 @@ from typing import NamedTuple
 class MutableDataclass:
     x: int
 
-# TODO: these should pass
-static_assert(is_subtype_of(MutableDataclass, HasX))  # error: [static-assert-error]
-static_assert(is_assignable_to(MutableDataclass, HasX))  # error: [static-assert-error]
+static_assert(is_subtype_of(MutableDataclass, HasX))
+static_assert(is_assignable_to(MutableDataclass, HasX))
 
 @dataclass(frozen=True)
 class ImmutableDataclass:
     x: int
 
-static_assert(not is_subtype_of(ImmutableDataclass, HasX))
-static_assert(not is_assignable_to(ImmutableDataclass, HasX))
+# TODO: these should pass
+static_assert(not is_subtype_of(ImmutableDataclass, HasX))  # error: [static-assert-error]
+static_assert(not is_assignable_to(ImmutableDataclass, HasX))  # error: [static-assert-error]
 
 class NamedTupleWithX(NamedTuple):
     x: int
 
-static_assert(not is_subtype_of(NamedTupleWithX, HasX))
-static_assert(not is_assignable_to(NamedTupleWithX, HasX))
+# TODO: these should pass
+static_assert(not is_subtype_of(NamedTupleWithX, HasX))  # error: [static-assert-error]
+static_assert(not is_assignable_to(NamedTupleWithX, HasX))  # error: [static-assert-error]
 ```
 
 However, a type with a read-write property `x` *does* satisfy the `HasX` protocol. The `HasX`
@@ -590,9 +590,8 @@ class XProperty:
     def x(self, x: int) -> None:
         self._x = x**2
 
-# TODO: these should pass
-static_assert(is_subtype_of(XProperty, HasX))  # error: [static-assert-error]
-static_assert(is_assignable_to(XProperty, HasX))  # error: [static-assert-error]
+static_assert(is_subtype_of(XProperty, HasX))
+static_assert(is_assignable_to(XProperty, HasX))
 ```
 
 Attribute members on protocol classes are allowed to have default values, just like instance
@@ -717,9 +716,8 @@ from typing import Protocol
 
 class UniversalSet(Protocol): ...
 
-# TODO: these should pass
-static_assert(is_assignable_to(object, UniversalSet))  # error: [static-assert-error]
-static_assert(is_subtype_of(object, UniversalSet))  # error: [static-assert-error]
+static_assert(is_assignable_to(object, UniversalSet))
+static_assert(is_subtype_of(object, UniversalSet))
 ```
 
 Which means that `UniversalSet` here is in fact an equivalent type to `object`:
@@ -727,8 +725,7 @@ Which means that `UniversalSet` here is in fact an equivalent type to `object`:
 ```py
 from knot_extensions import is_equivalent_to
 
-# TODO: this should pass
-static_assert(is_equivalent_to(UniversalSet, object))  # error: [static-assert-error]
+static_assert(is_equivalent_to(UniversalSet, object))
 ```
 
 `object` is a subtype of certain other protocols too. Since all fully static types (whether nominal
@@ -739,17 +736,16 @@ means that these protocols are also equivalent to `UniversalSet` and `object`:
 class SupportsStr(Protocol):
     def __str__(self) -> str: ...
 
-# TODO: these should pass
-static_assert(is_equivalent_to(SupportsStr, UniversalSet))  # error: [static-assert-error]
-static_assert(is_equivalent_to(SupportsStr, object))  # error: [static-assert-error]
+static_assert(is_equivalent_to(SupportsStr, UniversalSet))
+static_assert(is_equivalent_to(SupportsStr, object))
 
 class SupportsClass(Protocol):
-    __class__: type
+    @property
+    def __class__(self) -> type: ...
 
-# TODO: these should pass
-static_assert(is_equivalent_to(SupportsClass, UniversalSet))  # error: [static-assert-error]
-static_assert(is_equivalent_to(SupportsClass, SupportsStr))  # error: [static-assert-error]
-static_assert(is_equivalent_to(SupportsClass, object))  # error: [static-assert-error]
+static_assert(is_equivalent_to(SupportsClass, UniversalSet))
+static_assert(is_equivalent_to(SupportsClass, SupportsStr))
+static_assert(is_equivalent_to(SupportsClass, object))
 ```
 
 If a protocol contains members that are not defined on `object`, then that protocol will (like all
@@ -786,8 +782,7 @@ class HasX(Protocol):
 class AlsoHasX(Protocol):
     x: int
 
-# TODO: this should pass
-static_assert(is_equivalent_to(HasX, AlsoHasX))  # error: [static-assert-error]
+static_assert(is_equivalent_to(HasX, AlsoHasX))
 ```
 
 And unions containing equivalent protocols are recognised as equivalent, even when the order is not
@@ -803,8 +798,7 @@ class AlsoHasY(Protocol):
 class A: ...
 class B: ...
 
-# TODO: this should pass
-static_assert(is_equivalent_to(A | HasX | B | HasY, B | AlsoHasY | AlsoHasX | A))  # error: [static-assert-error]
+static_assert(is_equivalent_to(A | HasX | B | HasY, B | AlsoHasY | AlsoHasX | A))
 ```
 
 ## Intersections of protocols
@@ -882,9 +876,9 @@ from knot_extensions import is_subtype_of, is_assignable_to, static_assert, Type
 class HasX(Protocol):
     x: int
 
-# TODO: these should pass
+# TODO: this should pass
 static_assert(is_subtype_of(TypeOf[module], HasX))  # error: [static-assert-error]
-static_assert(is_assignable_to(TypeOf[module], HasX))  # error: [static-assert-error]
+static_assert(is_assignable_to(TypeOf[module], HasX))
 
 class ExplicitProtocolSubtype(HasX, Protocol):
     y: int
@@ -896,9 +890,8 @@ class ImplicitProtocolSubtype(Protocol):
     x: int
     y: str
 
-# TODO: these should pass
-static_assert(is_subtype_of(ImplicitProtocolSubtype, HasX))  # error: [static-assert-error]
-static_assert(is_assignable_to(ImplicitProtocolSubtype, HasX))  # error: [static-assert-error]
+static_assert(is_subtype_of(ImplicitProtocolSubtype, HasX))
+static_assert(is_assignable_to(ImplicitProtocolSubtype, HasX))
 
 class Meta(type):
     x: int
@@ -933,23 +926,24 @@ def f(obj: ClassVarXProto):
 class InstanceAttrX:
     x: int
 
-static_assert(not is_assignable_to(InstanceAttrX, ClassVarXProto))
-static_assert(not is_subtype_of(InstanceAttrX, ClassVarXProto))
+# TODO: these should pass
+static_assert(not is_assignable_to(InstanceAttrX, ClassVarXProto))  # error: [static-assert-error]
+static_assert(not is_subtype_of(InstanceAttrX, ClassVarXProto))  # error: [static-assert-error]
 
 class PropertyX:
     @property
     def x(self) -> int:
         return 42
 
-static_assert(not is_assignable_to(PropertyX, ClassVarXProto))
-static_assert(not is_subtype_of(PropertyX, ClassVarXProto))
+# TODO: these should pass
+static_assert(not is_assignable_to(PropertyX, ClassVarXProto))  # error: [static-assert-error]
+static_assert(not is_subtype_of(PropertyX, ClassVarXProto))  # error: [static-assert-error]
 
 class ClassVarX:
     x: ClassVar[int] = 42
 
-# TODO: these should pass
-static_assert(is_assignable_to(ClassVarX, ClassVarXProto))  # error: [static-assert-error]
-static_assert(is_subtype_of(ClassVarX, ClassVarXProto))  # error: [static-assert-error]
+static_assert(is_assignable_to(ClassVarX, ClassVarXProto))
+static_assert(is_subtype_of(ClassVarX, ClassVarXProto))
 ```
 
 This is mentioned by the
@@ -976,18 +970,16 @@ class HasXProperty(Protocol):
 class XAttr:
     x: int
 
-# TODO: these should pass
-static_assert(is_subtype_of(XAttr, HasXProperty))  # error: [static-assert-error]
-static_assert(is_assignable_to(XAttr, HasXProperty))  # error: [static-assert-error]
+static_assert(is_subtype_of(XAttr, HasXProperty))
+static_assert(is_assignable_to(XAttr, HasXProperty))
 
 class XReadProperty:
     @property
     def x(self) -> int:
         return 42
 
-# TODO: these should pass
-static_assert(is_subtype_of(XReadProperty, HasXProperty))  # error: [static-assert-error]
-static_assert(is_assignable_to(XReadProperty, HasXProperty))  # error: [static-assert-error]
+static_assert(is_subtype_of(XReadProperty, HasXProperty))
+static_assert(is_assignable_to(XReadProperty, HasXProperty))
 
 class XReadWriteProperty:
     @property
@@ -997,22 +989,20 @@ class XReadWriteProperty:
     @x.setter
     def x(self, val: int) -> None: ...
 
-# TODO: these should pass
-static_assert(is_subtype_of(XReadWriteProperty, HasXProperty))  # error: [static-assert-error]
-static_assert(is_assignable_to(XReadWriteProperty, HasXProperty))  # error: [static-assert-error]
+static_assert(is_subtype_of(XReadWriteProperty, HasXProperty))
+static_assert(is_assignable_to(XReadWriteProperty, HasXProperty))
 
 class XClassVar:
     x: ClassVar[int] = 42
 
-static_assert(is_subtype_of(XClassVar, HasXProperty))  # error: [static-assert-error]
-static_assert(is_assignable_to(XClassVar, HasXProperty))  # error: [static-assert-error]
+static_assert(is_subtype_of(XClassVar, HasXProperty))
+static_assert(is_assignable_to(XClassVar, HasXProperty))
 
 class XFinal:
     x: Final = 42
 
-# TODO: these should pass
-static_assert(is_subtype_of(XFinal, HasXProperty))  # error: [static-assert-error]
-static_assert(is_assignable_to(XFinal, HasXProperty))  # error: [static-assert-error]
+static_assert(is_subtype_of(XFinal, HasXProperty))
+static_assert(is_assignable_to(XFinal, HasXProperty))
 ```
 
 A read-only property on a protocol, unlike a mutable attribute, is covariant: `XSub` in the below
@@ -1025,9 +1015,8 @@ class MyInt(int): ...
 class XSub:
     x: MyInt
 
-# TODO: these should pass
-static_assert(is_subtype_of(XSub, HasXProperty))  # error: [static-assert-error]
-static_assert(is_assignable_to(XSub, HasXProperty))  # error: [static-assert-error]
+static_assert(is_subtype_of(XSub, HasXProperty))
+static_assert(is_assignable_to(XSub, HasXProperty))
 ```
 
 A read/write property on a protocol, where the getter returns the same type that the setter takes,
@@ -1043,17 +1032,17 @@ class HasMutableXProperty(Protocol):
 class XAttr:
     x: int
 
-# TODO: these should pass
-static_assert(is_subtype_of(XAttr, HasXProperty))  # error: [static-assert-error]
-static_assert(is_assignable_to(XAttr, HasXProperty))  # error: [static-assert-error]
+static_assert(is_subtype_of(XAttr, HasXProperty))
+static_assert(is_assignable_to(XAttr, HasXProperty))
 
 class XReadProperty:
     @property
     def x(self) -> int:
         return 42
 
-static_assert(not is_subtype_of(XReadProperty, HasXProperty))
-static_assert(not is_assignable_to(XReadProperty, HasXProperty))
+# TODO: these should pass
+static_assert(not is_subtype_of(XReadProperty, HasXProperty))  # error: [static-assert-error]
+static_assert(not is_assignable_to(XReadProperty, HasXProperty))  # error: [static-assert-error]
 
 class XReadWriteProperty:
     @property
@@ -1063,15 +1052,15 @@ class XReadWriteProperty:
     @x.setter
     def x(self, val: int) -> None: ...
 
-# TODO: these should pass
-static_assert(is_subtype_of(XReadWriteProperty, HasXProperty))  # error: [static-assert-error]
-static_assert(is_assignable_to(XReadWriteProperty, HasXProperty))  # error: [static-assert-error]
+static_assert(is_subtype_of(XReadWriteProperty, HasXProperty))
+static_assert(is_assignable_to(XReadWriteProperty, HasXProperty))
 
 class XSub:
     x: MyInt
 
-static_assert(not is_subtype_of(XSub, HasXProperty))
-static_assert(not is_assignable_to(XSub, HasXProperty))
+# TODO: should pass
+static_assert(not is_subtype_of(XSub, HasXProperty))  # error: [static-assert-error]
+static_assert(not is_assignable_to(XSub, HasXProperty))  # error: [static-assert-error]
 ```
 
 A protocol with a read/write property `x` is exactly equivalent to a protocol with a mutable
@@ -1083,16 +1072,13 @@ from knot_extensions import is_equivalent_to
 class HasMutableXAttr(Protocol):
     x: int
 
-# TODO: this should pass
-static_assert(is_equivalent_to(HasMutableXAttr, HasMutableXProperty))  # error: [static-assert-error]
+static_assert(is_equivalent_to(HasMutableXAttr, HasMutableXProperty))
 
-# TODO: these should pass
-static_assert(is_subtype_of(HasMutableXAttr, HasXProperty))  # error: [static-assert-error]
-static_assert(is_assignable_to(HasMutableXAttr, HasXProperty))  # error: [static-assert-error]
+static_assert(is_subtype_of(HasMutableXAttr, HasXProperty))
+static_assert(is_assignable_to(HasMutableXAttr, HasXProperty))
 
-# TODO: these should pass
-static_assert(is_subtype_of(HasMutableXProperty, HasXProperty))  # error: [static-assert-error]
-static_assert(is_assignable_to(HasMutableXProperty, HasXProperty))  # error: [static-assert-error]
+static_assert(is_subtype_of(HasMutableXProperty, HasXProperty))
+static_assert(is_assignable_to(HasMutableXProperty, HasXProperty))
 ```
 
 A read/write property on a protocol, where the setter accepts a subtype of the type returned by the
@@ -1119,9 +1105,8 @@ class HasAsymmetricXProperty(Protocol):
 class XAttr:
     x: int
 
-# TODO: these should pass
-static_assert(is_subtype_of(XAttr, HasAsymmetricXProperty))  # error: [static-assert-error]
-static_assert(is_assignable_to(XAttr, HasAsymmetricXProperty))  # error: [static-assert-error]
+static_assert(is_subtype_of(XAttr, HasAsymmetricXProperty))
+static_assert(is_assignable_to(XAttr, HasAsymmetricXProperty))
 ```
 
 The end conclusion of this is that the getter-returned type of a property is always covariant and
@@ -1132,9 +1117,8 @@ regular mutable attribute, where the implied getter-returned and setter-accepted
 class XAttrSub:
     x: MyInt
 
-# TODO: these should pass
-static_assert(is_subtype_of(XAttrSub, HasAsymmetricXProperty))  # error: [static-assert-error]
-static_assert(is_assignable_to(XAttrSub, HasAsymmetricXProperty))  # error: [static-assert-error]
+static_assert(is_subtype_of(XAttrSub, HasAsymmetricXProperty))
+static_assert(is_assignable_to(XAttrSub, HasAsymmetricXProperty))
 
 class MyIntSub(MyInt):
     pass
@@ -1142,8 +1126,9 @@ class MyIntSub(MyInt):
 class XAttrSubSub:
     x: MyIntSub
 
-static_assert(not is_subtype_of(XAttrSubSub, HasAsymmetricXProperty))
-static_assert(not is_assignable_to(XAttrSubSub, HasAsymmetricXProperty))
+# TODO: should pass
+static_assert(not is_subtype_of(XAttrSubSub, HasAsymmetricXProperty))  # error: [static-assert-error]
+static_assert(not is_assignable_to(XAttrSubSub, HasAsymmetricXProperty))  # error: [static-assert-error]
 ```
 
 An asymmetric property on a protocol can also be satisfied by an asymmetric property on a nominal
@@ -1159,9 +1144,8 @@ class XAsymmetricProperty:
     @x.setter
     def x(self, x: int) -> None: ...
 
-# TODO: these should pass
-static_assert(is_subtype_of(XAsymmetricProperty, HasAsymmetricXProperty))  # error: [static-assert-error]
-static_assert(is_assignable_to(XAsymmetricProperty, HasAsymmetricXProperty))  # error: [static-assert-error]
+static_assert(is_subtype_of(XAsymmetricProperty, HasAsymmetricXProperty))
+static_assert(is_assignable_to(XAsymmetricProperty, HasAsymmetricXProperty))
 ```
 
 A custom descriptor attribute on the nominal class will also suffice:
@@ -1176,9 +1160,8 @@ class Descriptor:
 class XCustomDescriptor:
     x: Descriptor = Descriptor()
 
-# TODO: these should pass
-static_assert(is_subtype_of(XCustomDescriptor, HasAsymmetricXProperty))  # error: [static-assert-error]
-static_assert(is_assignable_to(XCustomDescriptor, HasAsymmetricXProperty))  # error: [static-assert-error]
+static_assert(is_subtype_of(XCustomDescriptor, HasAsymmetricXProperty))
+static_assert(is_assignable_to(XCustomDescriptor, HasAsymmetricXProperty))
 ```
 
 Moreover, a read-only property on a protocol can be satisfied by a nominal class that defines a
@@ -1191,19 +1174,20 @@ class HasGetAttr:
     def __getattr__(self, attr: str) -> int:
         return 42
 
-# TODO: these should pass
-static_assert(is_subtype_of(HasGetAttr, HasXProperty))  # error: [static-assert-error]
-static_assert(is_assignable_to(HasGetAttr, HasXProperty))  # error: [static-assert-error]
+static_assert(is_subtype_of(HasGetAttr, HasXProperty))
+static_assert(is_assignable_to(HasGetAttr, HasXProperty))
 
-static_assert(not is_subtype_of(HasGetAttr, HasMutableXAttr))
-static_assert(not is_subtype_of(HasGetAttr, HasMutableXAttr))
+# TODO: these should pass
+static_assert(not is_subtype_of(HasGetAttr, HasMutableXAttr))  # error: [static-assert-error]
+static_assert(not is_subtype_of(HasGetAttr, HasMutableXAttr))  # error: [static-assert-error]
 
 class HasGetAttrWithUnsuitableReturn:
     def __getattr__(self, attr: str) -> tuple[int, int]:
         return (1, 2)
 
-static_assert(not is_subtype_of(HasGetAttrWithUnsuitableReturn, HasXProperty))
-static_assert(not is_assignable_to(HasGetAttrWithUnsuitableReturn, HasXProperty))
+# TODO: these should pass
+static_assert(not is_subtype_of(HasGetAttrWithUnsuitableReturn, HasXProperty))  # error: [static-assert-error]
+static_assert(not is_assignable_to(HasGetAttrWithUnsuitableReturn, HasXProperty))  # error: [static-assert-error]
 
 class HasGetAttrAndSetAttr:
     def __getattr__(self, attr: str) -> MyInt:
@@ -1211,9 +1195,10 @@ class HasGetAttrAndSetAttr:
 
     def __setattr__(self, attr: str, value: int) -> None: ...
 
+static_assert(is_subtype_of(HasGetAttrAndSetAttr, HasXProperty))
+static_assert(is_assignable_to(HasGetAttrAndSetAttr, HasXProperty))
+
 # TODO: these should pass
-static_assert(is_subtype_of(HasGetAttrAndSetAttr, HasXProperty))  # error: [static-assert-error]
-static_assert(is_assignable_to(HasGetAttrAndSetAttr, HasXProperty))  # error: [static-assert-error]
 static_assert(is_subtype_of(HasGetAttrAndSetAttr, XAsymmetricProperty))  # error: [static-assert-error]
 static_assert(is_assignable_to(HasGetAttrAndSetAttr, XAsymmetricProperty))  # error: [static-assert-error]
 ```
@@ -1314,9 +1299,12 @@ class FalsyFooSubclass(FalsyFoo, Protocol):
     y: str
 
 def g(a: Truthy, b: FalsyFoo, c: FalsyFooSubclass):
-    reveal_type(bool(a))  # revealed: Literal[True]
-    reveal_type(bool(b))  # revealed: Literal[False]
-    reveal_type(bool(c))  # revealed: Literal[False]
+    # TODO should be `Literal[True]
+    reveal_type(bool(a))  # revealed: bool
+    # TODO should be `Literal[False]
+    reveal_type(bool(b))  # revealed: bool
+    # TODO should be `Literal[False]
+    reveal_type(bool(c))  # revealed: bool
 ```
 
 It is not sufficient for a protocol to have a callable `__bool__` instance member that returns
@@ -1363,12 +1351,12 @@ from knot_extensions import is_subtype_of, is_assignable_to
 class NominalWithX:
     x: int = 42
 
-# TODO: these should pass
-static_assert(is_assignable_to(NominalWithX, FullyStatic))  # error: [static-assert-error]
-static_assert(is_assignable_to(NominalWithX, NotFullyStatic))  # error: [static-assert-error]
-static_assert(is_subtype_of(NominalWithX, FullyStatic))  # error: [static-assert-error]
+static_assert(is_assignable_to(NominalWithX, FullyStatic))
+static_assert(is_assignable_to(NominalWithX, NotFullyStatic))
+static_assert(is_subtype_of(NominalWithX, FullyStatic))
 
-static_assert(not is_subtype_of(NominalWithX, NotFullyStatic))
+# TODO: this should pass
+static_assert(not is_subtype_of(NominalWithX, NotFullyStatic))  # error: [static-assert-error]
 ```
 
 Empty protocols are fully static; this follows from the fact that an empty protocol is equivalent to

--- a/crates/red_knot_python_semantic/resources/mdtest/scopes/builtin.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/scopes/builtin.md
@@ -13,7 +13,7 @@ if returns_bool():
     chr: int = 1
 
 def f():
-    reveal_type(chr)  # revealed: int | (def chr(i: int | SupportsIndex, /) -> str)
+    reveal_type(chr)  # revealed: int | (def chr(i: SupportsIndex, /) -> str)
 ```
 
 ## Conditionally global or builtin, with annotation
@@ -28,5 +28,5 @@ if returns_bool():
     chr: int = 1
 
 def f():
-    reveal_type(chr)  # revealed: int | (def chr(i: int | SupportsIndex, /) -> str)
+    reveal_type(chr)  # revealed: int | (def chr(i: SupportsIndex, /) -> str)
 ```

--- a/crates/red_knot_python_semantic/src/symbol.rs
+++ b/crates/red_knot_python_semantic/src/symbol.rs
@@ -1114,7 +1114,7 @@ mod tests {
     fn assert_bound_string_symbol<'db>(db: &'db dyn Db, symbol: Symbol<'db>) {
         assert!(matches!(
             symbol,
-            Symbol::Type(Type::Instance(_), Boundness::Bound)
+            Symbol::Type(Type::NominalInstance(_), Boundness::Bound)
         ));
         assert_eq!(symbol.expect_type(), KnownClass::Str.to_instance(db));
     }

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -5140,7 +5140,8 @@ impl<'db> Type<'db> {
             | Type::BytesLiteral(_)
             | Type::SliceLiteral(_)
             | Type::BoundSuper(_)
-            | Type::Instance(_)
+            | Type::NominalInstance(_)
+            | Type::ProtocolInstance(_)
             | Type::KnownInstance(_) => {}
         }
     }

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1469,38 +1469,6 @@ impl<'db> Type<'db> {
                 true
             }
 
-            // TODO: This is a workaround to avoid false positives (e.g. when checking function calls
-            // with `SupportsIndex` parameters), which should be removed when we understand protocols.
-            (lhs, Type::NominalInstance(instance))
-                if instance.class().is_known(db, KnownClass::SupportsIndex) =>
-            {
-                match lhs {
-                    Type::NominalInstance(instance)
-                        if matches!(
-                            instance.class().known(db),
-                            Some(KnownClass::Int | KnownClass::SupportsIndex)
-                        ) =>
-                    {
-                        true
-                    }
-                    Type::IntLiteral(_) => true,
-                    _ => false,
-                }
-            }
-
-            // TODO: ditto for avoiding false positives when checking function calls with `Sized` parameters.
-            (lhs, Type::NominalInstance(instance))
-                if instance.class().is_known(db, KnownClass::Sized) =>
-            {
-                matches!(
-                    lhs.to_meta_type(db).member(db, "__len__"),
-                    SymbolAndQualifiers {
-                        symbol: Symbol::Type(..),
-                        ..
-                    }
-                )
-            }
-
             (Type::NominalInstance(self_instance), Type::NominalInstance(target_instance)) => {
                 self_instance.is_assignable_to(db, target_instance)
             }

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -4132,7 +4132,7 @@ impl<'db> Type<'db> {
                 SubclassOfInner::Class(class) => Type::from(class).signatures(db),
             },
 
-            Type::NominalInstance(_) => {
+            Type::NominalInstance(_) | Type::ProtocolInstance(_) => {
                 // Note that for objects that have a (possibly not callable!) `__call__` attribute,
                 // we will get the signature of the `__call__` attribute, but will pass in the type
                 // of the original object as the "callable type". That ensures that we get errors

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1167,12 +1167,6 @@ impl<'db> Type<'db> {
                 false
             }
 
-            (Type::Callable(_), _) => {
-                // TODO: Implement subtyping between callable types and other types like
-                // function literals, bound methods, class literals, `type[]`, etc.)
-                false
-            }
-
             (Type::NominalInstance(_) | Type::ProtocolInstance(_), Type::Callable(_)) => {
                 let call_symbol = self.member(db, "__call__").symbol;
                 match call_symbol {
@@ -1189,6 +1183,12 @@ impl<'db> Type<'db> {
             // TODO: `Callable` types are also structural types.
             (Type::ProtocolInstance(_), _) => false,
             (_, Type::ProtocolInstance(protocol)) => self.satisfies_protocol(db, protocol),
+
+            (Type::Callable(_), _) => {
+                // TODO: Implement subtyping between callable types and other types like
+                // function literals, bound methods, class literals, `type[]`, etc.)
+                false
+            }
 
             // A fully static heterogeneous tuple type `A` is a subtype of a fully static heterogeneous tuple type `B`
             // iff the two tuple types have the same number of elements and each element-type in `A` is a subtype

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1,4 +1,3 @@
-use instance::{Protocol, ProtocolInstanceType};
 use itertools::Either;
 
 use std::slice::Iter;
@@ -52,7 +51,8 @@ pub(crate) use crate::types::narrow::infer_narrowing_constraint;
 use crate::types::signatures::{Parameter, ParameterForm, Parameters};
 use crate::{Db, FxOrderSet, Module, Program};
 pub(crate) use class::{ClassLiteral, ClassType, GenericAlias, KnownClass};
-pub(crate) use instance::NominalInstanceType;
+use instance::Protocol;
+pub(crate) use instance::{NominalInstanceType, ProtocolInstanceType};
 pub(crate) use known_instance::KnownInstanceType;
 
 mod builder;

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -899,6 +899,7 @@ impl<'db> Type<'db> {
     ///   as these are irrelevant to whether a callable type `X` is equivalent to a callable type `Y`.
     /// - Strips the types of default values from parameters in `Callable` types: only whether a parameter
     ///   *has* or *does not have* a default value is relevant to whether two `Callable` types  are equivalent.
+    /// - Converts class-based protocols into synthesized protocols
     #[must_use]
     pub fn normalized(self, db: &'db dyn Db) -> Self {
         match self {
@@ -1602,13 +1603,6 @@ impl<'db> Type<'db> {
             }
             _ => false,
         }
-    }
-
-    fn satisfies_protocol(self, db: &'db dyn Db, protocol: ProtocolInstanceType<'db>) -> bool {
-        protocol
-            .protocol_members(db)
-            .iter()
-            .all(|member| !self.member(db, member).symbol.is_unbound())
     }
 
     /// Return true if this type and `other` have no common elements.

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -492,6 +492,7 @@ pub enum Type<'db> {
     /// Construct this variant using the `Type::instance` constructor function.
     NominalInstance(NominalInstanceType<'db>),
     /// The set of Python objects that conform to the interface described by a given protocol.
+    /// Construct this variant using the `Type::instance` constructor function.
     ProtocolInstance(ProtocolInstanceType<'db>),
     /// A single Python object that requires special treatment in the type system
     KnownInstance(KnownInstanceType<'db>),
@@ -1180,7 +1181,6 @@ impl<'db> Type<'db> {
                 left.is_subtype_of(db, right)
             }
             // A protocol instance can never be a subtype of a nominal type, with the *sole* exception of `object`.
-            // TODO: `Callable` types are also structural types.
             (Type::ProtocolInstance(_), _) => false,
             (_, Type::ProtocolInstance(protocol)) => self.satisfies_protocol(db, protocol),
 
@@ -1510,7 +1510,6 @@ impl<'db> Type<'db> {
             // Other than the dynamic types such as `Any`/`Unknown`/`Todo` handled above,
             // a protocol instance can never be assignable to a nominal type,
             // with the *sole* exception of `object`.
-            // TODO: `Callable` types are also structural types.
             (Type::ProtocolInstance(_), _) => false,
             (_, Type::ProtocolInstance(protocol)) => self.satisfies_protocol(db, protocol),
 
@@ -1537,8 +1536,8 @@ impl<'db> Type<'db> {
             (Type::NominalInstance(left), Type::NominalInstance(right)) => {
                 left.is_equivalent_to(db, right)
             }
-            (Type::ProtocolInstance(first), Type::ProtocolInstance(right)) => {
-                first.is_equivalent_to(db, right)
+            (Type::ProtocolInstance(left), Type::ProtocolInstance(right)) => {
+                left.is_equivalent_to(db, right)
             }
             (Type::ProtocolInstance(protocol), nominal @ Type::NominalInstance(n))
             | (nominal @ Type::NominalInstance(n), Type::ProtocolInstance(protocol)) => {
@@ -1594,8 +1593,8 @@ impl<'db> Type<'db> {
                 first.is_gradual_equivalent_to(db, second)
             }
 
-            (Type::ProtocolInstance(first), Type::ProtocolInstance(right)) => {
-                first.is_gradual_equivalent_to(db, right)
+            (Type::ProtocolInstance(first), Type::ProtocolInstance(second)) => {
+                first.is_gradual_equivalent_to(db, second)
             }
             (Type::ProtocolInstance(protocol), nominal @ Type::NominalInstance(n))
             | (nominal @ Type::NominalInstance(n), Type::ProtocolInstance(protocol)) => {

--- a/crates/red_knot_python_semantic/src/types/builder.rs
+++ b/crates/red_knot_python_semantic/src/types/builder.rs
@@ -591,7 +591,7 @@ impl<'db> InnerIntersectionBuilder<'db> {
             }
             _ => {
                 let known_instance = new_positive
-                    .into_instance()
+                    .into_nominal_instance()
                     .and_then(|instance| instance.class().known(db));
 
                 if known_instance == Some(KnownClass::Object) {
@@ -705,7 +705,7 @@ impl<'db> InnerIntersectionBuilder<'db> {
         let contains_bool = || {
             self.positive
                 .iter()
-                .filter_map(|ty| ty.into_instance())
+                .filter_map(|ty| ty.into_nominal_instance())
                 .filter_map(|instance| instance.class().known(db))
                 .any(KnownClass::is_bool)
         };

--- a/crates/red_knot_python_semantic/src/types/builder.rs
+++ b/crates/red_knot_python_semantic/src/types/builder.rs
@@ -611,7 +611,7 @@ impl<'db> InnerIntersectionBuilder<'db> {
                         Type::AlwaysFalsy if addition_is_bool_instance => {
                             new_positive = Type::BooleanLiteral(false);
                         }
-                        Type::Instance(instance)
+                        Type::NominalInstance(instance)
                             if instance.class().is_known(db, KnownClass::Bool) =>
                         {
                             match new_positive {
@@ -722,7 +722,7 @@ impl<'db> InnerIntersectionBuilder<'db> {
             Type::Never => {
                 // Adding ~Never to an intersection is a no-op.
             }
-            Type::Instance(instance) if instance.class().is_object(db) => {
+            Type::NominalInstance(instance) if instance.class().is_object(db) => {
                 // Adding ~object to an intersection results in Never.
                 *self = Self::default();
                 self.positive.insert(Type::Never);

--- a/crates/red_knot_python_semantic/src/types/class.rs
+++ b/crates/red_knot_python_semantic/src/types/class.rs
@@ -144,6 +144,10 @@ impl<'db> ClassType<'db> {
         }
     }
 
+    pub(super) fn is_protocol(self, db: &'db dyn Db) -> bool {
+        self.class_literal(db).0.is_protocol(db)
+    }
+
     pub(crate) fn name(self, db: &'db dyn Db) -> &'db ast::name::Name {
         let (class_literal, _) = self.class_literal(db);
         class_literal.name(db)
@@ -1076,6 +1080,7 @@ impl<'db> ClassLiteral<'db> {
                     Parameters::new([Parameter::positional_or_keyword(Name::new_static("other"))
                         // TODO: could be `Self`.
                         .with_annotated_type(Type::instance(
+                            db,
                             self.apply_optional_specialization(db, specialization),
                         ))]),
                     Some(KnownClass::Bool.to_instance(db)),
@@ -2084,7 +2089,7 @@ impl<'db> KnownClass {
     pub(crate) fn to_instance(self, db: &'db dyn Db) -> Type<'db> {
         self.to_class_literal(db)
             .to_class_type(db)
-            .map(Type::instance)
+            .map(|class| Type::instance(db, class))
             .unwrap_or_else(Type::unknown)
     }
 

--- a/crates/red_knot_python_semantic/src/types/class.rs
+++ b/crates/red_knot_python_semantic/src/types/class.rs
@@ -1907,8 +1907,6 @@ pub enum KnownClass {
     TypeAliasType,
     NoDefaultType,
     NewType,
-    Sized,
-    // TODO: This can probably be removed when we have support for protocols
     SupportsIndex,
     // Collections
     ChainMap,
@@ -1992,7 +1990,6 @@ impl<'db> KnownClass {
             | Self::DefaultDict
             | Self::Deque
             | Self::Float
-            | Self::Sized
             | Self::Enum
             | Self::ABCMeta
             // Evaluating `NotImplementedType` in a boolean context was deprecated in Python 3.9
@@ -2017,7 +2014,7 @@ impl<'db> KnownClass {
     /// 2. It's probably more performant.
     const fn is_protocol(self) -> bool {
         match self {
-            Self::SupportsIndex | Self::Sized => true,
+            Self::SupportsIndex => true,
 
             Self::Any
             | Self::Bool
@@ -2117,7 +2114,6 @@ impl<'db> KnownClass {
             Self::Counter => "Counter",
             Self::DefaultDict => "defaultdict",
             Self::Deque => "deque",
-            Self::Sized => "Sized",
             Self::OrderedDict => "OrderedDict",
             Self::Enum => "Enum",
             Self::ABCMeta => "ABCMeta",
@@ -2291,8 +2287,7 @@ impl<'db> KnownClass {
             | Self::SpecialForm
             | Self::TypeVar
             | Self::StdlibAlias
-            | Self::SupportsIndex
-            | Self::Sized => KnownModule::Typing,
+            | Self::SupportsIndex => KnownModule::Typing,
             Self::TypeAliasType
             | Self::TypeVarTuple
             | Self::ParamSpec
@@ -2380,7 +2375,6 @@ impl<'db> KnownClass {
             | Self::ParamSpecArgs
             | Self::ParamSpecKwargs
             | Self::TypeVarTuple
-            | Self::Sized
             | Self::Enum
             | Self::ABCMeta
             | Self::Super
@@ -2440,7 +2434,6 @@ impl<'db> KnownClass {
             | Self::ParamSpecArgs
             | Self::ParamSpecKwargs
             | Self::TypeVarTuple
-            | Self::Sized
             | Self::Enum
             | Self::ABCMeta
             | Self::Super
@@ -2502,7 +2495,6 @@ impl<'db> KnownClass {
             "_SpecialForm" => Self::SpecialForm,
             "_NoDefaultType" => Self::NoDefaultType,
             "SupportsIndex" => Self::SupportsIndex,
-            "Sized" => Self::Sized,
             "Enum" => Self::Enum,
             "ABCMeta" => Self::ABCMeta,
             "super" => Self::Super,
@@ -2575,7 +2567,6 @@ impl<'db> KnownClass {
             | Self::ParamSpecArgs
             | Self::ParamSpecKwargs
             | Self::TypeVarTuple
-            | Self::Sized
             | Self::NewType => matches!(module, KnownModule::Typing | KnownModule::TypingExtensions),
         }
     }

--- a/crates/red_knot_python_semantic/src/types/class.rs
+++ b/crates/red_knot_python_semantic/src/types/class.rs
@@ -144,10 +144,6 @@ impl<'db> ClassType<'db> {
         }
     }
 
-    pub(super) fn is_protocol(self, db: &'db dyn Db) -> bool {
-        self.class_literal(db).0.is_protocol(db)
-    }
-
     pub(crate) fn name(self, db: &'db dyn Db) -> &'db ast::name::Name {
         let (class_literal, _) = self.class_literal(db);
         class_literal.name(db)

--- a/crates/red_knot_python_semantic/src/types/class.rs
+++ b/crates/red_knot_python_semantic/src/types/class.rs
@@ -1726,7 +1726,7 @@ impl<'db> ProtocolClassLiteral<'db> {
     /// It is illegal for a protocol class to have any instance attributes that are not declared
     /// in the protocol's class body. If any are assigned to, they are not taken into account in
     /// the protocol's list of members.
-    pub(super) fn protocol_members(self, db: &'db dyn Db) -> FxOrderSet<Name> {
+    pub(super) fn protocol_members(self, db: &'db dyn Db) -> &'db FxOrderSet<Name> {
         /// The list of excluded members is subject to change between Python versions,
         /// especially for dunders, but it probably doesn't matter *too* much if this
         /// list goes out of date. It's up to date as of Python commit 87b1ea016b1454b1e83b9113fa9435849b7743aa
@@ -1763,52 +1763,60 @@ impl<'db> ProtocolClassLiteral<'db> {
             )
         }
 
-        let mut members = FxOrderSet::default();
+        #[salsa::tracked(return_ref)]
+        fn cached_protocol_members<'db>(
+            db: &'db dyn Db,
+            class: ClassLiteral<'db>,
+        ) -> FxOrderSet<Name> {
+            let mut members = FxOrderSet::default();
 
-        for parent_protocol in self
-            .iter_mro(db, None)
-            .filter_map(ClassBase::into_class)
-            .filter_map(|class| class.class_literal(db).0.into_protocol_class(db))
-        {
-            let parent_scope = parent_protocol.body_scope(db);
-            let use_def_map = use_def_map(db, parent_scope);
-            let symbol_table = symbol_table(db, parent_scope);
+            for parent_protocol in class
+                .iter_mro(db, None)
+                .filter_map(ClassBase::into_class)
+                .filter_map(|class| class.class_literal(db).0.into_protocol_class(db))
+            {
+                let parent_scope = parent_protocol.body_scope(db);
+                let use_def_map = use_def_map(db, parent_scope);
+                let symbol_table = symbol_table(db, parent_scope);
 
-            members.extend(
-                use_def_map
-                    .all_public_declarations()
-                    .flat_map(|(symbol_id, declarations)| {
-                        symbol_from_declarations(db, declarations).map(|symbol| (symbol_id, symbol))
-                    })
-                    .filter_map(|(symbol_id, symbol)| {
-                        symbol.symbol.ignore_possibly_unbound().map(|_| symbol_id)
-                    })
-                    // Bindings in the class body that are not declared in the class body
-                    // are not valid protocol members, and we plan to emit diagnostics for them
-                    // elsewhere. Invalid or not, however, it's important that we still consider
-                    // them to be protocol members. The implementation of `issubclass()` and
-                    // `isinstance()` for runtime-checkable protocols considers them to be protocol
-                    // members at runtime, and it's important that we accurately understand
-                    // type narrowing that uses `isinstance()` or `issubclass()` with
-                    // runtime-checkable protocols.
-                    .chain(
-                        use_def_map
-                            .all_public_bindings()
-                            .filter_map(|(symbol_id, bindings)| {
+                members.extend(
+                    use_def_map
+                        .all_public_declarations()
+                        .flat_map(|(symbol_id, declarations)| {
+                            symbol_from_declarations(db, declarations)
+                                .map(|symbol| (symbol_id, symbol))
+                        })
+                        .filter_map(|(symbol_id, symbol)| {
+                            symbol.symbol.ignore_possibly_unbound().map(|_| symbol_id)
+                        })
+                        // Bindings in the class body that are not declared in the class body
+                        // are not valid protocol members, and we plan to emit diagnostics for them
+                        // elsewhere. Invalid or not, however, it's important that we still consider
+                        // them to be protocol members. The implementation of `issubclass()` and
+                        // `isinstance()` for runtime-checkable protocols considers them to be protocol
+                        // members at runtime, and it's important that we accurately understand
+                        // type narrowing that uses `isinstance()` or `issubclass()` with
+                        // runtime-checkable protocols.
+                        .chain(use_def_map.all_public_bindings().filter_map(
+                            |(symbol_id, bindings)| {
                                 symbol_from_bindings(db, bindings)
                                     .ignore_possibly_unbound()
                                     .map(|_| symbol_id)
-                            }),
-                    )
-                    .map(|symbol_id| symbol_table.symbol(symbol_id).name())
-                    .filter(|name| !excluded_from_proto_members(name))
-                    .cloned(),
-            );
+                            },
+                        ))
+                        .map(|symbol_id| symbol_table.symbol(symbol_id).name())
+                        .filter(|name| !excluded_from_proto_members(name))
+                        .cloned(),
+                );
+            }
+
+            members.sort();
+            members.shrink_to_fit();
+            members
         }
 
-        members.sort();
-        members.shrink_to_fit();
-        members
+        let _span = tracing::trace_span!("protocol_members", "class='{}'", self.name(db)).entered();
+        cached_protocol_members(db, *self)
     }
 
     pub(super) fn is_runtime_checkable(self, db: &'db dyn Db) -> bool {

--- a/crates/red_knot_python_semantic/src/types/class.rs
+++ b/crates/red_knot_python_semantic/src/types/class.rs
@@ -145,6 +145,16 @@ impl<'db> ClassType<'db> {
     }
 
     pub(super) fn is_protocol(self, db: &'db dyn Db) -> bool {
+        // We need to construct the types "instance of `str`" and "instance of `_version_info`"
+        // very eagerly when type-checking a variety of things. That means we can't go through the normal
+        // `ClassLiteral::is_protocol` path, because that would require us to evaluate the types of the bases
+        // of these classes, which would cause Salsa cycles (or other, more exotic kinds of Salsa panics!).
+        if matches!(
+            self.known(db),
+            Some(KnownClass::Str | KnownClass::VersionInfo)
+        ) {
+            return false;
+        }
         self.class_literal(db).0.is_protocol(db)
     }
 

--- a/crates/red_knot_python_semantic/src/types/class_base.rs
+++ b/crates/red_knot_python_semantic/src/types/class_base.rs
@@ -106,6 +106,7 @@ impl<'db> ClassBase<'db> {
             | Type::SubclassOf(_)
             | Type::TypeVar(_)
             | Type::BoundSuper(_)
+            | Type::ProtocolInstance(_)
             | Type::AlwaysFalsy
             | Type::AlwaysTruthy => None,
             Type::KnownInstance(known_instance) => match known_instance {

--- a/crates/red_knot_python_semantic/src/types/class_base.rs
+++ b/crates/red_knot_python_semantic/src/types/class_base.rs
@@ -78,12 +78,14 @@ impl<'db> ClassBase<'db> {
                 Self::Class(literal.default_specialization(db))
             }),
             Type::GenericAlias(generic) => Some(Self::Class(ClassType::Generic(generic))),
-            Type::Instance(instance) if instance.class().is_known(db, KnownClass::GenericAlias) => {
+            Type::NominalInstance(instance)
+                if instance.class().is_known(db, KnownClass::GenericAlias) =>
+            {
                 Self::try_from_type(db, todo_type!("GenericAlias instance"))
             }
             Type::Union(_) => None, // TODO -- forces consideration of multiple possible MROs?
             Type::Intersection(_) => None, // TODO -- probably incorrect?
-            Type::Instance(_) => None, // TODO -- handle `__mro_entries__`?
+            Type::NominalInstance(_) => None, // TODO -- handle `__mro_entries__`?
             Type::PropertyInstance(_) => None,
             Type::Never
             | Type::BooleanLiteral(_)

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -73,12 +73,14 @@ impl Display for DisplayRepresentation<'_> {
         match self.ty {
             Type::Dynamic(dynamic) => dynamic.fmt(f),
             Type::Never => f.write_str("Never"),
-            Type::Instance(instance) => match (instance.class(), instance.class().known(self.db)) {
-                (_, Some(KnownClass::NoneType)) => f.write_str("None"),
-                (_, Some(KnownClass::NoDefaultType)) => f.write_str("NoDefault"),
-                (ClassType::NonGeneric(class), _) => f.write_str(class.name(self.db)),
-                (ClassType::Generic(alias), _) => write!(f, "{}", alias.display(self.db)),
-            },
+            Type::NominalInstance(instance) => {
+                match (instance.class(), instance.class().known(self.db)) {
+                    (_, Some(KnownClass::NoneType)) => f.write_str("None"),
+                    (_, Some(KnownClass::NoDefaultType)) => f.write_str("NoDefault"),
+                    (ClassType::NonGeneric(class), _) => f.write_str(class.name(self.db)),
+                    (ClassType::Generic(alias), _) => write!(f, "{}", alias.display(self.db)),
+                }
+            }
             Type::PropertyInstance(_) => f.write_str("property"),
             Type::ModuleLiteral(module) => {
                 write!(f, "<module '{}'>", module.module(self.db).name())

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -783,6 +783,7 @@ mod tests {
     use ruff_python_ast::name::Name;
 
     use crate::db::tests::setup_db;
+    use crate::symbol::typing_extensions_symbol;
     use crate::types::{
         KnownClass, Parameter, Parameters, Signature, SliceLiteralType, StringLiteralType, Type,
     };
@@ -851,6 +852,31 @@ mod tests {
                 .display(&db)
                 .to_string(),
             r#"Literal["\""]"#
+        );
+    }
+
+    #[test]
+    fn synthesized_protocol_display() {
+        let db = setup_db();
+
+        // Call `.normalized()` to turn the class-based protocol into a nameless synthesized one.
+        let supports_index_synthesized = KnownClass::SupportsIndex.to_instance(&db).normalized(&db);
+        assert_eq!(
+            supports_index_synthesized.display(&db).to_string(),
+            "<Protocol with members '__index__'>"
+        );
+
+        let iterator_synthesized = typing_extensions_symbol(&db, "Iterator")
+            .symbol
+            .ignore_possibly_unbound()
+            .unwrap()
+            .to_instance(&db)
+            .unwrap()
+            .normalized(&db); // Call `.normalized()` to turn the class-based protocol into a nameless synthesized one.
+
+        assert_eq!(
+            iterator_synthesized.display(&db).to_string(),
+            "<Protocol with members '__iter__', '__next__'>"
         );
     }
 

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -10,15 +10,12 @@ use crate::types::class::{ClassLiteral, ClassType, GenericAlias};
 use crate::types::generics::{GenericContext, Specialization};
 use crate::types::signatures::{Parameter, Parameters, Signature};
 use crate::types::{
-    FunctionSignature, IntersectionType, KnownClass, MethodWrapperKind, StringLiteralType,
-    SubclassOfInner, Type, TypeVarBoundOrConstraints, TypeVarInstance, UnionType,
-    WrapperDescriptorKind,
+    CallableType, FunctionSignature, IntersectionType, KnownClass, MethodWrapperKind, Protocol,
+    StringLiteralType, SubclassOfInner, Type, TypeVarBoundOrConstraints, TypeVarInstance,
+    UnionType, WrapperDescriptorKind,
 };
 use crate::Db;
 use rustc_hash::FxHashMap;
-
-use super::instance::Protocol;
-use super::CallableType;
 
 impl<'db> Type<'db> {
     pub fn display(&self, db: &'db dyn Db) -> DisplayType {

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1065,7 +1065,7 @@ impl<'db> TypeInferenceBuilder<'db> {
     ) -> bool {
         match left {
             Type::BooleanLiteral(_) | Type::IntLiteral(_) => {}
-            Type::Instance(instance)
+            Type::NominalInstance(instance)
                 if matches!(
                     instance.class().known(self.db()),
                     Some(KnownClass::Float | KnownClass::Int | KnownClass::Bool)
@@ -2517,7 +2517,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             }
 
             // Super instances do not allow attribute assignment
-            Type::Instance(instance) if instance.class().is_known(db, KnownClass::Super) => {
+            Type::NominalInstance(instance) if instance.class().is_known(db, KnownClass::Super) => {
                 if emit_diagnostics {
                     if let Some(builder) = self.context.report_lint(&INVALID_ASSIGNMENT, target) {
                         builder.into_diagnostic(format_args!(
@@ -2542,7 +2542,7 @@ impl<'db> TypeInferenceBuilder<'db> {
 
             Type::Dynamic(..) | Type::Never => true,
 
-            Type::Instance(..)
+            Type::NominalInstance(..)
             | Type::BooleanLiteral(..)
             | Type::IntLiteral(..)
             | Type::StringLiteral(..)
@@ -3033,7 +3033,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         }
 
         // Handle various singletons.
-        if let Type::Instance(instance) = declared_ty.inner_type() {
+        if let Type::NominalInstance(instance) = declared_ty.inner_type() {
             if instance
                 .class()
                 .is_known(self.db(), KnownClass::SpecialForm)
@@ -5125,7 +5125,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 | Type::ClassLiteral(_)
                 | Type::GenericAlias(_)
                 | Type::SubclassOf(_)
-                | Type::Instance(_)
+                | Type::NominalInstance(_)
                 | Type::KnownInstance(_)
                 | Type::PropertyInstance(_)
                 | Type::Union(_)
@@ -5405,7 +5405,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 | Type::ClassLiteral(_)
                 | Type::GenericAlias(_)
                 | Type::SubclassOf(_)
-                | Type::Instance(_)
+                | Type::NominalInstance(_)
                 | Type::KnownInstance(_)
                 | Type::PropertyInstance(_)
                 | Type::Intersection(_)
@@ -5430,7 +5430,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 | Type::ClassLiteral(_)
                 | Type::GenericAlias(_)
                 | Type::SubclassOf(_)
-                | Type::Instance(_)
+                | Type::NominalInstance(_)
                 | Type::KnownInstance(_)
                 | Type::PropertyInstance(_)
                 | Type::Intersection(_)
@@ -5863,13 +5863,13 @@ impl<'db> TypeInferenceBuilder<'db> {
                     right_ty: right,
                 }),
             },
-            (Type::IntLiteral(_), Type::Instance(_)) => self.infer_binary_type_comparison(
+            (Type::IntLiteral(_), Type::NominalInstance(_)) => self.infer_binary_type_comparison(
                 KnownClass::Int.to_instance(self.db()),
                 op,
                 right,
                 range,
             ),
-            (Type::Instance(_), Type::IntLiteral(_)) => self.infer_binary_type_comparison(
+            (Type::NominalInstance(_), Type::IntLiteral(_)) => self.infer_binary_type_comparison(
                 left,
                 op,
                 KnownClass::Int.to_instance(self.db()),
@@ -5995,7 +5995,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 KnownClass::Bytes.to_instance(self.db()),
                 range,
             ),
-            (Type::Tuple(_), Type::Instance(instance))
+            (Type::Tuple(_), Type::NominalInstance(instance))
                 if instance
                     .class()
                     .is_known(self.db(), KnownClass::VersionInfo) =>
@@ -6007,7 +6007,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                     range,
                 )
             }
-            (Type::Instance(instance), Type::Tuple(_))
+            (Type::NominalInstance(instance), Type::Tuple(_))
                 if instance
                     .class()
                     .is_known(self.db(), KnownClass::VersionInfo) =>
@@ -6393,7 +6393,7 @@ impl<'db> TypeInferenceBuilder<'db> {
     ) -> Type<'db> {
         match (value_ty, slice_ty) {
             (
-                Type::Instance(instance),
+                Type::NominalInstance(instance),
                 Type::IntLiteral(_) | Type::BooleanLiteral(_) | Type::SliceLiteral(_),
             ) if instance
                 .class()
@@ -6699,7 +6699,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 Err(_) => SliceArg::Unsupported,
             },
             Some(Type::BooleanLiteral(b)) => SliceArg::Arg(Some(i32::from(b))),
-            Some(Type::Instance(instance))
+            Some(Type::NominalInstance(instance))
                 if instance.class().is_known(self.db(), KnownClass::NoneType) =>
             {
                 SliceArg::Arg(None)

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2543,6 +2543,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             Type::Dynamic(..) | Type::Never => true,
 
             Type::NominalInstance(..)
+            | Type::ProtocolInstance(_)
             | Type::BooleanLiteral(..)
             | Type::IntLiteral(..)
             | Type::StringLiteral(..)
@@ -5126,6 +5127,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 | Type::GenericAlias(_)
                 | Type::SubclassOf(_)
                 | Type::NominalInstance(_)
+                | Type::ProtocolInstance(_)
                 | Type::KnownInstance(_)
                 | Type::PropertyInstance(_)
                 | Type::Union(_)
@@ -5406,6 +5408,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 | Type::GenericAlias(_)
                 | Type::SubclassOf(_)
                 | Type::NominalInstance(_)
+                | Type::ProtocolInstance(_)
                 | Type::KnownInstance(_)
                 | Type::PropertyInstance(_)
                 | Type::Intersection(_)
@@ -5431,6 +5434,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 | Type::GenericAlias(_)
                 | Type::SubclassOf(_)
                 | Type::NominalInstance(_)
+                | Type::ProtocolInstance(_)
                 | Type::KnownInstance(_)
                 | Type::PropertyInstance(_)
                 | Type::Intersection(_)

--- a/crates/red_knot_python_semantic/src/types/instance.rs
+++ b/crates/red_knot_python_semantic/src/types/instance.rs
@@ -5,12 +5,12 @@ use crate::Db;
 
 impl<'db> Type<'db> {
     pub(crate) const fn instance(class: ClassType<'db>) -> Self {
-        Self::Instance(InstanceType { class })
+        Self::NominalInstance(NominalInstanceType { class })
     }
 
-    pub(crate) const fn into_instance(self) -> Option<InstanceType<'db>> {
+    pub(crate) const fn into_instance(self) -> Option<NominalInstanceType<'db>> {
         match self {
-            Type::Instance(instance_type) => Some(instance_type),
+            Type::NominalInstance(instance_type) => Some(instance_type),
             _ => None,
         }
     }
@@ -18,13 +18,13 @@ impl<'db> Type<'db> {
 
 /// A type representing the set of runtime objects which are instances of a certain nominal class.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, salsa::Update)]
-pub struct InstanceType<'db> {
-    // Keep this field private, so that the only way of constructing `InstanceType` instances
+pub struct NominalInstanceType<'db> {
+    // Keep this field private, so that the only way of constructing `NominalInstanceType` instances
     // is through the `Type::instance` constructor function.
     class: ClassType<'db>,
 }
 
-impl<'db> InstanceType<'db> {
+impl<'db> NominalInstanceType<'db> {
     pub(super) fn class(self) -> ClassType<'db> {
         self.class
     }
@@ -87,8 +87,8 @@ impl<'db> InstanceType<'db> {
     }
 }
 
-impl<'db> From<InstanceType<'db>> for Type<'db> {
-    fn from(value: InstanceType<'db>) -> Self {
-        Self::Instance(value)
+impl<'db> From<NominalInstanceType<'db>> for Type<'db> {
+    fn from(value: NominalInstanceType<'db>) -> Self {
+        Self::NominalInstance(value)
     }
 }

--- a/crates/red_knot_python_semantic/src/types/instance.rs
+++ b/crates/red_knot_python_semantic/src/types/instance.rs
@@ -170,7 +170,7 @@ impl<'db> ProtocolInstanceType<'db> {
     /// TODO: consider the types of the members as well as their existence
     pub(super) fn is_subtype_of(self, db: &'db dyn Db, other: Self) -> bool {
         self.protocol_members(db)
-            .is_subset(other.protocol_members(db))
+            .is_superset(other.protocol_members(db))
     }
 
     /// TODO: consider the types of the members as well as their existence

--- a/crates/red_knot_python_semantic/src/types/instance.rs
+++ b/crates/red_knot_python_semantic/src/types/instance.rs
@@ -208,12 +208,18 @@ impl<'db> Protocol<'db> {
     #[salsa::tracked(return_ref)]
     fn protocol_members(self, db: &'db dyn Db) -> FxOrderSet<Name> {
         match self {
-            Self::FromClass(class) => class
-                .class_literal(db)
-                .0
-                .into_protocol_class(db)
-                .expect("Protocol class literal should be a protocol class")
-                .protocol_members(db),
+            Self::FromClass(class) => {
+                let class = class
+                    .class_literal(db)
+                    .0
+                    .into_protocol_class(db)
+                    .expect("Protocol class literal should be a protocol class");
+
+                let _span = tracing::trace_span!("protocol_members", "class='{}'", class.name(db))
+                    .entered();
+
+                class.protocol_members(db)
+            }
             Self::Synthesized(synthesized) => synthesized.members(db).clone(),
         }
     }

--- a/crates/red_knot_python_semantic/src/types/instance.rs
+++ b/crates/red_knot_python_semantic/src/types/instance.rs
@@ -138,12 +138,8 @@ impl<'db> ProtocolInstanceType<'db> {
     }
 
     pub(super) fn normalized(self, db: &'db dyn Db) -> Type<'db> {
-        let members = self.protocol_members(db);
         let object = KnownClass::Object.to_instance(db);
-        if members
-            .iter()
-            .all(|member| !object.member(db, member).symbol.is_unbound())
-        {
+        if object.satisfies_protocol(db, self) {
             return object;
         }
         match self.0 {
@@ -180,7 +176,7 @@ impl<'db> ProtocolInstanceType<'db> {
 
     /// TODO: consider the types of the members as well as their existence
     pub(super) fn is_equivalent_to(self, db: &'db dyn Db, other: Self) -> bool {
-        self.protocol_members(db).set_eq(other.protocol_members(db))
+        self.normalized(db) == other.normalized(db)
     }
 
     /// TODO: consider the types of the members as well as their existence

--- a/crates/red_knot_python_semantic/src/types/instance.rs
+++ b/crates/red_knot_python_semantic/src/types/instance.rs
@@ -22,6 +22,9 @@ impl<'db> Type<'db> {
     }
 
     /// Return `true` if `self` conforms to the interface described by `protocol`.
+    ///
+    /// TODO: we may need to split this into two methods in the future, once we start
+    /// differentiating between fully-static and non-fully-static protocols.
     pub(super) fn satisfies_protocol(
         self,
         db: &'db dyn Db,

--- a/crates/red_knot_python_semantic/src/types/instance.rs
+++ b/crates/red_knot_python_semantic/src/types/instance.rs
@@ -205,22 +205,15 @@ pub(super) enum Protocol<'db> {
 
 #[salsa::tracked]
 impl<'db> Protocol<'db> {
-    #[salsa::tracked(return_ref)]
-    fn protocol_members(self, db: &'db dyn Db) -> FxOrderSet<Name> {
+    fn protocol_members(self, db: &'db dyn Db) -> &'db FxOrderSet<Name> {
         match self {
-            Self::FromClass(class) => {
-                let class = class
-                    .class_literal(db)
-                    .0
-                    .into_protocol_class(db)
-                    .expect("Protocol class literal should be a protocol class");
-
-                let _span = tracing::trace_span!("protocol_members", "class='{}'", class.name(db))
-                    .entered();
-
-                class.protocol_members(db)
-            }
-            Self::Synthesized(synthesized) => synthesized.members(db).clone(),
+            Self::FromClass(class) => class
+                .class_literal(db)
+                .0
+                .into_protocol_class(db)
+                .expect("Protocol class literal should be a protocol class")
+                .protocol_members(db),
+            Self::Synthesized(synthesized) => synthesized.members(db),
         }
     }
 }

--- a/crates/red_knot_python_semantic/src/types/known_instance.rs
+++ b/crates/red_knot_python_semantic/src/types/known_instance.rs
@@ -1,6 +1,6 @@
 //! The `KnownInstance` type.
 //!
-//! Despite its name, this is quite a different type from [`super::InstanceType`].
+//! Despite its name, this is quite a different type from [`super::NominalInstanceType`].
 //! For the vast majority of instance-types in Python, we cannot say how many possible
 //! inhabitants there are or could be of that type at runtime. Each variant of the
 //! [`KnownInstanceType`] enum, however, represents a specific runtime symbol
@@ -260,7 +260,7 @@ impl<'db> KnownInstanceType<'db> {
     ///
     /// For example, the symbol `typing.Literal` is an instance of `typing._SpecialForm`,
     /// so `KnownInstanceType::Literal.instance_fallback(db)`
-    /// returns `Type::Instance(InstanceType { class: <typing._SpecialForm> })`.
+    /// returns `Type::NominalInstance(NominalInstanceType { class: <typing._SpecialForm> })`.
     pub(super) fn instance_fallback(self, db: &dyn Db) -> Type {
         self.class().to_instance(db)
     }

--- a/crates/red_knot_python_semantic/src/types/narrow.rs
+++ b/crates/red_knot_python_semantic/src/types/narrow.rs
@@ -472,7 +472,7 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
                         union.map(db, |ty| filter_to_cannot_be_equal(db, *ty, rhs_ty))
                     }
                     // Treat `bool` as `Literal[True, False]`.
-                    Type::Instance(instance) if instance.class().is_known(db, KnownClass::Bool) => {
+                    Type::NominalInstance(instance) if instance.class().is_known(db, KnownClass::Bool) => {
                         UnionType::from_elements(
                             db,
                             [Type::BooleanLiteral(true), Type::BooleanLiteral(false)]
@@ -501,7 +501,7 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
 
     fn evaluate_expr_ne(&mut self, lhs_ty: Type<'db>, rhs_ty: Type<'db>) -> Option<Type<'db>> {
         match (lhs_ty, rhs_ty) {
-            (Type::Instance(instance), Type::IntLiteral(i))
+            (Type::NominalInstance(instance), Type::IntLiteral(i))
                 if instance.class().is_known(self.db, KnownClass::Bool) =>
             {
                 if i == 0 {

--- a/crates/red_knot_python_semantic/src/types/narrow.rs
+++ b/crates/red_knot_python_semantic/src/types/narrow.rs
@@ -159,7 +159,7 @@ impl KnownConstraintFunction {
     /// union types are not yet supported. Returns `None` if the `classinfo` argument has a wrong type.
     fn generate_constraint<'db>(self, db: &'db dyn Db, classinfo: Type<'db>) -> Option<Type<'db>> {
         let constraint_fn = |class| match self {
-            KnownConstraintFunction::IsInstance => Type::instance(class),
+            KnownConstraintFunction::IsInstance => Type::instance(db, class),
             KnownConstraintFunction::IsSubclass => SubclassOfType::from(db, class),
         };
 
@@ -682,7 +682,7 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
                         let symbol = self.expect_expr_name_symbol(id);
                         constraints.insert(
                             symbol,
-                            Type::instance(rhs_class.unknown_specialization(self.db)),
+                            Type::instance(self.db, rhs_class.unknown_specialization(self.db)),
                         );
                     }
                 }

--- a/crates/red_knot_python_semantic/src/types/narrow.rs
+++ b/crates/red_knot_python_semantic/src/types/narrow.rs
@@ -472,7 +472,9 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
                         union.map(db, |ty| filter_to_cannot_be_equal(db, *ty, rhs_ty))
                     }
                     // Treat `bool` as `Literal[True, False]`.
-                    Type::NominalInstance(instance) if instance.class().is_known(db, KnownClass::Bool) => {
+                    Type::NominalInstance(instance)
+                        if instance.class().is_known(db, KnownClass::Bool) =>
+                    {
                         UnionType::from_elements(
                             db,
                             [Type::BooleanLiteral(true), Type::BooleanLiteral(false)]

--- a/crates/red_knot_python_semantic/src/types/subclass_of.rs
+++ b/crates/red_knot_python_semantic/src/types/subclass_of.rs
@@ -16,8 +16,8 @@ impl<'db> SubclassOfType<'db> {
     /// This method does not always return a [`Type::SubclassOf`] variant.
     /// If the class object is known to be a final class,
     /// this method will return a [`Type::ClassLiteral`] variant; this is a more precise type.
-    /// If the class object is `builtins.object`, `Type::Instance(<builtins.type>)` will be returned;
-    /// this is no more precise, but it is exactly equivalent to `type[object]`.
+    /// If the class object is `builtins.object`, `Type::NominalInstance(<builtins.type>)`
+    /// will be returned; this is no more precise, but it is exactly equivalent to `type[object]`.
     ///
     /// The eager normalization here means that we do not need to worry elsewhere about distinguishing
     /// between `@final` classes and other classes when dealing with [`Type::SubclassOf`] variants.

--- a/crates/red_knot_python_semantic/src/types/subclass_of.rs
+++ b/crates/red_knot_python_semantic/src/types/subclass_of.rs
@@ -94,9 +94,9 @@ impl<'db> SubclassOfType<'db> {
         }
     }
 
-    pub(crate) fn to_instance(self) -> Type<'db> {
+    pub(crate) fn to_instance(self, db: &'db dyn Db) -> Type<'db> {
         match self.subclass_of {
-            SubclassOfInner::Class(class) => Type::instance(class),
+            SubclassOfInner::Class(class) => Type::instance(db, class),
             SubclassOfInner::Dynamic(dynamic_type) => Type::Dynamic(dynamic_type),
         }
     }

--- a/crates/red_knot_python_semantic/src/types/type_ordering.rs
+++ b/crates/red_knot_python_semantic/src/types/type_ordering.rs
@@ -137,8 +137,6 @@ pub(super) fn union_or_intersection_elements_ordering<'db>(
         (_, Type::NominalInstance(_)) => Ordering::Greater,
 
         (Type::ProtocolInstance(left_proto), Type::ProtocolInstance(right_proto)) => {
-            debug_assert_eq!(*left, left_proto.normalized(db));
-            debug_assert_eq!(*right, right_proto.normalized(db));
             left_proto.cmp(right_proto)
         }
         (Type::ProtocolInstance(_), _) => Ordering::Less,

--- a/crates/red_knot_python_semantic/src/types/type_ordering.rs
+++ b/crates/red_knot_python_semantic/src/types/type_ordering.rs
@@ -129,10 +129,12 @@ pub(super) fn union_or_intersection_elements_ordering<'db>(
 
         (Type::SubclassOf(_), _) => Ordering::Less,
         (_, Type::SubclassOf(_)) => Ordering::Greater,
-        (Type::Instance(left), Type::Instance(right)) => left.class().cmp(&right.class()),
+        (Type::NominalInstance(left), Type::NominalInstance(right)) => {
+            left.class().cmp(&right.class())
+        }
 
-        (Type::Instance(_), _) => Ordering::Less,
-        (_, Type::Instance(_)) => Ordering::Greater,
+        (Type::NominalInstance(_), _) => Ordering::Less,
+        (_, Type::NominalInstance(_)) => Ordering::Greater,
 
         (Type::TypeVar(left), Type::TypeVar(right)) => left.cmp(right),
         (Type::TypeVar(_), _) => Ordering::Less,

--- a/crates/red_knot_python_semantic/src/types/type_ordering.rs
+++ b/crates/red_knot_python_semantic/src/types/type_ordering.rs
@@ -129,12 +129,20 @@ pub(super) fn union_or_intersection_elements_ordering<'db>(
 
         (Type::SubclassOf(_), _) => Ordering::Less,
         (_, Type::SubclassOf(_)) => Ordering::Greater,
+
         (Type::NominalInstance(left), Type::NominalInstance(right)) => {
             left.class().cmp(&right.class())
         }
-
         (Type::NominalInstance(_), _) => Ordering::Less,
         (_, Type::NominalInstance(_)) => Ordering::Greater,
+
+        (Type::ProtocolInstance(left_proto), Type::ProtocolInstance(right_proto)) => {
+            debug_assert_eq!(*left, left_proto.normalized(db));
+            debug_assert_eq!(*right, right_proto.normalized(db));
+            left_proto.cmp(right_proto)
+        }
+        (Type::ProtocolInstance(_), _) => Ordering::Less,
+        (_, Type::ProtocolInstance(_)) => Ordering::Greater,
 
         (Type::TypeVar(left), Type::TypeVar(right)) => left.cmp(right),
         (Type::TypeVar(_), _) => Ordering::Less,


### PR DESCRIPTION
## Summary

This PR adds initial support for protocol types to red-knot.

Specifically, it does the following things:
- Adds a new `Type::ProtocolInstance` variant. A `ProtocolInstanceType` represents "the set of all possible runtime objects that would satisfy a given protocol".
- Renames `Type::Instance`/`InstanceType` to `Type::NominalInstance`/`NominalInstanceType`, to differentiate them from `Type::ProtocolInstance`/`ProtocolInstanceType`.
- Reworks the `Type::instance()` constructor: it now checks whether the class passed into the constructor is a protocol class. If it is, it returns a `Type::ProtocolInstance()`; if not, it returns a `Type::NominalInstance`
- Implements naive versions of subtyping, assignability and equivalence for protocol types, both relative to other protocol types and relative to other `Type` variants altogether.
- Removes hardcoded special-casing for `typing.SupportsIndex` and `typing.Sized`. This special-casing is now redundant.
- Removes the `KnownClass::Sized` variant altogether: its only purpose was to achieve the special-cased support for this protocol in red-knot.

There is still much to be done, and many TODOs remain. The most obvious piece of outstanding work is that we still do not consider the _types_ of the members declared on a protocol class when we consider whether another type is assignable to a protocol type. I.e., this assertion currently fails on this branch, when it should pass due to the fact that `Bar.x` has type `str` but `Foo` demands that inhabitants of the type must have an `x` attribute of type `int`:

```py
from typing import Protocol
from knot_extensions import static_assert, is_assignable_to

class Foo(Protocol):
    x: int

class Bar:
    x = "foo"

static_assert(not is_assignable_to(Bar, Foo))
```

As such, this PR gets rid of many false-positive diagnostics associated with protocols. But it comes at the cost of introducing many potential false negatives. These will be tackled in followup PRs.

## Test Plan

- Existing mdtests updated
- New mdtests added for issues that were surfaced via mypy_primer on early versions of this branch
- Unit test added for the `Display` implementation of synthesized protocols
- Ran `uvx --from=./python/py-fuzzer fuzz 0-2000 --only-new-bugs  --baseline-executable=./target/main/debug/red_knot --bin=red_knot` to verify that this branch doesn't introduce any new panics detectable by the `py-fuzzer` script
- Ran `QUICKCHECK_TESTS=100000 cargo test --release -p red_knot_python_semantic -- --ignored types::property_tests::stable` to check that the property tests still pass
  - (This PR doesn't yet add the machinery to the property tests so that they would ever actually test any protocol types, so this is unsurprising. But I double-checked anyway.)
- The mypy_primer report looks excellent: all hits appear to either be false positives going away, or pre-existing error messages changing slightly
