### PR TITLE
Use structs for JSON serialization

### DIFF
--- a/crates/ruff_db/src/diagnostic/mod.rs
+++ b/crates/ruff_db/src/diagnostic/mod.rs
@@ -432,8 +432,9 @@ impl Diagnostic {
     /// Returns the [`SourceFile`] which the message belongs to.
     ///
     /// Panics if the diagnostic has no primary span, or if its file is not a `SourceFile`.
-    pub fn expect_ruff_source_file(&self) -> SourceFile {
-        self.expect_primary_span().expect_ruff_file().clone()
+    pub fn expect_ruff_source_file(&self) -> &SourceFile {
+        self.ruff_source_file()
+            .expect("Expected a ruff source file")
     }
 
     /// Returns the [`TextRange`] for the diagnostic.

--- a/crates/ruff_db/src/diagnostic/mod.rs
+++ b/crates/ruff_db/src/diagnostic/mod.rs
@@ -432,9 +432,8 @@ impl Diagnostic {
     /// Returns the [`SourceFile`] which the message belongs to.
     ///
     /// Panics if the diagnostic has no primary span, or if its file is not a `SourceFile`.
-    pub fn expect_ruff_source_file(&self) -> &SourceFile {
-        self.ruff_source_file()
-            .expect("Expected a ruff source file")
+    pub fn expect_ruff_source_file(&self) -> SourceFile {
+        self.expect_primary_span().expect_ruff_file().clone()
     }
 
     /// Returns the [`TextRange`] for the diagnostic.

--- a/crates/ruff_linter/src/message/diff.rs
+++ b/crates/ruff_linter/src/message/diff.rs
@@ -21,7 +21,7 @@ use crate::{Applicability, Fix};
 /// * Compute the diff from the [`Edit`] because diff calculation is expensive.
 pub(super) struct Diff<'a> {
     fix: &'a Fix,
-    source_code: SourceFile,
+    source_code: &'a SourceFile,
 }
 
 impl<'a> Diff<'a> {

--- a/crates/ruff_linter/src/message/diff.rs
+++ b/crates/ruff_linter/src/message/diff.rs
@@ -21,7 +21,7 @@ use crate::{Applicability, Fix};
 /// * Compute the diff from the [`Edit`] because diff calculation is expensive.
 pub(super) struct Diff<'a> {
     fix: &'a Fix,
-    source_code: &'a SourceFile,
+    source_code: SourceFile,
 }
 
 impl<'a> Diff<'a> {

--- a/crates/ruff_linter/src/message/json.rs
+++ b/crates/ruff_linter/src/message/json.rs
@@ -1,8 +1,7 @@
 use std::io::Write;
 
 use ruff_diagnostics::Applicability;
-use serde::ser::SerializeSeq;
-use serde::{Serialize, Serializer};
+use serde::Serialize;
 
 use ruff_db::diagnostic::{Diagnostic, SecondaryCode};
 use ruff_notebook::NotebookIndex;
@@ -24,34 +23,13 @@ impl Emitter for JsonEmitter {
     ) -> anyhow::Result<()> {
         serde_json::to_writer_pretty(
             writer,
-            &ExpandedMessages {
-                diagnostics,
-                context,
-            },
+            &diagnostics
+                .iter()
+                .map(|diag| message_to_json_value(diag, context))
+                .collect::<Vec<_>>(),
         )?;
 
         Ok(())
-    }
-}
-
-struct ExpandedMessages<'a> {
-    diagnostics: &'a [Diagnostic],
-    context: &'a EmitterContext<'a>,
-}
-
-impl Serialize for ExpandedMessages<'_> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut s = serializer.serialize_seq(Some(self.diagnostics.len()))?;
-
-        for message in self.diagnostics {
-            let value = message_to_json_value(message, self.context);
-            s.serialize_element(&value)?;
-        }
-
-        s.end()
     }
 }
 
@@ -63,6 +41,16 @@ pub(crate) fn message_to_json_value<'a>(
     let source_code = source_file.to_source_code();
     let filename = message.expect_ruff_filename();
     let notebook_index = context.notebook_index(&filename);
+
+    let fix = message.fix().map(|fix| JsonFix {
+        applicability: fix.applicability(),
+        message: message.suggestion(),
+        edits: fix
+            .edits()
+            .iter()
+            .map(|edit| JsonEdit::from_edit(edit, &source_code, notebook_index))
+            .collect::<Vec<_>>(),
+    });
 
     let mut start_location = source_code.line_column(message.expect_range().start());
     let mut end_location = source_code.line_column(message.expect_range().end());
@@ -83,16 +71,6 @@ pub(crate) fn message_to_json_value<'a>(
             noqa_location.map(|location| notebook_index.translate_line_column(&location));
     }
 
