### PR TITLE
Add comma to panic message

### DIFF
--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -605,7 +605,7 @@ where
                 "This indicates a bug in ty.",
             ));
 
-            let report_message = "If you could open an issue at https://github.com/astral-sh/ty/issues/new?title=%5Bpanic%5D we'd be very appreciative!";
+            let report_message = "If you could open an issue at https://github.com/astral-sh/ty/issues/new?title=%5Bpanic%5D, we'd be very appreciative!";
             diagnostic.sub(SubDiagnostic::new(Severity::Info, report_message));
             diagnostic.sub(SubDiagnostic::new(
                 Severity::Info,


### PR DESCRIPTION
## Summary

Consistent with other variants of this, separate the conditional clause.
