### PR TITLE
[`flake8-bandit`] Make `S604` and `S609` examples error out-of-the-box

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/shell_injection.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/shell_injection.rs
@@ -108,10 +108,10 @@ impl Violation for SubprocessWithoutShellEqualsTrue {
 ///
 /// ## Example
 /// ```python
-/// import subprocess
+/// import my_custom_subprocess
 ///
 /// user_input = input("Enter a command: ")
-/// subprocess.run(user_input, shell=True)
+/// my_custom_subprocess.run(user_input, shell=True)
 /// ```
 ///
 /// ## References
@@ -265,14 +265,14 @@ impl Violation for StartProcessWithPartialPath {
 /// ```python
 /// import subprocess
 ///
-/// subprocess.Popen(["chmod", "777", "*.py"])
+/// subprocess.Popen(["chmod", "777", "*.py"], shell=True)
 /// ```
 ///
 /// Use instead:
 /// ```python
 /// import subprocess
 ///
-/// subprocess.Popen(["chmod", "777", "main.py"])
+/// subprocess.Popen(["chmod", "777", "main.py"], shell=True)
 /// ```
 ///
 /// ## References


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Part of #18972

Both in one PR since they are in the same file.

S604
---

This PR makes [call-with-shell-equals-true (S604)](https://docs.astral.sh/ruff/rules/call-with-shell-equals-true/#call-with-shell-equals-true-s604)'s example error out-of-the-box

[Old example](https://play.ruff.rs/a054fb79-7653-47f7-9ab5-3d8b7540c810)
```py
import subprocess

user_input = input("Enter a command: ")
subprocess.run(user_input, shell=True)
```

[New example](https://play.ruff.rs/6fea81b4-e745-4b85-8bea-faaabea5c86d)
```py
import my_custom_subprocess

user_input = input("Enter a command: ")
my_custom_subprocess.run(user_input, shell=True)
```

The old example doesn't raise `S604` because it gets overwritten by [subprocess-popen-with-shell-equals-true (S602)](https://docs.astral.sh/ruff/rules/subprocess-popen-with-shell-equals-true/#subprocess-popen-with-shell-equals-true-s602) (which is a good idea to prevent two lints saying the same thing from being raised)

S609
---

This PR makes [unix-command-wildcard-injection (S609)](https://docs.astral.sh/ruff/rules/unix-command-wildcard-injection/#unix-command-wildcard-injection-s609)'s example error out-of-the-box

[Old example](https://play.ruff.rs/849860fa-0d12-4916-bdbc-64a0fa14cd9b)
```py
import subprocess

subprocess.Popen(["chmod", "777", "*.py"])
```

[New example](https://play.ruff.rs/77a54d7c-cf78-4158-bcf8-96dd698cf366)
```py
import subprocess

subprocess.Popen(["chmod", "777", "*.py"], shell=True)
```

I'm not familiar enough with `subprocess` to know why `shell=True` is required to make `S609` raise here, but it works.

## Test Plan

<!-- How was it tested? -->

N/A, no functionality/tests affected