### PR TITLE
[ty] Fix false-positive `[invalid-return-type]` diagnostics on generator functions

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/function/return_type.md
+++ b/crates/ty_python_semantic/resources/mdtest/function/return_type.md
@@ -340,3 +340,28 @@ def f() -> int:
 def f(cond: bool) -> str:
     return "hello" if cond else NotImplemented
 ```
+
+## Generator functions
+
+A function with a `yield` statement anywhere in its body is a [generator function](https://docs.python.org/3/glossary.html#term-generator).
+These functions implicitly return an instance of `types.GeneratorType` even if they do not contain any `return` statements.
+
+```py
+import types
+import typing
+
+def f() -> types.GeneratorType:
+    yield 42
+
+def g() -> typing.Generator:
+    yield 42
+
+def h() -> typing.Iterator:
+    yield 42
+
+def i() -> typing.Iterable:
+    yield 42
+
+def j() -> str:  # error: [invalid-return-type] "Function implicitly returns `types.GeneratorType`, which is not assignable to return type `str`"
+    yield 42
+```

--- a/crates/ty_python_semantic/resources/mdtest/function/return_type.md
+++ b/crates/ty_python_semantic/resources/mdtest/function/return_type.md
@@ -343,8 +343,12 @@ def f(cond: bool) -> str:
 
 ## Generator functions
 
-A function with a `yield` statement anywhere in its body is a [generator function](https://docs.python.org/3/glossary.html#term-generator).
-These functions implicitly return an instance of `types.GeneratorType` even if they do not contain any `return` statements.
+<!-- snapshot-diagnostics -->
+
+A function with a `yield` statement anywhere in its body is a
+[generator function](https://docs.python.org/3/glossary.html#term-generator). A generator function
+implicitly returns an instance of `types.GeneratorType` even if it does not contain any `return`
+statements.
 
 ```py
 import types
@@ -362,6 +366,31 @@ def h() -> typing.Iterator:
 def i() -> typing.Iterable:
     yield 42
 
