### PR TITLE
[ty] Move search path resolution to `Options::to_program_settings`

### DIFF
--- a/crates/ruff/tests/analyze_graph.rs
+++ b/crates/ruff/tests/analyze_graph.rs
@@ -566,7 +566,9 @@ fn venv() -> Result<()> {
         ----- stderr -----
         ruff failed
           Cause: Invalid search path settings
-          Cause: Failed to discover the site-packages directory: Invalid `--python` argument `none`: does not point to a Python executable or a directory on disk
+          Cause: Failed to discover the site-packages directory
+          Cause: Invalid `--python` argument `none`: does not point to a Python executable or a directory on disk
+          Cause: No such file or directory (os error 2)
         ");
     });
 

--- a/crates/ruff_graph/src/db.rs
+++ b/crates/ruff_graph/src/db.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use std::sync::Arc;
 use zip::CompressionMethod;
 
@@ -42,6 +42,10 @@ impl ModuleDb {
         }
 
         let db = Self::default();
+        let search_paths = search_paths
+            .to_search_paths(db.system(), db.vendored())
+            .context("Invalid search path settings")?;
+
         Program::from_settings(
             &db,
             ProgramSettings {
@@ -52,7 +56,7 @@ impl ModuleDb {
                 python_platform: PythonPlatform::default(),
                 search_paths,
             },
-        )?;
+        );
 
         Ok(db)
     }

