### PR TITLE
[`pycodestyle`] Make example error out-of-the-box (`E114`)

### DIFF
--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/indentation.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/indentation.rs
@@ -65,7 +65,6 @@ impl Violation for IndentationWithInvalidMultiple {
 ///
 /// Use instead:
 /// ```python
-/// ```python
 /// if True:
 ///     # a = 1
 ///     ...

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/indentation.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/indentation.rs
@@ -58,14 +58,17 @@ impl Violation for IndentationWithInvalidMultiple {
 ///
 /// ## Example
 /// ```python
-/// # Comment 1
-///  # Comment 2
+/// if True:
+///    # a = 1
+///     ...
 /// ```
 ///
 /// Use instead:
 /// ```python
-/// # Comment 1
-/// # Comment 2
+/// ```python
+/// if True:
+///     # a = 1
+///     ...
 /// ```
 ///
 /// ## Formatter compatibility

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/indentation.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/indentation.rs
@@ -58,14 +58,14 @@ impl Violation for IndentationWithInvalidMultiple {
 ///
 /// ## Example
 /// ```python
-/// if True:
-///    # a = 1
+/// # Comment 1
+///  # Comment 2
 /// ```
 ///
 /// Use instead:
 /// ```python
-/// if True:
-///     # a = 1
+/// # Comment 1
+/// # Comment 2
 /// ```
 ///
 /// ## Formatter compatibility


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Part of #18972

This PR makes [indentation-with-invalid-multiple-comment (E114)](https://docs.astral.sh/ruff/rules/indentation-with-invalid-multiple-comment/#indentation-with-invalid-multiple-comment-e114)'s example not raise a syntax error by adding a 4 space indented `...`. The example still gave `E114` without this, but adding the `...` both makes the change in indentation of the comment clearer, and makes it not give a `SyntaxError`.

## Test Plan

<!-- How was it tested? -->

N/A, no functionality/tests affected