### PR TITLE
Fix YTT201 for '!=' comparisons

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_2020/rules/compare.rs
+++ b/crates/ruff_linter/src/rules/flake8_2020/rules/compare.rs
@@ -88,12 +88,23 @@ impl Violation for SysVersionCmpStr3 {
 /// - [Python documentation: `sys.version`](https://docs.python.org/3/library/sys.html#sys.version)
 /// - [Python documentation: `sys.version_info`](https://docs.python.org/3/library/sys.html#sys.version_info)
 #[derive(ViolationMetadata)]
-pub(crate) struct SysVersionInfo0Eq3;
+pub(crate) struct SysVersionInfo0Eq3 {
+    op: CmpOp,
+}
 
 impl Violation for SysVersionInfo0Eq3 {
     #[derive_message_formats]
     fn message(&self) -> String {
-        "`sys.version_info[0] == 3` referenced (python4), use `>=`".to_string()
+        let recommendation = if matches!(self.op, CmpOp::Eq) {
+            ">="
+        } else {
+            "<"
+        };
+        format!(
+            "`sys.version_info[0] {} 3` referenced (python4), use `{}`",
+            self.op.as_str(),
+            recommendation
+        )
     }
 }
 
@@ -246,7 +257,7 @@ pub(crate) fn compare(checker: &Checker, left: &Expr, ops: &[CmpOp], comparators
                     {
                         if *n == 3 && checker.enabled(Rule::SysVersionInfo0Eq3) {
                             checker.report_diagnostic(Diagnostic::new(
-                                SysVersionInfo0Eq3,
+                                SysVersionInfo0Eq3 { op: ops[0] },
                                 left.range(),
                             ));
                         }

--- a/crates/ruff_linter/src/rules/flake8_2020/snapshots/ruff_linter__rules__flake8_2020__tests__YTT201_YTT201.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_2020/snapshots/ruff_linter__rules__flake8_2020__tests__YTT201_YTT201.py.snap
@@ -20,7 +20,7 @@ YTT201.py:8:7: YTT201 `sys.version_info[0] == 3` referenced (python4), use `>=`
 10 | PY2 = version_info[0] != 3
    |
 
-YTT201.py:9:7: YTT201 `sys.version_info[0] == 3` referenced (python4), use `>=`
+YTT201.py:9:7: YTT201 `sys.version_info[0] != 3` referenced (python4), use `<`
    |
  7 | PY3 = sys.version_info[0] == 3
  8 | PY3 = version_info[0] == 3
@@ -29,7 +29,7 @@ YTT201.py:9:7: YTT201 `sys.version_info[0] == 3` referenced (python4), use `>=`
 10 | PY2 = version_info[0] != 3
    |
 
-YTT201.py:10:7: YTT201 `sys.version_info[0] == 3` referenced (python4), use `>=`
+YTT201.py:10:7: YTT201 `sys.version_info[0] != 3` referenced (python4), use `<`
    |
  8 | PY3 = version_info[0] == 3
  9 | PY2 = sys.version_info[0] != 3


### PR DESCRIPTION
## Summary
- handle `sys.version_info[0] != 3` in YTT201
- update snapshot

## Testing
- `cargo fmt --all` *(fails: cargo-fmt not installed)*
- `cargo test -p ruff_linter` *(fails: could not fetch dependency)*