### PR TITLE
`ruff/__main__.py`: Remove unnecessary `os.fsdecode`

### DIFF
--- a/python/ruff/__main__.py
+++ b/python/ruff/__main__.py
@@ -78,7 +78,7 @@ def find_ruff_bin() -> str:
 
 
 if __name__ == "__main__":
-    ruff = os.fsdecode(find_ruff_bin())
+    ruff = find_ruff_bin()
     if sys.platform == "win32":
         import subprocess
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

This is really minor, but `find_ruff_bin()` returns `str`, so calling `os.fsdecode` is a no-op. This was missed when `find_ruff_bin()` was refactored to no longer return `Path`.

## Test Plan

N/A