### PR TITLE
Fix module name in ASYNC110, 115, and 116 fixes

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_async/helpers.rs
+++ b/crates/ruff_linter/src/rules/flake8_async/helpers.rs
@@ -24,8 +24,8 @@ impl AsyncModule {
 impl std::fmt::Display for AsyncModule {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            AsyncModule::AnyIo => write!(f, "asyncio"),
-            AsyncModule::AsyncIo => write!(f, "anyio"),
+            AsyncModule::AnyIo => write!(f, "anyio"),
+            AsyncModule::AsyncIo => write!(f, "asyncio"),
             AsyncModule::Trio => write!(f, "trio"),
         }
     }

--- a/crates/ruff_linter/src/rules/flake8_async/snapshots/ruff_linter__rules__flake8_async__tests__ASYNC110_ASYNC110.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_async/snapshots/ruff_linter__rules__flake8_async__tests__ASYNC110_ASYNC110.py.snap
@@ -17,7 +17,7 @@ ASYNC110.py:12:5: ASYNC110 Use `trio.Event` instead of awaiting `trio.sleep` in 
    | |__________________________________^ ASYNC110
    |
 
-ASYNC110.py:22:5: ASYNC110 Use `asyncio.Event` instead of awaiting `asyncio.sleep` in a `while` loop
+ASYNC110.py:22:5: ASYNC110 Use `anyio.Event` instead of awaiting `anyio.sleep` in a `while` loop
    |
 21 |   async def func():
 22 | /     while True:
@@ -25,7 +25,7 @@ ASYNC110.py:22:5: ASYNC110 Use `asyncio.Event` instead of awaiting `asyncio.slee
    | |_____________________________^ ASYNC110
    |
 
-ASYNC110.py:27:5: ASYNC110 Use `asyncio.Event` instead of awaiting `asyncio.sleep` in a `while` loop
+ASYNC110.py:27:5: ASYNC110 Use `anyio.Event` instead of awaiting `anyio.sleep` in a `while` loop
    |
 26 |   async def func():
 27 | /     while True:
@@ -33,7 +33,7 @@ ASYNC110.py:27:5: ASYNC110 Use `asyncio.Event` instead of awaiting `asyncio.slee
    | |___________________________________^ ASYNC110
    |
 
-ASYNC110.py:37:5: ASYNC110 Use `anyio.Event` instead of awaiting `anyio.sleep` in a `while` loop
+ASYNC110.py:37:5: ASYNC110 Use `asyncio.Event` instead of awaiting `asyncio.sleep` in a `while` loop
    |
 36 |   async def func():
 37 | /     while True:

--- a/crates/ruff_linter/src/rules/flake8_async/snapshots/ruff_linter__rules__flake8_async__tests__ASYNC115_ASYNC115.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_async/snapshots/ruff_linter__rules__flake8_async__tests__ASYNC115_ASYNC115.py.snap
@@ -133,7 +133,7 @@ ASYNC115.py:59:11: ASYNC115 [*] Use `trio.lowlevel.checkpoint()` instead of `tri
 61 61 | 
 62 62 | def func():
 
-ASYNC115.py:85:11: ASYNC115 [*] Use `asyncio.lowlevel.checkpoint()` instead of `asyncio.sleep(0)`
+ASYNC115.py:85:11: ASYNC115 [*] Use `anyio.lowlevel.checkpoint()` instead of `anyio.sleep(0)`
    |
 83 |     from anyio import sleep
 84 |
@@ -142,27 +142,19 @@ ASYNC115.py:85:11: ASYNC115 [*] Use `asyncio.lowlevel.checkpoint()` instead of `
 86 |     await anyio.sleep(1)  # OK
 87 |     await anyio.sleep(0, 1)  # OK
    |
-   = help: Replace with `asyncio.lowlevel.checkpoint()`
+   = help: Replace with `anyio.lowlevel.checkpoint()`
 
 ℹ Safe fix
