### PR TITLE
[ty] Use inferred type for `Final` symbols

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
@@ -3,18 +3,20 @@
 [`typing.Final`] is a type qualifier that is used to indicate that a symbol may not be reassigned in
 any scope. Final names declared in class scopes cannot be overridden in subclasses.
 
-## Basic
+## Basic type inference
 
 `mod.py`:
 
 ```py
 from typing import Final, Annotated
 
-FINAL_A: int = 1
+FINAL_A: Final[int] = 1
 FINAL_B: Annotated[Final[int], "the annotation for FINAL_B"] = 1
 FINAL_C: Final[Annotated[int, "the annotation for FINAL_C"]] = 1
 FINAL_D: Final = 1
 FINAL_E: "Final[int]" = 1
+FINAL_F: Final[int]
+FINAL_F = 1
 
 reveal_type(FINAL_A)  # revealed: Literal[1]
 reveal_type(FINAL_B)  # revealed: Literal[1]
@@ -22,25 +24,47 @@ reveal_type(FINAL_C)  # revealed: Literal[1]
 reveal_type(FINAL_D)  # revealed: Literal[1]
 reveal_type(FINAL_E)  # revealed: Literal[1]
 
-# TODO: All of these should be errors:
+def nonlocal_uses():
+    reveal_type(FINAL_A)  # revealed: Literal[1]
+    reveal_type(FINAL_B)  # revealed: Literal[1]
+    reveal_type(FINAL_C)  # revealed: Literal[1]
+    reveal_type(FINAL_D)  # revealed: Literal[1]
+    reveal_type(FINAL_E)  # revealed: Literal[1]
+```
+
+Imported types:
+
+```py
+from mod import FINAL_A, FINAL_B, FINAL_C, FINAL_D, FINAL_E, FINAL_F
+
+reveal_type(FINAL_A)  # revealed: Literal[1]
+reveal_type(FINAL_B)  # revealed: Literal[1]
+reveal_type(FINAL_C)  # revealed: Literal[1]
+reveal_type(FINAL_D)  # revealed: Literal[1]
+reveal_type(FINAL_E)  # revealed: Literal[1]
+reveal_type(FINAL_F)  # revealed: Literal[1]
+```
+
+## Not modifiable
+
+```py
+from typing import Final, Annotated
+
+FINAL_A: Final[int] = 1
+FINAL_B: Annotated[Final[int], "the annotation for FINAL_B"] = 1
+FINAL_C: Final[Annotated[int, "the annotation for FINAL_C"]] = 1
+FINAL_D: Final = 1
+FINAL_E: "Final[int]" = 1
+FINAL_F: Final[int]
+FINAL_F = 1
+
+# TODO: all of these should be errors
 FINAL_A = 2
 FINAL_B = 2
 FINAL_C = 2
 FINAL_D = 2
 FINAL_E = 2
-```
-
-Public types:
-
-```py
-from mod import FINAL_A, FINAL_B, FINAL_C, FINAL_D, FINAL_E
-
-# TODO: All of these should be Literal[1]
-reveal_type(FINAL_A)  # revealed: int
-reveal_type(FINAL_B)  # revealed: int
-reveal_type(FINAL_C)  # revealed: int
-reveal_type(FINAL_D)  # revealed: Unknown
-reveal_type(FINAL_E)  # revealed: int
+FINAL_F = 2
 ```
 
 ## Too many arguments

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -646,6 +646,15 @@ fn place_by_id<'db>(
     };
 
     match declared {
+        Ok(declared) if declared.qualifiers.contains(TypeQualifiers::FINAL) => {
+            let bindings = all_considered_bindings();
+            return place_from_bindings_impl(db, bindings, requires_explicit_reexport)
+                .with_qualifiers(declared.qualifiers);
+        }
+        _ => {}
+    }
+
+    match declared {
         // Place is declared, trust the declared type
         Ok(
             place_and_quals @ PlaceAndQualifiers {


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
