### PR TITLE
[`ruff`] add fix safety section (`RUF028`)

### DIFF
--- a/crates/ruff_linter/src/rules/ruff/rules/invalid_formatter_suppression_comment.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/invalid_formatter_suppression_comment.rs
@@ -49,6 +49,12 @@ use super::suppression_comment_visitor::{
 ///     # fmt: on
 ///     # yapf: enable
 /// ```
+///
+/// ## Fix safety
+///
+/// The fix is always marked as unsafe because it's not possible to clearly determine
+/// the user's true intent behind the suppression statement.
+///
 #[derive(ViolationMetadata)]
 pub(crate) struct InvalidFormatterSuppressionComment {
     reason: IgnoredReason,

--- a/crates/ruff_linter/src/rules/ruff/rules/invalid_formatter_suppression_comment.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/invalid_formatter_suppression_comment.rs
@@ -52,8 +52,8 @@ use super::suppression_comment_visitor::{
 ///
 /// ## Fix safety
 ///
-/// The fix is always marked as unsafe because it's not possible to clearly determine
-/// the user's true intent behind the suppression statement.
+/// This fix is always marked as unsafe because it deletes the invalid suppression comment,
+/// rather than trying to move it to a valid position, which the user more likely intended.
 ///
 #[derive(ViolationMetadata)]
 pub(crate) struct InvalidFormatterSuppressionComment {


### PR DESCRIPTION
The PR add the fix safety section for rule `RUF028` (https://github.com/astral-sh/ruff/issues/15584 )

See also [here](https://github.com/astral-sh/ruff/issues/15584#issuecomment-2820424485) for the reason behind the _unsafe_ of the fix.