### PR TITLE
[red-knot] Avoid including `__all__` in the exported names

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/import/star.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/import/star.md
@@ -923,6 +923,9 @@ reveal_type(X)  # revealed: bool
 
 # TODO: should emit [unresolved-reference] diagnostic & reveal `Unknown`
 reveal_type(Y)  # revealed: bool
+
+# error: [unresolved-reference]
+reveal_type(__all__)  # revealed: Unknown
 ```
 
 ### `__all__` with additions later on in the global scope

--- a/crates/red_knot_python_semantic/src/semantic_index/re_exports.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/re_exports.rs
@@ -71,10 +71,10 @@ impl<'db> ExportFinder<'db> {
     }
 
     fn possibly_add_export(&mut self, export: &'db Name, kind: PossibleExportKind) {
-        self.exports.insert(export, kind);
-
         if export == "__all__" {
             self.dunder_all = DunderAll::Present;
+        } else {
+            self.exports.insert(export, kind);
         }
     }
 


### PR DESCRIPTION
## Summary

This PR fixes a bug where the `__all__` was being included in the exported names which would lead to a hang on the following example.

The `__all__` variable is not exported from a `*`-import.

<details><summary>Example that hangs on <code>main</code></summary>
<p>

`play.py`:
```py
from submodule import *
```

`submodule/__init__.py`:
```py
from submodule import foo

reveal_type(foo)

__all__ = []
__all__ += foo.__all__
```

`submodule/foo/__init__.py`:
```py
__all__ = ["SubmoduleFoo"]


class SubmoduleFoo: ...
```

</p>
</details> 

## Test Plan

Update one of the existing star import test case to make sure `__all__` creates an unresolved-reference error and the inferred type is `Unknown`.

On `main`, this doesn't result into any error and the inferred type is `Unknown | list`.
