### PR TITLE
[pycodestyle] Add fix safety section to trailing_whitespace.rs

### DIFF
--- a/crates/ruff_linter/src/rules/pycodestyle/rules/trailing_whitespace.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/trailing_whitespace.rs
@@ -26,6 +26,11 @@ use crate::{AlwaysFixableViolation, Applicability, Edit, Fix};
 /// spam(1)\n#
 /// ```
 ///
+/// ## Fix Safety
+///
+/// This fix is marked unsafe if the whitespace is inside a multiline string,
+/// as removing it changes the string's content.
+///
 /// [PEP 8]: https://peps.python.org/pep-0008/#other-recommendations
 #[derive(ViolationMetadata)]
 pub(crate) struct TrailingWhitespace;
@@ -57,6 +62,11 @@ impl AlwaysFixableViolation for TrailingWhitespace {
 /// ```python
 /// class Foo(object):\n\n    bang = 12
 /// ```
+///
+/// ## Fix Safety
+///
+/// This fix is marked unsafe if the whitespace is inside a multiline string,
+/// as removing it changes the string's content.
 ///
 /// [PEP 8]: https://peps.python.org/pep-0008/#other-recommendations
 #[derive(ViolationMetadata)]


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Part of #15584

This PR adds fix safety sections to `W291` and `W293`

The unsafe caveat was added in #10049

https://github.com/astral-sh/ruff/blob/10a1d9f01e899201c8d37d29071fe68752d09544/crates/ruff_linter/src/rules/pycodestyle/rules/trailing_whitespace.rs#L92

Code example demonstrating unsafety:
```
PS ~\Desktop\New_folder\ruff>Get-Content issue.py
```
```py
# W291
"""
1
"""

# W293
"""

"""
```
```
PS ~\Desktop\New_folder\ruff>Get-Escaped-Content issue.py
```
```
# W291\n"""\n1 \n"""\n\n# W293\n"""\n \n"""\r\n
```
```
PS ~\Desktop\New_folder\ruff>uvx ruff check issue.py --isolated --select W
```
```snap
issue.py:3:2: W291 Trailing whitespace
  |
1 | # W291
2 | """
3 | 1
  |  ^ W291
4 | """
  |
  = help: Remove trailing whitespace

issue.py:8:1: W293 Blank line contains whitespace
  |
6 | # W293
7 | """
8 |
  | ^ W293
9 | """
  |
  = help: Remove whitespace from blank line

Found 2 errors.
No fixes available (2 hidden fixes can be enabled with the `--unsafe-fixes` option).
```

## Test Plan

<!-- How was it tested? -->

N/A, no tests affected.
