### PR TITLE
Run ty benchmarks when `ruff_benchmark` changes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -184,6 +184,7 @@ jobs:
             ':crates/ruff_python_trivia/**' \
             ':crates/ruff_source_file/**' \
             ':crates/ruff_text_size/**' \
+            ':crates/ruff_benchmark/**' \
             ':.github/workflows/ci.yaml' \
           ; then
               echo "changed=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
I noticed that the walltime benchmarks didn't run in https://github.com/astral-sh/ruff/pull/18757