### PR TITLE
[ty] Avoid stale diagnostics for open files diagnostic mode

### DIFF
--- a/crates/ty_server/src/session.rs
+++ b/crates/ty_server/src/session.rs
@@ -16,7 +16,7 @@ use ty_project::{ProjectDatabase, ProjectMetadata};
 
 pub(crate) use self::capabilities::ResolvedClientCapabilities;
 pub use self::index::DocumentQuery;
-pub(crate) use self::options::{AllOptions, ClientOptions};
+pub(crate) use self::options::{AllOptions, ClientOptions, DiagnosticMode};
 pub(crate) use self::settings::ClientSettings;
 use crate::document::{DocumentKey, DocumentVersion, NotebookDocument};
 use crate::session::request_queue::RequestQueue;

--- a/crates/ty_server/src/session/options.rs
+++ b/crates/ty_server/src/session/options.rs
@@ -25,6 +25,10 @@ impl GlobalOptions {
     pub(crate) fn into_settings(self) -> ClientSettings {
         self.client.into_settings()
     }
+
+    pub(crate) fn diagnostic_mode(&self) -> DiagnosticMode {
+        self.client.diagnostic_mode.unwrap_or_default()
+    }
 }
 
 /// This is a direct representation of the workspace settings schema, which inherits the schema of


### PR DESCRIPTION
## Summary

This PR fixes a bug where in `openFilesOnly` diagnostic mode, VS Code wouldn't clean up the diagnostics even though the server asked it to by sending an empty publish diagnostics.

This is not the long-term solution but a quick fix. Ideally, the server would dynamically register for workspace diagnostics but that requires listening for `didChangeConfiguration` notification which I'm going to be working on with https://github.com/astral-sh/ty/issues/82.

## Test Plan

### Before

This uses the latest stable version of ty.

https://github.com/user-attachments/assets/0cc6c513-ccad-4955-a1b6-a0ee242119d6

### After

This uses the debug build of ty from this PR.

https://github.com/user-attachments/assets/e539d569-d852-46a9-bbfc-d54375127c62


