### PR TITLE
unnecessary_dict_kwargs doc - a note on type checking benefits

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_pie/rules/unnecessary_dict_kwargs.rs
+++ b/crates/ruff_linter/src/rules/flake8_pie/rules/unnecessary_dict_kwargs.rs
@@ -16,7 +16,9 @@ use crate::{Applicability, Edit, Fix, FixAvailability, Violation};
 ///
 /// ## Why is this bad?
 /// If the `dict` keys are valid identifiers, they can be passed as keyword
-/// arguments directly.
+/// arguments directly, without constructing unnecessary dictionary.
+/// This also makes code more type-safe as type checkers often cannot
+/// precisely verify dynamic keyword arguments.
 ///
 /// ## Example
 ///
@@ -26,6 +28,9 @@ use crate::{Applicability, Edit, Fix, FixAvailability, Violation};
 ///
 ///
 /// print(foo(**{"bar": 2}))  # prints 3
+///
+/// # No typing errors, but results in an exception at runtime.
+/// print(foo(**{"bar": 2, "baz": 3}))
 /// ```
 ///
 /// Use instead:
@@ -36,6 +41,9 @@ use crate::{Applicability, Edit, Fix, FixAvailability, Violation};
 ///
 ///
 /// print(foo(bar=2))  # prints 3
+///
+/// # Typing error detected: No parameter named "baz".
+/// print(foo(bar=2, baz=3))
 /// ```
 ///
 /// ## Fix safety


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

Recently stumbled upon type checkers typically not being able to verify kwargs when they're unpacked from just constructed dictionary:

Snippet:
```python
def foo(bar: int):
    return bar + 1


print(foo(**{"bar": 2}))
# No typing errors.
print(foo(**{"bar":2, "baz":22}))
```

[pyright-play](https://pyright-play.net/?strict=true&code=CYUwZgBGD20BQCMCGAnAXBAlgOwC4Eo0BYAKAnIhRFwFcVsJkUIBqCARlK5IAcUdccGPABUIgN4AiJpIwAmAL758pPgKGw4YqTLRyANBGlIAXrLmLlQA)
[mypy-play](https://mypy-play.net/?mypy=latest&python=3.12&gist=2f8eb19089aa0bb1f7d65f69844cf4da)


And I've found that PIE804 can be helpful to highlight those cases.
Perhaps a note in PIE804 documentation can help advertise this rule as the one also enchancing type safety.

