### PR TITLE
[`flake8-type-checking`] Make example error out-of-the-box (`TC001`)

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
@@ -44,7 +44,7 @@ use crate::{Fix, FixAvailability, Violation};
 /// ```python
 /// from __future__ import annotations
 ///
-/// import local_module
+/// from . import local_module
 ///
 ///
 /// def func(sized: local_module.Container) -> int:
@@ -58,7 +58,7 @@ use crate::{Fix, FixAvailability, Violation};
 /// from typing import TYPE_CHECKING
 ///
 /// if TYPE_CHECKING:
-///     import local_module
+///     from . import local_module
 ///
 ///
 /// def func(sized: local_module.Container) -> int:


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Part of #18972

This PR makes [typing-only-first-party-import (TC001)](https://docs.astral.sh/ruff/rules/typing-only-first-party-import/#typing-only-first-party-import-tc001)'s example error out-of-the-box. The old example raised `TC002` instead of `TC001`, so this makes it a `from .` import to fix that.

[Old example](https://play.ruff.rs/1fdbb293-86fc-4ed2-b2ff-b4836cea0c59)
```py
from __future__ import annotations

import local_module


def func(sized: local_module.Container) -> int:
    return len(sized)
```

[New example](https://play.ruff.rs/b886535c-9203-48bb-812b-1aa306f2c287)
```py
from __future__ import annotations

from . import local_module


def func(sized: local_module.Container) -> int:
    return len(sized)
```

The "Use instead" section was also modified similarly.

## Test Plan

<!-- How was it tested? -->

N/A, no functionality/tests affected