### PR TITLE
[`flake8-async`] Make `ASYNC210` example error out-of-the-box

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_async/rules/blocking_http_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_async/rules/blocking_http_call.rs
@@ -20,12 +20,18 @@ use crate::checkers::ast::Checker;
 ///
 /// ## Example
 /// ```python
+/// import urllib
+///
+///
 /// async def fetch():
 ///     urllib.request.urlopen("https://example.com/foo/bar").read()
 /// ```
 ///
 /// Use instead:
 /// ```python
+/// import aiohttp
+///
+///
 /// async def fetch():
 ///     async with aiohttp.ClientSession() as session:
 ///         async with session.get("https://example.com/foo/bar") as resp:


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Part of #18972

This PR makes [blocking-http-call-in-async-function (ASYNC210)](https://docs.astral.sh/ruff/rules/blocking-http-call-in-async-function/#blocking-http-call-in-async-function-async210)'s example error out-of-the-box

[Old example](https://play.ruff.rs/20cba4f4-fe2f-428a-a721-311d1a081e64)
```py
async def fetch():
    urllib.request.urlopen("https://example.com/foo/bar").read()
```

[New example](https://play.ruff.rs/5ca2a10d-5294-49ee-baee-0447f7188d9b)
```py
import urllib


async def fetch():
    urllib.request.urlopen("https://example.com/foo/bar").read()
```

## Test Plan

<!-- How was it tested? -->

N/A, no functionality/tests affected