### PR TITLE
[`ruff`] add fix safety section (`RUF033`)

### DIFF
--- a/crates/ruff_linter/src/rules/ruff/rules/post_init_default.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/post_init_default.rs
@@ -61,6 +61,11 @@ use super::helpers::{dataclass_kind, DataclassKind};
 /// foo = Foo()  # Prints '1 2'.
 /// ```
 ///
+/// ## Fix safety
+///
+/// This fix is always marked as unsafe because it assumes that the user always
+/// wants `__post_init__`args to be `InitVar`s.
+///
 /// ## References
 /// - [Python documentation: Post-init processing](https://docs.python.org/3/library/dataclasses.html#post-init-processing)
 /// - [Python documentation: Init-only variables](https://docs.python.org/3/library/dataclasses.html#init-only-variables)


### PR DESCRIPTION
The PR add the fix safety section for rule `RUF033` (https://github.com/astral-sh/ruff/issues/15584 ).

I took as an example the case 

```python
from dataclasses import dataclass, InitVar

@dataclass
class User:
    name: str

    def __post_init__(self, greeting: str = "Hello"):
        print(f"{greeting}, {self.name}!")

@dataclass
class UserAfterFix:
    name: str
    greeting: InitVar[str] = "Hello"

    def __post_init__(self, greeting: str):
        print(f"{greeting}, {self.name}!")

User('Alice')  # print `Hello, Alice`
UserAfterFix('Alice') # raise an error
```