### PR TITLE
[`pydoclint`] Fix `SyntaxError` from fixes with line continuations (`D201`, `D202`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pydocstyle/D.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydocstyle/D.py
@@ -722,3 +722,10 @@ def inconsistent_indent_byte_size():
 
        Returns:
     """
+
+
+def line_continuation_chars():\
+
+    """No fix should be offered for D201/D202 because of the line continuation chars."""\
+
+    ...

--- a/crates/ruff_linter/src/rules/pydocstyle/snapshots/ruff_linter__rules__pydocstyle__tests__D201_D.py.snap
+++ b/crates/ruff_linter/src/rules/pydocstyle/snapshots/ruff_linter__rules__pydocstyle__tests__D201_D.py.snap
@@ -82,3 +82,14 @@ D.py:568:5: D201 [*] No blank lines allowed before function docstring (found 1)
 568 567 |     """Trailing and leading space.
 569 568 | 
 570 569 |     More content.
+
+D.py:729:5: D201 No blank lines allowed before function docstring (found 1)
+    |
+727 | def line_continuation_chars():\
+728 |
+729 |     """No fix should be offered for D201/D202 because of the line continuation chars."""\
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ D201
+730 |
+731 |     ...
+    |
+    = help: Remove blank line(s) before function docstring

--- a/crates/ruff_linter/src/rules/pydocstyle/snapshots/ruff_linter__rules__pydocstyle__tests__D202_D.py.snap
+++ b/crates/ruff_linter/src/rules/pydocstyle/snapshots/ruff_linter__rules__pydocstyle__tests__D202_D.py.snap
@@ -85,4 +85,15 @@ D.py:568:5: D202 [*] No blank lines allowed after function docstring (found 1)
 572     |-
 573 572 |     pass
 574 573 | 
-575 574 |
+575 574 | 
+
+D.py:729:5: D202 No blank lines allowed after function docstring (found 1)
+    |
+727 | def line_continuation_chars():\
+728 |
+729 |     """No fix should be offered for D201/D202 because of the line continuation chars."""\
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ D202
+730 |
+731 |     ...
+    |
+    = help: Remove blank line(s) after function docstring

--- a/crates/ruff_linter/src/rules/pydocstyle/snapshots/ruff_linter__rules__pydocstyle__tests__D208_D.py.snap
+++ b/crates/ruff_linter/src/rules/pydocstyle/snapshots/ruff_linter__rules__pydocstyle__tests__D208_D.py.snap
@@ -428,3 +428,5 @@ D.py:723:1: D208 [*] Docstring is over-indented
 723     |-       Returns:
     723 |+    Returns:
 724 724 |     """
+725 725 | 
+726 726 |


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

This PR fixes #7172 by suppressing the fixes for [docstring-missing-returns (DOC201)](https://docs.astral.sh/ruff/rules/docstring-missing-returns/#docstring-missing-returns-doc201) / [docstring-extraneous-returns (DOC202)](https://docs.astral.sh/ruff/rules/docstring-extraneous-returns/#docstring-extraneous-returns-doc202) if there is a surrounding line continuation character `\` that would make the fix cause a syntax error.

To do this, the lints are changed from `AlwaysFixableViolation` to `Violation` with `FixAvailability::Sometimes`.

In the case of `DOC201`, the fix is not given if the non-break line ends in a line continuation character `\`. Note that lines are iterated in reverse from the docstring to the function definition.

In the case of `DOC202`, the fix is not given if the docstring ends with a line continuation character `\`.

## Test Plan

<!-- How was it tested? -->

Added a test case.