### PR TITLE
[ty] Fix panic when trying to pull types for subscript expressions inside `Callable` type expressions

### DIFF
--- a/crates/ty_project/resources/test/corpus/callable_with_concatenate.py
+++ b/crates/ty_project/resources/test/corpus/callable_with_concatenate.py
@@ -1,0 +1,6 @@
+from typing_extensions import TypeVar, Callable, Concatenate, ParamSpec
+
+_T = TypeVar("_T")
+_P = ParamSpec("_P")
+
+def f(self, callable: Callable[Concatenate[_T, _P], _T]) -> Callable[_P, _T]: ...

--- a/crates/ty_project/tests/check.rs
+++ b/crates/ty_project/tests/check.rs
@@ -301,11 +301,6 @@ const KNOWN_FAILURES: &[(&str, bool, bool)] = &[
     // Fails with too-many-cycle-iterations due to a self-referential
     // type alias, see https://github.com/astral-sh/ty/issues/256
     ("crates/ruff_linter/resources/test/fixtures/pyflakes/F401_34.py", true, true),
-
-    // These are all "expression should belong to this TypeInference region and TypeInferenceBuilder should have inferred a type for it"
-    ("crates/ty_vendored/vendor/typeshed/stdlib/abc.pyi", true, true),
-    ("crates/ty_vendored/vendor/typeshed/stdlib/builtins.pyi", true, true),
-    ("crates/ty_vendored/vendor/typeshed/stdlib/curses/__init__.pyi", true, true),
 ];
 
 /// Attempting to check one of these files causes a stack overflow

--- a/crates/ty_project/tests/check.rs
+++ b/crates/ty_project/tests/check.rs
@@ -117,8 +117,10 @@ fn run_corpus_tests(pattern: &str) -> anyhow::Result<()> {
         let code = std::fs::read_to_string(source)?;
 
         let mut check_with_file_name = |path: &SystemPath| {
-            if DO_NOT_ATTEMPT.contains(&&*relative_path.as_str().replace('\\', "/")) {
-                println!("Skipping {relative_path:?} due to known stack overflow");
+            if relative_path.file_name() == Some("types.pyi") {
+                println!(
+                    "Skipping {relative_path:?}: paths with `types.pyi` as their final segment cause a stack overflow"
+                );
                 return;
             }
 
@@ -301,11 +303,4 @@ const KNOWN_FAILURES: &[(&str, bool, bool)] = &[
     // Fails with too-many-cycle-iterations due to a self-referential
     // type alias, see https://github.com/astral-sh/ty/issues/256
     ("crates/ruff_linter/resources/test/fixtures/pyflakes/F401_34.py", true, true),
-];
-
-/// Attempting to check one of these files causes a stack overflow
-const DO_NOT_ATTEMPT: &[&str] = &[
-    "crates/ty_vendored/vendor/typeshed/stdlib/pathlib/types.pyi",
-    "crates/ty_vendored/vendor/typeshed/stdlib/types.pyi",
-    "crates/ty_vendored/vendor/typeshed/stdlib/wsgiref/types.pyi",
 ];

--- a/crates/ty_python_semantic/resources/mdtest/annotations/callable.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/callable.md
@@ -267,9 +267,12 @@ But providing fewer than 2 arguments to `Concatenate` is an error:
 
 def _(
     c: Callable[Concatenate[int], int],  # error: [invalid-type-form] "Special form `typing.Concatenate` expected at least 2 parameters but got 1"
-    d: Callable[Concatenate[(int,)], int]  # error: [invalid-type-form] "Special form `typing.Concatenate` expected at least 2 parameters but got 1"
+    d: Callable[Concatenate[(int,)], int],  # error: [invalid-type-form] "Special form `typing.Concatenate` expected at least 2 parameters but got 1"
+    e: Callable[Concatenate[()], int]  # error: [invalid-type-form] "Special form `typing.Concatenate` expected at least 2 parameters but got 0"
 ):
     reveal_type(c)  # revealed: (...) -> int
+    reveal_type(d)  # revealed: (...) -> int
+    reveal_type(e)  # revealed: (...) -> int
 
 # fmt: on
 ```

--- a/crates/ty_python_semantic/resources/mdtest/annotations/callable.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/callable.md
@@ -252,6 +252,28 @@ def _(c: Callable[[Concatenate[int, str, ...], int], int]):
     reveal_type(c)  # revealed: (...) -> int
 ```
 
+Other type expressions can be nested inside `Concatenate`:
+
+```py
+def _(c: Callable[[Concatenate[int | str, type[str], ...], int], int]):
+    # TODO: Should reveal the correct signature
+    reveal_type(c)  # revealed: (...) -> int
+```
+
+But providing fewer than 2 arguments to `Concatenate` is an error:
+
+```py
+# fmt: off
+
+def _(
+    c: Callable[Concatenate[int], int],  # error: [invalid-type-form] "Special form `typing.Concatenate` expected at least 2 parameters but got 1"
+    d: Callable[Concatenate[(int,)], int]  # error: [invalid-type-form] "Special form `typing.Concatenate` expected at least 2 parameters but got 1"
+):
+    reveal_type(c)  # revealed: (...) -> int
+
+# fmt: on
+```
+
 ## Using `typing.ParamSpec`
 
 ```toml

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -9450,7 +9450,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     self.infer_type_expression(argument);
                 }
                 let num_arguments = arguments.len();
-                let ty = if num_arguments < 2 {
+                let inferred_type = if num_arguments < 2 {
                     if let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, subscript) {
                         builder.into_diagnostic(format_args!(
                             "Special form `{special_form}` expected at least 2 parameters but got {num_arguments}",
@@ -9461,9 +9461,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     todo_type!("`Concatenate[]` special form")
                 };
                 if arguments_slice.is_tuple_expr() {
-                    self.store_expression_type(arguments_slice, ty);
+                    self.store_expression_type(arguments_slice, inferred_type);
                 }
-                ty
+                inferred_type
             }
             SpecialFormType::Unpack => {
                 self.infer_type_expression(arguments_slice);

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -9622,7 +9622,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     }))
                 });
             }
-            ast::Expr::Subscript(_) => {
+            ast::Expr::Subscript(subscript) => {
+                let value_ty = self.infer_expression(&subscript.value);
+                self.infer_subscript_type_expression(subscript, value_ty);
                 // TODO: Support `Concatenate[...]`
                 return Some(Parameters::todo());
             }


### PR DESCRIPTION
## Summary

We weren't storing types for subscript expressions inside the parameter list of `Callable` type expressions; this was the cause of the corpus test failures for two files in our vendored copy of typeshed.

## Test Plan

- Removed the remaining typeshed entries from the `KNOWN_FAILURES` corpus list
- Added a standalone corpus test so that we still have coverage for this in case typeshed changes in the future
- Added an mdtest to cover the regression surfaced by primer on the first version of this PR
