### PR TITLE
[`flake8-bugbear`] Mark autofix for `B004` as unsafe if the `hasattr` call expr contains comments

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B004.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B004.py
@@ -29,3 +29,13 @@ def this_is_fine():
     o = object()
     if callable(o):
         print("Ooh, this is actually callable.")
+
+# https://github.com/astral-sh/ruff/issues/18741
+# The autofix for this is unsafe due to the comments.
+hasattr(
+    # comment 1
+    obj,  # comment 2
+    # comment 3
+    "__call__",  # comment 4
+    # comment 5
+)

--- a/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B004_B004.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B004_B004.py.snap
@@ -85,4 +85,32 @@ B004.py:24:8: B004 [*] Using `hasattr(x, "__call__")` to test if x is callable i
    25 |+    if builtins.callable(o):
 25 26 |         print("STILL a bug!")
 26 27 | 
-27 28 |
+27 28 | 
+
+B004.py:35:1: B004 [*] Using `hasattr(x, "__call__")` to test if x is callable is unreliable. Use `callable(x)` for consistent results.
+   |
+33 |   # https://github.com/astral-sh/ruff/issues/18741
+34 |   # The autofix for this is unsafe due to the comments.
+35 | / hasattr(
+36 | |     # comment 1
+37 | |     obj,  # comment 2
+38 | |     # comment 3
+39 | |     "__call__",  # comment 4
+40 | |     # comment 5
+41 | | )
+   | |_^ B004
+   |
+   = help: Replace with `callable()`
+
+ℹ Unsafe fix
+32 32 | 
+33 33 | # https://github.com/astral-sh/ruff/issues/18741
+34 34 | # The autofix for this is unsafe due to the comments.
+35    |-hasattr(
+36    |-    # comment 1
+37    |-    obj,  # comment 2
+38    |-    # comment 3
+39    |-    "__call__",  # comment 4
+40    |-    # comment 5
+41    |-)
+   35 |+callable(obj)


### PR DESCRIPTION


<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary
Fixes #18741
<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan
Add regression test
<!-- How was it tested? -->
