### PR TITLE
[ty] Remove generic types from the daily property test run (for now)

### DIFF
--- a/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
+++ b/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
@@ -220,8 +220,6 @@ fn arbitrary_core_type(g: &mut Gen) -> Ty {
         Ty::KnownClassInstance(KnownClass::Str),
         Ty::KnownClassInstance(KnownClass::Int),
         Ty::KnownClassInstance(KnownClass::Bool),
-        Ty::KnownClassInstance(KnownClass::List),
-        Ty::KnownClassInstance(KnownClass::Tuple),
         Ty::KnownClassInstance(KnownClass::FunctionType),
         Ty::KnownClassInstance(KnownClass::SpecialForm),
         Ty::KnownClassInstance(KnownClass::TypeVar),


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ty/issues/305.

As of https://github.com/astral-sh/ruff/pull/17832, we understand several classes as generic that we did not previously, including `list` and `tuple`. Instance-types for these classes don't yet pass our property tests, in part because of things such as we don't yet understand that `list[Any]` is not a fully static type. For now, let's make sure that we don't test these types in the daily property test run. We can add them back later when our generics implementation is further along.

## Test Plan

`QUICKCHECK_TESTS=100000 cargo test --release -p ty_python_semantic -- --ignored types::property_tests::stable`
