### PR TITLE
[ty] Default to latest supported python version

### DIFF
--- a/crates/ruff_db/src/lib.rs
+++ b/crates/ruff_db/src/lib.rs
@@ -133,7 +133,7 @@ mod tests {
         }
 
         fn python_version(&self) -> ruff_python_ast::PythonVersion {
-            ruff_python_ast::PythonVersion::latest()
+            ruff_python_ast::PythonVersion::latest_ty()
         }
     }
 

--- a/crates/ruff_python_ast/src/python_version.rs
+++ b/crates/ruff_python_ast/src/python_version.rs
@@ -59,6 +59,10 @@ impl PythonVersion {
         Self::PY313
     }
 
+    pub const fn latest_ty() -> Self {
+        Self::PY313
+    }
+
     pub const fn as_tuple(self) -> (u8, u8) {
         (self.major, self.minor)
     }

--- a/crates/ty/tests/cli.rs
+++ b/crates/ty/tests/cli.rs
@@ -1310,14 +1310,14 @@ fn defaults_to_a_new_python_version() -> anyhow::Result<()> {
     // Use default (which should be latest supported)
     let case = TestCase::with_files([
         (
-            "project/ty.toml",
+            "ty.toml",
             r#"
             [environment]
             python-platform = "linux"
             "#,
         ),
         (
-            "project/main.py",
+            "main.py",
             r#"
             import os
 

--- a/crates/ty/tests/cli.rs
+++ b/crates/ty/tests/cli.rs
@@ -1,6 +1,7 @@
 use anyhow::Context;
 use insta::internals::SettingsBindDropGuard;
 use insta_cmd::{assert_cmd_snapshot, get_cargo_bin};
+use ruff_python_ast::PythonVersion;
 use std::fmt::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -1256,6 +1257,80 @@ fn can_handle_large_binop_expressions() -> anyhow::Result<()> {
       |
 
     Found 1 diagnostic
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn defaults_to_a_new_python_version() -> anyhow::Result<()> {
+    let case = TestCase::with_files([
+        (
+            "ty.toml",
+            &*format!(
+                r#"
+                [environment]
+                python-version = "{}"
+                python-platform = "linux"
+                "#,
+                PythonVersion::default()
+            ),
+        ),
+        (
+            "main.py",
+            r#"
+            import os
+
+            os.grantpt(1) # only available on unix, Python 3.13 or newer
+            "#,
+        ),
+    ])?;
+
+    assert_cmd_snapshot!(case.command(), @r"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    error: lint:unresolved-attribute: Type `<module 'os'>` has no attribute `grantpt`
+     --> main.py:4:1
+      |
+    2 | import os
+    3 |
+    4 | os.grantpt(1) # only available on unix, Python 3.13 or newer
+      | ^^^^^^^^^^
+      |
+    info: `lint:unresolved-attribute` is enabled by default
+
+    Found 1 diagnostic
+
+    ----- stderr -----
+    ");
+
+    // Use default (which should be latest supported)
+    let case = TestCase::with_files([
+        (
+            "project/ty.toml",
+            r#"
+            [environment]
+            python-platform = "linux"
+            "#,
+        ),
+        (
+            "project/main.py",
+            r#"
+            import os
+
+            os.grantpt(1) # only available on unix, Python 3.13 or newer
+            "#,
+        ),
+    ])?;
+
+    assert_cmd_snapshot!(case.command(), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    All checks passed!
 
     ----- stderr -----
     ");

--- a/crates/ty_ide/src/inlay_hints.rs
+++ b/crates/ty_ide/src/inlay_hints.rs
@@ -191,7 +191,7 @@ mod tests {
         Program::from_settings(
             &db,
             ProgramSettings {
-                python_version: PythonVersion::latest(),
+                python_version: PythonVersion::latest_ty(),
                 python_platform: PythonPlatform::default(),
                 search_paths: SearchPathSettings {
                     extra_paths: vec![],

--- a/crates/ty_ide/src/lib.rs
+++ b/crates/ty_ide/src/lib.rs
@@ -227,7 +227,7 @@ mod tests {
         Program::from_settings(
             &db,
             ProgramSettings {
-                python_version: PythonVersion::latest(),
+                python_version: PythonVersion::latest_ty(),
                 python_platform: PythonPlatform::default(),
                 search_paths: SearchPathSettings {
                     extra_paths: vec![],

--- a/crates/ty_project/src/metadata/options.rs
+++ b/crates/ty_project/src/metadata/options.rs
@@ -61,7 +61,7 @@ impl Options {
             .environment
             .as_ref()
             .and_then(|env| env.python_version.as_deref().copied())
-            .unwrap_or_default();
+            .unwrap_or(PythonVersion::latest_ty());
         let python_platform = self
             .environment
             .as_ref()

--- a/crates/ty_project/src/metadata/pyproject.rs
+++ b/crates/ty_project/src/metadata/pyproject.rs
@@ -103,7 +103,7 @@ impl Project {
         let major =
             u8::try_from(major).map_err(|_| ResolveRequiresPythonError::TooLargeMajor(major))?;
         let minor =
-            u8::try_from(minor).map_err(|_| ResolveRequiresPythonError::TooLargeMajor(minor))?;
+            u8::try_from(minor).map_err(|_| ResolveRequiresPythonError::TooLargeMinor(minor))?;
 
         Ok(Some(
             requires_python

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -2734,7 +2734,7 @@ mod tests {
 
         Program::get(&db)
             .set_python_version(&mut db)
-            .to(PythonVersion::latest());
+            .to(PythonVersion::latest_ty());
 
         for class in KnownClass::iter() {
             assert_ne!(


### PR DESCRIPTION
## Summary

Default to the latest python version if a project has no `requires-python` constraint or `environment.python-version`.

I first assumed that this would be more complicated because we would also need to respect the requires-python uppper bound.
However, this isn't necessary because the fallback behavior only applies if a project has **no** requires-python constraint
(because we error if a requires-python constraint has no lower bound).

I do think that we'll want to have two python versions once we start adding version-dependent lint rules
because we don't want that users see different diagnostics (because they could now make use of some newer syntax) 
when running `ty check --python-version <newer>` when there `requires-python` clearly states that they have to support `<older-version>`.

The way this would be implemented is that `ty` knows both a `minimal-supported-python-version` and a `python-version` option. 

Closes https://github.com/astral-sh/ty/issues/112

## Test Plan

Added CLI test


I verified that none of the projects with mypy primer changes specifies a `requires-python` constraint.
