### PR TITLE
[ty] Fix panics when pulling types for `ClassVar` or `Final` parameterized with >1 argument

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_qualifiers/classvar.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_qualifiers/classvar.md
@@ -84,13 +84,11 @@ d.a = 2
 
 ## Too many arguments
 
-<!-- pull-types:skip -->
-
 ```py
 from typing import ClassVar
 
 class C:
-    # error: [invalid-type-form] "Type qualifier `typing.ClassVar` expects exactly one type parameter"
+    # error: [invalid-type-form] "Type qualifier `typing.ClassVar` expected exactly 1 argument, got 2"
     x: ClassVar[int, str] = 1
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
@@ -45,13 +45,11 @@ reveal_type(FINAL_E)  # revealed: int
 
 ## Too many arguments
 
-<!-- pull-types:skip -->
-
 ```py
 from typing import Final
 
 class C:
-    # error: [invalid-type-form] "Type qualifier `typing.Final` expects exactly one type parameter"
+    # error: [invalid-type-form] "Type qualifier `typing.Final` expected exactly 1 argument, got 2"
     x: Final[int, str] = 1
 ```
 


### PR DESCRIPTION
## Summary

On `main` we panic if we try to "pull types" for a file that includes a parameterized `Final` or `ClassVar` with the wrong number of arguments. This can cause unpredictable crashes in the playground in the same way as the video I recorded in https://github.com/astral-sh/ruff/pull/18642#issue-3139766135

## Test Plan

Mdtests
