### PR TITLE
[ty] Support frozen dataclasses

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/dataclasses.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses.md
@@ -369,14 +369,26 @@ To do
 
 ### `frozen`
 
-If true (the default is False), assigning to fields will generate a diagnostic. If `__setattr__()` or
-`__delattr__()` is defined in the class, we should emit a diagnostic.
+If true (the default is False), assigning to fields will generate a diagnostic.
 
 ```py
 from dataclasses import dataclass
 
 @dataclass(frozen=True)
-class Frozen:
+class MyFrozenClass:
+    x: int
+
+frozen_instance = MyFrozenClass(1)
+frozen_instance.x = 2  # error: [invalid-assignment]
+```
+
+If `__setattr__()` or `__delattr__()` is defined in the class, we should emit a diagnostic.
+
+```py
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class MyFrozenClass:
     x: int
 
     # TODO: Emit a diagnostic here
@@ -384,9 +396,37 @@ class Frozen:
 
     # TODO: Emit a diagnostic here
     def __delattr__(self, name: str) -> None: ...
+```
 
-frozen = Frozen(1)
-frozen.x = 2  # error: [invalid-assignment]
+This also works for generic dataclasses:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class MyFrozenGeneric[T]:
+    x: T
+
+frozen_instance = MyFrozenGeneric[int](1)
+frozen_instance.x = 2  # TODO
+```
+
+When attempting to mutate an unresolved attribute on a frozen dataclass, only `unresolved-attribute`
+is emitted:
+
+```py
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class MyFrozenClass: ...
+
+frozen = MyFrozenClass()
+frozen.x = 2  # error: [unresolved-attribute]
 ```
 
 ### `match_args`

--- a/crates/ty_python_semantic/resources/mdtest/dataclasses.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses.md
@@ -413,7 +413,7 @@ class MyFrozenGeneric[T]:
     x: T
 
 frozen_instance = MyFrozenGeneric[int](1)
-frozen_instance.x = 2  # TODO
+frozen_instance.x = 2  # error: [invalid-assignment]
 ```
 
 When attempting to mutate an unresolved attribute on a frozen dataclass, only `unresolved-attribute`

--- a/crates/ty_python_semantic/resources/mdtest/dataclasses.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses.md
@@ -369,7 +369,25 @@ To do
 
 ### `frozen`
 
-To do
+If true (the default is False), assigning to fields will generate a diagnostic. If __setattr__() or
+__delattr__() is defined in the class, we should emit a diagnostic.
+
+```py
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class Frozen:
+    x: int
+
+    # TODO: Emit a diagnostic here
+    def __setattr__(self, name: str, value: object) -> None: ...
+
+    # TODO: Emit a diagnostic here
+    def __delattr__(self, name: str) -> None: ...
+
+frozen = Frozen(1)
+frozen.x = 2  # error: [invalid-assignment]
+```
 
 ### `match_args`
 

--- a/crates/ty_python_semantic/resources/mdtest/dataclasses.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses.md
@@ -369,8 +369,8 @@ To do
 
 ### `frozen`
 
-If true (the default is False), assigning to fields will generate a diagnostic. If __setattr__() or
-__delattr__() is defined in the class, we should emit a diagnostic.
+If true (the default is False), assigning to fields will generate a diagnostic. If `__setattr__()` or
+`__delattr__()` is defined in the class, we should emit a diagnostic.
 
 ```py
 from dataclasses import dataclass


### PR DESCRIPTION
## Summary
https://github.com/astral-sh/ty/issues/111

This PR adds support for `frozen` dataclasses. It will emit a diagnostic with a similar message to mypy

Note: This does not include emitting a diagnostic if `__setattr__` or `__delattr__` are defined on the object as per the [spec](https://docs.python.org/3/library/dataclasses.html#module-contents)

## Test Plan
mdtest
