### PR TITLE
[ty] Handle typevars that have other typevars as a default

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -1945,7 +1945,7 @@ reveal_type(C.a_complex)  # revealed: int | float | complex
 reveal_type(C.a_tuple)  # revealed: tuple[int]
 reveal_type(C.a_range)  # revealed: range
 # TODO: revealed: slice[Any, Literal[1], Any]
-reveal_type(C.a_slice)  # revealed: slice[Any, _StartT_co, _StartT_co | _StopT_co]
+reveal_type(C.a_slice)  # revealed: slice[Any, Any, Any]
 reveal_type(C.a_type)  # revealed: type
 reveal_type(C.a_none)  # revealed: None
 ```

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/variables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/variables.md
@@ -86,6 +86,26 @@ S = TypeVar("S")
 reveal_type(S.__default__)  # revealed: NoDefault
 ```
 
+### Using other typevars as a default
+
+```py
+from typing import Generic, TypeVar, Union
+
+T = TypeVar("T")
+U = TypeVar("U", default=T)
+V = TypeVar("V", default=Union[T, U])
+
+class Valid(Generic[T, U, V]): ...
+
+reveal_type(Valid())  # revealed: Valid[Unknown, Unknown, Unknown]
+reveal_type(Valid[int]())  # revealed: Valid[int, int, int]
+reveal_type(Valid[int, str]())  # revealed: Valid[int, str, int | str]
+reveal_type(Valid[int, str, None]())  # revealed: Valid[int, str, None]
+
+# TODO: error, default value for U isn't available in the generic context
+class Invalid(Generic[U]): ...
+```
+
 ### Type variables with an upper bound
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
@@ -40,6 +40,25 @@ def g[S]():
     reveal_type(S.__default__)  # revealed: NoDefault
 ```
 
+### Using other typevars as a default
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+```py
+class Valid[T, U = T, V = T | U]: ...
+
+reveal_type(Valid())  # revealed: Valid[Unknown, Unknown, Unknown]
+reveal_type(Valid[int]())  # revealed: Valid[int, int, int]
+reveal_type(Valid[int, str]())  # revealed: Valid[int, str, int | str]
+reveal_type(Valid[int, str, None]())  # revealed: Valid[int, str, None]
+
+# error: [unresolved-reference]
+class Invalid[S = T]: ...
+```
+
 ### Type variables with an upper bound
 
 ```py

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -5032,7 +5032,7 @@ impl<'db> Type<'db> {
         type_mapping: TypeMapping<'a, 'db>,
     ) -> Type<'db> {
         match self {
-            Type::TypeVar(typevar) => type_mapping.get(typevar).unwrap_or(self),
+            Type::TypeVar(typevar) => type_mapping.get(db, typevar).unwrap_or(self),
 
             Type::FunctionLiteral(function) => {
                 Type::FunctionLiteral(function.apply_type_mapping(db, type_mapping))
@@ -6925,19 +6925,7 @@ impl<'db> FunctionType<'db> {
 
 impl<'db> Specialize<'db> for FunctionType<'db> {
     fn apply_type_mapping<'a>(&self, db: &'db dyn Db, type_mapping: TypeMapping<'a, 'db>) -> Self {
-        let specialization = self
-            .specialization(db)
-            .map(|existing| existing.apply_type_mapping(db, type_mapping));
-        Self::new(
-            db,
-            self.name(db).clone(),
-            self.known(db),
-            self.body_scope(db),
-            self.decorators(db),
-            self.dataclass_transformer_params(db),
-            self.inherited_generic_context(db),
-            specialization,
-        )
+        self.apply_specialization(db, type_mapping.into_specialization(db))
     }
 
     fn apply_specialization(&self, db: &'db dyn Db, specialization: Specialization<'db>) -> Self {

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -5039,7 +5039,7 @@ impl<'db> Type<'db> {
     /// via a call to the generic object.
     #[must_use]
     #[salsa::tracked]
-    fn apply_specialization(
+    pub fn apply_specialization(
         self,
         db: &'db dyn Db,
         specialization: Specialization<'db>,

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -45,7 +45,7 @@ use crate::types::call::{Bindings, CallArgumentTypes, CallableBinding};
 pub(crate) use crate::types::class_base::ClassBase;
 use crate::types::context::{LintDiagnosticGuard, LintDiagnosticGuardBuilder};
 use crate::types::diagnostic::{INVALID_TYPE_FORM, UNSUPPORTED_BOOL_CONVERSION};
-use crate::types::generics::{GenericContext, Specialization};
+use crate::types::generics::{GenericContext, Specialization, Specialize, TypeMapping};
 use crate::types::infer::infer_unpack_types;
 use crate::types::mro::{Mro, MroError, MroIterator};
 pub(crate) use crate::types::narrow::infer_narrowing_constraint;
@@ -342,16 +342,6 @@ pub struct PropertyInstanceType<'db> {
 }
 
 impl<'db> PropertyInstanceType<'db> {
-    fn apply_specialization(self, db: &'db dyn Db, specialization: Specialization<'db>) -> Self {
-        let getter = self
-            .getter(db)
-            .map(|ty| ty.apply_specialization(db, specialization));
-        let setter = self
-            .setter(db)
-            .map(|ty| ty.apply_specialization(db, specialization));
-        Self::new(db, getter, setter)
-    }
-
     fn find_legacy_typevars(
         self,
         db: &'db dyn Db,
@@ -363,6 +353,18 @@ impl<'db> PropertyInstanceType<'db> {
         if let Some(ty) = self.setter(db) {
             ty.find_legacy_typevars(db, typevars);
         }
+    }
+}
+
+impl<'db> Specialize<'db> for PropertyInstanceType<'db> {
+    fn apply_type_mapping<'a>(&self, db: &'db dyn Db, type_mapping: TypeMapping<'a, 'db>) -> Self {
+        let getter = self
+            .getter(db)
+            .map(|ty| ty.apply_type_mapping(db, type_mapping));
+        let setter = self
+            .setter(db)
+            .map(|ty| ty.apply_type_mapping(db, type_mapping));
+        Self::new(db, getter, setter)
     }
 }
 
@@ -5018,100 +5020,85 @@ impl<'db> Type<'db> {
         }
     }
 
-    #[must_use]
-    pub fn apply_optional_specialization(
-        self,
-        db: &'db dyn Db,
-        specialization: Option<Specialization<'db>>,
-    ) -> Type<'db> {
-        if let Some(specialization) = specialization {
-            self.apply_specialization(db, specialization)
-        } else {
-            self
-        }
-    }
-
     /// Applies a specialization to this type, replacing any typevars with the types that they are
     /// specialized to.
     ///
     /// Note that this does not specialize generic classes, functions, or type aliases! That is a
     /// different operation that is performed explicitly (via a subscript operation), or implicitly
     /// via a call to the generic object.
-    #[must_use]
-    #[salsa::tracked]
-    pub fn apply_specialization(
+    fn apply_type_mapping_inner<'a>(
         self,
         db: &'db dyn Db,
-        specialization: Specialization<'db>,
+        type_mapping: TypeMapping<'a, 'db>,
     ) -> Type<'db> {
         match self {
-            Type::TypeVar(typevar) => specialization.get(db, typevar).unwrap_or(self),
+            Type::TypeVar(typevar) => type_mapping.get(typevar).unwrap_or(self),
 
             Type::FunctionLiteral(function) => {
-                Type::FunctionLiteral(function.apply_specialization(db, specialization))
+                Type::FunctionLiteral(function.apply_type_mapping(db, type_mapping))
             }
 
             Type::BoundMethod(method) => Type::BoundMethod(BoundMethodType::new(
                 db,
-                method.function(db).apply_specialization(db, specialization),
-                method.self_instance(db).apply_specialization(db, specialization),
+                method.function(db).apply_type_mapping(db, type_mapping),
+                method.self_instance(db).apply_type_mapping(db, type_mapping),
             )),
 
             Type::NominalInstance(instance) => Type::NominalInstance(
-                instance.apply_specialization(db, specialization),
+                instance.apply_type_mapping(db, type_mapping),
             ),
 
             Type::MethodWrapper(MethodWrapperKind::FunctionTypeDunderGet(function)) => {
                 Type::MethodWrapper(MethodWrapperKind::FunctionTypeDunderGet(
-                    function.apply_specialization(db, specialization),
+                    function.apply_type_mapping(db, type_mapping),
                 ))
             }
 
             Type::MethodWrapper(MethodWrapperKind::FunctionTypeDunderCall(function)) => {
                 Type::MethodWrapper(MethodWrapperKind::FunctionTypeDunderCall(
-                    function.apply_specialization(db, specialization),
+                    function.apply_type_mapping(db, type_mapping),
                 ))
             }
 
             Type::MethodWrapper(MethodWrapperKind::PropertyDunderGet(property)) => {
                 Type::MethodWrapper(MethodWrapperKind::PropertyDunderGet(
-                    property.apply_specialization(db, specialization),
+                    property.apply_type_mapping(db, type_mapping),
                 ))
             }
 
             Type::MethodWrapper(MethodWrapperKind::PropertyDunderSet(property)) => {
                 Type::MethodWrapper(MethodWrapperKind::PropertyDunderSet(
-                    property.apply_specialization(db, specialization),
+                    property.apply_type_mapping(db, type_mapping),
                 ))
             }
 
             Type::Callable(callable) => {
-                Type::Callable(callable.apply_specialization(db, specialization))
+                Type::Callable(callable.apply_type_mapping(db, type_mapping))
             }
 
             Type::GenericAlias(generic) => {
                 let specialization = generic
                     .specialization(db)
-                    .apply_specialization(db, specialization);
+                    .apply_type_mapping(db, type_mapping);
                 Type::GenericAlias(GenericAlias::new(db, generic.origin(db), specialization))
             }
 
             Type::PropertyInstance(property) => {
-                Type::PropertyInstance(property.apply_specialization(db, specialization))
+                Type::PropertyInstance(property.apply_type_mapping(db, type_mapping))
             }
 
             Type::Union(union) => union.map(db, |element| {
-                element.apply_specialization(db, specialization)
+                element.apply_type_mapping(db, type_mapping)
             }),
             Type::Intersection(intersection) => {
                 let mut builder = IntersectionBuilder::new(db);
                 for positive in intersection.positive(db) {
                     builder =
-                        builder.add_positive(positive.apply_specialization(db, specialization));
+                        builder.add_positive(positive.apply_type_mapping(db, type_mapping));
                 }
                 for negative in intersection.negative(db) {
                     builder =
-                        builder.add_negative(negative.apply_specialization(db, specialization));
+                        builder.add_negative(negative.apply_type_mapping(db, type_mapping));
                 }
                 builder.build()
             }
@@ -5119,7 +5106,7 @@ impl<'db> Type<'db> {
                 db,
                 tuple
                     .iter(db)
-                    .map(|ty| ty.apply_specialization(db, specialization)),
+                    .map(|ty| ty.apply_type_mapping(db, type_mapping)),
             ),
 
             Type::Dynamic(_)
@@ -5450,6 +5437,12 @@ impl<'db> Type<'db> {
 impl<'db> From<&Type<'db>> for Type<'db> {
     fn from(value: &Type<'db>) -> Self {
         *value
+    }
+}
+
+impl<'db> Specialize<'db> for Type<'db> {
+    fn apply_type_mapping<'a>(&self, db: &'db dyn Db, type_mapping: TypeMapping<'a, 'db>) -> Self {
+        self.apply_type_mapping_inner(db, type_mapping)
     }
 }
 
@@ -6827,23 +6820,6 @@ impl<'db> FunctionType<'db> {
         )
     }
 
