### PR TITLE
Move Azure output format to the new diagnostic format

### DIFF
--- a/crates/ruff_db/src/diagnostic/mod.rs
+++ b/crates/ruff_db/src/diagnostic/mod.rs
@@ -1,13 +1,12 @@
 use std::{fmt::Formatter, sync::Arc};
 
-use render::{FileResolver, Input};
 use ruff_diagnostics::Fix;
 use ruff_source_file::{LineColumn, SourceCode, SourceFile};
 
 use ruff_annotate_snippets::Level as AnnotateLevel;
 use ruff_text_size::{Ranged, TextRange, TextSize};
 
-pub use self::render::DisplayDiagnostic;
+pub use self::render::{DisplayDiagnostic, FileResolver, Input};
 use crate::{Db, files::File};
 
 mod render;

--- a/crates/ruff_db/src/diagnostic/mod.rs
+++ b/crates/ruff_db/src/diagnostic/mod.rs
@@ -1238,6 +1238,16 @@ pub enum DiagnosticFormat {
     Azure,
 }
 
+impl DiagnosticFormat {
+    /// Return whether or not the format is targeted at human readers.
+    ///
+    /// This excludes structured formats like JSON and indicates that summary messages like "All
+    /// checks passed!" should be suppressed.
+    pub fn is_human_readable(self) -> bool {
+        !matches!(self, Self::Azure)
+    }
+}
+
 /// A representation of the kinds of messages inside a diagnostic.
 pub enum ConciseMessage<'a> {
     /// A diagnostic contains a non-empty main message and an empty

--- a/crates/ruff_db/src/diagnostic/mod.rs
+++ b/crates/ruff_db/src/diagnostic/mod.rs
@@ -1232,6 +1232,10 @@ pub enum DiagnosticFormat {
     ///
     /// This may use color when printing to a `tty`.
     Concise,
+    /// Print diagnostics in the [Azure Pipelines] format.
+    ///
+    /// [Azure Pipelines]: https://learn.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=bash#logissue-log-an-error-or-warning
+    Azure,
 }
 
 /// A representation of the kinds of messages inside a diagnostic.

--- a/crates/ruff_linter/src/message/mod.rs
+++ b/crates/ruff_linter/src/message/mod.rs
@@ -3,10 +3,13 @@ use std::fmt::Display;
 use std::io::Write;
 use std::ops::Deref;
 
-use ruff_db::diagnostic::{
-    Annotation, Diagnostic, DiagnosticId, LintName, SecondaryCode, Severity, Span,
-};
 use rustc_hash::FxHashMap;
+
+use ruff_db::diagnostic::{
+    Annotation, Diagnostic, DiagnosticId, FileResolver, Input, LintName, SecondaryCode, Severity,
+    Span,
+};
+use ruff_db::files::File;
 
 pub use azure::AzureEmitter;
 pub use github::GithubEmitter;
@@ -128,6 +131,22 @@ pub fn diagnostic_from_violation<T: Violation>(
         None,
         T::rule(),
     )
+}
+
+/// A dummy [`FileResolver`] for rendering diagnostics.
+///
+/// Ruff's variant of `UnifiedFile` doesn't require a resolver, but we still need one to pass to its
+/// methods.
+pub struct DummyFileResolver;
+
+impl FileResolver for DummyFileResolver {
+    fn path(&self, _file: File) -> &str {
+        unimplemented!("Expected a Ruff file for rendering a Ruff diagnostic");
+    }
+
+    fn input(&self, _file: File) -> Input {
+        unimplemented!("Expected a Ruff file for rendering a Ruff diagnostic");
+    }
 }
 
 struct MessageWithLocation<'a> {

--- a/crates/ty/docs/cli.md
+++ b/crates/ty/docs/cli.md
@@ -62,6 +62,7 @@ over all configuration files.</p>
 <ul>
 <li><code>full</code>:  Print diagnostics verbosely, with context and helpful hints [default]</li>
 <li><code>concise</code>:  Print diagnostics concisely, one per line</li>
