### PR TITLE
Stabilize RUF059

### DIFF
--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -1025,7 +1025,7 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         (Ruff, "056") => (RuleGroup::Preview, rules::ruff::rules::FalsyDictGetFallback),
         (Ruff, "057") => (RuleGroup::Preview, rules::ruff::rules::UnnecessaryRound),
         (Ruff, "058") => (RuleGroup::Preview, rules::ruff::rules::StarmapZip),
-        (Ruff, "059") => (RuleGroup::Preview, rules::ruff::rules::UnusedUnpackedVariable),
+        (Ruff, "059") => (RuleGroup::Stable, rules::ruff::rules::UnusedUnpackedVariable),
         (Ruff, "060") => (RuleGroup::Preview, rules::ruff::rules::InEmptyCollection),
         (Ruff, "100") => (RuleGroup::Stable, rules::ruff::rules::UnusedNOQA),
         (Ruff, "101") => (RuleGroup::Stable, rules::ruff::rules::RedirectedNOQA),


### PR DESCRIPTION
## Summary
- mark `unused-unpacked-variable` (RUF059) as stable in the rule registry

## Testing
- `cargo test -p ruff_linter rules::ruff::tests::rules::rule_unusedunpackedvariable_path_new_ruf059_0_py_expects -- --exact`
- `cargo test -p ruff_linter rules::ruff::tests::rules::rule_unusedunpackedvariable_path_new_ruf059_1_py_expects -- --exact`
- `cargo test -p ruff_linter rules::ruff::tests::rules::rule_unusedunpackedvariable_path_new_ruf059_2_py_expects -- --exact`
- `cargo test -p ruff_linter rules::ruff::tests::rules::rule_unusedunpackedvariable_path_new_ruf059_3_py_expects -- --exact`
- `cargo insta review`

------
https://chatgpt.com/codex/tasks/task_e_6841bb00a1bc8326b577f1887612955d