### PR TITLE
[ty] remove `lint:` prefix from top-level diagnostic preamble

### DIFF
--- a/crates/ruff_db/src/diagnostic/mod.rs
+++ b/crates/ruff_db/src/diagnostic/mod.rs
@@ -2,7 +2,6 @@ use std::{fmt::Formatter, sync::Arc};
 
 use render::{FileResolver, Input};
 use ruff_source_file::{SourceCode, SourceFile};
-use thiserror::Error;
 
 use ruff_annotate_snippets::Level as AnnotateLevel;
 use ruff_text_size::{Ranged, TextRange};
@@ -613,53 +612,18 @@ impl DiagnosticId {
         code.split_once(':').map(|(_, rest)| rest)
     }
 
-    /// Returns `true` if this `DiagnosticId` matches the given name.
+    /// Returns a concise description of this diagnostic ID.
     ///
-    /// ## Examples
-    /// ```
-    /// use ruff_db::diagnostic::DiagnosticId;
-    ///
-    /// assert!(DiagnosticId::Io.matches("io"));
-    /// assert!(DiagnosticId::lint("test").matches("lint:test"));
-    /// assert!(!DiagnosticId::lint("test").matches("test"));
-    /// ```
-    pub fn matches(&self, expected_name: &str) -> bool {
-        match self.as_str() {
-            Ok(id) => id == expected_name,
-            Err(DiagnosticAsStrError::Category { category, name }) => expected_name
-                .strip_prefix(category)
-                .and_then(|prefix| prefix.strip_prefix(":"))
-                .is_some_and(|rest| rest == name),
-        }
-    }
-
-    pub fn as_str(&self) -> Result<&str, DiagnosticAsStrError> {
-        Ok(match self {
+    /// Note that this doesn't include the lint's category. It
+    /// only includes the lint's name.
+    pub fn as_str(&self) -> &str {
+        match self {
             DiagnosticId::Panic => "panic",
             DiagnosticId::Io => "io",
             DiagnosticId::InvalidSyntax => "invalid-syntax",
-            DiagnosticId::Lint(name) => {
-                return Err(DiagnosticAsStrError::Category {
-                    category: "lint",
-                    name: name.as_str(),
-                })
-            }
+            DiagnosticId::Lint(name) => name.as_str(),
             DiagnosticId::RevealedType => "revealed-type",
             DiagnosticId::UnknownRule => "unknown-rule",
-        })
-    }
-
-    /// Returns a "concise" description of this diagnostic ID.
-    ///
-    /// Specifically, this avoids adding a `lint:` prefix (or other
-    /// possible category prefixes, although `lint` is the only one
-    /// as of 2025-05-09) to the diagnostic ID when this is a lint
-    /// identifier. This is useful in diagnostic rendering where we
-    /// want to elide this prefix.
-    fn as_concise_str(&self) -> &str {
-        match self.as_str() {
-            Ok(name) => name,
-            Err(DiagnosticAsStrError::Category { name, .. }) => name,
         }
     }
 
@@ -668,26 +632,9 @@ impl DiagnosticId {
     }
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Error)]
-pub enum DiagnosticAsStrError {
-    /// The id can't be converted to a string because it belongs to a sub-category.
-    #[error("id from a sub-category: {category}:{name}")]
-    Category {
-        /// The id's category.
-        category: &'static str,
-        /// The diagnostic id in this category.
-        name: &'static str,
-    },
-}
-
 impl std::fmt::Display for DiagnosticId {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self.as_str() {
-            Ok(name) => f.write_str(name),
-            Err(DiagnosticAsStrError::Category { category, name }) => {
-                write!(f, "{category}:{name}")
-            }
-        }
+        write!(f, "{}", self.as_str())
     }
 }
 

--- a/crates/ruff_db/src/diagnostic/mod.rs
+++ b/crates/ruff_db/src/diagnostic/mod.rs
@@ -649,6 +649,20 @@ impl DiagnosticId {
         })
     }
 
+    /// Returns a "concise" description of this diagnostic ID.
+    ///
+    /// Specifically, this avoids adding a `lint:` prefix (or other
+    /// possible category prefixes, although `lint` is the only one
+    /// as of 2025-05-09) to the diagnostic ID when this is a lint
+    /// identifier. This is useful in diagnostic rendering where we
+    /// want to elide this prefix.
+    fn as_concise_str(&self) -> &str {
+        match self.as_str() {
+            Ok(name) => name,
+            Err(DiagnosticAsStrError::Category { name, .. }) => name,
+        }
+    }
+
     pub fn is_invalid_syntax(&self) -> bool {
         matches!(self, Self::InvalidSyntax)
     }

--- a/crates/ruff_db/src/diagnostic/render.rs
+++ b/crates/ruff_db/src/diagnostic/render.rs
@@ -197,9 +197,7 @@ impl<'a> ResolvedDiagnostic<'a> {
                 ResolvedAnnotation::new(path, &diagnostic_source, ann)
             })
             .collect();
-        let message = if diag.inner.message.as_str().is_empty() {
-            diag.inner.id.as_concise_str().to_string()
-        } else {
+        let message =
             // TODO: See the comment on `Renderable::id` for
             // a plausible better idea than smushing the ID
             // into the diagnostic message.
@@ -207,8 +205,7 @@ impl<'a> ResolvedDiagnostic<'a> {
                 "{id}: {message}",
                 id = diag.inner.id.as_concise_str(),
                 message = diag.inner.message.as_str(),
-            )
-        };
+            );
         ResolvedDiagnostic {
             severity: diag.inner.severity,
             message,

--- a/crates/ruff_db/src/diagnostic/render.rs
+++ b/crates/ruff_db/src/diagnostic/render.rs
@@ -79,7 +79,7 @@ impl std::fmt::Display for DisplayDiagnostic<'_> {
                 f,
                 "{severity}[{id}]",
                 severity = fmt_styled(severity, severity_style),
-                id = fmt_styled(self.diag.id(), stylesheet.emphasis)
+                id = fmt_styled(self.diag.id().as_concise_str(), stylesheet.emphasis)
             )?;
 
             if let Some(span) = self.diag.primary_span() {
@@ -152,7 +152,7 @@ impl<'a> Resolved<'a> {
         for sub in &diag.inner.subs {
             diagnostics.push(ResolvedDiagnostic::from_sub_diagnostic(resolver, sub));
         }
-        let id = diag.inner.id.to_string();
+        let id = diag.inner.id.as_concise_str().to_string();
         Resolved { id, diagnostics }
     }
 
@@ -198,14 +198,14 @@ impl<'a> ResolvedDiagnostic<'a> {
             })
             .collect();
         let message = if diag.inner.message.as_str().is_empty() {
-            diag.inner.id.to_string()
+            diag.inner.id.as_concise_str().to_string()
         } else {
             // TODO: See the comment on `Renderable::id` for
             // a plausible better idea than smushing the ID
             // into the diagnostic message.
             format!(
                 "{id}: {message}",
-                id = diag.inner.id,
+                id = diag.inner.id.as_concise_str(),
                 message = diag.inner.message.as_str(),
             )
         };
@@ -799,7 +799,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: lint:test-diagnostic: main diagnostic message
+        error: test-diagnostic: main diagnostic message
          --> animals:5:1
           |
         3 | canary
@@ -823,7 +823,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        warning: lint:test-diagnostic: main diagnostic message
+        warning: test-diagnostic: main diagnostic message
          --> animals:5:1
           |
         3 | canary
@@ -843,7 +843,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        info: lint:test-diagnostic: main diagnostic message
+        info: test-diagnostic: main diagnostic message
          --> animals:5:1
           |
         3 | canary
@@ -870,7 +870,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: lint:test-diagnostic: main diagnostic message
+        error: test-diagnostic: main diagnostic message
          --> animals:1:1
           |
         1 | aardvark
@@ -889,7 +889,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: lint:test-diagnostic: main diagnostic message
+        error: test-diagnostic: main diagnostic message
          --> animals:1:1
           |
         1 | aardvark
@@ -910,7 +910,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: lint:test-diagnostic: main diagnostic message
+        error: test-diagnostic: main diagnostic message
          --> non-ascii:5:1
           |
         3 | ΔΔΔΔΔΔΔΔΔΔΔΔ
@@ -929,7 +929,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: lint:test-diagnostic: main diagnostic message
+        error: test-diagnostic: main diagnostic message
          --> non-ascii:2:2
           |
         1 | ☃☃☃☃☃☃☃☃☃☃☃☃
@@ -953,7 +953,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: lint:test-diagnostic: main diagnostic message
+        error: test-diagnostic: main diagnostic message
          --> animals:5:1
           |
         4 | dog
@@ -970,7 +970,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: lint:test-diagnostic: main diagnostic message
+        error: test-diagnostic: main diagnostic message
          --> animals:5:1
           |
         5 | elephant
@@ -985,7 +985,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: lint:test-diagnostic: main diagnostic message
+        error: test-diagnostic: main diagnostic message
          --> animals:1:1
           |
         1 | aardvark
@@ -1002,7 +1002,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: lint:test-diagnostic: main diagnostic message
+        error: test-diagnostic: main diagnostic message
           --> animals:11:1
            |
          9 | inchworm
@@ -1019,7 +1019,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: lint:test-diagnostic: main diagnostic message
+        error: test-diagnostic: main diagnostic message
           --> animals:5:1
            |
          1 | aardvark
@@ -1052,7 +1052,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: lint:test-diagnostic: main diagnostic message
+        error: test-diagnostic: main diagnostic message
           --> animals:1:1
            |
          1 | aardvark
@@ -1096,7 +1096,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: lint:test-diagnostic: main diagnostic message
+        error: test-diagnostic: main diagnostic message
          --> animals:1:1
           |
         1 | aardvark
@@ -1121,7 +1121,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: lint:test-diagnostic: main diagnostic message
+        error: test-diagnostic: main diagnostic message
          --> animals:1:1
           |
         1 | aardvark
@@ -1149,7 +1149,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: lint:test-diagnostic: main diagnostic message
+        error: test-diagnostic: main diagnostic message
          --> animals:1:1
           |
         1 | aardvark
@@ -1177,7 +1177,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: lint:test-diagnostic: main diagnostic message
+        error: test-diagnostic: main diagnostic message
          --> animals:1:1
           |
         1 | aardvark
@@ -1202,7 +1202,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: lint:test-diagnostic: main diagnostic message
+        error: test-diagnostic: main diagnostic message
           --> animals:1:1
            |
          1 | aardvark
@@ -1233,7 +1233,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: lint:test-diagnostic: main diagnostic message
+        error: test-diagnostic: main diagnostic message
           --> animals:1:1
            |
          1 | aardvark
@@ -1271,7 +1271,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: lint:test-diagnostic: main diagnostic message
+        error: test-diagnostic: main diagnostic message
          --> spacey-animals:8:1
           |
         7 | dog
@@ -1288,7 +1288,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: lint:test-diagnostic: main diagnostic message
+        error: test-diagnostic: main diagnostic message
           --> spacey-animals:12:1
            |
         11 | gorilla
@@ -1306,7 +1306,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: lint:test-diagnostic: main diagnostic message
+        error: test-diagnostic: main diagnostic message
           --> spacey-animals:13:1
            |
         11 | gorilla
@@ -1346,7 +1346,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: lint:test-diagnostic: main diagnostic message
+        error: test-diagnostic: main diagnostic message
          --> spacey-animals:3:1
           |
         3 | beetle
@@ -1375,7 +1375,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: lint:test-diagnostic: main diagnostic message
+        error: test-diagnostic: main diagnostic message
          --> animals:3:1
           |
         1 | aardvark
@@ -1412,7 +1412,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: lint:test-diagnostic: main diagnostic message
+        error: test-diagnostic: main diagnostic message
          --> animals:3:1
           |
         1 | aardvark
@@ -1449,7 +1449,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: lint:test-diagnostic: main diagnostic message
+        error: test-diagnostic: main diagnostic message
          --> animals:3:1
           |
         1 | aardvark
@@ -1477,7 +1477,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: lint:test-diagnostic: main diagnostic message
+        error: test-diagnostic: main diagnostic message
          --> animals:3:1
           |
         1 | aardvark
@@ -1513,7 +1513,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: lint:test-diagnostic: main diagnostic message
+        error: test-diagnostic: main diagnostic message
          --> animals:3:1
           |
         1 | aardvark
@@ -1552,7 +1552,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: lint:test-diagnostic: main diagnostic message
+        error: test-diagnostic: main diagnostic message
          --> animals:3:1
           |
         1 | aardvark
@@ -1600,7 +1600,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: lint:test-diagnostic: main diagnostic message
+        error: test-diagnostic: main diagnostic message
          --> animals:3:1
           |
         1 | aardvark
@@ -1636,7 +1636,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: lint:test-diagnostic: main diagnostic message
+        error: test-diagnostic: main diagnostic message
          --> animals:5:1
           |
         3 |   canary
@@ -1659,7 +1659,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: lint:test-diagnostic: main diagnostic message
+        error: test-diagnostic: main diagnostic message
          --> animals:5:1
           |
         3 |   canary
@@ -1679,7 +1679,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: lint:test-diagnostic: main diagnostic message
+        error: test-diagnostic: main diagnostic message
          --> animals:5:1
           |
         3 |   canary
@@ -1699,7 +1699,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: lint:test-diagnostic: main diagnostic message
+        error: test-diagnostic: main diagnostic message
           --> animals:5:4
            |
          3 |   canary
@@ -1721,7 +1721,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: lint:test-diagnostic: main diagnostic message
+        error: test-diagnostic: main diagnostic message
           --> animals:5:4
            |
          3 |   canary
@@ -1753,7 +1753,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: lint:test-diagnostic: main diagnostic message
+        error: test-diagnostic: main diagnostic message
          --> animals:4:1
           |
         2 |    beetle
@@ -1782,7 +1782,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: lint:test-diagnostic: main diagnostic message
+        error: test-diagnostic: main diagnostic message
          --> animals:4:1
           |
         2 |    beetle
@@ -1813,7 +1813,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: lint:test-diagnostic: main diagnostic message
+        error: test-diagnostic: main diagnostic message
          --> animals:5:1
           |
         3 |    canary
@@ -1848,7 +1848,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: lint:test-diagnostic: main diagnostic message
+        error: test-diagnostic: main diagnostic message
          --> animals:5:1
           |
         3 |    canary
@@ -1876,7 +1876,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: lint:test-diagnostic: main diagnostic message
+        error: test-diagnostic: main diagnostic message
          --> animals:5:1
           |
         3 |    canary
@@ -1908,7 +1908,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: lint:test-diagnostic: main diagnostic message
+        error: test-diagnostic: main diagnostic message
          --> animals:5:3
           |
         3 | canary
@@ -1930,7 +1930,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: lint:test-diagnostic: main diagnostic message
+        error: test-diagnostic: main diagnostic message
          --> animals:5:3
           |
         3 | canary
@@ -1963,7 +1963,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: lint:test-diagnostic: main diagnostic message
+        error: test-diagnostic: main diagnostic message
           --> animals:8:1
            |
          6 | finch
@@ -2003,7 +2003,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: lint:test-diagnostic: main diagnostic message
+        error: test-diagnostic: main diagnostic message
          --> animals:5:1
           |
         5 | elephant
@@ -2047,7 +2047,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: lint:test-diagnostic: main diagnostic message
+        error: test-diagnostic: main diagnostic message
          --> fruits:1:1
           |
         1 | apple
@@ -2082,7 +2082,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: lint:test-diagnostic: main diagnostic message
+        error: test-diagnostic: main diagnostic message
           --> animals:11:1
            |
         11 | kangaroo

--- a/crates/ruff_db/src/diagnostic/render.rs
+++ b/crates/ruff_db/src/diagnostic/render.rs
@@ -140,7 +140,6 @@ impl std::fmt::Display for DisplayDiagnostic<'_> {
 /// both.)
 #[derive(Debug)]
 struct Resolved<'a> {
-    id: String,
     diagnostics: Vec<ResolvedDiagnostic<'a>>,
 }
 
@@ -152,14 +151,12 @@ impl<'a> Resolved<'a> {
         for sub in &diag.inner.subs {
             diagnostics.push(ResolvedDiagnostic::from_sub_diagnostic(resolver, sub));
         }
-        let id = diag.inner.id.as_concise_str().to_string();
-        Resolved { id, diagnostics }
+        Resolved { diagnostics }
     }
 
     /// Creates a value that is amenable to rendering directly.
     fn to_renderable(&self, context: usize) -> Renderable<'_> {
         Renderable {
-            id: &self.id,
             diagnostics: self
                 .diagnostics
                 .iter()
@@ -177,6 +174,7 @@ impl<'a> Resolved<'a> {
 #[derive(Debug)]
 struct ResolvedDiagnostic<'a> {
     severity: Severity,
+    id: Option<String>,
     message: String,
     annotations: Vec<ResolvedAnnotation<'a>>,
 }
@@ -197,17 +195,11 @@ impl<'a> ResolvedDiagnostic<'a> {
                 ResolvedAnnotation::new(path, &diagnostic_source, ann)
             })
             .collect();
-        let message =
-            // TODO: See the comment on `Renderable::id` for
-            // a plausible better idea than smushing the ID
-            // into the diagnostic message.
-            format!(
-                "{id}: {message}",
-                id = diag.inner.id.as_concise_str(),
-                message = diag.inner.message.as_str(),
-            );
+        let id = Some(diag.inner.id.as_concise_str().to_string());
+        let message = diag.inner.message.as_str().to_string();
         ResolvedDiagnostic {
             severity: diag.inner.severity,
+            id,
             message,
             annotations,
         }
@@ -230,6 +222,7 @@ impl<'a> ResolvedDiagnostic<'a> {
             .collect();
         ResolvedDiagnostic {
             severity: diag.inner.severity,
+            id: None,
             message: diag.inner.message.as_str().to_string(),
             annotations,
         }
@@ -296,6 +289,7 @@ impl<'a> ResolvedDiagnostic<'a> {
             .sort_by(|snips1, snips2| snips1.has_primary.cmp(&snips2.has_primary).reverse());
         RenderableDiagnostic {
             severity: self.severity,
+            id: self.id.as_deref(),
             message: &self.message,
             snippets_by_input,
         }
@@ -375,20 +369,6 @@ impl<'a> ResolvedAnnotation<'a> {
 /// renderable value. This is usually the lifetime of `Resolved`.
 #[derive(Debug)]
 struct Renderable<'r> {
-    // TODO: This is currently unused in the rendering logic below. I'm not
-    // 100% sure yet where I want to put it, but I like what `rustc` does:
-    //
-    //     error[E0599]: no method named `sub_builder` <..snip..>
-    //
-    // I believe in order to do this, we'll need to patch it in to
-    // `ruff_annotate_snippets` though. We leave it here for now with that plan
-    // in mind.
-    //
-    // (At time of writing, 2025-03-13, we currently render the diagnostic
-    // ID into the main message of the parent diagnostic. We don't use this
-    // specific field to do that though.)
-    #[expect(dead_code)]
-    id: &'r str,
     diagnostics: Vec<RenderableDiagnostic<'r>>,
 }
 
@@ -397,6 +377,12 @@ struct Renderable<'r> {
 struct RenderableDiagnostic<'r> {
     /// The severity of the diagnostic.
     severity: Severity,
+    /// The ID of the diagnostic. The ID can usually be used on the CLI or in a
+    /// config file to change the severity of a lint.
+    ///
+    /// An ID is always present for top-level diagnostics and always absent for
+    /// sub-diagnostics.
+    id: Option<&'r str>,
     /// The message emitted with the diagnostic, before any snippets are
     /// rendered.
     message: &'r str,
@@ -417,7 +403,11 @@ impl RenderableDiagnostic<'_> {
                 .iter()
                 .map(|snippet| snippet.to_annotate(path))
         });
-        level.title(self.message).snippets(snippets)
+        let mut message = level.title(self.message);
+        if let Some(id) = self.id {
+            message = message.id(id);
+        }
+        message.snippets(snippets)
     }
 }
 
@@ -796,7 +786,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: test-diagnostic: main diagnostic message
+        error[test-diagnostic]: main diagnostic message
          --> animals:5:1
           |
         3 | canary
@@ -820,7 +810,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        warning: test-diagnostic: main diagnostic message
+        warning[test-diagnostic]: main diagnostic message
          --> animals:5:1
           |
         3 | canary
@@ -840,7 +830,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        info: test-diagnostic: main diagnostic message
+        info[test-diagnostic]: main diagnostic message
          --> animals:5:1
           |
         3 | canary
@@ -867,7 +857,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: test-diagnostic: main diagnostic message
+        error[test-diagnostic]: main diagnostic message
          --> animals:1:1
           |
         1 | aardvark
@@ -886,7 +876,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: test-diagnostic: main diagnostic message
+        error[test-diagnostic]: main diagnostic message
          --> animals:1:1
           |
         1 | aardvark
@@ -907,7 +897,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: test-diagnostic: main diagnostic message
+        error[test-diagnostic]: main diagnostic message
          --> non-ascii:5:1
           |
         3 | ΔΔΔΔΔΔΔΔΔΔΔΔ
@@ -926,7 +916,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: test-diagnostic: main diagnostic message
+        error[test-diagnostic]: main diagnostic message
          --> non-ascii:2:2
           |
         1 | ☃☃☃☃☃☃☃☃☃☃☃☃
@@ -950,7 +940,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: test-diagnostic: main diagnostic message
+        error[test-diagnostic]: main diagnostic message
          --> animals:5:1
           |
         4 | dog
@@ -967,7 +957,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: test-diagnostic: main diagnostic message
+        error[test-diagnostic]: main diagnostic message
          --> animals:5:1
           |
         5 | elephant
@@ -982,7 +972,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: test-diagnostic: main diagnostic message
+        error[test-diagnostic]: main diagnostic message
          --> animals:1:1
           |
         1 | aardvark
@@ -999,7 +989,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: test-diagnostic: main diagnostic message
+        error[test-diagnostic]: main diagnostic message
           --> animals:11:1
            |
          9 | inchworm
@@ -1016,7 +1006,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: test-diagnostic: main diagnostic message
+        error[test-diagnostic]: main diagnostic message
           --> animals:5:1
            |
          1 | aardvark
@@ -1049,7 +1039,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: test-diagnostic: main diagnostic message
+        error[test-diagnostic]: main diagnostic message
           --> animals:1:1
            |
          1 | aardvark
@@ -1093,7 +1083,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: test-diagnostic: main diagnostic message
+        error[test-diagnostic]: main diagnostic message
          --> animals:1:1
           |
         1 | aardvark
@@ -1118,7 +1108,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: test-diagnostic: main diagnostic message
+        error[test-diagnostic]: main diagnostic message
          --> animals:1:1
           |
         1 | aardvark
@@ -1146,7 +1136,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: test-diagnostic: main diagnostic message
+        error[test-diagnostic]: main diagnostic message
          --> animals:1:1
           |
         1 | aardvark
@@ -1174,7 +1164,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: test-diagnostic: main diagnostic message
+        error[test-diagnostic]: main diagnostic message
          --> animals:1:1
           |
         1 | aardvark
@@ -1199,7 +1189,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: test-diagnostic: main diagnostic message
+        error[test-diagnostic]: main diagnostic message
           --> animals:1:1
            |
          1 | aardvark
@@ -1230,7 +1220,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: test-diagnostic: main diagnostic message
+        error[test-diagnostic]: main diagnostic message
           --> animals:1:1
            |
          1 | aardvark
@@ -1268,7 +1258,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: test-diagnostic: main diagnostic message
+        error[test-diagnostic]: main diagnostic message
          --> spacey-animals:8:1
           |
         7 | dog
@@ -1285,7 +1275,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: test-diagnostic: main diagnostic message
+        error[test-diagnostic]: main diagnostic message
           --> spacey-animals:12:1
            |
         11 | gorilla
@@ -1303,7 +1293,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: test-diagnostic: main diagnostic message
+        error[test-diagnostic]: main diagnostic message
           --> spacey-animals:13:1
            |
         11 | gorilla
@@ -1343,7 +1333,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: test-diagnostic: main diagnostic message
+        error[test-diagnostic]: main diagnostic message
          --> spacey-animals:3:1
           |
         3 | beetle
@@ -1372,7 +1362,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: test-diagnostic: main diagnostic message
+        error[test-diagnostic]: main diagnostic message
          --> animals:3:1
           |
         1 | aardvark
@@ -1409,7 +1399,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: test-diagnostic: main diagnostic message
+        error[test-diagnostic]: main diagnostic message
          --> animals:3:1
           |
         1 | aardvark
@@ -1446,7 +1436,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: test-diagnostic: main diagnostic message
+        error[test-diagnostic]: main diagnostic message
          --> animals:3:1
           |
         1 | aardvark
@@ -1474,7 +1464,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: test-diagnostic: main diagnostic message
+        error[test-diagnostic]: main diagnostic message
          --> animals:3:1
           |
         1 | aardvark
@@ -1510,7 +1500,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: test-diagnostic: main diagnostic message
+        error[test-diagnostic]: main diagnostic message
          --> animals:3:1
           |
         1 | aardvark
@@ -1549,7 +1539,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: test-diagnostic: main diagnostic message
+        error[test-diagnostic]: main diagnostic message
          --> animals:3:1
           |
         1 | aardvark
@@ -1597,7 +1587,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: test-diagnostic: main diagnostic message
+        error[test-diagnostic]: main diagnostic message
          --> animals:3:1
           |
         1 | aardvark
@@ -1633,7 +1623,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: test-diagnostic: main diagnostic message
+        error[test-diagnostic]: main diagnostic message
          --> animals:5:1
           |
         3 |   canary
@@ -1656,7 +1646,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: test-diagnostic: main diagnostic message
+        error[test-diagnostic]: main diagnostic message
          --> animals:5:1
           |
         3 |   canary
@@ -1676,7 +1666,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: test-diagnostic: main diagnostic message
+        error[test-diagnostic]: main diagnostic message
          --> animals:5:1
           |
         3 |   canary
@@ -1696,7 +1686,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: test-diagnostic: main diagnostic message
+        error[test-diagnostic]: main diagnostic message
           --> animals:5:4
            |
          3 |   canary
@@ -1718,7 +1708,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: test-diagnostic: main diagnostic message
+        error[test-diagnostic]: main diagnostic message
           --> animals:5:4
            |
          3 |   canary
@@ -1750,7 +1740,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: test-diagnostic: main diagnostic message
+        error[test-diagnostic]: main diagnostic message
          --> animals:4:1
           |
         2 |    beetle
@@ -1779,7 +1769,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: test-diagnostic: main diagnostic message
+        error[test-diagnostic]: main diagnostic message
          --> animals:4:1
           |
         2 |    beetle
@@ -1810,7 +1800,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: test-diagnostic: main diagnostic message
+        error[test-diagnostic]: main diagnostic message
          --> animals:5:1
           |
         3 |    canary
@@ -1845,7 +1835,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: test-diagnostic: main diagnostic message
+        error[test-diagnostic]: main diagnostic message
          --> animals:5:1
           |
         3 |    canary
@@ -1873,7 +1863,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: test-diagnostic: main diagnostic message
+        error[test-diagnostic]: main diagnostic message
          --> animals:5:1
           |
         3 |    canary
@@ -1905,7 +1895,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: test-diagnostic: main diagnostic message
+        error[test-diagnostic]: main diagnostic message
          --> animals:5:3
           |
         3 | canary
@@ -1927,7 +1917,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: test-diagnostic: main diagnostic message
+        error[test-diagnostic]: main diagnostic message
          --> animals:5:3
           |
         3 | canary
@@ -1960,7 +1950,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: test-diagnostic: main diagnostic message
+        error[test-diagnostic]: main diagnostic message
           --> animals:8:1
            |
          6 | finch
@@ -2000,7 +1990,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: test-diagnostic: main diagnostic message
+        error[test-diagnostic]: main diagnostic message
          --> animals:5:1
           |
         5 | elephant
@@ -2044,7 +2034,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: test-diagnostic: main diagnostic message
+        error[test-diagnostic]: main diagnostic message
          --> fruits:1:1
           |
         1 | apple
@@ -2079,7 +2069,7 @@ watermelon
         insta::assert_snapshot!(
             env.render(&diag),
             @r"
-        error: test-diagnostic: main diagnostic message
+        error[test-diagnostic]: main diagnostic message
           --> animals:11:1
            |
         11 | kangaroo

--- a/crates/ruff_db/src/diagnostic/render.rs
+++ b/crates/ruff_db/src/diagnostic/render.rs
@@ -79,7 +79,7 @@ impl std::fmt::Display for DisplayDiagnostic<'_> {
                 f,
                 "{severity}[{id}]",
                 severity = fmt_styled(severity, severity_style),
-                id = fmt_styled(self.diag.id().as_concise_str(), stylesheet.emphasis)
+                id = fmt_styled(self.diag.id(), stylesheet.emphasis)
             )?;
 
             if let Some(span) = self.diag.primary_span() {
@@ -195,7 +195,7 @@ impl<'a> ResolvedDiagnostic<'a> {
                 ResolvedAnnotation::new(path, &diagnostic_source, ann)
             })
             .collect();
