### PR TITLE
[ty] bottom-up improvement of diagnostic messages for union type function calls

### DIFF
--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -59,26 +59,37 @@ type KeyDiagnosticFields = (
     Severity,
 );
 
+// left: [
+// (Lint(LintName("invalid-argument-type")), Some("/src/tomllib/_parser.py"), Some(8224..8254), "Argument to function `skip_until` is incorrect", Error),
+// (Lint(LintName("invalid-argument-type")), Some("/src/tomllib/_parser.py"), Some(16914..16948), "Argument to function `skip_until` is incorrect", Error),
+// (Lint(LintName("invalid-argument-type")), Some("/src/tomllib/_parser.py"), Some(17319..17363), "Argument to function `skip_until` is incorrect", Error),
+// ]
+//right: [
+// (Lint(LintName("invalid-argument-type")), Some("/src/tomllib/_parser.py"), Some(8224..8254), "Argument to this function is incorrect", Error),
+// (Lint(LintName("invalid-argument-type")), Some("/src/tomllib/_parser.py"), Some(16914..16948), "Argument to this function is incorrect", Error),
+// (Lint(LintName("invalid-argument-type")), Some("/src/tomllib/_parser.py"), Some(17319..17363), "Argument to this function is incorrect", Error),
+// ]
+
 static EXPECTED_TOMLLIB_DIAGNOSTICS: &[KeyDiagnosticFields] = &[
     (
         DiagnosticId::lint("invalid-argument-type"),
         Some("/src/tomllib/_parser.py"),
         Some(8224..8254),
-        "Argument to this function is incorrect",
+        "Argument to function `skip_until` is incorrect",
         Severity::Error,
     ),
     (
         DiagnosticId::lint("invalid-argument-type"),
         Some("/src/tomllib/_parser.py"),
         Some(16914..16948),
-        "Argument to this function is incorrect",
+        "Argument to function `skip_until` is incorrect",
         Severity::Error,
     ),
     (
         DiagnosticId::lint("invalid-argument-type"),
         Some("/src/tomllib/_parser.py"),
         Some(17319..17363),
-        "Argument to this function is incorrect",
+        "Argument to function `skip_until` is incorrect",
         Severity::Error,
     ),
 ];

--- a/crates/ty_python_semantic/resources/mdtest/annotations/new_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/new_types.md
@@ -12,7 +12,7 @@ X = GenericAlias(type, ())
 A = NewType("A", int)
 # TODO: typeshed for `typing.GenericAlias` uses `type` for the first argument. `NewType` should be special-cased
 # to be compatible with `type`
