### PR TITLE
[ty] Use better datetime format for server logs

### DIFF
--- a/crates/ty_server/Cargo.toml
+++ b/crates/ty_server/Cargo.toml
@@ -31,7 +31,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 shellexpand = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["chrono"] }
 
 [dev-dependencies]
 

--- a/crates/ty_server/src/logging.rs
+++ b/crates/ty_server/src/logging.rs
@@ -4,17 +4,18 @@
 //! are written to `stderr` by default, which should appear in the logs for most LSP clients. A
 //! `logFile` path can also be specified in the settings, and output will be directed there
 //! instead.
-use core::str;
-use serde::Deserialize;
-use std::{path::PathBuf, str::FromStr, sync::Arc};
-use tracing::level_filters::LevelFilter;
-use tracing_subscriber::{
-    Layer,
-    fmt::{time::Uptime, writer::BoxMakeWriter},
-    layer::SubscriberExt,
-};
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::sync::Arc;
 
-pub(crate) fn init_logging(log_level: LogLevel, log_file: Option<&std::path::Path>) {
+use serde::Deserialize;
+use tracing::level_filters::LevelFilter;
+use tracing_subscriber::Layer;
+use tracing_subscriber::fmt::time::ChronoLocal;
+use tracing_subscriber::fmt::writer::BoxMakeWriter;
+use tracing_subscriber::layer::SubscriberExt;
+
+pub(crate) fn init_logging(log_level: LogLevel, log_file: Option<&Path>) {
     let log_file = log_file
         .map(|path| {
             // this expands `logFile` so that tildes and environment variables
@@ -49,10 +50,11 @@ pub(crate) fn init_logging(log_level: LogLevel, log_file: Option<&std::path::Pat
         Some(file) => BoxMakeWriter::new(Arc::new(file)),
         None => BoxMakeWriter::new(std::io::stderr),
     };
+    let is_trace_level = log_level == LogLevel::Trace;
     let subscriber = tracing_subscriber::Registry::default().with(
         tracing_subscriber::fmt::layer()
-            .with_timer(Uptime::default())
-            .with_thread_names(true)
+            .with_timer(ChronoLocal::new("%Y-%m-%d %H:%M:%S.%f".to_string()))
+            .with_thread_names(is_trace_level)
             .with_ansi(false)
             .with_writer(logger)
             .with_filter(LogLevelFilter { filter: log_level }),
@@ -108,7 +110,7 @@ impl<S> tracing_subscriber::layer::Filter<S> for LogLevelFilter {
         meta.level() <= &filter
     }
 
-    fn max_level_hint(&self) -> Option<tracing::level_filters::LevelFilter> {
+    fn max_level_hint(&self) -> Option<LevelFilter> {
         Some(LevelFilter::from_level(self.filter.trace_level()))
     }
 }


### PR DESCRIPTION
This PR improves the timer format for ty server logs to be same as Ruff.

Ref: https://github.com/astral-sh/ruff/pull/16389