### PR TITLE
Fix F701 to F707 errors in tests

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_bandit/S112.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_bandit/S112.py
@@ -1,29 +1,30 @@
-try:
-    pass
-except Exception:
-    continue
+for _ in []:
+    try:
+        pass
+    except Exception:
+        continue
 
-try:
-    pass
-except:
-    continue
+    try:
+        pass
+    except:
+        continue
 
-try:
-    pass
-except (Exception,):
-    continue
+    try:
+        pass
+    except (Exception,):
+        continue
 
-try:
-    pass
-except (Exception, ValueError):
-    continue
+    try:
+        pass
+    except (Exception, ValueError):
+        continue
 
-try:
-    pass
-except ValueError:
-    continue
+    try:
+        pass
+    except ValueError:
+        continue
 
-try:
-    pass
-except (ValueError,):
-    continue
+    try:
+        pass
+    except (ValueError,):
+        continue

--- a/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B031.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B031.py
@@ -185,38 +185,45 @@ for _section, section_items in groupby(items, key=lambda p: p[1]):
     collect_shop_items(shopper, section_items)
 
 # Shouldn't trigger the warning when there is a return statement.
-for _section, section_items in groupby(items, key=lambda p: p[1]):
-    if _section == "greens":
+def foo():
+    for _section, section_items in groupby(items, key=lambda p: p[1]):
+        if _section == "greens":
+            collect_shop_items(shopper, section_items)
+            return
+        elif _section == "frozen items":
+            return section_items
         collect_shop_items(shopper, section_items)
-        return
-    elif _section == "frozen items":
-        return section_items
-    collect_shop_items(shopper, section_items)
 
 # Should trigger the warning for duplicate access, even if is a return statement after.
-for _section, section_items in groupby(items, key=lambda p: p[1]):
-    if _section == "greens":
-        collect_shop_items(shopper, section_items)
-        collect_shop_items(shopper, section_items)
-        return
+def foo():
+    from itertools import groupby
+    for _section, section_items in groupby(items, key=lambda p: p[1]):
+        if _section == "greens":
+            collect_shop_items(shopper, section_items)
+            collect_shop_items(shopper, section_items)
+            return
 
 # Should trigger the warning for duplicate access, even if is a return in another branch.
-for _section, section_items in groupby(items, key=lambda p: p[1]):
-    if _section == "greens":
-        collect_shop_items(shopper, section_items)
-        return
-    elif _section == "frozen items":
-        collect_shop_items(shopper, section_items)
-        collect_shop_items(shopper, section_items)
+def foo():
+    from itertools import groupby
+    for _section, section_items in groupby(items, key=lambda p: p[1]):
+        if _section == "greens":
+            collect_shop_items(shopper, section_items)
+            return
+        elif _section == "frozen items":
+            collect_shop_items(shopper, section_items)
+            collect_shop_items(shopper, section_items)
 
 # Should trigger, since only one branch has a return statement.
-for _section, section_items in groupby(items, key=lambda p: p[1]):
-    if _section == "greens":
-        collect_shop_items(shopper, section_items)
-        return
-    elif _section == "frozen items":
-        collect_shop_items(shopper, section_items)
-    collect_shop_items(shopper, section_items)  # B031
+def foo():
+    from itertools import groupby
+    for _section, section_items in groupby(items, key=lambda p: p[1]):
+        if _section == "greens":
+            collect_shop_items(shopper, section_items)
+            return
+        elif _section == "frozen items":
+            collect_shop_items(shopper, section_items)
+        collect_shop_items(shopper, section_items)  # B031
 
 # Let's redefine the `groupby` function to make sure we pick up the correct one.
 # NOTE: This should always be at the end of the file.

--- a/crates/ruff_linter/resources/test/fixtures/flake8_pie/PIE804.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pie/PIE804.py
@@ -26,8 +26,9 @@ abc(**{'a': b}, **{'a': c})  # PIE804
 abc(a=1, **{'a': c}, **{'b': c})  # PIE804
 
 # Some values need to be parenthesized.
-abc(foo=1, **{'bar': (bar := 1)})  # PIE804
-abc(foo=1, **{'bar': (yield 1)})  # PIE804
+def foo():
+    abc(foo=1, **{'bar': (bar := 1)})  # PIE804
+    abc(foo=1, **{'bar': (yield 1)})  # PIE804
 
 # https://github.com/astral-sh/ruff/issues/18036
 # The autofix for this is unsafe due to the comments inside the dictionary.

--- a/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM115.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM115.py
@@ -27,8 +27,9 @@ with contextlib.ExitStack() as stack:
     close_files = stack.pop_all().close
 
 # OK
-with contextlib.AsyncExitStack() as exit_stack:
-    f = await exit_stack.enter_async_context(open("filename"))
+async def foo():
+    with contextlib.AsyncExitStack() as exit_stack:
+        f = await exit_stack.enter_async_context(open("filename"))
 
 # OK (false negative)
 with contextlib.ExitStack():
@@ -275,9 +276,10 @@ class ExampleClassTests(TestCase):
         cls.enterClassContext(open("filename"))
 
 # OK
-class ExampleAsyncTests(IsolatedAsyncioTestCase):
-    async def test_something(self):
-        await self.enterAsyncContext(open("filename"))
+async def foo():
+    class ExampleAsyncTests(IsolatedAsyncioTestCase):
+        async def test_something(self):
+            await self.enterAsyncContext(open("filename"))
 
 # OK
 class ExampleTests(TestCase):

--- a/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM116.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM116.py
@@ -1,98 +1,99 @@
-# Errors
-a = "hello"
+def foo():
+    # Errors
+    a = "hello"
 
