### PR TITLE
[`flake8-bandit`] Make example error out-of-the-box (`S412`)

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/suspicious_imports.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/suspicious_imports.rs
@@ -283,7 +283,7 @@ impl Violation for SuspiciousXmlrpcImport {
 ///
 /// ## Example
 /// ```python
-/// import wsgiref.handlers.CGIHandler
+/// from wsgiref.handlers import CGIHandler
 /// ```
 ///
 /// ## References


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Part of #18972

This PR makes [suspicious-httpoxy-import (S412)](https://docs.astral.sh/ruff/rules/suspicious-httpoxy-import/#suspicious-httpoxy-import-s412)'s example error out-of-the-box. Since the checked imports are classes instead of modules, the example isn't valid. See #19009 for more details
```
PS ~>py -c "import wsgiref.handlers.CGIHandler"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
    import wsgiref.handlers.CGIHandler
ModuleNotFoundError: No module named 'wsgiref.handlers.CGIHandler'; 'wsgiref.handlers' is not a package
PS ~>py -c "from wsgiref.handlers import CGIHandler"
PS ~>
```

[Old example](https://play.ruff.rs/bf48c901-6a46-4795-ba1d-c6af79d5c96e)
```py
import wsgiref.handlers.CGIHandler
```

[New example](https://play.ruff.rs/1f0e1e60-1f0f-484a-9a17-2d0290a68f2a)
```py
from wsgiref.handlers import CGIHandler
```

## Test Plan

<!-- How was it tested? -->

N/A, no functionality/tests affected