### PR TITLE
[ty] Treat lambda functions as types.FunctionType

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/expression/lambda.md
+++ b/crates/ty_python_semantic/resources/mdtest/expression/lambda.md
@@ -115,3 +115,22 @@ a5: Callable[[], None] = lambda x: None
 # error: [invalid-assignment]
 a6: Callable[[int], None] = lambda: None
 ```
+
+## Function-like behavior of lambdas
+
+All `lambda` functions are instances of `types.FunctionType` and should have access to the same set
+of attributes.
+
+```py
+x = lambda y: y
+
+reveal_type(x.__code__)  # revealed: CodeType
+reveal_type(x.__name__)  # revealed: str
+reveal_type(x.__defaults__)  # revealed: tuple[Any, ...] | None
+reveal_type(x.__annotations__)  # revealed: dict[str, @Todo(Support for `typing.TypeAlias`)]
+reveal_type(x.__dict__)  # revealed: dict[str, Any]
+reveal_type(x.__doc__)  # revealed: str | None
+reveal_type(x.__kwdefaults__)  # revealed: dict[str, Any] | None
+reveal_type(x.__module__)  # revealed: str
+reveal_type(x.__qualname__)  # revealed: str
+```

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -4955,7 +4955,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         // TODO: Useful inference of a lambda's return type will require a different approach,
         // which does the inference of the body expression based on arguments at each call site,
         // rather than eagerly computing a return type without knowing the argument types.
-        CallableType::single(self.db(), Signature::new(parameters, Some(Type::unknown())))
+        CallableType::function_like(self.db(), Signature::new(parameters, Some(Type::unknown())))
     }
 
     /// Returns the type of the first parameter if the given scope is function-like (i.e. function or lambda).


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
Implements https://github.com/astral-sh/ty/issues/567. 

Since `lambda` functions are instance of `types.FunctionType`, we should be able to access to attribute such as `__code__`, `__name__` and more. With this PR, we will have the following type and no more errors : 

```py
from typing import reveal_type

x = lambda y: y

reveal_type(x.__code__)  # revealed: CodeType
```

## Test Plan

<!-- How was it tested? -->

I have added mdtests, but since I am not familiar with attributes of `types.FunctionType`, my tests may be either too redundant or not exhaustive enough.
