### PR TITLE
[red-knot] Ban direct instantiation of generic protocols as well as non-generic ones

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/protocols.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/protocols.md
@@ -304,6 +304,11 @@ reveal_type(typing.Protocol is not typing_extensions.Protocol)  # revealed: bool
 
 Neither `Protocol`, nor any protocol class, can be directly instantiated:
 
+```toml
+[environment]
+python-version = "3.12"
+```
+
 ```py
 from typing_extensions import Protocol, reveal_type
 
@@ -315,6 +320,12 @@ class MyProtocol(Protocol):
 
 # error: [call-non-callable] "Cannot instantiate class `MyProtocol`"
 reveal_type(MyProtocol())  # revealed: MyProtocol
+
+class GenericProtocol[T](Protocol):
+    x: T
+
+# error: [call-non-callable] "Cannot instantiate class `GenericProtocol`"
+reveal_type(GenericProtocol[int]())  # revealed: GenericProtocol[int]
 ```
 
 But a non-protocol class can be instantiated, even if it has `Protocol` in its MRO:

--- a/crates/red_knot_python_semantic/resources/mdtest/protocols.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/protocols.md
@@ -334,6 +334,10 @@ But a non-protocol class can be instantiated, even if it has `Protocol` in its M
 class SubclassOfMyProtocol(MyProtocol): ...
 
 reveal_type(SubclassOfMyProtocol())  # revealed: SubclassOfMyProtocol
+
+class SubclassOfGenericProtocol[T](GenericProtocol[T]): ...
+
+reveal_type(SubclassOfGenericProtocol[int]())  # revealed: SubclassOfGenericProtocol[int]
 ```
 
 And as a corollary, `type[MyProtocol]` can also be called:

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Calls_to_protocol_classes.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Calls_to_protocol_classes.snap
@@ -31,8 +31,12 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/protocols.md
 17 | class SubclassOfMyProtocol(MyProtocol): ...
 18 | 
 19 | reveal_type(SubclassOfMyProtocol())  # revealed: SubclassOfMyProtocol
-20 | def f(x: type[MyProtocol]):
-21 |     reveal_type(x())  # revealed: MyProtocol
+20 | 
+21 | class SubclassOfGenericProtocol[T](GenericProtocol[T]): ...
+22 | 
+23 | reveal_type(SubclassOfGenericProtocol[int]())  # revealed: SubclassOfGenericProtocol[int]
+24 | def f(x: type[MyProtocol]):
+25 |     reveal_type(x())  # revealed: MyProtocol
 ```
 
 # Diagnostics
@@ -99,6 +103,27 @@ info: revealed-type: Revealed type
 ```
 
 ```
+error: lint:call-non-callable: Cannot instantiate class `GenericProtocol`
+  --> src/mdtest_snippet.py:16:13
+   |
+15 | # error: [call-non-callable] "Cannot instantiate class `GenericProtocol`"
+16 | reveal_type(GenericProtocol[int]())  # revealed: GenericProtocol[int]
+   |             ^^^^^^^^^^^^^^^^^^^^^^ This call will raise `TypeError` at runtime
+17 | class SubclassOfMyProtocol(MyProtocol): ...
+   |
+info: Protocol classes cannot be instantiated
+  --> src/mdtest_snippet.py:12:7
+   |
+10 | reveal_type(MyProtocol())  # revealed: MyProtocol
+11 |
+12 | class GenericProtocol[T](Protocol):
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `GenericProtocol` declared as a protocol here
+13 |     x: T
+   |
+
+```
+
+```
 info: revealed-type: Revealed type
   --> src/mdtest_snippet.py:16:1
    |
@@ -118,19 +143,33 @@ info: revealed-type: Revealed type
 18 |
 19 | reveal_type(SubclassOfMyProtocol())  # revealed: SubclassOfMyProtocol
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `SubclassOfMyProtocol`
-20 | def f(x: type[MyProtocol]):
-21 |     reveal_type(x())  # revealed: MyProtocol
+20 |
+21 | class SubclassOfGenericProtocol[T](GenericProtocol[T]): ...
    |
 
 ```
 
 ```
 info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:21:5
+  --> src/mdtest_snippet.py:23:1
    |
-19 | reveal_type(SubclassOfMyProtocol())  # revealed: SubclassOfMyProtocol
-20 | def f(x: type[MyProtocol]):
-21 |     reveal_type(x())  # revealed: MyProtocol
+21 | class SubclassOfGenericProtocol[T](GenericProtocol[T]): ...
+22 |
+23 | reveal_type(SubclassOfGenericProtocol[int]())  # revealed: SubclassOfGenericProtocol[int]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `SubclassOfGenericProtocol[int]`
+24 | def f(x: type[MyProtocol]):
+25 |     reveal_type(x())  # revealed: MyProtocol
+   |
+
+```
+
+```
+info: revealed-type: Revealed type
+  --> src/mdtest_snippet.py:25:5
+   |
+23 | reveal_type(SubclassOfGenericProtocol[int]())  # revealed: SubclassOfGenericProtocol[int]
+24 | def f(x: type[MyProtocol]):
+25 |     reveal_type(x())  # revealed: MyProtocol
    |     ^^^^^^^^^^^^^^^^ `MyProtocol`
    |
 

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Calls_to_protocol_classes.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Calls_to_protocol_classes.snap
@@ -22,11 +22,17 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/protocols.md
  8 | 
  9 | # error: [call-non-callable] "Cannot instantiate class `MyProtocol`"
 10 | reveal_type(MyProtocol())  # revealed: MyProtocol
