### PR TITLE
[pylint] add fix safety section (PLR1722)

### DIFF
--- a/crates/ruff_linter/src/rules/pylint/rules/sys_exit_alias.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/sys_exit_alias.rs
@@ -19,6 +19,8 @@ use ruff_text_size::Ranged;
 /// Prefer `sys.exit()`, as the `sys` module is guaranteed to exist in all
 /// contexts.
 ///
+/// ## Fix safety
+///
 /// ## Example
 /// ```python
 /// if __name__ == "__main__":


### PR DESCRIPTION
Still a WIP

## Summary

The fix was marked unsafe in commit 0fc76ba2762157548e2a9ea6ae487713fc39e215

