### PR TITLE
[`flake8-async`] Make `ASYNC105` example error out-of-the-box

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_async/rules/sync_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_async/rules/sync_call.rs
@@ -18,12 +18,18 @@ use crate::{Edit, Fix, FixAvailability, Violation};
 ///
 /// ## Example
 /// ```python
+/// import trio
+///
+///
 /// async def double_sleep(x):
 ///     trio.sleep(2 * x)
 /// ```
 ///
 /// Use instead:
 /// ```python
+/// import trio
+///
+///
 /// async def double_sleep(x):
 ///     await trio.sleep(2 * x)
 /// ```


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Part of #18972

This PR makes [trio-sync-call (ASYNC105)](https://docs.astral.sh/ruff/rules/trio-sync-call/#trio-sync-call-async105)'s example error out-of-the-box

[Old example](https://play.ruff.rs/5b267e01-1c0a-4902-949e-45fc46f8b0d0)
```py
async def double_sleep(x):
    trio.sleep(2 * x)
```

[New example](https://play.ruff.rs/eba6ea40-ff88-4ea8-8cb4-cea472c15c53)
```py
import trio


async def double_sleep(x):
    trio.sleep(2 * x)
```

## Test Plan

<!-- How was it tested? -->

N/A, no functionality/tests affected