### PR TITLE
feat: check mro for `Unknown` in `is_assignable_to`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/exception/basic.md
+++ b/crates/ty_python_semantic/resources/mdtest/exception/basic.md
@@ -96,6 +96,17 @@ def foo(
         reveal_type(g)  # revealed: Unknown
 ```
 
+```py
+from compat import BASE_EXCEPTION_CLASS  # error: [unresolved-import] "Cannot resolve imported module `compat`"
+
+class Error(BASE_EXCEPTION_CLASS): ...
+
+try:
+    ...
+except Error as err:
+    ...
+```
+
 ## Object raised is not an exception
 
 ```py

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1542,6 +1542,14 @@ impl<'db> Type<'db> {
                 true
             }
 
+            (Type::ClassLiteral(class), Type::SubclassOf(_))
+                if class
+                    .iter_mro(db, None)
+                    .any(|x| ClassBase::Dynamic(DynamicType::Unknown) == x) =>
+            {
+                true
+            }
+
             // Every `type[...]` is assignable to `type`
             (Type::SubclassOf(_), _)
                 if KnownClass::Type


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

Hi, this is in regards to https://github.com/astral-sh/ty/issues/447.

## Summary

Now checks the MRO for `Unknown` when checking the assignability between `Type::ClassLiteral` and `Type::SubclassOf` since `Unknown` is assignable to any type.
There are probably more cases where this check would be interesting.

I'm not entirely sure how to handle the `Specialization` argument to `ClassLiteral::iter_mro` and whether it is ok to pass `None` here.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

Added markdown tests.
<!-- How was it tested? -->
