### PR TITLE
[ty] Install more dependencies before benchmarking hydra-zen

### DIFF
--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -434,7 +434,7 @@ fn hydra(criterion: &mut Criterion) {
             repository: "https://github.com/mit-ll-responsible-ai/hydra-zen",
             commit: "dd2b50a9614c6f8c46c5866f283c8f7e7a960aa8",
             paths: vec![SystemPath::new("src")],
-            dependencies: vec!["pydantic", "beartype", "hydra-core"],
+            dependencies: vec!["pydantic", "beartype", "hydra-core", "pytest", "hypothesis"],
             max_dep_date: "2025-06-17",
             python_version: PythonVersion::PY313,
         },


### PR DESCRIPTION
## Summary

This makes the number of `unresolved-import` diagnostics on hydra-zen go down from 136 to 16. The overall number of diagnostics goes down from 703 to 588.

That seems worth the cost of installing them considering that hydra-zen would likely have these imports installed if they were running ty in CI, and we want the benchmark to accurately mimic the experience users would have if they ran ty on these projects in CI. (In CI, gathering suggestions for an `unresolved-import` diagnostic would usually be a very cold path, for example, because there would usually be a very small number of diagnostics like this.)

## Test Plan

I:
1. Cloned [hydra-zen](https://github.com/mit-ll-responsible-ai/hydra-zen)
2. Created a virtual environment at `<hydra-zen repo root>/.venv`
3. Ran `uv pip install pydantic beartype hydra-core
4. Ran `path/to/ty/binary check` and observed that there were 136 `unresolved-import diagnostics
5. Ran `uv pip install pytest hypothesis`
6. Ran `path/to/ty/binary check` and observed that there were now only 16 `unresolved-import diagnostics
