### PR TITLE
[ty] Update docs for Python version inference

### DIFF
--- a/crates/ty/docs/cli.md
+++ b/crates/ty/docs/cli.md
@@ -72,8 +72,7 @@ over all configuration files.</p>
 <p>This is used to specialize the type of <code>sys.platform</code> and will affect the visibility of platform-specific functions and attributes. If the value is set to <code>all</code>, no assumptions are made about the target platform. If unspecified, the current system's platform will be used.</p>
 </dd><dt id="ty-check--python-version"><a href="#ty-check--python-version"><code>--python-version</code></a>, <code>--target-version</code> <i>version</i></dt><dd><p>Python version to assume when resolving types.</p>
 <p>The Python version affects allowed syntax, type definitions of the standard library, and type definitions of first- and third-party modules that are conditional on the Python version.</p>
-<p>By default, the Python version is inferred as the lower bound of the project's <code>requires-python</code> field from the <code>pyproject.toml</code>, if available. Otherwise, the latest stable version supported by ty is used, which is currently 3.13.</p>
-<p>ty will not infer the Python version from the Python environment at this time.</p>
+<p>By default, the Python version is inferred as the lower bound of the project's <code>requires-python</code> field from the <code>pyproject.toml</code>, if available. Otherwise, if a virtual environment has been configured or detected and a Python version can be inferred from the virtual environment's metadata, that version will be used. If neither of these applies, ty will fall back to the latest stable Python version supported by ty (currently 3.13).</p>
 <p>Possible values:</p>
 <ul>
 <li><code>3.7</code></li>

--- a/crates/ty/src/args.rs
+++ b/crates/ty/src/args.rs
@@ -82,10 +82,10 @@ pub(crate) struct CheckCommand {
     /// type definitions of first- and third-party modules that are conditional on the Python version.
     ///
     /// By default, the Python version is inferred as the lower bound of the project's
-    /// `requires-python` field from the `pyproject.toml`, if available. Otherwise, the latest
-    /// stable version supported by ty is used, which is currently 3.13.
-    ///
-    /// ty will not infer the Python version from the Python environment at this time.
+    /// `requires-python` field from the `pyproject.toml`, if available. Otherwise, if a virtual
+    /// environment has been configured or detected and a Python version can be inferred from the
+    /// virtual environment's metadata, that version will be used. If neither of these applies, ty
+    /// will fall back to the latest stable Python version supported by ty (currently 3.13).
     #[arg(long, value_name = "VERSION", alias = "target-version")]
     pub(crate) python_version: Option<PythonVersion>,
 


### PR DESCRIPTION
## Summary

Following https://github.com/astral-sh/ruff/pull/18057, we now infer the Python version from the user's virtual environment if it's possible to do so and the user has not configured a Python version explicitly. I forgot to update the docs.

## Test Plan

`cargo dev generate-all`
