### PR TITLE
[ty] Add support for global __debug__ constant

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/scopes/global-constants.md
+++ b/crates/ty_python_semantic/resources/mdtest/scopes/global-constants.md
@@ -1,8 +1,8 @@
 # Global Constants
 
-## \_\_debug\_\_ constant
+## `__debug__` constant
 
-\_\_debug\_\_ constant should be globally available.
+The [`__debug__` constant] should be globally available:
 
 ```py
 reveal_type(__debug__)  # revealed: bool
@@ -10,3 +10,5 @@ reveal_type(__debug__)  # revealed: bool
 def foo():
     reveal_type(__debug__)  # revealed: bool
 ```
+
+[`__debug__` constant]: https://docs.python.org/3/library/constants.html#debug__

--- a/crates/ty_python_semantic/resources/mdtest/scopes/global-constants.md
+++ b/crates/ty_python_semantic/resources/mdtest/scopes/global-constants.md
@@ -1,0 +1,12 @@
+# Global Constants
+
+## \_\_debug\_\_ constant
+
+\_\_debug\_\_ constant should be globally available.
+
+```py
+reveal_type(__debug__)  # revealed: bool
+
+def foo():
+    reveal_type(__debug__)  # revealed: bool
+```

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -1073,6 +1073,8 @@ mod implicit_globals {
             Place::bound(KnownClass::Str.to_instance(db)).into()
         } else if name == "__builtins__" {
             Place::bound(Type::any()).into()
+        } else if name == "__debug__" {
+            Place::bound(KnownClass::Bool.to_instance(db)).into()
         }
         // In general we wouldn't check to see whether a symbol exists on a class before doing the
         // `.member()` call on the instance type -- we'd just do the `.member`() call on the instance


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

Closes https://github.com/astral-sh/ty/issues/577. Make global `__debug__` a `bool` constant.

## Test Plan

<!-- How was it tested? -->

Mdtest `global-constants.md` was created to check if resolved type was `bool`.
