### PR TITLE
add full option name in formatter warning

### DIFF
--- a/crates/ruff/tests/format.rs
+++ b/crates/ruff/tests/format.rs
@@ -862,7 +862,7 @@ if condition:
     	print('Should change quotes')
 
     ----- stderr -----
-    warning: The following rule may cause conflicts when used with the formatter: `COM812`. To avoid unexpected behavior, we recommend disabling this rule, either by removing it from the `select` or `extend-select` configuration, or adding it to the `ignore` configuration.
+    warning: The following rule may cause conflicts when used with the formatter: `COM812`. To avoid unexpected behavior, we recommend disabling this rule, either by removing it from the `select` or `extend-select` configuration, or adding it to the `lint.ignore` configuration.
     "#);
     Ok(())
 }


### PR DESCRIPTION
## Summary
So this PR fixes #18199 in the issue mentioned the error message is as followed
```
$ ruff format --check .build/mytool.py
warning: The following rule may cause conflicts when used with the formatter: `COM812`. To avoid unexpected behavior, we recommend disabling this rule, either by removing it from the `select` or `extend-select` configuration, or adding it to the `ignore` configuration.
 ```
the new message contains full option name as guided in issue the new message looks like this 
```
$ ruff format --check .build/mytool.py
warning: The following rule may cause conflicts when used with the formatter: `COM812`. To avoid unexpected behavior, we recommend disabling this rule, either by removing it from the `select` or `extend-select` configuration, or adding it to the `lint.ignore` configuration.
```
## Test Plan
I just did manual testing 