### PR TITLE
[ty] Allow declared-only class-level attributes to be accessed on the class

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/dunder.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/dunder.md
@@ -120,8 +120,7 @@ def _(flag: bool):
 
 ### Dunder methods as class-level annotations with no value
 
-Class-level annotations with no value assigned are considered instance-only, and aren't available as
-dunder methods:
+Class-level annotations with no value assigned are considered to be accessible on the class:
 
 ```py
 from typing import Callable
@@ -129,10 +128,8 @@ from typing import Callable
 class C:
     __call__: Callable[..., None]
 
-# error: [call-non-callable]
 C()()
 
-# error: [invalid-assignment]
 _: Callable[..., None] = C()
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/dataclasses.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses.md
@@ -810,21 +810,6 @@ D(1)  # OK
 D()  # error: [missing-argument]
 ```
 
-### Accessing instance attributes on the class itself
-
-Just like for normal classes, accessing instance attributes on the class itself is not allowed:
-
-```py
-from dataclasses import dataclass
-
-@dataclass
-class C:
-    x: int
-
-# error: [unresolved-attribute] "Attribute `x` can only be accessed on instances, not on the class object `<class 'C'>` itself."
-C.x
-```
-
 ### Return type of `dataclass(...)`
 
 A call like `dataclass(order=True)` returns a callable itself, which is then used as the decorator.

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -533,6 +533,12 @@ class FooSubclassOfAny:
     x: SubclassOfAny
 
 static_assert(not is_subtype_of(FooSubclassOfAny, HasX))
+
+# `FooSubclassOfAny` is assignable to `HasX` for the following reason. The `x` attribute on `FooSubclassOfAny`
+# is accessible on the class itself. When accessing `x` on an instance, the descriptor protocol is invoked, and
+# `__get__` is looked up on `SubclassOfAny`. Every member access on `SubclassOfAny` yields `Any`, so `__get__` is
+# also available, and calling `Any` also yields `Any`. Thus, accessing `x` on an instance of `FooSubclassOfAny`
+# yields `Any`, which is assignable to `int` and vice versa.
 static_assert(is_assignable_to(FooSubclassOfAny, HasX))
 
 class FooWithY(Foo):

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -533,7 +533,7 @@ class FooSubclassOfAny:
     x: SubclassOfAny
 
 static_assert(not is_subtype_of(FooSubclassOfAny, HasX))
-static_assert(not is_assignable_to(FooSubclassOfAny, HasX))
+static_assert(is_assignable_to(FooSubclassOfAny, HasX))
 
 class FooWithY(Foo):
     y: int
@@ -1586,11 +1586,7 @@ def g(a: Truthy, b: FalsyFoo, c: FalsyFooSubclass):
     reveal_type(bool(c))  # revealed: Literal[False]
 ```
 
-It is not sufficient for a protocol to have a callable `__bool__` instance member that returns
-`Literal[True]` for it to be considered always truthy. Dunder methods are looked up on the class
-rather than the instance. If a protocol `X` has an instance-attribute `__bool__` member, it is
-unknowable whether that attribute can be accessed on the type of an object that satisfies `X`'s
-interface:
+The same works with a class-level declaration of `__bool__`:
 
 ```py
 from typing import Callable
@@ -1599,7 +1595,7 @@ class InstanceAttrBool(Protocol):
     __bool__: Callable[[], Literal[True]]
 
 def h(obj: InstanceAttrBool):
-    reveal_type(bool(obj))  # revealed: bool
+    reveal_type(bool(obj))  # revealed: Literal[True]
 ```
 
 ## Callable protocols
@@ -1832,7 +1828,8 @@ def _(r: Recursive):
     reveal_type(r.direct)  # revealed: Recursive
     reveal_type(r.union)  # revealed: None | Recursive
     reveal_type(r.intersection1)  # revealed: C & Recursive
-    reveal_type(r.intersection2)  # revealed: C & ~Recursive
+    # revealed: @Todo(map_with_boundness: intersections with negative contributions) | (C & ~Recursive)
+    reveal_type(r.intersection2)
     reveal_type(r.t)  # revealed: tuple[int, tuple[str, Recursive]]
     reveal_type(r.callable1)  # revealed: (int, /) -> Recursive
     reveal_type(r.callable2)  # revealed: (Recursive, /) -> int

--- a/crates/ty_python_semantic/resources/mdtest/type_qualifiers/classvar.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_qualifiers/classvar.md
@@ -64,24 +64,6 @@ c = C()
 c.a = 2
 ```
 
-and similarly here:
-
-```py
-class Base:
-    a: ClassVar[int] = 1
-
-class Derived(Base):
-    if flag():
-        a: int
-
-reveal_type(Derived.a)  # revealed: int
-
-d = Derived()
-
-# error: [invalid-attribute-access]
-d.a = 2
-```
-
 ## Too many arguments
 
 ```py

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -235,29 +235,28 @@ pub(crate) fn class_symbol<'db>(
 ) -> PlaceAndQualifiers<'db> {
     place_table(db, scope)
         .place_id_by_name(name)
-        .map(|symbol| {
-            let symbol_and_quals = place_by_id(
+        .map(|place| {
+            let place_and_quals = place_by_id(
                 db,
                 scope,
-                symbol,
+                place,
                 RequiresExplicitReExport::No,
                 ConsideredDefinitions::EndOfScope,
             );
 
-            if symbol_and_quals.is_class_var() {
-                // For declared class vars we do not need to check if they have bindings,
-                // we just trust the declaration.
-                return symbol_and_quals;
+            if !place_and_quals.place.is_unbound() {
+                // Trust the declared type if we see a class-level declaration
+                return place_and_quals;
             }
 
             if let PlaceAndQualifiers {
                 place: Place::Type(ty, _),
                 qualifiers,
-            } = symbol_and_quals
+            } = place_and_quals
             {
                 // Otherwise, we need to check if the symbol has bindings
                 let use_def = use_def_map(db, scope);
-                let bindings = use_def.end_of_scope_bindings(symbol);
+                let bindings = use_def.end_of_scope_bindings(place);
                 let inferred = place_from_bindings_impl(db, bindings, RequiresExplicitReExport::No);
 
                 // TODO: we should not need to calculate inferred type second time. This is a temporary


### PR DESCRIPTION
## Summary

Allow declared-only class-level attributes to be accessed on the class:
```py
class C:
    attr: int

C.attr  # this is now allowed
``` 

closes https://github.com/astral-sh/ty/issues/384
closes https://github.com/astral-sh/ty/issues/553

## Ecosystem analysis

![image](https://github.com/user-attachments/assets/7aa6c130-36a5-4466-8888-808ee1865aff)

* We see many removed `unresolved-attribute` false-positives for code that makes use of sqlalchemy, as expected (see changes for `prefect`)
* We see many removed `call-non-callable` false-positives for uses of `pytest.skip` and similar, as expected
* Most new diagnostics seem to be related to cases like the following, where we previously inferred `int` for `Derived().x`, but now we infer `int | None`. I think this should be a conflicting-declarations/bad-override error anyway? The new behavior may even be preferred here?
  ```py
  class Base:
      x: int | None
  
  
  class Derived(Base):
      def __init__(self):
          self.x: int = 1
  ```

## Test Plan

<!-- How was it tested? -->
