### PR TITLE
fix casing of `analyze.direction` variant names

### DIFF
--- a/crates/ruff_graph/src/settings.rs
+++ b/crates/ruff_graph/src/settings.rs
@@ -36,14 +36,20 @@ impl fmt::Display for AnalyzeSettings {
 }
 
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq, CacheKey)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "kebab-case")
+)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 pub enum Direction {
     /// Construct a map from module to its dependencies (i.e., the modules that it imports).
     #[default]
+    #[cfg_attr(feature = "serde", serde(alias = "Dependencies"))]
     Dependencies,
     /// Construct a map from module to its dependents (i.e., the modules that import it).
+    #[cfg_attr(feature = "serde", serde(alias = "Dependents"))]
     Dependents,
 }
 

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -873,14 +873,14 @@
           "description": "Construct a map from module to its dependencies (i.e., the modules that it imports).",
           "type": "string",
           "enum": [
-            "Dependencies"
+            "dependencies"
           ]
         },
         {
           "description": "Construct a map from module to its dependents (i.e., the modules that import it).",
           "type": "string",
           "enum": [
-            "Dependents"
+            "dependents"
           ]
         }
       ]


### PR DESCRIPTION
## Summary

Fixes `analyze.direction` to use kebab-case for the variant names. 

## Test Plan

Created a `ruff.toml` and tested that both `dependents` and `Dependents` were accepted
