### PR TITLE
[red-knot] Cache source type during semanic index building

### DIFF
--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -119,7 +119,7 @@ impl<'db> SemanticIndexBuilder<'db> {
         let mut builder = Self {
             db,
             file,
-            source_type: file.source_type(db),
+            source_type: file.source_type(db.upcast()),
             module: parsed,
             scope_stack: Vec::new(),
             current_assignments: vec![],


### PR DESCRIPTION
## Summary

I noticed this when debugging a salsa panic because the semantic index building for `types.pyi` created pages of `report_tracked_read(file.path)` calls. 
Cache the source type to avoid a lookup for every single `Definition`

## Test Plan

The pages of `report_tracked_read` are gone :)
