### PR TITLE
Fix rendering of admonition in docs

### DIFF
--- a/docs/requirements-insiders.txt
+++ b/docs/requirements-insiders.txt
@@ -5,3 +5,4 @@ mkdocs-material @ git+ssh://git@github.com/astral-sh/mkdocs-material-insiders.gi
 mkdocs-redirects==1.2.2
 mdformat==0.7.22
 mdformat-mkdocs==4.1.2
+mkdocs-github-admonitions-plugin @ https://github.com/PGijsbers/admonitions.git#7343d2f4a92e4d1491094530ef3d0d02d93afbb7

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,3 +5,4 @@ mkdocs-material==9.5.38
 mkdocs-redirects==1.2.2
 mdformat==0.7.22
 mdformat-mkdocs==4.1.2
+mkdocs-github-admonitions-plugin @ https://github.com/PGijsbers/admonitions.git#7343d2f4a92e4d1491094530ef3d0d02d93afbb7

--- a/mkdocs.template.yml
+++ b/mkdocs.template.yml
@@ -62,6 +62,7 @@ markdown_extensions:
       alternate_style: true
 plugins:
   - search
+  - gh-admonitions
 extra_css:
   - stylesheets/extra.css
 extra_javascript:


### PR DESCRIPTION
## Summary

GitHub and mkdocs use different syntaxes for admonition. The mkdocs admonition have more features but we have some markdown files that are both rendered on GitHub and mkdocs.
This PR includes a mkdocs plugin that transforms GitHub admonition to mkdocs admonitions. 

An alternative to the extension is to extend `generate_mkdocs` to also replace admonitions. Given that the plugin already exists, this seemed easier. 

I had to tag a specific commit because the pypi release doen't include the fix for https://github.com/PGijsbers/admonitions/issues/3

Fixes https://github.com/astral-sh/ruff/issues/18158

## Test Plan

Build the docs locally
