### PR TITLE
remove unnecessary `__future__` import in `ruff.__main__`

### DIFF
--- a/python/ruff/.ruff.toml
+++ b/python/ruff/.ruff.toml
@@ -1,0 +1,4 @@
+extend = "../../pyproject.toml"
+
+[lint.isort]
+required-imports = []

--- a/python/ruff/__main__.py
+++ b/python/ruff/__main__.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import os
 import sys
 import sysconfig

--- a/python/ruff/__main__.py
+++ b/python/ruff/__main__.py
@@ -42,7 +42,7 @@ def find_ruff_bin() -> str:
     paths = os.environ.get("PATH", "").split(os.pathsep)
     if len(paths) >= 2:
 
-        def get_last_three_path_parts(path: str) -> list[str]:
+        def get_last_three_path_parts(path: str) -> "list[str]":
             """Return a list of up to the last three parts of a path."""
             parts = []
 


### PR DESCRIPTION
## Summary

The `__future__.annotations` import in `ruff.__main__` was not needed, as there are no forward references or type-check-only imports.

Instead, I manually stringified the `list[str]` annotation, for compatibility with older Python versions.

Since the `pyproject.toml` ruff config for `isort` requires `__future__.annotations` to be present everywhere, I assumed that there must be some reason for that, and did not change it. I instead used a local `.ruff.toml` to override it for the only the `ruff` python package.

## Test Plan

Check that `python -m ruff` does not raise.
