### PR TITLE
[red-knot] Fix control flow for `assert` statements

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/assert.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/assert.md
@@ -79,6 +79,28 @@ def two(x: int | None, y: int | None):
     reveal_type(y)  # revealed: int | None
 ```
 
+## Assertions with `test` predicates that are statically known to always be `True`
+
+```py
+assert True, (x := 1)
+
+# error: [unresolved-reference]
+reveal_type(x)  # revealed: Unknown
+
+assert False, (y := 1)
+
+# The `assert` statement is terminal if `test` resolves to `False`,
+# so even though we know the `msg` branch will have been taken here
+# (we know what the truthiness of `False is!), we also know that the
+# `y` definition is not visible from this point in control flow
+# (because this point in control flow is unreachable).
+# We make sure that this does not emit an `[unresolved-reference]`
+# diagnostic by adding a reachability constraint,
+# but the inferred type is `Unknown`.
+#
+reveal_type(y)  # revealed: Unknown
+```
+
 ## Assertions with messages that reference definitions from the `test`
 
 ```py

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/assert.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/assert.md
@@ -51,3 +51,42 @@ def _(x: Literal[1, 2, 3], y: Literal[1, 2, 3]):
     assert y not in (1, 2)
     reveal_type(y)  # revealed: Literal[3]
 ```
+
+## Assertions with messages
+
+```py
+def _(x: int | None, y: int | None):
+    reveal_type(x)  # revealed: int | None
+    assert x is None, reveal_type(x)  # revealed: int
+    reveal_type(x)  # revealed: None
+
+    reveal_type(y)  # revealed: int | None
+    assert isinstance(y, int), reveal_type(y)  # revealed: None
+    reveal_type(y)  # revealed: int
+```
+
+## Assertions with definitions inside the message
+
+```py
+def one(x: int | None):
+    assert x is None, (y := x * 42) * reveal_type(y)  # revealed: int
+
+    # error: [unresolved-reference]
+    reveal_type(y)  # revealed: Unknown
+
+def two(x: int | None, y: int | None):
+    assert x is None, (y := 42) * reveal_type(y)  # revealed: Literal[42]
+    reveal_type(y)  # revealed: int | None
+```
+
+## Assertions with messages that reference definitions from the `test`
+
+```py
+def one(x: int | None):
+    assert (y := x), reveal_type(y)  # revealed: (int & ~AlwaysTruthy) | None
+    reveal_type(y)  # revealed: int & ~AlwaysFalsy
+
+def two(x: int | None):
+    assert isinstance((y := x), int), reveal_type(y)  # revealed: None
+    reveal_type(y)  # revealed: int
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/unreachable.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/unreachable.md
@@ -362,6 +362,15 @@ def f():
     ExceptionGroup
 ```
 
+Similarly, assertions with statically-known falsy conditions can lead to unreachable code:
+
+```py
+def f():
+    assert sys.version_info > (3, 11)
+
+    ExceptionGroup
+```
+
 Finally, not that anyone would ever use it, but it also works for `while` loops:
 
 ```py

--- a/crates/red_knot_python_semantic/src/semantic_index/predicate.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/predicate.rs
@@ -49,6 +49,15 @@ pub(crate) struct Predicate<'db> {
     pub(crate) is_positive: bool,
 }
 
+impl Predicate<'_> {
+    pub(crate) fn negated(self) -> Self {
+        Self {
+            node: self.node,
+            is_positive: !self.is_positive,
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, salsa::Update)]
 pub(crate) enum PredicateNode<'db> {
     Expression(Expression<'db>),


### PR DESCRIPTION
## Summary

@sharkdp and I realised in our 1:1 this morning that our control flow for `assert` statements isn't quite accurate at the moment. Namely, for something like this:

```py
def _(x: int | None):
    assert x is None, reveal_type(x)
```

we currently reveal `None` for `x` here, but this is incorrect. In actual fact, the `msg` expression of an `assert` statement (the expression after the comma) will only be evaluated if the test (`x is None`) evaluates to `False`. As such, we should be adding a constraint of `~None` to `x` in the `msg` expression, which should simplify the inferred type of `x` to `int` in that context (`(int | None) & ~None` -> `int`).

## Test Plan

Mdtests added.
