### PR TITLE
Fix doc for nvim setting examples

### DIFF
--- a/docs/editors/settings.md
+++ b/docs/editors/settings.md
@@ -66,7 +66,9 @@ _Using configuration file path:_
     ```lua
     require('lspconfig').ruff.setup {
       init_options = {
-        configuration = "~/path/to/ruff.toml"
+        settings = {
+          configuration = "~/path/to/ruff.toml"
+        }
       }
     }
     ```
@@ -117,20 +119,22 @@ _Using inline configuration:_
     ```lua
     require('lspconfig').ruff.setup {
       init_options = {
-        configuration = {
-          lint = {
-            unfixable = {"F401"},
-            ["extend-select"] = {"TID251"},
-            ["flake8-tidy-imports"] = {
-              ["banned-api"] = {
-                ["typing.TypedDict"] = {
-                  msg = "Use `typing_extensions.TypedDict` instead"
+        settings = {
+          configuration = {
+            lint = {
+              unfixable = {"F401"},
+              ["extend-select"] = {"TID251"},
+              ["flake8-tidy-imports"] = {
+                ["banned-api"] = {
+                  ["typing.TypedDict"] = {
+                    msg = "Use `typing_extensions.TypedDict` instead"
+                  }
                 }
               }
+            },
+            format = {
+              ["quote-style"] = "single"
             }
-          },
-          format = {
-            ["quote-style"] = "single"
           }
         }
       }


### PR DESCRIPTION
## Summary
This PR fixes an error in the example Neovim configuration on [this documentation page](https://docs.astral.sh/ruff/editors/settings/#configuration).
The `configuration` block should be nested under `settings`, consistent with other properties and as outlined [here](https://docs.astral.sh/ruff/editors/setup/#neovim).

I encountered this issue when copying the example to configure ruff integration in my neovim - the config didn’t work until I corrected the nesting.

## Test Plan
- [x] Confirmed that the corrected configuration works in a real Neovim + Ruff setup
- [x] Verified that the updated configuration renders correctly in MkDocs
<img width="382" alt="image" src="https://github.com/user-attachments/assets/0722fb35-8ffa-4b10-90ba-c6e8417e40bf" />

