### PR TITLE
[ty] Respect `MRO_NO_OBJECT_FALLBACK` policy when looking up symbols on `type` instances

### DIFF
--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2567,9 +2567,13 @@ impl<'db> Type<'db> {
             // `Type::NominalInstance(type)` is equivalent to looking up the name in the
             // MRO of the class `object`.
             Type::NominalInstance(instance) if instance.class.is_known(db, KnownClass::Type) => {
-                KnownClass::Object
-                    .to_class_literal(db)
-                    .find_name_in_mro_with_policy(db, name, policy)
+                if policy.mro_no_object_fallback() {
+                    Some(Symbol::Unbound.into())
+                } else {
+                    KnownClass::Object
+                        .to_class_literal(db)
+                        .find_name_in_mro_with_policy(db, name, policy)
+                }
             }
 
             Type::FunctionLiteral(_)


### PR DESCRIPTION
## Summary

This should address a problem that came up while working on https://github.com/astral-sh/ruff/pull/18280. When looking up an attribute (typically a dunder method) with the `MRO_NO_OBJECT_FALLBACK` policy, the attribute is first looked  up on the meta type. If the meta type happens to be `type`, we go through the following branch in `find_name_in_mro_with_policy`:

https://github.com/astral-sh/ruff/blob/97ff015c88354b5d45b52a9b1460c30978b5c29b/crates/ty_python_semantic/src/types.rs#L2565-L2573

The problem is that we now look up the attribute on `object` *directly* (instead of just having `object` in the MRO). In this case, `MRO_NO_OBJECT_FALLBACK` has no effect in `class_member_from_mro`:

https://github.com/astral-sh/ruff/blob/c3feb8ce27350a4c7a560671f4668dd47761260e/crates/ty_python_semantic/src/types/class.rs#L1081-L1082

So instead, we need to explicitly respect the `MRO_NO_OBJECT_FALLBACK` policy here by returning `Symbol::Unbound`.

## Test Plan

Added new Markdown tests that explain the ecosystem changes that we observe.