### PR TITLE
[`pylint`, `pyupgrade`] Fix syntax errors in examples (`PLW1501`, `UP028`)

### DIFF
--- a/crates/ruff_linter/src/rules/pylint/rules/bad_open_mode.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/bad_open_mode.rs
@@ -24,13 +24,13 @@ use crate::checkers::ast::Checker;
 /// ## Example
 /// ```python
 /// with open("file", "rwx") as f:
-///     return f.read()
+///     content =  f.read()
 /// ```
 ///
 /// Use instead:
 /// ```python
 /// with open("file", "r") as f:
-///     return f.read()
+///     content = f.read()
 /// ```
 ///
 /// ## References

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/yield_in_for_loop.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/yield_in_for_loop.rs
@@ -15,21 +15,23 @@ use crate::{Edit, Fix, FixAvailability, Violation};
 ///
 /// ## Example
 /// ```python
-/// for x in foo:
-///     yield x
+/// def bar():
+///     for x in foo:
+///         yield x
 ///
-/// global y
-/// for y in foo:
-///     yield y
+///     global y
+///     for y in foo:
+///         yield y
 /// ```
 ///
 /// Use instead:
 /// ```python
-/// yield from foo
+/// def bar():
+///     yield from foo
 ///
-/// for _element in foo:
-///     y = _element
-///     yield y
+///     for _element in foo:
+///         y = _element
+///         yield y
 /// ```
 ///
 /// ## Fix safety


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

From me and @ntBre's discussion in #19111.

This PR makes these two examples into valid code, since they previously had `F701`-`F707` syntax errors. `SIM110` was already fixed in a different PR, I just forgot to pull.

## Test Plan

<!-- How was it tested? -->

N/A, no tests/functionality affected.