### PR TITLE
[`ruff`] Fix `RUF033` breaking with named default expressions

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF033.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF033.py
@@ -81,6 +81,9 @@ class Foo:
         bar: int = (x := 1)  #  comment
         ,
         baz: int = (y := 2),  # comment
+        foo = (a := 1)  #  comment
+        ,
+        faz = (b := 2),  # comment
     ) -> None:
         pass
 
@@ -93,3 +96,31 @@ class Foo:
         baz: int = 2,  # comment
     ) -> None:
         pass
+
+
+@dataclass
+class Foo:
+    def __post_init__(
+        self,
+        arg1: int = (1)  # comment
+        ,
+        arg2: int = ((1))  # comment
+        ,
+        arg2: int = (i for i in range(10))  # comment
+        ,
+    ) -> None:
+        pass
+
+
+# makes little sense, but is valid syntax
+def dafuq():
+    @dataclass
+    class Foo:
+        def __post_init__(
+            self,
+            bar: (int) = (yield from range(5))  # comment
+            ,
+        ) -> None:
+            ...
+
+    return Foo

--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF033.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF033.py
@@ -65,3 +65,31 @@ class Foo:
     bar = "should've used attrs"
 
     def __post_init__(self, bar: str = "ahhh", baz: str = "hmm") -> None: ...
+
+
+# https://github.com/astral-sh/ruff/issues/18950
+@dataclass
+class Foo:
+    def __post_init__(self, bar: int = (x := 1)) -> None:
+        pass
+
+
+@dataclass
+class Foo:
+    def __post_init__(
+        self,
+        bar: int = (x := 1)  #  comment
+        ,
+        baz: int = (y := 2),  # comment
+    ) -> None:
+        pass
+
+
+@dataclass
+class Foo:
+    def __post_init__(
+        self,
+        bar: int = 1,  # comment
+        baz: int = 2,  # comment
+    ) -> None:
+        pass

--- a/crates/ruff_linter/src/rules/ruff/rules/post_init_default.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/post_init_default.rs
@@ -154,7 +154,6 @@ fn use_initvar(
     // Delete the default value. For example,
     // - def __post_init__(self, foo: int = 0) -> None: ...
     // + def __post_init__(self, foo: int) -> None: ...
-    debug_assert!(only_default_between_param_name_end_and_param(parameter));
     let default_edit = Edit::deletion(parameter.parameter.end(), parameter.end());
 
     // Add `dataclasses.InitVar` field to class body.
@@ -206,21 +205,4 @@ fn use_initvar(
         locator.line_start(post_init_def.start()),
     );
     Ok(Fix::unsafe_edits(import_edit, [default_edit, initvar_edit]))
-}
-
-/// Check that no other construct is between the parameter name and the end of the parameter
-/// definition (including the default value).
-fn only_default_between_param_name_end_and_param(parameter: &ast::ParameterWithDefault) -> bool {
-    let ast::ParameterWithDefault {
-        // Full destructuring to force compilation error when new fields are added.
-        // New fields potentially need consideration in the logic below.
-        range: _,
-        node_index: _,
-        parameter,
-        default,
-    } = parameter;
-    let default = default
-        .as_deref()
-        .expect("called no_expr_after_default on a non-defaulted parameter");
-    parameter.range.end() < default.range().start()
 }

--- a/crates/ruff_linter/src/rules/ruff/rules/post_init_default.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/post_init_default.rs
@@ -118,7 +118,7 @@ pub(crate) fn post_init_default(checker: &Checker, function_def: &ast::StmtFunct
 
         if !stopped_fixes {
             diagnostic.try_set_fix(|| {
-                use_initvar(current_scope, function_def, &parameter, default, checker)
+                use_initvar(current_scope, function_def, parameter, default, checker)
             });
             // Need to stop fixes as soon as there is a parameter we cannot fix.
             // Otherwise, we risk a syntax error (a parameter without a default

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF033_RUF033.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF033_RUF033.py.snap
@@ -200,7 +200,7 @@ RUF033.py:81:21: RUF033 [*] `__post_init__` method with argument defaults
    82 |+        bar: int  #  comment
 82 83 |         ,
 83 84 |         baz: int = (y := 2),  # comment
-84 85 |     ) -> None:
+84 85 |         foo = (a := 1)  #  comment
 
 RUF033.py:83:21: RUF033 [*] `__post_init__` method with argument defaults
    |
@@ -208,8 +208,8 @@ RUF033.py:83:21: RUF033 [*] `__post_init__` method with argument defaults
 82 |         ,
 83 |         baz: int = (y := 2),  # comment
    |                     ^^^^^^ RUF033
-84 |     ) -> None:
-85 |         pass
+84 |         foo = (a := 1)  #  comment
+85 |         ,
    |
    = help: Use `dataclasses.InitVar` instead
 