--- a/crates/ruff_graph/src/db.rs
+++ b/crates/ruff_graph/src/db.rs
@@ -49,10 +49,10 @@ impl ModuleDb {
         Program::from_settings(
             &db,
             ProgramSettings {
-                python_version: Some(PythonVersionWithSource {
+                python_version: PythonVersionWithSource {
                     version: python_version,
                     source: PythonVersionSource::default(),
-                }),
+                },
                 python_platform: PythonPlatform::default(),
                 search_paths,
             },

--- a/crates/ty/tests/cli/main.rs
+++ b/crates/ty/tests/cli/main.rs
@@ -621,6 +621,10 @@ impl CliTest {
         let mut settings = insta::Settings::clone_current();
         settings.add_filter(&tempdir_filter(&project_dir), "<temp_dir>/");
         settings.add_filter(r#"\\(\w\w|\s|\.|")"#, "/$1");
+        settings.add_filter(
+            r#"The system cannot find the file specified."#,
+            "No such file or directory",
+        );
 
         let settings_scope = settings.bind_to_scope();
 

--- a/crates/ty/tests/cli/python_environment.rs
+++ b/crates/ty/tests/cli/python_environment.rs
@@ -590,8 +590,8 @@ fn python_cli_argument_virtual_environment() -> anyhow::Result<()> {
     ----- stderr -----
     WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
     ty failed
-      Cause: Invalid search path settings
-      Cause: Failed to discover the site-packages directory: Invalid `--python` argument `<temp_dir>/my-venv/foo/some_other_file.txt`: does not point to a Python executable or a directory on disk
+      Cause: Failed to discover the site-packages directory
+      Cause: Invalid `--python` argument `<temp_dir>/my-venv/foo/some_other_file.txt`: does not point to a Python executable or a directory on disk
     ");
 
     // And so are paths that do not exist on disk
@@ -603,8 +603,9 @@ fn python_cli_argument_virtual_environment() -> anyhow::Result<()> {
     ----- stderr -----
     WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
     ty failed
-      Cause: Invalid search path settings
-      Cause: Failed to discover the site-packages directory: Invalid `--python` argument `<temp_dir>/not-a-directory-or-executable`: does not point to a Python executable or a directory on disk
+      Cause: Failed to discover the site-packages directory
+      Cause: Invalid `--python` argument `<temp_dir>/not-a-directory-or-executable`: does not point to a Python executable or a directory on disk
+      Cause: No such file or directory (os error 2)
     ");
 
     Ok(())
@@ -685,8 +686,8 @@ fn config_file_broken_python_setting() -> anyhow::Result<()> {
     ----- stderr -----
     WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
     ty failed
-      Cause: Invalid search path settings
-      Cause: Failed to discover the site-packages directory: Invalid `environment.python` setting
+      Cause: Failed to discover the site-packages directory
+      Cause: Invalid `environment.python` setting
 
     --> Invalid setting in configuration file `<temp_dir>/pyproject.toml`
        |
@@ -695,6 +696,8 @@ fn config_file_broken_python_setting() -> anyhow::Result<()> {
     11 | python = "not-a-directory-or-executable"
        |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ does not point to a Python executable or a directory on disk
        |
+
+      Cause: No such file or directory (os error 2)
     "#);
 
     Ok(())
@@ -722,8 +725,8 @@ fn config_file_python_setting_directory_with_no_site_packages() -> anyhow::Resul
     ----- stderr -----
     WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
     ty failed
-      Cause: Invalid search path settings
-      Cause: Failed to discover the site-packages directory: Invalid `environment.python` setting
+      Cause: Failed to discover the site-packages directory
+      Cause: Invalid `environment.python` setting
 
     --> Invalid setting in configuration file `<temp_dir>/pyproject.toml`
       |
@@ -761,8 +764,8 @@ fn unix_system_installation_with_no_lib_directory() -> anyhow::Result<()> {
     ----- stderr -----
     WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
     ty failed
-      Cause: Invalid search path settings
-      Cause: Failed to discover the site-packages directory: Failed to iterate over the contents of the `lib` directory of the Python installation
+      Cause: Failed to discover the site-packages directory
+      Cause: Failed to iterate over the contents of the `lib` directory of the Python installation
 
     --> Invalid setting in configuration file `<temp_dir>/pyproject.toml`
       |
@@ -771,6 +774,8 @@ fn unix_system_installation_with_no_lib_directory() -> anyhow::Result<()> {
     3 | python = "directory-but-no-site-packages"
       |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       |
+
+      Cause: No such file or directory (os error 2)
     "#);
 
     Ok(())
@@ -1040,6 +1045,172 @@ fn environment_root_takes_precedence_over_src_root() -> anyhow::Result<()> {
     5 | [tool.ty.environment]
       |
     info: The `src.root` setting was ignored in favor of the `environment.root` setting
+
+    Found 1 diagnostic
+
+    ----- stderr -----
+    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
+    "#);
+
+    Ok(())
+}
+
+#[test]
+fn default_root_src_layout() -> anyhow::Result<()> {
+    let case = CliTest::with_files([
+        ("src/foo.py", "foo = 10"),
+        ("bar.py", "bar = 20"),
+        (
+            "src/main.py",
+            r#"
+            from foo import foo
+            from bar import bar
+
+            print(f"{foo} {bar}")
+            "#,
+        ),
+    ])?;
+
+    assert_cmd_snapshot!(case.command(), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    All checks passed!
+
+    ----- stderr -----
+    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn default_root_project_name_folder() -> anyhow::Result<()> {
+    let case = CliTest::with_files([
+        (
+            "pyproject.toml",
+            r#"
+            [project]
+            name = "psycopg"
+            "#,
+        ),
+        ("psycopg/psycopg/foo.py", "foo = 10"),
+        ("bar.py", "bar = 20"),
+        (
+            "psycopg/psycopg/main.py",
+            r#"
+            from psycopg.foo import foo
+            from bar import bar
+
+            print(f"{foo} {bar}")
+            "#,
+        ),
+    ])?;
+
+    assert_cmd_snapshot!(case.command(), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    All checks passed!
+
+    ----- stderr -----
+    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn default_root_flat_layout() -> anyhow::Result<()> {
+    let case = CliTest::with_files([
+        ("app/foo.py", "foo = 10"),
+        ("bar.py", "bar = 20"),
+        (
+            "app/main.py",
+            r#"
+            from app.foo import foo
+            from bar import bar
+
+            print(f"{foo} {bar}")
+            "#,
+        ),
+    ])?;
+
+    assert_cmd_snapshot!(case.command(), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    All checks passed!
+
+    ----- stderr -----
+    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn default_root_tests_folder() -> anyhow::Result<()> {
+    let case = CliTest::with_files([
+        ("src/foo.py", "foo = 10"),
+        ("tests/bar.py", "bar = 20"),
+        (
+            "tests/test_bar.py",
+            r#"
+            from foo import foo
+            from bar import bar
+
+            print(f"{foo} {bar}")
+            "#,
+        ),
+    ])?;
+
+    assert_cmd_snapshot!(case.command(), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    All checks passed!
+
+    ----- stderr -----
+    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
+    ");
+
+    Ok(())
+}
+
+/// If `tests/__init__.py` is present, it is considered a package and `tests` is not added to `sys.path`.
+#[test]
+fn default_root_tests_package() -> anyhow::Result<()> {
+    let case = CliTest::with_files([
+        ("src/foo.py", "foo = 10"),
+        ("tests/__init__.py", ""),
+        ("tests/bar.py", "bar = 20"),
+        (
+            "tests/test_bar.py",
+            r#"
+            from foo import foo
+            from bar import bar  # expected unresolved import
+
+            print(f"{foo} {bar}")
+            "#,
+        ),
+    ])?;
+
+    assert_cmd_snapshot!(case.command(), @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    error[unresolved-import]: Cannot resolve imported module `bar`
+     --> tests/test_bar.py:3:6
+      |
+    2 | from foo import foo
+    3 | from bar import bar  # expected unresolved import
+      |      ^^^
+    4 |
+    5 | print(f"{foo} {bar}")
+      |
+    info: make sure your Python environment is properly configured: https://github.com/astral-sh/ty/blob/main/docs/README.md#python-environment
+    info: rule `unresolved-import` is enabled by default
 
     Found 1 diagnostic
 

--- a/crates/ty_ide/src/inlay_hints.rs
+++ b/crates/ty_ide/src/inlay_hints.rs
@@ -150,6 +150,7 @@ mod tests {
 
     use insta::assert_snapshot;
     use ruff_db::{
+        Db as _,
         files::{File, system_path_to_file},
         source::source_text,
     };
@@ -159,8 +160,7 @@ mod tests {
 
     use ruff_db::system::{DbWithWritableSystem, SystemPathBuf};
     use ty_python_semantic::{
-        Program, ProgramSettings, PythonPath, PythonPlatform, PythonVersionWithSource,
-        SearchPathSettings,
+        Program, ProgramSettings, PythonPlatform, PythonVersionWithSource, SearchPathSettings,
     };
 
     pub(super) fn inlay_hint_test(source: &str) -> InlayHintTest {
@@ -188,20 +188,18 @@ mod tests {
 
         let file = system_path_to_file(&db, "main.py").expect("newly written file to existing");
 
+        let search_paths = SearchPathSettings::new(vec![SystemPathBuf::from("/")])
+            .to_search_paths(db.system(), db.vendored())
+            .expect("Valid search path settings");
+
         Program::from_settings(
             &db,
             ProgramSettings {
                 python_version: Some(PythonVersionWithSource::default()),
                 python_platform: PythonPlatform::default(),
-                search_paths: SearchPathSettings {
-                    extra_paths: vec![],
-                    src_roots: vec![SystemPathBuf::from("/")],
-                    custom_typeshed: None,
-                    python_path: PythonPath::KnownSitePackages(vec![]),
-                },
+                search_paths,
             },
-        )
-        .expect("Default settings to be valid");
+        );
 
         InlayHintTest { db, file, range }
     }

--- a/crates/ty_ide/src/inlay_hints.rs
+++ b/crates/ty_ide/src/inlay_hints.rs
@@ -195,7 +195,7 @@ mod tests {
         Program::from_settings(
             &db,
             ProgramSettings {
-                python_version: Some(PythonVersionWithSource::default()),
+                python_version: PythonVersionWithSource::default(),
                 python_platform: PythonPlatform::default(),
                 search_paths,
             },

--- a/crates/ty_ide/src/lib.rs
+++ b/crates/ty_ide/src/lib.rs
@@ -308,7 +308,7 @@ mod tests {
             Program::from_settings(
                 &db,
                 ProgramSettings {
-                    python_version: Some(PythonVersionWithSource::default()),
+                    python_version: PythonVersionWithSource::default(),
                     python_platform: PythonPlatform::default(),
                     search_paths,
                 },

--- a/crates/ty_ide/src/lib.rs
+++ b/crates/ty_ide/src/lib.rs
@@ -203,14 +203,13 @@ impl HasNavigationTargets for TypeDefinition<'_> {
 mod tests {
     use crate::db::tests::TestDb;
     use insta::internals::SettingsBindDropGuard;
-    use ruff_db::Upcast;
     use ruff_db::diagnostic::{Diagnostic, DiagnosticFormat, DisplayDiagnosticConfig};
     use ruff_db::files::{File, system_path_to_file};
     use ruff_db::system::{DbWithWritableSystem, SystemPath, SystemPathBuf};
+    use ruff_db::{Db, Upcast};
     use ruff_text_size::TextSize;
     use ty_python_semantic::{
-        Program, ProgramSettings, PythonPath, PythonPlatform, PythonVersionWithSource,
-        SearchPathSettings,
+        Program, ProgramSettings, PythonPlatform, PythonVersionWithSource, SearchPathSettings,
     };
 
     /// A way to create a simple single-file (named `main.py`) cursor test.
@@ -302,20 +301,18 @@ mod tests {
                 cursor = Some(Cursor { file, offset });
             }
 
+            let search_paths = SearchPathSettings::new(vec![SystemPathBuf::from("/")])
+                .to_search_paths(db.system(), db.vendored())
+                .expect("Valid search path settings");
+
             Program::from_settings(
                 &db,
                 ProgramSettings {
                     python_version: Some(PythonVersionWithSource::default()),
                     python_platform: PythonPlatform::default(),
-                    search_paths: SearchPathSettings {
-                        extra_paths: vec![],
-                        src_roots: vec![SystemPathBuf::from("/")],
-                        custom_typeshed: None,
-                        python_path: PythonPath::KnownSitePackages(vec![]),
-                    },
+                    search_paths,
                 },
-            )
-            .expect("Default settings to be valid");
+            );
 
             let mut insta_settings = insta::Settings::clone_current();
             insta_settings.add_filter(r#"\\(\w\w|\s|\.|")"#, "/$1");

--- a/crates/ty_project/src/db.rs
+++ b/crates/ty_project/src/db.rs
@@ -68,8 +68,8 @@ impl ProjectDatabase {
         //   we may want to have a dedicated method for this?
 
         // Initialize the `Program` singleton
-        let program_settings = project_metadata.to_program_settings(db.system());
-        Program::from_settings(&db, program_settings)?;
+        let program_settings = project_metadata.to_program_settings(db.system(), db.vendored())?;
+        Program::from_settings(&db, program_settings);
 
         db.project = Some(
             Project::from_metadata(&db, project_metadata)

--- a/crates/ty_project/src/db/changes.rs
+++ b/crates/ty_project/src/db/changes.rs
@@ -277,7 +277,7 @@ impl ProjectDatabase {
                 .to_program_settings(self.system(), self.vendored())
             {
                 Ok(program_settings) => {
-                    program.update_search_paths(self, program_settings.search_paths);
+                    program.update_from_settings(self, program_settings);
                 }
                 Err(error) => {
                     tracing::error!("Failed to resolve program settings: {error}");

--- a/crates/ty_project/src/db/changes.rs
+++ b/crates/ty_project/src/db/changes.rs
@@ -228,13 +228,16 @@ impl ProjectDatabase {
                         );
                     }
 
-                    let program_settings = metadata.to_program_settings(self.system());
-
-                    let program = Program::get(self);
-                    if let Err(error) = program.update_from_settings(self, program_settings) {
-                        tracing::error!(
-                            "Failed to update the program settings, keeping the old program settings: {error}"
-                        );
+                    match metadata.to_program_settings(self.system(), self.vendored()) {
+                        Ok(program_settings) => {
+                            let program = Program::get(self);
+                            program.update_from_settings(self, program_settings);
+                        }
+                        Err(error) => {
+                            tracing::error!(
+                                "Failed to convert metadata to program settings, continuing without applying them: {error}"
+                            );
+                        }
                     }
 
                     if metadata.root() == project.root(self) {
@@ -269,13 +272,16 @@ impl ProjectDatabase {
 
             return result;
         } else if result.custom_stdlib_changed {
-            let search_paths = project
+            match project
                 .metadata(self)
-                .to_program_settings(self.system())
-                .search_paths;
-
-            if let Err(error) = program.update_search_paths(self, &search_paths) {
-                tracing::error!("Failed to set the new search paths: {error}");
+                .to_program_settings(self.system(), self.vendored())
+            {
+                Ok(program_settings) => {
+                    program.update_search_paths(self, program_settings.search_paths);
+                }
+                Err(error) => {
+                    tracing::error!("Failed to resolve program settings: {error}");
+                }
             }
         }
 

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -714,6 +714,7 @@ mod tests {
     use crate::Db;
     use crate::ProjectMetadata;
     use crate::db::tests::TestDb;
+    use ruff_db::Db as _;
     use ruff_db::files::system_path_to_file;
     use ruff_db::source::source_text;
     use ruff_db::system::{DbWithTestSystem, DbWithWritableSystem as _, SystemPath, SystemPathBuf};
@@ -735,10 +736,11 @@ mod tests {
             ProgramSettings {
                 python_version: Some(PythonVersionWithSource::default()),
                 python_platform: PythonPlatform::default(),
-                search_paths: SearchPathSettings::new(vec![SystemPathBuf::from(".")]),
+                search_paths: SearchPathSettings::new(vec![SystemPathBuf::from(".")])
+                    .to_search_paths(db.system(), db.vendored())
+                    .expect("Valid search path settings"),
             },
-        )
-        .expect("Failed to configure program settings");
+        );
 
         db.write_file(path, "x = 10")?;
         let file = system_path_to_file(&db, path).unwrap();

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -734,7 +734,7 @@ mod tests {
         Program::from_settings(
             &db,
             ProgramSettings {
-                python_version: Some(PythonVersionWithSource::default()),
+                python_version: PythonVersionWithSource::default(),
                 python_platform: PythonPlatform::default(),
                 search_paths: SearchPathSettings::new(vec![SystemPathBuf::from(".")])
                     .to_search_paths(db.system(), db.vendored())

--- a/crates/ty_project/src/metadata/options.rs
+++ b/crates/ty_project/src/metadata/options.rs
@@ -14,6 +14,7 @@ use ruff_db::diagnostic::{
 };
 use ruff_db::files::system_path_to_file;
 use ruff_db::system::{System, SystemPath, SystemPathBuf};
+use ruff_db::vendored::VendoredFileSystem;
 use ruff_macros::{Combine, OptionsMetadata, RustDoc};
 use ruff_options_metadata::{OptionSet, OptionsMetadata, Visit};
 use ruff_python_ast::PythonVersion;
@@ -28,7 +29,8 @@ use thiserror::Error;
 use ty_python_semantic::lint::{GetLintError, Level, LintSource, RuleSelection};
 use ty_python_semantic::{
     ProgramSettings, PythonPath, PythonPlatform, PythonVersionFileSource, PythonVersionSource,
-    PythonVersionWithSource, SearchPathSettings, SysPrefixPathOrigin,
+    PythonVersionWithSource, SearchPathSettings, SearchPathValidationError, SearchPaths,
+    SysPrefixPathOrigin,
 };
 
 use super::settings::{Override, Settings, TerminalSettings};
@@ -104,7 +106,8 @@ impl Options {
         project_root: &SystemPath,
         project_name: &str,
         system: &dyn System,
-    ) -> ProgramSettings {
+        vendored: &VendoredFileSystem,
+    ) -> anyhow::Result<ProgramSettings> {
         let environment = self.environment.or_default();
 
         let python_version =
@@ -129,19 +132,20 @@ impl Options {
                 tracing::info!("Defaulting to python-platform `{default}`");
                 default
             });
-        ProgramSettings {
+        Ok(ProgramSettings {
             python_version,
             python_platform,
-            search_paths: self.to_search_path_settings(project_root, project_name, system),
-        }
+            search_paths: self.to_search_paths(project_root, project_name, system, vendored)?,
+        })
     }
 
-    fn to_search_path_settings(
+    fn to_search_paths(
         &self,
         project_root: &SystemPath,
         project_name: &str,
         system: &dyn System,
-    ) -> SearchPathSettings {
+        vendored: &VendoredFileSystem,
+    ) -> Result<SearchPaths, SearchPathValidationError> {
         let environment = self.environment.or_default();
         let src = self.src.or_default();
 
@@ -197,7 +201,7 @@ impl Options {
             roots
         };
 
-        SearchPathSettings {
+        let settings = SearchPathSettings {
             extra_paths: environment
                 .extra_paths
                 .as_deref()
@@ -239,7 +243,9 @@ impl Options {
                         SysPrefixPathOrigin::LocalVenv,
                     )
                 }),
-        }
+        };
+
+        settings.to_search_paths(system, vendored)
     }
 
     pub(crate) fn to_settings(

--- a/crates/ty_project/src/metadata/value.rs
+++ b/crates/ty_project/src/metadata/value.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Deserializer};
 use std::cell::RefCell;
 use std::cmp::Ordering;
 use std::fmt;
+use std::fmt::Formatter;
 use std::hash::{Hash, Hasher};
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
@@ -357,6 +358,12 @@ impl RelativePathBuf {
         };
 
         SystemPath::absolute(&self.0, relative_to)
+    }
+}
+
+impl fmt::Display for RelativePathBuf {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
     }
 }
 

--- a/crates/ty_python_semantic/src/db.rs
+++ b/crates/ty_python_semantic/src/db.rs
@@ -183,10 +183,10 @@ pub(crate) mod tests {
             Program::from_settings(
                 &db,
                 ProgramSettings {
-                    python_version: Some(PythonVersionWithSource {
+                    python_version: PythonVersionWithSource {
                         version: self.python_version,
                         source: PythonVersionSource::default(),
-                    }),
+                    },
                     python_platform: self.python_platform,
                     search_paths: SearchPathSettings::new(vec![src_root])
                         .to_search_paths(db.system(), db.vendored())

--- a/crates/ty_python_semantic/src/db.rs
+++ b/crates/ty_python_semantic/src/db.rs
@@ -188,10 +188,11 @@ pub(crate) mod tests {
                         source: PythonVersionSource::default(),
                     }),
                     python_platform: self.python_platform,
-                    search_paths: SearchPathSettings::new(vec![src_root]),
+                    search_paths: SearchPathSettings::new(vec![src_root])
+                        .to_search_paths(db.system(), db.vendored())
+                        .context("Invalid search path settings")?,
                 },
-            )
-            .context("Failed to configure Program settings")?;
+            );
 
             Ok(db)
         }

--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -6,7 +6,10 @@ use crate::lint::{LintRegistry, LintRegistryBuilder};
 use crate::suppression::{INVALID_IGNORE_COMMENT, UNKNOWN_RULE, UNUSED_IGNORE_COMMENT};
 pub use db::Db;
 pub use module_name::ModuleName;
-pub use module_resolver::{KnownModule, Module, resolve_module, system_module_search_paths};
+pub use module_resolver::{
+    KnownModule, Module, SearchPathValidationError, SearchPaths, resolve_module,
+    system_module_search_paths,
+};
 pub use program::{
     Program, ProgramSettings, PythonPath, PythonVersionFileSource, PythonVersionSource,
     PythonVersionWithSource, SearchPathSettings,

--- a/crates/ty_python_semantic/src/module_resolver/mod.rs
+++ b/crates/ty_python_semantic/src/module_resolver/mod.rs
@@ -1,8 +1,10 @@
 use std::iter::FusedIterator;
 
 pub use module::{KnownModule, Module};
+pub use path::SearchPathValidationError;
+pub use resolver::SearchPaths;
+pub(crate) use resolver::file_to_module;
 pub use resolver::resolve_module;
-pub(crate) use resolver::{SearchPaths, file_to_module};
 use ruff_db::system::SystemPath;
 
 use crate::Db;

--- a/crates/ty_python_semantic/src/module_resolver/path.rs
+++ b/crates/ty_python_semantic/src/module_resolver/path.rs
@@ -9,7 +9,6 @@ use ruff_db::system::{System, SystemPath, SystemPathBuf};
 use ruff_db::vendored::{VendoredPath, VendoredPathBuf};
 
 use super::typeshed::{TypeshedVersionsParseError, TypeshedVersionsQueryResult, typeshed_versions};
-use crate::db::Db;
 use crate::module_name::ModuleName;
 use crate::module_resolver::resolver::ResolverContext;
 use crate::site_packages::SitePackagesDiscoveryError;
@@ -325,62 +324,37 @@ fn query_stdlib_version(
 /// If validation fails for a search path derived from the user settings,
 /// a message must be displayed to the user,
 /// as type checking cannot be done reliably in these circumstances.
-#[derive(Debug)]
-pub(crate) enum SearchPathValidationError {
+#[derive(Debug, thiserror::Error)]
+pub enum SearchPathValidationError {
     /// The path provided by the user was not a directory
+    #[error("{0} does not point to a directory")]
     NotADirectory(SystemPathBuf),
 
     /// The path provided by the user is a directory,
     /// but no `stdlib/` subdirectory exists.
     /// (This is only relevant for stdlib search paths.)
+    #[error("The directory at {0} has no `stdlib/` subdirectory")]
     NoStdlibSubdirectory(SystemPathBuf),
 
     /// The typeshed path provided by the user is a directory,
     /// but `stdlib/VERSIONS` could not be read.
     /// (This is only relevant for stdlib search paths.)
+    #[error("Failed to read the custom typeshed versions file '{path}'")]
     FailedToReadVersionsFile {
         path: SystemPathBuf,
+        #[source]
         error: std::io::Error,
     },
 
     /// The path provided by the user is a directory,
     /// and a `stdlib/VERSIONS` file exists, but it fails to parse.
     /// (This is only relevant for stdlib search paths.)
+    #[error(transparent)]
     VersionsParseError(TypeshedVersionsParseError),
 
     /// Failed to discover the site-packages for the configured virtual environment.
-    SitePackagesDiscovery(SitePackagesDiscoveryError),
-}
-
-impl fmt::Display for SearchPathValidationError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::NotADirectory(path) => write!(f, "{path} does not point to a directory"),
-            Self::NoStdlibSubdirectory(path) => {
-                write!(f, "The directory at {path} has no `stdlib/` subdirectory")
-            }
-            Self::FailedToReadVersionsFile { path, error } => {
-                write!(
-                    f,
-                    "Failed to read the custom typeshed versions file '{path}': {error}"
-                )
-            }
-            Self::VersionsParseError(underlying_error) => underlying_error.fmt(f),
-            SearchPathValidationError::SitePackagesDiscovery(error) => {
-                write!(f, "Failed to discover the site-packages directory: {error}")
-            }
-        }
-    }
-}
-
-impl std::error::Error for SearchPathValidationError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        if let Self::VersionsParseError(underlying_error) = self {
-            Some(underlying_error)
-        } else {
-            None
-        }
-    }
+    #[error("Failed to discover the site-packages directory")]
+    SitePackagesDiscovery(#[source] SitePackagesDiscoveryError),
 }
 
 impl From<TypeshedVersionsParseError> for SearchPathValidationError {
@@ -459,8 +433,10 @@ impl SearchPath {
     }
 
     /// Create a new standard-library search path pointing to a custom directory on disk
-    pub(crate) fn custom_stdlib(db: &dyn Db, typeshed: &SystemPath) -> SearchPathResult<Self> {
-        let system = db.system();
+    pub(crate) fn custom_stdlib(
+        system: &dyn System,
+        typeshed: &SystemPath,
+    ) -> SearchPathResult<Self> {
         if !system.is_directory(typeshed) {
             return Err(SearchPathValidationError::NotADirectory(
                 typeshed.to_path_buf(),
@@ -526,6 +502,10 @@ impl SearchPath {
             &*self.0,
             SearchPathInner::StandardLibraryCustom(_) | SearchPathInner::StandardLibraryVendored(_)
         )
+    }
+
+    pub(crate) fn is_first_party(&self) -> bool {
+        matches!(&*self.0, SearchPathInner::FirstParty(_))
     }
 
     fn is_valid_extension(&self, extension: &str) -> bool {
@@ -707,7 +687,7 @@ mod tests {
             .build();
 
         assert_eq!(
-            SearchPath::custom_stdlib(&db, stdlib.parent().unwrap())
+            SearchPath::custom_stdlib(db.system(), stdlib.parent().unwrap())
                 .unwrap()
                 .to_module_path()
                 .with_py_extension(),
@@ -715,7 +695,7 @@ mod tests {
         );
 
         assert_eq!(
-            &SearchPath::custom_stdlib(&db, stdlib.parent().unwrap())
+            &SearchPath::custom_stdlib(db.system(), stdlib.parent().unwrap())
                 .unwrap()
                 .join("foo")
                 .with_pyi_extension(),
@@ -826,7 +806,7 @@ mod tests {
         let TestCase { db, stdlib, .. } = TestCaseBuilder::new()
             .with_mocked_typeshed(MockedTypeshed::default())
             .build();
-        SearchPath::custom_stdlib(&db, stdlib.parent().unwrap())
+        SearchPath::custom_stdlib(db.system(), stdlib.parent().unwrap())
             .unwrap()
             .to_module_path()
             .push("bar.py");
@@ -838,7 +818,7 @@ mod tests {
         let TestCase { db, stdlib, .. } = TestCaseBuilder::new()
             .with_mocked_typeshed(MockedTypeshed::default())
             .build();
-        SearchPath::custom_stdlib(&db, stdlib.parent().unwrap())
+        SearchPath::custom_stdlib(db.system(), stdlib.parent().unwrap())
             .unwrap()
             .to_module_path()
             .push("bar.rs");
@@ -870,7 +850,7 @@ mod tests {
             .with_mocked_typeshed(MockedTypeshed::default())
             .build();
 
-        let root = SearchPath::custom_stdlib(&db, stdlib.parent().unwrap()).unwrap();
+        let root = SearchPath::custom_stdlib(db.system(), stdlib.parent().unwrap()).unwrap();
 
         // Must have a `.pyi` extension or no extension:
         let bad_absolute_path = SystemPath::new("foo/stdlib/x.py");
@@ -918,7 +898,7 @@ mod tests {
             .with_mocked_typeshed(typeshed)
             .with_python_version(python_version)
             .build();
-        let stdlib = SearchPath::custom_stdlib(&db, stdlib.parent().unwrap()).unwrap();
+        let stdlib = SearchPath::custom_stdlib(db.system(), stdlib.parent().unwrap()).unwrap();
         (db, stdlib)
     }
 

--- a/crates/ty_python_semantic/src/module_resolver/resolver.rs
+++ b/crates/ty_python_semantic/src/module_resolver/resolver.rs
@@ -1487,10 +1487,10 @@ mod tests {
         Program::from_settings(
             &db,
             ProgramSettings {
-                python_version: Some(PythonVersionWithSource {
+                python_version: PythonVersionWithSource {
                     version: PythonVersion::PY38,
                     source: PythonVersionSource::default(),
-                }),
+                },
                 python_platform: PythonPlatform::default(),
                 search_paths: SearchPathSettings {
                     custom_typeshed: Some(custom_typeshed),
@@ -2006,7 +2006,7 @@ not_a_directory
         Program::from_settings(
             &db,
             ProgramSettings {
-                python_version: Some(PythonVersionWithSource::default()),
+                python_version: PythonVersionWithSource::default(),
                 python_platform: PythonPlatform::default(),
                 search_paths: SearchPathSettings {
                     python_path: PythonPath::KnownSitePackages(vec![
@@ -2084,7 +2084,7 @@ not_a_directory
         Program::from_settings(
             &db,
             ProgramSettings {
-                python_version: Some(PythonVersionWithSource::default()),
+                python_version: PythonVersionWithSource::default(),
                 python_platform: PythonPlatform::default(),
                 search_paths: SearchPathSettings::new(vec![src])
                     .to_search_paths(db.system(), db.vendored())
@@ -2123,7 +2123,7 @@ not_a_directory
         Program::from_settings(
             &db,
             ProgramSettings {
-                python_version: Some(PythonVersionWithSource::default()),
+                python_version: PythonVersionWithSource::default(),
                 python_platform: PythonPlatform::default(),
                 search_paths: SearchPathSettings {
                     python_path: PythonPath::KnownSitePackages(vec![site_packages.clone()]),

--- a/crates/ty_python_semantic/src/module_resolver/resolver.rs
+++ b/crates/ty_python_semantic/src/module_resolver/resolver.rs
@@ -142,9 +142,9 @@ pub(crate) fn search_paths(db: &dyn Db) -> SearchPathIterator {
     Program::get(db).search_paths(db).iter(db)
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SearchPaths {
-    /// Search paths that have been statically determined purely from reading Ruff's configuration settings.
+    /// Search paths that have been statically determined purely from reading ty's configuration settings.
     /// These shouldn't ever change unless the config settings themselves change.
     static_paths: Vec<SearchPath>,
 
@@ -174,8 +174,9 @@ impl SearchPaths {
     ///
     /// [module resolution order]: https://typing.python.org/en/latest/spec/distributing.html#import-resolution-ordering
     pub(crate) fn from_settings(
-        db: &dyn Db,
         settings: &SearchPathSettings,
+        system: &dyn System,
+        vendored: &VendoredFileSystem,
     ) -> Result<Self, SearchPathValidationError> {
         fn canonicalize(path: &SystemPath, system: &dyn System) -> SystemPathBuf {
             system
@@ -190,14 +191,10 @@ impl SearchPaths {
             python_path,
         } = settings;
 
-        let system = db.system();
-        let files = db.files();
-
         let mut static_paths = vec![];
 
         for path in extra_paths {
             let path = canonicalize(path, system);
-            files.try_add_root(db.upcast(), &path, FileRootKind::LibrarySearchPath);
             tracing::debug!("Adding extra search-path '{path}'");
 
             static_paths.push(SearchPath::extra(system, path)?);
@@ -212,8 +209,6 @@ impl SearchPaths {
             let typeshed = canonicalize(typeshed, system);
             tracing::debug!("Adding custom-stdlib search path '{typeshed}'");
 
-            files.try_add_root(db.upcast(), &typeshed, FileRootKind::LibrarySearchPath);
-
             let versions_path = typeshed.join("stdlib/VERSIONS");
 
             let versions_content = system.read_to_string(&versions_path).map_err(|error| {
@@ -225,13 +220,13 @@ impl SearchPaths {
 
             let parsed: TypeshedVersions = versions_content.parse()?;
 
-            let search_path = SearchPath::custom_stdlib(db, &typeshed)?;
+            let search_path = SearchPath::custom_stdlib(system, &typeshed)?;
 
             (parsed, search_path)
         } else {
             tracing::debug!("Using vendored stdlib");
             (
-                vendored_typeshed_versions(db),
+                vendored_typeshed_versions(vendored),
                 SearchPath::vendored_stdlib(),
             )
         };
@@ -282,7 +277,6 @@ impl SearchPaths {
 
         for path in site_packages_paths {
             tracing::debug!("Adding site-packages search path '{path}'");
-            files.try_add_root(db.upcast(), &path, FileRootKind::LibrarySearchPath);
             site_packages.push(SearchPath::site_packages(system, path)?);
         }
 
@@ -311,6 +305,17 @@ impl SearchPaths {
             typeshed_versions,
             python_version_from_pyvenv_cfg: python_version,
         })
+    }
+
+    pub(crate) fn try_register_static_roots(&self, db: &dyn Db) {
+        let files = db.files();
+        for path in self.static_paths.iter().chain(self.site_packages.iter()) {
+            if let Some(system_path) = path.as_system_path() {
+                if !path.is_first_party() {
+                    files.try_add_root(db.upcast(), system_path, FileRootKind::LibrarySearchPath);
+                }
+            }
+        }
     }
 
     pub(super) fn iter<'a>(&'a self, db: &'a dyn Db) -> SearchPathIterator<'a> {
@@ -1488,14 +1493,14 @@ mod tests {
                 }),
                 python_platform: PythonPlatform::default(),
                 search_paths: SearchPathSettings {
-                    extra_paths: vec![],
-                    src_roots: vec![src.clone()],
                     custom_typeshed: Some(custom_typeshed),
                     python_path: PythonPath::KnownSitePackages(vec![site_packages]),
-                },
+                    ..SearchPathSettings::new(vec![src.clone()])
+                }
+                .to_search_paths(db.system(), db.vendored())
+                .expect("Valid search path settings"),
             },
-        )
-        .context("Invalid program settings")?;
+        );
 
         let foo_module = resolve_module(&db, &ModuleName::new_static("foo").unwrap()).unwrap();
         let bar_module = resolve_module(&db, &ModuleName::new_static("bar").unwrap()).unwrap();
@@ -2004,17 +2009,16 @@ not_a_directory
                 python_version: Some(PythonVersionWithSource::default()),
                 python_platform: PythonPlatform::default(),
                 search_paths: SearchPathSettings {
-                    extra_paths: vec![],
-                    src_roots: vec![SystemPathBuf::from("/src")],
-                    custom_typeshed: None,
                     python_path: PythonPath::KnownSitePackages(vec![
                         venv_site_packages,
                         system_site_packages,
                     ]),
-                },
+                    ..SearchPathSettings::new(vec![SystemPathBuf::from("/src")])
+                }
+                .to_search_paths(db.system(), db.vendored())
+                .expect("Valid search path settings"),
             },
-        )
-        .expect("Valid program settings");
+        );
 
         // The editable installs discovered from the `.pth` file in the first `site-packages` directory
         // take precedence over the second `site-packages` directory...
@@ -2082,15 +2086,11 @@ not_a_directory
             ProgramSettings {
                 python_version: Some(PythonVersionWithSource::default()),
                 python_platform: PythonPlatform::default(),
-                search_paths: SearchPathSettings {
-                    extra_paths: vec![],
-                    src_roots: vec![src],
-                    custom_typeshed: None,
-                    python_path: PythonPath::KnownSitePackages(vec![]),
-                },
+                search_paths: SearchPathSettings::new(vec![src])
+                    .to_search_paths(db.system(), db.vendored())
+                    .expect("valid search path settings"),
             },
-        )
-        .expect("Valid program settings");
+        );
 
         // Now try to resolve the module `A` (note the capital `A` instead of `a`).
         let a_module_name = ModuleName::new_static("A").unwrap();
@@ -2126,14 +2126,13 @@ not_a_directory
                 python_version: Some(PythonVersionWithSource::default()),
                 python_platform: PythonPlatform::default(),
                 search_paths: SearchPathSettings {
-                    extra_paths: vec![],
-                    src_roots: vec![project_directory],
-                    custom_typeshed: None,
                     python_path: PythonPath::KnownSitePackages(vec![site_packages.clone()]),
-                },
+                    ..SearchPathSettings::new(vec![project_directory])
+                }
+                .to_search_paths(db.system(), db.vendored())
+                .unwrap(),
             },
-        )
-        .unwrap();
+        );
 
         let foo_module_file = File::new(&db, FilePath::System(installed_foo_module));
         let module = file_to_module(&db, foo_module_file).unwrap();

--- a/crates/ty_python_semantic/src/module_resolver/testing.rs
+++ b/crates/ty_python_semantic/src/module_resolver/testing.rs
@@ -238,10 +238,10 @@ impl TestCaseBuilder<MockedTypeshed> {
         Program::from_settings(
             &db,
             ProgramSettings {
-                python_version: Some(PythonVersionWithSource {
+                python_version: PythonVersionWithSource {
                     version: python_version,
                     source: PythonVersionSource::default(),
-                }),
+                },
                 python_platform,
                 search_paths: SearchPathSettings {
                     custom_typeshed: Some(typeshed.clone()),
@@ -299,10 +299,10 @@ impl TestCaseBuilder<VendoredTypeshed> {
         Program::from_settings(
             &db,
             ProgramSettings {
-                python_version: Some(PythonVersionWithSource {
+                python_version: PythonVersionWithSource {
                     version: python_version,
                     source: PythonVersionSource::default(),
-                }),
+                },
                 python_platform,
                 search_paths: SearchPathSettings {
                     python_path: PythonPath::KnownSitePackages(vec![site_packages.clone()]),

--- a/crates/ty_python_semantic/src/module_resolver/testing.rs
+++ b/crates/ty_python_semantic/src/module_resolver/testing.rs
@@ -1,3 +1,4 @@
+use ruff_db::Db;
 use ruff_db::system::{
     DbWithTestSystem as _, DbWithWritableSystem as _, SystemPath, SystemPathBuf,
 };
@@ -243,14 +244,14 @@ impl TestCaseBuilder<MockedTypeshed> {
                 }),
                 python_platform,
                 search_paths: SearchPathSettings {
-                    extra_paths: vec![],
-                    src_roots: vec![src.clone()],
                     custom_typeshed: Some(typeshed.clone()),
                     python_path: PythonPath::KnownSitePackages(vec![site_packages.clone()]),
-                },
+                    ..SearchPathSettings::new(vec![src.clone()])
+                }
+                .to_search_paths(db.system(), db.vendored())
+                .expect("valid search path settings"),
             },
-        )
-        .expect("Valid program settings");
+        );
 
         TestCase {
             db,
@@ -306,10 +307,11 @@ impl TestCaseBuilder<VendoredTypeshed> {
                 search_paths: SearchPathSettings {
                     python_path: PythonPath::KnownSitePackages(vec![site_packages.clone()]),
                     ..SearchPathSettings::new(vec![src.clone()])
-                },
+                }
+                .to_search_paths(db.system(), db.vendored())
+                .expect("valid search path settings"),
             },
-        )
-        .expect("Valid search path settings");
+        );
 
         TestCase {
             db,

--- a/crates/ty_python_semantic/src/program.rs
+++ b/crates/ty_python_semantic/src/program.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::sync::Arc;
 
 use crate::Db;
@@ -40,22 +39,14 @@ impl Program {
 
     pub fn from_settings(db: &dyn Db, settings: ProgramSettings) -> Self {
         let ProgramSettings {
-            python_version: python_version_with_source,
+            python_version,
             python_platform,
             search_paths,
         } = settings;
 
         search_paths.try_register_static_roots(db);
 
-        let python_version_with_source =
-            Self::resolve_python_version(python_version_with_source, &search_paths);
-
-        tracing::info!(
-            "Python version: Python {python_version}, platform: {python_platform}",
-            python_version = python_version_with_source.version
-        );
-
-        Program::builder(python_version_with_source, python_platform, search_paths)
+        Program::builder(python_version, python_platform, search_paths)
             .durability(Durability::HIGH)
             .new(db)
     }
@@ -64,33 +55,16 @@ impl Program {
         self.python_version_with_source(db).version
     }
 
-    fn resolve_python_version(
-        config_value: Option<PythonVersionWithSource>,
-        search_paths: &SearchPaths,
-    ) -> PythonVersionWithSource {
-        config_value
-            .or_else(|| {
-                search_paths
-                    .try_resolve_installation_python_version()
-                    .map(Cow::into_owned)
-            })
-            .unwrap_or_default()
-    }
-
     pub fn update_from_settings(self, db: &mut dyn Db, settings: ProgramSettings) {
         let ProgramSettings {
-            python_version: python_version_with_source,
+            python_version,
             python_platform,
             search_paths,
         } = settings;
 
-        search_paths.try_register_static_roots(db);
-
-        let new_python_version =
-            Self::resolve_python_version(python_version_with_source, &search_paths);
-
         if self.search_paths(db) != &search_paths {
             tracing::debug!("Updating search paths");
+            search_paths.try_register_static_roots(db);
             self.set_search_paths(db).to(search_paths);
         }
 
@@ -99,37 +73,12 @@ impl Program {
             self.set_python_platform(db).to(python_platform);
         }
 
-        if &new_python_version != self.python_version_with_source(db) {
+        if &python_version != self.python_version_with_source(db) {
             tracing::debug!(
                 "Updating python version: Python {version}",
-                version = new_python_version.version
+                version = python_version.version
             );
-            self.set_python_version_with_source(db)
-                .to(new_python_version);
-        }
-    }
-
-    /// Update the search paths for the program.
-    pub fn update_search_paths(self, db: &mut dyn Db, search_paths: SearchPaths) {
-        let current_python_version = self.python_version_with_source(db);
-
-        let python_version_from_environment = search_paths
-            .try_resolve_installation_python_version()
-            .map(Cow::into_owned)
-            .unwrap_or_default();
-
-        if current_python_version != &python_version_from_environment
-            && current_python_version.source.priority()
-                <= python_version_from_environment.source.priority()
-        {
-            tracing::debug!("Updating Python version from environment");
-            self.set_python_version_with_source(db)
-                .to(python_version_from_environment);
-        }
-
-        if self.search_paths(db) != &search_paths {
-            tracing::debug!("Updating search paths");
-            self.set_search_paths(db).to(search_paths);
+            self.set_python_version_with_source(db).to(python_version);
         }
     }
 
@@ -140,7 +89,7 @@ impl Program {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ProgramSettings {
-    pub python_version: Option<PythonVersionWithSource>,
+    pub python_version: PythonVersionWithSource,
     pub python_platform: PythonPlatform,
     pub search_paths: SearchPaths,
 }
@@ -168,35 +117,6 @@ pub enum PythonVersionSource {
     /// We fell back to a default value because the value was not specified via the CLI or a config file.
     #[default]
     Default,
-}
-
-impl PythonVersionSource {
-    fn priority(&self) -> PythonSourcePriority {
-        match self {
-            PythonVersionSource::Default => PythonSourcePriority::Default,
-            PythonVersionSource::PyvenvCfgFile(_) => PythonSourcePriority::PyvenvCfgFile,
-            PythonVersionSource::ConfigFile(_) => PythonSourcePriority::ConfigFile,
-            PythonVersionSource::Cli => PythonSourcePriority::Cli,
-            PythonVersionSource::InstallationDirectoryLayout { .. } => {
-                PythonSourcePriority::InstallationDirectoryLayout
-            }
-        }
-    }
-}
-
-/// The priority in which Python version sources are considered.
-/// The lower down the variant appears in this enum, the higher its priority.
-///
-/// For example, if a Python version is specified in a pyproject.toml file
-/// but *also* via a CLI argument, the CLI argument will take precedence.
-#[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord)]
-#[cfg_attr(test, derive(strum_macros::EnumIter))]
-enum PythonSourcePriority {
-    Default,
-    InstallationDirectoryLayout,
-    PyvenvCfgFile,
-    ConfigFile,
-    Cli,
 }
 
 /// Information regarding the file and [`TextRange`] of the configuration
@@ -314,76 +234,5 @@ pub enum PythonPath {
 impl PythonPath {
     pub fn sys_prefix(path: impl Into<SystemPathBuf>, origin: SysPrefixPathOrigin) -> Self {
         Self::IntoSysPrefix(path.into(), origin)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use strum::IntoEnumIterator;
-
-    #[test]
-    fn test_python_version_source_priority() {
-        for priority in PythonSourcePriority::iter() {
-            match priority {
-                // CLI source takes priority over all other sources.
-                PythonSourcePriority::Cli => {
-                    for other in PythonSourcePriority::iter() {
-                        assert!(priority >= other, "{other:?}");
-                    }
-                }
-                // Config files have lower priority than CLI arguments,
-                // but higher than pyvenv.cfg files and the fallback default.
-                PythonSourcePriority::ConfigFile => {
-                    for other in PythonSourcePriority::iter() {
-                        match other {
-                            PythonSourcePriority::Cli => assert!(other > priority, "{other:?}"),
-                            PythonSourcePriority::ConfigFile => assert_eq!(priority, other),
-                            PythonSourcePriority::PyvenvCfgFile
-                            | PythonSourcePriority::Default
-                            | PythonSourcePriority::InstallationDirectoryLayout => {
-                                assert!(priority > other, "{other:?}");
-                            }
-                        }
-                    }
-                }
-                // Pyvenv.cfg files have lower priority than CLI flags and config files,
-                // but higher than the default fallback.
-                PythonSourcePriority::PyvenvCfgFile => {
-                    for other in PythonSourcePriority::iter() {
-                        match other {
-                            PythonSourcePriority::Cli | PythonSourcePriority::ConfigFile => {
-                                assert!(other > priority, "{other:?}");
-                            }
-                            PythonSourcePriority::PyvenvCfgFile => assert_eq!(priority, other),
-                            PythonSourcePriority::Default
-                            | PythonSourcePriority::InstallationDirectoryLayout => {
-                                assert!(priority > other, "{other:?}");
-                            }
-                        }
-                    }
-                }
-                PythonSourcePriority::InstallationDirectoryLayout => {
-                    for other in PythonSourcePriority::iter() {
-                        match other {
-                            PythonSourcePriority::Cli
-                            | PythonSourcePriority::ConfigFile
-                            | PythonSourcePriority::PyvenvCfgFile => {
-                                assert!(other > priority, "{other:?}");
-                            }
-                            PythonSourcePriority::InstallationDirectoryLayout => {
-                                assert_eq!(priority, other);
-                            }
-                            PythonSourcePriority::Default => assert!(priority > other, "{other:?}"),
-                        }
-                    }
-                }
-                PythonSourcePriority::Default => {
-                    for other in PythonSourcePriority::iter() {
-                        assert!(priority <= other, "{other:?}");
-                    }
-                }
-            }
-        }
     }
 }

--- a/crates/ty_python_semantic/src/site_packages.rs
+++ b/crates/ty_python_semantic/src/site_packages.rs
@@ -532,7 +532,7 @@ impl SystemEnvironment {
 
 /// Enumeration of ways in which `site-packages` discovery can fail.
 #[derive(Debug)]
-pub(crate) enum SitePackagesDiscoveryError {
+pub enum SitePackagesDiscoveryError {
     /// `site-packages` discovery failed because the provided path couldn't be canonicalized.
     CanonicalizationError(SystemPathBuf, SysPrefixPathOrigin, io::Error),
 
@@ -698,7 +698,7 @@ fn display_error(
 
 /// The various ways in which parsing a `pyvenv.cfg` file could fail
 #[derive(Debug)]
-pub(crate) enum PyvenvCfgParseErrorKind {
+pub enum PyvenvCfgParseErrorKind {
     MalformedKeyValuePair { line_number: NonZeroUsize },
     NoHomeKey,
     InvalidHomeValue(io::Error),
@@ -853,7 +853,7 @@ fn site_packages_directory_from_sys_prefix(
 ///
 /// [`sys.prefix`]: https://docs.python.org/3/library/sys.html#sys.prefix
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub(crate) struct SysPrefixPath {
+pub struct SysPrefixPath {
     inner: SystemPathBuf,
     origin: SysPrefixPathOrigin,
 }

--- a/crates/ty_python_semantic/tests/corpus.rs
+++ b/crates/ty_python_semantic/tests/corpus.rs
@@ -1,8 +1,8 @@
 use anyhow::{Context, anyhow};
-use ruff_db::Upcast;
 use ruff_db::files::{File, Files, system_path_to_file};
 use ruff_db::system::{DbWithTestSystem, System, SystemPath, SystemPathBuf, TestSystem};
 use ruff_db::vendored::VendoredFileSystem;
+use ruff_db::{Db, Upcast};
 use ruff_python_ast::PythonVersion;
 
 use ty_python_semantic::lint::{LintRegistry, RuleSelection};
@@ -210,10 +210,11 @@ impl CorpusDb {
                     source: PythonVersionSource::default(),
                 }),
                 python_platform: PythonPlatform::default(),
-                search_paths: SearchPathSettings::new(vec![]),
+                search_paths: SearchPathSettings::new(vec![])
+                    .to_search_paths(db.system(), db.vendored())
+                    .unwrap(),
             },
-        )
-        .unwrap();
+        );
 
         db
     }

--- a/crates/ty_python_semantic/tests/corpus.rs
+++ b/crates/ty_python_semantic/tests/corpus.rs
@@ -205,10 +205,10 @@ impl CorpusDb {
         Program::from_settings(
             &db,
             ProgramSettings {
-                python_version: Some(PythonVersionWithSource {
+                python_version: PythonVersionWithSource {
                     version: PythonVersion::latest_ty(),
                     source: PythonVersionSource::default(),
-                }),
+                },
                 python_platform: PythonPlatform::default(),
                 search_paths: SearchPathSettings::new(vec![])
                     .to_search_paths(db.system(), db.vendored())

--- a/crates/ty_test/src/assertion.rs
+++ b/crates/ty_test/src/assertion.rs
@@ -501,7 +501,7 @@ mod tests {
         let mut db = Db::setup();
 
         let settings = ProgramSettings {
-            python_version: Some(PythonVersionWithSource::default()),
+            python_version: PythonVersionWithSource::default(),
             python_platform: PythonPlatform::default(),
             search_paths: SearchPathSettings::new(Vec::new())
                 .to_search_paths(db.system(), db.vendored())

--- a/crates/ty_test/src/assertion.rs
+++ b/crates/ty_test/src/assertion.rs
@@ -489,8 +489,8 @@ pub(crate) enum ErrorAssertionParseError<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ruff_db::files::system_path_to_file;
     use ruff_db::system::DbWithWritableSystem as _;
+    use ruff_db::{Db as _, files::system_path_to_file};
     use ruff_python_trivia::textwrap::dedent;
     use ruff_source_file::OneIndexed;
     use ty_python_semantic::{
@@ -503,13 +503,11 @@ mod tests {
         let settings = ProgramSettings {
             python_version: Some(PythonVersionWithSource::default()),
             python_platform: PythonPlatform::default(),
-            search_paths: SearchPathSettings::new(Vec::new()),
+            search_paths: SearchPathSettings::new(Vec::new())
+                .to_search_paths(db.system(), db.vendored())
+                .unwrap(),
         };
-        match Program::try_get(&db) {
-            Some(program) => program.update_from_settings(&mut db, settings),
-            None => Program::from_settings(&db, settings).map(|_| ()),
-        }
-        .expect("Failed to update Program settings in TestDb");
+        Program::init_or_update(&mut db, settings);
 
         db.write_file("/src/test.py", source).unwrap();
         let file = system_path_to_file(&db, "/src/test.py").unwrap();

--- a/crates/ty_test/src/lib.rs
+++ b/crates/ty_test/src/lib.rs
@@ -260,10 +260,10 @@ fn run_test(
     let configuration = test.configuration();
 
     let settings = ProgramSettings {
-        python_version: Some(PythonVersionWithSource {
+        python_version: PythonVersionWithSource {
             version: python_version,
             source: PythonVersionSource::Cli,
-        }),
+        },
         python_platform: configuration
             .python_platform()
             .unwrap_or(PythonPlatform::Identifier("linux".to_string())),

--- a/crates/ty_test/src/lib.rs
+++ b/crates/ty_test/src/lib.rs
@@ -5,7 +5,6 @@ use camino::Utf8Path;
 use colored::Colorize;
 use config::SystemKind;
 use parser as test_parser;
-use ruff_db::Upcast;
 use ruff_db::diagnostic::{
     Diagnostic, DisplayDiagnosticConfig, create_parse_diagnostic,
     create_unsupported_syntax_diagnostic,
@@ -15,6 +14,7 @@ use ruff_db::panic::catch_unwind;
 use ruff_db::parsed::parsed_module;
 use ruff_db::system::{DbWithWritableSystem as _, SystemPath, SystemPathBuf};
 use ruff_db::testing::{setup_logging, setup_logging_with_filter};
+use ruff_db::{Db as _, Upcast};
 use ruff_source_file::{LineIndex, OneIndexed};
 use std::backtrace::BacktraceStatus;
 use std::fmt::Write;
@@ -280,14 +280,12 @@ fn run_test(
                     )
                 })
                 .unwrap_or(PythonPath::KnownSitePackages(vec![])),
-        },
+        }
+        .to_search_paths(db.system(), db.vendored())
+        .expect("Failed to resolve search path settings"),
     };
 
-    match Program::try_get(db) {
-        Some(program) => program.update_from_settings(db, settings),
-        None => Program::from_settings(db, settings).map(|_| ()),
-    }
-    .expect("Failed to update Program settings in TestDb");
+    Program::init_or_update(db, settings);
 
     // When snapshot testing is enabled, this is populated with
     // all diagnostics. Otherwise it remains empty.

--- a/crates/ty_test/src/matcher.rs
+++ b/crates/ty_test/src/matcher.rs
@@ -338,6 +338,7 @@ impl Matcher {
 #[cfg(test)]
 mod tests {
     use super::FailuresByLine;
+    use ruff_db::Db;
     use ruff_db::diagnostic::{Annotation, Diagnostic, DiagnosticId, Severity, Span};
     use ruff_db::files::{File, system_path_to_file};
     use ruff_db::system::DbWithWritableSystem as _;
@@ -387,13 +388,11 @@ mod tests {
         let settings = ProgramSettings {
             python_version: Some(PythonVersionWithSource::default()),
             python_platform: PythonPlatform::default(),
-            search_paths: SearchPathSettings::new(Vec::new()),
+            search_paths: SearchPathSettings::new(Vec::new())
+                .to_search_paths(db.system(), db.vendored())
+                .expect("Valid search paths settings"),
         };
-        match Program::try_get(&db) {
-            Some(program) => program.update_from_settings(&mut db, settings),
-            None => Program::from_settings(&db, settings).map(|_| ()),
-        }
-        .expect("Failed to update Program settings in TestDb");
+        Program::init_or_update(&mut db, settings);
 
         db.write_file("/src/test.py", source).unwrap();
         let file = system_path_to_file(&db, "/src/test.py").unwrap();

--- a/crates/ty_test/src/matcher.rs
+++ b/crates/ty_test/src/matcher.rs
@@ -386,7 +386,7 @@ mod tests {
         let mut db = crate::db::Db::setup();
 
         let settings = ProgramSettings {
-            python_version: Some(PythonVersionWithSource::default()),
+            python_version: PythonVersionWithSource::default(),
             python_platform: PythonPlatform::default(),
             search_paths: SearchPathSettings::new(Vec::new())
                 .to_search_paths(db.system(), db.vendored())

--- a/crates/ty_wasm/src/lib.rs
+++ b/crates/ty_wasm/src/lib.rs
@@ -1,7 +1,6 @@
 use std::any::Any;
 
 use js_sys::{Error, JsString};
-use ruff_db::Upcast;
 use ruff_db::diagnostic::{self, DisplayDiagnosticConfig};
 use ruff_db::files::{File, FileRange, system_path_to_file};
 use ruff_db::source::{line_index, source_text};
@@ -10,6 +9,7 @@ use ruff_db::system::{
     CaseSensitivity, DirectoryEntry, GlobError, MemoryFileSystem, Metadata, PatternError, System,
     SystemPath, SystemPathBuf, SystemVirtualPath,
 };
+use ruff_db::{Db as _, Upcast};
 use ruff_notebook::Notebook;
 use ruff_python_formatter::formatted_file;
 use ruff_source_file::{LineIndex, OneIndexed, SourceLocation};
@@ -97,10 +97,10 @@ impl Workspace {
         )
         .map_err(into_error)?;
 
-        let program_settings = project.to_program_settings(&self.system);
-        Program::get(&self.db)
-            .update_from_settings(&mut self.db, program_settings)
+        let program_settings = project
+            .to_program_settings(&self.system, self.db.vendored())
             .map_err(into_error)?;
+        Program::get(&self.db).update_from_settings(&mut self.db, program_settings);
 
         self.db.project().reload(&mut self.db, project);
 

--- a/fuzz/fuzz_targets/ty_check_invalid_syntax.rs
+++ b/fuzz/fuzz_targets/ty_check_invalid_syntax.rs
@@ -118,12 +118,13 @@ fn setup_db() -> TestDb {
     Program::from_settings(
         &db,
         ProgramSettings {
-            python_version: Some(PythonVersionWithSource::default()),
+            python_version: PythonVersionWithSource::default(),
             python_platform: PythonPlatform::default(),
-            search_paths: SearchPathSettings::new(vec![src_root]),
+            search_paths: SearchPathSettings::new(vec![src_root])
+                .to_search_paths(db.system(), db.vendored())
+                .expect("Valid search path settings"),
         },
-    )
-    .expect("Valid search path settings");
+    );
 
     db
 }


### PR DESCRIPTION
## Summary

This PR moves the `SearchPaths::from_settings` call and the resolution of the final Python version into `Options::to_program_settings`. 

We want to use `ProgramSettings` as a cache key for persistent caching (e.g., checking different Python versions should resolve in loading different persistent caches). For this to work well, it's important that `ProgramSettings` mainly holds resolved settings. For example, it's essential that the following two runs in an activated virtual environment using Python 3.10 result in the same computed cache key: `ty check --python-version 3.10` and `ty check`.

The reason I made this change now is that I investigated what it would mean if the LSP passed the selected interpreter in the Python extension as a lowest-priority fallback value. We want to make sure that ty reuses the persistent cache between a `ty check --python-version 3.10` run and when the interpreter selected in the IDE uses Python 3.10.

This should hopefully also simplify the handling of `VIRTUAL_ENV` and `CONDA_ENV` as fallback if no python version is provided.



## Test Plan

Existing tests. I did move some tests from `ProjectMetadata` to CLI tests because keeping them in the metadata tests would have required increasing the visibility of many fields.