### PR TITLE
[ty] WIP: Disambiguate legacy typevars

### DIFF
--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -338,7 +338,7 @@ impl<'db> OverloadLiteral<'db> {
         let definition = self.definition(db);
         let generic_context = function_stmt_node.type_params.as_ref().map(|type_params| {
             let index = semantic_index(db, scope.file(db));
-            GenericContext::from_type_params(db, index, type_params)
+            GenericContext::from_type_params(db, index, type_params, definition)
         });
         Signature::from_function(
             db,

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -8800,7 +8800,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
             })
             .collect();
-        typevars.map(|typevars| GenericContext::new(self.db(), typevars))
+        typevars.map(|typevars| GenericContext::new(self.db(), typevars, None))
     }
 
     fn infer_slice_expression(&mut self, slice: &ast::ExprSlice) -> Type<'db> {

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -331,7 +331,7 @@ impl<'db> Signature<'db> {
             }
         });
         let legacy_generic_context =
-            GenericContext::from_function_params(db, &parameters, return_ty);
+            GenericContext::from_function_params(db, &parameters, return_ty, definition);
 
         if generic_context.is_some() && legacy_generic_context.is_some() {
             // TODO: Raise a diagnostic!


### PR DESCRIPTION
This addresses @carljm's comment https://github.com/astral-sh/ruff/pull/17956#pullrequestreview-2826559665 about wanting to disambiguate legacy typevars that are used in multiple generic contexts.

WIP, not ready for review yet