### PR TITLE
[red-knot] Assignability of class literals to Callables

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
@@ -529,6 +529,18 @@ c: Callable[[Any], str] = A().f
 c: Callable[[Any], str] = A().g
 ```
 
+### Class literal types
+
+```py
+from typing import Any, Callable
+
+c: Callable[[str], Any] = str
+c: Callable[[str], Any] = int
+
+# error: [invalid-assignment]
+c: Callable[[str], Any] = object
+```
+
 ### Overloads
 
 `overloaded.pyi`:

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1488,6 +1488,13 @@ impl<'db> Type<'db> {
                 }
             }
 
+            (Type::ClassLiteral(class_literal), Type::Callable(_)) => {
+                if let Some(callable) = class_literal.into_callable(db) {
+                    return callable.is_assignable_to(db, target);
+                }
+                false
+            }
+
             (Type::FunctionLiteral(self_function_literal), Type::Callable(_)) => {
                 self_function_literal
                     .into_callable_type(db)


### PR DESCRIPTION
## Summary

Subtyping was already modeled, but assignability also needs an explicit branch. Removes 921 ecosystem false positives.

## Test Plan

New Markdown tests.
