### PR TITLE
[`refurb`] Add fix safety section to `FURB122`

### DIFF
--- a/crates/ruff_linter/src/rules/refurb/rules/for_loop_writes.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/for_loop_writes.rs
@@ -37,6 +37,9 @@ use crate::rules::refurb::helpers::parenthesize_loop_iter_if_necessary;
 ///     f.writelines(line.encode() for line in lines)
 /// ```
 ///
+/// ## Fix safety
+/// This fix is unsafe if it would cause comments to be deleted.
+///
 /// ## References
 /// - [Python documentation: `io.IOBase.writelines`](https://docs.python.org/3/library/io.html#io.IOBase.writelines)
 #[derive(ViolationMetadata)]


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Part of #15584

This adds a `Fix safety` section to [for-loop-writes (FURB122)](https://docs.astral.sh/ruff/rules/for-loop-writes/#for-loop-writes-furb122).

The fix/lint was introduced in #10630
No reasoning is given on the unsafety in the PR/code.
The unsafety is determined here:
https://github.com/astral-sh/ruff/blob/ea812d0813faf6e0ed2d39354e85d08f9b857c90/crates/ruff_linter/src/rules/refurb/rules/for_loop_writes.rs#L200-L204
Unsafe fix demonstration:
[playground](https://play.ruff.rs/06592f33-10b9-4a77-b31e-0d3a98f402f4)
```py
with open("issue.txt", "w") as f:
    for i in range(10):
        # will be deleted
        f.write(str(i))
```

## Test Plan

<!-- How was it tested? -->
