### PR TITLE
[ty] Optimize `Type::has_relation_to()`

### DIFF
--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -346,7 +346,7 @@ impl<'db> ClassType<'db> {
         self.has_relation_to(
             db,
             other,
-            TypeRelation::Subtyping(ApplicabilityCheck::default()),
+            &TypeRelation::Subtyping(ApplicabilityCheck::default()),
         )
     }
 
@@ -354,7 +354,7 @@ impl<'db> ClassType<'db> {
         self,
         db: &'db dyn Db,
         other: Self,
-        relation: TypeRelation,
+        relation: &TypeRelation,
     ) -> bool {
         self.iter_mro(db).any(|base| {
             match base {

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -12,7 +12,8 @@ use crate::types::function::{DataclassTransformerParams, KnownFunction};
 use crate::types::generics::{GenericContext, Specialization};
 use crate::types::signatures::{CallableSignature, Parameter, Parameters, Signature};
 use crate::types::{
-    CallableType, DataclassParams, KnownInstanceType, TypeMapping, TypeRelation, TypeVarInstance,
+    ApplicabilityCheck, CallableType, DataclassParams, KnownInstanceType, TypeMapping,
+    TypeRelation, TypeVarInstance,
 };
 use crate::{
     Db, FxOrderSet, KnownModule, Program,
@@ -342,7 +343,11 @@ impl<'db> ClassType<'db> {
 
     /// Return `true` if `other` is present in this class's MRO.
     pub(super) fn is_subclass_of(self, db: &'db dyn Db, other: ClassType<'db>) -> bool {
-        self.has_relation_to(db, other, TypeRelation::Subtyping)
+        self.has_relation_to(
+            db,
+            other,
+            TypeRelation::Subtyping(ApplicabilityCheck::default()),
+        )
     }
 
     pub(super) fn has_relation_to(

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -716,7 +716,7 @@ impl<'db> FunctionType<'db> {
         relation: TypeRelation,
     ) -> bool {
         match relation {
-            TypeRelation::Subtyping => self.is_subtype_of(db, other),
+            TypeRelation::Subtyping(..) => self.is_subtype_of(db, other),
             TypeRelation::Assignability => self.is_assignable_to(db, other),
         }
     }

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -713,7 +713,7 @@ impl<'db> FunctionType<'db> {
         self,
         db: &'db dyn Db,
         other: Self,
-        relation: TypeRelation,
+        relation: &TypeRelation,
     ) -> bool {
         match relation {
             TypeRelation::Subtyping(..) => self.is_subtype_of(db, other),

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -376,7 +376,7 @@ impl<'db> Specialization<'db> {
             if self_type.is_dynamic() || other_type.is_dynamic() {
                 match relation {
                     TypeRelation::Assignability => continue,
-                    TypeRelation::Subtyping => return false,
+                    TypeRelation::Subtyping(..) => return false,
                 }
             }
 
@@ -388,7 +388,7 @@ impl<'db> Specialization<'db> {
             //   - bivariant: skip, can't make subtyping/assignability false
             let compatible = match typevar.variance(db) {
                 TypeVarVariance::Invariant => match relation {
-                    TypeRelation::Subtyping => self_type.is_equivalent_to(db, *other_type),
+                    TypeRelation::Subtyping(..) => self_type.is_equivalent_to(db, *other_type),
                     TypeRelation::Assignability => {
                         self_type.is_assignable_to(db, *other_type)
                             && other_type.is_assignable_to(db, *self_type)

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -362,7 +362,7 @@ impl<'db> Specialization<'db> {
         self,
         db: &'db dyn Db,
         other: Self,
-        relation: TypeRelation,
+        relation: &TypeRelation,
     ) -> bool {
         let generic_context = self.generic_context(db);
         if generic_context != other.generic_context(db) {

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -84,7 +84,7 @@ impl<'db> NominalInstanceType<'db> {
         self,
         db: &'db dyn Db,
         other: Self,
-        relation: TypeRelation,
+        relation: &TypeRelation,
     ) -> bool {
         self.class.has_relation_to(db, other.class, relation)
     }
@@ -263,7 +263,7 @@ impl<'db> ProtocolInstanceType<'db> {
         self,
         db: &'db dyn Db,
         other: Self,
-        mut relation: TypeRelation,
+        relation: &TypeRelation,
     ) -> bool {
         if !relation.applies_to(
             db,

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -263,13 +263,16 @@ impl<'db> ProtocolInstanceType<'db> {
         self,
         db: &'db dyn Db,
         other: Self,
-        relation: TypeRelation,
+        mut relation: TypeRelation,
     ) -> bool {
-        relation.applies_to(
+        if !relation.applies_to(
             db,
             Type::ProtocolInstance(self),
             Type::ProtocolInstance(other),
-        ) && other
+        ) {
+            return false;
+        }
+        other
             .inner
             .interface(db)
             .is_sub_interface_of(db, self.inner.interface(db))

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -105,7 +105,7 @@ impl<'db> CallableSignature<'db> {
         relation: TypeRelation,
     ) -> bool {
         match relation {
-            TypeRelation::Subtyping => self.is_subtype_of(db, other),
+            TypeRelation::Subtyping(..) => self.is_subtype_of(db, other),
             TypeRelation::Assignability => self.is_assignable_to(db, other),
         }
     }
@@ -545,14 +545,15 @@ impl<'db> Signature<'db> {
 
     /// Return `true` if a callable with signature `self` is a subtype of a callable with signature
     /// `other`.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `self` or `other` is not a fully static signature.
     pub(crate) fn is_subtype_of(&self, db: &'db dyn Db, other: &Signature<'db>) -> bool {
         self.is_assignable_to_impl(other, |type1, type2| {
-            // SAFETY: Subtype relation is only checked for fully static types.
-            type1.unwrap().is_subtype_of(db, type2.unwrap())
+            let Some(type1) = type1 else {
+                return false;
+            };
+            let Some(type2) = type2 else {
+                return false;
+            };
+            type1.is_subtype_of(db, type2)
         })
     }
 

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -102,7 +102,7 @@ impl<'db> CallableSignature<'db> {
         &self,
         db: &'db dyn Db,
         other: &Self,
-        relation: TypeRelation,
+        relation: &TypeRelation,
     ) -> bool {
         match relation {
             TypeRelation::Subtyping(..) => self.is_subtype_of(db, other),

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -113,7 +113,7 @@ impl<'db> SubclassOfType<'db> {
         self,
         db: &'db dyn Db,
         other: SubclassOfType<'db>,
-        relation: TypeRelation,
+        relation: &TypeRelation,
     ) -> bool {
         match (self.subclass_of, other.subclass_of) {
             (SubclassOfInner::Dynamic(_), _) | (_, SubclassOfInner::Dynamic(_)) => {


### PR DESCRIPTION
## Summary

`Type::is_fully_static` is called from `Type::has_relation_to` to check whether the relation applies to a given pair of types. `Type::is_fully_static` deeply recurses into types to check whether a type is fully static or not. But `Type::has_relation_to` often calls itself recursively, and it shouldn't be necessary when doing a recursive call of `Type::has_relation_to` to check _again_ whether the pair of types is fully static or not: that should already have been checked by the top-most call.

This PR changes the `TypeRelation` enum so that if we're doing a subtyping check through `Type::has_relation_to`, we "remember" whether we've already checked that this pair of types is fully static or not. If so, we just return the cached result.

Locally I see a 3% speedup from these changes on the `many_tuple_assignments` benchmark. [Codspeed](https://codspeed.io/astral-sh/ruff/branches/alex%2Foptimize-subtyping) sees maybe a tiny improvement on that benchmark in CI, but it's small enough to be dismissed as noise :-(

I still think this might be worth doing anyway: the current design _looks_ extremely inefficient, even if it isn't actually costing us much in any of our current benchmarks.

In the future, we can also unify `Type::is_equivalent_to()` and `Type::is_gradual_equivalent_to()` the same way that I unified `Type::is_assignable_to` and `Type::is_subtype_of`. This would allow us to pass the `TypeRelation` enum into those methods too, which would mean we wouldn't have to redundantly check whether a pair of types was both fully static if that had already been checked by an outer call. (These methods are both called by `Type::has_relation_to`.)

## Test Plan

All existing tests pass and there is no mypy_primer fallout.
