### PR TITLE
Fix f-string interpolation escaping

### DIFF
--- a/crates/ruff_python_codegen/src/generator.rs
+++ b/crates/ruff_python_codegen/src/generator.rs
@@ -1912,6 +1912,7 @@ class Foo:
         assert_round_trip!(r#"f"{ chr(65)  =   :#x}""#);
         assert_round_trip!(r#"f"{  ( chr(65)  ) = }""#);
         assert_round_trip!(r#"f"{a=!r:0.05f}""#);
+        assert_round_trip!(r#"f"{1=\n}""#); // https://github.com/astral-sh/ruff/issues/18742
     }
 
     #[test]

--- a/crates/ruff_python_codegen/src/generator.rs
+++ b/crates/ruff_python_codegen/src/generator.rs
@@ -1936,7 +1936,7 @@ class Foo:
         assert_round_trip!(r#"f"{ chr(65)  =   :#x}""#);
         assert_round_trip!(r#"f"{  ( chr(65)  ) = }""#);
         assert_round_trip!(r#"f"{a=!r:0.05f}""#);
-        assert_round_trip!(r#"
+        assert_round_trip!(&r#"
 f"{1=
 }"
 "#

--- a/crates/ruff_python_codegen/src/generator.rs
+++ b/crates/ruff_python_codegen/src/generator.rs
@@ -1936,7 +1936,12 @@ class Foo:
         assert_round_trip!(r#"f"{ chr(65)  =   :#x}""#);
         assert_round_trip!(r#"f"{  ( chr(65)  ) = }""#);
         assert_round_trip!(r#"f"{a=!r:0.05f}""#);
-        assert_round_trip!(r#"f"{1=\n}""#); // https://github.com/astral-sh/ruff/issues/18742
+        assert_round_trip!(r#"
+f"{1=
+}"
+"#
+            .trim()
+            .replace('\n', LineEnding::default().as_str())); // https://github.com/astral-sh/ruff/issues/18742
     }
 
     #[test]

--- a/crates/ruff_python_codegen/src/generator.rs
+++ b/crates/ruff_python_codegen/src/generator.rs
@@ -1419,9 +1419,13 @@ impl<'a> Generator<'a> {
         }
     }
 
-    fn unparse_interpolated_string_body(&mut self, values: &[ast::InterpolatedStringElement]) {
+    fn unparse_interpolated_string_body(
+        &mut self,
+        values: &[ast::InterpolatedStringElement],
+        flags: AnyStringFlags,
+    ) {
         for value in values {
-            self.unparse_interpolated_string_element(value);
+            self.unparse_interpolated_string_element(value, flags);
         }
     }
 
@@ -1431,6 +1435,7 @@ impl<'a> Generator<'a> {
         debug_text: Option<&DebugText>,
         conversion: ConversionFlag,
         spec: Option<&ast::InterpolatedStringFormatSpec>,
+        flags: AnyStringFlags,
     ) {
         let mut generator = Generator::new(self.indent, self.line_ending);
         generator.unparse_expr(val, precedence::FORMATTED_VALUE);
@@ -1460,19 +1465,23 @@ impl<'a> Generator<'a> {
 
         if let Some(spec) = spec {
             self.p(":");
-            self.unparse_f_string_specifier(&spec.elements);
+            self.unparse_f_string_specifier(&spec.elements, flags);
         }
 
         self.p("}");
     }
 
-    fn unparse_interpolated_string_element(&mut self, element: &ast::InterpolatedStringElement) {
+    fn unparse_interpolated_string_element(
+        &mut self,
+        element: &ast::InterpolatedStringElement,
+        flags: AnyStringFlags,
+    ) {
         match element {
             ast::InterpolatedStringElement::Literal(ast::InterpolatedStringLiteralElement {
                 value,
                 ..
             }) => {
-                self.unparse_interpolated_string_literal_element(value);
+                self.unparse_interpolated_string_literal_element(value, flags);
             }
             ast::InterpolatedStringElement::Interpolation(ast::InterpolatedElement {
                 expression,
@@ -1486,17 +1495,32 @@ impl<'a> Generator<'a> {
                 debug_text.as_ref(),
                 *conversion,
                 format_spec.as_deref(),
+                flags,
             ),
         }
     }
 
-    fn unparse_interpolated_string_literal_element(&mut self, s: &str) {
+    fn unparse_interpolated_string_literal_element(&mut self, s: &str, flags: AnyStringFlags) {
         let s = s.replace('{', "{{").replace('}', "}}");
-        self.p(&s);
+        if flags.prefix().is_raw() {
+            self.buffer += &s;
+            return;
+        }
+        let escape = UnicodeEscape::with_preferred_quote(&s, flags.quote_style());
+        if let Some(len) = escape.layout().len {
+            self.buffer.reserve(len);
+        }
+        escape
+            .write_body(&mut self.buffer)
+            .expect("Writing to a String buffer should never fail");
     }
 
-    fn unparse_f_string_specifier(&mut self, values: &[ast::InterpolatedStringElement]) {
-        self.unparse_interpolated_string_body(values);
+    fn unparse_f_string_specifier(
+        &mut self,
+        values: &[ast::InterpolatedStringElement],
+        flags: AnyStringFlags,
+    ) {
+        self.unparse_interpolated_string_body(values, flags);
     }
 
     /// Unparse `values` with [`Generator::unparse_f_string_body`], using `quote` as the preferred
@@ -1506,10 +1530,10 @@ impl<'a> Generator<'a> {
         values: &[ast::InterpolatedStringElement],
         flags: AnyStringFlags,
     ) {
-        let mut generator = Generator::new(self.indent, self.line_ending);
-        generator.unparse_interpolated_string_body(values);
-        let body = &generator.buffer;
-        self.p_str_repr(body, flags);
+        self.p(flags.prefix().as_str());
+        self.p(flags.quote_str());
+        self.unparse_interpolated_string_body(values, flags);
+        self.p(flags.quote_str());
     }
 
     fn unparse_t_string_value(&mut self, value: &ast::TStringValue) {


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Fixes #18742

Since I wasn't very clear about the actual problem in #18742, here's it re-explained:

When ever an f-string contains a slash, it will get re-escaped, causing quadratic slash growth depending on the depth of f-string nesting.

Note: For all these examples I'll use `SIM201` since it's very easy to trigger, but this applies to any rule that uses AST-based changes and can contain f-strings.
Note: I'm using the playground instead of the command line to get these examples, since they generate syntax errors and thus don't show the broken code.
Note: I'm targeting python 3.12 for all of this, since it all in-multiline-string-inside-f-string newline -> `\n` conversions instantly cause a syntax error pre-3.12, and this PR does not fix that issue.

[Examples in the playground](https://play.ruff.rs/6189667c-b3d8-44b2-a9c9-8b4b4489d2ef)
```py
not f"{"\\"}" == 1
# Fixes to
f'{"\\\\"}' != 1

not f"{f"{"\\"}"}" == 1
# Fixes to
f"{f'{\"\\\\\\\\\"}'}" != 1

not f"{f"{f"{"\\"}"}"}" == 1
# Fixes to
f"{f\"{f'{\\\"\\\\\\\\\\\\\\\\\\\"}'}\"}" != 1
```

This is where the original bug I found in #18742 came from:
The code
```py
f"{1=
}"
```
Because of the `=`, it gets written verbatim to the code generator's internal buffer as `f"{1=\n}"`, and then because of the code bug gets string encoded, leading to a buffer of `f"{1=\\n}"`, which is the syntax error I originally found.

The issue came from passing the generated string of the f-string node through the normal string handler. My assumption is this was to save on code duplication/having to re-do the string prefix, but it causes any backslashes inside the f-string to be double escaped.

This PR fixes that by giving the f-string string parts their own specialized code for only outputting the string body without the quotes.

Note: It looks like there are a couple different ways of adding the output to the buffer: `self.p`, `write!(self.buffer`, and `self.buffer +=`. I chose ones I thought might fit, but I'm not sure of the difference between all of them, or if I should have chosen differently.

## Test Plan

<!-- How was it tested? -->

Added a test to the `self_documenting_fstring` section