### PR TITLE
Remove deprecated macOS config file discovery

### DIFF
--- a/crates/ruff_workspace/src/pyproject.rs
+++ b/crates/ruff_workspace/src/pyproject.rs
@@ -114,7 +114,6 @@ pub fn find_fallback_target_version<P: AsRef<Path>>(path: P) -> Option<PythonVer
 #[cfg(not(target_arch = "wasm32"))]
 pub fn find_user_settings_toml() -> Option<PathBuf> {
     use etcetera::BaseStrategy;
-    use ruff_linter::warn_user_once;
 
     let strategy = etcetera::base_strategy::choose_base_strategy().ok()?;
     let config_dir = strategy.config_dir().join("ruff");
@@ -124,23 +123,6 @@ pub fn find_user_settings_toml() -> Option<PathBuf> {
         let path = config_dir.join(filename);
         if path.is_file() {
             return Some(path);
-        }
-    }
-
-    // On macOS, we used to support reading from `/Users/Alice/Library/Application Support`.
-    if cfg!(target_os = "macos") {
-        let strategy = etcetera::base_strategy::Apple::new().ok()?;
-        let deprecated_config_dir = strategy.data_dir().join("ruff");
-
-        for file in [".ruff.toml", "ruff.toml", "pyproject.toml"] {
-            let path = deprecated_config_dir.join(file);
-            if path.is_file() {
-                warn_user_once!(
-                    "Reading configuration from `~/Library/Application Support` is deprecated. Please move your configuration to `{}/{file}`.",
-                    config_dir.display(),
-                );
-                return Some(path);
-            }
         }
     }
 


### PR DESCRIPTION
## Summary
In #11115 we moved from defaulting to $HOME/Library/Application Support to $XDG_HOME on macOS and added a deprecation warning if we find files in the old location. So this PR removes the warning
closes #19145 

## Test Plan
Ran `cargo test`
