### PR TITLE
[ty] Clarify diagnostic message

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -1787,7 +1787,7 @@ date.day = 8
 date.month = 4
 date.year = 2025
 
-# error: [unresolved-attribute] "Can not assign object of `Literal["UTC"]` to attribute `tz` on type `Date` with custom `__setattr__` method."
+# error: [unresolved-attribute] "Can not assign object of type `Literal["UTC"]` to attribute `tz` on type `Date` with custom `__setattr__` method."
 date.tz = "UTC"
 ```
 

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -3495,7 +3495,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                             self.context.report_lint(&UNRESOLVED_ATTRIBUTE, target)
                                         {
                                             builder.into_diagnostic(format_args!(
-                                                "Can not assign object of `{}` to attribute \
+                                                "Can not assign object of type `{}` to attribute \
                                                  `{attribute}` on type `{}` with \
                                                  custom `__setattr__` method.",
                                                 value_ty.display(db),


### PR DESCRIPTION
This diagnostic message was missing the word "type"