### PR TITLE
[`flake8-return`] Fix `RET504` autofix generating a syntax error

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_return/RET504.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_return/RET504.py
@@ -427,3 +427,8 @@ def f():
     (#=
     x) = 1
     return x
+
+def f():
+    x = (1
+              )
+    return x

--- a/crates/ruff_linter/resources/test/fixtures/flake8_return/RET504.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_return/RET504.py
@@ -421,3 +421,9 @@ def func(a: dict[str, int]) -> list[dict[str, int]]:
     if "services" in a:
         services = a["services"]
         return services
+
+# See: https://github.com/astral-sh/ruff/issues/18411
+def f():
+    (#=
+    x) = 1
+    return x

--- a/crates/ruff_linter/src/rules/flake8_return/rules/function.rs
+++ b/crates/ruff_linter/src/rules/flake8_return/rules/function.rs
@@ -615,15 +615,15 @@ fn unnecessary_assign(checker: &Checker, stack: &Stack) {
 
             let eq_token = checker
                 .tokens()
+                .before(assign.value.start())
                 .iter()
-                .filter(|token| assign.range().contains_range(token.range()))
-                .find(|token| token.kind() == TokenKind::Equal)
+                .rfind(|token| token.kind() == TokenKind::Equal)
                 .unwrap();
 
             let content = checker.source();
             // Replace the `x = 1` statement with `return 1`.
             let replace_assign = Edit::range_replacement(
-                if content[eq_token.range().end().to_usize()..]
+                if content[eq_token.end().to_usize()..]
                     .chars()
                     .next()
                     .is_some_and(is_python_whitespace)

--- a/crates/ruff_linter/src/rules/flake8_return/snapshots/ruff_linter__rules__flake8_return__tests__RET504_RET504.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_return/snapshots/ruff_linter__rules__flake8_return__tests__RET504_RET504.py.snap
@@ -269,6 +269,8 @@ RET504.py:429:12: RET504 [*] Unnecessary assignment to `x` before `return` state
 428 |     x) = 1
 429 |     return x
     |            ^ RET504
+430 |
+431 | def f():
     |
     = help: Remove unnecessary assignment
 
@@ -280,3 +282,24 @@ RET504.py:429:12: RET504 [*] Unnecessary assignment to `x` before `return` state
 428     |-    x) = 1
 429     |-    return x
     427 |+    return 1
+430 428 | 
+431 429 | def f():
+432 430 |     x = (1
+
+RET504.py:434:12: RET504 [*] Unnecessary assignment to `x` before `return` statement
+    |
+432 |     x = (1
+433 |               )
+434 |     return x
+    |            ^ RET504
+    |
+    = help: Remove unnecessary assignment
+
+ℹ Unsafe fix
+429 429 |     return x
+430 430 | 
+431 431 | def f():
+432     |-    x = (1
+    432 |+    return (1
+433 433 |               )
+434     |-    return x

--- a/crates/ruff_linter/src/rules/flake8_return/snapshots/ruff_linter__rules__flake8_return__tests__RET504_RET504.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_return/snapshots/ruff_linter__rules__flake8_return__tests__RET504_RET504.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_return/mod.rs
-snapshot_kind: text
 ---
 RET504.py:6:12: RET504 [*] Unnecessary assignment to `a` before `return` statement
   |
@@ -248,6 +247,8 @@ RET504.py:423:16: RET504 [*] Unnecessary assignment to `services` before `return
 422 |         services = a["services"]
 423 |         return services
     |                ^^^^^^^^ RET504
+424 |
+425 | # See: https://github.com/astral-sh/ruff/issues/18411
     |
     = help: Remove unnecessary assignment
 
@@ -258,3 +259,24 @@ RET504.py:423:16: RET504 [*] Unnecessary assignment to `services` before `return
 422     |-        services = a["services"]
 423     |-        return services
     422 |+        return a["services"]
+424 423 | 
+425 424 | # See: https://github.com/astral-sh/ruff/issues/18411
+426 425 | def f():
+
+RET504.py:429:12: RET504 [*] Unnecessary assignment to `x` before `return` statement
+    |
+427 |     (#=
+428 |     x) = 1
+429 |     return x
+    |            ^ RET504
+    |
+    = help: Remove unnecessary assignment
+
+ℹ Unsafe fix
+424 424 | 
+425 425 | # See: https://github.com/astral-sh/ruff/issues/18411
+426 426 | def f():
+427     |-    (#=
+428     |-    x) = 1
+429     |-    return x
+    427 |+    return 1


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

Fixes #18411

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

Add regression test.
<!-- How was it tested? -->
