### PR TITLE
[`pyflakes`] Mark `F504`/`F522`/`F523` autofix as unsafe if there's a call with side effect

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyflakes/F504.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyflakes/F504.py
@@ -14,3 +14,6 @@ hidden = {"a": "!"}
 "" % {
   'test1': '',  'test2': '',
 }
+
+# https://github.com/astral-sh/ruff/issues/18806
+"Hello, %(name)s" % {"greeting": print(1), "name": "World"}

--- a/crates/ruff_linter/resources/test/fixtures/pyflakes/F522.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyflakes/F522.py
@@ -4,3 +4,6 @@
 "{bar:{spam}}".format(bar=2, spam=3, eggs=4, ham=5)  # F522
 (''
  .format(x=2))  # F522
+
+# https://github.com/astral-sh/ruff/issues/18806
+"Hello, {name}".format(greeting=print(1), name="World")

--- a/crates/ruff_linter/resources/test/fixtures/pyflakes/F522.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyflakes/F522.py
@@ -6,4 +6,9 @@
  .format(x=2))  # F522
 
 # https://github.com/astral-sh/ruff/issues/18806
+# The fix here is unsafe because the unused argument has side effect
 "Hello, {name}".format(greeting=print(1), name="World")
+
+# The fix here is safe because the unused argument has no side effect,
+# even though the used argument has a side effect
+"Hello, {name}".format(greeting="Pikachu", name=print(1))

--- a/crates/ruff_linter/resources/test/fixtures/pyflakes/F523.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyflakes/F523.py
@@ -35,3 +35,6 @@
 # Removing the final argument.
 "Hello".format("world")
 "Hello".format("world", key="value")
+
+# https://github.com/astral-sh/ruff/issues/18806
+"Hello, {0}".format("world", print(1))

--- a/crates/ruff_linter/resources/test/fixtures/pyflakes/F523.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyflakes/F523.py
@@ -37,4 +37,9 @@
 "Hello".format("world", key="value")
 
 # https://github.com/astral-sh/ruff/issues/18806
+# The fix here is unsafe because the unused argument has side effect
 "Hello, {0}".format("world", print(1))
+
+# The fix here is safe because the unused argument has no side effect,
+# even though the used argument has a side effect
+"Hello, {0}".format(print(1), "Pikachu")

