### PR TITLE
[`Airflow`] Make `AIR302` example error out-of-the-box

### DIFF
--- a/crates/ruff_linter/src/rules/airflow/rules/moved_to_provider_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/moved_to_provider_in_3.rs
@@ -23,14 +23,14 @@ use crate::{FixAvailability, Violation};
 ///
 /// ## Example
 /// ```python
-/// from airflow.auth.managers.fab.fab_auth_manage import FabAuthManager
+/// from airflow.auth.managers.fab.fab_auth_manager import FabAuthManager
 ///
 /// fab_auth_manager_app = FabAuthManager().get_fastapi_app()
 /// ```
 ///
 /// Use instead:
 /// ```python
-/// from airflow.providers.fab.auth_manager.fab_auth_manage import FabAuthManager
+/// from airflow.providers.fab.auth_manager.fab_auth_manager import FabAuthManager
 ///
 /// fab_auth_manager_app = FabAuthManager().get_fastapi_app()
 /// ```

--- a/crates/ruff_linter/src/rules/airflow/rules/moved_to_provider_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/moved_to_provider_in_3.rs
@@ -24,11 +24,15 @@ use crate::{FixAvailability, Violation};
 /// ## Example
 /// ```python
 /// from airflow.auth.managers.fab.fab_auth_manage import FabAuthManager
+///
+/// fab_auth_manager_app = FabAuthManager().get_fastapi_app()
 /// ```
 ///
 /// Use instead:
 /// ```python
 /// from airflow.providers.fab.auth_manager.fab_auth_manage import FabAuthManager
+///
+/// fab_auth_manager_app = FabAuthManager().get_fastapi_app()
 /// ```
 #[derive(ViolationMetadata)]
 pub(crate) struct Airflow3MovedToProvider<'a> {


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Part of #18972

This PR makes [airflow3-moved-to-provider (AIR302)](https://docs.astral.sh/ruff/rules/airflow3-moved-to-provider/#airflow3-moved-to-provider-air302)'s example error out-of-the-box

[Old example](https://play.ruff.rs/1026c008-57bc-4330-93b9-141444f2a611)
```py
from airflow.auth.managers.fab.fab_auth_manage import FabAuthManager
```

[New example](https://play.ruff.rs/b690e809-a81d-4265-9fde-1494caa0b7fd)
```py
from airflow.auth.managers.fab.fab_auth_manager import FabAuthManager

fab_auth_manager_app = FabAuthManager().get_fastapi_app()
```

## Test Plan

<!-- How was it tested? -->

N/A, no functionality/tests affected