### PR TITLE
[ty] fix 'BitwiseAnd' bug

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/binary/booleans.md
+++ b/crates/ty_python_semantic/resources/mdtest/binary/booleans.md
@@ -120,36 +120,48 @@ def _(a: bool):
         reveal_type(a & x)  # revealed: int
         reveal_type(a ^ x)  # revealed: int
 
-    def lhs_is_bool(x: bool):
-        reveal_type(x | a)  # revealed: bool
-        reveal_type(x & a)  # revealed: bool
-        reveal_type(x ^ a)  # revealed: bool
+    def lhs_is_int_literal():
+        reveal_type(0 | a)  # revealed: int
+        reveal_type(0 & a)  # revealed: int
+        reveal_type(0 ^ a)  # revealed: int
 
-    def rhs_is_bool(x: bool):
-        reveal_type(a | x)  # revealed: bool
-        reveal_type(a & x)  # revealed: bool
-        reveal_type(a ^ x)  # revealed: bool
+        reveal_type(1 | a)  # revealed: int
+        reveal_type(1 & a)  # revealed: int
+        reveal_type(1 ^ a)  # revealed: int
+
+    def lhs_is_true():
+        reveal_type(True | a)  # revealed: bool
+        reveal_type(True & a)  # revealed: bool
+        reveal_type(True ^ a)  # revealed: bool
+
+    def rhs_is_true():
+        reveal_type(a | True)  # revealed: bool
+        reveal_type(a & True)  # revealed: bool
+        reveal_type(a ^ True)  # revealed: bool
+
+    def lhs_is_false():
+        reveal_type(False | a)  # revealed: bool
+        reveal_type(False & a)  # revealed: bool
+        reveal_type(False ^ a)  # revealed: bool
+
+    def rhs_is_false():
+        reveal_type(a | False)  # revealed: bool
+        reveal_type(a & False)  # revealed: bool
+        reveal_type(a ^ False)  # revealed: bool
 
     def both_are_bool(x: bool, y: bool):
         reveal_type(x | y)  # revealed: bool
         reveal_type(x & y)  # revealed: bool
         reveal_type(x ^ y)  # revealed: bool
 
-    def x() -> bool:
-        return random.random() > 0.5
+    def lhs_is_int_literal_rhs_is_bool_literal():
+        reveal_type(0 & True)  # revealed: Literal[0]
+        reveal_type(0 | True)  # revealed: Literal[1]
+        reveal_type(3 & True)  # revealed: Literal[1]
+        reveal_type(3 | True)  # revealed: Literal[3]
 
