### PR TITLE
Deprecate lint rules that correspond to syntax errors 

### DIFF
--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -170,7 +170,7 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         (Pyflakes, "401") => (RuleGroup::Stable, rules::pyflakes::rules::UnusedImport),
         (Pyflakes, "402") => (RuleGroup::Stable, rules::pyflakes::rules::ImportShadowedByLoopVar),
         (Pyflakes, "403") => (RuleGroup::Stable, rules::pyflakes::rules::UndefinedLocalWithImportStar),
-        (Pyflakes, "404") => (RuleGroup::Stable, rules::pyflakes::rules::LateFutureImport),
+        (Pyflakes, "404") => (RuleGroup::Deprecated, rules::pyflakes::rules::LateFutureImport),
         (Pyflakes, "405") => (RuleGroup::Stable, rules::pyflakes::rules::UndefinedLocalWithImportStarUsage),
         (Pyflakes, "406") => (RuleGroup::Stable, rules::pyflakes::rules::UndefinedLocalWithNestedImportStarUsage),
         (Pyflakes, "407") => (RuleGroup::Stable, rules::pyflakes::rules::FutureFeatureNotDefined),

--- a/crates/ruff_python_parser/src/semantic_errors.rs
+++ b/crates/ruff_python_parser/src/semantic_errors.rs
@@ -990,6 +990,8 @@ impl Ranged for SemanticSyntaxError {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, get_size2::GetSize)]
 pub enum SemanticSyntaxErrorKind {
     /// Represents the use of a `__future__` import after the beginning of a file.
+    /// ## Deprecation
+    /// This rule is deprecated.
     ///
     /// ## Examples
     ///


### PR DESCRIPTION
## Summary
partially closes #19122 

## Test Plan
followed the contributing.md

Question:- in this issues we have something around 7-8 rules we have to deprecate so should we add them in this PR or different different PR's ?? 
