### PR TITLE
[`flake8-bugbear`] Make `B028` example error out-of-the-box

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/no_explicit_stacklevel.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/no_explicit_stacklevel.rs
@@ -20,11 +20,15 @@ use crate::{checkers::ast::Checker, fix::edits::add_argument};
 ///
 /// ## Example
 /// ```python
+/// import warnings
+///
 /// warnings.warn("This is a warning")
 /// ```
 ///
 /// Use instead:
 /// ```python
+/// import warnings
+///
 /// warnings.warn("This is a warning", stacklevel=2)
 /// ```
 ///


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Part of #18972

This PR makes [no-explicit-stacklevel (B028)](https://docs.astral.sh/ruff/rules/no-explicit-stacklevel/#no-explicit-stacklevel-b028)'s example error out-of-the-box

[Old example](https://play.ruff.rs/1ee80aec-2d6e-4a3f-8e98-da82b6a9f544)
```py
warnings.warn("This is a warning")
```

[New example](https://play.ruff.rs/343593aa-38a0-4d76-a32b-5abd0a4306cc)
```py
import warnings

warnings.warn("This is a warning")
```

Imports were also added to the "use instead" section

## Test Plan

<!-- How was it tested? -->

N/A, no functionality/tests affected