### PR TITLE
[ty] Refactor argument matching / type checking in call binding

### DIFF
--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -1914,6 +1914,174 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
     }
 }
 
+struct ArgumentTypeChecker<'a, 'db> {
+    db: &'db dyn Db,
+    signature: &'a Signature<'db>,
+    arguments: &'a CallArguments<'a>,
+    argument_types: &'a [Type<'db>],
+    argument_parameters: &'a [Option<usize>],
+    parameter_tys: &'a mut [Option<Type<'db>>],
+    errors: &'a mut Vec<BindingError<'db>>,
+
+    specialization: Option<Specialization<'db>>,
+    inherited_specialization: Option<Specialization<'db>>,
+}
+
+impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
+    fn new(
+        db: &'db dyn Db,
+        signature: &'a Signature<'db>,
+        arguments: &'a CallArguments<'a>,
+        argument_types: &'a [Type<'db>],
+        argument_parameters: &'a [Option<usize>],
+        parameter_tys: &'a mut [Option<Type<'db>>],
+        errors: &'a mut Vec<BindingError<'db>>,
+    ) -> Self {
+        Self {
+            db,
+            signature,
+            arguments,
+            argument_types,
+            argument_parameters,
+            parameter_tys,
+            errors,
+            specialization: None,
+            inherited_specialization: None,
+        }
+    }
+
+    fn enumerate_argument_types(
+        &self,
+    ) -> impl Iterator<Item = (usize, Option<usize>, Argument<'a>, Type<'db>)> + 'a {
+        let mut iter = (self.arguments.iter())
+            .zip(self.argument_types.iter().copied())
+            .enumerate();
+        let mut num_synthetic_args = 0;
+        std::iter::from_fn(move || {
+            let (argument_index, (argument, argument_type)) = iter.next()?;
+            let adjusted_argument_index = if matches!(argument, Argument::Synthetic) {
+                // If we are erroring on a synthetic argument, we'll just emit the
+                // diagnostic on the entire Call node, since there's no argument node for
+                // this argument at the call site
+                num_synthetic_args += 1;
+                None
+            } else {
+                // Adjust the argument index to skip synthetic args, which don't appear at
+                // the call site and thus won't be in the Call node arguments list.
+                Some(argument_index - num_synthetic_args)
+            };
+            Some((
+                argument_index,
+                adjusted_argument_index,
+                argument,
+                argument_type,
+            ))
+        })
+    }
+
+    fn infer_specialization(&mut self) {
+        if self.signature.generic_context.is_none()
+            && self.signature.inherited_generic_context.is_none()
+        {
+            return;
+        }
+
+        let parameters = self.signature.parameters();
+        let mut builder = SpecializationBuilder::new(self.db);
+        for (argument_index, adjusted_argument_index, _, argument_type) in
+            self.enumerate_argument_types()
+        {
+            let Some(parameter_index) = self.argument_parameters[argument_index] else {
+                // There was an error with argument when matching parameters, so don't bother
+                // type-checking it.
+                continue;
+            };
+            let parameter = &parameters[parameter_index];
+            let Some(expected_type) = parameter.annotated_type() else {
+                continue;
+            };
+            if let Err(error) = builder.infer(expected_type, argument_type) {
+                self.errors.push(BindingError::SpecializationError {
+                    error,
+                    argument_index: adjusted_argument_index,
+                });
+            }
+        }
+        self.specialization = self.signature.generic_context.map(|gc| builder.build(gc));
+        self.inherited_specialization = self.signature.inherited_generic_context.map(|gc| {
+            // The inherited generic context is used when inferring the specialization of a generic
+            // class from a constructor call. In this case (only), we promote any typevars that are
+            // inferred as a literal to the corresponding instance type.
+            builder
+                .build(gc)
+                .apply_type_mapping(self.db, &TypeMapping::PromoteLiterals)
+        });
+    }
+
+    fn check_argument_type(
+        &mut self,
+        argument_index: usize,
+        adjusted_argument_index: Option<usize>,
+        argument: Argument<'a>,
+        mut argument_type: Type<'db>,
+    ) {
+        let Some(parameter_index) = self.argument_parameters[argument_index] else {
+            // There was an error with argument when matching parameters, so don't bother
+            // type-checking it.
+            return;
+        };
+        let parameters = self.signature.parameters();
+        let parameter = &parameters[parameter_index];
+        if let Some(mut expected_ty) = parameter.annotated_type() {
+            if let Some(specialization) = self.specialization {
+                argument_type = argument_type.apply_specialization(self.db, specialization);
+                expected_ty = expected_ty.apply_specialization(self.db, specialization);
+            }
+            if let Some(inherited_specialization) = self.inherited_specialization {
+                argument_type =
+                    argument_type.apply_specialization(self.db, inherited_specialization);
+                expected_ty = expected_ty.apply_specialization(self.db, inherited_specialization);
+            }
+            if !argument_type.is_assignable_to(self.db, expected_ty) {
+                let positional = matches!(argument, Argument::Positional | Argument::Synthetic)
+                    && !parameter.is_variadic();
+                self.errors.push(BindingError::InvalidArgumentType {
+                    parameter: ParameterContext::new(parameter, parameter_index, positional),
+                    argument_index: adjusted_argument_index,
+                    expected_ty,
+                    provided_ty: argument_type,
+                });
+            }
+        }
+        // We still update the actual type of the parameter in this binding to match the
+        // argument, even if the argument type is not assignable to the expected parameter
+        // type.
+        if let Some(existing) = self.parameter_tys[parameter_index].replace(argument_type) {
+            // We already verified in `match_parameters` that we only match multiple arguments
+            // with variadic parameters.
+            let union = UnionType::from_elements(self.db, [existing, argument_type]);
+            self.parameter_tys[parameter_index] = Some(union);
+        }
+    }
+
+    fn check_argument_types(&mut self) {
+        for (argument_index, adjusted_argument_index, argument, argument_type) in
+            self.enumerate_argument_types()
+        {
+            self.check_argument_type(
+                argument_index,
+                adjusted_argument_index,
+                argument,
+                argument_type,
+            );
+        }
+    }
+
+    fn finish(self) -> (Option<Specialization<'db>>, Option<Specialization<'db>>) {
+        (self.specialization, self.inherited_specialization)
+    }
+}
+
 /// Binding information for one of the overloads of a callable.
 #[derive(Debug)]
 pub(crate) struct Binding<'db> {
