### PR TITLE
[`flake8-simplify`] Fix `SIM911` autofix creating a syntax error

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM911.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM911.py
@@ -23,3 +23,8 @@ for k, v in zip(d2.keys(), d2.values()):  # SIM911
 items = zip(x.keys(), x.values())  # OK
 
 items.bar = zip(x.keys(), x.values())  # OK
+
+
+# https://github.com/astral-sh/ruff/issues/18776
+flag_stars = {}
+for country, stars in(zip)(flag_stars.keys(), flag_stars.values()):...

--- a/crates/ruff_linter/src/rules/flake8_simplify/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/mod.rs
@@ -48,6 +48,7 @@ mod tests {
     #[test_case(Rule::IfElseBlockInsteadOfDictGet, Path::new("SIM401.py"))]
     #[test_case(Rule::SplitStaticString, Path::new("SIM905.py"))]
     #[test_case(Rule::DictGetWithNoneDefault, Path::new("SIM910.py"))]
+    #[test_case(Rule::ZipDictKeysAndValues, Path::new("SIM911.py"))]
     fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.noqa_code(), path.to_string_lossy());
         let diagnostics = test_path(

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/zip_dict_keys_and_values.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/zip_dict_keys_and_values.rs
@@ -1,6 +1,7 @@
 use ast::{ExprAttribute, ExprName, Identifier};
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_python_ast::{self as ast, Arguments, Expr};
+use ruff_python_parser::TokenKind;
 use ruff_python_semantic::analyze::typing::is_dict;
 use ruff_text_size::Ranged;
 
@@ -101,7 +102,19 @@ pub(crate) fn zip_dict_keys_and_values(checker: &Checker, expr: &ast::ExprCall) 
         return;
     }
 
-    let expected = format!("{}.items()", checker.locator().slice(var1));
+    // Check if there's a whitespace between the `in` keyword and the following expression
+    let has_whitespace = checker
+        .tokens()
+        .before(func.start())
+        .iter()
+        .rfind(|token| token.kind() == TokenKind::In)
+        .is_some_and(|token| token.start() == func.start());
+
+    let expected = if has_whitespace {
+        format!("{}.items()", checker.locator().slice(var1))
+    } else {
+        format!(" {}.items()", checker.locator().slice(var1))
+    };
     let actual = checker.locator().slice(expr);
 
     let mut diagnostic = checker.report_diagnostic(

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM911_SIM911.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM911_SIM911.py.snap
@@ -1,0 +1,75 @@
+---
+source: crates/ruff_linter/src/rules/flake8_simplify/mod.rs
+---
+SIM911.py:2:17: SIM911 [*] Use ` d.items()` instead of `zip(d.keys(), d.values())`
+  |
+1 | def foo(d: dict[str, str]) -> None:
+2 |     for k, v in zip(d.keys(), d.values()):  # SIM911
+  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM911
+3 |         ...
+  |
+  = help: Replace `zip(d.keys(), d.values())` with ` d.items()`
+
+ℹ Safe fix
+1 1 | def foo(d: dict[str, str]) -> None:
+2   |-    for k, v in zip(d.keys(), d.values()):  # SIM911
+  2 |+    for k, v in  d.items():  # SIM911
+3 3 |         ...
+4 4 | 
+5 5 |     for k, v in zip(d.keys(), d.values(), strict=True):  # SIM911
+
+SIM911.py:5:17: SIM911 [*] Use ` d.items()` instead of `zip(d.keys(), d.values(), strict=True)`
+  |
+3 |         ...
+4 |
+5 |     for k, v in zip(d.keys(), d.values(), strict=True):  # SIM911
+  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM911
+6 |         ...
+  |
+  = help: Replace `zip(d.keys(), d.values(), strict=True)` with ` d.items()`
+
+ℹ Safe fix
+2 2 |     for k, v in zip(d.keys(), d.values()):  # SIM911
+3 3 |         ...
+4 4 | 
+5   |-    for k, v in zip(d.keys(), d.values(), strict=True):  # SIM911
+  5 |+    for k, v in  d.items():  # SIM911
+6 6 |         ...
+7 7 | 
+8 8 |     for k, v in zip(d.keys(), d.values(), struct=True):  # OK
+
+SIM911.py:20:13: SIM911 [*] Use ` d2.items()` instead of `zip(d2.keys(), d2.values())`
+   |
+18 |     ...
+19 |
+20 | for k, v in zip(d2.keys(), d2.values()):  # SIM911
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM911
+21 |     ...
+   |
+   = help: Replace `zip(d2.keys(), d2.values())` with ` d2.items()`
+
+ℹ Safe fix
+17 17 | for k, v in zip(d1.items(), d2.values()):  # OK
+18 18 |     ...
+19 19 | 
+20    |-for k, v in zip(d2.keys(), d2.values()):  # SIM911
+   20 |+for k, v in  d2.items():  # SIM911
+21 21 |     ...
+22 22 | 
+23 23 | items = zip(x.keys(), x.values())  # OK
+
+SIM911.py:30:22: SIM911 [*] Use ` flag_stars.items()` instead of `(zip)(flag_stars.keys(), flag_stars.values())`
+   |
+28 | # https://github.com/astral-sh/ruff/issues/18776
+29 | flag_stars = {}
+30 | for country, stars in(zip)(flag_stars.keys(), flag_stars.values()):...
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM911
+   |
+   = help: Replace `(zip)(flag_stars.keys(), flag_stars.values())` with ` flag_stars.items()`
+
+ℹ Safe fix
+27 27 | 
+28 28 | # https://github.com/astral-sh/ruff/issues/18776
+29 29 | flag_stars = {}
+30    |-for country, stars in(zip)(flag_stars.keys(), flag_stars.values()):...
+   30 |+for country, stars in flag_stars.items():...


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary
The fix would create a syntax error if there wasn't a space between the `in` keyword and the following expression.
For example:
```python
for country, stars in(zip)(flag_stars.keys(), flag_stars.values()):...
```

I also noticed that the tests for `SIM911` were note being run, so I fixed that.

Fixes #18776

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

Add regression test
<!-- How was it tested? -->
