### PR TITLE
Fix example syntax for pydocstyle ignore_var_parameters option

### DIFF
--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -3118,7 +3118,7 @@ pub struct PydocstyleOptions {
         default = r#"false"#,
         value_type = "bool",
         example = r#"
-            ignore_var_parameters = true
+            ignore-var-parameters = true
         "#
     )]
     pub ignore_var_parameters: Option<bool>,


### PR DESCRIPTION
## Summary

I noticed an error in the `pyproject.toml` syntax for the pydocstyle option [`ignore-var-parameters`](https://docs.astral.sh/ruff/settings/#lint_pydocstyle_ignore-var-parameters). This PR switches underscores to hyphens in the example to correct the syntax.

## Test Plan

All checks from [contributor guidelines](https://docs.astral.sh/ruff/contributing/#development) have been run and passed. Additionally, I have confirmed that the corrected example syntax correctly implements the option and avoids parsing errors on pyproject.toml.
