### PR TITLE
[`refurb`] Detect more exotic float literals in `FURB164`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/refurb/FURB164.py
+++ b/crates/ruff_linter/resources/test/fixtures/refurb/FURB164.py
@@ -20,6 +20,12 @@ _ = Decimal.from_float(float("-inf"))
 _ = Decimal.from_float(float("Infinity"))
 _ = Decimal.from_float(float("-Infinity"))
 _ = Decimal.from_float(float("nan"))
+_ = Decimal.from_float(float("-NaN "))
+_ = Decimal.from_float(float(" \n+nan   \t"))
+_ = Decimal.from_float(float("  iNf \n\t "))
+_ = Decimal.from_float(float("   -inF\n \t"))
+_ = Decimal.from_float(float("  InfinIty \n\t "))
+_ = Decimal.from_float(float("   -InfinIty\n \t"))
 
 # OK
 _ = Fraction(0.1)

--- a/crates/ruff_linter/src/rules/refurb/rules/unnecessary_from_float.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/unnecessary_from_float.rs
@@ -3,6 +3,7 @@ use ruff_python_ast::{self as ast, Expr, ExprCall};
 use ruff_text_size::Ranged;
 
 use crate::checkers::ast::Checker;
+use crate::linter::float::as_non_finite_float_string_literal;
 use crate::{Edit, Fix, FixAvailability, Violation};
 
 /// ## What it does
