### PR TITLE
[ty] Temporarily disable the multithreaded pydantic benchmark

### DIFF
--- a/crates/ruff_benchmark/benches/ty_walltime.rs
+++ b/crates/ruff_benchmark/benches/ty_walltime.rs
@@ -242,19 +242,20 @@ fn large(bencher: Bencher, benchmark: &Benchmark) {
     run_single_threaded(bencher, benchmark);
 }
 
-#[bench(args=[&*PYDANTIC], sample_size=3, sample_count=3)]
-fn multithreaded(bencher: Bencher, benchmark: &Benchmark) {
-    let thread_pool = ThreadPoolBuilder::new().build().unwrap();
+// Currently disabled because the benchmark is too noisy (± 10%) to give useful feedback.
+// #[bench(args=[&*PYDANTIC], sample_size=3, sample_count=3)]
+// fn multithreaded(bencher: Bencher, benchmark: &Benchmark) {
+//     let thread_pool = ThreadPoolBuilder::new().build().unwrap();
 
-    bencher
-        .with_inputs(|| benchmark.setup_iteration())
-        .bench_local_values(|db| {
-            thread_pool.install(|| {
-                check_project(&db, benchmark.max_diagnostics);
-                db
-            })
-        });
-}
+//     bencher
+//         .with_inputs(|| benchmark.setup_iteration())
+//         .bench_local_values(|db| {
+//             thread_pool.install(|| {
+//                 check_project(&db, benchmark.max_diagnostics);
+//                 db
+//             })
+//         });
+// }
 
 fn main() {
     ThreadPoolBuilder::new()


### PR DESCRIPTION
The benchmark is currently very noisy (± 10%). This leads to codspeed reports on PRs, because we often exceed the trigger threshold. This is confusing to ty contributors who are not aware about the flakiness. Let's disable it for now.


FYI @MichaReiser 