### PR TITLE
[ty] Argument type expansion for overload call evaluation

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/overloads.md
@@ -220,3 +220,32 @@ def _(flag: bool):
     reveal_type(f(False))  # revealed: F
     reveal_type(f(flag))  # revealed: T | F
 ```
+
+### Builtin type: `tuple`
+
+`overloaded.pyi`:
+
+```pyi
+from typing import Literal, overload
+
+class A: ...
+class B: ...
+class C: ...
+class D: ...
+
+@overload
+def f(x: tuple[A, int], y: tuple[int, Literal[True]]) -> A: ...
+@overload
+def f(x: tuple[A, int], y: tuple[int, Literal[False]]) -> B: ...
+@overload
+def f(x: tuple[B, int], y: tuple[int, Literal[True]]) -> C: ...
+@overload
+def f(x: tuple[B, int], y: tuple[int, Literal[False]]) -> D: ...
+```
+
+```py
+from overloaded import A, B, f
+
+def _(x: tuple[A | B, int], y: tuple[int, bool]):
+    reveal_type(f(x, y))  # revealed: A | B | C | D
+```

--- a/crates/ty_python_semantic/resources/mdtest/call/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/overloads.md
@@ -1,0 +1,223 @@
+# Overloads
+
+When ty evaluates the call of an overloaded function, it attempts to "match" the supplied arguments
+with one or more overloads. This document describes the algorithm that it uses for overload
+matching, which is the same as the one mentioned in the
+[spec](https://typing.python.org/en/latest/spec/overload.html#overload-call-evaluation).
+
+## Arity check
+
+The first step is to perform arity check. The non-overloaded cases are described in the
+[function](./function.md) document.
+
+`overloaded.pyi`:
+
+```pyi
+from typing import overload
+
+@overload
+def f() -> None: ...
+@overload
+def f(x: int) -> int: ...
+```
+
+```py
+from overloaded import f
+
+# These matches a single overload
+reveal_type(f())  # revealed: None
+reveal_type(f(1))  # revealed: int
+
+# error: [no-matching-overload] "No overload of function `f` matches arguments"
+reveal_type(f("a", "b"))  # revealed: Unknown
+```
+
+## Type checking
+
+The second step is to perform type checking. This is done for all the overloads that passed the
+arity check.
+
+### Single match
+
+`overloaded.pyi`:
+
+```pyi
+from typing import overload
+
+@overload
+def f(x: int) -> int: ...
+@overload
+def f(x: str) -> str: ...
+@overload
+def f(x: bytes) -> bytes: ...
+```
+
+Here, all of the calls below pass the arity check, so we proceed to type checking which filters out
+all but the matching overload:
+
+```py
+from overloaded import f
+
+reveal_type(f(1))  # revealed: int
+reveal_type(f("a"))  # revealed: str
+reveal_type(f(b"b"))  # revealed: bytes
+```
+
+### Multiple matches
+
+`overloaded.pyi`:
+
+```pyi
+from typing import overload
+
+class A: ...
+class B(A): ...
+
+@overload
+def f(x: A) -> A: ...
+@overload
+def f(x: B, y: int = 0) -> B: ...
+```
+
+```py
+from overloaded import A, B, f
+
+# These calls pass the arity check, and type checking matches both overloads:
+reveal_type(f(A()))  # revealed: A
+reveal_type(f(B()))  # revealed: A
+
+# But, in this case, the arity check filters out the first overload, so we only have one match:
+reveal_type(f(B(), 1))  # revealed: B
+```
+
+## Argument type expansion
+
+This step is performed only if the previous steps resulted in **no matches**.
+
+In this case, the algorithm would perform [argument type
+expansion](https://typing.python.org/en/latest/spec/overload.html#argument-type-expansion) and loops
+over from the type checking step, evaluating the argument lists.
+
+### Expanding the only argument
+
+`overloaded.pyi`:
+
+```pyi
+from typing import overload
+
+class A: ...
+class B: ...
+class C: ...
+
+@overload
+def f(x: A) -> A: ...
+@overload
+def f(x: B) -> B: ...
+@overload
+def f(x: C) -> C: ...
+```
+
+```py
+from overloaded import A, B, C, f
+
+def _(ab: A | B, ac: A | C, bc: B | C):
+    reveal_type(f(ab))  # revealed: A | B
+    reveal_type(f(bc))  # revealed: B | C
+    reveal_type(f(ac))  # revealed: A | C
+```
+
+### Expanding first argument
+
+If the set of argument lists created by expanding the first argument evaluates successfully, the
+algorithm shouldn't expand the second argument.
+
+`overloaded.pyi`:
+
+```pyi
+from typing import Literal, overload
+
+class A: ...
+class B: ...
+class C: ...
+class D: ...
+
+@overload
+def f(x: A, y: C) -> A: ...
+@overload
+def f(x: A, y: D) -> B: ...
+@overload
+def f(x: B, y: C) -> C: ...
+@overload
+def f(x: B, y: D) -> D: ...
+```
+
+```py
+from overloaded import A, B, C, D, f
+
+def _(a_b: A | B):
+    reveal_type(f(a_b, C()))  # revealed: A | C
+    reveal_type(f(a_b, D()))  # revealed: B | D
+
+
+# But, if it doesn't, it should expand the second argument and try again:
+def _(a_b: A | B, c_d: C | D):
+    reveal_type(f(a_b, c_d))  # revealed: A | B | C | D
+```
+
+### Expanding second argument
+
+If the first argument cannot be expanded, the algorithm should move on to the second argument,
+keeping the first argument as is.
+
+`overloaded.pyi`:
+
+```pyi
+from typing import overload
+
+class A: ...
+class B: ...
+class C: ...
+class D: ...
+
+@overload
+def f(x: A, y: B) -> B: ...
+@overload
+def f(x: A, y: C) -> C: ...
+@overload
+def f(x: B, y: D) -> D: ...
+```
+
+```py
+from overloaded import A, B, C, D, f
+
+def _(a: A, bc: B | C, cd: C | D):
+    reveal_type(f(a, bc))  # revealed: B | C
+
+    # error: [no-matching-overload] "No overload of function `f` matches arguments"
+    reveal_type(f(a, cd))  # revealed: Unknown
+```
+
+### Builtin type: `bool`
+
+`overloaded.pyi`:
+
+```pyi
+from typing import Literal, overload
+
+class T: ...
+class F: ...
+
+@overload
+def f(x: Literal[True]) -> T: ...
+@overload
+def f(x: Literal[False]) -> F: ...
+```
+
+```py
+from overloaded import f
+
+def _(flag: bool):
+    reveal_type(f(True))  # revealed: T
+    reveal_type(f(False))  # revealed: F
+    reveal_type(f(flag))  # revealed: T | F
+```

--- a/crates/ty_python_semantic/resources/mdtest/call/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/overloads.md
@@ -24,7 +24,7 @@ def f(x: int) -> int: ...
 ```py
 from overloaded import f
 
