### PR TITLE
[ty] Support type annotation for legacy typing aliases for generic classes

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/stdlib_typing_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/stdlib_typing_aliases.md
@@ -31,41 +31,31 @@ def f(
     ordered_dict_parametrized: typing.OrderedDict[int, str],
 ):
     reveal_type(list_bare)  # revealed: list[Unknown]
-    # TODO: revealed: list[int]
-    reveal_type(list_parametrized)  # revealed: list[Unknown]
+    reveal_type(list_parametrized)  # revealed: list[int]
 
     reveal_type(dict_bare)  # revealed: dict[Unknown, Unknown]
-    # TODO: revealed: dict[int, str]
-    reveal_type(dict_parametrized)  # revealed: dict[Unknown, Unknown]
+    reveal_type(dict_parametrized)  # revealed: dict[int, str]
 
     reveal_type(set_bare)  # revealed: set[Unknown]
-    # TODO: revealed: set[int]
-    reveal_type(set_parametrized)  # revealed: set[Unknown]
+    reveal_type(set_parametrized)  # revealed: set[int]
 
-    # TODO: revealed: frozenset[Unknown]
     reveal_type(frozen_set_bare)  # revealed: frozenset[Unknown]
-    # TODO: revealed: frozenset[str]
-    reveal_type(frozen_set_parametrized)  # revealed: frozenset[Unknown]
+    reveal_type(frozen_set_parametrized)  # revealed: frozenset[str]
 
     reveal_type(chain_map_bare)  # revealed: ChainMap[Unknown, Unknown]
-    # TODO: revealed: ChainMap[str, int]
-    reveal_type(chain_map_parametrized)  # revealed: ChainMap[Unknown, Unknown]
+    reveal_type(chain_map_parametrized)  # revealed: ChainMap[str, int]
 
     reveal_type(counter_bare)  # revealed: Counter[Unknown]
-    # TODO: revealed: Counter[int]
-    reveal_type(counter_parametrized)  # revealed: Counter[Unknown]
+    reveal_type(counter_parametrized)  # revealed: Counter[int]
 
     reveal_type(default_dict_bare)  # revealed: defaultdict[Unknown, Unknown]
-    # TODO: revealed: defaultdict[str, int]
-    reveal_type(default_dict_parametrized)  # revealed: defaultdict[Unknown, Unknown]
+    reveal_type(default_dict_parametrized)  # revealed: defaultdict[str, int]
 
     reveal_type(deque_bare)  # revealed: deque[Unknown]
-    # TODO: revealed: deque[str]
-    reveal_type(deque_parametrized)  # revealed: deque[Unknown]
+    reveal_type(deque_parametrized)  # revealed: deque[str]
 
     reveal_type(ordered_dict_bare)  # revealed: OrderedDict[Unknown, Unknown]
