### PR TITLE
Fix missing `combine` call for `lint.typing-extensions` setting

### DIFF
--- a/crates/ruff/tests/lint.rs
+++ b/crates/ruff/tests/lint.rs
@@ -5676,12 +5676,10 @@ class Foo:
             .arg("-")
             .pass_stdin(contents),
         @r"
-    success: false
-    exit_code: 1
+    success: true
+    exit_code: 0
     ----- stdout -----
-    -:5:10: PYI019 [*] Use `Self` instead of custom TypeVar `T`
-    Found 1 error.
-    [*] 1 fixable with the `--fix` option.
+    All checks passed!
 
     ----- stderr -----
     "

--- a/crates/ruff/tests/lint.rs
+++ b/crates/ruff/tests/lint.rs
@@ -5654,3 +5654,36 @@ fn semantic_syntax_errors() -> Result<()> {
 
     Ok(())
 }
+
+/// Regression test for <https://github.com/astral-sh/ruff/issues/17821>.
+///
+/// `lint.typing-extensions = false` with Python 3.9 should disable the PYI019 lint because it would
+/// try to import `Self` from `typing_extensions`
+#[test]
+fn combine_typing_extensions_config() {
+    let contents = "
+from typing import TypeVar
+T = TypeVar('T')
+class Foo:
+    def f(self: T) -> T: ...
+";
+    assert_cmd_snapshot!(
+        Command::new(get_cargo_bin(BIN_NAME))
+            .args(STDIN_BASE_OPTIONS)
+            .args(["--config", "lint.typing-extensions = false"])
+            .arg("--select=PYI019")
+            .arg("--target-version=py39")
+            .arg("-")
+            .pass_stdin(contents),
+        @r"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    -:5:10: PYI019 [*] Use `Self` instead of custom TypeVar `T`
+    Found 1 error.
+    [*] 1 fixable with the `--fix` option.
+
+    ----- stderr -----
+    "
+    );
+}

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -1173,7 +1173,7 @@ impl LintConfiguration {
             pylint: self.pylint.combine(config.pylint),
             pyupgrade: self.pyupgrade.combine(config.pyupgrade),
             ruff: self.ruff.combine(config.ruff),
-            typing_extensions: self.typing_extensions,
+            typing_extensions: self.typing_extensions.or(config.typing_extensions),
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #17821.

## Test Plan

New CLI test. This might be overkill for such a simple fix, but it made me feel better to add a test.
