### PR TITLE
[`flake8-logging`] Add fix safety section to `LOG002`

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_logging/rules/invalid_get_logger_argument.rs
+++ b/crates/ruff_linter/src/rules/flake8_logging/rules/invalid_get_logger_argument.rs
@@ -39,6 +39,10 @@ use crate::{Edit, Fix, FixAvailability, Violation};
 /// logger = logging.getLogger(__name__)
 /// ```
 ///
+/// ## Fix safety
+/// This fix is always unsafe, as changing the arguments to getLogger can change the
+/// received logger object, and thus program behavior.
+///
 /// [logging documentation]: https://docs.python.org/3/library/logging.html#logger-objects
 #[derive(ViolationMetadata)]
 pub(crate) struct InvalidGetLoggerArgument;


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Part of #15584

This adds a `Fix safety` section to [invalid-get-logger-argument (LOG002)](https://docs.astral.sh/ruff/rules/invalid-get-logger-argument/#invalid-get-logger-argument-log002).

The fix/lint was introduced in #7399
No reasoning is given on the unsafety in the PR/code
Unsafe fix demonstration:
[playground](https://play.ruff.rs/e8008cbf-2ef5-4d38-8255-324f90e624cb)
```py
import logging
logger = logging.getLogger(__file__)
```

## Test Plan

<!-- How was it tested? -->

N/A, no tests/functionality affected