### PR TITLE
[ty] Track open files in the server

### DIFF
--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -382,14 +382,14 @@ impl Project {
         // both have a durability of `LOW`.
         if path.is_vendored_path() {
             return false;
+        } else if path.is_system_virtual_path() {
+            return true;
         }
 
         if let Some(open_files) = self.open_files(db) {
             open_files.contains(&file)
-        } else if file.path(db).is_system_path() {
-            self.files(db).contains(&file)
         } else {
-            file.path(db).is_system_virtual_path()
+            self.files(db).contains(&file)
         }
     }
 

--- a/crates/ty_server/src/server/api/notifications/did_close.rs
+++ b/crates/ty_server/src/server/api/notifications/did_close.rs
@@ -8,6 +8,9 @@ use crate::system::AnySystemPath;
 use lsp_server::ErrorCode;
 use lsp_types::DidCloseTextDocumentParams;
 use lsp_types::notification::DidCloseTextDocument;
+use ruff_db::Db as _;
+use ruff_db::files::system_path_to_file;
+use ty_project::Db as _;
 use ty_project::watch::ChangeEvent;
 
 pub(crate) struct DidCloseTextDocumentHandler;
@@ -33,12 +36,33 @@ impl SyncNotificationHandler for DidCloseTextDocumentHandler {
             .close_document(&key)
             .with_failure_code(ErrorCode::InternalError)?;
 
-        if let AnySystemPath::SystemVirtual(virtual_path) = key.path() {
-            let db = session.default_project_db_mut();
-            db.apply_changes(
-                vec![ChangeEvent::DeletedVirtual(virtual_path.clone())],
-                None,
-            );
+        match key.path() {
+            AnySystemPath::System(system_path) => {
+                let db = match session.project_db_for_path_mut(system_path) {
+                    Some(db) => db,
+                    None => session.default_project_db_mut(),
+                };
+                let Ok(file) = system_path_to_file(db, system_path) else {
+                    // This can only fail when the path is a directory or it doesn't exists but the
+                    // file should exists for this handler in this branch.
+                    tracing::warn!("Failed to create a salsa file for {}", system_path);
+                    return Ok(());
+                };
+                db.project().close_file(db, file);
+            }
+            AnySystemPath::SystemVirtual(virtual_path) => {
+                let db = session.default_project_db_mut();
+                // TODO: This seems redundant now that we also try to close the file in the
+                // project in that we can directly do `virtual_path.close(db)` in the following
+                // branch instead which is what this event does as well.
+                db.apply_changes(
+                    vec![ChangeEvent::DeletedVirtual(virtual_path.clone())],
+                    None,
+                );
+                if let Some(virtual_file) = db.files().try_virtual_file(virtual_path) {
+                    db.project().close_file(db, virtual_file.file());
+                }
+            }
         }
 
         if !session.global_settings().diagnostic_mode().is_workspace() {

--- a/crates/ty_server/src/server/api/requests/workspace_diagnostic.rs
+++ b/crates/ty_server/src/server/api/requests/workspace_diagnostic.rs
@@ -33,7 +33,9 @@ impl BackgroundRequestHandler for WorkspaceDiagnosticRequestHandler {
         let index = snapshot.index();
 
         if !index.global_settings().diagnostic_mode().is_workspace() {
-            tracing::debug!("Workspace diagnostics is disabled; returning empty report");
+            // VS Code sends us the workspace diagnostic request every 2 seconds, so these logs can
+            // be quite verbose.
+            tracing::trace!("Workspace diagnostics is disabled; returning empty report");
             return Ok(WorkspaceDiagnosticReportResult::Report(
                 WorkspaceDiagnosticReport { items: vec![] },
             ));


### PR DESCRIPTION
## Summary

Closes: astral-sh/ty#619

This PR changes the way files are being tracked in the ty server. Specifically, it makes the following changes for the respective notification handler:

- `didOpen`: Add the `File` corresponding to the document that was opened in the open file set. This requires interning the `File` eagerly because previously it was interned only when it was required and not on open notification
- `didClose`: Remove the `File` corresponding to the document was is closed from the open file set

Note: This PR on it's own breaks workspace diagnostics because the diagnostic builder is only created if the file (that the diagnostic is being reported for) is open. This will be fixed in a follow-up PR (#19182).

## Test Plan

Confirmed that workspace diagnostics break as expected (refer to the above note) and confirmed that it's fixed by #19182).