### PR TITLE
Minor code simplification

### DIFF
--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -2765,9 +2765,7 @@ impl<'a> Checker<'a> {
 
                         self.semantic.restore(snapshot);
 
-                        if self.semantic.in_annotation()
-                            && self.semantic.in_typing_only_annotation()
-                        {
+                        if self.semantic.in_typing_only_annotation() {
                             if self.is_rule_enabled(Rule::QuotedAnnotation) {
                                 pyupgrade::rules::quoted_annotation(self, annotation, range);
                             }


### PR DESCRIPTION
When inside a typing only annotation, the code is always inside an annotation, too.