### PR TITLE
[`pyupgrade`] Fix `super(__class__, self)` detection in UP008 (super-call-with-parameters)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP008.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP008.py
@@ -79,3 +79,14 @@ class DataClass:
 def normal(self):
     super(DataClass, self).f()  # OK
     super().f()  # OK (`TypeError` in practice)
+
+
+# see: https://github.com/astral-sh/ruff/issues/18477
+class A:
+    def foo(self):
+        pass
+
+
+class B(A):
+    def bar(self):
+        super(__class__, self).foo()

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/super_call_with_parameters.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/super_call_with_parameters.rs
@@ -121,7 +121,9 @@ pub(crate) fn super_call_with_parameters(checker: &Checker, call: &ast::ExprCall
         return;
     };
 
-    if !(first_arg_id == parent_name.as_str() && second_arg_id == parent_arg.name().as_str()) {
+    if !((first_arg_id == "__class__" || first_arg_id == parent_name.as_str())
+        && second_arg_id == parent_arg.name().as_str())
+    {
         return;
     }
 

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP008.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP008.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_linter/src/rules/pyupgrade/mod.rs
-snapshot_kind: text
 ---
 UP008.py:17:23: UP008 [*] Use `super()` instead of `super(__class__, self)`
    |
@@ -126,4 +125,20 @@ UP008.py:74:14: UP008 [*] Use `super()` instead of `super(__class__, self)`
    74 |+        super().f()  # Error
 75 75 |         super().f()  # OK
 76 76 | 
-77 77 |
+77 77 | 
+
+UP008.py:92:14: UP008 [*] Use `super()` instead of `super(__class__, self)`
+   |
+90 | class B(A):
+91 |     def bar(self):
+92 |         super(__class__, self).foo()
+   |              ^^^^^^^^^^^^^^^^^ UP008
+   |
+   = help: Remove `__super__` parameters
+
+ℹ Unsafe fix
+89 89 | 
+90 90 | class B(A):
+91 91 |     def bar(self):
+92    |-        super(__class__, self).foo()
+   92 |+        super().foo()


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary
/closes https://github.com/astral-sh/ruff/issues/18477
<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan
update snapshots
<!-- How was it tested? -->
