### PR TITLE
[ty] Pull types on synthesized Python files created by mdtest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4004,6 +4004,7 @@ dependencies = [
  "test-case",
  "thiserror 2.0.12",
  "tracing",
+ "ty_python_semantic",
  "ty_test",
  "ty_vendored",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4040,6 +4040,7 @@ name = "ty_test"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "bitflags 2.9.1",
  "camino",
  "colored 3.0.0",
  "insta",

--- a/crates/ty_python_semantic/Cargo.toml
+++ b/crates/ty_python_semantic/Cargo.toml
@@ -50,6 +50,7 @@ strum_macros = { workspace = true }
 [dev-dependencies]
 ruff_db = { workspace = true, features = ["testing", "os"] }
 ruff_python_parser = { workspace = true }
+ty_python_semantic = { workspace = true, features = ["testing"] }
 ty_test = { workspace = true }
 ty_vendored = { workspace = true }
 
@@ -63,6 +64,7 @@ quickcheck_macros = { version = "1.0.0" }
 
 [features]
 serde = ["ruff_db/serde", "dep:serde", "ruff_python_ast/serde"]
+testing = []
 
 [lints]
 workspace = true

--- a/crates/ty_python_semantic/resources/mdtest/annotations/any.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/any.md
@@ -139,6 +139,8 @@ x: int = MagicMock()
 
 ## Invalid
 
+<!-- pull-types:skip -->
+
 `Any` cannot be parameterized:
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/annotations/callable.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/callable.md
@@ -58,6 +58,8 @@ def _(c: Callable[[int, 42, str, False], None]):
 
 ### Missing return type
 
+<!-- pull-types:skip -->
+
 Using a parameter list:
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/type_api.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_api.md
@@ -14,6 +14,8 @@ directly.
 
 ### Negation
 
+<!-- pull-types:skip -->
+
 ```py
 from typing import Literal
 from ty_extensions import Not, static_assert
@@ -371,6 +373,8 @@ static_assert(not is_single_valued(Literal["a"] | Literal["b"]))
 
 ## `TypeOf`
 
+<!-- pull-types:skip -->
+
 We use `TypeOf` to get the inferred type of an expression. This is useful when we want to refer to
 it in a type expression. For example, if we want to make sure that the class literal type `str` is a
 subtype of `type[str]`, we can not use `is_subtype_of(str, type[str])`, as that would test if the
@@ -411,6 +415,8 @@ def f(x: TypeOf) -> None:
 ```
 
 ## `CallableTypeOf`
+
+<!-- pull-types:skip -->
 
 The `CallableTypeOf` special form can be used to extract the `Callable` structural type inhabited by
 a given callable object. This can be used to get the externally visibly signature of the object,

--- a/crates/ty_python_semantic/resources/mdtest/type_qualifiers/classvar.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_qualifiers/classvar.md
@@ -84,6 +84,8 @@ d.a = 2
 
 ## Too many arguments
 
+<!-- pull-types:skip -->
+
 ```py
 from typing import ClassVar
 

--- a/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
@@ -45,6 +45,8 @@ reveal_type(FINAL_E)  # revealed: int
 
 ## Too many arguments
 
+<!-- pull-types:skip -->
+
 ```py
 from typing import Final
 

--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -35,6 +35,9 @@ pub mod types;
 mod unpack;
 mod util;
 
+#[cfg(feature = "testing")]
+pub mod pull_types;
+
 type FxOrderSet<V> = ordermap::set::OrderSet<V, BuildHasherDefault<FxHasher>>;
 
 /// Returns the default registry with all known semantic lints.

--- a/crates/ty_python_semantic/src/pull_types.rs
+++ b/crates/ty_python_semantic/src/pull_types.rs
@@ -1,0 +1,134 @@
+//! A utility visitor for testing, which attempts to "pull a type" for ever sub-node in a given AST.
+//!
+//! This is used in the "corpus" and (indirectly) the "mdtest" integration tests for this crate.
+//! (Mdtest uses the `pull_types` function via the `ty_test` crate.)
+
+use crate::{Db, HasType, SemanticModel};
+use ruff_db::{files::File, parsed::parsed_module};
+use ruff_python_ast::{
+    self as ast, visitor::source_order, visitor::source_order::SourceOrderVisitor,
+};
+
+pub fn pull_types(db: &dyn Db, file: File) {
+    let mut visitor = PullTypesVisitor::new(db, file);
+
+    let ast = parsed_module(db.upcast(), file).load(db.upcast());
+
+    visitor.visit_body(ast.suite());
+}
+
+struct PullTypesVisitor<'db> {
+    model: SemanticModel<'db>,
+}
+
+impl<'db> PullTypesVisitor<'db> {
+    fn new(db: &'db dyn Db, file: File) -> Self {
+        Self {
+            model: SemanticModel::new(db, file),
+        }
+    }
+
+    fn visit_target(&mut self, target: &ast::Expr) {
+        match target {
+            ast::Expr::List(ast::ExprList { elts, .. })
+            | ast::Expr::Tuple(ast::ExprTuple { elts, .. }) => {
+                for element in elts {
+                    self.visit_target(element);
+                }
+            }
+            _ => self.visit_expr(target),
+        }
+    }
+}
+
+impl SourceOrderVisitor<'_> for PullTypesVisitor<'_> {
+    fn visit_stmt(&mut self, stmt: &ast::Stmt) {
+        match stmt {
+            ast::Stmt::FunctionDef(function) => {
+                let _ty = function.inferred_type(&self.model);
+            }
+            ast::Stmt::ClassDef(class) => {
+                let _ty = class.inferred_type(&self.model);
+            }
+            ast::Stmt::Assign(assign) => {
+                for target in &assign.targets {
+                    self.visit_target(target);
+                }
+                self.visit_expr(&assign.value);
+                return;
+            }
+            ast::Stmt::For(for_stmt) => {
+                self.visit_target(&for_stmt.target);
+                self.visit_expr(&for_stmt.iter);
+                self.visit_body(&for_stmt.body);
+                self.visit_body(&for_stmt.orelse);
+                return;
+            }
+            ast::Stmt::With(with_stmt) => {
+                for item in &with_stmt.items {
+                    if let Some(target) = &item.optional_vars {
+                        self.visit_target(target);
+                    }
+                    self.visit_expr(&item.context_expr);
+                }
+
+                self.visit_body(&with_stmt.body);
+                return;
+            }
+            ast::Stmt::AnnAssign(_)
+            | ast::Stmt::Return(_)
+            | ast::Stmt::Delete(_)
+            | ast::Stmt::AugAssign(_)
+            | ast::Stmt::TypeAlias(_)
+            | ast::Stmt::While(_)
+            | ast::Stmt::If(_)
+            | ast::Stmt::Match(_)
+            | ast::Stmt::Raise(_)
+            | ast::Stmt::Try(_)
+            | ast::Stmt::Assert(_)
+            | ast::Stmt::Import(_)
+            | ast::Stmt::ImportFrom(_)
+            | ast::Stmt::Global(_)
+            | ast::Stmt::Nonlocal(_)
+            | ast::Stmt::Expr(_)
+            | ast::Stmt::Pass(_)
+            | ast::Stmt::Break(_)
+            | ast::Stmt::Continue(_)
+            | ast::Stmt::IpyEscapeCommand(_) => {}
+        }
+
+        source_order::walk_stmt(self, stmt);
+    }
+
+    fn visit_expr(&mut self, expr: &ast::Expr) {
+        let _ty = expr.inferred_type(&self.model);
+
+        source_order::walk_expr(self, expr);
+    }
+
+    fn visit_comprehension(&mut self, comprehension: &ast::Comprehension) {
+        self.visit_expr(&comprehension.iter);
+        self.visit_target(&comprehension.target);
+        for if_expr in &comprehension.ifs {
+            self.visit_expr(if_expr);
+        }
+    }
+
+    fn visit_parameter(&mut self, parameter: &ast::Parameter) {
+        let _ty = parameter.inferred_type(&self.model);
+
+        source_order::walk_parameter(self, parameter);
+    }
+
+    fn visit_parameter_with_default(&mut self, parameter_with_default: &ast::ParameterWithDefault) {
+        let _ty = parameter_with_default.inferred_type(&self.model);
+
+        source_order::walk_parameter_with_default(self, parameter_with_default);
+    }
+
+    fn visit_alias(&mut self, alias: &ast::Alias) {
+        let _ty = alias.inferred_type(&self.model);
+
+        source_order::walk_alias(self, alias);
+    }
+}

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -471,8 +471,10 @@ impl<'db> TypeInference<'db> {
     #[track_caller]
     pub(crate) fn expression_type(&self, expression: ScopedExpressionId) -> Type<'db> {
         self.try_expression_type(expression).expect(
-            "expression should belong to this TypeInference region and \
-            TypeInferenceBuilder should have inferred a type for it",
+            "Failed to retrieve the inferred type for an `ast::Expr` node \
+            passed to `TypeInference::expression_type()`. The `TypeInferenceBuilder` \
+            should infer and store types for all `ast::Expr` nodes in any `TypeInference` \
+            region it analyzes.",
         )
     }
 

