### PR TITLE
[pyupgrade] make fix unsafe if it deletes comments (UP010, unnecessary-future-import)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP010.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP010.py
@@ -12,3 +12,4 @@ if True:
 if True:
     from __future__ import generator_stop
     from __future__ import invalid_module, generators
+    from __future__ import generators  # comment

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_future_import.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_future_import.rs
@@ -1,7 +1,7 @@
 use itertools::Itertools;
 use ruff_python_ast::{Alias, Stmt};
 
-use ruff_diagnostics::{Applicability, AlwaysFixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysFixableViolation, Applicability, Diagnostic, Fix};
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_text_size::Ranged;
 

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP010.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP010.py.snap
@@ -156,6 +156,7 @@ UP010.py:13:5: UP010 [*] Unnecessary `__future__` import `generator_stop` for ta
 13 |     from __future__ import generator_stop
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP010
 14 |     from __future__ import invalid_module, generators
+15 |     from __future__ import generators  # comment
    |
    = help: Remove unnecessary `__future__` import
 
@@ -165,6 +166,7 @@ UP010.py:13:5: UP010 [*] Unnecessary `__future__` import `generator_stop` for ta
 12 12 | if True:
 13    |-    from __future__ import generator_stop
 14 13 |     from __future__ import invalid_module, generators
+15 14 |     from __future__ import generators  # comment
 
 UP010.py:14:5: UP010 [*] Unnecessary `__future__` import `generators` for target Python version
    |
@@ -172,6 +174,7 @@ UP010.py:14:5: UP010 [*] Unnecessary `__future__` import `generators` for target
 13 |     from __future__ import generator_stop
 14 |     from __future__ import invalid_module, generators
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP010
+15 |     from __future__ import generators  # comment
    |
    = help: Remove unnecessary `__future__` import
 
@@ -181,3 +184,19 @@ UP010.py:14:5: UP010 [*] Unnecessary `__future__` import `generators` for target
 13 13 |     from __future__ import generator_stop
 14    |-    from __future__ import invalid_module, generators
    14 |+    from __future__ import invalid_module
+15 15 |     from __future__ import generators  # comment
+
+UP010.py:15:5: UP010 [*] Unnecessary `__future__` import `generators` for target Python version
+   |
+13 |     from __future__ import generator_stop
+14 |     from __future__ import invalid_module, generators
+15 |     from __future__ import generators  # comment
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP010
+   |
+   = help: Remove unnecessary `__future__` import
+
+ℹ Unsafe fix
+12 12 | if True:
+13 13 |     from __future__ import generator_stop
+14 14 |     from __future__ import invalid_module, generators
+15    |-    from __future__ import generators  # comment


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->
/closes #18282
## Summary

The [`unnecessary-future-import`](https://docs.astral.sh/ruff/rules/unnecessary-future-import/) (UP010) fix should be marked as unsafe when it deletes a comment on the same line as the import. Currently, the fix removes the entire line including comments, which may cause unintended code/comment loss. This change ensures that such fixes are flagged as unsafe and require manual review.

## Test Plan

<!-- How was it tested? -->
