### PR TITLE
[ty] Fix completion order in playground

### DIFF
--- a/playground/ty/src/Editor/Editor.tsx
+++ b/playground/ty/src/Editor/Editor.tsx
@@ -202,9 +202,13 @@ class PlaygroundServer
       new TyPosition(position.lineNumber, position.column),
     );
 
+    // If completions is 100, this gives us "99" which has a length of two
+    const digitsLength = String(completions.length - 1).length;
+
     return {
-      suggestions: completions.map((completion) => ({
+      suggestions: completions.map((completion, i) => ({
         label: completion.label,
+        sortText: String(i).padStart(digitsLength, "0"),
         kind: CompletionItemKind.Variable,
         insertText: completion.label,
         // TODO(micha): It's unclear why this field is required for monaco but not VS Code.
@@ -491,7 +495,7 @@ class PlaygroundServer
     this.typeDefinitionProviderDisposable.dispose();
     this.inlayHintsDisposable.dispose();
     this.formatDisposable.dispose();
-    this.editorOpenerDisposable.dispose();
+    this.completionDisposable.dispose();
   }
 }
 


### PR DESCRIPTION
## Summary

By default, Monaco sorts the completion items by the label but we want to preserve the order
returned by the `completions` functions. Ideally, we could just disable sorting but I couldn't find a way to do this.

This PR sets the `sortText` which monaco uses for sorting. It's a bit awkward because it's a string (which gets compared in alphabetic ordering)
But the basic idea is that we use the padded index as sort key.

## Test Plan

https://github.com/user-attachments/assets/acc589e6-bffe-4033-9de6-714dc1bd3e33