-# error: [invalid-argument-type] "Argument to this function is incorrect: Expected `type`, found `NewType`"
+# error: [invalid-argument-type] "Argument to function `__new__` is incorrect: Expected `type`, found `NewType`"
 B = GenericAlias(A, ())
 
 def _(

--- a/crates/ty_python_semantic/resources/mdtest/call/annotation.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/annotation.md
@@ -9,8 +9,8 @@ def _(c: Callable[[], int]):
 def _(c: Callable[[int, str], int]):
     reveal_type(c(1, "a"))  # revealed: int
 
-    # error: [invalid-argument-type] "Argument to this function is incorrect: Expected `int`, found `Literal["a"]`"
-    # error: [invalid-argument-type] "Argument to this function is incorrect: Expected `str`, found `Literal[1]`"
+    # error: [invalid-argument-type] "Argument is incorrect: Expected `int`, found `Literal["a"]`"
+    # error: [invalid-argument-type] "Argument is incorrect: Expected `str`, found `Literal[1]`"
     reveal_type(c("a", 1))  # revealed: int
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/call/callable_instance.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/callable_instance.md
@@ -85,7 +85,7 @@ class C:
 
 c = C()
 
-# error: 15 [invalid-argument-type] "Argument to this function is incorrect: Expected `int`, found `Literal["foo"]`"
+# error: 15 [invalid-argument-type] "Argument to bound method `__call__` is incorrect: Expected `int`, found `Literal["foo"]`"
 reveal_type(c("foo"))  # revealed: int
 ```
 
@@ -99,7 +99,7 @@ class C:
 
 c = C()
 
-# error: 13 [invalid-argument-type] "Argument to this function is incorrect: Expected `int`, found `C`"
+# error: 13 [invalid-argument-type] "Argument to bound method `__call__` is incorrect: Expected `int`, found `C`"
 reveal_type(c())  # revealed: int
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/call/constructor.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/constructor.md
@@ -100,7 +100,9 @@ def _(flag: bool) -> None:
 
     reveal_type(Foo(1))  # revealed: Foo
     # error: [invalid-argument-type] "Argument to this function is incorrect: Expected `int`, found `Literal["1"]`"
+    # error: [invalid-argument-type] "Argument to this function is incorrect: Expected `int`, found `Literal["1"]`"
     reveal_type(Foo("1"))  # revealed: Foo
+    # error: [missing-argument] "No argument provided for required parameter `x` of function `__new__`"
     # error: [missing-argument] "No argument provided for required parameter `x` of function `__new__`"
     reveal_type(Foo())  # revealed: Foo
     # error: [too-many-positional-arguments] "Too many positional arguments to function `__new__`: expected 1, got 2"
@@ -231,7 +233,9 @@ def _(flag: bool) -> None:
 
     reveal_type(Foo(1))  # revealed: Foo
     # error: [invalid-argument-type] "Argument to this function is incorrect: Expected `int`, found `Literal["1"]`"
+    # error: [invalid-argument-type] "Argument to this function is incorrect: Expected `int`, found `Literal["1"]`"
     reveal_type(Foo("1"))  # revealed: Foo
+    # error: [missing-argument] "No argument provided for required parameter `x` of bound method `__init__`"
     # error: [missing-argument] "No argument provided for required parameter `x` of bound method `__init__`"
     reveal_type(Foo())  # revealed: Foo
     # error: [too-many-positional-arguments] "Too many positional arguments to bound method `__init__`: expected 1, got 2"

--- a/crates/ty_python_semantic/resources/mdtest/call/constructor.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/constructor.md
@@ -99,8 +99,8 @@ def _(flag: bool) -> None:
             def __new__(cls, x: int, y: int = 1): ...
 
     reveal_type(Foo(1))  # revealed: Foo
-    # error: [invalid-argument-type] "Argument to this function is incorrect: Expected `int`, found `Literal["1"]`"
-    # error: [invalid-argument-type] "Argument to this function is incorrect: Expected `int`, found `Literal["1"]`"
+    # error: [invalid-argument-type] "Argument to function `__new__` is incorrect: Expected `int`, found `Literal["1"]`"
+    # error: [invalid-argument-type] "Argument to function `__new__` is incorrect: Expected `int`, found `Literal["1"]`"
     reveal_type(Foo("1"))  # revealed: Foo
     # error: [missing-argument] "No argument provided for required parameter `x` of function `__new__`"
     # error: [missing-argument] "No argument provided for required parameter `x` of function `__new__`"
@@ -232,8 +232,8 @@ def _(flag: bool) -> None:
             def __init__(self, x: int, y: int = 1): ...
 
     reveal_type(Foo(1))  # revealed: Foo
-    # error: [invalid-argument-type] "Argument to this function is incorrect: Expected `int`, found `Literal["1"]`"
-    # error: [invalid-argument-type] "Argument to this function is incorrect: Expected `int`, found `Literal["1"]`"
+    # error: [invalid-argument-type] "Argument to bound method `__init__` is incorrect: Expected `int`, found `Literal["1"]`"
+    # error: [invalid-argument-type] "Argument to bound method `__init__` is incorrect: Expected `int`, found `Literal["1"]`"
     reveal_type(Foo("1"))  # revealed: Foo
     # error: [missing-argument] "No argument provided for required parameter `x` of bound method `__init__`"
     # error: [missing-argument] "No argument provided for required parameter `x` of bound method `__init__`"

--- a/crates/ty_python_semantic/resources/mdtest/call/function.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/function.md
@@ -77,7 +77,7 @@ def _(flag: bool):
 def f(x: int) -> int:
     return 1
 
-# error: 15 [invalid-argument-type] "Argument to this function is incorrect: Expected `int`, found `Literal["foo"]`"
+# error: 15 [invalid-argument-type] "Argument to function `f` is incorrect: Expected `int`, found `Literal["foo"]`"
 reveal_type(f("foo"))  # revealed: int
 ```
 
@@ -87,7 +87,7 @@ reveal_type(f("foo"))  # revealed: int
 def f(x: int, /) -> int:
     return 1
 
-# error: 15 [invalid-argument-type] "Argument to this function is incorrect: Expected `int`, found `Literal["foo"]`"
+# error: 15 [invalid-argument-type] "Argument to function `f` is incorrect: Expected `int`, found `Literal["foo"]`"
 reveal_type(f("foo"))  # revealed: int
 ```
 
@@ -97,7 +97,7 @@ reveal_type(f("foo"))  # revealed: int
 def f(*args: int) -> int:
     return 1
 
-# error: 15 [invalid-argument-type] "Argument to this function is incorrect: Expected `int`, found `Literal["foo"]`"
+# error: 15 [invalid-argument-type] "Argument to function `f` is incorrect: Expected `int`, found `Literal["foo"]`"
 reveal_type(f("foo"))  # revealed: int
 ```
 
@@ -107,7 +107,7 @@ reveal_type(f("foo"))  # revealed: int
 def f(x: int) -> int:
     return 1
 
-# error: 15 [invalid-argument-type] "Argument to this function is incorrect: Expected `int`, found `Literal["foo"]`"
+# error: 15 [invalid-argument-type] "Argument to function `f` is incorrect: Expected `int`, found `Literal["foo"]`"
 reveal_type(f(x="foo"))  # revealed: int
 ```
 
@@ -117,7 +117,7 @@ reveal_type(f(x="foo"))  # revealed: int
 def f(*, x: int) -> int:
     return 1
 
-# error: 15 [invalid-argument-type] "Argument to this function is incorrect: Expected `int`, found `Literal["foo"]`"
+# error: 15 [invalid-argument-type] "Argument to function `f` is incorrect: Expected `int`, found `Literal["foo"]`"
 reveal_type(f(x="foo"))  # revealed: int
 ```
 
@@ -127,7 +127,7 @@ reveal_type(f(x="foo"))  # revealed: int
 def f(**kwargs: int) -> int:
     return 1
 
-# error: 15 [invalid-argument-type] "Argument to this function is incorrect: Expected `int`, found `Literal["foo"]`"
+# error: 15 [invalid-argument-type] "Argument to function `f` is incorrect: Expected `int`, found `Literal["foo"]`"
 reveal_type(f(x="foo"))  # revealed: int
 ```
 
@@ -137,8 +137,8 @@ reveal_type(f(x="foo"))  # revealed: int
 def f(x: int = 1, y: str = "foo") -> int:
     return 1
 
-# error: 15 [invalid-argument-type] "Argument to this function is incorrect: Expected `str`, found `Literal[2]`"
-# error: 20 [invalid-argument-type] "Argument to this function is incorrect: Expected `int`, found `Literal["bar"]`"
+# error: 15 [invalid-argument-type] "Argument to function `f` is incorrect: Expected `str`, found `Literal[2]`"
+# error: 20 [invalid-argument-type] "Argument to function `f` is incorrect: Expected `int`, found `Literal["bar"]`"
 reveal_type(f(y=2, x="bar"))  # revealed: int
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/call/getattr_static.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/getattr_static.md
@@ -115,7 +115,7 @@ inspect.getattr_static()
 # error: [missing-argument] "No argument provided for required parameter `attr`"
 inspect.getattr_static(C())
 
-# error: [invalid-argument-type] "Argument to this function is incorrect: Expected `str`, found `Literal[1]`"
+# error: [invalid-argument-type] "Argument to function `getattr_static` is incorrect: Expected `str`, found `Literal[1]`"
 inspect.getattr_static(C(), 1)
 
 # error: [too-many-positional-arguments] "Too many positional arguments to function `getattr_static`: expected 3, got 4"

--- a/crates/ty_python_semantic/resources/mdtest/call/invalid_syntax.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/invalid_syntax.md
@@ -24,7 +24,7 @@ to the valid order:
 def f(**kw: int, x: str) -> int:
     return 1
 
-# error: 15 [invalid-argument-type] "Argument to this function is incorrect: Expected `str`, found `Literal[1]`"
+# error: 15 [invalid-argument-type] "Argument to function `f` is incorrect: Expected `str`, found `Literal[1]`"
 reveal_type(f(1))  # revealed: int
 ```
 
@@ -38,7 +38,7 @@ def f(x: int = 1, y: str) -> int:
     return 1
 
 reveal_type(f(y="foo"))  # revealed: int
-# error: [invalid-argument-type] "Argument to this function is incorrect: Expected `int`, found `Literal["foo"]`"
+# error: [invalid-argument-type] "Argument to function `f` is incorrect: Expected `int`, found `Literal["foo"]`"
 # error: [missing-argument] "No argument provided for required parameter `y` of function `f`"
 reveal_type(f("foo"))  # revealed: int
 ```

--- a/crates/ty_python_semantic/resources/mdtest/call/methods.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/methods.md
@@ -350,7 +350,7 @@ class D:
         # This function is wrongly annotated, it should be `type[D]` instead of `D`
         pass
 
-# error: [invalid-argument-type] "Argument to this function is incorrect: Expected `D`, found `<class 'D'>`"
+# error: [invalid-argument-type] "Argument to bound method `f` is incorrect: Expected `D`, found `<class 'D'>`"
 D.f()
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/call/subclass_of.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/subclass_of.md
@@ -20,7 +20,7 @@ class C:
 def _(subclass_of_c: type[C]):
     reveal_type(subclass_of_c(1))  # revealed: C
 
-    # error: [invalid-argument-type] "Argument to this function is incorrect: Expected `int`, found `Literal["a"]`"
+    # error: [invalid-argument-type] "Argument to bound method `__init__` is incorrect: Expected `int`, found `Literal["a"]`"
     reveal_type(subclass_of_c("a"))  # revealed: C
     # error: [missing-argument] "No argument provided for required parameter `x` of bound method `__init__`"
     reveal_type(subclass_of_c())  # revealed: C

--- a/crates/ty_python_semantic/resources/mdtest/call/union.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/union.md
@@ -94,7 +94,7 @@ def _(flag: bool):
     else:
         f = f2
 
-    # error: [invalid-argument-type] "Argument to this function is incorrect: Expected `str`, found `Literal[3]`"
+    # error: [invalid-argument-type] "Argument to function `f2` is incorrect: Expected `str`, found `Literal[3]`"
     x = f(3)
     reveal_type(x)  # revealed: int | str
 ```

--- a/crates/ty_python_semantic/resources/mdtest/call/union.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/union.md
@@ -56,8 +56,8 @@ def _(flag: bool, flag2: bool):
     else:
         def f() -> int:
             return 1
-    # TODO we should mention all non-callable elements of the union
     # error: [call-non-callable] "Object of type `Literal[1]` is not callable"
+    # error: [call-non-callable] "Object of type `Literal["foo"]` is not callable"
     # revealed: Unknown | int
     reveal_type(f())
 ```
@@ -125,8 +125,8 @@ def _(flag: bool):
     else:
         f = f2
 
-    # TODO: we should show all errors from the union, not arbitrarily pick one union element
     # error: [too-many-positional-arguments] "Too many positional arguments to function `f1`: expected 0, got 1"
+    # error: [too-many-positional-arguments] "Too many positional arguments to function `f2`: expected 0, got 1"
     x = f(3)
     reveal_type(x)  # revealed: Unknown
 ```
@@ -143,8 +143,8 @@ def _(flag: bool):
     else:
         f = C()
 
-    # TODO: we should either show all union errors here, or prioritize the not-callable error
     # error: [too-many-positional-arguments] "Too many positional arguments to function `f1`: expected 0, got 1"
+    # error: [call-non-callable] "Object of type `C` is not callable"
     x = f(3)
     reveal_type(x)  # revealed: Unknown
 ```

--- a/crates/ty_python_semantic/resources/mdtest/decorators.md
+++ b/crates/ty_python_semantic/resources/mdtest/decorators.md
@@ -207,7 +207,7 @@ first argument:
 def wrong_signature(f: int) -> str:
     return "a"
 
-# error: [invalid-argument-type] "Argument to this function is incorrect: Expected `int`, found `def f(x) -> Unknown`"
+# error: [invalid-argument-type] "Argument to function `wrong_signature` is incorrect: Expected `int`, found `def f(x) -> Unknown`"
 @wrong_signature
 def f(x): ...
 

--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/union_call.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/union_call.md
@@ -99,9 +99,9 @@ def _(n: int):
     else:
         f = PossiblyNotCallable()
     # error: [too-many-positional-arguments]
-    # error: [invalid-argument-type] "Argument to this function is incorrect: Expected `str`, found `Literal[3]`"
+    # error: [invalid-argument-type] "Argument to function `f2` is incorrect: Expected `str`, found `Literal[3]`"
     # error: [missing-argument]
-    # error: [invalid-argument-type] "Argument to this function is incorrect: Argument type `Literal[3]` does not satisfy upper bound of type variable `T`"
+    # error: [invalid-argument-type] "Argument to function `f4` is incorrect: Argument type `Literal[3]` does not satisfy upper bound of type variable `T`"
     # error: [call-non-callable] "Object of type `Literal[5]` is not callable"
     # error: [no-matching-overload]
     # error: [call-non-callable] "Object of type `PossiblyNotCallable` is not callable (possibly unbound `__call__` method)"

--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/union_call.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/union_call.md
@@ -1,0 +1,121 @@
+# Calling a union of function types
+
+<!-- snapshot-diagnostics -->
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+## A smaller scale example
+
+```py
+def f1() -> int:
+    return 0
+
+def f2(name: str) -> int:
+    return 0
+
+def _(flag: bool):
+    if flag:
+        f = f1
+    else:
+        f = f2
+    # error: [too-many-positional-arguments]
+    x = f(3)
+```
+
+## Multiple variants but only one is invalid
+
+This test in particular demonstrates some of the smarts of this diagnostic. Namely, since only one
+variant is invalid, additional context specific to that variant is added to the diagnostic output.
+(If more than one variant is invalid, then this additional context is elided to avoid overwhelming
+the end user.)
+
+```py
+def f1(a: int) -> int:
+    return 0
+
+def f2(name: str) -> int:
+    return 0
+
+def _(flag: bool):
+    if flag:
+        f = f1
+    else:
+        f = f2
+    # error: [invalid-argument-type]
+    x = f(3)
+```
+
+## Try to cover all possible reasons
+
+These tests is likely to become stale over time, but this was added when the union-specific
+diagnostic was initially created. In each test, we try to cover as much as we can. This is mostly
+just ensuring that we get test coverage for each of the possible diagnostic messages.
+
+### Cover non-keyword related reasons
+
+```py
+from inspect import getattr_static
+
+def f1() -> int:
+    return 0
+
+def f2(name: str) -> int:
+    return 0
+
+def f3(a: int, b: int) -> int:
+    return 0
+
+def f4[T: str](x: T) -> int:
+    return 0
+
+class OverloadExample:
+    def f(self, x: str) -> int:
+        return 0
+
+f5 = getattr_static(OverloadExample, "f").__get__
+
+def _(n: int):
+    class PossiblyNotCallable:
+        if n == 0:
+            def __call__(self) -> int:
+                return 0
+
+    if n == 0:
+        f = f1
+    elif n == 1:
+        f = f2
+    elif n == 2:
+        f = f3
+    elif n == 3:
+        f = f4
+    elif n == 4:
+        f = 5
+    elif n == 5:
+        f = f5
+    else:
+        f = PossiblyNotCallable()
+    # error: [too-many-positional-arguments]
+    x = f(3)
+```
+
+### Cover keyword argument related reasons
+
+```py
+def any(*args, **kwargs) -> int:
+    return 0
+
+def f1(name: str) -> int:
+    return 0
+
+def _(n: int):
+    if n == 0:
+        f = f1
+    else:
+        f = any
+    # error: [parameter-already-assigned]
+    # error: [unknown-argument]
+    y = f("foo", name="bar", unknown="quux")
+```

--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/union_call.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/union_call.md
@@ -22,6 +22,7 @@ def _(flag: bool):
     else:
         f = f2
     # error: [too-many-positional-arguments]
+    # error: [invalid-argument-type]
     x = f(3)
 ```
 
@@ -98,6 +99,12 @@ def _(n: int):
     else:
         f = PossiblyNotCallable()
     # error: [too-many-positional-arguments]
+    # error: [invalid-argument-type] "Argument to this function is incorrect: Expected `str`, found `Literal[3]`"
+    # error: [missing-argument]
+    # error: [invalid-argument-type] "Argument to this function is incorrect: Argument type `Literal[3]` does not satisfy upper bound of type variable `T`"
+    # error: [call-non-callable] "Object of type `Literal[5]` is not callable"
+    # error: [no-matching-overload]
+    # error: [call-non-callable] "Object of type `PossiblyNotCallable` is not callable (possibly unbound `__call__` method)"
     x = f(3)
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/doc/public_type_undeclared_symbols.md
+++ b/crates/ty_python_semantic/resources/mdtest/doc/public_type_undeclared_symbols.md
@@ -42,7 +42,7 @@ def f(w: Wrapper) -> None:
     v: int | None = w.value
 
     # This function call is incorrect, because `w.value` could be `None`. We therefore emit the following
-    # error: "Argument to this function is incorrect: Expected `int`, found `Unknown | None`"
+    # error: "Argument to function `accepts_int` is incorrect: Expected `int`, found `Unknown | None`"
     c = accepts_int(w.value)
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -123,11 +123,11 @@ reveal_type(Bounded[int]())  # revealed: Bounded[int]
 reveal_type(Bounded[IntSubclass]())  # revealed: Bounded[IntSubclass]
 
 # TODO: update this diagnostic to talk about type parameters and specializations
-# error: [invalid-argument-type] "Argument to this function is incorrect: Expected `int`, found `str`"
+# error: [invalid-argument-type] "Argument to class `Bounded` is incorrect: Expected `int`, found `str`"
 reveal_type(Bounded[str]())  # revealed: Unknown
 
 # TODO: update this diagnostic to talk about type parameters and specializations
-# error:  [invalid-argument-type] "Argument to this function is incorrect: Expected `int`, found `int | str`"
+# error:  [invalid-argument-type] "Argument to class `Bounded` is incorrect: Expected `int`, found `int | str`"
 reveal_type(Bounded[int | str]())  # revealed: Unknown
 
 reveal_type(BoundedByUnion[int]())  # revealed: BoundedByUnion[int]
@@ -156,7 +156,7 @@ reveal_type(Constrained[str]())  # revealed: Constrained[str]
 reveal_type(Constrained[int | str]())  # revealed: Constrained[int | str]
 
 # TODO: update this diagnostic to talk about type parameters and specializations
-# error: [invalid-argument-type] "Argument to this function is incorrect: Expected `int | str`, found `object`"
+# error: [invalid-argument-type] "Argument to class `Constrained` is incorrect: Expected `int | str`, found `object`"
 reveal_type(Constrained[object]())  # revealed: Unknown
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
@@ -98,11 +98,11 @@ reveal_type(Bounded[int]())  # revealed: Bounded[int]
 reveal_type(Bounded[IntSubclass]())  # revealed: Bounded[IntSubclass]
 
 # TODO: update this diagnostic to talk about type parameters and specializations
-# error: [invalid-argument-type] "Argument to this function is incorrect: Expected `int`, found `str`"
+# error: [invalid-argument-type] "Argument to class `Bounded` is incorrect: Expected `int`, found `str`"
 reveal_type(Bounded[str]())  # revealed: Unknown
 
 # TODO: update this diagnostic to talk about type parameters and specializations
-# error: [invalid-argument-type] "Argument to this function is incorrect: Expected `int`, found `int | str`"
+# error: [invalid-argument-type] "Argument to class `Bounded` is incorrect: Expected `int`, found `int | str`"
 reveal_type(Bounded[int | str]())  # revealed: Unknown
 
 reveal_type(BoundedByUnion[int]())  # revealed: BoundedByUnion[int]
@@ -129,7 +129,7 @@ reveal_type(Constrained[str]())  # revealed: Constrained[str]
 reveal_type(Constrained[int | str]())  # revealed: Constrained[int | str]
 
 # TODO: update this diagnostic to talk about type parameters and specializations
-# error: [invalid-argument-type] "Argument to this function is incorrect: Expected `int | str`, found `object`"
+# error: [invalid-argument-type] "Argument to class `Constrained` is incorrect: Expected `int | str`, found `object`"
 reveal_type(Constrained[object]())  # revealed: Unknown
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/scoping.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/scoping.md
@@ -84,7 +84,7 @@ class C[T]:
 c: C[int] = C[int]()
 c.m1(1)
 c.m2(1)
-# error: [invalid-argument-type] "Argument to this function is incorrect: Expected `int`, found `Literal["string"]`"
+# error: [invalid-argument-type] "Argument to bound method `m2` is incorrect: Expected `int`, found `Literal["string"]`"
 c.m2("string")
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/properties.md
+++ b/crates/ty_python_semantic/resources/mdtest/properties.md
@@ -146,7 +146,7 @@ class C:
     @property
     def attr(self) -> int:
         return 1
-    # error: [invalid-argument-type] "Argument to this function is incorrect: Expected `(Any, Any, /) -> None`, found `def attr(self) -> None`"
+    # error: [invalid-argument-type] "Argument to bound method `setter` is incorrect: Expected `(Any, Any, /) -> None`, found `def attr(self) -> None`"
     @attr.setter
     def attr(self) -> None:
         pass
@@ -156,7 +156,7 @@ class C:
 
 ```py
 class C:
-    # error: [invalid-argument-type] "Argument to this function is incorrect: Expected `((Any, /) -> Any) | None`, found `def attr(self, x: int) -> int`"
+    # error: [invalid-argument-type] "Argument to class `property` is incorrect: Expected `((Any, /) -> Any) | None`, found `def attr(self, x: int) -> int`"
     @property
     def attr(self, x: int) -> int:
         return 1

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___Legacy_syntax_-_Inferring_a_bound_typevar.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___Legacy_syntax_-_Inferring_a_bound_typevar.snap
@@ -68,7 +68,7 @@ info[revealed-type]: Revealed type
 ```
 
 ```
-error[invalid-argument-type]: Argument to this function is incorrect
+error[invalid-argument-type]: Argument to function `f` is incorrect
   --> src/mdtest_snippet.py:12:15
    |
 10 | reveal_type(f(True))  # revealed: Literal[True]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___Legacy_syntax_-_Inferring_a_constrained_typevar.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___Legacy_syntax_-_Inferring_a_constrained_typevar.snap
@@ -83,7 +83,7 @@ info[revealed-type]: Revealed type
 ```
 
 ```
-error[invalid-argument-type]: Argument to this function is incorrect
+error[invalid-argument-type]: Argument to function `f` is incorrect
   --> src/mdtest_snippet.py:13:15
    |
 11 | reveal_type(f(None))  # revealed: None

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___PEP_695_syntax_-_Inferring_a_bound_typevar.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___PEP_695_syntax_-_Inferring_a_bound_typevar.snap
@@ -65,7 +65,7 @@ info[revealed-type]: Revealed type
 ```
 
 ```
-error[invalid-argument-type]: Argument to this function is incorrect
+error[invalid-argument-type]: Argument to function `f` is incorrect
  --> src/mdtest_snippet.py:9:15
   |
 7 | reveal_type(f(True))  # revealed: Literal[True]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___PEP_695_syntax_-_Inferring_a_constrained_typevar.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___PEP_695_syntax_-_Inferring_a_constrained_typevar.snap
@@ -80,7 +80,7 @@ info[revealed-type]: Revealed type
 ```
 
 ```
-error[invalid-argument-type]: Argument to this function is incorrect
+error[invalid-argument-type]: Argument to function `f` is incorrect
   --> src/mdtest_snippet.py:10:15
    |
  8 | reveal_type(f(None))  # revealed: None

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Basic.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Basic.snap
@@ -21,7 +21,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 # Diagnostics
 
 ```
-error[invalid-argument-type]: Argument to this function is incorrect
+error[invalid-argument-type]: Argument to function `foo` is incorrect
  --> src/mdtest_snippet.py:4:5
   |
 2 |     return x * x

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Calls_to_methods.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Calls_to_methods.snap
@@ -23,7 +23,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 # Diagnostics
 
 ```
-error[invalid-argument-type]: Argument to this function is incorrect
+error[invalid-argument-type]: Argument to bound method `square` is incorrect
  --> src/mdtest_snippet.py:6:10
   |
 5 | c = C()

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Different_files.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Different_files.snap
@@ -27,7 +27,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 # Diagnostics
 
 ```
-error[invalid-argument-type]: Argument to this function is incorrect
+error[invalid-argument-type]: Argument to function `foo` is incorrect
  --> src/mdtest_snippet.py:3:13
   |
 1 | import package

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Different_source_order.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Different_source_order.snap
@@ -22,7 +22,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 # Diagnostics
 
 ```
-error[invalid-argument-type]: Argument to this function is incorrect
+error[invalid-argument-type]: Argument to function `foo` is incorrect
  --> src/mdtest_snippet.py:2:9
   |
 1 | def bar():

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters.snap
@@ -21,7 +21,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 # Diagnostics
 
 ```
-error[invalid-argument-type]: Argument to this function is incorrect
+error[invalid-argument-type]: Argument to function `foo` is incorrect
  --> src/mdtest_snippet.py:4:8
   |
 2 |     return x * y * z

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters_across_multiple_lines.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters_across_multiple_lines.snap
@@ -25,7 +25,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 # Diagnostics
 
 ```
-error[invalid-argument-type]: Argument to this function is incorrect
+error[invalid-argument-type]: Argument to function `foo` is incorrect
  --> src/mdtest_snippet.py:8:8
   |
 6 |     return x * y * z

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters_with_multiple_invalid_arguments.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters_with_multiple_invalid_arguments.snap
@@ -24,7 +24,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 # Diagnostics
 
 ```
-error[invalid-argument-type]: Argument to this function is incorrect
+error[invalid-argument-type]: Argument to function `foo` is incorrect
  --> src/mdtest_snippet.py:7:5
   |
 5 | # error: [invalid-argument-type]
@@ -44,7 +44,7 @@ info: `invalid-argument-type` is enabled by default
 ```
 
 ```
-error[invalid-argument-type]: Argument to this function is incorrect
+error[invalid-argument-type]: Argument to function `foo` is incorrect
  --> src/mdtest_snippet.py:7:10
   |
 5 | # error: [invalid-argument-type]
@@ -64,7 +64,7 @@ info: `invalid-argument-type` is enabled by default
 ```
 
 ```
-error[invalid-argument-type]: Argument to this function is incorrect
+error[invalid-argument-type]: Argument to function `foo` is incorrect
  --> src/mdtest_snippet.py:7:15
   |
 5 | # error: [invalid-argument-type]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Test_calling_a_function_whose_type_is_vendored_from_`typeshed`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Test_calling_a_function_whose_type_is_vendored_from_`typeshed`.snap
@@ -20,7 +20,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 # Diagnostics
 
 ```
-error[invalid-argument-type]: Argument to this function is incorrect
+error[invalid-argument-type]: Argument to function `loads` is incorrect
  --> src/mdtest_snippet.py:3:12
   |
 1 | import json

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Keyword_only_arguments.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Keyword_only_arguments.snap
@@ -21,7 +21,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 # Diagnostics
 
 ```
-error[invalid-argument-type]: Argument to this function is incorrect
+error[invalid-argument-type]: Argument to function `foo` is incorrect
  --> src/mdtest_snippet.py:4:11
   |
 2 |     return x * y * z

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Mix_of_arguments.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Mix_of_arguments.snap
@@ -21,7 +21,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 # Diagnostics
 
 ```
-error[invalid-argument-type]: Argument to this function is incorrect
+error[invalid-argument-type]: Argument to function `foo` is incorrect
  --> src/mdtest_snippet.py:4:11
   |
 2 |     return x * y * z

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_One_keyword_argument.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_One_keyword_argument.snap
@@ -21,7 +21,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 # Diagnostics
 
 ```
-error[invalid-argument-type]: Argument to this function is incorrect
+error[invalid-argument-type]: Argument to function `foo` is incorrect
  --> src/mdtest_snippet.py:4:11
   |
 2 |     return x * y * z

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Only_positional.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Only_positional.snap
@@ -21,7 +21,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 # Diagnostics
 
 ```
-error[invalid-argument-type]: Argument to this function is incorrect
+error[invalid-argument-type]: Argument to function `foo` is incorrect
  --> src/mdtest_snippet.py:4:8
   |
 2 |     return x * y * z

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Synthetic_arguments.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Synthetic_arguments.snap
@@ -23,7 +23,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 # Diagnostics
 
 ```
-error[invalid-argument-type]: Argument to this function is incorrect
+error[invalid-argument-type]: Argument to bound method `__call__` is incorrect
  --> src/mdtest_snippet.py:6:3
   |
 5 | c = C()

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Variadic_arguments.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Variadic_arguments.snap
@@ -21,7 +21,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 # Diagnostics
 
 ```
-error[invalid-argument-type]: Argument to this function is incorrect
+error[invalid-argument-type]: Argument to function `foo` is incorrect
  --> src/mdtest_snippet.py:4:14
   |
 2 |     return len(numbers)

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Variadic_keyword_arguments.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Variadic_keyword_arguments.snap
@@ -21,7 +21,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 # Diagnostics
 
 ```
-error[invalid-argument-type]: Argument to this function is incorrect
+error[invalid-argument-type]: Argument to function `foo` is incorrect
  --> src/mdtest_snippet.py:4:20
   |
 2 |     return len(numbers)

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/union_call.md_-_Calling_a_union_of_function_types_-_A_smaller_scale_example.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/union_call.md_-_Calling_a_union_of_function_types_-_A_smaller_scale_example.snap
@@ -31,7 +31,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/union_call.m
 # Diagnostics
 
 ```
-error: lint:invalid-argument-type: Argument to this function is incorrect
+error[invalid-argument-type]: Argument to function `f2` is incorrect
   --> src/mdtest_snippet.py:14:11
    |
 12 |     # error: [too-many-positional-arguments]
@@ -48,12 +48,14 @@ info: Function defined here
   |     ^^ --------- Parameter declared here
 5 |     return 0
   |
-info: `lint:invalid-argument-type` is enabled by default
+info: Union variant `def f2(name: str) -> int` is incompatible with this call site
+info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> int)`
+info: `invalid-argument-type` is enabled by default
 
 ```
 
 ```
-error: lint:too-many-positional-arguments: Too many positional arguments to function `f1`: expected 0, got 1
+error[too-many-positional-arguments]: Too many positional arguments to function `f1`: expected 0, got 1
   --> src/mdtest_snippet.py:14:11
    |
 12 |     # error: [too-many-positional-arguments]
@@ -61,6 +63,8 @@ error: lint:too-many-positional-arguments: Too many positional arguments to func
 14 |     x = f(3)
    |           ^
    |
-info: `lint:too-many-positional-arguments` is enabled by default
+info: Union variant `def f1() -> int` is incompatible with this call site
+info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> int)`
+info: `too-many-positional-arguments` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/union_call.md_-_Calling_a_union_of_function_types_-_A_smaller_scale_example.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/union_call.md_-_Calling_a_union_of_function_types_-_A_smaller_scale_example.snap
@@ -24,18 +24,41 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/union_call.m
 10 |     else:
 11 |         f = f2
 12 |     # error: [too-many-positional-arguments]
-13 |     x = f(3)
+13 |     # error: [invalid-argument-type]
+14 |     x = f(3)
 ```
 
 # Diagnostics
 
 ```
-error: lint:too-many-positional-arguments: Too many positional arguments to function `f1`: expected 0, got 1
-  --> src/mdtest_snippet.py:13:11
+error: lint:invalid-argument-type: Argument to this function is incorrect
+  --> src/mdtest_snippet.py:14:11
    |
-11 |         f = f2
 12 |     # error: [too-many-positional-arguments]
-13 |     x = f(3)
+13 |     # error: [invalid-argument-type]
+14 |     x = f(3)
+   |           ^ Expected `str`, found `Literal[3]`
+   |
+info: Function defined here
+ --> src/mdtest_snippet.py:4:5
+  |
+2 |     return 0
+3 |
+4 | def f2(name: str) -> int:
+  |     ^^ --------- Parameter declared here
+5 |     return 0
+  |
+info: `lint:invalid-argument-type` is enabled by default
+
+```
+
+```
+error: lint:too-many-positional-arguments: Too many positional arguments to function `f1`: expected 0, got 1
+  --> src/mdtest_snippet.py:14:11
+   |
+12 |     # error: [too-many-positional-arguments]
+13 |     # error: [invalid-argument-type]
+14 |     x = f(3)
    |           ^
    |
 info: `lint:too-many-positional-arguments` is enabled by default

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/union_call.md_-_Calling_a_union_of_function_types_-_A_smaller_scale_example.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/union_call.md_-_Calling_a_union_of_function_types_-_A_smaller_scale_example.snap
@@ -1,0 +1,43 @@
+---
+source: crates/ty_test/src/lib.rs
+expression: snapshot
+---
+---
+mdtest name: union_call.md - Calling a union of function types - A smaller scale example
+mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/union_call.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+ 1 | def f1() -> int:
+ 2 |     return 0
+ 3 | 
+ 4 | def f2(name: str) -> int:
+ 5 |     return 0
+ 6 | 
+ 7 | def _(flag: bool):
+ 8 |     if flag:
+ 9 |         f = f1
+10 |     else:
+11 |         f = f2
+12 |     # error: [too-many-positional-arguments]
+13 |     x = f(3)
+```
+
+# Diagnostics
+
+```
+error: lint:too-many-positional-arguments: Too many positional arguments to function `f1`: expected 0, got 1
+  --> src/mdtest_snippet.py:13:11
+   |
+11 |         f = f2
+12 |     # error: [too-many-positional-arguments]
+13 |     x = f(3)
+   |           ^
+   |
+info: `lint:too-many-positional-arguments` is enabled by default
+
+```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/union_call.md_-_Calling_a_union_of_function_types_-_Multiple_variants_but_only_one_is_invalid.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/union_call.md_-_Calling_a_union_of_function_types_-_Multiple_variants_but_only_one_is_invalid.snap
@@ -30,7 +30,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/union_call.m
 # Diagnostics
 
 ```
-error: lint:invalid-argument-type: Argument to this function is incorrect
+error[invalid-argument-type]: Argument to function `f2` is incorrect
   --> src/mdtest_snippet.py:13:11
    |
 11 |         f = f2
@@ -47,6 +47,8 @@ info: Function defined here
   |     ^^ --------- Parameter declared here
 5 |     return 0
   |
-info: `lint:invalid-argument-type` is enabled by default
+info: Union variant `def f2(name: str) -> int` is incompatible with this call site
+info: Attempted to call union type `(def f1(a: int) -> int) | (def f2(name: str) -> int)`
+info: `invalid-argument-type` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/union_call.md_-_Calling_a_union_of_function_types_-_Multiple_variants_but_only_one_is_invalid.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/union_call.md_-_Calling_a_union_of_function_types_-_Multiple_variants_but_only_one_is_invalid.snap
@@ -1,0 +1,52 @@
+---
+source: crates/ty_test/src/lib.rs
+expression: snapshot
+---
+---
+mdtest name: union_call.md - Calling a union of function types - Multiple variants but only one is invalid
+mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/union_call.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+ 1 | def f1(a: int) -> int:
+ 2 |     return 0
+ 3 | 
+ 4 | def f2(name: str) -> int:
+ 5 |     return 0
+ 6 | 
+ 7 | def _(flag: bool):
+ 8 |     if flag:
+ 9 |         f = f1
+10 |     else:
+11 |         f = f2
+12 |     # error: [invalid-argument-type]
+13 |     x = f(3)
+```
+
+# Diagnostics
+
+```
+error: lint:invalid-argument-type: Argument to this function is incorrect
+  --> src/mdtest_snippet.py:13:11
+   |
+11 |         f = f2
+12 |     # error: [invalid-argument-type]
+13 |     x = f(3)
+   |           ^ Expected `str`, found `Literal[3]`
+   |
+info: Function defined here
+ --> src/mdtest_snippet.py:4:5
+  |
+2 |     return 0
+3 |
+4 | def f2(name: str) -> int:
+  |     ^^ --------- Parameter declared here
+5 |     return 0
+  |
+info: `lint:invalid-argument-type` is enabled by default
+
+```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/union_call.md_-_Calling_a_union_of_function_types_-_Try_to_cover_all_possible_reasons_-_Cover_keyword_argument_related_reasons.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/union_call.md_-_Calling_a_union_of_function_types_-_Try_to_cover_all_possible_reasons_-_Cover_keyword_argument_related_reasons.snap
@@ -1,0 +1,57 @@
+---
+source: crates/ty_test/src/lib.rs
+expression: snapshot
+---
+---
+mdtest name: union_call.md - Calling a union of function types - Try to cover all possible reasons - Cover keyword argument related reasons
+mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/union_call.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+ 1 | def any(*args, **kwargs) -> int:
+ 2 |     return 0
+ 3 | 
+ 4 | def f1(name: str) -> int:
+ 5 |     return 0
+ 6 | 
+ 7 | def _(n: int):
+ 8 |     if n == 0:
+ 9 |         f = f1
+10 |     else:
+11 |         f = any
+12 |     # error: [parameter-already-assigned]
+13 |     # error: [unknown-argument]
+14 |     y = f("foo", name="bar", unknown="quux")
+```
+
+# Diagnostics
+
+```
+error: lint:parameter-already-assigned: Multiple values provided for parameter `name` of function `f1`
+  --> src/mdtest_snippet.py:14:18
+   |
+12 |     # error: [parameter-already-assigned]
+13 |     # error: [unknown-argument]
+14 |     y = f("foo", name="bar", unknown="quux")
+   |                  ^^^^^^^^^^
+   |
+info: `lint:parameter-already-assigned` is enabled by default
+
+```
+
+```
+error: lint:unknown-argument: Argument `unknown` does not match any known parameter of function `f1`
+  --> src/mdtest_snippet.py:14:30
+   |
+12 |     # error: [parameter-already-assigned]
+13 |     # error: [unknown-argument]
+14 |     y = f("foo", name="bar", unknown="quux")
+   |                              ^^^^^^^^^^^^^^
+   |
+info: `lint:unknown-argument` is enabled by default
+
+```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/union_call.md_-_Calling_a_union_of_function_types_-_Try_to_cover_all_possible_reasons_-_Cover_keyword_argument_related_reasons.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/union_call.md_-_Calling_a_union_of_function_types_-_Try_to_cover_all_possible_reasons_-_Cover_keyword_argument_related_reasons.snap
@@ -31,7 +31,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/union_call.m
 # Diagnostics
 
 ```
