### PR TITLE
Docs normalization

### DIFF
--- a/crates/ruff_linter/src/rules/fastapi/rules/fastapi_redundant_response_model.rs
+++ b/crates/ruff_linter/src/rules/fastapi/rules/fastapi_redundant_response_model.rs
@@ -58,7 +58,6 @@ use crate::{AlwaysFixableViolation, Fix};
 /// async def create_item(item: Item) -> Item:
 ///     return item
 /// ```
-
 #[derive(ViolationMetadata)]
 pub(crate) struct FastApiRedundantResponseModel;
 

--- a/crates/ruff_linter/src/rules/flake8_builtins/rules/builtin_import_shadowing.rs
+++ b/crates/ruff_linter/src/rules/flake8_builtins/rules/builtin_import_shadowing.rs
@@ -40,7 +40,6 @@ use crate::rules::flake8_builtins::helpers::shadows_builtin;
 /// ## Options
 /// - `lint.flake8-builtins.ignorelist`
 /// - `target-version`
-///
 #[derive(ViolationMetadata)]
 pub(crate) struct BuiltinImportShadowing {
     name: String,

--- a/crates/ruff_linter/src/rules/flake8_pie/rules/duplicate_class_field_definition.rs
+++ b/crates/ruff_linter/src/rules/flake8_pie/rules/duplicate_class_field_definition.rs
@@ -31,7 +31,7 @@ use crate::{AlwaysFixableViolation, Fix};
 ///     ...
 /// ```
 ///
-/// ## Fix Safety
+/// ## Fix safety
 /// This fix is always marked as unsafe since we cannot know
 //  for certain which assignment was intended.
 #[derive(ViolationMetadata)]

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/custom_type_var_for_self.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/custom_type_var_for_self.rs
@@ -53,7 +53,7 @@ use crate::{Applicability, Edit, Fix, FixAvailability, Violation};
 ///     def bar(cls, arg: int) -> Self: ...
 /// ```
 ///
-/// ## Fix Behaviour
+/// ## Fix behaviour
 /// The fix replaces all references to the custom type variable in the method's header and body
 /// with references to `Self`. The fix also adds an import of `Self` if neither `Self` nor `typing`
 /// is already imported in the module. If your [`target-version`] setting is set to Python 3.11 or

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/custom_type_var_for_self.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/custom_type_var_for_self.rs
@@ -53,7 +53,7 @@ use crate::{Applicability, Edit, Fix, FixAvailability, Violation};
 ///     def bar(cls, arg: int) -> Self: ...
 /// ```
 ///
-/// ## Fix behaviour and safety
+/// ## Fix Behaviour
 /// The fix replaces all references to the custom type variable in the method's header and body
 /// with references to `Self`. The fix also adds an import of `Self` if neither `Self` nor `typing`
 /// is already imported in the module. If your [`target-version`] setting is set to Python 3.11 or
@@ -67,6 +67,7 @@ use crate::{Applicability, Edit, Fix, FixAvailability, Violation};
 /// [`unused-private-type-var`][PYI018] for a rule that will clean up unused private type
 /// variables.
 ///
+/// # Fix Safety
 /// The fix is only marked as unsafe if there is the possibility that it might delete a comment
 /// from your code.
 ///

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/custom_type_var_for_self.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/custom_type_var_for_self.rs
@@ -67,7 +67,7 @@ use crate::{Applicability, Edit, Fix, FixAvailability, Violation};
 /// [`unused-private-type-var`][PYI018] for a rule that will clean up unused private type
 /// variables.
 ///
-/// # Fix safety
+/// ## Fix safety
 /// The fix is only marked as unsafe if there is the possibility that it might delete a comment
 /// from your code.
 ///

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/custom_type_var_for_self.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/custom_type_var_for_self.rs
@@ -67,7 +67,7 @@ use crate::{Applicability, Edit, Fix, FixAvailability, Violation};
 /// [`unused-private-type-var`][PYI018] for a rule that will clean up unused private type
 /// variables.
 ///
-/// # Fix Safety
+/// # Fix safety
 /// The fix is only marked as unsafe if there is the possibility that it might delete a comment
 /// from your code.
 ///

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/assertion.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/assertion.rs
@@ -187,7 +187,6 @@ impl Violation for PytestAssertAlwaysFalse {
 ///
 /// ## References
 /// - [`pytest` documentation: Assertion introspection details](https://docs.pytest.org/en/7.1.x/how-to/assert.html#assertion-introspection-details)
-
 #[derive(ViolationMetadata)]
 pub(crate) struct PytestUnittestAssertion {
     assertion: String,

--- a/crates/ruff_linter/src/rules/flake8_return/rules/function.rs
+++ b/crates/ruff_linter/src/rules/flake8_return/rules/function.rs
@@ -55,7 +55,6 @@ use super::super::visitor::{ReturnVisitor, Stack};
 /// ## Fix safety
 /// This rule's fix is marked as unsafe for cases in which comments would be
 /// dropped from the `return` statement.
-///
 #[derive(ViolationMetadata)]
 pub(crate) struct UnnecessaryReturnNone;
 

--- a/crates/ruff_linter/src/rules/flake8_return/rules/function.rs
+++ b/crates/ruff_linter/src/rules/flake8_return/rules/function.rs
@@ -52,7 +52,7 @@ use super::super::visitor::{ReturnVisitor, Stack};
 ///     return
 /// ```
 ///
-/// ## Fix Safety
+/// ## Fix safety
 /// This rule's fix is marked as unsafe for cases in which comments would be
 /// dropped from the `return` statement.
 ///

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_with.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_with.rs
@@ -45,7 +45,7 @@ use crate::{FixAvailability, Violation};
 ///     pass
 /// ```
 ///
-/// # Fix safety
+/// ## Fix safety
 ///
 /// This fix is marked as always unsafe unless [preview] mode is enabled, in which case it is always
 /// marked as safe. Note that the fix is unavailable if it would remove comments (in either case).

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
@@ -34,7 +34,7 @@ use crate::{Edit, Fix, FixAvailability, Violation};
 /// return any(predicate(item) for item in iterable)
 /// ```
 ///
-/// # Fix safety
+/// ## Fix safety
 ///
 /// This fix is always marked as unsafe because it might remove comments.
 ///

--- a/crates/ruff_linter/src/rules/flynt/rules/static_join_to_fstring.rs
+++ b/crates/ruff_linter/src/rules/flynt/rules/static_join_to_fstring.rs
@@ -28,7 +28,7 @@ use crate::rules::flynt::helpers;
 /// f"{foo} {bar}"
 /// ```
 ///
-/// # Fix safety
+/// ## Fix safety
 /// The fix is always marked unsafe because the evaluation of the f-string
 /// expressions will default to calling the `__format__` method of each
 /// object, whereas `str.join` expects each object to be an instance of

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/ambiguous_variable_name.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/ambiguous_variable_name.rs
@@ -32,7 +32,6 @@ use crate::rules::pycodestyle::helpers::is_ambiguous_name;
 /// o = 123
 /// i = 42
 /// ```
-///
 #[derive(ViolationMetadata)]
 pub(crate) struct AmbiguousVariableName(pub String);
 

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/trailing_whitespace.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/trailing_whitespace.rs
@@ -62,7 +62,7 @@ impl AlwaysFixableViolation for TrailingWhitespace {
 /// class Foo(object):\n\n    bang = 12
 /// ```
 ///
-/// ## Fix Safety
+/// ## Fix safety
 ///
 /// This fix is marked unsafe if the whitespace is inside a multiline string,
 /// as removing it changes the string's content.

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/trailing_whitespace.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/trailing_whitespace.rs
@@ -25,7 +25,7 @@ use crate::{AlwaysFixableViolation, Applicability, Edit, Fix};
 /// spam(1)\n#
 /// ```
 ///
-/// ## Fix Safety
+/// ## Fix safety
 ///
 /// This fix is marked unsafe if the whitespace is inside a multiline string,
 /// as removing it changes the string's content.

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/whitespace_after_decorator.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/whitespace_after_decorator.rs
@@ -29,7 +29,6 @@ use crate::{AlwaysFixableViolation, Edit, Fix};
 /// ```
 ///
 /// [PEP 8]: https://peps.python.org/pep-0008/#maximum-line-length
-
 #[derive(ViolationMetadata)]
 pub(crate) struct WhitespaceAfterDecorator;
 

--- a/crates/ruff_linter/src/rules/pylint/rules/dict_index_missing_items.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/dict_index_missing_items.rs
@@ -45,7 +45,6 @@ use crate::checkers::ast::Checker;
 /// for instrument, section in ORCHESTRA.items():
 ///     print(f"{instrument}: {section}")
 /// ```
-
 #[derive(ViolationMetadata)]
 pub(crate) struct DictIndexMissingItems;
 

--- a/crates/ruff_linter/src/rules/pylint/rules/missing_maxsplit_arg.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/missing_maxsplit_arg.rs
@@ -29,7 +29,6 @@ use crate::checkers::ast::Checker;
 /// url = "www.example.com"
 /// prefix = url.split(".", maxsplit=1)[0]
 /// ```
-
 #[derive(ViolationMetadata)]
 pub(crate) struct MissingMaxsplitArg;
 

--- a/crates/ruff_linter/src/rules/pylint/rules/nan_comparison.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/nan_comparison.rs
@@ -32,7 +32,6 @@ use crate::linter::float::as_nan_float_string_literal;
 /// if math.isnan(x):
 ///     pass
 /// ```
-///
 #[derive(ViolationMetadata)]
 pub(crate) struct NanComparison {
     nan: Nan,

--- a/crates/ruff_linter/src/rules/pylint/rules/redeclared_assigned_name.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/redeclared_assigned_name.rs
@@ -27,7 +27,6 @@ use crate::checkers::ast::Checker;
 /// _, b, a = (1, 2, 3)
 /// print(a)  # 3
 /// ```
-///
 #[derive(ViolationMetadata)]
 pub(crate) struct RedeclaredAssignedName {
     name: String,

--- a/crates/ruff_linter/src/rules/pylint/rules/redefined_argument_from_local.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/redefined_argument_from_local.rs
@@ -29,7 +29,6 @@ use crate::Violation;
 ///
 /// ## References
 /// - [Pylint documentation](https://pylint.readthedocs.io/en/latest/user_guide/messages/refactor/redefined-argument-from-local.html)
-
 #[derive(ViolationMetadata)]
 pub(crate) struct RedefinedArgumentFromLocal {
     pub(crate) name: String,

--- a/crates/ruff_linter/src/rules/pylint/rules/unnecessary_dunder_call.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/unnecessary_dunder_call.rs
@@ -62,7 +62,6 @@ use ruff_python_ast::PythonVersion;
 /// def is_greater_than_two(x: int) -> bool:
 ///     return x > 2
 /// ```
-///
 #[derive(ViolationMetadata)]
 pub(crate) struct UnnecessaryDunderCall {
     method: String,

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/replace_str_enum.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/replace_str_enum.rs
@@ -76,7 +76,6 @@ use crate::{Edit, Fix, FixAvailability, Violation};
 /// - [enum.StrEnum](https://docs.python.org/3/library/enum.html#enum.StrEnum)
 ///
 /// [breaking change]: https://blog.pecar.me/python-enum
-
 #[derive(ViolationMetadata)]
 pub(crate) struct ReplaceStrEnum {
     name: String,

--- a/crates/ruff_linter/src/rules/refurb/rules/implicit_cwd.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/implicit_cwd.rs
@@ -24,7 +24,6 @@ use crate::{checkers::ast::Checker, importer::ImportRequest};
 ///
 /// ## References
 /// - [Python documentation: `Path.cwd`](https://docs.python.org/3/library/pathlib.html#pathlib.Path.cwd)
-
 #[derive(ViolationMetadata)]
 pub(crate) struct ImplicitCwd;
 

--- a/crates/ruff_linter/src/rules/refurb/rules/regex_flag_alias.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/regex_flag_alias.rs
@@ -31,7 +31,6 @@ use crate::{AlwaysFixableViolation, Edit, Fix};
 /// if re.match("^hello", "hello world", re.IGNORECASE):
 ///     ...
 /// ```
-///
 #[derive(ViolationMetadata)]
 pub(crate) struct RegexFlagAlias {
     flag: RegexFlag,

--- a/crates/ruff_linter/src/rules/ruff/rules/decimal_from_float_literal.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/decimal_from_float_literal.rs
@@ -28,7 +28,7 @@ use crate::{AlwaysFixableViolation, Edit, Fix};
 /// num = Decimal("1.2345")
 /// ```
 ///
-/// ## Fix Safety
+/// ## Fix safety
 /// This rule's fix is marked as unsafe because it changes the underlying value
 /// of the `Decimal` instance that is constructed. This can lead to unexpected
 /// behavior if your program relies on the previous value (whether deliberately or not).

--- a/crates/ruff_linter/src/rules/ruff/rules/invalid_formatter_suppression_comment.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/invalid_formatter_suppression_comment.rs
@@ -54,7 +54,6 @@ use super::suppression_comment_visitor::{
 ///
 /// This fix is always marked as unsafe because it deletes the invalid suppression comment,
 /// rather than trying to move it to a valid position, which the user more likely intended.
-///
 #[derive(ViolationMetadata)]
 pub(crate) struct InvalidFormatterSuppressionComment {
     reason: IgnoredReason,

--- a/crates/ruff_linter/src/rules/ruff/rules/unnecessary_round.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unnecessary_round.rs
@@ -33,7 +33,6 @@ use crate::{AlwaysFixableViolation, Applicability, Edit, Fix};
 ///
 /// The fix is marked unsafe if it is not possible to guarantee that the first argument of
 /// `round()` is of type `int`, or if the fix deletes comments.
-///
 #[derive(ViolationMetadata)]
 pub(crate) struct UnnecessaryRound;
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

While working on a detector for #15584, I noticed several inconsistencies in the docs, so this PR fixes them.
- Blank line between doc comment and `#[derive(ViolationMetadata)]`
- Empty doc comment before `#[derive(ViolationMetadata)]`
- `## Fix Safety` instead of `## Fix safety`

## Test Plan

<!-- How was it tested? -->

N/A, no functionality/tests affected