### PR TITLE
[ty] fix assigning a typevar to a union with itself

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
@@ -320,6 +320,17 @@ def two_final_constrained[T: (FinalClass, AnotherFinalClass), U: (FinalClass, An
     static_assert(not is_subtype_of(U, T))
 ```
 
+A bound or constrained typevar is a subtype of itself in a union:
+
+```py
+def union[T: Base, U: (Base, Unrelated)](t: T, u: U) -> None:
+    static_assert(is_assignable_to(T, T | None))
+    static_assert(is_assignable_to(U, U | None))
+
+    static_assert(is_subtype_of(T, T | None))
+    static_assert(is_subtype_of(U, U | None))
+```
+
 ## Singletons and single-valued types
 
 (Note: for simplicity, all of the prose in this section refers to _singleton_ types, but all of the


### PR DESCRIPTION
## Summary

Noticed in https://github.com/astral-sh/ruff/pull/17800 that a typevar was not considered assignable to a union containing itself.

A bound typevar `T: int` must be assignable to e.g. `int | None` but must also be assignable to e.g. `T | None`. There's no way to order the bound/constrained-typevar and union arms of `is_subtype_of` and `is_assignable_to` that would achieve both of these; it requires trying the recursive union treatment for one possibility (treat the typevar as itself), and then if that fails, also trying it for the other possibility (treat the typevar as its bound/constraints).

It doesn't work to just put the union case first and let the typevar bound/constraint handling happen one level deeper, because then we fail to consider e.g. `T: (X, Y)` a subtype of `X | Y` -- we would separately try `X | Y <: X` and `X | Y <: Y`, and both fail. (There's already a test for this, fortunately, or I probably would have pushed the simpler fix that breaks it.)

## Test Plan

Added mdtest.
