### PR TITLE
[ty] Change `environment.root` to accept multiple paths

### DIFF
--- a/crates/ty/docs/configuration.md
+++ b/crates/ty/docs/configuration.md
@@ -134,9 +134,11 @@ python-version = "3.12"
 
 #### `root`
 
-The root of the project, used for finding first-party modules.
+The root paths of the project, used for finding first-party modules.
 
-If left unspecified, ty will try to detect common project layouts and initialize `src.root` accordingly:
+Accepts a list of directory paths searched in priority order (first has highest priority).
+
+If left unspecified, ty will try to detect common project layouts and initialize `root` accordingly:
 
 * if a `./src` directory exists, include `.` and `./src` in the first party search path (src layout or flat)
 * if a `./<project-name>/<project-name>` directory exists, include `.` and `./<project-name>` in the first party search path
@@ -147,13 +149,14 @@ it will also be included in the first party search path.
 
 **Default value**: `null`
 
-**Type**: `str`
+**Type**: `list[str]`
 
 **Example usage** (`pyproject.toml`):
 
 ```toml
 [tool.ty.environment]
-root = "./app"
+# Multiple directories (priority order)
+root = ["./src", "./lib", "./vendor"]
 ```
 
 ---

--- a/crates/ty/tests/cli/python_environment.rs
+++ b/crates/ty/tests/cli/python_environment.rs
@@ -972,9 +972,9 @@ fn src_root_deprecation_warning_with_environment_root() -> anyhow::Result<()> {
             r#"
             [tool.ty.src]
             root = "./src"
-            
+
             [tool.ty.environment]
-            root = "./app"
+            root = ["./app"]
             "#,
         ),
         ("app/test.py", ""),
@@ -1012,9 +1012,9 @@ fn environment_root_takes_precedence_over_src_root() -> anyhow::Result<()> {
             r#"
             [tool.ty.src]
             root = "./src"
-            
+
             [tool.ty.environment]
-            root = "./app"
+            root = ["./app"]
             "#,
         ),
         ("src/test.py", "import my_module"),

--- a/ty.schema.json
+++ b/ty.schema.json
@@ -120,11 +120,14 @@
           ]
         },
         "root": {
-          "description": "The root of the project, used for finding first-party modules.\n\nIf left unspecified, ty will try to detect common project layouts and initialize `src.root` accordingly:\n\n* if a `./src` directory exists, include `.` and `./src` in the first party search path (src layout or flat) * if a `./<project-name>/<project-name>` directory exists, include `.` and `./<project-name>` in the first party search path * otherwise, default to `.` (flat layout)\n\nBesides, if a `./tests` directory exists and is not a package (i.e. it does not contain an `__init__.py` file), it will also be included in the first party search path.",
+          "description": "The root paths of the project, used for finding first-party modules.\n\nAccepts a list of directory paths searched in priority order (first has highest priority).\n\nIf left unspecified, ty will try to detect common project layouts and initialize `root` accordingly:\n\n* if a `./src` directory exists, include `.` and `./src` in the first party search path (src layout or flat) * if a `./<project-name>/<project-name>` directory exists, include `.` and `./<project-name>` in the first party search path * otherwise, default to `.` (flat layout)\n\nBesides, if a `./tests` directory exists and is not a package (i.e. it does not contain an `__init__.py` file), it will also be included in the first party search path.",
           "type": [
-            "string",
+            "array",
             "null"
-          ]
+          ],
+          "items": {
+            "type": "string"
+          }
         },
         "typeshed": {
           "description": "Optional path to a \"typeshed\" directory on disk for us to use for standard-library types. If this is not provided, we will fallback to our vendored typeshed stubs for the stdlib, bundled as a zip file in the binary",


### PR DESCRIPTION
## Summary
Change `environment.root` to accept multiple paths to allow e.g. `root = ["./app", "./tests"]`.

I decided not to extend the syntax to support globs for now. I think that's something we can add later if it proves to be necessary. Supporting globs also has the downside that it requires a directory traversal to find all matches.

Closes https://github.com/astral-sh/ty/issues/179


## Test Plan

Updated tests
