### PR TITLE
[`flake8-pie`] Small docs fix to `PIE794`

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_pie/rules/duplicate_class_field_definition.rs
+++ b/crates/ruff_linter/src/rules/flake8_pie/rules/duplicate_class_field_definition.rs
@@ -33,7 +33,7 @@ use crate::{AlwaysFixableViolation, Fix};
 ///
 /// ## Fix Safety
 /// This fix is always marked as unsafe since we cannot know
-//  for certain which assignment was intended.
+/// for certain which assignment was intended.
 #[derive(ViolationMetadata)]
 pub(crate) struct DuplicateClassFieldDefinition {
     name: String,


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

I noticed this since my code for finding missing safety fix sections flagged it, there is a missing `/` causing part of the new changes to be a normal comment instead of a doc comment

## Test Plan

<!-- How was it tested? -->

N/A, no functionality/tests affected