### PR TITLE
Display `ty version` for `ty --version` and `ty -V`

### DIFF
--- a/crates/ty/Cargo.toml
+++ b/crates/ty/Cargo.toml
@@ -20,7 +20,7 @@ ty_server = { workspace = true }
 
 anyhow = { workspace = true }
 argfile = { workspace = true }
-clap = { workspace = true, features = ["wrap_help"] }
+clap = { workspace = true, features = ["wrap_help", "string"] }
 colored = { workspace = true }
 countme = { workspace = true, features = ["enable"] }
 crossbeam = { workspace = true }

--- a/crates/ty/src/args.rs
+++ b/crates/ty/src/args.rs
@@ -8,7 +8,7 @@ use ty_python_semantic::lint;
 
 #[derive(Debug, Parser)]
 #[command(author, name = "ty", about = "An extremely fast Python type checker.")]
-#[command(version)]
+#[command(long_version = crate::version::version())]
 pub(crate) struct Args {
     #[command(subcommand)]
     pub(crate) command: Command,

--- a/crates/ty/src/version.rs
+++ b/crates/ty/src/version.rs
@@ -35,6 +35,12 @@ impl fmt::Display for VersionInfo {
     }
 }
 
+impl From<VersionInfo> for clap::builder::Str {
+    fn from(val: VersionInfo) -> Self {
+        val.to_string().into()
+    }
+}
+
 /// Returns information about ty's version.
 pub(crate) fn version() -> VersionInfo {
     // Environment variables are only read at compile-time


### PR DESCRIPTION
e.g.,

```
❯ uv run -q -- ty -V
ty 0.0.0-alpha.4 (08881edba 2025-05-05)
❯ uv run -q -- ty --version
ty 0.0.0-alpha.4 (08881edba 2025-05-05)
```

Previously, this just displayed `ty 0.0.0` because it didn't use our custom version implementation. We no longer have a short version — matching the interface in uv. We could add a variant for it, if it seems important to people. However, I think we found it more confusing than not over there and didn't get any complaints about the change.

Closes https://github.com/astral-sh/ty/issues/54