### PR TITLE
[red-knot] Distinguish fully static protocols from non-fully-static protocols

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/protocols.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/protocols.md
@@ -1087,7 +1087,8 @@ from knot_extensions import is_equivalent_to
 class HasMutableXAttr(Protocol):
     x: int
 
-static_assert(is_equivalent_to(HasMutableXAttr, HasMutableXProperty))
+# TODO: should pass
+static_assert(is_equivalent_to(HasMutableXAttr, HasMutableXProperty))  # error: [static-assert-error]
 
 static_assert(is_subtype_of(HasMutableXAttr, HasXProperty))
 static_assert(is_assignable_to(HasMutableXAttr, HasXProperty))
@@ -1350,25 +1351,32 @@ class NotFullyStatic(Protocol):
     x: Any
 
 static_assert(is_fully_static(FullyStatic))
-
-# TODO: should pass
-static_assert(not is_fully_static(NotFullyStatic))  # error: [static-assert-error]
+static_assert(not is_fully_static(NotFullyStatic))
 ```
 
-Non-fully-static protocols do not participate in subtyping, only assignability:
+Non-fully-static protocols do not participate in subtyping or equivalence, only assignability and
+gradual equivalence:
 
 ```py
-from knot_extensions import is_subtype_of, is_assignable_to
+from knot_extensions import is_subtype_of, is_assignable_to, is_equivalent_to, is_gradual_equivalent_to
 
 class NominalWithX:
     x: int = 42
 
 static_assert(is_assignable_to(NominalWithX, FullyStatic))
 static_assert(is_assignable_to(NominalWithX, NotFullyStatic))
+
+static_assert(not is_subtype_of(FullyStatic, NotFullyStatic))
+static_assert(not is_subtype_of(NotFullyStatic, FullyStatic))
+static_assert(not is_subtype_of(NominalWithX, NotFullyStatic))
+
 static_assert(is_subtype_of(NominalWithX, FullyStatic))
 
-# TODO: this should pass
-static_assert(not is_subtype_of(NominalWithX, NotFullyStatic))  # error: [static-assert-error]
+static_assert(is_equivalent_to(FullyStatic, FullyStatic))
+static_assert(not is_equivalent_to(NotFullyStatic, NotFullyStatic))
+
+static_assert(is_gradual_equivalent_to(FullyStatic, FullyStatic))
+static_assert(is_gradual_equivalent_to(NotFullyStatic, NotFullyStatic))
 ```
 
 Empty protocols are fully static; this follows from the fact that an empty protocol is equivalent to

--- a/crates/red_knot_python_semantic/resources/mdtest/protocols.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/protocols.md
@@ -1367,8 +1367,13 @@ static_assert(is_assignable_to(NominalWithX, FullyStatic))
 static_assert(is_assignable_to(NominalWithX, NotFullyStatic))
 
 static_assert(not is_subtype_of(FullyStatic, NotFullyStatic))
+static_assert(is_assignable_to(FullyStatic, NotFullyStatic))
+
 static_assert(not is_subtype_of(NotFullyStatic, FullyStatic))
+static_assert(is_assignable_to(NotFullyStatic, FullyStatic))
+
 static_assert(not is_subtype_of(NominalWithX, NotFullyStatic))
+static_assert(is_assignable_to(NominalWithX, NotFullyStatic))
 
 static_assert(is_subtype_of(NominalWithX, FullyStatic))
 
@@ -1377,6 +1382,12 @@ static_assert(not is_equivalent_to(NotFullyStatic, NotFullyStatic))
 
 static_assert(is_gradual_equivalent_to(FullyStatic, FullyStatic))
 static_assert(is_gradual_equivalent_to(NotFullyStatic, NotFullyStatic))
+
+class AlsoNotFullyStatic(Protocol):
+    x: Any
+
+static_assert(not is_equivalent_to(NotFullyStatic, AlsoNotFullyStatic))
+static_assert(is_gradual_equivalent_to(NotFullyStatic, AlsoNotFullyStatic))
 ```
 
 Empty protocols are fully static; this follows from the fact that an empty protocol is equivalent to

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -68,6 +68,7 @@ mod instance;
 mod known_instance;
 mod mro;
 mod narrow;
+mod protocol_class;
 mod signatures;
 mod slots;
 mod string_annotation;

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -674,7 +674,7 @@ impl<'db> Type<'db> {
                         .any(|ty| ty.contains_todo(db))
             }
 
