### PR TITLE
[`refurb`] Fix `FURB129` autofix generating invalid syntax

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/refurb/FURB129.py
+++ b/crates/ruff_linter/resources/test/fixtures/refurb/FURB129.py
@@ -43,14 +43,12 @@ def func():
 
 import builtins
 
-
 with builtins.open("FURB129.py") as f:
     for line in f.readlines():
         pass
 
 
 from builtins import open as o
-
 
 with o("FURB129.py") as f:
     for line in f.readlines():
@@ -88,4 +86,17 @@ with open("FURB129.py") as f:
     for _line in f.readlines(10):
         pass
     for _not_line in f.readline():
+        pass
+
+# https://github.com/astral-sh/ruff/issues/18231
+with open("furb129.py") as f:
+    for line in (f).readlines():
+        pass
+
+with open("furb129.py") as f:
+    [line for line in (f).readlines()]
+
+
+with open("furb129.py") as f:
+    for line in (((f))).readlines():
         pass

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB129_FURB129.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB129_FURB129.py.snap
@@ -204,40 +204,95 @@ FURB129.py:38:22: FURB129 [*] Instead of calling `readlines()`, iterate over fil
 40 40 |         for _line in bar.readlines():
 41 41 |             pass
 
-FURB129.py:48:17: FURB129 [*] Instead of calling `readlines()`, iterate over file object directly
+FURB129.py:47:17: FURB129 [*] Instead of calling `readlines()`, iterate over file object directly
    |
-47 | with builtins.open("FURB129.py") as f:
-48 |     for line in f.readlines():
+46 | with builtins.open("FURB129.py") as f:
+47 |     for line in f.readlines():
    |                 ^^^^^^^^^^^^^ FURB129
-49 |         pass
+48 |         pass
    |
    = help: Remove `readlines()`
 
 ℹ Unsafe fix
+44 44 | import builtins
 45 45 | 
-46 46 | 
-47 47 | with builtins.open("FURB129.py") as f:
-48    |-    for line in f.readlines():
-   48 |+    for line in f:
-49 49 |         pass
+46 46 | with builtins.open("FURB129.py") as f:
+47    |-    for line in f.readlines():
+   47 |+    for line in f:
+48 48 |         pass
+49 49 | 
 50 50 | 
-51 51 | 
 
-FURB129.py:56:17: FURB129 [*] Instead of calling `readlines()`, iterate over file object directly
+FURB129.py:54:17: FURB129 [*] Instead of calling `readlines()`, iterate over file object directly
    |
-55 | with o("FURB129.py") as f:
-56 |     for line in f.readlines():
+53 | with o("FURB129.py") as f:
+54 |     for line in f.readlines():
    |                 ^^^^^^^^^^^^^ FURB129
-57 |         pass
+55 |         pass
    |
    = help: Remove `readlines()`
 
 ℹ Unsafe fix
-53 53 | 
-54 54 | 
-55 55 | with o("FURB129.py") as f:
-56    |-    for line in f.readlines():
-   56 |+    for line in f:
-57 57 |         pass
-58 58 | 
-59 59 |
+51 51 | from builtins import open as o
+52 52 | 
+53 53 | with o("FURB129.py") as f:
+54    |-    for line in f.readlines():
+   54 |+    for line in f:
+55 55 |         pass
+56 56 | 
+57 57 | 
+
+FURB129.py:93:17: FURB129 [*] Instead of calling `readlines()`, iterate over file object directly
+   |
+91 | # https://github.com/astral-sh/ruff/issues/18231
+92 | with open("furb129.py") as f:
+93 |     for line in (f).readlines():
+   |                 ^^^^^^^^^^^^^^^ FURB129
+94 |         pass
+   |
+   = help: Remove `readlines()`
+
+ℹ Unsafe fix
+90 90 | 
+91 91 | # https://github.com/astral-sh/ruff/issues/18231
+92 92 | with open("furb129.py") as f:
+93    |-    for line in (f).readlines():
+   93 |+    for line in f:
+94 94 |         pass
+95 95 | 
+96 96 | with open("furb129.py") as f:
+
+FURB129.py:97:23: FURB129 [*] Instead of calling `readlines()`, iterate over file object directly
+   |
+96 | with open("furb129.py") as f:
+97 |     [line for line in (f).readlines()]
+   |                       ^^^^^^^^^^^^^^^ FURB129
+   |
+   = help: Remove `readlines()`
+
+ℹ Unsafe fix
+94 94 |         pass
+95 95 | 
+96 96 | with open("furb129.py") as f:
+97    |-    [line for line in (f).readlines()]
+   97 |+    [line for line in f]
+98 98 | 
+99 99 | 
+100 100 | with open("furb129.py") as f:
+
+FURB129.py:101:17: FURB129 [*] Instead of calling `readlines()`, iterate over file object directly
+    |
+100 | with open("furb129.py") as f:
+101 |     for line in (((f))).readlines():
+    |                 ^^^^^^^^^^^^^^^^^^^ FURB129
+102 |         pass
+    |
+    = help: Remove `readlines()`
+
+ℹ Unsafe fix
+98  98  | 
+99  99  | 
+100 100 | with open("furb129.py") as f:
+101     |-    for line in (((f))).readlines():
+    101 |+    for line in ((f)):
+102 102 |         pass

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__preview__FURB129_FURB129.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__preview__FURB129_FURB129.py.snap
@@ -204,40 +204,95 @@ FURB129.py:38:22: FURB129 [*] Instead of calling `readlines()`, iterate over fil
 40 40 |         for _line in bar.readlines():
 41 41 |             pass
 
