### PR TITLE
[ty] Exclude members starting with `_abc_` from a protocol interface

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -389,6 +389,7 @@ not be considered protocol members by type checkers either:
 class Lumberjack(Protocol):
     __slots__ = ()
     __match_args__ = ()
+    _abc_foo: str  # any attribute starting with `_abc_` is excluded as a protocol attribute
     x: int
 
     def __new__(cls, x: int) -> "Lumberjack":

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -273,7 +273,7 @@ impl<'a, 'db> ProtocolMember<'a, 'db> {
 /// The list of excluded members is subject to change between Python versions,
 /// especially for dunders, but it probably doesn't matter *too* much if this
 /// list goes out of date. It's up to date as of Python commit 87b1ea016b1454b1e83b9113fa9435849b7743aa
-/// (<https://github.com/python/cpython/blob/87b1ea016b1454b1e83b9113fa9435849b7743aa/Lib/typing.py#L1776-L1791>)
+/// (<https://github.com/python/cpython/blob/87b1ea016b1454b1e83b9113fa9435849b7743aa/Lib/typing.py#L1776-L1814>)
 fn excluded_from_proto_members(member: &str) -> bool {
     matches!(
         member,
@@ -303,7 +303,7 @@ fn excluded_from_proto_members(member: &str) -> bool {
             | "__annotate__"
             | "__annotate_func__"
             | "__annotations_cache__"
-    )
+    ) || member.starts_with("_abc_")
 }
 
 /// Inner Salsa query for [`ProtocolClassLiteral::interface`].


### PR DESCRIPTION
## Summary

As well as excluding a hardcoded set of special attributes, CPython at runtime also excludes any attributes or declarations starting with `_abc_` from the set of members that make up a protocol interface. I missed this in my initial implementation.

This is a bit of a CPython implementation detail, but I do think it's important that we try to model the runtime as best we can here. The closer we are to the runtime behaviour, the closer we come to sound behaviour when narrowing types from `isinstance()` checks against runtime-checkable protocols (for example)

## Test Plan

Extended an existing mdtest
