### PR TITLE
[ty] Use an interval map for scopes by expression

### DIFF
--- a/crates/ruff_python_ast/src/node_index.rs
+++ b/crates/ruff_python_ast/src/node_index.rs
@@ -49,6 +49,16 @@ impl NodeIndex {
     pub fn as_usize(self) -> usize {
         self.0 as _
     }
+
+    pub fn as_u32(self) -> u32 {
+        self.0
+    }
+}
+
+impl From<u32> for NodeIndex {
+    fn from(value: u32) -> Self {
+        NodeIndex(value)
+    }
 }
 
 impl From<u32> for AtomicNodeIndex {

--- a/crates/ty_python_semantic/src/semantic_index.rs
+++ b/crates/ty_python_semantic/src/semantic_index.rs
@@ -622,7 +622,7 @@ impl FusedIterator for ChildrenIter<'_> {}
 /// Lookups require `O(log n)` time, where `n` is roughly the number of scopes (roughly
 /// because sub-scopes can be interleaved with expressions in the outer scope, e.g. function, some statements, a function).
 #[derive(Eq, PartialEq, Debug, get_size2::GetSize, Default)]
-struct ExpressionsScopeMap(Box<[(std::ops::Range<NodeIndex>, FileScopeId)]>);
+struct ExpressionsScopeMap(Box<[(std::ops::RangeInclusive<NodeIndex>, FileScopeId)]>);
 
 impl ExpressionsScopeMap {
     fn try_get<E>(&self, node: &E) -> Option<FileScopeId>
@@ -633,7 +633,7 @@ impl ExpressionsScopeMap {
 
         let entry = self
             .0
-            .binary_search_by_key(&node_index, |(range, _)| range.start);
+            .binary_search_by_key(&node_index, |(range, _)| *range.start());
 
         let index = match entry {
             Ok(index) => index,

--- a/crates/ty_python_semantic/src/semantic_index.rs
+++ b/crates/ty_python_semantic/src/semantic_index.rs
@@ -5,6 +5,7 @@ use ruff_db::files::File;
 use ruff_db::parsed::parsed_module;
 use ruff_index::{IndexSlice, IndexVec};
 
+use ruff_python_ast::NodeIndex;
 use ruff_python_parser::semantic_errors::SemanticSyntaxError;
 use rustc_hash::{FxHashMap, FxHashSet};
 use salsa::Update;
@@ -24,6 +25,7 @@ use crate::semantic_index::place::{
     ScopeKind, ScopedPlaceId,
 };
 use crate::semantic_index::use_def::{EagerSnapshotKey, ScopedEagerSnapshotId, UseDefMap};
+use crate::semantic_model::HasTrackedScope;
 use crate::util::get_size::untracked_arc_size;
 
 pub mod ast_ids;
@@ -203,7 +205,7 @@ pub(crate) struct SemanticIndex<'db> {
     scopes: IndexVec<FileScopeId, Scope>,
 
     /// Map expressions to their corresponding scope.
-    scopes_by_expression: FxHashMap<ExpressionNodeKey, FileScopeId>,
+    scopes_by_expression: ExpressionsScopeMap,
 
     /// Map from a node creating a definition to its definition.
     definitions_by_node: FxHashMap<DefinitionNodeKey, Definitions<'db>>,
@@ -268,25 +270,26 @@ impl<'db> SemanticIndex<'db> {
 
     /// Returns the ID of the `expression`'s enclosing scope.
     #[track_caller]
-    pub(crate) fn expression_scope_id(
-        &self,
-        expression: impl Into<ExpressionNodeKey>,
-    ) -> FileScopeId {
-        self.scopes_by_expression[&expression.into()]
+    pub(crate) fn expression_scope_id<E>(&self, expression: &E) -> FileScopeId
+    where
+        E: HasTrackedScope,
+    {
+        self.try_expression_scope_id(expression)
+            .expect("Expression to be part of a scope if it is from the same module")
     }
 
     /// Returns the ID of the `expression`'s enclosing scope.
-    pub(crate) fn try_expression_scope_id(
-        &self,
-        expression: impl Into<ExpressionNodeKey>,
-    ) -> Option<FileScopeId> {
-        self.scopes_by_expression.get(&expression.into()).copied()
+    pub(crate) fn try_expression_scope_id<E>(&self, expression: &E) -> Option<FileScopeId>
+    where
+        E: HasTrackedScope,
+    {
+        self.scopes_by_expression.try_get(expression)
     }
 
     /// Returns the [`Scope`] of the `expression`'s enclosing scope.
     #[allow(unused)]
     #[track_caller]
-    pub(crate) fn expression_scope(&self, expression: impl Into<ExpressionNodeKey>) -> &Scope {
+    pub(crate) fn expression_scope(&self, expression: &impl HasTrackedScope) -> &Scope {
         &self.scopes[self.expression_scope_id(expression)]
     }
 
@@ -613,6 +616,40 @@ impl<'a> Iterator for ChildrenIter<'a> {
 }
 
 impl FusedIterator for ChildrenIter<'_> {}
+
+/// Interval map that maps a range of expression node ids to their corresponding scopes.
+///
+/// Lookups require `O(log n)` time, where `n` is roughly the number of scopes (roughly
+/// becaues sub-scopes can be interleaved with expressions in the outer scope, e.g. function, some statements, a function).
+#[derive(Eq, PartialEq, Debug, get_size2::GetSize)]
+struct ExpressionsScopeMap {
+    scopes_by_expression: Box<[(std::ops::Range<NodeIndex>, FileScopeId)]>,
+}
+
+impl ExpressionsScopeMap {
+    fn try_get<E>(&self, node: &E) -> Option<FileScopeId>
+    where
+        E: HasTrackedScope,
+    {
+        let node_index = node.node_index().load();
+
+        let entry = self
+            .scopes_by_expression
+            .binary_search_by_key(&node_index, |(range, _)| range.start);
+
+        let index = match entry {
+            Ok(index) => index,
+            Err(index) => index.checked_sub(1)?,
+        };
+
+        let (range, scope_id) = &self.scopes_by_expression[index];
+        if range.contains(&node_index) {
+            Some(*scope_id)
+        } else {
+            None
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/ty_python_semantic/src/semantic_index/builder.rs
+++ b/crates/ty_python_semantic/src/semantic_index/builder.rs
@@ -10,7 +10,7 @@ use ruff_db::source::{SourceText, source_text};
 use ruff_index::IndexVec;
 use ruff_python_ast::name::Name;
 use ruff_python_ast::visitor::{Visitor, walk_expr, walk_pattern, walk_stmt};
-use ruff_python_ast::{self as ast, NodeIndex, PySourceType, PythonVersion};
+use ruff_python_ast::{self as ast, HasNodeIndex, NodeIndex, PySourceType, PythonVersion};
 use ruff_python_parser::semantic_errors::{
     SemanticSyntaxChecker, SemanticSyntaxContext, SemanticSyntaxError, SemanticSyntaxErrorKind,
 };
@@ -2708,18 +2708,18 @@ impl ExpressionsScopeMapBuilder {
         let mut interval_map = Vec::new();
 
         let mut current_scope = first.1;
-        let mut range = first.0..NodeIndex::from(first.0.as_u32() + 1);
+        let mut range = first.0..=NodeIndex::from(first.0.as_u32() + 1);
 
         for (index, scope) in iter {
             if scope == current_scope {
-                range.end = NodeIndex::from(index.as_u32() + 1);
+                range = *range.start()..=index;
                 continue;
             }
 
             interval_map.push((range, current_scope));
 
             current_scope = scope;
-            range = index..NodeIndex::from(index.as_u32() + 1);
+            range = index..=index;
         }
 
         interval_map.push((range, current_scope));


### PR DESCRIPTION
## Summary

The semantic index stores a map from expression to scope because we need to know in which `TypeInference` (scope) to look up the expression's type. Today, we use a hash map to store the expression-to-scope mapping. 

This PR replaces the hash map with an interval map (vector-based) that maps a range of node IDs (expressions) to their corresponding scope. The advantage of an interval map over a hash map is that it reduces memory consumption from `O(expressions)` to `O(~scopes)`. 

The main downside (other than increased complexity) is that the lookup complexity increases from `O(1)` to `O(log(~scopes))`. Looking at the benchmark results, the fact that we need to write less data outweighs the slightly slower lookup times. 

The instrumented benchmarks show a 1-2% performance improvement. I measured memory consumption on a large project and the overall memory consumption of all semantic indices decreased by about 5%,

## Test plan

`cargo test`