### PR TITLE
[EXPERIMENT] [red-knot] TypeVarInstance and intersection of callables

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/binary/integers.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/binary/integers.md
@@ -50,11 +50,11 @@ reveal_type(1 ** (largest_u32 + 1))  # revealed: int
 reveal_type(2**largest_u32)  # revealed: int
 
 def variable(x: int):
-    reveal_type(x**2)  # revealed: int
+    reveal_type(x**2)  # revealed: (int & Any) | (int & float & Any)
     # TODO: should be `Any` (overload 5 on `__pow__`), requires correct overload matching
-    reveal_type(2**x)  # revealed: int
+    reveal_type(2**x)  # revealed: (int & Any) | (int & float & Any)
     # TODO: should be `Any` (overload 5 on `__pow__`), requires correct overload matching
-    reveal_type(x**x)  # revealed: int
+    reveal_type(x**x)  # revealed: (int & Any) | (int & float & Any)
 ```
 
 If the second argument is \<0, a `float` is returned at runtime. If the first argument is \<0 but

--- a/crates/red_knot_python_semantic/resources/mdtest/dataclasses.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/dataclasses.md
@@ -570,7 +570,7 @@ class ConvertToLength:
 class C:
     converter: ConvertToLength = ConvertToLength()
 
-reveal_type(C.__init__)  # revealed: (converter: str = Literal[""]) -> None
+reveal_type(C.__init__)  # revealed: (converter: str = Never) -> None
 
 c = C("abc")
 reveal_type(c.converter)  # revealed: int

--- a/crates/red_knot_python_semantic/resources/mdtest/descriptor_protocol.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/descriptor_protocol.md
@@ -459,7 +459,7 @@ class Descriptor:
 class C:
     d: Descriptor = Descriptor()
 
-reveal_type(C.d)  # revealed: Literal["called on class object"]
+reveal_type(C.d)  # revealed: Never
 
 reveal_type(C().d)  # revealed: Literal["called on instance"]
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/function/return_type.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/function/return_type.md
@@ -203,7 +203,7 @@ from typing import TypeVar
 
 T = TypeVar("T")
 
-# TODO: `invalid-return-type` error should be emitted
+# error: [invalid-return-type]
 def m(x: T) -> T: ...
 ```
 

--- a/crates/red_knot_python_semantic/resources/mdtest/generics/legacy.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/generics/legacy.md
@@ -19,6 +19,9 @@ in newer Python releases.
 from typing import TypeVar
 
 T = TypeVar("T")
+reveal_type(type(T))  # revealed: Literal[TypeVar]
+reveal_type(T)  # revealed: typing.TypeVar
+reveal_type(T.__name__)  # revealed: Literal["T"]
 ```
 
 ### Directly assigned to a variable
@@ -29,7 +32,12 @@ T = TypeVar("T")
 ```py
 from typing import TypeVar
 
-# TODO: error
+T = TypeVar("T")
+# TODO: no error
+# error: [invalid-legacy-type-variable]
+U: TypeVar = TypeVar("U")
+
+# error: [invalid-legacy-type-variable] "A legacy `typing.TypeVar` must be immediately assigned to a variable"
 TestList = list[TypeVar("W")]
 ```
 
@@ -40,7 +48,7 @@ TestList = list[TypeVar("W")]
 ```py
 from typing import TypeVar
 
-# TODO: error
+# error: [invalid-legacy-type-variable] "The name of a legacy `typing.TypeVar` (`Q`) must match the name of the variable it is assigned to (`T`)"
 T = TypeVar("Q")
 ```
 
@@ -55,6 +63,52 @@ T = TypeVar("T")
 
 # TODO: error
 T = TypeVar("T")
+```
+
+### Type variables with a default
+
+Note that the `__default__` property is only available in Python ≥3.13.
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+```py
+from typing import TypeVar
+
+T = TypeVar("T", default=int)
+reveal_type(T.__default__)  # revealed: int
+reveal_type(T.__bound__)  # revealed: None
+reveal_type(T.__constraints__)  # revealed: tuple[()]
+
+S = TypeVar("S")
+reveal_type(S.__default__)  # revealed: NoDefault
+```
+
+### Type variables with an upper bound
+
+```py
+from typing import TypeVar
+
+T = TypeVar("T", bound=int)
+reveal_type(T.__bound__)  # revealed: int
+reveal_type(T.__constraints__)  # revealed: tuple[()]
+
+S = TypeVar("S")
+reveal_type(S.__bound__)  # revealed: None
+```
+
+### Type variables with constraints
+
+```py
+from typing import TypeVar
+
+T = TypeVar("T", int, str)
+reveal_type(T.__constraints__)  # revealed: tuple[int, str]
+
+S = TypeVar("S")
+reveal_type(S.__constraints__)  # revealed: tuple[()]
 ```
 
 ### Cannot have only one constraint

