### PR TITLE
[`flake8-typechecking

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_type_checking/TC008.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_type_checking/TC008.py
@@ -28,6 +28,8 @@ m: TypeAlias = ('int'  # TC008
     | None)
 n: TypeAlias = ('int'  # TC008 (fix removes comment currently)
     ' | None')
+o: TypeAlias = """int
+| None"""
 
 type B = 'Dict'  # TC008
 type D = 'Foo[str]'  # TC008
@@ -41,6 +43,8 @@ type M = ('int'  # TC008
     | None)
 type N = ('int'  # TC008 (fix removes comment currently)
     ' | None')
+type O = """int
+| None"""
 
 
 class Baz:

--- a/crates/ruff_linter/src/rules/flake8_type_checking/rules/type_alias_quotes.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/rules/type_alias_quotes.rs
@@ -87,11 +87,15 @@ impl Violation for UnquotedTypeAlias {
 /// ## Example
 /// Given:
 /// ```python
+/// from typing import TypeAlias
+///
 /// OptInt: TypeAlias = "int | None"
 /// ```
 ///
 /// Use instead:
 /// ```python
+/// from typing import TypeAlias
+///
 /// OptInt: TypeAlias = int | None
 /// ```
 ///

--- a/crates/ruff_linter/src/rules/flake8_type_checking/rules/type_alias_quotes.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/rules/type_alias_quotes.rs
@@ -287,7 +287,13 @@ pub(crate) fn quoted_type_alias(
 
     let range = annotation_expr.range();
     let mut diagnostic = checker.report_diagnostic(QuotedTypeAlias, range);
-    let edit = Edit::range_replacement(annotation_expr.value.to_string(), range);
+    let fix_string = annotation_expr.value.to_string();
+    let fix_string = if fix_string.contains('\n') || fix_string.contains('\r') {
+        format!("({fix_string})")
+    } else {
+        fix_string
+    };
+    let edit = Edit::range_replacement(fix_string, range);
     if checker.comment_ranges().intersects(range) {
         diagnostic.set_fix(Fix::unsafe_edit(edit));
     } else {

--- a/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__quoted-type-alias_TC008.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__quoted-type-alias_TC008.py.snap
@@ -156,8 +156,8 @@ TC008.py:29:17: TC008 [*] Remove quotes from type alias
    |  _________________^
 30 | |     ' | None')
    | |_____________^ TC008
-31 |
-32 |   type B = 'Dict'  # TC008
+31 |   o: TypeAlias = """int
+32 |   | None"""
    |
    = help: Remove quotes
 
@@ -168,253 +168,303 @@ TC008.py:29:17: TC008 [*] Remove quotes from type alias
 29    |-n: TypeAlias = ('int'  # TC008 (fix removes comment currently)
 30    |-    ' | None')
    29 |+n: TypeAlias = (int | None)
-31 30 | 
-32 31 | type B = 'Dict'  # TC008
-33 32 | type D = 'Foo[str]'  # TC008
+31 30 | o: TypeAlias = """int
+32 31 | | None"""
+33 32 | 
 
-TC008.py:32:10: TC008 [*] Remove quotes from type alias
+TC008.py:31:16: TC008 [*] Remove quotes from type alias
    |
-30 |     ' | None')
-31 |
-32 | type B = 'Dict'  # TC008
-   |          ^^^^^^ TC008
-33 | type D = 'Foo[str]'  # TC008
-34 | type E = 'Foo.bar'  # TC008
+29 |   n: TypeAlias = ('int'  # TC008 (fix removes comment currently)
+30 |       ' | None')
+31 |   o: TypeAlias = """int
+   |  ________________^
+32 | | | None"""
+   | |_________^ TC008
+33 |
+34 |   type B = 'Dict'  # TC008
    |
    = help: Remove quotes
 
 ℹ Safe fix
+28 28 |     | None)
 29 29 | n: TypeAlias = ('int'  # TC008 (fix removes comment currently)
 30 30 |     ' | None')
