### PR TITLE
[ty] Unify `Type::is_subtype_of()` and `Type::is_assignable_to()`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/intersection_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/intersection_types.md
@@ -303,12 +303,19 @@ static_assert(is_equivalent_to(Intersection[object, Not[P]], Not[P]))
 Continuing with more [complement laws], if we see both `P` and `~P` in an intersection, we can
 simplify to `Never`, even in the presence of other types:
 
+```toml
+[environment]
+python-version = "3.12"
+```
+
 ```py
 from ty_extensions import Intersection, Not
 from typing import Any
 
 class P: ...
 class Q: ...
+class R[T]: ...
+class S[T]: ...
 
 def _(
     i1: Intersection[P, Not[P]],
@@ -317,6 +324,8 @@ def _(
     i4: Intersection[Not[P], Q, P],
     i5: Intersection[P, Any, Not[P]],
     i6: Intersection[Not[P], Any, P],
+    i7: Intersection[R[P], Not[R[P]]],
+    i8: Intersection[R[P], Not[R[Q]]],
 ) -> None:
     reveal_type(i1)  # revealed: Never
     reveal_type(i2)  # revealed: Never
@@ -324,28 +333,40 @@ def _(
     reveal_type(i4)  # revealed: Never
     reveal_type(i5)  # revealed: Never
     reveal_type(i6)  # revealed: Never
+    reveal_type(i7)  # revealed: Never
+    reveal_type(i8)  # revealed: R[P] & ~R[Q]
 ```
 
 ### Union of a type and its negation
 
 Similarly, if we have both `P` and `~P` in a _union_, we can simplify that to `object`.
 
+```toml
+[environment]
+python-version = "3.12"
+```
+
 ```py
 from ty_extensions import Intersection, Not
 
 class P: ...
 class Q: ...
+class R[T]: ...
 
 def _(
     i1: P | Not[P],
     i2: Not[P] | P,
     i3: P | Q | Not[P],
     i4: Not[P] | Q | P,
+    i5: R[P] | Not[R[P]],
+    i6: R[P] | Not[R[Q]],
 ) -> None:
     reveal_type(i1)  # revealed: object
     reveal_type(i2)  # revealed: object
     reveal_type(i3)  # revealed: object
     reveal_type(i4)  # revealed: object
+    reveal_type(i5)  # revealed: object
+    reveal_type(i6)  # revealed: R[P] | ~R[Q]
 ```
 
 ### Negation is an involution

--- a/crates/ty_python_semantic/resources/mdtest/intersection_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/intersection_types.md
@@ -303,19 +303,15 @@ static_assert(is_equivalent_to(Intersection[object, Not[P]], Not[P]))
 Continuing with more [complement laws], if we see both `P` and `~P` in an intersection, we can
 simplify to `Never`, even in the presence of other types:
 
-```toml
-[environment]
-python-version = "3.12"
-```
-
 ```py
 from ty_extensions import Intersection, Not
-from typing import Any
+from typing import Any, Generic, TypeVar
+
+T_co = TypeVar("T_co", covariant=True)
 
 class P: ...
 class Q: ...
-class R[T]: ...
-class S[T]: ...
+class R(Generic[T_co]): ...
 
 def _(
     i1: Intersection[P, Not[P]],
@@ -341,17 +337,15 @@ def _(
 
 Similarly, if we have both `P` and `~P` in a _union_, we can simplify that to `object`.
 
-```toml
-[environment]
-python-version = "3.12"
-```
-
 ```py
 from ty_extensions import Intersection, Not
+from typing import Generic, TypeVar
+
+T_co = TypeVar("T_co", covariant=True)
 
 class P: ...
 class Q: ...
