### PR TITLE
[`airflow`] Add unsafe fix module moved cases (`AIR302`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_amazon.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_amazon.py
@@ -5,57 +5,29 @@ from airflow.hooks.S3_hook import (
     provide_bucket_name,
 )
 from airflow.operators.gcs_to_s3 import GCSToS3Operator
-
-
-
-
-
-
-
+from airflow.operators.google_api_to_s3_transfer import GoogleApiToS3Operator
+from airflow.operators.redshift_to_s3_operator import RedshiftToS3Operator
 from airflow.operators.s3_file_transform_operator import S3FileTransformOperator
-
-
-
-
+from airflow.operators.s3_to_redshift_operator import S3ToRedshiftOperator
 from airflow.sensors.s3_key_sensor import S3KeySensor
 
 S3Hook()
 provide_bucket_name()
 
 GCSToS3Operator()
-
-
-
-
-
-
-
-S3FileTransformOperator()
-
-
-
-
-S3KeySensor()
-
-from airflow.operators.google_api_to_s3_transfer import GoogleApiToS3Operator
-
 GoogleApiToS3Operator()
+RedshiftToS3Operator()
+S3FileTransformOperator()
+S3ToRedshiftOperator()
+S3KeySensor()
 
 from airflow.operators.google_api_to_s3_transfer import GoogleApiToS3Transfer
 
 GoogleApiToS3Transfer()
 
-from airflow.operators.redshift_to_s3_operator import RedshiftToS3Operator
-
-RedshiftToS3Operator()
-
 from airflow.operators.redshift_to_s3_operator import RedshiftToS3Transfer
 
 RedshiftToS3Transfer()
-
-from airflow.operators.s3_to_redshift_operator import S3ToRedshiftOperator
-
-S3ToRedshiftOperator()
 
 from airflow.operators.s3_to_redshift_operator import S3ToRedshiftTransfer
 

--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_amazon.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_amazon.py
@@ -5,19 +5,18 @@ from airflow.hooks.S3_hook import (
     provide_bucket_name,
 )
 from airflow.operators.gcs_to_s3 import GCSToS3Operator
-from airflow.operators.google_api_to_s3_transfer import (
-    GoogleApiToS3Operator,
-    GoogleApiToS3Transfer,
-)
-from airflow.operators.redshift_to_s3_operator import (
-    RedshiftToS3Operator,
-    RedshiftToS3Transfer,
-)
+
+
+
+
+
+
+
 from airflow.operators.s3_file_transform_operator import S3FileTransformOperator
-from airflow.operators.s3_to_redshift_operator import (
-    S3ToRedshiftOperator,
-    S3ToRedshiftTransfer,
-)
+
+
+
+
 from airflow.sensors.s3_key_sensor import S3KeySensor
 
 S3Hook()
@@ -25,15 +24,39 @@ provide_bucket_name()
 
 GCSToS3Operator()
 
-GoogleApiToS3Operator()
-GoogleApiToS3Transfer()
 
-RedshiftToS3Operator()
-RedshiftToS3Transfer()
+
+
+
+
 
 S3FileTransformOperator()
 
-S3ToRedshiftOperator()
-S3ToRedshiftTransfer()
+
+
 
 S3KeySensor()
+
+from airflow.operators.google_api_to_s3_transfer import GoogleApiToS3Operator
+
+GoogleApiToS3Operator()
+
+from airflow.operators.google_api_to_s3_transfer import GoogleApiToS3Transfer
+
+GoogleApiToS3Transfer()
+
+from airflow.operators.redshift_to_s3_operator import RedshiftToS3Operator
+
+RedshiftToS3Operator()
+
+from airflow.operators.redshift_to_s3_operator import RedshiftToS3Transfer
+
+RedshiftToS3Transfer()
+
+from airflow.operators.s3_to_redshift_operator import S3ToRedshiftOperator
+
+S3ToRedshiftOperator()
+
+from airflow.operators.s3_to_redshift_operator import S3ToRedshiftTransfer
+
+S3ToRedshiftTransfer()

--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_common_sql.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_common_sql.py
@@ -4,10 +4,13 @@ from airflow.hooks.dbapi import (
     ConnectorProtocol,
     DbApiHook,
 )
+
+ConnectorProtocol()
+DbApiHook()
+
 from airflow.hooks.dbapi_hook import DbApiHook
 from airflow.operators.check_operator import SQLCheckOperator
 
-ConnectorProtocol()
 DbApiHook()
 SQLCheckOperator()
 

--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_hive.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_hive.py
@@ -14,24 +14,24 @@ from airflow.operators.hive_operator import HiveOperator
 from airflow.operators.hive_stats_operator import HiveStatsCollectionOperator
 from airflow.operators.hive_to_mysql import (
     HiveToMySqlOperator,
-    HiveToMySqlTransfer,
+
 )
 from airflow.operators.hive_to_samba_operator import HiveToSambaOperator
-from airflow.operators.mssql_to_hive import (
-    MsSqlToHiveOperator,
-    MsSqlToHiveTransfer,
-)
-from airflow.operators.mysql_to_hive import (
-    MySqlToHiveOperator,
-    MySqlToHiveTransfer,
-)
-from airflow.operators.s3_to_hive_operator import (
-    S3ToHiveOperator,
-    S3ToHiveTransfer,
-)
-from airflow.sensors.hive_partition_sensor import HivePartitionSensor
-from airflow.sensors.metastore_partition_sensor import MetastorePartitionSensor
-from airflow.sensors.named_hive_partition_sensor import NamedHivePartitionSensor
+
+    
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 closest_ds_partition()
 max_partition()
@@ -46,21 +46,62 @@ HiveOperator()
 HiveStatsCollectionOperator()
 
 HiveToMySqlOperator()
-HiveToMySqlTransfer()
+
 
 HiveToSambaOperator()
 
-MsSqlToHiveOperator()
-MsSqlToHiveTransfer()
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+from airflow.operators.hive_to_mysql import HiveToMySqlTransfer
+
+HiveToMySqlTransfer()
+
+from airflow.operators.mysql_to_hive import MySqlToHiveOperator
 
 MySqlToHiveOperator()
+
+from airflow.operators.mysql_to_hive import MySqlToHiveTransfer
+
 MySqlToHiveTransfer()
 
+from airflow.operators.mssql_to_hive import MsSqlToHiveOperator
+
+MsSqlToHiveOperator()
+
+from airflow.operators.mssql_to_hive import MsSqlToHiveTransfer
+
+MsSqlToHiveTransfer()
+
+from airflow.operators.s3_to_hive_operator import S3ToHiveOperator
+
 S3ToHiveOperator()
+
+from airflow.operators.s3_to_hive_operator import S3ToHiveTransfer
+
 S3ToHiveTransfer()
+
+from airflow.sensors.hive_partition_sensor import HivePartitionSensor
 
 HivePartitionSensor()
 
+from airflow.sensors.metastore_partition_sensor import MetastorePartitionSensor
+
 MetastorePartitionSensor()
 
+from airflow.sensors.named_hive_partition_sensor import NamedHivePartitionSensor
 NamedHivePartitionSensor()

--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_hive.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_hive.py
@@ -12,59 +12,21 @@ from airflow.macros.hive import (
 )
 from airflow.operators.hive_operator import HiveOperator
 from airflow.operators.hive_stats_operator import HiveStatsCollectionOperator
-from airflow.operators.hive_to_mysql import (
-    HiveToMySqlOperator,
-
-)
+from airflow.operators.hive_to_mysql import HiveToMySqlOperator
 from airflow.operators.hive_to_samba_operator import HiveToSambaOperator
 
-    
-
-
-
-
-
-
-
-
-
-
-
-
-
+HIVE_QUEUE_PRIORITIES
+HiveCliHook()
+HiveMetastoreHook()
+HiveServer2Hook()
 
 closest_ds_partition()
 max_partition()
 
-HiveCliHook()
-HiveMetastoreHook()
-HiveServer2Hook()
-HIVE_QUEUE_PRIORITIES
-
 HiveOperator()
-
 HiveStatsCollectionOperator()
-
 HiveToMySqlOperator()
-
-
 HiveToSambaOperator()
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 from airflow.operators.hive_to_mysql import HiveToMySqlTransfer
@@ -104,4 +66,5 @@ from airflow.sensors.metastore_partition_sensor import MetastorePartitionSensor
 MetastorePartitionSensor()
 
 from airflow.sensors.named_hive_partition_sensor import NamedHivePartitionSensor
+
 NamedHivePartitionSensor()

--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_kubernetes.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_kubernetes.py
@@ -16,15 +16,15 @@ from airflow.kubernetes.kube_client import (
 from airflow.kubernetes.kubernetes_helper_functions import (
     add_pod_suffix,
     annotations_for_logging_task_metadata,
-    annotations_to_key,
+    
     create_pod_id,
-    get_logs_task_metadata,
-    rand_str,
+    
+
 )
-from airflow.kubernetes.pod import (
-    Port,
-    Resources,
-)
+
+
+
+
 
 ALL_NAMESPACES
 POD_EXECUTOR_DONE_KEY
@@ -40,18 +40,18 @@ add_pod_suffix()
 create_pod_id()
 
 annotations_for_logging_task_metadata()
-annotations_to_key()
-get_logs_task_metadata()
-rand_str()
 
-Port()
-Resources()
+
+
+
+
+
 
 
 from airflow.kubernetes.pod_generator import (
     PodDefaults,
     PodGenerator,
-    PodGeneratorDeprecated,
+
     add_pod_suffix,
     datetime_to_label_safe_datestring,
     extend_object_field,
@@ -68,7 +68,7 @@ make_safe_label_value()
 merge_objects()
 PodGenerator()
 PodDefaults()
-PodGeneratorDeprecated()
+
 add_pod_suffix()
 rand_str()
 
@@ -87,8 +87,8 @@ PodDefaults()
 PodGenerator()
 make_safe_label_value()
 
-PodLauncher()
-PodStatus()
+
+
 
 
 from airflow.kubernetes.pod_launcher_deprecated import (
@@ -115,3 +115,25 @@ K8SModel()
 Secret()
 Volume()
 VolumeMount()
+
+
+from airflow.kubernetes.pod import (
+    Port,
+    Resources,
+)
+
+PodLauncher()
+PodStatus()
+
+from airflow.kubernetes.kubernetes_helper_functions import (
+    annotations_to_key,
+    get_logs_task_metadata,
+    rand_str,
+)
+annotations_to_key()
+get_logs_task_metadata()
+rand_str()
+
+from airflow.kubernetes.pod_generator import PodGeneratorDeprecated
+
+PodGeneratorDeprecated()

--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_kubernetes.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_kubernetes.py
@@ -16,15 +16,8 @@ from airflow.kubernetes.kube_client import (
 from airflow.kubernetes.kubernetes_helper_functions import (
     add_pod_suffix,
     annotations_for_logging_task_metadata,
-    
     create_pod_id,
-    
-
 )
-
-
-
-
 
 ALL_NAMESPACES
 POD_EXECUTOR_DONE_KEY
@@ -37,21 +30,13 @@ _enable_tcp_keepalive()
 get_kube_client()
 
 add_pod_suffix()
-create_pod_id()
-
 annotations_for_logging_task_metadata()
-
-
-
-
-
-
+create_pod_id()
 
 
 from airflow.kubernetes.pod_generator import (
     PodDefaults,
     PodGenerator,
-
     add_pod_suffix,
     datetime_to_label_safe_datestring,
     extend_object_field,
@@ -61,17 +46,15 @@ from airflow.kubernetes.pod_generator import (
     rand_str,
 )
 
+PodDefaults()
+PodGenerator()
+add_pod_suffix()
 datetime_to_label_safe_datestring()
 extend_object_field()
 label_safe_datestring_to_datetime()
 make_safe_label_value()
 merge_objects()
-PodGenerator()
-PodDefaults()
-
-add_pod_suffix()
 rand_str()
-
 
 from airflow.kubernetes.pod_generator_deprecated import (
     PodDefaults,
@@ -87,9 +70,8 @@ PodDefaults()
 PodGenerator()
 make_safe_label_value()
 
-
-
-
+PodLauncher()
+PodStatus()
 
 from airflow.kubernetes.pod_launcher_deprecated import (
     PodDefaults,
@@ -116,20 +98,12 @@ Secret()
 Volume()
 VolumeMount()
 
-
-from airflow.kubernetes.pod import (
-    Port,
-    Resources,
-)
-
-PodLauncher()
-PodStatus()
-
 from airflow.kubernetes.kubernetes_helper_functions import (
     annotations_to_key,
     get_logs_task_metadata,
     rand_str,
 )
+
 annotations_to_key()
 get_logs_task_metadata()
 rand_str()

--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_standard.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_standard.py
@@ -5,10 +5,6 @@ from airflow.operators.dagrun_operator import (
     TriggerDagRunLink,
     TriggerDagRunOperator,
 )
-
-
-
-
 from airflow.operators.latest_only_operator import LatestOnlyOperator
 from airflow.operators.python_operator import (
     BranchPythonOperator,
@@ -19,15 +15,12 @@ from airflow.operators.python_operator import (
 from airflow.sensors.external_task_sensor import (
     ExternalTaskMarker,
     ExternalTaskSensor,
-
 )
 
 BashOperator()
 
 TriggerDagRunLink()
 TriggerDagRunOperator()
-
-
 
 LatestOnlyOperator()
 
@@ -40,33 +33,46 @@ ExternalTaskMarker()
 ExternalTaskSensor()
 
 
-
-
-
-
-
-
-
-
 from airflow.hooks.subprocess import SubprocessResult
+
 SubprocessResult()
+
 from airflow.hooks.subprocess import working_directory
+
 working_directory()
+
 from airflow.operators.datetime import target_times_as_dates
+
 target_times_as_dates()
+
 from airflow.operators.trigger_dagrun import TriggerDagRunLink
+
 TriggerDagRunLink()
+
 from airflow.sensors.external_task import ExternalTaskSensorLink
+
 ExternalTaskSensorLink()
+
 from airflow.sensors.time_delta import WaitSensor
+
 WaitSensor()
+
 from airflow.operators.dummy import DummyOperator
+
 DummyOperator()
+
 from airflow.operators.dummy import EmptyOperator
+
 EmptyOperator()
+
 from airflow.operators.dummy_operator import DummyOperator
+
 DummyOperator()
+
 from airflow.operators.dummy_operator import EmptyOperator
+
 EmptyOperator()
+
 from airflow.sensors.external_task_sensor import ExternalTaskSensorLink
+
 ExternalTaskSensorLink()

--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_standard.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_standard.py
@@ -5,10 +5,10 @@ from airflow.operators.dagrun_operator import (
     TriggerDagRunLink,
     TriggerDagRunOperator,
 )
-from airflow.operators.dummy import (
-    DummyOperator,
-    EmptyOperator,
-)
+
+
+
+
 from airflow.operators.latest_only_operator import LatestOnlyOperator
 from airflow.operators.python_operator import (
     BranchPythonOperator,
@@ -19,15 +19,15 @@ from airflow.operators.python_operator import (
 from airflow.sensors.external_task_sensor import (
     ExternalTaskMarker,
     ExternalTaskSensor,
-    ExternalTaskSensorLink,
+
 )
 
 BashOperator()
 
 TriggerDagRunLink()
 TriggerDagRunOperator()
-DummyOperator()
-EmptyOperator()
+
+
 
 LatestOnlyOperator()
 
@@ -38,15 +38,15 @@ ShortCircuitOperator()
 
 ExternalTaskMarker()
 ExternalTaskSensor()
-ExternalTaskSensorLink()
 
-from airflow.operators.dummy_operator import (
-    DummyOperator,
-    EmptyOperator,
-)
 
-DummyOperator()
-EmptyOperator()
+
+
+
+
+
+
+
 
 from airflow.hooks.subprocess import SubprocessResult
 SubprocessResult()
@@ -60,3 +60,13 @@ from airflow.sensors.external_task import ExternalTaskSensorLink
 ExternalTaskSensorLink()
 from airflow.sensors.time_delta import WaitSensor
 WaitSensor()
+from airflow.operators.dummy import DummyOperator
+DummyOperator()
+from airflow.operators.dummy import EmptyOperator
+EmptyOperator()
+from airflow.operators.dummy_operator import DummyOperator
+DummyOperator()
+from airflow.operators.dummy_operator import EmptyOperator
+EmptyOperator()
+from airflow.sensors.external_task_sensor import ExternalTaskSensorLink
+ExternalTaskSensorLink()

--- a/crates/ruff_linter/src/rules/airflow/helpers.rs
+++ b/crates/ruff_linter/src/rules/airflow/helpers.rs
@@ -187,6 +187,9 @@ pub(crate) fn match_head(value: &Expr) -> Option<&ExprName> {
     }
 }
 
+/// Return the [`Fix`] that imports the new name and updates where the import is referenced.
+/// This is used for cases that member name has changed.
+/// (e.g., `airflow.datasts.Dataset` to `airflow.sdk.Asset`)
 pub(crate) fn generate_import_edit(
     expr: &Expr,
     checker: &Checker,
@@ -206,6 +209,9 @@ pub(crate) fn generate_import_edit(
     Some(Fix::safe_edits(import_edit, [replacement_edit]))
 }
 
+/// Return the [`Fix`] that remove the original import and import the same name with new path.
+/// This is used for cases that member name has not changed.
+/// (e.g., `airflow.operators.pig_operator.PigOperator` to `airflow.providers.apache.pig.hooks.pig.PigCliHook`)
 pub(crate) fn generate_remove_and_runtime_import_edit(
     expr: &Expr,
     checker: &Checker,

--- a/crates/ruff_linter/src/rules/airflow/helpers.rs
+++ b/crates/ruff_linter/src/rules/airflow/helpers.rs
@@ -1,10 +1,17 @@
+use crate::checkers::ast::Checker;
+use crate::fix::edits::remove_unused_imports;
+use crate::importer::ImportRequest;
 use crate::rules::numpy::helpers::{AttributeSearcher, ImportSearcher};
+use ruff_diagnostics::{Edit, Fix};
 use ruff_python_ast::name::QualifiedNameBuilder;
 use ruff_python_ast::statement_visitor::StatementVisitor;
 use ruff_python_ast::visitor::Visitor;
-use ruff_python_ast::{Expr, ExprName, StmtTry};
+use ruff_python_ast::{Expr, ExprAttribute, ExprName, StmtTry};
 use ruff_python_semantic::Exceptions;
 use ruff_python_semantic::SemanticModel;
+use ruff_python_semantic::{MemberNameImport, NameImport};
+use ruff_text_size::Ranged;
+use ruff_text_size::TextRange;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum Replacement {
@@ -169,4 +176,65 @@ pub(crate) fn is_airflow_builtin_or_provider(
 
         _ => false,
     }
+}
+
+/// Return the [`ast::ExprName`] at the head of the expression, if any.
+pub(crate) fn match_head(value: &Expr) -> Option<&ExprName> {
+    match value {
+        Expr::Attribute(ExprAttribute { value, .. }) => match_head(value),
+        Expr::Name(name) => Some(name),
+        _ => None,
+    }
+}
+
+pub(crate) fn generate_import_edit(
+    expr: &Expr,
+    checker: &Checker,
+    module: &str,
+    name: &str,
+    ranged: TextRange,
+) -> Option<Fix> {
+    let (import_edit, _) = checker
+        .importer()
+        .get_or_import_symbol(
+            &ImportRequest::import_from(module, name),
+            expr.start(),
+            checker.semantic(),
+        )
+        .ok()?;
+    let replacement_edit = Edit::range_replacement(name.to_string(), ranged.range());
+    Some(Fix::safe_edits(import_edit, [replacement_edit]))
+}
+
+pub(crate) fn generate_remove_and_runtime_import_edit(
+    expr: &Expr,
+    checker: &Checker,
+    module: &str,
+    name: &str,
+) -> Option<Fix> {
+    let head = match_head(expr)?;
+    let semantic = checker.semantic();
+    let binding = semantic
+        .resolve_name(head)
+        .or_else(|| checker.semantic().lookup_symbol(&head.id))
+        .map(|id| checker.semantic().binding(id))?;
+    let stmt = binding.statement(semantic)?;
+    let remove_edit = remove_unused_imports(
+        std::iter::once(name),
+        stmt,
+        None,
+        checker.locator(),
+        checker.stylist(),
+        checker.indexer(),
+    )
+    .ok()?;
+    let import_edit = checker.importer().add_import(
+        &NameImport::ImportFrom(MemberNameImport::member(
+            (*module).to_string(),
+            name.to_string(),
+        )),
+        expr.start(),
+    );
+
+    Some(Fix::unsafe_edits(remove_edit, [import_edit]))
 }

--- a/crates/ruff_linter/src/rules/airflow/helpers.rs
+++ b/crates/ruff_linter/src/rules/airflow/helpers.rs
@@ -181,7 +181,7 @@ pub(crate) fn is_airflow_builtin_or_provider(
 /// Return the [`ast::ExprName`] at the head of the expression, if any.
 pub(crate) fn match_head(value: &Expr) -> Option<&ExprName> {
     match value {
-        Expr::Attribute(ExprAttribute { value, .. }) => match_head(value),
+        Expr::Attribute(ExprAttribute { value, .. }) => value.as_name_expr(),
         Expr::Name(name) => Some(name),
         _ => None,
     }

--- a/crates/ruff_linter/src/rules/airflow/rules/moved_to_provider_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/moved_to_provider_in_3.rs
@@ -1,3 +1,8 @@
+use crate::checkers::ast::Checker;
+use crate::rules::airflow::helpers::{
+    ProviderReplacement, generate_import_edit, generate_remove_and_runtime_import_edit,
+    is_guarded_by_try_except,
+};
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_python_ast::name::QualifiedName;
 use ruff_python_ast::{Expr, ExprAttribute};
@@ -5,10 +10,7 @@ use ruff_python_semantic::Modules;
 use ruff_text_size::Ranged;
 use ruff_text_size::TextRange;
 
-use crate::checkers::ast::Checker;
-use crate::importer::ImportRequest;
-use crate::rules::airflow::helpers::{ProviderReplacement, is_guarded_by_try_except};
-use crate::{Edit, Fix, FixAvailability, Violation};
+use crate::{FixAvailability, Violation};
 
 /// ## What it does
 /// Checks for uses of Airflow functions and values that have been moved to it providers.
@@ -1219,21 +1221,17 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
         return;
     }
 
-    checker
-        .report_diagnostic(
-            Airflow3MovedToProvider {
-                deprecated: qualified_name,
-                replacement: replacement.clone(),
-            },
-            ranged,
-        )
-        .try_set_fix(|| {
-            let (import_edit, binding) = checker.importer().get_or_import_symbol(
-                &ImportRequest::import_from(module, name),
-                expr.start(),
-                checker.semantic(),
-            )?;
-            let replacement_edit = Edit::range_replacement(binding, ranged);
-            Ok(Fix::safe_edits(import_edit, [replacement_edit]))
-        });
+    let mut diagnostic = checker.report_diagnostic(
+        Airflow3MovedToProvider {
+            deprecated: qualified_name,
+            replacement: replacement.clone(),
+        },
+        ranged,
+    );
+
+    if let Some(fix) = generate_import_edit(expr, checker, module, name, ranged)
+        .or_else(|| generate_remove_and_runtime_import_edit(expr, checker, module, name))
+    {
+        diagnostic.set_fix(fix);
+    }
 }

--- a/crates/ruff_linter/src/rules/airflow/rules/moved_to_provider_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/moved_to_provider_in_3.rs
@@ -1171,7 +1171,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
         [
             "airflow",
             "sensors",
-            "external_task",
+            "external_task" | "external_task_sensor",
             "ExternalTaskSensorLink",
         ] => ProviderReplacement::AutoImport {
             module: "airflow.providers.standard.sensors.external_task",
@@ -1183,7 +1183,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             "airflow",
             "sensors",
             "external_task_sensor",
-            rest @ ("ExternalTaskMarker" | "ExternalTaskSensor" | "ExternalTaskSensorLink"),
+            rest @ ("ExternalTaskMarker" | "ExternalTaskSensor"),
         ] => ProviderReplacement::SourceModuleMovedToProvider {
             module: "airflow.providers.standard.sensors.external_task",
             name: (*rest).to_string(),

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_amazon.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_amazon.py.snap
@@ -1,13 +1,13 @@
 ---
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 ---
-AIR302_amazon.py:22:1: AIR302 [*] `airflow.hooks.S3_hook.S3Hook` is moved into `amazon` provider in Airflow 3.0;
+AIR302_amazon.py:14:1: AIR302 [*] `airflow.hooks.S3_hook.S3Hook` is moved into `amazon` provider in Airflow 3.0;
    |
-20 | from airflow.sensors.s3_key_sensor import S3KeySensor
-21 |
-22 | S3Hook()
+12 | from airflow.sensors.s3_key_sensor import S3KeySensor
+13 |
+14 | S3Hook()
    | ^^^^^^ AIR302
-23 | provide_bucket_name()
+15 | provide_bucket_name()
    |
    = help: Install `apache-airflow-providers-amazon>=1.0.0` and use `S3Hook` from `airflow.providers.amazon.aws.hooks.s3` instead.
 
@@ -20,21 +20,21 @@ AIR302_amazon.py:22:1: AIR302 [*] `airflow.hooks.S3_hook.S3Hook` is moved into `
 6  5  | )
 7  6  | from airflow.operators.gcs_to_s3 import GCSToS3Operator
 --------------------------------------------------------------------------------
-18 17 | 
-19 18 | 
-20 19 | from airflow.sensors.s3_key_sensor import S3KeySensor
-   20 |+from airflow.providers.amazon.aws.hooks.s3 import S3Hook
-21 21 | 
-22 22 | S3Hook()
-23 23 | provide_bucket_name()
+10 9  | from airflow.operators.s3_file_transform_operator import S3FileTransformOperator
+11 10 | from airflow.operators.s3_to_redshift_operator import S3ToRedshiftOperator
+12 11 | from airflow.sensors.s3_key_sensor import S3KeySensor
+   12 |+from airflow.providers.amazon.aws.hooks.s3 import S3Hook
+13 13 | 
+14 14 | S3Hook()
+15 15 | provide_bucket_name()
 
-AIR302_amazon.py:23:1: AIR302 [*] `airflow.hooks.S3_hook.provide_bucket_name` is moved into `amazon` provider in Airflow 3.0;
+AIR302_amazon.py:15:1: AIR302 [*] `airflow.hooks.S3_hook.provide_bucket_name` is moved into `amazon` provider in Airflow 3.0;
    |
-22 | S3Hook()
-23 | provide_bucket_name()
+14 | S3Hook()
+15 | provide_bucket_name()
    | ^^^^^^^^^^^^^^^^^^^ AIR302
-24 |
-25 | GCSToS3Operator()
+16 |
+17 | GCSToS3Operator()
    |
    = help: Install `apache-airflow-providers-amazon>=1.0.0` and use `provide_bucket_name` from `airflow.providers.amazon.aws.hooks.s3` instead.
 
@@ -45,22 +45,24 @@ AIR302_amazon.py:23:1: AIR302 [*] `airflow.hooks.S3_hook.provide_bucket_name` is
 5     |-    provide_bucket_name,
 6  5  | )
 7  6  | from airflow.operators.gcs_to_s3 import GCSToS3Operator
-8  7  | 
+8  7  | from airflow.operators.google_api_to_s3_transfer import GoogleApiToS3Operator
 --------------------------------------------------------------------------------
-18 17 | 
-19 18 | 
-20 19 | from airflow.sensors.s3_key_sensor import S3KeySensor
-   20 |+from airflow.providers.amazon.aws.hooks.s3 import provide_bucket_name
-21 21 | 
-22 22 | S3Hook()
-23 23 | provide_bucket_name()
+10 9  | from airflow.operators.s3_file_transform_operator import S3FileTransformOperator
+11 10 | from airflow.operators.s3_to_redshift_operator import S3ToRedshiftOperator
+12 11 | from airflow.sensors.s3_key_sensor import S3KeySensor
+   12 |+from airflow.providers.amazon.aws.hooks.s3 import provide_bucket_name
+13 13 | 
+14 14 | S3Hook()
+15 15 | provide_bucket_name()
 
-AIR302_amazon.py:25:1: AIR302 [*] `airflow.operators.gcs_to_s3.GCSToS3Operator` is moved into `amazon` provider in Airflow 3.0;
+AIR302_amazon.py:17:1: AIR302 [*] `airflow.operators.gcs_to_s3.GCSToS3Operator` is moved into `amazon` provider in Airflow 3.0;
    |
-23 | provide_bucket_name()
-24 |
-25 | GCSToS3Operator()
+15 | provide_bucket_name()
+16 |
+17 | GCSToS3Operator()
    | ^^^^^^^^^^^^^^^ AIR302
+18 | GoogleApiToS3Operator()
+19 | RedshiftToS3Operator()
    |
    = help: Install `apache-airflow-providers-amazon>=1.0.0` and use `GCSToS3Operator` from `airflow.providers.amazon.aws.transfers.gcs_to_s3` instead.
 
@@ -69,175 +71,182 @@ AIR302_amazon.py:25:1: AIR302 [*] `airflow.operators.gcs_to_s3.GCSToS3Operator` 
 5  5  |     provide_bucket_name,
 6  6  | )
 7     |-from airflow.operators.gcs_to_s3 import GCSToS3Operator
-8  7  | 
-9  8  | 
-10 9  | 
---------------------------------------------------------------------------------
-18 17 | 
-19 18 | 
-20 19 | from airflow.sensors.s3_key_sensor import S3KeySensor
-   20 |+from airflow.providers.amazon.aws.transfers.gcs_to_s3 import GCSToS3Operator
-21 21 | 
-22 22 | S3Hook()
-23 23 | provide_bucket_name()
+8  7  | from airflow.operators.google_api_to_s3_transfer import GoogleApiToS3Operator
+9  8  | from airflow.operators.redshift_to_s3_operator import RedshiftToS3Operator
+10 9  | from airflow.operators.s3_file_transform_operator import S3FileTransformOperator
+11 10 | from airflow.operators.s3_to_redshift_operator import S3ToRedshiftOperator
+12 11 | from airflow.sensors.s3_key_sensor import S3KeySensor
+   12 |+from airflow.providers.amazon.aws.transfers.gcs_to_s3 import GCSToS3Operator
+13 13 | 
+14 14 | S3Hook()
+15 15 | provide_bucket_name()
 
-AIR302_amazon.py:33:1: AIR302 [*] `airflow.operators.s3_file_transform_operator.S3FileTransformOperator` is moved into `amazon` provider in Airflow 3.0;
+AIR302_amazon.py:18:1: AIR302 [*] `airflow.operators.google_api_to_s3_transfer.GoogleApiToS3Operator` is moved into `amazon` provider in Airflow 3.0;
    |
-33 | S3FileTransformOperator()
+17 | GCSToS3Operator()
+18 | GoogleApiToS3Operator()
+   | ^^^^^^^^^^^^^^^^^^^^^ AIR302
+19 | RedshiftToS3Operator()
+20 | S3FileTransformOperator()
+   |
+   = help: Install `apache-airflow-providers-amazon>=1.0.0` and use `GoogleApiToS3Operator` from `airflow.providers.amazon.aws.transfers.google_api_to_s3` instead.
+
+ℹ Unsafe fix
+5  5  |     provide_bucket_name,
+6  6  | )
+7  7  | from airflow.operators.gcs_to_s3 import GCSToS3Operator
+8     |-from airflow.operators.google_api_to_s3_transfer import GoogleApiToS3Operator
+9  8  | from airflow.operators.redshift_to_s3_operator import RedshiftToS3Operator
+10 9  | from airflow.operators.s3_file_transform_operator import S3FileTransformOperator
+11 10 | from airflow.operators.s3_to_redshift_operator import S3ToRedshiftOperator
+12 11 | from airflow.sensors.s3_key_sensor import S3KeySensor
+   12 |+from airflow.providers.amazon.aws.transfers.google_api_to_s3 import GoogleApiToS3Operator
+13 13 | 
+14 14 | S3Hook()
+15 15 | provide_bucket_name()
+
+AIR302_amazon.py:19:1: AIR302 [*] `airflow.operators.redshift_to_s3_operator.RedshiftToS3Operator` is moved into `amazon` provider in Airflow 3.0;
+   |
+17 | GCSToS3Operator()
+18 | GoogleApiToS3Operator()
+19 | RedshiftToS3Operator()
+   | ^^^^^^^^^^^^^^^^^^^^ AIR302
+20 | S3FileTransformOperator()
+21 | S3ToRedshiftOperator()
+   |
+   = help: Install `apache-airflow-providers-amazon>=1.0.0` and use `RedshiftToS3Operator` from `airflow.providers.amazon.aws.transfers.redshift_to_s3` instead.
+
+ℹ Unsafe fix
+6  6  | )
+7  7  | from airflow.operators.gcs_to_s3 import GCSToS3Operator
+8  8  | from airflow.operators.google_api_to_s3_transfer import GoogleApiToS3Operator
+9     |-from airflow.operators.redshift_to_s3_operator import RedshiftToS3Operator
+10 9  | from airflow.operators.s3_file_transform_operator import S3FileTransformOperator
+11 10 | from airflow.operators.s3_to_redshift_operator import S3ToRedshiftOperator
+12 11 | from airflow.sensors.s3_key_sensor import S3KeySensor
+   12 |+from airflow.providers.amazon.aws.transfers.redshift_to_s3 import RedshiftToS3Operator
+13 13 | 
+14 14 | S3Hook()
+15 15 | provide_bucket_name()
+
+AIR302_amazon.py:20:1: AIR302 [*] `airflow.operators.s3_file_transform_operator.S3FileTransformOperator` is moved into `amazon` provider in Airflow 3.0;
+   |
+18 | GoogleApiToS3Operator()
+19 | RedshiftToS3Operator()
+20 | S3FileTransformOperator()
    | ^^^^^^^^^^^^^^^^^^^^^^^ AIR302
+21 | S3ToRedshiftOperator()
+22 | S3KeySensor()
    |
    = help: Install `apache-airflow-providers-amazon>=3.0.0` and use `S3FileTransformOperator` from `airflow.providers.amazon.aws.operators.s3` instead.
 
 ℹ Unsafe fix
-12 12 | 
+7  7  | from airflow.operators.gcs_to_s3 import GCSToS3Operator
+8  8  | from airflow.operators.google_api_to_s3_transfer import GoogleApiToS3Operator
+9  9  | from airflow.operators.redshift_to_s3_operator import RedshiftToS3Operator
+10    |-from airflow.operators.s3_file_transform_operator import S3FileTransformOperator
+11 10 | from airflow.operators.s3_to_redshift_operator import S3ToRedshiftOperator
+12 11 | from airflow.sensors.s3_key_sensor import S3KeySensor
+   12 |+from airflow.providers.amazon.aws.operators.s3 import S3FileTransformOperator
 13 13 | 
-14 14 | 
-15    |-from airflow.operators.s3_file_transform_operator import S3FileTransformOperator
-16 15 | 
-17 16 | 
-18 17 | 
-19 18 | 
-20 19 | from airflow.sensors.s3_key_sensor import S3KeySensor
-   20 |+from airflow.providers.amazon.aws.operators.s3 import S3FileTransformOperator
-21 21 | 
-22 22 | S3Hook()
-23 23 | provide_bucket_name()
+14 14 | S3Hook()
+15 15 | provide_bucket_name()
 
-AIR302_amazon.py:38:1: AIR302 [*] `airflow.sensors.s3_key_sensor.S3KeySensor` is moved into `amazon` provider in Airflow 3.0;
+AIR302_amazon.py:21:1: AIR302 [*] `airflow.operators.s3_to_redshift_operator.S3ToRedshiftOperator` is moved into `amazon` provider in Airflow 3.0;
    |
-38 | S3KeySensor()
+19 | RedshiftToS3Operator()
+20 | S3FileTransformOperator()
+21 | S3ToRedshiftOperator()
+   | ^^^^^^^^^^^^^^^^^^^^ AIR302
+22 | S3KeySensor()
+   |
+   = help: Install `apache-airflow-providers-amazon>=1.0.0` and use `S3ToRedshiftOperator` from `airflow.providers.amazon.aws.transfers.s3_to_redshift` instead.
+
+ℹ Unsafe fix
+8  8  | from airflow.operators.google_api_to_s3_transfer import GoogleApiToS3Operator
+9  9  | from airflow.operators.redshift_to_s3_operator import RedshiftToS3Operator
+10 10 | from airflow.operators.s3_file_transform_operator import S3FileTransformOperator
+11    |-from airflow.operators.s3_to_redshift_operator import S3ToRedshiftOperator
+12 11 | from airflow.sensors.s3_key_sensor import S3KeySensor
+   12 |+from airflow.providers.amazon.aws.transfers.s3_to_redshift import S3ToRedshiftOperator
+13 13 | 
+14 14 | S3Hook()
+15 15 | provide_bucket_name()
+
+AIR302_amazon.py:22:1: AIR302 [*] `airflow.sensors.s3_key_sensor.S3KeySensor` is moved into `amazon` provider in Airflow 3.0;
+   |
+20 | S3FileTransformOperator()
+21 | S3ToRedshiftOperator()
+22 | S3KeySensor()
    | ^^^^^^^^^^^ AIR302
-39 |
-40 | from airflow.operators.google_api_to_s3_transfer import GoogleApiToS3Operator
+23 |
+24 | from airflow.operators.google_api_to_s3_transfer import GoogleApiToS3Transfer
    |
    = help: Install `apache-airflow-providers-amazon>=1.0.0` and use `S3KeySensor` from `airflow.providers.amazon.aws.sensors.s3` instead.
 
 ℹ Unsafe fix
-17 17 | 
-18 18 | 
-19 19 | 
-20    |-from airflow.sensors.s3_key_sensor import S3KeySensor
-   20 |+from airflow.providers.amazon.aws.sensors.s3 import S3KeySensor
-21 21 | 
-22 22 | S3Hook()
-23 23 | provide_bucket_name()
+9  9  | from airflow.operators.redshift_to_s3_operator import RedshiftToS3Operator
+10 10 | from airflow.operators.s3_file_transform_operator import S3FileTransformOperator
+11 11 | from airflow.operators.s3_to_redshift_operator import S3ToRedshiftOperator
+12    |-from airflow.sensors.s3_key_sensor import S3KeySensor
+   12 |+from airflow.providers.amazon.aws.sensors.s3 import S3KeySensor
+13 13 | 
+14 14 | S3Hook()
+15 15 | provide_bucket_name()
 
-AIR302_amazon.py:42:1: AIR302 [*] `airflow.operators.google_api_to_s3_transfer.GoogleApiToS3Operator` is moved into `amazon` provider in Airflow 3.0;
+AIR302_amazon.py:26:1: AIR302 [*] `airflow.operators.google_api_to_s3_transfer.GoogleApiToS3Transfer` is moved into `amazon` provider in Airflow 3.0;
    |
-40 | from airflow.operators.google_api_to_s3_transfer import GoogleApiToS3Operator
-41 |
-42 | GoogleApiToS3Operator()
+24 | from airflow.operators.google_api_to_s3_transfer import GoogleApiToS3Transfer
+25 |
+26 | GoogleApiToS3Transfer()
    | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-43 |
-44 | from airflow.operators.google_api_to_s3_transfer import GoogleApiToS3Transfer
+27 |
+28 | from airflow.operators.redshift_to_s3_operator import RedshiftToS3Transfer
    |
    = help: Install `apache-airflow-providers-amazon>=1.0.0` and use `GoogleApiToS3Operator` from `airflow.providers.amazon.aws.transfers.google_api_to_s3` instead.
 
 ℹ Unsafe fix
-37 37 | 
-38 38 | S3KeySensor()
-39 39 | 
-40    |-from airflow.operators.google_api_to_s3_transfer import GoogleApiToS3Operator
-   40 |+from airflow.providers.amazon.aws.transfers.google_api_to_s3 import GoogleApiToS3Operator
-41 41 | 
-42 42 | GoogleApiToS3Operator()
-43 43 | 
+22 22 | S3KeySensor()
+23 23 | 
+24 24 | from airflow.operators.google_api_to_s3_transfer import GoogleApiToS3Transfer
+   25 |+from airflow.providers.amazon.aws.transfers.google_api_to_s3 import GoogleApiToS3Operator
+25 26 | 
+26 27 | GoogleApiToS3Transfer()
+27 28 | 
 
-AIR302_amazon.py:46:1: AIR302 [*] `airflow.operators.google_api_to_s3_transfer.GoogleApiToS3Transfer` is moved into `amazon` provider in Airflow 3.0;
+AIR302_amazon.py:30:1: AIR302 [*] `airflow.operators.redshift_to_s3_operator.RedshiftToS3Transfer` is moved into `amazon` provider in Airflow 3.0;
    |
-44 | from airflow.operators.google_api_to_s3_transfer import GoogleApiToS3Transfer
-45 |
-46 | GoogleApiToS3Transfer()
-   | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-47 |
-48 | from airflow.operators.redshift_to_s3_operator import RedshiftToS3Operator
-   |
-   = help: Install `apache-airflow-providers-amazon>=1.0.0` and use `GoogleApiToS3Operator` from `airflow.providers.amazon.aws.transfers.google_api_to_s3` instead.
-
-ℹ Unsafe fix
-42 42 | GoogleApiToS3Operator()
-43 43 | 
-44 44 | from airflow.operators.google_api_to_s3_transfer import GoogleApiToS3Transfer
-   45 |+from airflow.providers.amazon.aws.transfers.google_api_to_s3 import GoogleApiToS3Operator
-45 46 | 
-46 47 | GoogleApiToS3Transfer()
-47 48 | 
-
-AIR302_amazon.py:50:1: AIR302 [*] `airflow.operators.redshift_to_s3_operator.RedshiftToS3Operator` is moved into `amazon` provider in Airflow 3.0;
-   |
-48 | from airflow.operators.redshift_to_s3_operator import RedshiftToS3Operator
-49 |
-50 | RedshiftToS3Operator()
+28 | from airflow.operators.redshift_to_s3_operator import RedshiftToS3Transfer
+29 |
+30 | RedshiftToS3Transfer()
    | ^^^^^^^^^^^^^^^^^^^^ AIR302
-51 |
-52 | from airflow.operators.redshift_to_s3_operator import RedshiftToS3Transfer
+31 |
+32 | from airflow.operators.s3_to_redshift_operator import S3ToRedshiftTransfer
    |
    = help: Install `apache-airflow-providers-amazon>=1.0.0` and use `RedshiftToS3Operator` from `airflow.providers.amazon.aws.transfers.redshift_to_s3` instead.
 
 ℹ Unsafe fix
-45 45 | 
-46 46 | GoogleApiToS3Transfer()
-47 47 | 
-48    |-from airflow.operators.redshift_to_s3_operator import RedshiftToS3Operator
-   48 |+from airflow.providers.amazon.aws.transfers.redshift_to_s3 import RedshiftToS3Operator
-49 49 | 
-50 50 | RedshiftToS3Operator()
-51 51 | 
+26 26 | GoogleApiToS3Transfer()
+27 27 | 
+28 28 | from airflow.operators.redshift_to_s3_operator import RedshiftToS3Transfer
+   29 |+from airflow.providers.amazon.aws.transfers.redshift_to_s3 import RedshiftToS3Operator
+29 30 | 
+30 31 | RedshiftToS3Transfer()
+31 32 | 
 
-AIR302_amazon.py:54:1: AIR302 [*] `airflow.operators.redshift_to_s3_operator.RedshiftToS3Transfer` is moved into `amazon` provider in Airflow 3.0;
+AIR302_amazon.py:34:1: AIR302 [*] `airflow.operators.s3_to_redshift_operator.S3ToRedshiftTransfer` is moved into `amazon` provider in Airflow 3.0;
    |
-52 | from airflow.operators.redshift_to_s3_operator import RedshiftToS3Transfer
-53 |
-54 | RedshiftToS3Transfer()
-   | ^^^^^^^^^^^^^^^^^^^^ AIR302
-55 |
-56 | from airflow.operators.s3_to_redshift_operator import S3ToRedshiftOperator
-   |
-   = help: Install `apache-airflow-providers-amazon>=1.0.0` and use `RedshiftToS3Operator` from `airflow.providers.amazon.aws.transfers.redshift_to_s3` instead.
-
-ℹ Unsafe fix
-50 50 | RedshiftToS3Operator()
-51 51 | 
-52 52 | from airflow.operators.redshift_to_s3_operator import RedshiftToS3Transfer
-   53 |+from airflow.providers.amazon.aws.transfers.redshift_to_s3 import RedshiftToS3Operator
-53 54 | 
-54 55 | RedshiftToS3Transfer()
-55 56 | 
-
-AIR302_amazon.py:58:1: AIR302 [*] `airflow.operators.s3_to_redshift_operator.S3ToRedshiftOperator` is moved into `amazon` provider in Airflow 3.0;
-   |
-56 | from airflow.operators.s3_to_redshift_operator import S3ToRedshiftOperator
-57 |
-58 | S3ToRedshiftOperator()
-   | ^^^^^^^^^^^^^^^^^^^^ AIR302
-59 |
-60 | from airflow.operators.s3_to_redshift_operator import S3ToRedshiftTransfer
-   |
-   = help: Install `apache-airflow-providers-amazon>=1.0.0` and use `S3ToRedshiftOperator` from `airflow.providers.amazon.aws.transfers.s3_to_redshift` instead.
-
-ℹ Unsafe fix
-53 53 | 
-54 54 | RedshiftToS3Transfer()
-55 55 | 
-56    |-from airflow.operators.s3_to_redshift_operator import S3ToRedshiftOperator
-   56 |+from airflow.providers.amazon.aws.transfers.s3_to_redshift import S3ToRedshiftOperator
-57 57 | 
-58 58 | S3ToRedshiftOperator()
-59 59 | 
-
-AIR302_amazon.py:62:1: AIR302 [*] `airflow.operators.s3_to_redshift_operator.S3ToRedshiftTransfer` is moved into `amazon` provider in Airflow 3.0;
-   |
-60 | from airflow.operators.s3_to_redshift_operator import S3ToRedshiftTransfer
-61 |
-62 | S3ToRedshiftTransfer()
+32 | from airflow.operators.s3_to_redshift_operator import S3ToRedshiftTransfer
+33 |
+34 | S3ToRedshiftTransfer()
    | ^^^^^^^^^^^^^^^^^^^^ AIR302
    |
    = help: Install `apache-airflow-providers-amazon>=1.0.0` and use `S3ToRedshiftOperator` from `airflow.providers.amazon.aws.transfers.s3_to_redshift` instead.
 
 ℹ Unsafe fix
-58 58 | S3ToRedshiftOperator()
-59 59 | 
-60 60 | from airflow.operators.s3_to_redshift_operator import S3ToRedshiftTransfer
-   61 |+from airflow.providers.amazon.aws.transfers.s3_to_redshift import S3ToRedshiftOperator
-61 62 | 
-62 63 | S3ToRedshiftTransfer()
+30 30 | RedshiftToS3Transfer()
+31 31 | 
+32 32 | from airflow.operators.s3_to_redshift_operator import S3ToRedshiftTransfer
+   33 |+from airflow.providers.amazon.aws.transfers.s3_to_redshift import S3ToRedshiftOperator
+33 34 | 
+34 35 | S3ToRedshiftTransfer()

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_amazon.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_amazon.py.snap
@@ -1,113 +1,243 @@
 ---
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 ---
-AIR302_amazon.py:23:1: AIR302 `airflow.hooks.S3_hook.S3Hook` is moved into `amazon` provider in Airflow 3.0;
+AIR302_amazon.py:22:1: AIR302 [*] `airflow.hooks.S3_hook.S3Hook` is moved into `amazon` provider in Airflow 3.0;
    |
-21 | from airflow.sensors.s3_key_sensor import S3KeySensor
-22 |
-23 | S3Hook()
+20 | from airflow.sensors.s3_key_sensor import S3KeySensor
+21 |
+22 | S3Hook()
    | ^^^^^^ AIR302
-24 | provide_bucket_name()
+23 | provide_bucket_name()
    |
    = help: Install `apache-airflow-providers-amazon>=1.0.0` and use `S3Hook` from `airflow.providers.amazon.aws.hooks.s3` instead.
 
-AIR302_amazon.py:24:1: AIR302 `airflow.hooks.S3_hook.provide_bucket_name` is moved into `amazon` provider in Airflow 3.0;
+ℹ Unsafe fix
+1  1  | from __future__ import annotations
+2  2  | 
+3  3  | from airflow.hooks.S3_hook import (
+4     |-    S3Hook,
+5  4  |     provide_bucket_name,
+6  5  | )
+7  6  | from airflow.operators.gcs_to_s3 import GCSToS3Operator
+--------------------------------------------------------------------------------
+18 17 | 
+19 18 | 
+20 19 | from airflow.sensors.s3_key_sensor import S3KeySensor
+   20 |+from airflow.providers.amazon.aws.hooks.s3 import S3Hook
+21 21 | 
+22 22 | S3Hook()
+23 23 | provide_bucket_name()
+
+AIR302_amazon.py:23:1: AIR302 [*] `airflow.hooks.S3_hook.provide_bucket_name` is moved into `amazon` provider in Airflow 3.0;
    |
-23 | S3Hook()
-24 | provide_bucket_name()
+22 | S3Hook()
+23 | provide_bucket_name()
    | ^^^^^^^^^^^^^^^^^^^ AIR302
-25 |
-26 | GCSToS3Operator()
+24 |
+25 | GCSToS3Operator()
    |
    = help: Install `apache-airflow-providers-amazon>=1.0.0` and use `provide_bucket_name` from `airflow.providers.amazon.aws.hooks.s3` instead.
 
-AIR302_amazon.py:26:1: AIR302 `airflow.operators.gcs_to_s3.GCSToS3Operator` is moved into `amazon` provider in Airflow 3.0;
+ℹ Unsafe fix
+2  2  | 
+3  3  | from airflow.hooks.S3_hook import (
+4  4  |     S3Hook,
+5     |-    provide_bucket_name,
+6  5  | )
+7  6  | from airflow.operators.gcs_to_s3 import GCSToS3Operator
+8  7  | 
+--------------------------------------------------------------------------------
+18 17 | 
+19 18 | 
+20 19 | from airflow.sensors.s3_key_sensor import S3KeySensor
+   20 |+from airflow.providers.amazon.aws.hooks.s3 import provide_bucket_name
+21 21 | 
+22 22 | S3Hook()
+23 23 | provide_bucket_name()
+
+AIR302_amazon.py:25:1: AIR302 [*] `airflow.operators.gcs_to_s3.GCSToS3Operator` is moved into `amazon` provider in Airflow 3.0;
    |
-24 | provide_bucket_name()
-25 |
-26 | GCSToS3Operator()
+23 | provide_bucket_name()
+24 |
+25 | GCSToS3Operator()
    | ^^^^^^^^^^^^^^^ AIR302
-27 |
-28 | GoogleApiToS3Operator()
    |
    = help: Install `apache-airflow-providers-amazon>=1.0.0` and use `GCSToS3Operator` from `airflow.providers.amazon.aws.transfers.gcs_to_s3` instead.
 
-AIR302_amazon.py:28:1: AIR302 `airflow.operators.google_api_to_s3_transfer.GoogleApiToS3Operator` is moved into `amazon` provider in Airflow 3.0;
-   |
-26 | GCSToS3Operator()
-27 |
-28 | GoogleApiToS3Operator()
-   | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-29 | GoogleApiToS3Transfer()
-   |
-   = help: Install `apache-airflow-providers-amazon>=1.0.0` and use `GoogleApiToS3Operator` from `airflow.providers.amazon.aws.transfers.google_api_to_s3` instead.
+ℹ Unsafe fix
+4  4  |     S3Hook,
+5  5  |     provide_bucket_name,
+6  6  | )
+7     |-from airflow.operators.gcs_to_s3 import GCSToS3Operator
+8  7  | 
+9  8  | 
+10 9  | 
+--------------------------------------------------------------------------------
+18 17 | 
+19 18 | 
+20 19 | from airflow.sensors.s3_key_sensor import S3KeySensor
+   20 |+from airflow.providers.amazon.aws.transfers.gcs_to_s3 import GCSToS3Operator
+21 21 | 
+22 22 | S3Hook()
+23 23 | provide_bucket_name()
 
-AIR302_amazon.py:29:1: AIR302 `airflow.operators.google_api_to_s3_transfer.GoogleApiToS3Transfer` is moved into `amazon` provider in Airflow 3.0;
+AIR302_amazon.py:33:1: AIR302 [*] `airflow.operators.s3_file_transform_operator.S3FileTransformOperator` is moved into `amazon` provider in Airflow 3.0;
    |
-28 | GoogleApiToS3Operator()
-29 | GoogleApiToS3Transfer()
-   | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-30 |
-31 | RedshiftToS3Operator()
-   |
-   = help: Install `apache-airflow-providers-amazon>=1.0.0` and use `GoogleApiToS3Operator` from `airflow.providers.amazon.aws.transfers.google_api_to_s3` instead.
-
-AIR302_amazon.py:31:1: AIR302 `airflow.operators.redshift_to_s3_operator.RedshiftToS3Operator` is moved into `amazon` provider in Airflow 3.0;
-   |
-29 | GoogleApiToS3Transfer()
-30 |
-31 | RedshiftToS3Operator()
-   | ^^^^^^^^^^^^^^^^^^^^ AIR302
-32 | RedshiftToS3Transfer()
-   |
-   = help: Install `apache-airflow-providers-amazon>=1.0.0` and use `RedshiftToS3Operator` from `airflow.providers.amazon.aws.transfers.redshift_to_s3` instead.
-
-AIR302_amazon.py:32:1: AIR302 `airflow.operators.redshift_to_s3_operator.RedshiftToS3Transfer` is moved into `amazon` provider in Airflow 3.0;
-   |
-31 | RedshiftToS3Operator()
-32 | RedshiftToS3Transfer()
-   | ^^^^^^^^^^^^^^^^^^^^ AIR302
-33 |
-34 | S3FileTransformOperator()
-   |
-   = help: Install `apache-airflow-providers-amazon>=1.0.0` and use `RedshiftToS3Operator` from `airflow.providers.amazon.aws.transfers.redshift_to_s3` instead.
-
-AIR302_amazon.py:34:1: AIR302 `airflow.operators.s3_file_transform_operator.S3FileTransformOperator` is moved into `amazon` provider in Airflow 3.0;
-   |
-32 | RedshiftToS3Transfer()
-33 |
-34 | S3FileTransformOperator()
+33 | S3FileTransformOperator()
    | ^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-35 |
-36 | S3ToRedshiftOperator()
    |
    = help: Install `apache-airflow-providers-amazon>=3.0.0` and use `S3FileTransformOperator` from `airflow.providers.amazon.aws.operators.s3` instead.
 
-AIR302_amazon.py:36:1: AIR302 `airflow.operators.s3_to_redshift_operator.S3ToRedshiftOperator` is moved into `amazon` provider in Airflow 3.0;
-   |
-34 | S3FileTransformOperator()
-35 |
-36 | S3ToRedshiftOperator()
-   | ^^^^^^^^^^^^^^^^^^^^ AIR302
-37 | S3ToRedshiftTransfer()
-   |
-   = help: Install `apache-airflow-providers-amazon>=1.0.0` and use `S3ToRedshiftOperator` from `airflow.providers.amazon.aws.transfers.s3_to_redshift` instead.
+ℹ Unsafe fix
+12 12 | 
+13 13 | 
+14 14 | 
+15    |-from airflow.operators.s3_file_transform_operator import S3FileTransformOperator
+16 15 | 
+17 16 | 
+18 17 | 
+19 18 | 
+20 19 | from airflow.sensors.s3_key_sensor import S3KeySensor
+   20 |+from airflow.providers.amazon.aws.operators.s3 import S3FileTransformOperator
+21 21 | 
+22 22 | S3Hook()
+23 23 | provide_bucket_name()
 
-AIR302_amazon.py:37:1: AIR302 `airflow.operators.s3_to_redshift_operator.S3ToRedshiftTransfer` is moved into `amazon` provider in Airflow 3.0;
+AIR302_amazon.py:38:1: AIR302 [*] `airflow.sensors.s3_key_sensor.S3KeySensor` is moved into `amazon` provider in Airflow 3.0;
    |
-36 | S3ToRedshiftOperator()
-37 | S3ToRedshiftTransfer()
-   | ^^^^^^^^^^^^^^^^^^^^ AIR302
-38 |
-39 | S3KeySensor()
-   |
-   = help: Install `apache-airflow-providers-amazon>=1.0.0` and use `S3ToRedshiftOperator` from `airflow.providers.amazon.aws.transfers.s3_to_redshift` instead.
-
-AIR302_amazon.py:39:1: AIR302 `airflow.sensors.s3_key_sensor.S3KeySensor` is moved into `amazon` provider in Airflow 3.0;
-   |
-37 | S3ToRedshiftTransfer()
-38 |
-39 | S3KeySensor()
+38 | S3KeySensor()
    | ^^^^^^^^^^^ AIR302
+39 |
+40 | from airflow.operators.google_api_to_s3_transfer import GoogleApiToS3Operator
    |
    = help: Install `apache-airflow-providers-amazon>=1.0.0` and use `S3KeySensor` from `airflow.providers.amazon.aws.sensors.s3` instead.
+
+ℹ Unsafe fix
+17 17 | 
+18 18 | 
+19 19 | 
+20    |-from airflow.sensors.s3_key_sensor import S3KeySensor
+   20 |+from airflow.providers.amazon.aws.sensors.s3 import S3KeySensor
+21 21 | 
+22 22 | S3Hook()
+23 23 | provide_bucket_name()
+
+AIR302_amazon.py:42:1: AIR302 [*] `airflow.operators.google_api_to_s3_transfer.GoogleApiToS3Operator` is moved into `amazon` provider in Airflow 3.0;
+   |
+40 | from airflow.operators.google_api_to_s3_transfer import GoogleApiToS3Operator
+41 |
+42 | GoogleApiToS3Operator()
+   | ^^^^^^^^^^^^^^^^^^^^^ AIR302
+43 |
+44 | from airflow.operators.google_api_to_s3_transfer import GoogleApiToS3Transfer
+   |
+   = help: Install `apache-airflow-providers-amazon>=1.0.0` and use `GoogleApiToS3Operator` from `airflow.providers.amazon.aws.transfers.google_api_to_s3` instead.
+
+ℹ Unsafe fix
+37 37 | 
+38 38 | S3KeySensor()
+39 39 | 
+40    |-from airflow.operators.google_api_to_s3_transfer import GoogleApiToS3Operator
+   40 |+from airflow.providers.amazon.aws.transfers.google_api_to_s3 import GoogleApiToS3Operator
+41 41 | 
+42 42 | GoogleApiToS3Operator()
+43 43 | 
+
+AIR302_amazon.py:46:1: AIR302 [*] `airflow.operators.google_api_to_s3_transfer.GoogleApiToS3Transfer` is moved into `amazon` provider in Airflow 3.0;
+   |
+44 | from airflow.operators.google_api_to_s3_transfer import GoogleApiToS3Transfer
+45 |
+46 | GoogleApiToS3Transfer()
+   | ^^^^^^^^^^^^^^^^^^^^^ AIR302
+47 |
+48 | from airflow.operators.redshift_to_s3_operator import RedshiftToS3Operator
+   |
+   = help: Install `apache-airflow-providers-amazon>=1.0.0` and use `GoogleApiToS3Operator` from `airflow.providers.amazon.aws.transfers.google_api_to_s3` instead.
+
+ℹ Unsafe fix
+42 42 | GoogleApiToS3Operator()
+43 43 | 
+44 44 | from airflow.operators.google_api_to_s3_transfer import GoogleApiToS3Transfer
+   45 |+from airflow.providers.amazon.aws.transfers.google_api_to_s3 import GoogleApiToS3Operator
+45 46 | 
+46 47 | GoogleApiToS3Transfer()
+47 48 | 
+
+AIR302_amazon.py:50:1: AIR302 [*] `airflow.operators.redshift_to_s3_operator.RedshiftToS3Operator` is moved into `amazon` provider in Airflow 3.0;
+   |
+48 | from airflow.operators.redshift_to_s3_operator import RedshiftToS3Operator
+49 |
+50 | RedshiftToS3Operator()
+   | ^^^^^^^^^^^^^^^^^^^^ AIR302
+51 |
+52 | from airflow.operators.redshift_to_s3_operator import RedshiftToS3Transfer
+   |
+   = help: Install `apache-airflow-providers-amazon>=1.0.0` and use `RedshiftToS3Operator` from `airflow.providers.amazon.aws.transfers.redshift_to_s3` instead.
+
+ℹ Unsafe fix
+45 45 | 
+46 46 | GoogleApiToS3Transfer()
+47 47 | 
+48    |-from airflow.operators.redshift_to_s3_operator import RedshiftToS3Operator
+   48 |+from airflow.providers.amazon.aws.transfers.redshift_to_s3 import RedshiftToS3Operator
+49 49 | 
+50 50 | RedshiftToS3Operator()
+51 51 | 
+
+AIR302_amazon.py:54:1: AIR302 [*] `airflow.operators.redshift_to_s3_operator.RedshiftToS3Transfer` is moved into `amazon` provider in Airflow 3.0;
+   |
+52 | from airflow.operators.redshift_to_s3_operator import RedshiftToS3Transfer
+53 |
+54 | RedshiftToS3Transfer()
+   | ^^^^^^^^^^^^^^^^^^^^ AIR302
+55 |
+56 | from airflow.operators.s3_to_redshift_operator import S3ToRedshiftOperator
+   |
+   = help: Install `apache-airflow-providers-amazon>=1.0.0` and use `RedshiftToS3Operator` from `airflow.providers.amazon.aws.transfers.redshift_to_s3` instead.
+
+ℹ Unsafe fix
+50 50 | RedshiftToS3Operator()
+51 51 | 
+52 52 | from airflow.operators.redshift_to_s3_operator import RedshiftToS3Transfer
+   53 |+from airflow.providers.amazon.aws.transfers.redshift_to_s3 import RedshiftToS3Operator
+53 54 | 
+54 55 | RedshiftToS3Transfer()
+55 56 | 
+
+AIR302_amazon.py:58:1: AIR302 [*] `airflow.operators.s3_to_redshift_operator.S3ToRedshiftOperator` is moved into `amazon` provider in Airflow 3.0;
+   |
+56 | from airflow.operators.s3_to_redshift_operator import S3ToRedshiftOperator
+57 |
+58 | S3ToRedshiftOperator()
+   | ^^^^^^^^^^^^^^^^^^^^ AIR302
+59 |
+60 | from airflow.operators.s3_to_redshift_operator import S3ToRedshiftTransfer
+   |
+   = help: Install `apache-airflow-providers-amazon>=1.0.0` and use `S3ToRedshiftOperator` from `airflow.providers.amazon.aws.transfers.s3_to_redshift` instead.
+
+ℹ Unsafe fix
+53 53 | 
+54 54 | RedshiftToS3Transfer()
+55 55 | 
+56    |-from airflow.operators.s3_to_redshift_operator import S3ToRedshiftOperator
+   56 |+from airflow.providers.amazon.aws.transfers.s3_to_redshift import S3ToRedshiftOperator
+57 57 | 
+58 58 | S3ToRedshiftOperator()
+59 59 | 
+
+AIR302_amazon.py:62:1: AIR302 [*] `airflow.operators.s3_to_redshift_operator.S3ToRedshiftTransfer` is moved into `amazon` provider in Airflow 3.0;
+   |
+60 | from airflow.operators.s3_to_redshift_operator import S3ToRedshiftTransfer
+61 |
+62 | S3ToRedshiftTransfer()
+   | ^^^^^^^^^^^^^^^^^^^^ AIR302
+   |
+   = help: Install `apache-airflow-providers-amazon>=1.0.0` and use `S3ToRedshiftOperator` from `airflow.providers.amazon.aws.transfers.s3_to_redshift` instead.
+
+ℹ Unsafe fix
+58 58 | S3ToRedshiftOperator()
+59 59 | 
+60 60 | from airflow.operators.s3_to_redshift_operator import S3ToRedshiftTransfer
+   61 |+from airflow.providers.amazon.aws.transfers.s3_to_redshift import S3ToRedshiftOperator
+61 62 | 
+62 63 | S3ToRedshiftTransfer()

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_celery.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_celery.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 ---
-AIR302_celery.py:9:1: AIR302 `airflow.config_templates.default_celery.DEFAULT_CELERY_CONFIG` is moved into `celery` provider in Airflow 3.0;
+AIR302_celery.py:9:1: AIR302 [*] `airflow.config_templates.default_celery.DEFAULT_CELERY_CONFIG` is moved into `celery` provider in Airflow 3.0;
    |
  7 | )
  8 |
@@ -12,7 +12,20 @@ AIR302_celery.py:9:1: AIR302 `airflow.config_templates.default_celery.DEFAULT_CE
    |
    = help: Install `apache-airflow-providers-celery>=3.3.0` and use `DEFAULT_CELERY_CONFIG` from `airflow.providers.celery.executors.default_celery` instead.
 
-AIR302_celery.py:11:1: AIR302 `airflow.executors.celery_executor.app` is moved into `celery` provider in Airflow 3.0;
+ℹ Unsafe fix
+1 1 | from __future__ import annotations
+2 2 | 
+3   |-from airflow.config_templates.default_celery import DEFAULT_CELERY_CONFIG
+4 3 | from airflow.executors.celery_executor import (
+5 4 |     CeleryExecutor,
+6 5 |     app,
+7 6 | )
+  7 |+from airflow.providers.celery.executors.default_celery import DEFAULT_CELERY_CONFIG
+8 8 | 
+9 9 | DEFAULT_CELERY_CONFIG
+10 10 | 
+
+AIR302_celery.py:11:1: AIR302 [*] `airflow.executors.celery_executor.app` is moved into `celery` provider in Airflow 3.0;
    |
  9 | DEFAULT_CELERY_CONFIG
 10 |
@@ -22,10 +35,33 @@ AIR302_celery.py:11:1: AIR302 `airflow.executors.celery_executor.app` is moved i
    |
    = help: Install `apache-airflow-providers-celery>=3.3.0` and use `app` from `airflow.providers.celery.executors.celery_executor_utils` instead.
 
-AIR302_celery.py:12:1: AIR302 `airflow.executors.celery_executor.CeleryExecutor` is moved into `celery` provider in Airflow 3.0;
+ℹ Unsafe fix
+3 3 | from airflow.config_templates.default_celery import DEFAULT_CELERY_CONFIG
+4 4 | from airflow.executors.celery_executor import (
+5 5 |     CeleryExecutor,
+6   |-    app,
+7 6 | )
+  7 |+from airflow.providers.celery.executors.celery_executor_utils import app
+8 8 | 
+9 9 | DEFAULT_CELERY_CONFIG
+10 10 | 
+
+AIR302_celery.py:12:1: AIR302 [*] `airflow.executors.celery_executor.CeleryExecutor` is moved into `celery` provider in Airflow 3.0;
    |
 11 | app
 12 | CeleryExecutor()
    | ^^^^^^^^^^^^^^ AIR302
    |
    = help: Install `apache-airflow-providers-celery>=3.3.0` and use `CeleryExecutor` from `airflow.providers.celery.executors.celery_executor` instead.
+
+ℹ Unsafe fix
+2 2 | 
+3 3 | from airflow.config_templates.default_celery import DEFAULT_CELERY_CONFIG
+4 4 | from airflow.executors.celery_executor import (
+5   |-    CeleryExecutor,
+6 5 |     app,
+7 6 | )
+  7 |+from airflow.providers.celery.executors.celery_executor import CeleryExecutor
+8 8 | 
+9 9 | DEFAULT_CELERY_CONFIG
+10 10 |

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_common_sql.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_common_sql.py.snap
@@ -1,16 +1,15 @@
 ---
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 ---
-AIR302_common_sql.py:10:1: AIR302 [*] `airflow.hooks.dbapi.ConnectorProtocol` is moved into `common-sql` provider in Airflow 3.0;
-   |
- 8 | from airflow.operators.check_operator import SQLCheckOperator
- 9 |
-10 | ConnectorProtocol()
-   | ^^^^^^^^^^^^^^^^^ AIR302
-11 | DbApiHook()
-12 | SQLCheckOperator()
-   |
-   = help: Install `apache-airflow-providers-common-sql>=1.0.0` and use `ConnectorProtocol` from `airflow.providers.common.sql.hooks.sql` instead.
+AIR302_common_sql.py:8:1: AIR302 [*] `airflow.hooks.dbapi.ConnectorProtocol` is moved into `common-sql` provider in Airflow 3.0;
+  |
+6 | )
+7 |
+8 | ConnectorProtocol()
+  | ^^^^^^^^^^^^^^^^^ AIR302
+9 | DbApiHook()
+  |
+  = help: Install `apache-airflow-providers-common-sql>=1.0.0` and use `ConnectorProtocol` from `airflow.providers.common.sql.hooks.sql` instead.
 
 ℹ Unsafe fix
 1 1 | from __future__ import annotations
@@ -19,603 +18,622 @@ AIR302_common_sql.py:10:1: AIR302 [*] `airflow.hooks.dbapi.ConnectorProtocol` is
 4   |-    ConnectorProtocol,
 5 4 |     DbApiHook,
 6 5 | )
-7 6 | from airflow.hooks.dbapi_hook import DbApiHook
-8 7 | from airflow.operators.check_operator import SQLCheckOperator
-  8 |+from airflow.providers.common.sql.hooks.sql import ConnectorProtocol
-9 9 | 
-10 10 | ConnectorProtocol()
-11 11 | DbApiHook()
+  6 |+from airflow.providers.common.sql.hooks.sql import ConnectorProtocol
+7 7 | 
+8 8 | ConnectorProtocol()
+9 9 | DbApiHook()
 
-AIR302_common_sql.py:11:1: AIR302 [*] `airflow.hooks.dbapi_hook.DbApiHook` is moved into `common-sql` provider in Airflow 3.0;
+AIR302_common_sql.py:9:1: AIR302 [*] `airflow.hooks.dbapi.DbApiHook` is moved into `common-sql` provider in Airflow 3.0;
    |
-10 | ConnectorProtocol()
-11 | DbApiHook()
+ 8 | ConnectorProtocol()
+ 9 | DbApiHook()
    | ^^^^^^^^^ AIR302
-12 | SQLCheckOperator()
+10 |
+11 | from airflow.hooks.dbapi_hook import DbApiHook
    |
    = help: Install `apache-airflow-providers-common-sql>=1.0.0` and use `DbApiHook` from `airflow.providers.common.sql.hooks.sql` instead.
 
 ℹ Unsafe fix
+2 2 | 
+3 3 | from airflow.hooks.dbapi import (
 4 4 |     ConnectorProtocol,
-5 5 |     DbApiHook,
-6 6 | )
-7   |-from airflow.hooks.dbapi_hook import DbApiHook
-8 7 | from airflow.operators.check_operator import SQLCheckOperator
-  8 |+from airflow.providers.common.sql.hooks.sql import DbApiHook
-9 9 | 
-10 10 | ConnectorProtocol()
-11 11 | DbApiHook()
+5   |-    DbApiHook,
+6 5 | )
+  6 |+from airflow.providers.common.sql.hooks.sql import DbApiHook
+7 7 | 
+8 8 | ConnectorProtocol()
+9 9 | DbApiHook()
 
-AIR302_common_sql.py:12:1: AIR302 [*] `airflow.operators.check_operator.SQLCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302_common_sql.py:14:1: AIR302 [*] `airflow.hooks.dbapi_hook.DbApiHook` is moved into `common-sql` provider in Airflow 3.0;
    |
-10 | ConnectorProtocol()
-11 | DbApiHook()
-12 | SQLCheckOperator()
-   | ^^^^^^^^^^^^^^^^ AIR302
+12 | from airflow.operators.check_operator import SQLCheckOperator
+13 |
+14 | DbApiHook()
+   | ^^^^^^^^^ AIR302
+15 | SQLCheckOperator()
    |
-   = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `SQLCheckOperator` from `airflow.providers.common.sql.operators.sql` instead.
-
-ℹ Unsafe fix
-5 5 |     DbApiHook,
-6 6 | )
-7 7 | from airflow.hooks.dbapi_hook import DbApiHook
-8   |-from airflow.operators.check_operator import SQLCheckOperator
-  8 |+from airflow.providers.common.sql.operators.sql import SQLCheckOperator
-9 9 | 
-10 10 | ConnectorProtocol()
-11 11 | DbApiHook()
-
-AIR302_common_sql.py:18:1: AIR302 [*] `airflow.operators.sql.SQLCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
-   |
-16 | from airflow.operators.sql import SQLCheckOperator
-17 |
-18 | SQLCheckOperator()
-   | ^^^^^^^^^^^^^^^^ AIR302
-19 | CheckOperator()
-   |
-   = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `SQLCheckOperator` from `airflow.providers.common.sql.operators.sql` instead.
+   = help: Install `apache-airflow-providers-common-sql>=1.0.0` and use `DbApiHook` from `airflow.providers.common.sql.hooks.sql` instead.
 
 ℹ Unsafe fix
+8  8  | ConnectorProtocol()
+9  9  | DbApiHook()
+10 10 | 
+11    |-from airflow.hooks.dbapi_hook import DbApiHook
+12 11 | from airflow.operators.check_operator import SQLCheckOperator
+   12 |+from airflow.providers.common.sql.hooks.sql import DbApiHook
 13 13 | 
-14 14 | 
-15 15 | from airflow.operators.check_operator import CheckOperator
-16    |-from airflow.operators.sql import SQLCheckOperator
-   16 |+from airflow.providers.common.sql.operators.sql import SQLCheckOperator
+14 14 | DbApiHook()
+15 15 | SQLCheckOperator()
+
+AIR302_common_sql.py:15:1: AIR302 [*] `airflow.operators.check_operator.SQLCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+   |
+14 | DbApiHook()
+15 | SQLCheckOperator()
+   | ^^^^^^^^^^^^^^^^ AIR302
+   |
+   = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `SQLCheckOperator` from `airflow.providers.common.sql.operators.sql` instead.
+
+ℹ Unsafe fix
+9  9  | DbApiHook()
+10 10 | 
+11 11 | from airflow.hooks.dbapi_hook import DbApiHook
+12    |-from airflow.operators.check_operator import SQLCheckOperator
+   12 |+from airflow.providers.common.sql.operators.sql import SQLCheckOperator
+13 13 | 
+14 14 | DbApiHook()
+15 15 | SQLCheckOperator()
+
+AIR302_common_sql.py:21:1: AIR302 [*] `airflow.operators.sql.SQLCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+   |
+19 | from airflow.operators.sql import SQLCheckOperator
+20 |
+21 | SQLCheckOperator()
+   | ^^^^^^^^^^^^^^^^ AIR302
+22 | CheckOperator()
+   |
+   = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `SQLCheckOperator` from `airflow.providers.common.sql.operators.sql` instead.
+
+ℹ Unsafe fix
+16 16 | 
 17 17 | 
-18 18 | SQLCheckOperator()
-19 19 | CheckOperator()
-
-AIR302_common_sql.py:19:1: AIR302 [*] `airflow.operators.check_operator.CheckOperator` is moved into `common-sql` provider in Airflow 3.0;
-   |
-18 | SQLCheckOperator()
-19 | CheckOperator()
-   | ^^^^^^^^^^^^^ AIR302
-   |
-   = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `SQLCheckOperator` from `airflow.providers.common.sql.operators.sql` instead.
-
-ℹ Unsafe fix
-14 14 | 
-15 15 | from airflow.operators.check_operator import CheckOperator
-16 16 | from airflow.operators.sql import SQLCheckOperator
-   17 |+from airflow.providers.common.sql.operators.sql import SQLCheckOperator
-17 18 | 
-18 19 | SQLCheckOperator()
-19 20 | CheckOperator()
-
-AIR302_common_sql.py:24:1: AIR302 [*] `airflow.operators.druid_check_operator.CheckOperator` is moved into `common-sql` provider in Airflow 3.0;
-   |
-22 | from airflow.operators.druid_check_operator import CheckOperator
-23 |
-24 | CheckOperator()
-   | ^^^^^^^^^^^^^ AIR302
-   |
-   = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `SQLCheckOperator` from `airflow.providers.common.sql.operators.sql` instead.
-
-ℹ Unsafe fix
+18 18 | from airflow.operators.check_operator import CheckOperator
+19    |-from airflow.operators.sql import SQLCheckOperator
+   19 |+from airflow.providers.common.sql.operators.sql import SQLCheckOperator
 20 20 | 
-21 21 | 
-22 22 | from airflow.operators.druid_check_operator import CheckOperator
-   23 |+from airflow.providers.common.sql.operators.sql import SQLCheckOperator
-23 24 | 
-24 25 | CheckOperator()
-25 26 | 
+21 21 | SQLCheckOperator()
+22 22 | CheckOperator()
 
-AIR302_common_sql.py:29:1: AIR302 [*] `airflow.operators.presto_check_operator.CheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302_common_sql.py:22:1: AIR302 [*] `airflow.operators.check_operator.CheckOperator` is moved into `common-sql` provider in Airflow 3.0;
    |
-27 | from airflow.operators.presto_check_operator import CheckOperator
-28 |
-29 | CheckOperator()
+21 | SQLCheckOperator()
+22 | CheckOperator()
    | ^^^^^^^^^^^^^ AIR302
    |
    = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `SQLCheckOperator` from `airflow.providers.common.sql.operators.sql` instead.
 
 ℹ Unsafe fix
-25 25 | 
-26 26 | 
-27 27 | from airflow.operators.presto_check_operator import CheckOperator
-   28 |+from airflow.providers.common.sql.operators.sql import SQLCheckOperator
+17 17 | 
+18 18 | from airflow.operators.check_operator import CheckOperator
+19 19 | from airflow.operators.sql import SQLCheckOperator
+   20 |+from airflow.providers.common.sql.operators.sql import SQLCheckOperator
+20 21 | 
+21 22 | SQLCheckOperator()
+22 23 | CheckOperator()
+
+AIR302_common_sql.py:27:1: AIR302 [*] `airflow.operators.druid_check_operator.CheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+   |
+25 | from airflow.operators.druid_check_operator import CheckOperator
+26 |
+27 | CheckOperator()
+   | ^^^^^^^^^^^^^ AIR302
+   |
+   = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `SQLCheckOperator` from `airflow.providers.common.sql.operators.sql` instead.
+
+ℹ Unsafe fix
+23 23 | 
+24 24 | 
+25 25 | from airflow.operators.druid_check_operator import CheckOperator
+   26 |+from airflow.providers.common.sql.operators.sql import SQLCheckOperator
+26 27 | 
+27 28 | CheckOperator()
 28 29 | 
-29 30 | CheckOperator()
-30 31 | 
 
-AIR302_common_sql.py:39:1: AIR302 [*] `airflow.operators.druid_check_operator.DruidCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302_common_sql.py:32:1: AIR302 [*] `airflow.operators.presto_check_operator.CheckOperator` is moved into `common-sql` provider in Airflow 3.0;
    |
-37 | from airflow.operators.presto_check_operator import PrestoCheckOperator
-38 |
-39 | DruidCheckOperator()
+30 | from airflow.operators.presto_check_operator import CheckOperator
+31 |
+32 | CheckOperator()
+   | ^^^^^^^^^^^^^ AIR302
+   |
+   = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `SQLCheckOperator` from `airflow.providers.common.sql.operators.sql` instead.
+
+ℹ Unsafe fix
+28 28 | 
+29 29 | 
+30 30 | from airflow.operators.presto_check_operator import CheckOperator
+   31 |+from airflow.providers.common.sql.operators.sql import SQLCheckOperator
+31 32 | 
+32 33 | CheckOperator()
+33 34 | 
+
+AIR302_common_sql.py:42:1: AIR302 [*] `airflow.operators.druid_check_operator.DruidCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+   |
+40 | from airflow.operators.presto_check_operator import PrestoCheckOperator
+41 |
+42 | DruidCheckOperator()
    | ^^^^^^^^^^^^^^^^^^ AIR302
-40 | PrestoCheckOperator()
-41 | IntervalCheckOperator()
+43 | PrestoCheckOperator()
+44 | IntervalCheckOperator()
    |
    = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `SQLCheckOperator` from `airflow.providers.common.sql.operators.sql` instead.
 
 ℹ Unsafe fix
-35 35 | )
-36 36 | from airflow.operators.druid_check_operator import DruidCheckOperator
-37 37 | from airflow.operators.presto_check_operator import PrestoCheckOperator
-   38 |+from airflow.providers.common.sql.operators.sql import SQLCheckOperator
-38 39 | 
-39 40 | DruidCheckOperator()
-40 41 | PrestoCheckOperator()
+38 38 | )
+39 39 | from airflow.operators.druid_check_operator import DruidCheckOperator
+40 40 | from airflow.operators.presto_check_operator import PrestoCheckOperator
+   41 |+from airflow.providers.common.sql.operators.sql import SQLCheckOperator
+41 42 | 
+42 43 | DruidCheckOperator()
+43 44 | PrestoCheckOperator()
 
-AIR302_common_sql.py:40:1: AIR302 [*] `airflow.operators.presto_check_operator.PrestoCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302_common_sql.py:43:1: AIR302 [*] `airflow.operators.presto_check_operator.PrestoCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
    |
-39 | DruidCheckOperator()
-40 | PrestoCheckOperator()
+42 | DruidCheckOperator()
+43 | PrestoCheckOperator()
    | ^^^^^^^^^^^^^^^^^^^ AIR302
-41 | IntervalCheckOperator()
-42 | SQLIntervalCheckOperator()
+44 | IntervalCheckOperator()
+45 | SQLIntervalCheckOperator()
    |
    = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `SQLCheckOperator` from `airflow.providers.common.sql.operators.sql` instead.
 
 ℹ Unsafe fix
-35 35 | )
-36 36 | from airflow.operators.druid_check_operator import DruidCheckOperator
-37 37 | from airflow.operators.presto_check_operator import PrestoCheckOperator
-   38 |+from airflow.providers.common.sql.operators.sql import SQLCheckOperator
-38 39 | 
-39 40 | DruidCheckOperator()
-40 41 | PrestoCheckOperator()
+38 38 | )
+39 39 | from airflow.operators.druid_check_operator import DruidCheckOperator
+40 40 | from airflow.operators.presto_check_operator import PrestoCheckOperator
+   41 |+from airflow.providers.common.sql.operators.sql import SQLCheckOperator
+41 42 | 
+42 43 | DruidCheckOperator()
+43 44 | PrestoCheckOperator()
 
-AIR302_common_sql.py:41:1: AIR302 [*] `airflow.operators.check_operator.IntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302_common_sql.py:44:1: AIR302 [*] `airflow.operators.check_operator.IntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
    |
-39 | DruidCheckOperator()
-40 | PrestoCheckOperator()
-41 | IntervalCheckOperator()
+42 | DruidCheckOperator()
+43 | PrestoCheckOperator()
+44 | IntervalCheckOperator()
    | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-42 | SQLIntervalCheckOperator()
+45 | SQLIntervalCheckOperator()
    |
    = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `SQLIntervalCheckOperator` from `airflow.providers.common.sql.operators.sql` instead.
 
 ℹ Unsafe fix
-31 31 | 
-32 32 | from airflow.operators.check_operator import (
-33 33 |     IntervalCheckOperator,
-34    |-    SQLIntervalCheckOperator,
-35 34 | )
-36 35 | from airflow.operators.druid_check_operator import DruidCheckOperator
-37 36 | from airflow.operators.presto_check_operator import PrestoCheckOperator
-   37 |+from airflow.providers.common.sql.operators.sql import SQLIntervalCheckOperator
-38 38 | 
-39 39 | DruidCheckOperator()
-40 40 | PrestoCheckOperator()
+34 34 | 
+35 35 | from airflow.operators.check_operator import (
+36 36 |     IntervalCheckOperator,
+37    |-    SQLIntervalCheckOperator,
+38 37 | )
+39 38 | from airflow.operators.druid_check_operator import DruidCheckOperator
+40 39 | from airflow.operators.presto_check_operator import PrestoCheckOperator
+   40 |+from airflow.providers.common.sql.operators.sql import SQLIntervalCheckOperator
+41 41 | 
+42 42 | DruidCheckOperator()
+43 43 | PrestoCheckOperator()
 
-AIR302_common_sql.py:42:1: AIR302 [*] `airflow.operators.check_operator.SQLIntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302_common_sql.py:45:1: AIR302 [*] `airflow.operators.check_operator.SQLIntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
    |
-40 | PrestoCheckOperator()
-41 | IntervalCheckOperator()
-42 | SQLIntervalCheckOperator()
+43 | PrestoCheckOperator()
+44 | IntervalCheckOperator()
+45 | SQLIntervalCheckOperator()
    | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
    |
    = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `SQLIntervalCheckOperator` from `airflow.providers.common.sql.operators.sql` instead.
 
 ℹ Unsafe fix
-31 31 | 
-32 32 | from airflow.operators.check_operator import (
-33 33 |     IntervalCheckOperator,
-34    |-    SQLIntervalCheckOperator,
-35 34 | )
-36 35 | from airflow.operators.druid_check_operator import DruidCheckOperator
-37 36 | from airflow.operators.presto_check_operator import PrestoCheckOperator
-   37 |+from airflow.providers.common.sql.operators.sql import SQLIntervalCheckOperator
-38 38 | 
-39 39 | DruidCheckOperator()
-40 40 | PrestoCheckOperator()
+34 34 | 
+35 35 | from airflow.operators.check_operator import (
+36 36 |     IntervalCheckOperator,
+37    |-    SQLIntervalCheckOperator,
+38 37 | )
+39 38 | from airflow.operators.druid_check_operator import DruidCheckOperator
+40 39 | from airflow.operators.presto_check_operator import PrestoCheckOperator
+   40 |+from airflow.providers.common.sql.operators.sql import SQLIntervalCheckOperator
+41 41 | 
+42 42 | DruidCheckOperator()
+43 43 | PrestoCheckOperator()
 
-AIR302_common_sql.py:51:1: AIR302 [*] `airflow.operators.presto_check_operator.IntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302_common_sql.py:54:1: AIR302 [*] `airflow.operators.presto_check_operator.IntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
    |
-49 | from airflow.operators.sql import SQLIntervalCheckOperator
-50 |
-51 | IntervalCheckOperator()
+52 | from airflow.operators.sql import SQLIntervalCheckOperator
+53 |
+54 | IntervalCheckOperator()
    | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-52 | SQLIntervalCheckOperator()
-53 | PrestoIntervalCheckOperator()
+55 | SQLIntervalCheckOperator()
+56 | PrestoIntervalCheckOperator()
    |
    = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `SQLIntervalCheckOperator` from `airflow.providers.common.sql.operators.sql` instead.
 
 ℹ Unsafe fix
-47 47 |     PrestoIntervalCheckOperator,
-48 48 | )
-49 49 | from airflow.operators.sql import SQLIntervalCheckOperator
-   50 |+from airflow.providers.common.sql.operators.sql import SQLIntervalCheckOperator
-50 51 | 
-51 52 | IntervalCheckOperator()
-52 53 | SQLIntervalCheckOperator()
+50 50 |     PrestoIntervalCheckOperator,
+51 51 | )
+52 52 | from airflow.operators.sql import SQLIntervalCheckOperator
+   53 |+from airflow.providers.common.sql.operators.sql import SQLIntervalCheckOperator
+53 54 | 
+54 55 | IntervalCheckOperator()
+55 56 | SQLIntervalCheckOperator()
 
-AIR302_common_sql.py:52:1: AIR302 [*] `airflow.operators.sql.SQLIntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302_common_sql.py:55:1: AIR302 [*] `airflow.operators.sql.SQLIntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
    |
-51 | IntervalCheckOperator()
-52 | SQLIntervalCheckOperator()
+54 | IntervalCheckOperator()
+55 | SQLIntervalCheckOperator()
    | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-53 | PrestoIntervalCheckOperator()
+56 | PrestoIntervalCheckOperator()
    |
    = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `SQLIntervalCheckOperator` from `airflow.providers.common.sql.operators.sql` instead.
 
 ℹ Unsafe fix
-46 46 |     IntervalCheckOperator,
-47 47 |     PrestoIntervalCheckOperator,
-48 48 | )
-49    |-from airflow.operators.sql import SQLIntervalCheckOperator
-   49 |+from airflow.providers.common.sql.operators.sql import SQLIntervalCheckOperator
-50 50 | 
-51 51 | IntervalCheckOperator()
-52 52 | SQLIntervalCheckOperator()
+49 49 |     IntervalCheckOperator,
+50 50 |     PrestoIntervalCheckOperator,
+51 51 | )
+52    |-from airflow.operators.sql import SQLIntervalCheckOperator
+   52 |+from airflow.providers.common.sql.operators.sql import SQLIntervalCheckOperator
+53 53 | 
+54 54 | IntervalCheckOperator()
+55 55 | SQLIntervalCheckOperator()
 
-AIR302_common_sql.py:53:1: AIR302 [*] `airflow.operators.presto_check_operator.PrestoIntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302_common_sql.py:56:1: AIR302 [*] `airflow.operators.presto_check_operator.PrestoIntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
    |
-51 | IntervalCheckOperator()
-52 | SQLIntervalCheckOperator()
-53 | PrestoIntervalCheckOperator()
+54 | IntervalCheckOperator()
+55 | SQLIntervalCheckOperator()
+56 | PrestoIntervalCheckOperator()
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
    |
    = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `SQLIntervalCheckOperator` from `airflow.providers.common.sql.operators.sql` instead.
 
 ℹ Unsafe fix
-47 47 |     PrestoIntervalCheckOperator,
-48 48 | )
-49 49 | from airflow.operators.sql import SQLIntervalCheckOperator
-   50 |+from airflow.providers.common.sql.operators.sql import SQLIntervalCheckOperator
-50 51 | 
-51 52 | IntervalCheckOperator()
-52 53 | SQLIntervalCheckOperator()
+50 50 |     PrestoIntervalCheckOperator,
+51 51 | )
+52 52 | from airflow.operators.sql import SQLIntervalCheckOperator
+   53 |+from airflow.providers.common.sql.operators.sql import SQLIntervalCheckOperator
+53 54 | 
+54 55 | IntervalCheckOperator()
+55 56 | SQLIntervalCheckOperator()
 
-AIR302_common_sql.py:61:1: AIR302 [*] `airflow.operators.check_operator.SQLThresholdCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302_common_sql.py:64:1: AIR302 [*] `airflow.operators.check_operator.SQLThresholdCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
    |
-59 | )
-60 |
-61 | SQLThresholdCheckOperator()
+62 | )
+63 |
+64 | SQLThresholdCheckOperator()
    | ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-62 | ThresholdCheckOperator()
+65 | ThresholdCheckOperator()
    |
    = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `SQLThresholdCheckOperator` from `airflow.providers.common.sql.operators.sql` instead.
 
 ℹ Unsafe fix
-54 54 | 
-55 55 | 
-56 56 | from airflow.operators.check_operator import (
-57    |-    SQLThresholdCheckOperator,
-58 57 |     ThresholdCheckOperator,
-59 58 | )
-   59 |+from airflow.providers.common.sql.operators.sql import SQLThresholdCheckOperator
-60 60 | 
-61 61 | SQLThresholdCheckOperator()
-62 62 | ThresholdCheckOperator()
+57 57 | 
+58 58 | 
+59 59 | from airflow.operators.check_operator import (
+60    |-    SQLThresholdCheckOperator,
+61 60 |     ThresholdCheckOperator,
+62 61 | )
+   62 |+from airflow.providers.common.sql.operators.sql import SQLThresholdCheckOperator
+63 63 | 
+64 64 | SQLThresholdCheckOperator()
+65 65 | ThresholdCheckOperator()
 
-AIR302_common_sql.py:62:1: AIR302 [*] `airflow.operators.check_operator.ThresholdCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302_common_sql.py:65:1: AIR302 [*] `airflow.operators.check_operator.ThresholdCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
    |
-61 | SQLThresholdCheckOperator()
-62 | ThresholdCheckOperator()
+64 | SQLThresholdCheckOperator()
+65 | ThresholdCheckOperator()
    | ^^^^^^^^^^^^^^^^^^^^^^ AIR302
    |
    = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `SQLThresholdCheckOperator` from `airflow.providers.common.sql.operators.sql` instead.
 
 ℹ Unsafe fix
-54 54 | 
-55 55 | 
-56 56 | from airflow.operators.check_operator import (
-57    |-    SQLThresholdCheckOperator,
-58 57 |     ThresholdCheckOperator,
-59 58 | )
-   59 |+from airflow.providers.common.sql.operators.sql import SQLThresholdCheckOperator
-60 60 | 
-61 61 | SQLThresholdCheckOperator()
-62 62 | ThresholdCheckOperator()
+57 57 | 
+58 58 | 
+59 59 | from airflow.operators.check_operator import (
+60    |-    SQLThresholdCheckOperator,
+61 60 |     ThresholdCheckOperator,
+62 61 | )
+   62 |+from airflow.providers.common.sql.operators.sql import SQLThresholdCheckOperator
+63 63 | 
+64 64 | SQLThresholdCheckOperator()
+65 65 | ThresholdCheckOperator()
 
-AIR302_common_sql.py:67:1: AIR302 [*] `airflow.operators.sql.SQLThresholdCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302_common_sql.py:70:1: AIR302 [*] `airflow.operators.sql.SQLThresholdCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
    |
-65 | from airflow.operators.sql import SQLThresholdCheckOperator
-66 |
-67 | SQLThresholdCheckOperator()
+68 | from airflow.operators.sql import SQLThresholdCheckOperator
+69 |
+70 | SQLThresholdCheckOperator()
    | ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
    |
    = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `SQLThresholdCheckOperator` from `airflow.providers.common.sql.operators.sql` instead.
 
 ℹ Unsafe fix
-62 62 | ThresholdCheckOperator()
-63 63 | 
-64 64 | 
-65    |-from airflow.operators.sql import SQLThresholdCheckOperator
-   65 |+from airflow.providers.common.sql.operators.sql import SQLThresholdCheckOperator
+65 65 | ThresholdCheckOperator()
 66 66 | 
-67 67 | SQLThresholdCheckOperator()
-68 68 | 
+67 67 | 
+68    |-from airflow.operators.sql import SQLThresholdCheckOperator
+   68 |+from airflow.providers.common.sql.operators.sql import SQLThresholdCheckOperator
+69 69 | 
+70 70 | SQLThresholdCheckOperator()
+71 71 | 
 
-AIR302_common_sql.py:75:1: AIR302 [*] `airflow.operators.check_operator.SQLValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302_common_sql.py:78:1: AIR302 [*] `airflow.operators.check_operator.SQLValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
    |
-73 | )
-74 |
-75 | SQLValueCheckOperator()
+76 | )
+77 |
+78 | SQLValueCheckOperator()
    | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-76 | ValueCheckOperator()
+79 | ValueCheckOperator()
    |
    = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `SQLValueCheckOperator` from `airflow.providers.common.sql.operators.sql` instead.
 
 ℹ Unsafe fix
-68 68 | 
-69 69 | 
-70 70 | from airflow.operators.check_operator import (
-71    |-    SQLValueCheckOperator,
-72 71 |     ValueCheckOperator,
-73 72 | )
-   73 |+from airflow.providers.common.sql.operators.sql import SQLValueCheckOperator
-74 74 | 
-75 75 | SQLValueCheckOperator()
-76 76 | ValueCheckOperator()
+71 71 | 
+72 72 | 
+73 73 | from airflow.operators.check_operator import (
+74    |-    SQLValueCheckOperator,
+75 74 |     ValueCheckOperator,
+76 75 | )
+   76 |+from airflow.providers.common.sql.operators.sql import SQLValueCheckOperator
+77 77 | 
+78 78 | SQLValueCheckOperator()
+79 79 | ValueCheckOperator()
 
-AIR302_common_sql.py:76:1: AIR302 [*] `airflow.operators.check_operator.ValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302_common_sql.py:79:1: AIR302 [*] `airflow.operators.check_operator.ValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
    |
-75 | SQLValueCheckOperator()
-76 | ValueCheckOperator()
+78 | SQLValueCheckOperator()
+79 | ValueCheckOperator()
    | ^^^^^^^^^^^^^^^^^^ AIR302
    |
    = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `SQLValueCheckOperator` from `airflow.providers.common.sql.operators.sql` instead.
 
 ℹ Unsafe fix
-68 68 | 
-69 69 | 
-70 70 | from airflow.operators.check_operator import (
-71    |-    SQLValueCheckOperator,
-72 71 |     ValueCheckOperator,
-73 72 | )
-   73 |+from airflow.providers.common.sql.operators.sql import SQLValueCheckOperator
-74 74 | 
-75 75 | SQLValueCheckOperator()
-76 76 | ValueCheckOperator()
+71 71 | 
+72 72 | 
+73 73 | from airflow.operators.check_operator import (
+74    |-    SQLValueCheckOperator,
+75 74 |     ValueCheckOperator,
+76 75 | )
+   76 |+from airflow.providers.common.sql.operators.sql import SQLValueCheckOperator
+77 77 | 
+78 78 | SQLValueCheckOperator()
+79 79 | ValueCheckOperator()
 
-AIR302_common_sql.py:85:1: AIR302 [*] `airflow.operators.sql.SQLValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302_common_sql.py:88:1: AIR302 [*] `airflow.operators.sql.SQLValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
    |
-83 | from airflow.operators.sql import SQLValueCheckOperator
-84 |
-85 | SQLValueCheckOperator()
+86 | from airflow.operators.sql import SQLValueCheckOperator
+87 |
+88 | SQLValueCheckOperator()
    | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-86 | ValueCheckOperator()
-87 | PrestoValueCheckOperator()
+89 | ValueCheckOperator()
+90 | PrestoValueCheckOperator()
    |
    = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `SQLValueCheckOperator` from `airflow.providers.common.sql.operators.sql` instead.
 
 ℹ Unsafe fix
-80 80 |     PrestoValueCheckOperator,
-81 81 |     ValueCheckOperator,
-82 82 | )
-83    |-from airflow.operators.sql import SQLValueCheckOperator
-   83 |+from airflow.providers.common.sql.operators.sql import SQLValueCheckOperator
-84 84 | 
-85 85 | SQLValueCheckOperator()
-86 86 | ValueCheckOperator()
+83 83 |     PrestoValueCheckOperator,
+84 84 |     ValueCheckOperator,
+85 85 | )
+86    |-from airflow.operators.sql import SQLValueCheckOperator
+   86 |+from airflow.providers.common.sql.operators.sql import SQLValueCheckOperator
+87 87 | 
+88 88 | SQLValueCheckOperator()
+89 89 | ValueCheckOperator()
 
-AIR302_common_sql.py:86:1: AIR302 [*] `airflow.operators.presto_check_operator.ValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302_common_sql.py:89:1: AIR302 [*] `airflow.operators.presto_check_operator.ValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
    |
-85 | SQLValueCheckOperator()
-86 | ValueCheckOperator()
+88 | SQLValueCheckOperator()
+89 | ValueCheckOperator()
    | ^^^^^^^^^^^^^^^^^^ AIR302
-87 | PrestoValueCheckOperator()
+90 | PrestoValueCheckOperator()
    |
    = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `SQLValueCheckOperator` from `airflow.providers.common.sql.operators.sql` instead.
 
 ℹ Unsafe fix
-81 81 |     ValueCheckOperator,
-82 82 | )
-83 83 | from airflow.operators.sql import SQLValueCheckOperator
-   84 |+from airflow.providers.common.sql.operators.sql import SQLValueCheckOperator
-84 85 | 
-85 86 | SQLValueCheckOperator()
-86 87 | ValueCheckOperator()
+84 84 |     ValueCheckOperator,
+85 85 | )
+86 86 | from airflow.operators.sql import SQLValueCheckOperator
+   87 |+from airflow.providers.common.sql.operators.sql import SQLValueCheckOperator
+87 88 | 
+88 89 | SQLValueCheckOperator()
+89 90 | ValueCheckOperator()
 
-AIR302_common_sql.py:87:1: AIR302 [*] `airflow.operators.presto_check_operator.PrestoValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302_common_sql.py:90:1: AIR302 [*] `airflow.operators.presto_check_operator.PrestoValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
    |
-85 | SQLValueCheckOperator()
-86 | ValueCheckOperator()
-87 | PrestoValueCheckOperator()
+88 | SQLValueCheckOperator()
+89 | ValueCheckOperator()
+90 | PrestoValueCheckOperator()
    | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
    |
    = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `SQLValueCheckOperator` from `airflow.providers.common.sql.operators.sql` instead.
 
 ℹ Unsafe fix
-81 81 |     ValueCheckOperator,
-82 82 | )
-83 83 | from airflow.operators.sql import SQLValueCheckOperator
-   84 |+from airflow.providers.common.sql.operators.sql import SQLValueCheckOperator
-84 85 | 
-85 86 | SQLValueCheckOperator()
-86 87 | ValueCheckOperator()
+84 84 |     ValueCheckOperator,
+85 85 | )
+86 86 | from airflow.operators.sql import SQLValueCheckOperator
+   87 |+from airflow.providers.common.sql.operators.sql import SQLValueCheckOperator
+87 88 | 
+88 89 | SQLValueCheckOperator()
+89 90 | ValueCheckOperator()
 
-AIR302_common_sql.py:99:1: AIR302 [*] `airflow.operators.sql.BaseSQLOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302_common_sql.py:102:1: AIR302 [*] `airflow.operators.sql.BaseSQLOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
- 97 | )
- 98 |
- 99 | BaseSQLOperator()
+100 | )
+101 |
+102 | BaseSQLOperator()
     | ^^^^^^^^^^^^^^^ AIR302
-100 | BranchSQLOperator()
-101 | SQLTableCheckOperator()
+103 | BranchSQLOperator()
+104 | SQLTableCheckOperator()
     |
     = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `BaseSQLOperator` from `airflow.providers.common.sql.operators.sql` instead.
 
 ℹ Unsafe fix
-88 88 | 
-89 89 | 
-90 90 | from airflow.operators.sql import (
-91    |-    BaseSQLOperator,
-92 91 |     BranchSQLOperator,
-93 92 |     SQLColumnCheckOperator,
-94 93 |     SQLTableCheckOperator,
-95 94 |     _convert_to_float_if_possible,
-96 95 |     parse_boolean,
-97 96 | )
-   97 |+from airflow.providers.common.sql.operators.sql import BaseSQLOperator
-98 98 | 
-99 99 | BaseSQLOperator()
-100 100 | BranchSQLOperator()
+91  91  | 
+92  92  | 
+93  93  | from airflow.operators.sql import (
+94      |-    BaseSQLOperator,
+95  94  |     BranchSQLOperator,
+96  95  |     SQLColumnCheckOperator,
+97  96  |     SQLTableCheckOperator,
+98  97  |     _convert_to_float_if_possible,
+99  98  |     parse_boolean,
+100 99  | )
+    100 |+from airflow.providers.common.sql.operators.sql import BaseSQLOperator
+101 101 | 
+102 102 | BaseSQLOperator()
+103 103 | BranchSQLOperator()
 
-AIR302_common_sql.py:100:1: AIR302 [*] `airflow.operators.sql.BranchSQLOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302_common_sql.py:103:1: AIR302 [*] `airflow.operators.sql.BranchSQLOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
- 99 | BaseSQLOperator()
-100 | BranchSQLOperator()
+102 | BaseSQLOperator()
+103 | BranchSQLOperator()
     | ^^^^^^^^^^^^^^^^^ AIR302
-101 | SQLTableCheckOperator()
-102 | SQLColumnCheckOperator()
+104 | SQLTableCheckOperator()
+105 | SQLColumnCheckOperator()
     |
     = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `BranchSQLOperator` from `airflow.providers.common.sql.operators.sql` instead.
 
 ℹ Unsafe fix
-89 89 | 
-90 90 | from airflow.operators.sql import (
-91 91 |     BaseSQLOperator,
-92    |-    BranchSQLOperator,
-93 92 |     SQLColumnCheckOperator,
-94 93 |     SQLTableCheckOperator,
-95 94 |     _convert_to_float_if_possible,
-96 95 |     parse_boolean,
-97 96 | )
-   97 |+from airflow.providers.common.sql.operators.sql import BranchSQLOperator
-98 98 | 
-99 99 | BaseSQLOperator()
-100 100 | BranchSQLOperator()
+92  92  | 
+93  93  | from airflow.operators.sql import (
+94  94  |     BaseSQLOperator,
+95      |-    BranchSQLOperator,
+96  95  |     SQLColumnCheckOperator,
+97  96  |     SQLTableCheckOperator,
+98  97  |     _convert_to_float_if_possible,
+99  98  |     parse_boolean,
+100 99  | )
+    100 |+from airflow.providers.common.sql.operators.sql import BranchSQLOperator
+101 101 | 
+102 102 | BaseSQLOperator()
+103 103 | BranchSQLOperator()
 
-AIR302_common_sql.py:101:1: AIR302 [*] `airflow.operators.sql.SQLTableCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302_common_sql.py:104:1: AIR302 [*] `airflow.operators.sql.SQLTableCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
- 99 | BaseSQLOperator()
-100 | BranchSQLOperator()
-101 | SQLTableCheckOperator()
+102 | BaseSQLOperator()
+103 | BranchSQLOperator()
+104 | SQLTableCheckOperator()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-102 | SQLColumnCheckOperator()
-103 | _convert_to_float_if_possible()
+105 | SQLColumnCheckOperator()
+106 | _convert_to_float_if_possible()
     |
     = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `SQLTableCheckOperator` from `airflow.providers.common.sql.operators.sql` instead.
 
 ℹ Unsafe fix
-91 91 |     BaseSQLOperator,
-92 92 |     BranchSQLOperator,
-93 93 |     SQLColumnCheckOperator,
-94    |-    SQLTableCheckOperator,
-95 94 |     _convert_to_float_if_possible,
-96 95 |     parse_boolean,
-97 96 | )
-   97 |+from airflow.providers.common.sql.operators.sql import SQLTableCheckOperator
-98 98 | 
-99 99 | BaseSQLOperator()
-100 100 | BranchSQLOperator()
+94  94  |     BaseSQLOperator,
+95  95  |     BranchSQLOperator,
+96  96  |     SQLColumnCheckOperator,
+97      |-    SQLTableCheckOperator,
+98  97  |     _convert_to_float_if_possible,
+99  98  |     parse_boolean,
+100 99  | )
+    100 |+from airflow.providers.common.sql.operators.sql import SQLTableCheckOperator
+101 101 | 
+102 102 | BaseSQLOperator()
+103 103 | BranchSQLOperator()
 
-AIR302_common_sql.py:102:1: AIR302 [*] `airflow.operators.sql.SQLColumnCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR302_common_sql.py:105:1: AIR302 [*] `airflow.operators.sql.SQLColumnCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-100 | BranchSQLOperator()
-101 | SQLTableCheckOperator()
-102 | SQLColumnCheckOperator()
+103 | BranchSQLOperator()
+104 | SQLTableCheckOperator()
+105 | SQLColumnCheckOperator()
     | ^^^^^^^^^^^^^^^^^^^^^^ AIR302
-103 | _convert_to_float_if_possible()
-104 | parse_boolean()
+106 | _convert_to_float_if_possible()
+107 | parse_boolean()
     |
     = help: Install `apache-airflow-providers-common-sql>=1.0.0` and use `SQLColumnCheckOperator` from `airflow.providers.common.sql.operators.sql` instead.
 
 ℹ Unsafe fix
-90 90 | from airflow.operators.sql import (
-91 91 |     BaseSQLOperator,
-92 92 |     BranchSQLOperator,
-93    |-    SQLColumnCheckOperator,
-94 93 |     SQLTableCheckOperator,
-95 94 |     _convert_to_float_if_possible,
-96 95 |     parse_boolean,
-97 96 | )
-   97 |+from airflow.providers.common.sql.operators.sql import SQLColumnCheckOperator
-98 98 | 
-99 99 | BaseSQLOperator()
-100 100 | BranchSQLOperator()
+93  93  | from airflow.operators.sql import (
+94  94  |     BaseSQLOperator,
+95  95  |     BranchSQLOperator,
+96      |-    SQLColumnCheckOperator,
+97  96  |     SQLTableCheckOperator,
+98  97  |     _convert_to_float_if_possible,
+99  98  |     parse_boolean,
+100 99  | )
+    100 |+from airflow.providers.common.sql.operators.sql import SQLColumnCheckOperator
+101 101 | 
+102 102 | BaseSQLOperator()
+103 103 | BranchSQLOperator()
 
-AIR302_common_sql.py:103:1: AIR302 [*] `airflow.operators.sql._convert_to_float_if_possible` is moved into `common-sql` provider in Airflow 3.0;
+AIR302_common_sql.py:106:1: AIR302 [*] `airflow.operators.sql._convert_to_float_if_possible` is moved into `common-sql` provider in Airflow 3.0;
     |
-101 | SQLTableCheckOperator()
-102 | SQLColumnCheckOperator()
-103 | _convert_to_float_if_possible()
+104 | SQLTableCheckOperator()
+105 | SQLColumnCheckOperator()
+106 | _convert_to_float_if_possible()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-104 | parse_boolean()
+107 | parse_boolean()
     |
     = help: Install `apache-airflow-providers-common-sql>=1.0.0` and use `_convert_to_float_if_possible` from `airflow.providers.common.sql.operators.sql` instead.
 
 ℹ Unsafe fix
-92 92 |     BranchSQLOperator,
-93 93 |     SQLColumnCheckOperator,
-94 94 |     SQLTableCheckOperator,
-95    |-    _convert_to_float_if_possible,
-96 95 |     parse_boolean,
-97 96 | )
-   97 |+from airflow.providers.common.sql.operators.sql import _convert_to_float_if_possible
-98 98 | 
-99 99 | BaseSQLOperator()
-100 100 | BranchSQLOperator()
+95  95  |     BranchSQLOperator,
+96  96  |     SQLColumnCheckOperator,
+97  97  |     SQLTableCheckOperator,
+98      |-    _convert_to_float_if_possible,
+99  98  |     parse_boolean,
+100 99  | )
+    100 |+from airflow.providers.common.sql.operators.sql import _convert_to_float_if_possible
+101 101 | 
+102 102 | BaseSQLOperator()
+103 103 | BranchSQLOperator()
 
-AIR302_common_sql.py:104:1: AIR302 [*] `airflow.operators.sql.parse_boolean` is moved into `common-sql` provider in Airflow 3.0;
+AIR302_common_sql.py:107:1: AIR302 [*] `airflow.operators.sql.parse_boolean` is moved into `common-sql` provider in Airflow 3.0;
     |
-102 | SQLColumnCheckOperator()
-103 | _convert_to_float_if_possible()
-104 | parse_boolean()
+105 | SQLColumnCheckOperator()
+106 | _convert_to_float_if_possible()
+107 | parse_boolean()
     | ^^^^^^^^^^^^^ AIR302
     |
     = help: Install `apache-airflow-providers-common-sql>=1.0.0` and use `parse_boolean` from `airflow.providers.common.sql.operators.sql` instead.
 
 ℹ Unsafe fix
-93 93 |     SQLColumnCheckOperator,
-94 94 |     SQLTableCheckOperator,
-95 95 |     _convert_to_float_if_possible,
-96    |-    parse_boolean,
-97 96 | )
-   97 |+from airflow.providers.common.sql.operators.sql import parse_boolean
-98 98 | 
-99 99 | BaseSQLOperator()
-100 100 | BranchSQLOperator()
+96  96  |     SQLColumnCheckOperator,
+97  97  |     SQLTableCheckOperator,
+98  98  |     _convert_to_float_if_possible,
+99      |-    parse_boolean,
+100 99  | )
+    100 |+from airflow.providers.common.sql.operators.sql import parse_boolean
+101 101 | 
+102 102 | BaseSQLOperator()
+103 103 | BranchSQLOperator()
 
-AIR302_common_sql.py:109:1: AIR302 [*] `airflow.sensors.sql.SqlSensor` is moved into `common-sql` provider in Airflow 3.0;
+AIR302_common_sql.py:112:1: AIR302 [*] `airflow.sensors.sql.SqlSensor` is moved into `common-sql` provider in Airflow 3.0;
     |
-107 | from airflow.sensors.sql import SqlSensor
-108 |
-109 | SqlSensor()
+110 | from airflow.sensors.sql import SqlSensor
+111 |
+112 | SqlSensor()
     | ^^^^^^^^^ AIR302
     |
     = help: Install `apache-airflow-providers-common-sql>=1.0.0` and use `SqlSensor` from `airflow.providers.common.sql.sensors.sql` instead.
 
 ℹ Unsafe fix
-104 104 | parse_boolean()
-105 105 | 
-106 106 | 
-107     |-from airflow.sensors.sql import SqlSensor
-    107 |+from airflow.providers.common.sql.sensors.sql import SqlSensor
+107 107 | parse_boolean()
 108 108 | 
-109 109 | SqlSensor()
-110 110 | 
+109 109 | 
+110     |-from airflow.sensors.sql import SqlSensor
+    110 |+from airflow.providers.common.sql.sensors.sql import SqlSensor
+111 111 | 
+112 112 | SqlSensor()
+113 113 | 
 
-AIR302_common_sql.py:114:1: AIR302 [*] `airflow.sensors.sql_sensor.SqlSensor` is moved into `common-sql` provider in Airflow 3.0;
+AIR302_common_sql.py:117:1: AIR302 [*] `airflow.sensors.sql_sensor.SqlSensor` is moved into `common-sql` provider in Airflow 3.0;
     |
-112 | from airflow.sensors.sql_sensor import SqlSensor
-113 |
-114 | SqlSensor()
+115 | from airflow.sensors.sql_sensor import SqlSensor
+116 |
+117 | SqlSensor()
     | ^^^^^^^^^ AIR302
     |
     = help: Install `apache-airflow-providers-common-sql>=1.0.0` and use `SqlSensor` from `airflow.providers.common.sql.sensors.sql` instead.
 
 ℹ Unsafe fix
-109 109 | SqlSensor()
-110 110 | 
-111 111 | 
-112     |-from airflow.sensors.sql_sensor import SqlSensor
-    112 |+from airflow.providers.common.sql.sensors.sql import SqlSensor
+112 112 | SqlSensor()
 113 113 | 
-114 114 | SqlSensor()
-115 115 |
+114 114 | 
+115     |-from airflow.sensors.sql_sensor import SqlSensor
+    115 |+from airflow.providers.common.sql.sensors.sql import SqlSensor
+116 116 | 
+117 117 | SqlSensor()
+118 118 |

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_common_sql.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_common_sql.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 ---
-AIR302_common_sql.py:10:1: AIR302 `airflow.hooks.dbapi.ConnectorProtocol` is moved into `common-sql` provider in Airflow 3.0;
+AIR302_common_sql.py:10:1: AIR302 [*] `airflow.hooks.dbapi.ConnectorProtocol` is moved into `common-sql` provider in Airflow 3.0;
    |
  8 | from airflow.operators.check_operator import SQLCheckOperator
  9 |
@@ -12,7 +12,21 @@ AIR302_common_sql.py:10:1: AIR302 `airflow.hooks.dbapi.ConnectorProtocol` is mov
    |
    = help: Install `apache-airflow-providers-common-sql>=1.0.0` and use `ConnectorProtocol` from `airflow.providers.common.sql.hooks.sql` instead.
 
-AIR302_common_sql.py:11:1: AIR302 `airflow.hooks.dbapi_hook.DbApiHook` is moved into `common-sql` provider in Airflow 3.0;
+ℹ Unsafe fix
+1 1 | from __future__ import annotations
+2 2 | 
+3 3 | from airflow.hooks.dbapi import (
+4   |-    ConnectorProtocol,
+5 4 |     DbApiHook,
+6 5 | )
+7 6 | from airflow.hooks.dbapi_hook import DbApiHook
+8 7 | from airflow.operators.check_operator import SQLCheckOperator
+  8 |+from airflow.providers.common.sql.hooks.sql import ConnectorProtocol
+9 9 | 
+10 10 | ConnectorProtocol()
+11 11 | DbApiHook()
+
+AIR302_common_sql.py:11:1: AIR302 [*] `airflow.hooks.dbapi_hook.DbApiHook` is moved into `common-sql` provider in Airflow 3.0;
    |
 10 | ConnectorProtocol()
 11 | DbApiHook()
@@ -21,7 +35,18 @@ AIR302_common_sql.py:11:1: AIR302 `airflow.hooks.dbapi_hook.DbApiHook` is moved 
    |
    = help: Install `apache-airflow-providers-common-sql>=1.0.0` and use `DbApiHook` from `airflow.providers.common.sql.hooks.sql` instead.
 
-AIR302_common_sql.py:12:1: AIR302 `airflow.operators.check_operator.SQLCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+ℹ Unsafe fix
+4 4 |     ConnectorProtocol,
+5 5 |     DbApiHook,
+6 6 | )
+7   |-from airflow.hooks.dbapi_hook import DbApiHook
+8 7 | from airflow.operators.check_operator import SQLCheckOperator
+  8 |+from airflow.providers.common.sql.hooks.sql import DbApiHook
+9 9 | 
+10 10 | ConnectorProtocol()
+11 11 | DbApiHook()
+
+AIR302_common_sql.py:12:1: AIR302 [*] `airflow.operators.check_operator.SQLCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
    |
 10 | ConnectorProtocol()
 11 | DbApiHook()
@@ -30,7 +55,17 @@ AIR302_common_sql.py:12:1: AIR302 `airflow.operators.check_operator.SQLCheckOper
    |
    = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `SQLCheckOperator` from `airflow.providers.common.sql.operators.sql` instead.
 
-AIR302_common_sql.py:18:1: AIR302 `airflow.operators.sql.SQLCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+ℹ Unsafe fix
+5 5 |     DbApiHook,
+6 6 | )
+7 7 | from airflow.hooks.dbapi_hook import DbApiHook
+8   |-from airflow.operators.check_operator import SQLCheckOperator
+  8 |+from airflow.providers.common.sql.operators.sql import SQLCheckOperator
+9 9 | 
+10 10 | ConnectorProtocol()
+11 11 | DbApiHook()
+
+AIR302_common_sql.py:18:1: AIR302 [*] `airflow.operators.sql.SQLCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
    |
 16 | from airflow.operators.sql import SQLCheckOperator
 17 |
@@ -40,7 +75,17 @@ AIR302_common_sql.py:18:1: AIR302 `airflow.operators.sql.SQLCheckOperator` is mo
    |
    = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `SQLCheckOperator` from `airflow.providers.common.sql.operators.sql` instead.
 
-AIR302_common_sql.py:19:1: AIR302 `airflow.operators.check_operator.CheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+ℹ Unsafe fix
+13 13 | 
+14 14 | 
+15 15 | from airflow.operators.check_operator import CheckOperator
+16    |-from airflow.operators.sql import SQLCheckOperator
+   16 |+from airflow.providers.common.sql.operators.sql import SQLCheckOperator
+17 17 | 
+18 18 | SQLCheckOperator()
+19 19 | CheckOperator()
+
+AIR302_common_sql.py:19:1: AIR302 [*] `airflow.operators.check_operator.CheckOperator` is moved into `common-sql` provider in Airflow 3.0;
    |
 18 | SQLCheckOperator()
 19 | CheckOperator()
@@ -48,7 +93,16 @@ AIR302_common_sql.py:19:1: AIR302 `airflow.operators.check_operator.CheckOperato
    |
    = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `SQLCheckOperator` from `airflow.providers.common.sql.operators.sql` instead.
 
-AIR302_common_sql.py:24:1: AIR302 `airflow.operators.druid_check_operator.CheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+ℹ Unsafe fix
+14 14 | 
+15 15 | from airflow.operators.check_operator import CheckOperator
+16 16 | from airflow.operators.sql import SQLCheckOperator
+   17 |+from airflow.providers.common.sql.operators.sql import SQLCheckOperator
+17 18 | 
+18 19 | SQLCheckOperator()
+19 20 | CheckOperator()
+
+AIR302_common_sql.py:24:1: AIR302 [*] `airflow.operators.druid_check_operator.CheckOperator` is moved into `common-sql` provider in Airflow 3.0;
    |
 22 | from airflow.operators.druid_check_operator import CheckOperator
 23 |
@@ -57,7 +111,16 @@ AIR302_common_sql.py:24:1: AIR302 `airflow.operators.druid_check_operator.CheckO
    |
    = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `SQLCheckOperator` from `airflow.providers.common.sql.operators.sql` instead.
 
-AIR302_common_sql.py:29:1: AIR302 `airflow.operators.presto_check_operator.CheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+ℹ Unsafe fix
+20 20 | 
+21 21 | 
+22 22 | from airflow.operators.druid_check_operator import CheckOperator
+   23 |+from airflow.providers.common.sql.operators.sql import SQLCheckOperator
+23 24 | 
+24 25 | CheckOperator()
+25 26 | 
+
+AIR302_common_sql.py:29:1: AIR302 [*] `airflow.operators.presto_check_operator.CheckOperator` is moved into `common-sql` provider in Airflow 3.0;
    |
 27 | from airflow.operators.presto_check_operator import CheckOperator
 28 |
@@ -66,7 +129,16 @@ AIR302_common_sql.py:29:1: AIR302 `airflow.operators.presto_check_operator.Check
    |
    = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `SQLCheckOperator` from `airflow.providers.common.sql.operators.sql` instead.
 
-AIR302_common_sql.py:39:1: AIR302 `airflow.operators.druid_check_operator.DruidCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+ℹ Unsafe fix
+25 25 | 
+26 26 | 
+27 27 | from airflow.operators.presto_check_operator import CheckOperator
+   28 |+from airflow.providers.common.sql.operators.sql import SQLCheckOperator
+28 29 | 
+29 30 | CheckOperator()
+30 31 | 
+
+AIR302_common_sql.py:39:1: AIR302 [*] `airflow.operators.druid_check_operator.DruidCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
    |
 37 | from airflow.operators.presto_check_operator import PrestoCheckOperator
 38 |
@@ -77,7 +149,16 @@ AIR302_common_sql.py:39:1: AIR302 `airflow.operators.druid_check_operator.DruidC
    |
    = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `SQLCheckOperator` from `airflow.providers.common.sql.operators.sql` instead.
 
-AIR302_common_sql.py:40:1: AIR302 `airflow.operators.presto_check_operator.PrestoCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+ℹ Unsafe fix
+35 35 | )
+36 36 | from airflow.operators.druid_check_operator import DruidCheckOperator
+37 37 | from airflow.operators.presto_check_operator import PrestoCheckOperator
+   38 |+from airflow.providers.common.sql.operators.sql import SQLCheckOperator
+38 39 | 
+39 40 | DruidCheckOperator()
+40 41 | PrestoCheckOperator()
+
+AIR302_common_sql.py:40:1: AIR302 [*] `airflow.operators.presto_check_operator.PrestoCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
    |
 39 | DruidCheckOperator()
 40 | PrestoCheckOperator()
@@ -87,7 +168,16 @@ AIR302_common_sql.py:40:1: AIR302 `airflow.operators.presto_check_operator.Prest
    |
    = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `SQLCheckOperator` from `airflow.providers.common.sql.operators.sql` instead.
 
-AIR302_common_sql.py:41:1: AIR302 `airflow.operators.check_operator.IntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+ℹ Unsafe fix
+35 35 | )
+36 36 | from airflow.operators.druid_check_operator import DruidCheckOperator
+37 37 | from airflow.operators.presto_check_operator import PrestoCheckOperator
+   38 |+from airflow.providers.common.sql.operators.sql import SQLCheckOperator
+38 39 | 
+39 40 | DruidCheckOperator()
+40 41 | PrestoCheckOperator()
+
+AIR302_common_sql.py:41:1: AIR302 [*] `airflow.operators.check_operator.IntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
    |
 39 | DruidCheckOperator()
 40 | PrestoCheckOperator()
@@ -97,7 +187,20 @@ AIR302_common_sql.py:41:1: AIR302 `airflow.operators.check_operator.IntervalChec
    |
    = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `SQLIntervalCheckOperator` from `airflow.providers.common.sql.operators.sql` instead.
 
-AIR302_common_sql.py:42:1: AIR302 `airflow.operators.check_operator.SQLIntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+ℹ Unsafe fix
+31 31 | 
+32 32 | from airflow.operators.check_operator import (
+33 33 |     IntervalCheckOperator,
+34    |-    SQLIntervalCheckOperator,
+35 34 | )
+36 35 | from airflow.operators.druid_check_operator import DruidCheckOperator
+37 36 | from airflow.operators.presto_check_operator import PrestoCheckOperator
+   37 |+from airflow.providers.common.sql.operators.sql import SQLIntervalCheckOperator
+38 38 | 
+39 39 | DruidCheckOperator()
+40 40 | PrestoCheckOperator()
+
+AIR302_common_sql.py:42:1: AIR302 [*] `airflow.operators.check_operator.SQLIntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
    |
 40 | PrestoCheckOperator()
 41 | IntervalCheckOperator()
@@ -106,7 +209,20 @@ AIR302_common_sql.py:42:1: AIR302 `airflow.operators.check_operator.SQLIntervalC
    |
    = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `SQLIntervalCheckOperator` from `airflow.providers.common.sql.operators.sql` instead.
 
-AIR302_common_sql.py:51:1: AIR302 `airflow.operators.presto_check_operator.IntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+ℹ Unsafe fix
+31 31 | 
+32 32 | from airflow.operators.check_operator import (
+33 33 |     IntervalCheckOperator,
+34    |-    SQLIntervalCheckOperator,
+35 34 | )
+36 35 | from airflow.operators.druid_check_operator import DruidCheckOperator
+37 36 | from airflow.operators.presto_check_operator import PrestoCheckOperator
+   37 |+from airflow.providers.common.sql.operators.sql import SQLIntervalCheckOperator
+38 38 | 
+39 39 | DruidCheckOperator()
+40 40 | PrestoCheckOperator()
+
+AIR302_common_sql.py:51:1: AIR302 [*] `airflow.operators.presto_check_operator.IntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
    |
 49 | from airflow.operators.sql import SQLIntervalCheckOperator
 50 |
@@ -117,7 +233,16 @@ AIR302_common_sql.py:51:1: AIR302 `airflow.operators.presto_check_operator.Inter
    |
    = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `SQLIntervalCheckOperator` from `airflow.providers.common.sql.operators.sql` instead.
 
-AIR302_common_sql.py:52:1: AIR302 `airflow.operators.sql.SQLIntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+ℹ Unsafe fix
+47 47 |     PrestoIntervalCheckOperator,
+48 48 | )
+49 49 | from airflow.operators.sql import SQLIntervalCheckOperator
+   50 |+from airflow.providers.common.sql.operators.sql import SQLIntervalCheckOperator
+50 51 | 
+51 52 | IntervalCheckOperator()
+52 53 | SQLIntervalCheckOperator()
+
+AIR302_common_sql.py:52:1: AIR302 [*] `airflow.operators.sql.SQLIntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
    |
 51 | IntervalCheckOperator()
 52 | SQLIntervalCheckOperator()
@@ -126,7 +251,17 @@ AIR302_common_sql.py:52:1: AIR302 `airflow.operators.sql.SQLIntervalCheckOperato
    |
    = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `SQLIntervalCheckOperator` from `airflow.providers.common.sql.operators.sql` instead.
 
-AIR302_common_sql.py:53:1: AIR302 `airflow.operators.presto_check_operator.PrestoIntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+ℹ Unsafe fix
+46 46 |     IntervalCheckOperator,
+47 47 |     PrestoIntervalCheckOperator,
+48 48 | )
+49    |-from airflow.operators.sql import SQLIntervalCheckOperator
+   49 |+from airflow.providers.common.sql.operators.sql import SQLIntervalCheckOperator
+50 50 | 
+51 51 | IntervalCheckOperator()
+52 52 | SQLIntervalCheckOperator()
+
+AIR302_common_sql.py:53:1: AIR302 [*] `airflow.operators.presto_check_operator.PrestoIntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
    |
 51 | IntervalCheckOperator()
 52 | SQLIntervalCheckOperator()
@@ -135,7 +270,16 @@ AIR302_common_sql.py:53:1: AIR302 `airflow.operators.presto_check_operator.Prest
    |
    = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `SQLIntervalCheckOperator` from `airflow.providers.common.sql.operators.sql` instead.
 
-AIR302_common_sql.py:61:1: AIR302 `airflow.operators.check_operator.SQLThresholdCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+ℹ Unsafe fix
+47 47 |     PrestoIntervalCheckOperator,
+48 48 | )
+49 49 | from airflow.operators.sql import SQLIntervalCheckOperator
+   50 |+from airflow.providers.common.sql.operators.sql import SQLIntervalCheckOperator
+50 51 | 
+51 52 | IntervalCheckOperator()
+52 53 | SQLIntervalCheckOperator()
+
+AIR302_common_sql.py:61:1: AIR302 [*] `airflow.operators.check_operator.SQLThresholdCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
    |
 59 | )
 60 |
@@ -145,7 +289,19 @@ AIR302_common_sql.py:61:1: AIR302 `airflow.operators.check_operator.SQLThreshold
    |
    = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `SQLThresholdCheckOperator` from `airflow.providers.common.sql.operators.sql` instead.
 
-AIR302_common_sql.py:62:1: AIR302 `airflow.operators.check_operator.ThresholdCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+ℹ Unsafe fix
+54 54 | 
+55 55 | 
+56 56 | from airflow.operators.check_operator import (
+57    |-    SQLThresholdCheckOperator,
+58 57 |     ThresholdCheckOperator,
+59 58 | )
+   59 |+from airflow.providers.common.sql.operators.sql import SQLThresholdCheckOperator
+60 60 | 
+61 61 | SQLThresholdCheckOperator()
+62 62 | ThresholdCheckOperator()
+
+AIR302_common_sql.py:62:1: AIR302 [*] `airflow.operators.check_operator.ThresholdCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
    |
 61 | SQLThresholdCheckOperator()
 62 | ThresholdCheckOperator()
@@ -153,7 +309,19 @@ AIR302_common_sql.py:62:1: AIR302 `airflow.operators.check_operator.ThresholdChe
    |
    = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `SQLThresholdCheckOperator` from `airflow.providers.common.sql.operators.sql` instead.
 
-AIR302_common_sql.py:67:1: AIR302 `airflow.operators.sql.SQLThresholdCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+ℹ Unsafe fix
+54 54 | 
+55 55 | 
+56 56 | from airflow.operators.check_operator import (
+57    |-    SQLThresholdCheckOperator,
+58 57 |     ThresholdCheckOperator,
+59 58 | )
+   59 |+from airflow.providers.common.sql.operators.sql import SQLThresholdCheckOperator
+60 60 | 
+61 61 | SQLThresholdCheckOperator()
+62 62 | ThresholdCheckOperator()
+
+AIR302_common_sql.py:67:1: AIR302 [*] `airflow.operators.sql.SQLThresholdCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
    |
 65 | from airflow.operators.sql import SQLThresholdCheckOperator
 66 |
@@ -162,7 +330,17 @@ AIR302_common_sql.py:67:1: AIR302 `airflow.operators.sql.SQLThresholdCheckOperat
    |
    = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `SQLThresholdCheckOperator` from `airflow.providers.common.sql.operators.sql` instead.
 
-AIR302_common_sql.py:75:1: AIR302 `airflow.operators.check_operator.SQLValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+ℹ Unsafe fix
+62 62 | ThresholdCheckOperator()
+63 63 | 
+64 64 | 
+65    |-from airflow.operators.sql import SQLThresholdCheckOperator
+   65 |+from airflow.providers.common.sql.operators.sql import SQLThresholdCheckOperator
+66 66 | 
+67 67 | SQLThresholdCheckOperator()
+68 68 | 
+
+AIR302_common_sql.py:75:1: AIR302 [*] `airflow.operators.check_operator.SQLValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
    |
 73 | )
 74 |
@@ -172,7 +350,19 @@ AIR302_common_sql.py:75:1: AIR302 `airflow.operators.check_operator.SQLValueChec
    |
    = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `SQLValueCheckOperator` from `airflow.providers.common.sql.operators.sql` instead.
 
-AIR302_common_sql.py:76:1: AIR302 `airflow.operators.check_operator.ValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+ℹ Unsafe fix
+68 68 | 
+69 69 | 
+70 70 | from airflow.operators.check_operator import (
+71    |-    SQLValueCheckOperator,
+72 71 |     ValueCheckOperator,
+73 72 | )
+   73 |+from airflow.providers.common.sql.operators.sql import SQLValueCheckOperator
+74 74 | 
+75 75 | SQLValueCheckOperator()
+76 76 | ValueCheckOperator()
+
+AIR302_common_sql.py:76:1: AIR302 [*] `airflow.operators.check_operator.ValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
    |
 75 | SQLValueCheckOperator()
 76 | ValueCheckOperator()
@@ -180,7 +370,19 @@ AIR302_common_sql.py:76:1: AIR302 `airflow.operators.check_operator.ValueCheckOp
    |
    = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `SQLValueCheckOperator` from `airflow.providers.common.sql.operators.sql` instead.
 
-AIR302_common_sql.py:85:1: AIR302 `airflow.operators.sql.SQLValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+ℹ Unsafe fix
+68 68 | 
+69 69 | 
+70 70 | from airflow.operators.check_operator import (
+71    |-    SQLValueCheckOperator,
+72 71 |     ValueCheckOperator,
+73 72 | )
+   73 |+from airflow.providers.common.sql.operators.sql import SQLValueCheckOperator
+74 74 | 
+75 75 | SQLValueCheckOperator()
+76 76 | ValueCheckOperator()
+
+AIR302_common_sql.py:85:1: AIR302 [*] `airflow.operators.sql.SQLValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
    |
 83 | from airflow.operators.sql import SQLValueCheckOperator
 84 |
@@ -191,7 +393,17 @@ AIR302_common_sql.py:85:1: AIR302 `airflow.operators.sql.SQLValueCheckOperator` 
    |
    = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `SQLValueCheckOperator` from `airflow.providers.common.sql.operators.sql` instead.
 
-AIR302_common_sql.py:86:1: AIR302 `airflow.operators.presto_check_operator.ValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+ℹ Unsafe fix
+80 80 |     PrestoValueCheckOperator,
+81 81 |     ValueCheckOperator,
+82 82 | )
+83    |-from airflow.operators.sql import SQLValueCheckOperator
+   83 |+from airflow.providers.common.sql.operators.sql import SQLValueCheckOperator
+84 84 | 
+85 85 | SQLValueCheckOperator()
+86 86 | ValueCheckOperator()
+
+AIR302_common_sql.py:86:1: AIR302 [*] `airflow.operators.presto_check_operator.ValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
    |
 85 | SQLValueCheckOperator()
 86 | ValueCheckOperator()
@@ -200,7 +412,16 @@ AIR302_common_sql.py:86:1: AIR302 `airflow.operators.presto_check_operator.Value
    |
    = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `SQLValueCheckOperator` from `airflow.providers.common.sql.operators.sql` instead.
 
-AIR302_common_sql.py:87:1: AIR302 `airflow.operators.presto_check_operator.PrestoValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+ℹ Unsafe fix
+81 81 |     ValueCheckOperator,
+82 82 | )
+83 83 | from airflow.operators.sql import SQLValueCheckOperator
+   84 |+from airflow.providers.common.sql.operators.sql import SQLValueCheckOperator
+84 85 | 
+85 86 | SQLValueCheckOperator()
+86 87 | ValueCheckOperator()
+
+AIR302_common_sql.py:87:1: AIR302 [*] `airflow.operators.presto_check_operator.PrestoValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
    |
 85 | SQLValueCheckOperator()
 86 | ValueCheckOperator()
@@ -209,7 +430,16 @@ AIR302_common_sql.py:87:1: AIR302 `airflow.operators.presto_check_operator.Prest
    |
    = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `SQLValueCheckOperator` from `airflow.providers.common.sql.operators.sql` instead.
 
-AIR302_common_sql.py:99:1: AIR302 `airflow.operators.sql.BaseSQLOperator` is moved into `common-sql` provider in Airflow 3.0;
+ℹ Unsafe fix
+81 81 |     ValueCheckOperator,
+82 82 | )
+83 83 | from airflow.operators.sql import SQLValueCheckOperator
+   84 |+from airflow.providers.common.sql.operators.sql import SQLValueCheckOperator
+84 85 | 
+85 86 | SQLValueCheckOperator()
+86 87 | ValueCheckOperator()
+
+AIR302_common_sql.py:99:1: AIR302 [*] `airflow.operators.sql.BaseSQLOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
  97 | )
  98 |
@@ -220,7 +450,23 @@ AIR302_common_sql.py:99:1: AIR302 `airflow.operators.sql.BaseSQLOperator` is mov
     |
     = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `BaseSQLOperator` from `airflow.providers.common.sql.operators.sql` instead.
 
-AIR302_common_sql.py:100:1: AIR302 `airflow.operators.sql.BranchSQLOperator` is moved into `common-sql` provider in Airflow 3.0;
+ℹ Unsafe fix
+88 88 | 
+89 89 | 
+90 90 | from airflow.operators.sql import (
+91    |-    BaseSQLOperator,
+92 91 |     BranchSQLOperator,
+93 92 |     SQLColumnCheckOperator,
+94 93 |     SQLTableCheckOperator,
+95 94 |     _convert_to_float_if_possible,
+96 95 |     parse_boolean,
+97 96 | )
+   97 |+from airflow.providers.common.sql.operators.sql import BaseSQLOperator
+98 98 | 
+99 99 | BaseSQLOperator()
+100 100 | BranchSQLOperator()
+
+AIR302_common_sql.py:100:1: AIR302 [*] `airflow.operators.sql.BranchSQLOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
  99 | BaseSQLOperator()
 100 | BranchSQLOperator()
@@ -230,7 +476,22 @@ AIR302_common_sql.py:100:1: AIR302 `airflow.operators.sql.BranchSQLOperator` is 
     |
     = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `BranchSQLOperator` from `airflow.providers.common.sql.operators.sql` instead.
 
-AIR302_common_sql.py:101:1: AIR302 `airflow.operators.sql.SQLTableCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+ℹ Unsafe fix
+89 89 | 
+90 90 | from airflow.operators.sql import (
+91 91 |     BaseSQLOperator,
+92    |-    BranchSQLOperator,
+93 92 |     SQLColumnCheckOperator,
+94 93 |     SQLTableCheckOperator,
+95 94 |     _convert_to_float_if_possible,
+96 95 |     parse_boolean,
+97 96 | )
+   97 |+from airflow.providers.common.sql.operators.sql import BranchSQLOperator
+98 98 | 
+99 99 | BaseSQLOperator()
+100 100 | BranchSQLOperator()
+
+AIR302_common_sql.py:101:1: AIR302 [*] `airflow.operators.sql.SQLTableCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
  99 | BaseSQLOperator()
 100 | BranchSQLOperator()
@@ -241,7 +502,20 @@ AIR302_common_sql.py:101:1: AIR302 `airflow.operators.sql.SQLTableCheckOperator`
     |
     = help: Install `apache-airflow-providers-common-sql>=1.1.0` and use `SQLTableCheckOperator` from `airflow.providers.common.sql.operators.sql` instead.
 
-AIR302_common_sql.py:102:1: AIR302 `airflow.operators.sql.SQLColumnCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+ℹ Unsafe fix
+91 91 |     BaseSQLOperator,
+92 92 |     BranchSQLOperator,
+93 93 |     SQLColumnCheckOperator,
+94    |-    SQLTableCheckOperator,
+95 94 |     _convert_to_float_if_possible,
+96 95 |     parse_boolean,
+97 96 | )
+   97 |+from airflow.providers.common.sql.operators.sql import SQLTableCheckOperator
+98 98 | 
+99 99 | BaseSQLOperator()
+100 100 | BranchSQLOperator()
+
+AIR302_common_sql.py:102:1: AIR302 [*] `airflow.operators.sql.SQLColumnCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
 100 | BranchSQLOperator()
 101 | SQLTableCheckOperator()
@@ -252,7 +526,21 @@ AIR302_common_sql.py:102:1: AIR302 `airflow.operators.sql.SQLColumnCheckOperator
     |
     = help: Install `apache-airflow-providers-common-sql>=1.0.0` and use `SQLColumnCheckOperator` from `airflow.providers.common.sql.operators.sql` instead.
 
-AIR302_common_sql.py:103:1: AIR302 `airflow.operators.sql._convert_to_float_if_possible` is moved into `common-sql` provider in Airflow 3.0;
+ℹ Unsafe fix
+90 90 | from airflow.operators.sql import (
+91 91 |     BaseSQLOperator,
+92 92 |     BranchSQLOperator,
+93    |-    SQLColumnCheckOperator,
+94 93 |     SQLTableCheckOperator,
+95 94 |     _convert_to_float_if_possible,
+96 95 |     parse_boolean,
+97 96 | )
+   97 |+from airflow.providers.common.sql.operators.sql import SQLColumnCheckOperator
+98 98 | 
+99 99 | BaseSQLOperator()
+100 100 | BranchSQLOperator()
+
+AIR302_common_sql.py:103:1: AIR302 [*] `airflow.operators.sql._convert_to_float_if_possible` is moved into `common-sql` provider in Airflow 3.0;
     |
 101 | SQLTableCheckOperator()
 102 | SQLColumnCheckOperator()
@@ -262,7 +550,19 @@ AIR302_common_sql.py:103:1: AIR302 `airflow.operators.sql._convert_to_float_if_p
     |
     = help: Install `apache-airflow-providers-common-sql>=1.0.0` and use `_convert_to_float_if_possible` from `airflow.providers.common.sql.operators.sql` instead.
 
-AIR302_common_sql.py:104:1: AIR302 `airflow.operators.sql.parse_boolean` is moved into `common-sql` provider in Airflow 3.0;
+ℹ Unsafe fix
+92 92 |     BranchSQLOperator,
+93 93 |     SQLColumnCheckOperator,
+94 94 |     SQLTableCheckOperator,
+95    |-    _convert_to_float_if_possible,
+96 95 |     parse_boolean,
+97 96 | )
+   97 |+from airflow.providers.common.sql.operators.sql import _convert_to_float_if_possible
+98 98 | 
+99 99 | BaseSQLOperator()
+100 100 | BranchSQLOperator()
+
+AIR302_common_sql.py:104:1: AIR302 [*] `airflow.operators.sql.parse_boolean` is moved into `common-sql` provider in Airflow 3.0;
     |
 102 | SQLColumnCheckOperator()
 103 | _convert_to_float_if_possible()
@@ -271,7 +571,18 @@ AIR302_common_sql.py:104:1: AIR302 `airflow.operators.sql.parse_boolean` is move
     |
     = help: Install `apache-airflow-providers-common-sql>=1.0.0` and use `parse_boolean` from `airflow.providers.common.sql.operators.sql` instead.
 
-AIR302_common_sql.py:109:1: AIR302 `airflow.sensors.sql.SqlSensor` is moved into `common-sql` provider in Airflow 3.0;
+ℹ Unsafe fix
+93 93 |     SQLColumnCheckOperator,
+94 94 |     SQLTableCheckOperator,
+95 95 |     _convert_to_float_if_possible,
+96    |-    parse_boolean,
+97 96 | )
+   97 |+from airflow.providers.common.sql.operators.sql import parse_boolean
+98 98 | 
+99 99 | BaseSQLOperator()
+100 100 | BranchSQLOperator()
+
+AIR302_common_sql.py:109:1: AIR302 [*] `airflow.sensors.sql.SqlSensor` is moved into `common-sql` provider in Airflow 3.0;
     |
 107 | from airflow.sensors.sql import SqlSensor
 108 |
@@ -280,7 +591,17 @@ AIR302_common_sql.py:109:1: AIR302 `airflow.sensors.sql.SqlSensor` is moved into
     |
     = help: Install `apache-airflow-providers-common-sql>=1.0.0` and use `SqlSensor` from `airflow.providers.common.sql.sensors.sql` instead.
 
-AIR302_common_sql.py:114:1: AIR302 `airflow.sensors.sql_sensor.SqlSensor` is moved into `common-sql` provider in Airflow 3.0;
+ℹ Unsafe fix
+104 104 | parse_boolean()
+105 105 | 
+106 106 | 
+107     |-from airflow.sensors.sql import SqlSensor
+    107 |+from airflow.providers.common.sql.sensors.sql import SqlSensor
+108 108 | 
+109 109 | SqlSensor()
+110 110 | 
+
+AIR302_common_sql.py:114:1: AIR302 [*] `airflow.sensors.sql_sensor.SqlSensor` is moved into `common-sql` provider in Airflow 3.0;
     |
 112 | from airflow.sensors.sql_sensor import SqlSensor
 113 |
@@ -288,3 +609,13 @@ AIR302_common_sql.py:114:1: AIR302 `airflow.sensors.sql_sensor.SqlSensor` is mov
     | ^^^^^^^^^ AIR302
     |
     = help: Install `apache-airflow-providers-common-sql>=1.0.0` and use `SqlSensor` from `airflow.providers.common.sql.sensors.sql` instead.
+
+ℹ Unsafe fix
+109 109 | SqlSensor()
+110 110 | 
+111 111 | 
+112     |-from airflow.sensors.sql_sensor import SqlSensor
+    112 |+from airflow.providers.common.sql.sensors.sql import SqlSensor
+113 113 | 
+114 114 | SqlSensor()
+115 115 |

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_daskexecutor.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_daskexecutor.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 ---
-AIR302_daskexecutor.py:5:1: AIR302 `airflow.executors.dask_executor.DaskExecutor` is moved into `daskexecutor` provider in Airflow 3.0;
+AIR302_daskexecutor.py:5:1: AIR302 [*] `airflow.executors.dask_executor.DaskExecutor` is moved into `daskexecutor` provider in Airflow 3.0;
   |
 3 | from airflow.executors.dask_executor import DaskExecutor
 4 |
@@ -9,3 +9,11 @@ AIR302_daskexecutor.py:5:1: AIR302 `airflow.executors.dask_executor.DaskExecutor
   | ^^^^^^^^^^^^ AIR302
   |
   = help: Install `apache-airflow-providers-daskexecutor>=1.0.0` and use `DaskExecutor` from `airflow.providers.daskexecutor.executors.dask_executor` instead.
+
+ℹ Unsafe fix
+1 1 | from __future__ import annotations
+2 2 | 
+3   |-from airflow.executors.dask_executor import DaskExecutor
+  3 |+from airflow.providers.daskexecutor.executors.dask_executor import DaskExecutor
+4 4 | 
+5 5 | DaskExecutor()

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_druid.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_druid.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 ---
-AIR302_druid.py:12:1: AIR302 `airflow.hooks.druid_hook.DruidDbApiHook` is moved into `apache-druid` provider in Airflow 3.0;
+AIR302_druid.py:12:1: AIR302 [*] `airflow.hooks.druid_hook.DruidDbApiHook` is moved into `apache-druid` provider in Airflow 3.0;
    |
 10 | )
 11 |
@@ -11,7 +11,23 @@ AIR302_druid.py:12:1: AIR302 `airflow.hooks.druid_hook.DruidDbApiHook` is moved 
    |
    = help: Install `apache-airflow-providers-apache-druid>=1.0.0` and use `DruidDbApiHook` from `airflow.providers.apache.druid.hooks.druid` instead.
 
-AIR302_druid.py:13:1: AIR302 `airflow.hooks.druid_hook.DruidHook` is moved into `apache-druid` provider in Airflow 3.0;
+ℹ Unsafe fix
+1  1  | from __future__ import annotations
+2  2  | 
+3  3  | from airflow.hooks.druid_hook import (
+4     |-    DruidDbApiHook,
+5  4  |     DruidHook,
+6  5  | )
+7  6  | from airflow.operators.hive_to_druid import (
+8  7  |     HiveToDruidOperator,
+9  8  |     HiveToDruidTransfer,
+10 9  | )
+   10 |+from airflow.providers.apache.druid.hooks.druid import DruidDbApiHook
+11 11 | 
+12 12 | DruidDbApiHook()
+13 13 | DruidHook()
+
+AIR302_druid.py:13:1: AIR302 [*] `airflow.hooks.druid_hook.DruidHook` is moved into `apache-druid` provider in Airflow 3.0;
    |
 12 | DruidDbApiHook()
 13 | DruidHook()
@@ -21,7 +37,22 @@ AIR302_druid.py:13:1: AIR302 `airflow.hooks.druid_hook.DruidHook` is moved into 
    |
    = help: Install `apache-airflow-providers-apache-druid>=1.0.0` and use `DruidHook` from `airflow.providers.apache.druid.hooks.druid` instead.
 
-AIR302_druid.py:15:1: AIR302 `airflow.operators.hive_to_druid.HiveToDruidOperator` is moved into `apache-druid` provider in Airflow 3.0;
+ℹ Unsafe fix
+2  2  | 
+3  3  | from airflow.hooks.druid_hook import (
+4  4  |     DruidDbApiHook,
+5     |-    DruidHook,
+6  5  | )
+7  6  | from airflow.operators.hive_to_druid import (
+8  7  |     HiveToDruidOperator,
+9  8  |     HiveToDruidTransfer,
+10 9  | )
+   10 |+from airflow.providers.apache.druid.hooks.druid import DruidHook
+11 11 | 
+12 12 | DruidDbApiHook()
+13 13 | DruidHook()
+
+AIR302_druid.py:15:1: AIR302 [*] `airflow.operators.hive_to_druid.HiveToDruidOperator` is moved into `apache-druid` provider in Airflow 3.0;
    |
 13 | DruidHook()
 14 |
@@ -31,10 +62,34 @@ AIR302_druid.py:15:1: AIR302 `airflow.operators.hive_to_druid.HiveToDruidOperato
    |
    = help: Install `apache-airflow-providers-apache-druid>=1.0.0` and use `HiveToDruidOperator` from `airflow.providers.apache.druid.transfers.hive_to_druid` instead.
 
-AIR302_druid.py:16:1: AIR302 `airflow.operators.hive_to_druid.HiveToDruidTransfer` is moved into `apache-druid` provider in Airflow 3.0;
+ℹ Unsafe fix
+5  5  |     DruidHook,
+6  6  | )
+7  7  | from airflow.operators.hive_to_druid import (
+8     |-    HiveToDruidOperator,
+9  8  |     HiveToDruidTransfer,
+10 9  | )
+   10 |+from airflow.providers.apache.druid.transfers.hive_to_druid import HiveToDruidOperator
+11 11 | 
+12 12 | DruidDbApiHook()
+13 13 | DruidHook()
+
+AIR302_druid.py:16:1: AIR302 [*] `airflow.operators.hive_to_druid.HiveToDruidTransfer` is moved into `apache-druid` provider in Airflow 3.0;
    |
 15 | HiveToDruidOperator()
 16 | HiveToDruidTransfer()
    | ^^^^^^^^^^^^^^^^^^^ AIR302
    |
    = help: Install `apache-airflow-providers-apache-druid>=1.0.0` and use `HiveToDruidOperator` from `airflow.providers.apache.druid.transfers.hive_to_druid` instead.
+
+ℹ Unsafe fix
+5  5  |     DruidHook,
+6  6  | )
+7  7  | from airflow.operators.hive_to_druid import (
+8     |-    HiveToDruidOperator,
+9  8  |     HiveToDruidTransfer,
+10 9  | )
+   10 |+from airflow.providers.apache.druid.transfers.hive_to_druid import HiveToDruidOperator
+11 11 | 
+12 12 | DruidDbApiHook()
+13 13 | DruidHook()

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_fab.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_fab.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 ---
-AIR302_fab.py:10:1: AIR302 `airflow.api.auth.backend.basic_auth.CLIENT_AUTH` is moved into `fab` provider in Airflow 3.0;
+AIR302_fab.py:10:1: AIR302 [*] `airflow.api.auth.backend.basic_auth.CLIENT_AUTH` is moved into `fab` provider in Airflow 3.0;
    |
  8 | )
  9 |
@@ -12,7 +12,21 @@ AIR302_fab.py:10:1: AIR302 `airflow.api.auth.backend.basic_auth.CLIENT_AUTH` is 
    |
    = help: Install `apache-airflow-providers-fab>=1.0.0` and use `CLIENT_AUTH` from `airflow.providers.fab.auth_manager.api.auth.backend.basic_auth` instead.
 
-AIR302_fab.py:11:1: AIR302 `airflow.api.auth.backend.basic_auth.init_app` is moved into `fab` provider in Airflow 3.0;
+ℹ Unsafe fix
+1 1 | from __future__ import annotations
+2 2 | 
+3 3 | from airflow.api.auth.backend.basic_auth import (
+4   |-    CLIENT_AUTH,
+5 4 |     auth_current_user,
+6 5 |     init_app,
+7 6 |     requires_authentication,
+8 7 | )
+  8 |+from airflow.providers.fab.auth_manager.api.auth.backend.basic_auth import CLIENT_AUTH
+9 9 | 
+10 10 | CLIENT_AUTH
+11 11 | init_app()
+
+AIR302_fab.py:11:1: AIR302 [*] `airflow.api.auth.backend.basic_auth.init_app` is moved into `fab` provider in Airflow 3.0;
    |
 10 | CLIENT_AUTH
 11 | init_app()
@@ -22,7 +36,19 @@ AIR302_fab.py:11:1: AIR302 `airflow.api.auth.backend.basic_auth.init_app` is mov
    |
    = help: Install `apache-airflow-providers-fab>=1.0.0` and use `init_app` from `airflow.providers.fab.auth_manager.api.auth.backend.basic_auth` instead.
 
-AIR302_fab.py:12:1: AIR302 `airflow.api.auth.backend.basic_auth.auth_current_user` is moved into `fab` provider in Airflow 3.0;
+ℹ Unsafe fix
+3 3 | from airflow.api.auth.backend.basic_auth import (
+4 4 |     CLIENT_AUTH,
+5 5 |     auth_current_user,
+6   |-    init_app,
+7 6 |     requires_authentication,
+8 7 | )
+  8 |+from airflow.providers.fab.auth_manager.api.auth.backend.basic_auth import init_app
+9 9 | 
+10 10 | CLIENT_AUTH
+11 11 | init_app()
+
+AIR302_fab.py:12:1: AIR302 [*] `airflow.api.auth.backend.basic_auth.auth_current_user` is moved into `fab` provider in Airflow 3.0;
    |
 10 | CLIENT_AUTH
 11 | init_app()
@@ -32,7 +58,20 @@ AIR302_fab.py:12:1: AIR302 `airflow.api.auth.backend.basic_auth.auth_current_use
    |
    = help: Install `apache-airflow-providers-fab>=1.0.0` and use `auth_current_user` from `airflow.providers.fab.auth_manager.api.auth.backend.basic_auth` instead.
 
-AIR302_fab.py:13:1: AIR302 `airflow.api.auth.backend.basic_auth.requires_authentication` is moved into `fab` provider in Airflow 3.0;
+ℹ Unsafe fix
+2 2 | 
+3 3 | from airflow.api.auth.backend.basic_auth import (
+4 4 |     CLIENT_AUTH,
+5   |-    auth_current_user,
+6 5 |     init_app,
+7 6 |     requires_authentication,
+8 7 | )
+  8 |+from airflow.providers.fab.auth_manager.api.auth.backend.basic_auth import auth_current_user
+9 9 | 
+10 10 | CLIENT_AUTH
+11 11 | init_app()
+
+AIR302_fab.py:13:1: AIR302 [*] `airflow.api.auth.backend.basic_auth.requires_authentication` is moved into `fab` provider in Airflow 3.0;
    |
 11 | init_app()
 12 | auth_current_user()
@@ -43,7 +82,18 @@ AIR302_fab.py:13:1: AIR302 `airflow.api.auth.backend.basic_auth.requires_authent
    |
    = help: Install `apache-airflow-providers-fab>=1.0.0` and use `requires_authentication` from `airflow.providers.fab.auth_manager.api.auth.backend.basic_auth` instead.
 
-AIR302_fab.py:23:1: AIR302 `airflow.api.auth.backend.kerberos_auth.log` is moved into `fab` provider in Airflow 3.0;
+ℹ Unsafe fix
+4 4 |     CLIENT_AUTH,
+5 5 |     auth_current_user,
+6 6 |     init_app,
+7   |-    requires_authentication,
+8 7 | )
+  8 |+from airflow.providers.fab.auth_manager.api.auth.backend.basic_auth import requires_authentication
+9 9 | 
+10 10 | CLIENT_AUTH
+11 11 | init_app()
+
+AIR302_fab.py:23:1: AIR302 [*] `airflow.api.auth.backend.kerberos_auth.log` is moved into `fab` provider in Airflow 3.0;
    |
 21 | )
 22 |
@@ -54,7 +104,19 @@ AIR302_fab.py:23:1: AIR302 `airflow.api.auth.backend.kerberos_auth.log` is moved
    |
    = help: Install `apache-airflow-providers-fab>=1.0.0` and use `log` from `airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth` instead.
 
-AIR302_fab.py:24:1: AIR302 `airflow.api.auth.backend.kerberos_auth.CLIENT_AUTH` is moved into `fab` provider in Airflow 3.0;
+ℹ Unsafe fix
+16 16 |     CLIENT_AUTH,
+17 17 |     find_user,
+18 18 |     init_app,
+19    |-    log,
+20 19 |     requires_authentication,
+21 20 | )
+   21 |+from airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth import log
+22 22 | 
+23 23 | log()
+24 24 | CLIENT_AUTH
+
+AIR302_fab.py:24:1: AIR302 [*] `airflow.api.auth.backend.kerberos_auth.CLIENT_AUTH` is moved into `fab` provider in Airflow 3.0;
    |
 23 | log()
 24 | CLIENT_AUTH
@@ -64,7 +126,22 @@ AIR302_fab.py:24:1: AIR302 `airflow.api.auth.backend.kerberos_auth.CLIENT_AUTH` 
    |
    = help: Install `apache-airflow-providers-fab>=1.0.0` and use `CLIENT_AUTH` from `airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth` instead.
 
-AIR302_fab.py:25:1: AIR302 `airflow.api.auth.backend.kerberos_auth.find_user` is moved into `fab` provider in Airflow 3.0;
+ℹ Unsafe fix
+13 13 | requires_authentication()
+14 14 | 
+15 15 | from airflow.api.auth.backend.kerberos_auth import (
+16    |-    CLIENT_AUTH,
+17 16 |     find_user,
+18 17 |     init_app,
+19 18 |     log,
+20 19 |     requires_authentication,
+21 20 | )
+   21 |+from airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth import CLIENT_AUTH
+22 22 | 
+23 23 | log()
+24 24 | CLIENT_AUTH
+
+AIR302_fab.py:25:1: AIR302 [*] `airflow.api.auth.backend.kerberos_auth.find_user` is moved into `fab` provider in Airflow 3.0;
    |
 23 | log()
 24 | CLIENT_AUTH
@@ -75,7 +152,21 @@ AIR302_fab.py:25:1: AIR302 `airflow.api.auth.backend.kerberos_auth.find_user` is
    |
    = help: Install `apache-airflow-providers-fab>=1.0.0` and use `find_user` from `airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth` instead.
 
-AIR302_fab.py:26:1: AIR302 `airflow.api.auth.backend.kerberos_auth.init_app` is moved into `fab` provider in Airflow 3.0;
+ℹ Unsafe fix
+14 14 | 
+15 15 | from airflow.api.auth.backend.kerberos_auth import (
+16 16 |     CLIENT_AUTH,
+17    |-    find_user,
+18 17 |     init_app,
+19 18 |     log,
+20 19 |     requires_authentication,
+21 20 | )
+   21 |+from airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth import find_user
+22 22 | 
+23 23 | log()
+24 24 | CLIENT_AUTH
+
+AIR302_fab.py:26:1: AIR302 [*] `airflow.api.auth.backend.kerberos_auth.init_app` is moved into `fab` provider in Airflow 3.0;
    |
 24 | CLIENT_AUTH
 25 | find_user()
@@ -85,7 +176,20 @@ AIR302_fab.py:26:1: AIR302 `airflow.api.auth.backend.kerberos_auth.init_app` is 
    |
    = help: Install `apache-airflow-providers-fab>=1.0.0` and use `init_app` from `airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth` instead.
 
-AIR302_fab.py:27:1: AIR302 `airflow.api.auth.backend.kerberos_auth.requires_authentication` is moved into `fab` provider in Airflow 3.0;
+ℹ Unsafe fix
+15 15 | from airflow.api.auth.backend.kerberos_auth import (
+16 16 |     CLIENT_AUTH,
+17 17 |     find_user,
+18    |-    init_app,
+19 18 |     log,
+20 19 |     requires_authentication,
+21 20 | )
+   21 |+from airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth import init_app
+22 22 | 
+23 23 | log()
+24 24 | CLIENT_AUTH
+
+AIR302_fab.py:27:1: AIR302 [*] `airflow.api.auth.backend.kerberos_auth.requires_authentication` is moved into `fab` provider in Airflow 3.0;
    |
 25 | find_user()
 26 | init_app()
@@ -96,7 +200,18 @@ AIR302_fab.py:27:1: AIR302 `airflow.api.auth.backend.kerberos_auth.requires_auth
    |
    = help: Install `apache-airflow-providers-fab>=1.0.0` and use `requires_authentication` from `airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth` instead.
 
-AIR302_fab.py:37:1: AIR302 `airflow.auth.managers.fab.api.auth.backend.kerberos_auth.log` is moved into `fab` provider in Airflow 3.0;
+ℹ Unsafe fix
+17 17 |     find_user,
+18 18 |     init_app,
+19 19 |     log,
+20    |-    requires_authentication,
+21 20 | )
+   21 |+from airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth import requires_authentication
+22 22 | 
+23 23 | log()
+24 24 | CLIENT_AUTH
+
+AIR302_fab.py:37:1: AIR302 [*] `airflow.auth.managers.fab.api.auth.backend.kerberos_auth.log` is moved into `fab` provider in Airflow 3.0;
    |
 35 | )
 36 |
@@ -107,7 +222,19 @@ AIR302_fab.py:37:1: AIR302 `airflow.auth.managers.fab.api.auth.backend.kerberos_
    |
    = help: Install `apache-airflow-providers-fab>=1.0.0` and use `log` from `airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth` instead.
 
-AIR302_fab.py:38:1: AIR302 `airflow.auth.managers.fab.api.auth.backend.kerberos_auth.CLIENT_AUTH` is moved into `fab` provider in Airflow 3.0;
+ℹ Unsafe fix
+30 30 |     CLIENT_AUTH,
+31 31 |     find_user,
+32 32 |     init_app,
+33    |-    log,
+34 33 |     requires_authentication,
+35 34 | )
+   35 |+from airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth import log
+36 36 | 
+37 37 | log()
+38 38 | CLIENT_AUTH
+
+AIR302_fab.py:38:1: AIR302 [*] `airflow.auth.managers.fab.api.auth.backend.kerberos_auth.CLIENT_AUTH` is moved into `fab` provider in Airflow 3.0;
    |
 37 | log()
 38 | CLIENT_AUTH
@@ -117,7 +244,22 @@ AIR302_fab.py:38:1: AIR302 `airflow.auth.managers.fab.api.auth.backend.kerberos_
    |
    = help: Install `apache-airflow-providers-fab>=1.0.0` and use `CLIENT_AUTH` from `airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth` instead.
 
-AIR302_fab.py:39:1: AIR302 `airflow.auth.managers.fab.api.auth.backend.kerberos_auth.find_user` is moved into `fab` provider in Airflow 3.0;
+ℹ Unsafe fix
+27 27 | requires_authentication()
+28 28 | 
+29 29 | from airflow.auth.managers.fab.api.auth.backend.kerberos_auth import (
+30    |-    CLIENT_AUTH,
+31 30 |     find_user,
+32 31 |     init_app,
+33 32 |     log,
+34 33 |     requires_authentication,
+35 34 | )
+   35 |+from airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth import CLIENT_AUTH
+36 36 | 
+37 37 | log()
+38 38 | CLIENT_AUTH
+
+AIR302_fab.py:39:1: AIR302 [*] `airflow.auth.managers.fab.api.auth.backend.kerberos_auth.find_user` is moved into `fab` provider in Airflow 3.0;
    |
 37 | log()
 38 | CLIENT_AUTH
@@ -128,7 +270,21 @@ AIR302_fab.py:39:1: AIR302 `airflow.auth.managers.fab.api.auth.backend.kerberos_
    |
    = help: Install `apache-airflow-providers-fab>=1.0.0` and use `find_user` from `airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth` instead.
 
-AIR302_fab.py:40:1: AIR302 `airflow.auth.managers.fab.api.auth.backend.kerberos_auth.init_app` is moved into `fab` provider in Airflow 3.0;
+ℹ Unsafe fix
+28 28 | 
+29 29 | from airflow.auth.managers.fab.api.auth.backend.kerberos_auth import (
+30 30 |     CLIENT_AUTH,
+31    |-    find_user,
+32 31 |     init_app,
+33 32 |     log,
+34 33 |     requires_authentication,
+35 34 | )
+   35 |+from airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth import find_user
+36 36 | 
+37 37 | log()
+38 38 | CLIENT_AUTH
+
+AIR302_fab.py:40:1: AIR302 [*] `airflow.auth.managers.fab.api.auth.backend.kerberos_auth.init_app` is moved into `fab` provider in Airflow 3.0;
    |
 38 | CLIENT_AUTH
 39 | find_user()
@@ -138,7 +294,20 @@ AIR302_fab.py:40:1: AIR302 `airflow.auth.managers.fab.api.auth.backend.kerberos_
    |
    = help: Install `apache-airflow-providers-fab>=1.0.0` and use `init_app` from `airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth` instead.
 
-AIR302_fab.py:41:1: AIR302 `airflow.auth.managers.fab.api.auth.backend.kerberos_auth.requires_authentication` is moved into `fab` provider in Airflow 3.0;
+ℹ Unsafe fix
+29 29 | from airflow.auth.managers.fab.api.auth.backend.kerberos_auth import (
+30 30 |     CLIENT_AUTH,
+31 31 |     find_user,
+32    |-    init_app,
+33 32 |     log,
+34 33 |     requires_authentication,
+35 34 | )
+   35 |+from airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth import init_app
+36 36 | 
+37 37 | log()
+38 38 | CLIENT_AUTH
+
+AIR302_fab.py:41:1: AIR302 [*] `airflow.auth.managers.fab.api.auth.backend.kerberos_auth.requires_authentication` is moved into `fab` provider in Airflow 3.0;
    |
 39 | find_user()
 40 | init_app()
@@ -149,7 +318,18 @@ AIR302_fab.py:41:1: AIR302 `airflow.auth.managers.fab.api.auth.backend.kerberos_
    |
    = help: Install `apache-airflow-providers-fab>=1.0.0` and use `requires_authentication` from `airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth` instead.
 
-AIR302_fab.py:49:1: AIR302 `airflow.auth.managers.fab.fab_auth_manager.FabAuthManager` is moved into `fab` provider in Airflow 3.0;
+ℹ Unsafe fix
+31 31 |     find_user,
+32 32 |     init_app,
+33 33 |     log,
+34    |-    requires_authentication,
+35 34 | )
+   35 |+from airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth import requires_authentication
+36 36 | 
+37 37 | log()
+38 38 | CLIENT_AUTH
+
+AIR302_fab.py:49:1: AIR302 [*] `airflow.auth.managers.fab.fab_auth_manager.FabAuthManager` is moved into `fab` provider in Airflow 3.0;
    |
 47 | )
 48 |
@@ -160,7 +340,21 @@ AIR302_fab.py:49:1: AIR302 `airflow.auth.managers.fab.fab_auth_manager.FabAuthMa
    |
    = help: Install `apache-airflow-providers-fab>=1.0.0` and use `FabAuthManager` from `airflow.providers.fab.auth_manager.fab_auth_manager` instead.
 
-AIR302_fab.py:50:1: AIR302 `airflow.auth.managers.fab.security_manager.override.MAX_NUM_DATABASE_USER_SESSIONS` is moved into `fab` provider in Airflow 3.0;
+ℹ Unsafe fix
+40 40 | init_app()
+41 41 | requires_authentication()
+42 42 | 
+43    |-from airflow.auth.managers.fab.fab_auth_manager import FabAuthManager
+44 43 | from airflow.auth.managers.fab.security_manager.override import (
+45 44 |     MAX_NUM_DATABASE_USER_SESSIONS,
+46 45 |     FabAirflowSecurityManagerOverride,
+47 46 | )
+   47 |+from airflow.providers.fab.auth_manager.fab_auth_manager import FabAuthManager
+48 48 | 
+49 49 | FabAuthManager()
+50 50 | MAX_NUM_DATABASE_USER_SESSIONS
+
+AIR302_fab.py:50:1: AIR302 [*] `airflow.auth.managers.fab.security_manager.override.MAX_NUM_DATABASE_USER_SESSIONS` is moved into `fab` provider in Airflow 3.0;
    |
 49 | FabAuthManager()
 50 | MAX_NUM_DATABASE_USER_SESSIONS
@@ -169,7 +363,19 @@ AIR302_fab.py:50:1: AIR302 `airflow.auth.managers.fab.security_manager.override.
    |
    = help: Install `apache-airflow-providers-fab>=1.0.0` and use `MAX_NUM_DATABASE_USER_SESSIONS` from `airflow.providers.fab.auth_manager.security_manager.override` instead.
 
-AIR302_fab.py:51:1: AIR302 `airflow.auth.managers.fab.security_manager.override.FabAirflowSecurityManagerOverride` is moved into `fab` provider in Airflow 3.0;
+ℹ Unsafe fix
+42 42 | 
+43 43 | from airflow.auth.managers.fab.fab_auth_manager import FabAuthManager
+44 44 | from airflow.auth.managers.fab.security_manager.override import (
+45    |-    MAX_NUM_DATABASE_USER_SESSIONS,
+46 45 |     FabAirflowSecurityManagerOverride,
+47 46 | )
+   47 |+from airflow.providers.fab.auth_manager.security_manager.override import MAX_NUM_DATABASE_USER_SESSIONS
+48 48 | 
+49 49 | FabAuthManager()
+50 50 | MAX_NUM_DATABASE_USER_SESSIONS
+
+AIR302_fab.py:51:1: AIR302 [*] `airflow.auth.managers.fab.security_manager.override.FabAirflowSecurityManagerOverride` is moved into `fab` provider in Airflow 3.0;
    |
 49 | FabAuthManager()
 50 | MAX_NUM_DATABASE_USER_SESSIONS
@@ -180,7 +386,18 @@ AIR302_fab.py:51:1: AIR302 `airflow.auth.managers.fab.security_manager.override.
    |
    = help: Install `apache-airflow-providers-fab>=1.0.0` and use `FabAirflowSecurityManagerOverride` from `airflow.providers.fab.auth_manager.security_manager.override` instead.
 
-AIR302_fab.py:55:1: AIR302 `airflow.www.security.FabAirflowSecurityManagerOverride` is moved into `fab` provider in Airflow 3.0;
+ℹ Unsafe fix
+43 43 | from airflow.auth.managers.fab.fab_auth_manager import FabAuthManager
+44 44 | from airflow.auth.managers.fab.security_manager.override import (
+45 45 |     MAX_NUM_DATABASE_USER_SESSIONS,
+46    |-    FabAirflowSecurityManagerOverride,
+47 46 | )
+   47 |+from airflow.providers.fab.auth_manager.security_manager.override import FabAirflowSecurityManagerOverride
+48 48 | 
+49 49 | FabAuthManager()
+50 50 | MAX_NUM_DATABASE_USER_SESSIONS
+
+AIR302_fab.py:55:1: AIR302 [*] `airflow.www.security.FabAirflowSecurityManagerOverride` is moved into `fab` provider in Airflow 3.0;
    |
 53 | from airflow.www.security import FabAirflowSecurityManagerOverride
 54 |
@@ -188,3 +405,12 @@ AIR302_fab.py:55:1: AIR302 `airflow.www.security.FabAirflowSecurityManagerOverri
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
    |
    = help: Install `apache-airflow-providers-fab>=1.0.0` and use `FabAirflowSecurityManagerOverride` from `airflow.providers.fab.auth_manager.security_manager.override` instead.
+
+ℹ Unsafe fix
+50 50 | MAX_NUM_DATABASE_USER_SESSIONS
+51 51 | FabAirflowSecurityManagerOverride()
+52 52 | 
+53    |-from airflow.www.security import FabAirflowSecurityManagerOverride
+   53 |+from airflow.providers.fab.auth_manager.security_manager.override import FabAirflowSecurityManagerOverride
+54 54 | 
+55 55 | FabAirflowSecurityManagerOverride()

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_hdfs.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_hdfs.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 ---
-AIR302_hdfs.py:6:1: AIR302 `airflow.hooks.webhdfs_hook.WebHDFSHook` is moved into `apache-hdfs` provider in Airflow 3.0;
+AIR302_hdfs.py:6:1: AIR302 [*] `airflow.hooks.webhdfs_hook.WebHDFSHook` is moved into `apache-hdfs` provider in Airflow 3.0;
   |
 4 | from airflow.sensors.web_hdfs_sensor import WebHdfsSensor
 5 |
@@ -11,10 +11,30 @@ AIR302_hdfs.py:6:1: AIR302 `airflow.hooks.webhdfs_hook.WebHDFSHook` is moved int
   |
   = help: Install `apache-airflow-providers-apache-hdfs>=1.0.0` and use `WebHDFSHook` from `airflow.providers.apache.hdfs.hooks.webhdfs` instead.
 
-AIR302_hdfs.py:7:1: AIR302 `airflow.sensors.web_hdfs_sensor.WebHdfsSensor` is moved into `apache-hdfs` provider in Airflow 3.0;
+ℹ Unsafe fix
+1 1 | from __future__ import annotations
+2 2 | 
+3   |-from airflow.hooks.webhdfs_hook import WebHDFSHook
+4 3 | from airflow.sensors.web_hdfs_sensor import WebHdfsSensor
+  4 |+from airflow.providers.apache.hdfs.hooks.webhdfs import WebHDFSHook
+5 5 | 
+6 6 | WebHDFSHook()
+7 7 | WebHdfsSensor()
+
+AIR302_hdfs.py:7:1: AIR302 [*] `airflow.sensors.web_hdfs_sensor.WebHdfsSensor` is moved into `apache-hdfs` provider in Airflow 3.0;
   |
 6 | WebHDFSHook()
 7 | WebHdfsSensor()
   | ^^^^^^^^^^^^^ AIR302
   |
   = help: Install `apache-airflow-providers-apache-hdfs>=1.0.0` and use `WebHdfsSensor` from `airflow.providers.apache.hdfs.sensors.web_hdfs` instead.
+
+ℹ Unsafe fix
+1 1 | from __future__ import annotations
+2 2 | 
+3 3 | from airflow.hooks.webhdfs_hook import WebHDFSHook
+4   |-from airflow.sensors.web_hdfs_sensor import WebHdfsSensor
+  4 |+from airflow.providers.apache.hdfs.sensors.web_hdfs import WebHdfsSensor
+5 5 | 
+6 6 | WebHDFSHook()
+7 7 | WebHdfsSensor()

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_hive.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_hive.py.snap
@@ -1,17 +1,32 @@
 ---
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 ---
-AIR302_hive.py:36:1: AIR302 `airflow.macros.hive.closest_ds_partition` is moved into `apache-hive` provider in Airflow 3.0;
+AIR302_hive.py:36:1: AIR302 [*] `airflow.macros.hive.closest_ds_partition` is moved into `apache-hive` provider in Airflow 3.0;
    |
-34 | from airflow.sensors.named_hive_partition_sensor import NamedHivePartitionSensor
-35 |
 36 | closest_ds_partition()
    | ^^^^^^^^^^^^^^^^^^^^ AIR302
 37 | max_partition()
    |
    = help: Install `apache-airflow-providers-apache-hive>=5.1.0` and use `closest_ds_partition` from `airflow.providers.apache.hive.macros.hive` instead.
 
-AIR302_hive.py:37:1: AIR302 `airflow.macros.hive.max_partition` is moved into `apache-hive` provider in Airflow 3.0;
+ℹ Unsafe fix
+7  7  |     HiveServer2Hook,
+8  8  | )
+9  9  | from airflow.macros.hive import (
+10    |-    closest_ds_partition,
+11 10 |     max_partition,
+12 11 | )
+13 12 | from airflow.operators.hive_operator import HiveOperator
+--------------------------------------------------------------------------------
+17 16 | 
+18 17 | )
+19 18 | from airflow.operators.hive_to_samba_operator import HiveToSambaOperator
+   19 |+from airflow.providers.apache.hive.macros.hive import closest_ds_partition
+20 20 | 
+21 21 |     
+22 22 | 
+
+AIR302_hive.py:37:1: AIR302 [*] `airflow.macros.hive.max_partition` is moved into `apache-hive` provider in Airflow 3.0;
    |
 36 | closest_ds_partition()
 37 | max_partition()
@@ -21,7 +36,24 @@ AIR302_hive.py:37:1: AIR302 `airflow.macros.hive.max_partition` is moved into `a
    |
    = help: Install `apache-airflow-providers-apache-hive>=5.1.0` and use `max_partition` from `airflow.providers.apache.hive.macros.hive` instead.
 
-AIR302_hive.py:39:1: AIR302 `airflow.hooks.hive_hooks.HiveCliHook` is moved into `apache-hive` provider in Airflow 3.0;
+ℹ Unsafe fix
+8  8  | )
+9  9  | from airflow.macros.hive import (
+10 10 |     closest_ds_partition,
+11    |-    max_partition,
+12 11 | )
+13 12 | from airflow.operators.hive_operator import HiveOperator
+14 13 | from airflow.operators.hive_stats_operator import HiveStatsCollectionOperator
+--------------------------------------------------------------------------------
+17 16 | 
+18 17 | )
+19 18 | from airflow.operators.hive_to_samba_operator import HiveToSambaOperator
+   19 |+from airflow.providers.apache.hive.macros.hive import max_partition
+20 20 | 
+21 21 |     
+22 22 | 
+
+AIR302_hive.py:39:1: AIR302 [*] `airflow.hooks.hive_hooks.HiveCliHook` is moved into `apache-hive` provider in Airflow 3.0;
    |
 37 | max_partition()
 38 |
@@ -32,7 +64,24 @@ AIR302_hive.py:39:1: AIR302 `airflow.hooks.hive_hooks.HiveCliHook` is moved into
    |
    = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `HiveCliHook` from `airflow.providers.apache.hive.hooks.hive` instead.
 
-AIR302_hive.py:40:1: AIR302 `airflow.hooks.hive_hooks.HiveMetastoreHook` is moved into `apache-hive` provider in Airflow 3.0;
+ℹ Unsafe fix
+2  2  | 
+3  3  | from airflow.hooks.hive_hooks import (
+4  4  |     HIVE_QUEUE_PRIORITIES,
+5     |-    HiveCliHook,
+6  5  |     HiveMetastoreHook,
+7  6  |     HiveServer2Hook,
+8  7  | )
+--------------------------------------------------------------------------------
+17 16 | 
+18 17 | )
+19 18 | from airflow.operators.hive_to_samba_operator import HiveToSambaOperator
+   19 |+from airflow.providers.apache.hive.hooks.hive import HiveCliHook
+20 20 | 
+21 21 |     
+22 22 | 
+
+AIR302_hive.py:40:1: AIR302 [*] `airflow.hooks.hive_hooks.HiveMetastoreHook` is moved into `apache-hive` provider in Airflow 3.0;
    |
 39 | HiveCliHook()
 40 | HiveMetastoreHook()
@@ -42,7 +91,24 @@ AIR302_hive.py:40:1: AIR302 `airflow.hooks.hive_hooks.HiveMetastoreHook` is move
    |
    = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `HiveMetastoreHook` from `airflow.providers.apache.hive.hooks.hive` instead.
 
-AIR302_hive.py:41:1: AIR302 `airflow.hooks.hive_hooks.HiveServer2Hook` is moved into `apache-hive` provider in Airflow 3.0;
+ℹ Unsafe fix
+3  3  | from airflow.hooks.hive_hooks import (
+4  4  |     HIVE_QUEUE_PRIORITIES,
+5  5  |     HiveCliHook,
+6     |-    HiveMetastoreHook,
+7  6  |     HiveServer2Hook,
+8  7  | )
+9  8  | from airflow.macros.hive import (
+--------------------------------------------------------------------------------
+17 16 | 
+18 17 | )
+19 18 | from airflow.operators.hive_to_samba_operator import HiveToSambaOperator
+   19 |+from airflow.providers.apache.hive.hooks.hive import HiveMetastoreHook
+20 20 | 
+21 21 |     
+22 22 | 
+
+AIR302_hive.py:41:1: AIR302 [*] `airflow.hooks.hive_hooks.HiveServer2Hook` is moved into `apache-hive` provider in Airflow 3.0;
    |
 39 | HiveCliHook()
 40 | HiveMetastoreHook()
@@ -52,7 +118,24 @@ AIR302_hive.py:41:1: AIR302 `airflow.hooks.hive_hooks.HiveServer2Hook` is moved 
    |
    = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `HiveServer2Hook` from `airflow.providers.apache.hive.hooks.hive` instead.
 
-AIR302_hive.py:42:1: AIR302 `airflow.hooks.hive_hooks.HIVE_QUEUE_PRIORITIES` is moved into `apache-hive` provider in Airflow 3.0;
+ℹ Unsafe fix
+4  4  |     HIVE_QUEUE_PRIORITIES,
+5  5  |     HiveCliHook,
+6  6  |     HiveMetastoreHook,
+7     |-    HiveServer2Hook,
+8  7  | )
+9  8  | from airflow.macros.hive import (
+10 9  |     closest_ds_partition,
+--------------------------------------------------------------------------------
+17 16 | 
+18 17 | )
+19 18 | from airflow.operators.hive_to_samba_operator import HiveToSambaOperator
+   19 |+from airflow.providers.apache.hive.hooks.hive import HiveServer2Hook
+20 20 | 
+21 21 |     
+22 22 | 
+
+AIR302_hive.py:42:1: AIR302 [*] `airflow.hooks.hive_hooks.HIVE_QUEUE_PRIORITIES` is moved into `apache-hive` provider in Airflow 3.0;
    |
 40 | HiveMetastoreHook()
 41 | HiveServer2Hook()
@@ -63,7 +146,24 @@ AIR302_hive.py:42:1: AIR302 `airflow.hooks.hive_hooks.HIVE_QUEUE_PRIORITIES` is 
    |
    = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `HIVE_QUEUE_PRIORITIES` from `airflow.providers.apache.hive.hooks.hive` instead.
 
-AIR302_hive.py:44:1: AIR302 `airflow.operators.hive_operator.HiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
+ℹ Unsafe fix
+1  1  | from __future__ import annotations
+2  2  | 
+3  3  | from airflow.hooks.hive_hooks import (
+4     |-    HIVE_QUEUE_PRIORITIES,
+5  4  |     HiveCliHook,
+6  5  |     HiveMetastoreHook,
+7  6  |     HiveServer2Hook,
+--------------------------------------------------------------------------------
+17 16 | 
+18 17 | )
+19 18 | from airflow.operators.hive_to_samba_operator import HiveToSambaOperator
+   19 |+from airflow.providers.apache.hive.hooks.hive import HIVE_QUEUE_PRIORITIES
+20 20 | 
+21 21 |     
+22 22 | 
+
+AIR302_hive.py:44:1: AIR302 [*] `airflow.operators.hive_operator.HiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
    |
 42 | HIVE_QUEUE_PRIORITIES
 43 |
@@ -74,7 +174,23 @@ AIR302_hive.py:44:1: AIR302 `airflow.operators.hive_operator.HiveOperator` is mo
    |
    = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `HiveOperator` from `airflow.providers.apache.hive.operators.hive` instead.
 
-AIR302_hive.py:46:1: AIR302 `airflow.operators.hive_stats_operator.HiveStatsCollectionOperator` is moved into `apache-hive` provider in Airflow 3.0;
+ℹ Unsafe fix
+10 10 |     closest_ds_partition,
+11 11 |     max_partition,
+12 12 | )
+13    |-from airflow.operators.hive_operator import HiveOperator
+14 13 | from airflow.operators.hive_stats_operator import HiveStatsCollectionOperator
+15 14 | from airflow.operators.hive_to_mysql import (
+16 15 |     HiveToMySqlOperator,
+17 16 | 
+18 17 | )
+19 18 | from airflow.operators.hive_to_samba_operator import HiveToSambaOperator
+   19 |+from airflow.providers.apache.hive.operators.hive import HiveOperator
+20 20 | 
+21 21 |     
+22 22 | 
+
+AIR302_hive.py:46:1: AIR302 [*] `airflow.operators.hive_stats_operator.HiveStatsCollectionOperator` is moved into `apache-hive` provider in Airflow 3.0;
    |
 44 | HiveOperator()
 45 |
@@ -85,124 +201,258 @@ AIR302_hive.py:46:1: AIR302 `airflow.operators.hive_stats_operator.HiveStatsColl
    |
    = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `HiveStatsCollectionOperator` from `airflow.providers.apache.hive.operators.hive_stats` instead.
 
-AIR302_hive.py:48:1: AIR302 `airflow.operators.hive_to_mysql.HiveToMySqlOperator` is moved into `apache-hive` provider in Airflow 3.0;
+ℹ Unsafe fix
+11 11 |     max_partition,
+12 12 | )
+13 13 | from airflow.operators.hive_operator import HiveOperator
+14    |-from airflow.operators.hive_stats_operator import HiveStatsCollectionOperator
+15 14 | from airflow.operators.hive_to_mysql import (
+16 15 |     HiveToMySqlOperator,
+17 16 | 
+18 17 | )
+19 18 | from airflow.operators.hive_to_samba_operator import HiveToSambaOperator
+   19 |+from airflow.providers.apache.hive.operators.hive_stats import HiveStatsCollectionOperator
+20 20 | 
+21 21 |     
+22 22 | 
+
+AIR302_hive.py:48:1: AIR302 [*] `airflow.operators.hive_to_mysql.HiveToMySqlOperator` is moved into `apache-hive` provider in Airflow 3.0;
    |
 46 | HiveStatsCollectionOperator()
 47 |
 48 | HiveToMySqlOperator()
    | ^^^^^^^^^^^^^^^^^^^ AIR302
-49 | HiveToMySqlTransfer()
    |
    = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `HiveToMySqlOperator` from `airflow.providers.apache.hive.transfers.hive_to_mysql` instead.
 
-AIR302_hive.py:49:1: AIR302 `airflow.operators.hive_to_mysql.HiveToMySqlTransfer` is moved into `apache-hive` provider in Airflow 3.0;
-   |
-48 | HiveToMySqlOperator()
-49 | HiveToMySqlTransfer()
-   | ^^^^^^^^^^^^^^^^^^^ AIR302
-50 |
-51 | HiveToSambaOperator()
-   |
-   = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `HiveToMySqlOperator` from `airflow.providers.apache.hive.transfers.hive_to_mysql` instead.
+ℹ Unsafe fix
+12 12 | )
+13 13 | from airflow.operators.hive_operator import HiveOperator
+14 14 | from airflow.operators.hive_stats_operator import HiveStatsCollectionOperator
+15    |-from airflow.operators.hive_to_mysql import (
+16    |-    HiveToMySqlOperator,
+17    |-
+18    |-)
+19 15 | from airflow.operators.hive_to_samba_operator import HiveToSambaOperator
+   16 |+from airflow.providers.apache.hive.transfers.hive_to_mysql import HiveToMySqlOperator
+20 17 | 
+21 18 |     
+22 19 | 
 
-AIR302_hive.py:51:1: AIR302 `airflow.operators.hive_to_samba_operator.HiveToSambaOperator` is moved into `apache-hive` provider in Airflow 3.0;
+AIR302_hive.py:51:1: AIR302 [*] `airflow.operators.hive_to_samba_operator.HiveToSambaOperator` is moved into `apache-hive` provider in Airflow 3.0;
    |
-49 | HiveToMySqlTransfer()
-50 |
 51 | HiveToSambaOperator()
    | ^^^^^^^^^^^^^^^^^^^ AIR302
-52 |
-53 | MsSqlToHiveOperator()
    |
    = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `HiveToSambaOperator` from `airflow.providers.apache.hive.transfers.hive_to_samba` instead.
 
-AIR302_hive.py:53:1: AIR302 `airflow.operators.mssql_to_hive.MsSqlToHiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
-   |
-51 | HiveToSambaOperator()
-52 |
-53 | MsSqlToHiveOperator()
-   | ^^^^^^^^^^^^^^^^^^^ AIR302
-54 | MsSqlToHiveTransfer()
-   |
-   = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `MsSqlToHiveOperator` from `airflow.providers.apache.hive.transfers.mssql_to_hive` instead.
+ℹ Unsafe fix
+16 16 |     HiveToMySqlOperator,
+17 17 | 
+18 18 | )
+19    |-from airflow.operators.hive_to_samba_operator import HiveToSambaOperator
+   19 |+from airflow.providers.apache.hive.transfers.hive_to_samba import HiveToSambaOperator
+20 20 | 
+21 21 |     
+22 22 | 
 
-AIR302_hive.py:54:1: AIR302 `airflow.operators.mssql_to_hive.MsSqlToHiveTransfer` is moved into `apache-hive` provider in Airflow 3.0;
+AIR302_hive.py:72:1: AIR302 [*] `airflow.operators.hive_to_mysql.HiveToMySqlTransfer` is moved into `apache-hive` provider in Airflow 3.0;
    |
-53 | MsSqlToHiveOperator()
-54 | MsSqlToHiveTransfer()
+70 | from airflow.operators.hive_to_mysql import HiveToMySqlTransfer
+71 |
+72 | HiveToMySqlTransfer()
    | ^^^^^^^^^^^^^^^^^^^ AIR302
-55 |
-56 | MySqlToHiveOperator()
+73 |
+74 | from airflow.operators.mysql_to_hive import MySqlToHiveOperator
    |
-   = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `MsSqlToHiveOperator` from `airflow.providers.apache.hive.transfers.mssql_to_hive` instead.
+   = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `HiveToMySqlOperator` from `airflow.providers.apache.hive.transfers.hive_to_mysql` instead.
 
-AIR302_hive.py:56:1: AIR302 `airflow.operators.mysql_to_hive.MySqlToHiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
+ℹ Unsafe fix
+68 68 | 
+69 69 | 
+70 70 | from airflow.operators.hive_to_mysql import HiveToMySqlTransfer
+   71 |+from airflow.providers.apache.hive.transfers.hive_to_mysql import HiveToMySqlOperator
+71 72 | 
+72 73 | HiveToMySqlTransfer()
+73 74 | 
+
+AIR302_hive.py:76:1: AIR302 [*] `airflow.operators.mysql_to_hive.MySqlToHiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
    |
-54 | MsSqlToHiveTransfer()
-55 |
-56 | MySqlToHiveOperator()
+74 | from airflow.operators.mysql_to_hive import MySqlToHiveOperator
+75 |
+76 | MySqlToHiveOperator()
    | ^^^^^^^^^^^^^^^^^^^ AIR302
-57 | MySqlToHiveTransfer()
+77 |
+78 | from airflow.operators.mysql_to_hive import MySqlToHiveTransfer
    |
    = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `MySqlToHiveOperator` from `airflow.providers.apache.hive.transfers.mysql_to_hive` instead.
 
-AIR302_hive.py:57:1: AIR302 `airflow.operators.mysql_to_hive.MySqlToHiveTransfer` is moved into `apache-hive` provider in Airflow 3.0;
+ℹ Unsafe fix
+71 71 | 
+72 72 | HiveToMySqlTransfer()
+73 73 | 
+74    |-from airflow.operators.mysql_to_hive import MySqlToHiveOperator
+   74 |+from airflow.providers.apache.hive.transfers.mysql_to_hive import MySqlToHiveOperator
+75 75 | 
+76 76 | MySqlToHiveOperator()
+77 77 | 
+
+AIR302_hive.py:80:1: AIR302 [*] `airflow.operators.mysql_to_hive.MySqlToHiveTransfer` is moved into `apache-hive` provider in Airflow 3.0;
    |
-56 | MySqlToHiveOperator()
-57 | MySqlToHiveTransfer()
+78 | from airflow.operators.mysql_to_hive import MySqlToHiveTransfer
+79 |
+80 | MySqlToHiveTransfer()
    | ^^^^^^^^^^^^^^^^^^^ AIR302
-58 |
-59 | S3ToHiveOperator()
+81 |
+82 | from airflow.operators.mssql_to_hive import MsSqlToHiveOperator
    |
    = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `MySqlToHiveOperator` from `airflow.providers.apache.hive.transfers.mysql_to_hive` instead.
 
-AIR302_hive.py:59:1: AIR302 `airflow.operators.s3_to_hive_operator.S3ToHiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
-   |
-57 | MySqlToHiveTransfer()
-58 |
-59 | S3ToHiveOperator()
-   | ^^^^^^^^^^^^^^^^ AIR302
-60 | S3ToHiveTransfer()
-   |
-   = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `S3ToHiveOperator` from `airflow.providers.apache.hive.transfers.s3_to_hive` instead.
+ℹ Unsafe fix
+76 76 | MySqlToHiveOperator()
+77 77 | 
+78 78 | from airflow.operators.mysql_to_hive import MySqlToHiveTransfer
+   79 |+from airflow.providers.apache.hive.transfers.mysql_to_hive import MySqlToHiveOperator
+79 80 | 
+80 81 | MySqlToHiveTransfer()
+81 82 | 
 
-AIR302_hive.py:60:1: AIR302 `airflow.operators.s3_to_hive_operator.S3ToHiveTransfer` is moved into `apache-hive` provider in Airflow 3.0;
+AIR302_hive.py:84:1: AIR302 [*] `airflow.operators.mssql_to_hive.MsSqlToHiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
    |
-59 | S3ToHiveOperator()
-60 | S3ToHiveTransfer()
-   | ^^^^^^^^^^^^^^^^ AIR302
-61 |
-62 | HivePartitionSensor()
-   |
-   = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `S3ToHiveOperator` from `airflow.providers.apache.hive.transfers.s3_to_hive` instead.
-
-AIR302_hive.py:62:1: AIR302 `airflow.sensors.hive_partition_sensor.HivePartitionSensor` is moved into `apache-hive` provider in Airflow 3.0;
-   |
-60 | S3ToHiveTransfer()
-61 |
-62 | HivePartitionSensor()
+82 | from airflow.operators.mssql_to_hive import MsSqlToHiveOperator
+83 |
+84 | MsSqlToHiveOperator()
    | ^^^^^^^^^^^^^^^^^^^ AIR302
-63 |
-64 | MetastorePartitionSensor()
+85 |
+86 | from airflow.operators.mssql_to_hive import MsSqlToHiveTransfer
    |
-   = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `HivePartitionSensor` from `airflow.providers.apache.hive.sensors.hive_partition` instead.
+   = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `MsSqlToHiveOperator` from `airflow.providers.apache.hive.transfers.mssql_to_hive` instead.
 
-AIR302_hive.py:64:1: AIR302 `airflow.sensors.metastore_partition_sensor.MetastorePartitionSensor` is moved into `apache-hive` provider in Airflow 3.0;
-   |
-62 | HivePartitionSensor()
-63 |
-64 | MetastorePartitionSensor()
-   | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-65 |
-66 | NamedHivePartitionSensor()
-   |
-   = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `MetastorePartitionSensor` from `airflow.providers.apache.hive.sensors.metastore_partition` instead.
+ℹ Unsafe fix
+79 79 | 
+80 80 | MySqlToHiveTransfer()
+81 81 | 
+82    |-from airflow.operators.mssql_to_hive import MsSqlToHiveOperator
+   82 |+from airflow.providers.apache.hive.transfers.mssql_to_hive import MsSqlToHiveOperator
+83 83 | 
+84 84 | MsSqlToHiveOperator()
+85 85 | 
 
-AIR302_hive.py:66:1: AIR302 `airflow.sensors.named_hive_partition_sensor.NamedHivePartitionSensor` is moved into `apache-hive` provider in Airflow 3.0;
+AIR302_hive.py:88:1: AIR302 [*] `airflow.operators.mssql_to_hive.MsSqlToHiveTransfer` is moved into `apache-hive` provider in Airflow 3.0;
    |
-64 | MetastorePartitionSensor()
-65 |
-66 | NamedHivePartitionSensor()
-   | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
+86 | from airflow.operators.mssql_to_hive import MsSqlToHiveTransfer
+87 |
+88 | MsSqlToHiveTransfer()
+   | ^^^^^^^^^^^^^^^^^^^ AIR302
+89 |
+90 | from airflow.operators.s3_to_hive_operator import S3ToHiveOperator
    |
-   = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `NamedHivePartitionSensor` from `airflow.providers.apache.hive.sensors.named_hive_partition` instead.
+   = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `MsSqlToHiveOperator` from `airflow.providers.apache.hive.transfers.mssql_to_hive` instead.
+
+ℹ Unsafe fix
+84 84 | MsSqlToHiveOperator()
+85 85 | 
+86 86 | from airflow.operators.mssql_to_hive import MsSqlToHiveTransfer
+   87 |+from airflow.providers.apache.hive.transfers.mssql_to_hive import MsSqlToHiveOperator
+87 88 | 
+88 89 | MsSqlToHiveTransfer()
+89 90 | 
+
+AIR302_hive.py:92:1: AIR302 [*] `airflow.operators.s3_to_hive_operator.S3ToHiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
+   |
+90 | from airflow.operators.s3_to_hive_operator import S3ToHiveOperator
+91 |
+92 | S3ToHiveOperator()
+   | ^^^^^^^^^^^^^^^^ AIR302
+93 |
+94 | from airflow.operators.s3_to_hive_operator import S3ToHiveTransfer
+   |
+   = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `S3ToHiveOperator` from `airflow.providers.apache.hive.transfers.s3_to_hive` instead.
+
+ℹ Unsafe fix
+87 87 | 
+88 88 | MsSqlToHiveTransfer()
+89 89 | 
+90    |-from airflow.operators.s3_to_hive_operator import S3ToHiveOperator
+   90 |+from airflow.providers.apache.hive.transfers.s3_to_hive import S3ToHiveOperator
+91 91 | 
+92 92 | S3ToHiveOperator()
+93 93 | 
+
+AIR302_hive.py:96:1: AIR302 [*] `airflow.operators.s3_to_hive_operator.S3ToHiveTransfer` is moved into `apache-hive` provider in Airflow 3.0;
+   |
+94 | from airflow.operators.s3_to_hive_operator import S3ToHiveTransfer
+95 |
+96 | S3ToHiveTransfer()
+   | ^^^^^^^^^^^^^^^^ AIR302
+97 |
+98 | from airflow.sensors.hive_partition_sensor import HivePartitionSensor
+   |
+   = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `S3ToHiveOperator` from `airflow.providers.apache.hive.transfers.s3_to_hive` instead.
+
+ℹ Unsafe fix
+92 92 | S3ToHiveOperator()
+93 93 | 
+94 94 | from airflow.operators.s3_to_hive_operator import S3ToHiveTransfer
+   95 |+from airflow.providers.apache.hive.transfers.s3_to_hive import S3ToHiveOperator
+95 96 | 
+96 97 | S3ToHiveTransfer()
+97 98 | 
+
+AIR302_hive.py:100:1: AIR302 [*] `airflow.sensors.hive_partition_sensor.HivePartitionSensor` is moved into `apache-hive` provider in Airflow 3.0;
+    |
+ 98 | from airflow.sensors.hive_partition_sensor import HivePartitionSensor
+ 99 |
+100 | HivePartitionSensor()
+    | ^^^^^^^^^^^^^^^^^^^ AIR302
+101 |
+102 | from airflow.sensors.metastore_partition_sensor import MetastorePartitionSensor
+    |
+    = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `HivePartitionSensor` from `airflow.providers.apache.hive.sensors.hive_partition` instead.
+
+ℹ Unsafe fix
+95 95 | 
+96 96 | S3ToHiveTransfer()
+97 97 | 
+98    |-from airflow.sensors.hive_partition_sensor import HivePartitionSensor
+   98 |+from airflow.providers.apache.hive.sensors.hive_partition import HivePartitionSensor
+99 99 | 
+100 100 | HivePartitionSensor()
+101 101 | 
+
+AIR302_hive.py:104:1: AIR302 [*] `airflow.sensors.metastore_partition_sensor.MetastorePartitionSensor` is moved into `apache-hive` provider in Airflow 3.0;
+    |
+102 | from airflow.sensors.metastore_partition_sensor import MetastorePartitionSensor
+103 |
+104 | MetastorePartitionSensor()
+    | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
+105 |
+106 | from airflow.sensors.named_hive_partition_sensor import NamedHivePartitionSensor
+    |
+    = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `MetastorePartitionSensor` from `airflow.providers.apache.hive.sensors.metastore_partition` instead.
+
+ℹ Unsafe fix
+99  99  | 
+100 100 | HivePartitionSensor()
+101 101 | 
+102     |-from airflow.sensors.metastore_partition_sensor import MetastorePartitionSensor
+    102 |+from airflow.providers.apache.hive.sensors.metastore_partition import MetastorePartitionSensor
+103 103 | 
+104 104 | MetastorePartitionSensor()
+105 105 | 
+
+AIR302_hive.py:107:1: AIR302 [*] `airflow.sensors.named_hive_partition_sensor.NamedHivePartitionSensor` is moved into `apache-hive` provider in Airflow 3.0;
+    |
+106 | from airflow.sensors.named_hive_partition_sensor import NamedHivePartitionSensor
+107 | NamedHivePartitionSensor()
+    | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
+    |
+    = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `NamedHivePartitionSensor` from `airflow.providers.apache.hive.sensors.named_hive_partition` instead.
+
+ℹ Unsafe fix
+103 103 | 
+104 104 | MetastorePartitionSensor()
+105 105 | 
+106     |-from airflow.sensors.named_hive_partition_sensor import NamedHivePartitionSensor
+    106 |+from airflow.providers.apache.hive.sensors.named_hive_partition import NamedHivePartitionSensor
+107 107 | NamedHivePartitionSensor()

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_hive.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_hive.py.snap
@@ -1,148 +1,14 @@
 ---
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 ---
-AIR302_hive.py:36:1: AIR302 [*] `airflow.macros.hive.closest_ds_partition` is moved into `apache-hive` provider in Airflow 3.0;
+AIR302_hive.py:18:1: AIR302 [*] `airflow.hooks.hive_hooks.HIVE_QUEUE_PRIORITIES` is moved into `apache-hive` provider in Airflow 3.0;
    |
-36 | closest_ds_partition()
-   | ^^^^^^^^^^^^^^^^^^^^ AIR302
-37 | max_partition()
-   |
-   = help: Install `apache-airflow-providers-apache-hive>=5.1.0` and use `closest_ds_partition` from `airflow.providers.apache.hive.macros.hive` instead.
-
-ℹ Unsafe fix
-7  7  |     HiveServer2Hook,
-8  8  | )
-9  9  | from airflow.macros.hive import (
-10    |-    closest_ds_partition,
-11 10 |     max_partition,
-12 11 | )
-13 12 | from airflow.operators.hive_operator import HiveOperator
---------------------------------------------------------------------------------
-17 16 | 
-18 17 | )
-19 18 | from airflow.operators.hive_to_samba_operator import HiveToSambaOperator
-   19 |+from airflow.providers.apache.hive.macros.hive import closest_ds_partition
-20 20 | 
-21 21 |     
-22 22 | 
-
-AIR302_hive.py:37:1: AIR302 [*] `airflow.macros.hive.max_partition` is moved into `apache-hive` provider in Airflow 3.0;
-   |
-36 | closest_ds_partition()
-37 | max_partition()
-   | ^^^^^^^^^^^^^ AIR302
-38 |
-39 | HiveCliHook()
-   |
-   = help: Install `apache-airflow-providers-apache-hive>=5.1.0` and use `max_partition` from `airflow.providers.apache.hive.macros.hive` instead.
-
-ℹ Unsafe fix
-8  8  | )
-9  9  | from airflow.macros.hive import (
-10 10 |     closest_ds_partition,
-11    |-    max_partition,
-12 11 | )
-13 12 | from airflow.operators.hive_operator import HiveOperator
-14 13 | from airflow.operators.hive_stats_operator import HiveStatsCollectionOperator
---------------------------------------------------------------------------------
-17 16 | 
-18 17 | )
-19 18 | from airflow.operators.hive_to_samba_operator import HiveToSambaOperator
-   19 |+from airflow.providers.apache.hive.macros.hive import max_partition
-20 20 | 
-21 21 |     
-22 22 | 
-
-AIR302_hive.py:39:1: AIR302 [*] `airflow.hooks.hive_hooks.HiveCliHook` is moved into `apache-hive` provider in Airflow 3.0;
-   |
-37 | max_partition()
-38 |
-39 | HiveCliHook()
-   | ^^^^^^^^^^^ AIR302
-40 | HiveMetastoreHook()
-41 | HiveServer2Hook()
-   |
-   = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `HiveCliHook` from `airflow.providers.apache.hive.hooks.hive` instead.
-
-ℹ Unsafe fix
-2  2  | 
-3  3  | from airflow.hooks.hive_hooks import (
-4  4  |     HIVE_QUEUE_PRIORITIES,
-5     |-    HiveCliHook,
-6  5  |     HiveMetastoreHook,
-7  6  |     HiveServer2Hook,
-8  7  | )
---------------------------------------------------------------------------------
-17 16 | 
-18 17 | )
-19 18 | from airflow.operators.hive_to_samba_operator import HiveToSambaOperator
-   19 |+from airflow.providers.apache.hive.hooks.hive import HiveCliHook
-20 20 | 
-21 21 |     
-22 22 | 
-
-AIR302_hive.py:40:1: AIR302 [*] `airflow.hooks.hive_hooks.HiveMetastoreHook` is moved into `apache-hive` provider in Airflow 3.0;
-   |
-39 | HiveCliHook()
-40 | HiveMetastoreHook()
-   | ^^^^^^^^^^^^^^^^^ AIR302
-41 | HiveServer2Hook()
-42 | HIVE_QUEUE_PRIORITIES
-   |
-   = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `HiveMetastoreHook` from `airflow.providers.apache.hive.hooks.hive` instead.
-
-ℹ Unsafe fix
-3  3  | from airflow.hooks.hive_hooks import (
-4  4  |     HIVE_QUEUE_PRIORITIES,
-5  5  |     HiveCliHook,
-6     |-    HiveMetastoreHook,
-7  6  |     HiveServer2Hook,
-8  7  | )
-9  8  | from airflow.macros.hive import (
---------------------------------------------------------------------------------
-17 16 | 
-18 17 | )
-19 18 | from airflow.operators.hive_to_samba_operator import HiveToSambaOperator
-   19 |+from airflow.providers.apache.hive.hooks.hive import HiveMetastoreHook
-20 20 | 
-21 21 |     
-22 22 | 
-
-AIR302_hive.py:41:1: AIR302 [*] `airflow.hooks.hive_hooks.HiveServer2Hook` is moved into `apache-hive` provider in Airflow 3.0;
-   |
-39 | HiveCliHook()
-40 | HiveMetastoreHook()
-41 | HiveServer2Hook()
-   | ^^^^^^^^^^^^^^^ AIR302
-42 | HIVE_QUEUE_PRIORITIES
-   |
-   = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `HiveServer2Hook` from `airflow.providers.apache.hive.hooks.hive` instead.
-
-ℹ Unsafe fix
-4  4  |     HIVE_QUEUE_PRIORITIES,
-5  5  |     HiveCliHook,
-6  6  |     HiveMetastoreHook,
-7     |-    HiveServer2Hook,
-8  7  | )
-9  8  | from airflow.macros.hive import (
-10 9  |     closest_ds_partition,
---------------------------------------------------------------------------------
-17 16 | 
-18 17 | )
-19 18 | from airflow.operators.hive_to_samba_operator import HiveToSambaOperator
-   19 |+from airflow.providers.apache.hive.hooks.hive import HiveServer2Hook
-20 20 | 
-21 21 |     
-22 22 | 
-
-AIR302_hive.py:42:1: AIR302 [*] `airflow.hooks.hive_hooks.HIVE_QUEUE_PRIORITIES` is moved into `apache-hive` provider in Airflow 3.0;
-   |
-40 | HiveMetastoreHook()
-41 | HiveServer2Hook()
-42 | HIVE_QUEUE_PRIORITIES
+16 | from airflow.operators.hive_to_samba_operator import HiveToSambaOperator
+17 |
+18 | HIVE_QUEUE_PRIORITIES
    | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-43 |
-44 | HiveOperator()
+19 | HiveCliHook()
+20 | HiveMetastoreHook()
    |
    = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `HIVE_QUEUE_PRIORITIES` from `airflow.providers.apache.hive.hooks.hive` instead.
 
@@ -155,22 +21,155 @@ AIR302_hive.py:42:1: AIR302 [*] `airflow.hooks.hive_hooks.HIVE_QUEUE_PRIORITIES`
 6  5  |     HiveMetastoreHook,
 7  6  |     HiveServer2Hook,
 --------------------------------------------------------------------------------
-17 16 | 
-18 17 | )
-19 18 | from airflow.operators.hive_to_samba_operator import HiveToSambaOperator
-   19 |+from airflow.providers.apache.hive.hooks.hive import HIVE_QUEUE_PRIORITIES
-20 20 | 
-21 21 |     
-22 22 | 
+14 13 | from airflow.operators.hive_stats_operator import HiveStatsCollectionOperator
+15 14 | from airflow.operators.hive_to_mysql import HiveToMySqlOperator
+16 15 | from airflow.operators.hive_to_samba_operator import HiveToSambaOperator
+   16 |+from airflow.providers.apache.hive.hooks.hive import HIVE_QUEUE_PRIORITIES
+17 17 | 
+18 18 | HIVE_QUEUE_PRIORITIES
+19 19 | HiveCliHook()
 
-AIR302_hive.py:44:1: AIR302 [*] `airflow.operators.hive_operator.HiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
+AIR302_hive.py:19:1: AIR302 [*] `airflow.hooks.hive_hooks.HiveCliHook` is moved into `apache-hive` provider in Airflow 3.0;
    |
-42 | HIVE_QUEUE_PRIORITIES
-43 |
-44 | HiveOperator()
+18 | HIVE_QUEUE_PRIORITIES
+19 | HiveCliHook()
+   | ^^^^^^^^^^^ AIR302
+20 | HiveMetastoreHook()
+21 | HiveServer2Hook()
+   |
+   = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `HiveCliHook` from `airflow.providers.apache.hive.hooks.hive` instead.
+
+ℹ Unsafe fix
+2  2  | 
+3  3  | from airflow.hooks.hive_hooks import (
+4  4  |     HIVE_QUEUE_PRIORITIES,
+5     |-    HiveCliHook,
+6  5  |     HiveMetastoreHook,
+7  6  |     HiveServer2Hook,
+8  7  | )
+--------------------------------------------------------------------------------
+14 13 | from airflow.operators.hive_stats_operator import HiveStatsCollectionOperator
+15 14 | from airflow.operators.hive_to_mysql import HiveToMySqlOperator
+16 15 | from airflow.operators.hive_to_samba_operator import HiveToSambaOperator
+   16 |+from airflow.providers.apache.hive.hooks.hive import HiveCliHook
+17 17 | 
+18 18 | HIVE_QUEUE_PRIORITIES
+19 19 | HiveCliHook()
+
+AIR302_hive.py:20:1: AIR302 [*] `airflow.hooks.hive_hooks.HiveMetastoreHook` is moved into `apache-hive` provider in Airflow 3.0;
+   |
+18 | HIVE_QUEUE_PRIORITIES
+19 | HiveCliHook()
+20 | HiveMetastoreHook()
+   | ^^^^^^^^^^^^^^^^^ AIR302
+21 | HiveServer2Hook()
+   |
+   = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `HiveMetastoreHook` from `airflow.providers.apache.hive.hooks.hive` instead.
+
+ℹ Unsafe fix
+3  3  | from airflow.hooks.hive_hooks import (
+4  4  |     HIVE_QUEUE_PRIORITIES,
+5  5  |     HiveCliHook,
+6     |-    HiveMetastoreHook,
+7  6  |     HiveServer2Hook,
+8  7  | )
+9  8  | from airflow.macros.hive import (
+--------------------------------------------------------------------------------
+14 13 | from airflow.operators.hive_stats_operator import HiveStatsCollectionOperator
+15 14 | from airflow.operators.hive_to_mysql import HiveToMySqlOperator
+16 15 | from airflow.operators.hive_to_samba_operator import HiveToSambaOperator
+   16 |+from airflow.providers.apache.hive.hooks.hive import HiveMetastoreHook
+17 17 | 
+18 18 | HIVE_QUEUE_PRIORITIES
+19 19 | HiveCliHook()
+
+AIR302_hive.py:21:1: AIR302 [*] `airflow.hooks.hive_hooks.HiveServer2Hook` is moved into `apache-hive` provider in Airflow 3.0;
+   |
+19 | HiveCliHook()
+20 | HiveMetastoreHook()
+21 | HiveServer2Hook()
+   | ^^^^^^^^^^^^^^^ AIR302
+22 |
+23 | closest_ds_partition()
+   |
+   = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `HiveServer2Hook` from `airflow.providers.apache.hive.hooks.hive` instead.
+
+ℹ Unsafe fix
+4  4  |     HIVE_QUEUE_PRIORITIES,
+5  5  |     HiveCliHook,
+6  6  |     HiveMetastoreHook,
+7     |-    HiveServer2Hook,
+8  7  | )
+9  8  | from airflow.macros.hive import (
+10 9  |     closest_ds_partition,
+--------------------------------------------------------------------------------
+14 13 | from airflow.operators.hive_stats_operator import HiveStatsCollectionOperator
+15 14 | from airflow.operators.hive_to_mysql import HiveToMySqlOperator
+16 15 | from airflow.operators.hive_to_samba_operator import HiveToSambaOperator
+   16 |+from airflow.providers.apache.hive.hooks.hive import HiveServer2Hook
+17 17 | 
+18 18 | HIVE_QUEUE_PRIORITIES
+19 19 | HiveCliHook()
+
+AIR302_hive.py:23:1: AIR302 [*] `airflow.macros.hive.closest_ds_partition` is moved into `apache-hive` provider in Airflow 3.0;
+   |
+21 | HiveServer2Hook()
+22 |
+23 | closest_ds_partition()
+   | ^^^^^^^^^^^^^^^^^^^^ AIR302
+24 | max_partition()
+   |
+   = help: Install `apache-airflow-providers-apache-hive>=5.1.0` and use `closest_ds_partition` from `airflow.providers.apache.hive.macros.hive` instead.
+
+ℹ Unsafe fix
+7  7  |     HiveServer2Hook,
+8  8  | )
+9  9  | from airflow.macros.hive import (
+10    |-    closest_ds_partition,
+11 10 |     max_partition,
+12 11 | )
+13 12 | from airflow.operators.hive_operator import HiveOperator
+14 13 | from airflow.operators.hive_stats_operator import HiveStatsCollectionOperator
+15 14 | from airflow.operators.hive_to_mysql import HiveToMySqlOperator
+16 15 | from airflow.operators.hive_to_samba_operator import HiveToSambaOperator
+   16 |+from airflow.providers.apache.hive.macros.hive import closest_ds_partition
+17 17 | 
+18 18 | HIVE_QUEUE_PRIORITIES
+19 19 | HiveCliHook()
+
+AIR302_hive.py:24:1: AIR302 [*] `airflow.macros.hive.max_partition` is moved into `apache-hive` provider in Airflow 3.0;
+   |
+23 | closest_ds_partition()
+24 | max_partition()
+   | ^^^^^^^^^^^^^ AIR302
+25 |
+26 | HiveOperator()
+   |
+   = help: Install `apache-airflow-providers-apache-hive>=5.1.0` and use `max_partition` from `airflow.providers.apache.hive.macros.hive` instead.
+
+ℹ Unsafe fix
+8  8  | )
+9  9  | from airflow.macros.hive import (
+10 10 |     closest_ds_partition,
+11    |-    max_partition,
+12 11 | )
+13 12 | from airflow.operators.hive_operator import HiveOperator
+14 13 | from airflow.operators.hive_stats_operator import HiveStatsCollectionOperator
+15 14 | from airflow.operators.hive_to_mysql import HiveToMySqlOperator
+16 15 | from airflow.operators.hive_to_samba_operator import HiveToSambaOperator
+   16 |+from airflow.providers.apache.hive.macros.hive import max_partition
+17 17 | 
+18 18 | HIVE_QUEUE_PRIORITIES
+19 19 | HiveCliHook()
+
+AIR302_hive.py:26:1: AIR302 [*] `airflow.operators.hive_operator.HiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
+   |
+24 | max_partition()
+25 |
+26 | HiveOperator()
    | ^^^^^^^^^^^^ AIR302
-45 |
-46 | HiveStatsCollectionOperator()
+27 | HiveStatsCollectionOperator()
+28 | HiveToMySqlOperator()
    |
    = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `HiveOperator` from `airflow.providers.apache.hive.operators.hive` instead.
 
@@ -180,24 +179,20 @@ AIR302_hive.py:44:1: AIR302 [*] `airflow.operators.hive_operator.HiveOperator` i
 12 12 | )
 13    |-from airflow.operators.hive_operator import HiveOperator
 14 13 | from airflow.operators.hive_stats_operator import HiveStatsCollectionOperator
-15 14 | from airflow.operators.hive_to_mysql import (
-16 15 |     HiveToMySqlOperator,
-17 16 | 
-18 17 | )
-19 18 | from airflow.operators.hive_to_samba_operator import HiveToSambaOperator
-   19 |+from airflow.providers.apache.hive.operators.hive import HiveOperator
-20 20 | 
-21 21 |     
-22 22 | 
+15 14 | from airflow.operators.hive_to_mysql import HiveToMySqlOperator
+16 15 | from airflow.operators.hive_to_samba_operator import HiveToSambaOperator
+   16 |+from airflow.providers.apache.hive.operators.hive import HiveOperator
+17 17 | 
+18 18 | HIVE_QUEUE_PRIORITIES
+19 19 | HiveCliHook()
 
-AIR302_hive.py:46:1: AIR302 [*] `airflow.operators.hive_stats_operator.HiveStatsCollectionOperator` is moved into `apache-hive` provider in Airflow 3.0;
+AIR302_hive.py:27:1: AIR302 [*] `airflow.operators.hive_stats_operator.HiveStatsCollectionOperator` is moved into `apache-hive` provider in Airflow 3.0;
    |
-44 | HiveOperator()
-45 |
-46 | HiveStatsCollectionOperator()
+26 | HiveOperator()
+27 | HiveStatsCollectionOperator()
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-47 |
-48 | HiveToMySqlOperator()
+28 | HiveToMySqlOperator()
+29 | HiveToSambaOperator()
    |
    = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `HiveStatsCollectionOperator` from `airflow.providers.apache.hive.operators.hive_stats` instead.
 
@@ -206,22 +201,20 @@ AIR302_hive.py:46:1: AIR302 [*] `airflow.operators.hive_stats_operator.HiveStats
 12 12 | )
 13 13 | from airflow.operators.hive_operator import HiveOperator
 14    |-from airflow.operators.hive_stats_operator import HiveStatsCollectionOperator
-15 14 | from airflow.operators.hive_to_mysql import (
-16 15 |     HiveToMySqlOperator,
-17 16 | 
-18 17 | )
-19 18 | from airflow.operators.hive_to_samba_operator import HiveToSambaOperator
-   19 |+from airflow.providers.apache.hive.operators.hive_stats import HiveStatsCollectionOperator
-20 20 | 
-21 21 |     
-22 22 | 
+15 14 | from airflow.operators.hive_to_mysql import HiveToMySqlOperator
+16 15 | from airflow.operators.hive_to_samba_operator import HiveToSambaOperator
+   16 |+from airflow.providers.apache.hive.operators.hive_stats import HiveStatsCollectionOperator
+17 17 | 
+18 18 | HIVE_QUEUE_PRIORITIES
+19 19 | HiveCliHook()
 
-AIR302_hive.py:48:1: AIR302 [*] `airflow.operators.hive_to_mysql.HiveToMySqlOperator` is moved into `apache-hive` provider in Airflow 3.0;
+AIR302_hive.py:28:1: AIR302 [*] `airflow.operators.hive_to_mysql.HiveToMySqlOperator` is moved into `apache-hive` provider in Airflow 3.0;
    |
-46 | HiveStatsCollectionOperator()
-47 |
-48 | HiveToMySqlOperator()
+26 | HiveOperator()
+27 | HiveStatsCollectionOperator()
+28 | HiveToMySqlOperator()
    | ^^^^^^^^^^^^^^^^^^^ AIR302
+29 | HiveToSambaOperator()
    |
    = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `HiveToMySqlOperator` from `airflow.providers.apache.hive.transfers.hive_to_mysql` instead.
 
@@ -229,230 +222,231 @@ AIR302_hive.py:48:1: AIR302 [*] `airflow.operators.hive_to_mysql.HiveToMySqlOper
 12 12 | )
 13 13 | from airflow.operators.hive_operator import HiveOperator
 14 14 | from airflow.operators.hive_stats_operator import HiveStatsCollectionOperator
-15    |-from airflow.operators.hive_to_mysql import (
-16    |-    HiveToMySqlOperator,
-17    |-
-18    |-)
-19 15 | from airflow.operators.hive_to_samba_operator import HiveToSambaOperator
+15    |-from airflow.operators.hive_to_mysql import HiveToMySqlOperator
+16 15 | from airflow.operators.hive_to_samba_operator import HiveToSambaOperator
    16 |+from airflow.providers.apache.hive.transfers.hive_to_mysql import HiveToMySqlOperator
-20 17 | 
-21 18 |     
-22 19 | 
+17 17 | 
+18 18 | HIVE_QUEUE_PRIORITIES
+19 19 | HiveCliHook()
 
-AIR302_hive.py:51:1: AIR302 [*] `airflow.operators.hive_to_samba_operator.HiveToSambaOperator` is moved into `apache-hive` provider in Airflow 3.0;
+AIR302_hive.py:29:1: AIR302 [*] `airflow.operators.hive_to_samba_operator.HiveToSambaOperator` is moved into `apache-hive` provider in Airflow 3.0;
    |
-51 | HiveToSambaOperator()
+27 | HiveStatsCollectionOperator()
+28 | HiveToMySqlOperator()
+29 | HiveToSambaOperator()
    | ^^^^^^^^^^^^^^^^^^^ AIR302
    |
    = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `HiveToSambaOperator` from `airflow.providers.apache.hive.transfers.hive_to_samba` instead.
 
 ℹ Unsafe fix
-16 16 |     HiveToMySqlOperator,
+13 13 | from airflow.operators.hive_operator import HiveOperator
+14 14 | from airflow.operators.hive_stats_operator import HiveStatsCollectionOperator
+15 15 | from airflow.operators.hive_to_mysql import HiveToMySqlOperator
+16    |-from airflow.operators.hive_to_samba_operator import HiveToSambaOperator
+   16 |+from airflow.providers.apache.hive.transfers.hive_to_samba import HiveToSambaOperator
 17 17 | 
-18 18 | )
-19    |-from airflow.operators.hive_to_samba_operator import HiveToSambaOperator
-   19 |+from airflow.providers.apache.hive.transfers.hive_to_samba import HiveToSambaOperator
-20 20 | 
-21 21 |     
-22 22 | 
+18 18 | HIVE_QUEUE_PRIORITIES
+19 19 | HiveCliHook()
 
-AIR302_hive.py:72:1: AIR302 [*] `airflow.operators.hive_to_mysql.HiveToMySqlTransfer` is moved into `apache-hive` provider in Airflow 3.0;
+AIR302_hive.py:34:1: AIR302 [*] `airflow.operators.hive_to_mysql.HiveToMySqlTransfer` is moved into `apache-hive` provider in Airflow 3.0;
    |
-70 | from airflow.operators.hive_to_mysql import HiveToMySqlTransfer
-71 |
-72 | HiveToMySqlTransfer()
+32 | from airflow.operators.hive_to_mysql import HiveToMySqlTransfer
+33 |
+34 | HiveToMySqlTransfer()
    | ^^^^^^^^^^^^^^^^^^^ AIR302
-73 |
-74 | from airflow.operators.mysql_to_hive import MySqlToHiveOperator
+35 |
+36 | from airflow.operators.mysql_to_hive import MySqlToHiveOperator
    |
    = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `HiveToMySqlOperator` from `airflow.providers.apache.hive.transfers.hive_to_mysql` instead.
 
 ℹ Unsafe fix
-68 68 | 
+30 30 | 
+31 31 | 
+32 32 | from airflow.operators.hive_to_mysql import HiveToMySqlTransfer
+   33 |+from airflow.providers.apache.hive.transfers.hive_to_mysql import HiveToMySqlOperator
+33 34 | 
+34 35 | HiveToMySqlTransfer()
+35 36 | 
+
+AIR302_hive.py:38:1: AIR302 [*] `airflow.operators.mysql_to_hive.MySqlToHiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
+   |
+36 | from airflow.operators.mysql_to_hive import MySqlToHiveOperator
+37 |
+38 | MySqlToHiveOperator()
+   | ^^^^^^^^^^^^^^^^^^^ AIR302
+39 |
+40 | from airflow.operators.mysql_to_hive import MySqlToHiveTransfer
+   |
+   = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `MySqlToHiveOperator` from `airflow.providers.apache.hive.transfers.mysql_to_hive` instead.
+
+ℹ Unsafe fix
+33 33 | 
+34 34 | HiveToMySqlTransfer()
+35 35 | 
+36    |-from airflow.operators.mysql_to_hive import MySqlToHiveOperator
+   36 |+from airflow.providers.apache.hive.transfers.mysql_to_hive import MySqlToHiveOperator
+37 37 | 
+38 38 | MySqlToHiveOperator()
+39 39 | 
+
+AIR302_hive.py:42:1: AIR302 [*] `airflow.operators.mysql_to_hive.MySqlToHiveTransfer` is moved into `apache-hive` provider in Airflow 3.0;
+   |
+40 | from airflow.operators.mysql_to_hive import MySqlToHiveTransfer
+41 |
+42 | MySqlToHiveTransfer()
+   | ^^^^^^^^^^^^^^^^^^^ AIR302
+43 |
+44 | from airflow.operators.mssql_to_hive import MsSqlToHiveOperator
+   |
+   = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `MySqlToHiveOperator` from `airflow.providers.apache.hive.transfers.mysql_to_hive` instead.
+
+ℹ Unsafe fix
+38 38 | MySqlToHiveOperator()
+39 39 | 
+40 40 | from airflow.operators.mysql_to_hive import MySqlToHiveTransfer
+   41 |+from airflow.providers.apache.hive.transfers.mysql_to_hive import MySqlToHiveOperator
+41 42 | 
+42 43 | MySqlToHiveTransfer()
+43 44 | 
+
+AIR302_hive.py:46:1: AIR302 [*] `airflow.operators.mssql_to_hive.MsSqlToHiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
+   |
+44 | from airflow.operators.mssql_to_hive import MsSqlToHiveOperator
+45 |
+46 | MsSqlToHiveOperator()
+   | ^^^^^^^^^^^^^^^^^^^ AIR302
+47 |
+48 | from airflow.operators.mssql_to_hive import MsSqlToHiveTransfer
+   |
+   = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `MsSqlToHiveOperator` from `airflow.providers.apache.hive.transfers.mssql_to_hive` instead.
+
+ℹ Unsafe fix
+41 41 | 
+42 42 | MySqlToHiveTransfer()
+43 43 | 
+44    |-from airflow.operators.mssql_to_hive import MsSqlToHiveOperator
+   44 |+from airflow.providers.apache.hive.transfers.mssql_to_hive import MsSqlToHiveOperator
+45 45 | 
+46 46 | MsSqlToHiveOperator()
+47 47 | 
+
+AIR302_hive.py:50:1: AIR302 [*] `airflow.operators.mssql_to_hive.MsSqlToHiveTransfer` is moved into `apache-hive` provider in Airflow 3.0;
+   |
+48 | from airflow.operators.mssql_to_hive import MsSqlToHiveTransfer
+49 |
+50 | MsSqlToHiveTransfer()
+   | ^^^^^^^^^^^^^^^^^^^ AIR302
+51 |
+52 | from airflow.operators.s3_to_hive_operator import S3ToHiveOperator
+   |
+   = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `MsSqlToHiveOperator` from `airflow.providers.apache.hive.transfers.mssql_to_hive` instead.
+
+ℹ Unsafe fix
+46 46 | MsSqlToHiveOperator()
+47 47 | 
+48 48 | from airflow.operators.mssql_to_hive import MsSqlToHiveTransfer
+   49 |+from airflow.providers.apache.hive.transfers.mssql_to_hive import MsSqlToHiveOperator
+49 50 | 
+50 51 | MsSqlToHiveTransfer()
+51 52 | 
+
+AIR302_hive.py:54:1: AIR302 [*] `airflow.operators.s3_to_hive_operator.S3ToHiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
+   |
+52 | from airflow.operators.s3_to_hive_operator import S3ToHiveOperator
+53 |
+54 | S3ToHiveOperator()
+   | ^^^^^^^^^^^^^^^^ AIR302
+55 |
+56 | from airflow.operators.s3_to_hive_operator import S3ToHiveTransfer
+   |
+   = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `S3ToHiveOperator` from `airflow.providers.apache.hive.transfers.s3_to_hive` instead.
+
+ℹ Unsafe fix
+49 49 | 
+50 50 | MsSqlToHiveTransfer()
+51 51 | 
+52    |-from airflow.operators.s3_to_hive_operator import S3ToHiveOperator
+   52 |+from airflow.providers.apache.hive.transfers.s3_to_hive import S3ToHiveOperator
+53 53 | 
+54 54 | S3ToHiveOperator()
+55 55 | 
+
+AIR302_hive.py:58:1: AIR302 [*] `airflow.operators.s3_to_hive_operator.S3ToHiveTransfer` is moved into `apache-hive` provider in Airflow 3.0;
+   |
+56 | from airflow.operators.s3_to_hive_operator import S3ToHiveTransfer
+57 |
+58 | S3ToHiveTransfer()
+   | ^^^^^^^^^^^^^^^^ AIR302
+59 |
+60 | from airflow.sensors.hive_partition_sensor import HivePartitionSensor
+   |
+   = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `S3ToHiveOperator` from `airflow.providers.apache.hive.transfers.s3_to_hive` instead.
+
+ℹ Unsafe fix
+54 54 | S3ToHiveOperator()
+55 55 | 
+56 56 | from airflow.operators.s3_to_hive_operator import S3ToHiveTransfer
+   57 |+from airflow.providers.apache.hive.transfers.s3_to_hive import S3ToHiveOperator
+57 58 | 
+58 59 | S3ToHiveTransfer()
+59 60 | 
+
+AIR302_hive.py:62:1: AIR302 [*] `airflow.sensors.hive_partition_sensor.HivePartitionSensor` is moved into `apache-hive` provider in Airflow 3.0;
+   |
+60 | from airflow.sensors.hive_partition_sensor import HivePartitionSensor
+61 |
+62 | HivePartitionSensor()
+   | ^^^^^^^^^^^^^^^^^^^ AIR302
+63 |
+64 | from airflow.sensors.metastore_partition_sensor import MetastorePartitionSensor
+   |
+   = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `HivePartitionSensor` from `airflow.providers.apache.hive.sensors.hive_partition` instead.
+
+ℹ Unsafe fix
+57 57 | 
+58 58 | S3ToHiveTransfer()
+59 59 | 
+60    |-from airflow.sensors.hive_partition_sensor import HivePartitionSensor
+   60 |+from airflow.providers.apache.hive.sensors.hive_partition import HivePartitionSensor
+61 61 | 
+62 62 | HivePartitionSensor()
+63 63 | 
+
+AIR302_hive.py:66:1: AIR302 [*] `airflow.sensors.metastore_partition_sensor.MetastorePartitionSensor` is moved into `apache-hive` provider in Airflow 3.0;
+   |
+64 | from airflow.sensors.metastore_partition_sensor import MetastorePartitionSensor
+65 |
+66 | MetastorePartitionSensor()
+   | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
+67 |
+68 | from airflow.sensors.named_hive_partition_sensor import NamedHivePartitionSensor
+   |
+   = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `MetastorePartitionSensor` from `airflow.providers.apache.hive.sensors.metastore_partition` instead.
+
+ℹ Unsafe fix
+61 61 | 
+62 62 | HivePartitionSensor()
+63 63 | 
+64    |-from airflow.sensors.metastore_partition_sensor import MetastorePartitionSensor
+   64 |+from airflow.providers.apache.hive.sensors.metastore_partition import MetastorePartitionSensor
+65 65 | 
+66 66 | MetastorePartitionSensor()
+67 67 | 
+
+AIR302_hive.py:70:1: AIR302 [*] `airflow.sensors.named_hive_partition_sensor.NamedHivePartitionSensor` is moved into `apache-hive` provider in Airflow 3.0;
+   |
+68 | from airflow.sensors.named_hive_partition_sensor import NamedHivePartitionSensor
+69 |
+70 | NamedHivePartitionSensor()
+   | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
+   |
+   = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `NamedHivePartitionSensor` from `airflow.providers.apache.hive.sensors.named_hive_partition` instead.
+
+ℹ Unsafe fix
+65 65 | 
+66 66 | MetastorePartitionSensor()
+67 67 | 
+68    |-from airflow.sensors.named_hive_partition_sensor import NamedHivePartitionSensor
+   68 |+from airflow.providers.apache.hive.sensors.named_hive_partition import NamedHivePartitionSensor
 69 69 | 
-70 70 | from airflow.operators.hive_to_mysql import HiveToMySqlTransfer
-   71 |+from airflow.providers.apache.hive.transfers.hive_to_mysql import HiveToMySqlOperator
-71 72 | 
-72 73 | HiveToMySqlTransfer()
-73 74 | 
-
-AIR302_hive.py:76:1: AIR302 [*] `airflow.operators.mysql_to_hive.MySqlToHiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
-   |
-74 | from airflow.operators.mysql_to_hive import MySqlToHiveOperator
-75 |
-76 | MySqlToHiveOperator()
-   | ^^^^^^^^^^^^^^^^^^^ AIR302
-77 |
-78 | from airflow.operators.mysql_to_hive import MySqlToHiveTransfer
-   |
-   = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `MySqlToHiveOperator` from `airflow.providers.apache.hive.transfers.mysql_to_hive` instead.
-
-ℹ Unsafe fix
-71 71 | 
-72 72 | HiveToMySqlTransfer()
-73 73 | 
-74    |-from airflow.operators.mysql_to_hive import MySqlToHiveOperator
-   74 |+from airflow.providers.apache.hive.transfers.mysql_to_hive import MySqlToHiveOperator
-75 75 | 
-76 76 | MySqlToHiveOperator()
-77 77 | 
-
-AIR302_hive.py:80:1: AIR302 [*] `airflow.operators.mysql_to_hive.MySqlToHiveTransfer` is moved into `apache-hive` provider in Airflow 3.0;
-   |
-78 | from airflow.operators.mysql_to_hive import MySqlToHiveTransfer
-79 |
-80 | MySqlToHiveTransfer()
-   | ^^^^^^^^^^^^^^^^^^^ AIR302
-81 |
-82 | from airflow.operators.mssql_to_hive import MsSqlToHiveOperator
-   |
-   = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `MySqlToHiveOperator` from `airflow.providers.apache.hive.transfers.mysql_to_hive` instead.
-
-ℹ Unsafe fix
-76 76 | MySqlToHiveOperator()
-77 77 | 
-78 78 | from airflow.operators.mysql_to_hive import MySqlToHiveTransfer
-   79 |+from airflow.providers.apache.hive.transfers.mysql_to_hive import MySqlToHiveOperator
-79 80 | 
-80 81 | MySqlToHiveTransfer()
-81 82 | 
-
-AIR302_hive.py:84:1: AIR302 [*] `airflow.operators.mssql_to_hive.MsSqlToHiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
-   |
-82 | from airflow.operators.mssql_to_hive import MsSqlToHiveOperator
-83 |
-84 | MsSqlToHiveOperator()
-   | ^^^^^^^^^^^^^^^^^^^ AIR302
-85 |
-86 | from airflow.operators.mssql_to_hive import MsSqlToHiveTransfer
-   |
-   = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `MsSqlToHiveOperator` from `airflow.providers.apache.hive.transfers.mssql_to_hive` instead.
-
-ℹ Unsafe fix
-79 79 | 
-80 80 | MySqlToHiveTransfer()
-81 81 | 
-82    |-from airflow.operators.mssql_to_hive import MsSqlToHiveOperator
-   82 |+from airflow.providers.apache.hive.transfers.mssql_to_hive import MsSqlToHiveOperator
-83 83 | 
-84 84 | MsSqlToHiveOperator()
-85 85 | 
-
-AIR302_hive.py:88:1: AIR302 [*] `airflow.operators.mssql_to_hive.MsSqlToHiveTransfer` is moved into `apache-hive` provider in Airflow 3.0;
-   |
-86 | from airflow.operators.mssql_to_hive import MsSqlToHiveTransfer
-87 |
-88 | MsSqlToHiveTransfer()
-   | ^^^^^^^^^^^^^^^^^^^ AIR302
-89 |
-90 | from airflow.operators.s3_to_hive_operator import S3ToHiveOperator
-   |
-   = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `MsSqlToHiveOperator` from `airflow.providers.apache.hive.transfers.mssql_to_hive` instead.
-
-ℹ Unsafe fix
-84 84 | MsSqlToHiveOperator()
-85 85 | 
-86 86 | from airflow.operators.mssql_to_hive import MsSqlToHiveTransfer
-   87 |+from airflow.providers.apache.hive.transfers.mssql_to_hive import MsSqlToHiveOperator
-87 88 | 
-88 89 | MsSqlToHiveTransfer()
-89 90 | 
-
-AIR302_hive.py:92:1: AIR302 [*] `airflow.operators.s3_to_hive_operator.S3ToHiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
-   |
-90 | from airflow.operators.s3_to_hive_operator import S3ToHiveOperator
-91 |
-92 | S3ToHiveOperator()
-   | ^^^^^^^^^^^^^^^^ AIR302
-93 |
-94 | from airflow.operators.s3_to_hive_operator import S3ToHiveTransfer
-   |
-   = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `S3ToHiveOperator` from `airflow.providers.apache.hive.transfers.s3_to_hive` instead.
-
-ℹ Unsafe fix
-87 87 | 
-88 88 | MsSqlToHiveTransfer()
-89 89 | 
-90    |-from airflow.operators.s3_to_hive_operator import S3ToHiveOperator
-   90 |+from airflow.providers.apache.hive.transfers.s3_to_hive import S3ToHiveOperator
-91 91 | 
-92 92 | S3ToHiveOperator()
-93 93 | 
-
-AIR302_hive.py:96:1: AIR302 [*] `airflow.operators.s3_to_hive_operator.S3ToHiveTransfer` is moved into `apache-hive` provider in Airflow 3.0;
-   |
-94 | from airflow.operators.s3_to_hive_operator import S3ToHiveTransfer
-95 |
-96 | S3ToHiveTransfer()
-   | ^^^^^^^^^^^^^^^^ AIR302
-97 |
-98 | from airflow.sensors.hive_partition_sensor import HivePartitionSensor
-   |
-   = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `S3ToHiveOperator` from `airflow.providers.apache.hive.transfers.s3_to_hive` instead.
-
-ℹ Unsafe fix
-92 92 | S3ToHiveOperator()
-93 93 | 
-94 94 | from airflow.operators.s3_to_hive_operator import S3ToHiveTransfer
-   95 |+from airflow.providers.apache.hive.transfers.s3_to_hive import S3ToHiveOperator
-95 96 | 
-96 97 | S3ToHiveTransfer()
-97 98 | 
-
-AIR302_hive.py:100:1: AIR302 [*] `airflow.sensors.hive_partition_sensor.HivePartitionSensor` is moved into `apache-hive` provider in Airflow 3.0;
-    |
- 98 | from airflow.sensors.hive_partition_sensor import HivePartitionSensor
- 99 |
-100 | HivePartitionSensor()
-    | ^^^^^^^^^^^^^^^^^^^ AIR302
-101 |
-102 | from airflow.sensors.metastore_partition_sensor import MetastorePartitionSensor
-    |
-    = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `HivePartitionSensor` from `airflow.providers.apache.hive.sensors.hive_partition` instead.
-
-ℹ Unsafe fix
-95 95 | 
-96 96 | S3ToHiveTransfer()
-97 97 | 
-98    |-from airflow.sensors.hive_partition_sensor import HivePartitionSensor
-   98 |+from airflow.providers.apache.hive.sensors.hive_partition import HivePartitionSensor
-99 99 | 
-100 100 | HivePartitionSensor()
-101 101 | 
-
-AIR302_hive.py:104:1: AIR302 [*] `airflow.sensors.metastore_partition_sensor.MetastorePartitionSensor` is moved into `apache-hive` provider in Airflow 3.0;
-    |
-102 | from airflow.sensors.metastore_partition_sensor import MetastorePartitionSensor
-103 |
-104 | MetastorePartitionSensor()
-    | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-105 |
-106 | from airflow.sensors.named_hive_partition_sensor import NamedHivePartitionSensor
-    |
-    = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `MetastorePartitionSensor` from `airflow.providers.apache.hive.sensors.metastore_partition` instead.
-
-ℹ Unsafe fix
-99  99  | 
-100 100 | HivePartitionSensor()
-101 101 | 
-102     |-from airflow.sensors.metastore_partition_sensor import MetastorePartitionSensor
-    102 |+from airflow.providers.apache.hive.sensors.metastore_partition import MetastorePartitionSensor
-103 103 | 
-104 104 | MetastorePartitionSensor()
-105 105 | 
-
-AIR302_hive.py:107:1: AIR302 [*] `airflow.sensors.named_hive_partition_sensor.NamedHivePartitionSensor` is moved into `apache-hive` provider in Airflow 3.0;
-    |
-106 | from airflow.sensors.named_hive_partition_sensor import NamedHivePartitionSensor
-107 | NamedHivePartitionSensor()
-    | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-    |
-    = help: Install `apache-airflow-providers-apache-hive>=1.0.0` and use `NamedHivePartitionSensor` from `airflow.providers.apache.hive.sensors.named_hive_partition` instead.
-
-ℹ Unsafe fix
-103 103 | 
-104 104 | MetastorePartitionSensor()
-105 105 | 
-106     |-from airflow.sensors.named_hive_partition_sensor import NamedHivePartitionSensor
-    106 |+from airflow.providers.apache.hive.sensors.named_hive_partition import NamedHivePartitionSensor
-107 107 | NamedHivePartitionSensor()
+70 70 | NamedHivePartitionSensor()

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_http.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_http.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 ---
-AIR302_http.py:7:1: AIR302 `airflow.hooks.http_hook.HttpHook` is moved into `http` provider in Airflow 3.0;
+AIR302_http.py:7:1: AIR302 [*] `airflow.hooks.http_hook.HttpHook` is moved into `http` provider in Airflow 3.0;
   |
 5 | from airflow.sensors.http_sensor import HttpSensor
 6 |
@@ -11,6 +11,17 @@ AIR302_http.py:7:1: AIR302 `airflow.hooks.http_hook.HttpHook` is moved into `htt
 9 | HttpSensor()
   |
   = help: Install `apache-airflow-providers-http>=1.0.0` and use `HttpHook` from `airflow.providers.http.hooks.http` instead.
+
+ℹ Unsafe fix
+1 1 | from __future__ import annotations
+2 2 | 
+3   |-from airflow.hooks.http_hook import HttpHook
+4 3 | from airflow.operators.http_operator import SimpleHttpOperator
+5 4 | from airflow.sensors.http_sensor import HttpSensor
+  5 |+from airflow.providers.http.hooks.http import HttpHook
+6 6 | 
+7 7 | HttpHook()
+8 8 | SimpleHttpOperator()
 
 AIR302_http.py:8:1: AIR302 [*] `airflow.operators.http_operator.SimpleHttpOperator` is moved into `http` provider in Airflow 3.0;
   |
@@ -32,7 +43,7 @@ AIR302_http.py:8:1: AIR302 [*] `airflow.operators.http_operator.SimpleHttpOperat
    9  |+HttpOperator()
 9  10 | HttpSensor()
 
-AIR302_http.py:9:1: AIR302 `airflow.sensors.http_sensor.HttpSensor` is moved into `http` provider in Airflow 3.0;
+AIR302_http.py:9:1: AIR302 [*] `airflow.sensors.http_sensor.HttpSensor` is moved into `http` provider in Airflow 3.0;
   |
 7 | HttpHook()
 8 | SimpleHttpOperator()
@@ -40,3 +51,13 @@ AIR302_http.py:9:1: AIR302 `airflow.sensors.http_sensor.HttpSensor` is moved int
   | ^^^^^^^^^^ AIR302
   |
   = help: Install `apache-airflow-providers-http>=1.0.0` and use `HttpSensor` from `airflow.providers.http.sensors.http` instead.
+
+ℹ Unsafe fix
+2 2 | 
+3 3 | from airflow.hooks.http_hook import HttpHook
+4 4 | from airflow.operators.http_operator import SimpleHttpOperator
+5   |-from airflow.sensors.http_sensor import HttpSensor
+  5 |+from airflow.providers.http.sensors.http import HttpSensor
+6 6 | 
+7 7 | HttpHook()
+8 8 | SimpleHttpOperator()

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_jdbc.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_jdbc.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 ---
-AIR302_jdbc.py:8:1: AIR302 `airflow.hooks.jdbc_hook.JdbcHook` is moved into `jdbc` provider in Airflow 3.0;
+AIR302_jdbc.py:8:1: AIR302 [*] `airflow.hooks.jdbc_hook.JdbcHook` is moved into `jdbc` provider in Airflow 3.0;
   |
 6 | )
 7 |
@@ -11,10 +11,33 @@ AIR302_jdbc.py:8:1: AIR302 `airflow.hooks.jdbc_hook.JdbcHook` is moved into `jdb
   |
   = help: Install `apache-airflow-providers-jdbc>=1.0.0` and use `JdbcHook` from `airflow.providers.jdbc.hooks.jdbc` instead.
 
-AIR302_jdbc.py:9:1: AIR302 `airflow.hooks.jdbc_hook.jaydebeapi` is moved into `jdbc` provider in Airflow 3.0;
+ℹ Unsafe fix
+1 1 | from __future__ import annotations
+2 2 | 
+3 3 | from airflow.hooks.jdbc_hook import (
+4   |-    JdbcHook,
+5 4 |     jaydebeapi,
+6 5 | )
+  6 |+from airflow.providers.jdbc.hooks.jdbc import JdbcHook
+7 7 | 
+8 8 | JdbcHook()
+9 9 | jaydebeapi()
+
+AIR302_jdbc.py:9:1: AIR302 [*] `airflow.hooks.jdbc_hook.jaydebeapi` is moved into `jdbc` provider in Airflow 3.0;
   |
 8 | JdbcHook()
 9 | jaydebeapi()
   | ^^^^^^^^^^ AIR302
   |
   = help: Install `apache-airflow-providers-jdbc>=1.0.0` and use `jaydebeapi` from `airflow.providers.jdbc.hooks.jdbc` instead.
+
+ℹ Unsafe fix
+2 2 | 
+3 3 | from airflow.hooks.jdbc_hook import (
+4 4 |     JdbcHook,
+5   |-    jaydebeapi,
+6 5 | )
+  6 |+from airflow.providers.jdbc.hooks.jdbc import jaydebeapi
+7 7 | 
+8 8 | JdbcHook()
+9 9 | jaydebeapi()

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_kubernetes.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_kubernetes.py.snap
@@ -1,17 +1,32 @@
 ---
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 ---
-AIR302_kubernetes.py:29:1: AIR302 `airflow.executors.kubernetes_executor_types.ALL_NAMESPACES` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302_kubernetes.py:29:1: AIR302 [*] `airflow.executors.kubernetes_executor_types.ALL_NAMESPACES` is moved into `cncf-kubernetes` provider in Airflow 3.0;
    |
-27 | )
-28 |
 29 | ALL_NAMESPACES
    | ^^^^^^^^^^^^^^ AIR302
 30 | POD_EXECUTOR_DONE_KEY
    |
    = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `ALL_NAMESPACES` from `airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types` instead.
 
-AIR302_kubernetes.py:30:1: AIR302 `airflow.executors.kubernetes_executor_types.POD_EXECUTOR_DONE_KEY` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+ℹ Unsafe fix
+1  1  | from __future__ import annotations
+2  2  | 
+3  3  | from airflow.executors.kubernetes_executor_types import (
+4     |-    ALL_NAMESPACES,
+5  4  |     POD_EXECUTOR_DONE_KEY,
+6  5  | )
+7  6  | from airflow.kubernetes.k8s_model import (
+--------------------------------------------------------------------------------
+21 20 |     
+22 21 | 
+23 22 | )
+   23 |+from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types import ALL_NAMESPACES
+24 24 | 
+25 25 | 
+26 26 | 
+
+AIR302_kubernetes.py:30:1: AIR302 [*] `airflow.executors.kubernetes_executor_types.POD_EXECUTOR_DONE_KEY` is moved into `cncf-kubernetes` provider in Airflow 3.0;
    |
 29 | ALL_NAMESPACES
 30 | POD_EXECUTOR_DONE_KEY
@@ -21,7 +36,24 @@ AIR302_kubernetes.py:30:1: AIR302 `airflow.executors.kubernetes_executor_types.P
    |
    = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `POD_EXECUTOR_DONE_KEY` from `airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types` instead.
 
-AIR302_kubernetes.py:32:1: AIR302 `airflow.kubernetes.k8s_model.K8SModel` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+ℹ Unsafe fix
+2  2  | 
+3  3  | from airflow.executors.kubernetes_executor_types import (
+4  4  |     ALL_NAMESPACES,
+5     |-    POD_EXECUTOR_DONE_KEY,
+6  5  | )
+7  6  | from airflow.kubernetes.k8s_model import (
+8  7  |     K8SModel,
+--------------------------------------------------------------------------------
+21 20 |     
+22 21 | 
+23 22 | )
+   23 |+from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types import POD_EXECUTOR_DONE_KEY
+24 24 | 
+25 25 | 
+26 26 | 
+
+AIR302_kubernetes.py:32:1: AIR302 [*] `airflow.kubernetes.k8s_model.K8SModel` is moved into `cncf-kubernetes` provider in Airflow 3.0;
    |
 30 | POD_EXECUTOR_DONE_KEY
 31 |
@@ -31,7 +63,24 @@ AIR302_kubernetes.py:32:1: AIR302 `airflow.kubernetes.k8s_model.K8SModel` is mov
    |
    = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `K8SModel` from `airflow.providers.cncf.kubernetes.k8s_model` instead.
 
-AIR302_kubernetes.py:33:1: AIR302 `airflow.kubernetes.k8s_model.append_to_pod` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+ℹ Unsafe fix
+5  5  |     POD_EXECUTOR_DONE_KEY,
+6  6  | )
+7  7  | from airflow.kubernetes.k8s_model import (
+8     |-    K8SModel,
+9  8  |     append_to_pod,
+10 9  | )
+11 10 | from airflow.kubernetes.kube_client import (
+--------------------------------------------------------------------------------
+21 20 |     
+22 21 | 
+23 22 | )
+   23 |+from airflow.providers.cncf.kubernetes.k8s_model import K8SModel
+24 24 | 
+25 25 | 
+26 26 | 
+
+AIR302_kubernetes.py:33:1: AIR302 [*] `airflow.kubernetes.k8s_model.append_to_pod` is moved into `cncf-kubernetes` provider in Airflow 3.0;
    |
 32 | K8SModel()
 33 | append_to_pod()
@@ -41,7 +90,24 @@ AIR302_kubernetes.py:33:1: AIR302 `airflow.kubernetes.k8s_model.append_to_pod` i
    |
    = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `append_to_pod` from `airflow.providers.cncf.kubernetes.k8s_model` instead.
 
-AIR302_kubernetes.py:35:1: AIR302 `airflow.kubernetes.kube_client._disable_verify_ssl` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+ℹ Unsafe fix
+6  6  | )
+7  7  | from airflow.kubernetes.k8s_model import (
+8  8  |     K8SModel,
+9     |-    append_to_pod,
+10 9  | )
+11 10 | from airflow.kubernetes.kube_client import (
+12 11 |     _disable_verify_ssl,
+--------------------------------------------------------------------------------
+21 20 |     
+22 21 | 
+23 22 | )
+   23 |+from airflow.providers.cncf.kubernetes.k8s_model import append_to_pod
+24 24 | 
+25 25 | 
+26 26 | 
+
+AIR302_kubernetes.py:35:1: AIR302 [*] `airflow.kubernetes.kube_client._disable_verify_ssl` is moved into `cncf-kubernetes` provider in Airflow 3.0;
    |
 33 | append_to_pod()
 34 |
@@ -52,7 +118,24 @@ AIR302_kubernetes.py:35:1: AIR302 `airflow.kubernetes.kube_client._disable_verif
    |
    = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `_disable_verify_ssl` from `airflow.providers.cncf.kubernetes.kube_client` instead.
 
-AIR302_kubernetes.py:36:1: AIR302 `airflow.kubernetes.kube_client._enable_tcp_keepalive` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+ℹ Unsafe fix
+9  9  |     append_to_pod,
+10 10 | )
+11 11 | from airflow.kubernetes.kube_client import (
+12    |-    _disable_verify_ssl,
+13 12 |     _enable_tcp_keepalive,
+14 13 |     get_kube_client,
+15 14 | )
+--------------------------------------------------------------------------------
+21 20 |     
+22 21 | 
+23 22 | )
+   23 |+from airflow.providers.cncf.kubernetes.kube_client import _disable_verify_ssl
+24 24 | 
+25 25 | 
+26 26 | 
+
+AIR302_kubernetes.py:36:1: AIR302 [*] `airflow.kubernetes.kube_client._enable_tcp_keepalive` is moved into `cncf-kubernetes` provider in Airflow 3.0;
    |
 35 | _disable_verify_ssl()
 36 | _enable_tcp_keepalive()
@@ -61,7 +144,24 @@ AIR302_kubernetes.py:36:1: AIR302 `airflow.kubernetes.kube_client._enable_tcp_ke
    |
    = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `_enable_tcp_keepalive` from `airflow.providers.cncf.kubernetes.kube_client` instead.
 
-AIR302_kubernetes.py:37:1: AIR302 `airflow.kubernetes.kube_client.get_kube_client` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+ℹ Unsafe fix
+10 10 | )
+11 11 | from airflow.kubernetes.kube_client import (
+12 12 |     _disable_verify_ssl,
+13    |-    _enable_tcp_keepalive,
+14 13 |     get_kube_client,
+15 14 | )
+16 15 | from airflow.kubernetes.kubernetes_helper_functions import (
+--------------------------------------------------------------------------------
+21 20 |     
+22 21 | 
+23 22 | )
+   23 |+from airflow.providers.cncf.kubernetes.kube_client import _enable_tcp_keepalive
+24 24 | 
+25 25 | 
+26 26 | 
+
+AIR302_kubernetes.py:37:1: AIR302 [*] `airflow.kubernetes.kube_client.get_kube_client` is moved into `cncf-kubernetes` provider in Airflow 3.0;
    |
 35 | _disable_verify_ssl()
 36 | _enable_tcp_keepalive()
@@ -71,6 +171,23 @@ AIR302_kubernetes.py:37:1: AIR302 `airflow.kubernetes.kube_client.get_kube_clien
 39 | add_pod_suffix()
    |
    = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `get_kube_client` from `airflow.providers.cncf.kubernetes.kube_client` instead.
+
+ℹ Unsafe fix
+11 11 | from airflow.kubernetes.kube_client import (
+12 12 |     _disable_verify_ssl,
+13 13 |     _enable_tcp_keepalive,
+14    |-    get_kube_client,
+15 14 | )
+16 15 | from airflow.kubernetes.kubernetes_helper_functions import (
+17 16 |     add_pod_suffix,
+--------------------------------------------------------------------------------
+21 20 |     
+22 21 | 
+23 22 | )
+   23 |+from airflow.providers.cncf.kubernetes.kube_client import get_kube_client
+24 24 | 
+25 25 | 
+26 26 | 
 
 AIR302_kubernetes.py:39:1: AIR302 [*] `airflow.kubernetes.kubernetes_helper_functions.add_pod_suffix` is moved into `cncf-kubernetes` provider in Airflow 3.0;
    |
@@ -83,13 +200,13 @@ AIR302_kubernetes.py:39:1: AIR302 [*] `airflow.kubernetes.kubernetes_helper_func
    = help: Install `apache-airflow-providers-cncf-kubernetes>=10.0.0` and use `add_unique_suffix` from `airflow.providers.cncf.kubernetes.kubernetes_helper_functions` instead.
 
 ℹ Safe fix
-25 25 |     Port,
-26 26 |     Resources,
-27 27 | )
-   28 |+from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import add_unique_suffix
-28 29 | 
-29 30 | ALL_NAMESPACES
-30 31 | POD_EXECUTOR_DONE_KEY
+21 21 |     
+22 22 | 
+23 23 | )
+   24 |+from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import add_unique_suffix
+24 25 | 
+25 26 | 
+26 27 | 
 --------------------------------------------------------------------------------
 36 37 | _enable_tcp_keepalive()
 37 38 | get_kube_client()
@@ -111,13 +228,13 @@ AIR302_kubernetes.py:40:1: AIR302 [*] `airflow.kubernetes.kubernetes_helper_func
    = help: Install `apache-airflow-providers-cncf-kubernetes>=10.0.0` and use `create_unique_id` from `airflow.providers.cncf.kubernetes.kubernetes_helper_functions` instead.
 
 ℹ Safe fix
-25 25 |     Port,
-26 26 |     Resources,
-27 27 | )
-   28 |+from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import create_unique_id
-28 29 | 
-29 30 | ALL_NAMESPACES
-30 31 | POD_EXECUTOR_DONE_KEY
+21 21 |     
+22 22 | 
+23 23 | )
+   24 |+from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import create_unique_id
+24 25 | 
+25 26 | 
+26 27 | 
 --------------------------------------------------------------------------------
 37 38 | get_kube_client()
 38 39 | 
@@ -126,105 +243,33 @@ AIR302_kubernetes.py:40:1: AIR302 [*] `airflow.kubernetes.kubernetes_helper_func
    41 |+create_unique_id()
 41 42 | 
 42 43 | annotations_for_logging_task_metadata()
-43 44 | annotations_to_key()
+43 44 | 
 
-AIR302_kubernetes.py:42:1: AIR302 `airflow.kubernetes.kubernetes_helper_functions.annotations_for_logging_task_metadata` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302_kubernetes.py:42:1: AIR302 [*] `airflow.kubernetes.kubernetes_helper_functions.annotations_for_logging_task_metadata` is moved into `cncf-kubernetes` provider in Airflow 3.0;
    |
 40 | create_pod_id()
 41 |
 42 | annotations_for_logging_task_metadata()
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-43 | annotations_to_key()
-44 | get_logs_task_metadata()
    |
    = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `annotations_for_logging_task_metadata` from `airflow.providers.cncf.kubernetes.kubernetes_helper_functions` instead.
 
-AIR302_kubernetes.py:43:1: AIR302 `airflow.kubernetes.kubernetes_helper_functions.annotations_to_key` is moved into `cncf-kubernetes` provider in Airflow 3.0;
-   |
-42 | annotations_for_logging_task_metadata()
-43 | annotations_to_key()
-   | ^^^^^^^^^^^^^^^^^^ AIR302
-44 | get_logs_task_metadata()
-45 | rand_str()
-   |
-   = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `annotations_to_key` from `airflow.providers.cncf.kubernetes.kubernetes_helper_functions` instead.
+ℹ Unsafe fix
+15 15 | )
+16 16 | from airflow.kubernetes.kubernetes_helper_functions import (
+17 17 |     add_pod_suffix,
+18    |-    annotations_for_logging_task_metadata,
+19    |-    
+20 18 |     create_pod_id,
+21 19 |     
+22 20 | 
+23 21 | )
+   22 |+from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import annotations_for_logging_task_metadata
+24 23 | 
+25 24 | 
+26 25 | 
 
-AIR302_kubernetes.py:44:1: AIR302 `airflow.kubernetes.kubernetes_helper_functions.get_logs_task_metadata` is moved into `cncf-kubernetes` provider in Airflow 3.0;
-   |
-42 | annotations_for_logging_task_metadata()
-43 | annotations_to_key()
-44 | get_logs_task_metadata()
-   | ^^^^^^^^^^^^^^^^^^^^^^ AIR302
-45 | rand_str()
-   |
-   = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `get_logs_task_metadata` from `airflow.providers.cncf.kubernetes.kubernetes_helper_functions` instead.
-
-AIR302_kubernetes.py:45:1: AIR302 `airflow.kubernetes.kubernetes_helper_functions.rand_str` is moved into `cncf-kubernetes` provider in Airflow 3.0;
-   |
-43 | annotations_to_key()
-44 | get_logs_task_metadata()
-45 | rand_str()
-   | ^^^^^^^^ AIR302
-46 |
-47 | Port()
-   |
-   = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `rand_str` from `airflow.providers.cncf.kubernetes.kubernetes_helper_functions` instead.
-
-AIR302_kubernetes.py:47:1: AIR302 [*] `airflow.kubernetes.pod.Port` is moved into `cncf-kubernetes` provider in Airflow 3.0;
-   |
-45 | rand_str()
-46 |
-47 | Port()
-   | ^^^^ AIR302
-48 | Resources()
-   |
-   = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `V1ContainerPort` from `kubernetes.client.models` instead.
-
-ℹ Safe fix
-25 25 |     Port,
-26 26 |     Resources,
-27 27 | )
-   28 |+from kubernetes.client.models import V1ContainerPort
-28 29 | 
-29 30 | ALL_NAMESPACES
-30 31 | POD_EXECUTOR_DONE_KEY
---------------------------------------------------------------------------------
-44 45 | get_logs_task_metadata()
-45 46 | rand_str()
-46 47 | 
-47    |-Port()
-   48 |+V1ContainerPort()
-48 49 | Resources()
-49 50 | 
-50 51 | 
-
-AIR302_kubernetes.py:48:1: AIR302 [*] `airflow.kubernetes.pod.Resources` is moved into `cncf-kubernetes` provider in Airflow 3.0;
-   |
-47 | Port()
-48 | Resources()
-   | ^^^^^^^^^ AIR302
-   |
-   = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `V1ResourceRequirements` from `kubernetes.client.models` instead.
-
-ℹ Safe fix
-25 25 |     Port,
-26 26 |     Resources,
-27 27 | )
-   28 |+from kubernetes.client.models import V1ResourceRequirements
-28 29 | 
-29 30 | ALL_NAMESPACES
-30 31 | POD_EXECUTOR_DONE_KEY
---------------------------------------------------------------------------------
-45 46 | rand_str()
-46 47 | 
-47 48 | Port()
-48    |-Resources()
-   49 |+V1ResourceRequirements()
-49 50 | 
-50 51 | 
-51 52 | from airflow.kubernetes.pod_generator import (
-
-AIR302_kubernetes.py:64:1: AIR302 `airflow.kubernetes.pod_generator.datetime_to_label_safe_datestring` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302_kubernetes.py:64:1: AIR302 [*] `airflow.kubernetes.pod_generator.datetime_to_label_safe_datestring` is moved into `cncf-kubernetes` provider in Airflow 3.0;
    |
 62 | )
 63 |
@@ -235,7 +280,23 @@ AIR302_kubernetes.py:64:1: AIR302 `airflow.kubernetes.pod_generator.datetime_to_
    |
    = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `datetime_to_label_safe_datestring` from `airflow.providers.cncf.kubernetes.pod_generator` instead.
 
-AIR302_kubernetes.py:65:1: AIR302 `airflow.kubernetes.pod_generator.extend_object_field` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+ℹ Unsafe fix
+53 53 |     PodGenerator,
+54 54 | 
+55 55 |     add_pod_suffix,
+56    |-    datetime_to_label_safe_datestring,
+57 56 |     extend_object_field,
+58 57 |     label_safe_datestring_to_datetime,
+59 58 |     make_safe_label_value,
+60 59 |     merge_objects,
+61 60 |     rand_str,
+62 61 | )
+   62 |+from airflow.providers.cncf.kubernetes.pod_generator import datetime_to_label_safe_datestring
+63 63 | 
+64 64 | datetime_to_label_safe_datestring()
+65 65 | extend_object_field()
+
+AIR302_kubernetes.py:65:1: AIR302 [*] `airflow.kubernetes.pod_generator.extend_object_field` is moved into `cncf-kubernetes` provider in Airflow 3.0;
    |
 64 | datetime_to_label_safe_datestring()
 65 | extend_object_field()
@@ -245,7 +306,22 @@ AIR302_kubernetes.py:65:1: AIR302 `airflow.kubernetes.pod_generator.extend_objec
    |
    = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `extend_object_field` from `airflow.providers.cncf.kubernetes.pod_generator` instead.
 
-AIR302_kubernetes.py:66:1: AIR302 `airflow.kubernetes.pod_generator.label_safe_datestring_to_datetime` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+ℹ Unsafe fix
+54 54 | 
+55 55 |     add_pod_suffix,
+56 56 |     datetime_to_label_safe_datestring,
+57    |-    extend_object_field,
+58 57 |     label_safe_datestring_to_datetime,
+59 58 |     make_safe_label_value,
+60 59 |     merge_objects,
+61 60 |     rand_str,
+62 61 | )
+   62 |+from airflow.providers.cncf.kubernetes.pod_generator import extend_object_field
+63 63 | 
+64 64 | datetime_to_label_safe_datestring()
+65 65 | extend_object_field()
+
+AIR302_kubernetes.py:66:1: AIR302 [*] `airflow.kubernetes.pod_generator.label_safe_datestring_to_datetime` is moved into `cncf-kubernetes` provider in Airflow 3.0;
    |
 64 | datetime_to_label_safe_datestring()
 65 | extend_object_field()
@@ -256,7 +332,21 @@ AIR302_kubernetes.py:66:1: AIR302 `airflow.kubernetes.pod_generator.label_safe_d
    |
    = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `label_safe_datestring_to_datetime` from `airflow.providers.cncf.kubernetes.pod_generator` instead.
 
-AIR302_kubernetes.py:67:1: AIR302 `airflow.kubernetes.pod_generator.make_safe_label_value` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+ℹ Unsafe fix
+55 55 |     add_pod_suffix,
+56 56 |     datetime_to_label_safe_datestring,
+57 57 |     extend_object_field,
+58    |-    label_safe_datestring_to_datetime,
+59 58 |     make_safe_label_value,
+60 59 |     merge_objects,
+61 60 |     rand_str,
+62 61 | )
+   62 |+from airflow.providers.cncf.kubernetes.pod_generator import label_safe_datestring_to_datetime
+63 63 | 
+64 64 | datetime_to_label_safe_datestring()
+65 65 | extend_object_field()
+
+AIR302_kubernetes.py:67:1: AIR302 [*] `airflow.kubernetes.pod_generator.make_safe_label_value` is moved into `cncf-kubernetes` provider in Airflow 3.0;
    |
 65 | extend_object_field()
 66 | label_safe_datestring_to_datetime()
@@ -267,7 +357,20 @@ AIR302_kubernetes.py:67:1: AIR302 `airflow.kubernetes.pod_generator.make_safe_la
    |
    = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `make_safe_label_value` from `airflow.providers.cncf.kubernetes.pod_generator` instead.
 
-AIR302_kubernetes.py:68:1: AIR302 `airflow.kubernetes.pod_generator.merge_objects` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+ℹ Unsafe fix
+56 56 |     datetime_to_label_safe_datestring,
+57 57 |     extend_object_field,
+58 58 |     label_safe_datestring_to_datetime,
+59    |-    make_safe_label_value,
+60 59 |     merge_objects,
+61 60 |     rand_str,
+62 61 | )
+   62 |+from airflow.providers.cncf.kubernetes.pod_generator import make_safe_label_value
+63 63 | 
+64 64 | datetime_to_label_safe_datestring()
+65 65 | extend_object_field()
+
+AIR302_kubernetes.py:68:1: AIR302 [*] `airflow.kubernetes.pod_generator.merge_objects` is moved into `cncf-kubernetes` provider in Airflow 3.0;
    |
 66 | label_safe_datestring_to_datetime()
 67 | make_safe_label_value()
@@ -278,43 +381,78 @@ AIR302_kubernetes.py:68:1: AIR302 `airflow.kubernetes.pod_generator.merge_object
    |
    = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `merge_objects` from `airflow.providers.cncf.kubernetes.pod_generator` instead.
 
-AIR302_kubernetes.py:69:1: AIR302 `airflow.kubernetes.pod_generator.PodGenerator` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+ℹ Unsafe fix
+57 57 |     extend_object_field,
+58 58 |     label_safe_datestring_to_datetime,
+59 59 |     make_safe_label_value,
+60    |-    merge_objects,
+61 60 |     rand_str,
+62 61 | )
+   62 |+from airflow.providers.cncf.kubernetes.pod_generator import merge_objects
+63 63 | 
+64 64 | datetime_to_label_safe_datestring()
+65 65 | extend_object_field()
+
+AIR302_kubernetes.py:69:1: AIR302 [*] `airflow.kubernetes.pod_generator.PodGenerator` is moved into `cncf-kubernetes` provider in Airflow 3.0;
    |
 67 | make_safe_label_value()
 68 | merge_objects()
 69 | PodGenerator()
    | ^^^^^^^^^^^^ AIR302
 70 | PodDefaults()
-71 | PodGeneratorDeprecated()
    |
    = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `PodGenerator` from `airflow.providers.cncf.kubernetes.pod_generator` instead.
 
-AIR302_kubernetes.py:70:1: AIR302 `airflow.kubernetes.pod_generator.PodDefaults` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+ℹ Unsafe fix
+50 50 | 
+51 51 | from airflow.kubernetes.pod_generator import (
+52 52 |     PodDefaults,
+53    |-    PodGenerator,
+54    |-
+55 53 |     add_pod_suffix,
+56 54 |     datetime_to_label_safe_datestring,
+57 55 |     extend_object_field,
+--------------------------------------------------------------------------------
+60 58 |     merge_objects,
+61 59 |     rand_str,
+62 60 | )
+   61 |+from airflow.providers.cncf.kubernetes.pod_generator import PodGenerator
+63 62 | 
+64 63 | datetime_to_label_safe_datestring()
+65 64 | extend_object_field()
+
+AIR302_kubernetes.py:70:1: AIR302 [*] `airflow.kubernetes.pod_generator.PodDefaults` is moved into `cncf-kubernetes` provider in Airflow 3.0;
    |
 68 | merge_objects()
 69 | PodGenerator()
 70 | PodDefaults()
    | ^^^^^^^^^^^ AIR302
-71 | PodGeneratorDeprecated()
+71 |
 72 | add_pod_suffix()
    |
    = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `PodDefaults` from `airflow.providers.cncf.kubernetes.utils.xcom_sidecar` instead.
 
-AIR302_kubernetes.py:71:1: AIR302 `airflow.kubernetes.pod_generator.PodGeneratorDeprecated` is moved into `cncf-kubernetes` provider in Airflow 3.0;
-   |
-69 | PodGenerator()
-70 | PodDefaults()
-71 | PodGeneratorDeprecated()
-   | ^^^^^^^^^^^^^^^^^^^^^^ AIR302
-72 | add_pod_suffix()
-73 | rand_str()
-   |
-   = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `PodGenerator` from `airflow.providers.cncf.kubernetes.pod_generator` instead.
+ℹ Unsafe fix
+49 49 | 
+50 50 | 
+51 51 | from airflow.kubernetes.pod_generator import (
+52    |-    PodDefaults,
+53 52 |     PodGenerator,
+54 53 | 
+55 54 |     add_pod_suffix,
+--------------------------------------------------------------------------------
+60 59 |     merge_objects,
+61 60 |     rand_str,
+62 61 | )
+   62 |+from airflow.providers.cncf.kubernetes.utils.xcom_sidecar import PodDefaults
+63 63 | 
+64 64 | datetime_to_label_safe_datestring()
+65 65 | extend_object_field()
 
 AIR302_kubernetes.py:72:1: AIR302 [*] `airflow.kubernetes.pod_generator.add_pod_suffix` is moved into `cncf-kubernetes` provider in Airflow 3.0;
    |
 70 | PodDefaults()
-71 | PodGeneratorDeprecated()
+71 |
 72 | add_pod_suffix()
    | ^^^^^^^^^^^^^^ AIR302
 73 | rand_str()
@@ -332,23 +470,33 @@ AIR302_kubernetes.py:72:1: AIR302 [*] `airflow.kubernetes.pod_generator.add_pod_
 --------------------------------------------------------------------------------
 69 70 | PodGenerator()
 70 71 | PodDefaults()
-71 72 | PodGeneratorDeprecated()
+71 72 | 
 72    |-add_pod_suffix()
    73 |+add_unique_suffix()
 73 74 | rand_str()
 74 75 | 
 75 76 | 
 
-AIR302_kubernetes.py:73:1: AIR302 `airflow.kubernetes.pod_generator.rand_str` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302_kubernetes.py:73:1: AIR302 [*] `airflow.kubernetes.pod_generator.rand_str` is moved into `cncf-kubernetes` provider in Airflow 3.0;
    |
-71 | PodGeneratorDeprecated()
 72 | add_pod_suffix()
 73 | rand_str()
    | ^^^^^^^^ AIR302
    |
    = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `rand_str` from `airflow.providers.cncf.kubernetes.kubernetes_helper_functions` instead.
 
-AIR302_kubernetes.py:86:1: AIR302 `airflow.kubernetes.pod_generator_deprecated.PodDefaults` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+ℹ Unsafe fix
+58 58 |     label_safe_datestring_to_datetime,
+59 59 |     make_safe_label_value,
+60 60 |     merge_objects,
+61    |-    rand_str,
+62 61 | )
+   62 |+from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import rand_str
+63 63 | 
+64 64 | datetime_to_label_safe_datestring()
+65 65 | extend_object_field()
+
+AIR302_kubernetes.py:86:1: AIR302 [*] `airflow.kubernetes.pod_generator_deprecated.PodDefaults` is moved into `cncf-kubernetes` provider in Airflow 3.0;
    |
 84 | )
 85 |
@@ -359,7 +507,24 @@ AIR302_kubernetes.py:86:1: AIR302 `airflow.kubernetes.pod_generator_deprecated.P
    |
    = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `PodDefaults` from `airflow.providers.cncf.kubernetes.utils.xcom_sidecar` instead.
 
-AIR302_kubernetes.py:87:1: AIR302 `airflow.kubernetes.pod_generator_deprecated.PodGenerator` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+ℹ Unsafe fix
+74 74 | 
+75 75 | 
+76 76 | from airflow.kubernetes.pod_generator_deprecated import (
+77    |-    PodDefaults,
+78 77 |     PodGenerator,
+79 78 |     make_safe_label_value,
+80 79 | )
+--------------------------------------------------------------------------------
+82 81 |     PodLauncher,
+83 82 |     PodStatus,
+84 83 | )
+   84 |+from airflow.providers.cncf.kubernetes.utils.xcom_sidecar import PodDefaults
+85 85 | 
+86 86 | PodDefaults()
+87 87 | PodGenerator()
+
+AIR302_kubernetes.py:87:1: AIR302 [*] `airflow.kubernetes.pod_generator_deprecated.PodGenerator` is moved into `cncf-kubernetes` provider in Airflow 3.0;
    |
 86 | PodDefaults()
 87 | PodGenerator()
@@ -368,69 +533,47 @@ AIR302_kubernetes.py:87:1: AIR302 `airflow.kubernetes.pod_generator_deprecated.P
    |
    = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `PodGenerator` from `airflow.providers.cncf.kubernetes.pod_generator` instead.
 
-AIR302_kubernetes.py:88:1: AIR302 `airflow.kubernetes.pod_generator_deprecated.make_safe_label_value` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+ℹ Unsafe fix
+75 75 | 
+76 76 | from airflow.kubernetes.pod_generator_deprecated import (
+77 77 |     PodDefaults,
+78    |-    PodGenerator,
+79 78 |     make_safe_label_value,
+80 79 | )
+81 80 | from airflow.kubernetes.pod_launcher import (
+82 81 |     PodLauncher,
+83 82 |     PodStatus,
+84 83 | )
+   84 |+from airflow.providers.cncf.kubernetes.pod_generator import PodGenerator
+85 85 | 
+86 86 | PodDefaults()
+87 87 | PodGenerator()
+
+AIR302_kubernetes.py:88:1: AIR302 [*] `airflow.kubernetes.pod_generator_deprecated.make_safe_label_value` is moved into `cncf-kubernetes` provider in Airflow 3.0;
    |
 86 | PodDefaults()
 87 | PodGenerator()
 88 | make_safe_label_value()
    | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-89 |
-90 | PodLauncher()
    |
    = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `make_safe_label_value` from `airflow.providers.cncf.kubernetes.pod_generator` instead.
 
-AIR302_kubernetes.py:90:1: AIR302 [*] `airflow.kubernetes.pod_launcher.PodLauncher` is moved into `cncf-kubernetes` provider in Airflow 3.0;
-   |
-88 | make_safe_label_value()
-89 |
-90 | PodLauncher()
-   | ^^^^^^^^^^^ AIR302
-91 | PodStatus()
-   |
-   = help: Install `apache-airflow-providers-cncf-kubernetes>=3.0.0` and use `PodManager` from `airflow.providers.cncf.kubernetes.utils.pod_manager` instead.
+ℹ Unsafe fix
+76 76 | from airflow.kubernetes.pod_generator_deprecated import (
+77 77 |     PodDefaults,
+78 78 |     PodGenerator,
+79    |-    make_safe_label_value,
+80 79 | )
+81 80 | from airflow.kubernetes.pod_launcher import (
+82 81 |     PodLauncher,
+83 82 |     PodStatus,
+84 83 | )
+   84 |+from airflow.providers.cncf.kubernetes.pod_generator import make_safe_label_value
+85 85 | 
+86 86 | PodDefaults()
+87 87 | PodGenerator()
 
-ℹ Safe fix
-82 82 |     PodLauncher,
-83 83 |     PodStatus,
-84 84 | )
-   85 |+from airflow.providers.cncf.kubernetes.utils.pod_manager import PodManager
-85 86 | 
-86 87 | PodDefaults()
-87 88 | PodGenerator()
-88 89 | make_safe_label_value()
-89 90 | 
-90    |-PodLauncher()
-   91 |+PodManager()
-91 92 | PodStatus()
-92 93 | 
-93 94 | 
-
-AIR302_kubernetes.py:91:1: AIR302 [*] `airflow.kubernetes.pod_launcher.PodStatus` is moved into `cncf-kubernetes` provider in Airflow 3.0;
-   |
-90 | PodLauncher()
-91 | PodStatus()
-   | ^^^^^^^^^ AIR302
-   |
-   = help: Install `apache-airflow-providers-cncf-kubernetes>=3.0.0` and use `PodPhase` from ` airflow.providers.cncf.kubernetes.utils.pod_manager` instead.
-
-ℹ Safe fix
-82 82 |     PodLauncher,
-83 83 |     PodStatus,
-84 84 | )
-   85 |+from  airflow.providers.cncf.kubernetes.utils.pod_manager import PodPhase
-85 86 | 
-86 87 | PodDefaults()
-87 88 | PodGenerator()
-88 89 | make_safe_label_value()
-89 90 | 
-90 91 | PodLauncher()
-91    |-PodStatus()
-   92 |+PodPhase()
-92 93 | 
-93 94 | 
-94 95 | from airflow.kubernetes.pod_launcher_deprecated import (
-
-AIR302_kubernetes.py:108:1: AIR302 `airflow.kubernetes.pod_launcher_deprecated.PodDefaults` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302_kubernetes.py:108:1: AIR302 [*] `airflow.kubernetes.pod_launcher_deprecated.PodDefaults` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
 106 | from airflow.kubernetes.volume_mount import VolumeMount
 107 |
@@ -440,6 +583,23 @@ AIR302_kubernetes.py:108:1: AIR302 `airflow.kubernetes.pod_launcher_deprecated.P
 110 | PodStatus()
     |
     = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `PodDefaults` from `airflow.providers.cncf.kubernetes.utils.xcom_sidecar` instead.
+
+ℹ Unsafe fix
+92  92  | 
+93  93  | 
+94  94  | from airflow.kubernetes.pod_launcher_deprecated import (
+95      |-    PodDefaults,
+96  95  |     PodLauncher,
+97  96  |     PodStatus,
+98  97  |     get_kube_client,
+--------------------------------------------------------------------------------
+104 103 | )
+105 104 | from airflow.kubernetes.volume import Volume
+106 105 | from airflow.kubernetes.volume_mount import VolumeMount
+    106 |+from airflow.providers.cncf.kubernetes.utils.xcom_sidecar import PodDefaults
+107 107 | 
+108 108 | PodDefaults()
+109 109 | PodLauncher()
 
 AIR302_kubernetes.py:109:1: AIR302 [*] `airflow.kubernetes.pod_launcher_deprecated.PodLauncher` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
@@ -488,7 +648,7 @@ AIR302_kubernetes.py:110:1: AIR302 [*] `airflow.kubernetes.pod_launcher_deprecat
 112 113 | 
 113 114 | PodRuntimeInfoEnv()
 
-AIR302_kubernetes.py:111:1: AIR302 `airflow.kubernetes.pod_launcher_deprecated.get_kube_client` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302_kubernetes.py:111:1: AIR302 [*] `airflow.kubernetes.pod_launcher_deprecated.get_kube_client` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
 109 | PodLauncher()
 110 | PodStatus()
@@ -498,6 +658,23 @@ AIR302_kubernetes.py:111:1: AIR302 `airflow.kubernetes.pod_launcher_deprecated.g
 113 | PodRuntimeInfoEnv()
     |
     = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `get_kube_client` from `airflow.providers.cncf.kubernetes.kube_client` instead.
+
+ℹ Unsafe fix
+95  95  |     PodDefaults,
+96  96  |     PodLauncher,
+97  97  |     PodStatus,
+98      |-    get_kube_client,
+99  98  | )
+100 99  | from airflow.kubernetes.pod_runtime_info_env import PodRuntimeInfoEnv
+101 100 | from airflow.kubernetes.secret import (
+--------------------------------------------------------------------------------
+104 103 | )
+105 104 | from airflow.kubernetes.volume import Volume
+106 105 | from airflow.kubernetes.volume_mount import VolumeMount
+    106 |+from airflow.providers.cncf.kubernetes.kube_client import get_kube_client
+107 107 | 
+108 108 | PodDefaults()
+109 109 | PodLauncher()
 
 AIR302_kubernetes.py:113:1: AIR302 [*] `airflow.kubernetes.pod_runtime_info_env.PodRuntimeInfoEnv` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
@@ -527,7 +704,7 @@ AIR302_kubernetes.py:113:1: AIR302 [*] `airflow.kubernetes.pod_runtime_info_env.
 115 116 | Secret()
 116 117 | Volume()
 
-AIR302_kubernetes.py:114:1: AIR302 `airflow.kubernetes.secret.K8SModel` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302_kubernetes.py:114:1: AIR302 [*] `airflow.kubernetes.secret.K8SModel` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
 113 | PodRuntimeInfoEnv()
 114 | K8SModel()
@@ -537,7 +714,21 @@ AIR302_kubernetes.py:114:1: AIR302 `airflow.kubernetes.secret.K8SModel` is moved
     |
     = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `K8SModel` from `airflow.providers.cncf.kubernetes.k8s_model` instead.
 
-AIR302_kubernetes.py:115:1: AIR302 `airflow.kubernetes.secret.Secret` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+ℹ Unsafe fix
+99  99  | )
+100 100 | from airflow.kubernetes.pod_runtime_info_env import PodRuntimeInfoEnv
+101 101 | from airflow.kubernetes.secret import (
+102     |-    K8SModel,
+103 102 |     Secret,
+104 103 | )
+105 104 | from airflow.kubernetes.volume import Volume
+106 105 | from airflow.kubernetes.volume_mount import VolumeMount
+    106 |+from airflow.providers.cncf.kubernetes.k8s_model import K8SModel
+107 107 | 
+108 108 | PodDefaults()
+109 109 | PodLauncher()
+
+AIR302_kubernetes.py:115:1: AIR302 [*] `airflow.kubernetes.secret.Secret` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
 113 | PodRuntimeInfoEnv()
 114 | K8SModel()
@@ -547,6 +738,19 @@ AIR302_kubernetes.py:115:1: AIR302 `airflow.kubernetes.secret.Secret` is moved i
 117 | VolumeMount()
     |
     = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `Secret` from `airflow.providers.cncf.kubernetes.secret` instead.
+
+ℹ Unsafe fix
+100 100 | from airflow.kubernetes.pod_runtime_info_env import PodRuntimeInfoEnv
+101 101 | from airflow.kubernetes.secret import (
+102 102 |     K8SModel,
+103     |-    Secret,
+104 103 | )
+105 104 | from airflow.kubernetes.volume import Volume
+106 105 | from airflow.kubernetes.volume_mount import VolumeMount
+    106 |+from airflow.providers.cncf.kubernetes.secret import Secret
+107 107 | 
+108 108 | PodDefaults()
+109 109 | PodLauncher()
 
 AIR302_kubernetes.py:116:1: AIR302 [*] `airflow.kubernetes.volume.Volume` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
@@ -573,6 +777,8 @@ AIR302_kubernetes.py:116:1: AIR302 [*] `airflow.kubernetes.volume.Volume` is mov
 116     |-Volume()
     117 |+V1Volume()
 117 118 | VolumeMount()
+118 119 | 
+119 120 | 
 
 AIR302_kubernetes.py:117:1: AIR302 [*] `airflow.kubernetes.volume_mount.VolumeMount` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
@@ -597,3 +803,136 @@ AIR302_kubernetes.py:117:1: AIR302 [*] `airflow.kubernetes.volume_mount.VolumeMo
 116 117 | Volume()
 117     |-VolumeMount()
     118 |+V1VolumeMount()
+118 119 | 
+119 120 | 
+120 121 | from airflow.kubernetes.pod import (
+
+AIR302_kubernetes.py:125:1: AIR302 [*] `airflow.kubernetes.pod_launcher_deprecated.PodLauncher` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+    |
+123 | )
+124 |
+125 | PodLauncher()
+    | ^^^^^^^^^^^ AIR302
+126 | PodStatus()
+    |
+    = help: Install `apache-airflow-providers-cncf-kubernetes>=3.0.0` and use `PodManager` from `airflow.providers.cncf.kubernetes.utils.pod_manager` instead.
+
+ℹ Safe fix
+121 121 |     Port,
+122 122 |     Resources,
+123 123 | )
+    124 |+from airflow.providers.cncf.kubernetes.utils.pod_manager import PodManager
+124 125 | 
+125     |-PodLauncher()
+    126 |+PodManager()
+126 127 | PodStatus()
+127 128 | 
+128 129 | from airflow.kubernetes.kubernetes_helper_functions import (
+
+AIR302_kubernetes.py:126:1: AIR302 [*] `airflow.kubernetes.pod_launcher_deprecated.PodStatus` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+    |
+125 | PodLauncher()
+126 | PodStatus()
+    | ^^^^^^^^^ AIR302
+127 |
+128 | from airflow.kubernetes.kubernetes_helper_functions import (
+    |
+    = help: Install `apache-airflow-providers-cncf-kubernetes>=3.0.0` and use `PodPhase` from ` airflow.providers.cncf.kubernetes.utils.pod_manager` instead.
+
+ℹ Safe fix
+121 121 |     Port,
+122 122 |     Resources,
+123 123 | )
+    124 |+from  airflow.providers.cncf.kubernetes.utils.pod_manager import PodPhase
+124 125 | 
+125 126 | PodLauncher()
+126     |-PodStatus()
+    127 |+PodPhase()
+127 128 | 
+128 129 | from airflow.kubernetes.kubernetes_helper_functions import (
+129 130 |     annotations_to_key,
+
+AIR302_kubernetes.py:133:1: AIR302 [*] `airflow.kubernetes.kubernetes_helper_functions.annotations_to_key` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+    |
+131 |     rand_str,
+132 | )
+133 | annotations_to_key()
+    | ^^^^^^^^^^^^^^^^^^ AIR302
+134 | get_logs_task_metadata()
+135 | rand_str()
+    |
+    = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `annotations_to_key` from `airflow.providers.cncf.kubernetes.kubernetes_helper_functions` instead.
+
+ℹ Unsafe fix
+126 126 | PodStatus()
+127 127 | 
+128 128 | from airflow.kubernetes.kubernetes_helper_functions import (
+129     |-    annotations_to_key,
+130 129 |     get_logs_task_metadata,
+131 130 |     rand_str,
+132 131 | )
+    132 |+from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import annotations_to_key
+133 133 | annotations_to_key()
+134 134 | get_logs_task_metadata()
+135 135 | rand_str()
+
+AIR302_kubernetes.py:134:1: AIR302 [*] `airflow.kubernetes.kubernetes_helper_functions.get_logs_task_metadata` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+    |
+132 | )
+133 | annotations_to_key()
+134 | get_logs_task_metadata()
+    | ^^^^^^^^^^^^^^^^^^^^^^ AIR302
+135 | rand_str()
+    |
+    = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `get_logs_task_metadata` from `airflow.providers.cncf.kubernetes.kubernetes_helper_functions` instead.
+
+ℹ Unsafe fix
+127 127 | 
+128 128 | from airflow.kubernetes.kubernetes_helper_functions import (
+129 129 |     annotations_to_key,
+130     |-    get_logs_task_metadata,
+131 130 |     rand_str,
+132 131 | )
+    132 |+from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import get_logs_task_metadata
+133 133 | annotations_to_key()
+134 134 | get_logs_task_metadata()
+135 135 | rand_str()
+
+AIR302_kubernetes.py:135:1: AIR302 [*] `airflow.kubernetes.kubernetes_helper_functions.rand_str` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+    |
+133 | annotations_to_key()
+134 | get_logs_task_metadata()
+135 | rand_str()
+    | ^^^^^^^^ AIR302
+136 |
+137 | from airflow.kubernetes.pod_generator import PodGeneratorDeprecated
+    |
+    = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `rand_str` from `airflow.providers.cncf.kubernetes.kubernetes_helper_functions` instead.
+
+ℹ Unsafe fix
+128 128 | from airflow.kubernetes.kubernetes_helper_functions import (
+129 129 |     annotations_to_key,
+130 130 |     get_logs_task_metadata,
+131     |-    rand_str,
+132 131 | )
+    132 |+from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import rand_str
+133 133 | annotations_to_key()
+134 134 | get_logs_task_metadata()
+135 135 | rand_str()
+
+AIR302_kubernetes.py:139:1: AIR302 [*] `airflow.kubernetes.pod_generator.PodGeneratorDeprecated` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+    |
+137 | from airflow.kubernetes.pod_generator import PodGeneratorDeprecated
+138 |
+139 | PodGeneratorDeprecated()
+    | ^^^^^^^^^^^^^^^^^^^^^^ AIR302
+    |
+    = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `PodGenerator` from `airflow.providers.cncf.kubernetes.pod_generator` instead.
+
+ℹ Unsafe fix
+135 135 | rand_str()
+136 136 | 
+137 137 | from airflow.kubernetes.pod_generator import PodGeneratorDeprecated
+    138 |+from airflow.providers.cncf.kubernetes.pod_generator import PodGenerator
+138 139 | 
+139 140 | PodGeneratorDeprecated()

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_kubernetes.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_kubernetes.py.snap
@@ -1,11 +1,13 @@
 ---
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 ---
-AIR302_kubernetes.py:29:1: AIR302 [*] `airflow.executors.kubernetes_executor_types.ALL_NAMESPACES` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302_kubernetes.py:22:1: AIR302 [*] `airflow.executors.kubernetes_executor_types.ALL_NAMESPACES` is moved into `cncf-kubernetes` provider in Airflow 3.0;
    |
-29 | ALL_NAMESPACES
+20 | )
+21 |
+22 | ALL_NAMESPACES
    | ^^^^^^^^^^^^^^ AIR302
-30 | POD_EXECUTOR_DONE_KEY
+23 | POD_EXECUTOR_DONE_KEY
    |
    = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `ALL_NAMESPACES` from `airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types` instead.
 
@@ -18,21 +20,21 @@ AIR302_kubernetes.py:29:1: AIR302 [*] `airflow.executors.kubernetes_executor_typ
 6  5  | )
 7  6  | from airflow.kubernetes.k8s_model import (
 --------------------------------------------------------------------------------
-21 20 |     
-22 21 | 
-23 22 | )
-   23 |+from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types import ALL_NAMESPACES
-24 24 | 
-25 25 | 
-26 26 | 
+18 17 |     annotations_for_logging_task_metadata,
+19 18 |     create_pod_id,
+20 19 | )
+   20 |+from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types import ALL_NAMESPACES
+21 21 | 
+22 22 | ALL_NAMESPACES
+23 23 | POD_EXECUTOR_DONE_KEY
 
-AIR302_kubernetes.py:30:1: AIR302 [*] `airflow.executors.kubernetes_executor_types.POD_EXECUTOR_DONE_KEY` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302_kubernetes.py:23:1: AIR302 [*] `airflow.executors.kubernetes_executor_types.POD_EXECUTOR_DONE_KEY` is moved into `cncf-kubernetes` provider in Airflow 3.0;
    |
-29 | ALL_NAMESPACES
-30 | POD_EXECUTOR_DONE_KEY
+22 | ALL_NAMESPACES
+23 | POD_EXECUTOR_DONE_KEY
    | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-31 |
-32 | K8SModel()
+24 |
+25 | K8SModel()
    |
    = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `POD_EXECUTOR_DONE_KEY` from `airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types` instead.
 
@@ -45,21 +47,21 @@ AIR302_kubernetes.py:30:1: AIR302 [*] `airflow.executors.kubernetes_executor_typ
 7  6  | from airflow.kubernetes.k8s_model import (
 8  7  |     K8SModel,
 --------------------------------------------------------------------------------
-21 20 |     
-22 21 | 
-23 22 | )
-   23 |+from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types import POD_EXECUTOR_DONE_KEY
-24 24 | 
-25 25 | 
-26 26 | 
+18 17 |     annotations_for_logging_task_metadata,
+19 18 |     create_pod_id,
+20 19 | )
+   20 |+from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types import POD_EXECUTOR_DONE_KEY
+21 21 | 
+22 22 | ALL_NAMESPACES
+23 23 | POD_EXECUTOR_DONE_KEY
 
-AIR302_kubernetes.py:32:1: AIR302 [*] `airflow.kubernetes.k8s_model.K8SModel` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302_kubernetes.py:25:1: AIR302 [*] `airflow.kubernetes.k8s_model.K8SModel` is moved into `cncf-kubernetes` provider in Airflow 3.0;
    |
-30 | POD_EXECUTOR_DONE_KEY
-31 |
-32 | K8SModel()
+23 | POD_EXECUTOR_DONE_KEY
+24 |
+25 | K8SModel()
    | ^^^^^^^^ AIR302
-33 | append_to_pod()
+26 | append_to_pod()
    |
    = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `K8SModel` from `airflow.providers.cncf.kubernetes.k8s_model` instead.
 
@@ -72,21 +74,21 @@ AIR302_kubernetes.py:32:1: AIR302 [*] `airflow.kubernetes.k8s_model.K8SModel` is
 10 9  | )
 11 10 | from airflow.kubernetes.kube_client import (
 --------------------------------------------------------------------------------
-21 20 |     
-22 21 | 
-23 22 | )
-   23 |+from airflow.providers.cncf.kubernetes.k8s_model import K8SModel
-24 24 | 
-25 25 | 
-26 26 | 
+18 17 |     annotations_for_logging_task_metadata,
+19 18 |     create_pod_id,
+20 19 | )
+   20 |+from airflow.providers.cncf.kubernetes.k8s_model import K8SModel
+21 21 | 
+22 22 | ALL_NAMESPACES
+23 23 | POD_EXECUTOR_DONE_KEY
 
-AIR302_kubernetes.py:33:1: AIR302 [*] `airflow.kubernetes.k8s_model.append_to_pod` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302_kubernetes.py:26:1: AIR302 [*] `airflow.kubernetes.k8s_model.append_to_pod` is moved into `cncf-kubernetes` provider in Airflow 3.0;
    |
-32 | K8SModel()
-33 | append_to_pod()
+25 | K8SModel()
+26 | append_to_pod()
    | ^^^^^^^^^^^^^ AIR302
-34 |
-35 | _disable_verify_ssl()
+27 |
+28 | _disable_verify_ssl()
    |
    = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `append_to_pod` from `airflow.providers.cncf.kubernetes.k8s_model` instead.
 
@@ -99,22 +101,22 @@ AIR302_kubernetes.py:33:1: AIR302 [*] `airflow.kubernetes.k8s_model.append_to_po
 11 10 | from airflow.kubernetes.kube_client import (
 12 11 |     _disable_verify_ssl,
 --------------------------------------------------------------------------------
-21 20 |     
-22 21 | 
-23 22 | )
-   23 |+from airflow.providers.cncf.kubernetes.k8s_model import append_to_pod
-24 24 | 
-25 25 | 
-26 26 | 
+18 17 |     annotations_for_logging_task_metadata,
+19 18 |     create_pod_id,
+20 19 | )
+   20 |+from airflow.providers.cncf.kubernetes.k8s_model import append_to_pod
+21 21 | 
+22 22 | ALL_NAMESPACES
+23 23 | POD_EXECUTOR_DONE_KEY
 
-AIR302_kubernetes.py:35:1: AIR302 [*] `airflow.kubernetes.kube_client._disable_verify_ssl` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302_kubernetes.py:28:1: AIR302 [*] `airflow.kubernetes.kube_client._disable_verify_ssl` is moved into `cncf-kubernetes` provider in Airflow 3.0;
    |
-33 | append_to_pod()
-34 |
-35 | _disable_verify_ssl()
+26 | append_to_pod()
+27 |
+28 | _disable_verify_ssl()
    | ^^^^^^^^^^^^^^^^^^^ AIR302
-36 | _enable_tcp_keepalive()
-37 | get_kube_client()
+29 | _enable_tcp_keepalive()
+30 | get_kube_client()
    |
    = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `_disable_verify_ssl` from `airflow.providers.cncf.kubernetes.kube_client` instead.
 
@@ -127,20 +129,20 @@ AIR302_kubernetes.py:35:1: AIR302 [*] `airflow.kubernetes.kube_client._disable_v
 14 13 |     get_kube_client,
 15 14 | )
 --------------------------------------------------------------------------------
-21 20 |     
-22 21 | 
-23 22 | )
-   23 |+from airflow.providers.cncf.kubernetes.kube_client import _disable_verify_ssl
-24 24 | 
-25 25 | 
-26 26 | 
+18 17 |     annotations_for_logging_task_metadata,
+19 18 |     create_pod_id,
+20 19 | )
+   20 |+from airflow.providers.cncf.kubernetes.kube_client import _disable_verify_ssl
+21 21 | 
+22 22 | ALL_NAMESPACES
+23 23 | POD_EXECUTOR_DONE_KEY
 
-AIR302_kubernetes.py:36:1: AIR302 [*] `airflow.kubernetes.kube_client._enable_tcp_keepalive` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302_kubernetes.py:29:1: AIR302 [*] `airflow.kubernetes.kube_client._enable_tcp_keepalive` is moved into `cncf-kubernetes` provider in Airflow 3.0;
    |
-35 | _disable_verify_ssl()
-36 | _enable_tcp_keepalive()
+28 | _disable_verify_ssl()
+29 | _enable_tcp_keepalive()
    | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-37 | get_kube_client()
+30 | get_kube_client()
    |
    = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `_enable_tcp_keepalive` from `airflow.providers.cncf.kubernetes.kube_client` instead.
 
@@ -153,22 +155,22 @@ AIR302_kubernetes.py:36:1: AIR302 [*] `airflow.kubernetes.kube_client._enable_tc
 15 14 | )
 16 15 | from airflow.kubernetes.kubernetes_helper_functions import (
 --------------------------------------------------------------------------------
-21 20 |     
-22 21 | 
-23 22 | )
-   23 |+from airflow.providers.cncf.kubernetes.kube_client import _enable_tcp_keepalive
-24 24 | 
-25 25 | 
-26 26 | 
+18 17 |     annotations_for_logging_task_metadata,
+19 18 |     create_pod_id,
+20 19 | )
+   20 |+from airflow.providers.cncf.kubernetes.kube_client import _enable_tcp_keepalive
+21 21 | 
+22 22 | ALL_NAMESPACES
+23 23 | POD_EXECUTOR_DONE_KEY
 
-AIR302_kubernetes.py:37:1: AIR302 [*] `airflow.kubernetes.kube_client.get_kube_client` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302_kubernetes.py:30:1: AIR302 [*] `airflow.kubernetes.kube_client.get_kube_client` is moved into `cncf-kubernetes` provider in Airflow 3.0;
    |
-35 | _disable_verify_ssl()
-36 | _enable_tcp_keepalive()
-37 | get_kube_client()
+28 | _disable_verify_ssl()
+29 | _enable_tcp_keepalive()
+30 | get_kube_client()
    | ^^^^^^^^^^^^^^^ AIR302
-38 |
-39 | add_pod_suffix()
+31 |
+32 | add_pod_suffix()
    |
    = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `get_kube_client` from `airflow.providers.cncf.kubernetes.kube_client` instead.
 
@@ -180,77 +182,49 @@ AIR302_kubernetes.py:37:1: AIR302 [*] `airflow.kubernetes.kube_client.get_kube_c
 15 14 | )
 16 15 | from airflow.kubernetes.kubernetes_helper_functions import (
 17 16 |     add_pod_suffix,
---------------------------------------------------------------------------------
-21 20 |     
-22 21 | 
-23 22 | )
-   23 |+from airflow.providers.cncf.kubernetes.kube_client import get_kube_client
-24 24 | 
-25 25 | 
-26 26 | 
+18 17 |     annotations_for_logging_task_metadata,
+19 18 |     create_pod_id,
+20 19 | )
+   20 |+from airflow.providers.cncf.kubernetes.kube_client import get_kube_client
+21 21 | 
+22 22 | ALL_NAMESPACES
+23 23 | POD_EXECUTOR_DONE_KEY
 
-AIR302_kubernetes.py:39:1: AIR302 [*] `airflow.kubernetes.kubernetes_helper_functions.add_pod_suffix` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302_kubernetes.py:32:1: AIR302 [*] `airflow.kubernetes.kubernetes_helper_functions.add_pod_suffix` is moved into `cncf-kubernetes` provider in Airflow 3.0;
    |
-37 | get_kube_client()
-38 |
-39 | add_pod_suffix()
+30 | get_kube_client()
+31 |
+32 | add_pod_suffix()
    | ^^^^^^^^^^^^^^ AIR302
-40 | create_pod_id()
+33 | annotations_for_logging_task_metadata()
+34 | create_pod_id()
    |
    = help: Install `apache-airflow-providers-cncf-kubernetes>=10.0.0` and use `add_unique_suffix` from `airflow.providers.cncf.kubernetes.kubernetes_helper_functions` instead.
 
 ℹ Safe fix
-21 21 |     
-22 22 | 
-23 23 | )
-   24 |+from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import add_unique_suffix
-24 25 | 
-25 26 | 
-26 27 | 
+18 18 |     annotations_for_logging_task_metadata,
+19 19 |     create_pod_id,
+20 20 | )
+   21 |+from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import add_unique_suffix
+21 22 | 
+22 23 | ALL_NAMESPACES
+23 24 | POD_EXECUTOR_DONE_KEY
 --------------------------------------------------------------------------------
-36 37 | _enable_tcp_keepalive()
-37 38 | get_kube_client()
-38 39 | 
-39    |-add_pod_suffix()
-   40 |+add_unique_suffix()
-40 41 | create_pod_id()
-41 42 | 
-42 43 | annotations_for_logging_task_metadata()
+29 30 | _enable_tcp_keepalive()
+30 31 | get_kube_client()
+31 32 | 
+32    |-add_pod_suffix()
+   33 |+add_unique_suffix()
+33 34 | annotations_for_logging_task_metadata()
+34 35 | create_pod_id()
+35 36 | 
 
-AIR302_kubernetes.py:40:1: AIR302 [*] `airflow.kubernetes.kubernetes_helper_functions.create_pod_id` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302_kubernetes.py:33:1: AIR302 [*] `airflow.kubernetes.kubernetes_helper_functions.annotations_for_logging_task_metadata` is moved into `cncf-kubernetes` provider in Airflow 3.0;
    |
-39 | add_pod_suffix()
-40 | create_pod_id()
-   | ^^^^^^^^^^^^^ AIR302
-41 |
-42 | annotations_for_logging_task_metadata()
-   |
-   = help: Install `apache-airflow-providers-cncf-kubernetes>=10.0.0` and use `create_unique_id` from `airflow.providers.cncf.kubernetes.kubernetes_helper_functions` instead.
-
-ℹ Safe fix
-21 21 |     
-22 22 | 
-23 23 | )
-   24 |+from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import create_unique_id
-24 25 | 
-25 26 | 
-26 27 | 
---------------------------------------------------------------------------------
-37 38 | get_kube_client()
-38 39 | 
-39 40 | add_pod_suffix()
-40    |-create_pod_id()
-   41 |+create_unique_id()
-41 42 | 
-42 43 | annotations_for_logging_task_metadata()
-43 44 | 
-
-AIR302_kubernetes.py:42:1: AIR302 [*] `airflow.kubernetes.kubernetes_helper_functions.annotations_for_logging_task_metadata` is moved into `cncf-kubernetes` provider in Airflow 3.0;
-   |
-40 | create_pod_id()
-41 |
-42 | annotations_for_logging_task_metadata()
+32 | add_pod_suffix()
+33 | annotations_for_logging_task_metadata()
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
+34 | create_pod_id()
    |
    = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `annotations_for_logging_task_metadata` from `airflow.providers.cncf.kubernetes.kubernetes_helper_functions` instead.
 
@@ -259,680 +233,714 @@ AIR302_kubernetes.py:42:1: AIR302 [*] `airflow.kubernetes.kubernetes_helper_func
 16 16 | from airflow.kubernetes.kubernetes_helper_functions import (
 17 17 |     add_pod_suffix,
 18    |-    annotations_for_logging_task_metadata,
-19    |-    
-20 18 |     create_pod_id,
-21 19 |     
-22 20 | 
-23 21 | )
-   22 |+from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import annotations_for_logging_task_metadata
-24 23 | 
-25 24 | 
-26 25 | 
+19 18 |     create_pod_id,
+20 19 | )
+   20 |+from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import annotations_for_logging_task_metadata
+21 21 | 
+22 22 | ALL_NAMESPACES
+23 23 | POD_EXECUTOR_DONE_KEY
 
-AIR302_kubernetes.py:64:1: AIR302 [*] `airflow.kubernetes.pod_generator.datetime_to_label_safe_datestring` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302_kubernetes.py:34:1: AIR302 [*] `airflow.kubernetes.kubernetes_helper_functions.create_pod_id` is moved into `cncf-kubernetes` provider in Airflow 3.0;
    |
-62 | )
-63 |
-64 | datetime_to_label_safe_datestring()
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-65 | extend_object_field()
-66 | label_safe_datestring_to_datetime()
-   |
-   = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `datetime_to_label_safe_datestring` from `airflow.providers.cncf.kubernetes.pod_generator` instead.
-
-ℹ Unsafe fix
-53 53 |     PodGenerator,
-54 54 | 
-55 55 |     add_pod_suffix,
-56    |-    datetime_to_label_safe_datestring,
-57 56 |     extend_object_field,
-58 57 |     label_safe_datestring_to_datetime,
-59 58 |     make_safe_label_value,
-60 59 |     merge_objects,
-61 60 |     rand_str,
-62 61 | )
-   62 |+from airflow.providers.cncf.kubernetes.pod_generator import datetime_to_label_safe_datestring
-63 63 | 
-64 64 | datetime_to_label_safe_datestring()
-65 65 | extend_object_field()
-
-AIR302_kubernetes.py:65:1: AIR302 [*] `airflow.kubernetes.pod_generator.extend_object_field` is moved into `cncf-kubernetes` provider in Airflow 3.0;
-   |
-64 | datetime_to_label_safe_datestring()
-65 | extend_object_field()
-   | ^^^^^^^^^^^^^^^^^^^ AIR302
-66 | label_safe_datestring_to_datetime()
-67 | make_safe_label_value()
-   |
-   = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `extend_object_field` from `airflow.providers.cncf.kubernetes.pod_generator` instead.
-
-ℹ Unsafe fix
-54 54 | 
-55 55 |     add_pod_suffix,
-56 56 |     datetime_to_label_safe_datestring,
-57    |-    extend_object_field,
-58 57 |     label_safe_datestring_to_datetime,
-59 58 |     make_safe_label_value,
-60 59 |     merge_objects,
-61 60 |     rand_str,
-62 61 | )
-   62 |+from airflow.providers.cncf.kubernetes.pod_generator import extend_object_field
-63 63 | 
-64 64 | datetime_to_label_safe_datestring()
-65 65 | extend_object_field()
-
-AIR302_kubernetes.py:66:1: AIR302 [*] `airflow.kubernetes.pod_generator.label_safe_datestring_to_datetime` is moved into `cncf-kubernetes` provider in Airflow 3.0;
-   |
-64 | datetime_to_label_safe_datestring()
-65 | extend_object_field()
-66 | label_safe_datestring_to_datetime()
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-67 | make_safe_label_value()
-68 | merge_objects()
-   |
-   = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `label_safe_datestring_to_datetime` from `airflow.providers.cncf.kubernetes.pod_generator` instead.
-
-ℹ Unsafe fix
-55 55 |     add_pod_suffix,
-56 56 |     datetime_to_label_safe_datestring,
-57 57 |     extend_object_field,
-58    |-    label_safe_datestring_to_datetime,
-59 58 |     make_safe_label_value,
-60 59 |     merge_objects,
-61 60 |     rand_str,
-62 61 | )
-   62 |+from airflow.providers.cncf.kubernetes.pod_generator import label_safe_datestring_to_datetime
-63 63 | 
-64 64 | datetime_to_label_safe_datestring()
-65 65 | extend_object_field()
-
-AIR302_kubernetes.py:67:1: AIR302 [*] `airflow.kubernetes.pod_generator.make_safe_label_value` is moved into `cncf-kubernetes` provider in Airflow 3.0;
-   |
-65 | extend_object_field()
-66 | label_safe_datestring_to_datetime()
-67 | make_safe_label_value()
-   | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-68 | merge_objects()
-69 | PodGenerator()
-   |
-   = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `make_safe_label_value` from `airflow.providers.cncf.kubernetes.pod_generator` instead.
-
-ℹ Unsafe fix
-56 56 |     datetime_to_label_safe_datestring,
-57 57 |     extend_object_field,
-58 58 |     label_safe_datestring_to_datetime,
-59    |-    make_safe_label_value,
-60 59 |     merge_objects,
-61 60 |     rand_str,
-62 61 | )
-   62 |+from airflow.providers.cncf.kubernetes.pod_generator import make_safe_label_value
-63 63 | 
-64 64 | datetime_to_label_safe_datestring()
-65 65 | extend_object_field()
-
-AIR302_kubernetes.py:68:1: AIR302 [*] `airflow.kubernetes.pod_generator.merge_objects` is moved into `cncf-kubernetes` provider in Airflow 3.0;
-   |
-66 | label_safe_datestring_to_datetime()
-67 | make_safe_label_value()
-68 | merge_objects()
+32 | add_pod_suffix()
+33 | annotations_for_logging_task_metadata()
+34 | create_pod_id()
    | ^^^^^^^^^^^^^ AIR302
-69 | PodGenerator()
-70 | PodDefaults()
    |
-   = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `merge_objects` from `airflow.providers.cncf.kubernetes.pod_generator` instead.
+   = help: Install `apache-airflow-providers-cncf-kubernetes>=10.0.0` and use `create_unique_id` from `airflow.providers.cncf.kubernetes.kubernetes_helper_functions` instead.
 
-ℹ Unsafe fix
-57 57 |     extend_object_field,
-58 58 |     label_safe_datestring_to_datetime,
-59 59 |     make_safe_label_value,
-60    |-    merge_objects,
-61 60 |     rand_str,
-62 61 | )
-   62 |+from airflow.providers.cncf.kubernetes.pod_generator import merge_objects
-63 63 | 
-64 64 | datetime_to_label_safe_datestring()
-65 65 | extend_object_field()
-
-AIR302_kubernetes.py:69:1: AIR302 [*] `airflow.kubernetes.pod_generator.PodGenerator` is moved into `cncf-kubernetes` provider in Airflow 3.0;
-   |
-67 | make_safe_label_value()
-68 | merge_objects()
-69 | PodGenerator()
-   | ^^^^^^^^^^^^ AIR302
-70 | PodDefaults()
-   |
-   = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `PodGenerator` from `airflow.providers.cncf.kubernetes.pod_generator` instead.
-
-ℹ Unsafe fix
-50 50 | 
-51 51 | from airflow.kubernetes.pod_generator import (
-52 52 |     PodDefaults,
-53    |-    PodGenerator,
-54    |-
-55 53 |     add_pod_suffix,
-56 54 |     datetime_to_label_safe_datestring,
-57 55 |     extend_object_field,
+ℹ Safe fix
+18 18 |     annotations_for_logging_task_metadata,
+19 19 |     create_pod_id,
+20 20 | )
+   21 |+from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import create_unique_id
+21 22 | 
+22 23 | ALL_NAMESPACES
+23 24 | POD_EXECUTOR_DONE_KEY
 --------------------------------------------------------------------------------
-60 58 |     merge_objects,
-61 59 |     rand_str,
-62 60 | )
-   61 |+from airflow.providers.cncf.kubernetes.pod_generator import PodGenerator
-63 62 | 
-64 63 | datetime_to_label_safe_datestring()
-65 64 | extend_object_field()
+31 32 | 
+32 33 | add_pod_suffix()
+33 34 | annotations_for_logging_task_metadata()
+34    |-create_pod_id()
+   35 |+create_unique_id()
+35 36 | 
+36 37 | 
+37 38 | from airflow.kubernetes.pod_generator import (
 
-AIR302_kubernetes.py:70:1: AIR302 [*] `airflow.kubernetes.pod_generator.PodDefaults` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302_kubernetes.py:49:1: AIR302 [*] `airflow.kubernetes.pod_generator.PodDefaults` is moved into `cncf-kubernetes` provider in Airflow 3.0;
    |
-68 | merge_objects()
-69 | PodGenerator()
-70 | PodDefaults()
+47 | )
+48 |
+49 | PodDefaults()
    | ^^^^^^^^^^^ AIR302
-71 |
-72 | add_pod_suffix()
+50 | PodGenerator()
+51 | add_pod_suffix()
    |
    = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `PodDefaults` from `airflow.providers.cncf.kubernetes.utils.xcom_sidecar` instead.
 
 ℹ Unsafe fix
-49 49 | 
-50 50 | 
-51 51 | from airflow.kubernetes.pod_generator import (
-52    |-    PodDefaults,
-53 52 |     PodGenerator,
-54 53 | 
-55 54 |     add_pod_suffix,
+35 35 | 
+36 36 | 
+37 37 | from airflow.kubernetes.pod_generator import (
+38    |-    PodDefaults,
+39 38 |     PodGenerator,
+40 39 |     add_pod_suffix,
+41 40 |     datetime_to_label_safe_datestring,
 --------------------------------------------------------------------------------
-60 59 |     merge_objects,
-61 60 |     rand_str,
-62 61 | )
-   62 |+from airflow.providers.cncf.kubernetes.utils.xcom_sidecar import PodDefaults
-63 63 | 
-64 64 | datetime_to_label_safe_datestring()
-65 65 | extend_object_field()
+45 44 |     merge_objects,
+46 45 |     rand_str,
+47 46 | )
+   47 |+from airflow.providers.cncf.kubernetes.utils.xcom_sidecar import PodDefaults
+48 48 | 
+49 49 | PodDefaults()
+50 50 | PodGenerator()
 
-AIR302_kubernetes.py:72:1: AIR302 [*] `airflow.kubernetes.pod_generator.add_pod_suffix` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302_kubernetes.py:50:1: AIR302 [*] `airflow.kubernetes.pod_generator.PodGenerator` is moved into `cncf-kubernetes` provider in Airflow 3.0;
    |
-70 | PodDefaults()
-71 |
-72 | add_pod_suffix()
+49 | PodDefaults()
+50 | PodGenerator()
+   | ^^^^^^^^^^^^ AIR302
+51 | add_pod_suffix()
+52 | datetime_to_label_safe_datestring()
+   |
+   = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `PodGenerator` from `airflow.providers.cncf.kubernetes.pod_generator` instead.
+
+ℹ Unsafe fix
+36 36 | 
+37 37 | from airflow.kubernetes.pod_generator import (
+38 38 |     PodDefaults,
+39    |-    PodGenerator,
+40 39 |     add_pod_suffix,
+41 40 |     datetime_to_label_safe_datestring,
+42 41 |     extend_object_field,
+--------------------------------------------------------------------------------
+45 44 |     merge_objects,
+46 45 |     rand_str,
+47 46 | )
+   47 |+from airflow.providers.cncf.kubernetes.pod_generator import PodGenerator
+48 48 | 
+49 49 | PodDefaults()
+50 50 | PodGenerator()
+
+AIR302_kubernetes.py:51:1: AIR302 [*] `airflow.kubernetes.pod_generator.add_pod_suffix` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+   |
+49 | PodDefaults()
+50 | PodGenerator()
+51 | add_pod_suffix()
    | ^^^^^^^^^^^^^^ AIR302
-73 | rand_str()
+52 | datetime_to_label_safe_datestring()
+53 | extend_object_field()
    |
    = help: Install `apache-airflow-providers-cncf-kubernetes>=10.0.0` and use `add_unique_suffix` from `airflow.providers.cncf.kubernetes.kubernetes_helper_functions` instead.
 
 ℹ Safe fix
-60 60 |     merge_objects,
-61 61 |     rand_str,
-62 62 | )
-   63 |+from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import add_unique_suffix
-63 64 | 
-64 65 | datetime_to_label_safe_datestring()
-65 66 | extend_object_field()
---------------------------------------------------------------------------------
-69 70 | PodGenerator()
-70 71 | PodDefaults()
-71 72 | 
-72    |-add_pod_suffix()
-   73 |+add_unique_suffix()
-73 74 | rand_str()
-74 75 | 
-75 76 | 
+45 45 |     merge_objects,
+46 46 |     rand_str,
+47 47 | )
+   48 |+from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import add_unique_suffix
+48 49 | 
+49 50 | PodDefaults()
+50 51 | PodGenerator()
+51    |-add_pod_suffix()
+   52 |+add_unique_suffix()
+52 53 | datetime_to_label_safe_datestring()
+53 54 | extend_object_field()
+54 55 | label_safe_datestring_to_datetime()
 
-AIR302_kubernetes.py:73:1: AIR302 [*] `airflow.kubernetes.pod_generator.rand_str` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302_kubernetes.py:52:1: AIR302 [*] `airflow.kubernetes.pod_generator.datetime_to_label_safe_datestring` is moved into `cncf-kubernetes` provider in Airflow 3.0;
    |
-72 | add_pod_suffix()
-73 | rand_str()
-   | ^^^^^^^^ AIR302
+50 | PodGenerator()
+51 | add_pod_suffix()
+52 | datetime_to_label_safe_datestring()
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
+53 | extend_object_field()
+54 | label_safe_datestring_to_datetime()
    |
-   = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `rand_str` from `airflow.providers.cncf.kubernetes.kubernetes_helper_functions` instead.
-
-ℹ Unsafe fix
-58 58 |     label_safe_datestring_to_datetime,
-59 59 |     make_safe_label_value,
-60 60 |     merge_objects,
-61    |-    rand_str,
-62 61 | )
-   62 |+from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import rand_str
-63 63 | 
-64 64 | datetime_to_label_safe_datestring()
-65 65 | extend_object_field()
-
-AIR302_kubernetes.py:86:1: AIR302 [*] `airflow.kubernetes.pod_generator_deprecated.PodDefaults` is moved into `cncf-kubernetes` provider in Airflow 3.0;
-   |
-84 | )
-85 |
-86 | PodDefaults()
-   | ^^^^^^^^^^^ AIR302
-87 | PodGenerator()
-88 | make_safe_label_value()
-   |
-   = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `PodDefaults` from `airflow.providers.cncf.kubernetes.utils.xcom_sidecar` instead.
+   = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `datetime_to_label_safe_datestring` from `airflow.providers.cncf.kubernetes.pod_generator` instead.
 
 ℹ Unsafe fix
-74 74 | 
-75 75 | 
-76 76 | from airflow.kubernetes.pod_generator_deprecated import (
-77    |-    PodDefaults,
-78 77 |     PodGenerator,
-79 78 |     make_safe_label_value,
-80 79 | )
---------------------------------------------------------------------------------
-82 81 |     PodLauncher,
-83 82 |     PodStatus,
-84 83 | )
-   84 |+from airflow.providers.cncf.kubernetes.utils.xcom_sidecar import PodDefaults
-85 85 | 
-86 86 | PodDefaults()
-87 87 | PodGenerator()
+38 38 |     PodDefaults,
+39 39 |     PodGenerator,
+40 40 |     add_pod_suffix,
+41    |-    datetime_to_label_safe_datestring,
+42 41 |     extend_object_field,
+43 42 |     label_safe_datestring_to_datetime,
+44 43 |     make_safe_label_value,
+45 44 |     merge_objects,
+46 45 |     rand_str,
+47 46 | )
+   47 |+from airflow.providers.cncf.kubernetes.pod_generator import datetime_to_label_safe_datestring
+48 48 | 
+49 49 | PodDefaults()
+50 50 | PodGenerator()
 
-AIR302_kubernetes.py:87:1: AIR302 [*] `airflow.kubernetes.pod_generator_deprecated.PodGenerator` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302_kubernetes.py:53:1: AIR302 [*] `airflow.kubernetes.pod_generator.extend_object_field` is moved into `cncf-kubernetes` provider in Airflow 3.0;
    |
-86 | PodDefaults()
-87 | PodGenerator()
-   | ^^^^^^^^^^^^ AIR302
-88 | make_safe_label_value()
+51 | add_pod_suffix()
+52 | datetime_to_label_safe_datestring()
+53 | extend_object_field()
+   | ^^^^^^^^^^^^^^^^^^^ AIR302
+54 | label_safe_datestring_to_datetime()
+55 | make_safe_label_value()
    |
-   = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `PodGenerator` from `airflow.providers.cncf.kubernetes.pod_generator` instead.
+   = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `extend_object_field` from `airflow.providers.cncf.kubernetes.pod_generator` instead.
 
 ℹ Unsafe fix
-75 75 | 
-76 76 | from airflow.kubernetes.pod_generator_deprecated import (
-77 77 |     PodDefaults,
-78    |-    PodGenerator,
-79 78 |     make_safe_label_value,
-80 79 | )
-81 80 | from airflow.kubernetes.pod_launcher import (
-82 81 |     PodLauncher,
-83 82 |     PodStatus,
-84 83 | )
-   84 |+from airflow.providers.cncf.kubernetes.pod_generator import PodGenerator
-85 85 | 
-86 86 | PodDefaults()
-87 87 | PodGenerator()
+39 39 |     PodGenerator,
+40 40 |     add_pod_suffix,
+41 41 |     datetime_to_label_safe_datestring,
+42    |-    extend_object_field,
+43 42 |     label_safe_datestring_to_datetime,
+44 43 |     make_safe_label_value,
+45 44 |     merge_objects,
+46 45 |     rand_str,
+47 46 | )
+   47 |+from airflow.providers.cncf.kubernetes.pod_generator import extend_object_field
+48 48 | 
+49 49 | PodDefaults()
+50 50 | PodGenerator()
 
-AIR302_kubernetes.py:88:1: AIR302 [*] `airflow.kubernetes.pod_generator_deprecated.make_safe_label_value` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302_kubernetes.py:54:1: AIR302 [*] `airflow.kubernetes.pod_generator.label_safe_datestring_to_datetime` is moved into `cncf-kubernetes` provider in Airflow 3.0;
    |
-86 | PodDefaults()
-87 | PodGenerator()
-88 | make_safe_label_value()
+52 | datetime_to_label_safe_datestring()
+53 | extend_object_field()
+54 | label_safe_datestring_to_datetime()
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
+55 | make_safe_label_value()
+56 | merge_objects()
+   |
+   = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `label_safe_datestring_to_datetime` from `airflow.providers.cncf.kubernetes.pod_generator` instead.
+
+ℹ Unsafe fix
+40 40 |     add_pod_suffix,
+41 41 |     datetime_to_label_safe_datestring,
+42 42 |     extend_object_field,
+43    |-    label_safe_datestring_to_datetime,
+44 43 |     make_safe_label_value,
+45 44 |     merge_objects,
+46 45 |     rand_str,
+47 46 | )
+   47 |+from airflow.providers.cncf.kubernetes.pod_generator import label_safe_datestring_to_datetime
+48 48 | 
+49 49 | PodDefaults()
+50 50 | PodGenerator()
+
+AIR302_kubernetes.py:55:1: AIR302 [*] `airflow.kubernetes.pod_generator.make_safe_label_value` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+   |
+53 | extend_object_field()
+54 | label_safe_datestring_to_datetime()
+55 | make_safe_label_value()
    | ^^^^^^^^^^^^^^^^^^^^^ AIR302
+56 | merge_objects()
+57 | rand_str()
    |
    = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `make_safe_label_value` from `airflow.providers.cncf.kubernetes.pod_generator` instead.
 
 ℹ Unsafe fix
-76 76 | from airflow.kubernetes.pod_generator_deprecated import (
+41 41 |     datetime_to_label_safe_datestring,
+42 42 |     extend_object_field,
+43 43 |     label_safe_datestring_to_datetime,
+44    |-    make_safe_label_value,
+45 44 |     merge_objects,
+46 45 |     rand_str,
+47 46 | )
+   47 |+from airflow.providers.cncf.kubernetes.pod_generator import make_safe_label_value
+48 48 | 
+49 49 | PodDefaults()
+50 50 | PodGenerator()
+
+AIR302_kubernetes.py:56:1: AIR302 [*] `airflow.kubernetes.pod_generator.merge_objects` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+   |
+54 | label_safe_datestring_to_datetime()
+55 | make_safe_label_value()
+56 | merge_objects()
+   | ^^^^^^^^^^^^^ AIR302
+57 | rand_str()
+   |
+   = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `merge_objects` from `airflow.providers.cncf.kubernetes.pod_generator` instead.
+
+ℹ Unsafe fix
+42 42 |     extend_object_field,
+43 43 |     label_safe_datestring_to_datetime,
+44 44 |     make_safe_label_value,
+45    |-    merge_objects,
+46 45 |     rand_str,
+47 46 | )
+   47 |+from airflow.providers.cncf.kubernetes.pod_generator import merge_objects
+48 48 | 
+49 49 | PodDefaults()
+50 50 | PodGenerator()
+
+AIR302_kubernetes.py:57:1: AIR302 [*] `airflow.kubernetes.pod_generator.rand_str` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+   |
+55 | make_safe_label_value()
+56 | merge_objects()
+57 | rand_str()
+   | ^^^^^^^^ AIR302
+58 |
+59 | from airflow.kubernetes.pod_generator_deprecated import (
+   |
+   = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `rand_str` from `airflow.providers.cncf.kubernetes.kubernetes_helper_functions` instead.
+
+ℹ Unsafe fix
+43 43 |     label_safe_datestring_to_datetime,
+44 44 |     make_safe_label_value,
+45 45 |     merge_objects,
+46    |-    rand_str,
+47 46 | )
+   47 |+from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import rand_str
+48 48 | 
+49 49 | PodDefaults()
+50 50 | PodGenerator()
+
+AIR302_kubernetes.py:69:1: AIR302 [*] `airflow.kubernetes.pod_generator_deprecated.PodDefaults` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+   |
+67 | )
+68 |
+69 | PodDefaults()
+   | ^^^^^^^^^^^ AIR302
+70 | PodGenerator()
+71 | make_safe_label_value()
+   |
+   = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `PodDefaults` from `airflow.providers.cncf.kubernetes.utils.xcom_sidecar` instead.
+
+ℹ Unsafe fix
+57 57 | rand_str()
+58 58 | 
+59 59 | from airflow.kubernetes.pod_generator_deprecated import (
+60    |-    PodDefaults,
+61 60 |     PodGenerator,
+62 61 |     make_safe_label_value,
+63 62 | )
+--------------------------------------------------------------------------------
+65 64 |     PodLauncher,
+66 65 |     PodStatus,
+67 66 | )
+   67 |+from airflow.providers.cncf.kubernetes.utils.xcom_sidecar import PodDefaults
+68 68 | 
+69 69 | PodDefaults()
+70 70 | PodGenerator()
+
+AIR302_kubernetes.py:70:1: AIR302 [*] `airflow.kubernetes.pod_generator_deprecated.PodGenerator` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+   |
+69 | PodDefaults()
+70 | PodGenerator()
+   | ^^^^^^^^^^^^ AIR302
+71 | make_safe_label_value()
+   |
+   = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `PodGenerator` from `airflow.providers.cncf.kubernetes.pod_generator` instead.
+
+ℹ Unsafe fix
+58 58 | 
+59 59 | from airflow.kubernetes.pod_generator_deprecated import (
+60 60 |     PodDefaults,
+61    |-    PodGenerator,
+62 61 |     make_safe_label_value,
+63 62 | )
+64 63 | from airflow.kubernetes.pod_launcher import (
+65 64 |     PodLauncher,
+66 65 |     PodStatus,
+67 66 | )
+   67 |+from airflow.providers.cncf.kubernetes.pod_generator import PodGenerator
+68 68 | 
+69 69 | PodDefaults()
+70 70 | PodGenerator()
+
+AIR302_kubernetes.py:71:1: AIR302 [*] `airflow.kubernetes.pod_generator_deprecated.make_safe_label_value` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+   |
+69 | PodDefaults()
+70 | PodGenerator()
+71 | make_safe_label_value()
+   | ^^^^^^^^^^^^^^^^^^^^^ AIR302
+72 |
+73 | PodLauncher()
+   |
+   = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `make_safe_label_value` from `airflow.providers.cncf.kubernetes.pod_generator` instead.
+
+ℹ Unsafe fix
+59 59 | from airflow.kubernetes.pod_generator_deprecated import (
+60 60 |     PodDefaults,
+61 61 |     PodGenerator,
+62    |-    make_safe_label_value,
+63 62 | )
+64 63 | from airflow.kubernetes.pod_launcher import (
+65 64 |     PodLauncher,
+66 65 |     PodStatus,
+67 66 | )
+   67 |+from airflow.providers.cncf.kubernetes.pod_generator import make_safe_label_value
+68 68 | 
+69 69 | PodDefaults()
+70 70 | PodGenerator()
+
+AIR302_kubernetes.py:73:1: AIR302 [*] `airflow.kubernetes.pod_launcher.PodLauncher` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+   |
+71 | make_safe_label_value()
+72 |
+73 | PodLauncher()
+   | ^^^^^^^^^^^ AIR302
+74 | PodStatus()
+   |
+   = help: Install `apache-airflow-providers-cncf-kubernetes>=3.0.0` and use `PodManager` from `airflow.providers.cncf.kubernetes.utils.pod_manager` instead.
+
+ℹ Safe fix
+65 65 |     PodLauncher,
+66 66 |     PodStatus,
+67 67 | )
+   68 |+from airflow.providers.cncf.kubernetes.utils.pod_manager import PodManager
+68 69 | 
+69 70 | PodDefaults()
+70 71 | PodGenerator()
+71 72 | make_safe_label_value()
+72 73 | 
+73    |-PodLauncher()
+   74 |+PodManager()
+74 75 | PodStatus()
+75 76 | 
+76 77 | from airflow.kubernetes.pod_launcher_deprecated import (
+
+AIR302_kubernetes.py:74:1: AIR302 [*] `airflow.kubernetes.pod_launcher.PodStatus` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+   |
+73 | PodLauncher()
+74 | PodStatus()
+   | ^^^^^^^^^ AIR302
+75 |
+76 | from airflow.kubernetes.pod_launcher_deprecated import (
+   |
+   = help: Install `apache-airflow-providers-cncf-kubernetes>=3.0.0` and use `PodPhase` from ` airflow.providers.cncf.kubernetes.utils.pod_manager` instead.
+
+ℹ Safe fix
+65 65 |     PodLauncher,
+66 66 |     PodStatus,
+67 67 | )
+   68 |+from  airflow.providers.cncf.kubernetes.utils.pod_manager import PodPhase
+68 69 | 
+69 70 | PodDefaults()
+70 71 | PodGenerator()
+71 72 | make_safe_label_value()
+72 73 | 
+73 74 | PodLauncher()
+74    |-PodStatus()
+   75 |+PodPhase()
+75 76 | 
+76 77 | from airflow.kubernetes.pod_launcher_deprecated import (
+77 78 |     PodDefaults,
+
+AIR302_kubernetes.py:90:1: AIR302 [*] `airflow.kubernetes.pod_launcher_deprecated.PodDefaults` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+   |
+88 | from airflow.kubernetes.volume_mount import VolumeMount
+89 |
+90 | PodDefaults()
+   | ^^^^^^^^^^^ AIR302
+91 | PodLauncher()
+92 | PodStatus()
+   |
+   = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `PodDefaults` from `airflow.providers.cncf.kubernetes.utils.xcom_sidecar` instead.
+
+ℹ Unsafe fix
+74 74 | PodStatus()
+75 75 | 
+76 76 | from airflow.kubernetes.pod_launcher_deprecated import (
+77    |-    PodDefaults,
+78 77 |     PodLauncher,
+79 78 |     PodStatus,
+80 79 |     get_kube_client,
+--------------------------------------------------------------------------------
+86 85 | )
+87 86 | from airflow.kubernetes.volume import Volume
+88 87 | from airflow.kubernetes.volume_mount import VolumeMount
+   88 |+from airflow.providers.cncf.kubernetes.utils.xcom_sidecar import PodDefaults
+89 89 | 
+90 90 | PodDefaults()
+91 91 | PodLauncher()
+
+AIR302_kubernetes.py:91:1: AIR302 [*] `airflow.kubernetes.pod_launcher_deprecated.PodLauncher` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+   |
+90 | PodDefaults()
+91 | PodLauncher()
+   | ^^^^^^^^^^^ AIR302
+92 | PodStatus()
+93 | get_kube_client()
+   |
+   = help: Install `apache-airflow-providers-cncf-kubernetes>=3.0.0` and use `PodManager` from `airflow.providers.cncf.kubernetes.utils.pod_manager` instead.
+
+ℹ Safe fix
+86 86 | )
+87 87 | from airflow.kubernetes.volume import Volume
+88 88 | from airflow.kubernetes.volume_mount import VolumeMount
+   89 |+from airflow.providers.cncf.kubernetes.utils.pod_manager import PodManager
+89 90 | 
+90 91 | PodDefaults()
+91    |-PodLauncher()
+   92 |+PodManager()
+92 93 | PodStatus()
+93 94 | get_kube_client()
+94 95 | 
+
+AIR302_kubernetes.py:92:1: AIR302 [*] `airflow.kubernetes.pod_launcher_deprecated.PodStatus` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+   |
+90 | PodDefaults()
+91 | PodLauncher()
+92 | PodStatus()
+   | ^^^^^^^^^ AIR302
+93 | get_kube_client()
+   |
+   = help: Install `apache-airflow-providers-cncf-kubernetes>=3.0.0` and use `PodPhase` from ` airflow.providers.cncf.kubernetes.utils.pod_manager` instead.
+
+ℹ Safe fix
+86 86 | )
+87 87 | from airflow.kubernetes.volume import Volume
+88 88 | from airflow.kubernetes.volume_mount import VolumeMount
+   89 |+from  airflow.providers.cncf.kubernetes.utils.pod_manager import PodPhase
+89 90 | 
+90 91 | PodDefaults()
+91 92 | PodLauncher()
+92    |-PodStatus()
+   93 |+PodPhase()
+93 94 | get_kube_client()
+94 95 | 
+95 96 | PodRuntimeInfoEnv()
+
+AIR302_kubernetes.py:93:1: AIR302 [*] `airflow.kubernetes.pod_launcher_deprecated.get_kube_client` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+   |
+91 | PodLauncher()
+92 | PodStatus()
+93 | get_kube_client()
+   | ^^^^^^^^^^^^^^^ AIR302
+94 |
+95 | PodRuntimeInfoEnv()
+   |
+   = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `get_kube_client` from `airflow.providers.cncf.kubernetes.kube_client` instead.
+
+ℹ Unsafe fix
 77 77 |     PodDefaults,
-78 78 |     PodGenerator,
-79    |-    make_safe_label_value,
-80 79 | )
-81 80 | from airflow.kubernetes.pod_launcher import (
-82 81 |     PodLauncher,
-83 82 |     PodStatus,
-84 83 | )
-   84 |+from airflow.providers.cncf.kubernetes.pod_generator import make_safe_label_value
-85 85 | 
-86 86 | PodDefaults()
-87 87 | PodGenerator()
-
-AIR302_kubernetes.py:108:1: AIR302 [*] `airflow.kubernetes.pod_launcher_deprecated.PodDefaults` is moved into `cncf-kubernetes` provider in Airflow 3.0;
-    |
-106 | from airflow.kubernetes.volume_mount import VolumeMount
-107 |
-108 | PodDefaults()
-    | ^^^^^^^^^^^ AIR302
-109 | PodLauncher()
-110 | PodStatus()
-    |
-    = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `PodDefaults` from `airflow.providers.cncf.kubernetes.utils.xcom_sidecar` instead.
-
-ℹ Unsafe fix
-92  92  | 
-93  93  | 
-94  94  | from airflow.kubernetes.pod_launcher_deprecated import (
-95      |-    PodDefaults,
-96  95  |     PodLauncher,
-97  96  |     PodStatus,
-98  97  |     get_kube_client,
+78 78 |     PodLauncher,
+79 79 |     PodStatus,
+80    |-    get_kube_client,
+81 80 | )
+82 81 | from airflow.kubernetes.pod_runtime_info_env import PodRuntimeInfoEnv
+83 82 | from airflow.kubernetes.secret import (
 --------------------------------------------------------------------------------
-104 103 | )
-105 104 | from airflow.kubernetes.volume import Volume
-106 105 | from airflow.kubernetes.volume_mount import VolumeMount
-    106 |+from airflow.providers.cncf.kubernetes.utils.xcom_sidecar import PodDefaults
-107 107 | 
-108 108 | PodDefaults()
-109 109 | PodLauncher()
+86 85 | )
+87 86 | from airflow.kubernetes.volume import Volume
+88 87 | from airflow.kubernetes.volume_mount import VolumeMount
+   88 |+from airflow.providers.cncf.kubernetes.kube_client import get_kube_client
+89 89 | 
+90 90 | PodDefaults()
+91 91 | PodLauncher()
 
-AIR302_kubernetes.py:109:1: AIR302 [*] `airflow.kubernetes.pod_launcher_deprecated.PodLauncher` is moved into `cncf-kubernetes` provider in Airflow 3.0;
-    |
-108 | PodDefaults()
-109 | PodLauncher()
-    | ^^^^^^^^^^^ AIR302
-110 | PodStatus()
-111 | get_kube_client()
-    |
-    = help: Install `apache-airflow-providers-cncf-kubernetes>=3.0.0` and use `PodManager` from `airflow.providers.cncf.kubernetes.utils.pod_manager` instead.
-
-ℹ Safe fix
-104 104 | )
-105 105 | from airflow.kubernetes.volume import Volume
-106 106 | from airflow.kubernetes.volume_mount import VolumeMount
-    107 |+from airflow.providers.cncf.kubernetes.utils.pod_manager import PodManager
-107 108 | 
-108 109 | PodDefaults()
-109     |-PodLauncher()
-    110 |+PodManager()
-110 111 | PodStatus()
-111 112 | get_kube_client()
-112 113 | 
-
-AIR302_kubernetes.py:110:1: AIR302 [*] `airflow.kubernetes.pod_launcher_deprecated.PodStatus` is moved into `cncf-kubernetes` provider in Airflow 3.0;
-    |
-108 | PodDefaults()
-109 | PodLauncher()
-110 | PodStatus()
-    | ^^^^^^^^^ AIR302
-111 | get_kube_client()
-    |
-    = help: Install `apache-airflow-providers-cncf-kubernetes>=3.0.0` and use `PodPhase` from ` airflow.providers.cncf.kubernetes.utils.pod_manager` instead.
+AIR302_kubernetes.py:95:1: AIR302 [*] `airflow.kubernetes.pod_runtime_info_env.PodRuntimeInfoEnv` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+   |
+93 | get_kube_client()
+94 |
+95 | PodRuntimeInfoEnv()
+   | ^^^^^^^^^^^^^^^^^ AIR302
+96 | K8SModel()
+97 | Secret()
+   |
+   = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `V1EnvVar` from `kubernetes.client.models` instead.
 
 ℹ Safe fix
-104 104 | )
-105 105 | from airflow.kubernetes.volume import Volume
-106 106 | from airflow.kubernetes.volume_mount import VolumeMount
-    107 |+from  airflow.providers.cncf.kubernetes.utils.pod_manager import PodPhase
-107 108 | 
-108 109 | PodDefaults()
-109 110 | PodLauncher()
-110     |-PodStatus()
-    111 |+PodPhase()
-111 112 | get_kube_client()
-112 113 | 
-113 114 | PodRuntimeInfoEnv()
+86 86 | )
+87 87 | from airflow.kubernetes.volume import Volume
+88 88 | from airflow.kubernetes.volume_mount import VolumeMount
+   89 |+from kubernetes.client.models import V1EnvVar
+89 90 | 
+90 91 | PodDefaults()
+91 92 | PodLauncher()
+92 93 | PodStatus()
+93 94 | get_kube_client()
+94 95 | 
+95    |-PodRuntimeInfoEnv()
+   96 |+V1EnvVar()
+96 97 | K8SModel()
+97 98 | Secret()
+98 99 | Volume()
 
-AIR302_kubernetes.py:111:1: AIR302 [*] `airflow.kubernetes.pod_launcher_deprecated.get_kube_client` is moved into `cncf-kubernetes` provider in Airflow 3.0;
-    |
-109 | PodLauncher()
-110 | PodStatus()
-111 | get_kube_client()
-    | ^^^^^^^^^^^^^^^ AIR302
-112 |
-113 | PodRuntimeInfoEnv()
-    |
-    = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `get_kube_client` from `airflow.providers.cncf.kubernetes.kube_client` instead.
+AIR302_kubernetes.py:96:1: AIR302 [*] `airflow.kubernetes.secret.K8SModel` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+   |
+95 | PodRuntimeInfoEnv()
+96 | K8SModel()
+   | ^^^^^^^^ AIR302
+97 | Secret()
+98 | Volume()
+   |
+   = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `K8SModel` from `airflow.providers.cncf.kubernetes.k8s_model` instead.
 
 ℹ Unsafe fix
-95  95  |     PodDefaults,
-96  96  |     PodLauncher,
-97  97  |     PodStatus,
-98      |-    get_kube_client,
-99  98  | )
-100 99  | from airflow.kubernetes.pod_runtime_info_env import PodRuntimeInfoEnv
-101 100 | from airflow.kubernetes.secret import (
+81 81 | )
+82 82 | from airflow.kubernetes.pod_runtime_info_env import PodRuntimeInfoEnv
+83 83 | from airflow.kubernetes.secret import (
+84    |-    K8SModel,
+85 84 |     Secret,
+86 85 | )
+87 86 | from airflow.kubernetes.volume import Volume
+88 87 | from airflow.kubernetes.volume_mount import VolumeMount
+   88 |+from airflow.providers.cncf.kubernetes.k8s_model import K8SModel
+89 89 | 
+90 90 | PodDefaults()
+91 91 | PodLauncher()
+
+AIR302_kubernetes.py:97:1: AIR302 [*] `airflow.kubernetes.secret.Secret` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+   |
+95 | PodRuntimeInfoEnv()
+96 | K8SModel()
+97 | Secret()
+   | ^^^^^^ AIR302
+98 | Volume()
+99 | VolumeMount()
+   |
+   = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `Secret` from `airflow.providers.cncf.kubernetes.secret` instead.
+
+ℹ Unsafe fix
+82 82 | from airflow.kubernetes.pod_runtime_info_env import PodRuntimeInfoEnv
+83 83 | from airflow.kubernetes.secret import (
+84 84 |     K8SModel,
+85    |-    Secret,
+86 85 | )
+87 86 | from airflow.kubernetes.volume import Volume
+88 87 | from airflow.kubernetes.volume_mount import VolumeMount
+   88 |+from airflow.providers.cncf.kubernetes.secret import Secret
+89 89 | 
+90 90 | PodDefaults()
+91 91 | PodLauncher()
+
+AIR302_kubernetes.py:98:1: AIR302 [*] `airflow.kubernetes.volume.Volume` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+   |
+96 | K8SModel()
+97 | Secret()
+98 | Volume()
+   | ^^^^^^ AIR302
+99 | VolumeMount()
+   |
+   = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `V1Volume` from `kubernetes.client.models` instead.
+
+ℹ Safe fix
+86  86  | )
+87  87  | from airflow.kubernetes.volume import Volume
+88  88  | from airflow.kubernetes.volume_mount import VolumeMount
+    89  |+from kubernetes.client.models import V1Volume
+89  90  | 
+90  91  | PodDefaults()
+91  92  | PodLauncher()
 --------------------------------------------------------------------------------
-104 103 | )
-105 104 | from airflow.kubernetes.volume import Volume
-106 105 | from airflow.kubernetes.volume_mount import VolumeMount
-    106 |+from airflow.providers.cncf.kubernetes.kube_client import get_kube_client
-107 107 | 
-108 108 | PodDefaults()
-109 109 | PodLauncher()
+95  96  | PodRuntimeInfoEnv()
+96  97  | K8SModel()
+97  98  | Secret()
+98      |-Volume()
+    99  |+V1Volume()
+99  100 | VolumeMount()
+100 101 | 
+101 102 | from airflow.kubernetes.kubernetes_helper_functions import (
 
-AIR302_kubernetes.py:113:1: AIR302 [*] `airflow.kubernetes.pod_runtime_info_env.PodRuntimeInfoEnv` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302_kubernetes.py:99:1: AIR302 [*] `airflow.kubernetes.volume_mount.VolumeMount` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-111 | get_kube_client()
-112 |
-113 | PodRuntimeInfoEnv()
-    | ^^^^^^^^^^^^^^^^^ AIR302
-114 | K8SModel()
-115 | Secret()
-    |
-    = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `V1EnvVar` from `kubernetes.client.models` instead.
-
-ℹ Safe fix
-104 104 | )
-105 105 | from airflow.kubernetes.volume import Volume
-106 106 | from airflow.kubernetes.volume_mount import VolumeMount
-    107 |+from kubernetes.client.models import V1EnvVar
-107 108 | 
-108 109 | PodDefaults()
-109 110 | PodLauncher()
-110 111 | PodStatus()
-111 112 | get_kube_client()
-112 113 | 
-113     |-PodRuntimeInfoEnv()
-    114 |+V1EnvVar()
-114 115 | K8SModel()
-115 116 | Secret()
-116 117 | Volume()
-
-AIR302_kubernetes.py:114:1: AIR302 [*] `airflow.kubernetes.secret.K8SModel` is moved into `cncf-kubernetes` provider in Airflow 3.0;
-    |
-113 | PodRuntimeInfoEnv()
-114 | K8SModel()
-    | ^^^^^^^^ AIR302
-115 | Secret()
-116 | Volume()
-    |
-    = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `K8SModel` from `airflow.providers.cncf.kubernetes.k8s_model` instead.
-
-ℹ Unsafe fix
-99  99  | )
-100 100 | from airflow.kubernetes.pod_runtime_info_env import PodRuntimeInfoEnv
-101 101 | from airflow.kubernetes.secret import (
-102     |-    K8SModel,
-103 102 |     Secret,
-104 103 | )
-105 104 | from airflow.kubernetes.volume import Volume
-106 105 | from airflow.kubernetes.volume_mount import VolumeMount
-    106 |+from airflow.providers.cncf.kubernetes.k8s_model import K8SModel
-107 107 | 
-108 108 | PodDefaults()
-109 109 | PodLauncher()
-
-AIR302_kubernetes.py:115:1: AIR302 [*] `airflow.kubernetes.secret.Secret` is moved into `cncf-kubernetes` provider in Airflow 3.0;
-    |
-113 | PodRuntimeInfoEnv()
-114 | K8SModel()
-115 | Secret()
-    | ^^^^^^ AIR302
-116 | Volume()
-117 | VolumeMount()
-    |
-    = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `Secret` from `airflow.providers.cncf.kubernetes.secret` instead.
-
-ℹ Unsafe fix
-100 100 | from airflow.kubernetes.pod_runtime_info_env import PodRuntimeInfoEnv
-101 101 | from airflow.kubernetes.secret import (
-102 102 |     K8SModel,
-103     |-    Secret,
-104 103 | )
-105 104 | from airflow.kubernetes.volume import Volume
-106 105 | from airflow.kubernetes.volume_mount import VolumeMount
-    106 |+from airflow.providers.cncf.kubernetes.secret import Secret
-107 107 | 
-108 108 | PodDefaults()
-109 109 | PodLauncher()
-
-AIR302_kubernetes.py:116:1: AIR302 [*] `airflow.kubernetes.volume.Volume` is moved into `cncf-kubernetes` provider in Airflow 3.0;
-    |
-114 | K8SModel()
-115 | Secret()
-116 | Volume()
-    | ^^^^^^ AIR302
-117 | VolumeMount()
-    |
-    = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `V1Volume` from `kubernetes.client.models` instead.
-
-ℹ Safe fix
-104 104 | )
-105 105 | from airflow.kubernetes.volume import Volume
-106 106 | from airflow.kubernetes.volume_mount import VolumeMount
-    107 |+from kubernetes.client.models import V1Volume
-107 108 | 
-108 109 | PodDefaults()
-109 110 | PodLauncher()
---------------------------------------------------------------------------------
-113 114 | PodRuntimeInfoEnv()
-114 115 | K8SModel()
-115 116 | Secret()
-116     |-Volume()
-    117 |+V1Volume()
-117 118 | VolumeMount()
-118 119 | 
-119 120 | 
-
-AIR302_kubernetes.py:117:1: AIR302 [*] `airflow.kubernetes.volume_mount.VolumeMount` is moved into `cncf-kubernetes` provider in Airflow 3.0;
-    |
-115 | Secret()
-116 | Volume()
-117 | VolumeMount()
+ 97 | Secret()
+ 98 | Volume()
+ 99 | VolumeMount()
     | ^^^^^^^^^^^ AIR302
+100 |
+101 | from airflow.kubernetes.kubernetes_helper_functions import (
     |
     = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `V1VolumeMount` from `kubernetes.client.models` instead.
 
 ℹ Safe fix
-104 104 | )
-105 105 | from airflow.kubernetes.volume import Volume
-106 106 | from airflow.kubernetes.volume_mount import VolumeMount
-    107 |+from kubernetes.client.models import V1VolumeMount
-107 108 | 
-108 109 | PodDefaults()
-109 110 | PodLauncher()
+86  86  | )
+87  87  | from airflow.kubernetes.volume import Volume
+88  88  | from airflow.kubernetes.volume_mount import VolumeMount
+    89  |+from kubernetes.client.models import V1VolumeMount
+89  90  | 
+90  91  | PodDefaults()
+91  92  | PodLauncher()
 --------------------------------------------------------------------------------
-114 115 | K8SModel()
-115 116 | Secret()
-116 117 | Volume()
-117     |-VolumeMount()
-    118 |+V1VolumeMount()
-118 119 | 
-119 120 | 
-120 121 | from airflow.kubernetes.pod import (
+96  97  | K8SModel()
+97  98  | Secret()
+98  99  | Volume()
+99      |-VolumeMount()
+    100 |+V1VolumeMount()
+100 101 | 
+101 102 | from airflow.kubernetes.kubernetes_helper_functions import (
+102 103 |     annotations_to_key,
 
-AIR302_kubernetes.py:125:1: AIR302 [*] `airflow.kubernetes.pod_launcher_deprecated.PodLauncher` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302_kubernetes.py:107:1: AIR302 [*] `airflow.kubernetes.kubernetes_helper_functions.annotations_to_key` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-123 | )
-124 |
-125 | PodLauncher()
-    | ^^^^^^^^^^^ AIR302
-126 | PodStatus()
-    |
-    = help: Install `apache-airflow-providers-cncf-kubernetes>=3.0.0` and use `PodManager` from `airflow.providers.cncf.kubernetes.utils.pod_manager` instead.
-
-ℹ Safe fix
-121 121 |     Port,
-122 122 |     Resources,
-123 123 | )
-    124 |+from airflow.providers.cncf.kubernetes.utils.pod_manager import PodManager
-124 125 | 
-125     |-PodLauncher()
-    126 |+PodManager()
-126 127 | PodStatus()
-127 128 | 
-128 129 | from airflow.kubernetes.kubernetes_helper_functions import (
-
-AIR302_kubernetes.py:126:1: AIR302 [*] `airflow.kubernetes.pod_launcher_deprecated.PodStatus` is moved into `cncf-kubernetes` provider in Airflow 3.0;
-    |
-125 | PodLauncher()
-126 | PodStatus()
-    | ^^^^^^^^^ AIR302
-127 |
-128 | from airflow.kubernetes.kubernetes_helper_functions import (
-    |
-    = help: Install `apache-airflow-providers-cncf-kubernetes>=3.0.0` and use `PodPhase` from ` airflow.providers.cncf.kubernetes.utils.pod_manager` instead.
-
-ℹ Safe fix
-121 121 |     Port,
-122 122 |     Resources,
-123 123 | )
-    124 |+from  airflow.providers.cncf.kubernetes.utils.pod_manager import PodPhase
-124 125 | 
-125 126 | PodLauncher()
-126     |-PodStatus()
-    127 |+PodPhase()
-127 128 | 
-128 129 | from airflow.kubernetes.kubernetes_helper_functions import (
-129 130 |     annotations_to_key,
-
-AIR302_kubernetes.py:133:1: AIR302 [*] `airflow.kubernetes.kubernetes_helper_functions.annotations_to_key` is moved into `cncf-kubernetes` provider in Airflow 3.0;
-    |
-131 |     rand_str,
-132 | )
-133 | annotations_to_key()
+105 | )
+106 |
+107 | annotations_to_key()
     | ^^^^^^^^^^^^^^^^^^ AIR302
-134 | get_logs_task_metadata()
-135 | rand_str()
+108 | get_logs_task_metadata()
+109 | rand_str()
     |
     = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `annotations_to_key` from `airflow.providers.cncf.kubernetes.kubernetes_helper_functions` instead.
 
 ℹ Unsafe fix
-126 126 | PodStatus()
-127 127 | 
-128 128 | from airflow.kubernetes.kubernetes_helper_functions import (
-129     |-    annotations_to_key,
-130 129 |     get_logs_task_metadata,
-131 130 |     rand_str,
-132 131 | )
-    132 |+from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import annotations_to_key
-133 133 | annotations_to_key()
-134 134 | get_logs_task_metadata()
-135 135 | rand_str()
+99  99  | VolumeMount()
+100 100 | 
+101 101 | from airflow.kubernetes.kubernetes_helper_functions import (
+102     |-    annotations_to_key,
+103 102 |     get_logs_task_metadata,
+104 103 |     rand_str,
+105 104 | )
+    105 |+from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import annotations_to_key
+106 106 | 
+107 107 | annotations_to_key()
+108 108 | get_logs_task_metadata()
 
-AIR302_kubernetes.py:134:1: AIR302 [*] `airflow.kubernetes.kubernetes_helper_functions.get_logs_task_metadata` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302_kubernetes.py:108:1: AIR302 [*] `airflow.kubernetes.kubernetes_helper_functions.get_logs_task_metadata` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-132 | )
-133 | annotations_to_key()
-134 | get_logs_task_metadata()
+107 | annotations_to_key()
+108 | get_logs_task_metadata()
     | ^^^^^^^^^^^^^^^^^^^^^^ AIR302
-135 | rand_str()
+109 | rand_str()
     |
     = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `get_logs_task_metadata` from `airflow.providers.cncf.kubernetes.kubernetes_helper_functions` instead.
 
 ℹ Unsafe fix
-127 127 | 
-128 128 | from airflow.kubernetes.kubernetes_helper_functions import (
-129 129 |     annotations_to_key,
-130     |-    get_logs_task_metadata,
-131 130 |     rand_str,
-132 131 | )
-    132 |+from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import get_logs_task_metadata
-133 133 | annotations_to_key()
-134 134 | get_logs_task_metadata()
-135 135 | rand_str()
+100 100 | 
+101 101 | from airflow.kubernetes.kubernetes_helper_functions import (
+102 102 |     annotations_to_key,
+103     |-    get_logs_task_metadata,
+104 103 |     rand_str,
+105 104 | )
+    105 |+from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import get_logs_task_metadata
+106 106 | 
+107 107 | annotations_to_key()
+108 108 | get_logs_task_metadata()
 
-AIR302_kubernetes.py:135:1: AIR302 [*] `airflow.kubernetes.kubernetes_helper_functions.rand_str` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302_kubernetes.py:109:1: AIR302 [*] `airflow.kubernetes.kubernetes_helper_functions.rand_str` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-133 | annotations_to_key()
-134 | get_logs_task_metadata()
-135 | rand_str()
+107 | annotations_to_key()
+108 | get_logs_task_metadata()
+109 | rand_str()
     | ^^^^^^^^ AIR302
-136 |
-137 | from airflow.kubernetes.pod_generator import PodGeneratorDeprecated
+110 |
+111 | from airflow.kubernetes.pod_generator import PodGeneratorDeprecated
     |
     = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `rand_str` from `airflow.providers.cncf.kubernetes.kubernetes_helper_functions` instead.
 
 ℹ Unsafe fix
-128 128 | from airflow.kubernetes.kubernetes_helper_functions import (
-129 129 |     annotations_to_key,
-130 130 |     get_logs_task_metadata,
-131     |-    rand_str,
-132 131 | )
-    132 |+from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import rand_str
-133 133 | annotations_to_key()
-134 134 | get_logs_task_metadata()
-135 135 | rand_str()
+101 101 | from airflow.kubernetes.kubernetes_helper_functions import (
+102 102 |     annotations_to_key,
+103 103 |     get_logs_task_metadata,
+104     |-    rand_str,
+105 104 | )
+    105 |+from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import rand_str
+106 106 | 
+107 107 | annotations_to_key()
+108 108 | get_logs_task_metadata()
 
-AIR302_kubernetes.py:139:1: AIR302 [*] `airflow.kubernetes.pod_generator.PodGeneratorDeprecated` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR302_kubernetes.py:113:1: AIR302 [*] `airflow.kubernetes.pod_generator.PodGeneratorDeprecated` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-137 | from airflow.kubernetes.pod_generator import PodGeneratorDeprecated
-138 |
-139 | PodGeneratorDeprecated()
+111 | from airflow.kubernetes.pod_generator import PodGeneratorDeprecated
+112 |
+113 | PodGeneratorDeprecated()
     | ^^^^^^^^^^^^^^^^^^^^^^ AIR302
     |
     = help: Install `apache-airflow-providers-cncf-kubernetes>=7.4.0` and use `PodGenerator` from `airflow.providers.cncf.kubernetes.pod_generator` instead.
 
 ℹ Unsafe fix
-135 135 | rand_str()
-136 136 | 
-137 137 | from airflow.kubernetes.pod_generator import PodGeneratorDeprecated
-    138 |+from airflow.providers.cncf.kubernetes.pod_generator import PodGenerator
-138 139 | 
-139 140 | PodGeneratorDeprecated()
+109 109 | rand_str()
+110 110 | 
+111 111 | from airflow.kubernetes.pod_generator import PodGeneratorDeprecated
+    112 |+from airflow.providers.cncf.kubernetes.pod_generator import PodGenerator
+112 113 | 
+113 114 | PodGeneratorDeprecated()

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_mysql.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_mysql.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 ---
-AIR302_mysql.py:9:1: AIR302 `airflow.hooks.mysql_hook.MySqlHook` is moved into `mysql` provider in Airflow 3.0;
+AIR302_mysql.py:9:1: AIR302 [*] `airflow.hooks.mysql_hook.MySqlHook` is moved into `mysql` provider in Airflow 3.0;
    |
  7 | )
  8 |
@@ -12,7 +12,20 @@ AIR302_mysql.py:9:1: AIR302 `airflow.hooks.mysql_hook.MySqlHook` is moved into `
    |
    = help: Install `apache-airflow-providers-mysql>=1.0.0` and use `MySqlHook` from `airflow.providers.mysql.hooks.mysql` instead.
 
-AIR302_mysql.py:10:1: AIR302 `airflow.operators.presto_to_mysql.PrestoToMySqlOperator` is moved into `mysql` provider in Airflow 3.0;
+ℹ Unsafe fix
+1 1 | from __future__ import annotations
+2 2 | 
+3   |-from airflow.hooks.mysql_hook import MySqlHook
+4 3 | from airflow.operators.presto_to_mysql import (
+5 4 |     PrestoToMySqlOperator,
+6 5 |     PrestoToMySqlTransfer,
+7 6 | )
+  7 |+from airflow.providers.mysql.hooks.mysql import MySqlHook
+8 8 | 
+9 9 | MySqlHook()
+10 10 | PrestoToMySqlOperator()
+
+AIR302_mysql.py:10:1: AIR302 [*] `airflow.operators.presto_to_mysql.PrestoToMySqlOperator` is moved into `mysql` provider in Airflow 3.0;
    |
  9 | MySqlHook()
 10 | PrestoToMySqlOperator()
@@ -21,7 +34,19 @@ AIR302_mysql.py:10:1: AIR302 `airflow.operators.presto_to_mysql.PrestoToMySqlOpe
    |
    = help: Install `apache-airflow-providers-mysql>=1.0.0` and use `PrestoToMySqlOperator` from `airflow.providers.mysql.transfers.presto_to_mysql` instead.
 
-AIR302_mysql.py:11:1: AIR302 `airflow.operators.presto_to_mysql.PrestoToMySqlTransfer` is moved into `mysql` provider in Airflow 3.0;
+ℹ Unsafe fix
+2 2 | 
+3 3 | from airflow.hooks.mysql_hook import MySqlHook
+4 4 | from airflow.operators.presto_to_mysql import (
+5   |-    PrestoToMySqlOperator,
+6 5 |     PrestoToMySqlTransfer,
+7 6 | )
+  7 |+from airflow.providers.mysql.transfers.presto_to_mysql import PrestoToMySqlOperator
+8 8 | 
+9 9 | MySqlHook()
+10 10 | PrestoToMySqlOperator()
+
+AIR302_mysql.py:11:1: AIR302 [*] `airflow.operators.presto_to_mysql.PrestoToMySqlTransfer` is moved into `mysql` provider in Airflow 3.0;
    |
  9 | MySqlHook()
 10 | PrestoToMySqlOperator()
@@ -29,3 +54,15 @@ AIR302_mysql.py:11:1: AIR302 `airflow.operators.presto_to_mysql.PrestoToMySqlTra
    | ^^^^^^^^^^^^^^^^^^^^^ AIR302
    |
    = help: Install `apache-airflow-providers-mysql>=1.0.0` and use `PrestoToMySqlOperator` from `airflow.providers.mysql.transfers.presto_to_mysql` instead.
+
+ℹ Unsafe fix
+2 2 | 
+3 3 | from airflow.hooks.mysql_hook import MySqlHook
+4 4 | from airflow.operators.presto_to_mysql import (
+5   |-    PrestoToMySqlOperator,
+6 5 |     PrestoToMySqlTransfer,
+7 6 | )
+  7 |+from airflow.providers.mysql.transfers.presto_to_mysql import PrestoToMySqlOperator
+8 8 | 
+9 9 | MySqlHook()
+10 10 | PrestoToMySqlOperator()

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_oracle.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_oracle.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 ---
-AIR302_oracle.py:5:1: AIR302 `airflow.hooks.oracle_hook.OracleHook` is moved into `oracle` provider in Airflow 3.0;
+AIR302_oracle.py:5:1: AIR302 [*] `airflow.hooks.oracle_hook.OracleHook` is moved into `oracle` provider in Airflow 3.0;
   |
 3 | from airflow.hooks.oracle_hook import OracleHook
 4 |
@@ -9,3 +9,11 @@ AIR302_oracle.py:5:1: AIR302 `airflow.hooks.oracle_hook.OracleHook` is moved int
   | ^^^^^^^^^^ AIR302
   |
   = help: Install `apache-airflow-providers-oracle>=1.0.0` and use `OracleHook` from `airflow.providers.oracle.hooks.oracle` instead.
+
+ℹ Unsafe fix
+1 1 | from __future__ import annotations
+2 2 | 
+3   |-from airflow.hooks.oracle_hook import OracleHook
+  3 |+from airflow.providers.oracle.hooks.oracle import OracleHook
+4 4 | 
+5 5 | OracleHook()

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_papermill.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_papermill.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 ---
-AIR302_papermill.py:5:1: AIR302 `airflow.operators.papermill_operator.PapermillOperator` is moved into `papermill` provider in Airflow 3.0;
+AIR302_papermill.py:5:1: AIR302 [*] `airflow.operators.papermill_operator.PapermillOperator` is moved into `papermill` provider in Airflow 3.0;
   |
 3 | from airflow.operators.papermill_operator import PapermillOperator
 4 |
@@ -9,3 +9,11 @@ AIR302_papermill.py:5:1: AIR302 `airflow.operators.papermill_operator.PapermillO
   | ^^^^^^^^^^^^^^^^^ AIR302
   |
   = help: Install `apache-airflow-providers-papermill>=1.0.0` and use `PapermillOperator` from `airflow.providers.papermill.operators.papermill` instead.
+
+ℹ Unsafe fix
+1 1 | from __future__ import annotations
+2 2 | 
+3   |-from airflow.operators.papermill_operator import PapermillOperator
+  3 |+from airflow.providers.papermill.operators.papermill import PapermillOperator
+4 4 | 
+5 5 | PapermillOperator()

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_pig.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_pig.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 ---
-AIR302_pig.py:6:1: AIR302 `airflow.hooks.pig_hook.PigCliHook` is moved into `apache-pig` provider in Airflow 3.0;
+AIR302_pig.py:6:1: AIR302 [*] `airflow.hooks.pig_hook.PigCliHook` is moved into `apache-pig` provider in Airflow 3.0;
   |
 4 | from airflow.operators.pig_operator import PigOperator
 5 |
@@ -11,10 +11,30 @@ AIR302_pig.py:6:1: AIR302 `airflow.hooks.pig_hook.PigCliHook` is moved into `apa
   |
   = help: Install `apache-airflow-providers-apache-pig>=1.0.0` and use `PigCliHook` from `airflow.providers.apache.pig.hooks.pig` instead.
 
-AIR302_pig.py:7:1: AIR302 `airflow.operators.pig_operator.PigOperator` is moved into `apache-pig` provider in Airflow 3.0;
+ℹ Unsafe fix
+1 1 | from __future__ import annotations
+2 2 | 
+3   |-from airflow.hooks.pig_hook import PigCliHook
+4 3 | from airflow.operators.pig_operator import PigOperator
+  4 |+from airflow.providers.apache.pig.hooks.pig import PigCliHook
+5 5 | 
+6 6 | PigCliHook()
+7 7 | PigOperator()
+
+AIR302_pig.py:7:1: AIR302 [*] `airflow.operators.pig_operator.PigOperator` is moved into `apache-pig` provider in Airflow 3.0;
   |
 6 | PigCliHook()
 7 | PigOperator()
   | ^^^^^^^^^^^ AIR302
   |
   = help: Install `apache-airflow-providers-apache-pig>=1.0.0` and use `PigOperator` from `airflow.providers.apache.pig.operators.pig` instead.
+
+ℹ Unsafe fix
+1 1 | from __future__ import annotations
+2 2 | 
+3 3 | from airflow.hooks.pig_hook import PigCliHook
+4   |-from airflow.operators.pig_operator import PigOperator
+  4 |+from airflow.providers.apache.pig.operators.pig import PigOperator
+5 5 | 
+6 6 | PigCliHook()
+7 7 | PigOperator()

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_postgres.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_postgres.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 ---
-AIR302_postgres.py:6:1: AIR302 `airflow.hooks.postgres_hook.PostgresHook` is moved into `postgres` provider in Airflow 3.0;
+AIR302_postgres.py:6:1: AIR302 [*] `airflow.hooks.postgres_hook.PostgresHook` is moved into `postgres` provider in Airflow 3.0;
   |
 4 | from airflow.operators.postgres_operator import Mapping
 5 |
@@ -10,6 +10,16 @@ AIR302_postgres.py:6:1: AIR302 `airflow.hooks.postgres_hook.PostgresHook` is mov
 7 | Mapping()
   |
   = help: Install `apache-airflow-providers-postgres>=1.0.0` and use `PostgresHook` from `airflow.providers.postgres.hooks.postgres` instead.
+
+ℹ Unsafe fix
+1 1 | from __future__ import annotations
+2 2 | 
+3   |-from airflow.hooks.postgres_hook import PostgresHook
+4 3 | from airflow.operators.postgres_operator import Mapping
+  4 |+from airflow.providers.postgres.hooks.postgres import PostgresHook
+5 5 | 
+6 6 | PostgresHook()
+7 7 | Mapping()
 
 AIR302_postgres.py:7:1: AIR302 `airflow.operators.postgres_operator.Mapping` is removed in Airflow 3.0
   |

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_presto.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_presto.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 ---
-AIR302_presto.py:5:1: AIR302 `airflow.hooks.presto_hook.PrestoHook` is moved into `presto` provider in Airflow 3.0;
+AIR302_presto.py:5:1: AIR302 [*] `airflow.hooks.presto_hook.PrestoHook` is moved into `presto` provider in Airflow 3.0;
   |
 3 | from airflow.hooks.presto_hook import PrestoHook
 4 |
@@ -9,3 +9,11 @@ AIR302_presto.py:5:1: AIR302 `airflow.hooks.presto_hook.PrestoHook` is moved int
   | ^^^^^^^^^^ AIR302
   |
   = help: Install `apache-airflow-providers-presto>=1.0.0` and use `PrestoHook` from `airflow.providers.presto.hooks.presto` instead.
+
+ℹ Unsafe fix
+1 1 | from __future__ import annotations
+2 2 | 
+3   |-from airflow.hooks.presto_hook import PrestoHook
+  3 |+from airflow.providers.presto.hooks.presto import PrestoHook
+4 4 | 
+5 5 | PrestoHook()

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_samba.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_samba.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 ---
-AIR302_samba.py:5:1: AIR302 `airflow.hooks.samba_hook.SambaHook` is moved into `samba` provider in Airflow 3.0;
+AIR302_samba.py:5:1: AIR302 [*] `airflow.hooks.samba_hook.SambaHook` is moved into `samba` provider in Airflow 3.0;
   |
 3 | from airflow.hooks.samba_hook import SambaHook
 4 |
@@ -9,3 +9,11 @@ AIR302_samba.py:5:1: AIR302 `airflow.hooks.samba_hook.SambaHook` is moved into `
   | ^^^^^^^^^ AIR302
   |
   = help: Install `apache-airflow-providers-samba>=1.0.0` and use `SambaHook` from `airflow.providers.samba.hooks.samba` instead.
+
+ℹ Unsafe fix
+1 1 | from __future__ import annotations
+2 2 | 
+3   |-from airflow.hooks.samba_hook import SambaHook
+  3 |+from airflow.providers.samba.hooks.samba import SambaHook
+4 4 | 
+5 5 | SambaHook()

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_slack.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_slack.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 ---
-AIR302_slack.py:6:1: AIR302 `airflow.hooks.slack_hook.SlackHook` is moved into `slack` provider in Airflow 3.0;
+AIR302_slack.py:6:1: AIR302 [*] `airflow.hooks.slack_hook.SlackHook` is moved into `slack` provider in Airflow 3.0;
   |
 4 | from airflow.operators.slack_operator import SlackAPIOperator, SlackAPIPostOperator
 5 |
@@ -12,7 +12,17 @@ AIR302_slack.py:6:1: AIR302 `airflow.hooks.slack_hook.SlackHook` is moved into `
   |
   = help: Install `apache-airflow-providers-slack>=1.0.0` and use `SlackHook` from `airflow.providers.slack.hooks.slack` instead.
 
-AIR302_slack.py:7:1: AIR302 `airflow.operators.slack_operator.SlackAPIOperator` is moved into `slack` provider in Airflow 3.0;
+ℹ Unsafe fix
+1 1 | from __future__ import annotations
+2 2 | 
+3   |-from airflow.hooks.slack_hook import SlackHook
+4 3 | from airflow.operators.slack_operator import SlackAPIOperator, SlackAPIPostOperator
+  4 |+from airflow.providers.slack.hooks.slack import SlackHook
+5 5 | 
+6 6 | SlackHook()
+7 7 | SlackAPIOperator()
+
+AIR302_slack.py:7:1: AIR302 [*] `airflow.operators.slack_operator.SlackAPIOperator` is moved into `slack` provider in Airflow 3.0;
   |
 6 | SlackHook()
 7 | SlackAPIOperator()
@@ -21,7 +31,18 @@ AIR302_slack.py:7:1: AIR302 `airflow.operators.slack_operator.SlackAPIOperator` 
   |
   = help: Install `apache-airflow-providers-slack>=1.0.0` and use `SlackAPIOperator` from `airflow.providers.slack.operators.slack` instead.
 
-AIR302_slack.py:8:1: AIR302 `airflow.operators.slack_operator.SlackAPIPostOperator` is moved into `slack` provider in Airflow 3.0;
+ℹ Unsafe fix
+1 1 | from __future__ import annotations
+2 2 | 
+3 3 | from airflow.hooks.slack_hook import SlackHook
+4   |-from airflow.operators.slack_operator import SlackAPIOperator, SlackAPIPostOperator
+  4 |+from airflow.operators.slack_operator import SlackAPIPostOperator
+  5 |+from airflow.providers.slack.operators.slack import SlackAPIOperator
+5 6 | 
+6 7 | SlackHook()
+7 8 | SlackAPIOperator()
+
+AIR302_slack.py:8:1: AIR302 [*] `airflow.operators.slack_operator.SlackAPIPostOperator` is moved into `slack` provider in Airflow 3.0;
   |
 6 | SlackHook()
 7 | SlackAPIOperator()
@@ -29,3 +50,14 @@ AIR302_slack.py:8:1: AIR302 `airflow.operators.slack_operator.SlackAPIPostOperat
   | ^^^^^^^^^^^^^^^^^^^^ AIR302
   |
   = help: Install `apache-airflow-providers-slack>=1.0.0` and use `SlackAPIPostOperator` from `airflow.providers.slack.operators.slack` instead.
+
+ℹ Unsafe fix
+1 1 | from __future__ import annotations
+2 2 | 
+3 3 | from airflow.hooks.slack_hook import SlackHook
+4   |-from airflow.operators.slack_operator import SlackAPIOperator, SlackAPIPostOperator
+  4 |+from airflow.operators.slack_operator import SlackAPIOperator
+  5 |+from airflow.providers.slack.operators.slack import SlackAPIPostOperator
+5 6 | 
+6 7 | SlackHook()
+7 8 | SlackAPIOperator()

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_smtp.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_smtp.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 ---
-AIR302_smtp.py:5:1: AIR302 `airflow.operators.email_operator.EmailOperator` is moved into `smtp` provider in Airflow 3.0;
+AIR302_smtp.py:5:1: AIR302 [*] `airflow.operators.email_operator.EmailOperator` is moved into `smtp` provider in Airflow 3.0;
   |
 3 | from airflow.operators.email_operator import EmailOperator
 4 |
@@ -12,7 +12,16 @@ AIR302_smtp.py:5:1: AIR302 `airflow.operators.email_operator.EmailOperator` is m
   |
   = help: Install `apache-airflow-providers-smtp>=1.0.0` and use `EmailOperator` from `airflow.providers.smtp.operators.smtp` instead.
 
-AIR302_smtp.py:9:1: AIR302 `airflow.operators.email.EmailOperator` is moved into `smtp` provider in Airflow 3.0;
+ℹ Unsafe fix
+1 1 | from __future__ import annotations
+2 2 | 
+3   |-from airflow.operators.email_operator import EmailOperator
+  3 |+from airflow.providers.smtp.operators.smtp import EmailOperator
+4 4 | 
+5 5 | EmailOperator()
+6 6 | 
+
+AIR302_smtp.py:9:1: AIR302 [*] `airflow.operators.email.EmailOperator` is moved into `smtp` provider in Airflow 3.0;
   |
 7 | from airflow.operators.email import EmailOperator
 8 |
@@ -20,3 +29,12 @@ AIR302_smtp.py:9:1: AIR302 `airflow.operators.email.EmailOperator` is moved into
   | ^^^^^^^^^^^^^ AIR302
   |
   = help: Install `apache-airflow-providers-smtp>=1.0.0` and use `EmailOperator` from `airflow.providers.smtp.operators.smtp` instead.
+
+ℹ Unsafe fix
+4 4 | 
+5 5 | EmailOperator()
+6 6 | 
+7   |-from airflow.operators.email import EmailOperator
+  7 |+from airflow.providers.smtp.operators.smtp import EmailOperator
+8 8 | 
+9 9 | EmailOperator()

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_sqlite.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_sqlite.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 ---
-AIR302_sqlite.py:5:1: AIR302 `airflow.hooks.sqlite_hook.SqliteHook` is moved into `sqlite` provider in Airflow 3.0;
+AIR302_sqlite.py:5:1: AIR302 [*] `airflow.hooks.sqlite_hook.SqliteHook` is moved into `sqlite` provider in Airflow 3.0;
   |
 3 | from airflow.hooks.sqlite_hook import SqliteHook
 4 |
@@ -9,3 +9,11 @@ AIR302_sqlite.py:5:1: AIR302 `airflow.hooks.sqlite_hook.SqliteHook` is moved int
   | ^^^^^^^^^^ AIR302
   |
   = help: Install `apache-airflow-providers-sqlite>=1.0.0` and use `SqliteHook` from `airflow.providers.sqlite.hooks.sqlite` instead.
+
+ℹ Unsafe fix
+1 1 | from __future__ import annotations
+2 2 | 
+3   |-from airflow.hooks.sqlite_hook import SqliteHook
+  3 |+from airflow.providers.sqlite.hooks.sqlite import SqliteHook
+4 4 | 
+5 5 | SqliteHook()

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_standard.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_standard.py.snap
@@ -1,14 +1,14 @@
 ---
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 ---
-AIR302_standard.py:25:1: AIR302 [*] `airflow.operators.bash_operator.BashOperator` is moved into `standard` provider in Airflow 3.0;
+AIR302_standard.py:20:1: AIR302 [*] `airflow.operators.bash_operator.BashOperator` is moved into `standard` provider in Airflow 3.0;
    |
-23 | )
-24 |
-25 | BashOperator()
+18 | )
+19 |
+20 | BashOperator()
    | ^^^^^^^^^^^^ AIR302
-26 |
-27 | TriggerDagRunLink()
+21 |
+22 | TriggerDagRunLink()
    |
    = help: Install `apache-airflow-providers-standard>=0.0.1` and use `BashOperator` from `airflow.providers.standard.operators.bash` instead.
 
@@ -20,21 +20,21 @@ AIR302_standard.py:25:1: AIR302 [*] `airflow.operators.bash_operator.BashOperato
 5  4  |     TriggerDagRunLink,
 6  5  |     TriggerDagRunOperator,
 --------------------------------------------------------------------------------
-21 20 |     ExternalTaskSensor,
-22 21 | 
-23 22 | )
-   23 |+from airflow.providers.standard.operators.bash import BashOperator
-24 24 | 
-25 25 | BashOperator()
-26 26 | 
+16 15 |     ExternalTaskMarker,
+17 16 |     ExternalTaskSensor,
+18 17 | )
+   18 |+from airflow.providers.standard.operators.bash import BashOperator
+19 19 | 
+20 20 | BashOperator()
+21 21 | 
 
-AIR302_standard.py:27:1: AIR302 [*] `airflow.operators.dagrun_operator.TriggerDagRunLink` is moved into `standard` provider in Airflow 3.0;
+AIR302_standard.py:22:1: AIR302 [*] `airflow.operators.dagrun_operator.TriggerDagRunLink` is moved into `standard` provider in Airflow 3.0;
    |
-25 | BashOperator()
-26 |
-27 | TriggerDagRunLink()
+20 | BashOperator()
+21 |
+22 | TriggerDagRunLink()
    | ^^^^^^^^^^^^^^^^^ AIR302
-28 | TriggerDagRunOperator()
+23 | TriggerDagRunOperator()
    |
    = help: Install `apache-airflow-providers-standard>=0.0.2` and use `TriggerDagRunLink` from `airflow.providers.standard.operators.trigger_dagrun` instead.
 
@@ -45,21 +45,23 @@ AIR302_standard.py:27:1: AIR302 [*] `airflow.operators.dagrun_operator.TriggerDa
 5     |-    TriggerDagRunLink,
 6  5  |     TriggerDagRunOperator,
 7  6  | )
-8  7  | 
+8  7  | from airflow.operators.latest_only_operator import LatestOnlyOperator
 --------------------------------------------------------------------------------
-21 20 |     ExternalTaskSensor,
-22 21 | 
-23 22 | )
-   23 |+from airflow.providers.standard.operators.trigger_dagrun import TriggerDagRunLink
-24 24 | 
-25 25 | BashOperator()
-26 26 | 
+16 15 |     ExternalTaskMarker,
+17 16 |     ExternalTaskSensor,
+18 17 | )
+   18 |+from airflow.providers.standard.operators.trigger_dagrun import TriggerDagRunLink
+19 19 | 
+20 20 | BashOperator()
+21 21 | 
 
-AIR302_standard.py:28:1: AIR302 [*] `airflow.operators.dagrun_operator.TriggerDagRunOperator` is moved into `standard` provider in Airflow 3.0;
+AIR302_standard.py:23:1: AIR302 [*] `airflow.operators.dagrun_operator.TriggerDagRunOperator` is moved into `standard` provider in Airflow 3.0;
    |
-27 | TriggerDagRunLink()
-28 | TriggerDagRunOperator()
+22 | TriggerDagRunLink()
+23 | TriggerDagRunOperator()
    | ^^^^^^^^^^^^^^^^^^^^^ AIR302
+24 |
+25 | LatestOnlyOperator()
    |
    = help: Install `apache-airflow-providers-standard>=0.0.2` and use `TriggerDagRunOperator` from `airflow.providers.standard.operators.trigger_dagrun` instead.
 
@@ -69,418 +71,420 @@ AIR302_standard.py:28:1: AIR302 [*] `airflow.operators.dagrun_operator.TriggerDa
 5  5  |     TriggerDagRunLink,
 6     |-    TriggerDagRunOperator,
 7  6  | )
-8  7  | 
-9  8  | 
+8  7  | from airflow.operators.latest_only_operator import LatestOnlyOperator
+9  8  | from airflow.operators.python_operator import (
 --------------------------------------------------------------------------------
-21 20 |     ExternalTaskSensor,
-22 21 | 
-23 22 | )
-   23 |+from airflow.providers.standard.operators.trigger_dagrun import TriggerDagRunOperator
-24 24 | 
-25 25 | BashOperator()
-26 26 | 
+16 15 |     ExternalTaskMarker,
+17 16 |     ExternalTaskSensor,
+18 17 | )
+   18 |+from airflow.providers.standard.operators.trigger_dagrun import TriggerDagRunOperator
+19 19 | 
+20 20 | BashOperator()
+21 21 | 
 
-AIR302_standard.py:32:1: AIR302 [*] `airflow.operators.latest_only_operator.LatestOnlyOperator` is moved into `standard` provider in Airflow 3.0;
+AIR302_standard.py:25:1: AIR302 [*] `airflow.operators.latest_only_operator.LatestOnlyOperator` is moved into `standard` provider in Airflow 3.0;
    |
-32 | LatestOnlyOperator()
+23 | TriggerDagRunOperator()
+24 |
+25 | LatestOnlyOperator()
    | ^^^^^^^^^^^^^^^^^^ AIR302
-33 |
-34 | BranchPythonOperator()
+26 |
+27 | BranchPythonOperator()
    |
    = help: Install `apache-airflow-providers-standard>=0.0.3` and use `LatestOnlyOperator` from `airflow.providers.standard.operators.latest_only` instead.
 
 ℹ Unsafe fix
-9  9  | 
-10 10 | 
-11 11 | 
-12    |-from airflow.operators.latest_only_operator import LatestOnlyOperator
-13 12 | from airflow.operators.python_operator import (
-14 13 |     BranchPythonOperator,
-15 14 |     PythonOperator,
+5  5  |     TriggerDagRunLink,
+6  6  |     TriggerDagRunOperator,
+7  7  | )
+8     |-from airflow.operators.latest_only_operator import LatestOnlyOperator
+9  8  | from airflow.operators.python_operator import (
+10 9  |     BranchPythonOperator,
+11 10 |     PythonOperator,
 --------------------------------------------------------------------------------
-21 20 |     ExternalTaskSensor,
-22 21 | 
-23 22 | )
-   23 |+from airflow.providers.standard.operators.latest_only import LatestOnlyOperator
-24 24 | 
-25 25 | BashOperator()
-26 26 | 
+16 15 |     ExternalTaskMarker,
+17 16 |     ExternalTaskSensor,
+18 17 | )
+   18 |+from airflow.providers.standard.operators.latest_only import LatestOnlyOperator
+19 19 | 
+20 20 | BashOperator()
+21 21 | 
 
-AIR302_standard.py:34:1: AIR302 [*] `airflow.operators.python_operator.BranchPythonOperator` is moved into `standard` provider in Airflow 3.0;
+AIR302_standard.py:27:1: AIR302 [*] `airflow.operators.python_operator.BranchPythonOperator` is moved into `standard` provider in Airflow 3.0;
    |
-32 | LatestOnlyOperator()
-33 |
-34 | BranchPythonOperator()
+25 | LatestOnlyOperator()
+26 |
+27 | BranchPythonOperator()
    | ^^^^^^^^^^^^^^^^^^^^ AIR302
-35 | PythonOperator()
-36 | PythonVirtualenvOperator()
+28 | PythonOperator()
+29 | PythonVirtualenvOperator()
    |
    = help: Install `apache-airflow-providers-standard>=0.0.1` and use `BranchPythonOperator` from `airflow.providers.standard.operators.python` instead.
 
 ℹ Unsafe fix
-11 11 | 
-12 12 | from airflow.operators.latest_only_operator import LatestOnlyOperator
-13 13 | from airflow.operators.python_operator import (
-14    |-    BranchPythonOperator,
-15 14 |     PythonOperator,
-16 15 |     PythonVirtualenvOperator,
-17 16 |     ShortCircuitOperator,
+7  7  | )
+8  8  | from airflow.operators.latest_only_operator import LatestOnlyOperator
+9  9  | from airflow.operators.python_operator import (
+10    |-    BranchPythonOperator,
+11 10 |     PythonOperator,
+12 11 |     PythonVirtualenvOperator,
+13 12 |     ShortCircuitOperator,
 --------------------------------------------------------------------------------
-21 20 |     ExternalTaskSensor,
-22 21 | 
-23 22 | )
-   23 |+from airflow.providers.standard.operators.python import BranchPythonOperator
-24 24 | 
-25 25 | BashOperator()
-26 26 | 
+16 15 |     ExternalTaskMarker,
+17 16 |     ExternalTaskSensor,
+18 17 | )
+   18 |+from airflow.providers.standard.operators.python import BranchPythonOperator
+19 19 | 
+20 20 | BashOperator()
+21 21 | 
 
-AIR302_standard.py:35:1: AIR302 [*] `airflow.operators.python_operator.PythonOperator` is moved into `standard` provider in Airflow 3.0;
+AIR302_standard.py:28:1: AIR302 [*] `airflow.operators.python_operator.PythonOperator` is moved into `standard` provider in Airflow 3.0;
    |
-34 | BranchPythonOperator()
-35 | PythonOperator()
+27 | BranchPythonOperator()
+28 | PythonOperator()
    | ^^^^^^^^^^^^^^ AIR302
-36 | PythonVirtualenvOperator()
-37 | ShortCircuitOperator()
+29 | PythonVirtualenvOperator()
+30 | ShortCircuitOperator()
    |
    = help: Install `apache-airflow-providers-standard>=0.0.1` and use `PythonOperator` from `airflow.providers.standard.operators.python` instead.
 
 ℹ Unsafe fix
-12 12 | from airflow.operators.latest_only_operator import LatestOnlyOperator
-13 13 | from airflow.operators.python_operator import (
-14 14 |     BranchPythonOperator,
-15    |-    PythonOperator,
-16 15 |     PythonVirtualenvOperator,
-17 16 |     ShortCircuitOperator,
-18 17 | )
+8  8  | from airflow.operators.latest_only_operator import LatestOnlyOperator
+9  9  | from airflow.operators.python_operator import (
+10 10 |     BranchPythonOperator,
+11    |-    PythonOperator,
+12 11 |     PythonVirtualenvOperator,
+13 12 |     ShortCircuitOperator,
+14 13 | )
 --------------------------------------------------------------------------------
-21 20 |     ExternalTaskSensor,
-22 21 | 
-23 22 | )
-   23 |+from airflow.providers.standard.operators.python import PythonOperator
-24 24 | 
-25 25 | BashOperator()
-26 26 | 
+16 15 |     ExternalTaskMarker,
+17 16 |     ExternalTaskSensor,
+18 17 | )
+   18 |+from airflow.providers.standard.operators.python import PythonOperator
+19 19 | 
+20 20 | BashOperator()
+21 21 | 
 
-AIR302_standard.py:36:1: AIR302 [*] `airflow.operators.python_operator.PythonVirtualenvOperator` is moved into `standard` provider in Airflow 3.0;
+AIR302_standard.py:29:1: AIR302 [*] `airflow.operators.python_operator.PythonVirtualenvOperator` is moved into `standard` provider in Airflow 3.0;
    |
-34 | BranchPythonOperator()
-35 | PythonOperator()
-36 | PythonVirtualenvOperator()
+27 | BranchPythonOperator()
+28 | PythonOperator()
+29 | PythonVirtualenvOperator()
    | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-37 | ShortCircuitOperator()
+30 | ShortCircuitOperator()
    |
    = help: Install `apache-airflow-providers-standard>=0.0.1` and use `PythonVirtualenvOperator` from `airflow.providers.standard.operators.python` instead.
 
 ℹ Unsafe fix
-13 13 | from airflow.operators.python_operator import (
-14 14 |     BranchPythonOperator,
-15 15 |     PythonOperator,
-16    |-    PythonVirtualenvOperator,
-17 16 |     ShortCircuitOperator,
+9  9  | from airflow.operators.python_operator import (
+10 10 |     BranchPythonOperator,
+11 11 |     PythonOperator,
+12    |-    PythonVirtualenvOperator,
+13 12 |     ShortCircuitOperator,
+14 13 | )
+15 14 | from airflow.sensors.external_task_sensor import (
+16 15 |     ExternalTaskMarker,
+17 16 |     ExternalTaskSensor,
 18 17 | )
-19 18 | from airflow.sensors.external_task_sensor import (
---------------------------------------------------------------------------------
-21 20 |     ExternalTaskSensor,
-22 21 | 
-23 22 | )
-   23 |+from airflow.providers.standard.operators.python import PythonVirtualenvOperator
-24 24 | 
-25 25 | BashOperator()
-26 26 | 
+   18 |+from airflow.providers.standard.operators.python import PythonVirtualenvOperator
+19 19 | 
+20 20 | BashOperator()
+21 21 | 
 
-AIR302_standard.py:37:1: AIR302 [*] `airflow.operators.python_operator.ShortCircuitOperator` is moved into `standard` provider in Airflow 3.0;
+AIR302_standard.py:30:1: AIR302 [*] `airflow.operators.python_operator.ShortCircuitOperator` is moved into `standard` provider in Airflow 3.0;
    |
-35 | PythonOperator()
-36 | PythonVirtualenvOperator()
-37 | ShortCircuitOperator()
+28 | PythonOperator()
+29 | PythonVirtualenvOperator()
+30 | ShortCircuitOperator()
    | ^^^^^^^^^^^^^^^^^^^^ AIR302
-38 |
-39 | ExternalTaskMarker()
+31 |
+32 | ExternalTaskMarker()
    |
    = help: Install `apache-airflow-providers-standard>=0.0.1` and use `ShortCircuitOperator` from `airflow.providers.standard.operators.python` instead.
 
 ℹ Unsafe fix
-14 14 |     BranchPythonOperator,
-15 15 |     PythonOperator,
-16 16 |     PythonVirtualenvOperator,
-17    |-    ShortCircuitOperator,
+10 10 |     BranchPythonOperator,
+11 11 |     PythonOperator,
+12 12 |     PythonVirtualenvOperator,
+13    |-    ShortCircuitOperator,
+14 13 | )
+15 14 | from airflow.sensors.external_task_sensor import (
+16 15 |     ExternalTaskMarker,
+17 16 |     ExternalTaskSensor,
 18 17 | )
-19 18 | from airflow.sensors.external_task_sensor import (
-20 19 |     ExternalTaskMarker,
-21 20 |     ExternalTaskSensor,
-22 21 | 
-23 22 | )
-   23 |+from airflow.providers.standard.operators.python import ShortCircuitOperator
-24 24 | 
-25 25 | BashOperator()
-26 26 | 
+   18 |+from airflow.providers.standard.operators.python import ShortCircuitOperator
+19 19 | 
+20 20 | BashOperator()
+21 21 | 
 
-AIR302_standard.py:39:1: AIR302 [*] `airflow.sensors.external_task_sensor.ExternalTaskMarker` is moved into `standard` provider in Airflow 3.0;
+AIR302_standard.py:32:1: AIR302 [*] `airflow.sensors.external_task_sensor.ExternalTaskMarker` is moved into `standard` provider in Airflow 3.0;
    |
-37 | ShortCircuitOperator()
-38 |
-39 | ExternalTaskMarker()
+30 | ShortCircuitOperator()
+31 |
+32 | ExternalTaskMarker()
    | ^^^^^^^^^^^^^^^^^^ AIR302
-40 | ExternalTaskSensor()
+33 | ExternalTaskSensor()
    |
    = help: Install `apache-airflow-providers-standard>=0.0.3` and use `ExternalTaskMarker` from `airflow.providers.standard.sensors.external_task` instead.
 
 ℹ Unsafe fix
-17 17 |     ShortCircuitOperator,
-18 18 | )
-19 19 | from airflow.sensors.external_task_sensor import (
-20    |-    ExternalTaskMarker,
-21 20 |     ExternalTaskSensor,
-22 21 | 
-23 22 | )
-   23 |+from airflow.providers.standard.sensors.external_task import ExternalTaskMarker
-24 24 | 
-25 25 | BashOperator()
-26 26 | 
+13 13 |     ShortCircuitOperator,
+14 14 | )
+15 15 | from airflow.sensors.external_task_sensor import (
+16    |-    ExternalTaskMarker,
+17 16 |     ExternalTaskSensor,
+18 17 | )
+   18 |+from airflow.providers.standard.sensors.external_task import ExternalTaskMarker
+19 19 | 
+20 20 | BashOperator()
+21 21 | 
 
-AIR302_standard.py:40:1: AIR302 [*] `airflow.sensors.external_task_sensor.ExternalTaskSensor` is moved into `standard` provider in Airflow 3.0;
+AIR302_standard.py:33:1: AIR302 [*] `airflow.sensors.external_task_sensor.ExternalTaskSensor` is moved into `standard` provider in Airflow 3.0;
    |
-39 | ExternalTaskMarker()
-40 | ExternalTaskSensor()
+32 | ExternalTaskMarker()
+33 | ExternalTaskSensor()
    | ^^^^^^^^^^^^^^^^^^ AIR302
    |
    = help: Install `apache-airflow-providers-standard>=0.0.3` and use `ExternalTaskSensor` from `airflow.providers.standard.sensors.external_task` instead.
 
 ℹ Unsafe fix
-18 18 | )
-19 19 | from airflow.sensors.external_task_sensor import (
-20 20 |     ExternalTaskMarker,
-21    |-    ExternalTaskSensor,
-22 21 | 
-23 22 | )
-   23 |+from airflow.providers.standard.sensors.external_task import ExternalTaskSensor
-24 24 | 
-25 25 | BashOperator()
-26 26 | 
+14 14 | )
+15 15 | from airflow.sensors.external_task_sensor import (
+16 16 |     ExternalTaskMarker,
+17    |-    ExternalTaskSensor,
+18 17 | )
+   18 |+from airflow.providers.standard.sensors.external_task import ExternalTaskSensor
+19 19 | 
+20 20 | BashOperator()
+21 21 | 
 
-AIR302_standard.py:52:1: AIR302 [*] `airflow.hooks.subprocess.SubprocessResult` is moved into `standard` provider in Airflow 3.0;
+AIR302_standard.py:38:1: AIR302 [*] `airflow.hooks.subprocess.SubprocessResult` is moved into `standard` provider in Airflow 3.0;
    |
-51 | from airflow.hooks.subprocess import SubprocessResult
-52 | SubprocessResult()
+36 | from airflow.hooks.subprocess import SubprocessResult
+37 |
+38 | SubprocessResult()
    | ^^^^^^^^^^^^^^^^ AIR302
-53 | from airflow.hooks.subprocess import working_directory
-54 | working_directory()
+39 |
+40 | from airflow.hooks.subprocess import working_directory
    |
    = help: Install `apache-airflow-providers-standard>=0.0.3` and use `SubprocessResult` from `airflow.providers.standard.hooks.subprocess` instead.
 
 ℹ Unsafe fix
-48 48 | 
-49 49 | 
-50 50 | 
-51    |-from airflow.hooks.subprocess import SubprocessResult
-   51 |+from airflow.providers.standard.hooks.subprocess import SubprocessResult
-52 52 | SubprocessResult()
-53 53 | from airflow.hooks.subprocess import working_directory
-54 54 | working_directory()
+33 33 | ExternalTaskSensor()
+34 34 | 
+35 35 | 
+36    |-from airflow.hooks.subprocess import SubprocessResult
+   36 |+from airflow.providers.standard.hooks.subprocess import SubprocessResult
+37 37 | 
+38 38 | SubprocessResult()
+39 39 | 
 
-AIR302_standard.py:54:1: AIR302 [*] `airflow.hooks.subprocess.working_directory` is moved into `standard` provider in Airflow 3.0;
+AIR302_standard.py:42:1: AIR302 [*] `airflow.hooks.subprocess.working_directory` is moved into `standard` provider in Airflow 3.0;
    |
-52 | SubprocessResult()
-53 | from airflow.hooks.subprocess import working_directory
-54 | working_directory()
+40 | from airflow.hooks.subprocess import working_directory
+41 |
+42 | working_directory()
    | ^^^^^^^^^^^^^^^^^ AIR302
-55 | from airflow.operators.datetime import target_times_as_dates
-56 | target_times_as_dates()
+43 |
+44 | from airflow.operators.datetime import target_times_as_dates
    |
    = help: Install `apache-airflow-providers-standard>=0.0.3` and use `working_directory` from `airflow.providers.standard.hooks.subprocess` instead.
 
 ℹ Unsafe fix
-50 50 | 
-51 51 | from airflow.hooks.subprocess import SubprocessResult
-52 52 | SubprocessResult()
-53    |-from airflow.hooks.subprocess import working_directory
-   53 |+from airflow.providers.standard.hooks.subprocess import working_directory
-54 54 | working_directory()
-55 55 | from airflow.operators.datetime import target_times_as_dates
-56 56 | target_times_as_dates()
+37 37 | 
+38 38 | SubprocessResult()
+39 39 | 
+40    |-from airflow.hooks.subprocess import working_directory
+   40 |+from airflow.providers.standard.hooks.subprocess import working_directory
+41 41 | 
+42 42 | working_directory()
+43 43 | 
 
-AIR302_standard.py:56:1: AIR302 [*] `airflow.operators.datetime.target_times_as_dates` is moved into `standard` provider in Airflow 3.0;
+AIR302_standard.py:46:1: AIR302 [*] `airflow.operators.datetime.target_times_as_dates` is moved into `standard` provider in Airflow 3.0;
    |
-54 | working_directory()
-55 | from airflow.operators.datetime import target_times_as_dates
-56 | target_times_as_dates()
+44 | from airflow.operators.datetime import target_times_as_dates
+45 |
+46 | target_times_as_dates()
    | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-57 | from airflow.operators.trigger_dagrun import TriggerDagRunLink
-58 | TriggerDagRunLink()
+47 |
+48 | from airflow.operators.trigger_dagrun import TriggerDagRunLink
    |
    = help: Install `apache-airflow-providers-standard>=0.0.1` and use `target_times_as_dates` from `airflow.providers.standard.operators.datetime` instead.
 
 ℹ Unsafe fix
-52 52 | SubprocessResult()
-53 53 | from airflow.hooks.subprocess import working_directory
-54 54 | working_directory()
-55    |-from airflow.operators.datetime import target_times_as_dates
-   55 |+from airflow.providers.standard.operators.datetime import target_times_as_dates
-56 56 | target_times_as_dates()
-57 57 | from airflow.operators.trigger_dagrun import TriggerDagRunLink
-58 58 | TriggerDagRunLink()
+41 41 | 
+42 42 | working_directory()
+43 43 | 
+44    |-from airflow.operators.datetime import target_times_as_dates
+   44 |+from airflow.providers.standard.operators.datetime import target_times_as_dates
+45 45 | 
+46 46 | target_times_as_dates()
+47 47 | 
 
-AIR302_standard.py:58:1: AIR302 [*] `airflow.operators.trigger_dagrun.TriggerDagRunLink` is moved into `standard` provider in Airflow 3.0;
+AIR302_standard.py:50:1: AIR302 [*] `airflow.operators.trigger_dagrun.TriggerDagRunLink` is moved into `standard` provider in Airflow 3.0;
    |
-56 | target_times_as_dates()
-57 | from airflow.operators.trigger_dagrun import TriggerDagRunLink
-58 | TriggerDagRunLink()
+48 | from airflow.operators.trigger_dagrun import TriggerDagRunLink
+49 |
+50 | TriggerDagRunLink()
    | ^^^^^^^^^^^^^^^^^ AIR302
-59 | from airflow.sensors.external_task import ExternalTaskSensorLink
-60 | ExternalTaskSensorLink()
+51 |
+52 | from airflow.sensors.external_task import ExternalTaskSensorLink
    |
    = help: Install `apache-airflow-providers-standard>=0.0.2` and use `TriggerDagRunLink` from `airflow.providers.standard.operators.trigger_dagrun` instead.
 
 ℹ Unsafe fix
-54 54 | working_directory()
-55 55 | from airflow.operators.datetime import target_times_as_dates
-56 56 | target_times_as_dates()
-57    |-from airflow.operators.trigger_dagrun import TriggerDagRunLink
-   57 |+from airflow.providers.standard.operators.trigger_dagrun import TriggerDagRunLink
-58 58 | TriggerDagRunLink()
-59 59 | from airflow.sensors.external_task import ExternalTaskSensorLink
-60 60 | ExternalTaskSensorLink()
+45 45 | 
+46 46 | target_times_as_dates()
+47 47 | 
+48    |-from airflow.operators.trigger_dagrun import TriggerDagRunLink
+   48 |+from airflow.providers.standard.operators.trigger_dagrun import TriggerDagRunLink
+49 49 | 
+50 50 | TriggerDagRunLink()
+51 51 | 
 
-AIR302_standard.py:60:1: AIR302 [*] `airflow.sensors.external_task.ExternalTaskSensorLink` is moved into `standard` provider in Airflow 3.0;
+AIR302_standard.py:54:1: AIR302 [*] `airflow.sensors.external_task.ExternalTaskSensorLink` is moved into `standard` provider in Airflow 3.0;
    |
-58 | TriggerDagRunLink()
-59 | from airflow.sensors.external_task import ExternalTaskSensorLink
-60 | ExternalTaskSensorLink()
+52 | from airflow.sensors.external_task import ExternalTaskSensorLink
+53 |
+54 | ExternalTaskSensorLink()
    | ^^^^^^^^^^^^^^^^^^^^^^ AIR302
-61 | from airflow.sensors.time_delta import WaitSensor
-62 | WaitSensor()
+55 |
+56 | from airflow.sensors.time_delta import WaitSensor
    |
    = help: Install `apache-airflow-providers-standard>=0.0.3` and use `ExternalDagLink` from `airflow.providers.standard.sensors.external_task` instead.
 
 ℹ Safe fix
-57 57 | from airflow.operators.trigger_dagrun import TriggerDagRunLink
-58 58 | TriggerDagRunLink()
-59 59 | from airflow.sensors.external_task import ExternalTaskSensorLink
-60    |-ExternalTaskSensorLink()
-   60 |+from airflow.providers.standard.sensors.external_task import ExternalDagLink
-   61 |+ExternalDagLink()
-61 62 | from airflow.sensors.time_delta import WaitSensor
-62 63 | WaitSensor()
-63 64 | from airflow.operators.dummy import DummyOperator
+50 50 | TriggerDagRunLink()
+51 51 | 
+52 52 | from airflow.sensors.external_task import ExternalTaskSensorLink
+   53 |+from airflow.providers.standard.sensors.external_task import ExternalDagLink
+53 54 | 
+54    |-ExternalTaskSensorLink()
+   55 |+ExternalDagLink()
+55 56 | 
+56 57 | from airflow.sensors.time_delta import WaitSensor
+57 58 | 
 
-AIR302_standard.py:62:1: AIR302 [*] `airflow.sensors.time_delta.WaitSensor` is moved into `standard` provider in Airflow 3.0;
+AIR302_standard.py:58:1: AIR302 [*] `airflow.sensors.time_delta.WaitSensor` is moved into `standard` provider in Airflow 3.0;
    |
-60 | ExternalTaskSensorLink()
-61 | from airflow.sensors.time_delta import WaitSensor
-62 | WaitSensor()
+56 | from airflow.sensors.time_delta import WaitSensor
+57 |
+58 | WaitSensor()
    | ^^^^^^^^^^ AIR302
-63 | from airflow.operators.dummy import DummyOperator
-64 | DummyOperator()
+59 |
+60 | from airflow.operators.dummy import DummyOperator
    |
    = help: Install `apache-airflow-providers-standard>=0.0.1` and use `WaitSensor` from `airflow.providers.standard.sensors.time_delta` instead.
 
 ℹ Unsafe fix
-58 58 | TriggerDagRunLink()
-59 59 | from airflow.sensors.external_task import ExternalTaskSensorLink
-60 60 | ExternalTaskSensorLink()
-61    |-from airflow.sensors.time_delta import WaitSensor
-   61 |+from airflow.providers.standard.sensors.time_delta import WaitSensor
-62 62 | WaitSensor()
-63 63 | from airflow.operators.dummy import DummyOperator
-64 64 | DummyOperator()
+53 53 | 
+54 54 | ExternalTaskSensorLink()
+55 55 | 
+56    |-from airflow.sensors.time_delta import WaitSensor
+   56 |+from airflow.providers.standard.sensors.time_delta import WaitSensor
+57 57 | 
+58 58 | WaitSensor()
+59 59 | 
 
-AIR302_standard.py:64:1: AIR302 [*] `airflow.operators.dummy.DummyOperator` is moved into `standard` provider in Airflow 3.0;
+AIR302_standard.py:62:1: AIR302 [*] `airflow.operators.dummy.DummyOperator` is moved into `standard` provider in Airflow 3.0;
    |
-62 | WaitSensor()
-63 | from airflow.operators.dummy import DummyOperator
-64 | DummyOperator()
+60 | from airflow.operators.dummy import DummyOperator
+61 |
+62 | DummyOperator()
    | ^^^^^^^^^^^^^ AIR302
-65 | from airflow.operators.dummy import EmptyOperator
-66 | EmptyOperator()
+63 |
+64 | from airflow.operators.dummy import EmptyOperator
    |
    = help: Install `apache-airflow-providers-standard>=0.0.2` and use `EmptyOperator` from `airflow.providers.standard.operators.empty` instead.
 
 ℹ Safe fix
-61 61 | from airflow.sensors.time_delta import WaitSensor
-62 62 | WaitSensor()
-63 63 | from airflow.operators.dummy import DummyOperator
-64    |-DummyOperator()
-   64 |+from airflow.providers.standard.operators.empty import EmptyOperator
-   65 |+EmptyOperator()
-65 66 | from airflow.operators.dummy import EmptyOperator
-66 67 | EmptyOperator()
-67 68 | from airflow.operators.dummy_operator import DummyOperator
+58 58 | WaitSensor()
+59 59 | 
+60 60 | from airflow.operators.dummy import DummyOperator
+   61 |+from airflow.providers.standard.operators.empty import EmptyOperator
+61 62 | 
+62    |-DummyOperator()
+   63 |+EmptyOperator()
+63 64 | 
+64 65 | from airflow.operators.dummy import EmptyOperator
+65 66 | 
 
 AIR302_standard.py:66:1: AIR302 [*] `airflow.operators.dummy.EmptyOperator` is moved into `standard` provider in Airflow 3.0;
    |
-64 | DummyOperator()
-65 | from airflow.operators.dummy import EmptyOperator
+64 | from airflow.operators.dummy import EmptyOperator
+65 |
 66 | EmptyOperator()
    | ^^^^^^^^^^^^^ AIR302
-67 | from airflow.operators.dummy_operator import DummyOperator
-68 | DummyOperator()
+67 |
+68 | from airflow.operators.dummy_operator import DummyOperator
    |
    = help: Install `apache-airflow-providers-standard>=0.0.2` and use `EmptyOperator` from `airflow.providers.standard.operators.empty` instead.
 
 ℹ Unsafe fix
-62 62 | WaitSensor()
-63 63 | from airflow.operators.dummy import DummyOperator
-64 64 | DummyOperator()
-65    |-from airflow.operators.dummy import EmptyOperator
-   65 |+from airflow.providers.standard.operators.empty import EmptyOperator
+61 61 | 
+62 62 | DummyOperator()
+63 63 | 
+64    |-from airflow.operators.dummy import EmptyOperator
+   64 |+from airflow.providers.standard.operators.empty import EmptyOperator
+65 65 | 
 66 66 | EmptyOperator()
-67 67 | from airflow.operators.dummy_operator import DummyOperator
-68 68 | DummyOperator()
+67 67 | 
 
-AIR302_standard.py:68:1: AIR302 [*] `airflow.operators.dummy_operator.DummyOperator` is moved into `standard` provider in Airflow 3.0;
+AIR302_standard.py:70:1: AIR302 [*] `airflow.operators.dummy_operator.DummyOperator` is moved into `standard` provider in Airflow 3.0;
    |
-66 | EmptyOperator()
-67 | from airflow.operators.dummy_operator import DummyOperator
-68 | DummyOperator()
+68 | from airflow.operators.dummy_operator import DummyOperator
+69 |
+70 | DummyOperator()
    | ^^^^^^^^^^^^^ AIR302
-69 | from airflow.operators.dummy_operator import EmptyOperator
-70 | EmptyOperator()
-   |
-   = help: Install `apache-airflow-providers-standard>=0.0.2` and use `EmptyOperator` from `airflow.providers.standard.operators.empty` instead.
-
-ℹ Unsafe fix
-65 65 | from airflow.operators.dummy import EmptyOperator
-66 66 | EmptyOperator()
-67 67 | from airflow.operators.dummy_operator import DummyOperator
-   68 |+from airflow.providers.standard.operators.empty import EmptyOperator
-68 69 | DummyOperator()
-69 70 | from airflow.operators.dummy_operator import EmptyOperator
-70 71 | EmptyOperator()
-
-AIR302_standard.py:70:1: AIR302 [*] `airflow.operators.dummy_operator.EmptyOperator` is moved into `standard` provider in Airflow 3.0;
-   |
-68 | DummyOperator()
-69 | from airflow.operators.dummy_operator import EmptyOperator
-70 | EmptyOperator()
-   | ^^^^^^^^^^^^^ AIR302
-71 | from airflow.sensors.external_task_sensor import ExternalTaskSensorLink
-72 | ExternalTaskSensorLink()
+71 |
+72 | from airflow.operators.dummy_operator import EmptyOperator
    |
    = help: Install `apache-airflow-providers-standard>=0.0.2` and use `EmptyOperator` from `airflow.providers.standard.operators.empty` instead.
 
 ℹ Unsafe fix
 66 66 | EmptyOperator()
-67 67 | from airflow.operators.dummy_operator import DummyOperator
-68 68 | DummyOperator()
-69    |-from airflow.operators.dummy_operator import EmptyOperator
+67 67 | 
+68 68 | from airflow.operators.dummy_operator import DummyOperator
    69 |+from airflow.providers.standard.operators.empty import EmptyOperator
-70 70 | EmptyOperator()
-71 71 | from airflow.sensors.external_task_sensor import ExternalTaskSensorLink
-72 72 | ExternalTaskSensorLink()
+69 70 | 
+70 71 | DummyOperator()
+71 72 | 
 
-AIR302_standard.py:72:1: AIR302 [*] `airflow.sensors.external_task_sensor.ExternalTaskSensorLink` is moved into `standard` provider in Airflow 3.0;
+AIR302_standard.py:74:1: AIR302 [*] `airflow.operators.dummy_operator.EmptyOperator` is moved into `standard` provider in Airflow 3.0;
    |
-70 | EmptyOperator()
-71 | from airflow.sensors.external_task_sensor import ExternalTaskSensorLink
-72 | ExternalTaskSensorLink()
+72 | from airflow.operators.dummy_operator import EmptyOperator
+73 |
+74 | EmptyOperator()
+   | ^^^^^^^^^^^^^ AIR302
+75 |
+76 | from airflow.sensors.external_task_sensor import ExternalTaskSensorLink
+   |
+   = help: Install `apache-airflow-providers-standard>=0.0.2` and use `EmptyOperator` from `airflow.providers.standard.operators.empty` instead.
+
+ℹ Unsafe fix
+69 69 | 
+70 70 | DummyOperator()
+71 71 | 
+72    |-from airflow.operators.dummy_operator import EmptyOperator
+   72 |+from airflow.providers.standard.operators.empty import EmptyOperator
+73 73 | 
+74 74 | EmptyOperator()
+75 75 | 
+
+AIR302_standard.py:78:1: AIR302 [*] `airflow.sensors.external_task_sensor.ExternalTaskSensorLink` is moved into `standard` provider in Airflow 3.0;
+   |
+76 | from airflow.sensors.external_task_sensor import ExternalTaskSensorLink
+77 |
+78 | ExternalTaskSensorLink()
    | ^^^^^^^^^^^^^^^^^^^^^^ AIR302
    |
    = help: Install `apache-airflow-providers-standard>=0.0.3` and use `ExternalTaskSensorLink` from `airflow.providers.standard.sensors.external_task` instead.
 
 ℹ Unsafe fix
-68 68 | DummyOperator()
-69 69 | from airflow.operators.dummy_operator import EmptyOperator
-70 70 | EmptyOperator()
-71    |-from airflow.sensors.external_task_sensor import ExternalTaskSensorLink
-   71 |+from airflow.providers.standard.sensors.external_task import ExternalTaskSensorLink
-72 72 | ExternalTaskSensorLink()
+73 73 | 
+74 74 | EmptyOperator()
+75 75 | 
+76    |-from airflow.sensors.external_task_sensor import ExternalTaskSensorLink
+   76 |+from airflow.providers.standard.sensors.external_task import ExternalTaskSensorLink
+77 77 | 
+78 78 | ExternalTaskSensorLink()

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_standard.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_standard.py.snap
@@ -478,13 +478,13 @@ AIR302_standard.py:78:1: AIR302 [*] `airflow.sensors.external_task_sensor.Extern
 78 | ExternalTaskSensorLink()
    | ^^^^^^^^^^^^^^^^^^^^^^ AIR302
    |
-   = help: Install `apache-airflow-providers-standard>=0.0.3` and use `ExternalTaskSensorLink` from `airflow.providers.standard.sensors.external_task` instead.
+   = help: Install `apache-airflow-providers-standard>=0.0.3` and use `ExternalDagLink` from `airflow.providers.standard.sensors.external_task` instead.
 
-ℹ Unsafe fix
-73 73 | 
+ℹ Safe fix
 74 74 | EmptyOperator()
 75 75 | 
-76    |-from airflow.sensors.external_task_sensor import ExternalTaskSensorLink
-   76 |+from airflow.providers.standard.sensors.external_task import ExternalTaskSensorLink
-77 77 | 
-78 78 | ExternalTaskSensorLink()
+76 76 | from airflow.sensors.external_task_sensor import ExternalTaskSensorLink
+   77 |+from airflow.providers.standard.sensors.external_task import ExternalDagLink
+77 78 | 
+78    |-ExternalTaskSensorLink()
+   79 |+ExternalDagLink()

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_standard.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_standard.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 ---
-AIR302_standard.py:25:1: AIR302 `airflow.operators.bash_operator.BashOperator` is moved into `standard` provider in Airflow 3.0;
+AIR302_standard.py:25:1: AIR302 [*] `airflow.operators.bash_operator.BashOperator` is moved into `standard` provider in Airflow 3.0;
    |
 23 | )
 24 |
@@ -12,52 +12,76 @@ AIR302_standard.py:25:1: AIR302 `airflow.operators.bash_operator.BashOperator` i
    |
    = help: Install `apache-airflow-providers-standard>=0.0.1` and use `BashOperator` from `airflow.providers.standard.operators.bash` instead.
 
-AIR302_standard.py:27:1: AIR302 `airflow.operators.dagrun_operator.TriggerDagRunLink` is moved into `standard` provider in Airflow 3.0;
+ℹ Unsafe fix
+1  1  | from __future__ import annotations
+2  2  | 
+3     |-from airflow.operators.bash_operator import BashOperator
+4  3  | from airflow.operators.dagrun_operator import (
+5  4  |     TriggerDagRunLink,
+6  5  |     TriggerDagRunOperator,
+--------------------------------------------------------------------------------
+21 20 |     ExternalTaskSensor,
+22 21 | 
+23 22 | )
+   23 |+from airflow.providers.standard.operators.bash import BashOperator
+24 24 | 
+25 25 | BashOperator()
+26 26 | 
+
+AIR302_standard.py:27:1: AIR302 [*] `airflow.operators.dagrun_operator.TriggerDagRunLink` is moved into `standard` provider in Airflow 3.0;
    |
 25 | BashOperator()
 26 |
 27 | TriggerDagRunLink()
    | ^^^^^^^^^^^^^^^^^ AIR302
 28 | TriggerDagRunOperator()
-29 | DummyOperator()
    |
    = help: Install `apache-airflow-providers-standard>=0.0.2` and use `TriggerDagRunLink` from `airflow.providers.standard.operators.trigger_dagrun` instead.
 
-AIR302_standard.py:28:1: AIR302 `airflow.operators.dagrun_operator.TriggerDagRunOperator` is moved into `standard` provider in Airflow 3.0;
+ℹ Unsafe fix
+2  2  | 
+3  3  | from airflow.operators.bash_operator import BashOperator
+4  4  | from airflow.operators.dagrun_operator import (
+5     |-    TriggerDagRunLink,
+6  5  |     TriggerDagRunOperator,
+7  6  | )
+8  7  | 
+--------------------------------------------------------------------------------
+21 20 |     ExternalTaskSensor,
+22 21 | 
+23 22 | )
+   23 |+from airflow.providers.standard.operators.trigger_dagrun import TriggerDagRunLink
+24 24 | 
+25 25 | BashOperator()
+26 26 | 
+
+AIR302_standard.py:28:1: AIR302 [*] `airflow.operators.dagrun_operator.TriggerDagRunOperator` is moved into `standard` provider in Airflow 3.0;
    |
 27 | TriggerDagRunLink()
 28 | TriggerDagRunOperator()
    | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-29 | DummyOperator()
-30 | EmptyOperator()
    |
    = help: Install `apache-airflow-providers-standard>=0.0.2` and use `TriggerDagRunOperator` from `airflow.providers.standard.operators.trigger_dagrun` instead.
 
-AIR302_standard.py:29:1: AIR302 `airflow.operators.dummy.DummyOperator` is moved into `standard` provider in Airflow 3.0;
-   |
-27 | TriggerDagRunLink()
-28 | TriggerDagRunOperator()
-29 | DummyOperator()
-   | ^^^^^^^^^^^^^ AIR302
-30 | EmptyOperator()
-   |
-   = help: Install `apache-airflow-providers-standard>=0.0.2` and use `EmptyOperator` from `airflow.providers.standard.operators.empty` instead.
+ℹ Unsafe fix
+3  3  | from airflow.operators.bash_operator import BashOperator
+4  4  | from airflow.operators.dagrun_operator import (
+5  5  |     TriggerDagRunLink,
+6     |-    TriggerDagRunOperator,
+7  6  | )
+8  7  | 
+9  8  | 
+--------------------------------------------------------------------------------
+21 20 |     ExternalTaskSensor,
+22 21 | 
+23 22 | )
+   23 |+from airflow.providers.standard.operators.trigger_dagrun import TriggerDagRunOperator
+24 24 | 
+25 25 | BashOperator()
+26 26 | 
 
-AIR302_standard.py:30:1: AIR302 `airflow.operators.dummy.EmptyOperator` is moved into `standard` provider in Airflow 3.0;
+AIR302_standard.py:32:1: AIR302 [*] `airflow.operators.latest_only_operator.LatestOnlyOperator` is moved into `standard` provider in Airflow 3.0;
    |
-28 | TriggerDagRunOperator()
-29 | DummyOperator()
-30 | EmptyOperator()
-   | ^^^^^^^^^^^^^ AIR302
-31 |
-32 | LatestOnlyOperator()
-   |
-   = help: Install `apache-airflow-providers-standard>=0.0.2` and use `EmptyOperator` from `airflow.providers.standard.operators.empty` instead.
-
-AIR302_standard.py:32:1: AIR302 `airflow.operators.latest_only_operator.LatestOnlyOperator` is moved into `standard` provider in Airflow 3.0;
-   |
-30 | EmptyOperator()
-31 |
 32 | LatestOnlyOperator()
    | ^^^^^^^^^^^^^^^^^^ AIR302
 33 |
@@ -65,7 +89,24 @@ AIR302_standard.py:32:1: AIR302 `airflow.operators.latest_only_operator.LatestOn
    |
    = help: Install `apache-airflow-providers-standard>=0.0.3` and use `LatestOnlyOperator` from `airflow.providers.standard.operators.latest_only` instead.
 
-AIR302_standard.py:34:1: AIR302 `airflow.operators.python_operator.BranchPythonOperator` is moved into `standard` provider in Airflow 3.0;
+ℹ Unsafe fix
+9  9  | 
+10 10 | 
+11 11 | 
+12    |-from airflow.operators.latest_only_operator import LatestOnlyOperator
+13 12 | from airflow.operators.python_operator import (
+14 13 |     BranchPythonOperator,
+15 14 |     PythonOperator,
+--------------------------------------------------------------------------------
+21 20 |     ExternalTaskSensor,
+22 21 | 
+23 22 | )
+   23 |+from airflow.providers.standard.operators.latest_only import LatestOnlyOperator
+24 24 | 
+25 25 | BashOperator()
+26 26 | 
+
+AIR302_standard.py:34:1: AIR302 [*] `airflow.operators.python_operator.BranchPythonOperator` is moved into `standard` provider in Airflow 3.0;
    |
 32 | LatestOnlyOperator()
 33 |
@@ -76,7 +117,24 @@ AIR302_standard.py:34:1: AIR302 `airflow.operators.python_operator.BranchPythonO
    |
    = help: Install `apache-airflow-providers-standard>=0.0.1` and use `BranchPythonOperator` from `airflow.providers.standard.operators.python` instead.
 
-AIR302_standard.py:35:1: AIR302 `airflow.operators.python_operator.PythonOperator` is moved into `standard` provider in Airflow 3.0;
+ℹ Unsafe fix
+11 11 | 
+12 12 | from airflow.operators.latest_only_operator import LatestOnlyOperator
+13 13 | from airflow.operators.python_operator import (
+14    |-    BranchPythonOperator,
+15 14 |     PythonOperator,
+16 15 |     PythonVirtualenvOperator,
+17 16 |     ShortCircuitOperator,
+--------------------------------------------------------------------------------
+21 20 |     ExternalTaskSensor,
+22 21 | 
+23 22 | )
+   23 |+from airflow.providers.standard.operators.python import BranchPythonOperator
+24 24 | 
+25 25 | BashOperator()
+26 26 | 
+
+AIR302_standard.py:35:1: AIR302 [*] `airflow.operators.python_operator.PythonOperator` is moved into `standard` provider in Airflow 3.0;
    |
 34 | BranchPythonOperator()
 35 | PythonOperator()
@@ -86,7 +144,24 @@ AIR302_standard.py:35:1: AIR302 `airflow.operators.python_operator.PythonOperato
    |
    = help: Install `apache-airflow-providers-standard>=0.0.1` and use `PythonOperator` from `airflow.providers.standard.operators.python` instead.
 
-AIR302_standard.py:36:1: AIR302 `airflow.operators.python_operator.PythonVirtualenvOperator` is moved into `standard` provider in Airflow 3.0;
+ℹ Unsafe fix
+12 12 | from airflow.operators.latest_only_operator import LatestOnlyOperator
+13 13 | from airflow.operators.python_operator import (
+14 14 |     BranchPythonOperator,
+15    |-    PythonOperator,
+16 15 |     PythonVirtualenvOperator,
+17 16 |     ShortCircuitOperator,
+18 17 | )
+--------------------------------------------------------------------------------
+21 20 |     ExternalTaskSensor,
+22 21 | 
+23 22 | )
+   23 |+from airflow.providers.standard.operators.python import PythonOperator
+24 24 | 
+25 25 | BashOperator()
+26 26 | 
+
+AIR302_standard.py:36:1: AIR302 [*] `airflow.operators.python_operator.PythonVirtualenvOperator` is moved into `standard` provider in Airflow 3.0;
    |
 34 | BranchPythonOperator()
 35 | PythonOperator()
@@ -96,7 +171,24 @@ AIR302_standard.py:36:1: AIR302 `airflow.operators.python_operator.PythonVirtual
    |
    = help: Install `apache-airflow-providers-standard>=0.0.1` and use `PythonVirtualenvOperator` from `airflow.providers.standard.operators.python` instead.
 
-AIR302_standard.py:37:1: AIR302 `airflow.operators.python_operator.ShortCircuitOperator` is moved into `standard` provider in Airflow 3.0;
+ℹ Unsafe fix
+13 13 | from airflow.operators.python_operator import (
+14 14 |     BranchPythonOperator,
+15 15 |     PythonOperator,
+16    |-    PythonVirtualenvOperator,
+17 16 |     ShortCircuitOperator,
+18 17 | )
+19 18 | from airflow.sensors.external_task_sensor import (
+--------------------------------------------------------------------------------
+21 20 |     ExternalTaskSensor,
+22 21 | 
+23 22 | )
+   23 |+from airflow.providers.standard.operators.python import PythonVirtualenvOperator
+24 24 | 
+25 25 | BashOperator()
+26 26 | 
+
+AIR302_standard.py:37:1: AIR302 [*] `airflow.operators.python_operator.ShortCircuitOperator` is moved into `standard` provider in Airflow 3.0;
    |
 35 | PythonOperator()
 36 | PythonVirtualenvOperator()
@@ -107,58 +199,66 @@ AIR302_standard.py:37:1: AIR302 `airflow.operators.python_operator.ShortCircuitO
    |
    = help: Install `apache-airflow-providers-standard>=0.0.1` and use `ShortCircuitOperator` from `airflow.providers.standard.operators.python` instead.
 
-AIR302_standard.py:39:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskMarker` is moved into `standard` provider in Airflow 3.0;
+ℹ Unsafe fix
+14 14 |     BranchPythonOperator,
+15 15 |     PythonOperator,
+16 16 |     PythonVirtualenvOperator,
+17    |-    ShortCircuitOperator,
+18 17 | )
+19 18 | from airflow.sensors.external_task_sensor import (
+20 19 |     ExternalTaskMarker,
+21 20 |     ExternalTaskSensor,
+22 21 | 
+23 22 | )
+   23 |+from airflow.providers.standard.operators.python import ShortCircuitOperator
+24 24 | 
+25 25 | BashOperator()
+26 26 | 
+
+AIR302_standard.py:39:1: AIR302 [*] `airflow.sensors.external_task_sensor.ExternalTaskMarker` is moved into `standard` provider in Airflow 3.0;
    |
 37 | ShortCircuitOperator()
 38 |
 39 | ExternalTaskMarker()
    | ^^^^^^^^^^^^^^^^^^ AIR302
 40 | ExternalTaskSensor()
-41 | ExternalTaskSensorLink()
    |
    = help: Install `apache-airflow-providers-standard>=0.0.3` and use `ExternalTaskMarker` from `airflow.providers.standard.sensors.external_task` instead.
 
-AIR302_standard.py:40:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensor` is moved into `standard` provider in Airflow 3.0;
+ℹ Unsafe fix
+17 17 |     ShortCircuitOperator,
+18 18 | )
+19 19 | from airflow.sensors.external_task_sensor import (
+20    |-    ExternalTaskMarker,
+21 20 |     ExternalTaskSensor,
+22 21 | 
+23 22 | )
+   23 |+from airflow.providers.standard.sensors.external_task import ExternalTaskMarker
+24 24 | 
+25 25 | BashOperator()
+26 26 | 
+
+AIR302_standard.py:40:1: AIR302 [*] `airflow.sensors.external_task_sensor.ExternalTaskSensor` is moved into `standard` provider in Airflow 3.0;
    |
 39 | ExternalTaskMarker()
 40 | ExternalTaskSensor()
    | ^^^^^^^^^^^^^^^^^^ AIR302
-41 | ExternalTaskSensorLink()
    |
    = help: Install `apache-airflow-providers-standard>=0.0.3` and use `ExternalTaskSensor` from `airflow.providers.standard.sensors.external_task` instead.
 
-AIR302_standard.py:41:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensorLink` is moved into `standard` provider in Airflow 3.0;
-   |
-39 | ExternalTaskMarker()
-40 | ExternalTaskSensor()
-41 | ExternalTaskSensorLink()
-   | ^^^^^^^^^^^^^^^^^^^^^^ AIR302
-42 |
-43 | from airflow.operators.dummy_operator import (
-   |
-   = help: Install `apache-airflow-providers-standard>=0.0.3` and use `ExternalTaskSensorLink` from `airflow.providers.standard.sensors.external_task` instead.
+ℹ Unsafe fix
+18 18 | )
+19 19 | from airflow.sensors.external_task_sensor import (
+20 20 |     ExternalTaskMarker,
+21    |-    ExternalTaskSensor,
+22 21 | 
+23 22 | )
+   23 |+from airflow.providers.standard.sensors.external_task import ExternalTaskSensor
+24 24 | 
+25 25 | BashOperator()
+26 26 | 
 
-AIR302_standard.py:48:1: AIR302 `airflow.operators.dummy_operator.DummyOperator` is moved into `standard` provider in Airflow 3.0;
-   |
-46 | )
-47 |
-48 | DummyOperator()
-   | ^^^^^^^^^^^^^ AIR302
-49 | EmptyOperator()
-   |
-   = help: Install `apache-airflow-providers-standard>=0.0.2` and use `EmptyOperator` from `airflow.providers.standard.operators.empty` instead.
-
-AIR302_standard.py:49:1: AIR302 `airflow.operators.dummy_operator.EmptyOperator` is moved into `standard` provider in Airflow 3.0;
-   |
-48 | DummyOperator()
-49 | EmptyOperator()
-   | ^^^^^^^^^^^^^ AIR302
-50 |
-51 | from airflow.hooks.subprocess import SubprocessResult
-   |
-   = help: Install `apache-airflow-providers-standard>=0.0.2` and use `EmptyOperator` from `airflow.providers.standard.operators.empty` instead.
-
-AIR302_standard.py:52:1: AIR302 `airflow.hooks.subprocess.SubprocessResult` is moved into `standard` provider in Airflow 3.0;
+AIR302_standard.py:52:1: AIR302 [*] `airflow.hooks.subprocess.SubprocessResult` is moved into `standard` provider in Airflow 3.0;
    |
 51 | from airflow.hooks.subprocess import SubprocessResult
 52 | SubprocessResult()
@@ -168,7 +268,17 @@ AIR302_standard.py:52:1: AIR302 `airflow.hooks.subprocess.SubprocessResult` is m
    |
    = help: Install `apache-airflow-providers-standard>=0.0.3` and use `SubprocessResult` from `airflow.providers.standard.hooks.subprocess` instead.
 
-AIR302_standard.py:54:1: AIR302 `airflow.hooks.subprocess.working_directory` is moved into `standard` provider in Airflow 3.0;
+ℹ Unsafe fix
+48 48 | 
+49 49 | 
+50 50 | 
+51    |-from airflow.hooks.subprocess import SubprocessResult
+   51 |+from airflow.providers.standard.hooks.subprocess import SubprocessResult
+52 52 | SubprocessResult()
+53 53 | from airflow.hooks.subprocess import working_directory
+54 54 | working_directory()
+
+AIR302_standard.py:54:1: AIR302 [*] `airflow.hooks.subprocess.working_directory` is moved into `standard` provider in Airflow 3.0;
    |
 52 | SubprocessResult()
 53 | from airflow.hooks.subprocess import working_directory
@@ -179,7 +289,17 @@ AIR302_standard.py:54:1: AIR302 `airflow.hooks.subprocess.working_directory` is 
    |
    = help: Install `apache-airflow-providers-standard>=0.0.3` and use `working_directory` from `airflow.providers.standard.hooks.subprocess` instead.
 
-AIR302_standard.py:56:1: AIR302 `airflow.operators.datetime.target_times_as_dates` is moved into `standard` provider in Airflow 3.0;
+ℹ Unsafe fix
+50 50 | 
+51 51 | from airflow.hooks.subprocess import SubprocessResult
+52 52 | SubprocessResult()
+53    |-from airflow.hooks.subprocess import working_directory
+   53 |+from airflow.providers.standard.hooks.subprocess import working_directory
+54 54 | working_directory()
+55 55 | from airflow.operators.datetime import target_times_as_dates
+56 56 | target_times_as_dates()
+
+AIR302_standard.py:56:1: AIR302 [*] `airflow.operators.datetime.target_times_as_dates` is moved into `standard` provider in Airflow 3.0;
    |
 54 | working_directory()
 55 | from airflow.operators.datetime import target_times_as_dates
@@ -190,7 +310,17 @@ AIR302_standard.py:56:1: AIR302 `airflow.operators.datetime.target_times_as_date
    |
    = help: Install `apache-airflow-providers-standard>=0.0.1` and use `target_times_as_dates` from `airflow.providers.standard.operators.datetime` instead.
 
-AIR302_standard.py:58:1: AIR302 `airflow.operators.trigger_dagrun.TriggerDagRunLink` is moved into `standard` provider in Airflow 3.0;
+ℹ Unsafe fix
+52 52 | SubprocessResult()
+53 53 | from airflow.hooks.subprocess import working_directory
+54 54 | working_directory()
+55    |-from airflow.operators.datetime import target_times_as_dates
+   55 |+from airflow.providers.standard.operators.datetime import target_times_as_dates
+56 56 | target_times_as_dates()
+57 57 | from airflow.operators.trigger_dagrun import TriggerDagRunLink
+58 58 | TriggerDagRunLink()
+
+AIR302_standard.py:58:1: AIR302 [*] `airflow.operators.trigger_dagrun.TriggerDagRunLink` is moved into `standard` provider in Airflow 3.0;
    |
 56 | target_times_as_dates()
 57 | from airflow.operators.trigger_dagrun import TriggerDagRunLink
@@ -200,6 +330,16 @@ AIR302_standard.py:58:1: AIR302 `airflow.operators.trigger_dagrun.TriggerDagRunL
 60 | ExternalTaskSensorLink()
    |
    = help: Install `apache-airflow-providers-standard>=0.0.2` and use `TriggerDagRunLink` from `airflow.providers.standard.operators.trigger_dagrun` instead.
+
+ℹ Unsafe fix
+54 54 | working_directory()
+55 55 | from airflow.operators.datetime import target_times_as_dates
+56 56 | target_times_as_dates()
+57    |-from airflow.operators.trigger_dagrun import TriggerDagRunLink
+   57 |+from airflow.providers.standard.operators.trigger_dagrun import TriggerDagRunLink
+58 58 | TriggerDagRunLink()
+59 59 | from airflow.sensors.external_task import ExternalTaskSensorLink
+60 60 | ExternalTaskSensorLink()
 
 AIR302_standard.py:60:1: AIR302 [*] `airflow.sensors.external_task.ExternalTaskSensorLink` is moved into `standard` provider in Airflow 3.0;
    |
@@ -221,12 +361,126 @@ AIR302_standard.py:60:1: AIR302 [*] `airflow.sensors.external_task.ExternalTaskS
    61 |+ExternalDagLink()
 61 62 | from airflow.sensors.time_delta import WaitSensor
 62 63 | WaitSensor()
+63 64 | from airflow.operators.dummy import DummyOperator
 
-AIR302_standard.py:62:1: AIR302 `airflow.sensors.time_delta.WaitSensor` is moved into `standard` provider in Airflow 3.0;
+AIR302_standard.py:62:1: AIR302 [*] `airflow.sensors.time_delta.WaitSensor` is moved into `standard` provider in Airflow 3.0;
    |
 60 | ExternalTaskSensorLink()
 61 | from airflow.sensors.time_delta import WaitSensor
 62 | WaitSensor()
    | ^^^^^^^^^^ AIR302
+63 | from airflow.operators.dummy import DummyOperator
+64 | DummyOperator()
    |
    = help: Install `apache-airflow-providers-standard>=0.0.1` and use `WaitSensor` from `airflow.providers.standard.sensors.time_delta` instead.
+
+ℹ Unsafe fix
+58 58 | TriggerDagRunLink()
+59 59 | from airflow.sensors.external_task import ExternalTaskSensorLink
+60 60 | ExternalTaskSensorLink()
+61    |-from airflow.sensors.time_delta import WaitSensor
+   61 |+from airflow.providers.standard.sensors.time_delta import WaitSensor
+62 62 | WaitSensor()
+63 63 | from airflow.operators.dummy import DummyOperator
+64 64 | DummyOperator()
+
+AIR302_standard.py:64:1: AIR302 [*] `airflow.operators.dummy.DummyOperator` is moved into `standard` provider in Airflow 3.0;
+   |
+62 | WaitSensor()
+63 | from airflow.operators.dummy import DummyOperator
+64 | DummyOperator()
+   | ^^^^^^^^^^^^^ AIR302
+65 | from airflow.operators.dummy import EmptyOperator
+66 | EmptyOperator()
+   |
+   = help: Install `apache-airflow-providers-standard>=0.0.2` and use `EmptyOperator` from `airflow.providers.standard.operators.empty` instead.
+
+ℹ Safe fix
+61 61 | from airflow.sensors.time_delta import WaitSensor
+62 62 | WaitSensor()
+63 63 | from airflow.operators.dummy import DummyOperator
+64    |-DummyOperator()
+   64 |+from airflow.providers.standard.operators.empty import EmptyOperator
+   65 |+EmptyOperator()
+65 66 | from airflow.operators.dummy import EmptyOperator
+66 67 | EmptyOperator()
+67 68 | from airflow.operators.dummy_operator import DummyOperator
+
+AIR302_standard.py:66:1: AIR302 [*] `airflow.operators.dummy.EmptyOperator` is moved into `standard` provider in Airflow 3.0;
+   |
+64 | DummyOperator()
+65 | from airflow.operators.dummy import EmptyOperator
+66 | EmptyOperator()
+   | ^^^^^^^^^^^^^ AIR302
+67 | from airflow.operators.dummy_operator import DummyOperator
+68 | DummyOperator()
+   |
+   = help: Install `apache-airflow-providers-standard>=0.0.2` and use `EmptyOperator` from `airflow.providers.standard.operators.empty` instead.
+
+ℹ Unsafe fix
+62 62 | WaitSensor()
+63 63 | from airflow.operators.dummy import DummyOperator
+64 64 | DummyOperator()
+65    |-from airflow.operators.dummy import EmptyOperator
+   65 |+from airflow.providers.standard.operators.empty import EmptyOperator
+66 66 | EmptyOperator()
+67 67 | from airflow.operators.dummy_operator import DummyOperator
+68 68 | DummyOperator()
+
+AIR302_standard.py:68:1: AIR302 [*] `airflow.operators.dummy_operator.DummyOperator` is moved into `standard` provider in Airflow 3.0;
+   |
+66 | EmptyOperator()
+67 | from airflow.operators.dummy_operator import DummyOperator
+68 | DummyOperator()
+   | ^^^^^^^^^^^^^ AIR302
+69 | from airflow.operators.dummy_operator import EmptyOperator
+70 | EmptyOperator()
+   |
+   = help: Install `apache-airflow-providers-standard>=0.0.2` and use `EmptyOperator` from `airflow.providers.standard.operators.empty` instead.
+
+ℹ Unsafe fix
+65 65 | from airflow.operators.dummy import EmptyOperator
+66 66 | EmptyOperator()
+67 67 | from airflow.operators.dummy_operator import DummyOperator
+   68 |+from airflow.providers.standard.operators.empty import EmptyOperator
+68 69 | DummyOperator()
+69 70 | from airflow.operators.dummy_operator import EmptyOperator
+70 71 | EmptyOperator()
+
+AIR302_standard.py:70:1: AIR302 [*] `airflow.operators.dummy_operator.EmptyOperator` is moved into `standard` provider in Airflow 3.0;
+   |
+68 | DummyOperator()
+69 | from airflow.operators.dummy_operator import EmptyOperator
+70 | EmptyOperator()
+   | ^^^^^^^^^^^^^ AIR302
+71 | from airflow.sensors.external_task_sensor import ExternalTaskSensorLink
+72 | ExternalTaskSensorLink()
+   |
+   = help: Install `apache-airflow-providers-standard>=0.0.2` and use `EmptyOperator` from `airflow.providers.standard.operators.empty` instead.
+
+ℹ Unsafe fix
+66 66 | EmptyOperator()
+67 67 | from airflow.operators.dummy_operator import DummyOperator
+68 68 | DummyOperator()
+69    |-from airflow.operators.dummy_operator import EmptyOperator
+   69 |+from airflow.providers.standard.operators.empty import EmptyOperator
+70 70 | EmptyOperator()
+71 71 | from airflow.sensors.external_task_sensor import ExternalTaskSensorLink
+72 72 | ExternalTaskSensorLink()
+
+AIR302_standard.py:72:1: AIR302 [*] `airflow.sensors.external_task_sensor.ExternalTaskSensorLink` is moved into `standard` provider in Airflow 3.0;
+   |
+70 | EmptyOperator()
+71 | from airflow.sensors.external_task_sensor import ExternalTaskSensorLink
+72 | ExternalTaskSensorLink()
+   | ^^^^^^^^^^^^^^^^^^^^^^ AIR302
+   |
+   = help: Install `apache-airflow-providers-standard>=0.0.3` and use `ExternalTaskSensorLink` from `airflow.providers.standard.sensors.external_task` instead.
+
+ℹ Unsafe fix
+68 68 | DummyOperator()
+69 69 | from airflow.operators.dummy_operator import EmptyOperator
+70 70 | EmptyOperator()
+71    |-from airflow.sensors.external_task_sensor import ExternalTaskSensorLink
+   71 |+from airflow.providers.standard.sensors.external_task import ExternalTaskSensorLink
+72 72 | ExternalTaskSensorLink()

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_zendesk.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_zendesk.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 ---
-AIR302_zendesk.py:5:1: AIR302 `airflow.hooks.zendesk_hook.ZendeskHook` is moved into `zendesk` provider in Airflow 3.0;
+AIR302_zendesk.py:5:1: AIR302 [*] `airflow.hooks.zendesk_hook.ZendeskHook` is moved into `zendesk` provider in Airflow 3.0;
   |
 3 | from airflow.hooks.zendesk_hook import ZendeskHook
 4 |
@@ -9,3 +9,11 @@ AIR302_zendesk.py:5:1: AIR302 `airflow.hooks.zendesk_hook.ZendeskHook` is moved 
   | ^^^^^^^^^^^ AIR302
   |
   = help: Install `apache-airflow-providers-zendesk>=1.0.0` and use `ZendeskHook` from `airflow.providers.zendesk.hooks.zendesk` instead.
+
+ℹ Unsafe fix
+1 1 | from __future__ import annotations
+2 2 | 
+3   |-from airflow.hooks.zendesk_hook import ZendeskHook
+  3 |+from airflow.providers.zendesk.hooks.zendesk import ZendeskHook
+4 4 | 
+5 5 | ZendeskHook()


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Add utility functions `generate_import_edit` and `generate_remove_and_runtime_import_edit` to generate the fix needed for the airflow rules.

1. `generate_import_edit` is for the cases where the member name has changed. (e.g., `airflow.datasts.Dataset` to `airflow.sdk.Asset`) It's just extracted from the original logic
2. `generate_remove_and_runtime_import_edit` is for cases where the member name has not changed. (e.g., `airflow.operators.pig_operator.PigOperator` to `airflow.providers.apache.pig.hooks.pig.PigCliHook`) This is newly introduced. As it introduced runtime import, I mark it as an unsafe fix. Under the hook, it tried to find the original import statement, remove it, and add a new import fix

---

* rules fix
    * `airflow.sensors.external_task_sensor.ExternalTaskSensorLink` → `airflow.providers.standard.sensors.external_task.ExternalDagLink`

## Test Plan

<!-- How was it tested? -->
The existing test fixtures have been updated
