### PR TITLE
py-fuzzer: fix minimization logic when `--only-new-bugs` is passed

### DIFF
--- a/python/py-fuzzer/fuzz.py
+++ b/python/py-fuzzer/fuzz.py
@@ -32,6 +32,7 @@ import concurrent.futures
 import enum
 import subprocess
 import tempfile
+from collections.abc import Callable
 from dataclasses import KW_ONLY, dataclass
 from functools import partial
 from pathlib import Path
@@ -148,39 +149,51 @@ class FuzzResult:
 def fuzz_code(seed: Seed, args: ResolvedCliArgs) -> FuzzResult:
     """Return a `FuzzResult` instance describing the fuzzing result from this seed."""
     code = generate_random_code(seed)
-    has_bug = (
-        contains_new_bug(
-            code,
+    bug_found = False
+    minimizer_callback: Callable[[str], bool] | None = None
+
+    if args.baseline_executable_path is None:
+        if contains_bug(
+            code, executable=args.executable, executable_path=args.test_executable_path
+        ):
+            bug_found = True
+            minimizer_callback = partial(
+                contains_bug,
+                executable=args.executable,
+                executable_path=args.test_executable_path,
+            )
+    elif contains_new_bug(
+        code,
+        executable=args.executable,
+        test_executable_path=args.test_executable_path,
+        baseline_executable_path=args.baseline_executable_path,
+    ):
+        bug_found = True
+        minimizer_callback = partial(
+            contains_new_bug,
             executable=args.executable,
             test_executable_path=args.test_executable_path,
             baseline_executable_path=args.baseline_executable_path,
         )
-        if args.baseline_executable_path is not None
-        else contains_bug(
-            code, executable=args.executable, executable_path=args.test_executable_path
-        )
-    )
-    if has_bug:
-        callback = partial(
-            contains_bug,
-            executable=args.executable,
-            executable_path=args.test_executable_path,
-        )
-        try:
-            maybe_bug = MinimizedSourceCode(minimize_repro(code, callback))
-        except CouldNotMinimize as e:
-            # This is to double-check that there isn't a bug in
-            # `pysource-minimize`/`pysource-codegen`.
-            # `pysource-minimize` *should* never produce code that's invalid syntax.
-            try:
-                ast.parse(code)
-            except SyntaxError:
-                raise e from None
-            else:
-                maybe_bug = MinimizedSourceCode(code)
 
-    else:
-        maybe_bug = None
+    if not bug_found:
+        return FuzzResult(seed, None, args.executable)
+
+    assert minimizer_callback is not None
+
+    try:
+        maybe_bug = MinimizedSourceCode(minimize_repro(code, minimizer_callback))
+    except CouldNotMinimize as e:
+        # This is to double-check that there isn't a bug in
+        # `pysource-minimize`/`pysource-codegen`.
+        # `pysource-minimize` *should* never produce code that's invalid syntax.
+        try:
+            ast.parse(code)
+        except SyntaxError:
+            raise e from None
+        else:
+            maybe_bug = MinimizedSourceCode(code)
+
     return FuzzResult(seed, maybe_bug, args.executable)
 
 

--- a/python/py-fuzzer/fuzz.py
+++ b/python/py-fuzzer/fuzz.py
@@ -50,14 +50,12 @@ ExitCode = NewType("ExitCode", int)
 def redknot_contains_bug(code: str, *, red_knot_executable: Path) -> bool:
     """Return `True` if the code triggers a panic in type-checking code."""
     with tempfile.TemporaryDirectory() as tempdir:
-        Path(tempdir, "pyproject.toml").write_text('[project]\n\tname = "fuzz-input"')
-        Path(tempdir, "input.py").write_text(code)
+        input_file = Path(tempdir, "input.py")
+        input_file.write_text(code)
         completed_process = subprocess.run(
-            [red_knot_executable, "check", "--project", tempdir],
-            capture_output=True,
-            text=True,
+            [red_knot_executable, "check", input_file], capture_output=True, text=True
         )
-    return completed_process.returncode != 0 and completed_process.returncode != 1
+    return completed_process.returncode not in {0, 1, 2}
 
 
 def ruff_contains_bug(code: str, *, ruff_executable: Path) -> bool:


### PR DESCRIPTION
## Summary

This PR fixes an issue in the py-fuzzer script described in https://github.com/astral-sh/ruff/pull/17702#issuecomment-2841720242. Namely, if run with `--only-new-bugs`, it's not sufficient for the script to just check that the bug exists in the new version of Ruff/red-knot when the script is minimizing the code that triggers the bug. The script must also check that the minimized version of the code _also_ continues to _not_ cause a panic on the baseline executable if `--only-new-bugs` is passed. Otherwise, the minimization has gone "too far". It's no longer a _new_ bug if it's been minimized to a snippet that causes a panic on both the test executable _and_ the baseline executable.

The first commit here just simplifies the way we run red-knot on the randomly generated code: the `--project` CLI argument is no longer necessary, and it's no longer necessary to write a `pyproject.toml` file to the temporary directory. The second commit here is the one that meaningfully fixes the bug.

## Test Plan

I checked that the script continues to pass with mypy using `uv run --directory ./python/py-fuzzer --dev mypy` from the root of my local Ruff clone.

I also did the following to test this change:
1. I checked out https://github.com/astral-sh/ruff/commit/4a621c2c12fb65fae343883ad17ce535411c5712 (the commit prior to https://github.com/astral-sh/ruff/commit/8a6787b39e178ff829d58d775b4d65d83b061c53)
2. I ran `cargo build -p red_knot --target-dir ./target/baseline` to create a baseline executable.
3. I checked out this branch again.
4. I ran the following command:

   ```
   uvx \                                           
   --python=3.13 \
   --force-reinstall \
   --from=./python/py-fuzzer \
   fuzz \
   --baseline-executable="./target/baseline/debug/red_knot" \
   --bin=red_knot \
   --only-new-bugs \
   50
   ```

   which produced the following output:

   ```
   Running `cargo build --release` since no test executable was specified...
   Sequentially running the fuzzer on 1 randomly generated source-code files...
   Ran fuzzer on seed 50                                         [1/1]
   The following code triggers a red-knot panic:

   class name_3[name_2: name_0]:
       pass
   name_3.name_4
   assert name_3[name_0]
   import name_0

   New bugs found in the following seeds:
   50
   ```

   I then confirmed that the script had correctly minimized the snippet to something that caused a panic on this branch but had _not_ caused a panic prior to https://github.com/astral-sh/ruff/commit/8a6787b39e178ff829d58d775b4d65d83b061c53, unlike the buggy behaviour that the script displays on `main`.   
