### PR TITLE
[ruff_python_ast] remove unnecessary `crate::` prefixes

### DIFF
--- a/crates/ruff_python_ast/generate.py
+++ b/crates/ruff_python_ast/generate.py
@@ -913,7 +913,7 @@ def write_root_anynoderef(out: list[str], ast: Ast) -> None:
         impl<'a> AnyRootNodeRef<'a> {
             pub fn visit_source_order<'b, V>(self, visitor: &mut V)
             where
-                V: crate::visitor::source_order::SourceOrderVisitor<'b> + ?Sized,
+                V: SourceOrderVisitor<'b> + ?Sized,
                 'a: 'b,
             {
                 match self {

--- a/crates/ruff_python_ast/src/generated.rs
+++ b/crates/ruff_python_ast/src/generated.rs
@@ -8697,7 +8697,7 @@ impl crate::HasNodeIndex for AnyRootNodeRef<'_> {
 impl<'a> AnyRootNodeRef<'a> {
     pub fn visit_source_order<'b, V>(self, visitor: &mut V)
     where
-        V: crate::visitor::source_order::SourceOrderVisitor<'b> + ?Sized,
+        V: SourceOrderVisitor<'b> + ?Sized,
         'a: 'b,
     {
         match self {


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary
/closes #18651
<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