--- a/crates/ruff_linter/src/rules/pyflakes/rules/strings.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/strings.rs
@@ -140,6 +140,15 @@ impl Violation for PercentFormatExpectedSequence {
 /// "Hello, %(name)s" % {"name": "World"}
 /// ```
 ///
+/// ## Fix safety
+/// This rule's fix is marked as unsafe if there's a call expression in the
+/// `printf`-style format string.
+///
+/// For example, the fix would be marked as unsafe in the following case:
+/// ```python
+/// "Hello, %(name)s" % {"greeting": print(1), "name": "World"}
+/// ```
+///
 /// ## References
 /// - [Python documentation: `printf`-style String Formatting](https://docs.python.org/3/library/stdtypes.html#printf-style-string-formatting)
 #[derive(ViolationMetadata)]
@@ -381,6 +390,15 @@ impl Violation for StringDotFormatInvalidFormat {
 /// "Hello, {name}".format(name="World")
 /// ```
 ///
+/// ## Fix safety
+/// This rule's fix is marked as unsafe if there's a call expression in the
+/// `format` call.
+///
+/// For example, the fix would be marked as unsafe in the following case:
+/// ```python
+/// "Hello, {name}".format(greeting=print(1), name="World")
+/// ```
+///
 /// ## References
 /// - [Python documentation: `str.format`](https://docs.python.org/3/library/stdtypes.html#str.format)
 #[derive(ViolationMetadata)]
@@ -420,6 +438,15 @@ impl Violation for StringDotFormatExtraNamedArguments {
 /// Use instead:
 /// ```python
 /// "Hello, {0}".format("world")
+/// ```
+///
+/// ## Fix safety
+/// This rule's fix is marked as unsafe if there's a call expression in the
+/// `format` call.
+///
+/// For example, the fix would be marked as unsafe in the following case:
+/// ```python
+/// "Hello, {0}".format("world", print(1))
 /// ```
 ///
 /// ## References

--- a/crates/ruff_linter/src/rules/pyflakes/rules/strings.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/strings.rs
@@ -141,8 +141,9 @@ impl Violation for PercentFormatExpectedSequence {
 /// ```
 ///
 /// ## Fix safety
-/// This rule's fix is marked as unsafe if there's a call expression in the
-/// `printf`-style format string.
+/// This rule's fix is marked as unsafe for mapping key
+/// containing function calls with potential side effects,
+/// because removing such arguments could change the behavior of the code.
 ///
 /// For example, the fix would be marked as unsafe in the following case:
 /// ```python
@@ -391,8 +392,9 @@ impl Violation for StringDotFormatInvalidFormat {
 /// ```
 ///
 /// ## Fix safety
-/// This rule's fix is marked as unsafe if there's a call expression in the
-/// `format` call.
+/// This rule's fix is marked as unsafe if the unused keyword argument
+/// contains a function call with potential side effects,
+/// because removing such arguments could change the behavior of the code.
 ///
 /// For example, the fix would be marked as unsafe in the following case:
 /// ```python
@@ -441,8 +443,9 @@ impl Violation for StringDotFormatExtraNamedArguments {
 /// ```
 ///
 /// ## Fix safety
-/// This rule's fix is marked as unsafe if there's a call expression in the
-/// `format` call.
+/// This rule's fix is marked as unsafe if the unused positional argument
+/// contains a function call with potential side effects,
+/// because removing such arguments could change the behavior of the code.
 ///
 /// For example, the fix would be marked as unsafe in the following case:
 /// ```python

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F504_F504.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F504_F504.py.snap
@@ -89,6 +89,8 @@ F504.py:14:1: F504 [*] `%`-format string has unused named argument(s): test1, te
 15 | |   'test1': '',  'test2': '',
 16 | | }
    | |_^ F504
+17 |
+18 |   # https://github.com/astral-sh/ruff/issues/18806
    |
    = help: Remove extra named arguments: test1, test2
 
@@ -99,3 +101,20 @@ F504.py:14:1: F504 [*] `%`-format string has unused named argument(s): test1, te
 15    |-  'test1': '',16    |-  'test2': '',
    15 |+  
 17 16 | }
+18 17 | 
+19 18 | # https://github.com/astral-sh/ruff/issues/18806
+
+F504.py:20:1: F504 [*] `%`-format string has unused named argument(s): greeting
+   |
+19 | # https://github.com/astral-sh/ruff/issues/18806
+20 | "Hello, %(name)s" % {"greeting": print(1), "name": "World"}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ F504
+   |
+   = help: Remove extra named arguments: greeting
+
+ℹ Unsafe fix
+17 17 | }
+18 18 | 
+19 19 | # https://github.com/astral-sh/ruff/issues/18806
+20    |-"Hello, %(name)s" % {"greeting": print(1), "name": "World"}
+   20 |+"Hello, %(name)s" % {"name": "World"}

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F522_F522.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F522_F522.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_linter/src/rules/pyflakes/mod.rs
-snapshot_kind: text
 ---
 F522.py:1:1: F522 [*] `.format` call has unused named argument(s): bar
   |
@@ -55,6 +54,7 @@ F522.py:4:1: F522 [*] `.format` call has unused named argument(s): eggs, ham
   4 |+"{bar:{spam}}".format(bar=2, spam=3, )  # F522
 5 5 | (''
 6 6 |  .format(x=2))  # F522
+7 7 | 
 
 F522.py:5:2: F522 [*] `.format` call has unused named argument(s): x
   |
@@ -64,6 +64,8 @@ F522.py:5:2: F522 [*] `.format` call has unused named argument(s): x
   |  __^
 6 | |  .format(x=2))  # F522
   | |_____________^ F522
+7 |
+8 |   # https://github.com/astral-sh/ruff/issues/18806
   |
   = help: Remove extra named arguments: x
 
@@ -73,3 +75,21 @@ F522.py:5:2: F522 [*] `.format` call has unused named argument(s): x
 5 5 | (''
 6   |- .format(x=2))  # F522
   6 |+ .format())  # F522
+7 7 | 
+8 8 | # https://github.com/astral-sh/ruff/issues/18806
+9 9 | "Hello, {name}".format(greeting=print(1), name="World")
+
+F522.py:9:1: F522 [*] `.format` call has unused named argument(s): greeting
+  |
+8 | # https://github.com/astral-sh/ruff/issues/18806
+9 | "Hello, {name}".format(greeting=print(1), name="World")
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ F522
+  |
+  = help: Remove extra named arguments: greeting
+
+ℹ Unsafe fix
+6 6 |  .format(x=2))  # F522
+7 7 | 
+8 8 | # https://github.com/astral-sh/ruff/issues/18806
+9   |-"Hello, {name}".format(greeting=print(1), name="World")
+  9 |+"Hello, {name}".format(name="World")

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F522_F522.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F522_F522.py.snap
@@ -77,19 +77,41 @@ F522.py:5:2: F522 [*] `.format` call has unused named argument(s): x
   6 |+ .format())  # F522
 7 7 | 
 8 8 | # https://github.com/astral-sh/ruff/issues/18806
