### PR TITLE
[ty] Fix server version

### DIFF
--- a/crates/ruff/src/lib.rs
+++ b/crates/ruff/src/lib.rs
@@ -131,6 +131,7 @@ pub fn run(
     }: Args,
 ) -> Result<ExitStatus> {
     {
+        ruff_db::set_program_version(crate::version::version().to_string()).unwrap();
         let default_panic_hook = std::panic::take_hook();
         std::panic::set_hook(Box::new(move |info| {
             #[expect(clippy::print_stderr)]

--- a/crates/ruff_db/src/lib.rs
+++ b/crates/ruff_db/src/lib.rs
@@ -28,6 +28,21 @@ pub use web_time::{Instant, SystemTime, SystemTimeError};
 pub type FxDashMap<K, V> = dashmap::DashMap<K, V, BuildHasherDefault<FxHasher>>;
 pub type FxDashSet<K> = dashmap::DashSet<K, BuildHasherDefault<FxHasher>>;
 
+static VERSION: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+
+/// Returns the version of the executing program if set.
+pub fn program_version() -> Option<&'static str> {
+    VERSION.get().map(|version| version.as_str())
+}
+
+/// Sets the version of the executing program.
+///
+/// ## Errors
+/// If the version has already been initialized (can only be set once).
+pub fn set_program_version(version: String) -> Result<(), String> {
+    VERSION.set(version)
+}
+
 /// Most basic database that gives access to files, the host system, source code, and parsed AST.
 #[salsa::db]
 pub trait Db: salsa::Database {

--- a/crates/ty/src/lib.rs
+++ b/crates/ty/src/lib.rs
@@ -33,6 +33,7 @@ use ty_server::run_server;
 
 pub fn run() -> anyhow::Result<ExitStatus> {
     setup_rayon();
+    ruff_db::set_program_version(crate::version::version().to_string()).unwrap();
 
     let args = wild::args_os();
     let args = argfile::expand_args_from(args, argfile::parse_fromfile, argfile::PREFIX)

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -667,6 +667,13 @@ where
                     arch = std::env::consts::ARCH
                 ),
             ));
+            if let Some(version) = ruff_db::program_version() {
+                diagnostic.sub(SubDiagnostic::new(
+                    Severity::Info,
+                    format!("Version: {version}"),
+                ));
+            }
+
             diagnostic.sub(SubDiagnostic::new(
                 Severity::Info,
                 format!(

--- a/crates/ty_server/src/lib.rs
+++ b/crates/ty_server/src/lib.rs
@@ -17,10 +17,6 @@ pub(crate) const DIAGNOSTIC_NAME: &str = "ty";
 /// result type is needed.
 pub(crate) type Result<T> = anyhow::Result<T>;
 
-pub(crate) fn version() -> &'static str {
-    env!("CARGO_PKG_VERSION")
-}
-
 pub fn run_server() -> anyhow::Result<()> {
     let four = NonZeroUsize::new(4).unwrap();
 

--- a/crates/ty_server/src/server.rs
+++ b/crates/ty_server/src/server.rs
@@ -56,12 +56,10 @@ impl Server {
         let position_encoding = Self::find_best_position_encoding(&client_capabilities);
         let server_capabilities = Self::server_capabilities(position_encoding);
 
-        let connection = connection.initialize_finish(
-            id,
-            &server_capabilities,
-            crate::SERVER_NAME,
-            crate::version(),
-        )?;
+        let version = ruff_db::program_version().unwrap_or("Unknown");
+
+        let connection =
+            connection.initialize_finish(id, &server_capabilities, crate::SERVER_NAME, version)?;
 
         // The number 32 was chosen arbitrarily. The main goal was to have enough capacity to queue
         // some responses before blocking.
@@ -72,6 +70,8 @@ impl Server {
             global_options.tracing.log_level.unwrap_or_default(),
             global_options.tracing.log_file.as_deref(),
         );
+
+        tracing::debug!("Version: {version}");
 
         let mut workspace_for_url = |url: Url| {
             let Some(workspace_settings) = workspace_options.as_mut() else {

--- a/crates/ty_wasm/src/lib.rs
+++ b/crates/ty_wasm/src/lib.rs
@@ -36,6 +36,8 @@ pub fn version() -> String {
 pub fn run() {
     use log::Level;
 
+    ruff_db::set_program_version(version()).unwrap();
+
     // When the `console_error_panic_hook` feature is enabled, we can call the
     // `set_panic_hook` function at least once during initialization, and then
     // we will get better error messages if our code ever panics.


### PR DESCRIPTION
## Summary
Closes https://github.com/astral-sh/ty/issues/814

cargo-dist only sets the version of the ty crate. That means, the `CARGO_PKG_VERSION` is always 0.0.0 for the ty_server. 

This PR works around this by adding the `program_version` to `ruff_db` which gets initialized by the ty crate (where the version is correct)
and the server can read from. This has the nice side effect that the same version can be used in the type checking panic handler (in `ty_project`). 

An alternative would have been to pass the version to `ty_server` but we then couldn't use it in the catch handler in `ty_project`. 

I made some changes to ty's build script to take the commit from the ruff repository when not built inside the ty repository. 
This gives us at least some meaningful version identifier for debug builds.

## Test Plan

Version in `initialize` response:

```
    "serverInfo": {
        "name": "ty",
        "version": "ruff/0.12.2+87 (426fa4bb1 2025-07-11)"
    }
```

Version logged during startup

```
2025-07-11 15:19:23.122004000 DEBUG Version: ruff/0.12.2+87 (426fa4bb1 2025-07-11)
2025-07-11 15:19:23.127378000  INFO Defaulting to python-platform `darwin`
2025-07-11 15:19:23.127599000 DEBUG Discovering virtual environment in `/Users/micha/astral/test`
```

Version in panic handler


```
error[panic]: Panicked at crates/ty_python_semantic/src/types.rs:97:5 when checking `/Users/micha/astral/test/create.py`: `Test`
info: This indicates a bug in ty.
info: If you could open an issue at https://github.com/astral-sh/ty/issues/new?title=%5Bpanic%5D, we'd be very appreciative!
info: Platform: macos aarch64
info: Args: ["target/debug/ty", "check", "../test/create.py"]
info: Version: ruff/0.12.2+88 (0f58920fc 2025-07-11)
info: run with `RUST_BACKTRACE=1` environment variable to show the full backtrace information
info: query stacktrace:
   0: check_file_impl(Id(c00))
             at crates/ty_project/src/lib.rs:474
```