### PR TITLE
[`ruff`] Validate arguments before offering a fix (`RUF056`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF056.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF056.py
@@ -184,3 +184,5 @@ not my_dict.get("key", default=False)
 # TypeError is raised at runtime before and after the fix, but we still bail
 # out for having an unrecognized number of arguments
 not my_dict.get("key", False, foo=...)
+
+not my_dict.get(default=False)

--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF056.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF056.py
@@ -169,3 +169,17 @@ value = not my_dict.get(default=[], # comment1
 # testing invalid dict.get calls
 value = not my_dict.get(key="key", other="something", default=False)
 value = not my_dict.get(default=False, other="something", key="test")
+
+
+# regression tests for https://github.com/astral-sh/ruff/issues/18628
+# we should avoid fixes when there are unknown arguments present
+
+# extra positional
+not my_dict.get("key", False, "?!")
+
+# `default` is positional-only, so this is invalid
+not my_dict.get("key", default=False)
+
+# the fix is arguably okay here because the same `takes no keyword arguments`
+# TypeError is raised at runtime before and after the fix
+not my_dict.get("key", False, foo=...)

--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF056.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF056.py
@@ -181,5 +181,6 @@ not my_dict.get("key", False, "?!")
 not my_dict.get("key", default=False)
 
 # the fix is arguably okay here because the same `takes no keyword arguments`
-# TypeError is raised at runtime before and after the fix
+# TypeError is raised at runtime before and after the fix, but we still bail
+# out for having an unrecognized number of arguments
 not my_dict.get("key", False, foo=...)

--- a/crates/ruff_linter/src/rules/ruff/rules/falsy_dict_get_fallback.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/falsy_dict_get_fallback.rs
@@ -5,7 +5,7 @@ use ruff_text_size::Ranged;
 
 use crate::checkers::ast::Checker;
 use crate::fix::edits::{Parentheses, remove_argument};
-use crate::{AlwaysFixableViolation, Applicability, Fix};
+use crate::{Applicability, Fix, FixAvailability, Violation};
 
 /// ## What it does
 /// Checks for `dict.get(key, falsy_value)` calls in boolean test positions.
@@ -28,21 +28,34 @@ use crate::{AlwaysFixableViolation, Applicability, Fix};
 /// ```
 ///
 /// ## Fix safety
-/// This rule's fix is marked as safe, unless the `dict.get()` call contains comments between arguments.
+///
+/// This rule's fix is marked as safe, unless the `dict.get()` call contains comments between
+/// arguments that will be deleted.
+///
+/// ## Fix availability
+///
+/// This rule's fix is unavailable in cases where invalid arguments are provided to `dict.get`. As
+/// shown in the [documentation], `dict.get` takes two positional-only arguments, so invalid cases
+/// are identified by the presence of more than two arguments or any keyword arguments.
+///
+/// [documentation]: https://docs.python.org/3.13/library/stdtypes.html#dict.get
 #[derive(ViolationMetadata)]
 pub(crate) struct FalsyDictGetFallback;
 
-impl AlwaysFixableViolation for FalsyDictGetFallback {
+impl Violation for FalsyDictGetFallback {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+
     #[derive_message_formats]
     fn message(&self) -> String {
         "Avoid providing a falsy fallback to `dict.get()` in boolean test positions. The default fallback `None` is already falsy.".to_string()
     }
 
-    fn fix_title(&self) -> String {
-        "Remove falsy fallback from `dict.get()`".to_string()
+    fn fix_title(&self) -> Option<String> {
+        Some("Remove falsy fallback from `dict.get()`".to_string())
     }
 }
 
+/// RUF056
 pub(crate) fn falsy_dict_get_fallback(checker: &Checker, expr: &Expr) {
     let semantic = checker.semantic();
 
@@ -88,6 +101,16 @@ pub(crate) fn falsy_dict_get_fallback(checker: &Checker, expr: &Expr) {
     }
 
     let mut diagnostic = checker.report_diagnostic(FalsyDictGetFallback, fallback_arg.range());
+
+    // All arguments to `dict.get` are positional-only.
+    if !call.arguments.keywords.is_empty() {
+        return;
+    }
+
+    // And there are only two of them, at most.
+    if call.arguments.args.len() > 2 {
+        return;
+    }
 
     let comment_ranges = checker.comment_ranges();
 

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF056_RUF056.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF056_RUF056.py.snap
@@ -466,6 +466,8 @@ RUF056.py:170:55: RUF056 [*] Avoid providing a falsy fallback to `dict.get()` in
 170     |-value = not my_dict.get(key="key", other="something", default=False)
     170 |+value = not my_dict.get(key="key", other="something")
 171 171 | value = not my_dict.get(default=False, other="something", key="test")
+172 172 | 
+173 173 | 
 
 RUF056.py:171:25: RUF056 [*] Avoid providing a falsy fallback to `dict.get()` in boolean test positions. The default fallback `None` is already falsy.
     |
@@ -482,3 +484,62 @@ RUF056.py:171:25: RUF056 [*] Avoid providing a falsy fallback to `dict.get()` in
 170 170 | value = not my_dict.get(key="key", other="something", default=False)
 171     |-value = not my_dict.get(default=False, other="something", key="test")
     171 |+value = not my_dict.get(other="something", key="test")
+172 172 | 
+173 173 | 
+174 174 | # regression tests for https://github.com/astral-sh/ruff/issues/18628
+
+RUF056.py:178:24: RUF056 [*] Avoid providing a falsy fallback to `dict.get()` in boolean test positions. The default fallback `None` is already falsy.
+    |
+177 | # extra positional
+178 | not my_dict.get("key", False, "?!")
+    |                        ^^^^^ RUF056
+179 |
+180 | # `default` is positional-only, so this is invalid
+    |
+    = help: Remove falsy fallback from `dict.get()`
+
+ℹ Safe fix
+175 175 | # we should avoid fixes when there are unknown arguments present
+176 176 | 
+177 177 | # extra positional
+178     |-not my_dict.get("key", False, "?!")
+    178 |+not my_dict.get("key", "?!")
+179 179 | 
+180 180 | # `default` is positional-only, so this is invalid
+181 181 | not my_dict.get("key", default=False)
+
+RUF056.py:181:24: RUF056 [*] Avoid providing a falsy fallback to `dict.get()` in boolean test positions. The default fallback `None` is already falsy.
+    |
+180 | # `default` is positional-only, so this is invalid
+181 | not my_dict.get("key", default=False)
+    |                        ^^^^^^^^^^^^^ RUF056
+182 |
+183 | # the fix is arguably okay here because the same `takes no keyword arguments`
+    |
+    = help: Remove falsy fallback from `dict.get()`
+
+ℹ Safe fix
+178 178 | not my_dict.get("key", False, "?!")
+179 179 | 
+180 180 | # `default` is positional-only, so this is invalid
+181     |-not my_dict.get("key", default=False)
+    181 |+not my_dict.get("key")
+182 182 | 
+183 183 | # the fix is arguably okay here because the same `takes no keyword arguments`
+184 184 | # TypeError is raised at runtime before and after the fix
+
+RUF056.py:185:24: RUF056 [*] Avoid providing a falsy fallback to `dict.get()` in boolean test positions. The default fallback `None` is already falsy.
+    |
+183 | # the fix is arguably okay here because the same `takes no keyword arguments`
+184 | # TypeError is raised at runtime before and after the fix
+185 | not my_dict.get("key", False, foo=...)
+    |                        ^^^^^ RUF056
+    |
+    = help: Remove falsy fallback from `dict.get()`
+
+ℹ Safe fix
+182 182 | 
+183 183 | # the fix is arguably okay here because the same `takes no keyword arguments`
+184 184 | # TypeError is raised at runtime before and after the fix
+185     |-not my_dict.get("key", False, foo=...)
+    185 |+not my_dict.get("key", foo=...)

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF056_RUF056.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF056_RUF056.py.snap
@@ -346,7 +346,7 @@ RUF056.py:150:32: RUF056 [*] Avoid providing a falsy fallback to `dict.get()` in
 152 152 | # testing dict.get call using kwargs
 153 153 | value = not my_dict.get(key="key", default=False)  # [RUF056]
 
-RUF056.py:153:36: RUF056 [*] Avoid providing a falsy fallback to `dict.get()` in boolean test positions. The default fallback `None` is already falsy.
+RUF056.py:153:36: RUF056 Avoid providing a falsy fallback to `dict.get()` in boolean test positions. The default fallback `None` is already falsy.
     |
 152 | # testing dict.get call using kwargs
 153 | value = not my_dict.get(key="key", default=False)  # [RUF056]
@@ -355,17 +355,7 @@ RUF056.py:153:36: RUF056 [*] Avoid providing a falsy fallback to `dict.get()` in
     |
     = help: Remove falsy fallback from `dict.get()`
 
-ℹ Safe fix
-150 150 | value = not my_dict.get("key", "")  # [RUF056]
-151 151 | 
-152 152 | # testing dict.get call using kwargs
-153     |-value = not my_dict.get(key="key", default=False)  # [RUF056]
-    153 |+value = not my_dict.get(key="key")  # [RUF056]
-154 154 | value = not my_dict.get(default=[], key="key")  # [RUF056]
-155 155 | 
-156 156 | # testing invalid dict.get call with inline comment
-
-RUF056.py:154:25: RUF056 [*] Avoid providing a falsy fallback to `dict.get()` in boolean test positions. The default fallback `None` is already falsy.
+RUF056.py:154:25: RUF056 Avoid providing a falsy fallback to `dict.get()` in boolean test positions. The default fallback `None` is already falsy.
     |
 152 | # testing dict.get call using kwargs
 153 | value = not my_dict.get(key="key", default=False)  # [RUF056]
@@ -375,16 +365,6 @@ RUF056.py:154:25: RUF056 [*] Avoid providing a falsy fallback to `dict.get()` in
 156 | # testing invalid dict.get call with inline comment
     |
     = help: Remove falsy fallback from `dict.get()`
-
-ℹ Safe fix
-151 151 | 
-152 152 | # testing dict.get call using kwargs
-153 153 | value = not my_dict.get(key="key", default=False)  # [RUF056]
-154     |-value = not my_dict.get(default=[], key="key")  # [RUF056]
-    154 |+value = not my_dict.get(key="key")  # [RUF056]
-155 155 | 
-156 156 | # testing invalid dict.get call with inline comment
-157 157 | value = not my_dict.get("key", # comment1
 
 RUF056.py:158:22: RUF056 [*] Avoid providing a falsy fallback to `dict.get()` in boolean test positions. The default fallback `None` is already falsy.
     |
@@ -407,7 +387,7 @@ RUF056.py:158:22: RUF056 [*] Avoid providing a falsy fallback to `dict.get()` in
 160 159 | 
 161 160 | # testing invalid dict.get call with kwargs and inline comment
 
-RUF056.py:163:25: RUF056 [*] Avoid providing a falsy fallback to `dict.get()` in boolean test positions. The default fallback `None` is already falsy.
+RUF056.py:163:25: RUF056 Avoid providing a falsy fallback to `dict.get()` in boolean test positions. The default fallback `None` is already falsy.
     |
 161 | # testing invalid dict.get call with kwargs and inline comment
 162 | value = not my_dict.get(key="key", # comment1
@@ -418,18 +398,7 @@ RUF056.py:163:25: RUF056 [*] Avoid providing a falsy fallback to `dict.get()` in
     |
     = help: Remove falsy fallback from `dict.get()`
 
-ℹ Unsafe fix
-159 159 |                      ) # [RUF056]
-160 160 | 
-161 161 | # testing invalid dict.get call with kwargs and inline comment
-162     |-value = not my_dict.get(key="key", # comment1
-163     |-                        default=False # comment2
-    162 |+value = not my_dict.get(key="key" # comment2
-164 163 |                         )  # [RUF056]
-165 164 | value = not my_dict.get(default=[], # comment1
-166 165 |                         key="key" # comment2
-
-RUF056.py:165:25: RUF056 [*] Avoid providing a falsy fallback to `dict.get()` in boolean test positions. The default fallback `None` is already falsy.
+RUF056.py:165:25: RUF056 Avoid providing a falsy fallback to `dict.get()` in boolean test positions. The default fallback `None` is already falsy.
     |
 163 |                         default=False # comment2
 164 |                         )  # [RUF056]
@@ -440,17 +409,7 @@ RUF056.py:165:25: RUF056 [*] Avoid providing a falsy fallback to `dict.get()` in
     |
     = help: Remove falsy fallback from `dict.get()`
 
-ℹ Unsafe fix
-162 162 | value = not my_dict.get(key="key", # comment1
-163 163 |                         default=False # comment2
-164 164 |                         )  # [RUF056]
-165     |-value = not my_dict.get(default=[], # comment1
-    165 |+value = not my_dict.get(# comment1
-166 166 |                         key="key" # comment2
-167 167 |                         )  # [RUF056]
-168 168 | 
-
-RUF056.py:170:55: RUF056 [*] Avoid providing a falsy fallback to `dict.get()` in boolean test positions. The default fallback `None` is already falsy.
+RUF056.py:170:55: RUF056 Avoid providing a falsy fallback to `dict.get()` in boolean test positions. The default fallback `None` is already falsy.
     |
 169 | # testing invalid dict.get calls
 170 | value = not my_dict.get(key="key", other="something", default=False)
@@ -459,17 +418,7 @@ RUF056.py:170:55: RUF056 [*] Avoid providing a falsy fallback to `dict.get()` in
     |
     = help: Remove falsy fallback from `dict.get()`
 
-ℹ Safe fix
-167 167 |                         )  # [RUF056]
-168 168 | 
-169 169 | # testing invalid dict.get calls
-170     |-value = not my_dict.get(key="key", other="something", default=False)
-    170 |+value = not my_dict.get(key="key", other="something")
-171 171 | value = not my_dict.get(default=False, other="something", key="test")
-172 172 | 
-173 173 | 
-
-RUF056.py:171:25: RUF056 [*] Avoid providing a falsy fallback to `dict.get()` in boolean test positions. The default fallback `None` is already falsy.
+RUF056.py:171:25: RUF056 Avoid providing a falsy fallback to `dict.get()` in boolean test positions. The default fallback `None` is already falsy.
     |
 169 | # testing invalid dict.get calls
 170 | value = not my_dict.get(key="key", other="something", default=False)
@@ -478,17 +427,7 @@ RUF056.py:171:25: RUF056 [*] Avoid providing a falsy fallback to `dict.get()` in
     |
     = help: Remove falsy fallback from `dict.get()`
 
-ℹ Safe fix
-168 168 | 
-169 169 | # testing invalid dict.get calls
-170 170 | value = not my_dict.get(key="key", other="something", default=False)
-171     |-value = not my_dict.get(default=False, other="something", key="test")
-    171 |+value = not my_dict.get(other="something", key="test")
-172 172 | 
-173 173 | 
-174 174 | # regression tests for https://github.com/astral-sh/ruff/issues/18628
-
-RUF056.py:178:24: RUF056 [*] Avoid providing a falsy fallback to `dict.get()` in boolean test positions. The default fallback `None` is already falsy.
+RUF056.py:178:24: RUF056 Avoid providing a falsy fallback to `dict.get()` in boolean test positions. The default fallback `None` is already falsy.
     |
 177 | # extra positional
 178 | not my_dict.get("key", False, "?!")
@@ -498,17 +437,7 @@ RUF056.py:178:24: RUF056 [*] Avoid providing a falsy fallback to `dict.get()` in
     |
     = help: Remove falsy fallback from `dict.get()`
 
-ℹ Safe fix
-175 175 | # we should avoid fixes when there are unknown arguments present
-176 176 | 
-177 177 | # extra positional
-178     |-not my_dict.get("key", False, "?!")
-    178 |+not my_dict.get("key", "?!")
-179 179 | 
-180 180 | # `default` is positional-only, so this is invalid
-181 181 | not my_dict.get("key", default=False)
-
-RUF056.py:181:24: RUF056 [*] Avoid providing a falsy fallback to `dict.get()` in boolean test positions. The default fallback `None` is already falsy.
+RUF056.py:181:24: RUF056 Avoid providing a falsy fallback to `dict.get()` in boolean test positions. The default fallback `None` is already falsy.
     |
 180 | # `default` is positional-only, so this is invalid
 181 | not my_dict.get("key", default=False)
@@ -518,28 +447,11 @@ RUF056.py:181:24: RUF056 [*] Avoid providing a falsy fallback to `dict.get()` in
     |
     = help: Remove falsy fallback from `dict.get()`
 
-ℹ Safe fix
-178 178 | not my_dict.get("key", False, "?!")
-179 179 | 
-180 180 | # `default` is positional-only, so this is invalid
-181     |-not my_dict.get("key", default=False)
-    181 |+not my_dict.get("key")
-182 182 | 
-183 183 | # the fix is arguably okay here because the same `takes no keyword arguments`
-184 184 | # TypeError is raised at runtime before and after the fix
-
-RUF056.py:185:24: RUF056 [*] Avoid providing a falsy fallback to `dict.get()` in boolean test positions. The default fallback `None` is already falsy.
+RUF056.py:186:24: RUF056 Avoid providing a falsy fallback to `dict.get()` in boolean test positions. The default fallback `None` is already falsy.
     |
-183 | # the fix is arguably okay here because the same `takes no keyword arguments`
-184 | # TypeError is raised at runtime before and after the fix
-185 | not my_dict.get("key", False, foo=...)
+184 | # TypeError is raised at runtime before and after the fix, but we still bail
+185 | # out for having an unrecognized number of arguments
+186 | not my_dict.get("key", False, foo=...)
     |                        ^^^^^ RUF056
     |
     = help: Remove falsy fallback from `dict.get()`
-
-ℹ Safe fix
-182 182 | 
-183 183 | # the fix is arguably okay here because the same `takes no keyword arguments`
-184 184 | # TypeError is raised at runtime before and after the fix
-185     |-not my_dict.get("key", False, foo=...)
-    185 |+not my_dict.get("key", foo=...)

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF056_RUF056.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF056_RUF056.py.snap
@@ -453,5 +453,16 @@ RUF056.py:186:24: RUF056 Avoid providing a falsy fallback to `dict.get()` in boo
 185 | # out for having an unrecognized number of arguments
 186 | not my_dict.get("key", False, foo=...)
     |                        ^^^^^ RUF056
+187 |
+188 | not my_dict.get(default=False)
+    |
+    = help: Remove falsy fallback from `dict.get()`
+
+RUF056.py:188:17: RUF056 Avoid providing a falsy fallback to `dict.get()` in boolean test positions. The default fallback `None` is already falsy.
+    |
+186 | not my_dict.get("key", False, foo=...)
+187 |
+188 | not my_dict.get(default=False)
+    |                 ^^^^^^^^^^^^^ RUF056
     |
     = help: Remove falsy fallback from `dict.get()`


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ruff/issues/18628 by avoiding a fix if there are "unknown" arguments, including any keyword arguments and more than the expected 2 positional arguments.

I'm a bit on the fence here because it also seems reasonable to avoid a diagnostic at all. Especially in the final test case I added (`not my_dict.get(default=False)`), the hint suggesting to remove `default=False` seems pretty misleading. At the same time, I guess the diagnostic at least calls attention to the call site, which could help to fix the missing argument bug too.

As I commented on the issue, I double-checked that keyword arguments are invalid as far back as Python 3.8, even though the positional-only marker was only added to the [docs](https://docs.python.org/3.11/library/stdtypes.html#dict.get) in 3.12 (link is to 3.11, showing its absence).

## Test Plan

New tests derived from the bug report

## Stabilization

This was planned to be stabilized in 0.12, and the bug is less severe than some others, but if there's nobody opposed, I will plan **not to stabilize** this one for now.
