### PR TITLE
[ty] Remove brackets around option names

### DIFF
--- a/crates/ruff_dev/src/generate_ty_options.rs
+++ b/crates/ruff_dev/src/generate_ty_options.rs
@@ -134,13 +134,13 @@ impl Set {
 fn emit_field(output: &mut String, name: &str, field: &OptionField, parents: &[Set]) {
     let header_level = if parents.is_empty() { "###" } else { "####" };
 
-    let _ = writeln!(output, "{header_level} [`{name}`]");
+    let _ = writeln!(output, "{header_level} `{name}`");
 
     output.push('\n');
 
     if let Some(deprecated) = &field.deprecated {
-        output.push_str("!!! warning \"Deprecated\"\n");
-        output.push_str("    This option has been deprecated");
+        output.push_str("> [!WARN] \"Deprecated\"\n");
+        output.push_str("> This option has been deprecated");
 
         if let Some(since) = deprecated.since {
             write!(output, " in {since}").unwrap();

--- a/crates/ty/docs/configuration.md
+++ b/crates/ty/docs/configuration.md
@@ -1,5 +1,5 @@
 # Configuration
-#### [`respect-ignore-files`]
+#### `respect-ignore-files`
 
 Whether to automatically exclude files that are ignored by `.ignore`,
 `.gitignore`, `.git/info/exclude`, and global `gitignore` files.
@@ -18,7 +18,7 @@ respect-ignore-files = false
 
 ---
 
-#### [`rules`]
+#### `rules`
 
 Configures the enabled rules and their severity.
 
@@ -47,7 +47,7 @@ division-by-zero = "ignore"
 
 ## `environment`
 
-#### [`extra-paths`]
+#### `extra-paths`
 
 List of user-provided paths that should take first priority in the module resolution.
 Examples in other type checkers are mypy's `MYPYPATH` environment variable,
@@ -66,7 +66,7 @@ extra-paths = ["~/shared/my-search-path"]
 
 ---
 
-#### [`python`]
+#### `python`
 
 Path to the Python installation from which ty resolves type information and third-party dependencies.
 
@@ -88,7 +88,7 @@ python = "./.venv"
 
 ---
 
-#### [`python-platform`]
+#### `python-platform`
 
 Specifies the target platform that will be used to analyze the source code.
 If specified, ty will understand conditions based on comparisons with `sys.platform`, such
@@ -115,7 +115,7 @@ python-platform = "win32"
 
 ---
 
-#### [`python-version`]
+#### `python-version`
 
 Specifies the version of Python that will be used to analyze the source code.
 The version should be specified as a string in the format `M.m` where `M` is the major version
@@ -139,7 +139,7 @@ python-version = "3.12"
 
 ---
 
-#### [`typeshed`]
+#### `typeshed`
 
 Optional path to a "typeshed" directory on disk for us to use for standard-library types.
 If this is not provided, we will fallback to our vendored typeshed stubs for the stdlib,
@@ -160,7 +160,7 @@ typeshed = "/path/to/custom/typeshed"
 
 ## `src`
 
-#### [`root`]
+#### `root`
 
 The root(s) of the project, used for finding first-party modules.
 
@@ -179,7 +179,7 @@ root = ["./app"]
 
 ## `terminal`
 
-#### [`error-on-warning`]
+#### `error-on-warning`
 
 Use exit code 1 if there are any warning-level diagnostics.
 
@@ -199,7 +199,7 @@ error-on-warning = true
 
 ---
 
-#### [`output-format`]
+#### `output-format`
 
 The format to use for printing diagnostic messages.
 


### PR DESCRIPTION
## Summary

Remove the `[]` around the option names. I'm not sure why we emit those for ruff but they don't show up in the rendered documentation when hosted with mkdocs but they are shown on GitHub. 


