### PR TITLE
[ty] Enable 'ansi' feature to fix compile error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,6 +162,8 @@ tracing-log = { version = "0.2.0" }
 tracing-subscriber = { version = "0.3.18", default-features = false, features = [
     "env-filter",
     "fmt",
+    "ansi",
+    "smallvec"
 ] }
 tryfn = { version = "0.2.1" }
 typed-arena = { version = "2.0.2" }

--- a/crates/ty/Cargo.toml
+++ b/crates/ty/Cargo.toml
@@ -33,7 +33,7 @@ jiff = { workspace = true }
 rayon = { workspace = true }
 salsa = { workspace = true }
 tracing = { workspace = true, features = ["release_max_level_debug"] }
-tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
+tracing-subscriber = { workspace = true }
 tracing-flame = { workspace = true }
 wild = { workspace = true }
 


### PR DESCRIPTION
## Summary

`cargo install --path crates/ty -f` failed because of the missing `ansi` feature (required for the `pretty` tracing formatter).

This PR enables the `ansi` feature.

## Test Plan

`cargo install --path crates/ty -f` now succeeds
