### PR TITLE
switch the playground repo button to ty repo

### DIFF
--- a/playground/ruff/src/Editor/Chrome.tsx
+++ b/playground/ruff/src/Editor/Chrome.tsx
@@ -87,7 +87,7 @@ export default function Chrome() {
       <Header
         edit={revision}
         theme={theme}
-        logo="ruff"
+        tool="ruff"
         version={ruffVersion}
         onChangeTheme={setTheme}
         onShare={handleShare}

--- a/playground/shared/src/Header.tsx
+++ b/playground/shared/src/Header.tsx
@@ -9,7 +9,7 @@ import AstralButton from "./AstralButton";
 export default function Header({
   edit,
   theme,
-  logo,
+  tool,
   version,
   onChangeTheme,
   onReset,
@@ -17,7 +17,7 @@ export default function Header({
 }: {
   edit: number | null;
   theme: Theme;
-  logo: "ruff" | "ty";
+  tool: "ruff" | "ty";
   version: string | null;
   onChangeTheme: (theme: Theme) => void;
   onReset?(): void;
@@ -37,7 +37,7 @@ export default function Header({
       "
     >
       <div className="py-4 pl-2">
-        <Logo name={logo} className="fill-galaxy dark:fill-radiate" />
+        <Logo name={tool} className="fill-galaxy dark:fill-radiate" />
       </div>
       <div className="flex items-center min-w-0 gap-4 mx-2">
         {version ? (
@@ -46,7 +46,7 @@ export default function Header({
           </div>
         ) : null}
         <Divider />
-        <RepoButton />
+        <RepoButton href={`https://github.com/astral-sh/${tool}`} />
         <Divider />
         <div className="max-sm:hidden flex">
           <ResetButton onClicked={onReset} />

--- a/playground/shared/src/RepoButton.tsx
+++ b/playground/shared/src/RepoButton.tsx
@@ -2,7 +2,7 @@ export default function RepoButton() {
   return (
     <a
       className="rounded-full"
-      href="https://github.com/astral-sh/ruff"
+      href="https://github.com/astral-sh/ty"
       target="_blank"
       rel="noreferrer"
     >

--- a/playground/shared/src/RepoButton.tsx
+++ b/playground/shared/src/RepoButton.tsx
@@ -1,11 +1,6 @@
-export default function RepoButton() {
+export default function RepoButton({ href }: { href: string }) {
   return (
-    <a
-      className="rounded-full"
-      href="https://github.com/astral-sh/ty"
-      target="_blank"
-      rel="noreferrer"
-    >
+    <a className="rounded-full" href={href} target="_blank" rel="noreferrer">
       <svg
         xmlns="http://www.w3.org/2000/svg"
         width="24"

--- a/playground/ty/src/Playground.tsx
+++ b/playground/ty/src/Playground.tsx
@@ -156,7 +156,7 @@ export default function Playground() {
       <Header
         edit={files.revision}
         theme={theme}
-        logo="ty"
+        tool="ty"
         version={version}
         onChangeTheme={setTheme}
         onShare={handleShare}


### PR DESCRIPTION
## Summary

We should point to `ty` repo, not `ruff` repo, for ty.

## Test Plan

Ran the playground locally (`npm start --workspace ty-playground`) and saw the updated link target.
