### PR TITLE
[ty] Don't add incorrect subdiagnostic for unresolved reference

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -985,6 +985,32 @@ class Foo:
         y = x
 ```
 
+When accessing an attribute in a staticmethod, we don't suggest the use of `self.`.
+
+```py
+class Foo:
+    def __init__(self):
+        self.x = 42
+
+    @staticmethod
+    def static_method():
+        # error: [unresolved-reference] "Name `x` used when not defined"
+        y = x
+```
+
+When accessing an attribute in a classmethod, we don't suggest the use of `self.`.
+
+```py
+class Foo:
+    def __init__(self):
+        self.x = 42
+
+    @classmethod
+    def class_method(cls):
+        # error: [unresolved-reference] "Name `x` used when not defined"
+        y = x
+```
+
 ## Unions of attributes
 
 If the (meta)class is a union type or if the attribute on the (meta) class has a union type, we

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attributes.md_-_Attributes_-_Invalid_access_to_at…_(5457445ffed43a87).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attributes.md_-_Attributes_-_Invalid_access_to_at…_(5457445ffed43a87).snap
@@ -31,6 +31,22 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/attributes.md
 17 |     def method(self):
 18 |         # error: [unresolved-reference] "Name `x` used when not defined"
 19 |         y = x
+20 | class Foo:
+21 |     def __init__(self):
+22 |         self.x = 42
+23 | 
+24 |     @staticmethod
+25 |     def static_method():
+26 |         # error: [unresolved-reference] "Name `x` used when not defined"
+27 |         y = x
+28 | class Foo:
+29 |     def __init__(self):
+30 |         self.x = 42
+31 | 
+32 |     @classmethod
+33 |     def class_method(cls):
+34 |         # error: [unresolved-reference] "Name `x` used when not defined"
+35 |         y = x
 ```
 
 # Diagnostics
@@ -75,8 +91,38 @@ error[unresolved-reference]: Name `x` used when not defined
 18 |         # error: [unresolved-reference] "Name `x` used when not defined"
 19 |         y = x
    |             ^
+20 | class Foo:
+21 |     def __init__(self):
    |
 info: An attribute `x` is available: consider using `self.x`
+info: rule `unresolved-reference` is enabled by default
+
+```
+
+```
+error[unresolved-reference]: Name `x` used when not defined
+  --> src/mdtest_snippet.py:27:13
+   |
+25 |     def static_method():
+26 |         # error: [unresolved-reference] "Name `x` used when not defined"
+27 |         y = x
+   |             ^
+28 | class Foo:
+29 |     def __init__(self):
+   |
+info: rule `unresolved-reference` is enabled by default
+
+```
+
+```
+error[unresolved-reference]: Name `x` used when not defined
+  --> src/mdtest_snippet.py:35:13
+   |
+33 |     def class_method(cls):
+34 |         # error: [unresolved-reference] "Name `x` used when not defined"
+35 |         y = x
+   |             ^
+   |
 info: rule `unresolved-reference` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -2103,6 +2103,7 @@ pub enum KnownClass {
     BaseExceptionGroup,
     ExceptionGroup,
     Classmethod,
+    Staticmethod,
     Super,
     // enum
     Enum,
@@ -2232,6 +2233,7 @@ impl<'db> KnownClass {
             // (see https://docs.python.org/3/library/constants.html#NotImplemented)
             | Self::NotImplementedType
             | Self::Classmethod
+            | Self::Staticmethod
             | Self::Field
             | Self::NamedTupleFallback => Truthiness::Ambiguous,
         }
@@ -2275,6 +2277,7 @@ impl<'db> KnownClass {
             | Self::Exception
             | Self::ExceptionGroup
             | Self::Classmethod
+            | Self::Staticmethod
             | Self::GenericAlias
             | Self::GeneratorType
             | Self::AsyncGeneratorType
@@ -2336,6 +2339,7 @@ impl<'db> KnownClass {
             Self::Exception => "Exception",
             Self::ExceptionGroup => "ExceptionGroup",
             Self::Classmethod => "classmethod",
+            Self::Staticmethod => "staticmethod",
             Self::GenericAlias => "GenericAlias",
             Self::ModuleType => "ModuleType",
             Self::FunctionType => "FunctionType",
@@ -2558,6 +2562,7 @@ impl<'db> KnownClass {
             | Self::Exception
             | Self::ExceptionGroup
             | Self::Classmethod
+            | Self::Staticmethod
             | Self::Slice
             | Self::Super
             | Self::Property => KnownModule::Builtins,
@@ -2651,6 +2656,7 @@ impl<'db> KnownClass {
             | Self::Exception
             | Self::ExceptionGroup
             | Self::Classmethod
+            | Self::Staticmethod
             | Self::GenericAlias
             | Self::ModuleType
             | Self::FunctionType
@@ -2732,6 +2738,7 @@ impl<'db> KnownClass {
             | Self::Exception
             | Self::ExceptionGroup
             | Self::Classmethod
+            | Self::Staticmethod
             | Self::TypeVar
             | Self::ParamSpec
             | Self::ParamSpecArgs
@@ -2778,6 +2785,7 @@ impl<'db> KnownClass {
             "Exception" => Self::Exception,
             "ExceptionGroup" => Self::ExceptionGroup,
             "classmethod" => Self::Classmethod,
+            "staticmethod" => Self::Staticmethod,
             "GenericAlias" => Self::GenericAlias,
             "NoneType" => Self::NoneType,
             "ModuleType" => Self::ModuleType,
@@ -2861,6 +2869,7 @@ impl<'db> KnownClass {
             | Self::EllipsisType
             | Self::BaseExceptionGroup
             | Self::Classmethod
+            | Self::Staticmethod
             | Self::FunctionType
             | Self::MethodType
             | Self::MethodWrapperType


### PR DESCRIPTION


<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

Don't add subdiagnostic in staticmethod, and change message for classmethod

Resolves https://github.com/astral-sh/ty/issues/584 (partially i think)

## Test Plan

Add test and update snapshot
