### PR TITLE
[`pep8_naming`] Avoid false positives on standard library functions with uppercase names (`N802`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pep8_naming/N802.py
+++ b/crates/ruff_linter/resources/test/fixtures/pep8_naming/N802.py
@@ -48,6 +48,35 @@ from typing import override, overload
 def BAD_FUNC():
     pass
 
+
 @overload
 def BAD_FUNC():
     pass
+
+
+import ast
+from ast import NodeTransformer
+
+
+class Visitor(ast.NodeVisitor):
+    def visit_Constant(self, node):
+        pass
+
+    def bad_Name(self):
+        pass
+
+
+class Transformer(NodeTransformer):
+    def visit_Constant(self, node):
+        pass
+
+
+from http.server import BaseHTTPRequestHandler
+
+
+class MyRequestHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        pass
+
+    def dont_GET(self):
+        pass

--- a/crates/ruff_linter/src/rules/pep8_naming/snapshots/ruff_linter__rules__pep8_naming__tests__N802_N802.py.snap
+++ b/crates/ruff_linter/src/rules/pep8_naming/snapshots/ruff_linter__rules__pep8_naming__tests__N802_N802.py.snap
@@ -37,3 +37,21 @@ N802.py:40:9: N802 Function name `testTest` should be lowercase
    |         ^^^^^^^^ N802
 41 |         assert True
    |
+
+N802.py:65:9: N802 Function name `bad_Name` should be lowercase
+   |
+63 |         pass
+64 |
+65 |     def bad_Name(self):
+   |         ^^^^^^^^ N802
+66 |         pass
+   |
+
+N802.py:81:9: N802 Function name `dont_GET` should be lowercase
+   |
+79 |         pass
+80 |
+81 |     def dont_GET(self):
+   |         ^^^^^^^^ N802
+82 |         pass
+   |


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

This change prevents the `visit_*` methods of ast.NodeVisitor/NodeTransformer and the `do_*` methods of http.server.BaseHTTPRequestHandler from triggering N802. See #9400 for more information.

In `Lib/ast.py`:
```python
class NodeVisitor(object):
    def visit(self, node):
        """Visit a node."""
        method = 'visit_' + node.__class__.__name__
        visitor = getattr(self, method, self.generic_visit)
        return visitor(node)
```
Example usage
```python
from ast import NodeVisitor

class Visitor(NodeVisitor):
    def visit_Constant(self, node):
        print(f"visited a constant with value {node.value}")
```

Previously, this would trigger a N802 violation, even though the uppercase name is the intended way of using those subclasses. 

## Test Plan

I added tests to `pep8_naming/N802.py`.
