### PR TITLE
[red-knot] Revert blanket `clippy::too_many_arguments` allow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -231,10 +231,6 @@ unused_peekable = "warn"
 # Diagnostics are not actionable: Enable once https://github.com/rust-lang/rust-clippy/issues/13774 is resolved.
 large_stack_arrays = "allow"
 
-# Salsa generates functions with parameters for each field of a `salsa::interned` struct.
-# If we don't allow this, we get warnings for structs with too many fields.
-too_many_arguments = "allow"
-
 [profile.release]
 # Note that we set these explicitly, and these values
 # were chosen based on a trade-off between compile times


### PR DESCRIPTION
## Summary

Now that https://github.com/salsa-rs/salsa/issues/808 has been fixed, we can revert this global change in `Cargo.toml`.