### PR TITLE
[ty] Move arviz off the list of selected primer projects

### DIFF
--- a/crates/ty_python_semantic/resources/primer/bad.txt
+++ b/crates/ty_python_semantic/resources/primer/bad.txt
@@ -1,6 +1,7 @@
 Tanjun  # hangs
 antidote  # hangs / slow
 artigraph  # cycle panics (value_type_)
+arviz  # too many iterations on versions of arviz newer than https://github.com/arviz-devs/arviz/commit/3205b82bb4d6097c31f7334d7ac51a6de37002d0
 core  # cycle panics (value_type_)
 cpython  # access to field whilst being initialized, too many cycle iterations
 discord.py  # some kind of hang, only when multi-threaded?

--- a/crates/ty_python_semantic/resources/primer/good.txt
+++ b/crates/ty_python_semantic/resources/primer/good.txt
@@ -12,7 +12,6 @@ alerta
 altair
 anyio
 apprise
-arviz
 async-utils
 asynq
 attrs


### PR DESCRIPTION
## Summary

primer runs have been failing since https://github.com/arviz-devs/arviz/commit/3205b82bb4d6097c31f7334d7ac51a6de37002d0 landed on the arviz `main` branch. Seems like we're struggling with some of `xarray`'s type annotations? I confirmed locally that ty completes without crashing if you checkout the prior commit on the arviz `main` branch and then run `uv run --no-project --with=xarray ../ruff/target/debug/ty check`, but that it crashes with "too many cycle iterations" on https://github.com/arviz-devs/arviz/commit/3205b82bb4d6097c31f7334d7ac51a6de37002d0

## Test Plan

CI on this PR
