### PR TITLE
[ty] Reduce the overwhelming complexity of `TypeInferenceBuilder::infer_call_expression`

### DIFF
--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -3184,6 +3184,8 @@ impl KnownClass {
         }
     }
 
+    /// Evaluate a call to this known class, and emit any diagnostics that are necessary
+    /// as a result of the call.
     pub(super) fn check_call<'db>(
         self,
         context: &InferContext<'db, '_>,

--- a/crates/ty_python_semantic/src/types/context.rs
+++ b/crates/ty_python_semantic/src/types/context.rs
@@ -68,6 +68,10 @@ impl<'db, 'ast> InferContext<'db, 'ast> {
         self.module
     }
 
+    pub(crate) fn scope(&self) -> ScopeId<'db> {
+        self.scope
+    }
+
     /// Create a span with the range of the given expression
     /// in the file being currently type checked.
     ///

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -950,6 +950,8 @@ impl KnownFunction {
         }
     }
 
+    /// Evaluate a call to this known function, and emit any diagnostics that are necessary
+    /// as a result of the call.
     pub(super) fn check_call(
         self,
         context: &InferContext,

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -52,7 +52,7 @@
 use std::str::FromStr;
 
 use bitflags::bitflags;
-use ruff_db::diagnostic::Span;
+use ruff_db::diagnostic::{Annotation, DiagnosticId, Severity, Span};
 use ruff_db::files::{File, FileRange};
 use ruff_db::parsed::{ParsedModuleRef, parsed_module};
 use ruff_python_ast as ast;
@@ -64,11 +64,18 @@ use crate::semantic_index::ast_ids::HasScopedUseId;
 use crate::semantic_index::definition::Definition;
 use crate::semantic_index::place::ScopeId;
 use crate::semantic_index::semantic_index;
+use crate::types::context::InferContext;
+use crate::types::diagnostic::{
+    REDUNDANT_CAST, STATIC_ASSERT_ERROR, TYPE_ASSERTION_FAILURE,
+    report_bad_argument_to_get_protocol_members,
+    report_runtime_check_against_non_runtime_checkable_protocol,
+};
 use crate::types::generics::GenericContext;
 use crate::types::narrow::ClassInfoConstraintFunction;
 use crate::types::signatures::{CallableSignature, Signature};
 use crate::types::{
-    BoundMethodType, CallableType, Type, TypeMapping, TypeRelation, TypeVarInstance,
+    Binding, BoundMethodType, CallableType, DynamicType, Type, TypeMapping, TypeRelation,
+    TypeVarInstance,
 };
 use crate::{Db, FxOrderSet};
 
@@ -940,6 +947,197 @@ impl KnownFunction {
             | Self::DunderAllNames
             | Self::StaticAssert
             | Self::AllMembers => module.is_ty_extensions(),
+        }
+    }
+
+    pub(super) fn check_call(
+        self,
+        context: &InferContext,
+        overload_binding: &mut Binding,
+        call_expression: &ast::ExprCall,
+    ) {
+        let db = context.db();
+
+        match self {
+            KnownFunction::RevealType => {
+                let [Some(revealed_type)] = overload_binding.parameter_types() else {
+                    return;
+                };
+                let Some(builder) =
+                    context.report_diagnostic(DiagnosticId::RevealedType, Severity::Info)
+                else {
+                    return;
+                };
+                let mut diag = builder.into_diagnostic("Revealed type");
+                let span = context.span(&call_expression.arguments.args[0]);
+                diag.annotate(
+                    Annotation::primary(span)
+                        .message(format_args!("`{}`", revealed_type.display(db))),
+                );
+            }
+            KnownFunction::AssertType => {
+                let [Some(actual_ty), Some(asserted_ty)] = overload_binding.parameter_types()
+                else {
+                    return;
+                };
+
+                if actual_ty.is_equivalent_to(db, *asserted_ty) {
+                    return;
+                }
+                let Some(builder) = context.report_lint(&TYPE_ASSERTION_FAILURE, call_expression)
+                else {
+                    return;
+                };
+
+                let mut diagnostic = builder.into_diagnostic(format_args!(
+                    "Argument does not have asserted type `{}`",
+                    asserted_ty.display(db),
+                ));
+
+                diagnostic.annotate(
+                    Annotation::secondary(context.span(&call_expression.arguments.args[0]))
+                        .message(format_args!(
+                            "Inferred type of argument is `{}`",
+                            actual_ty.display(db),
+                        )),
+                );
+
+                diagnostic.info(format_args!(
+                    "`{asserted_type}` and `{inferred_type}` are not equivalent types",
+                    asserted_type = asserted_ty.display(db),
+                    inferred_type = actual_ty.display(db),
+                ));
+            }
+            KnownFunction::AssertNever => {
+                let [Some(actual_ty)] = overload_binding.parameter_types() else {
+                    return;
+                };
+                if actual_ty.is_equivalent_to(db, Type::Never) {
+                    return;
+                }
+                let Some(builder) = context.report_lint(&TYPE_ASSERTION_FAILURE, call_expression)
+                else {
+                    return;
+                };
+
+                let mut diagnostic =
+                    builder.into_diagnostic("Argument does not have asserted type `Never`");
+                diagnostic.annotate(
+                    Annotation::secondary(context.span(&call_expression.arguments.args[0]))
+                        .message(format_args!(
+                            "Inferred type of argument is `{}`",
+                            actual_ty.display(db)
+                        )),
+                );
+                diagnostic.info(format_args!(
+                    "`Never` and `{inferred_type}` are not equivalent types",
+                    inferred_type = actual_ty.display(db),
+                ));
+            }
+            KnownFunction::StaticAssert => {
+                let [Some(parameter_ty), message] = overload_binding.parameter_types() else {
+                    return;
+                };
+                let truthiness = match parameter_ty.try_bool(db) {
+                    Ok(truthiness) => truthiness,
+                    Err(err) => {
+                        let condition = call_expression
+                            .arguments
+                            .find_argument("condition", 0)
+                            .map(|argument| match argument {
+                                ruff_python_ast::ArgOrKeyword::Arg(expr) => {
+                                    ast::AnyNodeRef::from(expr)
+                                }
+                                ruff_python_ast::ArgOrKeyword::Keyword(keyword) => {
+                                    ast::AnyNodeRef::from(keyword)
+                                }
+                            })
+                            .unwrap_or(ast::AnyNodeRef::from(call_expression));
+
+                        err.report_diagnostic(context, condition);
+
+                        return;
+                    }
+                };
+
+                let Some(builder) = context.report_lint(&STATIC_ASSERT_ERROR, call_expression)
+                else {
+                    return;
+                };
+                if truthiness.is_always_true() {
+                    return;
+                }
+                if let Some(message) = message
+                    .and_then(Type::into_string_literal)
+                    .map(|s| s.value(db))
+                {
+                    builder.into_diagnostic(format_args!("Static assertion error: {message}"));
+                } else if *parameter_ty == Type::BooleanLiteral(false) {
+                    builder
+                        .into_diagnostic("Static assertion error: argument evaluates to `False`");
+                } else if truthiness.is_always_false() {
+                    builder.into_diagnostic(format_args!(
+                        "Static assertion error: argument of type `{parameter_ty}` \
+                            is statically known to be falsy",
+                        parameter_ty = parameter_ty.display(db)
+                    ));
+                } else {
+                    builder.into_diagnostic(format_args!(
+                        "Static assertion error: argument of type `{parameter_ty}` \
+                            has an ambiguous static truthiness",
+                        parameter_ty = parameter_ty.display(db)
+                    ));
+                }
+            }
+            KnownFunction::Cast => {
+                let [Some(casted_type), Some(source_type)] = overload_binding.parameter_types()
+                else {
+                    return;
+                };
+                let contains_unknown_or_todo =
+                    |ty| matches!(ty, Type::Dynamic(dynamic) if dynamic != DynamicType::Any);
+                if source_type.is_equivalent_to(db, *casted_type)
+                    && !casted_type.any_over_type(db, &|ty| contains_unknown_or_todo(ty))
+                    && !source_type.any_over_type(db, &|ty| contains_unknown_or_todo(ty))
+                {
+                    let Some(builder) = context.report_lint(&REDUNDANT_CAST, call_expression)
+                    else {
+                        return;
+                    };
+                    builder.into_diagnostic(format_args!(
+                        "Value is already of type `{}`",
+                        casted_type.display(db),
+                    ));
+                }
+            }
+            KnownFunction::GetProtocolMembers => {
+                let [Some(Type::ClassLiteral(class))] = overload_binding.parameter_types() else {
+                    return;
+                };
+                if class.is_protocol(db) {
+                    return;
+                }
+                report_bad_argument_to_get_protocol_members(context, call_expression, *class);
+            }
+            KnownFunction::IsInstance | KnownFunction::IsSubclass => {
+                let [_, Some(Type::ClassLiteral(class))] = overload_binding.parameter_types()
+                else {
+                    return;
+                };
+                let Some(protocol_class) = class.into_protocol_class(db) else {
+                    return;
+                };
+                if protocol_class.is_runtime_checkable(db) {
+                    return;
+                }
+                report_runtime_check_against_non_runtime_checkable_protocol(
+                    context,
+                    call_expression,
+                    protocol_class,
+                    self,
+                );
+            }
+            _ => {}
         }
     }
 }

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -5412,7 +5412,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             call_expression,
                         );
                     }
