### PR TITLE
[ty] Fix playground

### DIFF
--- a/playground/ty/src/Editor/Editor.tsx
+++ b/playground/ty/src/Editor/Editor.tsx
@@ -207,10 +207,10 @@ class PlaygroundServer
 
     return {
       suggestions: completions.map((completion, i) => ({
-        label: completion.label,
+        label: completion.name,
         sortText: String(i).padStart(digitsLength, "0"),
         kind: CompletionItemKind.Variable,
-        insertText: completion.label,
+        insertText: completion.name,
         // TODO(micha): It's unclear why this field is required for monaco but not VS Code.
         //  and omitting it works just fine? The LSP doesn't expose this information right now
         //  which is why we go with undefined for now.


### PR DESCRIPTION
I renamed a field on a `Completion` struct in #18982, and it looks like
this caused the playground to fail to build:
https://github.com/astral-sh/ruff/actions/runs/15928550050/job/44931734349

Maybe building that playground can be added to CI for pull requests?
