### PR TITLE
[`pyupgrade`] Make example error out-of-the-box (`UP040`)

### DIFF
--- a/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_type_alias.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_type_alias.rs
@@ -40,6 +40,8 @@ use super::{
 ///
 /// ## Example
 /// ```python
+/// from typing import TypeAlias, TypeAliasType
+///
 /// ListOfInt: TypeAlias = list[int]
 /// PositiveInt = TypeAliasType("PositiveInt", Annotated[int, Gt(0)])
 /// ```

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_type_alias.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_type_alias.rs
@@ -40,7 +40,8 @@ use super::{
 ///
 /// ## Example
 /// ```python
-/// from typing import TypeAlias, TypeAliasType
+/// from typing import Annotated, TypeAlias, TypeAliasType
+/// from annotated_types import Gt
 ///
 /// ListOfInt: TypeAlias = list[int]
 /// PositiveInt = TypeAliasType("PositiveInt", Annotated[int, Gt(0)])
@@ -48,6 +49,9 @@ use super::{
 ///
 /// Use instead:
 /// ```python
+/// from typing import Annotated
+/// from annotated_types import Gt
+///
 /// type ListOfInt = list[int]
 /// type PositiveInt = Annotated[int, Gt(0)]
 /// ```


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Part of #18972

This PR makes [non-pep695-type-alias (UP040)](https://docs.astral.sh/ruff/rules/non-pep695-type-alias/#non-pep695-type-alias-up040)'s example error out-of-the-box.

[Old example](https://play.ruff.rs/6beca1be-45cd-4e5a-aafa-6a0584c10d64)
```py
ListOfInt: TypeAlias = list[int]
PositiveInt = TypeAliasType("PositiveInt", Annotated[int, Gt(0)])
```

[New example](https://play.ruff.rs/bbad34da-bf07-44e6-9f34-53337e8f57d4)
```py
from typing import Annotated, TypeAlias, TypeAliasType
from annotated_types import Gt

ListOfInt: TypeAlias = list[int]
PositiveInt = TypeAliasType("PositiveInt", Annotated[int, Gt(0)])
```

Imports were also added to the "Use instead" section.

## Test Plan

<!-- How was it tested? -->

N/A, no functionality/tests affected