-11 | class SubclassOfMyProtocol(MyProtocol): ...
-12 | 
-13 | reveal_type(SubclassOfMyProtocol())  # revealed: SubclassOfMyProtocol
-14 | def f(x: type[MyProtocol]):
-15 |     reveal_type(x())  # revealed: MyProtocol
+11 | 
+12 | class GenericProtocol[T](Protocol):
+13 |     x: T
+14 | 
+15 | # error: [call-non-callable] "Cannot instantiate class `GenericProtocol`"
+16 | reveal_type(GenericProtocol[int]())  # revealed: GenericProtocol[int]
+17 | class SubclassOfMyProtocol(MyProtocol): ...
+18 | 
+19 | reveal_type(SubclassOfMyProtocol())  # revealed: SubclassOfMyProtocol
+20 | def f(x: type[MyProtocol]):
+21 |     reveal_type(x())  # revealed: MyProtocol
 ```
 
 # Diagnostics
@@ -64,7 +70,8 @@ error: lint:call-non-callable: Cannot instantiate class `MyProtocol`
  9 | # error: [call-non-callable] "Cannot instantiate class `MyProtocol`"
 10 | reveal_type(MyProtocol())  # revealed: MyProtocol
    |             ^^^^^^^^^^^^ This call will raise `TypeError` at runtime
-11 | class SubclassOfMyProtocol(MyProtocol): ...
+11 |
+12 | class GenericProtocol[T](Protocol):
    |
 info: Protocol classes cannot be instantiated
  --> src/mdtest_snippet.py:6:7
@@ -85,32 +92,45 @@ info: revealed-type: Revealed type
  9 | # error: [call-non-callable] "Cannot instantiate class `MyProtocol`"
 10 | reveal_type(MyProtocol())  # revealed: MyProtocol
    | ^^^^^^^^^^^^^^^^^^^^^^^^^ `MyProtocol`
-11 | class SubclassOfMyProtocol(MyProtocol): ...
+11 |
+12 | class GenericProtocol[T](Protocol):
    |
 
 ```
 
 ```
 info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:13:1
+  --> src/mdtest_snippet.py:16:1
    |
-11 | class SubclassOfMyProtocol(MyProtocol): ...
-12 |
-13 | reveal_type(SubclassOfMyProtocol())  # revealed: SubclassOfMyProtocol
+15 | # error: [call-non-callable] "Cannot instantiate class `GenericProtocol`"
+16 | reveal_type(GenericProtocol[int]())  # revealed: GenericProtocol[int]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `GenericProtocol[int]`
+17 | class SubclassOfMyProtocol(MyProtocol): ...
+   |
+
+```
+
+```
+info: revealed-type: Revealed type
+  --> src/mdtest_snippet.py:19:1
+   |
+17 | class SubclassOfMyProtocol(MyProtocol): ...
+18 |
+19 | reveal_type(SubclassOfMyProtocol())  # revealed: SubclassOfMyProtocol
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `SubclassOfMyProtocol`
-14 | def f(x: type[MyProtocol]):
-15 |     reveal_type(x())  # revealed: MyProtocol
+20 | def f(x: type[MyProtocol]):
+21 |     reveal_type(x())  # revealed: MyProtocol
    |
 
 ```
 
 ```
 info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:15:5
+  --> src/mdtest_snippet.py:21:5
    |
-13 | reveal_type(SubclassOfMyProtocol())  # revealed: SubclassOfMyProtocol
-14 | def f(x: type[MyProtocol]):
-15 |     reveal_type(x())  # revealed: MyProtocol
+19 | reveal_type(SubclassOfMyProtocol())  # revealed: SubclassOfMyProtocol
+20 | def f(x: type[MyProtocol]):
+21 |     reveal_type(x())  # revealed: MyProtocol
    |     ^^^^^^^^^^^^^^^^ `MyProtocol`
    |
 


### PR DESCRIPTION
## Summary

This PR fixes an oversight from https://github.com/astral-sh/ruff/pull/17597. On `main`, we currently emit a diagnostic for `MyNonGenericProtocol()` but not for `MyGenericProtocol[int]()`. (One is a `Type::ClassLiteral` in our model, the other is a `Type::GenericAlias`.)

## Test Plan

new mdtests added that fail on `main`.
