### PR TITLE
[ty] support accessing `__builtins__` global

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/scopes/moduletype_attrs.md
+++ b/crates/ty_python_semantic/resources/mdtest/scopes/moduletype_attrs.md
@@ -15,6 +15,7 @@ reveal_type(__package__)  # revealed: str | None
 reveal_type(__doc__)  # revealed: str | None
 reveal_type(__spec__)  # revealed: ModuleSpec | None
 reveal_type(__path__)  # revealed: MutableSequence[str]
+reveal_type(__builtins__)  # revealed: ModuleType
 
 class X:
     reveal_type(__name__)  # revealed: str

--- a/crates/ty_python_semantic/src/symbol.rs
+++ b/crates/ty_python_semantic/src/symbol.rs
@@ -1013,6 +1013,8 @@ mod implicit_globals {
         // None`.
         if name == "__file__" {
             Symbol::bound(KnownClass::Str.to_instance(db)).into()
+        } else if name == "__builtins__" {
+            Symbol::bound(KnownClass::ModuleType.to_instance(db)).into()
         }
         // In general we wouldn't check to see whether a symbol exists on a class before doing the
         // `.member()` call on the instance type -- we'd just do the `.member`() call on the instance


### PR DESCRIPTION
Hi, this is in regards to https://github.com/astral-sh/ty/issues/393 and intends to support `__builtins__` access.

<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

The PR adds an explicit check for `"__builtins__"` during name lookup, similar to how `"__file__"` is implemented. The inferred type is `ModuleType`.

I'm new to working on ty, so any feedback is welcome:)

## Test Plan

Added a markdown test for `__builtins__`.