-9 9 | "Hello, {name}".format(greeting=print(1), name="World")
+9 9 | # The fix here is unsafe because the unused argument has side effect
 
-F522.py:9:1: F522 [*] `.format` call has unused named argument(s): greeting
-  |
-8 | # https://github.com/astral-sh/ruff/issues/18806
-9 | "Hello, {name}".format(greeting=print(1), name="World")
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ F522
-  |
-  = help: Remove extra named arguments: greeting
+F522.py:10:1: F522 [*] `.format` call has unused named argument(s): greeting
+   |
+ 8 | # https://github.com/astral-sh/ruff/issues/18806
+ 9 | # The fix here is unsafe because the unused argument has side effect
+10 | "Hello, {name}".format(greeting=print(1), name="World")
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ F522
+11 |
+12 | # The fix here is safe because the unused argument has no side effect,
+   |
+   = help: Remove extra named arguments: greeting
 
 ℹ Unsafe fix
-6 6 |  .format(x=2))  # F522
-7 7 | 
-8 8 | # https://github.com/astral-sh/ruff/issues/18806
-9   |-"Hello, {name}".format(greeting=print(1), name="World")
-  9 |+"Hello, {name}".format(name="World")
+7  7  | 
+8  8  | # https://github.com/astral-sh/ruff/issues/18806
+9  9  | # The fix here is unsafe because the unused argument has side effect
+10    |-"Hello, {name}".format(greeting=print(1), name="World")
+   10 |+"Hello, {name}".format(name="World")
+11 11 | 
+12 12 | # The fix here is safe because the unused argument has no side effect,
+13 13 | # even though the used argument has a side effect
+
+F522.py:14:1: F522 [*] `.format` call has unused named argument(s): greeting
+   |
+12 | # The fix here is safe because the unused argument has no side effect,
+13 | # even though the used argument has a side effect
+14 | "Hello, {name}".format(greeting="Pikachu", name=print(1))
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ F522
+   |
+   = help: Remove extra named arguments: greeting
+
+ℹ Safe fix
+11 11 | 
+12 12 | # The fix here is safe because the unused argument has no side effect,
+13 13 | # even though the used argument has a side effect
+14    |-"Hello, {name}".format(greeting="Pikachu", name=print(1))
+   14 |+"Hello, {name}".format(name=print(1))

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F523_F523.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F523_F523.py.snap
@@ -308,19 +308,41 @@ F523.py:37:1: F523 [*] `.format` call has unused arguments at position(s): 0
    37 |+"Hello".format(key="value")
 38 38 | 
 39 39 | # https://github.com/astral-sh/ruff/issues/18806
