### PR TITLE
[ty] Avoid duplicate diagnostic in unpacking

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/unpacking.md
+++ b/crates/ty_python_semantic/resources/mdtest/unpacking.md
@@ -734,9 +734,6 @@ with ContextManager() as (a, *b):
 ### Unbound context manager expression
 
 ```py
-# TODO: should only be one diagnostic
-# error: [unresolved-reference] "Name `nonexistant` used when not defined"
-# error: [unresolved-reference] "Name `nonexistant` used when not defined"
 # error: [unresolved-reference] "Name `nonexistant` used when not defined"
 with nonexistant as (x, y):
     reveal_type(x)  # revealed: Unknown


### PR DESCRIPTION
## Summary

This PR fixes astral-sh/ty#185 by avoiding to infer the value expression for an unpacking.

This is done simply by only inferring the value expression in a non-unpacking branch for assignment statement, for statement, with statement and comprehensions.

This is a simpler alternative to https://github.com/astral-sh/ruff/pull/18890 which I only realized in hindsight! Ideally, the solution would to consider the "unpack" as it's own region and do all of the inference of every expressions involved in an unpacking inside the unpack query and then merge the results in the outer query. This would require access to the `Unpack` ingredient which is stored on the `Definition`. And, this would require create the said `Definition`s for all attributes and subscript expressions. It does simplify the target inference logic by streamlining it into a single `infer_target` method instead of the `infer_target`/`infer_target_impl` split.

Additionally, #18890 also solves a couple of TODOs around raising errors around attribute / subscript assignment.

## Test Plan

Update the existing test, go through a couple of ecosystem diagnostic.
