### PR TITLE
[`pyupgrade`] Add fix safety section to `UP010`

### DIFF
--- a/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_future_import.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_future_import.rs
@@ -30,6 +30,9 @@ use crate::{AlwaysFixableViolation, Applicability, Fix};
 /// print("Hello, world!")
 /// ```
 ///
+/// ## Fix safety
+/// This fix is marked unsafe if applying it would delete a comment.
+///
 /// ## Options
 /// - `target-version`
 ///


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Part of #15584

This adds a `Fix safety` section to [unnecessary-future-import (UP010)](https://docs.astral.sh/ruff/rules/unnecessary-future-import/#unnecessary-future-import-up010)

The unsafety is determined here:
https://github.com/astral-sh/ruff/blob/d9266284df170cd70908761b5d5ae45b25523a40/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_future_import.rs#L128-L132

Unsafe code example:
[playground](https://play.ruff.rs/c07d8c41-9ab8-4b86-805b-8cf482d450d9)
```py
from __future__ import (print_function,# ...
__annotations__)  # ...
```

## Test Plan

<!-- How was it tested? -->

N/A, no tests/functionality affected