### PR TITLE
[`ruff`] Handle extra arguments to `deque` (`RUF037`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF037.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF037.py
@@ -59,3 +59,10 @@ def f():
 
 def f():
     x = 0 or(deque)([])
+
+
+# regression tests for https://github.com/astral-sh/ruff/issues/18612
+def f():
+    deque([], *[10])  # RUF037
+    deque([], **{"maxlen": 10})  # RUF037
+    deque([], foo=1)  # RUF037

--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF037.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF037.py
@@ -63,6 +63,13 @@ def f():
 
 # regression tests for https://github.com/astral-sh/ruff/issues/18612
 def f():
-    deque([], *[10])  # RUF037
+    deque([], *[10])  # RUF037 but no fix
     deque([], **{"maxlen": 10})  # RUF037
     deque([], foo=1)  # RUF037
+
+
+# Somewhat related to the issue, both okay because we can't generally look
+# inside *args or **kwargs
+def f():
+    deque(*([], 10))  # Ok
+    deque(**{"iterable": [], "maxlen": 10})  # Ok

--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF037.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF037.py
@@ -73,3 +73,12 @@ def f():
 def f():
     deque(*([], 10))  # Ok
     deque(**{"iterable": [], "maxlen": 10})  # Ok
+
+# The fix for the cases above can now delete comments, which should make the
+# fix unsafe
+def f():
+    deque(
+        [  # a comment _in_ the list, deleted
+        ],  # a comment after the list, preserved
+        maxlen=10,  # a comment on maxlen, preserved
+        )

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF037_RUF037.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF037_RUF037.py.snap
@@ -194,3 +194,26 @@ RUF037.py:68:5: RUF037 [*] Unnecessary empty iterable within a deque call
 69 69 | 
 70 70 | 
 71 71 | # Somewhat related to the issue, both okay because we can't generally look
+
+RUF037.py:80:5: RUF037 [*] Unnecessary empty iterable within a deque call
+   |
+78 |   # fix unsafe
+79 |   def f():
+80 | /     deque(
+81 | |         [  # a comment _in_ the list, deleted
+82 | |         ],  # a comment after the list, preserved
+83 | |         maxlen=10,  # a comment on maxlen, preserved
+84 | |         )
+   | |_________^ RUF037
+   |
+   = help: Replace with `deque(maxlen=...)`
+
+ℹ Unsafe fix
+78 78 | # fix unsafe
+79 79 | def f():
+80 80 |     deque(
+81    |-        [  # a comment _in_ the list, deleted
+82    |-        ],  # a comment after the list, preserved
+   81 |+        # a comment after the list, preserved
+83 82 |         maxlen=10,  # a comment on maxlen, preserved
+84 83 |         )

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF037_RUF037.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF037_RUF037.py.snap
@@ -141,3 +141,60 @@ RUF037.py:61:13: RUF037 [*] Unnecessary empty iterable within a deque call
 60 60 | def f():
 61    |-    x = 0 or(deque)([])
    61 |+    x = 0 or(deque)()
+62 62 | 
+63 63 | 
+64 64 | # regression tests for https://github.com/astral-sh/ruff/issues/18612
+
+RUF037.py:66:5: RUF037 [*] Unnecessary empty iterable within a deque call
+   |
+64 | # regression tests for https://github.com/astral-sh/ruff/issues/18612
+65 | def f():
+66 |     deque([], *[10])  # RUF037
+   |     ^^^^^^^^^^^^^^^^ RUF037
+67 |     deque([], **{"maxlen": 10})  # RUF037
+68 |     deque([], foo=1)  # RUF037
+   |
+   = help: Replace with `deque()`
+
+ℹ Safe fix
+63 63 | 
+64 64 | # regression tests for https://github.com/astral-sh/ruff/issues/18612
+65 65 | def f():
+66    |-    deque([], *[10])  # RUF037
+   66 |+    deque()  # RUF037
+67 67 |     deque([], **{"maxlen": 10})  # RUF037
+68 68 |     deque([], foo=1)  # RUF037
+
+RUF037.py:67:5: RUF037 [*] Unnecessary empty iterable within a deque call
+   |
+65 | def f():
+66 |     deque([], *[10])  # RUF037
+67 |     deque([], **{"maxlen": 10})  # RUF037
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ RUF037
+68 |     deque([], foo=1)  # RUF037
+   |
+   = help: Replace with `deque()`
+
+ℹ Safe fix
+64 64 | # regression tests for https://github.com/astral-sh/ruff/issues/18612
+65 65 | def f():
+66 66 |     deque([], *[10])  # RUF037
+67    |-    deque([], **{"maxlen": 10})  # RUF037
+   67 |+    deque()  # RUF037
+68 68 |     deque([], foo=1)  # RUF037
+
+RUF037.py:68:5: RUF037 [*] Unnecessary empty iterable within a deque call
+   |
+66 |     deque([], *[10])  # RUF037
+67 |     deque([], **{"maxlen": 10})  # RUF037
+68 |     deque([], foo=1)  # RUF037
+   |     ^^^^^^^^^^^^^^^^ RUF037
+   |
+   = help: Replace with `deque()`
+
+ℹ Safe fix
+65 65 | def f():
+66 66 |     deque([], *[10])  # RUF037
+67 67 |     deque([], **{"maxlen": 10})  # RUF037
+68    |-    deque([], foo=1)  # RUF037
+   68 |+    deque()  # RUF037

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF037_RUF037.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF037_RUF037.py.snap
@@ -145,30 +145,21 @@ RUF037.py:61:13: RUF037 [*] Unnecessary empty iterable within a deque call
 63 63 | 
 64 64 | # regression tests for https://github.com/astral-sh/ruff/issues/18612
 
-RUF037.py:66:5: RUF037 [*] Unnecessary empty iterable within a deque call
+RUF037.py:66:5: RUF037 Unnecessary empty iterable within a deque call
    |
 64 | # regression tests for https://github.com/astral-sh/ruff/issues/18612
 65 | def f():
-66 |     deque([], *[10])  # RUF037
+66 |     deque([], *[10])  # RUF037 but no fix
    |     ^^^^^^^^^^^^^^^^ RUF037
 67 |     deque([], **{"maxlen": 10})  # RUF037
 68 |     deque([], foo=1)  # RUF037
    |
    = help: Replace with `deque()`
 
-ℹ Safe fix
-63 63 | 
-64 64 | # regression tests for https://github.com/astral-sh/ruff/issues/18612
-65 65 | def f():
-66    |-    deque([], *[10])  # RUF037
-   66 |+    deque()  # RUF037
-67 67 |     deque([], **{"maxlen": 10})  # RUF037
-68 68 |     deque([], foo=1)  # RUF037
-
 RUF037.py:67:5: RUF037 [*] Unnecessary empty iterable within a deque call
    |
 65 | def f():
-66 |     deque([], *[10])  # RUF037
+66 |     deque([], *[10])  # RUF037 but no fix
 67 |     deque([], **{"maxlen": 10})  # RUF037
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ RUF037
 68 |     deque([], foo=1)  # RUF037
@@ -178,14 +169,16 @@ RUF037.py:67:5: RUF037 [*] Unnecessary empty iterable within a deque call
 ℹ Safe fix
 64 64 | # regression tests for https://github.com/astral-sh/ruff/issues/18612
 65 65 | def f():
-66 66 |     deque([], *[10])  # RUF037
+66 66 |     deque([], *[10])  # RUF037 but no fix
 67    |-    deque([], **{"maxlen": 10})  # RUF037
-   67 |+    deque()  # RUF037
+   67 |+    deque(**{"maxlen": 10})  # RUF037
 68 68 |     deque([], foo=1)  # RUF037
+69 69 | 
+70 70 | 
 
 RUF037.py:68:5: RUF037 [*] Unnecessary empty iterable within a deque call
    |
-66 |     deque([], *[10])  # RUF037
+66 |     deque([], *[10])  # RUF037 but no fix
 67 |     deque([], **{"maxlen": 10})  # RUF037
 68 |     deque([], foo=1)  # RUF037
    |     ^^^^^^^^^^^^^^^^ RUF037
@@ -194,7 +187,10 @@ RUF037.py:68:5: RUF037 [*] Unnecessary empty iterable within a deque call
 
 ℹ Safe fix
 65 65 | def f():
-66 66 |     deque([], *[10])  # RUF037
+66 66 |     deque([], *[10])  # RUF037 but no fix
 67 67 |     deque([], **{"maxlen": 10})  # RUF037
 68    |-    deque([], foo=1)  # RUF037
-   68 |+    deque()  # RUF037
+   68 |+    deque(foo=1)  # RUF037
+69 69 | 
+70 70 | 
+71 71 | # Somewhat related to the issue, both okay because we can't generally look


### PR DESCRIPTION
I just realized this isn't right after writing up the PR description. `maxlen` can also be passed positionally, which would break this implementation, but we didn't have any existing tests for that.

## Summary

Fixes https://github.com/astral-sh/ruff/issues/18612 by:
- Bailing out without a fix in the case of `*args`, which I don't think we can fix reliably
- Reimplementing the fix as an `Edit::deletion` from `remove_argument` instead of an `Edit::range_replacement`

The latter allows us to preserve any additional arguments, including any named keyword args or `**kwargs`.

This version (and possibly the original version?) can also delete comments in what I expect to be a very rare case, so I marked the fix unsafe in those cases and updated the docs accordingly.

## Test Plan

New test cases derived from the issue.

## Stabilization

These are pretty significant changes, much like those to PYI059 in https://github.com/astral-sh/ruff/pull/18611 (and based a bit on the implementation there!), so I think it probably makes sense to un-stabilize this for the 0.12 release, but I'm open to other thoughts there.
