### PR TITLE
[`ruff`] Offer fixes for `RUF039` in more cases

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF039.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF039.py
@@ -53,3 +53,16 @@ regex.subn(br"""eak your machine with rm -""", rf"""/""")
 regex.splititer(both, non_literal)
 regex.subf(f, lambda _: r'means', '"format"')
 regex.subfn(fn, f'''a$1n't''', lambda: "'function'")
+
+
+# https://github.com/astral-sh/ruff/issues/16713
+re.compile("\a\f\n\r\t\u27F2\U0001F0A1\v\x41")  # with unsafe fix
+re.compile("\b")  # without fix
+re.compile("\"")  # without fix
+re.compile("\'")  # without fix
+re.compile('\"')  # without fix
+re.compile('\'')  # without fix
+re.compile("\\")  # without fix
+re.compile("\101")  # without fix
+re.compile("a\
+b")  # without fix

--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF039_concat.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF039_concat.py
@@ -91,3 +91,20 @@ regex.subf(
     br''br""br''
 )
 regex.subfn(br'I\s\nee*d\s[O0o]me\x20\Qoffe\E, ' br'b')
+
+
+# https://github.com/astral-sh/ruff/issues/16713
+re.compile(
+    "["
+    "\U0001F600-\U0001F64F"  # emoticons
+    "\U0001F300-\U0001F5FF"  # symbols & pictographs
+    "\U0001F680-\U0001F6FF"  # transport & map symbols
+    "\U0001F1E0-\U0001F1FF"  # flags (iOS)
+    "\U00002702-\U000027B0"
+    "\U000024C2-\U0001F251"
+    "\u200d"  # zero width joiner
+    "\u200c"  # zero width non-joiner
+    "\\u200c" # must not be escaped in a raw string
+    "]+",
+    flags=re.UNICODE,
+)

--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF039_py_version_sensitive.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF039_py_version_sensitive.py
@@ -1,0 +1,3 @@
+import re
+
+re.compile("\N{Partial Differential}")  # with unsafe fix if python target is 3.8 or higher, else without fix

--- a/crates/ruff_linter/src/rules/ruff/mod.rs
+++ b/crates/ruff_linter/src/rules/ruff/mod.rs
@@ -554,6 +554,44 @@ mod tests {
         Ok(())
     }
 
+    #[test_case(Rule::UnrawRePattern, Path::new("RUF039_py_version_sensitive.py"))]
+    fn preview_rules_py37(rule_code: Rule, path: &Path) -> Result<()> {
+        let snapshot = format!(
+            "preview__py37__{}_{}",
+            rule_code.noqa_code(),
+            path.to_string_lossy()
+        );
+        let diagnostics = test_path(
+            Path::new("ruff").join(path).as_path(),
+            &settings::LinterSettings {
+                preview: PreviewMode::Enabled,
+                unresolved_target_version: PythonVersion::PY37.into(),
+                ..settings::LinterSettings::for_rule(rule_code)
+            },
+        )?;
+        assert_diagnostics!(snapshot, diagnostics);
+        Ok(())
+    }
+
+    #[test_case(Rule::UnrawRePattern, Path::new("RUF039_py_version_sensitive.py"))]
+    fn preview_rules_py38(rule_code: Rule, path: &Path) -> Result<()> {
+        let snapshot = format!(
+            "preview__py38__{}_{}",
+            rule_code.noqa_code(),
+            path.to_string_lossy()
+        );
+        let diagnostics = test_path(
+            Path::new("ruff").join(path).as_path(),
+            &settings::LinterSettings {
+                preview: PreviewMode::Enabled,
+                unresolved_target_version: PythonVersion::PY38.into(),
+                ..settings::LinterSettings::for_rule(rule_code)
+            },
+        )?;
+        assert_diagnostics!(snapshot, diagnostics);
+        Ok(())
+    }
+
     #[test_case(Rule::UsedDummyVariable, Path::new("RUF052.py"), r"^_+", 1)]
     #[test_case(Rule::UsedDummyVariable, Path::new("RUF052.py"), r"", 2)]
     fn custom_regexp_preset(

--- a/crates/ruff_linter/src/rules/ruff/rules/unraw_re_pattern.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unraw_re_pattern.rs
@@ -196,7 +196,7 @@ fn check_string(checker: &Checker, literal: &StringLiteral, module: RegexModule,
     ));
 }
 
-/// Check how same it is to prepend the `r` prefix to the sting.
+/// Check how safe it is to prepend the `r` prefix to the string.
 ///
 /// ## Returns
 ///  * `None` if the prefix cannot be added,
