### PR TITLE
[`flake8-bandit`] Mark tuples of string literals as trusted input in `S603`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_bandit/S603.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_bandit/S603.py
@@ -39,3 +39,9 @@ run(c := "true")
 # But non-instant are not.
 (e := "echo")
 run(e)
+
+
+# https://github.com/astral-sh/ruff/issues/17798
+# Tuple literals are trusted
+check_output(("literal", "cmd", "using", "tuple"), text=True)
+Popen(("literal", "cmd", "using", "tuple"))

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/shell_injection.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/shell_injection.rs
@@ -289,11 +289,11 @@ impl Violation for UnixCommandWildcardInjection {
 }
 
 /// Check if an expression is a trusted input for subprocess.run.
-/// We assume that any str or list[str] literal can be trusted.
+/// We assume that any str, list[str] or tuple[str] literal can be trusted.
 fn is_trusted_input(arg: &Expr) -> bool {
     match arg {
         Expr::StringLiteral(_) => true,
-        Expr::List(ast::ExprList { elts, .. }) => {
+        Expr::List(ast::ExprList { elts, .. }) | Expr::Tuple(ast::ExprTuple { elts, .. }) => {
             elts.iter().all(|elt| matches!(elt, Expr::StringLiteral(_)))
         }
         Expr::Named(named) => is_trusted_input(&named.value),

--- a/crates/ruff_linter/src/rules/flake8_bandit/snapshots/ruff_linter__rules__flake8_bandit__tests__S603_S603.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bandit/snapshots/ruff_linter__rules__flake8_bandit__tests__S603_S603.py.snap
@@ -200,3 +200,20 @@ S603.py:41:1: S603 `subprocess` call: check for execution of untrusted input
 41 | run(e)
    | ^^^ S603
    |
+
+S603.py:46:1: S603 `subprocess` call: check for execution of untrusted input
+   |
+44 | # https://github.com/astral-sh/ruff/issues/17798
+45 | # Tuple literals are trusted
+46 | check_output(("literal", "cmd", "using", "tuple"), text=True)
+   | ^^^^^^^^^^^^ S603
+47 | Popen(("literal", "cmd", "using", "tuple"))
+   |
+
+S603.py:47:1: S603 `subprocess` call: check for execution of untrusted input
+   |
+45 | # Tuple literals are trusted
+46 | check_output(("literal", "cmd", "using", "tuple"), text=True)
+47 | Popen(("literal", "cmd", "using", "tuple"))
+   | ^^^^^ S603
+   |


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Fixes #17798
<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

Snapshot tests
<!-- How was it tested? -->
