### PR TITLE
[ty] Sort collected diagnostics before snapshotting them in mdtest

### DIFF
--- a/crates/ruff_db/src/diagnostic/mod.rs
+++ b/crates/ruff_db/src/diagnostic/mod.rs
@@ -235,10 +235,7 @@ impl Diagnostic {
 
     /// Returns a key that can be used to sort two diagnostics into the canonical order
     /// in which they should appear when rendered.
-    pub fn rendering_sort_key<'a, 'db>(&'a self, db: &'db dyn Db) -> impl Ord + 'a
-    where
-        'db: 'a,
-    {
+    pub fn rendering_sort_key<'a>(&'a self, db: &'a dyn Db) -> impl Ord + 'a {
         RenderingSortKey {
             db,
             diagnostic: self,
@@ -255,12 +252,12 @@ struct DiagnosticInner {
     subs: Vec<SubDiagnostic>,
 }
 
-struct RenderingSortKey<'db, 'a> {
-    db: &'db dyn Db,
+struct RenderingSortKey<'a> {
+    db: &'a dyn Db,
     diagnostic: &'a Diagnostic,
 }
 
-impl Ord for RenderingSortKey<'_, '_> {
+impl Ord for RenderingSortKey<'_> {
     // We sort diagnostics in a way that keeps them in source order
     // and grouped by file. After that, we fall back to severity
     // (with fatal messages sorting before info messages) and then
@@ -299,19 +296,19 @@ impl Ord for RenderingSortKey<'_, '_> {
     }
 }
 
-impl PartialOrd for RenderingSortKey<'_, '_> {
+impl PartialOrd for RenderingSortKey<'_> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl PartialEq for RenderingSortKey<'_, '_> {
+impl PartialEq for RenderingSortKey<'_> {
     fn eq(&self, other: &Self) -> bool {
         self.cmp(other).is_eq()
     }
 }
 
-impl Eq for RenderingSortKey<'_, '_> {}
+impl Eq for RenderingSortKey<'_> {}
 
 /// A collection of information subservient to a diagnostic.
 ///

--- a/crates/ruff_db/src/diagnostic/mod.rs
+++ b/crates/ruff_db/src/diagnostic/mod.rs
@@ -232,6 +232,18 @@ impl Diagnostic {
     pub fn primary_tags(&self) -> Option<&[DiagnosticTag]> {
         self.primary_annotation().map(|ann| ann.tags.as_slice())
     }
+
+    /// Returns a key that can be used to sort two diagnostics into the canonical order
+    /// in which they should appear when rendered.
+    pub fn rendering_sort_key<'a, 'db>(&'a self, db: &'db dyn Db) -> impl Ord + 'a
+    where
+        'db: 'a,
+    {
+        RenderingSortKey {
+            db,
+            diagnostic: self,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -242,6 +254,64 @@ struct DiagnosticInner {
     annotations: Vec<Annotation>,
     subs: Vec<SubDiagnostic>,
 }
+
+struct RenderingSortKey<'db, 'a> {
+    db: &'db dyn Db,
+    diagnostic: &'a Diagnostic,
+}
+
+impl Ord for RenderingSortKey<'_, '_> {
+    // We sort diagnostics in a way that keeps them in source order
+    // and grouped by file. After that, we fall back to severity
+    // (with fatal messages sorting before info messages) and then
+    // finally the diagnostic ID.
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        if let (Some(span1), Some(span2)) = (
+            self.diagnostic.primary_span(),
+            other.diagnostic.primary_span(),
+        ) {
+            let order = span1
+                .file()
+                .path(self.db)
+                .as_str()
+                .cmp(span2.file().path(self.db).as_str());
+            if order.is_ne() {
+                return order;
+            }
+
+            if let (Some(range1), Some(range2)) = (span1.range(), span2.range()) {
+                let order = range1.start().cmp(&range2.start());
+                if order.is_ne() {
+                    return order;
+                }
+            }
+        }
+        // Reverse so that, e.g., Fatal sorts before Info.
+        let order = self
+            .diagnostic
+            .severity()
+            .cmp(&other.diagnostic.severity())
+            .reverse();
+        if order.is_ne() {
+            return order;
+        }
+        self.diagnostic.id().cmp(&other.diagnostic.id())
+    }
+}
+
+impl PartialOrd for RenderingSortKey<'_, '_> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for RenderingSortKey<'_, '_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other).is_eq()
+    }
+}
+
+impl Eq for RenderingSortKey<'_, '_> {}
 
 /// A collection of information subservient to a diagnostic.
 ///

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -219,34 +219,10 @@ impl Project {
             .unwrap()
             .into_inner()
             .unwrap();
-        // We sort diagnostics in a way that keeps them in source order
-        // and grouped by file. After that, we fall back to severity
-        // (with fatal messages sorting before info messages) and then
-        // finally the diagnostic ID.
-        file_diagnostics.sort_by(|d1, d2| {
-            if let (Some(span1), Some(span2)) = (d1.primary_span(), d2.primary_span()) {
-                let order = span1
-                    .file()
-                    .path(db)
-                    .as_str()
-                    .cmp(span2.file().path(db).as_str());
-                if order.is_ne() {
-                    return order;
-                }
 
-                if let (Some(range1), Some(range2)) = (span1.range(), span2.range()) {
-                    let order = range1.start().cmp(&range2.start());
-                    if order.is_ne() {
-                        return order;
-                    }
-                }
-            }
-            // Reverse so that, e.g., Fatal sorts before Info.
-            let order = d1.severity().cmp(&d2.severity()).reverse();
-            if order.is_ne() {
-                return order;
-            }
-            d1.id().cmp(&d2.id())
+        file_diagnostics.sort_by(|left, right| {
+            left.rendering_sort_key(db)
+                .cmp(&right.rendering_sort_key(db))
         });
         diagnostics.extend(file_diagnostics);
         diagnostics

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_With_non-callable_iterator.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_With_non-callable_iterator.snap
@@ -47,6 +47,18 @@ info: `lint:not-iterable` is enabled by default
 ```
 
 ```
+info: revealed-type: Revealed type
+  --> src/mdtest_snippet.py:16:5
+   |
+14 |     # revealed: Unknown
+15 |     # error: [possibly-unresolved-reference]
+16 |     reveal_type(x)
+   |     ^^^^^^^^^^^^^^ `Unknown`
+   |
+
+```
+
+```
 warning: lint:possibly-unresolved-reference: Name `x` used when possibly not defined
   --> src/mdtest_snippet.py:16:17
    |
@@ -56,17 +68,5 @@ warning: lint:possibly-unresolved-reference: Name `x` used when possibly not def
    |                 ^
    |
 info: `lint:possibly-unresolved-reference` is enabled by default
-
-```
-
-```
-info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:16:5
-   |
-14 |     # revealed: Unknown
-15 |     # error: [possibly-unresolved-reference]
-16 |     reveal_type(x)
-   |     ^^^^^^^^^^^^^^ `Unknown`
-   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___Legacy_syntax_-_Inferring_a_bound_typevar.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___Legacy_syntax_-_Inferring_a_bound_typevar.snap
@@ -56,6 +56,18 @@ info: revealed-type: Revealed type
 ```
 
 ```
+info: revealed-type: Revealed type
+  --> src/mdtest_snippet.py:12:1
+   |
+10 | reveal_type(f(True))  # revealed: Literal[True]
+11 | # error: [invalid-argument-type]
+12 | reveal_type(f("string"))  # revealed: Unknown
+   | ^^^^^^^^^^^^^^^^^^^^^^^^ `Unknown`
+   |
+
+```
+
+```
 error: lint:invalid-argument-type: Argument to this function is incorrect
   --> src/mdtest_snippet.py:12:15
    |
@@ -75,17 +87,5 @@ info: Type variable defined here
 6 | def f(x: T) -> T:
   |
 info: `lint:invalid-argument-type` is enabled by default
-
-```
-
-```
-info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:12:1
-   |
-10 | reveal_type(f(True))  # revealed: Literal[True]
-11 | # error: [invalid-argument-type]
-12 | reveal_type(f("string"))  # revealed: Unknown
-   | ^^^^^^^^^^^^^^^^^^^^^^^^ `Unknown`
-   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___Legacy_syntax_-_Inferring_a_constrained_typevar.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___Legacy_syntax_-_Inferring_a_constrained_typevar.snap
@@ -71,6 +71,18 @@ info: revealed-type: Revealed type
 ```
 
 ```
+info: revealed-type: Revealed type
+  --> src/mdtest_snippet.py:13:1
+   |
+11 | reveal_type(f(None))  # revealed: None
+12 | # error: [invalid-argument-type]
+13 | reveal_type(f("string"))  # revealed: Unknown
+   | ^^^^^^^^^^^^^^^^^^^^^^^^ `Unknown`
+   |
+
+```
+
+```
 error: lint:invalid-argument-type: Argument to this function is incorrect
   --> src/mdtest_snippet.py:13:15
    |
@@ -90,17 +102,5 @@ info: Type variable defined here
 6 | def f(x: T) -> T:
   |
 info: `lint:invalid-argument-type` is enabled by default
-
-```
-
-```
-info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:13:1
-   |
-11 | reveal_type(f(None))  # revealed: None
-12 | # error: [invalid-argument-type]
-13 | reveal_type(f("string"))  # revealed: Unknown
-   | ^^^^^^^^^^^^^^^^^^^^^^^^ `Unknown`
-   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___PEP_695_syntax_-_Inferring_a_bound_typevar.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___PEP_695_syntax_-_Inferring_a_bound_typevar.snap
@@ -53,6 +53,18 @@ info: revealed-type: Revealed type
 ```
 
 ```
+info: revealed-type: Revealed type
+ --> src/mdtest_snippet.py:9:1
+  |
+7 | reveal_type(f(True))  # revealed: Literal[True]
+8 | # error: [invalid-argument-type]
+9 | reveal_type(f("string"))  # revealed: Unknown
+  | ^^^^^^^^^^^^^^^^^^^^^^^^ `Unknown`
+  |
+
+```
+
+```
 error: lint:invalid-argument-type: Argument to this function is incorrect
  --> src/mdtest_snippet.py:9:15
   |
@@ -71,17 +83,5 @@ info: Type variable defined here
 4 |     return x
   |
 info: `lint:invalid-argument-type` is enabled by default
-
-```
-
-```
-info: revealed-type: Revealed type
- --> src/mdtest_snippet.py:9:1
-  |
-7 | reveal_type(f(True))  # revealed: Literal[True]
-8 | # error: [invalid-argument-type]
-9 | reveal_type(f("string"))  # revealed: Unknown
-  | ^^^^^^^^^^^^^^^^^^^^^^^^ `Unknown`
-  |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___PEP_695_syntax_-_Inferring_a_constrained_typevar.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___PEP_695_syntax_-_Inferring_a_constrained_typevar.snap
@@ -68,6 +68,18 @@ info: revealed-type: Revealed type
 ```
 
 ```
+info: revealed-type: Revealed type
+  --> src/mdtest_snippet.py:10:1
+   |
+ 8 | reveal_type(f(None))  # revealed: None
+ 9 | # error: [invalid-argument-type]
+10 | reveal_type(f("string"))  # revealed: Unknown
+   | ^^^^^^^^^^^^^^^^^^^^^^^^ `Unknown`
+   |
+
+```
+
+```
 error: lint:invalid-argument-type: Argument to this function is incorrect
   --> src/mdtest_snippet.py:10:15
    |
@@ -86,17 +98,5 @@ info: Type variable defined here
 4 |     return x
   |
 info: `lint:invalid-argument-type` is enabled by default
-
-```
-
-```
-info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:10:1
-   |
- 8 | reveal_type(f(None))  # revealed: None
- 9 | # error: [invalid-argument-type]
-10 | reveal_type(f("string"))  # revealed: Unknown
-   | ^^^^^^^^^^^^^^^^^^^^^^^^ `Unknown`
-   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/mro.md_-_Method_Resolution_Order_tests_-_`__bases__`_lists_with_duplicate_bases.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/mro.md_-_Method_Resolution_Order_tests_-_`__bases__`_lists_with_duplicate_bases.snap
@@ -100,6 +100,33 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/mro.md
 # Diagnostics
 
 ```
+error: lint:duplicate-base: Duplicate base class `str`
+ --> src/mdtest_snippet.py:3:7
+  |
+1 | from typing_extensions import reveal_type
+2 |
+3 | class Foo(str, str): ...  # error: [duplicate-base] "Duplicate base class `str`"
+  |       ^^^^^^^^^^^^^
+4 |
+5 | reveal_type(Foo.__mro__)  # revealed: tuple[<class 'Foo'>, Unknown, <class 'object'>]
+  |
+info: The definition of class `Foo` will raise `TypeError` at runtime
+ --> src/mdtest_snippet.py:3:11
+  |
+1 | from typing_extensions import reveal_type
+2 |
+3 | class Foo(str, str): ...  # error: [duplicate-base] "Duplicate base class `str`"
+  |           ---  ^^^ Class `str` later repeated here
+  |           |
+  |           Class `str` first included in bases list here
+4 |
+5 | reveal_type(Foo.__mro__)  # revealed: tuple[<class 'Foo'>, Unknown, <class 'object'>]
+  |
+info: `lint:duplicate-base` is enabled by default
+
+```
+
+```
 info: revealed-type: Revealed type
  --> src/mdtest_snippet.py:5:1
   |
@@ -110,34 +137,6 @@ info: revealed-type: Revealed type
 6 |
 7 | class Spam: ...
   |
-
-```
-
-```
-info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:27:1
-   |
-25 | # fmt: on
-26 |
-27 | reveal_type(Ham.__mro__)  # revealed: tuple[<class 'Ham'>, Unknown, <class 'object'>]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^ `tuple[<class 'Ham'>, Unknown, <class 'object'>]`
-28 |
-29 | class Mushrooms: ...
-   |
-
-```
-
-```
-info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:32:1
-   |
-30 | class Omelette(Spam, Eggs, Mushrooms, Mushrooms): ...  # error: [duplicate-base]
-31 |
-32 | reveal_type(Omelette.__mro__)  # revealed: tuple[<class 'Omelette'>, Unknown, <class 'object'>]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `tuple[<class 'Omelette'>, Unknown, <class 'object'>]`
-33 |
-34 | # fmt: off
-   |
 
 ```
 
@@ -217,63 +216,16 @@ info: `lint:duplicate-base` is enabled by default
 ```
 
 ```
-error: lint:duplicate-base: Duplicate base class `A`
-  --> src/mdtest_snippet.py:76:7
+info: revealed-type: Revealed type
+  --> src/mdtest_snippet.py:27:1
    |
-75 |   # error: [duplicate-base]
-76 |   class E(
-   |  _______^
-77 | |     A,
-78 | |     A
-79 | | ):
-   | |_^
-80 |       # error: [unused-ignore-comment]
-81 |       x: int  # type: ignore[duplicate-base]
+25 | # fmt: on
+26 |
+27 | reveal_type(Ham.__mro__)  # revealed: tuple[<class 'Ham'>, Unknown, <class 'object'>]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^ `tuple[<class 'Ham'>, Unknown, <class 'object'>]`
+28 |
+29 | class Mushrooms: ...
    |
-info: The definition of class `E` will raise `TypeError` at runtime
-  --> src/mdtest_snippet.py:77:5
-   |
-75 | # error: [duplicate-base]
-76 | class E(
-77 |     A,
-   |     - Class `A` first included in bases list here
-78 |     A
-   |     ^ Class `A` later repeated here
-79 | ):
-80 |     # error: [unused-ignore-comment]
-   |
-info: `lint:duplicate-base` is enabled by default
-
-```
-
-```
-error: lint:duplicate-base: Duplicate base class `A`
-  --> src/mdtest_snippet.py:69:7
-   |
-68 |   # error: [duplicate-base]
-69 |   class D(
-   |  _______^
-70 | |     A,
-71 | |     # error: [unused-ignore-comment]
-72 | |     A,  # type: ignore[duplicate-base]
-73 | | ): ...
-   | |_^
-74 |
-75 |   # error: [duplicate-base]
-   |
-info: The definition of class `D` will raise `TypeError` at runtime
-  --> src/mdtest_snippet.py:70:5
-   |
-68 | # error: [duplicate-base]
-69 | class D(
-70 |     A,
-   |     - Class `A` first included in bases list here
-71 |     # error: [unused-ignore-comment]
-72 |     A,  # type: ignore[duplicate-base]
-   |     ^ Class `A` later repeated here
-73 | ): ...
-   |
-info: `lint:duplicate-base` is enabled by default
 
 ```
 
@@ -299,6 +251,20 @@ info: The definition of class `Omelette` will raise `TypeError` at runtime
 32 | reveal_type(Omelette.__mro__)  # revealed: tuple[<class 'Omelette'>, Unknown, <class 'object'>]
    |
 info: `lint:duplicate-base` is enabled by default
+
+```
+
+```
+info: revealed-type: Revealed type
+  --> src/mdtest_snippet.py:32:1
+   |
+30 | class Omelette(Spam, Eggs, Mushrooms, Mushrooms): ...  # error: [duplicate-base]
+31 |
+32 | reveal_type(Omelette.__mro__)  # revealed: tuple[<class 'Omelette'>, Unknown, <class 'object'>]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `tuple[<class 'Omelette'>, Unknown, <class 'object'>]`
+33 |
+34 | # fmt: off
+   |
 
 ```
 
@@ -348,28 +314,32 @@ info: `lint:duplicate-base` is enabled by default
 ```
 
 ```
-error: lint:duplicate-base: Duplicate base class `str`
- --> src/mdtest_snippet.py:3:7
-  |
-1 | from typing_extensions import reveal_type
-2 |
-3 | class Foo(str, str): ...  # error: [duplicate-base] "Duplicate base class `str`"
-  |       ^^^^^^^^^^^^^
-4 |
-5 | reveal_type(Foo.__mro__)  # revealed: tuple[<class 'Foo'>, Unknown, <class 'object'>]
-  |
-info: The definition of class `Foo` will raise `TypeError` at runtime
- --> src/mdtest_snippet.py:3:11
-  |
-1 | from typing_extensions import reveal_type
-2 |
-3 | class Foo(str, str): ...  # error: [duplicate-base] "Duplicate base class `str`"
-  |           ---  ^^^ Class `str` later repeated here
-  |           |
-  |           Class `str` first included in bases list here
-4 |
-5 | reveal_type(Foo.__mro__)  # revealed: tuple[<class 'Foo'>, Unknown, <class 'object'>]
-  |
+error: lint:duplicate-base: Duplicate base class `A`
+  --> src/mdtest_snippet.py:69:7
+   |
+68 |   # error: [duplicate-base]
+69 |   class D(
+   |  _______^
+70 | |     A,
+71 | |     # error: [unused-ignore-comment]
+72 | |     A,  # type: ignore[duplicate-base]
+73 | | ): ...
+   | |_^
+74 |
+75 |   # error: [duplicate-base]
+   |
+info: The definition of class `D` will raise `TypeError` at runtime
+  --> src/mdtest_snippet.py:70:5
+   |
+68 | # error: [duplicate-base]
+69 | class D(
+70 |     A,
+   |     - Class `A` first included in bases list here
+71 |     # error: [unused-ignore-comment]
+72 |     A,  # type: ignore[duplicate-base]
+   |     ^ Class `A` later repeated here
+73 | ): ...
+   |
 info: `lint:duplicate-base` is enabled by default
 
 ```
@@ -384,6 +354,36 @@ warning: lint:unused-ignore-comment
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unused blanket `type: ignore` directive
 73 | ): ...
    |
+
+```
+
+```
+error: lint:duplicate-base: Duplicate base class `A`
+  --> src/mdtest_snippet.py:76:7
+   |
+75 |   # error: [duplicate-base]
+76 |   class E(
+   |  _______^
+77 | |     A,
+78 | |     A
+79 | | ):
+   | |_^
+80 |       # error: [unused-ignore-comment]
+81 |       x: int  # type: ignore[duplicate-base]
+   |
+info: The definition of class `E` will raise `TypeError` at runtime
+  --> src/mdtest_snippet.py:77:5
+   |
+75 | # error: [duplicate-base]
+76 | class E(
+77 |     A,
+   |     - Class `A` first included in bases list here
+78 |     A
+   |     ^ Class `A` later repeated here
+79 | ):
+80 |     # error: [unused-ignore-comment]
+   |
+info: `lint:duplicate-base` is enabled by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorators_-_`@classmethod`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorators_-_`@classmethod`.snap
@@ -72,23 +72,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/overloads.md
 # Diagnostics
 
 ```
-error: lint:invalid-overload: Overloaded function `try_from3` does not use the `@classmethod` decorator consistently
-  --> src/mdtest_snippet.py:40:9
-   |
-38 |     def try_from3(cls, x: str) -> None: ...
-39 |     # error: [invalid-overload]
-40 |     def try_from3(cls, x: int | str) -> CheckClassMethod | None:
-   |         ---------
-   |         |
-   |         Missing here
-41 |         if isinstance(x, int):
-42 |             return cls(x)
-   |
-info: `lint:invalid-overload` is enabled by default
-
-```
-
-```
 error: lint:invalid-overload: Overloaded function `try_from1` does not use the `@classmethod` decorator consistently
   --> src/mdtest_snippet.py:13:9
    |
@@ -125,6 +108,23 @@ error: lint:invalid-overload: Overloaded function `try_from2` does not use the `
    |         --------- Missing here
 23 |     @overload
 24 |     @classmethod
+   |
+info: `lint:invalid-overload` is enabled by default
+
+```
+
+```
+error: lint:invalid-overload: Overloaded function `try_from3` does not use the `@classmethod` decorator consistently
+  --> src/mdtest_snippet.py:40:9
+   |
+38 |     def try_from3(cls, x: str) -> None: ...
+39 |     # error: [invalid-overload]
+40 |     def try_from3(cls, x: int | str) -> CheckClassMethod | None:
+   |         ---------
+   |         |
+   |         Missing here
+41 |         if isinstance(x, int):
+42 |             return cls(x)
    |
 info: `lint:invalid-overload` is enabled by default
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorators_-_`@final`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorators_-_`@final`.snap
@@ -66,22 +66,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/overloads.md
 
 ```
 error: lint:invalid-overload: `@final` decorator should be applied only to the overload implementation
-  --> src/mdtest_snippet.py:27:9
-   |
-25 |     def method3(self, x: str) -> str: ...
-26 |     # error: [invalid-overload]
-27 |     def method3(self, x: int | str) -> int | str:
-   |         -------
-   |         |
-   |         Implementation defined here
-28 |         return x
-   |
-info: `lint:invalid-overload` is enabled by default
-
-```
-
-```
-error: lint:invalid-overload: `@final` decorator should be applied only to the overload implementation
   --> src/mdtest_snippet.py:18:9
    |
 16 |     def method2(self, x: str) -> str: ...
@@ -91,6 +75,22 @@ error: lint:invalid-overload: `@final` decorator should be applied only to the o
    |         |
    |         Implementation defined here
 19 |         return x
+   |
+info: `lint:invalid-overload` is enabled by default
+
+```
+
+```
+error: lint:invalid-overload: `@final` decorator should be applied only to the overload implementation
+  --> src/mdtest_snippet.py:27:9
+   |
+25 |     def method3(self, x: str) -> str: ...
+26 |     # error: [invalid-overload]
+27 |     def method3(self, x: int | str) -> int | str:
+   |         -------
+   |         |
+   |         Implementation defined here
+28 |         return x
    |
 info: `lint:invalid-overload` is enabled by default
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Calls_to_protocol_classes.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Calls_to_protocol_classes.snap
@@ -42,6 +42,19 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/protocols.md
 # Diagnostics
 
 ```
+info: revealed-type: Revealed type
+ --> src/mdtest_snippet.py:4:1
+  |
+3 | # error: [call-non-callable]
+4 | reveal_type(Protocol())  # revealed: Unknown
+  | ^^^^^^^^^^^^^^^^^^^^^^^ `Unknown`
+5 |
+6 | class MyProtocol(Protocol):
+  |
+
+```
+
+```
 error: lint:call-non-callable: Object of type `typing.Protocol` is not callable
  --> src/mdtest_snippet.py:4:13
   |
@@ -57,14 +70,14 @@ info: `lint:call-non-callable` is enabled by default
 
 ```
 info: revealed-type: Revealed type
- --> src/mdtest_snippet.py:4:1
-  |
-3 | # error: [call-non-callable]
-4 | reveal_type(Protocol())  # revealed: Unknown
-  | ^^^^^^^^^^^^^^^^^^^^^^^ `Unknown`
-5 |
-6 | class MyProtocol(Protocol):
-  |
+  --> src/mdtest_snippet.py:10:1
+   |
+ 9 | # error: [call-non-callable] "Cannot instantiate class `MyProtocol`"
+10 | reveal_type(MyProtocol())  # revealed: MyProtocol
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^ `MyProtocol`
+11 |
+12 | class GenericProtocol[T](Protocol):
+   |
 
 ```
 
@@ -93,13 +106,12 @@ info: `lint:call-non-callable` is enabled by default
 
 ```
 info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:10:1
+  --> src/mdtest_snippet.py:16:1
    |
- 9 | # error: [call-non-callable] "Cannot instantiate class `MyProtocol`"
-10 | reveal_type(MyProtocol())  # revealed: MyProtocol
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^ `MyProtocol`
-11 |
-12 | class GenericProtocol[T](Protocol):
+15 | # error: [call-non-callable] "Cannot instantiate class `GenericProtocol`"
+16 | reveal_type(GenericProtocol[int]())  # revealed: GenericProtocol[int]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `GenericProtocol[int]`
+17 | class SubclassOfMyProtocol(MyProtocol): ...
    |
 
 ```
@@ -123,18 +135,6 @@ info: Protocol classes cannot be instantiated
 13 |     x: T
    |
 info: `lint:call-non-callable` is enabled by default
-
-```
-
-```
-info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:16:1
-   |
-15 | # error: [call-non-callable] "Cannot instantiate class `GenericProtocol`"
-16 | reveal_type(GenericProtocol[int]())  # revealed: GenericProtocol[int]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `GenericProtocol[int]`
-17 | class SubclassOfMyProtocol(MyProtocol): ...
-   |
 
 ```
 

--- a/crates/ty_test/src/lib.rs
+++ b/crates/ty_test/src/lib.rs
@@ -358,6 +358,7 @@ fn run_test(
                 }
             };
             diagnostics.extend(type_diagnostics.into_iter().cloned());
+            diagnostics.sort_by(|left, right|left.rendering_sort_key(db).cmp(&right.rendering_sort_key(db)));
 
             let failure = match matcher::match_file(db, test_file.file, &diagnostics) {
                 Ok(()) => None,


### PR DESCRIPTION
## Summary

ty's diagnostics are always sorted into a stable order when ty is executed on the command line. However, this sorting is not applied when the diagnostics are collected by mdtests, which can result in them being snapshotted in our tests in a different order than they would appear to users. That's quite confusing.

This PR fixes that by sorting the diagnostics collected by mdtest in the same way that we sort them when `ty` is actually executed on the command line.

## Test Plan

- `cargo test -p ty_python_semantic`
- `cargo test -p ty_project`
