### PR TITLE
[ty] ecosystem: Activate running on 'materialize'

### DIFF
--- a/crates/ty_python_semantic/resources/primer/bad.txt
+++ b/crates/ty_python_semantic/resources/primer/bad.txt
@@ -11,7 +11,6 @@ freqtrade  # cycle panics (try_metaclass_)
 hydpy  # cycle panics (try_metaclass_)
 ibis  # cycle panics (try_metaclass_)
 manticore  # stack overflow
-materialize  # stack overflow
 mypy  # cycle panic (signature_)
 pandas  # slow
 pandas-stubs  # cycle panics (try_metaclass_)

--- a/crates/ty_python_semantic/resources/primer/good.txt
+++ b/crates/ty_python_semantic/resources/primer/good.txt
@@ -49,6 +49,7 @@ jinja
 koda-validate
 kopf
 kornia
+materialize
 meson
 mitmproxy
 mkdocs


### PR DESCRIPTION
## Summary

I can not reproduce the stack overflow when running on `materialize`, even after running mypy_primer repeatedly.