### PR TITLE
support comments like `# test # noqa: RUF100` in `is_pragma_comment` 

### DIFF
--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E501_E501_5.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E501_E501_5.py.snap
@@ -1,6 +1,15 @@
 ---
 source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
 ---
+E501_5.py:5:89: E501 Line too long (96 > 88)
+  |
+4 | # OK (88 characters) - Multiple comments with pragma
+5 | "shape:" + "shape:" + "shape:" + "shape:" + "shape:" + "shape:" + "shape:" + "shape:aaa"  # test # type: ignore
+  |                                                                                         ^^^^^^^^ E501
+6 |
+7 | # OK (88 characters) - Multiple comments with different pragma
+  |
+
 E501_5.py:10:89: E501 Line too long (91 > 88)
    |
  8 | "shape:" + "shape:" + "shape:" + "shape:" + "shape:" + "shape:" + "shape:" + "shape:aaa"  # see issue # noqa: E501

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_0.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_0.snap
@@ -238,26 +238,6 @@ RUF100_0.py:74:6: RUF100 [*] Unused blanket `noqa` directive
 76 76 | # Valid
 77 77 | # this is a veryyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy long comment  # noqa: E501
 
-RUF100_0.py:77:120: RUF100 [*] Unused `noqa` directive (unused: `E501`)
-   |
-76 | # Valid
-77 | # this is a veryyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy long comment  # noqa: E501
-   |                                                                                                                        ^^^^^^^^^^^^ RUF100
-78 |
-79 | # Valid
-   |
-   = help: Remove unused `noqa` directive
-
-ℹ Safe fix
-74 74 | """  # noqa
-75 75 | 
-76 76 | # Valid
-77    |-# this is a veryyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy long comment  # noqa: E501
-   77 |+# this is a veryyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy long comment
-78 78 | 
-79 79 | # Valid
-80 80 | _ = """Here's a source: https://github.com/ethereum/web3.py/blob/ffe59daf10edc19ee5f05227b25bac8d090e8aa4/web3/_utils/events.py#L201
-
 RUF100_0.py:88:8: F401 [*] `shelve` imported but unused
    |
 86 | import collections  # noqa

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_0_prefix.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_0_prefix.snap
@@ -218,26 +218,6 @@ RUF100_0.py:74:6: RUF100 [*] Unused blanket `noqa` directive
 76 76 | # Valid
 77 77 | # this is a veryyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy long comment  # noqa: E501
 
-RUF100_0.py:77:120: RUF100 [*] Unused `noqa` directive (unused: `E501`)
-   |
-76 | # Valid
-77 | # this is a veryyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy long comment  # noqa: E501
-   |                                                                                                                        ^^^^^^^^^^^^ RUF100
-78 |
-79 | # Valid
-   |
-   = help: Remove unused `noqa` directive
-
-ℹ Safe fix
-74 74 | """  # noqa
-75 75 | 
-76 76 | # Valid
-77    |-# this is a veryyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy long comment  # noqa: E501
-   77 |+# this is a veryyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy long comment
-78 78 | 
-79 79 | # Valid
-80 80 | _ = """Here's a source: https://github.com/ethereum/web3.py/blob/ffe59daf10edc19ee5f05227b25bac8d090e8aa4/web3/_utils/events.py#L201
-
 RUF100_0.py:88:8: F401 [*] `shelve` imported but unused
    |
 86 | import collections  # noqa

