### PR TITLE
[ty] Stabilize completions

### DIFF
--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -9,7 +9,6 @@ use ruff_text_size::{Ranged, TextRange, TextSize};
 use crate::Db;
 use crate::find_node::covering_node;
 
-#[derive(Debug, Clone)]
 pub struct Completion {
     pub label: String,
 }

--- a/crates/ty_server/src/server.rs
+++ b/crates/ty_server/src/server.rs
@@ -2,7 +2,7 @@
 
 use self::schedule::spawn_main_loop;
 use crate::PositionEncoding;
-use crate::session::{AllSettings, ClientSettings, Experimental, Session};
+use crate::session::{AllSettings, ClientSettings, Session};
 use lsp_server::Connection;
 use lsp_types::{
     ClientCapabilities, DiagnosticOptions, DiagnosticServerCapabilities, HoverProviderCapability,
@@ -53,8 +53,7 @@ impl Server {
 
         let client_capabilities = init_params.capabilities;
         let position_encoding = Self::find_best_position_encoding(&client_capabilities);
-        let server_capabilities =
-            Self::server_capabilities(position_encoding, global_settings.experimental.as_ref());
+        let server_capabilities = Self::server_capabilities(position_encoding);
 
         let connection = connection.initialize_finish(
             id,
@@ -154,10 +153,7 @@ impl Server {
             .unwrap_or_default()
     }
 
-    fn server_capabilities(
-        position_encoding: PositionEncoding,
-        experimental: Option<&Experimental>,
-    ) -> ServerCapabilities {
+    fn server_capabilities(position_encoding: PositionEncoding) -> ServerCapabilities {
         ServerCapabilities {
             position_encoding: Some(position_encoding.into()),
             diagnostic_provider: Some(DiagnosticServerCapabilities::Options(DiagnosticOptions {
@@ -177,12 +173,10 @@ impl Server {
             inlay_hint_provider: Some(lsp_types::OneOf::Right(
                 InlayHintServerCapabilities::Options(InlayHintOptions::default()),
             )),
-            completion_provider: experimental
-                .is_some_and(Experimental::is_completions_enabled)
-                .then_some(lsp_types::CompletionOptions {
-                    trigger_characters: Some(vec!['.'.to_string()]),
-                    ..Default::default()
-                }),
+            completion_provider: Some(lsp_types::CompletionOptions {
+                trigger_characters: Some(vec!['.'.to_string()]),
+                ..Default::default()
+            }),
             ..Default::default()
         }
     }

--- a/crates/ty_server/src/session.rs
+++ b/crates/ty_server/src/session.rs
@@ -16,7 +16,6 @@ pub(crate) use self::capabilities::ResolvedClientCapabilities;
 pub use self::index::DocumentQuery;
 pub(crate) use self::settings::AllSettings;
 pub use self::settings::ClientSettings;
-pub(crate) use self::settings::Experimental;
 use crate::document::{DocumentKey, DocumentVersion, NotebookDocument};
 use crate::session::request_queue::RequestQueue;
 use crate::system::{AnySystemPath, LSPSystem};

--- a/crates/ty_server/src/session/settings.rs
+++ b/crates/ty_server/src/session/settings.rs
@@ -7,35 +7,11 @@ use serde::Deserialize;
 /// Maps a workspace URI to its associated client settings. Used during server initialization.
 pub(crate) type WorkspaceSettingsMap = FxHashMap<Url, ClientSettings>;
 
-#[derive(Debug, Deserialize, Default)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
-#[serde(rename_all = "camelCase")]
-struct Completions {
-    enable: Option<bool>,
-}
-
-#[derive(Debug, Deserialize, Default)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
-#[serde(rename_all = "camelCase")]
-pub(crate) struct Experimental {
-    completions: Option<Completions>,
-}
-
-impl Experimental {
-    /// Returns `true` if completions are enabled in the settings.
-    pub(crate) fn is_completions_enabled(&self) -> bool {
-        self.completions
-            .as_ref()
-            .is_some_and(|completions| completions.enable.unwrap_or_default())
-    }
-}
-
 /// This is a direct representation of the settings schema sent by the client.
 #[derive(Debug, Deserialize, Default)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
 #[serde(rename_all = "camelCase")]
 pub struct ClientSettings {
-    pub(crate) experimental: Option<Experimental>,
     // These settings are only needed for tracing, and are only read from the global configuration.
     // These will not be in the resolved settings.
     #[serde(flatten)]


### PR DESCRIPTION
Specifically, this PR reverts "Make completions an opt-in LSP feature (#17921)",
corresponding to commit 51e2effd2d6b6cf61bd245a3219168fe661d1a7d.

In practice, this means you don't need to opt into completions working
by enabling experimental features. i.e., I was able to remove this from
my LSP configuration:

```
"experimental": {
    "completions": {
        "enable": true
    }
},
```

There's still a lot of work left to do to make completions awesome, but
I think it's in a state where it would be useful to get real user
feedback. It's also meaningfully using ty to provide completions that
use type information.

Ref astral-sh/ty#86