@@ -224,54 +224,213 @@ RUF033.py:83:21: RUF033 [*] `__post_init__` method with argument defaults
 82 83 |         ,
 83    |-        baz: int = (y := 2),  # comment
    84 |+        baz: int,  # comment
-84 85 |     ) -> None:
-85 86 |         pass
-86 87 | 
+84 85 |         foo = (a := 1)  #  comment
+85 86 |         ,
+86 87 |         faz = (b := 2),  # comment
 
-RUF033.py:92:20: RUF033 [*] `__post_init__` method with argument defaults
+RUF033.py:84:16: RUF033 [*] `__post_init__` method with argument defaults
    |
-90 |     def __post_init__(
-91 |         self,
-92 |         bar: int = 1,  # comment
-   |                    ^ RUF033
-93 |         baz: int = 2,  # comment
-94 |     ) -> None:
-   |
-   = help: Use `dataclasses.InitVar` instead
-
-ℹ Unsafe fix
-87 87 | 
-88 88 | @dataclass
-89 89 | class Foo:
-   90 |+    bar: InitVar[int] = 1
-90 91 |     def __post_init__(
-91 92 |         self,
-92    |-        bar: int = 1,  # comment
-   93 |+        bar: int,  # comment
-93 94 |         baz: int = 2,  # comment
-94 95 |     ) -> None:
-95 96 |         pass
-
-RUF033.py:93:20: RUF033 [*] `__post_init__` method with argument defaults
-   |
-91 |         self,
-92 |         bar: int = 1,  # comment
-93 |         baz: int = 2,  # comment
-   |                    ^ RUF033
-94 |     ) -> None:
-95 |         pass
+82 |         ,
+83 |         baz: int = (y := 2),  # comment
+84 |         foo = (a := 1)  #  comment
+   |                ^^^^^^ RUF033
+85 |         ,
+86 |         faz = (b := 2),  # comment
    |
    = help: Use `dataclasses.InitVar` instead
 
 ℹ Unsafe fix
