### PR TITLE
[semantic-syntax-tests] Add test fixtures for AwaitOutsideAsync

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/syntax_errors/async_comprehension.py
+++ b/crates/ruff_linter/resources/test/fixtures/syntax_errors/async_comprehension.py
@@ -1,0 +1,11 @@
+async def elements(n):
+    yield n
+
+def regular_function():
+    [x async for x in elements(1)]
+
+    async with elements(1) as x:
+        pass
+
+    async for _ in elements(1):
+        pass

--- a/crates/ruff_linter/resources/test/fixtures/syntax_errors/await_outside_async_function.py
+++ b/crates/ruff_linter/resources/test/fixtures/syntax_errors/await_outside_async_function.py
@@ -1,0 +1,5 @@
+def func():
+    await 1
+
+# Top-level await
+await 1

--- a/crates/ruff_linter/src/linter.rs
+++ b/crates/ruff_linter/src/linter.rs
@@ -1111,6 +1111,8 @@ mod tests {
         Rule::LoadBeforeGlobalDeclaration,
         Path::new("load_before_global_declaration.py")
     )]
+    #[test_case(Rule::AwaitOutsideAsync, Path::new("await_outside_async_function.py"))]
+    #[test_case(Rule::AwaitOutsideAsync, Path::new("async_comprehension.py"))]
     fn test_syntax_errors(rule: Rule, path: &Path) -> Result<()> {
         let snapshot = path.to_string_lossy().to_string();
         let path = Path::new("resources/test/fixtures/syntax_errors").join(path);

--- a/crates/ruff_linter/src/snapshots/ruff_linter__linter__tests__async_comprehension.py.snap
+++ b/crates/ruff_linter/src/snapshots/ruff_linter__linter__tests__async_comprehension.py.snap
@@ -1,0 +1,31 @@
+---
+source: crates/ruff_linter/src/linter.rs
+---
+resources/test/fixtures/syntax_errors/async_comprehension.py:5:8: PLE1142 `await` should be used within an async function
+  |
+4 | def regular_function():
+5 |     [x async for x in elements(1)]
+  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^ PLE1142
+6 |
+7 |     async with elements(1) as x:
+  |
+
+resources/test/fixtures/syntax_errors/async_comprehension.py:7:5: PLE1142 `await` should be used within an async function
+   |
+ 5 |       [x async for x in elements(1)]
+ 6 |
+ 7 | /     async with elements(1) as x:
+ 8 | |         pass
+   | |____________^ PLE1142
+ 9 |
+10 |       async for _ in elements(1):
+   |
+
+resources/test/fixtures/syntax_errors/async_comprehension.py:10:5: PLE1142 `await` should be used within an async function
+   |
+ 8 |           pass
+ 9 |
+10 | /     async for _ in elements(1):
+11 | |         pass
+   | |____________^ PLE1142
+   |

--- a/crates/ruff_linter/src/snapshots/ruff_linter__linter__tests__await_outside_async_function.py.snap
+++ b/crates/ruff_linter/src/snapshots/ruff_linter__linter__tests__await_outside_async_function.py.snap
@@ -1,0 +1,18 @@
+---
+source: crates/ruff_linter/src/linter.rs
+---
+resources/test/fixtures/syntax_errors/await_outside_async_function.py:2:5: PLE1142 `await` should be used within an async function
+  |
+1 | def func():
+2 |     await 1
+  |     ^^^^^^^ PLE1142
+3 |
+4 | # Top-level await
+  |
+
+resources/test/fixtures/syntax_errors/await_outside_async_function.py:5:1: PLE1142 `await` should be used within an async function
+  |
+4 | # Top-level await
+5 | await 1
+  | ^^^^^^^ PLE1142
+  |


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->
Re: #17526 
## Summary
Add test fixtures for `AwaitOutsideAsync` and `AsyncComprehensionOutsideAsyncFunction` errors. 

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan
This is a test. 

<!-- How was it tested? -->
