### PR TITLE
Fix `\r` and `\r\n` handling in t- and f-string debug texts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,9 @@ crates/ruff_linter/resources/test/fixtures/pycodestyle/W605_1.py text eol=crlf
 crates/ruff_linter/resources/test/fixtures/pycodestyle/W391_2.py text eol=crlf
 crates/ruff_linter/resources/test/fixtures/pycodestyle/W391_3.py text eol=crlf
 
+crates/ruff_python_formatter/resources/test/fixtures/ruff/f-string-carriage-return-newline.py text eol=crlf
+crates/ruff_python_formatter/tests/snapshots/format@f-string-carriage-return-newline.py.snap text eol=crlf
+
 crates/ruff_python_formatter/resources/test/fixtures/ruff/docstring_code_examples_crlf.py text eol=crlf
 crates/ruff_python_formatter/tests/snapshots/format@docstring_code_examples_crlf.py.snap text eol=crlf
 

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/.editorconfig
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/.editorconfig
@@ -9,3 +9,7 @@ ij_formatter_enabled = false
 [docstring_tab_indentation.py]
 generated_code = true
 ij_formatter_enabled = false
+
+[f-string-carriage-return-newline.py]
+generated_code = true
+ij_formatter_enabled = false

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/f-string-carriage-return-newline.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/f-string-carriage-return-newline.py
@@ -1,0 +1,8 @@
+# Regression test for https://github.com/astral-sh/ruff/issues/18667
+f"{
+1=
+}"
+
+t"{
+1=
+}"

--- a/crates/ruff_python_formatter/tests/normalizer.rs
+++ b/crates/ruff_python_formatter/tests/normalizer.rs
@@ -196,6 +196,24 @@ impl Transformer for Normalizer {
         transformer::walk_expr(self, expr);
     }
 
+    fn visit_interpolated_string_element(
+        &self,
+        interpolated_string_element: &mut InterpolatedStringElement,
+    ) {
+        let InterpolatedStringElement::Interpolation(interpolation) = interpolated_string_element
+        else {
+            return;
+        };
+
+        let Some(debug) = &mut interpolation.debug_text else {
+            return;
+        };
+
+        // Changing the newlines to the configured newline is okay because Python normalizes all newlines to `\n`
+        debug.leading = debug.leading.replace("\r\n", "\n").replace('\r', "\n");
+        debug.trailing = debug.trailing.replace("\r\n", "\n").replace('\r', "\n");
+    }
+
     fn visit_string_literal(&self, string_literal: &mut ast::StringLiteral) {
         static STRIP_DOC_TESTS: LazyLock<Regex> = LazyLock::new(|| {
             Regex::new(

--- a/crates/ruff_python_formatter/tests/snapshots/format@f-string-carriage-return-newline.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@f-string-carriage-return-newline.py.snap
@@ -1,0 +1,27 @@
+---
+source: crates/ruff_python_formatter/tests/fixtures.rs
+input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/f-string-carriage-return-newline.py
+---
+## Input
+```python
+# Regression test for https://github.com/astral-sh/ruff/issues/18667
+f"{
+1=
+}"
+
+t"{
+1=
+}"
+```
+
+## Output
+```python
+# Regression test for https://github.com/astral-sh/ruff/issues/18667
+f"{
+1=
+}"
+
+t"{
+1=
+}"
+```


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ruff/issues/18667

The `Printer` only supports `\n`. We, therefore, need to normalize the newlines in debug texts during formatting. 

Normalizing the newlines doesn't change the Python semantics because Python normalizes all newlines to `\n` 



## Test Plan

Added snapshot test