--- a/crates/red_knot_python_semantic/resources/mdtest/generics/pep695.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/generics/pep695.md
@@ -17,8 +17,49 @@ instances of `typing.TypeVar`, just like legacy type variables.
 ```py
 def f[T]():
     reveal_type(type(T))  # revealed: Literal[TypeVar]
-    reveal_type(T)  # revealed: T
+    reveal_type(T)  # revealed: typing.TypeVar
     reveal_type(T.__name__)  # revealed: Literal["T"]
+```
+
+### Type variables with a default
+
+Note that the `__default__` property is only available in Python ≥3.13.
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+```py
+def f[T = int]():
+    reveal_type(T.__default__)  # revealed: int
+    reveal_type(T.__bound__)  # revealed: None
+    reveal_type(T.__constraints__)  # revealed: tuple[()]
+
+def g[S]():
+    reveal_type(S.__default__)  # revealed: NoDefault
+```
+
+### Type variables with an upper bound
+
+```py
+def f[T: int]():
+    reveal_type(T.__bound__)  # revealed: int
+    reveal_type(T.__constraints__)  # revealed: tuple[()]
+
+def g[S]():
+    reveal_type(S.__bound__)  # revealed: None
+```
+
+### Type variables with constraints
+
+```py
+def f[T: (int, str)]():
+    reveal_type(T.__constraints__)  # revealed: tuple[int, str]
+    reveal_type(T.__bound__)  # revealed: None
+
+def g[S]():
+    reveal_type(S.__constraints__)  # revealed: tuple[()]
 ```
 
 ### Cannot have only one constraint

--- a/crates/red_knot_python_semantic/resources/mdtest/generics/scoping.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/generics/scoping.md
@@ -142,8 +142,7 @@ class Legacy(Generic[T]):
         return y
 
 legacy: Legacy[int] = Legacy()
-# TODO: revealed: str
-reveal_type(legacy.m(1, "string"))  # revealed: @Todo(Support for `typing.TypeVar` instances in type expressions)
+reveal_type(legacy.m(1, "string"))  # revealed: Literal["string"]
 ```
 
 With PEP 695 syntax, it is clearer that the method uses a separate typevar:

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type.snap
@@ -28,7 +28,7 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/function/return_ty
 14 | 
 15 | T = TypeVar("T")
 16 | 
-17 | # TODO: `invalid-return-type` error should be emitted
+17 | # error: [invalid-return-type]
 18 | def m(x: T) -> T: ...
 ```
 
@@ -76,6 +76,17 @@ error: lint:invalid-return-type: Return type does not match returned value
    |     ^^^^^^ Expected `int`, found `None`
 12 |
 13 | from typing import TypeVar
+   |
+
+```
+
+```
+error: lint:invalid-return-type: Function can implicitly return `None`, which is not assignable to return type `T`
+  --> src/mdtest_snippet.py:18:16
+   |
+17 | # error: [invalid-return-type]
+18 | def m(x: T) -> T: ...
+   |                ^
    |
 
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/subscript/lists.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/subscript/lists.md
@@ -12,7 +12,7 @@ x = [1, 2, 3]
 reveal_type(x)  # revealed: list
 
 # TODO reveal int
-reveal_type(x[0])  # revealed: @Todo(Support for `typing.TypeVar` instances in type expressions)
+reveal_type(x[0])  # revealed: Unknown
 
 # TODO reveal list
 reveal_type(x[0:1])  # revealed: @Todo(specialized non-generic class)

--- a/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
@@ -583,6 +583,8 @@ from functools import partial
 
 def f(x: int, y: str) -> None: ...
 