--- a/crates/ty_test/Cargo.toml
+++ b/crates/ty_test/Cargo.toml
@@ -22,6 +22,7 @@ ty_python_semantic = { workspace = true, features = ["serde", "testing"] }
 ty_vendored = { workspace = true }
 
 anyhow = { workspace = true }
+bitflags = { workspace = true }
 camino = { workspace = true }
 colored = { workspace = true }
 insta = { workspace = true, features = ["filters"] }

--- a/crates/ty_test/Cargo.toml
+++ b/crates/ty_test/Cargo.toml
@@ -18,7 +18,7 @@ ruff_python_trivia = { workspace = true }
 ruff_source_file = { workspace = true }
 ruff_text_size = { workspace = true }
 ruff_python_ast = { workspace = true }
-ty_python_semantic = { workspace = true, features = ["serde"] }
+ty_python_semantic = { workspace = true, features = ["serde", "testing"] }
 ty_vendored = { workspace = true }
 
 anyhow = { workspace = true }


### PR DESCRIPTION
## Summary

Our "corpus tests" run an AST visitor that attempts to exhaustively check that each sub-expression in an AST has a type inferred for it. This is a great way to catch potential panics that might happen when you're hovering over an expression in an IDE, for example, since ty will try to retrieve the type of that node so that the IDE can show a nice tooltip to the user.

