### PR TITLE
[ty] Use diagnostic rendering for semantic token tests

### DIFF
--- a/crates/ty_ide/src/lib.rs
+++ b/crates/ty_ide/src/lib.rs
@@ -246,16 +246,29 @@ mod tests {
             I: IntoIterator<Item = D>,
             D: IntoDiagnostic,
         {
+            let config = DisplayDiagnosticConfig::default()
+                .color(false)
+                .format(DiagnosticFormat::Full);
+
+            self.render_diagnostics_with_config(diagnostics, &config)
+        }
+
+        pub(super) fn render_diagnostics_with_config<I, D>(
+            &self,
+            diagnostics: I,
+            config: &DisplayDiagnosticConfig,
+        ) -> String
+        where
+            I: IntoIterator<Item = D>,
+            D: IntoDiagnostic,
+        {
             use std::fmt::Write;
 
             let mut buf = String::new();
 
-            let config = DisplayDiagnosticConfig::default()
-                .color(false)
-                .format(DiagnosticFormat::Full);
             for diagnostic in diagnostics {
                 let diag = diagnostic.into_diagnostic();
-                write!(buf, "{}", diag.display(&self.db, &config)).unwrap();
+                write!(buf, "{}", diag.display(&self.db, config)).unwrap();
             }
 
             buf


### PR DESCRIPTION
## Summary

This PR changes the test infrastructure for semantic tokens to use the diagnostic rendering over printing the tokens with their text range.

The advantage of this approach is that I don't need a hex viewer to verify that the byte offsets are correct. 

However, it does come at the cost of much larger snapshots. I still think it's worth it considering that it improves readability of tests but it's certainly a trade off.

## Test Plan

Updated tests
