### PR TITLE
[ty] Add assignability between class with `__call__` class attribute and callable

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
@@ -674,8 +674,13 @@ c1: Callable[[int], None] = partial(f, y="a")
 
 ### Classes with `__call__` defined as attribute
 
+```toml
+[environment]
+python-version = "3.11"
+```
+
 ```py
-from typing import Callable, Any
+from typing import Callable, Any, Self
 from ty_extensions import static_assert, is_assignable_to
 
 class A:
@@ -688,17 +693,15 @@ class A:
 class B:
     def method1(self, b: int) -> int:
         return b
-
     __call__ = method1
 
 class C:
     def method1(self, c: int) -> int:
         return c
-
-    __call__: Callable[["C", int], int] = method1
+    __call__: Callable[[Self, int], int] = method1
 
 class D:
-    __call__: Callable[["D", int], int] = lambda self, d: d
+    __call__: Callable[[Self, int], int] = lambda self, d: d
 
 static_assert(is_assignable_to(A, Callable[[int], int]))
 

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
@@ -703,13 +703,11 @@ class C:
 class D:
     __call__: Callable[[Self, int], int] = lambda self, d: d
 
-static_assert(is_assignable_to(A, Callable[[int], int]))
-
-# TODO these tests should fail, but for now A.__call__ is Dynamic thus always return True.
-static_assert(not is_assignable_to(A, Callable[[int, int], int]))  # error: [static-assert-error]
-static_assert(not is_assignable_to(A, Callable[[int], str]))  # error: [static-assert-error]
-static_assert(not is_assignable_to(A, Callable[[str], int]))  # error: [static-assert-error]
-static_assert(not is_assignable_to(A, Callable[[str], str]))  # error: [static-assert-error]
+static_assert(not is_assignable_to(A, Callable[[int], int]))
+static_assert(not is_assignable_to(A, Callable[[int, int], int]))
+static_assert(not is_assignable_to(A, Callable[[int], str]))
+static_assert(not is_assignable_to(A, Callable[[str], int]))
+static_assert(not is_assignable_to(A, Callable[[str], str]))
 
 static_assert(is_assignable_to(B, Callable[[int], int]))
 static_assert(not is_assignable_to(B, Callable[[int, int], int]))
@@ -736,7 +734,7 @@ d = D()
 
 def f(fn: Callable[[int], int]) -> None: ...
 
-f(a)
+f(a)  # error: [invalid-argument-type]
 f(b)
 f(c)
 f(d)

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
@@ -1157,6 +1157,63 @@ def f(fn: Callable[[int], int]) -> None: ...
 f(a)
 ```
 
+### Classes with `__call__` defined as attribute
+
+```toml
+[environment]
+python-version = "3.11"
+```
+
+```py
+from typing import Callable, Any, Self
+from ty_extensions import static_assert, is_subtype_of
+
+class A:
+    def method1(self, a: int) -> int:
+        return a
+
+    def __init__(self):
+        self.__call__ = self.method1
+
+class B:
+    def method1(self, b: int) -> int:
+        return b
+    __call__ = method1
+
+class C:
+    def method1(self, c: int) -> int:
+        return c
+    __call__: Callable[[Self, int], int] = method1
+
+class D:
+    __call__: Callable[[Self, int], int] = lambda self, d: d
+
+static_assert(not is_subtype_of(A, Callable[[int], int]))
+static_assert(not is_subtype_of(A, Callable[[int, int], int]))
+static_assert(not is_subtype_of(A, Callable[[int], str]))
+static_assert(not is_subtype_of(A, Callable[[str], int]))
+static_assert(not is_subtype_of(A, Callable[[str], str]))
+
+# __call__ is not declared, so we infer a union with Unknown, which is not fully static
+static_assert(not is_subtype_of(B, Callable[[int], int]))
+static_assert(not is_subtype_of(B, Callable[[int, int], int]))
+static_assert(not is_subtype_of(B, Callable[[int], str]))
+static_assert(not is_subtype_of(B, Callable[[str], int]))
+static_assert(not is_subtype_of(B, Callable[[str], str]))
+
+static_assert(is_subtype_of(C, Callable[[int], int]))
+static_assert(not is_subtype_of(C, Callable[[C, int], int]))
+static_assert(not is_subtype_of(C, Callable[[int], str]))
+static_assert(not is_subtype_of(C, Callable[[str], int]))
+static_assert(not is_subtype_of(C, Callable[[str], str]))
+
+static_assert(is_subtype_of(D, Callable[[int], int]))
+static_assert(not is_subtype_of(D, Callable[[D, int], int]))
+static_assert(not is_subtype_of(D, Callable[[int], str]))
+static_assert(not is_subtype_of(D, Callable[[str], int]))
+static_assert(not is_subtype_of(D, Callable[[str], str]))
+```
+
 ### Class literals
 
 #### Classes with metaclasses


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

There are some classes that's callable but defined via `__call__` as attributes, e.g. [pytorch `Module`](https://github.com/pytorch/pytorch/blob/main/torch/nn/modules/module.py#L1906).

This PR should add support for checking assignability for such classes. Not sure if we should do subtyping though.

## Test Plan

<!-- How was it tested? -->

I added tests into `is_assignable_to.md`. Referred to this [`pyright` PR](https://github.com/microsoft/pyright/pull/5799) and this [`mypy` PR](https://github.com/python/mypy/pull/11150).

I tested multiple possible forms of having `__call__` attribute, and check if ty accepts & rejects callable types correctly.

## Things to Notice

- First time contributing, so please don't hesitate to point out anything that looks off!
- Regarding class `A` in the test: [`pyright`](https://github.com/microsoft/pyright/pull/5799) seems to reject `__call__` as instance variables when it comes to callable check, while `mypy` appears to accept it. The type of `a.__call__` checked by `ty` is `Unknown`, though I personally think it should be `Unknown | A.method1` with the `self` parameter already filled in. I'm open to discussing which approach would be best here.
- Regarding class `C` in the test. `pyright` doesn't allow assigning `c` into callable with `self` filled. However it does allow assigning `b` into callable (no explicit type hint on `__call__`). [link](https://pyright-play.net/?strict=true&code=GYJw9gtgBALgngBwJYDsDmUkQWEMoDCAhgDYlEBGJApgDRQDK1JwAUKwMbkDO3UAQgC5WUUVAAm1YFAjUYACzDiAjAApuzYPQqDMKGAEooAWgB8emMLHWoIOQFcQKKBXbWA%2Bu46kSnqAF4ZOUUVdk4ePgIrMUlpWQUlNQ0Weg5dVEMTcwzom1sHJygONzFPbzJPXWIyShoAbTqmFIsAXXoMloCghNDWWKhgVTTCH1rqBo72-RaDXQA6BfYKLv5VA04ugjXWQYp1wY4DIA)

Thanks for your time and feedback!