### PR TITLE
[ty] Add `python.ty.disableLanguageServices` config

### DIFF
--- a/crates/ty_server/src/lib.rs
+++ b/crates/ty_server/src/lib.rs
@@ -1,7 +1,7 @@
 use crate::server::{ConnectionInitializer, Server};
 use anyhow::Context;
 pub use document::{NotebookDocument, PositionEncoding, TextDocument};
-pub use session::{ClientSettings, DocumentQuery, DocumentSnapshot, Session};
+pub use session::{DocumentQuery, DocumentSnapshot, Session};
 use std::num::NonZeroUsize;
 
 mod document;

--- a/crates/ty_server/src/server/api/requests/completion.rs
+++ b/crates/ty_server/src/server/api/requests/completion.rs
@@ -30,6 +30,10 @@ impl BackgroundDocumentRequestHandler for CompletionRequestHandler {
         _client: &Client,
         params: CompletionParams,
     ) -> crate::server::Result<Option<CompletionResponse>> {
+        if snapshot.client_settings().is_language_services_disabled() {
+            return Ok(None);
+        }
+
         let Some(file) = snapshot.file(db) else {
             tracing::debug!("Failed to resolve file for {:?}", params);
             return Ok(None);

--- a/crates/ty_server/src/server/api/requests/goto_type_definition.rs
+++ b/crates/ty_server/src/server/api/requests/goto_type_definition.rs
@@ -28,6 +28,10 @@ impl BackgroundDocumentRequestHandler for GotoTypeDefinitionRequestHandler {
         _client: &Client,
         params: GotoTypeDefinitionParams,
     ) -> crate::server::Result<Option<GotoDefinitionResponse>> {
+        if snapshot.client_settings().is_language_services_disabled() {
+            return Ok(None);
+        }
+
         let Some(file) = snapshot.file(db) else {
             tracing::debug!("Failed to resolve file for {:?}", params);
             return Ok(None);

--- a/crates/ty_server/src/server/api/requests/hover.rs
+++ b/crates/ty_server/src/server/api/requests/hover.rs
@@ -28,6 +28,10 @@ impl BackgroundDocumentRequestHandler for HoverRequestHandler {
         _client: &Client,
         params: HoverParams,
     ) -> crate::server::Result<Option<lsp_types::Hover>> {
+        if snapshot.client_settings().is_language_services_disabled() {
+            return Ok(None);
+        }
+
         let Some(file) = snapshot.file(db) else {
             tracing::debug!("Failed to resolve file for {:?}", params);
             return Ok(None);

--- a/crates/ty_server/src/server/api/requests/inlay_hints.rs
+++ b/crates/ty_server/src/server/api/requests/inlay_hints.rs
@@ -27,6 +27,10 @@ impl BackgroundDocumentRequestHandler for InlayHintRequestHandler {
         _client: &Client,
         params: InlayHintParams,
     ) -> crate::server::Result<Option<Vec<lsp_types::InlayHint>>> {
+        if snapshot.client_settings().is_language_services_disabled() {
+            return Ok(None);
+        }
+
         let Some(file) = snapshot.file(db) else {
             tracing::debug!("Failed to resolve file for {:?}", params);
             return Ok(None);

--- a/crates/ty_server/src/session/options.rs
+++ b/crates/ty_server/src/session/options.rs
@@ -1,0 +1,158 @@
+use std::path::PathBuf;
+
+use lsp_types::Url;
+use rustc_hash::FxHashMap;
+use serde::Deserialize;
+
+use crate::logging::LogLevel;
+use crate::session::settings::ClientSettings;
+
+pub(crate) type WorkspaceOptionsMap = FxHashMap<Url, ClientOptions>;
+
+#[derive(Debug, Deserialize, Default)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct GlobalOptions {
+    #[serde(flatten)]
+    client: ClientOptions,
+
+    // These settings are only needed for tracing, and are only read from the global configuration.
+    // These will not be in the resolved settings.
+    #[serde(flatten)]
+    pub(crate) tracing: TracingOptions,
+}
+
+impl GlobalOptions {
+    pub(crate) fn into_settings(self) -> ClientSettings {
+        ClientSettings {
+            disable_language_services: self
+                .client
+                .python
+                .and_then(|python| python.ty)
+                .and_then(|ty| ty.disable_language_services)
+                .unwrap_or_default(),
+        }
+    }
+}
+
+/// This is a direct representation of the workspace settings schema, which inherits the schema of
+/// [`ClientOptions`] and adds extra fields to describe the workspace it applies to.
+#[derive(Debug, Deserialize)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
+#[serde(rename_all = "camelCase")]
+struct WorkspaceOptions {
+    #[serde(flatten)]
+    options: ClientOptions,
+    workspace: Url,
+}
+
+/// This is a direct representation of the settings schema sent by the client.
+#[derive(Debug, Deserialize, Default)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ClientOptions {
+    /// Settings under the `python.*` namespace in VS Code that are useful for the ty language
+    /// server.
+    python: Option<Python>,
+}
+
+// TODO(dhruvmanila): We need to mirror the "python.*" namespace on the server side but ideally it
+// would be useful to instead use `workspace/configuration` instead. This would be then used to get
+// all settings and not just the ones in "python.*".
+
+#[derive(Debug, Deserialize, Default)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
+#[serde(rename_all = "camelCase")]
+struct Python {
+    ty: Option<Ty>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
+#[serde(rename_all = "camelCase")]
+struct Ty {
+    disable_language_services: Option<bool>,
+}
+
+/// This is a direct representation of the settings schema sent by the client.
+/// Settings needed to initialize tracing. These will only be read from the global configuration.
+#[derive(Debug, Deserialize, Default)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TracingOptions {
+    pub(crate) log_level: Option<LogLevel>,
+
+    /// Path to the log file - tildes and environment variables are supported.
+    pub(crate) log_file: Option<PathBuf>,
+}
+
+/// This is the exact schema for initialization options sent in by the client during
+/// initialization.
+#[derive(Debug, Deserialize)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
+#[serde(untagged)]
+enum InitializationOptions {
+    #[serde(rename_all = "camelCase")]
+    HasWorkspaces {
+        #[serde(rename = "globalSettings")]
+        global: GlobalOptions,
+        #[serde(rename = "settings")]
+        workspace: Vec<WorkspaceOptions>,
+    },
+    GlobalOnly {
+        #[serde(default)]
+        settings: GlobalOptions,
+    },
+}
+
+impl Default for InitializationOptions {
+    fn default() -> Self {
+        Self::GlobalOnly {
+            settings: GlobalOptions::default(),
+        }
+    }
+}
+
+/// Built from the initialization options provided by the client.
+#[derive(Debug)]
+pub(crate) struct AllOptions {
+    pub(crate) global: GlobalOptions,
+    /// If this is `None`, the client only passed in global settings.
+    pub(crate) workspace: Option<WorkspaceOptionsMap>,
+}
+
+impl AllOptions {
+    /// Initializes the controller from the serialized initialization options. This fails if
+    /// `options` are not valid initialization options.
+    pub(crate) fn from_value(options: serde_json::Value) -> Self {
+        Self::from_init_options(
+            serde_json::from_value(options)
+                .map_err(|err| {
+                    tracing::error!("Failed to deserialize initialization options: {err}. Falling back to default client settings...");
+                })
+                .unwrap_or_default(),
+        )
+    }
+
+    fn from_init_options(options: InitializationOptions) -> Self {
+        let (global_options, workspace_options) = match options {
+            InitializationOptions::GlobalOnly { settings: options } => (options, None),
+            InitializationOptions::HasWorkspaces {
+                global: global_options,
+                workspace: workspace_options,
+            } => (global_options, Some(workspace_options)),
+        };
+
+        Self {
+            global: global_options,
+            workspace: workspace_options.map(|workspace_options| {
+                workspace_options
+                    .into_iter()
+                    .map(|workspace_options| {
+                        (workspace_options.workspace, workspace_options.options)
+                    })
+                    .collect()
+            }),
+        }
+    }
+}

--- a/crates/ty_server/src/session/settings.rs
+++ b/crates/ty_server/src/session/settings.rs
@@ -1,110 +1,14 @@
-use std::path::PathBuf;
-
-use lsp_types::Url;
-use rustc_hash::FxHashMap;
-use serde::Deserialize;
-
-/// Maps a workspace URI to its associated client settings. Used during server initialization.
-pub(crate) type WorkspaceSettingsMap = FxHashMap<Url, ClientSettings>;
-
-/// This is a direct representation of the settings schema sent by the client.
-#[derive(Debug, Deserialize, Default)]
+/// Resolved client settings for a specific document. These settings are meant to be
+/// used directly by the server, and are *not* a 1:1 representation with how the client
+/// sends them.
+#[derive(Clone, Debug)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
-#[serde(rename_all = "camelCase")]
-pub struct ClientSettings {
-    // These settings are only needed for tracing, and are only read from the global configuration.
-    // These will not be in the resolved settings.
-    #[serde(flatten)]
-    pub(crate) tracing: TracingSettings,
+pub(crate) struct ClientSettings {
+    pub(super) disable_language_services: bool,
 }
 
-/// Settings needed to initialize tracing. These will only be
-/// read from the global configuration.
-#[derive(Debug, Deserialize, Default)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
-#[serde(rename_all = "camelCase")]
-pub(crate) struct TracingSettings {
-    pub(crate) log_level: Option<crate::logging::LogLevel>,
-    /// Path to the log file - tildes and environment variables are supported.
-    pub(crate) log_file: Option<PathBuf>,
-}
-
-/// This is a direct representation of the workspace settings schema,
-/// which inherits the schema of [`ClientSettings`] and adds extra fields
-/// to describe the workspace it applies to.
-#[derive(Debug, Deserialize)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
-#[serde(rename_all = "camelCase")]
-struct WorkspaceSettings {
-    #[serde(flatten)]
-    settings: ClientSettings,
-    workspace: Url,
-}
-
-/// This is the exact schema for initialization options sent in by the client
-/// during initialization.
-#[derive(Debug, Deserialize)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
-#[serde(untagged)]
-enum InitializationOptions {
-    #[serde(rename_all = "camelCase")]
-    HasWorkspaces {
-        global_settings: ClientSettings,
-        #[serde(rename = "settings")]
-        workspace_settings: Vec<WorkspaceSettings>,
-    },
-    GlobalOnly {
-        #[serde(default)]
-        settings: ClientSettings,
-    },
-}
-
-/// Built from the initialization options provided by the client.
-#[derive(Debug)]
-pub(crate) struct AllSettings {
-    pub(crate) global_settings: ClientSettings,
-    /// If this is `None`, the client only passed in global settings.
-    pub(crate) workspace_settings: Option<WorkspaceSettingsMap>,
-}
-
-impl AllSettings {
-    /// Initializes the controller from the serialized initialization options.
-    /// This fails if `options` are not valid initialization options.
-    pub(crate) fn from_value(options: serde_json::Value) -> Self {
-        Self::from_init_options(
-            serde_json::from_value(options)
-                .map_err(|err| {
-                    tracing::error!("Failed to deserialize initialization options: {err}. Falling back to default client settings...");
-                })
-                .unwrap_or_default(),
-        )
-    }
-
-    fn from_init_options(options: InitializationOptions) -> Self {
-        let (global_settings, workspace_settings) = match options {
-            InitializationOptions::GlobalOnly { settings } => (settings, None),
-            InitializationOptions::HasWorkspaces {
-                global_settings,
-                workspace_settings,
-            } => (global_settings, Some(workspace_settings)),
-        };
-
-        Self {
-            global_settings,
-            workspace_settings: workspace_settings.map(|workspace_settings| {
-                workspace_settings
-                    .into_iter()
-                    .map(|settings| (settings.workspace, settings.settings))
-                    .collect()
-            }),
-        }
-    }
-}
-
-impl Default for InitializationOptions {
-    fn default() -> Self {
-        Self::GlobalOnly {
-            settings: ClientSettings::default(),
-        }
+impl ClientSettings {
+    pub(crate) fn is_language_services_disabled(&self) -> bool {
+        self.disable_language_services
     }
 }


### PR DESCRIPTION
## Summary

PR adding support for it in the VS Code extension: https://github.com/astral-sh/ty-vscode/pull/36

This PR adds support for `python.ty.disableLanguageServices` to the ty language server by accepting this as server setting.

This has the same issue as https://github.com/astral-sh/ty/issues/282 in that it only works when configured globally. Fixing that requires support for multiple workspaces in the server itself.

I also went ahead and did a similar refactor as the Ruff server to use "Options" and "Settings" to keep the code consistent although the combine functionality doesn't exists yet because workspace settings isn't supported in the ty server.

## Test Plan

Refer to https://github.com/astral-sh/ty-vscode/pull/36 for the test demo.
