### PR TITLE
Link to the rules.md in the ty repository

### DIFF
--- a/crates/ty/docs/configuration.md
+++ b/crates/ty/docs/configuration.md
@@ -22,7 +22,7 @@ respect-ignore-files = false
 
 Configures the enabled rules and their severity.
 
-See [the rules documentation](https://github.com/astral-sh/ruff/blob/main/crates/ty/docs/rules.md) for a list of all available rules.
+See [the rules documentation](https://github.com/astral-sh/ty/blob/main/docs/rules.md) for a list of all available rules.
 
 Valid severities are:
 

--- a/crates/ty_project/src/metadata/options.rs
+++ b/crates/ty_project/src/metadata/options.rs
@@ -31,7 +31,7 @@ pub struct Options {
 
     /// Configures the enabled rules and their severity.
     ///
-    /// See [the rules documentation](https://github.com/astral-sh/ruff/blob/main/crates/ty/docs/rules.md) for a list of all available rules.
+    /// See [the rules documentation](https://github.com/astral-sh/ty/blob/main/docs/rules.md) for a list of all available rules.
     ///
     /// Valid severities are:
     ///

--- a/ty.schema.json
+++ b/ty.schema.json
@@ -22,7 +22,7 @@
       ]
     },
     "rules": {
-      "description": "Configures the enabled rules and their severity.\n\nSee [the rules documentation](https://github.com/astral-sh/ruff/blob/main/crates/ty/docs/rules.md) for a list of all available rules.\n\nValid severities are:\n\n* `ignore`: Disable the rule. * `warn`: Enable the rule and create a warning diagnostic. * `error`: Enable the rule and create an error diagnostic. ty will exit with a non-zero code if any error diagnostics are emitted.",
+      "description": "Configures the enabled rules and their severity.\n\nSee [the rules documentation](https://github.com/astral-sh/ty/blob/main/docs/rules.md) for a list of all available rules.\n\nValid severities are:\n\n* `ignore`: Disable the rule. * `warn`: Enable the rule and create a warning diagnostic. * `error`: Enable the rule and create an error diagnostic. ty will exit with a non-zero code if any error diagnostics are emitted.",
       "anyOf": [
         {
           "$ref": "#/definitions/Rules"


### PR DESCRIPTION
## Summary

https://github.com/astral-sh/ty/pull/292 adds a script that copies over the reference documentation into the ty repository because
I worry that it's somewhat confusing for users to find the ty documentation in the ruff repository (and github doesn't support relative links into submodules). 

This PR updates the in the schema/configuration reference to point to the `rules.md` in the ty repository.

