### PR TITLE
[`flake8-simplify`] Make example error out-of-the-box (`SIM116`)

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/if_else_block_instead_of_dict_lookup.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/if_else_block_instead_of_dict_lookup.rs
@@ -22,13 +22,16 @@ use crate::checkers::ast::Checker;
 ///     return "Hello"
 /// elif x == 2:
 ///     return "Goodbye"
+/// elif x == 3:
+///     return "Good morning"
 /// else:
 ///     return "Goodnight"
 /// ```
 ///
 /// Use instead:
 /// ```python
-/// return {1: "Hello", 2: "Goodbye"}.get(x, "Goodnight")
+/// phrases = {1: "Hello", 2: "Goodye", 3: "Good morning"}
+/// return phrases.get(x, "Goodnight")
 /// ```
 #[derive(ViolationMetadata)]
 pub(crate) struct IfElseBlockInsteadOfDictLookup;

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/if_else_block_instead_of_dict_lookup.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/if_else_block_instead_of_dict_lookup.rs
@@ -18,20 +18,22 @@ use crate::checkers::ast::Checker;
 ///
 /// ## Example
 /// ```python
-/// if x == 1:
-///     return "Hello"
-/// elif x == 2:
-///     return "Goodbye"
-/// elif x == 3:
-///     return "Good morning"
-/// else:
-///     return "Goodnight"
+/// def find_phrase(x):
+///     if x == 1:
+///         return "Hello"
+///     elif x == 2:
+///         return "Goodbye"
+///     elif x == 3:
+///         return "Good morning"
+///     else:
+///         return "Goodnight"
 /// ```
 ///
 /// Use instead:
 /// ```python
-/// phrases = {1: "Hello", 2: "Goodye", 3: "Good morning"}
-/// return phrases.get(x, "Goodnight")
+/// def find_phrase(x):
+///     phrases = {1: "Hello", 2: "Goodye", 3: "Good morning"}
+///     return phrases.get(x, "Goodnight")
 /// ```
 #[derive(ViolationMetadata)]
 pub(crate) struct IfElseBlockInsteadOfDictLookup;


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Part of #18972

This PR makes [if-else-block-instead-of-dict-lookup (SIM116)](https://docs.astral.sh/ruff/rules/if-else-block-instead-of-dict-lookup/#if-else-block-instead-of-dict-lookup-sim116)'s example error out-of-the-box

[Old example](https://play.ruff.rs/718f17ee-fbe2-4520-97c6-153bc0f4502d)
```py
if x == 1:
    return "Hello"
elif x == 2:
    return "Goodbye"
else:
    return "Goodnight"
```

[New example](https://play.ruff.rs/8a9b47b4-da46-4a50-8576-362cdd707cee)
```py
def find_phrase(x):
    if x == 1:
        return "Hello"
    elif x == 2:
        return "Goodbye"
    elif x == 3:
        return "Good morning"
    else:
        return "Goodnight"
```

The "Use instead" section was also updated to reflect the new case. I also changed it to use an intermediary variable since I find the `return <long dict>.get` very ugly and hard to read.

## Test Plan

<!-- How was it tested? -->

N/A, no functionality/tests affected