### PR TITLE
[`flake8-simplify`] add fix safety section (`SIM110`)

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
@@ -34,6 +34,13 @@ use crate::line_width::LineWidthBuilder;
 /// return any(predicate(item) for item in iterable)
 /// ```
 ///
+/// # Fix safety
+///
+/// This fix is always marked as unsafe because Python generator expressions used in
+/// `any` or `all` are lazy—that is, they defer evaluation of each item until it is needed.
+/// This can lead to differences in behavior if, for example, the `predicate` is reassigned or
+/// modified during iteration. Additionally, the fix may remove comments.
+///
 /// ## References
 /// - [Python documentation: `any`](https://docs.python.org/3/library/functions.html#any)
 /// - [Python documentation: `all`](https://docs.python.org/3/library/functions.html#all)


### PR DESCRIPTION
The PR add the `fix safety` section for rule `SIM110` (#15584 )

### Unsafe Fix Example

```python
def predicate(item):
    global called
    called += 1
    if called == 1:
    # after first call we change the method
        def new_predicate(_): return False
        globals()['predicate'] = new_predicate
    return True

def foo():
    for item in range(10):
        if predicate(item):
            return True
    return False

def foo_gen():
    return any(predicate(item) for item in range(10))

called = 0
print(foo())      # true – returns immediately on first call

called = 0
print(foo_gen())  # false – second call uses new `predicate`
```

### Note

I notice that [here](https://github.com/astral-sh/ruff/blob/46be305ad243a5286d4269b1f8e5fd67623d38c2/crates/ruff_linter/src/rules/flake8_simplify/rules/reimplemented_builtin.rs#L60) we have two rules, `SIM110` & `SIM111`. The second one seems not anymore active. Should I delete `SIM111`
