### PR TITLE
[`pylint`] Mark `PLE0241` autofix as unsafe if there's comments in the base classes

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/duplicate_bases.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/duplicate_bases.py
@@ -70,3 +70,9 @@ class D(C):
 
 class E(A, C):
     ...
+
+# https://github.com/astral-sh/ruff/issues/18814
+class Bar(Foo,  # 1
+    Foo  # 2
+):
+    pass

--- a/crates/ruff_linter/src/rules/pylint/rules/duplicate_bases.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/duplicate_bases.rs
@@ -51,6 +51,7 @@ use crate::{Fix, FixAvailability, Violation};
 /// ):
 ///     pass
 /// ```
+///
 /// ## References
 /// - [Python documentation: Class definitions](https://docs.python.org/3/reference/compound_stmts.html#class-definitions)
 #[derive(ViolationMetadata)]

--- a/crates/ruff_linter/src/rules/pylint/rules/duplicate_bases.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/duplicate_bases.rs
@@ -45,8 +45,10 @@ use crate::{Fix, FixAvailability, Violation};
 ///     pass
 ///
 ///
-/// class Bar(Foo, # comment
-///     Foo):
+/// class Bar(
+///     Foo,  # comment
+///     Foo,
+/// ):
 ///     pass
 /// ```
 /// ## References

--- a/crates/ruff_linter/src/rules/pylint/rules/duplicate_bases.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/duplicate_bases.rs
@@ -1,3 +1,4 @@
+use ruff_diagnostics::Applicability;
 use ruff_python_ast::{self as ast, Arguments, Expr};
 use rustc_hash::{FxBuildHasher, FxHashSet};
 
@@ -34,6 +35,20 @@ use crate::{Fix, FixAvailability, Violation};
 ///     pass
 /// ```
 ///
+/// ## Fix safety
+/// This rule's fix is marked as unsafe if there's comments in the
+/// base classes.
+///
+/// For example, the fix would be marked as unsafe in the following case:
+/// ```python
+/// class Foo:
+///     pass
+///
+///
+/// class Bar(Foo, # comment
+///     Foo):
+///     pass
+/// ```
 /// ## References
 /// - [Python documentation: Class definitions](https://docs.python.org/3/reference/compound_stmts.html#class-definitions)
 #[derive(ViolationMetadata)]
@@ -81,7 +96,16 @@ pub(crate) fn duplicate_bases(checker: &Checker, name: &str, arguments: Option<&
                         Parentheses::Remove,
                         checker.locator().contents(),
                     )
-                    .map(Fix::safe_edit)
+                    .map(|edit| {
+                        Fix::applicable_edit(
+                            edit,
+                            if checker.comment_ranges().intersects(arguments.range()) {
+                                Applicability::Unsafe
+                            } else {
+                                Applicability::Safe
+                            },
+                        )
+                    })
                 });
             }
         }

--- a/crates/ruff_linter/src/rules/pylint/rules/duplicate_bases.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/duplicate_bases.rs
@@ -37,7 +37,7 @@ use crate::{Fix, FixAvailability, Violation};
 ///
 /// ## Fix safety
 /// This rule's fix is marked as unsafe if there's comments in the
-/// base classes.
+/// base classes, as comments may be removed..
 ///
 /// For example, the fix would be marked as unsafe in the following case:
 /// ```python

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLE0241_duplicate_bases.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLE0241_duplicate_bases.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_linter/src/rules/pylint/mod.rs
-snapshot_kind: text
 ---
 duplicate_bases.py:13:13: PLE0241 [*] Duplicate base `A` for class `F1`
    |
@@ -155,3 +154,24 @@ duplicate_bases.py:54:5: PLE0241 [*] Duplicate base `A` for class `G4`
 55 54 |     B,
 56 55 | ):
 57 56 |     ...
+
+duplicate_bases.py:76:5: PLE0241 [*] Duplicate base `Foo` for class `Bar`
+   |
+74 | # https://github.com/astral-sh/ruff/issues/18814
+75 | class Bar(Foo,  # 1
+76 |     Foo  # 2
+   |     ^^^ PLE0241
+77 | ):
+78 |     pass
+   |
+   = help: Remove duplicate base
+
+ℹ Unsafe fix
+72 72 |     ...
+73 73 | 
+74 74 | # https://github.com/astral-sh/ruff/issues/18814
+75    |-class Bar(Foo,  # 1
+76    |-    Foo  # 2
+   75 |+class Bar(Foo  # 2
+77 76 | ):
+78 77 |     pass


### PR DESCRIPTION


<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary
Fixes https://github.com/astral-sh/ruff/issues/18814
<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan
Add regression test
<!-- How was it tested? -->
