### PR TITLE
[ty] Add note to `unresolved-import` hinting to users to configure their Python environment

### DIFF
--- a/crates/ty/tests/cli.rs
+++ b/crates/ty/tests/cli.rs
@@ -296,6 +296,7 @@ fn cli_arguments_are_relative_to_the_current_directory() -> anyhow::Result<()> {
     3 |
     4 | stat = add(10, 15)
       |
+    info: make sure your Python environment is properly configured: https://github.com/astral-sh/ty/blob/main/docs/README.md#python-environment
     info: rule `unresolved-import` is enabled by default
 
     Found 1 diagnostic
@@ -481,6 +482,7 @@ fn cli_rule_severity() -> anyhow::Result<()> {
     3 |
     4 | y = 4 / 0
       |
+    info: make sure your Python environment is properly configured: https://github.com/astral-sh/ty/blob/main/docs/README.md#python-environment
     info: rule `unresolved-import` is enabled by default
 
     error[division-by-zero]: Cannot divide object of type `Literal[4]` by zero
@@ -532,6 +534,7 @@ fn cli_rule_severity() -> anyhow::Result<()> {
     3 |
     4 | y = 4 / 0
       |
+    info: make sure your Python environment is properly configured: https://github.com/astral-sh/ty/blob/main/docs/README.md#python-environment
     info: rule `unresolved-import` was selected on the command line
 
     warning[division-by-zero]: Cannot divide object of type `Literal[4]` by zero
@@ -1120,6 +1123,7 @@ fn check_specific_paths() -> anyhow::Result<()> {
     3 |
     4 | print(z)
       |
+    info: make sure your Python environment is properly configured: https://github.com/astral-sh/ty/blob/main/docs/README.md#python-environment
     info: rule `unresolved-import` is enabled by default
 
     error[unresolved-import]: Cannot resolve imported module `does_not_exist`
@@ -1128,6 +1132,7 @@ fn check_specific_paths() -> anyhow::Result<()> {
     2 | import does_not_exist  # error: unresolved-import
       |        ^^^^^^^^^^^^^^
       |
+    info: make sure your Python environment is properly configured: https://github.com/astral-sh/ty/blob/main/docs/README.md#python-environment
     info: rule `unresolved-import` is enabled by default
 
     Found 3 diagnostics
@@ -1153,6 +1158,7 @@ fn check_specific_paths() -> anyhow::Result<()> {
     3 |
     4 | print(z)
       |
+    info: make sure your Python environment is properly configured: https://github.com/astral-sh/ty/blob/main/docs/README.md#python-environment
     info: rule `unresolved-import` is enabled by default
 
     error[unresolved-import]: Cannot resolve imported module `does_not_exist`
@@ -1161,6 +1167,7 @@ fn check_specific_paths() -> anyhow::Result<()> {
     2 | import does_not_exist  # error: unresolved-import
       |        ^^^^^^^^^^^^^^
       |
+    info: make sure your Python environment is properly configured: https://github.com/astral-sh/ty/blob/main/docs/README.md#python-environment
     info: rule `unresolved-import` is enabled by default
 
     Found 2 diagnostics

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Multiple_objects_imp…_(cbfbf5ff94e6e104).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Multiple_objects_imp…_(cbfbf5ff94e6e104).snap
@@ -26,6 +26,7 @@ error[unresolved-import]: Cannot resolve imported module `does_not_exist`
 2 | from does_not_exist import foo, bar, baz
   |      ^^^^^^^^^^^^^^
   |
+info: make sure your Python environment is properly configured: https://github.com/astral-sh/ty/blob/main/docs/README.md#python-environment
 info: rule `unresolved-import` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Unresolvable_module_…_(846453deaca1071c).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Unresolvable_module_…_(846453deaca1071c).snap
@@ -24,6 +24,7 @@ error[unresolved-import]: Cannot resolve imported module `zqzqzqzqzqzqzq`
 1 | import zqzqzqzqzqzqzq  # error: [unresolved-import] "Cannot resolve imported module `zqzqzqzqzqzqzq`"
   |        ^^^^^^^^^^^^^^
   |
+info: make sure your Python environment is properly configured: https://github.com/astral-sh/ty/blob/main/docs/README.md#python-environment
 info: rule `unresolved-import` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Unresolvable_submodu…_(4fad4be9778578b7).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Unresolvable_submodu…_(4fad4be9778578b7).snap
@@ -36,6 +36,7 @@ error[unresolved-import]: Cannot resolve imported module `a.foo`
 3 |
 4 | # Topmost component unresolvable:
   |
+info: make sure your Python environment is properly configured: https://github.com/astral-sh/ty/blob/main/docs/README.md#python-environment
 info: rule `unresolved-import` is enabled by default
 
 ```
@@ -48,6 +49,7 @@ error[unresolved-import]: Cannot resolve imported module `b.foo`
 5 | import b.foo  # error: [unresolved-import] "Cannot resolve imported module `b.foo`"
   |        ^^^^^
   |
+info: make sure your Python environment is properly configured: https://github.com/astral-sh/ty/blob/main/docs/README.md#python-environment
 info: rule `unresolved-import` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_di…_-_An_unresolvable_impo…_(72d090df51ea97b8).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_di…_-_An_unresolvable_impo…_(72d090df51ea97b8).snap
@@ -28,6 +28,7 @@ error[unresolved-import]: Cannot resolve imported module `does_not_exist`
 2 |
 3 | x = does_not_exist.foo
   |
+info: make sure your Python environment is properly configured: https://github.com/astral-sh/ty/blob/main/docs/README.md#python-environment
 info: rule `unresolved-import` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_di…_-_Using_`from`_with_an…_(9fa713dfa17cc404).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_di…_-_Using_`from`_with_an…_(9fa713dfa17cc404).snap
@@ -28,6 +28,7 @@ error[unresolved-import]: Cannot resolve imported module `does_not_exist`
 2 |
 3 | stat = add(10, 15)
   |
+info: make sure your Python environment is properly configured: https://github.com/astral-sh/ty/blob/main/docs/README.md#python-environment
 info: rule `unresolved-import` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -3812,11 +3812,16 @@ impl<'db> TypeInferenceBuilder<'db> {
         let Some(builder) = self.context.report_lint(&UNRESOLVED_IMPORT, range) else {
             return;
         };
-        builder.into_diagnostic(format_args!(
+        let mut diagnostic = builder.into_diagnostic(format_args!(
             "Cannot resolve imported module `{}{}`",
             ".".repeat(level as usize),
             module.unwrap_or_default()
         ));
+        if level == 0 {
+            diagnostic.info(
+                "make sure your Python environment is properly configured: https://github.com/astral-sh/ty/blob/main/docs/README.md#python-environment"
+            );
+        }
     }
 
     fn infer_import_definition(


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

Closes https://github.com/astral-sh/ty/issues/453.

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Add an additional info diagnostic to `unresolved-import` check to hint to users that they should make sure their Python environment is properly configured for ty, linking them to the corresponding doc. This diagnostic is only shown when an import is not relative, e.g., `import maturin` not `import .maturin`.

## Test Plan

<!-- How was it tested? -->

Updated snapshots with new info message and reran tests.
