### PR TITLE
[ty] Update salsa

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3237,7 +3237,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 [[package]]
 name = "salsa"
 version = "0.21.1"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=f78a641d2086695ac0ef96cbe915bf80b5a690f2#f78a641d2086695ac0ef96cbe915bf80b5a690f2"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=2c869364a9592d06fdf45c422e1e4a7265a8fe8a#2c869364a9592d06fdf45c422e1e4a7265a8fe8a"
 dependencies = [
  "boxcar",
  "compact_str",
@@ -3260,12 +3260,12 @@ dependencies = [
 [[package]]
 name = "salsa-macro-rules"
 version = "0.21.1"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=f78a641d2086695ac0ef96cbe915bf80b5a690f2#f78a641d2086695ac0ef96cbe915bf80b5a690f2"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=2c869364a9592d06fdf45c422e1e4a7265a8fe8a#2c869364a9592d06fdf45c422e1e4a7265a8fe8a"
 
 [[package]]
 name = "salsa-macros"
 version = "0.21.1"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=f78a641d2086695ac0ef96cbe915bf80b5a690f2#f78a641d2086695ac0ef96cbe915bf80b5a690f2"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=2c869364a9592d06fdf45c422e1e4a7265a8fe8a#2c869364a9592d06fdf45c422e1e4a7265a8fe8a"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ rayon = { version = "1.10.0" }
 regex = { version = "1.10.2" }
 rustc-hash = { version = "2.0.0" }
 # When updating salsa, make sure to also update the revision in `fuzz/Cargo.toml`
-salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "f78a641d2086695ac0ef96cbe915bf80b5a690f2" }
+salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "2c869364a9592d06fdf45c422e1e4a7265a8fe8a" }
 schemars = { version = "0.8.16" }
 seahash = { version = "4.1.0" }
 serde = { version = "1.0.197", features = ["derive"] }

--- a/crates/ruff_graph/src/db.rs
+++ b/crates/ruff_graph/src/db.rs
@@ -98,6 +98,4 @@ impl Db for ModuleDb {
 }
 
 #[salsa::db]
-impl salsa::Database for ModuleDb {
-    fn salsa_event(&self, _event: &dyn Fn() -> salsa::Event) {}
-}
+impl salsa::Database for ModuleDb {}

--- a/crates/ty_ide/src/db.rs
+++ b/crates/ty_ide/src/db.rs
@@ -6,7 +6,7 @@ pub trait Db: SemanticDb + Upcast<dyn SemanticDb> + Upcast<dyn SourceDb> {}
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
 
     use super::Db;
     use ruff_db::files::{File, Files};
