### PR TITLE
[`pyupgrade`] Add fix safety section to `UP004`

### DIFF
--- a/crates/ruff_linter/src/rules/pyupgrade/rules/useless_object_inheritance.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/useless_object_inheritance.rs
@@ -26,6 +26,9 @@ use crate::{AlwaysFixableViolation, Fix};
 /// class Foo: ...
 /// ```
 ///
+/// ## Fix safety
+/// This fix is unsafe if it would cause comments to be deleted.
+///
 /// ## References
 /// - [PEP 3115 – Metaclasses in Python 3000](https://peps.python.org/pep-3115/)
 #[derive(ViolationMetadata)]


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Part of #15584

This adds a `Fix safety` section to [useless-object-inheritance (UP004)](https://docs.astral.sh/ruff/rules/useless-object-inheritance/#useless-object-inheritance-up004)

I could not track down the original PR as this rule is so old it has gone through several large ruff refactors.
No reasoning is given on the unsafety in the PR/code.
The unsafety is determined here:
https://github.com/astral-sh/ruff/blob/f24e650dfd9d20c3d01c2615da3f4778da3cf036/crates/ruff_linter/src/rules/pyupgrade/rules/useless_class_metaclass_type.rs#L76-L80

Unsafe fix demonstration:
[playground](https://play.ruff.rs/12b24eb4-d7a5-4ae0-93bb-492d64967ae3)
```py
class A(  # will be deleted
    object
):
    ...
```

## Test Plan

<!-- How was it tested? -->

N/A, no tests/functionality affected