### PR TITLE
[red-knot] ruff_db: render file paths in diagnostics as relative paths if possible

### DIFF
--- a/crates/red_knot/tests/cli.rs
+++ b/crates/red_knot/tests/cli.rs
@@ -6,14 +6,14 @@ use std::process::Command;
 use tempfile::TempDir;
 
 #[test]
-fn test_include_hidden_files_by_default() -> anyhow::Result<()> {
-    let case = TestCase::with_files([(".test.py", "~")])?;
-    assert_cmd_snapshot!(case.command(), @r"
+fn test_run_in_sub_directory() -> anyhow::Result<()> {
+    let case = TestCase::with_files([("test.py", "~"), ("subdir/nothing", "")])?;
+    assert_cmd_snapshot!(case.command().current_dir(case.root().join("subdir")).arg(".."), @r"
     success: false
     exit_code: 1
     ----- stdout -----
     error: invalid-syntax
-     --> <temp_dir>/.test.py:1:2
+     --> <temp_dir>/test.py:1:2
       |
     1 | ~
       |  ^ Expected an expression
@@ -25,6 +25,28 @@ fn test_include_hidden_files_by_default() -> anyhow::Result<()> {
     ");
     Ok(())
 }
+
+#[test]
+fn test_include_hidden_files_by_default() -> anyhow::Result<()> {
+    let case = TestCase::with_files([(".test.py", "~")])?;
+    assert_cmd_snapshot!(case.command(), @r"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    error: invalid-syntax
+     --> .test.py:1:2
+      |
+    1 | ~
+      |  ^ Expected an expression
+      |
+
+    Found 1 diagnostic
+
+    ----- stderr -----
+    ");
+    Ok(())
+}
+
 #[test]
 fn test_respect_ignore_files() -> anyhow::Result<()> {
     // First test that the default option works correctly (the file is skipped)
@@ -45,7 +67,7 @@ fn test_respect_ignore_files() -> anyhow::Result<()> {
     exit_code: 1
     ----- stdout -----
     error: invalid-syntax
-     --> <temp_dir>/test.py:1:2
+     --> test.py:1:2
       |
     1 | ~
       |  ^ Expected an expression
@@ -63,7 +85,7 @@ fn test_respect_ignore_files() -> anyhow::Result<()> {
     exit_code: 1
     ----- stdout -----
     error: invalid-syntax
-     --> <temp_dir>/test.py:1:2
+     --> test.py:1:2
       |
     1 | ~
       |  ^ Expected an expression
@@ -81,7 +103,7 @@ fn test_respect_ignore_files() -> anyhow::Result<()> {
     exit_code: 1
     ----- stdout -----
     error: invalid-syntax
-     --> <temp_dir>/test.py:1:2
+     --> test.py:1:2
       |
     1 | ~
       |  ^ Expected an expression
@@ -121,7 +143,7 @@ fn config_override_python_version() -> anyhow::Result<()> {
     exit_code: 1
     ----- stdout -----
     error: lint:unresolved-attribute: Type `<module 'sys'>` has no attribute `last_exc`
-     --> <temp_dir>/test.py:5:7
+     --> test.py:5:7
       |
     4 | # Access `sys.last_exc` that was only added in Python 3.12
     5 | print(sys.last_exc)
@@ -172,7 +194,7 @@ fn config_override_python_platform() -> anyhow::Result<()> {
     exit_code: 0
     ----- stdout -----
     info: revealed-type: Revealed type
-     --> <temp_dir>/test.py:5:1
+     --> test.py:5:1
       |
     3 | from typing_extensions import reveal_type
     4 |
@@ -190,7 +212,7 @@ fn config_override_python_platform() -> anyhow::Result<()> {
     exit_code: 0
     ----- stdout -----
     info: revealed-type: Revealed type
-     --> <temp_dir>/test.py:5:1
+     --> test.py:5:1
       |
     3 | from typing_extensions import reveal_type
     4 |
@@ -254,7 +276,7 @@ fn cli_arguments_are_relative_to_the_current_directory() -> anyhow::Result<()> {
     exit_code: 1
     ----- stdout -----
     error: lint:unresolved-import: Cannot resolve import `utils`
-     --> <temp_dir>/child/test.py:2:6
+     --> test.py:2:6
       |
     2 | from utils import add
       |      ^^^^^
@@ -354,7 +376,7 @@ fn configuration_rule_severity() -> anyhow::Result<()> {
     exit_code: 1
     ----- stdout -----
     error: lint:division-by-zero: Cannot divide object of type `Literal[4]` by zero
-     --> <temp_dir>/test.py:2:5
+     --> test.py:2:5
       |
     2 | y = 4 / 0
       |     ^^^^^
@@ -363,7 +385,7 @@ fn configuration_rule_severity() -> anyhow::Result<()> {
       |
 
     warning: lint:possibly-unresolved-reference: Name `x` used when possibly not defined
-     --> <temp_dir>/test.py:7:7
+     --> test.py:7:7
       |
     5 |     x = a
     6 |
@@ -390,7 +412,7 @@ fn configuration_rule_severity() -> anyhow::Result<()> {
     exit_code: 0
     ----- stdout -----
     warning: lint:division-by-zero: Cannot divide object of type `Literal[4]` by zero
-     --> <temp_dir>/test.py:2:5
+     --> test.py:2:5
       |
     2 | y = 4 / 0
       |     ^^^^^
@@ -430,7 +452,7 @@ fn cli_rule_severity() -> anyhow::Result<()> {
     exit_code: 1
     ----- stdout -----
     error: lint:unresolved-import: Cannot resolve import `does_not_exit`
-     --> <temp_dir>/test.py:2:8
+     --> test.py:2:8
       |
     2 | import does_not_exit
       |        ^^^^^^^^^^^^^
@@ -439,7 +461,7 @@ fn cli_rule_severity() -> anyhow::Result<()> {
       |
 
     error: lint:division-by-zero: Cannot divide object of type `Literal[4]` by zero
-     --> <temp_dir>/test.py:4:5
+     --> test.py:4:5
       |
     2 | import does_not_exit
     3 |
@@ -450,7 +472,7 @@ fn cli_rule_severity() -> anyhow::Result<()> {
       |
 
     warning: lint:possibly-unresolved-reference: Name `x` used when possibly not defined
-     --> <temp_dir>/test.py:9:7
+     --> test.py:9:7
       |
     7 |     x = a
     8 |
@@ -477,7 +499,7 @@ fn cli_rule_severity() -> anyhow::Result<()> {
     exit_code: 0
     ----- stdout -----
     warning: lint:unresolved-import: Cannot resolve import `does_not_exit`
-     --> <temp_dir>/test.py:2:8
+     --> test.py:2:8
       |
     2 | import does_not_exit
       |        ^^^^^^^^^^^^^
@@ -486,7 +508,7 @@ fn cli_rule_severity() -> anyhow::Result<()> {
       |
 
     warning: lint:division-by-zero: Cannot divide object of type `Literal[4]` by zero
-     --> <temp_dir>/test.py:4:5
+     --> test.py:4:5
       |
     2 | import does_not_exit
     3 |
@@ -528,7 +550,7 @@ fn cli_rule_severity_precedence() -> anyhow::Result<()> {
     exit_code: 1
     ----- stdout -----
     error: lint:division-by-zero: Cannot divide object of type `Literal[4]` by zero
-     --> <temp_dir>/test.py:2:5
+     --> test.py:2:5
       |
     2 | y = 4 / 0
       |     ^^^^^
@@ -537,7 +559,7 @@ fn cli_rule_severity_precedence() -> anyhow::Result<()> {
       |
 
     warning: lint:possibly-unresolved-reference: Name `x` used when possibly not defined
-     --> <temp_dir>/test.py:7:7
+     --> test.py:7:7
       |
     5 |     x = a
     6 |
@@ -565,7 +587,7 @@ fn cli_rule_severity_precedence() -> anyhow::Result<()> {
     exit_code: 0
     ----- stdout -----
     warning: lint:division-by-zero: Cannot divide object of type `Literal[4]` by zero
-     --> <temp_dir>/test.py:2:5
+     --> test.py:2:5
       |
     2 | y = 4 / 0
       |     ^^^^^
@@ -601,7 +623,7 @@ fn configuration_unknown_rules() -> anyhow::Result<()> {
     exit_code: 0
     ----- stdout -----
     warning: unknown-rule
-     --> <temp_dir>/pyproject.toml:3:1
+     --> pyproject.toml:3:1
       |
     2 | [tool.knot.rules]
     3 | division-by-zer = "warn" # incorrect rule name
@@ -644,7 +666,7 @@ fn exit_code_only_warnings() -> anyhow::Result<()> {
     exit_code: 0
     ----- stdout -----
     warning: lint:unresolved-reference: Name `x` used when not defined
-     --> <temp_dir>/test.py:1:7
+     --> test.py:1:7
       |
     1 | print(x)  # [unresolved-reference]
       |       ^
@@ -673,7 +695,7 @@ fn exit_code_only_info() -> anyhow::Result<()> {
     exit_code: 0
     ----- stdout -----
     info: revealed-type: Revealed type
-     --> <temp_dir>/test.py:3:1
+     --> test.py:3:1
       |
     2 | from typing_extensions import reveal_type
     3 | reveal_type(1)
@@ -703,7 +725,7 @@ fn exit_code_only_info_and_error_on_warning_is_true() -> anyhow::Result<()> {
     exit_code: 0
     ----- stdout -----
     info: revealed-type: Revealed type
-     --> <temp_dir>/test.py:3:1
+     --> test.py:3:1
       |
     2 | from typing_extensions import reveal_type
     3 | reveal_type(1)
@@ -727,7 +749,7 @@ fn exit_code_no_errors_but_error_on_warning_is_true() -> anyhow::Result<()> {
     exit_code: 1
     ----- stdout -----
     warning: lint:unresolved-reference: Name `x` used when not defined
-     --> <temp_dir>/test.py:1:7
+     --> test.py:1:7
       |
     1 | print(x)  # [unresolved-reference]
       |       ^
@@ -759,7 +781,7 @@ fn exit_code_no_errors_but_error_on_warning_is_enabled_in_configuration() -> any
     exit_code: 1
     ----- stdout -----
     warning: lint:unresolved-reference: Name `x` used when not defined
-     --> <temp_dir>/test.py:1:7
+     --> test.py:1:7
       |
     1 | print(x)  # [unresolved-reference]
       |       ^
@@ -788,7 +810,7 @@ fn exit_code_both_warnings_and_errors() -> anyhow::Result<()> {
     exit_code: 1
     ----- stdout -----
     warning: lint:unresolved-reference: Name `x` used when not defined
-     --> <temp_dir>/test.py:2:7
+     --> test.py:2:7
       |
     2 | print(x)     # [unresolved-reference]
       |       ^
@@ -796,7 +818,7 @@ fn exit_code_both_warnings_and_errors() -> anyhow::Result<()> {
       |
 
     error: lint:non-subscriptable: Cannot subscript object of type `Literal[4]` with no `__getitem__` method
-     --> <temp_dir>/test.py:3:7
+     --> test.py:3:7
       |
     2 | print(x)     # [unresolved-reference]
     3 | print(4[1])  # [non-subscriptable]
@@ -826,7 +848,7 @@ fn exit_code_both_warnings_and_errors_and_error_on_warning_is_true() -> anyhow::
     exit_code: 1
     ----- stdout -----
     warning: lint:unresolved-reference: Name `x` used when not defined
-     --> <temp_dir>/test.py:2:7
+     --> test.py:2:7
       |
     2 | print(x)     # [unresolved-reference]
       |       ^
@@ -834,7 +856,7 @@ fn exit_code_both_warnings_and_errors_and_error_on_warning_is_true() -> anyhow::
       |
 
     error: lint:non-subscriptable: Cannot subscript object of type `Literal[4]` with no `__getitem__` method
-     --> <temp_dir>/test.py:3:7
+     --> test.py:3:7
       |
     2 | print(x)     # [unresolved-reference]
     3 | print(4[1])  # [non-subscriptable]
@@ -864,7 +886,7 @@ fn exit_code_exit_zero_is_true() -> anyhow::Result<()> {
     exit_code: 0
     ----- stdout -----
     warning: lint:unresolved-reference: Name `x` used when not defined
-     --> <temp_dir>/test.py:2:7
+     --> test.py:2:7
       |
     2 | print(x)     # [unresolved-reference]
       |       ^
@@ -872,7 +894,7 @@ fn exit_code_exit_zero_is_true() -> anyhow::Result<()> {
       |
 
     error: lint:non-subscriptable: Cannot subscript object of type `Literal[4]` with no `__getitem__` method
-     --> <temp_dir>/test.py:3:7
+     --> test.py:3:7
       |
     2 | print(x)     # [unresolved-reference]
     3 | print(4[1])  # [non-subscriptable]
@@ -924,7 +946,7 @@ fn user_configuration() -> anyhow::Result<()> {
     exit_code: 0
     ----- stdout -----
     warning: lint:division-by-zero: Cannot divide object of type `Literal[4]` by zero
-     --> <temp_dir>/project/main.py:2:5
+     --> main.py:2:5
       |
     2 | y = 4 / 0
       |     ^^^^^
@@ -933,7 +955,7 @@ fn user_configuration() -> anyhow::Result<()> {
       |
 
     warning: lint:possibly-unresolved-reference: Name `x` used when possibly not defined
-     --> <temp_dir>/project/main.py:7:7
+     --> main.py:7:7
       |
     5 |     x = a
     6 |
@@ -966,7 +988,7 @@ fn user_configuration() -> anyhow::Result<()> {
     exit_code: 1
     ----- stdout -----
     warning: lint:division-by-zero: Cannot divide object of type `Literal[4]` by zero
-     --> <temp_dir>/project/main.py:2:5
+     --> main.py:2:5
       |
     2 | y = 4 / 0
       |     ^^^^^
@@ -975,7 +997,7 @@ fn user_configuration() -> anyhow::Result<()> {
       |
 
     error: lint:possibly-unresolved-reference: Name `x` used when possibly not defined
-     --> <temp_dir>/project/main.py:7:7
+     --> main.py:7:7
       |
     5 |     x = a
     6 |
@@ -1024,14 +1046,14 @@ fn check_specific_paths() -> anyhow::Result<()> {
     exit_code: 1
     ----- stdout -----
     error: lint:division-by-zero: Cannot divide object of type `Literal[4]` by zero
-     --> <temp_dir>/project/main.py:2:5
+     --> project/main.py:2:5
       |
     2 | y = 4 / 0  # error: division-by-zero
       |     ^^^^^
       |
 
     error: lint:unresolved-import: Cannot resolve import `main2`
-     --> <temp_dir>/project/other.py:2:6
+     --> project/other.py:2:6
       |
     2 | from main2 import z  # error: unresolved-import
       |      ^^^^^
@@ -1040,7 +1062,7 @@ fn check_specific_paths() -> anyhow::Result<()> {
       |
 
     error: lint:unresolved-import: Cannot resolve import `does_not_exist`
-     --> <temp_dir>/project/tests/test_main.py:2:8
+     --> project/tests/test_main.py:2:8
       |
     2 | import does_not_exist  # error: unresolved-import
       |        ^^^^^^^^^^^^^^
@@ -1061,7 +1083,7 @@ fn check_specific_paths() -> anyhow::Result<()> {
     exit_code: 1
     ----- stdout -----
     error: lint:unresolved-import: Cannot resolve import `main2`
-     --> <temp_dir>/project/other.py:2:6
+     --> project/other.py:2:6
       |
     2 | from main2 import z  # error: unresolved-import
       |      ^^^^^
@@ -1070,7 +1092,7 @@ fn check_specific_paths() -> anyhow::Result<()> {
       |
 
     error: lint:unresolved-import: Cannot resolve import `does_not_exist`
-     --> <temp_dir>/project/tests/test_main.py:2:8
+     --> project/tests/test_main.py:2:8
       |
     2 | import does_not_exist  # error: unresolved-import
       |        ^^^^^^^^^^^^^^
@@ -1130,8 +1152,8 @@ fn concise_diagnostics() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    warning[lint:unresolved-reference] <temp_dir>/test.py:2:7: Name `x` used when not defined
-    error[lint:non-subscriptable] <temp_dir>/test.py:3:7: Cannot subscript object of type `Literal[4]` with no `__getitem__` method
+    warning[lint:unresolved-reference] test.py:2:7: Name `x` used when not defined
+    error[lint:non-subscriptable] test.py:3:7: Cannot subscript object of type `Literal[4]` with no `__getitem__` method
     Found 2 diagnostics
 
     ----- stderr -----
@@ -1164,7 +1186,7 @@ fn concise_revealed_type() -> anyhow::Result<()> {
     success: true
     exit_code: 0
     ----- stdout -----
-    info[revealed-type] <temp_dir>/test.py:5:1: Revealed type: `Literal["hello"]`
+    info[revealed-type] test.py:5:1: Revealed type: `Literal["hello"]`
     Found 1 diagnostic
 
     ----- stderr -----

--- a/crates/red_knot_ide/src/goto.rs
+++ b/crates/red_knot_ide/src/goto.rs
@@ -272,9 +272,9 @@ mod tests {
             "#,
         );
 
-        assert_snapshot!(test.goto_type_definition(), @r###"
+        assert_snapshot!(test.goto_type_definition(), @r"
         info: lint:goto-type-definition: Type definition
-         --> /main.py:2:19
+         --> main.py:2:19
           |
         2 |             class Test: ...
           |                   ^^^^
@@ -282,14 +282,14 @@ mod tests {
         4 |             ab = Test()
           |
         info: Source
-         --> /main.py:4:13
+         --> main.py:4:13
           |
         2 |             class Test: ...
         3 |
         4 |             ab = Test()
           |             ^^
           |
-        "###);
+        ");
     }
 
     #[test]
@@ -304,9 +304,9 @@ mod tests {
         "#,
         );
 
-        assert_snapshot!(test.goto_type_definition(), @r###"
+        assert_snapshot!(test.goto_type_definition(), @r"
         info: lint:goto-type-definition: Type definition
-         --> /main.py:2:17
+         --> main.py:2:17
           |
         2 |             def foo(a, b): ...
           |                 ^^^
@@ -314,14 +314,14 @@ mod tests {
         4 |             ab = foo
           |
         info: Source
-         --> /main.py:6:13
+         --> main.py:6:13
           |
         4 |             ab = foo
         5 |
         6 |             ab
           |             ^^
           |
-        "###);
+        ");
     }
 
     #[test]
@@ -344,7 +344,7 @@ mod tests {
 
         assert_snapshot!(test.goto_type_definition(), @r"
         info: lint:goto-type-definition: Type definition
-         --> /main.py:3:17
+         --> main.py:3:17
           |
         3 |             def foo(a, b): ...
           |                 ^^^
@@ -352,7 +352,7 @@ mod tests {
         5 |             def bar(a, b): ...
           |
         info: Source
-          --> /main.py:12:13
+          --> main.py:12:13
            |
         10 |                 a = bar
         11 |
@@ -361,7 +361,7 @@ mod tests {
            |
 
         info: lint:goto-type-definition: Type definition
-         --> /main.py:5:17
+         --> main.py:5:17
           |
         3 |             def foo(a, b): ...
         4 |
@@ -371,7 +371,7 @@ mod tests {
         7 |             if random.choice():
           |
         info: Source
-          --> /main.py:12:13
+          --> main.py:12:13
            |
         10 |                 a = bar
         11 |
@@ -395,13 +395,13 @@ mod tests {
 
         assert_snapshot!(test.goto_type_definition(), @r"
         info: lint:goto-type-definition: Type definition
-         --> /lib.py:1:1
+         --> lib.py:1:1
           |
         1 | a = 10
           | ^^^^^^
           |
         info: Source
-         --> /main.py:4:13
+         --> main.py:4:13
           |
         2 |             import lib
         3 |
@@ -433,7 +433,7 @@ mod tests {
         440 |     def __new__(cls, object: object = ...) -> Self: ...
             |
         info: Source
-         --> /main.py:4:13
+         --> main.py:4:13
           |
         2 |             a: str = "test"
         3 |
@@ -462,7 +462,7 @@ mod tests {
         440 |     def __new__(cls, object: object = ...) -> Self: ...
             |
         info: Source
-         --> /main.py:2:22
+         --> main.py:2:22
           |
         2 |             a: str = "test"
           |                      ^^^^^^
@@ -478,20 +478,20 @@ mod tests {
             "#,
         );
 
-        assert_snapshot!(test.goto_type_definition(), @r###"
+        assert_snapshot!(test.goto_type_definition(), @r"
         info: lint:goto-type-definition: Type definition
-         --> /main.py:2:24
+         --> main.py:2:24
           |
         2 |             type Alias[T: int = bool] = list[T]
           |                        ^
           |
         info: Source
-         --> /main.py:2:46
+         --> main.py:2:46
           |
         2 |             type Alias[T: int = bool] = list[T]
           |                                              ^
           |
-        "###);
+        ");
     }
 
     #[test]
@@ -544,7 +544,7 @@ mod tests {
         440 |     def __new__(cls, object: object = ...) -> Self: ...
             |
         info: Source
-         --> /main.py:4:18
+         --> main.py:4:18
           |
         2 |             def test(a: str): ...
         3 |
@@ -579,7 +579,7 @@ mod tests {
         233 |     def __new__(cls, x: ConvertibleToInt = ..., /) -> Self: ...
             |
         info: Source
-         --> /main.py:4:18
+         --> main.py:4:18
           |
         2 |             def test(a: str): ...
         3 |
@@ -613,7 +613,7 @@ f(**kwargs<CURSOR>)
         1088 |     # Also multiprocessing.managers.SyncManager.dict()
              |
         info: Source
-         --> /main.py:6:5
+         --> main.py:6:5
           |
         4 | kwargs = { "name": "test"}
         5 |
@@ -644,7 +644,7 @@ f(**kwargs<CURSOR>)
         440 |     def __new__(cls, object: object = ...) -> Self: ...
             |
         info: Source
-         --> /main.py:3:17
+         --> main.py:3:17
           |
         2 |             def foo(a: str):
         3 |                 a
@@ -666,23 +666,23 @@ f(**kwargs<CURSOR>)
             "#,
         );
 
-        assert_snapshot!(test.goto_type_definition(), @r###"
+        assert_snapshot!(test.goto_type_definition(), @r"
         info: lint:goto-type-definition: Type definition
-         --> /main.py:2:19
+         --> main.py:2:19
           |
         2 |             class X:
           |                   ^
         3 |                 def foo(a, b): ...
           |
         info: Source
-         --> /main.py:7:13
+         --> main.py:7:13
           |
         5 |             x = X()
         6 |
         7 |             x.foo()
           |             ^
           |
-        "###);
+        ");
     }
 
     #[test]
@@ -695,9 +695,9 @@ f(**kwargs<CURSOR>)
             "#,
         );
 
-        assert_snapshot!(test.goto_type_definition(), @r###"
+        assert_snapshot!(test.goto_type_definition(), @r"
         info: lint:goto-type-definition: Type definition
-         --> /main.py:2:17
+         --> main.py:2:17
           |
         2 |             def foo(a, b): ...
           |                 ^^^
@@ -705,14 +705,14 @@ f(**kwargs<CURSOR>)
         4 |             foo()
           |
         info: Source
-         --> /main.py:4:13
+         --> main.py:4:13
           |
         2 |             def foo(a, b): ...
         3 |
         4 |             foo()
           |             ^^^
           |
-        "###);
+        ");
     }
 
     #[test]
@@ -737,7 +737,7 @@ f(**kwargs<CURSOR>)
         440 |     def __new__(cls, object: object = ...) -> Self: ...
             |
         info: Source
-         --> /main.py:4:27
+         --> main.py:4:27
           |
         2 |             def foo(a: str | None, b):
         3 |                 if a is not None:
@@ -767,7 +767,7 @@ f(**kwargs<CURSOR>)
         672 |         def __bool__(self) -> Literal[False]: ...
             |
         info: Source
-         --> /main.py:3:17
+         --> main.py:3:17
           |
         2 |             def foo(a: str | None, b):
         3 |                 a
@@ -785,7 +785,7 @@ f(**kwargs<CURSOR>)
         440 |     def __new__(cls, object: object = ...) -> Self: ...
             |
         info: Source
-         --> /main.py:3:17
+         --> main.py:3:17
           |
         2 |             def foo(a: str | None, b):
         3 |                 a

--- a/crates/red_knot_ide/src/hover.rs
+++ b/crates/red_knot_ide/src/hover.rs
@@ -156,7 +156,7 @@ mod tests {
         ```
         ---------------------------------------------
         info: lint:hover: Hovered content is
-         --> /main.py:4:9
+         --> main.py:4:9
           |
         2 |         a = 10
         3 |
@@ -192,7 +192,7 @@ mod tests {
         ```
         ---------------------------------------------
         info: lint:hover: Hovered content is
-          --> /main.py:10:9
+          --> main.py:10:9
            |
          9 |         foo = Foo()
         10 |         foo.a
@@ -214,7 +214,7 @@ mod tests {
         "#,
         );
 
-        assert_snapshot!(test.hover(), @r###"
+        assert_snapshot!(test.hover(), @r"
         def foo(a, b) -> Unknown
         ---------------------------------------------
         ```text
@@ -222,7 +222,7 @@ mod tests {
         ```
         ---------------------------------------------
         info: lint:hover: Hovered content is
-         --> /main.py:4:13
+         --> main.py:4:13
           |
         2 |             def foo(a, b): ...
         3 |
@@ -231,7 +231,7 @@ mod tests {
           |             |
           |             source
           |
-        "###);
+        ");
     }
 
     #[test]
@@ -251,7 +251,7 @@ mod tests {
         ```
         ---------------------------------------------
         info: lint:hover: Hovered content is
-         --> /main.py:3:17
+         --> main.py:3:17
           |
         2 |             def foo(a: int, b: int, c: int):
         3 |                 a + b == c
@@ -282,7 +282,7 @@ mod tests {
         ```
         ---------------------------------------------
         info: lint:hover: Hovered content is
-         --> /main.py:4:18
+         --> main.py:4:18
           |
         2 |             def test(a: int): ...
         3 |
@@ -312,7 +312,7 @@ mod tests {
             "#,
         );
 
-        assert_snapshot!(test.hover(), @r###"
+        assert_snapshot!(test.hover(), @r"
         (def foo(a, b) -> Unknown) | (def bar(a, b) -> Unknown)
         ---------------------------------------------
         ```text
@@ -320,7 +320,7 @@ mod tests {
         ```
         ---------------------------------------------
         info: lint:hover: Hovered content is
-          --> /main.py:12:13
+          --> main.py:12:13
            |
         10 |                 a = bar
         11 |
@@ -329,7 +329,7 @@ mod tests {
            |             |
            |             source
            |
-        "###);
+        ");
     }
 
     #[test]
@@ -352,7 +352,7 @@ mod tests {
         ```
         ---------------------------------------------
         info: lint:hover: Hovered content is
-         --> /main.py:4:13
+         --> main.py:4:13
           |
         2 |             import lib
         3 |
@@ -381,7 +381,7 @@ mod tests {
         ```
         ---------------------------------------------
         info: lint:hover: Hovered content is
-         --> /main.py:2:46
+         --> main.py:2:46
           |
         2 |             type Alias[T: int = bool] = list[T]
           |                                              ^- Cursor offset
@@ -407,7 +407,7 @@ mod tests {
         ```
         ---------------------------------------------
         info: lint:hover: Hovered content is
-         --> /main.py:2:53
+         --> main.py:2:53
           |
         2 |             type Alias[**P = [int, str]] = Callable[P, int]
           |                                                     ^- Cursor offset
@@ -433,7 +433,7 @@ mod tests {
         ```
         ---------------------------------------------
         info: lint:hover: Hovered content is
-         --> /main.py:2:43
+         --> main.py:2:43
           |
         2 |             type Alias[*Ts = ()] = tuple[*Ts]
           |                                           ^^- Cursor offset
@@ -461,7 +461,7 @@ mod tests {
         ```
         ---------------------------------------------
         info: lint:hover: Hovered content is
-         --> /main.py:3:13
+         --> main.py:3:13
           |
         2 |         class Foo:
         3 |             a: int
@@ -490,7 +490,7 @@ mod tests {
         ```
         ---------------------------------------------
         info: lint:hover: Hovered content is
-         --> /main.py:4:27
+         --> main.py:4:27
           |
         2 |             def foo(a: str | None, b):
         3 |                 if a is not None:

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Data_descriptors_-_Invalid_`__set__`_method_signature.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Data_descriptors_-_Invalid_`__set__`_method_signature.snap
@@ -29,7 +29,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/attrib
 
 ```
 error: lint:invalid-assignment: Invalid assignment to data descriptor attribute `attr` on type `C` with custom `__set__` method
-  --> /src/mdtest_snippet.py:11:1
+  --> src/mdtest_snippet.py:11:1
    |
 10 | # TODO: ideally, we would mention why this is an invalid assignment (wrong number of arguments for `__set__`)
 11 | instance.attr = 1  # error: [invalid-assignment]

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Data_descriptors_-_Invalid_argument_type.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Data_descriptors_-_Invalid_argument_type.snap
@@ -30,7 +30,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/attrib
 
 ```
 error: lint:invalid-assignment: Invalid assignment to data descriptor attribute `attr` on type `C` with custom `__set__` method
-  --> /src/mdtest_snippet.py:12:1
+  --> src/mdtest_snippet.py:12:1
    |
 11 | # TODO: ideally, we would mention why this is an invalid assignment (wrong argument type for `value` parameter)
 12 | instance.attr = "wrong"  # error: [invalid-assignment]

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Instance_attributes_with_class-level_defaults.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Instance_attributes_with_class-level_defaults.snap
@@ -27,7 +27,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/attrib
 
 ```
 error: lint:invalid-assignment: Object of type `Literal["wrong"]` is not assignable to attribute `attr` of type `int`
- --> /src/mdtest_snippet.py:6:1
+ --> src/mdtest_snippet.py:6:1
   |
 4 | instance = C()
 5 | instance.attr = 1  # fine
@@ -41,7 +41,7 @@ error: lint:invalid-assignment: Object of type `Literal["wrong"]` is not assigna
 
 ```
 error: lint:invalid-assignment: Object of type `Literal["wrong"]` is not assignable to attribute `attr` of type `int`
- --> /src/mdtest_snippet.py:9:1
+ --> src/mdtest_snippet.py:9:1
   |
 8 | C.attr = 1  # fine
 9 | C.attr = "wrong"  # error: [invalid-assignment]

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Possibly-unbound_attributes.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Possibly-unbound_attributes.snap
@@ -27,7 +27,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/attrib
 
 ```
 warning: lint:possibly-unbound-attribute: Attribute `attr` on type `Literal[C]` is possibly unbound
- --> /src/mdtest_snippet.py:6:5
+ --> src/mdtest_snippet.py:6:5
   |
 4 |             attr: int = 0
 5 |
@@ -41,7 +41,7 @@ warning: lint:possibly-unbound-attribute: Attribute `attr` on type `Literal[C]` 
 
 ```
 warning: lint:possibly-unbound-attribute: Attribute `attr` on type `C` is possibly unbound
- --> /src/mdtest_snippet.py:9:5
+ --> src/mdtest_snippet.py:9:5
   |
 8 |     instance = C()
 9 |     instance.attr = 1  # error: [possibly-unbound-attribute]

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Pure_instance_attributes.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Pure_instance_attributes.snap
@@ -27,7 +27,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/attrib
 
 ```
 error: lint:invalid-assignment: Object of type `Literal["wrong"]` is not assignable to attribute `attr` of type `int`
- --> /src/mdtest_snippet.py:7:1
+ --> src/mdtest_snippet.py:7:1
   |
 5 | instance = C()
 6 | instance.attr = 1  # fine
@@ -41,7 +41,7 @@ error: lint:invalid-assignment: Object of type `Literal["wrong"]` is not assigna
 
 ```
 error: lint:invalid-attribute-access: Cannot assign to instance attribute `attr` from the class object `Literal[C]`
- --> /src/mdtest_snippet.py:9:1
+ --> src/mdtest_snippet.py:9:1
   |
 7 | instance.attr = "wrong"  # error: [invalid-assignment]
 8 |

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Setting_attributes_on_union_types.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Setting_attributes_on_union_types.snap
@@ -38,7 +38,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/attrib
 
 ```
 error: lint:invalid-assignment: Object of type `Literal[1]` is not assignable to attribute `attr` on type `Literal[C1, C1]`
-  --> /src/mdtest_snippet.py:11:5
+  --> src/mdtest_snippet.py:11:5
    |
 10 |     # TODO: The error message here could be improved to explain why the assignment fails.
 11 |     C1.attr = 1  # error: [invalid-assignment]

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Unknown_attributes.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Unknown_attributes.snap
@@ -24,7 +24,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/attrib
 
 ```
 error: lint:unresolved-attribute: Unresolved attribute `non_existent` on type `Literal[C]`.
- --> /src/mdtest_snippet.py:3:1
+ --> src/mdtest_snippet.py:3:1
   |
 1 | class C: ...
 2 |
@@ -38,7 +38,7 @@ error: lint:unresolved-attribute: Unresolved attribute `non_existent` on type `L
 
 ```
 error: lint:unresolved-attribute: Unresolved attribute `non_existent` on type `C`.
- --> /src/mdtest_snippet.py:6:1
+ --> src/mdtest_snippet.py:6:1
   |
 5 | instance = C()
 6 | instance.non_existent = 1  # error: [unresolved-attribute]

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_`ClassVar`s.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_`ClassVar`s.snap
@@ -28,7 +28,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/attrib
 
 ```
 error: lint:invalid-assignment: Object of type `Literal["wrong"]` is not assignable to attribute `attr` of type `int`
- --> /src/mdtest_snippet.py:7:1
+ --> src/mdtest_snippet.py:7:1
   |
 6 | C.attr = 1  # fine
 7 | C.attr = "wrong"  # error: [invalid-assignment]
@@ -41,7 +41,7 @@ error: lint:invalid-assignment: Object of type `Literal["wrong"]` is not assigna
 
 ```
 error: lint:invalid-attribute-access: Cannot assign to ClassVar `attr` from an instance of type `C`
-  --> /src/mdtest_snippet.py:10:1
+  --> src/mdtest_snippet.py:10:1
    |
  9 | instance = C()
 10 | instance.attr = 1  # error: [invalid-attribute-access]

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Unresolvable_module_import.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Unresolvable_module_import.snap
@@ -19,7 +19,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/import/basic.md
 
 ```
 error: lint:unresolved-import: Cannot resolve import `zqzqzqzqzqzqzq`
- --> /src/mdtest_snippet.py:1:8
+ --> src/mdtest_snippet.py:1:8
   |
 1 | import zqzqzqzqzqzqzq  # error: [unresolved-import] "Cannot resolve import `zqzqzqzqzqzqzq`"
   |        ^^^^^^^^^^^^^^

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Unresolvable_submodule_imports.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Unresolvable_submodule_imports.snap
@@ -28,7 +28,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/import/basic.md
 
 ```
 error: lint:unresolved-import: Cannot resolve import `a.foo`
- --> /src/mdtest_snippet.py:2:8
+ --> src/mdtest_snippet.py:2:8
   |
 1 | # Topmost component resolvable, submodule not resolvable:
 2 | import a.foo  # error: [unresolved-import] "Cannot resolve import `a.foo`"
@@ -41,7 +41,7 @@ error: lint:unresolved-import: Cannot resolve import `a.foo`
 
 ```
 error: lint:unresolved-import: Cannot resolve import `b.foo`
- --> /src/mdtest_snippet.py:5:8
+ --> src/mdtest_snippet.py:5:8
   |
 4 | # Topmost component unresolvable:
 5 | import b.foo  # error: [unresolved-import] "Cannot resolve import `b.foo`"

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Bad_`__getitem__`_method.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Bad_`__getitem__`_method.snap
@@ -29,7 +29,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/loops/for.md
 
 ```
 error: lint:not-iterable: Object of type `Iterable` is not iterable
-  --> /src/mdtest_snippet.py:10:10
+  --> src/mdtest_snippet.py:10:10
    |
  9 | # error: [not-iterable]
 10 | for x in Iterable():
@@ -43,7 +43,7 @@ info: `__getitem__` must be at least as permissive as `def __getitem__(self, key
 
 ```
 info: revealed-type: Revealed type
-  --> /src/mdtest_snippet.py:11:5
+  --> src/mdtest_snippet.py:11:5
    |
  9 | # error: [not-iterable]
 10 | for x in Iterable():

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Invalid_iterable.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Invalid_iterable.snap
@@ -21,7 +21,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/loops/for.md
 
 ```
 error: lint:not-iterable: Object of type `Literal[123]` is not iterable
- --> /src/mdtest_snippet.py:2:10
+ --> src/mdtest_snippet.py:2:10
   |
 1 | nonsense = 123
 2 | for x in nonsense:  # error: [not-iterable]

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_New_over_old_style_iteration_protocol.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_New_over_old_style_iteration_protocol.snap
@@ -25,7 +25,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/loops/for.md
 
 ```
 error: lint:not-iterable: Object of type `NotIterable` is not iterable
- --> /src/mdtest_snippet.py:6:10
+ --> src/mdtest_snippet.py:6:10
   |
 4 |     __iter__: None = None
 5 |

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_No_`__iter__`_method_and_`__getitem__`_is_not_callable.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_No_`__iter__`_method_and_`__getitem__`_is_not_callable.snap
@@ -26,7 +26,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/loops/for.md
 
 ```
 error: lint:not-iterable: Object of type `Bad` is not iterable
- --> /src/mdtest_snippet.py:7:10
+ --> src/mdtest_snippet.py:7:10
   |
 6 | # error: [not-iterable]
 7 | for x in Bad():
@@ -39,7 +39,7 @@ info: It has no `__iter__` method and its `__getitem__` attribute has type `None
 
 ```
 info: revealed-type: Revealed type
- --> /src/mdtest_snippet.py:8:5
+ --> src/mdtest_snippet.py:8:5
   |
 6 | # error: [not-iterable]
 7 | for x in Bad():

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly-not-callable_`__getitem__`_method.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly-not-callable_`__getitem__`_method.snap
@@ -47,7 +47,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/loops/for.md
 
 ```
 error: lint:not-iterable: Object of type `Iterable1` may not be iterable
-  --> /src/mdtest_snippet.py:22:14
+  --> src/mdtest_snippet.py:22:14
    |
 21 |     # error: [not-iterable]
 22 |     for x in Iterable1():
@@ -62,7 +62,7 @@ info: `__getitem__` has type `CustomCallable`, which is not callable
 
 ```
 info: revealed-type: Revealed type
-  --> /src/mdtest_snippet.py:24:9
+  --> src/mdtest_snippet.py:24:9
    |
 22 |     for x in Iterable1():
 23 |         # TODO... `int` might be ideal here?
@@ -76,7 +76,7 @@ info: revealed-type: Revealed type
 
 ```
 error: lint:not-iterable: Object of type `Iterable2` may not be iterable
-  --> /src/mdtest_snippet.py:27:14
+  --> src/mdtest_snippet.py:27:14
    |
 26 |     # error: [not-iterable]
 27 |     for y in Iterable2():
@@ -91,7 +91,7 @@ info: `__getitem__` has type `(bound method Iterable2.__getitem__(key: int) -> i
 
 ```
 info: revealed-type: Revealed type
-  --> /src/mdtest_snippet.py:29:9
+  --> src/mdtest_snippet.py:29:9
    |
 27 |     for y in Iterable2():
 28 |         # TODO... `int` might be ideal here?

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__getitem__`_methods.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__getitem__`_methods.snap
@@ -44,7 +44,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/loops/for.md
 
 ```
 error: lint:not-iterable: Object of type `Iterable1` may not be iterable
-  --> /src/mdtest_snippet.py:20:14
+  --> src/mdtest_snippet.py:20:14
    |
 19 |     # error: [not-iterable]
 20 |     for x in Iterable1():
@@ -59,7 +59,7 @@ info: `__getitem__` has type `(bound method Iterable1.__getitem__(item: int) -> 
 
 ```
 info: revealed-type: Revealed type
-  --> /src/mdtest_snippet.py:22:9
+  --> src/mdtest_snippet.py:22:9
    |
 20 |     for x in Iterable1():
 21 |         # TODO: `str` might be better
@@ -73,7 +73,7 @@ info: revealed-type: Revealed type
 
 ```
 error: lint:not-iterable: Object of type `Iterable2` may not be iterable
-  --> /src/mdtest_snippet.py:25:14
+  --> src/mdtest_snippet.py:25:14
    |
 24 |     # error: [not-iterable]
 25 |     for y in Iterable2():
@@ -87,7 +87,7 @@ info: `__getitem__` must be at least as permissive as `def __getitem__(self, key
 
 ```
 info: revealed-type: Revealed type
-  --> /src/mdtest_snippet.py:26:9
+  --> src/mdtest_snippet.py:26:9
    |
 24 |     # error: [not-iterable]
 25 |     for y in Iterable2():

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__iter__`_methods.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__iter__`_methods.snap
@@ -48,7 +48,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/loops/for.md
 
 ```
 error: lint:not-iterable: Object of type `Iterable1` may not be iterable
-  --> /src/mdtest_snippet.py:17:14
+  --> src/mdtest_snippet.py:17:14
    |
 16 |     # error: [not-iterable]
 17 |     for x in Iterable1():
@@ -63,7 +63,7 @@ info: Expected signature for `__iter__` is `def __iter__(self): ...`
 
 ```
 info: revealed-type: Revealed type
-  --> /src/mdtest_snippet.py:18:9
+  --> src/mdtest_snippet.py:18:9
    |
 16 |     # error: [not-iterable]
 17 |     for x in Iterable1():
@@ -77,7 +77,7 @@ info: revealed-type: Revealed type
 
 ```
 error: lint:not-iterable: Object of type `Iterable2` may not be iterable
-  --> /src/mdtest_snippet.py:28:14
+  --> src/mdtest_snippet.py:28:14
    |
 27 |     # error: [not-iterable]
 28 |     for x in Iterable2():
@@ -91,7 +91,7 @@ info: Its `__iter__` attribute (with type `(bound method Iterable2.__iter__() ->
 
 ```
 info: revealed-type: Revealed type
-  --> /src/mdtest_snippet.py:30:9
+  --> src/mdtest_snippet.py:30:9
    |
 28 |     for x in Iterable2():
 29 |         # TODO: `int` would probably be better here:

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__next__`_method.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__next__`_method.snap
@@ -52,7 +52,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/loops/for.md
 
 ```
 error: lint:not-iterable: Object of type `Iterable1` may not be iterable
-  --> /src/mdtest_snippet.py:28:14
+  --> src/mdtest_snippet.py:28:14
    |
 27 |     # error: [not-iterable]
 28 |     for x in Iterable1():
@@ -66,7 +66,7 @@ info: Expected signature for `__next__` is `def __next__(self): ...`)
 
 ```
 info: revealed-type: Revealed type
-  --> /src/mdtest_snippet.py:29:9
+  --> src/mdtest_snippet.py:29:9
    |
 27 |     # error: [not-iterable]
 28 |     for x in Iterable1():
@@ -80,7 +80,7 @@ info: revealed-type: Revealed type
 
 ```
 error: lint:not-iterable: Object of type `Iterable2` may not be iterable
-  --> /src/mdtest_snippet.py:32:14
+  --> src/mdtest_snippet.py:32:14
    |
 31 |     # error: [not-iterable]
 32 |     for y in Iterable2():
@@ -94,7 +94,7 @@ info: Its `__iter__` method returns an object of type `Iterator2`, which has a `
 
 ```
 info: revealed-type: Revealed type
-  --> /src/mdtest_snippet.py:34:9
+  --> src/mdtest_snippet.py:34:9
    |
 32 |     for y in Iterable2():
 33 |         # TODO: `int` would probably be better here:

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_bad_`__getitem__`_method.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_bad_`__getitem__`_method.snap
@@ -37,7 +37,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/loops/for.md
 
 ```
 error: lint:not-iterable: Object of type `Iterable` may not be iterable
-  --> /src/mdtest_snippet.py:18:14
+  --> src/mdtest_snippet.py:18:14
    |
 17 |     # error: [not-iterable]
 18 |     for x in Iterable():
@@ -51,7 +51,7 @@ info: `__getitem__` must be at least as permissive as `def __getitem__(self, key
 
 ```
 info: revealed-type: Revealed type
-  --> /src/mdtest_snippet.py:19:9
+  --> src/mdtest_snippet.py:19:9
    |
 17 |     # error: [not-iterable]
 18 |     for x in Iterable():

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_possibly_invalid_`__getitem__`.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_possibly_invalid_`__getitem__`.snap
@@ -55,7 +55,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/loops/for.md
 
 ```
 error: lint:not-iterable: Object of type `Iterable1` may not be iterable
-  --> /src/mdtest_snippet.py:31:14
+  --> src/mdtest_snippet.py:31:14
    |
 30 |     # error: [not-iterable]
 31 |     for x in Iterable1():
@@ -69,7 +69,7 @@ info: It may not have an `__iter__` method and its `__getitem__` attribute (with
 
 ```
 info: revealed-type: Revealed type
-  --> /src/mdtest_snippet.py:33:9
+  --> src/mdtest_snippet.py:33:9
    |
 31 |     for x in Iterable1():
 32 |         # TODO: `bytes | str` might be better
@@ -83,7 +83,7 @@ info: revealed-type: Revealed type
 
 ```
 error: lint:not-iterable: Object of type `Iterable2` may not be iterable
-  --> /src/mdtest_snippet.py:36:14
+  --> src/mdtest_snippet.py:36:14
    |
 35 |     # error: [not-iterable]
 36 |     for y in Iterable2():
@@ -97,7 +97,7 @@ info: `__getitem__` must be at least as permissive as `def __getitem__(self, key
 
 ```
 info: revealed-type: Revealed type
-  --> /src/mdtest_snippet.py:37:9
+  --> src/mdtest_snippet.py:37:9
    |
 35 |     # error: [not-iterable]
 36 |     for y in Iterable2():

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_possibly_unbound_`__getitem__`.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_possibly_unbound_`__getitem__`.snap
@@ -36,7 +36,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/loops/for.md
 
 ```
 error: lint:not-iterable: Object of type `Iterable` may not be iterable
-  --> /src/mdtest_snippet.py:17:14
+  --> src/mdtest_snippet.py:17:14
    |
 16 |     # error: [not-iterable]
 17 |     for x in Iterable():
@@ -49,7 +49,7 @@ info: It may not have an `__iter__` method or a `__getitem__` method
 
 ```
 info: revealed-type: Revealed type
-  --> /src/mdtest_snippet.py:18:9
+  --> src/mdtest_snippet.py:18:9
    |
 16 |     # error: [not-iterable]
 17 |     for x in Iterable():

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Union_type_as_iterable_where_one_union_element_has_invalid_`__iter__`_method.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Union_type_as_iterable_where_one_union_element_has_invalid_`__iter__`_method.snap
@@ -37,7 +37,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/loops/for.md
 
 ```
 error: lint:not-iterable: Object of type `Test | Test2` may not be iterable
-  --> /src/mdtest_snippet.py:18:14
+  --> src/mdtest_snippet.py:18:14
    |
 16 |     # TODO: Improve error message to state which union variant isn't iterable (https://github.com/astral-sh/ruff/issues/13989)
 17 |     # error: [not-iterable]
@@ -51,7 +51,7 @@ info: Its `__iter__` method returns an object of type `TestIter | int`, which ma
 
 ```
 info: revealed-type: Revealed type
-  --> /src/mdtest_snippet.py:19:9
+  --> src/mdtest_snippet.py:19:9
    |
 17 |     # error: [not-iterable]
 18 |     for x in Test() if flag else Test2():

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Union_type_as_iterable_where_one_union_element_has_no_`__iter__`_method.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Union_type_as_iterable_where_one_union_element_has_no_`__iter__`_method.snap
@@ -32,7 +32,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/loops/for.md
 
 ```
 error: lint:not-iterable: Object of type `Test | Literal[42]` may not be iterable
-  --> /src/mdtest_snippet.py:13:14
+  --> src/mdtest_snippet.py:13:14
    |
 11 | def _(flag: bool):
 12 |     # error: [not-iterable]
@@ -46,7 +46,7 @@ info: It may not have an `__iter__` method and it doesn't have a `__getitem__` m
 
 ```
 info: revealed-type: Revealed type
-  --> /src/mdtest_snippet.py:14:9
+  --> src/mdtest_snippet.py:14:9
    |
 12 |     # error: [not-iterable]
 13 |     for x in Test() if flag else 42:

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_With_non-callable_iterator.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_With_non-callable_iterator.snap
@@ -34,7 +34,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/loops/for.md
 
 ```
 error: lint:not-iterable: Object of type `NotIterable` is not iterable
-  --> /src/mdtest_snippet.py:11:14
+  --> src/mdtest_snippet.py:11:14
    |
 10 |     # error: [not-iterable]
 11 |     for x in NotIterable():
@@ -47,7 +47,7 @@ info: Its `__iter__` attribute has type `int | None`, which is not callable
 
 ```
 warning: lint:possibly-unresolved-reference: Name `x` used when possibly not defined
-  --> /src/mdtest_snippet.py:16:17
+  --> src/mdtest_snippet.py:16:17
    |
 14 |     # revealed: Unknown
 15 |     # error: [possibly-unresolved-reference]
@@ -59,7 +59,7 @@ warning: lint:possibly-unresolved-reference: Name `x` used when possibly not def
 
 ```
 info: revealed-type: Revealed type
-  --> /src/mdtest_snippet.py:16:5
+  --> src/mdtest_snippet.py:16:5
    |
 14 |     # revealed: Unknown
 15 |     # error: [possibly-unresolved-reference]

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_does_not_return_an_iterator.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_does_not_return_an_iterator.snap
@@ -27,7 +27,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/loops/for.md
 
 ```
 error: lint:not-iterable: Object of type `Bad` is not iterable
- --> /src/mdtest_snippet.py:8:10
+ --> src/mdtest_snippet.py:8:10
   |
 7 | # error: [not-iterable]
 8 | for x in Bad():
@@ -40,7 +40,7 @@ info: Its `__iter__` method returns an object of type `int`, which has no `__nex
 
 ```
 info: revealed-type: Revealed type
- --> /src/mdtest_snippet.py:9:5
+ --> src/mdtest_snippet.py:9:5
   |
 7 | # error: [not-iterable]
 8 | for x in Bad():

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_method_with_a_bad_signature.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_method_with_a_bad_signature.snap
@@ -31,7 +31,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/loops/for.md
 
 ```
 error: lint:not-iterable: Object of type `Iterable` is not iterable
-  --> /src/mdtest_snippet.py:12:10
+  --> src/mdtest_snippet.py:12:10
    |
 11 | # error: [not-iterable]
 12 | for x in Iterable():
@@ -45,7 +45,7 @@ info: Expected signature `def __iter__(self): ...`
 
 ```
 info: revealed-type: Revealed type
-  --> /src/mdtest_snippet.py:13:5
+  --> src/mdtest_snippet.py:13:5
    |
 11 | # error: [not-iterable]
 12 | for x in Iterable():

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_returns_an_iterator_with_an_invalid_`__next__`_method.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_returns_an_iterator_with_an_invalid_`__next__`_method.snap
@@ -42,7 +42,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/loops/for.md
 
 ```
 error: lint:not-iterable: Object of type `Iterable1` is not iterable
-  --> /src/mdtest_snippet.py:19:10
+  --> src/mdtest_snippet.py:19:10
    |
 18 | # error: [not-iterable]
 19 | for x in Iterable1():
@@ -56,7 +56,7 @@ info: Expected signature for `__next__` is `def __next__(self): ...`
 
 ```
 info: revealed-type: Revealed type
-  --> /src/mdtest_snippet.py:20:5
+  --> src/mdtest_snippet.py:20:5
    |
 18 | # error: [not-iterable]
 19 | for x in Iterable1():
@@ -70,7 +70,7 @@ info: revealed-type: Revealed type
 
 ```
 error: lint:not-iterable: Object of type `Iterable2` is not iterable
-  --> /src/mdtest_snippet.py:23:10
+  --> src/mdtest_snippet.py:23:10
    |
 22 | # error: [not-iterable]
 23 | for y in Iterable2():
@@ -83,7 +83,7 @@ info: Its `__iter__` method returns an object of type `Iterator2`, which has a `
 
 ```
 info: revealed-type: Revealed type
-  --> /src/mdtest_snippet.py:24:5
+  --> src/mdtest_snippet.py:24:5
    |
 22 | # error: [not-iterable]
 23 | for y in Iterable2():

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/instances.md_-_Binary_operations_on_instances_-_Operations_involving_types_with_invalid_`__bool__`_methods.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/instances.md_-_Binary_operations_on_instances_-_Operations_involving_types_with_invalid_`__bool__`_methods.snap
@@ -25,7 +25,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/binary/instances.m
 
 ```
 error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable`
- --> /src/mdtest_snippet.py:7:8
+ --> src/mdtest_snippet.py:7:8
   |
 6 | # error: [unsupported-bool-conversion]
 7 | 10 and a and True

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Basic.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Basic.snap
@@ -22,7 +22,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/invali
 
 ```
 error: lint:invalid-argument-type: Argument to this function is incorrect
- --> /src/mdtest_snippet.py:4:5
+ --> src/mdtest_snippet.py:4:5
   |
 2 |     return x * x
 3 |
@@ -30,7 +30,7 @@ error: lint:invalid-argument-type: Argument to this function is incorrect
   |     ^^^^^^^ Expected `int`, found `Literal["hello"]`
   |
 info: Function defined here
- --> /src/mdtest_snippet.py:1:5
+ --> src/mdtest_snippet.py:1:5
   |
 1 | def foo(x: int) -> int:
   |     ^^^ ------ Parameter declared here

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Calls_to_methods.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Calls_to_methods.snap
@@ -24,14 +24,14 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/invali
 
 ```
 error: lint:invalid-argument-type: Argument to this function is incorrect
- --> /src/mdtest_snippet.py:6:10
+ --> src/mdtest_snippet.py:6:10
   |
 5 | c = C()
 6 | c.square("hello")  # error: [invalid-argument-type]
   |          ^^^^^^^ Expected `int`, found `Literal["hello"]`
   |
 info: Function defined here
- --> /src/mdtest_snippet.py:2:9
+ --> src/mdtest_snippet.py:2:9
   |
 1 | class C:
 2 |     def square(self, x: int) -> int:

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Different_files.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Different_files.snap
@@ -28,7 +28,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/invali
 
 ```
 error: lint:invalid-argument-type: Argument to this function is incorrect
- --> /src/mdtest_snippet.py:3:13
+ --> src/mdtest_snippet.py:3:13
   |
 1 | import package
 2 |
@@ -36,7 +36,7 @@ error: lint:invalid-argument-type: Argument to this function is incorrect
   |             ^^^^^^^ Expected `int`, found `Literal["hello"]`
   |
 info: Function defined here
- --> /src/package.py:1:5
+ --> src/package.py:1:5
   |
 1 | def foo(x: int) -> int:
   |     ^^^ ------ Parameter declared here

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Different_source_order.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Different_source_order.snap
@@ -23,7 +23,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/invali
 
 ```
 error: lint:invalid-argument-type: Argument to this function is incorrect
- --> /src/mdtest_snippet.py:2:9
+ --> src/mdtest_snippet.py:2:9
   |
 1 | def bar():
 2 |     foo("hello")  # error: [invalid-argument-type]
@@ -32,7 +32,7 @@ error: lint:invalid-argument-type: Argument to this function is incorrect
 4 | def foo(x: int) -> int:
   |
 info: Function defined here
- --> /src/mdtest_snippet.py:4:5
+ --> src/mdtest_snippet.py:4:5
   |
 2 |     foo("hello")  # error: [invalid-argument-type]
 3 |

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters.snap
@@ -22,7 +22,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/invali
 
 ```
 error: lint:invalid-argument-type: Argument to this function is incorrect
- --> /src/mdtest_snippet.py:4:8
+ --> src/mdtest_snippet.py:4:8
   |
 2 |     return x * y * z
 3 |
@@ -30,7 +30,7 @@ error: lint:invalid-argument-type: Argument to this function is incorrect
   |        ^^^^^^^ Expected `int`, found `Literal["hello"]`
   |
 info: Function defined here
- --> /src/mdtest_snippet.py:1:5
+ --> src/mdtest_snippet.py:1:5
   |
 1 | def foo(x: int, y: int, z: int) -> int:
   |     ^^^         ------ Parameter declared here

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters_across_multiple_lines.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters_across_multiple_lines.snap
@@ -26,7 +26,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/invali
 
 ```
 error: lint:invalid-argument-type: Argument to this function is incorrect
- --> /src/mdtest_snippet.py:8:8
+ --> src/mdtest_snippet.py:8:8
   |
 6 |     return x * y * z
 7 |
@@ -34,7 +34,7 @@ error: lint:invalid-argument-type: Argument to this function is incorrect
   |        ^^^^^^^ Expected `int`, found `Literal["hello"]`
   |
 info: Function defined here
- --> /src/mdtest_snippet.py:1:5
+ --> src/mdtest_snippet.py:1:5
   |
 1 | def foo(
   |     ^^^

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters_with_multiple_invalid_arguments.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters_with_multiple_invalid_arguments.snap
@@ -25,7 +25,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/invali
 
 ```
 error: lint:invalid-argument-type: Argument to this function is incorrect
- --> /src/mdtest_snippet.py:7:5
+ --> src/mdtest_snippet.py:7:5
   |
 5 | # error: [invalid-argument-type]
 6 | # error: [invalid-argument-type]
@@ -33,7 +33,7 @@ error: lint:invalid-argument-type: Argument to this function is incorrect
   |     ^^^ Expected `int`, found `Literal["a"]`
   |
 info: Function defined here
- --> /src/mdtest_snippet.py:1:5
+ --> src/mdtest_snippet.py:1:5
   |
 1 | def foo(x: int, y: int, z: int) -> int:
   |     ^^^ ------ Parameter declared here
@@ -44,7 +44,7 @@ info: Function defined here
 
 ```
 error: lint:invalid-argument-type: Argument to this function is incorrect
- --> /src/mdtest_snippet.py:7:10
+ --> src/mdtest_snippet.py:7:10
   |
 5 | # error: [invalid-argument-type]
 6 | # error: [invalid-argument-type]
@@ -52,7 +52,7 @@ error: lint:invalid-argument-type: Argument to this function is incorrect
   |          ^^^ Expected `int`, found `Literal["b"]`
   |
 info: Function defined here
- --> /src/mdtest_snippet.py:1:5
+ --> src/mdtest_snippet.py:1:5
   |
 1 | def foo(x: int, y: int, z: int) -> int:
   |     ^^^         ------ Parameter declared here
@@ -63,7 +63,7 @@ info: Function defined here
 
 ```
 error: lint:invalid-argument-type: Argument to this function is incorrect
- --> /src/mdtest_snippet.py:7:15
+ --> src/mdtest_snippet.py:7:15
   |
 5 | # error: [invalid-argument-type]
 6 | # error: [invalid-argument-type]
@@ -71,7 +71,7 @@ error: lint:invalid-argument-type: Argument to this function is incorrect
   |               ^^^ Expected `int`, found `Literal["c"]`
   |
 info: Function defined here
- --> /src/mdtest_snippet.py:1:5
+ --> src/mdtest_snippet.py:1:5
   |
 1 | def foo(x: int, y: int, z: int) -> int:
   |     ^^^                 ------ Parameter declared here

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Test_calling_a_function_whose_type_is_vendored_from_`typeshed`.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Test_calling_a_function_whose_type_is_vendored_from_`typeshed`.snap
@@ -21,7 +21,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/invali
 
 ```
 error: lint:invalid-argument-type: Argument to this function is incorrect
- --> /src/mdtest_snippet.py:3:12
+ --> src/mdtest_snippet.py:3:12
   |
 1 | import json
 2 |

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Keyword_only_arguments.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Keyword_only_arguments.snap
@@ -22,7 +22,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/invali
 
 ```
 error: lint:invalid-argument-type: Argument to this function is incorrect
- --> /src/mdtest_snippet.py:4:11
+ --> src/mdtest_snippet.py:4:11
   |
 2 |     return x * y * z
 3 |
@@ -30,7 +30,7 @@ error: lint:invalid-argument-type: Argument to this function is incorrect
   |           ^^^^^^^^^ Expected `int`, found `Literal["hello"]`
   |
 info: Function defined here
- --> /src/mdtest_snippet.py:1:5
+ --> src/mdtest_snippet.py:1:5
   |
 1 | def foo(x: int, y: int, *, z: int = 0) -> int:
   |     ^^^                    ---------- Parameter declared here

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Mix_of_arguments.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Mix_of_arguments.snap
@@ -22,7 +22,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/invali
 
 ```
 error: lint:invalid-argument-type: Argument to this function is incorrect
- --> /src/mdtest_snippet.py:4:11
+ --> src/mdtest_snippet.py:4:11
   |
 2 |     return x * y * z
 3 |
@@ -30,7 +30,7 @@ error: lint:invalid-argument-type: Argument to this function is incorrect
   |           ^^^^^^^^^ Expected `int`, found `Literal["hello"]`
   |
 info: Function defined here
- --> /src/mdtest_snippet.py:1:5
+ --> src/mdtest_snippet.py:1:5
   |
 1 | def foo(x: int, /, y: int, *, z: int = 0) -> int:
   |     ^^^                       ---------- Parameter declared here

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_One_keyword_argument.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_One_keyword_argument.snap
@@ -22,7 +22,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/invali
 
 ```
 error: lint:invalid-argument-type: Argument to this function is incorrect
- --> /src/mdtest_snippet.py:4:11
+ --> src/mdtest_snippet.py:4:11
   |
 2 |     return x * y * z
 3 |
@@ -30,7 +30,7 @@ error: lint:invalid-argument-type: Argument to this function is incorrect
   |           ^^^^^^^ Expected `int`, found `Literal["hello"]`
   |
 info: Function defined here
- --> /src/mdtest_snippet.py:1:5
+ --> src/mdtest_snippet.py:1:5
   |
 1 | def foo(x: int, y: int, z: int = 0) -> int:
   |     ^^^                 ---------- Parameter declared here

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Only_positional.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Only_positional.snap
@@ -22,7 +22,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/invali
 
 ```
 error: lint:invalid-argument-type: Argument to this function is incorrect
- --> /src/mdtest_snippet.py:4:8
+ --> src/mdtest_snippet.py:4:8
   |
 2 |     return x * y * z
 3 |
@@ -30,7 +30,7 @@ error: lint:invalid-argument-type: Argument to this function is incorrect
   |        ^^^^^^^ Expected `int`, found `Literal["hello"]`
   |
 info: Function defined here
- --> /src/mdtest_snippet.py:1:5
+ --> src/mdtest_snippet.py:1:5
   |
 1 | def foo(x: int, y: int, z: int, /) -> int:
   |     ^^^         ------ Parameter declared here

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Synthetic_arguments.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Synthetic_arguments.snap
@@ -24,14 +24,14 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/invali
 
 ```
 error: lint:invalid-argument-type: Argument to this function is incorrect
- --> /src/mdtest_snippet.py:6:3
+ --> src/mdtest_snippet.py:6:3
   |
 5 | c = C()
 6 | c("wrong")  # error: [invalid-argument-type]
   |   ^^^^^^^ Expected `int`, found `Literal["wrong"]`
   |
 info: Function defined here
- --> /src/mdtest_snippet.py:2:9
+ --> src/mdtest_snippet.py:2:9
   |
 1 | class C:
 2 |     def __call__(self, x: int) -> int:

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Variadic_arguments.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Variadic_arguments.snap
@@ -22,7 +22,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/invali
 
 ```
 error: lint:invalid-argument-type: Argument to this function is incorrect
- --> /src/mdtest_snippet.py:4:14
+ --> src/mdtest_snippet.py:4:14
   |
 2 |     return len(numbers)
 3 |
@@ -30,7 +30,7 @@ error: lint:invalid-argument-type: Argument to this function is incorrect
   |              ^^^^^^^ Expected `int`, found `Literal["hello"]`
   |
 info: Function defined here
- --> /src/mdtest_snippet.py:1:5
+ --> src/mdtest_snippet.py:1:5
   |
 1 | def foo(*numbers: int) -> int:
   |     ^^^ ------------- Parameter declared here

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Variadic_keyword_arguments.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Variadic_keyword_arguments.snap
@@ -22,7 +22,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/invali
 
 ```
 error: lint:invalid-argument-type: Argument to this function is incorrect
- --> /src/mdtest_snippet.py:4:20
+ --> src/mdtest_snippet.py:4:20
   |
 2 |     return len(numbers)
 3 |
@@ -30,7 +30,7 @@ error: lint:invalid-argument-type: Argument to this function is incorrect
   |                    ^^^^^^^^^ Expected `int`, found `Literal["hello"]`
   |
 info: Function defined here
- --> /src/mdtest_snippet.py:1:5
+ --> src/mdtest_snippet.py:1:5
   |
 1 | def foo(**numbers: int) -> int:
   |     ^^^ -------------- Parameter declared here

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/membership_test.md_-_Comparison___Membership_Test_-_Return_type_that_doesn't_implement_`__bool__`_correctly.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/membership_test.md_-_Comparison___Membership_Test_-_Return_type_that_doesn't_implement_`__bool__`_correctly.snap
@@ -29,7 +29,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/comparison/instanc
 
 ```
 error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable`
-  --> /src/mdtest_snippet.py:9:1
+  --> src/mdtest_snippet.py:9:1
    |
  8 | # error: [unsupported-bool-conversion]
  9 | 10 in WithContains()
@@ -43,7 +43,7 @@ info: `__bool__` on `NotBoolable` must be callable
 
 ```
 error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable`
-  --> /src/mdtest_snippet.py:11:1
+  --> src/mdtest_snippet.py:11:1
    |
  9 | 10 in WithContains()
 10 | # error: [unsupported-bool-conversion]

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/no_matching_overload.md_-_No_matching_overload_diagnostics_-_Calls_to_overloaded_functions.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/no_matching_overload.md_-_No_matching_overload_diagnostics_-_Calls_to_overloaded_functions.snap
@@ -19,7 +19,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/no_mat
 
 ```
 error: lint:no-matching-overload: No overload of class `type` matches arguments
- --> /src/mdtest_snippet.py:1:1
+ --> src/mdtest_snippet.py:1:1
   |
 1 | type("Foo", ())  # error: [no-matching-overload]
   | ^^^^^^^^^^^^^^^

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/not.md_-_Unary_not_-_Object_that_implements_`__bool__`_incorrectly.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/not.md_-_Unary_not_-_Object_that_implements_`__bool__`_incorrectly.snap
@@ -23,7 +23,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/unary/not.md
 
 ```
 error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable`
- --> /src/mdtest_snippet.py:5:1
+ --> src/mdtest_snippet.py:5:1
   |
 4 | # error: [unsupported-bool-conversion]
 5 | not NotBoolable()

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Calls_to_protocol_classes.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Calls_to_protocol_classes.snap
@@ -33,7 +33,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/protocols.md
 
 ```
 error: lint:call-non-callable: Object of type `typing.Protocol` is not callable
- --> /src/mdtest_snippet.py:4:13
+ --> src/mdtest_snippet.py:4:13
   |
 3 | # error: [call-non-callable]
 4 | reveal_type(Protocol())  # revealed: Unknown
@@ -46,7 +46,7 @@ error: lint:call-non-callable: Object of type `typing.Protocol` is not callable
 
 ```
 info: revealed-type: Revealed type
- --> /src/mdtest_snippet.py:4:1
+ --> src/mdtest_snippet.py:4:1
   |
 3 | # error: [call-non-callable]
 4 | reveal_type(Protocol())  # revealed: Unknown
@@ -59,7 +59,7 @@ info: revealed-type: Revealed type
 
 ```
 error: lint:call-non-callable: Cannot instantiate class `MyProtocol`
-  --> /src/mdtest_snippet.py:10:13
+  --> src/mdtest_snippet.py:10:13
    |
  9 | # error: [call-non-callable] "Cannot instantiate class `MyProtocol`"
 10 | reveal_type(MyProtocol())  # revealed: MyProtocol
@@ -67,7 +67,7 @@ error: lint:call-non-callable: Cannot instantiate class `MyProtocol`
 11 | class SubclassOfMyProtocol(MyProtocol): ...
    |
 info: Protocol classes cannot be instantiated
- --> /src/mdtest_snippet.py:6:7
+ --> src/mdtest_snippet.py:6:7
   |
 4 | reveal_type(Protocol())  # revealed: Unknown
 5 |
@@ -80,7 +80,7 @@ info: Protocol classes cannot be instantiated
 
 ```
 info: revealed-type: Revealed type
-  --> /src/mdtest_snippet.py:10:1
+  --> src/mdtest_snippet.py:10:1
    |
  9 | # error: [call-non-callable] "Cannot instantiate class `MyProtocol`"
 10 | reveal_type(MyProtocol())  # revealed: MyProtocol
@@ -92,7 +92,7 @@ info: revealed-type: Revealed type
 
 ```
 info: revealed-type: Revealed type
-  --> /src/mdtest_snippet.py:13:1
+  --> src/mdtest_snippet.py:13:1
    |
 11 | class SubclassOfMyProtocol(MyProtocol): ...
 12 |
@@ -106,7 +106,7 @@ info: revealed-type: Revealed type
 
 ```
 info: revealed-type: Revealed type
-  --> /src/mdtest_snippet.py:15:5
+  --> src/mdtest_snippet.py:15:5
    |
 13 | reveal_type(SubclassOfMyProtocol())  # revealed: SubclassOfMyProtocol
 14 | def f(x: type[MyProtocol]):

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Invalid_calls_to_`get_protocol_members()`.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Invalid_calls_to_`get_protocol_members()`.snap
@@ -30,7 +30,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/protocols.md
 
 ```
 error: lint:invalid-argument-type: Invalid argument to `get_protocol_members`
- --> /src/mdtest_snippet.py:5:1
+ --> src/mdtest_snippet.py:5:1
   |
 3 | class NotAProtocol: ...
 4 |
@@ -41,7 +41,7 @@ error: lint:invalid-argument-type: Invalid argument to `get_protocol_members`
   |
 info: Only protocol classes can be passed to `get_protocol_members`
 info: `NotAProtocol` is declared here, but it is not a protocol class:
- --> /src/mdtest_snippet.py:3:7
+ --> src/mdtest_snippet.py:3:7
   |
 1 | from typing_extensions import Protocol, get_protocol_members
 2 |
@@ -57,7 +57,7 @@ info: See https://typing.python.org/en/latest/spec/protocol.html#
 
 ```
 error: lint:invalid-argument-type: Invalid argument to `get_protocol_members`
-  --> /src/mdtest_snippet.py:9:1
+  --> src/mdtest_snippet.py:9:1
    |
  7 | class AlsoNotAProtocol(NotAProtocol, object): ...
  8 |
@@ -67,7 +67,7 @@ error: lint:invalid-argument-type: Invalid argument to `get_protocol_members`
    |
 info: Only protocol classes can be passed to `get_protocol_members`
 info: `AlsoNotAProtocol` is declared here, but it is not a protocol class:
- --> /src/mdtest_snippet.py:7:7
+ --> src/mdtest_snippet.py:7:7
   |
 5 | get_protocol_members(NotAProtocol)  # error: [invalid-argument-type]
 6 |

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Narrowing_of_protocols.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Narrowing_of_protocols.snap
@@ -58,7 +58,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/protocols.md
 
 ```
 error: lint:invalid-argument-type: Class `HasX` cannot be used as the second argument to `isinstance`
- --> /src/mdtest_snippet.py:7:8
+ --> src/mdtest_snippet.py:7:8
   |
 6 | def f(arg: object, arg2: type):
 7 |     if isinstance(arg, HasX):  # error: [invalid-argument-type]
@@ -67,7 +67,7 @@ error: lint:invalid-argument-type: Class `HasX` cannot be used as the second arg
 9 |     else:
   |
 info: `HasX` is declared as a protocol class, but it is not declared as runtime-checkable
- --> /src/mdtest_snippet.py:3:7
+ --> src/mdtest_snippet.py:3:7
   |
 1 | from typing_extensions import Protocol, reveal_type
 2 |
@@ -82,7 +82,7 @@ info: See https://docs.python.org/3/library/typing.html#typing.runtime_checkable
 
 ```
 info: revealed-type: Revealed type
-  --> /src/mdtest_snippet.py:8:9
+  --> src/mdtest_snippet.py:8:9
    |
  6 | def f(arg: object, arg2: type):
  7 |     if isinstance(arg, HasX):  # error: [invalid-argument-type]
@@ -96,7 +96,7 @@ info: revealed-type: Revealed type
 
 ```
 info: revealed-type: Revealed type
-  --> /src/mdtest_snippet.py:10:9
+  --> src/mdtest_snippet.py:10:9
    |
  8 |         reveal_type(arg)  # revealed: HasX
  9 |     else:
@@ -110,7 +110,7 @@ info: revealed-type: Revealed type
 
 ```
 error: lint:invalid-argument-type: Class `HasX` cannot be used as the second argument to `issubclass`
-  --> /src/mdtest_snippet.py:12:8
+  --> src/mdtest_snippet.py:12:8
    |
 10 |         reveal_type(arg)  # revealed: ~HasX
 11 |
@@ -120,7 +120,7 @@ error: lint:invalid-argument-type: Class `HasX` cannot be used as the second arg
 14 |     else:
    |
 info: `HasX` is declared as a protocol class, but it is not declared as runtime-checkable
- --> /src/mdtest_snippet.py:3:7
+ --> src/mdtest_snippet.py:3:7
   |
 1 | from typing_extensions import Protocol, reveal_type
 2 |
@@ -135,7 +135,7 @@ info: See https://docs.python.org/3/library/typing.html#typing.runtime_checkable
 
 ```
 info: revealed-type: Revealed type
-  --> /src/mdtest_snippet.py:13:9
+  --> src/mdtest_snippet.py:13:9
    |
 12 |     if issubclass(arg2, HasX):  # error: [invalid-argument-type]
 13 |         reveal_type(arg2)  # revealed: type[HasX]
@@ -148,7 +148,7 @@ info: revealed-type: Revealed type
 
 ```
 info: revealed-type: Revealed type
-  --> /src/mdtest_snippet.py:15:9
+  --> src/mdtest_snippet.py:15:9
    |
 13 |         reveal_type(arg2)  # revealed: type[HasX]
 14 |     else:
@@ -161,7 +161,7 @@ info: revealed-type: Revealed type
 
 ```
 info: revealed-type: Revealed type
-  --> /src/mdtest_snippet.py:24:9
+  --> src/mdtest_snippet.py:24:9
    |
 22 | def f(arg: object):
 23 |     if isinstance(arg, RuntimeCheckableHasX):  # no error!
@@ -175,7 +175,7 @@ info: revealed-type: Revealed type
 
 ```
 info: revealed-type: Revealed type
-  --> /src/mdtest_snippet.py:26:9
+  --> src/mdtest_snippet.py:26:9
    |
 24 |         reveal_type(arg)  # revealed: RuntimeCheckableHasX
 25 |     else:
@@ -189,7 +189,7 @@ info: revealed-type: Revealed type
 
 ```
 info: revealed-type: Revealed type
-  --> /src/mdtest_snippet.py:33:9
+  --> src/mdtest_snippet.py:33:9
    |
 31 | def f(arg1: type, arg2: type):
 32 |     if issubclass(arg1, RuntimeCheckableHasX):  # TODO: should emit an error here (has non-method members)
@@ -203,7 +203,7 @@ info: revealed-type: Revealed type
 
 ```
 info: revealed-type: Revealed type
-  --> /src/mdtest_snippet.py:35:9
+  --> src/mdtest_snippet.py:35:9
    |
 33 |         reveal_type(arg1)  # revealed: type[RuntimeCheckableHasX]
 34 |     else:
@@ -217,7 +217,7 @@ info: revealed-type: Revealed type
 
 ```
 info: revealed-type: Revealed type
-  --> /src/mdtest_snippet.py:38:9
+  --> src/mdtest_snippet.py:38:9
    |
 37 |     if issubclass(arg2, OnlyMethodMembers):  # no error!
 38 |         reveal_type(arg2)  # revealed: type[OnlyMethodMembers]
@@ -230,7 +230,7 @@ info: revealed-type: Revealed type
 
 ```
 info: revealed-type: Revealed type
-  --> /src/mdtest_snippet.py:40:9
+  --> src/mdtest_snippet.py:40:9
    |
 38 |         reveal_type(arg2)  # revealed: type[OnlyMethodMembers]
 39 |     else:

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_conditional_return_type.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_conditional_return_type.snap
@@ -32,7 +32,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/function/return_ty
 
 ```
 error: lint:invalid-return-type: Return type does not match returned value
- --> /src/mdtest_snippet.py:1:22
+ --> src/mdtest_snippet.py:1:22
   |
 1 | def f(cond: bool) -> str:
   |                      --- Expected `str` because of return type
@@ -50,7 +50,7 @@ error: lint:invalid-return-type: Return type does not match returned value
 
 ```
 error: lint:invalid-return-type: Return type does not match returned value
-  --> /src/mdtest_snippet.py:8:22
+  --> src/mdtest_snippet.py:8:22
    |
  6 |         return 1
  7 |
@@ -68,14 +68,14 @@ error: lint:invalid-return-type: Return type does not match returned value
 
 ```
 error: lint:invalid-return-type: Return type does not match returned value
-  --> /src/mdtest_snippet.py:14:16
+  --> src/mdtest_snippet.py:14:16
    |
 12 |     else:
 13 |         # error: [invalid-return-type]
 14 |         return 2
    |                ^ Expected `str`, found `Literal[2]`
    |
-  ::: /src/mdtest_snippet.py:8:22
+  ::: src/mdtest_snippet.py:8:22
    |
  6 |         return 1
  7 |

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_implicit_return_type.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_implicit_return_type.snap
@@ -41,7 +41,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/function/return_ty
 
 ```
 error: lint:invalid-return-type: Return type does not match returned value
- --> /src/mdtest_snippet.py:1:12
+ --> src/mdtest_snippet.py:1:12
   |
 1 | def f() -> None:
   |            ---- Expected `None` because of return type
@@ -57,7 +57,7 @@ error: lint:invalid-return-type: Return type does not match returned value
 
 ```
 error: lint:invalid-return-type: Function can implicitly return `None`, which is not assignable to return type `int`
- --> /src/mdtest_snippet.py:7:22
+ --> src/mdtest_snippet.py:7:22
   |
 6 | # error: [invalid-return-type]
 7 | def f(cond: bool) -> int:
@@ -70,7 +70,7 @@ error: lint:invalid-return-type: Function can implicitly return `None`, which is
 
 ```
 error: lint:invalid-return-type: Function can implicitly return `None`, which is not assignable to return type `int`
-  --> /src/mdtest_snippet.py:12:22
+  --> src/mdtest_snippet.py:12:22
    |
 11 | # error: [invalid-return-type]
 12 | def f(cond: bool) -> int:
@@ -83,7 +83,7 @@ error: lint:invalid-return-type: Function can implicitly return `None`, which is
 
 ```
 error: lint:invalid-return-type: Function can implicitly return `None`, which is not assignable to return type `int`
-  --> /src/mdtest_snippet.py:17:22
+  --> src/mdtest_snippet.py:17:22
    |
 16 | # error: [invalid-return-type]
 17 | def f(cond: bool) -> int:

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type.snap
@@ -36,7 +36,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/function/return_ty
 
 ```
 error: lint:invalid-return-type: Function can implicitly return `None`, which is not assignable to return type `int`
- --> /src/mdtest_snippet.py:2:12
+ --> src/mdtest_snippet.py:2:12
   |
 1 | # error: [invalid-return-type]
 2 | def f() -> int:
@@ -48,7 +48,7 @@ error: lint:invalid-return-type: Function can implicitly return `None`, which is
 
 ```
 error: lint:invalid-return-type: Return type does not match returned value
- --> /src/mdtest_snippet.py:5:12
+ --> src/mdtest_snippet.py:5:12
   |
 3 |     1
 4 |
@@ -65,7 +65,7 @@ error: lint:invalid-return-type: Return type does not match returned value
 
 ```
 error: lint:invalid-return-type: Return type does not match returned value
-  --> /src/mdtest_snippet.py:9:12
+  --> src/mdtest_snippet.py:9:12
    |
  7 |     return 1
  8 |

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type_in_stub_file.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type_in_stub_file.snap
@@ -31,7 +31,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/function/return_ty
 
 ```
 error: lint:invalid-return-type: Return type does not match returned value
- --> /src/mdtest_snippet.pyi:1:12
+ --> src/mdtest_snippet.pyi:1:12
   |
 1 | def f() -> int:
   |            --- Expected `int` because of return type
@@ -46,7 +46,7 @@ error: lint:invalid-return-type: Return type does not match returned value
 
 ```
 error: lint:invalid-return-type: Function can implicitly return `None`, which is not assignable to return type `int`
- --> /src/mdtest_snippet.pyi:6:14
+ --> src/mdtest_snippet.pyi:6:14
   |
 5 | # error: [invalid-return-type]
 6 | def foo() -> int:
@@ -59,7 +59,7 @@ error: lint:invalid-return-type: Function can implicitly return `None`, which is
 
 ```
 error: lint:invalid-return-type: Function can implicitly return `None`, which is not assignable to return type `int`
-  --> /src/mdtest_snippet.pyi:11:14
+  --> src/mdtest_snippet.pyi:11:14
    |
 10 | # error: [invalid-return-type]
 11 | def foo() -> int:

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/rich_comparison.md_-_Comparison___Rich_Comparison_-_Chained_comparisons_with_objects_that_don't_implement_`__bool__`_correctly.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/rich_comparison.md_-_Comparison___Rich_Comparison_-_Chained_comparisons_with_objects_that_don't_implement_`__bool__`_correctly.snap
@@ -34,7 +34,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/comparison/instanc
 
 ```
 error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable`
-  --> /src/mdtest_snippet.py:12:1
+  --> src/mdtest_snippet.py:12:1
    |
 11 | # error: [unsupported-bool-conversion]
 12 | 10 < Comparable() < 20
@@ -48,7 +48,7 @@ info: `__bool__` on `NotBoolable` must be callable
 
 ```
 error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable`
-  --> /src/mdtest_snippet.py:14:1
+  --> src/mdtest_snippet.py:14:1
    |
 12 | 10 < Comparable() < 20
 13 | # error: [unsupported-bool-conversion]

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/semantic_syntax_errors.md_-_Semantic_syntax_error_diagnostics_-_`async`_comprehensions_in_synchronous_comprehensions_-_Python_3.10.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/semantic_syntax_errors.md_-_Semantic_syntax_error_diagnostics_-_`async`_comprehensions_in_synchronous_comprehensions_-_Python_3.10.snap
@@ -33,7 +33,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/semant
 
 ```
 error: invalid-syntax
- --> /src/mdtest_snippet.py:6:19
+ --> src/mdtest_snippet.py:6:19
   |
 4 | async def f():
 5 |     # error: 19 [invalid-syntax] "cannot use an asynchronous comprehension inside of a synchronous comprehension on Python 3.10 (synt...

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/shadowing.md_-_Shadowing_-_Implicit_class_shadowing.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/shadowing.md_-_Shadowing_-_Implicit_class_shadowing.snap
@@ -21,7 +21,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/shadow
 
 ```
 error: lint:invalid-assignment: Implicit shadowing of class `C`
- --> /src/mdtest_snippet.py:3:1
+ --> src/mdtest_snippet.py:3:1
   |
 1 | class C: ...
 2 |

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/shadowing.md_-_Shadowing_-_Implicit_function_shadowing.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/shadowing.md_-_Shadowing_-_Implicit_function_shadowing.snap
@@ -21,7 +21,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/shadow
 
 ```
 error: lint:invalid-assignment: Implicit shadowing of function `f`
- --> /src/mdtest_snippet.py:3:1
+ --> src/mdtest_snippet.py:3:1
   |
 1 | def f(): ...
 2 |

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/tuples.md_-_Comparison___Tuples_-_Chained_comparisons_with_elements_that_incorrectly_implement_`__bool__`.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/tuples.md_-_Comparison___Tuples_-_Chained_comparisons_with_elements_that_incorrectly_implement_`__bool__`.snap
@@ -35,7 +35,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/comparison/tuples.
 
 ```
 error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable | Literal[False]`
-  --> /src/mdtest_snippet.py:15:1
+  --> src/mdtest_snippet.py:15:1
    |
 14 | # error: [unsupported-bool-conversion]
 15 | a < b < b

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/tuples.md_-_Comparison___Tuples_-_Equality_with_elements_that_incorrectly_implement_`__bool__`.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/tuples.md_-_Comparison___Tuples_-_Equality_with_elements_that_incorrectly_implement_`__bool__`.snap
@@ -27,7 +27,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/comparison/tuples.
 
 ```
 error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable`
- --> /src/mdtest_snippet.py:9:1
+ --> src/mdtest_snippet.py:9:1
   |
 8 | # error: [unsupported-bool-conversion]
 9 | (A(),) == (A(),)

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Exactly_too_few_values_to_unpack.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Exactly_too_few_values_to_unpack.snap
@@ -19,7 +19,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/unpack
 
 ```
 error: lint:invalid-assignment: Not enough values to unpack
- --> /src/mdtest_snippet.py:1:1
+ --> src/mdtest_snippet.py:1:1
   |
 1 | a, b = (1,)  # error: [invalid-assignment]
   | ^^^^   ---- Got 1

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Exactly_too_many_values_to_unpack.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Exactly_too_many_values_to_unpack.snap
@@ -19,7 +19,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/unpack
 
 ```
 error: lint:invalid-assignment: Too many values to unpack
- --> /src/mdtest_snippet.py:1:1
+ --> src/mdtest_snippet.py:1:1
   |
 1 | a, b = (1, 2, 3)  # error: [invalid-assignment]
   | ^^^^   --------- Got 3

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Right_hand_side_not_iterable.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Right_hand_side_not_iterable.snap
@@ -19,7 +19,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/unpack
 
 ```
 error: lint:not-iterable: Object of type `Literal[1]` is not iterable
- --> /src/mdtest_snippet.py:1:8
+ --> src/mdtest_snippet.py:1:8
   |
 1 | a, b = 1  # error: [not-iterable]
   |        ^

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Too_few_values_to_unpack.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Too_few_values_to_unpack.snap
@@ -19,7 +19,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/unpack
 
 ```
 error: lint:invalid-assignment: Not enough values to unpack
- --> /src/mdtest_snippet.py:1:1
+ --> src/mdtest_snippet.py:1:1
   |
 1 | [a, *b, c, d] = (1, 2)  # error: [invalid-assignment]
   | ^^^^^^^^^^^^^   ------ Got 2

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_An_unresolvable_import_that_does_not_use_`from`.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_An_unresolvable_import_that_does_not_use_`from`.snap
@@ -21,7 +21,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/unreso
 
 ```
 error: lint:unresolved-import: Cannot resolve import `does_not_exist`
- --> /src/mdtest_snippet.py:1:8
+ --> src/mdtest_snippet.py:1:8
   |
 1 | import does_not_exist  # error: [unresolved-import]
   |        ^^^^^^^^^^^^^^

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_a_resolvable_module_but_unresolvable_item.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_a_resolvable_module_but_unresolvable_item.snap
@@ -26,7 +26,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/unreso
 
 ```
 error: lint:unresolved-import: Module `a` has no member `does_not_exist`
- --> /src/mdtest_snippet.py:1:28
+ --> src/mdtest_snippet.py:1:28
   |
 1 | from a import does_exist1, does_not_exist, does_exist2  # error: [unresolved-import]
   |                            ^^^^^^^^^^^^^^

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_an_unknown_current_module.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_an_unknown_current_module.snap
@@ -21,7 +21,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/unreso
 
 ```
 error: lint:unresolved-import: Cannot resolve import `.does_not_exist`
- --> /src/mdtest_snippet.py:1:7
+ --> src/mdtest_snippet.py:1:7
   |
 1 | from .does_not_exist import add  # error: [unresolved-import]
   |       ^^^^^^^^^^^^^^

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_an_unknown_nested_module.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_an_unknown_nested_module.snap
@@ -21,7 +21,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/unreso
 
 ```
 error: lint:unresolved-import: Cannot resolve import `.does_not_exist.foo.bar`
- --> /src/mdtest_snippet.py:1:7
+ --> src/mdtest_snippet.py:1:7
   |
 1 | from .does_not_exist.foo.bar import add  # error: [unresolved-import]
   |       ^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_an_unresolvable_module.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_an_unresolvable_module.snap
@@ -21,7 +21,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/unreso
 
 ```
 error: lint:unresolved-import: Cannot resolve import `does_not_exist`
- --> /src/mdtest_snippet.py:1:6
+ --> src/mdtest_snippet.py:1:6
   |
 1 | from does_not_exist import add  # error: [unresolved-import]
   |      ^^^^^^^^^^^^^^

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_too_many_leading_dots.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_too_many_leading_dots.snap
@@ -33,7 +33,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/unreso
 
 ```
 error: lint:unresolved-import: Cannot resolve import `....foo`
- --> /src/package/subpackage/subsubpackage/__init__.py:1:10
+ --> src/package/subpackage/subsubpackage/__init__.py:1:10
   |
 1 | from ....foo import add  # error: [unresolved-import]
   |          ^^^

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/unsupported_bool_conversion.md_-_Different_ways_that_`unsupported-bool-conversion`_can_occur_-_Has_a_`__bool__`_attribute,_but_it's_not_callable.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/unsupported_bool_conversion.md_-_Different_ways_that_`unsupported-bool-conversion`_can_occur_-_Has_a_`__bool__`_attribute,_but_it's_not_callable.snap
@@ -25,7 +25,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/unsupp
 
 ```
 error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable`
- --> /src/mdtest_snippet.py:7:8
+ --> src/mdtest_snippet.py:7:8
   |
 6 | # error: [unsupported-bool-conversion]
 7 | 10 and a and True

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/unsupported_bool_conversion.md_-_Different_ways_that_`unsupported-bool-conversion`_can_occur_-_Has_a_`__bool__`_method,_but_has_an_incorrect_return_type.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/unsupported_bool_conversion.md_-_Different_ways_that_`unsupported-bool-conversion`_can_occur_-_Has_a_`__bool__`_method,_but_has_an_incorrect_return_type.snap
@@ -26,14 +26,14 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/unsupp
 
 ```
 error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable`
- --> /src/mdtest_snippet.py:8:8
+ --> src/mdtest_snippet.py:8:8
   |
 7 | # error: [unsupported-bool-conversion]
 8 | 10 and a and True
   |        ^
   |
 info: `str` is not assignable to `bool`
- --> /src/mdtest_snippet.py:2:9
+ --> src/mdtest_snippet.py:2:9
   |
 1 | class NotBoolable:
 2 |     def __bool__(self) -> str:

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/unsupported_bool_conversion.md_-_Different_ways_that_`unsupported-bool-conversion`_can_occur_-_Has_a_`__bool__`_method,_but_has_incorrect_parameters.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/unsupported_bool_conversion.md_-_Different_ways_that_`unsupported-bool-conversion`_can_occur_-_Has_a_`__bool__`_method,_but_has_incorrect_parameters.snap
@@ -26,14 +26,14 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/unsupp
 
 ```
 error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable`
- --> /src/mdtest_snippet.py:8:8
+ --> src/mdtest_snippet.py:8:8
   |
 7 | # error: [unsupported-bool-conversion]
 8 | 10 and a and True
   |        ^
   |
 info: `__bool__` methods must only have a `self` parameter
- --> /src/mdtest_snippet.py:2:9
+ --> src/mdtest_snippet.py:2:9
   |
 1 | class NotBoolable:
 2 |     def __bool__(self, foo):

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/unsupported_bool_conversion.md_-_Different_ways_that_`unsupported-bool-conversion`_can_occur_-_Part_of_a_union_where_at_least_one_member_has_incorrect_`__bool__`_method.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/unsupported_bool_conversion.md_-_Different_ways_that_`unsupported-bool-conversion`_can_occur_-_Part_of_a_union_where_at_least_one_member_has_incorrect_`__bool__`_method.snap
@@ -33,7 +33,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/unsupp
 
 ```
 error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for union `NotBoolable1 | NotBoolable2 | NotBoolable3` because `NotBoolable1` doesn't implement `__bool__` correctly
-  --> /src/mdtest_snippet.py:15:8
+  --> src/mdtest_snippet.py:15:8
    |
 14 | # error: [unsupported-bool-conversion]
 15 | 10 and get() and True

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/version_related_syntax_errors.md_-_Version-related_syntax_error_diagnostics_-_`match`_statement_-_Before_3.10.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/version_related_syntax_errors.md_-_Version-related_syntax_error_diagnostics_-_`match`_statement_-_Before_3.10.snap
@@ -21,7 +21,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/versio
 
 ```
 error: invalid-syntax
- --> /src/mdtest_snippet.py:1:1
+ --> src/mdtest_snippet.py:1:1
   |
 1 | match 2:  # error: 1 [invalid-syntax] "Cannot use `match` statement on Python 3.9 (syntax was added in Python 3.10)"
   | ^^^^^ Cannot use `match` statement on Python 3.9 (syntax was added in Python 3.10)

--- a/crates/ruff_db/src/diagnostic/render.rs
+++ b/crates/ruff_db/src/diagnostic/render.rs
@@ -10,6 +10,7 @@ use ruff_text_size::{TextRange, TextSize};
 use crate::{
     files::File,
     source::{line_index, source_text, SourceText},
+    system::SystemPath,
     Db,
 };
 
@@ -604,7 +605,10 @@ impl<'a> FileResolver<'a> {
 
     /// Returns the path associated with the file given.
     fn path(&self, file: File) -> &'a str {
-        file.path(self.db).as_str()
+        relativize_path(
+            self.db.system().current_directory(),
+            file.path(self.db).as_str(),
+        )
     }
 
     /// Returns the input contents associated with the file given.
@@ -674,6 +678,14 @@ fn context_after(source: &SourceCode<'_, '_>, len: usize, start: OneIndexed) -> 
         line = line.saturating_sub(1);
     }
     line
+}
+
+/// Convert an absolute path to be relative to the current working directory.
+fn relativize_path<'p>(cwd: &SystemPath, path: &'p str) -> &'p str {
+    if let Ok(path) = SystemPath::new(path).strip_prefix(cwd) {
+        return path.as_str();
+    }
+    path
 }
 
 #[cfg(test)]
@@ -757,7 +769,7 @@ watermelon
             env.render(&diag),
             @r"
         error: lint:test-diagnostic: main diagnostic message
-         --> /animals:5:1
+         --> animals:5:1
           |
         3 | canary
         4 | dog
@@ -781,7 +793,7 @@ watermelon
             env.render(&diag),
             @r"
         warning: lint:test-diagnostic: main diagnostic message
-         --> /animals:5:1
+         --> animals:5:1
           |
         3 | canary
         4 | dog
@@ -801,7 +813,7 @@ watermelon
             env.render(&diag),
             @r"
         info: lint:test-diagnostic: main diagnostic message
-         --> /animals:5:1
+         --> animals:5:1
           |
         3 | canary
         4 | dog
@@ -828,7 +840,7 @@ watermelon
             env.render(&diag),
             @r"
         error: lint:test-diagnostic: main diagnostic message
-         --> /animals:1:1
+         --> animals:1:1
           |
         1 | aardvark
           | ^
@@ -847,7 +859,7 @@ watermelon
             env.render(&diag),
             @r"
         error: lint:test-diagnostic: main diagnostic message
-         --> /animals:1:1
+         --> animals:1:1
           |
         1 | aardvark
           | ^ primary annotation message
@@ -868,7 +880,7 @@ watermelon
             env.render(&diag),
             @r"
         error: lint:test-diagnostic: main diagnostic message
-         --> /non-ascii:5:1
+         --> non-ascii:5:1
           |
         3 | ΔΔΔΔΔΔΔΔΔΔΔΔ
         4 | ββββββββββββ
@@ -887,7 +899,7 @@ watermelon
             env.render(&diag),
             @r"
         error: lint:test-diagnostic: main diagnostic message
-         --> /non-ascii:2:2
+         --> non-ascii:2:2
           |
         1 | ☃☃☃☃☃☃☃☃☃☃☃☃
         2 | 💩💩💩💩💩💩💩💩💩💩💩💩
@@ -911,7 +923,7 @@ watermelon
             env.render(&diag),
             @r"
         error: lint:test-diagnostic: main diagnostic message
-         --> /animals:5:1
+         --> animals:5:1
           |
         4 | dog
         5 | elephant
@@ -928,7 +940,7 @@ watermelon
             env.render(&diag),
             @r"
         error: lint:test-diagnostic: main diagnostic message
-         --> /animals:5:1
+         --> animals:5:1
           |
         5 | elephant
           | ^^^^^^^^
@@ -943,7 +955,7 @@ watermelon
             env.render(&diag),
             @r"
         error: lint:test-diagnostic: main diagnostic message
-         --> /animals:1:1
+         --> animals:1:1
           |
         1 | aardvark
           | ^^^^^^^^
@@ -960,7 +972,7 @@ watermelon
             env.render(&diag),
             @r"
         error: lint:test-diagnostic: main diagnostic message
-          --> /animals:11:1
+          --> animals:11:1
            |
          9 | inchworm
         10 | jackrabbit
@@ -977,7 +989,7 @@ watermelon
             env.render(&diag),
             @r"
         error: lint:test-diagnostic: main diagnostic message
-          --> /animals:5:1
+          --> animals:5:1
            |
          1 | aardvark
          2 | beetle
@@ -1010,14 +1022,14 @@ watermelon
             env.render(&diag),
             @r"
         error: lint:test-diagnostic: main diagnostic message
-          --> /animals:1:1
+          --> animals:1:1
            |
          1 | aardvark
            | ^^^^^^^^
          2 | beetle
          3 | canary
            |
-          ::: /animals:11:1
+          ::: animals:11:1
            |
          9 | inchworm
         10 | jackrabbit
@@ -1054,7 +1066,7 @@ watermelon
             env.render(&diag),
             @r"
         error: lint:test-diagnostic: main diagnostic message
-         --> /animals:1:1
+         --> animals:1:1
           |
         1 | aardvark
           | ^^^^^^^^
@@ -1079,7 +1091,7 @@ watermelon
             env.render(&diag),
             @r"
         error: lint:test-diagnostic: main diagnostic message
-         --> /animals:1:1
+         --> animals:1:1
           |
         1 | aardvark
           | ^^^^^^^^
@@ -1107,13 +1119,13 @@ watermelon
             env.render(&diag),
             @r"
         error: lint:test-diagnostic: main diagnostic message
-         --> /animals:1:1
+         --> animals:1:1
           |
         1 | aardvark
           | ^^^^^^^^
         2 | beetle
           |
-         ::: /animals:5:1
+         ::: animals:5:1
           |
         4 | dog
         5 | elephant
@@ -1135,7 +1147,7 @@ watermelon
             env.render(&diag),
             @r"
         error: lint:test-diagnostic: main diagnostic message
-         --> /animals:1:1
+         --> animals:1:1
           |
         1 | aardvark
           | ^^^^^^^^
@@ -1160,7 +1172,7 @@ watermelon
             env.render(&diag),
             @r"
         error: lint:test-diagnostic: main diagnostic message
-          --> /animals:1:1
+          --> animals:1:1
            |
          1 | aardvark
            | ^^^^^^^^
@@ -1191,7 +1203,7 @@ watermelon
             env.render(&diag),
             @r"
         error: lint:test-diagnostic: main diagnostic message
-          --> /animals:1:1
+          --> animals:1:1
            |
          1 | aardvark
            | ^^^^^^^^
@@ -1199,7 +1211,7 @@ watermelon
          3 | canary
          4 | dog
            |
-          ::: /animals:9:1
+          ::: animals:9:1
            |
          6 | finch
          7 | gorilla
@@ -1229,7 +1241,7 @@ watermelon
             env.render(&diag),
             @r"
         error: lint:test-diagnostic: main diagnostic message
-         --> /spacey-animals:8:1
+         --> spacey-animals:8:1
           |
         7 | dog
         8 | elephant
@@ -1246,7 +1258,7 @@ watermelon
             env.render(&diag),
             @r"
         error: lint:test-diagnostic: main diagnostic message
-          --> /spacey-animals:12:1
+          --> spacey-animals:12:1
            |
         11 | gorilla
         12 | hippopotamus
@@ -1264,7 +1276,7 @@ watermelon
             env.render(&diag),
             @r"
         error: lint:test-diagnostic: main diagnostic message
-          --> /spacey-animals:13:1
+          --> spacey-animals:13:1
            |
         11 | gorilla
         12 | hippopotamus
@@ -1304,12 +1316,12 @@ watermelon
             env.render(&diag),
             @r"
         error: lint:test-diagnostic: main diagnostic message
-         --> /spacey-animals:3:1
+         --> spacey-animals:3:1
           |
         3 | beetle
           | ^^^^^^
           |
-         ::: /spacey-animals:5:1
+         ::: spacey-animals:5:1
           |
         5 | canary
           | ^^^^^^
@@ -1333,7 +1345,7 @@ watermelon
             env.render(&diag),
             @r"
         error: lint:test-diagnostic: main diagnostic message
-         --> /animals:3:1
+         --> animals:3:1
           |
         1 | aardvark
         2 | beetle
@@ -1342,7 +1354,7 @@ watermelon
         4 | dog
         5 | elephant
           |
-         ::: /fruits:3:1
+         ::: fruits:3:1
           |
         1 | apple
         2 | banana
@@ -1370,7 +1382,7 @@ watermelon
             env.render(&diag),
             @r"
         error: lint:test-diagnostic: main diagnostic message
-         --> /animals:3:1
+         --> animals:3:1
           |
         1 | aardvark
         2 | beetle
@@ -1407,7 +1419,7 @@ watermelon
             env.render(&diag),
             @r"
         error: lint:test-diagnostic: main diagnostic message
-         --> /animals:3:1
+         --> animals:3:1
           |
         1 | aardvark
         2 | beetle
@@ -1435,7 +1447,7 @@ watermelon
             env.render(&diag),
             @r"
         error: lint:test-diagnostic: main diagnostic message
-         --> /animals:3:1
+         --> animals:3:1
           |
         1 | aardvark
         2 | beetle
@@ -1445,7 +1457,7 @@ watermelon
         5 | elephant
           |
         warning: sub-diagnostic message
-         --> /fruits:3:1
+         --> fruits:3:1
           |
         1 | apple
         2 | banana
@@ -1471,7 +1483,7 @@ watermelon
             env.render(&diag),
             @r"
         error: lint:test-diagnostic: main diagnostic message
-         --> /animals:3:1
+         --> animals:3:1
           |
         1 | aardvark
         2 | beetle
@@ -1481,7 +1493,7 @@ watermelon
         5 | elephant
           |
         warning: sub-diagnostic message
-         --> /fruits:3:1
+         --> fruits:3:1
           |
         1 | apple
         2 | banana
@@ -1491,7 +1503,7 @@ watermelon
         5 | orange
           |
         warning: sub-diagnostic message
-          --> /animals:11:1
+          --> animals:11:1
            |
          9 | inchworm
         10 | jackrabbit
@@ -1510,7 +1522,7 @@ watermelon
             env.render(&diag),
             @r"
         error: lint:test-diagnostic: main diagnostic message
-         --> /animals:3:1
+         --> animals:3:1
           |
         1 | aardvark
         2 | beetle
@@ -1520,7 +1532,7 @@ watermelon
         5 | elephant
           |
         warning: sub-diagnostic message
-          --> /animals:11:1
+          --> animals:11:1
            |
          9 | inchworm
         10 | jackrabbit
@@ -1528,7 +1540,7 @@ watermelon
            | ^^^^^^^^
            |
         warning: sub-diagnostic message
-         --> /fruits:3:1
+         --> fruits:3:1
           |
         1 | apple
         2 | banana
@@ -1558,7 +1570,7 @@ watermelon
             env.render(&diag),
             @r"
         error: lint:test-diagnostic: main diagnostic message
-         --> /animals:3:1
+         --> animals:3:1
           |
         1 | aardvark
         2 | beetle
@@ -1568,7 +1580,7 @@ watermelon
         5 | elephant
           |
         warning: sub-diagnostic message
-         --> /animals:3:1
+         --> animals:3:1
           |
         1 | aardvark
         2 | beetle
@@ -1594,7 +1606,7 @@ watermelon
             env.render(&diag),
             @r"
         error: lint:test-diagnostic: main diagnostic message
-         --> /animals:5:1
+         --> animals:5:1
           |
         3 |   canary
         4 |   dog
@@ -1617,7 +1629,7 @@ watermelon
             env.render(&diag),
             @r"
         error: lint:test-diagnostic: main diagnostic message
-         --> /animals:5:1
+         --> animals:5:1
           |
         3 |   canary
         4 |   dog
@@ -1637,7 +1649,7 @@ watermelon
             env.render(&diag),
             @r"
         error: lint:test-diagnostic: main diagnostic message
-         --> /animals:5:1
+         --> animals:5:1
           |
         3 |   canary
         4 |   dog
@@ -1657,7 +1669,7 @@ watermelon
             env.render(&diag),
             @r"
         error: lint:test-diagnostic: main diagnostic message
-          --> /animals:5:4
+          --> animals:5:4
            |
          3 |   canary
          4 |   dog
@@ -1679,7 +1691,7 @@ watermelon
             env.render(&diag),
             @r"
         error: lint:test-diagnostic: main diagnostic message
-          --> /animals:5:4
+          --> animals:5:4
            |
          3 |   canary
          4 |   dog
@@ -1711,7 +1723,7 @@ watermelon
             env.render(&diag),
             @r"
         error: lint:test-diagnostic: main diagnostic message
-         --> /animals:4:1
+         --> animals:4:1
           |
         2 |    beetle
         3 |    canary
@@ -1740,7 +1752,7 @@ watermelon
             env.render(&diag),
             @r"
         error: lint:test-diagnostic: main diagnostic message
-         --> /animals:4:1
+         --> animals:4:1
           |
         2 |    beetle
         3 |    canary
@@ -1771,7 +1783,7 @@ watermelon
             env.render(&diag),
             @r"
         error: lint:test-diagnostic: main diagnostic message
-         --> /animals:5:1
+         --> animals:5:1
           |
         3 |    canary
         4 |    dog
@@ -1806,7 +1818,7 @@ watermelon
             env.render(&diag),
             @r"
         error: lint:test-diagnostic: main diagnostic message
-         --> /animals:5:1
+         --> animals:5:1
           |
         3 |    canary
         4 |    dog
@@ -1834,7 +1846,7 @@ watermelon
             env.render(&diag),
             @r"
         error: lint:test-diagnostic: main diagnostic message
-         --> /animals:5:1
+         --> animals:5:1
           |
         3 |    canary
         4 |    dog
@@ -1866,7 +1878,7 @@ watermelon
             env.render(&diag),
             @r"
         error: lint:test-diagnostic: main diagnostic message
-         --> /animals:5:3
+         --> animals:5:3
           |
         3 | canary
         4 | dog
@@ -1888,7 +1900,7 @@ watermelon
             env.render(&diag),
             @r"
         error: lint:test-diagnostic: main diagnostic message
-         --> /animals:5:3
+         --> animals:5:3
           |
         3 | canary
         4 | dog
@@ -1921,7 +1933,7 @@ watermelon
             env.render(&diag),
             @r"
         error: lint:test-diagnostic: main diagnostic message
-          --> /animals:8:1
+          --> animals:8:1
            |
          6 | finch
          7 | gorilla
@@ -1930,7 +1942,7 @@ watermelon
          9 | inchworm
         10 | jackrabbit
            |
-          ::: /animals:1:1
+          ::: animals:1:1
            |
          1 | aardvark
            | -------- secondary
@@ -1961,27 +1973,27 @@ watermelon
             env.render(&diag),
             @r"
         error: lint:test-diagnostic: main diagnostic message
-         --> /animals:5:1
+         --> animals:5:1
           |
         5 | elephant
           | ^^^^^^^^ primary 5
           |
-         ::: /animals:9:1
+         ::: animals:9:1
           |
         9 | inchworm
           | ^^^^^^^^ primary 9
           |
-         ::: /animals:1:1
+         ::: animals:1:1
           |
         1 | aardvark
           | -------- secondary 1
           |
-         ::: /animals:3:1
+         ::: animals:3:1
           |
         3 | canary
           | ------ secondary 3
           |
-         ::: /animals:7:1
+         ::: animals:7:1
           |
         7 | gorilla
           | ------- secondary 7
@@ -2005,14 +2017,14 @@ watermelon
             env.render(&diag),
             @r"
         error: lint:test-diagnostic: main diagnostic message
-         --> /fruits:1:1
+         --> fruits:1:1
           |
         1 | apple
           | ^^^^^ primary
         2 | banana
         3 | cantelope
           |
-         ::: /animals:1:1
+         ::: animals:1:1
           |
         1 | aardvark
           | -------- secondary
@@ -2040,32 +2052,32 @@ watermelon
             env.render(&diag),
             @r"
         error: lint:test-diagnostic: main diagnostic message
-          --> /animals:11:1
+          --> animals:11:1
            |
         11 | kangaroo
            | ^^^^^^^^ primary animals 11
            |
-          ::: /animals:1:1
+          ::: animals:1:1
            |
          1 | aardvark
            | -------- secondary animals 1
            |
-          ::: /animals:3:1
+          ::: animals:3:1
            |
          3 | canary
            | ------ secondary animals 3
            |
-          ::: /animals:7:1
+          ::: animals:7:1
            |
          7 | gorilla
            | ------- secondary animals 7
            |
-          ::: /fruits:10:1
+          ::: fruits:10:1
            |
         10 | watermelon
            | ^^^^^^^^^^ primary fruits 10
            |
-          ::: /fruits:2:1
+          ::: fruits:2:1
            |
          2 | banana
            | ------ secondary fruits 2


### PR DESCRIPTION
This is done in what appears to be the same way as Ruff: we get the CWD,
strip the prefix from the path if possible, and use that. If stripping
the prefix fails, then we print the full path as-is.

Fixes #17233
