### PR TITLE
[ty] Do not report settings diagnostics in `check_file`

### DIFF
--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -285,16 +285,7 @@ impl Project {
             return Vec::new();
         }
 
-        let mut file_diagnostics: Vec<_> = self
-            .settings_diagnostics(db)
-            .iter()
-            .map(OptionDiagnostic::to_diagnostic)
-            .collect();
-
-        let check_diagnostics = self.check_file_impl(db, file);
-        file_diagnostics.extend(check_diagnostics);
-
-        file_diagnostics
+        self.check_file_impl(db, file)
     }
 
     /// Opens a file in the project.


### PR DESCRIPTION
This is the trivial first part of https://github.com/astral-sh/ty/issues/613

Ideally we should surface these elsewhere, but this is definitely Not the place to surface them.