### PR TITLE
[`pyupgrade`] Apply `UP035` only on py313+ for `get_type_hints()`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP035.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP035.py
@@ -110,6 +110,8 @@ from typing_extensions import CapsuleType
 # UP035 on py313+ only
 from typing_extensions import deprecated
 
+# UP035 on py313+ only
+from typing_extensions import get_type_hints
 
 # https://github.com/astral-sh/ruff/issues/15780
 from typing_extensions import is_typeddict

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_import.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_import.rs
@@ -271,7 +271,7 @@ const TYPING_TO_RE_39: &[&str] = &["Match", "Pattern"];
 const TYPING_RE_TO_RE_39: &[&str] = &["Match", "Pattern"];
 
 // Members of `typing_extensions` that were moved to `typing`.
-const TYPING_EXTENSIONS_TO_TYPING_39: &[&str] = &["Annotated", "get_type_hints"];
+const TYPING_EXTENSIONS_TO_TYPING_39: &[&str] = &["Annotated"];
 
 // Members of `typing` that were moved _and_ renamed (and thus cannot be
 // automatically fixed).
@@ -395,7 +395,12 @@ const TYPING_EXTENSIONS_TO_TYPING_313: &[&str] = &[
 ];
 
 // Members of `typing_extensions` that were moved to `types`.
-const TYPING_EXTENSIONS_TO_TYPES_313: &[&str] = &["CapsuleType"];
+const TYPING_EXTENSIONS_TO_TYPES_313: &[&str] = &[
+    "CapsuleType",
+    // Introduced in Python 3.5,
+    // but typing_extensions backports features from py313:
+    "get_type_hints",
+];
 
 // Members of typing_extensions that were moved to `warnings`
 const TYPING_EXTENSIONS_TO_WARNINGS_313: &[&str] = &["deprecated"];

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP035.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP035.py.snap
@@ -1179,6 +1179,8 @@ UP035.py:111:1: UP035 [*] Import from `warnings` instead: `deprecated`
 110 | # UP035 on py313+ only
 111 | from typing_extensions import deprecated
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP035
+112 |
+113 | # UP035 on py313+ only
     |
     = help: Import from `warnings`
 
@@ -1189,5 +1191,25 @@ UP035.py:111:1: UP035 [*] Import from `warnings` instead: `deprecated`
 111     |-from typing_extensions import deprecated
     111 |+from warnings import deprecated
 112 112 | 
-113 113 | 
-114 114 | # https://github.com/astral-sh/ruff/issues/15780
+113 113 | # UP035 on py313+ only
+114 114 | from typing_extensions import get_type_hints
+
+UP035.py:114:1: UP035 [*] Import from `types` instead: `get_type_hints`
+    |
+113 | # UP035 on py313+ only
+114 | from typing_extensions import get_type_hints
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP035
+115 |
+116 | # https://github.com/astral-sh/ruff/issues/15780
+    |
+    = help: Import from `types`
+
+ℹ Safe fix
+111 111 | from typing_extensions import deprecated
+112 112 | 
+113 113 | # UP035 on py313+ only
+114     |-from typing_extensions import get_type_hints
+    114 |+from types import get_type_hints
+115 115 | 
+116 116 | # https://github.com/astral-sh/ruff/issues/15780
+117 117 | from typing_extensions import is_typeddict


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

typing-extensions backports changes on <py3.13.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
