### PR TITLE
[red-knot] Run py-fuzzer in CI to check for new panics

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -637,7 +637,7 @@ jobs:
           path: ecosystem-result
 
   fuzz-redknot:
-    name: "Check for new red-knot panics"
+    name: "Fuzz for new red-knot panics"
     runs-on: depot-ubuntu-22.04-16
     needs:
       - cargo-test-linux

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -276,6 +276,10 @@ jobs:
         with:
           name: ruff
           path: target/debug/ruff
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: red_knot
+          path: target/debug/red_knot
 
   cargo-test-linux-release:
     name: "cargo test (linux, release)"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -636,6 +636,53 @@ jobs:
           name: ecosystem-result
           path: ecosystem-result
 
+  fuzz-redknot:
+    name: "Check for new red-knot panics"
+    runs-on: depot-ubuntu-22.04-16
+    needs:
+      - cargo-test-linux
+      - determine_changes
+    # Only runs on pull requests, since that is the only we way we can find the base version for comparison.
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-test') && github.event_name == 'pull_request' && needs.determine_changes.outputs.red_knot == 'true' }}
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
+        name: Download new red-knot binary
+        id: redknot-new
+        with:
+          name: red_knot
+          path: target/debug
+      - uses: dawidd6/action-download-artifact@20319c5641d495c8a52e688b7dc5fada6c3a9fbc # v8
+        name: Download baseline red-knot binary
+        with:
+          name: red_knot
+          branch: ${{ github.event.pull_request.base.ref }}
+          workflow: "ci.yaml"
+          check_artifacts: true
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
+      - name: Fuzz
+        env:
+          FORCE_COLOR: 1
+          NEW_REDKNOT: ${{ steps.redknot-new.outputs.download-path }}
+        run: |
+          # Make executable, since artifact download doesn't preserve this
+          chmod +x "${PWD}/red_knot" "${NEW_REDKNOT}/red_knot"
+
+          (
+            uvx \
+            --python="${PYTHON_VERSION}" \
+            --from=./python/py-fuzzer \
+            fuzz \
+            --test-executable="${NEW_REDKNOT}/red_knot" \
+            --baseline-executable="${PWD}/red_knot" \
+            --only-new-bugs \
+            --bin=red_knot \
+            0-500
+          )
+
   cargo-shear:
     name: "cargo shear"
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

This PR sets up a CI job that uses the py-fuzzer script to check whether a PR introduces new panics to red-knot.

The py-fuzzer script still finds lots of panics in red-knot generally (see https://github.com/astral-sh/ruff/issues/14737 for a tracking issue), so running it with the default arguments in CI would lead to a lot of red CI jobs. However, the py-fuzzer script _also_ has a `--only-new-bugs` CLI flag! If specified, it allows you to compare two binaries and check whether any _new_ panics have been introduced by the PR. If any have been introduced, the script fails; if there are no new panics relative to the baseline binary, however, the script exits with code 0.

The CI job here ends up looking like a cross between the `fuzz-parser` CI job in `ci.yaml` (which already runs the `py-fuzzer` script in CI for us, but which runs it with the `ruff` binary to fuzz the parser rather than red-knot) and the `ruff-ecosystem` CI job in `ci.yaml` (which, in a similar way to this new CI job, downloads two binaries and compares them to see if there's any differences).

The CI job is currently failing because there's no baseline red-knot binary for the job to download (this PR adds the CI job that will start uploading the red-knot binary for future CI jobs to download). I'm not totally sure how to address this -- I suppose I could split it up into two PRs, one that adds the job uploading the binary and then a second one that adds the job to actually use the binary? I'll wait for review on the general idea here before going ahead with that, though.

## Test Plan

I did the following:
- Built the binary on `main` with `--target-directory=target/main`
- Switched to a branch that had more panics and ran `cargo build -p red_knot`
- Ran the following command from my terminal and observed that the script only reported new panics that did not exist on `main`:

  ```
  uvx \
      --python="3.12" \
      --from=./python/py-fuzzer \
      fuzz \
      --test-executable="./target/debug/red_knot" \
      --baseline-executable="./target/main/debug/red_knot" \
      --only-new-bugs \
      --bin=red_knot \
      0-500
  ```
