### PR TITLE
Fix name resolution in package __init__.py

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pydocstyle/D103/__init__.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydocstyle/D103/__init__.py
@@ -1,0 +1,10 @@
+from .markers import no_docs_needed
+
+
+def must_have_docs():  # lint error
+    pass
+
+
+@no_docs_needed
+def ok_to_have_no_docs():  # no lint
+    pass

--- a/crates/ruff_linter/resources/test/fixtures/pydocstyle/D103/markers/__init__.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydocstyle/D103/markers/__init__.py
@@ -1,0 +1,12 @@
+def no_docs_needed(f):
+    """Mark function as not needing a docstring."""
+    return f
+
+
+def must_have_docs():  # lint error
+    pass
+
+
+@no_docs_needed
+def ok_to_have_no_docs():  # no lint
+    pass

--- a/crates/ruff_linter/resources/test/fixtures/pylint/import_self/subpackage/__init__.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/import_self/subpackage/__init__.py
@@ -1,0 +1,1 @@
+from .. import subpackage

--- a/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
@@ -978,12 +978,9 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                 }
             }
             if checker.enabled(Rule::ImportSelf) {
-                if let Some(diagnostic) = pylint::rules::import_from_self(
-                    level,
-                    module,
-                    names,
-                    checker.module.qualified_name(),
-                ) {
+                if let Some(diagnostic) =
+                    pylint::rules::import_from_self(level, module, names, &checker.module)
+                {
                     checker.report_diagnostic(diagnostic);
                 }
             }

--- a/crates/ruff_linter/src/rules/pydocstyle/mod.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/mod.rs
@@ -113,6 +113,26 @@ mod tests {
         Ok(())
     }
 
+    #[test_case(Rule::UndocumentedPublicFunction, Path::new("__init__.py"))]
+    #[test_case(Rule::UndocumentedPublicFunction, Path::new("markers/__init__.py"))]
+    fn ignore_local_decorators(rule_code: Rule, path: &Path) -> Result<()> {
+        let snapshot = format!("{}_{}", rule_code.noqa_code(), path.to_string_lossy());
+        let diagnostics = test_path(
+            Path::new("pydocstyle/D103").join(path).as_path(),
+            &settings::LinterSettings {
+                pydocstyle: Settings {
+                    ignore_decorators: ["D103.markers.no_docs_needed".to_string()]
+                        .into_iter()
+                        .collect(),
+                    ..Settings::default()
+                },
+                ..settings::LinterSettings::for_rule(rule_code)
+            },
+        )?;
+        assert_messages!(snapshot, diagnostics);
+        Ok(())
+    }
+
     #[test]
     fn bom() -> Result<()> {
         let diagnostics = test_path(

--- a/crates/ruff_linter/src/rules/pydocstyle/snapshots/ruff_linter__rules__pydocstyle__tests__D103___init__.py.snap
+++ b/crates/ruff_linter/src/rules/pydocstyle/snapshots/ruff_linter__rules__pydocstyle__tests__D103___init__.py.snap
@@ -1,0 +1,10 @@
+---
+source: crates/ruff_linter/src/rules/pydocstyle/mod.rs
+assertion_line: 132
+---
+__init__.py:4:5: D103 Missing docstring in public function
+  |
+4 | def must_have_docs():  # lint error
+  |     ^^^^^^^^^^^^^^ D103
+5 |     pass
+  |

--- a/crates/ruff_linter/src/rules/pydocstyle/snapshots/ruff_linter__rules__pydocstyle__tests__D103_markers____init__.py.snap
+++ b/crates/ruff_linter/src/rules/pydocstyle/snapshots/ruff_linter__rules__pydocstyle__tests__D103_markers____init__.py.snap
@@ -1,0 +1,10 @@
+---
+source: crates/ruff_linter/src/rules/pydocstyle/mod.rs
+assertion_line: 132
+---
+__init__.py:6:5: D103 Missing docstring in public function
+  |
+6 | def must_have_docs():  # lint error
+  |     ^^^^^^^^^^^^^^ D103
+7 |     pass
+  |

--- a/crates/ruff_linter/src/rules/pylint/mod.rs
+++ b/crates/ruff_linter/src/rules/pylint/mod.rs
@@ -80,6 +80,7 @@ mod tests {
         Path::new("import_private_name/submodule/__main__.py")
     )]
     #[test_case(Rule::ImportSelf, Path::new("import_self/module.py"))]
+    #[test_case(Rule::ImportSelf, Path::new("import_self/subpackage/__init__.py"))]
     #[test_case(Rule::InvalidAllFormat, Path::new("invalid_all_format.py"))]
     #[test_case(Rule::InvalidAllObject, Path::new("invalid_all_object.py"))]
     #[test_case(Rule::InvalidBoolReturnType, Path::new("invalid_return_type_bool.py"))]

--- a/crates/ruff_linter/src/rules/pylint/rules/import_self.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/import_self.rs
@@ -3,6 +3,7 @@ use ruff_python_ast::Alias;
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_python_ast::helpers::resolve_imported_module_path;
+use ruff_python_semantic::Module;
 use ruff_text_size::Ranged;
 
 /// ## What it does
@@ -55,10 +56,19 @@ pub(crate) fn import_from_self(
     level: u32,
     module: Option<&str>,
     names: &[Alias],
-    module_path: Option<&[String]>,
+    inside_module: &Module,
 ) -> Option<Diagnostic> {
-    let module_path = module_path?;
+    let module_path = inside_module.qualified_name()?;
     let imported_module_path = resolve_imported_module_path(level, module, Some(module_path))?;
+    let module_path = {
+        if inside_module.kind.is_package()
+            && module_path.iter().last().map(String::as_str) == Some("__init__")
+        {
+            &module_path[..module_path.len() - 1]
+        } else {
+            module_path
+        }
+    };
 
     if imported_module_path
         .split('.')

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW0406_import_self__subpackage____init__.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW0406_import_self__subpackage____init__.py.snap
@@ -1,0 +1,9 @@
+---
+source: crates/ruff_linter/src/rules/pylint/mod.rs
+assertion_line: 249
+---
+__init__.py:1:16: PLW0406 Module `import_self.subpackage` imports itself
+  |
+1 | from .. import subpackage
+  |                ^^^^^^^^^^ PLW0406
+  |

--- a/crates/ruff_python_semantic/src/model.rs
+++ b/crates/ruff_python_semantic/src/model.rs
@@ -1044,7 +1044,13 @@ impl<'a> SemanticModel<'a> {
             }
             BindingKind::ClassDefinition(_) | BindingKind::FunctionDefinition(_) => {
                 // If we have a fully-qualified path for the module, use it.
-                if let Some(path) = self.module.qualified_name() {
+                if let Some(mut path) = self.module.qualified_name() {
+                    if self.module.kind.is_package()
+                        && path.iter().last().map(String::as_str) == Some("__init__")
+                    {
+                        // Binding in `__init__.py` is resolved relative to the package.
+                        path = &path[..path.len() - 1];
+                    }
                     Some(
                         path.iter()
                             .map(String::as_str)


### PR DESCRIPTION
## Summary
When resolving the name while linting a package's `__init__.py` file, ruff was considering `__init__` to be a proper module name. Whereas it's not really. Classes, functions, and other objects defined in `__init__.py` will belong to the package. This PR fixes that resolution. In particular, `D103`, and `PLW0406` were affected. Maybe more that I couldn't find.

## Test Plan
I've added tests for the two rules I could find were affected by not properly resolving qualified names of objects inside a package's `__init__.py`.
