### PR TITLE
add test for typing_extensions.Self

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -50,6 +50,23 @@ class Outer:
             return self
 ```
 
+## typing_extensions
+
+```toml
+[environment]
+python-version = "3.10"
+```
+
+```py
+from typing_extensions import Self
+
+class C:
+    def method(self: Self) -> Self:
+        return self
+
+reveal_type(C().method())  # revealed: C
+```
+
 ## Class Methods
 
 ```toml

--- a/crates/ty_python_semantic/src/types/known_instance.rs
+++ b/crates/ty_python_semantic/src/types/known_instance.rs
@@ -86,8 +86,7 @@ pub enum KnownInstanceType<'db> {
     /// The symbol `typing.Callable`
     /// (which can also be found as `typing_extensions.Callable` or as `collections.abc.Callable`)
     Callable,
-
-    /// The symbol `typing.Self`
+    /// The symbol `typing.Self` (which can also be found as `typing_extensions.Self`)
     TypingSelf,
 
     // Various special forms, special aliases and type qualifiers that we don't yet understand


### PR DESCRIPTION
Using `typing_extensions.Self` already worked, but we were lacking a test for it.