### PR TITLE
[ty] Respect the gradual guarantee when reporting errors in resolving MROs

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/mro.md
+++ b/crates/ty_python_semantic/resources/mdtest/mro.md
@@ -393,7 +393,8 @@ class E(
 
 We do not emit errors on classes where multiple bases are inferred as `Unknown`, `Todo` or `Any`.
 Usually having duplicate bases in a bases list like this would cause us to emit a diagnostic;
-however, for gradual types this would break the [gradual guarantee](https://typing.python.org/en/latest/spec/concepts.html#the-gradual-guarantee):
+however, for gradual types this would break the
+[gradual guarantee](https://typing.python.org/en/latest/spec/concepts.html#the-gradual-guarantee):
 the dynamic base can usually be materialised to a type that would lead to a resolvable MRO.
 
 ```py


### PR DESCRIPTION
## Summary

If you have code like this:

```py
from module_we_cannot_resolve import Base1, Base2

class Foo(Base1, Base2): ...
```

then we issue a complaint about this, because both bases are inferred as `Unknown`. The duplicate bases mean that we cannot resolve a consistent Method Resolution Order for the class:

```
Cannot create a consistent method resolution order (MRO) for class `Foo` with bases list `[Unknown, Unknown]`
```

This violates [the gradual guarantee](https://typing.python.org/en/latest/spec/concepts.html#the-gradual-guarantee): if either `Unknown` were replaced with a fully static type, the error might go away. There's a long-standing TODO question about our behaviour in our tests here:

https://github.com/astral-sh/ruff/blob/981bd70d393fe29324c07c3ffce5ecddd40e6bd6/crates/ty_python_semantic/resources/mdtest/mro.md?plain=1#L395-L411

And I keep seeing `[inconsistent-mro]` errors in mypy_primer reports. So I think it is time that we do, indeed, revisit this and properly respect the gradual guarantee.

This PR switches things so that we do not report a diagnostic for unresolvable MROs if the reason for the MRO being unresolvable is that there are duplicate bases and the duplicate base in question is a dynamic type (`Todo`, `Any` or `Unknown`). We now silently fallback to an MRO of `<the class in question>, Unknown, object` in such cases, without reporting a diagnostic.

## Test Plan

`cargo test -p ty_python_semantic`
