### PR TITLE
[ty] Do not run `mypy_primer.yaml` when all changed files are Markdown files

### DIFF
--- a/.github/workflows/mypy_primer.yaml
+++ b/.github/workflows/mypy_primer.yaml
@@ -12,6 +12,7 @@ on:
       - ".github/workflows/mypy_primer.yaml"
       - ".github/workflows/mypy_primer_comment.yaml"
       - "Cargo.lock"
+      - "!**.md"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}


### PR DESCRIPTION
## Summary

Resolves [#781](https://github.com/astral-sh/ty/issues/781).

After this change, a PR that changes only `.md` files anywhere in the codebase will not cause the `mypy_primer.yaml` workflow to be run.

## Test Plan

None.
