### PR TITLE
[ty] Implement implicit inheritance from `Generic[]` for PEP-695 generic classes

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
@@ -69,6 +69,33 @@ T = TypeVar("T")
 class BothGenericSyntaxes[U](Generic[T]): ...
 ```
 
+Generic classes implicitly inherit from `Generic`:
+
+```py
+class Foo[T]: ...
+
+# revealed: tuple[<class 'Foo[Unknown]'>, typing.Generic, <class 'object'>]
+reveal_type(Foo.__mro__)
+# revealed: tuple[<class 'Foo[int]'>, typing.Generic, <class 'object'>]
+reveal_type(Foo[int].__mro__)
+
+class A: ...
+class Bar[T](A): ...
+
+# revealed: tuple[<class 'Bar[Unknown]'>, <class 'A'>, typing.Generic, <class 'object'>]
+reveal_type(Bar.__mro__)
+# revealed: tuple[<class 'Bar[int]'>, <class 'A'>, typing.Generic, <class 'object'>]
+reveal_type(Bar[int].__mro__)
+
+class B: ...
+class Baz[T](A, B): ...
+
+# revealed: tuple[<class 'Baz[Unknown]'>, <class 'A'>, <class 'B'>, typing.Generic, <class 'object'>]
+reveal_type(Baz.__mro__)
+# revealed: tuple[<class 'Baz[int]'>, <class 'A'>, <class 'B'>, typing.Generic, <class 'object'>]
+reveal_type(Baz[int].__mro__)
+```
+
 ## Specializing generic classes explicitly
 
 The type parameter can be specified explicitly:

--- a/crates/ty_python_semantic/resources/mdtest/mro.md
+++ b/crates/ty_python_semantic/resources/mdtest/mro.md
@@ -644,14 +644,14 @@ reveal_type(C.__mro__)  # revealed: tuple[<class 'C'>, Unknown, <class 'object'>
 
 class D(D.a):
     a: D
-#reveal_type(D.__class__)  # revealed: <class 'type'>
+reveal_type(D.__class__)  # revealed: <class 'type'>
 reveal_type(D.__mro__)  # revealed: tuple[<class 'D'>, Unknown, <class 'object'>]
 
 class E[T](E.a): ...
-#reveal_type(E.__class__)  # revealed: <class 'type'>
-reveal_type(E.__mro__)  # revealed: tuple[<class 'E[Unknown]'>, Unknown, <class 'object'>]
+reveal_type(E.__class__)  # revealed: <class 'type'>
+reveal_type(E.__mro__)  # revealed: tuple[<class 'E[Unknown]'>, Unknown, typing.Generic, <class 'object'>]
 
 class F[T](F(), F): ...  # error: [cyclic-class-definition]
-#reveal_type(F.__class__)  # revealed: <class 'type'>
+reveal_type(F.__class__)  # revealed: type[Unknown]
 reveal_type(F.__mro__)  # revealed: tuple[<class 'F[Unknown]'>, Unknown, <class 'object'>]
 ```

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -223,8 +223,11 @@ impl<'db> ClassType<'db> {
         }
     }
 
-    pub(super) const fn is_generic(self) -> bool {
-        matches!(self, Self::Generic(_))
+    pub(super) fn has_pep_695_type_params(self, db: &'db dyn Db) -> bool {
+        match self {
+            Self::NonGeneric(class) => class.has_pep_695_type_params(db),
+            Self::Generic(generic) => generic.origin(db).has_pep_695_type_params(db),
+        }
     }
 
     /// Returns the class literal and specialization for this class. For a non-generic class, this
@@ -571,6 +574,14 @@ impl<'db> ClassLiteral<'db> {
         self.pep695_generic_context(db)
             .or_else(|| self.legacy_generic_context(db))
             .or_else(|| self.inherited_legacy_generic_context(db))
+    }
+
+    pub(crate) fn has_pep_695_type_params(self, db: &'db dyn Db) -> bool {
+        self.pep695_generic_context(db).is_some()
+    }
+
+    pub(crate) fn has_legacy_generic_context(self, db: &'db dyn Db) -> bool {
+        self.legacy_generic_context(db).is_some()
     }
 
     #[salsa::tracked(cycle_fn=pep695_generic_context_cycle_recover, cycle_initial=pep695_generic_context_cycle_initial)]


### PR DESCRIPTION
## Summary

PEP-695 classes have `Generic` implicitly appended to the end of their `__bases__`:

```pycon
>>> class Foo[T]: ...
... 
>>> Foo.__mro__
(<class '__main__.Foo'>, <class 'typing.Generic'>, <class 'object'>)
>>> class Bar[T](int): ...
... 
>>> Bar.__mro__
(<class '__main__.Bar'>, <class 'int'>, <class 'typing.Generic'>, <class 'object'>)
```

This isn't something we fully model on `main`, leading us to infer inaccurate MROs for PEP-695 generic classes in some situations. This PR fixes that.

## Test Plan

mdtests
