### PR TITLE
[ty] Log target names at trace level

### DIFF
--- a/crates/ty_server/src/logging.rs
+++ b/crates/ty_server/src/logging.rs
@@ -55,6 +55,7 @@ pub(crate) fn init_logging(log_level: LogLevel, log_file: Option<&Path>) {
         tracing_subscriber::fmt::layer()
             .with_timer(ChronoLocal::new("%Y-%m-%d %H:%M:%S.%f".to_string()))
             .with_thread_names(is_trace_level)
+            .with_target(is_trace_level)
             .with_ansi(false)
             .with_writer(logger)
             .with_filter(LogLevelFilter { filter: log_level }),


### PR DESCRIPTION
Follow-up to https://github.com/astral-sh/ruff/pull/19083, also log the target names like `ty_python_semantic::module_resolver::resolver` in `2025-07-02 10:12:20.188697000 DEBUG ty_python_semantic::module_resolver::resolver: Adding first-party search path '/Users/dhruv/playground/ty_server'` at trace level.