### PR TITLE
Remove `Checker::report_diagnostics`

### DIFF
--- a/crates/ruff_linter/src/checkers/ast/analyze/bindings.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/bindings.rs
@@ -83,11 +83,7 @@ pub(crate) fn bindings(checker: &Checker) {
             }
         }
         if !checker.source_type.is_stub() && checker.enabled(Rule::UnquotedTypeAlias) {
-            if let Some(diagnostics) =
-                flake8_type_checking::rules::unquoted_type_alias(checker, binding)
-            {
-                checker.report_diagnostics(diagnostics);
-            }
+            flake8_type_checking::rules::unquoted_type_alias(checker, binding);
         }
         if checker.enabled(Rule::UnsortedDunderSlots) {
             if let Some(diagnostic) = ruff::rules::sort_dunder_slots(checker, binding) {

--- a/crates/ruff_linter/src/checkers/ast/analyze/definitions.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/definitions.rs
@@ -137,11 +137,7 @@ pub(crate) fn definitions(checker: &mut Checker) {
                     &checker.semantic,
                 )
             }) {
-                checker.report_diagnostics(flake8_annotations::rules::definition(
-                    checker,
-                    definition,
-                    *visibility,
-                ));
+                flake8_annotations::rules::definition(checker, definition, *visibility);
             }
             overloaded_name =
                 flake8_annotations::helpers::overloaded_name(definition, &checker.semantic);

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -385,15 +385,6 @@ impl<'a> Checker<'a> {
         diagnostics.push(diagnostic);
     }
 
