### PR TITLE
[`flake8-logging`] Stabilize `exc-info-outside-except-handler` (`LOG014`)

### DIFF
--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -1151,7 +1151,7 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         (Flake8Logging, "004") => (RuleGroup::Preview, rules::flake8_logging::rules::LogExceptionOutsideExceptHandler),
         (Flake8Logging, "007") => (RuleGroup::Stable, rules::flake8_logging::rules::ExceptionWithoutExcInfo),
         (Flake8Logging, "009") => (RuleGroup::Stable, rules::flake8_logging::rules::UndocumentedWarn),
-        (Flake8Logging, "014") => (RuleGroup::Preview, rules::flake8_logging::rules::ExcInfoOutsideExceptHandler),
+        (Flake8Logging, "014") => (RuleGroup::Stable, rules::flake8_logging::rules::ExcInfoOutsideExceptHandler),
         (Flake8Logging, "015") => (RuleGroup::Stable, rules::flake8_logging::rules::RootLoggerCall),
 
         _ => return None,


### PR DESCRIPTION
## Summary
- Stabilizes LOG014 (exc-info-outside-except-handler) rule by changing it from Preview to Stable

## Test plan
- ✅ Rule is already tested in main test function, no migration needed
- ✅ `make check` passes
- ✅ `make test` passes

## Rule Documentation
- [Test file](https://github.com/astral-sh/ruff/blob/main/crates/ruff_linter/src/rules/flake8_logging/mod.rs#L22-L23)
- [Rule documentation](https://docs.astral.sh/ruff/rules/exc-info-outside-except-handler/)