-87 87 | 
-88 88 | @dataclass
-89 89 | class Foo:
-   90 |+    baz: InitVar[int] = 2
-90 91 |     def __post_init__(
-91 92 |         self,
-92 93 |         bar: int = 1,  # comment
-93    |-        baz: int = 2,  # comment
-   94 |+        baz: int,  # comment
-94 95 |     ) -> None:
-95 96 |         pass
+76 76 | 
+77 77 | @dataclass
+78 78 | class Foo:
+   79 |+    foo: InitVar = (a := 1)
+79 80 |     def __post_init__(
+80 81 |         self,
+81 82 |         bar: int = (x := 1)  #  comment
+82 83 |         ,
+83 84 |         baz: int = (y := 2),  # comment
+84    |-        foo = (a := 1)  #  comment
+   85 |+        foo  #  comment
+85 86 |         ,
+86 87 |         faz = (b := 2),  # comment
+87 88 |     ) -> None:
+
+RUF033.py:86:16: RUF033 [*] `__post_init__` method with argument defaults
+   |
+84 |         foo = (a := 1)  #  comment
+85 |         ,
+86 |         faz = (b := 2),  # comment
+   |                ^^^^^^ RUF033
+87 |     ) -> None:
+88 |         pass
+   |
+   = help: Use `dataclasses.InitVar` instead
+
+ℹ Unsafe fix
+76 76 | 
+77 77 | @dataclass
+78 78 | class Foo:
+   79 |+    faz: InitVar = (b := 2)
+79 80 |     def __post_init__(
+80 81 |         self,
+81 82 |         bar: int = (x := 1)  #  comment
+--------------------------------------------------------------------------------
+83 84 |         baz: int = (y := 2),  # comment
+84 85 |         foo = (a := 1)  #  comment
+85 86 |         ,
+86    |-        faz = (b := 2),  # comment
+   87 |+        faz,  # comment
+87 88 |     ) -> None:
+88 89 |         pass
+89 90 | 
+
+RUF033.py:95:20: RUF033 [*] `__post_init__` method with argument defaults
+   |
+93 |     def __post_init__(
+94 |         self,
+95 |         bar: int = 1,  # comment
+   |                    ^ RUF033
+96 |         baz: int = 2,  # comment
+97 |     ) -> None:
+   |
+   = help: Use `dataclasses.InitVar` instead
+
+ℹ Unsafe fix
+90 90 | 
+91 91 | @dataclass
+92 92 | class Foo:
+   93 |+    bar: InitVar[int] = 1
+93 94 |     def __post_init__(
+94 95 |         self,
+95    |-        bar: int = 1,  # comment
+   96 |+        bar: int,  # comment
+96 97 |         baz: int = 2,  # comment
+97 98 |     ) -> None:
+98 99 |         pass
+
+RUF033.py:96:20: RUF033 [*] `__post_init__` method with argument defaults
+   |
+94 |         self,
+95 |         bar: int = 1,  # comment
+96 |         baz: int = 2,  # comment
+   |                    ^ RUF033
+97 |     ) -> None:
+98 |         pass
+   |
+   = help: Use `dataclasses.InitVar` instead
+
+ℹ Unsafe fix
+90 90 | 
+91 91 | @dataclass
+92 92 | class Foo:
+   93 |+    baz: InitVar[int] = 2
+93 94 |     def __post_init__(
+94 95 |         self,
+95 96 |         bar: int = 1,  # comment
+96    |-        baz: int = 2,  # comment
+   97 |+        baz: int,  # comment
+97 98 |     ) -> None:
+98 99 |         pass
+99 100 | 
+
+RUF033.py:105:22: RUF033 [*] `__post_init__` method with argument defaults
+    |
+103 |     def __post_init__(
+104 |         self,
+105 |         arg1: int = (1)  # comment
+    |                      ^ RUF033
+106 |         ,
+107 |         arg2: int = ((1))  # comment
+    |
+    = help: Use `dataclasses.InitVar` instead
+
+ℹ Unsafe fix
+100 100 | 
+101 101 | @dataclass
+102 102 | class Foo:
+    103 |+    arg1: InitVar[int] = (1)
+103 104 |     def __post_init__(
+104 105 |         self,
+105     |-        arg1: int = (1)  # comment
+    106 |+        arg1: int  # comment
+106 107 |         ,
+107 108 |         arg2: int = ((1))  # comment
+108 109 |         ,
+
+RUF033.py:107:23: RUF033 [*] `__post_init__` method with argument defaults
+    |
+105 |         arg1: int = (1)  # comment
+106 |         ,
+107 |         arg2: int = ((1))  # comment
+    |                       ^ RUF033
+108 |         ,
+109 |         arg2: int = (i for i in range(10))  # comment
+    |
+    = help: Use `dataclasses.InitVar` instead
+
+ℹ Unsafe fix
+100 100 | 
+101 101 | @dataclass
+102 102 | class Foo:
+    103 |+    arg2: InitVar[int] = ((1))
+103 104 |     def __post_init__(
+104 105 |         self,
+105 106 |         arg1: int = (1)  # comment
+106 107 |         ,
+107     |-        arg2: int = ((1))  # comment
+    108 |+        arg2: int  # comment
+108 109 |         ,
+109 110 |         arg2: int = (i for i in range(10))  # comment
+110 111 |         ,
+
+RUF033.py:109:21: RUF033 [*] `__post_init__` method with argument defaults
+    |
+107 |         arg2: int = ((1))  # comment
+108 |         ,
+109 |         arg2: int = (i for i in range(10))  # comment
+    |                     ^^^^^^^^^^^^^^^^^^^^^^ RUF033
+110 |         ,
+111 |     ) -> None:
+    |
+    = help: Use `dataclasses.InitVar` instead
+
+ℹ Unsafe fix
+100 100 | 
+101 101 | @dataclass
+102 102 | class Foo:
+    103 |+    arg2: InitVar[int] = (i for i in range(10))
+103 104 |     def __post_init__(
+104 105 |         self,
+105 106 |         arg1: int = (1)  # comment
+106 107 |         ,
+107 108 |         arg2: int = ((1))  # comment
+108 109 |         ,
+109     |-        arg2: int = (i for i in range(10))  # comment
+    110 |+        arg2: int  # comment
+110 111 |         ,
+111 112 |     ) -> None:
+112 113 |         pass
+
+RUF033.py:121:27: RUF033 [*] `__post_init__` method with argument defaults
+    |
+119 |         def __post_init__(
+120 |             self,
+121 |             bar: (int) = (yield from range(5))  # comment
+    |                           ^^^^^^^^^^^^^^^^^^^ RUF033
+122 |             ,
+123 |         ) -> None:
+    |
+    = help: Use `dataclasses.InitVar` instead
+
+ℹ Unsafe fix
+116 116 | def dafuq():
+117 117 |     @dataclass
+118 118 |     class Foo:
+    119 |+        bar: InitVar[int] = (yield from range(5))
+119 120 |         def __post_init__(
+120 121 |             self,
+121     |-            bar: (int) = (yield from range(5))  # comment
+    122 |+            bar: (int)  # comment
+122 123 |             ,
+123 124 |         ) -> None:
+124 125 |             ...

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF033_RUF033.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF033_RUF033.py.snap
@@ -156,3 +156,122 @@ RUF033.py:67:59: RUF033 `__post_init__` method with argument defaults
    |                                                           ^^^^^ RUF033
    |
    = help: Use `dataclasses.InitVar` instead
+
+RUF033.py:73:41: RUF033 [*] `__post_init__` method with argument defaults
+   |
+71 | @dataclass
+72 | class Foo:
+73 |     def __post_init__(self, bar: int = (x := 1)) -> None:
+   |                                         ^^^^^^ RUF033
+74 |         pass
+   |
+   = help: Use `dataclasses.InitVar` instead
+
+ℹ Unsafe fix
+70 70 | # https://github.com/astral-sh/ruff/issues/18950
+71 71 | @dataclass
+72 72 | class Foo:
+73    |-    def __post_init__(self, bar: int = (x := 1)) -> None:
+   73 |+    bar: InitVar[int] = (x := 1)
+   74 |+    def __post_init__(self, bar: int) -> None:
+74 75 |         pass
+75 76 | 
+76 77 | 
+
+RUF033.py:81:21: RUF033 [*] `__post_init__` method with argument defaults
+   |
+79 |     def __post_init__(
+80 |         self,
+81 |         bar: int = (x := 1)  #  comment
+   |                     ^^^^^^ RUF033
+82 |         ,
+83 |         baz: int = (y := 2),  # comment
+   |
+   = help: Use `dataclasses.InitVar` instead
+
+ℹ Unsafe fix
+76 76 | 
+77 77 | @dataclass
+78 78 | class Foo:
+   79 |+    bar: InitVar[int] = (x := 1)
+79 80 |     def __post_init__(
+80 81 |         self,
+81    |-        bar: int = (x := 1)  #  comment
+   82 |+        bar: int  #  comment
+82 83 |         ,
+83 84 |         baz: int = (y := 2),  # comment
+84 85 |     ) -> None:
+
+RUF033.py:83:21: RUF033 [*] `__post_init__` method with argument defaults
+   |
+81 |         bar: int = (x := 1)  #  comment
+82 |         ,
+83 |         baz: int = (y := 2),  # comment
+   |                     ^^^^^^ RUF033
+84 |     ) -> None:
+85 |         pass
+   |
+   = help: Use `dataclasses.InitVar` instead
+
+ℹ Unsafe fix
+76 76 | 
+77 77 | @dataclass
+78 78 | class Foo:
+   79 |+    baz: InitVar[int] = (y := 2)
+79 80 |     def __post_init__(
+80 81 |         self,
+81 82 |         bar: int = (x := 1)  #  comment
+82 83 |         ,
+83    |-        baz: int = (y := 2),  # comment
+   84 |+        baz: int,  # comment
+84 85 |     ) -> None:
+85 86 |         pass
+86 87 | 
+
+RUF033.py:92:20: RUF033 [*] `__post_init__` method with argument defaults
+   |
+90 |     def __post_init__(
+91 |         self,
+92 |         bar: int = 1,  # comment
+   |                    ^ RUF033
+93 |         baz: int = 2,  # comment
+94 |     ) -> None:
+   |
+   = help: Use `dataclasses.InitVar` instead
+
+ℹ Unsafe fix
+87 87 | 
+88 88 | @dataclass
+89 89 | class Foo:
+   90 |+    bar: InitVar[int] = 1
+90 91 |     def __post_init__(
+91 92 |         self,
+92    |-        bar: int = 1,  # comment
+   93 |+        bar: int,  # comment
+93 94 |         baz: int = 2,  # comment
+94 95 |     ) -> None:
+95 96 |         pass
+
+RUF033.py:93:20: RUF033 [*] `__post_init__` method with argument defaults
+   |
+91 |         self,
+92 |         bar: int = 1,  # comment
+93 |         baz: int = 2,  # comment
+   |                    ^ RUF033
+94 |     ) -> None:
+95 |         pass
+   |
+   = help: Use `dataclasses.InitVar` instead
+
+ℹ Unsafe fix
+87 87 | 
+88 88 | @dataclass
+89 89 | class Foo:
+   90 |+    baz: InitVar[int] = 2
+90 91 |     def __post_init__(
+91 92 |         self,
+92 93 |         bar: int = 1,  # comment
+93    |-        baz: int = 2,  # comment
+   94 |+        baz: int,  # comment
+94 95 |     ) -> None:
+95 96 |         pass


### PR DESCRIPTION
## Summary
The generated fix for `RUF033` would cause a syntax error for named expressions as parameter defaults.
```python
from dataclasses import InitVar, dataclass
@dataclass
class Foo:
    def __post_init__(self, bar: int = (x := 1)) -> None:
        pass
```
would be turned into
```python
from dataclasses import InitVar, dataclass
@dataclass
class Foo:
    x: InitVar[int] = x := 1
    def __post_init__(self, bar: int = (x := 1)) -> None:
        pass
```
instead of the syntactically correct
```python
# ...
x: InitVar[int] = (x := 1)
# ...
```

## Test Plan
Test reproducer (plus some extra tests) have been added to the test suite.

## Related
Fixes: https://github.com/astral-sh/ruff/issues/18950