-    fn apply_specialization(self, db: &'db dyn Db, specialization: Specialization<'db>) -> Self {
-        let specialization = match self.specialization(db) {
-            Some(existing) => existing.apply_specialization(db, specialization),
-            None => specialization,
-        };
-        Self::new(
-            db,
-            self.name(db).clone(),
-            self.known(db),
-            self.body_scope(db),
-            self.decorators(db),
-            self.dataclass_transformer_params(db),
-            self.inherited_generic_context(db),
-            Some(specialization),
-        )
-    }
-
     fn find_legacy_typevars(
         self,
         db: &'db dyn Db,
@@ -6944,6 +6920,41 @@ impl<'db> FunctionType<'db> {
         // functions yet. Refer to https://github.com/salsa-rs/salsa/pull/772. Remove the inner
         // function once it's supported.
         to_overloaded_impl(db, self).as_ref()
+    }
+}
+
+impl<'db> Specialize<'db> for FunctionType<'db> {
+    fn apply_type_mapping<'a>(&self, db: &'db dyn Db, type_mapping: TypeMapping<'a, 'db>) -> Self {
+        let specialization = self
+            .specialization(db)
+            .map(|existing| existing.apply_type_mapping(db, type_mapping));
+        Self::new(
+            db,
+            self.name(db).clone(),
+            self.known(db),
+            self.body_scope(db),
+            self.decorators(db),
+            self.dataclass_transformer_params(db),
+            self.inherited_generic_context(db),
+            specialization,
+        )
+    }
+
+    fn apply_specialization(&self, db: &'db dyn Db, specialization: Specialization<'db>) -> Self {
+        let specialization = match self.specialization(db) {
+            Some(existing) => existing.apply_specialization(db, specialization),
+            None => specialization,
+        };
+        Self::new(
+            db,
+            self.name(db).clone(),
+            self.known(db),
+            self.body_scope(db),
+            self.decorators(db),
+            self.dataclass_transformer_params(db),
+            self.inherited_generic_context(db),
+            Some(specialization),
+        )
     }
 }
 
