### PR TITLE
Apply fix availability and applicability when adding to `DiagnosticGuard` and remove `NoqaCode::rule`

### DIFF
--- a/crates/ruff/src/cache.rs
+++ b/crates/ruff/src/cache.rs
@@ -442,7 +442,7 @@ impl LintCacheData {
             // Parse the kebab-case rule name into a `Rule`. This will fail for syntax errors, so
             // this also serves to filter them out, but we shouldn't be caching files with syntax
             // errors anyway.
-            .filter_map(|msg| Some((msg.noqa_code().and_then(|code| code.rule())?, msg)))
+            .filter_map(|msg| Some((msg.name().parse().ok()?, msg)))
             .map(|(rule, msg)| {
                 // Make sure that all message use the same source file.
                 assert_eq!(

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -3246,6 +3246,10 @@ impl DiagnosticGuard<'_, '_> {
     /// Set the [`Fix`] used to fix the diagnostic.
     #[inline]
     pub(crate) fn set_fix(&mut self, fix: Fix) {
+        if !self.context.rules.should_fix(self.rule) {
+            self.fix = None;
+            return;
+        }
         let applicability = self.resolve_applicability(&fix);
         self.fix = Some(fix.with_applicability(applicability));
     }

--- a/crates/ruff_linter/src/fix/edits.rs
+++ b/crates/ruff_linter/src/fix/edits.rs
@@ -739,15 +739,16 @@ x = 1 \
         let diag = {
             use crate::rules::pycodestyle::rules::MissingNewlineAtEndOfFile;
             let mut iter = edits.into_iter();
-            OldDiagnostic::new(
+            let mut diagnostic = OldDiagnostic::new(
                 MissingNewlineAtEndOfFile, // The choice of rule here is arbitrary.
                 TextRange::default(),
                 &SourceFileBuilder::new("<filename>", "<code>").finish(),
-            )
-            .with_fix(Fix::safe_edits(
+            );
+            diagnostic.fix = Some(Fix::safe_edits(
                 iter.next().ok_or(anyhow!("expected edits nonempty"))?,
                 iter,
-            ))
+            ));
+            diagnostic
         };
         assert_eq!(apply_fixes([diag].iter(), &locator).code, expect);
         Ok(())

--- a/crates/ruff_linter/src/fix/mod.rs
+++ b/crates/ruff_linter/src/fix/mod.rs
@@ -186,12 +186,13 @@ mod tests {
         edit.into_iter()
             .map(|edit| {
                 // The choice of rule here is arbitrary.
-                let diagnostic = OldDiagnostic::new(
+                let mut diagnostic = OldDiagnostic::new(
                     MissingNewlineAtEndOfFile,
                     edit.range(),
                     &SourceFileBuilder::new(filename, source).finish(),
                 );
-                diagnostic.with_fix(Fix::safe_edit(edit))
+                diagnostic.fix = Some(Fix::safe_edit(edit));
+                diagnostic
             })
             .collect()
     }

--- a/crates/ruff_linter/src/linter.rs
+++ b/crates/ruff_linter/src/linter.rs
@@ -378,18 +378,7 @@ pub fn check_path(
 
     let (mut diagnostics, source_file) = context.into_parts();
 
-    if parsed.has_valid_syntax() {
-        // Remove fixes for any rules marked as unfixable.
-        for diagnostic in &mut diagnostics {
-            if diagnostic
-                .noqa_code()
-                .and_then(|code| code.rule())
-                .is_none_or(|rule| !settings.rules.should_fix(rule))
-            {
-                diagnostic.fix = None;
-            }
-        }
-    } else {
+    if !parsed.has_valid_syntax() {
         // Avoid fixing in case the source code contains syntax errors.
         for diagnostic in &mut diagnostics {
             diagnostic.fix = None;

--- a/crates/ruff_linter/src/linter.rs
+++ b/crates/ruff_linter/src/linter.rs
@@ -389,20 +389,6 @@ pub fn check_path(
                 diagnostic.fix = None;
             }
         }
-
-        // Update fix applicability to account for overrides
-        if !settings.fix_safety.is_empty() {
-            for diagnostic in &mut diagnostics {
-                if let Some(fix) = diagnostic.fix.take() {
-                    if let Some(rule) = diagnostic.noqa_code().and_then(|code| code.rule()) {
-                        let fixed_applicability = settings
-                            .fix_safety
-                            .resolve_applicability(rule, fix.applicability());
-                        diagnostic.set_fix(fix.with_applicability(fixed_applicability));
-                    }
-                }
-            }
-        }
     } else {
         // Avoid fixing in case the source code contains syntax errors.
         for diagnostic in &mut diagnostics {

--- a/crates/ruff_linter/src/message/mod.rs
+++ b/crates/ruff_linter/src/message/mod.rs
@@ -186,41 +186,6 @@ impl OldDiagnostic {
         )
     }
 
-    /// Consumes `self` and returns a new `Diagnostic` with the given `fix`.
-    #[inline]
-    #[must_use]
-    pub fn with_fix(mut self, fix: Fix) -> Self {
-        self.set_fix(fix);
-        self
-    }
-
-    /// Set the [`Fix`] used to fix the diagnostic.
-    #[inline]
-    pub fn set_fix(&mut self, fix: Fix) {
-        self.fix = Some(fix);
-    }
-
-    /// Set the [`Fix`] used to fix the diagnostic, if the provided function returns `Ok`.
-    /// Otherwise, log the error.
-    #[inline]
-    pub fn try_set_fix(&mut self, func: impl FnOnce() -> anyhow::Result<Fix>) {
-        match func() {
-            Ok(fix) => self.fix = Some(fix),
-            Err(err) => log::debug!("Failed to create fix for {}: {}", self.name(), err),
-        }
-    }
-
-    /// Set the [`Fix`] used to fix the diagnostic, if the provided function returns `Ok`.
-    /// Otherwise, log the error.
-    #[inline]
-    pub fn try_set_optional_fix(&mut self, func: impl FnOnce() -> anyhow::Result<Option<Fix>>) {
-        match func() {
-            Ok(None) => {}
-            Ok(Some(fix)) => self.fix = Some(fix),
-            Err(err) => log::debug!("Failed to create fix for {}: {}", self.name(), err),
-        }
-    }
-
     /// Consumes `self` and returns a new `Diagnostic` with the given parent node.
     #[inline]
     #[must_use]

--- a/crates/ruff_linter/src/registry.rs
+++ b/crates/ruff_linter/src/registry.rs
@@ -215,6 +215,12 @@ pub enum Linter {
 }
 
 pub trait RuleNamespace: Sized {
+    /// Returns the prefix that every single code that ruff uses to identify
+    /// rules from this linter starts with.  In the case that multiple
+    /// `#[prefix]`es are configured for the variant in the `Linter` enum
+    /// definition this is the empty string.
+    fn common_prefix(&self) -> &'static str;
+
     /// Attempts to parse the given rule code. If the prefix is recognized
     /// returns the respective variant along with the code with the common
     /// prefix stripped.

--- a/crates/ruff_linter/src/rule_selector.rs
+++ b/crates/ruff_linter/src/rule_selector.rs
@@ -265,6 +265,7 @@ mod schema {
     use strum::IntoEnumIterator;
 
     use crate::RuleSelector;
+    use crate::registry::RuleNamespace;
     use crate::rule_selector::{Linter, RuleCodePrefix};
 
     impl JsonSchema for RuleSelector {

--- a/crates/ruff_macros/src/map_codes.rs
+++ b/crates/ruff_macros/src/map_codes.rs
@@ -254,11 +254,9 @@ fn generate_rule_to_code(linter_to_rules: &BTreeMap<Ident, BTreeMap<String, Rule
     }
 
     let mut rule_noqa_code_match_arms = quote!();
-    let mut noqa_code_rule_match_arms = quote!();
     let mut rule_group_match_arms = quote!();
-    let mut noqa_code_consts = quote!();
 
-    for (i, (rule, codes)) in rule_to_codes.into_iter().enumerate() {
+    for (rule, codes) in rule_to_codes {
         let rule_name = rule.segments.last().unwrap();
         assert_eq!(
             codes.len(),
@@ -292,14 +290,6 @@ See also https://github.com/astral-sh/ruff/issues/2186.
 
         rule_noqa_code_match_arms.extend(quote! {
             #(#attrs)* Rule::#rule_name => NoqaCode(crate::registry::Linter::#linter.common_prefix(), #code),
-        });
-
-        let const_ident = quote::format_ident!("NOQA_PREFIX_{}", i);
-        noqa_code_consts.extend(quote! {
-            const #const_ident: &str = crate::registry::Linter::#linter.common_prefix();
-        });
-        noqa_code_rule_match_arms.extend(quote! {
-            #(#attrs)* NoqaCode(#const_ident, #code) => Some(Rule::#rule_name),
         });
 
         rule_group_match_arms.extend(quote! {
@@ -347,16 +337,6 @@ See also https://github.com/astral-sh/ruff/issues/2186.
                 match (self, rule) {
                     #linter_code_for_rule_match_arms
                     _ => None,
-                }
-            }
-        }
-
-        impl NoqaCode {
-            pub fn rule(&self) -> Option<Rule> {
-                #noqa_code_consts
-                match self {
-                    #noqa_code_rule_match_arms
-                    _ => None
                 }
             }
         }

--- a/crates/ruff_macros/src/rule_namespace.rs
+++ b/crates/ruff_macros/src/rule_namespace.rs
@@ -118,22 +118,16 @@ pub(crate) fn derive_impl(input: DeriveInput) -> syn::Result<proc_macro2::TokenS
                 None
             }
 
+            fn common_prefix(&self) -> &'static str {
+                match self { #common_prefix_match_arms }
+            }
+
             fn name(&self) -> &'static str {
                 match self { #name_match_arms }
             }
 
             fn url(&self) -> Option<&'static str> {
                 match self { #url_match_arms }
-            }
-        }
-
-        impl #ident {
-            /// Returns the prefix that every single code that ruff uses to identify
-            /// rules from this linter starts with.  In the case that multiple
-            /// `#[prefix]`es are configured for the variant in the `Linter` enum
-            /// definition this is the empty string.
-            pub const fn common_prefix(&self) -> &'static str {
-                match self { #common_prefix_match_arms }
             }
         }
     })

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -22,7 +22,7 @@ use ruff_cache::cache_dir;
 use ruff_formatter::IndentStyle;
 use ruff_graph::{AnalyzeSettings, Direction};
 use ruff_linter::line_width::{IndentWidth, LineLength};
-use ruff_linter::registry::{INCOMPATIBLE_CODES, Rule, RuleSet};
+use ruff_linter::registry::{INCOMPATIBLE_CODES, Rule, RuleNamespace, RuleSet};
 use ruff_linter::rule_selector::{PreviewOptions, Specificity};
 use ruff_linter::rules::{flake8_import_conventions, isort, pycodestyle};
 use ruff_linter::settings::fix_safety_table::FixSafetyTable;


### PR DESCRIPTION
## Summary

This PR removes the last two places we were using `NoqaCode::rule` in `linter.rs` (see https://github.com/astral-sh/ruff/pull/18391#discussion_r2154637329 and https://github.com/astral-sh/ruff/pull/18391#discussion_r2154649726) by  checking whether fixes are actually desired before adding them to a `DiagnosticGuard`. I implemented this by storing a `Violation`'s `Rule` on the `DiagnosticGuard` so that we could check if it was enabled in the embedded `LinterSettings` when trying to set a fix.

All of the corresponding `set_fix` methods on `OldDiagnostic` were now unused (except in tests where I just set `.fix` directly), so I moved these to the guard instead of keeping both sets.

The very last place where we were using `NoqaCode::rule` was in the cache. I just reverted this to parsing the `Rule` from the name. I had forgotten to update the comment there anyway. Hopefully this doesn't cause too much of a perf hit.

## Test Plan

Existing tests and benchmarks on this PR
