### PR TITLE
[ty] Format conflicting types as an enumeration

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/declaration/error.md
+++ b/crates/ty_python_semantic/resources/mdtest/declaration/error.md
@@ -16,7 +16,7 @@ def _(flag: bool):
     else:
         x: int
 
-    x = 1  # error: [conflicting-declarations] "Conflicting declared types for `x`: str, int"
+    x = 1  # error: [conflicting-declarations] "Conflicting declared types for `x`: `str` and `int`"
 ```
 
 ## Incompatible declarations for 2 (out of 3) types
@@ -29,7 +29,7 @@ def _(flag1: bool, flag2: bool):
         x: int
 
     # Here, the declared type for `x` is `int | str | Unknown`.
-    x = 1  # error: [conflicting-declarations] "Conflicting declared types for `x`: str, int"
+    x = 1  # error: [conflicting-declarations] "Conflicting declared types for `x`: `str` and `int`"
 ```
 
 ## Incompatible declarations with repeated types
@@ -47,7 +47,7 @@ def _(flag1: bool, flag2: bool, flag3: bool, flag4: bool):
     else:
         x: bytes
 
-    x = "a"  # error: [conflicting-declarations] "Conflicting declared types for `x`: str, int, bytes"
+    x = "a"  # error: [conflicting-declarations] "Conflicting declared types for `x`: `str`, `int` and `bytes`"
 ```
 
 ## Incompatible declarations with bad assignment

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -1643,7 +1643,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 if let Some(builder) = self.context.report_lint(&CONFLICTING_DECLARATIONS, node) {
                     builder.into_diagnostic(format_args!(
                         "Conflicting declared types for `{place}`: {}",
-                        conflicting.iter().map(|ty| ty.display(db)).join(", ")
+                        diagnostic::format_enumeration(conflicting.iter().map(|ty| ty.display(db)))
                     ));
                 }
                 ty.inner_type()


### PR DESCRIPTION
## Summary

Format conflicting declared types as
```
`str`, `int` and `bytes`
```

Thanks to @AlexWaygood for the initial draft.

## Test Plan

<!-- How was it tested? -->