@@ -7192,18 +7203,6 @@ impl<'db> CallableType<'db> {
         )
     }
 
-    /// Apply a specialization to this callable type.
-    ///
-    /// See [`Type::apply_specialization`] for more details.
-    fn apply_specialization(self, db: &'db dyn Db, specialization: Specialization<'db>) -> Self {
-        CallableType::from_overloads(
-            db,
-            self.signatures(db)
-                .iter()
-                .map(|signature| signature.apply_specialization(db, specialization)),
-        )
-    }
-
     fn find_legacy_typevars(
         self,
         db: &'db dyn Db,
@@ -7326,6 +7325,17 @@ impl<'db> CallableType<'db> {
                 false
             }
         }
+    }
+}
+
+impl<'db> Specialize<'db> for CallableType<'db> {
+    fn apply_type_mapping<'a>(&self, db: &'db dyn Db, type_mapping: TypeMapping<'a, 'db>) -> Self {
+        CallableType::from_overloads(
+            db,
+            self.signatures(db)
+                .iter()
+                .map(|signature| signature.apply_type_mapping(db, type_mapping)),
+        )
     }
 }
 

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -17,9 +17,7 @@ use crate::types::diagnostic::{
     NO_MATCHING_OVERLOAD, PARAMETER_ALREADY_ASSIGNED, TOO_MANY_POSITIONAL_ARGUMENTS,
     UNKNOWN_ARGUMENT,
 };
