### PR TITLE
py-fuzzer: allow relative executable paths

### DIFF
--- a/python/py-fuzzer/fuzz.py
+++ b/python/py-fuzzer/fuzz.py
@@ -54,7 +54,9 @@ def ty_contains_bug(code: str, *, ty_executable: Path) -> bool:
         input_file = Path(tempdir, "input.py")
         input_file.write_text(code)
         completed_process = subprocess.run(
-            [ty_executable, "check", input_file], capture_output=True, text=True
+            [ty_executable.resolve(), "check", input_file],
+            capture_output=True,
+            text=True,
         )
     return completed_process.returncode not in {0, 1, 2}
 
@@ -367,7 +369,9 @@ def parse_args() -> ResolvedCliArgs:
             )
         try:
             subprocess.run(
-                [args.baseline_executable, "--version"], check=True, capture_output=True
+                [args.baseline_executable.resolve(), "--version"],
+                check=True,
+                capture_output=True,
             )
         except FileNotFoundError:
             parser.error(

--- a/python/py-fuzzer/fuzz.py
+++ b/python/py-fuzzer/fuzz.py
@@ -54,9 +54,7 @@ def ty_contains_bug(code: str, *, ty_executable: Path) -> bool:
         input_file = Path(tempdir, "input.py")
         input_file.write_text(code)
         completed_process = subprocess.run(
-            [ty_executable.resolve(), "check", input_file],
-            capture_output=True,
-            text=True,
+            [ty_executable, "check", input_file], capture_output=True, text=True
         )
     return completed_process.returncode not in {0, 1, 2}
 
@@ -270,6 +268,10 @@ def run_fuzzer(args: ResolvedCliArgs) -> ExitCode:
         return ExitCode(0)
 
 
+def absolute_path(p: str) -> Path:
+    return Path(p).absolute()
+
+
 def parse_seed_argument(arg: str) -> int | range:
     """Helper for argument parsing"""
     if "-" in arg:
@@ -339,7 +341,7 @@ def parse_args() -> ResolvedCliArgs:
             "Executable to test. "
             "Defaults to a fresh build of the currently checked-out branch."
         ),
-        type=Path,
+        type=absolute_path,
     )
     parser.add_argument(
         "--baseline-executable",
@@ -348,7 +350,7 @@ def parse_args() -> ResolvedCliArgs:
             "Defaults to whatever version is installed "
             "in the Python environment."
         ),
-        type=Path,
+        type=absolute_path,
     )
     parser.add_argument(
         "--bin",
@@ -369,9 +371,7 @@ def parse_args() -> ResolvedCliArgs:
             )
         try:
             subprocess.run(
-                [args.baseline_executable.resolve(), "--version"],
-                check=True,
-                capture_output=True,
+                [args.baseline_executable, "--version"], check=True, capture_output=True
             )
         except FileNotFoundError:
             parser.error(


### PR DESCRIPTION
## Summary

I tried running `py-fuzzer` using executables in the current working directory, but that failed with:
```
▶ uvx --from ./python/py-fuzzer --reinstall fuzz --test-executable ./ty_feature --bin=ty --baseline-executable ./ty_main --only-new-bugs 0-500
Usage: fuzz [-h] [--only-new-bugs] [--quiet] [--test-executable TEST_EXECUTABLE] [--baseline-executable BASELINE_EXECUTABLE] --bin {ruff,ty} seeds [seeds ...]
fuzz: error: Bad argument passed to `--baseline-executable`: no such file or executable PosixPath('ty_main')
 "Bad argument passed to `--baseline-executable`: no such file or executable PosixPath('ty_main')"
```

Using `.absolute()` on the `Path` fixes this.


## Test Plan

Successful `py-fuzzer` run with the invocation above.