### PR TITLE
[red-knot] Don't panic when `primary-span` is missing while panicking

### DIFF
--- a/crates/red_knot_python_semantic/src/types/context.rs
+++ b/crates/red_knot_python_semantic/src/types/context.rs
@@ -468,6 +468,11 @@ impl Drop for DiagnosticGuard<'_, '_> {
         // once.
         let diag = self.diag.take().unwrap();
 
+        if std::thread::panicking() {
+            // Don't submit diagnostics when panicking because they might be incomplete.
+            return;
+        }
+
         let Some(ann) = diag.primary_annotation() else {
             panic!(
                 "All diagnostics reported by `InferContext` must have a \


### PR DESCRIPTION
## Summary

Panicking in a `Drop` implementation when the program is unwinding results in terminating the processes. 

We shouldn't panick in this case because the diagnostic is very likely incomplete and shoudln't be submitted.