@@ -2009,106 +2177,22 @@ impl<'db> Binding<'db> {
         arguments: &CallArguments<'_>,
         argument_types: &[Type<'db>],
     ) {
-        let mut num_synthetic_args = 0;
-        let get_argument_index = |argument_index: usize, num_synthetic_args: usize| {
-            if argument_index >= num_synthetic_args {
-                // Adjust the argument index to skip synthetic args, which don't appear at the call
-                // site and thus won't be in the Call node arguments list.
-                Some(argument_index - num_synthetic_args)
-            } else {
-                // we are erroring on a synthetic argument, we'll just emit the diagnostic on the
-                // entire Call node, since there's no argument node for this argument at the call site
-                None
-            }
-        };
-
-        let enumerate_argument_types = || {
-            arguments
-                .iter()
-                .zip(argument_types.iter().copied())
-                .enumerate()
-        };
+        let mut checker = ArgumentTypeChecker::new(
+            db,
+            &self.signature,
+            arguments,
+            argument_types,
+            &self.argument_parameters,
+            &mut self.parameter_tys,
+            &mut self.errors,
+        );
 
         // If this overload is generic, first see if we can infer a specialization of the function
         // from the arguments that were passed in.
-        let signature = &self.signature;
-        let parameters = signature.parameters();
-        if signature.generic_context.is_some() || signature.inherited_generic_context.is_some() {
-            let mut builder = SpecializationBuilder::new(db);
-            for (argument_index, (argument, argument_type)) in enumerate_argument_types() {
-                if matches!(argument, Argument::Synthetic) {
-                    num_synthetic_args += 1;
-                }
-                let Some(parameter_index) = self.argument_parameters[argument_index] else {
-                    // There was an error with argument when matching parameters, so don't bother
-                    // type-checking it.
-                    continue;
-                };
-                let parameter = &parameters[parameter_index];
-                let Some(expected_type) = parameter.annotated_type() else {
-                    continue;
-                };
-                if let Err(error) = builder.infer(expected_type, argument_type) {
-                    self.errors.push(BindingError::SpecializationError {
-                        error,
-                        argument_index: get_argument_index(argument_index, num_synthetic_args),
-                    });
-                }
-            }
-            self.specialization = signature.generic_context.map(|gc| builder.build(gc));
-            self.inherited_specialization = signature.inherited_generic_context.map(|gc| {
-                // The inherited generic context is used when inferring the specialization of a
-                // generic class from a constructor call. In this case (only), we promote any
-                // typevars that are inferred as a literal to the corresponding instance type.
-                builder
-                    .build(gc)
-                    .apply_type_mapping(db, &TypeMapping::PromoteLiterals)
-            });
-        }
+        checker.infer_specialization();
 
-        num_synthetic_args = 0;
-        for (argument_index, (argument, mut argument_type)) in enumerate_argument_types() {
-            if matches!(argument, Argument::Synthetic) {
-                num_synthetic_args += 1;
-            }
-            let Some(parameter_index) = self.argument_parameters[argument_index] else {
-                // There was an error with argument when matching parameters, so don't bother
-                // type-checking it.
-                continue;
-            };
-            let parameter = &parameters[parameter_index];
-            if let Some(mut expected_ty) = parameter.annotated_type() {
-                if let Some(specialization) = self.specialization {
-                    argument_type = argument_type.apply_specialization(db, specialization);
-                    expected_ty = expected_ty.apply_specialization(db, specialization);
-                }
-                if let Some(inherited_specialization) = self.inherited_specialization {
-                    argument_type =
-                        argument_type.apply_specialization(db, inherited_specialization);
-                    expected_ty = expected_ty.apply_specialization(db, inherited_specialization);
-                }
-                if !argument_type.is_assignable_to(db, expected_ty) {
-                    let positional = matches!(argument, Argument::Positional | Argument::Synthetic)
-                        && !parameter.is_variadic();
-                    self.errors.push(BindingError::InvalidArgumentType {
-                        parameter: ParameterContext::new(parameter, parameter_index, positional),
-                        argument_index: get_argument_index(argument_index, num_synthetic_args),
-                        expected_ty,
-                        provided_ty: argument_type,
-                    });
-                }
-            }
-            // We still update the actual type of the parameter in this binding to match the
-            // argument, even if the argument type is not assignable to the expected parameter
-            // type.
-            if let Some(existing) = self.parameter_tys[parameter_index].replace(argument_type) {
-                // We already verified in `match_parameters` that we only match multiple arguments
-                // with variadic parameters.
-                let union = UnionType::from_elements(db, [existing, argument_type]);
-                self.parameter_tys[parameter_index] = Some(union);
-            }
-        }
-
+        checker.check_argument_types();
+        (self.specialization, self.inherited_specialization) = checker.finish();
         if let Some(specialization) = self.specialization {
             self.return_ty = self.return_ty.apply_specialization(db, specialization);
         }


### PR DESCRIPTION
This PR extracts a lot of the complex logic in the `match_parameters` and `check_types` methods of our call binding machinery into separate helper types. This is setup for #18996, which will update this logic to handle variadic arguments. To do so, it is helpful to have the per-argument logic extracted into a method that we can call repeatedly for each _element_ of a variadic argument.

This should be a pure refactoring, with no behavioral changes.