### PR TITLE
[ty] Support LSP go-to with vendored typeshed stubs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4232,6 +4232,7 @@ dependencies = [
  "ty_ide",
  "ty_project",
  "ty_python_semantic",
+ "ty_vendored",
 ]
 
 [[package]]
@@ -4271,6 +4272,7 @@ version = "0.0.0"
 dependencies = [
  "path-slash",
  "ruff_db",
+ "static_assertions",
  "walkdir",
  "zip",
 ]

--- a/crates/ruff_db/src/system/os.rs
+++ b/crates/ruff_db/src/system/os.rs
@@ -160,6 +160,39 @@ impl System for OsSystem {
         None
     }
 
+    /// Returns an absolute cache directory on the system.
+    ///
+    /// On Linux and macOS, uses `$XDG_CACHE_HOME/ty` or `.cache/ty`.
+    /// On Windows, uses `C:\Users\User\AppData\Local\ty\cache`.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn cache_dir(&self) -> Option<SystemPathBuf> {
+        use etcetera::BaseStrategy as _;
+
+        let cache_dir = etcetera::base_strategy::choose_base_strategy()
+            .ok()
+            .map(|dirs| dirs.cache_dir().join("ty"))
+            .map(|cache_dir| {
+                if cfg!(windows) {
+                    // On Windows, we append `cache` to the LocalAppData directory, i.e., prefer
+                    // `C:\Users\User\AppData\Local\ty\cache` over `C:\Users\User\AppData\Local\ty`.
+                    cache_dir.join("cache")
+                } else {
+                    cache_dir
+                }
+            })
+            .and_then(|path| SystemPathBuf::from_path_buf(path).ok())
+            .unwrap_or_else(|| SystemPathBuf::from(".ty_cache"));
+
+        Some(cache_dir)
+    }
+
+    // TODO: Remove this feature gating once `ruff_wasm` no longer indirectly depends on `ruff_db` with the
+    //   `os` feature enabled (via `ruff_workspace` -> `ruff_graph` -> `ruff_db`).
+    #[cfg(target_arch = "wasm32")]
+    fn cache_dir(&self) -> Option<SystemPathBuf> {
+        None
+    }
+
     /// Creates a builder to recursively walk `path`.
     ///
     /// The walker ignores files according to [`ignore::WalkBuilder::standard_filters`]
@@ -190,6 +223,10 @@ impl System for OsSystem {
             let boxed: Box<dyn Iterator<Item = _>> = Box::new(iterator);
             boxed
         })
