### PR TITLE
[ty] Raise `invalid-exception-caught` even when exception is not captured

### DIFF
--- a/crates/ty_project/resources/test/corpus/except_handler_with_Any_bound_typevar.py
+++ b/crates/ty_project/resources/test/corpus/except_handler_with_Any_bound_typevar.py
@@ -1,0 +1,14 @@
+def name_1[name_0: name_0](name_2: name_0):
+    try:
+        pass
+    except name_2:
+        pass
+
+from typing import Any
+
+def name_2[T: Any](x: T):
+    try:
+        pass
+    except x:
+        pass
+

--- a/crates/ty_python_semantic/resources/mdtest/exception/basic.md
+++ b/crates/ty_python_semantic/resources/mdtest/exception/basic.md
@@ -94,6 +94,18 @@ def foo(
     # error: [invalid-exception-caught]
     except z as g:
         reveal_type(g)  # revealed: Unknown
+
+try:
+    {}.get("foo")
+# error: [invalid-exception-caught]
+except int:
+    pass
+
+try:
+    {}.get("foo")
+# error: [invalid-exception-caught]
+except int as err:
+    pass
 ```
 
 ## Object raised is not an exception

--- a/crates/ty_python_semantic/resources/mdtest/exception/basic.md
+++ b/crates/ty_python_semantic/resources/mdtest/exception/basic.md
@@ -85,6 +85,35 @@ except TypeError:
     pass
 ```
 
+## Exception which catches typevar
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Callable
+
+def silence[T: type[BaseException]](
+    func: Callable[[], None],
+    exception_type: T,
+):
+    try:
+        func()
+    except exception_type as e:
+        reveal_type(e)  # revealed: T'instance
+
+def silence2[T: (
+    type[ValueError],
+    type[TypeError],
+)](func: Callable[[], None], exception_type: T,):
+    try:
+        func()
+    except exception_type as e:
+        reveal_type(e)  # revealed: T'instance
+```
+
 ## Invalid exception handlers
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/exception/basic.md
+++ b/crates/ty_python_semantic/resources/mdtest/exception/basic.md
@@ -62,6 +62,15 @@ def foo(
         reveal_type(i)  # revealed: BaseException
 ```
 
+## Exception with no captured type
+
+```py
+try:
+    {}.get("foo")
+except TypeError:
+    pass
+```
+
 ## Invalid exception handlers
 
 ```py
@@ -99,12 +108,6 @@ try:
     {}.get("foo")
 # error: [invalid-exception-caught]
 except int:
-    pass
-
-try:
-    {}.get("foo")
-# error: [invalid-exception-caught]
-except int as err:
     pass
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/exception/except_star.md
+++ b/crates/ty_python_semantic/resources/mdtest/exception/except_star.md
@@ -43,7 +43,16 @@ except* (KeyboardInterrupt, AttributeError) as e:
     reveal_type(e)  # revealed: BaseExceptionGroup[KeyboardInterrupt | AttributeError]
 ```
 
-## Invalid `except*` handlers
+## `except*` with no captured exception type
+
+```py
+try:
+    help()
+except* TypeError:
+    pass
+```
+
+## Invalid `except*` handlers with or without a captured exception type
 
 ```py
 try:

--- a/crates/ty_python_semantic/resources/mdtest/exception/except_star.md
+++ b/crates/ty_python_semantic/resources/mdtest/exception/except_star.md
@@ -48,6 +48,11 @@ except* (KeyboardInterrupt, AttributeError) as e:
 ```py
 try:
     help()
+except* int:  # error: [invalid-exception-caught]
+    pass
+
+try:
+    help()
 except* 3 as e:  # error: [invalid-exception-caught]
     reveal_type(e)  # revealed: BaseExceptionGroup[Unknown]
 

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -1815,10 +1815,13 @@ impl<'db> BindingError<'db> {
                     typevar.name(context.db()),
                 ));
 
-                let typevar_range = typevar.definition(context.db()).full_range(context.db());
-                let mut sub = SubDiagnostic::new(Severity::Info, "Type variable defined here");
-                sub.annotate(Annotation::primary(typevar_range.into()));
-                diag.sub(sub);
+                if let Some(typevar_definition) = typevar.definition(context.db()) {
+                    let typevar_range = typevar_definition.full_range(context.db());
+                    let mut sub = SubDiagnostic::new(Severity::Info, "Type variable defined here");
+                    sub.annotate(Annotation::primary(typevar_range.into()));
+                    diag.sub(sub);
+                }
+
                 if let Some(union_diag) = union_diag {
                     union_diag.add_union_context(context.db(), &mut diag);
                 }

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -2555,11 +2555,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             })
     }
 
-    fn infer_exception(
-        &mut self,
-        handled_exceptions: Option<&ast::Expr>,
-        is_star: bool,
-    ) -> Type<'db> {
+    fn infer_exception(&mut self, node: Option<&ast::Expr>, is_star: bool) -> Type<'db> {
         fn extract_tuple_specialization<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Type<'db>> {
             let class = ty.into_nominal_instance()?.class;
             if !class.is_known(db, KnownClass::Tuple) {
@@ -2575,8 +2571,6 @@ impl<'db> TypeInferenceBuilder<'db> {
                 .is_assignable_to(db, KnownClass::BaseException.to_instance(db))
                 .then_some(specialization_instance)
         }
-
-        let node = handled_exceptions.as_deref();
 
         // If there is no handled exception, it's invalid syntax;
         // a diagnostic will have already been emitted

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -2711,7 +2711,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         let ty = Type::KnownInstance(KnownInstanceType::TypeVar(TypeVarInstance::new(
             self.db(),
             name.id.clone(),
-            definition,
+            Some(definition),
             bound_or_constraint,
             TypeVarVariance::Invariant, // TODO: infer this
             default_ty,
@@ -5361,7 +5361,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                                             KnownInstanceType::TypeVar(TypeVarInstance::new(
                                                 self.db(),
                                                 target.id.clone(),
-                                                containing_assignment,
+                                                Some(containing_assignment),
                                                 bound_or_constraint,
                                                 variance,
                                                 *default,


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

Closes https://github.com/astral-sh/ty/issues/448

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Fix bug where `invalid-exception-caught` is not raised on invalid exceptions without explicit capturing (i.e. not using the `as` keyword) by creating a new `infer_exception` method that is called when inferring exceptions both with and without a definition.

## Test Plan

<!-- How was it tested? -->

Added new tests to `exception/basic.md` (for basic exceptions) and `exception/except_star.md` (for star exceptions) to ensure that `invalid-exception-caught` is properly raised even when the exception is not explicitly captured.