-# SIM116
-if a == "foo":
-    return "bar"
-elif a == "bar":
-    return "baz"
-elif a == "boo":
-    return "ooh"
-else:
-    return 42
-
-# SIM116
-if a == 1:
-    return (1, 2, 3)
-elif a == 2:
-    return (4, 5, 6)
-elif a == 3:
-    return (7, 8, 9)
-else:
-    return (10, 11, 12)
-
-# SIM116
-if a == 1:
-    return (1, 2, 3)
-elif a == 2:
-    return (4, 5, 6)
-elif a == 3:
-    return (7, 8, 9)
-
-# SIM116
-if a == "hello 'sir'":
-    return (1, 2, 3)
-elif a == 'goodbye "mam"':
-    return (4, 5, 6)
-elif a == """Fairwell 'mister'""":
-    return (7, 8, 9)
-else:
-    return (10, 11, 12)
-
-# SIM116
-if a == b"one":
-    return 1
-elif a == b"two":
-    return 2
-elif a == b"three":
-    return 3
-
-# SIM116
-if a == "hello 'sir'":
-    return ("hello'", 'hi"', 3)
-elif a == 'goodbye "mam"':
-    return (4, 5, 6)
-elif a == """Fairwell 'mister'""":
-    return (7, 8, 9)
-else:
-    return (10, 11, 12)
-
-# OK
-if a == "foo":
-    return "bar"
-elif a == "bar":
-    return baz()
-elif a == "boo":
-    return "ooh"
-else:
-    return 42
-
-# OK
-if a == b"one":
-    return 1
-elif b == b"two":
-    return 2
-elif a == b"three":
-    return 3
-
-# SIM116
-if func_name == "create":
-    return "A"
-elif func_name == "modify":
-    return "M"
-elif func_name == "remove":
-    return "D"
-elif func_name == "move":
-    return "MV"
-
-# OK
-def no_return_in_else(platform):
-    if platform == "linux":
-        return "auditwheel repair -w {dest_dir} {wheel}"
-    elif platform == "macos":
-        return "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}"
-    elif platform == "windows":
-        return ""
+    # SIM116
+    if a == "foo":
+        return "bar"
+    elif a == "bar":
+        return "baz"
+    elif a == "boo":
+        return "ooh"
     else:
-        msg = f"Unknown platform: {platform!r}"
-        raise ValueError(msg)
+        return 42
+
+    # SIM116
+    if a == 1:
+        return (1, 2, 3)
+    elif a == 2:
+        return (4, 5, 6)
+    elif a == 3:
+        return (7, 8, 9)
+    else:
+        return (10, 11, 12)
+
+    # SIM116
+    if a == 1:
+        return (1, 2, 3)
+    elif a == 2:
+        return (4, 5, 6)
+    elif a == 3:
+        return (7, 8, 9)
+
+    # SIM116
+    if a == "hello 'sir'":
+        return (1, 2, 3)
+    elif a == 'goodbye "mam"':
+        return (4, 5, 6)
+    elif a == """Fairwell 'mister'""":
+        return (7, 8, 9)
+    else:
+        return (10, 11, 12)
+
+    # SIM116
+    if a == b"one":
+        return 1
+    elif a == b"two":
+        return 2
+    elif a == b"three":
+        return 3
+
+    # SIM116
+    if a == "hello 'sir'":
+        return ("hello'", 'hi"', 3)
+    elif a == 'goodbye "mam"':
+        return (4, 5, 6)
+    elif a == """Fairwell 'mister'""":
+        return (7, 8, 9)
+    else:
+        return (10, 11, 12)
+
+    # OK
+    if a == "foo":
+        return "bar"
+    elif a == "bar":
+        return baz()
+    elif a == "boo":
+        return "ooh"
+    else:
+        return 42
+
+    # OK
+    if a == b"one":
+        return 1
+    elif b == b"two":
+        return 2
+    elif a == b"three":
+        return 3
+
+    # SIM116
+    if func_name == "create":
+        return "A"
+    elif func_name == "modify":
+        return "M"
+    elif func_name == "remove":
+        return "D"
+    elif func_name == "move":
+        return "MV"
+
+    # OK
+    def no_return_in_else(platform):
+        if platform == "linux":
+            return "auditwheel repair -w {dest_dir} {wheel}"
+        elif platform == "macos":
+            return "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}"
+        elif platform == "windows":
+            return ""
+        else:
+            msg = f"Unknown platform: {platform!r}"
+            raise ValueError(msg)

--- a/crates/ruff_linter/resources/test/fixtures/pycodestyle/E27.py
+++ b/crates/ruff_linter/resources/test/fixtures/pycodestyle/E27.py
@@ -81,4 +81,5 @@ match(foo):
 # https://github.com/astral-sh/ruff/issues/12094
 pass;
 
-yield, x
+def foo():
+    yield, x

--- a/crates/ruff_linter/src/rules/flake8_bandit/snapshots/ruff_linter__rules__flake8_bandit__tests__S112_S112.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bandit/snapshots/ruff_linter__rules__flake8_bandit__tests__S112_S112.py.snap
@@ -1,46 +1,46 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_bandit/mod.rs
 ---
-S112.py:3:1: S112 `try`-`except`-`continue` detected, consider logging the exception
+S112.py:4:5: S112 `try`-`except`-`continue` detected, consider logging the exception
   |
-1 |   try:
-2 |       pass
-3 | / except Exception:
-4 | |     continue
-  | |____________^ S112
-5 |
-6 |   try:
+2 |       try:
+3 |           pass
+4 | /     except Exception:
+5 | |         continue
+  | |________________^ S112
+6 |
+7 |       try:
   |
 
-S112.py:8:1: S112 `try`-`except`-`continue` detected, consider logging the exception
+S112.py:9:5: S112 `try`-`except`-`continue` detected, consider logging the exception
    |
- 6 |   try:
- 7 |       pass
- 8 | / except:
- 9 | |     continue
-   | |____________^ S112
-10 |
-11 |   try:
-   |
-
-S112.py:13:1: S112 `try`-`except`-`continue` detected, consider logging the exception
-   |
-11 |   try:
-12 |       pass
-13 | / except (Exception,):
-14 | |     continue
-   | |____________^ S112
-15 |
-16 |   try:
+ 7 |       try:
+ 8 |           pass
+ 9 | /     except:
+10 | |         continue
+   | |________________^ S112
+11 |
+12 |       try:
    |
 
-S112.py:18:1: S112 `try`-`except`-`continue` detected, consider logging the exception
+S112.py:14:5: S112 `try`-`except`-`continue` detected, consider logging the exception
    |
