### PR TITLE
[ty] Optimize protocol subtyping by removing expensive and unnecessary equivalence check from the top of `Type::has_relation_to()`

### DIFF
--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1259,6 +1259,9 @@ impl<'db> Type<'db> {
 
             // Two identical typevars must always solve to the same type, so they are always
             // subtypes of each other and assignable to each other.
+            //
+            // Note that this is not handled by the early return at the beginning of this method,
+            // since subtyping between a TypeVar and an arbitrary other type cannot be guaranteed to be reflexive.
             (Type::TypeVar(lhs_typevar), Type::TypeVar(rhs_typevar))
                 if lhs_typevar == rhs_typevar =>
             {

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -7909,15 +7909,15 @@ impl<'db> UnionType<'db> {
 
     /// Return `true` if `self` represents the exact same sets of possible runtime objects as `other`
     pub(crate) fn is_equivalent_to(self, db: &'db dyn Db, other: Self) -> bool {
+        if self == other {
+            return true;
+        }
+
         let self_elements = self.elements(db);
         let other_elements = other.elements(db);
 
         if self_elements.len() != other_elements.len() {
             return false;
-        }
-
-        if self == other {
-            return true;
         }
 
         let sorted_self = self.normalized(db);
@@ -8000,8 +8000,11 @@ impl<'db> IntersectionType<'db> {
 
     /// Return `true` if `self` represents exactly the same set of possible runtime objects as `other`
     pub(crate) fn is_equivalent_to(self, db: &'db dyn Db, other: Self) -> bool {
-        let self_positive = self.positive(db);
+        if self == other {
+            return true;
+        }
 
+        let self_positive = self.positive(db);
         let other_positive = other.positive(db);
 
         if self_positive.len() != other_positive.len() {
@@ -8009,15 +8012,10 @@ impl<'db> IntersectionType<'db> {
         }
 
         let self_negative = self.negative(db);
-
         let other_negative = other.negative(db);
 
         if self_negative.len() != other_negative.len() {
             return false;
-        }
-
-        if self == other {
-            return true;
         }
 
         let sorted_self = self.normalized(db);

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1219,9 +1219,7 @@ impl<'db> Type<'db> {
         //
         // Note that we could do a full equivalence check here, but that would be both expensive
         // and unnecessary. This early return is only an optimisation.
-        if (relation.is_assignability() || self.subtyping_is_always_reflexive())
-            && self == target
-        {
+        if (relation.is_assignability() || self.subtyping_is_always_reflexive()) && self == target {
             return true;
         }
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1215,9 +1215,12 @@ impl<'db> Type<'db> {
 
     fn has_relation_to(self, db: &'db dyn Db, target: Type<'db>, relation: TypeRelation) -> bool {
         // Subtyping implies assignability, so if subtyping is reflexive and the two types are
-        // equivalent, it is both a subtype and assignable. Assignability is always reflexive.
+        // equal, it is both a subtype and assignable. Assignability is always reflexive.
+        //
+        // Note that we could do a full equivalence check here, but that would be both expensive
+        // and unnecessary. This early return is only an optimisation.
         if (relation.is_assignability() || self.subtyping_is_always_reflexive())
-            && self.is_equivalent_to(db, target)
+            && self == target
         {
             return true;
         }

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -443,8 +443,13 @@ impl<'db> ClassType<'db> {
     }
 
     pub(super) fn is_equivalent_to(self, db: &'db dyn Db, other: ClassType<'db>) -> bool {
+        if self == other {
+            return true;
+        }
+
         match (self, other) {
-            (ClassType::NonGeneric(this), ClassType::NonGeneric(other)) => this == other,
+            // A non-generic class is never equivalent to a generic class.
+            // Two non-generic classes are only equivalent if they are equal (handled above).
             (ClassType::NonGeneric(_), _) | (_, ClassType::NonGeneric(_)) => false,
 
             (ClassType::Generic(this), ClassType::Generic(other)) => {


### PR DESCRIPTION
# Summary

A full equivalence check at the top of `Type::has_relation_to()` is unnecessary. All our mdtests, and all our property tests, pass if it is replaced with a much cheaper naive equality check. The reason for this is that equivalence is generally the same as equality for atomic types (types that cannot contain other types); and "non-atomic" types (types that can contain other types within them) all have comprehensive subtyping logic lower down in the `Type::has_relation_to()` method. For every non-atomic type in our model currently, our subtyping logic is sufficiently generalized to also cover equivalent types; there's no need to check for equivalence separately.

Up till now, the inefficiency here hasn't mattered that much, because comparing two nominal types for equivalence is generally pretty cheap. (It is _not_ cheap for large unions, large intersections or large tuples (or combinations of the three), but these are all somewhat rare.) Unfortunately, however, comparing two _structural_ types for equivalence can be extremely expensive: determining whether two protocols are equivalent can necessitate a full structural check between the two underlying interfaces. That means that this PR yields a 7% speedup when checking `DateType`, which has some large protocols in it. We also see 1% speedups on a lot of other micro- and macro-benchmarks for ty, and no slowdowns: https://codspeed.io/astral-sh/ruff/branches/alex%2Fremove-equivalent-check?runnerMode=Instrumentation.

# Test plan
- Existing tests all pass
- `QUICKCHECK_TESTS=100000 cargo test --release -p ty_python_semantic -- --ignored types::property_tests::stable` passes
- Clean mypy_primer report