### PR TITLE
[ty] fix missing '>' in HTML anchor tags in CLI reference

### DIFF
--- a/crates/ruff_dev/src/generate_ty_cli_reference.rs
+++ b/crates/ruff_dev/src/generate_ty_cli_reference.rs
@@ -179,7 +179,7 @@ fn generate_command<'a>(output: &mut String, command: &'a Command, parents: &mut
                 let id = format!("{name_key}--{}", arg.get_id());
                 output.push_str(&format!("<dt id=\"{id}\">"));
                 output.push_str(&format!(
-                    "<a href=\"#{id}\"<code>{}</code></a>",
+                    "<a href=\"#{id}\"><code>{}</code></a>",
                     arg.get_id().to_string().to_uppercase(),
                 ));
                 output.push_str("</dt>");

--- a/crates/ty/docs/cli.md
+++ b/crates/ty/docs/cli.md
@@ -30,7 +30,7 @@ ty check [OPTIONS] [PATH]...
 
 <h3 class="cli-reference">Arguments</h3>
 
-<dl class="cli-reference"><dt id="ty-check--paths"><a href="#ty-check--paths"<code>PATHS</code></a></dt><dd><p>List of files or directories to check [default: the project root]</p>
+<dl class="cli-reference"><dt id="ty-check--paths"><a href="#ty-check--paths"><code>PATHS</code></a></dt><dd><p>List of files or directories to check [default: the project root]</p>
 </dd></dl>
 
 <h3 class="cli-reference">Options</h3>
@@ -125,7 +125,7 @@ ty generate-shell-completion <SHELL>
 
 <h3 class="cli-reference">Arguments</h3>
 
-<dl class="cli-reference"><dt id="ty-generate-shell-completion--shell"><a href="#ty-generate-shell-completion--shell"<code>SHELL</code></a></dt></dl>
+<dl class="cli-reference"><dt id="ty-generate-shell-completion--shell"><a href="#ty-generate-shell-completion--shell"><code>SHELL</code></a></dt></dl>
 
 <h3 class="cli-reference">Options</h3>
 


### PR DESCRIPTION
## Summary

This PR is a follow-up to [ty-issue #383](https://github.com/astral-sh/ty/pull/383), fixing the root cause of the HTML syntax errors in the CLI documentation generator. Instead of modifying the generated documentation directly, this PR fixes the generation script itself.

Changes:
- Add missing '>' after href attributes in anchor tags in generate_ty_cli_reference.rs
- Fixes the auto-generation source rather than the generated output
- Ensures all future documentation generations will have proper HTML syntax

## Test Plan
1. Ran the documentation generator to verify proper HTML syntax
2. Confirmed that the generated documentation maintains the same visual appearance
3. Verified that the HTML anchor tags are now properly formatted in the output