### PR TITLE
[ty] 

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/callable.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/callable.md
@@ -381,7 +381,7 @@ def f_okay(c: Callable[[], None]):
     if hasattr(c, "__qualname__"):
         c.__qualname__  # okay
         # `hasattr` only guarantees that an attribute is readable.
-        # error: [invalid-assignment] "Object of type `Literal["my_callable"]` is not assignable to attribute `__qualname__` on type `(() -> None) & <Protocol with members '__qualname__'>`"
+        # error: [invalid-assignment] "Object of type `Literal["my_callable"]` is not assignable to attribute `__qualname__` of type `(() -> None) & <Protocol with members '__qualname__'>`"
         c.__qualname__ = "my_callable"
 
         result = getattr_static(c, "__qualname__")

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -1100,7 +1100,7 @@ def _(flag: bool):
     reveal_type(C1.y)  # revealed: int | str
 
     C1.y = 100
-    # error: [invalid-assignment] "Object of type `Literal["problematic"]` is not assignable to attribute `y` on type `<class 'C1'> | <class 'C1'>`"
+    # error: [invalid-assignment] "Object of type `Literal["problematic"]` is not assignable to attribute `y` of type `<class 'C1'> | <class 'C1'>`"
     C1.y = "problematic"
 
     class C2:
@@ -1180,13 +1180,13 @@ def _(flag1: bool, flag2: bool):
     # error: [possibly-unbound-attribute] "Attribute `x` on type `<class 'C1'> | <class 'C2'> | <class 'C3'>` is possibly unbound"
     reveal_type(C.x)  # revealed: Unknown | Literal[1, 3]
 
-    # error: [invalid-assignment] "Object of type `Literal[100]` is not assignable to attribute `x` on type `<class 'C1'> | <class 'C2'> | <class 'C3'>`"
+    # error: [invalid-assignment] "Object of type `Literal[100]` is not assignable to attribute `x` of type `<class 'C1'> | <class 'C2'> | <class 'C3'>`"
     C.x = 100
 
     # error: [possibly-unbound-attribute] "Attribute `x` on type `C1 | C2 | C3` is possibly unbound"
     reveal_type(C().x)  # revealed: Unknown | Literal[1, 3]
 
-    # error: [invalid-assignment] "Object of type `Literal[100]` is not assignable to attribute `x` on type `C1 | C2 | C3`"
+    # error: [invalid-assignment] "Object of type `Literal[100]` is not assignable to attribute `x` of type `C1 | C2 | C3`"
     C().x = 100
 ```
 
@@ -1345,7 +1345,7 @@ def _(flag: bool):
 
     # TODO: This should ideally be a `unresolved-attribute` error. We need better union
     # handling in `validate_attribute_assignment` for this.
-    # error: [invalid-assignment] "Object of type `Literal[1]` is not assignable to attribute `x` on type `<class 'C1'> | <class 'C2'>`"
+    # error: [invalid-assignment] "Object of type `Literal[1]` is not assignable to attribute `x` of type `<class 'C1'> | <class 'C2'>`"
     C.x = 1
 ```
 
@@ -1934,7 +1934,7 @@ def _(flag: bool):
 
     mod.global_symbol = "b"
 
-    # error: [invalid-assignment] "Object of type `Literal[1]` is not assignable to attribute `global_symbol` on type `<module 'mod1'> | <module 'mod2'>`"
+    # error: [invalid-assignment] "Object of type `Literal[1]` is not assignable to attribute `global_symbol` of type `<module 'mod1'> | <module 'mod2'>`"
     mod.global_symbol = 1
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/narrow/complex_target.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/complex_target.md
@@ -88,6 +88,95 @@ if c.x is None:
 reveal_type(c.x)  # revealed: int | None
 ```
 
+### Constraints on attributes can constrain objects
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Literal
+
+class C:
+    tag: Literal["C"]
+    value: int
+
+class D:
+    tag: Literal["D"]
+    value: str
+
+def _(x: C | D, xs: list[C | D]):
+    if x.tag == "C":
+        reveal_type(x)  # revealed: C
+        reveal_type(x.value)  # revealed: int
+    elif x.tag == "D":
+        reveal_type(x)  # revealed: D
+        reveal_type(x.value)  # revealed: str
+    else:
+        reveal_type(x)  # revealed: Never
+        raise Exception("unreachable")
+
+    if xs[0].tag == "C":
+        reveal_type(xs[0])  # revealed: C
+        reveal_type(xs[1])  # revealed: C | D
+
+class CWrapper:
+    inner: C
+
+class DWrapper:
+    inner: D
+
+def _(x: CWrapper | DWrapper):
+    if x.inner.tag == "C":
+        reveal_type(x)  # revealed: CWrapper
+        reveal_type(x.inner)  # revealed: C
+        reveal_type(x.inner.value)  # revealed: int
+    elif x.inner.tag == "D":
+        reveal_type(x)  # revealed: DWrapper
+        reveal_type(x.inner)  # revealed: D
+        reveal_type(x.inner.value)  # revealed: str
+    else:
+        reveal_type(x)  # revealed: Never
+        raise Exception("unreachable")
+
+class E:
+    c_or_d: C | D
+
+def _(x: E):
+    if x.c_or_d.tag == "C":
+        reveal_type(x.c_or_d)  # revealed: C
+        reveal_type(x.c_or_d.value)  # revealed: int
+
+class F[T]:
+    x: T
+    y: T
+
+def _[T](f: F[T]):
+    if isinstance(f.x, int):
+        reveal_type(f)  # revealed: F[T] & <Protocol with members 'x'>
+        reveal_type(f.x)  # revealed: T & int
+        # Narrowing down the type of `y` is unsound because there is a possibility that, for example, `T = int | str`.
+        reveal_type(f.y)  # revealed: T
+
+class BadStr(str):
+    def __eq__(self, other: object) -> bool:
+        return True
+
+class G:
+    tag: str = BadStr("G")
+    value: int
+
+class H:
+    tag: str = BadStr("H")
+    value: str
+
+def _(x: G | H):
+    if x.tag == "G":
+        reveal_type(x)  # revealed: G | H
+        reveal_type(x.value)  # revealed: int | str
+```
+
 ### Multiple predicates
 
 ```py
@@ -143,12 +232,12 @@ def g[T](c: C[T]):
     if isinstance(c.x, int):
         reveal_type(c.x)  # revealed: T & int
         reveal_type(c.y)  # revealed: T
-        reveal_type(c)  # revealed: C[T]
+        reveal_type(c)  # revealed: C[T] & <Protocol with members 'x'>
     if isinstance(c.x, int) and isinstance(c.y, int):
         reveal_type(c.x)  # revealed: T & int
         reveal_type(c.y)  # revealed: T & int
         # TODO: Probably better if inferred as `C[T & int]` (mypy and pyright don't support this)
-        reveal_type(c)  # revealed: C[T]
+        reveal_type(c)  # revealed: C[T] & <Protocol with members 'x'> & <Protocol with members 'y'>
 ```
 
 ### With intermediate scopes

--- a/crates/ty_python_semantic/resources/mdtest/narrow/type_guards.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/type_guards.md
@@ -230,7 +230,7 @@ def _(a: tuple[Foo, Bar] | tuple[Bar, Foo], c: C[Any]):
         reveal_type(c.v)  # revealed: Any
 
     if reveal_type(is_bar(c.v)):  # revealed: TypeIs[Bar @ c.v]
-        reveal_type(c)  # revealed: C[Any]
+        reveal_type(c)  # revealed: C[Any] & <Protocol with members 'v'>
         reveal_type(c.v)  # revealed: Any & Bar
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -1109,10 +1109,16 @@ static_assert(is_subtype_of(XClassVar, HasXProperty))
 static_assert(is_assignable_to(XClassVar, HasXProperty))
 
 class XFinal:
