### PR TITLE
Mark FURB180 fix unsafe when class has bases

### DIFF
--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB180_FURB180.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB180_FURB180.py.snap
@@ -50,7 +50,7 @@ FURB180.py:26:18: FURB180 [*] Use of `metaclass=abc.ABCMeta` to define abstract 
    |
    = help: Replace with `abc.ABC`
 
-ℹ Safe fix
+ℹ Unsafe fix
 23 23 |     pass
 24 24 | 
 25 25 | 
@@ -68,7 +68,7 @@ FURB180.py:31:34: FURB180 [*] Use of `metaclass=abc.ABCMeta` to define abstract 
    |
    = help: Replace with `abc.ABC`
 
-ℹ Safe fix
+ℹ Unsafe fix
 28 28 |     def foo(self): pass
 29 29 | 
 30 30 | 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

Mark `FURB180`'s fix as unsafe if the class already has base classes. This is because the base classes might validate the other base classes (like `typing.Protocol` does) or otherwise alter runtime behavior if more base classes are added.

## Test Plan

The existing snapshot test covers this case already.

## References

Partially addresses https://github.com/astral-sh/ruff/issues/13307 (left out way to permit certain exceptions)
