### PR TITLE
[ty] recognize non-fully-static specializations

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_fully_static.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_fully_static.md
@@ -130,3 +130,13 @@ static_assert(is_fully_static(TypeOf[static]))
 static_assert(not is_fully_static(CallableTypeOf[gradual]))
 static_assert(is_fully_static(CallableTypeOf[static]))
 ```
+
+## Generics
+
+```py
+from typing import Any
+from ty_extensions import static_assert, is_fully_static
+
+static_assert(is_fully_static(list[int]))
+static_assert(not is_fully_static(list[Any]))
+```

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/truthiness.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/truthiness.md
@@ -112,7 +112,7 @@ from typing_extensions import _NoDefaultType
 static_assert(is_subtype_of(sys.version_info.__class__, AlwaysTruthy))
 static_assert(is_subtype_of(types.EllipsisType, AlwaysTruthy))
 static_assert(is_subtype_of(_NoDefaultType, AlwaysTruthy))
-static_assert(is_subtype_of(slice, AlwaysTruthy))
+static_assert(is_subtype_of(slice[int, int, int], AlwaysTruthy))
 static_assert(is_subtype_of(types.FunctionType, AlwaysTruthy))
 static_assert(is_subtype_of(types.MethodType, AlwaysTruthy))
 static_assert(is_subtype_of(typing.TypeVar, AlwaysTruthy))

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -292,6 +292,10 @@ pub struct Specialization<'db> {
 }
 
 impl<'db> Specialization<'db> {
+    pub(crate) fn is_fully_static(self, db: &'db dyn Db) -> bool {
+        self.types(db).iter().all(|ty| ty.is_fully_static(db))
+    }
+
     pub(crate) fn type_mapping(self) -> TypeMapping<'db, 'db> {
         TypeMapping::Specialization(self)
     }

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -66,6 +66,10 @@ impl<'db> NominalInstanceType<'db> {
         self.class
     }
 
+    pub(super) fn is_fully_static(self, db: &'db dyn Db) -> bool {
+        self.class.is_fully_static(db)
+    }
+
     pub(super) fn is_subtype_of(self, db: &'db dyn Db, other: Self) -> bool {
         // N.B. The subclass relation is fully static
         self.class.is_subclass_of(db, other.class)

--- a/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
+++ b/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
@@ -220,6 +220,8 @@ fn arbitrary_core_type(g: &mut Gen) -> Ty {
         Ty::KnownClassInstance(KnownClass::Str),
         Ty::KnownClassInstance(KnownClass::Int),
         Ty::KnownClassInstance(KnownClass::Bool),
+        Ty::KnownClassInstance(KnownClass::List),
+        Ty::KnownClassInstance(KnownClass::Tuple),
         Ty::KnownClassInstance(KnownClass::FunctionType),
         Ty::KnownClassInstance(KnownClass::SpecialForm),
         Ty::KnownClassInstance(KnownClass::TypeVar),


### PR DESCRIPTION
## Summary

Recognize that e.g. `list[Unknown]` is not a fully-static type.

Does not address the pre-existing TODO for recognizing that subclasses of dynamic are not fully-static.

## Test Plan

Added mdtests.
