### PR TITLE
[ty] Ecosystem checks: activate running on 'manticore'

### DIFF
--- a/crates/ty_python_semantic/resources/primer/bad.txt
+++ b/crates/ty_python_semantic/resources/primer/bad.txt
@@ -9,7 +9,6 @@ discord.py  # some kind of hang, only when multi-threaded?
 freqtrade  # cycle panics (try_metaclass_)
 hydpy  # cycle panics (try_metaclass_)
 ibis  # cycle panics (try_metaclass_)
-manticore  # stack overflow, see https://github.com/astral-sh/ruff/issues/17863
 pandas  # slow
 pandas-stubs  # cycle panics (try_metaclass_)
 pandera  # cycle panics (try_metaclass_)

--- a/crates/ty_python_semantic/resources/primer/good.txt
+++ b/crates/ty_python_semantic/resources/primer/good.txt
@@ -50,6 +50,7 @@ jinja
 koda-validate
 kopf
 kornia
+manticore
 materialize
 meson
 mitmproxy


### PR DESCRIPTION
## Summary

This is sort of an anticlimactic resolution to #17863, but now that we understand what the root cause for the stack overflows was, I think it's fine to enable running on this project. See the linked ticket for the full analysis.

closes #17863

## Test Plan

Ran lots of times locally and never observed a crash at worker thread stack sizes > 8 MiB.
