### PR TITLE
[`airflow`] Move rules from `AIR312` to `AIR302`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_standard.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_standard.py
@@ -47,3 +47,16 @@ from airflow.operators.dummy_operator import (
 
 DummyOperator()
 EmptyOperator()
+
+from airflow.hooks.subprocess import SubprocessResult
+SubprocessResult()
+from airflow.hooks.subprocess import working_directory
+working_directory()
+from airflow.operators.datetime import target_times_as_dates
+target_times_as_dates()
+from airflow.operators.trigger_dagrun import TriggerDagRunLink
+TriggerDagRunLink()
+from airflow.sensors.external_task import ExternalTaskSensorLink
+ExternalTaskSensorLink()
+from airflow.sensors.time_delta import WaitSensor
+WaitSensor()

--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR312.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR312.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from airflow.hooks.filesystem import FSHook
 from airflow.hooks.package_index import PackageIndexHook
-from airflow.hooks.subprocess import SubprocessHook, SubprocessResult, working_directory
+from airflow.hooks.subprocess import SubprocessHook
 from airflow.operators.bash import BashOperator
-from airflow.operators.datetime import BranchDateTimeOperator, target_times_as_dates
+from airflow.operators.datetime import BranchDateTimeOperator
 from airflow.operators.empty import EmptyOperator
 from airflow.operators.latest_only import LatestOnlyOperator
 from airflow.operators.python import (
@@ -13,16 +13,16 @@ from airflow.operators.python import (
     PythonVirtualenvOperator,
     ShortCircuitOperator,
 )
-from airflow.operators.trigger_dagrun import TriggerDagRunLink, TriggerDagRunOperator
+from airflow.operators.trigger_dagrun import TriggerDagRunOperator
 from airflow.operators.weekday import BranchDayOfWeekOperator
 from airflow.sensors.date_time import DateTimeSensor, DateTimeSensorAsync
 from airflow.sensors.external_task import (
     ExternalTaskMarker,
     ExternalTaskSensor,
-    ExternalTaskSensorLink,
+
 )
 from airflow.sensors.filesystem import FileSensor
-from airflow.sensors.time_delta import TimeDeltaSensor, TimeDeltaSensorAsync, WaitSensor
+from airflow.sensors.time_delta import TimeDeltaSensor, TimeDeltaSensorAsync
 from airflow.sensors.time_sensor import TimeSensor, TimeSensorAsync
 from airflow.sensors.weekday import DayOfWeekSensor
 from airflow.triggers.external_task import DagStateTrigger, WorkflowTrigger
@@ -31,10 +31,10 @@ from airflow.triggers.temporal import DateTimeTrigger, TimeDeltaTrigger
 
 FSHook()
 PackageIndexHook()
-SubprocessHook(), SubprocessResult(), working_directory()
+SubprocessHook()
 BashOperator()
-BranchDateTimeOperator(), target_times_as_dates()
-TriggerDagRunLink(), TriggerDagRunOperator()
+BranchDateTimeOperator()
+TriggerDagRunOperator()
 EmptyOperator()
 LatestOnlyOperator()
 (
@@ -45,10 +45,10 @@ LatestOnlyOperator()
 )
 BranchDayOfWeekOperator()
 DateTimeSensor(), DateTimeSensorAsync()
-ExternalTaskMarker(), ExternalTaskSensor(), ExternalTaskSensorLink()
+ExternalTaskMarker(), ExternalTaskSensor()
 FileSensor()
 TimeSensor(), TimeSensorAsync()
-TimeDeltaSensor(), TimeDeltaSensorAsync(), WaitSensor()
+TimeDeltaSensor(), TimeDeltaSensorAsync()
 DayOfWeekSensor()
 DagStateTrigger(), WorkflowTrigger()
 FileTrigger()

--- a/crates/ruff_linter/src/rules/airflow/rules/moved_to_provider_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/moved_to_provider_in_3.rs
@@ -1078,6 +1078,17 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
         },
 
         // apache-airflow-providers-standard
+        [
+            "airflow",
+            "hooks",
+            "subprocess",
+            rest @ ("SubprocessResult" | "working_directory"),
+        ] => ProviderReplacement::SourceModuleMovedToProvider {
+            name: (*rest).to_string(),
+            module: "airflow.providers.standard.hooks.subprocess",
+            provider: "standard",
+            version: "0.0.3",
+        },
         ["airflow", "operators", "bash_operator", "BashOperator"] => {
             ProviderReplacement::AutoImport {
                 module: "airflow.providers.standard.operators.bash",
@@ -1097,6 +1108,25 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             provider: "standard",
             version: "0.0.2",
         },
+        [
+            "airflow",
+            "operators",
+            "trigger_dagrun",
+            "TriggerDagRunLink",
+        ] => ProviderReplacement::AutoImport {
+            module: "airflow.providers.standard.operators.trigger_dagrun",
+            name: "TriggerDagRunLink",
+            provider: "standard",
+            version: "0.0.2",
+        },
+        ["airflow", "operators", "datetime", "target_times_as_dates"] => {
+            ProviderReplacement::AutoImport {
+                module: "airflow.providers.standard.operators.datetime",
+                name: "target_times_as_dates",
+                provider: "standard",
+                version: "0.0.1",
+            }
+        }
         [
             "airflow",
             "operators",
@@ -1136,13 +1166,30 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
         [
             "airflow",
             "sensors",
+            "external_task",
+            "ExternalTaskSensorLink",
+        ] => ProviderReplacement::AutoImport {
+            module: "airflow.providers.standard.sensors.external_task",
+            name: "ExternalDagLink",
+            provider: "standard",
+            version: "0.0.3",
+        },
+        [
+            "airflow",
+            "sensors",
             "external_task_sensor",
             rest @ ("ExternalTaskMarker" | "ExternalTaskSensor" | "ExternalTaskSensorLink"),
         ] => ProviderReplacement::SourceModuleMovedToProvider {
-            name: (*rest).to_string(),
             module: "airflow.providers.standard.sensors.external_task",
+            name: (*rest).to_string(),
             provider: "standard",
             version: "0.0.3",
+        },
+        ["airflow", "sensors", "time_delta", "WaitSensor"] => ProviderReplacement::AutoImport {
+            module: "airflow.providers.standard.sensors.time_delta",
+            name: "WaitSensor",
+            provider: "standard",
+            version: "0.0.1",
         },
 
         _ => return,

--- a/crates/ruff_linter/src/rules/airflow/rules/suggested_to_move_to_provider_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/suggested_to_move_to_provider_in_3.rs
@@ -127,14 +127,9 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
                 version: "0.0.1",
             }
         }
-        [
-            "airflow",
-            "hooks",
-            "subprocess",
-            rest @ ("SubprocessHook" | "SubprocessResult" | "working_directory"),
-        ] => ProviderReplacement::SourceModuleMovedToProvider {
-            name: (*rest).to_string(),
+        ["airflow", "hooks", "subprocess", "SubprocessHook"] => ProviderReplacement::AutoImport {
             module: "airflow.providers.standard.hooks.subprocess",
+            name: "SubprocessHook",
             provider: "standard",
             version: "0.0.3",
         },
@@ -144,25 +139,22 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             provider: "standard",
             version: "0.0.1",
         },
-        [
-            "airflow",
-            "operators",
-            "datetime",
-            rest @ ("BranchDateTimeOperator" | "target_times_as_dates"),
-        ] => ProviderReplacement::SourceModuleMovedToProvider {
-            name: (*rest).to_string(),
-            module: "airflow.providers.standard.operators.datetime",
-            provider: "standard",
-            version: "0.0.1",
-        },
+        ["airflow", "operators", "datetime", "BranchDateTimeOperator"] => {
+            ProviderReplacement::AutoImport {
+                module: "airflow.providers.standard.operators.datetime",
+                name: "BranchDateTimeOperator",
+                provider: "standard",
+                version: "0.0.1",
+            }
+        }
         [
             "airflow",
             "operators",
             "trigger_dagrun",
-            rest @ ("TriggerDagRunLink" | "TriggerDagRunOperator"),
-        ] => ProviderReplacement::SourceModuleMovedToProvider {
-            name: (*rest).to_string(),
+            "TriggerDagRunOperator",
+        ] => ProviderReplacement::AutoImport {
             module: "airflow.providers.standard.operators.trigger_dagrun",
+            name: "TriggerDagRunOperator",
             provider: "standard",
             version: "0.0.2",
         },
@@ -245,7 +237,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             "airflow",
             "sensors",
             "time_delta",
-            rest @ ("TimeDeltaSensor" | "TimeDeltaSensorAsync" | "WaitSensor"),
+            rest @ ("TimeDeltaSensor" | "TimeDeltaSensorAsync"),
         ] => ProviderReplacement::SourceModuleMovedToProvider {
             name: (*rest).to_string(),
             module: "airflow.providers.standard.sensors.time_delta",

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_standard.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_standard.py.snap
@@ -153,5 +153,80 @@ AIR302_standard.py:49:1: AIR302 `airflow.operators.dummy_operator.EmptyOperator`
 48 | DummyOperator()
 49 | EmptyOperator()
    | ^^^^^^^^^^^^^ AIR302
+50 |
+51 | from airflow.hooks.subprocess import SubprocessResult
    |
    = help: Install `apache-airflow-providers-standard>=0.0.2` and use `airflow.providers.standard.operators.empty.EmptyOperator` instead.
+
+AIR302_standard.py:52:1: AIR302 `airflow.hooks.subprocess.SubprocessResult` is moved into `standard` provider in Airflow 3.0;
+   |
+51 | from airflow.hooks.subprocess import SubprocessResult
+52 | SubprocessResult()
+   | ^^^^^^^^^^^^^^^^ AIR302
+53 | from airflow.hooks.subprocess import working_directory
+54 | working_directory()
+   |
+   = help: Install `apache-airflow-providers-standard>=0.0.3` and use `airflow.providers.standard.hooks.subprocess.SubprocessResult` instead.
+
+AIR302_standard.py:54:1: AIR302 `airflow.hooks.subprocess.working_directory` is moved into `standard` provider in Airflow 3.0;
+   |
+52 | SubprocessResult()
+53 | from airflow.hooks.subprocess import working_directory
+54 | working_directory()
+   | ^^^^^^^^^^^^^^^^^ AIR302
+55 | from airflow.operators.datetime import target_times_as_dates
+56 | target_times_as_dates()
+   |
+   = help: Install `apache-airflow-providers-standard>=0.0.3` and use `airflow.providers.standard.hooks.subprocess.working_directory` instead.
+
+AIR302_standard.py:56:1: AIR302 `airflow.operators.datetime.target_times_as_dates` is moved into `standard` provider in Airflow 3.0;
+   |
+54 | working_directory()
+55 | from airflow.operators.datetime import target_times_as_dates
+56 | target_times_as_dates()
+   | ^^^^^^^^^^^^^^^^^^^^^ AIR302
+57 | from airflow.operators.trigger_dagrun import TriggerDagRunLink
+58 | TriggerDagRunLink()
+   |
+   = help: Install `apache-airflow-providers-standard>=0.0.1` and use `airflow.providers.standard.operators.datetime.target_times_as_dates` instead.
+
+AIR302_standard.py:58:1: AIR302 `airflow.operators.trigger_dagrun.TriggerDagRunLink` is moved into `standard` provider in Airflow 3.0;
+   |
+56 | target_times_as_dates()
+57 | from airflow.operators.trigger_dagrun import TriggerDagRunLink
+58 | TriggerDagRunLink()
+   | ^^^^^^^^^^^^^^^^^ AIR302
+59 | from airflow.sensors.external_task import ExternalTaskSensorLink
+60 | ExternalTaskSensorLink()
+   |
+   = help: Install `apache-airflow-providers-standard>=0.0.2` and use `airflow.providers.standard.operators.trigger_dagrun.TriggerDagRunLink` instead.
+
+AIR302_standard.py:60:1: AIR302 [*] `airflow.sensors.external_task.ExternalTaskSensorLink` is moved into `standard` provider in Airflow 3.0;
+   |
+58 | TriggerDagRunLink()
+59 | from airflow.sensors.external_task import ExternalTaskSensorLink
+60 | ExternalTaskSensorLink()
+   | ^^^^^^^^^^^^^^^^^^^^^^ AIR302
+61 | from airflow.sensors.time_delta import WaitSensor
+62 | WaitSensor()
+   |
+   = help: Install `apache-airflow-providers-standard>=0.0.3` and use `airflow.providers.standard.sensors.external_task.ExternalDagLink` instead.
+
+ℹ Safe fix
+57 57 | from airflow.operators.trigger_dagrun import TriggerDagRunLink
+58 58 | TriggerDagRunLink()
+59 59 | from airflow.sensors.external_task import ExternalTaskSensorLink
+60    |-ExternalTaskSensorLink()
+   60 |+from airflow.providers.standard.sensors.external_task import ExternalDagLink
+   61 |+ExternalDagLink()
+61 62 | from airflow.sensors.time_delta import WaitSensor
+62 63 | WaitSensor()
+
+AIR302_standard.py:62:1: AIR302 `airflow.sensors.time_delta.WaitSensor` is moved into `standard` provider in Airflow 3.0;
+   |
+60 | ExternalTaskSensorLink()
+61 | from airflow.sensors.time_delta import WaitSensor
+62 | WaitSensor()
+   | ^^^^^^^^^^ AIR302
+   |
+   = help: Install `apache-airflow-providers-standard>=0.0.1` and use `airflow.providers.standard.sensors.time_delta.WaitSensor` instead.

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR312_AIR312.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR312_AIR312.py.snap
@@ -8,7 +8,7 @@ AIR312.py:32:1: AIR312 `airflow.hooks.filesystem.FSHook` is deprecated and moved
 32 | FSHook()
    | ^^^^^^ AIR312
 33 | PackageIndexHook()
-34 | SubprocessHook(), SubprocessResult(), working_directory()
+34 | SubprocessHook()
    |
    = help: Install `apache-airflow-providers-standard>=0.0.1` and use `airflow.providers.standard.hooks.filesystem.FSHook` instead.
 
@@ -17,7 +17,7 @@ AIR312.py:33:1: AIR312 `airflow.hooks.package_index.PackageIndexHook` is depreca
 32 | FSHook()
 33 | PackageIndexHook()
    | ^^^^^^^^^^^^^^^^ AIR312
-34 | SubprocessHook(), SubprocessResult(), working_directory()
+34 | SubprocessHook()
 35 | BashOperator()
    |
    = help: Install `apache-airflow-providers-standard>=0.0.1` and use `airflow.providers.standard.hooks.package_index.PackageIndexHook` instead.
@@ -26,85 +26,41 @@ AIR312.py:34:1: AIR312 `airflow.hooks.subprocess.SubprocessHook` is deprecated a
    |
 32 | FSHook()
 33 | PackageIndexHook()
-34 | SubprocessHook(), SubprocessResult(), working_directory()
+34 | SubprocessHook()
    | ^^^^^^^^^^^^^^ AIR312
 35 | BashOperator()
-36 | BranchDateTimeOperator(), target_times_as_dates()
+36 | BranchDateTimeOperator()
    |
    = help: Install `apache-airflow-providers-standard>=0.0.3` and use `airflow.providers.standard.hooks.subprocess.SubprocessHook` instead.
-
-AIR312.py:34:19: AIR312 `airflow.hooks.subprocess.SubprocessResult` is deprecated and moved into `standard` provider in Airflow 3.0; It still works in Airflow 3.0 but is expected to be removed in a future version.
-   |
-32 | FSHook()
-33 | PackageIndexHook()
-34 | SubprocessHook(), SubprocessResult(), working_directory()
-   |                   ^^^^^^^^^^^^^^^^ AIR312
-35 | BashOperator()
-36 | BranchDateTimeOperator(), target_times_as_dates()
-   |
-   = help: Install `apache-airflow-providers-standard>=0.0.3` and use `airflow.providers.standard.hooks.subprocess.SubprocessResult` instead.
-
-AIR312.py:34:39: AIR312 `airflow.hooks.subprocess.working_directory` is deprecated and moved into `standard` provider in Airflow 3.0; It still works in Airflow 3.0 but is expected to be removed in a future version.
-   |
-32 | FSHook()
-33 | PackageIndexHook()
-34 | SubprocessHook(), SubprocessResult(), working_directory()
-   |                                       ^^^^^^^^^^^^^^^^^ AIR312
-35 | BashOperator()
-36 | BranchDateTimeOperator(), target_times_as_dates()
-   |
-   = help: Install `apache-airflow-providers-standard>=0.0.3` and use `airflow.providers.standard.hooks.subprocess.working_directory` instead.
 
 AIR312.py:35:1: AIR312 `airflow.operators.bash.BashOperator` is deprecated and moved into `standard` provider in Airflow 3.0; It still works in Airflow 3.0 but is expected to be removed in a future version.
    |
 33 | PackageIndexHook()
-34 | SubprocessHook(), SubprocessResult(), working_directory()
+34 | SubprocessHook()
 35 | BashOperator()
    | ^^^^^^^^^^^^ AIR312
-36 | BranchDateTimeOperator(), target_times_as_dates()
-37 | TriggerDagRunLink(), TriggerDagRunOperator()
+36 | BranchDateTimeOperator()
+37 | TriggerDagRunOperator()
    |
    = help: Install `apache-airflow-providers-standard>=0.0.1` and use `airflow.providers.standard.operators.bash.BashOperator` instead.
 
 AIR312.py:36:1: AIR312 `airflow.operators.datetime.BranchDateTimeOperator` is deprecated and moved into `standard` provider in Airflow 3.0; It still works in Airflow 3.0 but is expected to be removed in a future version.
    |
-34 | SubprocessHook(), SubprocessResult(), working_directory()
+34 | SubprocessHook()
 35 | BashOperator()
-36 | BranchDateTimeOperator(), target_times_as_dates()
+36 | BranchDateTimeOperator()
    | ^^^^^^^^^^^^^^^^^^^^^^ AIR312
-37 | TriggerDagRunLink(), TriggerDagRunOperator()
+37 | TriggerDagRunOperator()
 38 | EmptyOperator()
    |
    = help: Install `apache-airflow-providers-standard>=0.0.1` and use `airflow.providers.standard.operators.datetime.BranchDateTimeOperator` instead.
 
-AIR312.py:36:27: AIR312 `airflow.operators.datetime.target_times_as_dates` is deprecated and moved into `standard` provider in Airflow 3.0; It still works in Airflow 3.0 but is expected to be removed in a future version.
-   |
-34 | SubprocessHook(), SubprocessResult(), working_directory()
-35 | BashOperator()
-36 | BranchDateTimeOperator(), target_times_as_dates()
-   |                           ^^^^^^^^^^^^^^^^^^^^^ AIR312
-37 | TriggerDagRunLink(), TriggerDagRunOperator()
-38 | EmptyOperator()
-   |
-   = help: Install `apache-airflow-providers-standard>=0.0.1` and use `airflow.providers.standard.operators.datetime.target_times_as_dates` instead.
-
-AIR312.py:37:1: AIR312 `airflow.operators.trigger_dagrun.TriggerDagRunLink` is deprecated and moved into `standard` provider in Airflow 3.0; It still works in Airflow 3.0 but is expected to be removed in a future version.
+AIR312.py:37:1: AIR312 `airflow.operators.trigger_dagrun.TriggerDagRunOperator` is deprecated and moved into `standard` provider in Airflow 3.0; It still works in Airflow 3.0 but is expected to be removed in a future version.
    |
 35 | BashOperator()
-36 | BranchDateTimeOperator(), target_times_as_dates()
-37 | TriggerDagRunLink(), TriggerDagRunOperator()
-   | ^^^^^^^^^^^^^^^^^ AIR312
-38 | EmptyOperator()
-39 | LatestOnlyOperator()
-   |
-   = help: Install `apache-airflow-providers-standard>=0.0.2` and use `airflow.providers.standard.operators.trigger_dagrun.TriggerDagRunLink` instead.
-
-AIR312.py:37:22: AIR312 `airflow.operators.trigger_dagrun.TriggerDagRunOperator` is deprecated and moved into `standard` provider in Airflow 3.0; It still works in Airflow 3.0 but is expected to be removed in a future version.
-   |
-35 | BashOperator()
-36 | BranchDateTimeOperator(), target_times_as_dates()
-37 | TriggerDagRunLink(), TriggerDagRunOperator()
-   |                      ^^^^^^^^^^^^^^^^^^^^^ AIR312
+36 | BranchDateTimeOperator()
+37 | TriggerDagRunOperator()
+   | ^^^^^^^^^^^^^^^^^^^^^ AIR312
 38 | EmptyOperator()
 39 | LatestOnlyOperator()
    |
@@ -112,8 +68,8 @@ AIR312.py:37:22: AIR312 `airflow.operators.trigger_dagrun.TriggerDagRunOperator`
 
 AIR312.py:38:1: AIR312 `airflow.operators.empty.EmptyOperator` is deprecated and moved into `standard` provider in Airflow 3.0; It still works in Airflow 3.0 but is expected to be removed in a future version.
    |
-36 | BranchDateTimeOperator(), target_times_as_dates()
-37 | TriggerDagRunLink(), TriggerDagRunOperator()
+36 | BranchDateTimeOperator()
+37 | TriggerDagRunOperator()
 38 | EmptyOperator()
    | ^^^^^^^^^^^^^ AIR312
 39 | LatestOnlyOperator()
@@ -123,7 +79,7 @@ AIR312.py:38:1: AIR312 `airflow.operators.empty.EmptyOperator` is deprecated and
 
 AIR312.py:39:1: AIR312 `airflow.operators.latest_only.LatestOnlyOperator` is deprecated and moved into `standard` provider in Airflow 3.0; It still works in Airflow 3.0 but is expected to be removed in a future version.
    |
-37 | TriggerDagRunLink(), TriggerDagRunOperator()
+37 | TriggerDagRunOperator()
 38 | EmptyOperator()
 39 | LatestOnlyOperator()
    | ^^^^^^^^^^^^^^^^^^ AIR312
@@ -183,7 +139,7 @@ AIR312.py:46:1: AIR312 `airflow.operators.weekday.BranchDayOfWeekOperator` is de
 46 | BranchDayOfWeekOperator()
    | ^^^^^^^^^^^^^^^^^^^^^^^ AIR312
 47 | DateTimeSensor(), DateTimeSensorAsync()
-48 | ExternalTaskMarker(), ExternalTaskSensor(), ExternalTaskSensorLink()
+48 | ExternalTaskMarker(), ExternalTaskSensor()
    |
    = help: Install `apache-airflow-providers-standard>=0.0.1` and use `airflow.providers.standard.operators.weekday.BranchDayOfWeekOperator` instead.
 
@@ -193,7 +149,7 @@ AIR312.py:47:1: AIR312 `airflow.sensors.date_time.DateTimeSensor` is deprecated 
 46 | BranchDayOfWeekOperator()
 47 | DateTimeSensor(), DateTimeSensorAsync()
    | ^^^^^^^^^^^^^^ AIR312
-48 | ExternalTaskMarker(), ExternalTaskSensor(), ExternalTaskSensorLink()
+48 | ExternalTaskMarker(), ExternalTaskSensor()
 49 | FileSensor()
    |
    = help: Install `apache-airflow-providers-standard>=0.0.1` and use `airflow.providers.standard.sensors.date_time.DateTimeSensor` instead.
@@ -204,7 +160,7 @@ AIR312.py:47:19: AIR312 `airflow.sensors.date_time.DateTimeSensorAsync` is depre
 46 | BranchDayOfWeekOperator()
 47 | DateTimeSensor(), DateTimeSensorAsync()
    |                   ^^^^^^^^^^^^^^^^^^^ AIR312
-48 | ExternalTaskMarker(), ExternalTaskSensor(), ExternalTaskSensorLink()
+48 | ExternalTaskMarker(), ExternalTaskSensor()
 49 | FileSensor()
    |
    = help: Install `apache-airflow-providers-standard>=0.0.1` and use `airflow.providers.standard.sensors.date_time.DateTimeSensorAsync` instead.
@@ -213,7 +169,7 @@ AIR312.py:48:1: AIR312 `airflow.sensors.external_task.ExternalTaskMarker` is dep
    |
 46 | BranchDayOfWeekOperator()
 47 | DateTimeSensor(), DateTimeSensorAsync()
-48 | ExternalTaskMarker(), ExternalTaskSensor(), ExternalTaskSensorLink()
+48 | ExternalTaskMarker(), ExternalTaskSensor()
    | ^^^^^^^^^^^^^^^^^^ AIR312
 49 | FileSensor()
 50 | TimeSensor(), TimeSensorAsync()
@@ -224,53 +180,42 @@ AIR312.py:48:23: AIR312 `airflow.sensors.external_task.ExternalTaskSensor` is de
    |
 46 | BranchDayOfWeekOperator()
 47 | DateTimeSensor(), DateTimeSensorAsync()
-48 | ExternalTaskMarker(), ExternalTaskSensor(), ExternalTaskSensorLink()
+48 | ExternalTaskMarker(), ExternalTaskSensor()
    |                       ^^^^^^^^^^^^^^^^^^ AIR312
 49 | FileSensor()
 50 | TimeSensor(), TimeSensorAsync()
    |
    = help: Install `apache-airflow-providers-standard>=0.0.3` and use `airflow.providers.standard.sensors.external_task.ExternalTaskSensor` instead.
 
-AIR312.py:48:45: AIR312 `airflow.sensors.external_task.ExternalTaskSensorLink` is deprecated and moved into `standard` provider in Airflow 3.0; It still works in Airflow 3.0 but is expected to be removed in a future version.
-   |
-46 | BranchDayOfWeekOperator()
-47 | DateTimeSensor(), DateTimeSensorAsync()
-48 | ExternalTaskMarker(), ExternalTaskSensor(), ExternalTaskSensorLink()
-   |                                             ^^^^^^^^^^^^^^^^^^^^^^ AIR312
-49 | FileSensor()
-50 | TimeSensor(), TimeSensorAsync()
-   |
-   = help: Install `apache-airflow-providers-standard>=0.0.3` and use `airflow.providers.standard.sensors.external_task.ExternalTaskSensorLink` instead.
-
 AIR312.py:49:1: AIR312 `airflow.sensors.filesystem.FileSensor` is deprecated and moved into `standard` provider in Airflow 3.0; It still works in Airflow 3.0 but is expected to be removed in a future version.
    |
 47 | DateTimeSensor(), DateTimeSensorAsync()
-48 | ExternalTaskMarker(), ExternalTaskSensor(), ExternalTaskSensorLink()
+48 | ExternalTaskMarker(), ExternalTaskSensor()
 49 | FileSensor()
    | ^^^^^^^^^^ AIR312
 50 | TimeSensor(), TimeSensorAsync()
-51 | TimeDeltaSensor(), TimeDeltaSensorAsync(), WaitSensor()
+51 | TimeDeltaSensor(), TimeDeltaSensorAsync()
    |
    = help: Install `apache-airflow-providers-standard>=0.0.2` and use `airflow.providers.standard.sensors.filesystem.FileSensor` instead.
 
 AIR312.py:50:1: AIR312 `airflow.sensors.time_sensor.TimeSensor` is deprecated and moved into `standard` provider in Airflow 3.0; It still works in Airflow 3.0 but is expected to be removed in a future version.
    |
-48 | ExternalTaskMarker(), ExternalTaskSensor(), ExternalTaskSensorLink()
+48 | ExternalTaskMarker(), ExternalTaskSensor()
 49 | FileSensor()
 50 | TimeSensor(), TimeSensorAsync()
    | ^^^^^^^^^^ AIR312
-51 | TimeDeltaSensor(), TimeDeltaSensorAsync(), WaitSensor()
+51 | TimeDeltaSensor(), TimeDeltaSensorAsync()
 52 | DayOfWeekSensor()
    |
    = help: Install `apache-airflow-providers-standard>=0.0.1` and use `airflow.providers.standard.sensors.time.TimeSensor` instead.
 
 AIR312.py:50:15: AIR312 `airflow.sensors.time_sensor.TimeSensorAsync` is deprecated and moved into `standard` provider in Airflow 3.0; It still works in Airflow 3.0 but is expected to be removed in a future version.
    |
-48 | ExternalTaskMarker(), ExternalTaskSensor(), ExternalTaskSensorLink()
+48 | ExternalTaskMarker(), ExternalTaskSensor()
 49 | FileSensor()
 50 | TimeSensor(), TimeSensorAsync()
    |               ^^^^^^^^^^^^^^^ AIR312
-51 | TimeDeltaSensor(), TimeDeltaSensorAsync(), WaitSensor()
+51 | TimeDeltaSensor(), TimeDeltaSensorAsync()
 52 | DayOfWeekSensor()
    |
    = help: Install `apache-airflow-providers-standard>=0.0.1` and use `airflow.providers.standard.sensors.time.TimeSensorAsync` instead.
@@ -279,7 +224,7 @@ AIR312.py:51:1: AIR312 `airflow.sensors.time_delta.TimeDeltaSensor` is deprecate
    |
 49 | FileSensor()
 50 | TimeSensor(), TimeSensorAsync()
-51 | TimeDeltaSensor(), TimeDeltaSensorAsync(), WaitSensor()
+51 | TimeDeltaSensor(), TimeDeltaSensorAsync()
    | ^^^^^^^^^^^^^^^ AIR312
 52 | DayOfWeekSensor()
 53 | DagStateTrigger(), WorkflowTrigger()
@@ -290,28 +235,17 @@ AIR312.py:51:20: AIR312 `airflow.sensors.time_delta.TimeDeltaSensorAsync` is dep
    |
 49 | FileSensor()
 50 | TimeSensor(), TimeSensorAsync()
-51 | TimeDeltaSensor(), TimeDeltaSensorAsync(), WaitSensor()
+51 | TimeDeltaSensor(), TimeDeltaSensorAsync()
    |                    ^^^^^^^^^^^^^^^^^^^^ AIR312
 52 | DayOfWeekSensor()
 53 | DagStateTrigger(), WorkflowTrigger()
    |
    = help: Install `apache-airflow-providers-standard>=0.0.1` and use `airflow.providers.standard.sensors.time_delta.TimeDeltaSensorAsync` instead.
 
-AIR312.py:51:44: AIR312 `airflow.sensors.time_delta.WaitSensor` is deprecated and moved into `standard` provider in Airflow 3.0; It still works in Airflow 3.0 but is expected to be removed in a future version.
-   |
-49 | FileSensor()
-50 | TimeSensor(), TimeSensorAsync()
-51 | TimeDeltaSensor(), TimeDeltaSensorAsync(), WaitSensor()
-   |                                            ^^^^^^^^^^ AIR312
-52 | DayOfWeekSensor()
-53 | DagStateTrigger(), WorkflowTrigger()
-   |
-   = help: Install `apache-airflow-providers-standard>=0.0.1` and use `airflow.providers.standard.sensors.time_delta.WaitSensor` instead.
-
 AIR312.py:52:1: AIR312 `airflow.sensors.weekday.DayOfWeekSensor` is deprecated and moved into `standard` provider in Airflow 3.0; It still works in Airflow 3.0 but is expected to be removed in a future version.
    |
 50 | TimeSensor(), TimeSensorAsync()
-51 | TimeDeltaSensor(), TimeDeltaSensorAsync(), WaitSensor()
+51 | TimeDeltaSensor(), TimeDeltaSensorAsync()
 52 | DayOfWeekSensor()
    | ^^^^^^^^^^^^^^^ AIR312
 53 | DagStateTrigger(), WorkflowTrigger()
@@ -321,7 +255,7 @@ AIR312.py:52:1: AIR312 `airflow.sensors.weekday.DayOfWeekSensor` is deprecated a
 
 AIR312.py:53:1: AIR312 `airflow.triggers.external_task.DagStateTrigger` is deprecated and moved into `standard` provider in Airflow 3.0; It still works in Airflow 3.0 but is expected to be removed in a future version.
    |
-51 | TimeDeltaSensor(), TimeDeltaSensorAsync(), WaitSensor()
+51 | TimeDeltaSensor(), TimeDeltaSensorAsync()
 52 | DayOfWeekSensor()
 53 | DagStateTrigger(), WorkflowTrigger()
    | ^^^^^^^^^^^^^^^ AIR312
@@ -332,7 +266,7 @@ AIR312.py:53:1: AIR312 `airflow.triggers.external_task.DagStateTrigger` is depre
 
 AIR312.py:53:20: AIR312 `airflow.triggers.external_task.WorkflowTrigger` is deprecated and moved into `standard` provider in Airflow 3.0; It still works in Airflow 3.0 but is expected to be removed in a future version.
    |
-51 | TimeDeltaSensor(), TimeDeltaSensorAsync(), WaitSensor()
+51 | TimeDeltaSensor(), TimeDeltaSensorAsync()
 52 | DayOfWeekSensor()
 53 | DagStateTrigger(), WorkflowTrigger()
    |                    ^^^^^^^^^^^^^^^ AIR312


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

In the later development of Airflow 3.0, backward compatibility was not added for some cases. Thus, the following rules are moved back to AIR302

* airflow.hooks.subprocess.SubprocessResult → airflow.providers.standard.hooks.subprocess.SubprocessResult
* airflow.hooks.subprocess.working_directory → airflow.providers.standard.hooks.subprocess.working_directory
* airflow.operators.datetime.target_times_as_dates → airflow.providers.standard.operators.datetime.target_times_as_dates
* airflow.operators.trigger_dagrun.TriggerDagRunLink → airflow.providers.standard.operators.trigger_dagrun.TriggerDagRunLink
* airflow.sensors.external_task.ExternalTaskSensorLink → airflow.providers.standard.sensors.external_task.ExternalDagLink (**This one contains a minor change**)
* airflow.sensors.time_delta.WaitSensor → airflow.providers.standard.sensors.time_delta.WaitSensor

## Test Plan

<!-- How was it tested? -->