-# These matches a single overload
+# These match a single overload
 reveal_type(f())  # revealed: None
 reveal_type(f(1))  # revealed: int
 
@@ -52,8 +52,8 @@ def f(x: str) -> str: ...
 def f(x: bytes) -> bytes: ...
 ```
 
-Here, all of the calls below pass the arity check, so we proceed to type checking which filters out
-all but the matching overload:
+Here, all of the calls below pass the arity check for all overloads, so we proceed to type checking
+which filters out all but the matching overload:
 
 ```py
 from overloaded import f

--- a/crates/ty_python_semantic/resources/mdtest/call/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/overloads.md
@@ -94,9 +94,9 @@ reveal_type(f(B(), 1))  # revealed: B
 
 This step is performed only if the previous steps resulted in **no matches**.
 
-In this case, the algorithm would perform [argument type
-expansion](https://typing.python.org/en/latest/spec/overload.html#argument-type-expansion) and loops
-over from the type checking step, evaluating the argument lists.
+In this case, the algorithm would perform
+[argument type expansion](https://typing.python.org/en/latest/spec/overload.html#argument-type-expansion)
+and loops over from the type checking step, evaluating the argument lists.
 
 ### Expanding the only argument
 
@@ -157,7 +157,6 @@ from overloaded import A, B, C, D, f
 def _(a_b: A | B):
     reveal_type(f(a_b, C()))  # revealed: A | C
     reveal_type(f(a_b, D()))  # revealed: B | D
-
 
 # But, if it doesn't, it should expand the second argument and try again:
 def _(a_b: A | B, c_d: C | D):

--- a/crates/ty_python_semantic/src/types/call/arguments.rs
+++ b/crates/ty_python_semantic/src/types/call/arguments.rs
@@ -1,6 +1,11 @@
 use std::borrow::Cow;
 use std::ops::{Deref, DerefMut};
 
+use itertools::{Either, Itertools};
+
+use crate::Db;
+use crate::types::{KnownClass, TupleType};
+
 use super::Type;
 
 /// Arguments for a single call, in source order.
@@ -86,6 +91,10 @@ impl<'a, 'db> CallArgumentTypes<'a, 'db> {
         Self { arguments, types }
     }
 
+    pub(crate) fn types(&self) -> &[Type<'db>] {
+        &self.types
+    }
+
     /// Prepend an optional extra synthetic argument (for a `self` or `cls` parameter) to the front
     /// of this argument list. (If `bound_self` is none, we return the argument list
     /// unmodified.)
@@ -108,6 +117,36 @@ impl<'a, 'db> CallArgumentTypes<'a, 'db> {
     pub(crate) fn iter(&self) -> impl Iterator<Item = (Argument<'a>, Type<'db>)> + '_ {
         self.arguments.iter().zip(self.types.iter().copied())
     }
+
+    pub(crate) fn expand(&self, db: &'db dyn Db) -> impl Iterator<Item = Vec<Vec<Type<'db>>>> + '_ {
+        let mut index = 0;
+
+        // TODO: Avoid cloning if there's no expansion needed
+        std::iter::successors(Some(vec![self.types.clone()]), move |previous| {
+            let expanded_types = loop {
+                let arg_type = self.types.get(index)?;
+                if let Some(expanded_types) = expand_type(db, *arg_type) {
+                    break expanded_types;
+                }
+                index += 1;
+            };
+
+            // Generate all combinations by expanding the type at `index`
+            let mut expanded_arg_types = Vec::with_capacity(expanded_types.len() * previous.len());
+
+            for pre_expanded_types in previous {
+                for subtype in &expanded_types {
+                    let mut new_expanded_types = pre_expanded_types.clone();
+                    new_expanded_types[index] = *subtype;
+                    expanded_arg_types.push(new_expanded_types);
+                }
+            }
+
+            index += 1;
+            Some(expanded_arg_types)
+        })
+        .skip(1) // Skip the first iteration which is just the original types
+    }
 }
 
 impl<'a> Deref for CallArgumentTypes<'a, '_> {
@@ -121,4 +160,36 @@ impl<'a> DerefMut for CallArgumentTypes<'a, '_> {
     fn deref_mut(&mut self) -> &mut CallArguments<'a> {
         &mut self.arguments
     }