-49 49 | 
-50 50 | 
-51 51 | from trio import Event, sleep
-   52 |+from asyncio import lowlevel
-52 53 | 
-53 54 | 
-54 55 | def func():
---------------------------------------------------------------------------------
-82 83 |     import anyio
-83 84 |     from anyio import sleep
-84 85 | 
+82 82 |     import anyio
+83 83 |     from anyio import sleep
+84 84 | 
 85    |-    await anyio.sleep(0)  # ASYNC115
-   86 |+    await lowlevel.checkpoint()  # ASYNC115
-86 87 |     await anyio.sleep(1)  # OK
-87 88 |     await anyio.sleep(0, 1)  # OK
-88 89 |     await anyio.sleep(...)  # OK
+   85 |+    await anyio.lowlevel.checkpoint()  # ASYNC115
+86 86 |     await anyio.sleep(1)  # OK
+87 87 |     await anyio.sleep(0, 1)  # OK
+88 88 |     await anyio.sleep(...)  # OK
 
-ASYNC115.py:91:5: ASYNC115 [*] Use `asyncio.lowlevel.checkpoint()` instead of `asyncio.sleep(0)`
+ASYNC115.py:91:5: ASYNC115 [*] Use `anyio.lowlevel.checkpoint()` instead of `anyio.sleep(0)`
    |
 89 |     await anyio.sleep()  # OK
 90 |
@@ -171,27 +163,19 @@ ASYNC115.py:91:5: ASYNC115 [*] Use `asyncio.lowlevel.checkpoint()` instead of `a
 92 |     foo = 0
 93 |     anyio.sleep(foo)  # OK
    |
-   = help: Replace with `asyncio.lowlevel.checkpoint()`
+   = help: Replace with `anyio.lowlevel.checkpoint()`
 
 ℹ Safe fix
-49 49 | 
-50 50 | 
-51 51 | from trio import Event, sleep
-   52 |+from asyncio import lowlevel
-52 53 | 
-53 54 | 
-54 55 | def func():
---------------------------------------------------------------------------------
-88 89 |     await anyio.sleep(...)  # OK
-89 90 |     await anyio.sleep()  # OK
-90 91 | 
+88 88 |     await anyio.sleep(...)  # OK
+89 89 |     await anyio.sleep()  # OK
+90 90 | 
 91    |-    anyio.sleep(0)  # ASYNC115
-   92 |+    lowlevel.checkpoint()  # ASYNC115
-92 93 |     foo = 0
-93 94 |     anyio.sleep(foo)  # OK
-94 95 |     anyio.sleep(1)  # OK
+   91 |+    anyio.lowlevel.checkpoint()  # ASYNC115
+92 92 |     foo = 0
+93 93 |     anyio.sleep(foo)  # OK
+94 94 |     anyio.sleep(1)  # OK
 
-ASYNC115.py:97:5: ASYNC115 [*] Use `asyncio.lowlevel.checkpoint()` instead of `asyncio.sleep(0)`
+ASYNC115.py:97:5: ASYNC115 [*] Use `anyio.lowlevel.checkpoint()` instead of `anyio.sleep(0)`
    |
 95 |     time.sleep(0)  # OK
 96 |
@@ -200,49 +184,33 @@ ASYNC115.py:97:5: ASYNC115 [*] Use `asyncio.lowlevel.checkpoint()` instead of `a
 98 |
 99 |     bar = "bar"
    |
-   = help: Replace with `asyncio.lowlevel.checkpoint()`
+   = help: Replace with `anyio.lowlevel.checkpoint()`
 
 ℹ Safe fix
-49 49 | 
-50 50 | 
-51 51 | from trio import Event, sleep
-   52 |+from asyncio import lowlevel
-52 53 | 
-53 54 | 
-54 55 | def func():
---------------------------------------------------------------------------------
-94 95 |     anyio.sleep(1)  # OK
-95 96 |     time.sleep(0)  # OK
-96 97 | 
+94 94 |     anyio.sleep(1)  # OK
+95 95 |     time.sleep(0)  # OK
+96 96 | 
 97    |-    sleep(0)  # ASYNC115
