### PR TITLE
[ty] Increase worker-thread stack size

### DIFF
--- a/crates/ty/src/main.rs
+++ b/crates/ty/src/main.rs
@@ -401,6 +401,12 @@ fn set_colored_override(color: Option<TerminalColor>) {
 fn setup_rayon() {
     ThreadPoolBuilder::default()
         .num_threads(max_parallelism().get())
+        // Use a reasonably large stack size to avoid running into stack overflows too easily. The
+        // size was chosen in such a way as to still be able to handle large expressions involving
+        // binary operators (x + x + … + x) both during the AST walk in semantic index building as
+        // well as during type checking. Using this stack size, we can handle handle expressions
+        // that are several times larger than the corresponding limits in existing type checkers.
+        .stack_size(16 * 1024 * 1024)
         .build_global()
         .unwrap();
 }


### PR DESCRIPTION
## Summary

closes #17472 

This is obviously just a band-aid solution to this problem (in that you can always make your [pathological inputs](https://github.com/sympy/sympy/blob/28994edd82a18c22a98a52245c173f3c836dcad3/sympy/polys/numberfields/resolvent_lookup.py) bigger and it will still crash), but I think this is not an unreasonable change — even if we add more sophisticated solutions later. I tried using `stacker` as suggested by @MichaReiser, and it works. But it's unclear where exactly would be the right place to put it, and even for the `sympy` problem, we would need to add it both in the semantic index builder AST traversal and in type inference. Increasing the default stack size for worker threads, as proposed here, doesn't solve the underlying problem (that there is a hard limit), but it is more universal in the sense that it is not specific to large binary-operator expression chains.

To determine a reasonable stack size, I created files that look like

*right associative*:
```py
from typing import reveal_type
total = (1 + (1 + (1 + (1 + (… + 1)))))
reveal_type(total)
```

*left associative*
```py
from typing import reveal_type
total = 1 + 1 + 1 + 1 + … + 1
reveal_type(total)
```

with a variable amount of operands (`N`). I then chose the stack size large enough to still be able to handle cases that existing type checkers can not:

```
right

  N = 20: mypy takes ~ 1min
  N = 350: pyright crashes with a stack overflow (mypy fails with "too many nested parentheses")
  N = 800: ty(main) infers Literal[800] instantly
  N = 1000: ty(main) crashes with "thread '<unknown>' has overflowed its stack"

  N = 7000: ty(this branch) infers Literal[7000] instantly
  N = 8000+: ty(this branch) crashes


left

  N = 300: pyright emits "Maximum parse depth exceeded; break expression into smaller sub-expressions"
           total is inferred as Unknown
  N = 5500: mypy crashes with "INTERNAL ERROR"
  N = 2500: ty(main) infers Literal[2500] instantly
  N = 3000: ty(main) crashes with "thread '<unknown>' has overflowed its stack"

  N = 22000: ty(this branch) infers Literal[22000] instantly
  N = 23000+: ty(this branch) crashes
```

## Test Plan

New regression test.