### PR TITLE
Only enable `js` feature of `uuid` crate for wasm crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3157,6 +3157,7 @@ dependencies = [
  "ruff_workspace",
  "serde",
  "serde-wasm-bindgen",
+ "uuid",
  "wasm-bindgen",
  "wasm-bindgen-test",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4178,6 +4178,7 @@ dependencies = [
  "ty_ide",
  "ty_project",
  "ty_python_semantic",
+ "uuid",
  "wasm-bindgen",
  "wasm-bindgen-test",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,7 +178,6 @@ uuid = { version = "1.6.1", features = [
     "v4",
     "fast-rng",
     "macro-diagnostics",
-    "js",
 ] }
 walkdir = { version = "2.3.2" }
 wasm-bindgen = { version = "0.2.92" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,7 +186,7 @@ wild = { version = "2" }
 zip = { version = "0.6.6", default-features = false }
 
 [workspace.metadata.cargo-shear]
-ignored = ["getrandom", "ruff_options_metadata"]
+ignored = ["getrandom", "ruff_options_metadata", "uuid"]
 
 
 [workspace.lints.rust]

--- a/crates/ruff_wasm/Cargo.toml
+++ b/crates/ruff_wasm/Cargo.toml
@@ -41,6 +41,8 @@ getrandom = { workspace = true, features = ["wasm_js"] }
 serde = { workspace = true }
 serde-wasm-bindgen = { workspace = true }
 wasm-bindgen = { workspace = true }
+# Not a direct dependency but required to compile for Wasm.
+uuid = { workspace = true, features = ["js"] }
 
 [dev-dependencies]
 wasm-bindgen-test = { workspace = true }

--- a/crates/ty_wasm/Cargo.toml
+++ b/crates/ty_wasm/Cargo.toml
@@ -40,6 +40,8 @@ log = { workspace = true }
 # See https://docs.rs/getrandom/latest/getrandom/#webassembly-support
 getrandom = { workspace = true, features = ["wasm_js"] }
 serde-wasm-bindgen = { workspace = true }
+# Not a direct dependency but required to compile for Wasm.
+uuid = { workspace = true, features = ["js"] }
 
 wasm-bindgen = { workspace = true }
 


### PR DESCRIPTION
## Summary

This moves the feature enablement from the workspace to only the crates that needs it, which means the other crates don't automatically enable this feature on the `uuid` crate (which causes wasm-bindgen to be pulled in).

## Test Plan

It builds still.