-16 |   try:
-17 |       pass
-18 | / except (Exception, ValueError):
-19 | |     continue
-   | |____________^ S112
-20 |
-21 |   try:
+12 |       try:
+13 |           pass
+14 | /     except (Exception,):
+15 | |         continue
+   | |________________^ S112
+16 |
+17 |       try:
+   |
+
+S112.py:19:5: S112 `try`-`except`-`continue` detected, consider logging the exception
+   |
+17 |       try:
+18 |           pass
+19 | /     except (Exception, ValueError):
+20 | |         continue
+   | |________________^ S112
+21 |
+22 |       try:
    |

--- a/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B031_B031.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B031_B031.py.snap
@@ -195,31 +195,31 @@ B031.py:144:33: B031 Using the generator returned from `itertools.groupby()` mor
 146 | for group in groupby(items, key=lambda p: p[1]):
     |
 
-B031.py:200:37: B031 Using the generator returned from `itertools.groupby()` more than once will do nothing on the second usage
+B031.py:203:41: B031 Using the generator returned from `itertools.groupby()` more than once will do nothing on the second usage
     |
-198 |     if _section == "greens":
-199 |         collect_shop_items(shopper, section_items)
-200 |         collect_shop_items(shopper, section_items)
-    |                                     ^^^^^^^^^^^^^ B031
-201 |         return
-    |
-
-B031.py:210:37: B031 Using the generator returned from `itertools.groupby()` more than once will do nothing on the second usage
-    |
-208 |     elif _section == "frozen items":
-209 |         collect_shop_items(shopper, section_items)
-210 |         collect_shop_items(shopper, section_items)
-    |                                     ^^^^^^^^^^^^^ B031
-211 |
-212 | # Should trigger, since only one branch has a return statement.
+201 |         if _section == "greens":
+202 |             collect_shop_items(shopper, section_items)
+203 |             collect_shop_items(shopper, section_items)
+    |                                         ^^^^^^^^^^^^^ B031
+204 |             return
     |
 
-B031.py:219:33: B031 Using the generator returned from `itertools.groupby()` more than once will do nothing on the second usage
+B031.py:215:41: B031 Using the generator returned from `itertools.groupby()` more than once will do nothing on the second usage
     |
-217 |     elif _section == "frozen items":
-218 |         collect_shop_items(shopper, section_items)
-219 |     collect_shop_items(shopper, section_items)  # B031
-    |                                 ^^^^^^^^^^^^^ B031
-220 |
-221 | # Let's redefine the `groupby` function to make sure we pick up the correct one.
+213 |         elif _section == "frozen items":
+214 |             collect_shop_items(shopper, section_items)
+215 |             collect_shop_items(shopper, section_items)
+    |                                         ^^^^^^^^^^^^^ B031
+216 |
+217 | # Should trigger, since only one branch has a return statement.
+    |
+
+B031.py:226:37: B031 Using the generator returned from `itertools.groupby()` more than once will do nothing on the second usage
+    |
+224 |         elif _section == "frozen items":
+225 |             collect_shop_items(shopper, section_items)
+226 |         collect_shop_items(shopper, section_items)  # B031
+    |                                     ^^^^^^^^^^^^^ B031
+227 |
+228 | # Let's redefine the `groupby` function to make sure we pick up the correct one.
     |

--- a/crates/ruff_linter/src/rules/flake8_pie/snapshots/ruff_linter__rules__flake8_pie__tests__PIE804_PIE804.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pie/snapshots/ruff_linter__rules__flake8_pie__tests__PIE804_PIE804.py.snap
@@ -190,72 +190,73 @@ PIE804.py:26:22: PIE804 [*] Unnecessary `dict` kwargs
    26 |+abc(a=1, **{'a': c}, b=c)  # PIE804
 27 27 | 
 28 28 | # Some values need to be parenthesized.
-29 29 | abc(foo=1, **{'bar': (bar := 1)})  # PIE804
+29 29 | def foo():
 
-PIE804.py:29:12: PIE804 [*] Unnecessary `dict` kwargs
+PIE804.py:30:16: PIE804 [*] Unnecessary `dict` kwargs
    |
 28 | # Some values need to be parenthesized.
-29 | abc(foo=1, **{'bar': (bar := 1)})  # PIE804
-   |            ^^^^^^^^^^^^^^^^^^^^^ PIE804
-30 | abc(foo=1, **{'bar': (yield 1)})  # PIE804
-   |
-   = help: Remove unnecessary kwargs
-
-ℹ Safe fix
-26 26 | abc(a=1, **{'a': c}, **{'b': c})  # PIE804
-27 27 | 
-28 28 | # Some values need to be parenthesized.
-29    |-abc(foo=1, **{'bar': (bar := 1)})  # PIE804
-   29 |+abc(foo=1, bar=(bar := 1))  # PIE804
-30 30 | abc(foo=1, **{'bar': (yield 1)})  # PIE804
-31 31 | 
-32 32 | # https://github.com/astral-sh/ruff/issues/18036
-
-PIE804.py:30:12: PIE804 [*] Unnecessary `dict` kwargs
-   |
-28 | # Some values need to be parenthesized.
-29 | abc(foo=1, **{'bar': (bar := 1)})  # PIE804
-30 | abc(foo=1, **{'bar': (yield 1)})  # PIE804
-   |            ^^^^^^^^^^^^^^^^^^^^ PIE804
-31 |
-32 | # https://github.com/astral-sh/ruff/issues/18036
+29 | def foo():
+30 |     abc(foo=1, **{'bar': (bar := 1)})  # PIE804
+   |                ^^^^^^^^^^^^^^^^^^^^^ PIE804
+31 |     abc(foo=1, **{'bar': (yield 1)})  # PIE804
    |
    = help: Remove unnecessary kwargs
 
 ℹ Safe fix
 27 27 | 
 28 28 | # Some values need to be parenthesized.
