### PR TITLE
[ty] Fix panics when pulling types for various special forms that have the wrong number of parameters

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/any.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/any.md
@@ -139,8 +139,6 @@ x: int = MagicMock()
 
 ## Invalid
 
-<!-- pull-types:skip -->
-
 `Any` cannot be parameterized:
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/type_api.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_api.md
@@ -23,8 +23,12 @@ def negate(n1: Not[int], n2: Not[Not[int]], n3: Not[Not[Not[int]]]) -> None:
     reveal_type(n2)  # revealed: int
     reveal_type(n3)  # revealed: ~int
 
-# error: "Special form `ty_extensions.Not` expected exactly one type parameter"
+# error: "Special form `ty_extensions.Not` expected exactly 1 type argument, got 2"
 n: Not[int, str]
+# error: [invalid-type-form] "Special form `ty_extensions.Not` expected exactly 1 type argument, got 0"
+o: Not[()]
+
+p: Not[(int,)]
 
 def static_truthiness(not_one: Not[Literal[1]]) -> None:
     # TODO: `bool` is not incorrect, but these would ideally be `Literal[True]` and `Literal[False]`
@@ -371,8 +375,6 @@ static_assert(not is_single_valued(Literal["a"] | Literal["b"]))
 
 ## `TypeOf`
 
-<!-- pull-types:skip -->
-
 We use `TypeOf` to get the inferred type of an expression. This is useful when we want to refer to
 it in a type expression. For example, if we want to make sure that the class literal type `str` is a
 subtype of `type[str]`, we can not use `is_subtype_of(str, type[str])`, as that would test if the
@@ -398,13 +400,13 @@ class Derived(Base): ...
 ```py
 def type_of_annotation() -> None:
     t1: TypeOf[Base] = Base
-    t2: TypeOf[Base] = Derived  # error: [invalid-assignment]
+    t2: TypeOf[(Base,)] = Derived  # error: [invalid-assignment]
 
     # Note how this is different from `type[…]` which includes subclasses:
     s1: type[Base] = Base
     s2: type[Base] = Derived  # no error here
 
-# error: "Special form `ty_extensions.TypeOf` expected exactly one type parameter"
+# error: "Special form `ty_extensions.TypeOf` expected exactly 1 type argument, got 3"
 t: TypeOf[int, str, bytes]
 
 # error: [invalid-type-form] "`ty_extensions.TypeOf` requires exactly one argument when used in a type expression"
@@ -413,8 +415,6 @@ def f(x: TypeOf) -> None:
 ```
 
 ## `CallableTypeOf`
-
-<!-- pull-types:skip -->
 
 The `CallableTypeOf` special form can be used to extract the `Callable` structural type inhabited by
 a given callable object. This can be used to get the externally visibly signature of the object,
@@ -434,15 +434,23 @@ def f2() -> int:
 def f3(x: int, y: str) -> None:
     return
 
-# error: [invalid-type-form] "Special form `ty_extensions.CallableTypeOf` expected exactly one type parameter"
+# error: [invalid-type-form] "Special form `ty_extensions.CallableTypeOf` expected exactly 1 type argument, got 2"
 c1: CallableTypeOf[f1, f2]
 
 # error: [invalid-type-form] "Expected the first argument to `ty_extensions.CallableTypeOf` to be a callable object, but got an object of type `Literal["foo"]`"
 c2: CallableTypeOf["foo"]
 
+# error: [invalid-type-form] "Expected the first argument to `ty_extensions.CallableTypeOf` to be a callable object, but got an object of type `Literal["foo"]`"
+c20: CallableTypeOf[("foo",)]
+
 # error: [invalid-type-form] "`ty_extensions.CallableTypeOf` requires exactly one argument when used in a type expression"
 def f(x: CallableTypeOf) -> None:
     reveal_type(x)  # revealed: Unknown
+
+c3: CallableTypeOf[(f3,)]
+
+# error: [invalid-type-form] "Special form `ty_extensions.CallableTypeOf` expected exactly 1 type argument, got 0"
+c4: CallableTypeOf[()]
 ```
 
 Using it in annotation to reveal the signature of the callable object:

--- a/crates/ty_python_semantic/resources/mdtest/type_api.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_api.md
@@ -14,8 +14,6 @@ directly.
 
 ### Negation
 
-<!-- pull-types:skip -->
-
 ```py
 from typing import Literal
 from ty_extensions import Not, static_assert

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -1888,6 +1888,26 @@ pub(crate) fn report_invalid_arguments_to_annotated(
     ));
 }
 
+pub(crate) fn report_invalid_argument_number_to_special_form(
+    context: &InferContext,
+    subscript: &ast::ExprSubscript,
+    special_form: SpecialFormType,
+    received_arguments: usize,
+    expected_arguments: u8,
+) {
+    let noun = if expected_arguments == 1 {
+        "type argument"
+    } else {
+        "type arguments"
+    };
+    if let Some(builder) = context.report_lint(&INVALID_TYPE_FORM, subscript) {
+        builder.into_diagnostic(format_args!(
+            "Special form `{special_form}` expected exactly {expected_arguments} {noun}, \
+            got {received_arguments}",
+        ));
+    }
+}
+
 pub(crate) fn report_bad_argument_to_get_protocol_members(
     context: &InferContext,
     call: &ast::ExprCall,

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -9201,6 +9201,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
         match value_ty {
             Type::ClassLiteral(literal) if literal.is_known(self.db(), KnownClass::Any) => {
+                self.infer_expression(slice);
                 if let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, subscript) {
                     builder.into_diagnostic("Type `typing.Any` expected no type parameter");
                 }

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -9432,12 +9432,16 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
             // Type API special forms
             SpecialFormType::Not => match arguments_slice {
-                ast::Expr::Tuple(_) => {
+                ast::Expr::Tuple(tuple) => {
+                    for element in tuple {
+                        self.infer_type_expression(element);
+                    }
                     if let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, subscript) {
                         builder.into_diagnostic(format_args!(
                             "Special form `{special_form}` expected exactly one type parameter",
                         ));
                     }
+                    self.store_expression_type(arguments_slice, Type::unknown());
                     Type::unknown()
                 }
                 _ => {


### PR DESCRIPTION
## Summary

On `main` we panic if we try to "pull types" for a file that includes a certain parameterized special form with the wrong number of arguments. This can cause unpredictable crashes in the playground, for example:

https://github.com/user-attachments/assets/e531d821-714e-433b-b9dd-b1b75b8c06d1

## Test Plan

Mdtests (which now pull types automatically if they don't have the `<!-- pull-types:skip -->` directive in them, following https://github.com/astral-sh/ruff/pull/18539)