@@ -137,14 +138,7 @@ pub(crate) fn unnecessary_from_float(checker: &Checker, call: &ExprCall) {
         let [float] = arguments.args.as_ref() else {
             break 'short_circuit;
         };
-        let Some(float) = float.as_string_literal_expr() else {
-            break 'short_circuit;
-        };
-        // FIXME: use `as_non_finite_float_string_literal` instead.
-        if !matches!(
-            float.value.to_str().to_lowercase().as_str(),
-            "inf" | "-inf" | "infinity" | "-infinity" | "nan"
-        ) {
+        if as_non_finite_float_string_literal(float).is_none() {
             break 'short_circuit;
         }
 

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB164_FURB164.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB164_FURB164.py.snap
@@ -313,7 +313,7 @@ FURB164.py:20:5: FURB164 [*] Verbose method `from_float` in `Decimal` constructi
    20 |+_ = Decimal("Infinity")
 21 21 | _ = Decimal.from_float(float("-Infinity"))
 22 22 | _ = Decimal.from_float(float("nan"))
-23 23 | 
+23 23 | _ = Decimal.from_float(float("-NaN "))
 
 FURB164.py:21:5: FURB164 [*] Verbose method `from_float` in `Decimal` construction
    |
@@ -322,6 +322,7 @@ FURB164.py:21:5: FURB164 [*] Verbose method `from_float` in `Decimal` constructi
 21 | _ = Decimal.from_float(float("-Infinity"))
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FURB164
 22 | _ = Decimal.from_float(float("nan"))
+23 | _ = Decimal.from_float(float("-NaN "))
    |
    = help: Replace with `Decimal` constructor
 
@@ -332,8 +333,8 @@ FURB164.py:21:5: FURB164 [*] Verbose method `from_float` in `Decimal` constructi
 21    |-_ = Decimal.from_float(float("-Infinity"))
    21 |+_ = Decimal("-Infinity")
 22 22 | _ = Decimal.from_float(float("nan"))
-23 23 | 
-24 24 | # OK
+23 23 | _ = Decimal.from_float(float("-NaN "))
+24 24 | _ = Decimal.from_float(float(" \n+nan   \t"))
 
 FURB164.py:22:5: FURB164 [*] Verbose method `from_float` in `Decimal` construction
    |
@@ -341,8 +342,8 @@ FURB164.py:22:5: FURB164 [*] Verbose method `from_float` in `Decimal` constructi
 21 | _ = Decimal.from_float(float("-Infinity"))
 22 | _ = Decimal.from_float(float("nan"))
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FURB164
-23 |
-24 | # OK
+23 | _ = Decimal.from_float(float("-NaN "))
+24 | _ = Decimal.from_float(float(" \n+nan   \t"))
    |
    = help: Replace with `Decimal` constructor
 
@@ -352,6 +353,131 @@ FURB164.py:22:5: FURB164 [*] Verbose method `from_float` in `Decimal` constructi
 21 21 | _ = Decimal.from_float(float("-Infinity"))
 22    |-_ = Decimal.from_float(float("nan"))
    22 |+_ = Decimal("nan")
-23 23 | 
-24 24 | # OK
-25 25 | _ = Fraction(0.1)
+23 23 | _ = Decimal.from_float(float("-NaN "))
+24 24 | _ = Decimal.from_float(float(" \n+nan   \t"))
+25 25 | _ = Decimal.from_float(float("  iNf \n\t "))
+
+FURB164.py:23:5: FURB164 [*] Verbose method `from_float` in `Decimal` construction
+   |
+21 | _ = Decimal.from_float(float("-Infinity"))
+22 | _ = Decimal.from_float(float("nan"))
+23 | _ = Decimal.from_float(float("-NaN "))
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FURB164
+24 | _ = Decimal.from_float(float(" \n+nan   \t"))
+25 | _ = Decimal.from_float(float("  iNf \n\t "))
+   |
+   = help: Replace with `Decimal` constructor
+
+ℹ Safe fix
+20 20 | _ = Decimal.from_float(float("Infinity"))
+21 21 | _ = Decimal.from_float(float("-Infinity"))
+22 22 | _ = Decimal.from_float(float("nan"))
+23    |-_ = Decimal.from_float(float("-NaN "))
+   23 |+_ = Decimal("-NaN ")
+24 24 | _ = Decimal.from_float(float(" \n+nan   \t"))
+25 25 | _ = Decimal.from_float(float("  iNf \n\t "))
+26 26 | _ = Decimal.from_float(float("   -inF\n \t"))
+
+FURB164.py:24:5: FURB164 [*] Verbose method `from_float` in `Decimal` construction
+   |
+22 | _ = Decimal.from_float(float("nan"))
+23 | _ = Decimal.from_float(float("-NaN "))
+24 | _ = Decimal.from_float(float(" \n+nan   \t"))
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FURB164
+25 | _ = Decimal.from_float(float("  iNf \n\t "))
+26 | _ = Decimal.from_float(float("   -inF\n \t"))
+   |
+   = help: Replace with `Decimal` constructor
+
+ℹ Safe fix
+21 21 | _ = Decimal.from_float(float("-Infinity"))
+22 22 | _ = Decimal.from_float(float("nan"))
+23 23 | _ = Decimal.from_float(float("-NaN "))
+24    |-_ = Decimal.from_float(float(" \n+nan   \t"))
+   24 |+_ = Decimal(" \n+nan   \t")
+25 25 | _ = Decimal.from_float(float("  iNf \n\t "))
+26 26 | _ = Decimal.from_float(float("   -inF\n \t"))
+27 27 | _ = Decimal.from_float(float("  InfinIty \n\t "))
+
+FURB164.py:25:5: FURB164 [*] Verbose method `from_float` in `Decimal` construction
+   |
+23 | _ = Decimal.from_float(float("-NaN "))
+24 | _ = Decimal.from_float(float(" \n+nan   \t"))
+25 | _ = Decimal.from_float(float("  iNf \n\t "))
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FURB164
+26 | _ = Decimal.from_float(float("   -inF\n \t"))
+27 | _ = Decimal.from_float(float("  InfinIty \n\t "))
+   |
+   = help: Replace with `Decimal` constructor
+
+ℹ Safe fix
+22 22 | _ = Decimal.from_float(float("nan"))
+23 23 | _ = Decimal.from_float(float("-NaN "))
+24 24 | _ = Decimal.from_float(float(" \n+nan   \t"))
+25    |-_ = Decimal.from_float(float("  iNf \n\t "))
+   25 |+_ = Decimal("  iNf \n\t ")
+26 26 | _ = Decimal.from_float(float("   -inF\n \t"))
+27 27 | _ = Decimal.from_float(float("  InfinIty \n\t "))
+28 28 | _ = Decimal.from_float(float("   -InfinIty\n \t"))
+
+FURB164.py:26:5: FURB164 [*] Verbose method `from_float` in `Decimal` construction
+   |
+24 | _ = Decimal.from_float(float(" \n+nan   \t"))
+25 | _ = Decimal.from_float(float("  iNf \n\t "))
+26 | _ = Decimal.from_float(float("   -inF\n \t"))
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FURB164
+27 | _ = Decimal.from_float(float("  InfinIty \n\t "))
+28 | _ = Decimal.from_float(float("   -InfinIty\n \t"))
+   |
+   = help: Replace with `Decimal` constructor
+
+ℹ Safe fix
+23 23 | _ = Decimal.from_float(float("-NaN "))
+24 24 | _ = Decimal.from_float(float(" \n+nan   \t"))
+25 25 | _ = Decimal.from_float(float("  iNf \n\t "))
+26    |-_ = Decimal.from_float(float("   -inF\n \t"))
+   26 |+_ = Decimal("   -inF\n \t")
+27 27 | _ = Decimal.from_float(float("  InfinIty \n\t "))
+28 28 | _ = Decimal.from_float(float("   -InfinIty\n \t"))
+29 29 | 
+
+FURB164.py:27:5: FURB164 [*] Verbose method `from_float` in `Decimal` construction
+   |
+25 | _ = Decimal.from_float(float("  iNf \n\t "))
+26 | _ = Decimal.from_float(float("   -inF\n \t"))
+27 | _ = Decimal.from_float(float("  InfinIty \n\t "))
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FURB164
+28 | _ = Decimal.from_float(float("   -InfinIty\n \t"))
+   |
+   = help: Replace with `Decimal` constructor
+
+ℹ Safe fix
+24 24 | _ = Decimal.from_float(float(" \n+nan   \t"))
+25 25 | _ = Decimal.from_float(float("  iNf \n\t "))
+26 26 | _ = Decimal.from_float(float("   -inF\n \t"))
+27    |-_ = Decimal.from_float(float("  InfinIty \n\t "))
+   27 |+_ = Decimal("  InfinIty \n\t ")
+28 28 | _ = Decimal.from_float(float("   -InfinIty\n \t"))
+29 29 | 
+30 30 | # OK
+
+FURB164.py:28:5: FURB164 [*] Verbose method `from_float` in `Decimal` construction
+   |
+26 | _ = Decimal.from_float(float("   -inF\n \t"))
+27 | _ = Decimal.from_float(float("  InfinIty \n\t "))
+28 | _ = Decimal.from_float(float("   -InfinIty\n \t"))
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FURB164
+29 |
+30 | # OK
+   |
+   = help: Replace with `Decimal` constructor
+
+ℹ Safe fix
+25 25 | _ = Decimal.from_float(float("  iNf \n\t "))
+26 26 | _ = Decimal.from_float(float("   -inF\n \t"))
+27 27 | _ = Decimal.from_float(float("  InfinIty \n\t "))
+28    |-_ = Decimal.from_float(float("   -InfinIty\n \t"))
+   28 |+_ = Decimal("   -InfinIty\n \t")
+29 29 | 
+30 30 | # OK
+31 31 | _ = Fraction(0.1)


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary
Make `FURB164` detect more valid non-finite float literals. E.g., `float("   -inF\n \t")`.

## Test Plan
New funky float literals have been added to the test file.

## Related
This is a follow up to https://github.com/astral-sh/ruff/pull/18630 fixing an issue I spotted while working that PR