### PR TITLE
[ty] allow `T: Never` as subtype of `Never`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_compendium/never.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_compendium/never.md
@@ -5,11 +5,11 @@
 ## `Never` is a subtype of every type
 
 The `Never` type is the bottom type of Python's type system. It is a subtype of every type, but no
-type is a subtype of `Never`, except for `Never` itself.
+type is a subtype of `Never`, except for `Never` itself or type variables with upper bound `Never`.
 
 ```py
 from ty_extensions import static_assert, is_subtype_of
-from typing_extensions import Never
+from typing_extensions import Never, TypeVar
 
 class C: ...
 
@@ -19,6 +19,9 @@ static_assert(is_subtype_of(Never, C))
 static_assert(is_subtype_of(Never, Never))
 
 static_assert(not is_subtype_of(int, Never))
+
+T = TypeVar("T", bound=Never)
+static_assert(is_subtype_of(T, Never))
 ```
 
 ## `Never` is assignable to every type

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
@@ -337,8 +337,6 @@ def bounded_by_gradual[T: Any](t: T) -> None:
 
     # Bottom materialization of `T: Any` is `T: Never`
     static_assert(is_fully_static(TypeOf[bottom_materialization(T)]))
-    # TODO: This should not error, see https://github.com/astral-sh/ty/issues/638
-    # error: [static-assert-error]
     static_assert(is_subtype_of(TypeOf[bottom_materialization(T)], Never))
 
 def constrained_by_gradual[T: (int, Any)](t: T) -> None:

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1204,12 +1204,7 @@ impl<'db> Type<'db> {
 
             // `Never` is the bottom type, the empty set.
             // It is a subtype of all other fully static types.
-            // No other fully static type is a subtype of `Never`.
             (Type::Never, _) => true,
-            (Type::TypeVar(instance), Type::Never) => instance
-                .upper_bound(db)
-                .is_some_and(|bound| bound.has_relation_to(db, target, relation)),
-            (_, Type::Never) => false,
 
             // Everything is a subtype of `object`.
             (_, Type::NominalInstance(instance)) if instance.class.is_object(db) => true,
@@ -1262,6 +1257,11 @@ impl<'db> Type<'db> {
             {
                 true
             }
+
+            // `Never` is the bottom type, the empty set.
+            // Other than one unlikely edge case (TypeVars bound to `Never`),
+            // no other fully static type is a subtype of `Never`.
+            (_, Type::Never) => false,
 
             (Type::Union(union), _) => union
                 .elements(db)

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1206,6 +1206,9 @@ impl<'db> Type<'db> {
             // It is a subtype of all other fully static types.
             // No other fully static type is a subtype of `Never`.
             (Type::Never, _) => true,
+            (Type::TypeVar(instance), Type::Never) => instance
+                .upper_bound(db)
+                .is_some_and(|bound| bound.has_relation_to(db, target, relation)),
             (_, Type::Never) => false,
 
             // Everything is a subtype of `object`.


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

Hi, this is intended to resolve https://github.com/astral-sh/ty/issues/638.

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
Check `Type::has_relation_to` for the upper bound of a `TypeVarInstance` when checking the relation to `Never`.

## Test Plan

Added markdown tests.