-    /// Extend the collection of [`Diagnostic`] objects in the [`Checker`]
-    pub(crate) fn report_diagnostics<I>(&self, diagnostics: I)
-    where
-        I: IntoIterator<Item = Diagnostic>,
-    {
-        let mut checker_diagnostics = self.diagnostics.borrow_mut();
-        checker_diagnostics.extend(diagnostics);
-    }
-
     /// Adds a [`TextRange`] to the set of ranges of variable names
     /// flagged in `flake8-bugbear` violations so far.
     ///

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_password_func_arg.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_password_func_arg.rs
@@ -52,19 +52,21 @@ impl Violation for HardcodedPasswordFuncArg {
 
 /// S106
 pub(crate) fn hardcoded_password_func_arg(checker: &Checker, keywords: &[Keyword]) {
-    for diagnostic in keywords.iter().filter_map(|keyword| {
-        string_literal(&keyword.value).filter(|string| !string.is_empty())?;
-        let arg = keyword.arg.as_ref()?;
-        if !matches_password_name(arg) {
-            return None;
+    for keyword in keywords {
+        if string_literal(&keyword.value).is_none_or(str::is_empty) {
+            continue;
         }
-        Some(Diagnostic::new(
+        let Some(arg) = &keyword.arg else {
+            continue;
+        };
+        if !matches_password_name(arg) {
+            continue;
+        }
+        checker.report_diagnostic(Diagnostic::new(
             HardcodedPasswordFuncArg {
                 name: arg.to_string(),
             },
             keyword.range(),
-        ))
-    }) {
-        checker.report_diagnostic(diagnostic);
+        ));
     }
 }

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_password_func_arg.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_password_func_arg.rs
@@ -52,7 +52,7 @@ impl Violation for HardcodedPasswordFuncArg {
 
 /// S106
 pub(crate) fn hardcoded_password_func_arg(checker: &Checker, keywords: &[Keyword]) {
-    checker.report_diagnostics(keywords.iter().filter_map(|keyword| {
+    for diagnostic in keywords.iter().filter_map(|keyword| {
         string_literal(&keyword.value).filter(|string| !string.is_empty())?;
         let arg = keyword.arg.as_ref()?;
         if !matches_password_name(arg) {
@@ -64,5 +64,7 @@ pub(crate) fn hardcoded_password_func_arg(checker: &Checker, keywords: &[Keyword
             },
             keyword.range(),
         ))
-    }));
+    }) {
+        checker.report_diagnostic(diagnostic);
+    }
 }

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_password_string.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_password_string.rs
@@ -76,17 +76,19 @@ pub(crate) fn compare_to_hardcoded_password_string(
     left: &Expr,
     comparators: &[Expr],
 ) {
-    for diagnostic in comparators.iter().filter_map(|comp| {
-        string_literal(comp).filter(|string| !string.is_empty())?;
-        let name = password_target(left)?;
-        Some(Diagnostic::new(
+    for comp in comparators {
+        if string_literal(comp).is_none_or(str::is_empty) {
+            continue;
+        }
+        let Some(name) = password_target(left) else {
+            continue;
+        };
+        checker.report_diagnostic(Diagnostic::new(
             HardcodedPasswordString {
                 name: name.to_string(),
             },
             comp.range(),
-        ))
-    }) {
-        checker.report_diagnostic(diagnostic);
+        ));
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_password_string.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_password_string.rs
@@ -76,7 +76,7 @@ pub(crate) fn compare_to_hardcoded_password_string(
     left: &Expr,
     comparators: &[Expr],
 ) {
-    checker.report_diagnostics(comparators.iter().filter_map(|comp| {
+    for diagnostic in comparators.iter().filter_map(|comp| {
         string_literal(comp).filter(|string| !string.is_empty())?;
         let name = password_target(left)?;
         Some(Diagnostic::new(
@@ -85,7 +85,9 @@ pub(crate) fn compare_to_hardcoded_password_string(
             },
             comp.range(),
         ))
-    }));
+    }) {
+        checker.report_diagnostic(diagnostic);
+    }
 }
 
 /// S105

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/function_call_in_argument_default.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/function_call_in_argument_default.rs
@@ -7,7 +7,6 @@ use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_python_ast::name::{QualifiedName, UnqualifiedName};
 use ruff_python_ast::visitor;
 use ruff_python_ast::visitor::Visitor;
-use ruff_python_semantic::SemanticModel;
 use ruff_python_semantic::analyze::typing::{
     is_immutable_annotation, is_immutable_func, is_immutable_newtype_call, is_mutable_func,
 };
@@ -83,20 +82,15 @@ impl Violation for FunctionCallInDefaultArgument {
 }
 
 struct ArgumentDefaultVisitor<'a, 'b> {
-    semantic: &'a SemanticModel<'b>,
+    checker: &'a Checker<'b>,
     extend_immutable_calls: &'a [QualifiedName<'b>],
-    diagnostics: Vec<Diagnostic>,
 }
 
 impl<'a, 'b> ArgumentDefaultVisitor<'a, 'b> {
-    fn new(
-        semantic: &'a SemanticModel<'b>,
-        extend_immutable_calls: &'a [QualifiedName<'b>],
-    ) -> Self {
+    fn new(checker: &'a Checker<'b>, extend_immutable_calls: &'a [QualifiedName<'b>]) -> Self {
         Self {
-            semantic,
+            checker,
             extend_immutable_calls,
-            diagnostics: Vec::new(),
         }
     }
 }
@@ -105,13 +99,21 @@ impl Visitor<'_> for ArgumentDefaultVisitor<'_, '_> {
     fn visit_expr(&mut self, expr: &Expr) {
         match expr {
             Expr::Call(ast::ExprCall { func, .. }) => {
-                if !is_mutable_func(func, self.semantic)
-                    && !is_immutable_func(func, self.semantic, self.extend_immutable_calls)
+                if !is_mutable_func(func, self.checker.semantic())
+                    && !is_immutable_func(
+                        func,
+                        self.checker.semantic(),
+                        self.extend_immutable_calls,
+                    )
                     && !func.as_name_expr().is_some_and(|name| {
-                        is_immutable_newtype_call(name, self.semantic, self.extend_immutable_calls)
+                        is_immutable_newtype_call(
+                            name,
+                            self.checker.semantic(),
+                            self.extend_immutable_calls,
+                        )
                     })
                 {
-                    self.diagnostics.push(Diagnostic::new(
+                    self.checker.report_diagnostic(Diagnostic::new(
                         FunctionCallInDefaultArgument {
                             name: UnqualifiedName::from_expr(func).map(|name| name.to_string()),
                         },
@@ -139,7 +141,7 @@ pub(crate) fn function_call_in_argument_default(checker: &Checker, parameters: &
         .map(|target| QualifiedName::from_dotted_name(target))
         .collect();
 
-    let mut visitor = ArgumentDefaultVisitor::new(checker.semantic(), &extend_immutable_calls);
+    let mut visitor = ArgumentDefaultVisitor::new(checker, &extend_immutable_calls);
     for parameter in parameters.iter_non_variadic_params() {
         if let Some(default) = parameter.default() {
             if !parameter.annotation().is_some_and(|expr| {
@@ -149,6 +151,4 @@ pub(crate) fn function_call_in_argument_default(checker: &Checker, parameters: &
             }
         }
     }
-
-    checker.report_diagnostics(visitor.diagnostics);
 }

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/duplicate_literal_member.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/duplicate_literal_member.rs
@@ -109,5 +109,7 @@ pub(crate) fn duplicate_literal_member<'a>(checker: &Checker, expr: &'a Expr) {
         }
     }
 
-    checker.report_diagnostics(diagnostics);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic(diagnostic);
+    }
 }

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/duplicate_union_member.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/duplicate_union_member.rs
@@ -139,7 +139,9 @@ pub(crate) fn duplicate_union_member<'a>(checker: &Checker, expr: &'a Expr) {
     }
 
     // Add all diagnostics to the checker
-    checker.report_diagnostics(diagnostics);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic(diagnostic);
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/assertion.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/assertion.rs
@@ -210,23 +210,23 @@ impl Violation for PytestUnittestAssertion {
 
 /// Visitor that tracks assert statements and checks if they reference
 /// the exception name.
-struct ExceptionHandlerVisitor<'a> {
+struct ExceptionHandlerVisitor<'a, 'b> {
     exception_name: &'a str,
     current_assert: Option<&'a Stmt>,
-    errors: Vec<Diagnostic>,
+    checker: &'a Checker<'b>,
 }
 
-impl<'a> ExceptionHandlerVisitor<'a> {
-    const fn new(exception_name: &'a str) -> Self {
+impl<'a, 'b> ExceptionHandlerVisitor<'a, 'b> {
+    const fn new(checker: &'a Checker<'b>, exception_name: &'a str) -> Self {
         Self {
             exception_name,
             current_assert: None,
-            errors: Vec::new(),
+            checker,
         }
     }
 }
 
-impl<'a> Visitor<'a> for ExceptionHandlerVisitor<'a> {
+impl<'a> Visitor<'a> for ExceptionHandlerVisitor<'a, '_> {
     fn visit_stmt(&mut self, stmt: &'a Stmt) {
         match stmt {
             Stmt::Assert(_) => {
@@ -243,7 +243,7 @@ impl<'a> Visitor<'a> for ExceptionHandlerVisitor<'a> {
             Expr::Name(ast::ExprName { id, .. }) => {
                 if let Some(current_assert) = self.current_assert {
                     if id.as_str() == self.exception_name {
-                        self.errors.push(Diagnostic::new(
+                        self.checker.report_diagnostic(Diagnostic::new(
                             PytestAssertInExcept {
                                 name: id.to_string(),
                             },
@@ -257,13 +257,12 @@ impl<'a> Visitor<'a> for ExceptionHandlerVisitor<'a> {
     }
 }
 
-fn check_assert_in_except(name: &str, body: &[Stmt]) -> Vec<Diagnostic> {
+fn check_assert_in_except(checker: &Checker, name: &str, body: &[Stmt]) {
     // Walk body to find assert statements that reference the exception name
-    let mut visitor = ExceptionHandlerVisitor::new(name);
+    let mut visitor = ExceptionHandlerVisitor::new(checker, name);
     for stmt in body {
         visitor.visit_stmt(stmt);
     }
-    visitor.errors
 }
 
 /// PT009
@@ -596,15 +595,13 @@ pub(crate) fn assert_falsy(checker: &Checker, stmt: &Stmt, test: &Expr) {
 
 /// PT017
 pub(crate) fn assert_in_exception_handler(checker: &Checker, handlers: &[ExceptHandler]) {
-    checker.report_diagnostics(handlers.iter().flat_map(|handler| match handler {
+    handlers.iter().for_each(|handler| match handler {
         ExceptHandler::ExceptHandler(ast::ExceptHandlerExceptHandler { name, body, .. }) => {
             if let Some(name) = name {
-                check_assert_in_except(name, body)
-            } else {
-                Vec::new()
+                check_assert_in_except(checker, name, body);
             }
         }
-    }));
+    });
 }
 
 #[derive(Copy, Clone)]

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/assertion.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/assertion.rs
@@ -595,13 +595,13 @@ pub(crate) fn assert_falsy(checker: &Checker, stmt: &Stmt, test: &Expr) {
 
 /// PT017
 pub(crate) fn assert_in_exception_handler(checker: &Checker, handlers: &[ExceptHandler]) {
-    handlers.iter().for_each(|handler| match handler {
-        ExceptHandler::ExceptHandler(ast::ExceptHandlerExceptHandler { name, body, .. }) => {
-            if let Some(name) = name {
-                check_assert_in_except(checker, name, body);
-            }
+    for handler in handlers {
+        let ExceptHandler::ExceptHandler(ast::ExceptHandlerExceptHandler { name, body, .. }) =
+            handler;
+        if let Some(name) = name {
+            check_assert_in_except(checker, name, body);
         }
-    });
+    }
 }
 
 #[derive(Copy, Clone)]

--- a/crates/ruff_linter/src/rules/flake8_unused_arguments/rules/unused_arguments.rs
+++ b/crates/ruff_linter/src/rules/flake8_unused_arguments/rules/unused_arguments.rs
@@ -304,20 +304,20 @@ fn call<'a>(
 ) {
     let semantic = checker.semantic();
     let dummy_variable_rgx = &checker.settings.dummy_variable_rgx;
-    for diagnostic in parameters.filter_map(|arg| {
-        let binding = scope
+    for arg in parameters {
+        let Some(binding) = scope
             .get(arg.name())
-            .map(|binding_id| semantic.binding(binding_id))?;
+            .map(|binding_id| semantic.binding(binding_id))
+        else {
+            continue;
+        };
         if binding.kind.is_argument()
             && binding.is_unused()
             && !dummy_variable_rgx.is_match(arg.name())
         {
-            Some(argumentable.check_for(arg.name.to_string(), binding.range()))
-        } else {
-            None
+            checker
+                .report_diagnostic(argumentable.check_for(arg.name.to_string(), binding.range()));
         }
-    }) {
-        checker.report_diagnostic(diagnostic);
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_unused_arguments/rules/unused_arguments.rs
+++ b/crates/ruff_linter/src/rules/flake8_unused_arguments/rules/unused_arguments.rs
@@ -304,7 +304,7 @@ fn call<'a>(
 ) {
     let semantic = checker.semantic();
     let dummy_variable_rgx = &checker.settings.dummy_variable_rgx;
-    checker.report_diagnostics(parameters.filter_map(|arg| {
+    for diagnostic in parameters.filter_map(|arg| {
         let binding = scope
             .get(arg.name())
             .map(|binding_id| semantic.binding(binding_id))?;
@@ -316,7 +316,9 @@ fn call<'a>(
         } else {
             None
         }
-    }));
+    }) {
+        checker.report_diagnostic(diagnostic);
+    }
 }
 
 /// Returns `true` if a function appears to be a base class stub. In other

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/literal_comparisons.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/literal_comparisons.rs
@@ -431,5 +431,7 @@ pub(crate) fn literal_comparisons(checker: &Checker, compare: &ast::ExprCompare)
         }
     }
 
-    checker.report_diagnostics(diagnostics);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic(diagnostic);
+    }
 }

--- a/crates/ruff_linter/src/rules/pydoclint/rules/check_docstring.rs
+++ b/crates/ruff_linter/src/rules/pydoclint/rules/check_docstring.rs
@@ -873,8 +873,6 @@ pub(crate) fn check_docstring(
     section_contexts: &SectionContexts,
     convention: Option<Convention>,
 ) {
-    let mut diagnostics = Vec::new();
-
     // Only check function docstrings.
     let Some(function_def) = definition.as_function_def() else {
         return;
@@ -927,7 +925,7 @@ pub(crate) fn check_docstring(
                                     semantic,
                                 )
                             {
-                                diagnostics.push(Diagnostic::new(
+                                checker.report_diagnostic(Diagnostic::new(
                                     DocstringMissingReturns,
                                     docstring.range(),
                                 ));
@@ -938,8 +936,10 @@ pub(crate) fn check_docstring(
                             .iter()
                             .any(|entry| !entry.is_none_return()) =>
                         {
-                            diagnostics
-                                .push(Diagnostic::new(DocstringMissingReturns, docstring.range()));
+                            checker.report_diagnostic(Diagnostic::new(
+                                DocstringMissingReturns,
+                                docstring.range(),
+                            ));
                         }
                         _ => {}
                     }
@@ -958,12 +958,16 @@ pub(crate) fn check_docstring(
                             |arguments| arguments.first().is_none_or(Expr::is_none_literal_expr),
                         ) =>
                     {
-                        diagnostics
-                            .push(Diagnostic::new(DocstringMissingYields, docstring.range()));
+                        checker.report_diagnostic(Diagnostic::new(
+                            DocstringMissingYields,
+                            docstring.range(),
+                        ));
                     }
                     None if body_entries.yields.iter().any(|entry| !entry.is_none_yield) => {
-                        diagnostics
-                            .push(Diagnostic::new(DocstringMissingYields, docstring.range()));
+                        checker.report_diagnostic(Diagnostic::new(
+                            DocstringMissingYields,
+                            docstring.range(),
+                        ));
                     }
                     _ => {}
                 }
@@ -996,7 +1000,7 @@ pub(crate) fn check_docstring(
                     },
                     docstring.range(),
                 );
-                diagnostics.push(diagnostic);
+                checker.report_diagnostic(diagnostic);
             }
         }
     }
@@ -1011,7 +1015,7 @@ pub(crate) fn check_docstring(
                     || body_entries.returns.iter().all(ReturnEntry::is_implicit)
                 {
                     let diagnostic = Diagnostic::new(DocstringExtraneousReturns, docstring.range());
-                    diagnostics.push(diagnostic);
+                    checker.report_diagnostic(diagnostic);
                 }
             }
         }
@@ -1021,7 +1025,7 @@ pub(crate) fn check_docstring(
             if docstring_sections.yields.is_some() {
                 if body_entries.yields.is_empty() {
                     let diagnostic = Diagnostic::new(DocstringExtraneousYields, docstring.range());
-                    diagnostics.push(diagnostic);
+                    checker.report_diagnostic(diagnostic);
                 }
             }
         }
@@ -1047,11 +1051,9 @@ pub(crate) fn check_docstring(
                         },
                         docstring.range(),
                     );
-                    diagnostics.push(diagnostic);
+                    checker.report_diagnostic(diagnostic);
                 }
             }
         }
     }
-
-    checker.report_diagnostics(diagnostics);
 }

--- a/crates/ruff_linter/src/rules/pylint/rules/boolean_chained_comparison.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/boolean_chained_comparison.rs
@@ -158,7 +158,9 @@ pub(crate) fn boolean_chained_comparison(checker: &Checker, expr_bool_op: &ExprB
             Some(diagnostic)
         });
 
-    checker.report_diagnostics(diagnostics);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic(diagnostic);
+    }
 }
 
 /// Checks whether two compare expressions are simplifiable

--- a/crates/ruff_linter/src/rules/pylint/rules/redefined_loop_name.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/redefined_loop_name.rs
@@ -379,15 +379,13 @@ pub(crate) fn redefined_loop_name(checker: &Checker, stmt: &Stmt) {
         _ => panic!("redefined_loop_name called on Statement that is not a `With` or `For`"),
     };
 
-    let mut diagnostics = Vec::new();
-
     for outer_assignment_target in &outer_assignment_targets {
         for inner_assignment_target in &inner_assignment_targets {
             // Compare the targets structurally.
             if ComparableExpr::from(outer_assignment_target.expr)
                 .eq(&(ComparableExpr::from(inner_assignment_target.expr)))
             {
-                diagnostics.push(Diagnostic::new(
+                checker.report_diagnostic(Diagnostic::new(
                     RedefinedLoopName {
                         name: checker.generator().expr(outer_assignment_target.expr),
                         outer_kind: outer_assignment_target.binding_kind,
@@ -398,6 +396,4 @@ pub(crate) fn redefined_loop_name(checker: &Checker, stmt: &Stmt) {
             }
         }
     }
-
-    checker.report_diagnostics(diagnostics);
 }

--- a/crates/ruff_linter/src/rules/pylint/rules/redefined_slots_in_subclass.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/redefined_slots_in_subclass.rs
@@ -1,6 +1,6 @@
 use std::hash::Hash;
 
-use ruff_python_semantic::{SemanticModel, analyze::class::iter_super_class};
+use ruff_python_semantic::analyze::class::iter_super_class;
 use rustc_hash::FxHashSet;
 
 use ruff_diagnostics::{Diagnostic, Violation};
@@ -66,12 +66,8 @@ pub(crate) fn redefined_slots_in_subclass(checker: &Checker, class_def: &ast::St
         return;
     }
 
-    let semantic = checker.semantic();
-    let diagnostics = class_slots
-        .iter()
-        .filter_map(|slot| check_super_slots(class_def, semantic, slot));
-    for diagnostic in diagnostics {
-        checker.report_diagnostic(diagnostic);
+    for slot in class_slots {
+        check_super_slots(checker, class_def, &slot);
     }
 }
 
@@ -105,25 +101,18 @@ impl Ranged for Slot<'_> {
     }
 }
 
-fn check_super_slots(
-    class_def: &ast::StmtClassDef,
-    semantic: &SemanticModel,
-    slot: &Slot,
-) -> Option<Diagnostic> {
-    iter_super_class(class_def, semantic)
-        .skip(1)
-        .find_map(&|super_class: &ast::StmtClassDef| {
-            if slots_members(&super_class.body).contains(slot) {
-                return Some(Diagnostic::new(
-                    RedefinedSlotsInSubclass {
-                        base: super_class.name.to_string(),
-                        slot_name: slot.name.to_string(),
-                    },
-                    slot.range(),
-                ));
-            }
-            None
-        })
+fn check_super_slots(checker: &Checker, class_def: &ast::StmtClassDef, slot: &Slot) {
+    for super_class in iter_super_class(class_def, checker.semantic()).skip(1) {
+        if slots_members(&super_class.body).contains(slot) {
+            checker.report_diagnostic(Diagnostic::new(
+                RedefinedSlotsInSubclass {
+                    base: super_class.name.to_string(),
+                    slot_name: slot.name.to_string(),
+                },
+                slot.range(),
+            ));
+        }
+    }
 }
 
 fn slots_members(body: &[Stmt]) -> FxHashSet<Slot> {

--- a/crates/ruff_linter/src/rules/pylint/rules/redefined_slots_in_subclass.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/redefined_slots_in_subclass.rs
@@ -70,7 +70,9 @@ pub(crate) fn redefined_slots_in_subclass(checker: &Checker, class_def: &ast::St
     let diagnostics = class_slots
         .iter()
         .filter_map(|slot| check_super_slots(class_def, semantic, slot));
-    checker.report_diagnostics(diagnostics);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic(diagnostic);
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/crates/ruff_linter/src/rules/refurb/rules/repeated_append.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/repeated_append.rs
@@ -86,48 +86,42 @@ pub(crate) fn repeated_append(checker: &Checker, stmt: &Stmt) {
         return;
     }
 
-    // group borrows from checker, so we can't directly push into checker.diagnostics
-    let diagnostics: Vec<Diagnostic> = group_appends(appends)
-        .iter()
-        .filter_map(|group| {
-            // Groups with just one element are fine, and shouldn't be replaced by `extend`.
-            if group.appends.len() <= 1 {
-                return None;
-            }
+    for group in group_appends(appends) {
+        // Groups with just one element are fine, and shouldn't be replaced by `extend`.
+        if group.appends.len() <= 1 {
+            continue;
+        }
 
-            let replacement = make_suggestion(group, checker.generator());
+        let replacement = make_suggestion(&group, checker.generator());
 
-            let mut diagnostic = Diagnostic::new(
-                RepeatedAppend {
-                    name: group.name().to_string(),
-                    replacement: SourceCodeSnippet::new(replacement.clone()),
-                },
-                group.range(),
-            );
+        let mut diagnostic = Diagnostic::new(
+            RepeatedAppend {
+                name: group.name().to_string(),
+                replacement: SourceCodeSnippet::new(replacement.clone()),
+            },
+            group.range(),
+        );
 
-            // We only suggest a fix when all appends in a group are clumped together. If they're
-            // non-consecutive, fixing them is much more difficult.
-            //
-            // Avoid fixing if there are comments in between the appends:
-            //
-            // ```python
-            // a.append(1)
-            // # comment
-            // a.append(2)
-            // ```
-            if group.is_consecutive && !checker.comment_ranges().intersects(group.range()) {
-                diagnostic.set_fix(Fix::unsafe_edit(Edit::replacement(
-                    replacement,
-                    group.start(),
-                    group.end(),
-                )));
-            }
+        // We only suggest a fix when all appends in a group are clumped together. If they're
+        // non-consecutive, fixing them is much more difficult.
+        //
+        // Avoid fixing if there are comments in between the appends:
+        //
+        // ```python
+        // a.append(1)
+        // # comment
+        // a.append(2)
+        // ```
+        if group.is_consecutive && !checker.comment_ranges().intersects(group.range()) {
+            diagnostic.set_fix(Fix::unsafe_edit(Edit::replacement(
+                replacement,
+                group.start(),
+                group.end(),
+            )));
+        }
 
-            Some(diagnostic)
-        })
-        .collect();
-
-    checker.report_diagnostics(diagnostics);
+        checker.report_diagnostic(diagnostic);
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/ruff_linter/src/rules/refurb/rules/write_whole_file.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/write_whole_file.rs
@@ -65,54 +65,28 @@ pub(crate) fn write_whole_file(checker: &Checker, with: &ast::StmtWith) {
     }
 
     // Then we need to match each `open` operation with exactly one `write` call.
-    let (matches, contents) = {
-        let mut matcher = WriteMatcher::new(candidates);
-        visitor::walk_body(&mut matcher, &with.body);
-        matcher.finish()
-    };
-
-    // All the matched operations should be reported.
-    let diagnostics: Vec<Diagnostic> = matches
-        .iter()
-        .zip(contents)
-        .map(|(open, content)| {
-            Diagnostic::new(
-                WriteWholeFile {
-                    filename: SourceCodeSnippet::from_str(&checker.generator().expr(open.filename)),
-                    suggestion: make_suggestion(open, content, checker.generator()),
-                },
-                open.item.range(),
-            )
-        })
-        .collect();
-    checker.report_diagnostics(diagnostics);
+    let mut matcher = WriteMatcher::new(checker, candidates);
+    visitor::walk_body(&mut matcher, &with.body);
 }
 
 /// AST visitor that matches `open` operations with the corresponding `write` calls.
-#[derive(Debug)]
-struct WriteMatcher<'a> {
+struct WriteMatcher<'a, 'b> {
+    checker: &'a Checker<'b>,
     candidates: Vec<FileOpen<'a>>,
-    matches: Vec<FileOpen<'a>>,
-    contents: Vec<&'a Expr>,
     loop_counter: u32,
 }
 
-impl<'a> WriteMatcher<'a> {
-    fn new(candidates: Vec<FileOpen<'a>>) -> Self {
+impl<'a, 'b> WriteMatcher<'a, 'b> {
+    fn new(checker: &'a Checker<'b>, candidates: Vec<FileOpen<'a>>) -> Self {
         Self {
+            checker,
             candidates,
-            matches: vec![],
-            contents: vec![],
             loop_counter: 0,
         }
     }
-
-    fn finish(self) -> (Vec<FileOpen<'a>>, Vec<&'a Expr>) {
-        (self.matches, self.contents)
-    }
 }
 
-impl<'a> Visitor<'a> for WriteMatcher<'a> {
+impl<'a> Visitor<'a> for WriteMatcher<'a, '_> {
     fn visit_stmt(&mut self, stmt: &'a Stmt) {
         if matches!(stmt, ast::Stmt::While(_) | ast::Stmt::For(_)) {
             self.loop_counter += 1;
@@ -131,8 +105,16 @@ impl<'a> Visitor<'a> for WriteMatcher<'a> {
                 .position(|open| open.is_ref(write_to))
             {
                 if self.loop_counter == 0 {
-                    self.matches.push(self.candidates.remove(open));
-                    self.contents.push(content);
+                    let open = self.candidates.remove(open);
+                    self.checker.report_diagnostic(Diagnostic::new(
+                        WriteWholeFile {
+                            filename: SourceCodeSnippet::from_str(
+                                &self.checker.generator().expr(open.filename),
+                            ),
+                            suggestion: make_suggestion(&open, content, self.checker.generator()),
+                        },
+                        open.item.range(),
+                    ));
                 } else {
                     self.candidates.remove(open);
                 }

--- a/crates/ruff_linter/src/rules/ruff/rules/ambiguous_unicode_character.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/ambiguous_unicode_character.rs
@@ -211,7 +211,9 @@ pub(crate) fn ambiguous_unicode_character_string(checker: &Checker, string_like:
                     context,
                     checker.settings,
                 );
-                checker.report_diagnostics(diagnostics);
+                for diagnostic in diagnostics {
+                    checker.report_diagnostic(diagnostic);
+                }
             }
             ast::StringLikePart::Bytes(_) => {}
             ast::StringLikePart::FString(f_string) => {
@@ -225,7 +227,9 @@ pub(crate) fn ambiguous_unicode_character_string(checker: &Checker, string_like:
                         context,
                         checker.settings,
                     );
-                    checker.report_diagnostics(diagnostics);
+                    for diagnostic in diagnostics {
+                        checker.report_diagnostic(diagnostic);
+                    }
                 }
             }
         }

--- a/crates/ruff_linter/src/rules/ruff/rules/post_init_default.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/post_init_default.rs
@@ -108,7 +108,6 @@ pub(crate) fn post_init_default(checker: &Checker, function_def: &ast::StmtFunct
     }
 
     let mut stopped_fixes = false;
-    let mut diagnostics = vec![];
 
     for parameter in function_def.parameters.iter_non_variadic_params() {
         let Some(default) = parameter.default() else {
@@ -132,10 +131,8 @@ pub(crate) fn post_init_default(checker: &Checker, function_def: &ast::StmtFunct
             stopped_fixes |= diagnostic.fix.is_none();
         }
 
-        diagnostics.push(diagnostic);
+        checker.report_diagnostic(diagnostic);
     }
-
-    checker.report_diagnostics(diagnostics);
 }
 
 /// Generate a [`Fix`] to transform a `__post_init__` default argument into a

--- a/crates/ruff_linter/src/rules/tryceratops/rules/useless_try_except.rs
+++ b/crates/ruff_linter/src/rules/tryceratops/rules/useless_try_except.rs
@@ -40,35 +40,30 @@ impl Violation for UselessTryExcept {
 
 /// TRY203 (previously TRY302)
 pub(crate) fn useless_try_except(checker: &Checker, handlers: &[ExceptHandler]) {
-    if let Some(diagnostics) = handlers
-        .iter()
-        .map(|handler| {
-            let ExceptHandler::ExceptHandler(ExceptHandlerExceptHandler { name, body, .. }) =
-                handler;
-            let Some(Stmt::Raise(ast::StmtRaise {
-                exc, cause: None, ..
-            })) = &body.first()
-            else {
-                return None;
-            };
-            if let Some(expr) = exc {
-                // E.g., `except ... as e: raise e`
-                if let Expr::Name(ast::ExprName { id, .. }) = expr.as_ref() {
-                    if name.as_ref().is_some_and(|name| name.as_str() == id) {
-                        return Some(Diagnostic::new(UselessTryExcept, handler.range()));
-                    }
+    if handlers.iter().all(|handler| {
+        let ExceptHandler::ExceptHandler(ExceptHandlerExceptHandler { name, body, .. }) = handler;
+        let Some(Stmt::Raise(ast::StmtRaise {
+            exc, cause: None, ..
+        })) = &body.first()
+        else {
+            return false;
+        };
+        if let Some(expr) = exc {
+            // E.g., `except ... as e: raise e`
+            if let Expr::Name(ast::ExprName { id, .. }) = expr.as_ref() {
+                if name.as_ref().is_some_and(|name| name.as_str() == id) {
+                    return true;
                 }
-                None
-            } else {
-                // E.g., `except ...: raise`
-                Some(Diagnostic::new(UselessTryExcept, handler.range()))
             }
-        })
-        .collect::<Option<Vec<_>>>()
-    {
+            false
+        } else {
+            // E.g., `except ...: raise`
+            true
+        }
+    }) {
         // Require that all handlers are useless, but create one diagnostic per handler.
-        for diagnostic in diagnostics {
-            checker.report_diagnostic(diagnostic);
+        for handler in handlers {
+            checker.report_diagnostic(Diagnostic::new(UselessTryExcept, handler.range()));
         }
     }
 }

--- a/crates/ruff_linter/src/rules/tryceratops/rules/useless_try_except.rs
+++ b/crates/ruff_linter/src/rules/tryceratops/rules/useless_try_except.rs
@@ -67,6 +67,8 @@ pub(crate) fn useless_try_except(checker: &Checker, handlers: &[ExceptHandler]) 
         .collect::<Option<Vec<_>>>()
     {
         // Require that all handlers are useless, but create one diagnostic per handler.
-        checker.report_diagnostics(diagnostics);
+        for diagnostic in diagnostics {
+            checker.report_diagnostic(diagnostic);
+        }
     }
 }


### PR DESCRIPTION
Summary
--

I thought that emitting multiple diagnostics at once would be difficult to port to a diagnostic construction model closer to ty's `InferContext::report_lint`, so as a first step toward that, this PR removes `Checker::report_diagnostics`.

In many cases I was able to do some related refactoring to avoid allocating a `Vec<Diagnostic>` at all, often by adding a `Checker` field to a `Visitor` or by passing a `Checker` instead of a `&mut Vec<Diagnostic>`.

In other cases, I had to fall back on something like

```rust
for diagnostic in diagnostics {
    checker.report_diagnostic(diagnostic);
}
```

which I guess is a bit worse than the `extend` call in `report_diagnostics`, but hopefully it won't make too much of a difference.

I'm still not quite sure what to do with the remaining loop cases. The two main use cases for collecting a sequence of diagnostics before emitting any of them are:

1. Applying a single `Fix` to a group of diagnostics
2. Avoiding an earlier diagnostic if something goes wrong later

I was hoping we could get away with just a `DiagnosticGuard` that reported a `Diagnostic` on drop, but I guess we will still need a `DiagnosticGuardBuilder` that can be collected in these cases and produce a `DiagnosticGuard` once we know we actually want the diagnostics.

Test Plan
--

Existing tests