-error: lint:parameter-already-assigned: Multiple values provided for parameter `name` of function `f1`
+error[parameter-already-assigned]: Multiple values provided for parameter `name` of function `f1`
   --> src/mdtest_snippet.py:14:18
    |
 12 |     # error: [parameter-already-assigned]
@@ -39,12 +39,14 @@ error: lint:parameter-already-assigned: Multiple values provided for parameter `
 14 |     y = f("foo", name="bar", unknown="quux")
    |                  ^^^^^^^^^^
    |
-info: `lint:parameter-already-assigned` is enabled by default
+info: Union variant `def f1(name: str) -> int` is incompatible with this call site
+info: Attempted to call union type `(def f1(name: str) -> int) | (def any(*args, **kwargs) -> int)`
+info: `parameter-already-assigned` is enabled by default
 
 ```
 
 ```
-error: lint:unknown-argument: Argument `unknown` does not match any known parameter of function `f1`
+error[unknown-argument]: Argument `unknown` does not match any known parameter of function `f1`
   --> src/mdtest_snippet.py:14:30
    |
 12 |     # error: [parameter-already-assigned]
@@ -52,6 +54,8 @@ error: lint:unknown-argument: Argument `unknown` does not match any known parame
 14 |     y = f("foo", name="bar", unknown="quux")
    |                              ^^^^^^^^^^^^^^
    |
-info: `lint:unknown-argument` is enabled by default
+info: Union variant `def f1(name: str) -> int` is incompatible with this call site
+info: Attempted to call union type `(def f1(name: str) -> int) | (def any(*args, **kwargs) -> int)`
+info: `unknown-argument` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/union_call.md_-_Calling_a_union_of_function_types_-_Try_to_cover_all_possible_reasons_-_Cover_non-keyword_related_reasons.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/union_call.md_-_Calling_a_union_of_function_types_-_Try_to_cover_all_possible_reasons_-_Cover_non-keyword_related_reasons.snap
@@ -53,18 +53,120 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/union_call.m
 39 |     else:
 40 |         f = PossiblyNotCallable()
 41 |     # error: [too-many-positional-arguments]
-42 |     x = f(3)
+42 |     # error: [invalid-argument-type] "Argument to this function is incorrect: Expected `str`, found `Literal[3]`"
+43 |     # error: [missing-argument]
+44 |     # error: [invalid-argument-type] "Argument to this function is incorrect: Argument type `Literal[3]` does not satisfy upper bound of type variable `T`"
+45 |     # error: [call-non-callable] "Object of type `Literal[5]` is not callable"
+46 |     # error: [no-matching-overload]
+47 |     # error: [call-non-callable] "Object of type `PossiblyNotCallable` is not callable (possibly unbound `__call__` method)"
+48 |     x = f(3)
 ```
 
 # Diagnostics
 
 ```
-error: lint:too-many-positional-arguments: Too many positional arguments to function `f1`: expected 0, got 1
-  --> src/mdtest_snippet.py:42:11
+error: lint:call-non-callable: Object of type `Literal[5]` is not callable
+  --> src/mdtest_snippet.py:48:9
    |
-40 |         f = PossiblyNotCallable()
-41 |     # error: [too-many-positional-arguments]
-42 |     x = f(3)
+46 |     # error: [no-matching-overload]
+47 |     # error: [call-non-callable] "Object of type `PossiblyNotCallable` is not callable (possibly unbound `__call__` method)"
+48 |     x = f(3)
+   |         ^^^^
+   |
+info: `lint:call-non-callable` is enabled by default
+
+```
+
+```
+error: lint:call-non-callable: Object of type `PossiblyNotCallable` is not callable (possibly unbound `__call__` method)
+  --> src/mdtest_snippet.py:48:9
+   |
+46 |     # error: [no-matching-overload]
+47 |     # error: [call-non-callable] "Object of type `PossiblyNotCallable` is not callable (possibly unbound `__call__` method)"
+48 |     x = f(3)
+   |         ^^^^
+   |
+info: `lint:call-non-callable` is enabled by default
+
+```
+
+```
+error: lint:missing-argument: No argument provided for required parameter `b` of function `f3`
+  --> src/mdtest_snippet.py:48:9
+   |
+46 |     # error: [no-matching-overload]
+47 |     # error: [call-non-callable] "Object of type `PossiblyNotCallable` is not callable (possibly unbound `__call__` method)"
+48 |     x = f(3)
+   |         ^^^^
+   |
+info: `lint:missing-argument` is enabled by default
+
+```
+
+```
+error: lint:no-matching-overload: No overload of method wrapper `__get__` of function `f` matches arguments
+  --> src/mdtest_snippet.py:48:9
+   |
+46 |     # error: [no-matching-overload]
+47 |     # error: [call-non-callable] "Object of type `PossiblyNotCallable` is not callable (possibly unbound `__call__` method)"
+48 |     x = f(3)
+   |         ^^^^
+   |
+info: `lint:no-matching-overload` is enabled by default
+
+```
+
+```
+error: lint:invalid-argument-type: Argument to this function is incorrect
+  --> src/mdtest_snippet.py:48:11
+   |
+46 |     # error: [no-matching-overload]
+47 |     # error: [call-non-callable] "Object of type `PossiblyNotCallable` is not callable (possibly unbound `__call__` method)"
+48 |     x = f(3)
+   |           ^ Expected `str`, found `Literal[3]`
+   |
+info: Function defined here
+ --> src/mdtest_snippet.py:6:5
+  |
+4 |     return 0
+5 |
+6 | def f2(name: str) -> int:
+  |     ^^ --------- Parameter declared here
+7 |     return 0
+  |
+info: `lint:invalid-argument-type` is enabled by default
+
+```
+
+```
+error: lint:invalid-argument-type: Argument to this function is incorrect
+  --> src/mdtest_snippet.py:48:11
+   |
+46 |     # error: [no-matching-overload]
+47 |     # error: [call-non-callable] "Object of type `PossiblyNotCallable` is not callable (possibly unbound `__call__` method)"
+48 |     x = f(3)
+   |           ^ Argument type `Literal[3]` does not satisfy upper bound of type variable `T`
+   |
+info: Type variable defined here
+  --> src/mdtest_snippet.py:12:8
+   |
+10 |     return 0
+11 |
+12 | def f4[T: str](x: T) -> int:
+   |        ^^^^^^
+13 |     return 0
+   |
+info: `lint:invalid-argument-type` is enabled by default
+
+```
+
+```
+error: lint:too-many-positional-arguments: Too many positional arguments to function `f1`: expected 0, got 1
+  --> src/mdtest_snippet.py:48:11
+   |
+46 |     # error: [no-matching-overload]
+47 |     # error: [call-non-callable] "Object of type `PossiblyNotCallable` is not callable (possibly unbound `__call__` method)"
+48 |     x = f(3)
    |           ^
    |
 info: `lint:too-many-positional-arguments` is enabled by default

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/union_call.md_-_Calling_a_union_of_function_types_-_Try_to_cover_all_possible_reasons_-_Cover_non-keyword_related_reasons.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/union_call.md_-_Calling_a_union_of_function_types_-_Try_to_cover_all_possible_reasons_-_Cover_non-keyword_related_reasons.snap
@@ -1,0 +1,72 @@
+---
+source: crates/ty_test/src/lib.rs
+expression: snapshot
+---
+---
+mdtest name: union_call.md - Calling a union of function types - Try to cover all possible reasons - Cover non-keyword related reasons
+mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/union_call.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+ 1 | from inspect import getattr_static
+ 2 | 
+ 3 | def f1() -> int:
+ 4 |     return 0
+ 5 | 
+ 6 | def f2(name: str) -> int:
+ 7 |     return 0
+ 8 | 
+ 9 | def f3(a: int, b: int) -> int:
+10 |     return 0
+11 | 
+12 | def f4[T: str](x: T) -> int:
+13 |     return 0
+14 | 
+15 | class OverloadExample:
+16 |     def f(self, x: str) -> int:
+17 |         return 0
+18 | 
+19 | f5 = getattr_static(OverloadExample, "f").__get__
+20 | 
+21 | def _(n: int):
+22 |     class PossiblyNotCallable:
+23 |         if n == 0:
+24 |             def __call__(self) -> int:
+25 |                 return 0
+26 | 
+27 |     if n == 0:
+28 |         f = f1
+29 |     elif n == 1:
+30 |         f = f2
+31 |     elif n == 2:
+32 |         f = f3
+33 |     elif n == 3:
+34 |         f = f4
+35 |     elif n == 4:
+36 |         f = 5
+37 |     elif n == 5:
+38 |         f = f5
+39 |     else:
+40 |         f = PossiblyNotCallable()
+41 |     # error: [too-many-positional-arguments]
+42 |     x = f(3)
+```
+
+# Diagnostics
+
+```
+error: lint:too-many-positional-arguments: Too many positional arguments to function `f1`: expected 0, got 1
+  --> src/mdtest_snippet.py:42:11
+   |
+40 |         f = PossiblyNotCallable()
+41 |     # error: [too-many-positional-arguments]
+42 |     x = f(3)
+   |           ^
+   |
+info: `lint:too-many-positional-arguments` is enabled by default
+
+```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/union_call.md_-_Calling_a_union_of_function_types_-_Try_to_cover_all_possible_reasons_-_Cover_non-keyword_related_reasons.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/union_call.md_-_Calling_a_union_of_function_types_-_Try_to_cover_all_possible_reasons_-_Cover_non-keyword_related_reasons.snap
@@ -53,9 +53,9 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/union_call.m
 39 |     else:
 40 |         f = PossiblyNotCallable()
 41 |     # error: [too-many-positional-arguments]