-   98 |+    lowlevel.checkpoint()  # ASYNC115
-98 99 | 
-99 100 |     bar = "bar"
-100 101 |     anyio.sleep(bar)
+   97 |+    anyio.lowlevel.checkpoint()  # ASYNC115
+98 98 | 
+99 99 |     bar = "bar"
+100 100 |     anyio.sleep(bar)
 
-ASYNC115.py:128:15: ASYNC115 [*] Use `asyncio.lowlevel.checkpoint()` instead of `asyncio.sleep(0)`
+ASYNC115.py:128:15: ASYNC115 [*] Use `anyio.lowlevel.checkpoint()` instead of `anyio.sleep(0)`
     |
 126 |     import anyio
 127 |
 128 |     anyio.run(anyio.sleep(0))  # ASYNC115
     |               ^^^^^^^^^^^^^^ ASYNC115
     |
-    = help: Replace with `asyncio.lowlevel.checkpoint()`
+    = help: Replace with `anyio.lowlevel.checkpoint()`
 
 ℹ Safe fix
-49  49  | 
-50  50  | 
-51  51  | from trio import Event, sleep
-    52  |+from asyncio import lowlevel
-52  53  | 
-53  54  | 
-54  55  | def func():
---------------------------------------------------------------------------------
-125 126 | def func():
-126 127 |     import anyio
-127 128 | 
+125 125 | def func():
+126 126 |     import anyio
+127 127 | 
 128     |-    anyio.run(anyio.sleep(0))  # ASYNC115
-    129 |+    anyio.run(lowlevel.checkpoint())  # ASYNC115
-129 130 | 
-130 131 | 
-131 132 | def func():
+    128 |+    anyio.run(anyio.lowlevel.checkpoint())  # ASYNC115
+129 129 | 
+130 130 | 
+131 131 | def func():

--- a/crates/ruff_linter/src/rules/flake8_async/snapshots/ruff_linter__rules__flake8_async__tests__ASYNC116_ASYNC116.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_async/snapshots/ruff_linter__rules__flake8_async__tests__ASYNC116_ASYNC116.py.snap
@@ -147,7 +147,7 @@ ASYNC116.py:57:11: ASYNC116 [*] `trio.sleep()` with >24 hour interval should usu
 59 60 | 
 60 61 | async def import_anyio():
 
-ASYNC116.py:64:11: ASYNC116 [*] `asyncio.sleep()` with >24 hour interval should usually be `asyncio.sleep_forever()`
+ASYNC116.py:64:11: ASYNC116 [*] `anyio.sleep()` with >24 hour interval should usually be `anyio.sleep_forever()`
    |
 63 |     # These examples are probably not meant to ever wake up:
 64 |     await anyio.sleep(100000)  # error: 116, "async"
@@ -155,27 +155,19 @@ ASYNC116.py:64:11: ASYNC116 [*] `asyncio.sleep()` with >24 hour interval should 
 65 |
 66 |     # 'inf literal' overflow trick
    |
-   = help: Replace with `asyncio.sleep_forever()`
+   = help: Replace with `anyio.sleep_forever()`
 
 ℹ Unsafe fix
-2  2  | # ASYNCIO_NO_ERROR - no asyncio.sleep_forever, so check intentionally doesn't trigger.
-3  3  | import math
-4  4  | from math import inf
-   5  |+from asyncio import sleep_forever
-5  6  | 
-6  7  | 
-7  8  | async def import_trio():
---------------------------------------------------------------------------------
-61 62 |     import anyio
-62 63 | 
-63 64 |     # These examples are probably not meant to ever wake up:
+61 61 |     import anyio
+62 62 | 
+63 63 |     # These examples are probably not meant to ever wake up:
 64    |-    await anyio.sleep(100000)  # error: 116, "async"
