### PR TITLE
[ty] Update salsa

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3249,7 +3249,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 [[package]]
 name = "salsa"
 version = "0.21.1"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=2c869364a9592d06fdf45c422e1e4a7265a8fe8a#2c869364a9592d06fdf45c422e1e4a7265a8fe8a"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=7edce6e248f35c8114b4b021cdb474a3fb2813b3#7edce6e248f35c8114b4b021cdb474a3fb2813b3"
 dependencies = [
  "boxcar",
  "compact_str",
@@ -3272,12 +3272,12 @@ dependencies = [
 [[package]]
 name = "salsa-macro-rules"
 version = "0.21.1"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=2c869364a9592d06fdf45c422e1e4a7265a8fe8a#2c869364a9592d06fdf45c422e1e4a7265a8fe8a"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=7edce6e248f35c8114b4b021cdb474a3fb2813b3#7edce6e248f35c8114b4b021cdb474a3fb2813b3"
 
 [[package]]
 name = "salsa-macros"
 version = "0.21.1"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=2c869364a9592d06fdf45c422e1e4a7265a8fe8a#2c869364a9592d06fdf45c422e1e4a7265a8fe8a"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=7edce6e248f35c8114b4b021cdb474a3fb2813b3#7edce6e248f35c8114b4b021cdb474a3fb2813b3"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ rayon = { version = "1.10.0" }
 regex = { version = "1.10.2" }
 rustc-hash = { version = "2.0.0" }
 # When updating salsa, make sure to also update the revision in `fuzz/Cargo.toml`
-salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "2c869364a9592d06fdf45c422e1e4a7265a8fe8a" }
+salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "7edce6e248f35c8114b4b021cdb474a3fb2813b3" }
 schemars = { version = "0.8.16" }
 seahash = { version = "4.1.0" }
 serde = { version = "1.0.197", features = ["derive"] }

