### PR TITLE
[red-knot] add tracing of salsa events in mdtests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2647,6 +2647,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.12",
  "toml",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/red_knot_test/Cargo.toml
+++ b/crates/red_knot_test/Cargo.toml
@@ -33,6 +33,7 @@ smallvec = { workspace = true }
 serde = { workspace = true }
 tempfile = { workspace = true }
 toml = { workspace = true }
+tracing = { workspace = true }
 thiserror = { workspace = true }
 
 [lints]

--- a/crates/red_knot_test/src/db.rs
+++ b/crates/red_knot_test/src/db.rs
@@ -96,7 +96,10 @@ impl SemanticDb for Db {
 
 #[salsa::db]
 impl salsa::Database for Db {
-    fn salsa_event(&self, _event: &dyn Fn() -> salsa::Event) {}
+    fn salsa_event(&self, event: &dyn Fn() -> salsa::Event) {
+        let event = event();
+        tracing::trace!("event: {:?}", event);
+    }
 }
 
 impl DbWithWritableSystem for Db {


### PR DESCRIPTION
## Summary

This helps with debugging Salsa issues reproduced in an mdtest, since it makes Salsa events (such as the `WillIterateCycle` event) visible in tracing.

## Test Plan

Used `log = "red_knot_test=trace"` in an mdtest and saw salsa events appear in the tracing output from running that test.


