### PR TITLE
[ty] Integer indexing into `bytes` returns `int`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/subscript/bytes.md
+++ b/crates/ty_python_semantic/resources/mdtest/subscript/bytes.md
@@ -5,16 +5,16 @@
 ```py
 b = b"\x00abc\xff"
 
-reveal_type(b[0])  # revealed: Literal[b"\x00"]
-reveal_type(b[1])  # revealed: Literal[b"a"]
-reveal_type(b[4])  # revealed: Literal[b"\xff"]
+reveal_type(b[0])  # revealed: Literal[0]
+reveal_type(b[1])  # revealed: Literal[97]
+reveal_type(b[4])  # revealed: Literal[255]
 
-reveal_type(b[-1])  # revealed: Literal[b"\xff"]
-reveal_type(b[-2])  # revealed: Literal[b"c"]
-reveal_type(b[-5])  # revealed: Literal[b"\x00"]
+reveal_type(b[-1])  # revealed: Literal[255]
+reveal_type(b[-2])  # revealed: Literal[99]
+reveal_type(b[-5])  # revealed: Literal[0]
 
-reveal_type(b[False])  # revealed: Literal[b"\x00"]
-reveal_type(b[True])  # revealed: Literal[b"a"]
+reveal_type(b[False])  # revealed: Literal[0]
+reveal_type(b[True])  # revealed: Literal[97]
 
 x = b[5]  # error: [index-out-of-bounds] "Index 5 is out of bounds for bytes literal `Literal[b"\x00abc\xff"]` with length 5"
 reveal_type(x)  # revealed: Unknown

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -7265,7 +7265,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                     Type::unknown()
                 }
             }
-            // Ex) Given `b"value"[1]`, return `b"a"`
+            // Ex) Given `b"value"[1]`, return `97` (i.e., `ord(b"a")`)
             (Type::BytesLiteral(literal_ty), Type::IntLiteral(int), _)
                 if i32::try_from(int).is_ok() =>
             {
@@ -7273,7 +7273,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 literal_value
                     .iter()
                     .py_index(i32::try_from(int).expect("checked in branch arm"))
-                    .map(|byte| Type::bytes_literal(self.db(), &[*byte]))
+                    .map(|byte| Type::IntLiteral((*byte).into()))
                     .unwrap_or_else(|_| {
                         report_index_out_of_bounds(
                             &self.context,


### PR DESCRIPTION
## Summary

Resolves [#461](https://github.com/astral-sh/ty/issues/461).

ty was hardcoded to infer `BytesLiteral` types for integer indexing into `BytesLiteral`. It will now infer `IntLiteral` types instead.

## Test Plan

Markdown tests.
