### PR TITLE
Include changelog reference for other major versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,3 +148,47 @@ The following behaviors have been stabilized:
 [`readlines-in-for`]: https://docs.astral.sh/ruff/rules/readlines-in-for
 [`subprocess-without-shell-equals-true`]: https://docs.astral.sh/ruff/rules/subprocess-without-shell-equals-true
 [`unused-noqa`]: https://docs.astral.sh/ruff/rules/unused-noqa
+
+## 0.11.x
+
+See [changelogs/0.11.x](./changelogs/0.11.x.md)
+
+## 0.10.x
+
+See [changelogs/0.10.x](./changelogs/0.10.x.md)
+
+## 0.9.x
+
+See [changelogs/0.9.x](./changelogs/0.9.x.md)
+
+## 0.8.x
+
+See [changelogs/0.8.x](./changelogs/0.8.x.md)
+
+## 0.7.x
+
+See [changelogs/0.7.x](./changelogs/0.7.x.md)
+
+## 0.6.x
+
+See [changelogs/0.6.x](./changelogs/0.6.x.md)
+
+## 0.5.x
+
+See [changelogs/0.5.x](./changelogs/0.5.x.md)
+
+## 0.4.x
+
+See [changelogs/0.4.x](./changelogs/0.4.x.md)
+
+## 0.3.x
+
+See [changelogs/0.3.x](./changelogs/0.3.x.md)
+
+## 0.2.x
+
+See [changelogs/0.2.x](./changelogs/0.2.x.md)
+
+## 0.1.x
+
+See [changelogs/0.1.x](./changelogs/0.1.x.md)


### PR DESCRIPTION
Add references to changelog files for other major versions in the main CHANGELOG.md file.