### PR TITLE
[ty] Understand classes that inherit from subscripted `Protocol[]` as generic

### DIFF
--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -59,7 +59,29 @@ type KeyDiagnosticFields = (
     Severity,
 );
 
-static EXPECTED_TOMLLIB_DIAGNOSTICS: &[KeyDiagnosticFields] = &[];
+static EXPECTED_TOMLLIB_DIAGNOSTICS: &[KeyDiagnosticFields] = &[
+    (
+        DiagnosticId::lint("invalid-argument-type"),
+        Some("/src/tomllib/_parser.py"),
+        Some(8224..8254),
+        "Argument to this function is incorrect",
+        Severity::Error,
+    ),
+    (
+        DiagnosticId::lint("invalid-argument-type"),
+        Some("/src/tomllib/_parser.py"),
+        Some(16914..16948),
+        "Argument to this function is incorrect",
+        Severity::Error,
+    ),
+    (
+        DiagnosticId::lint("invalid-argument-type"),
+        Some("/src/tomllib/_parser.py"),
+        Some(17319..17363),
+        "Argument to this function is incorrect",
+        Severity::Error,
+    ),
+];
 
 fn tomllib_path(file: &TestFile) -> SystemPathBuf {
     SystemPathBuf::from("src").join(file.name())

--- a/crates/ty_python_semantic/resources/mdtest/annotations/invalid.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/invalid.md
@@ -99,6 +99,8 @@ async def outer():  # avoid unrelated syntax errors on yield, yield from, and aw
 def _(
     a: {1: 2},  # error: [invalid-type-form] "Dict literals are not allowed in type expressions"
     b: {1, 2},  # error: [invalid-type-form] "Set literals are not allowed in type expressions"
+    # TODO: the `[not-iterable]` error here is a false positive
+    # error: [not-iterable] "Object of type `_T` is not iterable"
     c: {k: v for k, v in [(1, 2)]},  # error: [invalid-type-form] "Dict comprehensions are not allowed in type expressions"
     d: [k for k in [1, 2]],  # error: [invalid-type-form] "List comprehensions are not allowed in type expressions"
     e: {k for k in [1, 2]},  # error: [invalid-type-form] "Set comprehensions are not allowed in type expressions"

--- a/crates/ty_python_semantic/resources/mdtest/annotations/invalid.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/invalid.md
@@ -99,8 +99,6 @@ async def outer():  # avoid unrelated syntax errors on yield, yield from, and aw
 def _(
     a: {1: 2},  # error: [invalid-type-form] "Dict literals are not allowed in type expressions"
     b: {1, 2},  # error: [invalid-type-form] "Set literals are not allowed in type expressions"
-    # TODO: the `[not-iterable]` error here is a false positive
-    # error: [not-iterable] "Object of type `_T` is not iterable"
     c: {k: v for k, v in [(1, 2)]},  # error: [invalid-type-form] "Dict comprehensions are not allowed in type expressions"
     d: [k for k in [1, 2]],  # error: [invalid-type-form] "List comprehensions are not allowed in type expressions"
     e: {k for k in [1, 2]},  # error: [invalid-type-form] "Set comprehensions are not allowed in type expressions"

--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -33,7 +33,9 @@ class Shape:
         reveal_type(self)  # revealed: Unknown
         return self
 
-reveal_type(Shape().nested_type())  # revealed: @Todo(specialized non-generic class)
+# TODO: should be `list[Shape]`
+reveal_type(Shape().nested_type())  # revealed: list[Self]
+
 reveal_type(Shape().nested_func())  # revealed: Shape
 
 class Circle(Shape):

--- a/crates/ty_python_semantic/resources/mdtest/annotations/starred.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/starred.md
@@ -14,7 +14,7 @@ Ts = TypeVarTuple("Ts")
 
 def append_int(*args: *Ts) -> tuple[*Ts, int]:
     # TODO: tuple[*Ts]
-    reveal_type(args)  # revealed: tuple
+    reveal_type(args)  # revealed: tuple[Unknown, ...]
 
     return (*args, 1)
 

--- a/crates/ty_python_semantic/resources/mdtest/annotations/stdlib_typing_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/stdlib_typing_aliases.md
@@ -30,19 +30,17 @@ def f(
     ordered_dict_bare: typing.OrderedDict,
     ordered_dict_parametrized: typing.OrderedDict[int, str],
 ):
-    # TODO: revealed: list[Unknown]
-    reveal_type(list_bare)  # revealed: list
+    reveal_type(list_bare)  # revealed: list[Unknown]
     # TODO: revealed: list[int]
-    reveal_type(list_parametrized)  # revealed: list
+    reveal_type(list_parametrized)  # revealed: list[Unknown]
 
     reveal_type(dict_bare)  # revealed: dict[Unknown, Unknown]
     # TODO: revealed: dict[int, str]
     reveal_type(dict_parametrized)  # revealed: dict[Unknown, Unknown]
 
-    # TODO: revealed: set[Unknown]
-    reveal_type(set_bare)  # revealed: set
+    reveal_type(set_bare)  # revealed: set[Unknown]
     # TODO: revealed: set[int]
-    reveal_type(set_parametrized)  # revealed: set
+    reveal_type(set_parametrized)  # revealed: set[Unknown]
 
     # TODO: revealed: frozenset[Unknown]
     reveal_type(frozen_set_bare)  # revealed: frozenset
@@ -61,10 +59,9 @@ def f(
     # TODO: revealed: defaultdict[str, int]
     reveal_type(default_dict_parametrized)  # revealed: defaultdict[Unknown, Unknown]
 
-    # TODO: revealed: deque[Unknown]
-    reveal_type(deque_bare)  # revealed: deque
+    reveal_type(deque_bare)  # revealed: deque[Unknown]
     # TODO: revealed: deque[str]
-    reveal_type(deque_parametrized)  # revealed: deque
+    reveal_type(deque_parametrized)  # revealed: deque[Unknown]
 
     reveal_type(ordered_dict_bare)  # revealed: OrderedDict[Unknown, Unknown]
     # TODO: revealed: OrderedDict[int, str]
@@ -84,20 +81,18 @@ import typing
 
 class ListSubclass(typing.List): ...
 
-# TODO: generic protocols
-# revealed: tuple[<class 'ListSubclass'>, <class 'list'>, <class 'MutableSequence'>, <class 'Sequence'>, <class 'Reversible'>, <class 'Collection'>, <class 'Iterable'>, <class 'Container'>, @Todo(`Protocol[]` subscript), typing.Generic, <class 'object'>]
+# revealed: tuple[<class 'ListSubclass'>, <class 'list[Unknown]'>, <class 'MutableSequence[Unknown]'>, <class 'Sequence[Unknown]'>, <class 'Reversible[Unknown]'>, <class 'Collection[Unknown]'>, <class 'Iterable[Unknown]'>, <class 'Container[Unknown]'>, typing.Protocol[_T_co], typing.Generic[_T_co], <class 'object'>]
 reveal_type(ListSubclass.__mro__)
 
 class DictSubclass(typing.Dict): ...
 
-# TODO: generic protocols
-# revealed: tuple[<class 'DictSubclass'>, <class 'dict[Unknown, Unknown]'>, <class 'MutableMapping[Unknown, Unknown]'>, <class 'Mapping[Unknown, Unknown]'>, <class 'Collection'>, <class 'Iterable'>, <class 'Container'>, @Todo(`Protocol[]` subscript), typing.Generic, typing.Generic[_KT, _VT_co], <class 'object'>]
+# TODO: should not have multiple `Generic[]` elements
+# revealed: tuple[<class 'DictSubclass'>, <class 'dict[Unknown, Unknown]'>, <class 'MutableMapping[Unknown, Unknown]'>, <class 'Mapping[Unknown, Unknown]'>, <class 'Collection[Unknown]'>, <class 'Iterable[Unknown]'>, <class 'Container[Unknown]'>, typing.Protocol[_T_co], typing.Generic[_T_co], typing.Generic[_KT, _VT_co], <class 'object'>]
 reveal_type(DictSubclass.__mro__)
 
 class SetSubclass(typing.Set): ...
 
-# TODO: generic protocols
-# revealed: tuple[<class 'SetSubclass'>, <class 'set'>, <class 'MutableSet'>, <class 'AbstractSet'>, <class 'Collection'>, <class 'Iterable'>, <class 'Container'>, @Todo(`Protocol[]` subscript), typing.Generic, <class 'object'>]
+# revealed: tuple[<class 'SetSubclass'>, <class 'set[Unknown]'>, <class 'MutableSet[Unknown]'>, <class 'AbstractSet[Unknown]'>, <class 'Collection[Unknown]'>, <class 'Iterable[Unknown]'>, <class 'Container[Unknown]'>, typing.Protocol[_T_co], typing.Generic[_T_co], <class 'object'>]
 reveal_type(SetSubclass.__mro__)
 
 class FrozenSetSubclass(typing.FrozenSet): ...
@@ -112,31 +107,30 @@ reveal_type(FrozenSetSubclass.__mro__)
 
 class ChainMapSubclass(typing.ChainMap): ...
 
-# TODO: generic protocols
-# revealed: tuple[<class 'ChainMapSubclass'>, <class 'ChainMap[Unknown, Unknown]'>, <class 'MutableMapping[Unknown, Unknown]'>, <class 'Mapping[Unknown, Unknown]'>, <class 'Collection'>, <class 'Iterable'>, <class 'Container'>, @Todo(`Protocol[]` subscript), typing.Generic, typing.Generic[_KT, _VT_co], <class 'object'>]
+# TODO: should not have multiple `Generic[]` elements
+# revealed: tuple[<class 'ChainMapSubclass'>, <class 'ChainMap[Unknown, Unknown]'>, <class 'MutableMapping[Unknown, Unknown]'>, <class 'Mapping[Unknown, Unknown]'>, <class 'Collection[Unknown]'>, <class 'Iterable[Unknown]'>, <class 'Container[Unknown]'>, typing.Protocol[_T_co], typing.Generic[_T_co], typing.Generic[_KT, _VT_co], <class 'object'>]
 reveal_type(ChainMapSubclass.__mro__)
 
 class CounterSubclass(typing.Counter): ...
 
-# TODO: Should be (CounterSubclass, Counter, dict, MutableMapping, Mapping, Collection, Sized, Iterable, Container, Generic, object)
-# revealed: tuple[<class 'CounterSubclass'>, <class 'Counter[Unknown]'>, <class 'dict[Unknown, int]'>, <class 'MutableMapping[Unknown, int]'>, <class 'Mapping[Unknown, int]'>, <class 'Collection'>, <class 'Iterable'>, <class 'Container'>, @Todo(`Protocol[]` subscript), typing.Generic, typing.Generic[_KT, _VT_co], typing.Generic[_T], <class 'object'>]
+# TODO: Should have one `Generic[]` element, not three(!)
+# revealed: tuple[<class 'CounterSubclass'>, <class 'Counter[Unknown]'>, <class 'dict[Unknown, int]'>, <class 'MutableMapping[Unknown, int]'>, <class 'Mapping[Unknown, int]'>, <class 'Collection[Unknown]'>, <class 'Iterable[Unknown]'>, <class 'Container[Unknown]'>, typing.Protocol[_T_co], typing.Generic[_T_co], typing.Generic[_KT, _VT_co], typing.Generic[_T], <class 'object'>]
 reveal_type(CounterSubclass.__mro__)
 
 class DefaultDictSubclass(typing.DefaultDict): ...
 
-# TODO: Should be (DefaultDictSubclass, defaultdict, dict, MutableMapping, Mapping, Collection, Sized, Iterable, Container, Generic, object)
-# revealed: tuple[<class 'DefaultDictSubclass'>, <class 'defaultdict[Unknown, Unknown]'>, <class 'dict[Unknown, Unknown]'>, <class 'MutableMapping[Unknown, Unknown]'>, <class 'Mapping[Unknown, Unknown]'>, <class 'Collection'>, <class 'Iterable'>, <class 'Container'>, @Todo(`Protocol[]` subscript), typing.Generic, typing.Generic[_KT, _VT_co], <class 'object'>]
+# TODO: Should not have multiple `Generic[]` elements
+# revealed: tuple[<class 'DefaultDictSubclass'>, <class 'defaultdict[Unknown, Unknown]'>, <class 'dict[Unknown, Unknown]'>, <class 'MutableMapping[Unknown, Unknown]'>, <class 'Mapping[Unknown, Unknown]'>, <class 'Collection[Unknown]'>, <class 'Iterable[Unknown]'>, <class 'Container[Unknown]'>, typing.Protocol[_T_co], typing.Generic[_T_co], typing.Generic[_KT, _VT_co], <class 'object'>]
 reveal_type(DefaultDictSubclass.__mro__)
 
 class DequeSubclass(typing.Deque): ...
 
-# TODO: generic protocols
-# revealed: tuple[<class 'DequeSubclass'>, <class 'deque'>, <class 'MutableSequence'>, <class 'Sequence'>, <class 'Reversible'>, <class 'Collection'>, <class 'Iterable'>, <class 'Container'>, @Todo(`Protocol[]` subscript), typing.Generic, <class 'object'>]
+# revealed: tuple[<class 'DequeSubclass'>, <class 'deque[Unknown]'>, <class 'MutableSequence[Unknown]'>, <class 'Sequence[Unknown]'>, <class 'Reversible[Unknown]'>, <class 'Collection[Unknown]'>, <class 'Iterable[Unknown]'>, <class 'Container[Unknown]'>, typing.Protocol[_T_co], typing.Generic[_T_co], <class 'object'>]
 reveal_type(DequeSubclass.__mro__)
 
 class OrderedDictSubclass(typing.OrderedDict): ...
 
-# TODO: Should be (OrderedDictSubclass, OrderedDict, dict, MutableMapping, Mapping, Collection, Sized, Iterable, Container, Generic, object)
-# revealed: tuple[<class 'OrderedDictSubclass'>, <class 'OrderedDict[Unknown, Unknown]'>, <class 'dict[Unknown, Unknown]'>, <class 'MutableMapping[Unknown, Unknown]'>, <class 'Mapping[Unknown, Unknown]'>, <class 'Collection'>, <class 'Iterable'>, <class 'Container'>, @Todo(`Protocol[]` subscript), typing.Generic, typing.Generic[_KT, _VT_co], <class 'object'>]
+# TODO: Should not have multiple `Generic[]` elements
+# revealed: tuple[<class 'OrderedDictSubclass'>, <class 'OrderedDict[Unknown, Unknown]'>, <class 'dict[Unknown, Unknown]'>, <class 'MutableMapping[Unknown, Unknown]'>, <class 'Mapping[Unknown, Unknown]'>, <class 'Collection[Unknown]'>, <class 'Iterable[Unknown]'>, <class 'Container[Unknown]'>, typing.Protocol[_T_co], typing.Generic[_T_co], typing.Generic[_KT, _VT_co], <class 'object'>]
 reveal_type(OrderedDictSubclass.__mro__)
 ```

--- a/crates/ty_python_semantic/resources/mdtest/annotations/stdlib_typing_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/stdlib_typing_aliases.md
@@ -43,9 +43,9 @@ def f(
     reveal_type(set_parametrized)  # revealed: set[Unknown]
 
     # TODO: revealed: frozenset[Unknown]
-    reveal_type(frozen_set_bare)  # revealed: frozenset
+    reveal_type(frozen_set_bare)  # revealed: frozenset[Unknown]
     # TODO: revealed: frozenset[str]
-    reveal_type(frozen_set_parametrized)  # revealed: frozenset
+    reveal_type(frozen_set_parametrized)  # revealed: frozenset[Unknown]
 
     reveal_type(chain_map_bare)  # revealed: ChainMap[Unknown, Unknown]
     # TODO: revealed: ChainMap[str, int]
@@ -97,8 +97,7 @@ reveal_type(SetSubclass.__mro__)
 
 class FrozenSetSubclass(typing.FrozenSet): ...
 
-# TODO: generic protocols
-# revealed: tuple[<class 'FrozenSetSubclass'>, <class 'frozenset'>, <class 'AbstractSet'>, <class 'Collection'>, <class 'Iterable'>, <class 'Container'>, @Todo(`Protocol[]` subscript), typing.Generic, <class 'object'>]
+# revealed: tuple[<class 'FrozenSetSubclass'>, <class 'frozenset[Unknown]'>, <class 'AbstractSet[Unknown]'>, <class 'Collection[Unknown]'>, <class 'Iterable[Unknown]'>, <class 'Container[Unknown]'>, typing.Protocol[_T_co], typing.Generic[_T_co], <class 'object'>]
 reveal_type(FrozenSetSubclass.__mro__)
 
 ####################

--- a/crates/ty_python_semantic/resources/mdtest/annotations/unsupported_special_forms.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/unsupported_special_forms.md
@@ -16,7 +16,7 @@ Alias: TypeAlias = int
 
 def f(*args: Unpack[Ts]) -> tuple[Unpack[Ts]]:
     # TODO: should understand the annotation
-    reveal_type(args)  # revealed: tuple
+    reveal_type(args)  # revealed: tuple[Unknown, ...]
 
     reveal_type(Alias)  # revealed: @Todo(Support for `typing.TypeAlias`)
 
@@ -24,7 +24,7 @@ def g() -> TypeGuard[int]: ...
 def h() -> TypeIs[int]: ...
 def i(callback: Callable[Concatenate[int, P], R_co], *args: P.args, **kwargs: P.kwargs) -> R_co:
     # TODO: should understand the annotation
-    reveal_type(args)  # revealed: tuple
+    reveal_type(args)  # revealed: tuple[Unknown, ...]
     reveal_type(kwargs)  # revealed: dict[str, @Todo(Support for `typing.ParamSpec`)]
     return callback(42, *args, **kwargs)
 

--- a/crates/ty_python_semantic/resources/mdtest/assignment/annotations.md
+++ b/crates/ty_python_semantic/resources/mdtest/assignment/annotations.md
@@ -61,7 +61,7 @@ reveal_type(d)  # revealed: tuple[tuple[str, str], tuple[int, int]]
 reveal_type(e)  # revealed: @Todo(full tuple[...] support)
 reveal_type(f)  # revealed: @Todo(full tuple[...] support)
 reveal_type(g)  # revealed: @Todo(full tuple[...] support)
-reveal_type(h)  # revealed: tuple[@Todo(specialized non-generic class), @Todo(specialized non-generic class)]
+reveal_type(h)  # revealed: tuple[list[int], list[int]]
 
 reveal_type(i)  # revealed: tuple[str | int, str | int]
 reveal_type(j)  # revealed: tuple[str | int]
@@ -76,7 +76,7 @@ a: tuple[()] = (1, 2)
 # error: [invalid-assignment] "Object of type `tuple[Literal["foo"]]` is not assignable to `tuple[int]`"
 b: tuple[int] = ("foo",)
 
-# error: [invalid-assignment] "Object of type `tuple[list, Literal["foo"]]` is not assignable to `tuple[str | int, str]`"
+# error: [invalid-assignment] "Object of type `tuple[list[Unknown], Literal["foo"]]` is not assignable to `tuple[str | int, str]`"
 c: tuple[str | int, str] = ([], "foo")
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -1728,7 +1728,7 @@ reveal_type(False.real)  # revealed: Literal[0]
 All attribute access on literal `bytes` types is currently delegated to `builtins.bytes`:
 
 ```py
-# revealed: bound method Literal[b"foo"].join(iterable_of_bytes: @Todo(specialized non-generic class), /) -> bytes
+# revealed: bound method Literal[b"foo"].join(iterable_of_bytes: Iterable[@Todo(Support for `typing.TypeAlias`)], /) -> bytes
 reveal_type(b"foo".join)
 # revealed: bound method Literal[b"foo"].endswith(suffix: @Todo(Support for `typing.TypeAlias`), start: SupportsIndex | None = ellipsis, end: SupportsIndex | None = ellipsis, /) -> bool
 reveal_type(b"foo".endswith)

--- a/crates/ty_python_semantic/resources/mdtest/expression/lambda.md
+++ b/crates/ty_python_semantic/resources/mdtest/expression/lambda.md
@@ -79,8 +79,7 @@ lambda x=1: reveal_type(x)  # revealed: Unknown | Literal[1]
 Using a variadic parameter:
 
 ```py
-# TODO: should be `tuple[Unknown, ...]` (needs generics)
-lambda *args: reveal_type(args)  # revealed: tuple
+lambda *args: reveal_type(args)  # revealed: tuple[Unknown, ...]
 ```
 
 Using a keyword-variadic parameter:

--- a/crates/ty_python_semantic/resources/mdtest/function/parameters.md
+++ b/crates/ty_python_semantic/resources/mdtest/function/parameters.md
@@ -25,8 +25,8 @@ def f(a, b: int, c=1, d: int = 2, /, e=3, f: Literal[4] = 4, *args: object, g=5,
     reveal_type(f)  # revealed: Literal[4]
     reveal_type(g)  # revealed: Unknown | Literal[5]
     reveal_type(h)  # revealed: Literal[6]
-    # TODO: should be `tuple[object, ...]` (needs generics)
-    reveal_type(args)  # revealed: tuple
+    # TODO: should be `tuple[object, ...]`
+    reveal_type(args)  # revealed: tuple[Unknown, ...]
     reveal_type(kwargs)  # revealed: dict[str, str]
 ```
 
@@ -36,8 +36,7 @@ def f(a, b: int, c=1, d: int = 2, /, e=3, f: Literal[4] = 4, *args: object, g=5,
 
 ```py
 def g(*args, **kwargs):
-    # TODO: should be `tuple[Unknown, ...]` (needs generics)
-    reveal_type(args)  # revealed: tuple
+    reveal_type(args)  # revealed: tuple[Unknown, ...]
     reveal_type(kwargs)  # revealed: dict[str, Unknown]
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -399,7 +399,7 @@ In a specialized generic alias, the specialization is applied to the attributes 
 class.
 
 ```py
-from typing import Generic, TypeVar
+from typing import Generic, TypeVar, Protocol
 
 T = TypeVar("T")
 U = TypeVar("U")
@@ -425,6 +425,33 @@ reveal_type(c.y)  # revealed: str
 reveal_type(c.method1())  # revealed: int
 reveal_type(c.method2())  # revealed: str
 reveal_type(c.method3())  # revealed: LinkedList[int]
+
+class SomeProtocol(Protocol[T]):
+    x: T
+
+class Foo:
+    x: int
+
+class D(Generic[T, U]):
+    x: T
+    y: U
+
+    def method1(self) -> T:
+        return self.x
+
+    def method2(self) -> U:
+        return self.y
+
+    def method3(self) -> SomeProtocol[T]:
+        return Foo()
+
+d = D[int, str]()
+reveal_type(d.x)  # revealed: int
+reveal_type(d.y)  # revealed: str
+reveal_type(d.method1())  # revealed: int
+reveal_type(d.method2())  # revealed: str
+reveal_type(d.method3())  # revealed: SomeProtocol[int]
+reveal_type(d.method3().x)  # revealed: int
 ```
 
 ## Cyclic class definitions

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/variables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/variables.md
@@ -38,6 +38,7 @@ T = TypeVar("T")
 U: TypeVar = TypeVar("U")
 
 # error: [invalid-legacy-type-variable] "A legacy `typing.TypeVar` must be immediately assigned to a variable"
+# error: [invalid-type-form] "Function calls are not allowed in type expressions"
 TestList = list[TypeVar("W")]
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
@@ -65,7 +65,7 @@ from typing import Generic, TypeVar
 
 T = TypeVar("T")
 
-# error: [invalid-generic-class] "Cannot both inherit from `Generic` and use PEP 695 type variables"
+# error: [invalid-generic-class] "Cannot both inherit from `typing.Generic` and use PEP 695 type variables"
 class BothGenericSyntaxes[U](Generic[T]): ...
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/import/dunder_all.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/dunder_all.md
@@ -785,7 +785,7 @@ from subexporter import *
 
 # TODO: Should be `list[str]`
 # TODO: Should we avoid including `Unknown` for this case?
-reveal_type(__all__)  # revealed: Unknown | list
+reveal_type(__all__)  # revealed: Unknown | list[Unknown]
 
 __all__.append("B")
 

--- a/crates/ty_python_semantic/resources/mdtest/literal/collections/list.md
+++ b/crates/ty_python_semantic/resources/mdtest/literal/collections/list.md
@@ -3,5 +3,5 @@
 ## Empty list
 
 ```py
-reveal_type([])  # revealed: list
+reveal_type([])  # revealed: list[Unknown]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/literal/collections/set.md
+++ b/crates/ty_python_semantic/resources/mdtest/literal/collections/set.md
@@ -3,5 +3,5 @@
 ## Basic set
 
 ```py
-reveal_type({1, 2})  # revealed: set
+reveal_type({1, 2})  # revealed: set[Unknown]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/named_tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/named_tuple.md
@@ -48,8 +48,8 @@ alice2 = Person2(1, "Alice")
 # TODO: should be an error
 Person2(1)
 
-reveal_type(alice2.id)  # revealed: @Todo(GenericAlias instance)
-reveal_type(alice2.name)  # revealed: @Todo(GenericAlias instance)
+reveal_type(alice2.id)  # revealed: @Todo(functional `NamedTuple` syntax)
+reveal_type(alice2.name)  # revealed: @Todo(functional `NamedTuple` syntax)
 ```
 
 ### Multiple Inheritance

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -133,11 +133,11 @@ match x:
     case "foo" | 42 | None:
         reveal_type(x)  # revealed: Literal["foo", 42] | None
     case "foo" | tuple():
-        reveal_type(x)  # revealed: tuple
+        reveal_type(x)  # revealed: tuple[Unknown, ...]
     case True | False:
         reveal_type(x)  # revealed: bool
     case 3.14 | 2.718 | 1.414:
-        reveal_type(x)  # revealed: float & ~tuple
+        reveal_type(x)  # revealed: float & ~tuple[Unknown, ...]
 
 reveal_type(x)  # revealed: object
 ```
@@ -155,7 +155,7 @@ reveal_type(x)  # revealed: object
 match x:
     case "foo" | 42 | None if reveal_type(x):  # revealed: Literal["foo", 42] | None
         pass
-    case "foo" | tuple() if reveal_type(x):  # revealed: Literal["foo"] | tuple
+    case "foo" | tuple() if reveal_type(x):  # revealed: Literal["foo"] | tuple[Unknown, ...]
         pass
     case True | False if reveal_type(x):  # revealed: bool
         pass

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -58,6 +58,7 @@ class Bar1(Protocol[T], Generic[T]):
 class Bar2[T](Protocol):
     x: T
 
+# error: [invalid-generic-class] "Cannot both inherit from subscripted `typing.Protocol` and use PEP 695 type variables"
 class Bar3[T](Protocol[T]):
     x: T
 ```
@@ -70,8 +71,8 @@ simultaneously:
 class DuplicateBases(Protocol, Protocol[T]):
     x: T
 
-# TODO: should not have `Protocol` multiple times
-# revealed: tuple[<class 'DuplicateBases'>, typing.Protocol, @Todo(`Protocol[]` subscript), typing.Generic, <class 'object'>]
+# TODO: should not have `Protocol` or `Generic` multiple times
+# revealed: tuple[<class 'DuplicateBases[Unknown]'>, typing.Protocol, typing.Generic, typing.Protocol[T], typing.Generic[T], <class 'object'>]
 reveal_type(DuplicateBases.__mro__)
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/scopes/moduletype_attrs.md
+++ b/crates/ty_python_semantic/resources/mdtest/scopes/moduletype_attrs.md
@@ -13,8 +13,7 @@ reveal_type(__loader__)  # revealed: LoaderProtocol | None
 reveal_type(__package__)  # revealed: str | None
 reveal_type(__doc__)  # revealed: str | None
 reveal_type(__spec__)  # revealed: ModuleSpec | None
-
-reveal_type(__path__)  # revealed: @Todo(specialized non-generic class)
+reveal_type(__path__)  # revealed: MutableSequence[str]
 
 class X:
     reveal_type(__name__)  # revealed: str

--- a/crates/ty_python_semantic/resources/mdtest/subscript/lists.md
+++ b/crates/ty_python_semantic/resources/mdtest/subscript/lists.md
@@ -9,13 +9,13 @@ A list can be indexed into with:
 
 ```py
 x = [1, 2, 3]
-reveal_type(x)  # revealed: list
+reveal_type(x)  # revealed: list[Unknown]
 
 # TODO reveal int
 reveal_type(x[0])  # revealed: Unknown
 
 # TODO reveal list
-reveal_type(x[0:1])  # revealed: @Todo(specialized non-generic class)
+reveal_type(x[0:1])  # revealed: list[Unknown]
 
 # error: [call-non-callable]
 reveal_type(x["a"])  # revealed: Unknown

--- a/crates/ty_python_semantic/resources/mdtest/subscript/lists.md
+++ b/crates/ty_python_semantic/resources/mdtest/subscript/lists.md
@@ -14,7 +14,7 @@ reveal_type(x)  # revealed: list[Unknown]
 # TODO reveal int
 reveal_type(x[0])  # revealed: Unknown
 
-# TODO reveal list
+# TODO reveal list[int]
 reveal_type(x[0:1])  # revealed: list[Unknown]
 
 # error: [call-non-callable]

--- a/crates/ty_python_semantic/resources/mdtest/subscript/tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/subscript/tuple.md
@@ -83,9 +83,7 @@ python-version = "3.9"
 ```py
 class A(tuple[int, str]): ...
 
-# Runtime value: `(A, tuple, object)`
-# TODO: Generics
-reveal_type(A.__mro__)  # revealed: tuple[<class 'A'>, @Todo(GenericAlias instance), <class 'object'>]
+reveal_type(A.__mro__)  # revealed: tuple[<class 'A'>, <class 'tuple[@Todo(Generic tuple specializations), ...]'>, <class 'Sequence[@Todo(Generic tuple specializations)]'>, <class 'Reversible[@Todo(Generic tuple specializations)]'>, <class 'Collection[@Todo(Generic tuple specializations)]'>, <class 'Iterable[@Todo(Generic tuple specializations)]'>, <class 'Container[@Todo(Generic tuple specializations)]'>, typing.Protocol[_T_co], typing.Generic[_T_co], <class 'object'>]
 ```
 
 ## `typing.Tuple`
@@ -100,7 +98,7 @@ from typing import Any, Tuple
 class A: ...
 
 def _(c: Tuple, d: Tuple[int, A], e: Tuple[Any, ...]):
-    reveal_type(c)  # revealed: tuple
+    reveal_type(c)  # revealed: tuple[Unknown, ...]
     reveal_type(d)  # revealed: tuple[int, A]
     reveal_type(e)  # revealed: @Todo(full tuple[...] support)
 ```
@@ -115,7 +113,6 @@ from typing import Tuple
 
 class C(Tuple): ...
 
-# TODO: generic protocols
-# revealed: tuple[<class 'C'>, <class 'tuple'>, <class 'Sequence'>, <class 'Reversible'>, <class 'Collection'>, <class 'Iterable'>, <class 'Container'>, @Todo(`Protocol[]` subscript), typing.Generic, <class 'object'>]
+# revealed: tuple[<class 'C'>, <class 'tuple[Unknown, ...]'>, <class 'Sequence[Unknown]'>, <class 'Reversible[Unknown]'>, <class 'Collection[Unknown]'>, <class 'Iterable[Unknown]'>, <class 'Container[Unknown]'>, typing.Protocol[_T_co], typing.Generic[_T_co], <class 'object'>]
 reveal_type(C.__mro__)
 ```

--- a/crates/ty_python_semantic/resources/mdtest/subscript/tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/subscript/tuple.md
@@ -83,7 +83,8 @@ python-version = "3.9"
 ```py
 class A(tuple[int, str]): ...
 
-reveal_type(A.__mro__)  # revealed: tuple[<class 'A'>, <class 'tuple[@Todo(Generic tuple specializations), ...]'>, <class 'Sequence[@Todo(Generic tuple specializations)]'>, <class 'Reversible[@Todo(Generic tuple specializations)]'>, <class 'Collection[@Todo(Generic tuple specializations)]'>, <class 'Iterable[@Todo(Generic tuple specializations)]'>, <class 'Container[@Todo(Generic tuple specializations)]'>, typing.Protocol[_T_co], typing.Generic[_T_co], <class 'object'>]
+# revealed: tuple[<class 'A'>, <class 'tuple[@Todo(Generic tuple specializations), ...]'>, <class 'Sequence[@Todo(Generic tuple specializations)]'>, <class 'Reversible[@Todo(Generic tuple specializations)]'>, <class 'Collection[@Todo(Generic tuple specializations)]'>, <class 'Iterable[@Todo(Generic tuple specializations)]'>, <class 'Container[@Todo(Generic tuple specializations)]'>, typing.Protocol[_T_co], typing.Generic[_T_co], <class 'object'>]
+reveal_type(A.__mro__)
 ```
 
 ## `typing.Tuple`

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
@@ -151,7 +151,8 @@ static_assert(not is_subtype_of(tuple[B1, B2], tuple[()]))
 static_assert(not is_subtype_of(tuple[B1, B2], tuple[A1]))
 static_assert(not is_subtype_of(tuple[B1, B2], tuple[A1, A2, Unrelated]))
 
-static_assert(is_subtype_of(tuple[int], tuple))
+# TODO: should pass
+static_assert(is_subtype_of(tuple[int], tuple[object, ...]))  # error: [static-assert-error]
 ```
 
 ## Union types

--- a/crates/ty_python_semantic/resources/primer/bad.txt
+++ b/crates/ty_python_semantic/resources/primer/bad.txt
@@ -6,14 +6,20 @@ cpython  # access to field whilst being initialized, too many cycle iterations
 discord.py  # some kind of hang, only when multi-threaded?
 freqtrade  # hangs
 hydpy  # too many iterations
+ibis  # too many iterations
+jax  # too many iterations
+packaging  # too many iterations
 pandas  # slow
 pandas-stubs  # hangs/slow, or else https://github.com/salsa-rs/salsa/issues/831
 pandera  # stack overflow
+pip  # vendors packaging, see above
 prefect # slow
 pylint  # cycle panics (self-recursive type alias)
+pyodide  # too many cycle iterations
 pywin32  # bad use-def map (binding with definitely-visible unbound)
 schemathesis  # https://github.com/salsa-rs/salsa/issues/831
 scikit-learn  # success, but mypy-primer hangs processing the output
+setuptools  # vendors packaging, see above
 spack  # success, but mypy-primer hangs processing the output
 spark  # too many iterations
 steam.py  # hangs

--- a/crates/ty_python_semantic/resources/primer/good.txt
+++ b/crates/ty_python_semantic/resources/primer/good.txt
@@ -42,13 +42,11 @@ git-revise
 graphql-core
 httpx-caching
 hydra-zen
-ibis
 ignite
 imagehash
 isort
 itsdangerous
 janus
-jax
 jinja
 koda-validate
 kopf
@@ -70,11 +68,9 @@ openlibrary
 operator
 optuna
 paasta
-packaging
 paroxython
 parso
 pegen
-pip
 poetry
 porcupine
 ppb-vector
@@ -86,7 +82,6 @@ pydantic
 pyinstrument
 pyjwt
 pylox
-pyodide
 pyp
 pyppeteer
 pytest
@@ -100,7 +95,6 @@ rotki
 schema_salad
 scipy
 scrapy
-setuptools
 sockeye
 speedrun.com_global_scoreboard_webapp
 sphinx

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -662,7 +662,7 @@ impl<'db> Type<'db> {
 
     pub fn contains_todo(&self, db: &'db dyn Db) -> bool {
         match self {
-            Self::Dynamic(DynamicType::Todo(_) | DynamicType::SubscriptedProtocol) => true,
+            Self::Dynamic(DynamicType::Todo(_)) => true,
 
             Self::AlwaysFalsy
             | Self::AlwaysTruthy
@@ -703,9 +703,7 @@ impl<'db> Type<'db> {
             }
 
             Self::SubclassOf(subclass_of) => match subclass_of.subclass_of() {
-                SubclassOfInner::Dynamic(
-                    DynamicType::Todo(_) | DynamicType::SubscriptedProtocol,
-                ) => true,
+                SubclassOfInner::Dynamic(DynamicType::Todo(_)) => true,
                 SubclassOfInner::Dynamic(DynamicType::Unknown | DynamicType::Any) => false,
                 SubclassOfInner::Class(_) => false,
             },
@@ -722,12 +720,10 @@ impl<'db> Type<'db> {
             Self::BoundSuper(bound_super) => {
                 matches!(
                     bound_super.pivot_class(db),
-                    ClassBase::Dynamic(DynamicType::Todo(_) | DynamicType::SubscriptedProtocol)
+                    ClassBase::Dynamic(DynamicType::Todo(_))
                 ) || matches!(
                     bound_super.owner(db),
-                    SuperOwnerKind::Dynamic(
-                        DynamicType::Todo(_) | DynamicType::SubscriptedProtocol
-                    )
+                    SuperOwnerKind::Dynamic(DynamicType::Todo(_))
                 )
             }
 
@@ -5506,9 +5502,6 @@ pub enum DynamicType {
     ///
     /// This variant should be created with the `todo_type!` macro.
     Todo(TodoType),
-    /// Temporary type until we support generic protocols.
-    /// We use a separate variant (instead of `Todo(…)`) in order to be able to match on them explicitly.
-    SubscriptedProtocol,
 }
 
 impl std::fmt::Display for DynamicType {
@@ -5519,11 +5512,6 @@ impl std::fmt::Display for DynamicType {
             // `DynamicType::Todo`'s display should be explicit that is not a valid display of
             // any other type
             DynamicType::Todo(todo) => write!(f, "@Todo{todo}"),
-            DynamicType::SubscriptedProtocol => f.write_str(if cfg!(debug_assertions) {
-                "@Todo(`Protocol[]` subscript)"
-            } else {
-                "@Todo"
-            }),
         }
     }
 }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -5099,6 +5099,10 @@ impl<'db> Type<'db> {
                 instance.apply_type_mapping(db, type_mapping),
             ),
 
+            Type::ProtocolInstance(instance) => {
+                Type::ProtocolInstance(instance.apply_specialization(db, specialization))
+            }
+
             Type::MethodWrapper(MethodWrapperKind::FunctionTypeDunderGet(function)) => {
                 Type::MethodWrapper(MethodWrapperKind::FunctionTypeDunderGet(
                     function.apply_type_mapping(db, type_mapping),
@@ -5182,8 +5186,6 @@ impl<'db> Type<'db> {
             | Type::StringLiteral(_)
             | Type::BytesLiteral(_)
             | Type::BoundSuper(_)
-            // Same for `ProtocolInstance`
-            | Type::ProtocolInstance(_)
             | Type::KnownInstance(_) => self,
         }
     }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -5096,7 +5096,7 @@ impl<'db> Type<'db> {
             ),
 
             Type::ProtocolInstance(instance) => {
-                Type::ProtocolInstance(instance.apply_specialization(db, specialization))
+                Type::ProtocolInstance(instance.apply_specialization(db, type_mapping))
             }
 
             Type::MethodWrapper(MethodWrapperKind::FunctionTypeDunderGet(function)) => {

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -18,7 +18,7 @@ pub enum ClassBase<'db> {
     Class(ClassType<'db>),
     /// Although `Protocol` is not a class in typeshed's stubs, it is at runtime,
     /// and can appear in the MRO of a class.
-    Protocol,
+    Protocol(Option<GenericContext<'db>>),
     /// Bare `Generic` cannot be subclassed directly in user code,
     /// but nonetheless appears in the MRO of classes that inherit from `Generic[T]`,
     /// `Protocol[T]`, or bare `Protocol`.
@@ -50,11 +50,17 @@ impl<'db> ClassBase<'db> {
                     ClassBase::Class(ClassType::Generic(alias)) => {
                         write!(f, "<class '{}'>", alias.display(self.db))
                     }
-                    ClassBase::Protocol => f.write_str("typing.Protocol"),
+                    ClassBase::Protocol(generic_context) => {
+                        f.write_str("typing.Protocol")?;
+                        if let Some(generic_context) = generic_context {
+                            generic_context.display(self.db).fmt(f)?;
+                        }
+                        Ok(())
+                    }
                     ClassBase::Generic(generic_context) => {
                         f.write_str("typing.Generic")?;
                         if let Some(generic_context) = generic_context {
-                            write!(f, "{}", generic_context.display(self.db))?;
+                            generic_context.display(self.db).fmt(f)?;
                         }
                         Ok(())
                     }
@@ -71,7 +77,7 @@ impl<'db> ClassBase<'db> {
             ClassBase::Dynamic(DynamicType::Any) => "Any",
             ClassBase::Dynamic(DynamicType::Unknown) => "Unknown",
             ClassBase::Dynamic(DynamicType::Todo(_)) => "@Todo",
-            ClassBase::Protocol | ClassBase::Dynamic(DynamicType::SubscriptedProtocol) => {
+            ClassBase::Protocol(_) | ClassBase::Dynamic(DynamicType::SubscriptedProtocol) => {
                 "Protocol"
             }
             ClassBase::Generic(_) => "Generic",
@@ -199,7 +205,9 @@ impl<'db> ClassBase<'db> {
                 KnownInstanceType::Callable => {
                     Self::try_from_type(db, todo_type!("Support for Callable as a base class"))
                 }
-                KnownInstanceType::Protocol => Some(ClassBase::Protocol),
+                KnownInstanceType::Protocol(generic_context) => {
+                    Some(ClassBase::Protocol(generic_context))
+                }
                 KnownInstanceType::Generic(generic_context) => {
                     Some(ClassBase::Generic(generic_context))
                 }
@@ -210,14 +218,14 @@ impl<'db> ClassBase<'db> {
     pub(super) fn into_class(self) -> Option<ClassType<'db>> {
         match self {
             Self::Class(class) => Some(class),
-            Self::Dynamic(_) | Self::Generic(_) | Self::Protocol => None,
+            Self::Dynamic(_) | Self::Generic(_) | Self::Protocol(_) => None,
         }
     }
 
     fn apply_type_mapping<'a>(self, db: &'db dyn Db, type_mapping: TypeMapping<'a, 'db>) -> Self {
         match self {
             Self::Class(class) => Self::Class(class.apply_type_mapping(db, type_mapping)),
-            Self::Dynamic(_) | Self::Generic(_) | Self::Protocol => self,
+            Self::Dynamic(_) | Self::Generic(_) | Self::Protocol(_) => self,
         }
     }
 
@@ -241,7 +249,7 @@ impl<'db> ClassBase<'db> {
                     .try_mro(db, specialization)
                     .is_err_and(MroError::is_cycle)
             }
-            ClassBase::Dynamic(_) | ClassBase::Generic(_) | ClassBase::Protocol => false,
+            ClassBase::Dynamic(_) | ClassBase::Generic(_) | ClassBase::Protocol(_) => false,
         }
     }
 
@@ -252,8 +260,8 @@ impl<'db> ClassBase<'db> {
         additional_specialization: Option<Specialization<'db>>,
     ) -> impl Iterator<Item = ClassBase<'db>> {
         match self {
-            ClassBase::Protocol => {
-                ClassBaseMroIterator::length_3(db, self, ClassBase::Generic(None))
+            ClassBase::Protocol(context) => {
+                ClassBaseMroIterator::length_3(db, self, ClassBase::Generic(context))
             }
             ClassBase::Dynamic(DynamicType::SubscriptedProtocol) => {
                 ClassBaseMroIterator::length_3(db, self, ClassBase::Generic(None))
@@ -279,7 +287,9 @@ impl<'db> From<ClassBase<'db>> for Type<'db> {
         match value {
             ClassBase::Dynamic(dynamic) => Type::Dynamic(dynamic),
             ClassBase::Class(class) => class.into(),
-            ClassBase::Protocol => Type::KnownInstance(KnownInstanceType::Protocol),
+            ClassBase::Protocol(generic_context) => {
+                Type::KnownInstance(KnownInstanceType::Protocol(generic_context))
+            }
             ClassBase::Generic(generic_context) => {
                 Type::KnownInstance(KnownInstanceType::Generic(generic_context))
             }

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -77,9 +77,7 @@ impl<'db> ClassBase<'db> {
             ClassBase::Dynamic(DynamicType::Any) => "Any",
             ClassBase::Dynamic(DynamicType::Unknown) => "Unknown",
             ClassBase::Dynamic(DynamicType::Todo(_)) => "@Todo",
-            ClassBase::Protocol(_) | ClassBase::Dynamic(DynamicType::SubscriptedProtocol) => {
-                "Protocol"
-            }
+            ClassBase::Protocol(_) => "Protocol",
             ClassBase::Generic(_) => "Generic",
         }
     }
@@ -262,9 +260,6 @@ impl<'db> ClassBase<'db> {
         match self {
             ClassBase::Protocol(context) => {
                 ClassBaseMroIterator::length_3(db, self, ClassBase::Generic(context))
-            }
-            ClassBase::Dynamic(DynamicType::SubscriptedProtocol) => {
-                ClassBaseMroIterator::length_3(db, self, ClassBase::Generic(None))
             }
             ClassBase::Dynamic(_) | ClassBase::Generic(_) => {
                 ClassBaseMroIterator::length_2(db, self)

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -107,6 +107,7 @@ use super::diagnostic::{
     report_unresolved_reference, INVALID_METACLASS, INVALID_OVERLOAD, INVALID_PROTOCOL,
     REDUNDANT_CAST, STATIC_ASSERT_ERROR, SUBCLASS_OF_FINAL_CLASS, TYPE_ASSERTION_FAILURE,
 };
+use super::generics::{GenericContextOrigin, LegacyGenericBase};
 use super::slots::check_class_slots;
 use super::string_annotation::{
     parse_string_annotation, BYTE_STRING_TYPE_ANNOTATION, FSTRING_TYPE_ANNOTATION,
@@ -1020,14 +1021,16 @@ impl<'db> TypeInferenceBuilder<'db> {
 
             // (5) Check that a generic class does not have invalid or conflicting generic
             // contexts.
-            if class.pep695_generic_context(self.db()).is_some()
-                && class.legacy_generic_context(self.db()).is_some()
-            {
-                if let Some(builder) = self.context.report_lint(&INVALID_GENERIC_CLASS, class_node)
-                {
-                    builder.into_diagnostic(
-                        "Cannot both inherit from `Generic` and use PEP 695 type variables",
-                    );
+            if class.pep695_generic_context(self.db()).is_some() {
+                if let Some(legacy_context) = class.legacy_generic_context(self.db()) {
+                    if let Some(builder) =
+                        self.context.report_lint(&INVALID_GENERIC_CLASS, class_node)
+                    {
+                        builder.into_diagnostic(format_args!(
+                            "Cannot both inherit from {} and use PEP 695 type variables",
+                            legacy_context.origin(self.db())
+                        ));
+                    }
                 }
             }
 
@@ -4734,6 +4737,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                         | KnownClass::Property
                         | KnownClass::Super
                         | KnownClass::TypeVar
+                        | KnownClass::NamedTuple
                 )
             )
             // temporary special-casing for all subclasses of `enum.Enum`
@@ -6884,6 +6888,13 @@ impl<'db> TypeInferenceBuilder<'db> {
         // special cases, too.
         let value_ty = self.infer_expression(value);
         if let Type::ClassLiteral(class) = value_ty {
+            if class.is_known(self.db(), KnownClass::Tuple) {
+                self.infer_expression(slice);
+                // TODO heterogeneous and homogeneous tuples in value expressions
+                return Type::from(
+                    class.todo_specialization(self.db(), "Generic tuple specializations"),
+                );
+            }
             if let Some(generic_context) = class.generic_context(self.db()) {
                 return self.infer_explicit_class_specialization(
                     subscript,
@@ -7072,14 +7083,44 @@ impl<'db> TypeInferenceBuilder<'db> {
                 value_ty,
                 Type::IntLiteral(i64::from(bool)),
             ),
-            (Type::KnownInstance(KnownInstanceType::Protocol), _, _) => {
-                Type::Dynamic(DynamicType::SubscriptedProtocol)
+            (Type::KnownInstance(KnownInstanceType::Protocol(None)), Type::Tuple(typevars), _) => {
+                self.legacy_generic_class_context(
+                    value_node,
+                    typevars.elements(self.db()),
+                    LegacyGenericBase::Protocol,
+                )
+                .map(|context| Type::KnownInstance(KnownInstanceType::Protocol(Some(context))))
+                .unwrap_or_else(Type::unknown)
+            }
+            (Type::KnownInstance(KnownInstanceType::Protocol(None)), typevar, _) => self
+                .legacy_generic_class_context(
+                    value_node,
+                    std::slice::from_ref(&typevar),
+                    LegacyGenericBase::Protocol,
+                )
+                .map(|context| Type::KnownInstance(KnownInstanceType::Protocol(Some(context))))
+                .unwrap_or_else(Type::unknown),
+            (Type::KnownInstance(KnownInstanceType::Protocol(Some(_))), _, _) => {
+                // TODO: emit a diagnostic
+                todo_type!("doubly-specialized typing.Protocol")
             }
             (Type::KnownInstance(KnownInstanceType::Generic(None)), Type::Tuple(typevars), _) => {
-                self.infer_subscript_legacy_generic_class(value_node, typevars.elements(self.db()))
+                self.legacy_generic_class_context(
+                    value_node,
+                    typevars.elements(self.db()),
+                    LegacyGenericBase::Generic,
+                )
+                .map(|context| Type::KnownInstance(KnownInstanceType::Generic(Some(context))))
+                .unwrap_or_else(Type::unknown)
             }
             (Type::KnownInstance(KnownInstanceType::Generic(None)), typevar, _) => self
-                .infer_subscript_legacy_generic_class(value_node, std::slice::from_ref(&typevar)),
+                .legacy_generic_class_context(
+                    value_node,
+                    std::slice::from_ref(&typevar),
+                    LegacyGenericBase::Generic,
+                )
+                .map(|context| Type::KnownInstance(KnownInstanceType::Generic(Some(context))))
+                .unwrap_or_else(Type::unknown),
             (Type::KnownInstance(KnownInstanceType::Generic(Some(_))), _, _) => {
                 // TODO: emit a diagnostic
                 todo_type!("doubly-specialized typing.Generic")
@@ -7238,11 +7279,12 @@ impl<'db> TypeInferenceBuilder<'db> {
         }
     }
 
-    fn infer_subscript_legacy_generic_class(
+    fn legacy_generic_class_context(
         &mut self,
         value_node: &ast::Expr,
         typevars: &[Type<'db>],
-    ) -> Type<'db> {
+        origin: LegacyGenericBase,
+    ) -> Option<GenericContext<'db>> {
         let typevars: Option<FxOrderSet<_>> = typevars
             .iter()
             .map(|typevar| match typevar {
@@ -7252,7 +7294,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                         self.context.report_lint(&INVALID_ARGUMENT_TYPE, value_node)
                     {
                         builder.into_diagnostic(format_args!(
-                            "`{}` is not a valid argument to `typing.Generic`",
+                            "`{}` is not a valid argument to {origin}",
                             typevar.display(self.db()),
                         ));
                     }
@@ -7260,11 +7302,9 @@ impl<'db> TypeInferenceBuilder<'db> {
                 }
             })
             .collect();
-        let Some(typevars) = typevars else {
-            return Type::unknown();
-        };
-        let generic_context = GenericContext::new(self.db(), typevars);
-        Type::KnownInstance(KnownInstanceType::Generic(Some(generic_context)))
+        typevars.map(|typevars| {
+            GenericContext::new(self.db(), typevars, GenericContextOrigin::from(origin))
+        })
     }
 
     fn infer_slice_expression(&mut self, slice: &ast::ExprSlice) -> Type<'db> {
@@ -8420,9 +8460,14 @@ impl<'db> TypeInferenceBuilder<'db> {
                 self.infer_type_expression(arguments_slice);
                 todo_type!("`Unpack[]` special form")
             }
-            KnownInstanceType::Protocol => {
+            KnownInstanceType::Protocol(_) => {
                 self.infer_type_expression(arguments_slice);
-                Type::Dynamic(DynamicType::SubscriptedProtocol)
+                if let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, subscript) {
+                    builder.into_diagnostic(format_args!(
+                        "`typing.Protocol` is not allowed in type expressions",
+                    ));
+                }
+                Type::unknown()
             }
             KnownInstanceType::Generic(_) => {
                 self.infer_type_expression(arguments_slice);

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -5799,8 +5799,6 @@ impl<'db> TypeInferenceBuilder<'db> {
             | (_, unknown @ Type::Dynamic(DynamicType::Unknown), _) => Some(unknown),
             (todo @ Type::Dynamic(DynamicType::Todo(_)), _, _)
             | (_, todo @ Type::Dynamic(DynamicType::Todo(_)), _) => Some(todo),
-            (todo @ Type::Dynamic(DynamicType::SubscriptedProtocol), _, _)
-            | (_, todo @ Type::Dynamic(DynamicType::SubscriptedProtocol), _) => Some(todo),
             (Type::Never, _, _) | (_, Type::Never, _) => Some(Type::Never),
 
             (Type::IntLiteral(n), Type::IntLiteral(m), ast::Operator::Add) => Some(

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -260,6 +260,27 @@ impl<'db> ProtocolInstanceType<'db> {
                 .unwrap_or_else(|| KnownClass::Object.to_instance(db).instance_member(db, name)),
         }
     }
+
+    pub(super) fn apply_specialization(
+        self,
+        db: &'db dyn Db,
+        specialization: Specialization<'db>,
+    ) -> Self {
+        match self.0 {
+            Protocol::FromClass(class) => Self(Protocol::FromClass(
+                class.apply_specialization(db, specialization),
+            )),
+            Protocol::Synthesized(synthesized) => {
+                Self(Protocol::Synthesized(SynthesizedProtocolType::new(
+                    db,
+                    synthesized
+                        .interface(db)
+                        .clone()
+                        .apply_specialization(db, specialization),
+                )))
+            }
+        }
+    }
 }
 
 /// An enumeration of the two kinds of protocol types: those that originate from a class

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -261,17 +261,17 @@ impl<'db> ProtocolInstanceType<'db> {
         }
     }
 
-    pub(super) fn apply_specialization(
+    pub(super) fn apply_specialization<'a>(
         self,
         db: &'db dyn Db,
-        specialization: Specialization<'db>,
+        type_mapping: TypeMapping<'a, 'db>,
     ) -> Self {
         match self.0 {
             Protocol::FromClass(class) => Self(Protocol::FromClass(
-                class.apply_specialization(db, specialization),
+                class.apply_type_mapping(db, type_mapping),
             )),
             Protocol::Synthesized(synthesized) => Self(Protocol::Synthesized(
-                synthesized.apply_specialization(db, specialization),
+                synthesized.apply_type_mapping(db, type_mapping),
             )),
         }
     }
@@ -302,7 +302,7 @@ impl<'db> Protocol<'db> {
 
 mod synthesized_protocol {
     use crate::db::Db;
-    use crate::types::generics::Specialization;
+    use crate::types::generics::TypeMapping;
     use crate::types::protocol_class::ProtocolInterface;
 
     /// A "synthesized" protocol type that is dissociated from a class definition in source code.
@@ -322,12 +322,12 @@ mod synthesized_protocol {
             Self(interface.normalized(db))
         }
 
-        pub(super) fn apply_specialization(
+        pub(super) fn apply_type_mapping<'a>(
             self,
             db: &'db dyn Db,
-            specialization: Specialization<'db>,
+            type_mapping: TypeMapping<'a, 'db>,
         ) -> Self {
-            Self(self.0.specialized_and_normalized(db, specialization))
+            Self(self.0.specialized_and_normalized(db, type_mapping))
         }
 
         pub(in crate::types) fn interface(self) -> ProtocolInterface<'db> {

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -270,15 +270,9 @@ impl<'db> ProtocolInstanceType<'db> {
             Protocol::FromClass(class) => Self(Protocol::FromClass(
                 class.apply_specialization(db, specialization),
             )),
-            Protocol::Synthesized(synthesized) => {
-                Self(Protocol::Synthesized(SynthesizedProtocolType::new(
-                    db,
-                    synthesized
-                        .interface(db)
-                        .clone()
-                        .apply_specialization(db, specialization),
-                )))
-            }
+            Protocol::Synthesized(synthesized) => Self(Protocol::Synthesized(
+                synthesized.apply_specialization(db, specialization),
+            )),
         }
     }
 }
@@ -308,6 +302,7 @@ impl<'db> Protocol<'db> {
 
 mod synthesized_protocol {
     use crate::db::Db;
+    use crate::types::generics::Specialization;
     use crate::types::protocol_class::ProtocolInterface;
 
     /// A "synthesized" protocol type that is dissociated from a class definition in source code.
@@ -325,6 +320,14 @@ mod synthesized_protocol {
     impl<'db> SynthesizedProtocolType<'db> {
         pub(super) fn new(db: &'db dyn Db, interface: ProtocolInterface<'db>) -> Self {
             Self(interface.normalized(db))
+        }
+
+        pub(super) fn apply_specialization(
+            self,
+            db: &'db dyn Db,
+            specialization: Specialization<'db>,
+        ) -> Self {
+            Self(self.0.specialized_and_normalized(db, specialization))
         }
 
         pub(in crate::types) fn interface(self) -> ProtocolInterface<'db> {

--- a/crates/ty_python_semantic/src/types/mro.rs
+++ b/crates/ty_python_semantic/src/types/mro.rs
@@ -174,7 +174,9 @@ impl<'db> Mro<'db> {
                             continue;
                         }
                         match base {
-                            ClassBase::Class(_) | ClassBase::Generic(_) | ClassBase::Protocol(_) => {
+                            ClassBase::Class(_)
+                            | ClassBase::Generic(_)
+                            | ClassBase::Protocol(_) => {
                                 errors.push(DuplicateBaseError {
                                     duplicate_base: base,
                                     first_index: *first_index,

--- a/crates/ty_python_semantic/src/types/mro.rs
+++ b/crates/ty_python_semantic/src/types/mro.rs
@@ -174,7 +174,7 @@ impl<'db> Mro<'db> {
                             continue;
                         }
                         match base {
-                            ClassBase::Class(_) | ClassBase::Generic(_) | ClassBase::Protocol => {
+                            ClassBase::Class(_) | ClassBase::Generic(_) | ClassBase::Protocol(_) => {
                                 errors.push(DuplicateBaseError {
                                     duplicate_base: base,
                                     first_index: *first_index,

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -147,16 +147,22 @@ impl<'db> ProtocolInterface<'db> {
         }
     }
 
-    pub(super) fn apply_specialization(
+    pub(super) fn specialized_and_normalized(
         self,
         db: &'db dyn Db,
         specialization: Specialization<'db>,
     ) -> Self {
-        Self(
-            self.0
-                .into_iter()
-                .map(|(name, data)| (name, data.apply_specialization(db, specialization)))
-                .collect(),
+        Self::new(
+            db,
+            self._members(db)
+                .iter()
+                .map(|(name, data)| {
+                    (
+                        name.clone(),
+                        data.apply_specialization(db, specialization).normalized(db),
+                    )
+                })
+                .collect::<BTreeMap<_, _>>(),
         )
     }
 }
@@ -175,7 +181,7 @@ impl<'db> ProtocolMemberData<'db> {
         }
     }
 
-    fn apply_specialization(self, db: &'db dyn Db, specialization: Specialization<'db>) -> Self {
+    fn apply_specialization(&self, db: &'db dyn Db, specialization: Specialization<'db>) -> Self {
         Self {
             ty: self.ty.apply_specialization(db, specialization),
             qualifiers: self.qualifiers,

--- a/crates/ty_python_semantic/src/types/type_ordering.rs
+++ b/crates/ty_python_semantic/src/types/type_ordering.rs
@@ -386,8 +386,5 @@ fn dynamic_elements_ordering(left: DynamicType, right: DynamicType) -> Ordering 
 
         #[cfg(not(debug_assertions))]
         (DynamicType::Todo(TodoType), DynamicType::Todo(TodoType)) => Ordering::Equal,
-
-        (DynamicType::SubscriptedProtocol, _) => Ordering::Less,
-        (_, DynamicType::SubscriptedProtocol) => Ordering::Greater,
     }
 }

--- a/crates/ty_python_semantic/src/types/type_ordering.rs
+++ b/crates/ty_python_semantic/src/types/type_ordering.rs
@@ -153,11 +153,15 @@ pub(super) fn union_or_intersection_elements_ordering<'db>(
                 (ClassBase::Class(left), ClassBase::Class(right)) => left.cmp(&right),
                 (ClassBase::Class(_), _) => Ordering::Less,
                 (_, ClassBase::Class(_)) => Ordering::Greater,
-                (ClassBase::Protocol, _) => Ordering::Less,
-                (_, ClassBase::Protocol) => Ordering::Greater,
+
+                (ClassBase::Protocol(left), ClassBase::Protocol(right)) => left.cmp(&right),
+                (ClassBase::Protocol(_), _) => Ordering::Less,
+                (_, ClassBase::Protocol(_)) => Ordering::Greater,
+
                 (ClassBase::Generic(left), ClassBase::Generic(right)) => left.cmp(&right),
                 (ClassBase::Generic(_), _) => Ordering::Less,
                 (_, ClassBase::Generic(_)) => Ordering::Greater,
+
                 (ClassBase::Dynamic(left), ClassBase::Dynamic(right)) => {
                     dynamic_elements_ordering(left, right)
                 }
@@ -253,8 +257,11 @@ pub(super) fn union_or_intersection_elements_ordering<'db>(
                 (KnownInstanceType::Generic(_), _) => Ordering::Less,
                 (_, KnownInstanceType::Generic(_)) => Ordering::Greater,
 
-                (KnownInstanceType::Protocol, _) => Ordering::Less,
-                (_, KnownInstanceType::Protocol) => Ordering::Greater,
+                (KnownInstanceType::Protocol(left), KnownInstanceType::Protocol(right)) => {
+                    left.cmp(right)
+                }
+                (KnownInstanceType::Protocol(_), _) => Ordering::Less,
+                (_, KnownInstanceType::Protocol(_)) => Ordering::Greater,
 
                 (KnownInstanceType::NoReturn, _) => Ordering::Less,
                 (_, KnownInstanceType::NoReturn) => Ordering::Greater,


### PR DESCRIPTION
## Summary

- Understand that classes that inherit from `Protocol[]` are generic in exactly the same way as classes that inherit from `Generic[]`. This fixes our MRO inference for a large number of stdlib classes.
- Add the special case for displaying a specialisation of the `tuple` class: although `tuple` is only generic over a single type variable in typeshed, a homogeneous tuple is spelled `tuple[int, ...]` in type annotations rather than `tuple[int]`.
- Add TODO branches for various things that now lead to false-positive errors as a result of our improved understanding of the MROs for a whole range of stdlib classes. In particular:
  - Ensure we continue to not emit false positives on functional `NamedTuple` syntax, e.g. `Person = NamedTuple("Person", [("Name", int)])`
  - Ensure we continue to not emit false positives on classes that inherit from heterogeneous tuples, e.g. `tuple[int, str]`
  - Ensure we continue to not emit false positives on unpacked tuples in type annotations, e.g. `*tuple[int, ...]`

## Test Plan

Existing mdtests updated