+}
+
+fn expand_type<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Vec<Type<'db>>> {
+    // TODO: Expand enums to their variants
+    Some(match ty {
+        // We don't handle `type[A | B]` here because it's already stored in the expanded form
+        // i.e., `type[A] | type[B]` which is handled by the `Type::Union` case.
+        Type::NominalInstance(instance) if instance.class.is_known(db, KnownClass::Bool) => {
+            vec![Type::BooleanLiteral(true), Type::BooleanLiteral(false)]
+        }
+        Type::Tuple(tuple) => {
+            let expanded = tuple
+                .iter(db)
+                .map(|element| {
+                    if let Some(expanded) = expand_type(db, element) {
+                        Either::Left(expanded.into_iter())
+                    } else {
+                        Either::Right(std::iter::once(element))
+                    }
+                })
+                // TODO: Use a custom implementation?
+                .multi_cartesian_product()
+                .map(|types| TupleType::from_elements(db, types))
+                .collect::<Vec<_>>();
+            if expanded.len() == 1 {
+                return None;
+            }
+            expanded
+        }
+        Type::Union(union) => union.iter(db).copied().collect(),
+        _ => return None,
+    })
 }

--- a/crates/ty_python_semantic/src/types/call/arguments.rs
+++ b/crates/ty_python_semantic/src/types/call/arguments.rs
@@ -256,7 +256,7 @@ mod tests {
         ];
         let union_type = UnionType::from_elements(&db, types);
         let expanded = expand_type(&db, union_type).unwrap();
