### PR TITLE
[`flake8-pie`] Add fix safety section to `PIE794`

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_pie/rules/duplicate_class_field_definition.rs
+++ b/crates/ruff_linter/src/rules/flake8_pie/rules/duplicate_class_field_definition.rs
@@ -30,6 +30,11 @@ use crate::{AlwaysFixableViolation, Fix};
 ///     name = Tom
 ///     ...
 /// ```
+///
+/// ## Fix Safety
+/// This fix is always marked as unsafe, as the class body can have arbitrary
+/// code that makes use of the re-assigned variable, and the assignemnt itself
+/// could have side-effects.
 #[derive(ViolationMetadata)]
 pub(crate) struct DuplicateClassFieldDefinition {
     name: String,


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Part of #15584

This PR adds a fix safety section to `PIE794`

I could not track down when this rule was initially implemented/made unsafe due how old it could be + multiple large refactors to `ruff`.

There is no comment/reasoning in the code given for the unsafety.

Here is a code example demonstrating why it should be unsafe, since removing any of the assignments would change program behavior [playground](https://play.ruff.rs/01004644-4259-4449-a581-5007cd59846a)
```py
class A:
    x = 1
    x = 2
    print(x)

class B:
    x = print(3)
    x = print(4)

class C:
    x = [1,2,3]
    y = x
    x = y[1]
```

## Test Plan

<!-- How was it tested? -->

N/A, no tests affected.