### PR TITLE
[ty] Ignore descriptor class-level declarations for purposes of finding instance attributes, variant 2

### DIFF
--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -1779,6 +1779,8 @@ impl<'db> ClassLiteral<'db> {
                         // might never be called).
                         if !implicit.is_unbound() {
                             return implicit.into();
+                        } else {
+                            return Symbol::Unbound.into();
                         }
                     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