The corpus tests have a problem, though. There are a number of typing symbols to which ty applies heavy special casing. [It's](https://github.com/astral-sh/ruff/commit/72552f31e40577f32195624279ead0a5364a82e0) [quite](https://github.com/astral-sh/ruff/commit/95497ffaaba5bbceebda7c58c50a47292f9bdd39) [common](https://github.com/astral-sh/ruff/pull/18534) for us to forget to store a type for a subexpression when inferring types for these heavily special-cased symbols, especially in cases where these symbols are being used invalidly. Our corpus of Python snippets that we run the "corpus tests" over doesn't provide great coverage for these symbols, so it's easy for these mistakes to go unnnoticed.

We _do_ have a corpus of Python snippets that _do_ have good coverage for these symbols, however, and which even have pretty good coverage of these symbols being used invalidly: the Python files embedded inside our mdtests! Running the `PullTypesVisitor` over all snippets in our Markdown files should give us a much higher level of confidence that we're not forgetting to store types for any subexpressions in any files.

This PR adds a step to mdtest that runs the `PullTypesVisitor` over every synthesized file created by the mdtest framework. There are six existing mdtest suites that fail this new step; these Markdown files have been added to a `KNOWN_PULL_TYPES_FAILURES` list in the `ty_test` crate.

## Test Plan

`cargo test`
