### PR TITLE
[ty] Function argument inlay hints

### DIFF
--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -418,7 +418,7 @@ impl<'db> Signature<'db> {
     }
 
     /// Return the parameters in this signature.
-    pub(crate) fn parameters(&self) -> &Parameters<'db> {
+    pub fn parameters(&self) -> &Parameters<'db> {
         &self.parameters
     }
 
@@ -902,7 +902,7 @@ impl<'db> Signature<'db> {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]
-pub(crate) struct Parameters<'db> {
+pub struct Parameters<'db> {
     // TODO: use SmallVec here once invariance bug is fixed
     value: Vec<Parameter<'db>>,
 
@@ -1133,7 +1133,7 @@ impl<'db> Parameters<'db> {
     /// For a valid signature, this will be all positional parameters. In an invalid signature,
     /// there could be non-initial positional parameters; effectively, we just won't consider those
     /// to be positional, which is fine.
-    pub(crate) fn positional(&self) -> impl Iterator<Item = &Parameter<'db>> {
+    pub fn positional(&self) -> impl Iterator<Item = &Parameter<'db>> {
         self.iter().take_while(|param| param.is_positional())
     }
 
@@ -1201,7 +1201,7 @@ impl<'db> std::ops::Index<usize> for Parameters<'db> {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]
-pub(crate) struct Parameter<'db> {
+pub struct Parameter<'db> {
     /// Annotated type of the parameter.
     annotated_type: Option<Type<'db>>,
 
@@ -1378,28 +1378,28 @@ impl<'db> Parameter<'db> {
     }
 
     /// Returns `true` if this is a keyword-only parameter.
-    pub(crate) fn is_keyword_only(&self) -> bool {
+    pub fn is_keyword_only(&self) -> bool {
         matches!(self.kind, ParameterKind::KeywordOnly { .. })
     }
 
     /// Returns `true` if this is a positional-only parameter.
-    pub(crate) fn is_positional_only(&self) -> bool {
+    pub fn is_positional_only(&self) -> bool {
         matches!(self.kind, ParameterKind::PositionalOnly { .. })
     }
 
     /// Returns `true` if this is a variadic parameter.
-    pub(crate) fn is_variadic(&self) -> bool {
+    pub fn is_variadic(&self) -> bool {
         matches!(self.kind, ParameterKind::Variadic { .. })
     }
 
     /// Returns `true` if this is a keyword-variadic parameter.
-    pub(crate) fn is_keyword_variadic(&self) -> bool {
+    pub fn is_keyword_variadic(&self) -> bool {
         matches!(self.kind, ParameterKind::KeywordVariadic { .. })
     }
 
     /// Returns `true` if this is either a positional-only or standard (positional or keyword)
     /// parameter.
-    pub(crate) fn is_positional(&self) -> bool {
+    pub fn is_positional(&self) -> bool {
         matches!(
             self.kind,
             ParameterKind::PositionalOnly { .. } | ParameterKind::PositionalOrKeyword { .. }
@@ -1429,7 +1429,7 @@ impl<'db> Parameter<'db> {
     }
 
     /// Name of the parameter (if it has one).
-    pub(crate) fn name(&self) -> Option<&ast::name::Name> {
+    pub fn name(&self) -> Option<&ast::name::Name> {
         match &self.kind {
             ParameterKind::PositionalOnly { name, .. } => name.as_ref(),
             ParameterKind::PositionalOrKeyword { name, .. } => Some(name),

--- a/playground/package-lock.json
+++ b/playground/package-lock.json
@@ -6560,7 +6560,7 @@
         "ty_wasm": "file:ty_wasm"
       },
       "devDependencies": {
-        "vite-plugin-static-copy": "^3.1.0"
+        "vite-plugin-static-copy": "^3.0.0"
       }
     },
     "ty/ty_wasm": {


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

Add function argument inlay hints.

<img width="765" height="570" alt="image" src="https://github.com/user-attachments/assets/36a09289-ad37-4334-a028-5593d52722b8" />

As you can see for this I have made lots of visibility modifiers. I don't want to do this, but i have for an initial showcase of this feature.

If anyone can advise on a better solution (maybe some function inside the `ty_python_semantic` crate) that would be greatly appreciated.

## Test Plan

Add tests to `ty_ide/src/inlay_hints.rs`. 
