### PR TITLE
[`FastAPI`] Add fix safety section to `FAST002`

### DIFF
--- a/crates/ruff_linter/src/rules/fastapi/rules/fastapi_non_annotated_dependency.rs
+++ b/crates/ruff_linter/src/rules/fastapi/rules/fastapi_non_annotated_dependency.rs
@@ -59,11 +59,17 @@ use ruff_python_ast::PythonVersion;
 ///     return commons
 /// ```
 ///
+/// ## Fix safety
+/// This fix is always unsafe, as adding/removing/changing a function parameter's
+/// default value can change runtime behavior. Additionally, comments inside the 
+/// deprecated uses will be removed.
+///
 /// ## Availability
 ///
 /// Because this rule relies on the third-party `typing_extensions` module for Python versions
-/// before 3.9, its diagnostic will not be emitted, and no fix will be offered, if
-/// `typing_extensions` imports have been disabled by the [`lint.typing-extensions`] linter option.
+/// before 3.9, if the target version is < 3.9 and `typing_extensions` imports have been
+/// disabled by the [`lint.typing-extensions`] linter option the diagnostic will not be emitted
+/// and no fix will be offered.
 ///
 /// ## Options
 ///

--- a/crates/ruff_linter/src/rules/fastapi/rules/fastapi_non_annotated_dependency.rs
+++ b/crates/ruff_linter/src/rules/fastapi/rules/fastapi_non_annotated_dependency.rs
@@ -62,7 +62,7 @@ use ruff_python_ast::PythonVersion;
 /// ## Fix safety
 /// This fix is always unsafe, as adding/removing/changing a function parameter's
 /// default value can change runtime behavior. Additionally, comments inside the 
-/// deprecated uses will be removed.
+/// deprecated uses might be removed.
 ///
 /// ## Availability
 ///


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Part of #15584

This PR adds a fix safety section to [fast-api-non-annotated-dependency (FAST002)](https://docs.astral.sh/ruff/rules/fast-api-non-annotated-dependency/#fast-api-non-annotated-dependency-fast002). It also re-words the availability section since I found it confusing.

The lint/fix was added in #11579 as always unsafe.
No reasoning is given in the original PR/code as to why this was chosen.
Example of why the fix is unsafe:
https://play.ruff.rs/3bd0566e-1ef6-4cec-ae34-3b07cd308155
```py
from fastapi import Depends, FastAPI, Query

app = FastAPI()

# Fix will remove the parameter default value
@app.get("/items/")
async def read_items(commons: dict = Depends(common_parameters)):
    return commons

# Fix will delete comment and change default parameter value
@app.get("/items/")
async def read_items_1(q: str = Query(  # This comment will be deleted
    default="rick")):
    return q
```
After fixing both instances of `FAST002`:
```py
from fastapi import Depends, FastAPI, Query
from typing import Annotated

app = FastAPI()

# Fix will remove the parameter default value
@app.get("/items/")
async def read_items(commons: Annotated[dict, Depends(common_parameters)]):
    return commons

# Fix will delete comment and change default parameter value
@app.get("/items/")
async def read_items_1(q: Annotated[str, Query()] = "rick"):
    return q
```

## Test Plan

<!-- How was it tested? -->

N/A, no functionality/tests affected