### PR TITLE
Bump mypy_primer pin

### DIFF
--- a/.github/workflows/mypy_primer.yaml
+++ b/.github/workflows/mypy_primer.yaml
@@ -41,12 +41,9 @@ jobs:
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
         with:
           workspaces: "ruff"
+
       - name: Install Rust toolchain
         run: rustup show
-
-      - name: Install mypy_primer
-        run: |
-          uv tool install "git+https://github.com/hauntsaninja/mypy_primer@4c22d192a456e27badf85b3ea0f830707375d2b7"
 
       - name: Run mypy_primer
         shell: bash
@@ -67,7 +64,9 @@ jobs:
 
           echo "Project selector: $PRIMER_SELECTOR"
           # Allow the exit code to be 0 or 1, only fail for actual mypy_primer crashes/bugs
-          uvx mypy_primer \
+          uvx \
+            --from="git+https://github.com/hauntsaninja/mypy_primer@b83b9eade0b7ed2f4b9b129b163acac1ecb48f71" \
+            mypy_primer \
             --repo ruff \
             --type-checker knot \
             --old base_commit \


### PR DESCRIPTION
So that we get a version that includes https://github.com/hauntsaninja/mypy_primer/commit/b83b9eade0b7ed2f4b9b129b163acac1ecb48f71

Also simplify the workflow slightly (there's no need for a separate install step)