-use crate::types::generics::{
-    Specialization, SpecializationBuilder, SpecializationError, Specialize,
-};
+use crate::types::generics::{Specialization, SpecializationBuilder, SpecializationError};
 use crate::types::signatures::{Parameter, ParameterForm};
 use crate::types::{
     todo_type, BoundMethodType, DataclassParams, DataclassTransformerParams, FunctionDecorators,

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -17,7 +17,9 @@ use crate::types::diagnostic::{
     NO_MATCHING_OVERLOAD, PARAMETER_ALREADY_ASSIGNED, TOO_MANY_POSITIONAL_ARGUMENTS,
     UNKNOWN_ARGUMENT,
 };
-use crate::types::generics::{Specialization, SpecializationBuilder, SpecializationError};
+use crate::types::generics::{
+    Specialization, SpecializationBuilder, SpecializationError, Specialize,
+};
 use crate::types::signatures::{Parameter, ParameterForm};
 use crate::types::{
     todo_type, BoundMethodType, DataclassParams, DataclassTransformerParams, FunctionDecorators,

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -1370,21 +1370,6 @@ impl<'db> Binding<'db> {
         &self.parameter_tys
     }
 
-    /// Returns the bound types for each parameter, in parameter source order, with default values
-    /// applied for arguments that weren't matched to a parameter. Returns `None` if there are any
-    /// non-default arguments that weren't matched to a parameter.
-    pub(crate) fn parameter_types_with_defaults(
-        &self,
-        signature: &Signature<'db>,
-    ) -> Option<Box<[Type<'db>]>> {
-        signature
-            .parameters()
-            .iter()
-            .zip(&self.parameter_tys)
-            .map(|(parameter, parameter_ty)| parameter_ty.or(parameter.default_type()))
-            .collect()
-    }
-
     pub(crate) fn arguments_for_parameter<'a>(
         &'a self,
         argument_types: &'a CallArgumentTypes<'a, 'db>,

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -146,9 +146,7 @@ impl<'db> GenericAlias<'db> {
     pub(crate) fn definition(self, db: &'db dyn Db) -> Definition<'db> {
         self.origin(db).definition(db)
     }
-}
 
-impl<'db> GenericAlias<'db> {
     fn apply_type_mapping<'a>(self, db: &'db dyn Db, type_mapping: TypeMapping<'a, 'db>) -> Self {
         Self::new(
             db,
@@ -233,7 +231,7 @@ impl<'db> ClassType<'db> {
         self.is_known(db, KnownClass::Object)
     }
 
-    pub(crate) fn apply_type_mapping<'a>(
+    pub(super) fn apply_type_mapping<'a>(
         self,
         db: &'db dyn Db,
         type_mapping: TypeMapping<'a, 'db>,

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -1,4 +1,4 @@
-use crate::types::generics::{GenericContext, Specialization};
+use crate::types::generics::{GenericContext, Specialization, Specialize, TypeMapping};
 use crate::types::{
     todo_type, ClassType, DynamicType, KnownClass, KnownInstanceType, MroIterator, Type,
 };
@@ -202,29 +202,6 @@ impl<'db> ClassBase<'db> {
         }
     }
 
-    pub(crate) fn apply_specialization(
-        self,
-        db: &'db dyn Db,
-        specialization: Specialization<'db>,
-    ) -> Self {
-        match self {
-            Self::Class(class) => Self::Class(class.apply_specialization(db, specialization)),
-            Self::Dynamic(_) | Self::Generic(_) | Self::Protocol => self,
-        }
-    }
-
-    pub(crate) fn apply_optional_specialization(
-        self,
-        db: &'db dyn Db,
-        specialization: Option<Specialization<'db>>,
-    ) -> Self {
-        if let Some(specialization) = specialization {
-            self.apply_specialization(db, specialization)
-        } else {
-            self
-        }
-    }
-
     /// Iterate over the MRO of this base
     pub(super) fn mro(
         self,
@@ -270,6 +247,15 @@ impl<'db> From<ClassBase<'db>> for Type<'db> {
 impl<'db> From<&ClassBase<'db>> for Type<'db> {
     fn from(value: &ClassBase<'db>) -> Self {
         Self::from(*value)
+    }
+}
+
+impl<'db> Specialize<'db> for ClassBase<'db> {
+    fn apply_type_mapping<'a>(&self, db: &'db dyn Db, type_mapping: TypeMapping<'a, 'db>) -> Self {
+        match self {
+            Self::Class(class) => Self::Class(class.apply_type_mapping(db, type_mapping)),
+            Self::Dynamic(_) | Self::Generic(_) | Self::Protocol => *self,
+        }
     }
 }
 

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -202,6 +202,18 @@ impl<'db> ClassBase<'db> {
         }
     }
 
+    pub(crate) fn apply_optional_specialization(
+        self,
+        db: &'db dyn Db,
+        specialization: Option<Specialization<'db>>,
+    ) -> Self {
+        if let Some(specialization) = specialization {
+            self.apply_type_mapping(db, specialization.type_mapping())
+        } else {
+            self
+        }
+    }
+
     /// Iterate over the MRO of this base
     pub(super) fn mro(
         self,

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -1,4 +1,4 @@
-use crate::types::generics::{GenericContext, Specialization, Specialize, TypeMapping};
+use crate::types::generics::{GenericContext, Specialization, TypeMapping};
 use crate::types::{
     todo_type, ClassType, DynamicType, KnownClass, KnownInstanceType, MroIterator, Type,
 };
@@ -202,6 +202,13 @@ impl<'db> ClassBase<'db> {
         }
     }
 
+    fn apply_type_mapping<'a>(self, db: &'db dyn Db, type_mapping: TypeMapping<'a, 'db>) -> Self {
+        match self {
+            Self::Class(class) => Self::Class(class.apply_type_mapping(db, type_mapping)),
+            Self::Dynamic(_) | Self::Generic(_) | Self::Protocol => self,
+        }
+    }
+
     pub(crate) fn apply_optional_specialization(
         self,
         db: &'db dyn Db,
@@ -259,15 +266,6 @@ impl<'db> From<ClassBase<'db>> for Type<'db> {
 impl<'db> From<&ClassBase<'db>> for Type<'db> {
     fn from(value: &ClassBase<'db>) -> Self {
         Self::from(*value)
-    }
-}
-
-impl<'db> Specialize<'db> for ClassBase<'db> {
-    fn apply_type_mapping<'a>(&self, db: &'db dyn Db, type_mapping: TypeMapping<'a, 'db>) -> Self {
-        match self {
-            Self::Class(class) => Self::Class(class.apply_type_mapping(db, type_mapping)),
-            Self::Dynamic(_) | Self::Generic(_) | Self::Protocol => *self,
-        }
     }
 }
 

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -169,8 +169,8 @@ impl<'db> GenericContext<'db> {
         // class C[T, U = T]: ...
         // ```
         //
-        // If there is a mapping for `T`, we want to map `U` that type, not to `T`. To handle this,
-        // we repeatedly apply the specialization to itself, until we reach a fixed point.
+        // If there is a mapping for `T`, we want to map `U` to that type, not to `T`. To handle
+        // this, we repeatedly apply the specialization to itself, until we reach a fixed point.
         //
         // This loop will always terminate, since it's not possible to create cyclic typevar
         // references:

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -184,7 +184,7 @@ impl<'db> GenericContext<'db> {
         // If there is a mapping for `T`, we want to map `U` to that type, not to `T`. To handle
         // this, we repeatedly apply the specialization to itself, until we reach a fixed point.
         let mut expanded = vec![Type::unknown(); types.len()];
-        for (idx, (ty, typevar)) in types.into_iter().zip(variables).enumerate() {
+        for (idx, (ty, typevar)) in types.iter().zip(variables).enumerate() {
             if let Some(ty) = ty {
                 expanded[idx] = *ty;
                 continue;

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -6849,8 +6849,10 @@ impl<'db> TypeInferenceBuilder<'db> {
             }
             _ => CallArgumentTypes::positional([self.infer_type_expression(slice_node)]),
         };
-        let signature = generic_context.signature(self.db());
-        let signatures = Signatures::single(CallableSignature::single(value_ty, signature.clone()));
+        let signatures = Signatures::single(CallableSignature::single(
+            value_ty,
+            generic_context.signature(self.db()),
+        ));
         let bindings = match Bindings::match_parameters(signatures, &call_argument_types)
             .check_types(self.db(), &call_argument_types)
         {
@@ -6868,10 +6870,8 @@ impl<'db> TypeInferenceBuilder<'db> {
             .matching_overloads()
             .next()
             .expect("valid bindings should have matching overload");
-        let parameters = overload
-            .parameter_types_with_defaults(&signature)
-            .expect("matching overload should not have missing arguments");
-        let specialization = generic_context.specialize(self.db(), parameters);
+        let specialization =
+            generic_context.specialize_partial(self.db(), overload.parameter_types());
         Type::from(GenericAlias::new(self.db(), generic_class, specialization))
     }
 

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -3,7 +3,7 @@
 use super::protocol_class::ProtocolInterface;
 use super::{ClassType, KnownClass, SubclassOfType, Type};
 use crate::symbol::{Symbol, SymbolAndQualifiers};
-use crate::types::generics::{Specialize, TypeMapping};
+use crate::types::generics::TypeMapping;
 use crate::Db;
 
 pub(super) use synthesized_protocol::SynthesizedProtocolType;
@@ -112,19 +112,21 @@ impl<'db> NominalInstanceType<'db> {
     pub(super) fn to_meta_type(self, db: &'db dyn Db) -> Type<'db> {
         SubclassOfType::from(db, self.class)
     }
+
+    pub(crate) fn apply_type_mapping<'a>(
+        self,
+        db: &'db dyn Db,
+        type_mapping: TypeMapping<'a, 'db>,
+    ) -> Self {
+        Self {
+            class: self.class.apply_type_mapping(db, type_mapping),
+        }
+    }
 }
 
 impl<'db> From<NominalInstanceType<'db>> for Type<'db> {
     fn from(value: NominalInstanceType<'db>) -> Self {
         Self::NominalInstance(value)
-    }
-}
-
-impl<'db> Specialize<'db> for NominalInstanceType<'db> {
-    fn apply_type_mapping<'a>(&self, db: &'db dyn Db, type_mapping: TypeMapping<'a, 'db>) -> Self {
-        Self {
-            class: self.class.apply_type_mapping(db, type_mapping),
-        }
     }
 }
 

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -113,7 +113,7 @@ impl<'db> NominalInstanceType<'db> {
         SubclassOfType::from(db, self.class)
     }
 
-    pub(crate) fn apply_type_mapping<'a>(
+    pub(super) fn apply_type_mapping<'a>(
         self,
         db: &'db dyn Db,
         type_mapping: TypeMapping<'a, 'db>,

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -3,7 +3,7 @@
 use super::protocol_class::ProtocolInterface;
 use super::{ClassType, KnownClass, SubclassOfType, Type};
 use crate::symbol::{Symbol, SymbolAndQualifiers};
-use crate::types::generics::Specialization;
+use crate::types::generics::{Specialize, TypeMapping};
 use crate::Db;
 
 pub(super) use synthesized_protocol::SynthesizedProtocolType;
@@ -112,21 +112,19 @@ impl<'db> NominalInstanceType<'db> {
     pub(super) fn to_meta_type(self, db: &'db dyn Db) -> Type<'db> {
         SubclassOfType::from(db, self.class)
     }
-
-    pub(super) fn apply_specialization(
-        self,
-        db: &'db dyn Db,
-        specialization: Specialization<'db>,
-    ) -> Self {
-        Self {
-            class: self.class.apply_specialization(db, specialization),
-        }
-    }
 }
 
 impl<'db> From<NominalInstanceType<'db>> for Type<'db> {
     fn from(value: NominalInstanceType<'db>) -> Self {
         Self::NominalInstance(value)
+    }
+}
+
+impl<'db> Specialize<'db> for NominalInstanceType<'db> {
+    fn apply_type_mapping<'a>(&self, db: &'db dyn Db, type_mapping: TypeMapping<'a, 'db>) -> Self {
+        Self {
+            class: self.class.apply_type_mapping(db, type_mapping),
+        }
     }
 }
 

