### PR TITLE
Run mypy-primer with `TY_MAX_PARALLELISM=1`

### DIFF
--- a/.github/workflows/mypy_primer.yaml
+++ b/.github/workflows/mypy_primer.yaml
@@ -81,6 +81,7 @@ jobs:
             --new "$GITHUB_SHA" \
             --project-selector "/($PRIMER_SELECTOR)\$" \
             --output concise \
+            --concurrency 256 \
             --debug > mypy_primer.diff || [ $? -eq 1 ]
 
           # Output diff with ANSI color codes

--- a/.github/workflows/mypy_primer.yaml
+++ b/.github/workflows/mypy_primer.yaml
@@ -49,6 +49,7 @@ jobs:
       - name: Run mypy_primer
         shell: bash
         env:
+          TY_MAX_PARALLELISM: 1
           TY_MEMORY_REPORT: mypy_primer
         run: |
           cd ruff

--- a/.github/workflows/mypy_primer.yaml
+++ b/.github/workflows/mypy_primer.yaml
@@ -49,7 +49,6 @@ jobs:
       - name: Run mypy_primer
         shell: bash
         env:
-          TY_MAX_PARALLELISM: 1
           TY_MEMORY_REPORT: mypy_primer
         run: |
           cd ruff
@@ -81,7 +80,7 @@ jobs:
             --new "$GITHUB_SHA" \
             --project-selector "/($PRIMER_SELECTOR)\$" \
             --output concise \
-            --concurrency 256 \
+            --concurrency 4 \
             --debug > mypy_primer.diff || [ $? -eq 1 ]
 
           # Output diff with ANSI color codes


### PR DESCRIPTION
## Summary

The memory usage numbers are currently flaky partly due to memory usage being non-deterministic in multi-threaded runs. Running ty in single-threaded mode in the mypy-primer mode should fix this. From what I understand, mypy-primer has parallelism internally so this might not be significantly slower, but if it is then we'll need a separate CI job for memory usage.
