### PR TITLE
[ty] Use full range for assignment definitions

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_`typing.Final`_-_Full_diagnostics_(174fdd8134fb325b).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_`typing.Final`_-_Full_diagnostics_(174fdd8134fb325b).snap
@@ -30,7 +30,7 @@ error[invalid-assignment]: Reassignment of `Final` symbol `MY_CONSTANT` is not a
 1 | from typing import Final
 2 |
 3 | MY_CONSTANT: Final[int] = 1
-  | ----------- Original definition
+  | --------------------------- Original definition
 4 |
 5 | # more code
 6 |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___L…_-_Inferring_a_bound_ty…_(d50204b9d91b7bd1).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___L…_-_Inferring_a_bound_ty…_(d50204b9d91b7bd1).snap
@@ -82,7 +82,7 @@ info: Type variable defined here
 2 | from typing_extensions import reveal_type
 3 |
 4 | T = TypeVar("T", bound=int)
-  | ^
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 5 |
 6 | def f(x: T) -> T:
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___L…_-_Inferring_a_constrai…_(48ab83f977c109b4).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___L…_-_Inferring_a_constrai…_(48ab83f977c109b4).snap
@@ -97,7 +97,7 @@ info: Type variable defined here
 2 | from typing_extensions import reveal_type
 3 |
 4 | T = TypeVar("T", int, None)
-  | ^
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 5 |
 6 | def f(x: T) -> T:
   |


### PR DESCRIPTION
## Summary

Fix the `full_range` function for (annotated) assignment definition kinds.

## Test Plan

Update snapshot tests
