### PR TITLE
[`flake8-use-pathlib`] Don't handle bytes strings in `PTH123`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/full_name.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/full_name.py
@@ -62,14 +62,6 @@ def f() -> int:
     return 1
 open(f())
 
-open(b"foo")
-byte_str = b"bar"
-open(byte_str)
-
-def bytes_str_func() -> bytes:
-    return b"foo"
-open(bytes_str_func())
-
 # https://github.com/astral-sh/ruff/issues/17693
 os.stat(1)
 os.stat(x)

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/replaceable_by_pathlib.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/replaceable_by_pathlib.rs
@@ -135,7 +135,7 @@ pub(crate) fn replaceable_by_pathlib(checker: &Checker, call: &ExprCall) {
                 || call
                     .arguments
                     .find_positional(0)
-                    .is_some_and(|expr| is_file_descriptor_or_bytes_str(expr, checker.semantic()))
+                    .is_some_and(|expr| is_file_descriptor(expr, checker.semantic()))
             {
                 return;
             }
@@ -174,10 +174,6 @@ pub(crate) fn replaceable_by_pathlib(checker: &Checker, call: &ExprCall) {
     }
 }
 
-fn is_file_descriptor_or_bytes_str(expr: &Expr, semantic: &SemanticModel) -> bool {
-    is_file_descriptor(expr, semantic) || is_bytes_string(expr, semantic)
-}
-
 /// Returns `true` if the given expression looks like a file descriptor, i.e., if it is an integer.
 fn is_file_descriptor(expr: &Expr, semantic: &SemanticModel) -> bool {
     if matches!(
@@ -199,23 +195,6 @@ fn is_file_descriptor(expr: &Expr, semantic: &SemanticModel) -> bool {
     };
 
     typing::is_int(binding, semantic)
-}
-
-/// Returns `true` if the given expression is a bytes string.
-fn is_bytes_string(expr: &Expr, semantic: &SemanticModel) -> bool {
-    if matches!(expr, Expr::BytesLiteral(_)) {
-        return true;
-    }
-
-    let Some(name) = get_name_expr(expr) else {
-        return false;
-    };
-
-    let Some(binding) = semantic.only_binding(name).map(|id| semantic.binding(id)) else {
-        return false;
-    };
-
-    typing::is_bytes(binding, semantic)
 }
 
 fn get_name_expr(expr: &Expr) -> Option<&ast::ExprName> {


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

As discussed in #17699 we should not be handling bytes strings here.

This should be merged after #17712.
<!-- What's the purpose of the change? What does it do, and why? -->

