### PR TITLE
Filter private `builtins` members from completions

### DIFF
--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -472,6 +472,7 @@ mod tests {
 ",
         );
         test.assert_completions_include("filter");
+        test.assert_completions_do_not_include("_T");
     }
 
     #[test]

--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -473,6 +473,7 @@ mod tests {
         );
         test.assert_completions_include("filter");
         test.assert_completions_do_not_include("_T");
+        test.assert_completions_do_not_include("__annotations__");
     }
 
     #[test]

--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -15,7 +15,7 @@ pub use program::{
     PythonVersionWithSource, SearchPathSettings,
 };
 pub use python_platform::PythonPlatform;
-pub use semantic_model::{Completion, HasType, SemanticModel};
+pub use semantic_model::{Completion, HasType, NameKind, SemanticModel};
 pub use site_packages::{PythonEnvironment, SitePackagesPaths, SysPrefixPathOrigin};
 pub use util::diagnostics::add_inferred_python_version_hint_to_diagnostic;
 

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -73,7 +73,7 @@ impl<'db> SemanticModel<'db> {
         crate::types::all_members(self.db, ty)
             .into_iter()
             // Filter out private members from `builtins`
-            .filter(|name| !builtin || !name.starts_with('_'))
+            .filter(|name| !(builtin && matches!(NameKind::classify(name), NameKind::Sunder)))
             .map(|name| Completion { name, builtin })
             .collect()
     }
@@ -128,6 +128,39 @@ impl<'db> SemanticModel<'db> {
         let builtins = ModuleName::new("builtins").expect("valid module name");
         completions.extend(self.module_completions(&builtins));
         completions
+    }
+}
+
+/// A classification for completion names.
+///
+/// The ordering here is used for sorting completions based only on name.
+///
+/// This sorts "normal" names first, then dunder names and finally
+/// single-underscore names. This matches the order of the variants defined for
+/// this enum, which is in turn picked up by the derived trait implementation
+/// for `Ord`.
+#[derive(Clone, Copy, Eq, PartialEq, PartialOrd, Ord)]
+pub enum NameKind {
+    Normal,
+    Dunder,
+    Sunder,
+}
+
+impl NameKind {
+    pub fn classify(name: &Name) -> NameKind {
+        // Dunder needs a prefix and suffix double underscore.
+        // When there's only a prefix double underscore, this
+        // results in explicit name mangling. We let that be
+        // classified as-if they were single underscore names.
+        //
+        // Ref: <https://docs.python.org/3/reference/lexical_analysis.html#reserved-classes-of-identifiers>
+        if name.starts_with("__") && name.ends_with("__") {
+            NameKind::Dunder
+        } else if name.starts_with('_') {
+            NameKind::Sunder
+        } else {
+            NameKind::Normal
+        }
     }
 }
 


### PR DESCRIPTION
Closes https://github.com/astral-sh/ty/issues/757

A few thoughts here

1. This doesn't explicitly filter from the typeshed builtins as discussed in the issue, is that equivalent to the builtins module for our purposes or do we need to distinguish between them?
2. ~This doesn't distinguish between sunder and dunder, but probably should.~ There are dunder methods in the builtins stubs, but not at the top-level? It doesn't seem like the completions distinguish between these concepts though, as it'll suggest me `__annotations__` in the test? I added a test case around this for clarity. It'd be trivial to retain dunder completions, we'd just need to decide if we want to pull the nice `Kind` sorter out of the classification code for re-use. **N.B.**: See [thread](https://github.com/astral-sh/ruff/pull/19102#discussion_r2180951944) — I changed this in https://github.com/astral-sh/ruff/commit/fc3b1ed523e319c7d291b0c35aea804cf4472453.

And as pointed out by @AlexWaygood 

3. This is really a problem for all stub files, not just the builtins
4. This should probably just filter names that wouldn't exist at runtime, which would be "all private typevars/ParamSpecs/typevartuples in stubs, all private type aliases in stubs, and any classes decorated with @type_check_only" but not necessarily all private names in stubs

There is some context in the internal Discord, [here](https://discord.com/channels/1039017663004942429/1343690517745111081/1381233188114010135) and [here](https://discord.com/channels/1039017663004942429/1343690517745111081/1390079232780271658).

It seems plausible and reasonable to perform (3) and (4) as follow-ups.