### PR TITLE
[ty] Add regression-benchmark for attribute-assignment hang

### DIFF
--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -348,6 +348,58 @@ fn benchmark_many_tuple_assignments(criterion: &mut Criterion) {
     });
 }
 
+fn benchmark_many_attribute_assignments(criterion: &mut Criterion) {
+    setup_rayon();
+
+    criterion.bench_function("ty_micro[many_attribute_assignments]", |b| {
+        b.iter_batched_ref(
+            || {
+                // This is a regression benchmark for https://github.com/astral-sh/ty/issues/627.
+                // Before this was fixed, the following sample would take >1s to type check.
+                setup_micro_case(
+                    r#"
+                    class C:
+                        def f(self: "C"):
+                            if isinstance(self.a, str):
+                                return
+
+                            if isinstance(self.b, str):
+                                return
+                            if isinstance(self.b, str):
+                                return
+                            if isinstance(self.b, str):
+                                return
+                            if isinstance(self.b, str):
+                                return
+                            if isinstance(self.b, str):
+                                return
+                            if isinstance(self.b, str):
+                                return
+                            if isinstance(self.b, str):
+                                return
+                            if isinstance(self.b, str):
+                                return
+                            if isinstance(self.b, str):
+                                return
+                            if isinstance(self.b, str):
+                                return
+                            if isinstance(self.b, str):
+                                return
+                            if isinstance(self.b, str):
+                                return
+                    "#,
+                )
+            },
+            |case| {
+                let Case { db, .. } = case;
+                let result = db.check();
+                assert!(!result.is_empty());
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
 struct ProjectBenchmark<'a> {
     project: InstalledProject<'a>,
     fs: MemoryFileSystem,
@@ -483,6 +535,7 @@ criterion_group!(
     micro,
     benchmark_many_string_assignments,
     benchmark_many_tuple_assignments,
+    benchmark_many_attribute_assignments,
 );
 criterion_group!(project, anyio, attrs, hydra);
 criterion_main!(check_file, micro, project);


### PR DESCRIPTION
## Summary

Adds a new micro-benchmark as a regression test for https://github.com/astral-sh/ty/issues/627.

## Test Plan

Ran the benchmark on the parent commit of https://github.com/astral-sh/ruff/commit/89d915a1e34144051815dfcbe60ec2cdeb29909e, and verified that it took > 1s, while it takes ~10 ms after the fix.