-    def lhs_is_fn_bool():
-        reveal_type(x() | a)  # revealed: bool
-        reveal_type(x() & a)  # revealed: bool
-        reveal_type(x() ^ a)  # revealed: bool
-
-    def rhs_is_fn_bool():
-        reveal_type(a | x())  # revealed: bool
-        reveal_type(a & x())  # revealed: bool
-        reveal_type(a ^ x())  # revealed: bool
-
-    def both_are_fn_bool():
-        reveal_type(x() | x())  # revealed: bool
-        reveal_type(x() & x())  # revealed: bool
-        reveal_type(x() ^ x())  # revealed: bool
+        reveal_type(0 & False)  # revealed: Literal[0]
+        reveal_type(0 | False)  # revealed: Literal[0]
+        reveal_type(3 & False)  # revealed: Literal[0]
+        reveal_type(3 | False)  # revealed: Literal[3]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/binary/booleans.md
+++ b/crates/ty_python_semantic/resources/mdtest/binary/booleans.md
@@ -103,3 +103,53 @@ def _(a: bool):
         reveal_type(x / y)  # revealed: int | float
         reveal_type(x % y)  # revealed: int
 ```
+
+## Bitwise operations with a variable
+
+```py
+import random
+
+def _(a: bool):
+    def lhs_is_int(x: int):
+        reveal_type(x | a)  # revealed: int
+        reveal_type(x & a)  # revealed: int
+        reveal_type(x ^ a)  # revealed: int
+
+    def rhs_is_int(x: int):
+        reveal_type(a | x)  # revealed: int
+        reveal_type(a & x)  # revealed: int
+        reveal_type(a ^ x)  # revealed: int
+
+    def lhs_is_bool(x: bool):
+        reveal_type(x | a)  # revealed: bool
+        reveal_type(x & a)  # revealed: bool
+        reveal_type(x ^ a)  # revealed: bool
+
+    def rhs_is_bool(x: bool):
+        reveal_type(a | x)  # revealed: bool
+        reveal_type(a & x)  # revealed: bool
+        reveal_type(a ^ x)  # revealed: bool
+
+    def both_are_bool(x: bool, y: bool):
+        reveal_type(x | y)  # revealed: bool
+        reveal_type(x & y)  # revealed: bool
+        reveal_type(x ^ y)  # revealed: bool
+
+    def x() -> bool:
+        return random.random() > 0.5
+
+    def lhs_is_fn_bool():
+        reveal_type(x() | a)  # revealed: bool
+        reveal_type(x() & a)  # revealed: bool
+        reveal_type(x() ^ a)  # revealed: bool
+
+    def rhs_is_fn_bool():
+        reveal_type(a | x())  # revealed: bool
+        reveal_type(a & x())  # revealed: bool
+        reveal_type(a ^ x())  # revealed: bool
+
+    def both_are_fn_bool():
+        reveal_type(x() | x())  # revealed: bool
+        reveal_type(x() & x())  # revealed: bool
+        reveal_type(x() ^ x())  # revealed: bool
+```

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -6701,54 +6701,22 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             (Type::BooleanLiteral(b1), Type::BooleanLiteral(b2), ast::Operator::BitXor) => {
                 Some(Type::BooleanLiteral(b1 ^ b2))
             }
-            (
-                Type::BooleanLiteral(b1),
-                right,
-                ast::Operator::Add
-                | ast::Operator::Sub
-                | ast::Operator::Mult
-                | ast::Operator::Mod
-                | ast::Operator::FloorDiv
-                | ast::Operator::Pow
-                | ast::Operator::Div,
-            ) => self.infer_binary_expression_type(
-                node,
-                emitted_division_by_zero_diagnostic,
-                Type::IntLiteral(i64::from(b1)),
-                right,
-                op,
-            ),
-            (
-                left,
-                Type::BooleanLiteral(b2),
-                ast::Operator::Add
-                | ast::Operator::Sub
-                | ast::Operator::Mult
-                | ast::Operator::Mod
-                | ast::Operator::FloorDiv
-                | ast::Operator::Pow
-                | ast::Operator::Div,
-            ) => self.infer_binary_expression_type(
-                node,
-                emitted_division_by_zero_diagnostic,
-                left,
-                Type::IntLiteral(i64::from(b2)),
-                op,
-            ),
-            (Type::BooleanLiteral(_), right, op) => self.infer_binary_expression_type(
-                node,
-                emitted_division_by_zero_diagnostic,
-                KnownClass::Bool.to_instance(self.db()),
-                right,
-                op,
-            ),
-            (left, Type::BooleanLiteral(_), op) => self.infer_binary_expression_type(
-                node,
-                emitted_division_by_zero_diagnostic,
-                left,
-                KnownClass::Bool.to_instance(self.db()),
-                op,
-            ),
+            (Type::BooleanLiteral(b1), Type::BooleanLiteral(_) | Type::IntLiteral(_), op) => self
+                .infer_binary_expression_type(
+                    node,
+                    emitted_division_by_zero_diagnostic,
+                    Type::IntLiteral(i64::from(b1)),
+                    right_ty,
+                    op,
+                ),
+            (Type::IntLiteral(_), Type::BooleanLiteral(b2), op) => self
+                .infer_binary_expression_type(
+                    node,
+                    emitted_division_by_zero_diagnostic,
+                    left_ty,
+                    Type::IntLiteral(i64::from(b2)),
+                    op,
+                ),
             (Type::Tuple(lhs), Type::Tuple(rhs), ast::Operator::Add) => {
                 // Note: this only works on heterogeneous tuples.
                 let lhs_elements = lhs.elements(self.db());
@@ -6767,6 +6735,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             // fall back on looking for dunder methods on one of the operand types.
             (
                 Type::FunctionLiteral(_)
+                | Type::BooleanLiteral(_)
                 | Type::Callable(..)
                 | Type::BoundMethod(_)
                 | Type::WrapperDescriptor(_)
@@ -6793,6 +6762,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 | Type::BoundSuper(_)
                 | Type::TypeVar(_),
                 Type::FunctionLiteral(_)
+                | Type::BooleanLiteral(_)
                 | Type::Callable(..)
                 | Type::BoundMethod(_)
                 | Type::WrapperDescriptor(_)


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

This PR fixes a false type inference issue specified in https://github.com/astral-sh/ty/issues/649 

If there is a better solution, I'm open to implementing that too. The current version uses the right-hand-side type when it finds a `bool & NominalInstance` pair, which is an improvement over the previous version, but I'm guessing there are bugs introduces by this too. I will keep inspecting those as I wait for the reviews.

Closes https://github.com/astral-sh/ty/issues/649 

## Test Plan

<!-- How was it tested? -->

This PR was tested through a regression test, added as an inline test to the module.
