### PR TITLE
[`ruff`] Fix false positives and negatives in `RUF010`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF010.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF010.py
@@ -39,16 +39,16 @@ f"{ascii(bla)}"  # OK
 # https://github.com/astral-sh/ruff/issues/16325
 f"{str({})}"
 
-f"{ascii({} | {})}"
+f"{str({} | {})}"
 
 import builtins
 
 f"{builtins.repr(1)}"
 
-f"{ascii(1)=}"
+f"{repr(1)=}"
 
-f"{ascii(lambda: 1)}"
+f"{repr(lambda: 1)}"
 
-f"{ascii(x := 2)}"
+f"{repr(x := 2)}"
 
 f"{str(object=3)}"

--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF010.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF010.py
@@ -36,5 +36,13 @@ f"{ascii(bla)}"  # OK
 )
 
 
-# OK
+# https://github.com/astral-sh/ruff/issues/16325
 f"{str({})}"
+f"{ascii({} | {})}"
+
+import builtins
+
+f"{builtins.repr(1)}"
+f"{ascii(1)=}"
+f"{ascii(lambda: 1)}"
+f"{ascii(x := 2)}"

--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF010.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF010.py
@@ -38,11 +38,15 @@ f"{ascii(bla)}"  # OK
 
 # https://github.com/astral-sh/ruff/issues/16325
 f"{str({})}"
+
 f"{ascii({} | {})}"
 
 import builtins
 
 f"{builtins.repr(1)}"
+
 f"{ascii(1)=}"
+
 f"{ascii(lambda: 1)}"
+
 f"{ascii(x := 2)}"

--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF010.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF010.py
@@ -50,3 +50,5 @@ f"{ascii(1)=}"
 f"{ascii(lambda: 1)}"
 
 f"{ascii(x := 2)}"
+
+f"{str(object=3)}"

--- a/crates/ruff_linter/src/cst/matchers.rs
+++ b/crates/ruff_linter/src/cst/matchers.rs
@@ -1,9 +1,10 @@
 use crate::fix::codemods::CodegenStylist;
 use anyhow::{Result, bail};
 use libcst_native::{
-    Arg, Attribute, Call, Comparison, CompoundStatement, Dict, Expression, FunctionDef,
-    GeneratorExp, If, Import, ImportAlias, ImportFrom, ImportNames, IndentedBlock, Lambda,
-    ListComp, Module, SmallStatement, Statement, Suite, Tuple, With,
+    Arg, Attribute, Call, Comparison, CompoundStatement, Dict, Expression, FormattedString,
+    FormattedStringContent, FormattedStringExpression, FunctionDef, GeneratorExp, If, Import,
+    ImportAlias, ImportFrom, ImportNames, IndentedBlock, Lambda, ListComp, Module, Name,
+    SmallStatement, Statement, Suite, Tuple, With,
 };
 use ruff_python_codegen::Stylist;
 
@@ -103,6 +104,14 @@ pub(crate) fn match_attribute<'a, 'b>(
     }
 }
 
+pub(crate) fn match_name<'a, 'b>(expression: &'a Expression<'b>) -> Result<&'a Name<'b>> {
+    Ok(match expression {
+        Expression::Name(name) => name,
+        Expression::Attribute(attribute) => &attribute.attr,
+        _ => bail!("Expected Expression::Name"),
+    })
+}
+
 pub(crate) fn match_arg<'a, 'b>(call: &'a Call<'b>) -> Result<&'a Arg<'b>> {
     if let Some(arg) = call.args.first() {
         Ok(arg)
@@ -142,6 +151,28 @@ pub(crate) fn match_lambda<'a, 'b>(expression: &'a Expression<'b>) -> Result<&'a
         Ok(lambda)
     } else {
         bail!("Expected Expression::Lambda")
+    }
+}
+
+pub(crate) fn match_formatted_string<'a, 'b>(
+    expression: &'a mut Expression<'b>,
+) -> Result<&'a mut FormattedString<'b>> {
+    if let Expression::FormattedString(formatted_string) = expression {
+        Ok(formatted_string)
+    } else {
+        bail!("Expected Expression::FormattedString");
+    }
+}
+
+pub(crate) fn match_formatted_string_expression<'a, 'b>(
+    formatted_string_content: &'a mut FormattedStringContent<'b>,
+) -> Result<&'a mut FormattedStringExpression<'b>> {
+    if let FormattedStringContent::Expression(formatted_string_expression) =
+        formatted_string_content
+    {
+        Ok(formatted_string_expression)
+    } else {
+        bail!("Expected FormattedStringContent::Expression")
     }
 }
 

