### PR TITLE
Exclude broken symlinks from `meson-python` ecosystem check

### DIFF
--- a/python/ruff-ecosystem/ruff_ecosystem/defaults.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/defaults.py
@@ -4,6 +4,7 @@ Default projects for ecosystem checks
 
 from ruff_ecosystem.projects import (
     CheckOptions,
+    FormatOptions,
     Project,
     Repository,
 )
@@ -134,7 +135,10 @@ DEFAULT_TARGETS = [
     Project(repo=Repository(owner="wntrblm", name="nox", ref="main")),
     Project(repo=Repository(owner="pytest-dev", name="pytest", ref="main")),
     Project(repo=Repository(owner="encode", name="httpx", ref="master")),
-    Project(repo=Repository(owner="mesonbuild", name="meson-python", ref="main")),
+    Project(
+        repo=Repository(owner="mesonbuild", name="meson-python", ref="main"),
+        format_options=FormatOptions(exclude="tests/packages/symlinks/{baz,qux}.py"),
+    ),
     Project(repo=Repository(owner="pdm-project", name="pdm", ref="main")),
     Project(repo=Repository(owner="astropy", name="astropy", ref="main")),
 ]

--- a/python/ruff-ecosystem/ruff_ecosystem/defaults.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/defaults.py
@@ -137,7 +137,9 @@ DEFAULT_TARGETS = [
     Project(repo=Repository(owner="encode", name="httpx", ref="master")),
     Project(
         repo=Repository(owner="mesonbuild", name="meson-python", ref="main"),
-        format_options=FormatOptions(exclude="tests/packages/symlinks/{baz,qux}.py"),
+        format_options=FormatOptions(
+            exclude=["tests/packages/symlinks/baz.py", "tests/packages/symlinks/qux.py"]
+        ),
     ),
     Project(repo=Repository(owner="pdm-project", name="pdm", ref="main")),
     Project(repo=Repository(owner="astropy", name="astropy", ref="main")),

--- a/python/ruff-ecosystem/ruff_ecosystem/defaults.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/defaults.py
@@ -138,7 +138,7 @@ DEFAULT_TARGETS = [
     Project(
         repo=Repository(owner="mesonbuild", name="meson-python", ref="main"),
         format_options=FormatOptions(
-            exclude=["tests/packages/symlinks/baz.py", "tests/packages/symlinks/qux.py"]
+            exclude="tests/packages/symlinks/baz.py,tests/packages/symlinks/qux.py"
         ),
     ),
     Project(repo=Repository(owner="pdm-project", name="pdm", ref="main")),


### PR DESCRIPTION
Summary
--

This should resolve the formatter ecosystem errors we've been seeing lately. https://github.com/mesonbuild/meson-python/pull/728 added the links, which I think are intentionally broken for testing purposes.

Test Plan
--

Ecosystem check on this PR
