### PR TITLE
[ty] fix assigning a typevar to a union with itself

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
@@ -331,6 +331,27 @@ def union[T: Base, U: (Base, Unrelated)](t: T, u: U) -> None:
     static_assert(is_subtype_of(U, U | None))
 ```
 
+And an intersection of a typevar with another type is always a subtype of the TypeVar:
+
+```py
+from ty_extensions import Intersection, Not, is_disjoint_from
+
+class A: ...
+
+def inter[T: Base, U: (Base, Unrelated)](t: T, u: U) -> None:
+    static_assert(is_assignable_to(Intersection[T, Unrelated], T))
+    static_assert(is_subtype_of(Intersection[T, Unrelated], T))
+
+    static_assert(is_assignable_to(Intersection[U, A], U))
+    static_assert(is_subtype_of(Intersection[U, A], U))
+
+    # TODO: these should pass
+    static_assert(is_disjoint_from(Not[T], T))  # error: [static-assert-error]
+    static_assert(is_disjoint_from(T, Not[T]))  # error: [static-assert-error]
+    static_assert(is_disjoint_from(Not[U], U))  # error: [static-assert-error]
+    static_assert(is_disjoint_from(U, Not[U]))  # error: [static-assert-error]
+```
+
 ## Singletons and single-valued types
 
 (Note: for simplicity, all of the prose in this section refers to _singleton_ types, but all of the

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
@@ -320,6 +320,17 @@ def two_final_constrained[T: (FinalClass, AnotherFinalClass), U: (FinalClass, An
     static_assert(not is_subtype_of(U, T))
 ```
 