-31 31 | 
-32    |-type B = 'Dict'  # TC008
-   32 |+type B = Dict  # TC008
-33 33 | type D = 'Foo[str]'  # TC008
-34 34 | type E = 'Foo.bar'  # TC008
-35 35 | type G = 'OptStr'  # TC008
-
-TC008.py:33:10: TC008 [*] Remove quotes from type alias
-   |
-32 | type B = 'Dict'  # TC008
-33 | type D = 'Foo[str]'  # TC008
-   |          ^^^^^^^^^^ TC008
-34 | type E = 'Foo.bar'  # TC008
-35 | type G = 'OptStr'  # TC008
-   |
-   = help: Remove quotes
-
-ℹ Safe fix
-30 30 |     ' | None')
-31 31 | 
-32 32 | type B = 'Dict'  # TC008
-33    |-type D = 'Foo[str]'  # TC008
-   33 |+type D = Foo[str]  # TC008
-34 34 | type E = 'Foo.bar'  # TC008
-35 35 | type G = 'OptStr'  # TC008
-36 36 | type I = Foo['str']  # TC008
+31    |-o: TypeAlias = """int
+32    |-| None"""
+   31 |+o: TypeAlias = (int
+   32 |+| None)
+33 33 | 
+34 34 | type B = 'Dict'  # TC008
+35 35 | type D = 'Foo[str]'  # TC008
 
 TC008.py:34:10: TC008 [*] Remove quotes from type alias
    |
-32 | type B = 'Dict'  # TC008
-33 | type D = 'Foo[str]'  # TC008
-34 | type E = 'Foo.bar'  # TC008
-   |          ^^^^^^^^^ TC008
-35 | type G = 'OptStr'  # TC008
-36 | type I = Foo['str']  # TC008
+32 | | None"""
+33 |
+34 | type B = 'Dict'  # TC008
+   |          ^^^^^^ TC008
+35 | type D = 'Foo[str]'  # TC008
+36 | type E = 'Foo.bar'  # TC008
    |
    = help: Remove quotes
 
 ℹ Safe fix
-31 31 | 
-32 32 | type B = 'Dict'  # TC008
-33 33 | type D = 'Foo[str]'  # TC008
-34    |-type E = 'Foo.bar'  # TC008
-   34 |+type E = Foo.bar  # TC008
-35 35 | type G = 'OptStr'  # TC008
-36 36 | type I = Foo['str']  # TC008
-37 37 | type J = 'Baz'  # TC008
+31 31 | o: TypeAlias = """int
+32 32 | | None"""
+33 33 | 
+34    |-type B = 'Dict'  # TC008
+   34 |+type B = Dict  # TC008
+35 35 | type D = 'Foo[str]'  # TC008
+36 36 | type E = 'Foo.bar'  # TC008
+37 37 | type G = 'OptStr'  # TC008
 
 TC008.py:35:10: TC008 [*] Remove quotes from type alias
    |
-33 | type D = 'Foo[str]'  # TC008
-34 | type E = 'Foo.bar'  # TC008
-35 | type G = 'OptStr'  # TC008
-   |          ^^^^^^^^ TC008
-36 | type I = Foo['str']  # TC008
-37 | type J = 'Baz'  # TC008
+34 | type B = 'Dict'  # TC008
+35 | type D = 'Foo[str]'  # TC008
+   |          ^^^^^^^^^^ TC008
+36 | type E = 'Foo.bar'  # TC008
+37 | type G = 'OptStr'  # TC008
    |
    = help: Remove quotes
 
 ℹ Safe fix
-32 32 | type B = 'Dict'  # TC008
-33 33 | type D = 'Foo[str]'  # TC008
-34 34 | type E = 'Foo.bar'  # TC008
-35    |-type G = 'OptStr'  # TC008
-   35 |+type G = OptStr  # TC008
-36 36 | type I = Foo['str']  # TC008
-37 37 | type J = 'Baz'  # TC008
-38 38 | type K = 'K | None'  # TC008
+32 32 | | None"""
+33 33 | 
+34 34 | type B = 'Dict'  # TC008
+35    |-type D = 'Foo[str]'  # TC008
+   35 |+type D = Foo[str]  # TC008
+36 36 | type E = 'Foo.bar'  # TC008
+37 37 | type G = 'OptStr'  # TC008
+38 38 | type I = Foo['str']  # TC008
 
