### PR TITLE
[`flake8-simplify`] add fix safety section (`SIM210`)

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_ifexp.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_ifexp.rs
@@ -32,7 +32,7 @@ use crate::checkers::ast::Checker;
 /// This fix is marked as unsafe because it may change the program’s behavior if the condition does not
 /// return a proper Boolean. While the fix will try to wrap non-boolean values in a call to bool,
 /// custom implementations of comparison functions like `__eq__` can avoid the bool call and still
-/// lead to altered behavior.
+/// lead to altered behavior. Moreover, the fix may remove comments.
 ///
 /// ## References
 /// - [Python documentation: Truth Value Testing](https://docs.python.org/3/library/stdtypes.html#truth-value-testing)

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_ifexp.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_ifexp.rs
@@ -27,6 +27,13 @@ use crate::checkers::ast::Checker;
 /// bool(a)
 /// ```
 ///
+/// ## Fix safety
+///
+/// This fix is marked as unsafe because it may change the program’s behavior if the condition does not
+/// return a proper Boolean. While the fix will try to wrap non-boolean values in a call to bool,
+/// custom implementations of comparison functions like `__eq__` can avoid the bool call and still
+/// lead to altered behavior.
+///
 /// ## References
 /// - [Python documentation: Truth Value Testing](https://docs.python.org/3/library/stdtypes.html#truth-value-testing)
 #[derive(ViolationMetadata)]


### PR DESCRIPTION
The PR add the `fix safety` section for rule `SIM210` (#15584 )

It is a little cheating, as the Fix safety section is copy/pasted by #18086 as the problem is the same.

### Unsafe Fix Example

```python
class Foo():
    def __eq__(self, other):
        return 0

def foo():
    return True if Foo() == 0 else False

def foo_fix():
    return Foo() == 0

print(foo()) # False
print(foo_fix()) # 0
```
