### PR TITLE
[ty] Deeply normalize many types

### DIFF
--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -31,6 +31,19 @@ impl<'db> ClassBase<'db> {
         Self::Dynamic(DynamicType::Unknown)
     }
 
+    pub(crate) fn normalized(self, db: &'db dyn Db) -> Self {
+        match self {
+            Self::Dynamic(dynamic) => Self::Dynamic(dynamic.normalized()),
+            Self::Class(class) => Self::Class(class.normalized(db)),
+            Self::Protocol(generic_context) => {
+                Self::Protocol(generic_context.map(|context| context.normalized(db)))
+            }
+            Self::Generic(generic_context) => {
+                Self::Generic(generic_context.map(|context| context.normalized(db)))
+            }
+        }
+    }
+
     pub(crate) fn display(self, db: &'db dyn Db) -> impl std::fmt::Display + 'db {
         struct Display<'db> {
             base: ClassBase<'db>,

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -237,6 +237,15 @@ impl<'db> GenericContext<'db> {
 
         Specialization::new(db, self, expanded.into_boxed_slice())
     }
+
+    pub(crate) fn normalized(self, db: &'db dyn Db) -> Self {
+        let variables: FxOrderSet<_> = self
+            .variables(db)
+            .iter()
+            .map(|ty| ty.normalized(db))
+            .collect();
+        Self::new(db, variables, self.origin(db))
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
@@ -559,6 +568,16 @@ impl<'db> PartialSpecialization<'_, 'db> {
         PartialSpecialization {
             generic_context: self.generic_context,
             types: Cow::from(self.types.clone().into_owned()),
+        }
+    }
+
+    pub(crate) fn normalized(&self, db: &'db dyn Db) -> PartialSpecialization<'db, 'db> {
+        let generic_context = self.generic_context.normalized(db);
+        let types: Cow<_> = self.types.iter().map(|ty| ty.normalized(db)).collect();
+
+        PartialSpecialization {
+            generic_context,
+            types,
         }
     }
 }

--- a/crates/ty_python_semantic/src/types/known_instance.rs
+++ b/crates/ty_python_semantic/src/types/known_instance.rs
@@ -153,6 +153,53 @@ impl<'db> KnownInstanceType<'db> {
         }
     }
 
+    pub(crate) fn normalized(self, db: &'db dyn Db) -> Self {
+        match self {
+            Self::Annotated
+            | Self::Literal
+            | Self::LiteralString
+            | Self::Optional
+            | Self::Union
+            | Self::NoReturn
+            | Self::Never
+            | Self::Tuple
+            | Self::Type
+            | Self::TypingSelf
+            | Self::Final
+            | Self::ClassVar
+            | Self::Callable
+            | Self::Concatenate
+            | Self::Unpack
+            | Self::Required
+            | Self::NotRequired
+            | Self::TypeAlias
+            | Self::TypeGuard
+            | Self::TypedDict
+            | Self::TypeIs
+            | Self::List
+            | Self::Dict
+            | Self::DefaultDict
+            | Self::Set
+            | Self::FrozenSet
+            | Self::Counter
+            | Self::Deque
+            | Self::ChainMap
+            | Self::OrderedDict
+            | Self::ReadOnly
+            | Self::Unknown
+            | Self::AlwaysTruthy
+            | Self::AlwaysFalsy
+            | Self::Not
+            | Self::Intersection
+            | Self::TypeOf
+            | Self::CallableTypeOf => self,
+            Self::TypeVar(tvar) => Self::TypeVar(tvar.normalized(db)),
+            Self::Protocol(ctx) => Self::Protocol(ctx.map(|ctx| ctx.normalized(db))),
+            Self::Generic(ctx) => Self::Generic(ctx.map(|ctx| ctx.normalized(db))),
+            Self::TypeAliasType(alias) => Self::TypeAliasType(alias.normalized(db)),
+        }
+    }
+
     /// Return the repr of the symbol at runtime
     pub(crate) fn repr(self, db: &'db dyn Db) -> impl Display + 'db {
         KnownInstanceRepr {

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -122,6 +122,12 @@ impl<'db> SubclassOfType<'db> {
         }
     }
 
+    pub(crate) fn normalized(self, db: &'db dyn Db) -> Self {
+        Self {
+            subclass_of: self.subclass_of.normalized(db),
+        }
+    }
+
     pub(crate) fn to_instance(self, db: &'db dyn Db) -> Type<'db> {
         match self.subclass_of {
             SubclassOfInner::Class(class) => Type::instance(db, class),
@@ -170,6 +176,13 @@ impl<'db> SubclassOfInner<'db> {
         match self {
             Self::Class(_) => None,
             Self::Dynamic(dynamic) => Some(dynamic),
+        }
+    }
+
+    pub(crate) fn normalized(self, db: &'db dyn Db) -> Self {
+        match self {
+            Self::Class(class) => Self::Class(class.normalized(db)),
+            Self::Dynamic(dynamic) => Self::Dynamic(dynamic.normalized()),
         }
     }
 


### PR DESCRIPTION
## Summary

This PR applies deep normalization to many type variants that wrap other types. This should mean that we have more robust handling for equivalence and gradual equivalence even when encountering differently ordered unions.

I went down this road because I was hoping it would solve https://github.com/astral-sh/ty/issues/459. It doesn't look like it does (at least not on its own), but it seems like something that should make us more robust in the long term anyway.

## Test Plan

`cargo test -p ty_python_semantic`
