### PR TITLE
Move common parsing methods to the `Cursor` struct

### DIFF
--- a/crates/ruff_python_trivia/src/cursor.rs
+++ b/crates/ruff_python_trivia/src/cursor.rs
@@ -21,6 +21,11 @@ impl<'a> Cursor<'a> {
         }
     }
 
+    /// Retrieves the current offset of the cursor within the source code.
+    pub fn offset(&self) -> TextSize {
+        self.source_length - self.text_len()
+    }
+
     /// Return the remaining input as a string slice.
     pub fn chars(&self) -> Chars<'a> {
         self.chars.clone()
@@ -163,5 +168,9 @@ impl<'a> Cursor<'a> {
     ///  - If `count` indexes into a multi-byte character.
     pub fn skip_bytes(&mut self, count: usize) {
         self.chars = self.chars.as_str()[count..].chars();
+    }
+
+    pub fn skip_non_newline_whitespace(&mut self) {
+        self.eat_while(|c| c.is_whitespace() && c != '\n');
     }
 }

--- a/crates/ty_test/src/assertion.rs
+++ b/crates/ty_test/src/assertion.rs
@@ -40,7 +40,7 @@ use ruff_db::parsed::parsed_module;
 use ruff_db::source::{SourceText, line_index, source_text};
 use ruff_python_trivia::{CommentRanges, Cursor};
 use ruff_source_file::{LineIndex, OneIndexed};
-use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
+use ruff_text_size::{Ranged, TextRange, TextSize};
 use smallvec::SmallVec;
 use std::ops::Deref;
 use std::str::FromStr;
@@ -360,22 +360,12 @@ impl<'a> ErrorAssertionParser<'a> {
         }
     }
 
