### PR TITLE
[`flake8_async`] Fix sleep argument name for anyio (`ASYNC115`, `ASYNC116`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_async/ASYNC115.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_async/ASYNC115.py
@@ -146,6 +146,7 @@ def func():
 
     anyio.run(main)
 
+
 async def test_anyio_async115_helpers():
     import anyio
 
@@ -153,7 +154,8 @@ async def test_anyio_async115_helpers():
     await anyio.sleep(seconds=1)  # OK
 
     await anyio.sleep(delay=0)  # ASYNC115
-    await anyio.sleep(seconds=0)  # ASYNC115
+    await anyio.sleep(seconds=0)  # OK
+
 
 async def test_trio_async115_helpers():
     import trio
@@ -162,4 +164,4 @@ async def test_trio_async115_helpers():
     await trio.sleep(delay=1)  # OK
 
     await trio.sleep(seconds=0)  # ASYNC115
-    await trio.sleep(delay=0)  # ASYNC115
+    await trio.sleep(delay=0)  # OK

--- a/crates/ruff_linter/resources/test/fixtures/flake8_async/ASYNC115.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_async/ASYNC115.py
@@ -150,13 +150,16 @@ async def test_anyio_async115_helpers():
     import anyio
 
     await anyio.sleep(delay=1)  # OK
+    await anyio.sleep(seconds=1)  # OK
 
-    await anyio.sleep(seconds=1)  # ASYNC115
-
+    await anyio.sleep(delay=0)  # ASYNC115
+    await anyio.sleep(seconds=0)  # ASYNC115
 
 async def test_trio_async115_helpers():
     import trio
 
     await trio.sleep(seconds=1)  # OK
+    await trio.sleep(delay=1)  # OK
 
-    await trio.sleep(delay=1)  # ASYNC115
+    await trio.sleep(seconds=0)  # ASYNC115
+    await trio.sleep(delay=0)  # ASYNC115

--- a/crates/ruff_linter/resources/test/fixtures/flake8_async/ASYNC115.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_async/ASYNC115.py
@@ -145,3 +145,18 @@ def func():
             sleep = 10
 
     anyio.run(main)
+
+async def test_anyio_async115_helpers():
+    import anyio
+
+    await anyio.sleep(delay=1)  # OK
+
+    await anyio.sleep(seconds=1)  # ASYNC115
+
+
+async def test_trio_async115_helpers():
+    import trio
+
+    await trio.sleep(seconds=1)  # OK
+
+    await trio.sleep(delay=1)  # ASYNC115

--- a/crates/ruff_linter/resources/test/fixtures/flake8_async/ASYNC116.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_async/ASYNC116.py
@@ -109,6 +109,7 @@ async def import_from_anyio():
     # catch from import
     await sleep(86401)  # error: 116, "async"
 
+
 async def test_anyio_async116_helpers():
     import anyio
 
@@ -116,7 +117,7 @@ async def test_anyio_async116_helpers():
     await anyio.sleep(seconds=1)  # OK
 
     await anyio.sleep(delay=86401)  # ASYNC116
-    await anyio.sleep(seconds=86401)  # ASYNC116
+    await anyio.sleep(seconds=86401)  # OK
 
 
 async def test_trio_async116_helpers():
@@ -126,4 +127,4 @@ async def test_trio_async116_helpers():
     await trio.sleep(delay=1)  # OK
 
     await trio.sleep(seconds=86401)  # ASYNC116
-    await trio.sleep(delay=86401)  # ASYNC116
+    await trio.sleep(delay=86401)  # OK

--- a/crates/ruff_linter/resources/test/fixtures/flake8_async/ASYNC116.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_async/ASYNC116.py
@@ -113,13 +113,17 @@ async def test_anyio_async116_helpers():
     import anyio
 
     await anyio.sleep(delay=1)  # OK
+    await anyio.sleep(seconds=1)  # OK
 
-    await anyio.sleep(seconds=1)  # ASYNC116
+    await anyio.sleep(delay=86401)  # ASYNC116
+    await anyio.sleep(seconds=86401)  # ASYNC116
 
 
 async def test_trio_async116_helpers():
     import trio
 
     await trio.sleep(seconds=1)  # OK
+    await trio.sleep(delay=1)  # OK
 
-    await trio.sleep(delay=1)  # ASYNC116
+    await trio.sleep(seconds=86401)  # ASYNC116
+    await trio.sleep(delay=86401)  # ASYNC116

--- a/crates/ruff_linter/resources/test/fixtures/flake8_async/ASYNC116.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_async/ASYNC116.py
@@ -108,3 +108,18 @@ async def import_from_anyio():
 
     # catch from import
     await sleep(86401)  # error: 116, "async"
+
+async def test_anyio_async116_helpers():
+    import anyio
+
+    await anyio.sleep(delay=1)  # OK
+
+    await anyio.sleep(seconds=1)  # ASYNC116
+
+
+async def test_trio_async116_helpers():
+    import trio
+
+    await trio.sleep(seconds=1)  # OK
+
+    await trio.sleep(delay=1)  # ASYNC116

--- a/crates/ruff_linter/src/rules/flake8_async/rules/async_zero_sleep.rs
+++ b/crates/ruff_linter/src/rules/flake8_async/rules/async_zero_sleep.rs
@@ -77,7 +77,7 @@ pub(crate) fn async_zero_sleep(checker: &Checker, call: &ExprCall) {
     let arg_name = match module {
         AsyncModule::Trio => "seconds",
         AsyncModule::AnyIo => "delay",
-        _ => return,
+        AsyncModule::AsyncIo => return,
     };
 
     let Some(arg) = call.arguments.find_argument_value(arg_name, 0) else {

--- a/crates/ruff_linter/src/rules/flake8_async/rules/async_zero_sleep.rs
+++ b/crates/ruff_linter/src/rules/flake8_async/rules/async_zero_sleep.rs
@@ -62,7 +62,25 @@ pub(crate) fn async_zero_sleep(checker: &Checker, call: &ExprCall) {
         return;
     }
 
-    let Some(arg) = call.arguments.find_argument_value("seconds", 0) else {
+    let Some(qualified_name) = checker
+        .semantic()
+        .resolve_qualified_name(call.func.as_ref())
+    else {
+        return;
+    };
+
+    let Some(module) = AsyncModule::try_from(&qualified_name) else {
+        return;
+    };
+
+    // Determine the correct argument name
+    let arg_name = match module {
+        AsyncModule::Trio => "seconds",
+        AsyncModule::AnyIo => "delay",
+        _ => return,
+    };
+
+    let Some(arg) = call.arguments.find_argument_value(arg_name, 0) else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/flake8_async/rules/long_sleep_not_forever.rs
+++ b/crates/ruff_linter/src/rules/flake8_async/rules/long_sleep_not_forever.rs
@@ -71,7 +71,25 @@ pub(crate) fn long_sleep_not_forever(checker: &Checker, call: &ExprCall) {
         return;
     }
 
-    let Some(arg) = call.arguments.find_argument_value("seconds", 0) else {
+    let Some(qualified_name) = checker
+        .semantic()
+        .resolve_qualified_name(call.func.as_ref())
+    else {
+        return;
+    };
+
+    let Some(module) = AsyncModule::try_from(&qualified_name) else {
+        return;
+    };
+
+    // Determine the correct argument name
+    let arg_name = match module {
+        AsyncModule::Trio => "seconds",
+        AsyncModule::AnyIo => "delay",
+        _ => return,
+    };
+
+    let Some(arg) = call.arguments.find_argument_value(arg_name, 0) else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/flake8_async/rules/long_sleep_not_forever.rs
+++ b/crates/ruff_linter/src/rules/flake8_async/rules/long_sleep_not_forever.rs
@@ -86,7 +86,7 @@ pub(crate) fn long_sleep_not_forever(checker: &Checker, call: &ExprCall) {
     let arg_name = match module {
         AsyncModule::Trio => "seconds",
         AsyncModule::AnyIo => "delay",
-        _ => return,
+        AsyncModule::AsyncIo => return,
     };
 
     let Some(arg) = call.arguments.find_argument_value(arg_name, 0) else {

--- a/crates/ruff_linter/src/rules/flake8_async/snapshots/ruff_linter__rules__flake8_async__tests__ASYNC115_ASYNC115.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_async/snapshots/ruff_linter__rules__flake8_async__tests__ASYNC115_ASYNC115.py.snap
@@ -215,40 +215,40 @@ ASYNC115.py:128:15: ASYNC115 [*] Use `anyio.lowlevel.checkpoint()` instead of `a
 130 130 | 
 131 131 | def func():
 
-ASYNC115.py:155:11: ASYNC115 [*] Use `anyio.lowlevel.checkpoint()` instead of `anyio.sleep(0)`
+ASYNC115.py:156:11: ASYNC115 [*] Use `anyio.lowlevel.checkpoint()` instead of `anyio.sleep(0)`
     |
-153 |     await anyio.sleep(seconds=1)  # OK
-154 |
-155 |     await anyio.sleep(delay=0)  # ASYNC115
+154 |     await anyio.sleep(seconds=1)  # OK
+155 |
+156 |     await anyio.sleep(delay=0)  # ASYNC115
     |           ^^^^^^^^^^^^^^^^^^^^ ASYNC115
-156 |     await anyio.sleep(seconds=0)  # ASYNC115
+157 |     await anyio.sleep(seconds=0)  # OK
     |
     = help: Replace with `anyio.lowlevel.checkpoint()`
 
 ℹ Safe fix
-152 152 |     await anyio.sleep(delay=1)  # OK
-153 153 |     await anyio.sleep(seconds=1)  # OK
-154 154 | 
-155     |-    await anyio.sleep(delay=0)  # ASYNC115
-    155 |+    await anyio.lowlevel.checkpoint()  # ASYNC115
-156 156 |     await anyio.sleep(seconds=0)  # ASYNC115
-157 157 | 
-158 158 | async def test_trio_async115_helpers():
+153 153 |     await anyio.sleep(delay=1)  # OK
+154 154 |     await anyio.sleep(seconds=1)  # OK
+155 155 | 
+156     |-    await anyio.sleep(delay=0)  # ASYNC115
+    156 |+    await anyio.lowlevel.checkpoint()  # ASYNC115
+157 157 |     await anyio.sleep(seconds=0)  # OK
+158 158 | 
+159 159 | 
 
-ASYNC115.py:164:11: ASYNC115 [*] Use `trio.lowlevel.checkpoint()` instead of `trio.sleep(0)`
+ASYNC115.py:166:11: ASYNC115 [*] Use `trio.lowlevel.checkpoint()` instead of `trio.sleep(0)`
     |
-162 |     await trio.sleep(delay=1)  # OK
-163 |
-164 |     await trio.sleep(seconds=0)  # ASYNC115
+164 |     await trio.sleep(delay=1)  # OK
+165 |
+166 |     await trio.sleep(seconds=0)  # ASYNC115
     |           ^^^^^^^^^^^^^^^^^^^^^ ASYNC115
-165 |     await trio.sleep(delay=0)  # ASYNC115
+167 |     await trio.sleep(delay=0)  # OK
     |
     = help: Replace with `trio.lowlevel.checkpoint()`
 
 ℹ Safe fix
-161 161 |     await trio.sleep(seconds=1)  # OK
-162 162 |     await trio.sleep(delay=1)  # OK
-163 163 | 
-164     |-    await trio.sleep(seconds=0)  # ASYNC115
-    164 |+    await trio.lowlevel.checkpoint()  # ASYNC115
-165 165 |     await trio.sleep(delay=0)  # ASYNC115
+163 163 |     await trio.sleep(seconds=1)  # OK
+164 164 |     await trio.sleep(delay=1)  # OK
+165 165 | 
+166     |-    await trio.sleep(seconds=0)  # ASYNC115
+    166 |+    await trio.lowlevel.checkpoint()  # ASYNC115
+167 167 |     await trio.sleep(delay=0)  # OK

--- a/crates/ruff_linter/src/rules/flake8_async/snapshots/ruff_linter__rules__flake8_async__tests__ASYNC115_ASYNC115.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_async/snapshots/ruff_linter__rules__flake8_async__tests__ASYNC115_ASYNC115.py.snap
@@ -214,3 +214,41 @@ ASYNC115.py:128:15: ASYNC115 [*] Use `anyio.lowlevel.checkpoint()` instead of `a
 129 129 | 
 130 130 | 
 131 131 | def func():
+
+ASYNC115.py:155:11: ASYNC115 [*] Use `anyio.lowlevel.checkpoint()` instead of `anyio.sleep(0)`
+    |
+153 |     await anyio.sleep(seconds=1)  # OK
+154 |
+155 |     await anyio.sleep(delay=0)  # ASYNC115
+    |           ^^^^^^^^^^^^^^^^^^^^ ASYNC115
+156 |     await anyio.sleep(seconds=0)  # ASYNC115
+    |
+    = help: Replace with `anyio.lowlevel.checkpoint()`
+
+ℹ Safe fix
+152 152 |     await anyio.sleep(delay=1)  # OK
+153 153 |     await anyio.sleep(seconds=1)  # OK
+154 154 | 
+155     |-    await anyio.sleep(delay=0)  # ASYNC115
+    155 |+    await anyio.lowlevel.checkpoint()  # ASYNC115
+156 156 |     await anyio.sleep(seconds=0)  # ASYNC115
+157 157 | 
+158 158 | async def test_trio_async115_helpers():
+
+ASYNC115.py:164:11: ASYNC115 [*] Use `trio.lowlevel.checkpoint()` instead of `trio.sleep(0)`
+    |
+162 |     await trio.sleep(delay=1)  # OK
+163 |
+164 |     await trio.sleep(seconds=0)  # ASYNC115
+    |           ^^^^^^^^^^^^^^^^^^^^^ ASYNC115
+165 |     await trio.sleep(delay=0)  # ASYNC115
+    |
+    = help: Replace with `trio.lowlevel.checkpoint()`
+
+ℹ Safe fix
+161 161 |     await trio.sleep(seconds=1)  # OK
+162 162 |     await trio.sleep(delay=1)  # OK
+163 163 | 
+164     |-    await trio.sleep(seconds=0)  # ASYNC115
+    164 |+    await trio.lowlevel.checkpoint()  # ASYNC115
+165 165 |     await trio.sleep(delay=0)  # ASYNC115

--- a/crates/ruff_linter/src/rules/flake8_async/snapshots/ruff_linter__rules__flake8_async__tests__ASYNC116_ASYNC116.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_async/snapshots/ruff_linter__rules__flake8_async__tests__ASYNC116_ASYNC116.py.snap
@@ -272,8 +272,6 @@ ASYNC116.py:110:11: ASYNC116 [*] `anyio.sleep()` with >24 hour interval should u
 109 |     # catch from import
 110 |     await sleep(86401)  # error: 116, "async"
     |           ^^^^^^^^^^^^ ASYNC116
-111 |
-112 | async def test_anyio_async116_helpers():
     |
     = help: Replace with `anyio.sleep_forever()`
 
@@ -292,43 +290,43 @@ ASYNC116.py:110:11: ASYNC116 [*] `anyio.sleep()` with >24 hour interval should u
 110     |-    await sleep(86401)  # error: 116, "async"
     111 |+    await sleep_forever()  # error: 116, "async"
 111 112 | 
-112 113 | async def test_anyio_async116_helpers():
-113 114 |     import anyio
+112 113 | 
+113 114 | async def test_anyio_async116_helpers():
 
-ASYNC116.py:118:11: ASYNC116 [*] `anyio.sleep()` with >24 hour interval should usually be `anyio.sleep_forever()`
+ASYNC116.py:119:11: ASYNC116 [*] `anyio.sleep()` with >24 hour interval should usually be `anyio.sleep_forever()`
     |
-116 |     await anyio.sleep(seconds=1)  # OK
-117 |
-118 |     await anyio.sleep(delay=86401)  # ASYNC116
+117 |     await anyio.sleep(seconds=1)  # OK
+118 |
+119 |     await anyio.sleep(delay=86401)  # ASYNC116
     |           ^^^^^^^^^^^^^^^^^^^^^^^^ ASYNC116
-119 |     await anyio.sleep(seconds=86401)  # ASYNC116
+120 |     await anyio.sleep(seconds=86401)  # OK
     |
     = help: Replace with `anyio.sleep_forever()`
 
 ℹ Unsafe fix
-115 115 |     await anyio.sleep(delay=1)  # OK
-116 116 |     await anyio.sleep(seconds=1)  # OK
-117 117 | 
-118     |-    await anyio.sleep(delay=86401)  # ASYNC116
-    118 |+    await anyio.sleep_forever()  # ASYNC116
-119 119 |     await anyio.sleep(seconds=86401)  # ASYNC116
-120 120 | 
+116 116 |     await anyio.sleep(delay=1)  # OK
+117 117 |     await anyio.sleep(seconds=1)  # OK
+118 118 | 
+119     |-    await anyio.sleep(delay=86401)  # ASYNC116
+    119 |+    await anyio.sleep_forever()  # ASYNC116
+120 120 |     await anyio.sleep(seconds=86401)  # OK
 121 121 | 
+122 122 | 
 
-ASYNC116.py:128:11: ASYNC116 [*] `trio.sleep()` with >24 hour interval should usually be `trio.sleep_forever()`
+ASYNC116.py:129:11: ASYNC116 [*] `trio.sleep()` with >24 hour interval should usually be `trio.sleep_forever()`
     |
-126 |     await trio.sleep(delay=1)  # OK
-127 |
-128 |     await trio.sleep(seconds=86401)  # ASYNC116
+127 |     await trio.sleep(delay=1)  # OK
+128 |
+129 |     await trio.sleep(seconds=86401)  # ASYNC116
     |           ^^^^^^^^^^^^^^^^^^^^^^^^^ ASYNC116
-129 |     await trio.sleep(delay=86401)  # ASYNC116
+130 |     await trio.sleep(delay=86401)  # OK
     |
     = help: Replace with `trio.sleep_forever()`
 
 ℹ Unsafe fix
-125 125 |     await trio.sleep(seconds=1)  # OK
-126 126 |     await trio.sleep(delay=1)  # OK
-127 127 | 
-128     |-    await trio.sleep(seconds=86401)  # ASYNC116
-    128 |+    await trio.sleep_forever()  # ASYNC116
-129 129 |     await trio.sleep(delay=86401)  # ASYNC116
+126 126 |     await trio.sleep(seconds=1)  # OK
+127 127 |     await trio.sleep(delay=1)  # OK
+128 128 | 
+129     |-    await trio.sleep(seconds=86401)  # ASYNC116
+    129 |+    await trio.sleep_forever()  # ASYNC116
+130 130 |     await trio.sleep(delay=86401)  # OK

--- a/crates/ruff_linter/src/rules/flake8_async/snapshots/ruff_linter__rules__flake8_async__tests__ASYNC116_ASYNC116.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_async/snapshots/ruff_linter__rules__flake8_async__tests__ASYNC116_ASYNC116.py.snap
@@ -294,3 +294,41 @@ ASYNC116.py:110:11: ASYNC116 [*] `anyio.sleep()` with >24 hour interval should u
 111 112 | 
 112 113 | async def test_anyio_async116_helpers():
 113 114 |     import anyio
+
+ASYNC116.py:118:11: ASYNC116 [*] `anyio.sleep()` with >24 hour interval should usually be `anyio.sleep_forever()`
+    |
+116 |     await anyio.sleep(seconds=1)  # OK
+117 |
+118 |     await anyio.sleep(delay=86401)  # ASYNC116
+    |           ^^^^^^^^^^^^^^^^^^^^^^^^ ASYNC116
+119 |     await anyio.sleep(seconds=86401)  # ASYNC116
+    |
+    = help: Replace with `anyio.sleep_forever()`
+
+ℹ Unsafe fix
+115 115 |     await anyio.sleep(delay=1)  # OK
+116 116 |     await anyio.sleep(seconds=1)  # OK
+117 117 | 
+118     |-    await anyio.sleep(delay=86401)  # ASYNC116
+    118 |+    await anyio.sleep_forever()  # ASYNC116
+119 119 |     await anyio.sleep(seconds=86401)  # ASYNC116
+120 120 | 
+121 121 | 
+
+ASYNC116.py:128:11: ASYNC116 [*] `trio.sleep()` with >24 hour interval should usually be `trio.sleep_forever()`
+    |
+126 |     await trio.sleep(delay=1)  # OK
+127 |
+128 |     await trio.sleep(seconds=86401)  # ASYNC116
+    |           ^^^^^^^^^^^^^^^^^^^^^^^^^ ASYNC116
+129 |     await trio.sleep(delay=86401)  # ASYNC116
+    |
+    = help: Replace with `trio.sleep_forever()`
+
+ℹ Unsafe fix
+125 125 |     await trio.sleep(seconds=1)  # OK
+126 126 |     await trio.sleep(delay=1)  # OK
+127 127 | 
+128     |-    await trio.sleep(seconds=86401)  # ASYNC116
+    128 |+    await trio.sleep_forever()  # ASYNC116
+129 129 |     await trio.sleep(delay=86401)  # ASYNC116

--- a/crates/ruff_linter/src/rules/flake8_async/snapshots/ruff_linter__rules__flake8_async__tests__ASYNC116_ASYNC116.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_async/snapshots/ruff_linter__rules__flake8_async__tests__ASYNC116_ASYNC116.py.snap
@@ -272,6 +272,8 @@ ASYNC116.py:110:11: ASYNC116 [*] `anyio.sleep()` with >24 hour interval should u
 109 |     # catch from import
 110 |     await sleep(86401)  # error: 116, "async"
     |           ^^^^^^^^^^^^ ASYNC116
+111 |
+112 | async def test_anyio_async116_helpers():
     |
     = help: Replace with `anyio.sleep_forever()`
 
@@ -289,3 +291,6 @@ ASYNC116.py:110:11: ASYNC116 [*] `anyio.sleep()` with >24 hour interval should u
 109 110 |     # catch from import
 110     |-    await sleep(86401)  # error: 116, "async"
     111 |+    await sleep_forever()  # error: 116, "async"
+111 112 | 
+112 113 | async def test_anyio_async116_helpers():
+113 114 |     import anyio


### PR DESCRIPTION
#18164
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

Fix incorrect argument name detection for `anyio.sleep` and `trio.sleep` in ASYNC115 lint check.  
The linter previously assumed the keyword argument for sleep duration was always `seconds`, causing false positives when `delay` was used with `anyio.sleep`.  
This update correctly distinguishes between `seconds` (Trio) and `delay` (AnyIO), improving accuracy.

Fixes https://github.com/astral-sh/ruff/issues/18164

## Test Plan

- Added test cases covering both `anyio.sleep(delay=0)` and `trio.sleep(seconds=0)` usage.  
- Verified ASYNC115 warnings are correctly triggered or suppressed based on argument names.  
- Manual testing with examples from the linked issue.