-    let fix = message.fix().map(|fix| JsonFix {
-        applicability: fix.applicability(),
-        message: message.suggestion(),
-        edits: ExpandedEdits {
-            edits: fix.edits(),
-            source_code,
-            notebook_index,
-        },
-    });
-
     JsonDiagnostic {
         code: message.secondary_code(),
         url: message.to_url(),
@@ -103,80 +81,6 @@ pub(crate) fn message_to_json_value<'a>(
         end_location: end_location.into(),
         filename,
         noqa_row: noqa_location.map(|location| location.line),
-    }
-}
-
-struct ExpandedEdits<'a> {
-    edits: &'a [Edit],
-    source_code: SourceCode<'a, 'a>,
-    notebook_index: Option<&'a NotebookIndex>,
-}
-
-impl Serialize for ExpandedEdits<'_> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut s = serializer.serialize_seq(Some(self.edits.len()))?;
-
-        for edit in self.edits {
-            let mut location = self.source_code.line_column(edit.start());
-            let mut end_location = self.source_code.line_column(edit.end());
-
-            if let Some(notebook_index) = self.notebook_index {
-                // There exists a newline between each cell's source code in the
-                // concatenated source code in Ruff. This newline doesn't actually
-                // exists in the JSON source field.
-                //
-                // Now, certain edits may try to remove this newline, which means
-                // the edit will spill over to the first character of the next cell.
-                // If it does, we need to translate the end location to the last
-                // character of the previous cell.
-                match (
-                    notebook_index.cell(location.line),
-                    notebook_index.cell(end_location.line),
-                ) {
-                    (Some(start_cell), Some(end_cell)) if start_cell != end_cell => {
-                        debug_assert_eq!(end_location.column.get(), 1);
-
-                        let prev_row = end_location.line.saturating_sub(1);
-                        end_location = LineColumn {
-                            line: notebook_index.cell_row(prev_row).unwrap_or(OneIndexed::MIN),
-                            column: self
-                                .source_code
-                                .line_column(self.source_code.line_end_exclusive(prev_row))
-                                .column,
-                        };
-                    }
-                    (Some(_), None) => {
-                        debug_assert_eq!(end_location.column.get(), 1);
-
-                        let prev_row = end_location.line.saturating_sub(1);
-                        end_location = LineColumn {
-                            line: notebook_index.cell_row(prev_row).unwrap_or(OneIndexed::MIN),
-                            column: self
-                                .source_code
-                                .line_column(self.source_code.line_end_exclusive(prev_row))
-                                .column,
-                        };
-                    }
-                    _ => {
-                        end_location = notebook_index.translate_line_column(&end_location);
-                    }
-                }
-                location = notebook_index.translate_line_column(&location);
-            }
-
-            let value = JsonEdit {
-                content: edit.content().unwrap_or_default(),
-                location: location.into(),
-                end_location: end_location.into(),
-            };
-
-            s.serialize_element(&value)?;
-        }
-
-        s.end()
     }
 }
 
@@ -196,7 +100,7 @@ pub(crate) struct JsonDiagnostic<'a> {
 #[derive(Serialize)]
 struct JsonFix<'a> {
     applicability: Applicability,
-    edits: ExpandedEdits<'a>,
+    edits: Vec<JsonEdit<'a>>,
     message: Option<&'a str>,
 }
 
@@ -220,6 +124,65 @@ struct JsonEdit<'a> {
     content: &'a str,
     end_location: JsonLocation,
     location: JsonLocation,
+}
+
+impl<'a> JsonEdit<'a> {
+    fn from_edit(
+        edit: &'a Edit,
+        source_code: &SourceCode,
+        notebook_index: Option<&'a NotebookIndex>,
+    ) -> JsonEdit<'a> {
+        let mut location = source_code.line_column(edit.start());
+        let mut end_location = source_code.line_column(edit.end());
+
+        if let Some(notebook_index) = notebook_index {
+            // There exists a newline between each cell's source code in the
+            // concatenated source code in Ruff. This newline doesn't actually
+            // exists in the JSON source field.
+            //
+            // Now, certain edits may try to remove this newline, which means
+            // the edit will spill over to the first character of the next cell.
+            // If it does, we need to translate the end location to the last
+            // character of the previous cell.
+            match (
+                notebook_index.cell(location.line),
+                notebook_index.cell(end_location.line),
+            ) {
+                (Some(start_cell), Some(end_cell)) if start_cell != end_cell => {
+                    debug_assert_eq!(end_location.column.get(), 1);
+
+                    let prev_row = end_location.line.saturating_sub(1);
+                    end_location = LineColumn {
+                        line: notebook_index.cell_row(prev_row).unwrap_or(OneIndexed::MIN),
+                        column: source_code
+                            .line_column(source_code.line_end_exclusive(prev_row))
+                            .column,
+                    };
+                }
+                (Some(_), None) => {
+                    debug_assert_eq!(end_location.column.get(), 1);
+
+                    let prev_row = end_location.line.saturating_sub(1);
+                    end_location = LineColumn {
+                        line: notebook_index.cell_row(prev_row).unwrap_or(OneIndexed::MIN),
+                        column: source_code
+                            .line_column(source_code.line_end_exclusive(prev_row))
+                            .column,
+                    };
+                }
+                _ => {
+                    end_location = notebook_index.translate_line_column(&end_location);
+                }
+            }
+            location = notebook_index.translate_line_column(&location);
+        }
+
+        JsonEdit {
+            content: edit.content().unwrap_or_default(),
+            location: location.into(),
+            end_location: end_location.into(),
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

See https://github.com/astral-sh/ruff/pull/19133#discussion_r2198413586 for recent discussion. This PR moves to using structs for the types in our JSON output format instead of the `json!` macro.

I didn't rename any of the `message` references because that should be handled when rebasing #19133 onto this.

My plan for handling the `preview` behavior with the new diagnostics is to use a wrapper enum. Something like:

```rust
#[derive(Serialize)]
#[serde(untagged)]
pub(crate) enum JsonDiagnostic<'a> {
    Old(OldJsonDiagnostic<'a>),
}

#[derive(Serialize)]
pub(crate) struct OldJsonDiagnostic<'a> {
    // ...
}
```

Initially I thought I could use a `&dyn Serialize` for the affected fields, but I see that `Serialize` isn't dyn-compatible in testing this now.

## Test Plan

Existing tests. One quirk of the new types is that their fields are in alphabetical order. I guess `json!` sorts the fields alphabetically? The tests were failing before I sorted the struct fields.

## Other formats

It looks like the `rdjson`, `sarif`, and `gitlab` formats also use `json!`, so if we decide to merge this, I can do something similar for those before moving them to the new diagnostic format.
