### PR TITLE
Filter `ruff_linter::VERSION` out of SARIF output tests

### DIFF
--- a/crates/ruff/tests/lint.rs
+++ b/crates/ruff/tests/lint.rs
@@ -5723,6 +5723,7 @@ match 42:  # invalid-syntax
         filters => vec![
             (tempdir_filter(&tempdir).as_str(), "[TMP]/"),
             (r#""[^"]+\\?/?input.py"#, r#""[TMP]/input.py"#),
+            (ruff_linter::VERSION, "[VERSION]"),
         ]
     }, {
         assert_cmd_snapshot!(

--- a/crates/ruff/tests/snapshots/lint__output_format_sarif.snap
+++ b/crates/ruff/tests/snapshots/lint__output_format_sarif.snap
@@ -132,7 +132,7 @@ exit_code: 1
               }
             }
           ],
-          "version": "0.12.2"
+          "version": "[VERSION]"
         }
       }
     }


### PR DESCRIPTION
Summary
--

Fixes the test failures in #19279. This is the same variable used to construct the SARIF output:

https://github.com/astral-sh/ruff/blob/350d563c883cae8c16f376946ae5f2d0fc111e3b/crates/ruff_linter/src/message/sarif.rs#L39-L44

Test Plan
--

Existing tests with the modified filter