-        let id = Some(diag.inner.id.as_concise_str().to_string());
+        let id = Some(diag.inner.id.to_string());
         let message = diag.inner.message.as_str().to_string();
         ResolvedDiagnostic {
             severity: diag.inner.severity,

--- a/crates/ty/tests/cli.rs
+++ b/crates/ty/tests/cli.rs
@@ -14,7 +14,7 @@ fn test_run_in_sub_directory() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    error: invalid-syntax
+    error: invalid-syntax: 
      --> <temp_dir>/test.py:1:2
       |
     1 | ~
@@ -35,7 +35,7 @@ fn test_include_hidden_files_by_default() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    error: invalid-syntax
+    error: invalid-syntax: 
      --> .test.py:1:2
       |
     1 | ~
@@ -68,7 +68,7 @@ fn test_respect_ignore_files() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    error: invalid-syntax
+    error: invalid-syntax: 
      --> test.py:1:2
       |
     1 | ~
@@ -86,7 +86,7 @@ fn test_respect_ignore_files() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    error: invalid-syntax
+    error: invalid-syntax: 
      --> test.py:1:2
       |
     1 | ~
@@ -104,7 +104,7 @@ fn test_respect_ignore_files() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    error: invalid-syntax
+    error: invalid-syntax: 
      --> test.py:1:2
       |
     1 | ~
@@ -637,7 +637,7 @@ fn configuration_unknown_rules() -> anyhow::Result<()> {
     success: true
     exit_code: 0
     ----- stdout -----
-    warning: unknown-rule
+    warning: unknown-rule: 
      --> pyproject.toml:3:1
       |
     2 | [tool.ty.rules]

--- a/crates/ty/tests/cli.rs
+++ b/crates/ty/tests/cli.rs
@@ -14,7 +14,7 @@ fn test_run_in_sub_directory() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    error: invalid-syntax: 
+    error[invalid-syntax]
      --> <temp_dir>/test.py:1:2
       |
     1 | ~
@@ -35,7 +35,7 @@ fn test_include_hidden_files_by_default() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    error: invalid-syntax: 
+    error[invalid-syntax]
      --> .test.py:1:2
       |
     1 | ~
@@ -68,7 +68,7 @@ fn test_respect_ignore_files() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    error: invalid-syntax: 
+    error[invalid-syntax]
      --> test.py:1:2
       |
     1 | ~
@@ -86,7 +86,7 @@ fn test_respect_ignore_files() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    error: invalid-syntax: 
+    error[invalid-syntax]
      --> test.py:1:2
       |
     1 | ~
@@ -104,7 +104,7 @@ fn test_respect_ignore_files() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    error: invalid-syntax: 
+    error[invalid-syntax]
      --> test.py:1:2
       |
     1 | ~
@@ -144,7 +144,7 @@ fn config_override_python_version() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    error: unresolved-attribute: Type `<module 'sys'>` has no attribute `last_exc`
+    error[unresolved-attribute]: Type `<module 'sys'>` has no attribute `last_exc`
      --> test.py:5:7
       |
     4 | # Access `sys.last_exc` that was only added in Python 3.12
@@ -278,7 +278,7 @@ fn cli_arguments_are_relative_to_the_current_directory() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    error: unresolved-import: Cannot resolve imported module `utils`
+    error[unresolved-import]: Cannot resolve imported module `utils`
      --> test.py:2:6
       |
     2 | from utils import add
@@ -379,7 +379,7 @@ fn configuration_rule_severity() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    error: division-by-zero: Cannot divide object of type `Literal[4]` by zero
+    error[division-by-zero]: Cannot divide object of type `Literal[4]` by zero
      --> test.py:2:5
       |
     2 | y = 4 / 0
@@ -389,7 +389,7 @@ fn configuration_rule_severity() -> anyhow::Result<()> {
       |
     info: `lint:division-by-zero` is enabled by default
 
-    error: unresolved-reference: Name `prin` used when not defined
+    error[unresolved-reference]: Name `prin` used when not defined
      --> test.py:7:1
       |
     5 |     x = a
@@ -417,7 +417,7 @@ fn configuration_rule_severity() -> anyhow::Result<()> {
     success: true
     exit_code: 0
     ----- stdout -----
-    warning: division-by-zero: Cannot divide object of type `Literal[4]` by zero
+    warning[division-by-zero]: Cannot divide object of type `Literal[4]` by zero
      --> test.py:2:5
       |
     2 | y = 4 / 0
@@ -458,7 +458,7 @@ fn cli_rule_severity() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    error: unresolved-import: Cannot resolve imported module `does_not_exit`
+    error[unresolved-import]: Cannot resolve imported module `does_not_exit`
      --> test.py:2:8
       |
     2 | import does_not_exit
@@ -468,7 +468,7 @@ fn cli_rule_severity() -> anyhow::Result<()> {
       |
     info: `lint:unresolved-import` is enabled by default
 
-    error: division-by-zero: Cannot divide object of type `Literal[4]` by zero
+    error[division-by-zero]: Cannot divide object of type `Literal[4]` by zero
      --> test.py:4:5
       |
     2 | import does_not_exit
@@ -480,7 +480,7 @@ fn cli_rule_severity() -> anyhow::Result<()> {
       |
     info: `lint:division-by-zero` is enabled by default
 
-    error: unresolved-reference: Name `prin` used when not defined
+    error[unresolved-reference]: Name `prin` used when not defined
      --> test.py:9:1
       |
     7 |     x = a
@@ -508,7 +508,7 @@ fn cli_rule_severity() -> anyhow::Result<()> {
     success: true
     exit_code: 0
     ----- stdout -----
-    warning: unresolved-import: Cannot resolve imported module `does_not_exit`
+    warning[unresolved-import]: Cannot resolve imported module `does_not_exit`
      --> test.py:2:8
       |
     2 | import does_not_exit
@@ -518,7 +518,7 @@ fn cli_rule_severity() -> anyhow::Result<()> {
       |
     info: `lint:unresolved-import` was selected on the command line
 
-    warning: division-by-zero: Cannot divide object of type `Literal[4]` by zero
+    warning[division-by-zero]: Cannot divide object of type `Literal[4]` by zero
      --> test.py:4:5
       |
     2 | import does_not_exit
@@ -561,7 +561,7 @@ fn cli_rule_severity_precedence() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    error: division-by-zero: Cannot divide object of type `Literal[4]` by zero
+    error[division-by-zero]: Cannot divide object of type `Literal[4]` by zero
      --> test.py:2:5
       |
     2 | y = 4 / 0
@@ -571,7 +571,7 @@ fn cli_rule_severity_precedence() -> anyhow::Result<()> {
       |
     info: `lint:division-by-zero` is enabled by default
 
-    error: unresolved-reference: Name `prin` used when not defined
+    error[unresolved-reference]: Name `prin` used when not defined
      --> test.py:7:1
       |
     5 |     x = a
@@ -600,7 +600,7 @@ fn cli_rule_severity_precedence() -> anyhow::Result<()> {
     success: true
     exit_code: 0
     ----- stdout -----
-    warning: division-by-zero: Cannot divide object of type `Literal[4]` by zero
+    warning[division-by-zero]: Cannot divide object of type `Literal[4]` by zero
      --> test.py:2:5
       |
     2 | y = 4 / 0
@@ -637,7 +637,7 @@ fn configuration_unknown_rules() -> anyhow::Result<()> {
     success: true
     exit_code: 0
     ----- stdout -----
-    warning: unknown-rule: 
+    warning[unknown-rule]
      --> pyproject.toml:3:1
       |
     2 | [tool.ty.rules]
@@ -662,7 +662,7 @@ fn cli_unknown_rules() -> anyhow::Result<()> {
     success: true
     exit_code: 0
     ----- stdout -----
-    warning: unknown-rule: Unknown lint rule `division-by-zer`
+    warning[unknown-rule]: Unknown lint rule `division-by-zer`
 
     Found 1 diagnostic
 
@@ -680,7 +680,7 @@ fn exit_code_only_warnings() -> anyhow::Result<()> {
     success: true
     exit_code: 0
     ----- stdout -----
-    warning: unresolved-reference: Name `x` used when not defined
+    warning[unresolved-reference]: Name `x` used when not defined
      --> test.py:1:7
       |
     1 | print(x)  # [unresolved-reference]
@@ -764,7 +764,7 @@ fn exit_code_no_errors_but_error_on_warning_is_true() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    warning: unresolved-reference: Name `x` used when not defined
+    warning[unresolved-reference]: Name `x` used when not defined
      --> test.py:1:7
       |
     1 | print(x)  # [unresolved-reference]
@@ -797,7 +797,7 @@ fn exit_code_no_errors_but_error_on_warning_is_enabled_in_configuration() -> any
     success: false
     exit_code: 1
     ----- stdout -----
-    warning: unresolved-reference: Name `x` used when not defined
+    warning[unresolved-reference]: Name `x` used when not defined
      --> test.py:1:7
       |
     1 | print(x)  # [unresolved-reference]
@@ -827,7 +827,7 @@ fn exit_code_both_warnings_and_errors() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    warning: unresolved-reference: Name `x` used when not defined
+    warning[unresolved-reference]: Name `x` used when not defined
      --> test.py:2:7
       |
     2 | print(x)     # [unresolved-reference]
@@ -836,7 +836,7 @@ fn exit_code_both_warnings_and_errors() -> anyhow::Result<()> {
       |
     info: `lint:unresolved-reference` was selected on the command line
 
-    error: non-subscriptable: Cannot subscript object of type `Literal[4]` with no `__getitem__` method
+    error[non-subscriptable]: Cannot subscript object of type `Literal[4]` with no `__getitem__` method
      --> test.py:3:7
       |
     2 | print(x)     # [unresolved-reference]
@@ -867,7 +867,7 @@ fn exit_code_both_warnings_and_errors_and_error_on_warning_is_true() -> anyhow::
     success: false
     exit_code: 1
     ----- stdout -----
-    warning: unresolved-reference: Name `x` used when not defined
+    warning[unresolved-reference]: Name `x` used when not defined
      --> test.py:2:7
       |
     2 | print(x)     # [unresolved-reference]
@@ -876,7 +876,7 @@ fn exit_code_both_warnings_and_errors_and_error_on_warning_is_true() -> anyhow::
       |
     info: `lint:unresolved-reference` was selected on the command line
 
-    error: non-subscriptable: Cannot subscript object of type `Literal[4]` with no `__getitem__` method
+    error[non-subscriptable]: Cannot subscript object of type `Literal[4]` with no `__getitem__` method
      --> test.py:3:7
       |
     2 | print(x)     # [unresolved-reference]
@@ -907,7 +907,7 @@ fn exit_code_exit_zero_is_true() -> anyhow::Result<()> {
     success: true
     exit_code: 0
     ----- stdout -----
-    warning: unresolved-reference: Name `x` used when not defined
+    warning[unresolved-reference]: Name `x` used when not defined
      --> test.py:2:7
       |
     2 | print(x)     # [unresolved-reference]
@@ -916,7 +916,7 @@ fn exit_code_exit_zero_is_true() -> anyhow::Result<()> {
       |
     info: `lint:unresolved-reference` was selected on the command line
 
-    error: non-subscriptable: Cannot subscript object of type `Literal[4]` with no `__getitem__` method
+    error[non-subscriptable]: Cannot subscript object of type `Literal[4]` with no `__getitem__` method
      --> test.py:3:7
       |
     2 | print(x)     # [unresolved-reference]
@@ -969,7 +969,7 @@ fn user_configuration() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    warning: division-by-zero: Cannot divide object of type `Literal[4]` by zero
+    warning[division-by-zero]: Cannot divide object of type `Literal[4]` by zero
      --> main.py:2:5
       |
     2 | y = 4 / 0
@@ -979,7 +979,7 @@ fn user_configuration() -> anyhow::Result<()> {
       |
     info: `lint:division-by-zero` was selected in the configuration file
 
-    error: unresolved-reference: Name `prin` used when not defined
+    error[unresolved-reference]: Name `prin` used when not defined
      --> main.py:7:1
       |
     5 |     x = a
@@ -1013,7 +1013,7 @@ fn user_configuration() -> anyhow::Result<()> {
     success: true
     exit_code: 0
     ----- stdout -----
-    warning: division-by-zero: Cannot divide object of type `Literal[4]` by zero
+    warning[division-by-zero]: Cannot divide object of type `Literal[4]` by zero
      --> main.py:2:5
       |
     2 | y = 4 / 0
@@ -1023,7 +1023,7 @@ fn user_configuration() -> anyhow::Result<()> {
       |
     info: `lint:division-by-zero` was selected in the configuration file
 
-    warning: unresolved-reference: Name `prin` used when not defined
+    warning[unresolved-reference]: Name `prin` used when not defined
      --> main.py:7:1
       |
     5 |     x = a
@@ -1073,7 +1073,7 @@ fn check_specific_paths() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    error: division-by-zero: Cannot divide object of type `Literal[4]` by zero
+    error[division-by-zero]: Cannot divide object of type `Literal[4]` by zero
      --> project/main.py:2:5
       |
     2 | y = 4 / 0  # error: division-by-zero
@@ -1081,7 +1081,7 @@ fn check_specific_paths() -> anyhow::Result<()> {
       |
     info: `lint:division-by-zero` is enabled by default
 
-    error: unresolved-import: Cannot resolve imported module `main2`
+    error[unresolved-import]: Cannot resolve imported module `main2`
      --> project/other.py:2:6
       |
     2 | from main2 import z  # error: unresolved-import
@@ -1091,7 +1091,7 @@ fn check_specific_paths() -> anyhow::Result<()> {
       |
     info: `lint:unresolved-import` is enabled by default
 
-    error: unresolved-import: Cannot resolve imported module `does_not_exist`
+    error[unresolved-import]: Cannot resolve imported module `does_not_exist`
      --> project/tests/test_main.py:2:8
       |
     2 | import does_not_exist  # error: unresolved-import
@@ -1113,7 +1113,7 @@ fn check_specific_paths() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    error: unresolved-import: Cannot resolve imported module `main2`
+    error[unresolved-import]: Cannot resolve imported module `main2`
      --> project/other.py:2:6
       |
     2 | from main2 import z  # error: unresolved-import
@@ -1123,7 +1123,7 @@ fn check_specific_paths() -> anyhow::Result<()> {
       |
     info: `lint:unresolved-import` is enabled by default
 
-    error: unresolved-import: Cannot resolve imported module `does_not_exist`
+    error[unresolved-import]: Cannot resolve imported module `does_not_exist`
      --> project/tests/test_main.py:2:8
       |
     2 | import does_not_exist  # error: unresolved-import
@@ -1157,9 +1157,9 @@ fn check_non_existing_path() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    error: io: `<temp_dir>/project/main.py`: No such file or directory (os error 2)
+    error[io]: `<temp_dir>/project/main.py`: No such file or directory (os error 2)
 
-    error: io: `<temp_dir>/project/tests`: No such file or directory (os error 2)
+    error[io]: `<temp_dir>/project/tests`: No such file or directory (os error 2)
 
     Found 2 diagnostics
 
@@ -1292,7 +1292,7 @@ fn defaults_to_a_new_python_version() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    error: unresolved-attribute: Type `<module 'os'>` has no attribute `grantpt`
+    error[unresolved-attribute]: Type `<module 'os'>` has no attribute `grantpt`
      --> main.py:4:1
       |
     2 | import os
@@ -1347,7 +1347,7 @@ fn cli_config_args_toml_string_basic() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    warning: unresolved-reference: Name `x` used when not defined
+    warning[unresolved-reference]: Name `x` used when not defined
      --> test.py:1:7
       |
     1 | print(x)  # [unresolved-reference]
@@ -1365,7 +1365,7 @@ fn cli_config_args_toml_string_basic() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    error: unresolved-reference: Name `x` used when not defined
+    error[unresolved-reference]: Name `x` used when not defined
      --> test.py:1:7
       |
     1 | print(x)  # [unresolved-reference]
@@ -1397,7 +1397,7 @@ fn cli_config_args_overrides_knot_toml() -> anyhow::Result<()> {
     success: true
     exit_code: 0
     ----- stdout -----
-    warning: unresolved-reference: Name `x` used when not defined
+    warning[unresolved-reference]: Name `x` used when not defined
      --> test.py:1:7
       |
     1 | print(x)  # [unresolved-reference]
@@ -1420,7 +1420,7 @@ fn cli_config_args_later_overrides_earlier() -> anyhow::Result<()> {
     success: true
     exit_code: 0
     ----- stdout -----
-    warning: unresolved-reference: Name `x` used when not defined
+    warning[unresolved-reference]: Name `x` used when not defined
      --> test.py:1:7
       |
     1 | print(x)  # [unresolved-reference]

--- a/crates/ty/tests/cli.rs
+++ b/crates/ty/tests/cli.rs
@@ -144,7 +144,7 @@ fn config_override_python_version() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    error: lint:unresolved-attribute: Type `<module 'sys'>` has no attribute `last_exc`
+    error: unresolved-attribute: Type `<module 'sys'>` has no attribute `last_exc`
      --> test.py:5:7
       |
     4 | # Access `sys.last_exc` that was only added in Python 3.12
@@ -278,7 +278,7 @@ fn cli_arguments_are_relative_to_the_current_directory() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    error: lint:unresolved-import: Cannot resolve imported module `utils`
+    error: unresolved-import: Cannot resolve imported module `utils`
      --> test.py:2:6
       |
     2 | from utils import add
@@ -379,7 +379,7 @@ fn configuration_rule_severity() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    error: lint:division-by-zero: Cannot divide object of type `Literal[4]` by zero
+    error: division-by-zero: Cannot divide object of type `Literal[4]` by zero
      --> test.py:2:5
       |
     2 | y = 4 / 0
@@ -389,7 +389,7 @@ fn configuration_rule_severity() -> anyhow::Result<()> {
       |
     info: `lint:division-by-zero` is enabled by default
 
-    error: lint:unresolved-reference: Name `prin` used when not defined
+    error: unresolved-reference: Name `prin` used when not defined
      --> test.py:7:1
       |
     5 |     x = a
@@ -417,7 +417,7 @@ fn configuration_rule_severity() -> anyhow::Result<()> {
     success: true
     exit_code: 0
     ----- stdout -----
-    warning: lint:division-by-zero: Cannot divide object of type `Literal[4]` by zero
+    warning: division-by-zero: Cannot divide object of type `Literal[4]` by zero
      --> test.py:2:5
       |
     2 | y = 4 / 0
@@ -458,7 +458,7 @@ fn cli_rule_severity() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    error: lint:unresolved-import: Cannot resolve imported module `does_not_exit`
+    error: unresolved-import: Cannot resolve imported module `does_not_exit`
      --> test.py:2:8
       |
     2 | import does_not_exit
@@ -468,7 +468,7 @@ fn cli_rule_severity() -> anyhow::Result<()> {
       |
     info: `lint:unresolved-import` is enabled by default
 
-    error: lint:division-by-zero: Cannot divide object of type `Literal[4]` by zero
+    error: division-by-zero: Cannot divide object of type `Literal[4]` by zero
      --> test.py:4:5
       |
     2 | import does_not_exit
@@ -480,7 +480,7 @@ fn cli_rule_severity() -> anyhow::Result<()> {
       |
     info: `lint:division-by-zero` is enabled by default
 
-    error: lint:unresolved-reference: Name `prin` used when not defined
+    error: unresolved-reference: Name `prin` used when not defined
      --> test.py:9:1
       |
     7 |     x = a
@@ -508,7 +508,7 @@ fn cli_rule_severity() -> anyhow::Result<()> {
     success: true
     exit_code: 0
     ----- stdout -----
-    warning: lint:unresolved-import: Cannot resolve imported module `does_not_exit`
+    warning: unresolved-import: Cannot resolve imported module `does_not_exit`
      --> test.py:2:8
       |
     2 | import does_not_exit
@@ -518,7 +518,7 @@ fn cli_rule_severity() -> anyhow::Result<()> {
       |
     info: `lint:unresolved-import` was selected on the command line
 
-    warning: lint:division-by-zero: Cannot divide object of type `Literal[4]` by zero
+    warning: division-by-zero: Cannot divide object of type `Literal[4]` by zero
      --> test.py:4:5
       |
     2 | import does_not_exit
@@ -561,7 +561,7 @@ fn cli_rule_severity_precedence() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    error: lint:division-by-zero: Cannot divide object of type `Literal[4]` by zero
+    error: division-by-zero: Cannot divide object of type `Literal[4]` by zero
      --> test.py:2:5
       |
     2 | y = 4 / 0
@@ -571,7 +571,7 @@ fn cli_rule_severity_precedence() -> anyhow::Result<()> {
       |
     info: `lint:division-by-zero` is enabled by default
 
-    error: lint:unresolved-reference: Name `prin` used when not defined
+    error: unresolved-reference: Name `prin` used when not defined
      --> test.py:7:1
       |
     5 |     x = a
@@ -600,7 +600,7 @@ fn cli_rule_severity_precedence() -> anyhow::Result<()> {
     success: true
     exit_code: 0
     ----- stdout -----
-    warning: lint:division-by-zero: Cannot divide object of type `Literal[4]` by zero
+    warning: division-by-zero: Cannot divide object of type `Literal[4]` by zero
      --> test.py:2:5
       |
     2 | y = 4 / 0
@@ -680,7 +680,7 @@ fn exit_code_only_warnings() -> anyhow::Result<()> {
     success: true
     exit_code: 0
     ----- stdout -----
-    warning: lint:unresolved-reference: Name `x` used when not defined
+    warning: unresolved-reference: Name `x` used when not defined
      --> test.py:1:7
       |
     1 | print(x)  # [unresolved-reference]
@@ -764,7 +764,7 @@ fn exit_code_no_errors_but_error_on_warning_is_true() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    warning: lint:unresolved-reference: Name `x` used when not defined
+    warning: unresolved-reference: Name `x` used when not defined
      --> test.py:1:7
       |
     1 | print(x)  # [unresolved-reference]
@@ -797,7 +797,7 @@ fn exit_code_no_errors_but_error_on_warning_is_enabled_in_configuration() -> any
     success: false
     exit_code: 1
     ----- stdout -----
-    warning: lint:unresolved-reference: Name `x` used when not defined
+    warning: unresolved-reference: Name `x` used when not defined
      --> test.py:1:7
       |
     1 | print(x)  # [unresolved-reference]
@@ -827,7 +827,7 @@ fn exit_code_both_warnings_and_errors() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    warning: lint:unresolved-reference: Name `x` used when not defined
+    warning: unresolved-reference: Name `x` used when not defined
      --> test.py:2:7
       |
     2 | print(x)     # [unresolved-reference]
@@ -836,7 +836,7 @@ fn exit_code_both_warnings_and_errors() -> anyhow::Result<()> {
       |
     info: `lint:unresolved-reference` was selected on the command line
 
-    error: lint:non-subscriptable: Cannot subscript object of type `Literal[4]` with no `__getitem__` method
+    error: non-subscriptable: Cannot subscript object of type `Literal[4]` with no `__getitem__` method
      --> test.py:3:7
       |
     2 | print(x)     # [unresolved-reference]
@@ -867,7 +867,7 @@ fn exit_code_both_warnings_and_errors_and_error_on_warning_is_true() -> anyhow::
     success: false
     exit_code: 1
     ----- stdout -----
-    warning: lint:unresolved-reference: Name `x` used when not defined
+    warning: unresolved-reference: Name `x` used when not defined
      --> test.py:2:7
       |
     2 | print(x)     # [unresolved-reference]
@@ -876,7 +876,7 @@ fn exit_code_both_warnings_and_errors_and_error_on_warning_is_true() -> anyhow::
       |
     info: `lint:unresolved-reference` was selected on the command line
 
-    error: lint:non-subscriptable: Cannot subscript object of type `Literal[4]` with no `__getitem__` method
+    error: non-subscriptable: Cannot subscript object of type `Literal[4]` with no `__getitem__` method
      --> test.py:3:7
       |
     2 | print(x)     # [unresolved-reference]
@@ -907,7 +907,7 @@ fn exit_code_exit_zero_is_true() -> anyhow::Result<()> {
     success: true
     exit_code: 0
     ----- stdout -----
-    warning: lint:unresolved-reference: Name `x` used when not defined
+    warning: unresolved-reference: Name `x` used when not defined
      --> test.py:2:7
       |
     2 | print(x)     # [unresolved-reference]
@@ -916,7 +916,7 @@ fn exit_code_exit_zero_is_true() -> anyhow::Result<()> {
       |
     info: `lint:unresolved-reference` was selected on the command line
 
-    error: lint:non-subscriptable: Cannot subscript object of type `Literal[4]` with no `__getitem__` method
+    error: non-subscriptable: Cannot subscript object of type `Literal[4]` with no `__getitem__` method
      --> test.py:3:7
       |
     2 | print(x)     # [unresolved-reference]
@@ -969,7 +969,7 @@ fn user_configuration() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    warning: lint:division-by-zero: Cannot divide object of type `Literal[4]` by zero
+    warning: division-by-zero: Cannot divide object of type `Literal[4]` by zero
      --> main.py:2:5
       |
     2 | y = 4 / 0
@@ -979,7 +979,7 @@ fn user_configuration() -> anyhow::Result<()> {
       |
     info: `lint:division-by-zero` was selected in the configuration file
 
-    error: lint:unresolved-reference: Name `prin` used when not defined
+    error: unresolved-reference: Name `prin` used when not defined
      --> main.py:7:1
       |
     5 |     x = a
@@ -1013,7 +1013,7 @@ fn user_configuration() -> anyhow::Result<()> {
     success: true
     exit_code: 0
     ----- stdout -----
-    warning: lint:division-by-zero: Cannot divide object of type `Literal[4]` by zero
+    warning: division-by-zero: Cannot divide object of type `Literal[4]` by zero
      --> main.py:2:5
       |
     2 | y = 4 / 0
@@ -1023,7 +1023,7 @@ fn user_configuration() -> anyhow::Result<()> {
       |
     info: `lint:division-by-zero` was selected in the configuration file
 
-    warning: lint:unresolved-reference: Name `prin` used when not defined
+    warning: unresolved-reference: Name `prin` used when not defined
      --> main.py:7:1
       |
     5 |     x = a
@@ -1073,7 +1073,7 @@ fn check_specific_paths() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    error: lint:division-by-zero: Cannot divide object of type `Literal[4]` by zero
+    error: division-by-zero: Cannot divide object of type `Literal[4]` by zero
      --> project/main.py:2:5
       |
     2 | y = 4 / 0  # error: division-by-zero
@@ -1081,7 +1081,7 @@ fn check_specific_paths() -> anyhow::Result<()> {
       |
     info: `lint:division-by-zero` is enabled by default
 
-    error: lint:unresolved-import: Cannot resolve imported module `main2`
+    error: unresolved-import: Cannot resolve imported module `main2`
      --> project/other.py:2:6
       |
     2 | from main2 import z  # error: unresolved-import
@@ -1091,7 +1091,7 @@ fn check_specific_paths() -> anyhow::Result<()> {
       |
     info: `lint:unresolved-import` is enabled by default
 
-    error: lint:unresolved-import: Cannot resolve imported module `does_not_exist`
+    error: unresolved-import: Cannot resolve imported module `does_not_exist`
      --> project/tests/test_main.py:2:8
       |
     2 | import does_not_exist  # error: unresolved-import
@@ -1113,7 +1113,7 @@ fn check_specific_paths() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    error: lint:unresolved-import: Cannot resolve imported module `main2`
+    error: unresolved-import: Cannot resolve imported module `main2`
      --> project/other.py:2:6
       |
     2 | from main2 import z  # error: unresolved-import
@@ -1123,7 +1123,7 @@ fn check_specific_paths() -> anyhow::Result<()> {
       |
     info: `lint:unresolved-import` is enabled by default
 
-    error: lint:unresolved-import: Cannot resolve imported module `does_not_exist`
+    error: unresolved-import: Cannot resolve imported module `does_not_exist`
      --> project/tests/test_main.py:2:8
       |
     2 | import does_not_exist  # error: unresolved-import
@@ -1185,8 +1185,8 @@ fn concise_diagnostics() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    warning[lint:unresolved-reference] test.py:2:7: Name `x` used when not defined
-    error[lint:non-subscriptable] test.py:3:7: Cannot subscript object of type `Literal[4]` with no `__getitem__` method
+    warning[unresolved-reference] test.py:2:7: Name `x` used when not defined
+    error[non-subscriptable] test.py:3:7: Cannot subscript object of type `Literal[4]` with no `__getitem__` method
     Found 2 diagnostics
 
     ----- stderr -----
@@ -1292,7 +1292,7 @@ fn defaults_to_a_new_python_version() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    error: lint:unresolved-attribute: Type `<module 'os'>` has no attribute `grantpt`
+    error: unresolved-attribute: Type `<module 'os'>` has no attribute `grantpt`
      --> main.py:4:1
       |
     2 | import os
@@ -1347,7 +1347,7 @@ fn cli_config_args_toml_string_basic() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    warning: lint:unresolved-reference: Name `x` used when not defined
+    warning: unresolved-reference: Name `x` used when not defined
      --> test.py:1:7
       |
     1 | print(x)  # [unresolved-reference]
@@ -1358,14 +1358,14 @@ fn cli_config_args_toml_string_basic() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-      ");
+    ");
 
     // Short flag
     assert_cmd_snapshot!(case.command().arg("-c").arg("terminal.error-on-warning=true"), @r"
     success: false
     exit_code: 1
     ----- stdout -----
-    error: lint:unresolved-reference: Name `x` used when not defined
+    error: unresolved-reference: Name `x` used when not defined
      --> test.py:1:7
       |
     1 | print(x)  # [unresolved-reference]
@@ -1376,7 +1376,7 @@ fn cli_config_args_toml_string_basic() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-      ");
+    ");
 
     Ok(())
 }
@@ -1397,7 +1397,7 @@ fn cli_config_args_overrides_knot_toml() -> anyhow::Result<()> {
     success: true
     exit_code: 0
     ----- stdout -----
-    warning: lint:unresolved-reference: Name `x` used when not defined
+    warning: unresolved-reference: Name `x` used when not defined
      --> test.py:1:7
       |
     1 | print(x)  # [unresolved-reference]
@@ -1420,7 +1420,7 @@ fn cli_config_args_later_overrides_earlier() -> anyhow::Result<()> {
     success: true
     exit_code: 0
     ----- stdout -----
-    warning: lint:unresolved-reference: Name `x` used when not defined
+    warning: unresolved-reference: Name `x` used when not defined
      --> test.py:1:7
       |
     1 | print(x)  # [unresolved-reference]

--- a/crates/ty/tests/cli.rs
+++ b/crates/ty/tests/cli.rs
@@ -151,7 +151,7 @@ fn config_override_python_version() -> anyhow::Result<()> {
     5 | print(sys.last_exc)
       |       ^^^^^^^^^^^^
       |
-    info: `lint:unresolved-attribute` is enabled by default
+    info: `unresolved-attribute` is enabled by default
 
     Found 1 diagnostic
 
@@ -196,7 +196,7 @@ fn config_override_python_platform() -> anyhow::Result<()> {
     success: true
     exit_code: 0
     ----- stdout -----
-    info: revealed-type: Revealed type
+    info[revealed-type]: Revealed type
      --> test.py:5:13
       |
     3 | from typing_extensions import reveal_type
@@ -214,7 +214,7 @@ fn config_override_python_platform() -> anyhow::Result<()> {
     success: true
     exit_code: 0
     ----- stdout -----
-    info: revealed-type: Revealed type
+    info[revealed-type]: Revealed type
      --> test.py:5:13
       |
     3 | from typing_extensions import reveal_type
@@ -286,7 +286,7 @@ fn cli_arguments_are_relative_to_the_current_directory() -> anyhow::Result<()> {
     3 |
     4 | stat = add(10, 15)
       |
-    info: `lint:unresolved-import` is enabled by default
+    info: `unresolved-import` is enabled by default
 
     Found 1 diagnostic
 
@@ -387,7 +387,7 @@ fn configuration_rule_severity() -> anyhow::Result<()> {
     3 |
     4 | for a in range(0, int(y)):
       |
-    info: `lint:division-by-zero` is enabled by default
+    info: `division-by-zero` is enabled by default
 
     error[unresolved-reference]: Name `prin` used when not defined
      --> test.py:7:1
@@ -397,7 +397,7 @@ fn configuration_rule_severity() -> anyhow::Result<()> {
     7 | prin(x)  # unresolved-reference
       | ^^^^
       |
-    info: `lint:unresolved-reference` is enabled by default
+    info: `unresolved-reference` is enabled by default
 
     Found 2 diagnostics
 
@@ -425,7 +425,7 @@ fn configuration_rule_severity() -> anyhow::Result<()> {
     3 |
     4 | for a in range(0, int(y)):
       |
-    info: `lint:division-by-zero` was selected in the configuration file
+    info: `division-by-zero` was selected in the configuration file
 
     Found 1 diagnostic
 
@@ -466,7 +466,7 @@ fn cli_rule_severity() -> anyhow::Result<()> {
     3 |
     4 | y = 4 / 0
       |
-    info: `lint:unresolved-import` is enabled by default
+    info: `unresolved-import` is enabled by default
 
     error[division-by-zero]: Cannot divide object of type `Literal[4]` by zero
      --> test.py:4:5
@@ -478,7 +478,7 @@ fn cli_rule_severity() -> anyhow::Result<()> {
     5 |
     6 | for a in range(0, int(y)):
       |
-    info: `lint:division-by-zero` is enabled by default
+    info: `division-by-zero` is enabled by default
 
     error[unresolved-reference]: Name `prin` used when not defined
      --> test.py:9:1
@@ -488,7 +488,7 @@ fn cli_rule_severity() -> anyhow::Result<()> {
     9 | prin(x)  # unresolved-reference
       | ^^^^
       |
-    info: `lint:unresolved-reference` is enabled by default
+    info: `unresolved-reference` is enabled by default
 
     Found 3 diagnostics
 
@@ -516,7 +516,7 @@ fn cli_rule_severity() -> anyhow::Result<()> {
     3 |
     4 | y = 4 / 0
       |
-    info: `lint:unresolved-import` was selected on the command line
+    info: `unresolved-import` was selected on the command line
 
     warning[division-by-zero]: Cannot divide object of type `Literal[4]` by zero
      --> test.py:4:5
@@ -528,7 +528,7 @@ fn cli_rule_severity() -> anyhow::Result<()> {
     5 |
     6 | for a in range(0, int(y)):
       |
-    info: `lint:division-by-zero` was selected on the command line
+    info: `division-by-zero` was selected on the command line
 
     Found 2 diagnostics
 
@@ -569,7 +569,7 @@ fn cli_rule_severity_precedence() -> anyhow::Result<()> {
     3 |
     4 | for a in range(0, int(y)):
       |
-    info: `lint:division-by-zero` is enabled by default
+    info: `division-by-zero` is enabled by default
 
     error[unresolved-reference]: Name `prin` used when not defined
      --> test.py:7:1
@@ -579,7 +579,7 @@ fn cli_rule_severity_precedence() -> anyhow::Result<()> {
     7 | prin(x)  # unresolved-reference
       | ^^^^
       |
-    info: `lint:unresolved-reference` is enabled by default
+    info: `unresolved-reference` is enabled by default
 
     Found 2 diagnostics
 
@@ -608,7 +608,7 @@ fn cli_rule_severity_precedence() -> anyhow::Result<()> {
     3 |
     4 | for a in range(0, int(y)):
       |
-    info: `lint:division-by-zero` was selected on the command line
+    info: `division-by-zero` was selected on the command line
 
     Found 1 diagnostic
 
@@ -686,7 +686,7 @@ fn exit_code_only_warnings() -> anyhow::Result<()> {
     1 | print(x)  # [unresolved-reference]
       |       ^
       |
-    info: `lint:unresolved-reference` was selected on the command line
+    info: `unresolved-reference` was selected on the command line
 
     Found 1 diagnostic
 
@@ -710,7 +710,7 @@ fn exit_code_only_info() -> anyhow::Result<()> {
     success: true
     exit_code: 0
     ----- stdout -----
-    info: revealed-type: Revealed type
+    info[revealed-type]: Revealed type
      --> test.py:3:13
       |
     2 | from typing_extensions import reveal_type
@@ -740,7 +740,7 @@ fn exit_code_only_info_and_error_on_warning_is_true() -> anyhow::Result<()> {
     success: true
     exit_code: 0
     ----- stdout -----
-    info: revealed-type: Revealed type
+    info[revealed-type]: Revealed type
      --> test.py:3:13
       |
     2 | from typing_extensions import reveal_type
@@ -770,7 +770,7 @@ fn exit_code_no_errors_but_error_on_warning_is_true() -> anyhow::Result<()> {
     1 | print(x)  # [unresolved-reference]
       |       ^
       |
-    info: `lint:unresolved-reference` was selected on the command line
+    info: `unresolved-reference` was selected on the command line
 
     Found 1 diagnostic
 
@@ -803,7 +803,7 @@ fn exit_code_no_errors_but_error_on_warning_is_enabled_in_configuration() -> any
     1 | print(x)  # [unresolved-reference]
       |       ^
       |
-    info: `lint:unresolved-reference` was selected on the command line
+    info: `unresolved-reference` was selected on the command line
 
     Found 1 diagnostic
 
@@ -834,7 +834,7 @@ fn exit_code_both_warnings_and_errors() -> anyhow::Result<()> {
       |       ^
     3 | print(4[1])  # [non-subscriptable]
       |
-    info: `lint:unresolved-reference` was selected on the command line
+    info: `unresolved-reference` was selected on the command line
 
     error[non-subscriptable]: Cannot subscript object of type `Literal[4]` with no `__getitem__` method
      --> test.py:3:7
@@ -843,7 +843,7 @@ fn exit_code_both_warnings_and_errors() -> anyhow::Result<()> {
     3 | print(4[1])  # [non-subscriptable]
       |       ^
       |
-    info: `lint:non-subscriptable` is enabled by default
+    info: `non-subscriptable` is enabled by default
 
     Found 2 diagnostics
 
@@ -874,7 +874,7 @@ fn exit_code_both_warnings_and_errors_and_error_on_warning_is_true() -> anyhow::
       |       ^
     3 | print(4[1])  # [non-subscriptable]
       |
-    info: `lint:unresolved-reference` was selected on the command line
+    info: `unresolved-reference` was selected on the command line
 
     error[non-subscriptable]: Cannot subscript object of type `Literal[4]` with no `__getitem__` method
      --> test.py:3:7
@@ -883,7 +883,7 @@ fn exit_code_both_warnings_and_errors_and_error_on_warning_is_true() -> anyhow::
     3 | print(4[1])  # [non-subscriptable]
       |       ^
       |
-    info: `lint:non-subscriptable` is enabled by default
+    info: `non-subscriptable` is enabled by default
 
     Found 2 diagnostics
 
@@ -914,7 +914,7 @@ fn exit_code_exit_zero_is_true() -> anyhow::Result<()> {
       |       ^
     3 | print(4[1])  # [non-subscriptable]
       |
-    info: `lint:unresolved-reference` was selected on the command line
+    info: `unresolved-reference` was selected on the command line
 
     error[non-subscriptable]: Cannot subscript object of type `Literal[4]` with no `__getitem__` method
      --> test.py:3:7
@@ -923,7 +923,7 @@ fn exit_code_exit_zero_is_true() -> anyhow::Result<()> {
     3 | print(4[1])  # [non-subscriptable]
       |       ^
       |
-    info: `lint:non-subscriptable` is enabled by default
+    info: `non-subscriptable` is enabled by default
 
     Found 2 diagnostics
 
@@ -977,7 +977,7 @@ fn user_configuration() -> anyhow::Result<()> {
     3 |
     4 | for a in range(0, int(y)):
       |
-    info: `lint:division-by-zero` was selected in the configuration file
+    info: `division-by-zero` was selected in the configuration file
 
     error[unresolved-reference]: Name `prin` used when not defined
      --> main.py:7:1
@@ -987,7 +987,7 @@ fn user_configuration() -> anyhow::Result<()> {
     7 | prin(x)
       | ^^^^
       |
-    info: `lint:unresolved-reference` is enabled by default
+    info: `unresolved-reference` is enabled by default
 
     Found 2 diagnostics
 
@@ -1021,7 +1021,7 @@ fn user_configuration() -> anyhow::Result<()> {
     3 |
     4 | for a in range(0, int(y)):
       |
-    info: `lint:division-by-zero` was selected in the configuration file
+    info: `division-by-zero` was selected in the configuration file
 
     warning[unresolved-reference]: Name `prin` used when not defined
      --> main.py:7:1
@@ -1031,7 +1031,7 @@ fn user_configuration() -> anyhow::Result<()> {
     7 | prin(x)
       | ^^^^
       |
-    info: `lint:unresolved-reference` was selected in the configuration file
+    info: `unresolved-reference` was selected in the configuration file
 
     Found 2 diagnostics
 
@@ -1079,7 +1079,7 @@ fn check_specific_paths() -> anyhow::Result<()> {
     2 | y = 4 / 0  # error: division-by-zero
       |     ^^^^^
       |
-    info: `lint:division-by-zero` is enabled by default
+    info: `division-by-zero` is enabled by default
 
     error[unresolved-import]: Cannot resolve imported module `main2`
      --> project/other.py:2:6
@@ -1089,7 +1089,7 @@ fn check_specific_paths() -> anyhow::Result<()> {
     3 |
     4 | print(z)
       |
-    info: `lint:unresolved-import` is enabled by default
+    info: `unresolved-import` is enabled by default
 
     error[unresolved-import]: Cannot resolve imported module `does_not_exist`
      --> project/tests/test_main.py:2:8
@@ -1097,7 +1097,7 @@ fn check_specific_paths() -> anyhow::Result<()> {
     2 | import does_not_exist  # error: unresolved-import
       |        ^^^^^^^^^^^^^^
       |
-    info: `lint:unresolved-import` is enabled by default
+    info: `unresolved-import` is enabled by default
 
     Found 3 diagnostics
 
@@ -1121,7 +1121,7 @@ fn check_specific_paths() -> anyhow::Result<()> {
     3 |
     4 | print(z)
       |
-    info: `lint:unresolved-import` is enabled by default
+    info: `unresolved-import` is enabled by default
 
     error[unresolved-import]: Cannot resolve imported module `does_not_exist`
      --> project/tests/test_main.py:2:8
@@ -1129,7 +1129,7 @@ fn check_specific_paths() -> anyhow::Result<()> {
     2 | import does_not_exist  # error: unresolved-import
       |        ^^^^^^^^^^^^^^
       |
-    info: `lint:unresolved-import` is enabled by default
+    info: `unresolved-import` is enabled by default
 
     Found 2 diagnostics
 
@@ -1247,7 +1247,7 @@ fn can_handle_large_binop_expressions() -> anyhow::Result<()> {
     success: true
     exit_code: 0
     ----- stdout -----
-    info: revealed-type: Revealed type
+    info[revealed-type]: Revealed type
      --> test.py:4:13
       |
     2 | from typing_extensions import reveal_type
@@ -1300,7 +1300,7 @@ fn defaults_to_a_new_python_version() -> anyhow::Result<()> {
     4 | os.grantpt(1) # only available on unix, Python 3.13 or newer
       | ^^^^^^^^^^
       |
-    info: `lint:unresolved-attribute` is enabled by default
+    info: `unresolved-attribute` is enabled by default
 
     Found 1 diagnostic
 
@@ -1353,7 +1353,7 @@ fn cli_config_args_toml_string_basic() -> anyhow::Result<()> {
     1 | print(x)  # [unresolved-reference]
       |       ^
       |
-    info: `lint:unresolved-reference` was selected on the command line
+    info: `unresolved-reference` was selected on the command line
 
     Found 1 diagnostic
 
@@ -1371,7 +1371,7 @@ fn cli_config_args_toml_string_basic() -> anyhow::Result<()> {
     1 | print(x)  # [unresolved-reference]
       |       ^
       |
-    info: `lint:unresolved-reference` is enabled by default
+    info: `unresolved-reference` is enabled by default
 
     Found 1 diagnostic
 
@@ -1403,7 +1403,7 @@ fn cli_config_args_overrides_knot_toml() -> anyhow::Result<()> {
     1 | print(x)  # [unresolved-reference]
       |       ^
       |
-    info: `lint:unresolved-reference` was selected on the command line
+    info: `unresolved-reference` was selected on the command line
 
     Found 1 diagnostic
 
@@ -1426,7 +1426,7 @@ fn cli_config_args_later_overrides_earlier() -> anyhow::Result<()> {
     1 | print(x)  # [unresolved-reference]
       |       ^
       |
-    info: `lint:unresolved-reference` was selected on the command line
+    info: `unresolved-reference` was selected on the command line
 
     Found 1 diagnostic
 

--- a/crates/ty_ide/src/goto.rs
+++ b/crates/ty_ide/src/goto.rs
@@ -273,7 +273,7 @@ mod tests {
         );
 
         assert_snapshot!(test.goto_type_definition(), @r"
-        info: lint:goto-type-definition: Type definition
+        info: goto-type-definition: Type definition
          --> main.py:2:19
           |
         2 |             class Test: ...
@@ -305,7 +305,7 @@ mod tests {
         );
 
         assert_snapshot!(test.goto_type_definition(), @r"
-        info: lint:goto-type-definition: Type definition
+        info: goto-type-definition: Type definition
          --> main.py:2:17
           |
         2 |             def foo(a, b): ...
@@ -343,7 +343,7 @@ mod tests {
         );
 
         assert_snapshot!(test.goto_type_definition(), @r"
-        info: lint:goto-type-definition: Type definition
+        info: goto-type-definition: Type definition
          --> main.py:3:17
           |
         3 |             def foo(a, b): ...
@@ -360,7 +360,7 @@ mod tests {
            |             ^
            |
 
-        info: lint:goto-type-definition: Type definition
+        info: goto-type-definition: Type definition
          --> main.py:5:17
           |
         3 |             def foo(a, b): ...
@@ -394,7 +394,7 @@ mod tests {
         test.write_file("lib.py", "a = 10").unwrap();
 
         assert_snapshot!(test.goto_type_definition(), @r"
-        info: lint:goto-type-definition: Type definition
+        info: goto-type-definition: Type definition
          --> lib.py:1:1
           |
         1 | a = 10
@@ -422,7 +422,7 @@ mod tests {
         );
 
         assert_snapshot!(test.goto_type_definition(), @r#"
-        info: lint:goto-type-definition: Type definition
+        info: goto-type-definition: Type definition
            --> stdlib/builtins.pyi:438:7
             |
         436 |     def __getitem__(self, key: int, /) -> str | int | None: ...
@@ -451,7 +451,7 @@ mod tests {
         );
 
         assert_snapshot!(test.goto_type_definition(), @r#"
-        info: lint:goto-type-definition: Type definition
+        info: goto-type-definition: Type definition
            --> stdlib/builtins.pyi:438:7
             |
         436 |     def __getitem__(self, key: int, /) -> str | int | None: ...
@@ -479,7 +479,7 @@ mod tests {
         );
 
         assert_snapshot!(test.goto_type_definition(), @r"
-        info: lint:goto-type-definition: Type definition
+        info: goto-type-definition: Type definition
          --> main.py:2:24
           |
         2 |             type Alias[T: int = bool] = list[T]
@@ -533,7 +533,7 @@ mod tests {
         );
 
         assert_snapshot!(test.goto_type_definition(), @r#"
-        info: lint:goto-type-definition: Type definition
+        info: goto-type-definition: Type definition
            --> stdlib/builtins.pyi:438:7
             |
         436 |     def __getitem__(self, key: int, /) -> str | int | None: ...
@@ -568,7 +568,7 @@ mod tests {
         //   the keyword is typed as a string. It's only the passed argument that
         //   is an int. Navigating to `str` would match pyright's behavior.
         assert_snapshot!(test.goto_type_definition(), @r"
-        info: lint:goto-type-definition: Type definition
+        info: goto-type-definition: Type definition
            --> stdlib/builtins.pyi:231:7
             |
         229 | _LiteralInteger = _PositiveInteger | _NegativeInteger | Literal[0]  # noqa: Y026  # TODO: Use TypeAlias once mypy bugs are fixed
@@ -602,7 +602,7 @@ f(**kwargs<CURSOR>)
         );
 
         assert_snapshot!(test.goto_type_definition(), @r#"
-        info: lint:goto-type-definition: Type definition
+        info: goto-type-definition: Type definition
             --> stdlib/builtins.pyi:1086:7
              |
         1084 |     def __class_getitem__(cls, item: Any, /) -> GenericAlias: ...
@@ -633,7 +633,7 @@ f(**kwargs<CURSOR>)
         );
 
         assert_snapshot!(test.goto_type_definition(), @r"
-        info: lint:goto-type-definition: Type definition
+        info: goto-type-definition: Type definition
            --> stdlib/builtins.pyi:438:7
             |
         436 |     def __getitem__(self, key: int, /) -> str | int | None: ...
@@ -667,7 +667,7 @@ f(**kwargs<CURSOR>)
         );
 
         assert_snapshot!(test.goto_type_definition(), @r"
-        info: lint:goto-type-definition: Type definition
+        info: goto-type-definition: Type definition
          --> main.py:2:19
           |
         2 |             class X:
@@ -696,7 +696,7 @@ f(**kwargs<CURSOR>)
         );
 
         assert_snapshot!(test.goto_type_definition(), @r"
-        info: lint:goto-type-definition: Type definition
+        info: goto-type-definition: Type definition
          --> main.py:2:17
           |
         2 |             def foo(a, b): ...
@@ -726,7 +726,7 @@ f(**kwargs<CURSOR>)
         );
 
         assert_snapshot!(test.goto_type_definition(), @r"
-        info: lint:goto-type-definition: Type definition
+        info: goto-type-definition: Type definition
            --> stdlib/builtins.pyi:438:7
             |
         436 |     def __getitem__(self, key: int, /) -> str | int | None: ...
@@ -757,7 +757,7 @@ f(**kwargs<CURSOR>)
         );
 
         assert_snapshot!(test.goto_type_definition(), @r"
-        info: lint:goto-type-definition: Type definition
+        info: goto-type-definition: Type definition
            --> stdlib/types.pyi:671:11
             |
         669 | if sys.version_info >= (3, 10):
@@ -774,7 +774,7 @@ f(**kwargs<CURSOR>)
           |                 ^
           |
 
-        info: lint:goto-type-definition: Type definition
+        info: goto-type-definition: Type definition
            --> stdlib/builtins.pyi:438:7
             |
         436 |     def __getitem__(self, key: int, /) -> str | int | None: ...

--- a/crates/ty_ide/src/goto.rs
+++ b/crates/ty_ide/src/goto.rs
@@ -273,7 +273,7 @@ mod tests {
         );
 
         assert_snapshot!(test.goto_type_definition(), @r"
-        info: goto-type-definition: Type definition
+        info[goto-type-definition]: Type definition
          --> main.py:2:19
           |
         2 |             class Test: ...
@@ -305,7 +305,7 @@ mod tests {
         );
 
         assert_snapshot!(test.goto_type_definition(), @r"
-        info: goto-type-definition: Type definition
+        info[goto-type-definition]: Type definition
          --> main.py:2:17
           |
         2 |             def foo(a, b): ...
@@ -343,7 +343,7 @@ mod tests {
         );
 
         assert_snapshot!(test.goto_type_definition(), @r"
-        info: goto-type-definition: Type definition
+        info[goto-type-definition]: Type definition
          --> main.py:3:17
           |
         3 |             def foo(a, b): ...
@@ -360,7 +360,7 @@ mod tests {
            |             ^
            |
 
-        info: goto-type-definition: Type definition
+        info[goto-type-definition]: Type definition
          --> main.py:5:17
           |
         3 |             def foo(a, b): ...
@@ -394,7 +394,7 @@ mod tests {
         test.write_file("lib.py", "a = 10").unwrap();
 
         assert_snapshot!(test.goto_type_definition(), @r"
-        info: goto-type-definition: Type definition
+        info[goto-type-definition]: Type definition
          --> lib.py:1:1
           |
         1 | a = 10
@@ -422,7 +422,7 @@ mod tests {
         );
 
         assert_snapshot!(test.goto_type_definition(), @r#"
-        info: goto-type-definition: Type definition
+        info[goto-type-definition]: Type definition
            --> stdlib/builtins.pyi:438:7
             |
         436 |     def __getitem__(self, key: int, /) -> str | int | None: ...
@@ -451,7 +451,7 @@ mod tests {
         );
 
         assert_snapshot!(test.goto_type_definition(), @r#"
-        info: goto-type-definition: Type definition
+        info[goto-type-definition]: Type definition
            --> stdlib/builtins.pyi:438:7
             |
         436 |     def __getitem__(self, key: int, /) -> str | int | None: ...
@@ -479,7 +479,7 @@ mod tests {
         );
 
         assert_snapshot!(test.goto_type_definition(), @r"
-        info: goto-type-definition: Type definition
+        info[goto-type-definition]: Type definition
          --> main.py:2:24
           |
         2 |             type Alias[T: int = bool] = list[T]
@@ -533,7 +533,7 @@ mod tests {
         );
 
         assert_snapshot!(test.goto_type_definition(), @r#"
-        info: goto-type-definition: Type definition
+        info[goto-type-definition]: Type definition
            --> stdlib/builtins.pyi:438:7
             |
         436 |     def __getitem__(self, key: int, /) -> str | int | None: ...
@@ -568,7 +568,7 @@ mod tests {
         //   the keyword is typed as a string. It's only the passed argument that
         //   is an int. Navigating to `str` would match pyright's behavior.
         assert_snapshot!(test.goto_type_definition(), @r"
-        info: goto-type-definition: Type definition
+        info[goto-type-definition]: Type definition
            --> stdlib/builtins.pyi:231:7
             |
         229 | _LiteralInteger = _PositiveInteger | _NegativeInteger | Literal[0]  # noqa: Y026  # TODO: Use TypeAlias once mypy bugs are fixed
@@ -602,7 +602,7 @@ f(**kwargs<CURSOR>)
         );
 
         assert_snapshot!(test.goto_type_definition(), @r#"
-        info: goto-type-definition: Type definition
+        info[goto-type-definition]: Type definition
             --> stdlib/builtins.pyi:1086:7
              |
         1084 |     def __class_getitem__(cls, item: Any, /) -> GenericAlias: ...
@@ -633,7 +633,7 @@ f(**kwargs<CURSOR>)
         );
 
         assert_snapshot!(test.goto_type_definition(), @r"
-        info: goto-type-definition: Type definition
+        info[goto-type-definition]: Type definition
            --> stdlib/builtins.pyi:438:7
             |
         436 |     def __getitem__(self, key: int, /) -> str | int | None: ...
@@ -667,7 +667,7 @@ f(**kwargs<CURSOR>)
         );
 
         assert_snapshot!(test.goto_type_definition(), @r"
-        info: goto-type-definition: Type definition
+        info[goto-type-definition]: Type definition
          --> main.py:2:19
           |
         2 |             class X:
@@ -696,7 +696,7 @@ f(**kwargs<CURSOR>)
         );
 
         assert_snapshot!(test.goto_type_definition(), @r"
-        info: goto-type-definition: Type definition
+        info[goto-type-definition]: Type definition
          --> main.py:2:17
           |
         2 |             def foo(a, b): ...
@@ -726,7 +726,7 @@ f(**kwargs<CURSOR>)
         );
 
         assert_snapshot!(test.goto_type_definition(), @r"
-        info: goto-type-definition: Type definition
+        info[goto-type-definition]: Type definition
            --> stdlib/builtins.pyi:438:7
             |
         436 |     def __getitem__(self, key: int, /) -> str | int | None: ...
@@ -757,7 +757,7 @@ f(**kwargs<CURSOR>)
         );
 
         assert_snapshot!(test.goto_type_definition(), @r"
-        info: goto-type-definition: Type definition
+        info[goto-type-definition]: Type definition
            --> stdlib/types.pyi:671:11
             |
         669 | if sys.version_info >= (3, 10):
@@ -774,7 +774,7 @@ f(**kwargs<CURSOR>)
           |                 ^
           |
 
-        info: goto-type-definition: Type definition
+        info[goto-type-definition]: Type definition
            --> stdlib/builtins.pyi:438:7
             |
         436 |     def __getitem__(self, key: int, /) -> str | int | None: ...

--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -156,7 +156,7 @@ mod tests {
         Literal[10]
         ```
         ---------------------------------------------
-        info: hover: Hovered content is
+        info[hover]: Hovered content is
          --> main.py:4:9
           |
         2 |         a = 10
@@ -192,7 +192,7 @@ mod tests {
         int
         ```
         ---------------------------------------------
-        info: hover: Hovered content is
+        info[hover]: Hovered content is
           --> main.py:10:9
            |
          9 |         foo = Foo()
@@ -222,7 +222,7 @@ mod tests {
         def foo(a, b) -> Unknown
         ```
         ---------------------------------------------
-        info: hover: Hovered content is
+        info[hover]: Hovered content is
          --> main.py:4:13
           |
         2 |             def foo(a, b): ...
@@ -251,7 +251,7 @@ mod tests {
         bool
         ```
         ---------------------------------------------
-        info: hover: Hovered content is
+        info[hover]: Hovered content is
          --> main.py:3:17
           |
         2 |             def foo(a: int, b: int, c: int):
@@ -282,7 +282,7 @@ mod tests {
         Literal[123]
         ```
         ---------------------------------------------
-        info: hover: Hovered content is
+        info[hover]: Hovered content is
          --> main.py:4:18
           |
         2 |             def test(a: int): ...
@@ -320,7 +320,7 @@ mod tests {
         (def foo(a, b) -> Unknown) | (def bar(a, b) -> Unknown)
         ```
         ---------------------------------------------
-        info: hover: Hovered content is
+        info[hover]: Hovered content is
           --> main.py:12:13
            |
         10 |                 a = bar
@@ -352,7 +352,7 @@ mod tests {
         <module 'lib'>
         ```
         ---------------------------------------------
-        info: hover: Hovered content is
+        info[hover]: Hovered content is
          --> main.py:4:13
           |
         2 |             import lib
@@ -381,7 +381,7 @@ mod tests {
         T
         ```
         ---------------------------------------------
-        info: hover: Hovered content is
+        info[hover]: Hovered content is
          --> main.py:2:46
           |
         2 |             type Alias[T: int = bool] = list[T]
@@ -407,7 +407,7 @@ mod tests {
         @Todo
         ```
         ---------------------------------------------
-        info: hover: Hovered content is
+        info[hover]: Hovered content is
          --> main.py:2:53
           |
         2 |             type Alias[**P = [int, str]] = Callable[P, int]
@@ -433,7 +433,7 @@ mod tests {
         @Todo
         ```
         ---------------------------------------------
-        info: hover: Hovered content is
+        info[hover]: Hovered content is
          --> main.py:2:43
           |
         2 |             type Alias[*Ts = ()] = tuple[*Ts]
@@ -459,7 +459,7 @@ mod tests {
         Literal[1]
         ```
         ---------------------------------------------
-        info: hover: Hovered content is
+        info[hover]: Hovered content is
          --> main.py:2:13
           |
         2 |             value = 1
@@ -490,7 +490,7 @@ mod tests {
         Literal[1]
         ```
         ---------------------------------------------
-        info: hover: Hovered content is
+        info[hover]: Hovered content is
          --> main.py:3:13
           |
         2 |             value = 1
@@ -520,7 +520,7 @@ mod tests {
         Literal[2]
         ```
         ---------------------------------------------
-        info: hover: Hovered content is
+        info[hover]: Hovered content is
          --> main.py:5:13
           |
         3 |                 attr: int = 1
@@ -553,7 +553,7 @@ mod tests {
         Unknown | Literal[1]
         ```
         ---------------------------------------------
-        info: hover: Hovered content is
+        info[hover]: Hovered content is
          --> main.py:5:13
           |
         3 |                 attr = 1
@@ -582,7 +582,7 @@ mod tests {
         int
         ```
         ---------------------------------------------
-        info: hover: Hovered content is
+        info[hover]: Hovered content is
          --> main.py:3:13
           |
         2 |         class Foo:
@@ -610,7 +610,7 @@ mod tests {
         Literal[1]
         ```
         ---------------------------------------------
-        info: hover: Hovered content is
+        info[hover]: Hovered content is
          --> main.py:3:13
           |
         2 |         class Foo:
@@ -639,7 +639,7 @@ mod tests {
         int
         ```
         ---------------------------------------------
-        info: hover: Hovered content is
+        info[hover]: Hovered content is
          --> main.py:4:17
           |
         2 |         class Foo:
@@ -669,7 +669,7 @@ mod tests {
         str
         ```
         ---------------------------------------------
-        info: hover: Hovered content is
+        info[hover]: Hovered content is
          --> main.py:4:27
           |
         2 |             def foo(a: str | None, b):

--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -156,7 +156,7 @@ mod tests {
         Literal[10]
         ```
         ---------------------------------------------
-        info: lint:hover: Hovered content is
+        info: hover: Hovered content is
          --> main.py:4:9
           |
         2 |         a = 10
@@ -192,7 +192,7 @@ mod tests {
         int
         ```
         ---------------------------------------------
-        info: lint:hover: Hovered content is
+        info: hover: Hovered content is
           --> main.py:10:9
            |
          9 |         foo = Foo()
@@ -222,7 +222,7 @@ mod tests {
         def foo(a, b) -> Unknown
         ```
         ---------------------------------------------
-        info: lint:hover: Hovered content is
+        info: hover: Hovered content is
          --> main.py:4:13
           |
         2 |             def foo(a, b): ...
@@ -251,7 +251,7 @@ mod tests {
         bool
         ```
         ---------------------------------------------
-        info: lint:hover: Hovered content is
+        info: hover: Hovered content is
          --> main.py:3:17
           |
         2 |             def foo(a: int, b: int, c: int):
@@ -282,7 +282,7 @@ mod tests {
         Literal[123]
         ```
         ---------------------------------------------
-        info: lint:hover: Hovered content is
+        info: hover: Hovered content is
          --> main.py:4:18
           |
         2 |             def test(a: int): ...
@@ -320,7 +320,7 @@ mod tests {
         (def foo(a, b) -> Unknown) | (def bar(a, b) -> Unknown)
         ```
         ---------------------------------------------
-        info: lint:hover: Hovered content is
+        info: hover: Hovered content is
           --> main.py:12:13
            |
         10 |                 a = bar
@@ -352,7 +352,7 @@ mod tests {
         <module 'lib'>
         ```
         ---------------------------------------------
-        info: lint:hover: Hovered content is
+        info: hover: Hovered content is
          --> main.py:4:13
           |
         2 |             import lib
@@ -381,7 +381,7 @@ mod tests {
         T
         ```
         ---------------------------------------------
-        info: lint:hover: Hovered content is
+        info: hover: Hovered content is
          --> main.py:2:46
           |
         2 |             type Alias[T: int = bool] = list[T]
@@ -407,7 +407,7 @@ mod tests {
         @Todo
         ```
         ---------------------------------------------
-        info: lint:hover: Hovered content is
+        info: hover: Hovered content is
          --> main.py:2:53
           |
         2 |             type Alias[**P = [int, str]] = Callable[P, int]
@@ -433,7 +433,7 @@ mod tests {
         @Todo
         ```
         ---------------------------------------------
-        info: lint:hover: Hovered content is
+        info: hover: Hovered content is
          --> main.py:2:43
           |
         2 |             type Alias[*Ts = ()] = tuple[*Ts]
@@ -459,7 +459,7 @@ mod tests {
         Literal[1]
         ```
         ---------------------------------------------
-        info: lint:hover: Hovered content is
+        info: hover: Hovered content is
          --> main.py:2:13
           |
         2 |             value = 1
@@ -490,7 +490,7 @@ mod tests {
         Literal[1]
         ```
         ---------------------------------------------
-        info: lint:hover: Hovered content is
+        info: hover: Hovered content is
          --> main.py:3:13
           |
         2 |             value = 1
@@ -520,7 +520,7 @@ mod tests {
         Literal[2]
         ```
         ---------------------------------------------
-        info: lint:hover: Hovered content is
+        info: hover: Hovered content is
          --> main.py:5:13
           |
         3 |                 attr: int = 1
@@ -553,7 +553,7 @@ mod tests {
         Unknown | Literal[1]
         ```
         ---------------------------------------------
-        info: lint:hover: Hovered content is
+        info: hover: Hovered content is
          --> main.py:5:13
           |
         3 |                 attr = 1
@@ -582,7 +582,7 @@ mod tests {
         int
         ```
         ---------------------------------------------
-        info: lint:hover: Hovered content is
+        info: hover: Hovered content is
          --> main.py:3:13
           |
         2 |         class Foo:
@@ -610,7 +610,7 @@ mod tests {
         Literal[1]
         ```
         ---------------------------------------------
-        info: lint:hover: Hovered content is
+        info: hover: Hovered content is
          --> main.py:3:13
           |
         2 |         class Foo:
@@ -639,7 +639,7 @@ mod tests {
         int
         ```
         ---------------------------------------------
-        info: lint:hover: Hovered content is
+        info: hover: Hovered content is
          --> main.py:4:17
           |
         2 |         class Foo:
@@ -669,7 +669,7 @@ mod tests {
         str
         ```
         ---------------------------------------------
-        info: lint:hover: Hovered content is
+        info: hover: Hovered content is
          --> main.py:4:27
           |
         2 |             def foo(a: str | None, b):

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Data_descriptors_-_Invalid_`__set__`_method_signature.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Data_descriptors_-_Invalid_`__set__`_method_signature.snap
@@ -28,7 +28,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/attribute_as
 # Diagnostics
 
 ```
-error: invalid-assignment: Invalid assignment to data descriptor attribute `attr` on type `C` with custom `__set__` method
+error[invalid-assignment]: Invalid assignment to data descriptor attribute `attr` on type `C` with custom `__set__` method
   --> src/mdtest_snippet.py:11:1
    |
 10 | # TODO: ideally, we would mention why this is an invalid assignment (wrong number of arguments for `__set__`)

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Data_descriptors_-_Invalid_`__set__`_method_signature.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Data_descriptors_-_Invalid_`__set__`_method_signature.snap
@@ -28,7 +28,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/attribute_as
 # Diagnostics
 
 ```
-error: lint:invalid-assignment: Invalid assignment to data descriptor attribute `attr` on type `C` with custom `__set__` method
+error: invalid-assignment: Invalid assignment to data descriptor attribute `attr` on type `C` with custom `__set__` method
   --> src/mdtest_snippet.py:11:1
    |
 10 | # TODO: ideally, we would mention why this is an invalid assignment (wrong number of arguments for `__set__`)

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Data_descriptors_-_Invalid_`__set__`_method_signature.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Data_descriptors_-_Invalid_`__set__`_method_signature.snap
@@ -35,6 +35,6 @@ error[invalid-assignment]: Invalid assignment to data descriptor attribute `attr
 11 | instance.attr = 1  # error: [invalid-assignment]
    | ^^^^^^^^^^^^^
    |
-info: `lint:invalid-assignment` is enabled by default
+info: `invalid-assignment` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Data_descriptors_-_Invalid_argument_type.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Data_descriptors_-_Invalid_argument_type.snap
@@ -36,6 +36,6 @@ error[invalid-assignment]: Invalid assignment to data descriptor attribute `attr
 12 | instance.attr = "wrong"  # error: [invalid-assignment]
    | ^^^^^^^^^^^^^
    |
-info: `lint:invalid-assignment` is enabled by default
+info: `invalid-assignment` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Data_descriptors_-_Invalid_argument_type.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Data_descriptors_-_Invalid_argument_type.snap
@@ -29,7 +29,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/attribute_as
 # Diagnostics
 
 ```
-error: invalid-assignment: Invalid assignment to data descriptor attribute `attr` on type `C` with custom `__set__` method
+error[invalid-assignment]: Invalid assignment to data descriptor attribute `attr` on type `C` with custom `__set__` method
   --> src/mdtest_snippet.py:12:1
    |
 11 | # TODO: ideally, we would mention why this is an invalid assignment (wrong argument type for `value` parameter)

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Data_descriptors_-_Invalid_argument_type.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Data_descriptors_-_Invalid_argument_type.snap
@@ -29,7 +29,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/attribute_as
 # Diagnostics
 
 ```
-error: lint:invalid-assignment: Invalid assignment to data descriptor attribute `attr` on type `C` with custom `__set__` method
+error: invalid-assignment: Invalid assignment to data descriptor attribute `attr` on type `C` with custom `__set__` method
   --> src/mdtest_snippet.py:12:1
    |
 11 | # TODO: ideally, we would mention why this is an invalid assignment (wrong argument type for `value` parameter)

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Instance_attributes_with_class-level_defaults.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Instance_attributes_with_class-level_defaults.snap
@@ -26,7 +26,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/attribute_as
 # Diagnostics
 
 ```
-error: lint:invalid-assignment: Object of type `Literal["wrong"]` is not assignable to attribute `attr` of type `int`
+error: invalid-assignment: Object of type `Literal["wrong"]` is not assignable to attribute `attr` of type `int`
  --> src/mdtest_snippet.py:6:1
   |
 4 | instance = C()
@@ -41,7 +41,7 @@ info: `lint:invalid-assignment` is enabled by default
 ```
 
 ```
-error: lint:invalid-assignment: Object of type `Literal["wrong"]` is not assignable to attribute `attr` of type `int`
+error: invalid-assignment: Object of type `Literal["wrong"]` is not assignable to attribute `attr` of type `int`
  --> src/mdtest_snippet.py:9:1
   |
 8 | C.attr = 1  # fine

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Instance_attributes_with_class-level_defaults.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Instance_attributes_with_class-level_defaults.snap
@@ -26,7 +26,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/attribute_as
 # Diagnostics
 
 ```
-error: invalid-assignment: Object of type `Literal["wrong"]` is not assignable to attribute `attr` of type `int`
+error[invalid-assignment]: Object of type `Literal["wrong"]` is not assignable to attribute `attr` of type `int`
  --> src/mdtest_snippet.py:6:1
   |
 4 | instance = C()
@@ -41,7 +41,7 @@ info: `lint:invalid-assignment` is enabled by default
 ```
 
 ```
-error: invalid-assignment: Object of type `Literal["wrong"]` is not assignable to attribute `attr` of type `int`
+error[invalid-assignment]: Object of type `Literal["wrong"]` is not assignable to attribute `attr` of type `int`
  --> src/mdtest_snippet.py:9:1
   |
 8 | C.attr = 1  # fine

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Instance_attributes_with_class-level_defaults.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Instance_attributes_with_class-level_defaults.snap
@@ -36,7 +36,7 @@ error[invalid-assignment]: Object of type `Literal["wrong"]` is not assignable t
 7 |
 8 | C.attr = 1  # fine
   |
-info: `lint:invalid-assignment` is enabled by default
+info: `invalid-assignment` is enabled by default
 
 ```
 
@@ -48,6 +48,6 @@ error[invalid-assignment]: Object of type `Literal["wrong"]` is not assignable t
 9 | C.attr = "wrong"  # error: [invalid-assignment]
   | ^^^^^^
   |
-info: `lint:invalid-assignment` is enabled by default
+info: `invalid-assignment` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Possibly-unbound_attributes.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Possibly-unbound_attributes.snap
@@ -26,7 +26,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/attribute_as
 # Diagnostics
 
 ```
-warning: lint:possibly-unbound-attribute: Attribute `attr` on type `<class 'C'>` is possibly unbound
+warning: possibly-unbound-attribute: Attribute `attr` on type `<class 'C'>` is possibly unbound
  --> src/mdtest_snippet.py:6:5
   |
 4 |             attr: int = 0
@@ -41,7 +41,7 @@ info: `lint:possibly-unbound-attribute` is enabled by default
 ```
 
 ```
-warning: lint:possibly-unbound-attribute: Attribute `attr` on type `C` is possibly unbound
+warning: possibly-unbound-attribute: Attribute `attr` on type `C` is possibly unbound
  --> src/mdtest_snippet.py:9:5
   |
 8 |     instance = C()

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Possibly-unbound_attributes.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Possibly-unbound_attributes.snap
@@ -26,7 +26,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/attribute_as
 # Diagnostics
 
 ```
-warning: possibly-unbound-attribute: Attribute `attr` on type `<class 'C'>` is possibly unbound
+warning[possibly-unbound-attribute]: Attribute `attr` on type `<class 'C'>` is possibly unbound
  --> src/mdtest_snippet.py:6:5
   |
 4 |             attr: int = 0
@@ -41,7 +41,7 @@ info: `lint:possibly-unbound-attribute` is enabled by default
 ```
 
 ```
-warning: possibly-unbound-attribute: Attribute `attr` on type `C` is possibly unbound
+warning[possibly-unbound-attribute]: Attribute `attr` on type `C` is possibly unbound
  --> src/mdtest_snippet.py:9:5
   |
 8 |     instance = C()

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Possibly-unbound_attributes.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Possibly-unbound_attributes.snap
@@ -36,7 +36,7 @@ warning[possibly-unbound-attribute]: Attribute `attr` on type `<class 'C'>` is p
 7 |
 8 |     instance = C()
   |
-info: `lint:possibly-unbound-attribute` is enabled by default
+info: `possibly-unbound-attribute` is enabled by default
 
 ```
 
@@ -48,6 +48,6 @@ warning[possibly-unbound-attribute]: Attribute `attr` on type `C` is possibly un
 9 |     instance.attr = 1  # error: [possibly-unbound-attribute]
   |     ^^^^^^^^^^^^^
   |
-info: `lint:possibly-unbound-attribute` is enabled by default
+info: `possibly-unbound-attribute` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Pure_instance_attributes.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Pure_instance_attributes.snap
@@ -26,7 +26,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/attribute_as
 # Diagnostics
 
 ```
-error: lint:invalid-assignment: Object of type `Literal["wrong"]` is not assignable to attribute `attr` of type `int`
+error: invalid-assignment: Object of type `Literal["wrong"]` is not assignable to attribute `attr` of type `int`
  --> src/mdtest_snippet.py:7:1
   |
 5 | instance = C()
@@ -41,7 +41,7 @@ info: `lint:invalid-assignment` is enabled by default
 ```
 
 ```
-error: lint:invalid-attribute-access: Cannot assign to instance attribute `attr` from the class object `<class 'C'>`
+error: invalid-attribute-access: Cannot assign to instance attribute `attr` from the class object `<class 'C'>`
  --> src/mdtest_snippet.py:9:1
   |
 7 | instance.attr = "wrong"  # error: [invalid-assignment]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Pure_instance_attributes.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Pure_instance_attributes.snap
@@ -36,7 +36,7 @@ error[invalid-assignment]: Object of type `Literal["wrong"]` is not assignable t
 8 |
 9 | C.attr = 1  # error: [invalid-attribute-access]
   |
-info: `lint:invalid-assignment` is enabled by default
+info: `invalid-assignment` is enabled by default
 
 ```
 
@@ -49,6 +49,6 @@ error[invalid-attribute-access]: Cannot assign to instance attribute `attr` from
 9 | C.attr = 1  # error: [invalid-attribute-access]
   | ^^^^^^
   |
-info: `lint:invalid-attribute-access` is enabled by default
+info: `invalid-attribute-access` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Pure_instance_attributes.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Pure_instance_attributes.snap
@@ -26,7 +26,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/attribute_as
 # Diagnostics
 
 ```
-error: invalid-assignment: Object of type `Literal["wrong"]` is not assignable to attribute `attr` of type `int`
+error[invalid-assignment]: Object of type `Literal["wrong"]` is not assignable to attribute `attr` of type `int`
  --> src/mdtest_snippet.py:7:1
   |
 5 | instance = C()
@@ -41,7 +41,7 @@ info: `lint:invalid-assignment` is enabled by default
 ```
 
 ```
-error: invalid-attribute-access: Cannot assign to instance attribute `attr` from the class object `<class 'C'>`
+error[invalid-attribute-access]: Cannot assign to instance attribute `attr` from the class object `<class 'C'>`
  --> src/mdtest_snippet.py:9:1
   |
 7 | instance.attr = "wrong"  # error: [invalid-assignment]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Setting_attributes_on_union_types.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Setting_attributes_on_union_types.snap
@@ -37,7 +37,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/attribute_as
 # Diagnostics
 
 ```
-error: lint:invalid-assignment: Object of type `Literal[1]` is not assignable to attribute `attr` on type `<class 'C1'> | <class 'C1'>`
+error: invalid-assignment: Object of type `Literal[1]` is not assignable to attribute `attr` on type `<class 'C1'> | <class 'C1'>`
   --> src/mdtest_snippet.py:11:5
    |
 10 |     # TODO: The error message here could be improved to explain why the assignment fails.

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Setting_attributes_on_union_types.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Setting_attributes_on_union_types.snap
@@ -46,6 +46,6 @@ error[invalid-assignment]: Object of type `Literal[1]` is not assignable to attr
 12 |
 13 |     class C2:
    |
-info: `lint:invalid-assignment` is enabled by default
+info: `invalid-assignment` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Setting_attributes_on_union_types.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Setting_attributes_on_union_types.snap
@@ -37,7 +37,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/attribute_as
 # Diagnostics
 
 ```
-error: invalid-assignment: Object of type `Literal[1]` is not assignable to attribute `attr` on type `<class 'C1'> | <class 'C1'>`
+error[invalid-assignment]: Object of type `Literal[1]` is not assignable to attribute `attr` on type `<class 'C1'> | <class 'C1'>`
   --> src/mdtest_snippet.py:11:5
    |
 10 |     # TODO: The error message here could be improved to explain why the assignment fails.

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Unknown_attributes.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Unknown_attributes.snap
@@ -23,7 +23,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/attribute_as
 # Diagnostics
 
 ```
-error: unresolved-attribute: Unresolved attribute `non_existent` on type `<class 'C'>`.
+error[unresolved-attribute]: Unresolved attribute `non_existent` on type `<class 'C'>`.
  --> src/mdtest_snippet.py:3:1
   |
 1 | class C: ...
@@ -38,7 +38,7 @@ info: `lint:unresolved-attribute` is enabled by default
 ```
 
 ```
-error: unresolved-attribute: Unresolved attribute `non_existent` on type `C`.
+error[unresolved-attribute]: Unresolved attribute `non_existent` on type `C`.
  --> src/mdtest_snippet.py:6:1
   |
 5 | instance = C()

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Unknown_attributes.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Unknown_attributes.snap
@@ -23,7 +23,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/attribute_as
 # Diagnostics
 
 ```
-error: lint:unresolved-attribute: Unresolved attribute `non_existent` on type `<class 'C'>`.
+error: unresolved-attribute: Unresolved attribute `non_existent` on type `<class 'C'>`.
  --> src/mdtest_snippet.py:3:1
   |
 1 | class C: ...
@@ -38,7 +38,7 @@ info: `lint:unresolved-attribute` is enabled by default
 ```
 
 ```
-error: lint:unresolved-attribute: Unresolved attribute `non_existent` on type `C`.
+error: unresolved-attribute: Unresolved attribute `non_existent` on type `C`.
  --> src/mdtest_snippet.py:6:1
   |
 5 | instance = C()

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Unknown_attributes.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_Unknown_attributes.snap
@@ -33,7 +33,7 @@ error[unresolved-attribute]: Unresolved attribute `non_existent` on type `<class
 4 |
 5 | instance = C()
   |
-info: `lint:unresolved-attribute` is enabled by default
+info: `unresolved-attribute` is enabled by default
 
 ```
 
@@ -45,6 +45,6 @@ error[unresolved-attribute]: Unresolved attribute `non_existent` on type `C`.
 6 | instance.non_existent = 1  # error: [unresolved-attribute]
   | ^^^^^^^^^^^^^^^^^^^^^
   |
-info: `lint:unresolved-attribute` is enabled by default
+info: `unresolved-attribute` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_`ClassVar`s.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_`ClassVar`s.snap
@@ -36,7 +36,7 @@ error[invalid-assignment]: Object of type `Literal["wrong"]` is not assignable t
 8 |
 9 | instance = C()
   |
-info: `lint:invalid-assignment` is enabled by default
+info: `invalid-assignment` is enabled by default
 
 ```
 
@@ -48,6 +48,6 @@ error[invalid-attribute-access]: Cannot assign to ClassVar `attr` from an instan
 10 | instance.attr = 1  # error: [invalid-attribute-access]
    | ^^^^^^^^^^^^^
    |
-info: `lint:invalid-attribute-access` is enabled by default
+info: `invalid-attribute-access` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_`ClassVar`s.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_`ClassVar`s.snap
@@ -27,7 +27,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/attribute_as
 # Diagnostics
 
 ```
-error: invalid-assignment: Object of type `Literal["wrong"]` is not assignable to attribute `attr` of type `int`
+error[invalid-assignment]: Object of type `Literal["wrong"]` is not assignable to attribute `attr` of type `int`
  --> src/mdtest_snippet.py:7:1
   |
 6 | C.attr = 1  # fine
@@ -41,7 +41,7 @@ info: `lint:invalid-assignment` is enabled by default
 ```
 
 ```
-error: invalid-attribute-access: Cannot assign to ClassVar `attr` from an instance of type `C`
+error[invalid-attribute-access]: Cannot assign to ClassVar `attr` from an instance of type `C`
   --> src/mdtest_snippet.py:10:1
    |
  9 | instance = C()

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_`ClassVar`s.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment.md_-_Attribute_assignment_-_`ClassVar`s.snap
@@ -27,7 +27,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/attribute_as
 # Diagnostics
 
 ```
-error: lint:invalid-assignment: Object of type `Literal["wrong"]` is not assignable to attribute `attr` of type `int`
+error: invalid-assignment: Object of type `Literal["wrong"]` is not assignable to attribute `attr` of type `int`
  --> src/mdtest_snippet.py:7:1
   |
 6 | C.attr = 1  # fine
@@ -41,7 +41,7 @@ info: `lint:invalid-assignment` is enabled by default
 ```
 
 ```
-error: lint:invalid-attribute-access: Cannot assign to ClassVar `attr` from an instance of type `C`
+error: invalid-attribute-access: Cannot assign to ClassVar `attr` from an instance of type `C`
   --> src/mdtest_snippet.py:10:1
    |
  9 | instance = C()

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Multiple_objects_imported_from_an_unresolved_module.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Multiple_objects_imported_from_an_unresolved_module.snap
@@ -26,6 +26,6 @@ error[unresolved-import]: Cannot resolve imported module `does_not_exist`
 2 | from does_not_exist import foo, bar, baz
   |      ^^^^^^^^^^^^^^
   |
-info: `lint:unresolved-import` is enabled by default
+info: `unresolved-import` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Multiple_objects_imported_from_an_unresolved_module.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Multiple_objects_imported_from_an_unresolved_module.snap
@@ -19,7 +19,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/import/basic.md
 # Diagnostics
 
 ```
-error: unresolved-import: Cannot resolve imported module `does_not_exist`
+error[unresolved-import]: Cannot resolve imported module `does_not_exist`
  --> src/mdtest_snippet.py:2:6
   |
 1 | # error: [unresolved-import]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Multiple_objects_imported_from_an_unresolved_module.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Multiple_objects_imported_from_an_unresolved_module.snap
@@ -19,7 +19,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/import/basic.md
 # Diagnostics
 
 ```
-error: lint:unresolved-import: Cannot resolve imported module `does_not_exist`
+error: unresolved-import: Cannot resolve imported module `does_not_exist`
  --> src/mdtest_snippet.py:2:6
   |
 1 | # error: [unresolved-import]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Unresolvable_module_import.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Unresolvable_module_import.snap
@@ -18,7 +18,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/import/basic.md
 # Diagnostics
 
 ```
-error: lint:unresolved-import: Cannot resolve imported module `zqzqzqzqzqzqzq`
+error: unresolved-import: Cannot resolve imported module `zqzqzqzqzqzqzq`
  --> src/mdtest_snippet.py:1:8
   |
 1 | import zqzqzqzqzqzqzq  # error: [unresolved-import] "Cannot resolve imported module `zqzqzqzqzqzqzq`"

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Unresolvable_module_import.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Unresolvable_module_import.snap
@@ -24,6 +24,6 @@ error[unresolved-import]: Cannot resolve imported module `zqzqzqzqzqzqzq`
 1 | import zqzqzqzqzqzqzq  # error: [unresolved-import] "Cannot resolve imported module `zqzqzqzqzqzqzq`"
   |        ^^^^^^^^^^^^^^
   |
-info: `lint:unresolved-import` is enabled by default
+info: `unresolved-import` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Unresolvable_module_import.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Unresolvable_module_import.snap
@@ -18,7 +18,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/import/basic.md
 # Diagnostics
 
 ```
-error: unresolved-import: Cannot resolve imported module `zqzqzqzqzqzqzq`
+error[unresolved-import]: Cannot resolve imported module `zqzqzqzqzqzqzq`
  --> src/mdtest_snippet.py:1:8
   |
 1 | import zqzqzqzqzqzqzq  # error: [unresolved-import] "Cannot resolve imported module `zqzqzqzqzqzqzq`"

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Unresolvable_submodule_imports.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Unresolvable_submodule_imports.snap
@@ -27,7 +27,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/import/basic.md
 # Diagnostics
 
 ```
-error: unresolved-import: Cannot resolve imported module `a.foo`
+error[unresolved-import]: Cannot resolve imported module `a.foo`
  --> src/mdtest_snippet.py:2:8
   |
 1 | # Topmost component resolvable, submodule not resolvable:
@@ -41,7 +41,7 @@ info: `lint:unresolved-import` is enabled by default
 ```
 
 ```
-error: unresolved-import: Cannot resolve imported module `b.foo`
+error[unresolved-import]: Cannot resolve imported module `b.foo`
  --> src/mdtest_snippet.py:5:8
   |
 4 | # Topmost component unresolvable:

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Unresolvable_submodule_imports.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Unresolvable_submodule_imports.snap
@@ -27,7 +27,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/import/basic.md
 # Diagnostics
 
 ```
-error: lint:unresolved-import: Cannot resolve imported module `a.foo`
+error: unresolved-import: Cannot resolve imported module `a.foo`
  --> src/mdtest_snippet.py:2:8
   |
 1 | # Topmost component resolvable, submodule not resolvable:
@@ -41,7 +41,7 @@ info: `lint:unresolved-import` is enabled by default
 ```
 
 ```
-error: lint:unresolved-import: Cannot resolve imported module `b.foo`
+error: unresolved-import: Cannot resolve imported module `b.foo`
  --> src/mdtest_snippet.py:5:8
   |
 4 | # Topmost component unresolvable:

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Unresolvable_submodule_imports.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Unresolvable_submodule_imports.snap
@@ -36,7 +36,7 @@ error[unresolved-import]: Cannot resolve imported module `a.foo`
 3 |
 4 | # Topmost component unresolvable:
   |
-info: `lint:unresolved-import` is enabled by default
+info: `unresolved-import` is enabled by default
 
 ```
 
@@ -48,6 +48,6 @@ error[unresolved-import]: Cannot resolve imported module `b.foo`
 5 | import b.foo  # error: [unresolved-import] "Cannot resolve imported module `b.foo`"
   |        ^^^^^
   |
-info: `lint:unresolved-import` is enabled by default
+info: `unresolved-import` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Bad_`__getitem__`_method.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Bad_`__getitem__`_method.snap
@@ -28,7 +28,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/for.md
 # Diagnostics
 
 ```
-error: not-iterable: Object of type `Iterable` is not iterable
+error[not-iterable]: Object of type `Iterable` is not iterable
   --> src/mdtest_snippet.py:10:10
    |
  9 | # error: [not-iterable]
@@ -43,7 +43,7 @@ info: `lint:not-iterable` is enabled by default
 ```
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
   --> src/mdtest_snippet.py:11:17
    |
  9 | # error: [not-iterable]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Bad_`__getitem__`_method.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Bad_`__getitem__`_method.snap
@@ -38,7 +38,7 @@ error[not-iterable]: Object of type `Iterable` is not iterable
    |
 info: It has no `__iter__` method and its `__getitem__` method has an incorrect signature for the old-style iteration protocol
 info: `__getitem__` must be at least as permissive as `def __getitem__(self, key: int): ...` to satisfy the old-style iteration protocol
-info: `lint:not-iterable` is enabled by default
+info: `not-iterable` is enabled by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Bad_`__getitem__`_method.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Bad_`__getitem__`_method.snap
@@ -28,7 +28,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/for.md
 # Diagnostics
 
 ```
-error: lint:not-iterable: Object of type `Iterable` is not iterable
+error: not-iterable: Object of type `Iterable` is not iterable
   --> src/mdtest_snippet.py:10:10
    |
  9 | # error: [not-iterable]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Invalid_iterable.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Invalid_iterable.snap
@@ -20,7 +20,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/for.md
 # Diagnostics
 
 ```
-error: not-iterable: Object of type `Literal[123]` is not iterable
+error[not-iterable]: Object of type `Literal[123]` is not iterable
  --> src/mdtest_snippet.py:2:10
   |
 1 | nonsense = 123

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Invalid_iterable.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Invalid_iterable.snap
@@ -20,7 +20,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/for.md
 # Diagnostics
 
 ```
-error: lint:not-iterable: Object of type `Literal[123]` is not iterable
+error: not-iterable: Object of type `Literal[123]` is not iterable
  --> src/mdtest_snippet.py:2:10
   |
 1 | nonsense = 123

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Invalid_iterable.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Invalid_iterable.snap
@@ -29,6 +29,6 @@ error[not-iterable]: Object of type `Literal[123]` is not iterable
 3 |     pass
   |
 info: It doesn't have an `__iter__` method or a `__getitem__` method
-info: `lint:not-iterable` is enabled by default
+info: `not-iterable` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_New_over_old_style_iteration_protocol.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_New_over_old_style_iteration_protocol.snap
@@ -34,6 +34,6 @@ error[not-iterable]: Object of type `NotIterable` is not iterable
 7 |     pass
   |
 info: Its `__iter__` attribute has type `None`, which is not callable
-info: `lint:not-iterable` is enabled by default
+info: `not-iterable` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_New_over_old_style_iteration_protocol.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_New_over_old_style_iteration_protocol.snap
@@ -24,7 +24,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/for.md
 # Diagnostics
 
 ```
-error: not-iterable: Object of type `NotIterable` is not iterable
+error[not-iterable]: Object of type `NotIterable` is not iterable
  --> src/mdtest_snippet.py:6:10
   |
 4 |     __iter__: None = None

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_New_over_old_style_iteration_protocol.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_New_over_old_style_iteration_protocol.snap
@@ -24,7 +24,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/for.md
 # Diagnostics
 
 ```
-error: lint:not-iterable: Object of type `NotIterable` is not iterable
+error: not-iterable: Object of type `NotIterable` is not iterable
  --> src/mdtest_snippet.py:6:10
   |
 4 |     __iter__: None = None

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_No_`__iter__`_method_and_`__getitem__`_is_not_callable.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_No_`__iter__`_method_and_`__getitem__`_is_not_callable.snap
@@ -34,7 +34,7 @@ error[not-iterable]: Object of type `Bad` is not iterable
 8 |     reveal_type(x)  # revealed: Unknown
   |
 info: It has no `__iter__` method and its `__getitem__` attribute has type `None`, which is not callable
-info: `lint:not-iterable` is enabled by default
+info: `not-iterable` is enabled by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_No_`__iter__`_method_and_`__getitem__`_is_not_callable.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_No_`__iter__`_method_and_`__getitem__`_is_not_callable.snap
@@ -25,7 +25,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/for.md
 # Diagnostics
 
 ```
-error: lint:not-iterable: Object of type `Bad` is not iterable
+error: not-iterable: Object of type `Bad` is not iterable
  --> src/mdtest_snippet.py:7:10
   |
 6 | # error: [not-iterable]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_No_`__iter__`_method_and_`__getitem__`_is_not_callable.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_No_`__iter__`_method_and_`__getitem__`_is_not_callable.snap
@@ -25,7 +25,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/for.md
 # Diagnostics
 
 ```
-error: not-iterable: Object of type `Bad` is not iterable
+error[not-iterable]: Object of type `Bad` is not iterable
  --> src/mdtest_snippet.py:7:10
   |
 6 | # error: [not-iterable]
@@ -39,7 +39,7 @@ info: `lint:not-iterable` is enabled by default
 ```
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
  --> src/mdtest_snippet.py:8:17
   |
 6 | # error: [not-iterable]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly-not-callable_`__getitem__`_method.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly-not-callable_`__getitem__`_method.snap
@@ -46,7 +46,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/for.md
 # Diagnostics
 
 ```
-error: lint:not-iterable: Object of type `Iterable1` may not be iterable
+error: not-iterable: Object of type `Iterable1` may not be iterable
   --> src/mdtest_snippet.py:22:14
    |
 21 |     # error: [not-iterable]
@@ -76,7 +76,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-error: lint:not-iterable: Object of type `Iterable2` may not be iterable
+error: not-iterable: Object of type `Iterable2` may not be iterable
   --> src/mdtest_snippet.py:27:14
    |
 26 |     # error: [not-iterable]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly-not-callable_`__getitem__`_method.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly-not-callable_`__getitem__`_method.snap
@@ -57,7 +57,7 @@ error[not-iterable]: Object of type `Iterable1` may not be iterable
    |
 info: It has no `__iter__` method and its `__getitem__` attribute is invalid
 info: `__getitem__` has type `CustomCallable`, which is not callable
-info: `lint:not-iterable` is enabled by default
+info: `not-iterable` is enabled by default
 
 ```
 
@@ -87,7 +87,7 @@ error[not-iterable]: Object of type `Iterable2` may not be iterable
    |
 info: It has no `__iter__` method and its `__getitem__` attribute is invalid
 info: `__getitem__` has type `(bound method Iterable2.__getitem__(key: int) -> int) | None`, which is not callable
-info: `lint:not-iterable` is enabled by default
+info: `not-iterable` is enabled by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly-not-callable_`__getitem__`_method.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly-not-callable_`__getitem__`_method.snap
@@ -46,7 +46,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/for.md
 # Diagnostics
 
 ```
-error: not-iterable: Object of type `Iterable1` may not be iterable
+error[not-iterable]: Object of type `Iterable1` may not be iterable
   --> src/mdtest_snippet.py:22:14
    |
 21 |     # error: [not-iterable]
@@ -62,7 +62,7 @@ info: `lint:not-iterable` is enabled by default
 ```
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
   --> src/mdtest_snippet.py:24:21
    |
 22 |     for x in Iterable1():
@@ -76,7 +76,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-error: not-iterable: Object of type `Iterable2` may not be iterable
+error[not-iterable]: Object of type `Iterable2` may not be iterable
   --> src/mdtest_snippet.py:27:14
    |
 26 |     # error: [not-iterable]
@@ -92,7 +92,7 @@ info: `lint:not-iterable` is enabled by default
 ```
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
   --> src/mdtest_snippet.py:29:21
    |
 27 |     for y in Iterable2():

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__getitem__`_methods.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__getitem__`_methods.snap
@@ -43,7 +43,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/for.md
 # Diagnostics
 
 ```
-error: not-iterable: Object of type `Iterable1` may not be iterable
+error[not-iterable]: Object of type `Iterable1` may not be iterable
   --> src/mdtest_snippet.py:20:14
    |
 19 |     # error: [not-iterable]
@@ -59,7 +59,7 @@ info: `lint:not-iterable` is enabled by default
 ```
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
   --> src/mdtest_snippet.py:22:21
    |
 20 |     for x in Iterable1():
@@ -73,7 +73,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-error: not-iterable: Object of type `Iterable2` may not be iterable
+error[not-iterable]: Object of type `Iterable2` may not be iterable
   --> src/mdtest_snippet.py:25:14
    |
 24 |     # error: [not-iterable]
@@ -88,7 +88,7 @@ info: `lint:not-iterable` is enabled by default
 ```
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
   --> src/mdtest_snippet.py:26:21
    |
 24 |     # error: [not-iterable]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__getitem__`_methods.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__getitem__`_methods.snap
@@ -43,7 +43,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/for.md
 # Diagnostics
 
 ```
-error: lint:not-iterable: Object of type `Iterable1` may not be iterable
+error: not-iterable: Object of type `Iterable1` may not be iterable
   --> src/mdtest_snippet.py:20:14
    |
 19 |     # error: [not-iterable]
@@ -73,7 +73,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-error: lint:not-iterable: Object of type `Iterable2` may not be iterable
+error: not-iterable: Object of type `Iterable2` may not be iterable
   --> src/mdtest_snippet.py:25:14
    |
 24 |     # error: [not-iterable]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__getitem__`_methods.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__getitem__`_methods.snap
@@ -54,7 +54,7 @@ error[not-iterable]: Object of type `Iterable1` may not be iterable
    |
 info: It has no `__iter__` method and its `__getitem__` attribute is invalid
 info: `__getitem__` has type `(bound method Iterable1.__getitem__(item: int) -> str) | None`, which is not callable
-info: `lint:not-iterable` is enabled by default
+info: `not-iterable` is enabled by default
 
 ```
 
@@ -83,7 +83,7 @@ error[not-iterable]: Object of type `Iterable2` may not be iterable
    |
 info: It has no `__iter__` method and its `__getitem__` method (with type `(bound method Iterable2.__getitem__(item: int) -> str) | (bound method Iterable2.__getitem__(item: str) -> int)`) may have an incorrect signature for the old-style iteration protocol
 info: `__getitem__` must be at least as permissive as `def __getitem__(self, key: int): ...` to satisfy the old-style iteration protocol
-info: `lint:not-iterable` is enabled by default
+info: `not-iterable` is enabled by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__iter__`_methods.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__iter__`_methods.snap
@@ -58,7 +58,7 @@ error[not-iterable]: Object of type `Iterable1` may not be iterable
 info: Its `__iter__` method may have an invalid signature
 info: Type of `__iter__` is `(bound method Iterable1.__iter__() -> Iterator) | (bound method Iterable1.__iter__(invalid_extra_arg) -> Iterator)`
 info: Expected signature for `__iter__` is `def __iter__(self): ...`
-info: `lint:not-iterable` is enabled by default
+info: `not-iterable` is enabled by default
 
 ```
 
@@ -87,7 +87,7 @@ error[not-iterable]: Object of type `Iterable2` may not be iterable
 30 |         reveal_type(x)  # revealed: int | Unknown
    |
 info: Its `__iter__` attribute (with type `(bound method Iterable2.__iter__() -> Iterator) | None`) may not be callable
-info: `lint:not-iterable` is enabled by default
+info: `not-iterable` is enabled by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__iter__`_methods.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__iter__`_methods.snap
@@ -47,7 +47,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/for.md
 # Diagnostics
 
 ```
-error: lint:not-iterable: Object of type `Iterable1` may not be iterable
+error: not-iterable: Object of type `Iterable1` may not be iterable
   --> src/mdtest_snippet.py:17:14
    |
 16 |     # error: [not-iterable]
@@ -77,7 +77,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-error: lint:not-iterable: Object of type `Iterable2` may not be iterable
+error: not-iterable: Object of type `Iterable2` may not be iterable
   --> src/mdtest_snippet.py:28:14
    |
 27 |     # error: [not-iterable]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__iter__`_methods.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__iter__`_methods.snap
@@ -47,7 +47,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/for.md
 # Diagnostics
 
 ```
-error: not-iterable: Object of type `Iterable1` may not be iterable
+error[not-iterable]: Object of type `Iterable1` may not be iterable
   --> src/mdtest_snippet.py:17:14
    |
 16 |     # error: [not-iterable]
@@ -63,7 +63,7 @@ info: `lint:not-iterable` is enabled by default
 ```
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
   --> src/mdtest_snippet.py:18:21
    |
 16 |     # error: [not-iterable]
@@ -77,7 +77,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-error: not-iterable: Object of type `Iterable2` may not be iterable
+error[not-iterable]: Object of type `Iterable2` may not be iterable
   --> src/mdtest_snippet.py:28:14
    |
 27 |     # error: [not-iterable]
@@ -92,7 +92,7 @@ info: `lint:not-iterable` is enabled by default
 ```
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
   --> src/mdtest_snippet.py:30:21
    |
 28 |     for x in Iterable2():

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__next__`_method.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__next__`_method.snap
@@ -51,7 +51,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/for.md
 # Diagnostics
 
 ```
-error: lint:not-iterable: Object of type `Iterable1` may not be iterable
+error: not-iterable: Object of type `Iterable1` may not be iterable
   --> src/mdtest_snippet.py:28:14
    |
 27 |     # error: [not-iterable]
@@ -80,7 +80,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-error: lint:not-iterable: Object of type `Iterable2` may not be iterable
+error: not-iterable: Object of type `Iterable2` may not be iterable
   --> src/mdtest_snippet.py:32:14
    |
 31 |     # error: [not-iterable]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__next__`_method.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__next__`_method.snap
@@ -61,7 +61,7 @@ error[not-iterable]: Object of type `Iterable1` may not be iterable
    |
 info: Its `__iter__` method returns an object of type `Iterator1`, which may have an invalid `__next__` method
 info: Expected signature for `__next__` is `def __next__(self): ...`)
-info: `lint:not-iterable` is enabled by default
+info: `not-iterable` is enabled by default
 
 ```
 
@@ -90,7 +90,7 @@ error[not-iterable]: Object of type `Iterable2` may not be iterable
 34 |         reveal_type(y)  # revealed: int | Unknown
    |
 info: Its `__iter__` method returns an object of type `Iterator2`, which has a `__next__` attribute that may not be callable
-info: `lint:not-iterable` is enabled by default
+info: `not-iterable` is enabled by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__next__`_method.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__next__`_method.snap
@@ -51,7 +51,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/for.md
 # Diagnostics
 
 ```
-error: not-iterable: Object of type `Iterable1` may not be iterable
+error[not-iterable]: Object of type `Iterable1` may not be iterable
   --> src/mdtest_snippet.py:28:14
    |
 27 |     # error: [not-iterable]
@@ -66,7 +66,7 @@ info: `lint:not-iterable` is enabled by default
 ```
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
   --> src/mdtest_snippet.py:29:21
    |
 27 |     # error: [not-iterable]
@@ -80,7 +80,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-error: not-iterable: Object of type `Iterable2` may not be iterable
+error[not-iterable]: Object of type `Iterable2` may not be iterable
   --> src/mdtest_snippet.py:32:14
    |
 31 |     # error: [not-iterable]
@@ -95,7 +95,7 @@ info: `lint:not-iterable` is enabled by default
 ```
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
   --> src/mdtest_snippet.py:34:21
    |
 32 |     for y in Iterable2():

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_bad_`__getitem__`_method.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_bad_`__getitem__`_method.snap
@@ -36,7 +36,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/for.md
 # Diagnostics
 
 ```
-error: not-iterable: Object of type `Iterable` may not be iterable
+error[not-iterable]: Object of type `Iterable` may not be iterable
   --> src/mdtest_snippet.py:18:14
    |
 17 |     # error: [not-iterable]
@@ -51,7 +51,7 @@ info: `lint:not-iterable` is enabled by default
 ```
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
   --> src/mdtest_snippet.py:19:21
    |
 17 |     # error: [not-iterable]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_bad_`__getitem__`_method.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_bad_`__getitem__`_method.snap
@@ -46,7 +46,7 @@ error[not-iterable]: Object of type `Iterable` may not be iterable
    |
 info: It may not have an `__iter__` method and its `__getitem__` method has an incorrect signature for the old-style iteration protocol
 info: `__getitem__` must be at least as permissive as `def __getitem__(self, key: int): ...` to satisfy the old-style iteration protocol
-info: `lint:not-iterable` is enabled by default
+info: `not-iterable` is enabled by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_bad_`__getitem__`_method.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_bad_`__getitem__`_method.snap
@@ -36,7 +36,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/for.md
 # Diagnostics
 
 ```
-error: lint:not-iterable: Object of type `Iterable` may not be iterable
+error: not-iterable: Object of type `Iterable` may not be iterable
   --> src/mdtest_snippet.py:18:14
    |
 17 |     # error: [not-iterable]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_possibly_invalid_`__getitem__`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_possibly_invalid_`__getitem__`.snap
@@ -54,7 +54,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/for.md
 # Diagnostics
 
 ```
-error: lint:not-iterable: Object of type `Iterable1` may not be iterable
+error: not-iterable: Object of type `Iterable1` may not be iterable
   --> src/mdtest_snippet.py:31:14
    |
 30 |     # error: [not-iterable]
@@ -83,7 +83,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-error: lint:not-iterable: Object of type `Iterable2` may not be iterable
+error: not-iterable: Object of type `Iterable2` may not be iterable
   --> src/mdtest_snippet.py:36:14
    |
 35 |     # error: [not-iterable]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_possibly_invalid_`__getitem__`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_possibly_invalid_`__getitem__`.snap
@@ -64,7 +64,7 @@ error[not-iterable]: Object of type `Iterable1` may not be iterable
 33 |         reveal_type(x)  # revealed: bytes | str | Unknown
    |
 info: It may not have an `__iter__` method and its `__getitem__` attribute (with type `(bound method Iterable1.__getitem__(item: int) -> str) | None`) may not be callable
-info: `lint:not-iterable` is enabled by default
+info: `not-iterable` is enabled by default
 
 ```
 
@@ -93,7 +93,7 @@ error[not-iterable]: Object of type `Iterable2` may not be iterable
    |
 info: It may not have an `__iter__` method and its `__getitem__` method (with type `(bound method Iterable2.__getitem__(item: int) -> str) | (bound method Iterable2.__getitem__(item: str) -> int)`) may have an incorrect signature for the old-style iteration protocol
 info: `__getitem__` must be at least as permissive as `def __getitem__(self, key: int): ...` to satisfy the old-style iteration protocol
-info: `lint:not-iterable` is enabled by default
+info: `not-iterable` is enabled by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_possibly_invalid_`__getitem__`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_possibly_invalid_`__getitem__`.snap
@@ -54,7 +54,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/for.md
 # Diagnostics
 
 ```
-error: not-iterable: Object of type `Iterable1` may not be iterable
+error[not-iterable]: Object of type `Iterable1` may not be iterable
   --> src/mdtest_snippet.py:31:14
    |
 30 |     # error: [not-iterable]
@@ -69,7 +69,7 @@ info: `lint:not-iterable` is enabled by default
 ```
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
   --> src/mdtest_snippet.py:33:21
    |
 31 |     for x in Iterable1():
@@ -83,7 +83,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-error: not-iterable: Object of type `Iterable2` may not be iterable
+error[not-iterable]: Object of type `Iterable2` may not be iterable
   --> src/mdtest_snippet.py:36:14
    |
 35 |     # error: [not-iterable]
@@ -98,7 +98,7 @@ info: `lint:not-iterable` is enabled by default
 ```
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
   --> src/mdtest_snippet.py:37:21
    |
 35 |     # error: [not-iterable]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_possibly_unbound_`__getitem__`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_possibly_unbound_`__getitem__`.snap
@@ -35,7 +35,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/for.md
 # Diagnostics
 
 ```
-error: lint:not-iterable: Object of type `Iterable` may not be iterable
+error: not-iterable: Object of type `Iterable` may not be iterable
   --> src/mdtest_snippet.py:17:14
    |
 16 |     # error: [not-iterable]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_possibly_unbound_`__getitem__`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_possibly_unbound_`__getitem__`.snap
@@ -35,7 +35,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/for.md
 # Diagnostics
 
 ```
-error: not-iterable: Object of type `Iterable` may not be iterable
+error[not-iterable]: Object of type `Iterable` may not be iterable
   --> src/mdtest_snippet.py:17:14
    |
 16 |     # error: [not-iterable]
@@ -49,7 +49,7 @@ info: `lint:not-iterable` is enabled by default
 ```
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
   --> src/mdtest_snippet.py:18:21
    |
 16 |     # error: [not-iterable]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_possibly_unbound_`__getitem__`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_unbound_`__iter__`_and_possibly_unbound_`__getitem__`.snap
@@ -44,7 +44,7 @@ error[not-iterable]: Object of type `Iterable` may not be iterable
 18 |         reveal_type(x)  # revealed: int | bytes
    |
 info: It may not have an `__iter__` method or a `__getitem__` method
-info: `lint:not-iterable` is enabled by default
+info: `not-iterable` is enabled by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Union_type_as_iterable_where_one_union_element_has_invalid_`__iter__`_method.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Union_type_as_iterable_where_one_union_element_has_invalid_`__iter__`_method.snap
@@ -46,7 +46,7 @@ error[not-iterable]: Object of type `Test | Test2` may not be iterable
 19 |         reveal_type(x)  # revealed: int
    |
 info: Its `__iter__` method returns an object of type `TestIter | int`, which may not have a `__next__` method
-info: `lint:not-iterable` is enabled by default
+info: `not-iterable` is enabled by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Union_type_as_iterable_where_one_union_element_has_invalid_`__iter__`_method.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Union_type_as_iterable_where_one_union_element_has_invalid_`__iter__`_method.snap
@@ -36,7 +36,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/for.md
 # Diagnostics
 
 ```
-error: not-iterable: Object of type `Test | Test2` may not be iterable
+error[not-iterable]: Object of type `Test | Test2` may not be iterable
   --> src/mdtest_snippet.py:18:14
    |
 16 |     # TODO: Improve error message to state which union variant isn't iterable (https://github.com/astral-sh/ruff/issues/13989)
@@ -51,7 +51,7 @@ info: `lint:not-iterable` is enabled by default
 ```
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
   --> src/mdtest_snippet.py:19:21
    |
 17 |     # error: [not-iterable]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Union_type_as_iterable_where_one_union_element_has_invalid_`__iter__`_method.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Union_type_as_iterable_where_one_union_element_has_invalid_`__iter__`_method.snap
@@ -36,7 +36,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/for.md
 # Diagnostics
 
 ```
-error: lint:not-iterable: Object of type `Test | Test2` may not be iterable
+error: not-iterable: Object of type `Test | Test2` may not be iterable
   --> src/mdtest_snippet.py:18:14
    |
 16 |     # TODO: Improve error message to state which union variant isn't iterable (https://github.com/astral-sh/ruff/issues/13989)

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Union_type_as_iterable_where_one_union_element_has_no_`__iter__`_method.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Union_type_as_iterable_where_one_union_element_has_no_`__iter__`_method.snap
@@ -31,7 +31,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/for.md
 # Diagnostics
 
 ```
-error: not-iterable: Object of type `Test | Literal[42]` may not be iterable
+error[not-iterable]: Object of type `Test | Literal[42]` may not be iterable
   --> src/mdtest_snippet.py:13:14
    |
 11 | def _(flag: bool):
@@ -46,7 +46,7 @@ info: `lint:not-iterable` is enabled by default
 ```
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
   --> src/mdtest_snippet.py:14:21
    |
 12 |     # error: [not-iterable]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Union_type_as_iterable_where_one_union_element_has_no_`__iter__`_method.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Union_type_as_iterable_where_one_union_element_has_no_`__iter__`_method.snap
@@ -41,7 +41,7 @@ error[not-iterable]: Object of type `Test | Literal[42]` may not be iterable
 14 |         reveal_type(x)  # revealed: int
    |
 info: It may not have an `__iter__` method and it doesn't have a `__getitem__` method
-info: `lint:not-iterable` is enabled by default
+info: `not-iterable` is enabled by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Union_type_as_iterable_where_one_union_element_has_no_`__iter__`_method.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Union_type_as_iterable_where_one_union_element_has_no_`__iter__`_method.snap
@@ -31,7 +31,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/for.md
 # Diagnostics
 
 ```
-error: lint:not-iterable: Object of type `Test | Literal[42]` may not be iterable
+error: not-iterable: Object of type `Test | Literal[42]` may not be iterable
   --> src/mdtest_snippet.py:13:14
    |
 11 | def _(flag: bool):

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_With_non-callable_iterator.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_With_non-callable_iterator.snap
@@ -42,7 +42,7 @@ error[not-iterable]: Object of type `NotIterable` is not iterable
 12 |         pass
    |
 info: Its `__iter__` attribute has type `int | None`, which is not callable
-info: `lint:not-iterable` is enabled by default
+info: `not-iterable` is enabled by default
 
 ```
 
@@ -55,7 +55,7 @@ info[possibly-unresolved-reference]: Name `x` used when possibly not defined
 16 |     reveal_type(x)
    |                 ^
    |
-info: `lint:possibly-unresolved-reference` is enabled by default
+info: `possibly-unresolved-reference` is enabled by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_With_non-callable_iterator.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_With_non-callable_iterator.snap
@@ -33,7 +33,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/for.md
 # Diagnostics
 
 ```
-error: not-iterable: Object of type `NotIterable` is not iterable
+error[not-iterable]: Object of type `NotIterable` is not iterable
   --> src/mdtest_snippet.py:11:14
    |
 10 |     # error: [not-iterable]
@@ -47,7 +47,7 @@ info: `lint:not-iterable` is enabled by default
 ```
 
 ```
-info: possibly-unresolved-reference: Name `x` used when possibly not defined
+info[possibly-unresolved-reference]: Name `x` used when possibly not defined
   --> src/mdtest_snippet.py:16:17
    |
 14 |     # revealed: Unknown
@@ -60,7 +60,7 @@ info: `lint:possibly-unresolved-reference` is enabled by default
 ```
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
   --> src/mdtest_snippet.py:16:17
    |
 14 |     # revealed: Unknown

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_With_non-callable_iterator.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_With_non-callable_iterator.snap
@@ -33,7 +33,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/for.md
 # Diagnostics
 
 ```
-error: lint:not-iterable: Object of type `NotIterable` is not iterable
+error: not-iterable: Object of type `NotIterable` is not iterable
   --> src/mdtest_snippet.py:11:14
    |
 10 |     # error: [not-iterable]
@@ -47,7 +47,7 @@ info: `lint:not-iterable` is enabled by default
 ```
 
 ```
-info: lint:possibly-unresolved-reference: Name `x` used when possibly not defined
+info: possibly-unresolved-reference: Name `x` used when possibly not defined
   --> src/mdtest_snippet.py:16:17
    |
 14 |     # revealed: Unknown

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_does_not_return_an_iterator.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_does_not_return_an_iterator.snap
@@ -26,7 +26,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/for.md
 # Diagnostics
 
 ```
-error: not-iterable: Object of type `Bad` is not iterable
+error[not-iterable]: Object of type `Bad` is not iterable
  --> src/mdtest_snippet.py:8:10
   |
 7 | # error: [not-iterable]
@@ -40,7 +40,7 @@ info: `lint:not-iterable` is enabled by default
 ```
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
  --> src/mdtest_snippet.py:9:17
   |
 7 | # error: [not-iterable]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_does_not_return_an_iterator.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_does_not_return_an_iterator.snap
@@ -35,7 +35,7 @@ error[not-iterable]: Object of type `Bad` is not iterable
 9 |     reveal_type(x)  # revealed: Unknown
   |
 info: Its `__iter__` method returns an object of type `int`, which has no `__next__` method
-info: `lint:not-iterable` is enabled by default
+info: `not-iterable` is enabled by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_does_not_return_an_iterator.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_does_not_return_an_iterator.snap
@@ -26,7 +26,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/for.md
 # Diagnostics
 
 ```
-error: lint:not-iterable: Object of type `Bad` is not iterable
+error: not-iterable: Object of type `Bad` is not iterable
  --> src/mdtest_snippet.py:8:10
   |
 7 | # error: [not-iterable]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_method_with_a_bad_signature.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_method_with_a_bad_signature.snap
@@ -30,7 +30,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/for.md
 # Diagnostics
 
 ```
-error: lint:not-iterable: Object of type `Iterable` is not iterable
+error: not-iterable: Object of type `Iterable` is not iterable
   --> src/mdtest_snippet.py:12:10
    |
 11 | # error: [not-iterable]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_method_with_a_bad_signature.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_method_with_a_bad_signature.snap
@@ -30,7 +30,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/for.md
 # Diagnostics
 
 ```
-error: not-iterable: Object of type `Iterable` is not iterable
+error[not-iterable]: Object of type `Iterable` is not iterable
   --> src/mdtest_snippet.py:12:10
    |
 11 | # error: [not-iterable]
@@ -45,7 +45,7 @@ info: `lint:not-iterable` is enabled by default
 ```
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
   --> src/mdtest_snippet.py:13:17
    |
 11 | # error: [not-iterable]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_method_with_a_bad_signature.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_method_with_a_bad_signature.snap
@@ -40,7 +40,7 @@ error[not-iterable]: Object of type `Iterable` is not iterable
    |
 info: Its `__iter__` method has an invalid signature
 info: Expected signature `def __iter__(self): ...`
-info: `lint:not-iterable` is enabled by default
+info: `not-iterable` is enabled by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_returns_an_iterator_with_an_invalid_`__next__`_method.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_returns_an_iterator_with_an_invalid_`__next__`_method.snap
@@ -41,7 +41,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/for.md
 # Diagnostics
 
 ```
-error: not-iterable: Object of type `Iterable1` is not iterable
+error[not-iterable]: Object of type `Iterable1` is not iterable
   --> src/mdtest_snippet.py:19:10
    |
 18 | # error: [not-iterable]
@@ -56,7 +56,7 @@ info: `lint:not-iterable` is enabled by default
 ```
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
   --> src/mdtest_snippet.py:20:17
    |
 18 | # error: [not-iterable]
@@ -70,7 +70,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-error: not-iterable: Object of type `Iterable2` is not iterable
+error[not-iterable]: Object of type `Iterable2` is not iterable
   --> src/mdtest_snippet.py:23:10
    |
 22 | # error: [not-iterable]
@@ -84,7 +84,7 @@ info: `lint:not-iterable` is enabled by default
 ```
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
   --> src/mdtest_snippet.py:24:17
    |
 22 | # error: [not-iterable]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_returns_an_iterator_with_an_invalid_`__next__`_method.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_returns_an_iterator_with_an_invalid_`__next__`_method.snap
@@ -41,7 +41,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/for.md
 # Diagnostics
 
 ```
-error: lint:not-iterable: Object of type `Iterable1` is not iterable
+error: not-iterable: Object of type `Iterable1` is not iterable
   --> src/mdtest_snippet.py:19:10
    |
 18 | # error: [not-iterable]
@@ -70,7 +70,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-error: lint:not-iterable: Object of type `Iterable2` is not iterable
+error: not-iterable: Object of type `Iterable2` is not iterable
   --> src/mdtest_snippet.py:23:10
    |
 22 | # error: [not-iterable]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_returns_an_iterator_with_an_invalid_`__next__`_method.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_returns_an_iterator_with_an_invalid_`__next__`_method.snap
@@ -51,7 +51,7 @@ error[not-iterable]: Object of type `Iterable1` is not iterable
    |
 info: Its `__iter__` method returns an object of type `Iterator1`, which has an invalid `__next__` method
 info: Expected signature for `__next__` is `def __next__(self): ...`
-info: `lint:not-iterable` is enabled by default
+info: `not-iterable` is enabled by default
 
 ```
 
@@ -79,7 +79,7 @@ error[not-iterable]: Object of type `Iterable2` is not iterable
 24 |     reveal_type(y)  # revealed: Unknown
    |
 info: Its `__iter__` method returns an object of type `Iterator2`, which has a `__next__` attribute that is not callable
-info: `lint:not-iterable` is enabled by default
+info: `not-iterable` is enabled by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___Legacy_syntax_-_Inferring_a_bound_typevar.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___Legacy_syntax_-_Inferring_a_bound_typevar.snap
@@ -29,7 +29,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/legacy/function
 # Diagnostics
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
   --> src/mdtest_snippet.py:9:13
    |
  7 |     return x
@@ -43,7 +43,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
   --> src/mdtest_snippet.py:10:13
    |
  9 | reveal_type(f(1))  # revealed: Literal[1]
@@ -56,7 +56,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
   --> src/mdtest_snippet.py:12:13
    |
 10 | reveal_type(f(True))  # revealed: Literal[True]
@@ -68,7 +68,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-error: invalid-argument-type: Argument to this function is incorrect
+error[invalid-argument-type]: Argument to this function is incorrect
   --> src/mdtest_snippet.py:12:15
    |
 10 | reveal_type(f(True))  # revealed: Literal[True]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___Legacy_syntax_-_Inferring_a_bound_typevar.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___Legacy_syntax_-_Inferring_a_bound_typevar.snap
@@ -68,7 +68,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-error: lint:invalid-argument-type: Argument to this function is incorrect
+error: invalid-argument-type: Argument to this function is incorrect
   --> src/mdtest_snippet.py:12:15
    |
 10 | reveal_type(f(True))  # revealed: Literal[True]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___Legacy_syntax_-_Inferring_a_bound_typevar.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___Legacy_syntax_-_Inferring_a_bound_typevar.snap
@@ -86,6 +86,6 @@ info: Type variable defined here
 5 |
 6 | def f(x: T) -> T:
   |
-info: `lint:invalid-argument-type` is enabled by default
+info: `invalid-argument-type` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___Legacy_syntax_-_Inferring_a_constrained_typevar.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___Legacy_syntax_-_Inferring_a_constrained_typevar.snap
@@ -83,7 +83,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-error: lint:invalid-argument-type: Argument to this function is incorrect
+error: invalid-argument-type: Argument to this function is incorrect
   --> src/mdtest_snippet.py:13:15
    |
 11 | reveal_type(f(None))  # revealed: None

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___Legacy_syntax_-_Inferring_a_constrained_typevar.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___Legacy_syntax_-_Inferring_a_constrained_typevar.snap
@@ -30,7 +30,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/legacy/function
 # Diagnostics
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
   --> src/mdtest_snippet.py:9:13
    |
  7 |     return x
@@ -44,7 +44,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
   --> src/mdtest_snippet.py:10:13
    |
  9 | reveal_type(f(1))  # revealed: int
@@ -57,7 +57,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
   --> src/mdtest_snippet.py:11:13
    |
  9 | reveal_type(f(1))  # revealed: int
@@ -71,7 +71,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
   --> src/mdtest_snippet.py:13:13
    |
 11 | reveal_type(f(None))  # revealed: None
@@ -83,7 +83,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-error: invalid-argument-type: Argument to this function is incorrect
+error[invalid-argument-type]: Argument to this function is incorrect
   --> src/mdtest_snippet.py:13:15
    |
 11 | reveal_type(f(None))  # revealed: None

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___Legacy_syntax_-_Inferring_a_constrained_typevar.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___Legacy_syntax_-_Inferring_a_constrained_typevar.snap
@@ -101,6 +101,6 @@ info: Type variable defined here
 5 |
 6 | def f(x: T) -> T:
   |
-info: `lint:invalid-argument-type` is enabled by default
+info: `invalid-argument-type` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___PEP_695_syntax_-_Inferring_a_bound_typevar.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___PEP_695_syntax_-_Inferring_a_bound_typevar.snap
@@ -26,7 +26,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/pep695/function
 # Diagnostics
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
  --> src/mdtest_snippet.py:6:13
   |
 4 |     return x
@@ -40,7 +40,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
  --> src/mdtest_snippet.py:7:13
   |
 6 | reveal_type(f(1))  # revealed: Literal[1]
@@ -53,7 +53,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
  --> src/mdtest_snippet.py:9:13
   |
 7 | reveal_type(f(True))  # revealed: Literal[True]
@@ -65,7 +65,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-error: invalid-argument-type: Argument to this function is incorrect
+error[invalid-argument-type]: Argument to this function is incorrect
  --> src/mdtest_snippet.py:9:15
   |
 7 | reveal_type(f(True))  # revealed: Literal[True]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___PEP_695_syntax_-_Inferring_a_bound_typevar.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___PEP_695_syntax_-_Inferring_a_bound_typevar.snap
@@ -65,7 +65,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-error: lint:invalid-argument-type: Argument to this function is incorrect
+error: invalid-argument-type: Argument to this function is incorrect
  --> src/mdtest_snippet.py:9:15
   |
 7 | reveal_type(f(True))  # revealed: Literal[True]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___PEP_695_syntax_-_Inferring_a_bound_typevar.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___PEP_695_syntax_-_Inferring_a_bound_typevar.snap
@@ -82,6 +82,6 @@ info: Type variable defined here
   |       ^^^^^^
 4 |     return x
   |
-info: `lint:invalid-argument-type` is enabled by default
+info: `invalid-argument-type` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___PEP_695_syntax_-_Inferring_a_constrained_typevar.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___PEP_695_syntax_-_Inferring_a_constrained_typevar.snap
@@ -80,7 +80,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-error: lint:invalid-argument-type: Argument to this function is incorrect
+error: invalid-argument-type: Argument to this function is incorrect
   --> src/mdtest_snippet.py:10:15
    |
  8 | reveal_type(f(None))  # revealed: None

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___PEP_695_syntax_-_Inferring_a_constrained_typevar.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___PEP_695_syntax_-_Inferring_a_constrained_typevar.snap
@@ -27,7 +27,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/pep695/function
 # Diagnostics
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
  --> src/mdtest_snippet.py:6:13
   |
 4 |     return x
@@ -41,7 +41,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
  --> src/mdtest_snippet.py:7:13
   |
 6 | reveal_type(f(1))  # revealed: int
@@ -54,7 +54,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
   --> src/mdtest_snippet.py:8:13
    |
  6 | reveal_type(f(1))  # revealed: int
@@ -68,7 +68,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
   --> src/mdtest_snippet.py:10:13
    |
  8 | reveal_type(f(None))  # revealed: None
@@ -80,7 +80,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-error: invalid-argument-type: Argument to this function is incorrect
+error[invalid-argument-type]: Argument to this function is incorrect
   --> src/mdtest_snippet.py:10:15
    |
  8 | reveal_type(f(None))  # revealed: None

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___PEP_695_syntax_-_Inferring_a_constrained_typevar.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___PEP_695_syntax_-_Inferring_a_constrained_typevar.snap
@@ -97,6 +97,6 @@ info: Type variable defined here
   |       ^^^^^^^^^^^^^^
 4 |     return x
   |
-info: `lint:invalid-argument-type` is enabled by default
+info: `invalid-argument-type` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/instances.md_-_Binary_operations_on_instances_-_Operations_involving_types_with_invalid_`__bool__`_methods.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/instances.md_-_Binary_operations_on_instances_-_Operations_involving_types_with_invalid_`__bool__`_methods.snap
@@ -24,7 +24,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/binary/instances.md
 # Diagnostics
 
 ```
-error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable`
+error: unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable`
  --> src/mdtest_snippet.py:7:8
   |
 6 | # error: [unsupported-bool-conversion]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/instances.md_-_Binary_operations_on_instances_-_Operations_involving_types_with_invalid_`__bool__`_methods.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/instances.md_-_Binary_operations_on_instances_-_Operations_involving_types_with_invalid_`__bool__`_methods.snap
@@ -24,7 +24,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/binary/instances.md
 # Diagnostics
 
 ```
-error: unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable`
+error[unsupported-bool-conversion]: Boolean conversion is unsupported for type `NotBoolable`
  --> src/mdtest_snippet.py:7:8
   |
 6 | # error: [unsupported-bool-conversion]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/instances.md_-_Binary_operations_on_instances_-_Operations_involving_types_with_invalid_`__bool__`_methods.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/instances.md_-_Binary_operations_on_instances_-_Operations_involving_types_with_invalid_`__bool__`_methods.snap
@@ -32,6 +32,6 @@ error[unsupported-bool-conversion]: Boolean conversion is unsupported for type `
   |        ^
   |
 info: `__bool__` on `NotBoolable` must be callable
-info: `lint:unsupported-bool-conversion` is enabled by default
+info: `unsupported-bool-conversion` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Basic.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Basic.snap
@@ -36,6 +36,6 @@ info: Function defined here
   |     ^^^ ------ Parameter declared here
 2 |     return x * x
   |
-info: `lint:invalid-argument-type` is enabled by default
+info: `invalid-argument-type` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Basic.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Basic.snap
@@ -21,7 +21,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 # Diagnostics
 
 ```
-error: lint:invalid-argument-type: Argument to this function is incorrect
+error: invalid-argument-type: Argument to this function is incorrect
  --> src/mdtest_snippet.py:4:5
   |
 2 |     return x * x

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Basic.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Basic.snap
@@ -21,7 +21,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 # Diagnostics
 
 ```
-error: invalid-argument-type: Argument to this function is incorrect
+error[invalid-argument-type]: Argument to this function is incorrect
  --> src/mdtest_snippet.py:4:5
   |
 2 |     return x * x

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Calls_to_methods.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Calls_to_methods.snap
@@ -38,6 +38,6 @@ info: Function defined here
   |         ^^^^^^       ------ Parameter declared here
 3 |         return x * x
   |
-info: `lint:invalid-argument-type` is enabled by default
+info: `invalid-argument-type` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Calls_to_methods.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Calls_to_methods.snap
@@ -23,7 +23,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 # Diagnostics
 
 ```
-error: lint:invalid-argument-type: Argument to this function is incorrect
+error: invalid-argument-type: Argument to this function is incorrect
  --> src/mdtest_snippet.py:6:10
   |
 5 | c = C()

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Calls_to_methods.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Calls_to_methods.snap
@@ -23,7 +23,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 # Diagnostics
 
 ```
-error: invalid-argument-type: Argument to this function is incorrect
+error[invalid-argument-type]: Argument to this function is incorrect
  --> src/mdtest_snippet.py:6:10
   |
 5 | c = C()

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Different_files.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Different_files.snap
@@ -27,7 +27,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 # Diagnostics
 
 ```
-error: lint:invalid-argument-type: Argument to this function is incorrect
+error: invalid-argument-type: Argument to this function is incorrect
  --> src/mdtest_snippet.py:3:13
   |
 1 | import package

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Different_files.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Different_files.snap
@@ -42,6 +42,6 @@ info: Function defined here
   |     ^^^ ------ Parameter declared here
 2 |     return x * x
   |
-info: `lint:invalid-argument-type` is enabled by default
+info: `invalid-argument-type` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Different_files.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Different_files.snap
@@ -27,7 +27,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 # Diagnostics
 
 ```
-error: invalid-argument-type: Argument to this function is incorrect
+error[invalid-argument-type]: Argument to this function is incorrect
  --> src/mdtest_snippet.py:3:13
   |
 1 | import package

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Different_source_order.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Different_source_order.snap
@@ -22,7 +22,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 # Diagnostics
 
 ```
-error: invalid-argument-type: Argument to this function is incorrect
+error[invalid-argument-type]: Argument to this function is incorrect
  --> src/mdtest_snippet.py:2:9
   |
 1 | def bar():

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Different_source_order.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Different_source_order.snap
@@ -22,7 +22,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 # Diagnostics
 
 ```
-error: lint:invalid-argument-type: Argument to this function is incorrect
+error: invalid-argument-type: Argument to this function is incorrect
  --> src/mdtest_snippet.py:2:9
   |
 1 | def bar():

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Different_source_order.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Different_source_order.snap
@@ -40,6 +40,6 @@ info: Function defined here
   |     ^^^ ------ Parameter declared here
 5 |     return x * x
   |
-info: `lint:invalid-argument-type` is enabled by default
+info: `invalid-argument-type` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters.snap
@@ -36,6 +36,6 @@ info: Function defined here
   |     ^^^         ------ Parameter declared here
 2 |     return x * y * z
   |
-info: `lint:invalid-argument-type` is enabled by default
+info: `invalid-argument-type` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters.snap
@@ -21,7 +21,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 # Diagnostics
 
 ```
-error: lint:invalid-argument-type: Argument to this function is incorrect
+error: invalid-argument-type: Argument to this function is incorrect
  --> src/mdtest_snippet.py:4:8
   |
 2 |     return x * y * z

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters.snap
@@ -21,7 +21,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 # Diagnostics
 
 ```
-error: invalid-argument-type: Argument to this function is incorrect
+error[invalid-argument-type]: Argument to this function is incorrect
  --> src/mdtest_snippet.py:4:8
   |
 2 |     return x * y * z

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters_across_multiple_lines.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters_across_multiple_lines.snap
@@ -25,7 +25,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 # Diagnostics
 
 ```
-error: lint:invalid-argument-type: Argument to this function is incorrect
+error: invalid-argument-type: Argument to this function is incorrect
  --> src/mdtest_snippet.py:8:8
   |
 6 |     return x * y * z

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters_across_multiple_lines.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters_across_multiple_lines.snap
@@ -44,6 +44,6 @@ info: Function defined here
 4 |     z: int,
 5 | ) -> int:
   |
-info: `lint:invalid-argument-type` is enabled by default
+info: `invalid-argument-type` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters_across_multiple_lines.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters_across_multiple_lines.snap
@@ -25,7 +25,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 # Diagnostics
 
 ```
-error: invalid-argument-type: Argument to this function is incorrect
+error[invalid-argument-type]: Argument to this function is incorrect
  --> src/mdtest_snippet.py:8:8
   |
 6 |     return x * y * z

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters_with_multiple_invalid_arguments.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters_with_multiple_invalid_arguments.snap
@@ -24,7 +24,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 # Diagnostics
 
 ```
-error: lint:invalid-argument-type: Argument to this function is incorrect
+error: invalid-argument-type: Argument to this function is incorrect
  --> src/mdtest_snippet.py:7:5
   |
 5 | # error: [invalid-argument-type]
@@ -44,7 +44,7 @@ info: `lint:invalid-argument-type` is enabled by default
 ```
 
 ```
-error: lint:invalid-argument-type: Argument to this function is incorrect
+error: invalid-argument-type: Argument to this function is incorrect
  --> src/mdtest_snippet.py:7:10
   |
 5 | # error: [invalid-argument-type]
@@ -64,7 +64,7 @@ info: `lint:invalid-argument-type` is enabled by default
 ```
 
 ```
-error: lint:invalid-argument-type: Argument to this function is incorrect
+error: invalid-argument-type: Argument to this function is incorrect
  --> src/mdtest_snippet.py:7:15
   |
 5 | # error: [invalid-argument-type]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters_with_multiple_invalid_arguments.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters_with_multiple_invalid_arguments.snap
@@ -39,7 +39,7 @@ info: Function defined here
   |     ^^^ ------ Parameter declared here
 2 |     return x * y * z
   |
-info: `lint:invalid-argument-type` is enabled by default
+info: `invalid-argument-type` is enabled by default
 
 ```
 
@@ -59,7 +59,7 @@ info: Function defined here
   |     ^^^         ------ Parameter declared here
 2 |     return x * y * z
   |
-info: `lint:invalid-argument-type` is enabled by default
+info: `invalid-argument-type` is enabled by default
 
 ```
 
@@ -79,6 +79,6 @@ info: Function defined here
   |     ^^^                 ------ Parameter declared here
 2 |     return x * y * z
   |
-info: `lint:invalid-argument-type` is enabled by default
+info: `invalid-argument-type` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters_with_multiple_invalid_arguments.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Many_parameters_with_multiple_invalid_arguments.snap
@@ -24,7 +24,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 # Diagnostics
 
 ```
-error: invalid-argument-type: Argument to this function is incorrect
+error[invalid-argument-type]: Argument to this function is incorrect
  --> src/mdtest_snippet.py:7:5
   |
 5 | # error: [invalid-argument-type]
@@ -44,7 +44,7 @@ info: `lint:invalid-argument-type` is enabled by default
 ```
 
 ```
-error: invalid-argument-type: Argument to this function is incorrect
+error[invalid-argument-type]: Argument to this function is incorrect
  --> src/mdtest_snippet.py:7:10
   |
 5 | # error: [invalid-argument-type]
@@ -64,7 +64,7 @@ info: `lint:invalid-argument-type` is enabled by default
 ```
 
 ```
-error: invalid-argument-type: Argument to this function is incorrect
+error[invalid-argument-type]: Argument to this function is incorrect
  --> src/mdtest_snippet.py:7:15
   |
 5 | # error: [invalid-argument-type]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Test_calling_a_function_whose_type_is_vendored_from_`typeshed`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Test_calling_a_function_whose_type_is_vendored_from_`typeshed`.snap
@@ -20,7 +20,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 # Diagnostics
 
 ```
-error: invalid-argument-type: Argument to this function is incorrect
+error[invalid-argument-type]: Argument to this function is incorrect
  --> src/mdtest_snippet.py:3:12
   |
 1 | import json

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Test_calling_a_function_whose_type_is_vendored_from_`typeshed`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Test_calling_a_function_whose_type_is_vendored_from_`typeshed`.snap
@@ -40,6 +40,6 @@ info: Function defined here
 41 |     *,
 42 |     cls: type[JSONDecoder] | None = None,
    |
-info: `lint:invalid-argument-type` is enabled by default
+info: `invalid-argument-type` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Test_calling_a_function_whose_type_is_vendored_from_`typeshed`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Test_calling_a_function_whose_type_is_vendored_from_`typeshed`.snap
@@ -20,7 +20,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 # Diagnostics
 
 ```
-error: lint:invalid-argument-type: Argument to this function is incorrect
+error: invalid-argument-type: Argument to this function is incorrect
  --> src/mdtest_snippet.py:3:12
   |
 1 | import json

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Keyword_only_arguments.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Keyword_only_arguments.snap
@@ -36,6 +36,6 @@ info: Function defined here
   |     ^^^                    ---------- Parameter declared here
 2 |     return x * y * z
   |
-info: `lint:invalid-argument-type` is enabled by default
+info: `invalid-argument-type` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Keyword_only_arguments.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Keyword_only_arguments.snap
@@ -21,7 +21,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 # Diagnostics
 
 ```
-error: lint:invalid-argument-type: Argument to this function is incorrect
+error: invalid-argument-type: Argument to this function is incorrect
  --> src/mdtest_snippet.py:4:11
   |
 2 |     return x * y * z

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Keyword_only_arguments.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Keyword_only_arguments.snap
@@ -21,7 +21,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 # Diagnostics
 
 ```
-error: invalid-argument-type: Argument to this function is incorrect
+error[invalid-argument-type]: Argument to this function is incorrect
  --> src/mdtest_snippet.py:4:11
   |
 2 |     return x * y * z

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Mix_of_arguments.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Mix_of_arguments.snap
@@ -36,6 +36,6 @@ info: Function defined here
   |     ^^^                       ---------- Parameter declared here
 2 |     return x * y * z
   |
-info: `lint:invalid-argument-type` is enabled by default
+info: `invalid-argument-type` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Mix_of_arguments.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Mix_of_arguments.snap
@@ -21,7 +21,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 # Diagnostics
 
 ```
-error: lint:invalid-argument-type: Argument to this function is incorrect
+error: invalid-argument-type: Argument to this function is incorrect
  --> src/mdtest_snippet.py:4:11
   |
 2 |     return x * y * z

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Mix_of_arguments.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Mix_of_arguments.snap
@@ -21,7 +21,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 # Diagnostics
 
 ```
-error: invalid-argument-type: Argument to this function is incorrect
+error[invalid-argument-type]: Argument to this function is incorrect
  --> src/mdtest_snippet.py:4:11
   |
 2 |     return x * y * z

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_One_keyword_argument.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_One_keyword_argument.snap
@@ -36,6 +36,6 @@ info: Function defined here
   |     ^^^                 ---------- Parameter declared here
 2 |     return x * y * z
   |
-info: `lint:invalid-argument-type` is enabled by default
+info: `invalid-argument-type` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_One_keyword_argument.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_One_keyword_argument.snap
@@ -21,7 +21,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 # Diagnostics
 
 ```
-error: lint:invalid-argument-type: Argument to this function is incorrect
+error: invalid-argument-type: Argument to this function is incorrect
  --> src/mdtest_snippet.py:4:11
   |
 2 |     return x * y * z

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_One_keyword_argument.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_One_keyword_argument.snap
@@ -21,7 +21,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 # Diagnostics
 
 ```
-error: invalid-argument-type: Argument to this function is incorrect
+error[invalid-argument-type]: Argument to this function is incorrect
  --> src/mdtest_snippet.py:4:11
   |
 2 |     return x * y * z

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Only_positional.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Only_positional.snap
@@ -36,6 +36,6 @@ info: Function defined here
   |     ^^^         ------ Parameter declared here
 2 |     return x * y * z
   |
-info: `lint:invalid-argument-type` is enabled by default
+info: `invalid-argument-type` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Only_positional.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Only_positional.snap
@@ -21,7 +21,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 # Diagnostics
 
 ```
-error: lint:invalid-argument-type: Argument to this function is incorrect
+error: invalid-argument-type: Argument to this function is incorrect
  --> src/mdtest_snippet.py:4:8
   |
 2 |     return x * y * z

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Only_positional.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Only_positional.snap
@@ -21,7 +21,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 # Diagnostics
 
 ```
-error: invalid-argument-type: Argument to this function is incorrect
+error[invalid-argument-type]: Argument to this function is incorrect
  --> src/mdtest_snippet.py:4:8
   |
 2 |     return x * y * z

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Synthetic_arguments.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Synthetic_arguments.snap
@@ -23,7 +23,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 # Diagnostics
 
 ```
-error: lint:invalid-argument-type: Argument to this function is incorrect
+error: invalid-argument-type: Argument to this function is incorrect
  --> src/mdtest_snippet.py:6:3
   |
 5 | c = C()

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Synthetic_arguments.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Synthetic_arguments.snap
@@ -38,6 +38,6 @@ info: Function defined here
   |         ^^^^^^^^       ------ Parameter declared here
 3 |         return 1
   |
-info: `lint:invalid-argument-type` is enabled by default
+info: `invalid-argument-type` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Synthetic_arguments.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Synthetic_arguments.snap
@@ -23,7 +23,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 # Diagnostics
 
 ```
-error: invalid-argument-type: Argument to this function is incorrect
+error[invalid-argument-type]: Argument to this function is incorrect
  --> src/mdtest_snippet.py:6:3
   |
 5 | c = C()

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Variadic_arguments.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Variadic_arguments.snap
@@ -21,7 +21,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 # Diagnostics
 
 ```
-error: lint:invalid-argument-type: Argument to this function is incorrect
+error: invalid-argument-type: Argument to this function is incorrect
  --> src/mdtest_snippet.py:4:14
   |
 2 |     return len(numbers)

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Variadic_arguments.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Variadic_arguments.snap
@@ -36,6 +36,6 @@ info: Function defined here
   |     ^^^ ------------- Parameter declared here
 2 |     return len(numbers)
   |
-info: `lint:invalid-argument-type` is enabled by default
+info: `invalid-argument-type` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Variadic_arguments.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Variadic_arguments.snap
@@ -21,7 +21,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 # Diagnostics
 
 ```
-error: invalid-argument-type: Argument to this function is incorrect
+error[invalid-argument-type]: Argument to this function is incorrect
  --> src/mdtest_snippet.py:4:14
   |
 2 |     return len(numbers)

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Variadic_keyword_arguments.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Variadic_keyword_arguments.snap
@@ -36,6 +36,6 @@ info: Function defined here
   |     ^^^ -------------- Parameter declared here
 2 |     return len(numbers)
   |
-info: `lint:invalid-argument-type` is enabled by default
+info: `invalid-argument-type` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Variadic_keyword_arguments.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Variadic_keyword_arguments.snap
@@ -21,7 +21,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 # Diagnostics
 
 ```
-error: invalid-argument-type: Argument to this function is incorrect
+error[invalid-argument-type]: Argument to this function is incorrect
  --> src/mdtest_snippet.py:4:20
   |
 2 |     return len(numbers)

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Variadic_keyword_arguments.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_type.md_-_Invalid_argument_type_diagnostics_-_Tests_for_a_variety_of_argument_types_-_Variadic_keyword_arguments.snap
@@ -21,7 +21,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 # Diagnostics
 
 ```
-error: lint:invalid-argument-type: Argument to this function is incorrect
+error: invalid-argument-type: Argument to this function is incorrect
  --> src/mdtest_snippet.py:4:20
   |
 2 |     return len(numbers)

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/membership_test.md_-_Comparison___Membership_Test_-_Return_type_that_doesn't_implement_`__bool__`_correctly.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/membership_test.md_-_Comparison___Membership_Test_-_Return_type_that_doesn't_implement_`__bool__`_correctly.snap
@@ -28,7 +28,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/comparison/instances/mem
 # Diagnostics
 
 ```
-error: unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable`
+error[unsupported-bool-conversion]: Boolean conversion is unsupported for type `NotBoolable`
   --> src/mdtest_snippet.py:9:1
    |
  8 | # error: [unsupported-bool-conversion]
@@ -43,7 +43,7 @@ info: `lint:unsupported-bool-conversion` is enabled by default
 ```
 
 ```
-error: unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable`
+error[unsupported-bool-conversion]: Boolean conversion is unsupported for type `NotBoolable`
   --> src/mdtest_snippet.py:11:1
    |
  9 | 10 in WithContains()

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/membership_test.md_-_Comparison___Membership_Test_-_Return_type_that_doesn't_implement_`__bool__`_correctly.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/membership_test.md_-_Comparison___Membership_Test_-_Return_type_that_doesn't_implement_`__bool__`_correctly.snap
@@ -38,7 +38,7 @@ error[unsupported-bool-conversion]: Boolean conversion is unsupported for type `
 11 | 10 not in WithContains()
    |
 info: `__bool__` on `NotBoolable` must be callable
-info: `lint:unsupported-bool-conversion` is enabled by default
+info: `unsupported-bool-conversion` is enabled by default
 
 ```
 
@@ -52,6 +52,6 @@ error[unsupported-bool-conversion]: Boolean conversion is unsupported for type `
    | ^^^^^^^^^^^^^^^^^^^^^^^^
    |
 info: `__bool__` on `NotBoolable` must be callable
-info: `lint:unsupported-bool-conversion` is enabled by default
+info: `unsupported-bool-conversion` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/membership_test.md_-_Comparison___Membership_Test_-_Return_type_that_doesn't_implement_`__bool__`_correctly.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/membership_test.md_-_Comparison___Membership_Test_-_Return_type_that_doesn't_implement_`__bool__`_correctly.snap
@@ -28,7 +28,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/comparison/instances/mem
 # Diagnostics
 
 ```
-error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable`
+error: unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable`
   --> src/mdtest_snippet.py:9:1
    |
  8 | # error: [unsupported-bool-conversion]
@@ -43,7 +43,7 @@ info: `lint:unsupported-bool-conversion` is enabled by default
 ```
 
 ```
-error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable`
+error: unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable`
   --> src/mdtest_snippet.py:11:1
    |
  9 | 10 in WithContains()

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/mro.md_-_Method_Resolution_Order_tests_-_`__bases__`_lists_with_duplicate_bases.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/mro.md_-_Method_Resolution_Order_tests_-_`__bases__`_lists_with_duplicate_bases.snap
@@ -122,7 +122,7 @@ info: The definition of class `Foo` will raise `TypeError` at runtime
 4 |
 5 | reveal_type(Foo.__mro__)  # revealed: tuple[<class 'Foo'>, Unknown, <class 'object'>]
   |
-info: `lint:duplicate-base` is enabled by default
+info: `duplicate-base` is enabled by default
 
 ```
 
@@ -174,7 +174,7 @@ info: The definition of class `Ham` will raise `TypeError` at runtime
 22 |     Eggs,
 23 | ): ...
    |
-info: `lint:duplicate-base` is enabled by default
+info: `duplicate-base` is enabled by default
 
 ```
 
@@ -211,7 +211,7 @@ info: The definition of class `Ham` will raise `TypeError` at runtime
    |     ^^^^ Class `Eggs` later repeated here
 23 | ): ...
    |
-info: `lint:duplicate-base` is enabled by default
+info: `duplicate-base` is enabled by default
 
 ```
 
@@ -250,7 +250,7 @@ info: The definition of class `Omelette` will raise `TypeError` at runtime
 31 |
 32 | reveal_type(Omelette.__mro__)  # revealed: tuple[<class 'Omelette'>, Unknown, <class 'object'>]
    |
-info: `lint:duplicate-base` is enabled by default
+info: `duplicate-base` is enabled by default
 
 ```
 
@@ -309,7 +309,7 @@ info: The definition of class `VeryEggyOmelette` will raise `TypeError` at runti
    |     ^^^^ Class `Eggs` later repeated here
 47 | ): ...
    |
-info: `lint:duplicate-base` is enabled by default
+info: `duplicate-base` is enabled by default
 
 ```
 
@@ -340,7 +340,7 @@ info: The definition of class `D` will raise `TypeError` at runtime
    |     ^ Class `A` later repeated here
 73 | ): ...
    |
-info: `lint:duplicate-base` is enabled by default
+info: `duplicate-base` is enabled by default
 
 ```
 
@@ -383,7 +383,7 @@ info: The definition of class `E` will raise `TypeError` at runtime
 79 | ):
 80 |     # error: [unused-ignore-comment]
    |
-info: `lint:duplicate-base` is enabled by default
+info: `duplicate-base` is enabled by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/mro.md_-_Method_Resolution_Order_tests_-_`__bases__`_lists_with_duplicate_bases.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/mro.md_-_Method_Resolution_Order_tests_-_`__bases__`_lists_with_duplicate_bases.snap
@@ -100,7 +100,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/mro.md
 # Diagnostics
 
 ```
-error: lint:duplicate-base: Duplicate base class `str`
+error: duplicate-base: Duplicate base class `str`
  --> src/mdtest_snippet.py:3:7
   |
 1 | from typing_extensions import reveal_type
@@ -141,7 +141,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-error: lint:duplicate-base: Duplicate base class `Spam`
+error: duplicate-base: Duplicate base class `Spam`
   --> src/mdtest_snippet.py:16:7
    |
 14 |   # error: [duplicate-base] "Duplicate base class `Spam`"
@@ -179,7 +179,7 @@ info: `lint:duplicate-base` is enabled by default
 ```
 
 ```
-error: lint:duplicate-base: Duplicate base class `Eggs`
+error: duplicate-base: Duplicate base class `Eggs`
   --> src/mdtest_snippet.py:16:7
    |
 14 |   # error: [duplicate-base] "Duplicate base class `Spam`"
@@ -230,7 +230,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-error: lint:duplicate-base: Duplicate base class `Mushrooms`
+error: duplicate-base: Duplicate base class `Mushrooms`
   --> src/mdtest_snippet.py:30:7
    |
 29 | class Mushrooms: ...
@@ -269,7 +269,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-error: lint:duplicate-base: Duplicate base class `Eggs`
+error: duplicate-base: Duplicate base class `Eggs`
   --> src/mdtest_snippet.py:37:7
    |
 36 |   # error: [duplicate-base] "Duplicate base class `Eggs`"
@@ -314,7 +314,7 @@ info: `lint:duplicate-base` is enabled by default
 ```
 
 ```
-error: lint:duplicate-base: Duplicate base class `A`
+error: duplicate-base: Duplicate base class `A`
   --> src/mdtest_snippet.py:69:7
    |
 68 |   # error: [duplicate-base]
@@ -345,7 +345,7 @@ info: `lint:duplicate-base` is enabled by default
 ```
 
 ```
-info: lint:unused-ignore-comment
+info: unused-ignore-comment
   --> src/mdtest_snippet.py:72:9
    |
 70 |     A,
@@ -358,7 +358,7 @@ info: lint:unused-ignore-comment
 ```
 
 ```
-error: lint:duplicate-base: Duplicate base class `A`
+error: duplicate-base: Duplicate base class `A`
   --> src/mdtest_snippet.py:76:7
    |
 75 |   # error: [duplicate-base]
@@ -388,7 +388,7 @@ info: `lint:duplicate-base` is enabled by default
 ```
 
 ```
-info: lint:unused-ignore-comment
+info: unused-ignore-comment
   --> src/mdtest_snippet.py:81:13
    |
 79 | ):

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/mro.md_-_Method_Resolution_Order_tests_-_`__bases__`_lists_with_duplicate_bases.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/mro.md_-_Method_Resolution_Order_tests_-_`__bases__`_lists_with_duplicate_bases.snap
@@ -345,7 +345,7 @@ info: `lint:duplicate-base` is enabled by default
 ```
 
 ```
-info: unused-ignore-comment
+info: unused-ignore-comment: 
   --> src/mdtest_snippet.py:72:9
    |
 70 |     A,
@@ -388,7 +388,7 @@ info: `lint:duplicate-base` is enabled by default
 ```
 
 ```
-info: unused-ignore-comment
+info: unused-ignore-comment: 
   --> src/mdtest_snippet.py:81:13
    |
 79 | ):

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/mro.md_-_Method_Resolution_Order_tests_-_`__bases__`_lists_with_duplicate_bases.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/mro.md_-_Method_Resolution_Order_tests_-_`__bases__`_lists_with_duplicate_bases.snap
@@ -100,7 +100,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/mro.md
 # Diagnostics
 
 ```
-error: duplicate-base: Duplicate base class `str`
+error[duplicate-base]: Duplicate base class `str`
  --> src/mdtest_snippet.py:3:7
   |
 1 | from typing_extensions import reveal_type
@@ -127,7 +127,7 @@ info: `lint:duplicate-base` is enabled by default
 ```
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
  --> src/mdtest_snippet.py:5:13
   |
 3 | class Foo(str, str): ...  # error: [duplicate-base] "Duplicate base class `str`"
@@ -141,7 +141,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-error: duplicate-base: Duplicate base class `Spam`
+error[duplicate-base]: Duplicate base class `Spam`
   --> src/mdtest_snippet.py:16:7
    |
 14 |   # error: [duplicate-base] "Duplicate base class `Spam`"
@@ -179,7 +179,7 @@ info: `lint:duplicate-base` is enabled by default
 ```
 
 ```
-error: duplicate-base: Duplicate base class `Eggs`
+error[duplicate-base]: Duplicate base class `Eggs`
   --> src/mdtest_snippet.py:16:7
    |
 14 |   # error: [duplicate-base] "Duplicate base class `Spam`"
@@ -216,7 +216,7 @@ info: `lint:duplicate-base` is enabled by default
 ```
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
   --> src/mdtest_snippet.py:27:13
    |
 25 | # fmt: on
@@ -230,7 +230,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-error: duplicate-base: Duplicate base class `Mushrooms`
+error[duplicate-base]: Duplicate base class `Mushrooms`
   --> src/mdtest_snippet.py:30:7
    |
 29 | class Mushrooms: ...
@@ -255,7 +255,7 @@ info: `lint:duplicate-base` is enabled by default
 ```
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
   --> src/mdtest_snippet.py:32:13
    |
 30 | class Omelette(Spam, Eggs, Mushrooms, Mushrooms): ...  # error: [duplicate-base]
@@ -269,7 +269,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-error: duplicate-base: Duplicate base class `Eggs`
+error[duplicate-base]: Duplicate base class `Eggs`
   --> src/mdtest_snippet.py:37:7
    |
 36 |   # error: [duplicate-base] "Duplicate base class `Eggs`"
@@ -314,7 +314,7 @@ info: `lint:duplicate-base` is enabled by default
 ```
 
 ```
-error: duplicate-base: Duplicate base class `A`
+error[duplicate-base]: Duplicate base class `A`
   --> src/mdtest_snippet.py:69:7
    |
 68 |   # error: [duplicate-base]
@@ -345,7 +345,7 @@ info: `lint:duplicate-base` is enabled by default
 ```
 
 ```
-info: unused-ignore-comment: 
+info[unused-ignore-comment]
   --> src/mdtest_snippet.py:72:9
    |
 70 |     A,
@@ -358,7 +358,7 @@ info: unused-ignore-comment:
 ```
 
 ```
-error: duplicate-base: Duplicate base class `A`
+error[duplicate-base]: Duplicate base class `A`
   --> src/mdtest_snippet.py:76:7
    |
 75 |   # error: [duplicate-base]
@@ -388,7 +388,7 @@ info: `lint:duplicate-base` is enabled by default
 ```
 
 ```
-info: unused-ignore-comment: 
+info[unused-ignore-comment]
   --> src/mdtest_snippet.py:81:13
    |
 79 | ):

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/no_matching_overload.md_-_No_matching_overload_diagnostics_-_Calls_to_overloaded_functions.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/no_matching_overload.md_-_No_matching_overload_diagnostics_-_Calls_to_overloaded_functions.snap
@@ -18,7 +18,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/no_matching_
 # Diagnostics
 
 ```
-error: lint:no-matching-overload: No overload of class `type` matches arguments
+error: no-matching-overload: No overload of class `type` matches arguments
  --> src/mdtest_snippet.py:1:1
   |
 1 | type("Foo", ())  # error: [no-matching-overload]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/no_matching_overload.md_-_No_matching_overload_diagnostics_-_Calls_to_overloaded_functions.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/no_matching_overload.md_-_No_matching_overload_diagnostics_-_Calls_to_overloaded_functions.snap
@@ -24,6 +24,6 @@ error[no-matching-overload]: No overload of class `type` matches arguments
 1 | type("Foo", ())  # error: [no-matching-overload]
   | ^^^^^^^^^^^^^^^
   |
-info: `lint:no-matching-overload` is enabled by default
+info: `no-matching-overload` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/no_matching_overload.md_-_No_matching_overload_diagnostics_-_Calls_to_overloaded_functions.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/no_matching_overload.md_-_No_matching_overload_diagnostics_-_Calls_to_overloaded_functions.snap
@@ -18,7 +18,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/no_matching_
 # Diagnostics
 
 ```
-error: no-matching-overload: No overload of class `type` matches arguments
+error[no-matching-overload]: No overload of class `type` matches arguments
  --> src/mdtest_snippet.py:1:1
   |
 1 | type("Foo", ())  # error: [no-matching-overload]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/not.md_-_Unary_not_-_Object_that_implements_`__bool__`_incorrectly.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/not.md_-_Unary_not_-_Object_that_implements_`__bool__`_incorrectly.snap
@@ -22,7 +22,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/unary/not.md
 # Diagnostics
 
 ```
-error: unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable`
+error[unsupported-bool-conversion]: Boolean conversion is unsupported for type `NotBoolable`
  --> src/mdtest_snippet.py:5:1
   |
 4 | # error: [unsupported-bool-conversion]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/not.md_-_Unary_not_-_Object_that_implements_`__bool__`_incorrectly.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/not.md_-_Unary_not_-_Object_that_implements_`__bool__`_incorrectly.snap
@@ -30,6 +30,6 @@ error[unsupported-bool-conversion]: Boolean conversion is unsupported for type `
   | ^^^^^^^^^^^^^^^^^
   |
 info: `__bool__` on `NotBoolable` must be callable
-info: `lint:unsupported-bool-conversion` is enabled by default
+info: `unsupported-bool-conversion` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/not.md_-_Unary_not_-_Object_that_implements_`__bool__`_incorrectly.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/not.md_-_Unary_not_-_Object_that_implements_`__bool__`_incorrectly.snap
@@ -22,7 +22,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/unary/not.md
 # Diagnostics
 
 ```
-error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable`
+error: unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable`
  --> src/mdtest_snippet.py:5:1
   |
 4 | # error: [unsupported-bool-conversion]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_At_least_two_overloads.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_At_least_two_overloads.snap
@@ -35,7 +35,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/overloads.md
 # Diagnostics
 
 ```
-error: lint:invalid-overload: Overloaded function `func` requires at least two overloads
+error: invalid-overload: Overloaded function `func` requires at least two overloads
  --> src/mdtest_snippet.py:4:5
   |
 3 | @overload
@@ -52,7 +52,7 @@ info: `lint:invalid-overload` is enabled by default
 ```
 
 ```
-error: lint:invalid-overload: Overloaded function `func` requires at least two overloads
+error: invalid-overload: Overloaded function `func` requires at least two overloads
  --> src/mdtest_snippet.pyi:5:5
   |
 3 | @overload

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_At_least_two_overloads.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_At_least_two_overloads.snap
@@ -35,7 +35,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/overloads.md
 # Diagnostics
 
 ```
-error: invalid-overload: Overloaded function `func` requires at least two overloads
+error[invalid-overload]: Overloaded function `func` requires at least two overloads
  --> src/mdtest_snippet.py:4:5
   |
 3 | @overload
@@ -52,7 +52,7 @@ info: `lint:invalid-overload` is enabled by default
 ```
 
 ```
-error: invalid-overload: Overloaded function `func` requires at least two overloads
+error[invalid-overload]: Overloaded function `func` requires at least two overloads
  --> src/mdtest_snippet.pyi:5:5
   |
 3 | @overload

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_At_least_two_overloads.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_At_least_two_overloads.snap
@@ -47,7 +47,7 @@ error[invalid-overload]: Overloaded function `func` requires at least two overlo
   |     ^^^^
 8 |     return x
   |
-info: `lint:invalid-overload` is enabled by default
+info: `invalid-overload` is enabled by default
 
 ```
 
@@ -62,6 +62,6 @@ error[invalid-overload]: Overloaded function `func` requires at least two overlo
   |     |
   |     Only one overload defined here
   |
-info: `lint:invalid-overload` is enabled by default
+info: `invalid-overload` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorators_-_`@classmethod`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorators_-_`@classmethod`.snap
@@ -72,7 +72,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/overloads.md
 # Diagnostics
 
 ```
-error: invalid-overload: Overloaded function `try_from1` does not use the `@classmethod` decorator consistently
+error[invalid-overload]: Overloaded function `try_from1` does not use the `@classmethod` decorator consistently
   --> src/mdtest_snippet.py:13:9
    |
 11 |     def try_from1(cls, x: int) -> CheckClassMethod: ...
@@ -91,7 +91,7 @@ info: `lint:invalid-overload` is enabled by default
 ```
 
 ```
-error: invalid-overload: Overloaded function `try_from2` does not use the `@classmethod` decorator consistently
+error[invalid-overload]: Overloaded function `try_from2` does not use the `@classmethod` decorator consistently
   --> src/mdtest_snippet.py:28:9
    |
 26 |     @classmethod
@@ -114,7 +114,7 @@ info: `lint:invalid-overload` is enabled by default
 ```
 
 ```
-error: invalid-overload: Overloaded function `try_from3` does not use the `@classmethod` decorator consistently
+error[invalid-overload]: Overloaded function `try_from3` does not use the `@classmethod` decorator consistently
   --> src/mdtest_snippet.py:40:9
    |
 38 |     def try_from3(cls, x: str) -> None: ...

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorators_-_`@classmethod`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorators_-_`@classmethod`.snap
@@ -72,7 +72,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/overloads.md
 # Diagnostics
 
 ```
-error: lint:invalid-overload: Overloaded function `try_from1` does not use the `@classmethod` decorator consistently
+error: invalid-overload: Overloaded function `try_from1` does not use the `@classmethod` decorator consistently
   --> src/mdtest_snippet.py:13:9
    |
 11 |     def try_from1(cls, x: int) -> CheckClassMethod: ...
@@ -91,7 +91,7 @@ info: `lint:invalid-overload` is enabled by default
 ```
 
 ```
-error: lint:invalid-overload: Overloaded function `try_from2` does not use the `@classmethod` decorator consistently
+error: invalid-overload: Overloaded function `try_from2` does not use the `@classmethod` decorator consistently
   --> src/mdtest_snippet.py:28:9
    |
 26 |     @classmethod
@@ -114,7 +114,7 @@ info: `lint:invalid-overload` is enabled by default
 ```
 
 ```
-error: lint:invalid-overload: Overloaded function `try_from3` does not use the `@classmethod` decorator consistently
+error: invalid-overload: Overloaded function `try_from3` does not use the `@classmethod` decorator consistently
   --> src/mdtest_snippet.py:40:9
    |
 38 |     def try_from3(cls, x: str) -> None: ...

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorators_-_`@classmethod`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorators_-_`@classmethod`.snap
@@ -86,7 +86,7 @@ error[invalid-overload]: Overloaded function `try_from1` does not use the `@clas
 17 |         if isinstance(x, int):
 18 |             return cls(x)
    |
-info: `lint:invalid-overload` is enabled by default
+info: `invalid-overload` is enabled by default
 
 ```
 
@@ -109,7 +109,7 @@ error[invalid-overload]: Overloaded function `try_from2` does not use the `@clas
 23 |     @overload
 24 |     @classmethod
    |
-info: `lint:invalid-overload` is enabled by default
+info: `invalid-overload` is enabled by default
 
 ```
 
@@ -126,6 +126,6 @@ error[invalid-overload]: Overloaded function `try_from3` does not use the `@clas
 41 |         if isinstance(x, int):
 42 |             return cls(x)
    |
-info: `lint:invalid-overload` is enabled by default
+info: `invalid-overload` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorators_-_`@final`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorators_-_`@final`.snap
@@ -65,7 +65,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/overloads.md
 # Diagnostics
 
 ```
-error: invalid-overload: `@final` decorator should be applied only to the overload implementation
+error[invalid-overload]: `@final` decorator should be applied only to the overload implementation
   --> src/mdtest_snippet.py:18:9
    |
 16 |     def method2(self, x: str) -> str: ...
@@ -81,7 +81,7 @@ info: `lint:invalid-overload` is enabled by default
 ```
 
 ```
-error: invalid-overload: `@final` decorator should be applied only to the overload implementation
+error[invalid-overload]: `@final` decorator should be applied only to the overload implementation
   --> src/mdtest_snippet.py:27:9
    |
 25 |     def method3(self, x: str) -> str: ...
@@ -97,7 +97,7 @@ info: `lint:invalid-overload` is enabled by default
 ```
 
 ```
-error: invalid-overload: `@final` decorator should be applied only to the first overload
+error[invalid-overload]: `@final` decorator should be applied only to the first overload
   --> src/mdtest_snippet.pyi:11:9
    |
 10 |     @overload

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorators_-_`@final`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorators_-_`@final`.snap
@@ -76,7 +76,7 @@ error[invalid-overload]: `@final` decorator should be applied only to the overlo
    |         Implementation defined here
 19 |         return x
    |
-info: `lint:invalid-overload` is enabled by default
+info: `invalid-overload` is enabled by default
 
 ```
 
@@ -92,7 +92,7 @@ error[invalid-overload]: `@final` decorator should be applied only to the overlo
    |         Implementation defined here
 28 |         return x
    |
-info: `lint:invalid-overload` is enabled by default
+info: `invalid-overload` is enabled by default
 
 ```
 
@@ -109,6 +109,6 @@ error[invalid-overload]: `@final` decorator should be applied only to the first 
 15 |     def method2(self, x: str) -> str: ...
    |         ^^^^^^^
    |
-info: `lint:invalid-overload` is enabled by default
+info: `invalid-overload` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorators_-_`@final`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorators_-_`@final`.snap
@@ -65,7 +65,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/overloads.md
 # Diagnostics
 
 ```
-error: lint:invalid-overload: `@final` decorator should be applied only to the overload implementation
+error: invalid-overload: `@final` decorator should be applied only to the overload implementation
   --> src/mdtest_snippet.py:18:9
    |
 16 |     def method2(self, x: str) -> str: ...
@@ -81,7 +81,7 @@ info: `lint:invalid-overload` is enabled by default
 ```
 
 ```
-error: lint:invalid-overload: `@final` decorator should be applied only to the overload implementation
+error: invalid-overload: `@final` decorator should be applied only to the overload implementation
   --> src/mdtest_snippet.py:27:9
    |
 25 |     def method3(self, x: str) -> str: ...
@@ -97,7 +97,7 @@ info: `lint:invalid-overload` is enabled by default
 ```
 
 ```
-error: lint:invalid-overload: `@final` decorator should be applied only to the first overload
+error: invalid-overload: `@final` decorator should be applied only to the first overload
   --> src/mdtest_snippet.pyi:11:9
    |
 10 |     @overload

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorators_-_`@override`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorators_-_`@override`.snap
@@ -93,7 +93,7 @@ error[invalid-overload]: `@override` decorator should be applied only to the ove
    |         Implementation defined here
 28 |         return x
    |
-info: `lint:invalid-overload` is enabled by default
+info: `invalid-overload` is enabled by default
 
 ```
 
@@ -109,7 +109,7 @@ error[invalid-overload]: `@override` decorator should be applied only to the ove
    |         Implementation defined here
 38 |         return x
    |
-info: `lint:invalid-overload` is enabled by default
+info: `invalid-overload` is enabled by default
 
 ```
 
@@ -127,6 +127,6 @@ error[invalid-overload]: `@override` decorator should be applied only to the fir
 22 |     def method(self, x: str) -> str: ...
    |         ^^^^^^
    |
-info: `lint:invalid-overload` is enabled by default
+info: `invalid-overload` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorators_-_`@override`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorators_-_`@override`.snap
@@ -82,7 +82,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/overloads.md
 # Diagnostics
 
 ```
-error: invalid-overload: `@override` decorator should be applied only to the overload implementation
+error[invalid-overload]: `@override` decorator should be applied only to the overload implementation
   --> src/mdtest_snippet.py:27:9
    |
 25 |     def method(self, x: str) -> str: ...
@@ -98,7 +98,7 @@ info: `lint:invalid-overload` is enabled by default
 ```
 
 ```
-error: invalid-overload: `@override` decorator should be applied only to the overload implementation
+error[invalid-overload]: `@override` decorator should be applied only to the overload implementation
   --> src/mdtest_snippet.py:37:9
    |
 35 |     def method(self, x: str) -> str: ...
@@ -114,7 +114,7 @@ info: `lint:invalid-overload` is enabled by default
 ```
 
 ```
-error: invalid-overload: `@override` decorator should be applied only to the first overload
+error[invalid-overload]: `@override` decorator should be applied only to the first overload
   --> src/mdtest_snippet.pyi:18:9
    |
 16 | class Sub2(Base):

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorators_-_`@override`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorators_-_`@override`.snap
@@ -82,7 +82,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/overloads.md
 # Diagnostics
 
 ```
-error: lint:invalid-overload: `@override` decorator should be applied only to the overload implementation
+error: invalid-overload: `@override` decorator should be applied only to the overload implementation
   --> src/mdtest_snippet.py:27:9
    |
 25 |     def method(self, x: str) -> str: ...
@@ -98,7 +98,7 @@ info: `lint:invalid-overload` is enabled by default
 ```
 
 ```
-error: lint:invalid-overload: `@override` decorator should be applied only to the overload implementation
+error: invalid-overload: `@override` decorator should be applied only to the overload implementation
   --> src/mdtest_snippet.py:37:9
    |
 35 |     def method(self, x: str) -> str: ...
@@ -114,7 +114,7 @@ info: `lint:invalid-overload` is enabled by default
 ```
 
 ```
-error: lint:invalid-overload: `@override` decorator should be applied only to the first overload
+error: invalid-overload: `@override` decorator should be applied only to the first overload
   --> src/mdtest_snippet.pyi:18:9
    |
 16 | class Sub2(Base):

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Overload_without_an_implementation_-_Regular_modules.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Overload_without_an_implementation_-_Regular_modules.snap
@@ -31,7 +31,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/overloads.md
 # Diagnostics
 
 ```
-error: invalid-overload: Overloaded non-stub function `func` must have an implementation
+error[invalid-overload]: Overloaded non-stub function `func` must have an implementation
  --> src/mdtest_snippet.py:7:5
   |
 5 | @overload
@@ -46,7 +46,7 @@ info: `lint:invalid-overload` is enabled by default
 ```
 
 ```
-error: invalid-overload: Overloaded non-stub function `method` must have an implementation
+error[invalid-overload]: Overloaded non-stub function `method` must have an implementation
   --> src/mdtest_snippet.py:14:9
    |
 12 |     @overload

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Overload_without_an_implementation_-_Regular_modules.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Overload_without_an_implementation_-_Regular_modules.snap
@@ -31,7 +31,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/overloads.md
 # Diagnostics
 
 ```
-error: lint:invalid-overload: Overloaded non-stub function `func` must have an implementation
+error: invalid-overload: Overloaded non-stub function `func` must have an implementation
  --> src/mdtest_snippet.py:7:5
   |
 5 | @overload
@@ -46,7 +46,7 @@ info: `lint:invalid-overload` is enabled by default
 ```
 
 ```
-error: lint:invalid-overload: Overloaded non-stub function `method` must have an implementation
+error: invalid-overload: Overloaded non-stub function `method` must have an implementation
   --> src/mdtest_snippet.py:14:9
    |
 12 |     @overload

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Overload_without_an_implementation_-_Regular_modules.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Overload_without_an_implementation_-_Regular_modules.snap
@@ -41,7 +41,7 @@ error[invalid-overload]: Overloaded non-stub function `func` must have an implem
 8 |
 9 | class Foo:
   |
-info: `lint:invalid-overload` is enabled by default
+info: `invalid-overload` is enabled by default
 
 ```
 
@@ -54,6 +54,6 @@ error[invalid-overload]: Overloaded non-stub function `method` must have an impl
 14 |     def method(self, x: str) -> str: ...
    |         ^^^^^^
    |
-info: `lint:invalid-overload` is enabled by default
+info: `invalid-overload` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Calls_to_protocol_classes.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Calls_to_protocol_classes.snap
@@ -42,7 +42,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/protocols.md
 # Diagnostics
 
 ```
-error: call-non-callable: Object of type `typing.Protocol` is not callable
+error[call-non-callable]: Object of type `typing.Protocol` is not callable
  --> src/mdtest_snippet.py:4:13
   |
 3 | # error: [call-non-callable]
@@ -56,7 +56,7 @@ info: `lint:call-non-callable` is enabled by default
 ```
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
  --> src/mdtest_snippet.py:4:13
   |
 3 | # error: [call-non-callable]
@@ -69,7 +69,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-error: call-non-callable: Cannot instantiate class `MyProtocol`
+error[call-non-callable]: Cannot instantiate class `MyProtocol`
   --> src/mdtest_snippet.py:10:13
    |
  9 | # error: [call-non-callable] "Cannot instantiate class `MyProtocol`"
@@ -92,7 +92,7 @@ info: `lint:call-non-callable` is enabled by default
 ```
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
   --> src/mdtest_snippet.py:10:13
    |
  9 | # error: [call-non-callable] "Cannot instantiate class `MyProtocol`"
@@ -105,7 +105,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-error: call-non-callable: Cannot instantiate class `GenericProtocol`
+error[call-non-callable]: Cannot instantiate class `GenericProtocol`
   --> src/mdtest_snippet.py:16:13
    |
 15 | # error: [call-non-callable] "Cannot instantiate class `GenericProtocol`"
@@ -127,7 +127,7 @@ info: `lint:call-non-callable` is enabled by default
 ```
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
   --> src/mdtest_snippet.py:16:13
    |
 15 | # error: [call-non-callable] "Cannot instantiate class `GenericProtocol`"
@@ -139,7 +139,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
   --> src/mdtest_snippet.py:19:13
    |
 17 | class SubclassOfMyProtocol(MyProtocol): ...
@@ -153,7 +153,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
   --> src/mdtest_snippet.py:23:13
    |
 21 | class SubclassOfGenericProtocol[T](GenericProtocol[T]): ...
@@ -167,7 +167,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
   --> src/mdtest_snippet.py:25:17
    |
 23 | reveal_type(SubclassOfGenericProtocol[int]())  # revealed: SubclassOfGenericProtocol[int]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Calls_to_protocol_classes.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Calls_to_protocol_classes.snap
@@ -42,7 +42,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/protocols.md
 # Diagnostics
 
 ```
-error: lint:call-non-callable: Object of type `typing.Protocol` is not callable
+error: call-non-callable: Object of type `typing.Protocol` is not callable
  --> src/mdtest_snippet.py:4:13
   |
 3 | # error: [call-non-callable]
@@ -69,7 +69,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-error: lint:call-non-callable: Cannot instantiate class `MyProtocol`
+error: call-non-callable: Cannot instantiate class `MyProtocol`
   --> src/mdtest_snippet.py:10:13
    |
  9 | # error: [call-non-callable] "Cannot instantiate class `MyProtocol`"
@@ -105,7 +105,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-error: lint:call-non-callable: Cannot instantiate class `GenericProtocol`
+error: call-non-callable: Cannot instantiate class `GenericProtocol`
   --> src/mdtest_snippet.py:16:13
    |
 15 | # error: [call-non-callable] "Cannot instantiate class `GenericProtocol`"

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Calls_to_protocol_classes.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Calls_to_protocol_classes.snap
@@ -51,7 +51,7 @@ error[call-non-callable]: Object of type `typing.Protocol` is not callable
 5 |
 6 | class MyProtocol(Protocol):
   |
-info: `lint:call-non-callable` is enabled by default
+info: `call-non-callable` is enabled by default
 
 ```
 
@@ -87,7 +87,7 @@ info: Protocol classes cannot be instantiated
   |       ^^^^^^^^^^^^^^^^^^^^ `MyProtocol` declared as a protocol here
 7 |     x: int
   |
-info: `lint:call-non-callable` is enabled by default
+info: `call-non-callable` is enabled by default
 
 ```
 
@@ -122,7 +122,7 @@ info: Protocol classes cannot be instantiated
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `GenericProtocol` declared as a protocol here
 13 |     x: T
    |
-info: `lint:call-non-callable` is enabled by default
+info: `call-non-callable` is enabled by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Invalid_calls_to_`get_protocol_members()`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Invalid_calls_to_`get_protocol_members()`.snap
@@ -29,7 +29,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/protocols.md
 # Diagnostics
 
 ```
-error: invalid-argument-type: Invalid argument to `get_protocol_members`
+error[invalid-argument-type]: Invalid argument to `get_protocol_members`
  --> src/mdtest_snippet.py:5:1
   |
 3 | class NotAProtocol: ...
@@ -57,7 +57,7 @@ info: `lint:invalid-argument-type` is enabled by default
 ```
 
 ```
-error: invalid-argument-type: Invalid argument to `get_protocol_members`
+error[invalid-argument-type]: Invalid argument to `get_protocol_members`
   --> src/mdtest_snippet.py:9:1
    |
  7 | class AlsoNotAProtocol(NotAProtocol, object): ...

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Invalid_calls_to_`get_protocol_members()`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Invalid_calls_to_`get_protocol_members()`.snap
@@ -52,7 +52,7 @@ info: `NotAProtocol` is declared here, but it is not a protocol class:
   |
 info: A class is only a protocol class if it directly inherits from `typing.Protocol` or `typing_extensions.Protocol`
 info: See https://typing.python.org/en/latest/spec/protocol.html#
-info: `lint:invalid-argument-type` is enabled by default
+info: `invalid-argument-type` is enabled by default
 
 ```
 
@@ -79,6 +79,6 @@ info: `AlsoNotAProtocol` is declared here, but it is not a protocol class:
   |
 info: A class is only a protocol class if it directly inherits from `typing.Protocol` or `typing_extensions.Protocol`
 info: See https://typing.python.org/en/latest/spec/protocol.html#
-info: `lint:invalid-argument-type` is enabled by default
+info: `invalid-argument-type` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Invalid_calls_to_`get_protocol_members()`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Invalid_calls_to_`get_protocol_members()`.snap
@@ -29,7 +29,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/protocols.md
 # Diagnostics
 
 ```
-error: lint:invalid-argument-type: Invalid argument to `get_protocol_members`
+error: invalid-argument-type: Invalid argument to `get_protocol_members`
  --> src/mdtest_snippet.py:5:1
   |
 3 | class NotAProtocol: ...
@@ -57,7 +57,7 @@ info: `lint:invalid-argument-type` is enabled by default
 ```
 
 ```
-error: lint:invalid-argument-type: Invalid argument to `get_protocol_members`
+error: invalid-argument-type: Invalid argument to `get_protocol_members`
   --> src/mdtest_snippet.py:9:1
    |
  7 | class AlsoNotAProtocol(NotAProtocol, object): ...

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Narrowing_of_protocols.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Narrowing_of_protocols.snap
@@ -57,7 +57,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/protocols.md
 # Diagnostics
 
 ```
-error: lint:invalid-argument-type: Class `HasX` cannot be used as the second argument to `isinstance`
+error: invalid-argument-type: Class `HasX` cannot be used as the second argument to `isinstance`
  --> src/mdtest_snippet.py:7:8
   |
 6 | def f(arg: object, arg2: type):
@@ -110,7 +110,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-error: lint:invalid-argument-type: Class `HasX` cannot be used as the second argument to `issubclass`
+error: invalid-argument-type: Class `HasX` cannot be used as the second argument to `issubclass`
   --> src/mdtest_snippet.py:12:8
    |
 10 |         reveal_type(arg)  # revealed: ~HasX

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Narrowing_of_protocols.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Narrowing_of_protocols.snap
@@ -77,7 +77,7 @@ info: `HasX` is declared as a protocol class, but it is not declared as runtime-
   |
 info: A protocol class can only be used in `isinstance` checks if it is decorated with `@typing.runtime_checkable` or `@typing_extensions.runtime_checkable`
 info: See https://docs.python.org/3/library/typing.html#typing.runtime_checkable
-info: `lint:invalid-argument-type` is enabled by default
+info: `invalid-argument-type` is enabled by default
 
 ```
 
@@ -131,7 +131,7 @@ info: `HasX` is declared as a protocol class, but it is not declared as runtime-
   |
 info: A protocol class can only be used in `issubclass` checks if it is decorated with `@typing.runtime_checkable` or `@typing_extensions.runtime_checkable`
 info: See https://docs.python.org/3/library/typing.html#typing.runtime_checkable
-info: `lint:invalid-argument-type` is enabled by default
+info: `invalid-argument-type` is enabled by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Narrowing_of_protocols.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Narrowing_of_protocols.snap
@@ -57,7 +57,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/protocols.md
 # Diagnostics
 
 ```
-error: invalid-argument-type: Class `HasX` cannot be used as the second argument to `isinstance`
+error[invalid-argument-type]: Class `HasX` cannot be used as the second argument to `isinstance`
  --> src/mdtest_snippet.py:7:8
   |
 6 | def f(arg: object, arg2: type):
@@ -82,7 +82,7 @@ info: `lint:invalid-argument-type` is enabled by default
 ```
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
   --> src/mdtest_snippet.py:8:21
    |
  6 | def f(arg: object, arg2: type):
@@ -96,7 +96,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
   --> src/mdtest_snippet.py:10:21
    |
  8 |         reveal_type(arg)  # revealed: HasX
@@ -110,7 +110,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-error: invalid-argument-type: Class `HasX` cannot be used as the second argument to `issubclass`
+error[invalid-argument-type]: Class `HasX` cannot be used as the second argument to `issubclass`
   --> src/mdtest_snippet.py:12:8
    |
 10 |         reveal_type(arg)  # revealed: ~HasX
@@ -136,7 +136,7 @@ info: `lint:invalid-argument-type` is enabled by default
 ```
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
   --> src/mdtest_snippet.py:13:21
    |
 12 |     if issubclass(arg2, HasX):  # error: [invalid-argument-type]
@@ -149,7 +149,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
   --> src/mdtest_snippet.py:15:21
    |
 13 |         reveal_type(arg2)  # revealed: type[HasX]
@@ -162,7 +162,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
   --> src/mdtest_snippet.py:24:21
    |
 22 | def f(arg: object):
@@ -176,7 +176,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
   --> src/mdtest_snippet.py:26:21
    |
 24 |         reveal_type(arg)  # revealed: RuntimeCheckableHasX
@@ -190,7 +190,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
   --> src/mdtest_snippet.py:33:21
    |
 31 | def f(arg1: type, arg2: type):
@@ -204,7 +204,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
   --> src/mdtest_snippet.py:35:21
    |
 33 |         reveal_type(arg1)  # revealed: type[RuntimeCheckableHasX]
@@ -218,7 +218,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
   --> src/mdtest_snippet.py:38:21
    |
 37 |     if issubclass(arg2, OnlyMethodMembers):  # no error!
@@ -231,7 +231,7 @@ info: revealed-type: Revealed type
 ```
 
 ```
-info: revealed-type: Revealed type
+info[revealed-type]: Revealed type
   --> src/mdtest_snippet.py:40:21
    |
 38 |         reveal_type(arg2)  # revealed: type[OnlyMethodMembers]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Generator_functions.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Generator_functions.snap
@@ -54,7 +54,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/function/return_type.md
 # Diagnostics
 
 ```
-error: lint:invalid-return-type: Return type does not match returned value
+error: invalid-return-type: Return type does not match returned value
   --> src/mdtest_snippet.py:19:12
    |
 17 |     yield from i()
@@ -71,7 +71,7 @@ info: `lint:invalid-return-type` is enabled by default
 ```
 
 ```
-error: lint:invalid-return-type: Return type does not match returned value
+error: invalid-return-type: Return type does not match returned value
   --> src/mdtest_snippet.py:36:18
    |
 34 |     yield 42

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Generator_functions.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Generator_functions.snap
@@ -66,7 +66,7 @@ error[invalid-return-type]: Return type does not match returned value
    |
 info: Function is inferred as returning `types.GeneratorType` because it is a generator function
 info: See https://docs.python.org/3/glossary.html#term-generator for more details
-info: `lint:invalid-return-type` is enabled by default
+info: `invalid-return-type` is enabled by default
 
 ```
 
@@ -82,6 +82,6 @@ error[invalid-return-type]: Return type does not match returned value
    |
 info: Function is inferred as returning `types.AsyncGeneratorType` because it is an async generator function
 info: See https://docs.python.org/3/glossary.html#term-asynchronous-generator for more details
-info: `lint:invalid-return-type` is enabled by default
+info: `invalid-return-type` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Generator_functions.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Generator_functions.snap
@@ -54,7 +54,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/function/return_type.md
 # Diagnostics
 
 ```
-error: invalid-return-type: Return type does not match returned value
+error[invalid-return-type]: Return type does not match returned value
   --> src/mdtest_snippet.py:19:12
    |
 17 |     yield from i()
@@ -71,7 +71,7 @@ info: `lint:invalid-return-type` is enabled by default
 ```
 
 ```
-error: invalid-return-type: Return type does not match returned value
+error[invalid-return-type]: Return type does not match returned value
   --> src/mdtest_snippet.py:36:18
    |
 34 |     yield 42

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_conditional_return_type.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_conditional_return_type.snap
@@ -45,7 +45,7 @@ error[invalid-return-type]: Return type does not match returned value
 7 |
 8 | def f(cond: bool) -> str:
   |
-info: `lint:invalid-return-type` is enabled by default
+info: `invalid-return-type` is enabled by default
 
 ```
 
@@ -64,7 +64,7 @@ error[invalid-return-type]: Return type does not match returned value
 12 |     else:
 13 |         # error: [invalid-return-type]
    |
-info: `lint:invalid-return-type` is enabled by default
+info: `invalid-return-type` is enabled by default
 
 ```
 
@@ -86,6 +86,6 @@ error[invalid-return-type]: Return type does not match returned value
  9 |     if cond:
 10 |         # error: [invalid-return-type]
    |
-info: `lint:invalid-return-type` is enabled by default
+info: `invalid-return-type` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_conditional_return_type.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_conditional_return_type.snap
@@ -31,7 +31,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/function/return_type.md
 # Diagnostics
 
 ```
-error: lint:invalid-return-type: Return type does not match returned value
+error: invalid-return-type: Return type does not match returned value
  --> src/mdtest_snippet.py:1:22
   |
 1 | def f(cond: bool) -> str:
@@ -50,7 +50,7 @@ info: `lint:invalid-return-type` is enabled by default
 ```
 
 ```
-error: lint:invalid-return-type: Return type does not match returned value
+error: invalid-return-type: Return type does not match returned value
   --> src/mdtest_snippet.py:8:22
    |
  6 |         return 1
@@ -69,7 +69,7 @@ info: `lint:invalid-return-type` is enabled by default
 ```
 
 ```
-error: lint:invalid-return-type: Return type does not match returned value
+error: invalid-return-type: Return type does not match returned value
   --> src/mdtest_snippet.py:14:16
    |
 12 |     else:

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_conditional_return_type.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_conditional_return_type.snap
@@ -31,7 +31,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/function/return_type.md
 # Diagnostics
 
 ```
-error: invalid-return-type: Return type does not match returned value
+error[invalid-return-type]: Return type does not match returned value
  --> src/mdtest_snippet.py:1:22
   |
 1 | def f(cond: bool) -> str:
@@ -50,7 +50,7 @@ info: `lint:invalid-return-type` is enabled by default
 ```
 
 ```
-error: invalid-return-type: Return type does not match returned value
+error[invalid-return-type]: Return type does not match returned value
   --> src/mdtest_snippet.py:8:22
    |
  6 |         return 1
@@ -69,7 +69,7 @@ info: `lint:invalid-return-type` is enabled by default
 ```
 
 ```
-error: invalid-return-type: Return type does not match returned value
+error[invalid-return-type]: Return type does not match returned value
   --> src/mdtest_snippet.py:14:16
    |
 12 |     else:

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_implicit_return_type.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_implicit_return_type.snap
@@ -52,7 +52,7 @@ error[invalid-return-type]: Return type does not match returned value
 5 |
 6 | # error: [invalid-return-type]
   |
-info: `lint:invalid-return-type` is enabled by default
+info: `invalid-return-type` is enabled by default
 
 ```
 
@@ -66,7 +66,7 @@ error[invalid-return-type]: Function can implicitly return `None`, which is not 
 8 |     if cond:
 9 |         return 1
   |
-info: `lint:invalid-return-type` is enabled by default
+info: `invalid-return-type` is enabled by default
 
 ```
 
@@ -80,7 +80,7 @@ error[invalid-return-type]: Function can implicitly return `None`, which is not 
 13 |     if cond:
 14 |         raise ValueError()
    |
-info: `lint:invalid-return-type` is enabled by default
+info: `invalid-return-type` is enabled by default
 
 ```
 
@@ -94,6 +94,6 @@ error[invalid-return-type]: Function can implicitly return `None`, which is not 
 18 |     if cond:
 19 |         cond = False
    |
-info: `lint:invalid-return-type` is enabled by default
+info: `invalid-return-type` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_implicit_return_type.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_implicit_return_type.snap
@@ -40,7 +40,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/function/return_type.md
 # Diagnostics
 
 ```
-error: invalid-return-type: Return type does not match returned value
+error[invalid-return-type]: Return type does not match returned value
  --> src/mdtest_snippet.py:1:12
   |
 1 | def f() -> None:
@@ -57,7 +57,7 @@ info: `lint:invalid-return-type` is enabled by default
 ```
 
 ```
-error: invalid-return-type: Function can implicitly return `None`, which is not assignable to return type `int`
+error[invalid-return-type]: Function can implicitly return `None`, which is not assignable to return type `int`
  --> src/mdtest_snippet.py:7:22
   |
 6 | # error: [invalid-return-type]
@@ -71,7 +71,7 @@ info: `lint:invalid-return-type` is enabled by default
 ```
 
 ```
-error: invalid-return-type: Function can implicitly return `None`, which is not assignable to return type `int`
+error[invalid-return-type]: Function can implicitly return `None`, which is not assignable to return type `int`
   --> src/mdtest_snippet.py:12:22
    |
 11 | # error: [invalid-return-type]
@@ -85,7 +85,7 @@ info: `lint:invalid-return-type` is enabled by default
 ```
 
 ```
-error: invalid-return-type: Function can implicitly return `None`, which is not assignable to return type `int`
+error[invalid-return-type]: Function can implicitly return `None`, which is not assignable to return type `int`
   --> src/mdtest_snippet.py:17:22
    |
 16 | # error: [invalid-return-type]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_implicit_return_type.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_implicit_return_type.snap
@@ -40,7 +40,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/function/return_type.md
 # Diagnostics
 
 ```
-error: lint:invalid-return-type: Return type does not match returned value
+error: invalid-return-type: Return type does not match returned value
  --> src/mdtest_snippet.py:1:12
   |
 1 | def f() -> None:
@@ -57,7 +57,7 @@ info: `lint:invalid-return-type` is enabled by default
 ```
 
 ```
-error: lint:invalid-return-type: Function can implicitly return `None`, which is not assignable to return type `int`
+error: invalid-return-type: Function can implicitly return `None`, which is not assignable to return type `int`
  --> src/mdtest_snippet.py:7:22
   |
 6 | # error: [invalid-return-type]
@@ -71,7 +71,7 @@ info: `lint:invalid-return-type` is enabled by default
 ```
 
 ```
-error: lint:invalid-return-type: Function can implicitly return `None`, which is not assignable to return type `int`
+error: invalid-return-type: Function can implicitly return `None`, which is not assignable to return type `int`
   --> src/mdtest_snippet.py:12:22
    |
 11 | # error: [invalid-return-type]
@@ -85,7 +85,7 @@ info: `lint:invalid-return-type` is enabled by default
 ```
 
 ```
-error: lint:invalid-return-type: Function can implicitly return `None`, which is not assignable to return type `int`
+error: invalid-return-type: Function can implicitly return `None`, which is not assignable to return type `int`
   --> src/mdtest_snippet.py:17:22
    |
 16 | # error: [invalid-return-type]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type.snap
@@ -35,7 +35,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/function/return_type.md
 # Diagnostics
 
 ```
-error: lint:invalid-return-type: Function can implicitly return `None`, which is not assignable to return type `int`
+error: invalid-return-type: Function can implicitly return `None`, which is not assignable to return type `int`
  --> src/mdtest_snippet.py:2:12
   |
 1 | # error: [invalid-return-type]
@@ -48,7 +48,7 @@ info: `lint:invalid-return-type` is enabled by default
 ```
 
 ```
-error: lint:invalid-return-type: Return type does not match returned value
+error: invalid-return-type: Return type does not match returned value
  --> src/mdtest_snippet.py:5:12
   |
 3 |     1
@@ -66,7 +66,7 @@ info: `lint:invalid-return-type` is enabled by default
 ```
 
 ```
-error: lint:invalid-return-type: Return type does not match returned value
+error: invalid-return-type: Return type does not match returned value
   --> src/mdtest_snippet.py:9:12
    |
  7 |     return 1
@@ -84,7 +84,7 @@ info: `lint:invalid-return-type` is enabled by default
 ```
 
 ```
-error: lint:invalid-return-type: Function can implicitly return `None`, which is not assignable to return type `T`
+error: invalid-return-type: Function can implicitly return `None`, which is not assignable to return type `T`
   --> src/mdtest_snippet.py:18:16
    |
 17 | # error: [invalid-return-type]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type.snap
@@ -43,7 +43,7 @@ error[invalid-return-type]: Function can implicitly return `None`, which is not 
   |            ^^^
 3 |     1
   |
-info: `lint:invalid-return-type` is enabled by default
+info: `invalid-return-type` is enabled by default
 
 ```
 
@@ -61,7 +61,7 @@ error[invalid-return-type]: Return type does not match returned value
 8 |
 9 | def f() -> int:
   |
-info: `lint:invalid-return-type` is enabled by default
+info: `invalid-return-type` is enabled by default
 
 ```
 
@@ -79,7 +79,7 @@ error[invalid-return-type]: Return type does not match returned value
 12 |
 13 | from typing import TypeVar
    |
-info: `lint:invalid-return-type` is enabled by default
+info: `invalid-return-type` is enabled by default
 
 ```
 
@@ -91,6 +91,6 @@ error[invalid-return-type]: Function can implicitly return `None`, which is not 
 18 | def m(x: T) -> T: ...
    |                ^
    |
-info: `lint:invalid-return-type` is enabled by default
+info: `invalid-return-type` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type.snap
@@ -35,7 +35,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/function/return_type.md
 # Diagnostics
 
 ```
-error: invalid-return-type: Function can implicitly return `None`, which is not assignable to return type `int`
+error[invalid-return-type]: Function can implicitly return `None`, which is not assignable to return type `int`
  --> src/mdtest_snippet.py:2:12
   |
 1 | # error: [invalid-return-type]
@@ -48,7 +48,7 @@ info: `lint:invalid-return-type` is enabled by default
 ```
 
 ```
-error: invalid-return-type: Return type does not match returned value
+error[invalid-return-type]: Return type does not match returned value
  --> src/mdtest_snippet.py:5:12
   |
 3 |     1
@@ -66,7 +66,7 @@ info: `lint:invalid-return-type` is enabled by default
 ```
 
 ```
-error: invalid-return-type: Return type does not match returned value
+error[invalid-return-type]: Return type does not match returned value
   --> src/mdtest_snippet.py:9:12
    |
  7 |     return 1
@@ -84,7 +84,7 @@ info: `lint:invalid-return-type` is enabled by default
 ```
 
 ```
-error: invalid-return-type: Function can implicitly return `None`, which is not assignable to return type `T`
+error[invalid-return-type]: Function can implicitly return `None`, which is not assignable to return type `T`
   --> src/mdtest_snippet.py:18:16
    |
 17 | # error: [invalid-return-type]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type_in_stub_file.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type_in_stub_file.snap
@@ -30,7 +30,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/function/return_type.md
 # Diagnostics
 
 ```
-error: invalid-return-type: Return type does not match returned value
+error[invalid-return-type]: Return type does not match returned value
  --> src/mdtest_snippet.pyi:1:12
   |
 1 | def f() -> int:
@@ -46,7 +46,7 @@ info: `lint:invalid-return-type` is enabled by default
 ```
 
 ```
-error: invalid-return-type: Function can implicitly return `None`, which is not assignable to return type `int`
+error[invalid-return-type]: Function can implicitly return `None`, which is not assignable to return type `int`
  --> src/mdtest_snippet.pyi:6:14
   |
 5 | # error: [invalid-return-type]
@@ -60,7 +60,7 @@ info: `lint:invalid-return-type` is enabled by default
 ```
 
 ```
-error: invalid-return-type: Function can implicitly return `None`, which is not assignable to return type `int`
+error[invalid-return-type]: Function can implicitly return `None`, which is not assignable to return type `int`
   --> src/mdtest_snippet.pyi:11:14
    |
 10 | # error: [invalid-return-type]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type_in_stub_file.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type_in_stub_file.snap
@@ -30,7 +30,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/function/return_type.md
 # Diagnostics
 
 ```
-error: lint:invalid-return-type: Return type does not match returned value
+error: invalid-return-type: Return type does not match returned value
  --> src/mdtest_snippet.pyi:1:12
   |
 1 | def f() -> int:
@@ -46,7 +46,7 @@ info: `lint:invalid-return-type` is enabled by default
 ```
 
 ```
-error: lint:invalid-return-type: Function can implicitly return `None`, which is not assignable to return type `int`
+error: invalid-return-type: Function can implicitly return `None`, which is not assignable to return type `int`
  --> src/mdtest_snippet.pyi:6:14
   |
 5 | # error: [invalid-return-type]
@@ -60,7 +60,7 @@ info: `lint:invalid-return-type` is enabled by default
 ```
 
 ```
-error: lint:invalid-return-type: Function can implicitly return `None`, which is not assignable to return type `int`
+error: invalid-return-type: Function can implicitly return `None`, which is not assignable to return type `int`
   --> src/mdtest_snippet.pyi:11:14
    |
 10 | # error: [invalid-return-type]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type_in_stub_file.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type_in_stub_file.snap
@@ -41,7 +41,7 @@ error[invalid-return-type]: Return type does not match returned value
 4 |
 5 | # error: [invalid-return-type]
   |
-info: `lint:invalid-return-type` is enabled by default
+info: `invalid-return-type` is enabled by default
 
 ```
 
@@ -55,7 +55,7 @@ error[invalid-return-type]: Function can implicitly return `None`, which is not 
 7 |     print("...")
 8 |     ...
   |
-info: `lint:invalid-return-type` is enabled by default
+info: `invalid-return-type` is enabled by default
 
 ```
 
@@ -69,6 +69,6 @@ error[invalid-return-type]: Function can implicitly return `None`, which is not 
 12 |     f"""{foo} is a function that ..."""
 13 |     ...
    |
-info: `lint:invalid-return-type` is enabled by default
+info: `invalid-return-type` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/rich_comparison.md_-_Comparison___Rich_Comparison_-_Chained_comparisons_with_objects_that_don't_implement_`__bool__`_correctly.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/rich_comparison.md_-_Comparison___Rich_Comparison_-_Chained_comparisons_with_objects_that_don't_implement_`__bool__`_correctly.snap
@@ -43,7 +43,7 @@ error[unsupported-bool-conversion]: Boolean conversion is unsupported for type `
 14 | 10 < Comparable() < Comparable()
    |
 info: `__bool__` on `NotBoolable` must be callable
-info: `lint:unsupported-bool-conversion` is enabled by default
+info: `unsupported-bool-conversion` is enabled by default
 
 ```
 
@@ -59,6 +59,6 @@ error[unsupported-bool-conversion]: Boolean conversion is unsupported for type `
 16 | Comparable() < Comparable()  # fine
    |
 info: `__bool__` on `NotBoolable` must be callable
-info: `lint:unsupported-bool-conversion` is enabled by default
+info: `unsupported-bool-conversion` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/rich_comparison.md_-_Comparison___Rich_Comparison_-_Chained_comparisons_with_objects_that_don't_implement_`__bool__`_correctly.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/rich_comparison.md_-_Comparison___Rich_Comparison_-_Chained_comparisons_with_objects_that_don't_implement_`__bool__`_correctly.snap
@@ -33,7 +33,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/comparison/instances/ric
 # Diagnostics
 
 ```
-error: unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable`
+error[unsupported-bool-conversion]: Boolean conversion is unsupported for type `NotBoolable`
   --> src/mdtest_snippet.py:12:1
    |
 11 | # error: [unsupported-bool-conversion]
@@ -48,7 +48,7 @@ info: `lint:unsupported-bool-conversion` is enabled by default
 ```
 
 ```
-error: unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable`
+error[unsupported-bool-conversion]: Boolean conversion is unsupported for type `NotBoolable`
   --> src/mdtest_snippet.py:14:1
    |
 12 | 10 < Comparable() < 20

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/rich_comparison.md_-_Comparison___Rich_Comparison_-_Chained_comparisons_with_objects_that_don't_implement_`__bool__`_correctly.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/rich_comparison.md_-_Comparison___Rich_Comparison_-_Chained_comparisons_with_objects_that_don't_implement_`__bool__`_correctly.snap
@@ -33,7 +33,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/comparison/instances/ric
 # Diagnostics
 
 ```
-error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable`
+error: unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable`
   --> src/mdtest_snippet.py:12:1
    |
 11 | # error: [unsupported-bool-conversion]
@@ -48,7 +48,7 @@ info: `lint:unsupported-bool-conversion` is enabled by default
 ```
 
 ```
-error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable`
+error: unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable`
   --> src/mdtest_snippet.py:14:1
    |
 12 | 10 < Comparable() < 20

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/semantic_syntax_errors.md_-_Semantic_syntax_error_diagnostics_-_`async`_comprehensions_in_synchronous_comprehensions_-_Python_3.10.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/semantic_syntax_errors.md_-_Semantic_syntax_error_diagnostics_-_`async`_comprehensions_in_synchronous_comprehensions_-_Python_3.10.snap
@@ -32,7 +32,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/semantic_syn
 # Diagnostics
 
 ```
-error: invalid-syntax
+error: invalid-syntax: 
  --> src/mdtest_snippet.py:6:19
   |
 4 | async def f():

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/semantic_syntax_errors.md_-_Semantic_syntax_error_diagnostics_-_`async`_comprehensions_in_synchronous_comprehensions_-_Python_3.10.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/semantic_syntax_errors.md_-_Semantic_syntax_error_diagnostics_-_`async`_comprehensions_in_synchronous_comprehensions_-_Python_3.10.snap
@@ -32,7 +32,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/semantic_syn
 # Diagnostics
 
 ```
-error: invalid-syntax: 
+error[invalid-syntax]
  --> src/mdtest_snippet.py:6:19
   |
 4 | async def f():

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/shadowing.md_-_Shadowing_-_Implicit_class_shadowing.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/shadowing.md_-_Shadowing_-_Implicit_class_shadowing.snap
@@ -20,7 +20,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/shadowing.md
 # Diagnostics
 
 ```
-error: invalid-assignment: Implicit shadowing of class `C`
+error[invalid-assignment]: Implicit shadowing of class `C`
  --> src/mdtest_snippet.py:3:1
   |
 1 | class C: ...

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/shadowing.md_-_Shadowing_-_Implicit_class_shadowing.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/shadowing.md_-_Shadowing_-_Implicit_class_shadowing.snap
@@ -20,7 +20,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/shadowing.md
 # Diagnostics
 
 ```
-error: lint:invalid-assignment: Implicit shadowing of class `C`
+error: invalid-assignment: Implicit shadowing of class `C`
  --> src/mdtest_snippet.py:3:1
   |
 1 | class C: ...

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/shadowing.md_-_Shadowing_-_Implicit_class_shadowing.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/shadowing.md_-_Shadowing_-_Implicit_class_shadowing.snap
@@ -29,6 +29,6 @@ error[invalid-assignment]: Implicit shadowing of class `C`
   | ^
   |
 info: Annotate to make it explicit if this is intentional
-info: `lint:invalid-assignment` is enabled by default
+info: `invalid-assignment` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/shadowing.md_-_Shadowing_-_Implicit_function_shadowing.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/shadowing.md_-_Shadowing_-_Implicit_function_shadowing.snap
@@ -29,6 +29,6 @@ error[invalid-assignment]: Implicit shadowing of function `f`
   | ^
   |
 info: Annotate to make it explicit if this is intentional
-info: `lint:invalid-assignment` is enabled by default
+info: `invalid-assignment` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/shadowing.md_-_Shadowing_-_Implicit_function_shadowing.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/shadowing.md_-_Shadowing_-_Implicit_function_shadowing.snap
@@ -20,7 +20,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/shadowing.md
 # Diagnostics
 
 ```
-error: lint:invalid-assignment: Implicit shadowing of function `f`
+error: invalid-assignment: Implicit shadowing of function `f`
  --> src/mdtest_snippet.py:3:1
   |
 1 | def f(): ...

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/shadowing.md_-_Shadowing_-_Implicit_function_shadowing.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/shadowing.md_-_Shadowing_-_Implicit_function_shadowing.snap
@@ -20,7 +20,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/shadowing.md
 # Diagnostics
 
 ```
-error: invalid-assignment: Implicit shadowing of function `f`
+error[invalid-assignment]: Implicit shadowing of function `f`
  --> src/mdtest_snippet.py:3:1
   |
 1 | def f(): ...

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/tuples.md_-_Comparison___Tuples_-_Chained_comparisons_with_elements_that_incorrectly_implement_`__bool__`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/tuples.md_-_Comparison___Tuples_-_Chained_comparisons_with_elements_that_incorrectly_implement_`__bool__`.snap
@@ -34,7 +34,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/comparison/tuples.md
 # Diagnostics
 
 ```
-error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable | Literal[False]`
+error: unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable | Literal[False]`
   --> src/mdtest_snippet.py:15:1
    |
 14 | # error: [unsupported-bool-conversion]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/tuples.md_-_Comparison___Tuples_-_Chained_comparisons_with_elements_that_incorrectly_implement_`__bool__`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/tuples.md_-_Comparison___Tuples_-_Chained_comparisons_with_elements_that_incorrectly_implement_`__bool__`.snap
@@ -44,6 +44,6 @@ error[unsupported-bool-conversion]: Boolean conversion is unsupported for type `
 17 | a < b  # fine
    |
 info: `__bool__` on `NotBoolable | Literal[False]` must be callable
-info: `lint:unsupported-bool-conversion` is enabled by default
+info: `unsupported-bool-conversion` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/tuples.md_-_Comparison___Tuples_-_Chained_comparisons_with_elements_that_incorrectly_implement_`__bool__`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/tuples.md_-_Comparison___Tuples_-_Chained_comparisons_with_elements_that_incorrectly_implement_`__bool__`.snap
@@ -34,7 +34,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/comparison/tuples.md
 # Diagnostics
 
 ```
-error: unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable | Literal[False]`
+error[unsupported-bool-conversion]: Boolean conversion is unsupported for type `NotBoolable | Literal[False]`
   --> src/mdtest_snippet.py:15:1
    |
 14 | # error: [unsupported-bool-conversion]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/tuples.md_-_Comparison___Tuples_-_Equality_with_elements_that_incorrectly_implement_`__bool__`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/tuples.md_-_Comparison___Tuples_-_Equality_with_elements_that_incorrectly_implement_`__bool__`.snap
@@ -26,7 +26,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/comparison/tuples.md
 # Diagnostics
 
 ```
-error: unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable`
+error[unsupported-bool-conversion]: Boolean conversion is unsupported for type `NotBoolable`
  --> src/mdtest_snippet.py:9:1
   |
 8 | # error: [unsupported-bool-conversion]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/tuples.md_-_Comparison___Tuples_-_Equality_with_elements_that_incorrectly_implement_`__bool__`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/tuples.md_-_Comparison___Tuples_-_Equality_with_elements_that_incorrectly_implement_`__bool__`.snap
@@ -26,7 +26,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/comparison/tuples.md
 # Diagnostics
 
 ```
-error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable`
+error: unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable`
  --> src/mdtest_snippet.py:9:1
   |
 8 | # error: [unsupported-bool-conversion]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/tuples.md_-_Comparison___Tuples_-_Equality_with_elements_that_incorrectly_implement_`__bool__`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/tuples.md_-_Comparison___Tuples_-_Equality_with_elements_that_incorrectly_implement_`__bool__`.snap
@@ -34,6 +34,6 @@ error[unsupported-bool-conversion]: Boolean conversion is unsupported for type `
   | ^^^^^^^^^^^^^^^^
   |
 info: `__bool__` on `NotBoolable` must be callable
-info: `lint:unsupported-bool-conversion` is enabled by default
+info: `unsupported-bool-conversion` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Exactly_too_few_values_to_unpack.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Exactly_too_few_values_to_unpack.snap
@@ -18,7 +18,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/unpacking.md
 # Diagnostics
 
 ```
-error: lint:invalid-assignment: Not enough values to unpack
+error: invalid-assignment: Not enough values to unpack
  --> src/mdtest_snippet.py:1:1
   |
 1 | a, b = (1,)  # error: [invalid-assignment]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Exactly_too_few_values_to_unpack.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Exactly_too_few_values_to_unpack.snap
@@ -26,6 +26,6 @@ error[invalid-assignment]: Not enough values to unpack
   | |
   | Expected 2
   |
-info: `lint:invalid-assignment` is enabled by default
+info: `invalid-assignment` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Exactly_too_few_values_to_unpack.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Exactly_too_few_values_to_unpack.snap
@@ -18,7 +18,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/unpacking.md
 # Diagnostics
 
 ```
-error: invalid-assignment: Not enough values to unpack
+error[invalid-assignment]: Not enough values to unpack
  --> src/mdtest_snippet.py:1:1
   |
 1 | a, b = (1,)  # error: [invalid-assignment]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Exactly_too_many_values_to_unpack.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Exactly_too_many_values_to_unpack.snap
@@ -18,7 +18,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/unpacking.md
 # Diagnostics
 
 ```
-error: lint:invalid-assignment: Too many values to unpack
+error: invalid-assignment: Too many values to unpack
  --> src/mdtest_snippet.py:1:1
   |
 1 | a, b = (1, 2, 3)  # error: [invalid-assignment]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Exactly_too_many_values_to_unpack.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Exactly_too_many_values_to_unpack.snap
@@ -18,7 +18,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/unpacking.md
 # Diagnostics
 
 ```
-error: invalid-assignment: Too many values to unpack
+error[invalid-assignment]: Too many values to unpack
  --> src/mdtest_snippet.py:1:1
   |
 1 | a, b = (1, 2, 3)  # error: [invalid-assignment]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Exactly_too_many_values_to_unpack.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Exactly_too_many_values_to_unpack.snap
@@ -26,6 +26,6 @@ error[invalid-assignment]: Too many values to unpack
   | |
   | Expected 2
   |
-info: `lint:invalid-assignment` is enabled by default
+info: `invalid-assignment` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Right_hand_side_not_iterable.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Right_hand_side_not_iterable.snap
@@ -18,7 +18,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/unpacking.md
 # Diagnostics
 
 ```
-error: not-iterable: Object of type `Literal[1]` is not iterable
+error[not-iterable]: Object of type `Literal[1]` is not iterable
  --> src/mdtest_snippet.py:1:8
   |
 1 | a, b = 1  # error: [not-iterable]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Right_hand_side_not_iterable.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Right_hand_side_not_iterable.snap
@@ -18,7 +18,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/unpacking.md
 # Diagnostics
 
 ```
-error: lint:not-iterable: Object of type `Literal[1]` is not iterable
+error: not-iterable: Object of type `Literal[1]` is not iterable
  --> src/mdtest_snippet.py:1:8
   |
 1 | a, b = 1  # error: [not-iterable]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Right_hand_side_not_iterable.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Right_hand_side_not_iterable.snap
@@ -25,6 +25,6 @@ error[not-iterable]: Object of type `Literal[1]` is not iterable
   |        ^
   |
 info: It doesn't have an `__iter__` method or a `__getitem__` method
-info: `lint:not-iterable` is enabled by default
+info: `not-iterable` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Too_few_values_to_unpack.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Too_few_values_to_unpack.snap
@@ -18,7 +18,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/unpacking.md
 # Diagnostics
 
 ```
-error: lint:invalid-assignment: Not enough values to unpack
+error: invalid-assignment: Not enough values to unpack
  --> src/mdtest_snippet.py:1:1
   |
 1 | [a, *b, c, d] = (1, 2)  # error: [invalid-assignment]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Too_few_values_to_unpack.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Too_few_values_to_unpack.snap
@@ -26,6 +26,6 @@ error[invalid-assignment]: Not enough values to unpack
   | |
   | Expected 3 or more
   |
-info: `lint:invalid-assignment` is enabled by default
+info: `invalid-assignment` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Too_few_values_to_unpack.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Too_few_values_to_unpack.snap
@@ -18,7 +18,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/unpacking.md
 # Diagnostics
 
 ```
-error: invalid-assignment: Not enough values to unpack
+error[invalid-assignment]: Not enough values to unpack
  --> src/mdtest_snippet.py:1:1
   |
 1 | [a, *b, c, d] = (1, 2)  # error: [invalid-assignment]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_An_unresolvable_import_that_does_not_use_`from`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_An_unresolvable_import_that_does_not_use_`from`.snap
@@ -28,6 +28,6 @@ error[unresolved-import]: Cannot resolve imported module `does_not_exist`
 2 |
 3 | x = does_not_exist.foo
   |
-info: `lint:unresolved-import` is enabled by default
+info: `unresolved-import` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_An_unresolvable_import_that_does_not_use_`from`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_An_unresolvable_import_that_does_not_use_`from`.snap
@@ -20,7 +20,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/unresolved_i
 # Diagnostics
 
 ```
-error: lint:unresolved-import: Cannot resolve imported module `does_not_exist`
+error: unresolved-import: Cannot resolve imported module `does_not_exist`
  --> src/mdtest_snippet.py:1:8
   |
 1 | import does_not_exist  # error: [unresolved-import]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_An_unresolvable_import_that_does_not_use_`from`.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_An_unresolvable_import_that_does_not_use_`from`.snap
@@ -20,7 +20,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/unresolved_i
 # Diagnostics
 
 ```
-error: unresolved-import: Cannot resolve imported module `does_not_exist`
+error[unresolved-import]: Cannot resolve imported module `does_not_exist`
  --> src/mdtest_snippet.py:1:8
   |
 1 | import does_not_exist  # error: [unresolved-import]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_a_resolvable_module_but_unresolvable_item.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_a_resolvable_module_but_unresolvable_item.snap
@@ -25,7 +25,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/unresolved_i
 # Diagnostics
 
 ```
-error: unresolved-import: Module `a` has no member `does_not_exist`
+error[unresolved-import]: Module `a` has no member `does_not_exist`
  --> src/mdtest_snippet.py:1:28
   |
 1 | from a import does_exist1, does_not_exist, does_exist2  # error: [unresolved-import]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_a_resolvable_module_but_unresolvable_item.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_a_resolvable_module_but_unresolvable_item.snap
@@ -25,7 +25,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/unresolved_i
 # Diagnostics
 
 ```
-error: lint:unresolved-import: Module `a` has no member `does_not_exist`
+error: unresolved-import: Module `a` has no member `does_not_exist`
  --> src/mdtest_snippet.py:1:28
   |
 1 | from a import does_exist1, does_not_exist, does_exist2  # error: [unresolved-import]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_a_resolvable_module_but_unresolvable_item.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_a_resolvable_module_but_unresolvable_item.snap
@@ -31,6 +31,6 @@ error[unresolved-import]: Module `a` has no member `does_not_exist`
 1 | from a import does_exist1, does_not_exist, does_exist2  # error: [unresolved-import]
   |                            ^^^^^^^^^^^^^^
   |
-info: `lint:unresolved-import` is enabled by default
+info: `unresolved-import` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_an_unknown_current_module.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_an_unknown_current_module.snap
@@ -28,6 +28,6 @@ error[unresolved-import]: Cannot resolve imported module `.does_not_exist`
 2 |
 3 | stat = add(10, 15)
   |
-info: `lint:unresolved-import` is enabled by default
+info: `unresolved-import` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_an_unknown_current_module.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_an_unknown_current_module.snap
@@ -20,7 +20,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/unresolved_i
 # Diagnostics
 
 ```
-error: unresolved-import: Cannot resolve imported module `.does_not_exist`
+error[unresolved-import]: Cannot resolve imported module `.does_not_exist`
  --> src/mdtest_snippet.py:1:7
   |
 1 | from .does_not_exist import add  # error: [unresolved-import]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_an_unknown_current_module.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_an_unknown_current_module.snap
@@ -20,7 +20,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/unresolved_i
 # Diagnostics
 
 ```
-error: lint:unresolved-import: Cannot resolve imported module `.does_not_exist`
+error: unresolved-import: Cannot resolve imported module `.does_not_exist`
  --> src/mdtest_snippet.py:1:7
   |
 1 | from .does_not_exist import add  # error: [unresolved-import]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_an_unknown_nested_module.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_an_unknown_nested_module.snap
@@ -28,6 +28,6 @@ error[unresolved-import]: Cannot resolve imported module `.does_not_exist.foo.ba
 2 |
 3 | stat = add(10, 15)
   |
-info: `lint:unresolved-import` is enabled by default
+info: `unresolved-import` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_an_unknown_nested_module.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_an_unknown_nested_module.snap
@@ -20,7 +20,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/unresolved_i
 # Diagnostics
 
 ```
-error: unresolved-import: Cannot resolve imported module `.does_not_exist.foo.bar`
+error[unresolved-import]: Cannot resolve imported module `.does_not_exist.foo.bar`
  --> src/mdtest_snippet.py:1:7
   |
 1 | from .does_not_exist.foo.bar import add  # error: [unresolved-import]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_an_unknown_nested_module.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_an_unknown_nested_module.snap
@@ -20,7 +20,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/unresolved_i
 # Diagnostics
 
 ```
-error: lint:unresolved-import: Cannot resolve imported module `.does_not_exist.foo.bar`
+error: unresolved-import: Cannot resolve imported module `.does_not_exist.foo.bar`
  --> src/mdtest_snippet.py:1:7
   |
 1 | from .does_not_exist.foo.bar import add  # error: [unresolved-import]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_an_unresolvable_module.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_an_unresolvable_module.snap
@@ -28,6 +28,6 @@ error[unresolved-import]: Cannot resolve imported module `does_not_exist`
 2 |
 3 | stat = add(10, 15)
   |
-info: `lint:unresolved-import` is enabled by default
+info: `unresolved-import` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_an_unresolvable_module.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_an_unresolvable_module.snap
@@ -20,7 +20,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/unresolved_i
 # Diagnostics
 
 ```
-error: lint:unresolved-import: Cannot resolve imported module `does_not_exist`
+error: unresolved-import: Cannot resolve imported module `does_not_exist`
  --> src/mdtest_snippet.py:1:6
   |
 1 | from does_not_exist import add  # error: [unresolved-import]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_an_unresolvable_module.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_an_unresolvable_module.snap
@@ -20,7 +20,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/unresolved_i
 # Diagnostics
 
 ```
-error: unresolved-import: Cannot resolve imported module `does_not_exist`
+error[unresolved-import]: Cannot resolve imported module `does_not_exist`
  --> src/mdtest_snippet.py:1:6
   |
 1 | from does_not_exist import add  # error: [unresolved-import]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_too_many_leading_dots.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_too_many_leading_dots.snap
@@ -40,6 +40,6 @@ error[unresolved-import]: Cannot resolve imported module `....foo`
 2 |
 3 | stat = add(10, 15)
   |
-info: `lint:unresolved-import` is enabled by default
+info: `unresolved-import` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_too_many_leading_dots.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_too_many_leading_dots.snap
@@ -32,7 +32,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/unresolved_i
 # Diagnostics
 
 ```
-error: unresolved-import: Cannot resolve imported module `....foo`
+error[unresolved-import]: Cannot resolve imported module `....foo`
  --> src/package/subpackage/subsubpackage/__init__.py:1:10
   |
 1 | from ....foo import add  # error: [unresolved-import]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_too_many_leading_dots.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_diagnostics_-_Using_`from`_with_too_many_leading_dots.snap
@@ -32,7 +32,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/unresolved_i
 # Diagnostics
 
 ```
-error: lint:unresolved-import: Cannot resolve imported module `....foo`
+error: unresolved-import: Cannot resolve imported module `....foo`
  --> src/package/subpackage/subsubpackage/__init__.py:1:10
   |
 1 | from ....foo import add  # error: [unresolved-import]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_conversion.md_-_Different_ways_that_`unsupported-bool-conversion`_can_occur_-_Has_a_`__bool__`_attribute,_but_it's_not_callable.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_conversion.md_-_Different_ways_that_`unsupported-bool-conversion`_can_occur_-_Has_a_`__bool__`_attribute,_but_it's_not_callable.snap
@@ -24,7 +24,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/unsupported_
 # Diagnostics
 
 ```
-error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable`
+error: unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable`
  --> src/mdtest_snippet.py:7:8
   |
 6 | # error: [unsupported-bool-conversion]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_conversion.md_-_Different_ways_that_`unsupported-bool-conversion`_can_occur_-_Has_a_`__bool__`_attribute,_but_it's_not_callable.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_conversion.md_-_Different_ways_that_`unsupported-bool-conversion`_can_occur_-_Has_a_`__bool__`_attribute,_but_it's_not_callable.snap
@@ -24,7 +24,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/unsupported_
 # Diagnostics
 
 ```
-error: unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable`
+error[unsupported-bool-conversion]: Boolean conversion is unsupported for type `NotBoolable`
  --> src/mdtest_snippet.py:7:8
   |
 6 | # error: [unsupported-bool-conversion]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_conversion.md_-_Different_ways_that_`unsupported-bool-conversion`_can_occur_-_Has_a_`__bool__`_attribute,_but_it's_not_callable.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_conversion.md_-_Different_ways_that_`unsupported-bool-conversion`_can_occur_-_Has_a_`__bool__`_attribute,_but_it's_not_callable.snap
@@ -32,6 +32,6 @@ error[unsupported-bool-conversion]: Boolean conversion is unsupported for type `
   |        ^
   |
 info: `__bool__` on `NotBoolable` must be callable
-info: `lint:unsupported-bool-conversion` is enabled by default
+info: `unsupported-bool-conversion` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_conversion.md_-_Different_ways_that_`unsupported-bool-conversion`_can_occur_-_Has_a_`__bool__`_method,_but_has_an_incorrect_return_type.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_conversion.md_-_Different_ways_that_`unsupported-bool-conversion`_can_occur_-_Has_a_`__bool__`_method,_but_has_an_incorrect_return_type.snap
@@ -25,7 +25,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/unsupported_
 # Diagnostics
 
 ```
-error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable`
+error: unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable`
  --> src/mdtest_snippet.py:8:8
   |
 7 | # error: [unsupported-bool-conversion]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_conversion.md_-_Different_ways_that_`unsupported-bool-conversion`_can_occur_-_Has_a_`__bool__`_method,_but_has_an_incorrect_return_type.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_conversion.md_-_Different_ways_that_`unsupported-bool-conversion`_can_occur_-_Has_a_`__bool__`_method,_but_has_an_incorrect_return_type.snap
@@ -25,7 +25,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/unsupported_
 # Diagnostics
 
 ```
-error: unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable`
+error[unsupported-bool-conversion]: Boolean conversion is unsupported for type `NotBoolable`
  --> src/mdtest_snippet.py:8:8
   |
 7 | # error: [unsupported-bool-conversion]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_conversion.md_-_Different_ways_that_`unsupported-bool-conversion`_can_occur_-_Has_a_`__bool__`_method,_but_has_an_incorrect_return_type.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_conversion.md_-_Different_ways_that_`unsupported-bool-conversion`_can_occur_-_Has_a_`__bool__`_method,_but_has_an_incorrect_return_type.snap
@@ -42,6 +42,6 @@ info: `str` is not assignable to `bool`
   |         Method defined here
 3 |         return "wat"
   |
-info: `lint:unsupported-bool-conversion` is enabled by default
+info: `unsupported-bool-conversion` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_conversion.md_-_Different_ways_that_`unsupported-bool-conversion`_can_occur_-_Has_a_`__bool__`_method,_but_has_incorrect_parameters.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_conversion.md_-_Different_ways_that_`unsupported-bool-conversion`_can_occur_-_Has_a_`__bool__`_method,_but_has_incorrect_parameters.snap
@@ -42,6 +42,6 @@ info: `__bool__` methods must only have a `self` parameter
   |         Method defined here
 3 |         return False
   |
-info: `lint:unsupported-bool-conversion` is enabled by default
+info: `unsupported-bool-conversion` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_conversion.md_-_Different_ways_that_`unsupported-bool-conversion`_can_occur_-_Has_a_`__bool__`_method,_but_has_incorrect_parameters.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_conversion.md_-_Different_ways_that_`unsupported-bool-conversion`_can_occur_-_Has_a_`__bool__`_method,_but_has_incorrect_parameters.snap
@@ -25,7 +25,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/unsupported_
 # Diagnostics
 
 ```
-error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable`
+error: unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable`
  --> src/mdtest_snippet.py:8:8
   |
 7 | # error: [unsupported-bool-conversion]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_conversion.md_-_Different_ways_that_`unsupported-bool-conversion`_can_occur_-_Has_a_`__bool__`_method,_but_has_incorrect_parameters.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_conversion.md_-_Different_ways_that_`unsupported-bool-conversion`_can_occur_-_Has_a_`__bool__`_method,_but_has_incorrect_parameters.snap
@@ -25,7 +25,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/unsupported_
 # Diagnostics
 
 ```
-error: unsupported-bool-conversion: Boolean conversion is unsupported for type `NotBoolable`
+error[unsupported-bool-conversion]: Boolean conversion is unsupported for type `NotBoolable`
  --> src/mdtest_snippet.py:8:8
   |
 7 | # error: [unsupported-bool-conversion]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_conversion.md_-_Different_ways_that_`unsupported-bool-conversion`_can_occur_-_Part_of_a_union_where_at_least_one_member_has_incorrect_`__bool__`_method.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_conversion.md_-_Different_ways_that_`unsupported-bool-conversion`_can_occur_-_Part_of_a_union_where_at_least_one_member_has_incorrect_`__bool__`_method.snap
@@ -32,7 +32,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/unsupported_
 # Diagnostics
 
 ```
-error: lint:unsupported-bool-conversion: Boolean conversion is unsupported for union `NotBoolable1 | NotBoolable2 | NotBoolable3` because `NotBoolable1` doesn't implement `__bool__` correctly
+error: unsupported-bool-conversion: Boolean conversion is unsupported for union `NotBoolable1 | NotBoolable2 | NotBoolable3` because `NotBoolable1` doesn't implement `__bool__` correctly
   --> src/mdtest_snippet.py:15:8
    |
 14 | # error: [unsupported-bool-conversion]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_conversion.md_-_Different_ways_that_`unsupported-bool-conversion`_can_occur_-_Part_of_a_union_where_at_least_one_member_has_incorrect_`__bool__`_method.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_conversion.md_-_Different_ways_that_`unsupported-bool-conversion`_can_occur_-_Part_of_a_union_where_at_least_one_member_has_incorrect_`__bool__`_method.snap
@@ -32,7 +32,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/unsupported_
 # Diagnostics
 
 ```
-error: unsupported-bool-conversion: Boolean conversion is unsupported for union `NotBoolable1 | NotBoolable2 | NotBoolable3` because `NotBoolable1` doesn't implement `__bool__` correctly
+error[unsupported-bool-conversion]: Boolean conversion is unsupported for union `NotBoolable1 | NotBoolable2 | NotBoolable3` because `NotBoolable1` doesn't implement `__bool__` correctly
   --> src/mdtest_snippet.py:15:8
    |
 14 | # error: [unsupported-bool-conversion]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_conversion.md_-_Different_ways_that_`unsupported-bool-conversion`_can_occur_-_Part_of_a_union_where_at_least_one_member_has_incorrect_`__bool__`_method.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_conversion.md_-_Different_ways_that_`unsupported-bool-conversion`_can_occur_-_Part_of_a_union_where_at_least_one_member_has_incorrect_`__bool__`_method.snap
@@ -39,6 +39,6 @@ error[unsupported-bool-conversion]: Boolean conversion is unsupported for union 
 15 | 10 and get() and True
    |        ^^^^^
    |
-info: `lint:unsupported-bool-conversion` is enabled by default
+info: `unsupported-bool-conversion` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/version_related_syntax_errors.md_-_Version-related_syntax_error_diagnostics_-_`match`_statement_-_Before_3.10.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/version_related_syntax_errors.md_-_Version-related_syntax_error_diagnostics_-_`match`_statement_-_Before_3.10.snap
@@ -20,7 +20,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/version_rela
 # Diagnostics
 
 ```
-error: invalid-syntax
+error: invalid-syntax: 
  --> src/mdtest_snippet.py:1:1
   |
 1 | match 2:  # error: 1 [invalid-syntax] "Cannot use `match` statement on Python 3.9 (syntax was added in Python 3.10)"

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/version_related_syntax_errors.md_-_Version-related_syntax_error_diagnostics_-_`match`_statement_-_Before_3.10.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/version_related_syntax_errors.md_-_Version-related_syntax_error_diagnostics_-_`match`_statement_-_Before_3.10.snap
@@ -20,7 +20,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/version_rela
 # Diagnostics
 
 ```
-error: invalid-syntax: 
+error[invalid-syntax]
  --> src/mdtest_snippet.py:1:1
   |
 1 | match 2:  # error: 1 [invalid-syntax] "Cannot use `match` statement on Python 3.9 (syntax was added in Python 3.10)"

--- a/crates/ty_wasm/tests/api.rs
+++ b/crates/ty_wasm/tests/api.rs
@@ -22,7 +22,7 @@ fn check() {
 
     let diagnostic = &result[0];
 
-    assert_eq!(diagnostic.id(), "lint:unresolved-import");
+    assert_eq!(diagnostic.id(), "unresolved-import");
     assert_eq!(
         diagnostic.to_range(&workspace).unwrap().start,
         Position { line: 1, column: 8 }


### PR DESCRIPTION
This also puts the lint ID into brackets attached to the severity.

That is, this:

```
error: lint:invalid-argument-type: Argument to this function is incorrect
```

is changed to:

```
error[invalid-argument-type]: Argument to this function is incorrect
```

Fixes #289 