### PR TITLE
[ty] Add diagnosis for function with no return statement but with return type annotation

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/function/return_type.md
+++ b/crates/ty_python_semantic/resources/mdtest/function/return_type.md
@@ -278,6 +278,20 @@ def f(cond: bool) -> int:
         return 2
 ```
 
+## Invalid implicit return type always None
+
+<!-- snapshot-diagnostics -->
+
+If the function has no `return` statement or if it has only bare `return` statement (no variable in
+the return statement), then we show a diagnostic hint that the return annotation should be
+`-> None`.
+
+```py
+# error: [invalid-return-type] "Function always implicitly return `None`, which is not assignable to return type `int`"
+def f() -> int:
+    print("hello")
+```
+
 ## NotImplemented
 
 ### Default Python version

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Diagnostics_for_`inv…_(35563a74094b14d5).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Diagnostics_for_`inv…_(35563a74094b14d5).snap
@@ -24,13 +24,14 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/function/return_type.md
 # Diagnostics
 
 ```
-error[invalid-return-type]: Function can implicitly return `None`, which is not assignable to return type `str`
+error[invalid-return-type]: Function always implicitly return `None`, which is not assignable to return type `str`
  --> src/mdtest_snippet.py:7:25
   |
 6 | class Concrete(Abstract):
 7 |     def method(self) -> str: ...  # error: [invalid-return-type]
   |                         ^^^
   |
+info: Consider changing your return annotation to `-> None`
 info: Only functions in stub files, methods on protocol classes, or methods with `@abstractmethod` are permitted to have empty bodies
 info: Class `Concrete` has `typing.Protocol` in its MRO, but it is not a protocol class
 info: Only classes that directly inherit from `typing.Protocol` or `typing_extensions.Protocol` are considered protocol classes

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_implicit_ret…_(393cb38bf7119649).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_implicit_ret…_(393cb38bf7119649).snap
@@ -71,7 +71,7 @@ info: rule `invalid-return-type` is enabled by default
 ```
 
 ```
-error[invalid-return-type]: Function can implicitly return `None`, which is not assignable to return type `int`
+error[invalid-return-type]: Function always implicitly return `None`, which is not assignable to return type `int`
   --> src/mdtest_snippet.py:12:22
    |
 11 | # error: [invalid-return-type]
@@ -80,6 +80,7 @@ error[invalid-return-type]: Function can implicitly return `None`, which is not 
 13 |     if cond:
 14 |         raise ValueError()
    |
+info: Consider changing your return annotation to `-> None`
 info: rule `invalid-return-type` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_implicit_ret…_(3d2d19aa49b28f1c).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_implicit_ret…_(3d2d19aa49b28f1c).snap
@@ -1,0 +1,34 @@
+---
+source: crates/ty_test/src/lib.rs
+expression: snapshot
+---
+---
+mdtest name: return_type.md - Function return type - Invalid implicit return type always None
+mdtest path: crates/ty_python_semantic/resources/mdtest/function/return_type.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+1 | # error: [invalid-return-type] "Function always implicitly return `None`, which is not assignable to return type `int`"
+2 | def f() -> int:
+3 |     print("hello")
+```
+
+# Diagnostics
+
+```
+error[invalid-return-type]: Function always implicitly return `None`, which is not assignable to return type `int`
+ --> src/mdtest_snippet.py:2:12
+  |
+1 | # error: [invalid-return-type] "Function always implicitly return `None`, which is not assignable to return type `int`"
+2 | def f() -> int:
+  |            ^^^
+3 |     print("hello")
+  |
+info: Consider changing your return annotation to `-> None`
+info: rule `invalid-return-type` is enabled by default
+
+```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type_(a91e0c67519cd77f).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type_(a91e0c67519cd77f).snap
@@ -35,7 +35,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/function/return_type.md
 # Diagnostics
 
 ```
