### PR TITLE
[`pylint`] Fix docs example that produced different output (`PLW0603`)

### DIFF
--- a/crates/ruff_linter/src/rules/pylint/rules/global_statement.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/global_statement.rs
@@ -31,8 +31,9 @@ use crate::checkers::ast::Checker;
 ///
 ///
 /// def foo():
+///     var = 10
 ///     print(var)
-///     return 10
+///     return var
 ///
 ///
 /// var = foo()


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
Closes #18139 
I have modified the example to produce the same output as the original code:
```
10
10
```
