### PR TITLE
[docs] fix duplicated 'are' in comment for PTH123 rule

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/replaceable_by_pathlib.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/replaceable_by_pathlib.rs
@@ -99,7 +99,7 @@ pub(crate) fn replaceable_by_pathlib(checker: &Checker, call: &ExprCall) {
             // PTH123
             ["" | "builtins", "open"] => {
                 // `closefd` and `opener` are not supported by pathlib, so check if they are
-                // are set to non-default values.
+                // set to non-default values.
                 // https://github.com/astral-sh/ruff/issues/7620
                 // Signature as of Python 3.11 (https://docs.python.org/3/library/functions.html#open):
                 // ```text


### PR DESCRIPTION


## Summary

fix duplicated 'are' in comment for PTH123 rule, while read the code, I noticed duplicate words in the comments. Here's a simple fix.