-29 29 | abc(foo=1, **{'bar': (bar := 1)})  # PIE804
-30    |-abc(foo=1, **{'bar': (yield 1)})  # PIE804
-   30 |+abc(foo=1, bar=(yield 1))  # PIE804
-31 31 | 
-32 32 | # https://github.com/astral-sh/ruff/issues/18036
-33 33 | # The autofix for this is unsafe due to the comments inside the dictionary.
+29 29 | def foo():
+30    |-    abc(foo=1, **{'bar': (bar := 1)})  # PIE804
+   30 |+    abc(foo=1, bar=(bar := 1))  # PIE804
+31 31 |     abc(foo=1, **{'bar': (yield 1)})  # PIE804
+32 32 | 
+33 33 | # https://github.com/astral-sh/ruff/issues/18036
 
-PIE804.py:35:5: PIE804 [*] Unnecessary `dict` kwargs
+PIE804.py:31:16: PIE804 [*] Unnecessary `dict` kwargs
    |
-33 |   # The autofix for this is unsafe due to the comments inside the dictionary.
-34 |   foo(
-35 | /     **{
-36 | |         # Comment 1
-37 | |         "x": 1.0,
-38 | |         # Comment 2
-39 | |         "y": 2.0,
-40 | |     }
+29 | def foo():
+30 |     abc(foo=1, **{'bar': (bar := 1)})  # PIE804
+31 |     abc(foo=1, **{'bar': (yield 1)})  # PIE804
+   |                ^^^^^^^^^^^^^^^^^^^^ PIE804
+32 |
+33 | # https://github.com/astral-sh/ruff/issues/18036
+   |
+   = help: Remove unnecessary kwargs
+
+ℹ Safe fix
+28 28 | # Some values need to be parenthesized.
+29 29 | def foo():
+30 30 |     abc(foo=1, **{'bar': (bar := 1)})  # PIE804
+31    |-    abc(foo=1, **{'bar': (yield 1)})  # PIE804
+   31 |+    abc(foo=1, bar=(yield 1))  # PIE804
+32 32 | 
+33 33 | # https://github.com/astral-sh/ruff/issues/18036
+34 34 | # The autofix for this is unsafe due to the comments inside the dictionary.
+
+PIE804.py:36:5: PIE804 [*] Unnecessary `dict` kwargs
+   |
+34 |   # The autofix for this is unsafe due to the comments inside the dictionary.
+35 |   foo(
+36 | /     **{
+37 | |         # Comment 1
+38 | |         "x": 1.0,
+39 | |         # Comment 2
+40 | |         "y": 2.0,
+41 | |     }
    | |_____^ PIE804
-41 |   )
+42 |   )
    |
    = help: Remove unnecessary kwargs
 
 ℹ Unsafe fix
-32 32 | # https://github.com/astral-sh/ruff/issues/18036
-33 33 | # The autofix for this is unsafe due to the comments inside the dictionary.
-34 34 | foo(
-35    |-    **{
-36    |-        # Comment 1
-37    |-        "x": 1.0,
-38    |-        # Comment 2
-39    |-        "y": 2.0,
-40    |-    }
-   35 |+    x=1.0, y=2.0
-41 36 | )
+33 33 | # https://github.com/astral-sh/ruff/issues/18036
+34 34 | # The autofix for this is unsafe due to the comments inside the dictionary.
+35 35 | foo(
+36    |-    **{
+37    |-        # Comment 1
+38    |-        "x": 1.0,
+39    |-        # Comment 2
+40    |-        "y": 2.0,
+41    |-    }
+   36 |+    x=1.0, y=2.0
+42 37 | )

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM115_SIM115.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM115_SIM115.py.snap
@@ -50,285 +50,285 @@ SIM115.py:12:5: SIM115 Use a context manager for opening files
 14 | f.close()
    |
 
-SIM115.py:39:9: SIM115 Use a context manager for opening files
+SIM115.py:40:9: SIM115 Use a context manager for opening files
    |
-37 | # SIM115
-38 | with contextlib.ExitStack():
-39 |     f = open("filename")
+38 | # SIM115
+39 | with contextlib.ExitStack():
+40 |     f = open("filename")
    |         ^^^^ SIM115
-40 |
-41 | # OK
-   |
-
-SIM115.py:80:5: SIM115 Use a context manager for opening files
-   |
-78 | import fileinput
-79 |
-80 | f = tempfile.NamedTemporaryFile()
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM115
-81 | f = tempfile.TemporaryFile()
-82 | f = tempfile.SpooledTemporaryFile()
+41 |
+42 | # OK
    |
 
 SIM115.py:81:5: SIM115 Use a context manager for opening files
    |
-80 | f = tempfile.NamedTemporaryFile()
-81 | f = tempfile.TemporaryFile()
-   |     ^^^^^^^^^^^^^^^^^^^^^^ SIM115
-82 | f = tempfile.SpooledTemporaryFile()
-83 | f = tarfile.open("foo.tar")
+79 | import fileinput
+80 |
+81 | f = tempfile.NamedTemporaryFile()
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM115
+82 | f = tempfile.TemporaryFile()
+83 | f = tempfile.SpooledTemporaryFile()
    |
 
 SIM115.py:82:5: SIM115 Use a context manager for opening files
    |
-80 | f = tempfile.NamedTemporaryFile()
-81 | f = tempfile.TemporaryFile()
-82 | f = tempfile.SpooledTemporaryFile()
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM115
-83 | f = tarfile.open("foo.tar")
-84 | f = TarFile("foo.tar").open()
+81 | f = tempfile.NamedTemporaryFile()
+82 | f = tempfile.TemporaryFile()
+   |     ^^^^^^^^^^^^^^^^^^^^^^ SIM115
+83 | f = tempfile.SpooledTemporaryFile()
+84 | f = tarfile.open("foo.tar")
    |
 
 SIM115.py:83:5: SIM115 Use a context manager for opening files
    |
-81 | f = tempfile.TemporaryFile()
-82 | f = tempfile.SpooledTemporaryFile()
-83 | f = tarfile.open("foo.tar")
-   |     ^^^^^^^^^^^^ SIM115
-84 | f = TarFile("foo.tar").open()
-85 | f = tarfile.TarFile("foo.tar").open()
+81 | f = tempfile.NamedTemporaryFile()
+82 | f = tempfile.TemporaryFile()
+83 | f = tempfile.SpooledTemporaryFile()
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM115
+84 | f = tarfile.open("foo.tar")
+85 | f = TarFile("foo.tar").open()
    |
 
 SIM115.py:84:5: SIM115 Use a context manager for opening files
    |
