### PR TITLE
[`flake8-simplify`] Fix `SIM905` autofix for `rsplit` creating a reversed list literal

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM905.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM905.py
@@ -31,7 +31,7 @@ no_sep = None
 
 " a*a a*a a ".split("*", -1)  # [" a", "a a", "a a "]
 "".split()  # []
-""" 	
+"""
 """.split()  # []
 "   	".split()  # []
 "/abc/".split() # ["/abc/"]
@@ -73,7 +73,7 @@ r"\n " "\n".split()  # [r"\n"]
 
 # negatives
 
-# invalid values should not cause panic 
+# invalid values should not cause panic
 "a,b,c,d".split(maxsplit="hello")
 "a,b,c,d".split(maxsplit=-"hello")
 
@@ -106,3 +106,7 @@ b"TesT.WwW.ExamplE.CoM".split(b".")
 '''itemC'''
 "'itemD'"
 """.split()
+
+# https://github.com/astral-sh/ruff/issues/18042
+print("a,b".rsplit(","))
+print("a,b,c".rsplit(",", 1))

--- a/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
@@ -516,7 +516,6 @@ pub(crate) fn expression(expr: &Expr, checker: &Checker) {
                             if checker.enabled(Rule::SplitStaticString) {
                                 flake8_simplify::rules::split_static_string(
                                     checker,
-                                    attr,
                                     call,
                                     string_value,
                                 );

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM905_SIM905.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM905_SIM905.py.snap
@@ -352,7 +352,7 @@ SIM905.py:32:1: SIM905 [*] Consider using a list literal instead of `str.split`
 32 | " a*a a*a a ".split("*", -1)  # [" a", "a a", "a a "]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM905
 33 | "".split()  # []
-34 | """     
+34 | """
    |
    = help: Replace with list literal
 
@@ -363,7 +363,7 @@ SIM905.py:32:1: SIM905 [*] Consider using a list literal instead of `str.split`
 32    |-" a*a a*a a ".split("*", -1)  # [" a", "a a", "a a "]
    32 |+[" a", "a a", "a a "]  # [" a", "a a", "a a "]
 33 33 | "".split()  # []
-34 34 | """ 	
+34 34 | """
 35 35 | """.split()  # []
 
 SIM905.py:33:1: SIM905 [*] Consider using a list literal instead of `str.split`
@@ -371,7 +371,7 @@ SIM905.py:33:1: SIM905 [*] Consider using a list literal instead of `str.split`
 32 | " a*a a*a a ".split("*", -1)  # [" a", "a a", "a a "]
 33 | "".split()  # []
    | ^^^^^^^^^^ SIM905
-34 | """     
+34 | """
 35 | """.split()  # []
    |
    = help: Replace with list literal
@@ -382,7 +382,7 @@ SIM905.py:33:1: SIM905 [*] Consider using a list literal instead of `str.split`
 32 32 | " a*a a*a a ".split("*", -1)  # [" a", "a a", "a a "]
 33    |-"".split()  # []
    33 |+[]  # []
-34 34 | """ 	
+34 34 | """
 35 35 | """.split()  # []
 36 36 | "   	".split()  # []
 
@@ -390,7 +390,7 @@ SIM905.py:34:1: SIM905 [*] Consider using a list literal instead of `str.split`
    |
 32 |   " a*a a*a a ".split("*", -1)  # [" a", "a a", "a a "]
 33 |   "".split()  # []
-34 | / """     
+34 | / """
 35 | | """.split()  # []
    | |___________^ SIM905
 36 |   "       ".split()  # []
@@ -402,7 +402,7 @@ SIM905.py:34:1: SIM905 [*] Consider using a list literal instead of `str.split`
 31 31 | 
 32 32 | " a*a a*a a ".split("*", -1)  # [" a", "a a", "a a "]
 33 33 | "".split()  # []
-34    |-""" 	
+34    |-"""
 35    |-""".split()  # []
    34 |+[]  # []
 36 35 | "   	".split()  # []
@@ -411,7 +411,7 @@ SIM905.py:34:1: SIM905 [*] Consider using a list literal instead of `str.split`
 
 SIM905.py:36:1: SIM905 [*] Consider using a list literal instead of `str.split`
    |
-34 | """     
+34 | """
 35 | """.split()  # []
 36 | "       ".split()  # []
    | ^^^^^^^^^^^^^^^^^ SIM905
@@ -422,7 +422,7 @@ SIM905.py:36:1: SIM905 [*] Consider using a list literal instead of `str.split`
 
 ℹ Safe fix
 33 33 | "".split()  # []
-34 34 | """ 	
+34 34 | """
 35 35 | """.split()  # []
 36    |-"   	".split()  # []
    36 |+[]  # []
@@ -442,7 +442,7 @@ SIM905.py:37:1: SIM905 [*] Consider using a list literal instead of `str.split`
    = help: Replace with list literal
 
 ℹ Safe fix
-34 34 | """ 	
+34 34 | """
 35 35 | """.split()  # []
 36 36 | "   	".split()  # []
 37    |-"/abc/".split() # ["/abc/"]
@@ -854,6 +854,8 @@ SIM905.py:103:1: SIM905 [*] Consider using a list literal instead of `str.split`
 107 | | "'itemD'"
 108 | | """.split()
     | |___________^ SIM905
+109 |
+110 |   # https://github.com/astral-sh/ruff/issues/18042
     |
     = help: Replace with list literal
 
@@ -868,3 +870,39 @@ SIM905.py:103:1: SIM905 [*] Consider using a list literal instead of `str.split`
 107     |-"'itemD'"
 108     |-""".split()
     103 |+['"itemA"', "'itemB'", "'''itemC'''", "\"'itemD'\""]
+109 104 | 
+110 105 | # https://github.com/astral-sh/ruff/issues/18042
+111 106 | print("a,b".rsplit(","))
+
+SIM905.py:111:7: SIM905 [*] Consider using a list literal instead of `str.split`
+    |
+110 | # https://github.com/astral-sh/ruff/issues/18042
+111 | print("a,b".rsplit(","))
+    |       ^^^^^^^^^^^^^^^^^ SIM905
+112 | print("a,b,c".rsplit(",", 1))
+    |
+    = help: Replace with list literal
+
+ℹ Safe fix
+108 108 | """.split()
+109 109 | 
+110 110 | # https://github.com/astral-sh/ruff/issues/18042
+111     |-print("a,b".rsplit(","))
+    111 |+print(["a", "b"])
+112 112 | print("a,b,c".rsplit(",", 1))
+
+SIM905.py:112:7: SIM905 [*] Consider using a list literal instead of `str.split`
+    |
+110 | # https://github.com/astral-sh/ruff/issues/18042
+111 | print("a,b".rsplit(","))
+112 | print("a,b,c".rsplit(",", 1))
+    |       ^^^^^^^^^^^^^^^^^^^^^^ SIM905
+    |
+    = help: Replace with list literal
+
+ℹ Safe fix
+109 109 | 
+110 110 | # https://github.com/astral-sh/ruff/issues/18042
+111 111 | print("a,b".rsplit(","))
+112     |-print("a,b,c".rsplit(",", 1))
+    112 |+print(["a", "b,c"])


### PR DESCRIPTION


<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Fixes #18042
<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

Update existing snapshot tests.
<!-- How was it tested? -->
