### PR TITLE
[`airflow`] Fix `SQLTableCheckOperator` typo (`AIR302`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_common_sql.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_common_sql.py
@@ -91,14 +91,14 @@ from airflow.operators.sql import (
     BaseSQLOperator,
     BranchSQLOperator,
     SQLColumnCheckOperator,
-    SQLTablecheckOperator,
+    SQLTableCheckOperator,
     _convert_to_float_if_possible,
     parse_boolean,
 )
 
 BaseSQLOperator()
 BranchSQLOperator()
-SQLTablecheckOperator()
+SQLTableCheckOperator()
 SQLColumnCheckOperator()
 _convert_to_float_if_possible()
 parse_boolean()

--- a/crates/ruff_linter/src/rules/airflow/rules/moved_to_provider_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/moved_to_provider_in_3.rs
@@ -288,7 +288,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             }
         }
         ["airflow", "operators", "sql", rest] => match *rest {
-            "BaseSQLOperator" | "BranchSQLOperator" | "SQLTablecheckOperator" => {
+            "BaseSQLOperator" | "BranchSQLOperator" | "SQLTableCheckOperator" => {
                 ProviderReplacement::SourceModuleMovedToProvider {
                     name: (*rest).to_string(),
                     module: "airflow.providers.common.sql.operators.sql",

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_common_sql.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_common_sql.py.snap
@@ -216,7 +216,7 @@ AIR302_common_sql.py:99:1: AIR302 `airflow.operators.sql.BaseSQLOperator` is mov
  99 | BaseSQLOperator()
     | ^^^^^^^^^^^^^^^ AIR302
 100 | BranchSQLOperator()
-101 | SQLTablecheckOperator()
+101 | SQLTableCheckOperator()
     |
     = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.BaseSQLOperator` instead.
 
@@ -225,26 +225,26 @@ AIR302_common_sql.py:100:1: AIR302 `airflow.operators.sql.BranchSQLOperator` is 
  99 | BaseSQLOperator()
 100 | BranchSQLOperator()
     | ^^^^^^^^^^^^^^^^^ AIR302
-101 | SQLTablecheckOperator()
+101 | SQLTableCheckOperator()
 102 | SQLColumnCheckOperator()
     |
     = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.BranchSQLOperator` instead.
 
-AIR302_common_sql.py:101:1: AIR302 `airflow.operators.sql.SQLTablecheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302_common_sql.py:101:1: AIR302 `airflow.operators.sql.SQLTableCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
  99 | BaseSQLOperator()
 100 | BranchSQLOperator()
-101 | SQLTablecheckOperator()
+101 | SQLTableCheckOperator()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR302
 102 | SQLColumnCheckOperator()
 103 | _convert_to_float_if_possible()
     |
-    = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLTablecheckOperator` instead.
+    = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLTableCheckOperator` instead.
 
 AIR302_common_sql.py:102:1: AIR302 `airflow.operators.sql.SQLColumnCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
 100 | BranchSQLOperator()
-101 | SQLTablecheckOperator()
+101 | SQLTableCheckOperator()
 102 | SQLColumnCheckOperator()
     | ^^^^^^^^^^^^^^^^^^^^^^ AIR302
 103 | _convert_to_float_if_possible()
@@ -254,7 +254,7 @@ AIR302_common_sql.py:102:1: AIR302 `airflow.operators.sql.SQLColumnCheckOperator
 
 AIR302_common_sql.py:103:1: AIR302 `airflow.operators.sql._convert_to_float_if_possible` is moved into `common-sql` provider in Airflow 3.0;
     |
-101 | SQLTablecheckOperator()
+101 | SQLTableCheckOperator()
 102 | SQLColumnCheckOperator()
 103 | _convert_to_float_if_possible()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

`SQLTablecheckOperator` should be `SQLTableCheckOperator` instead

## Test Plan

<!-- How was it tested? -->

The test fixture has been updated
