### PR TITLE
[ty] Fix relative imports in stub packages

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/import/stub_packages.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/stub_packages.md
@@ -311,6 +311,5 @@ class YamlLoader: ...
 ```py
 import yaml
 
-# TODO: This should not be an error
-yaml.YamlLoader  # error: [unresolved-attribute] "Type `<module 'yaml'>` has no attribute `YamlLoader`"
+reveal_type(yaml.YamlLoader)  # revealed: <class 'YamlLoader'>
 ```


### PR DESCRIPTION
## Summary

Relative imports call `file_to_module` which always returned `None` for stub packages because
a stub package path like `pyyaml-stubs/__init__.py` can't be converted into a valid `ModuleName` because `-stubs` isn't a valid identifier. 

This PR fixes the path to module name conversion by stripping the `-stubs` suffix. 

Fixes https://github.com/astral-sh/ty/issues/408

## Test Plan

See fixed mdtest (Thanks @sharkdp for writing a failing test for it!)
