### PR TITLE
[`ruff`] Support byte strings (`RUF055`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF055_3.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF055_3.py
@@ -1,0 +1,24 @@
+import re
+
+b_src = b"abc"
+
+# Should be replaced with `b_src.replace(rb"x", b"y")`
+re.sub(rb"x", b"y", b_src)
+
+# Should be replaced with `b_src.startswith(rb"abc")`
+if re.match(rb"abc", b_src):
+    pass
+
+# Should be replaced with `rb"x" in b_src`
+if re.search(rb"x", b_src):
+    pass
+
+# Should be replaced with `b_src.split(rb"abc")`
+re.split(rb"abc", b_src)
+
+# Patterns containing metacharacters should NOT be replaced
+re.sub(rb"ab[c]", b"", b_src)
+re.match(rb"ab[c]", b_src)
+re.search(rb"ab[c]", b_src)
+re.fullmatch(rb"ab[c]", b_src)
+re.split(rb"ab[c]", b_src) 

--- a/crates/ruff_linter/src/rules/ruff/mod.rs
+++ b/crates/ruff_linter/src/rules/ruff/mod.rs
@@ -534,6 +534,7 @@ mod tests {
     #[test_case(Rule::UnnecessaryRegularExpression, Path::new("RUF055_0.py"))]
     #[test_case(Rule::UnnecessaryRegularExpression, Path::new("RUF055_1.py"))]
     #[test_case(Rule::UnnecessaryRegularExpression, Path::new("RUF055_2.py"))]
+    #[test_case(Rule::UnnecessaryRegularExpression, Path::new("RUF055_3.py"))]
     #[test_case(Rule::PytestRaisesAmbiguousPattern, Path::new("RUF043.py"))]
     #[test_case(Rule::IndentedFormFeed, Path::new("RUF054.py"))]
     #[test_case(Rule::ImplicitClassVarInDataclass, Path::new("RUF045.py"))]

--- a/crates/ruff_linter/src/rules/ruff/rules/unnecessary_regular_expression.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unnecessary_regular_expression.rs
@@ -11,7 +11,6 @@ use ruff_text_size::TextRange;
 use crate::checkers::ast::Checker;
 use crate::{Applicability, Edit, Fix, FixAvailability, Violation};
 
-const METACHARACTERS: [char; 12] = ['.', '^', '$', '*', '+', '?', '{', '[', '\\', '|', '(', ')'];
 /// ## What it does
 ///
 /// Checks for uses of the `re` module that can be replaced with builtin `str` methods.

--- a/crates/ruff_linter/src/rules/ruff/rules/unnecessary_regular_expression.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unnecessary_regular_expression.rs
@@ -102,7 +102,7 @@ pub(crate) fn unnecessary_regular_expression(checker: &Checker, call: &ExprCall)
         return;
     };
 
-    // Reject any regex metacharacters. Compare to the complete list
+    // For now, reject any regex metacharacters. Compare to the complete list
     // from https://docs.python.org/3/howto/regex.html#matching-characters
 
     let has_metacharacters = match &literal {

--- a/crates/ruff_linter/src/rules/ruff/rules/unnecessary_regular_expression.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unnecessary_regular_expression.rs
@@ -104,7 +104,6 @@ pub(crate) fn unnecessary_regular_expression(checker: &Checker, call: &ExprCall)
 
     // For now, reject any regex metacharacters. Compare to the complete list
     // from https://docs.python.org/3/howto/regex.html#matching-characters
-
     let has_metacharacters = match &literal {
         Literal::Str(str_lit) => str_lit.value.to_str().contains(METACHARACTERS),
         Literal::Bytes(bytes_lit) => bytes_lit

--- a/crates/ruff_linter/src/rules/ruff/rules/unnecessary_regular_expression.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unnecessary_regular_expression.rs
@@ -1,8 +1,8 @@
 use itertools::Itertools;
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_python_ast::{
-    Arguments, CmpOp, Expr, ExprAttribute, ExprCall, ExprCompare, ExprContext, ExprStringLiteral,
-    ExprUnaryOp, Identifier, UnaryOp,
+    Arguments, CmpOp, Expr, ExprAttribute, ExprBytesLiteral, ExprCall, ExprCompare, ExprContext,
+    ExprStringLiteral, ExprUnaryOp, Identifier, UnaryOp,
 };
 use ruff_python_semantic::analyze::typing::find_binding_value;
 use ruff_python_semantic::{Modules, SemanticModel};
@@ -95,17 +95,25 @@ pub(crate) fn unnecessary_regular_expression(checker: &Checker, call: &ExprCall)
         return;
     };
 
-    // For now, restrict this rule to string literals and variables that can be resolved to literals
-    let Some(string_lit) = resolve_string_literal(re_func.pattern, semantic) else {
+    // Restrict this rule to string or bytes literals (or variables resolved to such literals).
+    let Some(literal) = resolve_literal(re_func.pattern, semantic) else {
         return;
     };
 
-    // For now, reject any regex metacharacters. Compare to the complete list
+    // Reject any regex metacharacters. Compare to the complete list
     // from https://docs.python.org/3/howto/regex.html#matching-characters
-    let has_metacharacters = string_lit
-        .value
-        .to_str()
-        .contains(['.', '^', '$', '*', '+', '?', '{', '[', '\\', '|', '(', ')']);
+    let has_metacharacters = match &literal {
+        Literal::Str(str_lit) => str_lit
+            .value
+            .to_str()
+            .contains(['.', '^', '$', '*', '+', '?', '{', '[', '\\', '|', '(', ')']),
+        Literal::Bytes(bytes_lit) => bytes_lit.value.bytes().any(|b| {
+            matches!(
+                b,
+                b'.' | b'^' | b'$' | b'*' | b'+' | b'?' | b'{' | b'[' | b'\\' | b'|' | b'(' | b')'
+            )
+        }),
+    };
 
     if has_metacharacters {
         return;
@@ -186,25 +194,29 @@ impl<'a> ReFunc<'a> {
             // version
             ("sub", 3) => {
                 let repl = call.arguments.find_argument_value("repl", 1)?;
-                let lit = resolve_string_literal(repl, semantic)?;
+                let lit = resolve_literal(repl, semantic)?;
                 let mut fixable = true;
-                for (c, next) in lit.value.chars().tuple_windows() {
-                    // `\0` (or any other ASCII digit) and `\g` have special meaning in `repl` strings.
-                    // Meanwhile, nearly all other escapes of ASCII letters in a `repl` string causes
-                    // `re.PatternError` to be raised at runtime.
-                    //
-                    // If we see that the escaped character is an alphanumeric ASCII character,
-                    // we should only emit a diagnostic suggesting to replace the `re.sub()` call with
-                    // `str.replace`if we can detect that the escaped character is one that is both
-                    // valid in a `repl` string *and* does not have any special meaning in a REPL string.
-                    //
-                    // It's out of scope for this rule to change invalid `re.sub()` calls into something
-                    // that would not raise an exception at runtime. They should be left as-is.
-                    if c == '\\' && next.is_ascii_alphanumeric() {
-                        if "abfnrtv".contains(next) {
-                            fixable = false;
-                        } else {
-                            return None;
+
+                if let Literal::Str(lit_str) = lit {
+                    // Retain existing escape analysis for string replacement literals.
+                    for (c, next) in lit_str.value.chars().tuple_windows() {
+                        // `\\0` (or any other ASCII digit) and `\\g` have special meaning in `repl` strings.
+                        // Meanwhile, nearly all other escapes of ASCII letters in a `repl` string causes
+                        // `re.PatternError` to be raised at runtime.
+                        //
+                        // If we see that the escaped character is an alphanumeric ASCII character,
+                        // we should only emit a diagnostic suggesting to replace the `re.sub()` call with
+                        // `str.replace`if we can detect that the escaped character is one that is both
+                        // valid in a `repl` string *and* does not have any special meaning in a REPL string.
+                        //
+                        // It's out of scope for this rule to change invalid `re.sub()` calls into something
+                        // that would not raise an exception at runtime. They should be left as-is.
+                        if c == '\\' && next.is_ascii_alphanumeric() {
+                            if "abfnrtv".contains(next) {
+                                fixable = false;
+                            } else {
+                                return None;
+                            }
                         }
                     }
                 }
@@ -327,6 +339,43 @@ impl<'a> ReFunc<'a> {
             node_index: ruff_python_ast::AtomicNodeIndex::dummy(),
         })
     }
+}
+
+/// A literal that can be either a string or a bytes literal.
+enum Literal<'a> {
+    Str(&'a ExprStringLiteral),
+    Bytes(&'a ExprBytesLiteral),
+}
+
+/// Try to resolve `name` to an [`ExprBytesLiteral`] in `semantic`.
+fn resolve_bytes_literal<'a>(
+    name: &'a Expr,
+    semantic: &'a SemanticModel,
+) -> Option<&'a ExprBytesLiteral> {
+    if name.is_bytes_literal_expr() {
+        return name.as_bytes_literal_expr();
+    }
+
+    if let Some(name_expr) = name.as_name_expr() {
+        let binding = semantic.binding(semantic.only_binding(name_expr)?);
+        let value = find_binding_value(binding, semantic)?;
+        if value.is_bytes_literal_expr() {
+            return value.as_bytes_literal_expr();
+        }
+    }
+
+    None
+}
+
+/// Try to resolve `name` to either a string or bytes literal in `semantic`.
+fn resolve_literal<'a>(name: &'a Expr, semantic: &'a SemanticModel) -> Option<Literal<'a>> {
+    if let Some(str_lit) = resolve_string_literal(name, semantic) {
+        return Some(Literal::Str(str_lit));
+    }
+    if let Some(bytes_lit) = resolve_bytes_literal(name, semantic) {
+        return Some(Literal::Bytes(bytes_lit));
+    }
+    None
 }
 
 /// Try to resolve `name` to an [`ExprStringLiteral`] in `semantic`.

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__preview__RUF055_RUF055_3.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__preview__RUF055_RUF055_3.py.snap
@@ -1,0 +1,80 @@
+---
+source: crates/ruff_linter/src/rules/ruff/mod.rs
+---
+RUF055_3.py:6:1: RUF055 [*] Plain string pattern passed to `re` function
+  |
+5 | # Should be replaced with `b_src.replace(rb"x", b"y")`
+6 | re.sub(rb"x", b"y", b_src)
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^ RUF055
+7 |
+8 | # Should be replaced with `b_src.startswith(rb"abc")`
+  |
+  = help: Replace with `b_src.replace(rb"x", b"y")`
+
+ℹ Safe fix
+3 3 | b_src = b"abc"
+4 4 | 
+5 5 | # Should be replaced with `b_src.replace(rb"x", b"y")`
+6   |-re.sub(rb"x", b"y", b_src)
+  6 |+b_src.replace(rb"x", b"y")
+7 7 | 
+8 8 | # Should be replaced with `b_src.startswith(rb"abc")`
+9 9 | if re.match(rb"abc", b_src):
+
+RUF055_3.py:9:4: RUF055 [*] Plain string pattern passed to `re` function
+   |
+ 8 | # Should be replaced with `b_src.startswith(rb"abc")`
+ 9 | if re.match(rb"abc", b_src):
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^ RUF055
+10 |     pass
+   |
+   = help: Replace with `b_src.startswith(rb"abc")`
+
+ℹ Safe fix
+6  6  | re.sub(rb"x", b"y", b_src)
+7  7  | 
+8  8  | # Should be replaced with `b_src.startswith(rb"abc")`
+9     |-if re.match(rb"abc", b_src):
+   9  |+if b_src.startswith(rb"abc"):
+10 10 |     pass
+11 11 | 
+12 12 | # Should be replaced with `rb"x" in b_src`
+
+RUF055_3.py:13:4: RUF055 [*] Plain string pattern passed to `re` function
+   |
+12 | # Should be replaced with `rb"x" in b_src`
+13 | if re.search(rb"x", b_src):
+   |    ^^^^^^^^^^^^^^^^^^^^^^^ RUF055
+14 |     pass
+   |
+   = help: Replace with `rb"x" in b_src`
+
+ℹ Safe fix
+10 10 |     pass
+11 11 | 
+12 12 | # Should be replaced with `rb"x" in b_src`
+13    |-if re.search(rb"x", b_src):
+   13 |+if rb"x" in b_src:
+14 14 |     pass
+15 15 | 
+16 16 | # Should be replaced with `b_src.split(rb"abc")`
+
+RUF055_3.py:17:1: RUF055 [*] Plain string pattern passed to `re` function
+   |
+16 | # Should be replaced with `b_src.split(rb"abc")`
+17 | re.split(rb"abc", b_src)
+   | ^^^^^^^^^^^^^^^^^^^^^^^^ RUF055
+18 |
+19 | # Patterns containing metacharacters should NOT be replaced
+   |
+   = help: Replace with `b_src.split(rb"abc")`
+
+ℹ Safe fix
+14 14 |     pass
+15 15 | 
+16 16 | # Should be replaced with `b_src.split(rb"abc")`
+17    |-re.split(rb"abc", b_src)
+   17 |+b_src.split(rb"abc")
+18 18 | 
+19 19 | # Patterns containing metacharacters should NOT be replaced
+20 20 | re.sub(rb"ab[c]", b"", b_src)


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Closes #18739

## Test Plan

<!-- How was it tested? -->