+# TODO: no error
+# error: [invalid-assignment] "Object of type `partial` is not assignable to `(int, /) -> None`"
 c1: Callable[[int], None] = partial(f, y="a")
 ```
 

--- a/crates/red_knot_python_semantic/src/semantic_index/expression.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/expression.rs
@@ -44,6 +44,17 @@ pub(crate) struct Expression<'db> {
     #[return_ref]
     pub(crate) node_ref: AstNodeRef<ast::Expr>,
 
+    /// An assignment statement, if this expression is immediately used as the rhs of that
+    /// assignment.
+    ///
+    /// (Note that this is the _immediately_ containing assignment — if a complex expression is
+    /// assigned to some target, only the outermost expression node has this set. The inner
+    /// expressions are used to build up the assignment result, and are not "immediately assigned"
+    /// to the target, and so have `None` for this field.)
+    #[no_eq]
+    #[tracked]
+    pub(crate) assigned_to: Option<AstNodeRef<ast::StmtAssign>>,
+
     /// Should this expression be inferred as a normal expression or a type expression?
     pub(crate) kind: ExpressionKind,
 

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -348,6 +348,19 @@ impl<'db> PropertyInstanceType<'db> {
             .map(|ty| ty.apply_specialization(db, specialization));
         Self::new(db, getter, setter)
     }
+
+    fn find_legacy_typevars(
+        self,
+        db: &'db dyn Db,
+        typevars: &mut FxOrderSet<TypeVarInstance<'db>>,
+    ) {
+        if let Some(ty) = self.getter(db) {
+            ty.find_legacy_typevars(db, typevars);
+        }
+        if let Some(ty) = self.setter(db) {
+            ty.find_legacy_typevars(db, typevars);
+        }
+    }
 }
 
 bitflags! {
@@ -923,6 +936,7 @@ impl<'db> Type<'db> {
                         typevar.definition(db),
                         Some(TypeVarBoundOrConstraints::UpperBound(bound.normalized(db))),
                         typevar.default_ty(db),
+                        typevar.kind(db),
                     ))
                 }
                 Some(TypeVarBoundOrConstraints::Constraints(union)) => {
@@ -932,6 +946,7 @@ impl<'db> Type<'db> {
                         typevar.definition(db),
                         Some(TypeVarBoundOrConstraints::Constraints(union.normalized(db))),
                         typevar.default_ty(db),
+                        typevar.kind(db),
                     ))
                 }
                 None => self,
@@ -3799,6 +3814,56 @@ impl<'db> Type<'db> {
                     Signatures::single(signature)
                 }
 
+                Some(KnownClass::TypeVar) => {
+                    // ```py
+                    // class TypeVar:
+                    //     def __new__(
+                    //         cls,
+                    //         name: str,
+                    //         *constraints: Any,
+                    //         bound: Any | None = None,
+                    //         contravariant: bool = False,
+                    //         covariant: bool = False,
+                    //         infer_variance: bool = False,
+                    //         default: Any = ...,
+                    //     ) -> Self: ...
+                    // ```
+                    let signature = CallableSignature::single(
+                        self,
+                        Signature::new(
+                            Parameters::new([
+                                Parameter::positional_or_keyword(Name::new_static("name"))
+                                    .with_annotated_type(Type::LiteralString),
+                                Parameter::variadic(Name::new_static("constraints"))
+                                    .type_form()
+                                    .with_annotated_type(Type::any()),
+                                Parameter::keyword_only(Name::new_static("bound"))
+                                    .type_form()
+                                    .with_annotated_type(UnionType::from_elements(
+                                        db,
+                                        [Type::any(), Type::none(db)],
+                                    ))
+                                    .with_default_type(Type::none(db)),
+                                Parameter::keyword_only(Name::new_static("default"))
+                                    .type_form()
+                                    .with_annotated_type(Type::any())
+                                    .with_default_type(KnownClass::NoneType.to_instance(db)),
+                                Parameter::keyword_only(Name::new_static("contravariant"))
+                                    .with_annotated_type(KnownClass::Bool.to_instance(db))
+                                    .with_default_type(Type::BooleanLiteral(false)),
+                                Parameter::keyword_only(Name::new_static("covariant"))
+                                    .with_annotated_type(KnownClass::Bool.to_instance(db))
+                                    .with_default_type(Type::BooleanLiteral(false)),
+                                Parameter::keyword_only(Name::new_static("infer_variance"))
+                                    .with_annotated_type(KnownClass::Bool.to_instance(db))
+                                    .with_default_type(Type::BooleanLiteral(false)),
+                            ]),
+                            Some(KnownClass::TypeVar.to_instance(db)),
+                        ),
+                    );
+                    Signatures::single(signature)
+                }
+
                 Some(KnownClass::Property) => {
                     let getter_signature = Signature::new(
                         Parameters::new([
@@ -4306,27 +4371,43 @@ impl<'db> Type<'db> {
                 new_call_outcome @ (None | Some(Ok(_))),
                 init_call_outcome @ (None | Some(Ok(_))),
             ) => {
+                fn combine_specializations<'db>(
+                    db: &'db dyn Db,
+                    s1: Option<Specialization<'db>>,
+                    s2: Option<Specialization<'db>>,
+                ) -> Option<Specialization<'db>> {
+                    match (s1, s2) {
+                        (None, None) => None,
+                        (Some(s), None) | (None, Some(s)) => Some(s),
+                        (Some(s1), Some(s2)) => Some(s1.combine(db, s2)),
+                    }
+                }
+
+                fn combine_binding_specialization<'db>(
+                    db: &'db dyn Db,
+                    binding: &CallableBinding<'db>,
+                ) -> Option<Specialization<'db>> {
+                    binding
+                        .matching_overloads()
+                        .map(|(_, binding)| binding.inherited_specialization())
+                        .reduce(|acc, specialization| {
+                            combine_specializations(db, acc, specialization)
+                        })
+                        .flatten()
+                }
+
                 let new_specialization = new_call_outcome
                     .and_then(Result::ok)
                     .as_ref()
                     .and_then(Bindings::single_element)
-                    .and_then(CallableBinding::matching_overload)
-                    .and_then(|(_, binding)| binding.inherited_specialization());
+                    .and_then(|binding| combine_binding_specialization(db, binding));
                 let init_specialization = init_call_outcome
                     .and_then(Result::ok)
                     .as_ref()
                     .and_then(Bindings::single_element)
-                    .and_then(CallableBinding::matching_overload)
-                    .and_then(|(_, binding)| binding.inherited_specialization());
-                let specialization = match (new_specialization, init_specialization) {
-                    (None, None) => None,
-                    (Some(specialization), None) | (None, Some(specialization)) => {
-                        Some(specialization)
-                    }
-                    (Some(new_specialization), Some(init_specialization)) => {
-                        Some(new_specialization.combine(db, init_specialization))
-                    }
-                };
+                    .and_then(|binding| combine_binding_specialization(db, binding));
+                let specialization =
+                    combine_specializations(db, new_specialization, init_specialization);
                 let specialized = specialization
                     .map(|specialization| {
                         Type::instance(ClassType::Generic(GenericAlias::new(
@@ -4834,6 +4915,93 @@ impl<'db> Type<'db> {
         }
     }
 
+    /// Locates any legacy `TypeVar`s in this type, and adds them to a set. This is used to build
+    /// up a generic context from any legacy `TypeVar`s that appear in a function parameter list or
+    /// `Generic` specialization.
+    pub(crate) fn find_legacy_typevars(
+        self,
+        db: &'db dyn Db,
+        typevars: &mut FxOrderSet<TypeVarInstance<'db>>,
+    ) {
+        match self {
+            Type::TypeVar(typevar) => {
+                if typevar.is_legacy(db) {
+                    typevars.insert(typevar);
+                }
+            }
+
+            Type::FunctionLiteral(function) => function.find_legacy_typevars(db, typevars),
+
+            Type::BoundMethod(method) => {
+                method.self_instance(db).find_legacy_typevars(db, typevars);
+                method.function(db).find_legacy_typevars(db, typevars);
+            }
+
+            Type::MethodWrapper(
+                MethodWrapperKind::FunctionTypeDunderGet(function)
+                | MethodWrapperKind::FunctionTypeDunderCall(function),
+            ) => {
+                function.find_legacy_typevars(db, typevars);
+            }
+
+            Type::MethodWrapper(
+                MethodWrapperKind::PropertyDunderGet(property)
+                | MethodWrapperKind::PropertyDunderSet(property),
+            ) => {
+                property.find_legacy_typevars(db, typevars);
+            }
+
+            Type::Callable(callable) => {
+                callable.find_legacy_typevars(db, typevars);
+            }
+
+            Type::PropertyInstance(property) => {
+                property.find_legacy_typevars(db, typevars);
+            }
+
+            Type::Union(union) => {
+                for element in union.iter(db) {
+                    element.find_legacy_typevars(db, typevars);
+                }
+            }
+            Type::Intersection(intersection) => {
+                for positive in intersection.positive(db) {
+                    positive.find_legacy_typevars(db, typevars);
+                }
+                for negative in intersection.negative(db) {
+                    negative.find_legacy_typevars(db, typevars);
+                }
+            }
+            Type::Tuple(tuple) => {
+                for element in tuple.iter(db) {
+                    element.find_legacy_typevars(db, typevars);
+                }
+            }
+
+            Type::Dynamic(_)
+            | Type::Never
+            | Type::AlwaysTruthy
+            | Type::AlwaysFalsy
+            | Type::WrapperDescriptor(_)
+            | Type::MethodWrapper(MethodWrapperKind::StrStartswith(_))
+            | Type::DataclassDecorator(_)
+            | Type::DataclassTransformer(_)
+            | Type::ModuleLiteral(_)
+            | Type::ClassLiteral(_)
+            | Type::GenericAlias(_)
+            | Type::SubclassOf(_)
+            | Type::IntLiteral(_)
+            | Type::BooleanLiteral(_)
+            | Type::LiteralString
+            | Type::StringLiteral(_)
+            | Type::BytesLiteral(_)
+            | Type::SliceLiteral(_)
+            | Type::BoundSuper(_)
+            | Type::Instance(_)
+            | Type::KnownInstance(_) => {}
+        }
+    }
+
     /// Return the string representation of this type when converted to string as it would be
     /// provided by the `__str__` method.
     ///
@@ -4844,9 +5012,7 @@ impl<'db> Type<'db> {
         match self {
             Type::IntLiteral(_) | Type::BooleanLiteral(_) => self.repr(db),
             Type::StringLiteral(_) | Type::LiteralString => *self,
-            Type::KnownInstance(known_instance) => {
-                Type::string_literal(db, known_instance.repr(db))
-            }
+            Type::KnownInstance(known_instance) => Type::string_literal(db, known_instance.repr()),
             // TODO: handle more complex types
             _ => KnownClass::Str.to_instance(db),
         }
@@ -4864,9 +5030,7 @@ impl<'db> Type<'db> {
                 Type::string_literal(db, &format!("'{}'", literal.value(db).escape_default()))
             }
             Type::LiteralString => Type::LiteralString,
-            Type::KnownInstance(known_instance) => {
-                Type::string_literal(db, known_instance.repr(db))
-            }
+            Type::KnownInstance(known_instance) => Type::string_literal(db, known_instance.repr()),
             // TODO: handle more complex types
             _ => KnownClass::Str.to_instance(db),
         }
@@ -5235,12 +5399,12 @@ impl<'db> InvalidTypeExpression<'db> {
                     InvalidTypeExpression::TypeQualifier(qualifier) => write!(
                         f,
                         "Type qualifier `{q}` is not allowed in type expressions (only in annotation expressions)",
-                        q = qualifier.repr(self.db)
+                        q = qualifier.repr()
                     ),
                     InvalidTypeExpression::TypeQualifierRequiresOneArgument(qualifier) => write!(
                         f,
                         "Type qualifier `{q}` is not allowed in type expressions (only in annotation expressions, and only with exactly one argument)",
-                        q = qualifier.repr(self.db)
+                        q = qualifier.repr()
                     ),
                     InvalidTypeExpression::InvalidType(ty) => write!(
                         f,
@@ -5253,6 +5417,13 @@ impl<'db> InvalidTypeExpression<'db> {
 
         Display { error: self, db }
     }
+}
+
+/// Whether this typecar was created via the legacy `TypeVar` constructor, or using PEP 695 syntax.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum TypeVarKind {
+    Legacy,
+    Pep695,
 }
 
 /// Data regarding a single type variable.
@@ -5276,9 +5447,15 @@ pub struct TypeVarInstance<'db> {
 
     /// The default type for this TypeVar
     default_ty: Option<Type<'db>>,
+
+    pub kind: TypeVarKind,
 }
 
 impl<'db> TypeVarInstance<'db> {
+    pub(crate) fn is_legacy(self, db: &'db dyn Db) -> bool {
+        matches!(self.kind(db), TypeVarKind::Legacy)
+    }
+
     #[allow(unused)]
     pub(crate) fn upper_bound(self, db: &'db dyn Db) -> Option<Type<'db>> {
         if let Some(TypeVarBoundOrConstraints::UpperBound(ty)) = self.bound_or_constraints(db) {
@@ -6368,6 +6545,17 @@ impl<'db> FunctionType<'db> {
         )
     }
 
+    fn find_legacy_typevars(
+        self,
+        db: &'db dyn Db,
+        typevars: &mut FxOrderSet<TypeVarInstance<'db>>,
+    ) {
+        let signatures = self.signature(db);
+        for signature in signatures {
+            signature.find_legacy_typevars(db, typevars);
+        }
+    }
+
     /// Returns `self` as [`OverloadedFunction`] if it is overloaded, [`None`] otherwise.
     ///
     /// ## Note
@@ -6696,6 +6884,16 @@ impl<'db> CallableType<'db> {
                 .iter()
                 .map(|signature| signature.apply_specialization(db, specialization)),
         )
+    }
+
+    fn find_legacy_typevars(
+        self,
+        db: &'db dyn Db,
+        typevars: &mut FxOrderSet<TypeVarInstance<'db>>,
+    ) {
+        for signature in self.signatures(db) {
+            signature.find_legacy_typevars(db, typevars);
+        }
     }
 
     /// Check whether this callable type is fully static.

--- a/crates/red_knot_python_semantic/src/types/diagnostic.rs
+++ b/crates/red_knot_python_semantic/src/types/diagnostic.rs
@@ -35,6 +35,7 @@ pub(crate) fn register_lints(registry: &mut LintRegistryBuilder) {
     registry.register_lint(&INVALID_CONTEXT_MANAGER);
     registry.register_lint(&INVALID_DECLARATION);
     registry.register_lint(&INVALID_EXCEPTION_CAUGHT);
+    registry.register_lint(&INVALID_LEGACY_TYPE_VARIABLE);
     registry.register_lint(&INVALID_METACLASS);
     registry.register_lint(&INVALID_PARAMETER_DEFAULT);
     registry.register_lint(&INVALID_PROTOCOL);
@@ -386,6 +387,34 @@ declare_lint! {
     ///  This rule corresponds to Ruff's [`except-with-non-exception-classes` (`B030`)](https://docs.astral.sh/ruff/rules/except-with-non-exception-classes)
     pub(crate) static INVALID_EXCEPTION_CAUGHT = {
         summary: "detects exception handlers that catch classes that do not inherit from `BaseException`",
+        status: LintStatus::preview("1.0.0"),
+        default_level: Level::Error,
+    }
+}
+
+declare_lint! {
+    /// ## What it does
+    /// Checks for the creation of invalid legacy `TypeVar`s
+    ///
+    /// ## Why is this bad?
+    /// There are several requirements that you must follow when creating a legacy `TypeVar`.
+    ///
+    /// ## Examples
+    /// ```python
+    /// from typing import TypeVar
+    ///
+    /// T = TypeVar("T")  # okay
+    /// Q = TypeVar("S")  # error: TypeVar name must match the variable it's assigned to
+    /// T = TypeVar("T")  # error: TypeVars should not be redefined
+    ///
+    /// # error: TypeVar must be immediately assigned to a variable
+    /// def f(t: TypeVar("U")): ...
+    /// ```
+    ///
+    /// ## References
+    /// - [Typing spec: Generics](https://typing.python.org/en/latest/spec/generics.html#introduction)
+    pub(crate) static INVALID_LEGACY_TYPE_VARIABLE = {
+        summary: "detects invalid legacy type variables",
         status: LintStatus::preview("1.0.0"),
         default_level: Level::Error,
     }
@@ -1314,7 +1343,7 @@ pub(crate) fn report_invalid_arguments_to_annotated(
     builder.into_diagnostic(format_args!(
         "Special form `{}` expected at least 2 arguments \
          (one type and at least one metadata element)",
-        KnownInstanceType::Annotated.repr(context.db())
+        KnownInstanceType::Annotated.repr()
     ));
 }
 
@@ -1362,7 +1391,7 @@ pub(crate) fn report_invalid_arguments_to_callable(
     };
     builder.into_diagnostic(format_args!(
         "Special form `{}` expected exactly two arguments (parameter types and return type)",
-        KnownInstanceType::Callable.repr(context.db())
+        KnownInstanceType::Callable.repr()
     ));
 }
 

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -94,7 +94,7 @@ impl Display for DisplayRepresentation<'_> {
                 SubclassOfInner::Class(class) => write!(f, "type[{}]", class.name(self.db)),
                 SubclassOfInner::Dynamic(dynamic) => write!(f, "type[{dynamic}]"),
             },
-            Type::KnownInstance(known_instance) => f.write_str(known_instance.repr(self.db)),
+            Type::KnownInstance(known_instance) => f.write_str(known_instance.repr()),
             Type::FunctionLiteral(function) => {
                 let signature = function.signature(self.db);
 

--- a/crates/red_knot_python_semantic/src/types/known_instance.rs
+++ b/crates/red_knot_python_semantic/src/types/known_instance.rs
@@ -109,6 +109,10 @@ impl<'db> KnownInstanceType<'db> {
             | Self::Literal
             | Self::LiteralString
             | Self::Optional
+            // This is a legacy `TypeVar` _outside_ of any generic class or function, so it's
+            // AlwaysTrue. The truthiness of a typevar inside of a generic class or function
+            // depends on its bounds and constraints; but that's represented by `Type::TypeVar` and
+            // handled in elsewhere.
             | Self::TypeVar(_)
             | Self::Union
             | Self::NoReturn
@@ -152,7 +156,7 @@ impl<'db> KnownInstanceType<'db> {
     }
 
     /// Return the repr of the symbol at runtime
-    pub(crate) fn repr(self, db: &'db dyn Db) -> &'db str {
+    pub(crate) fn repr(self) -> &'db str {
         match self {
             Self::Annotated => "typing.Annotated",
             Self::Literal => "typing.Literal",
@@ -188,7 +192,10 @@ impl<'db> KnownInstanceType<'db> {
             Self::Protocol => "typing.Protocol",
             Self::Generic => "typing.Generic",
             Self::ReadOnly => "typing.ReadOnly",
-            Self::TypeVar(typevar) => typevar.name(db),
+            // This is a legacy `TypeVar` _outside_ of any generic class or function, so we render
+            // it as an instance of `typing.TypeVar`. Inside of a generic class or function, we'll
+            // have a `Type::TypeVar(_)`, which is rendered as the typevar's name.
+            Self::TypeVar(_) => "typing.TypeVar",
             Self::TypeAliasType(_) => "typing.TypeAliasType",
             Self::Unknown => "knot_extensions.Unknown",
             Self::AlwaysTruthy => "knot_extensions.AlwaysTruthy",

--- a/crates/ruff_benchmark/benches/red_knot.rs
+++ b/crates/ruff_benchmark/benches/red_knot.rs
@@ -59,13 +59,22 @@ type KeyDiagnosticFields = (
     Severity,
 );
 
-static EXPECTED_TOMLLIB_DIAGNOSTICS: &[KeyDiagnosticFields] = &[(
-    DiagnosticId::lint("unused-ignore-comment"),
-    Some("/src/tomllib/_parser.py"),
-    Some(22299..22333),
-    "Unused blanket `type: ignore` directive",
-    Severity::Warning,
-)];
+static EXPECTED_TOMLLIB_DIAGNOSTICS: &[KeyDiagnosticFields] = &[
+    (
+        DiagnosticId::lint("no-matching-overload"),
+        Some("/src/tomllib/_parser.py"),
+        Some(2329..2358),
+        "No overload of bound method `__init__` matches arguments",
+        Severity::Error,
+    ),
+    (
+        DiagnosticId::lint("unused-ignore-comment"),
+        Some("/src/tomllib/_parser.py"),
+        Some(22299..22333),
+        "Unused blanket `type: ignore` directive",
+        Severity::Warning,
+    ),
+];
 
 fn tomllib_path(file: &TestFile) -> SystemPathBuf {
     SystemPathBuf::from("src").join(file.name())

--- a/knot.schema.json
+++ b/knot.schema.json
@@ -446,6 +446,16 @@
             }
           ]
         },
+        "invalid-legacy-type-variable": {
+          "title": "detects invalid legacy type variables",
+          "description": "## What it does\nChecks for the creation of invalid legacy `TypeVar`s\n\n## Why is this bad?\nThere are several requirements that you must follow when creating a legacy `TypeVar`.\n\n## Examples\n```python\nfrom typing import TypeVar\n\nT = TypeVar(\"T\")  # okay\nQ = TypeVar(\"S\")  # error: TypeVar name must match the variable it's assigned to\nT = TypeVar(\"T\")  # error: TypeVars should not be redefined\n\n# error: TypeVar must be immediately assigned to a variable\ndef f(t: TypeVar(\"U\")): ...\n```\n\n## References\n- [Typing spec: Generics](https://typing.python.org/en/latest/spec/generics.html#introduction)",
+          "default": "error",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Level"
+            }
+          ]
+        },
         "invalid-metaclass": {
           "title": "detects invalid `metaclass=` arguments",
           "description": "## What it does\nChecks for arguments to `metaclass=` that are invalid.\n\n## Why is this bad?\nPython allows arbitrary expressions to be used as the argument to `metaclass=`.\nThese expressions, however, need to be callable and accept the same arguments\nas `type.__new__`.\n\n## Example\n\n```python\ndef f(): ...\n\n# TypeError: f() takes 0 positional arguments but 3 were given\nclass B(metaclass=f): ...\n```\n\n## References\n- [Python documentation: Metaclasses](https://docs.python.org/3/reference/datamodel.html#metaclasses)",


### PR DESCRIPTION
## Ecosystem analysis
It _does_ seem to be reducing the number of overall diagnostics but not by much compared to what already exists.

<details><summary>Stats until "TypeVarInstance PR"</summary>
<p>

```
                           Diagnostic Analysis Report                           
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━━━┓
┃ Diagnostic ID                      ┃ Severity ┃ Removed ┃ Added ┃ Net Change ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━╇━━━━━━━━━━━━┩
│ lint:call-non-callable             │ error    │      98 │   497 │       +399 │
│ lint:call-possibly-unbound-method  │ warning  │       9 │    53 │        +44 │
│ lint:invalid-argument-type         │ error    │     409 │   818 │       +409 │
│ lint:invalid-assignment            │ error    │      16 │    95 │        +79 │
│ lint:invalid-legacy-type-variable  │ error    │       0 │     6 │         +6 │
│ lint:invalid-parameter-default     │ error    │       2 │     7 │         +5 │
│ lint:invalid-raise                 │ error    │       0 │     1 │         +1 │
│ lint:invalid-return-type           │ error    │      23 │    92 │        +69 │
│ lint:invalid-type-form             │ error    │       0 │    11 │        +11 │
│ lint:missing-argument              │ error    │      12 │     3 │         -9 │
│ lint:no-matching-overload          │ error    │       0 │ 19051 │     +19051 │
│ lint:non-subscriptable             │ error    │       0 │     2 │         +2 │
│ lint:not-iterable                  │ error    │       0 │     7 │         +7 │
│ lint:possibly-unbound-attribute    │ warning  │      24 │    50 │        +26 │
│ lint:possibly-unresolved-reference │ warning  │       2 │     0 │         -2 │
│ lint:redundant-cast                │ warning  │       4 │     5 │         +1 │
│ lint:type-assertion-failure        │ error    │       8 │     8 │          0 │
│ lint:unknown-argument              │ error    │      26 │     0 │        -26 │
│ lint:unresolved-attribute          │ error    │      14 │    67 │        +53 │
│ lint:unresolved-reference          │ warning  │       2 │     1 │         -1 │
│ lint:unsupported-operator          │ error    │      19 │    65 │        +46 │
│ lint:unused-ignore-comment         │ warning  │     150 │     0 │       -150 │
├────────────────────────────────────┼──────────┼─────────┼───────┼────────────┤
│ TOTAL                              │          │     818 │ 20839 │     +20021 │
└────────────────────────────────────┴──────────┴─────────┴───────┴────────────┘
Analysis complete. Found 22 unique diagnostic IDs.
Total diagnostics removed: 818
Total diagnostics added: 20839
Net change: +20021
```

</p>
</details> 

<details><summary>Stats with "intersection of callables" on top of "TypeVarInstance PR"</summary>
<p>

```
                           Diagnostic Analysis Report                           
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━━━┓
┃ Diagnostic ID                      ┃ Severity ┃ Removed ┃ Added ┃ Net Change ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━╇━━━━━━━━━━━━┩
│ lint:call-non-callable             │ error    │     124 │   158 │        +34 │
│ lint:call-possibly-unbound-method  │ warning  │      25 │    63 │        +38 │
│ lint:division-by-zero              │ error    │       0 │    13 │        +13 │
│ lint:invalid-argument-type         │ error    │     493 │   807 │       +314 │
│ lint:invalid-assignment            │ error    │      37 │    95 │        +58 │
│ lint:invalid-base                  │ error    │       2 │     2 │          0 │
│ lint:invalid-legacy-type-variable  │ error    │       0 │     6 │         +6 │
│ lint:invalid-parameter-default     │ error    │       2 │     7 │         +5 │
│ lint:invalid-raise                 │ error    │       0 │     1 │         +1 │
│ lint:invalid-return-type           │ error    │      76 │    91 │        +15 │
│ lint:invalid-super-argument        │ error    │       1 │     1 │          0 │
│ lint:invalid-type-form             │ error    │       2 │    11 │         +9 │
│ lint:missing-argument              │ error    │      12 │     2 │        -10 │
│ lint:no-matching-overload          │ error    │       5 │ 19049 │     +19044 │
│ lint:non-subscriptable             │ error    │       6 │     2 │         -4 │
│ lint:not-iterable                  │ error    │       3 │     8 │         +5 │
│ lint:possibly-unbound-attribute    │ warning  │     134 │   126 │         -8 │
│ lint:possibly-unresolved-reference │ warning  │      13 │     0 │        -13 │
│ lint:redundant-cast                │ warning  │       4 │     5 │         +1 │
│ lint:type-assertion-failure        │ error    │      30 │    33 │         +3 │
│ lint:unknown-argument              │ error    │      26 │     0 │        -26 │
│ lint:unresolved-attribute          │ error    │      64 │    62 │         -2 │
│ lint:unresolved-reference          │ warning  │       2 │     9 │         +7 │
│ lint:unsupported-operator          │ error    │      48 │    70 │        +22 │
│ lint:unused-ignore-comment         │ warning  │     145 │     3 │       -142 │
├────────────────────────────────────┼──────────┼─────────┼───────┼────────────┤
│ TOTAL                              │          │    1254 │ 20624 │     +19370 │
└────────────────────────────────────┴──────────┴─────────┴───────┴────────────┘
Analysis complete. Found 25 unique diagnostic IDs.
Total diagnostics removed: 1254
Total diagnostics added: 20624
Net change: +19370
```

</p>
</details> 

Here's the diff of the mypy-primer diffs: https://www.diffchecker.com/409icClh/
