### PR TITLE
Show a warning at the end of the diagnostic list if there are any fatal warnings

### DIFF
--- a/crates/ruff_db/src/diagnostic/mod.rs
+++ b/crates/ruff_db/src/diagnostic/mod.rs
@@ -674,6 +674,10 @@ impl Severity {
             Severity::Fatal => AnnotateLevel::Error,
         }
     }
+
+    pub const fn is_fatal(self) -> bool {
+        matches!(self, Severity::Fatal)
+    }
 }
 
 /// Configuration for rendering diagnostics.

--- a/crates/ty/src/main.rs
+++ b/crates/ty/src/main.rs
@@ -307,7 +307,7 @@ impl MainLoop {
                             )?;
 
                             if max_severity.is_fatal() {
-                                tracing::warn!("A panic occurred while checking some files. Not all project files were analyzed. See the diagnostics list above for details.");
+                                tracing::warn!("A fatal occurred while checking some files. Not all project files were analyzed. See the diagnostics list above for details.");
                             }
 
                             if self.watcher.is_none() {

--- a/crates/ty/src/main.rs
+++ b/crates/ty/src/main.rs
@@ -306,6 +306,10 @@ impl MainLoop {
                                 if diagnostics_count > 1 { "s" } else { "" }
                             )?;
 
+                            if max_severity.is_fatal() {
+                                tracing::warn!("A panic occurred while checking some files. Not all project files were analyzed. See the diagnostics list above for details.");
+                            }
+
                             if self.watcher.is_none() {
                                 return Ok(match max_severity {
                                     Severity::Info => ExitStatus::Success,


### PR DESCRIPTION
## Test Plan

```
error: panic: Panicked at crates/ty_python_semantic/src/types/infer.rs:7321:9 when checking `test.py`: `Test`
info: This indicates a bug in ty.
info: If you could open an issue at https://github.com/astral-sh/ty/issues/new?title=%5Bpanic%5D we'd be very appreciative!
info: Platform: macos aarch64
info: Args: ["..."]
info: run with `RUST_BACKTRACE=1` environment variable to show the full backtrace information
info: query stacktrace:
   0: infer_deferred_types(Id(166f))
             at crates/ty_python_semantic/src/types/infer.rs:183
   1: signature_(Id(5413))
             at crates/ty_python_semantic/src/types.rs:6559
   2: infer_scope_types(Id(1004))
             at crates/ty_python_semantic/src/types/infer.rs:118
   3: check_types(Id(c00))
             at crates/ty_python_semantic/src/types.rs:83


Found 1 diagnostic
WARN A panic occurred while checking some files. Not all project files were analyzed. See the diagnostics list above for details.


```