### PR TITLE
[ty] Add missing bitwise-operator branches for boolean and integer arithmetic

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/binary/booleans.md
+++ b/crates/ty_python_semantic/resources/mdtest/binary/booleans.md
@@ -51,6 +51,12 @@ reveal_type(a & a)  # revealed: Literal[True]
 reveal_type(a & b)  # revealed: Literal[False]
 reveal_type(b & a)  # revealed: Literal[False]
 reveal_type(b & b)  # revealed: Literal[False]
+
+# bitwise XOR
+reveal_type(a ^ a)  # revealed: Literal[False]
+reveal_type(a ^ b)  # revealed: Literal[True]
+reveal_type(b ^ a)  # revealed: Literal[True]
+reveal_type(b ^ b)  # revealed: Literal[False]
 ```
 
 ## Arithmetic with a variable

--- a/crates/ty_python_semantic/resources/mdtest/binary/integers.md
+++ b/crates/ty_python_semantic/resources/mdtest/binary/integers.md
@@ -9,6 +9,9 @@ reveal_type(3 * -1)  # revealed: Literal[-3]
 reveal_type(-3 // 3)  # revealed: Literal[-1]
 reveal_type(-3 / 3)  # revealed: float
 reveal_type(5 % 3)  # revealed: Literal[2]
+reveal_type(3 | 4)  # revealed: Literal[7]
+reveal_type(5 & 6)  # revealed: Literal[4]
+reveal_type(7 ^ 2)  # revealed: Literal[5]
 
 # error: [unsupported-operator] "Operator `+` is unsupported between objects of type `Literal[2]` and `Literal["f"]`"
 reveal_type(2 + "f")  # revealed: Unknown

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -5773,6 +5773,18 @@ impl<'db> TypeInferenceBuilder<'db> {
                 }
             }),
 
+            (Type::IntLiteral(n), Type::IntLiteral(m), ast::Operator::BitOr) => {
+                Some(Type::IntLiteral(n | m))
+            }
+
+            (Type::IntLiteral(n), Type::IntLiteral(m), ast::Operator::BitAnd) => {
+                Some(Type::IntLiteral(n & m))
+            }
+
+            (Type::IntLiteral(n), Type::IntLiteral(m), ast::Operator::BitXor) => {
+                Some(Type::IntLiteral(n ^ m))
+            }
+
             (Type::BytesLiteral(lhs), Type::BytesLiteral(rhs), ast::Operator::Add) => {
                 let bytes = [&**lhs.value(self.db()), &**rhs.value(self.db())].concat();
                 Some(Type::bytes_literal(self.db(), &bytes))
@@ -5826,6 +5838,14 @@ impl<'db> TypeInferenceBuilder<'db> {
 
             (Type::BooleanLiteral(b1), Type::BooleanLiteral(b2), ast::Operator::BitOr) => {
                 Some(Type::BooleanLiteral(b1 | b2))
+            }
+
+            (Type::BooleanLiteral(b1), Type::BooleanLiteral(b2), ast::Operator::BitAnd) => {
+                Some(Type::BooleanLiteral(b1 & b2))
+            }
+
+            (Type::BooleanLiteral(b1), Type::BooleanLiteral(b2), ast::Operator::BitXor) => {
+                Some(Type::BooleanLiteral(b1 ^ b2))
             }
 
             (Type::BooleanLiteral(bool_value), right, op) => self.infer_binary_expression_type(


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ty/issues/270

## Test Plan

mdtests
