### PR TITLE
[ty] Add warning that docs are autogenerated

### DIFF
--- a/crates/ruff_dev/src/generate_ty_cli_reference.rs
+++ b/crates/ruff_dev/src/generate_ty_cli_reference.rs
@@ -80,6 +80,7 @@ fn generate() -> String {
 
     let mut parents = Vec::new();
 
+    output.push_str("<!-- WARNING: This file is auto-generated (cargo dev generate-all). Edit the doc comments in 'crates/ty/src/args.rs' if you want to change anything here. -->\n\n");
     output.push_str("# CLI Reference\n\n");
     generate_command(&mut output, &ty, &mut parents);
 

--- a/crates/ruff_dev/src/generate_ty_options.rs
+++ b/crates/ruff_dev/src/generate_ty_options.rs
@@ -25,6 +25,10 @@ pub(crate) fn main(args: &Args) -> anyhow::Result<()> {
     let file_name = "crates/ty/docs/configuration.md";
     let markdown_path = PathBuf::from(ROOT_DIR).join(file_name);
 
+    output.push_str(
+        "<!-- WARNING: This file is auto-generated (cargo dev generate-all). Update the doc comments on the 'Options' struct in 'crates/ty_project/src/metadata/options.rs' if you want to change anything here. -->\n\n",
+    );
+
     generate_set(
         &mut output,
         Set::Toplevel(Options::metadata()),

--- a/crates/ruff_dev/src/generate_ty_rules.rs
+++ b/crates/ruff_dev/src/generate_ty_rules.rs
@@ -56,6 +56,10 @@ fn generate_markdown() -> String {
 
     let mut output = String::new();
 
+    let _ = writeln!(
+        &mut output,
+        "<!-- WARNING: This file is auto-generated (cargo dev generate-all). Edit the lint-declarations in 'crates/ty_python_semantic/src/types/diagnostic.rs' if you want to change anything here. -->\n"
+    );
     let _ = writeln!(&mut output, "# Rules\n");
 
     let mut lints: Vec<_> = registry.lints().iter().collect();

--- a/crates/ty/docs/cli.md
+++ b/crates/ty/docs/cli.md
@@ -1,3 +1,5 @@
+<!-- WARNING: This file is auto-generated (cargo dev generate-all). Edit the doc comments in 'crates/ty/src/args.rs' if you want to change anything here. -->
+
 # CLI Reference
 
 ## ty

--- a/crates/ty/docs/configuration.md
+++ b/crates/ty/docs/configuration.md
@@ -1,3 +1,5 @@
+<!-- WARNING: This file is auto-generated (cargo dev generate-all). Update the doc comments on the 'Options' struct in 'crates/ty_project/src/metadata/options.rs' if you want to change anything here. -->
+
 # Configuration
 #### `respect-ignore-files`
 

--- a/crates/ty/docs/rules.md
+++ b/crates/ty/docs/rules.md
@@ -1,3 +1,5 @@
+<!-- WARNING: This file is auto-generated (cargo dev generate-all). Edit the lint-declarations in 'crates/ty_python_semantic/src/types/diagnostic.rs' if you want to change anything here. -->
+
 # Rules
 
 ## `byte-string-type-annotation`


### PR DESCRIPTION
## Summary

This is a practice I followed on previous projects. Should hopefully further help developers who want to update the documentation?

The big downside is that it's annoying to see this *as a user of the documentation* if you don't open the Markdown file in the browser. But I'd argue that those files don't really follow the original Markdown spirit anyway with all the inline HTML. So maybe it's fine?