### PR TITLE
Add simple integration tests for all output formats

### DIFF
--- a/crates/ruff/tests/lint.rs
+++ b/crates/ruff/tests/lint.rs
@@ -5721,7 +5721,8 @@ match 42:  # invalid-syntax
 
     insta::with_settings!({
         filters => vec![
-            (tempdir_filter(&tempdir.path().to_string_lossy().replace("\\", "\\\\")).as_str(), "[TMP]/"),
+            (tempdir_filter(&tempdir).as_str(), "[TMP]/"),
+            (tempdir_filter(tempdir.path().to_string_lossy().replace('\\', "/")).as_str(), "[TMP]/"),
         ]
     }, {
         assert_cmd_snapshot!(

--- a/crates/ruff/tests/lint.rs
+++ b/crates/ruff/tests/lint.rs
@@ -5705,7 +5705,6 @@ class Foo:
 #[test_case::test_case("rdjson")]
 #[test_case::test_case("azure")]
 #[test_case::test_case("sarif")]
-#[allow(clippy::print_stderr)] // TODO
 fn output_format(output_format: &str) -> Result<()> {
     const CONTENT: &str = "\
 import os  # F401
@@ -5720,18 +5719,9 @@ match 42:  # invalid-syntax
 
     let snapshot = format!("output_format_{output_format}");
 
-    // TODO(brent) debugging Windows failures
-    eprintln!(
-        "{} => {}",
-        tempdir.path().display(),
-        tempdir_filter(&tempdir)
-    );
-    eprintln!("{} => {}", input.display(), tempdir_filter(&input));
-
     insta::with_settings!({
         filters => vec![
-            (tempdir_filter(&tempdir).as_str(), "[TMP]/"),
-            (tempdir_filter(&input).as_str(), "[TMP]/input.py"),
+            (tempdir_filter(&tempdir.path().to_string_lossy().replace("\\", "\\\\")).as_str(), "[TMP]/"),
         ]
     }, {
         assert_cmd_snapshot!(

--- a/crates/ruff/tests/lint.rs
+++ b/crates/ruff/tests/lint.rs
@@ -5705,6 +5705,7 @@ class Foo:
 #[test_case::test_case("rdjson")]
 #[test_case::test_case("azure")]
 #[test_case::test_case("sarif")]
+#[allow(clippy::print_stderr)] // TODO
 fn output_format(output_format: &str) -> Result<()> {
     const CONTENT: &str = "\
 import os  # F401
@@ -5718,6 +5719,14 @@ match 42:  # invalid-syntax
     fs::write(&input, CONTENT)?;
 
     let snapshot = format!("output_format_{output_format}");
+
+    // TODO(brent) debugging Windows failures
+    eprintln!(
+        "{:?} => {:?}",
+        tempdir.path(),
+        tempdir_filter(&tempdir).as_str()
+    );
+    eprintln!("{:?} => {:?}", input, tempdir_filter(&input).as_str());
 
     insta::with_settings!({
         filters => vec![

--- a/crates/ruff/tests/lint.rs
+++ b/crates/ruff/tests/lint.rs
@@ -5722,7 +5722,7 @@ match 42:  # invalid-syntax
     insta::with_settings!({
         filters => vec![
             (tempdir_filter(&tempdir).as_str(), "[TMP]/"),
-            (tempdir_filter(tempdir.path().to_string_lossy().replace('\\', "/")).as_str(), "[TMP]/"),
+            (r#""[^"]+\\?/?input.py"#, r#""[TMP]/input.py"#),
         ]
     }, {
         assert_cmd_snapshot!(

--- a/crates/ruff/tests/lint.rs
+++ b/crates/ruff/tests/lint.rs
@@ -5719,13 +5719,10 @@ match 42:  # invalid-syntax
 
     let snapshot = format!("output_format_{output_format}");
 
-    let tempdir_canon = dunce::canonicalize(tempdir.path())?;
-    let input_canon = dunce::canonicalize(&input)?;
-
     insta::with_settings!({
         filters => vec![
-            (tempdir_filter(&tempdir_canon).as_str(), "[TMP]/"),
-            (tempdir_filter(&input_canon).as_str(), "[TMP]/input.py"),
+            (tempdir_filter(&tempdir).as_str(), "[TMP]/"),
+            (tempdir_filter(&input).as_str(), "[TMP]/input.py"),
         ]
     }, {
         assert_cmd_snapshot!(

--- a/crates/ruff/tests/lint.rs
+++ b/crates/ruff/tests/lint.rs
@@ -5737,7 +5737,7 @@ match 42:  # invalid-syntax
                     "input.py",
                 ])
                 .current_dir(&tempdir),
-        )
+        );
     });
 
     Ok(())

--- a/crates/ruff/tests/lint.rs
+++ b/crates/ruff/tests/lint.rs
@@ -5719,8 +5719,14 @@ match 42:  # invalid-syntax
 
     let snapshot = format!("output_format_{output_format}");
 
+    let tempdir_canon = dunce::canonicalize(tempdir.path())?;
+    let input_canon = dunce::canonicalize(&input)?;
+
     insta::with_settings!({
-        filters => vec![(tempdir_filter(dunce::canonicalize(&tempdir)?).as_str(), "[TMP]/")]
+        filters => vec![
+            (tempdir_filter(&tempdir_canon).as_str(), "[TMP]/"),
+            (tempdir_filter(&input_canon).as_str(), "[TMP]/input.py"),
+        ]
     }, {
         assert_cmd_snapshot!(
             snapshot,

--- a/crates/ruff/tests/lint.rs
+++ b/crates/ruff/tests/lint.rs
@@ -5722,11 +5722,11 @@ match 42:  # invalid-syntax
 
     // TODO(brent) debugging Windows failures
     eprintln!(
-        "{:?} => {:?}",
-        tempdir.path(),
-        tempdir_filter(&tempdir).as_str()
+        "{} => {}",
+        tempdir.path().display(),
+        tempdir_filter(&tempdir)
     );
-    eprintln!("{:?} => {:?}", input, tempdir_filter(&input).as_str());
+    eprintln!("{} => {}", input.display(), tempdir_filter(&input));
 
     insta::with_settings!({
         filters => vec![

--- a/crates/ruff/tests/lint.rs
+++ b/crates/ruff/tests/lint.rs
@@ -5720,7 +5720,7 @@ match 42:  # invalid-syntax
     let snapshot = format!("output_format_{output_format}");
 
     insta::with_settings!({
-        filters => vec![(tempdir_filter(&tempdir).as_str(), "[TMP]/")]
+        filters => vec![(tempdir_filter(dunce::canonicalize(&tempdir)?).as_str(), "[TMP]/")]
     }, {
         assert_cmd_snapshot!(
             snapshot,

--- a/crates/ruff/tests/snapshots/lint__output_format_azure.snap
+++ b/crates/ruff/tests/snapshots/lint__output_format_azure.snap
@@ -1,0 +1,23 @@
+---
+source: crates/ruff/tests/lint.rs
+info:
+  program: ruff
+  args:
+    - check
+    - "--no-cache"
+    - "--output-format"
+    - azure
+    - "--select"
+    - "F401,F821"
+    - "--target-version"
+    - py39
+    - input.py
+---
+success: false
+exit_code: 1
+----- stdout -----
+##vso[task.logissue type=error;sourcepath=[TMP]/input.py;linenumber=1;columnnumber=8;code=F401;]`os` imported but unused
+##vso[task.logissue type=error;sourcepath=[TMP]/input.py;linenumber=2;columnnumber=5;code=F821;]Undefined name `y`
+##vso[task.logissue type=error;sourcepath=[TMP]/input.py;linenumber=3;columnnumber=1;]SyntaxError: Cannot use `match` statement on Python 3.9 (syntax was added in Python 3.10)
+
+----- stderr -----

--- a/crates/ruff/tests/snapshots/lint__output_format_concise.snap
+++ b/crates/ruff/tests/snapshots/lint__output_format_concise.snap
@@ -1,0 +1,25 @@
+---
+source: crates/ruff/tests/lint.rs
+info:
+  program: ruff
+  args:
+    - check
+    - "--no-cache"
+    - "--output-format"
+    - concise
+    - "--select"
+    - "F401,F821"
+    - "--target-version"
+    - py39
+    - input.py
+---
+success: false
+exit_code: 1
+----- stdout -----
+input.py:1:8: F401 [*] `os` imported but unused
+input.py:2:5: F821 Undefined name `y`
+input.py:3:1: SyntaxError: Cannot use `match` statement on Python 3.9 (syntax was added in Python 3.10)
+Found 3 errors.
+[*] 1 fixable with the `--fix` option.
+
+----- stderr -----

--- a/crates/ruff/tests/snapshots/lint__output_format_full.snap
+++ b/crates/ruff/tests/snapshots/lint__output_format_full.snap
@@ -1,0 +1,49 @@
+---
+source: crates/ruff/tests/lint.rs
+info:
+  program: ruff
+  args:
+    - check
+    - "--no-cache"
+    - "--output-format"
+    - full
+    - "--select"
+    - "F401,F821"
+    - "--target-version"
+    - py39
+    - input.py
+---
+success: false
+exit_code: 1
+----- stdout -----
+input.py:1:8: F401 [*] `os` imported but unused
+  |
+1 | import os  # F401
+  |        ^^ F401
+2 | x = y      # F821
+3 | match 42:  # invalid-syntax
+  |
+  = help: Remove unused import: `os`
+
+input.py:2:5: F821 Undefined name `y`
+  |
+1 | import os  # F401
+2 | x = y      # F821
+  |     ^ F821
+3 | match 42:  # invalid-syntax
+4 |     case _: ...
+  |
+
+input.py:3:1: SyntaxError: Cannot use `match` statement on Python 3.9 (syntax was added in Python 3.10)
+  |
+1 | import os  # F401
+2 | x = y      # F821
+3 | match 42:  # invalid-syntax
+  | ^^^^^
+4 |     case _: ...
+  |
+
+Found 3 errors.
+[*] 1 fixable with the `--fix` option.
+
+----- stderr -----

--- a/crates/ruff/tests/snapshots/lint__output_format_github.snap
+++ b/crates/ruff/tests/snapshots/lint__output_format_github.snap
@@ -1,0 +1,23 @@
+---
+source: crates/ruff/tests/lint.rs
+info:
+  program: ruff
+  args:
+    - check
+    - "--no-cache"
+    - "--output-format"
+    - github
+    - "--select"
+    - "F401,F821"
+    - "--target-version"
+    - py39
+    - input.py
+---
+success: false
+exit_code: 1
+----- stdout -----
+::error title=Ruff (F401),file=[TMP]/input.py,line=1,col=8,endLine=1,endColumn=10::input.py:1:8: F401 `os` imported but unused
+::error title=Ruff (F821),file=[TMP]/input.py,line=2,col=5,endLine=2,endColumn=6::input.py:2:5: F821 Undefined name `y`
+::error title=Ruff,file=[TMP]/input.py,line=3,col=1,endLine=3,endColumn=6::input.py:3:1: SyntaxError: Cannot use `match` statement on Python 3.9 (syntax was added in Python 3.10)
+
+----- stderr -----

--- a/crates/ruff/tests/snapshots/lint__output_format_gitlab.snap
+++ b/crates/ruff/tests/snapshots/lint__output_format_gitlab.snap
@@ -1,0 +1,60 @@
+---
+source: crates/ruff/tests/lint.rs
+info:
+  program: ruff
+  args:
+    - check
+    - "--no-cache"
+    - "--output-format"
+    - gitlab
+    - "--select"
+    - "F401,F821"
+    - "--target-version"
+    - py39
+    - input.py
+---
+success: false
+exit_code: 1
+----- stdout -----
+[
+  {
+    "check_name": "F401",
+    "description": "`os` imported but unused",
+    "fingerprint": "4dbad37161e65c72",
+    "location": {
+      "lines": {
+        "begin": 1,
+        "end": 1
+      },
+      "path": "input.py"
+    },
+    "severity": "major"
+  },
+  {
+    "check_name": "F821",
+    "description": "Undefined name `y`",
+    "fingerprint": "7af59862a085230",
+    "location": {
+      "lines": {
+        "begin": 2,
+        "end": 2
+      },
+      "path": "input.py"
+    },
+    "severity": "major"
+  },
+  {
+    "check_name": "syntax-error",
+    "description": "Cannot use `match` statement on Python 3.9 (syntax was added in Python 3.10)",
+    "fingerprint": "e558cec859bb66e8",
+    "location": {
+      "lines": {
+        "begin": 3,
+        "end": 3
+      },
+      "path": "input.py"
+    },
+    "severity": "major"
+  }
+]
+----- stderr -----

--- a/crates/ruff/tests/snapshots/lint__output_format_grouped.snap
+++ b/crates/ruff/tests/snapshots/lint__output_format_grouped.snap
@@ -1,0 +1,27 @@
+---
+source: crates/ruff/tests/lint.rs
+info:
+  program: ruff
+  args:
+    - check
+    - "--no-cache"
+    - "--output-format"
+    - grouped
+    - "--select"
+    - "F401,F821"
+    - "--target-version"
+    - py39
+    - input.py
+---
+success: false
+exit_code: 1
+----- stdout -----
+input.py:
+  1:8 F401 [*] `os` imported but unused
+  2:5 F821 Undefined name `y`
+  3:1 SyntaxError: Cannot use `match` statement on Python 3.9 (syntax was added in Python 3.10)
+
+Found 3 errors.
+[*] 1 fixable with the `--fix` option.
+
+----- stderr -----

--- a/crates/ruff/tests/snapshots/lint__output_format_json-lines.snap
+++ b/crates/ruff/tests/snapshots/lint__output_format_json-lines.snap
@@ -1,0 +1,23 @@
+---
+source: crates/ruff/tests/lint.rs
+info:
+  program: ruff
+  args:
+    - check
+    - "--no-cache"
+    - "--output-format"
+    - json-lines
+    - "--select"
+    - "F401,F821"
+    - "--target-version"
+    - py39
+    - input.py
+---
+success: false
+exit_code: 1
+----- stdout -----
+{"cell":null,"code":"F401","end_location":{"column":10,"row":1},"filename":"[TMP]/input.py","fix":{"applicability":"safe","edits":[{"content":"","end_location":{"column":1,"row":2},"location":{"column":1,"row":1}}],"message":"Remove unused import: `os`"},"location":{"column":8,"row":1},"message":"`os` imported but unused","noqa_row":1,"url":"https://docs.astral.sh/ruff/rules/unused-import"}
+{"cell":null,"code":"F821","end_location":{"column":6,"row":2},"filename":"[TMP]/input.py","fix":null,"location":{"column":5,"row":2},"message":"Undefined name `y`","noqa_row":2,"url":"https://docs.astral.sh/ruff/rules/undefined-name"}
+{"cell":null,"code":null,"end_location":{"column":6,"row":3},"filename":"[TMP]/input.py","fix":null,"location":{"column":1,"row":3},"message":"SyntaxError: Cannot use `match` statement on Python 3.9 (syntax was added in Python 3.10)","noqa_row":null,"url":null}
+
+----- stderr -----

--- a/crates/ruff/tests/snapshots/lint__output_format_json.snap
+++ b/crates/ruff/tests/snapshots/lint__output_format_json.snap
@@ -1,0 +1,88 @@
+---
+source: crates/ruff/tests/lint.rs
+info:
+  program: ruff
+  args:
+    - check
+    - "--no-cache"
+    - "--output-format"
+    - json
+    - "--select"
+    - "F401,F821"
+    - "--target-version"
+    - py39
+    - input.py
+---
+success: false
+exit_code: 1
+----- stdout -----
+[
+  {
+    "cell": null,
+    "code": "F401",
+    "end_location": {
+      "column": 10,
+      "row": 1
+    },
+    "filename": "[TMP]/input.py",
+    "fix": {
+      "applicability": "safe",
+      "edits": [
+        {
+          "content": "",
+          "end_location": {
+            "column": 1,
+            "row": 2
+          },
+          "location": {
+            "column": 1,
+            "row": 1
+          }
+        }
+      ],
+      "message": "Remove unused import: `os`"
+    },
+    "location": {
+      "column": 8,
+      "row": 1
+    },
+    "message": "`os` imported but unused",
+    "noqa_row": 1,
+    "url": "https://docs.astral.sh/ruff/rules/unused-import"
+  },
+  {
+    "cell": null,
+    "code": "F821",
+    "end_location": {
+      "column": 6,
+      "row": 2
+    },
+    "filename": "[TMP]/input.py",
+    "fix": null,
+    "location": {
+      "column": 5,
+      "row": 2
+    },
+    "message": "Undefined name `y`",
+    "noqa_row": 2,
+    "url": "https://docs.astral.sh/ruff/rules/undefined-name"
+  },
+  {
+    "cell": null,
+    "code": null,
+    "end_location": {
+      "column": 6,
+      "row": 3
+    },
+    "filename": "[TMP]/input.py",
+    "fix": null,
+    "location": {
+      "column": 1,
+      "row": 3
+    },
+    "message": "SyntaxError: Cannot use `match` statement on Python 3.9 (syntax was added in Python 3.10)",
+    "noqa_row": null,
+    "url": null
+  }
+]
+----- stderr -----

--- a/crates/ruff/tests/snapshots/lint__output_format_junit.snap
+++ b/crates/ruff/tests/snapshots/lint__output_format_junit.snap
@@ -1,0 +1,34 @@
+---
+source: crates/ruff/tests/lint.rs
+info:
+  program: ruff
+  args:
+    - check
+    - "--no-cache"
+    - "--output-format"
+    - junit
+    - "--select"
+    - "F401,F821"
+    - "--target-version"
+    - py39
+    - input.py
+---
+success: false
+exit_code: 1
+----- stdout -----
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="ruff" tests="3" failures="3" errors="0">
+    <testsuite name="[TMP]/input.py" tests="3" disabled="0" errors="0" failures="3" package="org.ruff">
+        <testcase name="org.ruff.F401" classname="[TMP]/input" line="1" column="8">
+            <failure message="`os` imported but unused">line 1, col 8, `os` imported but unused</failure>
+        </testcase>
+        <testcase name="org.ruff.F821" classname="[TMP]/input" line="2" column="5">
+            <failure message="Undefined name `y`">line 2, col 5, Undefined name `y`</failure>
+        </testcase>
+        <testcase name="org.ruff" classname="[TMP]/input" line="3" column="1">
+            <failure message="SyntaxError: Cannot use `match` statement on Python 3.9 (syntax was added in Python 3.10)">line 3, col 1, SyntaxError: Cannot use `match` statement on Python 3.9 (syntax was added in Python 3.10)</failure>
+        </testcase>
+    </testsuite>
+</testsuites>
+
+----- stderr -----

--- a/crates/ruff/tests/snapshots/lint__output_format_pylint.snap
+++ b/crates/ruff/tests/snapshots/lint__output_format_pylint.snap
@@ -1,0 +1,23 @@
+---
+source: crates/ruff/tests/lint.rs
+info:
+  program: ruff
+  args:
+    - check
+    - "--no-cache"
+    - "--output-format"
+    - pylint
+    - "--select"
+    - "F401,F821"
+    - "--target-version"
+    - py39
+    - input.py
+---
+success: false
+exit_code: 1
+----- stdout -----
+input.py:1: [F401] `os` imported but unused
+input.py:2: [F821] Undefined name `y`
+input.py:3: SyntaxError: Cannot use `match` statement on Python 3.9 (syntax was added in Python 3.10)
+
+----- stderr -----

--- a/crates/ruff/tests/snapshots/lint__output_format_rdjson.snap
+++ b/crates/ruff/tests/snapshots/lint__output_format_rdjson.snap
@@ -1,0 +1,103 @@
+---
+source: crates/ruff/tests/lint.rs
+info:
+  program: ruff
+  args:
+    - check
+    - "--no-cache"
+    - "--output-format"
+    - rdjson
+    - "--select"
+    - "F401,F821"
+    - "--target-version"
+    - py39
+    - input.py
+---
+success: false
+exit_code: 1
+----- stdout -----
+{
+  "diagnostics": [
+    {
+      "code": {
+        "url": "https://docs.astral.sh/ruff/rules/unused-import",
+        "value": "F401"
+      },
+      "location": {
+        "path": "[TMP]/input.py",
+        "range": {
+          "end": {
+            "column": 10,
+            "line": 1
+          },
+          "start": {
+            "column": 8,
+            "line": 1
+          }
+        }
+      },
+      "message": "`os` imported but unused",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 1,
+              "line": 2
+            },
+            "start": {
+              "column": 1,
+              "line": 1
+            }
+          },
+          "text": ""
+        }
+      ]
+    },
+    {
+      "code": {
+        "url": "https://docs.astral.sh/ruff/rules/undefined-name",
+        "value": "F821"
+      },
+      "location": {
+        "path": "[TMP]/input.py",
+        "range": {
+          "end": {
+            "column": 6,
+            "line": 2
+          },
+          "start": {
+            "column": 5,
+            "line": 2
+          }
+        }
+      },
+      "message": "Undefined name `y`"
+    },
+    {
+      "code": {
+        "url": null,
+        "value": null
+      },
+      "location": {
+        "path": "[TMP]/input.py",
+        "range": {
+          "end": {
+            "column": 6,
+            "line": 3
+          },
+          "start": {
+            "column": 1,
+            "line": 3
+          }
+        }
+      },
+      "message": "SyntaxError: Cannot use `match` statement on Python 3.9 (syntax was added in Python 3.10)"
+    }
+  ],
+  "severity": "warning",
+  "source": {
+    "name": "ruff",
+    "url": "https://docs.astral.sh/ruff"
+  }
+}
+----- stderr -----

--- a/crates/ruff/tests/snapshots/lint__output_format_sarif.snap
+++ b/crates/ruff/tests/snapshots/lint__output_format_sarif.snap
@@ -1,0 +1,142 @@
+---
+source: crates/ruff/tests/lint.rs
+info:
+  program: ruff
+  args:
+    - check
+    - "--no-cache"
+    - "--output-format"
+    - sarif
+    - "--select"
+    - "F401,F821"
+    - "--target-version"
+    - py39
+    - input.py
+---
+success: false
+exit_code: 1
+----- stdout -----
+{
+  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+  "runs": [
+    {
+      "results": [
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://[TMP]/input.py"
+                },
+                "region": {
+                  "endColumn": 10,
+                  "endLine": 1,
+                  "startColumn": 8,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "`os` imported but unused"
+          },
+          "ruleId": "F401"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://[TMP]/input.py"
+                },
+                "region": {
+                  "endColumn": 6,
+                  "endLine": 2,
+                  "startColumn": 5,
+                  "startLine": 2
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "Undefined name `y`"
+          },
+          "ruleId": "F821"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://[TMP]/input.py"
+                },
+                "region": {
+                  "endColumn": 6,
+                  "endLine": 3,
+                  "startColumn": 1,
+                  "startLine": 3
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "SyntaxError: Cannot use `match` statement on Python 3.9 (syntax was added in Python 3.10)"
+          },
+          "ruleId": null
+        }
+      ],
+      "tool": {
+        "driver": {
+          "informationUri": "https://github.com/astral-sh/ruff",
+          "name": "ruff",
+          "rules": [
+            {
+              "fullDescription": {
+                "text": "## What it does\nChecks for unused imports.\n\n## Why is this bad?\nUnused imports add a performance overhead at runtime, and risk creating\nimport cycles. They also increase the cognitive load of reading the code.\n\nIf an import statement is used to check for the availability or existence\nof a module, consider using `importlib.util.find_spec` instead.\n\nIf an import statement is used to re-export a symbol as part of a module's\npublic interface, consider using a \"redundant\" import alias, which\ninstructs Ruff (and other tools) to respect the re-export, and avoid\nmarking it as unused, as in:\n\n```python\nfrom module import member as member\n```\n\nAlternatively, you can use `__all__` to declare a symbol as part of the module's\ninterface, as in:\n\n```python\n# __init__.py\nimport some_module\n\n__all__ = [\"some_module\"]\n```\n\n## Fix safety\n\nFixes to remove unused imports are safe, except in `__init__.py` files.\n\nApplying fixes to `__init__.py` files is currently in preview. The fix offered depends on the\ntype of the unused import. Ruff will suggest a safe fix to export first-party imports with\neither a redundant alias or, if already present in the file, an `__all__` entry. If multiple\n`__all__` declarations are present, Ruff will not offer a fix. Ruff will suggest an unsafe fix\nto remove third-party and standard library imports -- the fix is unsafe because the module's\ninterface changes.\n\n## Example\n\n```python\nimport numpy as np  # unused import\n\n\ndef area(radius):\n    return 3.14 * radius**2\n```\n\nUse instead:\n\n```python\ndef area(radius):\n    return 3.14 * radius**2\n```\n\nTo check the availability of a module, use `importlib.util.find_spec`:\n\n```python\nfrom importlib.util import find_spec\n\nif find_spec(\"numpy\") is not None:\n    print(\"numpy is installed\")\nelse:\n    print(\"numpy is not installed\")\n```\n\n## Preview\nWhen [preview](https://docs.astral.sh/ruff/preview/) is enabled,\nthe criterion for determining whether an import is first-party\nis stricter, which could affect the suggested fix. See [this FAQ section](https://docs.astral.sh/ruff/faq/#how-does-ruff-determine-which-of-my-imports-are-first-party-third-party-etc) for more details.\n\n## Options\n- `lint.ignore-init-module-imports`\n- `lint.pyflakes.allowed-unused-imports`\n\n## References\n- [Python documentation: `import`](https://docs.python.org/3/reference/simple_stmts.html#the-import-statement)\n- [Python documentation: `importlib.util.find_spec`](https://docs.python.org/3/library/importlib.html#importlib.util.find_spec)\n- [Typing documentation: interface conventions](https://typing.python.org/en/latest/source/libraries.html#library-interface-public-and-private-symbols)\n"
+              },
+              "help": {
+                "text": "`{name}` imported but unused; consider using `importlib.util.find_spec` to test for availability"
+              },
+              "helpUri": "https://docs.astral.sh/ruff/rules/unused-import",
+              "id": "F401",
+              "properties": {
+                "id": "F401",
+                "kind": "Pyflakes",
+                "name": "unused-import",
+                "problem.severity": "error"
+              },
+              "shortDescription": {
+                "text": "`{name}` imported but unused; consider using `importlib.util.find_spec` to test for availability"
+              }
+            },
+            {
+              "fullDescription": {
+                "text": "## What it does\nChecks for uses of undefined names.\n\n## Why is this bad?\nAn undefined name is likely to raise `NameError` at runtime.\n\n## Example\n```python\ndef double():\n    return n * 2  # raises `NameError` if `n` is undefined when `double` is called\n```\n\nUse instead:\n```python\ndef double(n):\n    return n * 2\n```\n\n## Options\n- [`target-version`]: Can be used to configure which symbols Ruff will understand\n  as being available in the `builtins` namespace.\n\n## References\n- [Python documentation: Naming and binding](https://docs.python.org/3/reference/executionmodel.html#naming-and-binding)\n"
+              },
+              "help": {
+                "text": "Undefined name `{name}`. {tip}"
+              },
+              "helpUri": "https://docs.astral.sh/ruff/rules/undefined-name",
+              "id": "F821",
+              "properties": {
+                "id": "F821",
+                "kind": "Pyflakes",
+                "name": "undefined-name",
+                "problem.severity": "error"
+              },
+              "shortDescription": {
+                "text": "Undefined name `{name}`. {tip}"
+              }
+            }
+          ],
+          "version": "0.12.2"
+        }
+      }
+    }
+  ],
+  "version": "2.1.0"
+}
+----- stderr -----

--- a/crates/ruff/tests/snapshots/lint__output_format_sarif.snap
+++ b/crates/ruff/tests/snapshots/lint__output_format_sarif.snap
@@ -27,7 +27,7 @@ exit_code: 1
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file://[TMP]/input.py"
+                  "uri": "[TMP]/input.py"
                 },
                 "region": {
                   "endColumn": 10,
@@ -49,7 +49,7 @@ exit_code: 1
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file://[TMP]/input.py"
+                  "uri": "[TMP]/input.py"
                 },
                 "region": {
                   "endColumn": 6,
@@ -71,7 +71,7 @@ exit_code: 1
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file://[TMP]/input.py"
+                  "uri": "[TMP]/input.py"
                 },
                 "region": {
                   "endColumn": 6,


### PR DESCRIPTION
Summary
--

I spun this off from #19133 to be sure to get an accurate baseline before modifying any of the formats. I picked the code snippet to include a lint diagnostic with a fix, one without a fix, and one syntax error. I'm happy to expand it if there are any other kinds we want to test.

I initially passed `CONTENT` on stdin, but I was a bit surprised to notice that some of our output formats include an absolute path to the file. I switched to a `TempDir` to use the `tempdir_filter`.

Test Plan
--

New CLI tests