--- a/crates/ruff_db/src/files.rs
+++ b/crates/ruff_db/src/files.rs
@@ -277,7 +277,7 @@ impl std::panic::RefUnwindSafe for Files {}
 #[salsa::input]
 pub struct File {
     /// The path of the file (immutable).
-    #[return_ref]
+    #[returns(ref)]
     pub path: FilePath,
 
     /// The unix permissions of the file. Only supported on unix systems. Always `None` on Windows

--- a/crates/ruff_db/src/files/file_root.rs
+++ b/crates/ruff_db/src/files/file_root.rs
@@ -19,8 +19,8 @@ use crate::Db;
 #[salsa::input(debug)]
 pub struct FileRoot {
     /// The path of a root is guaranteed to never change.
-    #[return_ref]
-    path_buf: SystemPathBuf,
+    #[returns(deref)]
+    pub path: SystemPathBuf,
 
     /// The kind of the root at the time of its creation.
     kind_at_time_of_creation: FileRootKind,
@@ -32,10 +32,6 @@ pub struct FileRoot {
 }
 
 impl FileRoot {
-    pub fn path(self, db: &dyn Db) -> &SystemPath {
-        self.path_buf(db)
-    }
-
     pub fn durability(self, db: &dyn Db) -> salsa::Durability {
         self.kind_at_time_of_creation(db).durability()
     }

--- a/crates/ruff_db/src/parsed.rs
+++ b/crates/ruff_db/src/parsed.rs
@@ -20,7 +20,7 @@ use crate::Db;
 /// reflected in the changed AST offsets.
 /// The other reason is that Ruff's AST doesn't implement `Eq` which Sala requires
 /// for determining if a query result is unchanged.
-#[salsa::tracked(return_ref, no_eq)]
+#[salsa::tracked(returns(ref), no_eq)]
 pub fn parsed_module(db: &dyn Db, file: File) -> ParsedModule {
     let _span = tracing::trace_span!("parsed_module", ?file).entered();
 

--- a/crates/ruff_graph/src/db.rs
+++ b/crates/ruff_graph/src/db.rs
@@ -88,8 +88,8 @@ impl Db for ModuleDb {
         !file.path(self).is_vendored_path()
     }
 
-    fn rule_selection(&self) -> Arc<RuleSelection> {
-        self.rule_selection.clone()
+    fn rule_selection(&self) -> &RuleSelection {
+        &self.rule_selection
     }
 
     fn lint_registry(&self) -> &LintRegistry {

--- a/crates/ty_ide/src/db.rs
+++ b/crates/ty_ide/src/db.rs
@@ -120,8 +120,8 @@ pub(crate) mod tests {
             !file.path(self).is_vendored_path()
         }
 
-        fn rule_selection(&self) -> Arc<RuleSelection> {
-            self.rule_selection.clone()
+        fn rule_selection(&self) -> &RuleSelection {
+            &self.rule_selection
         }
 
         fn lint_registry(&self) -> &LintRegistry {

--- a/crates/ty_project/src/db.rs
+++ b/crates/ty_project/src/db.rs
@@ -149,7 +149,7 @@ impl SemanticDb for ProjectDatabase {
         project.is_file_open(self, file)
     }
 
-    fn rule_selection(&self) -> Arc<RuleSelection> {
+    fn rule_selection(&self) -> &RuleSelection {
         self.project().rules(self)
     }
 
@@ -327,7 +327,7 @@ pub(crate) mod tests {
             !file.path(self).is_vendored_path()
         }
 
-        fn rule_selection(&self) -> Arc<RuleSelection> {
+        fn rule_selection(&self) -> &RuleSelection {
             self.project().rules(self)
         }
 

--- a/crates/ty_python_semantic/src/db.rs
+++ b/crates/ty_python_semantic/src/db.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use crate::lint::{LintRegistry, RuleSelection};
 use ruff_db::files::File;
 use ruff_db::{Db as SourceDb, Upcast};
@@ -9,7 +7,7 @@ use ruff_db::{Db as SourceDb, Upcast};
 pub trait Db: SourceDb + Upcast<dyn SourceDb> {
     fn is_file_open(&self, file: File) -> bool;
 
-    fn rule_selection(&self) -> Arc<RuleSelection>;
+    fn rule_selection(&self) -> &RuleSelection;
 
     fn lint_registry(&self) -> &LintRegistry;
 }
@@ -125,8 +123,8 @@ pub(crate) mod tests {
             !file.path(self).is_vendored_path()
         }
 
-        fn rule_selection(&self) -> Arc<RuleSelection> {
-            self.rule_selection.clone()
+        fn rule_selection(&self) -> &RuleSelection {
+            &self.rule_selection
         }
 
         fn lint_registry(&self) -> &LintRegistry {

--- a/crates/ty_python_semantic/src/module_resolver/resolver.rs
+++ b/crates/ty_python_semantic/src/module_resolver/resolver.rs
@@ -349,7 +349,7 @@ impl SearchPaths {
 /// The editable-install search paths for the first `site-packages` directory
 /// should come between the two `site-packages` directories when it comes to
 /// module-resolution priority.
-#[salsa::tracked(return_ref)]
+#[salsa::tracked(returns(deref))]
 pub(crate) fn dynamic_resolution_paths(db: &dyn Db) -> Vec<SearchPath> {
     tracing::debug!("Resolving dynamic module resolution paths");
 
@@ -583,7 +583,7 @@ impl<'db> Iterator for PthFileIterator<'db> {
 /// This is needed because Salsa requires that all query arguments are salsa ingredients.
 #[salsa::interned(debug)]
 struct ModuleNameIngredient<'db> {
-    #[return_ref]
+    #[returns(ref)]
     pub(super) name: ModuleName,
 }
 

--- a/crates/ty_python_semantic/src/program.rs
+++ b/crates/ty_python_semantic/src/program.rs
@@ -13,10 +13,10 @@ use salsa::Setter;
 pub struct Program {
     pub python_version: PythonVersion,
 
-    #[return_ref]
+    #[returns(ref)]
     pub python_platform: PythonPlatform,
 
-    #[return_ref]
+    #[returns(ref)]
     pub(crate) search_paths: SearchPaths,
 }
 

--- a/crates/ty_python_semantic/src/semantic_index/definition.rs
+++ b/crates/ty_python_semantic/src/semantic_index/definition.rs
@@ -34,7 +34,7 @@ pub struct Definition<'db> {
     /// WARNING: Only access this field when doing type inference for the same
     /// file as where `Definition` is defined to avoid cross-file query dependencies.
     #[no_eq]
-    #[return_ref]
+    #[returns(ref)]
     #[tracked]
     pub(crate) kind: DefinitionKind<'db>,
 

--- a/crates/ty_python_semantic/src/semantic_index/expression.rs
+++ b/crates/ty_python_semantic/src/semantic_index/expression.rs
@@ -41,7 +41,7 @@ pub(crate) struct Expression<'db> {
     /// The expression node.
     #[no_eq]
     #[tracked]
-    #[return_ref]
+    #[returns(deref)]
     pub(crate) node_ref: AstNodeRef<ast::Expr>,
 
     /// An assignment statement, if this expression is immediately used as the rhs of that

--- a/crates/ty_python_semantic/src/semantic_index/predicate.rs
+++ b/crates/ty_python_semantic/src/semantic_index/predicate.rs
@@ -83,7 +83,7 @@ pub(crate) struct PatternPredicate<'db> {
 
     pub(crate) subject: Expression<'db>,
 
-    #[return_ref]
+    #[returns(ref)]
     pub(crate) kind: PatternPredicateKind<'db>,
 
     pub(crate) guard: Option<Expression<'db>>,

--- a/crates/ty_python_semantic/src/semantic_index/re_exports.rs
+++ b/crates/ty_python_semantic/src/semantic_index/re_exports.rs
@@ -43,7 +43,7 @@ fn exports_cycle_initial(_db: &dyn Db, _file: File) -> Box<[Name]> {
     Box::default()
 }
 
-#[salsa::tracked(return_ref, cycle_fn=exports_cycle_recover, cycle_initial=exports_cycle_initial)]
+#[salsa::tracked(returns(deref), cycle_fn=exports_cycle_recover, cycle_initial=exports_cycle_initial)]
 pub(super) fn exported_names(db: &dyn Db, file: File) -> Box<[Name]> {
     let module = parsed_module(db.upcast(), file);
     let mut finder = ExportFinder::new(db, file);

--- a/crates/ty_python_semantic/src/suppression.rs
+++ b/crates/ty_python_semantic/src/suppression.rs
@@ -86,7 +86,7 @@ declare_lint! {
     }
 }
 
-#[salsa::tracked(return_ref)]
+#[salsa::tracked(returns(ref))]
 pub(crate) fn suppressions(db: &dyn Db, file: File) -> Suppressions {
     let parsed = parsed_module(db.upcast(), file);
     let source = source_text(db.upcast(), file);

--- a/crates/ty_python_semantic/src/symbol.rs
+++ b/crates/ty_python_semantic/src/symbol.rs
@@ -1014,7 +1014,7 @@ mod implicit_globals {
     /// Conceptually this function could be a `Set` rather than a list,
     /// but the number of symbols declared in this scope is likely to be very small,
     /// so the cost of hashing the names is likely to be more expensive than it's worth.
-    #[salsa::tracked(return_ref)]
+    #[salsa::tracked(returns(deref))]
     fn module_type_symbols<'db>(db: &'db dyn Db) -> smallvec::SmallVec<[ast::name::Name; 8]> {
         let Some(module_type) = KnownClass::ModuleType
             .to_class_literal(db)

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -447,7 +447,7 @@ impl<'db> Bindings<'db> {
                             overload.parameter_types()
                         {
                             overload.set_return_type(Type::BooleanLiteral(
-                                literal.value(db).starts_with(&**prefix.value(db)),
+                                literal.value(db).starts_with(prefix.value(db)),
                             ));
                         }
                     }

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -239,7 +239,6 @@ impl<'db> ClassBase<'db> {
                 let (class_literal, specialization) = class.class_literal(db);
                 class_literal
                     .try_mro(db, specialization)
-                    .as_ref()
                     .is_err_and(MroError::is_cycle)
             }
             ClassBase::Dynamic(_) | ClassBase::Generic(_) | ClassBase::Protocol => false,

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -223,8 +223,7 @@ impl Display for DisplayRepresentation<'_> {
             Type::StringLiteral(string) => string.display(self.db).fmt(f),
             Type::LiteralString => f.write_str("LiteralString"),
             Type::BytesLiteral(bytes) => {
-                let escape =
-                    AsciiEscape::with_preferred_quote(bytes.value(self.db).as_ref(), Quote::Double);
+                let escape = AsciiEscape::with_preferred_quote(bytes.value(self.db), Quote::Double);
 
                 escape.bytes_repr(TripleQuotes::No).write(f)
             }

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -15,7 +15,7 @@ use crate::{Db, FxOrderSet};
 /// containing context.
 #[salsa::interned(debug)]
 pub struct GenericContext<'db> {
-    #[return_ref]
+    #[returns(ref)]
     pub(crate) variables: FxOrderSet<TypeVarInstance<'db>>,
 }
 
@@ -216,7 +216,7 @@ impl<'db> GenericContext<'db> {
 #[salsa::interned(debug)]
 pub struct Specialization<'db> {
     pub(crate) generic_context: GenericContext<'db>,
-    #[return_ref]
+    #[returns(deref)]
     pub(crate) types: Box<[Type<'db>]>,
 }
 
@@ -249,7 +249,7 @@ impl<'db> Specialization<'db> {
     ) -> Self {
         let types: Box<[_]> = self
             .types(db)
-            .into_iter()
+            .iter()
             .map(|ty| ty.apply_type_mapping(db, type_mapping))
             .collect();
         Specialization::new(db, self.generic_context(db), types)
@@ -282,7 +282,7 @@ impl<'db> Specialization<'db> {
         // explicitly tells us which typevars are mapped.
         let types: Box<[_]> = self
             .types(db)
-            .into_iter()
+            .iter()
             .zip(other.types(db))
             .map(|(self_type, other_type)| match (self_type, other_type) {
                 (unknown, known) | (known, unknown) if unknown.is_unknown() => *known,

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -59,7 +59,7 @@ impl<'db> Deref for ProtocolClassLiteral<'db> {
 /// The interface of a protocol: the members of that protocol, and the types of those members.
 #[salsa::interned(debug)]
 pub(super) struct ProtocolInterface<'db> {
-    #[return_ref]
+    #[returns(ref)]
     _members: BTreeMap<Name, ProtocolMemberData<'db>>,
 }
 

--- a/crates/ty_python_semantic/src/types/type_ordering.rs
+++ b/crates/ty_python_semantic/src/types/type_ordering.rs
@@ -150,20 +150,20 @@ pub(super) fn union_or_intersection_elements_ordering<'db>(
 
         (Type::BoundSuper(left), Type::BoundSuper(right)) => {
             (match (left.pivot_class(db), right.pivot_class(db)) {
-                (ClassBase::Class(left), ClassBase::Class(right)) => left.cmp(right),
+                (ClassBase::Class(left), ClassBase::Class(right)) => left.cmp(&right),
                 (ClassBase::Class(_), _) => Ordering::Less,
                 (_, ClassBase::Class(_)) => Ordering::Greater,
                 (ClassBase::Protocol, _) => Ordering::Less,
                 (_, ClassBase::Protocol) => Ordering::Greater,
-                (ClassBase::Generic(left), ClassBase::Generic(right)) => left.cmp(right),
+                (ClassBase::Generic(left), ClassBase::Generic(right)) => left.cmp(&right),
                 (ClassBase::Generic(_), _) => Ordering::Less,
                 (_, ClassBase::Generic(_)) => Ordering::Greater,
                 (ClassBase::Dynamic(left), ClassBase::Dynamic(right)) => {
-                    dynamic_elements_ordering(*left, *right)
+                    dynamic_elements_ordering(left, right)
                 }
             })
             .then_with(|| match (left.owner(db), right.owner(db)) {
-                (SuperOwnerKind::Class(left), SuperOwnerKind::Class(right)) => left.cmp(right),
+                (SuperOwnerKind::Class(left), SuperOwnerKind::Class(right)) => left.cmp(&right),
                 (SuperOwnerKind::Class(_), _) => Ordering::Less,
                 (_, SuperOwnerKind::Class(_)) => Ordering::Greater,
                 (SuperOwnerKind::Instance(left), SuperOwnerKind::Instance(right)) => {
@@ -172,7 +172,7 @@ pub(super) fn union_or_intersection_elements_ordering<'db>(
                 (SuperOwnerKind::Instance(_), _) => Ordering::Less,
                 (_, SuperOwnerKind::Instance(_)) => Ordering::Greater,
                 (SuperOwnerKind::Dynamic(left), SuperOwnerKind::Dynamic(right)) => {
-                    dynamic_elements_ordering(*left, *right)
+                    dynamic_elements_ordering(left, right)
                 }
             })
         }

--- a/crates/ty_python_semantic/src/types/unpacker.rs
+++ b/crates/ty_python_semantic/src/types/unpacker.rs
@@ -226,7 +226,7 @@ impl<'db> Unpacker<'db> {
         // If there is a starred expression, it will consume all of the types at that location.
         let Some(starred_index) = targets.iter().position(ast::Expr::is_starred_expr) else {
             // Otherwise, the types will be unpacked 1-1 to the targets.
-            return Cow::Borrowed(tuple_ty.elements(self.db()).as_ref());
+            return Cow::Borrowed(tuple_ty.elements(self.db()));
         };
 
         if tuple_ty.len(self.db()) >= targets.len() - 1 {

--- a/crates/ty_python_semantic/src/unpack.rs
+++ b/crates/ty_python_semantic/src/unpack.rs
@@ -37,7 +37,7 @@ pub(crate) struct Unpack<'db> {
     /// The target expression that is being unpacked. For example, in `(a, b) = (1, 2)`, the target
     /// expression is `(a, b)`.
     #[no_eq]
-    #[return_ref]
+    #[returns(deref)]
     #[tracked]
     pub(crate) target: AstNodeRef<ast::Expr>,
 
@@ -102,7 +102,7 @@ impl<'db> UnpackValue<'db> {
 
     /// Returns the expression as an [`AnyNodeRef`].
     pub(crate) fn as_any_node_ref(self, db: &'db dyn Db) -> AnyNodeRef<'db> {
-        self.expression().node_ref(db).node().into()
+        self.expression().node_ref(db).into()
     }
 
     pub(crate) const fn kind(self) -> UnpackKind {

--- a/crates/ty_test/src/db.rs
+++ b/crates/ty_test/src/db.rs
@@ -90,8 +90,8 @@ impl SemanticDb for Db {
         !file.path(self).is_vendored_path()
     }
 
-    fn rule_selection(&self) -> Arc<RuleSelection> {
-        self.rule_selection.clone()
+    fn rule_selection(&self) -> &RuleSelection {
+        &self.rule_selection
     }
 
     fn lint_registry(&self) -> &LintRegistry {

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -30,7 +30,7 @@ ty_python_semantic = { path = "../crates/ty_python_semantic" }
 ty_vendored = { path = "../crates/ty_vendored" }
 
 libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer", default-features = false }
-salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "2c869364a9592d06fdf45c422e1e4a7265a8fe8a" }
+salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "7edce6e248f35c8114b4b021cdb474a3fb2813b3" }
 similar = { version = "2.5.0" }
 tracing = { version = "0.1.40" }
 

--- a/fuzz/fuzz_targets/ty_check_invalid_syntax.rs
+++ b/fuzz/fuzz_targets/ty_check_invalid_syntax.rs
@@ -95,8 +95,8 @@ impl SemanticDb for TestDb {
         !file.path(self).is_vendored_path()
     }
 
-    fn rule_selection(&self) -> Arc<RuleSelection> {
-        self.rule_selection.clone()
+    fn rule_selection(&self) -> &RuleSelection {
+        &self.rule_selection
     }
 
     fn lint_registry(&self) -> &LintRegistry {


### PR DESCRIPTION
This PR updates salsa to get the new `returns(ref)`, `returns(deref)`, `returns(as_ref)` and `retruns(as_deref)` (in addition to the existing `returns(clone)`, `returns(ref)` and `returns_copy)`. 

This helps simplify some of our code.

This PR also pulls in a perf improvement related to incremental verification of queries involving fixpoint.