### PR TITLE
[ty] Add support for PyPy virtual environments

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,6 +1,7 @@
 doc-valid-idents = [
     "..",
     "CodeQL",
+    "CPython",
     "FastAPI",
     "IPython",
     "LangChain",
@@ -14,7 +15,7 @@ doc-valid-idents = [
     "SNMPv1",
     "SNMPv2",
     "SNMPv3",
-    "PyFlakes"
+    "PyFlakes",
 ]
 
 ignore-interior-mutability = [


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Allows for better package discovery, ex. PyPy (fixes https://github.com/astral-sh/ty/issues/450)

Instead of only looking for `site-packages` in `lib/pythonX.Y/`, we also look into `lib/pypyX.Y/`. To avoid guesswork, we look at the `Implementation` value provided by virtual environments inside `pyvenv.cfg`. 


- CPython or GraalPy -> `lib/pythonX.Y/site-packages`
- Pypy -> `lib/pypyX.Y/site-packages`
- Missing/Other value? -> Check both locations


## Test Plan

<!-- How was it tested? -->

As of now, passed all current tests, but no new tests have been added yet.

TODO: 
1. Add new tests, i.e., adding Implementation field (PyPy vs CPython vs other vs missing) to VirtualEnvironmentTestCase
2. Update comments/docstrings
