### PR TITLE
[`flake8-async`] Make `ASYNC251` example error out-of-the-box

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_async/rules/blocking_sleep.rs
+++ b/crates/ruff_linter/src/rules/flake8_async/rules/blocking_sleep.rs
@@ -19,12 +19,18 @@ use crate::checkers::ast::Checker;
 ///
 /// ## Example
 /// ```python
+/// import time
+///
+///
 /// async def fetch():
 ///     time.sleep(1)
 /// ```
 ///
 /// Use instead:
 /// ```python
+/// import asyncio
+///
+///
 /// async def fetch():
 ///     await asyncio.sleep(1)
 /// ```


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Part of #18972

This PR makes [blocking-sleep-in-async-function (ASYNC251)](https://docs.astral.sh/ruff/rules/blocking-sleep-in-async-function/#blocking-sleep-in-async-function-async251)'s example error out-of-the-box

[Old example](https://play.ruff.rs/796684a2-c437-4390-b754-491e576ffe5e)
```py
async def fetch():
    time.sleep(1)
```

[New example](https://play.ruff.rs/90741192-fd0d-49fb-a04e-3127312da659)
```py
import time


async def fetch():
    time.sleep(1)
```

Imports were also added to the `Use instead:` section to make it valid code out-of-the-box.

## Test Plan

<!-- How was it tested? -->

N/A, no functionality/tests affected