### PR TITLE
Add a note to diagnostics why the rule is enabled

### DIFF
--- a/crates/ty/tests/cli.rs
+++ b/crates/ty/tests/cli.rs
@@ -150,6 +150,7 @@ fn config_override_python_version() -> anyhow::Result<()> {
     5 | print(sys.last_exc)
       |       ^^^^^^^^^^^^
       |
+    info: `lint:unresolved-attribute` is on by default
 
     Found 1 diagnostic
 
@@ -284,6 +285,7 @@ fn cli_arguments_are_relative_to_the_current_directory() -> anyhow::Result<()> {
     3 |
     4 | stat = add(10, 15)
       |
+    info: `lint:unresolved-import` is on by default
 
     Found 1 diagnostic
 
@@ -384,6 +386,7 @@ fn configuration_rule_severity() -> anyhow::Result<()> {
     3 |
     4 | for a in range(0, int(y)):
       |
+    info: `lint:division-by-zero` is on by default
 
     warning: lint:possibly-unresolved-reference: Name `x` used when possibly not defined
      --> test.py:7:7
@@ -393,6 +396,7 @@ fn configuration_rule_severity() -> anyhow::Result<()> {
     7 | print(x)  # possibly-unresolved-reference
       |       ^
       |
+    info: `lint:possibly-unresolved-reference` is on by default
 
     Found 2 diagnostics
 
@@ -420,6 +424,7 @@ fn configuration_rule_severity() -> anyhow::Result<()> {
     3 |
     4 | for a in range(0, int(y)):
       |
+    info: `lint:division-by-zero` is enabled in a configuration file
 
     Found 1 diagnostic
 
@@ -460,6 +465,7 @@ fn cli_rule_severity() -> anyhow::Result<()> {
     3 |
     4 | y = 4 / 0
       |
+    info: `lint:unresolved-import` is on by default
 
     error: lint:division-by-zero: Cannot divide object of type `Literal[4]` by zero
      --> test.py:4:5
@@ -471,6 +477,7 @@ fn cli_rule_severity() -> anyhow::Result<()> {
     5 |
     6 | for a in range(0, int(y)):
       |
+    info: `lint:division-by-zero` is on by default
 
     warning: lint:possibly-unresolved-reference: Name `x` used when possibly not defined
      --> test.py:9:7
@@ -480,6 +487,7 @@ fn cli_rule_severity() -> anyhow::Result<()> {
     9 | print(x)  # possibly-unresolved-reference
       |       ^
       |
+    info: `lint:possibly-unresolved-reference` is on by default
 
     Found 3 diagnostics
 
@@ -507,6 +515,7 @@ fn cli_rule_severity() -> anyhow::Result<()> {
     3 |
     4 | y = 4 / 0
       |
+    info: `lint:unresolved-import` is enabled on the command line
 
     warning: lint:division-by-zero: Cannot divide object of type `Literal[4]` by zero
      --> test.py:4:5
@@ -518,6 +527,7 @@ fn cli_rule_severity() -> anyhow::Result<()> {
     5 |
     6 | for a in range(0, int(y)):
       |
+    info: `lint:division-by-zero` is enabled on the command line
 
     Found 2 diagnostics
 
@@ -558,6 +568,7 @@ fn cli_rule_severity_precedence() -> anyhow::Result<()> {
     3 |
     4 | for a in range(0, int(y)):
       |
+    info: `lint:division-by-zero` is on by default
 
     warning: lint:possibly-unresolved-reference: Name `x` used when possibly not defined
      --> test.py:7:7
@@ -567,6 +578,7 @@ fn cli_rule_severity_precedence() -> anyhow::Result<()> {
     7 | print(x)  # possibly-unresolved-reference
       |       ^
       |
+    info: `lint:possibly-unresolved-reference` is on by default
 
     Found 2 diagnostics
 
@@ -595,6 +607,7 @@ fn cli_rule_severity_precedence() -> anyhow::Result<()> {
     3 |
     4 | for a in range(0, int(y)):
       |
+    info: `lint:division-by-zero` is enabled on the command line
 
     Found 1 diagnostic
 
@@ -672,6 +685,7 @@ fn exit_code_only_warnings() -> anyhow::Result<()> {
     1 | print(x)  # [unresolved-reference]
       |       ^
       |
+    info: `lint:unresolved-reference` is on by default
 
     Found 1 diagnostic
 
@@ -755,6 +769,7 @@ fn exit_code_no_errors_but_error_on_warning_is_true() -> anyhow::Result<()> {
     1 | print(x)  # [unresolved-reference]
       |       ^
       |
+    info: `lint:unresolved-reference` is on by default
 
     Found 1 diagnostic
 
@@ -787,6 +802,7 @@ fn exit_code_no_errors_but_error_on_warning_is_enabled_in_configuration() -> any
     1 | print(x)  # [unresolved-reference]
       |       ^
       |
+    info: `lint:unresolved-reference` is on by default
 
     Found 1 diagnostic
 
@@ -817,6 +833,7 @@ fn exit_code_both_warnings_and_errors() -> anyhow::Result<()> {
       |       ^
     3 | print(4[1])  # [non-subscriptable]
       |
+    info: `lint:unresolved-reference` is on by default
 
     error: lint:non-subscriptable: Cannot subscript object of type `Literal[4]` with no `__getitem__` method
      --> test.py:3:7
@@ -825,6 +842,7 @@ fn exit_code_both_warnings_and_errors() -> anyhow::Result<()> {
     3 | print(4[1])  # [non-subscriptable]
       |       ^
       |
+    info: `lint:non-subscriptable` is on by default
 
     Found 2 diagnostics
 
@@ -855,6 +873,7 @@ fn exit_code_both_warnings_and_errors_and_error_on_warning_is_true() -> anyhow::
       |       ^
     3 | print(4[1])  # [non-subscriptable]
       |
+    info: `lint:unresolved-reference` is on by default
 
     error: lint:non-subscriptable: Cannot subscript object of type `Literal[4]` with no `__getitem__` method
      --> test.py:3:7
@@ -863,6 +882,7 @@ fn exit_code_both_warnings_and_errors_and_error_on_warning_is_true() -> anyhow::
     3 | print(4[1])  # [non-subscriptable]
       |       ^
       |
+    info: `lint:non-subscriptable` is on by default
 
     Found 2 diagnostics
 
@@ -893,6 +913,7 @@ fn exit_code_exit_zero_is_true() -> anyhow::Result<()> {
       |       ^
     3 | print(4[1])  # [non-subscriptable]
       |
+    info: `lint:unresolved-reference` is on by default
 
     error: lint:non-subscriptable: Cannot subscript object of type `Literal[4]` with no `__getitem__` method
      --> test.py:3:7
@@ -901,6 +922,7 @@ fn exit_code_exit_zero_is_true() -> anyhow::Result<()> {
     3 | print(4[1])  # [non-subscriptable]
       |       ^
       |
+    info: `lint:non-subscriptable` is on by default
 
     Found 2 diagnostics
 
@@ -954,6 +976,7 @@ fn user_configuration() -> anyhow::Result<()> {
     3 |
     4 | for a in range(0, int(y)):
       |
+    info: `lint:division-by-zero` is enabled in a configuration file
 
     warning: lint:possibly-unresolved-reference: Name `x` used when possibly not defined
      --> main.py:7:7
@@ -963,6 +986,7 @@ fn user_configuration() -> anyhow::Result<()> {
     7 | print(x)
       |       ^
       |
+    info: `lint:possibly-unresolved-reference` is on by default
 
     Found 2 diagnostics
 
@@ -996,6 +1020,7 @@ fn user_configuration() -> anyhow::Result<()> {
     3 |
     4 | for a in range(0, int(y)):
       |
+    info: `lint:division-by-zero` is enabled in a configuration file
 
     error: lint:possibly-unresolved-reference: Name `x` used when possibly not defined
      --> main.py:7:7
@@ -1005,6 +1030,7 @@ fn user_configuration() -> anyhow::Result<()> {
     7 | print(x)
       |       ^
       |
+    info: `lint:possibly-unresolved-reference` is enabled in a configuration file
 
     Found 2 diagnostics
 
@@ -1052,6 +1078,7 @@ fn check_specific_paths() -> anyhow::Result<()> {
     2 | y = 4 / 0  # error: division-by-zero
       |     ^^^^^
       |
+    info: `lint:division-by-zero` is on by default
 
     error: lint:unresolved-import: Cannot resolve imported module `main2`
      --> project/other.py:2:6
@@ -1061,6 +1088,7 @@ fn check_specific_paths() -> anyhow::Result<()> {
     3 |
     4 | print(z)
       |
+    info: `lint:unresolved-import` is on by default
 
     error: lint:unresolved-import: Cannot resolve imported module `does_not_exist`
      --> project/tests/test_main.py:2:8
@@ -1068,6 +1096,7 @@ fn check_specific_paths() -> anyhow::Result<()> {
     2 | import does_not_exist  # error: unresolved-import
       |        ^^^^^^^^^^^^^^
       |
+    info: `lint:unresolved-import` is on by default
 
     Found 3 diagnostics
 
@@ -1091,6 +1120,7 @@ fn check_specific_paths() -> anyhow::Result<()> {
     3 |
     4 | print(z)
       |
+    info: `lint:unresolved-import` is on by default
 
     error: lint:unresolved-import: Cannot resolve imported module `does_not_exist`
      --> project/tests/test_main.py:2:8
@@ -1098,6 +1128,7 @@ fn check_specific_paths() -> anyhow::Result<()> {
     2 | import does_not_exist  # error: unresolved-import
       |        ^^^^^^^^^^^^^^
       |
+    info: `lint:unresolved-import` is on by default
 
     Found 2 diagnostics
 

--- a/crates/ty/tests/cli.rs
+++ b/crates/ty/tests/cli.rs
@@ -150,7 +150,7 @@ fn config_override_python_version() -> anyhow::Result<()> {
     5 | print(sys.last_exc)
       |       ^^^^^^^^^^^^
       |
-    info: `lint:unresolved-attribute` is on by default
+    info: `lint:unresolved-attribute` is enabled by default
 
     Found 1 diagnostic
 
@@ -285,7 +285,7 @@ fn cli_arguments_are_relative_to_the_current_directory() -> anyhow::Result<()> {
     3 |
     4 | stat = add(10, 15)
       |
-    info: `lint:unresolved-import` is on by default
+    info: `lint:unresolved-import` is enabled by default
 
     Found 1 diagnostic
 
@@ -386,7 +386,7 @@ fn configuration_rule_severity() -> anyhow::Result<()> {
     3 |
     4 | for a in range(0, int(y)):
       |
-    info: `lint:division-by-zero` is on by default
+    info: `lint:division-by-zero` is enabled by default
 
     warning: lint:possibly-unresolved-reference: Name `x` used when possibly not defined
      --> test.py:7:7
@@ -396,7 +396,7 @@ fn configuration_rule_severity() -> anyhow::Result<()> {
     7 | print(x)  # possibly-unresolved-reference
       |       ^
       |
-    info: `lint:possibly-unresolved-reference` is on by default
+    info: `lint:possibly-unresolved-reference` is enabled by default
 
     Found 2 diagnostics
 
@@ -424,7 +424,7 @@ fn configuration_rule_severity() -> anyhow::Result<()> {
     3 |
     4 | for a in range(0, int(y)):
       |
-    info: `lint:division-by-zero` is enabled in a configuration file
+    info: `lint:division-by-zero` was selected in the configuration file
 
     Found 1 diagnostic
 
@@ -465,7 +465,7 @@ fn cli_rule_severity() -> anyhow::Result<()> {
     3 |
     4 | y = 4 / 0
       |
-    info: `lint:unresolved-import` is on by default
+    info: `lint:unresolved-import` is enabled by default
 
     error: lint:division-by-zero: Cannot divide object of type `Literal[4]` by zero
      --> test.py:4:5
@@ -477,7 +477,7 @@ fn cli_rule_severity() -> anyhow::Result<()> {
     5 |
     6 | for a in range(0, int(y)):
       |
-    info: `lint:division-by-zero` is on by default
+    info: `lint:division-by-zero` is enabled by default
 
     warning: lint:possibly-unresolved-reference: Name `x` used when possibly not defined
      --> test.py:9:7
@@ -487,7 +487,7 @@ fn cli_rule_severity() -> anyhow::Result<()> {
     9 | print(x)  # possibly-unresolved-reference
       |       ^
       |
-    info: `lint:possibly-unresolved-reference` is on by default
+    info: `lint:possibly-unresolved-reference` is enabled by default
 
     Found 3 diagnostics
 
@@ -515,7 +515,7 @@ fn cli_rule_severity() -> anyhow::Result<()> {
     3 |
     4 | y = 4 / 0
       |
-    info: `lint:unresolved-import` is enabled on the command line
+    info: `lint:unresolved-import` was selected on the command line
 
     warning: lint:division-by-zero: Cannot divide object of type `Literal[4]` by zero
      --> test.py:4:5
@@ -527,7 +527,7 @@ fn cli_rule_severity() -> anyhow::Result<()> {
     5 |
     6 | for a in range(0, int(y)):
       |
-    info: `lint:division-by-zero` is enabled on the command line
+    info: `lint:division-by-zero` was selected on the command line
 
     Found 2 diagnostics
 
@@ -568,7 +568,7 @@ fn cli_rule_severity_precedence() -> anyhow::Result<()> {
     3 |
     4 | for a in range(0, int(y)):
       |
-    info: `lint:division-by-zero` is on by default
+    info: `lint:division-by-zero` is enabled by default
 
     warning: lint:possibly-unresolved-reference: Name `x` used when possibly not defined
      --> test.py:7:7
@@ -578,7 +578,7 @@ fn cli_rule_severity_precedence() -> anyhow::Result<()> {
     7 | print(x)  # possibly-unresolved-reference
       |       ^
       |
-    info: `lint:possibly-unresolved-reference` is on by default
+    info: `lint:possibly-unresolved-reference` is enabled by default
 
     Found 2 diagnostics
 
@@ -607,7 +607,7 @@ fn cli_rule_severity_precedence() -> anyhow::Result<()> {
     3 |
     4 | for a in range(0, int(y)):
       |
-    info: `lint:division-by-zero` is enabled on the command line
+    info: `lint:division-by-zero` was selected on the command line
 
     Found 1 diagnostic
 
@@ -685,7 +685,7 @@ fn exit_code_only_warnings() -> anyhow::Result<()> {
     1 | print(x)  # [unresolved-reference]
       |       ^
       |
-    info: `lint:unresolved-reference` is on by default
+    info: `lint:unresolved-reference` is enabled by default
 
     Found 1 diagnostic
 
@@ -769,7 +769,7 @@ fn exit_code_no_errors_but_error_on_warning_is_true() -> anyhow::Result<()> {
     1 | print(x)  # [unresolved-reference]
       |       ^
       |
-    info: `lint:unresolved-reference` is on by default
+    info: `lint:unresolved-reference` is enabled by default
 
     Found 1 diagnostic
 
@@ -802,7 +802,7 @@ fn exit_code_no_errors_but_error_on_warning_is_enabled_in_configuration() -> any
     1 | print(x)  # [unresolved-reference]
       |       ^
       |
-    info: `lint:unresolved-reference` is on by default
+    info: `lint:unresolved-reference` is enabled by default
 
     Found 1 diagnostic
 
@@ -833,7 +833,7 @@ fn exit_code_both_warnings_and_errors() -> anyhow::Result<()> {
       |       ^
     3 | print(4[1])  # [non-subscriptable]
       |
-    info: `lint:unresolved-reference` is on by default
+    info: `lint:unresolved-reference` is enabled by default
 
     error: lint:non-subscriptable: Cannot subscript object of type `Literal[4]` with no `__getitem__` method
      --> test.py:3:7
@@ -842,7 +842,7 @@ fn exit_code_both_warnings_and_errors() -> anyhow::Result<()> {
     3 | print(4[1])  # [non-subscriptable]
       |       ^
       |
-    info: `lint:non-subscriptable` is on by default
+    info: `lint:non-subscriptable` is enabled by default
 
     Found 2 diagnostics
 
@@ -873,7 +873,7 @@ fn exit_code_both_warnings_and_errors_and_error_on_warning_is_true() -> anyhow::
       |       ^
     3 | print(4[1])  # [non-subscriptable]
       |
-    info: `lint:unresolved-reference` is on by default
+    info: `lint:unresolved-reference` is enabled by default
 
     error: lint:non-subscriptable: Cannot subscript object of type `Literal[4]` with no `__getitem__` method
      --> test.py:3:7
@@ -882,7 +882,7 @@ fn exit_code_both_warnings_and_errors_and_error_on_warning_is_true() -> anyhow::
     3 | print(4[1])  # [non-subscriptable]
       |       ^
       |
-    info: `lint:non-subscriptable` is on by default
+    info: `lint:non-subscriptable` is enabled by default
 
     Found 2 diagnostics
 
@@ -913,7 +913,7 @@ fn exit_code_exit_zero_is_true() -> anyhow::Result<()> {
       |       ^
     3 | print(4[1])  # [non-subscriptable]
       |
-    info: `lint:unresolved-reference` is on by default
+    info: `lint:unresolved-reference` is enabled by default
 
     error: lint:non-subscriptable: Cannot subscript object of type `Literal[4]` with no `__getitem__` method
      --> test.py:3:7
@@ -922,7 +922,7 @@ fn exit_code_exit_zero_is_true() -> anyhow::Result<()> {
     3 | print(4[1])  # [non-subscriptable]
       |       ^
       |
-    info: `lint:non-subscriptable` is on by default
+    info: `lint:non-subscriptable` is enabled by default
 
     Found 2 diagnostics
 
@@ -976,7 +976,7 @@ fn user_configuration() -> anyhow::Result<()> {
     3 |
     4 | for a in range(0, int(y)):
       |
-    info: `lint:division-by-zero` is enabled in a configuration file
+    info: `lint:division-by-zero` was selected in the configuration file
 
     warning: lint:possibly-unresolved-reference: Name `x` used when possibly not defined
      --> main.py:7:7
@@ -986,7 +986,7 @@ fn user_configuration() -> anyhow::Result<()> {
     7 | print(x)
       |       ^
       |
-    info: `lint:possibly-unresolved-reference` is on by default
+    info: `lint:possibly-unresolved-reference` is enabled by default
 
     Found 2 diagnostics
 
@@ -1020,7 +1020,7 @@ fn user_configuration() -> anyhow::Result<()> {
     3 |
     4 | for a in range(0, int(y)):
       |
-    info: `lint:division-by-zero` is enabled in a configuration file
+    info: `lint:division-by-zero` was selected in the configuration file
 
     error: lint:possibly-unresolved-reference: Name `x` used when possibly not defined
      --> main.py:7:7
@@ -1030,7 +1030,7 @@ fn user_configuration() -> anyhow::Result<()> {
     7 | print(x)
       |       ^
       |
-    info: `lint:possibly-unresolved-reference` is enabled in a configuration file
+    info: `lint:possibly-unresolved-reference` was selected in the configuration file
 
     Found 2 diagnostics
 
@@ -1078,7 +1078,7 @@ fn check_specific_paths() -> anyhow::Result<()> {
     2 | y = 4 / 0  # error: division-by-zero
       |     ^^^^^
       |
-    info: `lint:division-by-zero` is on by default
+    info: `lint:division-by-zero` is enabled by default
 
     error: lint:unresolved-import: Cannot resolve imported module `main2`
      --> project/other.py:2:6
@@ -1088,7 +1088,7 @@ fn check_specific_paths() -> anyhow::Result<()> {
     3 |
     4 | print(z)
       |
-    info: `lint:unresolved-import` is on by default
+    info: `lint:unresolved-import` is enabled by default
 
     error: lint:unresolved-import: Cannot resolve imported module `does_not_exist`
      --> project/tests/test_main.py:2:8
@@ -1096,7 +1096,7 @@ fn check_specific_paths() -> anyhow::Result<()> {
     2 | import does_not_exist  # error: unresolved-import
       |        ^^^^^^^^^^^^^^
       |
-    info: `lint:unresolved-import` is on by default
+    info: `lint:unresolved-import` is enabled by default
 
     Found 3 diagnostics
 
@@ -1120,7 +1120,7 @@ fn check_specific_paths() -> anyhow::Result<()> {
     3 |
     4 | print(z)
       |
-    info: `lint:unresolved-import` is on by default
+    info: `lint:unresolved-import` is enabled by default
 
     error: lint:unresolved-import: Cannot resolve imported module `does_not_exist`
      --> project/tests/test_main.py:2:8
@@ -1128,7 +1128,7 @@ fn check_specific_paths() -> anyhow::Result<()> {
     2 | import does_not_exist  # error: unresolved-import
       |        ^^^^^^^^^^^^^^
       |
-    info: `lint:unresolved-import` is on by default
+    info: `lint:unresolved-import` is enabled by default
 
     Found 2 diagnostics
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Data_descriptors_-_Invalid_`__set__`_method_signature.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Data_descriptors_-_Invalid_`__set__`_method_signature.snap
@@ -35,6 +35,6 @@ error: lint:invalid-assignment: Invalid assignment to data descriptor attribute 
 11 | instance.attr = 1  # error: [invalid-assignment]
    | ^^^^^^^^^^^^^
    |
-info: `lint:invalid-assignment` is on by default
+info: `lint:invalid-assignment` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Data_descriptors_-_Invalid_`__set__`_method_signature.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Data_descriptors_-_Invalid_`__set__`_method_signature.snap
@@ -35,5 +35,6 @@ error: lint:invalid-assignment: Invalid assignment to data descriptor attribute 
 11 | instance.attr = 1  # error: [invalid-assignment]
    | ^^^^^^^^^^^^^
    |
+info: `lint:invalid-assignment` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Data_descriptors_-_Invalid_argument_type.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Data_descriptors_-_Invalid_argument_type.snap
@@ -36,5 +36,6 @@ error: lint:invalid-assignment: Invalid assignment to data descriptor attribute 
 12 | instance.attr = "wrong"  # error: [invalid-assignment]
    | ^^^^^^^^^^^^^
    |
+info: `lint:invalid-assignment` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Data_descriptors_-_Invalid_argument_type.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Data_descriptors_-_Invalid_argument_type.snap
@@ -36,6 +36,6 @@ error: lint:invalid-assignment: Invalid assignment to data descriptor attribute 
 12 | instance.attr = "wrong"  # error: [invalid-assignment]
    | ^^^^^^^^^^^^^
    |
-info: `lint:invalid-assignment` is on by default
+info: `lint:invalid-assignment` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Instance_attributes_with_class-level_defaults.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Instance_attributes_with_class-level_defaults.snap
@@ -36,6 +36,7 @@ error: lint:invalid-assignment: Object of type `Literal["wrong"]` is not assigna
 7 |
 8 | C.attr = 1  # fine
   |
+info: `lint:invalid-assignment` is on by default
 
 ```
 
@@ -47,5 +48,6 @@ error: lint:invalid-assignment: Object of type `Literal["wrong"]` is not assigna
 9 | C.attr = "wrong"  # error: [invalid-assignment]
   | ^^^^^^
   |
+info: `lint:invalid-assignment` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Instance_attributes_with_class-level_defaults.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Instance_attributes_with_class-level_defaults.snap
@@ -36,7 +36,7 @@ error: lint:invalid-assignment: Object of type `Literal["wrong"]` is not assigna
 7 |
 8 | C.attr = 1  # fine
   |
-info: `lint:invalid-assignment` is on by default
+info: `lint:invalid-assignment` is enabled by default
 
 ```
 
@@ -48,6 +48,6 @@ error: lint:invalid-assignment: Object of type `Literal["wrong"]` is not assigna
 9 | C.attr = "wrong"  # error: [invalid-assignment]
   | ^^^^^^
   |
-info: `lint:invalid-assignment` is on by default
+info: `lint:invalid-assignment` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Possibly-unbound_attributes.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Possibly-unbound_attributes.snap
@@ -36,6 +36,7 @@ warning: lint:possibly-unbound-attribute: Attribute `attr` on type `Literal[C]` 
 7 |
 8 |     instance = C()
   |
+info: `lint:possibly-unbound-attribute` is on by default
 
 ```
 
@@ -47,5 +48,6 @@ warning: lint:possibly-unbound-attribute: Attribute `attr` on type `C` is possib
 9 |     instance.attr = 1  # error: [possibly-unbound-attribute]
   |     ^^^^^^^^^^^^^
   |
+info: `lint:possibly-unbound-attribute` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Possibly-unbound_attributes.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Possibly-unbound_attributes.snap
@@ -36,7 +36,7 @@ warning: lint:possibly-unbound-attribute: Attribute `attr` on type `Literal[C]` 
 7 |
 8 |     instance = C()
   |
-info: `lint:possibly-unbound-attribute` is on by default
+info: `lint:possibly-unbound-attribute` is enabled by default
 
 ```
 
@@ -48,6 +48,6 @@ warning: lint:possibly-unbound-attribute: Attribute `attr` on type `C` is possib
 9 |     instance.attr = 1  # error: [possibly-unbound-attribute]
   |     ^^^^^^^^^^^^^
   |
-info: `lint:possibly-unbound-attribute` is on by default
+info: `lint:possibly-unbound-attribute` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Pure_instance_attributes.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Pure_instance_attributes.snap
@@ -36,7 +36,7 @@ error: lint:invalid-assignment: Object of type `Literal["wrong"]` is not assigna
 8 |
 9 | C.attr = 1  # error: [invalid-attribute-access]
   |
-info: `lint:invalid-assignment` is on by default
+info: `lint:invalid-assignment` is enabled by default
 
 ```
 
@@ -49,6 +49,6 @@ error: lint:invalid-attribute-access: Cannot assign to instance attribute `attr`
 9 | C.attr = 1  # error: [invalid-attribute-access]
   | ^^^^^^
   |
-info: `lint:invalid-attribute-access` is on by default
+info: `lint:invalid-attribute-access` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Pure_instance_attributes.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Pure_instance_attributes.snap
@@ -36,6 +36,7 @@ error: lint:invalid-assignment: Object of type `Literal["wrong"]` is not assigna
 8 |
 9 | C.attr = 1  # error: [invalid-attribute-access]
   |
+info: `lint:invalid-assignment` is on by default
 
 ```
 
@@ -48,5 +49,6 @@ error: lint:invalid-attribute-access: Cannot assign to instance attribute `attr`
 9 | C.attr = 1  # error: [invalid-attribute-access]
   | ^^^^^^
   |
+info: `lint:invalid-attribute-access` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Setting_attributes_on_union_types.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Setting_attributes_on_union_types.snap
@@ -46,6 +46,6 @@ error: lint:invalid-assignment: Object of type `Literal[1]` is not assignable to
 12 |
 13 |     class C2:
    |
-info: `lint:invalid-assignment` is on by default
+info: `lint:invalid-assignment` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Setting_attributes_on_union_types.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Setting_attributes_on_union_types.snap
@@ -46,5 +46,6 @@ error: lint:invalid-assignment: Object of type `Literal[1]` is not assignable to
 12 |
 13 |     class C2:
    |
+info: `lint:invalid-assignment` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Unknown_attributes.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Unknown_attributes.snap
@@ -33,6 +33,7 @@ error: lint:unresolved-attribute: Unresolved attribute `non_existent` on type `L
 4 |
 5 | instance = C()
   |
+info: `lint:unresolved-attribute` is on by default
 
 ```
 
@@ -44,5 +45,6 @@ error: lint:unresolved-attribute: Unresolved attribute `non_existent` on type `C
 6 | instance.non_existent = 1  # error: [unresolved-attribute]
   | ^^^^^^^^^^^^^^^^^^^^^
   |
+info: `lint:unresolved-attribute` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Unknown_attributes.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Unknown_attributes.snap
@@ -33,7 +33,7 @@ error: lint:unresolved-attribute: Unresolved attribute `non_existent` on type `L
 4 |
 5 | instance = C()
   |
-info: `lint:unresolved-attribute` is on by default
+info: `lint:unresolved-attribute` is enabled by default
 
 ```
 
@@ -45,6 +45,6 @@ error: lint:unresolved-attribute: Unresolved attribute `non_existent` on type `C
 6 | instance.non_existent = 1  # error: [unresolved-attribute]
   | ^^^^^^^^^^^^^^^^^^^^^
   |
-info: `lint:unresolved-attribute` is on by default
+info: `lint:unresolved-attribute` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_`ClassVar`s.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_`ClassVar`s.snap
@@ -36,6 +36,7 @@ error: lint:invalid-assignment: Object of type `Literal["wrong"]` is not assigna
 8 |
 9 | instance = C()
   |
+info: `lint:invalid-assignment` is on by default
 
 ```
 
@@ -47,5 +48,6 @@ error: lint:invalid-attribute-access: Cannot assign to ClassVar `attr` from an i
 10 | instance.attr = 1  # error: [invalid-attribute-access]
    | ^^^^^^^^^^^^^
    |
+info: `lint:invalid-attribute-access` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_`ClassVar`s.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_`ClassVar`s.snap
@@ -36,7 +36,7 @@ error: lint:invalid-assignment: Object of type `Literal["wrong"]` is not assigna
 8 |
 9 | instance = C()
   |
-info: `lint:invalid-assignment` is on by default
+info: `lint:invalid-assignment` is enabled by default
 
 ```
 
@@ -48,6 +48,6 @@ error: lint:invalid-attribute-access: Cannot assign to ClassVar `attr` from an i
 10 | instance.attr = 1  # error: [invalid-attribute-access]
    | ^^^^^^^^^^^^^
    |
-info: `lint:invalid-attribute-access` is on by default
+info: `lint:invalid-attribute-access` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Multiple_objects_imported_from_an_unresolved_module.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Multiple_objects_imported_from_an_unresolved_module.snap
@@ -26,5 +26,6 @@ error: lint:unresolved-import: Cannot resolve imported module `does_not_exist`
 2 | from does_not_exist import foo, bar, baz
   |      ^^^^^^^^^^^^^^
   |
+info: `lint:unresolved-import` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Unresolvable_module_import.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Unresolvable_module_import.snap
@@ -24,5 +24,6 @@ error: lint:unresolved-import: Cannot resolve imported module `zqzqzqzqzqzqzq`
 1 | import zqzqzqzqzqzqzq  # error: [unresolved-import] "Cannot resolve imported module `zqzqzqzqzqzqzq`"
   |        ^^^^^^^^^^^^^^
   |
+info: `lint:unresolved-import` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Unresolvable_module_import.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Unresolvable_module_import.snap
@@ -24,6 +24,6 @@ error: lint:unresolved-import: Cannot resolve imported module `zqzqzqzqzqzqzq`
 1 | import zqzqzqzqzqzqzq  # error: [unresolved-import] "Cannot resolve imported module `zqzqzqzqzqzqzq`"
   |        ^^^^^^^^^^^^^^
   |
-info: `lint:unresolved-import` is on by default
+info: `lint:unresolved-import` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Unresolvable_submodule_imports.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Unresolvable_submodule_imports.snap
@@ -36,6 +36,7 @@ error: lint:unresolved-import: Cannot resolve imported module `a.foo`
 3 |
 4 | # Topmost component unresolvable:
   |
+info: `lint:unresolved-import` is on by default
 
 ```
 
@@ -47,5 +48,6 @@ error: lint:unresolved-import: Cannot resolve imported module `b.foo`
 5 | import b.foo  # error: [unresolved-import] "Cannot resolve imported module `b.foo`"
   |        ^^^^^
   |
+info: `lint:unresolved-import` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Unresolvable_submodule_imports.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Unresolvable_submodule_imports.snap
@@ -36,7 +36,7 @@ error: lint:unresolved-import: Cannot resolve imported module `a.foo`
 3 |
 4 | # Topmost component unresolvable:
   |
-info: `lint:unresolved-import` is on by default
+info: `lint:unresolved-import` is enabled by default
 
 ```
 
@@ -48,6 +48,6 @@ error: lint:unresolved-import: Cannot resolve imported module `b.foo`
 5 | import b.foo  # error: [unresolved-import] "Cannot resolve imported module `b.foo`"
   |        ^^^^^
   |
-info: `lint:unresolved-import` is on by default
+info: `lint:unresolved-import` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Bad_`__getitem__`_method.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Bad_`__getitem__`_method.snap
@@ -38,6 +38,7 @@ error: lint:not-iterable: Object of type `Iterable` is not iterable
    |
 info: It has no `__iter__` method and its `__getitem__` method has an incorrect signature for the old-style iteration protocol
 info: `__getitem__` must be at least as permissive as `def __getitem__(self, key: int): ...` to satisfy the old-style iteration protocol
+info: `lint:not-iterable` is on by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Bad_`__getitem__`_method.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Bad_`__getitem__`_method.snap
@@ -38,7 +38,7 @@ error: lint:not-iterable: Object of type `Iterable` is not iterable
    |
 info: It has no `__iter__` method and its `__getitem__` method has an incorrect signature for the old-style iteration protocol
 info: `__getitem__` must be at least as permissive as `def __getitem__(self, key: int): ...` to satisfy the old-style iteration protocol
-info: `lint:not-iterable` is on by default
+info: `lint:not-iterable` is enabled by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Invalid_iterable.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Invalid_iterable.snap
@@ -29,6 +29,6 @@ error: lint:not-iterable: Object of type `Literal[123]` is not iterable
 3 |     pass
   |
 info: It doesn't have an `__iter__` method or a `__getitem__` method
-info: `lint:not-iterable` is on by default
+info: `lint:not-iterable` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Invalid_iterable.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Invalid_iterable.snap
@@ -29,5 +29,6 @@ error: lint:not-iterable: Object of type `Literal[123]` is not iterable
 3 |     pass
   |
 info: It doesn't have an `__iter__` method or a `__getitem__` method
+info: `lint:not-iterable` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_New_over_old_style_iteration_protocol.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_New_over_old_style_iteration_protocol.snap
@@ -34,6 +34,6 @@ error: lint:not-iterable: Object of type `NotIterable` is not iterable
 7 |     pass
   |
 info: Its `__iter__` attribute has type `None`, which is not callable
-info: `lint:not-iterable` is on by default
+info: `lint:not-iterable` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_New_over_old_style_iteration_protocol.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_New_over_old_style_iteration_protocol.snap
@@ -34,5 +34,6 @@ error: lint:not-iterable: Object of type `NotIterable` is not iterable
 7 |     pass
   |
 info: Its `__iter__` attribute has type `None`, which is not callable
+info: `lint:not-iterable` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_No_`__iter__`_method_and_`__getitem__`_is_not_callable.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_No_`__iter__`_method_and_`__getitem__`_is_not_callable.snap
@@ -34,7 +34,7 @@ error: lint:not-iterable: Object of type `Bad` is not iterable
 8 |     reveal_type(x)  # revealed: Unknown
   |
 info: It has no `__iter__` method and its `__getitem__` attribute has type `None`, which is not callable
-info: `lint:not-iterable` is on by default
+info: `lint:not-iterable` is enabled by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_No_`__iter__`_method_and_`__getitem__`_is_not_callable.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_No_`__iter__`_method_and_`__getitem__`_is_not_callable.snap
@@ -34,6 +34,7 @@ error: lint:not-iterable: Object of type `Bad` is not iterable
 8 |     reveal_type(x)  # revealed: Unknown
   |
 info: It has no `__iter__` method and its `__getitem__` attribute has type `None`, which is not callable
+info: `lint:not-iterable` is on by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly-not-callable_`__getitem__`_method.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly-not-callable_`__getitem__`_method.snap
@@ -57,7 +57,7 @@ error: lint:not-iterable: Object of type `Iterable1` may not be iterable
    |
 info: It has no `__iter__` method and its `__getitem__` attribute is invalid
 info: `__getitem__` has type `CustomCallable`, which is not callable
-info: `lint:not-iterable` is on by default
+info: `lint:not-iterable` is enabled by default
 
 ```
 
@@ -87,7 +87,7 @@ error: lint:not-iterable: Object of type `Iterable2` may not be iterable
    |
 info: It has no `__iter__` method and its `__getitem__` attribute is invalid
 info: `__getitem__` has type `(bound method Iterable2.__getitem__(key: int) -> int) | None`, which is not callable
-info: `lint:not-iterable` is on by default
+info: `lint:not-iterable` is enabled by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly-not-callable_`__getitem__`_method.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly-not-callable_`__getitem__`_method.snap
@@ -57,6 +57,7 @@ error: lint:not-iterable: Object of type `Iterable1` may not be iterable
    |
 info: It has no `__iter__` method and its `__getitem__` attribute is invalid
 info: `__getitem__` has type `CustomCallable`, which is not callable
+info: `lint:not-iterable` is on by default
 
 ```
 
@@ -86,6 +87,7 @@ error: lint:not-iterable: Object of type `Iterable2` may not be iterable
    |
 info: It has no `__iter__` method and its `__getitem__` attribute is invalid
 info: `__getitem__` has type `(bound method Iterable2.__getitem__(key: int) -> int) | None`, which is not callable
+info: `lint:not-iterable` is on by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__getitem__`_methods.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__getitem__`_methods.snap
@@ -54,6 +54,7 @@ error: lint:not-iterable: Object of type `Iterable1` may not be iterable
    |
 info: It has no `__iter__` method and its `__getitem__` attribute is invalid
 info: `__getitem__` has type `(bound method Iterable1.__getitem__(item: int) -> str) | None`, which is not callable
+info: `lint:not-iterable` is on by default
 
 ```
 
@@ -82,6 +83,7 @@ error: lint:not-iterable: Object of type `Iterable2` may not be iterable
    |
 info: It has no `__iter__` method and its `__getitem__` method (with type `(bound method Iterable2.__getitem__(item: int) -> str) | (bound method Iterable2.__getitem__(item: str) -> int)`) may have an incorrect signature for the old-style iteration protocol
 info: `__getitem__` must be at least as permissive as `def __getitem__(self, key: int): ...` to satisfy the old-style iteration protocol
+info: `lint:not-iterable` is on by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__getitem__`_methods.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__getitem__`_methods.snap
@@ -54,7 +54,7 @@ error: lint:not-iterable: Object of type `Iterable1` may not be iterable
    |
 info: It has no `__iter__` method and its `__getitem__` attribute is invalid
 info: `__getitem__` has type `(bound method Iterable1.__getitem__(item: int) -> str) | None`, which is not callable
-info: `lint:not-iterable` is on by default
+info: `lint:not-iterable` is enabled by default
 
 ```
 
@@ -83,7 +83,7 @@ error: lint:not-iterable: Object of type `Iterable2` may not be iterable
    |
 info: It has no `__iter__` method and its `__getitem__` method (with type `(bound method Iterable2.__getitem__(item: int) -> str) | (bound method Iterable2.__getitem__(item: str) -> int)`) may have an incorrect signature for the old-style iteration protocol
 info: `__getitem__` must be at least as permissive as `def __getitem__(self, key: int): ...` to satisfy the old-style iteration protocol
-info: `lint:not-iterable` is on by default
+info: `lint:not-iterable` is enabled by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__iter__`_methods.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__iter__`_methods.snap
@@ -58,6 +58,7 @@ error: lint:not-iterable: Object of type `Iterable1` may not be iterable
 info: Its `__iter__` method may have an invalid signature
 info: Type of `__iter__` is `(bound method Iterable1.__iter__() -> Iterator) | (bound method Iterable1.__iter__(invalid_extra_arg) -> Iterator)`
 info: Expected signature for `__iter__` is `def __iter__(self): ...`
+info: `lint:not-iterable` is on by default
 
 ```
 
@@ -86,6 +87,7 @@ error: lint:not-iterable: Object of type `Iterable2` may not be iterable
 30 |         reveal_type(x)  # revealed: int | Unknown
    |
 info: Its `__iter__` attribute (with type `(bound method Iterable2.__iter__() -> Iterator) | None`) may not be callable
+info: `lint:not-iterable` is on by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__iter__`_methods.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__iter__`_methods.snap
@@ -58,7 +58,7 @@ error: lint:not-iterable: Object of type `Iterable1` may not be iterable
 info: Its `__iter__` method may have an invalid signature
 info: Type of `__iter__` is `(bound method Iterable1.__iter__() -> Iterator) | (bound method Iterable1.__iter__(invalid_extra_arg) -> Iterator)`
 info: Expected signature for `__iter__` is `def __iter__(self): ...`
-info: `lint:not-iterable` is on by default
+info: `lint:not-iterable` is enabled by default
 
 ```
 
@@ -87,7 +87,7 @@ error: lint:not-iterable: Object of type `Iterable2` may not be iterable
 30 |         reveal_type(x)  # revealed: int | Unknown
    |
 info: Its `__iter__` attribute (with type `(bound method Iterable2.__iter__() -> Iterator) | None`) may not be callable
-info: `lint:not-iterable` is on by default
+info: `lint:not-iterable` is enabled by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__next__`_method.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__next__`_method.snap
@@ -61,7 +61,7 @@ error: lint:not-iterable: Object of type `Iterable1` may not be iterable
    |
 info: Its `__iter__` method returns an object of type `Iterator1`, which may have an invalid `__next__` method
 info: Expected signature for `__next__` is `def __next__(self): ...`)
-info: `lint:not-iterable` is on by default
+info: `lint:not-iterable` is enabled by default
 
 ```
 
@@ -90,7 +90,7 @@ error: lint:not-iterable: Object of type `Iterable2` may not be iterable
 34 |         reveal_type(y)  # revealed: int | Unknown
    |
 info: Its `__iter__` method returns an object of type `Iterator2`, which has a `__next__` attribute that may not be callable
-info: `lint:not-iterable` is on by default
+info: `lint:not-iterable` is enabled by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__next__`_method.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__next__`_method.snap
@@ -61,6 +61,7 @@ error: lint:not-iterable: Object of type `Iterable1` may not be iterable
    |
 info: Its `__iter__` method returns an object of type `Iterator1`, which may have an invalid `__next__` method
 info: Expected signature for `__next__` is `def __next__(self): ...`)
+info: `lint:not-iterable` is on by default
 
 ```
 
@@ -89,6 +90,7 @@ error: lint:not-iterable: Object of type `Iterable2` may not be iterable
 34 |         reveal_type(y)  # revealed: int | Unknown
    |
 info: Its `__iter__` method returns an object of type `Iterator2`, which has a `__next__` attribute that may not be callable
+info: `lint:not-iterable` is on by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_bad_`__getitem__`_method.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_bad_`__getitem__`_method.snap
@@ -46,7 +46,7 @@ error: lint:not-iterable: Object of type `Iterable` may not be iterable
    |
 info: It may not have an `__iter__` method and its `__getitem__` method has an incorrect signature for the old-style iteration protocol
 info: `__getitem__` must be at least as permissive as `def __getitem__(self, key: int): ...` to satisfy the old-style iteration protocol
-info: `lint:not-iterable` is on by default
+info: `lint:not-iterable` is enabled by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_bad_`__getitem__`_method.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_bad_`__getitem__`_method.snap
@@ -46,6 +46,7 @@ error: lint:not-iterable: Object of type `Iterable` may not be iterable
    |
 info: It may not have an `__iter__` method and its `__getitem__` method has an incorrect signature for the old-style iteration protocol
 info: `__getitem__` must be at least as permissive as `def __getitem__(self, key: int): ...` to satisfy the old-style iteration protocol
+info: `lint:not-iterable` is on by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_possibly_invalid_`__getitem__`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_possibly_invalid_`__getitem__`.snap
@@ -64,6 +64,7 @@ error: lint:not-iterable: Object of type `Iterable1` may not be iterable
 33 |         reveal_type(x)  # revealed: bytes | str | Unknown
    |
 info: It may not have an `__iter__` method and its `__getitem__` attribute (with type `(bound method Iterable1.__getitem__(item: int) -> str) | None`) may not be callable
+info: `lint:not-iterable` is on by default
 
 ```
 
@@ -92,6 +93,7 @@ error: lint:not-iterable: Object of type `Iterable2` may not be iterable
    |
 info: It may not have an `__iter__` method and its `__getitem__` method (with type `(bound method Iterable2.__getitem__(item: int) -> str) | (bound method Iterable2.__getitem__(item: str) -> int)`) may have an incorrect signature for the old-style iteration protocol
 info: `__getitem__` must be at least as permissive as `def __getitem__(self, key: int): ...` to satisfy the old-style iteration protocol
+info: `lint:not-iterable` is on by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_possibly_invalid_`__getitem__`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_possibly_invalid_`__getitem__`.snap
@@ -64,7 +64,7 @@ error: lint:not-iterable: Object of type `Iterable1` may not be iterable
 33 |         reveal_type(x)  # revealed: bytes | str | Unknown
    |
 info: It may not have an `__iter__` method and its `__getitem__` attribute (with type `(bound method Iterable1.__getitem__(item: int) -> str) | None`) may not be callable
-info: `lint:not-iterable` is on by default
+info: `lint:not-iterable` is enabled by default
 
 ```
 
@@ -93,7 +93,7 @@ error: lint:not-iterable: Object of type `Iterable2` may not be iterable
    |
 info: It may not have an `__iter__` method and its `__getitem__` method (with type `(bound method Iterable2.__getitem__(item: int) -> str) | (bound method Iterable2.__getitem__(item: str) -> int)`) may have an incorrect signature for the old-style iteration protocol
 info: `__getitem__` must be at least as permissive as `def __getitem__(self, key: int): ...` to satisfy the old-style iteration protocol
-info: `lint:not-iterable` is on by default
+info: `lint:not-iterable` is enabled by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_possibly_unbound_`__getitem__`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_possibly_unbound_`__getitem__`.snap
@@ -44,6 +44,7 @@ error: lint:not-iterable: Object of type `Iterable` may not be iterable
 18 |         reveal_type(x)  # revealed: int | bytes
    |
 info: It may not have an `__iter__` method or a `__getitem__` method
+info: `lint:not-iterable` is on by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_possibly_unbound_`__getitem__`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_possibly_unbound_`__getitem__`.snap
@@ -44,7 +44,7 @@ error: lint:not-iterable: Object of type `Iterable` may not be iterable
 18 |         reveal_type(x)  # revealed: int | bytes
    |
 info: It may not have an `__iter__` method or a `__getitem__` method
-info: `lint:not-iterable` is on by default
+info: `lint:not-iterable` is enabled by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Union_type_as_iterable_where_one_union_element_has_invalid_`__iter__`_method.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Union_type_as_iterable_where_one_union_element_has_invalid_`__iter__`_method.snap
@@ -46,6 +46,7 @@ error: lint:not-iterable: Object of type `Test | Test2` may not be iterable
 19 |         reveal_type(x)  # revealed: int
    |
 info: Its `__iter__` method returns an object of type `TestIter | int`, which may not have a `__next__` method
+info: `lint:not-iterable` is on by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Union_type_as_iterable_where_one_union_element_has_invalid_`__iter__`_method.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Union_type_as_iterable_where_one_union_element_has_invalid_`__iter__`_method.snap
@@ -46,7 +46,7 @@ error: lint:not-iterable: Object of type `Test | Test2` may not be iterable
 19 |         reveal_type(x)  # revealed: int
    |
 info: Its `__iter__` method returns an object of type `TestIter | int`, which may not have a `__next__` method
-info: `lint:not-iterable` is on by default
+info: `lint:not-iterable` is enabled by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Union_type_as_iterable_where_one_union_element_has_no_`__iter__`_method.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Union_type_as_iterable_where_one_union_element_has_no_`__iter__`_method.snap
@@ -41,7 +41,7 @@ error: lint:not-iterable: Object of type `Test | Literal[42]` may not be iterabl
 14 |         reveal_type(x)  # revealed: int
    |
 info: It may not have an `__iter__` method and it doesn't have a `__getitem__` method
-info: `lint:not-iterable` is on by default
+info: `lint:not-iterable` is enabled by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Union_type_as_iterable_where_one_union_element_has_no_`__iter__`_method.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Union_type_as_iterable_where_one_union_element_has_no_`__iter__`_method.snap
@@ -41,6 +41,7 @@ error: lint:not-iterable: Object of type `Test | Literal[42]` may not be iterabl
 14 |         reveal_type(x)  # revealed: int
    |
 info: It may not have an `__iter__` method and it doesn't have a `__getitem__` method
+info: `lint:not-iterable` is on by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_With_non-callable_iterator.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_With_non-callable_iterator.snap
@@ -42,6 +42,7 @@ error: lint:not-iterable: Object of type `NotIterable` is not iterable
 12 |         pass
    |
 info: Its `__iter__` attribute has type `int | None`, which is not callable
+info: `lint:not-iterable` is on by default
 
 ```
 
@@ -54,6 +55,7 @@ warning: lint:possibly-unresolved-reference: Name `x` used when possibly not def
 16 |     reveal_type(x)
    |                 ^
    |
+info: `lint:possibly-unresolved-reference` is on by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_With_non-callable_iterator.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_With_non-callable_iterator.snap
@@ -42,7 +42,7 @@ error: lint:not-iterable: Object of type `NotIterable` is not iterable
 12 |         pass
    |
 info: Its `__iter__` attribute has type `int | None`, which is not callable
-info: `lint:not-iterable` is on by default
+info: `lint:not-iterable` is enabled by default
 
 ```
 
@@ -55,7 +55,7 @@ warning: lint:possibly-unresolved-reference: Name `x` used when possibly not def
 16 |     reveal_type(x)
    |                 ^
    |
-info: `lint:possibly-unresolved-reference` is on by default
+info: `lint:possibly-unresolved-reference` is enabled by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_does_not_return_an_iterator.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_does_not_return_an_iterator.snap
@@ -35,6 +35,7 @@ error: lint:not-iterable: Object of type `Bad` is not iterable
 9 |     reveal_type(x)  # revealed: Unknown
   |
 info: Its `__iter__` method returns an object of type `int`, which has no `__next__` method
+info: `lint:not-iterable` is on by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_does_not_return_an_iterator.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_does_not_return_an_iterator.snap
@@ -35,7 +35,7 @@ error: lint:not-iterable: Object of type `Bad` is not iterable
 9 |     reveal_type(x)  # revealed: Unknown
   |
 info: Its `__iter__` method returns an object of type `int`, which has no `__next__` method
-info: `lint:not-iterable` is on by default
+info: `lint:not-iterable` is enabled by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_method_with_a_bad_signature.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_method_with_a_bad_signature.snap
@@ -40,7 +40,7 @@ error: lint:not-iterable: Object of type `Iterable` is not iterable
    |
 info: Its `__iter__` method has an invalid signature
 info: Expected signature `def __iter__(self): ...`
-info: `lint:not-iterable` is on by default
+info: `lint:not-iterable` is enabled by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_method_with_a_bad_signature.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_method_with_a_bad_signature.snap
@@ -40,6 +40,7 @@ error: lint:not-iterable: Object of type `Iterable` is not iterable
    |
 info: Its `__iter__` method has an invalid signature
 info: Expected signature `def __iter__(self): ...`
+info: `lint:not-iterable` is on by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_returns_an_iterator_with_an_invalid_`__next__`_method.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_returns_an_iterator_with_an_invalid_`__next__`_method.snap
@@ -51,6 +51,7 @@ error: lint:not-iterable: Object of type `Iterable1` is not iterable
    |
 info: Its `__iter__` method returns an object of type `Iterator1`, which has an invalid `__next__` method
 info: Expected signature for `__next__` is `def __next__(self): ...`
+info: `lint:not-iterable` is on by default
 
 ```
 
@@ -78,6 +79,7 @@ error: lint:not-iterable: Object of type `Iterable2` is not iterable
 24 |     reveal_type(y)  # revealed: Unknown
    |
 info: Its `__iter__` method returns an object of type `Iterator2`, which has a `__next__` attribute that is not callable
+info: `lint:not-iterable` is on by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_returns_an_iterator_with_an_invalid_`__next__`_method.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_returns_an_iterator_with_an_invalid_`__next__`_method.snap
@@ -51,7 +51,7 @@ error: lint:not-iterable: Object of type `Iterable1` is not iterable
    |
 info: Its `__iter__` method returns an object of type `Iterator1`, which has an invalid `__next__` method
 info: Expected signature for `__next__` is `def __next__(self): ...`
-info: `lint:not-iterable` is on by default
+info: `lint:not-iterable` is enabled by default
 
 ```
 
@@ -79,7 +79,7 @@ error: lint:not-iterable: Object of type `Iterable2` is not iterable
 24 |     reveal_type(y)  # revealed: Unknown
    |
 info: Its `__iter__` method returns an object of type `Iterator2`, which has a `__next__` attribute that is not callable
-info: `lint:not-iterable` is on by default
+info: `lint:not-iterable` is enabled by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___Legacy_syntax_-_Inferring_a_bound_typevar.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___Legacy_syntax_-_Inferring_a_bound_typevar.snap
@@ -74,7 +74,7 @@ info: Type variable defined here
 5 |
 6 | def f(x: T) -> T:
   |
-info: `lint:invalid-argument-type` is on by default
+info: `lint:invalid-argument-type` is enabled by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___Legacy_syntax_-_Inferring_a_bound_typevar.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___Legacy_syntax_-_Inferring_a_bound_typevar.snap
@@ -74,6 +74,7 @@ info: Type variable defined here
 5 |
 6 | def f(x: T) -> T:
   |
+info: `lint:invalid-argument-type` is on by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___Legacy_syntax_-_Inferring_a_constrained_typevar.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___Legacy_syntax_-_Inferring_a_constrained_typevar.snap
@@ -89,6 +89,7 @@ info: Type variable defined here
 5 |
 6 | def f(x: T) -> T:
   |
+info: `lint:invalid-argument-type` is on by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___Legacy_syntax_-_Inferring_a_constrained_typevar.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___Legacy_syntax_-_Inferring_a_constrained_typevar.snap
@@ -89,7 +89,7 @@ info: Type variable defined here
 5 |
 6 | def f(x: T) -> T:
   |
-info: `lint:invalid-argument-type` is on by default
+info: `lint:invalid-argument-type` is enabled by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___PEP_695_syntax_-_Inferring_a_bound_typevar.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___PEP_695_syntax_-_Inferring_a_bound_typevar.snap
@@ -70,7 +70,7 @@ info: Type variable defined here
   |       ^^^^^^
 4 |     return x
   |
-info: `lint:invalid-argument-type` is on by default
+info: `lint:invalid-argument-type` is enabled by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___PEP_695_syntax_-_Inferring_a_bound_typevar.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___PEP_695_syntax_-_Inferring_a_bound_typevar.snap
@@ -70,6 +70,7 @@ info: Type variable defined here
   |       ^^^^^^
 4 |     return x
   |
+info: `lint:invalid-argument-type` is on by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___PEP_695_syntax_-_Inferring_a_constrained_typevar.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___PEP_695_syntax_-_Inferring_a_constrained_typevar.snap
@@ -85,7 +85,7 @@ info: Type variable defined here
   |       ^^^^^^^^^^^^^^
 4 |     return x
   |
-info: `lint:invalid-argument-type` is on by default
+info: `lint:invalid-argument-type` is enabled by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___PEP_695_syntax_-_Inferring_a_constrained_typevar.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___PEP_695_syntax_-_Inferring_a_constrained_typevar.snap
@@ -85,6 +85,7 @@ info: Type variable defined here
   |       ^^^^^^^^^^^^^^
 4 |     return x
   |
+info: `lint:invalid-argument-type` is on by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/instances.md_-_Binary_operations_on_instances_-_Operations_involving_types_with_invalid_`__bool__`_methods.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/instances.md_-_Binary_operations_on_instances_-_Operations_involving_types_with_invalid_`__bool__`_methods.snap
@@ -32,5 +32,6 @@ error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for t
   |        ^
   |
 info: `__bool__` on `NotBoolable` must be callable
+info: `lint:unsupported-bool-conversion` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/instances.md_-_Binary_operations_on_instances_-_Operations_involving_types_with_invalid_`__bool__`_methods.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/instances.md_-_Binary_operations_on_instances_-_Operations_involving_types_with_invalid_`__bool__`_methods.snap
@@ -32,6 +32,6 @@ error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for t
   |        ^
   |
 info: `__bool__` on `NotBoolable` must be callable
-info: `lint:unsupported-bool-conversion` is on by default
+info: `lint:unsupported-bool-conversion` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Basic.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Basic.snap
@@ -36,6 +36,6 @@ info: Function defined here
   |     ^^^ ------ Parameter declared here
 2 |     return x * x
   |
-info: `lint:invalid-argument-type` is on by default
+info: `lint:invalid-argument-type` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Basic.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Basic.snap
@@ -36,5 +36,6 @@ info: Function defined here
   |     ^^^ ------ Parameter declared here
 2 |     return x * x
   |
+info: `lint:invalid-argument-type` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Calls_to_methods.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Calls_to_methods.snap
@@ -38,5 +38,6 @@ info: Function defined here
   |         ^^^^^^       ------ Parameter declared here
 3 |         return x * x
   |
+info: `lint:invalid-argument-type` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Calls_to_methods.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Calls_to_methods.snap
@@ -38,6 +38,6 @@ info: Function defined here
   |         ^^^^^^       ------ Parameter declared here
 3 |         return x * x
   |
-info: `lint:invalid-argument-type` is on by default
+info: `lint:invalid-argument-type` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Different_files.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Different_files.snap
@@ -42,6 +42,6 @@ info: Function defined here
   |     ^^^ ------ Parameter declared here
 2 |     return x * x
   |
-info: `lint:invalid-argument-type` is on by default
+info: `lint:invalid-argument-type` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Different_files.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Different_files.snap
@@ -42,5 +42,6 @@ info: Function defined here
   |     ^^^ ------ Parameter declared here
 2 |     return x * x
   |
+info: `lint:invalid-argument-type` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Different_source_order.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Different_source_order.snap
@@ -40,6 +40,6 @@ info: Function defined here
   |     ^^^ ------ Parameter declared here
 5 |     return x * x
   |
-info: `lint:invalid-argument-type` is on by default
+info: `lint:invalid-argument-type` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Different_source_order.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Different_source_order.snap
@@ -40,5 +40,6 @@ info: Function defined here
   |     ^^^ ------ Parameter declared here
 5 |     return x * x
   |
+info: `lint:invalid-argument-type` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters.snap
@@ -36,5 +36,6 @@ info: Function defined here
   |     ^^^         ------ Parameter declared here
 2 |     return x * y * z
   |
+info: `lint:invalid-argument-type` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters.snap
@@ -36,6 +36,6 @@ info: Function defined here
   |     ^^^         ------ Parameter declared here
 2 |     return x * y * z
   |
-info: `lint:invalid-argument-type` is on by default
+info: `lint:invalid-argument-type` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters_across_multiple_lines.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters_across_multiple_lines.snap
@@ -44,5 +44,6 @@ info: Function defined here
 4 |     z: int,
 5 | ) -> int:
   |
+info: `lint:invalid-argument-type` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters_across_multiple_lines.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters_across_multiple_lines.snap
@@ -44,6 +44,6 @@ info: Function defined here
 4 |     z: int,
 5 | ) -> int:
   |
-info: `lint:invalid-argument-type` is on by default
+info: `lint:invalid-argument-type` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters_with_multiple_invalid_arguments.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters_with_multiple_invalid_arguments.snap
@@ -39,7 +39,7 @@ info: Function defined here
   |     ^^^ ------ Parameter declared here
 2 |     return x * y * z
   |
-info: `lint:invalid-argument-type` is on by default
+info: `lint:invalid-argument-type` is enabled by default
 
 ```
 
@@ -59,7 +59,7 @@ info: Function defined here
   |     ^^^         ------ Parameter declared here
 2 |     return x * y * z
   |
-info: `lint:invalid-argument-type` is on by default
+info: `lint:invalid-argument-type` is enabled by default
 
 ```
 
@@ -79,6 +79,6 @@ info: Function defined here
   |     ^^^                 ------ Parameter declared here
 2 |     return x * y * z
   |
-info: `lint:invalid-argument-type` is on by default
+info: `lint:invalid-argument-type` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters_with_multiple_invalid_arguments.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters_with_multiple_invalid_arguments.snap
@@ -39,6 +39,7 @@ info: Function defined here
   |     ^^^ ------ Parameter declared here
 2 |     return x * y * z
   |
+info: `lint:invalid-argument-type` is on by default
 
 ```
 
@@ -58,6 +59,7 @@ info: Function defined here
   |     ^^^         ------ Parameter declared here
 2 |     return x * y * z
   |
+info: `lint:invalid-argument-type` is on by default
 
 ```
 
@@ -77,5 +79,6 @@ info: Function defined here
   |     ^^^                 ------ Parameter declared here
 2 |     return x * y * z
   |
+info: `lint:invalid-argument-type` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Test_calling_a_function_whose_type_is_vendored_from_`typeshed`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Test_calling_a_function_whose_type_is_vendored_from_`typeshed`.snap
@@ -40,5 +40,6 @@ info: Function defined here
 41 |     *,
 42 |     cls: type[JSONDecoder] | None = None,
    |
+info: `lint:invalid-argument-type` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Test_calling_a_function_whose_type_is_vendored_from_`typeshed`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Test_calling_a_function_whose_type_is_vendored_from_`typeshed`.snap
@@ -40,6 +40,6 @@ info: Function defined here
 41 |     *,
 42 |     cls: type[JSONDecoder] | None = None,
    |
-info: `lint:invalid-argument-type` is on by default
+info: `lint:invalid-argument-type` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Keyword_only_arguments.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Keyword_only_arguments.snap
@@ -36,6 +36,6 @@ info: Function defined here
   |     ^^^                    ---------- Parameter declared here
 2 |     return x * y * z
   |
-info: `lint:invalid-argument-type` is on by default
+info: `lint:invalid-argument-type` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Keyword_only_arguments.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Keyword_only_arguments.snap
@@ -36,5 +36,6 @@ info: Function defined here
   |     ^^^                    ---------- Parameter declared here
 2 |     return x * y * z
   |
+info: `lint:invalid-argument-type` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Mix_of_arguments.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Mix_of_arguments.snap
@@ -36,5 +36,6 @@ info: Function defined here
   |     ^^^                       ---------- Parameter declared here
 2 |     return x * y * z
   |
+info: `lint:invalid-argument-type` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Mix_of_arguments.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Mix_of_arguments.snap
@@ -36,6 +36,6 @@ info: Function defined here
   |     ^^^                       ---------- Parameter declared here
 2 |     return x * y * z
   |
-info: `lint:invalid-argument-type` is on by default
+info: `lint:invalid-argument-type` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_One_keyword_argument.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_One_keyword_argument.snap
@@ -36,6 +36,6 @@ info: Function defined here
   |     ^^^                 ---------- Parameter declared here
 2 |     return x * y * z
   |
-info: `lint:invalid-argument-type` is on by default
+info: `lint:invalid-argument-type` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_One_keyword_argument.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_One_keyword_argument.snap
@@ -36,5 +36,6 @@ info: Function defined here
   |     ^^^                 ---------- Parameter declared here
 2 |     return x * y * z
   |
+info: `lint:invalid-argument-type` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Only_positional.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Only_positional.snap
@@ -36,5 +36,6 @@ info: Function defined here
   |     ^^^         ------ Parameter declared here
 2 |     return x * y * z
   |
+info: `lint:invalid-argument-type` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Only_positional.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Only_positional.snap
@@ -36,6 +36,6 @@ info: Function defined here
   |     ^^^         ------ Parameter declared here
 2 |     return x * y * z
   |
-info: `lint:invalid-argument-type` is on by default
+info: `lint:invalid-argument-type` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Synthetic_arguments.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Synthetic_arguments.snap
@@ -38,5 +38,6 @@ info: Function defined here
   |         ^^^^^^^^       ------ Parameter declared here
 3 |         return 1
   |
+info: `lint:invalid-argument-type` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Synthetic_arguments.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Synthetic_arguments.snap
@@ -38,6 +38,6 @@ info: Function defined here
   |         ^^^^^^^^       ------ Parameter declared here
 3 |         return 1
   |
-info: `lint:invalid-argument-type` is on by default
+info: `lint:invalid-argument-type` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Variadic_arguments.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Variadic_arguments.snap
@@ -36,5 +36,6 @@ info: Function defined here
   |     ^^^ ------------- Parameter declared here
 2 |     return len(numbers)
   |
+info: `lint:invalid-argument-type` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Variadic_arguments.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Variadic_arguments.snap
@@ -36,6 +36,6 @@ info: Function defined here
   |     ^^^ ------------- Parameter declared here
 2 |     return len(numbers)
   |
-info: `lint:invalid-argument-type` is on by default
+info: `lint:invalid-argument-type` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Variadic_keyword_arguments.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Variadic_keyword_arguments.snap
@@ -36,6 +36,6 @@ info: Function defined here
   |     ^^^ -------------- Parameter declared here
 2 |     return len(numbers)
   |
-info: `lint:invalid-argument-type` is on by default
+info: `lint:invalid-argument-type` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Variadic_keyword_arguments.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Variadic_keyword_arguments.snap
@@ -36,5 +36,6 @@ info: Function defined here
   |     ^^^ -------------- Parameter declared here
 2 |     return len(numbers)
   |
+info: `lint:invalid-argument-type` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/membership_test.md_-_Comparison___Membership_Test_-_Return_type_that_doesn't_implement_`__bool__`_correctly.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/membership_test.md_-_Comparison___Membership_Test_-_Return_type_that_doesn't_implement_`__bool__`_correctly.snap
@@ -38,7 +38,7 @@ error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for t
 11 | 10 not in WithContains()
    |
 info: `__bool__` on `NotBoolable` must be callable
-info: `lint:unsupported-bool-conversion` is on by default
+info: `lint:unsupported-bool-conversion` is enabled by default
 
 ```
 
@@ -52,6 +52,6 @@ error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for t
    | ^^^^^^^^^^^^^^^^^^^^^^^^
    |
 info: `__bool__` on `NotBoolable` must be callable
-info: `lint:unsupported-bool-conversion` is on by default
+info: `lint:unsupported-bool-conversion` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/membership_test.md_-_Comparison___Membership_Test_-_Return_type_that_doesn't_implement_`__bool__`_correctly.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/membership_test.md_-_Comparison___Membership_Test_-_Return_type_that_doesn't_implement_`__bool__`_correctly.snap
@@ -38,6 +38,7 @@ error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for t
 11 | 10 not in WithContains()
    |
 info: `__bool__` on `NotBoolable` must be callable
+info: `lint:unsupported-bool-conversion` is on by default
 
 ```
 
@@ -51,5 +52,6 @@ error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for t
    | ^^^^^^^^^^^^^^^^^^^^^^^^
    |
 info: `__bool__` on `NotBoolable` must be callable
+info: `lint:unsupported-bool-conversion` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/no_matching_overload.md_-_No_matching_overload_diagnostics_-_Calls_to_overloaded_functions.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/no_matching_overload.md_-_No_matching_overload_diagnostics_-_Calls_to_overloaded_functions.snap
@@ -24,6 +24,6 @@ error: lint:no-matching-overload: No overload of class `type` matches arguments
 1 | type("Foo", ())  # error: [no-matching-overload]
   | ^^^^^^^^^^^^^^^
   |
-info: `lint:no-matching-overload` is on by default
+info: `lint:no-matching-overload` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/no_matching_overload.md_-_No_matching_overload_diagnostics_-_Calls_to_overloaded_functions.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/no_matching_overload.md_-_No_matching_overload_diagnostics_-_Calls_to_overloaded_functions.snap
@@ -24,5 +24,6 @@ error: lint:no-matching-overload: No overload of class `type` matches arguments
 1 | type("Foo", ())  # error: [no-matching-overload]
   | ^^^^^^^^^^^^^^^
   |
+info: `lint:no-matching-overload` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/not.md_-_Unary_not_-_Object_that_implements_`__bool__`_incorrectly.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/not.md_-_Unary_not_-_Object_that_implements_`__bool__`_incorrectly.snap
@@ -30,5 +30,6 @@ error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for t
   | ^^^^^^^^^^^^^^^^^
   |
 info: `__bool__` on `NotBoolable` must be callable
+info: `lint:unsupported-bool-conversion` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/not.md_-_Unary_not_-_Object_that_implements_`__bool__`_incorrectly.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/not.md_-_Unary_not_-_Object_that_implements_`__bool__`_incorrectly.snap
@@ -30,6 +30,6 @@ error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for t
   | ^^^^^^^^^^^^^^^^^
   |
 info: `__bool__` on `NotBoolable` must be callable
-info: `lint:unsupported-bool-conversion` is on by default
+info: `lint:unsupported-bool-conversion` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_At_least_two_overloads.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_At_least_two_overloads.snap
@@ -47,7 +47,7 @@ error: lint:invalid-overload: Overloaded function `func` requires at least two o
   |     ^^^^
 8 |     return x
   |
-info: `lint:invalid-overload` is on by default
+info: `lint:invalid-overload` is enabled by default
 
 ```
 
@@ -62,6 +62,6 @@ error: lint:invalid-overload: Overloaded function `func` requires at least two o
   |     |
   |     Only one overload defined here
   |
-info: `lint:invalid-overload` is on by default
+info: `lint:invalid-overload` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_At_least_two_overloads.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_At_least_two_overloads.snap
@@ -47,6 +47,7 @@ error: lint:invalid-overload: Overloaded function `func` requires at least two o
   |     ^^^^
 8 |     return x
   |
+info: `lint:invalid-overload` is on by default
 
 ```
 
@@ -61,5 +62,6 @@ error: lint:invalid-overload: Overloaded function `func` requires at least two o
   |     |
   |     Only one overload defined here
   |
+info: `lint:invalid-overload` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorators_-_`@classmethod`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorators_-_`@classmethod`.snap
@@ -84,7 +84,7 @@ error: lint:invalid-overload: Overloaded function `try_from3` does not use the `
 41 |         if isinstance(x, int):
 42 |             return cls(x)
    |
-info: `lint:invalid-overload` is on by default
+info: `lint:invalid-overload` is enabled by default
 
 ```
 
@@ -103,7 +103,7 @@ error: lint:invalid-overload: Overloaded function `try_from1` does not use the `
 17 |         if isinstance(x, int):
 18 |             return cls(x)
    |
-info: `lint:invalid-overload` is on by default
+info: `lint:invalid-overload` is enabled by default
 
 ```
 
@@ -126,6 +126,6 @@ error: lint:invalid-overload: Overloaded function `try_from2` does not use the `
 23 |     @overload
 24 |     @classmethod
    |
-info: `lint:invalid-overload` is on by default
+info: `lint:invalid-overload` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorators_-_`@classmethod`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorators_-_`@classmethod`.snap
@@ -84,6 +84,7 @@ error: lint:invalid-overload: Overloaded function `try_from3` does not use the `
 41 |         if isinstance(x, int):
 42 |             return cls(x)
    |
+info: `lint:invalid-overload` is on by default
 
 ```
 
@@ -102,6 +103,7 @@ error: lint:invalid-overload: Overloaded function `try_from1` does not use the `
 17 |         if isinstance(x, int):
 18 |             return cls(x)
    |
+info: `lint:invalid-overload` is on by default
 
 ```
 
@@ -124,5 +126,6 @@ error: lint:invalid-overload: Overloaded function `try_from2` does not use the `
 23 |     @overload
 24 |     @classmethod
    |
+info: `lint:invalid-overload` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorators_-_`@final`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorators_-_`@final`.snap
@@ -76,7 +76,7 @@ error: lint:invalid-overload: `@final` decorator should be applied only to the o
    |         Implementation defined here
 28 |         return x
    |
-info: `lint:invalid-overload` is on by default
+info: `lint:invalid-overload` is enabled by default
 
 ```
 
@@ -92,7 +92,7 @@ error: lint:invalid-overload: `@final` decorator should be applied only to the o
    |         Implementation defined here
 19 |         return x
    |
-info: `lint:invalid-overload` is on by default
+info: `lint:invalid-overload` is enabled by default
 
 ```
 
@@ -109,6 +109,6 @@ error: lint:invalid-overload: `@final` decorator should be applied only to the f
 15 |     def method2(self, x: str) -> str: ...
    |         ^^^^^^^
    |
-info: `lint:invalid-overload` is on by default
+info: `lint:invalid-overload` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorators_-_`@final`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorators_-_`@final`.snap
@@ -76,6 +76,7 @@ error: lint:invalid-overload: `@final` decorator should be applied only to the o
    |         Implementation defined here
 28 |         return x
    |
+info: `lint:invalid-overload` is on by default
 
 ```
 
@@ -91,6 +92,7 @@ error: lint:invalid-overload: `@final` decorator should be applied only to the o
    |         Implementation defined here
 19 |         return x
    |
+info: `lint:invalid-overload` is on by default
 
 ```
 
@@ -107,5 +109,6 @@ error: lint:invalid-overload: `@final` decorator should be applied only to the f
 15 |     def method2(self, x: str) -> str: ...
    |         ^^^^^^^
    |
+info: `lint:invalid-overload` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorators_-_`@override`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorators_-_`@override`.snap
@@ -93,6 +93,7 @@ error: lint:invalid-overload: `@override` decorator should be applied only to th
    |         Implementation defined here
 28 |         return x
    |
+info: `lint:invalid-overload` is on by default
 
 ```
 
@@ -108,6 +109,7 @@ error: lint:invalid-overload: `@override` decorator should be applied only to th
    |         Implementation defined here
 38 |         return x
    |
+info: `lint:invalid-overload` is on by default
 
 ```
 
@@ -125,5 +127,6 @@ error: lint:invalid-overload: `@override` decorator should be applied only to th
 22 |     def method(self, x: str) -> str: ...
    |         ^^^^^^
    |
+info: `lint:invalid-overload` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorators_-_`@override`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorators_-_`@override`.snap
@@ -93,7 +93,7 @@ error: lint:invalid-overload: `@override` decorator should be applied only to th
    |         Implementation defined here
 28 |         return x
    |
-info: `lint:invalid-overload` is on by default
+info: `lint:invalid-overload` is enabled by default
 
 ```
 
@@ -109,7 +109,7 @@ error: lint:invalid-overload: `@override` decorator should be applied only to th
    |         Implementation defined here
 38 |         return x
    |
-info: `lint:invalid-overload` is on by default
+info: `lint:invalid-overload` is enabled by default
 
 ```
 
@@ -127,6 +127,6 @@ error: lint:invalid-overload: `@override` decorator should be applied only to th
 22 |     def method(self, x: str) -> str: ...
    |         ^^^^^^
    |
-info: `lint:invalid-overload` is on by default
+info: `lint:invalid-overload` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Overload_without_an_implementation_-_Regular_modules.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Overload_without_an_implementation_-_Regular_modules.snap
@@ -41,7 +41,7 @@ error: lint:invalid-overload: Overloaded non-stub function `func` must have an i
 8 |
 9 | class Foo:
   |
-info: `lint:invalid-overload` is on by default
+info: `lint:invalid-overload` is enabled by default
 
 ```
 
@@ -54,6 +54,6 @@ error: lint:invalid-overload: Overloaded non-stub function `method` must have an
 14 |     def method(self, x: str) -> str: ...
    |         ^^^^^^
    |
-info: `lint:invalid-overload` is on by default
+info: `lint:invalid-overload` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Overload_without_an_implementation_-_Regular_modules.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Overload_without_an_implementation_-_Regular_modules.snap
@@ -41,6 +41,7 @@ error: lint:invalid-overload: Overloaded non-stub function `func` must have an i
 8 |
 9 | class Foo:
   |
+info: `lint:invalid-overload` is on by default
 
 ```
 
@@ -53,5 +54,6 @@ error: lint:invalid-overload: Overloaded non-stub function `method` must have an
 14 |     def method(self, x: str) -> str: ...
    |         ^^^^^^
    |
+info: `lint:invalid-overload` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Calls_to_protocol_classes.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Calls_to_protocol_classes.snap
@@ -51,6 +51,7 @@ error: lint:call-non-callable: Object of type `typing.Protocol` is not callable
 5 |
 6 | class MyProtocol(Protocol):
   |
+info: `lint:call-non-callable` is on by default
 
 ```
 
@@ -86,6 +87,7 @@ info: Protocol classes cannot be instantiated
   |       ^^^^^^^^^^^^^^^^^^^^ `MyProtocol` declared as a protocol here
 7 |     x: int
   |
+info: `lint:call-non-callable` is on by default
 
 ```
 
@@ -120,6 +122,7 @@ info: Protocol classes cannot be instantiated
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `GenericProtocol` declared as a protocol here
 13 |     x: T
    |
+info: `lint:call-non-callable` is on by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Calls_to_protocol_classes.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Calls_to_protocol_classes.snap
@@ -51,7 +51,7 @@ error: lint:call-non-callable: Object of type `typing.Protocol` is not callable
 5 |
 6 | class MyProtocol(Protocol):
   |
-info: `lint:call-non-callable` is on by default
+info: `lint:call-non-callable` is enabled by default
 
 ```
 
@@ -87,7 +87,7 @@ info: Protocol classes cannot be instantiated
   |       ^^^^^^^^^^^^^^^^^^^^ `MyProtocol` declared as a protocol here
 7 |     x: int
   |
-info: `lint:call-non-callable` is on by default
+info: `lint:call-non-callable` is enabled by default
 
 ```
 
@@ -122,7 +122,7 @@ info: Protocol classes cannot be instantiated
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `GenericProtocol` declared as a protocol here
 13 |     x: T
    |
-info: `lint:call-non-callable` is on by default
+info: `lint:call-non-callable` is enabled by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Invalid_calls_to_`get_protocol_members()`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Invalid_calls_to_`get_protocol_members()`.snap
@@ -52,6 +52,7 @@ info: `NotAProtocol` is declared here, but it is not a protocol class:
   |
 info: A class is only a protocol class if it directly inherits from `typing.Protocol` or `typing_extensions.Protocol`
 info: See https://typing.python.org/en/latest/spec/protocol.html#
+info: `lint:invalid-argument-type` is on by default
 
 ```
 
@@ -78,5 +79,6 @@ info: `AlsoNotAProtocol` is declared here, but it is not a protocol class:
   |
 info: A class is only a protocol class if it directly inherits from `typing.Protocol` or `typing_extensions.Protocol`
 info: See https://typing.python.org/en/latest/spec/protocol.html#
+info: `lint:invalid-argument-type` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Invalid_calls_to_`get_protocol_members()`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Invalid_calls_to_`get_protocol_members()`.snap
@@ -52,7 +52,7 @@ info: `NotAProtocol` is declared here, but it is not a protocol class:
   |
 info: A class is only a protocol class if it directly inherits from `typing.Protocol` or `typing_extensions.Protocol`
 info: See https://typing.python.org/en/latest/spec/protocol.html#
-info: `lint:invalid-argument-type` is on by default
+info: `lint:invalid-argument-type` is enabled by default
 
 ```
 
@@ -79,6 +79,6 @@ info: `AlsoNotAProtocol` is declared here, but it is not a protocol class:
   |
 info: A class is only a protocol class if it directly inherits from `typing.Protocol` or `typing_extensions.Protocol`
 info: See https://typing.python.org/en/latest/spec/protocol.html#
-info: `lint:invalid-argument-type` is on by default
+info: `lint:invalid-argument-type` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Narrowing_of_protocols.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Narrowing_of_protocols.snap
@@ -77,7 +77,7 @@ info: `HasX` is declared as a protocol class, but it is not declared as runtime-
   |
 info: A protocol class can only be used in `isinstance` checks if it is decorated with `@typing.runtime_checkable` or `@typing_extensions.runtime_checkable`
 info: See https://docs.python.org/3/library/typing.html#typing.runtime_checkable
-info: `lint:invalid-argument-type` is on by default
+info: `lint:invalid-argument-type` is enabled by default
 
 ```
 
@@ -131,7 +131,7 @@ info: `HasX` is declared as a protocol class, but it is not declared as runtime-
   |
 info: A protocol class can only be used in `issubclass` checks if it is decorated with `@typing.runtime_checkable` or `@typing_extensions.runtime_checkable`
 info: See https://docs.python.org/3/library/typing.html#typing.runtime_checkable
-info: `lint:invalid-argument-type` is on by default
+info: `lint:invalid-argument-type` is enabled by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Narrowing_of_protocols.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Narrowing_of_protocols.snap
@@ -77,6 +77,7 @@ info: `HasX` is declared as a protocol class, but it is not declared as runtime-
   |
 info: A protocol class can only be used in `isinstance` checks if it is decorated with `@typing.runtime_checkable` or `@typing_extensions.runtime_checkable`
 info: See https://docs.python.org/3/library/typing.html#typing.runtime_checkable
+info: `lint:invalid-argument-type` is on by default
 
 ```
 
@@ -130,6 +131,7 @@ info: `HasX` is declared as a protocol class, but it is not declared as runtime-
   |
 info: A protocol class can only be used in `issubclass` checks if it is decorated with `@typing.runtime_checkable` or `@typing_extensions.runtime_checkable`
 info: See https://docs.python.org/3/library/typing.html#typing.runtime_checkable
+info: `lint:invalid-argument-type` is on by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Generator_functions.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Generator_functions.snap
@@ -63,6 +63,7 @@ error: lint:invalid-return-type: Return type does not match returned value
    |
 info: Function is inferred as returning `types.GeneratorType` because it is a generator function
 info: See https://docs.python.org/3/glossary.html#term-generator for more details
+info: `lint:invalid-return-type` is enabled by default
 
 ```
 
@@ -78,5 +79,6 @@ error: lint:invalid-return-type: Return type does not match returned value
    |
 info: Function is inferred as returning `types.AsyncGeneratorType` because it is an async generator function
 info: See https://docs.python.org/3/glossary.html#term-asynchronous-generator for more details
+info: `lint:invalid-return-type` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_conditional_return_type.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_conditional_return_type.snap
@@ -45,6 +45,7 @@ error: lint:invalid-return-type: Return type does not match returned value
 7 |
 8 | def f(cond: bool) -> str:
   |
+info: `lint:invalid-return-type` is on by default
 
 ```
 
@@ -63,6 +64,7 @@ error: lint:invalid-return-type: Return type does not match returned value
 12 |     else:
 13 |         # error: [invalid-return-type]
    |
+info: `lint:invalid-return-type` is on by default
 
 ```
 
@@ -84,5 +86,6 @@ error: lint:invalid-return-type: Return type does not match returned value
  9 |     if cond:
 10 |         # error: [invalid-return-type]
    |
+info: `lint:invalid-return-type` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_conditional_return_type.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_conditional_return_type.snap
@@ -45,7 +45,7 @@ error: lint:invalid-return-type: Return type does not match returned value
 7 |
 8 | def f(cond: bool) -> str:
   |
-info: `lint:invalid-return-type` is on by default
+info: `lint:invalid-return-type` is enabled by default
 
 ```
 
@@ -64,7 +64,7 @@ error: lint:invalid-return-type: Return type does not match returned value
 12 |     else:
 13 |         # error: [invalid-return-type]
    |
-info: `lint:invalid-return-type` is on by default
+info: `lint:invalid-return-type` is enabled by default
 
 ```
 
@@ -86,6 +86,6 @@ error: lint:invalid-return-type: Return type does not match returned value
  9 |     if cond:
 10 |         # error: [invalid-return-type]
    |
-info: `lint:invalid-return-type` is on by default
+info: `lint:invalid-return-type` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_implicit_return_type.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_implicit_return_type.snap
@@ -52,6 +52,7 @@ error: lint:invalid-return-type: Return type does not match returned value
 5 |
 6 | # error: [invalid-return-type]
   |
+info: `lint:invalid-return-type` is on by default
 
 ```
 
@@ -65,6 +66,7 @@ error: lint:invalid-return-type: Function can implicitly return `None`, which is
 8 |     if cond:
 9 |         return 1
   |
+info: `lint:invalid-return-type` is on by default
 
 ```
 
@@ -78,6 +80,7 @@ error: lint:invalid-return-type: Function can implicitly return `None`, which is
 13 |     if cond:
 14 |         raise ValueError()
    |
+info: `lint:invalid-return-type` is on by default
 
 ```
 
@@ -91,5 +94,6 @@ error: lint:invalid-return-type: Function can implicitly return `None`, which is
 18 |     if cond:
 19 |         cond = False
    |
+info: `lint:invalid-return-type` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_implicit_return_type.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_implicit_return_type.snap
@@ -52,7 +52,7 @@ error: lint:invalid-return-type: Return type does not match returned value
 5 |
 6 | # error: [invalid-return-type]
   |
-info: `lint:invalid-return-type` is on by default
+info: `lint:invalid-return-type` is enabled by default
 
 ```
 
@@ -66,7 +66,7 @@ error: lint:invalid-return-type: Function can implicitly return `None`, which is
 8 |     if cond:
 9 |         return 1
   |
-info: `lint:invalid-return-type` is on by default
+info: `lint:invalid-return-type` is enabled by default
 
 ```
 
@@ -80,7 +80,7 @@ error: lint:invalid-return-type: Function can implicitly return `None`, which is
 13 |     if cond:
 14 |         raise ValueError()
    |
-info: `lint:invalid-return-type` is on by default
+info: `lint:invalid-return-type` is enabled by default
 
 ```
 
@@ -94,6 +94,6 @@ error: lint:invalid-return-type: Function can implicitly return `None`, which is
 18 |     if cond:
 19 |         cond = False
    |
-info: `lint:invalid-return-type` is on by default
+info: `lint:invalid-return-type` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type.snap
@@ -43,6 +43,7 @@ error: lint:invalid-return-type: Function can implicitly return `None`, which is
   |            ^^^
 3 |     1
   |
+info: `lint:invalid-return-type` is on by default
 
 ```
 
@@ -60,6 +61,7 @@ error: lint:invalid-return-type: Return type does not match returned value
 8 |
 9 | def f() -> int:
   |
+info: `lint:invalid-return-type` is on by default
 
 ```
 
@@ -77,6 +79,7 @@ error: lint:invalid-return-type: Return type does not match returned value
 12 |
 13 | from typing import TypeVar
    |
+info: `lint:invalid-return-type` is on by default
 
 ```
 
@@ -88,5 +91,6 @@ error: lint:invalid-return-type: Function can implicitly return `None`, which is
 18 | def m(x: T) -> T: ...
    |                ^
    |
+info: `lint:invalid-return-type` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type.snap
@@ -43,7 +43,7 @@ error: lint:invalid-return-type: Function can implicitly return `None`, which is
   |            ^^^
 3 |     1
   |
-info: `lint:invalid-return-type` is on by default
+info: `lint:invalid-return-type` is enabled by default
 
 ```
 
@@ -61,7 +61,7 @@ error: lint:invalid-return-type: Return type does not match returned value
 8 |
 9 | def f() -> int:
   |
-info: `lint:invalid-return-type` is on by default
+info: `lint:invalid-return-type` is enabled by default
 
 ```
 
@@ -79,7 +79,7 @@ error: lint:invalid-return-type: Return type does not match returned value
 12 |
 13 | from typing import TypeVar
    |
-info: `lint:invalid-return-type` is on by default
+info: `lint:invalid-return-type` is enabled by default
 
 ```
 
@@ -91,6 +91,6 @@ error: lint:invalid-return-type: Function can implicitly return `None`, which is
 18 | def m(x: T) -> T: ...
    |                ^
    |
-info: `lint:invalid-return-type` is on by default
+info: `lint:invalid-return-type` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type_in_stub_file.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type_in_stub_file.snap
@@ -41,6 +41,7 @@ error: lint:invalid-return-type: Return type does not match returned value
 4 |
 5 | # error: [invalid-return-type]
   |
+info: `lint:invalid-return-type` is on by default
 
 ```
 
@@ -54,6 +55,7 @@ error: lint:invalid-return-type: Function can implicitly return `None`, which is
 7 |     print("...")
 8 |     ...
   |
+info: `lint:invalid-return-type` is on by default
 
 ```
 
@@ -67,5 +69,6 @@ error: lint:invalid-return-type: Function can implicitly return `None`, which is
 12 |     f"""{foo} is a function that ..."""
 13 |     ...
    |
+info: `lint:invalid-return-type` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type_in_stub_file.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type_in_stub_file.snap
@@ -41,7 +41,7 @@ error: lint:invalid-return-type: Return type does not match returned value
 4 |
 5 | # error: [invalid-return-type]
   |
-info: `lint:invalid-return-type` is on by default
+info: `lint:invalid-return-type` is enabled by default
 
 ```
 
@@ -55,7 +55,7 @@ error: lint:invalid-return-type: Function can implicitly return `None`, which is
 7 |     print("...")
 8 |     ...
   |
-info: `lint:invalid-return-type` is on by default
+info: `lint:invalid-return-type` is enabled by default
 
 ```
 
@@ -69,6 +69,6 @@ error: lint:invalid-return-type: Function can implicitly return `None`, which is
 12 |     f"""{foo} is a function that ..."""
 13 |     ...
    |
-info: `lint:invalid-return-type` is on by default
+info: `lint:invalid-return-type` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/rich_comparison.md_-_Comparison___Rich_Comparison_-_Chained_comparisons_with_objects_that_don't_implement_`__bool__`_correctly.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/rich_comparison.md_-_Comparison___Rich_Comparison_-_Chained_comparisons_with_objects_that_don't_implement_`__bool__`_correctly.snap
@@ -43,6 +43,7 @@ error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for t
 14 | 10 < Comparable() < Comparable()
    |
 info: `__bool__` on `NotBoolable` must be callable
+info: `lint:unsupported-bool-conversion` is on by default
 
 ```
 
@@ -58,5 +59,6 @@ error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for t
 16 | Comparable() < Comparable()  # fine
    |
 info: `__bool__` on `NotBoolable` must be callable
+info: `lint:unsupported-bool-conversion` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/rich_comparison.md_-_Comparison___Rich_Comparison_-_Chained_comparisons_with_objects_that_don't_implement_`__bool__`_correctly.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/rich_comparison.md_-_Comparison___Rich_Comparison_-_Chained_comparisons_with_objects_that_don't_implement_`__bool__`_correctly.snap
@@ -43,7 +43,7 @@ error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for t
 14 | 10 < Comparable() < Comparable()
    |
 info: `__bool__` on `NotBoolable` must be callable
-info: `lint:unsupported-bool-conversion` is on by default
+info: `lint:unsupported-bool-conversion` is enabled by default
 
 ```
 
@@ -59,6 +59,6 @@ error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for t
 16 | Comparable() < Comparable()  # fine
    |
 info: `__bool__` on `NotBoolable` must be callable
-info: `lint:unsupported-bool-conversion` is on by default
+info: `lint:unsupported-bool-conversion` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/shadowing.md_-_Shadowing_-_Implicit_class_shadowing.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/shadowing.md_-_Shadowing_-_Implicit_class_shadowing.snap
@@ -29,5 +29,6 @@ error: lint:invalid-assignment: Implicit shadowing of class `C`
   | ^
   |
 info: Annotate to make it explicit if this is intentional
+info: `lint:invalid-assignment` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/shadowing.md_-_Shadowing_-_Implicit_class_shadowing.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/shadowing.md_-_Shadowing_-_Implicit_class_shadowing.snap
@@ -29,6 +29,6 @@ error: lint:invalid-assignment: Implicit shadowing of class `C`
   | ^
   |
 info: Annotate to make it explicit if this is intentional
-info: `lint:invalid-assignment` is on by default
+info: `lint:invalid-assignment` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/shadowing.md_-_Shadowing_-_Implicit_function_shadowing.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/shadowing.md_-_Shadowing_-_Implicit_function_shadowing.snap
@@ -29,6 +29,6 @@ error: lint:invalid-assignment: Implicit shadowing of function `f`
   | ^
   |
 info: Annotate to make it explicit if this is intentional
-info: `lint:invalid-assignment` is on by default
+info: `lint:invalid-assignment` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/shadowing.md_-_Shadowing_-_Implicit_function_shadowing.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/shadowing.md_-_Shadowing_-_Implicit_function_shadowing.snap
@@ -29,5 +29,6 @@ error: lint:invalid-assignment: Implicit shadowing of function `f`
   | ^
   |
 info: Annotate to make it explicit if this is intentional
+info: `lint:invalid-assignment` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/tuples.md_-_Comparison___Tuples_-_Chained_comparisons_with_elements_that_incorrectly_implement_`__bool__`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/tuples.md_-_Comparison___Tuples_-_Chained_comparisons_with_elements_that_incorrectly_implement_`__bool__`.snap
@@ -44,5 +44,6 @@ error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for t
 17 | a < b  # fine
    |
 info: `__bool__` on `NotBoolable | Literal[False]` must be callable
+info: `lint:unsupported-bool-conversion` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/tuples.md_-_Comparison___Tuples_-_Chained_comparisons_with_elements_that_incorrectly_implement_`__bool__`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/tuples.md_-_Comparison___Tuples_-_Chained_comparisons_with_elements_that_incorrectly_implement_`__bool__`.snap
@@ -44,6 +44,6 @@ error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for t
 17 | a < b  # fine
    |
 info: `__bool__` on `NotBoolable | Literal[False]` must be callable
-info: `lint:unsupported-bool-conversion` is on by default
+info: `lint:unsupported-bool-conversion` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/tuples.md_-_Comparison___Tuples_-_Equality_with_elements_that_incorrectly_implement_`__bool__`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/tuples.md_-_Comparison___Tuples_-_Equality_with_elements_that_incorrectly_implement_`__bool__`.snap
@@ -34,5 +34,6 @@ error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for t
   | ^^^^^^^^^^^^^^^^
   |
 info: `__bool__` on `NotBoolable` must be callable
+info: `lint:unsupported-bool-conversion` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/tuples.md_-_Comparison___Tuples_-_Equality_with_elements_that_incorrectly_implement_`__bool__`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/tuples.md_-_Comparison___Tuples_-_Equality_with_elements_that_incorrectly_implement_`__bool__`.snap
@@ -34,6 +34,6 @@ error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for t
   | ^^^^^^^^^^^^^^^^
   |
 info: `__bool__` on `NotBoolable` must be callable
-info: `lint:unsupported-bool-conversion` is on by default
+info: `lint:unsupported-bool-conversion` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Exactly_too_few_values_to_unpack.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Exactly_too_few_values_to_unpack.snap
@@ -26,5 +26,6 @@ error: lint:invalid-assignment: Not enough values to unpack
   | |
   | Expected 2
   |
+info: `lint:invalid-assignment` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Exactly_too_few_values_to_unpack.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Exactly_too_few_values_to_unpack.snap
@@ -26,6 +26,6 @@ error: lint:invalid-assignment: Not enough values to unpack
   | |
   | Expected 2
   |
-info: `lint:invalid-assignment` is on by default
+info: `lint:invalid-assignment` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Exactly_too_many_values_to_unpack.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Exactly_too_many_values_to_unpack.snap
@@ -26,5 +26,6 @@ error: lint:invalid-assignment: Too many values to unpack
   | |
   | Expected 2
   |
+info: `lint:invalid-assignment` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Exactly_too_many_values_to_unpack.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Exactly_too_many_values_to_unpack.snap
@@ -26,6 +26,6 @@ error: lint:invalid-assignment: Too many values to unpack
   | |
   | Expected 2
   |
-info: `lint:invalid-assignment` is on by default
+info: `lint:invalid-assignment` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Right_hand_side_not_iterable.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Right_hand_side_not_iterable.snap
@@ -25,6 +25,6 @@ error: lint:not-iterable: Object of type `Literal[1]` is not iterable
   |        ^
   |
 info: It doesn't have an `__iter__` method or a `__getitem__` method
-info: `lint:not-iterable` is on by default
+info: `lint:not-iterable` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Right_hand_side_not_iterable.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Right_hand_side_not_iterable.snap
@@ -25,5 +25,6 @@ error: lint:not-iterable: Object of type `Literal[1]` is not iterable
   |        ^
   |
 info: It doesn't have an `__iter__` method or a `__getitem__` method
+info: `lint:not-iterable` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Too_few_values_to_unpack.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Too_few_values_to_unpack.snap
@@ -26,5 +26,6 @@ error: lint:invalid-assignment: Not enough values to unpack
   | |
   | Expected 3 or more
   |
+info: `lint:invalid-assignment` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Too_few_values_to_unpack.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Too_few_values_to_unpack.snap
@@ -26,6 +26,6 @@ error: lint:invalid-assignment: Not enough values to unpack
   | |
   | Expected 3 or more
   |
-info: `lint:invalid-assignment` is on by default
+info: `lint:invalid-assignment` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_An_unresolvable_import_that_does_not_use_`from`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_An_unresolvable_import_that_does_not_use_`from`.snap
@@ -28,5 +28,6 @@ error: lint:unresolved-import: Cannot resolve imported module `does_not_exist`
 2 |
 3 | x = does_not_exist.foo
   |
+info: `lint:unresolved-import` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_An_unresolvable_import_that_does_not_use_`from`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_An_unresolvable_import_that_does_not_use_`from`.snap
@@ -28,6 +28,6 @@ error: lint:unresolved-import: Cannot resolve imported module `does_not_exist`
 2 |
 3 | x = does_not_exist.foo
   |
-info: `lint:unresolved-import` is on by default
+info: `lint:unresolved-import` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_a_resolvable_module_but_unresolvable_item.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_a_resolvable_module_but_unresolvable_item.snap
@@ -31,5 +31,6 @@ error: lint:unresolved-import: Module `a` has no member `does_not_exist`
 1 | from a import does_exist1, does_not_exist, does_exist2  # error: [unresolved-import]
   |                            ^^^^^^^^^^^^^^
   |
+info: `lint:unresolved-import` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_a_resolvable_module_but_unresolvable_item.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_a_resolvable_module_but_unresolvable_item.snap
@@ -31,6 +31,6 @@ error: lint:unresolved-import: Module `a` has no member `does_not_exist`
 1 | from a import does_exist1, does_not_exist, does_exist2  # error: [unresolved-import]
   |                            ^^^^^^^^^^^^^^
   |
-info: `lint:unresolved-import` is on by default
+info: `lint:unresolved-import` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_an_unknown_current_module.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_an_unknown_current_module.snap
@@ -28,6 +28,6 @@ error: lint:unresolved-import: Cannot resolve imported module `.does_not_exist`
 2 |
 3 | stat = add(10, 15)
   |
-info: `lint:unresolved-import` is on by default
+info: `lint:unresolved-import` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_an_unknown_current_module.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_an_unknown_current_module.snap
@@ -28,5 +28,6 @@ error: lint:unresolved-import: Cannot resolve imported module `.does_not_exist`
 2 |
 3 | stat = add(10, 15)
   |
+info: `lint:unresolved-import` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_an_unknown_nested_module.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_an_unknown_nested_module.snap
@@ -28,6 +28,6 @@ error: lint:unresolved-import: Cannot resolve imported module `.does_not_exist.f
 2 |
 3 | stat = add(10, 15)
   |
-info: `lint:unresolved-import` is on by default
+info: `lint:unresolved-import` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_an_unknown_nested_module.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_an_unknown_nested_module.snap
@@ -28,5 +28,6 @@ error: lint:unresolved-import: Cannot resolve imported module `.does_not_exist.f
 2 |
 3 | stat = add(10, 15)
   |
+info: `lint:unresolved-import` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_an_unresolvable_module.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_an_unresolvable_module.snap
@@ -28,6 +28,6 @@ error: lint:unresolved-import: Cannot resolve imported module `does_not_exist`
 2 |
 3 | stat = add(10, 15)
   |
-info: `lint:unresolved-import` is on by default
+info: `lint:unresolved-import` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_an_unresolvable_module.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_an_unresolvable_module.snap
@@ -28,5 +28,6 @@ error: lint:unresolved-import: Cannot resolve imported module `does_not_exist`
 2 |
 3 | stat = add(10, 15)
   |
+info: `lint:unresolved-import` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_too_many_leading_dots.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_too_many_leading_dots.snap
@@ -40,6 +40,6 @@ error: lint:unresolved-import: Cannot resolve imported module `....foo`
 2 |
 3 | stat = add(10, 15)
   |
-info: `lint:unresolved-import` is on by default
+info: `lint:unresolved-import` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_too_many_leading_dots.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_too_many_leading_dots.snap
@@ -40,5 +40,6 @@ error: lint:unresolved-import: Cannot resolve imported module `....foo`
 2 |
 3 | stat = add(10, 15)
   |
+info: `lint:unresolved-import` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_conversion.md_-_Different_ways_that_`unsupported-bool-conversion`_can_occur_-_Has_a_`__bool__`_attribute,_but_it's_not_callable.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_conversion.md_-_Different_ways_that_`unsupported-bool-conversion`_can_occur_-_Has_a_`__bool__`_attribute,_but_it's_not_callable.snap
@@ -32,5 +32,6 @@ error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for t
   |        ^
   |
 info: `__bool__` on `NotBoolable` must be callable
+info: `lint:unsupported-bool-conversion` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_conversion.md_-_Different_ways_that_`unsupported-bool-conversion`_can_occur_-_Has_a_`__bool__`_attribute,_but_it's_not_callable.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_conversion.md_-_Different_ways_that_`unsupported-bool-conversion`_can_occur_-_Has_a_`__bool__`_attribute,_but_it's_not_callable.snap
@@ -32,6 +32,6 @@ error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for t
   |        ^
   |
 info: `__bool__` on `NotBoolable` must be callable
-info: `lint:unsupported-bool-conversion` is on by default
+info: `lint:unsupported-bool-conversion` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_conversion.md_-_Different_ways_that_`unsupported-bool-conversion`_can_occur_-_Has_a_`__bool__`_method,_but_has_an_incorrect_return_type.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_conversion.md_-_Different_ways_that_`unsupported-bool-conversion`_can_occur_-_Has_a_`__bool__`_method,_but_has_an_incorrect_return_type.snap
@@ -42,5 +42,6 @@ info: `str` is not assignable to `bool`
   |         Method defined here
 3 |         return "wat"
   |
+info: `lint:unsupported-bool-conversion` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_conversion.md_-_Different_ways_that_`unsupported-bool-conversion`_can_occur_-_Has_a_`__bool__`_method,_but_has_an_incorrect_return_type.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_conversion.md_-_Different_ways_that_`unsupported-bool-conversion`_can_occur_-_Has_a_`__bool__`_method,_but_has_an_incorrect_return_type.snap
@@ -42,6 +42,6 @@ info: `str` is not assignable to `bool`
   |         Method defined here
 3 |         return "wat"
   |
-info: `lint:unsupported-bool-conversion` is on by default
+info: `lint:unsupported-bool-conversion` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_conversion.md_-_Different_ways_that_`unsupported-bool-conversion`_can_occur_-_Has_a_`__bool__`_method,_but_has_incorrect_parameters.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_conversion.md_-_Different_ways_that_`unsupported-bool-conversion`_can_occur_-_Has_a_`__bool__`_method,_but_has_incorrect_parameters.snap
@@ -42,6 +42,6 @@ info: `__bool__` methods must only have a `self` parameter
   |         Method defined here
 3 |         return False
   |
-info: `lint:unsupported-bool-conversion` is on by default
+info: `lint:unsupported-bool-conversion` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_conversion.md_-_Different_ways_that_`unsupported-bool-conversion`_can_occur_-_Has_a_`__bool__`_method,_but_has_incorrect_parameters.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_conversion.md_-_Different_ways_that_`unsupported-bool-conversion`_can_occur_-_Has_a_`__bool__`_method,_but_has_incorrect_parameters.snap
@@ -42,5 +42,6 @@ info: `__bool__` methods must only have a `self` parameter
   |         Method defined here
 3 |         return False
   |
+info: `lint:unsupported-bool-conversion` is on by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_conversion.md_-_Different_ways_that_`unsupported-bool-conversion`_can_occur_-_Part_of_a_union_where_at_least_one_member_has_incorrect_`__bool__`_method.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_conversion.md_-_Different_ways_that_`unsupported-bool-conversion`_can_occur_-_Part_of_a_union_where_at_least_one_member_has_incorrect_`__bool__`_method.snap
@@ -39,6 +39,6 @@ error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for u
 15 | 10 and get() and True
    |        ^^^^^
    |
-info: `lint:unsupported-bool-conversion` is on by default
+info: `lint:unsupported-bool-conversion` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_conversion.md_-_Different_ways_that_`unsupported-bool-conversion`_can_occur_-_Part_of_a_union_where_at_least_one_member_has_incorrect_`__bool__`_method.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_conversion.md_-_Different_ways_that_`unsupported-bool-conversion`_can_occur_-_Part_of_a_union_where_at_least_one_member_has_incorrect_`__bool__`_method.snap
@@ -39,5 +39,6 @@ error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for u
 15 | 10 and get() and True
    |        ^^^^^
    |
+info: `lint:unsupported-bool-conversion` is on by default
 
 ```

--- a/crates/ty_python_semantic/src/lint.rs
+++ b/crates/ty_python_semantic/src/lint.rs
@@ -505,6 +505,10 @@ impl RuleSelection {
         self.lints.get(&lint).map(|(severity, _)| *severity)
     }
 
+    pub fn get(&self, lint: LintId) -> Option<(Severity, LintSource)> {
+        self.lints.get(&lint).copied()
+    }
+
     /// Returns `true` if the `lint` is enabled.
     pub fn is_enabled(&self, lint: LintId) -> bool {
         self.severity(lint).is_some()

--- a/crates/ty_python_semantic/src/types/context.rs
+++ b/crates/ty_python_semantic/src/types/context.rs
@@ -318,9 +318,11 @@ impl Drop for LintDiagnosticGuard<'_, '_> {
         diag.sub(SubDiagnostic::new(
             Severity::Info,
             match self.source {
-                LintSource::Default => format!("`{}` is on by default", diag.id()),
-                LintSource::Cli => format!("`{}` is enabled on the command line", diag.id()),
-                LintSource::File => format!("`{}` is enabled in a configuration file", diag.id()),
+                LintSource::Default => format!("`{}` is enabled by default", diag.id()),
+                LintSource::Cli => format!("`{}` was selected on the command line", diag.id()),
+                LintSource::File => {
+                    format!("`{}` was selected in the configuration file", diag.id())
+                }
             },
         ));
 

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -190,7 +190,6 @@ impl<'db> ProtocolInstanceType<'db> {
 
     /// Return `true` if this protocol type is fully static.
     pub(super) fn is_fully_static(self, db: &'db dyn Db) -> bool {
-        dbg!(self);
         self.0.interface(db).is_fully_static(db)
     }
 

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -190,6 +190,7 @@ impl<'db> ProtocolInstanceType<'db> {
 
     /// Return `true` if this protocol type is fully static.
     pub(super) fn is_fully_static(self, db: &'db dyn Db) -> bool {
+        dbg!(self);
         self.0.interface(db).is_fully_static(db)
     }
 


### PR DESCRIPTION
## Summary

This PR adds a note to every lint diagnostic that explains why the rule is enabled.

It would be nice if we had a `note` severity.

## Test Plan

See updated snapshots.
