### PR TITLE
[ty] Ensure that a function-literal type is always equivalent to itself

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_equivalent_to.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_equivalent_to.md
@@ -334,4 +334,30 @@ static_assert(is_equivalent_to(CallableTypeOf[pg], CallableTypeOf[cpg]))
 static_assert(is_equivalent_to(CallableTypeOf[cpg], CallableTypeOf[pg]))
 ```
 
+## Function-literal types and bound-method types
+
+Function-literal types and bound-method types are always considered self-equivalent, even if they
+have unannotated parameters, or parameters with not-fully-static annotations.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from ty_extensions import is_equivalent_to, TypeOf, static_assert
+
+def f(): ...
+
+static_assert(is_equivalent_to(TypeOf[f], TypeOf[f]))
+
+class A:
+    def method(self) -> int:
+        return 42
+
+static_assert(is_equivalent_to(TypeOf[A.method], TypeOf[A.method]))
+type X = TypeOf[A.method]
+static_assert(is_equivalent_to(X, X))
+```
+
 [the equivalence relation]: https://typing.python.org/en/latest/spec/glossary.html#term-equivalent

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -7146,10 +7146,11 @@ impl<'db> FunctionType<'db> {
         // However, our representation of a function literal includes any specialization that
         // should be applied to the signature. Different specializations of the same function
         // literal are only subtypes of each other if they result in subtype signatures.
-        self.body_scope(db) == other.body_scope(db)
-            && self
-                .into_callable_type(db)
-                .is_subtype_of(db, other.into_callable_type(db))
+        self.is_equivalent_to(db, other)
+            || (self.body_scope(db) == other.body_scope(db)
+                && self
+                    .into_callable_type(db)
+                    .is_subtype_of(db, other.into_callable_type(db)))
     }
 
     fn is_assignable_to(self, db: &'db dyn Db, other: Self) -> bool {
@@ -7164,10 +7165,7 @@ impl<'db> FunctionType<'db> {
     }
 
     fn is_equivalent_to(self, db: &'db dyn Db, other: Self) -> bool {
-        self.body_scope(db) == other.body_scope(db)
-            && self
-                .into_callable_type(db)
-                .is_equivalent_to(db, other.into_callable_type(db))
+        self.normalized(db) == other.normalized(db)
     }
 
     fn is_gradual_equivalent_to(self, db: &'db dyn Db, other: Self) -> bool {

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -7146,7 +7146,7 @@ impl<'db> FunctionType<'db> {
         // However, our representation of a function literal includes any specialization that
         // should be applied to the signature. Different specializations of the same function
         // literal are only subtypes of each other if they result in subtype signatures.
-        self.is_equivalent_to(db, other)
+        self.normalized(db) == other.normalized(db)
             || (self.body_scope(db) == other.body_scope(db)
                 && self
                     .into_callable_type(db)
@@ -7166,6 +7166,10 @@ impl<'db> FunctionType<'db> {
 
     fn is_equivalent_to(self, db: &'db dyn Db, other: Self) -> bool {
         self.normalized(db) == other.normalized(db)
+            || (self.body_scope(db) == other.body_scope(db)
+                && self
+                    .into_callable_type(db)
+                    .is_equivalent_to(db, other.into_callable_type(db)))
     }
 
     fn is_gradual_equivalent_to(self, db: &'db dyn Db, other: Self) -> bool {

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -302,8 +302,8 @@ impl<'db> Signature<'db> {
 
     pub(crate) fn normalized(&self, db: &'db dyn Db) -> Self {
         Self {
-            generic_context: self.generic_context,
-            inherited_generic_context: self.inherited_generic_context,
+            generic_context: self.generic_context.map(|ctx| ctx.normalized(db)),
+            inherited_generic_context: self.inherited_generic_context.map(|ctx| ctx.normalized(db)),
             parameters: self
                 .parameters
                 .iter()


### PR DESCRIPTION
## Summary

This is a short-term fix to some of our type-equivalence logic for function-literal and bound-method types. The issue was that two `Callable` types will not be considered equivalent if any parameter in either type is unannotated (and it is obviously very common in methods for the `self` parameter to be unannotated!). Following https://github.com/astral-sh/ruff/commit/97058e80930969d63bc2cdc6fcff8f84a2d7de4e, equivalence of two `FunctionLiteral` types defers to equivalence of the `CallableType` supertypes of the two function-literal types.

Long-term, we should clarify this situation by splitting `FunctionLiteral` into two separate variants, as described by @dcreager in https://github.com/astral-sh/ty/issues/459#issuecomment-2895084351 and https://github.com/astral-sh/ty/issues/462

Closes https://github.com/astral-sh/ty/issues/459

## Test Plan

- `cargo test -p ty_python_semantic`
- `QUICKCHECK_TESTS=100000 cargo test --release -p ty_python_semantic -- --ignored types::property_tests::stable`
