### PR TITLE
[ty] Ensure that `T` is disjoint from `~T` even when `T` is a TypeVar

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
@@ -345,11 +345,10 @@ def inter[T: Base, U: (Base, Unrelated)](t: T, u: U) -> None:
     static_assert(is_assignable_to(Intersection[U, A], U))
     static_assert(is_subtype_of(Intersection[U, A], U))
 
-    # TODO: these should pass
-    static_assert(is_disjoint_from(Not[T], T))  # error: [static-assert-error]
-    static_assert(is_disjoint_from(T, Not[T]))  # error: [static-assert-error]
-    static_assert(is_disjoint_from(Not[U], U))  # error: [static-assert-error]
-    static_assert(is_disjoint_from(U, Not[U]))  # error: [static-assert-error]
+    static_assert(is_disjoint_from(Not[T], T))
+    static_assert(is_disjoint_from(T, Not[T]))
+    static_assert(is_disjoint_from(Not[U], U))
+    static_assert(is_disjoint_from(U, Not[U]))
 ```
 
 ## Equivalence

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1643,6 +1643,13 @@ impl<'db> Type<'db> {
                 false
             }
 
+            (tvar @ Type::TypeVar(_), Type::Intersection(intersection))
+            | (Type::Intersection(intersection), tvar @ Type::TypeVar(_))
+                if intersection.negative(db).contains(&tvar) =>
+            {
+                true
+            }
+
             // An unbounded typevar is never disjoint from any other type, since it might be
             // specialized to any type. A bounded typevar is not disjoint from its bound, and is
             // only disjoint from other types if its bound is. A constrained typevar is disjoint


### PR DESCRIPTION
Same as https://github.com/astral-sh/ruff/pull/17910 but for disjointness