-40 40 | "Hello, {0}".format("world", print(1))
+40 40 | # The fix here is unsafe because the unused argument has side effect
 
-F523.py:40:1: F523 [*] `.format` call has unused arguments at position(s): 1
+F523.py:41:1: F523 [*] `.format` call has unused arguments at position(s): 1
    |
 39 | # https://github.com/astral-sh/ruff/issues/18806
-40 | "Hello, {0}".format("world", print(1))
+40 | # The fix here is unsafe because the unused argument has side effect
+41 | "Hello, {0}".format("world", print(1))
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ F523
+42 |
+43 | # The fix here is safe because the unused argument has no side effect,
    |
    = help: Remove extra positional arguments at position(s): 1
 
 ℹ Unsafe fix
-37 37 | "Hello".format("world", key="value")
 38 38 | 
 39 39 | # https://github.com/astral-sh/ruff/issues/18806
-40    |-"Hello, {0}".format("world", print(1))
-   40 |+"Hello, {0}".format("world", )
+40 40 | # The fix here is unsafe because the unused argument has side effect
+41    |-"Hello, {0}".format("world", print(1))
+   41 |+"Hello, {0}".format("world", )
+42 42 | 
+43 43 | # The fix here is safe because the unused argument has no side effect,
+44 44 | # even though the used argument has a side effect
+
+F523.py:45:1: F523 [*] `.format` call has unused arguments at position(s): 1
+   |
+43 | # The fix here is safe because the unused argument has no side effect,
+44 | # even though the used argument has a side effect
+45 | "Hello, {0}".format(print(1), "Pikachu")
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ F523
+   |
+   = help: Remove extra positional arguments at position(s): 1
+
+ℹ Safe fix
+42 42 | 
+43 43 | # The fix here is safe because the unused argument has no side effect,
+44 44 | # even though the used argument has a side effect
+45    |-"Hello, {0}".format(print(1), "Pikachu")
+   45 |+"Hello, {0}".format(print(1), )

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F523_F523.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F523_F523.py.snap
@@ -286,6 +286,8 @@ F523.py:36:1: F523 [*] `.format` call has unused arguments at position(s): 0
 36    |-"Hello".format("world")
    36 |+"Hello"
 37 37 | "Hello".format("world", key="value")
+38 38 | 
+39 39 | # https://github.com/astral-sh/ruff/issues/18806
 
 F523.py:37:1: F523 [*] `.format` call has unused arguments at position(s): 0
    |
@@ -293,6 +295,8 @@ F523.py:37:1: F523 [*] `.format` call has unused arguments at position(s): 0
 36 | "Hello".format("world")
 37 | "Hello".format("world", key="value")
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ F523
+38 |
+39 | # https://github.com/astral-sh/ruff/issues/18806
    |
    = help: Remove extra positional arguments at position(s): 0
 
@@ -302,3 +306,21 @@ F523.py:37:1: F523 [*] `.format` call has unused arguments at position(s): 0
 36 36 | "Hello".format("world")
 37    |-"Hello".format("world", key="value")
    37 |+"Hello".format(key="value")
+38 38 | 
+39 39 | # https://github.com/astral-sh/ruff/issues/18806
+40 40 | "Hello, {0}".format("world", print(1))
+
+F523.py:40:1: F523 [*] `.format` call has unused arguments at position(s): 1
+   |
+39 | # https://github.com/astral-sh/ruff/issues/18806
+40 | "Hello, {0}".format("world", print(1))
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ F523
+   |
+   = help: Remove extra positional arguments at position(s): 1
+
+ℹ Unsafe fix
+37 37 | "Hello".format("world", key="value")
+38 38 | 
+39 39 | # https://github.com/astral-sh/ruff/issues/18806
+40    |-"Hello, {0}".format("world", print(1))
+   40 |+"Hello, {0}".format("world", )


### PR DESCRIPTION


<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary
Fixes #18806
<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan
Add regression test
<!-- How was it tested? -->
