### PR TITLE
Fix link typo in ty's CONTRIBUTING.md

### DIFF
--- a/crates/ty/CONTRIBUTING.md
+++ b/crates/ty/CONTRIBUTING.md
@@ -133,7 +133,7 @@ for instructions on running these checks locally.
 
 ## Coding guidelines
 
-We use the [Salsa](https:://github.com/salsa-rs/salsa) library for incremental computation. Many
+We use the [Salsa](https://github.com/salsa-rs/salsa) library for incremental computation. Many
 methods take a Salsa database (usually `db: &'db dyn Db`) as an argument. This should always be the
 first argument (or second after `self`).
 


### PR DESCRIPTION
## Summary

There was a single character typo in a documentation link which got it misinterpreted as a relative link to a non-existent page. 

## Test Plan

Checked the link now goes to the Salsa repository
