### PR TITLE
[`flake8-simplify`] enable fix in preview mode (`SIM117`)

### DIFF
--- a/crates/ruff_linter/src/preview.rs
+++ b/crates/ruff_linter/src/preview.rs
@@ -130,3 +130,7 @@ pub(crate) const fn is_check_file_level_directives_enabled(settings: &LinterSett
 pub(crate) const fn is_readlines_in_for_fix_safe(settings: &LinterSettings) -> bool {
     settings.preview.is_enabled()
 }
+
+pub(crate) const fn multiple_with_statements_enabled(settings: &LinterSettings) -> bool {
+    settings.preview.is_enabled()
+}


### PR DESCRIPTION
The PR add the `fix safety` section for rule `SIM117` (#15584 ), and enable a fix in preview mode.

@dylwil3 Is the first time I'm exposed to the preview mode. So please let me know what should I do/fix. I hope I got what you wanted to say.

