### PR TITLE
[`pylint`] Fix false negative in `modified-iterating-set` lint when target variable is reassigned

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/modified_iterating_set.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/modified_iterating_set.py
@@ -25,6 +25,23 @@ for num in odds:
     if num > 1:
         odds.add(num + 1)
 
+# https://github.com/astral-sh/ruff/issues/18818
+nums1 = {1, 2, 3}
+nums1 = {1, 2, 3}
+for num1 in nums1:
+    nums1.add(num1 + 5)
+
+nums2 = 1
+nums2 = {1, 2, 3}
+for num2 in nums2:
+    nums2.add(num2 + 5)
+
+nums3 = {1, 2 ,3}
+def foo():
+    nums3 = {1, 2, 3}
+    for num3 in nums3:
+        nums3.add(num3 + 5)
+
 # OK
 
 nums = {1, 2, 3}
@@ -58,3 +75,8 @@ def add_colors():
 
 add_colors()
 print(colors)
+
+nums4 = {1, 2, 3}
+nums4 = 3
+for num4 in nums4:
+    nums4.add(num4 + 5)

--- a/crates/ruff_linter/resources/test/fixtures/pylint/modified_iterating_set.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/modified_iterating_set.py
@@ -80,3 +80,13 @@ nums4 = {1, 2, 3}
 nums4 = 3
 for num4 in nums4:
     nums4.add(num4 + 5)
+
+nums5 = {}
+for num5 in nums5:
+    nums5 = {}
+    nums5.add(num5 + 5)
+
+nums6 = {1, 2, 3}
+for num6 in nums6:
+    nums6 = {4, 5, 6}
+    nums6.add(num6 + 5)

--- a/crates/ruff_linter/src/preview.rs
+++ b/crates/ruff_linter/src/preview.rs
@@ -84,3 +84,8 @@ pub(crate) const fn is_ignore_init_files_in_useless_alias_enabled(
 ) -> bool {
     settings.preview.is_enabled()
 }
+
+// https://github.com/astral-sh/ruff/pull/18833
+pub(crate) const fn is_shadowed_set_variable_bindings_enabled(settings: &LinterSettings) -> bool {
+    settings.preview.is_enabled()
+}

--- a/crates/ruff_linter/src/rules/pylint/mod.rs
+++ b/crates/ruff_linter/src/rules/pylint/mod.rs
@@ -455,4 +455,22 @@ mod tests {
         assert_diagnostics!(diagnostics);
         Ok(())
     }
+
+    #[test_case(Rule::ModifiedIteratingSet, Path::new("modified_iterating_set.py"))]
+    fn preview_rules(rule_code: Rule, path: &Path) -> Result<()> {
+        let snapshot = format!(
+            "preview__{}_{}",
+            rule_code.noqa_code(),
+            path.to_string_lossy()
+        );
+        let diagnostics = test_path(
+            Path::new("pylint").join(path).as_path(),
+            &LinterSettings {
+                preview: PreviewMode::Enabled,
+                ..LinterSettings::for_rule(rule_code)
+            },
+        )?;
+        assert_messages!(snapshot, diagnostics);
+        Ok(())
+    }
 }

--- a/crates/ruff_linter/src/rules/pylint/rules/modified_iterating_set.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/modified_iterating_set.rs
@@ -69,7 +69,7 @@ pub(crate) fn modified_iterating_set(checker: &Checker, for_stmt: &StmtFor) {
         return;
     };
 
