### PR TITLE
Drop confusing second `*` from glob pattern example

### DIFF
--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -353,7 +353,7 @@ pub struct Options {
         scope = "per-file-target-version",
         example = r#"
             # Override the project-wide Python version for a developer scripts directory:
-            "scripts/**.py" = "py312"
+            "scripts/*.py" = "py312"
         "#
     )]
     pub per_file_target_version: Option<FxHashMap<String, PythonVersion>>,


### PR DESCRIPTION
Summary
--

As @AlexWaygood noted on the 0.12 release blog post draft, the existing example is a bit confusing. Either `**/*.py` or just `*.py`, as I went with here, makes more sense, although the old version (`scripts/**.py`) also worked when I tested it. However, this probably shouldn't be relied upon since the [globset](https://docs.rs/globset/latest/globset/#syntax) docs say:

> Using ** anywhere else is illegal

where "anywhere else" comes after the listing of the three valid positions:
1. At the start of a pattern (`**/`)
2. At the end of a pattern (`/**`)
3. Or directly between two slashes (`/**/`)

I think the current version is luckily treated the same as a single `*`, and the default globbing settings allow it to match subdirectories such that the new example pattern will apply to the whole `scripts` tree in a project like this:

```
.
├── README.md
├── pyproject.toml
├── scripts
│   ├── matching.py
│   └── sub
│       └── nested.py
└── src
    └── main.py
```

Test Plan
--

Local testing of the new pattern, but the specifics of the pattern aren't as important as having a more intuitive-looking/correct example.