-class R[T]: ...
+class R(Generic[T_co]): ...
 
 def _(
     i1: P | Not[P],

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -902,8 +902,7 @@ from ty_extensions import is_subtype_of, is_assignable_to, static_assert, TypeOf
 class HasX(Protocol):
     x: int
 
-# TODO: this should pass
-static_assert(is_subtype_of(TypeOf[module], HasX))  # error: [static-assert-error]
+static_assert(is_subtype_of(TypeOf[module], HasX))
 static_assert(is_assignable_to(TypeOf[module], HasX))
 
 class ExplicitProtocolSubtype(HasX, Protocol):

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
@@ -224,6 +224,10 @@ static_assert(is_assignable_to(TypeOf[Bar[Any]], type[Foo[int]]))
 static_assert(is_assignable_to(TypeOf[Bar], type[Foo]))
 static_assert(is_assignable_to(TypeOf[Bar[Any]], type[Foo[Any]]))
 static_assert(is_assignable_to(TypeOf[Bar[Any]], type[Foo[int]]))
+
+# TODO: these should pass (all subscripts inside `type[]` type expressions are currently TODO types)
+static_assert(not is_assignable_to(TypeOf[Bar[int]], type[Foo[bool]]))  # error: [static-assert-error]
+static_assert(not is_assignable_to(TypeOf[Foo[bool]], type[Bar[int]]))  # error: [static-assert-error]
 ```
 
 ## `type[]` is not assignable to types disjoint from `builtins.type`

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
@@ -209,6 +209,21 @@ class AnyMeta(metaclass=Any): ...
 static_assert(is_assignable_to(type[AnyMeta], type))
 static_assert(is_assignable_to(type[AnyMeta], type[object]))
 static_assert(is_assignable_to(type[AnyMeta], type[Any]))
+
+from typing import TypeVar, Generic, Any
+
+T_co = TypeVar("T_co", covariant=True)
+
+class Foo(Generic[T_co]): ...
+class Bar(Foo[T_co], Generic[T_co]): ...
+
+static_assert(is_assignable_to(TypeOf[Bar[int]], type[Foo[int]]))
+static_assert(is_assignable_to(TypeOf[Bar[bool]], type[Foo[int]]))
+static_assert(is_assignable_to(TypeOf[Bar], type[Foo[int]]))
+static_assert(is_assignable_to(TypeOf[Bar[Any]], type[Foo[int]]))
+static_assert(is_assignable_to(TypeOf[Bar], type[Foo]))
+static_assert(is_assignable_to(TypeOf[Bar[Any]], type[Foo[Any]]))
+static_assert(is_assignable_to(TypeOf[Bar[Any]], type[Foo[int]]))
 ```
 
 ## `type[]` is not assignable to types disjoint from `builtins.type`

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1373,6 +1373,19 @@ impl<'db> Type<'db> {
                 .metaclass_instance_type(db)
                 .has_relation_to(db, target, relation),
 
+            // This branch upholds two properties:
+            // - For any type `T` that is assignable to `type`, `T` shall be assignable to `type[Any]`.
+            // - For any type `T` that is assignable to `type`, `type[Any]` shall be assignable to `T`.
+            //
+            // This is really the same as the very first branch in this `match` statement that handles dynamic types.
+            // That branch upholds two properties:
+            // - For any type `S` that is assignable to `object` (which is _all_ types), `S` shall be assignable to `Any`
+            // - For any type `S` that is assignable to `object` (which is _all_ types), `Any` shall be assignable to `S`.
+            //
+            // The only difference between this branch and the first branch is that the first branch deals with the type
+            // `object & Any` (which simplifies to `Any`!) whereas this branch deals with the type `type & Any`.
+            //
+            // See also: <https://github.com/astral-sh/ty/issues/222>
             (Type::SubclassOf(subclass_of_ty), other)
             | (other, Type::SubclassOf(subclass_of_ty))
                 if subclass_of_ty.is_dynamic()

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -340,16 +340,6 @@ impl<'db> ClassType<'db> {
         class_literal.is_final(db)
     }
 
-    /// Is this class a subclass of `Any` or `Unknown`?
-    pub(crate) fn is_subclass_of_any_or_unknown(self, db: &'db dyn Db) -> bool {
-        self.iter_mro(db).any(|base| {
-            matches!(
-                base,
-                ClassBase::Dynamic(DynamicType::Any | DynamicType::Unknown)
-            )
-        })
-    }
-
     /// Return `true` if `other` is present in this class's MRO.
     pub(super) fn is_subclass_of(self, db: &'db dyn Db, other: ClassType<'db>) -> bool {
         self.iter_mro(db).any(|base| {

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -12,7 +12,7 @@ use crate::types::function::{DataclassTransformerParams, KnownFunction};
 use crate::types::generics::{GenericContext, Specialization};
 use crate::types::signatures::{CallableSignature, Parameter, Parameters, Signature};
 use crate::types::{
-    CallableType, DataclassParams, KnownInstanceType, TypeMapping, TypeVarInstance,
+    CallableType, DataclassParams, KnownInstanceType, TypeMapping, TypeRelation, TypeVarInstance,
 };
 use crate::{
     Db, FxOrderSet, KnownModule, Program,
@@ -29,8 +29,8 @@ use crate::{
         place_table, semantic_index, use_def_map,
     },
     types::{
-        CallArgumentTypes, CallError, CallErrorKind, DynamicType, MetaclassCandidate, TupleType,
-        UnionBuilder, UnionType, definition_expression_type,
+        CallArgumentTypes, CallError, CallErrorKind, MetaclassCandidate, TupleType, UnionBuilder,
+        UnionType, definition_expression_type,
     },
 };
 use indexmap::IndexSet;
@@ -342,11 +342,20 @@ impl<'db> ClassType<'db> {
 
     /// Return `true` if `other` is present in this class's MRO.
     pub(super) fn is_subclass_of(self, db: &'db dyn Db, other: ClassType<'db>) -> bool {
+        self.has_relation_to(db, other, TypeRelation::Subtyping)
+    }
+
+    pub(super) fn has_relation_to(
+        self,
+        db: &'db dyn Db,
+        other: Self,
+        relation: TypeRelation,
+    ) -> bool {
         self.iter_mro(db).any(|base| {
             match base {
-                // `is_subclass_of` is checking the subtype relation, in which gradual types do not
-                // participate.
-                ClassBase::Dynamic(_) => false,
+                ClassBase::Dynamic(_) => {
+                    relation.applies_to_non_fully_static_types() && !other.is_final(db)
+                }
 
                 // Protocol and Generic are not represented by a ClassType.
                 ClassBase::Protocol | ClassBase::Generic => false,
@@ -355,9 +364,11 @@ impl<'db> ClassType<'db> {
                     (ClassType::NonGeneric(base), ClassType::NonGeneric(other)) => base == other,
                     (ClassType::Generic(base), ClassType::Generic(other)) => {
                         base.origin(db) == other.origin(db)
-                            && base
-                                .specialization(db)
-                                .is_subtype_of(db, other.specialization(db))
+                            && base.specialization(db).has_relation_to(
+                                db,
+                                other.specialization(db),
+                                relation,
+                            )
                     }
                     (ClassType::Generic(_), ClassType::NonGeneric(_))
                     | (ClassType::NonGeneric(_), ClassType::Generic(_)) => false,
@@ -378,30 +389,6 @@ impl<'db> ClassType<'db> {
                         .is_equivalent_to(db, other.specialization(db))
             }
         }
-    }
-
-    pub(super) fn is_assignable_to(self, db: &'db dyn Db, other: ClassType<'db>) -> bool {
-        self.iter_mro(db).any(|base| {
-            match base {
-                ClassBase::Dynamic(DynamicType::Any | DynamicType::Unknown) => !other.is_final(db),
-                ClassBase::Dynamic(_) => false,
-
-                // Protocol and Generic are not represented by a ClassType.
-                ClassBase::Protocol | ClassBase::Generic => false,
-
-                ClassBase::Class(base) => match (base, other) {
-                    (ClassType::NonGeneric(base), ClassType::NonGeneric(other)) => base == other,
-                    (ClassType::Generic(base), ClassType::Generic(other)) => {
-                        base.origin(db) == other.origin(db)
-                            && base
-                                .specialization(db)
-                                .is_assignable_to(db, other.specialization(db))
-                    }
-                    (ClassType::Generic(_), ClassType::NonGeneric(_))
-                    | (ClassType::NonGeneric(_), ClassType::Generic(_)) => false,
-                },
-            }
-        })
     }
 
     pub(super) fn is_gradual_equivalent_to(self, db: &'db dyn Db, other: ClassType<'db>) -> bool {

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -279,10 +279,6 @@ impl<'db> ClassBase<'db> {
             }
         }
     }
-
-    pub(crate) const fn is_dynamic(self) -> bool {
-        matches!(self, Self::Dynamic(_))
-    }
 }
 
 impl<'db> From<ClassType<'db>> for ClassBase<'db> {

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -67,7 +67,9 @@ use crate::semantic_index::semantic_index;
 use crate::types::generics::GenericContext;
 use crate::types::narrow::ClassInfoConstraintFunction;
 use crate::types::signatures::{CallableSignature, Signature};
-use crate::types::{BoundMethodType, CallableType, Type, TypeMapping, TypeVarInstance};
+use crate::types::{
+    BoundMethodType, CallableType, Type, TypeMapping, TypeRelation, TypeVarInstance,
+};
 use crate::{Db, FxOrderSet};
 
 /// A collection of useful spans for annotating functions.
@@ -705,6 +707,18 @@ impl<'db> FunctionType<'db> {
         self_instance: Type<'db>,
     ) -> Type<'db> {
         Type::BoundMethod(BoundMethodType::new(db, self, self_instance))
+    }
+
+    pub(crate) fn has_relation_to(
+        self,
+        db: &'db dyn Db,
+        other: Self,
+        relation: TypeRelation,
+    ) -> bool {
+        match relation {
+            TypeRelation::Subtyping => self.is_subtype_of(db, other),
+            TypeRelation::Assignability => self.is_assignable_to(db, other),
+        }
     }
 
     pub(crate) fn is_subtype_of(self, db: &'db dyn Db, other: Self) -> bool {

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -358,14 +358,6 @@ impl<'db> Specialization<'db> {
         Self::new(db, self.generic_context(db), types)
     }
 
-    pub(crate) fn is_subtype_of(self, db: &'db dyn Db, other: Self) -> bool {
-        self.has_relation_to(db, other, TypeRelation::Subtyping)
-    }
-
-    pub(crate) fn is_assignable_to(self, db: &'db dyn Db, other: Self) -> bool {
-        self.has_relation_to(db, other, TypeRelation::Assignability)
-    }
-
     pub(crate) fn has_relation_to(
         self,
         db: &'db dyn Db,

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -9,7 +9,7 @@ use crate::types::class_base::ClassBase;
 use crate::types::instance::{NominalInstanceType, Protocol, ProtocolInstanceType};
 use crate::types::signatures::{Parameter, Parameters, Signature};
 use crate::types::{
-    KnownInstanceType, Type, TypeMapping, TypeVarBoundOrConstraints, TypeVarInstance,
+    KnownInstanceType, Type, TypeMapping, TypeRelation, TypeVarBoundOrConstraints, TypeVarInstance,
     TypeVarVariance, UnionType, declaration_type, todo_type,
 };
 use crate::{Db, FxOrderSet};
@@ -358,7 +358,20 @@ impl<'db> Specialization<'db> {
         Self::new(db, self.generic_context(db), types)
     }
 
-    pub(crate) fn is_subtype_of(self, db: &'db dyn Db, other: Specialization<'db>) -> bool {
+    pub(crate) fn is_subtype_of(self, db: &'db dyn Db, other: Self) -> bool {
+        self.has_relation_to(db, other, TypeRelation::Subtyping)
+    }
+
+    pub(crate) fn is_assignable_to(self, db: &'db dyn Db, other: Self) -> bool {
+        self.has_relation_to(db, other, TypeRelation::Assignability)
+    }
+
+    pub(crate) fn has_relation_to(
+        self,
+        db: &'db dyn Db,
+        other: Self,
+        relation: TypeRelation,
+    ) -> bool {
         let generic_context = self.generic_context(db);
         if generic_context != other.generic_context(db) {
             return false;
@@ -368,20 +381,31 @@ impl<'db> Specialization<'db> {
             .zip(self.types(db))
             .zip(other.types(db))
         {
-            if matches!(self_type, Type::Dynamic(_)) || matches!(other_type, Type::Dynamic(_)) {
-                return false;
+            if self_type.is_dynamic() || other_type.is_dynamic() {
+                match relation {
+                    TypeRelation::Assignability => continue,
+                    TypeRelation::Subtyping => return false,
+                }
             }
 
-            // Subtyping of each type in the specialization depends on the variance of the
-            // corresponding typevar:
+            // Subtyping/assignability of each type in the specialization depends on the variance
+            // of the corresponding typevar:
             //   - covariant: verify that self_type <: other_type
             //   - contravariant: verify that other_type <: self_type
-            //   - invariant: verify that self_type == other_type
-            //   - bivariant: skip, can't make subtyping false
+            //   - invariant: verify that self_type <: other_type AND other_type <: self_type
+            //   - bivariant: skip, can't make subtyping/assignability false
             let compatible = match typevar.variance(db) {
-                TypeVarVariance::Invariant => self_type.is_equivalent_to(db, *other_type),
-                TypeVarVariance::Covariant => self_type.is_subtype_of(db, *other_type),
-                TypeVarVariance::Contravariant => other_type.is_subtype_of(db, *self_type),
+                TypeVarVariance::Invariant => match relation {
+                    TypeRelation::Subtyping => self_type.is_equivalent_to(db, *other_type),
+                    TypeRelation::Assignability => {
+                        self_type.is_assignable_to(db, *other_type)
+                            && other_type.is_assignable_to(db, *self_type)
+                    }
+                },
+                TypeVarVariance::Covariant => self_type.has_relation_to(db, *other_type, relation),
+                TypeVarVariance::Contravariant => {
+                    other_type.has_relation_to(db, *self_type, relation)
+                }
                 TypeVarVariance::Bivariant => true,
             };
             if !compatible {
@@ -416,43 +440,6 @@ impl<'db> Specialization<'db> {
                 TypeVarVariance::Invariant
                 | TypeVarVariance::Covariant
                 | TypeVarVariance::Contravariant => self_type.is_equivalent_to(db, *other_type),
-                TypeVarVariance::Bivariant => true,
-            };
-            if !compatible {
-                return false;
-            }
-        }
-
-        true
-    }
-
-    pub(crate) fn is_assignable_to(self, db: &'db dyn Db, other: Specialization<'db>) -> bool {
-        let generic_context = self.generic_context(db);
-        if generic_context != other.generic_context(db) {
-            return false;
-        }
-
-        for ((typevar, self_type), other_type) in (generic_context.variables(db).into_iter())
-            .zip(self.types(db))
-            .zip(other.types(db))
-        {
-            if matches!(self_type, Type::Dynamic(_)) || matches!(other_type, Type::Dynamic(_)) {
-                continue;
-            }
-
-            // Assignability of each type in the specialization depends on the variance of the
-            // corresponding typevar:
-            //   - covariant: verify that self_type <: other_type
-            //   - contravariant: verify that other_type <: self_type
-            //   - invariant: verify that self_type <: other_type AND other_type <: self_type
-            //   - bivariant: skip, can't make assignability false
-            let compatible = match typevar.variance(db) {
-                TypeVarVariance::Invariant => {
-                    self_type.is_assignable_to(db, *other_type)
-                        && other_type.is_assignable_to(db, *self_type)
-                }
-                TypeVarVariance::Covariant => self_type.is_assignable_to(db, *other_type),
-                TypeVarVariance::Contravariant => other_type.is_assignable_to(db, *self_type),
                 TypeVarVariance::Bivariant => true,
             };
             if !compatible {

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -86,10 +86,7 @@ impl<'db> NominalInstanceType<'db> {
         other: Self,
         relation: TypeRelation,
     ) -> bool {
-        match relation {
-            TypeRelation::Subtyping => self.class.is_subclass_of(db, other.class),
-            TypeRelation::Assignability => self.class.is_assignable_to(db, other.class),
-        }
+        self.class.has_relation_to(db, other.class, relation)
     }
 
     pub(super) fn is_equivalent_to(self, db: &'db dyn Db, other: Self) -> bool {

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -98,7 +98,7 @@ impl<'db> CallableSignature<'db> {
             .all(|signature| signature.is_fully_static(db))
     }
 
-    pub(crate) fn has_type_relation(
+    pub(crate) fn has_relation_to(
         &self,
         db: &'db dyn Db,
         other: &Self,

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -18,7 +18,7 @@ use smallvec::{SmallVec, smallvec};
 use super::{DynamicType, Type, definition_expression_type};
 use crate::semantic_index::definition::Definition;
 use crate::types::generics::GenericContext;
-use crate::types::{ClassLiteral, TypeMapping, TypeVarInstance, todo_type};
+use crate::types::{ClassLiteral, TypeMapping, TypeRelation, TypeVarInstance, todo_type};
 use crate::{Db, FxOrderSet};
 use ruff_python_ast::{self as ast, name::Name};
 
@@ -98,11 +98,23 @@ impl<'db> CallableSignature<'db> {
             .all(|signature| signature.is_fully_static(db))
     }
 
+    pub(crate) fn has_type_relation(
+        &self,
+        db: &'db dyn Db,
+        other: &Self,
+        relation: TypeRelation,
+    ) -> bool {
+        match relation {
+            TypeRelation::Subtyping => self.is_subtype_of(db, other),
+            TypeRelation::Assignability => self.is_assignable_to(db, other),
+        }
+    }
+
     /// Check whether this callable type is a subtype of another callable type.
     ///
     /// See [`Type::is_subtype_of`] for more details.
     pub(crate) fn is_subtype_of(&self, db: &'db dyn Db, other: &Self) -> bool {
-        Self::is_assignable_to_impl(
+        Self::has_relation_to_impl(
             &self.overloads,
             &other.overloads,
             &|self_signature, other_signature| self_signature.is_subtype_of(db, other_signature),
@@ -113,7 +125,7 @@ impl<'db> CallableSignature<'db> {
     ///
     /// See [`Type::is_assignable_to`] for more details.
     pub(crate) fn is_assignable_to(&self, db: &'db dyn Db, other: &Self) -> bool {
-        Self::is_assignable_to_impl(
+        Self::has_relation_to_impl(
             &self.overloads,
             &other.overloads,
             &|self_signature, other_signature| self_signature.is_assignable_to(db, other_signature),
@@ -124,7 +136,7 @@ impl<'db> CallableSignature<'db> {
     /// types.
     ///
     /// The `check_signature` closure is used to check the relation between two [`Signature`]s.
-    fn is_assignable_to_impl<F>(
+    fn has_relation_to_impl<F>(
         self_signatures: &[Signature<'db>],
         other_signatures: &[Signature<'db>],
         check_signature: &F,
@@ -140,7 +152,7 @@ impl<'db> CallableSignature<'db> {
 
             // `self` is possibly overloaded while `other` is definitely not overloaded.
             (_, [_]) => self_signatures.iter().any(|self_signature| {
-                Self::is_assignable_to_impl(
+                Self::has_relation_to_impl(
                     std::slice::from_ref(self_signature),
                     other_signatures,
                     check_signature,
@@ -149,7 +161,7 @@ impl<'db> CallableSignature<'db> {
 
             // `self` is definitely not overloaded while `other` is possibly overloaded.
             ([_], _) => other_signatures.iter().all(|other_signature| {
-                Self::is_assignable_to_impl(
+                Self::has_relation_to_impl(
                     self_signatures,
                     std::slice::from_ref(other_signature),
                     check_signature,
@@ -158,7 +170,7 @@ impl<'db> CallableSignature<'db> {
 
             // `self` is definitely overloaded while `other` is possibly overloaded.
             (_, _) => other_signatures.iter().all(|other_signature| {
-                Self::is_assignable_to_impl(
+                Self::has_relation_to_impl(
                     self_signatures,
                     std::slice::from_ref(other_signature),
                     check_signature,

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -31,10 +31,14 @@ impl<'db> SubclassOfType<'db> {
             SubclassOfInner::Class(class) => {
                 if class.is_final(db) {
                     Type::from(class)
-                } else if class.is_object(db) {
-                    KnownClass::Type.to_instance(db)
                 } else {
-                    Type::SubclassOf(Self { subclass_of })
+                    match class.known(db) {
+                        Some(KnownClass::Object) => KnownClass::Type.to_instance(db),
+                        Some(KnownClass::Any) => Type::SubclassOf(Self {
+                            subclass_of: SubclassOfInner::Dynamic(DynamicType::Any),
+                        }),
+                        _ => Type::SubclassOf(Self { subclass_of }),
+                    }
                 }
             }
         }

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -124,8 +124,7 @@ impl<'db> SubclassOfType<'db> {
             // and `type[int]` describes all possible runtime subclasses of the class `int`.
             // The first set is a subset of the second set, because `bool` is itself a subclass of `int`.
             (SubclassOfInner::Class(self_class), SubclassOfInner::Class(other_class)) => {
-                // N.B. The subclass relation is fully static
-                self_class.is_subclass_of(db, other_class)
+                self_class.has_relation_to(db, other_class, relation)
             }
         }
     }

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -103,14 +103,10 @@ impl<'db> SubclassOfType<'db> {
         Type::from(self.subclass_of).find_name_in_mro_with_policy(db, name, policy)
     }
 
-    /// Return `true` if `self` is a subtype of `other`.
-    ///
-    /// This can only return `true` if `self.subclass_of` is a [`SubclassOfInner::Class`] variant;
-    /// only fully static types participate in subtyping.
-    pub(crate) fn is_subtype_of(self, db: &'db dyn Db, other: SubclassOfType<'db>) -> bool {
+    /// Return `true` if `self` is assignable to `other`.
+    pub(crate) fn is_assignable_to(self, db: &'db dyn Db, other: SubclassOfType<'db>) -> bool {
         match (self.subclass_of, other.subclass_of) {
-            // Non-fully-static types do not participate in subtyping
-            (SubclassOfInner::Dynamic(_), _) | (_, SubclassOfInner::Dynamic(_)) => false,
+            (SubclassOfInner::Dynamic(_), _) | (_, SubclassOfInner::Dynamic(_)) => true,
 
             // For example, `type[bool]` describes all possible runtime subclasses of the class `bool`,
             // and `type[int]` describes all possible runtime subclasses of the class `int`.


### PR DESCRIPTION
## Summary

There's lots of duplication between `Type::is_subtype_of()` and `Type::is_assignable_to()`, and we've had multiple bugs in the past because we've remembered to update `Type::is_subtype_of()` but have not realised that `Type::is_assignable_to()` also needed to be updated. This PR unifies the two methods: they are now both thin wrappers over a `Type::has_assignability_relation` method.

## Test Plan

- Existing tests
- New tests.
	- Some of these cover latent bugs that were accidentally fixed in this refactor
	- Some of them cover bugs that early versions of this PR introduced but were revealed by mypy_primer and have since been fixed.
- Property tests
- mypy_primer
