### PR TITLE
Match tuple formatting

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/pattern/pattern_maybe_parenthesize.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/pattern/pattern_maybe_parenthesize.py
@@ -288,5 +288,13 @@ match x:
     ]:
         pass
 
-
+match a, b:
+    case [], []:
+        ...
+    case [], _:
+        ...
+    case _, []:
+        ...
+    case _, _:
+        ...
 

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/pattern_match_regression_brackets.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/pattern_match_regression_brackets.py
@@ -1,0 +1,8 @@
+# Ruff in some cases added brackets around tuples in some cases; deviating from Black.
+# Ensure we don't revert already-applied formats with the fix.
+# See https://github.com/astral-sh/ruff/pull/18147
+match a, b:
+    case [[], []]:
+        ...
+    case [[], _]:
+        ...

--- a/crates/ruff_python_formatter/src/pattern/pattern_match_sequence.rs
+++ b/crates/ruff_python_formatter/src/pattern/pattern_match_sequence.rs
@@ -80,8 +80,7 @@ pub(crate) enum SequenceType {
 impl SequenceType {
     pub(crate) fn from_pattern(pattern: &PatternMatchSequence, source: &str) -> SequenceType {
         if source[pattern.range()].starts_with('[') {
-            // Count top-level commata to distinguish between a list pattern `[...]`
-            // and a tuple pattern with a list element `[], ...`
+            // A top-level comma indicates a tuple with a leading list, not a list
             let is_list =
                 SimpleTokenizer::new(source, TextRange::new(pattern.start(), pattern.end()))
                     .skip_trivia()

--- a/crates/ruff_python_formatter/src/pattern/pattern_match_sequence.rs
+++ b/crates/ruff_python_formatter/src/pattern/pattern_match_sequence.rs
@@ -91,7 +91,7 @@ impl SequenceType {
                         _ => Ok(depth),
                     });
             match is_list {
-                Err(_) => SequenceType::TupleNoParens,
+                Err(()) => SequenceType::TupleNoParens,
                 Ok(_) => SequenceType::List,
             }
         } else if source[pattern.range()].starts_with('(') {

--- a/crates/ruff_python_formatter/src/pattern/pattern_match_sequence.rs
+++ b/crates/ruff_python_formatter/src/pattern/pattern_match_sequence.rs
@@ -79,22 +79,26 @@ pub(crate) enum SequenceType {
 
 impl SequenceType {
     pub(crate) fn from_pattern(pattern: &PatternMatchSequence, source: &str) -> SequenceType {
-        if source[pattern.range()].starts_with('[') {
-            // A top-level comma indicates a tuple with a leading list, not a list
-            let is_list =
-                SimpleTokenizer::new(source, TextRange::new(pattern.start(), pattern.end()))
-                    .skip_trivia()
-                    .try_fold(0, |depth, token| match token.kind() {
-                        SimpleTokenKind::LBracket => Ok(depth + 1),
-                        SimpleTokenKind::RBracket => Ok(depth - 1),
-                        SimpleTokenKind::Comma if depth == 0 => Err(()),
-                        _ => Ok(depth),
-                    });
-            match is_list {
-                Err(()) => SequenceType::TupleNoParens,
-                Ok(_) => SequenceType::List,
-            }
-        } else if source[pattern.range()].starts_with('(') {
+        let before_first_pattern = &source[TextRange::new(
+            pattern.start(),
+            pattern
+                .patterns
+                .first()
+                .map(Ranged::start)
+                .unwrap_or(pattern.end()),
+        )];
+        let after_last_patttern = &source[TextRange::new(
+            pattern.start(),
+            pattern
+                .patterns
+                .first()
+                .map(Ranged::end)
+                .unwrap_or(pattern.end()),
+        )];
+
+        if before_first_pattern.starts_with('[') && !after_last_patttern.ends_with(',') {
+            SequenceType::List
+        } else if before_first_pattern.starts_with('(') {
             // If the pattern is empty, it must be a parenthesized tuple with no members. (This
             // branch exists to differentiate between a tuple with and without its own parentheses,
             // but a tuple without its own parentheses must have at least one member.)

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__pattern_matching_trailing_comma.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__pattern_matching_trailing_comma.py.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/ruff_python_formatter/tests/fixtures.rs
 input_file: crates/ruff_python_formatter/resources/test/fixtures/black/cases/pattern_matching_trailing_comma.py
-snapshot_kind: text
 ---
 ## Input
 
@@ -27,7 +26,7 @@ match more := (than, one), indeed,:
 ```diff
 --- Black
 +++ Ruff
-@@ -8,13 +8,16 @@
+@@ -8,7 +8,10 @@
          pass
  
  
@@ -38,15 +37,7 @@ match more := (than, one), indeed,:
 +):
      case _, (5, 6):
          pass
--    case (
-+    case [
-         [[5], (6)],
-         [7],
--    ):
-+    ]:
-         pass
-     case _:
-         pass
+     case (
 ```
 
 ## Ruff Output
@@ -68,10 +59,10 @@ match (
 ):
     case _, (5, 6):
         pass
-    case [
+    case (
         [[5], (6)],
         [7],
-    ]:
+    ):
         pass
     case _:
         pass

--- a/crates/ruff_python_formatter/tests/snapshots/format@pattern__pattern_maybe_parenthesize.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@pattern__pattern_maybe_parenthesize.py.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/ruff_python_formatter/tests/fixtures.rs
 input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/pattern/pattern_maybe_parenthesize.py
-snapshot_kind: text
 ---
 ## Input
 ```python
@@ -295,7 +294,15 @@ match x:
     ]:
         pass
 
-
+match a, b:
+    case [], []:
+        ...
+    case [], _:
+        ...
+    case _, []:
+        ...
+    case _, _:
+        ...
 
 ```
 
@@ -592,4 +599,14 @@ match x:
         ccccccccccccccccccccccccccccccccc,
     ]:
         pass
+
+match a, b:
+    case [], []:
+        ...
+    case [], _:
+        ...
+    case _, []:
+        ...
+    case _, _:
+        ...
 ```

--- a/crates/ruff_python_formatter/tests/snapshots/format@pattern_match_regression_brackets.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@pattern_match_regression_brackets.py.snap
@@ -1,0 +1,27 @@
+---
+source: crates/ruff_python_formatter/tests/fixtures.rs
+input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/pattern_match_regression_brackets.py
+---
+## Input
+```python
+# Ruff in some cases added brackets around tuples in some cases; deviating from Black.
+# Ensure we don't revert already-applied formats with the fix.
+# See https://github.com/astral-sh/ruff/pull/18147
+match a, b:
+    case [[], []]:
+        ...
+    case [[], _]:
+        ...
+```
+
+## Output
+```python
+# Ruff in some cases added brackets around tuples in some cases; deviating from Black.
+# Ensure we don't revert already-applied formats with the fix.
+# See https://github.com/astral-sh/ruff/pull/18147
+match a, b:
+    case [[], []]:
+        ...
+    case [[], _]:
+        ...
+```


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

Closes #17969 

## Summary
Add check to sequence type determination of `match` formatting to distinguish between a list and a tuple whose leading element is a list. 

Previously, we only checked for an opening bracket, `[`, now we additionally check for top level commata to determine if it is a tuple and return the according type.

The resulting formatting behaviour is consistent with Black.
<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan
Added a test case to ruff's tests. 
Note: this case is not covered in tests imported from Black. 

Manually compared Black, and this fix on the example from the issue. 
<!-- How was it tested? -->
