### PR TITLE
[`perflint`] Fix `PERF101` autofix creating a syntax error and mark autofix as unsafe if there are comments in the `list` call expr

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/perflint/PERF101.py
+++ b/crates/ruff_linter/resources/test/fixtures/perflint/PERF101.py
@@ -85,3 +85,19 @@ import builtins
 
 for i in builtins.list(nested_tuple):  # PERF101
     pass
+
+# https://github.com/astral-sh/ruff/issues/18783
+items = (1, 2, 3)
+for i in(list)(items):
+    print(i)
+
+# https://github.com/astral-sh/ruff/issues/18784
+items = (1, 2, 3)
+for i in (  # 1
+    list  # 2
+    # 3
+)(  # 4
+    items  # 5
+    # 6
+):
+    print(i)

--- a/crates/ruff_linter/src/rules/perflint/rules/unnecessary_list_cast.rs
+++ b/crates/ruff_linter/src/rules/perflint/rules/unnecessary_list_cast.rs
@@ -40,7 +40,7 @@ use crate::{AlwaysFixableViolation, Edit, Fix};
 ///
 /// ## Fix safety
 /// This rule's fix is marked as unsafe if there's comments in the
-/// `list()` call.
+/// `list()` call, as comments may be removed.
 ///
 /// For example, the fix would be marked as unsafe in the following case:
 /// ```python

--- a/crates/ruff_linter/src/rules/perflint/rules/unnecessary_list_cast.rs
+++ b/crates/ruff_linter/src/rules/perflint/rules/unnecessary_list_cast.rs
@@ -45,7 +45,7 @@ use crate::{AlwaysFixableViolation, Edit, Fix};
 /// For example, the fix would be marked as unsafe in the following case:
 /// ```python
 /// items = (1, 2, 3)
-/// for i in list( # comment
+/// for i in list(  # comment
 ///     items
 /// ):
 ///     print(i)

--- a/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__PERF101_PERF101.py.snap
+++ b/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__PERF101_PERF101.py.snap
@@ -168,7 +168,7 @@ PERF101.py:34:10: PERF101 [*] Do not cast an iterable to `list` before iterating
    |
    = help: Remove `list()` cast
 
-ℹ Safe fix
+ℹ Unsafe fix
 31 31 | ):
 32 32 |     pass
 33 33 | 
@@ -238,3 +238,56 @@ PERF101.py:86:10: PERF101 [*] Do not cast an iterable to `list` before iterating
 86    |-for i in builtins.list(nested_tuple):  # PERF101
    86 |+for i in nested_tuple:  # PERF101
 87 87 |     pass
+88 88 | 
+89 89 | # https://github.com/astral-sh/ruff/issues/18783
+
+PERF101.py:91:9: PERF101 [*] Do not cast an iterable to `list` before iterating over it
+   |
+89 | # https://github.com/astral-sh/ruff/issues/18783
+90 | items = (1, 2, 3)
+91 | for i in(list)(items):
+   |         ^^^^^^^^^^^^^ PERF101
+92 |     print(i)
+   |
+   = help: Remove `list()` cast
+
+ℹ Safe fix
+88 88 | 
+89 89 | # https://github.com/astral-sh/ruff/issues/18783
+90 90 | items = (1, 2, 3)
+91    |-for i in(list)(items):
+   91 |+for i in items:
+92 92 |     print(i)
+93 93 | 
+94 94 | # https://github.com/astral-sh/ruff/issues/18784
+
+PERF101.py:96:10: PERF101 [*] Do not cast an iterable to `list` before iterating over it
+    |
+ 94 |   # https://github.com/astral-sh/ruff/issues/18784
+ 95 |   items = (1, 2, 3)
+ 96 |   for i in (  # 1
+    |  __________^
+ 97 | |     list  # 2
+ 98 | |     # 3
+ 99 | | )(  # 4
+100 | |     items  # 5
+101 | |     # 6
+102 | | ):
+    | |_^ PERF101
+103 |       print(i)
+    |
+    = help: Remove `list()` cast
+
+ℹ Unsafe fix
+93  93  | 
+94  94  | # https://github.com/astral-sh/ruff/issues/18784
+95  95  | items = (1, 2, 3)
+96      |-for i in (  # 1
+97      |-    list  # 2
+98      |-    # 3
+99      |-)(  # 4
+100     |-    items  # 5
+101     |-    # 6
+102     |-):
+    96  |+for i in items:
+103 97  |     print(i)


### PR DESCRIPTION


<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

Fixes #18783 and #18784
<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan
Add  regression tests
<!-- How was it tested? -->
