### PR TITLE
[ty] Fix false positives for legacy `ParamSpec`s inside `Callable` type expressions

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/callable.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/callable.md
@@ -264,10 +264,9 @@ from typing_extensions import ParamSpec
 
 P2 = ParamSpec("P2")
 
-# TODO: Not an error; remove once `ParamSpec` is supported
-# error: [invalid-type-form]
+# TODO: argument list should not be `...` (requires `ParamSpec` support)
 def _(c: Callable[P2, int]):
-    reveal_type(c)  # revealed: (...) -> Unknown
+    reveal_type(c)  # revealed: (...) -> int
 ```
 
 ## Using `typing.Unpack`


### PR DESCRIPTION
## Summary

Full `ParamSpec` support will be some way off, but it's pretty easy to remove false positives for legacy `ParamSpec`s in the meantime. We already got rid of false positives for PEP-695 `ParamSpec`s in an earlier PR.

## Test Plan

Existing mdtests updated
