### PR TITLE
[ty] Fix assignability checks for invariant generics parameterized by gradual types

### DIFF
--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -457,10 +457,13 @@ impl<'db> Specialization<'db> {
             // corresponding typevar:
             //   - covariant: verify that self_type <: other_type
             //   - contravariant: verify that other_type <: self_type
-            //   - invariant: verify that self_type == other_type
+            //   - invariant: verify that self_type <: other_type AND other_type <: self_type
             //   - bivariant: skip, can't make assignability false
             let compatible = match typevar.variance(db) {
-                TypeVarVariance::Invariant => self_type.is_gradual_equivalent_to(db, *other_type),
+                TypeVarVariance::Invariant => {
+                    self_type.is_assignable_to(db, *other_type)
+                        && other_type.is_assignable_to(db, *self_type)
+                }
                 TypeVarVariance::Covariant => self_type.is_assignable_to(db, *other_type),
                 TypeVarVariance::Contravariant => other_type.is_assignable_to(db, *self_type),
                 TypeVarVariance::Bivariant => true,


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ty/issues/424. All the examples in that issue work correctly with this PR branch.

`bool | Any` is not gradually equivalent to `int`, because `bool | Any` could materialize to many possible fully static types that would not be equivalent to `int`: the set of possible sets represented by `bool | Any` is not the same as the (length-1) set of possible sets represented by `int`. Yet `bool | Any` is assignable to `int`, and `int` is assignable to `bool | Any`. The mutual assignability of both is all that is necessary for `list[bool | Any]` to be assignable to `list[int]` and for `list[int]` to be assignable to `list[bool | Any]`.

## Test Plan

mdtests added courtesy of @JelleZijlstra!
