### PR TITLE
Hug closing `}` when f-string expression has a  format specifier

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring.py
@@ -296,7 +296,7 @@ x = f"{x  !s
 x = f"{
     x!s:>{
         0
-        # comment 21
+        # comment 21-2
     }}"
 
 

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring.py
@@ -285,6 +285,13 @@ x = f"{x   =   !  s
          :>0
 
          }"
+# This is interesting. There can be a comment after the format specifier but only if it's
+# on it's own line. Refer to https://github.com/astral-sh/ruff/pull/7787 for more details.
+# We'll format is as trailing comments.
+x = f"{x  !s
+         :>0
+         # comment 21
+         }"
 
 x = f"{
     x!s:>{

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring.py
@@ -317,9 +317,17 @@ f"{  # comment 26
     # comment 28
 } woah {x}"
 
+
+f"""{foo
+      :a{
+      a # comment 29
+      # comment 30
+      }
+}"""
+
 # Regression test for https://github.com/astral-sh/ruff/issues/18672
 f"{
-    # comment 29
+    # comment 31
     foo
    :>
 }"

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring.py
@@ -242,18 +242,22 @@ f"{ # comment 15
 }"  # comment 19
 # comment 20
 
-# Single-quoted f-strings with a format specificer can be multiline
-f"aaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbb ccccccccccc {
-    variable:.3f} ddddddddddddddd eeeeeeee"
+# The specifier of an f-string must hug the closing `}` because a multiline format specifier is invalid syntax in a single
+# quoted f-string.
+f"aaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbb ccccccccccc {variable
+:.3f} ddddddddddddddd eeeeeeee"
 
-# But, if it's triple-quoted then we can't or the format specificer will have a
-# trailing newline
-f"""aaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbb ccccccccccc {
-    variable:.3f} ddddddddddddddd eeeeeeee"""
+# The same applies for triple quoted f-strings, except that we need to preserve the newline before the closing `}`.
+# or we risk altering the meaning of the f-string.
+f"""aaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbb ccccccccccc {variable
+    :.3f} ddddddddddddddd eeeeeeee"""
+f"""aaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbb ccccccccccc {variable:.3f
+} ddddddddddddddd eeeeeeee"""
 
-# But, we can break the ones which don't have a format specifier
-f"""fooooooooooooooooooo barrrrrrrrrrrrrrrrrrr {
-        xxxxxxxxxxxxxxx:.3f} aaaaaaaaaaaaaaaaa { xxxxxxxxxxxxxxxxxxxx } bbbbbbbbbbbb"""
+aaaaaaaaaaa = f"""asaaaaaaaaaaaaaaaa {
+   aaaaaaaaaaaa + bbbbbbbbbbbb + ccccccccccccccc + dddddddd
+   # comment
+   :.3f} cccccccccc"""
 
 # Throw in a random comment in it but surprise, this is not a comment but just a text
 # which is part of the format specifier
@@ -281,13 +285,13 @@ x = f"{x   =   !  s
          :>0
 
          }"
-# This is interesting. There can be a comment after the format specifier but only if it's
-# on it's own line. Refer to https://github.com/astral-sh/ruff/pull/7787 for more details.
-# We'll format is as trailing comments.
-x = f"{x  !s
-         :>0
-         # comment 21
-         }"
+
+x = f"{
+    x!s:>{
+        0
+        # comment 21
+    }}"
+
 
 x = f"""
 {              # comment 22
@@ -312,6 +316,13 @@ f"{  # comment 26
     # comment 27
     # comment 28
 } woah {x}"
+
+# Regression test for https://github.com/astral-sh/ruff/issues/18672
+f"{
+    # comment 29
+    foo
+   :>
+}"
 
 # Assignment statement
 

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/tstring.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/tstring.py
@@ -284,7 +284,12 @@ x = t"{x   =   !  s
 # This is interesting. There can be a comment after the format specifier but only if it's
 # on it's own line. Refer to https://github.com/astral-sh/ruff/pull/7787 for more details.
 # We'll format is as trailing comments.
-x = t"{
+x = t"{x  !s
+         :>0
+         # comment 21
+         }"
+
+x = f"{
     x!s:>{
         0
         # comment 21
@@ -305,14 +310,14 @@ x = t"""{"foo " +    # comment 24
         """
 
 # Mix of various features.
-t"""{  # comment 26
+t"{  # comment 26
     foo # after foo
    :>{
           x # after x
           }
     # comment 27
     # comment 28
-} woah {x}"""
+} woah {x}"
 
 # Assignment statement
 

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/tstring.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/tstring.py
@@ -240,18 +240,20 @@ t"{ # comment 15
 }"  # comment 19
 # comment 20
 
-# Single-quoted t-strings with a format specificer can be multiline
+# The specifier of a t-string must hug the closing `}` because a multiline format specifier is invalid syntax in a single
+# quoted f-string.
 t"aaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbb ccccccccccc {
-    variable:.3f} ddddddddddddddd eeeeeeee"
+    variable
+    :.3f} ddddddddddddddd eeeeeeee"
 
-# But, if it's triple-quoted then we can't or the format specificer will have a
-# trailing newline
-t"""aaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbb ccccccccccc {
-    variable:.3f} ddddddddddddddd eeeeeeee"""
+# The same applies for triple quoted t-strings, except that we need to preserve the newline before the closing `}`.
+# or we risk altering the meaning of the f-string.
+t"""aaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbb ccccccccccc {variable
+    :.3f} ddddddddddddddd eeeeeeee"""
+t"""aaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbb ccccccccccc {variable
+    :.3f
+} ddddddddddddddd eeeeeeee"""
 
-# But, we can break the ones which don't have a format specifier
-t"""fooooooooooooooooooo barrrrrrrrrrrrrrrrrrr {
-        xxxxxxxxxxxxxxx:.3f} aaaaaaaaaaaaaaaaa { xxxxxxxxxxxxxxxxxxxx } bbbbbbbbbbbb"""
 
 # Throw in a random comment in it but surprise, this is not a comment but just a text
 # which is part of the format specifier
@@ -282,10 +284,11 @@ x = t"{x   =   !  s
 # This is interesting. There can be a comment after the format specifier but only if it's
 # on it's own line. Refer to https://github.com/astral-sh/ruff/pull/7787 for more details.
 # We'll format is as trailing comments.
-x = t"{x  !s
-         :>0
-         # comment 21
-         }"
+x = t"{
+    x!s:>{
+        0
+        # comment 21
+    }}"
 
 x = t"""
 {              # comment 22
@@ -302,14 +305,14 @@ x = t"""{"foo " +    # comment 24
         """
 
 # Mix of various features.
-t"{  # comment 26
+t"""{  # comment 26
     foo # after foo
    :>{
           x # after x
           }
     # comment 27
     # comment 28
-} woah {x}"
+} woah {x}"""
 
 # Assignment statement
 

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/tstring.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/tstring.py
@@ -292,7 +292,7 @@ x = t"{x  !s
 x = f"{
     x!s:>{
         0
-        # comment 21
+        # comment 21-2
     }}"
 
 x = t"""

--- a/crates/ruff_python_formatter/src/comments/placement.rs
+++ b/crates/ruff_python_formatter/src/comments/placement.rs
@@ -321,28 +321,24 @@ fn handle_enclosed_comment<'a>(
         },
         AnyNodeRef::FString(fstring) => CommentPlacement::dangling(fstring, comment),
         AnyNodeRef::TString(tstring) => CommentPlacement::dangling(tstring, comment),
-        AnyNodeRef::InterpolatedElement(_) => {
-            // Handle comments after the format specifier (should be rare):
-            //
-            // ```python
-            // f"literal {
-            //     expr:.3f
-            //     # comment
-            // }"
-            // ```
-            //
-            // This is a valid comment placement.
-            if matches!(
-                comment.preceding_node(),
-                Some(
-                    AnyNodeRef::InterpolatedElement(_)
-                        | AnyNodeRef::InterpolatedStringLiteralElement(_)
-                )
-            ) {
-                CommentPlacement::trailing(comment.enclosing_node(), comment)
-            } else {
-                handle_bracketed_end_of_line_comment(comment, source)
+        AnyNodeRef::InterpolatedElement(element) => {
+            if let Some(preceding) = comment.preceding_node() {
+                // Own line comment before format specifier
+                // ```py
+                // aaaaaaaaaaa = f"""asaaaaaaaaaaaaaaaa {
+                //    aaaaaaaaaaaa + bbbbbbbbbbbb + ccccccccccccccc + dddddddd
+                //    # comment
+                //    :.3f} cccccccccc"""
+                // ```
+                if comment.line_position().is_own_line()
+                    && element.format_spec.is_some()
+                    && comment.following_node().is_some()
+                {
+                    return CommentPlacement::trailing(preceding, comment);
+                }
             }
+
+            handle_bracketed_end_of_line_comment(comment, source)
         }
 
         AnyNodeRef::ExprList(_)

