### PR TITLE
Update `ty version` to use parent Git repository information

### DIFF
--- a/crates/ty/build.rs
+++ b/crates/ty/build.rs
@@ -9,6 +9,7 @@ fn main() {
     // https://github.com/rust-lang/cargo/issues/3946
     let workspace_root = Path::new(&std::env::var("CARGO_MANIFEST_DIR").unwrap())
         .join("..")
+        .join("..")
         .join("..");
 
     commit_info(&workspace_root);
@@ -48,7 +49,8 @@ fn commit_info(workspace_root: &Path) {
         .arg("-1")
         .arg("--date=short")
         .arg("--abbrev=9")
-        .arg("--format=%H %h %cd %(describe)")
+        .arg("--format=%H %h %cd %(describe:tags)")
+        .current_dir(workspace_root)
         .output()
     {
         Ok(output) if output.status.success() => output,
@@ -65,7 +67,9 @@ fn commit_info(workspace_root: &Path) {
     // https://git-scm.com/docs/pretty-formats#Documentation/pretty-formats.txt-emdescribeoptionsem
     if let Some(describe) = parts.next() {
         let mut describe_parts = describe.split('-');
-        let _last_tag = describe_parts.next().unwrap();
+        let last_tag = describe_parts.next().unwrap();
+
+        println!("cargo::rustc-env=TY_LAST_TAG={last_tag}");
 
         // If this is the tagged commit, this component will be missing
         println!(

--- a/crates/ty/src/version.rs
+++ b/crates/ty/src/version.rs
@@ -6,6 +6,7 @@ pub(crate) struct CommitInfo {
     short_commit_hash: String,
     commit_date: String,
     commits_since_last_tag: u32,
+    last_tag: Option<String>,
 }
 
 /// ty's version.
@@ -43,9 +44,6 @@ pub(crate) fn version() -> VersionInfo {
         };
     }
 
-    // This version is pulled from Cargo.toml and set by Cargo
-    let version = option_env_str!("CARGO_PKG_VERSION").unwrap();
-
     // Commit info is pulled from git and set by `build.rs`
     let commit_info = option_env_str!("TY_COMMIT_SHORT_HASH").map(|short_commit_hash| CommitInfo {
         short_commit_hash,
@@ -53,7 +51,19 @@ pub(crate) fn version() -> VersionInfo {
         commits_since_last_tag: option_env_str!("TY_LAST_TAG_DISTANCE")
             .as_deref()
             .map_or(0, |value| value.parse::<u32>().unwrap_or(0)),
+        last_tag: option_env_str!("TY_LAST_TAG"),
     });
+
+    let version = commit_info
+        .as_ref()
+        .and_then(|info| {
+            info.last_tag.as_ref().map(|tag| {
+                tag.strip_prefix("v")
+                    .map(std::string::ToString::to_string)
+                    .unwrap_or(tag.clone())
+            })
+        })
+        .unwrap_or("unknown".to_string());
 
     VersionInfo {
         version,
@@ -84,6 +94,7 @@ mod tests {
                 short_commit_hash: "53b0f5d92".to_string(),
                 commit_date: "2023-10-19".to_string(),
                 commits_since_last_tag: 0,
+                last_tag: None,
             }),
         };
         assert_snapshot!(version, @"0.0.0 (53b0f5d92 2023-10-19)");
@@ -97,6 +108,7 @@ mod tests {
                 short_commit_hash: "53b0f5d92".to_string(),
                 commit_date: "2023-10-19".to_string(),
                 commits_since_last_tag: 24,
+                last_tag: None,
             }),
         };
         assert_snapshot!(version, @"0.0.0+24 (53b0f5d92 2023-10-19)");


### PR DESCRIPTION
Currently, `ty version` pulls its information from the Ruff repository — but we want this to pull from the repository in the directory _above_ when Ruff is a submodule.

I tested this in the `ty` repository after tagging an arbitrary commit:

```
❯ uv run --refresh-package ty --reinstall-package ty ty version
      Built ty @ file:///Users/zb/workspace/ty
Uninstalled 1 package in 2ms
Installed 1 package in 1ms
ty 0.0.0+3 (34253b1d4 2025-05-05)
```

We also use the last Git tag as the source of truth for the version, instead of the crate version. However, we'll need a way to set the version for releases still, as the tag is published _after_ the build. We can either tag early (without pushing the tag to the remote), or add another environment variable. (**Note, this approach is changed in a follow-up. See https://github.com/astral-sh/ruff/pull/17868**)

From this repository, the version will be `unknown`:

```
❯ cargo run -q --bin ty -- version
ty unknown
```

We could add special handling like... `ty unknown (ruff@...)` but I see that as a secondary goal.

Closes https://github.com/astral-sh/ty/issues/5

The reviewer situation in this repository is unhinged, cc @Gankra and @MichaReiser for review.