### PR TITLE
[ty] Fix `ClassLiteral.into_callable` for dataclasses

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
@@ -1774,6 +1774,25 @@ static_assert(is_subtype_of(type[B], Callable[[str], B]))
 static_assert(not is_subtype_of(type[B], Callable[[int], B]))
 ```
 
+### Dataclasses
+
+Dataclasses synthesize a `__init__` method.
+
+```py
+from typing import Callable
+from ty_extensions import TypeOf, static_assert, is_subtype_of
+from dataclasses import dataclass
+
+@dataclass
+class A:
+    x: "A" | None
+
+static_assert(is_subtype_of(type[A], Callable[[A], A]))
+static_assert(is_subtype_of(type[A], Callable[[None], A]))
+static_assert(is_subtype_of(type[A], Callable[[A | None], A]))
+static_assert(not is_subtype_of(type[A], Callable[[int], A]))
+```
+
 ### Bound methods
 
 ```py

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -671,17 +671,13 @@ impl<'db> ClassType<'db> {
                 };
 
                 if let Some(signature) = signature {
-                    let synthesized_signature = |signature: Signature<'db>| {
+                    let synthesized_signature = |signature: &Signature<'db>| {
                         Signature::new(signature.parameters().clone(), Some(correct_return_type))
                             .bind_self()
                     };
 
                     let synthesized_dunder_init_signature = CallableSignature::from_overloads(
-                        signature
-                            .overloads
-                            .iter()
-                            .cloned()
-                            .map(synthesized_signature),
+                        signature.overloads.iter().map(synthesized_signature),
                     );
 
                     Some(Type::Callable(CallableType::new(


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

Slightly refactor ClassLiteral.into_callable to also look for `__init__` functions of type Type::Callable to fix the issue with dataclasses, as the synthensized __init__ created by dataclass isn't covered as it isn't FunctionLiteral

Fixes https://github.com/astral-sh/ty/issues/760

## Test Plan

Add subtype test from the issue
