### PR TITLE
Ignore PRs labeled with `ty` for Ruff changelog

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ force-exclude = '''
 major_labels = []  # Ruff never uses the major version number
 minor_labels = ["breaking"]   # Bump the minor version on breaking changes
 
-changelog_ignore_labels = ["internal", "ci", "red-knot", "testing"]
+changelog_ignore_labels = ["internal", "ci", "testing", "ty"]
 
 changelog_sections.breaking = "Breaking changes"
 changelog_sections.preview = "Preview features"


### PR DESCRIPTION
## Summary

Update our rooster configuration to ignore PRs labeled with `ty` in addition to `red-knot` when generating Ruff's changelog. 


