### PR TITLE
[ty] Add tests for `else` branches of `hasattr()` narrowing

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/narrow/hasattr.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/hasattr.md
@@ -15,12 +15,24 @@ def f(x: Foo):
     if hasattr(x, "spam"):
         reveal_type(x)  # revealed: Foo & <Protocol with members 'spam'>
         reveal_type(x.spam)  # revealed: object
+    else:
+        reveal_type(x)  # revealed: Foo & ~<Protocol with members 'spam'>
+
+        # TODO: should error and reveal `Unknown`
+        reveal_type(x.spam)  # revealed: @Todo(map_with_boundness: intersections with negative contributions)
 
     if hasattr(x, "not-an-identifier"):
+        reveal_type(x)  # revealed: Foo
+    else:
         reveal_type(x)  # revealed: Foo
 
 def y(x: Bar):
     if hasattr(x, "spam"):
         reveal_type(x)  # revealed: Never
         reveal_type(x.spam)  # revealed: Never
+    else:
+        reveal_type(x)  # revealed: Bar
+
+        # error: [unresolved-attribute]
+        reveal_type(x.spam)  # revealed: Unknown
 ```


### PR DESCRIPTION
## Summary

This addresses @sharkdp's post-merge review in https://github.com/astral-sh/ruff/pull/18053#discussion_r2086190617

## Test Plan

`cargo test -p ty_python_semantic`
