### PR TITLE
[`pylint`] Make example error out-of-the-box (`PLE2502`)

### DIFF
--- a/crates/ruff_linter/src/rules/pylint/rules/bidirectional_unicode.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/bidirectional_unicode.rs
@@ -47,7 +47,7 @@ const BIDI_UNICODE: [char; 10] = [
 /// ```
 ///
 /// ## References
-/// - [PEP 672: Bidirectional Text](https://peps.python.org/pep-0672/#bidirectional-marks-embeddings-overrides-and-isolates)
+/// - [PEP 672: Bidirectional Marks, Embeddings, Overrides and Isolates](https://peps.python.org/pep-0672/#bidirectional-marks-embeddings-overrides-and-isolates)
 #[derive(ViolationMetadata)]
 pub(crate) struct BidirectionalUnicode;
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Part of #18972
Fixes #14346

This PR makes [bidirectional-unicode (PLE2502)](https://docs.astral.sh/ruff/rules/bidirectional-unicode/#bidirectional-unicode-ple2502)'s example error out-of-the-box, by converting it to use one of the test cases. The documentation in general is also updated to replace "bidirectional unicode character" with "bidirectional formatting character", as those are the only ones checked for, and the "unicode" suffix is redundant. The new example section looks like this:
<img width="1074" height="264" alt="image" src="https://github.com/user-attachments/assets/cc1d2cb4-b590-4f20-a4d2-15b744872cdd" />

The "References" section link is also updated to reflect the rule's actual behavior.

## Test Plan

<!-- How was it tested? -->

N/A, no functionality/tests affected