### PR TITLE
[ty] Introduce and use `System::env_var` for better test isolation

### DIFF
--- a/crates/ruff_db/src/system.rs
+++ b/crates/ruff_db/src/system.rs
@@ -171,6 +171,21 @@ pub trait System: Debug {
         PatternError,
     >;
 
+    /// Fetches the environment variable `key` from the current process.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`std::env::VarError::NotPresent`] if:
+    /// - The variable is not set.
+    /// - The variable's name contains an equal sign or NUL (`'='` or `'\0'`).
+    ///
+    /// Returns [`std::env::VarError::NotUnicode`] if the variable's value is not valid
+    /// Unicode.
+    fn env_var(&self, name: &str) -> std::result::Result<String, std::env::VarError> {
+        let _ = name;
+        Err(std::env::VarError::NotPresent)
+    }
+
     fn as_any(&self) -> &dyn std::any::Any;
 
     fn as_any_mut(&mut self) -> &mut dyn std::any::Any;

--- a/crates/ruff_db/src/system/os.rs
+++ b/crates/ruff_db/src/system/os.rs
@@ -214,6 +214,10 @@ impl System for OsSystem {
             })
         })))
     }
+
+    fn env_var(&self, name: &str) -> std::result::Result<String, std::env::VarError> {
+        std::env::var(name)
+    }
 }
 
 impl OsSystem {

--- a/crates/ty_project/src/metadata/options.rs
+++ b/crates/ty_project/src/metadata/options.rs
@@ -192,12 +192,12 @@ impl Options {
                     PythonPath::sys_prefix(python_path.absolute(project_root, system), origin)
                 })
                 .or_else(|| {
-                    std::env::var("VIRTUAL_ENV").ok().map(|virtual_env| {
+                    system.env_var("VIRTUAL_ENV").ok().map(|virtual_env| {
                         PythonPath::sys_prefix(virtual_env, SysPrefixPathOrigin::VirtualEnvVar)
                     })
                 })
                 .or_else(|| {
-                    std::env::var("CONDA_PREFIX").ok().map(|path| {
+                    system.env_var("CONDA_PREFIX").ok().map(|path| {
                         PythonPath::sys_prefix(path, SysPrefixPathOrigin::CondaPrefixVar)
                     })
                 })

--- a/crates/ty_server/src/system.rs
+++ b/crates/ty_server/src/system.rs
@@ -247,6 +247,10 @@ impl System for LSPSystem {
     fn case_sensitivity(&self) -> CaseSensitivity {
         self.os_system.case_sensitivity()
     }
+
+    fn env_var(&self, name: &str) -> std::result::Result<String, std::env::VarError> {
+        self.os_system.env_var(name)
+    }
 }
 
 fn not_a_text_document(path: impl Display) -> std::io::Error {


### PR DESCRIPTION
## Summary

Our venv discovery is too good. The corpus tests can now fail if a virtual environment is activated
because ty picks up the `VIRTUAL_ENV` environment variable.

This PR adds a new `env_var` method to `System`, which ensures tests are fully isolated from the host environment (at least when using a `TestSystem`)

## Test Plan

The corpus tests no longer fail when inside a venv
