### PR TITLE
[`flake8-pytest-style`] Make example error out-of-the-box (`PT030`)

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/warns.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/warns.rs
@@ -76,11 +76,11 @@ impl Violation for PytestWarnsWithMultipleStatements {
 ///
 ///
 /// def test_foo():
-///     with pytest.warns(RuntimeWarning):
+///     with pytest.warns(Warning):
 ///         ...
 ///
 ///     # empty string is also an error
-///     with pytest.warns(RuntimeWarning, match=""):
+///     with pytest.warns(Warning, match=""):
 ///         ...
 /// ```
 ///
@@ -90,7 +90,7 @@ impl Violation for PytestWarnsWithMultipleStatements {
 ///
 ///
 /// def test_foo():
-///     with pytest.warns(RuntimeWarning, match="expected message"):
+///     with pytest.warns(Warning, match="expected message"):
 ///         ...
 /// ```
 ///


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Part of #18972

This PR makes [pytest-warns-too-broad (PT030)](https://docs.astral.sh/ruff/rules/pytest-warns-too-broad/#pytest-warns-too-broad-pt030)'s example error out-of-the-box

[Old example](https://play.ruff.rs/2296ae7e-c775-427a-a020-6fb25321f3f7)
```py
import pytest


def test_foo():
    with pytest.warns(RuntimeWarning):
        ...

    # empty string is also an error
    with pytest.warns(RuntimeWarning, match=""):
        ...
```

[New example](https://play.ruff.rs/af35a482-1c2f-47ee-aff3-ff1e9fa447de)
```py
import pytest


def test_foo():
    with pytest.warns(Warning):
        ...

    # empty string is also an error
    with pytest.warns(Warning, match=""):
        ...
```

`RuntimeWarning` is not in the default [warns-require-match-for](https://docs.astral.sh/ruff/settings/#lint_flake8-pytest-style_warns-require-match-for) list, while `Warning` is. The "Use instead" section was also updated similarly

## Test Plan

<!-- How was it tested? -->

N/A, no functionality/tests affected