### PR TITLE
[`flake8-bandit`] Fix `S412` false negative

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_bandit/S412.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_bandit/S412.py
@@ -1,1 +1,4 @@
 from twisted.web.twcgi import CGIScript  # S412
+import twisted.web.twcgi.CGIScript  # S412
+from wsgiref.handlers import CGIHandler  # S412
+import wsgiref.handlers.CGIHandler  # S412

--- a/crates/ruff_linter/resources/test/fixtures/flake8_bandit/S412.pyi
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_bandit/S412.pyi
@@ -1,1 +1,4 @@
 from twisted.web.twcgi import CGIScript
+import twisted.web.twcgi.CGIScript
+from wsgiref.handlers import CGIHandler
+import wsgiref.handlers.CGIHandler

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/suspicious_imports.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/suspicious_imports.rs
@@ -396,6 +396,9 @@ pub(crate) fn suspicious_imports(checker: &Checker, stmt: &Stmt) {
                     "xmlrpc" => {
                         checker.report_diagnostic_if_enabled(SuspiciousXmlrpcImport, name.range);
                     }
+                    "wsgiref.handlers.CGIHandler" | "twisted.web.twcgi.CGIScript" => {
+                        checker.report_diagnostic_if_enabled(SuspiciousHttpoxyImport, name.range);
+                    }
                     "Crypto.Cipher" | "Crypto.Hash" | "Crypto.IO" | "Crypto.Protocol"
                     | "Crypto.PublicKey" | "Crypto.Random" | "Crypto.Signature" | "Crypto.Util" => {
                         checker.report_diagnostic_if_enabled(SuspiciousPycryptoImport, name.range);

--- a/crates/ruff_linter/src/rules/flake8_bandit/snapshots/ruff_linter__rules__flake8_bandit__tests__S412_S412.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bandit/snapshots/ruff_linter__rules__flake8_bandit__tests__S412_S412.py.snap
@@ -1,9 +1,36 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_bandit/mod.rs
-snapshot_kind: text
 ---
 S412.py:1:6: S412 `httpoxy` is a set of vulnerabilities that affect application code running inCGI, or CGI-like environments. The use of CGI for web applications should be avoided
   |
 1 | from twisted.web.twcgi import CGIScript  # S412
   |      ^^^^^^^^^^^^^^^^^ S412
+2 | import twisted.web.twcgi.CGIScript  # S412
+3 | from wsgiref.handlers import CGIHandler  # S412
+  |
+
+S412.py:2:8: S412 `httpoxy` is a set of vulnerabilities that affect application code running inCGI, or CGI-like environments. The use of CGI for web applications should be avoided
+  |
+1 | from twisted.web.twcgi import CGIScript  # S412
+2 | import twisted.web.twcgi.CGIScript  # S412
+  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ S412
+3 | from wsgiref.handlers import CGIHandler  # S412
+4 | import wsgiref.handlers.CGIHandler  # S412
+  |
+
+S412.py:3:6: S412 `httpoxy` is a set of vulnerabilities that affect application code running inCGI, or CGI-like environments. The use of CGI for web applications should be avoided
+  |
+1 | from twisted.web.twcgi import CGIScript  # S412
+2 | import twisted.web.twcgi.CGIScript  # S412
+3 | from wsgiref.handlers import CGIHandler  # S412
+  |      ^^^^^^^^^^^^^^^^ S412
+4 | import wsgiref.handlers.CGIHandler  # S412
+  |
+
+S412.py:4:8: S412 `httpoxy` is a set of vulnerabilities that affect application code running inCGI, or CGI-like environments. The use of CGI for web applications should be avoided
+  |
+2 | import twisted.web.twcgi.CGIScript  # S412
+3 | from wsgiref.handlers import CGIHandler  # S412
+4 | import wsgiref.handlers.CGIHandler  # S412
+  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ S412
   |


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Part of #18972

This PR fixes a false negative in [suspicious-httpoxy-import (S412)](https://docs.astral.sh/ruff/rules/suspicious-httpoxy-import/#suspicious-httpoxy-import-s412) if the suspicious import is imported directly, ie `import wsgiref.handlers.CGIHandler` and `import twisted.web.twcgi.CGIScript`

## Test Plan

<!-- How was it tested? -->

Added additional cases to test file