+    }
+
+    fn as_writable(&self) -> Option<&dyn WritableSystem> {
+        Some(self)
     }
 
     fn as_any(&self) -> &dyn Any {
@@ -310,6 +347,10 @@ impl OsSystem {
 }
 
 impl WritableSystem for OsSystem {
+    fn create_new_file(&self, path: &SystemPath) -> Result<()> {
+        std::fs::File::create_new(path).map(drop)
+    }
+
     fn write_file(&self, path: &SystemPath, content: &str) -> Result<()> {
         std::fs::write(path.as_std_path(), content)
     }

--- a/crates/ruff_db/src/system/test.rs
+++ b/crates/ruff_db/src/system/test.rs
@@ -102,6 +102,10 @@ impl System for TestSystem {
         self.system().user_config_directory()
     }
 
+    fn cache_dir(&self) -> Option<SystemPathBuf> {
+        self.system().cache_dir()
+    }
+
     fn read_directory<'a>(
         &'a self,
         path: &SystemPath,
@@ -121,6 +125,10 @@ impl System for TestSystem {
         PatternError,
     > {
         self.system().glob(pattern)
+    }
+
+    fn as_writable(&self) -> Option<&dyn WritableSystem> {
+        Some(self)
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
@@ -149,6 +157,10 @@ impl Default for TestSystem {
 }
 
 impl WritableSystem for TestSystem {
+    fn create_new_file(&self, path: &SystemPath) -> Result<()> {
+        self.system().create_new_file(path)
+    }
+
     fn write_file(&self, path: &SystemPath, content: &str) -> Result<()> {
         self.system().write_file(path, content)
     }
@@ -335,6 +347,10 @@ impl System for InMemorySystem {
         self.user_config_directory.lock().unwrap().clone()
     }
 
+    fn cache_dir(&self) -> Option<SystemPathBuf> {
+        None
+    }
+
     fn read_directory<'a>(
         &'a self,
         path: &SystemPath,
@@ -357,6 +373,10 @@ impl System for InMemorySystem {
         Ok(Box::new(iterator))
     }
 
+    fn as_writable(&self) -> Option<&dyn WritableSystem> {
+        Some(self)
+    }
+
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
@@ -377,6 +397,10 @@ impl System for InMemorySystem {
 }
 
 impl WritableSystem for InMemorySystem {
+    fn create_new_file(&self, path: &SystemPath) -> Result<()> {
+        self.memory_fs.create_new_file(path)
+    }
+
     fn write_file(&self, path: &SystemPath, content: &str) -> Result<()> {
         self.memory_fs.write_file(path, content)
     }

--- a/crates/ruff_db/src/vendored.rs
+++ b/crates/ruff_db/src/vendored.rs
@@ -4,12 +4,12 @@ use std::fmt::{self, Debug};
 use std::io::{self, Read, Write};
 use std::sync::{Arc, Mutex, MutexGuard};
 
-use crate::file_revision::FileRevision;
 use zip::result::ZipResult;
 use zip::write::FileOptions;
 use zip::{CompressionMethod, ZipArchive, ZipWriter, read::ZipFile};
 
 pub use self::path::{VendoredPath, VendoredPathBuf};
+use crate::file_revision::FileRevision;
 
 mod path;
 

--- a/crates/ty_server/Cargo.toml
+++ b/crates/ty_server/Cargo.toml
@@ -19,6 +19,7 @@ ruff_text_size = { workspace = true }
 ty_ide = { workspace = true }
 ty_project = { workspace = true }
 ty_python_semantic = { workspace = true }
+ty_vendored = { workspace = true }
 
 anyhow = { workspace = true }
 crossbeam = { workspace = true }

--- a/crates/ty_test/src/db.rs
+++ b/crates/ty_test/src/db.rs
@@ -235,6 +235,10 @@ impl System for MdtestSystem {
         self.as_system().user_config_directory()
     }
 
+    fn cache_dir(&self) -> Option<SystemPathBuf> {
+        self.as_system().cache_dir()
+    }
+
     fn read_directory<'a>(
         &'a self,
         path: &SystemPath,
@@ -262,6 +266,10 @@ impl System for MdtestSystem {
             .glob(self.normalize_path(SystemPath::new(pattern)).as_str())
     }
 
+    fn as_writable(&self) -> Option<&dyn WritableSystem> {
+        Some(self)
+    }
+
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
@@ -272,6 +280,10 @@ impl System for MdtestSystem {
 }
 
 impl WritableSystem for MdtestSystem {
+    fn create_new_file(&self, path: &SystemPath) -> ruff_db::system::Result<()> {
+        self.as_system().create_new_file(&self.normalize_path(path))
+    }
+
     fn write_file(&self, path: &SystemPath, content: &str) -> ruff_db::system::Result<()> {
         self.as_system()
             .write_file(&self.normalize_path(path), content)

--- a/crates/ty_vendored/Cargo.toml
+++ b/crates/ty_vendored/Cargo.toml
@@ -12,6 +12,7 @@ license = { workspace = true }
 
 [dependencies]
 ruff_db = { workspace = true }
+static_assertions = { workspace = true }
 zip = { workspace = true }
 
 [build-dependencies]

--- a/crates/ty_vendored/src/lib.rs
+++ b/crates/ty_vendored/src/lib.rs
@@ -1,6 +1,12 @@
 use ruff_db::vendored::VendoredFileSystem;
 use std::sync::LazyLock;
 
+/// The source commit of the vendored typeshed.
+pub const SOURCE_COMMIT: &str =
+    include_str!("../../../crates/ty_vendored/vendor/typeshed/source_commit.txt").trim_ascii_end();
+
+static_assertions::const_assert_eq!(SOURCE_COMMIT.len(), 40);
+
 // The file path here is hardcoded in this crate's `build.rs` script.
 // Luckily this crate will fail to build if this file isn't available at build time.
 static TYPESHED_ZIP_BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/zipped_typeshed.zip"));

--- a/crates/ty_wasm/src/lib.rs
+++ b/crates/ty_wasm/src/lib.rs
@@ -7,7 +7,7 @@ use ruff_db::source::{line_index, source_text};
 use ruff_db::system::walk_directory::WalkDirectoryBuilder;
 use ruff_db::system::{
     CaseSensitivity, DirectoryEntry, GlobError, MemoryFileSystem, Metadata, PatternError, System,
-    SystemPath, SystemPathBuf, SystemVirtualPath,
+    SystemPath, SystemPathBuf, SystemVirtualPath, WritableSystem,
 };
 use ruff_db::{Db as _, Upcast};
 use ruff_notebook::Notebook;
@@ -695,6 +695,10 @@ impl System for WasmSystem {
         None
     }
 
+    fn cache_dir(&self) -> Option<SystemPathBuf> {
+        None
+    }
+
     fn read_directory<'a>(
         &'a self,
         path: &SystemPath,
@@ -713,6 +717,10 @@ impl System for WasmSystem {
         pattern: &str,
     ) -> Result<Box<dyn Iterator<Item = Result<SystemPathBuf, GlobError>> + '_>, PatternError> {
         Ok(Box::new(self.fs.glob(pattern)?))
+    }
+
+    fn as_writable(&self) -> Option<&dyn WritableSystem> {
+        None
     }
 
     fn as_any(&self) -> &dyn Any {


### PR DESCRIPTION
## Summary

Extracts the vendored typeshed stubs lazily and caches them on the local filesystem to support go-to in the LSP.

Resolves https://github.com/astral-sh/ty/issues/77.

## Test Plan

https://github.com/user-attachments/assets/2d949a97-6f78-40ff-9788-84a6c1fc0c8b