### PR TITLE
Use `insta` settings instead of `cfg`

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_no_pep420/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_no_pep420/mod.rs
@@ -39,7 +39,9 @@ mod tests {
                 ..LinterSettings::for_rule(Rule::ImplicitNamespacePackage)
             },
         )?;
-        assert_messages!(snapshot, diagnostics);
+        insta::with_settings!({filters => vec![(r"\\", "/")]}, {
+            assert_messages!(snapshot, diagnostics);
+        });
         Ok(())
     }
 }

--- a/crates/ruff_linter/src/rules/flake8_no_pep420/rules/implicit_namespace_package.rs
+++ b/crates/ruff_linter/src/rules/flake8_no_pep420/rules/implicit_namespace_package.rs
@@ -83,10 +83,6 @@ pub(crate) fn implicit_namespace_package(
         // Ignore PEP 723 scripts.
         && ScriptTag::parse(locator.contents().as_bytes()).is_none()
     {
-        #[cfg(all(test, windows))]
-        let path = path
-            .to_string_lossy()
-            .replace(std::path::MAIN_SEPARATOR, "/"); // The snapshot test expects / as the path separator.
         return Some(Diagnostic::new(
             ImplicitNamespacePackage {
                 filename: fs::relativize_path(path),
@@ -104,11 +100,6 @@ pub(crate) fn implicit_namespace_package(
                     .ancestors()
                     .find(|parent| !parent.join("__init__.py").exists())
                 {
-                    #[cfg(all(test, windows))]
-                    let path = path
-                        .to_string_lossy()
-                        .replace(std::path::MAIN_SEPARATOR, "/"); // The snapshot test expects / as the path separator.
-
                     return Some(Diagnostic::new(
                         ImplicitNamespacePackage {
                             filename: fs::relativize_path(path),


### PR DESCRIPTION
Summary
--

I noticed these `cfg` directives while working on diagnostics. I think it makes more sense to apply an `insta` filter in the test instead. I copied this filter from a CLI test for the same rule.

Test Plan
--

Existing tests, especially Windows CI on this PR
