### PR TITLE
[ty] Document configuration schema

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ exclude: |
     .github/workflows/release.yml|
     crates/ty_vendored/vendor/.*|
     crates/ty_project/resources/.*|
+    crates/ty/docs/configuration.md|
     crates/ty/docs/rules.md|
     crates/ruff_benchmark/resources/.*|
     crates/ruff_linter/resources/.*|

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2881,7 +2881,6 @@ dependencies = [
 name = "ruff_options_metadata"
 version = "0.0.0"
 dependencies = [
- "ruff_macros",
  "serde",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2583,6 +2583,7 @@ dependencies = [
  "ruff_linter",
  "ruff_macros",
  "ruff_notebook",
+ "ruff_options_metadata",
  "ruff_python_ast",
  "ruff_python_formatter",
  "ruff_python_parser",
@@ -2709,6 +2710,7 @@ dependencies = [
  "ruff_formatter",
  "ruff_linter",
  "ruff_notebook",
+ "ruff_options_metadata",
  "ruff_python_ast",
  "ruff_python_codegen",
  "ruff_python_formatter",
@@ -2873,6 +2875,14 @@ dependencies = [
  "test-case",
  "thiserror 2.0.12",
  "uuid",
+]
+
+[[package]]
+name = "ruff_options_metadata"
+version = "0.0.0"
+dependencies = [
+ "ruff_macros",
+ "serde",
 ]
 
 [[package]]
@@ -3161,6 +3171,7 @@ dependencies = [
  "ruff_graph",
  "ruff_linter",
  "ruff_macros",
+ "ruff_options_metadata",
  "ruff_python_ast",
  "ruff_python_formatter",
  "ruff_python_semantic",
@@ -4014,6 +4025,7 @@ dependencies = [
  "ruff_cache",
  "ruff_db",
  "ruff_macros",
+ "ruff_options_metadata",
  "ruff_python_ast",
  "ruff_python_formatter",
  "ruff_text_size",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ ruff_index = { path = "crates/ruff_index" }
 ruff_linter = { path = "crates/ruff_linter" }
 ruff_macros = { path = "crates/ruff_macros" }
 ruff_notebook = { path = "crates/ruff_notebook" }
+ruff_options_metadata = { path = "crates/ruff_options_metadata" }
 ruff_python_ast = { path = "crates/ruff_python_ast" }
 ruff_python_codegen = { path = "crates/ruff_python_codegen" }
 ruff_python_formatter = { path = "crates/ruff_python_formatter" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,7 +183,7 @@ wild = { version = "2" }
 zip = { version = "0.6.6", default-features = false }
 
 [workspace.metadata.cargo-shear]
-ignored = ["getrandom"]
+ignored = ["getrandom", "ruff_options_metadata"]
 
 
 [workspace.lints.rust]

--- a/crates/ruff/Cargo.toml
+++ b/crates/ruff/Cargo.toml
@@ -20,6 +20,7 @@ ruff_graph = { workspace = true, features = ["serde", "clap"] }
 ruff_linter = { workspace = true, features = ["clap"] }
 ruff_macros = { workspace = true }
 ruff_notebook = { workspace = true }
+ruff_options_metadata = { workspace = true, features = ["serde"] }
 ruff_python_ast = { workspace = true }
 ruff_python_formatter = { workspace = true }
 ruff_python_parser = { workspace = true }

--- a/crates/ruff/src/args.rs
+++ b/crates/ruff/src/args.rs
@@ -22,12 +22,12 @@ use ruff_linter::settings::types::{
     PythonVersion, UnsafeFixes,
 };
 use ruff_linter::{RuleParser, RuleSelector, RuleSelectorParser};
+use ruff_options_metadata::{OptionEntry, OptionsMetadata};
 use ruff_python_ast as ast;
 use ruff_source_file::{LineIndex, OneIndexed, PositionEncoding};
 use ruff_text_size::TextRange;
 use ruff_workspace::configuration::{Configuration, RuleSelection};
 use ruff_workspace::options::{Options, PycodestyleOptions};
-use ruff_workspace::options_base::{OptionEntry, OptionsMetadata};
 use ruff_workspace::resolver::ConfigurationTransformer;
 use rustc_hash::FxHashMap;
 use toml;

--- a/crates/ruff/src/commands/completions/config.rs
+++ b/crates/ruff/src/commands/completions/config.rs
@@ -2,10 +2,8 @@ use clap::builder::{PossibleValue, TypedValueParser, ValueParserFactory};
 use itertools::Itertools;
 use std::str::FromStr;
 
-use ruff_workspace::{
-    options::Options,
-    options_base::{OptionField, OptionSet, OptionsMetadata, Visit},
-};
+use ruff_options_metadata::{OptionField, OptionSet, OptionsMetadata, Visit};
+use ruff_workspace::options::Options;
 
 #[derive(Default)]
 struct CollectOptionsVisitor {

--- a/crates/ruff/src/commands/config.rs
+++ b/crates/ruff/src/commands/config.rs
@@ -2,8 +2,8 @@ use anyhow::{anyhow, Result};
 
 use crate::args::HelpFormat;
 
+use ruff_options_metadata::OptionsMetadata;
 use ruff_workspace::options::Options;
-use ruff_workspace::options_base::OptionsMetadata;
 
 #[expect(clippy::print_stdout)]
 pub(crate) fn config(key: Option<&str>, format: HelpFormat) -> Result<()> {

--- a/crates/ruff_dev/Cargo.toml
+++ b/crates/ruff_dev/Cargo.toml
@@ -17,6 +17,7 @@ ruff_diagnostics = { workspace = true }
 ruff_formatter = { workspace = true }
 ruff_linter = { workspace = true, features = ["schemars"] }
 ruff_notebook = { workspace = true }
+ruff_options_metadata = { workspace = true }
 ruff_python_ast = { workspace = true }
 ruff_python_codegen = { workspace = true }
 ruff_python_formatter = { workspace = true }

--- a/crates/ruff_dev/src/generate_all.rs
+++ b/crates/ruff_dev/src/generate_all.rs
@@ -41,7 +41,7 @@ pub(crate) fn main(args: &Args) -> Result<()> {
     generate_docs::main(&generate_docs::Args {
         dry_run: args.mode.is_dry_run(),
     })?;
-    generate_ty_options::main(generate_ty_options::Args { mode: args.mode })?;
+    generate_ty_options::main(&generate_ty_options::Args { mode: args.mode })?;
     generate_ty_rules::main(&generate_ty_rules::Args { mode: args.mode })?;
     Ok(())
 }

--- a/crates/ruff_dev/src/generate_all.rs
+++ b/crates/ruff_dev/src/generate_all.rs
@@ -3,7 +3,8 @@
 use anyhow::Result;
 
 use crate::{
-    generate_cli_help, generate_docs, generate_json_schema, generate_ty_rules, generate_ty_schema,
+    generate_cli_help, generate_docs, generate_json_schema, generate_ty_options, generate_ty_rules,
+    generate_ty_schema,
 };
 
 pub(crate) const REGENERATE_ALL_COMMAND: &str = "cargo dev generate-all";
@@ -40,6 +41,7 @@ pub(crate) fn main(args: &Args) -> Result<()> {
     generate_docs::main(&generate_docs::Args {
         dry_run: args.mode.is_dry_run(),
     })?;
+    generate_ty_options::main(generate_ty_options::Args { mode: args.mode })?;
     generate_ty_rules::main(&generate_ty_rules::Args { mode: args.mode })?;
     Ok(())
 }

--- a/crates/ruff_dev/src/generate_docs.rs
+++ b/crates/ruff_dev/src/generate_docs.rs
@@ -13,8 +13,8 @@ use strum::IntoEnumIterator;
 
 use ruff_diagnostics::FixAvailability;
 use ruff_linter::registry::{Linter, Rule, RuleNamespace};
+use ruff_options_metadata::{OptionEntry, OptionsMetadata};
 use ruff_workspace::options::Options;
-use ruff_workspace::options_base::{OptionEntry, OptionsMetadata};
 
 use crate::ROOT_DIR;
 

--- a/crates/ruff_dev/src/generate_rules_table.rs
+++ b/crates/ruff_dev/src/generate_rules_table.rs
@@ -11,8 +11,8 @@ use strum::IntoEnumIterator;
 use ruff_diagnostics::FixAvailability;
 use ruff_linter::registry::{Linter, Rule, RuleNamespace};
 use ruff_linter::upstream_categories::UpstreamCategoryAndPrefix;
+use ruff_options_metadata::OptionsMetadata;
 use ruff_workspace::options::Options;
-use ruff_workspace::options_base::OptionsMetadata;
 
 const FIX_SYMBOL: &str = "🛠️";
 const PREVIEW_SYMBOL: &str = "🧪";

--- a/crates/ruff_dev/src/generate_ty_options.rs
+++ b/crates/ruff_dev/src/generate_ty_options.rs
@@ -65,7 +65,7 @@ pub(crate) fn main(args: &Args) -> anyhow::Result<()> {
 fn generate_set(output: &mut String, set: Set, parents: &mut Vec<Set>) {
     match &set {
         Set::Toplevel(_) => {
-            output.push_str("### Top-level\n");
+            output.push_str("# Configuration\n");
         }
         Set::Named { name, .. } => {
             let title = parents
@@ -73,7 +73,7 @@ fn generate_set(output: &mut String, set: Set, parents: &mut Vec<Set>) {
                 .filter_map(|set| set.name())
                 .chain(std::iter::once(name.as_str()))
                 .join(".");
-            writeln!(output, "#### `{title}`\n",).unwrap();
+            writeln!(output, "## `{title}`\n",).unwrap();
         }
     }
 
@@ -136,7 +136,7 @@ impl Set {
 }
 
 fn emit_field(output: &mut String, name: &str, field: &OptionField, parents: &[Set]) {
-    let header_level = if parents.is_empty() { "####" } else { "#####" };
+    let header_level = if parents.is_empty() { "###" } else { "####" };
 
     let _ = writeln!(output, "{header_level} [`{name}`]");
 

--- a/crates/ruff_dev/src/generate_ty_options.rs
+++ b/crates/ruff_dev/src/generate_ty_options.rs
@@ -24,7 +24,7 @@ pub(crate) struct Args {
     pub(crate) mode: Mode,
 }
 
-pub(crate) fn main(args: Args) -> anyhow::Result<()> {
+pub(crate) fn main(args: &Args) -> anyhow::Result<()> {
     let mut output = String::new();
     let markdown_path = PathBuf::from(ROOT_DIR).join("crates/ty/docs/configuration.md");
 
@@ -265,4 +265,24 @@ enum ConfigurationFile {
     PyprojectToml,
     #[expect(dead_code)]
     TyToml,
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+    use std::env;
+
+    use crate::generate_all::Mode;
+
+    use super::{main, Args};
+
+    #[test]
+    fn ty_configuration_markdown_up_to_date() -> Result<()> {
+        let mode = if env::var("TY_UPDATE_SCHEMA").as_deref() == Ok("1") {
+            Mode::Write
+        } else {
+            Mode::Check
+        };
+        main(&Args { mode })
+    }
 }

--- a/crates/ruff_dev/src/generate_ty_options.rs
+++ b/crates/ruff_dev/src/generate_ty_options.rs
@@ -247,7 +247,6 @@ enum ConfigurationFile {
 #[cfg(test)]
 mod tests {
     use anyhow::Result;
-    use std::env;
 
     use crate::generate_all::Mode;
 
@@ -256,5 +255,6 @@ mod tests {
     #[test]
     fn ty_configuration_markdown_up_to_date() -> Result<()> {
         main(&Args { mode: Mode::Check })?;
+        Ok(())
     }
 }

--- a/crates/ruff_dev/src/generate_ty_options.rs
+++ b/crates/ruff_dev/src/generate_ty_options.rs
@@ -9,7 +9,6 @@ use pretty_assertions::StrComparison;
 use std::{fmt::Write, path::PathBuf};
 
 use ruff_options_metadata::{OptionField, OptionSet, OptionsMetadata, Visit};
-use ruff_python_trivia::textwrap;
 use ty_project::metadata::Options;
 
 use crate::{
@@ -165,9 +164,8 @@ fn emit_field(output: &mut String, name: &str, field: &OptionField, parents: &[S
     output.push('\n');
     let _ = writeln!(output, "**Type**: `{}`", field.value_type);
     output.push('\n');
-    output.push_str("**Example usage**:\n\n");
+    output.push_str("**Example usage** (`pyproject.toml`):\n\n");
     output.push_str(&format_example(
-        "pyproject.toml",
         &format_header(
             field.scope,
             field.example,
@@ -179,17 +177,11 @@ fn emit_field(output: &mut String, name: &str, field: &OptionField, parents: &[S
     output.push('\n');
 }
 
-fn format_example(tab_name: &str, header: &str, content: &str) -> String {
+fn format_example(header: &str, content: &str) -> String {
     if header.is_empty() {
-        format!(
-            "**{tab_name}**\n\n    ```toml\n{}\n    ```\n",
-            textwrap::indent(content, "    ")
-        )
+        format!("```toml\n{content}\n```\n",)
     } else {
-        format!(
-            "**{tab_name}**\n\n    ```toml\n    {header}\n{}\n    ```\n",
-            textwrap::indent(content, "    ")
-        )
+        format!("```toml\n{header}\n{content}\n```\n",)
     }
 }
 

--- a/crates/ruff_dev/src/generate_ty_options.rs
+++ b/crates/ruff_dev/src/generate_ty_options.rs
@@ -1,6 +1,4 @@
 //! Generate a Markdown-compatible listing of configuration options for `pyproject.toml`.
-//!
-//! Used for <https://docs.astral.sh/ruff/settings/>.
 #![allow(clippy::print_stdout, clippy::print_stderr)]
 
 use anyhow::bail;

--- a/crates/ruff_dev/src/generate_ty_options.rs
+++ b/crates/ruff_dev/src/generate_ty_options.rs
@@ -1,6 +1,8 @@
 //! Generate a Markdown-compatible listing of configuration options for `pyproject.toml`.
 //!
 //! Used for <https://docs.astral.sh/ruff/settings/>.
+#![allow(clippy::print_stdout, clippy::print_stderr)]
+
 use anyhow::bail;
 use itertools::Itertools;
 use pretty_assertions::StrComparison;
@@ -146,20 +148,12 @@ impl Set {
 
 fn emit_field(output: &mut String, name: &str, field: &OptionField, parents: &[Set]) {
     let header_level = if parents.is_empty() { "####" } else { "#####" };
-    let parents_anchor = parents.iter().filter_map(|parent| parent.name()).join("_");
 
-    if parents_anchor.is_empty() {
-        let _ = writeln!(output, "{header_level} [`{name}`](#{name}) {{: #{name} }}");
-    } else {
-        let _ =
-            writeln!(output,
-            "{header_level} [`{name}`](#{parents_anchor}_{name}) {{: #{parents_anchor}_{name} }}"
-        );
+    let _ = writeln!(output, "{header_level} [`{name}`]");
 
-        // the anchor used to just be the name, but now it's the group name
-        // for backwards compatibility, we need to keep the old anchor
-        let _ = writeln!(output, "<span id=\"{name}\"></span>");
-    }
+    // the anchor used to just be the name, but now it's the group name
+    // for backwards compatibility, we need to keep the old anchor
+    let _ = writeln!(output, "<span id=\"{name}\"></span>");
 
     output.push('\n');
 

--- a/crates/ruff_dev/src/generate_ty_options.rs
+++ b/crates/ruff_dev/src/generate_ty_options.rs
@@ -26,7 +26,8 @@ pub(crate) struct Args {
 
 pub(crate) fn main(args: &Args) -> anyhow::Result<()> {
     let mut output = String::new();
-    let markdown_path = PathBuf::from(ROOT_DIR).join("crates/ty/docs/configuration.md");
+    let file_name = "crates/ty/docs/configuration.md";
+    let markdown_path = PathBuf::from(ROOT_DIR).join(file_name);
 
     generate_set(
         &mut output,
@@ -41,30 +42,18 @@ pub(crate) fn main(args: &Args) -> anyhow::Result<()> {
         Mode::Check => {
             let current = std::fs::read_to_string(&markdown_path)?;
             if output == current {
-                println!(
-                    "Up-to-date: {markdown_path}",
-                    markdown_path = markdown_path.display()
-                );
+                println!("Up-to-date: {file_name}",);
             } else {
                 let comparison = StrComparison::new(&current, &output);
-                bail!(
-                    "{markdown_path} changed, please run `{REGENERATE_ALL_COMMAND}`:\n{comparison}",
-                    markdown_path = markdown_path.display()
-                );
+                bail!("{file_name} changed, please run `{REGENERATE_ALL_COMMAND}`:\n{comparison}",);
             }
         }
         Mode::Write => {
             let current = std::fs::read_to_string(&markdown_path)?;
             if current == output {
-                println!(
-                    "Up-to-date: {markdown_path}",
-                    markdown_path = markdown_path.display()
-                );
+                println!("Up-to-date: {file_name}",);
             } else {
-                println!(
-                    "Updating: {markdown_path}",
-                    markdown_path = markdown_path.display()
-                );
+                println!("Updating: {file_name}",);
                 std::fs::write(markdown_path, output.as_bytes())?;
             }
         }
@@ -150,10 +139,6 @@ fn emit_field(output: &mut String, name: &str, field: &OptionField, parents: &[S
     let header_level = if parents.is_empty() { "####" } else { "#####" };
 
     let _ = writeln!(output, "{header_level} [`{name}`]");
-
-    // the anchor used to just be the name, but now it's the group name
-    // for backwards compatibility, we need to keep the old anchor
-    let _ = writeln!(output, "<span id=\"{name}\"></span>");
 
     output.push('\n');
 
@@ -278,11 +263,6 @@ mod tests {
 
     #[test]
     fn ty_configuration_markdown_up_to_date() -> Result<()> {
-        let mode = if env::var("TY_UPDATE_SCHEMA").as_deref() == Ok("1") {
-            Mode::Write
-        } else {
-            Mode::Check
-        };
-        main(&Args { mode })
+        main(&Args { mode: Mode::Check })?;
     }
 }

--- a/crates/ruff_dev/src/main.rs
+++ b/crates/ruff_dev/src/main.rs
@@ -94,7 +94,7 @@ fn main() -> Result<ExitCode> {
         Command::GenerateRulesTable => println!("{}", generate_rules_table::generate()),
         Command::GenerateTyRules(args) => generate_ty_rules::main(&args)?,
         Command::GenerateOptions => println!("{}", generate_options::generate()),
-        Command::GenerateTyOptions(args) => generate_ty_options::main(args)?,
+        Command::GenerateTyOptions(args) => generate_ty_options::main(&args)?,
         Command::GenerateCliHelp(args) => generate_cli_help::main(&args)?,
         Command::GenerateDocs(args) => generate_docs::main(&args)?,
         Command::PrintAST(args) => print_ast::main(&args)?,

--- a/crates/ruff_dev/src/main.rs
+++ b/crates/ruff_dev/src/main.rs
@@ -15,6 +15,7 @@ mod generate_docs;
 mod generate_json_schema;
 mod generate_options;
 mod generate_rules_table;
+mod generate_ty_options;
 mod generate_ty_rules;
 mod generate_ty_schema;
 mod print_ast;
@@ -48,6 +49,7 @@ enum Command {
     GenerateTyRules(generate_ty_rules::Args),
     /// Generate a Markdown-compatible listing of configuration options.
     GenerateOptions,
+    GenerateTyOptions(generate_ty_options::Args),
     /// Generate CLI help.
     GenerateCliHelp(generate_cli_help::Args),
     /// Generate Markdown docs.
@@ -92,6 +94,7 @@ fn main() -> Result<ExitCode> {
         Command::GenerateRulesTable => println!("{}", generate_rules_table::generate()),
         Command::GenerateTyRules(args) => generate_ty_rules::main(&args)?,
         Command::GenerateOptions => println!("{}", generate_options::generate()),
+        Command::GenerateTyOptions(args) => generate_ty_options::main(args)?,
         Command::GenerateCliHelp(args) => generate_cli_help::main(&args)?,
         Command::GenerateDocs(args) => generate_docs::main(&args)?,
         Command::PrintAST(args) => print_ast::main(&args)?,

--- a/crates/ruff_macros/src/config.rs
+++ b/crates/ruff_macros/src/config.rs
@@ -86,8 +86,8 @@ pub(crate) fn derive_impl(input: DeriveInput) -> syn::Result<TokenStream> {
 
             Ok(quote! {
                 #[automatically_derived]
-                impl crate::options_base::OptionsMetadata for #ident {
-                    fn record(visit: &mut dyn crate::options_base::Visit) {
+                impl ruff_options_metadata::OptionsMetadata for #ident {
+                    fn record(visit: &mut dyn ruff_options_metadata::Visit) {
                         #(#output);*
                     }
 
@@ -125,7 +125,7 @@ fn handle_option_group(field: &Field) -> syn::Result<proc_macro2::TokenStream> {
                 let kebab_name = LitStr::new(&ident.to_string().replace('_', "-"), ident.span());
 
                 Ok(quote_spanned!(
-                    ident.span() => (visit.record_set(#kebab_name, crate::options_base::OptionSet::of::<#path>()))
+                    ident.span() => (visit.record_set(#kebab_name, ruff_options_metadata::OptionSet::of::<#path>()))
                 ))
             }
             _ => Err(syn::Error::new(
@@ -214,14 +214,14 @@ fn handle_option(field: &Field, attr: &Attribute) -> syn::Result<proc_macro2::To
         let note = quote_option(deprecated.note);
         let since = quote_option(deprecated.since);
 
-        quote!(Some(crate::options_base::Deprecated { since: #since, message: #note }))
+        quote!(Some(ruff_options_metadata::Deprecated { since: #since, message: #note }))
     } else {
         quote!(None)
     };
 
     Ok(quote_spanned!(
         ident.span() => {
-            visit.record_field(#kebab_name, crate::options_base::OptionField{
+            visit.record_field(#kebab_name, ruff_options_metadata::OptionField{
                 doc: &#doc,
                 default: &#default,
                 value_type: &#value_type,

--- a/crates/ruff_options_metadata/Cargo.toml
+++ b/crates/ruff_options_metadata/Cargo.toml
@@ -14,7 +14,6 @@ license = { workspace = true }
 serde = { workspace = true, optional = true }
 
 [dev-dependencies]
-ruff_macros = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/ruff_options_metadata/Cargo.toml
+++ b/crates/ruff_options_metadata/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "ruff_options_metadata"
+version = "0.0.0"
+publish = false
+authors = { workspace = true }
+edition = { workspace = true }
+rust-version = { workspace = true }
+homepage = { workspace = true }
+documentation = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
+
+[dependencies]
+serde = { workspace = true, optional = true }
+
+[dev-dependencies]
+ruff_macros = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/ruff_python_ast/src/python_version.rs
+++ b/crates/ruff_python_ast/src/python_version.rs
@@ -60,6 +60,7 @@ impl PythonVersion {
     }
 
     pub const fn latest_ty() -> Self {
+        // Make sure to update the default value for  `EnvironmentOptions::python_version` when bumping this version.
         Self::PY313
     }
 

--- a/crates/ruff_workspace/Cargo.toml
+++ b/crates/ruff_workspace/Cargo.toml
@@ -18,6 +18,7 @@ ruff_formatter = { workspace = true }
 ruff_graph = { workspace = true, features = ["serde", "schemars"] }
 ruff_linter = { workspace = true }
 ruff_macros = { workspace = true }
+ruff_options_metadata = { workspace = true }
 ruff_python_ast = { workspace = true }
 ruff_python_formatter = { workspace = true, features = ["serde"] }
 ruff_python_semantic = { workspace = true, features = ["serde"] }

--- a/crates/ruff_workspace/src/lib.rs
+++ b/crates/ruff_workspace/src/lib.rs
@@ -3,7 +3,6 @@ pub mod options;
 pub mod pyproject;
 pub mod resolver;
 
-pub mod options_base;
 mod settings;
 
 pub use settings::{FileResolverSettings, FormatterSettings, Settings};

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -6,7 +6,6 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 use strum::IntoEnumIterator;
 
-use crate::options_base::{OptionsMetadata, Visit};
 use crate::settings::LineEnding;
 use ruff_formatter::IndentStyle;
 use ruff_graph::Direction;
@@ -32,6 +31,7 @@ use ruff_linter::settings::types::{
 };
 use ruff_linter::{warn_user_once, RuleSelector};
 use ruff_macros::{CombineOptions, OptionsMetadata};
+use ruff_options_metadata::{OptionsMetadata, Visit};
 use ruff_python_ast::name::Name;
 use ruff_python_formatter::{DocstringCodeLineWidth, QuoteStyle};
 use ruff_python_semantic::NameImports;

--- a/crates/ty/docs/configuration.md
+++ b/crates/ty/docs/configuration.md
@@ -9,14 +9,12 @@ Enabled by default.
 
 **Type**: `bool`
 
-**Example usage**:
+**Example usage** (`pyproject.toml`):
 
-**pyproject.toml**
-
-    ```toml
-    [tool.ty]
-    respect-ignore-files = false
-    ```
+```toml
+[tool.ty]
+respect-ignore-files = false
+```
 
 ---
 
@@ -37,15 +35,13 @@ Valid severities are:
 
 **Type**: `dict[str, ignore | warn | error]`
 
-**Example usage**:
+**Example usage** (`pyproject.toml`):
 
-**pyproject.toml**
-
-    ```toml
-    [tool.ty.rules]
-    possibly-unresolved-reference = "warn"
-    division-by-zero = "ignore"
-    ```
+```toml
+[tool.ty.rules]
+possibly-unresolved-reference = "warn"
+division-by-zero = "ignore"
+```
 
 ---
 
@@ -61,14 +57,12 @@ or pyright's `stubPath` configuration setting.
 
 **Type**: `list[str]`
 
-**Example usage**:
+**Example usage** (`pyproject.toml`):
 
-**pyproject.toml**
-
-    ```toml
-    [tool.ty.environment]
-    extra-paths = ["~/shared/my-search-path"]
-    ```
+```toml
+[tool.ty.environment]
+extra-paths = ["~/shared/my-search-path"]
+```
 
 ---
 
@@ -85,14 +79,12 @@ This option is commonly used to specify the path to a virtual environment.
 
 **Type**: `str`
 
-**Example usage**:
+**Example usage** (`pyproject.toml`):
 
-**pyproject.toml**
-
-    ```toml
-    [tool.ty.environment]
-    python = "./.venv"
-    ```
+```toml
+[tool.ty.environment]
+python = "./.venv"
+```
 
 ---
 
@@ -113,15 +105,13 @@ If no platform is specified, ty will use the current platform:
 
 **Type**: `"win32" | "darwin" | "android" | "ios" | "linux" | str`
 
-**Example usage**:
+**Example usage** (`pyproject.toml`):
 
-**pyproject.toml**
-
-    ```toml
-    [tool.ty.environment]
-    # Tailor type stubs and conditionalized type definitions to windows.
-    python-platform = "win32"
-    ```
+```toml
+[tool.ty.environment]
+# Tailor type stubs and conditionalized type definitions to windows.
+python-platform = "win32"
+```
 
 ---
 
@@ -138,14 +128,12 @@ It will also tailor its use of type stub files, which conditionalizes type defin
 
 **Type**: `"3.7" | "3.8" | "3.9" | "3.10" | "3.11" | "3.12" | "3.13" | <major>.<minor>`
 
-**Example usage**:
+**Example usage** (`pyproject.toml`):
 
-**pyproject.toml**
-
-    ```toml
-    [tool.ty.environment]
-    python-version = "3.12"
-    ```
+```toml
+[tool.ty.environment]
+python-version = "3.12"
+```
 
 ---
 
@@ -159,14 +147,12 @@ bundled as a zip file in the binary
 
 **Type**: `str`
 
-**Example usage**:
+**Example usage** (`pyproject.toml`):
 
-**pyproject.toml**
-
-    ```toml
-    [tool.ty.environment]
-    typeshed = "/path/to/custom/typeshed"
-    ```
+```toml
+[tool.ty.environment]
+typeshed = "/path/to/custom/typeshed"
+```
 
 ---
 
@@ -180,14 +166,12 @@ The root of the project, used for finding first-party modules.
 
 **Type**: `list[str]`
 
-**Example usage**:
+**Example usage** (`pyproject.toml`):
 
-**pyproject.toml**
-
-    ```toml
-    [tool.ty.src]
-    root = ["./app"]
-    ```
+```toml
+[tool.ty.src]
+root = ["./app"]
+```
 
 ---
 
@@ -203,15 +187,13 @@ Defaults to `false`.
 
 **Type**: `bool`
 
-**Example usage**:
+**Example usage** (`pyproject.toml`):
 
-**pyproject.toml**
-
-    ```toml
-    [tool.ty.terminal]
-    # Error if ty emits any warning-level diagnostics.
-    error-on-warning = true
-    ```
+```toml
+[tool.ty.terminal]
+# Error if ty emits any warning-level diagnostics.
+error-on-warning = true
+```
 
 ---
 
@@ -225,14 +207,12 @@ Defaults to `full`.
 
 **Type**: `full | concise`
 
-**Example usage**:
+**Example usage** (`pyproject.toml`):
 
-**pyproject.toml**
-
-    ```toml
-    [tool.ty.terminal]
-    output-format = "concise"
-    ```
+```toml
+[tool.ty.terminal]
+output-format = "concise"
+```
 
 ---
 

--- a/crates/ty/docs/configuration.md
+++ b/crates/ty/docs/configuration.md
@@ -1,6 +1,5 @@
 ### Top-level
 ##### [`respect-ignore-files`]
-<span id="respect-ignore-files"></span>
 
 Whether to automatically exclude files that are ignored by `.ignore`,
 `.gitignore`, `.git/info/exclude`, and global `gitignore` files.
@@ -22,7 +21,6 @@ Enabled by default.
 ---
 
 ##### [`rules`]
-<span id="rules"></span>
 
 Configures the enabled lints and their severity.
 
@@ -45,7 +43,6 @@ Configures the enabled lints and their severity.
 #### `environment`
 
 ##### [`extra-paths`]
-<span id="extra-paths"></span>
 
 List of user-provided paths that should take first priority in the module resolution.
 Examples in other type checkers are mypy's `MYPYPATH` environment variable,
@@ -67,7 +64,6 @@ or pyright's `stubPath` configuration setting.
 ---
 
 ##### [`python`]
-<span id="python"></span>
 
 Path to the Python installation from which ty resolves type information and third-party dependencies.
 
@@ -92,7 +88,6 @@ This option is commonly used to specify the path to a virtual environment.
 ---
 
 ##### [`python-platform`]
-<span id="python-platform"></span>
 
 Specifies the target platform that will be used to analyze the source code.
 If specified, ty will tailor its use of type stub files,
@@ -122,7 +117,6 @@ If no platform is specified, ty will use the current platform:
 ---
 
 ##### [`python-version`]
-<span id="python-version"></span>
 
 Specifies the version of Python that will be used to analyze the source code.
 The version should be specified as a string in the format `M.m` where `M` is the major version
@@ -147,7 +141,6 @@ It will also tailor its use of type stub files, which conditionalizes type defin
 ---
 
 ##### [`typeshed`]
-<span id="typeshed"></span>
 
 Optional path to a "typeshed" directory on disk for us to use for standard-library types.
 If this is not provided, we will fallback to our vendored typeshed stubs for the stdlib,
@@ -171,7 +164,6 @@ bundled as a zip file in the binary
 #### `src`
 
 ##### [`root`]
-<span id="root"></span>
 
 The root of the project, used for finding first-party modules.
 
@@ -193,7 +185,6 @@ The root of the project, used for finding first-party modules.
 #### `terminal`
 
 ##### [`error-on-warning`]
-<span id="error-on-warning"></span>
 
 Use exit code 1 if there are any warning-level diagnostics.
 
@@ -216,7 +207,6 @@ Defaults to `false`.
 ---
 
 ##### [`output-format`]
-<span id="output-format"></span>
 
 The format to use for printing diagnostic messages.
 

--- a/crates/ty/docs/configuration.md
+++ b/crates/ty/docs/configuration.md
@@ -33,7 +33,7 @@ Valid severities are:
 
 **Default value**: `{...}`
 
-**Type**: `dict[str, ignore | warn | error]`
+**Type**: `dict[RuleName, "ignore" | "warn" | "error"]`
 
 **Example usage** (`pyproject.toml`):
 
@@ -91,8 +91,8 @@ python = "./.venv"
 #### [`python-platform`]
 
 Specifies the target platform that will be used to analyze the source code.
-If specified, ty will tailor its use of type stub files,
-which conditionalize type definitions based on the platform.
+If specified, ty will understand conditions based on comparisons with `sys.platform`, such
+as are commonly found in typeshed to reflect the differing contents of the standard library across platforms.
 
 If no platform is specified, ty will use the current platform:
 - `win32` for Windows
@@ -122,7 +122,9 @@ The version should be specified as a string in the format `M.m` where `M` is the
 and `m` is the minor (e.g. `"3.0"` or `"3.6"`).
 If a version is provided, ty will generate errors if the source code makes use of language features
 that are not supported in that version.
-It will also tailor its use of type stub files, which conditionalizes type definitions based on the version.
+It will also understand conditionals based on comparisons with `sys.version_info`, such
+as are commonly found in typeshed to reflect the differing contents of the standard
+library across Python versions.
 
 **Default value**: `"3.13"`
 
@@ -160,7 +162,7 @@ typeshed = "/path/to/custom/typeshed"
 
 #### [`root`]
 
-The root of the project, used for finding first-party modules.
+The root(s) of the project, used for finding first-party modules.
 
 **Default value**: `[".", "./src"]`
 

--- a/crates/ty/docs/configuration.md
+++ b/crates/ty/docs/configuration.md
@@ -1,0 +1,218 @@
+### Top-level
+The options for the project.
+
+##### [`rules`](#rules) {: #rules }
+
+Configures the enabled lints and their severity.
+
+**Default value**: `{...}`
+
+**Type**: `dict[str, ignore | warn | error]`
+
+**Example usage**:
+
+**pyproject.toml**
+
+    ```toml
+    [tool.ty.rules]
+    possibly-unresolved-reference = "warn"
+    division-by-zero = "ignore"
+    ```
+
+---
+
+#### `environment`
+
+##### [`extra-paths`](#environment_extra-paths) {: #environment_extra-paths }
+<span id="extra-paths"></span>
+
+List of user-provided paths that should take first priority in the module resolution.
+Examples in other type checkers are mypy's `MYPYPATH` environment variable,
+or pyright's `stubPath` configuration setting.
+
+**Default value**: `[]`
+
+**Type**: `list[str]`
+
+**Example usage**:
+
+**pyproject.toml**
+
+    ```toml
+    [tool.ty.environment]
+    extra-paths = ["~/shared/my-search-path"]
+    ```
+
+---
+
+##### [`python`](#environment_python) {: #environment_python }
+<span id="python"></span>
+
+Path to the Python installation from which ty resolves type information and third-party dependencies.
+
+ty will search in the path's `site-packages` directories for type information and
+third-party imports.
+
+This option is commonly used to specify the path to a virtual environment.
+
+**Default value**: `null`
+
+**Type**: `str`
+
+**Example usage**:
+
+**pyproject.toml**
+
+    ```toml
+    [tool.ty.environment]
+    python = "./.venv"
+    ```
+
+---
+
+##### [`python-platform`](#environment_python-platform) {: #environment_python-platform }
+<span id="python-platform"></span>
+
+Specifies the target platform that will be used to analyze the source code.
+If specified, ty will tailor its use of type stub files,
+which conditionalize type definitions based on the platform.
+
+If no platform is specified, ty will use the current platform:
+- `win32` for Windows
+- `darwin` for macOS
+- `android` for Android
+- `ios` for iOS
+- `linux` for everything else
+
+**Default value**: `<current-platform>`
+
+**Type**: `"win32" | "darwin" | "android" | "ios" | "linux" | str`
+
+**Example usage**:
+
+**pyproject.toml**
+
+    ```toml
+    [tool.ty.environment]
+    # Tailor type stubs and conditionalized type definitions to windows.
+    python-platform = "win32"
+    ```
+
+---
+
+##### [`python-version`](#environment_python-version) {: #environment_python-version }
+<span id="python-version"></span>
+
+Specifies the version of Python that will be used to analyze the source code.
+The version should be specified as a string in the format `M.m` where `M` is the major version
+and `m` is the minor (e.g. `"3.0"` or `"3.6"`).
+If a version is provided, ty will generate errors if the source code makes use of language features
+that are not supported in that version.
+It will also tailor its use of type stub files, which conditionalizes type definitions based on the version.
+
+**Default value**: `"3.13"`
+
+**Type**: `"3.7" | "3.8" | "3.9" | "3.10" | "3.11" | "3.12" | "3.13" | <major>.<minor>`
+
+**Example usage**:
+
+**pyproject.toml**
+
+    ```toml
+    [tool.ty.environment]
+    python-version = "3.12"
+    ```
+
+---
+
+##### [`typeshed`](#environment_typeshed) {: #environment_typeshed }
+<span id="typeshed"></span>
+
+Optional path to a "typeshed" directory on disk for us to use for standard-library types.
+If this is not provided, we will fallback to our vendored typeshed stubs for the stdlib,
+bundled as a zip file in the binary
+
+**Default value**: `null`
+
+**Type**: `str`
+
+**Example usage**:
+
+**pyproject.toml**
+
+    ```toml
+    [tool.ty.environment]
+    typeshed = "/path/to/custom/typeshed"
+    ```
+
+---
+
+#### `src`
+
+##### [`root`](#src_root) {: #src_root }
+<span id="root"></span>
+
+The root of the project, used for finding first-party modules.
+
+**Default value**: `[".", "./src"]`
+
+**Type**: `list[str]`
+
+**Example usage**:
+
+**pyproject.toml**
+
+    ```toml
+    [tool.ty.src]
+    root = ["./app"]
+    ```
+
+---
+
+#### `terminal`
+
+##### [`error-on-warning`](#terminal_error-on-warning) {: #terminal_error-on-warning }
+<span id="error-on-warning"></span>
+
+Use exit code 1 if there are any warning-level diagnostics.
+
+Defaults to `false`.
+
+**Default value**: `false`
+
+**Type**: `bool`
+
+**Example usage**:
+
+**pyproject.toml**
+
+    ```toml
+    [tool.ty.terminal]
+    # Error if ty emits any warning-level diagnostics.
+    error-on-warning = true
+    ```
+
+---
+
+##### [`output-format`](#terminal_output-format) {: #terminal_output-format }
+<span id="output-format"></span>
+
+The format to use for printing diagnostic messages.
+
+Defaults to `full`.
+
+**Default value**: `full`
+
+**Type**: `full | concise`
+
+**Example usage**:
+
+**pyproject.toml**
+
+    ```toml
+    [tool.ty.terminal]
+    output-format = "concise"
+    ```
+
+---
+

--- a/crates/ty/docs/configuration.md
+++ b/crates/ty/docs/configuration.md
@@ -1,7 +1,28 @@
 ### Top-level
-The options for the project.
+##### [`respect-ignore-files`]
+<span id="respect-ignore-files"></span>
 
-##### [`rules`](#rules) {: #rules }
+Whether to automatically exclude files that are ignored by `.ignore`,
+`.gitignore`, `.git/info/exclude`, and global `gitignore` files.
+Enabled by default.
+
+**Default value**: `true`
+
+**Type**: `bool`
+
+**Example usage**:
+
+**pyproject.toml**
+
+    ```toml
+    [tool.ty]
+    respect-ignore-files = false
+    ```
+
+---
+
+##### [`rules`]
+<span id="rules"></span>
 
 Configures the enabled lints and their severity.
 
@@ -23,7 +44,7 @@ Configures the enabled lints and their severity.
 
 #### `environment`
 
-##### [`extra-paths`](#environment_extra-paths) {: #environment_extra-paths }
+##### [`extra-paths`]
 <span id="extra-paths"></span>
 
 List of user-provided paths that should take first priority in the module resolution.
@@ -45,7 +66,7 @@ or pyright's `stubPath` configuration setting.
 
 ---
 
-##### [`python`](#environment_python) {: #environment_python }
+##### [`python`]
 <span id="python"></span>
 
 Path to the Python installation from which ty resolves type information and third-party dependencies.
@@ -70,7 +91,7 @@ This option is commonly used to specify the path to a virtual environment.
 
 ---
 
-##### [`python-platform`](#environment_python-platform) {: #environment_python-platform }
+##### [`python-platform`]
 <span id="python-platform"></span>
 
 Specifies the target platform that will be used to analyze the source code.
@@ -100,7 +121,7 @@ If no platform is specified, ty will use the current platform:
 
 ---
 
-##### [`python-version`](#environment_python-version) {: #environment_python-version }
+##### [`python-version`]
 <span id="python-version"></span>
 
 Specifies the version of Python that will be used to analyze the source code.
@@ -125,7 +146,7 @@ It will also tailor its use of type stub files, which conditionalizes type defin
 
 ---
 
-##### [`typeshed`](#environment_typeshed) {: #environment_typeshed }
+##### [`typeshed`]
 <span id="typeshed"></span>
 
 Optional path to a "typeshed" directory on disk for us to use for standard-library types.
@@ -149,7 +170,7 @@ bundled as a zip file in the binary
 
 #### `src`
 
-##### [`root`](#src_root) {: #src_root }
+##### [`root`]
 <span id="root"></span>
 
 The root of the project, used for finding first-party modules.
@@ -171,7 +192,7 @@ The root of the project, used for finding first-party modules.
 
 #### `terminal`
 
-##### [`error-on-warning`](#terminal_error-on-warning) {: #terminal_error-on-warning }
+##### [`error-on-warning`]
 <span id="error-on-warning"></span>
 
 Use exit code 1 if there are any warning-level diagnostics.
@@ -194,7 +215,7 @@ Defaults to `false`.
 
 ---
 
-##### [`output-format`](#terminal_output-format) {: #terminal_output-format }
+##### [`output-format`]
 <span id="output-format"></span>
 
 The format to use for printing diagnostic messages.

--- a/crates/ty/docs/configuration.md
+++ b/crates/ty/docs/configuration.md
@@ -26,10 +26,10 @@ See [the rules documentation](https://github.com/astral-sh/ruff/blob/main/crates
 
 Valid severities are:
 
-- `ignore`: Disable the rule.
-- `warn`: Enable the rule and create a warning diagnostic.
-- `error`: Enable the rule and create an error diagnostic.
-   ty will exit with a non-zero code if any error diagnostics are emitted.
+* `ignore`: Disable the rule.
+* `warn`: Enable the rule and create a warning diagnostic.
+* `error`: Enable the rule and create an error diagnostic.
+  ty will exit with a non-zero code if any error diagnostics are emitted.
 
 **Default value**: `{...}`
 

--- a/crates/ty/docs/configuration.md
+++ b/crates/ty/docs/configuration.md
@@ -1,5 +1,5 @@
-### Top-level
-##### [`respect-ignore-files`]
+# Configuration
+#### [`respect-ignore-files`]
 
 Whether to automatically exclude files that are ignored by `.ignore`,
 `.gitignore`, `.git/info/exclude`, and global `gitignore` files.
@@ -20,9 +20,18 @@ Enabled by default.
 
 ---
 
-##### [`rules`]
+#### [`rules`]
 
-Configures the enabled lints and their severity.
+Configures the enabled rules and their severity.
+
+See [the rules documentation](https://github.com/astral-sh/ruff/blob/main/crates/ty/docs/rules.md) for a list of all available rules.
+
+Valid severities are:
+
+- `ignore`: Disable the rule.
+- `warn`: Enable the rule and create a warning diagnostic.
+- `error`: Enable the rule and create an error diagnostic.
+   ty will exit with a non-zero code if any error diagnostics are emitted.
 
 **Default value**: `{...}`
 
@@ -40,9 +49,9 @@ Configures the enabled lints and their severity.
 
 ---
 
-#### `environment`
+## `environment`
 
-##### [`extra-paths`]
+#### [`extra-paths`]
 
 List of user-provided paths that should take first priority in the module resolution.
 Examples in other type checkers are mypy's `MYPYPATH` environment variable,
@@ -63,7 +72,7 @@ or pyright's `stubPath` configuration setting.
 
 ---
 
-##### [`python`]
+#### [`python`]
 
 Path to the Python installation from which ty resolves type information and third-party dependencies.
 
@@ -87,7 +96,7 @@ This option is commonly used to specify the path to a virtual environment.
 
 ---
 
-##### [`python-platform`]
+#### [`python-platform`]
 
 Specifies the target platform that will be used to analyze the source code.
 If specified, ty will tailor its use of type stub files,
@@ -116,7 +125,7 @@ If no platform is specified, ty will use the current platform:
 
 ---
 
-##### [`python-version`]
+#### [`python-version`]
 
 Specifies the version of Python that will be used to analyze the source code.
 The version should be specified as a string in the format `M.m` where `M` is the major version
@@ -140,7 +149,7 @@ It will also tailor its use of type stub files, which conditionalizes type defin
 
 ---
 
-##### [`typeshed`]
+#### [`typeshed`]
 
 Optional path to a "typeshed" directory on disk for us to use for standard-library types.
 If this is not provided, we will fallback to our vendored typeshed stubs for the stdlib,
@@ -161,9 +170,9 @@ bundled as a zip file in the binary
 
 ---
 
-#### `src`
+## `src`
 
-##### [`root`]
+#### [`root`]
 
 The root of the project, used for finding first-party modules.
 
@@ -182,9 +191,9 @@ The root of the project, used for finding first-party modules.
 
 ---
 
-#### `terminal`
+## `terminal`
 
-##### [`error-on-warning`]
+#### [`error-on-warning`]
 
 Use exit code 1 if there are any warning-level diagnostics.
 
@@ -206,7 +215,7 @@ Defaults to `false`.
 
 ---
 
-##### [`output-format`]
+#### [`output-format`]
 
 The format to use for printing diagnostic messages.
 

--- a/crates/ty_project/Cargo.toml
+++ b/crates/ty_project/Cargo.toml
@@ -15,6 +15,7 @@ license.workspace = true
 ruff_cache = { workspace = true }
 ruff_db = { workspace = true, features = ["cache", "serde"] }
 ruff_macros = { workspace = true }
+ruff_options_metadata = { workspace = true }
 ruff_python_ast = { workspace = true, features = ["serde"] }
 ruff_python_formatter = { workspace = true, optional = true }
 ruff_text_size = { workspace = true }
@@ -44,11 +45,7 @@ insta = { workspace = true, features = ["redactions", "ron"] }
 [features]
 default = ["zstd"]
 deflate = ["ty_vendored/deflate"]
-schemars = [
-    "dep:schemars",
-    "ruff_db/schemars",
-    "ty_python_semantic/schemars",
-]
+schemars = ["dep:schemars", "ruff_db/schemars", "ty_python_semantic/schemars"]
 zstd = ["ty_vendored/zstd"]
 format = ["ruff_python_formatter"]
 

--- a/crates/ty_project/src/metadata.rs
+++ b/crates/ty_project/src/metadata.rs
@@ -8,7 +8,7 @@ use ty_python_semantic::ProgramSettings;
 use crate::combine::Combine;
 use crate::metadata::pyproject::{Project, PyProject, PyProjectError, ResolveRequiresPythonError};
 use crate::metadata::value::ValueSource;
-use options::Options;
+pub use options::Options;
 use options::TyTomlError;
 
 mod configuration_file;

--- a/crates/ty_project/src/metadata/options.rs
+++ b/crates/ty_project/src/metadata/options.rs
@@ -14,7 +14,6 @@ use ty_python_semantic::{ProgramSettings, PythonPath, PythonPlatform, SearchPath
 
 use super::settings::{Settings, TerminalSettings};
 
-/// The options for the project.
 #[derive(
     Debug, Default, Clone, PartialEq, Eq, Combine, Serialize, Deserialize, OptionsMetadata,
 )]

--- a/crates/ty_project/src/metadata/options.rs
+++ b/crates/ty_project/src/metadata/options.rs
@@ -3,7 +3,7 @@ use crate::Db;
 use ruff_db::diagnostic::{Annotation, Diagnostic, DiagnosticFormat, DiagnosticId, Severity, Span};
 use ruff_db::files::system_path_to_file;
 use ruff_db::system::{System, SystemPath};
-use ruff_macros::Combine;
+use ruff_macros::{Combine, OptionsMetadata};
 use ruff_python_ast::PythonVersion;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
@@ -15,24 +15,48 @@ use ty_python_semantic::{ProgramSettings, PythonPath, PythonPlatform, SearchPath
 use super::settings::{Settings, TerminalSettings};
 
 /// The options for the project.
-#[derive(Debug, Default, Clone, PartialEq, Eq, Combine, Serialize, Deserialize)]
+#[derive(
+    Debug, Default, Clone, PartialEq, Eq, Combine, Serialize, Deserialize, OptionsMetadata,
+)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Options {
     /// Configures the type checking environment.
+    #[option_group]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub environment: Option<EnvironmentOptions>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[option_group]
     pub src: Option<SrcOptions>,
 
     /// Configures the enabled lints and their severity.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[option(
+        default = r#"{...}"#,
+        value_type = r#"dict[str, ignore | warn | error]"#,
+        example = r#"
+            [tool.ty.rules]
+            possibly-unresolved-reference = "warn"
+            division-by-zero = "ignore"
+        "#
+    )]
     pub rules: Option<Rules>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[option_group]
     pub terminal: Option<TerminalOptions>,
 
+    /// Whether to automatically exclude files that are ignored by `.ignore`,
+    /// `.gitignore`, `.git/info/exclude`, and global `gitignore` files.
+    /// Enabled by default.
+    #[option(
+        default = r#"true"#,
+        value_type = r#"bool"#,
+        example = r#"
+            respect-ignore-files = false
+        "#
+    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub respect_ignore_files: Option<bool>,
 }
@@ -226,17 +250,26 @@ impl Options {
     }
 }
 
-#[derive(Debug, Default, Clone, Eq, PartialEq, Combine, Serialize, Deserialize)]
+#[derive(
+    Debug, Default, Clone, Eq, PartialEq, Combine, Serialize, Deserialize, OptionsMetadata,
+)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct EnvironmentOptions {
     /// Specifies the version of Python that will be used to analyze the source code.
     /// The version should be specified as a string in the format `M.m` where `M` is the major version
-    /// and `m` is the minor (e.g. "3.0" or "3.6").
+    /// and `m` is the minor (e.g. `"3.0"` or `"3.6"`).
     /// If a version is provided, ty will generate errors if the source code makes use of language features
     /// that are not supported in that version.
     /// It will also tailor its use of type stub files, which conditionalizes type definitions based on the version.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[option(
+        default = r#""3.13""#,
+        value_type = r#""3.7" | "3.8" | "3.9" | "3.10" | "3.11" | "3.12" | "3.13" | <major>.<minor>"#,
+        example = r#"
+            python-version = "3.12"
+        "#
+    )]
     pub python_version: Option<RangedValue<PythonVersion>>,
 
     /// Specifies the target platform that will be used to analyze the source code.
@@ -250,18 +283,40 @@ pub struct EnvironmentOptions {
     /// - `ios` for iOS
     /// - `linux` for everything else
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[option(
+        default = r#"<current-platform>"#,
+        value_type = r#""win32" | "darwin" | "android" | "ios" | "linux" | str"#,
+        example = r#"
+        # Tailor type stubs and conditionalized type definitions to windows.
+        python-platform = "win32"
+        "#
+    )]
     pub python_platform: Option<RangedValue<PythonPlatform>>,
 
     /// List of user-provided paths that should take first priority in the module resolution.
-    /// Examples in other type checkers are mypy's MYPYPATH environment variable,
-    /// or pyright's stubPath configuration setting.
+    /// Examples in other type checkers are mypy's `MYPYPATH` environment variable,
+    /// or pyright's `stubPath` configuration setting.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[option(
+        default = r#"[]"#,
+        value_type = "list[str]",
+        example = r#"
+            extra-paths = ["~/shared/my-search-path"]
+        "#
+    )]
     pub extra_paths: Option<Vec<RelativePathBuf>>,
 
     /// Optional path to a "typeshed" directory on disk for us to use for standard-library types.
     /// If this is not provided, we will fallback to our vendored typeshed stubs for the stdlib,
     /// bundled as a zip file in the binary
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[option(
+        default = r#"null"#,
+        value_type = "str",
+        example = r#"
+            typeshed = "/path/to/custom/typeshed"
+        "#
+    )]
     pub typeshed: Option<RelativePathBuf>,
 
     /// Path to the Python installation from which ty resolves type information and third-party dependencies.
@@ -271,15 +326,31 @@ pub struct EnvironmentOptions {
     ///
     /// This option is commonly used to specify the path to a virtual environment.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[option(
+        default = r#"null"#,
+        value_type = "str",
+        example = r#"
+            python = "./.venv"
+        "#
+    )]
     pub python: Option<RelativePathBuf>,
 }
 
-#[derive(Debug, Default, Clone, Eq, PartialEq, Combine, Serialize, Deserialize)]
+#[derive(
+    Debug, Default, Clone, Eq, PartialEq, Combine, Serialize, Deserialize, OptionsMetadata,
+)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct SrcOptions {
     /// The root of the project, used for finding first-party modules.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[option(
+        default = r#"[".", "./src"]"#,
+        value_type = "list[str]",
+        example = r#"
+            root = ["./app"]
+        "#
+    )]
     pub root: Option<RelativePathBuf>,
 }
 
@@ -301,7 +372,9 @@ impl FromIterator<(RangedValue<String>, RangedValue<Level>)> for Rules {
     }
 }
 
-#[derive(Debug, Default, Clone, Eq, PartialEq, Combine, Serialize, Deserialize)]
+#[derive(
+    Debug, Default, Clone, Eq, PartialEq, Combine, Serialize, Deserialize, OptionsMetadata,
+)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct TerminalOptions {
@@ -309,10 +382,25 @@ pub struct TerminalOptions {
     ///
     /// Defaults to `full`.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[option(
+        default = r#"full"#,
+        value_type = "full | concise",
+        example = r#"
+            output-format = "concise"
+        "#
+    )]
     pub output_format: Option<RangedValue<DiagnosticFormat>>,
     /// Use exit code 1 if there are any warning-level diagnostics.
     ///
     /// Defaults to `false`.
+    #[option(
+        default = r#"false"#,
+        value_type = "bool",
+        example = r#"
+        # Error if ty emits any warning-level diagnostics.
+        error-on-warning = true
+        "#
+    )]
     pub error_on_warning: Option<bool>,
 }
 

--- a/crates/ty_project/src/metadata/options.rs
+++ b/crates/ty_project/src/metadata/options.rs
@@ -42,7 +42,7 @@ pub struct Options {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[option(
         default = r#"{...}"#,
-        value_type = r#"dict[str, ignore | warn | error]"#,
+        value_type = r#"dict[RuleName, "ignore" | "warn" | "error"]"#,
         example = r#"
             [tool.ty.rules]
             possibly-unresolved-reference = "warn"
@@ -269,7 +269,9 @@ pub struct EnvironmentOptions {
     /// and `m` is the minor (e.g. `"3.0"` or `"3.6"`).
     /// If a version is provided, ty will generate errors if the source code makes use of language features
     /// that are not supported in that version.
-    /// It will also tailor its use of type stub files, which conditionalizes type definitions based on the version.
+    /// It will also understand conditionals based on comparisons with `sys.version_info`, such
+    /// as are commonly found in typeshed to reflect the differing contents of the standard
+    /// library across Python versions.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[option(
         default = r#""3.13""#,
@@ -281,8 +283,8 @@ pub struct EnvironmentOptions {
     pub python_version: Option<RangedValue<PythonVersion>>,
 
     /// Specifies the target platform that will be used to analyze the source code.
-    /// If specified, ty will tailor its use of type stub files,
-    /// which conditionalize type definitions based on the platform.
+    /// If specified, ty will understand conditions based on comparisons with `sys.platform`, such
+    /// as are commonly found in typeshed to reflect the differing contents of the standard library across platforms.
     ///
     /// If no platform is specified, ty will use the current platform:
     /// - `win32` for Windows
@@ -350,7 +352,7 @@ pub struct EnvironmentOptions {
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct SrcOptions {
-    /// The root of the project, used for finding first-party modules.
+    /// The root(s) of the project, used for finding first-party modules.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[option(
         default = r#"[".", "./src"]"#,

--- a/crates/ty_project/src/metadata/options.rs
+++ b/crates/ty_project/src/metadata/options.rs
@@ -35,10 +35,10 @@ pub struct Options {
     ///
     /// Valid severities are:
     ///
-    /// - `ignore`: Disable the rule.
-    /// - `warn`: Enable the rule and create a warning diagnostic.
-    /// - `error`: Enable the rule and create an error diagnostic.
-    ///    ty will exit with a non-zero code if any error diagnostics are emitted.
+    /// * `ignore`: Disable the rule.
+    /// * `warn`: Enable the rule and create a warning diagnostic.
+    /// * `error`: Enable the rule and create an error diagnostic.
+    ///   ty will exit with a non-zero code if any error diagnostics are emitted.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[option(
         default = r#"{...}"#,

--- a/crates/ty_project/src/metadata/options.rs
+++ b/crates/ty_project/src/metadata/options.rs
@@ -29,7 +29,16 @@ pub struct Options {
     #[option_group]
     pub src: Option<SrcOptions>,
 
-    /// Configures the enabled lints and their severity.
+    /// Configures the enabled rules and their severity.
+    ///
+    /// See [the rules documentation](https://github.com/astral-sh/ruff/blob/main/crates/ty/docs/rules.md) for a list of all available rules.
+    ///
+    /// Valid severities are:
+    ///
+    /// - `ignore`: Disable the rule.
+    /// - `warn`: Enable the rule and create a warning diagnostic.
+    /// - `error`: Enable the rule and create an error diagnostic.
+    ///    ty will exit with a non-zero code if any error diagnostics are emitted.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[option(
         default = r#"{...}"#,

--- a/ty.schema.json
+++ b/ty.schema.json
@@ -22,7 +22,7 @@
       ]
     },
     "rules": {
-      "description": "Configures the enabled lints and their severity.",
+      "description": "Configures the enabled rules and their severity.\n\nSee [the rules documentation](https://github.com/astral-sh/ruff/blob/main/crates/ty/docs/rules.md) for a list of all available rules.\n\nValid severities are:\n\n- `ignore`: Disable the rule. - `warn`: Enable the rule and create a warning diagnostic. - `error`: Enable the rule and create an error diagnostic. ty will exit with a non-zero code if any error diagnostics are emitted.",
       "anyOf": [
         {
           "$ref": "#/definitions/Rules"

--- a/ty.schema.json
+++ b/ty.schema.json
@@ -95,7 +95,7 @@
           ]
         },
         "python-platform": {
-          "description": "Specifies the target platform that will be used to analyze the source code. If specified, ty will tailor its use of type stub files, which conditionalize type definitions based on the platform.\n\nIf no platform is specified, ty will use the current platform: - `win32` for Windows - `darwin` for macOS - `android` for Android - `ios` for iOS - `linux` for everything else",
+          "description": "Specifies the target platform that will be used to analyze the source code. If specified, ty will understand conditions based on comparisons with `sys.platform`, such as are commonly found in typeshed to reflect the differing contents of the standard library across platforms.\n\nIf no platform is specified, ty will use the current platform: - `win32` for Windows - `darwin` for macOS - `android` for Android - `ios` for iOS - `linux` for everything else",
           "anyOf": [
             {
               "$ref": "#/definitions/PythonPlatform"
@@ -106,7 +106,7 @@
           ]
         },
         "python-version": {
-          "description": "Specifies the version of Python that will be used to analyze the source code. The version should be specified as a string in the format `M.m` where `M` is the major version and `m` is the minor (e.g. `\"3.0\"` or `\"3.6\"`). If a version is provided, ty will generate errors if the source code makes use of language features that are not supported in that version. It will also tailor its use of type stub files, which conditionalizes type definitions based on the version.",
+          "description": "Specifies the version of Python that will be used to analyze the source code. The version should be specified as a string in the format `M.m` where `M` is the major version and `m` is the minor (e.g. `\"3.0\"` or `\"3.6\"`). If a version is provided, ty will generate errors if the source code makes use of language features that are not supported in that version. It will also understand conditionals based on comparisons with `sys.version_info`, such as are commonly found in typeshed to reflect the differing contents of the standard library across Python versions.",
           "anyOf": [
             {
               "$ref": "#/definitions/PythonVersion"
@@ -839,7 +839,7 @@
       "type": "object",
       "properties": {
         "root": {
-          "description": "The root of the project, used for finding first-party modules.",
+          "description": "The root(s) of the project, used for finding first-party modules.",
           "type": [
             "string",
             "null"

--- a/ty.schema.json
+++ b/ty.schema.json
@@ -78,7 +78,7 @@
       "type": "object",
       "properties": {
         "extra-paths": {
-          "description": "List of user-provided paths that should take first priority in the module resolution. Examples in other type checkers are mypy's MYPYPATH environment variable, or pyright's stubPath configuration setting.",
+          "description": "List of user-provided paths that should take first priority in the module resolution. Examples in other type checkers are mypy's `MYPYPATH` environment variable, or pyright's `stubPath` configuration setting.",
           "type": [
             "array",
             "null"
@@ -106,7 +106,7 @@
           ]
         },
         "python-version": {
-          "description": "Specifies the version of Python that will be used to analyze the source code. The version should be specified as a string in the format `M.m` where `M` is the major version and `m` is the minor (e.g. \"3.0\" or \"3.6\"). If a version is provided, ty will generate errors if the source code makes use of language features that are not supported in that version. It will also tailor its use of type stub files, which conditionalizes type definitions based on the version.",
+          "description": "Specifies the version of Python that will be used to analyze the source code. The version should be specified as a string in the format `M.m` where `M` is the major version and `m` is the minor (e.g. `\"3.0\"` or `\"3.6\"`). If a version is provided, ty will generate errors if the source code makes use of language features that are not supported in that version. It will also tailor its use of type stub files, which conditionalizes type definitions based on the version.",
           "anyOf": [
             {
               "$ref": "#/definitions/PythonVersion"

--- a/ty.schema.json
+++ b/ty.schema.json
@@ -22,7 +22,7 @@
       ]
     },
     "rules": {
-      "description": "Configures the enabled rules and their severity.\n\nSee [the rules documentation](https://github.com/astral-sh/ruff/blob/main/crates/ty/docs/rules.md) for a list of all available rules.\n\nValid severities are:\n\n- `ignore`: Disable the rule. - `warn`: Enable the rule and create a warning diagnostic. - `error`: Enable the rule and create an error diagnostic. ty will exit with a non-zero code if any error diagnostics are emitted.",
+      "description": "Configures the enabled rules and their severity.\n\nSee [the rules documentation](https://github.com/astral-sh/ruff/blob/main/crates/ty/docs/rules.md) for a list of all available rules.\n\nValid severities are:\n\n* `ignore`: Disable the rule. * `warn`: Enable the rule and create a warning diagnostic. * `error`: Enable the rule and create an error diagnostic. ty will exit with a non-zero code if any error diagnostics are emitted.",
       "anyOf": [
         {
           "$ref": "#/definitions/Rules"

--- a/ty.schema.json
+++ b/ty.schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Options",
-  "description": "The options for the project.",
   "type": "object",
   "properties": {
     "environment": {
@@ -16,6 +15,7 @@
       ]
     },
     "respect-ignore-files": {
+      "description": "Whether to automatically exclude files that are ignored by `.ignore`, `.gitignore`, `.git/info/exclude`, and global `gitignore` files. Enabled by default.",
       "type": [
         "boolean",
         "null"


### PR DESCRIPTION
## Summary

The ultimate goal of this PR is to have a generate documentation of ty's configuration schema. To get there, I had to

* Extract `options_base` from `ruff_workspace` into the shared `ruff_options_metadata` crate
* Derive `OptionsMetadata` for ty's `Options` struct and attribute all fields with `#[option]` or `#[option_group]`
* Copy paste ruff's dev-script that generates the options. Rename `tool.ruff` to `tool.ty`


Ideally, we'd include the schema in the `README.md`... but the readme isn't in this repository but in the ty repository. 
For now, it should be good enough if we link to the `configuration.md` from ty's `README.md`


## Test Plan

See commited markdown file
