### PR TITLE
[ty] Fix duplicate diagnostics for unresolved module when an `import from` statement imports multiple members

### DIFF
--- a/crates/ty/tests/cli.rs
+++ b/crates/ty/tests/cli.rs
@@ -276,7 +276,7 @@ fn cli_arguments_are_relative_to_the_current_directory() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    error: lint:unresolved-import: Cannot resolve import `utils`
+    error: lint:unresolved-import: Cannot resolve imported module `utils`
      --> test.py:2:6
       |
     2 | from utils import add
@@ -452,7 +452,7 @@ fn cli_rule_severity() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    error: lint:unresolved-import: Cannot resolve import `does_not_exit`
+    error: lint:unresolved-import: Cannot resolve imported module `does_not_exit`
      --> test.py:2:8
       |
     2 | import does_not_exit
@@ -499,7 +499,7 @@ fn cli_rule_severity() -> anyhow::Result<()> {
     success: true
     exit_code: 0
     ----- stdout -----
-    warning: lint:unresolved-import: Cannot resolve import `does_not_exit`
+    warning: lint:unresolved-import: Cannot resolve imported module `does_not_exit`
      --> test.py:2:8
       |
     2 | import does_not_exit
@@ -1053,7 +1053,7 @@ fn check_specific_paths() -> anyhow::Result<()> {
       |     ^^^^^
       |
 
-    error: lint:unresolved-import: Cannot resolve import `main2`
+    error: lint:unresolved-import: Cannot resolve imported module `main2`
      --> project/other.py:2:6
       |
     2 | from main2 import z  # error: unresolved-import
@@ -1062,7 +1062,7 @@ fn check_specific_paths() -> anyhow::Result<()> {
     4 | print(z)
       |
 
-    error: lint:unresolved-import: Cannot resolve import `does_not_exist`
+    error: lint:unresolved-import: Cannot resolve imported module `does_not_exist`
      --> project/tests/test_main.py:2:8
       |
     2 | import does_not_exist  # error: unresolved-import
@@ -1083,7 +1083,7 @@ fn check_specific_paths() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    error: lint:unresolved-import: Cannot resolve import `main2`
+    error: lint:unresolved-import: Cannot resolve imported module `main2`
      --> project/other.py:2:6
       |
     2 | from main2 import z  # error: unresolved-import
@@ -1092,7 +1092,7 @@ fn check_specific_paths() -> anyhow::Result<()> {
     4 | print(z)
       |
 
-    error: lint:unresolved-import: Cannot resolve import `does_not_exist`
+    error: lint:unresolved-import: Cannot resolve imported module `does_not_exist`
      --> project/tests/test_main.py:2:8
       |
     2 | import does_not_exist  # error: unresolved-import

--- a/crates/ty_python_semantic/resources/mdtest/call/union.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/union.md
@@ -16,7 +16,7 @@ def _(flag: bool):
 ## Calling with an unknown union
 
 ```py
-from nonexistent import f  # error: [unresolved-import] "Cannot resolve import `nonexistent`"
+from nonexistent import f  # error: [unresolved-import] "Cannot resolve imported module `nonexistent`"
 
 def coinflip() -> bool:
     return True

--- a/crates/ty_python_semantic/resources/mdtest/import/basic.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/basic.md
@@ -121,7 +121,7 @@ class C: ...
 <!-- snapshot-diagnostics -->
 
 ```py
-import zqzqzqzqzqzqzq  # error: [unresolved-import] "Cannot resolve import `zqzqzqzqzqzqzq`"
+import zqzqzqzqzqzqzq  # error: [unresolved-import] "Cannot resolve imported module `zqzqzqzqzqzqzq`"
 ```
 
 ## Unresolvable submodule imports
@@ -130,10 +130,10 @@ import zqzqzqzqzqzqzq  # error: [unresolved-import] "Cannot resolve import `zqzq
 
 ```py
 # Topmost component resolvable, submodule not resolvable:
-import a.foo  # error: [unresolved-import] "Cannot resolve import `a.foo`"
+import a.foo  # error: [unresolved-import] "Cannot resolve imported module `a.foo`"
 
 # Topmost component unresolvable:
-import b.foo  # error: [unresolved-import] "Cannot resolve import `b.foo`"
+import b.foo  # error: [unresolved-import] "Cannot resolve imported module `b.foo`"
 ```
 
 `a/__init__.py`:
@@ -163,4 +163,16 @@ from AveryLongPathAveryLongPathAveryLongPathAveryLongPathAveryLongPathAveryLongP
 )
 
 reveal_type(Foo())  # revealed: Foo
+```
+
+## Multiple objects imported from an unresolved module
+
+<!-- snapshot-diagnostics -->
+
+If multiple members are imported from a module that cannot be resolved, only a single diagnostic is
+emitted for the `import from` statement:
+
+```py
+# error: [unresolved-import]
+from does_not_exist import foo, bar, baz
 ```

--- a/crates/ty_python_semantic/resources/mdtest/import/errors.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/errors.md
@@ -3,7 +3,7 @@
 ## Unresolved import statement
 
 ```py
-import bar  # error: "Cannot resolve import `bar`"
+import bar  # error: "Cannot resolve imported module `bar`"
 
 reveal_type(bar)  # revealed: Unknown
 ```
@@ -11,7 +11,7 @@ reveal_type(bar)  # revealed: Unknown
 ## Unresolved import from statement
 
 ```py
-from bar import baz  # error: "Cannot resolve import `bar`"
+from bar import baz  # error: "Cannot resolve imported module `bar`"
 
 reveal_type(baz)  # revealed: Unknown
 ```
@@ -34,7 +34,7 @@ reveal_type(thing)  # revealed: Unknown
 `a.py`:
 
 ```py
-import foo as foo  # error: "Cannot resolve import `foo`"
+import foo as foo  # error: "Cannot resolve imported module `foo`"
 
 reveal_type(foo)  # revealed: Unknown
 ```

--- a/crates/ty_python_semantic/resources/mdtest/import/star.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/star.md
@@ -1369,7 +1369,7 @@ If the module is unresolved, we emit a diagnostic just like for any other unreso
 
 ```py
 # TODO: not a great error message
-from foo import *  # error: [unresolved-import] "Cannot resolve import `foo`"
+from foo import *  # error: [unresolved-import] "Cannot resolve imported module `foo`"
 ```
 
 ### Nested scope

--- a/crates/ty_python_semantic/resources/mdtest/mdtest_custom_typeshed.md
+++ b/crates/ty_python_semantic/resources/mdtest/mdtest_custom_typeshed.md
@@ -81,7 +81,7 @@ new_module: 3.11-
 ```py
 from old_module import OldClass
 
-# error: [unresolved-import] "Cannot resolve import `new_module`"
+# error: [unresolved-import] "Cannot resolve imported module `new_module`"
 from new_module import NewClass
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/mro.md
+++ b/crates/ty_python_semantic/resources/mdtest/mro.md
@@ -313,7 +313,6 @@ reveal_type(Omelette.__mro__)  # revealed: tuple[Literal[Omelette], Unknown, Lit
 
 ```py
 # error: [unresolved-import]
-# error: [unresolved-import]
 from does_not_exist import unknown_object_1, unknown_object_2
 
 reveal_type(unknown_object_1)  # revealed: Unknown

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Multiple_objects_imported_from_an_unresolved_module.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Multiple_objects_imported_from_an_unresolved_module.snap
@@ -1,0 +1,30 @@
+---
+source: crates/ty_test/src/lib.rs
+expression: snapshot
+---
+---
+mdtest name: basic.md - Structures - Multiple objects imported from an unresolved module
+mdtest path: crates/ty_python_semantic/resources/mdtest/import/basic.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+1 | # error: [unresolved-import]
+2 | from does_not_exist import foo, bar, baz
+```
+
+# Diagnostics
+
+```
+error: lint:unresolved-import: Cannot resolve imported module `does_not_exist`
+ --> src/mdtest_snippet.py:2:6
+  |
+1 | # error: [unresolved-import]
+2 | from does_not_exist import foo, bar, baz
+  |      ^^^^^^^^^^^^^^
+  |
+
+```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Unresolvable_module_import.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Unresolvable_module_import.snap
@@ -12,16 +12,16 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/import/basic.md
 ## mdtest_snippet.py
 
 ```
-1 | import zqzqzqzqzqzqzq  # error: [unresolved-import] "Cannot resolve import `zqzqzqzqzqzqzq`"
+1 | import zqzqzqzqzqzqzq  # error: [unresolved-import] "Cannot resolve imported module `zqzqzqzqzqzqzq`"
 ```
 
 # Diagnostics
 
 ```
-error: lint:unresolved-import: Cannot resolve import `zqzqzqzqzqzqzq`
+error: lint:unresolved-import: Cannot resolve imported module `zqzqzqzqzqzqzq`
  --> src/mdtest_snippet.py:1:8
   |
-1 | import zqzqzqzqzqzqzq  # error: [unresolved-import] "Cannot resolve import `zqzqzqzqzqzqzq`"
+1 | import zqzqzqzqzqzqzq  # error: [unresolved-import] "Cannot resolve imported module `zqzqzqzqzqzqzq`"
   |        ^^^^^^^^^^^^^^
   |
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Unresolvable_submodule_imports.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Unresolvable_submodule_imports.snap
@@ -13,10 +13,10 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/import/basic.md
 
 ```
 1 | # Topmost component resolvable, submodule not resolvable:
-2 | import a.foo  # error: [unresolved-import] "Cannot resolve import `a.foo`"
+2 | import a.foo  # error: [unresolved-import] "Cannot resolve imported module `a.foo`"
 3 | 
 4 | # Topmost component unresolvable:
-5 | import b.foo  # error: [unresolved-import] "Cannot resolve import `b.foo`"
+5 | import b.foo  # error: [unresolved-import] "Cannot resolve imported module `b.foo`"
 ```
 
 ## a/__init__.py
@@ -27,11 +27,11 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/import/basic.md
 # Diagnostics
 
 ```
-error: lint:unresolved-import: Cannot resolve import `a.foo`
+error: lint:unresolved-import: Cannot resolve imported module `a.foo`
  --> src/mdtest_snippet.py:2:8
   |
 1 | # Topmost component resolvable, submodule not resolvable:
-2 | import a.foo  # error: [unresolved-import] "Cannot resolve import `a.foo`"
+2 | import a.foo  # error: [unresolved-import] "Cannot resolve imported module `a.foo`"
   |        ^^^^^
 3 |
 4 | # Topmost component unresolvable:
@@ -40,11 +40,11 @@ error: lint:unresolved-import: Cannot resolve import `a.foo`
 ```
 
 ```
-error: lint:unresolved-import: Cannot resolve import `b.foo`
+error: lint:unresolved-import: Cannot resolve imported module `b.foo`
  --> src/mdtest_snippet.py:5:8
   |
 4 | # Topmost component unresolvable:
-5 | import b.foo  # error: [unresolved-import] "Cannot resolve import `b.foo`"
+5 | import b.foo  # error: [unresolved-import] "Cannot resolve imported module `b.foo`"
   |        ^^^^^
   |
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_An_unresolvable_import_that_does_not_use_`from`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_An_unresolvable_import_that_does_not_use_`from`.snap
@@ -20,7 +20,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/unresolved_i
 # Diagnostics
 
 ```
-error: lint:unresolved-import: Cannot resolve import `does_not_exist`
+error: lint:unresolved-import: Cannot resolve imported module `does_not_exist`
  --> src/mdtest_snippet.py:1:8
   |
 1 | import does_not_exist  # error: [unresolved-import]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_an_unknown_current_module.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_an_unknown_current_module.snap
@@ -20,7 +20,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/unresolved_i
 # Diagnostics
 
 ```
-error: lint:unresolved-import: Cannot resolve import `.does_not_exist`
+error: lint:unresolved-import: Cannot resolve imported module `.does_not_exist`
  --> src/mdtest_snippet.py:1:7
   |
 1 | from .does_not_exist import add  # error: [unresolved-import]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_an_unknown_nested_module.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_an_unknown_nested_module.snap
@@ -20,7 +20,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/unresolved_i
 # Diagnostics
 
 ```
-error: lint:unresolved-import: Cannot resolve import `.does_not_exist.foo.bar`
+error: lint:unresolved-import: Cannot resolve imported module `.does_not_exist.foo.bar`
  --> src/mdtest_snippet.py:1:7
   |
 1 | from .does_not_exist.foo.bar import add  # error: [unresolved-import]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_an_unresolvable_module.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_an_unresolvable_module.snap
@@ -20,7 +20,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/unresolved_i
 # Diagnostics
 
 ```
-error: lint:unresolved-import: Cannot resolve import `does_not_exist`
+error: lint:unresolved-import: Cannot resolve imported module `does_not_exist`
  --> src/mdtest_snippet.py:1:6
   |
 1 | from does_not_exist import add  # error: [unresolved-import]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_too_many_leading_dots.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_too_many_leading_dots.snap
@@ -32,7 +32,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/unresolved_i
 # Diagnostics
 
 ```
-error: lint:unresolved-import: Cannot resolve import `....foo`
+error: lint:unresolved-import: Cannot resolve imported module `....foo`
  --> src/package/subpackage/subsubpackage/__init__.py:1:10
   |
 1 | from ....foo import add  # error: [unresolved-import]

--- a/crates/ty_wasm/tests/api.rs
+++ b/crates/ty_wasm/tests/api.rs
@@ -27,5 +27,8 @@ fn check() {
         diagnostic.to_range(&workspace).unwrap().start,
         Position { line: 1, column: 8 }
     );
-    assert_eq!(diagnostic.message(), "Cannot resolve import `random22`");
+    assert_eq!(
+        diagnostic.message(),
+        "Cannot resolve imported module `random22`"
+    );
 }


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ruff/issues/17876. Rather than emitting a separate diagnostic for the unresolved module on each `ast::Alias` in the `ImportFrom` statement, we only emit a single diagnostic for the statement as a whole.

## Test Plan

new mdtests and snapshots
