### PR TITLE
[ty] Fix stale documents on Windows

### DIFF
--- a/crates/ty_server/src/document.rs
+++ b/crates/ty_server/src/document.rs
@@ -7,6 +7,8 @@ mod text_document;
 
 pub(crate) use location::ToLink;
 use lsp_types::{PositionEncodingKind, Url};
+
+use crate::system::AnySystemPath;
 pub use notebook::NotebookDocument;
 pub(crate) use range::{FileRangeExt, PositionExt, RangeExt, TextSizeExt, ToRangeExt};
 pub(crate) use text_document::DocumentVersion;
@@ -40,19 +42,30 @@ impl From<PositionEncoding> for ruff_source_file::PositionEncoding {
 /// A unique document ID, derived from a URL passed as part of an LSP request.
 /// This document ID can point to either be a standalone Python file, a full notebook, or a cell within a notebook.
 #[derive(Clone, Debug)]
-pub enum DocumentKey {
-    Notebook(Url),
-    NotebookCell(Url),
-    Text(Url),
+pub(crate) enum DocumentKey {
+    Notebook(AnySystemPath),
+    NotebookCell {
+        cell_url: Url,
+        notebook_path: AnySystemPath,
+    },
+    Text(AnySystemPath),
 }
 
 impl DocumentKey {
-    /// Returns the URL associated with the key.
-    pub(crate) fn url(&self) -> &Url {
+    /// Returns the file path associated with the key.
+    pub(crate) fn path(&self) -> &AnySystemPath {
         match self {
-            DocumentKey::NotebookCell(url)
-            | DocumentKey::Notebook(url)
-            | DocumentKey::Text(url) => url,
+            DocumentKey::Notebook(path) | DocumentKey::Text(path) => path,
+            DocumentKey::NotebookCell { notebook_path, .. } => notebook_path,
+        }
+    }
+
+    /// Returns the URL for this document key. For notebook cells, returns the cell URL.
+    /// For other document types, converts the path to a URL.
+    pub(crate) fn to_url(&self) -> Option<Url> {
+        match self {
+            DocumentKey::NotebookCell { cell_url, .. } => Some(cell_url.clone()),
+            DocumentKey::Notebook(path) | DocumentKey::Text(path) => path.to_url(),
         }
     }
 }
@@ -60,7 +73,11 @@ impl DocumentKey {
 impl std::fmt::Display for DocumentKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::NotebookCell(url) | Self::Notebook(url) | Self::Text(url) => url.fmt(f),
+            Self::NotebookCell { cell_url, .. } => cell_url.fmt(f),
+            Self::Notebook(path) | Self::Text(path) => match path {
+                AnySystemPath::System(system_path) => system_path.fmt(f),
+                AnySystemPath::SystemVirtual(virtual_path) => virtual_path.fmt(f),
+            },
         }
     }
 }

--- a/crates/ty_server/src/lib.rs
+++ b/crates/ty_server/src/lib.rs
@@ -1,6 +1,6 @@
 use crate::server::{ConnectionInitializer, Server};
 use anyhow::Context;
-pub use document::{DocumentKey, NotebookDocument, PositionEncoding, TextDocument};
+pub use document::{NotebookDocument, PositionEncoding, TextDocument};
 pub use session::{ClientSettings, DocumentQuery, DocumentSnapshot, Session};
 use std::num::NonZeroUsize;
 

--- a/crates/ty_server/src/server/api.rs
+++ b/crates/ty_server/src/server/api.rs
@@ -1,6 +1,6 @@
 use crate::server::schedule::Task;
 use crate::session::Session;
-use crate::system::{AnySystemPath, url_to_any_system_path};
+use crate::system::AnySystemPath;
 use anyhow::anyhow;
 use lsp_server as server;
 use lsp_server::RequestId;
@@ -154,7 +154,7 @@ where
 
         let url = R::document_url(&params).into_owned();
 
-        let Ok(path) = url_to_any_system_path(&url) else {
+        let Ok(path) = AnySystemPath::try_from_url(&url) else {
             tracing::warn!("Ignoring request for invalid `{url}`");
             return Box::new(|_| {});
         };

--- a/crates/ty_server/src/server/api/notifications/did_change_watched_files.rs
+++ b/crates/ty_server/src/server/api/notifications/did_change_watched_files.rs
@@ -4,7 +4,7 @@ use crate::server::api::diagnostics::publish_diagnostics;
 use crate::server::api::traits::{NotificationHandler, SyncNotificationHandler};
 use crate::session::Session;
 use crate::session::client::Client;
-use crate::system::{AnySystemPath, url_to_any_system_path};
+use crate::system::AnySystemPath;
 use lsp_types as types;
 use lsp_types::{FileChangeType, notification as notif};
 use rustc_hash::FxHashMap;
@@ -26,7 +26,7 @@ impl SyncNotificationHandler for DidChangeWatchedFiles {
         let mut events_by_db: FxHashMap<_, Vec<ChangeEvent>> = FxHashMap::default();
 
         for change in params.changes {
-            let path = match url_to_any_system_path(&change.uri) {
+            let path = match AnySystemPath::try_from_url(&change.uri) {
                 Ok(path) => path,
                 Err(err) => {
                     tracing::warn!(
@@ -111,8 +111,8 @@ impl SyncNotificationHandler for DidChangeWatchedFiles {
                     )
                     .with_failure_code(lsp_server::ErrorCode::InternalError)?;
             } else {
-                for url in session.text_document_urls() {
-                    publish_diagnostics(session, url.clone(), client)?;
+                for key in session.text_document_keys() {
+                    publish_diagnostics(session, &key, client)?;
                 }
             }
 

--- a/crates/ty_server/src/server/api/notifications/did_open_notebook.rs
+++ b/crates/ty_server/src/server/api/notifications/did_open_notebook.rs
@@ -11,7 +11,7 @@ use crate::server::api::LSPResult;
 use crate::server::api::traits::{NotificationHandler, SyncNotificationHandler};
 use crate::session::Session;
 use crate::session::client::Client;
-use crate::system::{AnySystemPath, url_to_any_system_path};
+use crate::system::AnySystemPath;
 
 pub(crate) struct DidOpenNotebookHandler;
 
@@ -25,7 +25,7 @@ impl SyncNotificationHandler for DidOpenNotebookHandler {
         _client: &Client,
         params: DidOpenNotebookDocumentParams,
     ) -> Result<()> {
-        let Ok(path) = url_to_any_system_path(&params.notebook_document.uri) else {
+        let Ok(path) = AnySystemPath::try_from_url(&params.notebook_document.uri) else {
             return Ok(());
         };
 
@@ -36,15 +36,15 @@ impl SyncNotificationHandler for DidOpenNotebookHandler {
             params.cell_text_documents,
         )
         .with_failure_code(ErrorCode::InternalError)?;
-        session.open_notebook_document(params.notebook_document.uri, notebook);
+        session.open_notebook_document(&path, notebook);
 
-        match path {
-            AnySystemPath::System(path) => {
-                let db = match session.project_db_for_path_mut(path.as_std_path()) {
+        match &path {
+            AnySystemPath::System(system_path) => {
+                let db = match session.project_db_for_path_mut(system_path.as_std_path()) {
                     Some(db) => db,
                     None => session.default_project_db_mut(),
                 };
-                db.apply_changes(vec![ChangeEvent::Opened(path)], None);
+                db.apply_changes(vec![ChangeEvent::Opened(system_path.clone())], None);
             }
             AnySystemPath::SystemVirtual(virtual_path) => {
                 let db = session.default_project_db_mut();

--- a/crates/ty_server/src/session.rs
+++ b/crates/ty_server/src/session.rs
@@ -19,7 +19,7 @@ pub use self::settings::ClientSettings;
 pub(crate) use self::settings::Experimental;
 use crate::document::{DocumentKey, DocumentVersion, NotebookDocument};
 use crate::session::request_queue::RequestQueue;
-use crate::system::{AnySystemPath, LSPSystem, url_to_any_system_path};
+use crate::system::{AnySystemPath, LSPSystem};
 use crate::{PositionEncoding, TextDocument};
 
 mod capabilities;
@@ -158,13 +158,13 @@ impl Session {
             .unwrap()
     }
 
-    pub fn key_from_url(&self, url: Url) -> DocumentKey {
+    pub(crate) fn key_from_url(&self, url: Url) -> crate::Result<DocumentKey> {
         self.index().key_from_url(url)
     }
 
     /// Creates a document snapshot with the URL referencing the document to snapshot.
     pub fn take_snapshot(&self, url: Url) -> Option<DocumentSnapshot> {
-        let key = self.key_from_url(url);
+        let key = self.key_from_url(url).ok()?;
         Some(DocumentSnapshot {
             resolved_client_capabilities: self.resolved_client_capabilities.clone(),
             document_ref: self.index().make_document_ref(key)?,
@@ -173,20 +173,33 @@ impl Session {
     }
 
     /// Iterates over the LSP URLs for all open text documents. These URLs are valid file paths.
-    pub(super) fn text_document_urls(&self) -> impl Iterator<Item = &Url> + '_ {
-        self.index().text_document_urls()
+    pub(super) fn text_document_urls(&self) -> impl Iterator<Item = Url> + '_ {
+        self.index()
+            .text_document_paths()
+            .filter_map(|path| path.to_url())
     }
 
-    /// Registers a notebook document at the provided `url`.
-    /// If a document is already open here, it will be overwritten.
-    pub fn open_notebook_document(&mut self, url: Url, document: NotebookDocument) {
-        self.index_mut().open_notebook_document(url, document);
+    /// Iterates over the document keys for all open text documents.
+    pub(super) fn text_document_keys(&self) -> impl Iterator<Item = DocumentKey> + '_ {
+        self.index()
+            .text_document_paths()
+            .map(|path| DocumentKey::Text(path.clone()))
     }
 
-    /// Registers a text document at the provided `url`.
+    /// Registers a notebook document at the provided `path`.
     /// If a document is already open here, it will be overwritten.
-    pub(crate) fn open_text_document(&mut self, url: Url, document: TextDocument) {
-        self.index_mut().open_text_document(url, document);
+    pub(crate) fn open_notebook_document(
+        &mut self,
+        path: &AnySystemPath,
+        document: NotebookDocument,
+    ) {
+        self.index_mut().open_notebook_document(path, document);
+    }
+
+    /// Registers a text document at the provided `path`.
+    /// If a document is already open here, it will be overwritten.
+    pub(crate) fn open_text_document(&mut self, path: &AnySystemPath, document: TextDocument) {
+        self.index_mut().open_text_document(path, document);
     }
 
     /// Updates a text document at the associated `key`.
@@ -314,7 +327,7 @@ impl DocumentSnapshot {
     }
 
     pub(crate) fn file(&self, db: &dyn Db) -> Option<File> {
-        match url_to_any_system_path(self.document_ref.file_url()).ok()? {
+        match AnySystemPath::try_from_url(self.document_ref.file_url()).ok()? {
             AnySystemPath::System(path) => system_path_to_file(db, path).ok(),
             AnySystemPath::SystemVirtual(virtual_path) => db
                 .files()

--- a/crates/ty_server/src/session/index.rs
+++ b/crates/ty_server/src/session/index.rs
@@ -1,4 +1,3 @@
-use std::path::Path;
 use std::sync::Arc;
 
 use lsp_types::Url;
@@ -7,6 +6,7 @@ use rustc_hash::FxHashMap;
 use crate::{
     PositionEncoding, TextDocument,
     document::{DocumentKey, DocumentVersion, NotebookDocument},
+    system::AnySystemPath,
 };
 
 use super::ClientSettings;
@@ -14,11 +14,11 @@ use super::ClientSettings;
 /// Stores and tracks all open documents in a session, along with their associated settings.
 #[derive(Default, Debug)]
 pub(crate) struct Index {
-    /// Maps all document file URLs to the associated document controller
-    documents: FxHashMap<Url, DocumentController>,
+    /// Maps all document file paths to the associated document controller
+    documents: FxHashMap<AnySystemPath, DocumentController>,
 
-    /// Maps opaque cell URLs to a notebook URL (document)
-    notebook_cells: FxHashMap<Url, Url>,
+    /// Maps opaque cell URLs to a notebook path (document)
+    notebook_cells: FxHashMap<Url, AnySystemPath>,
 
     /// Global settings provided by the client.
     #[expect(dead_code)]
@@ -34,18 +34,18 @@ impl Index {
         }
     }
 
-    pub(super) fn text_document_urls(&self) -> impl Iterator<Item = &Url> + '_ {
+    pub(super) fn text_document_paths(&self) -> impl Iterator<Item = &AnySystemPath> + '_ {
         self.documents
             .iter()
-            .filter_map(|(url, doc)| doc.as_text().and(Some(url)))
+            .filter_map(|(path, doc)| doc.as_text().and(Some(path)))
     }
 
     #[expect(dead_code)]
-    pub(super) fn notebook_document_urls(&self) -> impl Iterator<Item = &Url> + '_ {
+    pub(super) fn notebook_document_paths(&self) -> impl Iterator<Item = &AnySystemPath> + '_ {
         self.documents
             .iter()
             .filter(|(_, doc)| doc.as_notebook().is_some())
-            .map(|(url, _)| url)
+            .map(|(path, _)| path)
     }
 
     pub(super) fn update_text_document(
@@ -57,7 +57,7 @@ impl Index {
     ) -> crate::Result<()> {
         let controller = self.document_controller_for_key(key)?;
         let Some(document) = controller.as_text_mut() else {
-            anyhow::bail!("Text document URI does not point to a text document");
+            anyhow::bail!("Text document path does not point to a text document");
         };
 
         if content_changes.is_empty() {
@@ -70,16 +70,24 @@ impl Index {
         Ok(())
     }
 
-    pub(crate) fn key_from_url(&self, url: Url) -> DocumentKey {
-        if self.notebook_cells.contains_key(&url) {
-            DocumentKey::NotebookCell(url)
-        } else if Path::new(url.path())
-            .extension()
-            .is_some_and(|ext| ext.eq_ignore_ascii_case("ipynb"))
-        {
-            DocumentKey::Notebook(url)
+    pub(crate) fn key_from_url(&self, url: Url) -> crate::Result<DocumentKey> {
+        if let Some(notebook_path) = self.notebook_cells.get(&url) {
+            Ok(DocumentKey::NotebookCell {
+                cell_url: url,
+                notebook_path: notebook_path.clone(),
+            })
         } else {
-            DocumentKey::Text(url)
+            let path = AnySystemPath::try_from_url(&url)
+                .map_err(|_| anyhow::anyhow!("Failed to convert URL to system path: {}", url))?;
+
+            if path
+                .extension()
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("ipynb"))
+            {
+                Ok(DocumentKey::Notebook(path))
+            } else {
+                Ok(DocumentKey::Text(path))
+            }
         }
     }
 
@@ -98,20 +106,18 @@ impl Index {
             ..
         }) = cells.as_ref().and_then(|cells| cells.structure.as_ref())
         {
-            let Some(path) = self.url_for_key(key).cloned() else {
-                anyhow::bail!("Tried to open unavailable document `{key}`");
-            };
+            let notebook_path = key.path().clone();
 
             for opened_cell in did_open {
                 self.notebook_cells
-                    .insert(opened_cell.uri.clone(), path.clone());
+                    .insert(opened_cell.uri.clone(), notebook_path.clone());
             }
             // deleted notebook cells are closed via textDocument/didClose - we don't close them here.
         }
 
         let controller = self.document_controller_for_key(key)?;
         let Some(notebook) = controller.as_notebook_mut() else {
-            anyhow::bail!("Notebook document URI does not point to a notebook document");
+            anyhow::bail!("Notebook document path does not point to a notebook document");
         };
 
         notebook.update(cells, metadata, new_version, encoding)?;
@@ -119,27 +125,36 @@ impl Index {
     }
 
     pub(crate) fn make_document_ref(&self, key: DocumentKey) -> Option<DocumentQuery> {
-        let url = self.url_for_key(&key)?.clone();
-        let controller = self.documents.get(&url)?;
-        let cell_url = match key {
-            DocumentKey::NotebookCell(cell_url) => Some(cell_url),
-            _ => None,
+        let path = key.path();
+        let controller = self.documents.get(path)?;
+        let (cell_url, file_url) = match &key {
+            DocumentKey::NotebookCell {
+                cell_url,
+                notebook_path,
+            } => (Some(cell_url.clone()), notebook_path.to_url()?),
+            DocumentKey::Notebook(path) | DocumentKey::Text(path) => (None, path.to_url()?),
         };
-        Some(controller.make_ref(cell_url, url))
+        Some(controller.make_ref(cell_url, file_url))
     }
 
-    pub(super) fn open_text_document(&mut self, url: Url, document: TextDocument) {
+    pub(super) fn open_text_document(&mut self, path: &AnySystemPath, document: TextDocument) {
         self.documents
-            .insert(url, DocumentController::new_text(document));
+            .insert(path.clone(), DocumentController::new_text(document));
     }
 
-    pub(super) fn open_notebook_document(&mut self, notebook_url: Url, document: NotebookDocument) {
+    pub(super) fn open_notebook_document(
+        &mut self,
+        notebook_path: &AnySystemPath,
+        document: NotebookDocument,
+    ) {
         for cell_url in document.cell_urls() {
             self.notebook_cells
-                .insert(cell_url.clone(), notebook_url.clone());
+                .insert(cell_url.clone(), notebook_path.clone());
         }
-        self.documents
-            .insert(notebook_url, DocumentController::new_notebook(document));
+        self.documents.insert(
+            notebook_path.clone(),
+            DocumentController::new_notebook(document),
+        );
     }
 
     pub(super) fn close_document(&mut self, key: &DocumentKey) -> crate::Result<()> {
@@ -148,18 +163,16 @@ impl Index {
         // is requested to be `closed` by VS Code after the notebook gets updated.
         // This is not documented in the LSP specification explicitly, and this assumption
         // may need revisiting in the future as we support more editors with notebook support.
-        if let DocumentKey::NotebookCell(uri) = key {
-            if self.notebook_cells.remove(uri).is_none() {
-                tracing::warn!("Tried to remove a notebook cell that does not exist: {uri}",);
+        if let DocumentKey::NotebookCell { cell_url, .. } = key {
+            if self.notebook_cells.remove(cell_url).is_none() {
+                tracing::warn!("Tried to remove a notebook cell that does not exist: {cell_url}",);
             }
             return Ok(());
         }
-        let Some(url) = self.url_for_key(key).cloned() else {
-            anyhow::bail!("Tried to close unavailable document `{key}`");
-        };
+        let path = key.path();
 
-        let Some(_) = self.documents.remove(&url) else {
-            anyhow::bail!("tried to close document that didn't exist at {}", url)
+        let Some(_) = self.documents.remove(path) else {
+            anyhow::bail!("tried to close document that didn't exist at {}", key)
         };
         Ok(())
     }
@@ -168,20 +181,11 @@ impl Index {
         &mut self,
         key: &DocumentKey,
     ) -> crate::Result<&mut DocumentController> {
-        let Some(url) = self.url_for_key(key).cloned() else {
-            anyhow::bail!("Tried to open unavailable document `{key}`");
-        };
-        let Some(controller) = self.documents.get_mut(&url) else {
-            anyhow::bail!("Document controller not available at `{}`", url);
+        let path = key.path();
+        let Some(controller) = self.documents.get_mut(path) else {
+            anyhow::bail!("Document controller not available at `{}`", key);
         };
         Ok(controller)
-    }
-
-    fn url_for_key<'a>(&'a self, key: &'a DocumentKey) -> Option<&'a Url> {
-        match key {
-            DocumentKey::Notebook(path) | DocumentKey::Text(path) => Some(path),
-            DocumentKey::NotebookCell(uri) => self.notebook_cells.get(uri),
-        }
     }
 }
 
@@ -263,19 +267,6 @@ pub enum DocumentQuery {
 }
 
 impl DocumentQuery {
-    /// Retrieve the original key that describes this document query.
-    #[expect(dead_code)]
-    pub(crate) fn make_key(&self) -> DocumentKey {
-        match self {
-            Self::Text { file_url, .. } => DocumentKey::Text(file_url.clone()),
-            Self::Notebook {
-                cell_url: Some(cell_uri),
-                ..
-            } => DocumentKey::NotebookCell(cell_uri.clone()),
-            Self::Notebook { file_url, .. } => DocumentKey::Notebook(file_url.clone()),
-        }
-    }
-
     /// Attempts to access the underlying notebook document that this query is selecting.
     pub fn as_notebook(&self) -> Option<&NotebookDocument> {
         match self {

--- a/crates/ty_server/src/system.rs
+++ b/crates/ty_server/src/system.rs
@@ -14,27 +14,8 @@ use ruff_notebook::{Notebook, NotebookError};
 use ty_python_semantic::Db;
 
 use crate::DocumentQuery;
+use crate::document::DocumentKey;
 use crate::session::index::Index;
-
-/// Converts the given [`Url`] to an [`AnySystemPath`].
-///
-/// If the URL scheme is `file`, then the path is converted to a [`SystemPathBuf`]. Otherwise, the
-/// URL is converted to a [`SystemVirtualPathBuf`].
-///
-/// This fails in the following cases:
-/// * The URL cannot be converted to a file path (refer to [`Url::to_file_path`]).
-/// * If the URL is not a valid UTF-8 string.
-pub(crate) fn url_to_any_system_path(url: &Url) -> std::result::Result<AnySystemPath, ()> {
-    if url.scheme() == "file" {
-        Ok(AnySystemPath::System(
-            SystemPathBuf::from_path_buf(url.to_file_path()?).map_err(|_| ())?,
-        ))
-    } else {
-        Ok(AnySystemPath::SystemVirtual(
-            SystemVirtualPath::new(url.as_str()).to_path_buf(),
-        ))
-    }
-}
 
 pub(crate) fn file_to_url(db: &dyn Db, file: File) -> Option<Url> {
     match file.path(db) {
@@ -47,17 +28,55 @@ pub(crate) fn file_to_url(db: &dyn Db, file: File) -> Option<Url> {
 }
 
 /// Represents either a [`SystemPath`] or a [`SystemVirtualPath`].
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub(crate) enum AnySystemPath {
     System(SystemPathBuf),
     SystemVirtual(SystemVirtualPathBuf),
 }
 
 impl AnySystemPath {
+    /// Converts the given [`Url`] to an [`AnySystemPath`].
+    ///
+    /// If the URL scheme is `file`, then the path is converted to a [`SystemPathBuf`]. Otherwise, the
+    /// URL is converted to a [`SystemVirtualPathBuf`].
+    ///
+    /// This fails in the following cases:
+    /// * The URL cannot be converted to a file path (refer to [`Url::to_file_path`]).
+    /// * If the URL is not a valid UTF-8 string.
+    pub(crate) fn try_from_url(url: &Url) -> std::result::Result<Self, ()> {
+        if url.scheme() == "file" {
+            Ok(AnySystemPath::System(
+                SystemPathBuf::from_path_buf(url.to_file_path()?).map_err(|_| ())?,
+            ))
+        } else {
+            Ok(AnySystemPath::SystemVirtual(
+                SystemVirtualPath::new(url.as_str()).to_path_buf(),
+            ))
+        }
+    }
+
     pub(crate) const fn as_system(&self) -> Option<&SystemPathBuf> {
         match self {
             AnySystemPath::System(system_path_buf) => Some(system_path_buf),
             AnySystemPath::SystemVirtual(_) => None,
+        }
+    }
+
+    /// Returns the extension of the path, if any.
+    pub(crate) fn extension(&self) -> Option<&str> {
+        match self {
+            AnySystemPath::System(system_path) => system_path.extension(),
+            AnySystemPath::SystemVirtual(virtual_path) => virtual_path.extension(),
+        }
+    }
+
+    /// Converts the path to a URL.
+    pub(crate) fn to_url(&self) -> Option<Url> {
+        match self {
+            AnySystemPath::System(system_path) => {
+                Url::from_file_path(system_path.as_std_path()).ok()
+            }
+            AnySystemPath::SystemVirtual(virtual_path) => Url::parse(virtual_path.as_str()).ok(),
         }
     }
 }
@@ -107,33 +126,32 @@ impl LSPSystem {
         self.index.as_ref().unwrap()
     }
 
-    fn make_document_ref(&self, url: Url) -> Option<DocumentQuery> {
+    fn make_document_ref(&self, path: &AnySystemPath) -> Option<DocumentQuery> {
         let index = self.index();
-        let key = index.key_from_url(url);
+        let key = self.path_to_document_key(path)?;
         index.make_document_ref(key)
     }
 
+    fn path_to_document_key(&self, path: &AnySystemPath) -> Option<DocumentKey> {
+        // For text documents, we assume it's a text document unless it's a notebook file.
+        // This logic could be enhanced to check the file extension for notebooks.
+        match path.extension() {
+            Some("ipynb") => Some(DocumentKey::Notebook(path.clone())),
+            _ => Some(DocumentKey::Text(path.clone())),
+        }
+    }
+
     fn system_path_to_document_ref(&self, path: &SystemPath) -> Result<Option<DocumentQuery>> {
-        let url = Url::from_file_path(path.as_std_path()).map_err(|()| {
-            std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                format!("Failed to convert system path to URL: {path:?}"),
-            )
-        })?;
-        Ok(self.make_document_ref(url))
+        let any_path = AnySystemPath::System(path.to_path_buf());
+        Ok(self.make_document_ref(&any_path))
     }
 
     fn system_virtual_path_to_document_ref(
         &self,
         path: &SystemVirtualPath,
     ) -> Result<Option<DocumentQuery>> {
-        let url = Url::parse(path.as_str()).map_err(|_| {
-            std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                format!("Failed to convert virtual path to URL: {path:?}"),
-            )
-        })?;
-        Ok(self.make_document_ref(url))
+        let any_path = AnySystemPath::SystemVirtual(path.to_path_buf());
+        Ok(self.make_document_ref(&any_path))
     }
 }
 


### PR DESCRIPTION
## Summary

This is mostly a refactor which should fix the stale diagnostics on Windows (I've to test this when I'm back home and have access to my windows machine).

The main refactor is that `Index` now stores a map from `AnySystemPath` to the documents instead of `Url`. This removes the need to convert between `Url -> AnySystemPath` and `AnySystemPath -> Url`, which can lead mismatches.


## Test Plan

<!-- How was it tested? -->
