### PR TITLE
Revert "[ty] Better control flow for boolean expressions that are inside if (#18010)"

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/boolean/short_circuit.md
+++ b/crates/ty_python_semantic/resources/mdtest/boolean/short_circuit.md
@@ -7,14 +7,14 @@ Similarly, in `and` expressions, if the left-hand side is falsy, the right-hand 
 evaluated.
 
 ```py
-def _(flag: bool, number: int):
-    flag or (y := number)
-    # error: [possibly-unresolved-reference]
-    reveal_type(y)  # revealed: int
+def _(flag: bool):
+    if flag or (x := 1):
+        # error: [possibly-unresolved-reference]
+        reveal_type(x)  # revealed: Literal[1]
 
-    flag and (x := number)
-    # error: [possibly-unresolved-reference]
-    reveal_type(x)  # revealed: int
+    if flag and (x := 1):
+        # error: [possibly-unresolved-reference]
+        reveal_type(x)  # revealed: Literal[1]
 ```
 
 ## First expression is always evaluated
@@ -64,157 +64,4 @@ def _(flag1: bool, flag2: bool):
     if (flag1 and (z := 1)) or reveal_type(z):  # revealed: Literal[1]
         # error: [possibly-unresolved-reference]
         reveal_type(z)  # revealed: Literal[1]
-```
-
-## Inside if-else blocks, we can sometimes know that short-circuit couldn't happen
-
-When if-test contains `And` condition, in the scope of if-body we can be sure that the test is
-truthy and therefore short-circuiting couldn't happen. Similarly, when if-test contains `Or`
-condition, in the scope of if-else we can be sure that the test is falsy, and therefore
-short-circuiting couldn't happen.
-
-### And
-
-```py
-def _(flag: bool, number: int):
-    if flag and (x := number):
-        # x must be defined here
-        reveal_type(x)  # revealed: int & ~AlwaysFalsy
-    else:
-        # TODO: could be int & AlwaysFalsy
-        # error: [possibly-unresolved-reference]
-        reveal_type(x)  # revealed: int
-
-    # error: [possibly-unresolved-reference]
-    reveal_type(x)  # revealed: int
-```
-
-### Or
-
-```py
-def _(flag: bool, number: int):
-    if flag or (x := number):
-        # TODO: could be int & AlwaysTruthy
-        # error: [possibly-unresolved-reference]
-        reveal_type(x)  # revealed: int
-    else:
-        # x must be defined here
-        reveal_type(x)  # revealed: int & ~AlwaysTruthy
-
-    # error: [possibly-unresolved-reference]
-    reveal_type(x)  # revealed: int
-```
-
-### Elif
-
-```py
-def _(flag: bool, flag2: bool, number: int):
-    if flag or (x := number):
-        # error: [possibly-unresolved-reference]
-        reveal_type(x)  # revealed: int
-    elif flag2 or (y := number):
-        # x must be defined here
-        reveal_type(x)  # revealed: int & ~AlwaysTruthy
-
-        # error: [possibly-unresolved-reference]
-        reveal_type(y)  # revealed: int
-    else:
-        # x and y must be defined here
-        reveal_type(x)  # revealed: int & ~AlwaysTruthy
-        reveal_type(y)  # revealed: int & ~AlwaysTruthy
-
-    if flag or (x := number):
-        # error: [possibly-unresolved-reference]
-        reveal_type(x)  # revealed: int
-    elif flag2 and (y := number):
-        # x must be defined here
-        reveal_type(x)  # revealed: int & ~AlwaysTruthy
-
-        reveal_type(y)  # revealed: int & ~AlwaysFalsy
-    else:
-        # x must be defined here
-        reveal_type(x)  # revealed: int & ~AlwaysTruthy
-
-        # error: [possibly-unresolved-reference]
-        reveal_type(y)  # revealed: int
-
-    if flag and (x := number):
-        reveal_type(x)  # revealed: int & ~AlwaysFalsy
-    elif flag2 or (y := number):
-        # error: [possibly-unresolved-reference]
-        reveal_type(x)  # revealed: int
-
-        # error: [possibly-unresolved-reference]
-        reveal_type(y)  # revealed: int
-    else:
-        # error: [possibly-unresolved-reference]
-        reveal_type(x)  # revealed: int
-
-        reveal_type(y)  # revealed: int & ~AlwaysTruthy
-```
-
-### Nested boolean expression
-
-```py
-def _(flag: bool, number: int):
-    # error: [possibly-unresolved-reference]
-    (flag or (x := number)) and reveal_type(x)  # revealed: int
-
-def _(flag: bool, number: int):
-    # x must be defined here
-    (flag or (x := number)) or reveal_type(x)  # revealed: int & ~AlwaysTruthy
-
-def _(flag: bool, flag_2: bool, number: int):
-    if flag and (flag_2 and (x := number)):
-        # x must be defined here
-        reveal_type(x)  # revealed: int & ~AlwaysFalsy
-
-def _(flag: bool, flag_2: bool, number: int):
-    if flag and (flag_2 or (x := number)):
-        # error: [possibly-unresolved-reference]
-        reveal_type(x)  # revealed: int
-    else:
-        # error: [possibly-unresolved-reference]
-        reveal_type(x)  # revealed: int
-
-def _(flag: bool, flag_2: bool, number: int):
-    if flag or (flag_2 or (x := number)):
-        # error: [possibly-unresolved-reference]
-        reveal_type(x)  # revealed: int
-    else:
-        # x must be defined here
-        reveal_type(x)  # revealed: int & ~AlwaysTruthy
-```
-
-## This logic can be applied in additional cases that aren't supported yet
-
-### If Expression
-
-```py
-def _(flag: bool, number: int):
-    # TODO: x must be defined here
-    # error: [possibly-unresolved-reference]
-    reveal_type(x) if flag and (x := number) else None  # revealed: int & ~AlwaysFalsy
-```
-
-### While Statement
-
-```py
-def _(flag: bool, number: int):
-    while flag and (x := number):
-        # TODO: x must be defined here
-        # error: [possibly-unresolved-reference]
-        reveal_type(x)  # revealed: int & ~AlwaysFalsy
-
-    # error: [possibly-unresolved-reference]
-    reveal_type(x)  # revealed: int
-
-def _(flag: bool, number: int):
-    while flag or (x := number):
-        # error: [possibly-unresolved-reference]
-        reveal_type(x)  # revealed: int
-
-    # TODO: x must be defined here
-    # error: [possibly-unresolved-reference]
-    reveal_type(x)  # revealed: int & ~AlwaysTruthy
 ```

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/boolean.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/boolean.md
@@ -52,7 +52,7 @@ def _(x: A | B):
 
     if False and isinstance(x, A):
         # TODO: should emit an `unreachable code` diagnostic
-        reveal_type(x)  # revealed: Never
+        reveal_type(x)  # revealed: A
     else:
         reveal_type(x)  # revealed: A | B
 
@@ -65,7 +65,7 @@ def _(x: A | B):
         reveal_type(x)  # revealed: A | B
     else:
         # TODO: should emit an `unreachable code` diagnostic
-        reveal_type(x)  # revealed: Never
+        reveal_type(x)  # revealed: B & ~A
 
     reveal_type(x)  # revealed: A | B
 ```


### PR DESCRIPTION
This reverts commit 9910ec700c45efcb9734926fb1412bec22b34100.

## Summary

This change introduced a serious performance regression. Revert it while we investigate.

Fixes https://github.com/astral-sh/ty/issues/431

## Test Plan

Timing on the snippet in https://github.com/astral-sh/ty/issues/431 again shows times similar to before the regression.
