### PR TITLE
[ty] Display "All checks passed!" message in green

### DIFF
--- a/crates/ty/src/lib.rs
+++ b/crates/ty/src/lib.rs
@@ -15,6 +15,7 @@ use crate::args::{CheckCommand, Command, TerminalColor};
 use crate::logging::setup_tracing;
 use anyhow::{anyhow, Context};
 use clap::{CommandFactory, Parser};
+use colored::Colorize;
 use crossbeam::channel as crossbeam_channel;
 use rayon::ThreadPoolBuilder;
 use ruff_db::diagnostic::{Diagnostic, DisplayDiagnosticConfig, Severity};
@@ -260,7 +261,7 @@ impl MainLoop {
                         let mut stdout = stdout().lock();
 
                         if result.is_empty() {
-                            writeln!(stdout, "All checks passed!")?;
+                            writeln!(stdout, "{}", "All checks passed!".green().bold())?;
 
                             if self.watcher.is_none() {
                                 return Ok(ExitStatus::Success);


### PR DESCRIPTION
## Summary

Currently if there are errors in your code, you'll see lots of red on the terminal, but if everything's good then you only get black and white feedback. It's kind of a downer!

This makes ty more "enthusiastic" about things if there were no errors in your code. Previously:

![image](https://github.com/user-attachments/assets/3441d014-af05-4b0a-b701-1a01e0695ac5)

With this PR:

![image](https://github.com/user-attachments/assets/28fc37c1-688f-45b0-8f30-34720ed110a2)

## Test Plan

See screenshots above
