### PR TITLE
[ty] Understand homogeneous tuple annotations

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/starred.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/starred.md
@@ -19,5 +19,5 @@ def append_int(*args: *Ts) -> tuple[*Ts, int]:
     return (*args, 1)
 
 # TODO should be tuple[Literal[True], Literal["a"], int]
-reveal_type(append_int(True, "a"))  # revealed: @Todo(full tuple[...] support)
+reveal_type(append_int(True, "a"))  # revealed: @Todo(PEP 646)
 ```

--- a/crates/ty_python_semantic/resources/mdtest/annotations/starred.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/starred.md
@@ -13,8 +13,7 @@ from typing_extensions import TypeVarTuple
 Ts = TypeVarTuple("Ts")
 
 def append_int(*args: *Ts) -> tuple[*Ts, int]:
-    # TODO: tuple[*Ts]
-    reveal_type(args)  # revealed: tuple[Unknown, ...]
+    reveal_type(args)  # revealed: @Todo(PEP 646)
 
     return (*args, 1)
 

--- a/crates/ty_python_semantic/resources/mdtest/annotations/unsupported_special_forms.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/unsupported_special_forms.md
@@ -15,16 +15,13 @@ R_co = TypeVar("R_co", covariant=True)
 Alias: TypeAlias = int
 
 def f(*args: Unpack[Ts]) -> tuple[Unpack[Ts]]:
-    # TODO: should understand the annotation
-    reveal_type(args)  # revealed: tuple[Unknown, ...]
-
+    reveal_type(args)  # revealed: tuple[@Todo(`Unpack[]` special form), ...]
     reveal_type(Alias)  # revealed: @Todo(Support for `typing.TypeAlias`)
 
 def g() -> TypeGuard[int]: ...
 def h() -> TypeIs[int]: ...
 def i(callback: Callable[Concatenate[int, P], R_co], *args: P.args, **kwargs: P.kwargs) -> R_co:
-    # TODO: should understand the annotation
-    reveal_type(args)  # revealed: tuple[Unknown, ...]
+    reveal_type(args)  # revealed: tuple[@Todo(Support for `typing.ParamSpec`), ...]
     reveal_type(kwargs)  # revealed: dict[str, @Todo(Support for `typing.ParamSpec`)]
     return callback(42, *args, **kwargs)
 

--- a/crates/ty_python_semantic/resources/mdtest/assignment/annotations.md
+++ b/crates/ty_python_semantic/resources/mdtest/assignment/annotations.md
@@ -56,13 +56,13 @@ reveal_type(a)  # revealed: tuple[()]
 reveal_type(b)  # revealed: tuple[int]
 reveal_type(c)  # revealed: tuple[str, int]
 reveal_type(d)  # revealed: tuple[tuple[str, str], tuple[int, int]]
+reveal_type(e)  # revealed: tuple[str, ...]
 
-# TODO: homogeneous tuples, PEP-646 tuples, generics
-reveal_type(e)  # revealed: @Todo(full tuple[...] support)
+# TODO: PEP-646 tuples
 reveal_type(f)  # revealed: @Todo(full tuple[...] support)
 reveal_type(g)  # revealed: @Todo(full tuple[...] support)
-reveal_type(h)  # revealed: tuple[list[int], list[int]]
 
+reveal_type(h)  # revealed: tuple[list[int], list[int]]
 reveal_type(i)  # revealed: tuple[str | int, str | int]
 reveal_type(j)  # revealed: tuple[str | int]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/assignment/annotations.md
+++ b/crates/ty_python_semantic/resources/mdtest/assignment/annotations.md
@@ -58,9 +58,8 @@ reveal_type(c)  # revealed: tuple[str, int]
 reveal_type(d)  # revealed: tuple[tuple[str, str], tuple[int, int]]
 reveal_type(e)  # revealed: tuple[str, ...]
 
-# TODO: PEP-646 tuples
-reveal_type(f)  # revealed: @Todo(full tuple[...] support)
-reveal_type(g)  # revealed: @Todo(full tuple[...] support)
+reveal_type(f)  # revealed: @Todo(PEP 646)
+reveal_type(g)  # revealed: @Todo(PEP 646)
 
 reveal_type(h)  # revealed: tuple[list[int], list[int]]
 reveal_type(i)  # revealed: tuple[str | int, str | int]

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -1676,7 +1676,7 @@ functions are instances of that class:
 ```py
 def f(): ...
 
