### PR TITLE
[pylint] Ignore __init__.py files in (PLC0414)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/import_aliasing_2/__init__.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/import_aliasing_2/__init__.py
@@ -1,0 +1,8 @@
+# pylint: disable=unused-import, missing-docstring, invalid-name, reimported, import-error, wrong-import-order, no-name-in-module, shadowed-import
+# Functional tests for import aliasing
+# 1. useless-import-alias
+
+import collections as collections
+from collections import OrderedDict as OrderedDict
+from . import foo as foo
+from .foo import bar as bar

--- a/crates/ruff_linter/src/rules/pylint/mod.rs
+++ b/crates/ruff_linter/src/rules/pylint/mod.rs
@@ -168,6 +168,7 @@ mod tests {
     )]
     #[test_case(Rule::UselessElseOnLoop, Path::new("useless_else_on_loop.py"))]
     #[test_case(Rule::UselessImportAlias, Path::new("import_aliasing.py"))]
+    #[test_case(Rule::UselessImportAlias, Path::new("import_aliasing_2/__init__.py"))]
     #[test_case(Rule::UselessReturn, Path::new("useless_return.py"))]
     #[test_case(Rule::UselessWithLock, Path::new("useless_with_lock.py"))]
     #[test_case(Rule::UnreachableCode, Path::new("unreachable.py"))]

--- a/crates/ruff_linter/src/rules/pylint/rules/useless_import_alias.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/useless_import_alias.rs
@@ -67,6 +67,13 @@ pub(crate) fn useless_import_alias(checker: &Checker, alias: &Alias) {
     if alias.name.as_str() != asname.as_str() {
         return;
     }
+
+    // A re-export in __init__.py is probably intentional.
+    let in_init = checker.path().ends_with("__init__.py");
+    if in_init {
+        return;
+    }
+
     // A required import with a useless alias causes an infinite loop.
     // See https://github.com/astral-sh/ruff/issues/14283
     let required_import_conflict = checker
@@ -100,6 +107,13 @@ pub(crate) fn useless_import_from_alias(
     if alias.name.as_str() != asname.as_str() {
         return;
     }
+
+    // A re-export in __init__.py is probably intentional.
+    let in_init = checker.path().ends_with("__init__.py");
+    if in_init {
+        return;
+    }
+
     // A required import with a useless alias causes an infinite loop.
     // See https://github.com/astral-sh/ruff/issues/14283
     let required_import_conflict = checker.settings.isort.requires_member_import(

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLC0414_import_aliasing_2____init__.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLC0414_import_aliasing_2____init__.py.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff_linter/src/rules/pylint/mod.rs
+---
+


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

Ignore `__init__.py` files in `useless-import-alias` (PLC0414).
See discussion in #18365: we want to allow redundant aliases in `__init__.py` files, as they're almost always intentional explicit re-exports.
Closes #18365
<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
I added a new snapshot test.