### PR TITLE
[semantic-syntax-tests] for for `InvalidStarExpression`, `DuplicateMatchKey`, and `DuplicateMatchClassAttribute`

### DIFF
--- a/crates/ruff_linter/src/linter.rs
+++ b/crates/ruff_linter/src/linter.rs
@@ -1063,6 +1063,53 @@ mod tests {
         PythonVersion::PY310,
         "MultipleCaseAssignment"
     )]
+    #[test_case(
+        "duplicate_match_key",
+        "
+        match x:
+            case {'key': 1, 'key': 2}:
+                pass
+        ",
+        PythonVersion::PY310,
+        "DuplicateMatchKey"
+    )]
+    #[test_case(
+        "duplicate_match_class_attribute",
+        "
+        match x:
+            case Point(x=1, x=2):
+                pass
+        ",
+        PythonVersion::PY310,
+        "DuplicateMatchClassAttribute"
+    )]
+    #[test_case(
+        "invalid_star_expression",
+        "
+        def func():
+            return *x
+        ",
+        PythonVersion::PY310,
+        "InvalidStarExpression"
+    )]
+    #[test_case(
+        "invalid_star_expression_for",
+        "
+        for *x in range(10):
+            pass
+        ",
+        PythonVersion::PY310,
+        "InvalidStarExpression"
+    )]
+    #[test_case(
+        "invalid_star_expression_yield",
+        "
+        def func():
+            yield *x
+        ",
+        PythonVersion::PY310,
+        "InvalidStarExpression"
+    )]
     fn test_semantic_errors(
         name: &str,
         contents: &str,

--- a/crates/ruff_linter/src/snapshots/ruff_linter__linter__tests__semantic_syntax_error_DuplicateMatchClassAttribute_duplicate_match_class_attribute_3.10.snap
+++ b/crates/ruff_linter/src/snapshots/ruff_linter__linter__tests__semantic_syntax_error_DuplicateMatchClassAttribute_duplicate_match_class_attribute_3.10.snap
@@ -1,0 +1,10 @@
+---
+source: crates/ruff_linter/src/linter.rs
+---
+<filename>:3:21: SyntaxError: attribute name `x` repeated in class pattern
+  |
+2 | match x:
+3 |     case Point(x=1, x=2):
+  |                     ^
+4 |         pass
+  |

--- a/crates/ruff_linter/src/snapshots/ruff_linter__linter__tests__semantic_syntax_error_DuplicateMatchKey_duplicate_match_key_3.10.snap
+++ b/crates/ruff_linter/src/snapshots/ruff_linter__linter__tests__semantic_syntax_error_DuplicateMatchKey_duplicate_match_key_3.10.snap
@@ -1,0 +1,10 @@
+---
+source: crates/ruff_linter/src/linter.rs
+---
+<filename>:3:21: SyntaxError: mapping pattern checks duplicate key `'key'`
+  |
+2 | match x:
+3 |     case {'key': 1, 'key': 2}:
+  |                     ^^^^^
+4 |         pass
+  |

--- a/crates/ruff_linter/src/snapshots/ruff_linter__linter__tests__semantic_syntax_error_InvalidStarExpression_invalid_star_expression_3.10.snap
+++ b/crates/ruff_linter/src/snapshots/ruff_linter__linter__tests__semantic_syntax_error_InvalidStarExpression_invalid_star_expression_3.10.snap
@@ -1,0 +1,9 @@
+---
+source: crates/ruff_linter/src/linter.rs
+---
+<filename>:3:12: SyntaxError: can't use starred expression here
+  |
+2 | def func():
+3 |     return *x
+  |            ^^
+  |

--- a/crates/ruff_linter/src/snapshots/ruff_linter__linter__tests__semantic_syntax_error_InvalidStarExpression_invalid_star_expression_3.10.snap
+++ b/crates/ruff_linter/src/snapshots/ruff_linter__linter__tests__semantic_syntax_error_InvalidStarExpression_invalid_star_expression_3.10.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/linter.rs
 ---
-<filename>:3:12: SyntaxError: can't use starred expression here
+<filename>:3:12: SyntaxError: Starred expression cannot be used here
   |
 2 | def func():
 3 |     return *x

--- a/crates/ruff_linter/src/snapshots/ruff_linter__linter__tests__semantic_syntax_error_InvalidStarExpression_invalid_star_expression_for_3.10.snap
+++ b/crates/ruff_linter/src/snapshots/ruff_linter__linter__tests__semantic_syntax_error_InvalidStarExpression_invalid_star_expression_for_3.10.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/linter.rs
 ---
-<filename>:2:5: SyntaxError: can't use starred expression here
+<filename>:2:5: SyntaxError: Starred expression cannot be used here
   |
 2 | for *x in range(10):
   |     ^^

--- a/crates/ruff_linter/src/snapshots/ruff_linter__linter__tests__semantic_syntax_error_InvalidStarExpression_invalid_star_expression_for_3.10.snap
+++ b/crates/ruff_linter/src/snapshots/ruff_linter__linter__tests__semantic_syntax_error_InvalidStarExpression_invalid_star_expression_for_3.10.snap
@@ -1,0 +1,9 @@
+---
+source: crates/ruff_linter/src/linter.rs
+---
+<filename>:2:5: SyntaxError: can't use starred expression here
+  |
+2 | for *x in range(10):
+  |     ^^
+3 |     pass
+  |

--- a/crates/ruff_linter/src/snapshots/ruff_linter__linter__tests__semantic_syntax_error_InvalidStarExpression_invalid_star_expression_yield_3.10.snap
+++ b/crates/ruff_linter/src/snapshots/ruff_linter__linter__tests__semantic_syntax_error_InvalidStarExpression_invalid_star_expression_yield_3.10.snap
@@ -1,0 +1,9 @@
+---
+source: crates/ruff_linter/src/linter.rs
+---
+<filename>:3:11: SyntaxError: can't use starred expression here
+  |
+2 | def func():
+3 |     yield *x
+  |           ^^
+  |

--- a/crates/ruff_linter/src/snapshots/ruff_linter__linter__tests__semantic_syntax_error_InvalidStarExpression_invalid_star_expression_yield_3.10.snap
+++ b/crates/ruff_linter/src/snapshots/ruff_linter__linter__tests__semantic_syntax_error_InvalidStarExpression_invalid_star_expression_yield_3.10.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/linter.rs
 ---
-<filename>:3:11: SyntaxError: can't use starred expression here
+<filename>:3:11: SyntaxError: Starred expression cannot be used here
   |
 2 | def func():
 3 |     yield *x

--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/semantic_syntax_errors.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/semantic_syntax_errors.md
@@ -100,6 +100,26 @@ match 2:
         ...
 ```
 
+## Duplicate `match` class attribute
+
+Attribute names in class patterns must be unique:
+
+```toml
+[environment]
+python-version = "3.10"
+```
+
+```py
+class Point:
+    pass
+
+obj = Point()
+match obj:
+    # error: [invalid-syntax] "attribute name `x` repeated in class pattern"
+    case Point(x=1, x=2):
+        pass
+```
+
 ## `return`, `yield`, `yield from`, and `await` outside function
 
 ```py
@@ -183,6 +203,28 @@ class C[T, T]:
 
 # error: [invalid-syntax] "duplicate type parameter"
 def f[X, Y, X]():
+    pass
+```
+
+## Invalid star expression
+
+Star expressions can't be used in certain contexts:
+
+```py
+def func():
+    # error: [invalid-syntax] "can't use starred expression here"
+    return *[1, 2, 3]
+
+def gen():
+    # error: [invalid-syntax] "can't use starred expression here"
+    yield * [1, 2, 3]
+
+# error: [invalid-syntax] "can't use starred expression here"
+for *x in range(10):
+    pass
+
+# error: [invalid-syntax] "can't use starred expression here"
+for x in *range(10):
     pass
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/semantic_syntax_errors.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/semantic_syntax_errors.md
@@ -212,18 +212,18 @@ Star expressions can't be used in certain contexts:
 
 ```py
 def func():
-    # error: [invalid-syntax] "can't use starred expression here"
+    # error: [invalid-syntax] "Starred expression cannot be used here"
     return *[1, 2, 3]
 
 def gen():
-    # error: [invalid-syntax] "can't use starred expression here"
+    # error: [invalid-syntax] "Starred expression cannot be used here"
     yield * [1, 2, 3]
 
-# error: [invalid-syntax] "can't use starred expression here"
+# error: [invalid-syntax] "Starred expression cannot be used here"
 for *x in range(10):
     pass
 
-# error: [invalid-syntax] "can't use starred expression here"
+# error: [invalid-syntax] "Starred expression cannot be used here"
 for x in *range(10):
     pass
 ```


### PR DESCRIPTION
Re: #17526 

## Summary
Add integration tests for Python Semantic Syntax for `InvalidStarExpression`, `DuplicateMatchKey`, and `DuplicateMatchClassAttribute`.

## Note
- Red knot integration tests for `DuplicateMatchKey` exist already in line 89-101.
<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan
This is a test.
<!-- How was it tested? -->
