### PR TITLE
Stabilize `generic-not-last-base-class` (`PYI059`)

### DIFF
--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -809,7 +809,7 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         (Flake8Pyi, "056") => (RuleGroup::Stable, rules::flake8_pyi::rules::UnsupportedMethodCallOnAll),
         (Flake8Pyi, "058") => (RuleGroup::Stable, rules::flake8_pyi::rules::GeneratorReturnFromIterMethod),
         (Flake8Pyi, "057") => (RuleGroup::Stable, rules::flake8_pyi::rules::ByteStringUsage),
-        (Flake8Pyi, "059") => (RuleGroup::Preview, rules::flake8_pyi::rules::GenericNotLastBaseClass),
+        (Flake8Pyi, "059") => (RuleGroup::Stable, rules::flake8_pyi::rules::GenericNotLastBaseClass),
         (Flake8Pyi, "061") => (RuleGroup::Preview, rules::flake8_pyi::rules::RedundantNoneLiteral),
         (Flake8Pyi, "062") => (RuleGroup::Stable, rules::flake8_pyi::rules::DuplicateLiteralMember),
         (Flake8Pyi, "063") => (RuleGroup::Stable, rules::flake8_pyi::rules::Pep484StylePositionalOnlyParameter),

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/generic_not_last_base_class.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/generic_not_last_base_class.rs
@@ -13,8 +13,8 @@ use crate::{Fix, FixAvailability, Violation};
 /// ## Why is this bad?
 /// If `Generic[]` is not the final class in the bases tuple, unexpected
 /// behaviour can occur at runtime (See [this CPython issue][1] for an example).
-/// The rule is also applied to stub files, but, unlike at runtime,
-/// in stubs it is purely enforced for stylistic consistency.
+/// The rule is also applied to stub files, where it won't cause issues at runtime,
+/// because type checkers may also behave unpredictably in this case.
 ///
 /// For example:
 /// ```python


### PR DESCRIPTION
Summary
--

The tests were already in the right place, I just updated the documentation slightly to reflect the discussion [here](https://github.com/astral-sh/ruff/pull/18519#issuecomment-2956344254) and on Discord.

Documentation: https://docs.astral.sh/ruff/rules/generic-not-last-base-class

Tests: https://github.com/astral-sh/ruff/blob/brent/release-0.12.0/crates/ruff_linter/src/rules/flake8_pyi/mod.rs#L51-L52

I considered mentioning the MRO explicitly and linking to [this](https://docs.python.org/3/howto/mro.html) but decided that might be a bit too technical for the rule docs.

Now I see that ty links to the [glossary](https://docs.python.org/3/glossary.html#term-method-resolution-order), which would be another option.

Test Plan
--

Existing tests
