### PR TITLE
[ty] Avoid panicking when there are multiple workspaces

### DIFF
--- a/crates/ty_server/src/message.rs
+++ b/crates/ty_server/src/message.rs
@@ -44,3 +44,11 @@ macro_rules! show_err_msg {
         crate::message::show_message(::core::format_args!($msg$(, $($arg)*)?).to_string(), lsp_types::MessageType::ERROR)
     };
 }
+
+/// Sends a request to display a warning to the client with a formatted message. The warning is
+/// sent in a `window/showMessage` notification.
+macro_rules! show_warn_msg {
+    ($msg:expr$(, $($arg:tt)*)?) => {
+        crate::message::show_message(::core::format_args!($msg$(, $($arg)*)?).to_string(), lsp_types::MessageType::WARNING)
+    };
+}

--- a/crates/ty_server/src/server.rs
+++ b/crates/ty_server/src/server.rs
@@ -96,10 +96,20 @@ impl Server {
                 anyhow::anyhow!("Failed to get the current working directory while creating a default workspace.")
             })?;
 
-        if workspaces.len() > 1 {
-            // TODO(dhruvmanila): Support multi-root workspaces
-            anyhow::bail!("Multi-root workspaces are not supported yet");
-        }
+        let workspaces = if workspaces.len() > 1 {
+            let first_workspace = workspaces.into_iter().next().unwrap();
+            tracing::warn!(
+                "Multiple workspaces are not yet supported, using the first workspace: {}",
+                &first_workspace.0
+            );
+            show_warn_msg!(
+                "Multiple workspaces are not yet supported, using the first workspace: {}",
+                &first_workspace.0
+            );
+            vec![first_workspace]
+        } else {
+            workspaces
+        };
 
         Ok(Self {
             connection,


### PR DESCRIPTION
## Summary

This PR updates the language server to avoid panicking when there are multiple workspace folders passed during initialization. The server currently picks up the first workspace folder and provides a warning and a log message.

## Test Plan

<img width="1724" alt="Screenshot 2025-05-17 at 11 43 09" src="https://github.com/user-attachments/assets/1a7ddbc3-198d-4191-a28f-9b69321e8f99" />

