### PR TITLE
disable jemalloc on android

### DIFF
--- a/crates/ruff/Cargo.toml
+++ b/crates/ruff/Cargo.toml
@@ -84,7 +84,7 @@ dist = true
 [target.'cfg(target_os = "windows")'.dependencies]
 mimalloc = { workspace = true }
 
-[target.'cfg(all(not(target_os = "windows"), not(target_os = "openbsd"), not(target_os = "aix"), any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "powerpc64")))'.dependencies]
+[target.'cfg(all(not(target_os = "windows"), not(target_os = "openbsd"), not(target_os = "aix"), not(target_os = "android"), any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "powerpc64")))'.dependencies]
 tikv-jemallocator = { workspace = true }
 
 [lints]

--- a/crates/ruff/src/main.rs
+++ b/crates/ruff/src/main.rs
@@ -15,6 +15,7 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
     not(target_os = "windows"),
     not(target_os = "openbsd"),
     not(target_os = "aix"),
+    not(target_os = "android"),
     any(
         target_arch = "x86_64",
         target_arch = "aarch64",

--- a/crates/ty/src/main.rs
+++ b/crates/ty/src/main.rs
@@ -8,7 +8,7 @@ pub fn main() -> ExitStatus {
 
         // Use `writeln` instead of `eprintln` to avoid panicking when the stderr pipe is broken.
         let mut stderr = io::stderr().lock();
-        //
+
         // This communicates that this isn't a linter error but ty itself hard-errored for
         // some reason (e.g. failed to resolve the configuration)
         writeln!(stderr, "{}", "ty failed".red().bold()).ok();

--- a/crates/ty/src/main.rs
+++ b/crates/ty/src/main.rs
@@ -8,7 +8,7 @@ pub fn main() -> ExitStatus {
 
         // Use `writeln` instead of `eprintln` to avoid panicking when the stderr pipe is broken.
         let mut stderr = io::stderr().lock();
-
+        //
         // This communicates that this isn't a linter error but ty itself hard-errored for
         // some reason (e.g. failed to resolve the configuration)
         writeln!(stderr, "{}", "ty failed".red().bold()).ok();


### PR DESCRIPTION
## Summary

The android ndk no longer ships with gcc by default, but jemalloc requires it. 
There are some [tricks](https://github.com/astral-sh/ruff/issues/17527#issuecomment-2824783704) that allow building jemalloc without gcc but this feels unnecessarily complicated.

For now, let's disable jemalloc.

Fixes https://github.com/astral-sh/ruff/issues/18016
Related https://github.com/astral-sh/ruff/issues/17527

## Test Plan

I don't have an android device.
