### PR TITLE
[ty] Detect overloads decorated with `@dataclass_transform`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/dataclass_transform.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclass_transform.md
@@ -283,11 +283,11 @@ class D2:
 
 # TODO: these should not be errors
 D1("a")  # error: [too-many-positional-arguments]
-D2("a")  # error: [too-many-positional-arguments]
+D2("a")
 
 # TODO: these should be invalid-argument-type errors
 D1(1.2)  # error: [too-many-positional-arguments]
-D2(1.2)  # error: [too-many-positional-arguments]
+D2(1.2)  # error: [invalid-argument-type]
 ```
 
 [`typing.dataclass_transform`]: https://docs.python.org/3/library/typing.html#typing.dataclass_transform

--- a/crates/ty_python_semantic/resources/mdtest/dataclass_transform.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclass_transform.md
@@ -281,12 +281,10 @@ class D1:
 class D2:
     x: str
 
-# TODO: these should not be errors
-D1("a")  # error: [too-many-positional-arguments]
+D1("a")
 D2("a")
 
-# TODO: these should be invalid-argument-type errors
-D1(1.2)  # error: [too-many-positional-arguments]
+D1(1.2)  # error: [invalid-argument-type]
 D2(1.2)  # error: [invalid-argument-type]
 ```
 

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -811,7 +811,7 @@ impl<'db> Bindings<'db> {
                                     .overloads
                                     .iter()
                                     .for_each(&mut handle_dataclass_transformer_params);
-                            };
+                            }
 
                             handle_dataclass_transformer_params(&function_type);
                         }

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -2121,6 +2121,17 @@ impl<'db> TypeInferenceBuilder<'db> {
             }
 
             if let Type::FunctionLiteral(f) = decorator_ty {
+                // We do not yet detect or flag `@dataclass_transformer` applied to more than one
+                // overload, or an overload and the implementation both. Nevertheless, this is not
+                // allowed. We do not try to treat the offenders intelligently -- just use the
+                // params of the last seen usage of `@dataclass_transformer`
+                if let Some(overloaded) = f.to_overloaded(self.db()) {
+                    overloaded.overloads.iter().for_each(|overload| {
+                        if let Some(params) = overload.dataclass_transformer_params(self.db()) {
+                            dataclass_params = Some(params.into());
+                        }
+                    });
+                }
                 if let Some(params) = f.dataclass_transformer_params(self.db()) {
                     dataclass_params = Some(params.into());
                     continue;

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -2121,10 +2121,10 @@ impl<'db> TypeInferenceBuilder<'db> {
             }
 
             if let Type::FunctionLiteral(f) = decorator_ty {
-                // We do not yet detect or flag `@dataclass_transformer` applied to more than one
+                // We do not yet detect or flag `@dataclass_transform` applied to more than one
                 // overload, or an overload and the implementation both. Nevertheless, this is not
                 // allowed. We do not try to treat the offenders intelligently -- just use the
-                // params of the last seen usage of `@dataclass_transformer`
+                // params of the last seen usage of `@dataclass_transform`
                 if let Some(overloaded) = f.to_overloaded(self.db()) {
                     overloaded.overloads.iter().for_each(|overload| {
                         if let Some(params) = overload.dataclass_transformer_params(self.db()) {


### PR DESCRIPTION
## Summary

Fixes #17541

Before this change, in the case of overloaded functions, `@dataclass_transform` was detected only when applied to the implementation, not the overloads.
However, the spec also allows this decorator to be applied to any of the overloads as well.
With this PR, we start handling `@dataclass_transform`s applied to overloads.

## Test Plan

Fixed existing TODOs in the test suite.
