### PR TITLE
[red-knot] micro-optimise `ClassLiteral::is_protocol`

### DIFF
--- a/crates/red_knot_python_semantic/src/types/class.rs
+++ b/crates/red_knot_python_semantic/src/types/class.rs
@@ -534,7 +534,7 @@ impl<'db> ClassLiteral<'db> {
 
     /// Determine if this class is a protocol.
     pub(super) fn is_protocol(self, db: &'db dyn Db) -> bool {
-        self.explicit_bases(db).iter().any(|base| {
+        self.explicit_bases(db).iter().rev().take(3).any(|base| {
             matches!(
                 base,
                 Type::KnownInstance(KnownInstanceType::Protocol)


### PR DESCRIPTION
## Summary

I doubt it makes any significant difference to performance, but if `Protocol` is present in the bases list of a valid protocol class, it must either:
1. be the last base
2. or be the last-but-one base (with the final base being `Generic[]` or `object`)
3. or be the last-but-two base (with the penultimate base being `Generic[]` and the final base being `object`)

## Test Plan

Existing tests pass