-FURB129.py:48:17: FURB129 [*] Instead of calling `readlines()`, iterate over file object directly
+FURB129.py:47:17: FURB129 [*] Instead of calling `readlines()`, iterate over file object directly
    |
-47 | with builtins.open("FURB129.py") as f:
-48 |     for line in f.readlines():
+46 | with builtins.open("FURB129.py") as f:
+47 |     for line in f.readlines():
    |                 ^^^^^^^^^^^^^ FURB129
-49 |         pass
+48 |         pass
    |
    = help: Remove `readlines()`
 
 ℹ Safe fix
+44 44 | import builtins
 45 45 | 
-46 46 | 
-47 47 | with builtins.open("FURB129.py") as f:
-48    |-    for line in f.readlines():
-   48 |+    for line in f:
-49 49 |         pass
+46 46 | with builtins.open("FURB129.py") as f:
+47    |-    for line in f.readlines():
+   47 |+    for line in f:
+48 48 |         pass
+49 49 | 
 50 50 | 
-51 51 | 
 
-FURB129.py:56:17: FURB129 [*] Instead of calling `readlines()`, iterate over file object directly
+FURB129.py:54:17: FURB129 [*] Instead of calling `readlines()`, iterate over file object directly
    |
-55 | with o("FURB129.py") as f:
-56 |     for line in f.readlines():
+53 | with o("FURB129.py") as f:
+54 |     for line in f.readlines():
    |                 ^^^^^^^^^^^^^ FURB129
-57 |         pass
+55 |         pass
    |
    = help: Remove `readlines()`
 
 ℹ Safe fix
-53 53 | 
-54 54 | 
-55 55 | with o("FURB129.py") as f:
-56    |-    for line in f.readlines():
-   56 |+    for line in f:
-57 57 |         pass
-58 58 | 
-59 59 |
+51 51 | from builtins import open as o
+52 52 | 
+53 53 | with o("FURB129.py") as f:
+54    |-    for line in f.readlines():
+   54 |+    for line in f:
+55 55 |         pass
+56 56 | 
+57 57 | 
+
+FURB129.py:93:17: FURB129 [*] Instead of calling `readlines()`, iterate over file object directly
+   |
+91 | # https://github.com/astral-sh/ruff/issues/18231
+92 | with open("furb129.py") as f:
+93 |     for line in (f).readlines():
+   |                 ^^^^^^^^^^^^^^^ FURB129
+94 |         pass
+   |
+   = help: Remove `readlines()`
+
+ℹ Safe fix
+90 90 | 
+91 91 | # https://github.com/astral-sh/ruff/issues/18231
+92 92 | with open("furb129.py") as f:
+93    |-    for line in (f).readlines():
+   93 |+    for line in f:
+94 94 |         pass
+95 95 | 
+96 96 | with open("furb129.py") as f:
+
+FURB129.py:97:23: FURB129 [*] Instead of calling `readlines()`, iterate over file object directly
+   |
+96 | with open("furb129.py") as f:
+97 |     [line for line in (f).readlines()]
+   |                       ^^^^^^^^^^^^^^^ FURB129
+   |
+   = help: Remove `readlines()`
+
+ℹ Safe fix
+94 94 |         pass
+95 95 | 
+96 96 | with open("furb129.py") as f:
+97    |-    [line for line in (f).readlines()]
+   97 |+    [line for line in f]
+98 98 | 
+99 99 | 
+100 100 | with open("furb129.py") as f:
+
+FURB129.py:101:17: FURB129 [*] Instead of calling `readlines()`, iterate over file object directly
+    |
+100 | with open("furb129.py") as f:
+101 |     for line in (((f))).readlines():
+    |                 ^^^^^^^^^^^^^^^^^^^ FURB129
+102 |         pass
+    |
+    = help: Remove `readlines()`
+
+ℹ Safe fix
+98  98  | 
+99  99  | 
+100 100 | with open("furb129.py") as f:
+101     |-    for line in (((f))).readlines():
+    101 |+    for line in ((f)):
+102 102 |         pass


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

Fixes #18231

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

Snapshot tests
<!-- How was it tested? -->