-    # TODO: revealed: OrderedDict[int, str]
-    reveal_type(ordered_dict_parametrized)  # revealed: OrderedDict[Unknown, Unknown]
+    reveal_type(ordered_dict_parametrized)  # revealed: OrderedDict[int, str]
 ```
 
 ## Inheritance

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -8727,42 +8727,73 @@ impl<'db> TypeInferenceBuilder<'db> {
                 }
             },
 
-            // TODO: Generics
-            KnownInstanceType::ChainMap => {
-                self.infer_type_expression(arguments_slice);
-                KnownClass::ChainMap.to_instance(db)
-            }
-            KnownInstanceType::OrderedDict => {
-                self.infer_type_expression(arguments_slice);
-                KnownClass::OrderedDict.to_instance(db)
-            }
-            KnownInstanceType::Dict => {
-                self.infer_type_expression(arguments_slice);
-                KnownClass::Dict.to_instance(db)
-            }
+            KnownInstanceType::ChainMap => match arguments_slice {
+                ast::Expr::Tuple(t) => {
+                    let args_ty = t.elts.iter().map(|elt| self.infer_type_expression(elt));
+                    let ty = KnownClass::ChainMap.to_specialized_instance(db, args_ty);
+                    self.store_expression_type(arguments_slice, ty);
+                    ty
+                }
+                _ => {
+                    self.infer_type_expression(arguments_slice);
+                    KnownClass::ChainMap.to_instance(db)
+                }
+            },
+            KnownInstanceType::OrderedDict => match arguments_slice {
+                ast::Expr::Tuple(t) => {
+                    let args_ty = t.elts.iter().map(|elt| self.infer_type_expression(elt));
+                    let ty = KnownClass::OrderedDict.to_specialized_instance(db, args_ty);
+                    self.store_expression_type(arguments_slice, ty);
+                    ty
+                }
+                _ => {
+                    self.infer_type_expression(arguments_slice);
+                    KnownClass::OrderedDict.to_instance(db)
+                }
+            },
+            KnownInstanceType::Dict => match arguments_slice {
+                ast::Expr::Tuple(t) => {
+                    let args_ty = t.elts.iter().map(|elt| self.infer_type_expression(elt));
+                    let ty = KnownClass::Dict.to_specialized_instance(db, args_ty);
+                    self.store_expression_type(arguments_slice, ty);
+                    ty
+                }
+                _ => {
+                    self.infer_type_expression(arguments_slice);
+                    KnownClass::Dict.to_instance(db)
+                }
+            },
             KnownInstanceType::List => {
-                self.infer_type_expression(arguments_slice);
-                KnownClass::List.to_instance(db)
+                let ty = self.infer_type_expression(arguments_slice);
+                KnownClass::List.to_specialized_instance(db, [ty])
             }
-            KnownInstanceType::DefaultDict => {
-                self.infer_type_expression(arguments_slice);
-                KnownClass::DefaultDict.to_instance(db)
-            }
+            KnownInstanceType::DefaultDict => match arguments_slice {
+                ast::Expr::Tuple(t) => {
+                    let args_ty = t.elts.iter().map(|elt| self.infer_type_expression(elt));
+                    let ty = KnownClass::DefaultDict.to_specialized_instance(db, args_ty);
+                    self.store_expression_type(arguments_slice, ty);
+                    ty
+                }
+                _ => {
+                    self.infer_type_expression(arguments_slice);
+                    KnownClass::DefaultDict.to_instance(db)
+                }
+            },
             KnownInstanceType::Counter => {
-                self.infer_type_expression(arguments_slice);
-                KnownClass::Counter.to_instance(db)
+                let ty = self.infer_type_expression(arguments_slice);
+                KnownClass::Counter.to_specialized_instance(db, [ty])
             }
             KnownInstanceType::Set => {
-                self.infer_type_expression(arguments_slice);
-                KnownClass::Set.to_instance(db)
+                let ty = self.infer_type_expression(arguments_slice);
+                KnownClass::Set.to_specialized_instance(db, [ty])
             }
             KnownInstanceType::FrozenSet => {
-                self.infer_type_expression(arguments_slice);
-                KnownClass::FrozenSet.to_instance(db)
+                let ty = self.infer_type_expression(arguments_slice);
+                KnownClass::FrozenSet.to_specialized_instance(db, [ty])
             }
             KnownInstanceType::Deque => {
-                self.infer_type_expression(arguments_slice);
-                KnownClass::Deque.to_instance(db)
+                let ty = self.infer_type_expression(arguments_slice);
+                KnownClass::Deque.to_specialized_instance(db, [ty])
             }
 
             KnownInstanceType::ReadOnly => {


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

Implements https://github.com/astral-sh/ty/issues/548.

This PR implements type annotations for legacy typing aliases for generic classes. 

Namely:
* `typing.List[T]`
* `typing.Dict[T, U]`
* `typing.Set[T]`
* `typing.FrozenSet[T]`
* `typing.ChainMap[T, U]`
* `typing.Counter[T]`
* `typing.DefaultDict[T, U]`
* `typing.Deque[T]`
* `typing.OrderedDict[T, U]`

Here is an example for `Dict` : 

```py
from typing import Dict

def f(x: Dict[str, int]):
    reveal_type(x)  # revealed: dict[str, int]
```

Thank you @dcreager and @carljm for helping me out!
## Test Plan

<!-- How was it tested? -->
I modified existing mdtest. I can add more cases if necessary!
