### PR TITLE
[ty] Add regression test for leading tab mis-alignment in diagnostic rendering

### DIFF
--- a/crates/ruff_annotate_snippets/tests/fixtures/color/regression_leading_tab_label_alignment.svg
+++ b/crates/ruff_annotate_snippets/tests/fixtures/color/regression_leading_tab_label_alignment.svg
@@ -1,0 +1,38 @@
+<svg width="740px" height="146px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .fg-bright-blue { fill: #5555FF }
+    .fg-bright-red { fill: #FF5555 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error[E0308]</tspan><tspan>: </tspan><tspan class="bold">call-non-callable</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan> </tspan><tspan class="fg-bright-blue bold">--&gt;</tspan><tspan> $DIR/main.py:5:9</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan>  </tspan><tspan class="fg-bright-blue bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-blue bold">4 |</tspan><tspan> def f():</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-blue bold">5 |</tspan><tspan>     return (1 == '2')()  # Tab indented</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan>            </tspan><tspan class="fg-bright-red bold">^^^^^^^^^^^^</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan>  </tspan><tspan class="fg-bright-blue bold">|</tspan>
+</tspan>
+  </text>
+
+</svg>

--- a/crates/ruff_annotate_snippets/tests/fixtures/color/regression_leading_tab_label_alignment.toml
+++ b/crates/ruff_annotate_snippets/tests/fixtures/color/regression_leading_tab_label_alignment.toml
@@ -1,0 +1,45 @@
+
+# [crates/ruff_db/src/diagnostic/render.rs:123:47] diag.to_annotate() = Message {
+    # level: Error,
+    # id: Some(
+        # "call-non-callable",
+    # ),
+    # title: "Object of type `bool` is not callable",
+    # snippets: [
+        # Snippet {
+            # origin: Some(
+                # "main.py",
+            # ),
+            # line_start: 1,
+            # source: "def f():\n\treturn (1 == '2')()  # Tab indented\n",
+            # annotations: [
+                # Annotation {
+                    # range: 17..29,
+                    # label: None,
+                    # level: Error,
+                # },
+            # ],
+            # fold: false,
+        # },
+    # ],
+    # footer: [],
+# }
+
+[message]
+level = "Error"
+id = "E0308"
+title = "call-non-callable"
+
+[[message.snippets]]
+source = "def f():\n\treturn (1 == '2')()  # Tab indented\n"
+line_start = 4
+origin = "$DIR/main.py"
+
+[[message.snippets.annotations]]
+label = ""
+level = "Error"
+range = [17, 29]
+
+[renderer]
+# anonymized_line_numbers = true
+color = true


### PR DESCRIPTION
It turns out that astral-sh/ty#18692 also fixed astral-sh/ty#203. This
PR adds a regression test for it. (Locally, I "unfixed" the bug and
confirmed that this is actually a regression test.)

Fixes astral-sh/ty#203
