### PR TITLE
[ty] ty_ide: Hotfix for `expression_scope_id` panics

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -4,6 +4,10 @@ extend-exclude = [
     "crates/ty_vendored/vendor/**/*",
     "**/resources/**/*",
     "**/snapshots/**/*",
+    # Completion tests tend to have a lot of incomplete
+    # words naturally. It's annoying to have to make all
+    # of them actually words. So just ignore typos here.
+    "crates/ty_ide/src/completion.rs",
 ]
 
 [default.extend-words]

--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -861,6 +861,181 @@ print(f\"{some<CURSOR>
         ");
     }
 
+    // Ref: https://github.com/astral-sh/ty/issues/572
+    #[test]
+    fn scope_id_missing_function_identifier1() {
+        let test = cursor_test(
+            "\
+def m<CURSOR>
+",
+        );
+
+        assert_snapshot!(test.completions(), @r"
+        m
+        ");
+    }
+
+    // Ref: https://github.com/astral-sh/ty/issues/572
+    #[test]
+    fn scope_id_missing_function_identifier2() {
+        let test = cursor_test(
+            "\
+def m<CURSOR>(): pass
+",
+        );
+
+        assert_snapshot!(test.completions(), @r"
+        m
+        ");
+    }
+
+    // Ref: https://github.com/astral-sh/ty/issues/572
+    #[test]
+    fn fscope_id_missing_function_identifier3() {
+        let test = cursor_test(
+            "\
+def m(): pass
+<CURSOR>
+",
+        );
+
+        assert_snapshot!(test.completions(), @r"
+        m
+        ");
+    }
+
+    // Ref: https://github.com/astral-sh/ty/issues/572
+    #[test]
+    fn scope_id_missing_class_identifier1() {
+        let test = cursor_test(
+            "\
+class M<CURSOR>
+",
+        );
+
+        assert_snapshot!(test.completions(), @r"
+        M
+        ");
+    }
+
+    // Ref: https://github.com/astral-sh/ty/issues/572
+    #[test]
+    fn scope_id_missing_type_alias1() {
+        let test = cursor_test(
+            "\
+Fo<CURSOR> = float
+",
+        );
+
+        assert_snapshot!(test.completions(), @r"
+        Fo
+        float
+        ");
+    }
+
+    // Ref: https://github.com/astral-sh/ty/issues/572
+    #[test]
+    fn scope_id_missing_import1() {
+        let test = cursor_test(
+            "\
+import fo<CURSOR>
+",
+        );
+
+        assert_snapshot!(test.completions(), @r"
+        fo
+        ");
+    }
+
+    // Ref: https://github.com/astral-sh/ty/issues/572
+    #[test]
+    fn scope_id_missing_import2() {
+        let test = cursor_test(
+            "\
+import foo as ba<CURSOR>
+",
+        );
+
+        assert_snapshot!(test.completions(), @r"
+        ba
+        ");
+    }
+
+    // Ref: https://github.com/astral-sh/ty/issues/572
+    #[test]
+    fn scope_id_missing_from_import1() {
+        let test = cursor_test(
+            "\
+from fo<CURSOR> import wat
+",
+        );
+
+        assert_snapshot!(test.completions(), @r"
+        wat
+        ");
+    }
+
+    // Ref: https://github.com/astral-sh/ty/issues/572
+    #[test]
+    fn scope_id_missing_from_import2() {
+        let test = cursor_test(
+            "\
+from foo import wa<CURSOR>
+",
+        );
+
+        assert_snapshot!(test.completions(), @r"
+        wa
+        ");
+    }
+
+    // Ref: https://github.com/astral-sh/ty/issues/572
+    #[test]
+    fn scope_id_missing_from_import3() {
+        let test = cursor_test(
+            "\
+from foo import wat as ba<CURSOR>
+",
+        );
+
+        assert_snapshot!(test.completions(), @r"
+        ba
+        ");
+    }
+
+    // Ref: https://github.com/astral-sh/ty/issues/572
+    #[test]
+    fn scope_id_missing_try_except1() {
+        let test = cursor_test(
+            "\
+try:
+    pass
+except Type<CURSOR>:
+    pass
+",
+        );
+
+        assert_snapshot!(test.completions(), @r"
+        Type
+        ");
+    }
+
+    // Ref: https://github.com/astral-sh/ty/issues/572
+    #[test]
+    fn scope_id_missing_global1() {
+        let test = cursor_test(
+            "\
+def _():
+    global fo<CURSOR>
+",
+        );
+
+        assert_snapshot!(test.completions(), @r"
+        _
+        fo
+        ");
+    }
+
     impl CursorTest {
         fn completions(&self) -> String {
             let completions = completion(&self.db, self.file, self.cursor_offset);

--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -870,9 +870,7 @@ def m<CURSOR>
 ",
         );
 
-        assert_snapshot!(test.completions(), @r"
-        m
-        ");
+        assert_snapshot!(test.completions(), @"<No completions found>");
     }
 
     // Ref: https://github.com/astral-sh/ty/issues/572
@@ -884,9 +882,7 @@ def m<CURSOR>(): pass
 ",
         );
 
-        assert_snapshot!(test.completions(), @r"
-        m
-        ");
+        assert_snapshot!(test.completions(), @"<No completions found>");
     }
 
     // Ref: https://github.com/astral-sh/ty/issues/572
@@ -913,9 +909,7 @@ class M<CURSOR>
 ",
         );
 
-        assert_snapshot!(test.completions(), @r"
-        M
-        ");
+        assert_snapshot!(test.completions(), @"<No completions found>");
     }
 
     // Ref: https://github.com/astral-sh/ty/issues/572
@@ -942,9 +936,7 @@ import fo<CURSOR>
 ",
         );
 
-        assert_snapshot!(test.completions(), @r"
-        fo
-        ");
+        assert_snapshot!(test.completions(), @"<No completions found>");
     }
 
     // Ref: https://github.com/astral-sh/ty/issues/572
@@ -956,9 +948,7 @@ import foo as ba<CURSOR>
 ",
         );
 
-        assert_snapshot!(test.completions(), @r"
-        ba
-        ");
+        assert_snapshot!(test.completions(), @"<No completions found>");
     }
 
     // Ref: https://github.com/astral-sh/ty/issues/572
@@ -970,9 +960,7 @@ from fo<CURSOR> import wat
 ",
         );
 
-        assert_snapshot!(test.completions(), @r"
-        wat
-        ");
+        assert_snapshot!(test.completions(), @"<No completions found>");
     }
 
     // Ref: https://github.com/astral-sh/ty/issues/572
@@ -984,9 +972,7 @@ from foo import wa<CURSOR>
 ",
         );
 
-        assert_snapshot!(test.completions(), @r"
-        wa
-        ");
+        assert_snapshot!(test.completions(), @"<No completions found>");
     }
 
     // Ref: https://github.com/astral-sh/ty/issues/572
@@ -998,9 +984,7 @@ from foo import wat as ba<CURSOR>
 ",
         );
 
-        assert_snapshot!(test.completions(), @r"
-        ba
-        ");
+        assert_snapshot!(test.completions(), @"<No completions found>");
     }
 
     // Ref: https://github.com/astral-sh/ty/issues/572
@@ -1030,10 +1014,7 @@ def _():
 ",
         );
 
-        assert_snapshot!(test.completions(), @r"
-        _
-        fo
-        ");
+        assert_snapshot!(test.completions(), @"<No completions found>");
     }
 
     impl CursorTest {

--- a/crates/ty_python_semantic/src/semantic_index.rs
+++ b/crates/ty_python_semantic/src/semantic_index.rs
@@ -259,6 +259,14 @@ impl<'db> SemanticIndex<'db> {
         self.scopes_by_expression[&expression.into()]
     }
 
+    /// Returns the ID of the `expression`'s enclosing scope.
+    pub(crate) fn try_expression_scope_id(
+        &self,
+        expression: impl Into<ExpressionNodeKey>,
+    ) -> Option<FileScopeId> {
+        self.scopes_by_expression.get(&expression.into()).copied()
+    }
+
     /// Returns the [`Scope`] of the `expression`'s enclosing scope.
     #[allow(unused)]
     #[track_caller]


### PR DESCRIPTION
## Summary

Implement a hotfix for the playground/LSP crashes related to missing `expression_scope_id`s.

relates to: https://github.com/astral-sh/ty/issues/572

## Test Plan

* Regression tests from https://github.com/astral-sh/ruff/pull/18441
* Ran the playground locally to check if panics occur / completions still work.