### PR TITLE
[`flake8-bugbear`] Make `B911` example error out-of-the-box

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/batched_without_explicit_strict.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/batched_without_explicit_strict.rs
@@ -20,16 +20,22 @@ use crate::{FixAvailability, Violation};
 ///
 /// ## Example
 /// ```python
+/// import itertools
+///
 /// itertools.batched(iterable, n)
 /// ```
 ///
 /// Use instead if the batches must be of uniform length:
 /// ```python
+/// import itertools
+///
 /// itertools.batched(iterable, n, strict=True)
 /// ```
 ///
 /// Or if the batches can be of non-uniform length:
 /// ```python
+/// import itertools
+///
 /// itertools.batched(iterable, n, strict=False)
 /// ```
 ///


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Part of #18972

This PR makes [batched-without-explicit-strict (B911)](https://docs.astral.sh/ruff/rules/batched-without-explicit-strict/#batched-without-explicit-strict-b911)'s example error out-of-the-box

[Old example](https://play.ruff.rs/a897d96b-0749-4291-8a62-dfd4caf290a0)
```py
itertools.batched(iterable, n)
```

[New example](https://play.ruff.rs/1c1e0ab7-014c-4dc2-abed-c2cb6cd01f70)
```py
import itertools

itertools.batched(iterable, n)
```

Imports were also added to the "use instead" sections

## Test Plan

<!-- How was it tested? -->

N/A, no functionality/tests affected