+<li><code>azure</code>:  Print diagnostics in the format used for Azure Pipelines</li>
 </ul></dd><dt id="ty-check--project"><a href="#ty-check--project"><code>--project</code></a> <i>project</i></dt><dd><p>Run the command within the given project directory.</p>
 <p>All <code>pyproject.toml</code> files will be discovered by walking up the directory tree from the given project directory, as will the project's virtual environment (<code>.venv</code>) unless the <code>venv-path</code> option is set.</p>
 <p>Other command-line arguments (such as relative paths) will be resolved relative to the current working directory.</p>

--- a/crates/ty/docs/configuration.md
+++ b/crates/ty/docs/configuration.md
@@ -474,7 +474,7 @@ Defaults to `full`.
 
 **Default value**: `full`
 
-**Type**: `full | concise`
+**Type**: `full | concise | azure`
 
 **Example usage** (`pyproject.toml`):
 

--- a/crates/ty/src/args.rs
+++ b/crates/ty/src/args.rs
@@ -321,6 +321,9 @@ pub enum OutputFormat {
     /// dropped.
     #[value(name = "concise")]
     Concise,
+    /// Print diagnostics in the format used for Azure Pipelines.
+    #[value(name = "azure")]
+    Azure,
 }
 
 impl From<OutputFormat> for ruff_db::diagnostic::DiagnosticFormat {
@@ -328,6 +331,7 @@ impl From<OutputFormat> for ruff_db::diagnostic::DiagnosticFormat {
         match format {
             OutputFormat::Full => Self::Full,
             OutputFormat::Concise => Self::Concise,
+            OutputFormat::Azure => Self::Azure,
         }
     }
 }

--- a/crates/ty/tests/cli/main.rs
+++ b/crates/ty/tests/cli/main.rs
@@ -542,7 +542,6 @@ fn azure_diagnostics() -> anyhow::Result<()> {
     ----- stdout -----
     ##vso[task.logissue type=warning;sourcepath=test.py;linenumber=2;columnnumber=7;]Name `x` used when not defined
     ##vso[task.logissue type=error;sourcepath=test.py;linenumber=3;columnnumber=7;]Cannot subscript object of type `Literal[4]` with no `__getitem__` method
-    Found 2 diagnostics
 
     ----- stderr -----
     WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.

--- a/crates/ty_project/src/metadata/options.rs
+++ b/crates/ty_project/src/metadata/options.rs
@@ -990,7 +990,7 @@ pub struct TerminalOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[option(
         default = r#"full"#,
-        value_type = "full | concise",
+        value_type = "full | concise | azure",
         example = r#"
             output-format = "concise"
         "#

--- a/ty.schema.json
+++ b/ty.schema.json
@@ -74,6 +74,13 @@
           "enum": [
             "concise"
           ]
+        },
+        {
+          "description": "Print diagnostics in the [Azure Pipelines] format.\n\n[Azure Pipelines]: https://learn.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=bash#logissue-log-an-error-or-warning",
+          "type": "string",
+          "enum": [
+            "azure"
+          ]
         }
       ]
     },


### PR DESCRIPTION
## Summary

This PR adds a dummy `FileResolver` to Ruff to enable using the `ruff_db::Diagnostic` rendering code and ports one of the simplest output formats (`azure`) to a `ruff_db::DiagnosticFormat`. This also made it very easy to add support for this output format to ty.

I think this will eventually allow us to rework, or even remove, the `Emitter` infrastructure in Ruff, but my plan for now is just to port the internals of each `Emitter`.

We didn't have any tests for this, but I removed this check:

https://github.com/astral-sh/ruff/blob/333191b7f7d78473a4ee88f6a24e199b29b01070/crates/ruff_linter/src/message/azure.rs#L22-L28

because the line numbers in notebooks look sensible to me. This matches the current behavior of ty too.

## Test Plan

Existing Ruff tests and a new ty CLI test
