### PR TITLE
[ty] remove any_over_type

### DIFF
--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -1145,11 +1145,11 @@ impl KnownFunction {
                 let [Some(casted_type), Some(source_type)] = parameter_types else {
                     return None;
                 };
-                let contains_unknown_or_todo =
+                let is_unknown_or_todo =
                     |ty| matches!(ty, Type::Dynamic(dynamic) if dynamic != DynamicType::Any);
                 if source_type.is_equivalent_to(db, *casted_type)
-                    && !casted_type.any_over_type(db, &|ty| contains_unknown_or_todo(ty))
-                    && !source_type.any_over_type(db, &|ty| contains_unknown_or_todo(ty))
+                    && !is_unknown_or_todo(*casted_type)
+                    && !is_unknown_or_todo(*source_type)
                 {
                     let builder = context.report_lint(&REDUNDANT_CAST, call_expression)?;
                     builder.into_diagnostic(format_args!(

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -229,15 +229,6 @@ impl<'db> ProtocolInstanceType<'db> {
         }
     }
 
-    /// Return `true` if the types of any of the members match the closure passed in.
-    pub(super) fn any_over_type(
-        self,
-        db: &'db dyn Db,
-        type_fn: &dyn Fn(Type<'db>) -> bool,
-    ) -> bool {
-        self.inner.interface(db).any_over_type(db, type_fn)
-    }
-
     /// Return `true` if this protocol type has the given type relation to the protocol `other`.
     ///
     /// TODO: consider the types of the members as well as their existence

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -152,16 +152,6 @@ impl<'db> ProtocolInterface<'db> {
             .all(|member_name| other.inner(db).contains_key(member_name))
     }
 
-    /// Return `true` if the types of any of the members match the closure passed in.
-    pub(super) fn any_over_type(
-        self,
-        db: &'db dyn Db,
-        type_fn: &dyn Fn(Type<'db>) -> bool,
-    ) -> bool {
-        self.members(db)
-            .any(|member| member.any_over_type(db, type_fn))
-    }
-
     pub(super) fn normalized_impl(self, db: &'db dyn Db, visitor: &mut TypeVisitor<'db>) -> Self {
         Self::new(
             db,
@@ -369,14 +359,6 @@ impl<'a, 'db> ProtocolMember<'a, 'db> {
                 member_type.has_relation_to(db, attribute_type, relation)
                     && attribute_type.has_relation_to(db, *member_type, relation)
             }
-        }
-    }
-
-    fn any_over_type(&self, db: &'db dyn Db, type_fn: &dyn Fn(Type<'db>) -> bool) -> bool {
-        match &self.kind {
-            ProtocolMemberKind::Method(callable) => callable.any_over_type(db, type_fn),
-            ProtocolMemberKind::Property(property) => property.any_over_type(db, type_fn),
-            ProtocolMemberKind::Other(ty) => ty.any_over_type(db, type_fn),
         }
     }
 }


### PR DESCRIPTION
## Summary

Remove the recursive type walk `any_over_type` and its sole current use in deciding whether to emit a redundant-cast diagnostic; instead, just skip the redundant-cast diagnostic if we are casting `Unknown` or `Todo` as a top-level type. This removes another recursive type walk (and its associated recursive-type complications).

The ecosystem report suggests the number of false positives this currently adds is quite manageable, and the few that it does add can mostly be removed by targeting a few cases where we currently create `Todo` types. While suppressing false positives from `Todo` types is useful in the short term and worth doing when it's easy, I don't think it should drive significant architecture decisions or extra runtime work.

If we do decide (even though it currently seems to have little impact on the ecosystem report) that it's important for gradual-guarantee reasons to do deep suppression of `redundant-cast` when nested `Unknown` types are involved (I am not sure how strong the case for this is, since the use of `cast` in the first place suggests a typed codebase), I think the better approach to this would be a strategy parameter to `is_equivalent_to` that could cause `Unknown` to not be considered equivalent to `Unknown` or `Any`, rather than a separate recursive type walk.

## Test Plan

CI