-    x: Final = 42
+    x: Final[int] = 42
 
 static_assert(is_subtype_of(XFinal, HasXProperty))
 static_assert(is_assignable_to(XFinal, HasXProperty))
+
+class XImplicitFinal:
+    x: Final = 42
+
+static_assert(not is_subtype_of(XImplicitFinal, HasXProperty))
+static_assert(is_assignable_to(XImplicitFinal, HasXProperty))
 ```
 
 A read-only property on a protocol, unlike a mutable attribute, is covariant: `XSub` in the below
@@ -1150,9 +1156,8 @@ class XReadProperty:
     def x(self) -> int:
         return 42
 
-# TODO: these should pass
-static_assert(not is_subtype_of(XReadProperty, HasXProperty))  # error: [static-assert-error]
-static_assert(not is_assignable_to(XReadProperty, HasXProperty))  # error: [static-assert-error]
+static_assert(is_subtype_of(XReadProperty, HasXProperty))
+static_assert(is_assignable_to(XReadProperty, HasXProperty))
 
 class XReadWriteProperty:
     @property
@@ -1164,13 +1169,6 @@ class XReadWriteProperty:
 
 static_assert(is_subtype_of(XReadWriteProperty, HasXProperty))
 static_assert(is_assignable_to(XReadWriteProperty, HasXProperty))
-
-class XSub:
-    x: MyInt
-
-# TODO: should pass
-static_assert(not is_subtype_of(XSub, HasXProperty))  # error: [static-assert-error]
-static_assert(not is_assignable_to(XSub, HasXProperty))  # error: [static-assert-error]
 ```
 
 A protocol with a read/write property `x` is exactly equivalent to a protocol with a mutable
@@ -1237,9 +1235,8 @@ class MyIntSub(MyInt):
 class XAttrSubSub:
     x: MyIntSub
 
-# TODO: should pass
-static_assert(not is_subtype_of(XAttrSubSub, HasAsymmetricXProperty))  # error: [static-assert-error]
-static_assert(not is_assignable_to(XAttrSubSub, HasAsymmetricXProperty))  # error: [static-assert-error]
+static_assert(not is_subtype_of(XAttrSubSub, HasAsymmetricXProperty))
+static_assert(not is_assignable_to(XAttrSubSub, HasAsymmetricXProperty))
 ```
 
 An asymmetric property on a protocol can also be satisfied by an asymmetric property on a nominal
@@ -1266,7 +1263,7 @@ class Descriptor:
     def __get__(self, instance, owner) -> MyInt:
         return MyInt(0)
 
-    def __set__(self, value: int) -> None: ...
+    def __set__(self, instance, value: int) -> None: ...
 
 class XCustomDescriptor:
     x: Descriptor = Descriptor()
@@ -1296,9 +1293,8 @@ class HasGetAttrWithUnsuitableReturn:
     def __getattr__(self, attr: str) -> tuple[int, int]:
         return (1, 2)
 
-# TODO: these should pass
-static_assert(not is_subtype_of(HasGetAttrWithUnsuitableReturn, HasXProperty))  # error: [static-assert-error]
-static_assert(not is_assignable_to(HasGetAttrWithUnsuitableReturn, HasXProperty))  # error: [static-assert-error]
+static_assert(not is_subtype_of(HasGetAttrWithUnsuitableReturn, HasXProperty))
+static_assert(not is_assignable_to(HasGetAttrWithUnsuitableReturn, HasXProperty))
 
 class HasGetAttrAndSetAttr:
     def __getattr__(self, attr: str) -> MyInt:
@@ -1309,9 +1305,17 @@ class HasGetAttrAndSetAttr:
 static_assert(is_subtype_of(HasGetAttrAndSetAttr, HasXProperty))
 static_assert(is_assignable_to(HasGetAttrAndSetAttr, HasXProperty))
 
-# TODO: these should pass
-static_assert(is_subtype_of(HasGetAttrAndSetAttr, XAsymmetricProperty))  # error: [static-assert-error]
-static_assert(is_assignable_to(HasGetAttrAndSetAttr, XAsymmetricProperty))  # error: [static-assert-error]
+static_assert(is_subtype_of(HasGetAttrAndSetAttr, HasAsymmetricXProperty))
+static_assert(is_assignable_to(HasGetAttrAndSetAttr, HasAsymmetricXProperty))
+
+class HasSetAttrWithUnsuitableInput:
+    def __getattr__(self, attr: str) -> int:
+        return 1
+
+    def __setattr__(self, attr: str, value: str) -> None: ...
+
+static_assert(not is_subtype_of(HasSetAttrWithUnsuitableInput, HasMutableXProperty))
+static_assert(not is_assignable_to(HasSetAttrWithUnsuitableInput, HasMutableXProperty))
 ```
 
 ## Subtyping of protocols with method members

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment…_-_Attribute_assignment_-_Setting_attributes_o…_(467e26496f4c0c13).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment…_-_Attribute_assignment_-_Setting_attributes_o…_(467e26496f4c0c13).snap
@@ -37,7 +37,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/attribute_as
 # Diagnostics
 
 ```
-error[invalid-assignment]: Object of type `Literal[1]` is not assignable to attribute `attr` on type `<class 'C1'> | <class 'C1'>`
+error[invalid-assignment]: Object of type `Literal[1]` is not assignable to attribute `attr` of type `<class 'C1'> | <class 'C1'>`
   --> src/mdtest_snippet.py:11:5
    |
 10 |     # TODO: The error message here could be improved to explain why the assignment fails.

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
@@ -466,7 +466,7 @@ static_assert(is_disjoint_from(type[UsesMeta1], type[UsesMeta2]))
 
 ```py
 from ty_extensions import is_disjoint_from, static_assert, TypeOf
-from typing import final
+from typing import final, Protocol, Literal
 
 class C:
     @property
@@ -485,6 +485,29 @@ static_assert(not is_disjoint_from(Whatever, TypeOf[C.prop]))
 static_assert(not is_disjoint_from(TypeOf[C.prop], Whatever))
 static_assert(is_disjoint_from(TypeOf[C.prop], D))
 static_assert(is_disjoint_from(D, TypeOf[C.prop]))
+
+@final
+class E:
+    @property
+    def prop(self) -> int:
+        return 1
+
+class F:
+    prop: Literal["a"]
+
+class HasIntProp(Protocol):
+    @property
+    def prop(self) -> int: ...
+
+class HasReadWriteIntProp(Protocol):
+    @property
+    def prop(self) -> int: ...
+    @prop.setter
+    def prop(self, value: int) -> None: ...
+
+static_assert(not is_disjoint_from(HasIntProp, E))
+static_assert(is_disjoint_from(HasIntProp, F))
+static_assert(is_disjoint_from(HasReadWriteIntProp, E))
 ```
 
 ### `TypeGuard` and `TypeIs`

--- a/crates/ty_python_semantic/resources/mdtest/unreachable.md
+++ b/crates/ty_python_semantic/resources/mdtest/unreachable.md
@@ -197,8 +197,6 @@ could be improved.
 import sys
 
 if sys.platform == "win32":
-    # TODO: we should not emit an error here
-    # error: [possibly-unbound-attribute]
     sys.getwindowsversion()
 ```
 

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -829,6 +829,7 @@ fn place_from_bindings_impl<'db>(
     let predicates = bindings_with_constraints.predicates;
     let reachability_constraints = bindings_with_constraints.reachability_constraints;
     let boundness_analysis = bindings_with_constraints.boundness_analysis;