-42 |     # error: [invalid-argument-type] "Argument to this function is incorrect: Expected `str`, found `Literal[3]`"
+42 |     # error: [invalid-argument-type] "Argument to function `f2` is incorrect: Expected `str`, found `Literal[3]`"
 43 |     # error: [missing-argument]
-44 |     # error: [invalid-argument-type] "Argument to this function is incorrect: Argument type `Literal[3]` does not satisfy upper bound of type variable `T`"
+44 |     # error: [invalid-argument-type] "Argument to function `f4` is incorrect: Argument type `Literal[3]` does not satisfy upper bound of type variable `T`"
 45 |     # error: [call-non-callable] "Object of type `Literal[5]` is not callable"
 46 |     # error: [no-matching-overload]
 47 |     # error: [call-non-callable] "Object of type `PossiblyNotCallable` is not callable (possibly unbound `__call__` method)"
@@ -65,7 +65,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/union_call.m
 # Diagnostics
 
 ```
-error: lint:call-non-callable: Object of type `Literal[5]` is not callable
+error[call-non-callable]: Object of type `Literal[5]` is not callable
   --> src/mdtest_snippet.py:48:9
    |
 46 |     # error: [no-matching-overload]
@@ -73,12 +73,14 @@ error: lint:call-non-callable: Object of type `Literal[5]` is not callable
 48 |     x = f(3)
    |         ^^^^
    |
-info: `lint:call-non-callable` is enabled by default
+info: Union variant `Literal[5]` is incompatible with this call site
+info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> int) | (def f3(a: int, b: int) -> int) | (def f4(x: T) -> int) | Literal[5] | Unknown | (<method-wrapper `__get__` of `f`>) | PossiblyNotCallable`
+info: `call-non-callable` is enabled by default
 
 ```
 
 ```
