### PR TITLE
[ty] Change layout of extra verbose output and respect `--color` for verbose output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1944,15 +1944,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nu-ansi-term"
-version = "0.50.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
-dependencies = [
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2706,7 +2697,6 @@ dependencies = [
  "thiserror 2.0.12",
  "tracing",
  "tracing-subscriber",
- "tracing-tree",
  "web-time",
  "zip",
 ]
@@ -3949,7 +3939,7 @@ checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
  "chrono",
  "matchers",
- "nu-ansi-term 0.46.0",
+ "nu-ansi-term",
  "once_cell",
  "regex",
  "sharded-slab",
@@ -3958,18 +3948,6 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
-]
-
-[[package]]
-name = "tracing-tree"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f459ca79f1b0d5f71c54ddfde6debfc59c8b6eeb46808ae492077f739dc7b49c"
-dependencies = [
- "nu-ansi-term 0.50.1",
- "tracing-core",
- "tracing-log",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4011,7 +4011,6 @@ dependencies = [
  "tracing",
  "tracing-flame",
  "tracing-subscriber",
- "tracing-tree",
  "ty_project",
  "ty_python_semantic",
  "ty_server",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,7 +162,6 @@ tracing-subscriber = { version = "0.3.18", default-features = false, features = 
     "env-filter",
     "fmt",
 ] }
-tracing-tree = { version = "0.4.0" }
 tryfn = { version = "0.2.1" }
 typed-arena = { version = "2.0.2" }
 unic-ucd-category = { version = "0.9" }

--- a/crates/ruff_db/Cargo.toml
+++ b/crates/ruff_db/Cargo.toml
@@ -36,7 +36,6 @@ path-slash = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, optional = true }
-tracing-tree = { workspace = true, optional = true }
 rustc-hash = { workspace = true }
 zip = { workspace = true }
 
@@ -55,4 +54,4 @@ cache = ["ruff_cache"]
 os = ["ignore", "dep:etcetera"]
 serde = ["dep:serde", "camino/serde1"]
 # Exposes testing utilities.
-testing = ["tracing-subscriber", "tracing-tree"]
+testing = ["tracing-subscriber"]

--- a/crates/ty/Cargo.toml
+++ b/crates/ty/Cargo.toml
@@ -35,7 +35,6 @@ salsa = { workspace = true }
 tracing = { workspace = true, features = ["release_max_level_debug"] }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 tracing-flame = { workspace = true }
-tracing-tree = { workspace = true }
 wild = { workspace = true }
 
 [dev-dependencies]

--- a/crates/ty/src/lib.rs
+++ b/crates/ty/src/lib.rs
@@ -60,7 +60,7 @@ fn run_check(args: CheckCommand) -> anyhow::Result<ExitStatus> {
 
     let verbosity = args.verbosity.level();
     countme::enable(verbosity.is_trace());
-    let _guard = setup_tracing(verbosity)?;
+    let _guard = setup_tracing(verbosity, args.color.unwrap_or_default())?;
 
     tracing::warn!(
         "ty is pre-release software and not ready for production use. \

--- a/crates/ty/src/logging.rs
+++ b/crates/ty/src/logging.rs
@@ -4,7 +4,7 @@ use anyhow::Context;
 use colored::Colorize;
 use std::fmt;
 use std::fs::File;
-use std::io::BufWriter;
+use std::io::{BufWriter, IsTerminal};
 use tracing::{Event, Subscriber};
 use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::fmt::format::Writer;
@@ -115,16 +115,16 @@ pub(crate) fn setup_tracing(level: VerbosityLevel) -> anyhow::Result<TracingGuar
         .with(filter)
         .with(profiling_layer);
 
+    let ansi =
+        colored::control::SHOULD_COLORIZE.should_colorize() && std::io::stderr().is_terminal();
+
     if level.is_trace() {
         let subscriber = registry.with(
-            tracing_tree::HierarchicalLayer::default()
-                .with_indent_lines(true)
-                .with_indent_amount(2)
-                .with_bracketed_fields(true)
+            tracing_subscriber::fmt::layer()
+                .event_format(tracing_subscriber::fmt::format().pretty())
                 .with_thread_ids(true)
-                .with_targets(true)
-                .with_writer(std::io::stderr)
-                .with_timer(tracing_tree::time::Uptime::default()),
+                .with_ansi(ansi)
+                .with_writer(std::io::stderr),
         );
 
         subscriber.init();
@@ -136,6 +136,7 @@ pub(crate) fn setup_tracing(level: VerbosityLevel) -> anyhow::Result<TracingGuar
                     display_timestamp: level.is_extra_verbose(),
                     show_spans: false,
                 })
+                .with_ansi(ansi)
                 .with_writer(std::io::stderr),
         );
 


### PR DESCRIPTION
## Summary

This makes two improvements to our tracing logging:

1. It disables ANSI if stderr isn't a terminal or `--color never` is specified
2. It replaces `tracing-tree` with the pretty formatter. tracing-tree is prone to panicking during unwinding due to a poisoned lock (https://github.com/davidbarsky/tracing-tree/issues/85). I also find it doesn't render nicely once multi threading is involved and deeply nested spans can be hard to read. The pretty format is a bit more verbose but I sort of like it. I can spli this change out if it proves controversial

```
  2025-05-14T08:39:04.479874Z TRACE ty_python_semantic::module_resolver::resolver: Resolved module `typing` to `vendored://stdlib/typing.pyi`
    at crates/ty_python_semantic/src/module_resolver/resolver.rs:47 on ThreadId(10)
    in ty_python_semantic::module_resolver::resolver::resolve_module with name=typing
    in ty_python_semantic::types::infer::infer_scope_types with scope=Id(1c00) file=File(System("/Users/micha/astral/test/tomllib/_types.py"))
    in ty_python_semantic::types::check_types with file=File(System("/Users/micha/astral/test/tomllib/_types.py"))
    in ty_project::check_file with file=file(Id(c06))
    in ty_project::Project::check

  2025-05-14T08:39:04.479889Z TRACE ruff_db::files: Adding file '/Users/micha/astral/test/__future__-stubs.py'
    at crates/ruff_db/src/files.rs:90 on ThreadId(4)
    in ty_python_semantic::module_resolver::resolver::resolve_module with name=__future__
    in ty_python_semantic::types::infer::infer_scope_types with scope=Id(2000) file=File(System("/Users/micha/astral/test/tomllib/_re.py"))
    in ty_python_semantic::types::check_types with file=File(System("/Users/micha/astral/test/tomllib/_re.py"))
    in ty_project::check_file with file=file(Id(c08))
    in ty_project::Project::check
```

## Test Plan

Verified that piping the logs to a file doesn't contain any ansi escpaes. Verified that the output is still colored when stderr isn't redirected
