### PR TITLE
[`flake8-use-pathlib`] Add fix safety section to `PTH201`

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/path_constructor_current_directory.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/path_constructor_current_directory.rs
@@ -33,6 +33,10 @@ use crate::{AlwaysFixableViolation, Applicability, Edit, Fix};
 /// _ = Path()
 /// ```
 ///
+/// ## Fix safety
+/// This fix is marked unsafe if there are comments inside the parentheses, as applying
+/// the fix will delete them.
+///
 /// ## References
 /// - [Python documentation: `Path`](https://docs.python.org/3/library/pathlib.html#pathlib.Path)
 #[derive(ViolationMetadata)]


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

This adds a `Fix safety` section to [path-constructor-current-directory (PTH201)](https://docs.astral.sh/ruff/rules/path-constructor-current-directory/#path-constructor-current-directory-pth201)

I could not track down the original PR as this rule is so old it has gone through several large ruff refactors.
The unsafety is determined here:
https://github.com/astral-sh/ruff/blob/d9266284df170cd70908761b5d5ae45b25523a40/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/path_constructor_current_directory.rs#L55-L59
Unsafe code example:
[playground](https://play.ruff.rs/76da532a-c7ad-4ef9-bba3-4626296e5317)
```py
from pathlib import Path
Path(#
    "."#
)
```

## Test Plan

<!-- How was it tested? -->

N/A, no tests/functionality affected