### PR TITLE
[`ruff`] add fix safety section (`RUF013`)

### DIFF
--- a/crates/ruff_linter/src/rules/ruff/rules/implicit_optional.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/implicit_optional.rs
@@ -72,6 +72,11 @@ use super::super::typing::type_hint_explicitly_allows_none;
 /// ## Options
 /// - `target-version`
 ///
+/// ## Fix safety
+///
+/// This fix is always marked as unsafe because it is not possible to establish if the equality
+/// with `None` has specific semantics different from `Optional`.
+///
 /// [PEP 484]: https://peps.python.org/pep-0484/#union-types
 #[derive(ViolationMetadata)]
 pub(crate) struct ImplicitOptional {


### PR DESCRIPTION
The PR add the fix safety section for rule `RUF013` (https://github.com/astral-sh/ruff/issues/15584 )

This is the only reason I could come up. However, I could not find a good example where the fix is unsafe. 