### PR TITLE
[`airflow`] apply try catch guard to all AIR3 rules (`AIR3`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR301_names_try.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR301_names_try.py
@@ -1,17 +1,8 @@
 from __future__ import annotations
 
 try:
-    from airflow.sdk import Asset
+    from airflow.assets.manager import AssetManager
 except ModuleNotFoundError:
-    from airflow.datasets import Dataset as Asset
+    from airflow.datasets.manager import DatasetManager as AssetManager
 
-Asset
-
-try:
-    from airflow.sdk import Asset
-except ModuleNotFoundError:
-    from airflow import datasets
-
-    Asset = datasets.Dataset
-
-asset = Asset()
+AssetManager()

--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_try.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_try.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+try:
+    from airflow.providers.http.operators.http import HttpOperator
+except ModuleNotFoundError:
+    from airflow.operators.http_operator import SimpleHttpOperator as HttpOperator
+
+HttpOperator()

--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR311_try.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR311_try.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+try:
+    from airflow.sdk import Asset
+except ModuleNotFoundError:
+    from airflow.datasets import Dataset as Asset
+
+Asset()

--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR312_try.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR312_try.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+try:
+    from airflow.providers.standard.triggers.file import FileTrigger
+except ModuleNotFoundError:
+    from airflow.triggers.file import FileTrigger
+
+FileTrigger()

--- a/crates/ruff_linter/src/rules/airflow/mod.rs
+++ b/crates/ruff_linter/src/rules/airflow/mod.rs
@@ -46,9 +46,12 @@ mod tests {
     #[test_case(Rule::Airflow3MovedToProvider, Path::new("AIR302_sqlite.py"))]
     #[test_case(Rule::Airflow3MovedToProvider, Path::new("AIR302_zendesk.py"))]
     #[test_case(Rule::Airflow3MovedToProvider, Path::new("AIR302_standard.py"))]
+    #[test_case(Rule::Airflow3MovedToProvider, Path::new("AIR302_try.py"))]
     #[test_case(Rule::Airflow3SuggestedUpdate, Path::new("AIR311_args.py"))]
     #[test_case(Rule::Airflow3SuggestedUpdate, Path::new("AIR311_names.py"))]
+    #[test_case(Rule::Airflow3SuggestedUpdate, Path::new("AIR311_try.py"))]
     #[test_case(Rule::Airflow3SuggestedToMoveToProvider, Path::new("AIR312.py"))]
+    #[test_case(Rule::Airflow3SuggestedToMoveToProvider, Path::new("AIR312_try.py"))]
     fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.noqa_code(), path.to_string_lossy());
         let diagnostics = test_path(

--- a/crates/ruff_linter/src/rules/airflow/rules/suggested_to_move_to_provider_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/suggested_to_move_to_provider_in_3.rs
@@ -1,6 +1,6 @@
 use crate::importer::ImportRequest;
 
-use crate::rules::airflow::helpers::ProviderReplacement;
+use crate::rules::airflow::helpers::{is_guarded_by_try_except, ProviderReplacement};
 use ruff_diagnostics::{Diagnostic, Edit, Fix, FixAvailability, Violation};
 use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_python_ast::{Expr, ExprAttribute};
@@ -279,22 +279,47 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
         ranged.range(),
     );
 
-    if let ProviderReplacement::AutoImport {
-        module,
-        name,
-        provider: _,
-        version: _,
-    } = replacement
-    {
-        diagnostic.try_set_fix(|| {
-            let (import_edit, binding) = checker.importer().get_or_import_symbol(
-                &ImportRequest::import_from(module, name),
-                expr.start(),
-                checker.semantic(),
-            )?;
-            let replacement_edit = Edit::range_replacement(binding, ranged.range());
-            Ok(Fix::safe_edits(import_edit, [replacement_edit]))
-        });
+    let semantic = checker.semantic();
+    match replacement {
+        ProviderReplacement::AutoImport {
+            module,
+            name,
+            provider: _,
+            version: _,
+        } => {
+            if is_guarded_by_try_except(expr, module, name, semantic) {
+                return;
+            }
+            diagnostic.try_set_fix(|| {
+                let (import_edit, binding) = checker.importer().get_or_import_symbol(
+                    &ImportRequest::import_from(module, name),
+                    expr.start(),
+                    checker.semantic(),
+                )?;
+                let replacement_edit = Edit::range_replacement(binding, ranged.range());
+                Ok(Fix::safe_edits(import_edit, [replacement_edit]))
+            });
+        }
+        ProviderReplacement::SourceModuleMovedToProvider {
+            module,
+            name,
+            provider: _,
+            version: _,
+        } => {
+            if is_guarded_by_try_except(expr, module, name.as_str(), semantic) {
+                return;
+            }
+            diagnostic.try_set_fix(|| {
+                let (import_edit, binding) = checker.importer().get_or_import_symbol(
+                    &ImportRequest::import_from(module, name.as_str()),
+                    expr.start(),
+                    checker.semantic(),
+                )?;
+                let replacement_edit = Edit::range_replacement(binding, ranged.range());
+                Ok(Fix::safe_edits(import_edit, [replacement_edit]))
+            });
+        }
+        _ => {}
     }
 
     checker.report_diagnostic(diagnostic);

--- a/crates/ruff_linter/src/rules/airflow/rules/suggested_to_move_to_provider_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/suggested_to_move_to_provider_in_3.rs
@@ -280,46 +280,25 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
     );
 
     let semantic = checker.semantic();
-    match replacement {
-        ProviderReplacement::AutoImport {
-            module,
-            name,
-            provider: _,
-            version: _,
-        } => {
-            if is_guarded_by_try_except(expr, module, name, semantic) {
-                return;
-            }
-            diagnostic.try_set_fix(|| {
-                let (import_edit, binding) = checker.importer().get_or_import_symbol(
-                    &ImportRequest::import_from(module, name),
-                    expr.start(),
-                    checker.semantic(),
-                )?;
-                let replacement_edit = Edit::range_replacement(binding, ranged.range());
-                Ok(Fix::safe_edits(import_edit, [replacement_edit]))
-            });
+    if let Some((module, name)) = match &replacement {
+        ProviderReplacement::AutoImport { module, name, .. } => Some((module, *name)),
+        ProviderReplacement::SourceModuleMovedToProvider { module, name, .. } => {
+            Some((module, name.as_str()))
         }
-        ProviderReplacement::SourceModuleMovedToProvider {
-            module,
-            name,
-            provider: _,
-            version: _,
-        } => {
-            if is_guarded_by_try_except(expr, module, name.as_str(), semantic) {
-                return;
-            }
-            diagnostic.try_set_fix(|| {
-                let (import_edit, binding) = checker.importer().get_or_import_symbol(
-                    &ImportRequest::import_from(module, name.as_str()),
-                    expr.start(),
-                    checker.semantic(),
-                )?;
-                let replacement_edit = Edit::range_replacement(binding, ranged.range());
-                Ok(Fix::safe_edits(import_edit, [replacement_edit]))
-            });
+        _ => None,
+    } {
+        if is_guarded_by_try_except(expr, module, name, semantic) {
+            return;
         }
-        _ => {}
+        diagnostic.try_set_fix(|| {
+            let (import_edit, binding) = checker.importer().get_or_import_symbol(
+                &ImportRequest::import_from(module, name),
+                expr.start(),
+                checker.semantic(),
+            )?;
+            let replacement_edit = Edit::range_replacement(binding, ranged.range());
+            Ok(Fix::safe_edits(import_edit, [replacement_edit]))
+        });
     }
 
     checker.report_diagnostic(diagnostic);

--- a/crates/ruff_linter/src/rules/airflow/rules/suggested_to_update_3_0.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/suggested_to_update_3_0.rs
@@ -283,10 +283,6 @@ fn check_name(checker: &Checker, expr: &Expr, range: TextRange) {
         _ => return,
     };
 
-    if is_guarded_by_try_except(expr, &replacement, semantic) {
-        return;
-    }
-
     let mut diagnostic = Diagnostic::new(
         Airflow3SuggestedUpdate {
             deprecated: qualified_name.to_string(),
@@ -295,16 +291,37 @@ fn check_name(checker: &Checker, expr: &Expr, range: TextRange) {
         range,
     );
 
-    if let Replacement::AutoImport { module, name } = replacement {
-        diagnostic.try_set_fix(|| {
-            let (import_edit, binding) = checker.importer().get_or_import_symbol(
-                &ImportRequest::import_from(module, name),
-                expr.start(),
-                checker.semantic(),
-            )?;
-            let replacement_edit = Edit::range_replacement(binding, range);
-            Ok(Fix::safe_edits(import_edit, [replacement_edit]))
-        });
+    let semantic = checker.semantic();
+    match replacement {
+        Replacement::AutoImport { module, name } => {
+            if is_guarded_by_try_except(expr, module, name, semantic) {
+                return;
+            }
+            diagnostic.try_set_fix(|| {
+                let (import_edit, binding) = checker.importer().get_or_import_symbol(
+                    &ImportRequest::import_from(module, name),
+                    expr.start(),
+                    checker.semantic(),
+                )?;
+                let replacement_edit = Edit::range_replacement(binding, range);
+                Ok(Fix::safe_edits(import_edit, [replacement_edit]))
+            });
+        }
+        Replacement::SourceModuleMoved { module, name } => {
+            if is_guarded_by_try_except(expr, module, name.as_str(), semantic) {
+                return;
+            }
+            diagnostic.try_set_fix(|| {
+                let (import_edit, binding) = checker.importer().get_or_import_symbol(
+                    &ImportRequest::import_from(module, name.as_str()),
+                    expr.start(),
+                    checker.semantic(),
+                )?;
+                let replacement_edit = Edit::range_replacement(binding, range);
+                Ok(Fix::safe_edits(import_edit, [replacement_edit]))
+            });
+        }
+        _ => {}
     }
 
     checker.report_diagnostic(diagnostic);

--- a/crates/ruff_linter/src/rules/airflow/rules/suggested_to_update_3_0.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/suggested_to_update_3_0.rs
@@ -292,36 +292,23 @@ fn check_name(checker: &Checker, expr: &Expr, range: TextRange) {
     );
 
     let semantic = checker.semantic();
-    match replacement {
-        Replacement::AutoImport { module, name } => {
-            if is_guarded_by_try_except(expr, module, name, semantic) {
-                return;
-            }
-            diagnostic.try_set_fix(|| {
-                let (import_edit, binding) = checker.importer().get_or_import_symbol(
-                    &ImportRequest::import_from(module, name),
-                    expr.start(),
-                    checker.semantic(),
-                )?;
-                let replacement_edit = Edit::range_replacement(binding, range);
-                Ok(Fix::safe_edits(import_edit, [replacement_edit]))
-            });
+    if let Some((module, name)) = match &replacement {
+        Replacement::AutoImport { module, name } => Some((module, *name)),
+        Replacement::SourceModuleMoved { module, name } => Some((module, name.as_str())),
+        _ => None,
+    } {
+        if is_guarded_by_try_except(expr, module, name, semantic) {
+            return;
         }
-        Replacement::SourceModuleMoved { module, name } => {
-            if is_guarded_by_try_except(expr, module, name.as_str(), semantic) {
-                return;
-            }
-            diagnostic.try_set_fix(|| {
-                let (import_edit, binding) = checker.importer().get_or_import_symbol(
-                    &ImportRequest::import_from(module, name.as_str()),
-                    expr.start(),
-                    checker.semantic(),
-                )?;
-                let replacement_edit = Edit::range_replacement(binding, range);
-                Ok(Fix::safe_edits(import_edit, [replacement_edit]))
-            });
-        }
-        _ => {}
+        diagnostic.try_set_fix(|| {
+            let (import_edit, binding) = checker.importer().get_or_import_symbol(
+                &ImportRequest::import_from(module, name),
+                expr.start(),
+                checker.semantic(),
+            )?;
+            let replacement_edit = Edit::range_replacement(binding, range);
+            Ok(Fix::safe_edits(import_edit, [replacement_edit]))
+        });
     }
 
     checker.report_diagnostic(diagnostic);

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_try.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_try.py.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff_linter/src/rules/airflow/mod.rs
+---
+

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR311_AIR311_names.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR311_AIR311_names.py.snap
@@ -258,7 +258,7 @@ AIR311_names.py:49:1: AIR311 `airflow.models.Connection` is removed in Airflow 3
    |
    = help: Use `airflow.sdk.Connection` instead
 
-AIR311_names.py:50:1: AIR311 `airflow.models.DAG` is removed in Airflow 3.0; It still works in Airflow 3.0 but is expected to be removed in a future version.
+AIR311_names.py:50:1: AIR311 [*] `airflow.models.DAG` is removed in Airflow 3.0; It still works in Airflow 3.0 but is expected to be removed in a future version.
    |
 48 | # airflow.models
 49 | Connection()
@@ -267,6 +267,24 @@ AIR311_names.py:50:1: AIR311 `airflow.models.DAG` is removed in Airflow 3.0; It 
 51 | Variable()
    |
    = help: Use `airflow.sdk.DAG` instead
+
+ℹ Safe fix
+22 22 | from airflow.models.dag import DAG as DAGFromDag
+23 23 | from airflow.timetables.datasets import DatasetOrTimeSchedule
+24 24 | from airflow.utils.dag_parsing_context import get_parsing_context
+   25 |+from airflow.sdk import DAG
+25 26 | 
+26 27 | # airflow
+27 28 | DatasetFromRoot()
+--------------------------------------------------------------------------------
+47 48 | 
+48 49 | # airflow.models
+49 50 | Connection()
+50    |-DAGFromModel()
+   51 |+DAG()
+51 52 | Variable()
+52 53 | 
+53 54 | # airflow.models.baseoperator
 
 AIR311_names.py:51:1: AIR311 `airflow.models.Variable` is removed in Airflow 3.0; It still works in Airflow 3.0 but is expected to be removed in a future version.
    |
@@ -310,7 +328,7 @@ AIR311_names.py:56:1: AIR311 `airflow.models.baseoperator.cross_downstream` is r
    |
    = help: Use `airflow.sdk.cross_downstream` instead
 
-AIR311_names.py:62:1: AIR311 `airflow.models.dag.DAG` is removed in Airflow 3.0; It still works in Airflow 3.0 but is expected to be removed in a future version.
+AIR311_names.py:62:1: AIR311 [*] `airflow.models.dag.DAG` is removed in Airflow 3.0; It still works in Airflow 3.0 but is expected to be removed in a future version.
    |
 61 | # airflow.models.dag
 62 | DAGFromDag()
@@ -319,6 +337,24 @@ AIR311_names.py:62:1: AIR311 `airflow.models.dag.DAG` is removed in Airflow 3.0;
 64 | DatasetOrTimeSchedule()
    |
    = help: Use `airflow.sdk.DAG` instead
+
+ℹ Safe fix
+22 22 | from airflow.models.dag import DAG as DAGFromDag
+23 23 | from airflow.timetables.datasets import DatasetOrTimeSchedule
+24 24 | from airflow.utils.dag_parsing_context import get_parsing_context
+   25 |+from airflow.sdk import DAG
+25 26 | 
+26 27 | # airflow
+27 28 | DatasetFromRoot()
+--------------------------------------------------------------------------------
+59 60 | BaseOperatorLink()
+60 61 | 
+61 62 | # airflow.models.dag
+62    |-DAGFromDag()
+   63 |+DAG()
+63 64 | # airflow.timetables.datasets
+64 65 | DatasetOrTimeSchedule()
+65 66 | 
 
 AIR311_names.py:64:1: AIR311 [*] `airflow.timetables.datasets.DatasetOrTimeSchedule` is removed in Airflow 3.0; It still works in Airflow 3.0 but is expected to be removed in a future version.
    |

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR311_AIR311_try.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR311_AIR311_try.py.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff_linter/src/rules/airflow/mod.rs
+---
+

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR312_AIR312_try.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR312_AIR312_try.py.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff_linter/src/rules/airflow/mod.rs
+---
+


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

If a try-catch block guards the names, we don't raise warnings. During this change, I discovered that some of the replacement types were missed. Thus, I extend the fix to types other than AutoImport as well

## Test Plan

<!-- How was it tested? -->

Test fixtures are added and updated.