### PR TITLE
[ty] Rewrite `Type::any_over_type` using a new generalised `TypeVisitor` trait

### DIFF
--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -43,6 +43,7 @@ pub mod pull_types;
 
 type FxOrderSet<V> = ordermap::set::OrderSet<V, BuildHasherDefault<FxHasher>>;
 type FxIndexMap<K, V> = indexmap::IndexMap<K, V, BuildHasherDefault<FxHasher>>;
+type FxIndexSet<V> = indexmap::IndexSet<V, BuildHasherDefault<FxHasher>>;
 
 /// Returns the default registry with all known semantic lints.
 pub fn default_lint_registry() -> &'static LintRegistry {

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -21,8 +21,8 @@ use crate::types::signatures::{CallableSignature, Parameter, Parameters, Signatu
 use crate::types::tuple::TupleType;
 use crate::types::{
     BareTypeAliasType, Binding, BoundSuperError, BoundSuperType, CallableType, DataclassParams,
-    KnownInstanceType, TypeAliasType, TypeMapping, TypeRelation, TypeVarBoundOrConstraints,
-    TypeVarInstance, TypeVarKind, TypeVisitor, infer_definition_types,
+    KnownInstanceType, TypeAliasType, TypeMapping, TypeRelation, TypeTransformer,
+    TypeVarBoundOrConstraints, TypeVarInstance, TypeVarKind, infer_definition_types,
 };
 use crate::{
     Db, FxOrderSet, KnownModule, Program,
@@ -190,7 +190,11 @@ pub(super) fn walk_generic_alias<'db, V: super::visitor::TypeVisitor<'db> + ?Siz
 impl get_size2::GetSize for GenericAlias<'_> {}
 
 impl<'db> GenericAlias<'db> {
-    pub(super) fn normalized_impl(self, db: &'db dyn Db, visitor: &mut TypeVisitor<'db>) -> Self {
+    pub(super) fn normalized_impl(
+        self,
+        db: &'db dyn Db,
+        visitor: &mut TypeTransformer<'db>,
+    ) -> Self {
         Self::new(
             db,
             self.origin(db),
@@ -261,7 +265,11 @@ pub enum ClassType<'db> {
 
 #[salsa::tracked]
 impl<'db> ClassType<'db> {
-    pub(super) fn normalized_impl(self, db: &'db dyn Db, visitor: &mut TypeVisitor<'db>) -> Self {
+    pub(super) fn normalized_impl(
+        self,
+        db: &'db dyn Db,
+        visitor: &mut TypeTransformer<'db>,
+    ) -> Self {
         match self {
             Self::NonGeneric(_) => self,
             Self::Generic(generic) => Self::Generic(generic.normalized_impl(db, visitor)),

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -15,7 +15,7 @@ use crate::semantic_index::{DeclarationWithConstraint, SemanticIndex};
 use crate::types::context::InferContext;
 use crate::types::diagnostic::{INVALID_LEGACY_TYPE_VARIABLE, INVALID_TYPE_ALIAS_TYPE};
 use crate::types::function::{DataclassTransformerParams, KnownFunction};
-use crate::types::generics::{GenericContext, Specialization};
+use crate::types::generics::{GenericContext, Specialization, walk_specialization};
 use crate::types::infer::nearest_enclosing_class;
 use crate::types::signatures::{CallableSignature, Parameter, Parameters, Signature};
 use crate::types::tuple::TupleType;
@@ -176,6 +176,14 @@ impl CodeGeneratorKind {
 pub struct GenericAlias<'db> {
     pub(crate) origin: ClassLiteral<'db>,
     pub(crate) specialization: Specialization<'db>,
+}
+
+pub(super) fn walk_generic_alias<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
+    db: &'db dyn Db,
+    alias: GenericAlias<'db>,
+    visitor: &mut V,
+) {
+    walk_specialization(db, alias.specialization(db), visitor);
 }
 
 // The Salsa heap is tracked separately.

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -2,7 +2,7 @@ use crate::Db;
 use crate::types::generics::Specialization;
 use crate::types::{
     ClassType, DynamicType, KnownClass, KnownInstanceType, MroError, MroIterator, SpecialFormType,
-    Type, TypeMapping, TypeVisitor, todo_type,
+    Type, TypeMapping, TypeTransformer, todo_type,
 };
 
 /// Enumeration of the possible kinds of types we allow in class bases.
@@ -31,7 +31,11 @@ impl<'db> ClassBase<'db> {
         Self::Dynamic(DynamicType::Unknown)
     }
 
-    pub(crate) fn normalized_impl(self, db: &'db dyn Db, visitor: &mut TypeVisitor<'db>) -> Self {
+    pub(crate) fn normalized_impl(
+        self,
+        db: &'db dyn Db,
+        visitor: &mut TypeTransformer<'db>,
+    ) -> Self {
         match self {
             Self::Dynamic(dynamic) => Self::Dynamic(dynamic.normalized()),
             Self::Class(class) => Self::Class(class.normalized_impl(db, visitor)),

--- a/crates/ty_python_semantic/src/types/cyclic.rs
+++ b/crates/ty_python_semantic/src/types/cyclic.rs
@@ -1,12 +1,12 @@
-use crate::FxOrderSet;
+use crate::FxIndexSet;
 use crate::types::Type;
 
 #[derive(Debug, Default)]
-pub(crate) struct TypeVisitor<'db> {
-    seen: FxOrderSet<Type<'db>>,
+pub(crate) struct TypeTransformer<'db> {
+    seen: FxIndexSet<Type<'db>>,
 }
 
-impl<'db> TypeVisitor<'db> {
+impl<'db> TypeTransformer<'db> {
     pub(crate) fn visit(
         &mut self,
         ty: Type<'db>,

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -76,7 +76,7 @@ use crate::types::signatures::{CallableSignature, Signature};
 use crate::types::visitor::any_over_type;
 use crate::types::{
     BoundMethodType, CallableType, DynamicType, KnownClass, Type, TypeMapping, TypeRelation,
-    TypeVarInstance, TypeVisitor, walk_type_mapping,
+    TypeTransformer, TypeVarInstance, walk_type_mapping,
 };
 use crate::{Db, FxOrderSet, ModuleName, resolve_module};
 
@@ -556,7 +556,7 @@ impl<'db> FunctionLiteral<'db> {
         }))
     }
 
-    fn normalized_impl(self, db: &'db dyn Db, visitor: &mut TypeVisitor<'db>) -> Self {
+    fn normalized_impl(self, db: &'db dyn Db, visitor: &mut TypeTransformer<'db>) -> Self {
         let context = self
             .inherited_generic_context(db)
             .map(|ctx| ctx.normalized_impl(db, visitor));
@@ -841,11 +841,15 @@ impl<'db> FunctionType<'db> {
     }
 
     pub(crate) fn normalized(self, db: &'db dyn Db) -> Self {
-        let mut visitor = TypeVisitor::default();
+        let mut visitor = TypeTransformer::default();
         self.normalized_impl(db, &mut visitor)
     }
 
-    pub(crate) fn normalized_impl(self, db: &'db dyn Db, visitor: &mut TypeVisitor<'db>) -> Self {
+    pub(crate) fn normalized_impl(
+        self,
+        db: &'db dyn Db,
+        visitor: &mut TypeTransformer<'db>,
+    ) -> Self {
         let mappings: Box<_> = self
             .type_mappings(db)
             .iter()

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -10,8 +10,8 @@ use crate::types::instance::{NominalInstanceType, Protocol, ProtocolInstanceType
 use crate::types::signatures::{Parameter, Parameters, Signature};
 use crate::types::tuple::{TupleSpec, TupleType};
 use crate::types::{
-    KnownInstanceType, Type, TypeMapping, TypeRelation, TypeVarBoundOrConstraints, TypeVarInstance,
-    TypeVarVariance, TypeVisitor, UnionType, declaration_type,
+    KnownInstanceType, Type, TypeMapping, TypeRelation, TypeTransformer, TypeVarBoundOrConstraints,
+    TypeVarInstance, TypeVarVariance, UnionType, declaration_type,
 };
 use crate::{Db, FxOrderSet};
 
@@ -243,7 +243,11 @@ impl<'db> GenericContext<'db> {
         Specialization::new(db, self, expanded.into_boxed_slice(), None)
     }
 
-    pub(crate) fn normalized_impl(self, db: &'db dyn Db, visitor: &mut TypeVisitor<'db>) -> Self {
+    pub(crate) fn normalized_impl(
+        self,
+        db: &'db dyn Db,
+        visitor: &mut TypeTransformer<'db>,
+    ) -> Self {
         let variables: FxOrderSet<_> = self
             .variables(db)
             .iter()
@@ -400,7 +404,11 @@ impl<'db> Specialization<'db> {
         Specialization::new(db, self.generic_context(db), types, None)
     }
 
-    pub(crate) fn normalized_impl(self, db: &'db dyn Db, visitor: &mut TypeVisitor<'db>) -> Self {
+    pub(crate) fn normalized_impl(
+        self,
+        db: &'db dyn Db,
+        visitor: &mut TypeTransformer<'db>,
+    ) -> Self {
         let types: Box<[_]> = self
             .types(db)
             .iter()
@@ -571,7 +579,7 @@ impl<'db> PartialSpecialization<'_, 'db> {
     pub(crate) fn normalized_impl(
         &self,
         db: &'db dyn Db,
-        visitor: &mut TypeVisitor<'db>,
+        visitor: &mut TypeTransformer<'db>,
     ) -> PartialSpecialization<'db, 'db> {
         let generic_context = self.generic_context.normalized_impl(db, visitor);
         let types: Cow<_> = self

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -15,7 +15,7 @@ use std::{collections::HashMap, slice::Iter};
 use itertools::EitherOrBoth;
 use smallvec::{SmallVec, smallvec};
 
-use super::{DynamicType, Type, TypeVarVariance, TypeVisitor, definition_expression_type};
+use super::{DynamicType, Type, TypeTransformer, TypeVarVariance, definition_expression_type};
 use crate::semantic_index::definition::Definition;
 use crate::types::generics::{GenericContext, walk_generic_context};
 use crate::types::{TypeMapping, TypeRelation, TypeVarInstance, todo_type};
@@ -61,7 +61,11 @@ impl<'db> CallableSignature<'db> {
         )
     }
 
-    pub(crate) fn normalized_impl(&self, db: &'db dyn Db, visitor: &mut TypeVisitor<'db>) -> Self {
+    pub(crate) fn normalized_impl(
+        &self,
+        db: &'db dyn Db,
+        visitor: &mut TypeTransformer<'db>,
+    ) -> Self {
         Self::from_overloads(
             self.overloads
                 .iter()
@@ -357,7 +361,11 @@ impl<'db> Signature<'db> {
         }
     }
 
-    pub(crate) fn normalized_impl(&self, db: &'db dyn Db, visitor: &mut TypeVisitor<'db>) -> Self {
+    pub(crate) fn normalized_impl(
+        &self,
+        db: &'db dyn Db,
+        visitor: &mut TypeTransformer<'db>,
+    ) -> Self {
         Self {
             generic_context: self
                 .generic_context
@@ -1299,7 +1307,11 @@ impl<'db> Parameter<'db> {
     /// Normalize nested unions and intersections in the annotated type, if any.
     ///
     /// See [`Type::normalized`] for more details.
-    pub(crate) fn normalized_impl(&self, db: &'db dyn Db, visitor: &mut TypeVisitor<'db>) -> Self {
+    pub(crate) fn normalized_impl(
+        &self,
+        db: &'db dyn Db,
+        visitor: &mut TypeTransformer<'db>,
+    ) -> Self {
         let Parameter {
             annotated_type,
             kind,

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -17,7 +17,7 @@ use smallvec::{SmallVec, smallvec};
 
 use super::{DynamicType, Type, TypeVarVariance, TypeVisitor, definition_expression_type};
 use crate::semantic_index::definition::Definition;
-use crate::types::generics::GenericContext;
+use crate::types::generics::{GenericContext, walk_generic_context};
 use crate::types::{TypeMapping, TypeRelation, TypeVarInstance, todo_type};
 use crate::{Db, FxOrderSet};
 use ruff_python_ast::{self as ast, name::Name};
@@ -231,6 +231,29 @@ pub struct Signature<'db> {
 
     /// Annotated return type, if any.
     pub(crate) return_ty: Option<Type<'db>>,
+}
+
+pub(super) fn walk_signature<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
+    db: &'db dyn Db,
+    signature: &Signature<'db>,
+    visitor: &mut V,
+) {
+    if let Some(generic_context) = &signature.generic_context {
+        walk_generic_context(db, *generic_context, visitor);
+    }
+    if let Some(inherited_generic_context) = &signature.inherited_generic_context {
+        walk_generic_context(db, *inherited_generic_context, visitor);
+    }
+    // By default we usually don't visit the type of the default value,
+    // as it isn't relevant to most things
+    for parameter in &signature.parameters {
+        if let Some(ty) = parameter.annotated_type() {
+            visitor.visit_type(db, ty);
+        }
+    }
+    if let Some(return_ty) = &signature.return_ty {
+        visitor.visit_type(db, *return_ty);
+    }
 }
 
 impl<'db> Signature<'db> {

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -3,7 +3,7 @@ use ruff_python_ast::name::Name;
 use crate::place::PlaceAndQualifiers;
 use crate::types::{
     ClassType, DynamicType, KnownClass, MemberLookupPolicy, Type, TypeMapping, TypeRelation,
-    TypeVarInstance, TypeVisitor,
+    TypeTransformer, TypeVarInstance,
 };
 use crate::{Db, FxOrderSet};
 
@@ -179,7 +179,11 @@ impl<'db> SubclassOfType<'db> {
         }
     }
 
-    pub(crate) fn normalized_impl(self, db: &'db dyn Db, visitor: &mut TypeVisitor<'db>) -> Self {
+    pub(crate) fn normalized_impl(
+        self,
+        db: &'db dyn Db,
+        visitor: &mut TypeTransformer<'db>,
+    ) -> Self {
         Self {
             subclass_of: self.subclass_of.normalized_impl(db, visitor),
         }
@@ -236,7 +240,11 @@ impl<'db> SubclassOfInner<'db> {
         }
     }
 
-    pub(crate) fn normalized_impl(self, db: &'db dyn Db, visitor: &mut TypeVisitor<'db>) -> Self {
+    pub(crate) fn normalized_impl(
+        self,
+        db: &'db dyn Db,
+        visitor: &mut TypeTransformer<'db>,
+    ) -> Self {
         match self {
             Self::Class(class) => Self::Class(class.normalized_impl(db, visitor)),
             Self::Dynamic(dynamic) => Self::Dynamic(dynamic.normalized()),

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -16,6 +16,14 @@ pub struct SubclassOfType<'db> {
     subclass_of: SubclassOfInner<'db>,
 }
 
+pub(super) fn walk_subclass_of_type<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
+    db: &'db dyn Db,
+    subclass_of: SubclassOfType<'db>,
+    visitor: &mut V,
+) {
+    visitor.visit_type(db, Type::from(subclass_of.subclass_of));
+}
+
 impl<'db> SubclassOfType<'db> {
     /// Construct a new [`Type`] instance representing a given class object (or a given dynamic type)
     /// and all possible subclasses of that class object/dynamic type.

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -88,6 +88,16 @@ pub struct TupleType<'db> {
     pub(crate) tuple: TupleSpec<'db>,
 }
 
+pub(super) fn walk_tuple_type<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
+    db: &'db dyn Db,
+    tuple: TupleType<'db>,
+    visitor: &mut V,
+) {
+    for element in tuple.tuple(db).all_elements() {
+        visitor.visit_type(db, *element);
+    }
+}
+
 // The Salsa heap is tracked separately.
 impl get_size2::GetSize for TupleType<'_> {}
 

--- a/crates/ty_python_semantic/src/types/visitor.rs
+++ b/crates/ty_python_semantic/src/types/visitor.rs
@@ -1,0 +1,275 @@
+use crate::{
+    Db, FxIndexSet,
+    types::{
+        BoundMethodType, BoundSuperType, CallableType, GenericAlias, IntersectionType,
+        KnownInstanceType, MethodWrapperKind, NominalInstanceType, PropertyInstanceType,
+        ProtocolInstanceType, SubclassOfType, Type, TypeAliasType, TypeIsType, TypeVarInstance,
+        UnionType,
+        class::walk_generic_alias,
+        function::{FunctionType, walk_function_type},
+        instance::{walk_nominal_instance_type, walk_protocol_instance_type},
+        subclass_of::walk_subclass_of_type,
+        tuple::{TupleType, walk_tuple_type},
+        walk_bound_method_type, walk_bound_super_type, walk_callable_type, walk_intersection_type,
+        walk_known_instance_type, walk_method_wrapper_type, walk_property_instance_type,
+        walk_type_alias_type, walk_type_var_type, walk_typeis_type, walk_union,
+    },
+};
+
+/// A visitor trait that recurses into nested types.
+///
+/// The trait does not guard against infinite recursion out of the box,
+/// but it makes it easy for implementors of the trait to do so.
+/// See [`any_over_type`] for an example of how to do this.
+pub(crate) trait TypeVisitor<'db> {
+    fn visit_type(&mut self, db: &'db dyn Db, ty: Type<'db>);
+
+    fn visit_union_type(&mut self, db: &'db dyn Db, union: UnionType<'db>) {
+        walk_union(db, union, self);
+    }
+
+    fn visit_intersection_type(&mut self, db: &'db dyn Db, intersection: IntersectionType<'db>) {
+        walk_intersection_type(db, intersection, self);
+    }
+
+    fn visit_tuple_type(&mut self, db: &'db dyn Db, tuple: TupleType<'db>) {
+        walk_tuple_type(db, tuple, self);
+    }
+
+    fn visit_callable_type(&mut self, db: &'db dyn Db, callable: CallableType<'db>) {
+        walk_callable_type(db, callable, self);
+    }
+
+    fn visit_property_instance_type(
+        &mut self,
+        db: &'db dyn Db,
+        property: PropertyInstanceType<'db>,
+    ) {
+        walk_property_instance_type(db, property, self);
+    }
+
+    fn visit_typeis_type(&mut self, db: &'db dyn Db, type_is: TypeIsType<'db>) {
+        walk_typeis_type(db, type_is, self);
+    }
+
+    fn visit_subclass_of_type(&mut self, db: &'db dyn Db, subclass_of: SubclassOfType<'db>) {
+        walk_subclass_of_type(db, subclass_of, self);
+    }
+
+    fn visit_generic_alias_type(&mut self, db: &'db dyn Db, alias: GenericAlias<'db>) {
+        walk_generic_alias(db, alias, self);
+    }
+
+    fn visit_function_type(&mut self, db: &'db dyn Db, function: FunctionType<'db>) {
+        walk_function_type(db, function, self);
+    }
+
+    fn visit_bound_method_type(&mut self, db: &'db dyn Db, method: BoundMethodType<'db>) {
+        walk_bound_method_type(db, method, self);
+    }
+
+    fn visit_bound_super_type(&mut self, db: &'db dyn Db, bound_super: BoundSuperType<'db>) {
+        walk_bound_super_type(db, bound_super, self);
+    }
+
+    fn visit_nominal_instance_type(&mut self, db: &'db dyn Db, nominal: NominalInstanceType<'db>) {
+        walk_nominal_instance_type(db, nominal, self);
+    }
+
+    fn visit_type_var_type(&mut self, db: &'db dyn Db, type_var: TypeVarInstance<'db>) {
+        walk_type_var_type(db, type_var, self);
+    }
+
+    fn visit_protocol_instance_type(
+        &mut self,
+        db: &'db dyn Db,
+        protocol: ProtocolInstanceType<'db>,
+    ) {
+        walk_protocol_instance_type(db, protocol, self);
+    }
+
+    fn visit_method_wrapper_type(
+        &mut self,
+        db: &'db dyn Db,
+        method_wrapper: MethodWrapperKind<'db>,
+    ) {
+        walk_method_wrapper_type(db, method_wrapper, self);
+    }
+
+    fn visit_known_instance_type(
+        &mut self,
+        db: &'db dyn Db,
+        known_instance: KnownInstanceType<'db>,
+    ) {
+        walk_known_instance_type(db, known_instance, self);
+    }
+
+    fn visit_type_alias_type(&mut self, db: &'db dyn Db, type_alias: TypeAliasType<'db>) {
+        walk_type_alias_type(db, type_alias, self);
+    }
+}
+
+/// Enumeration of types that may contain other types, such as unions, intersections, and generics.
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+enum NonAtomicType<'db> {
+    Union(UnionType<'db>),
+    Intersection(IntersectionType<'db>),
+    Tuple(TupleType<'db>),
+    FunctionLiteral(FunctionType<'db>),
+    BoundMethod(BoundMethodType<'db>),
+    BoundSuper(BoundSuperType<'db>),
+    MethodWrapper(MethodWrapperKind<'db>),
+    Callable(CallableType<'db>),
+    GenericAlias(GenericAlias<'db>),
+    KnownInstance(KnownInstanceType<'db>),
+    SubclassOf(SubclassOfType<'db>),
+    NominalInstance(NominalInstanceType<'db>),
+    PropertyInstance(PropertyInstanceType<'db>),
+    TypeIs(TypeIsType<'db>),
+    TypeVar(TypeVarInstance<'db>),
+    ProtocolInstance(ProtocolInstanceType<'db>),
+}
+
+enum TypeKind<'db> {
+    Atomic,
+    NonAtomic(NonAtomicType<'db>),
+}
+
+impl<'db> From<Type<'db>> for TypeKind<'db> {
+    fn from(ty: Type<'db>) -> Self {
+        match ty {
+            Type::AlwaysFalsy
+            | Type::AlwaysTruthy
+            | Type::Never
+            | Type::LiteralString
+            | Type::IntLiteral(_)
+            | Type::BooleanLiteral(_)
+            | Type::StringLiteral(_)
+            | Type::BytesLiteral(_)
+            | Type::DataclassDecorator(_)
+            | Type::DataclassTransformer(_)
+            | Type::WrapperDescriptor(_)
+            | Type::ModuleLiteral(_)
+            | Type::ClassLiteral(_)
+            | Type::SpecialForm(_)
+            | Type::Dynamic(_) => TypeKind::Atomic,
+
+            // Non-atomic types
+            Type::FunctionLiteral(function) => {
+                TypeKind::NonAtomic(NonAtomicType::FunctionLiteral(function))
+            }
+            Type::Intersection(intersection) => {
+                TypeKind::NonAtomic(NonAtomicType::Intersection(intersection))
+            }
+            Type::Union(union) => TypeKind::NonAtomic(NonAtomicType::Union(union)),
+            Type::Tuple(tuple) => TypeKind::NonAtomic(NonAtomicType::Tuple(tuple)),
+            Type::BoundMethod(method) => TypeKind::NonAtomic(NonAtomicType::BoundMethod(method)),
+            Type::BoundSuper(bound_super) => {
+                TypeKind::NonAtomic(NonAtomicType::BoundSuper(bound_super))
+            }
+            Type::MethodWrapper(method_wrapper) => {
+                TypeKind::NonAtomic(NonAtomicType::MethodWrapper(method_wrapper))
+            }
+            Type::Callable(callable) => TypeKind::NonAtomic(NonAtomicType::Callable(callable)),
+            Type::GenericAlias(alias) => TypeKind::NonAtomic(NonAtomicType::GenericAlias(alias)),
+            Type::KnownInstance(known_instance) => {
+                TypeKind::NonAtomic(NonAtomicType::KnownInstance(known_instance))
+            }
+            Type::SubclassOf(subclass_of) => {
+                TypeKind::NonAtomic(NonAtomicType::SubclassOf(subclass_of))
+            }
+            Type::NominalInstance(nominal) => {
+                TypeKind::NonAtomic(NonAtomicType::NominalInstance(nominal))
+            }
+            Type::ProtocolInstance(protocol) => {
+                TypeKind::NonAtomic(NonAtomicType::ProtocolInstance(protocol))
+            }
+            Type::PropertyInstance(property) => {
+                TypeKind::NonAtomic(NonAtomicType::PropertyInstance(property))
+            }
+            Type::TypeVar(type_var) => TypeKind::NonAtomic(NonAtomicType::TypeVar(type_var)),
+            Type::TypeIs(type_is) => TypeKind::NonAtomic(NonAtomicType::TypeIs(type_is)),
+        }
+    }
+}
+
+fn walk_non_atomic_type<'db, V: TypeVisitor<'db> + ?Sized>(
+    db: &'db dyn Db,
+    non_atomic_type: NonAtomicType<'db>,
+    visitor: &mut V,
+) {
+    match non_atomic_type {
+        NonAtomicType::FunctionLiteral(function) => visitor.visit_function_type(db, function),
+        NonAtomicType::Intersection(intersection) => {
+            visitor.visit_intersection_type(db, intersection);
+        }
+        NonAtomicType::Union(union) => visitor.visit_union_type(db, union),
+        NonAtomicType::Tuple(tuple) => visitor.visit_tuple_type(db, tuple),
+        NonAtomicType::BoundMethod(method) => visitor.visit_bound_method_type(db, method),
+        NonAtomicType::BoundSuper(bound_super) => visitor.visit_bound_super_type(db, bound_super),
+        NonAtomicType::MethodWrapper(method_wrapper) => {
+            visitor.visit_method_wrapper_type(db, method_wrapper);
+        }
+        NonAtomicType::Callable(callable) => visitor.visit_callable_type(db, callable),
+        NonAtomicType::GenericAlias(alias) => visitor.visit_generic_alias_type(db, alias),
+        NonAtomicType::KnownInstance(known_instance) => {
+            visitor.visit_known_instance_type(db, known_instance);
+        }
+        NonAtomicType::SubclassOf(subclass_of) => visitor.visit_subclass_of_type(db, subclass_of),
+        NonAtomicType::NominalInstance(nominal) => visitor.visit_nominal_instance_type(db, nominal),
+        NonAtomicType::PropertyInstance(property) => {
+            visitor.visit_property_instance_type(db, property);
+        }
+        NonAtomicType::TypeIs(type_is) => visitor.visit_typeis_type(db, type_is),
+        NonAtomicType::TypeVar(type_var) => visitor.visit_type_var_type(db, type_var),
+        NonAtomicType::ProtocolInstance(protocol) => {
+            visitor.visit_protocol_instance_type(db, protocol);
+        }
+    }
+}
+
+/// Return `true` if `ty`, or any of the types contained in `ty`, match the closure passed in.
+///
+/// The function guards against infinite recursion
+/// by keeping track of the non-atomic types it has already seen.
+pub(super) fn any_over_type<'db>(
+    db: &'db dyn Db,
+    ty: Type<'db>,
+    query: &dyn Fn(Type<'db>) -> bool,
+) -> bool {
+    struct AnyOverTypeVisitor<'db, 'a> {
+        query: &'a dyn Fn(Type<'db>) -> bool,
+        seen_types: FxIndexSet<NonAtomicType<'db>>,
+        found_matching_type: bool,
+    }
+
+    impl<'db> TypeVisitor<'db> for AnyOverTypeVisitor<'db, '_> {
+        fn visit_type(&mut self, db: &'db dyn Db, ty: Type<'db>) {
+            if self.found_matching_type {
+                return;
+            }
+            self.found_matching_type |= (self.query)(ty);
+            if self.found_matching_type {
+                return;
+            }
+            match TypeKind::from(ty) {
+                TypeKind::Atomic => {}
+                TypeKind::NonAtomic(non_atomic_type) => {
+                    if !self.seen_types.insert(non_atomic_type) {
+                        // If we have already seen this type, we can skip it.
+                        return;
+                    }
+                    walk_non_atomic_type(db, non_atomic_type, self);
+                }
+            }
+        }
+    }
+
+    let mut visitor = AnyOverTypeVisitor {
+        query,
+        seen_types: FxIndexSet::default(),
+        found_matching_type: false,
+    };
+    visitor.visit_type(db, ty);
+    visitor.found_matching_type
+}


### PR DESCRIPTION
## Summary

Our `Type::any_over_type()` method has two problems:
1. There are several types where it does not recurse into all nested types!
2. It doesn't guard against recursion at all. This isn't much of a problem now, but becomes more of a problem when we introduce more recursive types, such as in https://github.com/astral-sh/ruff/pull/18659

This PR introduces a new `TypeVisitor` trait that aims to solve both of these issues in a generalized way:
1. Walking nested types is delegated down to `walk_*_type` functions that live close to the structs they walk. For example, walking all nested types in a `NominalInstanceType` is handled by a `walk_nominal_instance_type` function that lives next to the `NominalInstanceType` struct in `instance.rs`. This makes it less likely that we'll forget to update the function if we add a new field to `NominalInstanceType` in the future.
2. The trait makes it easy to write concrete implementations that guard against recursion in an efficient way.

`Type::any_over_type` is reimplemented as a standalone `any_over_type` function that uses a concrete implementation of the new `TypeVisitor` trait as its implementation.

If we like the direction this PR is going in, we might want to rename the existing `TypeVisitor` struct that @carljm added in https://github.com/astral-sh/ruff/pull/19003. We _may_ also want to reimplement `Type::normalize` and `Type::apply_type_mapping` using a similar `TypeTransformer` trait, but I'll defer to @carljm on that point, since he has ongoing work in this area.

## Test Plan

All existing tests pass.
