### PR TITLE
Remove R from redirects, as it is not a valid rule

### DIFF
--- a/crates/ruff_linter/src/rule_redirects.rs
+++ b/crates/ruff_linter/src/rule_redirects.rs
@@ -20,8 +20,6 @@ static REDIRECTS: LazyLock<HashMap<&'static str, &'static str>> = LazyLock::new(
         ("C9", "C90"),
         ("T1", "T10"),
         ("T2", "T20"),
-        // TODO(charlie): Remove by 2023-02-01.
-        ("R", "RET"),
         ("R5", "RET5"),
         ("R50", "RET50"),
         ("R501", "RET501"),


### PR DESCRIPTION
## Summary

This PR should fix the following bug: https://github.com/astral-sh/ruff/issues/17890

## Test Plan

Tested against a local repository. main branch `ruff check --select R` works, with this redirect removed, `ruff check --select R` throws `error: invalid value 'R' for '--select <RULE_CODE>'`

All existing tests still pass. 

Not sure if it is worthwhile/necessary to add a unit test for this fix?