### PR TITLE
[`flake8-async`] Make `ASYNC110` example error out-of-the-box

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_async/rules/async_busy_wait.rs
+++ b/crates/ruff_linter/src/rules/flake8_async/rules/async_busy_wait.rs
@@ -16,8 +16,9 @@ use crate::rules::flake8_async::helpers::AsyncModule;
 ///
 /// ## Example
 /// ```python
-/// DONE = False
+/// import asyncio
 ///
+/// DONE = False
 ///
 /// async def func():
 ///     while not DONE:
@@ -26,8 +27,9 @@ use crate::rules::flake8_async::helpers::AsyncModule;
 ///
 /// Use instead:
 /// ```python
-/// DONE = asyncio.Event()
+/// import asyncio
 ///
+/// DONE = asyncio.Event()
 ///
 /// async def func():
 ///     await DONE.wait()

--- a/crates/ruff_linter/src/rules/flake8_async/rules/async_busy_wait.rs
+++ b/crates/ruff_linter/src/rules/flake8_async/rules/async_busy_wait.rs
@@ -20,6 +20,7 @@ use crate::rules::flake8_async::helpers::AsyncModule;
 ///
 /// DONE = False
 ///
+///
 /// async def func():
 ///     while not DONE:
 ///         await asyncio.sleep(1)
@@ -30,6 +31,7 @@ use crate::rules::flake8_async::helpers::AsyncModule;
 /// import asyncio
 ///
 /// DONE = asyncio.Event()
+///
 ///
 /// async def func():
 ///     await DONE.wait()


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Part of #18972

This PR makes [async-busy-wait (ASYNC110)](https://docs.astral.sh/ruff/rules/async-busy-wait/#async-busy-wait-async110)'s example error out-of-the-box

[Old example](https://play.ruff.rs/29e675b6-cd48-4208-8d4f-1c3a7b4d85c9)
```py
DONE = False


async def func():
    while not DONE:
        await asyncio.sleep(1)
```

[New example](https://play.ruff.rs/d21c27b5-fdfd-46f1-ae30-5f8c1399d936)
```py
import asyncio

DONE = False

async def func():
    while not DONE:
        await asyncio.sleep(1)
```

## Test Plan

<!-- How was it tested? -->

N/A, no functionality/tests affected