--- a/crates/ruff_python_formatter/src/context.rs
+++ b/crates/ruff_python_formatter/src/context.rs
@@ -7,7 +7,7 @@ use ruff_python_parser::Tokens;
 
 use crate::PyFormatOptions;
 use crate::comments::Comments;
-use crate::other::interpolated_string_element::InterpolatedElementContext;
+use crate::other::interpolated_string::InterpolatedStringContext;
 
 pub struct PyFormatContext<'a> {
     options: PyFormatOptions,
@@ -143,7 +143,7 @@ pub(crate) enum InterpolatedStringState {
     /// curly brace in `f"foo {x}"`.
     ///
     /// The containing `FStringContext` is the surrounding f-string context.
-    InsideInterpolatedElement(InterpolatedElementContext),
+    InsideInterpolatedElement(InterpolatedStringContext),
     /// The formatter is outside an f-string.
     #[default]
     Outside,
@@ -153,7 +153,7 @@ impl InterpolatedStringState {
     pub(crate) fn can_contain_line_breaks(self) -> Option<bool> {
         match self {
             InterpolatedStringState::InsideInterpolatedElement(context) => {
-                Some(context.can_contain_line_breaks())
+                Some(context.is_multiline())
             }
             InterpolatedStringState::Outside => None,
         }

--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -232,14 +232,14 @@ if True:
     #[test]
     fn quick_test() {
         let source = r#"
-def main() -> None:
-    if True:
-        some_very_long_variable_name_abcdefghijk = Foo()
-        some_very_long_variable_name_abcdefghijk = some_very_long_variable_name_abcdefghijk[
-            some_very_long_variable_name_abcdefghijk.some_very_long_attribute_name
-            == "This is a very long string abcdefghijk"
-        ]
-
+# Mix of various features.
+f"{
+    foo
+    :>{
+            x # after x
+            }
+    # comment 27
+} woah {x}"
 "#;
         let source_type = PySourceType::Python;
 

--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -232,14 +232,14 @@ if True:
     #[test]
     fn quick_test() {
         let source = r#"
-# Mix of various features.
-f"{
-    foo
-    :>{
-            x # after x
-            }
-    # comment 27
-} woah {x}"
+def main() -> None:
+    if True:
+        some_very_long_variable_name_abcdefghijk = Foo()
+        some_very_long_variable_name_abcdefghijk = some_very_long_variable_name_abcdefghijk[
+            some_very_long_variable_name_abcdefghijk.some_very_long_attribute_name
+            == "This is a very long string abcdefghijk"
+        ]
+
 "#;
         let source_type = PySourceType::Python;
 

--- a/crates/ruff_python_formatter/src/other/interpolated_string.rs
+++ b/crates/ruff_python_formatter/src/other/interpolated_string.rs
@@ -21,8 +21,8 @@ impl InterpolatedStringContext {
         self.enclosing_flags
     }
 
-    pub(crate) const fn layout(self) -> InterpolatedStringLayout {
-        self.layout
+    pub(crate) const fn is_multiline(self) -> bool {
+        matches!(self.layout, InterpolatedStringLayout::Multiline)
     }
 }
 

--- a/crates/ruff_python_formatter/src/other/interpolated_string_element.rs
+++ b/crates/ruff_python_formatter/src/other/interpolated_string_element.rs
@@ -241,7 +241,6 @@ impl Format<PyFormatContext<'_>> for FormatInterpolatedElement<'_> {
 
                 if conversion.is_none() && format_spec.is_none() {
                     bracket_spacing.fmt(f)?;
-                } else if comments.has_trailing_own_line(self.element) {
                 }
 
                 Ok(())

--- a/crates/ruff_python_formatter/src/other/interpolated_string_element.rs
+++ b/crates/ruff_python_formatter/src/other/interpolated_string_element.rs
@@ -277,13 +277,11 @@ impl Format<PyFormatContext<'_>> for FormatInterpolatedElement<'_> {
                         // For strings ending with a format spec, don't add a newline between the end of the format spec
                         // and closing curly brace because that is invalid syntax for single quoted strings and
                         // the newline is preserved as part of the format spec for triple quoted strings.
-                        write!(
-                            f,
-                            [
-                                open_parenthesis_comments,
-                                indent(&format_args![soft_line_break(), item])
-                            ]
-                        )?;
+                        group(&format_args![
+                            open_parenthesis_comments,
+                            indent(&format_args![soft_line_break(), item])
+                        ])
+                        .fmt(&mut f)?;
                     }
                 } else {
                     let mut buffer = RemoveSoftLinesBuffer::new(&mut *f);

--- a/crates/ruff_python_formatter/src/other/interpolated_string_element.rs
+++ b/crates/ruff_python_formatter/src/other/interpolated_string_element.rs
@@ -241,6 +241,7 @@ impl Format<PyFormatContext<'_>> for FormatInterpolatedElement<'_> {
 
                 if conversion.is_none() && format_spec.is_none() {
                     bracket_spacing.fmt(f)?;
+                } else if comments.has_trailing_own_line(self.element) {
                 }
 
                 Ok(())
@@ -258,7 +259,15 @@ impl Format<PyFormatContext<'_>> for FormatInterpolatedElement<'_> {
                 let mut f = WithNodeLevel::new(NodeLevel::ParenthesizedExpression, f);
 
                 if self.context.is_multiline() {
-                    if format_spec.is_none() {
+                    // TODO: The `or comments.has_trailing...` can be removed once newlines in format specs are a syntax error.
+                    // This is to support the following case:
+                    // ```py
+                    // x = f"{x  !s
+                    //          :>0
+                    //          # comment 21
+                    // }"
+                    // ```
+                    if format_spec.is_none() || comments.has_trailing_own_line(self.element) {
                         group(&format_args![
                             open_parenthesis_comments,
                             soft_block_indent(&item)

--- a/crates/ruff_python_formatter/src/other/interpolated_string_element.rs
+++ b/crates/ruff_python_formatter/src/other/interpolated_string_element.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use ruff_formatter::{Buffer, FormatOptions as _, RemoveSoftLinesBuffer, format_args, write};
 use ruff_python_ast::{
     AnyStringFlags, ConversionFlag, Expr, InterpolatedElement, InterpolatedStringElement,
-    InterpolatedStringLiteralElement, StringFlags,
+    InterpolatedStringLiteralElement,
 };
 use ruff_text_size::{Ranged, TextSlice};
 
@@ -78,52 +78,10 @@ impl Format<PyFormatContext<'_>> for FormatFStringLiteralElement<'_> {
     }
 }
 
-/// Context representing an f-string expression element.
-#[derive(Clone, Copy, Debug)]
-pub(crate) struct InterpolatedElementContext {
-    /// The context of the parent f-string containing this expression element.
-    parent_context: InterpolatedStringContext,
-    /// Indicates whether this expression element has format specifier or not.
-    has_format_spec: bool,
-}
-
-impl InterpolatedElementContext {
-    /// Returns the [`InterpolatedStringContext`] containing this expression element.
-    pub(crate) fn interpolated_string(self) -> InterpolatedStringContext {
-        self.parent_context
-    }
-
-    /// Returns `true` if the expression element can contain line breaks.
-    pub(crate) fn can_contain_line_breaks(self) -> bool {
-        self.parent_context.layout().is_multiline()
-            // For a triple-quoted f-string, the element can't be formatted into multiline if it
-            // has a format specifier because otherwise the newline would be treated as part of the
-            // format specifier.
-            //
-            // Given the following f-string:
-            // ```python
-            // f"""aaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbb ccccccccccc {variable:.3f} ddddddddddddddd eeeeeeee"""
-            // ```
-            //
-            // We can't format it as:
-            // ```python
-            // f"""aaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbb ccccccccccc {
-            //     variable:.3f
-            // } ddddddddddddddd eeeeeeee"""
-            // ```
-            //
-            // Here, the format specifier string would become ".3f\n", which is not what we want.
-            // But, if the original source code already contained a newline, they'll be preserved.
-            //
-            // The Python version is irrelevant in this case.
-            && !(self.parent_context.flags().is_triple_quoted() && self.has_format_spec)
-    }
-}
-
 /// Formats an f-string expression element.
 pub(crate) struct FormatInterpolatedElement<'a> {
     element: &'a InterpolatedElement,
-    context: InterpolatedElementContext,
+    context: InterpolatedStringContext,
 }
 
 impl<'a> FormatInterpolatedElement<'a> {
@@ -131,13 +89,7 @@ impl<'a> FormatInterpolatedElement<'a> {
         element: &'a InterpolatedElement,
         context: InterpolatedStringContext,
     ) -> Self {
-        Self {
-            element,
-            context: InterpolatedElementContext {
-                parent_context: context,
-                has_format_spec: element.format_spec.is_some(),
-            },
-        }
+        Self { element, context }
     }
 }
 
@@ -150,6 +102,8 @@ impl Format<PyFormatContext<'_>> for FormatInterpolatedElement<'_> {
             format_spec,
             ..
         } = self.element;
+
+        let expression = &**expression;
 
         if let Some(debug_text) = debug_text {
             token("{").fmt(f)?;
@@ -179,7 +133,7 @@ impl Format<PyFormatContext<'_>> for FormatInterpolatedElement<'_> {
                 f,
                 [
                     NormalizedDebugText(&debug_text.leading),
-                    verbatim_text(&**expression),
+                    verbatim_text(expression),
                     NormalizedDebugText(&debug_text.trailing),
                 ]
             )?;
@@ -202,6 +156,8 @@ impl Format<PyFormatContext<'_>> for FormatInterpolatedElement<'_> {
             let comments = f.context().comments().clone();
             let dangling_item_comments = comments.dangling(self.element);
 
+            let multiline = self.context.is_multiline();
+
             // If an expression starts with a `{`, we need to add a space before the
             // curly brace to avoid turning it into a literal curly with `{{`.
             //
@@ -216,7 +172,7 @@ impl Format<PyFormatContext<'_>> for FormatInterpolatedElement<'_> {
             // added to maintain consistency.
             let bracket_spacing =
                 needs_bracket_spacing(expression, f.context()).then_some(format_with(|f| {
-                    if self.context.can_contain_line_breaks() {
+                    if multiline {
                         soft_line_break_or_space().fmt(f)
                     } else {
                         space().fmt(f)
@@ -241,29 +197,47 @@ impl Format<PyFormatContext<'_>> for FormatInterpolatedElement<'_> {
                 }
 
                 if let Some(format_spec) = format_spec.as_deref() {
+                    // ```py
+                    // f"{
+                    //     foo
+                    //     # comment 27
+                    //    :test}"
+                    // ```
+                    if comments.has_trailing_own_line(expression) {
+                        soft_line_break().fmt(f)?;
+                    }
+
                     token(":").fmt(f)?;
 
                     for element in &format_spec.elements {
-                        FormatInterpolatedStringElement::new(
-                            element,
-                            self.context.interpolated_string(),
-                        )
-                        .fmt(f)?;
+                        FormatInterpolatedStringElement::new(element, self.context).fmt(f)?;
                     }
-
-                    // These trailing comments can only occur if the format specifier is
-                    // present. For example,
-                    //
-                    // ```python
-                    // f"{
-                    //    x:.3f
-                    //    # comment
-                    // }"
-                    // ```
-                    //
-                    // Any other trailing comments are attached to the expression itself.
-                    trailing_comments(comments.trailing(self.element)).fmt(f)?;
                 }
+
+                // These trailing comments can only occur if the format specifier is
+                // present. For example,
+                //
+                // ```python
+                // f"{
+                //    x:.3f
+                //    # comment
+                // }"
+                // ```
+
+                // This can also be triggered outside of a format spec, at
+                // least until https://github.com/astral-sh/ruff/issues/18632 is a syntax error
+                // TODO(https://github.com/astral-sh/ruff/issues/18632) Remove this
+                //   and double check if it is still necessary for the triple quoted case
+                //   once this is a syntax error.
+                // ```py
+                // f"{
+                //     foo
+                //    :{x}
+                //     # comment 28
+                // } woah {x}"
+                // ```
+                // Any other trailing comments are attached to the expression itself.
+                trailing_comments(comments.trailing(self.element)).fmt(f)?;
 
                 if conversion.is_none() && format_spec.is_none() {
                     bracket_spacing.fmt(f)?;
@@ -283,12 +257,25 @@ impl Format<PyFormatContext<'_>> for FormatInterpolatedElement<'_> {
             {
                 let mut f = WithNodeLevel::new(NodeLevel::ParenthesizedExpression, f);
 
-                if self.context.can_contain_line_breaks() {
-                    group(&format_args![
-                        open_parenthesis_comments,
-                        soft_block_indent(&item)
-                    ])
-                    .fmt(&mut f)?;
+                if self.context.is_multiline() {
+                    if format_spec.is_none() {
+                        group(&format_args![
+                            open_parenthesis_comments,
+                            soft_block_indent(&item)
+                        ])
+                        .fmt(&mut f)?;
+                    } else {
+                        // For strings ending with a format spec, don't add a newline between the end of the format spec
+                        // and closing curly brace because that is invalid syntax for single quoted strings and
+                        // the newline is preserved as part of the format spec for triple quoted strings.
+                        write!(
+                            f,
+                            [
+                                open_parenthesis_comments,
+                                indent(&format_args![soft_line_break(), item])
+                            ]
+                        )?;
+                    }
                 } else {
                     let mut buffer = RemoveSoftLinesBuffer::new(&mut *f);
 

--- a/crates/ruff_python_formatter/src/string/normalize.rs
+++ b/crates/ruff_python_formatter/src/string/normalize.rs
@@ -50,7 +50,7 @@ impl<'a, 'src> StringNormalizer<'a, 'src> {
         if let InterpolatedStringState::InsideInterpolatedElement(parent_context) =
             self.context.interpolated_string_state()
         {
-            let parent_flags = parent_context.interpolated_string().flags();
+            let parent_flags = parent_context.flags();
             if !parent_flags.is_triple_quoted() || string.flags().is_triple_quoted() {
                 // This logic is even necessary when using preserve and the target python version doesn't support PEP701 because
                 // we might end up joining two f-strings that have different quote styles, in which case we need to alternate the quotes

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__pep_701.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__pep_701.py.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/ruff_python_formatter/tests/fixtures.rs
 input_file: crates/ruff_python_formatter/resources/test/fixtures/black/cases/pep_701.py
-snapshot_kind: text
 ---
 ## Input
 
@@ -170,7 +169,7 @@ rf"\{"a"}"
  
  x = """foo {{ {2 + 2}bar
  baz"""
-@@ -28,74 +26,62 @@
+@@ -28,55 +26,49 @@
  
  x = f"""foo {{ {2 + 2}bar {{ baz"""
  
@@ -233,21 +232,16 @@ rf"\{"a"}"
 +x = f"a{2 + 2:=^{foo(x + y**2):something else}one more}b"
 +f"{(abc := 10)}"
  
--f"This is a really long string, but just make sure that you reflow fstrings {
+ f"This is a really long string, but just make sure that you reflow fstrings {
 -    2+2:d
 -}"
 -f"This is a really long string, but just make sure that you reflow fstrings correctly {2+2:d}"
-+f"This is a really long string, but just make sure that you reflow fstrings {2 + 2:d}"
++    2 + 2:d}"
 +f"This is a really long string, but just make sure that you reflow fstrings correctly {2 + 2:d}"
  
  f"{2+2=}"
  f"{2+2    =    }"
- f"{     2      +     2    =    }"
- 
--f"""foo {
--    datetime.datetime.now():%Y
-+f"""foo {datetime.datetime.now():%Y
- %m
+@@ -88,14 +80,10 @@
  %d
  }"""
  
@@ -264,7 +258,7 @@ rf"\{"a"}"
  )
  
  f"`escape` only permitted in {{'html', 'latex', 'latex-math'}}, \
-@@ -105,8 +91,10 @@
+@@ -105,8 +93,10 @@
  rf"\{{\}}"
  
  f"""
@@ -277,7 +271,7 @@ rf"\{"a"}"
  """
  
  value: str = f"""foo
-@@ -124,13 +112,15 @@
+@@ -124,13 +114,15 @@
  
  f'{{\\"kind\\":\\"ConfigMap\\",\\"metadata\\":{{\\"annotations\\":{{}},\\"name\\":\\"cluster-info\\",\\"namespace\\":\\"amazon-cloudwatch\\"}}}}'
  
@@ -371,14 +365,16 @@ x = f"a{2 + 2:=^{foo(x + y**2):something else}}b"
 x = f"a{2 + 2:=^{foo(x + y**2):something else}one more}b"
 f"{(abc := 10)}"
 
-f"This is a really long string, but just make sure that you reflow fstrings {2 + 2:d}"
+f"This is a really long string, but just make sure that you reflow fstrings {
+    2 + 2:d}"
 f"This is a really long string, but just make sure that you reflow fstrings correctly {2 + 2:d}"
 
 f"{2+2=}"
 f"{2+2    =    }"
 f"{     2      +     2    =    }"
 
-f"""foo {datetime.datetime.now():%Y
+f"""foo {
+    datetime.datetime.now():%Y
 %m
 %d
 }"""

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__pep_701.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__pep_701.py.snap
@@ -169,7 +169,7 @@ rf"\{"a"}"
  
  x = """foo {{ {2 + 2}bar
  baz"""
-@@ -28,55 +26,49 @@
+@@ -28,55 +26,48 @@
  
  x = f"""foo {{ {2 + 2}bar {{ baz"""
  
@@ -232,16 +232,16 @@ rf"\{"a"}"
 +x = f"a{2 + 2:=^{foo(x + y**2):something else}one more}b"
 +f"{(abc := 10)}"
  
- f"This is a really long string, but just make sure that you reflow fstrings {
+-f"This is a really long string, but just make sure that you reflow fstrings {
 -    2+2:d
 -}"
 -f"This is a really long string, but just make sure that you reflow fstrings correctly {2+2:d}"
-+    2 + 2:d}"
++f"This is a really long string, but just make sure that you reflow fstrings {2 + 2:d}"
 +f"This is a really long string, but just make sure that you reflow fstrings correctly {2 + 2:d}"
  
  f"{2+2=}"
  f"{2+2    =    }"
-@@ -88,14 +80,10 @@
+@@ -88,14 +79,10 @@
  %d
  }"""
  
@@ -258,7 +258,7 @@ rf"\{"a"}"
  )
  
  f"`escape` only permitted in {{'html', 'latex', 'latex-math'}}, \
-@@ -105,8 +93,10 @@
+@@ -105,8 +92,10 @@
  rf"\{{\}}"
  
  f"""
@@ -271,7 +271,7 @@ rf"\{"a"}"
  """
  
  value: str = f"""foo
-@@ -124,13 +114,15 @@
+@@ -124,13 +113,15 @@
  
  f'{{\\"kind\\":\\"ConfigMap\\",\\"metadata\\":{{\\"annotations\\":{{}},\\"name\\":\\"cluster-info\\",\\"namespace\\":\\"amazon-cloudwatch\\"}}}}'
  
@@ -365,8 +365,7 @@ x = f"a{2 + 2:=^{foo(x + y**2):something else}}b"
 x = f"a{2 + 2:=^{foo(x + y**2):something else}one more}b"
 f"{(abc := 10)}"
 
-f"This is a really long string, but just make sure that you reflow fstrings {
-    2 + 2:d}"
+f"This is a really long string, but just make sure that you reflow fstrings {2 + 2:d}"
 f"This is a really long string, but just make sure that you reflow fstrings correctly {2 + 2:d}"
 
 f"{2+2=}"

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
@@ -302,7 +302,7 @@ x = f"{x  !s
 x = f"{
     x!s:>{
         0
-        # comment 21
+        # comment 21-2
     }}"
 
 
@@ -1090,7 +1090,7 @@ x = f"{
 x = f"{
     x!s:>{
         0
-        # comment 21
+        # comment 21-2
     }}"
 
 
@@ -1918,7 +1918,7 @@ x = f"{
 x = f"{
     x!s:>{
         0
-        # comment 21
+        # comment 21-2
     }}"
 
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
@@ -323,9 +323,17 @@ f"{  # comment 26
     # comment 28
 } woah {x}"
 
+
+f"""{foo
+      :a{
+      a # comment 29
+      # comment 30
+      }
+}"""
+
 # Regression test for https://github.com/astral-sh/ruff/issues/18672
 f"{
-    # comment 29
+    # comment 31
     foo
    :>
 }"
@@ -1095,9 +1103,17 @@ f"{  # comment 26
         # comment 28
     }} woah {x}"
 
+
+f"""{
+    foo:a{
+        a  # comment 29
+        # comment 30
+    }
+}"""
+
 # Regression test for https://github.com/astral-sh/ruff/issues/18672
 f"{
-    # comment 29
+    # comment 31
     foo:>}"
 
 # Assignment statement
@@ -1907,9 +1923,17 @@ f"{  # comment 26
         # comment 28
     }} woah {x}"
 
+
+f"""{
+    foo:a{
+        a  # comment 29
+        # comment 30
+    }
+}"""
+
 # Regression test for https://github.com/astral-sh/ruff/issues/18672
 f"{
-    # comment 29
+    # comment 31
     foo:>}"
 
 # Assignment statement

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
@@ -248,18 +248,22 @@ f"{ # comment 15
 }"  # comment 19
 # comment 20
 
-# Single-quoted f-strings with a format specificer can be multiline
-f"aaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbb ccccccccccc {
-    variable:.3f} ddddddddddddddd eeeeeeee"
+# The specifier of an f-string must hug the closing `}` because a multiline format specifier is invalid syntax in a single
+# quoted f-string.
+f"aaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbb ccccccccccc {variable
+:.3f} ddddddddddddddd eeeeeeee"
 
-# But, if it's triple-quoted then we can't or the format specificer will have a
-# trailing newline
-f"""aaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbb ccccccccccc {
-    variable:.3f} ddddddddddddddd eeeeeeee"""
+# The same applies for triple quoted f-strings, except that we need to preserve the newline before the closing `}`.
+# or we risk altering the meaning of the f-string.
+f"""aaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbb ccccccccccc {variable
+    :.3f} ddddddddddddddd eeeeeeee"""
+f"""aaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbb ccccccccccc {variable:.3f
+} ddddddddddddddd eeeeeeee"""
 
-# But, we can break the ones which don't have a format specifier
-f"""fooooooooooooooooooo barrrrrrrrrrrrrrrrrrr {
-        xxxxxxxxxxxxxxx:.3f} aaaaaaaaaaaaaaaaa { xxxxxxxxxxxxxxxxxxxx } bbbbbbbbbbbb"""
+aaaaaaaaaaa = f"""asaaaaaaaaaaaaaaaa {
+   aaaaaaaaaaaa + bbbbbbbbbbbb + ccccccccccccccc + dddddddd
+   # comment
+   :.3f} cccccccccc"""
 
 # Throw in a random comment in it but surprise, this is not a comment but just a text
 # which is part of the format specifier
@@ -287,13 +291,13 @@ x = f"{x   =   !  s
          :>0
 
          }"
-# This is interesting. There can be a comment after the format specifier but only if it's
-# on it's own line. Refer to https://github.com/astral-sh/ruff/pull/7787 for more details.
-# We'll format is as trailing comments.
-x = f"{x  !s
-         :>0
-         # comment 21
-         }"
+
+x = f"{
+    x!s:>{
+        0
+        # comment 21
+    }}"
+
 
 x = f"""
 {              # comment 22
@@ -318,6 +322,13 @@ f"{  # comment 26
     # comment 27
     # comment 28
 } woah {x}"
+
+# Regression test for https://github.com/astral-sh/ruff/issues/18672
+f"{
+    # comment 29
+    foo
+   :>
+}"
 
 # Assignment statement
 
@@ -1012,26 +1023,32 @@ f"{  # comment 15
 }"  # comment 19
 # comment 20
 
-# Single-quoted f-strings with a format specificer can be multiline
+# The specifier of an f-string must hug the closing `}` because a multiline format specifier is invalid syntax in a single
+# quoted f-string.
 f"aaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbb ccccccccccc {
+    variable:.3f} ddddddddddddddd eeeeeeee"
+
+# The same applies for triple quoted f-strings, except that we need to preserve the newline before the closing `}`.
+# or we risk altering the meaning of the f-string.
+f"""aaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbb ccccccccccc {
+    variable:.3f} ddddddddddddddd eeeeeeee"""
+f"""aaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbb ccccccccccc {
     variable:.3f
-} ddddddddddddddd eeeeeeee"
+} ddddddddddddddd eeeeeeee"""
 
-# But, if it's triple-quoted then we can't or the format specificer will have a
-# trailing newline
-f"""aaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbb ccccccccccc {variable:.3f} ddddddddddddddd eeeeeeee"""
-
-# But, we can break the ones which don't have a format specifier
-f"""fooooooooooooooooooo barrrrrrrrrrrrrrrrrrr {xxxxxxxxxxxxxxx:.3f} aaaaaaaaaaaaaaaaa {
-    xxxxxxxxxxxxxxxxxxxx
-} bbbbbbbbbbbb"""
+aaaaaaaaaaa = f"""asaaaaaaaaaaaaaaaa {
+    aaaaaaaaaaaa + bbbbbbbbbbbb + ccccccccccccccc + dddddddd
+    # comment
+    :.3f} cccccccccc"""
 
 # Throw in a random comment in it but surprise, this is not a comment but just a text
 # which is part of the format specifier
-aaaaaaaaaaa = f"""asaaaaaaaaaaaaaaaa {aaaaaaaaaaaa + bbbbbbbbbbbb + ccccccccccccccc + dddddddd:.3f
+aaaaaaaaaaa = f"""asaaaaaaaaaaaaaaaa {
+    aaaaaaaaaaaa + bbbbbbbbbbbb + ccccccccccccccc + dddddddd:.3f
      # comment
 } cccccccccc"""
-aaaaaaaaaaa = f"""asaaaaaaaaaaaaaaaa {aaaaaaaaaaaa + bbbbbbbbbbbb + ccccccccccccccc + dddddddd:.3f
+aaaaaaaaaaa = f"""asaaaaaaaaaaaaaaaa {
+    aaaaaaaaaaaa + bbbbbbbbbbbb + ccccccccccccccc + dddddddd:.3f
      # comment} cccccccccc"""
 
 # Conversion flags
@@ -1047,13 +1064,13 @@ x = f"aaaaaaaaa { x   = !r}"
 
 # Combine conversion flags with format specifiers
 x = f"{x   =   !s:>0}"
-# This is interesting. There can be a comment after the format specifier but only if it's
-# on it's own line. Refer to https://github.com/astral-sh/ruff/pull/7787 for more details.
-# We'll format is as trailing comments.
+
 x = f"{
-    x!s:>0
-    # comment 21
-}"
+    x!s:>{
+        0
+        # comment 21
+    }}"
+
 
 x = f"""
 {              # comment 22
@@ -1074,10 +1091,14 @@ x = f"""{
 f"{  # comment 26
     foo:>{  # after foo
         x  # after x
-    }
-    # comment 27
-    # comment 28
-} woah {x}"
+        # comment 27
+        # comment 28
+    }} woah {x}"
+
+# Regression test for https://github.com/astral-sh/ruff/issues/18672
+f"{
+    # comment 29
+    foo:>}"
 
 # Assignment statement
 
@@ -1244,10 +1265,12 @@ aaaaaaaaaaaaaaaaaa = (
 )
 
 # The newline is only considered when it's a tripled-quoted f-string.
-aaaaaaaaaaaaaaaaaa = f"""testeeeeeeeeeeeeeeeeeeeeeeeee{a:.3f
+aaaaaaaaaaaaaaaaaa = f"""testeeeeeeeeeeeeeeeeeeeeeeeee{
+    a:.3f
     }moreeeeeeeeeeeeeeeeeetest"""  # comment
 
-aaaaaaaaaaaaaaaaaa = f"""testeeeeeeeeeeeeeeeeeeeeeeeee{a:.3f
+aaaaaaaaaaaaaaaaaa = f"""testeeeeeeeeeeeeeeeeeeeeeeeee{
+    a:.3f
     }moreeeeeeeeeeeeeeeeeetest"""  # comment
 
 # Remove the parentheses here
@@ -1812,26 +1835,32 @@ f"{  # comment 15
 }"  # comment 19
 # comment 20
 
-# Single-quoted f-strings with a format specificer can be multiline
+# The specifier of an f-string must hug the closing `}` because a multiline format specifier is invalid syntax in a single
+# quoted f-string.
 f"aaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbb ccccccccccc {
+    variable:.3f} ddddddddddddddd eeeeeeee"
+
+# The same applies for triple quoted f-strings, except that we need to preserve the newline before the closing `}`.
+# or we risk altering the meaning of the f-string.
+f"""aaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbb ccccccccccc {
+    variable:.3f} ddddddddddddddd eeeeeeee"""
+f"""aaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbb ccccccccccc {
     variable:.3f
-} ddddddddddddddd eeeeeeee"
+} ddddddddddddddd eeeeeeee"""
 
-# But, if it's triple-quoted then we can't or the format specificer will have a
-# trailing newline
-f"""aaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbb ccccccccccc {variable:.3f} ddddddddddddddd eeeeeeee"""
-
-# But, we can break the ones which don't have a format specifier
-f"""fooooooooooooooooooo barrrrrrrrrrrrrrrrrrr {xxxxxxxxxxxxxxx:.3f} aaaaaaaaaaaaaaaaa {
-    xxxxxxxxxxxxxxxxxxxx
-} bbbbbbbbbbbb"""
+aaaaaaaaaaa = f"""asaaaaaaaaaaaaaaaa {
+    aaaaaaaaaaaa + bbbbbbbbbbbb + ccccccccccccccc + dddddddd
+    # comment
+    :.3f} cccccccccc"""
 
 # Throw in a random comment in it but surprise, this is not a comment but just a text
 # which is part of the format specifier
-aaaaaaaaaaa = f"""asaaaaaaaaaaaaaaaa {aaaaaaaaaaaa + bbbbbbbbbbbb + ccccccccccccccc + dddddddd:.3f
+aaaaaaaaaaa = f"""asaaaaaaaaaaaaaaaa {
+    aaaaaaaaaaaa + bbbbbbbbbbbb + ccccccccccccccc + dddddddd:.3f
      # comment
 } cccccccccc"""
-aaaaaaaaaaa = f"""asaaaaaaaaaaaaaaaa {aaaaaaaaaaaa + bbbbbbbbbbbb + ccccccccccccccc + dddddddd:.3f
+aaaaaaaaaaa = f"""asaaaaaaaaaaaaaaaa {
+    aaaaaaaaaaaa + bbbbbbbbbbbb + ccccccccccccccc + dddddddd:.3f
      # comment} cccccccccc"""
 
 # Conversion flags
@@ -1847,13 +1876,13 @@ x = f"aaaaaaaaa { x   = !r}"
 
 # Combine conversion flags with format specifiers
 x = f"{x   =   !s:>0}"
-# This is interesting. There can be a comment after the format specifier but only if it's
-# on it's own line. Refer to https://github.com/astral-sh/ruff/pull/7787 for more details.
-# We'll format is as trailing comments.
+
 x = f"{
-    x!s:>0
-    # comment 21
-}"
+    x!s:>{
+        0
+        # comment 21
+    }}"
+
 
 x = f"""
 {              # comment 22
@@ -1874,10 +1903,14 @@ x = f"""{
 f"{  # comment 26
     foo:>{  # after foo
         x  # after x
-    }
-    # comment 27
-    # comment 28
-} woah {x}"
+        # comment 27
+        # comment 28
+    }} woah {x}"
+
+# Regression test for https://github.com/astral-sh/ruff/issues/18672
+f"{
+    # comment 29
+    foo:>}"
 
 # Assignment statement
 
@@ -2044,10 +2077,12 @@ aaaaaaaaaaaaaaaaaa = (
 )
 
 # The newline is only considered when it's a tripled-quoted f-string.
-aaaaaaaaaaaaaaaaaa = f"""testeeeeeeeeeeeeeeeeeeeeeeeee{a:.3f
+aaaaaaaaaaaaaaaaaa = f"""testeeeeeeeeeeeeeeeeeeeeeeeee{
+    a:.3f
     }moreeeeeeeeeeeeeeeeeetest"""  # comment
 
-aaaaaaaaaaaaaaaaaa = f"""testeeeeeeeeeeeeeeeeeeeeeeeee{a:.3f
+aaaaaaaaaaaaaaaaaa = f"""testeeeeeeeeeeeeeeeeeeeeeeeee{
+    a:.3f
     }moreeeeeeeeeeeeeeeeeetest"""  # comment
 
 # Remove the parentheses here

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
@@ -291,6 +291,13 @@ x = f"{x   =   !  s
          :>0
 
          }"
+# This is interesting. There can be a comment after the format specifier but only if it's
+# on it's own line. Refer to https://github.com/astral-sh/ruff/pull/7787 for more details.
+# We'll format is as trailing comments.
+x = f"{x  !s
+         :>0
+         # comment 21
+         }"
 
 x = f"{
     x!s:>{
@@ -1072,6 +1079,13 @@ x = f"aaaaaaaaa { x   = !r}"
 
 # Combine conversion flags with format specifiers
 x = f"{x   =   !s:>0}"
+# This is interesting. There can be a comment after the format specifier but only if it's
+# on it's own line. Refer to https://github.com/astral-sh/ruff/pull/7787 for more details.
+# We'll format is as trailing comments.
+x = f"{
+    x!s:>0
+    # comment 21
+}"
 
 x = f"{
     x!s:>{
@@ -1099,9 +1113,10 @@ x = f"""{
 f"{  # comment 26
     foo:>{  # after foo
         x  # after x
-        # comment 27
-        # comment 28
-    }} woah {x}"
+    }
+    # comment 27
+    # comment 28
+} woah {x}"
 
 
 f"""{
@@ -1892,6 +1907,13 @@ x = f"aaaaaaaaa { x   = !r}"
 
 # Combine conversion flags with format specifiers
 x = f"{x   =   !s:>0}"
+# This is interesting. There can be a comment after the format specifier but only if it's
+# on it's own line. Refer to https://github.com/astral-sh/ruff/pull/7787 for more details.
+# We'll format is as trailing comments.
+x = f"{
+    x!s:>0
+    # comment 21
+}"
 
 x = f"{
     x!s:>{
@@ -1919,9 +1941,10 @@ x = f"""{
 f"{  # comment 26
     foo:>{  # after foo
         x  # after x
-        # comment 27
-        # comment 28
-    }} woah {x}"
+    }
+    # comment 27
+    # comment 28
+} woah {x}"
 
 
 f"""{

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__tstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__tstring.py.snap
@@ -246,18 +246,20 @@ t"{ # comment 15
 }"  # comment 19
 # comment 20
 
-# Single-quoted t-strings with a format specificer can be multiline
+# The specifier of a t-string must hug the closing `}` because a multiline format specifier is invalid syntax in a single
+# quoted f-string.
 t"aaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbb ccccccccccc {
-    variable:.3f} ddddddddddddddd eeeeeeee"
+    variable
+    :.3f} ddddddddddddddd eeeeeeee"
 
-# But, if it's triple-quoted then we can't or the format specificer will have a
-# trailing newline
-t"""aaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbb ccccccccccc {
-    variable:.3f} ddddddddddddddd eeeeeeee"""
+# The same applies for triple quoted t-strings, except that we need to preserve the newline before the closing `}`.
+# or we risk altering the meaning of the f-string.
+t"""aaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbb ccccccccccc {variable
+    :.3f} ddddddddddddddd eeeeeeee"""
+t"""aaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbb ccccccccccc {variable
+    :.3f
+} ddddddddddddddd eeeeeeee"""
 
-# But, we can break the ones which don't have a format specifier
-t"""fooooooooooooooooooo barrrrrrrrrrrrrrrrrrr {
-        xxxxxxxxxxxxxxx:.3f} aaaaaaaaaaaaaaaaa { xxxxxxxxxxxxxxxxxxxx } bbbbbbbbbbbb"""
 
 # Throw in a random comment in it but surprise, this is not a comment but just a text
 # which is part of the format specifier
@@ -288,10 +290,11 @@ x = t"{x   =   !  s
 # This is interesting. There can be a comment after the format specifier but only if it's
 # on it's own line. Refer to https://github.com/astral-sh/ruff/pull/7787 for more details.
 # We'll format is as trailing comments.
-x = t"{x  !s
-         :>0
-         # comment 21
-         }"
+x = t"{
+    x!s:>{
+        0
+        # comment 21
+    }}"
 
 x = t"""
 {              # comment 22
@@ -308,14 +311,14 @@ x = t"""{"foo " +    # comment 24
         """
 
 # Mix of various features.
-t"{  # comment 26
+t"""{  # comment 26
     foo # after foo
    :>{
           x # after x
           }
     # comment 27
     # comment 28
-} woah {x}"
+} woah {x}"""
 
 # Assignment statement
 
@@ -1008,26 +1011,28 @@ t"{  # comment 15
 }"  # comment 19
 # comment 20
 
-# Single-quoted t-strings with a format specificer can be multiline
+# The specifier of a t-string must hug the closing `}` because a multiline format specifier is invalid syntax in a single
+# quoted f-string.
 t"aaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbb ccccccccccc {
+    variable:.3f} ddddddddddddddd eeeeeeee"
+
+# The same applies for triple quoted t-strings, except that we need to preserve the newline before the closing `}`.
+# or we risk altering the meaning of the f-string.
+t"""aaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbb ccccccccccc {
+    variable:.3f} ddddddddddddddd eeeeeeee"""
+t"""aaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbb ccccccccccc {
     variable:.3f
-} ddddddddddddddd eeeeeeee"
+} ddddddddddddddd eeeeeeee"""
 
-# But, if it's triple-quoted then we can't or the format specificer will have a
-# trailing newline
-t"""aaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbb ccccccccccc {variable:.3f} ddddddddddddddd eeeeeeee"""
-
-# But, we can break the ones which don't have a format specifier
-t"""fooooooooooooooooooo barrrrrrrrrrrrrrrrrrr {xxxxxxxxxxxxxxx:.3f} aaaaaaaaaaaaaaaaa {
-    xxxxxxxxxxxxxxxxxxxx
-} bbbbbbbbbbbb"""
 
 # Throw in a random comment in it but surprise, this is not a comment but just a text
 # which is part of the format specifier
-aaaaaaaaaaa = t"""asaaaaaaaaaaaaaaaa {aaaaaaaaaaaa + bbbbbbbbbbbb + ccccccccccccccc + dddddddd:.3f
+aaaaaaaaaaa = t"""asaaaaaaaaaaaaaaaa {
+    aaaaaaaaaaaa + bbbbbbbbbbbb + ccccccccccccccc + dddddddd:.3f
      # comment
 } cccccccccc"""
-aaaaaaaaaaa = t"""asaaaaaaaaaaaaaaaa {aaaaaaaaaaaa + bbbbbbbbbbbb + ccccccccccccccc + dddddddd:.3f
+aaaaaaaaaaa = t"""asaaaaaaaaaaaaaaaa {
+    aaaaaaaaaaaa + bbbbbbbbbbbb + ccccccccccccccc + dddddddd:.3f
      # comment} cccccccccc"""
 
 # Conversion flags
@@ -1047,9 +1052,10 @@ x = t"{x   =   !s:>0}"
 # on it's own line. Refer to https://github.com/astral-sh/ruff/pull/7787 for more details.
 # We'll format is as trailing comments.
 x = t"{
-    x!s:>0
-    # comment 21
-}"
+    x!s:>{
+        0
+        # comment 21
+    }}"
 
 x = t"""
 {              # comment 22
@@ -1067,13 +1073,13 @@ x = t"""{
         """
 
 # Mix of various features.
-t"{  # comment 26
+t"""{  # comment 26
     foo:>{  # after foo
         x  # after x
     }
     # comment 27
     # comment 28
-} woah {x}"
+} woah {x}"""
 
 # Assignment statement
 
@@ -1240,10 +1246,12 @@ aaaaaaaaaaaaaaaaaa = (
 )
 
 # The newline is only considered when it's a tripled-quoted t-string.
-aaaaaaaaaaaaaaaaaa = t"""testeeeeeeeeeeeeeeeeeeeeeeeee{a:.3f
+aaaaaaaaaaaaaaaaaa = t"""testeeeeeeeeeeeeeeeeeeeeeeeee{
+    a:.3f
     }moreeeeeeeeeeeeeeeeeetest"""  # comment
 
-aaaaaaaaaaaaaaaaaa = t"""testeeeeeeeeeeeeeeeeeeeeeeeee{a:.3f
+aaaaaaaaaaaaaaaaaa = t"""testeeeeeeeeeeeeeeeeeeeeeeeee{
+    a:.3f
     }moreeeeeeeeeeeeeeeeeetest"""  # comment
 
 # Remove the parentheses here

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__tstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__tstring.py.snap
@@ -298,7 +298,7 @@ x = t"{x  !s
 x = f"{
     x!s:>{
         0
-        # comment 21
+        # comment 21-2
     }}"
 
 x = t"""
@@ -1064,7 +1064,7 @@ x = t"{
 x = f"{
     x!s:>{
         0
-        # comment 21
+        # comment 21-2
     }}"
 
 x = t"""

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__tstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__tstring.py.snap
@@ -290,7 +290,12 @@ x = t"{x   =   !  s
 # This is interesting. There can be a comment after the format specifier but only if it's
 # on it's own line. Refer to https://github.com/astral-sh/ruff/pull/7787 for more details.
 # We'll format is as trailing comments.
-x = t"{
+x = t"{x  !s
+         :>0
+         # comment 21
+         }"
+
+x = f"{
     x!s:>{
         0
         # comment 21
@@ -311,14 +316,14 @@ x = t"""{"foo " +    # comment 24
         """
 
 # Mix of various features.
-t"""{  # comment 26
+t"{  # comment 26
     foo # after foo
    :>{
           x # after x
           }
     # comment 27
     # comment 28
-} woah {x}"""
+} woah {x}"
 
 # Assignment statement
 
@@ -1052,6 +1057,11 @@ x = t"{x   =   !s:>0}"
 # on it's own line. Refer to https://github.com/astral-sh/ruff/pull/7787 for more details.
 # We'll format is as trailing comments.
 x = t"{
+    x!s:>0
+    # comment 21
+}"
+
+x = f"{
     x!s:>{
         0
         # comment 21
@@ -1073,13 +1083,13 @@ x = t"""{
         """
 
 # Mix of various features.
-t"""{  # comment 26
+t"{  # comment 26
     foo:>{  # after foo
         x  # after x
     }
     # comment 27
     # comment 28
-} woah {x}"""
+} woah {x}"
 
 # Assignment statement
 

--- a/crates/ty_python_semantic/src/python_platform.rs
+++ b/crates/ty_python_semantic/src/python_platform.rs
@@ -1,12 +1,10 @@
 use std::fmt::{Display, Formatter};
 
-use ruff_macros::RustDoc;
-
 /// The target platform to assume when resolving types.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(
     feature = "serde",
-    derive(serde::Serialize, serde::Deserialize, RustDoc),
+    derive(serde::Serialize, serde::Deserialize, ruff_macros::RustDoc),
     serde(rename_all = "kebab-case")
 )]
 pub enum PythonPlatform {


### PR DESCRIPTION
## Summary

This PR changes how we format f-string expressions with a format specifier. 

Before: 

* triple-quoted f- or t-strings with a format specifier were always formatted onto a single line
* single-quoted f- or t-strings could break over multiple lines even when they had format specifiers. The format specifier was separated by a newline + indent from the closing `}`. This is now invalid syntax under Python 3.13.4.
  ```py
  f"testeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee{
      a:.3f
  }moreeeeeeeeeeeeeeeeeetest"  
  ```

This PR changes two address the invalid syntax and make single and triple quoted strings more consisent:

* f- or t-string elements with a format specifier now hug the closing `}`. This ensures that the formatter doesn't introduce a now invalid line break after the format specifier. 
  ```py
  f"testeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee{
      a:.3f}moreeeeeeeeeeeeeeeeeetest"  
  ```
* Remove the restriction that triple-quoted f- or t-strings can't use the multiline layout if they have a format specifier. This isn't required to fix the invalid syntax BUT it fixes an issue where the formatter requires two passes to correctly format comments nested inside an interpolated format specifier:
  ```py
  f"""{foo
     :a{
       a # more
      # comment
     }
  }"""
  ```
  which before this PR gets formatted to:

  ```py
  f"""{foo:a{a}
  }"""  # more
      # comment
  ```
  which is fairly different from the source. I think making this change should be fine, if this PR makes it into the minor release tomorrow. 

I considered if we should always keep elements with a format specifier flat. However, this gets very tricky if the format specifier is already formatted over multiple lines and contains comments (see the triple-quoted case above). That's why I opted to allow them and making the behavior consistent between single and triple quoted strings.


Fixes https://github.com/astral-sh/ruff/issues/18672
Fixes https://github.com/astral-sh/ruff/issues/18632

Note, this PR doesn't change the parser / lexer

## Test Plan

Updated / added tests