-82 | f = tempfile.SpooledTemporaryFile()
-83 | f = tarfile.open("foo.tar")
-84 | f = TarFile("foo.tar").open()
-   |     ^^^^^^^^^^^^^^^^^^^^^^^ SIM115
-85 | f = tarfile.TarFile("foo.tar").open()
-86 | f = tarfile.TarFile().open()
+82 | f = tempfile.TemporaryFile()
+83 | f = tempfile.SpooledTemporaryFile()
+84 | f = tarfile.open("foo.tar")
+   |     ^^^^^^^^^^^^ SIM115
+85 | f = TarFile("foo.tar").open()
+86 | f = tarfile.TarFile("foo.tar").open()
    |
 
 SIM115.py:85:5: SIM115 Use a context manager for opening files
    |
-83 | f = tarfile.open("foo.tar")
-84 | f = TarFile("foo.tar").open()
-85 | f = tarfile.TarFile("foo.tar").open()
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM115
-86 | f = tarfile.TarFile().open()
-87 | f = zipfile.ZipFile("foo.zip").open("foo.txt")
+83 | f = tempfile.SpooledTemporaryFile()
+84 | f = tarfile.open("foo.tar")
+85 | f = TarFile("foo.tar").open()
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ SIM115
+86 | f = tarfile.TarFile("foo.tar").open()
+87 | f = tarfile.TarFile().open()
    |
 
 SIM115.py:86:5: SIM115 Use a context manager for opening files
    |
-84 | f = TarFile("foo.tar").open()
-85 | f = tarfile.TarFile("foo.tar").open()
-86 | f = tarfile.TarFile().open()
-   |     ^^^^^^^^^^^^^^^^^^^^^^ SIM115
-87 | f = zipfile.ZipFile("foo.zip").open("foo.txt")
-88 | f = io.open("foo.txt")
+84 | f = tarfile.open("foo.tar")
+85 | f = TarFile("foo.tar").open()
+86 | f = tarfile.TarFile("foo.tar").open()
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM115
+87 | f = tarfile.TarFile().open()
+88 | f = zipfile.ZipFile("foo.zip").open("foo.txt")
    |
 
 SIM115.py:87:5: SIM115 Use a context manager for opening files
    |
-85 | f = tarfile.TarFile("foo.tar").open()
-86 | f = tarfile.TarFile().open()
-87 | f = zipfile.ZipFile("foo.zip").open("foo.txt")
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM115
-88 | f = io.open("foo.txt")
-89 | f = io.open_code("foo.txt")
+85 | f = TarFile("foo.tar").open()
+86 | f = tarfile.TarFile("foo.tar").open()
+87 | f = tarfile.TarFile().open()
+   |     ^^^^^^^^^^^^^^^^^^^^^^ SIM115
+88 | f = zipfile.ZipFile("foo.zip").open("foo.txt")
+89 | f = io.open("foo.txt")
    |
 
 SIM115.py:88:5: SIM115 Use a context manager for opening files
    |
-86 | f = tarfile.TarFile().open()
-87 | f = zipfile.ZipFile("foo.zip").open("foo.txt")
-88 | f = io.open("foo.txt")
-   |     ^^^^^^^ SIM115
-89 | f = io.open_code("foo.txt")
-90 | f = codecs.open("foo.txt")
+86 | f = tarfile.TarFile("foo.tar").open()
+87 | f = tarfile.TarFile().open()
+88 | f = zipfile.ZipFile("foo.zip").open("foo.txt")
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM115
+89 | f = io.open("foo.txt")
+90 | f = io.open_code("foo.txt")
    |
 
 SIM115.py:89:5: SIM115 Use a context manager for opening files
    |
-87 | f = zipfile.ZipFile("foo.zip").open("foo.txt")
-88 | f = io.open("foo.txt")
-89 | f = io.open_code("foo.txt")
-   |     ^^^^^^^^^^^^ SIM115
-90 | f = codecs.open("foo.txt")
-91 | f = bz2.open("foo.txt")
+87 | f = tarfile.TarFile().open()
+88 | f = zipfile.ZipFile("foo.zip").open("foo.txt")
+89 | f = io.open("foo.txt")
+   |     ^^^^^^^ SIM115
+90 | f = io.open_code("foo.txt")
+91 | f = codecs.open("foo.txt")
    |
 
 SIM115.py:90:5: SIM115 Use a context manager for opening files
    |
-88 | f = io.open("foo.txt")
-89 | f = io.open_code("foo.txt")
-90 | f = codecs.open("foo.txt")
-   |     ^^^^^^^^^^^ SIM115
-91 | f = bz2.open("foo.txt")
-92 | f = gzip.open("foo.txt")
+88 | f = zipfile.ZipFile("foo.zip").open("foo.txt")
+89 | f = io.open("foo.txt")
+90 | f = io.open_code("foo.txt")
+   |     ^^^^^^^^^^^^ SIM115
+91 | f = codecs.open("foo.txt")
+92 | f = bz2.open("foo.txt")
    |
 
 SIM115.py:91:5: SIM115 Use a context manager for opening files
    |
-89 | f = io.open_code("foo.txt")
-90 | f = codecs.open("foo.txt")
-91 | f = bz2.open("foo.txt")
-   |     ^^^^^^^^ SIM115
-92 | f = gzip.open("foo.txt")
-93 | f = dbm.open("foo.db")
+89 | f = io.open("foo.txt")
+90 | f = io.open_code("foo.txt")
+91 | f = codecs.open("foo.txt")
+   |     ^^^^^^^^^^^ SIM115
+92 | f = bz2.open("foo.txt")
+93 | f = gzip.open("foo.txt")
    |
 
 SIM115.py:92:5: SIM115 Use a context manager for opening files
    |
