### PR TITLE
[ty] Use more parallelism when running corpus tests

### DIFF
--- a/crates/ty_python_semantic/tests/corpus.rs
+++ b/crates/ty_python_semantic/tests/corpus.rs
@@ -12,6 +12,8 @@ use ty_python_semantic::{
     SearchPathSettings, default_lint_registry,
 };
 
+use test_case::test_case;
+
 fn get_cargo_workspace_root() -> anyhow::Result<SystemPathBuf> {
     Ok(SystemPathBuf::from(String::from_utf8(
         std::process::Command::new("cargo")
@@ -39,19 +41,15 @@ fn parser_no_panic() -> anyhow::Result<()> {
     ))
 }
 
-#[test]
-fn linter_af_no_panic() -> anyhow::Result<()> {
+#[test_case("a-e")]
+#[test_case("f")]
+#[test_case("g-o")]
+#[test_case("p")]
+#[test_case("q-z")]
+fn linter_no_panic(range: &str) -> anyhow::Result<()> {
     let workspace_root = get_cargo_workspace_root()?;
     run_corpus_tests(&format!(
-        "{workspace_root}/crates/ruff_linter/resources/test/fixtures/[a-f]*/**/*.py"
-    ))
-}
-
-#[test]
-fn linter_gz_no_panic() -> anyhow::Result<()> {
-    let workspace_root = get_cargo_workspace_root()?;
-    run_corpus_tests(&format!(
-        "{workspace_root}/crates/ruff_linter/resources/test/fixtures/[g-z]*/**/*.py"
+        "{workspace_root}/crates/ruff_linter/resources/test/fixtures/[{range}]*/**/*.py"
     ))
 }
 
@@ -63,11 +61,14 @@ fn linter_stubs_no_panic() -> anyhow::Result<()> {
     ))
 }
 
-#[test]
-fn typeshed_no_panic() -> anyhow::Result<()> {
+#[test_case("a-e")]
+#[test_case("f-k")]
+#[test_case("l-p")]
+#[test_case("q-z")]
+fn typeshed_no_panic(range: &str) -> anyhow::Result<()> {
     let workspace_root = get_cargo_workspace_root()?;
     run_corpus_tests(&format!(
-        "{workspace_root}/crates/ty_vendored/vendor/typeshed/**/*.pyi"
+        "{workspace_root}/crates/ty_vendored/vendor/typeshed/stdlib/[{range}]*.pyi"
     ))
 }
 

--- a/crates/ty_python_semantic/tests/corpus.rs
+++ b/crates/ty_python_semantic/tests/corpus.rs
@@ -46,6 +46,7 @@ fn parser_no_panic() -> anyhow::Result<()> {
 #[test_case("g-o")]
 #[test_case("p")]
 #[test_case("q-z")]
+#[test_case("!a-z")]
 fn linter_no_panic(range: &str) -> anyhow::Result<()> {
     let workspace_root = get_cargo_workspace_root()?;
     run_corpus_tests(&format!(
@@ -65,6 +66,7 @@ fn linter_stubs_no_panic() -> anyhow::Result<()> {
 #[test_case("f-k")]
 #[test_case("l-p")]
 #[test_case("q-z")]
+#[test_case("!a-z")]
 fn typeshed_no_panic(range: &str) -> anyhow::Result<()> {
     let workspace_root = get_cargo_workspace_root()?;
     run_corpus_tests(&format!(


### PR DESCRIPTION
## Summary

Now that we've moved the corpus tests to the `ty_python_semantic` crate, running `cargo test -p ty_python_semantic` takes an annoying amount of time locally. (This also hasn't been helped by the fact that we run a lot more corpus tests after https://github.com/astral-sh/ruff/pull/18531.) We can speed things up quite a bit by splitting the corpus tests up more, so that they run in parallel.

## Test Plan

On `main` locally:

```
~/dev/ruff (main)⚡ % cargo test -p ty_python_semantic --test corpus              
   Compiling ty_python_semantic v0.0.0 (/Users/alexw/dev/ruff/crates/ty_python_semantic)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.81s
     Running tests/corpus.rs (target/debug/deps/corpus-1d987a322669ccb0)

running 6 tests
test corpus_no_panic ... ok
test linter_stubs_no_panic ... ok
test parser_no_panic ... ok
test linter_af_no_panic ... ok
test linter_gz_no_panic ... ok
test typeshed_no_panic ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 8.63s
```

On this PR branch locally:

```
~/dev/ruff (alex/split-corpus-tests-more)⚡ % cargo test -p ty_python_semantic --test corpus
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.08s
     Running tests/corpus.rs (target/debug/deps/corpus-1d987a322669ccb0)

running 12 tests
test corpus_no_panic ... ok
test linter_no_panic::_a_e_expects ... ok
test linter_no_panic::_g_o_expects ... ok
test linter_stubs_no_panic ... ok
test parser_no_panic ... ok
test typeshed_no_panic::_f_k_expects ... ok
test typeshed_no_panic::_l_p_expects ... ok
test typeshed_no_panic::_a_e_expects ... ok
test linter_no_panic::_q_z_expects ... ok
test typeshed_no_panic::_q_z_expects ... ok
test linter_no_panic::_p_expects ... ok
test linter_no_panic::_f_expects ... ok

test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.77s
```

I.e., a speedup of around 5s