### PR TITLE
[`flake8-pyi`] Make example error out-of-the-box (`PYI062`)

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/duplicate_literal_member.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/duplicate_literal_member.rs
@@ -19,11 +19,15 @@ use crate::{AlwaysFixableViolation, Applicability, Edit, Fix};
 ///
 /// ## Example
 /// ```python
+/// from typing import Literal
+///
 /// foo: Literal["a", "b", "a"]
 /// ```
 ///
 /// Use instead:
 /// ```python
+/// from typing import Literal
+///
 /// foo: Literal["a", "b"]
 /// ```
 ///


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Part of #18972

This PR makes [duplicate-literal-member (PYI062)](https://docs.astral.sh/ruff/rules/duplicate-literal-member/#duplicate-literal-member-pyi062)'s example error out-of-the-box

[Old example](https://play.ruff.rs/6b00b41c-c1c5-4421-873d-fc2a143e7337)
```py
foo: Literal["a", "b", "a"]
```

[New example](https://play.ruff.rs/1aea839b-9ae8-4848-bb83-2637e1a68ce4)
```py
from typing import Literal

foo: Literal["a", "b", "a"]
```

Imports were also added to the "use instead" section.

## Test Plan

<!-- How was it tested? -->

N/A, no functionality/tests affected