### PR TITLE
Fix insider docs requirement syntax

### DIFF
--- a/docs/requirements-insiders.txt
+++ b/docs/requirements-insiders.txt
@@ -5,4 +5,4 @@ mkdocs-material @ git+ssh://git@github.com/astral-sh/mkdocs-material-insiders.gi
 mkdocs-redirects==1.2.2
 mdformat==0.7.22
 mdformat-mkdocs==4.1.2
-mkdocs-github-admonitions-plugin @ https://github.com/PGijsbers/admonitions.git#7343d2f4a92e4d1491094530ef3d0d02d93afbb7
+mkdocs-github-admonitions-plugin @ git+https://github.com/PGijsbers/admonitions.git#7343d2f4a92e4d1491094530ef3d0d02d93afbb7

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,4 +5,4 @@ mkdocs-material==9.5.38
 mkdocs-redirects==1.2.2
 mdformat==0.7.22
 mdformat-mkdocs==4.1.2
-mkdocs-github-admonitions-plugin @ https://github.com/PGijsbers/admonitions.git#7343d2f4a92e4d1491094530ef3d0d02d93afbb7
+mkdocs-github-admonitions-plugin @ git+https://github.com/PGijsbers/admonitions.git#7343d2f4a92e4d1491094530ef3d0d02d93afbb7


### PR DESCRIPTION
Attempting to fix the `mkdocs` workflow (maybe `uv` is more forgiving than `pip` for the syntax in `requirements.txt`?)
