### PR TITLE
Rename `ruff_linter::Diagnostic` to `OldDiagnostic`

### DIFF
--- a/crates/ruff/src/commands/check.rs
+++ b/crates/ruff/src/commands/check.rs
@@ -12,7 +12,7 @@ use rayon::prelude::*;
 use rustc_hash::FxHashMap;
 
 use ruff_db::panic::catch_unwind;
-use ruff_linter::Diagnostic;
+use ruff_linter::OldDiagnostic;
 use ruff_linter::message::Message;
 use ruff_linter::package::PackageRoot;
 use ruff_linter::registry::Rule;
@@ -131,7 +131,7 @@ pub(crate) fn check(
 
                     Diagnostics::new(
                         vec![Message::from_diagnostic(
-                            Diagnostic::new(IOError { message }, TextRange::default()),
+                            OldDiagnostic::new(IOError { message }, TextRange::default()),
                             dummy,
                             None,
                         )],

--- a/crates/ruff/src/diagnostics.rs
+++ b/crates/ruff/src/diagnostics.rs
@@ -12,7 +12,7 @@ use colored::Colorize;
 use log::{debug, warn};
 use rustc_hash::FxHashMap;
 
-use ruff_linter::Diagnostic;
+use ruff_linter::OldDiagnostic;
 use ruff_linter::codes::Rule;
 use ruff_linter::linter::{FixTable, FixerResult, LinterResult, ParseSource, lint_fix, lint_only};
 use ruff_linter::message::Message;
@@ -64,7 +64,7 @@ impl Diagnostics {
                     let source_file = SourceFileBuilder::new(name, "").finish();
                     Self::new(
                         vec![Message::from_diagnostic(
-                            Diagnostic::new(
+                            OldDiagnostic::new(
                                 IOError {
                                     message: err.to_string(),
                                 },

--- a/crates/ruff_linter/src/checkers/filesystem.rs
+++ b/crates/ruff_linter/src/checkers/filesystem.rs
@@ -3,8 +3,8 @@ use std::path::Path;
 use ruff_python_ast::PythonVersion;
 use ruff_python_trivia::CommentRanges;
 
-use crate::Diagnostic;
 use crate::Locator;
+use crate::OldDiagnostic;
 use crate::package::PackageRoot;
 use crate::preview::is_allow_nested_roots_enabled;
 use crate::registry::Rule;
@@ -20,8 +20,8 @@ pub(crate) fn check_file_path(
     comment_ranges: &CommentRanges,
     settings: &LinterSettings,
     target_version: PythonVersion,
-) -> Vec<Diagnostic> {
-    let mut diagnostics: Vec<Diagnostic> = vec![];
+) -> Vec<OldDiagnostic> {
+    let mut diagnostics: Vec<OldDiagnostic> = vec![];
 
     // flake8-no-pep420
     if settings.rules.enabled(Rule::ImplicitNamespacePackage) {

--- a/crates/ruff_linter/src/checkers/imports.rs
+++ b/crates/ruff_linter/src/checkers/imports.rs
@@ -7,8 +7,8 @@ use ruff_python_codegen::Stylist;
 use ruff_python_index::Indexer;
 use ruff_python_parser::Parsed;
 
-use crate::Diagnostic;
 use crate::Locator;
+use crate::OldDiagnostic;
 use crate::directives::IsortDirectives;
 use crate::package::PackageRoot;
 use crate::registry::Rule;
@@ -28,7 +28,7 @@ pub(crate) fn check_imports(
     source_type: PySourceType,
     cell_offsets: Option<&CellOffsets>,
     target_version: PythonVersion,
-) -> Vec<Diagnostic> {
+) -> Vec<OldDiagnostic> {
     // Extract all import blocks from the AST.
     let tracker = {
         let mut tracker =

--- a/crates/ruff_linter/src/checkers/logical_lines.rs
+++ b/crates/ruff_linter/src/checkers/logical_lines.rs
@@ -4,8 +4,8 @@ use ruff_python_parser::{TokenKind, Tokens};
 use ruff_source_file::LineRanges;
 use ruff_text_size::{Ranged, TextRange};
 
-use crate::Diagnostic;
 use crate::Locator;
+use crate::OldDiagnostic;
 use crate::line_width::IndentWidth;
 use crate::registry::{AsRule, Rule};
 use crate::rules::pycodestyle::rules::logical_lines::{
@@ -40,7 +40,7 @@ pub(crate) fn check_logical_lines(
     indexer: &Indexer,
     stylist: &Stylist,
     settings: &LinterSettings,
-) -> Vec<Diagnostic> {
+) -> Vec<OldDiagnostic> {
     let mut context = LogicalLinesContext::new(settings);
 
     let mut prev_line = None;
@@ -196,7 +196,7 @@ pub(crate) fn check_logical_lines(
 #[derive(Debug, Clone)]
 pub(crate) struct LogicalLinesContext<'a> {
     settings: &'a LinterSettings,
-    diagnostics: Vec<Diagnostic>,
+    diagnostics: Vec<OldDiagnostic>,
 }
 
 impl<'a> LogicalLinesContext<'a> {
@@ -207,7 +207,7 @@ impl<'a> LogicalLinesContext<'a> {
         }
     }
 
-    pub(crate) fn push_diagnostic(&mut self, diagnostic: Diagnostic) {
+    pub(crate) fn push_diagnostic(&mut self, diagnostic: OldDiagnostic) {
         if self.settings.rules.enabled(diagnostic.rule()) {
             self.diagnostics.push(diagnostic);
         }

--- a/crates/ruff_linter/src/checkers/noqa.rs
+++ b/crates/ruff_linter/src/checkers/noqa.rs
@@ -20,11 +20,11 @@ use crate::rules::pygrep_hooks;
 use crate::rules::ruff;
 use crate::rules::ruff::rules::{UnusedCodes, UnusedNOQA};
 use crate::settings::LinterSettings;
-use crate::{Diagnostic, Edit, Fix};
+use crate::{Edit, Fix, OldDiagnostic};
 
 #[expect(clippy::too_many_arguments)]
 pub(crate) fn check_noqa(
-    diagnostics: &mut Vec<Diagnostic>,
+    diagnostics: &mut Vec<OldDiagnostic>,
     path: &Path,
     locator: &Locator,
     comment_ranges: &CommentRanges,
@@ -136,7 +136,7 @@ pub(crate) fn check_noqa(
                     if matches.is_empty() {
                         let edit = delete_comment(directive.range(), locator);
                         let mut diagnostic =
-                            Diagnostic::new(UnusedNOQA { codes: None }, directive.range());
+                            OldDiagnostic::new(UnusedNOQA { codes: None }, directive.range());
                         diagnostic.set_fix(Fix::safe_edit(edit));
 
                         diagnostics.push(diagnostic);
@@ -212,7 +212,7 @@ pub(crate) fn check_noqa(
                                 directive.range(),
                             )
                         };
-                        let mut diagnostic = Diagnostic::new(
+                        let mut diagnostic = OldDiagnostic::new(
                             UnusedNOQA {
                                 codes: Some(UnusedCodes {
                                     disabled: disabled_codes

--- a/crates/ruff_linter/src/checkers/physical_lines.rs
+++ b/crates/ruff_linter/src/checkers/physical_lines.rs
@@ -5,8 +5,8 @@ use ruff_python_index::Indexer;
 use ruff_source_file::UniversalNewlines;
 use ruff_text_size::TextSize;
 
-use crate::Diagnostic;
 use crate::Locator;
+use crate::OldDiagnostic;
 use crate::registry::Rule;
 use crate::rules::flake8_copyright::rules::missing_copyright_notice;
 use crate::rules::pycodestyle::rules::{
@@ -23,8 +23,8 @@ pub(crate) fn check_physical_lines(
     indexer: &Indexer,
     doc_lines: &[TextSize],
     settings: &LinterSettings,
-) -> Vec<Diagnostic> {
-    let mut diagnostics: Vec<Diagnostic> = vec![];
+) -> Vec<OldDiagnostic> {
+    let mut diagnostics: Vec<OldDiagnostic> = vec![];
 
     let enforce_doc_line_too_long = settings.rules.enabled(Rule::DocLineTooLong);
     let enforce_line_too_long = settings.rules.enabled(Rule::LineTooLong);

--- a/crates/ruff_linter/src/checkers/tokens.rs
+++ b/crates/ruff_linter/src/checkers/tokens.rs
@@ -8,8 +8,8 @@ use ruff_python_codegen::Stylist;
 use ruff_python_index::Indexer;
 use ruff_python_parser::Tokens;
 
-use crate::Diagnostic;
 use crate::Locator;
+use crate::OldDiagnostic;
 use crate::directives::TodoComment;
 use crate::registry::{AsRule, Rule};
 use crate::rules::pycodestyle::rules::BlankLinesChecker;
@@ -29,8 +29,8 @@ pub(crate) fn check_tokens(
     settings: &LinterSettings,
     source_type: PySourceType,
     cell_offsets: Option<&CellOffsets>,
-) -> Vec<Diagnostic> {
-    let mut diagnostics: Vec<Diagnostic> = vec![];
+) -> Vec<OldDiagnostic> {
+    let mut diagnostics: Vec<OldDiagnostic> = vec![];
     let comment_ranges = indexer.comment_ranges();
 
     if settings.rules.any_enabled(&[

--- a/crates/ruff_linter/src/diagnostic.rs
+++ b/crates/ruff_linter/src/diagnostic.rs
@@ -8,7 +8,7 @@ use crate::violation::Violation;
 use crate::{Fix, codes::Rule};
 
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub struct Diagnostic {
+pub struct OldDiagnostic {
     /// The message body to display to the user, to explain the diagnostic.
     pub body: String,
     /// The message to display to the user, to explain the suggested fix.
@@ -20,7 +20,7 @@ pub struct Diagnostic {
     pub(crate) rule: Rule,
 }
 
-impl Diagnostic {
+impl OldDiagnostic {
     // TODO(brent) We temporarily allow this to avoid updating all of the call sites to add
     // references. I expect this method to go away or change significantly with the rest of the
     // diagnostic refactor, but if it still exists in this form at the end of the refactor, we
@@ -87,13 +87,13 @@ impl Diagnostic {
     }
 }
 
-impl AsRule for Diagnostic {
+impl AsRule for OldDiagnostic {
     fn rule(&self) -> Rule {
         self.rule
     }
 }
 
-impl Ranged for Diagnostic {
+impl Ranged for OldDiagnostic {
     fn range(&self) -> TextRange {
         self.range
     }

--- a/crates/ruff_linter/src/fix/edits.rs
+++ b/crates/ruff_linter/src/fix/edits.rs
@@ -607,7 +607,7 @@ mod tests {
         add_to_dunder_all, make_redundant_alias, next_stmt_break, trailing_semicolon,
     };
     use crate::message::Message;
-    use crate::{Diagnostic, Edit, Fix};
+    use crate::{Edit, Fix, OldDiagnostic};
 
     /// Parse the given source using [`Mode::Module`] and return the first statement.
     fn parse_first_stmt(source: &str) -> Result<Stmt> {
@@ -738,7 +738,7 @@ x = 1 \
         let diag = {
             use crate::rules::pycodestyle::rules::MissingNewlineAtEndOfFile;
             let mut iter = edits.into_iter();
-            let diag = Diagnostic::new(
+            let diag = OldDiagnostic::new(
                 MissingNewlineAtEndOfFile, // The choice of rule here is arbitrary.
                 TextRange::default(),
             )

--- a/crates/ruff_linter/src/fix/mod.rs
+++ b/crates/ruff_linter/src/fix/mod.rs
@@ -163,7 +163,7 @@ mod tests {
     use ruff_text_size::{Ranged, TextSize};
 
     use crate::Locator;
-    use crate::diagnostic::Diagnostic;
+    use crate::diagnostic::OldDiagnostic;
     use crate::fix::{FixResult, apply_fixes};
     use crate::message::Message;
     use crate::rules::pycodestyle::rules::MissingNewlineAtEndOfFile;
@@ -177,7 +177,7 @@ mod tests {
         edit.into_iter()
             .map(|edit| {
                 // The choice of rule here is arbitrary.
-                let diagnostic = Diagnostic::new(MissingNewlineAtEndOfFile, edit.range());
+                let diagnostic = OldDiagnostic::new(MissingNewlineAtEndOfFile, edit.range());
                 Message::from_diagnostic(
                     diagnostic.with_fix(Fix::safe_edit(edit)),
                     SourceFileBuilder::new(filename, source).finish(),

--- a/crates/ruff_linter/src/lib.rs
+++ b/crates/ruff_linter/src/lib.rs
@@ -14,7 +14,7 @@ pub use rule_selector::RuleSelector;
 pub use rule_selector::clap_completion::RuleSelectorParser;
 pub use rules::pycodestyle::rules::IOError;
 
-pub use diagnostic::Diagnostic;
+pub use diagnostic::OldDiagnostic;
 pub(crate) use ruff_diagnostics::{Applicability, Edit, Fix};
 pub use violation::{AlwaysFixableViolation, FixAvailability, Violation, ViolationMetadata};
 

--- a/crates/ruff_linter/src/linter.rs
+++ b/crates/ruff_linter/src/linter.rs
@@ -438,7 +438,7 @@ pub fn add_noqa_to_path(
     )
 }
 
-/// Generate a [`Message`] for each [`Diagnostic`] triggered by the given source
+/// Generate a [`Message`] for each [`OldDiagnostic`] triggered by the given source
 /// code.
 pub fn lint_only(
     path: &Path,

--- a/crates/ruff_linter/src/linter.rs
+++ b/crates/ruff_linter/src/linter.rs
@@ -17,7 +17,7 @@ use ruff_python_parser::{ParseError, ParseOptions, Parsed, UnsupportedSyntaxErro
 use ruff_source_file::SourceFileBuilder;
 use ruff_text_size::Ranged;
 
-use crate::Diagnostic;
+use crate::OldDiagnostic;
 use crate::checkers::ast::check_ast;
 use crate::checkers::filesystem::check_file_path;
 use crate::checkers::imports::check_imports;
@@ -503,7 +503,7 @@ pub fn lint_only(
 
 /// Convert from diagnostics to messages.
 fn diagnostics_to_messages(
-    diagnostics: Vec<Diagnostic>,
+    diagnostics: Vec<OldDiagnostic>,
     parse_errors: &[ParseError],
     unsupported_syntax_errors: &[UnsupportedSyntaxError],
     semantic_syntax_errors: &[SemanticSyntaxError],

--- a/crates/ruff_linter/src/message/mod.rs
+++ b/crates/ruff_linter/src/message/mod.rs
@@ -27,7 +27,7 @@ use crate::Locator;
 use crate::codes::NoqaCode;
 use crate::logging::DisplayParseErrorType;
 use crate::registry::Rule;
-use crate::{Diagnostic, Fix};
+use crate::{Fix, OldDiagnostic};
 
 mod azure;
 mod diff;
@@ -115,11 +115,11 @@ impl Message {
 
     /// Create a [`Message`] from the given [`Diagnostic`] corresponding to a rule violation.
     pub fn from_diagnostic(
-        diagnostic: Diagnostic,
+        diagnostic: OldDiagnostic,
         file: SourceFile,
         noqa_offset: Option<TextSize>,
     ) -> Message {
-        let Diagnostic {
+        let OldDiagnostic {
             body,
             suggestion,
             range,

--- a/crates/ruff_linter/src/message/mod.rs
+++ b/crates/ruff_linter/src/message/mod.rs
@@ -50,7 +50,7 @@ mod text;
 /// `noqa` offsets.
 ///
 /// For diagnostic messages, the [`db::Diagnostic`]'s primary message contains the
-/// [`Diagnostic::body`], and the primary annotation optionally contains the suggestion accompanying
+/// [`OldDiagnostic::body`], and the primary annotation optionally contains the suggestion accompanying
 /// a fix. The `db::Diagnostic::id` field contains the kebab-case lint name derived from the `Rule`.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Message {
@@ -113,7 +113,7 @@ impl Message {
         }
     }
 
-    /// Create a [`Message`] from the given [`Diagnostic`] corresponding to a rule violation.
+    /// Create a [`Message`] from the given [`OldDiagnostic`] corresponding to a rule violation.
     pub fn from_diagnostic(
         diagnostic: OldDiagnostic,
         file: SourceFile,

--- a/crates/ruff_linter/src/noqa.rs
+++ b/crates/ruff_linter/src/noqa.rs
@@ -1233,7 +1233,7 @@ mod tests {
     use crate::rules::pycodestyle::rules::{AmbiguousVariableName, UselessSemicolon};
     use crate::rules::pyflakes::rules::UnusedVariable;
     use crate::rules::pyupgrade::rules::PrintfStringFormatting;
-    use crate::{Diagnostic, Edit};
+    use crate::{Edit, OldDiagnostic};
     use crate::{Locator, generate_noqa_edits};
 
     fn assert_lexed_ranges_match_slices(
@@ -1253,7 +1253,7 @@ mod tests {
 
     /// Create a [`Message`] with a placeholder filename and rule code from `diagnostic`.
     fn message_from_diagnostic(
-        diagnostic: Diagnostic,
+        diagnostic: OldDiagnostic,
         path: impl AsRef<Path>,
         source: &str,
     ) -> Message {
@@ -2842,7 +2842,7 @@ mod tests {
         assert_eq!(count, 0);
         assert_eq!(output, format!("{contents}"));
 
-        let messages = [Diagnostic::new(
+        let messages = [OldDiagnostic::new(
             UnusedVariable {
                 name: "x".to_string(),
             },
@@ -2865,11 +2865,11 @@ mod tests {
         assert_eq!(output, "x = 1  # noqa: F841\n");
 
         let messages = [
-            Diagnostic::new(
+            OldDiagnostic::new(
                 AmbiguousVariableName("x".to_string()),
                 TextRange::new(TextSize::from(0), TextSize::from(0)),
             ),
-            Diagnostic::new(
+            OldDiagnostic::new(
                 UnusedVariable {
                     name: "x".to_string(),
                 },
@@ -2894,11 +2894,11 @@ mod tests {
         assert_eq!(output, "x = 1  # noqa: E741, F841\n");
 
         let messages = [
-            Diagnostic::new(
+            OldDiagnostic::new(
                 AmbiguousVariableName("x".to_string()),
                 TextRange::new(TextSize::from(0), TextSize::from(0)),
             ),
-            Diagnostic::new(
+            OldDiagnostic::new(
                 UnusedVariable {
                     name: "x".to_string(),
                 },
@@ -2936,7 +2936,7 @@ print(
 )
 "#;
         let noqa_line_for = [TextRange::new(8.into(), 68.into())].into_iter().collect();
-        let messages = [Diagnostic::new(
+        let messages = [OldDiagnostic::new(
             PrintfStringFormatting,
             TextRange::new(12.into(), 79.into()),
         )]
@@ -2968,7 +2968,7 @@ print(
 foo;
 bar =
 ";
-        let messages = [Diagnostic::new(
+        let messages = [OldDiagnostic::new(
             UselessSemicolon,
             TextRange::new(4.into(), 5.into()),
         )]

--- a/crates/ruff_linter/src/pyproject_toml.rs
+++ b/crates/ruff_linter/src/pyproject_toml.rs
@@ -5,8 +5,8 @@ use ruff_text_size::{TextRange, TextSize};
 
 use ruff_source_file::SourceFile;
 
-use crate::Diagnostic;
 use crate::IOError;
+use crate::OldDiagnostic;
 use crate::message::Message;
 use crate::registry::Rule;
 use crate::rules::ruff::rules::InvalidPyprojectToml;
@@ -29,7 +29,7 @@ pub fn lint_pyproject_toml(source_file: SourceFile, settings: &LinterSettings) -
                     source_file.name(),
                 );
                 if settings.rules.enabled(Rule::IOError) {
-                    let diagnostic = Diagnostic::new(IOError { message }, TextRange::default());
+                    let diagnostic = OldDiagnostic::new(IOError { message }, TextRange::default());
                     messages.push(Message::from_diagnostic(diagnostic, source_file, None));
                 } else {
                     warn!(
@@ -51,7 +51,7 @@ pub fn lint_pyproject_toml(source_file: SourceFile, settings: &LinterSettings) -
 
     if settings.rules.enabled(Rule::InvalidPyprojectToml) {
         let toml_err = err.message().to_string();
-        let diagnostic = Diagnostic::new(InvalidPyprojectToml { message: toml_err }, range);
+        let diagnostic = OldDiagnostic::new(InvalidPyprojectToml { message: toml_err }, range);
         messages.push(Message::from_diagnostic(diagnostic, source_file, None));
     }
 

--- a/crates/ruff_linter/src/rules/eradicate/rules/commented_out_code.rs
+++ b/crates/ruff_linter/src/rules/eradicate/rules/commented_out_code.rs
@@ -5,7 +5,7 @@ use ruff_text_size::TextRange;
 
 use crate::Locator;
 use crate::settings::LinterSettings;
-use crate::{Diagnostic, Edit, Fix, FixAvailability, Violation};
+use crate::{Edit, Fix, FixAvailability, OldDiagnostic, Violation};
 
 use super::super::detection::comment_contains_code;
 
@@ -47,7 +47,7 @@ impl Violation for CommentedOutCode {
 
 /// ERA001
 pub(crate) fn commented_out_code(
-    diagnostics: &mut Vec<Diagnostic>,
+    diagnostics: &mut Vec<OldDiagnostic>,
     locator: &Locator,
     comment_ranges: &CommentRanges,
     settings: &LinterSettings,
@@ -65,7 +65,7 @@ pub(crate) fn commented_out_code(
 
         // Verify that the comment is on its own line, and that it contains code.
         if is_own_line_comment(line) && comment_contains_code(line, &settings.task_tags[..]) {
-            let mut diagnostic = Diagnostic::new(CommentedOutCode, range);
+            let mut diagnostic = OldDiagnostic::new(CommentedOutCode, range);
             diagnostic.set_fix(Fix::display_only_edit(Edit::range_deletion(
                 locator.full_lines_range(range),
             )));

--- a/crates/ruff_linter/src/rules/flake8_builtins/rules/stdlib_module_shadowing.rs
+++ b/crates/ruff_linter/src/rules/flake8_builtins/rules/stdlib_module_shadowing.rs
@@ -8,7 +8,7 @@ use ruff_python_stdlib::sys::is_known_standard_library;
 use ruff_text_size::TextRange;
 
 use crate::settings::LinterSettings;
-use crate::{Diagnostic, Violation};
+use crate::{OldDiagnostic, Violation};
 
 /// ## What it does
 /// Checks for modules that use the same names as Python standard-library
@@ -69,7 +69,7 @@ pub(crate) fn stdlib_module_shadowing(
     mut path: &Path,
     settings: &LinterSettings,
     target_version: PythonVersion,
-) -> Option<Diagnostic> {
+) -> Option<OldDiagnostic> {
     if !PySourceType::try_from_path(path).is_some_and(PySourceType::is_py_file) {
         return None;
     }
@@ -107,7 +107,7 @@ pub(crate) fn stdlib_module_shadowing(
         return None;
     }
 
-    Some(Diagnostic::new(
+    Some(OldDiagnostic::new(
         StdlibModuleShadowing {
             name: module_name.to_string(),
         },

--- a/crates/ruff_linter/src/rules/flake8_commas/rules/trailing_commas.rs
+++ b/crates/ruff_linter/src/rules/flake8_commas/rules/trailing_commas.rs
@@ -5,7 +5,7 @@ use ruff_text_size::{Ranged, TextRange};
 
 use crate::Locator;
 use crate::{AlwaysFixableViolation, Violation};
-use crate::{Diagnostic, Edit, Fix};
+use crate::{Edit, Fix, OldDiagnostic};
 
 /// Simplified token type.
 #[derive(Copy, Clone, PartialEq, Eq)]
@@ -238,7 +238,7 @@ impl AlwaysFixableViolation for ProhibitedTrailingComma {
 
 /// COM812, COM818, COM819
 pub(crate) fn trailing_commas(
-    diagnostics: &mut Vec<Diagnostic>,
+    diagnostics: &mut Vec<OldDiagnostic>,
     tokens: &Tokens,
     locator: &Locator,
     indexer: &Indexer,
@@ -319,7 +319,7 @@ fn check_token(
     prev_prev: SimpleToken,
     context: Context,
     locator: &Locator,
-) -> Option<Diagnostic> {
+) -> Option<OldDiagnostic> {
     // Is it allowed to have a trailing comma before this token?
     let comma_allowed = token.ty == TokenType::ClosingBracket
         && match context.ty {
@@ -352,7 +352,7 @@ fn check_token(
     };
 
     if comma_prohibited {
-        let mut diagnostic = Diagnostic::new(ProhibitedTrailingComma, prev.range());
+        let mut diagnostic = OldDiagnostic::new(ProhibitedTrailingComma, prev.range());
         diagnostic.set_fix(Fix::safe_edit(Edit::range_deletion(diagnostic.range())));
         return Some(diagnostic);
     }
@@ -361,7 +361,7 @@ fn check_token(
     // Approximation: any comma followed by a statement-ending newline.
     let bare_comma_prohibited = prev.ty == TokenType::Comma && token.ty == TokenType::Newline;
     if bare_comma_prohibited {
-        return Some(Diagnostic::new(TrailingCommaOnBareTuple, prev.range()));
+        return Some(OldDiagnostic::new(TrailingCommaOnBareTuple, prev.range()));
     }
 
     if !comma_allowed {
@@ -383,7 +383,7 @@ fn check_token(
         );
     if comma_required {
         let mut diagnostic =
-            Diagnostic::new(MissingTrailingComma, TextRange::empty(prev_prev.end()));
+            OldDiagnostic::new(MissingTrailingComma, TextRange::empty(prev_prev.end()));
         // Create a replacement that includes the final bracket (or other token),
         // rather than just inserting a comma at the end. This prevents the UP034 fix
         // removing any brackets in the same linter pass - doing both at the same time could

--- a/crates/ruff_linter/src/rules/flake8_copyright/rules/missing_copyright_notice.rs
+++ b/crates/ruff_linter/src/rules/flake8_copyright/rules/missing_copyright_notice.rs
@@ -3,7 +3,7 @@ use ruff_text_size::{TextRange, TextSize};
 
 use crate::Locator;
 use crate::settings::LinterSettings;
-use crate::{Diagnostic, Violation};
+use crate::{OldDiagnostic, Violation};
 
 /// ## What it does
 /// Checks for the absence of copyright notices within Python files.
@@ -32,7 +32,7 @@ impl Violation for MissingCopyrightNotice {
 pub(crate) fn missing_copyright_notice(
     locator: &Locator,
     settings: &LinterSettings,
-) -> Option<Diagnostic> {
+) -> Option<OldDiagnostic> {
     // Ignore files that are too small to contain a copyright notice.
     if locator.len() < settings.flake8_copyright.min_file_size {
         return None;
@@ -54,7 +54,7 @@ pub(crate) fn missing_copyright_notice(
         }
     }
 
-    Some(Diagnostic::new(
+    Some(OldDiagnostic::new(
         MissingCopyrightNotice,
         TextRange::default(),
     ))

--- a/crates/ruff_linter/src/rules/flake8_executable/rules/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_executable/rules/mod.rs
@@ -7,8 +7,8 @@ pub(crate) use shebang_missing_python::*;
 pub(crate) use shebang_not_executable::*;
 pub(crate) use shebang_not_first_line::*;
 
-use crate::Diagnostic;
 use crate::Locator;
+use crate::OldDiagnostic;
 use crate::codes::Rule;
 use crate::comments::shebang::ShebangDirective;
 use crate::settings::LinterSettings;
@@ -20,7 +20,7 @@ mod shebang_not_executable;
 mod shebang_not_first_line;
 
 pub(crate) fn from_tokens(
-    diagnostics: &mut Vec<Diagnostic>,
+    diagnostics: &mut Vec<OldDiagnostic>,
     path: &Path,
     locator: &Locator,
     comment_ranges: &CommentRanges,

--- a/crates/ruff_linter/src/rules/flake8_executable/rules/shebang_leading_whitespace.rs
+++ b/crates/ruff_linter/src/rules/flake8_executable/rules/shebang_leading_whitespace.rs
@@ -3,7 +3,7 @@ use ruff_python_trivia::is_python_whitespace;
 use ruff_text_size::{TextRange, TextSize};
 
 use crate::Locator;
-use crate::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
+use crate::{AlwaysFixableViolation, Edit, Fix, OldDiagnostic};
 
 /// ## What it does
 /// Checks for whitespace before a shebang directive.
@@ -47,7 +47,7 @@ impl AlwaysFixableViolation for ShebangLeadingWhitespace {
 pub(crate) fn shebang_leading_whitespace(
     range: TextRange,
     locator: &Locator,
-) -> Option<Diagnostic> {
+) -> Option<OldDiagnostic> {
     // If the shebang is at the beginning of the file, abort.
     if range.start() == TextSize::from(0) {
         return None;
@@ -63,7 +63,7 @@ pub(crate) fn shebang_leading_whitespace(
     }
 
     let prefix = TextRange::up_to(range.start());
-    let mut diagnostic = Diagnostic::new(ShebangLeadingWhitespace, prefix);
+    let mut diagnostic = OldDiagnostic::new(ShebangLeadingWhitespace, prefix);
     diagnostic.set_fix(Fix::safe_edit(Edit::range_deletion(prefix)));
     Some(diagnostic)
 }

--- a/crates/ruff_linter/src/rules/flake8_executable/rules/shebang_missing_executable_file.rs
+++ b/crates/ruff_linter/src/rules/flake8_executable/rules/shebang_missing_executable_file.rs
@@ -9,7 +9,7 @@ use ruff_macros::{ViolationMetadata, derive_message_formats};
 use crate::registry::AsRule;
 #[cfg(target_family = "unix")]
 use crate::rules::flake8_executable::helpers::is_executable;
-use crate::{Diagnostic, Violation};
+use crate::{OldDiagnostic, Violation};
 
 /// ## What it does
 /// Checks for executable `.py` files that do not have a shebang.
@@ -49,14 +49,14 @@ impl Violation for ShebangMissingExecutableFile {
 
 /// EXE002
 #[cfg(target_family = "unix")]
-pub(crate) fn shebang_missing_executable_file(filepath: &Path) -> Option<Diagnostic> {
+pub(crate) fn shebang_missing_executable_file(filepath: &Path) -> Option<OldDiagnostic> {
     // WSL supports Windows file systems, which do not have executable bits.
     // Instead, everything is executable. Therefore, we skip this rule on WSL.
     if is_wsl::is_wsl() {
         return None;
     }
     if let Ok(true) = is_executable(filepath) {
-        return Some(Diagnostic::new(
+        return Some(OldDiagnostic::new(
             ShebangMissingExecutableFile,
             TextRange::default(),
         ));
@@ -65,6 +65,6 @@ pub(crate) fn shebang_missing_executable_file(filepath: &Path) -> Option<Diagnos
 }
 
 #[cfg(not(target_family = "unix"))]
-pub(crate) fn shebang_missing_executable_file(_filepath: &Path) -> Option<Diagnostic> {
+pub(crate) fn shebang_missing_executable_file(_filepath: &Path) -> Option<OldDiagnostic> {
     None
 }

--- a/crates/ruff_linter/src/rules/flake8_executable/rules/shebang_missing_python.rs
+++ b/crates/ruff_linter/src/rules/flake8_executable/rules/shebang_missing_python.rs
@@ -3,7 +3,7 @@ use ruff_text_size::TextRange;
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 
 use crate::comments::shebang::ShebangDirective;
-use crate::{Diagnostic, Violation};
+use crate::{OldDiagnostic, Violation};
 
 /// ## What it does
 /// Checks for a shebang directive in `.py` files that does not contain `python`,
@@ -44,10 +44,10 @@ impl Violation for ShebangMissingPython {
 pub(crate) fn shebang_missing_python(
     range: TextRange,
     shebang: &ShebangDirective,
-) -> Option<Diagnostic> {
+) -> Option<OldDiagnostic> {
     if shebang.contains("python") || shebang.contains("pytest") || shebang.contains("uv run") {
         return None;
     }
 
-    Some(Diagnostic::new(ShebangMissingPython, range))
+    Some(OldDiagnostic::new(ShebangMissingPython, range))
 }

--- a/crates/ruff_linter/src/rules/flake8_executable/rules/shebang_not_executable.rs
+++ b/crates/ruff_linter/src/rules/flake8_executable/rules/shebang_not_executable.rs
@@ -5,7 +5,7 @@ use ruff_text_size::TextRange;
 
 #[cfg(target_family = "unix")]
 use crate::rules::flake8_executable::helpers::is_executable;
-use crate::{Diagnostic, Violation};
+use crate::{OldDiagnostic, Violation};
 
 /// ## What it does
 /// Checks for a shebang directive in a file that is not executable.
@@ -48,7 +48,7 @@ impl Violation for ShebangNotExecutable {
 
 /// EXE001
 #[cfg(target_family = "unix")]
-pub(crate) fn shebang_not_executable(filepath: &Path, range: TextRange) -> Option<Diagnostic> {
+pub(crate) fn shebang_not_executable(filepath: &Path, range: TextRange) -> Option<OldDiagnostic> {
     // WSL supports Windows file systems, which do not have executable bits.
     // Instead, everything is executable. Therefore, we skip this rule on WSL.
     if is_wsl::is_wsl() {
@@ -56,13 +56,13 @@ pub(crate) fn shebang_not_executable(filepath: &Path, range: TextRange) -> Optio
     }
 
     if let Ok(false) = is_executable(filepath) {
-        return Some(Diagnostic::new(ShebangNotExecutable, range));
+        return Some(OldDiagnostic::new(ShebangNotExecutable, range));
     }
 
     None
 }
 
 #[cfg(not(target_family = "unix"))]
-pub(crate) fn shebang_not_executable(_filepath: &Path, _range: TextRange) -> Option<Diagnostic> {
+pub(crate) fn shebang_not_executable(_filepath: &Path, _range: TextRange) -> Option<OldDiagnostic> {
     None
 }

--- a/crates/ruff_linter/src/rules/flake8_executable/rules/shebang_not_first_line.rs
+++ b/crates/ruff_linter/src/rules/flake8_executable/rules/shebang_not_first_line.rs
@@ -3,7 +3,7 @@ use ruff_python_trivia::is_python_whitespace;
 use ruff_text_size::{TextRange, TextSize};
 
 use crate::Locator;
-use crate::{Diagnostic, Violation};
+use crate::{OldDiagnostic, Violation};
 
 /// ## What it does
 /// Checks for a shebang directive that is not at the beginning of the file.
@@ -42,7 +42,7 @@ impl Violation for ShebangNotFirstLine {
 }
 
 /// EXE005
-pub(crate) fn shebang_not_first_line(range: TextRange, locator: &Locator) -> Option<Diagnostic> {
+pub(crate) fn shebang_not_first_line(range: TextRange, locator: &Locator) -> Option<OldDiagnostic> {
     // If the shebang is at the beginning of the file, abort.
     if range.start() == TextSize::from(0) {
         return None;
@@ -57,5 +57,5 @@ pub(crate) fn shebang_not_first_line(range: TextRange, locator: &Locator) -> Opt
         return None;
     }
 
-    Some(Diagnostic::new(ShebangNotFirstLine, range))
+    Some(OldDiagnostic::new(ShebangNotFirstLine, range))
 }

--- a/crates/ruff_linter/src/rules/flake8_fixme/rules/todos.rs
+++ b/crates/ruff_linter/src/rules/flake8_fixme/rules/todos.rs
@@ -1,7 +1,7 @@
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 
 use crate::directives::{TodoComment, TodoDirectiveKind};
-use crate::{Diagnostic, Violation};
+use crate::{OldDiagnostic, Violation};
 
 /// ## What it does
 /// Checks for "TODO" comments.
@@ -114,19 +114,19 @@ impl Violation for LineContainsHack {
     }
 }
 
-pub(crate) fn todos(diagnostics: &mut Vec<Diagnostic>, directive_ranges: &[TodoComment]) {
+pub(crate) fn todos(diagnostics: &mut Vec<OldDiagnostic>, directive_ranges: &[TodoComment]) {
     diagnostics.extend(
         directive_ranges
             .iter()
             .map(|TodoComment { directive, .. }| match directive.kind {
                 // FIX001
-                TodoDirectiveKind::Fixme => Diagnostic::new(LineContainsFixme, directive.range),
+                TodoDirectiveKind::Fixme => OldDiagnostic::new(LineContainsFixme, directive.range),
                 // FIX002
-                TodoDirectiveKind::Hack => Diagnostic::new(LineContainsHack, directive.range),
+                TodoDirectiveKind::Hack => OldDiagnostic::new(LineContainsHack, directive.range),
                 // FIX003
-                TodoDirectiveKind::Todo => Diagnostic::new(LineContainsTodo, directive.range),
+                TodoDirectiveKind::Todo => OldDiagnostic::new(LineContainsTodo, directive.range),
                 // FIX004
-                TodoDirectiveKind::Xxx => Diagnostic::new(LineContainsXxx, directive.range),
+                TodoDirectiveKind::Xxx => OldDiagnostic::new(LineContainsXxx, directive.range),
             }),
     );
 }

--- a/crates/ruff_linter/src/rules/flake8_implicit_str_concat/rules/implicit.rs
+++ b/crates/ruff_linter/src/rules/flake8_implicit_str_concat/rules/implicit.rs
@@ -11,7 +11,7 @@ use ruff_text_size::{Ranged, TextRange};
 
 use crate::Locator;
 use crate::settings::LinterSettings;
-use crate::{Diagnostic, Edit, Fix, FixAvailability, Violation};
+use crate::{Edit, Fix, FixAvailability, OldDiagnostic, Violation};
 
 /// ## What it does
 /// Checks for implicitly concatenated strings on a single line.
@@ -103,7 +103,7 @@ impl Violation for MultiLineImplicitStringConcatenation {
 
 /// ISC001, ISC002
 pub(crate) fn implicit(
-    diagnostics: &mut Vec<Diagnostic>,
+    diagnostics: &mut Vec<OldDiagnostic>,
     tokens: &Tokens,
     locator: &Locator,
     indexer: &Indexer,
@@ -145,12 +145,12 @@ pub(crate) fn implicit(
         };
 
         if locator.contains_line_break(TextRange::new(a_range.end(), b_range.start())) {
-            diagnostics.push(Diagnostic::new(
+            diagnostics.push(OldDiagnostic::new(
                 MultiLineImplicitStringConcatenation,
                 TextRange::new(a_range.start(), b_range.end()),
             ));
         } else {
-            let mut diagnostic = Diagnostic::new(
+            let mut diagnostic = OldDiagnostic::new(
                 SingleLineImplicitStringConcatenation,
                 TextRange::new(a_range.start(), b_range.end()),
             );

--- a/crates/ruff_linter/src/rules/flake8_no_pep420/rules/implicit_namespace_package.rs
+++ b/crates/ruff_linter/src/rules/flake8_no_pep420/rules/implicit_namespace_package.rs
@@ -10,7 +10,7 @@ use crate::Locator;
 use crate::comments::shebang::ShebangDirective;
 use crate::fs;
 use crate::package::PackageRoot;
-use crate::{Diagnostic, Violation};
+use crate::{OldDiagnostic, Violation};
 
 /// ## What it does
 /// Checks for packages that are missing an `__init__.py` file.
@@ -64,7 +64,7 @@ pub(crate) fn implicit_namespace_package(
     project_root: &Path,
     src: &[PathBuf],
     allow_nested_roots: bool,
-) -> Option<Diagnostic> {
+) -> Option<OldDiagnostic> {
     if package.is_none()
         // Ignore non-`.py` files, which don't require an `__init__.py`.
         && PySourceType::try_from_path(path).is_some_and(PySourceType::is_py_file)
@@ -83,7 +83,7 @@ pub(crate) fn implicit_namespace_package(
         // Ignore PEP 723 scripts.
         && ScriptTag::parse(locator.contents().as_bytes()).is_none()
     {
-        return Some(Diagnostic::new(
+        return Some(OldDiagnostic::new(
             ImplicitNamespacePackage {
                 filename: fs::relativize_path(path),
                 parent: None,
@@ -100,7 +100,7 @@ pub(crate) fn implicit_namespace_package(
                     .ancestors()
                     .find(|parent| !parent.join("__init__.py").exists())
                 {
-                    return Some(Diagnostic::new(
+                    return Some(OldDiagnostic::new(
                         ImplicitNamespacePackage {
                             filename: fs::relativize_path(path),
                             parent: Some(fs::relativize_path(parent)),

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/type_comment_in_stub.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/type_comment_in_stub.rs
@@ -6,7 +6,7 @@ use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_python_trivia::CommentRanges;
 
 use crate::Locator;
-use crate::{Diagnostic, Violation};
+use crate::{OldDiagnostic, Violation};
 
 /// ## What it does
 /// Checks for the use of type comments (e.g., `x = 1  # type: int`) in stub
@@ -38,7 +38,7 @@ impl Violation for TypeCommentInStub {
 
 /// PYI033
 pub(crate) fn type_comment_in_stub(
-    diagnostics: &mut Vec<Diagnostic>,
+    diagnostics: &mut Vec<OldDiagnostic>,
     locator: &Locator,
     comment_ranges: &CommentRanges,
 ) {
@@ -46,7 +46,7 @@ pub(crate) fn type_comment_in_stub(
         let comment = locator.slice(range);
 
         if TYPE_COMMENT_REGEX.is_match(comment) && !TYPE_IGNORE_REGEX.is_match(comment) {
-            diagnostics.push(Diagnostic::new(TypeCommentInStub, range));
+            diagnostics.push(OldDiagnostic::new(TypeCommentInStub, range));
         }
     }
 }

--- a/crates/ruff_linter/src/rules/isort/rules/add_required_imports.rs
+++ b/crates/ruff_linter/src/rules/isort/rules/add_required_imports.rs
@@ -9,7 +9,7 @@ use ruff_text_size::{TextRange, TextSize};
 use crate::Locator;
 use crate::importer::Importer;
 use crate::settings::LinterSettings;
-use crate::{AlwaysFixableViolation, Diagnostic, Fix};
+use crate::{AlwaysFixableViolation, Fix, OldDiagnostic};
 
 /// ## What it does
 /// Adds any required imports, as specified by the user, to the top of the
@@ -91,7 +91,7 @@ fn add_required_import(
     locator: &Locator,
     stylist: &Stylist,
     source_type: PySourceType,
-) -> Option<Diagnostic> {
+) -> Option<OldDiagnostic> {
     // Don't add imports to semantically-empty files.
     if parsed.suite().iter().all(is_docstring_stmt) {
         return None;
@@ -112,7 +112,7 @@ fn add_required_import(
     }
 
     // Always insert the diagnostic at top-of-file.
-    let mut diagnostic = Diagnostic::new(
+    let mut diagnostic = OldDiagnostic::new(
         MissingRequiredImport(required_import.to_string()),
         TextRange::default(),
     );
@@ -129,7 +129,7 @@ pub(crate) fn add_required_imports(
     stylist: &Stylist,
     settings: &LinterSettings,
     source_type: PySourceType,
-) -> Vec<Diagnostic> {
+) -> Vec<OldDiagnostic> {
     settings
         .isort
         .required_imports

--- a/crates/ruff_linter/src/rules/isort/rules/organize_imports.rs
+++ b/crates/ruff_linter/src/rules/isort/rules/organize_imports.rs
@@ -18,7 +18,7 @@ use crate::package::PackageRoot;
 use crate::preview::is_full_path_match_source_strategy_enabled;
 use crate::rules::isort::categorize::MatchSourceStrategy;
 use crate::settings::LinterSettings;
-use crate::{Diagnostic, Edit, Fix, FixAvailability, Violation};
+use crate::{Edit, Fix, FixAvailability, OldDiagnostic, Violation};
 
 /// ## What it does
 /// De-duplicates, groups, and sorts imports based on the provided `isort` settings.
@@ -98,7 +98,7 @@ pub(crate) fn organize_imports(
     source_type: PySourceType,
     tokens: &Tokens,
     target_version: PythonVersion,
-) -> Option<Diagnostic> {
+) -> Option<OldDiagnostic> {
     let indentation = locator.slice(extract_indentation_range(&block.imports, locator));
     let indentation = leading_indentation(indentation);
 
@@ -110,7 +110,7 @@ pub(crate) fn organize_imports(
         || indexer
             .followed_by_multi_statement_line(block.imports.last().unwrap(), locator.contents())
     {
-        return Some(Diagnostic::new(UnsortedImports, range));
+        return Some(OldDiagnostic::new(UnsortedImports, range));
     }
 
     // Extract comments. Take care to grab any inline comments from the last line.
@@ -155,7 +155,7 @@ pub(crate) fn organize_imports(
     if matches_ignoring_indentation(actual, &expected) {
         return None;
     }
-    let mut diagnostic = Diagnostic::new(UnsortedImports, range);
+    let mut diagnostic = OldDiagnostic::new(UnsortedImports, range);
     diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
         indent(&expected, indentation).to_string(),
         fix_range,

--- a/crates/ruff_linter/src/rules/pep8_naming/rules/invalid_module_name.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/rules/invalid_module_name.rs
@@ -9,7 +9,7 @@ use ruff_text_size::TextRange;
 
 use crate::package::PackageRoot;
 use crate::rules::pep8_naming::settings::IgnoreNames;
-use crate::{Diagnostic, Violation};
+use crate::{OldDiagnostic, Violation};
 
 /// ## What it does
 /// Checks for module names that do not follow the `snake_case` naming
@@ -54,7 +54,7 @@ pub(crate) fn invalid_module_name(
     path: &Path,
     package: Option<PackageRoot<'_>>,
     ignore_names: &IgnoreNames,
-) -> Option<Diagnostic> {
+) -> Option<OldDiagnostic> {
     if !PySourceType::try_from_path(path).is_some_and(PySourceType::is_py_file_or_stub) {
         return None;
     }
@@ -80,7 +80,7 @@ pub(crate) fn invalid_module_name(
             if ignore_names.matches(&module_name) {
                 return None;
             }
-            return Some(Diagnostic::new(
+            return Some(OldDiagnostic::new(
                 InvalidModuleName {
                     name: module_name.to_string(),
                 },

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/blank_lines.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/blank_lines.rs
@@ -18,10 +18,10 @@ use ruff_text_size::TextRange;
 use ruff_text_size::TextSize;
 
 use crate::AlwaysFixableViolation;
-use crate::Diagnostic;
 use crate::Edit;
 use crate::Fix;
 use crate::Locator;
+use crate::OldDiagnostic;
 use crate::checkers::logical_lines::expand_indent;
 use crate::line_width::IndentWidth;
 use crate::rules::pycodestyle::helpers::is_non_logical_token;
@@ -721,7 +721,7 @@ impl<'a> BlankLinesChecker<'a> {
     }
 
     /// E301, E302, E303, E304, E305, E306
-    pub(crate) fn check_lines(&self, tokens: &Tokens, diagnostics: &mut Vec<Diagnostic>) {
+    pub(crate) fn check_lines(&self, tokens: &Tokens, diagnostics: &mut Vec<OldDiagnostic>) {
         let mut prev_indent_length: Option<usize> = None;
         let mut prev_logical_line: Option<LogicalLineInfo> = None;
         let mut state = BlankLinesState::default();
@@ -824,7 +824,7 @@ impl<'a> BlankLinesChecker<'a> {
         line: &LogicalLineInfo,
         state: &BlankLinesState,
         prev_indent_length: Option<usize>,
-        diagnostics: &mut Vec<Diagnostic>,
+        diagnostics: &mut Vec<OldDiagnostic>,
     ) {
         if line.preceding_blank_lines == 0
             // Only applies to methods.
@@ -842,7 +842,8 @@ impl<'a> BlankLinesChecker<'a> {
             && !self.source_type.is_stub()
         {
             // E301
-            let mut diagnostic = Diagnostic::new(BlankLineBetweenMethods, line.first_token_range);
+            let mut diagnostic =
+                OldDiagnostic::new(BlankLineBetweenMethods, line.first_token_range);
             diagnostic.set_fix(Fix::safe_edit(Edit::insertion(
                 self.stylist.line_ending().to_string(),
                 self.locator.line_start(state.last_non_comment_line_end),
@@ -896,7 +897,7 @@ impl<'a> BlankLinesChecker<'a> {
             && !line.is_beginning_of_cell
         {
             // E302
-            let mut diagnostic = Diagnostic::new(
+            let mut diagnostic = OldDiagnostic::new(
                 BlankLinesTopLevel {
                     actual_blank_lines: line.preceding_blank_lines.count(),
                     expected_blank_lines: expected_blank_lines_before_definition,
@@ -940,7 +941,7 @@ impl<'a> BlankLinesChecker<'a> {
 
         if line.blank_lines > max_blank_lines {
             // E303
-            let mut diagnostic = Diagnostic::new(
+            let mut diagnostic = OldDiagnostic::new(
                 TooManyBlankLines {
                     actual_blank_lines: line.blank_lines.count(),
                 },
@@ -966,7 +967,7 @@ impl<'a> BlankLinesChecker<'a> {
             && line.preceding_blank_lines > 0
         {
             // E304
-            let mut diagnostic = Diagnostic::new(
+            let mut diagnostic = OldDiagnostic::new(
                 BlankLineAfterDecorator {
                     actual_blank_lines: line.preceding_blank_lines.count(),
                 },
@@ -1013,7 +1014,7 @@ impl<'a> BlankLinesChecker<'a> {
             && !line.is_beginning_of_cell
         {
             // E305
-            let mut diagnostic = Diagnostic::new(
+            let mut diagnostic = OldDiagnostic::new(
                 BlankLinesAfterFunctionOrClass {
                     actual_blank_lines: line.preceding_blank_lines.count(),
                 },
@@ -1057,7 +1058,7 @@ impl<'a> BlankLinesChecker<'a> {
         {
             // E306
             let mut diagnostic =
-                Diagnostic::new(BlankLinesBeforeNestedDefinition, line.first_token_range);
+                OldDiagnostic::new(BlankLinesBeforeNestedDefinition, line.first_token_range);
 
             diagnostic.set_fix(Fix::safe_edit(Edit::insertion(
                 self.stylist.line_ending().to_string(),

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/compound_statements.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/compound_statements.rs
@@ -7,7 +7,7 @@ use ruff_text_size::{Ranged, TextSize};
 
 use crate::Locator;
 use crate::{AlwaysFixableViolation, Violation};
-use crate::{Diagnostic, Edit, Fix};
+use crate::{Edit, Fix, OldDiagnostic};
 
 /// ## What it does
 /// Checks for compound statements (multiple statements on the same line).
@@ -98,7 +98,7 @@ impl AlwaysFixableViolation for UselessSemicolon {
 
 /// E701, E702, E703
 pub(crate) fn compound_statements(
-    diagnostics: &mut Vec<Diagnostic>,
+    diagnostics: &mut Vec<OldDiagnostic>,
     tokens: &Tokens,
     locator: &Locator,
     indexer: &Indexer,
@@ -167,7 +167,7 @@ pub(crate) fn compound_statements(
                                 !has_non_trivia_tokens_till(token_iter.clone(), cell_range.end())
                             }))
                     {
-                        let mut diagnostic = Diagnostic::new(UselessSemicolon, range);
+                        let mut diagnostic = OldDiagnostic::new(UselessSemicolon, range);
                         diagnostic.set_fix(Fix::safe_edit(Edit::deletion(
                             indexer
                                 .preceded_by_continuations(range.start(), locator.contents())
@@ -224,7 +224,10 @@ pub(crate) fn compound_statements(
             | TokenKind::NonLogicalNewline => {}
             _ => {
                 if let Some(range) = semi {
-                    diagnostics.push(Diagnostic::new(MultipleStatementsOnOneLineSemicolon, range));
+                    diagnostics.push(OldDiagnostic::new(
+                        MultipleStatementsOnOneLineSemicolon,
+                        range,
+                    ));
 
                     // Reset.
                     semi = None;
@@ -232,7 +235,7 @@ pub(crate) fn compound_statements(
                 }
 
                 if let Some(range) = colon {
-                    diagnostics.push(Diagnostic::new(MultipleStatementsOnOneLineColon, range));
+                    diagnostics.push(OldDiagnostic::new(MultipleStatementsOnOneLineColon, range));
 
                     // Reset.
                     colon = None;

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/doc_line_too_long.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/doc_line_too_long.rs
@@ -4,7 +4,7 @@ use ruff_source_file::Line;
 
 use crate::rules::pycodestyle::overlong::Overlong;
 use crate::settings::LinterSettings;
-use crate::{Diagnostic, Violation};
+use crate::{OldDiagnostic, Violation};
 
 /// ## What it does
 /// Checks for doc lines that exceed the specified maximum character length.
@@ -86,7 +86,7 @@ pub(crate) fn doc_line_too_long(
     line: &Line,
     comment_ranges: &CommentRanges,
     settings: &LinterSettings,
-) -> Option<Diagnostic> {
+) -> Option<OldDiagnostic> {
     let limit = settings.pycodestyle.max_doc_length?;
     Overlong::try_from_line(
         line,
@@ -100,7 +100,7 @@ pub(crate) fn doc_line_too_long(
         settings.tab_size,
     )
     .map(|overlong| {
-        Diagnostic::new(
+        OldDiagnostic::new(
             DocLineTooLong(overlong.width(), limit.value() as usize),
             overlong.range(),
         )

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/line_too_long.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/line_too_long.rs
@@ -4,7 +4,7 @@ use ruff_source_file::Line;
 
 use crate::rules::pycodestyle::overlong::Overlong;
 use crate::settings::LinterSettings;
-use crate::{Diagnostic, Violation};
+use crate::{OldDiagnostic, Violation};
 
 /// ## What it does
 /// Checks for lines that exceed the specified maximum character length.
@@ -84,7 +84,7 @@ pub(crate) fn line_too_long(
     line: &Line,
     comment_ranges: &CommentRanges,
     settings: &LinterSettings,
-) -> Option<Diagnostic> {
+) -> Option<OldDiagnostic> {
     let limit = settings.pycodestyle.max_line_length;
 
     Overlong::try_from_line(
@@ -99,7 +99,7 @@ pub(crate) fn line_too_long(
         settings.tab_size,
     )
     .map(|overlong| {
-        Diagnostic::new(
+        OldDiagnostic::new(
             LineTooLong(overlong.width(), limit.value() as usize),
             overlong.range(),
         )

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/extraneous_whitespace.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/extraneous_whitespace.rs
@@ -3,9 +3,9 @@ use ruff_python_parser::TokenKind;
 use ruff_text_size::{Ranged, TextRange};
 
 use crate::AlwaysFixableViolation;
-use crate::Diagnostic;
 use crate::Edit;
 use crate::Fix;
+use crate::OldDiagnostic;
 use crate::checkers::logical_lines::LogicalLinesContext;
 
 use super::{LogicalLine, Whitespace};
@@ -165,7 +165,7 @@ pub(crate) fn extraneous_whitespace(line: &LogicalLine, context: &mut LogicalLin
                 BracketOrPunctuation::OpenBracket(symbol) if symbol != '{' || fstrings == 0 => {
                     let (trailing, trailing_len) = line.trailing_whitespace(token);
                     if !matches!(trailing, Whitespace::None) {
-                        let mut diagnostic = Diagnostic::new(
+                        let mut diagnostic = OldDiagnostic::new(
                             WhitespaceAfterOpenBracket { symbol },
                             TextRange::at(token.end(), trailing_len),
                         );
@@ -179,7 +179,7 @@ pub(crate) fn extraneous_whitespace(line: &LogicalLine, context: &mut LogicalLin
                         if let (Whitespace::Single | Whitespace::Many | Whitespace::Tab, offset) =
                             line.leading_whitespace(token)
                         {
-                            let mut diagnostic = Diagnostic::new(
+                            let mut diagnostic = OldDiagnostic::new(
                                 WhitespaceBeforeCloseBracket { symbol },
                                 TextRange::at(token.start() - offset, offset),
                             );
@@ -205,7 +205,7 @@ pub(crate) fn extraneous_whitespace(line: &LogicalLine, context: &mut LogicalLin
                                 // If we're in the second half of a double colon, disallow
                                 // any whitespace (e.g., `foo[1: :2]` or `foo[1 : : 2]`).
                                 if matches!(prev_token, Some(TokenKind::Colon)) {
-                                    let mut diagnostic = Diagnostic::new(
+                                    let mut diagnostic = OldDiagnostic::new(
                                         WhitespaceBeforePunctuation { symbol },
                                         TextRange::at(token.start() - offset, offset),
                                     );
@@ -220,7 +220,7 @@ pub(crate) fn extraneous_whitespace(line: &LogicalLine, context: &mut LogicalLin
                                     // Or `foo[index :, 2]`, but not `foo[index  :, 2]`.
                                     if let (Whitespace::Many | Whitespace::Tab, offset) = whitespace
                                     {
-                                        let mut diagnostic = Diagnostic::new(
+                                        let mut diagnostic = OldDiagnostic::new(
                                             WhitespaceBeforePunctuation { symbol },
                                             TextRange::at(token.start() - offset, offset),
                                         );
@@ -245,7 +245,7 @@ pub(crate) fn extraneous_whitespace(line: &LogicalLine, context: &mut LogicalLin
                                     // whitespace before the colon and so should the fix
                                     if let (Whitespace::Many | Whitespace::Tab, offset) = whitespace
                                     {
-                                        let mut diagnostic = Diagnostic::new(
+                                        let mut diagnostic = OldDiagnostic::new(
                                             WhitespaceBeforePunctuation { symbol },
                                             TextRange::at(token.start() - offset, offset),
                                         );
@@ -262,7 +262,7 @@ pub(crate) fn extraneous_whitespace(line: &LogicalLine, context: &mut LogicalLin
                                         .filter(|next| matches!(next.kind(), TokenKind::Colon))
                                         .unwrap_or(&token);
                                     if line.trailing_whitespace(token) != whitespace {
-                                        let mut diagnostic = Diagnostic::new(
+                                        let mut diagnostic = OldDiagnostic::new(
                                             WhitespaceBeforePunctuation { symbol },
                                             TextRange::at(token.start() - offset, offset),
                                         );
@@ -280,7 +280,7 @@ pub(crate) fn extraneous_whitespace(line: &LogicalLine, context: &mut LogicalLin
                                     // Avoid removing any whitespace for f-string debug expressions.
                                     continue;
                                 }
-                                let mut diagnostic = Diagnostic::new(
+                                let mut diagnostic = OldDiagnostic::new(
                                     WhitespaceBeforePunctuation { symbol },
                                     TextRange::at(token.start() - offset, offset),
                                 );

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/indentation.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/indentation.rs
@@ -2,7 +2,7 @@ use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_python_parser::TokenKind;
 use ruff_text_size::TextRange;
 
-use crate::Diagnostic;
+use crate::OldDiagnostic;
 use crate::Violation;
 
 use super::LogicalLine;
@@ -264,19 +264,19 @@ pub(crate) fn indentation(
     prev_indent_level: Option<usize>,
     indent_size: usize,
     range: TextRange,
-) -> Vec<Diagnostic> {
+) -> Vec<OldDiagnostic> {
     let mut diagnostics = vec![];
 
     if indent_level % indent_size != 0 {
         diagnostics.push(if logical_line.is_comment_only() {
-            Diagnostic::new(
+            OldDiagnostic::new(
                 IndentationWithInvalidMultipleComment {
                     indent_width: indent_size,
                 },
                 range,
             )
         } else {
-            Diagnostic::new(
+            OldDiagnostic::new(
                 IndentationWithInvalidMultiple {
                     indent_width: indent_size,
                 },
@@ -290,24 +290,24 @@ pub(crate) fn indentation(
 
     if indent_expect && indent_level <= prev_indent_level.unwrap_or(0) {
         diagnostics.push(if logical_line.is_comment_only() {
-            Diagnostic::new(NoIndentedBlockComment, range)
+            OldDiagnostic::new(NoIndentedBlockComment, range)
         } else {
-            Diagnostic::new(NoIndentedBlock, range)
+            OldDiagnostic::new(NoIndentedBlock, range)
         });
     } else if !indent_expect
         && prev_indent_level.is_some_and(|prev_indent_level| indent_level > prev_indent_level)
     {
         diagnostics.push(if logical_line.is_comment_only() {
-            Diagnostic::new(UnexpectedIndentationComment, range)
+            OldDiagnostic::new(UnexpectedIndentationComment, range)
         } else {
-            Diagnostic::new(UnexpectedIndentation, range)
+            OldDiagnostic::new(UnexpectedIndentation, range)
         });
     }
     if indent_expect {
         let expected_indent_amount = if indent_char == '\t' { 8 } else { 4 };
         let expected_indent_level = prev_indent_level.unwrap_or(0) + expected_indent_amount;
         if indent_level > expected_indent_level {
-            diagnostics.push(Diagnostic::new(
+            diagnostics.push(OldDiagnostic::new(
                 OverIndented {
                     is_comment: logical_line.is_comment_only(),
                 },

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/missing_whitespace.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/missing_whitespace.rs
@@ -4,7 +4,7 @@ use ruff_text_size::Ranged;
 
 use crate::Edit;
 use crate::checkers::logical_lines::LogicalLinesContext;
-use crate::{AlwaysFixableViolation, Diagnostic, Fix};
+use crate::{AlwaysFixableViolation, Fix, OldDiagnostic};
 
 use super::{DefinitionState, LogicalLine};
 
@@ -104,7 +104,7 @@ pub(crate) fn missing_whitespace(line: &LogicalLine, context: &mut LogicalLinesC
                     }
 
                     let diagnostic =
-                        Diagnostic::new(MissingWhitespace { token: kind }, token.range());
+                        OldDiagnostic::new(MissingWhitespace { token: kind }, token.range());
                     let fix = Fix::safe_edit(Edit::insertion(" ".to_string(), token.end()));
                     context.push_diagnostic(diagnostic.with_fix(fix));
                 }

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/missing_whitespace_after_keyword.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/missing_whitespace_after_keyword.rs
@@ -4,7 +4,7 @@ use ruff_text_size::Ranged;
 
 use crate::checkers::logical_lines::LogicalLinesContext;
 use crate::rules::pycodestyle::rules::logical_lines::LogicalLine;
-use crate::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
+use crate::{AlwaysFixableViolation, Edit, Fix, OldDiagnostic};
 
 /// ## What it does
 /// Checks for missing whitespace after keywords.
@@ -71,7 +71,7 @@ pub(crate) fn missing_whitespace_after_keyword(
                 ))
             && tok0.end() == tok1.start()
         {
-            let mut diagnostic = Diagnostic::new(MissingWhitespaceAfterKeyword, tok0.range());
+            let mut diagnostic = OldDiagnostic::new(MissingWhitespaceAfterKeyword, tok0.range());
             diagnostic.set_fix(Fix::safe_edit(Edit::insertion(" ".to_string(), tok0.end())));
             context.push_diagnostic(diagnostic);
         }

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/missing_whitespace_around_operator.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/missing_whitespace_around_operator.rs
@@ -5,7 +5,7 @@ use ruff_text_size::{Ranged, TextRange};
 use crate::checkers::logical_lines::LogicalLinesContext;
 use crate::rules::pycodestyle::helpers::is_non_logical_token;
 use crate::rules::pycodestyle::rules::logical_lines::{DefinitionState, LogicalLine};
-use crate::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
+use crate::{AlwaysFixableViolation, Edit, Fix, OldDiagnostic};
 
 /// ## What it does
 /// Checks for missing whitespace around all operators.
@@ -314,15 +314,15 @@ impl From<bool> for NeedsSpace {
     }
 }
 
-fn diagnostic_kind_for_operator(operator: TokenKind, range: TextRange) -> Diagnostic {
+fn diagnostic_kind_for_operator(operator: TokenKind, range: TextRange) -> OldDiagnostic {
     if operator == TokenKind::Percent {
-        Diagnostic::new(MissingWhitespaceAroundModuloOperator, range)
+        OldDiagnostic::new(MissingWhitespaceAroundModuloOperator, range)
     } else if operator.is_bitwise_or_shift() {
-        Diagnostic::new(MissingWhitespaceAroundBitwiseOrShiftOperator, range)
+        OldDiagnostic::new(MissingWhitespaceAroundBitwiseOrShiftOperator, range)
     } else if operator.is_arithmetic() {
-        Diagnostic::new(MissingWhitespaceAroundArithmeticOperator, range)
+        OldDiagnostic::new(MissingWhitespaceAroundArithmeticOperator, range)
     } else {
-        Diagnostic::new(MissingWhitespaceAroundOperator, range)
+        OldDiagnostic::new(MissingWhitespaceAroundOperator, range)
     }
 }
 

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/redundant_backslash.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/redundant_backslash.rs
@@ -6,7 +6,7 @@ use ruff_text_size::{Ranged, TextRange, TextSize};
 
 use crate::Locator;
 use crate::checkers::logical_lines::LogicalLinesContext;
-use crate::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
+use crate::{AlwaysFixableViolation, Edit, Fix, OldDiagnostic};
 
 use super::LogicalLine;
 
@@ -75,7 +75,7 @@ pub(crate) fn redundant_backslash(
                     for continuation_line in &continuation_lines[start_index..end_index] {
                         let backslash_end = locator.line_end(*continuation_line);
                         let backslash_start = backslash_end - TextSize::new(1);
-                        let mut diagnostic = Diagnostic::new(
+                        let mut diagnostic = OldDiagnostic::new(
                             RedundantBackslash,
                             TextRange::new(backslash_start, backslash_end),
                         );

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/space_around_operator.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/space_around_operator.rs
@@ -3,7 +3,7 @@ use ruff_python_parser::TokenKind;
 use ruff_text_size::{Ranged, TextRange};
 
 use crate::checkers::logical_lines::LogicalLinesContext;
-use crate::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
+use crate::{AlwaysFixableViolation, Edit, Fix, OldDiagnostic};
 
 use super::{LogicalLine, Whitespace};
 
@@ -206,7 +206,7 @@ pub(crate) fn space_around_operator(line: &LogicalLine, context: &mut LogicalLin
             if !after_operator {
                 match line.leading_whitespace(token) {
                     (Whitespace::Tab, offset) => {
-                        let mut diagnostic = Diagnostic::new(
+                        let mut diagnostic = OldDiagnostic::new(
                             TabBeforeOperator,
                             TextRange::at(token.start() - offset, offset),
                         );
@@ -217,7 +217,7 @@ pub(crate) fn space_around_operator(line: &LogicalLine, context: &mut LogicalLin
                         context.push_diagnostic(diagnostic);
                     }
                     (Whitespace::Many, offset) => {
-                        let mut diagnostic = Diagnostic::new(
+                        let mut diagnostic = OldDiagnostic::new(
                             MultipleSpacesBeforeOperator,
                             TextRange::at(token.start() - offset, offset),
                         );
@@ -234,7 +234,7 @@ pub(crate) fn space_around_operator(line: &LogicalLine, context: &mut LogicalLin
             match line.trailing_whitespace(token) {
                 (Whitespace::Tab, len) => {
                     let mut diagnostic =
-                        Diagnostic::new(TabAfterOperator, TextRange::at(token.end(), len));
+                        OldDiagnostic::new(TabAfterOperator, TextRange::at(token.end(), len));
                     diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                         " ".to_string(),
                         TextRange::at(token.end(), len),
@@ -242,7 +242,7 @@ pub(crate) fn space_around_operator(line: &LogicalLine, context: &mut LogicalLin
                     context.push_diagnostic(diagnostic);
                 }
                 (Whitespace::Many, len) => {
-                    let mut diagnostic = Diagnostic::new(
+                    let mut diagnostic = OldDiagnostic::new(
                         MultipleSpacesAfterOperator,
                         TextRange::at(token.end(), len),
                     );
@@ -267,7 +267,7 @@ pub(crate) fn space_after_comma(line: &LogicalLine, context: &mut LogicalLinesCo
             match line.trailing_whitespace(token) {
                 (Whitespace::Tab, len) => {
                     let mut diagnostic =
-                        Diagnostic::new(TabAfterComma, TextRange::at(token.end(), len));
+                        OldDiagnostic::new(TabAfterComma, TextRange::at(token.end(), len));
                     diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                         " ".to_string(),
                         TextRange::at(token.end(), len),
@@ -275,8 +275,10 @@ pub(crate) fn space_after_comma(line: &LogicalLine, context: &mut LogicalLinesCo
                     context.push_diagnostic(diagnostic);
                 }
                 (Whitespace::Many, len) => {
-                    let mut diagnostic =
-                        Diagnostic::new(MultipleSpacesAfterComma, TextRange::at(token.end(), len));
+                    let mut diagnostic = OldDiagnostic::new(
+                        MultipleSpacesAfterComma,
+                        TextRange::at(token.end(), len),
+                    );
                     diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                         " ".to_string(),
                         TextRange::at(token.end(), len),

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/whitespace_around_keywords.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/whitespace_around_keywords.rs
@@ -2,7 +2,7 @@ use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_text_size::{Ranged, TextRange};
 
 use crate::checkers::logical_lines::LogicalLinesContext;
-use crate::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
+use crate::{AlwaysFixableViolation, Edit, Fix, OldDiagnostic};
 
 use super::{LogicalLine, Whitespace};
 
@@ -133,7 +133,7 @@ pub(crate) fn whitespace_around_keywords(line: &LogicalLine, context: &mut Logic
                 match line.leading_whitespace(token) {
                     (Whitespace::Tab, offset) => {
                         let start = token.start();
-                        let mut diagnostic = Diagnostic::new(
+                        let mut diagnostic = OldDiagnostic::new(
                             TabBeforeKeyword,
                             TextRange::at(start - offset, offset),
                         );
@@ -145,7 +145,7 @@ pub(crate) fn whitespace_around_keywords(line: &LogicalLine, context: &mut Logic
                     }
                     (Whitespace::Many, offset) => {
                         let start = token.start();
-                        let mut diagnostic = Diagnostic::new(
+                        let mut diagnostic = OldDiagnostic::new(
                             MultipleSpacesBeforeKeyword,
                             TextRange::at(start - offset, offset),
                         );
@@ -162,7 +162,7 @@ pub(crate) fn whitespace_around_keywords(line: &LogicalLine, context: &mut Logic
             match line.trailing_whitespace(token) {
                 (Whitespace::Tab, len) => {
                     let mut diagnostic =
-                        Diagnostic::new(TabAfterKeyword, TextRange::at(token.end(), len));
+                        OldDiagnostic::new(TabAfterKeyword, TextRange::at(token.end(), len));
                     diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                         " ".to_string(),
                         TextRange::at(token.end(), len),
@@ -170,7 +170,7 @@ pub(crate) fn whitespace_around_keywords(line: &LogicalLine, context: &mut Logic
                     context.push_diagnostic(diagnostic);
                 }
                 (Whitespace::Many, len) => {
-                    let mut diagnostic = Diagnostic::new(
+                    let mut diagnostic = OldDiagnostic::new(
                         MultipleSpacesAfterKeyword,
                         TextRange::at(token.end(), len),
                     );

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/whitespace_around_named_parameter_equals.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/whitespace_around_named_parameter_equals.rs
@@ -4,7 +4,7 @@ use ruff_text_size::{Ranged, TextRange, TextSize};
 
 use crate::checkers::logical_lines::LogicalLinesContext;
 use crate::rules::pycodestyle::rules::logical_lines::{DefinitionState, LogicalLine};
-use crate::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
+use crate::{AlwaysFixableViolation, Edit, Fix, OldDiagnostic};
 
 /// ## What it does
 /// Checks for missing whitespace around the equals sign in an unannotated
@@ -126,7 +126,7 @@ pub(crate) fn whitespace_around_named_parameter_equals(
                     let start = token.start();
                     if start == prev_end && prev_end != TextSize::new(0) {
                         let mut diagnostic =
-                            Diagnostic::new(MissingWhitespaceAroundParameterEquals, token.range);
+                            OldDiagnostic::new(MissingWhitespaceAroundParameterEquals, token.range);
                         diagnostic.set_fix(Fix::safe_edit(Edit::insertion(
                             " ".to_string(),
                             token.start(),
@@ -141,7 +141,7 @@ pub(crate) fn whitespace_around_named_parameter_equals(
                             let next_start = next.start();
 
                             if next_start == token.end() {
-                                let mut diagnostic = Diagnostic::new(
+                                let mut diagnostic = OldDiagnostic::new(
                                     MissingWhitespaceAroundParameterEquals,
                                     token.range,
                                 );
@@ -157,7 +157,7 @@ pub(crate) fn whitespace_around_named_parameter_equals(
                 } else {
                     // If there's space between the preceding token and the equals sign, report it.
                     if token.start() != prev_end {
-                        let mut diagnostic = Diagnostic::new(
+                        let mut diagnostic = OldDiagnostic::new(
                             UnexpectedSpacesAroundKeywordParameterEquals,
                             TextRange::new(prev_end, token.start()),
                         );
@@ -171,7 +171,7 @@ pub(crate) fn whitespace_around_named_parameter_equals(
                             iter.next();
                         } else {
                             if next.start() != token.end() {
-                                let mut diagnostic = Diagnostic::new(
+                                let mut diagnostic = OldDiagnostic::new(
                                     UnexpectedSpacesAroundKeywordParameterEquals,
                                     TextRange::new(token.end(), next.start()),
                                 );

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/whitespace_before_comment.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/whitespace_before_comment.rs
@@ -7,7 +7,7 @@ use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 use crate::Locator;
 use crate::checkers::logical_lines::LogicalLinesContext;
 use crate::rules::pycodestyle::rules::logical_lines::LogicalLine;
-use crate::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
+use crate::{AlwaysFixableViolation, Edit, Fix, OldDiagnostic};
 
 /// ## What it does
 /// Checks if inline comments are separated by at least two spaces.
@@ -185,7 +185,7 @@ pub(crate) fn whitespace_before_comment(
             let is_inline_comment = !line_text.trim_whitespace().is_empty();
             if is_inline_comment {
                 if range.start() - prev_end < "  ".text_len() {
-                    let mut diagnostic = Diagnostic::new(
+                    let mut diagnostic = OldDiagnostic::new(
                         TooFewSpacesBeforeInlineComment,
                         TextRange::new(prev_end, range.start()),
                     );
@@ -210,7 +210,7 @@ pub(crate) fn whitespace_before_comment(
 
             if is_inline_comment {
                 if bad_prefix.is_some() || comment.chars().next().is_some_and(char::is_whitespace) {
-                    let mut diagnostic = Diagnostic::new(NoSpaceAfterInlineComment, range);
+                    let mut diagnostic = OldDiagnostic::new(NoSpaceAfterInlineComment, range);
                     diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                         format_leading_space(token_text),
                         range,
@@ -220,7 +220,7 @@ pub(crate) fn whitespace_before_comment(
             } else if let Some(bad_prefix) = bad_prefix {
                 if bad_prefix != '!' || !line.is_start_of_file() {
                     if bad_prefix != '#' {
-                        let mut diagnostic = Diagnostic::new(NoSpaceAfterBlockComment, range);
+                        let mut diagnostic = OldDiagnostic::new(NoSpaceAfterBlockComment, range);
                         diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                             format_leading_space(token_text),
                             range,
@@ -228,7 +228,7 @@ pub(crate) fn whitespace_before_comment(
                         context.push_diagnostic(diagnostic);
                     } else if !comment.is_empty() {
                         let mut diagnostic =
-                            Diagnostic::new(MultipleLeadingHashesForBlockComment, range);
+                            OldDiagnostic::new(MultipleLeadingHashesForBlockComment, range);
                         diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                             format_leading_hashes(token_text),
                             range,

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/whitespace_before_parameters.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/whitespace_before_parameters.rs
@@ -4,7 +4,7 @@ use ruff_text_size::{Ranged, TextRange, TextSize};
 
 use crate::checkers::logical_lines::LogicalLinesContext;
 use crate::rules::pycodestyle::rules::logical_lines::LogicalLine;
-use crate::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
+use crate::{AlwaysFixableViolation, Edit, Fix, OldDiagnostic};
 
 /// ## What it does
 /// Checks for extraneous whitespace immediately preceding an open parenthesis
@@ -76,7 +76,7 @@ pub(crate) fn whitespace_before_parameters(line: &LogicalLine, context: &mut Log
             let end = token.end() - TextSize::from(1);
             let kind: WhitespaceBeforeParameters = WhitespaceBeforeParameters { bracket: kind };
 
-            let mut diagnostic = Diagnostic::new(kind, TextRange::new(start, end));
+            let mut diagnostic = OldDiagnostic::new(kind, TextRange::new(start, end));
             diagnostic.set_fix(Fix::safe_edit(Edit::deletion(start, end)));
             context.push_diagnostic(diagnostic);
         }

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/missing_newline_at_end_of_file.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/missing_newline_at_end_of_file.rs
@@ -3,7 +3,7 @@ use ruff_python_codegen::Stylist;
 use ruff_text_size::{TextLen, TextRange};
 
 use crate::Locator;
-use crate::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
+use crate::{AlwaysFixableViolation, Edit, Fix, OldDiagnostic};
 
 /// ## What it does
 /// Checks for files missing a new line at the end of the file.
@@ -40,7 +40,7 @@ impl AlwaysFixableViolation for MissingNewlineAtEndOfFile {
 pub(crate) fn no_newline_at_end_of_file(
     locator: &Locator,
     stylist: &Stylist,
-) -> Option<Diagnostic> {
+) -> Option<OldDiagnostic> {
     let source = locator.contents();
 
     // Ignore empty and BOM only files.
@@ -51,7 +51,7 @@ pub(crate) fn no_newline_at_end_of_file(
     if !source.ends_with(['\n', '\r']) {
         let range = TextRange::empty(locator.contents().text_len());
 
-        let mut diagnostic = Diagnostic::new(MissingNewlineAtEndOfFile, range);
+        let mut diagnostic = OldDiagnostic::new(MissingNewlineAtEndOfFile, range);
         diagnostic.set_fix(Fix::safe_edit(Edit::insertion(
             stylist.line_ending().to_string(),
             range.start(),

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/mixed_spaces_and_tabs.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/mixed_spaces_and_tabs.rs
@@ -4,7 +4,7 @@ use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_python_trivia::leading_indentation;
 use ruff_source_file::Line;
 
-use crate::{Diagnostic, Violation};
+use crate::{OldDiagnostic, Violation};
 
 /// ## What it does
 /// Checks for mixed tabs and spaces in indentation.
@@ -37,11 +37,11 @@ impl Violation for MixedSpacesAndTabs {
 }
 
 /// E101
-pub(crate) fn mixed_spaces_and_tabs(line: &Line) -> Option<Diagnostic> {
+pub(crate) fn mixed_spaces_and_tabs(line: &Line) -> Option<OldDiagnostic> {
     let indent = leading_indentation(line.as_str());
 
     if indent.contains(' ') && indent.contains('\t') {
-        Some(Diagnostic::new(
+        Some(OldDiagnostic::new(
             MixedSpacesAndTabs,
             TextRange::at(line.start(), indent.text_len()),
         ))

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/tab_indentation.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/tab_indentation.rs
@@ -4,7 +4,7 @@ use ruff_source_file::LineRanges;
 use ruff_text_size::{TextRange, TextSize};
 
 use crate::Locator;
-use crate::{Diagnostic, Violation};
+use crate::{OldDiagnostic, Violation};
 
 /// ## What it does
 /// Checks for indentation that uses tabs.
@@ -34,7 +34,7 @@ impl Violation for TabIndentation {
 
 /// W191
 pub(crate) fn tab_indentation(
-    diagnostics: &mut Vec<Diagnostic>,
+    diagnostics: &mut Vec<OldDiagnostic>,
     locator: &Locator,
     indexer: &Indexer,
 ) {
@@ -46,7 +46,7 @@ pub(crate) fn tab_indentation(
 
         // Determine whether the tab is part of the line's indentation.
         if let Some(indent) = tab_indentation_at_line_start(range.start(), locator, indexer) {
-            diagnostics.push(Diagnostic::new(TabIndentation, indent));
+            diagnostics.push(OldDiagnostic::new(TabIndentation, indent));
         }
 
         // Advance to the next line.

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/too_many_newlines_at_end_of_file.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/too_many_newlines_at_end_of_file.rs
@@ -6,7 +6,7 @@ use ruff_notebook::CellOffsets;
 use ruff_python_parser::{Token, TokenKind, Tokens};
 use ruff_text_size::{Ranged, TextRange, TextSize};
 
-use crate::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
+use crate::{AlwaysFixableViolation, Edit, Fix, OldDiagnostic};
 
 /// ## What it does
 /// Checks for files with multiple trailing blank lines.
@@ -59,7 +59,7 @@ impl AlwaysFixableViolation for TooManyNewlinesAtEndOfFile {
 
 /// W391
 pub(crate) fn too_many_newlines_at_end_of_file(
-    diagnostics: &mut Vec<Diagnostic>,
+    diagnostics: &mut Vec<OldDiagnostic>,
     tokens: &Tokens,
     cell_offsets: Option<&CellOffsets>,
 ) {
@@ -76,7 +76,7 @@ pub(crate) fn too_many_newlines_at_end_of_file(
 fn notebook_newline_diagnostics<'a>(
     mut tokens_iter: Peekable<impl Iterator<Item = &'a Token>>,
     cell_offsets: &CellOffsets,
-) -> Vec<Diagnostic> {
+) -> Vec<OldDiagnostic> {
     let mut results = Vec::new();
     let offset_iter = cell_offsets.iter().rev();
 
@@ -101,7 +101,7 @@ fn notebook_newline_diagnostics<'a>(
 fn newline_diagnostic<'a>(
     tokens_iter: &mut Peekable<impl Iterator<Item = &'a Token>>,
     in_notebook: bool,
-) -> Option<Diagnostic> {
+) -> Option<OldDiagnostic> {
     let mut num_trailing_newlines: u32 = 0;
     let mut newline_range_start: Option<TextSize> = None;
     let mut newline_range_end: Option<TextSize> = None;
@@ -137,7 +137,7 @@ fn newline_diagnostic<'a>(
 
     let diagnostic_range = TextRange::new(start, end);
     Some(
-        Diagnostic::new(
+        OldDiagnostic::new(
             TooManyNewlinesAtEndOfFile {
                 num_trailing_newlines,
                 in_notebook,

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/trailing_whitespace.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/trailing_whitespace.rs
@@ -6,7 +6,7 @@ use ruff_text_size::{TextLen, TextRange, TextSize};
 use crate::Locator;
 use crate::registry::Rule;
 use crate::settings::LinterSettings;
-use crate::{AlwaysFixableViolation, Applicability, Diagnostic, Edit, Fix};
+use crate::{AlwaysFixableViolation, Applicability, Edit, Fix, OldDiagnostic};
 
 /// ## What it does
 /// Checks for superfluous trailing whitespace.
@@ -78,7 +78,7 @@ pub(crate) fn trailing_whitespace(
     locator: &Locator,
     indexer: &Indexer,
     settings: &LinterSettings,
-) -> Option<Diagnostic> {
+) -> Option<OldDiagnostic> {
     let whitespace_len: TextSize = line
         .chars()
         .rev()
@@ -95,7 +95,7 @@ pub(crate) fn trailing_whitespace(
         };
         if range == line.range() {
             if settings.rules.enabled(Rule::BlankLineWithWhitespace) {
-                let mut diagnostic = Diagnostic::new(BlankLineWithWhitespace, range);
+                let mut diagnostic = OldDiagnostic::new(BlankLineWithWhitespace, range);
                 // Remove any preceding continuations, to avoid introducing a potential
                 // syntax error.
                 diagnostic.set_fix(Fix::applicable_edit(
@@ -110,7 +110,7 @@ pub(crate) fn trailing_whitespace(
                 return Some(diagnostic);
             }
         } else if settings.rules.enabled(Rule::TrailingWhitespace) {
-            let mut diagnostic = Diagnostic::new(TrailingWhitespace, range);
+            let mut diagnostic = OldDiagnostic::new(TrailingWhitespace, range);
             diagnostic.set_fix(Fix::applicable_edit(
                 Edit::range_deletion(range),
                 applicability,

--- a/crates/ruff_linter/src/rules/pygrep_hooks/rules/blanket_noqa.rs
+++ b/crates/ruff_linter/src/rules/pygrep_hooks/rules/blanket_noqa.rs
@@ -4,7 +4,7 @@ use ruff_text_size::{Ranged, TextRange};
 
 use crate::Locator;
 use crate::noqa::{self, Directive, FileNoqaDirectives, NoqaDirectives};
-use crate::{Diagnostic, Edit, Fix, FixAvailability, Violation};
+use crate::{Edit, Fix, FixAvailability, OldDiagnostic, Violation};
 
 /// ## What it does
 /// Check for `noqa` annotations that suppress all diagnostics, as opposed to
@@ -74,14 +74,14 @@ impl Violation for BlanketNOQA {
 
 /// PGH004
 pub(crate) fn blanket_noqa(
-    diagnostics: &mut Vec<Diagnostic>,
+    diagnostics: &mut Vec<OldDiagnostic>,
     noqa_directives: &NoqaDirectives,
     locator: &Locator,
     file_noqa_directives: &FileNoqaDirectives,
 ) {
     for line in file_noqa_directives.lines() {
         if let Directive::All(_) = line.parsed_file_exemption {
-            diagnostics.push(Diagnostic::new(
+            diagnostics.push(OldDiagnostic::new(
                 BlanketNOQA {
                     missing_colon: false,
                     file_exemption: true,
@@ -105,7 +105,7 @@ pub(crate) fn blanket_noqa(
                 // Ex) `# noqa F401`
                 let start = all.end();
                 let end = start + cursor.token_len();
-                let mut diagnostic = Diagnostic::new(
+                let mut diagnostic = OldDiagnostic::new(
                     BlanketNOQA {
                         missing_colon: true,
                         file_exemption: false,
@@ -116,7 +116,7 @@ pub(crate) fn blanket_noqa(
                 diagnostics.push(diagnostic);
             } else {
                 // Otherwise, it looks like an intentional blanket `noqa` annotation.
-                diagnostics.push(Diagnostic::new(
+                diagnostics.push(OldDiagnostic::new(
                     BlanketNOQA {
                         missing_colon: false,
                         file_exemption: false,

--- a/crates/ruff_linter/src/rules/pygrep_hooks/rules/blanket_type_ignore.rs
+++ b/crates/ruff_linter/src/rules/pygrep_hooks/rules/blanket_type_ignore.rs
@@ -9,7 +9,7 @@ use ruff_python_trivia::CommentRanges;
 use ruff_text_size::TextSize;
 
 use crate::Locator;
-use crate::{Diagnostic, Violation};
+use crate::{OldDiagnostic, Violation};
 
 /// ## What it does
 /// Check for `type: ignore` annotations that suppress all type warnings, as
@@ -52,7 +52,7 @@ impl Violation for BlanketTypeIgnore {
 
 /// PGH003
 pub(crate) fn blanket_type_ignore(
-    diagnostics: &mut Vec<Diagnostic>,
+    diagnostics: &mut Vec<OldDiagnostic>,
     comment_ranges: &CommentRanges,
     locator: &Locator,
 ) {
@@ -92,7 +92,7 @@ pub(crate) fn blanket_type_ignore(
             // Match the optional `[...]` tag.
             if let Ok(codes) = parse_type_ignore_tag(comment) {
                 if codes.is_empty() {
-                    diagnostics.push(Diagnostic::new(
+                    diagnostics.push(OldDiagnostic::new(
                         BlanketTypeIgnore,
                         range.add_start(TextSize::try_from(start).unwrap()),
                     ));

--- a/crates/ruff_linter/src/rules/pylint/rules/bidirectional_unicode.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/bidirectional_unicode.rs
@@ -1,7 +1,7 @@
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::Line;
 
-use crate::{Diagnostic, Violation};
+use crate::{OldDiagnostic, Violation};
 
 const BIDI_UNICODE: [char; 10] = [
     '\u{202A}', //{LEFT-TO-RIGHT EMBEDDING}
@@ -53,10 +53,10 @@ impl Violation for BidirectionalUnicode {
 }
 
 /// PLE2502
-pub(crate) fn bidirectional_unicode(line: &Line) -> Vec<Diagnostic> {
+pub(crate) fn bidirectional_unicode(line: &Line) -> Vec<OldDiagnostic> {
     let mut diagnostics = Vec::new();
     if line.contains(BIDI_UNICODE) {
-        diagnostics.push(Diagnostic::new(BidirectionalUnicode, line.full_range()));
+        diagnostics.push(OldDiagnostic::new(BidirectionalUnicode, line.full_range()));
     }
     diagnostics
 }

--- a/crates/ruff_linter/src/rules/pylint/rules/empty_comment.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/empty_comment.rs
@@ -4,7 +4,7 @@ use ruff_source_file::LineRanges;
 use ruff_text_size::{TextRange, TextSize};
 
 use crate::Locator;
-use crate::{Diagnostic, Edit, Fix, FixAvailability, Violation};
+use crate::{Edit, Fix, FixAvailability, OldDiagnostic, Violation};
 
 /// ## What it does
 /// Checks for a # symbol appearing on a line not followed by an actual comment.
@@ -45,7 +45,7 @@ impl Violation for EmptyComment {
 
 /// PLR2044
 pub(crate) fn empty_comments(
-    diagnostics: &mut Vec<Diagnostic>,
+    diagnostics: &mut Vec<OldDiagnostic>,
     comment_ranges: &CommentRanges,
     locator: &Locator,
 ) {
@@ -65,7 +65,7 @@ pub(crate) fn empty_comments(
 }
 
 /// Return a [`Diagnostic`] if the comment at the given [`TextRange`] is empty.
-fn empty_comment(range: TextRange, locator: &Locator) -> Option<Diagnostic> {
+fn empty_comment(range: TextRange, locator: &Locator) -> Option<OldDiagnostic> {
     // Check: is the comment empty?
     if !locator
         .slice(range)
@@ -97,7 +97,7 @@ fn empty_comment(range: TextRange, locator: &Locator) -> Option<Diagnostic> {
         });
 
     Some(
-        Diagnostic::new(EmptyComment, TextRange::new(first_hash_col, line.end())).with_fix(
+        OldDiagnostic::new(EmptyComment, TextRange::new(first_hash_col, line.end())).with_fix(
             Fix::safe_edit(if let Some(deletion_start_col) = deletion_start_col {
                 Edit::deletion(line.start() + deletion_start_col, line.end())
             } else {

--- a/crates/ruff_linter/src/rules/pylint/rules/invalid_string_characters.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/invalid_string_characters.rs
@@ -3,7 +3,7 @@ use ruff_python_parser::{Token, TokenKind};
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 
 use crate::Locator;
-use crate::{Diagnostic, Edit, Fix, FixAvailability, Violation};
+use crate::{Edit, Fix, FixAvailability, OldDiagnostic, Violation};
 
 /// ## What it does
 /// Checks for strings that contain the control character `BS`.
@@ -181,7 +181,7 @@ impl Violation for InvalidCharacterZeroWidthSpace {
 
 /// PLE2510, PLE2512, PLE2513, PLE2514, PLE2515
 pub(crate) fn invalid_string_characters(
-    diagnostics: &mut Vec<Diagnostic>,
+    diagnostics: &mut Vec<OldDiagnostic>,
     token: &Token,
     locator: &Locator,
 ) {
@@ -197,13 +197,13 @@ pub(crate) fn invalid_string_characters(
         let c = match_.chars().next().unwrap();
         let range = TextRange::at(location, c.text_len());
         let (replacement, mut diagnostic) = match c {
-            '\x08' => ("\\b", Diagnostic::new(InvalidCharacterBackspace, range)),
-            '\x1A' => ("\\x1A", Diagnostic::new(InvalidCharacterSub, range)),
-            '\x1B' => ("\\x1B", Diagnostic::new(InvalidCharacterEsc, range)),
-            '\0' => ("\\0", Diagnostic::new(InvalidCharacterNul, range)),
+            '\x08' => ("\\b", OldDiagnostic::new(InvalidCharacterBackspace, range)),
+            '\x1A' => ("\\x1A", OldDiagnostic::new(InvalidCharacterSub, range)),
+            '\x1B' => ("\\x1B", OldDiagnostic::new(InvalidCharacterEsc, range)),
+            '\0' => ("\\0", OldDiagnostic::new(InvalidCharacterNul, range)),
             '\u{200b}' => (
                 "\\u200b",
-                Diagnostic::new(InvalidCharacterZeroWidthSpace, range),
+                OldDiagnostic::new(InvalidCharacterZeroWidthSpace, range),
             ),
             _ => {
                 continue;

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/extraneous_parentheses.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/extraneous_parentheses.rs
@@ -5,7 +5,7 @@ use ruff_python_parser::{Token, TokenKind, Tokens};
 use ruff_text_size::{Ranged, TextRange};
 
 use crate::Locator;
-use crate::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
+use crate::{AlwaysFixableViolation, Edit, Fix, OldDiagnostic};
 
 /// ## What it does
 /// Checks for extraneous parentheses.
@@ -115,7 +115,7 @@ fn match_extraneous_parentheses(tokens: &mut Iter<'_, Token>) -> Option<(TextRan
 
 /// UP034
 pub(crate) fn extraneous_parentheses(
-    diagnostics: &mut Vec<Diagnostic>,
+    diagnostics: &mut Vec<OldDiagnostic>,
     tokens: &Tokens,
     locator: &Locator,
 ) {
@@ -129,7 +129,7 @@ pub(crate) fn extraneous_parentheses(
             continue;
         };
 
-        let mut diagnostic = Diagnostic::new(
+        let mut diagnostic = OldDiagnostic::new(
             ExtraneousParentheses,
             TextRange::new(start_range.start(), end_range.end()),
         );

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_coding_comment.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_coding_comment.rs
@@ -9,7 +9,7 @@ use ruff_source_file::LineRanges;
 use ruff_text_size::{Ranged, TextRange, TextSize};
 
 use crate::Locator;
-use crate::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
+use crate::{AlwaysFixableViolation, Edit, Fix, OldDiagnostic};
 
 /// ## What it does
 /// Checks for unnecessary UTF-8 encoding declarations.
@@ -66,7 +66,7 @@ struct CodingCommentRange {
 
 /// UP009
 pub(crate) fn unnecessary_coding_comment(
-    diagnostics: &mut Vec<Diagnostic>,
+    diagnostics: &mut Vec<OldDiagnostic>,
     locator: &Locator,
     comment_ranges: &CommentRanges,
 ) {
@@ -106,7 +106,7 @@ pub(crate) fn unnecessary_coding_comment(
     }
 
     let fix = Fix::safe_edit(Edit::range_deletion(range.line));
-    let diagnostic = Diagnostic::new(UTF8EncodingDeclaration, range.comment);
+    let diagnostic = OldDiagnostic::new(UTF8EncodingDeclaration, range.comment);
 
     diagnostics.push(diagnostic.with_fix(fix));
 }

--- a/crates/ruff_linter/src/rules/ruff/rules/ambiguous_unicode_character.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/ambiguous_unicode_character.rs
@@ -13,7 +13,7 @@ use crate::registry::AsRule;
 use crate::rules::ruff::rules::Context;
 use crate::rules::ruff::rules::confusables::confusable;
 use crate::settings::LinterSettings;
-use crate::{Diagnostic, Violation};
+use crate::{OldDiagnostic, Violation};
 
 /// ## What it does
 /// Checks for ambiguous Unicode characters in strings.
@@ -176,7 +176,7 @@ impl Violation for AmbiguousUnicodeCharacterComment {
 
 /// RUF003
 pub(crate) fn ambiguous_unicode_character_comment(
-    diagnostics: &mut Vec<Diagnostic>,
+    diagnostics: &mut Vec<OldDiagnostic>,
     locator: &Locator,
     range: TextRange,
     settings: &LinterSettings,
@@ -342,25 +342,25 @@ impl Candidate {
         }
     }
 
-    fn into_diagnostic(self, context: Context, settings: &LinterSettings) -> Option<Diagnostic> {
+    fn into_diagnostic(self, context: Context, settings: &LinterSettings) -> Option<OldDiagnostic> {
         if !settings.allowed_confusables.contains(&self.confusable) {
             let char_range = TextRange::at(self.offset, self.confusable.text_len());
             let diagnostic = match context {
-                Context::String => Diagnostic::new(
+                Context::String => OldDiagnostic::new(
                     AmbiguousUnicodeCharacterString {
                         confusable: self.confusable,
                         representant: self.representant,
                     },
                     char_range,
                 ),
-                Context::Docstring => Diagnostic::new(
+                Context::Docstring => OldDiagnostic::new(
                     AmbiguousUnicodeCharacterDocstring {
                         confusable: self.confusable,
                         representant: self.representant,
                     },
                     char_range,
                 ),
-                Context::Comment => Diagnostic::new(
+                Context::Comment => OldDiagnostic::new(
                     AmbiguousUnicodeCharacterComment {
                         confusable: self.confusable,
                         representant: self.representant,

--- a/crates/ruff_linter/src/rules/ruff/rules/indented_form_feed.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/indented_form_feed.rs
@@ -4,7 +4,7 @@ use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::Line;
 use ruff_text_size::{TextRange, TextSize};
 
-use crate::{Diagnostic, Violation};
+use crate::{OldDiagnostic, Violation};
 
 /// ## What it does
 /// Checks for form feed characters preceded by either a space or a tab.
@@ -49,7 +49,7 @@ const SPACE: u8 = b' ';
 const TAB: u8 = b'\t';
 
 /// RUF054
-pub(crate) fn indented_form_feed(line: &Line) -> Option<Diagnostic> {
+pub(crate) fn indented_form_feed(line: &Line) -> Option<OldDiagnostic> {
     let index_relative_to_line = memchr(FORM_FEED, line.as_bytes())?;
 
     if index_relative_to_line == 0 {
@@ -68,5 +68,5 @@ pub(crate) fn indented_form_feed(line: &Line) -> Option<Diagnostic> {
     let absolute_index = line.start() + TextSize::new(relative_index);
     let range = TextRange::at(absolute_index, 1.into());
 
-    Some(Diagnostic::new(IndentedFormFeed, range))
+    Some(OldDiagnostic::new(IndentedFormFeed, range))
 }

--- a/crates/ruff_linter/src/rules/ruff/rules/invalid_rule_code.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/invalid_rule_code.rs
@@ -5,7 +5,7 @@ use crate::Locator;
 use crate::noqa::{Code, Directive};
 use crate::noqa::{Codes, NoqaDirectives};
 use crate::registry::Rule;
-use crate::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
+use crate::{AlwaysFixableViolation, Edit, Fix, OldDiagnostic};
 
 /// ## What it does
 /// Checks for `noqa` codes that are invalid.
@@ -48,7 +48,7 @@ impl AlwaysFixableViolation for InvalidRuleCode {
 
 /// RUF102 for invalid noqa codes
 pub(crate) fn invalid_noqa_code(
-    diagnostics: &mut Vec<Diagnostic>,
+    diagnostics: &mut Vec<OldDiagnostic>,
     noqa_directives: &NoqaDirectives,
     locator: &Locator,
     external: &[String],
@@ -86,8 +86,8 @@ fn code_is_valid(code: &Code, external: &[String]) -> bool {
 fn all_codes_invalid_diagnostic(
     directive: &Codes<'_>,
     invalid_codes: Vec<&Code<'_>>,
-) -> Diagnostic {
-    Diagnostic::new(
+) -> OldDiagnostic {
+    OldDiagnostic::new(
         InvalidRuleCode {
             rule_code: invalid_codes
                 .into_iter()
@@ -104,8 +104,8 @@ fn some_codes_are_invalid_diagnostic(
     codes: &Codes,
     invalid_code: &Code,
     locator: &Locator,
-) -> Diagnostic {
-    let diagnostic = Diagnostic::new(
+) -> OldDiagnostic {
+    let diagnostic = OldDiagnostic::new(
         InvalidRuleCode {
             rule_code: invalid_code.to_string(),
         },

--- a/crates/ruff_linter/src/rules/ruff/rules/redirected_noqa.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/redirected_noqa.rs
@@ -3,7 +3,7 @@ use ruff_text_size::Ranged;
 
 use crate::noqa::{Codes, Directive, FileNoqaDirectives, NoqaDirectives};
 use crate::rule_redirects::get_redirect_target;
-use crate::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
+use crate::{AlwaysFixableViolation, Edit, Fix, OldDiagnostic};
 
 /// ## What it does
 /// Checks for `noqa` directives that use redirected rule codes.
@@ -43,7 +43,10 @@ impl AlwaysFixableViolation for RedirectedNOQA {
 }
 
 /// RUF101 for in-line noqa directives
-pub(crate) fn redirected_noqa(diagnostics: &mut Vec<Diagnostic>, noqa_directives: &NoqaDirectives) {
+pub(crate) fn redirected_noqa(
+    diagnostics: &mut Vec<OldDiagnostic>,
+    noqa_directives: &NoqaDirectives,
+) {
     for line in noqa_directives.lines() {
         let Directive::Codes(directive) = &line.directive else {
             continue;
@@ -55,7 +58,7 @@ pub(crate) fn redirected_noqa(diagnostics: &mut Vec<Diagnostic>, noqa_directives
 
 /// RUF101 for file noqa directives
 pub(crate) fn redirected_file_noqa(
-    diagnostics: &mut Vec<Diagnostic>,
+    diagnostics: &mut Vec<OldDiagnostic>,
     noqa_directives: &FileNoqaDirectives,
 ) {
     for line in noqa_directives.lines() {
@@ -68,10 +71,10 @@ pub(crate) fn redirected_file_noqa(
 }
 
 /// Convert a sequence of [Codes] into [Diagnostic]s and append them to `diagnostics`.
-fn build_diagnostics(diagnostics: &mut Vec<Diagnostic>, codes: &Codes<'_>) {
+fn build_diagnostics(diagnostics: &mut Vec<OldDiagnostic>, codes: &Codes<'_>) {
     for code in codes.iter() {
         if let Some(redirected) = get_redirect_target(code.as_str()) {
-            let mut diagnostic = Diagnostic::new(
+            let mut diagnostic = OldDiagnostic::new(
                 RedirectedNOQA {
                     original: code.to_string(),
                     target: redirected.to_string(),

--- a/crates/ruff_linter/src/rules/ruff/rules/test_rules.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/test_rules.rs
@@ -19,7 +19,7 @@ use ruff_text_size::TextSize;
 
 use crate::Locator;
 use crate::registry::Rule;
-use crate::{Diagnostic, Edit, Fix, FixAvailability, Violation};
+use crate::{Edit, Fix, FixAvailability, OldDiagnostic, Violation};
 
 /// Check if a comment exists anywhere in a given file
 fn comment_exists(text: &str, locator: &Locator, comment_ranges: &CommentRanges) -> bool {
@@ -48,7 +48,7 @@ pub(crate) const TEST_RULES: &[Rule] = &[
 ];
 
 pub(crate) trait TestRule {
-    fn diagnostic(locator: &Locator, comment_ranges: &CommentRanges) -> Option<Diagnostic>;
+    fn diagnostic(locator: &Locator, comment_ranges: &CommentRanges) -> Option<OldDiagnostic>;
 }
 
 /// ## What it does
@@ -79,8 +79,8 @@ impl Violation for StableTestRule {
 }
 
 impl TestRule for StableTestRule {
-    fn diagnostic(_locator: &Locator, _comment_ranges: &CommentRanges) -> Option<Diagnostic> {
-        Some(Diagnostic::new(
+    fn diagnostic(_locator: &Locator, _comment_ranges: &CommentRanges) -> Option<OldDiagnostic> {
+        Some(OldDiagnostic::new(
             StableTestRule,
             ruff_text_size::TextRange::default(),
         ))
@@ -115,13 +115,13 @@ impl Violation for StableTestRuleSafeFix {
 }
 
 impl TestRule for StableTestRuleSafeFix {
-    fn diagnostic(locator: &Locator, comment_ranges: &CommentRanges) -> Option<Diagnostic> {
+    fn diagnostic(locator: &Locator, comment_ranges: &CommentRanges) -> Option<OldDiagnostic> {
         let comment = "# fix from stable-test-rule-safe-fix\n".to_string();
         if comment_exists(&comment, locator, comment_ranges) {
             None
         } else {
             Some(
-                Diagnostic::new(StableTestRuleSafeFix, ruff_text_size::TextRange::default())
+                OldDiagnostic::new(StableTestRuleSafeFix, ruff_text_size::TextRange::default())
                     .with_fix(Fix::safe_edit(Edit::insertion(comment, TextSize::new(0)))),
             )
         }
@@ -156,13 +156,13 @@ impl Violation for StableTestRuleUnsafeFix {
 }
 
 impl TestRule for StableTestRuleUnsafeFix {
-    fn diagnostic(locator: &Locator, comment_ranges: &CommentRanges) -> Option<Diagnostic> {
+    fn diagnostic(locator: &Locator, comment_ranges: &CommentRanges) -> Option<OldDiagnostic> {
         let comment = "# fix from stable-test-rule-unsafe-fix\n".to_string();
         if comment_exists(&comment, locator, comment_ranges) {
             None
         } else {
             Some(
-                Diagnostic::new(
+                OldDiagnostic::new(
                     StableTestRuleUnsafeFix,
                     ruff_text_size::TextRange::default(),
                 )
@@ -200,13 +200,13 @@ impl Violation for StableTestRuleDisplayOnlyFix {
 }
 
 impl TestRule for StableTestRuleDisplayOnlyFix {
-    fn diagnostic(locator: &Locator, comment_ranges: &CommentRanges) -> Option<Diagnostic> {
+    fn diagnostic(locator: &Locator, comment_ranges: &CommentRanges) -> Option<OldDiagnostic> {
         let comment = "# fix from stable-test-rule-display-only-fix\n".to_string();
         if comment_exists(&comment, locator, comment_ranges) {
             None
         } else {
             Some(
-                Diagnostic::new(
+                OldDiagnostic::new(
                     StableTestRuleDisplayOnlyFix,
                     ruff_text_size::TextRange::default(),
                 )
@@ -247,8 +247,8 @@ impl Violation for PreviewTestRule {
 }
 
 impl TestRule for PreviewTestRule {
-    fn diagnostic(_locator: &Locator, _comment_ranges: &CommentRanges) -> Option<Diagnostic> {
-        Some(Diagnostic::new(
+    fn diagnostic(_locator: &Locator, _comment_ranges: &CommentRanges) -> Option<OldDiagnostic> {
+        Some(OldDiagnostic::new(
             PreviewTestRule,
             ruff_text_size::TextRange::default(),
         ))
@@ -283,8 +283,8 @@ impl Violation for DeprecatedTestRule {
 }
 
 impl TestRule for DeprecatedTestRule {
-    fn diagnostic(_locator: &Locator, _comment_ranges: &CommentRanges) -> Option<Diagnostic> {
-        Some(Diagnostic::new(
+    fn diagnostic(_locator: &Locator, _comment_ranges: &CommentRanges) -> Option<OldDiagnostic> {
+        Some(OldDiagnostic::new(
             DeprecatedTestRule,
             ruff_text_size::TextRange::default(),
         ))
@@ -319,8 +319,8 @@ impl Violation for AnotherDeprecatedTestRule {
 }
 
 impl TestRule for AnotherDeprecatedTestRule {
-    fn diagnostic(_locator: &Locator, _comment_ranges: &CommentRanges) -> Option<Diagnostic> {
-        Some(Diagnostic::new(
+    fn diagnostic(_locator: &Locator, _comment_ranges: &CommentRanges) -> Option<OldDiagnostic> {
+        Some(OldDiagnostic::new(
             AnotherDeprecatedTestRule,
             ruff_text_size::TextRange::default(),
         ))
@@ -355,8 +355,8 @@ impl Violation for RemovedTestRule {
 }
 
 impl TestRule for RemovedTestRule {
-    fn diagnostic(_locator: &Locator, _comment_ranges: &CommentRanges) -> Option<Diagnostic> {
-        Some(Diagnostic::new(
+    fn diagnostic(_locator: &Locator, _comment_ranges: &CommentRanges) -> Option<OldDiagnostic> {
+        Some(OldDiagnostic::new(
             RemovedTestRule,
             ruff_text_size::TextRange::default(),
         ))
@@ -391,8 +391,8 @@ impl Violation for AnotherRemovedTestRule {
 }
 
 impl TestRule for AnotherRemovedTestRule {
-    fn diagnostic(_locator: &Locator, _comment_ranges: &CommentRanges) -> Option<Diagnostic> {
-        Some(Diagnostic::new(
+    fn diagnostic(_locator: &Locator, _comment_ranges: &CommentRanges) -> Option<OldDiagnostic> {
+        Some(OldDiagnostic::new(
             AnotherRemovedTestRule,
             ruff_text_size::TextRange::default(),
         ))
@@ -427,8 +427,8 @@ impl Violation for RedirectedFromTestRule {
 }
 
 impl TestRule for RedirectedFromTestRule {
-    fn diagnostic(_locator: &Locator, _comment_ranges: &CommentRanges) -> Option<Diagnostic> {
-        Some(Diagnostic::new(
+    fn diagnostic(_locator: &Locator, _comment_ranges: &CommentRanges) -> Option<OldDiagnostic> {
+        Some(OldDiagnostic::new(
             RedirectedFromTestRule,
             ruff_text_size::TextRange::default(),
         ))
@@ -463,8 +463,8 @@ impl Violation for RedirectedToTestRule {
 }
 
 impl TestRule for RedirectedToTestRule {
-    fn diagnostic(_locator: &Locator, _comment_ranges: &CommentRanges) -> Option<Diagnostic> {
-        Some(Diagnostic::new(
+    fn diagnostic(_locator: &Locator, _comment_ranges: &CommentRanges) -> Option<OldDiagnostic> {
+        Some(OldDiagnostic::new(
             RedirectedToTestRule,
             ruff_text_size::TextRange::default(),
         ))
@@ -499,8 +499,8 @@ impl Violation for RedirectedFromPrefixTestRule {
 }
 
 impl TestRule for RedirectedFromPrefixTestRule {
-    fn diagnostic(_locator: &Locator, _comment_ranges: &CommentRanges) -> Option<Diagnostic> {
-        Some(Diagnostic::new(
+    fn diagnostic(_locator: &Locator, _comment_ranges: &CommentRanges) -> Option<OldDiagnostic> {
+        Some(OldDiagnostic::new(
             RedirectedFromPrefixTestRule,
             ruff_text_size::TextRange::default(),
         ))


### PR DESCRIPTION
Summary
--

It's a bit late in the refactoring process, but I think there are still a couple of PRs left before getting rid of this type entirely, so I thought it would still be worth doing.

This PR is just a quick rename with no other changes.

Test Plan
--

Existing tests
