### PR TITLE
[`flake8-pyi`] Make `PYI032` example error out-of-the-box

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/any_eq_ne_annotation.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/any_eq_ne_annotation.rs
@@ -30,7 +30,6 @@ use crate::{AlwaysFixableViolation, Edit, Fix};
 /// ```pyi
 /// from typing import Any
 ///
-///
 /// class Foo:
 ///     def __eq__(self, obj: Any) -> bool: ...
 /// ```


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Part of #18972

This PR makes [datetime-min-max (DTZ901)](https://docs.astral.sh/ruff/rules/datetime-min-max/#datetime-min-max-dtz901)'s example error out-of-the-box

[Old example](https://play.ruff.rs/7e825d76-8a68-47fb-97ba-3da08fd46d02)
```py
class Foo:
    def __eq__(self, obj: typing.Any) -> bool: ...
```

[New example](https://play.ruff.rs/1353cb24-efa9-43f6-8bfe-d27007e55fbd)
```py
from typing import Any


class Foo:
    def __eq__(self, obj: Any) -> bool: ...
```

## Test Plan

<!-- How was it tested? -->

N/A, no functionality/tests affected