### PR TITLE
Upload red-knot binaries in CI on completion of linux tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -276,6 +276,10 @@ jobs:
         with:
           name: ruff
           path: target/debug/ruff
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: red_knot
+          path: target/debug/red_knot
 
   cargo-test-linux-release:
     name: "cargo test (linux, release)"


### PR DESCRIPTION
This is a preparatory PR for https://github.com/astral-sh/ruff/pull/17719. It needs to be split into a separate commit or CI wouldn't pass on that PR, since that PR needs to download a baseline binary from somewhere.