### PR TITLE
[ty] Extend tuple `__len__` and `__bool__` special casing to also cover tuple subclasses

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/expression/boolean.md
+++ b/crates/ty_python_semantic/resources/mdtest/expression/boolean.md
@@ -81,6 +81,11 @@ reveal_type(bool(True))  # revealed: Literal[True]
 def foo(): ...
 
 reveal_type(bool(foo))  # revealed: Literal[True]
+
+class Foo(tuple[int]): ...
+reveal_type(bool(Foo((0,))))  # revealed: Literal[True]
+reveal_type(Foo.__bool__)  # revealed: (self: tuple[int], /) -> Literal[True]
+reveal_type(Foo().__bool__)  # revealed: () -> Literal[True]
 ```
 
 ## Falsy values
@@ -92,6 +97,11 @@ reveal_type(bool(None))  # revealed: Literal[False]
 reveal_type(bool(""))  # revealed: Literal[False]
 reveal_type(bool(False))  # revealed: Literal[False]
 reveal_type(bool())  # revealed: Literal[False]
+
+class Foo(tuple[()]): ...
+reveal_type(bool(Foo()))  # revealed: Literal[False]
+reveal_type(Foo.__bool__)  # revealed: (self: tuple[()], /) -> Literal[False]
+reveal_type(Foo().__bool__)  # revealed: () -> Literal[False]
 ```
 
 ## Ambiguous values

--- a/crates/ty_python_semantic/resources/mdtest/expression/len.md
+++ b/crates/ty_python_semantic/resources/mdtest/expression/len.md
@@ -76,8 +76,13 @@ reveal_type(len(A()))  # revealed: Literal[0]
 reveal_type(len(B((1,))))  # revealed: Literal[1]
 reveal_type(len(C((1, "foo"))))  # revealed: Literal[2]
 
-reveal_type(A.__len__)  # revealed: Callable[[A], Literal[2]]
-reveal_type(A().__len__)  # revealed: Callable[[], Literal[2]]
+reveal_type(tuple[int, int].__len__)  # revealed: (self: tuple[int, int], /) -> Literal[2]
+
+def f(x: tuple[int, int]):
+    reveal_type(x.__len__)  # revealed: () -> Literal[2]
+
+reveal_type(A.__len__)  # revealed: (self: tuple[()], /) -> Literal[0]
+reveal_type(A().__len__)  # revealed: () -> Literal[0]
 ```
 
 ### Lists, sets and dictionaries

--- a/crates/ty_python_semantic/resources/mdtest/expression/len.md
+++ b/crates/ty_python_semantic/resources/mdtest/expression/len.md
@@ -65,6 +65,21 @@ reveal_type(len((*[], 1, 2)))  # revealed: Literal[3]
 reveal_type(len((*[], *{})))  # revealed: Literal[2]
 ```
 
+Tuple subclasses:
+
+```py
+class A(tuple[()]): ...
+class B(tuple[int]): ...
+class C(tuple[int, str]): ...
+
+reveal_type(len(A()))  # revealed: Literal[0]
+reveal_type(len(B((1,))))  # revealed: Literal[1]
+reveal_type(len(C((1, "foo"))))  # revealed: Literal[2]
+
+reveal_type(A.__len__)  # revealed: Callable[[A], Literal[2]]
+reveal_type(A().__len__)  # revealed: Callable[[], Literal[2]]
+```
+
 ### Lists, sets and dictionaries
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
@@ -536,6 +536,11 @@ static_assert(is_subtype_of(Never, AlwaysFalsy))
 
 ### `AlwaysTruthy` and `AlwaysFalsy`
 