-90 | f = codecs.open("foo.txt")
-91 | f = bz2.open("foo.txt")
-92 | f = gzip.open("foo.txt")
-   |     ^^^^^^^^^ SIM115
-93 | f = dbm.open("foo.db")
-94 | f = dbm.gnu.open("foo.db")
+90 | f = io.open_code("foo.txt")
+91 | f = codecs.open("foo.txt")
+92 | f = bz2.open("foo.txt")
+   |     ^^^^^^^^ SIM115
+93 | f = gzip.open("foo.txt")
+94 | f = dbm.open("foo.db")
    |
 
 SIM115.py:93:5: SIM115 Use a context manager for opening files
    |
-91 | f = bz2.open("foo.txt")
-92 | f = gzip.open("foo.txt")
-93 | f = dbm.open("foo.db")
-   |     ^^^^^^^^ SIM115
-94 | f = dbm.gnu.open("foo.db")
-95 | f = dbm.ndbm.open("foo.db")
+91 | f = codecs.open("foo.txt")
+92 | f = bz2.open("foo.txt")
+93 | f = gzip.open("foo.txt")
+   |     ^^^^^^^^^ SIM115
+94 | f = dbm.open("foo.db")
+95 | f = dbm.gnu.open("foo.db")
    |
 
 SIM115.py:94:5: SIM115 Use a context manager for opening files
    |
-92 | f = gzip.open("foo.txt")
-93 | f = dbm.open("foo.db")
-94 | f = dbm.gnu.open("foo.db")
-   |     ^^^^^^^^^^^^ SIM115
-95 | f = dbm.ndbm.open("foo.db")
-96 | f = dbm.dumb.open("foo.db")
+92 | f = bz2.open("foo.txt")
+93 | f = gzip.open("foo.txt")
+94 | f = dbm.open("foo.db")
+   |     ^^^^^^^^ SIM115
+95 | f = dbm.gnu.open("foo.db")
+96 | f = dbm.ndbm.open("foo.db")
    |
 
 SIM115.py:95:5: SIM115 Use a context manager for opening files
    |
-93 | f = dbm.open("foo.db")
-94 | f = dbm.gnu.open("foo.db")
-95 | f = dbm.ndbm.open("foo.db")
-   |     ^^^^^^^^^^^^^ SIM115
-96 | f = dbm.dumb.open("foo.db")
-97 | f = lzma.open("foo.xz")
+93 | f = gzip.open("foo.txt")
+94 | f = dbm.open("foo.db")
+95 | f = dbm.gnu.open("foo.db")
+   |     ^^^^^^^^^^^^ SIM115
+96 | f = dbm.ndbm.open("foo.db")
+97 | f = dbm.dumb.open("foo.db")
    |
 
 SIM115.py:96:5: SIM115 Use a context manager for opening files
    |
-94 | f = dbm.gnu.open("foo.db")
-95 | f = dbm.ndbm.open("foo.db")
-96 | f = dbm.dumb.open("foo.db")
+94 | f = dbm.open("foo.db")
+95 | f = dbm.gnu.open("foo.db")
+96 | f = dbm.ndbm.open("foo.db")
    |     ^^^^^^^^^^^^^ SIM115
-97 | f = lzma.open("foo.xz")
-98 | f = lzma.LZMAFile("foo.xz")
+97 | f = dbm.dumb.open("foo.db")
+98 | f = lzma.open("foo.xz")
    |
 
 SIM115.py:97:5: SIM115 Use a context manager for opening files
    |
-95 | f = dbm.ndbm.open("foo.db")
-96 | f = dbm.dumb.open("foo.db")
-97 | f = lzma.open("foo.xz")
-   |     ^^^^^^^^^ SIM115
-98 | f = lzma.LZMAFile("foo.xz")
-99 | f = shelve.open("foo.db")
+95 | f = dbm.gnu.open("foo.db")
+96 | f = dbm.ndbm.open("foo.db")
+97 | f = dbm.dumb.open("foo.db")
+   |     ^^^^^^^^^^^^^ SIM115
+98 | f = lzma.open("foo.xz")
+99 | f = lzma.LZMAFile("foo.xz")
    |
 
 SIM115.py:98:5: SIM115 Use a context manager for opening files
     |
- 96 | f = dbm.dumb.open("foo.db")
- 97 | f = lzma.open("foo.xz")
- 98 | f = lzma.LZMAFile("foo.xz")
-    |     ^^^^^^^^^^^^^ SIM115
- 99 | f = shelve.open("foo.db")
-100 | f = tokenize.open("foo.py")
+ 96 | f = dbm.ndbm.open("foo.db")
+ 97 | f = dbm.dumb.open("foo.db")
+ 98 | f = lzma.open("foo.xz")
+    |     ^^^^^^^^^ SIM115
+ 99 | f = lzma.LZMAFile("foo.xz")
+100 | f = shelve.open("foo.db")
     |
 
 SIM115.py:99:5: SIM115 Use a context manager for opening files
     |
- 97 | f = lzma.open("foo.xz")
- 98 | f = lzma.LZMAFile("foo.xz")
- 99 | f = shelve.open("foo.db")
-    |     ^^^^^^^^^^^ SIM115
-100 | f = tokenize.open("foo.py")
-101 | f = wave.open("foo.wav")
+ 97 | f = dbm.dumb.open("foo.db")
+ 98 | f = lzma.open("foo.xz")
+ 99 | f = lzma.LZMAFile("foo.xz")
+    |     ^^^^^^^^^^^^^ SIM115
+100 | f = shelve.open("foo.db")
+101 | f = tokenize.open("foo.py")
     |
 
 SIM115.py:100:5: SIM115 Use a context manager for opening files
     |
- 98 | f = lzma.LZMAFile("foo.xz")
- 99 | f = shelve.open("foo.db")
-100 | f = tokenize.open("foo.py")
-    |     ^^^^^^^^^^^^^ SIM115
-101 | f = wave.open("foo.wav")
-102 | f = tarfile.TarFile.taropen("foo.tar")
+ 98 | f = lzma.open("foo.xz")
+ 99 | f = lzma.LZMAFile("foo.xz")
+100 | f = shelve.open("foo.db")
+    |     ^^^^^^^^^^^ SIM115
+101 | f = tokenize.open("foo.py")
+102 | f = wave.open("foo.wav")
     |
 
 SIM115.py:101:5: SIM115 Use a context manager for opening files
     |
