### PR TITLE
`SourceOrderVisitor` should visit the `Identifier` part of the `PatternKeyword` node

### DIFF
--- a/crates/ruff_python_ast/src/visitor/source_order.rs
+++ b/crates/ruff_python_ast/src/visitor/source_order.rs
@@ -501,7 +501,7 @@ where
 {
     let node = AnyNodeRef::from(pattern_keyword);
     if visitor.enter_node(node).is_traverse() {
-        visitor.visit_pattern(&pattern_keyword.pattern);
+        pattern_keyword.visit_source_order(visitor);
     }
     visitor.leave_node(node);
 }

--- a/crates/ruff_python_ast_integration_tests/tests/snapshots/source_order__match_class_pattern.snap
+++ b/crates/ruff_python_ast_integration_tests/tests/snapshots/source_order__match_class_pattern.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/ruff_python_ast_integration_tests/tests/source_order.rs
 expression: trace
-snapshot_kind: text
 ---
 - ModModule
   - StmtMatch
@@ -21,12 +20,15 @@ snapshot_kind: text
         - ExprName
         - PatternArguments
           - PatternKeyword
+            - Identifier
             - PatternMatchValue
               - ExprNumberLiteral
           - PatternKeyword
+            - Identifier
             - PatternMatchValue
               - ExprNumberLiteral
           - PatternKeyword
+            - Identifier
             - PatternMatchValue
               - ExprNumberLiteral
       - StmtExpr


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

I've noticed that when using a custom `SourceOrderVisitor` to visit a `PatternKeyword` node, enter/exit is not invoked on `Identifier` part of that node. E.g.
```python
match x:
  case Foo(y=1): ...
#          ^ This is not visited
```
This PR proposes a fix for it. 

## Test Plan

`cargo test`
