### PR TITLE
[`red-knot`] Allow subclasses of Any to be assignable to Callable types

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/any.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/any.md
@@ -89,8 +89,6 @@ from unittest.mock import MagicMock
 x: int = MagicMock()
 ```
 
-## Any subclass assigned to Callable
-
 A subclass of `Any` can be assigned to a `Callable` and called.
 
 ```py
@@ -116,3 +114,4 @@ from typing import Any
 def f(x: Any[int]):
     reveal_type(x)  # revealed: Unknown
 ```
+

--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/any.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/any.md
@@ -141,4 +141,3 @@ from typing import Any
 def f(x: Any[int]):
     reveal_type(x)  # revealed: Unknown
 ```
-

--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/any.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/any.md
@@ -89,6 +89,22 @@ from unittest.mock import MagicMock
 x: int = MagicMock()
 ```
 
+## Any subclass assigned to Callable
+
+A subclass of `Any` can be assigned to a `Callable` and called.
+
+```py
+from typing import Callable, Any
+
+class MyMock(Any):
+    pass
+
+def f(c: Callable):
+    c()
+
+f(MyMock())
+```
+
 ## Invalid
 
 `Any` cannot be parameterized:

--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/any.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/any.md
@@ -94,14 +94,41 @@ A subclass of `Any` can be assigned to a `Callable` and called.
 ```py
 from typing import Callable, Any
 
-class MyMock(Any):
+class MockCallable(Any):
     pass
 
-def f(c: Callable):
-    c()
+def takes_callable(f: Callable):
+    f()
 
-f(MyMock())
+takes_callable(MockCallable())
 ```
+
+But `Any` cannot be assigned to `Final` or `Literal`
+
+```py
+from typing import Any, Literal
+
+class MockAny(Any):
+    pass
+
+x: Literal[1] = MockAny()  # error: [invalid-assignment]
+```
+
+
+```py
+from typing import final, Any
+
+@final
+class FinalA: ...
+
+@final
+class FinalB: ...
+
+class MockAny(Any): ...
+
+value: FinalA  | FinalB  = MockAny()  # error: [invalid-assignment]
+```
+
 
 ## Invalid
 

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1308,7 +1308,9 @@ impl<'db> Type<'db> {
             if self_instance.class().is_subclass_of_any_or_unknown(db) {
                 match target {
                     Type::ClassLiteral(_) => return false,
-                    Type::Instance(target_instance) => return target_instance.class().is_final(db),
+                    Type::Instance(target_instance) => {
+                        return !target_instance.class().is_final(db)
+                    }
                     _ => return true,
                 }
             }

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1302,7 +1302,8 @@ impl<'db> Type<'db> {
     ///
     /// [assignable to]: https://typing.python.org/en/latest/spec/concepts.html#the-assignable-to-or-consistent-subtyping-relation
     pub(crate) fn is_assignable_to(self, db: &'db dyn Db, target: Type<'db>) -> bool {
-        // Handle 'any' type early, as it can be assigned to most other types.
+        // Subclasses of Any are assignable to non-final, non-literal types,
+        // as Any can materialize to any such type, but not to final or literal types.
         if let Type::Instance(self_instance) = self {
             if self_instance.class().is_subclass_of_any_or_unknown(db) {
                 match target {

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1353,7 +1353,7 @@ impl<'db> Type<'db> {
                 .elements(db)
                 .iter()
                 .any(|&elem_ty| ty.is_assignable_to(db, elem_ty)),
-            
+
             // Subclasses of Any are assignable to non-final, non-literal types,
             // as Any can materialize to any such type, but not to final or literal types.
             (Type::Instance(instance), target)

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1353,7 +1353,9 @@ impl<'db> Type<'db> {
                 .elements(db)
                 .iter()
                 .any(|&elem_ty| ty.is_assignable_to(db, elem_ty)),
-
+            
+            // Subclasses of Any are assignable to non-final, non-literal types,
+            // as Any can materialize to any such type, but not to final or literal types.
             (Type::Instance(instance), target)
                 if instance.class().is_subclass_of_any_or_unknown(db) =>
             {

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1369,7 +1369,7 @@ impl<'db> Type<'db> {
                     Type::Instance(target_instance) if target_instance.class().is_final(db) => {
                         false
                     }
-                    _ => true,
+                    _ => true
                 }
             }
 

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1369,7 +1369,7 @@ impl<'db> Type<'db> {
                     Type::Instance(target_instance) if target_instance.class().is_final(db) => {
                         false
                     }
-                    _ => true
+                    _ => true,
                 }
             }
 

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1302,6 +1302,12 @@ impl<'db> Type<'db> {
     ///
     /// [assignable to]: https://typing.python.org/en/latest/spec/concepts.html#the-assignable-to-or-consistent-subtyping-relation
     pub(crate) fn is_assignable_to(self, db: &'db dyn Db, target: Type<'db>) -> bool {
+        // PEP 484: Any and its subclasses are assignable to all types.
+        if let Type::Instance(instance) = self {
+            if instance.class().is_subclass_of_any_or_unknown(db) {
+                return true;
+            }
+        }
         if self.is_gradual_equivalent_to(db, target) {
             return true;
         }

--- a/crates/red_knot_python_semantic/src/types/class.rs
+++ b/crates/red_knot_python_semantic/src/types/class.rs
@@ -284,13 +284,7 @@ impl<'db> ClassType<'db> {
             }
         }
 
-        if self.iter_mro(db).any(|base| {
-            matches!(
-                base,
-                ClassBase::Dynamic(DynamicType::Any | DynamicType::Unknown)
-            )
-        }) && !other.is_final(db)
-        {
+        if self.is_subclass_of_any_or_unknown(db) && !other.is_final(db) {
             return true;
         }
 

--- a/crates/red_knot_python_semantic/src/types/class.rs
+++ b/crates/red_knot_python_semantic/src/types/class.rs
@@ -195,6 +195,16 @@ impl<'db> ClassType<'db> {
         class_literal.is_final(db)
     }
 
+    /// Is this class a subclass of `Any` or `Unknown`?
+    pub(crate) fn is_subclass_of_any_or_unknown(self, db: &'db dyn Db) -> bool {
+        self.iter_mro(db).any(|base| {
+            matches!(
+                base,
+                ClassBase::Dynamic(DynamicType::Any | DynamicType::Unknown)
+            )
+        })
+    }
+
     /// If `self` and `other` are generic aliases of the same generic class, returns their
     /// corresponding specializations.
     fn compatible_specializations(


### PR DESCRIPTION
## Summary

Fixes #17701. I'm uncertain whether this Python code needs to be added to the test cases. I'd be happy to supplement it if needed.