--- a/crates/ruff_linter/src/cst/matchers.rs
+++ b/crates/ruff_linter/src/cst/matchers.rs
@@ -1,10 +1,9 @@
 use crate::fix::codemods::CodegenStylist;
 use anyhow::{Result, bail};
 use libcst_native::{
-    Arg, Attribute, Call, Comparison, CompoundStatement, Dict, Expression, FormattedString,
-    FormattedStringContent, FormattedStringExpression, FunctionDef, GeneratorExp, If, Import,
-    ImportAlias, ImportFrom, ImportNames, IndentedBlock, Lambda, ListComp, Module, Name,
-    SmallStatement, Statement, Suite, Tuple, With,
+    Arg, Attribute, Call, Comparison, CompoundStatement, Dict, Expression, FunctionDef,
+    GeneratorExp, If, Import, ImportAlias, ImportFrom, ImportNames, IndentedBlock, Lambda,
+    ListComp, Module, SmallStatement, Statement, Suite, Tuple, With,
 };
 use ruff_python_codegen::Stylist;
 
@@ -104,14 +103,6 @@ pub(crate) fn match_attribute<'a, 'b>(
     }
 }
 
-pub(crate) fn match_name<'a, 'b>(expression: &'a Expression<'b>) -> Result<&'a Name<'b>> {
-    if let Expression::Name(name) = expression {
-        Ok(name)
-    } else {
-        bail!("Expected Expression::Name")
-    }
-}
-
 pub(crate) fn match_arg<'a, 'b>(call: &'a Call<'b>) -> Result<&'a Arg<'b>> {
     if let Some(arg) = call.args.first() {
         Ok(arg)
@@ -151,28 +142,6 @@ pub(crate) fn match_lambda<'a, 'b>(expression: &'a Expression<'b>) -> Result<&'a
         Ok(lambda)
     } else {
         bail!("Expected Expression::Lambda")
-    }
-}
-
-pub(crate) fn match_formatted_string<'a, 'b>(
-    expression: &'a mut Expression<'b>,
-) -> Result<&'a mut FormattedString<'b>> {
-    if let Expression::FormattedString(formatted_string) = expression {
-        Ok(formatted_string)
-    } else {
-        bail!("Expected Expression::FormattedString");
-    }
-}
-
-pub(crate) fn match_formatted_string_expression<'a, 'b>(
-    formatted_string_content: &'a mut FormattedStringContent<'b>,
-) -> Result<&'a mut FormattedStringExpression<'b>> {
-    if let FormattedStringContent::Expression(formatted_string_expression) =
-        formatted_string_content
-    {
-        Ok(formatted_string_expression)
-    } else {
-        bail!("Expected FormattedStringContent::Expression")
     }
 }
 

--- a/crates/ruff_linter/src/cst/matchers.rs
+++ b/crates/ruff_linter/src/cst/matchers.rs
@@ -3,8 +3,8 @@ use anyhow::{Result, bail};
 use libcst_native::{
     Arg, Attribute, Call, Comparison, CompoundStatement, Dict, Expression, FormattedString,
     FormattedStringContent, FormattedStringExpression, FunctionDef, GeneratorExp, If, Import,
-    ImportAlias, ImportFrom, ImportNames, IndentedBlock, Lambda, ListComp, Module, Name,
-    SmallStatement, Statement, Suite, Tuple, With,
+    ImportAlias, ImportFrom, ImportNames, IndentedBlock, Lambda, ListComp, Module, SmallStatement,
+    Statement, Suite, Tuple, With,
 };
 use ruff_python_codegen::Stylist;
 
@@ -102,14 +102,6 @@ pub(crate) fn match_attribute<'a, 'b>(
     } else {
         bail!("Expected Expression::Attribute")
     }