-def j() -> str:  # error: [invalid-return-type] "Function implicitly returns `types.GeneratorType`, which is not assignable to return type `str`"
+def j() -> str:  # error: [invalid-return-type]
+    yield 42
+```
+
+If it is an `async` function with a `yield` statement in its body, it is an
+[asynchronous generator function](https://docs.python.org/3/glossary.html#term-asynchronous-generator).
+An asynchronous generator function implicitly returns an instance of `types.AsyncGeneratorType` even
+if it does not contain any `return` statements.
+
+```py
+import types
+import typing
+
+async def f() -> types.AsyncGeneratorType:
+    yield 42
+
+async def g() -> typing.AsyncGenerator:
+    yield 42
+
+async def h() -> typing.AsyncIterator:
+    yield 42
+
+async def i() -> typing.AsyncIterable:
+    yield 42
+
+async def j() -> str:  # error: [invalid-return-type]
     yield 42
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Generator_functions.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Generator_functions.snap
@@ -1,0 +1,82 @@
+---
+source: crates/ty_test/src/lib.rs
+expression: snapshot
+---
+---
+mdtest name: return_type.md - Function return type - Generator functions
+mdtest path: crates/ty_python_semantic/resources/mdtest/function/return_type.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+ 1 | import types
+ 2 | import typing
+ 3 | 
+ 4 | def f() -> types.GeneratorType:
+ 5 |     yield 42
+ 6 | 
+ 7 | def g() -> typing.Generator:
+ 8 |     yield 42
+ 9 | 
+10 | def h() -> typing.Iterator:
+11 |     yield 42
+12 | 
+13 | def i() -> typing.Iterable:
+14 |     yield 42
+15 | 
+16 | def j() -> str:  # error: [invalid-return-type]
+17 |     yield 42
+18 | import types
+19 | import typing
+20 | 
+21 | async def f() -> types.AsyncGeneratorType:
+22 |     yield 42
+23 | 
+24 | async def g() -> typing.AsyncGenerator:
+25 |     yield 42
+26 | 
+27 | async def h() -> typing.AsyncIterator:
+28 |     yield 42
+29 | 
+30 | async def i() -> typing.AsyncIterable:
+31 |     yield 42
+32 | 
+33 | async def j() -> str:  # error: [invalid-return-type]
+34 |     yield 42
+```
+
+# Diagnostics
+
+```
+error: lint:invalid-return-type: Return type does not match returned value
+  --> src/mdtest_snippet.py:16:12
+   |
+14 |     yield 42
+15 |
+16 | def j() -> str:  # error: [invalid-return-type]
+   |            ^^^ Expected `str`, found `types.GeneratorType`
+17 |     yield 42
+18 | import types
+   |
+info: Function is inferred as returning `types.GeneratorType` because it is a generator function
+info: See https://docs.python.org/3/glossary.html#term-generator for more details
+
+```
+
+```
+error: lint:invalid-return-type: Return type does not match returned value
+  --> src/mdtest_snippet.py:33:18
+   |
+31 |     yield 42
+32 |
+33 | async def j() -> str:  # error: [invalid-return-type]
+   |                  ^^^ Expected `str`, found `types.AsyncGeneratorType`
+34 |     yield 42
+   |
+info: Function is inferred as returning `types.AsyncGeneratorType` because it is a async generator function
+info: See https://docs.python.org/3/glossary.html#term-asynchronous-generator for more details
+
+```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Generator_functions.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Generator_functions.snap
@@ -76,7 +76,7 @@ error: lint:invalid-return-type: Return type does not match returned value
    |                  ^^^ Expected `str`, found `types.AsyncGeneratorType`
 34 |     yield 42
    |
-info: Function is inferred as returning `types.AsyncGeneratorType` because it is a async generator function
+info: Function is inferred as returning `types.AsyncGeneratorType` because it is an async generator function
 info: See https://docs.python.org/3/glossary.html#term-asynchronous-generator for more details
 
 ```

--- a/crates/ty_python_semantic/src/semantic_index.rs
+++ b/crates/ty_python_semantic/src/semantic_index.rs
@@ -194,6 +194,9 @@ pub(crate) struct SemanticIndex<'db> {
 
     /// List of all semantic syntax errors in this file.
     semantic_syntax_errors: Vec<SemanticSyntaxError>,
+
+    /// Set of all generator functions in this file.
+    generator_functions: FxHashSet<FileScopeId>,
 }
 
 impl<'db> SemanticIndex<'db> {

--- a/crates/ty_python_semantic/src/semantic_index/symbol.rs
+++ b/crates/ty_python_semantic/src/semantic_index/symbol.rs
@@ -13,7 +13,7 @@ use rustc_hash::FxHasher;
 use crate::ast_node_ref::AstNodeRef;
 use crate::node_key::NodeKey;
 use crate::semantic_index::visibility_constraints::ScopedVisibilityConstraintId;
-use crate::semantic_index::{semantic_index, SymbolMap};
+use crate::semantic_index::{semantic_index, SemanticIndex, SymbolMap};
 use crate::Db;
 
 #[derive(Eq, PartialEq, Debug)]
@@ -169,6 +169,10 @@ impl FileScopeId {
     pub fn to_scope_id(self, db: &dyn Db, file: File) -> ScopeId<'_> {
         let index = semantic_index(db, file);
         index.scope_ids_by_scope[self]
+    }
+
+    pub(crate) fn is_generator_function(self, index: &SemanticIndex) -> bool {
+        index.generator_functions.contains(&self)
     }
 }
 

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -1865,6 +1865,8 @@ pub enum KnownClass {
     MethodWrapperType,
     WrapperDescriptorType,
     UnionType,
+    GeneratorType,
+    AsyncGeneratorType,
     // Typeshed
     NoneType, // Part of `types` for Python >= 3.10
     // Typing
@@ -1929,6 +1931,8 @@ impl<'db> KnownClass {
             | Self::Super
             | Self::WrapperDescriptorType
             | Self::UnionType
+            | Self::GeneratorType
+            | Self::AsyncGeneratorType
             | Self::MethodWrapperType => Truthiness::AlwaysTrue,
 
             Self::NoneType => Truthiness::AlwaysFalse,
@@ -2013,6 +2017,8 @@ impl<'db> KnownClass {
             | Self::BaseExceptionGroup
             | Self::Classmethod
             | Self::GenericAlias
+            | Self::GeneratorType
+            | Self::AsyncGeneratorType
             | Self::ModuleType
             | Self::FunctionType
             | Self::MethodType
@@ -2075,6 +2081,8 @@ impl<'db> KnownClass {
             Self::UnionType => "UnionType",
             Self::MethodWrapperType => "MethodWrapperType",
             Self::WrapperDescriptorType => "WrapperDescriptorType",
+            Self::GeneratorType => "GeneratorType",
+            Self::AsyncGeneratorType => "AsyncGeneratorType",
             Self::NamedTuple => "NamedTuple",
             Self::NoneType => "NoneType",
             Self::SpecialForm => "_SpecialForm",
@@ -2116,7 +2124,7 @@ impl<'db> KnownClass {
         }
     }
 