-error: lint:call-non-callable: Object of type `PossiblyNotCallable` is not callable (possibly unbound `__call__` method)
+error[call-non-callable]: Object of type `PossiblyNotCallable` is not callable (possibly unbound `__call__` method)
   --> src/mdtest_snippet.py:48:9
    |
 46 |     # error: [no-matching-overload]
@@ -86,12 +88,14 @@ error: lint:call-non-callable: Object of type `PossiblyNotCallable` is not calla
 48 |     x = f(3)
    |         ^^^^
    |
-info: `lint:call-non-callable` is enabled by default
+info: Union variant `PossiblyNotCallable` is incompatible with this call site
+info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> int) | (def f3(a: int, b: int) -> int) | (def f4(x: T) -> int) | Literal[5] | Unknown | (<method-wrapper `__get__` of `f`>) | PossiblyNotCallable`
+info: `call-non-callable` is enabled by default
 
 ```
 
 ```
-error: lint:missing-argument: No argument provided for required parameter `b` of function `f3`
+error[missing-argument]: No argument provided for required parameter `b` of function `f3`
   --> src/mdtest_snippet.py:48:9
    |
 46 |     # error: [no-matching-overload]
@@ -99,12 +103,14 @@ error: lint:missing-argument: No argument provided for required parameter `b` of
 48 |     x = f(3)
    |         ^^^^
    |
-info: `lint:missing-argument` is enabled by default
+info: Union variant `def f3(a: int, b: int) -> int` is incompatible with this call site
+info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> int) | (def f3(a: int, b: int) -> int) | (def f4(x: T) -> int) | Literal[5] | Unknown | (<method-wrapper `__get__` of `f`>) | PossiblyNotCallable`
+info: `missing-argument` is enabled by default
 
 ```
 
 ```
