### PR TITLE
[ty] `type[…]` is always assignable to `type`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
@@ -196,6 +196,12 @@ static_assert(is_assignable_to(type[Any], Meta))
 static_assert(is_assignable_to(type[Unknown], Meta))
 static_assert(is_assignable_to(Meta, type[Any]))
 static_assert(is_assignable_to(Meta, type[Unknown]))
+
+class AnyMeta(metaclass=Any): ...
+
+static_assert(is_assignable_to(type[AnyMeta], type))
+static_assert(is_assignable_to(type[AnyMeta], type[object]))
+static_assert(is_assignable_to(type[AnyMeta], type[Any]))
 ```
 
 ## Heterogeneous tuple types

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1516,6 +1516,15 @@ impl<'db> Type<'db> {
                 true
             }
 
+            // Every `type[...]` is assignable to `type`
+            (Type::SubclassOf(_), _)
+                if KnownClass::Type
+                    .to_instance(db)
+                    .is_assignable_to(db, target) =>
+            {
+                true
+            }
+
             // All `type[...]` types are assignable to `type[Any]`, because `type[Any]` can
             // materialize to any `type[...]` type.
             //


### PR DESCRIPTION
## Summary

Model that `type[C]` is always assignable to `type`, even if `C` is not fully static.

closes https://github.com/astral-sh/ty/issues/312

## Test Plan

* New Markdown tests
* Property tests