+A bound or constrained typevar is a subtype of itself in a union:
+
+```py
+def union[T: Base, U: (Base, Unrelated)](t: T, u: U) -> None:
+    static_assert(is_assignable_to(T, T | None))
+    static_assert(is_assignable_to(U, U | None))
+
+    static_assert(is_subtype_of(T, T | None))
+    static_assert(is_subtype_of(U, U | None))
+```
+
 ## Singletons and single-valued types
 
 (Note: for simplicity, all of the prose in this section refers to _singleton_ types, but all of the

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
@@ -352,6 +352,75 @@ def inter[T: Base, U: (Base, Unrelated)](t: T, u: U) -> None:
     static_assert(is_disjoint_from(U, Not[U]))  # error: [static-assert-error]
 ```
 
+## Equivalence
+
+A fully static `TypeVar` is always equivalent to itself, but never to another `TypeVar`, since there
+is no guarantee that they will be specialized to the same type. (This is true even if both typevars
+are bounded by the same final class, since you can specialize the typevars to `Never` in addition to
+that final class.)
+
+```py
+from typing import final
+from ty_extensions import is_equivalent_to, static_assert, is_gradual_equivalent_to
+
+@final
+class FinalClass: ...
+
+@final
+class SecondFinalClass: ...
+
+def f[A, B, C: FinalClass, D: FinalClass, E: (FinalClass, SecondFinalClass), F: (FinalClass, SecondFinalClass)]():
+    static_assert(is_equivalent_to(A, A))
+    static_assert(is_equivalent_to(B, B))
+    static_assert(is_equivalent_to(C, C))
+    static_assert(is_equivalent_to(D, D))
+    static_assert(is_equivalent_to(E, E))
+    static_assert(is_equivalent_to(F, F))
+
+    static_assert(is_gradual_equivalent_to(A, A))
+    static_assert(is_gradual_equivalent_to(B, B))
+    static_assert(is_gradual_equivalent_to(C, C))
+    static_assert(is_gradual_equivalent_to(D, D))
+    static_assert(is_gradual_equivalent_to(E, E))
+    static_assert(is_gradual_equivalent_to(F, F))
+
+    static_assert(not is_equivalent_to(A, B))
+    static_assert(not is_equivalent_to(C, D))
+    static_assert(not is_equivalent_to(E, F))
+
+    static_assert(not is_gradual_equivalent_to(A, B))
+    static_assert(not is_gradual_equivalent_to(C, D))
+    static_assert(not is_gradual_equivalent_to(E, F))
+```
+
+TypeVars which have non-fully-static bounds or constraints do not participate in equivalence
+relations, but do participate in gradual equivalence relations.
+
+```py
+from typing import final, Any
+from ty_extensions import is_equivalent_to, static_assert, is_gradual_equivalent_to
+
+# fmt: off
+
+def f[
+    A: tuple[Any],
+    B: tuple[Any],
+    C: (tuple[Any], tuple[Any, Any]),
+    D: (tuple[Any], tuple[Any, Any])
+]():
+    static_assert(not is_equivalent_to(A, A))
+    static_assert(not is_equivalent_to(B, B))
+    static_assert(not is_equivalent_to(C, C))
+    static_assert(not is_equivalent_to(D, D))
+
+    static_assert(is_gradual_equivalent_to(A, A))
+    static_assert(is_gradual_equivalent_to(B, B))
+    static_assert(is_gradual_equivalent_to(C, C))
+    static_assert(is_gradual_equivalent_to(D, D))
+
+# fmt: on
+```
+
 ## Singletons and single-valued types
 
 (Note: for simplicity, all of the prose in this section refers to _singleton_ types, but all of the

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -995,14 +995,6 @@ impl<'db> Type<'db> {
             // Everything is a subtype of `object`.
             (_, Type::NominalInstance(instance)) if instance.class().is_object(db) => true,
 
-            // A fully static typevar is always a subtype of itself, and is never a subtype of any
-            // other typevar, since there is no guarantee that they will be specialized to the same
-            // type. (This is true even if both typevars are bounded by the same final class, since
-            // you can specialize the typevars to `Never` in addition to that final class.)
-            (Type::TypeVar(self_typevar), Type::TypeVar(other_typevar)) => {
-                self_typevar == other_typevar
-            }
-
             // In general, a TypeVar `T` is not a subtype of a type `S` unless one of the two conditions is satisfied:
             // 1. `T` is a bound TypeVar and `T`'s upper bound is a subtype of `S`.
             //    TypeVars without an explicit upper bound are treated as having an implicit upper bound of `object`.
@@ -1327,14 +1319,6 @@ impl<'db> Type<'db> {
             // TODO this special case might be removable once the below cases are comprehensive
             (_, Type::NominalInstance(instance)) if instance.class().is_object(db) => true,
 
-            // A typevar is always assignable to itself, and is never assignable to any other
-            // typevar, since there is no guarantee that they will be specialized to the same
-            // type. (This is true even if both typevars are bounded by the same final class, since
-            // you can specialize the typevars to `Never` in addition to that final class.)
-            (Type::TypeVar(self_typevar), Type::TypeVar(other_typevar)) => {
-                self_typevar == other_typevar
-            }
-
             // In general, a TypeVar `T` is not assignable to a type `S` unless one of the two conditions is satisfied:
             // 1. `T` is a bound TypeVar and `T`'s upper bound is assignable to `S`.
             //    TypeVars without an explicit upper bound are treated as having an implicit upper bound of `object`.
@@ -1568,11 +1552,6 @@ impl<'db> Type<'db> {
             }
             (Type::Tuple(left), Type::Tuple(right)) => left.is_equivalent_to(db, right),
             (Type::Callable(left), Type::Callable(right)) => left.is_equivalent_to(db, right),
-            // A fully static typevar is always equivalent to itself, and not any other typevar,
-            // since there is no guarantee that they will be specialized to the same type. (This is
-            // true even if both typevars are bounded by the same final class, since you can
-            // specialize the typevars to `Never` in addition to that final class.)
-            (Type::TypeVar(first), Type::TypeVar(second)) => first == second,
             (Type::NominalInstance(left), Type::NominalInstance(right)) => {
                 left.is_equivalent_to(db, right)
             }
@@ -1614,12 +1593,6 @@ impl<'db> Type<'db> {
                     _ => false,
                 }
             }
-
-            // A typevar is always gradually equivalent to itself, and not to any other typevar,
-            // since there is no guarantee that they will be specialized to the same type. (This is
-            // true even if both typevars are bounded by the same final class, since you can
-            // specialize the typevars to `Never` in addition to that final class.)
-            (Type::TypeVar(first), Type::TypeVar(second)) => first == second,
 
             (Type::NominalInstance(first), Type::NominalInstance(second)) => {
                 first.is_gradual_equivalent_to(db, second)


### PR DESCRIPTION
## Summary

This is an alternative PR to https://github.com/astral-sh/ruff/pull/17901. It retains the tests from that PR but uses a more targeted fix.

I don't think it's necessary to refactor the `Type::is_subtype_of()` and `Type::is_assignable_to()` methods to the extent that https://github.com/astral-sh/ruff/pull/17901 does. As far as I can see, the problem is specific to unions and intersections containing `TypeVar`s. I don't _think_ there's any situation where a `TypeVar` `T` can be assignable to a type `S` without its upper bound being assignable to `S` unless `S` is a union that directly contains `T`; this is the premise that my alternative implementation is based on.

I also added a couple more tests on top of the ones @carljm added.

## Test Plan

`cargo test -p ty_python_semantic`

Co-authored-by: Carl Meyer <carl@astral.sh>
