### PR TITLE
[`pycodestyle`] Fix `E731` autofix creating a syntax error for expressions spanned across multiple lines

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pycodestyle/E731.py
+++ b/crates/ruff_linter/resources/test/fixtures/pycodestyle/E731.py
@@ -184,3 +184,9 @@ foo_tooltip = (
     if data["foo"] is not None
     else ""
 )
+
+foo_tooltip = (
+    lambda x, data: f"\nfoo: {data['foo'][int(x)]}" +
+    more
+
+)

--- a/crates/ruff_linter/resources/test/fixtures/pycodestyle/E731.py
+++ b/crates/ruff_linter/resources/test/fixtures/pycodestyle/E731.py
@@ -177,3 +177,10 @@ x = lambda: (
     # comment
     y := 10
 )
+
+# https://github.com/astral-sh/ruff/issues/18475
+foo_tooltip = (
+    lambda x, data: f"\nfoo: {data['foo'][int(x)]}"
+    if data["foo"] is not None
+    else ""
+)

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/lambda_assignment.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/lambda_assignment.rs
@@ -1,14 +1,11 @@
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_python_ast::parenthesize::parenthesized_range;
 use ruff_python_ast::{
-    self as ast, Expr, ExprEllipsisLiteral, ExprLambda, ExprRef, Identifier, Parameter,
+    self as ast, Expr, ExprEllipsisLiteral, ExprLambda, Identifier, Parameter,
     ParameterWithDefault, Parameters, Stmt,
 };
 use ruff_python_semantic::SemanticModel;
-use ruff_python_trivia::{
-    BackwardsTokenizer, CommentRanges, SimpleToken, SimpleTokenKind, first_non_trivia_token,
-    has_leading_content, has_trailing_content, leading_indentation,
-};
+use ruff_python_trivia::{has_leading_content, has_trailing_content, leading_indentation};
 use ruff_source_file::UniversalNewlines;
 use ruff_text_size::{Ranged, TextRange};
 
@@ -95,7 +92,7 @@ pub(crate) fn lambda_assignment(
         let first_line = checker.locator().line_str(stmt.start());
         let indentation = leading_indentation(first_line);
         let mut indented = String::new();
-        for (idx, line) in function(id, lambda, annotation, checker)
+        for (idx, line) in function(id, lambda, annotation, stmt, checker)
             .universal_newlines()
             .enumerate()
         {
@@ -180,6 +177,7 @@ fn function(
     name: &str,
     lambda: &ExprLambda,
     annotation: Option<&Expr>,
+    stmt: &Stmt,
     checker: &Checker,
 ) -> String {
     // Use a dummy body. It gets replaced at the end with the actual body.
@@ -239,7 +237,7 @@ fn function(
             });
             let generated = checker.generator().stmt(&func);
 
-            return replace_trailing_ellipsis_with_original_expr(generated, lambda, checker);
+            return replace_trailing_ellipsis_with_original_expr(generated, lambda, stmt, checker);
         }
     }
     let function = Stmt::FunctionDef(ast::StmtFunctionDef {
@@ -254,12 +252,13 @@ fn function(
     });
     let generated = checker.generator().stmt(&function);
 
-    replace_trailing_ellipsis_with_original_expr(generated, lambda, checker)
+    replace_trailing_ellipsis_with_original_expr(generated, lambda, stmt, checker)
 }
 
 fn replace_trailing_ellipsis_with_original_expr(
     mut generated: String,
     lambda: &ExprLambda,
+    stmt: &Stmt,
     checker: &Checker,
 ) -> String {
     let original_expr_range = parenthesized_range(
@@ -273,12 +272,18 @@ fn replace_trailing_ellipsis_with_original_expr(
     // This prevents the autofix of introducing a syntax error if the lambda's body is an
     // expression spanned across multiple lines. To avoid the syntax error we preserve
     // the parenthesis around the body.
-    let original_expr_in_source =
-        if is_expression_parenthesized(lambda.into(), checker.comment_ranges(), checker.source()) {
-            format!("({})", checker.locator().slice(original_expr_range))
-        } else {
-            checker.locator().slice(original_expr_range).to_string()
-        };
+    let original_expr_in_source = if parenthesized_range(
+        lambda.into(),
+        stmt.into(),
+        checker.comment_ranges(),
+        checker.source(),
+    )
+    .is_some()
+    {
+        format!("({})", checker.locator().slice(original_expr_range))
+    } else {
+        checker.locator().slice(original_expr_range).to_string()
+    };
 
     let placeholder_ellipsis_start = generated.rfind("...").unwrap();
     let placeholder_ellipsis_end = placeholder_ellipsis_start + "...".len();
@@ -288,32 +293,4 @@ fn replace_trailing_ellipsis_with_original_expr(
         &original_expr_in_source,
     );
     generated
-}
-
-/// Returns `true` if the [`ExprRef`] is enclosed by parentheses in the source code.
-fn is_expression_parenthesized(
-    expr: ExprRef,
-    comment_ranges: &CommentRanges,
-    contents: &str,
-) -> bool {
-    // First test if there's a closing parentheses because it tends to be cheaper.
-    if matches!(
-        first_non_trivia_token(expr.end(), contents),
-        Some(SimpleToken {
-            kind: SimpleTokenKind::RParen,
-            ..
-        })
-    ) {
-        matches!(
-            BackwardsTokenizer::up_to(expr.start(), contents, comment_ranges)
-                .skip_trivia()
-                .next(),
-            Some(SimpleToken {
-                kind: SimpleTokenKind::LParen,
-                ..
-            })
-        )
-    } else {
-        false
-    }
 }

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E731_E731.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E731_E731.py.snap
@@ -318,7 +318,7 @@ E731.py:139:5: E731 Do not assign a `lambda` expression, use a `def`
 138 138 | class TemperatureScales(Enum):
 139     |-    CELSIUS = (lambda deg_c: deg_c)
     139 |+    def CELSIUS(deg_c):
-    140 |+        return deg_c
+    140 |+        return (deg_c)
 140 141 |     FAHRENHEIT = (lambda deg_c: deg_c * 9 / 5 + 32)
 141 142 | 
 142 143 | 
@@ -338,7 +338,7 @@ E731.py:140:5: E731 Do not assign a `lambda` expression, use a `def`
 139 139 |     CELSIUS = (lambda deg_c: deg_c)
 140     |-    FAHRENHEIT = (lambda deg_c: deg_c * 9 / 5 + 32)
     140 |+    def FAHRENHEIT(deg_c):
-    141 |+        return deg_c * 9 / 5 + 32
+    141 |+        return (deg_c * 9 / 5 + 32)
 141 142 | 
 142 143 | 
 143 144 | # Regression test for: https://github.com/astral-sh/ruff/issues/7141
@@ -474,6 +474,8 @@ E731.py:182:1: E731 [*] Do not assign a `lambda` expression, use a `def`
 185 | |     else ""
 186 | | )
     | |_^ E731
+187 |
+188 |   foo_tooltip = (
     |
     = help: Rewrite `foo_tooltip` as a `def`
 
@@ -489,3 +491,32 @@ E731.py:182:1: E731 [*] Do not assign a `lambda` expression, use a `def`
 185     |-    else ""
 186     |-)
     185 |+    else "")
