### PR TITLE
[ty] Change range of `revealed-type` diagnostic to be the range of the argument passed in, not the whole call

### DIFF
--- a/crates/ty/tests/cli.rs
+++ b/crates/ty/tests/cli.rs
@@ -197,12 +197,12 @@ fn config_override_python_platform() -> anyhow::Result<()> {
     exit_code: 0
     ----- stdout -----
     info: revealed-type: Revealed type
-     --> test.py:5:1
+     --> test.py:5:13
       |
     3 | from typing_extensions import reveal_type
     4 |
     5 | reveal_type(sys.platform)
-      | ^^^^^^^^^^^^^^^^^^^^^^^^^ `Literal["linux"]`
+      |             ^^^^^^^^^^^^ `Literal["linux"]`
       |
 
     Found 1 diagnostic
@@ -215,12 +215,12 @@ fn config_override_python_platform() -> anyhow::Result<()> {
     exit_code: 0
     ----- stdout -----
     info: revealed-type: Revealed type
-     --> test.py:5:1
+     --> test.py:5:13
       |
     3 | from typing_extensions import reveal_type
     4 |
     5 | reveal_type(sys.platform)
-      | ^^^^^^^^^^^^^^^^^^^^^^^^^ `LiteralString`
+      |             ^^^^^^^^^^^^ `LiteralString`
       |
 
     Found 1 diagnostic
@@ -711,11 +711,11 @@ fn exit_code_only_info() -> anyhow::Result<()> {
     exit_code: 0
     ----- stdout -----
     info: revealed-type: Revealed type
-     --> test.py:3:1
+     --> test.py:3:13
       |
     2 | from typing_extensions import reveal_type
     3 | reveal_type(1)
-      | ^^^^^^^^^^^^^^ `Literal[1]`
+      |             ^ `Literal[1]`
       |
 
     Found 1 diagnostic
@@ -741,11 +741,11 @@ fn exit_code_only_info_and_error_on_warning_is_true() -> anyhow::Result<()> {
     exit_code: 0
     ----- stdout -----
     info: revealed-type: Revealed type
-     --> test.py:3:1
+     --> test.py:3:13
       |
     2 | from typing_extensions import reveal_type
     3 | reveal_type(1)
-      | ^^^^^^^^^^^^^^ `Literal[1]`
+      |             ^ `Literal[1]`
       |
 
     Found 1 diagnostic
@@ -1219,7 +1219,7 @@ fn concise_revealed_type() -> anyhow::Result<()> {
     success: true
     exit_code: 0
     ----- stdout -----
-    info[revealed-type] test.py:5:1: Revealed type: `Literal["hello"]`
+    info[revealed-type] test.py:5:13: Revealed type: `Literal["hello"]`
     Found 1 diagnostic
 
     ----- stderr -----
@@ -1248,12 +1248,12 @@ fn can_handle_large_binop_expressions() -> anyhow::Result<()> {
     exit_code: 0
     ----- stdout -----
     info: revealed-type: Revealed type
-     --> test.py:4:1
+     --> test.py:4:13
       |
     2 | from typing_extensions import reveal_type
     3 | total = 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1...
     4 | reveal_type(total)
-      | ^^^^^^^^^^^^^^^^^^ `Literal[2000]`
+      |             ^^^^^ `Literal[2000]`
       |
 
     Found 1 diagnostic

--- a/crates/ty_python_semantic/resources/mdtest/expression/len.md
+++ b/crates/ty_python_semantic/resources/mdtest/expression/len.md
@@ -11,30 +11,28 @@ reveal_type(len(r"conca\t" "ena\tion"))  # revealed: Literal[14]
 reveal_type(len(b"ytes lite" rb"al"))  # revealed: Literal[11]
 reveal_type(len("𝒰𝕹🄸©🕲𝕕ℇ"))  # revealed: Literal[7]
 
-reveal_type(  # revealed: Literal[7]
-    len(
+# fmt: off
+
+reveal_type(len(  # revealed: Literal[7]
         """foo
 bar"""
-    )
-)
-reveal_type(  # revealed: Literal[9]
-    len(
+))
+
+reveal_type(len(  # revealed: Literal[9]
         r"""foo\r
 bar"""
-    )
-)
-reveal_type(  # revealed: Literal[7]
-    len(
+))
+
+reveal_type(len(  # revealed: Literal[7]
         b"""foo
 bar"""
-    )
-)
-reveal_type(  # revealed: Literal[9]
-    len(
+))
+reveal_type(len(  # revealed: Literal[9]
         rb"""foo\r
 bar"""
-    )
-)
+))
+
+# fmt: on
 ```
 
 ### Tuples
@@ -50,15 +48,17 @@ reveal_type(len(tuple()))  # revealed: int
 # TODO: Handle star unpacks; Should be: Literal[0]
 reveal_type(len((*[],)))  # revealed: Literal[1]
 
+# fmt: off
+
 # TODO: Handle star unpacks; Should be: Literal[1]
-reveal_type(  # revealed: Literal[2]
-    len(
-        (
-            *[],
-            1,
-        )
+reveal_type(len(  # revealed: Literal[2]
+    (
+        *[],
+        1,
     )
-)
+))
+
+# fmt: on
 
 # TODO: Handle star unpacks; Should be: Literal[2]
 reveal_type(len((*[], 1, 2)))  # revealed: Literal[3]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Bad_`__getitem__`_method.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Bad_`__getitem__`_method.snap
@@ -44,12 +44,12 @@ info: `lint:not-iterable` is enabled by default
 
 ```
 info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:11:5
+  --> src/mdtest_snippet.py:11:17
    |
  9 | # error: [not-iterable]
 10 | for x in Iterable():
 11 |     reveal_type(x)  # revealed: int
-   |     ^^^^^^^^^^^^^^ `int`
+   |                 ^ `int`
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_No_`__iter__`_method_and_`__getitem__`_is_not_callable.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_No_`__iter__`_method_and_`__getitem__`_is_not_callable.snap
@@ -40,12 +40,12 @@ info: `lint:not-iterable` is enabled by default
 
 ```
 info: revealed-type: Revealed type
- --> src/mdtest_snippet.py:8:5
+ --> src/mdtest_snippet.py:8:17
   |
 6 | # error: [not-iterable]
 7 | for x in Bad():
 8 |     reveal_type(x)  # revealed: Unknown
-  |     ^^^^^^^^^^^^^^ `Unknown`
+  |                 ^ `Unknown`
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly-not-callable_`__getitem__`_method.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly-not-callable_`__getitem__`_method.snap
@@ -63,12 +63,12 @@ info: `lint:not-iterable` is enabled by default
 
 ```
 info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:24:9
+  --> src/mdtest_snippet.py:24:21
    |
 22 |     for x in Iterable1():
 23 |         # TODO... `int` might be ideal here?
 24 |         reveal_type(x)  # revealed: int | Unknown
-   |         ^^^^^^^^^^^^^^ `int | Unknown`
+   |                     ^ `int | Unknown`
 25 |
 26 |     # error: [not-iterable]
    |
@@ -93,12 +93,12 @@ info: `lint:not-iterable` is enabled by default
 
 ```
 info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:29:9
+  --> src/mdtest_snippet.py:29:21
    |
 27 |     for y in Iterable2():
 28 |         # TODO... `int` might be ideal here?
 29 |         reveal_type(y)  # revealed: int | Unknown
-   |         ^^^^^^^^^^^^^^ `int | Unknown`
+   |                     ^ `int | Unknown`
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__getitem__`_methods.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__getitem__`_methods.snap
@@ -60,12 +60,12 @@ info: `lint:not-iterable` is enabled by default
 
 ```
 info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:22:9
+  --> src/mdtest_snippet.py:22:21
    |
 20 |     for x in Iterable1():
 21 |         # TODO: `str` might be better
 22 |         reveal_type(x)  # revealed: str | Unknown
-   |         ^^^^^^^^^^^^^^ `str | Unknown`
+   |                     ^ `str | Unknown`
 23 |
 24 |     # error: [not-iterable]
    |
@@ -89,12 +89,12 @@ info: `lint:not-iterable` is enabled by default
 
 ```
 info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:26:9
+  --> src/mdtest_snippet.py:26:21
    |
 24 |     # error: [not-iterable]
 25 |     for y in Iterable2():
 26 |         reveal_type(y)  # revealed: str | int
-   |         ^^^^^^^^^^^^^^ `str | int`
+   |                     ^ `str | int`
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__iter__`_methods.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__iter__`_methods.snap
@@ -64,12 +64,12 @@ info: `lint:not-iterable` is enabled by default
 
 ```
 info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:18:9
+  --> src/mdtest_snippet.py:18:21
    |
 16 |     # error: [not-iterable]
 17 |     for x in Iterable1():
 18 |         reveal_type(x)  # revealed: int
-   |         ^^^^^^^^^^^^^^ `int`
+   |                     ^ `int`
 19 |
 20 |     class Iterable2:
    |
@@ -93,12 +93,12 @@ info: `lint:not-iterable` is enabled by default
 
 ```
 info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:30:9
+  --> src/mdtest_snippet.py:30:21
    |
 28 |     for x in Iterable2():
 29 |         # TODO: `int` would probably be better here:
 30 |         reveal_type(x)  # revealed: int | Unknown
-   |         ^^^^^^^^^^^^^^ `int | Unknown`
+   |                     ^ `int | Unknown`
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__next__`_method.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__next__`_method.snap
@@ -67,12 +67,12 @@ info: `lint:not-iterable` is enabled by default
 
 ```
 info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:29:9
+  --> src/mdtest_snippet.py:29:21
    |
 27 |     # error: [not-iterable]
 28 |     for x in Iterable1():
 29 |         reveal_type(x)  # revealed: int | str
-   |         ^^^^^^^^^^^^^^ `int | str`
+   |                     ^ `int | str`
 30 |
 31 |     # error: [not-iterable]
    |
@@ -96,12 +96,12 @@ info: `lint:not-iterable` is enabled by default
 
 ```
 info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:34:9
+  --> src/mdtest_snippet.py:34:21
    |
 32 |     for y in Iterable2():
 33 |         # TODO: `int` would probably be better here:
 34 |         reveal_type(y)  # revealed: int | Unknown
-   |         ^^^^^^^^^^^^^^ `int | Unknown`
+   |                     ^ `int | Unknown`
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_bad_`__getitem__`_method.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_bad_`__getitem__`_method.snap
@@ -52,12 +52,12 @@ info: `lint:not-iterable` is enabled by default
 
 ```
 info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:19:9
+  --> src/mdtest_snippet.py:19:21
    |
 17 |     # error: [not-iterable]
 18 |     for x in Iterable():
 19 |         reveal_type(x)  # revealed: int | bytes
-   |         ^^^^^^^^^^^^^^ `int | bytes`
+   |                     ^ `int | bytes`
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_possibly_invalid_`__getitem__`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_possibly_invalid_`__getitem__`.snap
@@ -70,12 +70,12 @@ info: `lint:not-iterable` is enabled by default
 
 ```
 info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:33:9
+  --> src/mdtest_snippet.py:33:21
    |
 31 |     for x in Iterable1():
 32 |         # TODO: `bytes | str` might be better
 33 |         reveal_type(x)  # revealed: bytes | str | Unknown
-   |         ^^^^^^^^^^^^^^ `bytes | str | Unknown`
+   |                     ^ `bytes | str | Unknown`
 34 |
 35 |     # error: [not-iterable]
    |
@@ -99,12 +99,12 @@ info: `lint:not-iterable` is enabled by default
 
 ```
 info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:37:9
+  --> src/mdtest_snippet.py:37:21
    |
 35 |     # error: [not-iterable]
 36 |     for y in Iterable2():
 37 |         reveal_type(y)  # revealed: bytes | str | int
-   |         ^^^^^^^^^^^^^^ `bytes | str | int`
+   |                     ^ `bytes | str | int`
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_possibly_unbound_`__getitem__`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_possibly_unbound_`__getitem__`.snap
@@ -50,12 +50,12 @@ info: `lint:not-iterable` is enabled by default
 
 ```
 info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:18:9
+  --> src/mdtest_snippet.py:18:21
    |
 16 |     # error: [not-iterable]
 17 |     for x in Iterable():
 18 |         reveal_type(x)  # revealed: int | bytes
-   |         ^^^^^^^^^^^^^^ `int | bytes`
+   |                     ^ `int | bytes`
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Union_type_as_iterable_where_one_union_element_has_invalid_`__iter__`_method.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Union_type_as_iterable_where_one_union_element_has_invalid_`__iter__`_method.snap
@@ -52,12 +52,12 @@ info: `lint:not-iterable` is enabled by default
 
 ```
 info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:19:9
+  --> src/mdtest_snippet.py:19:21
    |
 17 |     # error: [not-iterable]
 18 |     for x in Test() if flag else Test2():
 19 |         reveal_type(x)  # revealed: int
-   |         ^^^^^^^^^^^^^^ `int`
+   |                     ^ `int`
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Union_type_as_iterable_where_one_union_element_has_no_`__iter__`_method.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Union_type_as_iterable_where_one_union_element_has_no_`__iter__`_method.snap
@@ -47,12 +47,12 @@ info: `lint:not-iterable` is enabled by default
 
 ```
 info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:14:9
+  --> src/mdtest_snippet.py:14:21
    |
 12 |     # error: [not-iterable]
 13 |     for x in Test() if flag else 42:
 14 |         reveal_type(x)  # revealed: int
-   |         ^^^^^^^^^^^^^^ `int`
+   |                     ^ `int`
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_With_non-callable_iterator.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_With_non-callable_iterator.snap
@@ -47,18 +47,6 @@ info: `lint:not-iterable` is enabled by default
 ```
 
 ```
-info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:16:5
-   |
-14 |     # revealed: Unknown
-15 |     # error: [possibly-unresolved-reference]
-16 |     reveal_type(x)
-   |     ^^^^^^^^^^^^^^ `Unknown`
-   |
-
-```
-
-```
 info: lint:possibly-unresolved-reference: Name `x` used when possibly not defined
   --> src/mdtest_snippet.py:16:17
    |
@@ -68,5 +56,17 @@ info: lint:possibly-unresolved-reference: Name `x` used when possibly not define
    |                 ^
    |
 info: `lint:possibly-unresolved-reference` is enabled by default
+
+```
+
+```
+info: revealed-type: Revealed type
+  --> src/mdtest_snippet.py:16:17
+   |
+14 |     # revealed: Unknown
+15 |     # error: [possibly-unresolved-reference]
+16 |     reveal_type(x)
+   |                 ^ `Unknown`
+   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_does_not_return_an_iterator.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_does_not_return_an_iterator.snap
@@ -41,12 +41,12 @@ info: `lint:not-iterable` is enabled by default
 
 ```
 info: revealed-type: Revealed type
- --> src/mdtest_snippet.py:9:5
+ --> src/mdtest_snippet.py:9:17
   |
 7 | # error: [not-iterable]
 8 | for x in Bad():
 9 |     reveal_type(x)  # revealed: Unknown
-  |     ^^^^^^^^^^^^^^ `Unknown`
+  |                 ^ `Unknown`
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_method_with_a_bad_signature.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_method_with_a_bad_signature.snap
@@ -46,12 +46,12 @@ info: `lint:not-iterable` is enabled by default
 
 ```
 info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:13:5
+  --> src/mdtest_snippet.py:13:17
    |
 11 | # error: [not-iterable]
 12 | for x in Iterable():
 13 |     reveal_type(x)  # revealed: int
-   |     ^^^^^^^^^^^^^^ `int`
+   |                 ^ `int`
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_returns_an_iterator_with_an_invalid_`__next__`_method.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_returns_an_iterator_with_an_invalid_`__next__`_method.snap
@@ -57,12 +57,12 @@ info: `lint:not-iterable` is enabled by default
 
 ```
 info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:20:5
+  --> src/mdtest_snippet.py:20:17
    |
 18 | # error: [not-iterable]
 19 | for x in Iterable1():
 20 |     reveal_type(x)  # revealed: int
-   |     ^^^^^^^^^^^^^^ `int`
+   |                 ^ `int`
 21 |
 22 | # error: [not-iterable]
    |
@@ -85,12 +85,12 @@ info: `lint:not-iterable` is enabled by default
 
 ```
 info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:24:5
+  --> src/mdtest_snippet.py:24:17
    |
 22 | # error: [not-iterable]
 23 | for y in Iterable2():
 24 |     reveal_type(y)  # revealed: Unknown
-   |     ^^^^^^^^^^^^^^ `Unknown`
+   |                 ^ `Unknown`
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___Legacy_syntax_-_Inferring_a_bound_typevar.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___Legacy_syntax_-_Inferring_a_bound_typevar.snap
@@ -30,12 +30,12 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/legacy/function
 
 ```
 info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:9:1
+  --> src/mdtest_snippet.py:9:13
    |
  7 |     return x
  8 |
  9 | reveal_type(f(1))  # revealed: Literal[1]
-   | ^^^^^^^^^^^^^^^^^ `Literal[1]`
+   |             ^^^^ `Literal[1]`
 10 | reveal_type(f(True))  # revealed: Literal[True]
 11 | # error: [invalid-argument-type]
    |
@@ -44,11 +44,11 @@ info: revealed-type: Revealed type
 
 ```
 info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:10:1
+  --> src/mdtest_snippet.py:10:13
    |
  9 | reveal_type(f(1))  # revealed: Literal[1]
 10 | reveal_type(f(True))  # revealed: Literal[True]
-   | ^^^^^^^^^^^^^^^^^^^^ `Literal[True]`
+   |             ^^^^^^^ `Literal[True]`
 11 | # error: [invalid-argument-type]
 12 | reveal_type(f("string"))  # revealed: Unknown
    |
@@ -57,12 +57,12 @@ info: revealed-type: Revealed type
 
 ```
 info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:12:1
+  --> src/mdtest_snippet.py:12:13
    |
 10 | reveal_type(f(True))  # revealed: Literal[True]
 11 | # error: [invalid-argument-type]
 12 | reveal_type(f("string"))  # revealed: Unknown
-   | ^^^^^^^^^^^^^^^^^^^^^^^^ `Unknown`
+   |             ^^^^^^^^^^^ `Unknown`
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___Legacy_syntax_-_Inferring_a_constrained_typevar.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___Legacy_syntax_-_Inferring_a_constrained_typevar.snap
@@ -31,12 +31,12 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/legacy/function
 
 ```
 info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:9:1
+  --> src/mdtest_snippet.py:9:13
    |
  7 |     return x
  8 |
  9 | reveal_type(f(1))  # revealed: int
-   | ^^^^^^^^^^^^^^^^^ `int`
+   |             ^^^^ `int`
 10 | reveal_type(f(True))  # revealed: int
 11 | reveal_type(f(None))  # revealed: None
    |
@@ -45,11 +45,11 @@ info: revealed-type: Revealed type
 
 ```
 info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:10:1
+  --> src/mdtest_snippet.py:10:13
    |
  9 | reveal_type(f(1))  # revealed: int
 10 | reveal_type(f(True))  # revealed: int
-   | ^^^^^^^^^^^^^^^^^^^^ `int`
+   |             ^^^^^^^ `int`
 11 | reveal_type(f(None))  # revealed: None
 12 | # error: [invalid-argument-type]
    |
@@ -58,12 +58,12 @@ info: revealed-type: Revealed type
 
 ```
 info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:11:1
+  --> src/mdtest_snippet.py:11:13
    |
  9 | reveal_type(f(1))  # revealed: int
 10 | reveal_type(f(True))  # revealed: int
 11 | reveal_type(f(None))  # revealed: None
-   | ^^^^^^^^^^^^^^^^^^^^ `None`
+   |             ^^^^^^^ `None`
 12 | # error: [invalid-argument-type]
 13 | reveal_type(f("string"))  # revealed: Unknown
    |
@@ -72,12 +72,12 @@ info: revealed-type: Revealed type
 
 ```
 info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:13:1
+  --> src/mdtest_snippet.py:13:13
    |
 11 | reveal_type(f(None))  # revealed: None
 12 | # error: [invalid-argument-type]
 13 | reveal_type(f("string"))  # revealed: Unknown
-   | ^^^^^^^^^^^^^^^^^^^^^^^^ `Unknown`
+   |             ^^^^^^^^^^^ `Unknown`
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___PEP_695_syntax_-_Inferring_a_bound_typevar.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___PEP_695_syntax_-_Inferring_a_bound_typevar.snap
@@ -27,12 +27,12 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/pep695/function
 
 ```
 info: revealed-type: Revealed type
- --> src/mdtest_snippet.py:6:1
+ --> src/mdtest_snippet.py:6:13
   |
 4 |     return x
 5 |
 6 | reveal_type(f(1))  # revealed: Literal[1]
-  | ^^^^^^^^^^^^^^^^^ `Literal[1]`
+  |             ^^^^ `Literal[1]`
 7 | reveal_type(f(True))  # revealed: Literal[True]
 8 | # error: [invalid-argument-type]
   |
@@ -41,11 +41,11 @@ info: revealed-type: Revealed type
 
 ```
 info: revealed-type: Revealed type
- --> src/mdtest_snippet.py:7:1
+ --> src/mdtest_snippet.py:7:13
   |
 6 | reveal_type(f(1))  # revealed: Literal[1]
 7 | reveal_type(f(True))  # revealed: Literal[True]
-  | ^^^^^^^^^^^^^^^^^^^^ `Literal[True]`
+  |             ^^^^^^^ `Literal[True]`
 8 | # error: [invalid-argument-type]
 9 | reveal_type(f("string"))  # revealed: Unknown
   |
@@ -54,12 +54,12 @@ info: revealed-type: Revealed type
 
 ```
 info: revealed-type: Revealed type
- --> src/mdtest_snippet.py:9:1
+ --> src/mdtest_snippet.py:9:13
   |
 7 | reveal_type(f(True))  # revealed: Literal[True]
 8 | # error: [invalid-argument-type]
 9 | reveal_type(f("string"))  # revealed: Unknown
-  | ^^^^^^^^^^^^^^^^^^^^^^^^ `Unknown`
+  |             ^^^^^^^^^^^ `Unknown`
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___PEP_695_syntax_-_Inferring_a_constrained_typevar.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___PEP_695_syntax_-_Inferring_a_constrained_typevar.snap
@@ -28,12 +28,12 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/pep695/function
 
 ```
 info: revealed-type: Revealed type
- --> src/mdtest_snippet.py:6:1
+ --> src/mdtest_snippet.py:6:13
   |
 4 |     return x
 5 |
 6 | reveal_type(f(1))  # revealed: int
-  | ^^^^^^^^^^^^^^^^^ `int`
+  |             ^^^^ `int`
 7 | reveal_type(f(True))  # revealed: int
 8 | reveal_type(f(None))  # revealed: None
   |
@@ -42,11 +42,11 @@ info: revealed-type: Revealed type
 
 ```
 info: revealed-type: Revealed type
- --> src/mdtest_snippet.py:7:1
+ --> src/mdtest_snippet.py:7:13
   |
 6 | reveal_type(f(1))  # revealed: int
 7 | reveal_type(f(True))  # revealed: int
-  | ^^^^^^^^^^^^^^^^^^^^ `int`
+  |             ^^^^^^^ `int`
 8 | reveal_type(f(None))  # revealed: None
 9 | # error: [invalid-argument-type]
   |
@@ -55,12 +55,12 @@ info: revealed-type: Revealed type
 
 ```
 info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:8:1
+  --> src/mdtest_snippet.py:8:13
    |
  6 | reveal_type(f(1))  # revealed: int
  7 | reveal_type(f(True))  # revealed: int
  8 | reveal_type(f(None))  # revealed: None
-   | ^^^^^^^^^^^^^^^^^^^^ `None`
+   |             ^^^^^^^ `None`
  9 | # error: [invalid-argument-type]
 10 | reveal_type(f("string"))  # revealed: Unknown
    |
@@ -69,12 +69,12 @@ info: revealed-type: Revealed type
 
 ```
 info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:10:1
+  --> src/mdtest_snippet.py:10:13
    |
  8 | reveal_type(f(None))  # revealed: None
  9 | # error: [invalid-argument-type]
 10 | reveal_type(f("string"))  # revealed: Unknown
-   | ^^^^^^^^^^^^^^^^^^^^^^^^ `Unknown`
+   |             ^^^^^^^^^^^ `Unknown`
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/mro.md_-_Method_Resolution_Order_tests_-_`__bases__`_lists_with_duplicate_bases.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/mro.md_-_Method_Resolution_Order_tests_-_`__bases__`_lists_with_duplicate_bases.snap
@@ -128,12 +128,12 @@ info: `lint:duplicate-base` is enabled by default
 
 ```
 info: revealed-type: Revealed type
- --> src/mdtest_snippet.py:5:1
+ --> src/mdtest_snippet.py:5:13
   |
 3 | class Foo(str, str): ...  # error: [duplicate-base] "Duplicate base class `str`"
 4 |
 5 | reveal_type(Foo.__mro__)  # revealed: tuple[<class 'Foo'>, Unknown, <class 'object'>]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^ `tuple[<class 'Foo'>, Unknown, <class 'object'>]`
+  |             ^^^^^^^^^^^ `tuple[<class 'Foo'>, Unknown, <class 'object'>]`
 6 |
 7 | class Spam: ...
   |
@@ -217,12 +217,12 @@ info: `lint:duplicate-base` is enabled by default
 
 ```
 info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:27:1
+  --> src/mdtest_snippet.py:27:13
    |
 25 | # fmt: on
 26 |
 27 | reveal_type(Ham.__mro__)  # revealed: tuple[<class 'Ham'>, Unknown, <class 'object'>]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^ `tuple[<class 'Ham'>, Unknown, <class 'object'>]`
+   |             ^^^^^^^^^^^ `tuple[<class 'Ham'>, Unknown, <class 'object'>]`
 28 |
 29 | class Mushrooms: ...
    |
@@ -256,12 +256,12 @@ info: `lint:duplicate-base` is enabled by default
 
 ```
 info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:32:1
+  --> src/mdtest_snippet.py:32:13
    |
 30 | class Omelette(Spam, Eggs, Mushrooms, Mushrooms): ...  # error: [duplicate-base]
 31 |
 32 | reveal_type(Omelette.__mro__)  # revealed: tuple[<class 'Omelette'>, Unknown, <class 'object'>]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `tuple[<class 'Omelette'>, Unknown, <class 'object'>]`
+   |             ^^^^^^^^^^^^^^^^ `tuple[<class 'Omelette'>, Unknown, <class 'object'>]`
 33 |
 34 | # fmt: off
    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Calls_to_protocol_classes.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Calls_to_protocol_classes.snap
@@ -42,19 +42,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/protocols.md
 # Diagnostics
 
 ```
-info: revealed-type: Revealed type
- --> src/mdtest_snippet.py:4:1
-  |
-3 | # error: [call-non-callable]
-4 | reveal_type(Protocol())  # revealed: Unknown
-  | ^^^^^^^^^^^^^^^^^^^^^^^ `Unknown`
-5 |
-6 | class MyProtocol(Protocol):
-  |
-
-```
-
-```
 error: lint:call-non-callable: Object of type `typing.Protocol` is not callable
  --> src/mdtest_snippet.py:4:13
   |
@@ -70,14 +57,14 @@ info: `lint:call-non-callable` is enabled by default
 
 ```
 info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:10:1
-   |
- 9 | # error: [call-non-callable] "Cannot instantiate class `MyProtocol`"
-10 | reveal_type(MyProtocol())  # revealed: MyProtocol
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^ `MyProtocol`
-11 |
-12 | class GenericProtocol[T](Protocol):
-   |
+ --> src/mdtest_snippet.py:4:13
+  |
+3 | # error: [call-non-callable]
+4 | reveal_type(Protocol())  # revealed: Unknown
+  |             ^^^^^^^^^^ `Unknown`
+5 |
+6 | class MyProtocol(Protocol):
+  |
 
 ```
 
@@ -106,12 +93,13 @@ info: `lint:call-non-callable` is enabled by default
 
 ```
 info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:16:1
+  --> src/mdtest_snippet.py:10:13
    |
-15 | # error: [call-non-callable] "Cannot instantiate class `GenericProtocol`"
-16 | reveal_type(GenericProtocol[int]())  # revealed: GenericProtocol[int]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `GenericProtocol[int]`
-17 | class SubclassOfMyProtocol(MyProtocol): ...
+ 9 | # error: [call-non-callable] "Cannot instantiate class `MyProtocol`"
+10 | reveal_type(MyProtocol())  # revealed: MyProtocol
+   |             ^^^^^^^^^^^^ `MyProtocol`
+11 |
+12 | class GenericProtocol[T](Protocol):
    |
 
 ```
@@ -140,12 +128,24 @@ info: `lint:call-non-callable` is enabled by default
 
 ```
 info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:19:1
+  --> src/mdtest_snippet.py:16:13
+   |
+15 | # error: [call-non-callable] "Cannot instantiate class `GenericProtocol`"
+16 | reveal_type(GenericProtocol[int]())  # revealed: GenericProtocol[int]
+   |             ^^^^^^^^^^^^^^^^^^^^^^ `GenericProtocol[int]`
+17 | class SubclassOfMyProtocol(MyProtocol): ...
+   |
+
+```
+
+```
+info: revealed-type: Revealed type
+  --> src/mdtest_snippet.py:19:13
    |
 17 | class SubclassOfMyProtocol(MyProtocol): ...
 18 |
 19 | reveal_type(SubclassOfMyProtocol())  # revealed: SubclassOfMyProtocol
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `SubclassOfMyProtocol`
+   |             ^^^^^^^^^^^^^^^^^^^^^^ `SubclassOfMyProtocol`
 20 |
 21 | class SubclassOfGenericProtocol[T](GenericProtocol[T]): ...
    |
@@ -154,12 +154,12 @@ info: revealed-type: Revealed type
 
 ```
 info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:23:1
+  --> src/mdtest_snippet.py:23:13
    |
 21 | class SubclassOfGenericProtocol[T](GenericProtocol[T]): ...
 22 |
 23 | reveal_type(SubclassOfGenericProtocol[int]())  # revealed: SubclassOfGenericProtocol[int]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `SubclassOfGenericProtocol[int]`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `SubclassOfGenericProtocol[int]`
 24 | def f(x: type[MyProtocol]):
 25 |     reveal_type(x())  # revealed: MyProtocol
    |
@@ -168,12 +168,12 @@ info: revealed-type: Revealed type
 
 ```
 info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:25:5
+  --> src/mdtest_snippet.py:25:17
    |
 23 | reveal_type(SubclassOfGenericProtocol[int]())  # revealed: SubclassOfGenericProtocol[int]
 24 | def f(x: type[MyProtocol]):
 25 |     reveal_type(x())  # revealed: MyProtocol
-   |     ^^^^^^^^^^^^^^^^ `MyProtocol`
+   |                 ^^^ `MyProtocol`
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Narrowing_of_protocols.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Narrowing_of_protocols.snap
@@ -83,12 +83,12 @@ info: `lint:invalid-argument-type` is enabled by default
 
 ```
 info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:8:9
+  --> src/mdtest_snippet.py:8:21
    |
  6 | def f(arg: object, arg2: type):
  7 |     if isinstance(arg, HasX):  # error: [invalid-argument-type]
  8 |         reveal_type(arg)  # revealed: HasX
-   |         ^^^^^^^^^^^^^^^^ `HasX`
+   |                     ^^^ `HasX`
  9 |     else:
 10 |         reveal_type(arg)  # revealed: ~HasX
    |
@@ -97,12 +97,12 @@ info: revealed-type: Revealed type
 
 ```
 info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:10:9
+  --> src/mdtest_snippet.py:10:21
    |
  8 |         reveal_type(arg)  # revealed: HasX
  9 |     else:
 10 |         reveal_type(arg)  # revealed: ~HasX
-   |         ^^^^^^^^^^^^^^^^ `~HasX`
+   |                     ^^^ `~HasX`
 11 |
 12 |     if issubclass(arg2, HasX):  # error: [invalid-argument-type]
    |
@@ -137,11 +137,11 @@ info: `lint:invalid-argument-type` is enabled by default
 
 ```
 info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:13:9
+  --> src/mdtest_snippet.py:13:21
    |
 12 |     if issubclass(arg2, HasX):  # error: [invalid-argument-type]
 13 |         reveal_type(arg2)  # revealed: type[HasX]
-   |         ^^^^^^^^^^^^^^^^^ `type[HasX]`
+   |                     ^^^^ `type[HasX]`
 14 |     else:
 15 |         reveal_type(arg2)  # revealed: type & ~type[HasX]
    |
@@ -150,12 +150,12 @@ info: revealed-type: Revealed type
 
 ```
 info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:15:9
+  --> src/mdtest_snippet.py:15:21
    |
 13 |         reveal_type(arg2)  # revealed: type[HasX]
 14 |     else:
 15 |         reveal_type(arg2)  # revealed: type & ~type[HasX]
-   |         ^^^^^^^^^^^^^^^^^ `type & ~type[HasX]`
+   |                     ^^^^ `type & ~type[HasX]`
 16 | from typing import runtime_checkable
    |
 
@@ -163,12 +163,12 @@ info: revealed-type: Revealed type
 
 ```
 info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:24:9
+  --> src/mdtest_snippet.py:24:21
    |
 22 | def f(arg: object):
 23 |     if isinstance(arg, RuntimeCheckableHasX):  # no error!
 24 |         reveal_type(arg)  # revealed: RuntimeCheckableHasX
-   |         ^^^^^^^^^^^^^^^^ `RuntimeCheckableHasX`
+   |                     ^^^ `RuntimeCheckableHasX`
 25 |     else:
 26 |         reveal_type(arg)  # revealed: ~RuntimeCheckableHasX
    |
@@ -177,12 +177,12 @@ info: revealed-type: Revealed type
 
 ```
 info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:26:9
+  --> src/mdtest_snippet.py:26:21
    |
 24 |         reveal_type(arg)  # revealed: RuntimeCheckableHasX
 25 |     else:
 26 |         reveal_type(arg)  # revealed: ~RuntimeCheckableHasX
-   |         ^^^^^^^^^^^^^^^^ `~RuntimeCheckableHasX`
+   |                     ^^^ `~RuntimeCheckableHasX`
 27 | @runtime_checkable
 28 | class OnlyMethodMembers(Protocol):
    |
@@ -191,12 +191,12 @@ info: revealed-type: Revealed type
 
 ```
 info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:33:9
+  --> src/mdtest_snippet.py:33:21
    |
 31 | def f(arg1: type, arg2: type):
 32 |     if issubclass(arg1, RuntimeCheckableHasX):  # TODO: should emit an error here (has non-method members)
 33 |         reveal_type(arg1)  # revealed: type[RuntimeCheckableHasX]
-   |         ^^^^^^^^^^^^^^^^^ `type[RuntimeCheckableHasX]`
+   |                     ^^^^ `type[RuntimeCheckableHasX]`
 34 |     else:
 35 |         reveal_type(arg1)  # revealed: type & ~type[RuntimeCheckableHasX]
    |
@@ -205,12 +205,12 @@ info: revealed-type: Revealed type
 
 ```
 info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:35:9
+  --> src/mdtest_snippet.py:35:21
    |
 33 |         reveal_type(arg1)  # revealed: type[RuntimeCheckableHasX]
 34 |     else:
 35 |         reveal_type(arg1)  # revealed: type & ~type[RuntimeCheckableHasX]
-   |         ^^^^^^^^^^^^^^^^^ `type & ~type[RuntimeCheckableHasX]`
+   |                     ^^^^ `type & ~type[RuntimeCheckableHasX]`
 36 |
 37 |     if issubclass(arg2, OnlyMethodMembers):  # no error!
    |
@@ -219,11 +219,11 @@ info: revealed-type: Revealed type
 
 ```
 info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:38:9
+  --> src/mdtest_snippet.py:38:21
    |
 37 |     if issubclass(arg2, OnlyMethodMembers):  # no error!
 38 |         reveal_type(arg2)  # revealed: type[OnlyMethodMembers]
-   |         ^^^^^^^^^^^^^^^^^ `type[OnlyMethodMembers]`
+   |                     ^^^^ `type[OnlyMethodMembers]`
 39 |     else:
 40 |         reveal_type(arg2)  # revealed: type & ~type[OnlyMethodMembers]
    |
@@ -232,12 +232,12 @@ info: revealed-type: Revealed type
 
 ```
 info: revealed-type: Revealed type
-  --> src/mdtest_snippet.py:40:9
+  --> src/mdtest_snippet.py:40:21
    |
 38 |         reveal_type(arg2)  # revealed: type[OnlyMethodMembers]
 39 |     else:
 40 |         reveal_type(arg2)  # revealed: type & ~type[OnlyMethodMembers]
-   |         ^^^^^^^^^^^^^^^^^ `type & ~type[OnlyMethodMembers]`
+   |                     ^^^^ `type & ~type[OnlyMethodMembers]`
    |
 
 ```

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -4781,7 +4781,9 @@ impl<'db> TypeInferenceBuilder<'db> {
                                             ) {
                                                 let mut diag =
                                                     builder.into_diagnostic("Revealed type");
-                                                let span = self.context.span(call_expression);
+                                                let span = self
+                                                    .context
+                                                    .span(&call_expression.arguments.args[0]);
                                                 diag.annotate(Annotation::primary(span).message(
                                                     format_args!(
                                                         "`{}`",


### PR DESCRIPTION
## Summary

I think we've discussed a few times that it would be desirable for the highlighted range of a `reveal_type` call to be this:

```
reveal_type(x)
            ^ Revealed type is `int`
```

Rather than this:

```
reveal_type(x)
^^^^^^^^^^^^^^ Revealed type is `int`
```

This PR implements that change

## Test Plan

Lots of snapshot changes
