### PR TITLE
T201/T203 Improve print/pprint docs

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_print/rules/print_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_print/rules/print_call.rs
@@ -21,7 +21,7 @@ use crate::registry::AsRule;
 /// ## Example
 /// ```python
 /// def sum_less_than_four(a, b):
-///     print(f"are there less than 4? {a}+{b} = {a+b}")
+///     print(f"Calling sum_less_than_four")
 ///     return a + b < 4
 /// ```
 ///
@@ -41,7 +41,7 @@ use crate::registry::AsRule;
 ///
 ///
 /// def sum_less_than_four(a, b):
-///     logging.info(f"are there less than 4? {a}+{b} = {a+b}")
+///     logging.debug("Calling sum_less_than_four")
 ///     return a + b < 4
 /// ```
 ///

--- a/crates/ruff_linter/src/rules/flake8_print/rules/print_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_print/rules/print_call.rs
@@ -11,26 +11,38 @@ use crate::registry::AsRule;
 /// Checks for `print` statements.
 ///
 /// ## Why is this bad?
-/// `print` statements are useful in some situations (e.g., debugging), but
-/// should typically be omitted from production code. `print` statements can
-/// lead to the accidental inclusion of sensitive information in logs, and are
-/// not configurable by clients, unlike `logging` statements.
+/// `print` statements used for debugging should be omitted from production
+/// code. They can lead the accidental inclusion of sensitive information in
+/// logs, and are not configurable by clients, unlike `logging` statements.
+///
+/// `print` statements used to produce output as a part of a command-line
+/// interface program are not typically a problem.
 ///
 /// ## Example
 /// ```python
-/// def add_numbers(a, b):
-///     print(f"The sum of {a} and {b} is {a + b}")
-///     return a + b
+/// def sum_less_than_four(a, b):
+///     print(f"are there less than 4? {a}+{b} = {a+b}")
+///     return a + b < 4
 /// ```
 ///
-/// Use instead:
+/// The automatic fix will remove the print statment entirely:
 /// ```python
-/// def add_numbers(a, b):
-///     return a + b
+/// def sum_less_than_four(a, b):
+///     return a + b < 4
+/// ```
+///
+/// To keep the line for logging purposes, instead use something like:
+/// ```python
+/// import logging
+///
+/// logging.basicConfig(level=logging.INFO)
+/// def sum_less_than_four(a, b):
+///     logging.info(f"are there less than 4? {a}+{b} = {a+b}")
+///     return a + b < 4
 /// ```
 ///
 /// ## Fix safety
-/// This rule's fix is marked as unsafe, as it may remove `print` statements
+/// This rule's fix is marked as unsafe, as it will remove `print` statements
 /// that are used beyond debugging purposes.
 #[derive(ViolationMetadata)]
 pub(crate) struct Print;
@@ -52,11 +64,13 @@ impl Violation for Print {
 /// Checks for `pprint` statements.
 ///
 /// ## Why is this bad?
-/// Like `print` statements, `pprint` statements are useful in some situations
-/// (e.g., debugging), but should typically be omitted from production code.
-/// `pprint` statements can lead to the accidental inclusion of sensitive
-/// information in logs, and are not configurable by clients, unlike `logging`
-/// statements.
+/// Like `print` statements, `pprint` statements used for debugging should
+/// be omitted from production code. They can lead the accidental inclusion
+/// of sensitive information in logs, and are not configurable by clients,
+/// unlike `logging` statements.
+///
+/// `pprint` statements used to produce output as a part of a command-line
+/// interface program are not typically a problem.
 ///
 /// ## Example
 /// ```python
@@ -77,7 +91,7 @@ impl Violation for Print {
 /// ```
 ///
 /// ## Fix safety
-/// This rule's fix is marked as unsafe, as it may remove `pprint` statements
+/// This rule's fix is marked as unsafe, as it will remove `pprint` statements
 /// that are used beyond debugging purposes.
 #[derive(ViolationMetadata)]
 pub(crate) struct PPrint;

--- a/crates/ruff_linter/src/rules/flake8_print/rules/print_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_print/rules/print_call.rs
@@ -25,17 +25,21 @@ use crate::registry::AsRule;
 ///     return a + b < 4
 /// ```
 ///
-/// The automatic fix will remove the print statment entirely:
+/// The automatic fix will remove the print statement entirely:
+///
 /// ```python
 /// def sum_less_than_four(a, b):
 ///     return a + b < 4
 /// ```
 ///
 /// To keep the line for logging purposes, instead use something like:
+///
 /// ```python
 /// import logging
 ///
 /// logging.basicConfig(level=logging.INFO)
+///
+///
 /// def sum_less_than_four(a, b):
 ///     logging.info(f"are there less than 4? {a}+{b} = {a+b}")
 ///     return a + b < 4


### PR DESCRIPTION

* discuss legitimate uses like CLI
* discuss how to log

## Summary
These rules are great when referring to adhoc debug print statements, but it's worth flagging up that there are absolutely fine legitimate uses of `print()` and `pprint()` and that the rule applies to debugging more or less exclusively.

It's not easy to come up with a simple, minimal example of what using `logging` looks like; I'm not convinced this one is great.

I'm not sure this is quite right, but I think there's a kernel of something better than what we've got, which is important because this appears to becoming the defacto reference for "why print in production code is bad"

## Test Plan

It hasn't been. But I did check the python code fragments didn't error on ruff.
