### PR TITLE
[ty] Remove last vestiges of `std::path` from `ty_server`

### DIFF
--- a/crates/ty_server/src/session.rs
+++ b/crates/ty_server/src/session.rs
@@ -2,7 +2,6 @@
 
 use std::collections::{BTreeMap, VecDeque};
 use std::ops::{Deref, DerefMut};
-use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::{Context, anyhow};
@@ -235,14 +234,7 @@ impl Session {
             // In the future, index the workspace directories to find all projects
             // and create a project database for each.
             let system = LSPSystem::new(self.index.as_ref().unwrap().clone());
-
-            let Some(system_path) = SystemPath::from_std_path(workspace.root()) else {
-                tracing::warn!(
-                    "Ignore workspace `{}` because it's root contains non UTF8 characters",
-                    workspace.root().display()
-                );
-                continue;
-            };
+            let system_path = workspace.root();
 
             let root = system_path.to_path_buf();
             let project = ProjectMetadata::discover(&root, &system)
@@ -473,11 +465,15 @@ impl Workspaces {
             .to_file_path()
             .map_err(|()| anyhow!("Workspace URL is not a file or directory: {url:?}"))?;
 
+        // Realistically I don't think this can fail because we got the path from a Url
+        let system_path = SystemPathBuf::from_path_buf(path)
+            .map_err(|_| anyhow!("Workspace URL is not valid UTF8"))?;
+
         self.workspaces.insert(
             url,
             Workspace {
                 options,
-                root: path,
+                root: system_path,
             },
         );
 
@@ -520,12 +516,12 @@ impl<'a> IntoIterator for &'a Workspaces {
 
 #[derive(Debug)]
 pub(crate) struct Workspace {
-    root: PathBuf,
+    root: SystemPathBuf,
     options: ClientOptions,
 }
 
 impl Workspace {
-    pub(crate) fn root(&self) -> &Path {
+    pub(crate) fn root(&self) -> &SystemPath {
         &self.root
     }
 }

--- a/crates/ty_server/src/session/options.rs
+++ b/crates/ty_server/src/session/options.rs
@@ -1,6 +1,5 @@
-use std::path::PathBuf;
-
 use lsp_types::Url;
+use ruff_db::system::SystemPathBuf;
 use rustc_hash::FxHashMap;
 use serde::Deserialize;
 
@@ -89,7 +88,7 @@ pub(crate) struct TracingOptions {
     pub(crate) log_level: Option<LogLevel>,
 
     /// Path to the log file - tildes and environment variables are supported.
-    pub(crate) log_file: Option<PathBuf>,
+    pub(crate) log_file: Option<SystemPathBuf>,
 }
 
 /// This is the exact schema for initialization options sent in by the client during


### PR DESCRIPTION
Fixes https://github.com/astral-sh/ty/issues/603