### PR TITLE
[Ty] Resolving Python path using `CONDA_PREFIX` variable to support Conda and Pixi

### DIFF
--- a/crates/ty_project/src/metadata/options.rs
+++ b/crates/ty_project/src/metadata/options.rs
@@ -174,6 +174,11 @@ impl Options {
                         .ok()
                         .map(PythonPath::from_virtual_env_var)
                 })
+                .or_else(|| {
+                    std::env::var("CONDA_PREFIX")
+                        .ok()
+                        .map(PythonPath::from_conda_prefix_var)
+                })
                 .unwrap_or_else(|| PythonPath::Discover(project_root.to_path_buf())),
         }
     }

--- a/crates/ty_python_semantic/src/program.rs
+++ b/crates/ty_python_semantic/src/program.rs
@@ -164,7 +164,7 @@ impl PythonPath {
     }
     
     pub fn from_conda_prefix_var(path: impl Into<SystemPathBuf>) -> Self {
-        Self::Resolve(path.into(), SysPrefixPathOrigin::PythonCliFlag)
+        Self::Resolve(path.into(), SysPrefixPathOrigin::CondaPrefixVar)
     }
 
     pub fn from_cli_flag(path: SystemPathBuf) -> Self {

--- a/crates/ty_python_semantic/src/program.rs
+++ b/crates/ty_python_semantic/src/program.rs
@@ -162,6 +162,10 @@ impl PythonPath {
     pub fn from_virtual_env_var(path: impl Into<SystemPathBuf>) -> Self {
         Self::SysPrefix(path.into(), SysPrefixPathOrigin::VirtualEnvVar)
     }
+    
+    pub fn from_conda_prefix_var(path: impl Into<SystemPathBuf>) -> Self {
+        Self::Resolve(path.into(), SysPrefixPathOrigin::PythonCliFlag)
+    }
 
     pub fn from_cli_flag(path: SystemPathBuf) -> Self {
         Self::Resolve(path, SysPrefixPathOrigin::PythonCliFlag)

--- a/crates/ty_python_semantic/src/site_packages.rs
+++ b/crates/ty_python_semantic/src/site_packages.rs
@@ -580,6 +580,7 @@ impl fmt::Display for SysPrefixPath {
 pub enum SysPrefixPathOrigin {
     PythonCliFlag,
     VirtualEnvVar,
+    CondaPrefixVar,
     Derived,
     LocalVenv,
 }
@@ -590,7 +591,7 @@ impl SysPrefixPathOrigin {
     pub(crate) fn must_be_virtual_env(self) -> bool {
         match self {
             Self::LocalVenv | Self::VirtualEnvVar => true,
-            Self::PythonCliFlag | Self::Derived => false,
+            Self::PythonCliFlag | Self::Derived | Self::CondaPrefixVar => false,
         }
     }
 }
@@ -600,6 +601,7 @@ impl Display for SysPrefixPathOrigin {
         match self {
             Self::PythonCliFlag => f.write_str("`--python` argument"),
             Self::VirtualEnvVar => f.write_str("`VIRTUAL_ENV` environment variable"),
+            Self::CondaPrefixVar => f.write_str("`CONDA_PREFIX` environment variable"),
             Self::Derived => f.write_str("derived `sys.prefix` path"),
             Self::LocalVenv => f.write_str("local virtual environment"),
         }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

Implement what was discussed in #265. Pixi and Conda set the `CONDA_PREFIX` environment variable and not `VIRTUAL_ENV`. With this PR, if no `--python flag` has been passed and `VIRTUAL_ENV` has not been set then we check `CONDA_PREFIX` and resolve the path. 

I am still not sure about how to implement: `CONDA_PREFIX` is checked only if there's no `.venv` directory in the project root. 

My guess is it should be something like this but the `.unwrap_or_else()` is still confusing to me and I can't figure out how to check for `CONDA_PREFIX` after the `.unwrap_or_else()` .
```rust
SearchPathSettings {
            extra_paths: extra_paths
                .unwrap_or_default()
                .into_iter()
                .map(|path| path.absolute(project_root, system))
                .collect(),
            src_roots,
            custom_typeshed: typeshed.map(|path| path.absolute(project_root, system)),
            python_path: python
                .map(|python_path| {
                    PythonPath::from_cli_flag(python_path.absolute(project_root, system))
                })
                .or_else(|| {
                    std::env::var("VIRTUAL_ENV")
                        .ok()
                        .map(PythonPath::from_virtual_env_var)
                })
                .unwrap_or_else(|| PythonPath::Discover(project_root.to_path_buf())
                .or_else(|| {
                                    std::env::var("CONDA_PREFIX")
                                        .ok()
                                        .map(PythonPath::from_conda_prefix_var)
                                })),
        }
```

## Test Plan

I reproduced the error from #265, and now there is no more `lint:unresolved-import` error. I am still not familar with the markdown tests but I will do more commits to provide tests. 


This is my first opensource contribution and I am still a student with 0 experience in Rust, please give me constructive feedbacks! I will try to learn as quickly as I can!
