### PR TITLE
[`flake8-datetimez`] Make `DTZ901` example error out-of-the-box

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/datetime_min_max.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/datetime_min_max.rs
@@ -18,19 +18,25 @@ use crate::checkers::ast::Checker;
 /// unexpectedly, as in:
 ///
 /// ```python
+/// import datetime
+///
 /// # Timezone: UTC-14
-/// datetime.min.timestamp()  # ValueError: year 0 is out of range
-/// datetime.max.timestamp()  # ValueError: year 10000 is out of range
+/// datetime.datetime.min.timestamp()  # ValueError: year 0 is out of range
+/// datetime.datetime.max.timestamp()  # ValueError: year 10000 is out of range
 /// ```
 ///
 /// ## Example
 /// ```python
-/// datetime.max
+/// import datetime
+///
+/// datetime.datetime.max
 /// ```
 ///
 /// Use instead:
 /// ```python
-/// datetime.max.replace(tzinfo=datetime.UTC)
+/// import datetime
+///
+/// datetime.datetime.max.replace(tzinfo=datetime.UTC)
 /// ```
 #[derive(ViolationMetadata)]
 pub(crate) struct DatetimeMinMax {


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Part of #18972

This PR makes [datetime-min-max (DTZ901)](https://docs.astral.sh/ruff/rules/datetime-min-max/#datetime-min-max-dtz901)'s example error out-of-the-box

[Old example](https://play.ruff.rs/c1202727-1a18-4d3f-92a4-334ede07ed3e)
```py
datetime.max
```

[New example](https://play.ruff.rs/af2c76aa-9beb-46bc-8e27-faf53ecdbe8c)
```py
import datetime

datetime.datetime.max
```

I also added imports to the problem demonstration and use instead.

## Test Plan

<!-- How was it tested? -->

N/A, no functionality/tests affected