### PR TITLE
[ty] Add a `DateType` benchmark

### DIFF
--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -498,11 +498,8 @@ fn bench_project(benchmark: &ProjectBenchmark, criterion: &mut Criterion) {
         let diagnostics = result.len();
 
         assert!(
-            diagnostics > 1 && diagnostics <= max_diagnostics,
-            "Expected between {} and {} diagnostics but got {}",
-            1,
-            max_diagnostics,
-            diagnostics
+            diagnostics <= max_diagnostics,
+            "Expected <={max_diagnostics} diagnostics but got {diagnostics}"
         );
     }
 
@@ -570,6 +567,23 @@ fn anyio(criterion: &mut Criterion) {
     bench_project(&benchmark, criterion);
 }
 
+fn datetype(criterion: &mut Criterion) {
+    let benchmark = ProjectBenchmark::new(
+        RealWorldProject {
+            name: "DateType",
+            repository: "https://github.com/glyph/DateType",
+            commit: "57c9c93cf2468069f72945fc04bf27b64100dad8",
+            paths: vec![SystemPath::new("src")],
+            dependencies: vec![],
+            max_dep_date: "2025-07-04",
+            python_version: PythonVersion::PY313,
+        },
+        0,
+    );
+
+    bench_project(&benchmark, criterion);
+}
+
 criterion_group!(check_file, benchmark_cold, benchmark_incremental);
 criterion_group!(
     micro,
@@ -578,5 +592,5 @@ criterion_group!(
     benchmark_complex_constrained_attributes_1,
     benchmark_complex_constrained_attributes_2,
 );
-criterion_group!(project, anyio, attrs, hydra);
+criterion_group!(project, anyio, attrs, hydra, datetype);
 criterion_main!(check_file, micro, project);


### PR DESCRIPTION
## Summary

The [`DateType`](https://github.com/glyph/DateType) library has some very large protocols in it. Currently we type-check it quite quickly, but the current version of https://github.com/astral-sh/ruff/pull/18659 makes our execution time on this library pathologically slow. That PR doesn't seem to have a big impact on any of our current benchmarks, however, so it seems we have some missing coverage in this area; I therefore propose that we add `DateType` as a benchmark.

Currently the benchmark runs pretty quickly (about half the runtime of attrs, which is our fastest real-world benchmark currently), and the library has 0 third-party dependencies, so the benchmark is quick to setup.

## Test Plan

`cargo bench -p ruff_benchmark --bench=ty`
