### PR TITLE
[`flake8-use-pathlib`] Fix `PTH123` false positive when `open` is passed a file descriptor from a function call

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/full_name.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/full_name.py
@@ -55,3 +55,8 @@ x = 2
 open(x)
 def foo(y: int):
     open(y)
+
+# https://github.com/astral-sh/ruff/issues/17691
+def f() -> int:
+    return 1
+open(f())

--- a/crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/full_name.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/full_name.py
@@ -60,3 +60,11 @@ def foo(y: int):
 def f() -> int:
     return 1
 open(f())
+
+open(b"foo")
+byte_str = b"bar"
+open(byte_str)
+
+def bytes_str_func() -> bytes:
+    return b"foo"
+open(bytes_str_func())

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/replaceable_by_pathlib.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/replaceable_by_pathlib.rs
@@ -180,7 +180,7 @@ fn is_file_descriptor(expr: &Expr, semantic: &SemanticModel) -> bool {
         return true;
     }
 
-    let Some(name) = expr.as_name_expr() else {
+    let Some(name) = get_name_expr(expr) else {
         return false;
     };
 
@@ -189,4 +189,12 @@ fn is_file_descriptor(expr: &Expr, semantic: &SemanticModel) -> bool {
     };
 
     typing::is_int(binding, semantic)
+}
+
+fn get_name_expr(expr: &Expr) -> Option<&ast::ExprName> {
+    match expr {
+        Expr::Name(name) => Some(name),
+        Expr::Call(ast::ExprCall { func, .. }) => get_name_expr(func),
+        _ => None,
+    }
 }

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/replaceable_by_pathlib.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/replaceable_by_pathlib.rs
@@ -126,10 +126,9 @@ pub(crate) fn replaceable_by_pathlib(checker: &Checker, call: &ExprCall) {
                         .arguments
                         .find_argument_value("opener", 7)
                         .is_some_and(|expr| !expr.is_none_literal_expr())
-                    || call
-                        .arguments
-                        .find_positional(0)
-                        .is_some_and(|expr| is_file_descriptor(expr, checker.semantic()))
+                    || call.arguments.find_positional(0).is_some_and(|expr| {
+                        is_file_descriptor_or_bytes_str(expr, checker.semantic())
+                    })
                 {
                     return None;
                 }
@@ -168,6 +167,10 @@ pub(crate) fn replaceable_by_pathlib(checker: &Checker, call: &ExprCall) {
     }
 }
 
+fn is_file_descriptor_or_bytes_str(expr: &Expr, semantic: &SemanticModel) -> bool {
+    is_file_descriptor(expr, semantic) || is_bytes_string(expr, semantic)
+}
+
 /// Returns `true` if the given expression looks like a file descriptor, i.e., if it is an integer.
 fn is_file_descriptor(expr: &Expr, semantic: &SemanticModel) -> bool {
     if matches!(
@@ -189,6 +192,23 @@ fn is_file_descriptor(expr: &Expr, semantic: &SemanticModel) -> bool {
     };
 
     typing::is_int(binding, semantic)
+}
+
+/// Returns `true` if the given expression is a bytes string.
+fn is_bytes_string(expr: &Expr, semantic: &SemanticModel) -> bool {
+    if matches!(expr, Expr::BytesLiteral(_)) {
+        return true;
+    }
+
+    let Some(name) = get_name_expr(expr) else {
+        return false;
+    };
+
+    let Some(binding) = semantic.only_binding(name).map(|id| semantic.binding(id)) else {
+        return false;
+    };
+
+    typing::is_bytes(binding, semantic)
 }
 
 fn get_name_expr(expr: &Expr) -> Option<&ast::ExprName> {

--- a/crates/ruff_python_semantic/src/analyze/typing.rs
+++ b/crates/ruff_python_semantic/src/analyze/typing.rs
@@ -639,6 +639,18 @@ pub fn check_type<T: TypeChecker>(binding: &Binding, semantic: &SemanticModel) -
             _ => false,
         },
 
+        BindingKind::FunctionDefinition(_) => match binding.statement(semantic) {
+            // ```python
+            // def foo() -> int:
+            //   ...
+            // ```
+            Some(Stmt::FunctionDef(ast::StmtFunctionDef { returns, .. })) => returns
+                .as_ref()
+                .is_some_and(|return_ann| T::match_annotation(return_ann, semantic)),
+
+            _ => false,
+        },
+
         _ => false,
     }
 }


### PR DESCRIPTION


<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary
Includes minor changes to the semantic type inference to help detect the return type of function call.

Fixes #17691

## Test Plan

Snapshot tests