-            Self::ProtocolInstance(protocol) => protocol.contains_todo(),
+            Self::ProtocolInstance(protocol) => protocol.contains_todo(db),
         }
     }
 
@@ -2061,7 +2061,7 @@ impl<'db> Type<'db> {
             | Type::AlwaysTruthy
             | Type::PropertyInstance(_) => true,
 
-            Type::ProtocolInstance(protocol) => protocol.is_fully_static(),
+            Type::ProtocolInstance(protocol) => protocol.is_fully_static(db),
 
             Type::TypeVar(typevar) => match typevar.bound_or_constraints(db) {
                 None => true,
@@ -2515,16 +2515,7 @@ impl<'db> Type<'db> {
 
             Type::NominalInstance(instance) => instance.class().instance_member(db, name),
 
-            Type::ProtocolInstance(protocol) => match protocol.inner() {
-                Protocol::FromClass(class) => class.instance_member(db, name),
-                Protocol::Synthesized(synthesized) => {
-                    if synthesized.members(db).contains(name) {
-                        SymbolAndQualifiers::todo("Capture type of synthesized protocol members")
-                    } else {
-                        Symbol::Unbound.into()
-                    }
-                }
-            },
+            Type::ProtocolInstance(protocol) => protocol.instance_member(db, name),
 
             Type::FunctionLiteral(_) => KnownClass::FunctionType
                 .to_instance(db)
@@ -5415,7 +5406,7 @@ impl std::fmt::Display for DynamicType {
 
 bitflags! {
     /// Type qualifiers that appear in an annotation expression.
-    #[derive(Copy, Clone, Debug, Eq, PartialEq, Default)]
+    #[derive(Copy, Clone, Debug, Eq, PartialEq, Default, salsa::Update, Hash)]
     pub(crate) struct TypeQualifiers: u8 {
         /// `typing.ClassVar`
         const CLASS_VAR = 1 << 0;

--- a/crates/red_knot_python_semantic/src/types/call/bind.rs
+++ b/crates/red_knot_python_semantic/src/types/call/bind.rs
@@ -621,9 +621,9 @@ impl<'db> Bindings<'db> {
                                     overload.set_return_type(Type::Tuple(TupleType::new(
                                         db,
                                         protocol_class
-                                            .protocol_members(db)
-                                            .iter()
-                                            .map(|member| Type::string_literal(db, member))
+                                            .interface(db)
+                                            .members()
+                                            .map(|member| Type::string_literal(db, member.name()))
                                             .collect::<Box<[Type<'db>]>>(),
                                     )));
                                 }

--- a/crates/red_knot_python_semantic/src/types/class.rs
+++ b/crates/red_knot_python_semantic/src/types/class.rs
@@ -1,5 +1,4 @@
 use std::hash::BuildHasherDefault;
-use std::ops::Deref;
 use std::sync::{LazyLock, Mutex};
 
 use super::{
@@ -668,7 +667,7 @@ impl<'db> ClassLiteral<'db> {
             .collect()
     }
 
-    fn known_function_decorators(
+    pub(super) fn known_function_decorators(
         self,
         db: &'db dyn Db,
     ) -> impl Iterator<Item = KnownFunction> + 'db {
@@ -1749,11 +1748,6 @@ impl<'db> ClassLiteral<'db> {
         }
     }
 
-    /// Returns `Some` if this is a protocol class, `None` otherwise.
-    pub(super) fn into_protocol_class(self, db: &'db dyn Db) -> Option<ProtocolClassLiteral<'db>> {
-        self.is_protocol(db).then_some(ProtocolClassLiteral(self))
-    }
-
     /// Returns the [`Span`] of the class's "header": the class name
     /// and any arguments passed to the `class` statement. E.g.
     ///
@@ -1782,208 +1776,6 @@ impl<'db> From<ClassLiteral<'db>> for Type<'db> {
         Type::ClassLiteral(class)
     }
 }
-
-/// Representation of a single `Protocol` class definition.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub(super) struct ProtocolClassLiteral<'db>(ClassLiteral<'db>);
-
-impl<'db> ProtocolClassLiteral<'db> {
-    /// Returns the protocol members of this class.
-    ///
-    /// A protocol's members define the interface declared by the protocol.
-    /// They therefore determine how the protocol should behave with regards to
-    /// assignability and subtyping.
-    ///
-    /// The list of members consists of all bindings and declarations that take place
-    /// in the protocol's class body, except for a list of excluded attributes which should
-    /// not be taken into account. (This list includes `__init__` and `__new__`, which can
-    /// legally be defined on protocol classes but do not constitute protocol members.)
-    ///
-    /// It is illegal for a protocol class to have any instance attributes that are not declared
-    /// in the protocol's class body. If any are assigned to, they are not taken into account in
-    /// the protocol's list of members.
-    pub(super) fn interface(self, db: &'db dyn Db) -> &'db ProtocolInterface<'db> {
-        /// Returns `true` if the given member should be excluded from the protocol interface.
-        ///
-        /// The list of excluded members is subject to change between Python versions,
-        /// especially for dunders, but it probably doesn't matter *too* much if this
-        /// list goes out of date. It's up to date as of Python commit 87b1ea016b1454b1e83b9113fa9435849b7743aa
-        /// (<https://github.com/python/cpython/blob/87b1ea016b1454b1e83b9113fa9435849b7743aa/Lib/typing.py#L1776-L1791>)
-        fn excluded_from_proto_members(member: &str) -> bool {
-            matches!(
-                member,
-                "_is_protocol"
-                    | "__non_callable_proto_members__"
-                    | "__static_attributes__"
-                    | "__orig_class__"
-                    | "__match_args__"
-                    | "__weakref__"
-                    | "__doc__"
-                    | "__parameters__"
-                    | "__module__"
-                    | "_MutableMapping__marker"
-                    | "__slots__"
-                    | "__dict__"
-                    | "__new__"
-                    | "__protocol_attrs__"
-                    | "__init__"
-                    | "__class_getitem__"
-                    | "__firstlineno__"
-                    | "__abstractmethods__"
-                    | "__orig_bases__"
-                    | "_is_runtime_protocol"
-                    | "__subclasshook__"
-                    | "__type_params__"
-                    | "__annotations__"
-                    | "__annotate__"
-                    | "__annotate_func__"
-                    | "__annotations_cache__"
-            )
-        }
-
-        #[salsa::tracked(return_ref, cycle_fn=proto_members_cycle_recover, cycle_initial=proto_members_cycle_initial)]
-        fn cached_protocol_interface<'db>(
-            db: &'db dyn Db,
-            class: ClassLiteral<'db>,
-        ) -> ProtocolInterface<'db> {
-            let mut members = vec![];
-
-            for parent_protocol in class
-                .iter_mro(db, None)
-                .filter_map(ClassBase::into_class)
-                .filter_map(|class| class.class_literal(db).0.into_protocol_class(db))
-            {
-                let parent_scope = parent_protocol.body_scope(db);
-                let use_def_map = use_def_map(db, parent_scope);
-                let symbol_table = symbol_table(db, parent_scope);
-
-                members.extend(
-                    use_def_map
-                        .all_public_declarations()
-                        .flat_map(|(symbol_id, declarations)| {
-                            symbol_from_declarations(db, declarations)
-                                .map(|symbol| (symbol_id, symbol))
-                        })
-                        .filter_map(|(symbol_id, symbol)| {
-                            symbol
-                                .symbol
-                                .ignore_possibly_unbound()
-                                .map(|ty| (symbol_id, ty, symbol.qualifiers))
-                        })
-                        // Bindings in the class body that are not declared in the class body
-                        // are not valid protocol members, and we plan to emit diagnostics for them
-                        // elsewhere. Invalid or not, however, it's important that we still consider
-                        // them to be protocol members. The implementation of `issubclass()` and
-                        // `isinstance()` for runtime-checkable protocols considers them to be protocol
-                        // members at runtime, and it's important that we accurately understand
-                        // type narrowing that uses `isinstance()` or `issubclass()` with
-                        // runtime-checkable protocols.
-                        .chain(use_def_map.all_public_bindings().filter_map(
-                            |(symbol_id, bindings)| {
-                                symbol_from_bindings(db, bindings)
-                                    .ignore_possibly_unbound()
-                                    .map(|ty| (symbol_id, ty, TypeQualifiers::default()))
-                            },
-                        ))
-                        .map(|(symbol_id, member, qualifiers)| {
-                            (symbol_table.symbol(symbol_id).name(), member, qualifiers)
-                        })
-                        .filter(|(name, _, _)| !excluded_from_proto_members(name))
-                        .map(|(name, ty, qualifiers)| ProtocolMember {
-                            name: name.clone(),
-                            ty,
-                            qualifiers,
-                        }),
-                );
-            }
-
-            members.sort_unstable_by(|m1, m2| m1.name().cmp(m2.name()));
-            members.dedup_by(|m1, m2| m1.name() == m2.name());
-            ProtocolInterface(members.into_boxed_slice())
-        }
-
-        fn proto_members_cycle_recover<'db>(
-            _db: &dyn Db,
-            _value: &ProtocolInterface<'db>,
-            _count: u32,
-            _class: ClassLiteral<'db>,
-        ) -> salsa::CycleRecoveryAction<ProtocolInterface<'db>> {
-            salsa::CycleRecoveryAction::Iterate
-        }
-
-        fn proto_members_cycle_initial<'db>(
-            _db: &dyn Db,
-            _class: ClassLiteral<'db>,
-        ) -> ProtocolInterface<'db> {
-            ProtocolInterface::default()
-        }
-
-        let _span = tracing::trace_span!("protocol_members", "class='{}'", self.name(db)).entered();
-        cached_protocol_interface(db, *self)
-    }
-
-    pub(super) fn is_runtime_checkable(self, db: &'db dyn Db) -> bool {
-        self.known_function_decorators(db)
-            .contains(&KnownFunction::RuntimeCheckable)
-    }
-}
-
-impl<'db> Deref for ProtocolClassLiteral<'db> {
-    type Target = ClassLiteral<'db>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-#[derive(Debug, PartialEq, Eq, salsa::Update, Default, Clone, Hash)]
-pub(super) struct ProtocolInterface<'db>(Box<[ProtocolMember<'db>]>);
-
-impl<'db> ProtocolInterface<'db> {
-    pub(super) fn members(&self) -> impl ExactSizeIterator<Item = &ProtocolMember<'db>> {
-        self.0.iter()
-    }
-
-    pub(super) fn is_fully_static(&self, db: &'db dyn Db) -> bool {
-        self.members().all(|member| member.ty.is_fully_static(db))
-    }
-
-    /// TODO: consider the types of the members as well as their names.
-    /// TODO: using a map as the underlying data structure would be more efficient here than a boxed slice.
-    pub(super) fn is_sub_interface_of(&self, other: &Self) -> bool {
-        self.members().all(|member| {
-            other
-                .members()
-                .any(|other_member| member.name() == other_member.name())
-        })
-    }
-
-    pub(super) fn contains_todo(&self, db: &'db dyn Db) -> bool {
-        self.members().any(|member| member.ty.contains_todo(db))
-    }
-}
-
-#[derive(Debug, PartialEq, Eq, salsa::Update, Clone, Hash)]
-pub(super) struct ProtocolMember<'db> {
-    name: Name,
-    ty: Type<'db>,
-    qualifiers: TypeQualifiers,
-}
-
-impl<'db> ProtocolMember<'db> {
-    pub(super) fn name(&self) -> &str {
-        &self.name
-    }
-
-    pub(super) fn ty(&self) -> Type<'db> {
-        self.ty
-    }
-
-    pub(super) fn qualifiers(&self) -> TypeQualifiers {
-        self.qualifiers
-    }
-}
-
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub(super) enum InheritanceCycle {

--- a/crates/red_knot_python_semantic/src/types/diagnostic.rs
+++ b/crates/red_knot_python_semantic/src/types/diagnostic.rs
@@ -1,5 +1,6 @@
 use super::context::InferContext;
 use super::ClassLiteral;
+use crate::db::Db;
 use crate::declare_lint;
 use crate::lint::{Level, LintRegistryBuilder, LintStatus};
 use crate::suppression::FileSuppressionId;
@@ -8,8 +9,7 @@ use crate::types::string_annotation::{
     IMPLICIT_CONCATENATED_STRING_TYPE_ANNOTATION, INVALID_SYNTAX_IN_FORWARD_ANNOTATION,
     RAW_STRING_TYPE_ANNOTATION,
 };
-use crate::types::{class::ProtocolClassLiteral, KnownFunction, KnownInstanceType, Type};
-use crate::Db;
+use crate::types::{protocol_class::ProtocolClassLiteral, KnownFunction, KnownInstanceType, Type};
 use ruff_db::diagnostic::{Annotation, Diagnostic, Severity, Span, SubDiagnostic};
 use ruff_python_ast::{self as ast, AnyNodeRef};
 use ruff_text_size::Ranged;

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -86,11 +86,11 @@ impl Display for DisplayRepresentation<'_> {
                 Protocol::FromClass(ClassType::Generic(alias)) => alias.display(self.db).fmt(f),
                 Protocol::Synthesized(synthetic) => {
                     f.write_str("<Protocol with members ")?;
-                    let member_list = synthetic.members(self.db);
+                    let member_list = synthetic.interface(self.db).members();
                     let num_members = member_list.len();
-                    for (i, member) in member_list.iter().enumerate() {
+                    for (i, member) in member_list.enumerate() {
                         let is_last = i == num_members - 1;
-                        write!(f, "'{member}'")?;
+                        write!(f, "'{}'", member.name())?;
                         if !is_last {
                             f.write_str(", ")?;
                         }

--- a/crates/red_knot_python_semantic/src/types/instance.rs
+++ b/crates/red_knot_python_semantic/src/types/instance.rs
@@ -182,43 +182,33 @@ impl<'db> ProtocolInstanceType<'db> {
 
     /// Return `true` if this protocol type is a subtype of the protocol `other`.
     pub(super) fn is_subtype_of(self, db: &'db dyn Db, other: Self) -> bool {
-        if !self.is_fully_static(db) {
-            return false;
-        }
-        if !other.is_fully_static(db) {
-            return false;
-        }
-        other
-            .0
-            .interface(db)
-            .is_sub_interface_of(self.0.interface(db))
+        self.is_fully_static(db) && other.is_fully_static(db) && self.is_assignable_to(db, other)
     }
 
     /// Return `true` if this protocol type is assignable to the protocol `other`.
     ///
     /// TODO: consider the types of the members as well as their existence
     pub(super) fn is_assignable_to(self, db: &'db dyn Db, other: Self) -> bool {
-        self.is_subtype_of(db, other)
+        other
+            .0
+            .interface(db)
+            .is_sub_interface_of(self.0.interface(db))
     }
 
     /// Return `true` if this protocol type is equivalent to the protocol `other`.
     ///
     /// TODO: consider the types of the members as well as their existence
     pub(super) fn is_equivalent_to(self, db: &'db dyn Db, other: Self) -> bool {
-        if !self.is_fully_static(db) {
-            return false;
-        }
-        if !other.is_fully_static(db) {
-            return false;
-        }
-        self.normalized(db) == other.normalized(db)
+        self.is_fully_static(db)
+            && other.is_fully_static(db)
+            && self.normalized(db) == other.normalized(db)
     }
 
     /// Return `true` if this protocol type is gradually equivalent to the protocol `other`.
     ///
     /// TODO: consider the types of the members as well as their existence
     pub(super) fn is_gradual_equivalent_to(self, db: &'db dyn Db, other: Self) -> bool {
-        self.is_equivalent_to(db, other)
+        self.normalized(db) == other.normalized(db)
     }
 
     /// Return `true` if this protocol type is disjoint from the protocol `other`.

--- a/crates/red_knot_python_semantic/src/types/instance.rs
+++ b/crates/red_knot_python_semantic/src/types/instance.rs
@@ -1,6 +1,6 @@
 //! Instance types: both nominal and structural.
 
-use super::class::ProtocolInterface;
+use super::protocol_class::ProtocolInterface;
 use super::{ClassType, KnownClass, SubclassOfType, Type};
 use crate::symbol::{Symbol, SymbolAndQualifiers};
 use crate::Db;

--- a/crates/red_knot_python_semantic/src/types/instance.rs
+++ b/crates/red_knot_python_semantic/src/types/instance.rs
@@ -225,8 +225,7 @@ impl<'db> ProtocolInstanceType<'db> {
             Protocol::FromClass(class) => class.instance_member(db, name),
             Protocol::Synthesized(synthesized) => synthesized
                 .interface(db)
-                .members()
-                .find(|member| member.name() == name)
+                .member_by_name(name)
                 .map(|member| SymbolAndQualifiers {
                     symbol: Symbol::bound(member.ty()),
                     qualifiers: member.qualifiers(),

--- a/crates/red_knot_python_semantic/src/types/protocol_class.rs
+++ b/crates/red_knot_python_semantic/src/types/protocol_class.rs
@@ -1,0 +1,219 @@
+use std::ops::Deref;
+
+use itertools::Itertools;
+
+use ruff_python_ast::name::Name;
+
+use crate::{
+    db::Db,
+    semantic_index::{symbol_table, use_def_map},
+    symbol::{symbol_from_bindings, symbol_from_declarations},
+    types::{ClassBase, ClassLiteral, KnownFunction, Type, TypeQualifiers},
+};
+
+impl<'db> ClassLiteral<'db> {
+    /// Returns `Some` if this is a protocol class, `None` otherwise.
+    pub(super) fn into_protocol_class(self, db: &'db dyn Db) -> Option<ProtocolClassLiteral<'db>> {
+        self.is_protocol(db).then_some(ProtocolClassLiteral(self))
+    }
+}
+
+/// Representation of a single `Protocol` class definition.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub(super) struct ProtocolClassLiteral<'db>(ClassLiteral<'db>);
+
+impl<'db> ProtocolClassLiteral<'db> {
+    /// Returns the protocol members of this class.
+    ///
+    /// A protocol's members define the interface declared by the protocol.
+    /// They therefore determine how the protocol should behave with regards to
+    /// assignability and subtyping.
+    ///
+    /// The list of members consists of all bindings and declarations that take place
+    /// in the protocol's class body, except for a list of excluded attributes which should
+    /// not be taken into account. (This list includes `__init__` and `__new__`, which can
+    /// legally be defined on protocol classes but do not constitute protocol members.)
+    ///
+    /// It is illegal for a protocol class to have any instance attributes that are not declared
+    /// in the protocol's class body. If any are assigned to, they are not taken into account in
+    /// the protocol's list of members.
+    pub(super) fn interface(self, db: &'db dyn Db) -> &'db ProtocolInterface<'db> {
+        let _span = tracing::trace_span!("protocol_members", "class='{}'", self.name(db)).entered();
+        cached_protocol_members(db, *self)
+    }
+
+    pub(super) fn is_runtime_checkable(self, db: &'db dyn Db) -> bool {
+        self.known_function_decorators(db)
+            .contains(&KnownFunction::RuntimeCheckable)
+    }
+}
+
+impl<'db> Deref for ProtocolClassLiteral<'db> {
+    type Target = ClassLiteral<'db>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, salsa::Update, Default, Clone, Hash)]
+pub(super) struct ProtocolInterface<'db>(Box<[ProtocolMember<'db>]>);
+
+impl<'db> ProtocolInterface<'db> {
+    pub(super) fn members(&self) -> impl ExactSizeIterator<Item = &ProtocolMember<'db>> {
+        self.0.iter()
+    }
+
+    pub(super) fn is_fully_static(&self, db: &'db dyn Db) -> bool {
+        self.members().all(|member| member.ty.is_fully_static(db))
+    }
+
+    /// TODO: consider the types of the members as well as their names.
+    /// TODO: using a map as the underlying data structure would be more efficient here than a boxed slice.
+    pub(super) fn is_sub_interface_of(&self, other: &Self) -> bool {
+        self.members().all(|member| {
+            other
+                .members()
+                .any(|other_member| member.name() == other_member.name())
+        })
+    }
+
+    pub(super) fn contains_todo(&self, db: &'db dyn Db) -> bool {
+        self.members().any(|member| member.ty.contains_todo(db))
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, salsa::Update, Clone, Hash)]
+pub(super) struct ProtocolMember<'db> {
+    name: Name,
+    ty: Type<'db>,
+    qualifiers: TypeQualifiers,
+}
+
+impl<'db> ProtocolMember<'db> {
+    pub(super) fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub(super) fn ty(&self) -> Type<'db> {
+        self.ty
+    }
+
+    pub(super) fn qualifiers(&self) -> TypeQualifiers {
+        self.qualifiers
+    }
+}
+
+/// The list of excluded members is subject to change between Python versions,
+/// especially for dunders, but it probably doesn't matter *too* much if this
+/// list goes out of date. It's up to date as of Python commit 87b1ea016b1454b1e83b9113fa9435849b7743aa
+/// (<https://github.com/python/cpython/blob/87b1ea016b1454b1e83b9113fa9435849b7743aa/Lib/typing.py#L1776-L1791>)
+fn excluded_from_proto_members(member: &str) -> bool {
+    matches!(
+        member,
+        "_is_protocol"
+            | "__non_callable_proto_members__"
+            | "__static_attributes__"
+            | "__orig_class__"
+            | "__match_args__"
+            | "__weakref__"
+            | "__doc__"
+            | "__parameters__"
+            | "__module__"
+            | "_MutableMapping__marker"
+            | "__slots__"
+            | "__dict__"
+            | "__new__"
+            | "__protocol_attrs__"
+            | "__init__"
+            | "__class_getitem__"
+            | "__firstlineno__"
+            | "__abstractmethods__"
+            | "__orig_bases__"
+            | "_is_runtime_protocol"
+            | "__subclasshook__"
+            | "__type_params__"
+            | "__annotations__"
+            | "__annotate__"
+            | "__annotate_func__"
+            | "__annotations_cache__"
+    )
+}
+
+#[salsa::tracked(return_ref, cycle_fn=proto_members_cycle_recover, cycle_initial=proto_members_cycle_initial)]
+fn cached_protocol_members<'db>(
+    db: &'db dyn Db,
+    class: ClassLiteral<'db>,
+) -> ProtocolInterface<'db> {
+    let mut members = vec![];
+
+    for parent_protocol in class
+        .iter_mro(db, None)
+        .filter_map(ClassBase::into_class)
+        .filter_map(|class| class.class_literal(db).0.into_protocol_class(db))
+    {
+        let parent_scope = parent_protocol.body_scope(db);
+        let use_def_map = use_def_map(db, parent_scope);
+        let symbol_table = symbol_table(db, parent_scope);
+
+        members.extend(
+            use_def_map
+                .all_public_declarations()
+                .flat_map(|(symbol_id, declarations)| {
+                    symbol_from_declarations(db, declarations).map(|symbol| (symbol_id, symbol))
+                })
+                .filter_map(|(symbol_id, symbol)| {
+                    symbol
+                        .symbol
+                        .ignore_possibly_unbound()
+                        .map(|ty| (symbol_id, ty, symbol.qualifiers))
+                })
+                // Bindings in the class body that are not declared in the class body
+                // are not valid protocol members, and we plan to emit diagnostics for them
+                // elsewhere. Invalid or not, however, it's important that we still consider
+                // them to be protocol members. The implementation of `issubclass()` and
+                // `isinstance()` for runtime-checkable protocols considers them to be protocol
+                // members at runtime, and it's important that we accurately understand
+                // type narrowing that uses `isinstance()` or `issubclass()` with
+                // runtime-checkable protocols.
+                .chain(
+                    use_def_map
+                        .all_public_bindings()
+                        .filter_map(|(symbol_id, bindings)| {
+                            symbol_from_bindings(db, bindings)
+                                .ignore_possibly_unbound()
+                                .map(|ty| (symbol_id, ty, TypeQualifiers::default()))
+                        }),
+                )
+                .map(|(symbol_id, member, qualifiers)| {
+                    (symbol_table.symbol(symbol_id).name(), member, qualifiers)
+                })
+                .filter(|(name, _, _)| !excluded_from_proto_members(name))
+                .map(|(name, ty, qualifiers)| ProtocolMember {
+                    name: name.clone(),
+                    ty,
+                    qualifiers,
+                }),
+        );
+    }
+
+    members.sort_unstable_by(|m1, m2| m1.name().cmp(m2.name()));
+    members.dedup_by(|m1, m2| m1.name() == m2.name());
+    ProtocolInterface(members.into_boxed_slice())
+}
+
+fn proto_members_cycle_recover<'db>(
+    _db: &dyn Db,
+    _value: &ProtocolInterface<'db>,
+    _count: u32,
+    _class: ClassLiteral<'db>,
+) -> salsa::CycleRecoveryAction<ProtocolInterface<'db>> {
+    salsa::CycleRecoveryAction::Iterate
+}
+
+fn proto_members_cycle_initial<'db>(
+    _db: &dyn Db,
+    _class: ClassLiteral<'db>,
+) -> ProtocolInterface<'db> {
+    ProtocolInterface::default()
+}


### PR DESCRIPTION
## Summary

This PR teaches red-knot to differentiate between fully-static and non-fully-static protocol types. This fixes several TODOs in the test suite, but the main motivation here is that it's an excuse to start collecting the types of protocol members as well as the names of those members -- these will be very important for a proper implementation of assignability and subtyping down the road.

This is best reviewed commit by commit:
1. The first commit implements the substantive changes of this PR
2. The second commit doesn't implement any substantive changes; it _only_ moves the protocol-related infrastructure out of `class.rs` and into a new submodule
3. The third commit just cleans up some documentation.

## Test Plan

Existing mdtest assertions updated, and some new ones added
