### PR TITLE
Remove rust-toolchain.toml from sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,9 +53,6 @@ exclude = [
     "crates/ruff_linter/resources/test/fixtures/**/*",
     "crates/ruff_linter/src/rules/*/snapshots/**/*"
 ]
-include = [
-    "rust-toolchain.toml"
-]
 
 [tool.ruff]
 target-version = "py38"


### PR DESCRIPTION
## Summary
The `rust-toolchain.toml` specifies the rust toolchain version that we use for development. 
Consumers of the `ruff` package can use any Rust version (that meets our MSRV) to build ruff from an sdist. 

Closes https://github.com/astral-sh/ruff/issues/17909

## Test Plan

Ran `uv build` and verified that the `rust-toolchain.toml` is no longer present in the `sdist` folder. 

I uninstalled all Rust toolchains and verified that `cargo build` re-installs the latest stable version. 

I verified that `cargo build` automatically installs the latest stable if the default Rust toolchain doesn't meet the MSRV.
