### PR TITLE
Make completions an opt-in LSP feature

### DIFF
--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -6,6 +6,7 @@ use ruff_text_size::TextSize;
 
 use crate::Db;
 
+#[derive(Debug, Clone)]
 pub struct Completion {
     pub label: String,
 }

--- a/crates/ty_server/src/session.rs
+++ b/crates/ty_server/src/session.rs
@@ -21,6 +21,7 @@ pub(crate) use self::capabilities::ResolvedClientCapabilities;
 pub use self::index::DocumentQuery;
 pub(crate) use self::settings::AllSettings;
 pub use self::settings::ClientSettings;
+pub(crate) use self::settings::Experimental;
 
 mod capabilities;
 pub(crate) mod index;

--- a/crates/ty_server/src/session/settings.rs
+++ b/crates/ty_server/src/session/settings.rs
@@ -7,11 +7,35 @@ use serde::Deserialize;
 /// Maps a workspace URI to its associated client settings. Used during server initialization.
 pub(crate) type WorkspaceSettingsMap = FxHashMap<Url, ClientSettings>;
 
+#[derive(Debug, Deserialize, Default)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
+#[serde(rename_all = "camelCase")]
+struct Completions {
+    enable: Option<bool>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct Experimental {
+    completions: Option<Completions>,
+}
+
+impl Experimental {
+    /// Returns `true` if completions are enabled in the settings.
+    pub(crate) fn is_completions_enabled(&self) -> bool {
+        self.completions
+            .as_ref()
+            .is_some_and(|completions| completions.enable.unwrap_or_default())
+    }
+}
+
 /// This is a direct representation of the settings schema sent by the client.
 #[derive(Debug, Deserialize, Default)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
 #[serde(rename_all = "camelCase")]
 pub struct ClientSettings {
+    pub(crate) experimental: Option<Experimental>,
     // These settings are only needed for tracing, and are only read from the global configuration.
     // These will not be in the resolved settings.
     #[serde(flatten)]


### PR DESCRIPTION
## Summary

We now expect the client to send initialization options to opt-in to experimental (but LSP-standardized) features, like completion support. Specifically, the client should set `"experimental.completions.enable": true`.

Closes https://github.com/astral-sh/ty/issues/74.
