### PR TITLE
[red-knot] Recurse into the types of protocol members when normalizing a protocol's interface

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/protocols.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/protocols.md
@@ -816,6 +816,22 @@ class B: ...
 static_assert(is_equivalent_to(A | HasX | B | HasY, B | AlsoHasY | AlsoHasX | A))
 ```
 
+Protocols are considered equivalent if their members are equivalent, even if those members are
+differently ordered unions:
+
+```py
+class C: ...
+
+class UnionProto1(Protocol):
+    x: A | B | C
+
+class UnionProto2(Protocol):
+    x: C | A | B
+
+static_assert(is_equivalent_to(UnionProto1, UnionProto2))
+static_assert(is_equivalent_to(UnionProto1 | A | B, B | UnionProto2 | A))
+```
+
 ## Intersections of protocols
 
 An intersection of two protocol types `X` and `Y` is equivalent to a protocol type `Z` that inherits

--- a/crates/red_knot_python_semantic/src/types/instance.rs
+++ b/crates/red_knot_python_semantic/src/types/instance.rs
@@ -5,7 +5,7 @@ use super::{ClassType, KnownClass, SubclassOfType, Type};
 use crate::symbol::{Symbol, SymbolAndQualifiers};
 use crate::Db;
 
-pub(super) use synthesized::SynthesizedProtocolType;
+pub(super) use synthesized_protocol::SynthesizedProtocolType;
 
 impl<'db> Type<'db> {
     pub(crate) fn instance(db: &'db dyn Db, class: ClassType<'db>) -> Self {
@@ -260,7 +260,7 @@ impl<'db> Protocol<'db> {
     }
 }
 
-mod synthesized {
+mod synthesized_protocol {
     use crate::db::Db;
     use crate::types::protocol_class::ProtocolInterface;
 
@@ -268,7 +268,7 @@ mod synthesized {
     ///
     /// Two synthesized protocol types with the same members will share the same Salsa ID,
     /// making them easy to compare for equivalence. A synthesized protocol type is therefore
-    /// returned by [`ProtocolInstanceType::normalized`] so that two protocols with the same members
+    /// returned by [`super::ProtocolInstanceType::normalized`] so that two protocols with the same members
     /// will be understood as equivalent even in the context of differently ordered unions or intersections.
     ///
     /// The constructor method of this type maintains the invariant that a synthesized protocol type

--- a/crates/red_knot_python_semantic/src/types/instance.rs
+++ b/crates/red_knot_python_semantic/src/types/instance.rs
@@ -166,7 +166,7 @@ impl<'db> ProtocolInstanceType<'db> {
         }
         match self.0 {
             Protocol::FromClass(_) => Type::ProtocolInstance(Self(Protocol::Synthesized(
-                SynthesizedProtocolType::new(db, self.0.interface(db)),
+                SynthesizedProtocolType::new(db, self.0.interface(db).clone()),
             ))),
             Protocol::Synthesized(_) => Type::ProtocolInstance(self),
         }
@@ -277,8 +277,11 @@ mod synthesized {
     pub(in crate::types) struct SynthesizedProtocolType<'db>(SynthesizedProtocolTypeInner<'db>);
 
     impl<'db> SynthesizedProtocolType<'db> {
-        pub(super) fn new(db: &'db dyn Db, interface: &'db ProtocolInterface<'db>) -> Self {
-            Self(SynthesizedProtocolTypeInner::new(db, interface.normalized(db)))
+        pub(super) fn new(db: &'db dyn Db, interface: ProtocolInterface<'db>) -> Self {
+            Self(SynthesizedProtocolTypeInner::new(
+                db,
+                interface.normalized(db),
+            ))
         }
 
         pub(in crate::types) fn interface(self, db: &'db dyn Db) -> &'db ProtocolInterface<'db> {

--- a/crates/red_knot_python_semantic/src/types/protocol_class.rs
+++ b/crates/red_knot_python_semantic/src/types/protocol_class.rs
@@ -96,6 +96,10 @@ impl<'db> ProtocolInterface<'db> {
     pub(super) fn contains_todo(&self, db: &'db dyn Db) -> bool {
         self.members().any(|member| member.ty.contains_todo(db))
     }
+
+    pub(super) fn normalized(&self, db: &'db dyn Db) -> Self {
+        self.clone()
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, salsa::Update)]

--- a/crates/red_knot_python_semantic/src/types/protocol_class.rs
+++ b/crates/red_knot_python_semantic/src/types/protocol_class.rs
@@ -97,8 +97,13 @@ impl<'db> ProtocolInterface<'db> {
         self.members().any(|member| member.ty.contains_todo(db))
     }
 
-    pub(super) fn normalized(&self, db: &'db dyn Db) -> Self {
-        self.clone()
+    pub(super) fn normalized(self, db: &'db dyn Db) -> Self {
+        Self(
+            self.0
+                .into_iter()
+                .map(|(name, data)| (name, data.normalized(db)))
+                .collect(),
+        )
     }
 }
 
@@ -106,6 +111,15 @@ impl<'db> ProtocolInterface<'db> {
 struct ProtocolMemberData<'db> {
     ty: Type<'db>,
     qualifiers: TypeQualifiers,
+}
+
+impl<'db> ProtocolMemberData<'db> {
+    fn normalized(self, db: &'db dyn Db) -> Self {
+        Self {
+            ty: self.ty.normalized(db),
+            qualifiers: self.qualifiers,
+        }
+    }
 }
 
 /// A single member of a protocol interface.


### PR DESCRIPTION
## Summary

Currently red-knot does not understand `Foo` and `Bar` here as being equivalent:

```py
from typing import Protocol

class A: ...
class B: ...
class C: ...

class Foo(Protocol):
    x: A | B | C

class Bar(Protocol):
    x: B | A | C
```

Nor does it understand `A | B | Foo` as being equivalent to `Bar | B | A`. This PR fixes that.

## Test Plan

new mdtest assertions added that fail on `main`
