### PR TITLE
[`flake8-bandit`] Make `S201` example error out-of-the-box

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/flask_debug_true.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/flask_debug_true.rs
@@ -18,7 +18,7 @@ use crate::checkers::ast::Checker;
 ///
 /// ## Example
 /// ```python
-/// import flask
+/// from flask import Flask
 ///
 /// app = Flask()
 ///
@@ -27,7 +27,9 @@ use crate::checkers::ast::Checker;
 ///
 /// Use instead:
 /// ```python
-/// import flask
+/// import os
+///
+/// from flask import Flask
 ///
 /// app = Flask()
 ///


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Part of #18972

This PR makes [flask-debug-true (S201)](https://docs.astral.sh/ruff/rules/flask-debug-true/#flask-debug-true-s201)'s example error out-of-the-box

[Old example](https://play.ruff.rs/d5e1a013-1107-4223-9094-0e8393ad3c64)
```py
import flask

app = Flask()

app.run(debug=True)
```

[New example](https://play.ruff.rs/c4aebd2c-0448-4471-8bad-3e38ace68367)
```py
from flask import Flask

app = Flask()

app.run(debug=True)
```

Imports were also added to the `Use instead:` section to make it valid code out-of-the-box.

## Test Plan

<!-- How was it tested? -->

N/A, no functionality/tests affected