-reveal_type(f.__defaults__)  # revealed: @Todo(full tuple[...] support) | None
+reveal_type(f.__defaults__)  # revealed: tuple[Any, ...] | None
 reveal_type(f.__kwdefaults__)  # revealed: dict[str, Any] | None
 ```
 
@@ -1730,7 +1730,7 @@ All attribute access on literal `bytes` types is currently delegated to `builtin
 ```py
 # revealed: bound method Literal[b"foo"].join(iterable_of_bytes: Iterable[@Todo(Support for `typing.TypeAlias`)], /) -> bytes
 reveal_type(b"foo".join)
-# revealed: bound method Literal[b"foo"].endswith(suffix: @Todo(Support for `typing.TypeAlias`), start: SupportsIndex | None = ellipsis, end: SupportsIndex | None = ellipsis, /) -> bool
+# revealed: bound method Literal[b"foo"].endswith(suffix: @Todo(Support for `typing.TypeAlias`) | tuple[@Todo(Support for `typing.TypeAlias`), ...], start: SupportsIndex | None = ellipsis, end: SupportsIndex | None = ellipsis, /) -> bool
 reveal_type(b"foo".endswith)
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/binary/instances.md
+++ b/crates/ty_python_semantic/resources/mdtest/binary/instances.md
@@ -317,8 +317,7 @@ reveal_type(A() + b"foo")  # revealed: A
 reveal_type(b"foo" + A())  # revealed: bytes
 
 reveal_type(A() + ())  # revealed: A
-# TODO this should be `A`, since `tuple.__add__` doesn't support `A` instances
-reveal_type(() + A())  # revealed: @Todo(full tuple[...] support)
+reveal_type(() + A())  # revealed: A
 
 literal_string_instance = "foo" * 1_000_000_000
 # the test is not testing what it's meant to be testing if this isn't a `LiteralString`:

--- a/crates/ty_python_semantic/resources/mdtest/binary/tuples.md
+++ b/crates/ty_python_semantic/resources/mdtest/binary/tuples.md
@@ -17,6 +17,9 @@ def _(x: tuple[int, str], y: tuple[None, tuple[int]]):
 
 ```py
 def _(x: tuple[int, ...], y: tuple[str, ...]):
-    reveal_type(x + y)  # revealed: @Todo(full tuple[...] support)
-    reveal_type(x + (1, 2))  # revealed: @Todo(full tuple[...] support)
+    # error: [unsupported-operator] "Operator `+` is unsupported between objects of type `tuple[int, ...]` and `tuple[str, ...]`"
+    reveal_type(x + y)  # revealed: Unknown
+
+    # TODO: should be `tuple[int, ...]`
+    reveal_type(x + (1, 2))  # revealed: tuple[_T_co, ...]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/binary/tuples.md
+++ b/crates/ty_python_semantic/resources/mdtest/binary/tuples.md
@@ -20,6 +20,13 @@ def _(x: tuple[int, ...], y: tuple[str, ...]):
     # error: [unsupported-operator] "Operator `+` is unsupported between objects of type `tuple[int, ...]` and `tuple[str, ...]`"
     reveal_type(x + y)  # revealed: Unknown
 
