### PR TITLE
Add rustfmt.toml file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
+# Please update rustfmt.toml when bumping the Rust edition
 edition = "2024"
 rust-version = "1.85"
 homepage = "https://docs.astral.sh/ruff"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+edition = "2024"
+style_edition = "2024"


### PR DESCRIPTION
My editor runs `rustfmt` on save to format Rust code, not `cargo fmt`.

With our recent bump to the Rust 2024 edition, the formatting that `rustfmt`/`cargo fmt` applies changed. Unfortunately, `rustfmt` and `cargo fmt` have different behaviors for determining which edition to use when formatting: `cargo fmt` looks for the Rust edition in `Cargo.toml`, whereas `rustfmt` looks for it in `rustfmt.toml`. As a result, whenever I save, I have to remember to manually run `cargo fmt` before committing/pushing.

There is an open issue asking for `rustfmt` to also look at `Cargo.toml` when it's present (https://github.com/rust-lang/rust.vim/issues/368), but it seems like they "closed" that issue just by bumping the default edition (six years ago, from 2015 to 2018).

In the meantime, this PR adds a `rustfmt.toml` file with our current Rust edition so that both invocation have the same behavior. I don't love that this duplicates information in `Cargo.toml`, but I've added a reminder comment there to hopefully ensure that we bump the edition in both places three years from now.