### PR TITLE
[`flake8-pyi`] Make example error out-of-the-box (`PYI042`)

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/type_alias_naming.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/type_alias_naming.rs
@@ -14,11 +14,15 @@ use crate::checkers::ast::Checker;
 ///
 /// ## Example
 /// ```pyi
+/// from typing import TypeAlias
+///
 /// type_alias_name: TypeAlias = int
 /// ```
 ///
 /// Use instead:
 /// ```pyi
+/// from typing import TypeAlias
+///
 /// TypeAliasName: TypeAlias = int
 /// ```
 #[derive(ViolationMetadata)]


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Part of #18972

This PR makes [snake-case-type-alias (PYI042)](https://docs.astral.sh/ruff/rules/snake-case-type-alias/#snake-case-type-alias-pyi042)'s example error out-of-the-box

[Old example](https://play.ruff.rs/8fafec81-2228-4ffe-81e8-1989b724cb47)
```py
type_alias_name: TypeAlias = int
```

[New example](https://play.ruff.rs/b396746c-e6d2-423c-bc13-01a533bb0747)
```py
from typing import TypeAlias

type_alias_name: TypeAlias = int
```

Imports were also added to the "use instead" section.

## Test Plan

<!-- How was it tested? -->

N/A, no functionality/tests affected