### PR TITLE
[`flake8-annotations`] Make `ANN401` example error out-of-the-box

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs
+++ b/crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs
@@ -478,6 +478,7 @@ impl Violation for MissingReturnTypeClassMethod {
 /// ```python
 /// from typing import Any
 ///
+///
 /// def foo(x: Any): ...
 /// ```
 ///

--- a/crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs
+++ b/crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs
@@ -485,6 +485,9 @@ impl Violation for MissingReturnTypeClassMethod {
 /// Use instead:
 ///
 /// ```python
+/// from typing import Any
+///
+///
 /// def foo(x: int): ...
 /// ```
 ///

--- a/crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs
+++ b/crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs
@@ -476,6 +476,8 @@ impl Violation for MissingReturnTypeClassMethod {
 /// ## Example
 ///
 /// ```python
+/// from typing import Any
+///
 /// def foo(x: Any): ...
 /// ```
 ///


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Part of #18972

This PR makes [any-type (ANN401)](https://docs.astral.sh/ruff/rules/any-type/#any-type-ann401)'s example error out-of-the-box

[Old example](https://play.ruff.rs/a392200b-2c51-4812-9cbd-9cb34595e46d)
```py
def foo(x: Any): ...
```

[New example](https://play.ruff.rs/61773d72-0255-4983-a092-b595fd2438b6)
```py
from typing import Any

def foo(x: Any): ...
```

## Test Plan

<!-- How was it tested? -->

N/A, no functionality/tests affected