- 99 | f = shelve.open("foo.db")
-100 | f = tokenize.open("foo.py")
-101 | f = wave.open("foo.wav")
-    |     ^^^^^^^^^ SIM115
-102 | f = tarfile.TarFile.taropen("foo.tar")
-103 | f = fileinput.input("foo.txt")
+ 99 | f = lzma.LZMAFile("foo.xz")
+100 | f = shelve.open("foo.db")
+101 | f = tokenize.open("foo.py")
+    |     ^^^^^^^^^^^^^ SIM115
+102 | f = wave.open("foo.wav")
+103 | f = tarfile.TarFile.taropen("foo.tar")
     |
 
 SIM115.py:102:5: SIM115 Use a context manager for opening files
     |
-100 | f = tokenize.open("foo.py")
-101 | f = wave.open("foo.wav")
-102 | f = tarfile.TarFile.taropen("foo.tar")
-    |     ^^^^^^^^^^^^^^^^^^^^^^^ SIM115
-103 | f = fileinput.input("foo.txt")
-104 | f = fileinput.FileInput("foo.txt")
+100 | f = shelve.open("foo.db")
+101 | f = tokenize.open("foo.py")
+102 | f = wave.open("foo.wav")
+    |     ^^^^^^^^^ SIM115
+103 | f = tarfile.TarFile.taropen("foo.tar")
+104 | f = fileinput.input("foo.txt")
     |
 
 SIM115.py:103:5: SIM115 Use a context manager for opening files
     |
-101 | f = wave.open("foo.wav")
-102 | f = tarfile.TarFile.taropen("foo.tar")
-103 | f = fileinput.input("foo.txt")
-    |     ^^^^^^^^^^^^^^^ SIM115
-104 | f = fileinput.FileInput("foo.txt")
+101 | f = tokenize.open("foo.py")
+102 | f = wave.open("foo.wav")
+103 | f = tarfile.TarFile.taropen("foo.tar")
+    |     ^^^^^^^^^^^^^^^^^^^^^^^ SIM115
+104 | f = fileinput.input("foo.txt")
+105 | f = fileinput.FileInput("foo.txt")
     |
 
 SIM115.py:104:5: SIM115 Use a context manager for opening files
     |
-102 | f = tarfile.TarFile.taropen("foo.tar")
-103 | f = fileinput.input("foo.txt")
-104 | f = fileinput.FileInput("foo.txt")
+102 | f = wave.open("foo.wav")
+103 | f = tarfile.TarFile.taropen("foo.tar")
+104 | f = fileinput.input("foo.txt")
+    |     ^^^^^^^^^^^^^^^ SIM115
+105 | f = fileinput.FileInput("foo.txt")
+    |
+
+SIM115.py:105:5: SIM115 Use a context manager for opening files
+    |
+103 | f = tarfile.TarFile.taropen("foo.tar")
+104 | f = fileinput.input("foo.txt")
+105 | f = fileinput.FileInput("foo.txt")
     |     ^^^^^^^^^^^^^^^^^^^ SIM115
-105 |
-106 | with contextlib.suppress(Exception):
+106 |
+107 | with contextlib.suppress(Exception):
     |
 
-SIM115.py:240:9: SIM115 Use a context manager for opening files
+SIM115.py:241:9: SIM115 Use a context manager for opening files
     |
-238 | def aliased():
-239 |     from shelve import open as open_shelf
-240 |     x = open_shelf("foo.dbm")
+239 | def aliased():
+240 |     from shelve import open as open_shelf
+241 |     x = open_shelf("foo.dbm")
     |         ^^^^^^^^^^ SIM115
-241 |     x.close()
+242 |     x.close()
     |
 
-SIM115.py:244:9: SIM115 Use a context manager for opening files
+SIM115.py:245:9: SIM115 Use a context manager for opening files
     |
-243 |     from tarfile import TarFile as TF
-244 |     f = TF("foo").open()
+244 |     from tarfile import TarFile as TF
+245 |     f = TF("foo").open()
     |         ^^^^^^^^^^^^^^ SIM115
-245 |     f.close()
+246 |     f.close()
     |
 
-SIM115.py:257:5: SIM115 Use a context manager for opening files
+SIM115.py:258:5: SIM115 Use a context manager for opening files
     |
-256 | # SIM115
-257 | f = dbm.sqlite3.open("foo.db")
+257 | # SIM115
+258 | f = dbm.sqlite3.open("foo.db")
     |     ^^^^^^^^^^^^^^^^ SIM115
-258 | f.close()
+259 | f.close()
     |

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM116_SIM116.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM116_SIM116.py.snap
@@ -1,110 +1,110 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_simplify/mod.rs
 ---
-SIM116.py:5:1: SIM116 Use a dictionary instead of consecutive `if` statements
+SIM116.py:6:5: SIM116 Use a dictionary instead of consecutive `if` statements
    |
- 4 |   # SIM116
- 5 | / if a == "foo":
- 6 | |     return "bar"
- 7 | | elif a == "bar":
- 8 | |     return "baz"
- 9 | | elif a == "boo":
-10 | |     return "ooh"
-11 | | else:
-12 | |     return 42
-   | |_____________^ SIM116
-13 |
-14 |   # SIM116
-   |
-
-SIM116.py:15:1: SIM116 Use a dictionary instead of consecutive `if` statements
-   |
-14 |   # SIM116
-15 | / if a == 1:
-16 | |     return (1, 2, 3)
-17 | | elif a == 2:
-18 | |     return (4, 5, 6)
-19 | | elif a == 3:
-20 | |     return (7, 8, 9)
-21 | | else:
-22 | |     return (10, 11, 12)
-   | |_______________________^ SIM116
-23 |
-24 |   # SIM116
+ 5 |       # SIM116
+ 6 | /     if a == "foo":
+ 7 | |         return "bar"
+ 8 | |     elif a == "bar":
+ 9 | |         return "baz"
+10 | |     elif a == "boo":
+11 | |         return "ooh"
+12 | |     else:
+13 | |         return 42
+   | |_________________^ SIM116
+14 |
+15 |       # SIM116
    |
 
