### PR TITLE
Parse `dist-workspace.toml` for version

### DIFF
--- a/crates/ty/src/version.rs
+++ b/crates/ty/src/version.rs
@@ -54,16 +54,20 @@ pub(crate) fn version() -> VersionInfo {
         last_tag: option_env_str!("TY_LAST_TAG"),
     });
 
-    let version = commit_info
-        .as_ref()
-        .and_then(|info| {
-            info.last_tag.as_ref().map(|tag| {
-                tag.strip_prefix("v")
-                    .map(std::string::ToString::to_string)
-                    .unwrap_or(tag.clone())
+    // The version is pulled from `dist-workspace.toml` and set by `build.rs`
+    let version = option_env_str!("TY_VERSION").unwrap_or_else(|| {
+        // If missing, using the last tag
+        commit_info
+            .as_ref()
+            .and_then(|info| {
+                info.last_tag.as_ref().map(|tag| {
+                    tag.strip_prefix("v")
+                        .map(std::string::ToString::to_string)
+                        .unwrap_or(tag.clone())
+                })
             })
-        })
-        .unwrap_or("unknown".to_string());
+            .unwrap_or("unknown".to_string())
+    });
 
     VersionInfo {
         version,


### PR DESCRIPTION
Extends https://github.com/astral-sh/ruff/pull/17866, using `dist-workspace.toml` as a source of truth for versions to enable version retrieval in distributions that are not Git repositories (i.e., Python source distributions and source tarballs consumed by Linux distros).

I retain the Git tag lookup from https://github.com/astral-sh/ruff/pull/17866 as a fallback — it seems harmless, but we could drop it to simplify things here.

I confirmed this works from the repository as well as Python source and binary distributions:

```
❯ uv run --refresh-package ty --reinstall-package ty -q --  ty version
ty 0.0.1-alpha.1+5 (2eadc9e61 2025-05-05)
❯ uv build
...
❯ uvx --from ty@dist/ty-0.0.0a1.tar.gz --no-cache -q -- ty version
ty 0.0.1-alpha.1
❯ uvx --from ty@dist/ty-0.0.0a1-py3-none-macosx_11_0_arm64.whl -q -- ty version
ty 0.0.1-alpha.1
```

Requires https://github.com/astral-sh/ty/pull/36

cc @Gankra and @MichaReiser for review.