### PR TITLE
Fix `test scripts` CI job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -495,7 +495,7 @@ jobs:
           persist-credentials: false
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
       - name: "Install Rust toolchain"
-        run: rustup show
+        run: rustup component add rustfmt
       # Run all code generation scripts, and verify that the current output is
       # already checked into git.
       - run: python crates/ruff_python_ast/generate.py


### PR DESCRIPTION
## Summary

The generate-ast script requires rust fmt. 

## Test Plan

CI
