### PR TITLE
[`refurb`] Make example error out-of-the-box (`FURB122`)

### DIFF
--- a/crates/ruff_linter/src/rules/refurb/rules/for_loop_writes.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/for_loop_writes.rs
@@ -19,22 +19,26 @@ use crate::rules::refurb::helpers::parenthesize_loop_iter_if_necessary;
 ///
 /// ## Example
 /// ```python
+/// from pathlib import Path
+///
 /// with Path("file").open("w") as f:
 ///     for line in lines:
 ///         f.write(line)
 ///
-/// with Path("file").open("wb") as f:
-///     for line in lines:
-///         f.write(line.encode())
+/// with Path("file").open("wb") as f_b:
+///     for line_b in lines_b:
+///         f_b.write(line_b.encode())
 /// ```
 ///
 /// Use instead:
 /// ```python
+/// from pathlib import Path
+///
 /// with Path("file").open("w") as f:
 ///     f.writelines(lines)
 ///
-/// with Path("file").open("wb") as f:
-///     f.writelines(line.encode() for line in lines)
+/// with Path("file").open("wb") as f_b:
+///     f_b.writelines(line_b.encode() for line_b in lines_b)
 /// ```
 ///
 /// ## Fix safety


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Part of #18972

This PR makes [for-loop-writes (FURB122)](https://docs.astral.sh/ruff/rules/for-loop-writes/#for-loop-writes-furb122)'s example error out-of-the-box. I also had to re-name the second case's variables to get both to raise at the same time, I suspect because of limitations in ruff's current semantic model. New names subject to bikeshedding, I just went with the least effort `_b` for binary suffix.

[Old example](https://play.ruff.rs/19e8e47a-8058-4013-aef5-e9b5eab65962)
```py
with Path("file").open("w") as f:
    for line in lines:
        f.write(line)

with Path("file").open("wb") as f:
    for line in lines:
        f.write(line.encode())
```

[New example](https://play.ruff.rs/e96b00e5-3c63-47c3-996d-dace420dd711)
```py
from pathlib import Path

with Path("file").open("w") as f:
    for line in lines:
        f.write(line)

with Path("file").open("wb") as f_b:
    for line_b in lines_b:
        f_b.write(line_b.encode())
```

The "Use instead" section was also modified similarly.

## Test Plan

<!-- How was it tested? -->

N/A, no functionality/tests affected