### PR TITLE
Add progress bar for `ty check`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3984,6 +3984,7 @@ dependencies = [
  "crossbeam",
  "ctrlc",
  "filetime",
+ "indicatif",
  "insta",
  "insta-cmd",
  "jiff",

--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -16,7 +16,7 @@ use ruff_python_ast::PythonVersion;
 use ty_project::metadata::options::{EnvironmentOptions, Options};
 use ty_project::metadata::value::RangedValue;
 use ty_project::watch::{ChangeEvent, ChangedKind};
-use ty_project::{Db, ProjectDatabase, ProjectMetadata};
+use ty_project::{Db, DummyReporter, ProjectDatabase, ProjectMetadata};
 
 struct Case {
     db: ProjectDatabase,
@@ -131,7 +131,7 @@ fn benchmark_incremental(criterion: &mut Criterion) {
     fn setup() -> Case {
         let case = setup_tomllib_case();
 
-        let result: Vec<_> = case.db.check().unwrap();
+        let result: Vec<_> = case.db.check(&DummyReporter).unwrap();
 
         assert_diagnostics(&case.db, &result, EXPECTED_TOMLLIB_DIAGNOSTICS);
 
@@ -159,7 +159,7 @@ fn benchmark_incremental(criterion: &mut Criterion) {
             None,
         );
 
-        let result = db.check().unwrap();
+        let result = db.check(&DummyReporter).unwrap();
 
         assert_eq!(result.len(), EXPECTED_TOMLLIB_DIAGNOSTICS.len());
     }
@@ -179,7 +179,7 @@ fn benchmark_cold(criterion: &mut Criterion) {
             setup_tomllib_case,
             |case| {
                 let Case { db, .. } = case;
-                let result: Vec<_> = db.check().unwrap();
+                let result: Vec<_> = db.check(&DummyReporter).unwrap();
 
                 assert_diagnostics(db, &result, EXPECTED_TOMLLIB_DIAGNOSTICS);
             },
@@ -293,7 +293,7 @@ fn benchmark_many_string_assignments(criterion: &mut Criterion) {
             },
             |case| {
                 let Case { db, .. } = case;
-                let result = db.check().unwrap();
+                let result = db.check(&DummyReporter).unwrap();
                 assert_eq!(result.len(), 0);
             },
             BatchSize::SmallInput,

--- a/crates/ty/Cargo.toml
+++ b/crates/ty/Cargo.toml
@@ -28,6 +28,7 @@ colored = { workspace = true }
 countme = { workspace = true, features = ["enable"] }
 crossbeam = { workspace = true }
 ctrlc = { version = "3.4.4" }
+indicatif = { workspace = true }
 jiff = { workspace = true }
 rayon = { workspace = true }
 salsa = { workspace = true }

--- a/crates/ty/tests/file_watching.rs
+++ b/crates/ty/tests/file_watching.rs
@@ -14,7 +14,7 @@ use ty_project::metadata::options::{EnvironmentOptions, Options};
 use ty_project::metadata::pyproject::{PyProject, Tool};
 use ty_project::metadata::value::{RangedValue, RelativePathBuf};
 use ty_project::watch::{directory_watcher, ChangeEvent, ProjectWatcher};
-use ty_project::{Db, ProjectDatabase, ProjectMetadata};
+use ty_project::{Db, DummyReporter, ProjectDatabase, ProjectMetadata};
 use ty_python_semantic::{resolve_module, ModuleName, PythonPlatform};
 
 struct TestCase {
@@ -1117,7 +1117,10 @@ print(sys.last_exc, os.getegid())
         Ok(())
     })?;
 
-    let diagnostics = case.db.check().context("Failed to check project.")?;
+    let diagnostics = case
+        .db
+        .check(&DummyReporter)
+        .context("Failed to check project.")?;
 
     assert_eq!(diagnostics.len(), 2);
     assert_eq!(
@@ -1142,7 +1145,10 @@ print(sys.last_exc, os.getegid())
     })
     .expect("Search path settings to be valid");
 
-    let diagnostics = case.db.check().context("Failed to check project.")?;
+    let diagnostics = case
+        .db
+        .check(&DummyReporter)
+        .context("Failed to check project.")?;
     assert!(diagnostics.is_empty());
 
     Ok(())

--- a/crates/ty_project/src/db.rs
+++ b/crates/ty_project/src/db.rs
@@ -2,7 +2,7 @@ use std::panic::RefUnwindSafe;
 use std::sync::Arc;
 
 use crate::DEFAULT_LINT_REGISTRY;
-use crate::{Project, ProjectMetadata};
+use crate::{Project, ProjectMetadata, Reporter};
 use ruff_db::diagnostic::Diagnostic;
 use ruff_db::files::{File, Files};
 use ruff_db::system::System;
@@ -68,8 +68,8 @@ impl ProjectDatabase {
     }
 
     /// Checks all open files in the project and its dependencies.
-    pub fn check(&self) -> Result<Vec<Diagnostic>, Cancelled> {
-        self.with_db(|db| db.project().check(db))
+    pub fn check(&self, reporter: &impl Reporter) -> Result<Vec<Diagnostic>, Cancelled> {
+        self.with_db(|db| db.project().check(db, reporter))
     }
 
     #[tracing::instrument(level = "debug", skip(self))]

--- a/crates/ty_project/src/files.rs
+++ b/crates/ty_project/src/files.rs
@@ -161,6 +161,10 @@ impl Indexed<'_> {
     pub(super) fn diagnostics(&self) -> &[IOErrorDiagnostic] {
         &self.inner.diagnostics
     }
+
+    pub(super) fn len(&self) -> usize {
+        self.inner.files.len()
+    }
 }
 
 impl Deref for Indexed<'_> {

--- a/crates/ty_wasm/src/lib.rs
+++ b/crates/ty_wasm/src/lib.rs
@@ -18,8 +18,8 @@ use ty_ide::{goto_type_definition, hover, inlay_hints, MarkupKind};
 use ty_project::metadata::options::Options;
 use ty_project::metadata::value::ValueSource;
 use ty_project::watch::{ChangeEvent, ChangedKind, CreatedKind, DeletedKind};
-use ty_project::ProjectMetadata;
 use ty_project::{Db, ProjectDatabase};
+use ty_project::{DummyReporter, ProjectMetadata};
 use ty_python_semantic::Program;
 use wasm_bindgen::prelude::*;
 
@@ -186,7 +186,7 @@ impl Workspace {
 
     /// Checks all open files
     pub fn check(&self) -> Result<Vec<Diagnostic>, Error> {
-        let result = self.db.check().map_err(into_error)?;
+        let result = self.db.check(&DummyReporter).map_err(into_error)?;
 
         Ok(result.into_iter().map(Diagnostic::wrap).collect())
     }


### PR DESCRIPTION
## Summary

Adds a simple progress bar for the `ty check` CLI command. The style is taken from uv, and like uv the bar is always shown - for smaller projects it is fast enough that it isn't noticeable. We could alternatively hide it completely based on some heuristic for the number of files, or only show it after some amount of time.

I also disabled it when `--watch` is passed, cancelling inflight checks was leading to zombie progress bars. I think we can fix this by using [`MultiProgress`](https://docs.rs/indicatif/latest/indicatif/struct.MultiProgress.html) and managing all the bars globally, but I left that out for now.

Resolves https://github.com/astral-sh/ty/issues/98.

## Test Plan

https://github.com/user-attachments/assets/1e6b76c6-f6cb-4967-8194-e774879b6dd1