### PR TITLE
[ty] Fix panic when trying to pull types for attribute expressions inside `Literal` type expressions

### DIFF
--- a/crates/ty_project/resources/test/corpus/literal_slices.py
+++ b/crates/ty_project/resources/test/corpus/literal_slices.py
@@ -1,0 +1,6 @@
+from typing import Literal
+
+class Format:
+    STRING = "string"
+
+def evaluate(format: Literal[Format.STRING]) -> str: ...

--- a/crates/ty_project/tests/check.rs
+++ b/crates/ty_project/tests/check.rs
@@ -304,18 +304,14 @@ const KNOWN_FAILURES: &[(&str, bool, bool)] = &[
 
     // These are all "expression should belong to this TypeInference region and TypeInferenceBuilder should have inferred a type for it"
     ("crates/ty_vendored/vendor/typeshed/stdlib/abc.pyi", true, true),
-    ("crates/ty_vendored/vendor/typeshed/stdlib/annotationlib.pyi", true, true),
     ("crates/ty_vendored/vendor/typeshed/stdlib/ast.pyi", true, true),
     ("crates/ty_vendored/vendor/typeshed/stdlib/builtins.pyi", true, true),
     ("crates/ty_vendored/vendor/typeshed/stdlib/curses/__init__.pyi", true, true),
-    ("crates/ty_vendored/vendor/typeshed/stdlib/dataclasses.pyi", true, true),
-    ("crates/ty_vendored/vendor/typeshed/stdlib/inspect.pyi", true, true),
     ("crates/ty_vendored/vendor/typeshed/stdlib/lzma.pyi", true, true),
     ("crates/ty_vendored/vendor/typeshed/stdlib/os/__init__.pyi", true, true),
     ("crates/ty_vendored/vendor/typeshed/stdlib/pathlib/__init__.pyi", true, true),
     ("crates/ty_vendored/vendor/typeshed/stdlib/pathlib/types.pyi", true, true),
     ("crates/ty_vendored/vendor/typeshed/stdlib/pstats.pyi", true, true),
-    ("crates/ty_vendored/vendor/typeshed/stdlib/signal.pyi", true, true),
     ("crates/ty_vendored/vendor/typeshed/stdlib/socket.pyi", true, true),
     ("crates/ty_vendored/vendor/typeshed/stdlib/sqlite3/__init__.pyi", true, true),
     ("crates/ty_vendored/vendor/typeshed/stdlib/tempfile.pyi", true, true),

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -9468,11 +9468,13 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             ast::Expr::Attribute(ast::ExprAttribute { value, attr, .. }) => {
                 let value_ty = self.infer_expression(value);
                 // TODO: Check that value type is enum otherwise return None
-                value_ty
+                let ty = value_ty
                     .member(self.db(), &attr.id)
                     .place
                     .ignore_possibly_unbound()
-                    .unwrap_or(Type::unknown())
+                    .unwrap_or(Type::unknown());
+                self.store_expression_type(parameters, ty);
+                ty
             }
             // for negative and positive numbers
             ast::Expr::UnaryOp(u)


### PR DESCRIPTION
## Summary

We weren't storing the type for attribute expressions inside `Literal` slices. This was causing us to panic when pulling types on four typeshed files.

## Test Plan

Added a corpus test that previously failed and removed four entries from the `KNOWN_FAILURES` corpus test ignorelist. All existing tests pass.