-        assert_eq!(expanded.len(), 3);
+        assert_eq!(expanded.len(), types.len());
         assert_eq!(expanded, types);
     }
 

--- a/crates/ty_python_semantic/src/types/call/arguments.rs
+++ b/crates/ty_python_semantic/src/types/call/arguments.rs
@@ -144,8 +144,8 @@ impl<'a, 'db> CallArgumentTypes<'a, 'db> {
 
             fn iter(&self) -> impl Iterator<Item = &Vec<Type<'db>>> + '_ {
                 match self {
-                    State::Initial(types) => Either::Left(std::iter::once(*types)),
-                    State::Expanded(expanded) => Either::Right(expanded.iter()),
+                    State::Initial(types) => std::slice::from_ref(*types).iter(),
+                    State::Expanded(expanded) => expanded.iter(),
                 }
             }
         }

--- a/crates/ty_python_semantic/src/types/call/arguments.rs
+++ b/crates/ty_python_semantic/src/types/call/arguments.rs
@@ -257,9 +257,7 @@ mod tests {
         let union_type = UnionType::from_elements(&db, types);
         let expanded = expand_type(&db, union_type).unwrap();
         assert_eq!(expanded.len(), 3);
-        for (expected, actual) in types.iter().zip(expanded) {
-            assert_eq!(expected, &actual);
-        }
+        assert_eq!(expanded, types);
     }
 
     #[test]
@@ -267,9 +265,9 @@ mod tests {
         let db = setup_db();
         let bool_instance = KnownClass::Bool.to_instance(&db);
         let expanded = expand_type(&db, bool_instance).unwrap();
-        assert_eq!(expanded.len(), 2);
-        assert_eq!(expanded[0], Type::BooleanLiteral(true));
-        assert_eq!(expanded[1], Type::BooleanLiteral(false));
+        let expected_types = [Type::BooleanLiteral(true), Type::BooleanLiteral(false)];
+        assert_eq!(expanded.len(), expected_types.len());
+        assert_eq!(expanded, expected_types);
     }
 
     #[test]
@@ -310,10 +308,8 @@ mod tests {
             TupleType::from_elements(&db, [false_ty, bytes_ty]),
         ];
         let expanded = expand_type(&db, tuple_type2).unwrap();
-        assert_eq!(expanded.len(), 6);
-        for (expected, actual) in expected_types.iter().zip(expanded) {
-            assert_eq!(expected, &actual);
-        }
+        assert_eq!(expanded.len(), expected_types.len());
+        assert_eq!(expanded, expected_types);
 
         // Mixed set of elements where some can be expanded while others cannot be.
         let tuple_type3 = TupleType::from_elements(
@@ -332,9 +328,7 @@ mod tests {
             TupleType::from_elements(&db, [false_ty, int_ty, bytes_ty, str_ty]),
         ];
         let expanded = expand_type(&db, tuple_type3).unwrap();
-        assert_eq!(expanded.len(), 4);
-        for (expected, actual) in expected_types.iter().zip(expanded) {
-            assert_eq!(expected, &actual);
-        }
+        assert_eq!(expanded.len(), expected_types.len());
+        assert_eq!(expanded, expected_types);
     }
 }

