### PR TITLE
[ty] Derive `PartialOrd, Ord` for `KnownInstanceType`

### DIFF
--- a/crates/ty_python_semantic/src/types/known_instance.rs
+++ b/crates/ty_python_semantic/src/types/known_instance.rs
@@ -18,7 +18,14 @@ use ruff_db::files::File;
 
 /// Enumeration of specific runtime symbols that are special enough
 /// that they can each be considered to inhabit a unique type.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, salsa::Update)]
+///
+/// # Ordering
+///
+/// Ordering between variants is stable and should be the same between runs.
+/// Ordering within variants (for variants that wrap associate data)
+/// is based on the known-instance's salsa-assigned id and not on its values.
+/// The id may change between runs, or when the type var instance was garbage collected and recreated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, salsa::Update, PartialOrd, Ord)]
 pub enum KnownInstanceType<'db> {
     /// The symbol `typing.Annotated` (which can also be found as `typing_extensions.Annotated`)
     Annotated,

--- a/crates/ty_python_semantic/src/types/type_ordering.rs
+++ b/crates/ty_python_semantic/src/types/type_ordering.rs
@@ -3,7 +3,7 @@ use std::cmp::Ordering;
 use crate::db::Db;
 
 use super::{
-    DynamicType, KnownInstanceType, SuperOwnerKind, TodoType, Type, class_base::ClassBase,
+    DynamicType, SuperOwnerKind, TodoType, Type, class_base::ClassBase,
     subclass_of::SubclassOfInner,
 };
 