+    let use_additional_constraints = bindings_with_constraints.use_additional_constraints;
     let mut bindings_with_constraints = bindings_with_constraints.peekable();
 
     let is_non_exported = |binding: Definition<'db>| {
@@ -935,7 +936,12 @@ fn place_from_bindings_impl<'db>(
             }
 
             let binding_ty = binding_type(db, binding);
-            Some(narrowing_constraint.narrow(db, binding_ty, binding.place(db)))
+            Some(narrowing_constraint.narrow(
+                db,
+                binding_ty,
+                binding.place(db),
+                use_additional_constraints,
+            ))
         },
     );
 

--- a/crates/ty_python_semantic/src/semantic_index/place.rs
+++ b/crates/ty_python_semantic/src/semantic_index/place.rs
@@ -208,7 +208,7 @@ impl PlaceExpr {
             .is_some_and(|last| last.as_member().is_some())
     }
 
-    fn root_exprs(&self) -> RootExprs<'_> {
+    pub(crate) fn root_exprs(&self) -> RootExprs<'_> {
         RootExprs {
             expr_ref: self.into(),
             len: self.sub_segments.len(),
@@ -367,7 +367,13 @@ impl<'e> From<&'e PlaceExpr> for PlaceExprRef<'e> {
     }
 }
 
-struct RootExprs<'e> {
+impl PlaceExprRef<'_> {
+    pub(crate) fn member_name(&self) -> Option<&ast::name::Name> {
+        self.sub_segments.last().and_then(|last| last.as_member())
+    }
+}
+
+pub(crate) struct RootExprs<'e> {
     expr_ref: PlaceExprRef<'e>,
     len: usize,
 }

--- a/crates/ty_python_semantic/src/semantic_index/use_def.rs
+++ b/crates/ty_python_semantic/src/semantic_index/use_def.rs
@@ -522,6 +522,7 @@ impl<'db> UseDefMap<'db> {
             narrowing_constraints: &self.narrowing_constraints,
             reachability_constraints: &self.reachability_constraints,
             boundness_analysis,
+            use_additional_constraints: true,
             inner: bindings.iter(),
         }
     }
@@ -573,6 +574,7 @@ pub(crate) struct BindingWithConstraintsIterator<'map, 'db> {
     pub(crate) narrowing_constraints: &'map NarrowingConstraints,
     pub(crate) reachability_constraints: &'map ReachabilityConstraints,
     pub(crate) boundness_analysis: BoundnessAnalysis,
+    pub(crate) use_additional_constraints: bool,
     inner: LiveBindingsIterator<'map>,
 }
 
@@ -598,6 +600,15 @@ impl<'map, 'db> Iterator for BindingWithConstraintsIterator<'map, 'db> {
 }
 
 impl std::iter::FusedIterator for BindingWithConstraintsIterator<'_, '_> {}
+
+impl BindingWithConstraintsIterator<'_, '_> {
+    pub(crate) fn with_use_additional_constraints(self, use_additional_constraints: bool) -> Self {
+        BindingWithConstraintsIterator {
+            use_additional_constraints,
+            ..self
+        }
+    }
+}
 
 pub(crate) struct BindingWithConstraints<'map, 'db> {
     pub(crate) binding: DefinitionState<'db>,
@@ -628,9 +639,12 @@ impl<'db> ConstraintsIterator<'_, 'db> {
         db: &'db dyn crate::Db,
         base_ty: Type<'db>,
         place: ScopedPlaceId,
+        use_additional_constraints: bool,
     ) -> Type<'db> {
         let constraint_tys: Vec<_> = self
