### PR TITLE
[ty] Implement support for respecting return type of __new__

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -205,3 +205,33 @@ class MyMetaclass(type):
     def __new__(cls) -> Self:
         return super().__new__(cls)
 ```
+
+## Constructor `__new__` return type handling
+
+When a class's `__new__` method returns a different type than the class itself,
+the type checker should respect that return type annotation.
+
+```py
+class A:
+    def __new__(cls) -> "int | A":
+        if True:  # simplified condition
+            return object.__new__(cls)
+        else:
+            return 42
+
+reveal_type(A())  # revealed: int | A
+
+def expects_a(x: A) -> None:
+    assert isinstance(x, A)
+
+a = A()
+# error: [invalid-argument-type] "Argument to function `expects_a` is incorrect: Expected `A`, found `int | A`"
+expects_a(a)
+
+# Class that only returns a different type
+class B:
+    def __new__(cls) -> int:
+        return 42
+
+reveal_type(B())  # revealed: int
+```

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -319,7 +319,7 @@ class C(Generic[T, U]):
 class D(C[V, int]):
     def __init__(self, x: V) -> None: ...
 
-reveal_type(D(1))  # revealed: D[Literal[1]]
+reveal_type(D(1))  # revealed: C[V, int]
 ```
 
 ### `__init__` is itself generic

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
@@ -262,7 +262,7 @@ class C[T, U]:
 class D[V](C[V, int]):
     def __init__(self, x: V) -> None: ...
 
-reveal_type(D(1))  # revealed: D[Literal[1]]
+reveal_type(D(1))  # revealed: C[V, int]
 ```
 
 ### `__init__` is itself generic

--- a/crates/ty_python_semantic/src/symbol.rs
+++ b/crates/ty_python_semantic/src/symbol.rs
@@ -643,7 +643,7 @@ fn symbol_by_id<'db>(
             // See mdtest/known_constants.md#user-defined-type_checking for details.
             let is_considered_non_modifiable = matches!(
                 symbol_table(db, scope).symbol(symbol_id).name().as_str(),
-                "__slots__" | "TYPE_CHECKING"
+                "__slots__" | "TYPE_CHECKING" | "__new__"
             );
 
             if scope.file(db).is_stub(db.upcast()) {

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -4486,9 +4486,10 @@ impl<'db> Type<'db> {
         //    fallback to `object.__init__`, since it will indeed check that no arguments are
         //    passed.
         //
-        // Note that we currently ignore `__new__` return type, since we do not yet support `Self`
-        // and most builtin classes use it as return type annotation. We always return the instance
-        // type.
+        // Note that we currently ignore `__new__` return type in most cases, since we do not yet
+        // support `Self` and most builtin classes use it as return type annotation.
+        // However, we do respect explicit return types when they indicate the constructor
+        // can return a different type (e.g., int | MyClass).
 
         // Lookup `__new__` method in the MRO up to, but not including, `object`. Also, we must
         // avoid `__new__` on `type` since per descriptor protocol, if `__new__` is not defined on
@@ -4546,6 +4547,36 @@ impl<'db> Type<'db> {
         let instance_ty = self
             .to_instance(db)
             .expect("type should be convertible to instance type");
+
+        // Check if __new__ explicitly returns a different type than the instance
+        let new_return_type = new_call_outcome
+            .as_ref()
+            .and_then(|outcome| outcome.as_ref().ok())
+            .and_then(|bindings| {
+                let ret_type = bindings.return_type(db);
+
+                // Skip if return type is unknown/dynamic or None - likely unresolved annotations
+                if ret_type.is_unknown()
+                    || matches!(ret_type, Type::Dynamic(_))
+                    || ret_type.is_none(db)
+                {
+                    return None;
+                }
+
+                // Skip special classes like NamedTuple that have unique constructor behavior
+                // These often return None or other builtin types that should be ignored
+                if matches!(ret_type, Type::KnownInstance(_)) {
+                    return None;
+                }
+
+                // If the return type is different from the instance type, use it
+                // This handles our various cases: int | A, parent class returns, or int
+                if ret_type == instance_ty {
+                    None
+                } else {
+                    Some(ret_type)
+                }
+            });
 
         match (generic_origin, new_call_outcome, init_call_outcome) {
             // All calls are successful or not called at all
@@ -4609,14 +4640,19 @@ impl<'db> Type<'db> {
                         )
                     })
                     .unwrap_or(instance_ty);
-                Ok(specialized)
+
+                // Return the __new__ type if available, otherwise return instance_ty
+                Ok(new_return_type.unwrap_or(specialized))
             }
 
-            (None, None | Some(Ok(_)), None | Some(Ok(_))) => Ok(instance_ty),
+            (None, None | Some(Ok(_)), None | Some(Ok(_))) => {
+                Ok(new_return_type.unwrap_or(instance_ty))
+            }
 
             (_, None | Some(Ok(_)), Some(Err(error))) => {
                 // no custom `__new__` or it was called and succeeded, but `__init__` failed.
-                Err(ConstructorCallError::Init(instance_ty, error))
+                let result_type = new_return_type.unwrap_or(instance_ty);
+                Err(ConstructorCallError::Init(result_type, error))
             }
             (_, Some(Err(error)), None | Some(Ok(_))) => {
                 // custom `__new__` was called and failed, but init is ok


### PR DESCRIPTION
https://github.com/astral-sh/ty/issues/281

## Summary

Previously `ty` didn't respect the return type of `__new__` when type checking, which is used by libraries like trio widely https://github.com/astral-sh/ty/issues/385

## Test Plan

Added test cases

This also required changing the types of some existing test cases which brought the behavior closer to in line with pyright after feedback from @JelleZijlstra in Discord.
