### PR TITLE
[ty] Remove unused variants from various `Known*` enums

### DIFF
--- a/crates/ty_python_semantic/src/module_resolver/module.rs
+++ b/crates/ty_python_semantic/src/module_resolver/module.rs
@@ -114,8 +114,7 @@ pub enum KnownModule {
     TypingExtensions,
     Typing,
     Sys,
-    #[allow(dead_code)]
-    Abc, // currently only used in tests
+    Abc,
     Dataclasses,
     Collections,
     Inspect,

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -1887,7 +1887,6 @@ pub enum KnownClass {
     FrozenSet,
     Dict,
     Slice,
-    Range,
     Property,
     BaseException,
     BaseExceptionGroup,
@@ -1996,7 +1995,6 @@ impl<'db> KnownClass {
             | Self::Bytes
             | Self::Bytearray
             | Self::FrozenSet
-            | Self::Range
             | Self::Property
             | Self::SpecialForm
             | Self::Dict
@@ -2051,7 +2049,6 @@ impl<'db> KnownClass {
             | Self::List
             | Self::Type
             | Self::Slice
-            | Self::Range
             | Self::Property
             | Self::BaseException
             | Self::BaseExceptionGroup
@@ -2109,7 +2106,6 @@ impl<'db> KnownClass {
             Self::List => "list",
             Self::Type => "type",
             Self::Slice => "slice",
-            Self::Range => "range",
             Self::Property => "property",
             Self::BaseException => "BaseException",
             Self::BaseExceptionGroup => "BaseExceptionGroup",
@@ -2331,7 +2327,6 @@ impl<'db> KnownClass {
             | Self::BaseExceptionGroup
             | Self::Classmethod
             | Self::Slice
-            | Self::Range
             | Self::Super
             | Self::Property => KnownModule::Builtins,
             Self::VersionInfo => KnownModule::Sys,
@@ -2416,7 +2411,6 @@ impl<'db> KnownClass {
             | Self::FrozenSet
             | Self::Dict
             | Self::Slice
-            | Self::Range
             | Self::Property
             | Self::BaseException
             | Self::BaseExceptionGroup
@@ -2478,7 +2472,6 @@ impl<'db> KnownClass {
             | Self::List
             | Self::Type
             | Self::Slice
-            | Self::Range
             | Self::Property
             | Self::GenericAlias
             | Self::ModuleType
@@ -2537,7 +2530,6 @@ impl<'db> KnownClass {
             "dict" => Self::Dict,
             "list" => Self::List,
             "slice" => Self::Slice,
-            "range" => Self::Range,
             "property" => Self::Property,
             "BaseException" => Self::BaseException,
             "BaseExceptionGroup" => Self::BaseExceptionGroup,
@@ -2607,7 +2599,6 @@ impl<'db> KnownClass {
             | Self::FrozenSet
             | Self::Dict
             | Self::Slice
-            | Self::Range
             | Self::Property
             | Self::GenericAlias
             | Self::ChainMap

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -26,10 +26,6 @@ pub enum ClassBase<'db> {
 }
 
 impl<'db> ClassBase<'db> {
-    pub(crate) const fn any() -> Self {
-        Self::Dynamic(DynamicType::Any)
-    }
-
     pub(crate) const fn unknown() -> Self {
         Self::Dynamic(DynamicType::Unknown)
     }
@@ -164,7 +160,6 @@ impl<'db> ClassBase<'db> {
                 | KnownInstanceType::AlwaysTruthy
                 | KnownInstanceType::AlwaysFalsy => None,
                 KnownInstanceType::Unknown => Some(Self::unknown()),
-                KnownInstanceType::Any => Some(Self::any()),
                 // TODO: Classes inheriting from `typing.Type` et al. also have `Generic` in their MRO
                 KnownInstanceType::Dict => {
                     Self::try_from_type(db, KnownClass::Dict.to_class_literal(db))

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -8045,9 +8045,6 @@ impl<'db> TypeInferenceBuilder<'db> {
                             )
                         }
                     }
-                    Type::KnownInstance(KnownInstanceType::Any) => {
-                        SubclassOfType::subclass_of_any()
-                    }
                     Type::KnownInstance(KnownInstanceType::Unknown) => {
                         SubclassOfType::subclass_of_unknown()
                     }
@@ -8486,7 +8483,6 @@ impl<'db> TypeInferenceBuilder<'db> {
             }
             KnownInstanceType::NoReturn
             | KnownInstanceType::Never
-            | KnownInstanceType::Any
             | KnownInstanceType::AlwaysTruthy
             | KnownInstanceType::AlwaysFalsy => {
                 self.infer_type_expression(arguments_slice);

--- a/crates/ty_python_semantic/src/types/known_instance.rs
+++ b/crates/ty_python_semantic/src/types/known_instance.rs
@@ -34,11 +34,6 @@ pub enum KnownInstanceType<'db> {
     NoReturn,
     /// The symbol `typing.Never` available since 3.11 (which can also be found as `typing_extensions.Never`)
     Never,
-    /// The symbol `typing.Any` (which can also be found as `typing_extensions.Any`)
-    /// This is not used since typeshed switched to representing `Any` as a class; now we use
-    /// `KnownClass::Any` instead. But we still support the old `Any = object()` representation, at
-    /// least for now. TODO maybe remove?
-    Any,
     /// The symbol `typing.Tuple` (which can also be found as `typing_extensions.Tuple`)
     Tuple,
     /// The symbol `typing.List` (which can also be found as `typing_extensions.List`)
@@ -121,7 +116,6 @@ impl<'db> KnownInstanceType<'db> {
             | Self::Union
             | Self::NoReturn
             | Self::Never
-            | Self::Any
             | Self::Tuple
             | Self::Type
             | Self::TypingSelf
@@ -177,7 +171,6 @@ impl<'db> KnownInstanceType<'db> {
             Self::Union => KnownClass::SpecialForm,
             Self::NoReturn => KnownClass::SpecialForm,
             Self::Never => KnownClass::SpecialForm,
-            Self::Any => KnownClass::Object,
             Self::Tuple => KnownClass::SpecialForm,
             Self::Type => KnownClass::SpecialForm,
             Self::TypingSelf => KnownClass::SpecialForm,
@@ -236,7 +229,6 @@ impl<'db> KnownInstanceType<'db> {
         symbol_name: &str,
     ) -> Option<Self> {
         let candidate = match symbol_name {
-            "Any" => Self::Any,
             "ClassVar" => Self::ClassVar,
             "Deque" => Self::Deque,
             "List" => Self::List,
@@ -291,8 +283,7 @@ impl<'db> KnownInstanceType<'db> {
     /// Some variants could validly be defined in either `typing` or `typing_extensions`, however.
     pub(super) fn check_module(self, module: KnownModule) -> bool {
         match self {
-            Self::Any
-            | Self::ClassVar
+            Self::ClassVar
             | Self::Deque
             | Self::List
             | Self::Dict
@@ -359,7 +350,6 @@ impl Display for KnownInstanceRepr<'_> {
             KnownInstanceType::Union => f.write_str("typing.Union"),
             KnownInstanceType::NoReturn => f.write_str("typing.NoReturn"),
             KnownInstanceType::Never => f.write_str("typing.Never"),
-            KnownInstanceType::Any => f.write_str("typing.Any"),
             KnownInstanceType::Tuple => f.write_str("typing.Tuple"),
             KnownInstanceType::Type => f.write_str("typing.Type"),
             KnownInstanceType::TypingSelf => f.write_str("typing.Self"),

--- a/crates/ty_python_semantic/src/types/type_ordering.rs
+++ b/crates/ty_python_semantic/src/types/type_ordering.rs
@@ -185,9 +185,6 @@ pub(super) fn union_or_intersection_elements_ordering<'db>(
 
         (Type::KnownInstance(left_instance), Type::KnownInstance(right_instance)) => {
             match (left_instance, right_instance) {
-                (KnownInstanceType::Any, _) => Ordering::Less,
-                (_, KnownInstanceType::Any) => Ordering::Greater,
-
                 (KnownInstanceType::Tuple, _) => Ordering::Less,
                 (_, KnownInstanceType::Tuple) => Ordering::Greater,
 


### PR DESCRIPTION
## Summary

`KnownClass::Range`, `KnownInstanceType::Any` and `ClassBase::any()` are no longer used or useful: all our tests pass with them removed. `KnownModule::Abc` _is_ now used outside of tests, however, so I removed the `#[allow(dead_code)]` branch above that variant.

## Test Plan

`cargo test -p ty_python_semantic`
