### PR TITLE
[ty] Support property tests for `BoundSuper`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
@@ -439,3 +439,29 @@ static_assert(is_disjoint_from(Callable[[], None], Literal[b""]))
 static_assert(is_disjoint_from(Callable[[], None], Literal[1]))
 static_assert(is_disjoint_from(Callable[[], None], Literal[True]))
 ```
+
+## Bound Super
+
+If both `super` are fully static, they are disjoint when at least one of their parameters differs.
+On the other hand, if either `super` is not fully static, they should never be considered disjoint.
+
+```py
+from ty_extensions import TypeOf, is_disjoint_from, static_assert
+
+def f(x):
+    static_assert(is_disjoint_from(TypeOf[super(int, int())], TypeOf[super(str, str())]))
+    static_assert(is_disjoint_from(TypeOf[super(int, int())], TypeOf[super(int, bool())]))
+    static_assert(not is_disjoint_from(TypeOf[super(int, int)], TypeOf[super(int, int)]))
+    static_assert(
+        not is_disjoint_from(
+            TypeOf[super(int, int())],
+            TypeOf[super(int, int())],
+        )
+    )
+
+    # includes gradual types
+    static_assert(not is_disjoint_from(TypeOf[super(x, x)], TypeOf[super(x, x)]))
+    static_assert(not is_disjoint_from(TypeOf[super(x, int())], TypeOf[super(x, str())]))
+    static_assert(not is_disjoint_from(TypeOf[super(int, x)], TypeOf[super(str, x)]))
+    static_assert(not is_disjoint_from(TypeOf[super(int, x)], TypeOf[super(x, int())]))
+```

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2087,10 +2087,23 @@ impl<'db> Type<'db> {
                     .is_disjoint_from(db, other)
             }
 
-            (Type::BoundSuper(_), Type::BoundSuper(_)) => !self.is_equivalent_to(db, other),
-            (Type::BoundSuper(_), other) | (other, Type::BoundSuper(_)) => KnownClass::Super
-                .to_instance(db)
-                .is_disjoint_from(db, other),
+            (Type::BoundSuper(_), Type::BoundSuper(_)) => {
+                if self.is_fully_static(db) && other.is_fully_static(db) {
+                    !self.is_equivalent_to(db, other)
+                } else {
+                    false
+                }
+            }
+            (bound_super @ Type::BoundSuper(_), other)
+            | (other, bound_super @ Type::BoundSuper(_)) => {
+                if bound_super.is_fully_static(db) {
+                    KnownClass::Super
+                        .to_instance(db)
+                        .is_disjoint_from(db, other)
+                } else {
+                    false
+                }
+            }
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR includes the following changes:

-  Fix incorrect `disjoint_from` behavior for `BoundSuper` types with dynamic parameters

- Add `Ty::BoundSuper` cases to property tests

## Test Plan

1. Property tests for `BoundSuper`
- `QUICKCHECK_TESTS=10000 cargo test -p ty_python_semantic -- --ignored types::property_tests::stable`

2. Regression tests for incorrect disjoint_from behavior (mdtest)
- `cargo test -p ty_python_semantic --test mdtest -- disjoint`

