### PR TITLE
[ty] Infer function call typevars in both directions

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -341,6 +341,39 @@ reveal_type(C(1, True))  # revealed: C[Literal[1]]
 wrong_innards: C[int] = C("five", 1)
 ```
 
+### Some `__init__` overloads only apply to certain specializations
+
+```py
+from typing import overload, Generic, TypeVar
+
+T = TypeVar("T")
+
+class C(Generic[T]):
+    @overload
+    def __init__(self: "C[str]", x: str) -> None: ...
+    @overload
+    def __init__(self: "C[bytes]", x: bytes) -> None: ...
+    @overload
+    def __init__(self, x: int) -> None: ...
+    def __init__(self, x: str | bytes | int) -> None: ...
+
+reveal_type(C("string"))  # revealed: C[str]
+reveal_type(C(b"bytes"))  # revealed: C[bytes]
+reveal_type(C(12))  # revealed: C[Unknown]
+
+C[str]("string")
+C[str](b"bytes")  # error: [no-matching-overload]
+C[str](12)
+
+C[bytes]("string")  # error: [no-matching-overload]
+C[bytes](b"bytes")
+C[bytes](12)
+
+C[None]("string")  # error: [no-matching-overload]
+C[None](b"bytes")  # error: [no-matching-overload]
+C[None](12)
+```
+
 ## Generic subclass
 
 When a generic subclass fills its superclass's type parameter with one of its own, the actual types

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
@@ -279,6 +279,37 @@ reveal_type(C(1, True))  # revealed: C[Literal[1]]
 wrong_innards: C[int] = C("five", 1)
 ```
 
+### Some `__init__` overloads only apply to certain specializations
+
+```py
+from typing import overload
+
+class C[T]:
+    @overload
+    def __init__(self: C[str], x: str) -> None: ...
+    @overload
+    def __init__(self: C[bytes], x: bytes) -> None: ...
+    @overload
+    def __init__(self, x: int) -> None: ...
+    def __init__(self, x: str | bytes | int) -> None: ...
+
+reveal_type(C("string"))  # revealed: C[str]
+reveal_type(C(b"bytes"))  # revealed: C[bytes]
+reveal_type(C(12))  # revealed: C[Unknown]
+
+C[str]("string")
+C[str](b"bytes")  # error: [no-matching-overload]
+C[str](12)
+
+C[bytes]("string")  # error: [no-matching-overload]
+C[bytes](b"bytes")
+C[bytes](12)
+
+C[None]("string")  # error: [no-matching-overload]
+C[None](b"bytes")  # error: [no-matching-overload]
+C[None](12)
+```
+
 ## Generic subclass
 
 When a generic subclass fills its superclass's type parameter with one of its own, the actual types

--- a/crates/ty_python_semantic/resources/mdtest/generics/scoping.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/scoping.md
@@ -102,7 +102,7 @@ class C[T]:
         return "a"
 
 reveal_type(getattr_static(C[int], "f"))  # revealed: def f(self, x: int) -> str
-reveal_type(getattr_static(C[int], "f").__get__)  # revealed: <method-wrapper `__get__` of `f[int]`>
+reveal_type(getattr_static(C[int], "f").__get__)  # revealed: <method-wrapper `__get__` of `f`>
 reveal_type(getattr_static(C[int], "f").__get__(None, C[int]))  # revealed: def f(self, x: int) -> str
 # revealed: bound method C[int].f(x: int) -> str
 reveal_type(getattr_static(C[int], "f").__get__(C[int](), C[int]))

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1170,6 +1170,11 @@ impl<'db> Type<'db> {
                 target.is_equivalent_to(db, Type::object(db))
             }
 
+            // These clauses handle type variants that include function literals. A function
+            // literal is the subtype of itself, and not of any other function literal. However,
+            // our representation of a function literal includes any specialization that should be
+            // applied to the signature. Different specializations of the same function literal are
+            // only subtypes of each other if they result in the same signature.
             (Type::FunctionLiteral(self_function), Type::FunctionLiteral(target_function)) => {
                 self_function.is_subtype_of(db, target_function)
             }
@@ -1514,6 +1519,11 @@ impl<'db> Type<'db> {
                 true
             }
 
+            // These clauses handle type variants that include function literals. A function
+            // literal is assignable to itself, and not to any other function literal. However, our
+            // representation of a function literal includes any specialization that should be
+            // applied to the signature. Different specializations of the same function literal are
+            // only assignable to each other if they result in the same signature.
             (Type::FunctionLiteral(self_function), Type::FunctionLiteral(target_function)) => {
                 self_function.is_assignable_to(db, target_function)
             }
