### PR TITLE
[`flake8-async`] Make `ASYNC100` example error out-of-the-box

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_async/rules/cancel_scope_no_checkpoint.rs
+++ b/crates/ruff_linter/src/rules/flake8_async/rules/cancel_scope_no_checkpoint.rs
@@ -21,6 +21,9 @@ use crate::rules::flake8_async::helpers::MethodName;
 ///
 /// ## Example
 /// ```python
+/// import asyncio
+///
+///
 /// async def func():
 ///     async with asyncio.timeout(2):
 ///         do_something()
@@ -28,6 +31,9 @@ use crate::rules::flake8_async::helpers::MethodName;
 ///
 /// Use instead:
 /// ```python
+/// import asyncio
+///
+///
 /// async def func():
 ///     async with asyncio.timeout(2):
 ///         do_something()


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Part of #18972

This PR makes [cancel-scope-no-checkpoint (ASYNC100)](https://docs.astral.sh/ruff/rules/cancel-scope-no-checkpoint/#cancel-scope-no-checkpoint-async100)'s example error out-of-the-box

[Old example](https://play.ruff.rs/6a399ae5-9b89-4438-b808-6604f1e40a70)
```py
async def func():
    async with asyncio.timeout(2):
        do_something()
```

[New example](https://play.ruff.rs/c44db531-d2f8-4a61-9e04-e5fc0ea989e3)
```py
import asyncio


async def func():
    async with asyncio.timeout(2):
        do_something()
```

## Test Plan

<!-- How was it tested? -->

N/A, no functionality/tests affected