### PR TITLE
[ty] Fix `--python` argument for Windows, and improve error messages for bad `--python` arguments

### DIFF
--- a/crates/ruff/tests/analyze_graph.rs
+++ b/crates/ruff/tests/analyze_graph.rs
@@ -566,7 +566,7 @@ fn venv() -> Result<()> {
         ----- stderr -----
         ruff failed
           Cause: Invalid search path settings
-          Cause: Failed to discover the site-packages directory: Invalid `--python` argument: `none` could not be canonicalized
+          Cause: Failed to discover the site-packages directory: Invalid `--python` argument: `none` does not point to a Python executable or a directory on disk
         ");
     });
 

--- a/crates/ruff_graph/src/db.rs
+++ b/crates/ruff_graph/src/db.rs
@@ -10,7 +10,7 @@ use ruff_python_ast::PythonVersion;
 use ty_python_semantic::lint::{LintRegistry, RuleSelection};
 use ty_python_semantic::{
     Db, Program, ProgramSettings, PythonPath, PythonPlatform, PythonVersionSource,
-    PythonVersionWithSource, SearchPathSettings, default_lint_registry,
+    PythonVersionWithSource, SearchPathSettings, SysPrefixPathOrigin, default_lint_registry,
 };
 
 static EMPTY_VENDORED: std::sync::LazyLock<VendoredFileSystem> = std::sync::LazyLock::new(|| {
@@ -37,7 +37,8 @@ impl ModuleDb {
     ) -> Result<Self> {
         let mut search_paths = SearchPathSettings::new(src_roots);
         if let Some(venv_path) = venv_path {
-            search_paths.python_path = PythonPath::from_cli_flag(venv_path);
+            search_paths.python_path =
+                PythonPath::sys_prefix(venv_path, SysPrefixPathOrigin::PythonCliFlag);
         }
 
         let db = Self::default();

--- a/crates/ty_python_semantic/src/module_resolver/resolver.rs
+++ b/crates/ty_python_semantic/src/module_resolver/resolver.rs
@@ -139,15 +139,6 @@ pub(crate) fn search_paths(db: &dyn Db) -> SearchPathIterator {
     Program::get(db).search_paths(db).iter(db)
 }
 
-/// Searches for a `.venv` directory in `project_root` that contains a `pyvenv.cfg` file.
-fn discover_venv_in(system: &dyn System, project_root: &SystemPath) -> Option<SystemPathBuf> {
-    let virtual_env_directory = project_root.join(".venv");
-
-    system
-        .is_file(&virtual_env_directory.join("pyvenv.cfg"))
-        .then_some(virtual_env_directory)
-}
-
 #[derive(Debug, PartialEq, Eq)]
 pub struct SearchPaths {
     /// Search paths that have been statically determined purely from reading Ruff's configuration settings.
@@ -243,68 +234,34 @@ impl SearchPaths {
         static_paths.push(stdlib_path);
 
         let (site_packages_paths, python_version) = match python_path {
-            PythonPath::SysPrefix(sys_prefix, origin) => {
-                tracing::debug!(
-                    "Discovering site-packages paths from sys-prefix `{sys_prefix}` ({origin}')"
-                );
-                // TODO: We may want to warn here if the venv's python version is older
-                //  than the one resolved in the program settings because it indicates
-                //  that the `target-version` is incorrectly configured or that the
-                //  venv is out of date.
-                PythonEnvironment::new(sys_prefix, *origin, system)?.into_settings(system)?
-            }
+            PythonPath::IntoSysPrefix(path, origin) => {
+                if *origin == SysPrefixPathOrigin::LocalVenv {
+                    tracing::debug!("Discovering virtual environment in `{path}`");
+                    let virtual_env_directory = path.join(".venv");
 
-            PythonPath::Resolve(target, origin) => {
-                tracing::debug!("Resolving {origin}: {target}");
-
-                let root = system
-                    // If given a file, assume it's a Python executable, e.g., `.venv/bin/python3`,
-                    // and search for a virtual environment in the root directory. Ideally, we'd
-                    // invoke the target to determine `sys.prefix` here, but that's more complicated
-                    // and may be deferred to uv.
-                    .is_file(target)
-                    .then(|| target.as_path())
-                    .take_if(|target| {
-                        // Avoid using the target if it doesn't look like a Python executable, e.g.,
-                        // to deny cases like `.venv/bin/foo`
-                        target
-                            .file_name()
-                            .is_some_and(|name| name.starts_with("python"))
-                    })
-                    .and_then(SystemPath::parent)
-                    .and_then(SystemPath::parent)
-                    // If not a file, use the path as given and allow let `PythonEnvironment::new`
-                    // handle the error.
-                    .unwrap_or(target);
-
-                PythonEnvironment::new(root, *origin, system)?.into_settings(system)?
-            }
-
-            PythonPath::Discover(root) => {
-                tracing::debug!("Discovering virtual environment in `{root}`");
-                discover_venv_in(db.system(), root)
-                    .and_then(|virtual_env_path| {
-                        tracing::debug!("Found `.venv` folder at `{}`", virtual_env_path);
-
-                        PythonEnvironment::new(
-                            virtual_env_path.clone(),
-                            SysPrefixPathOrigin::LocalVenv,
-                            system,
-                        )
-                        .and_then(|env| env.into_settings(system))
-                        .inspect_err(|err| {
+                    PythonEnvironment::new(
+                        &virtual_env_directory,
+                        SysPrefixPathOrigin::LocalVenv,
+                        system,
+                    )
+                    .and_then(|venv| venv.into_settings(system))
+                    .inspect_err(|err| {
+                        if system.is_directory(&virtual_env_directory) {
                             tracing::debug!(
                                 "Ignoring automatically detected virtual environment at `{}`: {}",
-                                virtual_env_path,
+                                &virtual_env_directory,
                                 err
                             );
-                        })
-                        .ok()
+                        }
                     })
-                    .unwrap_or_else(|| {
+                    .unwrap_or_else(|_| {
                         tracing::debug!("No virtual environment found");
                         (SitePackagesPaths::default(), None)
                     })
+                } else {
+                    tracing::debug!("Resolving {origin}: {path}");
+                    PythonEnvironment::new(path, *origin, system)?.into_settings(system)?
+                }
             }
 
             PythonPath::KnownSitePackages(paths) => (

--- a/crates/ty_python_semantic/src/program.rs
+++ b/crates/ty_python_semantic/src/program.rs
@@ -262,8 +262,10 @@ impl SearchPathSettings {
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum PythonPath {
-    /// A path that represents the value of [`sys.prefix`] at runtime in Python
-    /// for a given Python executable.
+    /// A path that either represents the value of [`sys.prefix`] at runtime in Python
+    /// for a given Python executable, or which represents a path relative to `sys.prefix`
+    /// that we will attempt later to resolve into `sys.prefix`. Exactly which this variant
+    /// represents depends on the [`SysPrefixPathOrigin`] element in the tuple.
     ///
     /// For the case of a virtual environment, where a
     /// Python binary is at `/.venv/bin/python`, `sys.prefix` is the path to
@@ -275,13 +277,7 @@ pub enum PythonPath {
     /// `/opt/homebrew/lib/python3.X/site-packages`.
     ///
     /// [`sys.prefix`]: https://docs.python.org/3/library/sys.html#sys.prefix
-    SysPrefix(SystemPathBuf, SysPrefixPathOrigin),
-
-    /// Resolve a path to an executable (or environment directory) into a usable environment.
-    Resolve(SystemPathBuf, SysPrefixPathOrigin),
-
-    /// Tries to discover a virtual environment in the given path.
-    Discover(SystemPathBuf),
+    IntoSysPrefix(SystemPathBuf, SysPrefixPathOrigin),
 
     /// Resolved site packages paths.
     ///
@@ -291,16 +287,8 @@ pub enum PythonPath {
 }
 
 impl PythonPath {
-    pub fn from_virtual_env_var(path: impl Into<SystemPathBuf>) -> Self {
-        Self::SysPrefix(path.into(), SysPrefixPathOrigin::VirtualEnvVar)
-    }
-
-    pub fn from_conda_prefix_var(path: impl Into<SystemPathBuf>) -> Self {
-        Self::Resolve(path.into(), SysPrefixPathOrigin::CondaPrefixVar)
-    }
-
-    pub fn from_cli_flag(path: SystemPathBuf) -> Self {
-        Self::Resolve(path, SysPrefixPathOrigin::PythonCliFlag)
+    pub fn sys_prefix(path: impl Into<SystemPathBuf>, origin: SysPrefixPathOrigin) -> Self {
+        Self::IntoSysPrefix(path.into(), origin)
     }
 }
 

--- a/crates/ty_test/src/lib.rs
+++ b/crates/ty_test/src/lib.rs
@@ -272,7 +272,7 @@ fn run_test(
             python_path: configuration
                 .python()
                 .map(|sys_prefix| {
-                    PythonPath::SysPrefix(
+                    PythonPath::IntoSysPrefix(
                         sys_prefix.to_path_buf(),
                         SysPrefixPathOrigin::PythonCliFlag,
                     )


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ty/issues/556.

On Windows, system installations have different layouts to virtual environments. In Windows virtual environments, the Python executable is found at `<sys.prefix>/Scripts/python.exe`. But in Windows system installations, the Python executable is found at `<sys.prefix>/python.exe`. That means that Windows users were able to point to Python executables inside virtual environments with the `--python` flag, but they weren't able to point to Python executables inside system installations.

This PR fixes that issue. It also makes a couple of other changes:
- Nearly all `sys.prefix` resolution is moved inside `site_packages.rs`. That was the original design of the `site-packages` resolution logic, but features implemented since the initial implementation have added some resolution and validation to `resolver.rs` inside the module resolver. That means that we've ended up with a somewhat confusing code structure and a situation where several checks are unnecessarily duplicated between the two modules.
- I noticed that we had quite bad error messages if you e.g. pointed to a path that didn't exist on disk with `--python` (we just gave a somewhat impenetrable message saying that we "failed to canonicalize" the path). I improved the error messages here and added CLI tests for `--python` and the `environment.python` configuration setting.

## Test Plan

- Existing tests pass
- Added new CLI tests
- I manually checked that virtual-environment discovery still works if no configuration is given

I'd love it if somebody who has a Windows machine setup for development could do some manual testing to check that pointing `--python` to a system-installation executable now works.