-error[invalid-return-type]: Function can implicitly return `None`, which is not assignable to return type `int`
+error[invalid-return-type]: Function always implicitly return `None`, which is not assignable to return type `int`
  --> src/mdtest_snippet.py:2:12
   |
 1 | # error: [invalid-return-type]
@@ -43,6 +43,7 @@ error[invalid-return-type]: Function can implicitly return `None`, which is not 
   |            ^^^
 3 |     1
   |
+info: Consider changing your return annotation to `-> None`
 info: rule `invalid-return-type` is enabled by default
 
 ```
@@ -84,13 +85,14 @@ info: rule `invalid-return-type` is enabled by default
 ```
 
 ```
-error[invalid-return-type]: Function can implicitly return `None`, which is not assignable to return type `T`
+error[invalid-return-type]: Function always implicitly return `None`, which is not assignable to return type `T`
   --> src/mdtest_snippet.py:18:16
    |
 17 | # error: [invalid-return-type]
 18 | def m(x: T) -> T: ...
    |                ^
    |
+info: Consider changing your return annotation to `-> None`
 info: rule `invalid-return-type` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type_…_(c3a523878447af6b).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type_…_(c3a523878447af6b).snap
@@ -46,7 +46,7 @@ info: rule `invalid-return-type` is enabled by default
 ```
 
 ```
-error[invalid-return-type]: Function can implicitly return `None`, which is not assignable to return type `int`
+error[invalid-return-type]: Function always implicitly return `None`, which is not assignable to return type `int`
  --> src/mdtest_snippet.pyi:6:14
   |
 5 | # error: [invalid-return-type]
@@ -55,12 +55,13 @@ error[invalid-return-type]: Function can implicitly return `None`, which is not 
 7 |     print("...")
 8 |     ...
   |
+info: Consider changing your return annotation to `-> None`
 info: rule `invalid-return-type` is enabled by default
 
 ```
 
 ```
-error[invalid-return-type]: Function can implicitly return `None`, which is not assignable to return type `int`
+error[invalid-return-type]: Function always implicitly return `None`, which is not assignable to return type `int`
   --> src/mdtest_snippet.pyi:11:14
    |
 10 | # error: [invalid-return-type]
@@ -69,6 +70,7 @@ error[invalid-return-type]: Function can implicitly return `None`, which is not 
 12 |     f"""{foo} is a function that ..."""
 13 |     ...
    |
+info: Consider changing your return annotation to `-> None`
 info: rule `invalid-return-type` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -1853,12 +1853,14 @@ impl<'db> TypeInferenceBuilder<'db> {
             if use_def.can_implicit_return(self.db())
                 && !Type::none(self.db()).is_assignable_to(self.db(), declared_ty)
             {
+                let no_return = self.return_types_and_ranges.is_empty();
                 report_implicit_return_type(
                     &self.context,
                     returns.range(),
                     declared_ty,
                     has_empty_body,
                     enclosing_class_context,
+                    no_return,
                 );
             }
         }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Partially implement https://github.com/astral-sh/ty/issues/538, 
```py
from pathlib import Path

def setup_test_project(registry_name: str, registry_url: str, project_dir: str) -> Path:
    pyproject_file = Path(project_dir) / "pyproject.toml"
    pyproject_file.write_text("...", encoding="utf-8")
```
As no return statement is defined in the function `setup_test_project` with annotated return type `Path`, we provide the following diagnosis : 

- error[invalid-return-type]: Function **always** implicitly returns `None`, which is not assignable to return type `Path`

with a subdiagnostic : 
- note: Consider changing your return annotation to `-> None`

I was not able to implement the second part `if the function only has bare return statements rather than return <variable> statements` without running into issues but I can still work on it if it is required for this PR.
 
## Test Plan

<!-- How was it tested? -->

mdtests with snapshots to capture the subdiagnostic. I have to mention that existing snapshots were modified since they now fall in this category.