### PR TITLE
[ty] Use `HashTable` in `PlaceTable`

### DIFF
--- a/crates/ty_python_semantic/src/semantic_index.rs
+++ b/crates/ty_python_semantic/src/semantic_index.rs
@@ -6,7 +6,7 @@ use ruff_db::parsed::parsed_module;
 use ruff_index::{IndexSlice, IndexVec};
 
 use ruff_python_parser::semantic_errors::SemanticSyntaxError;
-use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
+use rustc_hash::{FxHashMap, FxHashSet};
 use salsa::Update;
 use salsa::plumbing::AsId;
 
@@ -41,7 +41,7 @@ pub(crate) use self::use_def::{
     DeclarationWithConstraint, DeclarationsIterator,
 };
 
-type PlaceSet = hashbrown::HashMap<ScopedPlaceId, (), FxBuildHasher>;
+type PlaceSet = hashbrown::HashTable<ScopedPlaceId>;
 
 /// Returns the semantic index for `file`.
 ///


### PR DESCRIPTION
## Summary

Using `HashMap::raw_entry` is error prone. There are so many ways to hold the API wrong. 
Instead, use the new `HashTable` type that avoids those footguns. 

## Test Plan

`cargo test`