+187 186 | 
+188 187 | foo_tooltip = (
+189 188 |     lambda x, data: f"\nfoo: {data['foo'][int(x)]}" +
+
+E731.py:188:1: E731 [*] Do not assign a `lambda` expression, use a `def`
+    |
+186 |   )
+187 |
+188 | / foo_tooltip = (
+189 | |     lambda x, data: f"\nfoo: {data['foo'][int(x)]}" +
+190 | |     more
+191 | |
+192 | | )
+    | |_^ E731
+    |
+    = help: Rewrite `foo_tooltip` as a `def`
+
+ℹ Unsafe fix
+185 185 |     else ""
+186 186 | )
+187 187 | 
+188     |-foo_tooltip = (
+189     |-    lambda x, data: f"\nfoo: {data['foo'][int(x)]}" +
+190     |-    more
+191     |-
+192     |-)
+    188 |+def foo_tooltip(x, data):
+    189 |+    return (f"\nfoo: {data['foo'][int(x)]}" +
+    190 |+    more)

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E731_E731.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E731_E731.py.snap
@@ -449,6 +449,8 @@ E731.py:176:1: E731 [*] Do not assign a `lambda` expression, use a `def`
 178 | |     y := 10
 179 | | )
     | |_^ E731
+180 |
+181 |   # https://github.com/astral-sh/ruff/issues/18475
     |
     = help: Rewrite `x` as a `def`
 
@@ -462,3 +464,28 @@ E731.py:176:1: E731 [*] Do not assign a `lambda` expression, use a `def`
 177 178 |     # comment
 178 179 |     y := 10
 179 180 | )
+
+E731.py:182:1: E731 [*] Do not assign a `lambda` expression, use a `def`
+    |
+181 |   # https://github.com/astral-sh/ruff/issues/18475
+182 | / foo_tooltip = (
+183 | |     lambda x, data: f"\nfoo: {data['foo'][int(x)]}"
+184 | |     if data["foo"] is not None
+185 | |     else ""
+186 | | )
+    | |_^ E731
+    |
+    = help: Rewrite `foo_tooltip` as a `def`
+
+ℹ Unsafe fix
+179 179 | )
+180 180 | 
+181 181 | # https://github.com/astral-sh/ruff/issues/18475
+182     |-foo_tooltip = (
+183     |-    lambda x, data: f"\nfoo: {data['foo'][int(x)]}"
+    182 |+def foo_tooltip(x, data):
+    183 |+    return (f"\nfoo: {data['foo'][int(x)]}"
+184 184 |     if data["foo"] is not None
+185     |-    else ""
+186     |-)
+    185 |+    else "")


### PR DESCRIPTION


<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

Fixes #18475

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

Add regression test
<!-- How was it tested? -->
