### PR TITLE
[ty] ecosystem: activate running on 'sympy'

### DIFF
--- a/crates/ty_python_semantic/resources/primer/bad.txt
+++ b/crates/ty_python_semantic/resources/primer/bad.txt
@@ -9,7 +9,7 @@ discord.py  # some kind of hang, only when multi-threaded?
 freqtrade  # cycle panics (try_metaclass_)
 hydpy  # cycle panics (try_metaclass_)
 ibis  # cycle panics (try_metaclass_)
-manticore  # stack overflow
+manticore  # stack overflow, see https://github.com/astral-sh/ruff/issues/17863
 pandas  # slow
 pandas-stubs  # cycle panics (try_metaclass_)
 pandera  # cycle panics (try_metaclass_)
@@ -21,5 +21,4 @@ scikit-learn  # success, but mypy-primer hangs processing the output
 spack  # success, but mypy-primer hangs processing the output
 spark  # cycle panics (try_metaclass_)
 steam.py  # cycle panics (try_metaclass_), often hangs when multi-threaded
-sympy  # stack overflow
 xarray  # cycle panics (try_metaclass_)

--- a/crates/ty_python_semantic/resources/primer/good.txt
+++ b/crates/ty_python_semantic/resources/primer/good.txt
@@ -105,6 +105,7 @@ static-frame
 stone
 strawberry
 streamlit
+sympy
 tornado
 trio
 twine


### PR DESCRIPTION
## Summary

Following #17869, we should now be able to run `ty` on `sympy`.