### PR TITLE
[ty] Reduce 'complex_constrained_attributes_2' runtime

### DIFF
--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -428,10 +428,6 @@ fn benchmark_complex_constrained_attributes_2(criterion: &mut Criterion) {
                                 return
                             if isinstance(self.b, str):
                                 return
-                            if isinstance(self.b, str):
-                                return
-                            if isinstance(self.b, str):
-                                return
                     "#,
                 )
             },


### PR DESCRIPTION
Re: https://github.com/astral-sh/ruff/pull/18979#issuecomment-3012541095

Each check increases the runtime by a factor of 3, so this should be an order of magnitude faster.