### PR TITLE
[`flake8-pytest-style`] PT001/PT023 fix makes syntax error on parenthesized decorator

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_pytest_style/PT001.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pytest_style/PT001.py
@@ -83,3 +83,13 @@ def aliased_parentheses_no_params_multiline():
     # scope="module"
 )
 def my_fixture(): ...
+
+
+@(pytest.fixture())
+def outer_paren_fixture_no_params():
+    return 42
+
+
+@(fixture())
+def outer_paren_imported_fixture_no_params():
+    return 42

--- a/crates/ruff_linter/resources/test/fixtures/flake8_pytest_style/PT023.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pytest_style/PT023.py
@@ -88,3 +88,14 @@ class TestClass:
     # ),
 )
 def test_bar(param1, param2): ...
+
+
+@(pytest.mark.foo())
+def test_outer_paren_mark_function():
+    pass
+
+
+class TestClass:
+    @(pytest.mark.foo())
+    def test_method_outer_paren():
+        pass

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/fixture.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/fixture.rs
@@ -708,7 +708,7 @@ fn pytest_fixture_parentheses(
 fn check_fixture_decorator(checker: &Checker, func_name: &str, decorator: &Decorator) {
     match &decorator.expression {
         Expr::Call(ast::ExprCall {
-            func,
+            func: _,
             arguments,
             range: _,
             node_index: _,
@@ -719,10 +719,10 @@ fn check_fixture_decorator(checker: &Checker, func_name: &str, decorator: &Decor
                     && arguments.keywords.is_empty()
                 {
                     let fix = Fix::applicable_edit(
-                        Edit::deletion(func.end(), decorator.end()),
+                        Edit::range_deletion(arguments.range()),
                         if checker
                             .comment_ranges()
-                            .intersects(TextRange::new(func.end(), decorator.end()))
+                            .intersects(arguments.range())
                         {
                             Applicability::Unsafe
                         } else {

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/fixture.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/fixture.rs
@@ -720,10 +720,7 @@ fn check_fixture_decorator(checker: &Checker, func_name: &str, decorator: &Decor
                 {
                     let fix = Fix::applicable_edit(
                         Edit::range_deletion(arguments.range()),
-                        if checker
-                            .comment_ranges()
-                            .intersects(arguments.range())
-                        {
+                        if checker.comment_ranges().intersects(arguments.range()) {
                             Applicability::Unsafe
                         } else {
                             Applicability::Safe

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/marks.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/marks.rs
@@ -2,7 +2,7 @@ use ruff_diagnostics::Applicability;
 use ruff_python_ast::{self as ast, Arguments, Decorator, Expr};
 
 use ruff_macros::{ViolationMetadata, derive_message_formats};
-use ruff_text_size::{Ranged, TextRange};
+use ruff_text_size::Ranged;
 
 use crate::checkers::ast::Checker;
 use crate::registry::Rule;

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/marks.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/marks.rs
@@ -154,26 +154,20 @@ fn pytest_mark_parentheses(
 fn check_mark_parentheses(checker: &Checker, decorator: &Decorator, marker: &str) {
     match &decorator.expression {
         Expr::Call(ast::ExprCall {
-            func,
-            arguments:
-                Arguments {
-                    args,
-                    keywords,
-                    range: _,
-                    node_index: _,
-                },
+            func: _,
+            arguments,
             range: _,
             node_index: _,
         }) => {
             if !checker.settings().flake8_pytest_style.mark_parentheses
-                && args.is_empty()
-                && keywords.is_empty()
+                && arguments.args.is_empty()
+                && arguments.keywords.is_empty()
             {
                 let fix = Fix::applicable_edit(
-                    Edit::deletion(func.end(), decorator.end()),
+                    Edit::range_deletion(arguments.range()),
                     if checker
                         .comment_ranges()
-                        .intersects(TextRange::new(func.end(), decorator.end()))
+                        .intersects(arguments.range())
                     {
                         Applicability::Unsafe
                     } else {

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/marks.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/marks.rs
@@ -165,10 +165,7 @@ fn check_mark_parentheses(checker: &Checker, decorator: &Decorator, marker: &str
             {
                 let fix = Fix::applicable_edit(
                     Edit::range_deletion(arguments.range()),
-                    if checker
-                        .comment_ranges()
-                        .intersects(arguments.range())
-                    {
+                    if checker.comment_ranges().intersects(arguments.range()) {
                         Applicability::Unsafe
                     } else {
                         Applicability::Safe

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT001_default.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT001_default.snap
@@ -149,3 +149,42 @@ PT001.py:81:1: PT001 [*] Use `@pytest.fixture` over `@pytest.fixture()`
 84    |-)
    81 |+@pytest.fixture
 85 82 | def my_fixture(): ...
+86 83 | 
+87 84 | 
+
+PT001.py:88:1: PT001 [*] Use `@pytest.fixture` over `@pytest.fixture()`
+   |
+88 | @(pytest.fixture())
+   | ^^^^^^^^^^^^^^^^^^^ PT001
+89 | def outer_paren_fixture_no_params():
+90 |     return 42
+   |
+   = help: Remove parentheses
+
+ℹ Safe fix
+85 85 | def my_fixture(): ...
+86 86 | 
+87 87 | 
+88    |-@(pytest.fixture())
+   88 |+@(pytest.fixture)
+89 89 | def outer_paren_fixture_no_params():
+90 90 |     return 42
+91 91 | 
+
+PT001.py:93:1: PT001 [*] Use `@pytest.fixture` over `@pytest.fixture()`
+   |
+93 | @(fixture())
+   | ^^^^^^^^^^^^ PT001
+94 | def outer_paren_imported_fixture_no_params():
+95 |     return 42
+   |
+   = help: Remove parentheses
+
+ℹ Safe fix
+90 90 |     return 42
+91 91 | 
+92 92 | 
+93    |-@(fixture())
+   93 |+@(fixture)
+94 94 | def outer_paren_imported_fixture_no_params():
+95 95 |     return 42

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT023_default.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT023_default.snap
@@ -130,3 +130,43 @@ PT023.py:82:1: PT023 [*] Use `@pytest.mark.parametrize` over `@pytest.mark.param
 89    |-)
    82 |+@pytest.mark.parametrize
 90 83 | def test_bar(param1, param2): ...
+91 84 | 
+92 85 | 
+
+PT023.py:93:1: PT023 [*] Use `@pytest.mark.foo` over `@pytest.mark.foo()`
+   |
+93 | @(pytest.mark.foo())
+   | ^^^^^^^^^^^^^^^^^^^^ PT023
+94 | def test_outer_paren_mark_function():
+95 |     pass
+   |
+   = help: Remove parentheses
+
+ℹ Safe fix
+90 90 | def test_bar(param1, param2): ...
+91 91 | 
+92 92 | 
+93    |-@(pytest.mark.foo())
+   93 |+@(pytest.mark.foo)
+94 94 | def test_outer_paren_mark_function():
+95 95 |     pass
+96 96 | 
+
+PT023.py:99:5: PT023 [*] Use `@pytest.mark.foo` over `@pytest.mark.foo()`
+    |
+ 98 | class TestClass:
+ 99 |     @(pytest.mark.foo())
+    |     ^^^^^^^^^^^^^^^^^^^^ PT023
+100 |     def test_method_outer_paren():
+101 |         pass
+    |
+    = help: Remove parentheses
+
+ℹ Safe fix
+96  96  | 
+97  97  | 
+98  98  | class TestClass:
+99      |-    @(pytest.mark.foo())
+    99  |+    @(pytest.mark.foo)
+100 100 |     def test_method_outer_paren():
+101 101 |         pass


### PR DESCRIPTION
Fixes https://github.com/astral-sh/ruff/issues/18771

<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

1. PT001 – `@pytest.fixture` parentheses style
- Handles alias-imported fixtures and decorators wrapped in an outer pair of parentheses (e.g. @(pytest.fixture())).
- Ensures the rule honours the `lint.flake8-pytest-style.fixture-parentheses` setting for every variant.
- Updates reference tests (`PT001.py`) and snapshots.

2. PT023 – `@pytest.mark.<marker>` parentheses style
- Extends the checker so it also flags/removes superfluous parentheses when the mark is applied to classes, nested classes, or is itself wrapped in outer parentheses.
- Keeps behaviour consistent with `lint.flake8-pytest-style.mark-parentheses`.
- Adds/updates fixture file (`PT023.py`) and snapshots.


## Test Plan

1. Unit / snapshot tests
- `cargo nextest run` (or `cargo test`) — all suites pass.
- Updated `PT001` and `PT023` snapshots reviewed and accepted via cargo insta review.

2. Manual smoke test
- Ran `ruff check` on a sample project with mixed fixture/mark styles to confirm that:
- Unnecessary parentheses are now flagged/auto-fixed in every location.
- Legitimate calls with arguments remain unaffected.