### PR TITLE
[`Airflow`] Make `AIR312` example error out-of-the-box

### DIFF
--- a/crates/ruff_linter/src/rules/airflow/rules/suggested_to_move_to_provider_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/suggested_to_move_to_provider_in_3.rs
@@ -24,11 +24,29 @@ use ruff_text_size::TextRange;
 /// ## Example
 /// ```python
 /// from airflow.operators.python import PythonOperator
+///
+///
+/// def print_context(ds=None, **kwargs):
+///     print(kwargs)
+///     print(ds)
+///
+/// print_the_context = PythonOperator(
+///     task_id="print_the_context", python_callable=print_context
+/// )
 /// ```
 ///
 /// Use instead:
 /// ```python
 /// from airflow.providers.standard.operators.python import PythonOperator
+///
+///
+/// def print_context(ds=None, **kwargs):
+///     print(kwargs)
+///     print(ds)
+///
+/// print_the_context = PythonOperator(
+///     task_id="print_the_context", python_callable=print_context
+/// )
 /// ```
 #[derive(ViolationMetadata)]
 pub(crate) struct Airflow3SuggestedToMoveToProvider<'a> {

--- a/crates/ruff_linter/src/rules/airflow/rules/suggested_to_move_to_provider_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/suggested_to_move_to_provider_in_3.rs
@@ -30,6 +30,7 @@ use ruff_text_size::TextRange;
 ///     print(kwargs)
 ///     print(ds)
 ///
+///
 /// print_the_context = PythonOperator(
 ///     task_id="print_the_context", python_callable=print_context
 /// )
@@ -43,6 +44,7 @@ use ruff_text_size::TextRange;
 /// def print_context(ds=None, **kwargs):
 ///     print(kwargs)
 ///     print(ds)
+///
 ///
 /// print_the_context = PythonOperator(
 ///     task_id="print_the_context", python_callable=print_context


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Part of #18972

This PR makes [airflow3-moved-to-provider [airflow3-suggested-to-move-to-provider (AIR312)](https://docs.astral.sh/ruff/rules/airflow3-suggested-to-move-to-provider/#airflow3-suggested-to-move-to-provider-air312)'s example error out-of-the-box

[Old example](https://play.ruff.rs/1be0d654-1ed5-4a0b-8791-cc5db73333d5)
```py
from airflow.operators.python import PythonOperator
```

[New example](https://play.ruff.rs/b6260206-fa19-4ab2-8d45-ddd43c46a759)
```py
from airflow.operators.python import PythonOperator


def print_context(ds=None, **kwargs):
    print(kwargs)
    print(ds)


print_the_context = PythonOperator(
    task_id="print_the_context", python_callable=print_context
)
```

## Test Plan

<!-- How was it tested? -->

N/A, no functionality/tests affected