### PR TITLE
Convert `OldDiagnostic::noqa_code` to an `Option<String>`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2812,6 +2812,7 @@ dependencies = [
  "fern",
  "glob",
  "globset",
+ "hashbrown 0.15.4",
  "imperative",
  "insta",
  "is-macro",

--- a/crates/ruff/src/diagnostics.rs
+++ b/crates/ruff/src/diagnostics.rs
@@ -167,7 +167,7 @@ impl AddAssign for FixMap {
             let fixed_in_file = self.0.entry(filename).or_default();
             for (rule, name, count) in fixed.iter() {
                 if count > 0 {
-                    *fixed_in_file.entry(rule).or_default(name) += count;
+                    *fixed_in_file.entry(rule.to_string()).or_default(name) += count;
                 }
             }
         }

--- a/crates/ruff/src/diagnostics.rs
+++ b/crates/ruff/src/diagnostics.rs
@@ -167,7 +167,7 @@ impl AddAssign for FixMap {
             let fixed_in_file = self.0.entry(filename).or_default();
             for (rule, name, count) in fixed.iter() {
                 if count > 0 {
-                    *fixed_in_file.entry(rule.to_string()).or_default(name) += count;
+                    *fixed_in_file.entry(rule).or_default(name) += count;
                 }
             }
         }

--- a/crates/ruff/src/printer.rs
+++ b/crates/ruff/src/printer.rs
@@ -362,7 +362,7 @@ impl Printer {
                         writer,
                         "{:>count_width$}\t{:<code_width$}\t{}{}",
                         statistic.count.to_string().bold(),
-                        statistic.code.as_ref().unwrap_or_default().red().bold(),
+                        statistic.code.unwrap_or_default().red().bold(),
                         if any_fixable {
                             if statistic.fixable {
                                 &fixable

--- a/crates/ruff/src/printer.rs
+++ b/crates/ruff/src/printer.rs
@@ -362,7 +362,7 @@ impl Printer {
                         writer,
                         "{:>count_width$}\t{:<code_width$}\t{}{}",
                         statistic.count.to_string().bold(),
-                        statistic.code.as_ref().unwrap_or(&"").red().bold(),
+                        statistic.code.as_ref().unwrap_or_default().red().bold(),
                         if any_fixable {
                             if statistic.fixable {
                                 &fixable

--- a/crates/ruff/src/printer.rs
+++ b/crates/ruff/src/printer.rs
@@ -363,7 +363,12 @@ impl Printer {
                         writer,
                         "{:>count_width$}\t{:<code_width$}\t{}{}",
                         statistic.count.to_string().bold(),
-                        statistic.code.map_or("", |s| s.as_str()).red().bold(),
+                        statistic
+                            .code
+                            .map(SecondaryCode::as_str)
+                            .unwrap_or_default()
+                            .red()
+                            .bold(),
                         if any_fixable {
                             if statistic.fixable {
                                 &fixable

--- a/crates/ruff_linter/Cargo.toml
+++ b/crates/ruff_linter/Cargo.toml
@@ -38,6 +38,7 @@ colored = { workspace = true }
 fern = { workspace = true }
 glob = { workspace = true }
 globset = { workspace = true }
+hashbrown = { workspace = true }
 imperative = { workspace = true }
 is-macro = { workspace = true }
 is-wsl = { workspace = true }

--- a/crates/ruff_linter/src/checkers/noqa.rs
+++ b/crates/ruff_linter/src/checkers/noqa.rs
@@ -51,7 +51,7 @@ pub(crate) fn check_noqa(
             continue;
         };
 
-        if Rule::BlanketNOQA.noqa_code() == code {
+        if code == Rule::BlanketNOQA.noqa_code() {
             continue;
         }
 

--- a/crates/ruff_linter/src/checkers/noqa.rs
+++ b/crates/ruff_linter/src/checkers/noqa.rs
@@ -147,9 +147,9 @@ pub(crate) fn check_noqa(
 
                         if seen_codes.insert(original_code) {
                             let is_code_used = if is_file_level {
-                                context
-                                    .iter()
-                                    .any(|diag| diag.noqa_code().is_some_and(|noqa| noqa == code))
+                                context.iter().any(|diag| {
+                                    diag.secondary_code().is_some_and(|noqa| noqa == code)
+                                })
                             } else {
                                 matches.iter().any(|match_| *match_ == code)
                             } || settings

--- a/crates/ruff_linter/src/checkers/noqa.rs
+++ b/crates/ruff_linter/src/checkers/noqa.rs
@@ -47,27 +47,17 @@ pub(crate) fn check_noqa(
     // Remove any ignored diagnostics.
     'outer: for (index, diagnostic) in context.iter().enumerate() {
         // Can't ignore syntax errors.
-        let Some(code) = diagnostic.noqa_code() else {
+        let Some(code) = diagnostic.secondary_code() else {
             continue;
         };
 
-        if code == Rule::BlanketNOQA.noqa_code() {
+        if Rule::BlanketNOQA.noqa_code() == code {
             continue;
         }
 
-        match &exemption {
-            FileExemption::All(_) => {
-                // If the file is exempted, ignore all diagnostics.
-                ignored_diagnostics.push(index);
-                continue;
-            }
-            FileExemption::Codes(codes) => {
-                // If the diagnostic is ignored by a global exemption, ignore it.
-                if codes.contains(&&code) {
-                    ignored_diagnostics.push(index);
-                    continue;
-                }
-            }
+        if exemption.contains(&code) {
+            ignored_diagnostics.push(index);
+            continue;
         }
 
         let noqa_offsets = diagnostic
@@ -82,13 +72,13 @@ pub(crate) fn check_noqa(
             {
                 let suppressed = match &directive_line.directive {
                     Directive::All(_) => {
-                        directive_line.matches.push(code);
+                        directive_line.matches.push(code.to_string());
                         ignored_diagnostics.push(index);
                         true
                     }
                     Directive::Codes(directive) => {
-                        if directive.includes(code) {
-                            directive_line.matches.push(code);
+                        if directive.includes(&code) {
+                            directive_line.matches.push(code.to_string());
                             ignored_diagnostics.push(index);
                             true
                         } else {

--- a/crates/ruff_linter/src/checkers/noqa.rs
+++ b/crates/ruff_linter/src/checkers/noqa.rs
@@ -51,11 +51,11 @@ pub(crate) fn check_noqa(
             continue;
         };
 
-        if code == Rule::BlanketNOQA.noqa_code() {
+        if *code == Rule::BlanketNOQA.noqa_code() {
             continue;
         }
 
-        if exemption.contains(&code) {
+        if exemption.contains(code) {
             ignored_diagnostics.push(index);
             continue;
         }
@@ -72,13 +72,13 @@ pub(crate) fn check_noqa(
             {
                 let suppressed = match &directive_line.directive {
                     Directive::All(_) => {
-                        directive_line.matches.push(code.to_string());
+                        directive_line.matches.push(code.clone());
                         ignored_diagnostics.push(index);
                         true
                     }
                     Directive::Codes(directive) => {
-                        if directive.includes(&code) {
-                            directive_line.matches.push(code.to_string());
+                        if directive.includes(code) {
+                            directive_line.matches.push(code.clone());
                             ignored_diagnostics.push(index);
                             true
                         } else {
@@ -138,7 +138,7 @@ pub(crate) fn check_noqa(
                         if seen_codes.insert(original_code) {
                             let is_code_used = if is_file_level {
                                 context.iter().any(|diag| {
-                                    diag.secondary_code().is_some_and(|noqa| noqa == code)
+                                    diag.secondary_code().is_some_and(|noqa| *noqa == code)
                                 })
                             } else {
                                 matches.iter().any(|match_| *match_ == code)

--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -46,6 +46,12 @@ impl PartialEq<&str> for NoqaCode {
     }
 }
 
+impl PartialEq<NoqaCode> for &str {
+    fn eq(&self, other: &NoqaCode) -> bool {
+        other.eq(self)
+    }
+}
+
 impl serde::Serialize for NoqaCode {
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
     where

--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -6,27 +6,12 @@ use std::fmt::Formatter;
 
 use strum_macros::EnumIter;
 
-use crate::registry::{FromCodeError, Linter, RuleNamespace};
+use crate::registry::Linter;
 use crate::rule_selector::is_single_rule_selector;
 use crate::rules;
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct NoqaCode(&'static str, &'static str);
-
-impl std::str::FromStr for NoqaCode {
-    type Err = FromCodeError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let (linter, code) = Linter::parse_code(s).ok_or(FromCodeError::Unknown)?;
-        linter
-            .all_rules()
-            .find_map(|rule| {
-                let noqa_code = rule.noqa_code();
-                (noqa_code.suffix() == code).then_some(noqa_code)
-            })
-            .ok_or(FromCodeError::Unknown)
-    }
-}
 
 impl NoqaCode {
     /// Return the prefix for the [`NoqaCode`], e.g., `SIM` for `SIM101`.

--- a/crates/ruff_linter/src/fix/mod.rs
+++ b/crates/ruff_linter/src/fix/mod.rs
@@ -110,7 +110,7 @@ fn apply_fixes<'a>(
         }
 
         applied.extend(applied_edits.drain(..));
-        *fixed.entry(code.to_string()).or_default(name) += 1;
+        *fixed.entry(code).or_default(name) += 1;
     }
 
     // Add the remaining content.

--- a/crates/ruff_linter/src/fix/mod.rs
+++ b/crates/ruff_linter/src/fix/mod.rs
@@ -63,7 +63,7 @@ fn apply_fixes<'a>(
     let mut source_map = SourceMap::default();
 
     for (code, name, fix) in diagnostics
-        .filter_map(|msg| msg.noqa_code().map(|code| (code, msg.name(), msg)))
+        .filter_map(|msg| msg.secondary_code().map(|code| (code, msg.name(), msg)))
         .filter_map(|(code, name, diagnostic)| diagnostic.fix().map(|fix| (code, name, fix)))
         .sorted_by(|(_, name1, fix1), (_, name2, fix2)| cmp_fix(name1, name2, fix1, fix2))
     {
@@ -110,7 +110,7 @@ fn apply_fixes<'a>(
         }
 
         applied.extend(applied_edits.drain(..));
-        *fixed.entry(code).or_default(name) += 1;
+        *fixed.entry(code.to_string()).or_default(name) += 1;
     }
 
     // Add the remaining content.

--- a/crates/ruff_linter/src/linter.rs
+++ b/crates/ruff_linter/src/linter.rs
@@ -678,7 +678,7 @@ pub fn lint_fix<'a>(
     }
 }
 
-fn collect_rule_codes(rules: impl IntoIterator<Item = NoqaCode>) -> String {
+fn collect_rule_codes<T: std::fmt::Display>(rules: impl IntoIterator<Item = T>) -> String {
     rules
         .into_iter()
         .map(|rule| rule.to_string())
@@ -689,7 +689,7 @@ fn collect_rule_codes(rules: impl IntoIterator<Item = NoqaCode>) -> String {
 
 #[expect(clippy::print_stderr)]
 fn report_failed_to_converge_error(path: &Path, transformed: &str, diagnostics: &[OldDiagnostic]) {
-    let codes = collect_rule_codes(diagnostics.iter().filter_map(OldDiagnostic::noqa_code));
+    let codes = collect_rule_codes(diagnostics.iter().filter_map(OldDiagnostic::secondary_code));
     if cfg!(debug_assertions) {
         eprintln!(
             "{}{} Failed to converge after {} iterations in `{}` with rule codes {}:---\n{}\n---",

--- a/crates/ruff_linter/src/message/azure.rs
+++ b/crates/ruff_linter/src/message/azure.rs
@@ -33,7 +33,7 @@ impl Emitter for AzureEmitter {
                 line = location.line,
                 col = location.column,
                 code = diagnostic
-                    .noqa_code()
+                    .secondary_code()
                     .map_or_else(String::new, |code| format!("code={code};")),
                 body = diagnostic.body(),
             )?;

--- a/crates/ruff_linter/src/message/github.rs
+++ b/crates/ruff_linter/src/message/github.rs
@@ -33,7 +33,7 @@ impl Emitter for GithubEmitter {
                 writer,
                 "::error title=Ruff{code},file={file},line={row},col={column},endLine={end_row},endColumn={end_column}::",
                 code = diagnostic
-                    .noqa_code()
+                    .secondary_code()
                     .map_or_else(String::new, |code| format!(" ({code})")),
                 file = diagnostic.filename(),
                 row = source_location.line,
@@ -50,7 +50,7 @@ impl Emitter for GithubEmitter {
                 column = location.column,
             )?;
 
-            if let Some(code) = diagnostic.noqa_code() {
+            if let Some(code) = diagnostic.secondary_code() {
                 write!(writer, " {code}")?;
             }
 

--- a/crates/ruff_linter/src/message/gitlab.rs
+++ b/crates/ruff_linter/src/message/gitlab.rs
@@ -90,18 +90,15 @@ impl Serialize for SerializedMessages<'_> {
             }
             fingerprints.insert(message_fingerprint);
 
-            let (description, check_name) = if let Some(code) = diagnostic.noqa_code() {
-                (diagnostic.body().to_string(), code.to_string())
+            let (description, check_name) = if let Some(code) = diagnostic.secondary_code() {
+                (diagnostic.body().to_string(), code)
             } else {
                 let description = diagnostic.body();
                 let description_without_prefix = description
                     .strip_prefix("SyntaxError: ")
                     .unwrap_or(description);
 
-                (
-                    description_without_prefix.to_string(),
-                    "syntax-error".to_string(),
-                )
+                (description_without_prefix.to_string(), "syntax-error")
             };
 
             let value = json!({

--- a/crates/ruff_linter/src/message/gitlab.rs
+++ b/crates/ruff_linter/src/message/gitlab.rs
@@ -91,7 +91,7 @@ impl Serialize for SerializedMessages<'_> {
             fingerprints.insert(message_fingerprint);
 
             let (description, check_name) = if let Some(code) = diagnostic.secondary_code() {
-                (diagnostic.body().to_string(), code)
+                (diagnostic.body().to_string(), code.as_str())
             } else {
                 let description = diagnostic.body();
                 let description_without_prefix = description

--- a/crates/ruff_linter/src/message/json.rs
+++ b/crates/ruff_linter/src/message/json.rs
@@ -87,7 +87,7 @@ pub(crate) fn message_to_json_value(message: &OldDiagnostic, context: &EmitterCo
     }
 
     json!({
-        "code": message.noqa_code().map(|code| code.to_string()),
+        "code": message.secondary_code(),
         "url": message.to_url(),
         "message": message.body(),
         "fix": fix,

--- a/crates/ruff_linter/src/message/junit.rs
+++ b/crates/ruff_linter/src/message/junit.rs
@@ -59,7 +59,7 @@ impl Emitter for JunitEmitter {
                         body = message.body()
                     ));
                     let mut case = TestCase::new(
-                        if let Some(code) = message.noqa_code() {
+                        if let Some(code) = message.secondary_code() {
                             format!("org.ruff.{code}")
                         } else {
                             "org.ruff".to_string()

--- a/crates/ruff_linter/src/message/mod.rs
+++ b/crates/ruff_linter/src/message/mod.rs
@@ -252,6 +252,11 @@ impl OldDiagnostic {
         self.noqa_code.as_ref().and_then(|code| code.parse().ok())
     }
 
+    /// Returns the noqa code for the diagnostic message as a string.
+    pub fn secondary_code(&self) -> Option<&str> {
+        self.noqa_code.as_deref()
+    }
+
     /// Returns the URL for the rule documentation, if it exists.
     pub fn to_url(&self) -> Option<String> {
         if self.is_syntax_error() {

--- a/crates/ruff_linter/src/message/mod.rs
+++ b/crates/ruff_linter/src/message/mod.rs
@@ -62,7 +62,7 @@ pub struct OldDiagnostic {
     pub fix: Option<Fix>,
     pub parent: Option<TextSize>,
     pub(crate) noqa_offset: Option<TextSize>,
-    pub(crate) noqa_code: Option<NoqaCode>,
+    pub(crate) noqa_code: Option<String>,
 }
 
 impl OldDiagnostic {
@@ -115,7 +115,7 @@ impl OldDiagnostic {
             fix,
             parent,
             noqa_offset,
-            noqa_code: Some(rule.noqa_code()),
+            noqa_code: Some(rule.noqa_code().to_string()),
         }
     }
 
@@ -249,7 +249,7 @@ impl OldDiagnostic {
 
     /// Returns the [`NoqaCode`] corresponding to the diagnostic message.
     pub fn noqa_code(&self) -> Option<NoqaCode> {
-        self.noqa_code
+        self.noqa_code.as_ref().and_then(|code| code.parse().ok())
     }
 
     /// Returns the URL for the rule documentation, if it exists.

--- a/crates/ruff_linter/src/message/mod.rs
+++ b/crates/ruff_linter/src/message/mod.rs
@@ -387,7 +387,8 @@ impl<'a> EmitterContext<'a> {
 /// A secondary identifier for a lint diagnostic.
 ///
 /// For Ruff rules this means the noqa code.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Default, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Default, Hash, serde::Serialize)]
+#[serde(transparent)]
 pub struct SecondaryCode(String);
 
 impl SecondaryCode {
@@ -435,15 +436,6 @@ impl PartialEq<NoqaCode> for SecondaryCode {
 impl PartialEq<SecondaryCode> for NoqaCode {
     fn eq(&self, other: &SecondaryCode) -> bool {
         other.eq(self)
-    }
-}
-
-impl serde::Serialize for SecondaryCode {
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.serialize_str(&self.0)
     }
 }
 

--- a/crates/ruff_linter/src/message/mod.rs
+++ b/crates/ruff_linter/src/message/mod.rs
@@ -61,7 +61,7 @@ pub struct OldDiagnostic {
     pub fix: Option<Fix>,
     pub parent: Option<TextSize>,
     pub(crate) noqa_offset: Option<TextSize>,
-    pub(crate) noqa_code: Option<String>,
+    pub(crate) secondary_code: Option<String>,
 }
 
 impl OldDiagnostic {
@@ -78,7 +78,7 @@ impl OldDiagnostic {
             fix: None,
             parent: None,
             noqa_offset: None,
-            noqa_code: None,
+            secondary_code: None,
         }
     }
 
@@ -114,7 +114,7 @@ impl OldDiagnostic {
             fix,
             parent,
             noqa_offset,
-            noqa_code: Some(rule.noqa_code().to_string()),
+            secondary_code: Some(rule.noqa_code().to_string()),
         }
     }
 
@@ -248,7 +248,7 @@ impl OldDiagnostic {
 
     /// Returns the noqa code for the diagnostic message as a string.
     pub fn secondary_code(&self) -> Option<&str> {
-        self.noqa_code.as_deref()
+        self.secondary_code.as_deref()
     }
 
     /// Returns the URL for the rule documentation, if it exists.

--- a/crates/ruff_linter/src/message/mod.rs
+++ b/crates/ruff_linter/src/message/mod.rs
@@ -25,7 +25,6 @@ pub use sarif::SarifEmitter;
 pub use text::TextEmitter;
 
 use crate::Fix;
-use crate::codes::NoqaCode;
 use crate::logging::DisplayParseErrorType;
 use crate::registry::Rule;
 use crate::{Locator, Violation};
@@ -245,11 +244,6 @@ impl OldDiagnostic {
     /// Returns `true` if the diagnostic contains a [`Fix`].
     pub fn fixable(&self) -> bool {
         self.fix().is_some()
-    }
-
-    /// Returns the [`NoqaCode`] corresponding to the diagnostic message.
-    pub fn noqa_code(&self) -> Option<NoqaCode> {
-        self.noqa_code.as_ref().and_then(|code| code.parse().ok())
     }
 
     /// Returns the noqa code for the diagnostic message as a string.

--- a/crates/ruff_linter/src/message/pylint.rs
+++ b/crates/ruff_linter/src/message/pylint.rs
@@ -26,7 +26,7 @@ impl Emitter for PylintEmitter {
                 diagnostic.compute_start_location().line
             };
 
-            let body = if let Some(code) = diagnostic.noqa_code() {
+            let body = if let Some(code) = diagnostic.secondary_code() {
                 format!("[{code}] {body}", body = diagnostic.body())
             } else {
                 diagnostic.body().to_string()

--- a/crates/ruff_linter/src/message/rdjson.rs
+++ b/crates/ruff_linter/src/message/rdjson.rs
@@ -71,7 +71,7 @@ fn message_to_rdjson_value(message: &OldDiagnostic) -> Value {
                 "range": rdjson_range(start_location, end_location),
             },
             "code": {
-                "value": message.noqa_code().map(|code| code.to_string()),
+                "value": message.secondary_code(),
                 "url": message.to_url(),
             },
             "suggestions": rdjson_suggestions(fix.edits(), &source_code),
@@ -84,7 +84,7 @@ fn message_to_rdjson_value(message: &OldDiagnostic) -> Value {
                 "range": rdjson_range(start_location, end_location),
             },
             "code": {
-                "value": message.noqa_code().map(|code| code.to_string()),
+                "value": message.secondary_code(),
                 "url": message.to_url(),
             },
         })

--- a/crates/ruff_linter/src/message/sarif.rs
+++ b/crates/ruff_linter/src/message/sarif.rs
@@ -9,7 +9,7 @@ use ruff_source_file::OneIndexed;
 
 use crate::VERSION;
 use crate::fs::normalize_path;
-use crate::message::{Emitter, EmitterContext, OldDiagnostic};
+use crate::message::{Emitter, EmitterContext, OldDiagnostic, SecondaryCode};
 use crate::registry::{Linter, RuleNamespace};
 
 pub struct SarifEmitter;
@@ -53,15 +53,15 @@ impl Emitter for SarifEmitter {
 #[derive(Debug, Clone)]
 struct SarifRule<'a> {
     name: &'a str,
-    code: &'a str,
+    code: &'a SecondaryCode,
     linter: &'a str,
     summary: &'a str,
     explanation: Option<&'a str>,
     url: Option<String>,
 }
 
-impl<'a> From<&'a str> for SarifRule<'a> {
-    fn from(code: &'a str) -> Self {
+impl<'a> From<&'a SecondaryCode> for SarifRule<'a> {
+    fn from(code: &'a SecondaryCode) -> Self {
         // This is a manual re-implementation of Rule::from_code, but we also want the Linter. This
         // avoids calling Linter::parse_code twice.
         let (linter, suffix) = Linter::parse_code(code).unwrap();
@@ -110,7 +110,7 @@ impl Serialize for SarifRule<'_> {
 
 #[derive(Debug)]
 struct SarifResult<'a> {
-    code: Option<&'a str>,
+    code: Option<&'a SecondaryCode>,
     level: String,
     message: String,
     uri: String,

--- a/crates/ruff_linter/src/message/sarif.rs
+++ b/crates/ruff_linter/src/message/sarif.rs
@@ -8,7 +8,6 @@ use serde_json::json;
 use ruff_source_file::OneIndexed;
 
 use crate::VERSION;
-use crate::codes::NoqaCode;
 use crate::fs::normalize_path;
 use crate::message::{Emitter, EmitterContext, OldDiagnostic};
 use crate::registry::{Linter, RuleNamespace};
@@ -29,7 +28,7 @@ impl Emitter for SarifEmitter {
 
         let unique_rules: HashSet<_> = results.iter().filter_map(|result| result.code).collect();
         let mut rules: Vec<SarifRule> = unique_rules.into_iter().map(SarifRule::from).collect();
-        rules.sort_by(|a, b| a.code.cmp(&b.code));
+        rules.sort_by(|a, b| a.code.cmp(b.code));
 
         let output = json!({
             "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
@@ -54,26 +53,25 @@ impl Emitter for SarifEmitter {
 #[derive(Debug, Clone)]
 struct SarifRule<'a> {
     name: &'a str,
-    code: String,
+    code: &'a str,
     linter: &'a str,
     summary: &'a str,
     explanation: Option<&'a str>,
     url: Option<String>,
 }
 
-impl From<NoqaCode> for SarifRule<'_> {
-    fn from(code: NoqaCode) -> Self {
-        let code_str = code.to_string();
+impl<'a> From<&'a str> for SarifRule<'a> {
+    fn from(code: &'a str) -> Self {
         // This is a manual re-implementation of Rule::from_code, but we also want the Linter. This
         // avoids calling Linter::parse_code twice.
-        let (linter, suffix) = Linter::parse_code(&code_str).unwrap();
+        let (linter, suffix) = Linter::parse_code(code).unwrap();
         let rule = linter
             .all_rules()
             .find(|rule| rule.noqa_code().suffix() == suffix)
             .expect("Expected a valid noqa code corresponding to a rule");
         Self {
             name: rule.into(),
-            code: code_str,
+            code,
             linter: linter.name(),
             summary: rule.message_formats()[0],
             explanation: rule.explanation(),
@@ -111,8 +109,8 @@ impl Serialize for SarifRule<'_> {
 }
 
 #[derive(Debug)]
-struct SarifResult {
-    code: Option<NoqaCode>,
+struct SarifResult<'a> {
+    code: Option<&'a str>,
     level: String,
     message: String,
     uri: String,
@@ -122,14 +120,14 @@ struct SarifResult {
     end_column: OneIndexed,
 }
 
-impl SarifResult {
+impl<'a> SarifResult<'a> {
     #[cfg(not(target_arch = "wasm32"))]
-    fn from_message(message: &OldDiagnostic) -> Result<Self> {
+    fn from_message(message: &'a OldDiagnostic) -> Result<Self> {
         let start_location = message.compute_start_location();
         let end_location = message.compute_end_location();
         let path = normalize_path(&*message.filename());
         Ok(Self {
-            code: message.noqa_code(),
+            code: message.secondary_code(),
             level: "error".to_string(),
             message: message.body().to_string(),
             uri: url::Url::from_file_path(&path)
@@ -144,12 +142,12 @@ impl SarifResult {
 
     #[cfg(target_arch = "wasm32")]
     #[expect(clippy::unnecessary_wraps)]
-    fn from_message(message: &OldDiagnostic) -> Result<Self> {
+    fn from_message(message: &'a OldDiagnostic) -> Result<Self> {
         let start_location = message.compute_start_location();
         let end_location = message.compute_end_location();
         let path = normalize_path(&*message.filename());
         Ok(Self {
-            code: message.noqa_code(),
+            code: message.secondary_code(),
             level: "error".to_string(),
             message: message.body().to_string(),
             uri: path.display().to_string(),
@@ -161,7 +159,7 @@ impl SarifResult {
     }
 }
 
-impl Serialize for SarifResult {
+impl Serialize for SarifResult<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -184,7 +182,7 @@ impl Serialize for SarifResult {
                     }
                 }
             }],
-            "ruleId": self.code.map(|code| code.to_string()),
+            "ruleId": self.code,
         })
         .serialize(serializer)
     }

--- a/crates/ruff_linter/src/message/text.rs
+++ b/crates/ruff_linter/src/message/text.rs
@@ -252,7 +252,7 @@ impl Display for MessageCodeFrame<'_> {
         )
         .fix_up_empty_spans_after_line_terminator();
 
-        let label = self.message.secondary_code().unwrap_or("");
+        let label = self.message.secondary_code().unwrap_or_default();
 
         let line_start = self.notebook_index.map_or_else(
             || start_index.get(),

--- a/crates/ruff_linter/src/message/text.rs
+++ b/crates/ruff_linter/src/message/text.rs
@@ -151,8 +151,8 @@ impl Display for RuleCodeAndBody<'_> {
             if let Some(fix) = self.message.fix() {
                 // Do not display an indicator for inapplicable fixes
                 if fix.applies(self.unsafe_fixes.required_applicability()) {
-                    if let Some(code) = self.message.noqa_code() {
-                        write!(f, "{} ", code.to_string().red().bold())?;
+                    if let Some(code) = self.message.secondary_code() {
+                        write!(f, "{} ", code.red().bold())?;
                     }
                     return write!(
                         f,
@@ -164,11 +164,11 @@ impl Display for RuleCodeAndBody<'_> {
             }
         }
 
-        if let Some(code) = self.message.noqa_code() {
+        if let Some(code) = self.message.secondary_code() {
             write!(
                 f,
                 "{code} {body}",
-                code = code.to_string().red().bold(),
+                code = code.red().bold(),
                 body = self.message.body(),
             )
         } else {
@@ -252,10 +252,7 @@ impl Display for MessageCodeFrame<'_> {
         )
         .fix_up_empty_spans_after_line_terminator();
 
-        let label = self
-            .message
-            .noqa_code()
-            .map_or_else(String::new, |code| code.to_string());
+        let label = self.message.secondary_code().unwrap_or("");
 
         let line_start = self.notebook_index.map_or_else(
             || start_index.get(),
@@ -269,7 +266,7 @@ impl Display for MessageCodeFrame<'_> {
 
         let span = usize::from(source.annotation_range.start())
             ..usize::from(source.annotation_range.end());
-        let annotation = Level::Error.span(span).label(&label);
+        let annotation = Level::Error.span(span).label(label);
         let snippet = Snippet::source(&source.text)
             .line_start(line_start)
             .annotation(annotation)

--- a/crates/ruff_linter/src/message/text.rs
+++ b/crates/ruff_linter/src/message/text.rs
@@ -14,7 +14,7 @@ use crate::Locator;
 use crate::fs::relativize_path;
 use crate::line_width::{IndentWidth, LineWidthBuilder};
 use crate::message::diff::Diff;
-use crate::message::{Emitter, EmitterContext, OldDiagnostic};
+use crate::message::{Emitter, EmitterContext, OldDiagnostic, SecondaryCode};
 use crate::settings::types::UnsafeFixes;
 
 bitflags! {
@@ -252,7 +252,11 @@ impl Display for MessageCodeFrame<'_> {
         )
         .fix_up_empty_spans_after_line_terminator();
 
-        let label = self.message.secondary_code().unwrap_or_default();
+        let label = self
+            .message
+            .secondary_code()
+            .map(SecondaryCode::as_str)
+            .unwrap_or_default();
 
         let line_start = self.notebook_index.map_or_else(
             || start_index.get(),

--- a/crates/ruff_linter/src/noqa.rs
+++ b/crates/ruff_linter/src/noqa.rs
@@ -146,45 +146,48 @@ pub(crate) fn rule_is_ignored(
 
 /// A summary of the file-level exemption as extracted from [`FileNoqaDirectives`].
 #[derive(Debug)]
-pub(crate) enum FileExemption<'a> {
+pub(crate) enum FileExemption {
     /// The file is exempt from all rules.
-    All(Vec<&'a SecondaryCode>),
+    All(Vec<Rule>),
     /// The file is exempt from the given rules.
-    Codes(Vec<&'a SecondaryCode>),
+    Codes(Vec<Rule>),
 }
 
-impl FileExemption<'_> {
+impl FileExemption {
     /// Returns `true` if the file is exempt from the given rule, as identified by its noqa code.
-    pub(crate) fn contains<T: for<'a> PartialEq<&'a str>>(&self, needle: &T) -> bool {
+    pub(crate) fn contains_secondary_code(&self, needle: &SecondaryCode) -> bool {
         match self {
             FileExemption::All(_) => true,
-            FileExemption::Codes(codes) => codes.iter().any(|code| *needle == code),
+            FileExemption::Codes(codes) => codes.iter().any(|code| *needle == code.noqa_code()),
         }
     }
 
     /// Returns `true` if the file is exempt from the given rule.
     pub(crate) fn includes(&self, needle: Rule) -> bool {
-        self.contains(&needle.noqa_code())
+        match self {
+            FileExemption::All(_) => true,
+            FileExemption::Codes(codes) => codes.contains(&needle),
+        }
     }
 
     /// Returns `true` if the file exemption lists the rule directly, rather than via a blanket
     /// exemption.
     pub(crate) fn enumerates(&self, needle: Rule) -> bool {
-        let needle = needle.noqa_code();
         let codes = match self {
             FileExemption::All(codes) => codes,
             FileExemption::Codes(codes) => codes,
         };
-        codes.iter().any(|code| needle == **code)
+        codes.contains(&needle)
     }
 }
 
-impl<'a> From<&'a FileNoqaDirectives<'a>> for FileExemption<'a> {
+impl<'a> From<&'a FileNoqaDirectives<'a>> for FileExemption {
     fn from(directives: &'a FileNoqaDirectives) -> Self {
         let codes = directives
             .lines()
             .iter()
             .flat_map(|line| &line.matches)
+            .copied()
             .collect();
         if directives
             .lines()
@@ -206,7 +209,7 @@ pub(crate) struct FileNoqaDirectiveLine<'a> {
     /// The blanket noqa directive.
     pub(crate) parsed_file_exemption: Directive<'a>,
     /// The codes that are ignored by the parsed exemptions.
-    pub(crate) matches: Vec<SecondaryCode>,
+    pub(crate) matches: Vec<Rule>,
 }
 
 impl Ranged for FileNoqaDirectiveLine<'_> {
@@ -271,9 +274,9 @@ impl<'a> FileNoqaDirectives<'a> {
                                     return None;
                                 }
 
-                                if  Rule::from_code(get_redirect_target(code).unwrap_or(code)).is_ok()
+                                if let Ok(rule) = Rule::from_code(get_redirect_target(code).unwrap_or(code))
                                 {
-                                    Some(SecondaryCode::new(code.to_string()))
+                                    Some(rule)
                                 } else {
                                     #[expect(deprecated)]
                                     let line = locator.compute_line_index(range.start());
@@ -305,6 +308,10 @@ impl<'a> FileNoqaDirectives<'a> {
 
     pub(crate) fn lines(&self) -> &[FileNoqaDirectiveLine] {
         &self.0
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.0.is_empty()
     }
 }
 
@@ -854,7 +861,7 @@ fn find_noqa_comments<'a>(
             continue;
         };
 
-        if exemption.contains(code) {
+        if exemption.contains_secondary_code(code) {
             comments_by_line.push(None);
             continue;
         }
@@ -1010,7 +1017,7 @@ pub(crate) struct NoqaDirectiveLine<'a> {
     /// The noqa directive.
     pub(crate) directive: Directive<'a>,
     /// The codes that are ignored by the directive.
-    pub(crate) matches: Vec<SecondaryCode>,
+    pub(crate) matches: Vec<Rule>,
     /// Whether the directive applies to `range.end`.
     pub(crate) includes_end: bool,
 }
@@ -1134,6 +1141,10 @@ impl<'a> NoqaDirectives<'a> {
 
     pub(crate) fn lines(&self) -> &[NoqaDirectiveLine] {
         &self.inner
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.inner.is_empty()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pyflakes/mod.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/mod.rs
@@ -774,9 +774,10 @@ mod tests {
         messages.sort_by_key(Ranged::start);
         let actual = messages
             .iter()
-            .filter_map(OldDiagnostic::noqa_code)
+            .filter(|msg| !msg.is_syntax_error())
+            .map(OldDiagnostic::name)
             .collect::<Vec<_>>();
-        let expected: Vec<_> = expected.iter().map(Rule::noqa_code).collect();
+        let expected: Vec<_> = expected.iter().map(|rule| rule.name().as_str()).collect();
         assert_eq!(actual, expected);
     }
 

--- a/crates/ruff_linter/src/test.rs
+++ b/crates/ruff_linter/src/test.rs
@@ -237,9 +237,9 @@ Source with applied fixes:
 
     let messages = messages
         .into_iter()
-        .filter_map(|msg| Some((msg.noqa_code()?, msg)))
+        .filter_map(|msg| Some((msg.secondary_code()?.to_string(), msg)))
         .map(|(code, mut diagnostic)| {
-            let rule = Rule::from_code(&code.to_string()).unwrap();
+            let rule = Rule::from_code(&code).unwrap();
             let fixable = diagnostic.fix().is_some_and(|fix| {
                 matches!(
                     fix.applicability(),

--- a/crates/ruff_server/src/lint.rs
+++ b/crates/ruff_server/src/lint.rs
@@ -239,7 +239,7 @@ fn to_lsp_diagnostic(
     let body = diagnostic.body().to_string();
     let fix = diagnostic.fix();
     let suggestion = diagnostic.suggestion();
-    let code = diagnostic.noqa_code();
+    let code = diagnostic.secondary_code();
 
     let fix = fix.and_then(|fix| fix.applies(Applicability::Unsafe).then_some(fix));
 

--- a/crates/ruff_wasm/src/lib.rs
+++ b/crates/ruff_wasm/src/lib.rs
@@ -208,7 +208,7 @@ impl Workspace {
         let messages: Vec<ExpandedMessage> = diagnostics
             .into_iter()
             .map(|msg| ExpandedMessage {
-                code: msg.noqa_code().map(|code| code.to_string()),
+                code: msg.secondary_code().map(ToString::to_string),
                 message: msg.body().to_string(),
                 start_location: source_code.line_column(msg.start()).into(),
                 end_location: source_code.line_column(msg.end()).into(),


### PR DESCRIPTION
## Summary

I think this should be the last step before combining `OldDiagnostic` and `ruff_db::Diagnostic`. We can't store a `NoqaCode` on `ruff_db::Diagnostic`, so I converted the `noqa_code` field to an `Option<String>` and then propagated this change to all of the callers. 

I tried to use `&str` everywhere it was possible, so I think the remaining `to_string` calls are necessary. I spent some time trying to convert _everything_ to `&str` but ran into lifetime issues, especially in the `FixTable`. Maybe we can take another look at that if it causes a performance regression, but hopefully these paths aren't too hot. We also avoid some `to_string` calls, so it might even out a bit too.

## Test Plan

Existing tests
