### PR TITLE
Default `src.root` to `['.', '<project_name>']` if the directory exists

### DIFF
--- a/crates/ty/docs/configuration.md
+++ b/crates/ty/docs/configuration.md
@@ -164,7 +164,11 @@ typeshed = "/path/to/custom/typeshed"
 
 The root of the project, used for finding first-party modules.
 
-**Default value**: `[".", "./src"]`
+If left unspecified, ty will default to the current working directory and:
+* `./src` if it exists
+* `./<project-name>` if the folder `./<project-name>/<project-name>` exists
+
+**Default value**: `null`
 
 **Type**: `str`
 

--- a/crates/ty/docs/configuration.md
+++ b/crates/ty/docs/configuration.md
@@ -164,9 +164,11 @@ typeshed = "/path/to/custom/typeshed"
 
 The root of the project, used for finding first-party modules.
 
-If left unspecified, ty will default to the current working directory and:
-* `./src` if it exists
-* `./<project-name>` if the folder `./<project-name>/<project-name>` exists
+If left unspecified, ty will try to detect common project layouts and initialize `src.root` accordingly:
+
+* if a `./src` directory exists, include `.` and `./src` in the first party search path (src layout or flat)
+* if a `./<project-name>/<project-name>` directory exists, include `.` and `./<project-name>` in the first party search path
+* otherwise, default to `.` (flat layout)
 
 **Default value**: `null`
 

--- a/crates/ty_project/src/metadata.rs
+++ b/crates/ty_project/src/metadata.rs
@@ -244,7 +244,8 @@ impl ProjectMetadata {
     }
 
     pub fn to_program_settings(&self, system: &dyn System) -> ProgramSettings {
-        self.options.to_program_settings(self.root(), system)
+        self.options
+            .to_program_settings(self.root(), self.name(), system)
     }
 
     /// Combine the project options with the CLI options where the CLI options take precedence.

--- a/ty.schema.json
+++ b/ty.schema.json
@@ -839,7 +839,7 @@
       "type": "object",
       "properties": {
         "root": {
-          "description": "The root of the project, used for finding first-party modules.\n\nIf left unspecified, ty will default to the current working directory and: * `./src` if it exists * `./<project-name>` if the folder `./<project-name>/<project-name>` exists",
+          "description": "The root of the project, used for finding first-party modules.\n\nIf left unspecified, ty will try to detect common project layouts and initialize `src.root` accordingly:\n\n* if a `./src` directory exists, include `.` and `./src` in the first party search path (src layout or flat) * if a `./<project-name>/<project-name>` directory exists, include `.` and `./<project-name>` in the first party search path * otherwise, default to `.` (flat layout)",
           "type": [
             "string",
             "null"

--- a/ty.schema.json
+++ b/ty.schema.json
@@ -839,7 +839,7 @@
       "type": "object",
       "properties": {
         "root": {
-          "description": "The root of the project, used for finding first-party modules.",
+          "description": "The root of the project, used for finding first-party modules.\n\nIf left unspecified, ty will default to the current working directory and: * `./src` if it exists * `./<project-name>` if the folder `./<project-name>/<project-name>` exists",
           "type": [
             "string",
             "null"


### PR DESCRIPTION
## Summary

I noticed in #18137 that we fail to resolve all imports for some ecosystem repositories because they don't use the "traditional" src or flat layouts. Instead, they use a `src` layout but they use the project name instead of `src` for the "src folder name". 

An example is `psycopg` where all source files are in `psycopg/psycopg/_adapters_map.py:279:14`

This PR extends our heuristics for `src.root` to recognize if a project has a `<project>/<project>` folder (and no `src` folder) and, if so, includes it in the `src.root`. 

The motivation for this change is to support more projects with zero configuration. 

I don't have a good sense of how common this project layout is, but it seems worth supporting, given that multiple ecosystem projects use it. This also makes our mypy primer results significantely more useful :)

## Test plan

See mypy primer results, added unit tests.