### PR TITLE
[`flake8-future-annotations`] Add autofix (`FA100`) 

### DIFF
--- a/crates/ruff_linter/src/importer/mod.rs
+++ b/crates/ruff_linter/src/importer/mod.rs
@@ -73,16 +73,23 @@ impl<'a> Importer<'a> {
     /// of the file. Otherwise, it will be added after the most recent top-level
     /// import statement.
     pub(crate) fn add_import(&self, import: &NameImport, at: TextSize) -> Edit {
-        let required_import = import.to_string();
         if let Some(stmt) = self.preceding_import(at) {
             // Insert after the last top-level import.
             Insertion::end_of_statement(stmt, self.locator, self.stylist)
-                .into_edit(&required_import)
+                .into_edit(&import.to_string())
         } else {
-            // Insert at the start of the file.
-            Insertion::start_of_file(self.python_ast, self.locator, self.stylist)
-                .into_edit(&required_import)
+            self.add_import_at_start_of_file(import)
         }
+    }
+
+    /// Add an import statement to import the given module at the top of the file.
+    ///
+    /// Note that most callers should prefer [`Importer::add_import`], which will instead add
+    /// imports after the last top-level import, but this method may be needed in certain cases,
+    /// such as when importing from `__future__`.
+    pub(crate) fn add_import_at_start_of_file(&self, import: &NameImport) -> Edit {
+        Insertion::start_of_file(self.python_ast, self.locator, self.stylist)
+            .into_edit(&import.to_string())
     }
 
     /// Move an existing import to the top-level, thereby making it available at runtime.

--- a/crates/ruff_linter/src/importer/mod.rs
+++ b/crates/ruff_linter/src/importer/mod.rs
@@ -73,23 +73,16 @@ impl<'a> Importer<'a> {
     /// of the file. Otherwise, it will be added after the most recent top-level
     /// import statement.
     pub(crate) fn add_import(&self, import: &NameImport, at: TextSize) -> Edit {
+        let required_import = import.to_string();
         if let Some(stmt) = self.preceding_import(at) {
             // Insert after the last top-level import.
             Insertion::end_of_statement(stmt, self.locator, self.stylist)
-                .into_edit(&import.to_string())
+                .into_edit(&required_import)
         } else {
-            self.add_import_at_start_of_file(import)
+            // Insert at the start of the file.
+            Insertion::start_of_file(self.python_ast, self.locator, self.stylist)
+                .into_edit(&required_import)
         }
-    }
-
-    /// Add an import statement to import the given module at the top of the file.
-    ///
-    /// Note that most callers should prefer [`Importer::add_import`], which will instead add
-    /// imports after the last top-level import, but this method may be needed in certain cases,
-    /// such as when importing from `__future__`.
-    pub(crate) fn add_import_at_start_of_file(&self, import: &NameImport) -> Edit {
-        Insertion::start_of_file(self.python_ast, self.locator, self.stylist)
-            .into_edit(&import.to_string())
     }
 
     /// Move an existing import to the top-level, thereby making it available at runtime.

--- a/crates/ruff_linter/src/rules/flake8_future_annotations/rules/future_rewritable_type_annotation.rs
+++ b/crates/ruff_linter/src/rules/flake8_future_annotations/rules/future_rewritable_type_annotation.rs
@@ -5,7 +5,7 @@ use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_python_semantic::{MemberNameImport, NameImport};
 use ruff_text_size::Ranged;
 
-use crate::Violation;
+use crate::AlwaysFixableViolation;
 use crate::checkers::ast::Checker;
 
 /// ## What it does
@@ -70,17 +70,15 @@ pub(crate) struct FutureRewritableTypeAnnotation {
     name: String,
 }
 
-impl Violation for FutureRewritableTypeAnnotation {
-    const FIX_AVAILABILITY: crate::FixAvailability = crate::FixAvailability::Sometimes;
-
+impl AlwaysFixableViolation for FutureRewritableTypeAnnotation {
     #[derive_message_formats]
     fn message(&self) -> String {
         let FutureRewritableTypeAnnotation { name } = self;
         format!("Add `from __future__ import annotations` to simplify `{name}`")
     }
 
-    fn fix_title(&self) -> Option<String> {
-        Some(self.message())
+    fn fix_title(&self) -> String {
+        self.message()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_future_annotations/rules/future_rewritable_type_annotation.rs
+++ b/crates/ruff_linter/src/rules/flake8_future_annotations/rules/future_rewritable_type_annotation.rs
@@ -99,11 +99,11 @@ pub(crate) fn future_rewritable_type_annotation(checker: &Checker, expr: &Expr) 
         "__future__".to_string(),
         "annotations".to_string(),
     ));
-    let edit = checker
-        .importer()
-        .add_import(import, ruff_text_size::TextSize::default());
-
     checker
         .report_diagnostic(FutureRewritableTypeAnnotation { name }, expr.range())
-        .set_fix(Fix::unsafe_edit(edit));
+        .set_fix(Fix::unsafe_edit(
+            checker
+                .importer()
+                .add_import(import, ruff_text_size::TextSize::default()),
+        ));
 }

--- a/crates/ruff_linter/src/rules/flake8_future_annotations/rules/future_rewritable_type_annotation.rs
+++ b/crates/ruff_linter/src/rules/flake8_future_annotations/rules/future_rewritable_type_annotation.rs
@@ -63,6 +63,10 @@ use crate::checkers::ast::Checker;
 /// def func(obj: dict[str, int | None]) -> None: ...
 /// ```
 ///
+/// ## Fix safety
+/// This rule's fix is marked as unsafe, as adding `from __future__ import annotations`
+/// may change the semantics of the program.
+///
 /// ## Options
 /// - `target-version`
 #[derive(ViolationMetadata)]
@@ -101,5 +105,5 @@ pub(crate) fn future_rewritable_type_annotation(checker: &Checker, expr: &Expr) 
 
     checker
         .report_diagnostic(FutureRewritableTypeAnnotation { name }, expr.range())
-        .set_fix(Fix::safe_edit(edit));
+        .set_fix(Fix::unsafe_edit(edit));
 }

--- a/crates/ruff_linter/src/rules/flake8_future_annotations/rules/future_rewritable_type_annotation.rs
+++ b/crates/ruff_linter/src/rules/flake8_future_annotations/rules/future_rewritable_type_annotation.rs
@@ -82,7 +82,7 @@ impl AlwaysFixableViolation for FutureRewritableTypeAnnotation {
     }
 
     fn fix_title(&self) -> String {
-        self.message()
+        "Add `from __future__ import annotations`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_future_annotations/rules/future_rewritable_type_annotation.rs
+++ b/crates/ruff_linter/src/rules/flake8_future_annotations/rules/future_rewritable_type_annotation.rs
@@ -95,7 +95,9 @@ pub(crate) fn future_rewritable_type_annotation(checker: &Checker, expr: &Expr) 
         "__future__".to_string(),
         "annotations".to_string(),
     ));
-    let edit = checker.importer().add_import_at_start_of_file(import);
+    let edit = checker
+        .importer()
+        .add_import(import, ruff_text_size::TextSize::default());
 
     checker
         .report_diagnostic(FutureRewritableTypeAnnotation { name }, expr.range())

--- a/crates/ruff_linter/src/rules/flake8_future_annotations/snapshots/ruff_linter__rules__flake8_future_annotations__tests__edge_case.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_future_annotations/snapshots/ruff_linter__rules__flake8_future_annotations__tests__edge_case.py.snap
@@ -8,9 +8,9 @@ edge_case.py:5:13: FA100 [*] Add `from __future__ import annotations` to simplif
 6 |     a_list: t.List[str] = []
 7 |     a_list.append("hello")
   |
-  = help: Add `from __future__ import annotations` to simplify `typing.List`
+  = help: Add `from __future__ import annotations`
 
-ℹ Safe fix
+ℹ Unsafe fix
   1 |+from __future__ import annotations
 1 2 | from typing import List
 2 3 | import typing as t
@@ -23,9 +23,9 @@ edge_case.py:6:13: FA100 [*] Add `from __future__ import annotations` to simplif
   |             ^^^^^^ FA100
 7 |     a_list.append("hello")
   |
-  = help: Add `from __future__ import annotations` to simplify `typing.List`
+  = help: Add `from __future__ import annotations`
 
-ℹ Safe fix
+ℹ Unsafe fix
   1 |+from __future__ import annotations
 1 2 | from typing import List
 2 3 | import typing as t

--- a/crates/ruff_linter/src/rules/flake8_future_annotations/snapshots/ruff_linter__rules__flake8_future_annotations__tests__edge_case.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_future_annotations/snapshots/ruff_linter__rules__flake8_future_annotations__tests__edge_case.py.snap
@@ -1,19 +1,32 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_future_annotations/mod.rs
-snapshot_kind: text
 ---
-edge_case.py:5:13: FA100 Add `from __future__ import annotations` to simplify `typing.List`
+edge_case.py:5:13: FA100 [*] Add `from __future__ import annotations` to simplify `typing.List`
   |
 5 | def main(_: List[int]) -> None:
   |             ^^^^ FA100
 6 |     a_list: t.List[str] = []
 7 |     a_list.append("hello")
   |
+  = help: Add `from __future__ import annotations` to simplify `typing.List`
 
-edge_case.py:6:13: FA100 Add `from __future__ import annotations` to simplify `typing.List`
+ℹ Safe fix
+  1 |+from __future__ import annotations
+1 2 | from typing import List
+2 3 | import typing as t
+3 4 | 
+
+edge_case.py:6:13: FA100 [*] Add `from __future__ import annotations` to simplify `typing.List`
   |
 5 | def main(_: List[int]) -> None:
 6 |     a_list: t.List[str] = []
   |             ^^^^^^ FA100
 7 |     a_list.append("hello")
   |
+  = help: Add `from __future__ import annotations` to simplify `typing.List`
+
+ℹ Safe fix
+  1 |+from __future__ import annotations
+1 2 | from typing import List
+2 3 | import typing as t
+3 4 |

--- a/crates/ruff_linter/src/rules/flake8_future_annotations/snapshots/ruff_linter__rules__flake8_future_annotations__tests__from_typing_import.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_future_annotations/snapshots/ruff_linter__rules__flake8_future_annotations__tests__from_typing_import.py.snap
@@ -1,11 +1,17 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_future_annotations/mod.rs
-snapshot_kind: text
 ---
-from_typing_import.py:5:13: FA100 Add `from __future__ import annotations` to simplify `typing.List`
+from_typing_import.py:5:13: FA100 [*] Add `from __future__ import annotations` to simplify `typing.List`
   |
 4 | def main() -> None:
 5 |     a_list: List[str] = []
   |             ^^^^ FA100
 6 |     a_list.append("hello")
   |
+  = help: Add `from __future__ import annotations` to simplify `typing.List`
+
+ℹ Safe fix
+  1 |+from __future__ import annotations
+1 2 | from typing import List
+2 3 | 
+3 4 |

--- a/crates/ruff_linter/src/rules/flake8_future_annotations/snapshots/ruff_linter__rules__flake8_future_annotations__tests__from_typing_import.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_future_annotations/snapshots/ruff_linter__rules__flake8_future_annotations__tests__from_typing_import.py.snap
@@ -8,9 +8,9 @@ from_typing_import.py:5:13: FA100 [*] Add `from __future__ import annotations` t
   |             ^^^^ FA100
 6 |     a_list.append("hello")
   |
-  = help: Add `from __future__ import annotations` to simplify `typing.List`
+  = help: Add `from __future__ import annotations`
 
-ℹ Safe fix
+ℹ Unsafe fix
   1 |+from __future__ import annotations
 1 2 | from typing import List
 2 3 | 

--- a/crates/ruff_linter/src/rules/flake8_future_annotations/snapshots/ruff_linter__rules__flake8_future_annotations__tests__from_typing_import_many.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_future_annotations/snapshots/ruff_linter__rules__flake8_future_annotations__tests__from_typing_import_many.py.snap
@@ -9,9 +9,9 @@ from_typing_import_many.py:5:13: FA100 [*] Add `from __future__ import annotatio
 6 |     a_list.append("hello")
 7 |     a_dict = cast(Dict[int | None, Union[int, Set[bool]]], {})
   |
-  = help: Add `from __future__ import annotations` to simplify `typing.List`
+  = help: Add `from __future__ import annotations`
 
-ℹ Safe fix
+ℹ Unsafe fix
   1 |+from __future__ import annotations
 1 2 | from typing import Dict, List, Optional, Set, Union, cast
 2 3 | 
@@ -25,9 +25,9 @@ from_typing_import_many.py:5:18: FA100 [*] Add `from __future__ import annotatio
 6 |     a_list.append("hello")
 7 |     a_dict = cast(Dict[int | None, Union[int, Set[bool]]], {})
   |
-  = help: Add `from __future__ import annotations` to simplify `typing.Optional`
+  = help: Add `from __future__ import annotations`
 
-ℹ Safe fix
+ℹ Unsafe fix
   1 |+from __future__ import annotations
 1 2 | from typing import Dict, List, Optional, Set, Union, cast
 2 3 | 

--- a/crates/ruff_linter/src/rules/flake8_future_annotations/snapshots/ruff_linter__rules__flake8_future_annotations__tests__from_typing_import_many.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_future_annotations/snapshots/ruff_linter__rules__flake8_future_annotations__tests__from_typing_import_many.py.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_future_annotations/mod.rs
-snapshot_kind: text
 ---
-from_typing_import_many.py:5:13: FA100 Add `from __future__ import annotations` to simplify `typing.List`
+from_typing_import_many.py:5:13: FA100 [*] Add `from __future__ import annotations` to simplify `typing.List`
   |
 4 | def main() -> None:
 5 |     a_list: List[Optional[str]] = []
@@ -10,8 +9,15 @@ from_typing_import_many.py:5:13: FA100 Add `from __future__ import annotations` 
 6 |     a_list.append("hello")
 7 |     a_dict = cast(Dict[int | None, Union[int, Set[bool]]], {})
   |
+  = help: Add `from __future__ import annotations` to simplify `typing.List`
 
-from_typing_import_many.py:5:18: FA100 Add `from __future__ import annotations` to simplify `typing.Optional`
+ℹ Safe fix
+  1 |+from __future__ import annotations
+1 2 | from typing import Dict, List, Optional, Set, Union, cast
+2 3 | 
+3 4 | 
+
+from_typing_import_many.py:5:18: FA100 [*] Add `from __future__ import annotations` to simplify `typing.Optional`
   |
 4 | def main() -> None:
 5 |     a_list: List[Optional[str]] = []
@@ -19,3 +25,10 @@ from_typing_import_many.py:5:18: FA100 Add `from __future__ import annotations` 
 6 |     a_list.append("hello")
 7 |     a_dict = cast(Dict[int | None, Union[int, Set[bool]]], {})
   |
+  = help: Add `from __future__ import annotations` to simplify `typing.Optional`
+
+ℹ Safe fix
+  1 |+from __future__ import annotations
+1 2 | from typing import Dict, List, Optional, Set, Union, cast
+2 3 | 
+3 4 |

--- a/crates/ruff_linter/src/rules/flake8_future_annotations/snapshots/ruff_linter__rules__flake8_future_annotations__tests__import_typing.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_future_annotations/snapshots/ruff_linter__rules__flake8_future_annotations__tests__import_typing.py.snap
@@ -8,9 +8,9 @@ import_typing.py:5:13: FA100 [*] Add `from __future__ import annotations` to sim
   |             ^^^^^^^^^^^ FA100
 6 |     a_list.append("hello")
   |
-  = help: Add `from __future__ import annotations` to simplify `typing.List`
+  = help: Add `from __future__ import annotations`
 
-ℹ Safe fix
+ℹ Unsafe fix
   1 |+from __future__ import annotations
 1 2 | import typing
 2 3 | 

--- a/crates/ruff_linter/src/rules/flake8_future_annotations/snapshots/ruff_linter__rules__flake8_future_annotations__tests__import_typing.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_future_annotations/snapshots/ruff_linter__rules__flake8_future_annotations__tests__import_typing.py.snap
@@ -1,11 +1,17 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_future_annotations/mod.rs
-snapshot_kind: text
 ---
-import_typing.py:5:13: FA100 Add `from __future__ import annotations` to simplify `typing.List`
+import_typing.py:5:13: FA100 [*] Add `from __future__ import annotations` to simplify `typing.List`
   |
 4 | def main() -> None:
 5 |     a_list: typing.List[str] = []
   |             ^^^^^^^^^^^ FA100
 6 |     a_list.append("hello")
   |
+  = help: Add `from __future__ import annotations` to simplify `typing.List`
+
+ℹ Safe fix
+  1 |+from __future__ import annotations
+1 2 | import typing
+2 3 | 
+3 4 |

--- a/crates/ruff_linter/src/rules/flake8_future_annotations/snapshots/ruff_linter__rules__flake8_future_annotations__tests__import_typing_as.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_future_annotations/snapshots/ruff_linter__rules__flake8_future_annotations__tests__import_typing_as.py.snap
@@ -8,9 +8,9 @@ import_typing_as.py:5:13: FA100 [*] Add `from __future__ import annotations` to 
   |             ^^^^^^ FA100
 6 |     a_list.append("hello")
   |
-  = help: Add `from __future__ import annotations` to simplify `typing.List`
+  = help: Add `from __future__ import annotations`
 
-ℹ Safe fix
+ℹ Unsafe fix
   1 |+from __future__ import annotations
 1 2 | import typing as t
 2 3 | 

--- a/crates/ruff_linter/src/rules/flake8_future_annotations/snapshots/ruff_linter__rules__flake8_future_annotations__tests__import_typing_as.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_future_annotations/snapshots/ruff_linter__rules__flake8_future_annotations__tests__import_typing_as.py.snap
@@ -1,11 +1,17 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_future_annotations/mod.rs
-snapshot_kind: text
 ---
-import_typing_as.py:5:13: FA100 Add `from __future__ import annotations` to simplify `typing.List`
+import_typing_as.py:5:13: FA100 [*] Add `from __future__ import annotations` to simplify `typing.List`
   |
 4 | def main() -> None:
 5 |     a_list: t.List[str] = []
   |             ^^^^^^ FA100
 6 |     a_list.append("hello")
   |
+  = help: Add `from __future__ import annotations` to simplify `typing.List`
+
+ℹ Safe fix
+  1 |+from __future__ import annotations
+1 2 | import typing as t
+2 3 | 
+3 4 |


### PR DESCRIPTION
Summary
--

This PR resolves the easiest part of https://github.com/astral-sh/ruff/issues/18502 by adding an autofix that just adds
`from __future__ import annotations` at the top of the file, in the same way
as FA102, which already has an identical unsafe fix.

Test Plan
--

Existing snapshots, updated to add the fixes.