@@ -271,7 +271,7 @@ fn raw_applicability(
             // to `re`, however, it's not exactly the same runtime value.
             // Similarly, for the other escape sequences.
             if !match_allowed_escape_sequence(chars.peek().copied()) {
-                // If the next character is not one of whitelisted one, we likely cannot safely turn
+                // If the next character is not one of the whitelisted ones, we likely cannot safely turn
                 // this into a raw string.
                 return None;
             }

--- a/crates/ruff_linter/src/rules/ruff/rules/unraw_re_pattern.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unraw_re_pattern.rs
@@ -25,9 +25,8 @@ use crate::{Edit, Fix, FixAvailability, Violation};
 /// using raw strings to avoid double escaping.
 ///
 /// ## Fix safety
-/// If a fix is available and the string/bytes literal contains an escape sequence, the fix is
-/// marked unsafe because it alters the runtime value of the literal while retaining the regex
-/// semantics.
+/// The fix is unsafe if the string/bytes literal contains an escape sequence because the fix alters
+/// the runtime value of the literal while retaining the regex semantics.
 ///
 /// For example
 /// ```python
@@ -38,6 +37,15 @@ use crate::{Edit, Fix, FixAvailability, Violation};
 /// # character as before.
 /// re.compile(r"1\n2")
 /// ```
+///
+/// ## Fix availability
+///  A fix is not available if either
+///  * the argument is a string with a (no-op) `u` prefix (e.g., `u"foo"`) as the prefix is
+///    incompatible with the raw prefix `r`
+///  * the argument is a string or bytes literal with an escape sequence that has a different
+///    meaning in the context of a regular expression such as `\b`, which is word boundary or
+///    backspace in a regex, depending on the context, but always a backspace in string and bytes
+///    literals.
 ///
 /// ## Example
 ///

--- a/crates/ruff_linter/src/rules/ruff/rules/unraw_re_pattern.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unraw_re_pattern.rs
@@ -1,13 +1,13 @@
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 
+use ruff_diagnostics::Applicability;
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_python_ast::{
-    BytesLiteral, Expr, ExprBytesLiteral, ExprCall, ExprStringLiteral, StringLiteral,
+    BytesLiteral, Expr, ExprBytesLiteral, ExprCall, ExprStringLiteral, PythonVersion, StringLiteral,
 };
 use ruff_python_semantic::{Modules, SemanticModel};
-
-use ruff_text_size::Ranged;
+use ruff_text_size::{Ranged, TextRange};
 
 use crate::checkers::ast::Checker;
 use crate::{Edit, Fix, FixAvailability, Violation};
@@ -23,6 +23,21 @@ use crate::{Edit, Fix, FixAvailability, Violation};
 /// ## Why is this bad?
 /// Regular expressions should be written
 /// using raw strings to avoid double escaping.
+///
+/// ## Fix safety
+/// If a fix is available and the string/bytes literal contains an escape sequence, the fix is
+/// marked unsafe because it alters the runtime value of the literal while retaining the regex
+/// semantics.
+///
+/// For example
+/// ```python
+/// # Literal is `1\n2`.
+/// re.compile("1\n2")
+///
+/// # Literal is `1\\n2`, but the regex library will interpret `\\n` and will still match a newline
+/// # character as before.
+/// re.compile(r"1\n2")
+/// ```
 ///
 /// ## Example
 ///
@@ -163,20 +178,35 @@ fn check_string(checker: &Checker, literal: &StringLiteral, module: RegexModule,
     let range = literal.range;
     let mut diagnostic = checker.report_diagnostic(UnrawRePattern { module, func, kind }, range);
 
-    if
-    // The (no-op) `u` prefix is a syntax error when combined with `r`
-    !literal.flags.prefix().is_unicode()
-    // We are looking for backslash characters
-    // in the raw source code here, because `\n`
-    // gets converted to a single character already
-    // at the lexing stage.
-    &&!checker.locator().slice(literal.range()).contains('\\')
-    {
-        diagnostic.set_fix(Fix::safe_edit(Edit::insertion(
-            "r".to_string(),
-            literal.range().start(),
-        )));
+    let Some(applicability) = raw_string_applicability(checker, literal) else {
+        return;
+    };
+
+    diagnostic.set_fix(Fix::applicable_edit(
+        Edit::insertion("r".to_string(), literal.range().start()),
+        applicability,
+    ));
+}
+
+/// Check how same it is to prepend the `r` prefix to the sting.
+///
+/// ## Returns
+///  * `None` if the prefix cannot be added,
+///  * `Some(a)` if it can be added with applicability `a`.
+fn raw_string_applicability(checker: &Checker, literal: &StringLiteral) -> Option<Applicability> {
+    if literal.flags.prefix().is_unicode() {
+        // The (no-op) `u` prefix is a syntax error when combined with `r`
+        return None;
     }
+
+    raw_applicability(checker, literal.range(), |escaped| {
+        matches!(
+            escaped,
+            Some('a' | 'f' | 'n' | 'r' | 't' | 'u' | 'U' | 'v' | 'x')
+        ) || checker.target_version() >= PythonVersion::PY38 && escaped.is_some_and(|c| c == 'N')
+    })
+
+    // re.compile("\a\f\n\N{Partial Differential}\r\t\u27F2\U0001F0A1\v\x41")  # with unsafe fix
 }
 
 fn check_bytes(checker: &Checker, literal: &BytesLiteral, module: RegexModule, func: &str) {
@@ -187,5 +217,53 @@ fn check_bytes(checker: &Checker, literal: &BytesLiteral, module: RegexModule, f
     let kind = PatternKind::Bytes;
     let func = func.to_string();
     let range = literal.range;
-    checker.report_diagnostic(UnrawRePattern { module, func, kind }, range);
+    let mut diagnostic = checker.report_diagnostic(UnrawRePattern { module, func, kind }, range);
+
+    let Some(applicability) = raw_byte_applicability(checker, literal) else {
+        return;
+    };
+
+    diagnostic.set_fix(Fix::applicable_edit(
+        Edit::insertion("r".to_string(), literal.range().start()),
+        applicability,
+    ));
+}
+
+/// Check how same it is to prepend the `r` prefix to the byte sting.
+///
+/// ## Returns
+///  * `None` if the prefix cannot be added,
+///  * `Some(a)` if it can be added with applicability `a`.
+fn raw_byte_applicability(checker: &Checker, literal: &BytesLiteral) -> Option<Applicability> {
+    raw_applicability(checker, literal.range(), |escaped| {
+        matches!(escaped, Some('a' | 'f' | 'n' | 'r' | 't' | 'v' | 'x'))
+    })
+}
+
+fn raw_applicability(
+    checker: &Checker,
+    literal_range: TextRange,
+    match_allowed_escape_sequence: impl Fn(Option<char>) -> bool,
+) -> Option<Applicability> {
+    let mut found_slash = false;
+    let mut chars = checker.locator().slice(literal_range).chars().peekable();
+    while let Some(char) = chars.next() {
+        if char == '\\' {
+            found_slash = true;
+            // Turning `"\uXXXX"` into `r"\uXXXX"` is behaviorally equivalent when passed
+            // to `re`, however, it's not exactly the same runtime value.
+            // Similarly, for the other escape sequences.
+            if !match_allowed_escape_sequence(chars.peek().copied()) {
+                // If the next character is not one of whitelisted one, we likely cannot safely turn
+                // this into a raw string.
+                return None;
+            }
+        }
+    }
+
+    Some(if found_slash {
+        Applicability::Unsafe
+    } else {
+        Applicability::Safe
+    })
 }

--- a/crates/ruff_linter/src/rules/ruff/rules/unraw_re_pattern.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unraw_re_pattern.rs
@@ -207,12 +207,21 @@ fn raw_string_applicability(checker: &Checker, literal: &StringLiteral) -> Optio
         return None;
     }
 
-    raw_applicability(checker, literal.range(), |escaped| {
-        matches!(
-            escaped,
-            Some('a' | 'f' | 'n' | 'r' | 't' | 'u' | 'U' | 'v' | 'x')
-        ) || checker.target_version() >= PythonVersion::PY38 && escaped.is_some_and(|c| c == 'N')
-    })
+    if checker.target_version() >= PythonVersion::PY38 {
+        raw_applicability(checker, literal.range(), |escaped| {
+            matches!(
+                escaped,
+                Some('a' | 'f' | 'n' | 'r' | 't' | 'u' | 'U' | 'v' | 'x' | 'N')
+            )
+        })
+    } else {
+        raw_applicability(checker, literal.range(), |escaped| {
+            matches!(
+                escaped,
+                Some('a' | 'f' | 'n' | 'r' | 't' | 'u' | 'U' | 'v' | 'x')
+            )
+        })
+    }
 
     // re.compile("\a\f\n\N{Partial Differential}\r\t\u27F2\U0001F0A1\v\x41")  # with unsafe fix
 }

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__preview__RUF039_RUF039.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__preview__RUF039_RUF039.py.snap
@@ -21,7 +21,7 @@ RUF039.py:5:12: RUF039 [*] First argument to `re.compile()` is not raw string
 7 7 | re.finditer("dou\ble")
 8 8 | re.fullmatch('''t\riple single''')
 
-RUF039.py:6:12: RUF039 First argument to `re.findall()` is not raw string
+RUF039.py:6:12: RUF039 [*] First argument to `re.findall()` is not raw string
   |
 4 | # Errors
 5 | re.compile('single free-spacing', flags=re.X)
@@ -31,6 +31,16 @@ RUF039.py:6:12: RUF039 First argument to `re.findall()` is not raw string
 8 | re.fullmatch('''t\riple single''')
   |
   = help: Replace with raw string
+
+ℹ Unsafe fix
+3 3 | 
+4 4 | # Errors
+5 5 | re.compile('single free-spacing', flags=re.X)
+6   |-re.findall('si\ngle')
+  6 |+re.findall(r'si\ngle')
+7 7 | re.finditer("dou\ble")
+8 8 | re.fullmatch('''t\riple single''')
+9 9 | re.match("""\triple double""")
 
 RUF039.py:7:13: RUF039 First argument to `re.finditer()` is not raw string
   |
@@ -43,7 +53,7 @@ RUF039.py:7:13: RUF039 First argument to `re.finditer()` is not raw string
   |
   = help: Replace with raw string
 
-RUF039.py:8:14: RUF039 First argument to `re.fullmatch()` is not raw string
+RUF039.py:8:14: RUF039 [*] First argument to `re.fullmatch()` is not raw string
    |
  6 | re.findall('si\ngle')
  7 | re.finditer("dou\ble")
@@ -54,7 +64,17 @@ RUF039.py:8:14: RUF039 First argument to `re.fullmatch()` is not raw string
    |
    = help: Replace with raw string
 
-RUF039.py:9:10: RUF039 First argument to `re.match()` is not raw string
+ℹ Unsafe fix
+5 5 | re.compile('single free-spacing', flags=re.X)
+6 6 | re.findall('si\ngle')
+7 7 | re.finditer("dou\ble")
+8   |-re.fullmatch('''t\riple single''')
+  8 |+re.fullmatch(r'''t\riple single''')
+9 9 | re.match("""\triple double""")
+10 10 | re.search('two', 'args')
+11 11 | re.split("raw", r'second')
+
+RUF039.py:9:10: RUF039 [*] First argument to `re.match()` is not raw string
    |
  7 | re.finditer("dou\ble")
  8 | re.fullmatch('''t\riple single''')
@@ -64,6 +84,16 @@ RUF039.py:9:10: RUF039 First argument to `re.match()` is not raw string
 11 | re.split("raw", r'second')
    |
    = help: Replace with raw string
+
+ℹ Unsafe fix
+6  6  | re.findall('si\ngle')
+7  7  | re.finditer("dou\ble")
+8  8  | re.fullmatch('''t\riple single''')
+9     |-re.match("""\triple double""")
+   9  |+re.match(r"""\triple double""")
+10 10 | re.search('two', 'args')
+11 11 | re.split("raw", r'second')
+12 12 | re.sub(u'''nicode''', u"f(?i)rst")
 
 RUF039.py:10:11: RUF039 [*] First argument to `re.search()` is not raw string
    |
@@ -117,7 +147,7 @@ RUF039.py:12:8: RUF039 First argument to `re.sub()` is not raw string
    |
    = help: Replace with raw string
 
-RUF039.py:13:9: RUF039 First argument to `re.subn()` is not raw bytes literal
+RUF039.py:13:9: RUF039 [*] First argument to `re.subn()` is not raw bytes literal
    |
 11 | re.split("raw", r'second')
 12 | re.sub(u'''nicode''', u"f(?i)rst")
@@ -127,6 +157,16 @@ RUF039.py:13:9: RUF039 First argument to `re.subn()` is not raw bytes literal
 15 | regex.compile('single free-spacing', flags=regex.X)
    |
    = help: Replace with raw bytes literal
+
+ℹ Safe fix
+10 10 | re.search('two', 'args')
+11 11 | re.split("raw", r'second')
+12 12 | re.sub(u'''nicode''', u"f(?i)rst")
+13    |-re.subn(b"""ytes are""", f"\u006e")
+   13 |+re.subn(rb"""ytes are""", f"\u006e")
+14 14 | 
+15 15 | regex.compile('single free-spacing', flags=regex.X)
+16 16 | regex.findall('si\ngle')
 
 RUF039.py:15:15: RUF039 [*] First argument to `regex.compile()` is not raw string
    |
@@ -149,7 +189,7 @@ RUF039.py:15:15: RUF039 [*] First argument to `regex.compile()` is not raw strin
 17 17 | regex.finditer("dou\ble")
 18 18 | regex.fullmatch('''t\riple single''')
 
-RUF039.py:16:15: RUF039 First argument to `regex.findall()` is not raw string
+RUF039.py:16:15: RUF039 [*] First argument to `regex.findall()` is not raw string
    |
 15 | regex.compile('single free-spacing', flags=regex.X)
 16 | regex.findall('si\ngle')
@@ -158,6 +198,16 @@ RUF039.py:16:15: RUF039 First argument to `regex.findall()` is not raw string
 18 | regex.fullmatch('''t\riple single''')
    |
    = help: Replace with raw string
+
+ℹ Unsafe fix
+13 13 | re.subn(b"""ytes are""", f"\u006e")
+14 14 | 
+15 15 | regex.compile('single free-spacing', flags=regex.X)
+16    |-regex.findall('si\ngle')
+   16 |+regex.findall(r'si\ngle')
+17 17 | regex.finditer("dou\ble")
+18 18 | regex.fullmatch('''t\riple single''')
+19 19 | regex.match("""\triple double""")
 
 RUF039.py:17:16: RUF039 First argument to `regex.finditer()` is not raw string
    |
@@ -170,7 +220,7 @@ RUF039.py:17:16: RUF039 First argument to `regex.finditer()` is not raw string
    |
    = help: Replace with raw string
 
-RUF039.py:18:17: RUF039 First argument to `regex.fullmatch()` is not raw string
+RUF039.py:18:17: RUF039 [*] First argument to `regex.fullmatch()` is not raw string
    |
 16 | regex.findall('si\ngle')
 17 | regex.finditer("dou\ble")
@@ -181,7 +231,17 @@ RUF039.py:18:17: RUF039 First argument to `regex.fullmatch()` is not raw string
    |
    = help: Replace with raw string
 
-RUF039.py:19:13: RUF039 First argument to `regex.match()` is not raw string
+ℹ Unsafe fix
+15 15 | regex.compile('single free-spacing', flags=regex.X)
+16 16 | regex.findall('si\ngle')
+17 17 | regex.finditer("dou\ble")
+18    |-regex.fullmatch('''t\riple single''')
+   18 |+regex.fullmatch(r'''t\riple single''')
+19 19 | regex.match("""\triple double""")
+20 20 | regex.search('two', 'args')
+21 21 | regex.split("raw", r'second')
+
+RUF039.py:19:13: RUF039 [*] First argument to `regex.match()` is not raw string
    |
 17 | regex.finditer("dou\ble")
 18 | regex.fullmatch('''t\riple single''')
@@ -191,6 +251,16 @@ RUF039.py:19:13: RUF039 First argument to `regex.match()` is not raw string
 21 | regex.split("raw", r'second')
    |
    = help: Replace with raw string
+
+ℹ Unsafe fix
+16 16 | regex.findall('si\ngle')
+17 17 | regex.finditer("dou\ble")
+18 18 | regex.fullmatch('''t\riple single''')
+19    |-regex.match("""\triple double""")
+   19 |+regex.match(r"""\triple double""")
+20 20 | regex.search('two', 'args')
+21 21 | regex.split("raw", r'second')
+22 22 | regex.sub(u'''nicode''', u"f(?i)rst")
 
 RUF039.py:20:14: RUF039 [*] First argument to `regex.search()` is not raw string
    |
@@ -244,7 +314,7 @@ RUF039.py:22:11: RUF039 First argument to `regex.sub()` is not raw string
    |
    = help: Replace with raw string
 
-RUF039.py:23:12: RUF039 First argument to `regex.subn()` is not raw bytes literal
+RUF039.py:23:12: RUF039 [*] First argument to `regex.subn()` is not raw bytes literal
    |
 21 | regex.split("raw", r'second')
 22 | regex.sub(u'''nicode''', u"f(?i)rst")
@@ -254,6 +324,16 @@ RUF039.py:23:12: RUF039 First argument to `regex.subn()` is not raw bytes litera
 25 | regex.template("""(?m)
    |
    = help: Replace with raw bytes literal
+
+ℹ Safe fix
+20 20 | regex.search('two', 'args')
+21 21 | regex.split("raw", r'second')
+22 22 | regex.sub(u'''nicode''', u"f(?i)rst")
+23    |-regex.subn(b"""ytes are""", f"\u006e")
+   23 |+regex.subn(rb"""ytes are""", f"\u006e")
+24 24 | 
+25 25 | regex.template("""(?m)
+26 26 |     (?:ulti)?
 
 RUF039.py:25:16: RUF039 [*] First argument to `regex.template()` is not raw string
    |
@@ -278,3 +358,111 @@ RUF039.py:25:16: RUF039 [*] First argument to `regex.template()` is not raw stri
 26 26 |     (?:ulti)?
 27 27 |     (?=(?<!(?<=(?!l)))
 28 28 |     l(?i:ne)
+
+RUF039.py:59:12: RUF039 [*] First argument to `re.compile()` is not raw string
+   |
+58 | # https://github.com/astral-sh/ruff/issues/16713
+59 | re.compile("\a\f\n\r\t\u27F2\U0001F0A1\v\x41")  # with unsafe fix
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RUF039
+60 | re.compile("\b")  # without fix
+61 | re.compile("\"")  # without fix
+   |
+   = help: Replace with raw string
+
+ℹ Unsafe fix
+56 56 | 
+57 57 | 
+58 58 | # https://github.com/astral-sh/ruff/issues/16713
+59    |-re.compile("\a\f\n\r\t\u27F2\U0001F0A1\v\x41")  # with unsafe fix
+   59 |+re.compile(r"\a\f\n\r\t\u27F2\U0001F0A1\v\x41")  # with unsafe fix
+60 60 | re.compile("\b")  # without fix
+61 61 | re.compile("\"")  # without fix
+62 62 | re.compile("\'")  # without fix
+
+RUF039.py:60:12: RUF039 First argument to `re.compile()` is not raw string
+   |
+58 | # https://github.com/astral-sh/ruff/issues/16713
+59 | re.compile("\a\f\n\r\t\u27F2\U0001F0A1\v\x41")  # with unsafe fix
+60 | re.compile("\b")  # without fix
+   |            ^^^^ RUF039
+61 | re.compile("\"")  # without fix
+62 | re.compile("\'")  # without fix
+   |
+   = help: Replace with raw string
+
+RUF039.py:61:12: RUF039 First argument to `re.compile()` is not raw string
+   |
+59 | re.compile("\a\f\n\r\t\u27F2\U0001F0A1\v\x41")  # with unsafe fix
+60 | re.compile("\b")  # without fix
+61 | re.compile("\"")  # without fix
+   |            ^^^^ RUF039
+62 | re.compile("\'")  # without fix
+63 | re.compile('\"')  # without fix
+   |
+   = help: Replace with raw string
+
+RUF039.py:62:12: RUF039 First argument to `re.compile()` is not raw string
+   |
+60 | re.compile("\b")  # without fix
+61 | re.compile("\"")  # without fix
+62 | re.compile("\'")  # without fix
+   |            ^^^^ RUF039
+63 | re.compile('\"')  # without fix
+64 | re.compile('\'')  # without fix
+   |
+   = help: Replace with raw string
+
+RUF039.py:63:12: RUF039 First argument to `re.compile()` is not raw string
+   |
+61 | re.compile("\"")  # without fix
+62 | re.compile("\'")  # without fix
+63 | re.compile('\"')  # without fix
+   |            ^^^^ RUF039
+64 | re.compile('\'')  # without fix
+65 | re.compile("\\")  # without fix
+   |
+   = help: Replace with raw string
+
+RUF039.py:64:12: RUF039 First argument to `re.compile()` is not raw string
+   |
+62 | re.compile("\'")  # without fix
+63 | re.compile('\"')  # without fix
+64 | re.compile('\'')  # without fix
+   |            ^^^^ RUF039
+65 | re.compile("\\")  # without fix
+66 | re.compile("\101")  # without fix
+   |
+   = help: Replace with raw string
+
+RUF039.py:65:12: RUF039 First argument to `re.compile()` is not raw string
+   |
+63 | re.compile('\"')  # without fix
+64 | re.compile('\'')  # without fix
+65 | re.compile("\\")  # without fix
+   |            ^^^^ RUF039
+66 | re.compile("\101")  # without fix
+67 | re.compile("a\
+   |
+   = help: Replace with raw string
+
+RUF039.py:66:12: RUF039 First argument to `re.compile()` is not raw string
+   |
+64 | re.compile('\'')  # without fix
+65 | re.compile("\\")  # without fix
+66 | re.compile("\101")  # without fix
+   |            ^^^^^^ RUF039
+67 | re.compile("a\
+68 | b")  # without fix
+   |
+   = help: Replace with raw string
+
+RUF039.py:67:12: RUF039 First argument to `re.compile()` is not raw string
+   |
+65 |   re.compile("\\")  # without fix
+66 |   re.compile("\101")  # without fix
+67 |   re.compile("a\
+   |  ____________^
+68 | | b")  # without fix
+   | |__^ RUF039
+   |
+   = help: Replace with raw string

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__preview__RUF039_RUF039_concat.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__preview__RUF039_RUF039_concat.py.snap
@@ -65,7 +65,7 @@ RUF039_concat.py:12:5: RUF039 [*] First argument to `re.findall()` is not raw st
 14 14 |     """
 15 15 | )
 
-RUF039_concat.py:26:5: RUF039 First argument to `re.match()` is not raw bytes literal
+RUF039_concat.py:26:5: RUF039 [*] First argument to `re.match()` is not raw bytes literal
    |
 24 | )
 25 | re.match(
@@ -75,6 +75,16 @@ RUF039_concat.py:26:5: RUF039 First argument to `re.match()` is not raw bytes li
 28 | )
    |
    = help: Replace with raw bytes literal
+
+ℹ Safe fix
+23 23 |     f'much?'
+24 24 | )
+25 25 | re.match(
+26    |-    b'reak'
+   26 |+    rb'reak'
+27 27 |     br'eak'
+28 28 | )
+29 29 | re.search(
 
 RUF039_concat.py:30:8: RUF039 First argument to `re.search()` is not raw string
    |
@@ -295,7 +305,7 @@ RUF039_concat.py:52:5: RUF039 [*] First argument to `regex.findall()` is not raw
 54 54 |     """
 55 55 | )
 
-RUF039_concat.py:66:5: RUF039 First argument to `regex.match()` is not raw bytes literal
+RUF039_concat.py:66:5: RUF039 [*] First argument to `regex.match()` is not raw bytes literal
    |
 64 | )
 65 | regex.match(
@@ -305,6 +315,16 @@ RUF039_concat.py:66:5: RUF039 First argument to `regex.match()` is not raw bytes
 68 | )
    |
    = help: Replace with raw bytes literal
+
+ℹ Safe fix
+63 63 |     f'much?'
+64 64 | )
+65 65 | regex.match(
+66    |-    b'reak'
+   66 |+    rb'reak'
+67 67 |     br'eak'
+68 68 | )
+69 69 | regex.search(
 
 RUF039_concat.py:70:8: RUF039 First argument to `regex.search()` is not raw string
    |
@@ -460,3 +480,223 @@ RUF039_concat.py:78:24: RUF039 [*] First argument to `regex.subn()` is not raw s
 79 79 | 
 80 80 | 
 81 81 | regex.template(
+
+RUF039_concat.py:98:5: RUF039 [*] First argument to `re.compile()` is not raw string
+    |
+ 96 | # https://github.com/astral-sh/ruff/issues/16713
+ 97 | re.compile(
+ 98 |     "["
+    |     ^^^ RUF039
+ 99 |     "\U0001F600-\U0001F64F"  # emoticons
+100 |     "\U0001F300-\U0001F5FF"  # symbols & pictographs
+    |
+    = help: Replace with raw string
+
+ℹ Safe fix
+95 95 | 
+96 96 | # https://github.com/astral-sh/ruff/issues/16713
+97 97 | re.compile(
+98    |-    "["
+   98 |+    r"["
+99 99 |     "\U0001F600-\U0001F64F"  # emoticons
+100 100 |     "\U0001F300-\U0001F5FF"  # symbols & pictographs
+101 101 |     "\U0001F680-\U0001F6FF"  # transport & map symbols
+
+RUF039_concat.py:99:5: RUF039 [*] First argument to `re.compile()` is not raw string
+    |
+ 97 | re.compile(
+ 98 |     "["
+ 99 |     "\U0001F600-\U0001F64F"  # emoticons
+    |     ^^^^^^^^^^^^^^^^^^^^^^^ RUF039
+100 |     "\U0001F300-\U0001F5FF"  # symbols & pictographs
+101 |     "\U0001F680-\U0001F6FF"  # transport & map symbols
+    |
+    = help: Replace with raw string
+
+ℹ Unsafe fix
+96  96  | # https://github.com/astral-sh/ruff/issues/16713
+97  97  | re.compile(
+98  98  |     "["
+99      |-    "\U0001F600-\U0001F64F"  # emoticons
+    99  |+    r"\U0001F600-\U0001F64F"  # emoticons
+100 100 |     "\U0001F300-\U0001F5FF"  # symbols & pictographs
+101 101 |     "\U0001F680-\U0001F6FF"  # transport & map symbols
+102 102 |     "\U0001F1E0-\U0001F1FF"  # flags (iOS)
+
+RUF039_concat.py:100:5: RUF039 [*] First argument to `re.compile()` is not raw string
+    |
+ 98 |     "["
+ 99 |     "\U0001F600-\U0001F64F"  # emoticons
+100 |     "\U0001F300-\U0001F5FF"  # symbols & pictographs
+    |     ^^^^^^^^^^^^^^^^^^^^^^^ RUF039
+101 |     "\U0001F680-\U0001F6FF"  # transport & map symbols
+102 |     "\U0001F1E0-\U0001F1FF"  # flags (iOS)
+    |
+    = help: Replace with raw string
+
+ℹ Unsafe fix
+97  97  | re.compile(
+98  98  |     "["
+99  99  |     "\U0001F600-\U0001F64F"  # emoticons
+100     |-    "\U0001F300-\U0001F5FF"  # symbols & pictographs
+    100 |+    r"\U0001F300-\U0001F5FF"  # symbols & pictographs
+101 101 |     "\U0001F680-\U0001F6FF"  # transport & map symbols
+102 102 |     "\U0001F1E0-\U0001F1FF"  # flags (iOS)
+103 103 |     "\U00002702-\U000027B0"
+
+RUF039_concat.py:101:5: RUF039 [*] First argument to `re.compile()` is not raw string
+    |
+ 99 |     "\U0001F600-\U0001F64F"  # emoticons
+100 |     "\U0001F300-\U0001F5FF"  # symbols & pictographs
+101 |     "\U0001F680-\U0001F6FF"  # transport & map symbols
+    |     ^^^^^^^^^^^^^^^^^^^^^^^ RUF039
+102 |     "\U0001F1E0-\U0001F1FF"  # flags (iOS)
+103 |     "\U00002702-\U000027B0"
+    |
+    = help: Replace with raw string
+
+ℹ Unsafe fix
+98  98  |     "["
+99  99  |     "\U0001F600-\U0001F64F"  # emoticons
+100 100 |     "\U0001F300-\U0001F5FF"  # symbols & pictographs
+101     |-    "\U0001F680-\U0001F6FF"  # transport & map symbols
+    101 |+    r"\U0001F680-\U0001F6FF"  # transport & map symbols
+102 102 |     "\U0001F1E0-\U0001F1FF"  # flags (iOS)
+103 103 |     "\U00002702-\U000027B0"
+104 104 |     "\U000024C2-\U0001F251"
+
+RUF039_concat.py:102:5: RUF039 [*] First argument to `re.compile()` is not raw string
+    |
+100 |     "\U0001F300-\U0001F5FF"  # symbols & pictographs
+101 |     "\U0001F680-\U0001F6FF"  # transport & map symbols
+102 |     "\U0001F1E0-\U0001F1FF"  # flags (iOS)
+    |     ^^^^^^^^^^^^^^^^^^^^^^^ RUF039
+103 |     "\U00002702-\U000027B0"
+104 |     "\U000024C2-\U0001F251"
+    |
+    = help: Replace with raw string
+
+ℹ Unsafe fix
+99  99  |     "\U0001F600-\U0001F64F"  # emoticons
+100 100 |     "\U0001F300-\U0001F5FF"  # symbols & pictographs
+101 101 |     "\U0001F680-\U0001F6FF"  # transport & map symbols
+102     |-    "\U0001F1E0-\U0001F1FF"  # flags (iOS)
+    102 |+    r"\U0001F1E0-\U0001F1FF"  # flags (iOS)
+103 103 |     "\U00002702-\U000027B0"
+104 104 |     "\U000024C2-\U0001F251"
+105 105 |     "\u200d"  # zero width joiner
+
+RUF039_concat.py:103:5: RUF039 [*] First argument to `re.compile()` is not raw string
+    |
+101 |     "\U0001F680-\U0001F6FF"  # transport & map symbols
+102 |     "\U0001F1E0-\U0001F1FF"  # flags (iOS)
+103 |     "\U00002702-\U000027B0"
+    |     ^^^^^^^^^^^^^^^^^^^^^^^ RUF039
+104 |     "\U000024C2-\U0001F251"
+105 |     "\u200d"  # zero width joiner
+    |
+    = help: Replace with raw string
+
+ℹ Unsafe fix
+100 100 |     "\U0001F300-\U0001F5FF"  # symbols & pictographs
+101 101 |     "\U0001F680-\U0001F6FF"  # transport & map symbols
+102 102 |     "\U0001F1E0-\U0001F1FF"  # flags (iOS)
+103     |-    "\U00002702-\U000027B0"
+    103 |+    r"\U00002702-\U000027B0"
+104 104 |     "\U000024C2-\U0001F251"
+105 105 |     "\u200d"  # zero width joiner
+106 106 |     "\u200c"  # zero width non-joiner
+
+RUF039_concat.py:104:5: RUF039 [*] First argument to `re.compile()` is not raw string
+    |
+102 |     "\U0001F1E0-\U0001F1FF"  # flags (iOS)
+103 |     "\U00002702-\U000027B0"
+104 |     "\U000024C2-\U0001F251"
+    |     ^^^^^^^^^^^^^^^^^^^^^^^ RUF039
+105 |     "\u200d"  # zero width joiner
+106 |     "\u200c"  # zero width non-joiner
+    |
+    = help: Replace with raw string
+
+ℹ Unsafe fix
+101 101 |     "\U0001F680-\U0001F6FF"  # transport & map symbols
+102 102 |     "\U0001F1E0-\U0001F1FF"  # flags (iOS)
+103 103 |     "\U00002702-\U000027B0"
+104     |-    "\U000024C2-\U0001F251"
+    104 |+    r"\U000024C2-\U0001F251"
+105 105 |     "\u200d"  # zero width joiner
+106 106 |     "\u200c"  # zero width non-joiner
+107 107 |     "\\u200c" # must not be escaped in a raw string
+
+RUF039_concat.py:105:5: RUF039 [*] First argument to `re.compile()` is not raw string
+    |
+103 |     "\U00002702-\U000027B0"
+104 |     "\U000024C2-\U0001F251"
+105 |     "\u200d"  # zero width joiner
+    |     ^^^^^^^^ RUF039
+106 |     "\u200c"  # zero width non-joiner
+107 |     "\\u200c" # must not be escaped in a raw string
+    |
+    = help: Replace with raw string
+
+ℹ Unsafe fix
+102 102 |     "\U0001F1E0-\U0001F1FF"  # flags (iOS)
+103 103 |     "\U00002702-\U000027B0"
+104 104 |     "\U000024C2-\U0001F251"
+105     |-    "\u200d"  # zero width joiner
+    105 |+    r"\u200d"  # zero width joiner
+106 106 |     "\u200c"  # zero width non-joiner
+107 107 |     "\\u200c" # must not be escaped in a raw string
+108 108 |     "]+",
+
+RUF039_concat.py:106:5: RUF039 [*] First argument to `re.compile()` is not raw string
+    |
+104 |     "\U000024C2-\U0001F251"
+105 |     "\u200d"  # zero width joiner
+106 |     "\u200c"  # zero width non-joiner
+    |     ^^^^^^^^ RUF039
+107 |     "\\u200c" # must not be escaped in a raw string
+108 |     "]+",
+    |
+    = help: Replace with raw string
+
+ℹ Unsafe fix
+103 103 |     "\U00002702-\U000027B0"
+104 104 |     "\U000024C2-\U0001F251"
+105 105 |     "\u200d"  # zero width joiner
+106     |-    "\u200c"  # zero width non-joiner
+    106 |+    r"\u200c"  # zero width non-joiner
+107 107 |     "\\u200c" # must not be escaped in a raw string
+108 108 |     "]+",
+109 109 |     flags=re.UNICODE,
+
+RUF039_concat.py:107:5: RUF039 First argument to `re.compile()` is not raw string
+    |
+105 |     "\u200d"  # zero width joiner
+106 |     "\u200c"  # zero width non-joiner
+107 |     "\\u200c" # must not be escaped in a raw string
+    |     ^^^^^^^^^ RUF039
+108 |     "]+",
+109 |     flags=re.UNICODE,
+    |
+    = help: Replace with raw string
+
+RUF039_concat.py:108:5: RUF039 [*] First argument to `re.compile()` is not raw string
+    |
+106 |     "\u200c"  # zero width non-joiner
+107 |     "\\u200c" # must not be escaped in a raw string
+108 |     "]+",
+    |     ^^^^ RUF039
+109 |     flags=re.UNICODE,
+110 | )
+    |
+    = help: Replace with raw string
+
+ℹ Safe fix
+105 105 |     "\u200d"  # zero width joiner
+106 106 |     "\u200c"  # zero width non-joiner
+107 107 |     "\\u200c" # must not be escaped in a raw string
+108     |-    "]+",
+    108 |+    r"]+",
+109 109 |     flags=re.UNICODE,
+110 110 | )

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__preview__py37__RUF039_RUF039_py_version_sensitive.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__preview__py37__RUF039_RUF039_py_version_sensitive.py.snap
@@ -1,0 +1,11 @@
+---
+source: crates/ruff_linter/src/rules/ruff/mod.rs
+---
+RUF039_py_version_sensitive.py:3:12: RUF039 First argument to `re.compile()` is not raw string
+  |
+1 | import re
+2 |
+3 | re.compile("\N{Partial Differential}")  # with unsafe fix if python target is 3.8 or higher, else without fix
+  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^ RUF039
+  |
+  = help: Replace with raw string

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__preview__py38__RUF039_RUF039_py_version_sensitive.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__preview__py38__RUF039_RUF039_py_version_sensitive.py.snap
@@ -1,0 +1,17 @@
+---
+source: crates/ruff_linter/src/rules/ruff/mod.rs
+---
+RUF039_py_version_sensitive.py:3:12: RUF039 [*] First argument to `re.compile()` is not raw string
+  |
+1 | import re
+2 |
+3 | re.compile("\N{Partial Differential}")  # with unsafe fix if python target is 3.8 or higher, else without fix
+  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^ RUF039
+  |
+  = help: Replace with raw string
+
+ℹ Unsafe fix
+1 1 | import re
+2 2 | 
+3   |-re.compile("\N{Partial Differential}")  # with unsafe fix if python target is 3.8 or higher, else without fix
+  3 |+re.compile(r"\N{Partial Differential}")  # with unsafe fix if python target is 3.8 or higher, else without fix


### PR DESCRIPTION
## Summary
Expand cases in which ruff can offer a fix for `RUF039` (some of which are unsafe).

While turning `"\n"` (== `\n`) into `r"\n"` (== `\\n`) is not equivalent at run-time, it's still functionally equivalent to do so in the context of [regex patterns](https://docs.python.org/3/library/re.html#regular-expression-syntax) as they themselves interpret the escape sequence. Therefore, an unsafe fix can be offered.

Further, this PR also makes ruff offer fixes for byte string literals, not only strings literals as before.

## Test Plan
Tests for all escape sequences have been added.

## Related
Closes: https://github.com/astral-sh/ruff/issues/16713
