### PR TITLE
[red-knot] Support overloads for callable equivalence

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_equivalent_to.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_equivalent_to.md
@@ -256,6 +256,65 @@ static_assert(is_equivalent_to(int | Callable[[int | str], None], Callable[[str 
 
 ### Overloads
 
-TODO
+#### One overload
+
+`overloaded.pyi`:
+
+```pyi
+from typing import overload
+
+class Grandparent: ...
+class Parent(Grandparent): ...
+class Child(Parent): ...
+
+@overload
+def overloaded(a: Child) -> None: ...
+@overload
+def overloaded(a: Parent) -> None: ...
+@overload
+def overloaded(a: Grandparent) -> None: ...
+```
+
+```py
+from knot_extensions import CallableTypeOf, is_equivalent_to, static_assert
+from overloaded import Grandparent, Parent, Child, overloaded
+
+def grandparent(a: Grandparent) -> None: ...
+
+static_assert(is_equivalent_to(CallableTypeOf[grandparent], CallableTypeOf[overloaded]))
+static_assert(is_equivalent_to(CallableTypeOf[overloaded], CallableTypeOf[grandparent]))
+```
+
+#### Both overloads
+
+`overloaded.pyi`:
+
+```pyi
+from typing import overload
+
+class Grandparent: ...
+class Parent(Grandparent): ...
+class Child(Parent): ...
+
+@overload
+def pg(a: Parent) -> None: ...
+@overload
+def pg(a: Grandparent) -> None: ...
+
+@overload
+def cpg(a: Child) -> None: ...
+@overload
+def cpg(a: Parent) -> None: ...
+@overload
+def cpg(a: Grandparent) -> None: ...
+```
+
+```py
+from knot_extensions import CallableTypeOf, is_equivalent_to, static_assert
+from overloaded import pg, cpg
+
+static_assert(is_equivalent_to(CallableTypeOf[pg], CallableTypeOf[cpg]))
+static_assert(is_equivalent_to(CallableTypeOf[cpg], CallableTypeOf[pg]))
+```
 
 [the equivalence relation]: https://typing.python.org/en/latest/spec/glossary.html#term-equivalent


### PR DESCRIPTION
## Summary

Part of #15383, this PR adds `is_equivalent_to` support for overloaded callables.

This is mainly done by delegating it to the subtyping check in that two types A and B are considered equivalent if A is a subtype of B and B is a subtype of A.

## Test Plan

Add test cases for overloaded callables in `is_equivalent_to.md`
