### PR TITLE
[ty] Fix mixed tuple subtyping

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
@@ -247,6 +247,18 @@ static_assert(
 
 static_assert(
     not is_subtype_of(
+        tuple[Literal["foo"], *tuple[int, ...]],
+        tuple[int, ...],
+    )
+)
+static_assert(
+    not is_subtype_of(
+        tuple[*tuple[int, ...], Literal["foo"]],
+        tuple[int, ...],
+    )
+)
+static_assert(
+    not is_subtype_of(
         tuple[Literal[1], Literal[2], *tuple[int, ...], Literal[10]],
         tuple[Literal[1], Literal[2], *tuple[int, ...], Literal[9], Literal[10]],
     )


### PR DESCRIPTION
## Summary

The code in the `Variable` branch of `VariableLengthTupleSpec::has_relation_to` was very clean and elegant, but unfortunately not quite right. It made the incorrect assumption that if you zip two possibly-different-length iterators together and iterate over the resulting zip iterator, the original two iterators will only have their common elements consumed. But in fact, the zip iterator detects that it is done when it receives a `None` from one iterator and `Some()` element from the other iterator, which means that it consumes one additional element from the longer iterator. This meant that we failed to detect mismatched types on this extra consumed element, because we never compared it to the variable type of the other tuple.

The fixed code isn't as clean or as elegant (instead of using `zip()` and `all()`, it relies on explicit lengths, indices, and for loops), but it fixes the bug. I spent a few minutes poking around to see if there was some way to use `.peekable()` or similar to fix the bug using iterators, but I didn't find anything that seemed clearer than just switching to indices and for loops.

Marking this PR internal since it fixes a bug in a commit that wasn't released yet.

## Test Plan

Added mdtests that failed before this fix and pass after it.