-   65 |+    await sleep_forever()  # error: 116, "async"
-65 66 | 
-66 67 |     # 'inf literal' overflow trick
-67 68 |     await anyio.sleep(1e999)  # error: 116, "async"
+   64 |+    await anyio.sleep_forever()  # error: 116, "async"
+65 65 | 
+66 66 |     # 'inf literal' overflow trick
+67 67 |     await anyio.sleep(1e999)  # error: 116, "async"
 
-ASYNC116.py:67:11: ASYNC116 [*] `asyncio.sleep()` with >24 hour interval should usually be `asyncio.sleep_forever()`
+ASYNC116.py:67:11: ASYNC116 [*] `anyio.sleep()` with >24 hour interval should usually be `anyio.sleep_forever()`
    |
 66 |     # 'inf literal' overflow trick
 67 |     await anyio.sleep(1e999)  # error: 116, "async"
@@ -183,27 +175,19 @@ ASYNC116.py:67:11: ASYNC116 [*] `asyncio.sleep()` with >24 hour interval should 
 68 |
 69 |     await anyio.sleep(86399)
    |
-   = help: Replace with `asyncio.sleep_forever()`
+   = help: Replace with `anyio.sleep_forever()`
 
 ℹ Unsafe fix
-2  2  | # ASYNCIO_NO_ERROR - no asyncio.sleep_forever, so check intentionally doesn't trigger.
-3  3  | import math
-4  4  | from math import inf
-   5  |+from asyncio import sleep_forever
-5  6  | 
-6  7  | 
-7  8  | async def import_trio():
---------------------------------------------------------------------------------
-64 65 |     await anyio.sleep(100000)  # error: 116, "async"
-65 66 | 
-66 67 |     # 'inf literal' overflow trick
+64 64 |     await anyio.sleep(100000)  # error: 116, "async"
+65 65 | 
+66 66 |     # 'inf literal' overflow trick
 67    |-    await anyio.sleep(1e999)  # error: 116, "async"
-   68 |+    await sleep_forever()  # error: 116, "async"
-68 69 | 
-69 70 |     await anyio.sleep(86399)
-70 71 |     await anyio.sleep(86400)
+   67 |+    await anyio.sleep_forever()  # error: 116, "async"
+68 68 | 
+69 69 |     await anyio.sleep(86399)
+70 70 |     await anyio.sleep(86400)
 
-ASYNC116.py:71:11: ASYNC116 [*] `asyncio.sleep()` with >24 hour interval should usually be `asyncio.sleep_forever()`
+ASYNC116.py:71:11: ASYNC116 [*] `anyio.sleep()` with >24 hour interval should usually be `anyio.sleep_forever()`
    |
 69 |     await anyio.sleep(86399)
 70 |     await anyio.sleep(86400)
@@ -211,27 +195,19 @@ ASYNC116.py:71:11: ASYNC116 [*] `asyncio.sleep()` with >24 hour interval should 
    |           ^^^^^^^^^^^^^^^^^^^^^ ASYNC116
 72 |     await anyio.sleep(86401)  # error: 116, "async"
    |
-   = help: Replace with `asyncio.sleep_forever()`
+   = help: Replace with `anyio.sleep_forever()`
 
 ℹ Unsafe fix
-2  2  | # ASYNCIO_NO_ERROR - no asyncio.sleep_forever, so check intentionally doesn't trigger.
-3  3  | import math
-4  4  | from math import inf
-   5  |+from asyncio import sleep_forever
-5  6  | 
-6  7  | 
-7  8  | async def import_trio():
---------------------------------------------------------------------------------
-68 69 | 
-69 70 |     await anyio.sleep(86399)
-70 71 |     await anyio.sleep(86400)
+68 68 | 
+69 69 |     await anyio.sleep(86399)
+70 70 |     await anyio.sleep(86400)
 71    |-    await anyio.sleep(86400.01)  # error: 116, "async"