--- a/crates/ty_python_semantic/src/types/mro.rs
+++ b/crates/ty_python_semantic/src/types/mro.rs
@@ -4,7 +4,7 @@ use std::ops::Deref;
 use rustc_hash::FxHashMap;
 
 use crate::types::class_base::ClassBase;
-use crate::types::generics::Specialization;
+use crate::types::generics::{Specialization, Specialize};
 use crate::types::{ClassLiteral, ClassType, Type};
 use crate::Db;
 

--- a/crates/ty_python_semantic/src/types/mro.rs
+++ b/crates/ty_python_semantic/src/types/mro.rs
@@ -4,7 +4,7 @@ use std::ops::Deref;
 use rustc_hash::FxHashMap;
 
 use crate::types::class_base::ClassBase;
-use crate::types::generics::{Specialization, Specialize};
+use crate::types::generics::Specialization;
 use crate::types::{ClassLiteral, ClassType, Type};
 use crate::Db;
 

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -17,7 +17,7 @@ use smallvec::{smallvec, SmallVec};
 
 use super::{definition_expression_type, DynamicType, Type};
 use crate::semantic_index::definition::Definition;
-use crate::types::generics::{GenericContext, Specialize, TypeMapping};
+use crate::types::generics::{GenericContext, Specialization, Specialize, TypeMapping};
 use crate::types::{todo_type, TypeVarInstance};
 use crate::{Db, FxOrderSet};
 use ruff_python_ast::{self as ast, name::Name};