-}
-
-pub(crate) fn match_name<'a, 'b>(expression: &'a Expression<'b>) -> Result<&'a Name<'b>> {
-    Ok(match expression {
-        Expression::Name(name) => name,
-        Expression::Attribute(attribute) => &attribute.attr,
-        _ => bail!("Expected Expression::Name"),
-    })
 }
 
 pub(crate) fn match_arg<'a, 'b>(call: &'a Call<'b>) -> Result<&'a Arg<'b>> {

--- a/crates/ruff_linter/src/rules/ruff/rules/explicit_f_string_type_conversion.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/explicit_f_string_type_conversion.rs
@@ -100,12 +100,15 @@ fn convert_call_to_conversion_flag(
     call: &ast::ExprCall,
     arg: &Expr,
 ) -> Result<Fix> {
-    // TODO: handle f"{𝑎𝑠𝑐𝑖𝑖(1)}", f"{str(*args)}"
     if element
         .as_interpolation()
         .is_some_and(|interpolation| interpolation.debug_text.is_some())
     {
         anyhow::bail!("Don't support fixing f-string with debug text!");
+    }
+
+    if matches!(arg, Expr::Starred(_)) {
+        anyhow::bail!("Starred expressions are not allowed in f-strings.");
     }
 
     let name = UnqualifiedName::from_expr(&call.func).unwrap();

--- a/crates/ruff_linter/src/rules/ruff/rules/explicit_f_string_type_conversion.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/explicit_f_string_type_conversion.rs
@@ -169,8 +169,8 @@ fn starts_with_brace(checker: &Checker, arg: &Expr) -> bool {
         .tokens()
         .in_range(arg.range())
         .iter()
-        // Skip the trivia tokens and the `(` from the arguments
-        .find(|token| !token.kind().is_trivia() && token.kind() != TokenKind::Lpar)
+        // Skip the trivia tokens
+        .find(|token| !token.kind().is_trivia())
         .is_some_and(|token| matches!(token.kind(), TokenKind::Lbrace))
 }
 

--- a/crates/ruff_linter/src/rules/ruff/rules/explicit_f_string_type_conversion.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/explicit_f_string_type_conversion.rs
@@ -93,7 +93,7 @@ pub(crate) fn explicit_f_string_type_conversion(checker: &Checker, f_string: &as
             }
         };
 
-        // Supress lint for starred expressions.
+        // Suppress lint for starred expressions.
         if matches!(arg, Expr::Starred(_)) {
             return;
         }

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF010_RUF010.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF010_RUF010.py.snap
@@ -252,7 +252,7 @@ RUF010.py:40:4: RUF010 [*] Use explicit conversion flag
 40 | f"{str({})}"
    |    ^^^^^^^ RUF010
 41 |
-42 | f"{ascii({} | {})}"
+42 | f"{str({} | {})}"
    |
    = help: Replace with conversion flag
 
@@ -263,8 +263,29 @@ RUF010.py:40:4: RUF010 [*] Use explicit conversion flag
 40    |-f"{str({})}"
    40 |+f"{ {}!s}"
 41 41 | 
-42 42 | f"{ascii({} | {})}"
+42 42 | f"{str({} | {})}"
 43 43 | 
+
+RUF010.py:42:4: RUF010 [*] Use explicit conversion flag
+   |
+40 | f"{str({})}"
+41 |
+42 | f"{str({} | {})}"
+   |    ^^^^^^^^^^^^ RUF010
+43 |
+44 | import builtins
+   |
+   = help: Replace with conversion flag
+
+ℹ Safe fix
+39 39 | # https://github.com/astral-sh/ruff/issues/16325
+40 40 | f"{str({})}"
+41 41 | 
+42    |-f"{str({} | {})}"
+   42 |+f"{ {} | {}!s}"
+43 43 | 
+44 44 | import builtins
+45 45 | 
 
 RUF010.py:46:4: RUF010 [*] Use explicit conversion flag
    |
@@ -273,7 +294,7 @@ RUF010.py:46:4: RUF010 [*] Use explicit conversion flag
 46 | f"{builtins.repr(1)}"
    |    ^^^^^^^^^^^^^^^^ RUF010
 47 |
-48 | f"{ascii(1)=}"
+48 | f"{repr(1)=}"
    |
    = help: Replace with conversion flag
 
@@ -284,12 +305,64 @@ RUF010.py:46:4: RUF010 [*] Use explicit conversion flag
 46    |-f"{builtins.repr(1)}"
    46 |+f"{1!r}"
 47 47 | 
-48 48 | f"{ascii(1)=}"
+48 48 | f"{repr(1)=}"
 49 49 | 
+
+RUF010.py:48:4: RUF010 Use explicit conversion flag
+   |
+46 | f"{builtins.repr(1)}"
+47 |
+48 | f"{repr(1)=}"
+   |    ^^^^^^^ RUF010
+49 |
+50 | f"{repr(lambda: 1)}"
+   |
+   = help: Replace with conversion flag
+
+RUF010.py:50:4: RUF010 [*] Use explicit conversion flag
+   |
+48 | f"{repr(1)=}"
+49 |
+50 | f"{repr(lambda: 1)}"
+   |    ^^^^^^^^^^^^^^^ RUF010
+51 |
+52 | f"{repr(x := 2)}"
+   |
+   = help: Replace with conversion flag
+
+ℹ Safe fix
+47 47 | 
+48 48 | f"{repr(1)=}"
+49 49 | 
+50    |-f"{repr(lambda: 1)}"
+   50 |+f"{(lambda: 1)!r}"
+51 51 | 
+52 52 | f"{repr(x := 2)}"
+53 53 | 
+
+RUF010.py:52:4: RUF010 [*] Use explicit conversion flag
+   |
+50 | f"{repr(lambda: 1)}"
+51 |
+52 | f"{repr(x := 2)}"
+   |    ^^^^^^^^^^^^ RUF010
+53 |
+54 | f"{str(object=3)}"
+   |
+   = help: Replace with conversion flag
+
+ℹ Safe fix
+49 49 | 
+50 50 | f"{repr(lambda: 1)}"
+51 51 | 
+52    |-f"{repr(x := 2)}"
+   52 |+f"{(x := 2)!r}"
+53 53 | 
+54 54 | f"{str(object=3)}"
 
 RUF010.py:54:4: RUF010 [*] Use explicit conversion flag
    |
-52 | f"{ascii(x := 2)}"
+52 | f"{repr(x := 2)}"
 53 |
 54 | f"{str(object=3)}"
    |    ^^^^^^^^^^^^^ RUF010
@@ -298,7 +371,7 @@ RUF010.py:54:4: RUF010 [*] Use explicit conversion flag
 
 ℹ Safe fix
 51 51 | 
-52 52 | f"{ascii(x := 2)}"
+52 52 | f"{repr(x := 2)}"
 53 53 | 
 54    |-f"{str(object=3)}"
    54 |+f"{3!s}"

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF010_RUF010.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF010_RUF010.py.snap
@@ -244,4 +244,45 @@ RUF010.py:35:20: RUF010 [*] Use explicit conversion flag
    35 |+    f" that flows {obj!r} of type {type(obj)}.{additional_message}"  # RUF010
 36 36 | )
 37 37 | 
