### PR TITLE
[`refurb`] Fix `FURB163` autofix creating a syntax error for `yield` expressions

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/refurb/FURB163.py
+++ b/crates/ruff_linter/resources/test/fixtures/refurb/FURB163.py
@@ -43,3 +43,11 @@ log(1, math.e)
 
 math.log(1, 2.0001)
 math.log(1, 10.0001)
+
+# https://github.com/astral-sh/ruff/issues/18747
+def log():
+    yield math.log((yield), math.e)
+
+
+def log():
+    yield math.log((yield from x), math.e)

--- a/crates/ruff_linter/src/rules/refurb/rules/redundant_log_base.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/redundant_log_base.rs
@@ -141,9 +141,13 @@ fn generate_fix(checker: &Checker, call: &ast::ExprCall, base: Base, arg: &Expr)
         call.start(),
         checker.semantic(),
     )?;
-    let number = checker.locator().slice(arg);
+    let arg_str = if matches!(arg, Expr::Yield(_) | Expr::YieldFrom(_)) {
+        &format!("({})", checker.locator().slice(arg))
+    } else {
+        checker.locator().slice(arg)
+    };
     Ok(Fix::safe_edits(
-        Edit::range_replacement(format!("{binding}({number})"), call.range()),
+        Edit::range_replacement(format!("{binding}({arg_str})"), call.range()),
         [edit],
     ))
 }

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB163_FURB163.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB163_FURB163.py.snap
@@ -166,3 +166,37 @@ FURB163.py:12:1: FURB163 [*] Prefer `math.log10(1)` over `math.log` with a redun
 13 13 | 
 14 14 | # OK
 15 15 | math.log2(1)
+
+FURB163.py:49:11: FURB163 [*] Prefer `math.log(yield)` over `math.log` with a redundant base
+   |
+47 | # https://github.com/astral-sh/ruff/issues/18747
+48 | def log():
+49 |     yield math.log((yield), math.e)
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^ FURB163
+   |
+   = help: Replace with `math.log(yield)`
+
+ℹ Safe fix
+46 46 | 
+47 47 | # https://github.com/astral-sh/ruff/issues/18747
+48 48 | def log():
+49    |-    yield math.log((yield), math.e)
+   49 |+    yield math.log((yield))
+50 50 | 
+51 51 | 
+52 52 | def log():
+
+FURB163.py:53:11: FURB163 [*] Prefer `math.log(yield from x)` over `math.log` with a redundant base
+   |
+52 | def log():
+53 |     yield math.log((yield from x), math.e)
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FURB163
+   |
+   = help: Replace with `math.log(yield from x)`
+
+ℹ Safe fix
+50 50 | 
+51 51 | 
+52 52 | def log():
+53    |-    yield math.log((yield from x), math.e)
+   53 |+    yield math.log((yield from x))


### PR DESCRIPTION


<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary
Fixes #18747

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan
Add regression test
<!-- How was it tested? -->
