### PR TITLE
[`refurb`] Add a note about float literal handling (`FURB157`)

### DIFF
--- a/crates/ruff_linter/src/rules/refurb/rules/verbose_decimal_constructor.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/verbose_decimal_constructor.rs
@@ -23,6 +23,9 @@ use crate::{Edit, Fix, FixAvailability, Violation};
 /// Prefer the more concise form of argument passing for `Decimal`
 /// constructors, as it's more readable and idiomatic.
 ///
+/// Note that this rule does not flag quoted float literals such as `Decimal("0.1")`, which will
+/// produce a more precise `Decimal` value than the unquoted `Decimal(0.1)`.
+///
 /// ## Example
 /// ```python
 /// Decimal("0")


### PR DESCRIPTION
Summary
--

Updates the rule docs to explicitly state how cases like `Decimal("0.1")` are handled (not affected) because the discussion of "float casts" referring to values like `nan` and `inf` is otherwise a bit confusing.

These changes are based on suggestions from @AlexWaygood on Notion, with a slight adjustment to use 0.1 instead of 0.5 since it causes a more immediate issue in the REPL:

```pycon
>>> from decimal import Decimal
>>> Decimal(0.5) == Decimal("0.5")
True
>>> Decimal(0.1) == Decimal("0.1")
False
```

Test plan
--

N/a