### PR TITLE
[ty] Allow classes to inherit from `type[Any]` or `type[Unknown]`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/mro.md
+++ b/crates/ty_python_semantic/resources/mdtest/mro.md
@@ -177,6 +177,23 @@ if not isinstance(DoesNotExist, type):
     reveal_type(Foo.__mro__)  # revealed: tuple[<class 'Foo'>, Unknown, <class 'object'>]
 ```
 
+## Inheritance from `type[Any]` and `type[Unknown]`
+
+Inheritance from `type[Any]` and `type[Unknown]` is also permitted, in keeping with the gradual
+guarantee:
+
+```py
+from typing import Any
+from ty_extensions import Unknown, Intersection
+
+def f(x: type[Any], y: Intersection[Unknown, type[Any]]):
+    class Foo(x): ...
+    reveal_type(Foo.__mro__)  # revealed: tuple[<class 'Foo'>, Any, <class 'object'>]
+
+    class Bar(y): ...
+    reveal_type(Bar.__mro__)  # revealed: tuple[<class 'Bar'>, Unknown, <class 'object'>]
+```
+
 ## `__bases__` lists that cause errors at runtime
 
 If the class's `__bases__` cause an exception to be raised at runtime and therefore the class

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/mro.md_-_Method_Resolution_Order_tests_-_`__bases__`_lists_with_duplicate_bases.snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/mro.md_-_Method_Resolution_Order_tests_-_`__bases__`_lists_with_duplicate_bases.snap
@@ -141,6 +141,43 @@ info[revealed-type]: Revealed type
 ```
 
 ```
+error[duplicate-base]: Duplicate base class `Eggs`
+  --> src/mdtest_snippet.py:16:7
+   |
+14 |   # error: [duplicate-base] "Duplicate base class `Spam`"
+15 |   # error: [duplicate-base] "Duplicate base class `Eggs`"
+16 |   class Ham(
+   |  _______^
+17 | |     Spam,
+18 | |     Eggs,
+19 | |     Bar,
+20 | |     Baz,
+21 | |     Spam,
+22 | |     Eggs,
+23 | | ): ...
+   | |_^
+24 |
+25 |   # fmt: on
+   |
+info: The definition of class `Ham` will raise `TypeError` at runtime
+  --> src/mdtest_snippet.py:18:5
+   |
+16 | class Ham(
+17 |     Spam,
+18 |     Eggs,
+   |     ---- Class `Eggs` first included in bases list here
+19 |     Bar,
+20 |     Baz,
+21 |     Spam,
+22 |     Eggs,
+   |     ^^^^ Class `Eggs` later repeated here
+23 | ): ...
+   |
+info: rule `duplicate-base` is enabled by default
+
+```
+
+```
 error[duplicate-base]: Duplicate base class `Spam`
   --> src/mdtest_snippet.py:16:7
    |
@@ -172,43 +209,6 @@ info: The definition of class `Ham` will raise `TypeError` at runtime
 21 |     Spam,
    |     ^^^^ Class `Spam` later repeated here
 22 |     Eggs,
-23 | ): ...
-   |
-info: rule `duplicate-base` is enabled by default
-
-```
-
-```
-error[duplicate-base]: Duplicate base class `Eggs`
-  --> src/mdtest_snippet.py:16:7
-   |
-14 |   # error: [duplicate-base] "Duplicate base class `Spam`"
-15 |   # error: [duplicate-base] "Duplicate base class `Eggs`"
-16 |   class Ham(
-   |  _______^
-17 | |     Spam,
-18 | |     Eggs,
-19 | |     Bar,
-20 | |     Baz,
-21 | |     Spam,
-22 | |     Eggs,
-23 | | ): ...
-   | |_^
-24 |
-25 |   # fmt: on
-   |
-info: The definition of class `Ham` will raise `TypeError` at runtime
-  --> src/mdtest_snippet.py:18:5
-   |
-16 | class Ham(
-17 |     Spam,
-18 |     Eggs,
-   |     ---- Class `Eggs` first included in bases list here
-19 |     Bar,
-20 |     Baz,
-21 |     Spam,
-22 |     Eggs,
-   |     ^^^^ Class `Eggs` later repeated here
 23 | ): ...
    |
 info: rule `duplicate-base` is enabled by default

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -543,13 +543,6 @@ impl<'db> Type<'db> {
         Self::Dynamic(DynamicType::Unknown)
     }
 
-    pub(crate) fn into_dynamic(self) -> Option<DynamicType> {
-        match self {
-            Type::Dynamic(dynamic_type) => Some(dynamic_type),
-            _ => None,
-        }
-    }
-
     pub fn object(db: &'db dyn Db) -> Self {
         KnownClass::Object.to_instance(db)
     }

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -138,6 +138,13 @@ impl<'db> SubclassOfInner<'db> {
         }
     }
 
+    pub(crate) const fn into_dynamic(self) -> Option<DynamicType> {
+        match self {
+            Self::Class(_) => None,
+            Self::Dynamic(dynamic) => Some(dynamic),
+        }
+    }
+
     pub(crate) fn try_from_type(db: &'db dyn Db, ty: Type<'db>) -> Option<Self> {
         match ty {
             Type::Dynamic(dynamic) => Some(Self::Dynamic(dynamic)),


### PR DESCRIPTION
## Summary

This continues our recent work to pay more respect to the gradual guarantee when inferring the MROs of classes. Classes are now permitted to inherit from `type[Any]` and `type[Unknown]`: since these are [actually intersection types](https://github.com/astral-sh/ty/issues/222), the same principle applies to these types as was established in https://github.com/astral-sh/ruff/pull/18055.

## Test Plan

mdtests added.

I wish I could tell you why the order of the diagnostics in the snapshot is changing as a result of these changes, but -- alas! -- I cannot. It doesn't seem like a massive problem, though.
