### PR TITLE
[`ruff`] Fix `RUF056` false negative on shadowed bindings

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF056.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF056.py
@@ -189,3 +189,8 @@ not my_dict.get("key", False, foo=...)
 # https://github.com/astral-sh/ruff/issues/18798
 d = {}
 not d.get("key", (False))
+
+# https://github.com/astral-sh/ruff/issues/18855
+dict = {}
+if dict.get(key, False):
+    ...

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF051_RUF051.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF051_RUF051.py.snap
@@ -79,7 +79,7 @@ RUF051.py:18:12: RUF051 [*] Use `pop` instead of `key in dict` followed by `del 
    |
    = help: Replace `if` statement with `.pop(..., None)`
 
-ℹ Safe fix
+ℹ Unsafe fix
 15 15 |         b''''''                     # Triple quotes
 16 16 |     ]
 17 17 | 
@@ -321,7 +321,7 @@ RUF051.py:59:5: RUF051 [*] Use `pop` instead of `key in dict` followed by `del d
    |
    = help: Replace `if` statement with `.pop(..., None)`
 
-ℹ Safe fix
+ℹ Unsafe fix
 55 55 | 
 56 56 | ### Safely fixable
 57 57 | 
@@ -342,7 +342,7 @@ RUF051.py:62:5: RUF051 [*] Use `pop` instead of `key in dict` followed by `del d
    |
    = help: Replace `if` statement with `.pop(..., None)`
 
-ℹ Safe fix
+ℹ Unsafe fix
 58 58 | if k in d:
 59 59 |     del d[k]
 60 60 | 
@@ -365,7 +365,7 @@ RUF051.py:65:5: RUF051 [*] Use `pop` instead of `key in dict` followed by `del d
    |
    = help: Replace `if` statement with `.pop(..., None)`
 
-ℹ Safe fix
+ℹ Unsafe fix
 61 61 | if '' in d:
 62 62 |     del d[""]
 63 63 | 
@@ -389,7 +389,7 @@ RUF051.py:69:12: RUF051 [*] Use `pop` instead of `key in dict` followed by `del 
    |
    = help: Replace `if` statement with `.pop(..., None)`
 
-ℹ Safe fix
+ℹ Unsafe fix
 66 66 |         b''''''
 67 67 |     ]
 68 68 | 
@@ -409,7 +409,7 @@ RUF051.py:72:5: RUF051 [*] Use `pop` instead of `key in dict` followed by `del d
    |
    = help: Replace `if` statement with `.pop(..., None)`
 
-ℹ Safe fix
+ℹ Unsafe fix
 68 68 | 
 69 69 | if 0 in d: del d[0]
 70 70 | 
@@ -430,7 +430,7 @@ RUF051.py:75:5: RUF051 [*] Use `pop` instead of `key in dict` followed by `del d
    |
    = help: Replace `if` statement with `.pop(..., None)`
 
-ℹ Safe fix
+ℹ Unsafe fix
 71 71 | if 3j in d:
 72 72 |     del d[3j]
 73 73 | 
@@ -451,7 +451,7 @@ RUF051.py:78:5: RUF051 [*] Use `pop` instead of `key in dict` followed by `del d
    |
    = help: Replace `if` statement with `.pop(..., None)`
 
-ℹ Safe fix
+ℹ Unsafe fix
 74 74 | if 0.1234 in d:
 75 75 |     del d[.1_2_3_4]
 76 76 | 
@@ -472,7 +472,7 @@ RUF051.py:81:5: RUF051 [*] Use `pop` instead of `key in dict` followed by `del d
    |
    = help: Replace `if` statement with `.pop(..., None)`
 
-ℹ Safe fix
+ℹ Unsafe fix
 77 77 | if True in d:
 78 78 |     del d[True]
 79 79 | 
@@ -495,7 +495,7 @@ RUF051.py:84:5: RUF051 [*] Use `pop` instead of `key in dict` followed by `del d
    |
    = help: Replace `if` statement with `.pop(..., None)`
 