-error: lint:no-matching-overload: No overload of method wrapper `__get__` of function `f` matches arguments
+error[no-matching-overload]: No overload of method wrapper `__get__` of function `f` matches arguments
   --> src/mdtest_snippet.py:48:9
    |
 46 |     # error: [no-matching-overload]
@@ -112,12 +118,14 @@ error: lint:no-matching-overload: No overload of method wrapper `__get__` of fun
 48 |     x = f(3)
    |         ^^^^
    |
-info: `lint:no-matching-overload` is enabled by default
+info: Union variant `<method-wrapper `__get__` of `f`>` is incompatible with this call site
+info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> int) | (def f3(a: int, b: int) -> int) | (def f4(x: T) -> int) | Literal[5] | Unknown | (<method-wrapper `__get__` of `f`>) | PossiblyNotCallable`
+info: `no-matching-overload` is enabled by default
 
 ```
 
 ```
-error: lint:invalid-argument-type: Argument to this function is incorrect
+error[invalid-argument-type]: Argument to function `f2` is incorrect
   --> src/mdtest_snippet.py:48:11
    |
 46 |     # error: [no-matching-overload]
@@ -134,12 +142,14 @@ info: Function defined here
   |     ^^ --------- Parameter declared here
 7 |     return 0
   |
-info: `lint:invalid-argument-type` is enabled by default
+info: Union variant `def f2(name: str) -> int` is incompatible with this call site
+info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> int) | (def f3(a: int, b: int) -> int) | (def f4(x: T) -> int) | Literal[5] | Unknown | (<method-wrapper `__get__` of `f`>) | PossiblyNotCallable`
+info: `invalid-argument-type` is enabled by default
 
 ```
 
 ```
