### PR TITLE
[ty] Enable more corpus tests

### DIFF
--- a/crates/ty_project/tests/check.rs
+++ b/crates/ty_project/tests/check.rs
@@ -59,7 +59,6 @@ fn linter_gz_no_panic() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "Enable running once there are fewer failures"]
 fn linter_stubs_no_panic() -> anyhow::Result<()> {
     let workspace_root = get_cargo_workspace_root()?;
     run_corpus_tests(&format!(
@@ -68,7 +67,6 @@ fn linter_stubs_no_panic() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "Enable running over typeshed stubs once there are fewer failures"]
 fn typeshed_no_panic() -> anyhow::Result<()> {
     let workspace_root = get_cargo_workspace_root()?;
     run_corpus_tests(&format!(
@@ -119,6 +117,11 @@ fn run_corpus_tests(pattern: &str) -> anyhow::Result<()> {
         let code = std::fs::read_to_string(source)?;
 
         let mut check_with_file_name = |path: &SystemPath| {
+            if DO_NOT_ATTEMPT.contains(&relative_path.as_str()) {
+                println!("Skipping {relative_path:?} due to known stack overflow");
+                return;
+            }
+
             memory_fs.write_file_all(path, &code).unwrap();
             File::sync_path(&mut db, path);
 
@@ -298,4 +301,29 @@ const KNOWN_FAILURES: &[(&str, bool, bool)] = &[
     // Fails with too-many-cycle-iterations due to a self-referential
     // type alias, see https://github.com/astral-sh/ty/issues/256
     ("crates/ruff_linter/resources/test/fixtures/pyflakes/F401_34.py", true, true),
+
+    // These are all "expression should belong to this TypeInference region and TypeInferenceBuilder should have inferred a type for it"
+    ("crates/ty_vendored/vendor/typeshed/stdlib/abc.pyi", true, true),
+    ("crates/ty_vendored/vendor/typeshed/stdlib/annotationlib.pyi", true, true),
+    ("crates/ty_vendored/vendor/typeshed/stdlib/ast.pyi", true, true),
+    ("crates/ty_vendored/vendor/typeshed/stdlib/builtins.pyi", true, true),
+    ("crates/ty_vendored/vendor/typeshed/stdlib/curses/__init__.pyi", true, true),
+    ("crates/ty_vendored/vendor/typeshed/stdlib/dataclasses.pyi", true, true),
+    ("crates/ty_vendored/vendor/typeshed/stdlib/inspect.pyi", true, true),
+    ("crates/ty_vendored/vendor/typeshed/stdlib/lzma.pyi", true, true),
+    ("crates/ty_vendored/vendor/typeshed/stdlib/os/__init__.pyi", true, true),
+    ("crates/ty_vendored/vendor/typeshed/stdlib/pathlib/__init__.pyi", true, true),
+    ("crates/ty_vendored/vendor/typeshed/stdlib/pathlib/types.pyi", true, true),
+    ("crates/ty_vendored/vendor/typeshed/stdlib/pstats.pyi", true, true),
+    ("crates/ty_vendored/vendor/typeshed/stdlib/signal.pyi", true, true),
+    ("crates/ty_vendored/vendor/typeshed/stdlib/socket.pyi", true, true),
+    ("crates/ty_vendored/vendor/typeshed/stdlib/sqlite3/__init__.pyi", true, true),
+    ("crates/ty_vendored/vendor/typeshed/stdlib/tempfile.pyi", true, true),
+];
+
+/// Attempting to check one of these files causes a stack overflow
+const DO_NOT_ATTEMPT: &[&str] = &[
+    "crates/ty_vendored/vendor/typeshed/stdlib/pathlib/types.pyi",
+    "crates/ty_vendored/vendor/typeshed/stdlib/types.pyi",
+    "crates/ty_vendored/vendor/typeshed/stdlib/wsgiref/types.pyi",
 ];

--- a/crates/ty_project/tests/check.rs
+++ b/crates/ty_project/tests/check.rs
@@ -117,7 +117,7 @@ fn run_corpus_tests(pattern: &str) -> anyhow::Result<()> {
         let code = std::fs::read_to_string(source)?;
 
         let mut check_with_file_name = |path: &SystemPath| {
-            if DO_NOT_ATTEMPT.contains(&relative_path.as_str()) {
+            if DO_NOT_ATTEMPT.contains(&&*relative_path.as_str().replace('\\', "/")) {
                 println!("Skipping {relative_path:?} due to known stack overflow");
                 return;
             }


### PR DESCRIPTION
## Summary

We now no longer panic on any of the files covered by the `linter_stubs_no_panic()` test, so we can safely enable that without adding any new files to the `KNOWN_FAILURES` list 🎉

We still do panic on several files in typeshed when attempting to pull types, but the number is now low enough that we can just list the failing files in `KNOWN_FAILURES`. Somewhat concerning is that we appear to have stack overflows when attempting to pull types in any typeshed files where the last segement of the path is "types.pyi". We should look into that -- but I still think it's worth expanding the corpus test to run over most typeshed files for now, to prevent future regressions.

## Test Plan

`cargo test -p ty_project --test check`