-TC008.py:36:14: TC008 [*] Remove quotes from type alias
+TC008.py:36:10: TC008 [*] Remove quotes from type alias
    |
-34 | type E = 'Foo.bar'  # TC008
-35 | type G = 'OptStr'  # TC008
-36 | type I = Foo['str']  # TC008
-   |              ^^^^^ TC008
-37 | type J = 'Baz'  # TC008
-38 | type K = 'K | None'  # TC008
+34 | type B = 'Dict'  # TC008
+35 | type D = 'Foo[str]'  # TC008
+36 | type E = 'Foo.bar'  # TC008
+   |          ^^^^^^^^^ TC008
+37 | type G = 'OptStr'  # TC008
+38 | type I = Foo['str']  # TC008
    |
    = help: Remove quotes
 
 ℹ Safe fix
-33 33 | type D = 'Foo[str]'  # TC008
-34 34 | type E = 'Foo.bar'  # TC008
-35 35 | type G = 'OptStr'  # TC008
-36    |-type I = Foo['str']  # TC008
-   36 |+type I = Foo[str]  # TC008
-37 37 | type J = 'Baz'  # TC008
-38 38 | type K = 'K | None'  # TC008
-39 39 | type L = 'int' | None  # TC008 (because TC010 is not enabled)
+33 33 | 
+34 34 | type B = 'Dict'  # TC008
+35 35 | type D = 'Foo[str]'  # TC008
+36    |-type E = 'Foo.bar'  # TC008
+   36 |+type E = Foo.bar  # TC008
+37 37 | type G = 'OptStr'  # TC008
+38 38 | type I = Foo['str']  # TC008
+39 39 | type J = 'Baz'  # TC008
 
 TC008.py:37:10: TC008 [*] Remove quotes from type alias
    |
-35 | type G = 'OptStr'  # TC008
-36 | type I = Foo['str']  # TC008
-37 | type J = 'Baz'  # TC008
-   |          ^^^^^ TC008
-38 | type K = 'K | None'  # TC008
-39 | type L = 'int' | None  # TC008 (because TC010 is not enabled)
+35 | type D = 'Foo[str]'  # TC008
+36 | type E = 'Foo.bar'  # TC008
+37 | type G = 'OptStr'  # TC008
+   |          ^^^^^^^^ TC008
+38 | type I = Foo['str']  # TC008
+39 | type J = 'Baz'  # TC008
    |
    = help: Remove quotes
 
 ℹ Safe fix
