### PR TITLE
[ty] Fix `ClassLiteral.into_callable`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
@@ -1774,6 +1774,23 @@ static_assert(is_subtype_of(type[B], Callable[[str], B]))
 static_assert(not is_subtype_of(type[B], Callable[[int], B]))
 ```
 
+### Dataclasses
+
+Dataclasses synthesize a `__init__` method.
+
+```py
+from typing import Callable
+from ty_extensions import TypeOf, static_assert, is_subtype_of
+from dataclasses import dataclass
+
+@dataclass
+class A:
+    x: "A" | None
+
+static_assert(is_subtype_of(type[A], Callable[[A], A]))
+static_assert(not is_subtype_of(type[A], Callable[[int], A]))
+```
+
 ### Bound methods
 
 ```py

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -615,12 +615,16 @@ impl<'db> ClassType<'db> {
             .member_lookup_with_policy(
                 db,
                 "__new__".into(),
-                MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK
-                    | MemberLookupPolicy::META_CLASS_NO_TYPE_FALLBACK,
+                MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
             )
             .place;
 
-        let dunder_new_ty = if let Some(Type::Callable(mut dunder_new_callable)) =
+        let dunder_new_ty = if matches!(
+            dunder_new_function_symbol,
+            Place::Type(Type::BoundMethod(_), _)
+        ) {
+            None
+        } else if let Some(Type::Callable(mut dunder_new_callable)) =
             place_to_signature(&dunder_new_function_symbol)
         {
             if matches!(

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -615,7 +615,8 @@ impl<'db> ClassType<'db> {
             .member_lookup_with_policy(
                 db,
                 "__new__".into(),
-                MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
+                MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK
+                    | MemberLookupPolicy::META_CLASS_NO_TYPE_FALLBACK,
             )
             .place;
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

Slightly refactor `ClassLiteral.into_callable` to use `Type.into_callable`. Essentially to firstly fix the issue with dataclasses, as the synthensized `__init__` created by dataclass isn't covered as it isn't `FunctionLiteral`


