### PR TITLE
[`pyupgrade`] Suppress `UP008` diagnostic if `super` symbol is not builtin

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP008.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP008.py
@@ -90,3 +90,10 @@ class A:
 class B(A):
     def bar(self):
         super(__class__, self).foo()
+
+
+# see: https://github.com/astral-sh/ruff/issues/18684
+class C:
+    def f(self):
+        super = print
+        super(C, self)

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/super_call_with_parameters.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/super_call_with_parameters.rs
@@ -66,7 +66,7 @@ impl AlwaysFixableViolation for SuperCallWithParameters {
 pub(crate) fn super_call_with_parameters(checker: &Checker, call: &ast::ExprCall) {
     // Only bother going through the super check at all if we're in a `super` call.
     // (We check this in `super_args` too, so this is just an optimization.)
-    if !is_super_call_with_arguments(call) {
+    if !is_super_call_with_arguments(call, checker) {
         return;
     }
     let scope = checker.semantic().current_scope();
@@ -167,9 +167,11 @@ pub(crate) fn super_call_with_parameters(checker: &Checker, call: &ast::ExprCall
 }
 
 /// Returns `true` if a call is an argumented `super` invocation.
-fn is_super_call_with_arguments(call: &ast::ExprCall) -> bool {
+fn is_super_call_with_arguments(call: &ast::ExprCall, checker: &Checker) -> bool {
     if let Expr::Name(ast::ExprName { id, .. }) = call.func.as_ref() {
-        id == "super" && !call.arguments.is_empty()
+        id == "super"
+            && !call.arguments.is_empty()
+            && checker.semantic().match_builtin_expr(&call.func, "super")
     } else {
         false
     }

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP008.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP008.py.snap
@@ -142,3 +142,6 @@ UP008.py:92:14: UP008 [*] Use `super()` instead of `super(__class__, self)`
 91 91 |     def bar(self):
 92    |-        super(__class__, self).foo()
    92 |+        super().foo()
+93 93 | 
+94 94 | 
+95 95 | # see: https://github.com/astral-sh/ruff/issues/18684


### PR DESCRIPTION


<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

Fixes #18684
<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

Add regression test
<!-- How was it tested? -->
