### PR TITLE
[ty] Silence false positives for PEP-695 ParamSpec annotations

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/callable.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/callable.md
@@ -249,10 +249,12 @@ Using a `ParamSpec` in a `Callable` annotation:
 ```py
 from typing_extensions import Callable
 
-# TODO: Not an error; remove once `ParamSpec` is supported
-# error: [invalid-type-form]
 def _[**P1](c: Callable[P1, int]):
-    reveal_type(c)  # revealed: (...) -> Unknown
+    reveal_type(P1.args)  # revealed: @Todo(ParamSpec)
+    reveal_type(P1.kwargs)  # revealed: @Todo(ParamSpec)
+
+    # TODO: Signature should be (**P1) -> int
+    reveal_type(c)  # revealed: (...) -> int
 ```
 
 And, using the legacy syntax:

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -76,7 +76,7 @@ impl<'db> ClassBase<'db> {
             ClassBase::Class(class) => class.name(db),
             ClassBase::Dynamic(DynamicType::Any) => "Any",
             ClassBase::Dynamic(DynamicType::Unknown) => "Unknown",
-            ClassBase::Dynamic(DynamicType::Todo(_)) => "@Todo",
+            ClassBase::Dynamic(DynamicType::Todo(_) | DynamicType::TodoPEP695ParamSpec) => "@Todo",
             ClassBase::Protocol(_) => "Protocol",
             ClassBase::Generic(_) => "Generic",
         }

--- a/crates/ty_python_semantic/src/types/type_ordering.rs
+++ b/crates/ty_python_semantic/src/types/type_ordering.rs
@@ -386,5 +386,8 @@ fn dynamic_elements_ordering(left: DynamicType, right: DynamicType) -> Ordering 
 
         #[cfg(not(debug_assertions))]
         (DynamicType::Todo(TodoType), DynamicType::Todo(TodoType)) => Ordering::Equal,
+
+        (DynamicType::TodoPEP695ParamSpec, _) => Ordering::Less,
+        (_, DynamicType::TodoPEP695ParamSpec) => Ordering::Greater,
     }
 }


### PR DESCRIPTION
## Summary

Suppress false positives for uses of PEP-695 `ParamSpec` in `Callable` annotations:
```py
from typing_extensions import Callable

def f[**P](c: Callable[P, int]):
    pass
```

addresses a comment here: https://github.com/astral-sh/ty/issues/157#issuecomment-2859284721

## Test Plan

Adapted Markdown tests
