### PR TITLE
[ty] Add builtins to completions derived from scope

### DIFF
--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -15,7 +15,7 @@ pub use program::{
     PythonVersionWithSource, SearchPathSettings,
 };
 pub use python_platform::PythonPlatform;
-pub use semantic_model::{HasType, SemanticModel};
+pub use semantic_model::{Completion, HasType, SemanticModel};
 pub use site_packages::{PythonEnvironment, SitePackagesPaths, SysPrefixPathOrigin};
 pub use util::diagnostics::add_inferred_python_version_hint_to_diagnostic;
 

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -6,7 +6,7 @@ use ruff_source_file::LineIndex;
 
 use crate::Db;
 use crate::module_name::ModuleName;
-use crate::module_resolver::{Module, resolve_module};
+use crate::module_resolver::{KnownModule, Module, resolve_module};
 use crate::semantic_index::ast_ids::HasScopedExpressionId;
 use crate::semantic_index::place::FileScopeId;
 use crate::semantic_index::semantic_index;
@@ -46,7 +46,7 @@ impl<'db> SemanticModel<'db> {
         &self,
         import: &ast::StmtImportFrom,
         _name: Option<usize>,
-    ) -> Vec<Name> {
+    ) -> Vec<Completion> {
         let module_name = match ModuleName::from_import_statement(self.db, self.file, import) {
             Ok(module_name) => module_name,
             Err(err) => {
@@ -58,18 +58,36 @@ impl<'db> SemanticModel<'db> {
                 return vec![];
             }
         };
-        let Some(module) = resolve_module(self.db, &module_name) else {
+        self.module_completions(&module_name)
+    }
+
+    /// Returns completions for symbols available in the given module as if
+    /// it were imported by this model's `File`.
+    fn module_completions(&self, module_name: &ModuleName) -> Vec<Completion> {
+        let Some(module) = resolve_module(self.db, module_name) else {
             tracing::debug!("Could not resolve module from `{module_name:?}`");
             return vec![];
         };
         let ty = Type::module_literal(self.db, self.file, &module);
-        crate::types::all_members(self.db, ty).into_iter().collect()
+        crate::types::all_members(self.db, ty)
+            .into_iter()
+            .map(|name| Completion {
+                name,
+                builtin: module.is_known(KnownModule::Builtins),
+            })
+            .collect()
     }
 
     /// Returns completions for symbols available in a `object.<CURSOR>` context.
-    pub fn attribute_completions(&self, node: &ast::ExprAttribute) -> Vec<Name> {
+    pub fn attribute_completions(&self, node: &ast::ExprAttribute) -> Vec<Completion> {
         let ty = node.value.inferred_type(self);
-        crate::types::all_members(self.db, ty).into_iter().collect()
+        crate::types::all_members(self.db, ty)
+            .into_iter()
+            .map(|name| Completion {
+                name,
+                builtin: false,
+            })
+            .collect()
     }
 
     /// Returns completions for symbols available in the scope containing the
@@ -77,7 +95,7 @@ impl<'db> SemanticModel<'db> {
     ///
     /// If a scope could not be determined, then completions for the global
     /// scope of this model's `File` are returned.
-    pub fn scoped_completions(&self, node: ast::AnyNodeRef<'_>) -> Vec<Name> {
+    pub fn scoped_completions(&self, node: ast::AnyNodeRef<'_>) -> Vec<Completion> {
         let index = semantic_index(self.db, self.file);
 
         // TODO: We currently use `try_expression_scope_id` here as a hotfix for [1].
@@ -96,15 +114,35 @@ impl<'db> SemanticModel<'db> {
         }) else {
             return vec![];
         };
-        let mut symbols = vec![];
+        let mut completions = vec![];
         for (file_scope, _) in index.ancestor_scopes(file_scope) {
-            symbols.extend(all_declarations_and_bindings(
-                self.db,
-                file_scope.to_scope_id(self.db, self.file),
-            ));
+            completions.extend(
+                all_declarations_and_bindings(self.db, file_scope.to_scope_id(self.db, self.file))
+                    .map(|name| Completion {
+                        name,
+                        builtin: false,
+                    }),
+            );
         }
-        symbols
+        // Builtins are available in all scopes.
+        let builtins = ModuleName::new("builtins").expect("valid module name");
+        completions.extend(self.module_completions(&builtins));
+        completions
     }
+}
+
+/// A suggestion for code completion.
+#[derive(Clone, Debug)]
+pub struct Completion {
+    /// The label shown to the user for this suggestion.
+    pub name: Name,
+    /// Whether this suggestion came from builtins or not.
+    ///
+    /// At time of writing (2025-06-26), this information
+    /// doesn't make it into the LSP response. Instead, we
+    /// use it mainly in tests so that we can write less
+    /// noisy tests.
+    pub builtin: bool,
 }
 
 pub trait HasType {

--- a/crates/ty_server/src/server/api/requests/completion.rs
+++ b/crates/ty_server/src/server/api/requests/completion.rs
@@ -56,7 +56,7 @@ impl BackgroundDocumentRequestHandler for CompletionRequestHandler {
             .into_iter()
             .enumerate()
             .map(|(i, comp)| CompletionItem {
-                label: comp.label,
+                label: comp.name.into(),
                 sort_text: Some(format!("{i:-max_index_len$}")),
                 ..Default::default()
             })

--- a/crates/ty_wasm/src/lib.rs
+++ b/crates/ty_wasm/src/lib.rs
@@ -309,7 +309,7 @@ impl Workspace {
         Ok(completions
             .into_iter()
             .map(|completion| Completion {
-                label: completion.label,
+                name: completion.name.into(),
             })
             .collect())
     }
@@ -619,7 +619,7 @@ pub struct Hover {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Completion {
     #[wasm_bindgen(getter_with_clone)]
-    pub label: String,
+    pub name: String,
 }
 
 #[wasm_bindgen]


### PR DESCRIPTION
Most of the work here was doing some light refactoring to facilitate
sensible testing. That is, we don't want to list every builtin included
in most tests, so we add some structure to the completion type returned.
Tests can now filter based on whether a completion is a builtin or not.

Otherwise, builtins are found using the existing infrastructure for
`object.attr` completions (where we hard-code the module name
`builtins`).

I did consider changing the sort order based on whether a completion
suggestion was a builtin or not. In particular, it seemed like it might
be a good idea to sort builtins after other scope based completions,
but before the dunder and sunder attributes. Namely, it seems likely
that there is an inverse correlation between the size of a scope and
the likelihood of an item in that scope being used at any given point.
So it *might* be a good idea to prioritize the likelier candidates in
the completions returned.

Additionally, the number of items introduced by adding builtins is quite
large. So I wondered whether mixing them in with everything else would
become too noisy.

However, it's not totally clear to me that this is the right thing to
do. Right now, I feel like there is a very obvious lexicographic
ordering that makes "finding" the right suggestion to activate
potentially easier than if the ranking mechanism is less clear.
(Technically, the dunder and sunder attributes are not sorted
lexicographically, but I'd put forward that most folks don't have an
intuitive understanding of where `_` ranks lexicographically with
respect to "regular" letters. Moreover, since dunder and sunder
attributes are all grouped together, I think the ordering here ends up
being very obvious after even a quick glance.)
