### PR TITLE
[ty] Don't require default typevars when specializing

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -157,6 +157,7 @@ WithDefaultU = TypeVar("WithDefaultU", default=int)
 
 class WithDefault(Generic[T, WithDefaultU]): ...
 
+reveal_type(WithDefault[str, str]())  # revealed: WithDefault[str, str]
 reveal_type(WithDefault[str]())  # revealed: WithDefault[str, int]
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -150,6 +150,16 @@ reveal_type(Constrained[int | str]())  # revealed: Constrained[int | str]
 reveal_type(Constrained[object]())  # revealed: Unknown
 ```
 
+If the type variable has a default, it can be omitted:
+
+```py
+WithDefaultU = TypeVar("WithDefaultU", default=int)
+
+class WithDefault(Generic[T, WithDefaultU]): ...
+
+reveal_type(WithDefault[str]())  # revealed: WithDefault[str, int]
+```
+
 ## Inferring generic class parameters
 
 We can infer the type parameter from a type context:

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
@@ -138,6 +138,7 @@ If the type variable has a default, it can be omitted:
 ```py
 class WithDefault[T, U = int]: ...
 
+reveal_type(WithDefault[str, str]())  # revealed: WithDefault[str, str]
 reveal_type(WithDefault[str]())  # revealed: WithDefault[str, int]
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
@@ -133,6 +133,14 @@ reveal_type(Constrained[int | str]())  # revealed: Constrained[int | str]
 reveal_type(Constrained[object]())  # revealed: Unknown
 ```
 
+If the type variable has a default, it can be omitted:
+
+```py
+class WithDefault[T, U = int]: ...
+
+reveal_type(WithDefault[str]())  # revealed: WithDefault[str, int]
+```
+
 ## Inferring generic class parameters
 
 We can infer the type parameter from a type context:

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -1316,8 +1316,25 @@ impl<'db> Binding<'db> {
         self.inherited_specialization
     }
 
+    /// Returns the bound types for each parameter, in parameter source order, or `None` if no
+    /// argument was matched to that parameter.
     pub(crate) fn parameter_types(&self) -> &[Option<Type<'db>>] {
         &self.parameter_tys
+    }
+
+    /// Returns the bound types for each parameter, in parameter source order, with default values
+    /// applied for arguments that weren't matched to a parameter. Returns `None` if there are any
+    /// non-default arguments that weren't matched to a parameter.
+    pub(crate) fn parameter_types_with_defaults(
+        &self,
+        signature: &Signature<'db>,
+    ) -> Option<Box<[Type<'db>]>> {
+        signature
+            .parameters()
+            .iter()
+            .zip(&self.parameter_tys)
+            .map(|(parameter, parameter_ty)| parameter_ty.or(parameter.default_type()))
+            .collect()
     }
 
     pub(crate) fn arguments_for_parameter<'a>(

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -123,6 +123,9 @@ impl<'db> GenericContext<'db> {
             }
             None => {}
         }
+        if let Some(default_ty) = typevar.default_ty(db) {
+            parameter = parameter.with_default_type(default_ty);
+        }
         parameter
     }
 


### PR DESCRIPTION
If a typevar is declared as having a default, we shouldn't require a type to be specified for that typevar when explicitly specializing a generic class:

```py
class WithDefault[T, U = int]: ...

reveal_type(WithDefault[str]())  # revealed: WithDefault[str, int]
```