### PR TITLE
[ty] Ensure `Literal` types are considered assignable to anything their `Instance` supertypes are assignable to

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
@@ -97,10 +97,14 @@ turn a subtype of `str`:
 ```py
 from ty_extensions import static_assert, is_assignable_to
 from typing_extensions import Literal, LiteralString
+from typing import Sequence, Any
 
 static_assert(is_assignable_to(Literal["foo"], Literal["foo"]))
 static_assert(is_assignable_to(Literal["foo"], LiteralString))
 static_assert(is_assignable_to(Literal["foo"], str))
+static_assert(is_assignable_to(Literal["foo"], Sequence))
+static_assert(is_assignable_to(Literal["foo"], Sequence[str]))
+static_assert(is_assignable_to(Literal["foo"], Sequence[Any]))
 
 static_assert(is_assignable_to(LiteralString, str))
 

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
@@ -107,6 +107,9 @@ static_assert(is_assignable_to(Literal["foo"], Sequence[str]))
 static_assert(is_assignable_to(Literal["foo"], Sequence[Any]))
 
 static_assert(is_assignable_to(LiteralString, str))
+static_assert(is_assignable_to(LiteralString, Sequence))
+static_assert(is_assignable_to(LiteralString, Sequence[str]))
+static_assert(is_assignable_to(LiteralString, Sequence[Any]))
 
 static_assert(not is_assignable_to(Literal["foo"], Literal["bar"]))
 static_assert(not is_assignable_to(str, Literal["foo"]))

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -10,8 +10,6 @@ class Person(TypedDict):
     name: str
     age: int | None
 
-# TODO: This should not be an error:
-# error: [invalid-assignment]
 alice: Person = {"name": "Alice", "age": 30}
 
 # Alternative syntax

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -10,6 +10,8 @@ class Person(TypedDict):
     name: str
     age: int | None
 
+# TODO: This should not be an error:
+# error: [invalid-assignment]
 alice: Person = {"name": "Alice", "age": 30}
 
 # Alternative syntax

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1614,6 +1614,17 @@ impl<'db> Type<'db> {
                 true
             }
 
+            (
+                Type::StringLiteral(_)
+                | Type::LiteralString
+                | Type::BooleanLiteral(_)
+                | Type::IntLiteral(_)
+                | Type::BytesLiteral(_)
+                | Type::ModuleLiteral(_),
+                _,
+            ) => (self.literal_fallback_instance(db))
+                .is_some_and(|instance| instance.is_assignable_to(db, target)),
+
             // Any type that is assignable to `type[object]` is also assignable to `type[Any]`,
             // because `type[Any]` can materialize to `type[object]`.
             (Type::NominalInstance(_), Type::SubclassOf(subclass_of_ty))

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1655,16 +1655,8 @@ impl<'db> Type<'db> {
                 }
             }
 
-            (
-                Type::StringLiteral(_)
-                | Type::LiteralString
-                | Type::BooleanLiteral(_)
-                | Type::IntLiteral(_)
-                | Type::BytesLiteral(_)
-                | Type::ModuleLiteral(_),
-                _,
-            ) if (self.literal_fallback_instance(db))
-                .is_some_and(|instance| instance.is_assignable_to(db, target)) =>
+            _ if self.literal_fallback_instance(db))
+                .is_some_and(|instance| instance.is_assignable_to(db, target) =>
             {
                 true
             }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1614,17 +1614,6 @@ impl<'db> Type<'db> {
                 true
             }
 
-            (
-                Type::StringLiteral(_)
-                | Type::LiteralString
-                | Type::BooleanLiteral(_)
-                | Type::IntLiteral(_)
-                | Type::BytesLiteral(_)
-                | Type::ModuleLiteral(_),
-                _,
-            ) => (self.literal_fallback_instance(db))
-                .is_some_and(|instance| instance.is_assignable_to(db, target)),
-
             // Any type that is assignable to `type[object]` is also assignable to `type[Any]`,
             // because `type[Any]` can materialize to `type[object]`.
             (Type::NominalInstance(_), Type::SubclassOf(subclass_of_ty))
@@ -1664,6 +1653,20 @@ impl<'db> Type<'db> {
                 } else {
                     false
                 }
+            }
+
+            (
+                Type::StringLiteral(_)
+                | Type::LiteralString
+                | Type::BooleanLiteral(_)
+                | Type::IntLiteral(_)
+                | Type::BytesLiteral(_)
+                | Type::ModuleLiteral(_),
+                _,
+            ) if (self.literal_fallback_instance(db))
+                .is_some_and(|instance| instance.is_assignable_to(db, target)) =>
+            {
+                true
             }
 
             (Type::ClassLiteral(class_literal), Type::Callable(_)) => {

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1655,8 +1655,9 @@ impl<'db> Type<'db> {
                 }
             }
 
-            _ if self.literal_fallback_instance(db))
-                .is_some_and(|instance| instance.is_assignable_to(db, target) =>
+            _ if self
+                .literal_fallback_instance(db)
+                .is_some_and(|instance| instance.is_assignable_to(db, target)) =>
             {
                 true
             }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

Resolves https://github.com/astral-sh/ty/issues/531

## Test Plan

Update `is_assignable_to.md`
