### PR TITLE
Update Neovim setup docs

### DIFF
--- a/docs/editors/setup.md
+++ b/docs/editors/setup.md
@@ -48,12 +48,6 @@ following to your `init.lua`:
     })
     ```
 
-    !!! note
-
-        If the installed version of `nvim-lspconfig` includes the changes from
-        [neovim/nvim-lspconfig@`70d1c2c`](https://github.com/neovim/nvim-lspconfig/commit/70d1c2c31a88af4b36019dc1551be16bffb8f9db),
-        you will need to use Ruff version `0.5.3` or later.
-
 === "Neovim 0.11+ (with [`vim.lsp.config`](https://neovim.io/doc/user/lsp.html#vim.lsp.config()))"
 
     ```lua
@@ -68,11 +62,11 @@ following to your `init.lua`:
     vim.lsp.enable('ruff')
     ```
 
-    !!! note
+!!! note
 
-        The [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig) plugin should contain the changes
-        from [neovim/nvim-lspconfig@`bc1981a`](https://github.com/neovim/nvim-lspconfig/commit/bc1981a0d38faa7df0ffc7cb45203d2ce86267d0).
-
+    If the installed version of `nvim-lspconfig` includes the changes from
+    [neovim/nvim-lspconfig@`70d1c2c`](https://github.com/neovim/nvim-lspconfig/commit/70d1c2c31a88af4b36019dc1551be16bffb8f9db),
+    you will need to use Ruff version `0.5.3` or later.
 
 If you're using Ruff alongside another language server (like Pyright), you may want to defer to that
 language server for certain capabilities, like [`textDocument/hover`](./features.md#hover):

--- a/docs/editors/setup.md
+++ b/docs/editors/setup.md
@@ -36,30 +36,30 @@ Ruff Language Server in Neovim. To set it up, install
 [configuration](https://github.com/neovim/nvim-lspconfig#configuration) documentation, and add the
 following to your `init.lua`:
 
-- Nvim 0.11+ (see [vim.lsp.config](https://neovim.io/doc/user/lsp.html#vim.lsp.config()))
+- Nvim 0.11+ (see [vim.lsp.config](<https://neovim.io/doc/user/lsp.html#vim.lsp.config()>))
 
-```lua
-vim.lsp.enable('ruff')
-vim.lsp.config('ruff', {
-  init_options = {
-    settings = {
-      -- Ruff language server settings go here
+  ```lua
+  vim.lsp.enable('ruff')
+  vim.lsp.config('ruff', {
+    init_options = {
+      settings = {
+        -- Ruff language server settings go here
+      }
     }
-  }
-})
-```
+  })
+  ```
 
 - Nvim 0.10 (legacy)
 
-```lua
-require('lspconfig').ruff.setup({
-  init_options = {
-    settings = {
-      -- Ruff language server settings go here
+  ```lua
+  require('lspconfig').ruff.setup({
+    init_options = {
+      settings = {
+        -- Ruff language server settings go here
+      }
     }
-  }
-})
-```
+  })
+  ```
 
 !!! note
 

--- a/docs/editors/setup.md
+++ b/docs/editors/setup.md
@@ -36,6 +36,21 @@ Ruff Language Server in Neovim. To set it up, install
 [configuration](https://github.com/neovim/nvim-lspconfig#configuration) documentation, and add the
 following to your `init.lua`:
 
+- Nvim 0.11+ (see [vim.lsp.config](https://neovim.io/doc/user/lsp.html#vim.lsp.config()))
+
+```lua
+vim.lsp.enable('ruff')
+vim.lsp.config('ruff', {
+  init_options = {
+    settings = {
+      -- Ruff language server settings go here
+    }
+  }
+})
+```
+
+- Nvim 0.10 (legacy)
+
 ```lua
 require('lspconfig').ruff.setup({
   init_options = {

--- a/docs/editors/setup.md
+++ b/docs/editors/setup.md
@@ -36,36 +36,43 @@ Ruff Language Server in Neovim. To set it up, install
 [configuration](https://github.com/neovim/nvim-lspconfig#configuration) documentation, and add the
 following to your `init.lua`:
 
-- Nvim 0.11+ (see [vim.lsp.config](<https://neovim.io/doc/user/lsp.html#vim.lsp.config()>))
+=== "Neovim 0.10 (with [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig))"
 
-  ```lua
-  vim.lsp.enable('ruff')
-  vim.lsp.config('ruff', {
-    init_options = {
-      settings = {
-        -- Ruff language server settings go here
+    ```lua
+    require('lspconfig').ruff.setup({
+      init_options = {
+        settings = {
+          -- Ruff language server settings go here
+        }
       }
-    }
-  })
-  ```
+    })
+    ```
 
-- Nvim 0.10 (legacy)
+    !!! note
 
-  ```lua
-  require('lspconfig').ruff.setup({
-    init_options = {
-      settings = {
-        -- Ruff language server settings go here
+        If the installed version of `nvim-lspconfig` includes the changes from
+        [neovim/nvim-lspconfig@`70d1c2c`](https://github.com/neovim/nvim-lspconfig/commit/70d1c2c31a88af4b36019dc1551be16bffb8f9db),
+        you will need to use Ruff version `0.5.3` or later.
+
+=== "Neovim 0.11+ (with [`vim.lsp.config`](https://neovim.io/doc/user/lsp.html#vim.lsp.config()))"
+
+    ```lua
+    vim.lsp.config('ruff', {
+      init_options = {
+        settings = {
+          -- Ruff language server settings go here
+        }
       }
-    }
-  })
-  ```
+    })
 
-!!! note
+    vim.lsp.enable('ruff')
+    ```
 
-    If the installed version of `nvim-lspconfig` includes the changes from
-    [neovim/nvim-lspconfig@`70d1c2c`](https://github.com/neovim/nvim-lspconfig/commit/70d1c2c31a88af4b36019dc1551be16bffb8f9db),
-    you will need to use Ruff version `0.5.3` or later.
+    !!! note
+
+        The [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig) plugin should contain the changes
+        from [neovim/nvim-lspconfig@`bc1981a`](https://github.com/neovim/nvim-lspconfig/commit/bc1981a0d38faa7df0ffc7cb45203d2ce86267d0).
+
 
 If you're using Ruff alongside another language server (like Pyright), you may want to defer to that
 language server for certain capabilities, like [`textDocument/hover`](./features.md#hover):


### PR DESCRIPTION
Nvim 0.11+ uses the builtin `vim.lsp.enable` and `vim.lsp.config` to enable and configure LSP clients. This adds the new non legacy way of configuring Nvim with `nvim-lspconfig` according to the upstream documentation.

<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
Update documentation for Nvim LSP configuration according to `nvim-lspconfig` and Nvim 0.11+

## Test Plan

Tested locally on macOS with Nvim 0.11.1 and `nvim-lspconfig` master/[ac1dfbe](https://github.com/neovim/nvim-lspconfig/tree/ac1dfbe3b60e5e23a2cff90e3bd6a3bc88031a57).