### PR TITLE
Improve docs on config file precedence

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -260,6 +260,10 @@ directory hierarchy is used for every individual file, with all paths in the con
 (e.g., `exclude` globs, `src` paths) being resolved relative to the directory containing that
 config file.
 
+If Ruff detects multiple configuration files in the same directory, the `.ruff.toml` file will take
+precedence over the `ruff.toml` file, and the `ruff.toml` file will take precedence over
+the `pyproject.toml` file.
+
 There are a few exceptions to these rules:
 
 1. In locating the "closest" `pyproject.toml` file for a given path, Ruff ignores any
@@ -301,11 +305,6 @@ config file, like so:
     # ...but use a different line length.
     line-length = 100
     ```
-
-All of the above rules apply equivalently to `pyproject.toml`, `ruff.toml`, and `.ruff.toml` files.
-If Ruff detects multiple configuration files in the same directory, the `.ruff.toml` file will take
-precedence over the `ruff.toml` file, and the `ruff.toml` file will take precedence over
-the `pyproject.toml` file.
 
 ### Inferring the Python version
 When no discovered configuration specifies a [`target-version`](settings.md#target-version), Ruff will attempt to fall back to the minimum version compatible with the `requires-python` field in a nearby `pyproject.toml`.


### PR DESCRIPTION
When working with ruff, I fell into the trap of having `.ruff.toml` and `pyproject.toml` config files. It took me some time to find the precedence rules from the docs. This PR aims to make the docs slightly more clear.

- In the section "Config file discovery" the precedence was described quite lengthy at the very end of the section. I propose it's more concise to describe this with a single sentence immediately after stating that there can be one config file per directory.
- At the very top, when listing all config file types, list them in the order of their precedence. Being equal otherwise, matching the order of precendence may alreay be a subtle hint to users.

