### PR TITLE
[`flake8-use-pathlib`] `PTH*` suppress diagnostic for all `os.*` functions that have the `dir_fd` parameter

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/PTH207.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/PTH207.py
@@ -9,3 +9,7 @@ extensions_dir = "./extensions"
 glob.glob(os.path.join(extensions_dir, "ops", "autograd", "*.cpp"))
 list(glob.iglob(os.path.join(extensions_dir, "ops", "autograd", "*.cpp")))
 search("*.png")
+
+# if `dir_fd` is set, suppress the diagnostic
+glob.glob(os.path.join(extensions_dir, "ops", "autograd", "*.cpp"), dir_fd=1)
+list(glob.iglob(os.path.join(extensions_dir, "ops", "autograd", "*.cpp"), dir_fd=1))

--- a/crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/full_name.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/full_name.py
@@ -87,3 +87,20 @@ def bar(x: int):
 os.rename("src", "dst", src_dir_fd=3, dst_dir_fd=4)
 os.rename("src", "dst", src_dir_fd=3)
 os.rename("src", "dst", dst_dir_fd=4)
+
+# if `dir_fd` is set, suppress the diagnostic
+os.readlink(p, dir_fd=1)
+os.stat(p, dir_fd=2)
+os.unlink(p, dir_fd=3)
+os.remove(p, dir_fd=4)
+os.rmdir(p, dir_fd=5)
+os.mkdir(p, dir_fd=6)
+os.chmod(p, dir_fd=7)
+# `chmod` can also receive a file descriptor in the first argument
+os.chmod(8)
+os.chmod(x)
+
+# if `src_dir_fd` or `dst_dir_fd` are set, suppress the diagnostic
+os.replace("src", "dst", src_dir_fd=1, dst_dir_fd=2)
+os.replace("src", "dst", src_dir_fd=1)
+os.replace("src", "dst", dst_dir_fd=2)

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/replaceable_by_pathlib.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/replaceable_by_pathlib.rs
@@ -35,12 +35,9 @@ pub(crate) fn replaceable_by_pathlib(checker: &Checker, call: &ExprCall) {
             // ```
             if call
                 .arguments
-                .find_positional(0)
+                .find_argument_value("path", 0)
                 .is_some_and(|expr| is_file_descriptor(expr, checker.semantic()))
-                || call
-                    .arguments
-                    .find_argument_value("dir_fd", 2)
-                    .is_some_and(|expr| !expr.is_none_literal_expr())
+                || is_argument_non_default(&call.arguments, "dir_fd", 2)
             {
                 return;
             }
@@ -56,11 +53,7 @@ pub(crate) fn replaceable_by_pathlib(checker: &Checker, call: &ExprCall) {
             //           0     1                2
             // os.mkdir(path, mode=0o777, *, dir_fd=None)
             // ```
-            if call
-                .arguments
-                .find_argument_value("dir_fd", 2)
-                .is_some_and(|expr| !expr.is_none_literal_expr())
-            {
+            if is_argument_non_default(&call.arguments, "dir_fd", 2) {
                 return;
             }
             OsMkdir.into()
@@ -74,14 +67,8 @@ pub(crate) fn replaceable_by_pathlib(checker: &Checker, call: &ExprCall) {
             //           0    1       2                3
             // os.rename(src, dst, *, src_dir_fd=None, dst_dir_fd=None)
             // ```
-            if call
-                .arguments
-                .find_argument_value("src_dir_fd", 2)
-                .is_some_and(|expr| !expr.is_none_literal_expr())
-                || call
-                    .arguments
-                    .find_argument_value("dst_dir_fd", 3)
-                    .is_some_and(|expr| !expr.is_none_literal_expr())
+            if is_argument_non_default(&call.arguments, "src_dir_fd", 2)
+                || is_argument_non_default(&call.arguments, "dst_dir_fd", 3)
             {
                 return;
             }
@@ -96,14 +83,8 @@ pub(crate) fn replaceable_by_pathlib(checker: &Checker, call: &ExprCall) {
             //              0    1       2                3
             // os.replace(src, dst, *, src_dir_fd=None, dst_dir_fd=None)
             // ```
-            if call
-                .arguments
-                .find_argument_value("src_dir_fd", 2)
-                .is_some_and(|expr| !expr.is_none_literal_expr())
-                || call
-                    .arguments
-                    .find_argument_value("dst_dir_fd", 3)
-                    .is_some_and(|expr| !expr.is_none_literal_expr())
+            if is_argument_non_default(&call.arguments, "src_dir_fd", 2)
+                || is_argument_non_default(&call.arguments, "dst_dir_fd", 3)
             {
                 return;
             }
@@ -117,11 +98,7 @@ pub(crate) fn replaceable_by_pathlib(checker: &Checker, call: &ExprCall) {
             //            0         1
             // os.rmdir(path, *, dir_fd=None)
             // ```
-            if call
-                .arguments
-                .find_argument_value("dir_fd", 1)
-                .is_some_and(|expr| !expr.is_none_literal_expr())
-            {
+            if is_argument_non_default(&call.arguments, "dir_fd", 1) {
                 return;
             }
             OsRmdir.into()
@@ -134,11 +111,7 @@ pub(crate) fn replaceable_by_pathlib(checker: &Checker, call: &ExprCall) {
             //            0         1
             // os.remove(path, *, dir_fd=None)
             // ```
-            if call
-                .arguments
-                .find_argument_value("dir_fd", 1)
-                .is_some_and(|expr| !expr.is_none_literal_expr())
-            {
+            if is_argument_non_default(&call.arguments, "dir_fd", 1) {
                 return;
             }
             OsRemove.into()
@@ -151,11 +124,7 @@ pub(crate) fn replaceable_by_pathlib(checker: &Checker, call: &ExprCall) {
             //            0         1
             // os.unlink(path, *, dir_fd=None)
             // ```
-            if call
-                .arguments
-                .find_argument_value("dir_fd", 1)
-                .is_some_and(|expr| !expr.is_none_literal_expr())
-            {
+            if is_argument_non_default(&call.arguments, "dir_fd", 1) {
                 return;
             }
             OsUnlink.into()
@@ -183,12 +152,9 @@ pub(crate) fn replaceable_by_pathlib(checker: &Checker, call: &ExprCall) {
             // ```
             if call
                 .arguments
-                .find_positional(0)
+                .find_argument_value("path", 0)
                 .is_some_and(|expr| is_file_descriptor(expr, checker.semantic()))
-                || call
-                    .arguments
-                    .find_argument_value("dir_fd", 1)
-                    .is_some_and(|expr| !expr.is_none_literal_expr())
+                || is_argument_non_default(&call.arguments, "dir_fd", 1)
             {
                 return;
             }
@@ -257,13 +223,10 @@ pub(crate) fn replaceable_by_pathlib(checker: &Checker, call: &ExprCall) {
                         Expr::BooleanLiteral(ExprBooleanLiteral { value: true, .. })
                     )
                 })
+                || is_argument_non_default(&call.arguments, "opener", 7)
                 || call
                     .arguments
-                    .find_argument_value("opener", 7)
-                    .is_some_and(|expr| !expr.is_none_literal_expr())
-                || call
-                    .arguments
-                    .find_positional(0)
+                    .find_argument_value("file", 0)
                     .is_some_and(|expr| is_file_descriptor(expr, checker.semantic()))
             {
                 return;
@@ -280,11 +243,7 @@ pub(crate) fn replaceable_by_pathlib(checker: &Checker, call: &ExprCall) {
             //               0           1              2            3                 4
             // glob.glob(pathname, *, root_dir=None, dir_fd=None, recursive=False, include_hidden=False)
             // ```
-            if call
-                .arguments
-                .find_argument_value("dir_fd", 2)
-                .is_some_and(|expr| !expr.is_none_literal_expr())
-            {
+            if is_argument_non_default(&call.arguments, "dir_fd", 2) {
                 return;
             }
 
@@ -301,11 +260,7 @@ pub(crate) fn replaceable_by_pathlib(checker: &Checker, call: &ExprCall) {
             //                0           1              2            3                 4
             // glob.iglob(pathname, *, root_dir=None, dir_fd=None, recursive=False, include_hidden=False)
             // ```
-            if call
-                .arguments
-                .find_argument_value("dir_fd", 2)
-                .is_some_and(|expr| !expr.is_none_literal_expr())
-            {
+            if is_argument_non_default(&call.arguments, "dir_fd", 2) {
                 return;
             }
 
@@ -323,11 +278,7 @@ pub(crate) fn replaceable_by_pathlib(checker: &Checker, call: &ExprCall) {
             //               0         1
             // os.readlink(path, *, dir_fd=None)
             // ```
-            if call
-                .arguments
-                .find_argument_value("dir_fd", 1)
-                .is_some_and(|expr| !expr.is_none_literal_expr())
-            {
+            if is_argument_non_default(&call.arguments, "dir_fd", 1) {
                 return;
             }
             OsReadlink.into()
@@ -380,4 +331,11 @@ fn get_name_expr(expr: &Expr) -> Option<&ast::ExprName> {
         Expr::Call(ast::ExprCall { func, .. }) => get_name_expr(func),
         _ => None,
     }
+}
+
+/// Returns `true` if argument `name` is set to a non-default `None` value.
+fn is_argument_non_default(arguments: &ast::Arguments, name: &str, position: usize) -> bool {
+    arguments
+        .find_argument_value(name, position)
+        .is_some_and(|expr| !expr.is_none_literal_expr())
 }

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/snapshots/ruff_linter__rules__flake8_use_pathlib__tests__PTH207_PTH207.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/snapshots/ruff_linter__rules__flake8_use_pathlib__tests__PTH207_PTH207.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_use_pathlib/mod.rs
-snapshot_kind: text
 ---
 PTH207.py:9:1: PTH207 Replace `glob` with `Path.glob` or `Path.rglob`
    |
@@ -26,4 +25,6 @@ PTH207.py:11:1: PTH207 Replace `glob` with `Path.glob` or `Path.rglob`
 10 | list(glob.iglob(os.path.join(extensions_dir, "ops", "autograd", "*.cpp")))
 11 | search("*.png")
    | ^^^^^^ PTH207
+12 |
+13 | # if `dir_fd` is set, suppress the diagnostic
    |


### PR DESCRIPTION

<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Fixes #17776.

This PR also handles all other `PTH*` rules that don't support file descriptors.

## Test Plan

<!-- How was it tested? -->

Update existing tests.
