### PR TITLE
[`pygrep_hooks`] add AsyncMock methods to `invalid-mock-access` (`PGH005`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pygrep_hooks/PGH005_0.py
+++ b/crates/ruff_linter/resources/test/fixtures/pygrep_hooks/PGH005_0.py
@@ -17,3 +17,23 @@ my_mock.assert_called()
 my_mock.assert_called_once_with()
 """like :meth:`Mock.assert_called_once_with`"""
 """like :meth:`MagicMock.assert_called_once_with`"""
+
+# Errors
+assert my_mock.not_awaited()
+assert my_mock.awaited_once_with()
+assert my_mock.not_awaited
+assert my_mock.awaited_once_with
+my_mock.assert_not_awaited
+my_mock.assert_awaited
+my_mock.assert_awaited_once_with
+my_mock.assert_awaited_once_with
+MyMock.assert_awaited_once_with
+assert my_mock.awaited
+
+# OK
+assert my_mock.await_count == 1
+my_mock.assert_not_awaited()
+my_mock.assert_awaited()
+my_mock.assert_awaited_once_with()
+"""like :meth:`Mock.assert_awaited_once_with`"""
+"""like :meth:`MagicMock.assert_awaited_once_with`"""

--- a/crates/ruff_linter/src/rules/pygrep_hooks/rules/invalid_mock_access.rs
+++ b/crates/ruff_linter/src/rules/pygrep_hooks/rules/invalid_mock_access.rs
@@ -60,6 +60,13 @@ pub(crate) fn uncalled_mock_method(checker: &Checker, expr: &Expr) {
                 | "assert_called_with"
                 | "assert_has_calls"
                 | "assert_not_called"
+                | "assert_awaited"
+                | "assert_awaited_once"
+                | "assert_awaited_with"
+                | "assert_awaited_once_with"
+                | "assert_any_await"
+                | "assert_has_awaits"
+                | "assert_not_awaited"
         ) {
             checker.report_diagnostic(
                 InvalidMockAccess {
@@ -89,6 +96,13 @@ pub(crate) fn non_existent_mock_method(checker: &Checker, test: &Expr) {
             | "called_with"
             | "has_calls"
             | "not_called"
+            | "awaited"
+            | "awaited_once"
+            | "awaited_with"
+            | "awaited_once_with"
+            | "any_await"
+            | "has_awaits"
+            | "not_awaited"
     ) {
         checker.report_diagnostic(
             InvalidMockAccess {

--- a/crates/ruff_linter/src/rules/pygrep_hooks/snapshots/ruff_linter__rules__pygrep_hooks__tests__PGH005_PGH005_0.py.snap
+++ b/crates/ruff_linter/src/rules/pygrep_hooks/snapshots/ruff_linter__rules__pygrep_hooks__tests__PGH005_PGH005_0.py.snap
@@ -88,3 +88,101 @@ PGH005_0.py:10:1: PGH005 Mock method should be called: `assert_called_once_with`
 11 |
 12 | # OK
    |
+
+PGH005_0.py:22:8: PGH005 Non-existent mock method: `not_awaited`
+   |
+21 | # Errors
+22 | assert my_mock.not_awaited()
+   |        ^^^^^^^^^^^^^^^^^^^^^ PGH005
+23 | assert my_mock.awaited_once_with()
+24 | assert my_mock.not_awaited
+   |
+
+PGH005_0.py:23:8: PGH005 Non-existent mock method: `awaited_once_with`
+   |
+21 | # Errors
+22 | assert my_mock.not_awaited()
+23 | assert my_mock.awaited_once_with()
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ PGH005
+24 | assert my_mock.not_awaited
+25 | assert my_mock.awaited_once_with
+   |
+
+PGH005_0.py:24:8: PGH005 Non-existent mock method: `not_awaited`
+   |
+22 | assert my_mock.not_awaited()
+23 | assert my_mock.awaited_once_with()
+24 | assert my_mock.not_awaited
+   |        ^^^^^^^^^^^^^^^^^^^ PGH005
+25 | assert my_mock.awaited_once_with
+26 | my_mock.assert_not_awaited
+   |
+
+PGH005_0.py:25:8: PGH005 Non-existent mock method: `awaited_once_with`
+   |
+23 | assert my_mock.awaited_once_with()
+24 | assert my_mock.not_awaited
+25 | assert my_mock.awaited_once_with
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^ PGH005
+26 | my_mock.assert_not_awaited
+27 | my_mock.assert_awaited
+   |
+
+PGH005_0.py:26:1: PGH005 Mock method should be called: `assert_not_awaited`
+   |
+24 | assert my_mock.not_awaited
+25 | assert my_mock.awaited_once_with
+26 | my_mock.assert_not_awaited
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ PGH005
+27 | my_mock.assert_awaited
+28 | my_mock.assert_awaited_once_with
+   |
+
+PGH005_0.py:27:1: PGH005 Mock method should be called: `assert_awaited`
+   |
+25 | assert my_mock.awaited_once_with
+26 | my_mock.assert_not_awaited
+27 | my_mock.assert_awaited
+   | ^^^^^^^^^^^^^^^^^^^^^^ PGH005
+28 | my_mock.assert_awaited_once_with
+29 | my_mock.assert_awaited_once_with
+   |
+
+PGH005_0.py:28:1: PGH005 Mock method should be called: `assert_awaited_once_with`
+   |
+26 | my_mock.assert_not_awaited
+27 | my_mock.assert_awaited
+28 | my_mock.assert_awaited_once_with
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PGH005
+29 | my_mock.assert_awaited_once_with
+30 | MyMock.assert_awaited_once_with
+   |
+
+PGH005_0.py:29:1: PGH005 Mock method should be called: `assert_awaited_once_with`
+   |
+27 | my_mock.assert_awaited
+28 | my_mock.assert_awaited_once_with
+29 | my_mock.assert_awaited_once_with
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PGH005
+30 | MyMock.assert_awaited_once_with
+31 | assert my_mock.awaited
+   |
+
+PGH005_0.py:30:1: PGH005 Mock method should be called: `assert_awaited_once_with`
+   |
+28 | my_mock.assert_awaited_once_with
+29 | my_mock.assert_awaited_once_with
+30 | MyMock.assert_awaited_once_with
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PGH005
+31 | assert my_mock.awaited
+   |
+
+PGH005_0.py:31:8: PGH005 Non-existent mock method: `awaited`
+   |
+29 | my_mock.assert_awaited_once_with
+30 | MyMock.assert_awaited_once_with
+31 | assert my_mock.awaited
+   |        ^^^^^^^^^^^^^^^ PGH005
+32 |
+33 | # OK
+   |


### PR DESCRIPTION
## Summary
This PR expands PGH005 to also check for AsyncMock methods in the same vein. E.g., currently `assert mock.not_called` is linted. This PR adds the corresponding async assertions `assert mock.not_awaited()`.
