### PR TITLE
[ty] Add completions for submodules that aren't attributes of their parent

### DIFF
--- a/crates/ruff_db/src/vendored.rs
+++ b/crates/ruff_db/src/vendored.rs
@@ -21,6 +21,19 @@ type LockedZipArchive<'a> = MutexGuard<'a, VendoredZipArchive>;
 ///
 /// "Files" in the `VendoredFileSystem` are read-only and immutable.
 /// Directories are supported, but symlinks and hardlinks cannot exist.
+///
+/// # Path separators
+///
+/// At time of writing (2025-07-11), this implementation always uses `/` as a
+/// path separator, even in Windows environments where `\` is traditionally
+/// used as a file path separator. Namely, this is only currently used with zip
+/// files built by `crates/ty_vendored/build.rs`.
+///
+/// Callers using this may provide paths that use a `\` as a separator. It will
+/// be transparently normalized to `/`.
+///
+/// This is particularly important because the presence of a trailing separator
+/// in a zip file is conventionally used to indicate a directory entry.
 #[derive(Clone)]
 pub struct VendoredFileSystem {
     inner: Arc<Mutex<VendoredZipArchive>>,

--- a/crates/ruff_db/src/vendored.rs
+++ b/crates/ruff_db/src/vendored.rs
@@ -115,6 +115,68 @@ impl VendoredFileSystem {
         read_to_string(self, path.as_ref())
     }
 
+    /// Read the direct children of the directory
+    /// identified by `path`.
+    ///
+    /// If `path` is not a directory, then this will
+    /// return an empty `Vec`.
+    pub fn read_directory(&self, dir: impl AsRef<VendoredPath>) -> Vec<DirectoryEntry> {
+        // N.B. We specifically do not return an iterator here to avoid
+        // holding a lock for the lifetime of the iterator returned.
+        // That is, it seems like a footgun to keep the zip archive
+        // locked during iteration, since the unit of work for each
+        // item in the iterator could be arbitrarily long. Allocating
+        // up front and stuffing all entries into it is probably the
+        // simplest solution and what we do here. If this becomes
+        // a problem, there are other strategies we could pursue.
+        // (Amortizing allocs, using a different synchronization
+        // behavior or even exposing additional APIs.) ---AG
+
+        fn read_directory(fs: &VendoredFileSystem, dir: &VendoredPath) -> Vec<DirectoryEntry> {
+            let mut normalized = NormalizedVendoredPath::from(dir);
+            if !normalized.as_str().ends_with('/') {
+                normalized = normalized.with_trailing_slash();
+            }
+            let archive = fs.lock_archive();
+            let mut entries = vec![];
+            for name in archive.0.file_names() {
+                // Any entry that doesn't have the `path` (with a
+                // trailing slash) as a prefix cannot possibly be in
+                // the directory referenced by `path`.
+                let Some(without_dir_prefix) = name.strip_prefix(normalized.as_str()) else {
+                    continue;
+                };
+                // Filter out an entry equivalent to the path given
+                // since we only want children of the directory.
+                if without_dir_prefix.is_empty() {
+                    continue;
+                }
+                // We only want *direct* children. Files that are
+                // direct children cannot have any slashes (or else
+                // they are not direct children). Directories that
+                // are direct children can only have one slash and
+                // it must be at the end.
+                //
+                // (We do this manually ourselves to avoid doing a
+                // full file lookup and metadata retrieval via the
+                // `zip` crate.)
+                let file_type = FileType::from_zip_file_name(without_dir_prefix);
+                let slash_count = without_dir_prefix.matches('/').count();
+                match file_type {
+                    FileType::File if slash_count > 0 => continue,
+                    FileType::Directory if slash_count > 1 => continue,
+                    _ => {}
+                }
+                entries.push(DirectoryEntry {
+                    path: VendoredPathBuf::from(name),
+                    file_type,
+                });
+            }
+            entries
+        }
+        read_directory(self, dir.as_ref())
+    }
+
     /// Acquire a lock on the underlying zip archive.
     /// The call will block until it is able to acquire the lock.
     ///
@@ -206,6 +268,14 @@ pub enum FileType {
 }
 
 impl FileType {
+    fn from_zip_file_name(name: &str) -> FileType {
+        if name.ends_with('/') {
+            FileType::Directory
+        } else {
+            FileType::File
+        }
+    }
+
     pub const fn is_file(self) -> bool {
         matches!(self, Self::File)
     }
@@ -241,6 +311,30 @@ impl Metadata {
 
     pub fn revision(&self) -> FileRevision {
         self.revision
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct DirectoryEntry {
+    path: VendoredPathBuf,
+    file_type: FileType,
+}
+
+impl DirectoryEntry {
+    pub fn new(path: VendoredPathBuf, file_type: FileType) -> Self {
+        Self { path, file_type }
+    }
+
+    pub fn into_path(self) -> VendoredPathBuf {
+        self.path
+    }
+
+    pub fn path(&self) -> &VendoredPath {
+        &self.path
+    }
+
+    pub fn file_type(&self) -> FileType {
+        self.file_type
     }
 }
 
@@ -496,6 +590,60 @@ pub(crate) mod tests {
     #[test]
     fn asyncio_dir_odd_components() {
         test_directory("./stdlib/asyncio/../asyncio/")
+    }
+
+    fn readdir_snapshot(fs: &VendoredFileSystem, path: &str) -> String {
+        let mut paths = fs
+            .read_directory(VendoredPath::new(path))
+            .into_iter()
+            .map(|entry| entry.path().to_string())
+            .collect::<Vec<String>>();
+        paths.sort();
+        paths.join("\n")
+    }
+
+    #[test]
+    fn read_directory_stdlib() {
+        let mock_typeshed = mock_typeshed();
+
+        assert_snapshot!(readdir_snapshot(&mock_typeshed, "stdlib"), @r"
+        vendored://stdlib/asyncio/
+        vendored://stdlib/functools.pyi
+        ");
+        assert_snapshot!(readdir_snapshot(&mock_typeshed, "stdlib/"), @r"
+        vendored://stdlib/asyncio/
+        vendored://stdlib/functools.pyi
+        ");
+        assert_snapshot!(readdir_snapshot(&mock_typeshed, "./stdlib"), @r"
+        vendored://stdlib/asyncio/
+        vendored://stdlib/functools.pyi
+        ");
+        assert_snapshot!(readdir_snapshot(&mock_typeshed, "./stdlib/"), @r"
+        vendored://stdlib/asyncio/
+        vendored://stdlib/functools.pyi
+        ");
+    }
+
+    #[test]
+    fn read_directory_asyncio() {
+        let mock_typeshed = mock_typeshed();
+
+        assert_snapshot!(
+            readdir_snapshot(&mock_typeshed, "stdlib/asyncio"),
+            @"vendored://stdlib/asyncio/tasks.pyi",
+        );
+        assert_snapshot!(
+            readdir_snapshot(&mock_typeshed, "./stdlib/asyncio"),
+            @"vendored://stdlib/asyncio/tasks.pyi",
+        );
+        assert_snapshot!(
+            readdir_snapshot(&mock_typeshed, "stdlib/asyncio/"),
+            @"vendored://stdlib/asyncio/tasks.pyi",
+        );
+        assert_snapshot!(
+            readdir_snapshot(&mock_typeshed, "./stdlib/asyncio/"),
+            @"vendored://stdlib/asyncio/tasks.pyi",
+        );
     }
 
     fn test_nonexistent_path(path: &str) {

--- a/crates/ruff_db/src/vendored/path.rs
+++ b/crates/ruff_db/src/vendored/path.rs
@@ -17,6 +17,10 @@ impl VendoredPath {
         unsafe { &*(path as *const Utf8Path as *const VendoredPath) }
     }
 
+    pub fn file_name(&self) -> Option<&str> {
+        self.0.file_name()
+    }
+
     pub fn to_path_buf(&self) -> VendoredPathBuf {
         VendoredPathBuf(self.0.to_path_buf())
     }

--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -2397,6 +2397,48 @@ Cougar = 3
     }
 
     #[test]
+    fn from_import_with_submodule1() {
+        let test = CursorTest::builder()
+            .source("main.py", "from package import <CURSOR>")
+            .source("package/__init__.py", "")
+            .source("package/foo.py", "")
+            .source("package/bar.pyi", "")
+            .source("package/foo-bar.py", "")
+            .source("package/data.txt", "")
+            .source("package/sub/__init__.py", "")
+            .source("package/not-a-submodule/__init__.py", "")
+            .build();
+
+        test.assert_completions_include("foo");
+        test.assert_completions_include("bar");
+        test.assert_completions_include("sub");
+        test.assert_completions_do_not_include("foo-bar");
+        test.assert_completions_do_not_include("data");
+        test.assert_completions_do_not_include("not-a-submodule");
+    }
+
+    #[test]
+    fn from_import_with_vendored_submodule1() {
+        let test = cursor_test(
+            "\
+from http import <CURSOR>
+",
+        );
+        test.assert_completions_include("client");
+    }
+
+    #[test]
+    fn from_import_with_vendored_submodule2() {
+        let test = cursor_test(
+            "\
+from email import <CURSOR>
+",
+        );
+        test.assert_completions_include("mime");
+        test.assert_completions_do_not_include("base");
+    }
+
+    #[test]
     fn import_submodule_not_attribute1() {
         let test = cursor_test(
             "\

--- a/crates/ty_python_semantic/src/module_resolver/module.rs
+++ b/crates/ty_python_semantic/src/module_resolver/module.rs
@@ -3,9 +3,13 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use ruff_db::files::File;
+use ruff_python_ast::name::Name;
+use ruff_python_stdlib::identifiers::is_identifier;
 
 use super::path::SearchPath;
+use crate::Db;
 use crate::module_name::ModuleName;
+use crate::module_resolver::path::SystemOrVendoredPathRef;
 
 /// Representation of a Python module.
 #[derive(Clone, PartialEq, Eq, Hash, get_size2::GetSize)]
@@ -84,6 +88,100 @@ impl Module {
             ModuleInner::FileModule { kind, .. } => *kind,
             ModuleInner::NamespacePackage { .. } => ModuleKind::Package,
         }
+    }
+
+    /// Return a list of all submodules of this module.
+    ///
+    /// Returns an empty list if the module is not a package, if it is an empty package,
+    /// or if it is a namespace package (one without an `__init__.py` or `__init__.pyi` file).
+    ///
+    /// The names returned correspond to the "base" name of the module.
+    /// That is, `{self.name}.{basename}` should give the full module name.
+    pub fn all_submodules(&self, db: &dyn Db) -> Vec<Name> {
+        self.all_submodules_inner(db).unwrap_or_default()
+    }
+
+    fn all_submodules_inner(&self, db: &dyn Db) -> Option<Vec<Name>> {
+        fn is_submodule(
+            is_dir: bool,
+            is_file: bool,
+            basename: Option<&str>,
+            extension: Option<&str>,
+        ) -> bool {
+            is_dir
+                || (is_file
+                    && matches!(extension, Some("py" | "pyi"))
+                    && !matches!(basename, Some("__init__.py" | "__init__.pyi")))
+        }
+
+        // It would be complex and expensive to compute all submodules for
+        // namespace packages, since a namespace package doesn't correspond
+        // to a single file; it can span multiple directories across multiple
+        // search paths. For now, we only compute submodules for traditional
+        // packages that exist in a single directory on a single search path.
+        let ModuleInner::FileModule {
+            kind: ModuleKind::Package,
+            file,
+            ..
+        } = &*self.inner
+        else {
+            return None;
+        };
+
+        let path = SystemOrVendoredPathRef::try_from_file(db, *file)?;
+        debug_assert!(
+            matches!(path.file_name(), Some("__init__.py" | "__init__.pyi")),
+            "expected package file `{:?}` to be `__init__.py` or `__init__.pyi`",
+            path.file_name(),
+        );
+
+        Some(match path.parent()? {
+            SystemOrVendoredPathRef::System(parent_directory) => db
+                .system()
+                .read_directory(parent_directory)
+                .inspect_err(|err| {
+                    tracing::debug!(
+                        "Failed to read {parent_directory:?} when looking for \
+                         its possible submodules: {err}"
+                    );
+                })
+                .ok()?
+                .flatten()
+                .filter(|entry| {
+                    let ty = entry.file_type();
+                    let path = entry.path();
+                    is_submodule(
+                        ty.is_directory(),
+                        ty.is_file(),
+                        path.file_name(),
+                        path.extension(),
+                    )
+                })
+                .filter_map(|entry| {
+                    let stem = entry.path().file_stem()?;
+                    is_identifier(stem).then(|| Name::from(stem))
+                })
+                .collect(),
+            SystemOrVendoredPathRef::Vendored(parent_directory) => db
+                .vendored()
+                .read_directory(parent_directory)
+                .into_iter()
+                .filter(|entry| {
+                    let ty = entry.file_type();
+                    let path = entry.path();
+                    is_submodule(
+                        ty.is_directory(),
+                        ty.is_file(),
+                        path.file_name(),
+                        path.extension(),
+                    )
+                })
+                .filter_map(|entry| {
+                    let stem = entry.path().file_stem()?;
+                    is_identifier(stem).then(|| Name::from(stem))
+                })
+                .collect(),
+        })
     }
 }
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -47,7 +47,7 @@ use crate::types::generics::{
     walk_partial_specialization, walk_specialization,
 };
 pub use crate::types::ide_support::{
-    CallSignatureDetails, all_members, call_signature_details, definition_kind_for_name,
+    CallSignatureDetails, Member, all_members, call_signature_details, definition_kind_for_name,
 };
 use crate::types::infer::infer_unpack_types;
 use crate::types::mro::{Mro, MroError, MroIterator};

--- a/crates/ty_server/src/server/api/requests/completion.rs
+++ b/crates/ty_server/src/server/api/requests/completion.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::time::Instant;
 
 use lsp_types::request::Completion;
 use lsp_types::{CompletionItem, CompletionItemKind, CompletionParams, CompletionResponse, Url};
@@ -31,6 +32,8 @@ impl BackgroundDocumentRequestHandler for CompletionRequestHandler {
         _client: &Client,
         params: CompletionParams,
     ) -> crate::server::Result<Option<CompletionResponse>> {
+        let start = Instant::now();
+
         if snapshot.client_settings().is_language_services_disabled() {
             return Ok(None);
         }
@@ -66,7 +69,12 @@ impl BackgroundDocumentRequestHandler for CompletionRequestHandler {
                 }
             })
             .collect();
+        let len = items.len();
         let response = CompletionResponse::Array(items);
+        tracing::debug!(
+            "Completions request returned {len} suggestions in {elapsed:?}",
+            elapsed = Instant::now().duration_since(start)
+        );
         Ok(Some(response))
     }
 }


### PR DESCRIPTION
While we did previously support submodule completions via our
`all_members` API, that only works when submodules are attributes of
their parent module. For example, `os.path`. But that didn't work when
the submodule was not an attribute of its parent. For example,
`http.client`. To make the latter work, we read the directory of the
parent module to discover its submodules.

Kudos to @AlexWaygood who started this patch. :-)

Note that this doesn't currently do any caching.
