### PR TITLE
[ty] Experiment: allow functions to be redefined (same signature)

### DIFF
--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -7203,10 +7203,9 @@ impl<'db> FunctionType<'db> {
         // However, our representation of a function literal includes any specialization that
         // should be applied to the signature. Different specializations of the same function
         // literal are only assignable to each other if they result in assignable signatures.
-        self.body_scope(db) == other.body_scope(db)
-            && self
-                .into_callable_type(db)
-                .is_assignable_to(db, other.into_callable_type(db))
+
+        self.into_callable_type(db)
+            .is_assignable_to(db, other.into_callable_type(db))
     }
 
     fn is_equivalent_to(self, db: &'db dyn Db, other: Self) -> bool {


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Explore another route towards solving https://github.com/astral-sh/ty/issues/350. The idea is to loosen the restrictions around function redefinitions, and make code like this pass without errors:
```py
def f(x: int) -> str:
    return "a"

def another_f(x: int) -> str:
    return "b"

f = another_f
```
The way this is implemented here is probably not how we would want to implement this, but the effect should be similar.

## Test Plan

<!-- How was it tested? -->
