### PR TITLE
[ty] Support extending `__all__` from an imported module even when the module is not an `ExprName` node

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/import/dunder_all.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/dunder_all.md
@@ -268,15 +268,25 @@ __all__ = ["foo"]
 foo = 42
 ```
 
+`exporter/sub2.py`:
+
+```py
+__all__ = ["bar"]
+
+bar = 56
+```
+
 `module.py`:
 
 ```py
 import exporter.sub
+import exporter.sub2
 
 __all__ = []
 
 if True:
     __all__.extend(exporter.sub.__all__)
+    __all__ += exporter.sub2.__all__
 ```
 
 `main.py`:
@@ -285,7 +295,7 @@ if True:
 import module
 from ty_extensions import dunder_all_names
 
-reveal_type(dunder_all_names(module))  # revealed: tuple[Literal["foo"]]
+reveal_type(dunder_all_names(module))  # revealed: tuple[Literal["bar"], Literal["foo"]]
 ```
 
 ### Extending with a list or submodule `__all__`

--- a/crates/ty_python_semantic/resources/mdtest/import/dunder_all.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/dunder_all.md
@@ -251,6 +251,43 @@ from ty_extensions import dunder_all_names
 reveal_type(dunder_all_names(exporter))
 ```
 
+### Augmenting list with a list or submodule `__all__` (2)
+
+The same again, but the submodule is an attribute expression rather than a name expression:
+
+`exporter/__init__.py`:
+
+```py
+```
+
+`exporter/sub.py`:
+
+```py
+__all__ = ["foo"]
+
+foo = 42
+```
+
+`module.py`:
+
+```py
+import exporter.sub
+
+__all__ = []
+
+if True:
+    __all__.extend(exporter.sub.__all__)
+```
+
+`main.py`:
+
+```py
+import module
+from ty_extensions import dunder_all_names
+
+reveal_type(dunder_all_names(module))  # revealed: tuple[Literal["foo"]]
+```
+
 ### Extending with a list or submodule `__all__`
 
 `subexporter.py`:

--- a/crates/ty_python_semantic/src/semantic_index.rs
+++ b/crates/ty_python_semantic/src/semantic_index.rs
@@ -387,6 +387,14 @@ impl<'db> SemanticIndex<'db> {
             .copied()
     }
 
+    pub(crate) fn is_standalone_expression(
+        &self,
+        expression_key: impl Into<ExpressionNodeKey>,
+    ) -> bool {
+        self.expressions_by_node
+            .contains_key(&expression_key.into())
+    }
+
     /// Returns the id of the scope that `node` creates.
     /// This is different from [`definition::Definition::scope`] which
     /// returns the scope in which that definition is defined in.

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -5505,7 +5505,12 @@ impl<'db> TypeInferenceBuilder<'db> {
             ctx: _,
         } = attribute;
 
-        let value_type = self.infer_expression(value);
+        let value_type = if self.index.is_standalone_expression(&**value) {
+            self.infer_standalone_expression(value)
+        } else {
+            self.infer_expression(value)
+        };
+
         let db = self.db();
 
         value_type


### PR DESCRIPTION
## Summary

This tweaks our `__all__` resolution logic so that patterns such as `__all__.extend(module.sub.sub.__all__)` are suppported (where the type of `module.sub.sub` is resolved as being a `ModuleLiteral`).

It seems like this doesn't have any impact on any mypy_primer projects, but it simplifies the code, is neutral on the benchmarks, and seems like a pretty reasonable pattern to support.

## Test Plan

added an mdtest that fails on `main`
