### PR TITLE
Use `#[expect(lint)]` over `#[allow(lint)]` where possible

### DIFF
--- a/crates/ruff/build.rs
+++ b/crates/ruff/build.rs
@@ -13,7 +13,6 @@ fn main() {
 
     commit_info(&workspace_root);
 
-    #[expect(clippy::disallowed_methods)]
     let target = std::env::var("TARGET").unwrap();
     println!("cargo::rustc-env=RUST_HOST_TARGET={target}");
 }

--- a/crates/ruff/build.rs
+++ b/crates/ruff/build.rs
@@ -13,7 +13,7 @@ fn main() {
 
     commit_info(&workspace_root);
 
-    #[allow(clippy::disallowed_methods)]
+    #[expect(clippy::disallowed_methods)]
     let target = std::env::var("TARGET").unwrap();
     println!("cargo::rustc-env=RUST_HOST_TARGET={target}");
 }

--- a/crates/ruff/src/args.rs
+++ b/crates/ruff/src/args.rs
@@ -1271,7 +1271,6 @@ pub struct AnalyzeGraphArgs {
 /// Configuration overrides provided via dedicated CLI flags:
 /// `--line-length`, `--respect-gitignore`, etc.
 #[derive(Clone, Default)]
-#[expect(clippy::struct_excessive_bools)]
 struct ExplicitConfigOverrides {
     dummy_variable_rgx: Option<Regex>,
     exclude: Option<Vec<FilePattern>>,

--- a/crates/ruff/src/args.rs
+++ b/crates/ruff/src/args.rs
@@ -93,7 +93,7 @@ pub struct Args {
     pub(crate) global_options: GlobalConfigArgs,
 }
 
-#[allow(clippy::large_enum_variant)]
+#[expect(clippy::large_enum_variant)]
 #[derive(Debug, clap::Subcommand)]
 pub enum Command {
     /// Run Ruff on the given files or directories.
@@ -184,7 +184,7 @@ pub struct AnalyzeGraphCommand {
 
 // The `Parser` derive is for ruff_dev, for ruff `Args` would be sufficient
 #[derive(Clone, Debug, clap::Parser)]
-#[allow(clippy::struct_excessive_bools)]
+#[expect(clippy::struct_excessive_bools)]
 pub struct CheckCommand {
     /// List of files or directories to check.
     #[clap(help = "List of files or directories to check [default: .]")]
@@ -446,7 +446,7 @@ pub struct CheckCommand {
 }
 
 #[derive(Clone, Debug, clap::Parser)]
-#[allow(clippy::struct_excessive_bools)]
+#[expect(clippy::struct_excessive_bools)]
 pub struct FormatCommand {
     /// List of files or directories to format.
     #[clap(help = "List of files or directories to format [default: .]")]
@@ -560,7 +560,7 @@ pub enum HelpFormat {
     Json,
 }
 
-#[allow(clippy::module_name_repetitions)]
+#[expect(clippy::module_name_repetitions)]
 #[derive(Debug, Default, Clone, clap::Args)]
 pub struct LogLevelArgs {
     /// Enable verbose logging.
@@ -1031,7 +1031,7 @@ Possible choices:
 
 /// CLI settings that are distinct from configuration (commands, lists of files,
 /// etc.).
-#[allow(clippy::struct_excessive_bools)]
+#[expect(clippy::struct_excessive_bools)]
 pub struct CheckArguments {
     pub add_noqa: bool,
     pub diff: bool,
@@ -1050,7 +1050,7 @@ pub struct CheckArguments {
 
 /// CLI settings that are distinct from configuration (commands, lists of files,
 /// etc.).
-#[allow(clippy::struct_excessive_bools)]
+#[expect(clippy::struct_excessive_bools)]
 pub struct FormatArguments {
     pub check: bool,
     pub no_cache: bool,
@@ -1271,7 +1271,7 @@ pub struct AnalyzeGraphArgs {
 /// Configuration overrides provided via dedicated CLI flags:
 /// `--line-length`, `--respect-gitignore`, etc.
 #[derive(Clone, Default)]
-#[allow(clippy::struct_excessive_bools)]
+#[expect(clippy::struct_excessive_bools)]
 struct ExplicitConfigOverrides {
     dummy_variable_rgx: Option<Regex>,
     exclude: Option<Vec<FilePattern>>,

--- a/crates/ruff/src/cache.rs
+++ b/crates/ruff/src/cache.rs
@@ -834,7 +834,6 @@ mod tests {
         // Regression test for issue #3086.
 
         #[cfg(unix)]
-        #[expect(clippy::items_after_statements)]
         fn flip_execute_permission_bit(path: &Path) -> io::Result<()> {
             use std::os::unix::fs::PermissionsExt;
             let file = fs::OpenOptions::new().write(true).open(path)?;
@@ -843,7 +842,6 @@ mod tests {
         }
 
         #[cfg(windows)]
-        #[expect(clippy::items_after_statements)]
         fn flip_read_only_permission(path: &Path) -> io::Result<()> {
             let file = fs::OpenOptions::new().write(true).open(path)?;
             let mut perms = file.metadata()?.permissions();

--- a/crates/ruff/src/cache.rs
+++ b/crates/ruff/src/cache.rs
@@ -86,7 +86,7 @@ pub(crate) struct Cache {
     changes: Mutex<Vec<Change>>,
     /// The "current" timestamp used as cache for the updates of
     /// [`FileCache::last_seen`]
-    #[allow(clippy::struct_field_names)]
+    #[expect(clippy::struct_field_names)]
     last_seen_cache: u64,
 }
 
@@ -146,7 +146,7 @@ impl Cache {
         Cache::new(path, package)
     }
 
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     fn new(path: PathBuf, package: PackageCache) -> Self {
         Cache {
             path,
@@ -204,7 +204,7 @@ impl Cache {
     }
 
     /// Applies the pending changes without storing the cache to disk.
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     pub(crate) fn save(&mut self) -> bool {
         /// Maximum duration for which we keep a file in cache that hasn't been seen.
         const MAX_LAST_SEEN: Duration = Duration::from_secs(30 * 24 * 60 * 60); // 30 days.
@@ -834,7 +834,7 @@ mod tests {
         // Regression test for issue #3086.
 
         #[cfg(unix)]
-        #[allow(clippy::items_after_statements)]
+        #[expect(clippy::items_after_statements)]
         fn flip_execute_permission_bit(path: &Path) -> io::Result<()> {
             use std::os::unix::fs::PermissionsExt;
             let file = fs::OpenOptions::new().write(true).open(path)?;
@@ -843,7 +843,7 @@ mod tests {
         }
 
         #[cfg(windows)]
-        #[allow(clippy::items_after_statements)]
+        #[expect(clippy::items_after_statements)]
         fn flip_read_only_permission(path: &Path) -> io::Result<()> {
             let file = fs::OpenOptions::new().write(true).open(path)?;
             let mut perms = file.metadata()?.permissions();

--- a/crates/ruff/src/commands/check.rs
+++ b/crates/ruff/src/commands/check.rs
@@ -30,7 +30,7 @@ use crate::cache::{Cache, PackageCacheMap, PackageCaches};
 use crate::diagnostics::Diagnostics;
 
 /// Run the linter over a collection of files.
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub(crate) fn check(
     files: &[PathBuf],
     pyproject_config: &PyprojectConfig,
@@ -181,7 +181,7 @@ pub(crate) fn check(
 
 /// Wraps [`lint_path`](crate::diagnostics::lint_path) in a [`catch_unwind`](std::panic::catch_unwind) and emits
 /// a diagnostic if the linting the file panics.
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn lint_path(
     path: &Path,
     package: Option<PackageRoot<'_>>,

--- a/crates/ruff/src/commands/check.rs
+++ b/crates/ruff/src/commands/check.rs
@@ -30,7 +30,6 @@ use crate::cache::{Cache, PackageCacheMap, PackageCaches};
 use crate::diagnostics::Diagnostics;
 
 /// Run the linter over a collection of files.
-#[expect(clippy::too_many_arguments)]
 pub(crate) fn check(
     files: &[PathBuf],
     pyproject_config: &PyprojectConfig,
@@ -181,7 +180,6 @@ pub(crate) fn check(
 
 /// Wraps [`lint_path`](crate::diagnostics::lint_path) in a [`catch_unwind`](std::panic::catch_unwind) and emits
 /// a diagnostic if the linting the file panics.
-#[expect(clippy::too_many_arguments)]
 fn lint_path(
     path: &Path,
     package: Option<PackageRoot<'_>>,

--- a/crates/ruff/src/commands/config.rs
+++ b/crates/ruff/src/commands/config.rs
@@ -5,7 +5,7 @@ use crate::args::HelpFormat;
 use ruff_workspace::options::Options;
 use ruff_workspace::options_base::OptionsMetadata;
 
-#[allow(clippy::print_stdout)]
+#[expect(clippy::print_stdout)]
 pub(crate) fn config(key: Option<&str>, format: HelpFormat) -> Result<()> {
     match key {
         None => {

--- a/crates/ruff/src/commands/format.rs
+++ b/crates/ruff/src/commands/format.rs
@@ -362,7 +362,7 @@ pub(crate) fn format_source(
                 })
             } else {
                 // Using `Printed::into_code` requires adding `ruff_formatter` as a direct dependency, and I suspect that Rust can optimize the closure away regardless.
-                #[allow(clippy::redundant_closure_for_method_calls)]
+                #[expect(clippy::redundant_closure_for_method_calls)]
                 format_module_source(unformatted, options).map(|formatted| formatted.into_code())
             };
 

--- a/crates/ruff/src/commands/rule.rs
+++ b/crates/ruff/src/commands/rule.rs
@@ -19,7 +19,7 @@ struct Explanation<'a> {
     summary: &'a str,
     message_formats: &'a [&'a str],
     fix: String,
-    #[allow(clippy::struct_field_names)]
+    #[expect(clippy::struct_field_names)]
     explanation: Option<&'a str>,
     preview: bool,
 }

--- a/crates/ruff/src/lib.rs
+++ b/crates/ruff/src/lib.rs
@@ -134,7 +134,7 @@ pub fn run(
     {
         let default_panic_hook = std::panic::take_hook();
         std::panic::set_hook(Box::new(move |info| {
-            #[allow(clippy::print_stderr)]
+            #[expect(clippy::print_stderr)]
             {
                 eprintln!(
                     r#"
@@ -326,7 +326,7 @@ pub fn check(args: CheckCommand, global_options: GlobalConfigArgs) -> Result<Exi
             commands::add_noqa::add_noqa(&files, &pyproject_config, &config_arguments)?;
         if modifications > 0 && config_arguments.log_level >= LogLevel::Default {
             let s = if modifications == 1 { "" } else { "s" };
-            #[allow(clippy::print_stderr)]
+            #[expect(clippy::print_stderr)]
             {
                 eprintln!("Added {modifications} noqa directive{s}.");
             }

--- a/crates/ruff/src/printer.rs
+++ b/crates/ruff/src/printer.rs
@@ -241,7 +241,6 @@ impl Printer {
         }
 
         if !self.flags.intersects(Flags::SHOW_VIOLATIONS) {
-            #[allow(deprecated)]
             if matches!(
                 self.format,
                 OutputFormat::Full | OutputFormat::Concise | OutputFormat::Grouped

--- a/crates/ruff_benchmark/benches/linter.rs
+++ b/crates/ruff_benchmark/benches/linter.rs
@@ -45,9 +45,9 @@ static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
         target_arch = "powerpc64"
     )
 ))]
-#[allow(non_upper_case_globals)]
+#[expect(non_upper_case_globals)]
 #[export_name = "_rjem_malloc_conf"]
-#[allow(unsafe_code)]
+#[expect(unsafe_code)]
 pub static _rjem_malloc_conf: &[u8] = b"dirty_decay_ms:-1,muzzy_decay_ms:-1\0";
 
 fn create_test_cases() -> Vec<TestCase> {

--- a/crates/ruff_cache/src/cache_key.rs
+++ b/crates/ruff_cache/src/cache_key.rs
@@ -213,7 +213,7 @@ macro_rules! impl_cache_key_tuple {
 
     ( $($name:ident)+) => (
         impl<$($name: CacheKey),+> CacheKey for ($($name,)+) where last_type!($($name,)+): ?Sized {
-            #[allow(non_snake_case)]
+            #[expect(non_snake_case)]
             #[inline]
             fn cache_key(&self, state: &mut CacheKeyHasher) {
                 let ($(ref $name,)+) = *self;

--- a/crates/ruff_cache/tests/cache_key.rs
+++ b/crates/ruff_cache/tests/cache_key.rs
@@ -47,7 +47,7 @@ fn struct_ignored_fields() {
     struct NamedFieldsStruct {
         a: String,
         #[cache_key(ignore)]
-        #[allow(unused)]
+        #[expect(unused)]
         b: String,
     }
 

--- a/crates/ruff_db/src/diagnostic/render.rs
+++ b/crates/ruff_db/src/diagnostic/render.rs
@@ -376,7 +376,7 @@ struct Renderable<'r> {
     // (At time of writing, 2025-03-13, we currently render the diagnostic
     // ID into the main message of the parent diagnostic. We don't use this
     // specific field to do that though.)
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     id: &'r str,
     diagnostics: Vec<RenderableDiagnostic<'r>>,
 }

--- a/crates/ruff_db/src/system/os.rs
+++ b/crates/ruff_db/src/system/os.rs
@@ -50,7 +50,6 @@ impl OsSystem {
 
         Self {
             // Spreading `..Default` because it isn't possible to feature gate the initializer of a single field.
-            #[expect(clippy::needless_update)]
             inner: Arc::new(OsSystemInner {
                 cwd: cwd.to_path_buf(),
                 case_sensitivity,

--- a/crates/ruff_db/src/system/os.rs
+++ b/crates/ruff_db/src/system/os.rs
@@ -50,7 +50,7 @@ impl OsSystem {
 
         Self {
             // Spreading `..Default` because it isn't possible to feature gate the initializer of a single field.
-            #[allow(clippy::needless_update)]
+            #[expect(clippy::needless_update)]
             inner: Arc::new(OsSystemInner {
                 cwd: cwd.to_path_buf(),
                 case_sensitivity,

--- a/crates/ruff_db/src/system/walk_directory.rs
+++ b/crates/ruff_db/src/system/walk_directory.rs
@@ -35,7 +35,7 @@ impl WalkDirectoryBuilder {
     /// Each additional path is traversed recursively.
     /// This should be preferred over building multiple
     /// walkers since it enables reusing resources.
-    #[allow(clippy::should_implement_trait)]
+    #[expect(clippy::should_implement_trait)]
     pub fn add(mut self, path: impl AsRef<SystemPath>) -> Self {
         self.paths.push(path.as_ref().to_path_buf());
         self

--- a/crates/ruff_db/src/vendored.rs
+++ b/crates/ruff_db/src/vendored.rs
@@ -172,7 +172,7 @@ impl Default for VendoredFileSystem {
 /// that users of the `VendoredFileSystem` could realistically need.
 /// For debugging purposes, however, we want to have all information
 /// available.
-#[allow(unused)]
+#[expect(unused)]
 #[derive(Debug)]
 struct ZipFileDebugInfo {
     crc32_hash: u32,

--- a/crates/ruff_dev/src/format_dev.rs
+++ b/crates/ruff_dev/src/format_dev.rs
@@ -63,7 +63,6 @@ fn find_pyproject_config(
 }
 
 /// Find files that ruff would check so we can format them. Adapted from `ruff`.
-#[expect(clippy::type_complexity)]
 fn ruff_check_paths<'a>(
     pyproject_config: &'a PyprojectConfig,
     cli: &FormatArguments,

--- a/crates/ruff_dev/src/format_dev.rs
+++ b/crates/ruff_dev/src/format_dev.rs
@@ -63,7 +63,7 @@ fn find_pyproject_config(
 }
 
 /// Find files that ruff would check so we can format them. Adapted from `ruff`.
-#[allow(clippy::type_complexity)]
+#[expect(clippy::type_complexity)]
 fn ruff_check_paths<'a>(
     pyproject_config: &'a PyprojectConfig,
     cli: &FormatArguments,
@@ -135,12 +135,12 @@ impl Statistics {
     }
 
     /// We currently prefer the similarity index, but i'd like to keep this around
-    #[allow(clippy::cast_precision_loss, unused)]
+    #[expect(clippy::cast_precision_loss, unused)]
     pub(crate) fn jaccard_index(&self) -> f32 {
         self.intersection as f32 / (self.black_input + self.ruff_output + self.intersection) as f32
     }
 
-    #[allow(clippy::cast_precision_loss)]
+    #[expect(clippy::cast_precision_loss)]
     pub(crate) fn similarity_index(&self) -> f32 {
         self.intersection as f32 / (self.black_input + self.intersection) as f32
     }
@@ -177,7 +177,7 @@ pub(crate) enum Format {
     Full,
 }
 
-#[allow(clippy::struct_excessive_bools)]
+#[expect(clippy::struct_excessive_bools)]
 #[derive(clap::Args)]
 pub(crate) struct Args {
     /// Like `ruff check`'s files. See `--multi-project` if you want to format an ecosystem
@@ -222,7 +222,7 @@ pub(crate) struct Args {
     #[arg(long)]
     pub(crate) files_with_errors: Option<u32>,
     #[clap(flatten)]
-    #[allow(clippy::struct_field_names)]
+    #[expect(clippy::struct_field_names)]
     pub(crate) log_level_args: LogLevelArgs,
 }
 

--- a/crates/ruff_dev/src/generate_rules_table.rs
+++ b/crates/ruff_dev/src/generate_rules_table.rs
@@ -34,7 +34,6 @@ fn generate_table(table_out: &mut String, rules: impl IntoIterator<Item = Rule>,
             RuleGroup::Deprecated => {
                 format!("<span title='Rule has been deprecated'>{WARNING_SYMBOL}</span>")
             }
-            #[allow(deprecated)]
             RuleGroup::Preview => {
                 format!("<span title='Rule is in preview'>{PREVIEW_SYMBOL}</span>")
             }
@@ -78,7 +77,7 @@ fn generate_table(table_out: &mut String, rules: impl IntoIterator<Item = Rule>,
             se = "</span>";
         }
 
-        #[allow(clippy::or_fun_call)]
+        #[expect(clippy::or_fun_call)]
         let _ = write!(
             table_out,
             "| {ss}{0}{1}{se} {{ #{0}{1} }} | {ss}{2}{se} | {ss}{3}{se} | {ss}{4}{se} |",

--- a/crates/ruff_dev/src/main.rs
+++ b/crates/ruff_dev/src/main.rs
@@ -34,7 +34,7 @@ struct Args {
 }
 
 #[derive(Subcommand)]
-#[allow(clippy::large_enum_variant)]
+#[expect(clippy::large_enum_variant)]
 enum Command {
     /// Run all code and documentation generation steps.
     GenerateAll(generate_all::Args),
@@ -82,7 +82,7 @@ fn main() -> Result<ExitCode> {
         command,
         global_options,
     } = Args::parse();
-    #[allow(clippy::print_stdout)]
+    #[expect(clippy::print_stdout)]
     match command {
         Command::GenerateAll(args) => generate_all::main(&args)?,
         Command::GenerateJSONSchema(args) => generate_json_schema::main(&args)?,

--- a/crates/ruff_formatter/src/arguments.rs
+++ b/crates/ruff_formatter/src/arguments.rs
@@ -24,7 +24,7 @@ impl<'fmt, Context> Argument<'fmt, Context> {
     /// Formats the value stored by this argument using the given formatter.
     #[inline]
     // Seems to only be triggered on wasm32 and looks like a false positive?
-    #[expect(clippy::trivially_copy_pass_by_ref)]
+    #[allow(clippy::trivially_copy_pass_by_ref)]
     pub(super) fn format(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
         self.value.fmt(f)
     }
@@ -61,7 +61,7 @@ impl<'fmt, Context> Arguments<'fmt, Context> {
 
     /// Returns the arguments
     #[inline]
-    #[expect(clippy::trivially_copy_pass_by_ref)] // Bug in Clippy? Sizeof Arguments is 16
+    #[allow(clippy::trivially_copy_pass_by_ref)] // Bug in Clippy? Sizeof Arguments is 16
     pub(super) fn items(&self) -> &'fmt [Argument<'fmt, Context>] {
         self.0
     }

--- a/crates/ruff_formatter/src/arguments.rs
+++ b/crates/ruff_formatter/src/arguments.rs
@@ -24,7 +24,7 @@ impl<'fmt, Context> Argument<'fmt, Context> {
     /// Formats the value stored by this argument using the given formatter.
     #[inline]
     // Seems to only be triggered on wasm32 and looks like a false positive?
-    #[allow(clippy::trivially_copy_pass_by_ref)]
+    #[expect(clippy::trivially_copy_pass_by_ref)]
     pub(super) fn format(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
         self.value.fmt(f)
     }
@@ -61,7 +61,7 @@ impl<'fmt, Context> Arguments<'fmt, Context> {
 
     /// Returns the arguments
     #[inline]
-    #[allow(clippy::trivially_copy_pass_by_ref)] // Bug in Clippy? Sizeof Arguments is 16
+    #[expect(clippy::trivially_copy_pass_by_ref)] // Bug in Clippy? Sizeof Arguments is 16
     pub(super) fn items(&self) -> &'fmt [Argument<'fmt, Context>] {
         self.0
     }

--- a/crates/ruff_formatter/src/builders.rs
+++ b/crates/ruff_formatter/src/builders.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use std::num::NonZeroU8;
 
 use ruff_text_size::TextRange;
-#[expect(clippy::enum_glob_use)]
+#[allow(clippy::enum_glob_use)]
 use Tag::*;
 
 use crate::format_element::tag::{Condition, Tag};

--- a/crates/ruff_formatter/src/builders.rs
+++ b/crates/ruff_formatter/src/builders.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use std::num::NonZeroU8;
 
 use ruff_text_size::TextRange;
-#[allow(clippy::enum_glob_use)]
+#[expect(clippy::enum_glob_use)]
 use Tag::*;
 
 use crate::format_element::tag::{Condition, Tag};

--- a/crates/ruff_formatter/src/format_element.rs
+++ b/crates/ruff_formatter/src/format_element.rs
@@ -519,7 +519,7 @@ impl TextWidth {
             let char_width = match c {
                 '\t' => indent_width.value(),
                 '\n' => return TextWidth::Multiline,
-                #[allow(clippy::cast_possible_truncation)]
+                #[expect(clippy::cast_possible_truncation)]
                 c => c.width().unwrap_or(0) as u32,
             };
             width += char_width;

--- a/crates/ruff_formatter/src/format_element/document.rs
+++ b/crates/ruff_formatter/src/format_element/document.rs
@@ -254,7 +254,7 @@ impl FormatOptions for IrFormatOptions {
 
 impl Format<IrFormatContext<'_>> for &[FormatElement] {
     fn fmt(&self, f: &mut Formatter<IrFormatContext>) -> FormatResult<()> {
-        #[allow(clippy::enum_glob_use)]
+        #[expect(clippy::enum_glob_use)]
         use Tag::*;
 
         write!(f, [ContentArrayStart])?;
@@ -280,7 +280,7 @@ impl Format<IrFormatContext<'_>> for &[FormatElement] {
                 | FormatElement::SourceCodeSlice { .. }) => {
                     fn write_escaped(element: &FormatElement, f: &mut Formatter<IrFormatContext>) {
                         let (text, text_width) = match element {
-                            #[allow(clippy::cast_possible_truncation)]
+                            #[expect(clippy::cast_possible_truncation)]
                             FormatElement::Token { text } => {
                                 (*text, TextWidth::Width(Width::new(text.len() as u32)))
                             }

--- a/crates/ruff_formatter/src/format_element/document.rs
+++ b/crates/ruff_formatter/src/format_element/document.rs
@@ -254,7 +254,7 @@ impl FormatOptions for IrFormatOptions {
 
 impl Format<IrFormatContext<'_>> for &[FormatElement] {
     fn fmt(&self, f: &mut Formatter<IrFormatContext>) -> FormatResult<()> {
-        #[expect(clippy::enum_glob_use)]
+        #[allow(clippy::enum_glob_use)]
         use Tag::*;
 
         write!(f, [ContentArrayStart])?;

--- a/crates/ruff_formatter/src/format_element/tag.rs
+++ b/crates/ruff_formatter/src/format_element/tag.rs
@@ -127,7 +127,7 @@ impl Tag {
     }
 
     pub const fn kind(&self) -> TagKind {
-        #[allow(clippy::enum_glob_use)]
+        #[expect(clippy::enum_glob_use)]
         use Tag::*;
 
         match self {
@@ -379,7 +379,7 @@ impl PartialEq for LabelId {
 }
 
 impl LabelId {
-    #[allow(clippy::needless_pass_by_value)]
+    #[expect(clippy::needless_pass_by_value)]
     pub fn of<T: LabelDefinition>(label: T) -> Self {
         Self {
             value: label.value(),

--- a/crates/ruff_formatter/src/format_element/tag.rs
+++ b/crates/ruff_formatter/src/format_element/tag.rs
@@ -127,7 +127,7 @@ impl Tag {
     }
 
     pub const fn kind(&self) -> TagKind {
-        #[expect(clippy::enum_glob_use)]
+        #[allow(clippy::enum_glob_use)]
         use Tag::*;
 
         match self {

--- a/crates/ruff_formatter/src/lib.rs
+++ b/crates/ruff_formatter/src/lib.rs
@@ -925,7 +925,7 @@ pub struct FormatState<Context> {
     group_id_builder: UniqueGroupIdBuilder,
 }
 
-#[allow(clippy::missing_fields_in_debug)]
+#[expect(clippy::missing_fields_in_debug)]
 impl<Context> std::fmt::Debug for FormatState<Context>
 where
     Context: std::fmt::Debug,

--- a/crates/ruff_formatter/src/printer/mod.rs
+++ b/crates/ruff_formatter/src/printer/mod.rs
@@ -94,7 +94,7 @@ impl<'a> Printer<'a> {
         queue: &mut PrintQueue<'a>,
         element: &'a FormatElement,
     ) -> PrintResult<()> {
-        #[expect(clippy::enum_glob_use)]
+        #[allow(clippy::enum_glob_use)]
         use Tag::*;
 
         let args = stack.top();
@@ -1151,7 +1151,7 @@ impl<'a, 'print> FitsMeasurer<'a, 'print> {
 
     /// Tests if the passed element fits on the current line or not.
     fn fits_element(&mut self, element: &'a FormatElement) -> PrintResult<Fits> {
-        #[expect(clippy::enum_glob_use)]
+        #[allow(clippy::enum_glob_use)]
         use Tag::*;
 
         let args = self.stack.top();

--- a/crates/ruff_formatter/src/printer/mod.rs
+++ b/crates/ruff_formatter/src/printer/mod.rs
@@ -94,7 +94,7 @@ impl<'a> Printer<'a> {
         queue: &mut PrintQueue<'a>,
         element: &'a FormatElement,
     ) -> PrintResult<()> {
-        #[allow(clippy::enum_glob_use)]
+        #[expect(clippy::enum_glob_use)]
         use Tag::*;
 
         let args = stack.top();
@@ -331,7 +331,7 @@ impl<'a> Printer<'a> {
             FormatElement::Tag(StartVerbatim(kind)) => {
                 if let VerbatimKind::Verbatim { length } = kind {
                     // SAFETY: Ruff only supports formatting files <= 4GB
-                    #[allow(clippy::cast_possible_truncation)]
+                    #[expect(clippy::cast_possible_truncation)]
                     self.state.verbatim_markers.push(TextRange::at(
                         TextSize::from(self.state.buffer.len() as u32),
                         *length,
@@ -464,7 +464,7 @@ impl<'a> Printer<'a> {
         self.push_marker();
 
         match text {
-            #[allow(clippy::cast_possible_truncation)]
+            #[expect(clippy::cast_possible_truncation)]
             Text::Token(token) => {
                 self.state.buffer.push_str(token);
                 self.state.line_width += token.len() as u32;
@@ -831,7 +831,7 @@ impl<'a> Printer<'a> {
         } else {
             self.state.buffer.push(char);
 
-            #[allow(clippy::cast_possible_truncation)]
+            #[expect(clippy::cast_possible_truncation)]
             let char_width = if char == '\t' {
                 self.options.indent_width.value()
             } else {
@@ -1151,7 +1151,7 @@ impl<'a, 'print> FitsMeasurer<'a, 'print> {
 
     /// Tests if the passed element fits on the current line or not.
     fn fits_element(&mut self, element: &'a FormatElement) -> PrintResult<Fits> {
-        #[allow(clippy::enum_glob_use)]
+        #[expect(clippy::enum_glob_use)]
         use Tag::*;
 
         let args = self.stack.top();
@@ -1480,7 +1480,7 @@ impl<'a, 'print> FitsMeasurer<'a, 'print> {
             u32::from(indent.level()) * self.options().indent_width() + u32::from(indent.align());
 
         match text {
-            #[allow(clippy::cast_possible_truncation)]
+            #[expect(clippy::cast_possible_truncation)]
             Text::Token(token) => {
                 self.state.line_width += token.len() as u32;
             }
@@ -1511,7 +1511,7 @@ impl<'a, 'print> FitsMeasurer<'a, 'print> {
                                 }
                             }
                             // SAFETY: A u32 is sufficient to format files <= 4GB
-                            #[allow(clippy::cast_possible_truncation)]
+                            #[expect(clippy::cast_possible_truncation)]
                             c => c.width().unwrap_or(0) as u32,
                         };
                         self.state.line_width += char_width;

--- a/crates/ruff_index/src/slice.rs
+++ b/crates/ruff_index/src/slice.rs
@@ -22,7 +22,7 @@ impl<I: Idx, T> IndexSlice<I, T> {
     pub const fn from_raw(raw: &[T]) -> &Self {
         let ptr: *const [T] = raw;
 
-        #[allow(unsafe_code)]
+        #[expect(unsafe_code)]
         // SAFETY: `IndexSlice` is `repr(transparent)` over a normal slice
         unsafe {
             &*(ptr as *const Self)
@@ -33,7 +33,7 @@ impl<I: Idx, T> IndexSlice<I, T> {
     pub fn from_raw_mut(raw: &mut [T]) -> &mut Self {
         let ptr: *mut [T] = raw;
 
-        #[allow(unsafe_code)]
+        #[expect(unsafe_code)]
         // SAFETY: `IndexSlice` is `repr(transparent)` over a normal slice
         unsafe {
             &mut *(ptr as *mut Self)
@@ -209,5 +209,5 @@ impl<I: Idx, T> Default for &mut IndexSlice<I, T> {
 
 // Whether `IndexSlice` is `Send` depends only on the data,
 // not the phantom data.
-#[allow(unsafe_code)]
+#[expect(unsafe_code)]
 unsafe impl<I: Idx, T> Send for IndexSlice<I, T> where T: Send {}

--- a/crates/ruff_index/src/vec.rs
+++ b/crates/ruff_index/src/vec.rs
@@ -179,16 +179,16 @@ impl<I: Idx, T, const N: usize> From<[T; N]> for IndexVec<I, T> {
 
 // Whether `IndexVec` is `Send` depends only on the data,
 // not the phantom data.
-#[allow(unsafe_code)]
+#[expect(unsafe_code)]
 unsafe impl<I: Idx, T> Send for IndexVec<I, T> where T: Send {}
 
-#[allow(unsafe_code)]
+#[expect(unsafe_code)]
 #[cfg(feature = "salsa")]
 unsafe impl<I, T> salsa::Update for IndexVec<I, T>
 where
     T: salsa::Update,
 {
-    #[allow(unsafe_code)]
+    #[expect(unsafe_code)]
     unsafe fn maybe_update(old_pointer: *mut Self, new_value: Self) -> bool {
         let old_vec: &mut IndexVec<I, T> = unsafe { &mut *old_pointer };
         salsa::Update::maybe_update(&mut old_vec.raw, new_value.raw)

--- a/crates/ruff_linter/src/checkers/ast/analyze/definitions.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/definitions.rs
@@ -184,7 +184,7 @@ pub(crate) fn definitions(checker: &mut Checker) {
 
             // We don't recognise implicitly concatenated strings as valid docstrings in our model currently.
             let Some(sole_string_part) = string_literal.as_single_part_string() else {
-                #[allow(deprecated)]
+                #[expect(deprecated)]
                 let location = checker
                     .locator
                     .compute_source_location(string_literal.start());

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -234,14 +234,14 @@ pub(crate) struct Checker<'a> {
     /// The target [`PythonVersion`] for version-dependent checks.
     target_version: PythonVersion,
     /// Helper visitor for detecting semantic syntax errors.
-    #[allow(clippy::struct_field_names)]
+    #[expect(clippy::struct_field_names)]
     semantic_checker: SemanticSyntaxChecker,
     /// Errors collected by the `semantic_checker`.
     semantic_errors: RefCell<Vec<SemanticSyntaxError>>,
 }
 
 impl<'a> Checker<'a> {
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub(crate) fn new(
         parsed: &'a Parsed<ModModule>,
         parsed_annotations_arena: &'a typed_arena::Arena<Result<ParsedAnnotation, ParseError>>,
@@ -362,7 +362,7 @@ impl<'a> Checker<'a> {
 
     /// Returns the [`SourceRow`] for the given offset.
     pub(crate) fn compute_source_row(&self, offset: TextSize) -> SourceRow {
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         let line = self.locator.compute_line_index(offset);
 
         if let Some(notebook_index) = self.notebook_index {
@@ -2909,7 +2909,7 @@ impl<'a> ParsedAnnotationsCache<'a> {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub(crate) fn check_ast(
     parsed: &Parsed<ModModule>,
     locator: &Locator,

--- a/crates/ruff_linter/src/checkers/imports.rs
+++ b/crates/ruff_linter/src/checkers/imports.rs
@@ -16,7 +16,7 @@ use crate::rules::isort::block::{Block, BlockBuilder};
 use crate::settings::LinterSettings;
 use crate::Locator;
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub(crate) fn check_imports(
     parsed: &Parsed<ModModule>,
     locator: &Locator,

--- a/crates/ruff_linter/src/checkers/noqa.rs
+++ b/crates/ruff_linter/src/checkers/noqa.rs
@@ -22,7 +22,7 @@ use crate::rules::ruff::rules::{UnusedCodes, UnusedNOQA};
 use crate::settings::LinterSettings;
 use crate::Locator;
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub(crate) fn check_noqa(
     diagnostics: &mut Vec<Diagnostic>,
     path: &Path,

--- a/crates/ruff_linter/src/checkers/tokens.rs
+++ b/crates/ruff_linter/src/checkers/tokens.rs
@@ -19,7 +19,7 @@ use crate::rules::{
 use crate::settings::LinterSettings;
 use crate::Locator;
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub(crate) fn check_tokens(
     tokens: &Tokens,
     path: &Path,

--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -61,7 +61,7 @@ pub enum RuleGroup {
 
 #[ruff_macros::map_codes]
 pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
-    #[allow(clippy::enum_glob_use)]
+    #[expect(clippy::enum_glob_use)]
     use Linter::*;
 
     #[rustfmt::skip]

--- a/crates/ruff_linter/src/docstrings/sections.rs
+++ b/crates/ruff_linter/src/docstrings/sections.rs
@@ -418,7 +418,7 @@ fn suspected_as_section(line: &str, style: SectionStyle) -> Option<SectionKind> 
 }
 
 /// Check if the suspected context is really a section header.
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn is_docstring_section(
     line: &Line,
     indent_size: TextSize,

--- a/crates/ruff_linter/src/fix/mod.rs
+++ b/crates/ruff_linter/src/fix/mod.rs
@@ -172,7 +172,6 @@ mod tests {
     use crate::rules::pycodestyle::rules::MissingNewlineAtEndOfFile;
     use crate::Locator;
 
-    #[allow(deprecated)]
     fn create_diagnostics(
         filename: &str,
         source: &str,

--- a/crates/ruff_linter/src/linter.rs
+++ b/crates/ruff_linter/src/linter.rs
@@ -98,7 +98,7 @@ pub struct FixerResult<'a> {
 }
 
 /// Generate [`Message`]s from the source code contents at the given `Path`.
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub fn check_path(
     path: &Path,
     package: Option<PackageRoot<'_>>,
@@ -538,7 +538,7 @@ fn diagnostics_to_messages(
 
 /// Generate `Diagnostic`s from source code content, iteratively fixing
 /// until stable.
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub fn lint_fix<'a>(
     path: &Path,
     package: Option<PackageRoot<'_>>,
@@ -672,7 +672,7 @@ fn collect_rule_codes(rules: impl IntoIterator<Item = Rule>) -> String {
         .join(", ")
 }
 
-#[allow(clippy::print_stderr)]
+#[expect(clippy::print_stderr)]
 fn report_failed_to_converge_error(path: &Path, transformed: &str, messages: &[Message]) {
     let codes = collect_rule_codes(messages.iter().filter_map(Message::rule));
     if cfg!(debug_assertions) {
@@ -705,7 +705,7 @@ This indicates a bug in Ruff. If you could open an issue at:
     }
 }
 
-#[allow(clippy::print_stderr)]
+#[expect(clippy::print_stderr)]
 fn report_fix_syntax_error(
     path: &Path,
     transformed: &str,

--- a/crates/ruff_linter/src/linter.rs
+++ b/crates/ruff_linter/src/linter.rs
@@ -538,7 +538,6 @@ fn diagnostics_to_messages(
 
 /// Generate `Diagnostic`s from source code content, iteratively fixing
 /// until stable.
-#[expect(clippy::too_many_arguments)]
 pub fn lint_fix<'a>(
     path: &Path,
     package: Option<PackageRoot<'_>>,

--- a/crates/ruff_linter/src/logging.rs
+++ b/crates/ruff_linter/src/logging.rs
@@ -109,7 +109,7 @@ pub enum LogLevel {
 }
 
 impl LogLevel {
-    #[allow(clippy::trivially_copy_pass_by_ref)]
+    #[expect(clippy::trivially_copy_pass_by_ref)]
     const fn level_filter(&self) -> log::LevelFilter {
         match self {
             LogLevel::Default => log::LevelFilter::Info,

--- a/crates/ruff_linter/src/message/sarif.rs
+++ b/crates/ruff_linter/src/message/sarif.rs
@@ -137,7 +137,7 @@ impl SarifResult {
     }
 
     #[cfg(target_arch = "wasm32")]
-    #[allow(clippy::unnecessary_wraps)]
+    #[expect(clippy::unnecessary_wraps)]
     fn from_message(message: &Message) -> Result<Self> {
         let start_location = message.compute_start_location();
         let end_location = message.compute_end_location();

--- a/crates/ruff_linter/src/noqa.rs
+++ b/crates/ruff_linter/src/noqa.rs
@@ -238,7 +238,7 @@ impl<'a> FileNoqaDirectives<'a> {
                     let no_indentation_at_offset =
                         indentation_at_offset(range.start(), locator.contents()).is_none();
                     if !warnings.is_empty() || no_indentation_at_offset {
-                        #[allow(deprecated)]
+                        #[expect(deprecated)]
                         let line = locator.compute_line_index(range.start());
                         let path_display = relativize_path(path);
 
@@ -268,7 +268,7 @@ impl<'a> FileNoqaDirectives<'a> {
                                 {
                                     Some(rule.noqa_code())
                                 } else {
-                                    #[allow(deprecated)]
+                                    #[expect(deprecated)]
                                     let line = locator.compute_line_index(range.start());
                                     let path_display = relativize_path(path);
                                     warn!("Invalid rule code provided to `# ruff: noqa` at {path_display}:{line}: {code}");
@@ -285,7 +285,7 @@ impl<'a> FileNoqaDirectives<'a> {
                     });
                 }
                 Err(err) => {
-                    #[allow(deprecated)]
+                    #[expect(deprecated)]
                     let line = locator.compute_line_index(range.start());
                     let path_display = relativize_path(path);
                     warn!("Invalid `# ruff: noqa` directive at {path_display}:{line}: {err}");
@@ -1053,7 +1053,7 @@ impl<'a> NoqaDirectives<'a> {
                     directive,
                 })) => {
                     if !warnings.is_empty() {
-                        #[allow(deprecated)]
+                        #[expect(deprecated)]
                         let line = locator.compute_line_index(range.start());
                         let path_display = relativize_path(path);
                         for warning in warnings {
@@ -1073,7 +1073,7 @@ impl<'a> NoqaDirectives<'a> {
                                 )
                                 .is_err()
                                 {
-                                    #[allow(deprecated)]
+                                    #[expect(deprecated)]
                                     let line = locator.compute_line_index(range.start());
                                     let path_display = relativize_path(path);
                                     warn!("Invalid rule code provided to `# noqa` at {path_display}:{line}: {code}");
@@ -1091,7 +1091,7 @@ impl<'a> NoqaDirectives<'a> {
                     });
                 }
                 Err(err) => {
-                    #[allow(deprecated)]
+                    #[expect(deprecated)]
                     let line = locator.compute_line_index(range.start());
                     let path_display = relativize_path(path);
                     warn!("Invalid `# noqa` directive on {path_display}:{line}: {err}");

--- a/crates/ruff_linter/src/registry/rule_set.rs
+++ b/crates/ruff_linter/src/registry/rule_set.rs
@@ -16,7 +16,7 @@ pub struct RuleSet([u64; RULESET_SIZE]);
 impl RuleSet {
     const EMPTY: [u64; RULESET_SIZE] = [0; RULESET_SIZE];
     // 64 fits into a u16 without truncation
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     const SLICE_BITS: u16 = u64::BITS as u16;
 
     /// Returns an empty rule set.
@@ -361,14 +361,14 @@ impl Iterator for RuleSetIterator {
         loop {
             let slice = self.set.0.get_mut(self.index as usize)?;
             // `trailing_zeros` is guaranteed to return a value in [0;64]
-            #[allow(clippy::cast_possible_truncation)]
+            #[expect(clippy::cast_possible_truncation)]
             let bit = slice.trailing_zeros() as u16;
 
             if bit < RuleSet::SLICE_BITS {
                 *slice ^= 1 << bit;
                 let rule_value = self.index * RuleSet::SLICE_BITS + bit;
                 // SAFETY: RuleSet guarantees that only valid rules are stored in the set.
-                #[allow(unsafe_code)]
+                #[expect(unsafe_code)]
                 return Some(unsafe { std::mem::transmute::<u16, Rule>(rule_value) });
             }
 

--- a/crates/ruff_linter/src/rule_selector.rs
+++ b/crates/ruff_linter/src/rule_selector.rs
@@ -314,7 +314,7 @@ mod schema {
                     .filter(|_rule| {
                         // Filter out all test-only rules
                         #[cfg(any(feature = "test-rules", test))]
-                        #[allow(clippy::used_underscore_binding)]
+                        #[expect(clippy::used_underscore_binding)]
                         if _rule.starts_with("RUF9") || _rule == "PLW0101" {
                             return false;
                         }

--- a/crates/ruff_linter/src/rules/fastapi/rules/fastapi_unused_path_parameter.rs
+++ b/crates/ruff_linter/src/rules/fastapi/rules/fastapi_unused_path_parameter.rs
@@ -79,7 +79,7 @@ impl Violation for FastApiUnusedPathParameter {
             function_name,
             is_positional,
         } = self;
-        #[allow(clippy::if_not_else)]
+        #[expect(clippy::if_not_else)]
         if !is_positional {
             format!("Parameter `{arg_name}` appears in route path, but not in `{function_name}` signature")
         } else {
@@ -190,7 +190,7 @@ pub(crate) fn fastapi_unused_path_parameter(
                 function_name: function_def.name.to_string(),
                 is_positional,
             },
-            #[allow(clippy::cast_possible_truncation)]
+            #[expect(clippy::cast_possible_truncation)]
             diagnostic_range
                 .add_start(TextSize::from(range.start as u32 + 1))
                 .sub_end(TextSize::from((path.len() - range.end + 1) as u32)),
@@ -424,7 +424,7 @@ impl<'a> Iterator for PathParamIterator<'a> {
                     let param_name_end = param_content.find(':').unwrap_or(param_content.len());
                     let param_name = &param_content[..param_name_end].trim();
 
-                    #[allow(clippy::range_plus_one)]
+                    #[expect(clippy::range_plus_one)]
                     return Some((param_name, start..end + 1));
                 }
             }

--- a/crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs
+++ b/crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs
@@ -150,7 +150,7 @@ impl Violation for MissingTypeKwargs {
 #[deprecated(note = "ANN101 has been removed")]
 pub(crate) struct MissingTypeSelf;
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 impl Violation for MissingTypeSelf {
     fn message(&self) -> String {
         unreachable!("ANN101 has been removed");
@@ -194,7 +194,7 @@ impl Violation for MissingTypeSelf {
 #[deprecated(note = "ANN102 has been removed")]
 pub(crate) struct MissingTypeCls;
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 impl Violation for MissingTypeCls {
     fn message(&self) -> String {
         unreachable!("ANN102 has been removed")

--- a/crates/ruff_linter/src/rules/flake8_annotations/settings.rs
+++ b/crates/ruff_linter/src/rules/flake8_annotations/settings.rs
@@ -5,7 +5,7 @@ use ruff_macros::CacheKey;
 use std::fmt::{Display, Formatter};
 
 #[derive(Debug, Clone, Default, CacheKey)]
-#[allow(clippy::struct_excessive_bools)]
+#[expect(clippy::struct_excessive_bools)]
 pub struct Settings {
     pub mypy_init_return: bool,
     pub suppress_dummy_args: bool,

--- a/crates/ruff_linter/src/rules/flake8_async/rules/async_function_with_timeout.rs
+++ b/crates/ruff_linter/src/rules/flake8_async/rules/async_function_with_timeout.rs
@@ -8,7 +8,7 @@ use crate::checkers::ast::Checker;
 use crate::rules::flake8_async::helpers::AsyncModule;
 use ruff_python_ast::PythonVersion;
 
-#[allow(clippy::doc_link_with_quotes)]
+#[expect(clippy::doc_link_with_quotes)]
 /// ## What it does
 /// Checks for `async` function definitions with `timeout` parameters.
 ///

--- a/crates/ruff_linter/src/rules/flake8_async/rules/long_sleep_not_forever.rs
+++ b/crates/ruff_linter/src/rules/flake8_async/rules/long_sleep_not_forever.rs
@@ -92,7 +92,7 @@ pub(crate) fn long_sleep_not_forever(checker: &Checker, call: &ExprCall) {
         }
         Number::Float(float_value) =>
         {
-            #[allow(clippy::cast_precision_loss)]
+            #[expect(clippy::cast_precision_loss)]
             if *float_value <= one_day_in_secs as f64 {
                 return;
             }

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
@@ -133,7 +133,7 @@ pub(crate) fn mutable_argument_default(checker: &Checker, function_def: &ast::St
 
 /// Generate a [`Fix`] to move a mutable argument default initialization
 /// into the function body.
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn move_initialization(
     function_def: &ast::StmtFunctionDef,
     parameter: &Parameter,

--- a/crates/ruff_linter/src/rules/flake8_commas/rules/trailing_commas.rs
+++ b/crates/ruff_linter/src/rules/flake8_commas/rules/trailing_commas.rs
@@ -74,7 +74,7 @@ impl From<(TokenKind, TextRange)> for SimpleToken {
             TokenKind::Import => TokenType::Named,
             _ => TokenType::Irrelevant,
         };
-        #[allow(clippy::inconsistent_struct_constructor)]
+        #[expect(clippy::inconsistent_struct_constructor)]
         Self { range, ty }
     }
 }

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/fixture.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/fixture.rs
@@ -218,7 +218,7 @@ impl AlwaysFixableViolation for PytestExtraneousScopeFunction {
 #[deprecated(note = "PT004 has been removed")]
 pub(crate) struct PytestMissingFixtureNameUnderscore;
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 impl Violation for PytestMissingFixtureNameUnderscore {
     fn message(&self) -> String {
         unreachable!("PT004 has been removed");
@@ -283,7 +283,7 @@ impl Violation for PytestMissingFixtureNameUnderscore {
 #[deprecated(note = "PT005 has been removed")]
 pub(crate) struct PytestIncorrectFixtureNameUnderscore;
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 impl Violation for PytestIncorrectFixtureNameUnderscore {
     fn message(&self) -> String {
         unreachable!("PT005 has been removed");

--- a/crates/ruff_linter/src/rules/isort/categorize.rs
+++ b/crates/ruff_linter/src/rules/isort/categorize.rs
@@ -79,16 +79,16 @@ enum Reason<'a> {
     Future,
     KnownStandardLibrary,
     SamePackage,
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     SourceMatch(&'a Path),
     NoMatch,
     UserDefinedSection,
     NoSections,
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     DisabledSection(&'a ImportSection),
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub(crate) fn categorize<'a>(
     module_name: &str,
     is_relative: bool,
@@ -172,7 +172,7 @@ fn match_sources<'a>(paths: &'a [PathBuf], base: &str) -> Option<&'a Path> {
     None
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub(crate) fn categorize_imports<'a>(
     block: ImportBlock<'a>,
     src: &[PathBuf],

--- a/crates/ruff_linter/src/rules/isort/format.rs
+++ b/crates/ruff_linter/src/rules/isort/format.rs
@@ -40,7 +40,7 @@ pub(crate) fn format_import(
 }
 
 /// Add an import-from statement to the [`RopeBuilder`].
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub(crate) fn format_import_from(
     import_from: &ImportFromData,
     comments: &ImportFromCommentSet,

--- a/crates/ruff_linter/src/rules/isort/mod.rs
+++ b/crates/ruff_linter/src/rules/isort/mod.rs
@@ -63,7 +63,7 @@ pub(crate) enum AnnotatedImport<'a> {
     },
 }
 
-#[expect(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
+#[expect(clippy::too_many_arguments)]
 pub(crate) fn format_imports(
     block: &Block,
     comments: Vec<Comment>,
@@ -149,7 +149,7 @@ pub(crate) fn format_imports(
     output
 }
 
-#[expect(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
+#[expect(clippy::too_many_arguments)]
 fn format_import_block(
     block: ImportBlock,
     line_length: LineLength,

--- a/crates/ruff_linter/src/rules/isort/mod.rs
+++ b/crates/ruff_linter/src/rules/isort/mod.rs
@@ -63,7 +63,7 @@ pub(crate) enum AnnotatedImport<'a> {
     },
 }
 
-#[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
+#[expect(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
 pub(crate) fn format_imports(
     block: &Block,
     comments: Vec<Comment>,
@@ -149,7 +149,7 @@ pub(crate) fn format_imports(
     output
 }
 
-#[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
+#[expect(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
 fn format_import_block(
     block: ImportBlock,
     line_length: LineLength,

--- a/crates/ruff_linter/src/rules/isort/rules/add_required_imports.rs
+++ b/crates/ruff_linter/src/rules/isort/rules/add_required_imports.rs
@@ -85,7 +85,6 @@ fn includes_import(stmt: &Stmt, target: &NameImport) -> bool {
     }
 }
 
-#[expect(clippy::too_many_arguments)]
 fn add_required_import(
     required_import: &NameImport,
     parsed: &Parsed<ModModule>,

--- a/crates/ruff_linter/src/rules/isort/rules/add_required_imports.rs
+++ b/crates/ruff_linter/src/rules/isort/rules/add_required_imports.rs
@@ -85,7 +85,7 @@ fn includes_import(stmt: &Stmt, target: &NameImport) -> bool {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn add_required_import(
     required_import: &NameImport,
     parsed: &Parsed<ModModule>,

--- a/crates/ruff_linter/src/rules/isort/rules/organize_imports.rs
+++ b/crates/ruff_linter/src/rules/isort/rules/organize_imports.rs
@@ -77,7 +77,7 @@ fn matches_ignoring_indentation(val1: &str, val2: &str) -> bool {
         })
 }
 
-#[allow(clippy::cast_sign_loss, clippy::too_many_arguments)]
+#[expect(clippy::cast_sign_loss, clippy::too_many_arguments)]
 /// I001
 pub(crate) fn organize_imports(
     block: &Block,

--- a/crates/ruff_linter/src/rules/isort/rules/organize_imports.rs
+++ b/crates/ruff_linter/src/rules/isort/rules/organize_imports.rs
@@ -77,7 +77,7 @@ fn matches_ignoring_indentation(val1: &str, val2: &str) -> bool {
         })
 }
 
-#[expect(clippy::cast_sign_loss, clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 /// I001
 pub(crate) fn organize_imports(
     block: &Block,

--- a/crates/ruff_linter/src/rules/isort/settings.rs
+++ b/crates/ruff_linter/src/rules/isort/settings.rs
@@ -45,7 +45,7 @@ impl Display for RelativeImportsOrder {
 }
 
 #[derive(Debug, Clone, CacheKey)]
-#[allow(clippy::struct_excessive_bools)]
+#[expect(clippy::struct_excessive_bools)]
 pub struct Settings {
     pub required_imports: BTreeSet<NameImport>,
     pub combine_as_imports: bool,

--- a/crates/ruff_linter/src/rules/pep8_naming/rules/invalid_first_argument_name.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/rules/invalid_first_argument_name.rs
@@ -143,7 +143,7 @@ impl Violation for InvalidFirstArgumentNameForClassMethod {
     #[derive_message_formats]
     // The first string below is what shows up in the documentation
     // in the rule table, and it is the more common case.
-    #[allow(clippy::if_not_else)]
+    #[expect(clippy::if_not_else)]
     fn message(&self) -> String {
         if !self.is_new {
             "First argument of a class method should be named `cls`".to_string()

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/blank_lines.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/blank_lines.rs
@@ -818,7 +818,7 @@ impl<'a> BlankLinesChecker<'a> {
         }
     }
 
-    #[allow(clippy::nonminimal_bool)]
+    #[expect(clippy::nonminimal_bool)]
     fn check_line(
         &self,
         line: &LogicalLineInfo,

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/errors.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/errors.rs
@@ -66,7 +66,7 @@ impl Violation for IOError {
 #[deprecated(note = "E999 has been removed")]
 pub(crate) struct SyntaxError;
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 impl Violation for SyntaxError {
     fn message(&self) -> String {
         unreachable!("E999 has been removed")

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/mod.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/mod.rs
@@ -392,7 +392,6 @@ impl LogicalLinesBuilder {
     }
 
     // SAFETY: `LogicalLines::from_tokens` asserts that the file has less than `u32::MAX` tokens and each tokens is at least one character long
-    #[expect(clippy::cast_possible_truncation)]
     fn push_token(&mut self, kind: TokenKind, range: TextRange) {
         let line = &mut self.current_line;
 

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/mod.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/mod.rs
@@ -392,7 +392,7 @@ impl LogicalLinesBuilder {
     }
 
     // SAFETY: `LogicalLines::from_tokens` asserts that the file has less than `u32::MAX` tokens and each tokens is at least one character long
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     fn push_token(&mut self, kind: TokenKind, range: TextRange) {
         let line = &mut self.current_line;
 
@@ -428,7 +428,7 @@ impl LogicalLinesBuilder {
     }
 
     // SAFETY: `LogicalLines::from_tokens` asserts that the file has less than `u32::MAX` tokens and each tokens is at least one character long
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     fn finish_line(&mut self) {
         let end = self.tokens.len() as u32;
         if self.current_line.tokens_start < end {

--- a/crates/ruff_linter/src/rules/pydoclint/rules/check_docstring.rs
+++ b/crates/ruff_linter/src/rules/pydoclint/rules/check_docstring.rs
@@ -523,7 +523,7 @@ impl Ranged for YieldEntry {
     }
 }
 
-#[allow(clippy::enum_variant_names)]
+#[expect(clippy::enum_variant_names)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ReturnEntryKind {
     NotNone,

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/indent.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/indent.rs
@@ -10,7 +10,7 @@ use crate::checkers::ast::Checker;
 use crate::docstrings::Docstring;
 use crate::registry::Rule;
 
-#[allow(clippy::tabs_in_doc_comments)]
+#[expect(clippy::tabs_in_doc_comments)]
 /// ## What it does
 /// Checks for docstrings that are indented with tabs.
 ///

--- a/crates/ruff_linter/src/rules/pylint/rules/import_private_name.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/import_private_name.rs
@@ -151,7 +151,7 @@ fn is_typing(reference: &ResolvedReference) -> bool {
         || reference.in_runtime_evaluated_annotation()
 }
 
-#[allow(clippy::struct_field_names)]
+#[expect(clippy::struct_field_names)]
 struct ImportInfo<'a> {
     module_name: &'a [&'a str],
     member_name: Cow<'a, str>,

--- a/crates/ruff_linter/src/rules/pylint/rules/magic_value_comparison.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/magic_value_comparison.rs
@@ -89,7 +89,7 @@ fn is_magic_value(literal_expr: LiteralExpressionRef, allowed_types: &[ConstantT
             !matches!(value.to_str(), "" | "__main__")
         }
         LiteralExpressionRef::NumberLiteral(ast::ExprNumberLiteral { value, .. }) => match value {
-            #[allow(clippy::float_cmp)]
+            #[expect(clippy::float_cmp)]
             ast::Number::Float(value) => !(*value == 0.0 || *value == 1.0),
             ast::Number::Int(value) => !matches!(*value, Int::ZERO | Int::ONE),
             ast::Number::Complex { .. } => true,

--- a/crates/ruff_linter/src/rules/pylint/rules/unreachable.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/unreachable.rs
@@ -98,7 +98,7 @@ fn reachable(cfg: &ControlFlowGraph) -> HashSet<BlockId> {
 /// Returns `Some(true)` if the condition is always true, e.g. `if True`, same
 /// with `Some(false)` if it's never taken. If it can't be determined it returns
 /// `None`, e.g. `if i == 100`.
-#[allow(clippy::unnecessary_wraps)]
+#[expect(clippy::unnecessary_wraps)]
 fn taken(condition: &Condition) -> Option<bool> {
     match condition {
         Condition::Always => Some(true),

--- a/crates/ruff_linter/src/rules/pylint/rules/useless_import_alias.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/useless_import_alias.rs
@@ -37,7 +37,7 @@ impl Violation for UselessImportAlias {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        #[allow(clippy::if_not_else)]
+        #[expect(clippy::if_not_else)]
         if !self.required_import_conflict {
             "Import alias does not rename original package".to_string()
         } else {

--- a/crates/ruff_linter/src/rules/refurb/rules/math_constant.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/math_constant.rs
@@ -105,7 +105,7 @@ enum Constant {
 }
 
 impl Constant {
-    #[allow(clippy::approx_constant)]
+    #[expect(clippy::approx_constant)]
     fn from_value(value: f64) -> Option<Self> {
         if (3.14..3.15).contains(&value) {
             matches_constant(std::f64::consts::PI, value).then_some(Self::Pi)

--- a/crates/ruff_linter/src/rules/refurb/rules/redundant_log_base.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/redundant_log_base.rs
@@ -129,7 +129,7 @@ fn is_number_literal(expr: &Expr, value: i8) -> bool {
         if let Number::Int(number) = &number_literal.value {
             return number.as_i8().is_some_and(|number| number == value);
         } else if let Number::Float(number) = number_literal.value {
-            #[allow(clippy::float_cmp)]
+            #[expect(clippy::float_cmp)]
             return number == f64::from(value);
         }
     }

--- a/crates/ruff_linter/src/settings/types.rs
+++ b/crates/ruff_linter/src/settings/types.rs
@@ -249,12 +249,12 @@ pub struct FilePatternSet {
     cache_key: u64,
     // This field is only for displaying the internals
     // of `set`.
-    #[allow(clippy::used_underscore_binding)]
+    #[expect(clippy::used_underscore_binding)]
     _set_internals: Vec<FilePattern>,
 }
 
 impl FilePatternSet {
-    #[allow(clippy::used_underscore_binding)]
+    #[expect(clippy::used_underscore_binding)]
     pub fn try_from_iter<I>(patterns: I) -> Result<Self, anyhow::Error>
     where
         I: IntoIterator<Item = FilePattern>,

--- a/crates/ruff_macros/src/combine_options.rs
+++ b/crates/ruff_macros/src/combine_options.rs
@@ -19,7 +19,7 @@ pub(crate) fn derive_impl(input: DeriveInput) -> syn::Result<proc_macro2::TokenS
                 #[automatically_derived]
                 impl crate::configuration::CombinePluginOptions for #ident {
                     fn combine(self, other: Self) -> Self {
-                        #[allow(deprecated)]
+                        #[expect(deprecated)]
                         Self {
                         #(
                             #output

--- a/crates/ruff_macros/src/newtype_index.rs
+++ b/crates/ruff_macros/src/newtype_index.rs
@@ -48,7 +48,7 @@ pub(super) fn generate_newtype_index(item: ItemStruct) -> syn::Result<proc_macro
                 //
                 // N.B. We have to use the unchecked variant here because we're
                 // in a const context and Option::unwrap isn't const yet.
-                #[allow(unsafe_code)]
+                #[expect(unsafe_code)]
                 Self(unsafe { std::num::NonZeroU32::new_unchecked((value as u32) + 1) })
             }
 
@@ -61,7 +61,7 @@ pub(super) fn generate_newtype_index(item: ItemStruct) -> syn::Result<proc_macro
                 //
                 // N.B. We have to use the unchecked variant here because we're
                 // in a const context and Option::unwrap isn't const yet.
-                #[allow(unsafe_code)]
+                #[expect(unsafe_code)]
                 Self(unsafe { std::num::NonZeroU32::new_unchecked(value + 1) })
             }
 

--- a/crates/ruff_macros/src/violation_metadata.rs
+++ b/crates/ruff_macros/src/violation_metadata.rs
@@ -9,7 +9,7 @@ pub(crate) fn violation_metadata(input: DeriveInput) -> syn::Result<TokenStream>
 
     Ok(quote! {
         #[automatically_derived]
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         impl ruff_diagnostics::ViolationMetadata for #name {
             fn rule_name() -> &'static str {
                 stringify!(#name)

--- a/crates/ruff_python_ast/generate.py
+++ b/crates/ruff_python_ast/generate.py
@@ -341,7 +341,7 @@ def write_owned_enum(out: list[str], ast: Ast) -> None:
         """)
 
         out.append(
-            "#[expect(dead_code, clippy::match_wildcard_for_single_variants)]"
+            "#[allow(dead_code, clippy::match_wildcard_for_single_variants)]"
         )  # Not all is_methods are used
         out.append(f"impl {group.name} {{")
         for node in group.nodes:
@@ -439,7 +439,7 @@ def write_owned_enum(out: list[str], ast: Ast) -> None:
     for group in ast.groups:
         out.append(f"""
             impl {group.owned_enum_ty} {{
-                #[expect(unused)]
+                #[allow(unused)]
                 pub(crate) fn visit_source_order<'a, V>(&'a self, visitor: &mut V)
                 where
                     V: crate::visitor::source_order::SourceOrderVisitor<'a> + ?Sized,

--- a/crates/ruff_python_ast/generate.py
+++ b/crates/ruff_python_ast/generate.py
@@ -341,7 +341,7 @@ def write_owned_enum(out: list[str], ast: Ast) -> None:
         """)
 
         out.append(
-            "#[allow(dead_code, clippy::match_wildcard_for_single_variants)]"
+            "#[expect(dead_code, clippy::match_wildcard_for_single_variants)]"
         )  # Not all is_methods are used
         out.append(f"impl {group.name} {{")
         for node in group.nodes:
@@ -439,7 +439,7 @@ def write_owned_enum(out: list[str], ast: Ast) -> None:
     for group in ast.groups:
         out.append(f"""
             impl {group.owned_enum_ty} {{
-                #[allow(unused)]
+                #[expect(unused)]
                 pub(crate) fn visit_source_order<'a, V>(&'a self, visitor: &mut V)
                 where
                     V: crate::visitor::source_order::SourceOrderVisitor<'a> + ?Sized,

--- a/crates/ruff_python_ast/src/comparable.rs
+++ b/crates/ruff_python_ast/src/comparable.rs
@@ -226,7 +226,6 @@ pub struct PatternMatchOr<'a> {
     patterns: Vec<ComparablePattern<'a>>,
 }
 
-#[expect(clippy::enum_variant_names)]
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub enum ComparablePattern<'a> {
     MatchValue(PatternMatchValue<'a>),

--- a/crates/ruff_python_ast/src/comparable.rs
+++ b/crates/ruff_python_ast/src/comparable.rs
@@ -226,7 +226,7 @@ pub struct PatternMatchOr<'a> {
     patterns: Vec<ComparablePattern<'a>>,
 }
 
-#[allow(clippy::enum_variant_names)]
+#[expect(clippy::enum_variant_names)]
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub enum ComparablePattern<'a> {
     MatchValue(PatternMatchValue<'a>),

--- a/crates/ruff_python_ast/src/generated.rs
+++ b/crates/ruff_python_ast/src/generated.rs
@@ -32,7 +32,7 @@ impl ruff_text_size::Ranged for Mod {
     }
 }
 
-#[allow(dead_code, clippy::match_wildcard_for_single_variants)]
+#[expect(clippy::match_wildcard_for_single_variants)]
 impl Mod {
     #[inline]
     pub const fn is_module(&self) -> bool {
@@ -321,7 +321,7 @@ impl ruff_text_size::Ranged for Stmt {
     }
 }
 
-#[allow(dead_code, clippy::match_wildcard_for_single_variants)]
+#[expect(clippy::match_wildcard_for_single_variants)]
 impl Stmt {
     #[inline]
     pub const fn is_function_def_stmt(&self) -> bool {
@@ -1517,7 +1517,7 @@ impl ruff_text_size::Ranged for Expr {
     }
 }
 
-#[allow(dead_code, clippy::match_wildcard_for_single_variants)]
+#[expect(clippy::match_wildcard_for_single_variants)]
 impl Expr {
     #[inline]
     pub const fn is_bool_op_expr(&self) -> bool {
@@ -2724,7 +2724,7 @@ impl ruff_text_size::Ranged for ExceptHandler {
     }
 }
 
-#[allow(dead_code, clippy::match_wildcard_for_single_variants)]
+#[expect(clippy::match_wildcard_for_single_variants)]
 impl ExceptHandler {
     #[inline]
     pub const fn is_except_handler(&self) -> bool {
@@ -2787,7 +2787,7 @@ impl ruff_text_size::Ranged for FStringElement {
     }
 }
 
-#[allow(dead_code, clippy::match_wildcard_for_single_variants)]
+#[expect(clippy::match_wildcard_for_single_variants)]
 impl FStringElement {
     #[inline]
     pub const fn is_expression(&self) -> bool {
@@ -2940,7 +2940,7 @@ impl ruff_text_size::Ranged for Pattern {
     }
 }
 
-#[allow(dead_code, clippy::match_wildcard_for_single_variants)]
+#[expect(clippy::match_wildcard_for_single_variants)]
 impl Pattern {
     #[inline]
     pub const fn is_match_value(&self) -> bool {
@@ -3275,7 +3275,7 @@ impl ruff_text_size::Ranged for TypeParam {
     }
 }
 
-#[allow(dead_code, clippy::match_wildcard_for_single_variants)]
+#[expect(clippy::match_wildcard_for_single_variants)]
 impl TypeParam {
     #[inline]
     pub const fn is_type_var(&self) -> bool {
@@ -3942,7 +3942,7 @@ impl ruff_text_size::Ranged for crate::Identifier {
 }
 
 impl Mod {
-    #[allow(unused)]
+    #[expect(unused)]
     pub(crate) fn visit_source_order<'a, V>(&'a self, visitor: &mut V)
     where
         V: crate::visitor::source_order::SourceOrderVisitor<'a> + ?Sized,
@@ -3955,7 +3955,6 @@ impl Mod {
 }
 
 impl Stmt {
-    #[allow(unused)]
     pub(crate) fn visit_source_order<'a, V>(&'a self, visitor: &mut V)
     where
         V: crate::visitor::source_order::SourceOrderVisitor<'a> + ?Sized,
@@ -3991,7 +3990,7 @@ impl Stmt {
 }
 
 impl Expr {
-    #[allow(unused)]
+    #[expect(unused)]
     pub(crate) fn visit_source_order<'a, V>(&'a self, visitor: &mut V)
     where
         V: crate::visitor::source_order::SourceOrderVisitor<'a> + ?Sized,
@@ -4034,7 +4033,7 @@ impl Expr {
 }
 
 impl ExceptHandler {
-    #[allow(unused)]
+    #[expect(unused)]
     pub(crate) fn visit_source_order<'a, V>(&'a self, visitor: &mut V)
     where
         V: crate::visitor::source_order::SourceOrderVisitor<'a> + ?Sized,
@@ -4046,7 +4045,7 @@ impl ExceptHandler {
 }
 
 impl FStringElement {
-    #[allow(unused)]
+    #[expect(unused)]
     pub(crate) fn visit_source_order<'a, V>(&'a self, visitor: &mut V)
     where
         V: crate::visitor::source_order::SourceOrderVisitor<'a> + ?Sized,
@@ -4059,7 +4058,7 @@ impl FStringElement {
 }
 
 impl Pattern {
-    #[allow(unused)]
+    #[expect(unused)]
     pub(crate) fn visit_source_order<'a, V>(&'a self, visitor: &mut V)
     where
         V: crate::visitor::source_order::SourceOrderVisitor<'a> + ?Sized,
@@ -4078,7 +4077,6 @@ impl Pattern {
 }
 
 impl TypeParam {
-    #[allow(unused)]
     pub(crate) fn visit_source_order<'a, V>(&'a self, visitor: &mut V)
     where
         V: crate::visitor::source_order::SourceOrderVisitor<'a> + ?Sized,

--- a/crates/ruff_python_ast/src/generated.rs
+++ b/crates/ruff_python_ast/src/generated.rs
@@ -32,7 +32,7 @@ impl ruff_text_size::Ranged for Mod {
     }
 }
 
-#[expect(clippy::match_wildcard_for_single_variants)]
+#[allow(dead_code, clippy::match_wildcard_for_single_variants)]
 impl Mod {
     #[inline]
     pub const fn is_module(&self) -> bool {
@@ -321,7 +321,7 @@ impl ruff_text_size::Ranged for Stmt {
     }
 }
 
-#[expect(clippy::match_wildcard_for_single_variants)]
+#[allow(dead_code, clippy::match_wildcard_for_single_variants)]
 impl Stmt {
     #[inline]
     pub const fn is_function_def_stmt(&self) -> bool {
@@ -1517,7 +1517,7 @@ impl ruff_text_size::Ranged for Expr {
     }
 }
 
-#[expect(clippy::match_wildcard_for_single_variants)]
+#[allow(dead_code, clippy::match_wildcard_for_single_variants)]
 impl Expr {
     #[inline]
     pub const fn is_bool_op_expr(&self) -> bool {
@@ -2724,7 +2724,7 @@ impl ruff_text_size::Ranged for ExceptHandler {
     }
 }
 
-#[expect(clippy::match_wildcard_for_single_variants)]
+#[allow(dead_code, clippy::match_wildcard_for_single_variants)]
 impl ExceptHandler {
     #[inline]
     pub const fn is_except_handler(&self) -> bool {
@@ -2787,7 +2787,7 @@ impl ruff_text_size::Ranged for FStringElement {
     }
 }
 
-#[expect(clippy::match_wildcard_for_single_variants)]
+#[allow(dead_code, clippy::match_wildcard_for_single_variants)]
 impl FStringElement {
     #[inline]
     pub const fn is_expression(&self) -> bool {
@@ -2940,7 +2940,7 @@ impl ruff_text_size::Ranged for Pattern {
     }
 }
 
-#[expect(clippy::match_wildcard_for_single_variants)]
+#[allow(dead_code, clippy::match_wildcard_for_single_variants)]
 impl Pattern {
     #[inline]
     pub const fn is_match_value(&self) -> bool {
@@ -3275,7 +3275,7 @@ impl ruff_text_size::Ranged for TypeParam {
     }
 }
 
-#[expect(clippy::match_wildcard_for_single_variants)]
+#[allow(dead_code, clippy::match_wildcard_for_single_variants)]
 impl TypeParam {
     #[inline]
     pub const fn is_type_var(&self) -> bool {
@@ -3942,7 +3942,7 @@ impl ruff_text_size::Ranged for crate::Identifier {
 }
 
 impl Mod {
-    #[expect(unused)]
+    #[allow(unused)]
     pub(crate) fn visit_source_order<'a, V>(&'a self, visitor: &mut V)
     where
         V: crate::visitor::source_order::SourceOrderVisitor<'a> + ?Sized,
@@ -3955,6 +3955,7 @@ impl Mod {
 }
 
 impl Stmt {
+    #[allow(unused)]
     pub(crate) fn visit_source_order<'a, V>(&'a self, visitor: &mut V)
     where
         V: crate::visitor::source_order::SourceOrderVisitor<'a> + ?Sized,
@@ -3990,7 +3991,7 @@ impl Stmt {
 }
 
 impl Expr {
-    #[expect(unused)]
+    #[allow(unused)]
     pub(crate) fn visit_source_order<'a, V>(&'a self, visitor: &mut V)
     where
         V: crate::visitor::source_order::SourceOrderVisitor<'a> + ?Sized,
@@ -4033,7 +4034,7 @@ impl Expr {
 }
 
 impl ExceptHandler {
-    #[expect(unused)]
+    #[allow(unused)]
     pub(crate) fn visit_source_order<'a, V>(&'a self, visitor: &mut V)
     where
         V: crate::visitor::source_order::SourceOrderVisitor<'a> + ?Sized,
@@ -4045,7 +4046,7 @@ impl ExceptHandler {
 }
 
 impl FStringElement {
-    #[expect(unused)]
+    #[allow(unused)]
     pub(crate) fn visit_source_order<'a, V>(&'a self, visitor: &mut V)
     where
         V: crate::visitor::source_order::SourceOrderVisitor<'a> + ?Sized,
@@ -4058,7 +4059,7 @@ impl FStringElement {
 }
 
 impl Pattern {
-    #[expect(unused)]
+    #[allow(unused)]
     pub(crate) fn visit_source_order<'a, V>(&'a self, visitor: &mut V)
     where
         V: crate::visitor::source_order::SourceOrderVisitor<'a> + ?Sized,
@@ -4077,6 +4078,7 @@ impl Pattern {
 }
 
 impl TypeParam {
+    #[allow(unused)]
     pub(crate) fn visit_source_order<'a, V>(&'a self, visitor: &mut V)
     where
         V: crate::visitor::source_order::SourceOrderVisitor<'a> + ?Sized,

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -352,7 +352,7 @@ impl Deref for FStringLiteralElement {
 /// Transforms a value prior to formatting it.
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, is_macro::Is)]
 #[repr(i8)]
-#[allow(clippy::cast_possible_wrap)]
+#[expect(clippy::cast_possible_wrap)]
 pub enum ConversionFlag {
     /// No conversion
     None = -1, // CPython uses -1

--- a/crates/ruff_python_codegen/src/generator.rs
+++ b/crates/ruff_python_codegen/src/generator.rs
@@ -1365,7 +1365,7 @@ impl<'a> Generator<'a> {
 
         if !conversion.is_none() {
             self.p("!");
-            #[allow(clippy::cast_possible_truncation)]
+            #[expect(clippy::cast_possible_truncation)]
             self.p(&format!("{}", conversion as u8 as char));
         }
 

--- a/crates/ruff_python_codegen/src/generator.rs
+++ b/crates/ruff_python_codegen/src/generator.rs
@@ -1365,7 +1365,7 @@ impl<'a> Generator<'a> {
 
         if !conversion.is_none() {
             self.p("!");
-            #[expect(clippy::cast_possible_truncation)]
+
             self.p(&format!("{}", conversion as u8 as char));
         }
 

--- a/crates/ruff_python_formatter/src/builders.rs
+++ b/crates/ruff_python_formatter/src/builders.rs
@@ -178,7 +178,6 @@ impl<'fmt, 'ast, 'buf> JoinCommaSeparatedBuilder<'fmt, 'ast, 'buf> {
         self
     }
 
-    #[allow(unused)]
     pub(crate) fn entries<T, I, F>(&mut self, entries: I) -> &mut Self
     where
         T: Ranged,

--- a/crates/ruff_python_formatter/src/cli.rs
+++ b/crates/ruff_python_formatter/src/cli.rs
@@ -24,7 +24,7 @@ pub enum Emit {
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
-#[allow(clippy::struct_excessive_bools)] // It's only the dev cli anyways
+#[expect(clippy::struct_excessive_bools)] // It's only the dev cli anyways
 pub struct Cli {
     /// Python files to format. If there are none, stdin will be used. `-` as stdin is not supported
     pub files: Vec<PathBuf>,

--- a/crates/ruff_python_formatter/src/comments/map.rs
+++ b/crates/ruff_python_formatter/src/comments/map.rs
@@ -244,7 +244,7 @@ impl<K: std::hash::Hash + Eq, V> MultiMap<K, V> {
     }
 
     /// Returns `true` if `key` has any *leading*, *dangling*, or *trailing* parts.
-    #[allow(unused)]
+
     pub(super) fn has(&self, key: &K) -> bool {
         self.index.contains_key(key)
     }
@@ -542,7 +542,7 @@ impl PartIndex {
         // OK because:
         // * The `value < u32::MAX` guarantees that the add doesn't overflow.
         // * The `+ 1` guarantees that the index is not zero
-        #[allow(clippy::cast_possible_truncation)]
+        #[expect(clippy::cast_possible_truncation)]
         Self(std::num::NonZeroU32::new((value as u32) + 1).expect("valid value"))
     }
 

--- a/crates/ruff_python_formatter/src/comments/map.rs
+++ b/crates/ruff_python_formatter/src/comments/map.rs
@@ -244,7 +244,6 @@ impl<K: std::hash::Hash + Eq, V> MultiMap<K, V> {
     }
 
     /// Returns `true` if `key` has any *leading*, *dangling*, or *trailing* parts.
-
     pub(super) fn has(&self, key: &K) -> bool {
         self.index.contains_key(key)
     }

--- a/crates/ruff_python_formatter/src/comments/visitor.rs
+++ b/crates/ruff_python_formatter/src/comments/visitor.rs
@@ -6,7 +6,7 @@ use ruff_python_ast::{AnyNodeRef, Identifier};
 use ruff_python_ast::{Mod, Stmt};
 // The interface is designed to only export the members relevant for iterating nodes in
 // pre-order.
-#[expect(clippy::wildcard_imports)]
+#[allow(clippy::wildcard_imports)]
 use ruff_python_ast::visitor::source_order::*;
 use ruff_python_trivia::{CommentLinePosition, CommentRanges};
 use ruff_text_size::{Ranged, TextRange, TextSize};

--- a/crates/ruff_python_formatter/src/comments/visitor.rs
+++ b/crates/ruff_python_formatter/src/comments/visitor.rs
@@ -6,7 +6,7 @@ use ruff_python_ast::{AnyNodeRef, Identifier};
 use ruff_python_ast::{Mod, Stmt};
 // The interface is designed to only export the members relevant for iterating nodes in
 // pre-order.
-#[allow(clippy::wildcard_imports)]
+#[expect(clippy::wildcard_imports)]
 use ruff_python_ast::visitor::source_order::*;
 use ruff_python_trivia::{CommentLinePosition, CommentRanges};
 use ruff_text_size::{Ranged, TextRange, TextSize};

--- a/crates/ruff_python_formatter/src/context.rs
+++ b/crates/ruff_python_formatter/src/context.rs
@@ -106,7 +106,6 @@ impl<'a> PyFormatContext<'a> {
     }
 
     /// Returns `true` if preview mode is enabled.
-    #[allow(unused)]
     pub(crate) const fn is_preview(&self) -> bool {
         self.options.preview().is_enabled()
     }

--- a/crates/ruff_python_formatter/src/expression/binary_like.rs
+++ b/crates/ruff_python_formatter/src/expression/binary_like.rs
@@ -571,7 +571,7 @@ impl<'a> FlatBinaryExpressionSlice<'a> {
             "Operand slice must contain at least one operand"
         );
 
-        #[allow(unsafe_code)]
+        #[expect(unsafe_code)]
         unsafe {
             // SAFETY: `BinaryChainSlice` has the same layout as a slice because it uses `repr(transparent)`
             &*(std::ptr::from_ref::<[OperandOrOperator<'a>]>(slice)

--- a/crates/ruff_python_formatter/src/expression/mod.rs
+++ b/crates/ruff_python_formatter/src/expression/mod.rs
@@ -523,7 +523,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for Expr {
 /// * The expression contains at least one parenthesized sub expression (optimization to avoid unnecessary work)
 ///
 /// This mimics Black's [`_maybe_split_omitting_optional_parens`](https://github.com/psf/black/blob/d1248ca9beaf0ba526d265f4108836d89cf551b7/src/black/linegen.py#L746-L820)
-#[allow(clippy::if_same_then_else)]
+#[expect(clippy::if_same_then_else)]
 pub(crate) fn can_omit_optional_parentheses(expr: &Expr, context: &PyFormatContext) -> bool {
     let mut visitor = CanOmitOptionalParenthesesVisitor::new(context);
     visitor.visit_subexpression(expr);
@@ -679,7 +679,7 @@ impl<'input> CanOmitOptionalParenthesesVisitor<'input> {
 
             // It's impossible for a file smaller or equal to 4GB to contain more than 2^32 comparisons
             // because each comparison requires a left operand, and `n` `operands` and right sides.
-            #[allow(clippy::cast_possible_truncation)]
+            #[expect(clippy::cast_possible_truncation)]
             Expr::BoolOp(ast::ExprBoolOp {
                 range: _,
                 op: _,
@@ -702,7 +702,7 @@ impl<'input> CanOmitOptionalParenthesesVisitor<'input> {
 
             // It's impossible for a file smaller or equal to 4GB to contain more than 2^32 comparisons
             // because each comparison requires a left operand, and `n` `operands` and right sides.
-            #[allow(clippy::cast_possible_truncation)]
+            #[expect(clippy::cast_possible_truncation)]
             Expr::Compare(ast::ExprCompare {
                 range: _,
                 left: _,

--- a/crates/ruff_python_formatter/src/expression/mod.rs
+++ b/crates/ruff_python_formatter/src/expression/mod.rs
@@ -523,7 +523,6 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for Expr {
 /// * The expression contains at least one parenthesized sub expression (optimization to avoid unnecessary work)
 ///
 /// This mimics Black's [`_maybe_split_omitting_optional_parens`](https://github.com/psf/black/blob/d1248ca9beaf0ba526d265f4108836d89cf551b7/src/black/linegen.py#L746-L820)
-#[expect(clippy::if_same_then_else)]
 pub(crate) fn can_omit_optional_parentheses(expr: &Expr, context: &PyFormatContext) -> bool {
     let mut visitor = CanOmitOptionalParenthesesVisitor::new(context);
     visitor.visit_subexpression(expr);

--- a/crates/ruff_python_formatter/src/main.rs
+++ b/crates/ruff_python_formatter/src/main.rs
@@ -14,7 +14,6 @@ pub(crate) fn read_from_stdin() -> Result<String> {
     Ok(buffer)
 }
 
-#[expect(clippy::print_stdout)]
 fn main() -> Result<()> {
     let cli: Cli = Cli::parse();
 

--- a/crates/ruff_python_formatter/src/main.rs
+++ b/crates/ruff_python_formatter/src/main.rs
@@ -14,7 +14,7 @@ pub(crate) fn read_from_stdin() -> Result<String> {
     Ok(buffer)
 }
 
-#[allow(clippy::print_stdout)]
+#[expect(clippy::print_stdout)]
 fn main() -> Result<()> {
     let cli: Cli = Cli::parse();
 

--- a/crates/ruff_python_formatter/src/prelude.rs
+++ b/crates/ruff_python_formatter/src/prelude.rs
@@ -1,7 +1,5 @@
-#[allow(unused_imports)]
 pub(crate) use crate::{
     builders::PyFormatterExtensions, AsFormat, FormatNodeRule, FormattedIterExt as _, IntoFormat,
     PyFormatContext, PyFormatter,
 };
-#[allow(unused_imports)]
 pub(crate) use ruff_formatter::prelude::*;

--- a/crates/ruff_python_formatter/src/range.rs
+++ b/crates/ruff_python_formatter/src/range.rs
@@ -546,7 +546,7 @@ impl NarrowRange<'_> {
         Some(SavedLevel { level: saved_level })
     }
 
-    #[allow(clippy::needless_pass_by_value)]
+    #[expect(clippy::needless_pass_by_value)]
     fn leave_level(&mut self, saved_state: SavedLevel) {
         self.level = saved_state.level;
     }

--- a/crates/ruff_python_formatter/src/statement/suite.rs
+++ b/crates/ruff_python_formatter/src/statement/suite.rs
@@ -170,7 +170,6 @@ impl FormatRule<Suite, PyFormatContext<'_>> for FormatSuite {
         } else {
             first.fmt(f)?;
 
-            #[expect(clippy::if_same_then_else)]
             let empty_line_after_docstring = if matches!(first, SuiteChildStatement::Docstring(_))
                 && self.kind == SuiteKind::Class
             {

--- a/crates/ruff_python_formatter/src/statement/suite.rs
+++ b/crates/ruff_python_formatter/src/statement/suite.rs
@@ -170,7 +170,7 @@ impl FormatRule<Suite, PyFormatContext<'_>> for FormatSuite {
         } else {
             first.fmt(f)?;
 
-            #[allow(clippy::if_same_then_else)]
+            #[expect(clippy::if_same_then_else)]
             let empty_line_after_docstring = if matches!(first, SuiteChildStatement::Docstring(_))
                 && self.kind == SuiteKind::Class
             {

--- a/crates/ruff_python_formatter/src/string/normalize.rs
+++ b/crates/ruff_python_formatter/src/string/normalize.rs
@@ -691,7 +691,6 @@ pub(crate) fn normalize_string(
                     }
 
                     if !new_flags.is_triple_quoted() {
-                        #[expect(clippy::if_same_then_else)]
                         if next == opposite_quote {
                             // Remove the escape by ending before the backslash and starting again with the quote
                             chars.next();

--- a/crates/ruff_python_formatter/src/string/normalize.rs
+++ b/crates/ruff_python_formatter/src/string/normalize.rs
@@ -691,7 +691,7 @@ pub(crate) fn normalize_string(
                     }
 
                     if !new_flags.is_triple_quoted() {
-                        #[allow(clippy::if_same_then_else)]
+                        #[expect(clippy::if_same_then_else)]
                         if next == opposite_quote {
                             // Remove the escape by ending before the backslash and starting again with the quote
                             chars.next();

--- a/crates/ruff_python_formatter/src/verbatim.rs
+++ b/crates/ruff_python_formatter/src/verbatim.rs
@@ -487,7 +487,7 @@ enum SuppressionComments<'a> {
 
     /// Comments that all fall into the formatted range.
     Formatted {
-        #[allow(unused)]
+        #[expect(unused)]
         comments: &'a [SourceComment],
     },
 }

--- a/crates/ruff_python_formatter/tests/normalizer.rs
+++ b/crates/ruff_python_formatter/tests/normalizer.rs
@@ -29,7 +29,6 @@ pub(crate) struct Normalizer;
 
 impl Normalizer {
     /// Transform an AST module into a normalized representation.
-    #[allow(dead_code)]
     pub(crate) fn visit_module(&self, module: &mut ast::Mod) {
         match module {
             ast::Mod::Module(module) => {

--- a/crates/ruff_python_formatter/tests/normalizer.rs
+++ b/crates/ruff_python_formatter/tests/normalizer.rs
@@ -29,6 +29,7 @@ pub(crate) struct Normalizer;
 
 impl Normalizer {
     /// Transform an AST module into a normalized representation.
+    #[allow(dead_code)]
     pub(crate) fn visit_module(&self, module: &mut ast::Mod) {
         match module {
             ast::Mod::Module(module) => {

--- a/crates/ruff_python_index/src/indexer.rs
+++ b/crates/ruff_python_index/src/indexer.rs
@@ -53,7 +53,7 @@ impl Indexer {
                 continuation_lines.push(line_start);
 
                 // SAFETY: Safe because of the len assertion at the top of the function.
-                #[allow(clippy::cast_possible_truncation)]
+                #[expect(clippy::cast_possible_truncation)]
                 {
                     line_start = prev_end + TextSize::new((index + 1) as u32);
                 }

--- a/crates/ruff_python_literal/src/cformat.rs
+++ b/crates/ruff_python_literal/src/cformat.rs
@@ -241,7 +241,7 @@ where
     Ok((format_type, c))
 }
 
-#[allow(clippy::cast_possible_wrap)]
+#[expect(clippy::cast_possible_wrap)]
 fn parse_quantity<T, I>(iter: &mut ParseIter<I>) -> Result<Option<CFormatQuantity>, ParsingError>
 where
     T: Into<char> + Copy,

--- a/crates/ruff_python_literal/src/escape.rs
+++ b/crates/ruff_python_literal/src/escape.rs
@@ -103,11 +103,7 @@ impl std::fmt::Display for StrRepr<'_, '_> {
 impl UnicodeEscape<'_> {
     const REPR_RESERVED_LEN: usize = 2; // for quotes
 
-    #[expect(
-        clippy::cast_possible_wrap,
-        clippy::cast_possible_truncation,
-        clippy::cast_sign_loss
-    )]
+    #[expect(clippy::cast_possible_wrap, clippy::cast_sign_loss)]
     pub fn repr_layout(source: &str, preferred_quote: Quote) -> EscapeLayout {
         Self::output_layout_with_checker(source, preferred_quote, |a, b| {
             Some((a as isize).checked_add(b as isize)? as usize)
@@ -265,11 +261,7 @@ impl<'a> AsciiEscape<'a> {
 }
 
 impl AsciiEscape<'_> {
-    #[expect(
-        clippy::cast_possible_wrap,
-        clippy::cast_possible_truncation,
-        clippy::cast_sign_loss
-    )]
+    #[expect(clippy::cast_possible_wrap, clippy::cast_sign_loss)]
     pub fn repr_layout(source: &[u8], preferred_quote: Quote) -> EscapeLayout {
         Self::output_layout_with_checker(source, preferred_quote, 3, |a, b| {
             Some((a as isize).checked_add(b as isize)? as usize)

--- a/crates/ruff_python_literal/src/escape.rs
+++ b/crates/ruff_python_literal/src/escape.rs
@@ -103,7 +103,7 @@ impl std::fmt::Display for StrRepr<'_, '_> {
 impl UnicodeEscape<'_> {
     const REPR_RESERVED_LEN: usize = 2; // for quotes
 
-    #[allow(
+    #[expect(
         clippy::cast_possible_wrap,
         clippy::cast_possible_truncation,
         clippy::cast_sign_loss
@@ -265,7 +265,7 @@ impl<'a> AsciiEscape<'a> {
 }
 
 impl AsciiEscape<'_> {
-    #[allow(
+    #[expect(
         clippy::cast_possible_wrap,
         clippy::cast_possible_truncation,
         clippy::cast_sign_loss

--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -1459,7 +1459,7 @@ impl<'src> Lexer<'src> {
 
     /// Retrieves the current offset of the cursor within the source code.
     // SAFETY: Lexer doesn't allow files larger than 4GB
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     #[inline]
     fn offset(&self) -> TextSize {
         TextSize::new(self.source.len() as u32) - self.cursor.text_len()

--- a/crates/ruff_python_parser/src/lexer/cursor.rs
+++ b/crates/ruff_python_parser/src/lexer/cursor.rs
@@ -62,7 +62,7 @@ impl<'src> Cursor<'src> {
     ///
     /// Use [`Cursor::rest`] to get the remaining text.
     // SAFETY: The `source.text_len` call in `new` would panic if the string length is larger than a `u32`.
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     pub(super) fn text_len(&self) -> TextSize {
         TextSize::new(self.chars.as_str().len() as u32)
     }

--- a/crates/ruff_python_parser/src/token_source.rs
+++ b/crates/ruff_python_parser/src/token_source.rs
@@ -210,7 +210,7 @@ pub(crate) struct TokenSourceCheckpoint {
 /// of `contents`.
 ///
 /// See [#9546](https://github.com/astral-sh/ruff/pull/9546) for a more detailed explanation.
-#[allow(dead_code)]
+#[expect(dead_code)]
 fn allocate_tokens_vec(contents: &str) -> Vec<Token> {
     let lower_bound = contents.len().saturating_mul(15) / 100;
     Vec::with_capacity(lower_bound)

--- a/crates/ruff_python_parser/tests/fixtures.rs
+++ b/crates/ruff_python_parser/tests/fixtures.rs
@@ -274,7 +274,7 @@ fn extract_options(source: &str) -> Option<ParseOptions> {
 // Use it for quickly debugging a parser issue.
 #[test]
 #[ignore]
-#[allow(clippy::print_stdout)]
+#[expect(clippy::print_stdout)]
 fn parser_quick_test() {
     let source = "\
 f'{'

--- a/crates/ruff_python_resolver/src/import_result.rs
+++ b/crates/ruff_python_resolver/src/import_result.rs
@@ -6,7 +6,7 @@ use crate::implicit_imports::ImplicitImports;
 use crate::py_typed::PyTypedInfo;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[allow(clippy::struct_excessive_bools)]
+#[expect(clippy::struct_excessive_bools)]
 pub(crate) struct ImportResult {
     /// Whether the import name was relative (e.g., ".foo").
     pub(crate) is_relative: bool,
@@ -76,7 +76,7 @@ pub(crate) struct ImportResult {
 
     /// If the import resolved to a type hint (i.e., a `.pyi` file), then
     /// a non-type-hint resolution will be stored here.
-    #[allow(clippy::struct_field_names)]
+    #[expect(clippy::struct_field_names)]
     pub(crate) non_stub_import_result: Option<Box<ImportResult>>,
 
     /// Information extracted from the `py.typed` in the package used to

--- a/crates/ruff_python_resolver/src/resolver.rs
+++ b/crates/ruff_python_resolver/src/resolver.rs
@@ -12,7 +12,7 @@ use crate::import_result::{ImportResult, ImportType};
 use crate::module_descriptor::ImportModuleDescriptor;
 use crate::{host, native_module, py_typed, search};
 
-#[allow(clippy::fn_params_excessive_bools)]
+#[expect(clippy::fn_params_excessive_bools)]
 fn resolve_module_descriptor(
     root: &Path,
     module_descriptor: &ImportModuleDescriptor,
@@ -206,7 +206,7 @@ fn resolve_module_descriptor(
 /// defined in [PEP 420].
 ///
 /// [PEP 420]: https://peps.python.org/pep-0420/
-#[allow(clippy::fn_params_excessive_bools)]
+#[expect(clippy::fn_params_excessive_bools)]
 fn resolve_absolute_import(
     root: &Path,
     module_descriptor: &ImportModuleDescriptor,

--- a/crates/ruff_python_semantic/src/analyze/typing.rs
+++ b/crates/ruff_python_semantic/src/analyze/typing.rs
@@ -1147,7 +1147,7 @@ pub fn find_assigned_value<'a>(symbol: &str, semantic: &'a SemanticModel<'a>) ->
 ///
 /// This function will return a `NumberLiteral` with value `Int(42)` when called with `foo` and a
 /// `StringLiteral` with value `"str"` when called with `bla`.
-#[allow(clippy::single_match)]
+#[expect(clippy::single_match)]
 pub fn find_binding_value<'a>(binding: &Binding, semantic: &'a SemanticModel) -> Option<&'a Expr> {
     match binding.kind {
         // Ex) `x := 1`

--- a/crates/ruff_python_stdlib/src/sys/builtin_modules.rs
+++ b/crates/ruff_python_stdlib/src/sys/builtin_modules.rs
@@ -9,7 +9,7 @@
 /// modules.
 ///
 /// [builtin module]: https://docs.python.org/3/library/sys.html#sys.builtin_module_names
-#[allow(clippy::unnested_or_patterns)]
+#[expect(clippy::unnested_or_patterns)]
 pub fn is_builtin_module(minor_version: u8, module: &str) -> bool {
     matches!(
         (minor_version, module),

--- a/crates/ruff_python_trivia/src/tokenizer.rs
+++ b/crates/ruff_python_trivia/src/tokenizer.rs
@@ -30,7 +30,7 @@ pub fn find_only_token_in_range(
     let token = tokens.next().expect("Expected a token");
     debug_assert_eq!(token.kind(), token_kind);
     let mut tokens = tokens.skip_while(|token| token.kind == SimpleTokenKind::LParen);
-    #[allow(clippy::debug_assert_with_mut_call)]
+    #[expect(clippy::debug_assert_with_mut_call)]
     {
         debug_assert_eq!(tokens.next(), None);
     }
@@ -114,7 +114,7 @@ pub fn lines_after_ignoring_trivia(offset: TextSize, code: &str) -> u32 {
 
 /// Counts the empty lines after `offset`, ignoring any trailing trivia on the same line as
 /// `offset`.
-#[allow(clippy::cast_possible_truncation)]
+#[expect(clippy::cast_possible_truncation)]
 pub fn lines_after_ignoring_end_of_line_trivia(offset: TextSize, code: &str) -> u32 {
     // SAFETY: We don't support files greater than 4GB, so casting to u32 is safe.
     SimpleTokenizer::starts_at(offset, code)

--- a/crates/ruff_server/src/edit/notebook.rs
+++ b/crates/ruff_server/src/edit/notebook.rs
@@ -247,7 +247,7 @@ mod tests {
     use super::NotebookDocument;
 
     enum TestCellContent {
-        #[allow(dead_code)]
+        #[expect(dead_code)]
         Markup(String),
         Code(String),
     }

--- a/crates/ruff_server/src/logging.rs
+++ b/crates/ruff_server/src/logging.rs
@@ -34,7 +34,7 @@ pub(crate) fn init_logging(log_level: LogLevel, log_file: Option<&std::path::Pat
                 .append(true)
                 .open(&path)
                 .map_err(|err| {
-                    #[allow(clippy::print_stderr)]
+                    #[expect(clippy::print_stderr)]
                     {
                         eprintln!(
                             "Failed to open file at {} for logging: {err}",

--- a/crates/ruff_server/src/server.rs
+++ b/crates/ruff_server/src/server.rs
@@ -170,7 +170,6 @@ impl Server {
         .join()
     }
 
-    #[expect(clippy::needless_pass_by_value)] // this is because we aren't using `next_request_id` yet.
     fn event_loop(
         connection: &Connection,
         client_capabilities: &ClientCapabilities,

--- a/crates/ruff_server/src/server.rs
+++ b/crates/ruff_server/src/server.rs
@@ -5,7 +5,7 @@ use lsp_types as types;
 use lsp_types::InitializeParams;
 use std::num::NonZeroUsize;
 // The new PanicInfoHook name requires MSRV >= 1.82
-#[allow(deprecated)]
+#[expect(deprecated)]
 use std::panic::PanicInfo;
 use std::str::FromStr;
 use types::ClientCapabilities;
@@ -116,7 +116,7 @@ impl Server {
 
     pub fn run(self) -> crate::Result<()> {
         // The new PanicInfoHook name requires MSRV >= 1.82
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         type PanicHook = Box<dyn Fn(&PanicInfo<'_>) + 'static + Sync + Send>;
         struct RestorePanicHook {
             hook: Option<PanicHook>,
@@ -170,7 +170,7 @@ impl Server {
         .join()
     }
 
-    #[allow(clippy::needless_pass_by_value)] // this is because we aren't using `next_request_id` yet.
+    #[expect(clippy::needless_pass_by_value)] // this is because we aren't using `next_request_id` yet.
     fn event_loop(
         connection: &Connection,
         client_capabilities: &ClientCapabilities,

--- a/crates/ruff_server/src/server/api.rs
+++ b/crates/ruff_server/src/server/api.rs
@@ -143,7 +143,7 @@ fn local_notification_task<'a, N: traits::SyncNotificationHandler>(
     }))
 }
 
-#[allow(dead_code)]
+#[expect(dead_code)]
 fn background_notification_thread<'a, N: traits::BackgroundDocumentNotificationHandler>(
     req: server::Notification,
     schedule: BackgroundSchedule,

--- a/crates/ruff_server/src/server/client.rs
+++ b/crates/ruff_server/src/server/client.rs
@@ -48,7 +48,7 @@ impl Client<'_> {
     }
 }
 
-#[allow(dead_code)] // we'll need to use `Notifier` in the future
+#[expect(dead_code)] // we'll need to use `Notifier` in the future
 impl Notifier {
     pub(crate) fn notify<N>(&self, params: N::Params) -> crate::Result<()>
     where

--- a/crates/ruff_server/src/server/schedule/thread/pool.rs
+++ b/crates/ruff_server/src/server/schedule/thread/pool.rs
@@ -106,7 +106,7 @@ impl Pool {
         self.job_sender.send(job).unwrap();
     }
 
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(super) fn len(&self) -> usize {
         self.extant_tasks.load(Ordering::SeqCst)
     }

--- a/crates/ruff_server/src/server/schedule/thread/priority.rs
+++ b/crates/ruff_server/src/server/schedule/thread/priority.rs
@@ -183,14 +183,14 @@ mod imp {
             QoSClass::Background => libc::qos_class_t::QOS_CLASS_BACKGROUND,
         };
 
-        #[allow(unsafe_code)]
+        #[expect(unsafe_code)]
         let code = unsafe { libc::pthread_set_qos_class_self_np(c, 0) };
 
         if code == 0 {
             return;
         }
 
-        #[allow(unsafe_code)]
+        #[expect(unsafe_code)]
         let errno = unsafe { *libc::__error() };
 
         match errno {
@@ -223,10 +223,10 @@ mod imp {
     }
 
     pub(super) fn get_current_thread_qos_class() -> Option<QoSClass> {
-        #[allow(unsafe_code)]
+        #[expect(unsafe_code)]
         let current_thread = unsafe { libc::pthread_self() };
         let mut qos_class_raw = libc::qos_class_t::QOS_CLASS_UNSPECIFIED;
-        #[allow(unsafe_code)]
+        #[expect(unsafe_code)]
         let code = unsafe {
             libc::pthread_get_qos_class_np(current_thread, &mut qos_class_raw, std::ptr::null_mut())
         };
@@ -241,7 +241,7 @@ mod imp {
             // ones which we cannot handle anyway
             //
             // 0: https://github.com/apple-oss-distributions/libpthread/blob/67e155c94093be9a204b69637d198eceff2c7c46/src/qos.c#L171-L177
-            #[allow(unsafe_code)]
+            #[expect(unsafe_code)]
             let errno = unsafe { *libc::__error() };
             unreachable!("`pthread_get_qos_class_np` failed unexpectedly (os error {errno})");
         }

--- a/crates/ruff_server/src/session/capabilities.rs
+++ b/crates/ruff_server/src/session/capabilities.rs
@@ -2,7 +2,7 @@ use lsp_types::ClientCapabilities;
 use ruff_linter::display_settings;
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
-#[allow(clippy::struct_excessive_bools)]
+#[expect(clippy::struct_excessive_bools)]
 pub(crate) struct ResolvedClientCapabilities {
     pub(crate) code_action_deferred_edit_resolution: bool,
     pub(crate) apply_edit: bool,

--- a/crates/ruff_server/src/session/index.rs
+++ b/crates/ruff_server/src/session/index.rs
@@ -517,7 +517,6 @@ impl DocumentController {
         }
     }
 
-    #[allow(dead_code)]
     pub(crate) fn as_text(&self) -> Option<&TextDocument> {
         match self {
             Self::Text(document) => Some(document),

--- a/crates/ruff_server/src/session/settings.rs
+++ b/crates/ruff_server/src/session/settings.rs
@@ -19,7 +19,7 @@ pub(crate) type WorkspaceSettingsMap = FxHashMap<Url, ClientSettings>;
 /// sends them.
 #[derive(Clone, Debug)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
-#[allow(clippy::struct_excessive_bools)]
+#[expect(clippy::struct_excessive_bools)]
 pub(crate) struct ResolvedClientSettings {
     fix_all: bool,
     organize_imports: bool,

--- a/crates/ruff_source_file/src/line_index.rs
+++ b/crates/ruff_source_file/src/line_index.rs
@@ -43,7 +43,7 @@ impl LineIndex {
                 b'\r' if bytes.get(i + 1) == Some(&b'\n') => continue,
                 b'\n' | b'\r' => {
                     // SAFETY: Assertion above guarantees `i <= u32::MAX`
-                    #[allow(clippy::cast_possible_truncation)]
+                    #[expect(clippy::cast_possible_truncation)]
                     line_starts.push(TextSize::from(i as u32) + TextSize::from(1));
                 }
                 _ => {}

--- a/crates/ruff_source_file/src/newlines.rs
+++ b/crates/ruff_source_file/src/newlines.rs
@@ -322,7 +322,7 @@ impl LineEnding {
         }
     }
 
-    #[allow(clippy::len_without_is_empty)]
+    #[expect(clippy::len_without_is_empty)]
     pub const fn len(&self) -> usize {
         match self {
             LineEnding::Lf | LineEnding::Cr => 1,

--- a/crates/ruff_text_size/src/serde_impls.rs
+++ b/crates/ruff_text_size/src/serde_impls.rs
@@ -31,7 +31,7 @@ impl Serialize for TextRange {
 }
 
 impl<'de> Deserialize<'de> for TextRange {
-    #[allow(clippy::nonminimal_bool)]
+    #[expect(clippy::nonminimal_bool)]
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,

--- a/crates/ruff_text_size/src/traits.rs
+++ b/crates/ruff_text_size/src/traits.rs
@@ -31,7 +31,7 @@ impl TextLen for &'_ String {
 impl Sealed for char {}
 impl TextLen for char {
     #[inline]
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     fn text_len(self) -> TextSize {
         (self.len_utf8() as u32).into()
     }

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -273,7 +273,6 @@ impl Configuration {
                 project_root: project_root.to_path_buf(),
             },
 
-            #[allow(deprecated)]
             linter: LinterSettings {
                 rules,
                 exclude: FilePatternSet::try_from_iter(lint.exclude.unwrap_or_default())?,
@@ -668,7 +667,7 @@ pub struct LintConfiguration {
 
 impl LintConfiguration {
     fn from_options(options: LintOptions, project_root: &Path) -> Result<Self> {
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         let ignore = options
             .common
             .ignore
@@ -676,7 +675,7 @@ impl LintConfiguration {
             .flatten()
             .chain(options.common.extend_ignore.into_iter().flatten())
             .collect();
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         let unfixable = options
             .common
             .unfixable
@@ -685,7 +684,7 @@ impl LintConfiguration {
             .chain(options.common.extend_unfixable.into_iter().flatten())
             .collect();
 
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         let ignore_init_module_imports = {
             if options.common.ignore_init_module_imports.is_some() {
                 warn_user_once!("The `ignore-init-module-imports` option is deprecated and will be removed in a future release. Ruff's handling of imports in `__init__.py` files has been improved (in preview) and unused imports will always be flagged.");
@@ -1193,7 +1192,7 @@ pub struct FormatConfiguration {
 }
 
 impl FormatConfiguration {
-    #[allow(clippy::needless_pass_by_value)]
+    #[expect(clippy::needless_pass_by_value)]
     pub fn from_options(options: FormatOptions, project_root: &Path) -> Result<Self> {
         Ok(Self {
             // `--extension` is a hidden command-line argument that isn't supported in configuration
@@ -1231,7 +1230,7 @@ impl FormatConfiguration {
     }
 
     #[must_use]
-    #[allow(clippy::needless_pass_by_value)]
+    #[expect(clippy::needless_pass_by_value)]
     pub fn combine(self, config: Self) -> Self {
         Self {
             exclude: self.exclude.or(config.exclude),
@@ -1260,7 +1259,7 @@ pub struct AnalyzeConfiguration {
 }
 
 impl AnalyzeConfiguration {
-    #[allow(clippy::needless_pass_by_value)]
+    #[expect(clippy::needless_pass_by_value)]
     pub fn from_options(options: AnalyzeOptions, project_root: &Path) -> Result<Self> {
         Ok(Self {
             exclude: options.exclude.map(|paths| {
@@ -1287,7 +1286,7 @@ impl AnalyzeConfiguration {
     }
 
     #[must_use]
-    #[allow(clippy::needless_pass_by_value)]
+    #[expect(clippy::needless_pass_by_value)]
     pub fn combine(self, config: Self) -> Self {
         Self {
             exclude: self.exclude.or(config.exclude),
@@ -1339,7 +1338,7 @@ fn warn_about_deprecated_top_level_lint_options(
     top_level_options: &LintCommonOptions,
     path: Option<&Path>,
 ) {
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     let LintCommonOptions {
         allowed_confusables,
         dummy_variable_rgx,
@@ -1659,7 +1658,7 @@ mod tests {
         Rule::BlankLinesBeforeNestedDefinition,
     ];
 
-    #[allow(clippy::needless_pass_by_value)]
+    #[expect(clippy::needless_pass_by_value)]
     fn resolve_rules(
         selections: impl IntoIterator<Item = RuleSelection>,
         preview: Option<PreviewOptions>,

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -1192,7 +1192,6 @@ pub struct FormatConfiguration {
 }
 
 impl FormatConfiguration {
-    #[expect(clippy::needless_pass_by_value)]
     pub fn from_options(options: FormatOptions, project_root: &Path) -> Result<Self> {
         Ok(Self {
             // `--extension` is a hidden command-line argument that isn't supported in configuration
@@ -1230,7 +1229,6 @@ impl FormatConfiguration {
     }
 
     #[must_use]
-    #[expect(clippy::needless_pass_by_value)]
     pub fn combine(self, config: Self) -> Self {
         Self {
             exclude: self.exclude.or(config.exclude),
@@ -1259,7 +1257,6 @@ pub struct AnalyzeConfiguration {
 }
 
 impl AnalyzeConfiguration {
-    #[expect(clippy::needless_pass_by_value)]
     pub fn from_options(options: AnalyzeOptions, project_root: &Path) -> Result<Self> {
         Ok(Self {
             exclude: options.exclude.map(|paths| {
@@ -1286,7 +1283,6 @@ impl AnalyzeConfiguration {
     }
 
     #[must_use]
-    #[expect(clippy::needless_pass_by_value)]
     pub fn combine(self, config: Self) -> Self {
         Self {
             exclude: self.exclude.or(config.exclude),
@@ -1658,7 +1654,6 @@ mod tests {
         Rule::BlankLinesBeforeNestedDefinition,
     ];
 
-    #[expect(clippy::needless_pass_by_value)]
     fn resolve_rules(
         selections: impl IntoIterator<Item = RuleSelection>,
         preview: Option<PreviewOptions>,

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -1150,14 +1150,14 @@ impl Flake8BanditOptions {
             extend_markup_names: self
                 .extend_markup_names
                 .or_else(|| {
-                    #[allow(deprecated)]
+                    #[expect(deprecated)]
                     ruff_options.and_then(|options| options.extend_markup_names.clone())
                 })
                 .unwrap_or_default(),
             allowed_markup_calls: self
                 .allowed_markup_calls
                 .or_else(|| {
-                    #[allow(deprecated)]
+                    #[expect(deprecated)]
                     ruff_options.and_then(|options| options.allowed_markup_calls.clone())
                 })
                 .unwrap_or_default(),
@@ -1308,7 +1308,7 @@ pub struct Flake8BuiltinsOptions {
 
 impl Flake8BuiltinsOptions {
     pub fn into_settings(self) -> ruff_linter::rules::flake8_builtins::settings::Settings {
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         ruff_linter::rules::flake8_builtins::settings::Settings {
             ignorelist: self
                 .ignorelist
@@ -3951,7 +3951,7 @@ impl From<LintOptionsWire> for LintOptions {
         } = value;
 
         LintOptions {
-            #[allow(deprecated)]
+            #[expect(deprecated)]
             common: LintCommonOptions {
                 allowed_confusables,
                 dummy_variable_rgx,

--- a/crates/ruff_workspace/src/pyproject.rs
+++ b/crates/ruff_workspace/src/pyproject.rs
@@ -399,7 +399,7 @@ strict-checking = false
 "#,
         )?;
 
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         let expected = Flake8BuiltinsOptions {
             builtins_allowed_modules: Some(vec!["asyncio".to_string()]),
             allowed_modules: Some(vec!["sys".to_string()]),

--- a/crates/ruff_workspace/src/settings.rs
+++ b/crates/ruff_workspace/src/settings.rs
@@ -19,7 +19,7 @@ use std::fmt;
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, CacheKey)]
-#[allow(clippy::struct_excessive_bools)]
+#[expect(clippy::struct_excessive_bools)]
 pub struct Settings {
     #[cache_key(ignore)]
     pub cache_dir: PathBuf,

--- a/crates/ruff_workspace/src/settings.rs
+++ b/crates/ruff_workspace/src/settings.rs
@@ -19,7 +19,6 @@ use std::fmt;
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, CacheKey)]
-#[expect(clippy::struct_excessive_bools)]
 pub struct Settings {
     #[cache_key(ignore)]
     pub cache_dir: PathBuf,

--- a/crates/ty/build.rs
+++ b/crates/ty/build.rs
@@ -13,7 +13,6 @@ fn main() {
 
     commit_info(&workspace_root);
 
-    #[expect(clippy::disallowed_methods)]
     let target = std::env::var("TARGET").unwrap();
     println!("cargo::rustc-env=RUST_HOST_TARGET={target}");
 }

--- a/crates/ty/build.rs
+++ b/crates/ty/build.rs
@@ -13,7 +13,7 @@ fn main() {
 
     commit_info(&workspace_root);
 
-    #[allow(clippy::disallowed_methods)]
+    #[expect(clippy::disallowed_methods)]
     let target = std::env::var("TARGET").unwrap();
     println!("cargo::rustc-env=RUST_HOST_TARGET={target}");
 }

--- a/crates/ty/src/logging.rs
+++ b/crates/ty/src/logging.rs
@@ -147,7 +147,7 @@ pub(crate) fn setup_tracing(level: VerbosityLevel) -> anyhow::Result<TracingGuar
     })
 }
 
-#[allow(clippy::type_complexity)]
+#[expect(clippy::type_complexity)]
 fn setup_profile<S>() -> (
     Option<tracing_flame::FlameLayer<S, BufWriter<File>>>,
     Option<tracing_flame::FlushGuard<BufWriter<File>>>,

--- a/crates/ty/src/main.rs
+++ b/crates/ty/src/main.rs
@@ -24,7 +24,6 @@ mod logging;
 mod python_version;
 mod version;
 
-#[expect(clippy::print_stdout, clippy::unnecessary_wraps, clippy::print_stderr)]
 pub fn main() -> ExitStatus {
     run().unwrap_or_else(|error| {
         use std::io::Write;

--- a/crates/ty/src/main.rs
+++ b/crates/ty/src/main.rs
@@ -24,7 +24,7 @@ mod logging;
 mod python_version;
 mod version;
 
-#[allow(clippy::print_stdout, clippy::unnecessary_wraps, clippy::print_stderr)]
+#[expect(clippy::print_stdout, clippy::unnecessary_wraps, clippy::print_stderr)]
 pub fn main() -> ExitStatus {
     run().unwrap_or_else(|error| {
         use std::io::Write;

--- a/crates/ty_ide/src/db.rs
+++ b/crates/ty_ide/src/db.rs
@@ -27,7 +27,7 @@ pub(crate) mod tests {
         rule_selection: Arc<RuleSelection>,
     }
 
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     impl TestDb {
         pub(crate) fn new() -> Self {
             Self {

--- a/crates/ty_project/src/metadata/value.rs
+++ b/crates/ty_project/src/metadata/value.rs
@@ -155,7 +155,7 @@ where
 }
 
 // The type already has an `iter` method thanks to `Deref`.
-#[allow(clippy::into_iter_without_iter)]
+#[expect(clippy::into_iter_without_iter)]
 impl<'a, T> IntoIterator for &'a RangedValue<T>
 where
     &'a T: IntoIterator,
@@ -168,7 +168,7 @@ where
 }
 
 // The type already has a `into_iter_mut` method thanks to `DerefMut`.
-#[allow(clippy::into_iter_without_iter)]
+#[expect(clippy::into_iter_without_iter)]
 impl<'a, T> IntoIterator for &'a mut RangedValue<T>
 where
     &'a mut T: IntoIterator,

--- a/crates/ty_project/src/watch/watcher.rs
+++ b/crates/ty_project/src/watch/watcher.rs
@@ -186,7 +186,7 @@ impl Debouncer {
         }
     }
 
-    #[allow(clippy::unused_self, clippy::needless_pass_by_value)]
+    #[expect(clippy::unused_self, clippy::needless_pass_by_value)]
     fn add_error(&mut self, error: notify::Error) {
         // Micha: I skimmed through some of notify's source code and it seems the most common errors
         // are IO errors. All other errors should really only happen when adding or removing a watched folders.

--- a/crates/ty_project/tests/check.rs
+++ b/crates/ty_project/tests/check.rs
@@ -76,7 +76,7 @@ fn typeshed_no_panic() -> anyhow::Result<()> {
     ))
 }
 
-#[allow(clippy::print_stdout)]
+#[expect(clippy::print_stdout)]
 fn run_corpus_tests(pattern: &str) -> anyhow::Result<()> {
     let root = SystemPathBuf::from("/src");
 

--- a/crates/ty_python_semantic/src/ast_node_ref.rs
+++ b/crates/ty_python_semantic/src/ast_node_ref.rs
@@ -43,7 +43,7 @@ pub struct AstNodeRef<T> {
     node: std::ptr::NonNull<T>,
 }
 
-#[allow(unsafe_code)]
+#[expect(unsafe_code)]
 impl<T> AstNodeRef<T> {
     /// Creates a new `AstNodeRef` that references `node`. The `parsed` is the [`ParsedModule`] to
     /// which the `AstNodeRef` belongs.
@@ -112,7 +112,7 @@ where
     }
 }
 
-#[allow(unsafe_code)]
+#[expect(unsafe_code)]
 unsafe impl<T> salsa::Update for AstNodeRef<T> {
     unsafe fn maybe_update(old_pointer: *mut Self, new_value: Self) -> bool {
         let old_ref = &mut (*old_pointer);
@@ -126,9 +126,9 @@ unsafe impl<T> salsa::Update for AstNodeRef<T> {
     }
 }
 
-#[allow(unsafe_code)]
+#[expect(unsafe_code)]
 unsafe impl<T> Send for AstNodeRef<T> where T: Send {}
-#[allow(unsafe_code)]
+#[expect(unsafe_code)]
 unsafe impl<T> Sync for AstNodeRef<T> where T: Sync {}
 
 #[cfg(test)]
@@ -139,7 +139,7 @@ mod tests {
     use ruff_python_parser::parse_unchecked_source;
 
     #[test]
-    #[allow(unsafe_code)]
+    #[expect(unsafe_code)]
     fn equality() {
         let parsed_raw = parse_unchecked_source("1 + 2", PySourceType::Python);
         let parsed = ParsedModule::new(parsed_raw.clone());
@@ -167,7 +167,7 @@ mod tests {
         assert_ne!(node1, other_node);
     }
 
-    #[allow(unsafe_code)]
+    #[expect(unsafe_code)]
     #[test]
     fn inequality() {
         let parsed_raw = parse_unchecked_source("1 + 2", PySourceType::Python);
@@ -186,7 +186,7 @@ mod tests {
     }
 
     #[test]
-    #[allow(unsafe_code)]
+    #[expect(unsafe_code)]
     fn debug() {
         let parsed_raw = parse_unchecked_source("1 + 2", PySourceType::Python);
         let parsed = ParsedModule::new(parsed_raw);

--- a/crates/ty_python_semantic/src/lint.rs
+++ b/crates/ty_python_semantic/src/lint.rs
@@ -244,7 +244,7 @@ macro_rules! declare_lint {
         }
     ) => {
         $( #[doc = $doc] )+
-        #[allow(clippy::needless_update)]
+        #[expect(clippy::needless_update)]
         $vis static $name: $crate::lint::LintMetadata = $crate::lint::LintMetadata {
             name: ruff_db::diagnostic::LintName::of(ruff_macros::kebab_case!($name)),
             summary: $summary,

--- a/crates/ty_python_semantic/src/list.rs
+++ b/crates/ty_python_semantic/src/list.rs
@@ -180,7 +180,7 @@ impl<K, V> ListBuilder<K, V> {
     /// as our return type, since we never return `None`. However, for consistency with our other
     /// methods, we always use `Option<I>` as the return type for any method that can return a
     /// list.
-    #[allow(clippy::unnecessary_wraps)]
+    #[expect(clippy::unnecessary_wraps)]
     fn add_cell(&mut self, rest: Option<ListCellId>, key: K, value: V) -> Option<ListCellId> {
         Some(self.storage.cells.push(ListCell { rest, key, value }))
     }
@@ -319,7 +319,7 @@ impl<K, V> ListBuilder<K, V> {
     /// Returns the intersection of two lists. The result will contain an entry for any key that
     /// appears in both lists. The corresponding values will be combined using the `combine`
     /// function that you provide.
-    #[allow(clippy::needless_pass_by_value)]
+    #[expect(clippy::needless_pass_by_value)]
     pub(crate) fn intersect_with<F>(
         &mut self,
         a: List<K, V>,
@@ -372,7 +372,7 @@ impl<K, V> ListBuilder<K, V> {
 
 impl<K> ListStorage<K, ()> {
     /// Iterates through the elements in a set _in reverse order_.
-    #[allow(clippy::needless_pass_by_value)]
+    #[expect(clippy::needless_pass_by_value)]
     pub(crate) fn iter_set_reverse(&self, set: List<K, ()>) -> ListSetReverseIterator<K> {
         ListSetReverseIterator {
             storage: self,
@@ -513,7 +513,7 @@ mod tests {
 
     impl<K, V> ListStorage<K, V> {
         /// Iterates through the entries in a list _in reverse order by key_.
-        #[allow(clippy::needless_pass_by_value)]
+        #[expect(clippy::needless_pass_by_value)]
         pub(crate) fn iter_reverse(&self, list: List<K, V>) -> ListReverseIterator<'_, K, V> {
             ListReverseIterator {
                 storage: self,
@@ -649,7 +649,7 @@ mod property_tests {
 
     #[quickcheck_macros::quickcheck]
     #[ignore]
-    #[allow(clippy::needless_pass_by_value)]
+    #[expect(clippy::needless_pass_by_value)]
     fn roundtrip_set_from_vec(elements: Vec<u16>) -> bool {
         let mut builder = ListBuilder::default();
         let set = builder.set_from_elements(&elements);
@@ -660,7 +660,7 @@ mod property_tests {
 
     #[quickcheck_macros::quickcheck]
     #[ignore]
-    #[allow(clippy::needless_pass_by_value)]
+    #[expect(clippy::needless_pass_by_value)]
     fn roundtrip_set_intersection(a_elements: Vec<u16>, b_elements: Vec<u16>) -> bool {
         let mut builder = ListBuilder::default();
         let a = builder.set_from_elements(&a_elements);
@@ -712,7 +712,7 @@ mod property_tests {
 
     #[quickcheck_macros::quickcheck]
     #[ignore]
-    #[allow(clippy::needless_pass_by_value)]
+    #[expect(clippy::needless_pass_by_value)]
     fn roundtrip_list_from_vec(pairs: Vec<(u16, u16)>) -> bool {
         let mut builder = ListBuilder::default();
         let list = builder.set_from_pairs(&pairs);
@@ -723,7 +723,7 @@ mod property_tests {
 
     #[quickcheck_macros::quickcheck]
     #[ignore]
-    #[allow(clippy::needless_pass_by_value)]
+    #[expect(clippy::needless_pass_by_value)]
     fn roundtrip_list_intersection(
         a_elements: Vec<(u16, u16)>,
         b_elements: Vec<(u16, u16)>,

--- a/crates/ty_python_semantic/src/semantic_index.rs
+++ b/crates/ty_python_semantic/src/semantic_index.rs
@@ -257,7 +257,7 @@ impl<'db> SemanticIndex<'db> {
     }
 
     /// Returns the parent scope of `scope_id`.
-    #[allow(unused)]
+    #[expect(unused)]
     #[track_caller]
     pub(crate) fn parent_scope(&self, scope_id: FileScopeId) -> Option<&Scope> {
         Some(&self.scopes[self.parent_scope_id(scope_id)?])

--- a/crates/ty_python_semantic/src/semantic_index/builder.rs
+++ b/crates/ty_python_semantic/src/semantic_index/builder.rs
@@ -239,7 +239,7 @@ impl<'db> SemanticIndexBuilder<'db> {
         let children_start = self.scopes.next_index() + 1;
 
         // SAFETY: `node` is guaranteed to be a child of `self.module`
-        #[allow(unsafe_code)]
+        #[expect(unsafe_code)]
         let node_with_kind = unsafe { node.to_kind(self.module.clone()) };
 
         let scope = Scope::new(
@@ -457,7 +457,7 @@ impl<'db> SemanticIndexBuilder<'db> {
         definition_node: impl Into<DefinitionNodeRef<'db>>,
     ) -> (Definition<'db>, usize) {
         let definition_node: DefinitionNodeRef<'_> = definition_node.into();
-        #[allow(unsafe_code)]
+        #[expect(unsafe_code)]
         // SAFETY: `definition_node` is guaranteed to be a child of `self.module`
         let kind = unsafe { definition_node.into_owned(self.module.clone()) };
         let category = kind.category(self.source_type.is_stub());
@@ -801,11 +801,11 @@ impl<'db> SemanticIndexBuilder<'db> {
             self.db,
             self.file,
             self.current_scope(),
-            #[allow(unsafe_code)]
+            #[expect(unsafe_code)]
             unsafe {
                 AstNodeRef::new(self.module.clone(), expression_node)
             },
-            #[allow(unsafe_code)]
+            #[expect(unsafe_code)]
             assigned_to
                 .map(|assigned_to| unsafe { AstNodeRef::new(self.module.clone(), assigned_to) }),
             expression_kind,
@@ -1009,7 +1009,7 @@ impl<'db> SemanticIndexBuilder<'db> {
                     value_file_scope,
                     self.current_scope(),
                     // SAFETY: `target` belongs to the `self.module` tree
-                    #[allow(unsafe_code)]
+                    #[expect(unsafe_code)]
                     unsafe {
                         AstNodeRef::new(self.module.clone(), target)
                     },
@@ -2188,7 +2188,7 @@ where
                     match self.current_assignment() {
                         Some(CurrentAssignment::Assign { node, unpack, .. }) => {
                             // SAFETY: `value` and `expr` belong to the `self.module` tree
-                            #[allow(unsafe_code)]
+                            #[expect(unsafe_code)]
                             let assignment = AssignmentDefinitionKind::new(
                                 TargetKind::from(unpack),
                                 unsafe { AstNodeRef::new(self.module.clone(), &node.value) },
@@ -2203,7 +2203,7 @@ where
                         Some(CurrentAssignment::AnnAssign(ann_assign)) => {
                             self.add_standalone_type_expression(&ann_assign.annotation);
                             // SAFETY: `annotation`, `value` and `expr` belong to the `self.module` tree
-                            #[allow(unsafe_code)]
+                            #[expect(unsafe_code)]
                             let assignment = AnnotatedAssignmentDefinitionKind::new(
                                 unsafe {
                                     AstNodeRef::new(self.module.clone(), &ann_assign.annotation)
@@ -2221,7 +2221,7 @@ where
                         }
                         Some(CurrentAssignment::For { node, unpack, .. }) => {
                             // // SAFETY: `iter` and `expr` belong to the `self.module` tree
-                            #[allow(unsafe_code)]
+                            #[expect(unsafe_code)]
                             let assignment = ForStmtDefinitionKind::new(
                                 TargetKind::from(unpack),
                                 unsafe { AstNodeRef::new(self.module.clone(), &node.iter) },
@@ -2241,7 +2241,7 @@ where
                             ..
                         }) => {
                             // SAFETY: `context_expr` and `expr` belong to the `self.module` tree
-                            #[allow(unsafe_code)]
+                            #[expect(unsafe_code)]
                             let assignment = WithItemDefinitionKind::new(
                                 TargetKind::from(unpack),
                                 unsafe { AstNodeRef::new(self.module.clone(), &item.context_expr) },
@@ -2260,7 +2260,7 @@ where
                             first,
                         }) => {
                             // SAFETY: `iter` and `expr` belong to the `self.module` tree
-                            #[allow(unsafe_code)]
+                            #[expect(unsafe_code)]
                             let assignment = ComprehensionDefinitionKind {
                                 target_kind: TargetKind::from(unpack),
                                 iterable: unsafe {

--- a/crates/ty_python_semantic/src/semantic_index/definition.rs
+++ b/crates/ty_python_semantic/src/semantic_index/definition.rs
@@ -300,7 +300,7 @@ pub(crate) struct MatchPatternDefinitionNodeRef<'a> {
 }
 
 impl<'db> DefinitionNodeRef<'db> {
-    #[allow(unsafe_code)]
+    #[expect(unsafe_code)]
     pub(super) unsafe fn into_owned(self, parsed: ParsedModule) -> DefinitionKind<'db> {
         match self {
             DefinitionNodeRef::Import(ImportDefinitionNodeRef {

--- a/crates/ty_python_semantic/src/semantic_index/symbol.rs
+++ b/crates/ty_python_semantic/src/semantic_index/symbol.rs
@@ -287,7 +287,7 @@ impl SymbolTable {
         &self.symbols[symbol_id.into()]
     }
 
-    #[allow(unused)]
+    #[expect(unused)]
     pub(crate) fn symbol_ids(&self) -> impl Iterator<Item = ScopedSymbolId> {
         self.symbols.indices()
     }
@@ -420,7 +420,7 @@ impl NodeWithScopeRef<'_> {
     ///
     /// # Safety
     /// The node wrapped by `self` must be a child of `module`.
-    #[allow(unsafe_code)]
+    #[expect(unsafe_code)]
     pub(super) unsafe fn to_kind(self, module: ParsedModule) -> NodeWithScopeKind {
         match self {
             NodeWithScopeRef::Module => NodeWithScopeKind::Module,

--- a/crates/ty_python_semantic/src/semantic_index/visibility_constraints.rs
+++ b/crates/ty_python_semantic/src/semantic_index/visibility_constraints.rs
@@ -267,7 +267,7 @@ impl Idx for ScopedVisibilityConstraintId {
     #[inline]
     fn new(value: usize) -> Self {
         assert!(value <= (SMALLEST_TERMINAL.0 as usize));
-        #[allow(clippy::cast_possible_truncation)]
+        #[expect(clippy::cast_possible_truncation)]
         Self(value as u32)
     }
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -5617,7 +5617,6 @@ impl<'db> TypeVarInstance<'db> {
         matches!(self.kind(db), TypeVarKind::Legacy)
     }
 
-    #[allow(unused)]
     pub(crate) fn upper_bound(self, db: &'db dyn Db) -> Option<Type<'db>> {
         if let Some(TypeVarBoundOrConstraints::UpperBound(ty)) = self.bound_or_constraints(db) {
             Some(ty)
@@ -5626,7 +5625,6 @@ impl<'db> TypeVarInstance<'db> {
         }
     }
 
-    #[allow(unused)]
     pub(crate) fn constraints(self, db: &'db dyn Db) -> Option<&'db [Type<'db>]> {
         if let Some(TypeVarBoundOrConstraints::Constraints(tuple)) = self.bound_or_constraints(db) {
             Some(tuple.elements(db))
@@ -5856,7 +5854,7 @@ impl<'db> IterationError<'db> {
             /// Emit a diagnostic that is certain that `iterable_type` is not iterable.
             ///
             /// `because` should explain why `iterable_type` is not iterable.
-            #[allow(clippy::wrong_self_convention)]
+            #[expect(clippy::wrong_self_convention)]
             fn is_not(self, because: impl std::fmt::Display) -> LintDiagnosticGuard<'a, 'a> {
                 let mut diag = self.builder.into_diagnostic(format_args!(
                     "Object of type `{iterable_type}` is not iterable",
@@ -6787,7 +6785,7 @@ impl<'db> FunctionType<'db> {
     /// 3. third `foo` definition, it would contain both overloads and the implementation which is
     ///    itself
     fn to_overloaded(self, db: &'db dyn Db) -> Option<&'db OverloadedFunction<'db>> {
-        #[allow(clippy::ref_option)] // TODO: Remove once salsa supports deref (https://github.com/salsa-rs/salsa/pull/772)
+        #[expect(clippy::ref_option)] // TODO: Remove once salsa supports deref (https://github.com/salsa-rs/salsa/pull/772)
         #[salsa::tracked(return_ref)]
         fn to_overloaded_impl<'db>(
             db: &'db dyn Db,

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -6785,7 +6785,7 @@ impl<'db> FunctionType<'db> {
     /// 3. third `foo` definition, it would contain both overloads and the implementation which is
     ///    itself
     fn to_overloaded(self, db: &'db dyn Db) -> Option<&'db OverloadedFunction<'db>> {
-        #[expect(clippy::ref_option)] // TODO: Remove once salsa supports deref (https://github.com/salsa-rs/salsa/pull/772)
+        #[allow(clippy::ref_option)]
         #[salsa::tracked(return_ref)]
         fn to_overloaded_impl<'db>(
             db: &'db dyn Db,

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -70,7 +70,7 @@ fn try_mro_cycle_recover<'db>(
     salsa::CycleRecoveryAction::Iterate
 }
 
-#[allow(clippy::unnecessary_wraps)]
+#[expect(clippy::unnecessary_wraps)]
 fn try_mro_cycle_initial<'db>(
     db: &'db dyn Db,
     self_: ClassLiteral<'db>,
@@ -82,7 +82,7 @@ fn try_mro_cycle_initial<'db>(
     ))
 }
 
-#[allow(clippy::ref_option, clippy::trivially_copy_pass_by_ref)]
+#[expect(clippy::ref_option, clippy::trivially_copy_pass_by_ref)]
 fn inheritance_cycle_recover<'db>(
     _db: &'db dyn Db,
     _value: &Option<InheritanceCycle>,

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -4078,7 +4078,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         }
     }
 
-    #[allow(clippy::unused_self)]
+    #[expect(clippy::unused_self)]
     fn infer_boolean_literal_expression(&mut self, literal: &ast::ExprBooleanLiteral) -> Type<'db> {
         let ast::ExprBooleanLiteral { range: _, value } = literal;
 

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -66,7 +66,7 @@ pub(crate) fn infer_narrowing_constraint<'db>(
     }
 }
 
-#[expect(clippy::ref_option)]
+#[allow(clippy::ref_option)]
 #[salsa::tracked(return_ref)]
 fn all_narrowing_constraints_for_pattern<'db>(
     db: &'db dyn Db,
@@ -75,7 +75,7 @@ fn all_narrowing_constraints_for_pattern<'db>(
     NarrowingConstraintsBuilder::new(db, PredicateNode::Pattern(pattern), true).finish()
 }
 
-#[expect(clippy::ref_option)]
+#[allow(clippy::ref_option)]
 #[salsa::tracked(
     return_ref,
     cycle_fn=constraints_for_expression_cycle_recover,
@@ -88,7 +88,7 @@ fn all_narrowing_constraints_for_expression<'db>(
     NarrowingConstraintsBuilder::new(db, PredicateNode::Expression(expression), true).finish()
 }
 
-#[expect(clippy::ref_option)]
+#[allow(clippy::ref_option)]
 #[salsa::tracked(
     return_ref,
     cycle_fn=negative_constraints_for_expression_cycle_recover,
@@ -101,7 +101,7 @@ fn all_negative_narrowing_constraints_for_expression<'db>(
     NarrowingConstraintsBuilder::new(db, PredicateNode::Expression(expression), false).finish()
 }
 
-#[expect(clippy::ref_option)]
+#[allow(clippy::ref_option)]
 #[salsa::tracked(return_ref)]
 fn all_negative_narrowing_constraints_for_pattern<'db>(
     db: &'db dyn Db,
@@ -110,7 +110,7 @@ fn all_negative_narrowing_constraints_for_pattern<'db>(
     NarrowingConstraintsBuilder::new(db, PredicateNode::Pattern(pattern), false).finish()
 }
 
-#[expect(clippy::ref_option)]
+#[allow(clippy::ref_option)]
 fn constraints_for_expression_cycle_recover<'db>(
     _db: &'db dyn Db,
     _value: &Option<NarrowingConstraints<'db>>,

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -66,7 +66,7 @@ pub(crate) fn infer_narrowing_constraint<'db>(
     }
 }
 
-#[allow(clippy::ref_option)]
+#[expect(clippy::ref_option)]
 #[salsa::tracked(return_ref)]
 fn all_narrowing_constraints_for_pattern<'db>(
     db: &'db dyn Db,
@@ -75,7 +75,7 @@ fn all_narrowing_constraints_for_pattern<'db>(
     NarrowingConstraintsBuilder::new(db, PredicateNode::Pattern(pattern), true).finish()
 }
 
-#[allow(clippy::ref_option)]
+#[expect(clippy::ref_option)]
 #[salsa::tracked(
     return_ref,
     cycle_fn=constraints_for_expression_cycle_recover,
@@ -88,7 +88,7 @@ fn all_narrowing_constraints_for_expression<'db>(
     NarrowingConstraintsBuilder::new(db, PredicateNode::Expression(expression), true).finish()
 }
 
-#[allow(clippy::ref_option)]
+#[expect(clippy::ref_option)]
 #[salsa::tracked(
     return_ref,
     cycle_fn=negative_constraints_for_expression_cycle_recover,
@@ -101,7 +101,7 @@ fn all_negative_narrowing_constraints_for_expression<'db>(
     NarrowingConstraintsBuilder::new(db, PredicateNode::Expression(expression), false).finish()
 }
 
-#[allow(clippy::ref_option)]
+#[expect(clippy::ref_option)]
 #[salsa::tracked(return_ref)]
 fn all_negative_narrowing_constraints_for_pattern<'db>(
     db: &'db dyn Db,
@@ -110,7 +110,7 @@ fn all_negative_narrowing_constraints_for_pattern<'db>(
     NarrowingConstraintsBuilder::new(db, PredicateNode::Pattern(pattern), false).finish()
 }
 
-#[allow(clippy::ref_option)]
+#[expect(clippy::ref_option)]
 fn constraints_for_expression_cycle_recover<'db>(
     _db: &'db dyn Db,
     _value: &Option<NarrowingConstraints<'db>>,
@@ -127,7 +127,7 @@ fn constraints_for_expression_cycle_initial<'db>(
     None
 }
 
-#[allow(clippy::ref_option)]
+#[expect(clippy::ref_option)]
 fn negative_constraints_for_expression_cycle_recover<'db>(
     _db: &'db dyn Db,
     _value: &Option<NarrowingConstraints<'db>>,

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1485,7 +1485,7 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::many_single_char_names)]
+    #[expect(clippy::many_single_char_names)]
     fn full() {
         let mut db = setup_db();
         db.write_dedented(

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1485,7 +1485,7 @@ mod tests {
     }
 
     #[test]
-    #[expect(clippy::many_single_char_names)]
+    #[allow(clippy::many_single_char_names)]
     fn full() {
         let mut db = setup_db();
         db.write_dedented(

--- a/crates/ty_python_semantic/src/util/subscript.rs
+++ b/crates/ty_python_semantic/src/util/subscript.rs
@@ -127,7 +127,7 @@ impl<T> PySlice for [T] {
         if len == 0 {
             // The iterator needs to have the same type as the step>0 case below,
             // so we need to use `.skip(0)`.
-            #[allow(clippy::iter_skip_zero)]
+            #[expect(clippy::iter_skip_zero)]
             return Ok(Either::Left(self.iter().skip(0).take(0).step_by(1)));
         }
 
@@ -192,7 +192,7 @@ impl<T> PySlice for [T] {
 }
 
 #[cfg(test)]
-#[allow(clippy::redundant_clone)]
+#[expect(clippy::redundant_clone)]
 mod tests {
     use crate::util::subscript::{OutOfBoundsError, StepSizeZeroError};
 

--- a/crates/ty_python_semantic/tests/mdtest.rs
+++ b/crates/ty_python_semantic/tests/mdtest.rs
@@ -7,7 +7,7 @@ use ty_test::OutputFormat;
     dir: "$CARGO_MANIFEST_DIR/resources/mdtest",
     glob: "**/*.md"
 )]
-#[allow(clippy::needless_pass_by_value)]
+#[expect(clippy::needless_pass_by_value)]
 fn mdtest(fixture: Fixture<&str>) {
     let absolute_fixture_path = Utf8Path::new(fixture.path());
     let crate_dir = Utf8Path::new(env!("CARGO_MANIFEST_DIR"));

--- a/crates/ty_server/src/document/notebook.rs
+++ b/crates/ty_server/src/document/notebook.rs
@@ -248,7 +248,7 @@ mod tests {
     use super::NotebookDocument;
 
     enum TestCellContent {
-        #[allow(dead_code)]
+        #[expect(dead_code)]
         Markup(String),
         Code(String),
     }

--- a/crates/ty_server/src/logging.rs
+++ b/crates/ty_server/src/logging.rs
@@ -34,7 +34,7 @@ pub(crate) fn init_logging(log_level: LogLevel, log_file: Option<&std::path::Pat
                 .append(true)
                 .open(&path)
                 .map_err(|err| {
-                    #[allow(clippy::print_stderr)]
+                    #[expect(clippy::print_stderr)]
                     {
                         eprintln!(
                             "Failed to open file at {} for logging: {err}",

--- a/crates/ty_server/src/server.rs
+++ b/crates/ty_server/src/server.rs
@@ -168,7 +168,6 @@ impl Server {
         .join()
     }
 
-    #[expect(clippy::needless_pass_by_value)] // this is because we aren't using `next_request_id` yet.
     fn event_loop(
         connection: &Connection,
         _client_capabilities: &ClientCapabilities,

--- a/crates/ty_server/src/server.rs
+++ b/crates/ty_server/src/server.rs
@@ -2,7 +2,7 @@
 
 use std::num::NonZeroUsize;
 // The new PanicInfoHook name requires MSRV >= 1.82
-#[allow(deprecated)]
+#[expect(deprecated)]
 use std::panic::PanicInfo;
 
 use lsp_server::Message;
@@ -114,7 +114,7 @@ impl Server {
 
     pub(crate) fn run(self) -> crate::Result<()> {
         // The new PanicInfoHook name requires MSRV >= 1.82
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         type PanicHook = Box<dyn Fn(&PanicInfo<'_>) + 'static + Sync + Send>;
         struct RestorePanicHook {
             hook: Option<PanicHook>,
@@ -168,7 +168,7 @@ impl Server {
         .join()
     }
 
-    #[allow(clippy::needless_pass_by_value)] // this is because we aren't using `next_request_id` yet.
+    #[expect(clippy::needless_pass_by_value)] // this is because we aren't using `next_request_id` yet.
     fn event_loop(
         connection: &Connection,
         _client_capabilities: &ClientCapabilities,

--- a/crates/ty_server/src/server/api.rs
+++ b/crates/ty_server/src/server/api.rs
@@ -144,7 +144,7 @@ fn local_notification_task<'a, N: traits::SyncNotificationHandler>(
     }))
 }
 
-#[allow(dead_code)]
+#[expect(dead_code)]
 fn background_notification_thread<'a, N: traits::BackgroundDocumentNotificationHandler>(
     req: server::Notification,
     schedule: BackgroundSchedule,

--- a/crates/ty_server/src/server/client.rs
+++ b/crates/ty_server/src/server/client.rs
@@ -48,7 +48,7 @@ impl Client<'_> {
     }
 }
 
-#[allow(dead_code)] // we'll need to use `Notifier` in the future
+#[expect(dead_code)] // we'll need to use `Notifier` in the future
 impl Notifier {
     pub(crate) fn notify<N>(&self, params: N::Params) -> crate::Result<()>
     where

--- a/crates/ty_server/src/server/schedule/thread/pool.rs
+++ b/crates/ty_server/src/server/schedule/thread/pool.rs
@@ -106,7 +106,7 @@ impl Pool {
         self.job_sender.send(job).unwrap();
     }
 
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(super) fn len(&self) -> usize {
         self.extant_tasks.load(Ordering::SeqCst)
     }

--- a/crates/ty_server/src/server/schedule/thread/priority.rs
+++ b/crates/ty_server/src/server/schedule/thread/priority.rs
@@ -183,14 +183,14 @@ mod imp {
             QoSClass::Background => libc::qos_class_t::QOS_CLASS_BACKGROUND,
         };
 
-        #[allow(unsafe_code)]
+        #[expect(unsafe_code)]
         let code = unsafe { libc::pthread_set_qos_class_self_np(c, 0) };
 
         if code == 0 {
             return;
         }
 
-        #[allow(unsafe_code)]
+        #[expect(unsafe_code)]
         let errno = unsafe { *libc::__error() };
 
         match errno {
@@ -223,10 +223,10 @@ mod imp {
     }
 
     pub(super) fn get_current_thread_qos_class() -> Option<QoSClass> {
-        #[allow(unsafe_code)]
+        #[expect(unsafe_code)]
         let current_thread = unsafe { libc::pthread_self() };
         let mut qos_class_raw = libc::qos_class_t::QOS_CLASS_UNSPECIFIED;
-        #[allow(unsafe_code)]
+        #[expect(unsafe_code)]
         let code = unsafe {
             libc::pthread_get_qos_class_np(current_thread, &mut qos_class_raw, std::ptr::null_mut())
         };
@@ -241,7 +241,7 @@ mod imp {
             // ones which we cannot handle anyway
             //
             // 0: https://github.com/apple-oss-distributions/libpthread/blob/67e155c94093be9a204b69637d198eceff2c7c46/src/qos.c#L171-L177
-            #[allow(unsafe_code)]
+            #[expect(unsafe_code)]
             let errno = unsafe { *libc::__error() };
             unreachable!("`pthread_get_qos_class_np` failed unexpectedly (os error {errno})");
         }

--- a/crates/ty_server/src/session/capabilities.rs
+++ b/crates/ty_server/src/session/capabilities.rs
@@ -1,7 +1,7 @@
 use lsp_types::{ClientCapabilities, MarkupKind};
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
-#[allow(clippy::struct_excessive_bools)]
+#[expect(clippy::struct_excessive_bools)]
 pub(crate) struct ResolvedClientCapabilities {
     pub(crate) code_action_deferred_edit_resolution: bool,
     pub(crate) apply_edit: bool,

--- a/crates/ty_server/src/session/index.rs
+++ b/crates/ty_server/src/session/index.rs
@@ -230,7 +230,6 @@ impl DocumentController {
         }
     }
 
-    #[allow(dead_code)]
     pub(crate) fn as_text(&self) -> Option<&TextDocument> {
         match self {
             Self::Text(document) => Some(document),

--- a/crates/ty_server/src/system.rs
+++ b/crates/ty_server/src/system.rs
@@ -258,6 +258,6 @@ fn virtual_path_not_found(path: impl Display) -> std::io::Error {
 fn document_revision(document: &DocumentQuery) -> FileRevision {
     // The file revision is just an opaque number which doesn't have any significant meaning other
     // than that the file has changed if the revisions are different.
-    #[allow(clippy::cast_sign_loss)]
+    #[expect(clippy::cast_sign_loss)]
     FileRevision::new(document.version() as u128)
 }

--- a/crates/ty_test/src/lib.rs
+++ b/crates/ty_test/src/lib.rs
@@ -33,7 +33,7 @@ const MDTEST_TEST_FILTER: &str = "MDTEST_TEST_FILTER";
 /// Run `path` as a markdown test suite with given `title`.
 ///
 /// Panic on test failure, and print failure details.
-#[allow(clippy::print_stdout)]
+#[expect(clippy::print_stdout)]
 pub fn run(
     absolute_fixture_path: &Utf8Path,
     relative_fixture_path: &Utf8Path,

--- a/crates/ty_wasm/src/lib.rs
+++ b/crates/ty_wasm/src/lib.rs
@@ -152,7 +152,7 @@ impl Workspace {
     }
 
     #[wasm_bindgen(js_name = "closeFile")]
-    #[allow(
+    #[expect(
         clippy::needless_pass_by_value,
         reason = "It's intentional that the file handle is consumed because it is no longer valid after closing"
     )]

--- a/crates/ty_wasm/src/lib.rs
+++ b/crates/ty_wasm/src/lib.rs
@@ -152,7 +152,7 @@ impl Workspace {
     }
 
     #[wasm_bindgen(js_name = "closeFile")]
-    #[expect(
+    #[allow(
         clippy::needless_pass_by_value,
         reason = "It's intentional that the file handle is consumed because it is no longer valid after closing"
     )]

--- a/scripts/generate_builtin_modules.py
+++ b/scripts/generate_builtin_modules.py
@@ -70,7 +70,7 @@ def generate_module(
                 /// modules.
                 ///
                 /// [builtin module]: https://docs.python.org/3/library/sys.html#sys.builtin_module_names
-                #[allow(clippy::unnested_or_patterns)]
+                #[expect(clippy::unnested_or_patterns)]
                 pub fn is_builtin_module(minor_version: u8, module: &str) -> bool {
                     matches!((minor_version, module),
                 """,


### PR DESCRIPTION
## Summary

`#[expect(lint)]` has the advantage that clippy warns if the code no longer raises said lint rule. 

This allowed me to remove some no longer needed `#[allow]` suppressions.

