### PR TITLE
[UP008]: use `super()`, not `__super__` in error messages

### DIFF
--- a/crates/ruff_linter/src/rules/pyupgrade/rules/super_call_with_parameters.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/super_call_with_parameters.rs
@@ -58,7 +58,7 @@ impl AlwaysFixableViolation for SuperCallWithParameters {
     }
 
     fn fix_title(&self) -> String {
-        "Remove `__super__` parameters".to_string()
+        "Remove `super()` parameters".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP008.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP008.py.snap
@@ -9,7 +9,7 @@ UP008.py:17:23: UP008 [*] Use `super()` instead of `super(__class__, self)`
 18 |         super(Child, self).method  # wrong
 19 |         super(
    |
-   = help: Remove `__super__` parameters
+   = help: Remove `super()` parameters
 
 ℹ Unsafe fix
 14 14 |         Parent.super(1, 2)  # ok
@@ -30,7 +30,7 @@ UP008.py:18:14: UP008 [*] Use `super()` instead of `super(__class__, self)`
 19 |         super(
 20 |             Child,
    |
-   = help: Remove `__super__` parameters
+   = help: Remove `super()` parameters
 
 ℹ Unsafe fix
 15 15 | 
@@ -53,7 +53,7 @@ UP008.py:19:14: UP008 [*] Use `super()` instead of `super(__class__, self)`
 22 | |         ).method()  # wrong
    | |_________^ UP008
    |
-   = help: Remove `__super__` parameters
+   = help: Remove `super()` parameters
 
 ℹ Unsafe fix
 16 16 |     def wrong(self):
@@ -76,7 +76,7 @@ UP008.py:36:14: UP008 [*] Use `super()` instead of `super(__class__, self)`
    |              ^^^^^^^^^^^^^^^ UP008
 37 |         super().f()
    |
-   = help: Remove `__super__` parameters
+   = help: Remove `super()` parameters
 
 ℹ Unsafe fix
 33 33 | 
@@ -95,7 +95,7 @@ UP008.py:50:18: UP008 [*] Use `super()` instead of `super(__class__, self)`
    |                  ^^^^^^^^^^^^^^^ UP008
 51 |             super().f()
    |
-   = help: Remove `__super__` parameters
+   = help: Remove `super()` parameters
 
 ℹ Unsafe fix
 47 47 |             super(MyClass, self).f()  # CANNOT use super()
@@ -115,7 +115,7 @@ UP008.py:74:14: UP008 [*] Use `super()` instead of `super(__class__, self)`
    |              ^^^^^^^^^^^^^^^^^ UP008
 75 |         super().f()  # OK
    |
-   = help: Remove `__super__` parameters
+   = help: Remove `super()` parameters
 
 ℹ Unsafe fix
 71 71 | @dataclass
@@ -134,7 +134,7 @@ UP008.py:92:14: UP008 [*] Use `super()` instead of `super(__class__, self)`
 92 |         super(__class__, self).foo()
    |              ^^^^^^^^^^^^^^^^^ UP008
    |
-   = help: Remove `__super__` parameters
+   = help: Remove `super()` parameters
 
 ℹ Unsafe fix
 89 89 | 
@@ -153,7 +153,7 @@ UP008.py:107:23: UP008 [*] Use `super()` instead of `super(__class__, self)`
 107 |         builtins.super(C, self)
     |                       ^^^^^^^^^ UP008
     |
-    = help: Remove `__super__` parameters
+    = help: Remove `super()` parameters
 
 ℹ Unsafe fix
 104 104 | 


### PR DESCRIPTION
When I try to grep CPython with `__super__` I get 0 results:

```
(.venv) ~/Desktop/cpython  main ✔                                                    
» ag __super__ . 
                
```

That's how we can understand that the naming is not the best.