### PR TITLE
[ty] Fix incorrect type of `src.root` in documentation

### DIFF
--- a/crates/ty/docs/configuration.md
+++ b/crates/ty/docs/configuration.md
@@ -162,17 +162,17 @@ typeshed = "/path/to/custom/typeshed"
 
 #### `root`
 
-The root(s) of the project, used for finding first-party modules.
+The root of the project, used for finding first-party modules.
 
 **Default value**: `[".", "./src"]`
 
-**Type**: `list[str]`
+**Type**: `str`
 
 **Example usage** (`pyproject.toml`):
 
 ```toml
 [tool.ty.src]
-root = ["./app"]
+root = "./app"
 ```
 
 ---

--- a/crates/ty_project/src/metadata/options.rs
+++ b/crates/ty_project/src/metadata/options.rs
@@ -352,13 +352,13 @@ pub struct EnvironmentOptions {
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct SrcOptions {
-    /// The root(s) of the project, used for finding first-party modules.
+    /// The root of the project, used for finding first-party modules.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[option(
         default = r#"[".", "./src"]"#,
-        value_type = "list[str]",
+        value_type = "str",
         example = r#"
-            root = ["./app"]
+            root = "./app"
         "#
     )]
     pub root: Option<RelativePathBuf>,

--- a/ty.schema.json
+++ b/ty.schema.json
@@ -839,7 +839,7 @@
       "type": "object",
       "properties": {
         "root": {
-          "description": "The root(s) of the project, used for finding first-party modules.",
+          "description": "The root of the project, used for finding first-party modules.",
           "type": [
             "string",
             "null"


### PR DESCRIPTION
## Summary

`src.root` is a single path. We do have plans to change the setting to a list (need to think about if we should allow empty lists) https://github.com/astral-sh/ty/issues/179 but we can change that later.

## Test Plan

See updated docs