-                    _ => (),
+                    _ => {}
                 }
             }
         }

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -78,16 +78,15 @@ use crate::types::diagnostic::{
     self, CALL_NON_CALLABLE, CONFLICTING_DECLARATIONS, CONFLICTING_METACLASS,
     CYCLIC_CLASS_DEFINITION, DIVISION_BY_ZERO, DUPLICATE_KW_ONLY, INCONSISTENT_MRO,
     INVALID_ARGUMENT_TYPE, INVALID_ASSIGNMENT, INVALID_ATTRIBUTE_ACCESS, INVALID_BASE,
-    INVALID_DECLARATION, INVALID_GENERIC_CLASS, INVALID_LEGACY_TYPE_VARIABLE,
-    INVALID_PARAMETER_DEFAULT, INVALID_TYPE_ALIAS_TYPE, INVALID_TYPE_FORM, INVALID_TYPE_GUARD_CALL,
-    INVALID_TYPE_VARIABLE_CONSTRAINTS, IncompatibleBases, POSSIBLY_UNBOUND_IMPLICIT_CALL,
-    POSSIBLY_UNBOUND_IMPORT, TypeCheckDiagnostics, UNDEFINED_REVEAL, UNRESOLVED_ATTRIBUTE,
-    UNRESOLVED_IMPORT, UNRESOLVED_REFERENCE, UNSUPPORTED_OPERATOR, report_implicit_return_type,
-    report_instance_layout_conflict, report_invalid_argument_number_to_special_form,
-    report_invalid_arguments_to_annotated, report_invalid_arguments_to_callable,
-    report_invalid_assignment, report_invalid_attribute_assignment,
-    report_invalid_generator_function_return_type, report_invalid_return_type,
-    report_possibly_unbound_attribute,
+    INVALID_DECLARATION, INVALID_GENERIC_CLASS, INVALID_PARAMETER_DEFAULT, INVALID_TYPE_FORM,
+    INVALID_TYPE_GUARD_CALL, INVALID_TYPE_VARIABLE_CONSTRAINTS, IncompatibleBases,
+    POSSIBLY_UNBOUND_IMPLICIT_CALL, POSSIBLY_UNBOUND_IMPORT, TypeCheckDiagnostics,
+    UNDEFINED_REVEAL, UNRESOLVED_ATTRIBUTE, UNRESOLVED_IMPORT, UNRESOLVED_REFERENCE,
+    UNSUPPORTED_OPERATOR, report_implicit_return_type, report_instance_layout_conflict,
+    report_invalid_argument_number_to_special_form, report_invalid_arguments_to_annotated,
+    report_invalid_arguments_to_callable, report_invalid_assignment,
+    report_invalid_attribute_assignment, report_invalid_generator_function_return_type,
+    report_invalid_return_type, report_possibly_unbound_attribute,
 };
 use crate::types::function::{
     FunctionDecorators, FunctionLiteral, FunctionType, KnownFunction, OverloadLiteral,
@@ -98,11 +97,11 @@ use crate::types::signatures::{CallableSignature, Signature};
 use crate::types::tuple::{TupleSpec, TupleType};
 use crate::types::unpacker::{UnpackResult, Unpacker};
 use crate::types::{
-    BareTypeAliasType, CallDunderError, CallableType, ClassLiteral, ClassType, DataclassParams,
-    DynamicType, IntersectionBuilder, IntersectionType, KnownClass, KnownInstanceType,
-    LintDiagnosticGuard, MemberLookupPolicy, MetaclassCandidate, PEP695TypeAliasType, Parameter,
-    ParameterForm, Parameters, SpecialFormType, StringLiteralType, SubclassOfType, Truthiness,
-    Type, TypeAliasType, TypeAndQualifiers, TypeArrayDisplay, TypeIsType, TypeQualifiers,
+    CallDunderError, CallableType, ClassLiteral, ClassType, DataclassParams, DynamicType,
+    IntersectionBuilder, IntersectionType, KnownClass, KnownInstanceType, LintDiagnosticGuard,
+    MemberLookupPolicy, MetaclassCandidate, PEP695TypeAliasType, Parameter, ParameterForm,
+    Parameters, SpecialFormType, StringLiteralType, SubclassOfType, Truthiness, Type,
+    TypeAliasType, TypeAndQualifiers, TypeArrayDisplay, TypeIsType, TypeQualifiers,
     TypeVarBoundOrConstraints, TypeVarInstance, TypeVarKind, TypeVarVariance, UnionBuilder,
     UnionType, binding_type, todo_type,
 };
@@ -124,10 +123,7 @@ use super::string_annotation::{
     BYTE_STRING_TYPE_ANNOTATION, FSTRING_TYPE_ANNOTATION, parse_string_annotation,
 };
 use super::subclass_of::SubclassOfInner;
-use super::{
-    BoundSuperError, BoundSuperType, ClassBase, NominalInstanceType,
-    add_inferred_python_version_hint_to_diagnostic,
-};
+use super::{ClassBase, NominalInstanceType, add_inferred_python_version_hint_to_diagnostic};
 
 /// Infer all types for a [`ScopeId`], including all definitions and expressions in that scope.
 /// Use when checking a scope, or needing to provide a type for an arbitrary expression in the
@@ -4678,9 +4674,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             ast::Expr::Named(named) => self.infer_named_expression(named),
             ast::Expr::If(if_expression) => self.infer_if_expression(if_expression),
             ast::Expr::Lambda(lambda_expression) => self.infer_lambda_expression(lambda_expression),
-            ast::Expr::Call(call_expression) => {
-                self.infer_call_expression(expression, call_expression)
-            }
+            ast::Expr::Call(call_expression) => self.infer_call_expression(call_expression),
             ast::Expr::Starred(starred) => self.infer_starred_expression(starred),
             ast::Expr::Yield(yield_expression) => self.infer_yield_expression(yield_expression),
             ast::Expr::YieldFrom(yield_from) => self.infer_yield_from_expression(yield_from),
@@ -5288,27 +5282,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         CallableType::function_like(self.db(), Signature::new(parameters, Some(Type::unknown())))
     }
 
