### PR TITLE
Update ty metadata

### DIFF
--- a/crates/ty/Cargo.toml
+++ b/crates/ty/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "ty"
 version = "0.0.0"
-edition.workspace = true
-rust-version.workspace = true
-homepage.workspace = true
-documentation.workspace = true
+# required for correct pypi metadata
+homepage = "https://github.com/astral-sh/ty/"
+documentation = "https://github.com/astral-sh/ty/"
 # Releases occur in this other repository!
 repository = "https://github.com/astral-sh/ty/"
+edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 


### PR DESCRIPTION
I noticed that the Homepage link on pypi is incorrect. It seems that maturin always picks the link from the crate metadata. This PR updatesu pdates the `Documentation` and `Homepage` metadata fields for the `ty` crate and points them at the ty repository. 

## Test plan

I ran `uv build` in the ty repository (after updating the ruff submodule to this commit) and verified that the `PKG-INFO` only contains links pointing to ty.