+```toml
+[environment]
+python-version = "3.11"
+```
+
 ```py
 from ty_extensions import AlwaysTruthy, AlwaysFalsy, Intersection, Not, is_subtype_of, static_assert
 from typing_extensions import Literal, LiteralString
@@ -573,6 +578,26 @@ static_assert(is_subtype_of(Intersection[LiteralString, Not[Literal["", "a"]]], 
 static_assert(is_subtype_of(Intersection[LiteralString, Not[Literal[""]]], Not[AlwaysFalsy]))
 # error: [static-assert-error]
 static_assert(is_subtype_of(Intersection[LiteralString, Not[Literal["", "a"]]], Not[AlwaysFalsy]))
+
+class Foo(tuple[int, str]): ...
+static_assert(is_subtype_of(Foo, AlwaysTruthy))
+
+class Bar(tuple[()]): ...
+static_assert(is_subtype_of(Bar, AlwaysFalsy))
+
+class Baz(tuple[int, *tuple[str, ...], bytes]): ...
+static_assert(is_subtype_of(Baz, AlwaysTruthy))
+
+class UnknownLength(tuple[int, ...]): ...
+static_assert(not is_subtype_of(UnknownLength, AlwaysTruthy))
+static_assert(not is_subtype_of(UnknownLength, AlwaysFalsy))
+
+class Invalid(tuple[int, str]):
+    # TODO: we should emit an error here (Liskov violation)
+    def __bool__(self) -> Literal[False]:
+        return False
+
+static_assert(is_subtype_of(Invalid, AlwaysFalsy))
 ```
 
 ### `TypeGuard` and `TypeIs`

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3465,6 +3465,11 @@ impl<'db> Type<'db> {
         let usize_len = match self {
             Type::BytesLiteral(bytes) => Some(bytes.python_len(db)),
             Type::StringLiteral(string) => Some(string.python_len(db)),
+
+            // N.B. This is strictly-speaking redundant, since the `__len__` method on tuples
+            // is special-cased in `ClassType::own_class_member`. However, it's probably more
+            // efficient to short-circuit here and check against the tuple spec directly,
+            // rather than going through the `__len__` method.
             Type::Tuple(tuple) => match tuple.tuple(db) {
                 TupleSpec::Fixed(tuple) => Some(tuple.len()),
                 TupleSpec::Variable(_) => None,

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -53,7 +53,7 @@ use crate::types::infer::infer_unpack_types;
 use crate::types::mro::{Mro, MroError, MroIterator};
 pub(crate) use crate::types::narrow::infer_narrowing_constraint;
 use crate::types::signatures::{Parameter, ParameterForm, Parameters, walk_signature};
-use crate::types::tuple::{TupleSpec, TupleType};
+use crate::types::tuple::TupleType;
 pub use crate::util::diagnostics::add_inferred_python_version_hint_to_diagnostic;
 use crate::{Db, FxOrderSet, Module, Program};
 pub(crate) use class::{ClassLiteral, ClassType, GenericAlias, KnownClass};
@@ -3431,14 +3431,7 @@ impl<'db> Type<'db> {
             Type::BooleanLiteral(bool) => Truthiness::from(*bool),
             Type::StringLiteral(str) => Truthiness::from(!str.value(db).is_empty()),
             Type::BytesLiteral(bytes) => Truthiness::from(!bytes.value(db).is_empty()),
-            Type::Tuple(tuple) => match tuple.tuple(db).len().size_hint() {
-                // The tuple type is AlwaysFalse if it contains only the empty tuple
-                (_, Some(0)) => Truthiness::AlwaysFalse,
-                // The tuple type is AlwaysTrue if its inhabitants must always have length >=1
-                (minimum, _) if minimum > 0 => Truthiness::AlwaysTrue,
-                // The tuple type is Ambiguous if its inhabitants could be of any length
-                _ => Truthiness::Ambiguous,
-            },
+            Type::Tuple(tuple) => tuple.truthiness(db),
         };
 
         Ok(truthiness)
@@ -3470,10 +3463,7 @@ impl<'db> Type<'db> {
             // is special-cased in `ClassType::own_class_member`. However, it's probably more
             // efficient to short-circuit here and check against the tuple spec directly,
             // rather than going through the `__len__` method.
-            Type::Tuple(tuple) => match tuple.tuple(db) {
-                TupleSpec::Fixed(tuple) => Some(tuple.len()),
-                TupleSpec::Variable(_) => None,
-            },
+            Type::Tuple(tuple) => tuple.tuple(db).len().into_fixed_length(),
 
             _ => None,
         };

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -563,9 +563,26 @@ impl<'db> ClassType<'db> {
     /// traverse through the MRO until it finds the member.
     pub(super) fn own_class_member(self, db: &'db dyn Db, name: &str) -> PlaceAndQualifiers<'db> {
         let (class_literal, specialization) = self.class_literal(db);
-        class_literal
-            .own_class_member(db, specialization, name)
-            .map_type(|ty| ty.apply_optional_specialization(db, specialization))
+        if name == "__len__" && class_literal.is_known(db, KnownClass::Tuple) {
+            let parameters =
+                Parameters::new([Parameter::positional_only(Some(Name::new_static("self")))
+                    .with_annotated_type(Type::instance(db, self))]);
+
+            let return_type = specialization
+                .and_then(|spec| spec.tuple(db).len().into_fixed_length())
+                .and_then(|len| i64::try_from(len).ok())
+                .map(Type::IntLiteral)
+                .unwrap_or_else(|| KnownClass::Int.to_instance(db));
+
+            let synthesized_dunder_len =
+                CallableType::function_like(db, Signature::new(parameters, Some(return_type)));
+
+            Place::bound(synthesized_dunder_len).into()
+        } else {
+            class_literal
+                .own_class_member(db, specialization, name)
+                .map_type(|ty| ty.apply_optional_specialization(db, specialization))
+        }
     }
 
     /// Look up an instance attribute (available in `__dict__`) of the given name.

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -587,8 +587,16 @@ impl<'db> ClassType<'db> {
             }
             "__bool__" if class_literal.is_known(db, KnownClass::Tuple) => {
                 let return_type = specialization
-                    .and_then(|spec| spec.tuple(db).len().into_fixed_length())
-                    .map(|len| Type::BooleanLiteral(len != 0))
+                    .map(|spec| {
+                        let length = spec.tuple(db).len();
+                        if length.minimum() > 0 {
+                            Type::BooleanLiteral(true)
+                        } else if length.maximum() == Some(0) {
+                            Type::BooleanLiteral(false)
+                        } else {
+                            KnownClass::Bool.to_instance(db)
+                        }
+                    })
                     .unwrap_or_else(|| KnownClass::Bool.to_instance(db));
 
                 synthesize_tuple_method(return_type)

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -578,6 +578,20 @@ impl<'db> ClassType<'db> {
                 CallableType::function_like(db, Signature::new(parameters, Some(return_type)));
 
             Place::bound(synthesized_dunder_len).into()
+        } else if name == "__bool__" && class_literal.is_known(db, KnownClass::Tuple) {
+            let parameters =
+                Parameters::new([Parameter::positional_only(Some(Name::new_static("self")))
+                    .with_annotated_type(Type::instance(db, self))]);
+
+            let return_type = specialization
+                .and_then(|spec| spec.tuple(db).len().into_fixed_length())
+                .map(|len| Type::BooleanLiteral(len != 0))
+                .unwrap_or_else(|| KnownClass::Bool.to_instance(db));
+
+            let synthesized_dunder_bool =
+                CallableType::function_like(db, Signature::new(parameters, Some(return_type)));
+
+            Place::bound(synthesized_dunder_bool).into()
         } else {
             class_literal
                 .own_class_member(db, specialization, name)

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -587,16 +587,7 @@ impl<'db> ClassType<'db> {
             }
             "__bool__" if class_literal.is_known(db, KnownClass::Tuple) => {
                 let return_type = specialization
-                    .map(|spec| {
-                        let length = spec.tuple(db).len();
-                        if length.minimum() > 0 {
-                            Type::BooleanLiteral(true)
-                        } else if length.maximum() == Some(0) {
-                            Type::BooleanLiteral(false)
-                        } else {
-                            KnownClass::Bool.to_instance(db)
-                        }
-                    })
+                    .map(|spec| spec.tuple(db).truthiness().into_type(db))
                     .unwrap_or_else(|| KnownClass::Bool.to_instance(db));
 
                 synthesize_tuple_method(return_type)

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -563,39 +563,39 @@ impl<'db> ClassType<'db> {
     /// traverse through the MRO until it finds the member.
     pub(super) fn own_class_member(self, db: &'db dyn Db, name: &str) -> PlaceAndQualifiers<'db> {
         let (class_literal, specialization) = self.class_literal(db);
-        if name == "__len__" && class_literal.is_known(db, KnownClass::Tuple) {
+
+        let synthesize_tuple_method = |return_type| {
             let parameters =
                 Parameters::new([Parameter::positional_only(Some(Name::new_static("self")))
                     .with_annotated_type(Type::instance(db, self))]);
 
-            let return_type = specialization
-                .and_then(|spec| spec.tuple(db).len().into_fixed_length())
-                .and_then(|len| i64::try_from(len).ok())
-                .map(Type::IntLiteral)
-                .unwrap_or_else(|| KnownClass::Int.to_instance(db));
-
-            let synthesized_dunder_len =
+            let synthesized_dunder_method =
                 CallableType::function_like(db, Signature::new(parameters, Some(return_type)));
 
-            Place::bound(synthesized_dunder_len).into()
-        } else if name == "__bool__" && class_literal.is_known(db, KnownClass::Tuple) {
-            let parameters =
-                Parameters::new([Parameter::positional_only(Some(Name::new_static("self")))
-                    .with_annotated_type(Type::instance(db, self))]);
+            Place::bound(synthesized_dunder_method).into()
+        };
 
-            let return_type = specialization
-                .and_then(|spec| spec.tuple(db).len().into_fixed_length())
-                .map(|len| Type::BooleanLiteral(len != 0))
-                .unwrap_or_else(|| KnownClass::Bool.to_instance(db));
+        match name {
+            "__len__" if class_literal.is_known(db, KnownClass::Tuple) => {
+                let return_type = specialization
+                    .and_then(|spec| spec.tuple(db).len().into_fixed_length())
+                    .and_then(|len| i64::try_from(len).ok())
+                    .map(Type::IntLiteral)
+                    .unwrap_or_else(|| KnownClass::Int.to_instance(db));
 
-            let synthesized_dunder_bool =
-                CallableType::function_like(db, Signature::new(parameters, Some(return_type)));
+                synthesize_tuple_method(return_type)
+            }
+            "__bool__" if class_literal.is_known(db, KnownClass::Tuple) => {
+                let return_type = specialization
+                    .and_then(|spec| spec.tuple(db).len().into_fixed_length())
+                    .map(|len| Type::BooleanLiteral(len != 0))
+                    .unwrap_or_else(|| KnownClass::Bool.to_instance(db));
 
-            Place::bound(synthesized_dunder_bool).into()
-        } else {
-            class_literal
+                synthesize_tuple_method(return_type)
+            }
+            _ => class_literal
                 .own_class_member(db, specialization, name)
-                .map_type(|ty| ty.apply_optional_specialization(db, specialization))
+                .map_type(|ty| ty.apply_optional_specialization(db, specialization)),
         }
     }
 

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -76,6 +76,13 @@ impl TupleLength {
             None => "unlimited".to_string(),
         }
     }
+
+    pub(crate) fn into_fixed_length(self) -> Option<usize> {
+        match self {
+            TupleLength::Fixed(len) => Some(len),
+            TupleLength::Variable(_, _) => None,
+        }
+    }
 }
 
 /// # Ordering

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -22,6 +22,7 @@ use std::hash::Hash;
 
 use itertools::{Either, EitherOrBoth, Itertools};
 
+use crate::types::Truthiness;
 use crate::types::class::{ClassType, KnownClass};
 use crate::types::{
     Type, TypeMapping, TypeRelation, TypeTransformer, TypeVarInstance, TypeVarVariance,
@@ -246,6 +247,10 @@ impl<'db> TupleType<'db> {
 
     pub(crate) fn is_single_valued(self, db: &'db dyn Db) -> bool {
         self.tuple(db).is_single_valued(db)
+    }
+
+    pub(crate) fn truthiness(self, db: &'db dyn Db) -> Truthiness {
+        self.tuple(db).truthiness()
     }
 }
 
@@ -971,6 +976,17 @@ impl<T> Tuple<T> {
         match self {
             Tuple::Fixed(tuple) => TupleLength::Fixed(tuple.len()),
             Tuple::Variable(tuple) => tuple.len(),
+        }
+    }
+
+    pub(crate) fn truthiness(&self) -> Truthiness {
+        match self.len().size_hint() {
+            // The tuple type is AlwaysFalse if it contains only the empty tuple
+            (_, Some(0)) => Truthiness::AlwaysFalse,
+            // The tuple type is AlwaysTrue if its inhabitants must always have length >=1
+            (minimum, _) if minimum > 0 => Truthiness::AlwaysTrue,
+            // The tuple type is Ambiguous if its inhabitants could be of any length
+            _ => Truthiness::Ambiguous,
         }
     }
 


### PR DESCRIPTION
## Summary

This PR extends our existing `__len__` and `__bool__` special casing so that it also works with tuple subclasses. I.e., for a class like `Foo` here, we will now understand that instances of `Foo` are always truthy, and that calling `len()` on an instance of `Foo` will always return `Literal[1]`:

```py
class Foo(tuple[int]): ...
```

The approach taken is to synthesize `__bool__` and `__len__` class attributes on the generic alias object `tuple[int]`. `tuple[int].__bool__` is inferred as a function-like `Callable` type with signature `(self: tuple[int], /) -> Literal[True]`; a similar approach is taken for `tuple.__len__`. This means that the correct signature for these methods is naturally inherited by subclasses; it means that protocol subtyping will work correctly for these subclasses; and it means that once we have implemented the Liskov Substitution Principle, unsound overrides of these methods on tuple subclasses will be naturally detected by ty.

## Test Plan

Mdtests

---

Co-authored-by: Brent Westbrook <36778786+ntBre@users.noreply.github.com>