@@ -180,144 +180,7 @@ pub(super) fn union_or_intersection_elements_ordering<'db>(
         (_, Type::BoundSuper(_)) => Ordering::Greater,
 
         (Type::KnownInstance(left_instance), Type::KnownInstance(right_instance)) => {
-            match (left_instance, right_instance) {
-                (KnownInstanceType::Tuple, _) => Ordering::Less,
-                (_, KnownInstanceType::Tuple) => Ordering::Greater,
-
-                (KnownInstanceType::AlwaysFalsy, _) => Ordering::Less,
-                (_, KnownInstanceType::AlwaysFalsy) => Ordering::Greater,
-
-                (KnownInstanceType::AlwaysTruthy, _) => Ordering::Less,
-                (_, KnownInstanceType::AlwaysTruthy) => Ordering::Greater,
-
-                (KnownInstanceType::Annotated, _) => Ordering::Less,
-                (_, KnownInstanceType::Annotated) => Ordering::Greater,
-
-                (KnownInstanceType::Callable, _) => Ordering::Less,
-                (_, KnownInstanceType::Callable) => Ordering::Greater,
-
-                (KnownInstanceType::ChainMap, _) => Ordering::Less,
-                (_, KnownInstanceType::ChainMap) => Ordering::Greater,
-
-                (KnownInstanceType::ClassVar, _) => Ordering::Less,
-                (_, KnownInstanceType::ClassVar) => Ordering::Greater,
-
-                (KnownInstanceType::Concatenate, _) => Ordering::Less,
-                (_, KnownInstanceType::Concatenate) => Ordering::Greater,
-
-                (KnownInstanceType::Counter, _) => Ordering::Less,
-                (_, KnownInstanceType::Counter) => Ordering::Greater,
-
-                (KnownInstanceType::DefaultDict, _) => Ordering::Less,
-                (_, KnownInstanceType::DefaultDict) => Ordering::Greater,
-
-                (KnownInstanceType::Deque, _) => Ordering::Less,
-                (_, KnownInstanceType::Deque) => Ordering::Greater,
-
-                (KnownInstanceType::Dict, _) => Ordering::Less,
-                (_, KnownInstanceType::Dict) => Ordering::Greater,
-
-                (KnownInstanceType::Final, _) => Ordering::Less,
-                (_, KnownInstanceType::Final) => Ordering::Greater,
-
-                (KnownInstanceType::FrozenSet, _) => Ordering::Less,
-                (_, KnownInstanceType::FrozenSet) => Ordering::Greater,
-
-                (KnownInstanceType::TypeGuard, _) => Ordering::Less,
-                (_, KnownInstanceType::TypeGuard) => Ordering::Greater,
-
-                (KnownInstanceType::TypedDict, _) => Ordering::Less,
-                (_, KnownInstanceType::TypedDict) => Ordering::Greater,
-
-                (KnownInstanceType::List, _) => Ordering::Less,
-                (_, KnownInstanceType::List) => Ordering::Greater,
-
-                (KnownInstanceType::Literal, _) => Ordering::Less,
-                (_, KnownInstanceType::Literal) => Ordering::Greater,
-
-                (KnownInstanceType::LiteralString, _) => Ordering::Less,
-                (_, KnownInstanceType::LiteralString) => Ordering::Greater,
-
-                (KnownInstanceType::Optional, _) => Ordering::Less,
-                (_, KnownInstanceType::Optional) => Ordering::Greater,
-
-                (KnownInstanceType::OrderedDict, _) => Ordering::Less,
-                (_, KnownInstanceType::OrderedDict) => Ordering::Greater,
-
-                (KnownInstanceType::Generic(left), KnownInstanceType::Generic(right)) => {
-                    left.cmp(right)
-                }
-                (KnownInstanceType::Generic(_), _) => Ordering::Less,
-                (_, KnownInstanceType::Generic(_)) => Ordering::Greater,
-
-                (KnownInstanceType::Protocol(left), KnownInstanceType::Protocol(right)) => {
-                    left.cmp(right)
-                }
-                (KnownInstanceType::Protocol(_), _) => Ordering::Less,
-                (_, KnownInstanceType::Protocol(_)) => Ordering::Greater,
-
-                (KnownInstanceType::NoReturn, _) => Ordering::Less,
-                (_, KnownInstanceType::NoReturn) => Ordering::Greater,
-
-                (KnownInstanceType::Never, _) => Ordering::Less,
-                (_, KnownInstanceType::Never) => Ordering::Greater,
-
-                (KnownInstanceType::Set, _) => Ordering::Less,
-                (_, KnownInstanceType::Set) => Ordering::Greater,
-
-                (KnownInstanceType::Type, _) => Ordering::Less,
-                (_, KnownInstanceType::Type) => Ordering::Greater,
-
-                (KnownInstanceType::TypeAlias, _) => Ordering::Less,
-                (_, KnownInstanceType::TypeAlias) => Ordering::Greater,
-
-                (KnownInstanceType::Unknown, _) => Ordering::Less,
-                (_, KnownInstanceType::Unknown) => Ordering::Greater,
-
-                (KnownInstanceType::Not, _) => Ordering::Less,
-                (_, KnownInstanceType::Not) => Ordering::Greater,
-
-                (KnownInstanceType::Intersection, _) => Ordering::Less,
-                (_, KnownInstanceType::Intersection) => Ordering::Greater,
-
-                (KnownInstanceType::TypeOf, _) => Ordering::Less,
-                (_, KnownInstanceType::TypeOf) => Ordering::Greater,
-
-                (KnownInstanceType::CallableTypeOf, _) => Ordering::Less,
-                (_, KnownInstanceType::CallableTypeOf) => Ordering::Greater,
-
-                (KnownInstanceType::Unpack, _) => Ordering::Less,
-                (_, KnownInstanceType::Unpack) => Ordering::Greater,
-
-                (KnownInstanceType::TypingSelf, _) => Ordering::Less,
-                (_, KnownInstanceType::TypingSelf) => Ordering::Greater,
-
-                (KnownInstanceType::Required, _) => Ordering::Less,
-                (_, KnownInstanceType::Required) => Ordering::Greater,
-
-                (KnownInstanceType::NotRequired, _) => Ordering::Less,
-                (_, KnownInstanceType::NotRequired) => Ordering::Greater,
-
-                (KnownInstanceType::TypeIs, _) => Ordering::Less,
-                (_, KnownInstanceType::TypeIs) => Ordering::Greater,
-
-                (KnownInstanceType::ReadOnly, _) => Ordering::Less,
-                (_, KnownInstanceType::ReadOnly) => Ordering::Greater,
-
-                (KnownInstanceType::Union, _) => Ordering::Less,
-                (_, KnownInstanceType::Union) => Ordering::Greater,
-
-                (
-                    KnownInstanceType::TypeAliasType(left),
-                    KnownInstanceType::TypeAliasType(right),
-                ) => left.cmp(right),
-                (KnownInstanceType::TypeAliasType(_), _) => Ordering::Less,
-                (_, KnownInstanceType::TypeAliasType(_)) => Ordering::Greater,
-
-                (KnownInstanceType::TypeVar(left), KnownInstanceType::TypeVar(right)) => {
-                    left.cmp(right)
-                }
-            }
+            left_instance.cmp(right_instance)
         }
 
         (Type::KnownInstance(_), _) => Ordering::Less,


### PR DESCRIPTION
## Summary

Unlike a series of integers or strings, there's no self-evident way in which a series of `KnownInstanceType`s should always be ordered if you're sorting them. This has always been the motivation for not deriving `PartialOrd` and `Ord` on this enum, and instead tediously writing this huge `match` statement out by hand.

Following https://github.com/astral-sh/ruff/pull/18212, however, we must explicitly derive `PartialOrd` and `Ord` for any Salsa-tracked structs that we wish to sort into an order. This is a good change -- it sharply brings into focus the fact that the orderings Salsa was previously implicitly deriving for us were also arbitrary orderings that had no grounding in the underlying type being represented by the Salsa ID. We already knew this, but now it's explicit.

The ordering of `KnownInstanceType`s isn't inherently any more arbitrary than the orderings we're deriving elsewhere; so let's just derive `PartialOrd, Ord` here too. It makes the code a fair bit simpler :-)

## Test Plan

`cargo test -p ty_python_semantic`
