### PR TITLE
Generalize special-casing for enums constructed with the functional syntax

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/unsupported_special_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/unsupported_special_types.md
@@ -8,9 +8,8 @@ import collections
 import enum
 import typing
 
-# TODO: should not error (requires understanding metaclass `__call__`)
-MyEnum = enum.Enum("MyEnum", ["foo", "bar", "baz"])  # error: [too-many-positional-arguments]
-
+MyEnum = enum.Enum("MyEnum", ["foo", "bar", "baz"])
+MyIntEnum = enum.IntEnum("MyIntEnum", ["foo", "bar", "baz"])
 MyTypedDict = typing.TypedDict("MyTypedDict", {"foo": int})
 MyNamedTuple1 = typing.NamedTuple("MyNamedTuple1", [("foo", int)])
 MyNamedTuple2 = collections.namedtuple("MyNamedTuple2", ["foo"])

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3890,6 +3890,9 @@ impl<'db> Type<'db> {
                     );
                     Signatures::single(signature)
                 }
+                Some(KnownClass::Enum) => {
+                    Signatures::single(CallableSignature::todo("functional `Enum` syntax"))
+                }
 
                 Some(KnownClass::Super) => {
                     // ```py
@@ -4836,14 +4839,6 @@ impl<'db> Type<'db> {
                 Some(KnownClass::NamedTuple) => Ok(todo_type!(
                     "Support for functional `typing.NamedTuple` syntax"
                 )),
-                _ if instance
-                    .class()
-                    .iter_mro(db)
-                    .filter_map(ClassBase::into_class)
-                    .any(|class| class.is_known(db, KnownClass::Enum)) =>
-                {
-                    Ok(todo_type!("Support for functional `enum` syntax"))
-                }
                 _ => Err(InvalidTypeExpressionError {
                     invalid_expressions: smallvec::smallvec![InvalidTypeExpression::InvalidType(
                         *self

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -4661,22 +4661,16 @@ impl<'db> TypeInferenceBuilder<'db> {
         // the `try_call` path below.
         // TODO: it should be possible to move these special cases into the `try_call_constructor`
         // path instead, or even remove some entirely once we support overloads fully.
-        let (call_constructor, known_class) = match callable_type {
-            Type::ClassLiteral(class) => (true, class.known(self.db())),
-            Type::GenericAlias(generic) => (true, ClassType::Generic(generic).known(self.db())),
-            Type::SubclassOf(subclass) => (
-                true,
-                subclass
-                    .subclass_of()
-                    .into_class()
-                    .and_then(|class| class.known(self.db())),
-            ),
-            _ => (false, None),
+        let class = match callable_type {
+            Type::ClassLiteral(class) => Some(ClassType::NonGeneric(class)),
+            Type::GenericAlias(generic) => Some(ClassType::Generic(generic)),
+            Type::SubclassOf(subclass) => subclass.subclass_of().into_class(),
+            _ => None,
         };
 
-        if call_constructor
-            && !matches!(
-                known_class,
+        if let Some(class) = class {
+            if !matches!(
+                class.known(self.db()),
                 Some(
                     KnownClass::Bool
                         | KnownClass::Str
@@ -4687,17 +4681,24 @@ impl<'db> TypeInferenceBuilder<'db> {
                         | KnownClass::TypeVar
                 )
             )
-        {
-            let argument_forms = vec![Some(ParameterForm::Value); call_arguments.len()];
-            let call_argument_types =
-                self.infer_argument_types(arguments, call_arguments, &argument_forms);
+            // temporary special-casing for all subclasses of `enum.Enum`
+            // until we support the functional syntax for creating enum classes
+            && KnownClass::Enum
+                .to_class_literal(self.db())
+                .to_class_type(self.db())
+                .is_none_or(|enum_class| !class.is_subclass_of(self.db(), enum_class))
+            {
+                let argument_forms = vec![Some(ParameterForm::Value); call_arguments.len()];
+                let call_argument_types =
+                    self.infer_argument_types(arguments, call_arguments, &argument_forms);
 
-            return callable_type
-                .try_call_constructor(self.db(), call_argument_types)
-                .unwrap_or_else(|err| {
-                    err.report_diagnostic(&self.context, callable_type, call_expression.into());
-                    err.return_type()
-                });
+                return callable_type
+                    .try_call_constructor(self.db(), call_argument_types)
+                    .unwrap_or_else(|err| {
+                        err.report_diagnostic(&self.context, callable_type, call_expression.into());
+                        err.return_type()
+                    });
+            }
         }
 
         let signatures = callable_type.signatures(self.db());


### PR DESCRIPTION
## Summary

This generalises the special-casing added in https://github.com/astral-sh/ruff/pull/17873 so that we also no longer emit false-positive diagnostics when enums are _created_ using the functional syntax. As a bonus, it also ends up being fewer lines of code overall.

## Test Plan

mdtests
