### PR TITLE
[ty] Emit unresolved-attribute diagnostics in annotated assignments

### DIFF
--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -3549,11 +3549,15 @@ impl<'db> TypeInferenceBuilder<'db> {
             } = assignment;
             let annotated =
                 self.infer_annotation_expression(annotation, DeferredExpressionState::None);
-            self.infer_optional_expression(value.as_deref());
 
             // If we have an annotated assignment like `self.attr: int = 1`, we still need to
             // do type inference on the `self.attr` target to get types for all sub-expressions.
-            self.infer_expression(target);
+            if let Some(value) = value {
+                let value_ty = self.infer_expression(value);
+                self.infer_target(target, value, |_builder, _value_expr| value_ty);
+            } else {
+                self.infer_expression(target);
+            }
 
             // But here we explicitly overwrite the type for the overall `self.attr` node with
             // the annotated type. We do no use `store_expression_type` here, because it checks


### PR DESCRIPTION
## Summary

Does not yet include any decision on whether or not these annotated attribute assignments should be allowed (for non-`self` assignments), but makes sure that we emit `unresolved-attribute` errors when trying to write to a non-existent attribute.

closes astral-sh/ty#509

## Test Plan

New Markdown tests