@@ -16,6 +16,8 @@ pub(crate) mod tests {
     use ty_python_semantic::lint::{LintRegistry, RuleSelection};
     use ty_python_semantic::{default_lint_registry, Db as SemanticDb, Program};
 
+    type Events = Arc<Mutex<Vec<salsa::Event>>>;
+
     #[salsa::db]
     #[derive(Clone)]
     pub(crate) struct TestDb {
@@ -23,31 +25,35 @@ pub(crate) mod tests {
         files: Files,
         system: TestSystem,
         vendored: VendoredFileSystem,
-        events: Arc<std::sync::Mutex<Vec<salsa::Event>>>,
+        events: Events,
         rule_selection: Arc<RuleSelection>,
     }
 
     #[expect(dead_code)]
     impl TestDb {
         pub(crate) fn new() -> Self {
+            let events = Events::default();
             Self {
-                storage: salsa::Storage::default(),
+                storage: salsa::Storage::new(Some(Box::new({
+                    let events = events.clone();
+                    move |event| {
+                        tracing::trace!("event: {event:?}");
+                        let mut events = events.lock().unwrap();
+                        events.push(event);
+                    }
+                }))),
                 system: TestSystem::default(),
                 vendored: ty_vendored::file_system().clone(),
-                events: Arc::default(),
+                events,
                 files: Files::default(),
                 rule_selection: Arc::new(RuleSelection::from_registry(default_lint_registry())),
             }
         }
 
         /// Takes the salsa events.
-        ///
-        /// ## Panics
-        /// If there are any pending salsa snapshots.
         pub(crate) fn take_salsa_events(&mut self) -> Vec<salsa::Event> {
-            let inner = Arc::get_mut(&mut self.events).expect("no pending salsa snapshots");
+            let mut events = self.events.lock().unwrap();
 
-            let events = inner.get_mut().unwrap();
             std::mem::take(&mut *events)
         }
 
@@ -127,12 +133,5 @@ pub(crate) mod tests {
     impl Db for TestDb {}
 
     #[salsa::db]
-    impl salsa::Database for TestDb {
-        fn salsa_event(&self, event: &dyn Fn() -> salsa::Event) {
-            let event = event();
-            tracing::trace!("event: {event:?}");
-            let mut events = self.events.lock().unwrap();
-            events.push(event);
-        }
-    }
+    impl salsa::Database for TestDb {}
 }

--- a/crates/ty_project/src/db.rs
+++ b/crates/ty_project/src/db.rs
@@ -9,7 +9,7 @@ use ruff_db::system::System;
 use ruff_db::vendored::VendoredFileSystem;
 use ruff_db::{Db as SourceDb, Upcast};
 use salsa::plumbing::ZalsaDatabase;
-use salsa::{Cancelled, Event};
+use salsa::Cancelled;
 use ty_ide::Db as IdeDb;
 use ty_python_semantic::lint::{LintRegistry, RuleSelection};
 use ty_python_semantic::{Db as SemanticDb, Program};
@@ -37,7 +37,19 @@ impl ProjectDatabase {
     {
         let mut db = Self {
             project: None,
-            storage: salsa::Storage::default(),
+            storage: salsa::Storage::new(Some(Box::new({
+                move |event| {
+                    if !tracing::enabled!(tracing::Level::TRACE) {
+                        return;
+                    }
+
+                    if matches!(event.kind, salsa::EventKind::WillCheckCancellation) {
+                        return;
+                    }
+
+                    tracing::trace!("Salsa event: {event:?}");
+                }
+            }))),
             files: Files::default(),
             system: Arc::new(system),
         };
@@ -156,20 +168,7 @@ impl SourceDb for ProjectDatabase {
 }
 
 #[salsa::db]
-impl salsa::Database for ProjectDatabase {
-    fn salsa_event(&self, event: &dyn Fn() -> Event) {
-        if !tracing::enabled!(tracing::Level::TRACE) {
-            return;
-        }
-
-        let event = event();
-        if matches!(event.kind, salsa::EventKind::WillCheckCancellation) {
-            return;
-        }
-
-        tracing::trace!("Salsa event: {event:?}");
-    }
-}
+impl salsa::Database for ProjectDatabase {}
 
 #[salsa::db]
 impl Db for ProjectDatabase {
@@ -206,9 +205,7 @@ mod format {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use std::sync::Arc;
-
-    use salsa::Event;
+    use std::sync::{Arc, Mutex};
 
     use ruff_db::files::Files;
     use ruff_db::system::{DbWithTestSystem, System, TestSystem};
@@ -221,11 +218,13 @@ pub(crate) mod tests {
     use crate::DEFAULT_LINT_REGISTRY;
     use crate::{Project, ProjectMetadata};
 
+    type Events = Arc<Mutex<Vec<salsa::Event>>>;
+
     #[salsa::db]
     #[derive(Clone)]
     pub(crate) struct TestDb {
         storage: salsa::Storage<Self>,
-        events: Arc<std::sync::Mutex<Vec<Event>>>,
+        events: Events,
         files: Files,
         system: TestSystem,
         vendored: VendoredFileSystem,
@@ -234,12 +233,19 @@ pub(crate) mod tests {
 
     impl TestDb {
         pub(crate) fn new(project: ProjectMetadata) -> Self {
+            let events = Events::default();
             let mut db = Self {
-                storage: salsa::Storage::default(),
+                storage: salsa::Storage::new(Some(Box::new({
+                    let events = events.clone();
+                    move |event| {
+                        let mut events = events.lock().unwrap();
+                        events.push(event);
+                    }
+                }))),
                 system: TestSystem::default(),
                 vendored: ty_vendored::file_system().clone(),
                 files: Files::default(),
-                events: Arc::default(),
+                events,
                 project: None,
             };
 
@@ -251,13 +257,9 @@ pub(crate) mod tests {
 
     impl TestDb {
         /// Takes the salsa events.
-        ///
-        /// ## Panics
-        /// If there are any pending salsa snapshots.
         pub(crate) fn take_salsa_events(&mut self) -> Vec<salsa::Event> {
-            let inner = Arc::get_mut(&mut self.events).expect("no pending salsa snapshots");
+            let mut events = self.events.lock().unwrap();
 
-            let events = inner.get_mut().unwrap();
             std::mem::take(&mut *events)
         }
     }
@@ -332,10 +334,5 @@ pub(crate) mod tests {
     }
 
     #[salsa::db]
-    impl salsa::Database for TestDb {
-        fn salsa_event(&self, event: &dyn Fn() -> Event) {
-            let mut events = self.events.lock().unwrap();
-            events.push(event());
-        }
-    }
+    impl salsa::Database for TestDb {}
 }

--- a/crates/ty_test/src/db.rs
+++ b/crates/ty_test/src/db.rs
@@ -29,7 +29,11 @@ impl Db {
 
         Self {
             system: MdtestSystem::in_memory(),
-            storage: salsa::Storage::default(),
+            storage: salsa::Storage::new(Some(Box::new({
+                move |event| {
+                    tracing::trace!("event: {:?}", event);
+                }
+            }))),
             vendored: ty_vendored::file_system().clone(),
             files: Files::default(),
             rule_selection: Arc::new(rule_selection),
@@ -95,12 +99,7 @@ impl SemanticDb for Db {
 }
 
 #[salsa::db]
-impl salsa::Database for Db {
-    fn salsa_event(&self, event: &dyn Fn() -> salsa::Event) {
-        let event = event();
-        tracing::trace!("event: {:?}", event);
-    }
-}
+impl salsa::Database for Db {}
 
 impl DbWithWritableSystem for Db {
     type System = MdtestSystem;

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -30,7 +30,7 @@ ty_python_semantic = { path = "../crates/ty_python_semantic" }
 ty_vendored = { path = "../crates/ty_vendored" }
 
 libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer", default-features = false }
-salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "f78a641d2086695ac0ef96cbe915bf80b5a690f2" }
+salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "2c869364a9592d06fdf45c422e1e4a7265a8fe8a" }
 similar = { version = "2.5.0" }
 tracing = { version = "0.1.40" }
 

--- a/fuzz/fuzz_targets/ty_check_invalid_syntax.rs
+++ b/fuzz/fuzz_targets/ty_check_invalid_syntax.rs
@@ -32,17 +32,19 @@ struct TestDb {
     files: Files,
     system: TestSystem,
     vendored: VendoredFileSystem,
-    events: Arc<Mutex<Vec<salsa::Event>>>,
     rule_selection: Arc<RuleSelection>,
 }
 
 impl TestDb {
     fn new() -> Self {
         Self {
-            storage: salsa::Storage::default(),
+            storage: salsa::Storage::new(Some(Box::new({
+                move |event| {
+                    tracing::trace!("event: {:?}", event);
+                }
+            }))),
             system: TestSystem::default(),
             vendored: ty_vendored::file_system().clone(),
-            events: Arc::default(),
             files: Files::default(),
             rule_selection: RuleSelection::from_registry(default_lint_registry()).into(),
         }
@@ -103,14 +105,7 @@ impl SemanticDb for TestDb {
 }
 
 #[salsa::db]
-impl salsa::Database for TestDb {
-    fn salsa_event(&self, event: &dyn Fn() -> salsa::Event) {
-        let event = event();
-        tracing::trace!("event: {:?}", event);
-        let mut events = self.events.lock().unwrap();
-        events.push(event);
-    }
-}
+impl salsa::Database for TestDb {}
 
 fn setup_db() -> TestDb {
     let db = TestDb::new();


### PR DESCRIPTION
## Summary

* Update salsa to pull in https://github.com/salsa-rs/salsa/pull/850.
* Some refactoring of salsa event callbacks in various `Db`'s due to https://github.com/salsa-rs/salsa/pull/849

closes https://github.com/astral-sh/ty/issues/108

## Test Plan

Ran `cargo run --bin ty -- -vvv` on a test file to make sure that salsa Events are still logged.