### PR TITLE
[red-knot] Synthesize a `__call__` attribute for Callable types

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/callable.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/callable.md
@@ -300,12 +300,7 @@ from typing import Callable
 def _(c: Callable[[int], int]):
     reveal_type(c.__init__)  # revealed: def __init__(self) -> None
     reveal_type(c.__class__)  # revealed: type
-
-    # TODO: The member lookup for `Callable` uses `object` which does not have a `__call__`
-    # attribute. We could special case `__call__` in this context. Refer to
-    # https://github.com/astral-sh/ruff/pull/16493#discussion_r1985098508 for more details.
-    # error: [unresolved-attribute] "Type `(int, /) -> int` has no attribute `__call__`"
-    reveal_type(c.__call__)  # revealed: Unknown
+    reveal_type(c.__call__)  # revealed: (int, /) -> int
 ```
 
 [gradual form]: https://typing.python.org/en/latest/spec/glossary.html#term-gradual-form

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -2953,6 +2953,10 @@ impl<'db> Type<'db> {
             Type::DataclassDecorator(_) => KnownClass::FunctionType
                 .to_instance(db)
                 .member_lookup_with_policy(db, name, policy),
+
+            Type::Callable(_) | Type::DataclassTransformer(_) if name_str == "__call__" => {
+                Symbol::bound(self).into()
+            }
             Type::Callable(_) | Type::DataclassTransformer(_) => KnownClass::Object
                 .to_instance(db)
                 .member_lookup_with_policy(db, name, policy),


### PR DESCRIPTION
## Summary

Currently this assertion fails on `main`, because we do not synthesize a `__call__` attribute for Callable types:

```py
from typing import Protocol, Callable
from knot_extensions import static_assert, is_assignable_to

class Foo(Protocol):
    def __call__(self, x: int, /) -> str: ...

static_assert(is_assignable_to(Callable[[int], str], Foo))
```

This PR fixes that.

See previous discussion about this in https://github.com/astral-sh/ruff/pull/16493#discussion_r1985098508 and https://github.com/astral-sh/ruff/pull/17682#issuecomment-2839527750

## Test Plan

Existing mdtests updated; a couple of new ones added.
