### PR TITLE
[`pylint`] Make example error out-of-the-box (`PLE1507`)

### DIFF
--- a/crates/ruff_linter/src/rules/pylint/rules/invalid_envvar_value.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/invalid_envvar_value.rs
@@ -18,11 +18,15 @@ use crate::checkers::ast::Checker;
 ///
 /// ## Example
 /// ```python
+/// import os
+///
 /// os.getenv(1)
 /// ```
 ///
 /// Use instead:
 /// ```python
+/// import os
+///
 /// os.getenv("1")
 /// ```
 #[derive(ViolationMetadata)]


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Part of #18972

This PR makes [invalid-envvar-value (PLE1507)](https://docs.astral.sh/ruff/rules/invalid-envvar-value/#invalid-envvar-value-ple1507)'s example error out-of-the-box.

[Old example](https://play.ruff.rs/a46a9bca-edd5-4474-b20d-e6b6d87291ca)
```py
os.getenv(1)
```

[New example](https://play.ruff.rs/8348d32d-71fa-422c-b228-e2bc343765b1)
```py
import os

os.getenv(1)
```

The "Use instead" section was also updated similarly.

## Test Plan

<!-- How was it tested? -->

N/A, no functionality/tests affected