### PR TITLE
[red-knot] Make `Type::signatures()` exhaustive

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -4049,7 +4049,25 @@ impl<'db> Type<'db> {
                 Signatures::single(CallableSignature::todo("Type::Intersection.call()"))
             }
 
-            _ => Signatures::not_callable(self),
+            // TODO: these are actually callable
+            Type::MethodWrapper(_) | Type::DataclassDecorator(_) => Signatures::not_callable(self),
+
+            // TODO: some `KnownInstance`s are callable (e.g. TypedDicts)
+            Type::KnownInstance(_) => Signatures::not_callable(self),
+
+            Type::PropertyInstance(_)
+            | Type::AlwaysFalsy
+            | Type::AlwaysTruthy
+            | Type::IntLiteral(_)
+            | Type::StringLiteral(_)
+            | Type::BytesLiteral(_)
+            | Type::BooleanLiteral(_)
+            | Type::LiteralString
+            | Type::SliceLiteral(_)
+            | Type::Tuple(_)
+            | Type::BoundSuper(_)
+            | Type::TypeVar(_)
+            | Type::ModuleLiteral(_) => Signatures::not_callable(self),
         }
     }
 


### PR DESCRIPTION
## Summary

I had a bug for a while on my protocols branch because I hadn't added an arm in this `match` statement for the new `Type::Protocol` variant. It would have been easier to track the bug down if I'd had a compile error telling me that I needed to add an arm for the new variant -- but there was no compile error, because of the fallback `_ => Signatures::not_callable(self)` branch at the end here.

This PR makes the `match` exhaustive, so that others don't have this problem in the future! It also looks like there might already be some bugs here due to existing `Type` variants not having dedicated arms in the `match`; I've added some TODOs to the code.

## Test Plan

`cargo test -p red_knot_python_semantic`
