### PR TITLE
[ruff_python_ast] Fix redundant visitation of test expressions in elif clause statements

### DIFF
--- a/crates/ruff_python_ast/src/visitor/transformer.rs
+++ b/crates/ruff_python_ast/src/visitor/transformer.rs
@@ -234,9 +234,6 @@ pub fn walk_stmt<V: Transformer + ?Sized>(visitor: &V, stmt: &mut Stmt) {
             visitor.visit_expr(test);
             visitor.visit_body(body);
             for clause in elif_else_clauses {
-                if let Some(test) = &mut clause.test {
-                    visitor.visit_expr(test);
-                }
                 walk_elif_else_clause(visitor, clause);
             }
         }


### PR DESCRIPTION
Fix redundant AST visitation of elif clause test expressions

<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR addresses a bug in the AST traversal logic where the test expressions of elif clauses were being visited multiple times.

Removed the initial redundant visitation call to elif test expressions that originally occurred at
https://github.com/astral-sh/ruff/blob/0fb94c052e8e5e48743bf70931c4810bcc1fe53e/crates/ruff_python_ast/src/visitor/transformer.rs#L237
which duplicated the standard processing already implemented at 

https://github.com/astral-sh/ruff/blob/0fb94c052e8e5e48743bf70931c4810bcc1fe53e/crates/ruff_python_ast/src/visitor/transformer.rs#L110


## Test Plan

<!-- How was it tested? -->