-    /// Retrieves the current offset of the cursor within the source code.
-    fn offset(&self) -> TextSize {
-        self.comment_source.text_len() - self.cursor.text_len()
-    }
-
-    /// Consume characters in the assertion comment until we find a non-whitespace character
-    fn skip_whitespace(&mut self) {
-        self.cursor.eat_while(char::is_whitespace);
-    }
-
     /// Attempt to parse the assertion comment into a [`ErrorAssertion`].
     fn parse(mut self) -> Result<ErrorAssertion<'a>, ErrorAssertionParseError<'a>> {
         let mut column = None;
         let mut rule = None;
 
-        self.skip_whitespace();
+        self.cursor.skip_non_newline_whitespace();
 
         while let Some(character) = self.cursor.bump() {
             match character {
@@ -387,9 +377,10 @@ impl<'a> ErrorAssertionParser<'a> {
                     if rule.is_some() {
                         return Err(ErrorAssertionParseError::ColumnNumberAfterRuleCode);
                     }
-                    let offset = self.offset() - TextSize::new(1);
+                    let offset = self.cursor.offset() - TextSize::new(1);
                     self.cursor.eat_while(|c| !c.is_whitespace());
-                    let column_str = &self.comment_source[TextRange::new(offset, self.offset())];
+                    let column_str =
+                        &self.comment_source[TextRange::new(offset, self.cursor.offset())];
                     column = OneIndexed::from_str(column_str)
                         .map(Some)
                         .map_err(|e| ErrorAssertionParseError::BadColumnNumber(column_str, e))?;
@@ -400,12 +391,14 @@ impl<'a> ErrorAssertionParser<'a> {
                     if rule.is_some() {
                         return Err(ErrorAssertionParseError::MultipleRuleCodes);
                     }
-                    let offset = self.offset();
+                    let offset = self.cursor.offset();
                     self.cursor.eat_while(|c| c != ']');
                     if self.cursor.is_eof() {
                         return Err(ErrorAssertionParseError::UnclosedRuleCode);
                     }
-                    rule = Some(self.comment_source[TextRange::new(offset, self.offset())].trim());
+                    rule = Some(
+                        self.comment_source[TextRange::new(offset, self.cursor.offset())].trim(),
+                    );
                     self.cursor.bump();
                 }
 
@@ -413,8 +406,8 @@ impl<'a> ErrorAssertionParser<'a> {
                 '"' => {
                     let comment_source = self.comment_source.trim();
                     return if comment_source.ends_with('"') {
-                        let rest =
-                            &comment_source[self.offset().to_usize()..comment_source.len() - 1];
+                        let rest = &comment_source
+                            [self.cursor.offset().to_usize()..comment_source.len() - 1];
                         Ok(ErrorAssertion {
                             rule,
                             column,
@@ -434,12 +427,12 @@ impl<'a> ErrorAssertionParser<'a> {
                 unexpected => {
                     return Err(ErrorAssertionParseError::UnexpectedCharacter {
                         character: unexpected,
-                        offset: self.offset().to_usize(),
+                        offset: self.cursor.offset().to_usize(),
                     });
                 }
             }
 
-            self.skip_whitespace();
+            self.cursor.skip_non_newline_whitespace();
         }
 
         if rule.is_some() {

--- a/crates/ty_test/src/parser.rs
+++ b/crates/ty_test/src/parser.rs
@@ -409,7 +409,6 @@ struct Parser<'s> {
     explicit_path: Option<&'s str>,
 
     source: &'s str,
-    source_len: TextSize,
 
     /// Stack of ancestor sections.
     stack: SectionStack,
@@ -438,7 +437,6 @@ impl<'s> Parser<'s> {
             cursor: Cursor::new(source),
             preceding_blank_lines: 0,
             explicit_path: None,
-            source_len: source.text_len(),
             stack: SectionStack::new(root_section_id),
             current_section_files: FxHashMap::default(),
             current_section_has_config: false,
@@ -460,10 +458,6 @@ impl<'s> Parser<'s> {
         }
     }
 
-    fn skip_whitespace(&mut self) {
-        self.cursor.eat_while(|c| c.is_whitespace() && c != '\n');
-    }
-
     fn skip_to_beginning_of_next_line(&mut self) -> bool {
         if let Some(position) = memchr::memchr(b'\n', self.cursor.as_bytes()) {
             self.cursor.skip_bytes(position + 1);
@@ -474,11 +468,11 @@ impl<'s> Parser<'s> {
     }
 
     fn consume_until(&mut self, mut end_predicate: impl FnMut(char) -> bool) -> Option<&'s str> {
-        let start = self.offset().to_usize();
+        let start = self.cursor.offset().to_usize();
 
         while !self.cursor.is_eof() {
             if end_predicate(self.cursor.first()) {
-                return Some(&self.source[start..self.offset().to_usize()]);
+                return Some(&self.source[start..self.cursor.offset().to_usize()]);
             }
             self.cursor.bump();
         }
@@ -537,7 +531,7 @@ impl<'s> Parser<'s> {
                     if self.cursor.eat_char2('`', '`') {
                         // We saw the triple-backtick beginning of a code block.
 
-                        let backtick_offset_start = self.offset() - "```".text_len();
+                        let backtick_offset_start = self.cursor.offset() - "```".text_len();
 
                         if self.preceding_blank_lines < 1 && self.explicit_path.is_none() {
                             bail!(
@@ -545,14 +539,14 @@ impl<'s> Parser<'s> {
                             );
                         }
 
-                        self.skip_whitespace();
+                        self.cursor.skip_non_newline_whitespace();
 
                         // Parse the code block language specifier
                         let lang = self
                             .consume_until(|c| matches!(c, ' ' | '\n'))
                             .unwrap_or_default();
 
-                        self.skip_whitespace();
+                        self.cursor.skip_non_newline_whitespace();
 
                         if !self.cursor.eat_char('\n') {
                             bail!(
@@ -570,7 +564,7 @@ impl<'s> Parser<'s> {
                                 code = &code[..code.len() - '\n'.len_utf8()];
                             }
 
-                            let backtick_offset_end = self.offset() - "```".text_len();
+                            let backtick_offset_end = self.cursor.offset() - "```".text_len();
 
                             self.process_code_block(
                                 lang,
@@ -590,7 +584,7 @@ impl<'s> Parser<'s> {
 
                         if let Some(path) = self.consume_until(|c| matches!(c, '`' | '\n')) {
                             if self.cursor.eat_char('`') {
-                                self.skip_whitespace();
+                                self.cursor.skip_non_newline_whitespace();
                                 if self.cursor.eat_char(':') {
                                     self.explicit_path = Some(path);
                                 }
@@ -609,7 +603,7 @@ impl<'s> Parser<'s> {
                     self.explicit_path = None;
 
                     if c.is_whitespace() {
-                        self.skip_whitespace();
+                        self.cursor.skip_non_newline_whitespace();
                         if self.cursor.eat_char('`')
                             && self.cursor.eat_char('`')
                             && self.cursor.eat_char('`')
@@ -819,11 +813,6 @@ impl<'s> Parser<'s> {
             // no parent section can have files.
             self.current_section_files.clear();
         }
-    }
-
-    /// Retrieves the current offset of the cursor within the source code.
-    fn offset(&self) -> TextSize {
-        self.source_len - self.cursor.text_len()
     }
 
     fn line_index(&self, char_index: TextSize) -> u32 {


### PR DESCRIPTION
## Summary

Two `Parser` structs in the `ty_test` crate have `offset()` and `skip_whitespace` methods that are identical in their implementations. These methods feel like they could live just as well on the `ruff_python_trivia` crate's `Cursor` struct, which would reduce code duplication.

The short-term motivation for doing this is that I found myself needing them yet again for another parsing task in https://github.com/astral-sh/ruff/pull/18057 -- but it seems like a reasonable thing to do anyway, so I'm splitting it out into a standalone PR.

## Test Plan

`cargo test -p ty_test`