-error: lint:invalid-argument-type: Argument to this function is incorrect
+error[invalid-argument-type]: Argument to function `f4` is incorrect
   --> src/mdtest_snippet.py:48:11
    |
 46 |     # error: [no-matching-overload]
@@ -156,12 +166,14 @@ info: Type variable defined here
    |        ^^^^^^
 13 |     return 0
    |
-info: `lint:invalid-argument-type` is enabled by default
+info: Union variant `def f4(x: T) -> int` is incompatible with this call site
+info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> int) | (def f3(a: int, b: int) -> int) | (def f4(x: T) -> int) | Literal[5] | Unknown | (<method-wrapper `__get__` of `f`>) | PossiblyNotCallable`
+info: `invalid-argument-type` is enabled by default
 
 ```
 
 ```
-error: lint:too-many-positional-arguments: Too many positional arguments to function `f1`: expected 0, got 1
+error[too-many-positional-arguments]: Too many positional arguments to function `f1`: expected 0, got 1
   --> src/mdtest_snippet.py:48:11
    |
 46 |     # error: [no-matching-overload]
@@ -169,6 +181,8 @@ error: lint:too-many-positional-arguments: Too many positional arguments to func
 48 |     x = f(3)
    |           ^
    |
-info: `lint:too-many-positional-arguments` is enabled by default
+info: Union variant `def f1() -> int` is incompatible with this call site
+info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> int) | (def f3(a: int, b: int) -> int) | (def f4(x: T) -> int) | Literal[5] | Unknown | (<method-wrapper `__get__` of `f`>) | PossiblyNotCallable`
+info: `too-many-positional-arguments` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -199,11 +199,8 @@ impl<'db> Bindings<'db> {
             }
         }
 