--- a/crates/ruff_python_formatter/src/comments/format.rs
+++ b/crates/ruff_python_formatter/src/comments/format.rs
@@ -377,7 +377,7 @@ impl Format<PyFormatContext<'_>> for FormatTrailingEndOfLineComment<'_> {
         let normalized_comment = normalize_comment(self.comment, source)?;
 
         // Don't reserve width for excluded pragma comments.
-        let reserved_width = if is_pragma_comment(&normalized_comment) {
+        let reserved_width = if is_pragma_comment(&normalized_comment).0 {
             0
         } else {
             // Start with 2 because of the two leading spaces.

--- a/crates/ruff_python_trivia/src/pragmas.rs
+++ b/crates/ruff_python_trivia/src/pragmas.rs
@@ -1,30 +1,89 @@
-/// Returns `true` if a comment appears to be a pragma comment.
+/// Returns a tuple containing:
+/// 1. A boolean indicating if a comment appears to be a pragma comment
+/// 2. The position in the comment where the pragma begins (0 if the entire comment is a pragma)
 ///
 /// ```
-/// assert!(ruff_python_trivia::is_pragma_comment("# type: ignore"));
-/// assert!(ruff_python_trivia::is_pragma_comment("# noqa: F401"));
-/// assert!(ruff_python_trivia::is_pragma_comment("# noqa"));
-/// assert!(ruff_python_trivia::is_pragma_comment("# NoQA"));
-/// assert!(ruff_python_trivia::is_pragma_comment("# nosec"));
-/// assert!(ruff_python_trivia::is_pragma_comment("# nosec B602, B607"));
-/// assert!(ruff_python_trivia::is_pragma_comment("# isort: off"));
-/// assert!(ruff_python_trivia::is_pragma_comment("# isort: skip"));
+/// assert_eq!(ruff_python_trivia::is_pragma_comment("# type: ignore"), (true, 0));
+/// assert_eq!(ruff_python_trivia::is_pragma_comment("# noqa: F401"), (true, 0));
+/// assert_eq!(ruff_python_trivia::is_pragma_comment("# noqa"), (true, 0));
+/// assert_eq!(ruff_python_trivia::is_pragma_comment("# NoQA"), (true, 0));
+/// assert_eq!(ruff_python_trivia::is_pragma_comment("# nosec"), (true, 0));
+/// assert_eq!(ruff_python_trivia::is_pragma_comment("# nosec B602, B607"), (true, 0));
+/// assert_eq!(ruff_python_trivia::is_pragma_comment("# isort: off"), (true, 0));
+/// assert_eq!(ruff_python_trivia::is_pragma_comment("# isort: skip"), (true, 0));
+/// assert_eq!(ruff_python_trivia::is_pragma_comment("# test # noqa"), (true, 6));
+/// assert_eq!(ruff_python_trivia::is_pragma_comment("# not a pragma"), (false, 0));
 /// ```
-pub fn is_pragma_comment(comment: &str) -> bool {
+pub fn is_pragma_comment(comment: &str) -> (bool, usize) {
+    // Check if the entire comment is a pragma
+    if let Some(content) = comment.strip_prefix('#') {
+        let trimmed = content.trim_start();
+
+        let is_pragma = 
+            // Case-insensitive match against `noqa` (which doesn't require a trailing colon).
+            matches!(
+                trimmed.as_bytes(),
+                [b'n' | b'N', b'o' | b'O', b'q' | b'Q', b'a' | b'A', ..]
+            ) ||
+                // Case-insensitive match against pragmas that don't require a trailing colon.
+                trimmed.starts_with("nosec") ||
+                // Case-sensitive match against a variety of pragmas that _do_ require a trailing colon.
+                trimmed
+                .split_once(':')
+                .is_some_and(|(maybe_pragma, _)| matches!(maybe_pragma, "isort" | "type" | "pyright" | "pylint" | "flake8" | "ruff" | "ty"));
+        
+        if is_pragma {
+            return (true, 0);
+        }
+    } else {
+        return (false, 0);
+    }
+    
+    // If the entire comment isn't a pragma, check for nested pragma comments
+    let content = comment.strip_prefix('#').unwrap_or(comment);
+    
+    let mut position = 0;
+    for (i, part) in content.split('#').enumerate() {
+        if i == 0 {
+            position += part.len();
+            continue;
+        }
+        
+        let hash_position = position; // Position of the '#' character
+        
+        // Check if this part forms a pragma comment by itself
+        let potential_pragma = format!("#{}", part.trim());
+        let (is_pragma, _) = is_pragma_comment_internal(&potential_pragma);
+        
+        if is_pragma {
+            return (true, hash_position);
+        }
+        
+        position += 1 + part.len(); // +1 for the '#'
+    }
+    
+    (false, 0)
+}
+
+/// Internal helper that uses the original boolean logic without recursion
+fn is_pragma_comment_internal(comment: &str) -> (bool, usize) {
     let Some(content) = comment.strip_prefix('#') else {
-        return false;
+        return (false, 0);
     };
     let trimmed = content.trim_start();
 
-    // Case-insensitive match against `noqa` (which doesn't require a trailing colon).
-    matches!(
-        trimmed.as_bytes(),
-        [b'n' | b'N', b'o' | b'O', b'q' | b'Q', b'a' | b'A', ..]
-    ) ||
-        // Case-insensitive match against pragmas that don't require a trailing colon.
-        trimmed.starts_with("nosec") ||
-        // Case-sensitive match against a variety of pragmas that _do_ require a trailing colon.
-        trimmed
-        .split_once(':')
-        .is_some_and(|(maybe_pragma, _)| matches!(maybe_pragma, "isort" | "type" | "pyright" | "pylint" | "flake8" | "ruff" | "ty"))
+    let is_pragma = 
+        // Case-insensitive match against `noqa` (which doesn't require a trailing colon).
+        matches!(
+            trimmed.as_bytes(),
+            [b'n' | b'N', b'o' | b'O', b'q' | b'Q', b'a' | b'A', ..]
+        ) ||
+            // Case-insensitive match against pragmas that don't require a trailing colon.
+            trimmed.starts_with("nosec") ||
+            // Case-sensitive match against a variety of pragmas that _do_ require a trailing colon.
+            trimmed
+            .split_once(':')
+            .is_some_and(|(maybe_pragma, _)| matches!(maybe_pragma, "isort" | "type" | "pyright" | "pylint" | "flake8" | "ruff" | "ty"));
+    
+    (is_pragma, 0)
 }


### PR DESCRIPTION
## Summary
the [`is_pragma_comment`](https://github.com/astral-sh/ruff/blob/ff6f0b6ab8fef4df5a14651cf9ef86f016ec0367/crates/ruff_python_trivia/src/pragmas.rs#L13-L30)

## Test Plan
manually tested with `cargo test`
closes #18470 