-    /// Returns the type of the first parameter if the given scope is function-like (i.e. function or lambda).
-    /// Returns `None` if the scope is not function-like, or has no parameters.
-    fn first_param_type_in_scope(&self, scope: ScopeId) -> Option<Type<'db>> {
-        let first_param = match scope.node(self.db()) {
-            NodeWithScopeKind::Function(f) => f.node(self.module()).parameters.iter().next(),
-            NodeWithScopeKind::Lambda(l) => {
-                l.node(self.module()).parameters.as_ref()?.iter().next()
-            }
-            _ => None,
-        }?;
-
-        let definition = self.index.expect_single_definition(first_param);
-
-        Some(infer_definition_types(self.db(), definition).binding_type(definition))
-    }
-
-    fn infer_call_expression(
-        &mut self,
-        call_expression_node: &ast::Expr,
-        call_expression: &ast::ExprCall,
-    ) -> Type<'db> {
+    fn infer_call_expression(&mut self, call_expression: &ast::ExprCall) -> Type<'db> {
         let ast::ExprCall {
             range: _,
             node_index: _,
@@ -5430,293 +5404,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         let Some(known_class) = class.known(self.db()) else {
                             continue;
                         };
-
-                        match known_class {
-                            KnownClass::Super => {
-                                // Handle the case where `super()` is called with no arguments.
-                                // In this case, we need to infer the two arguments:
-                                //   1. The nearest enclosing class
-                                //   2. The first parameter of the current function (typically `self` or `cls`)
-                                match overload.parameter_types() {
-                                    [] => {
-                                        let scope = self.scope();
-
-                                        let Some(enclosing_class) = nearest_enclosing_class(
-                                            self.db(),
-                                            self.index,
-                                            scope,
-                                            self.module(),
-                                        ) else {
-                                            overload.set_return_type(Type::unknown());
-                                            BoundSuperError::UnavailableImplicitArguments
-                                                .report_diagnostic(
-                                                    &self.context,
-                                                    call_expression.into(),
-                                                );
-                                            continue;
-                                        };
-
-                                        let Some(first_param) =
-                                            self.first_param_type_in_scope(scope)
-                                        else {
-                                            overload.set_return_type(Type::unknown());
-                                            BoundSuperError::UnavailableImplicitArguments
-                                                .report_diagnostic(
-                                                    &self.context,
-                                                    call_expression.into(),
-                                                );
-                                            continue;
-                                        };
-
-                                        let bound_super = BoundSuperType::build(
-                                            self.db(),
-                                            Type::ClassLiteral(enclosing_class),
-                                            first_param,
-                                        )
-                                        .unwrap_or_else(|err| {
-                                            err.report_diagnostic(
-                                                &self.context,
-                                                call_expression.into(),
-                                            );
-                                            Type::unknown()
-                                        });
-
-                                        overload.set_return_type(bound_super);
-                                    }
-                                    [Some(pivot_class_type), Some(owner_type)] => {
-                                        let bound_super = BoundSuperType::build(
-                                            self.db(),
-                                            *pivot_class_type,
-                                            *owner_type,
-                                        )
-                                        .unwrap_or_else(|err| {
-                                            err.report_diagnostic(
-                                                &self.context,
-                                                call_expression.into(),
-                                            );
-                                            Type::unknown()
-                                        });
-
-                                        overload.set_return_type(bound_super);
-                                    }
-                                    _ => (),
-                                }
-                            }
-
-                            KnownClass::TypeVar => {
-                                let assigned_to = (self.index)
-                                    .try_expression(call_expression_node)
-                                    .and_then(|expr| expr.assigned_to(self.db()));
-
-                                let Some(target) =
-                                    assigned_to
-                                        .as_ref()
-                                        .and_then(|assigned_to| {
-                                            match assigned_to.node(self.module()).targets.as_slice()
-                                            {
-                                                [ast::Expr::Name(target)] => Some(target),
-                                                _ => None,
-                                            }
-                                        })
-                                else {
-                                    if let Some(builder) = self
-                                        .context
-                                        .report_lint(&INVALID_LEGACY_TYPE_VARIABLE, call_expression)
-                                    {
-                                        builder.into_diagnostic(format_args!(
-                                            "A legacy `typing.TypeVar` must be immediately assigned to a variable",
-                                        ));
-                                    }
-                                    continue;
-                                };
-
-                                let [
-                                    Some(name_param),
-                                    constraints,
-                                    bound,
-                                    default,
-                                    contravariant,
-                                    covariant,
-                                    _infer_variance,
-                                ] = overload.parameter_types()
-                                else {
-                                    continue;
-                                };
-
-                                let covariant = match covariant {
-                                    Some(ty) => ty.bool(self.db()),
-                                    None => Truthiness::AlwaysFalse,
-                                };
-
-                                let contravariant = match contravariant {
-                                    Some(ty) => ty.bool(self.db()),
-                                    None => Truthiness::AlwaysFalse,
-                                };
-
-                                let variance = match (contravariant, covariant) {
-                                    (Truthiness::Ambiguous, _) => {
-                                        let Some(builder) = self.context.report_lint(
-                                            &INVALID_LEGACY_TYPE_VARIABLE,
-                                            call_expression,
-                                        ) else {
-                                            continue;
-                                        };
-                                        builder.into_diagnostic(
-                                            "The `contravariant` parameter of a legacy `typing.TypeVar` \
-                                            cannot have an ambiguous value",
-                                        );
-                                        continue;
-                                    }
-                                    (_, Truthiness::Ambiguous) => {
-                                        let Some(builder) = self.context.report_lint(
-                                            &INVALID_LEGACY_TYPE_VARIABLE,
-                                            call_expression,
-                                        ) else {
-                                            continue;
-                                        };
-                                        builder.into_diagnostic(
-                                            "The `covariant` parameter of a legacy `typing.TypeVar` \
-                                            cannot have an ambiguous value",
-                                        );
-                                        continue;
-                                    }
-                                    (Truthiness::AlwaysTrue, Truthiness::AlwaysTrue) => {
-                                        let Some(builder) = self.context.report_lint(
-                                            &INVALID_LEGACY_TYPE_VARIABLE,
-                                            call_expression,
-                                        ) else {
-                                            continue;
-                                        };
-                                        builder.into_diagnostic(
-                                            "A legacy `typing.TypeVar` cannot be both \
-                                            covariant and contravariant",
-                                        );
-                                        continue;
-                                    }
-                                    (Truthiness::AlwaysTrue, Truthiness::AlwaysFalse) => {
-                                        TypeVarVariance::Contravariant
-                                    }
-                                    (Truthiness::AlwaysFalse, Truthiness::AlwaysTrue) => {
-                                        TypeVarVariance::Covariant
-                                    }
-                                    (Truthiness::AlwaysFalse, Truthiness::AlwaysFalse) => {
-                                        TypeVarVariance::Invariant
-                                    }
-                                };
-
-                                let name_param = name_param
-                                    .into_string_literal()
-                                    .map(|name| name.value(self.db()));
-                                if name_param.is_none_or(|name_param| name_param != target.id) {
-                                    let Some(builder) = self.context.report_lint(
-                                        &INVALID_LEGACY_TYPE_VARIABLE,
-                                        call_expression,
-                                    ) else {
-                                        continue;
-                                    };
-                                    builder.into_diagnostic(format_args!(
-                                        "The name of a legacy `typing.TypeVar`{} must match \
-                                            the name of the variable it is assigned to (`{}`)",
-                                        if let Some(name_param) = name_param {
-                                            format!(" (`{name_param}`)")
-                                        } else {
-                                            String::new()
-                                        },
-                                        target.id,
-                                    ));
-                                    continue;
-                                }
-
-                                let bound_or_constraint = match (bound, constraints) {
-                                    (Some(bound), None) => {
-                                        Some(TypeVarBoundOrConstraints::UpperBound(*bound))
-                                    }
-
-                                    (None, Some(_constraints)) => {
-                                        // We don't use UnionType::from_elements or UnionBuilder here,
-                                        // because we don't want to simplify the list of constraints like
-                                        // we do with the elements of an actual union type.
-                                        // TODO: Consider using a new `OneOfType` connective here instead,
-                                        // since that more accurately represents the actual semantics of
-                                        // typevar constraints.
-                                        let elements = UnionType::new(
-                                            self.db(),
-                                            overload
-                                                .arguments_for_parameter(&call_argument_types, 1)
-                                                .map(|(_, ty)| ty)
-                                                .collect::<Box<_>>(),
-                                        );
-                                        Some(TypeVarBoundOrConstraints::Constraints(elements))
-                                    }
-
-                                    // TODO: Emit a diagnostic that TypeVar cannot be both bounded and
-                                    // constrained
-                                    (Some(_), Some(_)) => continue,
-
-                                    (None, None) => None,
-                                };
-
-                                let containing_assignment =
-                                    self.index.expect_single_definition(target);
-                                overload.set_return_type(Type::KnownInstance(
-                                    KnownInstanceType::TypeVar(TypeVarInstance::new(
-                                        self.db(),
-                                        target.id.clone(),
-                                        Some(containing_assignment),
-                                        bound_or_constraint,
-                                        variance,
-                                        *default,
-                                        TypeVarKind::Legacy,
-                                    )),
-                                ));
-                            }
-
-                            KnownClass::TypeAliasType => {
-                                let assigned_to = (self.index)
-                                    .try_expression(call_expression_node)
-                                    .and_then(|expr| expr.assigned_to(self.db()));
-
-                                let containing_assignment =
-                                    assigned_to
-                                        .as_ref()
-                                        .and_then(|assigned_to| {
-                                            match assigned_to.node(self.module()).targets.as_slice()
-                                            {
-                                                [ast::Expr::Name(target)] => Some(
-                                                    self.index.expect_single_definition(target),
-                                                ),
-                                                _ => None,
-                                            }
-                                        });
-
-                                let [Some(name), Some(value), ..] = overload.parameter_types()
-                                else {
-                                    continue;
-                                };
-
-                                if let Some(name) = name.into_string_literal() {
-                                    overload.set_return_type(Type::KnownInstance(
-                                        KnownInstanceType::TypeAliasType(TypeAliasType::Bare(
-                                            BareTypeAliasType::new(
-                                                self.db(),
-                                                ast::name::Name::new(name.value(self.db())),
-                                                containing_assignment,
-                                                value,
-                                            ),
-                                        )),
-                                    ));
-                                } else if let Some(builder) = self
-                                    .context
-                                    .report_lint(&INVALID_TYPE_ALIAS_TYPE, call_expression)
-                                {
-                                    builder.into_diagnostic(
-                                        "The name of a `typing.TypeAlias` must be a string literal",
-                                    );
-                                }
-                            }
-
-                            _ => (),
-                        }
+                        known_class.check_call(
+                            &self.context,
+                            self.index,
+                            overload,
+                            &call_argument_types,
+                            call_expression,
+                        );
                     }
                     _ => (),
                 }
@@ -8947,7 +8641,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             }
 
             ast::Expr::Call(call_expr) => {
-                self.infer_call_expression(expression, call_expr);
+                self.infer_call_expression(call_expr);
                 self.report_invalid_type_expression(
                     expression,
                     format_args!("Function calls are not allowed in type expressions"),


### PR DESCRIPTION
## Summary

This function is huge, and hugely indented. This PR breaks most of it out into two helper functions: `KnownFunction::check_call()` and `KnownClass::check_call`.

My immediate motivation is that we need to add yet more special cases to this function in order to properly handle `tuple` instantiations and instantiations of tuple subclasses. But I really don't relish the thought of doing that with the function's current structure 😆

## Test Plan

Existing tests all pass. No new ones are added; this is a pure refactor that should have no functional change.
