### PR TITLE
[`pyupgrade`] Make example error out-of-the-box (`UP046`)

### DIFF
--- a/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_generic_class.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_generic_class.rs
@@ -43,7 +43,7 @@ use super::{
 /// ## Example
 ///
 /// ```python
-/// from typing import TypeVar
+/// from typing import Generic, TypeVar
 ///
 /// T = TypeVar("T")
 ///


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Part of #18972

This PR makes [non-pep695-generic-class (UP046)](https://docs.astral.sh/ruff/rules/non-pep695-generic-class/#non-pep695-generic-class-up046)'s example error out-of-the-box.

[Old example](https://play.ruff.rs/9d51ffc3-6be5-4646-9f6a-4dd57bae7fcb)
```py
from typing import TypeVar

T = TypeVar("T")


class GenericClass(Generic[T]):
    var: T
```

[New example](https://play.ruff.rs/927bd849-4b61-43d0-b121-e51a4d7c40b8)
```py
from typing import Generic, TypeVar

T = TypeVar("T")


class GenericClass(Generic[T]):
    var: T
```

## Test Plan

<!-- How was it tested? -->

N/A, no functionality/tests affected