### PR TITLE
fix(AIR301): remove "airflow.utils.dag_parsing_context.get_parsing_context" which has been moved to AIR311

### DIFF
--- a/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
@@ -710,11 +710,6 @@ fn check_name(checker: &Checker, expr: &Expr, range: TextRange) {
             // airflow.utils.dag_cycle_tester
             ["dag_cycle_tester", "test_cycle"] => Replacement::None,
 
-            // airflow.utils.dag_parsing_context
-            ["dag_parsing_context", "get_parsing_context"] => {
-                Replacement::Name("airflow.sdk.get_parsing_context")
-            }
-
             // airflow.utils.db
             ["db", "create_session"] => Replacement::None,
 


### PR DESCRIPTION
…

<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
