### PR TITLE
[ty] Add a new property test: all types assignable to `Iterable[object]` should be considered iterable

### DIFF
--- a/crates/ty_python_semantic/src/types/property_tests.rs
+++ b/crates/ty_python_semantic/src/types/property_tests.rs
@@ -218,6 +218,7 @@ mod flaky {
     use itertools::Itertools;
 
     use super::{intersection, union};
+    use crate::types::{KnownClass, Type};
 
     // Negating `T` twice is equivalent to `T`.
     type_property_test!(
@@ -310,5 +311,15 @@ mod flaky {
     type_property_test!(
         bottom_materialization_of_type_is_assigneble_to_type, db,
         forall types t. t.bottom_materialization(db).is_assignable_to(db, t)
+    );
+
+    // Any type assignable to `Iterable[object]` should be considered iterable.
+    //
+    // Note that the inverse is not true, due to the fact that we recognize the old-style
+    // iteration protocol as well as the new-style iteration protocol: not all objects that
+    // we consider iterable are assignable to `Iterable[object]`.
+    type_property_test!(
+        all_type_assignable_to_iterable_are_iterable, db,
+        forall types t. t.is_assignable_to(db, KnownClass::Iterable.to_specialized_instance(db, [Type::object(db)])) => t.try_iterate(db).is_ok()
     );
 }


### PR DESCRIPTION
## Summary

Any type assignable to `Iterable[object]` should also be considered iterable by ty. Currently we consider far too many types to be assignable to `Iterable[object]`; this is one of the causes of the crash in https://github.com/astral-sh/ty/issues/764. As such, the property test added here is added as a flaky property test for now; the tests find many types for which this invariant currently does not hold true.

Note that there are many objects which are not assignable to `Iterable[object]`, but which we nonetheless consider iterable. This is a deliberate feature: as well as understanding the new-style iteration protocol (represented by `Iterable`), we also understand the old-style iteration protocol that works via the `__getitem__` dunder.

## Test Plan

`cargo test --release -p ty_python_semantic -- --ignored types::property_tests::flaky`