@@ -6942,9 +6952,7 @@ impl<'db> FunctionType<'db> {
         // A function literal is the subtype of itself, and not of any other function literal.
         // However, our representation of a function literal includes any specialization that
         // should be applied to the signature. Different specializations of the same function
-        // literal are only subtypes of each other if they result in the same signature. (Note that
-        // the equality check above will have already handled the case where `self` and `target`
-        // are the same function literal with the same specialization.)
+        // literal are only subtypes of each other if they result in the same signature.
         self.body_scope(db) == other.body_scope(db)
             && self
                 .into_callable_type(db)
@@ -6955,9 +6963,7 @@ impl<'db> FunctionType<'db> {
         // A function literal is assignable to itself, and not to any other function literal.
         // However, our representation of a function literal includes any specialization that
         // should be applied to the signature. Different specializations of the same function
-        // literal are only assignable to each other if they result in the same signature. (Note
-        // that the equality check above will have already handled the case where `self` and
-        // `target` are the same function literal with the same specialization.)
+        // literal are only assignable to each other if they result in the same signature.
         self.body_scope(db) == other.body_scope(db)
             && self
                 .into_callable_type(db)

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -6952,7 +6952,7 @@ impl<'db> FunctionType<'db> {
         // A function literal is the subtype of itself, and not of any other function literal.
         // However, our representation of a function literal includes any specialization that
         // should be applied to the signature. Different specializations of the same function
-        // literal are only subtypes of each other if they result in the same signature.
+        // literal are only subtypes of each other if they result in subtype signatures.
         self.body_scope(db) == other.body_scope(db)
             && self
                 .into_callable_type(db)
@@ -6963,7 +6963,7 @@ impl<'db> FunctionType<'db> {
         // A function literal is assignable to itself, and not to any other function literal.
         // However, our representation of a function literal includes any specialization that
         // should be applied to the signature. Different specializations of the same function
-        // literal are only assignable to each other if they result in the same signature.
+        // literal are only assignable to each other if they result in assignable signatures.
         self.body_scope(db) == other.body_scope(db)
             && self
                 .into_callable_type(db)

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -1412,7 +1412,7 @@ impl<'db> Binding<'db> {
         }
 
         num_synthetic_args = 0;
-        for (argument_index, (argument, argument_type)) in argument_types.iter().enumerate() {
+        for (argument_index, (argument, mut argument_type)) in argument_types.iter().enumerate() {
             if matches!(argument, Argument::Synthetic) {
                 num_synthetic_args += 1;
             }
@@ -1424,9 +1424,12 @@ impl<'db> Binding<'db> {
             let parameter = &parameters[parameter_index];
             if let Some(mut expected_ty) = parameter.annotated_type() {
                 if let Some(specialization) = self.specialization {
+                    argument_type = argument_type.apply_specialization(db, specialization);
                     expected_ty = expected_ty.apply_specialization(db, specialization);
                 }
                 if let Some(inherited_specialization) = self.inherited_specialization {
+                    argument_type =
+                        argument_type.apply_specialization(db, inherited_specialization);
                     expected_ty = expected_ty.apply_specialization(db, inherited_specialization);
                 }
                 if !argument_type.is_assignable_to(db, expected_ty) {

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -170,31 +170,15 @@ impl Display for DisplayRepresentation<'_> {
             Type::MethodWrapper(MethodWrapperKind::FunctionTypeDunderGet(function)) => {
                 write!(
                     f,
-                    "<method-wrapper `__get__` of `{function}{specialization}`>",
+                    "<method-wrapper `__get__` of `{function}`>",
                     function = function.name(self.db),
-                    specialization = if let Some(specialization) = function.specialization(self.db)
-                    {
-                        specialization
-                            .display_short(self.db, TupleSpecialization::No)
-                            .to_string()
-                    } else {
-                        String::new()
-                    },
                 )
             }
             Type::MethodWrapper(MethodWrapperKind::FunctionTypeDunderCall(function)) => {
                 write!(
                     f,
-                    "<method-wrapper `__call__` of `{function}{specialization}`>",
+                    "<method-wrapper `__call__` of `{function}`>",
                     function = function.name(self.db),
-                    specialization = if let Some(specialization) = function.specialization(self.db)
-                    {
-                        specialization
-                            .display_short(self.db, TupleSpecialization::No)
-                            .to_string()
-                    } else {
-                        String::new()
-                    },
                 )
             }
             Type::MethodWrapper(MethodWrapperKind::PropertyDunderGet(_)) => {

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -7,8 +7,8 @@ use crate::types::class_base::ClassBase;
 use crate::types::instance::{NominalInstanceType, Protocol, ProtocolInstanceType};
 use crate::types::signatures::{Parameter, Parameters, Signature};
 use crate::types::{
-    declaration_type, todo_type, KnownInstanceType, Type, TypeVarBoundOrConstraints,
-    TypeVarInstance, TypeVarVariance, UnionType,
+    KnownInstanceType, Type, TypeVarBoundOrConstraints, TypeVarInstance, TypeVarVariance,
+    UnionType, declaration_type, todo_type,
 };
 use crate::{Db, FxOrderSet};
 

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -641,32 +641,33 @@ impl<'db> SpecializationBuilder<'db> {
         }
 
         match (formal, actual) {
-            (Type::TypeVar(typevar), _) => match typevar.bound_or_constraints(self.db) {
+            (Type::TypeVar(typevar), ty) | (ty, Type::TypeVar(typevar)) => {
+                match typevar.bound_or_constraints(self.db) {
                 Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
-                    if !actual.is_assignable_to(self.db, bound) {
+                    if !ty.is_assignable_to(self.db, bound) {
                         return Err(SpecializationError::MismatchedBound {
                             typevar,
-                            argument: actual,
+                            argument: ty,
                         });
                     }
-                    self.add_type_mapping(typevar, actual);
+                    self.add_type_mapping(typevar, ty);
                 }
                 Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
                     for constraint in constraints.iter(self.db) {
-                        if actual.is_assignable_to(self.db, *constraint) {
+                        if ty.is_assignable_to(self.db, *constraint) {
                             self.add_type_mapping(typevar, *constraint);
                             return Ok(());
                         }
                     }
                     return Err(SpecializationError::MismatchedConstraint {
                         typevar,
-                        argument: actual,
+                        argument: ty,
                     });
                 }
                 _ => {
-                    self.add_type_mapping(typevar, actual);
+                    self.add_type_mapping(typevar, ty);
                 }
-            },
+                }}
 
             (Type::Tuple(formal_tuple), Type::Tuple(actual_tuple)) => {
                 let formal_elements = formal_tuple.elements(self.db);

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1528,7 +1528,7 @@ mod tests {
         db.write_dedented("/src/a.py", "def f(): ...").unwrap();
         let func = get_function_f(&db, "/src/a.py");
 
-        let sig = func.internal_signature(&db);
+        let sig = func.internal_signature(&db, None);
 
         assert!(sig.return_ty.is_none());
         assert_params(&sig, &[]);
@@ -1551,7 +1551,7 @@ mod tests {
         .unwrap();
         let func = get_function_f(&db, "/src/a.py");
 
-        let sig = func.internal_signature(&db);
+        let sig = func.internal_signature(&db, None);
 
         assert_eq!(sig.return_ty.unwrap().display(&db).to_string(), "bytes");
         assert_params(
@@ -1602,7 +1602,7 @@ mod tests {
         .unwrap();
         let func = get_function_f(&db, "/src/a.py");
 
-        let sig = func.internal_signature(&db);
+        let sig = func.internal_signature(&db, None);
 
         let [
             Parameter {
@@ -1638,7 +1638,7 @@ mod tests {
         .unwrap();
         let func = get_function_f(&db, "/src/a.pyi");
 
-        let sig = func.internal_signature(&db);
+        let sig = func.internal_signature(&db, None);
 
         let [
             Parameter {
@@ -1674,7 +1674,7 @@ mod tests {
         .unwrap();
         let func = get_function_f(&db, "/src/a.py");
 
-        let sig = func.internal_signature(&db);
+        let sig = func.internal_signature(&db, None);
 
         let [
             Parameter {
@@ -1720,7 +1720,7 @@ mod tests {
         .unwrap();
         let func = get_function_f(&db, "/src/a.pyi");
 
-        let sig = func.internal_signature(&db);
+        let sig = func.internal_signature(&db, None);
 
         let [
             Parameter {
@@ -1756,7 +1756,7 @@ mod tests {
         .unwrap();
         let func = get_function_f(&db, "/src/a.py");
 
-        let expected_sig = func.internal_signature(&db);
+        let expected_sig = func.internal_signature(&db, None);
 
         // With no decorators, internal and external signature are the same
         assert_eq!(


### PR DESCRIPTION
This primarily comes up with annotated `self` parameters in constructors:

```py
class C[T]:
    def __init__(self: C[int]): ...
```

Here, we want infer a specialization of `{T = int}` for a call that hits this overload. 

Normally when inferring a specialization of a function call, typevars appear in the parameter annotations, and not in the argument types.  In this case, this is reversed: we need to verify that the `self` argument (`C[T]`, as we have not yet completed specialization inference) is assignable to the parameter type `C[int]`.

To do this, we simply look for a typevar/type in both directions when performing inference, and apply the inferred specialization to argument types as well as parameter types before verifying assignability.

As a wrinkle, this exposed that we were not checking subtyping/assignability for function literals correctly. Our function literal representation includes an optional specialization that should be applied to the signature. Before, function literals were considered subtypes of (assignable to) each other only if they were identical Salsa objects. Two function literals with different specializations should still be considered subtypes of (assignable to) each other if those specializations result in the same function signature (typically because the function doesn't use the typevars in the specialization).

Closes https://github.com/astral-sh/ty/issues/370
Closes https://github.com/astral-sh/ty/issues/100
Closes https://github.com/astral-sh/ty/issues/258