### PR TITLE
[`flake8-logging`] Add fix safety section to `LOG001`

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_logging/rules/direct_logger_instantiation.rs
+++ b/crates/ruff_linter/src/rules/flake8_logging/rules/direct_logger_instantiation.rs
@@ -36,6 +36,10 @@ use crate::{Edit, Fix, FixAvailability, Violation};
 /// logger = logging.getLogger(__name__)
 /// ```
 ///
+/// ## Fix safety
+/// This fix is always unsafe, as changing from `Logger` to `getLogger`
+/// will cause the logger to be added to the logging tree.
+///
 /// [Logger Objects]: https://docs.python.org/3/library/logging.html#logger-objects
 #[derive(ViolationMetadata)]
 pub(crate) struct DirectLoggerInstantiation;


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Part of #15584

This adds a `Fix safety` section to [direct-logger-instantiation (LOG001)](https://docs.astral.sh/ruff/rules/direct-logger-instantiation/#direct-logger-instantiation-log001).

The fix/lint was introduced in #7397
No reasoning is given on the unsafety in the PR/code
Unsafe fix demonstration:
[playground](https://play.ruff.rs/72e7277e-a9db-4cd9-9afb-2c56ef2db361)
```py
import logging
logger = logging.Logger(__name__)
```

## Test Plan

<!-- How was it tested? -->

N/A, no tests/functionality affected