@@ -307,6 +307,14 @@ impl<'db> Signature<'db> {
                 .collect(),
             return_ty: self.return_ty.map(|return_ty| return_ty.normalized(db)),
         }
+    }
+
+    pub(crate) fn apply_specialization(
+        &self,
+        db: &'db dyn Db,
+        specialization: Specialization<'db>,
+    ) -> Self {
+        self.apply_type_mapping(db, specialization.type_mapping())
     }
 
     pub(crate) fn find_legacy_typevars(

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -17,7 +17,7 @@ use smallvec::{smallvec, SmallVec};
 
 use super::{definition_expression_type, DynamicType, Type};
 use crate::semantic_index::definition::Definition;
-use crate::types::generics::{GenericContext, Specialization};
+use crate::types::generics::{GenericContext, Specialize, TypeMapping};
 use crate::types::{todo_type, TypeVarInstance};
 use crate::{Db, FxOrderSet};
 use ruff_python_ast::{self as ast, name::Name};
@@ -306,21 +306,6 @@ impl<'db> Signature<'db> {
                 .map(|param| param.normalized(db))
                 .collect(),
             return_ty: self.return_ty.map(|return_ty| return_ty.normalized(db)),
-        }
-    }
-
-    pub(crate) fn apply_specialization(
-        &self,
-        db: &'db dyn Db,
-        specialization: Specialization<'db>,
-    ) -> Self {
-        Self {
-            generic_context: self.generic_context,
-            inherited_generic_context: self.inherited_generic_context,
-            parameters: self.parameters.apply_specialization(db, specialization),
-            return_ty: self
-                .return_ty
-                .map(|ty| ty.apply_specialization(db, specialization)),
         }
     }
 