-        // TODO: We currently only report errors for the first union element. Ideally, we'd report
-        // an error saying that the union type can't be called, followed by subdiagnostics
-        // explaining why.
-        if let Some(first) = self.into_iter().find(|b| b.as_result().is_err()) {
-            first.report_diagnostics(context, node);
+        for binding in self {
+            binding.report_diagnostics(context, node);
         }
     }
 


### PR DESCRIPTION
This PR is a redux of #17959. Namely, we still have the goal of
improving diagnostics for incorrect function calls through union types,
but we do it from a bottom-up approach. That is, instead of creating
one new aggregate "invalid union call" diagnostic, we keep all of the
existing diagnostics as-is but attach additional context to bring the
union type to the end user's attention.

The benefits of this PR I believe are:

1. We retain our existing taxonomy with no new "aggregate" diagnostics.
2. Errors on function calls through union types will now surface all
relevant diagnostics.
3. Errant union variants now get added `info`-level sub-diagnostics
that contextualize the union information.

One thing this _doesn't_ do that was discussed in #17959 is aggregate
errant union calls based on the diagnostic ID. That is, if there weren't
multiple incorrect union variants that are wrong for the same reason
(like `invalid-argument-type`), then it was suggested that we could
aggregate those into a single top-level diagnostic. I chose not go down
this path for a number of reasons:

1. It didn't seem plausibly straight-forward to do. I think it would
need a fair bit of refactoring.
2. I'm not convinced it's actually an improvement. It still has a
feeling of arbitrariness to it IMO. Moreover, it wasn't obvious to me
how to tie it all together in a way that was cohesive and made sense.
3. Time constraints. I've already spent a ton of time on this specific
diagnostic. :-)
