### PR TITLE
[`fastapi`] Avoid false positive for class dependencies (`FAST003`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/fastapi/FAST003.py
+++ b/crates/ruff_linter/resources/test/fixtures/fastapi/FAST003.py
@@ -178,3 +178,38 @@ async def unknown_1(other: str = Depends(unknown_unresolved)): ...
 async def unknown_2(other: str = Depends(unknown_not_function)): ...
 @app.get("/things/{thing_id}")
 async def unknown_3(other: str = Depends(unknown_imported)): ...
+
+
+# Class dependencies
+from pydantic import BaseModel
+from dataclasses import dataclass
+
+class PydanticParams(BaseModel):
+    my_id: int
+
+
+class InitParams:
+    def __init__(self, my_id: int):
+        self.my_id = my_id
+
+
+# Errors
+@app.get("/{id}")
+async def get_id_pydantic_full(
+    params: Annotated[PydanticParams, Depends(PydanticParams)],
+): ...
+@app.get("/{id}")
+async def get_id_pydantic_short(params: Annotated[PydanticParams, Depends()]): ...
+@app.get("/{id}")
+async def get_id_init_not_annotated(params = Depends(InitParams)): ...
+
+
+# No errors
+@app.get("/{my_id}")
+async def get_id_pydantic_full(
+    params: Annotated[PydanticParams, Depends(PydanticParams)],
+): ...
+@app.get("/{my_id}")
+async def get_id_pydantic_short(params: Annotated[PydanticParams, Depends()]): ...
+@app.get("/{my_id}")
+async def get_id_init_not_annotated(params = Depends(InitParams)): ...

--- a/crates/ruff_linter/src/rules/fastapi/snapshots/ruff_linter__rules__fastapi__tests__fast-api-unused-path-parameter_FAST003.py.snap
+++ b/crates/ruff_linter/src/rules/fastapi/snapshots/ruff_linter__rules__fastapi__tests__fast-api-unused-path-parameter_FAST003.py.snap
@@ -380,3 +380,64 @@ FAST003.py:160:19: FAST003 [*] Parameter `thing_id` appears in route path, but n
 162 162 | 
 163 163 | 
 164 164 | ### No errors
+
+FAST003.py:197:12: FAST003 [*] Parameter `id` appears in route path, but not in `get_id_pydantic_full` signature
+    |
+196 | # Errors
+197 | @app.get("/{id}")
+    |            ^^^^ FAST003
+198 | async def get_id_pydantic_full(
+199 |     params: Annotated[PydanticParams, Depends(PydanticParams)],
+    |
+    = help: Add `id` to function signature
+
+ℹ Unsafe fix
+196 196 | # Errors
+197 197 | @app.get("/{id}")
+198 198 | async def get_id_pydantic_full(
+199     |-    params: Annotated[PydanticParams, Depends(PydanticParams)],
+    199 |+    params: Annotated[PydanticParams, Depends(PydanticParams)], id,
+200 200 | ): ...
+201 201 | @app.get("/{id}")
+202 202 | async def get_id_pydantic_short(params: Annotated[PydanticParams, Depends()]): ...
+
+FAST003.py:201:12: FAST003 [*] Parameter `id` appears in route path, but not in `get_id_pydantic_short` signature
+    |
+199 |     params: Annotated[PydanticParams, Depends(PydanticParams)],
+200 | ): ...
+201 | @app.get("/{id}")
+    |            ^^^^ FAST003
+202 | async def get_id_pydantic_short(params: Annotated[PydanticParams, Depends()]): ...
+203 | @app.get("/{id}")
+    |
+    = help: Add `id` to function signature
+
+ℹ Unsafe fix
+199 199 |     params: Annotated[PydanticParams, Depends(PydanticParams)],
+200 200 | ): ...
+201 201 | @app.get("/{id}")
+202     |-async def get_id_pydantic_short(params: Annotated[PydanticParams, Depends()]): ...
+    202 |+async def get_id_pydantic_short(params: Annotated[PydanticParams, Depends()], id): ...
+203 203 | @app.get("/{id}")
+204 204 | async def get_id_init_not_annotated(params = Depends(InitParams)): ...
+205 205 | 
+
+FAST003.py:203:12: FAST003 [*] Parameter `id` appears in route path, but not in `get_id_init_not_annotated` signature
+    |
+201 | @app.get("/{id}")
+202 | async def get_id_pydantic_short(params: Annotated[PydanticParams, Depends()]): ...
+203 | @app.get("/{id}")
+    |            ^^^^ FAST003
+204 | async def get_id_init_not_annotated(params = Depends(InitParams)): ...
+    |
+    = help: Add `id` to function signature
+
+ℹ Unsafe fix
+201 201 | @app.get("/{id}")
+202 202 | async def get_id_pydantic_short(params: Annotated[PydanticParams, Depends()]): ...
+203 203 | @app.get("/{id}")
+204     |-async def get_id_init_not_annotated(params = Depends(InitParams)): ...
+    204 |+async def get_id_init_not_annotated(id, params = Depends(InitParams)): ...
+205 205 | 
+206 206 | 
+207 207 | # No errors


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

Closes #17226.

This PR updates the `FAST003` rule to correctly handle [FastAPI class dependencies](https://fastapi.tiangolo.com/tutorial/dependencies/classes-as-dependencies/). Specifically, if a path parameter is declared in either:

- a `pydantic.BaseModel` used as a dependency, or  
- the `__init__` method of a class used as a dependency,  

then `FAST003` will no longer incorrectly report it as unused.

FastAPI allows a shortcut when using annotated class dependencies - `Depends` can be called without arguments, e.g.:

```python
class MyParams(BaseModel):
    my_id: int

@router.get("/{my_id}")
def get_id(params: Annotated[MyParams, Depends()]): ...
```
This PR ensures that such usage is properly supported by the linter.

Note: Support for dataclasses is not included in this PR. Let me know if you’d like it to be added.

## Test Plan

Added relevant test cases to the `FAST003.py` fixture.
