### PR TITLE
[ty] Move `CheckMode` on `Project`

### DIFF
--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -111,6 +111,10 @@ pub struct Project {
     #[returns(deref)]
     settings_diagnostics: Vec<OptionDiagnostic>,
 
+    /// The mode in which the project should be checked.
+    ///
+    /// This changes the behavior of `check` to either check only the open files or all files in
+    /// the project including the virtual files that might exists in the editor.
     check_mode: CheckMode,
 }
 

--- a/crates/ty_project/src/metadata.rs
+++ b/crates/ty_project/src/metadata.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use thiserror::Error;
 use ty_python_semantic::ProgramSettings;
 
+use crate::CheckMode;
 use crate::combine::Combine;
 use crate::metadata::pyproject::{Project, PyProject, PyProjectError, ResolveRequiresPythonError};
 use crate::metadata::value::ValueSource;
@@ -28,6 +29,9 @@ pub struct ProjectMetadata {
     /// The raw options
     pub(super) options: Options,
 
+    /// The check mode for this project.
+    check_mode: CheckMode,
+
     /// Paths of configurations other than the project's configuration that were combined into [`Self::options`].
     ///
     /// This field stores the paths of the configuration files, mainly for
@@ -46,6 +50,7 @@ impl ProjectMetadata {
             root,
             extra_configuration_paths: Vec::default(),
             options: Options::default(),
+            check_mode: CheckMode::default(),
         }
     }
 
@@ -69,6 +74,7 @@ impl ProjectMetadata {
             root: system.current_directory().to_path_buf(),
             options,
             extra_configuration_paths: vec![path],
+            check_mode: CheckMode::default(),
         })
     }
 
@@ -116,7 +122,14 @@ impl ProjectMetadata {
             root,
             options,
             extra_configuration_paths: Vec::new(),
+            check_mode: CheckMode::default(),
         })
+    }
+
+    #[must_use]
+    pub fn with_check_mode(mut self, check_mode: CheckMode) -> Self {
+        self.check_mode = check_mode;
+        self
     }
 
     /// Discovers the closest project at `path` and returns its metadata.
@@ -265,6 +278,10 @@ impl ProjectMetadata {
 
     pub fn extra_configuration_paths(&self) -> &[SystemPathBuf] {
         &self.extra_configuration_paths
+    }
+
+    pub fn check_mode(&self) -> CheckMode {
+        self.check_mode
     }
 
     pub fn to_program_settings(

--- a/crates/ty_project/src/metadata.rs
+++ b/crates/ty_project/src/metadata.rs
@@ -384,11 +384,12 @@ mod tests {
 
         with_escaped_paths(|| {
             assert_ron_snapshot!(&project, @r#"
-                ProjectMetadata(
-                  name: Name("app"),
-                  root: "/app",
-                  options: Options(),
-                )
+            ProjectMetadata(
+              name: Name("app"),
+              root: "/app",
+              options: Options(),
+              check_mode: OpenFiles,
+            )
             "#);
         });
 
@@ -422,11 +423,12 @@ mod tests {
 
         with_escaped_paths(|| {
             assert_ron_snapshot!(&project, @r#"
-                ProjectMetadata(
-                  name: Name("backend"),
-                  root: "/app",
-                  options: Options(),
-                )
+            ProjectMetadata(
+              name: Name("backend"),
+              root: "/app",
+              options: Options(),
+              check_mode: OpenFiles,
+            )
             "#);
         });
 
@@ -523,6 +525,7 @@ expected `.`, `]`
                   root: Some("src"),
                 )),
               ),
+              check_mode: OpenFiles,
             )
             "#);
         });
@@ -565,16 +568,17 @@ expected `.`, `]`
 
         with_escaped_paths(|| {
             assert_ron_snapshot!(root, @r#"
-                              ProjectMetadata(
-                                name: Name("project-root"),
-                                root: "/app",
-                                options: Options(
-                                  src: Some(SrcOptions(
-                                    root: Some("src"),
-                                  )),
-                                ),
-                              )
-                              "#);
+            ProjectMetadata(
+              name: Name("project-root"),
+              root: "/app",
+              options: Options(
+                src: Some(SrcOptions(
+                  root: Some("src"),
+                )),
+              ),
+              check_mode: OpenFiles,
+            )
+            "#);
         });
 
         Ok(())
@@ -613,6 +617,7 @@ expected `.`, `]`
               name: Name("nested-project"),
               root: "/app/packages/a",
               options: Options(),
+              check_mode: OpenFiles,
             )
             "#);
         });
@@ -660,6 +665,7 @@ expected `.`, `]`
                   r#python-version: Some("3.10"),
                 )),
               ),
+              check_mode: OpenFiles,
             )
             "#);
         });
@@ -715,6 +721,7 @@ expected `.`, `]`
                   root: Some("src"),
                 )),
               ),
+              check_mode: OpenFiles,
             )
             "#);
         });

--- a/crates/ty_server/src/server/api/requests/workspace_diagnostic.rs
+++ b/crates/ty_server/src/server/api/requests/workspace_diagnostic.rs
@@ -7,7 +7,6 @@ use lsp_types::{
     WorkspaceFullDocumentDiagnosticReport,
 };
 use rustc_hash::FxHashMap;
-use ty_project::CheckMode;
 
 use crate::server::Result;
 use crate::server::api::diagnostics::to_lsp_diagnostic;
@@ -44,7 +43,7 @@ impl BackgroundRequestHandler for WorkspaceDiagnosticRequestHandler {
         let mut items = Vec::new();
 
         for db in snapshot.projects() {
-            let diagnostics = db.check_with_mode(CheckMode::AllFiles);
+            let diagnostics = db.check();
 
             // Group diagnostics by URL
             let mut diagnostics_by_url: FxHashMap<Url, Vec<_>> = FxHashMap::default();

--- a/crates/ty_server/src/session/options.rs
+++ b/crates/ty_server/src/session/options.rs
@@ -2,6 +2,7 @@ use lsp_types::Url;
 use ruff_db::system::SystemPathBuf;
 use rustc_hash::FxHashMap;
 use serde::Deserialize;
+use ty_project::CheckMode;
 
 use crate::logging::LogLevel;
 use crate::session::settings::ClientSettings;
@@ -65,6 +66,13 @@ pub(crate) enum DiagnosticMode {
 impl DiagnosticMode {
     pub(crate) fn is_workspace(self) -> bool {
         matches!(self, DiagnosticMode::Workspace)
+    }
+
+    pub(crate) fn into_check_mode(self) -> CheckMode {
+        match self {
+            DiagnosticMode::OpenFilesOnly => CheckMode::OpenFiles,
+            DiagnosticMode::Workspace => CheckMode::AllFiles,
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Follow-up from #19181 and as discussed in that PR, this PR moves the `CheckMode` to be part of the `Project` instead of a parameter.

This is used in the follow-up PR (#19182) that makes sure that checking a file / project and constructing the diagnostic builder considers the check mode instead of just checking whether the file is open or not.

## Test Plan

Refer #19182 