### PR TITLE
[ty] detect cycles in Type::is_disjoint_from

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -1862,6 +1862,21 @@ class Bar(Protocol):
 static_assert(is_equivalent_to(Foo, Bar))
 ```
 
+### Disjointness of recursive protocol and recursive final type
+
+```py
+from typing import Protocol
+from ty_extensions import is_disjoint_from, static_assert
+
+class Proto(Protocol):
+    x: "Proto"
+
+class Nominal:
+    x: "Nominal"
+
+static_assert(not is_disjoint_from(Proto, Nominal))
+```
+
 ### Regression test: narrowing with self-referential protocols
 
 This snippet caused us to panic on an early version of the implementation for protocols.

--- a/crates/ty_python_semantic/src/types/cyclic.rs
+++ b/crates/ty_python_semantic/src/types/cyclic.rs
@@ -1,23 +1,39 @@
 use crate::FxIndexSet;
 use crate::types::Type;
+use std::cmp::Eq;
+use std::hash::Hash;
 
-#[derive(Debug, Default)]
-pub(crate) struct TypeTransformer<'db> {
-    seen: FxIndexSet<Type<'db>>,
+pub(crate) type TypeTransformer<'db> = CycleDetector<Type<'db>, Type<'db>>;
+
+impl Default for TypeTransformer<'_> {
+    fn default() -> Self {
+        // TODO: proper recursive type handling
+
+        // This must be Any, not e.g. a todo type, because Any is the normalized form of the
+        // dynamic type (that is, todo types are normalized to Any).
+        CycleDetector::new(Type::any())
+    }
 }
 
-impl<'db> TypeTransformer<'db> {
-    pub(crate) fn visit(
-        &mut self,
-        ty: Type<'db>,
-        func: impl FnOnce(&mut Self) -> Type<'db>,
-    ) -> Type<'db> {
-        if !self.seen.insert(ty) {
-            // TODO: proper recursive type handling
+pub(crate) type PairVisitor<'db> = CycleDetector<(Type<'db>, Type<'db>), bool>;
 
-            // This must be Any, not e.g. a todo type, because Any is the normalized form of the
-            // dynamic type (that is, todo types are normalized to Any).
-            return Type::any();
+#[derive(Debug)]
+pub(crate) struct CycleDetector<T: Hash + Eq, R: Copy> {
+    seen: FxIndexSet<T>,
+    fallback: R,
+}
+
+impl<T: Hash + Eq, R: Copy> CycleDetector<T, R> {
+    pub(crate) fn new(fallback: R) -> Self {
+        CycleDetector {
+            seen: FxIndexSet::default(),
+            fallback,
+        }
+    }
+
+    pub(crate) fn visit(&mut self, item: T, func: impl FnOnce(&mut Self) -> R) -> R {
+        if !self.seen.insert(item) {
+            return self.fallback;
         }
         let ret = func(self);
         self.seen.pop();

--- a/crates/ty_python_semantic/src/types/cyclic.rs
+++ b/crates/ty_python_semantic/src/types/cyclic.rs
@@ -18,7 +18,7 @@ impl Default for TypeTransformer<'_> {
 pub(crate) type PairVisitor<'db> = CycleDetector<(Type<'db>, Type<'db>), bool>;
 
 #[derive(Debug)]
-pub(crate) struct CycleDetector<T: Hash + Eq, R: Copy> {
+pub(crate) struct CycleDetector<T, R> {
     seen: FxIndexSet<T>,
     fallback: R,
 }

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -5,6 +5,7 @@ use std::marker::PhantomData;
 use super::protocol_class::ProtocolInterface;
 use super::{ClassType, KnownClass, SubclassOfType, Type, TypeVarVariance};
 use crate::place::PlaceAndQualifiers;
+use crate::types::cyclic::PairVisitor;
 use crate::types::protocol_class::walk_protocol_interface;
 use crate::types::tuple::TupleType;
 use crate::types::{DynamicType, TypeMapping, TypeRelation, TypeTransformer, TypeVarInstance};
@@ -118,7 +119,7 @@ impl<'db> NominalInstanceType<'db> {
         self.class.is_equivalent_to(db, other.class)
     }
 
-    pub(super) fn is_disjoint_from(self, db: &'db dyn Db, other: Self) -> bool {
+    pub(super) fn is_disjoint_from_impl(self, db: &'db dyn Db, other: Self) -> bool {
         !self.class.could_coexist_in_mro_with(db, other.class)
     }
 
@@ -277,7 +278,12 @@ impl<'db> ProtocolInstanceType<'db> {
     /// TODO: a protocol `X` is disjoint from a protocol `Y` if `X` and `Y`
     /// have a member with the same name but disjoint types
     #[expect(clippy::unused_self)]
-    pub(super) fn is_disjoint_from(self, _db: &'db dyn Db, _other: Self) -> bool {
+    pub(super) fn is_disjoint_from_impl(
+        self,
+        _db: &'db dyn Db,
+        _other: Self,
+        _visitor: &mut PairVisitor<'db>,
+    ) -> bool {
         false
     }
 

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -170,7 +170,7 @@ impl<'db> SubclassOfType<'db> {
     /// Return` true` if `self` is a disjoint type from `other`.
     ///
     /// See [`Type::is_disjoint_from`] for more details.
-    pub(crate) fn is_disjoint_from(self, db: &'db dyn Db, other: Self) -> bool {
+    pub(crate) fn is_disjoint_from_impl(self, db: &'db dyn Db, other: Self) -> bool {
         match (self.subclass_of, other.subclass_of) {
             (SubclassOfInner::Dynamic(_), _) | (_, SubclassOfInner::Dynamic(_)) => false,
             (SubclassOfInner::Class(self_class), SubclassOfInner::Class(other_class)) => {


### PR DESCRIPTION
## Summary

Detect and prevent cycles in `Type::is_disjoint_from`, which can now occur with recursive protocols.

## Test Plan

Added mdtest.
