### PR TITLE
[`flake8-logging`] Avoid false positive for `exc_info=True` outside `logger.exception` (`LOG014`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_logging/LOG014_0.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_logging/LOG014_0.py
@@ -32,6 +32,12 @@ except ...:
 
 ### No errors
 
+logging.info("", exc_info=ValueError())
+logger.info("", exc_info=ValueError())
+
+logging.info("", exc_info=(exc_type, exc_value, exc_traceback))
+logger.info("", exc_info=(exc_type, exc_value, exc_traceback))
+
 logging.info("", exc_info=a)
 logger.info("", exc_info=a)
 

--- a/crates/ruff_linter/src/rules/flake8_logging/rules/exc_info_outside_except_handler.rs
+++ b/crates/ruff_linter/src/rules/flake8_logging/rules/exc_info_outside_except_handler.rs
@@ -98,6 +98,10 @@ pub(crate) fn exc_info_outside_except_handler(checker: &Checker, call: &ExprCall
         return;
     };
 
+    if !exc_info.value.is_literal_expr() {
+        return;
+    }
+
     let truthiness = Truthiness::from_expr(&exc_info.value, |id| semantic.has_builtin_binding(id));
 
     if truthiness.into_bool() != Some(true) {


### PR DESCRIPTION

<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

Fixes https://github.com/astral-sh/ruff/issues/18726 by also checking if its a literal and not only that it is truthy.

It would have been nice to check for inheritance of BaseException but I figured that is not possible yet...

## Test Plan

I added a few tests for valid input to exc_info
