### PR TITLE
[`flake8-pyi`] Avoid syntax error in the case of starred and keyword arguments (`PYI059`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI059.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI059.py
@@ -52,3 +52,15 @@ class MyList(Sized, Generic[T]):  # Generic already in last place
 
 class SomeGeneric(Generic[T]):  # Only one generic
     pass
+
+
+# syntax errors with starred and keyword arguments from
+# https://github.com/astral-sh/ruff/issues/18602
+class C1(Generic[T], str, **{"metaclass": type}):  # PYI059
+    ...
+
+class C2(Generic[T], str, metaclass=type):  # PYI059
+    ...
+
+class C3(Generic[T], metaclass=type, *[str]):  # PYI059 but no fix
+    ...

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/generic_not_last_base_class.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/generic_not_last_base_class.rs
@@ -105,13 +105,10 @@ pub(crate) fn generic_not_last_base_class(checker: &Checker, class_def: &ast::St
     //
     // where we would naively try to put `Generic[T]` after `*[str]`, which is also after a keyword
     // argument, causing the error.
-    //
-    // This also filters out keyword unpacking like `**{"metaclass": type}`, identified by a keyword
-    // with no name.
-    if bases.arguments_source_order().any(|arg| {
-        arg.value().is_starred_expr()
-            || matches!(arg, ArgOrKeyword::Keyword(ast::Keyword { arg: None, .. }))
-    }) {
+    if bases
+        .arguments_source_order()
+        .any(|arg| arg.value().is_starred_expr())
+    {
         return;
     }
 

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/generic_not_last_base_class.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/generic_not_last_base_class.rs
@@ -45,6 +45,11 @@ use crate::{Fix, FixAvailability, Violation};
 /// ):
 ///     ...
 /// ```
+///
+/// ## Fix availability
+///
+/// This rule's fix is only available when there are no `*args` present in the base class list.
+///
 /// ## References
 /// - [`typing.Generic` documentation](https://docs.python.org/3/library/typing.html#typing.Generic)
 ///

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI059_PYI059.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI059_PYI059.py.snap
@@ -111,3 +111,43 @@ PYI059.py:45:8: PYI059 `Generic[]` should always be the last base class
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI059
    |
    = help: Move `Generic[]` to the end
+
+PYI059.py:59:9: PYI059 `Generic[]` should always be the last base class
+   |
+57 | # syntax errors with starred and keyword arguments from
+58 | # https://github.com/astral-sh/ruff/issues/18602
+59 | class C1(Generic[T], str, **{"metaclass": type}):  # PYI059
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI059
+60 |     ...
+   |
+   = help: Move `Generic[]` to the end
+
+PYI059.py:62:9: PYI059 [*] `Generic[]` should always be the last base class
+   |
+60 |     ...
+61 |
+62 | class C2(Generic[T], str, metaclass=type):  # PYI059
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI059
+63 |     ...
+   |
+   = help: Move `Generic[]` to the end
+
+ℹ Safe fix
+59 59 | class C1(Generic[T], str, **{"metaclass": type}):  # PYI059
+60 60 |     ...
+61 61 | 
+62    |-class C2(Generic[T], str, metaclass=type):  # PYI059
+   62 |+class C2(str, Generic[T], metaclass=type):  # PYI059
+63 63 |     ...
+64 64 | 
+65 65 | class C3(Generic[T], metaclass=type, *[str]):  # PYI059 but no fix
+
+PYI059.py:65:9: PYI059 `Generic[]` should always be the last base class
+   |
+63 |     ...
+64 |
+65 | class C3(Generic[T], metaclass=type, *[str]):  # PYI059 but no fix
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI059
+66 |     ...
+   |
+   = help: Move `Generic[]` to the end

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI059_PYI059.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI059_PYI059.py.snap
@@ -112,7 +112,7 @@ PYI059.py:45:8: PYI059 `Generic[]` should always be the last base class
    |
    = help: Move `Generic[]` to the end
 
-PYI059.py:59:9: PYI059 `Generic[]` should always be the last base class
+PYI059.py:59:9: PYI059 [*] `Generic[]` should always be the last base class
    |
 57 | # syntax errors with starred and keyword arguments from
 58 | # https://github.com/astral-sh/ruff/issues/18602
@@ -121,6 +121,16 @@ PYI059.py:59:9: PYI059 `Generic[]` should always be the last base class
 60 |     ...
    |
    = help: Move `Generic[]` to the end
+
+ℹ Safe fix
+56 56 | 
+57 57 | # syntax errors with starred and keyword arguments from
+58 58 | # https://github.com/astral-sh/ruff/issues/18602
+59    |-class C1(Generic[T], str, **{"metaclass": type}):  # PYI059
+   59 |+class C1(str, Generic[T], **{"metaclass": type}):  # PYI059
+60 60 |     ...
+61 61 | 
+62 62 | class C2(Generic[T], str, metaclass=type):  # PYI059
 
 PYI059.py:62:9: PYI059 [*] `Generic[]` should always be the last base class
    |


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ruff/issues/18602 by:
1. Avoiding a fix when `*args` are present
2. Inserting the `Generic` base class right before the first keyword argument, if one is present

In an intermediate commit, I also had special handling to avoid a fix in the `**kwargs` case, but this is treated (roughly) as a normal keyword, and I believe handling it properly falls out of the other keyword fix.

## Test Plan

Existing PYI059 cases, plus new tests based on the issue