-    # TODO: should be `tuple[int, ...]`
-    reveal_type(x + (1, 2))  # revealed: tuple[_T_co, ...]
+    # TODO: should be `tuple[int, ...]`, should not error
+    reveal_type(x + (1, 2))  # revealed: Unknown
+
+from typing import Literal
+from ty_extensions import static_assert, is_assignable_to
+
+static_assert(is_assignable_to(tuple[Literal[1], Literal[2]], tuple[Literal[1, 2], ...]))
+static_assert(is_assignable_to(tuple[Literal[1, 2], ...], tuple[int, ...]))
+static_assert(is_assignable_to(tuple[Literal[1], Literal[2]], tuple[int, ...]))
 ```

--- a/crates/ty_python_semantic/resources/mdtest/binary/tuples.md
+++ b/crates/ty_python_semantic/resources/mdtest/binary/tuples.md
@@ -17,16 +17,7 @@ def _(x: tuple[int, str], y: tuple[None, tuple[int]]):
 
 ```py
 def _(x: tuple[int, ...], y: tuple[str, ...]):
-    # error: [unsupported-operator] "Operator `+` is unsupported between objects of type `tuple[int, ...]` and `tuple[str, ...]`"
-    reveal_type(x + y)  # revealed: Unknown
-
-    # TODO: should be `tuple[int, ...]`, should not error
-    reveal_type(x + (1, 2))  # revealed: Unknown
-
-from typing import Literal
-from ty_extensions import static_assert, is_assignable_to
-
-static_assert(is_assignable_to(tuple[Literal[1], Literal[2]], tuple[Literal[1, 2], ...]))
-static_assert(is_assignable_to(tuple[Literal[1, 2], ...], tuple[int, ...]))
-static_assert(is_assignable_to(tuple[Literal[1], Literal[2]], tuple[int, ...]))
+    # TODO: should be `tuple[int | str, ...]`
+    reveal_type(x + y)  # revealed: tuple[int | Unknown, ...]
+    reveal_type(x + (1, 2))  # revealed: tuple[int, ...]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/call/builtins.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/builtins.md
@@ -54,7 +54,7 @@ type(b"Foo", (), {})
 # error: [no-matching-overload] "No overload of class `type` matches arguments"
 type("Foo", Base, {})
 
-# TODO: this should be an error
+# error: [no-matching-overload] "No overload of class `type` matches arguments"
 type("Foo", (1, 2), {})
 
 # TODO: this should be an error

--- a/crates/ty_python_semantic/resources/mdtest/exception/basic.md
+++ b/crates/ty_python_semantic/resources/mdtest/exception/basic.md
@@ -45,6 +45,8 @@ def foo(
     x: type[AttributeError],
     y: tuple[type[OSError], type[RuntimeError]],
     z: tuple[type[BaseException], ...],
+    zz: tuple[type[TypeError | RuntimeError], ...],
+    zzz: type[BaseException] | tuple[type[BaseException], ...],
 ):
     try:
         help()