@@ -870,6 +855,19 @@ impl<'db> Signature<'db> {
     }
 }
 
+impl<'db> Specialize<'db> for Signature<'db> {
+    fn apply_type_mapping<'a>(&self, db: &'db dyn Db, type_mapping: TypeMapping<'a, 'db>) -> Self {
+        Self {
+            generic_context: self.generic_context,
+            inherited_generic_context: self.inherited_generic_context,
+            parameters: self.parameters.apply_type_mapping(db, type_mapping),
+            return_ty: self
+                .return_ty
+                .map(|ty| ty.apply_type_mapping(db, type_mapping)),
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Hash, salsa::Update)]
 pub(crate) struct Parameters<'db> {
     // TODO: use SmallVec here once invariance bug is fixed
@@ -1053,17 +1051,6 @@ impl<'db> Parameters<'db> {
         )
     }
 
-    fn apply_specialization(&self, db: &'db dyn Db, specialization: Specialization<'db>) -> Self {
-        Self {
-            value: self
-                .value
-                .iter()
-                .map(|param| param.apply_specialization(db, specialization))
-                .collect(),
-            is_gradual: self.is_gradual,
-        }
-    }
-
     pub(crate) fn len(&self) -> usize {
         self.value.len()
     }
@@ -1118,6 +1105,19 @@ impl<'db> Parameters<'db> {
         self.iter()
             .enumerate()
             .rfind(|(_, parameter)| parameter.is_keyword_variadic())
+    }
+}
+
+impl<'db> Specialize<'db> for Parameters<'db> {
+    fn apply_type_mapping<'a>(&self, db: &'db dyn Db, type_mapping: TypeMapping<'a, 'db>) -> Self {
+        Self {
+            value: self
+                .value
+                .iter()
+                .map(|param| param.apply_type_mapping(db, type_mapping))
+                .collect(),
+            is_gradual: self.is_gradual,
+        }
     }
 }
 
