### PR TITLE
[ty] Do not emit errors if enums or NamedTuples constructed using functional syntax are used in type expressions

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/unsupported_special_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/unsupported_special_types.md
@@ -1,0 +1,19 @@
+# Unsupported special types
+
+We do not understand the functional syntax for creating `NamedTuple`s, `TypedDict`s or `Enum`s yet.
+But we also do not emit false positives when these are used in type expressions.
+
+```py
+import collections
+import enum
+import typing
+
+# TODO: should not error (requires understanding metaclass `__call__`)
+MyEnum = enum.Enum("MyEnum", ["foo", "bar", "baz"])  # error: [too-many-positional-arguments]
+
+MyTypedDict = typing.TypedDict("MyTypedDict", {"foo": int})
+MyNamedTuple1 = typing.NamedTuple("MyNamedTuple1", [("foo", int)])
+MyNamedTuple2 = collections.namedtuple("MyNamedTuple2", ["foo"])
+
+def f(a: MyEnum, b: MyTypedDict, c: MyNamedTuple1, d: MyNamedTuple2): ...
+```

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -4833,6 +4833,17 @@ impl<'db> Type<'db> {
                 Some(KnownClass::UnionType) => Ok(todo_type!(
                     "Support for `types.UnionType` instances in type expressions"
                 )),
+                Some(KnownClass::NamedTuple) => Ok(todo_type!(
+                    "Support for functional `typing.NamedTuple` syntax"
+                )),
+                _ if instance
+                    .class()
+                    .iter_mro(db)
+                    .filter_map(ClassBase::into_class)
+                    .any(|class| class.is_known(db, KnownClass::Enum)) =>
+                {
+                    Ok(todo_type!("Support for functional `enum` syntax"))
+                }
                 _ => Err(InvalidTypeExpressionError {
                     invalid_expressions: smallvec::smallvec![InvalidTypeExpression::InvalidType(
                         *self


### PR DESCRIPTION
## Summary

This fixes some false positives that showed up in the primer diff for https://github.com/astral-sh/ruff/pull/17832

## Test Plan

new mdtests added that fail with false-positive diagnostics on `main`
