### PR TITLE
Update `--python` to accept paths to executables in virtual environments

### DIFF
--- a/crates/ty_python_semantic/src/program.rs
+++ b/crates/ty_python_semantic/src/program.rs
@@ -145,6 +145,9 @@ pub enum PythonPath {
     /// [`sys.prefix`]: https://docs.python.org/3/library/sys.html#sys.prefix
     SysPrefix(SystemPathBuf, SysPrefixPathOrigin),
 
+    /// Resolve a path to an executable (or virtual environment) into a usable environment.
+    Resolve(SystemPathBuf, SysPrefixPathOrigin),
+
     /// Tries to discover a virtual environment in the given path.
     Discover(SystemPathBuf),
 
@@ -161,6 +164,6 @@ impl PythonPath {
     }
 
     pub fn from_cli_flag(path: SystemPathBuf) -> Self {
-        Self::SysPrefix(path, SysPrefixPathOrigin::PythonCliFlag)
+        Self::Resolve(path, SysPrefixPathOrigin::PythonCliFlag)
     }
 }


### PR DESCRIPTION
## Summary

Updates the `--python` flag to accept Python executables in virtual environments. Notably, we do not query the executable and it _must_ be in a canonical location in a virtual environment. This is pretty naive, but solves for the trivial case of `ty check --python .venv/bin/python3` which will be a common mistake.

I explored this while trying to understand Python discovery in ty in service of https://github.com/astral-sh/ty/issues/272, I'm not attached to it, but figure it's worth sharing.

As an alternative, we can add more variants to the `SearchPathValidationError` and just improve the _error_ message, i.e., by hinting that this looks like a virtual environment and suggesting the concrete alternative path they should provide. We'll probably want to do that for some other cases anyway (e.g., `3.13` as described in the linked issue)

## Test Plan

e.g.,

```
uv run ty check --python .venv/bin/python3
```

needs test coverage still
