### PR TITLE
[ty] Pre-warm thread-pool for multithreaded benchmark

### DIFF
--- a/crates/ruff_benchmark/benches/ty_walltime.rs
+++ b/crates/ruff_benchmark/benches/ty_walltime.rs
@@ -246,6 +246,12 @@ fn large(bencher: Bencher, benchmark: &Benchmark) {
 fn multithreaded(bencher: Bencher, benchmark: &Benchmark) {
     let thread_pool = ThreadPoolBuilder::new().build().unwrap();
 
+    thread_pool.install(|| {
+        let db = benchmark.setup_iteration();
+        check_project(&db, benchmark.max_diagnostics);
+        db
+    });
+
     bencher
         .with_inputs(|| benchmark.setup_iteration())
         .bench_local_values(|db| {


### PR DESCRIPTION
## Summary

I don't know if this helps with the flakes but seems worth trying. 

Otherwise I suggest disabling the tests with `, ignore=cfg!(codspeed)` 

## Test Plan

CI
