### PR TITLE
[ty] Don't warn `yield` not in function when `yield` is in function

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyflakes/F704.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyflakes/F704.py
@@ -9,3 +9,11 @@ class Foo:
 yield 3
 yield from 3
 await f()
+
+def _():
+    # Invalid yield scopes; but not outside a function
+    type X[T: (yield 1)] = int
+    type Y = (yield 2)
+
+    # Valid yield scope
+    yield 3

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -690,7 +690,7 @@ impl SemanticSyntaxContext for Checker<'_> {
         false
     }
 
-    fn in_sync_comprehension_scope(&self) -> bool {
+    fn in_sync_comprehension(&self) -> bool {
         for scope in self.semantic.current_scopes() {
             if let ScopeKind::Generator {
                 kind:

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -690,6 +690,17 @@ impl SemanticSyntaxContext for Checker<'_> {
         false
     }
 
+    fn in_yield_allowed_context(&self) -> bool {
+        for scope in self.semantic.current_scopes() {
+            match scope.kind {
+                ScopeKind::Class(_) | ScopeKind::Generator { .. } => return false,
+                ScopeKind::Function(_) | ScopeKind::Lambda(_) => return true,
+                ScopeKind::Module | ScopeKind::Type => {}
+            }
+        }
+        false
+    }
+
     fn in_sync_comprehension(&self) -> bool {
         for scope in self.semantic.current_scopes() {
             if let ScopeKind::Generator {

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -690,7 +690,7 @@ impl SemanticSyntaxContext for Checker<'_> {
         false
     }
 
-    fn in_sync_comprehension(&self) -> bool {
+    fn in_sync_comprehension_scope(&self) -> bool {
         for scope in self.semantic.current_scopes() {
             if let ScopeKind::Generator {
                 kind:

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F704_F704.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F704_F704.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_linter/src/rules/pyflakes/mod.rs
-snapshot_kind: text
 ---
 F704.py:6:5: F704 `yield` statement outside of a function
   |
@@ -31,4 +30,6 @@ F704.py:11:1: F704 `await` statement outside of a function
 10 | yield from 3
 11 | await f()
    | ^^^^^^^^^ F704
+12 |
+13 | def _():
    |

--- a/crates/ruff_python_parser/src/semantic_errors.rs
+++ b/crates/ruff_python_parser/src/semantic_errors.rs
@@ -787,7 +787,7 @@ impl SemanticSyntaxChecker {
         }
 
         // Traverse scope stack to detect ancestors but prevent explicitly invalid contexts
-        if !ctx.in_sync_comprehension()
+        if !ctx.in_sync_comprehension_scope()
             && !ctx.in_generator_scope()
             && ctx.in_await_allowed_context()
         {
@@ -853,7 +853,7 @@ impl SemanticSyntaxChecker {
         if ctx.in_notebook() && ctx.in_module_scope() {
             return;
         }
-        if !ctx.in_sync_comprehension() {
+        if !ctx.in_sync_comprehension_scope() {
             return;
         }
         for generator in generators.iter().filter(|gen| gen.is_async) {
@@ -1734,7 +1734,7 @@ pub trait SemanticSyntaxContext {
     /// function to determine the (a)sync context. Instead, this method will search all enclosing
     /// scopes until it finds a sync comprehension. As a result, the two methods will typically be
     /// used together.
-    fn in_sync_comprehension(&self) -> bool;
+    fn in_sync_comprehension_scope(&self) -> bool;
 
     /// Returns `true` if the visitor is at the top-level module scope.
     fn in_module_scope(&self) -> bool;

--- a/crates/ruff_python_parser/src/semantic_errors.rs
+++ b/crates/ruff_python_parser/src/semantic_errors.rs
@@ -787,7 +787,7 @@ impl SemanticSyntaxChecker {
         }
 
         // Traverse scope stack to detect ancestors but prevent explicitly invalid contexts
-        if !ctx.in_sync_comprehension_scope()
+        if !ctx.in_sync_comprehension()
             && !ctx.in_generator_scope()
             && ctx.in_await_allowed_context()
         {
@@ -853,7 +853,7 @@ impl SemanticSyntaxChecker {
         if ctx.in_notebook() && ctx.in_module_scope() {
             return;
         }
-        if !ctx.in_sync_comprehension_scope() {
+        if !ctx.in_sync_comprehension() {
             return;
         }
         for generator in generators.iter().filter(|gen| gen.is_async) {
@@ -1734,7 +1734,7 @@ pub trait SemanticSyntaxContext {
     /// function to determine the (a)sync context. Instead, this method will search all enclosing
     /// scopes until it finds a sync comprehension. As a result, the two methods will typically be
     /// used together.
-    fn in_sync_comprehension_scope(&self) -> bool;
+    fn in_sync_comprehension(&self) -> bool;
 
     /// Returns `true` if the visitor is at the top-level module scope.
     fn in_module_scope(&self) -> bool;

--- a/crates/ruff_python_parser/tests/fixtures.rs
+++ b/crates/ruff_python_parser/tests/fixtures.rs
@@ -553,6 +553,10 @@ impl SemanticSyntaxContext for SemanticSyntaxCheckerVisitor<'_> {
         true
     }
 
+    fn in_yield_allowed_context(&self) -> bool {
+        true
+    }
+
     fn in_generator_scope(&self) -> bool {
         true
     }

--- a/crates/ruff_python_parser/tests/fixtures.rs
+++ b/crates/ruff_python_parser/tests/fixtures.rs
@@ -528,7 +528,7 @@ impl SemanticSyntaxContext for SemanticSyntaxCheckerVisitor<'_> {
         true
     }
 
-    fn in_sync_comprehension_scope(&self) -> bool {
+    fn in_sync_comprehension(&self) -> bool {
         for scope in &self.scopes {
             if let Scope::Comprehension { is_async: false } = scope {
                 return true;

--- a/crates/ruff_python_parser/tests/fixtures.rs
+++ b/crates/ruff_python_parser/tests/fixtures.rs
@@ -528,7 +528,7 @@ impl SemanticSyntaxContext for SemanticSyntaxCheckerVisitor<'_> {
         true
     }
 
-    fn in_sync_comprehension(&self) -> bool {
+    fn in_sync_comprehension_scope(&self) -> bool {
         for scope in &self.scopes {
             if let Scope::Comprehension { is_async: false } = scope {
                 return true;

--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/semantic_syntax_errors.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/semantic_syntax_errors.md
@@ -299,13 +299,13 @@ python-version = "3.12"
 
 ```py
 def _():
-# error: [invalid-type-form] "`yield` expressions are not allowed in type expressions"
-# error: [invalid-syntax] "yield expression cannot be used within a TypeVar bound"
+    # error: [invalid-type-form] "`yield` expressions are not allowed in type expressions"
+    # error: [invalid-syntax] "yield expression cannot be used within a TypeVar bound"
     type X[T: (yield 1)] = int
 
 def _():
-# error: [invalid-type-form] "`yield` expressions are not allowed in type expressions"
-# error: [invalid-syntax] "yield expression cannot be used within a type alias"
+    # error: [invalid-type-form] "`yield` expressions are not allowed in type expressions"
+    # error: [invalid-syntax] "yield expression cannot be used within a type alias"
     type Y = (yield 1)
 
 # error: [invalid-type-form] "Named expressions are not allowed in type expressions"

--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/semantic_syntax_errors.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/semantic_syntax_errors.md
@@ -313,10 +313,10 @@ def _():
 def f[T](x: int) -> (y := 3):
     return x
 
-# error: [invalid-syntax] "`yield from` statement outside of a function"
-# error: [invalid-syntax] "yield expression cannot be used within a generic definition"
-class C[T]((yield from [object])):
-    pass
+def _():
+    # error: [invalid-syntax] "yield expression cannot be used within a generic definition"
+    class C[T]((yield from [object])):
+        pass
 ```
 
 ## `await` outside async function

--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/semantic_syntax_errors.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/semantic_syntax_errors.md
@@ -298,15 +298,15 @@ python-version = "3.12"
 ```
 
 ```py
+def _():
 # error: [invalid-type-form] "`yield` expressions are not allowed in type expressions"
 # error: [invalid-syntax] "yield expression cannot be used within a TypeVar bound"
-# error: [invalid-syntax] "`yield` statement outside of a function"
-type X[T: (yield 1)] = int
+    type X[T: (yield 1)] = int
 
+def _():
 # error: [invalid-type-form] "`yield` expressions are not allowed in type expressions"
 # error: [invalid-syntax] "yield expression cannot be used within a type alias"
-# error: [invalid-syntax] "`yield` statement outside of a function"
-type Y = (yield 1)
+    type Y = (yield 1)
 
 # error: [invalid-type-form] "Named expressions are not allowed in type expressions"
 # error: [invalid-syntax] "named expression cannot be used within a generic definition"

--- a/crates/ty_python_semantic/src/semantic_index/builder.rs
+++ b/crates/ty_python_semantic/src/semantic_index/builder.rs
@@ -2480,7 +2480,7 @@ impl SemanticSyntaxContext for SemanticIndexBuilder<'_> {
         false
     }
 
-    fn in_sync_comprehension_scope(&self) -> bool {
+    fn in_sync_comprehension(&self) -> bool {
         for scope_info in self.scope_stack.iter().rev() {
             let scope = &self.scopes[scope_info.file_scope_id];
             let generators = match scope.node() {

--- a/crates/ty_python_semantic/src/semantic_index/builder.rs
+++ b/crates/ty_python_semantic/src/semantic_index/builder.rs
@@ -2480,6 +2480,18 @@ impl SemanticSyntaxContext for SemanticIndexBuilder<'_> {
         false
     }
 
+    fn in_yield_allowed_context(&self) -> bool {
+        for scope_info in self.scope_stack.iter().rev() {
+            let scope = &self.scopes[scope_info.file_scope_id];
+            match scope.kind() {
+                ScopeKind::Class | ScopeKind::Comprehension => return false,
+                ScopeKind::Function | ScopeKind::Lambda => return true,
+                ScopeKind::Module | ScopeKind::TypeAlias | ScopeKind::Annotation => {}
+            }
+        }
+        false
+    }
+
     fn in_sync_comprehension(&self) -> bool {
         for scope_info in self.scope_stack.iter().rev() {
             let scope = &self.scopes[scope_info.file_scope_id];

--- a/crates/ty_python_semantic/src/semantic_index/builder.rs
+++ b/crates/ty_python_semantic/src/semantic_index/builder.rs
@@ -2480,7 +2480,7 @@ impl SemanticSyntaxContext for SemanticIndexBuilder<'_> {
         false
     }
 
-    fn in_sync_comprehension(&self) -> bool {
+    fn in_sync_comprehension_scope(&self) -> bool {
         for scope_info in self.scope_stack.iter().rev() {
             let scope = &self.scopes[scope_info.file_scope_id];
             let generators = match scope.node() {

--- a/crates/ty_python_semantic/src/semantic_index/builder.rs
+++ b/crates/ty_python_semantic/src/semantic_index/builder.rs
@@ -2501,8 +2501,16 @@ impl SemanticSyntaxContext for SemanticIndexBuilder<'_> {
     }
 
     fn in_function_scope(&self) -> bool {
-        let kind = self.scopes[self.current_scope()].kind();
-        matches!(kind, ScopeKind::Function | ScopeKind::Lambda)
+        for scope_info in self.scope_stack.iter().rev() {
+            let scope = &self.scopes[scope_info.file_scope_id];
+            match scope.kind() {
+                ScopeKind::Lambda | ScopeKind::Function => {
+                    return true;
+                }
+                _ => {}
+            }
+        }
+        false
     }
 
     fn in_generator_scope(&self) -> bool {

--- a/crates/ty_python_semantic/src/semantic_index/builder.rs
+++ b/crates/ty_python_semantic/src/semantic_index/builder.rs
@@ -2501,16 +2501,8 @@ impl SemanticSyntaxContext for SemanticIndexBuilder<'_> {
     }
 
     fn in_function_scope(&self) -> bool {
-        for scope_info in self.scope_stack.iter().rev() {
-            let scope = &self.scopes[scope_info.file_scope_id];
-            match scope.kind() {
-                ScopeKind::Lambda | ScopeKind::Function => {
-                    return true;
-                }
-                _ => {}
-            }
-        }
-        false
+        let kind = self.scopes[self.current_scope()].kind();
+        matches!(kind, ScopeKind::Function | ScopeKind::Lambda)
     }
 
     fn in_generator_scope(&self) -> bool {


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->
Closes: https://github.com/astral-sh/ty/issues/299
## Summary
Don't warn `yield` not in function when `yield` is in function.

This is achieved by iterating through the scope stack to check if it contains a function scope. 
<!-- What's the purpose of the change? What does it do, and why? -->

The issue was found when creating the semantic syntax `md` integration tests (https://github.com/astral-sh/ruff/pull/17748#discussion_r2082080479). 
## Test Plan
Updated integration tests to reflect this behavior. 
<!-- How was it tested? -->

----

I don't know if I fully get how issues / PR's work across the boundaries of `ruff` and `ty`. Let me know if i'm doing something wrong.