### PR TITLE
[ty] Add long help for `--config` argument

### DIFF
--- a/crates/ty/docs/cli.md
+++ b/crates/ty/docs/cli.md
@@ -43,7 +43,10 @@ ty check [OPTIONS] [PATH]...
 <li><code>auto</code>:  Display colors if the output goes to an interactive terminal</li>
 <li><code>always</code>:  Always display colors</li>
 <li><code>never</code>:  Never display colors</li>
-</ul></dd><dt id="ty-check--config"><a href="#ty-check--config"><code>--config</code></a>, <code>-c</code> <i>config-option</i></dt><dd><p>A TOML <code>&lt;KEY&gt; = &lt;VALUE&gt;</code> pair</p>
+</ul></dd><dt id="ty-check--config"><a href="#ty-check--config"><code>--config</code></a>, <code>-c</code> <i>config-option</i></dt><dd><p>A TOML <code>&lt;KEY&gt; = &lt;VALUE&gt;</code> pair (such as you might find in a <code>ty.toml</code> configuration file)
+overriding a specific configuration option.</p>
+<p>Overrides of individual settings using this option always take precedence
+over all configuration files.</p>
 </dd><dt id="ty-check--error"><a href="#ty-check--error"><code>--error</code></a> <i>rule</i></dt><dd><p>Treat the given rule as having severity 'error'. Can be specified multiple times.</p>
 </dd><dt id="ty-check--error-on-warning"><a href="#ty-check--error-on-warning"><code>--error-on-warning</code></a></dt><dd><p>Use exit code 1 if there are any warning-level diagnostics</p>
 </dd><dt id="ty-check--exit-zero"><a href="#ty-check--exit-zero"><code>--exit-zero</code></a></dt><dd><p>Always use exit code 0, even when there are error-level diagnostics</p>

--- a/crates/ty/src/args.rs
+++ b/crates/ty/src/args.rs
@@ -322,9 +322,11 @@ pub(crate) enum TerminalColor {
     /// Never display colors.
     Never,
 }
+
 /// A TOML `<KEY> = <VALUE>` pair
 /// (such as you might find in a `ty.toml` configuration file)
 /// overriding a specific configuration option.
+///
 /// Overrides of individual settings using this option always take precedence
 /// over all configuration files.
 #[derive(Debug, Clone)]
@@ -359,7 +361,15 @@ impl clap::Args for ConfigsArg {
                 .short('c')
                 .long("config")
                 .value_name("CONFIG_OPTION")
-                .help("A TOML `<KEY> = <VALUE>` pair")
+                .help("A TOML `<KEY> = <VALUE>` pair overriding a specific configuration option.")
+                .long_help(
+                    "
+A TOML `<KEY> = <VALUE>` pair (such as you might find in a `ty.toml` configuration file)
+overriding a specific configuration option.
+
+Overrides of individual settings using this option always take precedence
+over all configuration files.",
+                )
                 .action(ArgAction::Append),
         )
     }


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/ty/issues/499

Help for the `--config` argument is given in a builder style. I decided to just use the docstring from the `ConfigsArg` struct. 

As for the trucated help for possible values (e.g. `--output-format full`), I couldn’t figure out how to get the long help from clap.