-    let Some(binding_id) = checker.semantic().only_binding(name) else {
+    let Some(binding_id) = checker.semantic().resolve_name(name) else {
         return;
     };
     if !is_set(checker.semantic().binding(binding_id), checker.semantic()) {
@@ -89,7 +89,7 @@ pub(crate) fn modified_iterating_set(checker: &Checker, for_stmt: &StmtFor) {
             return false;
         };
 
-        let Some(value_id) = checker.semantic().only_binding(value) else {
+        let Some(value_id) = checker.semantic().resolve_name(value) else {
             return false;
         };
 

--- a/crates/ruff_linter/src/rules/pylint/rules/modified_iterating_set.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/modified_iterating_set.rs
@@ -19,6 +19,9 @@ use crate::{AlwaysFixableViolation, Edit, Fix};
 /// If you need to modify a `set` within a loop, consider iterating over a copy
 /// of the `set` instead.
 ///
+/// In [preview], this rule will also detect any reassignment of the target variable,
+/// including reassignments that shadow existing bindings.
+///
 /// ## Known problems
 /// This rule favors false negatives over false positives. Specifically, it
 /// will only detect variables that can be inferred to be a `set` type based on
@@ -47,6 +50,8 @@ use crate::{AlwaysFixableViolation, Edit, Fix};
 ///
 /// ## References
 /// - [Python documentation: `set`](https://docs.python.org/3/library/stdtypes.html#set)
+///
+/// [preview]: https://docs.astral.sh/ruff/preview/
 #[derive(ViolationMetadata)]
 pub(crate) struct ModifiedIteratingSet {
     name: Name,

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLE4703_modified_iterating_set.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLE4703_modified_iterating_set.py.snap
@@ -114,7 +114,7 @@ modified_iterating_set.py:24:1: PLE4703 [*] Iterated set `odds` is modified with
 26 | |         odds.add(num + 1)
    | |_________________________^ PLE4703
 27 |
-28 |   # OK
+28 |   # https://github.com/astral-sh/ruff/issues/18818
    |
    = help: Iterate over a copy of `odds`
 
@@ -126,4 +126,70 @@ modified_iterating_set.py:24:1: PLE4703 [*] Iterated set `odds` is modified with
    24 |+for num in odds.copy():
 25 25 |     if num > 1:
 26 26 |         odds.add(num + 1)
-27 27 |
+27 27 | 
+
+modified_iterating_set.py:31:1: PLE4703 [*] Iterated set `nums1` is modified within the `for` loop
+   |
+29 |   nums1 = {1, 2, 3}
+30 |   nums1 = {1, 2, 3}
+31 | / for num1 in nums1:
+32 | |     nums1.add(num1 + 5)
+   | |_______________________^ PLE4703
+33 |
+34 |   nums2 = 1
+   |
+   = help: Iterate over a copy of `nums1`
+
+ℹ Unsafe fix
+28 28 | # https://github.com/astral-sh/ruff/issues/18818
+29 29 | nums1 = {1, 2, 3}
+30 30 | nums1 = {1, 2, 3}
+31    |-for num1 in nums1:
+   31 |+for num1 in nums1.copy():
+32 32 |     nums1.add(num1 + 5)
+33 33 | 
+34 34 | nums2 = 1
+
+modified_iterating_set.py:36:1: PLE4703 [*] Iterated set `nums2` is modified within the `for` loop
+   |
+34 |   nums2 = 1
+35 |   nums2 = {1, 2, 3}
+36 | / for num2 in nums2:
+37 | |     nums2.add(num2 + 5)
+   | |_______________________^ PLE4703
+38 |
+39 |   nums3 = {1, 2 ,3}
+   |
+   = help: Iterate over a copy of `nums2`
+
+ℹ Unsafe fix
+33 33 | 
+34 34 | nums2 = 1
+35 35 | nums2 = {1, 2, 3}
+36    |-for num2 in nums2:
+   36 |+for num2 in nums2.copy():
+37 37 |     nums2.add(num2 + 5)
+38 38 | 
+39 39 | nums3 = {1, 2 ,3}
+
+modified_iterating_set.py:42:5: PLE4703 [*] Iterated set `nums3` is modified within the `for` loop
+   |
+40 |   def foo():
+41 |       nums3 = {1, 2, 3}
+42 | /     for num3 in nums3:
+43 | |         nums3.add(num3 + 5)
+   | |___________________________^ PLE4703
+44 |
+45 |   # OK
+   |
+   = help: Iterate over a copy of `nums3`
+
+ℹ Unsafe fix
+39 39 | nums3 = {1, 2 ,3}
+40 40 | def foo():
+41 41 |     nums3 = {1, 2, 3}
+42    |-    for num3 in nums3:
+   42 |+    for num3 in nums3.copy():
+43 43 |         nums3.add(num3 + 5)
+44 44 | 
+45 45 | # OK

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__preview__PLE4703_modified_iterating_set.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__preview__PLE4703_modified_iterating_set.py.snap
@@ -128,6 +128,50 @@ modified_iterating_set.py:24:1: PLE4703 [*] Iterated set `odds` is modified with
 26 26 |         odds.add(num + 1)
 27 27 | 
 
+modified_iterating_set.py:31:1: PLE4703 [*] Iterated set `nums1` is modified within the `for` loop
+   |
+29 |   nums1 = {1, 2, 3}
+30 |   nums1 = {1, 2, 3}
+31 | / for num1 in nums1:
+32 | |     nums1.add(num1 + 5)
+   | |_______________________^ PLE4703
+33 |
+34 |   nums2 = 1
+   |
+   = help: Iterate over a copy of `nums1`
+
+ℹ Unsafe fix
+28 28 | # https://github.com/astral-sh/ruff/issues/18818
+29 29 | nums1 = {1, 2, 3}
+30 30 | nums1 = {1, 2, 3}
+31    |-for num1 in nums1:
+   31 |+for num1 in nums1.copy():
+32 32 |     nums1.add(num1 + 5)
+33 33 | 
+34 34 | nums2 = 1
+
+modified_iterating_set.py:36:1: PLE4703 [*] Iterated set `nums2` is modified within the `for` loop
+   |
+34 |   nums2 = 1
+35 |   nums2 = {1, 2, 3}
+36 | / for num2 in nums2:
+37 | |     nums2.add(num2 + 5)
+   | |_______________________^ PLE4703
+38 |
+39 |   nums3 = {1, 2 ,3}
+   |
+   = help: Iterate over a copy of `nums2`
+
+ℹ Unsafe fix
+33 33 | 
+34 34 | nums2 = 1
+35 35 | nums2 = {1, 2, 3}
+36    |-for num2 in nums2:
+   36 |+for num2 in nums2.copy():
+37 37 |     nums2.add(num2 + 5)
+38 38 | 
+39 39 | nums3 = {1, 2 ,3}
+
 modified_iterating_set.py:42:5: PLE4703 [*] Iterated set `nums3` is modified within the `for` loop
    |
 40 |   def foo():


### PR DESCRIPTION
## Summary

Resolves https://github.com/astral-sh/ruff/issues/18818

The change fixes the false negative described in the issue, but I want to ensure it doesn't break other scenarios.

I'm not sure why the original implementation only checked shadowed bindings with `only_binding()`, but I changed it to check any binding with `resolve_name()`. All existing tests pass, including my new test case, so the change appears to work correctly. 

However, I'd appreciate feedback on:
1. Why `only_binding()` was chosen initially
2. What edge cases my change might introduce
3. Whether this broader scope could cause false positives


## Test Plan

`cargo nextest run` and `cargo insta test`