### PR TITLE
Skip S608 for expressionless f-strings

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_bandit/S608.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_bandit/S608.py
@@ -166,3 +166,6 @@ query60 = f"""
         foo
     FROM ({user_input}) raw
 """
+
+# https://github.com/astral-sh/ruff/issues/17967
+query61 = f"SELECT * FROM table" # skip expressionless f-strings

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_sql_expression.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_sql_expression.rs
@@ -100,7 +100,15 @@ pub(crate) fn hardcoded_sql_expression(checker: &Checker, expr: &Expr) {
         }
 
         // f"select * from table where val = {val}"
-        Expr::FString(f_string) => concatenated_f_string(f_string, checker.locator()),
+        Expr::FString(f_string)
+            if f_string
+                .value
+                .f_strings()
+                .any(|fs| fs.elements.iter().any(ast::FStringElement::is_expression)) =>
+        {
+            concatenated_f_string(f_string, checker.locator())
+        }
+
         _ => return,
     };
 

--- a/crates/ruff_linter/src/rules/flake8_bandit/snapshots/ruff_linter__rules__flake8_bandit__tests__S608_S608.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bandit/snapshots/ruff_linter__rules__flake8_bandit__tests__S608_S608.py.snap
@@ -601,4 +601,6 @@ S608.py:164:11: S608 Possible SQL injection vector through string-based query co
 167 | |     FROM ({user_input}) raw
 168 | | """
     | |___^ S608
+169 |
+170 |   # https://github.com/astral-sh/ruff/issues/17967
     |


### PR DESCRIPTION

<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->
Closes: #17967
## Summary
Skip `S608` for expressionless f-strings.
Expressionless f-strings are not vulnerable to SQL injections and F541 catches expressionless f-strings with an autofix.

This is achieved with guarding on the `S608` f-string match with an occurrence check for expressions within it; analogous to the implementation of F451. 


<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan
Added a test fixture and updated snapshot.

<!-- How was it tested? -->
