### PR TITLE
[ty] Enforce sort order of completions

### DIFF
--- a/crates/ty_server/src/server/api/requests/completion.rs
+++ b/crates/ty_server/src/server/api/requests/completion.rs
@@ -51,10 +51,13 @@ impl BackgroundDocumentRequestHandler for CompletionRequestHandler {
             return Ok(None);
         }
 
+        let max_index_len = completions.len().saturating_sub(1).to_string().len();
         let items: Vec<CompletionItem> = completions
             .into_iter()
-            .map(|comp| CompletionItem {
+            .enumerate()
+            .map(|(i, comp)| CompletionItem {
                 label: comp.label,
+                sort_text: Some(format!("{i:-max_index_len$}")),
                 ..Default::default()
             })
             .collect();


### PR DESCRIPTION
We achieve this by setting the "sort text" field of every completion.
Since we are trying to be smart about the order, we want the client to
respect our order.

Prior to this change, VS Code was re-sorting completions in
lexicographic order. This in turn resulted in dunder attributes
appearing before "normal" attributes.
