### PR TITLE
[`pylint`] add fix safety section (`PLE4703`)

### DIFF
--- a/crates/ruff_linter/src/rules/pylint/rules/modified_iterating_set.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/modified_iterating_set.rs
@@ -24,6 +24,12 @@ use crate::checkers::ast::Checker;
 /// directly on the variable itself (e.g., `set.add()`), as opposed to
 /// modifications within other function calls (e.g., `some_function(set)`).
 ///
+/// ## Fix safety
+/// This fix is always marked as unsafe because it changes the iteration target
+/// from the original set to a copy of the set. While this prevents the RuntimeError
+/// that would occur when modifying a set during iteration, it may change the behavior
+/// of the code if the original set is modified elsewhere during the iteration.
+///
 /// ## Example
 /// ```python
 /// nums = {1, 2, 3}


### PR DESCRIPTION
This PR adds a fix safety section in comment for rule PLE4703.

parent: #15584 
impl was introduced at #970 (couldn't find newer PRs sorry!)