### PR TITLE
[ty] Reduce log level of 'symbol .. (via star import) not found' log message

### DIFF
--- a/crates/ty_python_semantic/src/semantic_index/visibility_constraints.rs
+++ b/crates/ty_python_semantic/src/semantic_index/visibility_constraints.rs
@@ -663,7 +663,7 @@ impl VisibilityConstraints {
                         if all_names.contains(symbol_name) {
                             Some(RequiresExplicitReExport::No)
                         } else {
-                            tracing::debug!(
+                            tracing::trace!(
                                 "Symbol `{}` (via star import) not found in `__all__` of `{}`",
                                 symbol_name,
                                 referenced_file.path(db)


### PR DESCRIPTION
## Summary

This seems pretty common and it now floods the console with debug messages, making `-vv` less useful. 



