### PR TITLE
[`ruff`] Allow more `field` calls from `attrs` (`RUF009`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF009_attrs.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF009_attrs.py
@@ -125,3 +125,12 @@ class J:
 class K:
     f: F = F()
     g: G = G()
+
+
+# Regression test for https://github.com/astral-sh/ruff/issues/19014
+# These are all valid field calls and should not cause diagnostics.
+@attr.define
+class TestAttrField:
+    attr_field_factory: list[int] = attr.field(factory=list)
+    attr_field_default: list[int] = attr.field(default=attr.Factory(list))
+    attr_factory: list[int] = attr.Factory(list)

--- a/crates/ruff_linter/src/rules/ruff/helpers.rs
+++ b/crates/ruff_linter/src/rules/ruff/helpers.rs
@@ -25,14 +25,14 @@ fn is_stdlib_dataclass_field(func: &Expr, semantic: &SemanticModel) -> bool {
         .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["dataclasses", "field"]))
 }
 
-/// Returns `true` if the given [`Expr`] is a call to `attr.ib()` or `attrs.field()`.
+/// Returns `true` if the given [`Expr`] is a call to an `attrs` field function.
 fn is_attrs_field(func: &Expr, semantic: &SemanticModel) -> bool {
     semantic
         .resolve_qualified_name(func)
         .is_some_and(|qualified_name| {
             matches!(
                 qualified_name.segments(),
-                ["attrs", "field" | "Factory"] | ["attr", "ib"]
+                ["attrs", "field" | "Factory"] | ["attr", "ib" | "field" | "Factory"]
             )
         })
 }


### PR DESCRIPTION
Summary
--

Closes #19014 by identifying more `field` functions from `attrs`. We already detected these when imported from `attrs` but not the `attr` module from the same package. These functions are identical to the `attrs` versions:

```pycon
>>> import attrs, attr
>>> attrs.field is attr.field
True
>>> attrs.Factory is attr.Factory
True
>>>
```

Test Plan
--

Regression tests based on the issue