### PR TITLE
update the repository for ty

### DIFF
--- a/crates/ty/Cargo.toml
+++ b/crates/ty/Cargo.toml
@@ -5,7 +5,8 @@ edition.workspace = true
 rust-version.workspace = true
 homepage.workspace = true
 documentation.workspace = true
-repository.workspace = true
+# Releases occur in this other repository!
+repository = "https://github.com/astral-sh/ty/"
 authors.workspace = true
 license.workspace = true
 


### PR DESCRIPTION
This metadata is used by cargo-dist for artifact URLs (in curl-sh expressions)
