### PR TITLE
[ty] Induct into instances and subclasses when finding and applying generics

### DIFF
--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -59,40 +59,7 @@ type KeyDiagnosticFields = (
     Severity,
 );
 
-// left: [
-// (Lint(LintName("invalid-argument-type")), Some("/src/tomllib/_parser.py"), Some(8224..8254), "Argument to function `skip_until` is incorrect", Error),
-// (Lint(LintName("invalid-argument-type")), Some("/src/tomllib/_parser.py"), Some(16914..16948), "Argument to function `skip_until` is incorrect", Error),
-// (Lint(LintName("invalid-argument-type")), Some("/src/tomllib/_parser.py"), Some(17319..17363), "Argument to function `skip_until` is incorrect", Error),
-// ]
-//right: [
-// (Lint(LintName("invalid-argument-type")), Some("/src/tomllib/_parser.py"), Some(8224..8254), "Argument to this function is incorrect", Error),
-// (Lint(LintName("invalid-argument-type")), Some("/src/tomllib/_parser.py"), Some(16914..16948), "Argument to this function is incorrect", Error),
-// (Lint(LintName("invalid-argument-type")), Some("/src/tomllib/_parser.py"), Some(17319..17363), "Argument to this function is incorrect", Error),
-// ]
-
-static EXPECTED_TOMLLIB_DIAGNOSTICS: &[KeyDiagnosticFields] = &[
-    (
-        DiagnosticId::lint("invalid-argument-type"),
-        Some("/src/tomllib/_parser.py"),
-        Some(8224..8254),
-        "Argument to function `skip_until` is incorrect",
-        Severity::Error,
-    ),
-    (
-        DiagnosticId::lint("invalid-argument-type"),
-        Some("/src/tomllib/_parser.py"),
-        Some(16914..16948),
-        "Argument to function `skip_until` is incorrect",
-        Severity::Error,
-    ),
-    (
-        DiagnosticId::lint("invalid-argument-type"),
-        Some("/src/tomllib/_parser.py"),
-        Some(17319..17363),
-        "Argument to function `skip_until` is incorrect",
-        Severity::Error,
-    ),
-];
+static EXPECTED_TOMLLIB_DIAGNOSTICS: &[KeyDiagnosticFields] = &[];
 
 fn tomllib_path(file: &TestFile) -> SystemPathBuf {
     SystemPathBuf::from("src").join(file.name())

--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -19,7 +19,7 @@ class Shape:
         reveal_type(self)  # revealed: Self
         return self
 
-    def nested_type(self) -> list[Self]:
+    def nested_type(self: Self) -> list[Self]:
         return [self]
 
     def nested_func(self: Self) -> Self:
@@ -33,9 +33,7 @@ class Shape:
         reveal_type(self)  # revealed: Unknown
         return self
 
-# TODO: should be `list[Shape]`
-reveal_type(Shape().nested_type())  # revealed: list[Self]
-
+reveal_type(Shape().nested_type())  # revealed: list[Shape]
 reveal_type(Shape().nested_func())  # revealed: Shape
 
 class Circle(Shape):

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -73,11 +73,11 @@ from typing import TypeVar
 
 T = TypeVar("T")
 
-def f(x: list[T]) -> T:
-    return x[0]
+def f(x: list[T]) -> list[T]:
+    return x
 
-# TODO: revealed: float
-reveal_type(f([1.0, 2.0]))  # revealed: Unknown
+# TODO: revealed: list[float]
+reveal_type(f([1.0, 2.0]))  # revealed: list[Unknown]
 ```
 
 ## Inferring a bound typevar

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -66,18 +66,76 @@ reveal_type(f("string"))  # revealed: Literal["string"]
 ## Inferring “deep” generic parameter types
 
 The matching up of call arguments and discovery of constraints on typevars can be a recursive
-process for arbitrarily-nested generic types in parameters.
+process for arbitrarily-nested generic classes and protocols in parameters.
+
+TODO: Note that we can currently only infer a specialization for a generic protocol when the
+argument _explicitly_ implements the protocol by listing it as a base class.
 
 ```py
-from typing import TypeVar
+from typing import Protocol, TypeVar
 
 T = TypeVar("T")
 
-def f(x: list[T]) -> list[T]:
+class CanIndex(Protocol[T]):
+    def __getitem__(self, index: int) -> T: ...
+
+class ExplicitlyImplements(CanIndex[T]): ...
+
+def takes_in_list(x: list[T]) -> list[T]:
     return x
 
-# TODO: revealed: list[float]
-reveal_type(f([1.0, 2.0]))  # revealed: list[Unknown]
+def takes_in_protocol(x: CanIndex[T]) -> T:
+    return x[0]
+
+def deep_list(x: list[str]) -> None:
+    # TODO: revealed: list[str]
+    reveal_type(takes_in_list(x))  # revealed: list[Unknown]
+    # TODO: revealed: str
+    reveal_type(takes_in_protocol(x))  # revealed: Unknown
+
+def deeper_list(x: list[set[str]]) -> None:
+    # TODO: revealed: list[set[str]]
+    reveal_type(takes_in_list(x))  # revealed: list[Unknown]
+    # TODO: revealed: set[str]
+    reveal_type(takes_in_protocol(x))  # revealed: Unknown
+
+def deep_explicit(x: ExplicitlyImplements[str]) -> None:
+    # TODO: revealed: str
+    reveal_type(takes_in_protocol(x))  # revealed: Unknown
+
+def deeper_explicit(x: ExplicitlyImplements[set[str]]) -> None:
+    # TODO: revealed: set[str]
+    reveal_type(takes_in_protocol(x))  # revealed: Unknown
+
+def takes_in_type(x: type[T]) -> type[T]:
+    return x
+
+reveal_type(takes_in_type(int))  # revealed: @Todo(unsupported type[X] special form)
+```
+
+This also works when passing in arguments that are subclasses of the parameter type.
+
+```py
+class Sub(list[int]): ...
+class GenericSub(list[T]): ...
+
+# TODO: revealed: list[int]
+reveal_type(takes_in_list(Sub()))  # revealed: list[Unknown]
+# TODO: revealed: int
+reveal_type(takes_in_protocol(Sub()))  # revealed: Unknown
+
+# TODO: revealed: list[str]
+reveal_type(takes_in_list(GenericSub[str]()))  # revealed: list[Unknown]
+# TODO: revealed: str
+reveal_type(takes_in_protocol(GenericSub[str]()))  # revealed: Unknown
+
+class ExplicitSub(ExplicitlyImplements[int]): ...
+class ExplicitGenericSub(ExplicitlyImplements[T]): ...
+
+# TODO: revealed: int
+reveal_type(takes_in_protocol(ExplicitSub()))  # revealed: Unknown
+# TODO: revealed: str
+reveal_type(takes_in_protocol(ExplicitGenericSub[str]()))  # revealed: Unknown
 ```
 
 ## Inferring a bound typevar

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -64,11 +64,11 @@ The matching up of call arguments and discovery of constraints on typevars can b
 process for arbitrarily-nested generic types in parameters.
 
 ```py
-def f[T](x: list[T]) -> T:
-    return x[0]
+def f[T](x: list[T]) -> list[T]:
+    return x
 
-# TODO: revealed: float
-reveal_type(f([1.0, 2.0]))  # revealed: Unknown
+# TODO: revealed: list[float]
+reveal_type(f([1.0, 2.0]))  # revealed: list[Unknown]
 ```
 
 ## Inferring a bound typevar

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -61,14 +61,76 @@ reveal_type(f("string"))  # revealed: Literal["string"]
 ## Inferring “deep” generic parameter types
 
 The matching up of call arguments and discovery of constraints on typevars can be a recursive
-process for arbitrarily-nested generic types in parameters.
+process for arbitrarily-nested generic classes and protocols in parameters.
+
+TODO: Note that we can currently only infer a specialization for a generic protocol when the
+argument _explicitly_ implements the protocol by listing it as a base class.
 
 ```py
-def f[T](x: list[T]) -> list[T]:
+from typing import Protocol, TypeVar
+
+S = TypeVar("S")
+
+class CanIndex(Protocol[S]):
+    def __getitem__(self, index: int) -> S: ...
+
+class ExplicitlyImplements[T](CanIndex[T]): ...
+
+def takes_in_list[T](x: list[T]) -> list[T]:
     return x
 
-# TODO: revealed: list[float]
-reveal_type(f([1.0, 2.0]))  # revealed: list[Unknown]
+def takes_in_protocol[T](x: CanIndex[T]) -> T:
+    return x[0]
+
+def deep_list(x: list[str]) -> None:
+    # TODO: revealed: list[str]
+    reveal_type(takes_in_list(x))  # revealed: list[Unknown]
+    # TODO: revealed: str
+    reveal_type(takes_in_protocol(x))  # revealed: Unknown
+
+def deeper_list(x: list[set[str]]) -> None:
+    # TODO: revealed: list[set[str]]
+    reveal_type(takes_in_list(x))  # revealed: list[Unknown]
+    # TODO: revealed: set[str]
+    reveal_type(takes_in_protocol(x))  # revealed: Unknown
+
+def deep_explicit(x: ExplicitlyImplements[str]) -> None:
+    # TODO: revealed: str
+    reveal_type(takes_in_protocol(x))  # revealed: Unknown
+
+def deeper_explicit(x: ExplicitlyImplements[set[str]]) -> None:
+    # TODO: revealed: set[str]
+    reveal_type(takes_in_protocol(x))  # revealed: Unknown
+
+def takes_in_type[T](x: type[T]) -> type[T]:
+    return x
+
+reveal_type(takes_in_type(int))  # revealed: @Todo(unsupported type[X] special form)
+```
+
+This also works when passing in arguments that are subclasses of the parameter type.
+
+```py
+class Sub(list[int]): ...
+class GenericSub[T](list[T]): ...
+
+# TODO: revealed: list[int]
+reveal_type(takes_in_list(Sub()))  # revealed: list[Unknown]
+# TODO: revealed: int
+reveal_type(takes_in_protocol(Sub()))  # revealed: Unknown
+
+# TODO: revealed: list[str]
+reveal_type(takes_in_list(GenericSub[str]()))  # revealed: list[Unknown]
+# TODO: revealed: str
+reveal_type(takes_in_protocol(GenericSub[str]()))  # revealed: Unknown
+
+class ExplicitSub(ExplicitlyImplements[int]): ...
+class ExplicitGenericSub[T](ExplicitlyImplements[T]): ...
+
+# TODO: revealed: int
+reveal_type(takes_in_protocol(ExplicitSub()))  # revealed: Unknown
+# TODO: revealed: str
+reveal_type(takes_in_protocol(ExplicitGenericSub[str]()))  # revealed: Unknown
 ```
 
 ## Inferring a bound typevar

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -4,8 +4,8 @@ use super::protocol_class::ProtocolInterface;
 use super::{ClassType, KnownClass, SubclassOfType, Type};
 use crate::symbol::{Symbol, SymbolAndQualifiers};
 use crate::types::generics::TypeMapping;
-use crate::types::ClassLiteral;
-use crate::Db;
+use crate::types::{ClassLiteral, TypeVarInstance};
+use crate::{Db, FxOrderSet};
 
 pub(super) use synthesized_protocol::SynthesizedProtocolType;
 
@@ -122,6 +122,14 @@ impl<'db> NominalInstanceType<'db> {
         Self {
             class: self.class.apply_type_mapping(db, type_mapping),
         }
+    }
+
+    pub(super) fn find_legacy_typevars(
+        self,
+        db: &'db dyn Db,
+        typevars: &mut FxOrderSet<TypeVarInstance<'db>>,
+    ) {
+        self.class.find_legacy_typevars(db, typevars);
     }
 }
 
@@ -261,7 +269,7 @@ impl<'db> ProtocolInstanceType<'db> {
         }
     }
 
-    pub(super) fn apply_specialization<'a>(
+    pub(super) fn apply_type_mapping<'a>(
         self,
         db: &'db dyn Db,
         type_mapping: TypeMapping<'a, 'db>,
@@ -273,6 +281,21 @@ impl<'db> ProtocolInstanceType<'db> {
             Protocol::Synthesized(synthesized) => Self(Protocol::Synthesized(
                 synthesized.apply_type_mapping(db, type_mapping),
             )),
+        }
+    }
+
+    pub(super) fn find_legacy_typevars(
+        self,
+        db: &'db dyn Db,
+        typevars: &mut FxOrderSet<TypeVarInstance<'db>>,
+    ) {
+        match self.0 {
+            Protocol::FromClass(class) => {
+                class.find_legacy_typevars(db, typevars);
+            }
+            Protocol::Synthesized(synthesized) => {
+                synthesized.find_legacy_typevars(db, typevars);
+            }
         }
     }
 }
@@ -301,9 +324,10 @@ impl<'db> Protocol<'db> {
 }
 
 mod synthesized_protocol {
-    use crate::db::Db;
     use crate::types::generics::TypeMapping;
     use crate::types::protocol_class::ProtocolInterface;
+    use crate::types::TypeVarInstance;
+    use crate::{Db, FxOrderSet};
 
     /// A "synthesized" protocol type that is dissociated from a class definition in source code.
     ///
@@ -328,6 +352,14 @@ mod synthesized_protocol {
             type_mapping: TypeMapping<'a, 'db>,
         ) -> Self {
             Self(self.0.specialized_and_normalized(db, type_mapping))
+        }
+
+        pub(super) fn find_legacy_typevars(
+            self,
+            db: &'db dyn Db,
+            typevars: &mut FxOrderSet<TypeVarInstance<'db>>,
+        ) {
+            self.0.find_legacy_typevars(db, typevars);
         }
 
         pub(in crate::types) fn interface(self) -> ProtocolInterface<'db> {

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -1,6 +1,8 @@
 use crate::symbol::SymbolAndQualifiers;
+use crate::types::generics::TypeMapping;
+use crate::{Db, FxOrderSet};
 
-use super::{ClassType, Db, DynamicType, KnownClass, MemberLookupPolicy, Type};
+use super::{ClassType, DynamicType, KnownClass, MemberLookupPolicy, Type, TypeVarInstance};
 
 /// A type that represents `type[C]`, i.e. the class object `C` and class objects that are subclasses of `C`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, salsa::Update)]
@@ -64,6 +66,32 @@ impl<'db> SubclassOfType<'db> {
 
     pub(crate) const fn is_fully_static(self) -> bool {
         !self.is_dynamic()
+    }
+
+    pub(super) fn apply_type_mapping<'a>(
+        self,
+        db: &'db dyn Db,
+        type_mapping: TypeMapping<'a, 'db>,
+    ) -> Self {
+        match self.subclass_of {
+            SubclassOfInner::Class(class) => Self {
+                subclass_of: SubclassOfInner::Class(class.apply_type_mapping(db, type_mapping)),
+            },
+            SubclassOfInner::Dynamic(_) => self,
+        }
+    }
+
+    pub(super) fn find_legacy_typevars(
+        self,
+        db: &'db dyn Db,
+        typevars: &mut FxOrderSet<TypeVarInstance<'db>>,
+    ) {
+        match self.subclass_of {
+            SubclassOfInner::Class(class) => {
+                class.find_legacy_typevars(db, typevars);
+            }
+            SubclassOfInner::Dynamic(_) => {}
+        }
     }
 
     pub(crate) fn find_name_in_mro_with_policy(


### PR DESCRIPTION
We were not inducting into instance types and subclass-of types when looking for legacy typevars, nor when apply specializations.

This addresses https://github.com/astral-sh/ruff/pull/17832#discussion_r2081502056

```py
from __future__ import annotations
from typing import TypeVar, Any, reveal_type

S = TypeVar("S")

class Foo[T]:
    def method(self, other: Foo[S]) -> Foo[T | S]: ...  # type: ignore[invalid-return-type]

def f(x: Foo[Any], y: Foo[Any]):
    reveal_type(x.method(y))  # revealed: `Foo[Any | S]`, but should be `Foo[Any]`
```

We were not detecting that `S` made `method` generic, since we were not finding it when searching the function signature for legacy typevars.