### PR TITLE
[red-knot] Add tests asserting that subclasses of `Any` are assignable to arbitrary protocol types

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/any.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/any.md
@@ -82,10 +82,10 @@ class OtherFinalClass: ...
 f: FinalClass | OtherFinalClass = SubclassOfAny()  # error: [invalid-assignment]
 ```
 
-A subclass of `Any` can also be assigned to arbitrary `Callable` types:
+A subclass of `Any` can also be assigned to arbitrary `Callable` and `Protocol` types:
 
 ```py
-from typing import Callable, Any
+from typing import Callable, Any, Protocol
 
 def takes_callable1(f: Callable):
     f()
@@ -96,6 +96,25 @@ def takes_callable2(f: Callable[[int], None]):
     f(1)
 
 takes_callable2(SubclassOfAny())
+
+class CallbackProtocol(Protocol):
+    def __call__(self, x: int, /) -> None: ...
+
+def takes_callback_proto(f: CallbackProtocol):
+    f(1)
+
+takes_callback_proto(SubclassOfAny())
+
+class OtherProtocol(Protocol):
+    x: int
+    @property
+    def foo(self) -> bytes: ...
+    @foo.setter
+    def foo(self, x: str) -> None: ...
+
+def takes_other_protocol(f: OtherProtocol): ...
+
+takes_other_protocol(SubclassOfAny())
 ```
 
 A subclass of `Any` cannot be assigned to literal types, since those can not be subclassed:


### PR DESCRIPTION
## Summary

I thought we might have to add some new branches to `Type::is_assignable_to` here, similar to what we did for `Callable` types in #17717. But it turns out that it just falls out naturally from the logic we already have in place. A subclass of `Any` just returns a synthesized attribute of type `Any` for any member access where the member is not explicitly annotated on the subclass. And protocol subtyping/assignability works entirely through member access APIs on `Type`.

## Test Plan

this PR is only tests
