### PR TITLE
[ty] Simplify `KnownClass::check_call()` and `KnownFunction::check_call()`

### DIFF
--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -5397,7 +5397,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 match binding_type {
                     Type::FunctionLiteral(function_literal) => {
                         if let Some(known_function) = function_literal.known(self.db()) {
-                            known_function.check_call(&self.context, overload, call_expression);
+                            known_function.check_call(
+                                &self.context,
+                                overload.parameter_types(),
+                                call_expression,
+                            );
                         }
                     }
 
@@ -5405,13 +5409,16 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         let Some(known_class) = class.known(self.db()) else {
                             continue;
                         };
-                        known_class.check_call(
+                        let overridden_return = known_class.check_call(
                             &self.context,
                             self.index,
                             overload,
                             &call_argument_types,
                             call_expression,
                         );
+                        if let Some(overridden_return) = overridden_return {
+                            overload.set_return_type(overridden_return);
+                        }
                     }
                     _ => {}
                 }


### PR DESCRIPTION
Neither of these methods really need a mutable reference to a `Binding`. `KnownFunction::check_call()` doesnt need a reference to a binding at all; it only needs the parameter types