-   72 |+    await sleep_forever()  # error: 116, "async"
-72 73 |     await anyio.sleep(86401)  # error: 116, "async"
-73 74 | 
-74 75 |     await anyio.sleep(-1)  # will raise a runtime error
+   71 |+    await anyio.sleep_forever()  # error: 116, "async"
+72 72 |     await anyio.sleep(86401)  # error: 116, "async"
+73 73 | 
+74 74 |     await anyio.sleep(-1)  # will raise a runtime error
 
-ASYNC116.py:72:11: ASYNC116 [*] `asyncio.sleep()` with >24 hour interval should usually be `asyncio.sleep_forever()`
+ASYNC116.py:72:11: ASYNC116 [*] `anyio.sleep()` with >24 hour interval should usually be `anyio.sleep_forever()`
    |
 70 |     await anyio.sleep(86400)
 71 |     await anyio.sleep(86400.01)  # error: 116, "async"
@@ -240,27 +216,19 @@ ASYNC116.py:72:11: ASYNC116 [*] `asyncio.sleep()` with >24 hour interval should 
 73 |
 74 |     await anyio.sleep(-1)  # will raise a runtime error
    |
-   = help: Replace with `asyncio.sleep_forever()`
+   = help: Replace with `anyio.sleep_forever()`
 
 ℹ Unsafe fix
-2  2  | # ASYNCIO_NO_ERROR - no asyncio.sleep_forever, so check intentionally doesn't trigger.
-3  3  | import math
-4  4  | from math import inf
-   5  |+from asyncio import sleep_forever
-5  6  | 
-6  7  | 
-7  8  | async def import_trio():
---------------------------------------------------------------------------------
-69 70 |     await anyio.sleep(86399)
-70 71 |     await anyio.sleep(86400)
-71 72 |     await anyio.sleep(86400.01)  # error: 116, "async"
+69 69 |     await anyio.sleep(86399)
+70 70 |     await anyio.sleep(86400)
+71 71 |     await anyio.sleep(86400.01)  # error: 116, "async"
 72    |-    await anyio.sleep(86401)  # error: 116, "async"
-   73 |+    await sleep_forever()  # error: 116, "async"
-73 74 | 
-74 75 |     await anyio.sleep(-1)  # will raise a runtime error
-75 76 |     await anyio.sleep(0)  # handled by different check
+   72 |+    await anyio.sleep_forever()  # error: 116, "async"
+73 73 | 
+74 74 |     await anyio.sleep(-1)  # will raise a runtime error
+75 75 |     await anyio.sleep(0)  # handled by different check
 
-ASYNC116.py:101:5: ASYNC116 [*] `asyncio.sleep()` with >24 hour interval should usually be `asyncio.sleep_forever()`
+ASYNC116.py:101:5: ASYNC116 [*] `anyio.sleep()` with >24 hour interval should usually be `anyio.sleep_forever()`
     |
 100 |     # does not require the call to be awaited, nor in an async fun
 101 |     anyio.sleep(86401)  # error: 116, "async"
@@ -268,66 +236,50 @@ ASYNC116.py:101:5: ASYNC116 [*] `asyncio.sleep()` with >24 hour interval should 
 102 |     # also checks that we don't break visit_Call
 103 |     anyio.run(anyio.sleep(86401))  # error: 116, "async"
     |
-    = help: Replace with `asyncio.sleep_forever()`
+    = help: Replace with `anyio.sleep_forever()`
 
 ℹ Unsafe fix
-2   2   | # ASYNCIO_NO_ERROR - no asyncio.sleep_forever, so check intentionally doesn't trigger.
-3   3   | import math
-4   4   | from math import inf
-    5   |+from asyncio import sleep_forever
-5   6   | 
-6   7   | 
-7   8   | async def import_trio():
---------------------------------------------------------------------------------
-98  99  |     import anyio
-99  100 | 
-100 101 |     # does not require the call to be awaited, nor in an async fun
+98  98  |     import anyio
+99  99  | 
+100 100 |     # does not require the call to be awaited, nor in an async fun
 101     |-    anyio.sleep(86401)  # error: 116, "async"
