### PR TITLE
[ty] Add subdiagnostic about empty bodies in more cases

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type_(a91e0c67519cd77f).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type_(a91e0c67519cd77f).snap
@@ -93,6 +93,7 @@ error[invalid-return-type]: Function always implicitly returns `None`, which is 
    |                ^
    |
 info: Consider changing the return annotation to `-> None` or adding a `return` statement
+info: Only functions in stub files, methods on protocol classes, or methods with `@abstractmethod` are permitted to have empty bodies
 info: rule `invalid-return-type` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -1828,14 +1828,14 @@ pub(super) fn report_implicit_return_type(
     if !has_empty_body {
         return;
     }
+    diagnostic.info(
+        "Only functions in stub files, methods on protocol classes, \
+            or methods with `@abstractmethod` are permitted to have empty bodies",
+    );
     let Some(class) = enclosing_class_of_method else {
         return;
     };
     if class.iter_mro(db, None).contains(&ClassBase::Protocol) {
-        diagnostic.info(
-            "Only functions in stub files, methods on protocol classes, \
-            or methods with `@abstractmethod` are permitted to have empty bodies",
-        );
         diagnostic.info(format_args!(
             "Class `{}` has `typing.Protocol` in its MRO, but it is not a protocol class",
             class.name(db)


### PR DESCRIPTION
## Summary

This message seems useful even if `Protocol` isn't present in a class's MRO. Fixes https://github.com/astral-sh/ty/issues/704

## Test Plan

snapshot