-    fn display(self, db: &'db dyn Db) -> impl std::fmt::Display + 'db {
+    pub(super) fn display(self, db: &'db dyn Db) -> impl std::fmt::Display + 'db {
         struct KnownClassDisplay<'db> {
             db: &'db dyn Db,
             class: KnownClass,
@@ -2293,6 +2301,8 @@ impl<'db> KnownClass {
             | Self::ModuleType
             | Self::FunctionType
             | Self::MethodType
+            | Self::GeneratorType
+            | Self::AsyncGeneratorType
             | Self::MethodWrapperType
             | Self::UnionType
             | Self::WrapperDescriptorType => KnownModule::Types,
@@ -2374,6 +2384,8 @@ impl<'db> KnownClass {
             | Self::GenericAlias
             | Self::ModuleType
             | Self::FunctionType
+            | Self::GeneratorType
+            | Self::AsyncGeneratorType
             | Self::MethodType
             | Self::MethodWrapperType
             | Self::WrapperDescriptorType
@@ -2434,6 +2446,8 @@ impl<'db> KnownClass {
             | Self::MethodType
             | Self::MethodWrapperType
             | Self::WrapperDescriptorType
+            | Self::GeneratorType
+            | Self::AsyncGeneratorType
             | Self::SpecialForm
             | Self::ChainMap
             | Self::Counter
@@ -2491,6 +2505,8 @@ impl<'db> KnownClass {
             "GenericAlias" => Self::GenericAlias,
             "NoneType" => Self::NoneType,
             "ModuleType" => Self::ModuleType,
+            "GeneratorType" => Self::GeneratorType,
+            "AsyncGeneratorType" => Self::AsyncGeneratorType,
             "FunctionType" => Self::FunctionType,
             "MethodType" => Self::MethodType,
             "UnionType" => Self::UnionType,
@@ -2574,6 +2590,8 @@ impl<'db> KnownClass {
             | Self::Super
             | Self::NotImplementedType
             | Self::UnionType
+            | Self::GeneratorType
+            | Self::AsyncGeneratorType
             | Self::WrapperDescriptorType => module == self.canonical_module(db),
             Self::NoneType => matches!(module, KnownModule::Typeshed | KnownModule::Types),
             Self::SpecialForm

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -1326,18 +1326,18 @@ pub(super) fn report_invalid_generator_function_return_type(
 
     let (description, link) = if inferred_return == KnownClass::AsyncGeneratorType {
         (
-            "async generator function",
+            "an async generator function",
             "https://docs.python.org/3/glossary.html#term-asynchronous-generator",
         )
     } else {
         (
-            "generator function",
+            "a generator function",
             "https://docs.python.org/3/glossary.html#term-generator",
         )
     };
 
     diag.info(format_args!(
-        "Function is inferred as returning `{inferred_ty}` because it is a {description}"
+        "Function is inferred as returning `{inferred_ty}` because it is {description}"
     ));
     diag.info(format_args!("See {link} for more details"));
 }

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -1,5 +1,5 @@
 use super::context::InferContext;
-use super::ClassLiteral;
+use super::{ClassLiteral, KnownClass};
 use crate::db::Db;
 use crate::declare_lint;
 use crate::lint::{Level, LintRegistryBuilder, LintStatus};
@@ -12,7 +12,7 @@ use crate::types::string_annotation::{
 use crate::types::{protocol_class::ProtocolClassLiteral, KnownFunction, KnownInstanceType, Type};
 use ruff_db::diagnostic::{Annotation, Diagnostic, Severity, Span, SubDiagnostic};
 use ruff_python_ast::{self as ast, AnyNodeRef};
-use ruff_text_size::Ranged;
+use ruff_text_size::{Ranged, TextRange};
 use rustc_hash::FxHashSet;
 use std::fmt::Formatter;
 
@@ -1305,6 +1305,41 @@ pub(super) fn report_invalid_return_type(
             expected_ty = expected_ty.display(context.db()),
         )),
     );
+}
+
+pub(super) fn report_invalid_generator_function_return_type(
+    context: &InferContext,
+    return_type_range: TextRange,
+    inferred_return: KnownClass,
+    expected_ty: Type,
+) {
+    let Some(builder) = context.report_lint(&INVALID_RETURN_TYPE, return_type_range) else {
+        return;
+    };
+
+    let mut diag = builder.into_diagnostic("Return type does not match returned value");
+    let inferred_ty = inferred_return.display(context.db());
+    diag.set_primary_message(format_args!(
+        "Expected `{expected_ty}`, found `{inferred_ty}`",
+        expected_ty = expected_ty.display(context.db()),
+    ));
+
+    let (description, link) = if inferred_return == KnownClass::AsyncGeneratorType {
+        (
+            "async generator function",
+            "https://docs.python.org/3/glossary.html#term-asynchronous-generator",
+        )
+    } else {
+        (
+            "generator function",
+            "https://docs.python.org/3/glossary.html#term-generator",
+        )
+    };
+
+    diag.info(format_args!(
+        "Function is inferred as returning `{inferred_ty}` because it is a {description}"
+    ));
+    diag.info(format_args!("See {link} for more details"));
 }
 
 pub(super) fn report_implicit_return_type(

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -1641,6 +1641,12 @@ impl<'db> TypeInferenceBuilder<'db> {
 
             let scope_id = self.index.node_scope(NodeWithScopeRef::Function(function));
             if scope_id.is_generator_function(self.index) {
+                // TODO: `AsyncGeneratorType` and `GeneratorType` are both generic classes.
+                //
+                // If type arguments are supplied to `(Async)Iterable`, `(Async)Iterator`,
+                // `(Async)Generator` or `(Async)GeneratorType` in the return annotation,
+                // we should iterate over the `yield` expressions and `return` statements in the function
+                // to check that they are consistent with the type arguments provided.
                 let inferred_return = if function.is_async {
                     KnownClass::AsyncGeneratorType
                 } else {


### PR DESCRIPTION
## Summary

A generator function implicitly returns an instance of `types.GeneratorType` even if it does not contain any `return` statements. Our `[invalid-return-type]` lint does not understand this currently, leading to false positives on generator functions: https://types.ruff.rs/3b0fcf8b-d607-43a7-8f37-d6df4b62122d. This PR fixes those false positives.

## Test Plan

new mdtests and snapshots added