-ℹ Safe fix
+ℹ Unsafe fix
 80 80 | if False in d:
 81 81 |     del d[False]
 82 82 | 
@@ -519,7 +519,7 @@ RUF051.py:89:5: RUF051 [*] Use `pop` instead of `key in dict` followed by `del d
    |
    = help: Replace `if` statement with `.pop(..., None)`
 
-ℹ Safe fix
+ℹ Unsafe fix
 85 85 |         None
 86 86 |     ]
 87 87 | 
@@ -541,7 +541,7 @@ RUF051.py:93:5: RUF051 [*] Use `pop` instead of `key in dict` followed by `del d
    |
    = help: Replace `if` statement with `.pop(..., None)`
 
-ℹ Safe fix
+ℹ Unsafe fix
 89 89 |     del d[
 90 90 |         ...]
 91 91 | 
@@ -562,7 +562,7 @@ RUF051.py:96:5: RUF051 [*] Use `pop` instead of `key in dict` followed by `del d
    |
    = help: Replace `if` statement with `.pop(..., None)`
 
-ℹ Safe fix
+ℹ Unsafe fix
 92 92 | if "a" "bc" in d:
 93 93 |     del d['abc']
 94 94 | 
@@ -581,7 +581,7 @@ RUF051.py:99:5: RUF051 [*] Use `pop` instead of `key in dict` followed by `del d
    |
    = help: Replace `if` statement with `.pop(..., None)`
 
-ℹ Safe fix
+ℹ Unsafe fix
 95  95  | if r"\foo" in d:
 96  96  |     del d['\\foo']
 97  97  | 

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF056_RUF056.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF056_RUF056.py.snap
@@ -480,6 +480,8 @@ RUF056.py:191:19: RUF056 [*] Avoid providing a falsy fallback to `dict.get()` in
 190 | d = {}
 191 | not d.get("key", (False))
     |                   ^^^^^ RUF056
+192 |
+193 | # https://github.com/astral-sh/ruff/issues/18855
     |
     = help: Remove falsy fallback from `dict.get()`
 
@@ -489,3 +491,24 @@ RUF056.py:191:19: RUF056 [*] Avoid providing a falsy fallback to `dict.get()` in
 190 190 | d = {}
 191     |-not d.get("key", (False))
     191 |+not d.get("key")
+192 192 | 
+193 193 | # https://github.com/astral-sh/ruff/issues/18855
+194 194 | dict = {}
+
+RUF056.py:195:18: RUF056 [*] Avoid providing a falsy fallback to `dict.get()` in boolean test positions. The default fallback `None` is already falsy.
+    |
+193 | # https://github.com/astral-sh/ruff/issues/18855
+194 | dict = {}
+195 | if dict.get(key, False):
+    |                  ^^^^^ RUF056
+196 |     ...
+    |
+    = help: Remove falsy fallback from `dict.get()`
+
+ℹ Safe fix
+192 192 | 
+193 193 | # https://github.com/astral-sh/ruff/issues/18855
+194 194 | dict = {}
+195     |-if dict.get(key, False):
+    195 |+if dict.get(key):
+196 196 |     ...

--- a/crates/ruff_python_semantic/src/analyze/typing.rs
+++ b/crates/ruff_python_semantic/src/analyze/typing.rs
@@ -48,7 +48,7 @@ pub enum SubscriptKind {
 }
 
 pub fn is_known_to_be_of_type_dict(semantic: &SemanticModel, expr: &ExprName) -> bool {
-    let Some(binding) = semantic.only_binding(expr).map(|id| semantic.binding(id)) else {
+    let Some(binding) = semantic.resolve_name(expr).map(|id| semantic.binding(id)) else {
         return false;
     };
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary
This PR also affects `RUF051` and `SIM401` due to a change made to `is_known_to_be_of_type_dict` function.

Fixes #18855
<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan
Add regression test
<!-- How was it tested? -->