@@ -1223,16 +1223,6 @@ impl<'db> Parameter<'db> {
     pub(crate) fn type_form(mut self) -> Self {
         self.form = ParameterForm::Type;
         self
-    }
-
-    fn apply_specialization(&self, db: &'db dyn Db, specialization: Specialization<'db>) -> Self {
-        Self {
-            annotated_type: self
-                .annotated_type
-                .map(|ty| ty.apply_specialization(db, specialization)),
-            kind: self.kind.apply_specialization(db, specialization),
-            form: self.form,
-        }
     }
 
     /// Strip information from the parameter so that two equivalent parameters compare equal.
@@ -1382,6 +1372,18 @@ impl<'db> Parameter<'db> {
     }
 }
 
+impl<'db> Specialize<'db> for Parameter<'db> {
+    fn apply_type_mapping<'a>(&self, db: &'db dyn Db, type_mapping: TypeMapping<'a, 'db>) -> Self {
+        Self {
+            annotated_type: self
+                .annotated_type
+                .map(|ty| ty.apply_type_mapping(db, type_mapping)),
+            kind: self.kind.apply_type_mapping(db, type_mapping),
+            form: self.form,
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Hash, salsa::Update)]
 pub(crate) enum ParameterKind<'db> {
     /// Positional-only parameter, e.g. `def f(x, /): ...`
@@ -1421,25 +1423,25 @@ pub(crate) enum ParameterKind<'db> {
     },
 }
 
-impl<'db> ParameterKind<'db> {
-    fn apply_specialization(&self, db: &'db dyn Db, specialization: Specialization<'db>) -> Self {
+impl<'db> Specialize<'db> for ParameterKind<'db> {
+    fn apply_type_mapping<'a>(&self, db: &'db dyn Db, type_mapping: TypeMapping<'a, 'db>) -> Self {
         match self {
             Self::PositionalOnly { default_type, name } => Self::PositionalOnly {
                 default_type: default_type
                     .as_ref()
-                    .map(|ty| ty.apply_specialization(db, specialization)),
+                    .map(|ty| ty.apply_type_mapping(db, type_mapping)),
                 name: name.clone(),
             },
             Self::PositionalOrKeyword { default_type, name } => Self::PositionalOrKeyword {
                 default_type: default_type
                     .as_ref()
-                    .map(|ty| ty.apply_specialization(db, specialization)),
+                    .map(|ty| ty.apply_type_mapping(db, type_mapping)),
                 name: name.clone(),
             },
             Self::KeywordOnly { default_type, name } => Self::KeywordOnly {
                 default_type: default_type
                     .as_ref()
-                    .map(|ty| ty.apply_specialization(db, specialization)),
+                    .map(|ty| ty.apply_type_mapping(db, type_mapping)),
                 name: name.clone(),
             },
             Self::Variadic { .. } | Self::KeywordVariadic { .. } => self.clone(),


### PR DESCRIPTION
It's possible for a typevar to list another typevar as its default value:

```py
class C[T, U = T]: ...
```

When specializing this class, if a type isn't provided for `U`, we would previously use the default as-is, leaving an unspecialized `T` typevar in the specialization. Instead, we want to use what `T` is mapped to as the type of `U`.

```py
reveal_type(C())  # revealed: C[Unknown, Unknown]
reveal_type(C[int]())  # revealed: C[int, int]
reveal_type(C[int, str]())  # revealed: C[int, str]
```

This is especially important for the `slice` built-in type.