### PR TITLE
[ty] Playground: Better default settings

### DIFF
--- a/playground/ty/src/Playground.tsx
+++ b/playground/ty/src/Playground.tsx
@@ -198,7 +198,7 @@ export const DEFAULT_SETTINGS = JSON.stringify(
       "python-version": "3.13",
     },
     rules: {
-      "division-by-zero": "error",
+      "undefined-reveal": "ignore",
     },
   },
   null,


### PR DESCRIPTION
## Summary

The playground default settings set the `division-by-zero` rule severity to `error`. This slightly confusing because `division-by-zero` is now disabled by default. I am assuming that we have a `rules` section in there to make it easier for users to customize those settings (in addition to what the JSON schema gives us).

Here, I'm proposing a different default rule-set (`"undefined-reveal": "ignore"`) that I would personally find more helpful for the playground in particular, since we're using it so frequently for MREs that often involve some `reveal_type` calls.

