### PR TITLE
[`flake8-simplify`] add fix safety section (`SIM103`)

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/needless_bool.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/needless_bool.rs
@@ -32,15 +32,21 @@ use crate::fix::snippet::SourceCodeSnippet;
 ///
 /// Or, given:
 /// ```python
-/// if x > 0:
-///     return True
-/// return False
+/// def foo(x: int) -> bool:
+///     if x > 0:
+///         return True
+///     return False
 /// ```
 ///
 /// Use instead:
 /// ```python
-/// return x > 0
+/// def foo(x: int) -> bool:
+///     return x > 0
 /// ```
+///
+/// ## Fix safety
+///
+/// The fix is marked as unsafe because it could remove comments.
 ///
 /// ## References
 /// - [Python documentation: Truth Value Testing](https://docs.python.org/3/library/stdtypes.html#truth-value-testing)

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/needless_bool.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/needless_bool.rs
@@ -19,15 +19,17 @@ use crate::fix::snippet::SourceCodeSnippet;
 /// ## Example
 /// Given:
 /// ```python
-/// if x > 0:
-///     return True
-/// else:
-///     return False
+/// def foo(x: int) -> bool:
+///     if x > 0:
+///         return True
+///     else:
+///         return False
 /// ```
 ///
 /// Use instead:
 /// ```python
-/// return x > 0
+/// def foo(x: int) -> bool:
+///     return x > 0
 /// ```
 ///
 /// Or, given:
@@ -46,7 +48,8 @@ use crate::fix::snippet::SourceCodeSnippet;
 ///
 /// ## Fix safety
 ///
-/// The fix is marked as unsafe because it could remove comments.
+/// This fix is marked as unsafe because it may change the program’s behavior if the condition does not
+/// return a proper Boolean. Additionally, the fix could remove comments.
 ///
 /// ## References
 /// - [Python documentation: Truth Value Testing](https://docs.python.org/3/library/stdtypes.html#truth-value-testing)

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/needless_bool.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/needless_bool.rs
@@ -49,7 +49,9 @@ use crate::fix::snippet::SourceCodeSnippet;
 /// ## Fix safety
 ///
 /// This fix is marked as unsafe because it may change the program’s behavior if the condition does not
-/// return a proper Boolean. Additionally, the fix could remove comments.
+/// return a proper Boolean. While the fix will try to wrap non-boolean values in a call to bool,
+/// custom implementations of comparison functions like `__eq__` can avoid the bool call and still
+/// lead to altered behavior.
 ///
 /// ## References
 /// - [Python documentation: Truth Value Testing](https://docs.python.org/3/library/stdtypes.html#truth-value-testing)


### PR DESCRIPTION
The PR add the `fix safety` section for rule `SIM103` (#15584 )

### Unsafe Fix Example

```python
class Foo:
    def __eq__(self, other):
        return 1
    
def foo():
    if Foo() == 1:
        return True
    return False

def foo_fix():
    return Foo() == 1
    
print(foo()) # True
print(foo_fix()) # 1
```

### Note

I updated the code snippet example, because I thought it was cool to have a correct example, i.e., that I can paste inside the playground and it works :-) 