### PR TITLE
[ty] Enable optimizations for salsa in debug profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -256,6 +256,9 @@ opt-level = 3
 [profile.dev.package.similar]
 opt-level = 3
 
+[profile.dev.package.salsa]
+opt-level = 3
+
 # Reduce complexity of a parser function that would trigger a locals limit in a wasm tool.
 # https://github.com/bytecodealliance/wasm-tools/blob/b5c3d98e40590512a3b12470ef358d5c7b983b15/crates/wasmparser/src/limits.rs#L29
 [profile.dev.package.ruff_python_parser]


### PR DESCRIPTION
## Summary

We use salsa a lot and it changes infrequently. This PR enables more aggressive optimizations for the salsa crate when using the debug profile.
This should give us faster test (and ty execution) at the cost of slightly longer compile times when compiling a new salsa version for the first time.

## Test Plan

This reduces the wall time for `cargo nextest run -p ty_python_semantic --test mdtest` from ~4s to ~3.3s on my machine
