### PR TITLE
Rename to `SessionSnapshot`, move unwind assertion closer

### DIFF
--- a/crates/ty_server/src/server/api/diagnostics.rs
+++ b/crates/ty_server/src/server/api/diagnostics.rs
@@ -80,7 +80,7 @@ pub(super) fn publish_diagnostics(
     let path = key.path();
 
     let snapshot = session
-        .take_snapshot(url.clone())
+        .take_document_snapshot(url.clone())
         .ok_or_else(|| anyhow::anyhow!("Unable to take snapshot for document with URL {url}"))
         .with_failure_code(lsp_server::ErrorCode::InternalError)?;
 

--- a/crates/ty_server/src/server/api/requests/workspace_diagnostic.rs
+++ b/crates/ty_server/src/server/api/requests/workspace_diagnostic.rs
@@ -1,3 +1,5 @@
+use std::panic::AssertUnwindSafe;
+
 use lsp_types::request::WorkspaceDiagnosticRequest;
 use lsp_types::{
     FullDocumentDiagnosticReport, Url, WorkspaceDiagnosticParams, WorkspaceDiagnosticReport,
@@ -12,7 +14,7 @@ use crate::server::api::diagnostics::to_lsp_diagnostic;
 use crate::server::api::traits::{
     BackgroundRequestHandler, RequestHandler, RetriableRequestHandler,
 };
-use crate::session::WorkspaceSnapshot;
+use crate::session::SessionSnapshot;
 use crate::session::client::Client;
 use crate::system::file_to_url;
 
@@ -24,7 +26,7 @@ impl RequestHandler for WorkspaceDiagnosticRequestHandler {
 
 impl BackgroundRequestHandler for WorkspaceDiagnosticRequestHandler {
     fn run(
-        snapshot: WorkspaceSnapshot,
+        snapshot: AssertUnwindSafe<SessionSnapshot>,
         _client: &Client,
         _params: WorkspaceDiagnosticParams,
     ) -> Result<WorkspaceDiagnosticReportResult> {

--- a/crates/ty_server/src/server/api/traits.rs
+++ b/crates/ty_server/src/server/api/traits.rs
@@ -1,7 +1,9 @@
 //! A stateful LSP implementation that calls into the ty API.
 
+use std::panic::AssertUnwindSafe;
+
 use crate::session::client::Client;
-use crate::session::{DocumentSnapshot, Session, WorkspaceSnapshot};
+use crate::session::{DocumentSnapshot, Session, SessionSnapshot};
 
 use lsp_types::notification::Notification as LSPNotification;
 use lsp_types::request::Request;
@@ -58,7 +60,7 @@ pub(super) trait BackgroundDocumentRequestHandler: RetriableRequestHandler {
 /// A request handler that can be run on a background thread.
 pub(super) trait BackgroundRequestHandler: RetriableRequestHandler {
     fn run(
-        snapshot: WorkspaceSnapshot,
+        snapshot: AssertUnwindSafe<SessionSnapshot>,
         client: &Client,
         params: <<Self as RequestHandler>::RequestType as Request>::Params,
     ) -> super::Result<<<Self as RequestHandler>::RequestType as Request>::Result>;


### PR DESCRIPTION
This PR addresses the post-merge review comments from https://github.com/astral-sh/ruff/pull/19041, specifically it:
- Rename `WorkspaceSnapshot` to `SessionSnapshot`
- Rename `take_workspace_snapshot` to `take_session_snapshot`
- Rename `take_snapshot` to `take_document_snapshot`
- Move `AssertUnwindSafe` closer to the `catch_unwind` call which requires the assertion