-34 34 | type E = 'Foo.bar'  # TC008
-35 35 | type G = 'OptStr'  # TC008
-36 36 | type I = Foo['str']  # TC008
-37    |-type J = 'Baz'  # TC008
-   37 |+type J = Baz  # TC008
-38 38 | type K = 'K | None'  # TC008
-39 39 | type L = 'int' | None  # TC008 (because TC010 is not enabled)
-40 40 | type M = ('int'  # TC008
+34 34 | type B = 'Dict'  # TC008
+35 35 | type D = 'Foo[str]'  # TC008
+36 36 | type E = 'Foo.bar'  # TC008
+37    |-type G = 'OptStr'  # TC008
+   37 |+type G = OptStr  # TC008
+38 38 | type I = Foo['str']  # TC008
+39 39 | type J = 'Baz'  # TC008
+40 40 | type K = 'K | None'  # TC008
 
-TC008.py:38:10: TC008 [*] Remove quotes from type alias
+TC008.py:38:14: TC008 [*] Remove quotes from type alias
    |
-36 | type I = Foo['str']  # TC008
-37 | type J = 'Baz'  # TC008
-38 | type K = 'K | None'  # TC008
-   |          ^^^^^^^^^^ TC008
-39 | type L = 'int' | None  # TC008 (because TC010 is not enabled)
-40 | type M = ('int'  # TC008
+36 | type E = 'Foo.bar'  # TC008
+37 | type G = 'OptStr'  # TC008
+38 | type I = Foo['str']  # TC008
+   |              ^^^^^ TC008
+39 | type J = 'Baz'  # TC008
+40 | type K = 'K | None'  # TC008
    |
    = help: Remove quotes
 
 ℹ Safe fix
-35 35 | type G = 'OptStr'  # TC008
-36 36 | type I = Foo['str']  # TC008
-37 37 | type J = 'Baz'  # TC008
-38    |-type K = 'K | None'  # TC008
-   38 |+type K = K | None  # TC008
-39 39 | type L = 'int' | None  # TC008 (because TC010 is not enabled)
-40 40 | type M = ('int'  # TC008
-41 41 |     | None)
+35 35 | type D = 'Foo[str]'  # TC008
+36 36 | type E = 'Foo.bar'  # TC008
+37 37 | type G = 'OptStr'  # TC008
+38    |-type I = Foo['str']  # TC008
+   38 |+type I = Foo[str]  # TC008
+39 39 | type J = 'Baz'  # TC008
+40 40 | type K = 'K | None'  # TC008
+41 41 | type L = 'int' | None  # TC008 (because TC010 is not enabled)
 
 TC008.py:39:10: TC008 [*] Remove quotes from type alias
    |
-37 | type J = 'Baz'  # TC008
-38 | type K = 'K | None'  # TC008
-39 | type L = 'int' | None  # TC008 (because TC010 is not enabled)
+37 | type G = 'OptStr'  # TC008
+38 | type I = Foo['str']  # TC008
+39 | type J = 'Baz'  # TC008
    |          ^^^^^ TC008
-40 | type M = ('int'  # TC008
-41 |     | None)
+40 | type K = 'K | None'  # TC008
+41 | type L = 'int' | None  # TC008 (because TC010 is not enabled)
    |
    = help: Remove quotes
 
 ℹ Safe fix
-36 36 | type I = Foo['str']  # TC008
-37 37 | type J = 'Baz'  # TC008
-38 38 | type K = 'K | None'  # TC008
-39    |-type L = 'int' | None  # TC008 (because TC010 is not enabled)
-   39 |+type L = int | None  # TC008 (because TC010 is not enabled)
-40 40 | type M = ('int'  # TC008
-41 41 |     | None)
-42 42 | type N = ('int'  # TC008 (fix removes comment currently)
+36 36 | type E = 'Foo.bar'  # TC008
+37 37 | type G = 'OptStr'  # TC008
+38 38 | type I = Foo['str']  # TC008
+39    |-type J = 'Baz'  # TC008
+   39 |+type J = Baz  # TC008
+40 40 | type K = 'K | None'  # TC008
+41 41 | type L = 'int' | None  # TC008 (because TC010 is not enabled)
+42 42 | type M = ('int'  # TC008
 
-TC008.py:40:11: TC008 [*] Remove quotes from type alias
+TC008.py:40:10: TC008 [*] Remove quotes from type alias
    |
-38 | type K = 'K | None'  # TC008
-39 | type L = 'int' | None  # TC008 (because TC010 is not enabled)
-40 | type M = ('int'  # TC008
-   |           ^^^^^ TC008
-41 |     | None)
-42 | type N = ('int'  # TC008 (fix removes comment currently)
+38 | type I = Foo['str']  # TC008
+39 | type J = 'Baz'  # TC008
+40 | type K = 'K | None'  # TC008
+   |          ^^^^^^^^^^ TC008
+41 | type L = 'int' | None  # TC008 (because TC010 is not enabled)
+42 | type M = ('int'  # TC008
    |
    = help: Remove quotes
 
 ℹ Safe fix
-37 37 | type J = 'Baz'  # TC008
-38 38 | type K = 'K | None'  # TC008
-39 39 | type L = 'int' | None  # TC008 (because TC010 is not enabled)
-40    |-type M = ('int'  # TC008
-   40 |+type M = (int  # TC008
-41 41 |     | None)
-42 42 | type N = ('int'  # TC008 (fix removes comment currently)
-43 43 |     ' | None')
+37 37 | type G = 'OptStr'  # TC008
+38 38 | type I = Foo['str']  # TC008
+39 39 | type J = 'Baz'  # TC008
+40    |-type K = 'K | None'  # TC008
+   40 |+type K = K | None  # TC008
+41 41 | type L = 'int' | None  # TC008 (because TC010 is not enabled)
+42 42 | type M = ('int'  # TC008
+43 43 |     | None)
+
+TC008.py:41:10: TC008 [*] Remove quotes from type alias
+   |
+39 | type J = 'Baz'  # TC008
+40 | type K = 'K | None'  # TC008
+41 | type L = 'int' | None  # TC008 (because TC010 is not enabled)
+   |          ^^^^^ TC008
+42 | type M = ('int'  # TC008
+43 |     | None)
+   |
+   = help: Remove quotes
+
+ℹ Safe fix
+38 38 | type I = Foo['str']  # TC008
+39 39 | type J = 'Baz'  # TC008
+40 40 | type K = 'K | None'  # TC008
+41    |-type L = 'int' | None  # TC008 (because TC010 is not enabled)
+   41 |+type L = int | None  # TC008 (because TC010 is not enabled)
+42 42 | type M = ('int'  # TC008
+43 43 |     | None)
+44 44 | type N = ('int'  # TC008 (fix removes comment currently)
 
 TC008.py:42:11: TC008 [*] Remove quotes from type alias
    |
-40 |   type M = ('int'  # TC008
-41 |       | None)
-42 |   type N = ('int'  # TC008 (fix removes comment currently)
+40 | type K = 'K | None'  # TC008
+41 | type L = 'int' | None  # TC008 (because TC010 is not enabled)
+42 | type M = ('int'  # TC008
+   |           ^^^^^ TC008
+43 |     | None)
+44 | type N = ('int'  # TC008 (fix removes comment currently)
+   |
+   = help: Remove quotes
+
+ℹ Safe fix
+39 39 | type J = 'Baz'  # TC008
+40 40 | type K = 'K | None'  # TC008
+41 41 | type L = 'int' | None  # TC008 (because TC010 is not enabled)
+42    |-type M = ('int'  # TC008
+   42 |+type M = (int  # TC008
+43 43 |     | None)
+44 44 | type N = ('int'  # TC008 (fix removes comment currently)
+45 45 |     ' | None')
+
+TC008.py:44:11: TC008 [*] Remove quotes from type alias
+   |
+42 |   type M = ('int'  # TC008
+43 |       | None)
+44 |   type N = ('int'  # TC008 (fix removes comment currently)
    |  ___________^
-43 | |     ' | None')
+45 | |     ' | None')
    | |_____________^ TC008
+46 |   type O = """int
+47 |   | None"""
    |
    = help: Remove quotes
 
 ℹ Unsafe fix
-39 39 | type L = 'int' | None  # TC008 (because TC010 is not enabled)
-40 40 | type M = ('int'  # TC008
-41 41 |     | None)
-42    |-type N = ('int'  # TC008 (fix removes comment currently)
-43    |-    ' | None')
-   42 |+type N = (int | None)
-44 43 | 
-45 44 | 
-46 45 | class Baz:
+41 41 | type L = 'int' | None  # TC008 (because TC010 is not enabled)
+42 42 | type M = ('int'  # TC008
+43 43 |     | None)
+44    |-type N = ('int'  # TC008 (fix removes comment currently)
+45    |-    ' | None')
+   44 |+type N = (int | None)
+46 45 | type O = """int
+47 46 | | None"""
+48 47 | 
 
-TC008.py:48:14: TC008 [*] Remove quotes from type alias
+TC008.py:46:10: TC008 [*] Remove quotes from type alias
    |
-46 | class Baz:
-47 |     a: TypeAlias = 'Baz'  # OK
-48 |     type A = 'Baz'  # TC008
-   |              ^^^^^ TC008
-49 |
-50 |     class Nested:
+44 |   type N = ('int'  # TC008 (fix removes comment currently)
+45 |       ' | None')
+46 |   type O = """int
+   |  __________^
+47 | | | None"""
+   | |_________^ TC008
    |
    = help: Remove quotes
 
 ℹ Safe fix
-45 45 | 
-46 46 | class Baz:
-47 47 |     a: TypeAlias = 'Baz'  # OK
-48    |-    type A = 'Baz'  # TC008
-   48 |+    type A = Baz  # TC008
+43 43 |     | None)
+44 44 | type N = ('int'  # TC008 (fix removes comment currently)
+45 45 |     ' | None')
+46    |-type O = """int
+47    |-| None"""
+   46 |+type O = (int
+   47 |+| None)
+48 48 | 
 49 49 | 
-50 50 |     class Nested:
-51 51 |         a: TypeAlias = 'Baz'  # OK
+50 50 | class Baz:
 
-TC008.py:52:18: TC008 [*] Remove quotes from type alias
+TC008.py:52:14: TC008 [*] Remove quotes from type alias
    |
-50 |     class Nested:
-51 |         a: TypeAlias = 'Baz'  # OK
-52 |         type A = 'Baz'  # TC008
+50 | class Baz:
+51 |     a: TypeAlias = 'Baz'  # OK
+52 |     type A = 'Baz'  # TC008
+   |              ^^^^^ TC008
+53 |
+54 |     class Nested:
+   |
+   = help: Remove quotes
+
+ℹ Safe fix
+49 49 | 
+50 50 | class Baz:
+51 51 |     a: TypeAlias = 'Baz'  # OK
+52    |-    type A = 'Baz'  # TC008
+   52 |+    type A = Baz  # TC008
+53 53 | 
+54 54 |     class Nested:
+55 55 |         a: TypeAlias = 'Baz'  # OK
+
+TC008.py:56:18: TC008 [*] Remove quotes from type alias
+   |
+54 |     class Nested:
+55 |         a: TypeAlias = 'Baz'  # OK
+56 |         type A = 'Baz'  # TC008
    |                  ^^^^^ TC008
    |
    = help: Remove quotes
 
 ℹ Safe fix
-49 49 | 
-50 50 |     class Nested:
-51 51 |         a: TypeAlias = 'Baz'  # OK
-52    |-        type A = 'Baz'  # TC008
-   52 |+        type A = Baz  # TC008
+53 53 | 
+54 54 |     class Nested:
+55 55 |         a: TypeAlias = 'Baz'  # OK
+56    |-        type A = 'Baz'  # TC008
+   56 |+        type A = Baz  # TC008


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

I noticed this while working on #18972. If the string targeted by [quoted-type-alias (TC008)](https://docs.astral.sh/ruff/rules/quoted-type-alias/#quoted-type-alias-tc008) is a multiline string, the fix would introduce a syntax error. This PR fixes that by adding parenthesis around the resulting replacement if the string contained any newline characters (`\n`, `\r`).

Failing examples: https://play.ruff.rs/8793eb95-860a-4bb3-9cbc-6a042fee2946
```
PS D:\rust_projects\ruff> Get-Content issue.py
```
```py
from typing import TypeAlias

OptInt: TypeAlias = """int
| None"""

type OptInt = """int
| None"""
```
```
PS D:\rust_projects\ruff> uvx ruff check issue.py --isolated --select TC008 --fix --diff --preview
```
```

error: Fix introduced a syntax error. Reverting all changes.

This indicates a bug in Ruff. If you could open an issue at:

    https://github.com/astral-sh/ruff/issues/new?title=%5BFix%20error%5D

...quoting the contents of `issue.py`, the rule codes TC008, along with the `pyproject.toml` settings and executed command, we'd be very appreciative!
```

I'm unsure why the snapshot diff is so noisy. It looks mostly reasonable to me, and has the expected fixes, so I think it's just due to the line numbers changing + the diff algorithm being not smart, but I would appreciate a double check on that.

This PR also makes the example error out-of-the-box for #18972

Old example: https://play.ruff.rs/f6cd5adb-7f9b-444d-bb3e-8c045241d93e
```py
OptInt: TypeAlias = "int | None"
```

New example: https://play.ruff.rs/906c1056-72c0-4777-b70b-2114eb9e6eaf
```py
from typing import TypeAlias

OptInt: TypeAlias = "int | None"
```

The import was also added to the "Use instead" section.

## Test Plan

<!-- How was it tested? -->

Added two test cases