@@ -53,8 +55,11 @@ def foo(
     except y as f:
         reveal_type(f)  # revealed: OSError | RuntimeError
     except z as g:
-        # TODO: should be `BaseException`
-        reveal_type(g)  # revealed: @Todo(full tuple[...] support)
+        reveal_type(g)  # revealed: BaseException
+    except zz as h:
+        reveal_type(h)  # revealed: TypeError | RuntimeError
+    except zzz as i:
+        reveal_type(i)  # revealed: BaseException
 ```
 
 ## Invalid exception handlers
@@ -86,9 +91,9 @@ def foo(
     # error: [invalid-exception-caught]
     except y as f:
         reveal_type(f)  # revealed: OSError | RuntimeError | Unknown
+    # error: [invalid-exception-caught]
     except z as g:
-        # TODO: should emit a diagnostic here:
-        reveal_type(g)  # revealed: @Todo(full tuple[...] support)
+        reveal_type(g)  # revealed: Unknown
 ```
 
 ## Object raised is not an exception

--- a/crates/ty_python_semantic/resources/mdtest/function/parameters.md
+++ b/crates/ty_python_semantic/resources/mdtest/function/parameters.md
@@ -25,8 +25,7 @@ def f(a, b: int, c=1, d: int = 2, /, e=3, f: Literal[4] = 4, *args: object, g=5,
     reveal_type(f)  # revealed: Literal[4]
     reveal_type(g)  # revealed: Unknown | Literal[5]
     reveal_type(h)  # revealed: Literal[6]
-    # TODO: should be `tuple[object, ...]`
-    reveal_type(args)  # revealed: tuple[Unknown, ...]
+    reveal_type(args)  # revealed: tuple[object, ...]
     reveal_type(kwargs)  # revealed: dict[str, str]
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
@@ -68,10 +68,7 @@ y: MyIntOrStr = None
 
 ```py
 type ListOrSet[T] = list[T] | set[T]
-
-# TODO: Should be `tuple[typing.TypeVar | typing.ParamSpec | typing.TypeVarTuple, ...]`,
-# as specified in the `typeshed` stubs.
-reveal_type(ListOrSet.__type_params__)  # revealed: @Todo(full tuple[...] support)
+reveal_type(ListOrSet.__type_params__)  # revealed: tuple[TypeVar | ParamSpec | TypeVarTuple, ...]
 ```
 
 ## `TypeAliasType` properties

--- a/crates/ty_python_semantic/resources/mdtest/subscript/tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/subscript/tuple.md
@@ -70,7 +70,7 @@ def _(m: int, n: int):
 
     tuple_slice = t[m:n]
     # TODO: Should be `tuple[Literal[1, 'a', b"b"] | None, ...]`
-    reveal_type(tuple_slice)  # revealed: @Todo(full tuple[...] support)
+    reveal_type(tuple_slice)  # revealed: tuple[Unknown, ...]
 ```
 
 ## Inheritance
@@ -101,7 +101,7 @@ class A: ...
 def _(c: Tuple, d: Tuple[int, A], e: Tuple[Any, ...]):
     reveal_type(c)  # revealed: tuple[Unknown, ...]
     reveal_type(d)  # revealed: tuple[int, A]
-    reveal_type(e)  # revealed: @Todo(full tuple[...] support)
+    reveal_type(e)  # revealed: tuple[Any, ...]
 ```
 
 ### Inheritance

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
@@ -198,7 +198,7 @@ static_assert(is_assignable_to(Meta, type[Any]))
 static_assert(is_assignable_to(Meta, type[Unknown]))
 ```
 
-## Tuple types
+## Heterogeneous tuple types
 
 ```py
 from ty_extensions import static_assert, is_assignable_to, AlwaysTruthy, AlwaysFalsy
@@ -230,6 +230,31 @@ static_assert(not is_assignable_to(tuple[int], tuple[int, str]))
 static_assert(not is_assignable_to(tuple[int, str], tuple[int]))
 static_assert(not is_assignable_to(tuple[int, int], tuple[Literal[1], int]))
 static_assert(not is_assignable_to(tuple[Any, Literal[2]], tuple[int, str]))
+```
+
+## Assignability of heterogeneous tuple types to homogeneous tuple types
+
+While a homogeneous tuple type is not assignable to any heterogeneous tuple types, a heterogeneous
+tuple type can be assignable to a homogeneous tuple type
+
+```py
+from typing import Literal, Any, Sequence
+from ty_extensions import static_assert, is_assignable_to, Not, AlwaysFalsy
+
+static_assert(is_assignable_to(tuple[Literal[1], Literal[2]], tuple[Literal[1, 2], ...]))
+static_assert(is_assignable_to(tuple[Literal[1], Literal[2]], tuple[int, ...]))
+static_assert(is_assignable_to(tuple[Literal[1], Literal[2]], tuple[int | str, ...]))
+static_assert(is_assignable_to(tuple[Literal[1], Literal[2]], tuple[Any, ...]))
+static_assert(is_assignable_to(tuple[Literal[1], Literal[2]], tuple[Not[AlwaysFalsy], ...]))
+static_assert(is_assignable_to(tuple[Literal[1], Literal[2]], Sequence[int]))
+
+static_assert(is_assignable_to(tuple[()], tuple[Literal[1, 2], ...]))
+static_assert(is_assignable_to(tuple[()], tuple[int, ...]))
+static_assert(is_assignable_to(tuple[()], tuple[int | str, ...]))
+static_assert(is_assignable_to(tuple[()], tuple[Not[AlwaysFalsy], ...]))
+static_assert(is_assignable_to(tuple[()], Sequence[int]))
+
+static_assert(not is_assignable_to(tuple[int, int], tuple[str, ...]))
 ```
 
 ## Union types

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
@@ -235,7 +235,8 @@ static_assert(not is_assignable_to(tuple[Any, Literal[2]], tuple[int, str]))
 ## Assignability of heterogeneous tuple types to homogeneous tuple types
 
 While a homogeneous tuple type is not assignable to any heterogeneous tuple types, a heterogeneous
-tuple type can be assignable to a homogeneous tuple type
+tuple type can be assignable to a homogeneous tuple type, and homogeneous tuple types can be
+assignable to `Sequence`:
 
 ```py
 from typing import Literal, Any, Sequence
@@ -247,6 +248,9 @@ static_assert(is_assignable_to(tuple[Literal[1], Literal[2]], tuple[int | str, .
 static_assert(is_assignable_to(tuple[Literal[1], Literal[2]], tuple[Any, ...]))
 static_assert(is_assignable_to(tuple[Literal[1], Literal[2]], tuple[Not[AlwaysFalsy], ...]))
 static_assert(is_assignable_to(tuple[Literal[1], Literal[2]], Sequence[int]))
+static_assert(is_assignable_to(tuple[int, ...], Sequence[int]))
+static_assert(is_assignable_to(tuple[int, ...], Sequence[Any]))
+static_assert(is_assignable_to(tuple[Any, ...], Sequence[int]))
 
 static_assert(is_assignable_to(tuple[()], tuple[Literal[1, 2], ...]))
 static_assert(is_assignable_to(tuple[()], tuple[int, ...]))

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
@@ -91,6 +91,10 @@ static_assert(is_disjoint_from(tuple[Literal[1], Literal[2]], tuple[Literal[1]])
 static_assert(is_disjoint_from(tuple[Literal[1], Literal[2]], tuple[Literal[1], Literal[3]]))
 
 static_assert(not is_disjoint_from(tuple[Literal[1], Literal[2]], tuple[Literal[1], int]))
+static_assert(not is_disjoint_from(tuple[Literal[1], Literal[2]], tuple[int, ...]))
+
+# TODO: should pass
+static_assert(is_disjoint_from(tuple[int, int], tuple[None, ...]))  # error: [static-assert-error]
 ```
 
 ## Unions

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_fully_static.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_fully_static.md
@@ -48,7 +48,9 @@ static_assert(not is_fully_static(Any | str))
 static_assert(not is_fully_static(str | Unknown))
 static_assert(not is_fully_static(Intersection[Any, Not[LiteralString]]))
 
-static_assert(not is_fully_static(tuple[Any, ...]))
+# TODO: should pass
+static_assert(not is_fully_static(tuple[Any, ...]))  # error: [static-assert-error]
+
 static_assert(not is_fully_static(tuple[int, Any]))
 static_assert(not is_fully_static(type[Any]))
 ```

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
@@ -156,7 +156,8 @@ static_assert(is_subtype_of(tuple[int], tuple[object, ...]))
 ## Subtyping of heterogeneous tuple types and homogeneous tuple types
 
 While a homogeneous tuple type is not a subtype of any heterogeneous tuple types, a heterogeneous
-tuple type can be a subtype of a homogeneous tuple type
+tuple type can be a subtype of a homogeneous tuple type, and homogeneous tuple types can be subtypes
+of `Sequence`:
 
 ```py
 from typing import Literal, Any, Sequence
@@ -167,6 +168,7 @@ static_assert(is_subtype_of(tuple[Literal[1], Literal[2]], tuple[int, ...]))
 static_assert(is_subtype_of(tuple[Literal[1], Literal[2]], tuple[int | str, ...]))
 static_assert(is_subtype_of(tuple[Literal[1], Literal[2]], tuple[Not[AlwaysFalsy], ...]))
 static_assert(is_subtype_of(tuple[Literal[1], Literal[2]], Sequence[int]))
+static_assert(is_subtype_of(tuple[int, ...], Sequence[int]))
 
 static_assert(is_subtype_of(tuple[()], tuple[Literal[1, 2], ...]))
 static_assert(is_subtype_of(tuple[()], tuple[int, ...]))
@@ -176,6 +178,8 @@ static_assert(is_subtype_of(tuple[()], Sequence[int]))
 
 static_assert(not is_subtype_of(tuple[Literal[1], Literal[2]], tuple[Any, ...]))
 static_assert(not is_subtype_of(tuple[int, int], tuple[str, ...]))
+static_assert(not is_subtype_of(tuple[int, ...], Sequence[Any]))
+static_assert(not is_subtype_of(tuple[Any, ...], Sequence[int]))
 ```
 
 ## Union types

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
@@ -118,7 +118,7 @@ static_assert(is_subtype_of(Literal[b"foo"], bytes))
 static_assert(is_subtype_of(Literal[b"foo"], object))
 ```
 
-## Tuple types
+## Heterogeneous tuple types
 
 ```py
 from ty_extensions import is_subtype_of, static_assert
@@ -151,6 +151,31 @@ static_assert(not is_subtype_of(tuple[B1, B2], tuple[()]))
 static_assert(not is_subtype_of(tuple[B1, B2], tuple[A1]))
 static_assert(not is_subtype_of(tuple[B1, B2], tuple[A1, A2, Unrelated]))
 static_assert(is_subtype_of(tuple[int], tuple[object, ...]))
+```
+
+## Subtyping of heterogeneous tuple types and homogeneous tuple types
+
+While a homogeneous tuple type is not a subtype of any heterogeneous tuple types, a heterogeneous
+tuple type can be a subtype of a homogeneous tuple type
+
+```py
+from typing import Literal, Any, Sequence
+from ty_extensions import static_assert, is_subtype_of, Not, AlwaysFalsy
+
+static_assert(is_subtype_of(tuple[Literal[1], Literal[2]], tuple[Literal[1, 2], ...]))
+static_assert(is_subtype_of(tuple[Literal[1], Literal[2]], tuple[int, ...]))
+static_assert(is_subtype_of(tuple[Literal[1], Literal[2]], tuple[int | str, ...]))
+static_assert(is_subtype_of(tuple[Literal[1], Literal[2]], tuple[Not[AlwaysFalsy], ...]))
+static_assert(is_subtype_of(tuple[Literal[1], Literal[2]], Sequence[int]))
+
+static_assert(is_subtype_of(tuple[()], tuple[Literal[1, 2], ...]))
+static_assert(is_subtype_of(tuple[()], tuple[int, ...]))
+static_assert(is_subtype_of(tuple[()], tuple[int | str, ...]))
+static_assert(is_subtype_of(tuple[()], tuple[Not[AlwaysFalsy], ...]))
+static_assert(is_subtype_of(tuple[()], Sequence[int]))
+
+static_assert(not is_subtype_of(tuple[Literal[1], Literal[2]], tuple[Any, ...]))
+static_assert(not is_subtype_of(tuple[int, int], tuple[str, ...]))
 ```
 
 ## Union types

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
@@ -150,9 +150,7 @@ static_assert(not is_subtype_of(tuple[B1, B2], tuple[Unrelated, Unrelated]))
 static_assert(not is_subtype_of(tuple[B1, B2], tuple[()]))
 static_assert(not is_subtype_of(tuple[B1, B2], tuple[A1]))
 static_assert(not is_subtype_of(tuple[B1, B2], tuple[A1, A2, Unrelated]))
-
-# TODO: should pass
-static_assert(is_subtype_of(tuple[int], tuple[object, ...]))  # error: [static-assert-error]
+static_assert(is_subtype_of(tuple[int], tuple[object, ...]))
 ```
 
 ## Union types

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1484,10 +1484,10 @@ impl<'db> Type<'db> {
                     )
             }
 
-            // These special cases are required because the left-hand side tuple might be a
+            // This special case is required because the left-hand side tuple might be a
             // gradual type, so we can not rely on subtyping. This allows us to assign e.g.
             // `tuple[Any, int]` to `tuple`.
-
+            //
             // `tuple[A, B, C]` is assignable to `tuple[A | B | C, ...]`
             (Type::Tuple(tuple), _)
                 if KnownClass::Tuple

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -8037,7 +8037,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 }
 
                 let ty = if return_todo {
-                    todo_type!("full tuple[...] support")
+                    todo_type!("PEP 646")
                 } else {
                     TupleType::from_elements(self.db(), element_types)
                 };
@@ -8053,7 +8053,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 let single_element_ty = self.infer_type_expression(single_element);
                 if element_could_alter_type_of_whole_tuple(single_element, single_element_ty, self)
                 {
-                    todo_type!("full tuple[...] support")
+                    todo_type!("PEP 646")
                 } else {
                     TupleType::from_elements(self.db(), std::iter::once(single_element_ty))
                 }

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -2473,16 +2473,32 @@ impl<'db> TypeInferenceBuilder<'db> {
         except_handler_definition: &ExceptHandlerDefinitionKind,
         definition: Definition<'db>,
     ) {
+        fn extract_tuple_specialization<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Type<'db>> {
+            let class = ty.into_nominal_instance()?.class();
+            if !class.is_known(db, KnownClass::Tuple) {
+                return None;
+            }
+            let ClassType::Generic(class) = class else {
+                return None;
+            };
+            let specialization = class.specialization(db).types(db)[0];
+            let specialization_instance = specialization.to_instance(db)?;
+
+            specialization_instance
+                .is_assignable_to(db, KnownClass::BaseException.to_instance(db))
+                .then_some(specialization_instance)
+        }
+
         let node = except_handler_definition.handled_exceptions();
 
         // If there is no handled exception, it's invalid syntax;
         // a diagnostic will have already been emitted
         let node_ty = node.map_or(Type::unknown(), |ty| self.infer_expression(ty));
+        let type_base_exception = KnownClass::BaseException.to_subclass_of(self.db());
 
         // If it's an `except*` handler, this won't actually be the type of the bound symbol;
         // it will actually be the type of the generic parameters to `BaseExceptionGroup` or `ExceptionGroup`.
         let symbol_ty = if let Type::Tuple(tuple) = node_ty {
-            let type_base_exception = KnownClass::BaseException.to_subclass_of(self.db());
             let mut builder = UnionBuilder::new(self.db());
             for element in tuple.elements(self.db()).iter().copied() {
                 builder = builder.add(
@@ -2500,27 +2516,37 @@ impl<'db> TypeInferenceBuilder<'db> {
                 );
             }
             builder.build()
-        } else if node_ty.is_subtype_of(self.db(), KnownClass::Tuple.to_instance(self.db())) {
-            todo_type!("Homogeneous tuple in exception handler")
+        } else if node_ty.is_assignable_to(self.db(), type_base_exception) {
+            node_ty.to_instance(self.db()).expect(
+                "`Type::to_instance()` should always return `Some()` \
+                    if called on a type assignable to `type[BaseException]`",
+            )
+        } else if node_ty.is_assignable_to(
+            self.db(),
+            KnownClass::Tuple.to_specialized_instance(self.db(), [type_base_exception]),
+        ) {
+            extract_tuple_specialization(self.db(), node_ty)
+                .unwrap_or_else(|| KnownClass::BaseException.to_instance(self.db()))
+        } else if node_ty.is_assignable_to(
+            self.db(),
+            UnionType::from_elements(
+                self.db(),
+                [
+                    type_base_exception,
+                    KnownClass::Tuple.to_specialized_instance(self.db(), [type_base_exception]),
+                ],
+            ),
+        ) {
+            KnownClass::BaseException.to_instance(self.db())
         } else {
-            let type_base_exception = KnownClass::BaseException.to_subclass_of(self.db());
-            if node_ty.is_assignable_to(self.db(), type_base_exception) {
-                node_ty.to_instance(self.db()).expect(
-                    "`Type::to_instance()` should always return `Some()` \
-                        if called on a type assignable to `type[BaseException]`",
-                )
-            } else {
-                if let Some(node) = node {
-                    report_invalid_exception_caught(&self.context, node, node_ty);
-                }
-                Type::unknown()
+            if let Some(node) = node {
+                report_invalid_exception_caught(&self.context, node, node_ty);
             }
+            Type::unknown()
         };
 
         let symbol_ty = if except_handler_definition.is_star() {
             // TODO: we should infer `ExceptionGroup` if `node_ty` is a subtype of `tuple[type[Exception], ...]`
-            // (needs support for homogeneous tuples).
-            //
             // TODO: should be generic with `symbol_ty` as the generic parameter
             KnownClass::BaseExceptionGroup.to_instance(self.db())
         } else {
@@ -7970,7 +7996,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             }
 
             match element {
-                ast::Expr::EllipsisLiteral(_) | ast::Expr::Starred(_) => true,
+                ast::Expr::Starred(_) => true,
                 ast::Expr::Subscript(ast::ExprSubscript { value, .. }) => {
                     let value_ty = if builder.deferred_state.in_string_annotation() {
                         // Using `.expression_type` does not work in string annotations, because
@@ -7980,17 +8006,23 @@ impl<'db> TypeInferenceBuilder<'db> {
                         builder.expression_type(value)
                     };
 
-                    matches!(value_ty, Type::KnownInstance(KnownInstanceType::Unpack))
+                    value_ty == Type::KnownInstance(KnownInstanceType::Unpack)
                 }
                 _ => false,
             }
         }
 
-        // TODO:
-        // - homogeneous tuples
-        // - PEP 646
+        // TODO: PEP 646
         match tuple_slice {
             ast::Expr::Tuple(elements) => {
+                if let [element, ellipsis @ ast::Expr::EllipsisLiteral(_)] = &*elements.elts {
+                    self.infer_expression(ellipsis);
+                    let result = KnownClass::Tuple
+                        .to_specialized_instance(self.db(), [self.infer_type_expression(element)]);
+                    self.store_expression_type(tuple_slice, result);
+                    return result;
+                }
+
                 let mut element_types = Vec::with_capacity(elements.len());
 
                 // Whether to infer `Todo` for the whole tuple


### PR DESCRIPTION
## Summary

With this PR, `ty` now understands that `tuple[int, ...]` should be understood as "take the generic `tuple` class in typeshed, and specialize it with a single `int` type argument".

Ironically, more code had to change in our exception-handling logic than in our type-expression-parsing logic here, in order to prevent regressions in our tests.

This PR is stacked on top of https://github.com/astral-sh/ruff/pull/18052, as without the fixes there this PR causes a prohibitive number of false-positive errors.

Closes https://github.com/astral-sh/ty/issues/237

## Test Plan

Existing mdtests updated.