-            .filter_map(|constraint| infer_narrowing_constraint(db, constraint, place))
+            .filter_map(|constraint| {
+                infer_narrowing_constraint(db, constraint, place, use_additional_constraints)
+            })
             .collect();
 
         if constraint_tys.is_empty() {

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2,6 +2,7 @@ use infer::nearest_enclosing_class;
 use itertools::Either;
 use ruff_db::parsed::parsed_module;
 
+use std::ops::BitAnd;
 use std::slice::Iter;
 
 use bitflags::bitflags;
@@ -169,6 +170,61 @@ pub(crate) enum AttributeKind {
 impl AttributeKind {
     const fn is_data(self) -> bool {
         matches!(self, Self::DataDescriptor)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum AttributeAssignmentResult<'db> {
+    Ok,
+    PossiblyUnbound,
+    TypeMismatch(Type<'db>),
+    TypeMismatchAndPossiblyUnbound(Type<'db>),
+    TwoTypeMismatch(Type<'db>, Type<'db>),
+    TwoTypeMismatchAndPossiblyUnbound(Type<'db>, Type<'db>),
+    CannotAssign,
+    CannotAssignToClassVar,
+    CannotAssignToInstanceAttr,
+    ReadOnlyProperty,
+    FailToSet,
+    FailToSetAndPossiblyUnbound,
+    FailToSetAndTypeMismatch(Type<'db>),
+    FailToSetAndTypeMismatchAndPossiblyUnbound(Type<'db>),
+    FailToSetAttr,
+    Unresolved,
+}
+
+impl BitAnd<Boundness> for AttributeAssignmentResult<'_> {
+    type Output = Self;
+
+    fn bitand(self, rhs: Boundness) -> Self::Output {
+        match (self, rhs) {
+            (Self::Ok, Boundness::PossiblyUnbound) => Self::PossiblyUnbound,
+            (Self::TypeMismatch(ty), Boundness::PossiblyUnbound) => {
+                Self::TypeMismatchAndPossiblyUnbound(ty)
+            }
+            (Self::FailToSet, Boundness::PossiblyUnbound) => Self::FailToSetAndPossiblyUnbound,
+            (Self::FailToSetAndTypeMismatch(ty), Boundness::PossiblyUnbound) => {
+                Self::FailToSetAndTypeMismatchAndPossiblyUnbound(ty)
+            }
+            (other, _) => other,
+        }
+    }
+}
+
+impl AttributeAssignmentResult<'_> {
+    pub(crate) const fn is_not_err(&self) -> bool {
+        matches!(self, Self::Ok | Self::PossiblyUnbound)
+    }
+
+    pub(crate) const fn is_possibly_unbound(&self) -> bool {
+        matches!(
+            self,
+            Self::PossiblyUnbound
+                | Self::TypeMismatchAndPossiblyUnbound(_)
+                | Self::TwoTypeMismatchAndPossiblyUnbound(_, _)
+                | Self::FailToSetAndPossiblyUnbound
+                | Self::FailToSetAndTypeMismatchAndPossiblyUnbound(_)
+        )
     }
 }
 
@@ -4429,6 +4485,330 @@ impl<'db> Type<'db> {
             | Type::BoundSuper(_)
             | Type::ModuleLiteral(_)
             | Type::TypeIs(_) => CallableBinding::not_callable(self).into(),
+        }
+    }
+
+    /// Make sure that the attribute assignment `obj.attribute = value` is valid.
+    ///
+    /// `attribute` is the name of the attribute being assigned, and `value_ty` is the type of the right-hand side of
+    /// the assignment.
+    fn validate_attribute_assignment(
+        self,
+        db: &'db dyn Db,
+        attribute: &str,
+        value_ty: Type<'db>,
+    ) -> AttributeAssignmentResult<'db> {
+        let and = |l, r| match (l, r) {
+            (AttributeAssignmentResult::Ok, AttributeAssignmentResult::Ok) => {
+                AttributeAssignmentResult::Ok
+            }
+            (AttributeAssignmentResult::Ok, AttributeAssignmentResult::PossiblyUnbound) => {
+                AttributeAssignmentResult::PossiblyUnbound
+            }
+            (AttributeAssignmentResult::Ok, AttributeAssignmentResult::TypeMismatch(ty)) => {
+                AttributeAssignmentResult::TypeMismatch(ty)
+            }
+            (
+                AttributeAssignmentResult::Ok,
+                AttributeAssignmentResult::TypeMismatchAndPossiblyUnbound(ty),
+            ) => AttributeAssignmentResult::TypeMismatchAndPossiblyUnbound(ty),
+            (AttributeAssignmentResult::FailToSet, AttributeAssignmentResult::Ok) => {
+                AttributeAssignmentResult::FailToSet
+            }
+            (AttributeAssignmentResult::FailToSet, AttributeAssignmentResult::PossiblyUnbound) => {
+                AttributeAssignmentResult::FailToSetAndPossiblyUnbound
+            }
+            (AttributeAssignmentResult::FailToSet, AttributeAssignmentResult::TypeMismatch(ty)) => {
+                AttributeAssignmentResult::FailToSetAndTypeMismatch(ty)
+            }
+            (
+                AttributeAssignmentResult::FailToSet,
+                AttributeAssignmentResult::TypeMismatchAndPossiblyUnbound(ty),
+            ) => AttributeAssignmentResult::FailToSetAndTypeMismatchAndPossiblyUnbound(ty),
+            (AttributeAssignmentResult::TypeMismatch(ty), AttributeAssignmentResult::Ok) => {
+                AttributeAssignmentResult::TypeMismatch(ty)
+            }
+            (
+                AttributeAssignmentResult::TypeMismatch(ty),
+                AttributeAssignmentResult::PossiblyUnbound,
+            ) => AttributeAssignmentResult::TypeMismatchAndPossiblyUnbound(ty),
+            (
+                AttributeAssignmentResult::TypeMismatch(l),
+                AttributeAssignmentResult::TypeMismatch(r),
+            ) => AttributeAssignmentResult::TwoTypeMismatch(l, r),
+            (
+                AttributeAssignmentResult::TypeMismatch(l),
+                AttributeAssignmentResult::TypeMismatchAndPossiblyUnbound(r),
+            ) => AttributeAssignmentResult::TwoTypeMismatchAndPossiblyUnbound(l, r),
+            _ => unreachable!(),
+        };
+
+        let ensure_assignable_to = |attr_ty| -> AttributeAssignmentResult {
+            if value_ty.is_assignable_to(db, attr_ty) {
+                AttributeAssignmentResult::Ok
+            } else {
+                AttributeAssignmentResult::TypeMismatch(attr_ty)
+            }
+        };
+
+        match self {
+            Type::Union(union) => {
+                let mut boundness = Boundness::Bound;
+                if union.elements(db).iter().all(|elem| {
+                    let res = elem.validate_attribute_assignment(db, attribute, value_ty);
+                    if res.is_possibly_unbound() {
+                        boundness = Boundness::PossiblyUnbound;
+                    }
+                    res.is_not_err()
+                }) {
+                    AttributeAssignmentResult::Ok & boundness
+                } else {
+                    AttributeAssignmentResult::TypeMismatch(self) & boundness
+                }
+            }
+
+            Type::Intersection(intersection) => {
+                let mut boundness = Boundness::Bound;
+                // TODO: Handle negative intersection elements
+                if intersection.positive(db).iter().any(|elem| {
+                    let res = elem.validate_attribute_assignment(db, attribute, value_ty);
+                    if res.is_possibly_unbound() {
+                        boundness = Boundness::PossiblyUnbound;
+                    }
+                    res.is_not_err()
+                }) {
+                    AttributeAssignmentResult::Ok & boundness
+                } else {
+                    AttributeAssignmentResult::TypeMismatch(self) & boundness
+                }
+            }
+
+            // Super instances do not allow attribute assignment
+            Type::NominalInstance(instance) if instance.class.is_known(db, KnownClass::Super) => {
+                AttributeAssignmentResult::CannotAssign
+            }
+            Type::BoundSuper(_) => AttributeAssignmentResult::CannotAssign,
+
+            Type::Dynamic(..) | Type::Never => AttributeAssignmentResult::Ok,
+
+            Type::NominalInstance(..)
+            | Type::ProtocolInstance(_)
+            | Type::BooleanLiteral(..)
+            | Type::IntLiteral(..)
+            | Type::StringLiteral(..)
+            | Type::BytesLiteral(..)
+            | Type::LiteralString
+            | Type::Tuple(..)
+            | Type::SpecialForm(..)
+            | Type::KnownInstance(..)
+            | Type::PropertyInstance(..)
+            | Type::FunctionLiteral(..)
+            | Type::Callable(..)
+            | Type::BoundMethod(_)
+            | Type::MethodWrapper(_)
+            | Type::WrapperDescriptor(_)
+            | Type::DataclassDecorator(_)
+            | Type::DataclassTransformer(_)
+            | Type::TypeVar(..)
+            | Type::AlwaysTruthy
+            | Type::AlwaysFalsy
+            | Type::TypeIs(_) => {
+                let is_read_only = || {
+                    let dataclass_params = match self {
+                        Type::NominalInstance(instance) => match instance.class {
+                            ClassType::NonGeneric(cls) => cls.dataclass_params(db),
+                            ClassType::Generic(cls) => cls.origin(db).dataclass_params(db),
+                        },
+                        _ => None,
+                    };
+
+                    dataclass_params.is_some_and(|params| params.contains(DataclassParams::FROZEN))
+                };
+
+                match self.class_member(db, attribute.into()) {
+                    meta_attr @ PlaceAndQualifiers { .. } if meta_attr.is_class_var() => {
+                        AttributeAssignmentResult::CannotAssignToClassVar
+                    }
+                    PlaceAndQualifiers {
+                        place: Place::Type(meta_attr_ty, meta_attr_boundness),
+                        qualifiers: _,
+                    } => {
+                        if is_read_only() {
+                            AttributeAssignmentResult::ReadOnlyProperty
+                        } else {
+                            let assignable_to_meta_attr = if let Place::Type(meta_dunder_set, _) =
+                                meta_attr_ty.class_member(db, "__set__".into()).place
+                            {
+                                let successful_call = meta_dunder_set
+                                    .try_call(
+                                        db,
+                                        &CallArgumentTypes::positional([
+                                            meta_attr_ty,
+                                            self,
+                                            value_ty,
+                                        ]),
+                                    )
+                                    .is_ok();
+
+                                if successful_call {
+                                    AttributeAssignmentResult::Ok
+                                } else {
+                                    AttributeAssignmentResult::FailToSet
+                                }
+                            } else {
+                                ensure_assignable_to(meta_attr_ty)
+                            };
+
+                            let assignable_to_instance_attribute = if meta_attr_boundness
+                                == Boundness::PossiblyUnbound
+                            {
+                                let (assignable, boundness) =
+                                    if let Place::Type(instance_attr_ty, instance_attr_boundness) =
+                                        self.instance_member(db, attribute).place
+                                    {
+                                        (
+                                            ensure_assignable_to(instance_attr_ty),
+                                            instance_attr_boundness,
+                                        )
+                                    } else {
+                                        (AttributeAssignmentResult::Ok, Boundness::PossiblyUnbound)
+                                    };
+
+                                assignable & boundness
+                            } else {
+                                AttributeAssignmentResult::Ok
+                            };
+
+                            and(assignable_to_meta_attr, assignable_to_instance_attribute)
+                        }
+                    }
+
+                    PlaceAndQualifiers {
+                        place: Place::Unbound,
+                        ..
+                    } => {
+                        if let Place::Type(instance_attr_ty, instance_attr_boundness) =
+                            self.instance_member(db, attribute).place
+                        {
+                            if is_read_only() {
+                                AttributeAssignmentResult::ReadOnlyProperty
+                                    & instance_attr_boundness
+                            } else {
+                                ensure_assignable_to(instance_attr_ty) & instance_attr_boundness
+                            }
+                        } else {
+                            let result = self.try_call_dunder_with_policy(
+                                db,
+                                "__setattr__",
+                                &mut CallArgumentTypes::positional([
+                                    Type::StringLiteral(StringLiteralType::new(
+                                        db,
+                                        Box::from(attribute),
+                                    )),
+                                    value_ty,
+                                ]),
+                                MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
+                            );
+
+                            match result {
+                                Ok(_) | Err(CallDunderError::PossiblyUnbound(_)) => {
+                                    AttributeAssignmentResult::Ok
+                                }
+                                Err(CallDunderError::CallError(..)) => {
+                                    AttributeAssignmentResult::FailToSetAttr
+                                }
+                                Err(CallDunderError::MethodNotAvailable) => {
+                                    AttributeAssignmentResult::Unresolved
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            Type::ClassLiteral(..) | Type::GenericAlias(..) | Type::SubclassOf(..) => {
+                match self.class_member(db, attribute.into()) {
+                    PlaceAndQualifiers {
+                        place: Place::Type(meta_attr_ty, meta_attr_boundness),
+                        qualifiers: _,
+                    } => {
+                        let assignable_to_meta_attr = if let Place::Type(meta_dunder_set, _) =
+                            meta_attr_ty.class_member(db, "__set__".into()).place
+                        {
+                            let successful_call = meta_dunder_set
+                                .try_call(
+                                    db,
+                                    &CallArgumentTypes::positional([meta_attr_ty, self, value_ty]),
+                                )
+                                .is_ok();
+
+                            if successful_call {
+                                AttributeAssignmentResult::Ok
+                            } else {
+                                AttributeAssignmentResult::FailToSet
+                            }
+                        } else {
+                            ensure_assignable_to(meta_attr_ty)
+                        };
+
+                        let assignable_to_class_attr =
+                            if meta_attr_boundness == Boundness::PossiblyUnbound {
+                                let (assignable, boundness) =
+                                    if let Place::Type(class_attr_ty, class_attr_boundness) = self
+                                        .find_name_in_mro(db, attribute)
+                                        .expect("called on Type::ClassLiteral or Type::SubclassOf")
+                                        .place
+                                    {
+                                        (ensure_assignable_to(class_attr_ty), class_attr_boundness)
+                                    } else {
+                                        (AttributeAssignmentResult::Ok, Boundness::PossiblyUnbound)
+                                    };
+
+                                assignable & boundness
+                            } else {
+                                AttributeAssignmentResult::Ok
+                            };
+
+                        and(assignable_to_meta_attr, assignable_to_class_attr)
+                    }
+                    PlaceAndQualifiers {
+                        place: Place::Unbound,
+                        ..
+                    } => {
+                        if let Place::Type(class_attr_ty, class_attr_boundness) = self
+                            .find_name_in_mro(db, attribute)
+                            .expect("called on Type::ClassLiteral or Type::SubclassOf")
+                            .place
+                        {
+                            ensure_assignable_to(class_attr_ty) & class_attr_boundness
+                        } else {
+                            let attribute_is_bound_on_instance =
+                                self.to_instance(db).is_some_and(|instance| {
+                                    !instance.instance_member(db, attribute).place.is_unbound()
+                                });
+
+                            // Attribute is declared or bound on instance. Forbid access from the class object
+                            if attribute_is_bound_on_instance {
+                                AttributeAssignmentResult::CannotAssignToInstanceAttr
+                            } else {
+                                AttributeAssignmentResult::Unresolved
+                            }
+                        }
+                    }
+                }
+            }
+
+            Type::ModuleLiteral(module) => {
+                if let Place::Type(attr_ty, _) = module.static_member(db, attribute) {
+                    if value_ty.is_assignable_to(db, attr_ty) {
+                        AttributeAssignmentResult::Ok
+                    } else {
+                        AttributeAssignmentResult::TypeMismatch(attr_ty)
+                    }
+                } else {
+                    AttributeAssignmentResult::Unresolved
+                }
+            }
         }
     }
 

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -72,7 +72,7 @@ use crate::types::diagnostic::{
 };
 use crate::types::generics::GenericContext;
 use crate::types::narrow::ClassInfoConstraintFunction;
-use crate::types::signatures::{CallableSignature, Signature};
+use crate::types::signatures::{CallableSignature, Parameter, Signature};
 use crate::types::{
     BoundMethodType, CallableType, DynamicType, KnownClass, Type, TypeMapping, TypeRelation,
     TypeVarInstance,
@@ -342,6 +342,13 @@ impl<'db> OverloadLiteral<'db> {
         )
     }
 
+    fn parameter_type(self, db: &'db dyn Db, index: usize) -> Option<Type<'db>> {
+        self.signature(db, None)
+            .parameters()
+            .get(index)
+            .and_then(Parameter::annotated_type)
+    }
+
     pub(crate) fn parameter_span(
         self,
         db: &'db dyn Db,
@@ -455,6 +462,10 @@ impl<'db> FunctionLiteral<'db> {
 
     fn definition(self, db: &'db dyn Db) -> Definition<'db> {
         self.last_definition(db).definition(db)
+    }
+
+    fn parameter_type(self, db: &'db dyn Db, index: usize) -> Option<Type<'db>> {
+        self.last_definition(db).parameter_type(db, index)
     }
 
     fn parameter_span(
@@ -659,6 +670,10 @@ impl<'db> FunctionType<'db> {
     /// over-invalidation.
     pub(crate) fn definition(self, db: &'db dyn Db) -> Definition<'db> {
         self.literal(db).definition(db)
+    }
+
+    pub(crate) fn parameter_type(self, db: &'db dyn Db, index: usize) -> Option<Type<'db>> {
+        self.literal(db).parameter_type(db, index)
     }
 
     /// Returns a tuple of two spans. The first is

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -97,13 +97,12 @@ use crate::types::signatures::{CallableSignature, Signature};
 use crate::types::tuple::{TupleSpec, TupleType};
 use crate::types::unpacker::{UnpackResult, Unpacker};
 use crate::types::{
-    CallDunderError, CallableType, ClassLiteral, ClassType, DataclassParams, DynamicType,
-    IntersectionBuilder, IntersectionType, KnownClass, KnownInstanceType, LintDiagnosticGuard,
-    MemberLookupPolicy, MetaclassCandidate, PEP695TypeAliasType, Parameter, ParameterForm,
-    Parameters, SpecialFormType, StringLiteralType, SubclassOfType, Truthiness, Type,
-    TypeAliasType, TypeAndQualifiers, TypeIsType, TypeQualifiers, TypeVarBoundOrConstraints,
-    TypeVarInstance, TypeVarKind, TypeVarVariance, UnionBuilder, UnionType, binding_type,
-    todo_type,
+    AttributeAssignmentResult, CallDunderError, CallableType, ClassLiteral, ClassType,
+    DataclassParams, DynamicType, IntersectionBuilder, IntersectionType, KnownClass,
+    KnownInstanceType, LintDiagnosticGuard, MetaclassCandidate, PEP695TypeAliasType, Parameter,
+    ParameterForm, Parameters, SpecialFormType, SubclassOfType, Truthiness, Type, TypeAliasType,
+    TypeAndQualifiers, TypeIsType, TypeQualifiers, TypeVarBoundOrConstraints, TypeVarInstance,
+    TypeVarKind, TypeVarVariance, UnionBuilder, UnionType, binding_type, todo_type,
 };
 use crate::unpack::{Unpack, UnpackPosition};
 use crate::util::diagnostics::format_enumeration;
@@ -3223,473 +3222,139 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         object_ty: Type<'db>,
         attribute: &str,
         value_ty: Type<'db>,
-        emit_diagnostics: bool,
-    ) -> bool {
-        let db = self.db();
-
-        let ensure_assignable_to = |attr_ty| -> bool {
-            let assignable = value_ty.is_assignable_to(db, attr_ty);
-            if !assignable && emit_diagnostics {
+    ) {
+        match object_ty.validate_attribute_assignment(self.db(), attribute, value_ty) {
+            AttributeAssignmentResult::Ok => {}
+            AttributeAssignmentResult::PossiblyUnbound => {
+                report_possibly_unbound_attribute(&self.context, target, attribute, object_ty);
+            }
+            ref res @ (AttributeAssignmentResult::TypeMismatch(target_ty)
+            | AttributeAssignmentResult::TypeMismatchAndPossiblyUnbound(target_ty)) => {
+                if res.is_possibly_unbound() {
+                    report_possibly_unbound_attribute(&self.context, target, attribute, object_ty);
+                }
+                // TODO: This is not a very helpful error message for union/intersection, as it does not include the underlying reason
+                // why the assignment is invalid. This would be a good use case for sub-diagnostics.
                 report_invalid_attribute_assignment(
                     &self.context,
                     target.into(),
-                    attr_ty,
+                    target_ty,
                     value_ty,
                     attribute,
                 );
             }
-            assignable
-        };
-
-        match object_ty {
-            Type::Union(union) => {
-                if union.elements(self.db()).iter().all(|elem| {
-                    self.validate_attribute_assignment(target, *elem, attribute, value_ty, false)
-                }) {
-                    true
-                } else {
-                    // TODO: This is not a very helpful error message, as it does not include the underlying reason
-                    // why the assignment is invalid. This would be a good use case for sub-diagnostics.
-                    if emit_diagnostics {
-                        if let Some(builder) = self.context.report_lint(&INVALID_ASSIGNMENT, target)
-                        {
-                            builder.into_diagnostic(format_args!(
-                                "Object of type `{}` is not assignable \
-                                 to attribute `{attribute}` on type `{}`",
-                                value_ty.display(self.db()),
-                                object_ty.display(self.db()),
-                            ));
-                        }
-                    }
-
-                    false
+            ref res @ (AttributeAssignmentResult::TwoTypeMismatch(l_target, r_target)
+            | AttributeAssignmentResult::TwoTypeMismatchAndPossiblyUnbound(
+                l_target,
+                r_target,
+            )) => {
+                if res.is_possibly_unbound() {
+                    report_possibly_unbound_attribute(&self.context, target, attribute, object_ty);
+                }
+                report_invalid_attribute_assignment(
+                    &self.context,
+                    target.into(),
+                    l_target,
+                    value_ty,
+                    attribute,
+                );
+                report_invalid_attribute_assignment(
+                    &self.context,
+                    target.into(),
+                    r_target,
+                    value_ty,
+                    attribute,
+                );
+            }
+            AttributeAssignmentResult::CannotAssign => {
+                if let Some(builder) = self.context.report_lint(&INVALID_ASSIGNMENT, target) {
+                    builder.into_diagnostic(format_args!(
+                        "Cannot assign to attribute `{attribute}` on type `{}`",
+                        object_ty.display(self.db()),
+                    ));
                 }
             }
-
-            Type::Intersection(intersection) => {
-                // TODO: Handle negative intersection elements
-                if intersection.positive(db).iter().any(|elem| {
-                    self.validate_attribute_assignment(target, *elem, attribute, value_ty, false)
-                }) {
-                    true
-                } else {
-                    if emit_diagnostics {
-                        if let Some(builder) = self.context.report_lint(&INVALID_ASSIGNMENT, target)
-                        {
-                            // TODO: same here, see above
-                            builder.into_diagnostic(format_args!(
-                                "Object of type `{}` is not assignable \
-                                 to attribute `{attribute}` on type `{}`",
-                                value_ty.display(self.db()),
-                                object_ty.display(self.db()),
-                            ));
-                        }
-                    }
-                    false
+            AttributeAssignmentResult::CannotAssignToClassVar => {
+                if let Some(builder) = self.context.report_lint(&INVALID_ATTRIBUTE_ACCESS, target) {
+                    builder.into_diagnostic(format_args!(
+                        "Cannot assign to ClassVar `{attribute}` \
+                             from an instance of type `{ty}`",
+                        ty = object_ty.display(self.db()),
+                    ));
                 }
             }
-
-            // Super instances do not allow attribute assignment
-            Type::NominalInstance(instance) if instance.class.is_known(db, KnownClass::Super) => {
-                if emit_diagnostics {
-                    if let Some(builder) = self.context.report_lint(&INVALID_ASSIGNMENT, target) {
-                        builder.into_diagnostic(format_args!(
-                            "Cannot assign to attribute `{attribute}` on type `{}`",
-                            object_ty.display(self.db()),
-                        ));
-                    }
-                }
-                false
-            }
-            Type::BoundSuper(_) => {
-                if emit_diagnostics {
-                    if let Some(builder) = self.context.report_lint(&INVALID_ASSIGNMENT, target) {
-                        builder.into_diagnostic(format_args!(
-                            "Cannot assign to attribute `{attribute}` on type `{}`",
-                            object_ty.display(self.db()),
-                        ));
-                    }
-                }
-                false
-            }
-
-            Type::Dynamic(..) | Type::Never => true,
-
-            Type::NominalInstance(..)
-            | Type::ProtocolInstance(_)
-            | Type::BooleanLiteral(..)
-            | Type::IntLiteral(..)
-            | Type::StringLiteral(..)
-            | Type::BytesLiteral(..)
-            | Type::LiteralString
-            | Type::Tuple(..)
-            | Type::SpecialForm(..)
-            | Type::KnownInstance(..)
-            | Type::PropertyInstance(..)
-            | Type::FunctionLiteral(..)
-            | Type::Callable(..)
-            | Type::BoundMethod(_)
-            | Type::MethodWrapper(_)
-            | Type::WrapperDescriptor(_)
-            | Type::DataclassDecorator(_)
-            | Type::DataclassTransformer(_)
-            | Type::TypeVar(..)
-            | Type::AlwaysTruthy
-            | Type::AlwaysFalsy
-            | Type::TypeIs(_) => {
-                let is_read_only = || {
-                    let dataclass_params = match object_ty {
-                        Type::NominalInstance(instance) => match instance.class {
-                            ClassType::NonGeneric(cls) => cls.dataclass_params(self.db()),
-                            ClassType::Generic(cls) => {
-                                cls.origin(self.db()).dataclass_params(self.db())
-                            }
-                        },
-                        _ => None,
-                    };
-
-                    dataclass_params.is_some_and(|params| params.contains(DataclassParams::FROZEN))
-                };
-
-                match object_ty.class_member(db, attribute.into()) {
-                    meta_attr @ PlaceAndQualifiers { .. } if meta_attr.is_class_var() => {
-                        if emit_diagnostics {
-                            if let Some(builder) =
-                                self.context.report_lint(&INVALID_ATTRIBUTE_ACCESS, target)
-                            {
-                                builder.into_diagnostic(format_args!(
-                                    "Cannot assign to ClassVar `{attribute}` \
-                                     from an instance of type `{ty}`",
-                                    ty = object_ty.display(self.db()),
-                                ));
-                            }
-                        }
-                        false
-                    }
-                    PlaceAndQualifiers {
-                        place: Place::Type(meta_attr_ty, meta_attr_boundness),
-                        qualifiers: _,
-                    } => {
-                        if is_read_only() {
-                            if emit_diagnostics {
-                                if let Some(builder) =
-                                    self.context.report_lint(&INVALID_ASSIGNMENT, target)
-                                {
-                                    builder.into_diagnostic(format_args!(
-                                        "Property `{attribute}` defined in `{ty}` is read-only",
-                                        ty = object_ty.display(self.db()),
-                                    ));
-                                }
-                            }
-                            false
-                        } else {
-                            let assignable_to_meta_attr = if let Place::Type(meta_dunder_set, _) =
-                                meta_attr_ty.class_member(db, "__set__".into()).place
-                            {
-                                let successful_call = meta_dunder_set
-                                    .try_call(
-                                        db,
-                                        &CallArgumentTypes::positional([
-                                            meta_attr_ty,
-                                            object_ty,
-                                            value_ty,
-                                        ]),
-                                    )
-                                    .is_ok();
-
-                                if !successful_call && emit_diagnostics {
-                                    if let Some(builder) =
-                                        self.context.report_lint(&INVALID_ASSIGNMENT, target)
-                                    {
-                                        // TODO: Here, it would be nice to emit an additional diagnostic that explains why the call failed
-                                        builder.into_diagnostic(format_args!(
-                                            "Invalid assignment to data descriptor attribute \
-                                         `{attribute}` on type `{}` with custom `__set__` method",
-                                            object_ty.display(db)
-                                        ));
-                                    }
-                                }
-
-                                successful_call
-                            } else {
-                                ensure_assignable_to(meta_attr_ty)
-                            };
-
-                            let assignable_to_instance_attribute = if meta_attr_boundness
-                                == Boundness::PossiblyUnbound
-                            {
-                                let (assignable, boundness) =
-                                    if let Place::Type(instance_attr_ty, instance_attr_boundness) =
-                                        object_ty.instance_member(db, attribute).place
-                                    {
-                                        (
-                                            ensure_assignable_to(instance_attr_ty),
-                                            instance_attr_boundness,
-                                        )
-                                    } else {
-                                        (true, Boundness::PossiblyUnbound)
-                                    };
-
-                                if boundness == Boundness::PossiblyUnbound {
-                                    report_possibly_unbound_attribute(
-                                        &self.context,
-                                        target,
-                                        attribute,
-                                        object_ty,
-                                    );
-                                }
-
-                                assignable
-                            } else {
-                                true
-                            };
-
-                            assignable_to_meta_attr && assignable_to_instance_attribute
-                        }
-                    }
-
-                    PlaceAndQualifiers {
-                        place: Place::Unbound,
-                        ..
-                    } => {
-                        if let Place::Type(instance_attr_ty, instance_attr_boundness) =
-                            object_ty.instance_member(db, attribute).place
-                        {
-                            if instance_attr_boundness == Boundness::PossiblyUnbound {
-                                report_possibly_unbound_attribute(
-                                    &self.context,
-                                    target,
-                                    attribute,
-                                    object_ty,
-                                );
-                            }
-
-                            if is_read_only() {
-                                if emit_diagnostics {
-                                    if let Some(builder) =
-                                        self.context.report_lint(&INVALID_ASSIGNMENT, target)
-                                    {
-                                        builder.into_diagnostic(format_args!(
-                                            "Property `{attribute}` defined in `{ty}` is read-only",
-                                            ty = object_ty.display(self.db()),
-                                        ));
-                                    }
-                                }
-                                false
-                            } else {
-                                ensure_assignable_to(instance_attr_ty)
-                            }
-                        } else {
-                            let result = object_ty.try_call_dunder_with_policy(
-                                db,
-                                "__setattr__",
-                                &mut CallArgumentTypes::positional([
-                                    Type::StringLiteral(StringLiteralType::new(
-                                        db,
-                                        Box::from(attribute),
-                                    )),
-                                    value_ty,
-                                ]),
-                                MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
-                            );
-
-                            match result {
-                                Ok(_) | Err(CallDunderError::PossiblyUnbound(_)) => true,
-                                Err(CallDunderError::CallError(..)) => {
-                                    if emit_diagnostics {
-                                        if let Some(builder) =
-                                            self.context.report_lint(&UNRESOLVED_ATTRIBUTE, target)
-                                        {
-                                            builder.into_diagnostic(format_args!(
-                                                "Can not assign object of `{}` to attribute \
-                                                 `{attribute}` on type `{}` with \
-                                                 custom `__setattr__` method.",
-                                                value_ty.display(db),
-                                                object_ty.display(db)
-                                            ));
-                                        }
-                                    }
-                                    false
-                                }
-                                Err(CallDunderError::MethodNotAvailable) => {
-                                    if emit_diagnostics {
-                                        if let Some(builder) =
-                                            self.context.report_lint(&UNRESOLVED_ATTRIBUTE, target)
-                                        {
-                                            builder.into_diagnostic(format_args!(
-                                                "Unresolved attribute `{}` on type `{}`.",
-                                                attribute,
-                                                object_ty.display(db)
-                                            ));
-                                        }
-                                    }
-
-                                    false
-                                }
-                            }
-                        }
-                    }
+            AttributeAssignmentResult::CannotAssignToInstanceAttr => {
+                if let Some(builder) = self.context.report_lint(&INVALID_ATTRIBUTE_ACCESS, target) {
+                    builder.into_diagnostic(format_args!(
+                        "Cannot assign to instance attribute \
+                                `{attribute}` from the class object `{ty}`",
+                        ty = object_ty.display(self.db()),
+                    ));
                 }
             }
-
-            Type::ClassLiteral(..) | Type::GenericAlias(..) | Type::SubclassOf(..) => {
-                match object_ty.class_member(db, attribute.into()) {
-                    PlaceAndQualifiers {
-                        place: Place::Type(meta_attr_ty, meta_attr_boundness),
-                        qualifiers: _,
-                    } => {
-                        let assignable_to_meta_attr = if let Place::Type(meta_dunder_set, _) =
-                            meta_attr_ty.class_member(db, "__set__".into()).place
-                        {
-                            let successful_call = meta_dunder_set
-                                .try_call(
-                                    db,
-                                    &CallArgumentTypes::positional([
-                                        meta_attr_ty,
-                                        object_ty,
-                                        value_ty,
-                                    ]),
-                                )
-                                .is_ok();
-
-                            if !successful_call && emit_diagnostics {
-                                if let Some(builder) =
-                                    self.context.report_lint(&INVALID_ASSIGNMENT, target)
-                                {
-                                    // TODO: Here, it would be nice to emit an additional diagnostic that explains why the call failed
-                                    builder.into_diagnostic(format_args!(
-                                        "Invalid assignment to data descriptor attribute \
-                                         `{attribute}` on type `{}` with custom `__set__` method",
-                                        object_ty.display(db)
-                                    ));
-                                }
-                            }
-
-                            successful_call
-                        } else {
-                            ensure_assignable_to(meta_attr_ty)
-                        };
-
-                        let assignable_to_class_attr = if meta_attr_boundness
-                            == Boundness::PossiblyUnbound
-                        {
-                            let (assignable, boundness) =
-                                if let Place::Type(class_attr_ty, class_attr_boundness) = object_ty
-                                    .find_name_in_mro(db, attribute)
-                                    .expect("called on Type::ClassLiteral or Type::SubclassOf")
-                                    .place
-                                {
-                                    (ensure_assignable_to(class_attr_ty), class_attr_boundness)
-                                } else {
-                                    (true, Boundness::PossiblyUnbound)
-                                };
-
-                            if boundness == Boundness::PossiblyUnbound {
-                                report_possibly_unbound_attribute(
-                                    &self.context,
-                                    target,
-                                    attribute,
-                                    object_ty,
-                                );
-                            }
-
-                            assignable
-                        } else {
-                            true
-                        };
-
-                        assignable_to_meta_attr && assignable_to_class_attr
-                    }
-                    PlaceAndQualifiers {
-                        place: Place::Unbound,
-                        ..
-                    } => {
-                        if let Place::Type(class_attr_ty, class_attr_boundness) = object_ty
-                            .find_name_in_mro(db, attribute)
-                            .expect("called on Type::ClassLiteral or Type::SubclassOf")
-                            .place
-                        {
-                            if class_attr_boundness == Boundness::PossiblyUnbound {
-                                report_possibly_unbound_attribute(
-                                    &self.context,
-                                    target,
-                                    attribute,
-                                    object_ty,
-                                );
-                            }
-
-                            ensure_assignable_to(class_attr_ty)
-                        } else {
-                            let attribute_is_bound_on_instance =
-                                object_ty.to_instance(self.db()).is_some_and(|instance| {
-                                    !instance
-                                        .instance_member(self.db(), attribute)
-                                        .place
-                                        .is_unbound()
-                                });
-
-                            // Attribute is declared or bound on instance. Forbid access from the class object
-                            if emit_diagnostics {
-                                if attribute_is_bound_on_instance {
-                                    if let Some(builder) =
-                                        self.context.report_lint(&INVALID_ATTRIBUTE_ACCESS, target)
-                                    {
-                                        builder.into_diagnostic(format_args!(
-                                            "Cannot assign to instance attribute \
-                                             `{attribute}` from the class object `{ty}`",
-                                            ty = object_ty.display(self.db()),
-                                        ));
-                                    }
-                                } else {
-                                    if let Some(builder) =
-                                        self.context.report_lint(&UNRESOLVED_ATTRIBUTE, target)
-                                    {
-                                        builder.into_diagnostic(format_args!(
-                                            "Unresolved attribute `{}` on type `{}`.",
-                                            attribute,
-                                            object_ty.display(db)
-                                        ));
-                                    }
-                                }
-                            }
-
-                            false
-                        }
-                    }
+            AttributeAssignmentResult::ReadOnlyProperty => {
+                if let Some(builder) = self.context.report_lint(&INVALID_ASSIGNMENT, target) {
+                    builder.into_diagnostic(format_args!(
+                        "Property `{attribute}` defined in `{ty}` is read-only",
+                        ty = object_ty.display(self.db()),
+                    ));
                 }
             }
-
-            Type::ModuleLiteral(module) => {
-                if let Place::Type(attr_ty, _) = module.static_member(db, attribute) {
-                    let assignable = value_ty.is_assignable_to(db, attr_ty);
-                    if assignable {
-                        true
-                    } else {
-                        if emit_diagnostics {
-                            report_invalid_attribute_assignment(
-                                &self.context,
-                                target.into(),
-                                attr_ty,
-                                value_ty,
-                                attribute,
-                            );
-                        }
-                        false
-                    }
-                } else {
-                    if emit_diagnostics {
-                        if let Some(builder) =
-                            self.context.report_lint(&UNRESOLVED_ATTRIBUTE, target)
-                        {
-                            builder.into_diagnostic(format_args!(
-                                "Unresolved attribute `{}` on type `{}`.",
-                                attribute,
-                                object_ty.display(db)
-                            ));
-                        }
-                    }
-
-                    false
+            res @ (AttributeAssignmentResult::FailToSet
+            | AttributeAssignmentResult::FailToSetAndPossiblyUnbound) => {
+                if res.is_possibly_unbound() {
+                    report_possibly_unbound_attribute(&self.context, target, attribute, object_ty);
+                }
+                if let Some(builder) = self.context.report_lint(&INVALID_ASSIGNMENT, target) {
+                    // TODO: Here, it would be nice to emit an additional diagnostic that explains why the call failed
+                    builder.into_diagnostic(format_args!(
+                        "Invalid assignment to data descriptor attribute \
+                        `{attribute}` on type `{}` with custom `__set__` method",
+                        object_ty.display(self.db())
+                    ));
+                }
+            }
+            ref res @ (AttributeAssignmentResult::FailToSetAndTypeMismatch(target_ty)
+            | AttributeAssignmentResult::FailToSetAndTypeMismatchAndPossiblyUnbound(
+                target_ty,
+            )) => {
+                if res.is_possibly_unbound() {
+                    report_possibly_unbound_attribute(&self.context, target, attribute, object_ty);
+                }
+                report_invalid_attribute_assignment(
+                    &self.context,
+                    target.into(),
+                    target_ty,
+                    value_ty,
+                    attribute,
+                );
+                if let Some(builder) = self.context.report_lint(&INVALID_ASSIGNMENT, target) {
+                    // TODO: Here, it would be nice to emit an additional diagnostic that explains why the call failed
+                    builder.into_diagnostic(format_args!(
+                        "Invalid assignment to data descriptor attribute \
+                            `{attribute}` on type `{}` with custom `__set__` method",
+                        object_ty.display(self.db())
+                    ));
+                }
+            }
+            AttributeAssignmentResult::FailToSetAttr => {
+                if let Some(builder) = self.context.report_lint(&UNRESOLVED_ATTRIBUTE, target) {
+                    builder.into_diagnostic(format_args!(
+                        "Can not assign object of `{}` to attribute \
+                                `{attribute}` on type `{}` with \
+                                custom `__setattr__` method.",
+                        value_ty.display(self.db()),
+                        object_ty.display(self.db())
+                    ));
+                }
+            }
+            AttributeAssignmentResult::Unresolved => {
+                if let Some(builder) = self.context.report_lint(&UNRESOLVED_ATTRIBUTE, target) {
+                    builder.into_diagnostic(format_args!(
+                        "Unresolved attribute `{}` on type `{}`.",
+                        attribute,
+                        object_ty.display(self.db())
+                    ));
                 }
             }
         }
@@ -3729,7 +3394,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         object_ty,
                         attr.id(),
                         assigned_ty,
-                        true,
                     );
                 }
             }

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -284,7 +284,7 @@ impl<'db> ProtocolMemberData<'db> {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, salsa::Update, Hash)]
-enum ProtocolMemberKind<'db> {
+pub(super) enum ProtocolMemberKind<'db> {
     Method(Type<'db>), // TODO: use CallableType
     Property(PropertyInstanceType<'db>),
     Other(Type<'db>),
@@ -357,6 +357,10 @@ impl<'a, 'db> ProtocolMember<'a, 'db> {
         self.name
     }
 
+    pub(super) fn kind(&self) -> ProtocolMemberKind<'db> {
+        self.kind
+    }
+
     pub(super) fn qualifiers(&self) -> TypeQualifiers {
         self.qualifiers
     }
@@ -367,10 +371,6 @@ impl<'a, 'db> ProtocolMember<'a, 'db> {
             ProtocolMemberKind::Property(property) => Type::PropertyInstance(*property),
             ProtocolMemberKind::Other(ty) => *ty,
         }
-    }
-
-    pub(super) const fn is_attribute_member(&self) -> bool {
-        matches!(self.kind, ProtocolMemberKind::Other(_))
     }
 
     /// Return `true` if `other` contains an attribute/method/property that satisfies


### PR DESCRIPTION
## Summary

This PR closes astral-sh/ty#643 (and depends on #19029).
It synthesizes constraints on objects (e.g. `x: Protocol[{"tag": (read) Literal["C"]}]`) from constraints on attributes (e.g. `x.tag: (read) Literal["C"]`).

## Test Plan

New tests in `complex_target.md`.