### PR TITLE
[ty] Re-enable multithreaded pydantic benchmark

### DIFF
--- a/crates/ruff_benchmark/benches/ty_walltime.rs
+++ b/crates/ruff_benchmark/benches/ty_walltime.rs
@@ -242,20 +242,19 @@ fn large(bencher: Bencher, benchmark: &Benchmark) {
     run_single_threaded(bencher, benchmark);
 }
 
-// Currently disabled because the benchmark is too noisy (± 10%) to give useful feedback.
-// #[bench(args=[&*PYDANTIC], sample_size=3, sample_count=3)]
-// fn multithreaded(bencher: Bencher, benchmark: &Benchmark) {
-//     let thread_pool = ThreadPoolBuilder::new().build().unwrap();
+#[bench(args=[&*PYDANTIC], sample_size=3, sample_count=8)]
+fn multithreaded(bencher: Bencher, benchmark: &Benchmark) {
+    let thread_pool = ThreadPoolBuilder::new().build().unwrap();
 
-//     bencher
-//         .with_inputs(|| benchmark.setup_iteration())
-//         .bench_local_values(|db| {
-//             thread_pool.install(|| {
-//                 check_project(&db, benchmark.max_diagnostics);
-//                 db
-//             })
-//         });
-// }
+    bencher
+        .with_inputs(|| benchmark.setup_iteration())
+        .bench_local_values(|db| {
+            thread_pool.install(|| {
+                check_project(&db, benchmark.max_diagnostics);
+                db
+            })
+        });
+}
 
 fn main() {
     ThreadPoolBuilder::new()


### PR DESCRIPTION
## Summary

I played with those numbers a bit locally and `sample_size=3, sample_count=8` seemed like a rather stable setup. This means a single sample consistents of 3 iterations of checking pydantic multithreaded. And this is repeated 8 times for statistics. A single check took ~300 ms previously on the runners, so this should only take 7 s.