-38 38 |
+38 38 | 
+
+RUF010.py:40:4: RUF010 [*] Use explicit conversion flag
+   |
+39 | # https://github.com/astral-sh/ruff/issues/16325
+40 | f"{str({})}"
+   |    ^^^^^^^ RUF010
+41 |
+42 | f"{ascii({} | {})}"
+   |
+   = help: Replace with conversion flag
+
+ℹ Safe fix
+37 37 | 
+38 38 | 
+39 39 | # https://github.com/astral-sh/ruff/issues/16325
+40    |-f"{str({})}"
+   40 |+f"{ {}!s}"
+41 41 | 
+42 42 | f"{ascii({} | {})}"
+43 43 | 
+
+RUF010.py:46:4: RUF010 [*] Use explicit conversion flag
+   |
+44 | import builtins
+45 |
+46 | f"{builtins.repr(1)}"
+   |    ^^^^^^^^^^^^^^^^ RUF010
+47 |
+48 | f"{ascii(1)=}"
+   |
+   = help: Replace with conversion flag
+
+ℹ Safe fix
+43 43 | 
+44 44 | import builtins
+45 45 | 
+46    |-f"{builtins.repr(1)}"
+   46 |+f"{1!r}"
+47 47 | 
+48 48 | f"{ascii(1)=}"
+49 49 |

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF010_RUF010.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF010_RUF010.py.snap
@@ -285,4 +285,20 @@ RUF010.py:46:4: RUF010 [*] Use explicit conversion flag
    46 |+f"{1!r}"
 47 47 | 
 48 48 | f"{ascii(1)=}"
-49 49 |
+49 49 | 
+
+RUF010.py:54:4: RUF010 [*] Use explicit conversion flag
+   |
+52 | f"{ascii(x := 2)}"
+53 |
+54 | f"{str(object=3)}"
+   |    ^^^^^^^^^^^^^ RUF010
+   |
+   = help: Replace with conversion flag
+
+ℹ Safe fix
+51 51 | 
+52 52 | f"{ascii(x := 2)}"
+53 53 | 
+54    |-f"{str(object=3)}"
+   54 |+f"{3!s}"


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

The fix is suppressed if the f-string has debug text or call expression arguments contains a starred expression, ex:
```python
f"{ascii(1)=}"
f"{ascii(*arg)}"
```

Fixes #16325

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

Add regression tests
<!-- How was it tested? -->
