### PR TITLE
[red-knot] mdtest.py: Watch for changes in `red_knot_vendored` and `red_knot_test` as well as in `red_knot_python_semantic`

### DIFF
--- a/crates/red_knot_python_semantic/mdtest.py
+++ b/crates/red_knot_python_semantic/mdtest.py
@@ -20,6 +20,11 @@ from watchfiles import Change, watch
 
 CRATE_NAME: Final = "red_knot_python_semantic"
 CRATE_ROOT: Final = Path(__file__).resolve().parent
+DIRS_TO_WATCH: Final = (
+    CRATE_ROOT,
+    CRATE_ROOT.parent / "red_knot_vendored",
+    CRATE_ROOT.parent / "red_knot_test/src",
+)
 MDTEST_DIR: Final = CRATE_ROOT / "resources" / "mdtest"
 
 
@@ -158,7 +163,7 @@ class MDTestRunner:
         self._run_mdtest()
         self.console.print("[dim]Ready to watch for changes...[/dim]")
 
-        for changes in watch(CRATE_ROOT):
+        for changes in watch(*DIRS_TO_WATCH):
             new_md_files = set()
             changed_md_files = set()
             rust_code_has_changed = False
@@ -166,7 +171,10 @@ class MDTestRunner:
             for change, path_str in changes:
                 path = Path(path_str)
 
-                if path.suffix == ".rs":
+                # Obviously a change to a vendored stub file isn't really "Rust code",
+                # but we need to rebuild the binary to pick up the changes,
+                # # so it comes to the same thing
+                if path.suffix in {".rs", ".pyi"}:
                     rust_code_has_changed = True
                     continue
 


### PR DESCRIPTION
## Summary

It's come up a few times recently that I've been incrementally experimenting with changes to red-knot's vendored typeshed or the mdtest framework itself, and I've found it surprising that the `mdtest.py` script I have running in the background didn't automatically recompile my mdtests and rerun them on every change. This PR tweaks `mdtest.py` so that it also watches for changes in those crates, and recompiles the binary for running tests if any `.rs` or `.pyi` files in those crates change.

## Test Plan

I set `mdtest.py` running in a terminal in my editor by running `uv run crates/red_knot_python_semantic/mdtest.py`. I then checked that all the following now triggered a recompilation of the tests:
- A change to a `.rs` file in `crates/red_knot_python_semantic`
- A change to a `.rs` file in `crates/red_knot_test`
- A change to a `.pyi` file in `crates/red_knot_vendored`

And that changing a `.md` file in `crates/red_knot_python_semantic` triggered a rerun of the test without a recompilation of the test.