--- a/crates/ty_python_semantic/src/types/call/arguments.rs
+++ b/crates/ty_python_semantic/src/types/call/arguments.rs
@@ -177,9 +177,10 @@ impl<'a, 'db> CallArgumentTypes<'a, 'db> {
 
             Some(State::Expanded(expanded_arg_types))
         })
-        .filter_map(|state| match state {
-            State::Initial(_) => None, // The initial state has no expanded types.
-            State::Expanded(expanded) => Some(expanded),
+        .skip(1) // Skip the initial state, which has no expanded types.
+        .map(|state| match state {
+            State::Initial(_) => unreachable!("initial state should be skipped"),
+            State::Expanded(expanded) => expanded,
         })
     }
 }

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -1144,7 +1144,7 @@ impl<'db> CallableBinding<'db> {
             }
         };
 
-        let snapshotter = Snapshotter::new(matching_overload_indexes);
+        let snapshotter = MatchingOverloadsSnapshotter::new(matching_overload_indexes);
 
         // State of the bindings _before_ evaluating (type checking) the matching overloads using
         // the non-expanded argument types.
@@ -1942,12 +1942,12 @@ impl<'db> MatchingOverloadsSnapshot<'db> {
 
 /// A helper to take snapshots of the matched overload bindings for the current state of the
 /// bindings.
-struct Snapshotter(Vec<usize>);
+struct MatchingOverloadsSnapshotter(Vec<usize>);
 
-impl Snapshotter {
+impl MatchingOverloadsSnapshotter {
     fn new(indexes: Vec<usize>) -> Self {
         debug_assert!(indexes.len() > 1);
-        Snapshotter(indexes)
+        MatchingOverloadsSnapshotter(indexes)
     }
 
     /// Takes a snapshot of the current state of the matched overload bindings.

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -188,9 +188,9 @@ impl<'db> Bindings<'db> {
     /// types that are not callable, returns `Type::Unknown`.
     pub(crate) fn return_type(&self, db: &'db dyn Db) -> Type<'db> {
         if let [binding] = self.elements.as_slice() {
-            return binding.return_type(db);
+            return binding.return_type();
         }
-        UnionType::from_elements(db, self.into_iter().map(|b| b.return_type(db)))
+        UnionType::from_elements(db, self.into_iter().map(CallableBinding::return_type))
     }
 
     /// Report diagnostics for all of the errors that occurred when trying to match actual
@@ -1316,7 +1316,7 @@ impl<'db> CallableBinding<'db> {
     /// function, this is the return type of the function. For an invalid call to an overloaded
     /// function, we return `Type::unknown`, since we cannot make any useful conclusions about
     /// which overload was intended to be called.
-    pub(crate) fn return_type(&self, db: &'db dyn Db) -> Type<'db> {
+    pub(crate) fn return_type(&self) -> Type<'db> {
         if let Some(return_type) = self.return_type {
             return return_type;
         }

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -1036,6 +1036,12 @@ pub(crate) struct CallableBinding<'db> {
     /// The type of the bound `self` or `cls` parameter if this signature is for a bound method.
     pub(crate) bound_type: Option<Type<'db>>,
 
+    /// The return type of this callable.
+    ///
+    /// This is only `Some` if it's an overloaded callable, "argument type expansion" was
+    /// performed, and one of the expansion evaluated successfully for all of the argument lists.
+    /// This type is then the union of all the return types of the matched overloads for the
+    /// expanded argument lists.
     return_type: Option<Type<'db>>,
 
     /// The bindings of each overload of this callable. Will be empty if the type is not callable.
@@ -1322,11 +1328,16 @@ impl<'db> CallableBinding<'db> {
             .filter(|(_, overload)| overload.as_result().is_ok())
     }
 
-    /// Returns the return type of this call. For a valid call, this is the return type of the
-    /// first overload that the arguments matched against. For an invalid call to a non-overloaded
-    /// function, this is the return type of the function. For an invalid call to an overloaded
-    /// function, we return `Type::unknown`, since we cannot make any useful conclusions about
-    /// which overload was intended to be called.
+    /// Returns the return type of this call.
+    ///
+    /// For a valid call, this is the return type of either a successful argument type expansion of
+    /// an overloaded function, or the return type of the first overload that the arguments matched
+    /// against.
+    ///
+    /// For an invalid call to a non-overloaded function, this is the return type of the function.
+    ///
+    /// For an invalid call to an overloaded function, we return `Type::unknown`, since we cannot
+    /// make any useful conclusions about which overload was intended to be called.
     pub(crate) fn return_type(&self) -> Type<'db> {
         if let Some(return_type) = self.return_type {
             return return_type;

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -1016,14 +1016,9 @@ impl<'db> From<Binding<'db>> for Bindings<'db> {
 /// If the callable has multiple overloads, the first one that matches is used as the overall
 /// binding match.
 ///
-/// TODO: Implement the call site evaluation algorithm in the [proposed updated typing
-/// spec][overloads], which is much more subtle than “first match wins”.
-///
 /// If the arguments cannot be matched to formal parameters, we store information about the
 /// specific errors that occurred when trying to match them up. If the callable has multiple
 /// overloads, we store this error information for each overload.
-///
-/// [overloads]: https://github.com/python/typing/pull/1839
 #[derive(Debug)]
 pub(crate) struct CallableBinding<'db> {
     /// The type that is (hopefully) callable.
@@ -1104,12 +1099,6 @@ impl<'db> CallableBinding<'db> {
         // before checking.
         let arguments = arguments.with_self(self.bound_type);
 
-        // TODO: This checks every overload. In the proposed more detailed call checking spec [1],
-        // arguments are checked for arity first, and are only checked for type assignability against
-        // the matching overloads. Make sure to implement that as part of separating call binding into
-        // two phases.
-        //
-        // [1] https://typing.python.org/en/latest/spec/overload.html#overload-call-evaluation
         for overload in &mut self.overloads {
             overload.match_parameters(arguments.as_ref(), argument_forms, conflicting_forms);
         }

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -569,7 +569,7 @@ impl<'db> SpecializationBuilder<'db> {
                 self.types
                     .get(variable)
                     .copied()
-                    .unwrap_or(variable.default_ty(self.db).unwrap_or(Type::unknown()))
+                    .unwrap_or_else(|| variable.default_ty(self.db).unwrap_or(Type::unknown()))
             })
             .collect();
         Specialization::new(self.db, generic_context, types)

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -569,7 +569,7 @@ impl<'db> SpecializationBuilder<'db> {
                 self.types
                     .get(variable)
                     .copied()
-                    .unwrap_or_else(|| variable.default_ty(self.db).unwrap_or(Type::unknown()))
+                    .unwrap_or(variable.default_ty(self.db).unwrap_or(Type::unknown()))
             })
             .collect();
         Specialization::new(self.db, generic_context, types)


### PR DESCRIPTION
## Summary

Part of astral-sh/ty#104, closes: astral-sh/ty#468

This PR implements the argument type expansion which is step 3 of the overload call evaluation algorithm.

Specifically, this step needs to be taken if type checking resolves to no matching overload and there are argument types that can be expanded.

## Test Plan

Add new test cases.

## Ecosystem analysis

This PR removes 174 `no-matching-overload` false positives -- I looked at a lot of them and they all are false positives.

One thing that I'm not able to understand is that in https://github.com/sphinx-doc/sphinx/blob/2b7e3adf27c158305acca9b5e4d0d93d3e4c6f09/sphinx/ext/autodoc/preserve_defaults.py#L179 the inferred type of `value` is `str | None` by ty and Pyright, which is correct, but it's only ty that raises `invalid-argument-type` error while Pyright doesn't. The constructor method of `DefaultValue` has declared type of `str` which is invalid.

There are few cases of false positives resulting due to the fact that ty doesn't implement narrowing on attribute expressions.