-SIM116.py:25:1: SIM116 Use a dictionary instead of consecutive `if` statements
+SIM116.py:16:5: SIM116 Use a dictionary instead of consecutive `if` statements
    |
-24 |   # SIM116
-25 | / if a == 1:
-26 | |     return (1, 2, 3)
-27 | | elif a == 2:
-28 | |     return (4, 5, 6)
-29 | | elif a == 3:
-30 | |     return (7, 8, 9)
-   | |____________________^ SIM116
-31 |
-32 |   # SIM116
-   |
-
-SIM116.py:33:1: SIM116 Use a dictionary instead of consecutive `if` statements
-   |
-32 |   # SIM116
-33 | / if a == "hello 'sir'":
-34 | |     return (1, 2, 3)
-35 | | elif a == 'goodbye "mam"':
-36 | |     return (4, 5, 6)
-37 | | elif a == """Fairwell 'mister'""":
-38 | |     return (7, 8, 9)
-39 | | else:
-40 | |     return (10, 11, 12)
-   | |_______________________^ SIM116
-41 |
-42 |   # SIM116
+15 |       # SIM116
+16 | /     if a == 1:
+17 | |         return (1, 2, 3)
+18 | |     elif a == 2:
+19 | |         return (4, 5, 6)
+20 | |     elif a == 3:
+21 | |         return (7, 8, 9)
+22 | |     else:
+23 | |         return (10, 11, 12)
+   | |___________________________^ SIM116
+24 |
+25 |       # SIM116
    |
 
-SIM116.py:43:1: SIM116 Use a dictionary instead of consecutive `if` statements
+SIM116.py:26:5: SIM116 Use a dictionary instead of consecutive `if` statements
    |
-42 |   # SIM116
-43 | / if a == b"one":
-44 | |     return 1
-45 | | elif a == b"two":
-46 | |     return 2
-47 | | elif a == b"three":
-48 | |     return 3
-   | |____________^ SIM116
-49 |
-50 |   # SIM116
-   |
-
-SIM116.py:51:1: SIM116 Use a dictionary instead of consecutive `if` statements
-   |
-50 |   # SIM116
-51 | / if a == "hello 'sir'":
-52 | |     return ("hello'", 'hi"', 3)
-53 | | elif a == 'goodbye "mam"':
-54 | |     return (4, 5, 6)
-55 | | elif a == """Fairwell 'mister'""":
-56 | |     return (7, 8, 9)
-57 | | else:
-58 | |     return (10, 11, 12)
-   | |_______________________^ SIM116
-59 |
-60 |   # OK
+25 |       # SIM116
+26 | /     if a == 1:
+27 | |         return (1, 2, 3)
+28 | |     elif a == 2:
+29 | |         return (4, 5, 6)
+30 | |     elif a == 3:
+31 | |         return (7, 8, 9)
+   | |________________________^ SIM116
+32 |
+33 |       # SIM116
    |
 
-SIM116.py:79:1: SIM116 Use a dictionary instead of consecutive `if` statements
+SIM116.py:34:5: SIM116 Use a dictionary instead of consecutive `if` statements
    |
-78 |   # SIM116
-79 | / if func_name == "create":
-80 | |     return "A"
-81 | | elif func_name == "modify":
-82 | |     return "M"
-83 | | elif func_name == "remove":
-84 | |     return "D"
-85 | | elif func_name == "move":
-86 | |     return "MV"
-   | |_______________^ SIM116
-87 |
-88 |   # OK
+33 |       # SIM116
+34 | /     if a == "hello 'sir'":
+35 | |         return (1, 2, 3)
+36 | |     elif a == 'goodbye "mam"':
+37 | |         return (4, 5, 6)
+38 | |     elif a == """Fairwell 'mister'""":
+39 | |         return (7, 8, 9)
+40 | |     else:
+41 | |         return (10, 11, 12)
+   | |___________________________^ SIM116
+42 |
+43 |       # SIM116
+   |
+
+SIM116.py:44:5: SIM116 Use a dictionary instead of consecutive `if` statements
+   |
+43 |       # SIM116
+44 | /     if a == b"one":
+45 | |         return 1
+46 | |     elif a == b"two":
+47 | |         return 2
+48 | |     elif a == b"three":
+49 | |         return 3
+   | |________________^ SIM116
+50 |
+51 |       # SIM116
+   |
+
+SIM116.py:52:5: SIM116 Use a dictionary instead of consecutive `if` statements
+   |
+51 |       # SIM116
+52 | /     if a == "hello 'sir'":
+53 | |         return ("hello'", 'hi"', 3)
+54 | |     elif a == 'goodbye "mam"':
+55 | |         return (4, 5, 6)
+56 | |     elif a == """Fairwell 'mister'""":
+57 | |         return (7, 8, 9)
+58 | |     else:
+59 | |         return (10, 11, 12)
+   | |___________________________^ SIM116
+60 |
+61 |       # OK
+   |
+
+SIM116.py:80:5: SIM116 Use a dictionary instead of consecutive `if` statements
+   |
+79 |       # SIM116
+80 | /     if func_name == "create":
+81 | |         return "A"
+82 | |     elif func_name == "modify":
+83 | |         return "M"
+84 | |     elif func_name == "remove":
+85 | |         return "D"
+86 | |     elif func_name == "move":
+87 | |         return "MV"
+   | |___________________^ SIM116
+88 |
+89 |       # OK
    |


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Per @ntBre in https://github.com/astral-sh/ruff/pull/19111, it would be a good idea to make the tests no longer have these syntax errors, so this PR updates the tests and snapshots.

`B031` gave me a lot of trouble since the ending test of declaring a function named `groupby` makes it so that inside other functions, it's unclear which `groupby` is referred to since it depends on when the function is called. To fix it I made each function have it's own `from itertools import groupby` so there's no more ambiguity.

## Test Plan

<!-- How was it tested? -->

Updated tests and snapshots.