-    102 |+    sleep_forever()  # error: 116, "async"
-102 103 |     # also checks that we don't break visit_Call
-103 104 |     anyio.run(anyio.sleep(86401))  # error: 116, "async"
-104 105 | 
+    101 |+    anyio.sleep_forever()  # error: 116, "async"
+102 102 |     # also checks that we don't break visit_Call
+103 103 |     anyio.run(anyio.sleep(86401))  # error: 116, "async"
+104 104 | 
 
-ASYNC116.py:103:15: ASYNC116 [*] `asyncio.sleep()` with >24 hour interval should usually be `asyncio.sleep_forever()`
+ASYNC116.py:103:15: ASYNC116 [*] `anyio.sleep()` with >24 hour interval should usually be `anyio.sleep_forever()`
     |
 101 |     anyio.sleep(86401)  # error: 116, "async"
 102 |     # also checks that we don't break visit_Call
 103 |     anyio.run(anyio.sleep(86401))  # error: 116, "async"
     |               ^^^^^^^^^^^^^^^^^^ ASYNC116
     |
-    = help: Replace with `asyncio.sleep_forever()`
+    = help: Replace with `anyio.sleep_forever()`
 
 ℹ Unsafe fix
-2   2   | # ASYNCIO_NO_ERROR - no asyncio.sleep_forever, so check intentionally doesn't trigger.
-3   3   | import math
-4   4   | from math import inf
-    5   |+from asyncio import sleep_forever
-5   6   | 
-6   7   | 
-7   8   | async def import_trio():
---------------------------------------------------------------------------------
-100 101 |     # does not require the call to be awaited, nor in an async fun
-101 102 |     anyio.sleep(86401)  # error: 116, "async"
-102 103 |     # also checks that we don't break visit_Call
+100 100 |     # does not require the call to be awaited, nor in an async fun
+101 101 |     anyio.sleep(86401)  # error: 116, "async"
+102 102 |     # also checks that we don't break visit_Call
 103     |-    anyio.run(anyio.sleep(86401))  # error: 116, "async"
-    104 |+    anyio.run(sleep_forever())  # error: 116, "async"
-104 105 | 
-105 106 | 
-106 107 | async def import_from_anyio():
+    103 |+    anyio.run(anyio.sleep_forever())  # error: 116, "async"
+104 104 | 
+105 105 | 
+106 106 | async def import_from_anyio():
 
-ASYNC116.py:110:11: ASYNC116 [*] `asyncio.sleep()` with >24 hour interval should usually be `asyncio.sleep_forever()`
+ASYNC116.py:110:11: ASYNC116 [*] `anyio.sleep()` with >24 hour interval should usually be `anyio.sleep_forever()`
     |
 109 |     # catch from import
 110 |     await sleep(86401)  # error: 116, "async"
     |           ^^^^^^^^^^^^ ASYNC116
     |
-    = help: Replace with `asyncio.sleep_forever()`
+    = help: Replace with `anyio.sleep_forever()`
 
 ℹ Unsafe fix
 2   2   | # ASYNCIO_NO_ERROR - no asyncio.sleep_forever, so check intentionally doesn't trigger.
 3   3   | import math
 4   4   | from math import inf
-    5   |+from asyncio import sleep_forever
+    5   |+from anyio import sleep_forever
 5   6   | 
 6   7   | 
 7   8   | async def import_trio():


### PR DESCRIPTION
## Summary

The `Display` implementation incorrectly mapped `anyio` to `asyncio` and `asyncio` to `anyio`.... 

Fixes https://github.com/astral-sh/ruff/issues/17728

## Test Plan

Update snapshots. I verified that said `anyio` methods exists
