### PR TITLE
[ty] Always pass `NO_INSTANCE_FALLBACK` in `try_call_dunder_with_policy`

### DIFF
--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -3231,8 +3231,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                                     )),
                                     value_ty,
                                 ]),
-                                MemberLookupPolicy::NO_INSTANCE_FALLBACK
-                                    | MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
+                                MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
                             );
 
                             match result {


### PR DESCRIPTION
## Summary

The previous `try_call_dunder_with_policy` API was a bit of a footgun since you needed to pass `NO_INSTANCE_FALLBACK` in *addition* to other policies that you wanted for the member lookup. Implicit calls to dunder methods never access instance members though, so we can do this implicitly in `try_call_dunder_with_policy`.

No functional changes.