### PR TITLE
[ty] Fix server hang after shutdown request

### DIFF
--- a/crates/ty_server/src/lib.rs
+++ b/crates/ty_server/src/lib.rs
@@ -37,10 +37,18 @@ pub fn run_server() -> anyhow::Result<()> {
 
     let io_result = io_threads.join();
 
-    match (server_result, io_result) {
+    let result = match (server_result, io_result) {
         (Ok(()), Ok(())) => Ok(()),
         (Err(server), Err(io)) => Err(server).context(format!("IO thread error: {io}")),
         (Err(server), _) => Err(server),
         (_, Err(io)) => Err(io).context("IO thread error"),
+    };
+
+    if let Err(err) = result.as_ref() {
+        tracing::warn!("Server shut down with an error: {err}");
+    } else {
+        tracing::info!("Server shut down");
     }
+
+    result
 }

--- a/crates/ty_server/src/server.rs
+++ b/crates/ty_server/src/server.rs
@@ -200,7 +200,7 @@ impl ServerPanicHookHandler {
         let hook = std::panic::take_hook();
         let client = Arc::new(client);
 
-        // Use a weak reference to the client because it must be dropped when existing or the
+        // Use a weak reference to the client because it must be dropped when exiting or the
         // io-threads join hangs forever (because client has a reference to the connection sender).
         let hook_client = Arc::downgrade(&client);
 

--- a/crates/ty_server/src/server.rs
+++ b/crates/ty_server/src/server.rs
@@ -186,8 +186,10 @@ impl Server {
     }
 }
 
+type PanicHook = Box<dyn Fn(&PanicHookInfo<'_>) + 'static + Sync + Send>;
+
 struct ServerPanicHookHandler {
-    hook: Option<Box<dyn Fn(&PanicHookInfo<'_>) + 'static + Sync + Send>>,
+    hook: Option<PanicHook>,
 }
 
 impl ServerPanicHookHandler {

--- a/crates/ty_server/src/server.rs
+++ b/crates/ty_server/src/server.rs
@@ -129,59 +129,12 @@ impl Server {
     }
 
     pub(crate) fn run(mut self) -> crate::Result<()> {
-        type PanicHook = Box<dyn Fn(&PanicHookInfo<'_>) + 'static + Sync + Send>;
-        struct RestorePanicHook<'a> {
-            hook: Option<PanicHook>,
-            client: &'a std::sync::Mutex<Option<Client>>,
-        }
-
-        impl Drop for RestorePanicHook<'_> {
-            fn drop(&mut self) {
-                if let Ok(mut client) = self.client.lock() {
-                    // Take the client and drop it
-                    let _ = client.take();
-                }
-                if let Some(hook) = self.hook.take() {
-                    std::panic::set_hook(hook);
-                }
-            }
-        }
-
-        // It's important that this client gets dropped when exiting the main loop or
-        // joining the io_thread will wait forever because we hold on to a connection sender.
-        let client = std::sync::Mutex::new(Some(Client::new(
+        let client = Client::new(
             self.main_loop_sender.clone(),
             self.connection.sender.clone(),
-        )));
+        );
 
-        // unregister any previously registered panic hook
-        // The hook will be restored when this function exits.
-        let _ = RestorePanicHook {
-            hook: Some(std::panic::take_hook()),
-            client: &client,
-        };
-
-        // When we panic, try to notify the client.
-        std::panic::set_hook(Box::new(move |panic_info| {
-            use std::io::Write;
-
-            let backtrace = std::backtrace::Backtrace::force_capture();
-            tracing::error!("{panic_info}\n{backtrace}");
-
-            // we also need to print to stderr directly for when using `$logTrace` because
-            // the message won't be sent to the client.
-            // But don't use `eprintln` because `eprintln` itself may panic if the pipe is broken.
-            let mut stderr = std::io::stderr().lock();
-            writeln!(stderr, "{panic_info}\n{backtrace}").ok();
-
-            if let Ok(Some(client)) = client.lock().as_deref() {
-                client.show_message(
-                    "The ty language server exited with a panic. See the logs for more details.",
-                    MessageType::ERROR,
-                )
-                .ok();
-            }
-        }));
+        let _panic_hook = ServerPanicHookHandler::new(client);
 
         spawn_main_loop(move || self.main_loop())?.join()
     }
@@ -229,6 +182,50 @@ impl Server {
                     ..Default::default()
                 }),
             ..Default::default()
+        }
+    }
+}
+
+struct ServerPanicHookHandler {
+    hook: Option<Box<dyn Fn(&PanicHookInfo<'_>) + 'static + Sync + Send>>,
+}
+
+impl ServerPanicHookHandler {
+    fn new(client: Client) -> Self {
+        let hook = std::panic::take_hook();
+        // When we panic, try to notify the client.
+        std::panic::set_hook(Box::new(move |panic_info| {
+            use std::io::Write;
+
+            let backtrace = std::backtrace::Backtrace::force_capture();
+            tracing::error!("{panic_info}\n{backtrace}");
+
+            // we also need to print to stderr directly for when using `$logTrace` because
+            // the message won't be sent to the client.
+            // But don't use `eprintln` because `eprintln` itself may panic if the pipe is broken.
+            let mut stderr = std::io::stderr().lock();
+            writeln!(stderr, "{panic_info}\n{backtrace}").ok();
+
+            client
+                .show_message(
+                    "The ty language server exited with a panic. See the logs for more details.",
+                    MessageType::ERROR,
+                )
+                .ok();
+        }));
+
+        Self { hook: Some(hook) }
+    }
+}
+
+impl Drop for ServerPanicHookHandler {
+    fn drop(&mut self) {
+        // Unregistering the panic hook is important because it ensures that the `Client`
+        // is dropped. Dropping the `Client` is necessary or the server will hang
+        // after a shutdown request because the io-threads keep running in the hope
+        // that the panic-hook's client will send a message.
+        if let Some(hook) = self.hook.take() {
+            std::panic::set_hook(hook);
         }
     }
 }

--- a/crates/ty_server/src/server/api.rs
+++ b/crates/ty_server/src/server/api.rs
@@ -49,15 +49,7 @@ pub(super) fn request(req: server::Request) -> Task {
         >(
             req, BackgroundSchedule::LatencySensitive
         ),
-        lsp_types::request::Shutdown::METHOD => {
-            tracing::debug!("Received shutdown request, waiting for shutdown notification.");
-            Ok(Task::local(move |session, client| {
-                session.set_shutdown_requested(true);
-                if let Err(error) = client.respond(&req.id, Ok(())) {
-                    tracing::debug!("Failed to send shutdown response: {error}");
-                }
-            }))
-        }
+        lsp_types::request::Shutdown::METHOD => sync_request_task::<requests::ShutdownHandler>(req),
 
         method => {
             tracing::warn!("Received request {method} which does not have a handler");
@@ -71,7 +63,7 @@ pub(super) fn request(req: server::Request) -> Task {
     .unwrap_or_else(|err| {
         tracing::error!("Encountered error when routing request with ID {id}: {err}");
 
-        Task::local(move |_session, client| {
+        Task::sync(move |_session, client| {
             client.show_error_message(
                 "ty failed to handle a request from the editor. Check the logs for more details.",
             );
@@ -91,25 +83,25 @@ pub(super) fn request(req: server::Request) -> Task {
 pub(super) fn notification(notif: server::Notification) -> Task {
     match notif.method.as_str() {
         notifications::DidCloseTextDocumentHandler::METHOD => {
-            local_notification_task::<notifications::DidCloseTextDocumentHandler>(notif)
+            sync_notification_task::<notifications::DidCloseTextDocumentHandler>(notif)
         }
         notifications::DidOpenTextDocumentHandler::METHOD => {
-            local_notification_task::<notifications::DidOpenTextDocumentHandler>(notif)
+            sync_notification_task::<notifications::DidOpenTextDocumentHandler>(notif)
         }
         notifications::DidChangeTextDocumentHandler::METHOD => {
-            local_notification_task::<notifications::DidChangeTextDocumentHandler>(notif)
+            sync_notification_task::<notifications::DidChangeTextDocumentHandler>(notif)
         }
         notifications::DidOpenNotebookHandler::METHOD => {
-            local_notification_task::<notifications::DidOpenNotebookHandler>(notif)
+            sync_notification_task::<notifications::DidOpenNotebookHandler>(notif)
         }
         notifications::DidCloseNotebookHandler::METHOD => {
-            local_notification_task::<notifications::DidCloseNotebookHandler>(notif)
+            sync_notification_task::<notifications::DidCloseNotebookHandler>(notif)
         }
         notifications::DidChangeWatchedFiles::METHOD => {
-            local_notification_task::<notifications::DidChangeWatchedFiles>(notif)
+            sync_notification_task::<notifications::DidChangeWatchedFiles>(notif)
         }
         lsp_types::notification::Cancel::METHOD => {
-            local_notification_task::<notifications::CancelNotificationHandler>(notif)
+            sync_notification_task::<notifications::CancelNotificationHandler>(notif)
         }
         lsp_types::notification::SetTrace::METHOD => {
             tracing::trace!("Ignoring `setTrace` notification");
@@ -123,7 +115,7 @@ pub(super) fn notification(notif: server::Notification) -> Task {
     }
         .unwrap_or_else(|err| {
             tracing::error!("Encountered error when routing notification: {err}");
-            Task::local(|_session, client| {
+            Task::sync(|_session, client| {
                 client.show_error_message(
                     "ty failed to handle a notification from the editor. Check the logs for more details."
                 );
@@ -131,12 +123,12 @@ pub(super) fn notification(notif: server::Notification) -> Task {
         })
 }
 
-fn _local_request_task<R: traits::SyncRequestHandler>(req: server::Request) -> Result<Task>
+fn sync_request_task<R: traits::SyncRequestHandler>(req: server::Request) -> Result<Task>
 where
     <<R as RequestHandler>::RequestType as Request>::Params: UnwindSafe,
 {
     let (id, params) = cast_request::<R>(req)?;
-    Ok(Task::local(move |session, client: &Client| {
+    Ok(Task::sync(move |session, client: &Client| {
         let _span = tracing::debug_span!("request", %id, method = R::METHOD).entered();
         let result = R::run(session, client, params);
         respond::<R>(&id, result, client);
@@ -254,11 +246,11 @@ where
     }
 }
 
-fn local_notification_task<N: traits::SyncNotificationHandler>(
+fn sync_notification_task<N: traits::SyncNotificationHandler>(
     notif: server::Notification,
 ) -> Result<Task> {
     let (id, params) = cast_notification::<N>(notif)?;
-    Ok(Task::local(move |session, client| {
+    Ok(Task::sync(move |session, client| {
         let _span = tracing::debug_span!("notification", method = N::METHOD).entered();
         if let Err(err) = N::run(session, client, params) {
             tracing::error!("An error occurred while running {id}: {err}");

--- a/crates/ty_server/src/server/api/requests.rs
+++ b/crates/ty_server/src/server/api/requests.rs
@@ -3,9 +3,11 @@ mod diagnostic;
 mod goto_type_definition;
 mod hover;
 mod inlay_hints;
+mod shutdown;
 
 pub(super) use completion::CompletionRequestHandler;
 pub(super) use diagnostic::DocumentDiagnosticRequestHandler;
 pub(super) use goto_type_definition::GotoTypeDefinitionRequestHandler;
 pub(super) use hover::HoverRequestHandler;
 pub(super) use inlay_hints::InlayHintRequestHandler;
+pub(super) use shutdown::ShutdownHandler;

--- a/crates/ty_server/src/server/api/requests/shutdown.rs
+++ b/crates/ty_server/src/server/api/requests/shutdown.rs
@@ -1,0 +1,17 @@
+use crate::Session;
+use crate::server::api::traits::{RequestHandler, SyncRequestHandler};
+use crate::session::client::Client;
+
+pub(crate) struct ShutdownHandler;
+
+impl RequestHandler for ShutdownHandler {
+    type RequestType = lsp_types::request::Shutdown;
+}
+
+impl SyncRequestHandler for ShutdownHandler {
+    fn run(session: &mut Session, _client: &Client, _params: ()) -> crate::server::Result<()> {
+        tracing::debug!("Received shutdown request, waiting for shutdown notification");
+        session.set_shutdown_requested(true);
+        Ok(())
+    }
+}

--- a/crates/ty_server/src/server/api/traits.rs
+++ b/crates/ty_server/src/server/api/traits.rs
@@ -17,7 +17,6 @@ pub(super) trait RequestHandler {
 /// This will block the main message receiver loop, meaning that no
 /// incoming requests or notifications will be handled while `run` is
 /// executing. Try to avoid doing any I/O or long-running computations.
-#[expect(dead_code)]
 pub(super) trait SyncRequestHandler: RequestHandler {
     fn run(
         session: &mut Session,

--- a/crates/ty_server/src/server/connection.rs
+++ b/crates/ty_server/src/server/connection.rs
@@ -1,18 +1,10 @@
 use lsp_server as lsp;
-use lsp_types::{notification::Notification, request::Request};
 
 pub(crate) type ConnectionSender = crossbeam::channel::Sender<lsp::Message>;
-type ConnectionReceiver = crossbeam::channel::Receiver<lsp::Message>;
 
 /// A builder for `Connection` that handles LSP initialization.
 pub(crate) struct ConnectionInitializer {
     connection: lsp::Connection,
-}
-
-/// Handles inbound and outbound messages with the client.
-pub(crate) struct Connection {
-    sender: ConnectionSender,
-    receiver: ConnectionReceiver,
 }
 
 impl ConnectionInitializer {
@@ -40,7 +32,7 @@ impl ConnectionInitializer {
         server_capabilities: &lsp_types::ServerCapabilities,
         name: &str,
         version: &str,
-    ) -> crate::Result<Connection> {
+    ) -> crate::Result<lsp_server::Connection> {
         self.connection.initialize_finish(
             id,
             serde_json::json!({
@@ -51,76 +43,7 @@ impl ConnectionInitializer {
                 }
             }),
         )?;
-        let Self {
-            connection: lsp::Connection { sender, receiver },
-        } = self;
-        Ok(Connection { sender, receiver })
-    }
-}
 
-impl Connection {
-    /// Make a new `ClientSender` for sending messages to the client.
-    pub(super) fn sender(&self) -> ConnectionSender {
-        self.sender.clone()
-    }
-
-    pub(super) fn send(&self, msg: lsp::Message) -> crate::Result<()> {
-        self.sender.send(msg)?;
-        Ok(())
-    }
-
-    /// An iterator over incoming messages from the client.
-    pub(super) fn incoming(&self) -> &crossbeam::channel::Receiver<lsp::Message> {
-        &self.receiver
-    }
-
-    /// Check and respond to any incoming shutdown requests; returns`true` if the server should be shutdown.
-    pub(super) fn handle_shutdown(&self, message: &lsp::Message) -> crate::Result<bool> {
-        match message {
-            lsp::Message::Request(lsp::Request { id, method, .. })
-                if method == lsp_types::request::Shutdown::METHOD =>
-            {
-                self.sender
-                    .send(lsp::Response::new_ok(id.clone(), ()).into())?;
-                tracing::info!("Shutdown request received. Waiting for an exit notification...");
-
-                loop {
-                    match &self
-                        .receiver
-                        .recv_timeout(std::time::Duration::from_secs(30))?
-                    {
-                        lsp::Message::Notification(lsp::Notification { method, .. })
-                            if method == lsp_types::notification::Exit::METHOD =>
-                        {
-                            tracing::info!("Exit notification received. Server shutting down...");
-                            return Ok(true);
-                        }
-                        lsp::Message::Request(lsp::Request { id, method, .. }) => {
-                            tracing::warn!(
-                                "Server received unexpected request {method} ({id}) while waiting for exit notification",
-                            );
-                            self.sender.send(lsp::Message::Response(lsp::Response::new_err(
-                                id.clone(),
-                                lsp::ErrorCode::InvalidRequest as i32,
-                                "Server received unexpected request while waiting for exit notification".to_string(),
-                            )))?;
-                        }
-                        message => {
-                            tracing::warn!(
-                                "Server received unexpected message while waiting for exit notification: {message:?}"
-                            );
-                        }
-                    }
-                }
-            }
-            lsp::Message::Notification(lsp::Notification { method, .. })
-                if method == lsp_types::notification::Exit::METHOD =>
-            {
-                anyhow::bail!(
-                    "Server received an exit notification before a shutdown request was sent. Exiting..."
-                );
-            }
-            _ => Ok(false),
-        }
+        Ok(self.connection)
     }
 }

--- a/crates/ty_server/src/server/schedule/task.rs
+++ b/crates/ty_server/src/server/schedule/task.rs
@@ -68,7 +68,7 @@ impl Task {
         })
     }
     /// Creates a new local task.
-    pub(crate) fn local<F>(func: F) -> Self
+    pub(crate) fn sync<F>(func: F) -> Self
     where
         F: FnOnce(&mut Session, &Client) + 'static,
     {
@@ -82,7 +82,7 @@ impl Task {
     where
         R: Serialize + Send + 'static,
     {
-        Self::local(move |_, client| {
+        Self::sync(move |_, client| {
             if let Err(err) = client.respond(&id, result) {
                 tracing::error!("Unable to send immediate response: {err}");
             }
@@ -91,6 +91,6 @@ impl Task {
 
     /// Creates a local task that does nothing.
     pub(crate) fn nothing() -> Self {
-        Self::local(move |_, _| {})
+        Self::sync(move |_, _| {})
     }
 }

--- a/crates/ty_server/src/session.rs
+++ b/crates/ty_server/src/session.rs
@@ -50,6 +50,9 @@ pub struct Session {
 
     /// Tracks the pending requests between client and server.
     request_queue: RequestQueue,
+
+    /// Has the client requested the server to shutdown.
+    shutdown_requested: bool,
 }
 
 impl Session {
@@ -86,6 +89,7 @@ impl Session {
                 client_capabilities,
             )),
             request_queue: RequestQueue::new(),
+            shutdown_requested: false,
         })
     }
 
@@ -95,6 +99,14 @@ impl Session {
 
     pub(crate) fn request_queue_mut(&mut self) -> &mut RequestQueue {
         &mut self.request_queue
+    }
+
+    pub(crate) fn is_shutdown_requested(&self) -> bool {
+        self.shutdown_requested
+    }
+
+    pub(crate) fn set_shutdown_requested(&mut self, requested: bool) {
+        self.shutdown_requested = requested;
     }
 
     // TODO(dhruvmanila): Ideally, we should have a single method for `workspace_db_for_path_mut`


### PR DESCRIPTION
## Summary

This fixes an error where the ty server didn't exit after receiving the shutdown request. 

The root cause was the panic handler which hold on to a client sender channel, preventing the io thread from exiting (because there was still the chance that we would send a message).

I tested that the server now correctly exits with VS code. However, I never see an exit notification when closing VS code, only when restarting the server with the restart command. This is consistent with ruff.


