### PR TITLE
[ty] Remove countme from salsa-structs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,11 +680,6 @@ name = "countme"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
-dependencies = [
- "dashmap 5.5.3",
- "once_cell",
- "rustc-hash 1.1.0",
-]
 
 [[package]]
 name = "cpufeatures"
@@ -850,19 +845,6 @@ dependencies = [
  "darling_core",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "dashmap"
-version = "5.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
-dependencies = [
- "cfg-if",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
 ]
 
 [[package]]
@@ -2262,7 +2244,7 @@ dependencies = [
  "once_cell",
  "pep440_rs",
  "regex",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "serde",
  "smallvec",
  "thiserror 1.0.69",
@@ -2772,7 +2754,7 @@ dependencies = [
  "ruff_source_file",
  "ruff_text_size",
  "ruff_workspace",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "serde",
  "serde_json",
  "shellexpand",
@@ -2818,7 +2800,7 @@ dependencies = [
  "ruff_python_formatter",
  "ruff_python_parser",
  "ruff_python_trivia",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "serde",
  "serde_json",
  "tikv-jemallocator",
@@ -2847,7 +2829,7 @@ dependencies = [
  "arc-swap",
  "camino",
  "countme",
- "dashmap 6.1.0",
+ "dashmap",
  "dunce",
  "etcetera",
  "filetime",
@@ -2866,7 +2848,7 @@ dependencies = [
  "ruff_python_trivia",
  "ruff_source_file",
  "ruff_text_size",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "salsa",
  "schemars",
  "serde",
@@ -2940,7 +2922,7 @@ dependencies = [
  "ruff_cache",
  "ruff_macros",
  "ruff_text_size",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "schemars",
  "serde",
  "static_assertions",
@@ -3022,7 +3004,7 @@ dependencies = [
  "ruff_python_trivia",
  "ruff_source_file",
  "ruff_text_size",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "schemars",
  "serde",
  "serde_json",
@@ -3094,7 +3076,7 @@ dependencies = [
  "ruff_python_trivia",
  "ruff_source_file",
  "ruff_text_size",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "salsa",
  "schemars",
  "serde",
@@ -3144,7 +3126,7 @@ dependencies = [
  "ruff_python_trivia",
  "ruff_source_file",
  "ruff_text_size",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "salsa",
  "schemars",
  "serde",
@@ -3193,7 +3175,7 @@ dependencies = [
  "ruff_python_trivia",
  "ruff_source_file",
  "ruff_text_size",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "serde",
  "serde_json",
  "static_assertions",
@@ -3217,7 +3199,7 @@ dependencies = [
  "ruff_python_parser",
  "ruff_python_stdlib",
  "ruff_text_size",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "schemars",
  "serde",
  "smallvec",
@@ -3278,7 +3260,7 @@ dependencies = [
  "ruff_source_file",
  "ruff_text_size",
  "ruff_workspace",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "serde",
  "serde_json",
  "shellexpand",
@@ -3367,7 +3349,7 @@ dependencies = [
  "ruff_python_semantic",
  "ruff_python_stdlib",
  "ruff_source_file",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "schemars",
  "serde",
  "shellexpand",
@@ -3385,12 +3367,6 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -3446,7 +3422,7 @@ dependencies = [
  "parking_lot",
  "portable-atomic",
  "rayon",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "salsa-macro-rules",
  "salsa-macros",
  "smallvec",
@@ -4144,7 +4120,6 @@ dependencies = [
  "clap",
  "clap_complete_command",
  "colored 3.0.0",
- "countme",
  "crossbeam",
  "ctrlc",
  "dunce",
@@ -4181,7 +4156,7 @@ dependencies = [
  "ruff_python_ast",
  "ruff_python_parser",
  "ruff_text_size",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "salsa",
  "smallvec",
  "tracing",
@@ -4213,7 +4188,7 @@ dependencies = [
  "ruff_python_ast",
  "ruff_python_formatter",
  "ruff_text_size",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "salsa",
  "schemars",
  "serde",
@@ -4234,7 +4209,6 @@ dependencies = [
  "camino",
  "colored 3.0.0",
  "compact_str",
- "countme",
  "dir-test",
  "drop_bomb",
  "get-size2",
@@ -4258,7 +4232,7 @@ dependencies = [
  "ruff_python_trivia",
  "ruff_source_file",
  "ruff_text_size",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "salsa",
  "schemars",
  "serde",
@@ -4290,7 +4264,7 @@ dependencies = [
  "ruff_notebook",
  "ruff_source_file",
  "ruff_text_size",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "salsa",
  "serde",
  "serde_json",
@@ -4328,7 +4302,7 @@ dependencies = [
  "ruff_python_trivia",
  "ruff_source_file",
  "ruff_text_size",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustc-stable-hash",
  "salsa",
  "serde",

--- a/crates/ty/Cargo.toml
+++ b/crates/ty/Cargo.toml
@@ -26,7 +26,6 @@ argfile = { workspace = true }
 clap = { workspace = true, features = ["wrap_help", "string", "env"] }
 clap_complete_command = { workspace = true }
 colored = { workspace = true }
-countme = { workspace = true, features = ["enable"] }
 crossbeam = { workspace = true }
 ctrlc = { version = "3.4.4" }
 indicatif = { workspace = true }

--- a/crates/ty/src/lib.rs
+++ b/crates/ty/src/lib.rs
@@ -59,7 +59,6 @@ fn run_check(args: CheckCommand) -> anyhow::Result<ExitStatus> {
     set_colored_override(args.color);
 
     let verbosity = args.verbosity.level();
-    countme::enable(verbosity.is_trace());
     let _guard = setup_tracing(verbosity, args.color.unwrap_or_default())?;
 
     tracing::warn!(
@@ -151,8 +150,6 @@ fn run_check(args: CheckCommand) -> anyhow::Result<ExitStatus> {
         Ok("full") => write!(stdout, "{}", db.salsa_memory_dump().display_full())?,
         _ => {}
     }
-
-    tracing::trace!("Counts for entire CLI run:\n{}", countme::get_all());
 
     std::mem::forget(db);
 
@@ -353,8 +350,6 @@ impl MainLoop {
                             "Discarding check result for outdated revision: current: {revision}, result revision: {check_revision}"
                         );
                     }
-
-                    tracing::trace!("Counts after last check:\n{}", countme::get_all());
                 }
 
                 MainLoopMessage::ApplyChanges(changes) => {

--- a/crates/ty_python_semantic/Cargo.toml
+++ b/crates/ty_python_semantic/Cargo.toml
@@ -29,7 +29,6 @@ bitflags = { workspace = true }
 camino = { workspace = true }
 colored = { workspace = true }
 compact_str = { workspace = true }
-countme = { workspace = true }
 drop_bomb = { workspace = true }
 get-size2 = { workspace = true }
 indexmap = { workspace = true }

--- a/crates/ty_python_semantic/src/semantic_index/builder.rs
+++ b/crates/ty_python_semantic/src/semantic_index/builder.rs
@@ -259,7 +259,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             .push(UseDefMapBuilder::new(is_class_scope));
         let ast_id_scope = self.ast_ids.push(AstIdsBuilder::default());
 
-        let scope_id = ScopeId::new(self.db, self.file, file_scope_id, countme::Count::default());
+        let scope_id = ScopeId::new(self.db, self.file, file_scope_id);
 
         self.scope_ids_by_scope.push(scope_id);
         let previous = self.scopes_by_node.insert(node.node_key(), file_scope_id);
@@ -495,7 +495,6 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             place,
             kind,
             is_reexported,
-            countme::Count::default(),
         );
 
         let num_definitions = {
@@ -731,7 +730,6 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             subject,
             kind,
             guard,
-            countme::Count::default(),
         );
         let predicate = PredicateOrLiteral::Predicate(Predicate {
             node: PredicateNode::Pattern(pattern_predicate),
@@ -781,7 +779,6 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             AstNodeRef::new(self.module, expression_node),
             assigned_to.map(|assigned_to| AstNodeRef::new(self.module, assigned_to)),
             expression_kind,
-            countme::Count::default(),
         );
         self.expressions_by_node
             .insert(expression_node.into(), expression);
@@ -986,7 +983,6 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     // Note `target` belongs to the `self.module` tree
                     AstNodeRef::new(self.module, target),
                     UnpackValue::new(unpackable.kind(), value),
-                    countme::Count::default(),
                 ));
                 Some(unpackable.as_current_assignment(unpack))
             }

--- a/crates/ty_python_semantic/src/semantic_index/definition.rs
+++ b/crates/ty_python_semantic/src/semantic_index/definition.rs
@@ -40,8 +40,6 @@ pub struct Definition<'db> {
 
     /// This is a dedicated field to avoid accessing `kind` to compute this value.
     pub(crate) is_reexported: bool,
-
-    count: countme::Count<Definition<'static>>,
 }
 
 // The Salsa heap is tracked separately.

--- a/crates/ty_python_semantic/src/semantic_index/expression.rs
+++ b/crates/ty_python_semantic/src/semantic_index/expression.rs
@@ -58,8 +58,6 @@ pub(crate) struct Expression<'db> {
 
     /// Should this expression be inferred as a normal expression or a type expression?
     pub(crate) kind: ExpressionKind,
-
-    count: countme::Count<Expression<'static>>,
 }
 
 // The Salsa heap is tracked separately.

--- a/crates/ty_python_semantic/src/semantic_index/place.rs
+++ b/crates/ty_python_semantic/src/semantic_index/place.rs
@@ -441,8 +441,6 @@ pub struct ScopeId<'db> {
     pub file: File,
 
     pub file_scope_id: FileScopeId,
-
-    count: countme::Count<ScopeId<'static>>,
 }
 
 // The Salsa heap is tracked separately.

--- a/crates/ty_python_semantic/src/semantic_index/predicate.rs
+++ b/crates/ty_python_semantic/src/semantic_index/predicate.rs
@@ -138,8 +138,6 @@ pub(crate) struct PatternPredicate<'db> {
     pub(crate) kind: PatternPredicateKind<'db>,
 
     pub(crate) guard: Option<Expression<'db>>,
-
-    count: countme::Count<PatternPredicate<'static>>,
 }
 
 // The Salsa heap is tracked separately.

--- a/crates/ty_python_semantic/src/unpack.rs
+++ b/crates/ty_python_semantic/src/unpack.rs
@@ -44,8 +44,6 @@ pub(crate) struct Unpack<'db> {
     /// The ingredient representing the value expression of the unpacking. For example, in
     /// `(a, b) = (1, 2)`, the value expression is `(1, 2)`.
     pub(crate) value: UnpackValue<'db>,
-
-    count: countme::Count<Unpack<'static>>,
 }
 
 impl<'db> Unpack<'db> {


### PR DESCRIPTION
## Summary

`TY_MEMORY_REPORT` gives us the same and maore information. Making the countme approach for salsa structs obsolete. 

E.g. `TY_MEMORY_REPORT` gives you

```
`Definition`                                       metadata=7.41MB   fields=17.77MB  count=185129
`Expression`                                       metadata=2.34MB   fields=3.12MB   count=48748
`OverloadLiteral`                                  metadata=1.48MB   fields=1.05MB   count=26361
`Type < 'db >::member_lookup_with_policy_::interned_arguments` metadata=0.78MB   fields=0.89MB   count=13874
`File`                                             metadata=0.81MB   fields=0.81MB   count=12712
`FunctionType`                                     metadata=1.51MB   fields=0.65MB   count=26956
`ScopeId`                                          metadata=1.39MB   fields=0.60MB   count=49716
`IntersectionType`                                 metadata=0.27MB   fields=0.55MB   count=4899
`Type < 'db >::class_member_with_policy_::interned_arguments` metadata=0.39MB   fields=0.44MB   count=6925
`FunctionLiteral`                                  metadata=1.48MB   fields=0.42MB   count=26395
`ClassLiteral`                                     metadata=0.35MB   fields=0.25MB   count=6286
`TupleType`                                        metadata=0.16MB   fields=0.23MB   count=2919
`place_by_id::interned_arguments`                  metadata=0.75MB   fields=0.22MB   count=13439
`Type < 'db >::try_call_dunder_get_::interned_arguments` metadata=0.10MB   fields=0.17MB   count=1808
`StringLiteralType`                                metadata=0.59MB   fields=0.17MB   count=10562
`TypeVarInstance`                                  metadata=0.09MB   fields=0.16MB   count=1579
`ClassLiteral < 'db >::try_mro_::interned_arguments` metadata=0.56MB   fields=0.16MB   count=10054
`Type < 'db >::apply_specialization_::interned_arguments` metadata=0.22MB   fields=0.16MB   count=3970
`Specialization`                                   metadata=0.24MB   fields=0.14MB   count=4347
`GenericAlias`                                     metadata=0.36MB   fields=0.10MB   count=6429
`CallableType`                                     metadata=0.06MB   fields=0.10MB   count=1005
`StarImportPlaceholderPredicate`                   metadata=0.12MB   fields=0.08MB   count=4167
`ModuleNameIngredient`                             metadata=0.15MB   fields=0.07MB   count=2739
`PropertyInstanceType`                             metadata=0.06MB   fields=0.07MB   count=1016
`BoundMethodType`                                  metadata=0.09MB   fields=0.06MB   count=1523
`UnionType`                                        metadata=0.20MB   fields=0.06MB   count=3619
`PatternPredicate`                                 metadata=0.02MB   fields=0.04MB   count=768
`Unpack`                                           metadata=0.03MB   fields=0.04MB   count=637
`ModuleLiteralType`                                metadata=0.11MB   fields=0.03MB   count=1979
`GenericContext`                                   metadata=0.03MB   fields=0.03MB   count=507
`BareTypeAliasType`                                metadata=0.01MB   fields=0.01MB   count=201
`PEP695TypeAliasType`                              metadata=0.02MB   fields=0.01MB   count=272
`Type < 'db >::lookup_dunder_new_::interned_arguments` metadata=0.01MB   fields=0.01MB   count=238
`ProtocolInterface`                                metadata=0.01MB   fields=0.00MB   count=143
`BytesLiteralType`                                 metadata=0.01MB   fields=0.00MB   count=137
`TypeIsType`                                       metadata=0.00MB   fields=0.00MB   count=39
`BoundSuperType`                                   metadata=0.00MB   fields=0.00MB   count=26
`Program`                                          metadata=0.00MB   fields=0.00MB   count=1
`Project`                                          metadata=0.00MB   fields=0.00MB   count=1
`FileRoot`                                         metadata=0.00MB   fields=0.00MB   count=1
`module_type_symbols::interned_arguments`          metadata=0.00MB   fields=0.00MB   count=1
`dynamic_resolution_paths::interned_arguments`     metadata=0.00MB   fields=0.00MB   count=1
```

## Test Plan

cargo build
