### PR TITLE
feat: add auto-fix for f-string logging statements

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_logging_format/G004.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_logging_format/G004.py
@@ -13,3 +13,49 @@ from logging import info
 
 info(f"{name}")
 info(f"{__name__}")
+
+# Test Multiline f-string with multiple variables
+the_total_number_of_files = 100
+the_number_of_files_changed = 25
+directory_path = "/home/hamir/project"
+
+logging.info(
+    f'Cleaned {the_number_of_files_changed} out of {the_total_number_of_files} files in {directory_path}.'
+)
+
+# Test Attribute access in f-string
+class FilePath:
+    def __init__(self, name):
+        self.name = name
+
+file_path = FilePath("config.py")
+logging.info(f'No changes made to {file_path.name}.')
+
+# Test Mixed format specifiers in f-string
+user_id = 12345
+username = "alice"
+balance = 1234.56
+logging.error(f'Error {404}: User {username} has insufficient balance ${balance:.2f}')
+
+# Test Complex expressions in f-string
+data = {"status": "success", "count": 100}
+logging.info(f'Processing {len(data)} items')
+logging.debug(f'Status: {data.get("status", "unknown").upper()}')
+
+# Test Various format specifiers
+temperature = 23.7
+items_count = 42
+logging.debug(f'Temperature: {temperature:.1f}°C')
+logging.warning(f'Items: {items_count:d}')
+
+# Test Repr formatting
+obj = {"key": "value"}
+logging.info(f'Object: {obj!r}')
+
+# Test Empty and text-only f-strings
+logging.debug(f'')
+logging.info(f'Static message without variables')
+
+# Test Nested expressions
+result = user_id * 2
+logging.info(f'Calculated result: {result + 100}')

--- a/crates/ruff_linter/src/rules/flake8_logging_format/rules/logging_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_logging_format/rules/logging_call.rs
@@ -1,4 +1,7 @@
-use ruff_python_ast::{self as ast, Arguments, Expr, Keyword, Operator};
+use ruff_python_ast::{
+    self as ast, Arguments, ConversionFlag, Expr, InterpolatedStringElement, Keyword, Operator,
+};
+use ruff_python_codegen::Generator;
 use ruff_python_semantic::analyze::logging;
 use ruff_python_stdlib::logging::LoggingLevel;
 use ruff_text_size::Ranged;
@@ -54,10 +57,6 @@ fn check_msg(checker: &Checker, msg: &Expr) {
             }
             _ => {}
         },
-        // Check for f-strings.
-        Expr::FString(_) => {
-            checker.report_diagnostic_if_enabled(LoggingFString, msg.range());
-        }
         // Check for .format() calls.
         Expr::Call(ast::ExprCall { func, .. }) => {
             if checker.is_rule_enabled(Rule::LoggingStringFormat) {
@@ -130,6 +129,152 @@ impl LoggingCallType {
     }
 }
 
+/// Convert an f-string to %-style formatting for logging calls.
+fn convert_f_string_to_percent_format(
+    f_string: &ast::ExprFString,
+    call: &ast::ExprCall,
+    msg_pos: usize,
+    generator: Generator,
+) -> ruff_diagnostics::Fix {
+    let mut format_string = String::new();
+    let mut arguments = Vec::new();
+
+    // Process all f-string elements
+    for element in f_string.value.elements() {
+        match element {
+            InterpolatedStringElement::Literal(literal) => {
+                format_string.push_str(&literal.value);
+            }
+            InterpolatedStringElement::Interpolation(interpolation) => {
+                // Convert the interpolation to a % format specifier
+                let format_spec = convert_interpolation_to_percent_format(interpolation);
+                format_string.push_str(&format_spec);
+                arguments.push(interpolation.expression.as_ref().clone());
+            }
+        }
+    }
+
+    // Create the new format string literal
+    let format_string_literal = ast::ExprStringLiteral {
+        value: ast::StringLiteralValue::single(ast::StringLiteral {
+            value: format_string.into_boxed_str(),
+            flags: ast::StringLiteralFlags::empty(),
+            range: f_string.range(),
+            node_index: ast::AtomicNodeIndex::dummy(),
+        }),
+        range: f_string.range(),
+        node_index: ast::AtomicNodeIndex::dummy(),
+    };
+
+    // Build a new arguments list for the logging call.
+    // Preserve existing arguments before the message position.
+    let mut new_args: Vec<ast::Expr> = call.arguments.args[..msg_pos].to_vec();
+
+    // Add the format string at the message position.
+    new_args.push(format_string_literal.into());
+
+    // Add the extracted f-string arguments.
+    new_args.extend(arguments);
+
+    // Add any remaining arguments after the original message position.
+    if msg_pos + 1 < call.arguments.args.len() {
+        new_args.extend_from_slice(&call.arguments.args[msg_pos + 1..]);
+    }
+
+    // Create new call arguments.
+    let new_arguments = ast::Arguments {
+        args: new_args.into(),
+        keywords: call.arguments.keywords.clone(),
+        range: call.arguments.range,
+        node_index: ast::AtomicNodeIndex::dummy(),
+    };
+
+    // Create the new call.
+    let new_call = ast::ExprCall {
+        func: call.func.clone(),
+        arguments: new_arguments,
+        range: call.range,
+        node_index: ast::AtomicNodeIndex::dummy(),
+    };
+
+    let replacement = generator.expr(&new_call.into());
+
+    Fix::safe_edit(Edit::range_replacement(replacement, call.range))
+}
+
+/// Convert an f-string interpolation to a % format specifier.
+fn convert_interpolation_to_percent_format(
+    interpolation: &ast::InterpolatedElement,
+) -> std::string::String {
+    let mut format_spec = String::from("%");
+
+    // Handle conversion flags
+    match interpolation.conversion {
+        ConversionFlag::Str => format_spec.push('s'),
+        ConversionFlag::Repr => format_spec.push('r'),
+        ConversionFlag::Ascii => format_spec.push('a'),
+        ConversionFlag::None => {
+            // Check if there's a format spec to determine the type
+            if let Some(format_spec_node) = &interpolation.format_spec {
+                let spec_text = extract_format_spec_text(format_spec_node);
+                if spec_text.is_empty() {
+                    format_spec.push('s');
+                } else {
+                    format_spec.push_str(&convert_format_spec_to_percent(&spec_text));
+                }
+            } else {
+                format_spec.push('s');
+            }
+        }
+    }
+
+    format_spec
+}
+
+/// Extract the format specification text from a format spec node.
+fn extract_format_spec_text(
+    format_spec: &ast::InterpolatedStringFormatSpec,
+) -> std::string::String {
+    let mut spec_text = String::new();
+
+    for element in &format_spec.elements {
+        match element {
+            InterpolatedStringElement::Literal(literal) => {
+                spec_text.push_str(&literal.value);
+            }
+            InterpolatedStringElement::Interpolation(_) => {
+                // Nested interpolations in format specs are complex, fall back to default
+                return String::new();
+            }
+        }
+    }
+
+    spec_text
+}
+
+/// Convert f-string format specification to % format specification.
+fn convert_format_spec_to_percent(specifier: &str) -> std::string::String {
+    // Handle common format specifications
+    match specifier {
+        // Float formatting
+        s if s.ends_with('e') => s.to_string(),
+        s if s.ends_with('f') => s.to_string(),
+        s if s.ends_with('g') => s.to_string(),
+
+        // Integer formatting
+        s if s.ends_with('d') => s.to_string(),
+        s if s.ends_with('o') => s.to_string(),
+        s if s.ends_with('x') => s.to_string(),
+        s if s.ends_with('X') => s.to_string(),
+
+        // String formatting
+        s if s.ends_with('s') => s.to_string(),
+
+        // Default to string for other cases
+        _ => "s".to_string(),
+    }
+}
+
 /// Check logging calls for violations.
 pub(crate) fn logging_call(checker: &Checker, call: &ast::ExprCall) {
     // Determine the call type (e.g., `info` vs. `exception`) and the range of the attribute.
@@ -168,7 +313,23 @@ pub(crate) fn logging_call(checker: &Checker, call: &ast::ExprCall) {
     // G001, G002, G003, G004
     let msg_pos = usize::from(matches!(logging_call_type, LoggingCallType::LogCall));
     if let Some(format_arg) = call.arguments.find_argument_value("msg", msg_pos) {
-        check_msg(checker, format_arg);
+        // Check for f-strings (G004) - handle this in a specific way to access the full call
+        if let Expr::FString(f_string) = format_arg {
+            if checker.is_rule_enabled(Rule::LoggingFString) {
+                let mut diagnostic = checker.report_diagnostic(LoggingFString, format_arg.range());
+                diagnostic.try_set_fix(|| {
+                    Ok(convert_f_string_to_percent_format(
+                        f_string,
+                        call,
+                        msg_pos,
+                        checker.generator(),
+                    ))
+                });
+            }
+        } else {
+            // Check other format violations (G001, G002, G003)
+            check_msg(checker, format_arg);
+        }
     }
 
     // G010

--- a/crates/ruff_linter/src/rules/flake8_logging_format/snapshots/ruff_linter__rules__flake8_logging_format__tests__G004.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_logging_format/snapshots/ruff_linter__rules__flake8_logging_format__tests__G004.py.snap
@@ -1,15 +1,26 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_logging_format/mod.rs
 ---
-G004.py:4:14: G004 Logging statement uses f-string
+G004.py:4:14: G004 [*] Logging statement uses f-string
   |
 3 | name = "world"
 4 | logging.info(f"Hello {name}")
   |              ^^^^^^^^^^^^^^^ G004
 5 | logging.log(logging.INFO, f"Hello {name}")
   |
+  = help: Replace f-string with % formatting
 
-G004.py:5:27: G004 Logging statement uses f-string
+ℹ Safe fix
+1 1 | import logging
+2 2 | 
+3 3 | name = "world"
+4   |-logging.info(f"Hello {name}")
+  4 |+logging.info('Hello %s', name)
+5 5 | logging.log(logging.INFO, f"Hello {name}")
+6 6 | 
+7 7 | _LOGGER = logging.getLogger()
+
+G004.py:5:27: G004 [*] Logging statement uses f-string
   |
 3 | name = "world"
 4 | logging.info(f"Hello {name}")
@@ -18,8 +29,19 @@ G004.py:5:27: G004 Logging statement uses f-string
 6 |
 7 | _LOGGER = logging.getLogger()
   |
+  = help: Replace f-string with % formatting
 
-G004.py:8:14: G004 Logging statement uses f-string
+ℹ Safe fix
+2 2 | 
+3 3 | name = "world"
+4 4 | logging.info(f"Hello {name}")
+5   |-logging.log(logging.INFO, f"Hello {name}")
+  5 |+logging.log(logging.INFO, 'Hello %s', name)
+6 6 | 
+7 7 | _LOGGER = logging.getLogger()
+8 8 | _LOGGER.info(f"{__name__}")
+
+G004.py:8:14: G004 [*] Logging statement uses f-string
    |
  7 | _LOGGER = logging.getLogger()
  8 | _LOGGER.info(f"{__name__}")
@@ -27,8 +49,19 @@ G004.py:8:14: G004 Logging statement uses f-string
  9 |
 10 | logging.getLogger().info(f"{name}")
    |
+   = help: Replace f-string with % formatting
 
-G004.py:10:26: G004 Logging statement uses f-string
+ℹ Safe fix
+5 5 | logging.log(logging.INFO, f"Hello {name}")
+6 6 | 
+7 7 | _LOGGER = logging.getLogger()
+8   |-_LOGGER.info(f"{__name__}")
+  8 |+_LOGGER.info('%s', __name__)
+9 9 | 
+10 10 | logging.getLogger().info(f"{name}")
+11 11 | 
+
+G004.py:10:26: G004 [*] Logging statement uses f-string
    |
  8 | _LOGGER.info(f"{__name__}")
  9 |
@@ -37,8 +70,19 @@ G004.py:10:26: G004 Logging statement uses f-string
 11 |
 12 | from logging import info
    |
+   = help: Replace f-string with % formatting
 
-G004.py:14:6: G004 Logging statement uses f-string
+ℹ Safe fix
+7  7  | _LOGGER = logging.getLogger()
+8  8  | _LOGGER.info(f"{__name__}")
+9  9  | 
+10    |-logging.getLogger().info(f"{name}")
+   10 |+logging.getLogger().info('%s', name)
+11 11 | 
+12 12 | from logging import info
+13 13 | 
+
+G004.py:14:6: G004 [*] Logging statement uses f-string
    |
 12 | from logging import info
 13 |
@@ -46,10 +90,255 @@ G004.py:14:6: G004 Logging statement uses f-string
    |      ^^^^^^^^^ G004
 15 | info(f"{__name__}")
    |
+   = help: Replace f-string with % formatting
 
-G004.py:15:6: G004 Logging statement uses f-string
+ℹ Safe fix
+11 11 | 
+12 12 | from logging import info
+13 13 | 
+14    |-info(f"{name}")
+   14 |+info('%s', name)
+15 15 | info(f"{__name__}")
+16 16 | 
+17 17 | # Test Multiline f-string with multiple variables
+
+G004.py:15:6: G004 [*] Logging statement uses f-string
    |
 14 | info(f"{name}")
 15 | info(f"{__name__}")
    |      ^^^^^^^^^^^^^ G004
+16 |
+17 | # Test Multiline f-string with multiple variables
    |
+   = help: Replace f-string with % formatting
+
+ℹ Safe fix
+12 12 | from logging import info
+13 13 | 
+14 14 | info(f"{name}")
+15    |-info(f"{__name__}")
+   15 |+info('%s', __name__)
+16 16 | 
+17 17 | # Test Multiline f-string with multiple variables
+18 18 | the_total_number_of_files = 100
+
+G004.py:23:5: G004 [*] Logging statement uses f-string
+   |
+22 | logging.info(
+23 |     f'Cleaned {the_number_of_files_changed} out of {the_total_number_of_files} files in {directory_path}.'
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ G004
+24 | )
+   |
+   = help: Replace f-string with % formatting
+
+ℹ Safe fix
+19 19 | the_number_of_files_changed = 25
+20 20 | directory_path = "/home/hamir/project"
+21 21 | 
+22    |-logging.info(
+23    |-    f'Cleaned {the_number_of_files_changed} out of {the_total_number_of_files} files in {directory_path}.'
+24    |-)
+   22 |+logging.info('Cleaned %s out of %s files in %s.', the_number_of_files_changed, the_total_number_of_files, directory_path)
+25 23 | 
+26 24 | # Test Attribute access in f-string
+27 25 | class FilePath:
+
+G004.py:32:14: G004 [*] Logging statement uses f-string
+   |
+31 | file_path = FilePath("config.py")
+32 | logging.info(f'No changes made to {file_path.name}.')
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ G004
+33 |
+34 | # Test Mixed format specifiers in f-string
+   |
+   = help: Replace f-string with % formatting
+
+ℹ Safe fix
+29 29 |         self.name = name
+30 30 | 
+31 31 | file_path = FilePath("config.py")
+32    |-logging.info(f'No changes made to {file_path.name}.')
+   32 |+logging.info('No changes made to %s.', file_path.name)
+33 33 | 
+34 34 | # Test Mixed format specifiers in f-string
+35 35 | user_id = 12345
+
+G004.py:38:15: G004 [*] Logging statement uses f-string
+   |
+36 | username = "alice"
+37 | balance = 1234.56
+38 | logging.error(f'Error {404}: User {username} has insufficient balance ${balance:.2f}')
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ G004
+39 |
+40 | # Test Complex expressions in f-string
+   |
+   = help: Replace f-string with % formatting
+
+ℹ Safe fix
+35 35 | user_id = 12345
+36 36 | username = "alice"
+37 37 | balance = 1234.56
+38    |-logging.error(f'Error {404}: User {username} has insufficient balance ${balance:.2f}')
+   38 |+logging.error('Error %s: User %s has insufficient balance $%.2f', 404, username, balance)
+39 39 | 
+40 40 | # Test Complex expressions in f-string
+41 41 | data = {"status": "success", "count": 100}
+
+G004.py:42:14: G004 [*] Logging statement uses f-string
+   |
+40 | # Test Complex expressions in f-string
+41 | data = {"status": "success", "count": 100}
+42 | logging.info(f'Processing {len(data)} items')
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ G004
+43 | logging.debug(f'Status: {data.get("status", "unknown").upper()}')
+   |
+   = help: Replace f-string with % formatting
+
+ℹ Safe fix
+39 39 | 
+40 40 | # Test Complex expressions in f-string
+41 41 | data = {"status": "success", "count": 100}
+42    |-logging.info(f'Processing {len(data)} items')
+   42 |+logging.info('Processing %s items', len(data))
+43 43 | logging.debug(f'Status: {data.get("status", "unknown").upper()}')
+44 44 | 
+45 45 | # Test Various format specifiers
+
+G004.py:43:15: G004 [*] Logging statement uses f-string
+   |
+41 | data = {"status": "success", "count": 100}
+42 | logging.info(f'Processing {len(data)} items')
+43 | logging.debug(f'Status: {data.get("status", "unknown").upper()}')
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ G004
+44 |
+45 | # Test Various format specifiers
+   |
+   = help: Replace f-string with % formatting
+
+ℹ Safe fix
+40 40 | # Test Complex expressions in f-string
+41 41 | data = {"status": "success", "count": 100}
+42 42 | logging.info(f'Processing {len(data)} items')
+43    |-logging.debug(f'Status: {data.get("status", "unknown").upper()}')
+   43 |+logging.debug('Status: %s', data.get("status", "unknown").upper())
+44 44 | 
+45 45 | # Test Various format specifiers
+46 46 | temperature = 23.7
+
+G004.py:48:15: G004 [*] Logging statement uses f-string
+   |
+46 | temperature = 23.7
+47 | items_count = 42
+48 | logging.debug(f'Temperature: {temperature:.1f}°C')
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ G004
+49 | logging.warning(f'Items: {items_count:d}')
+   |
+   = help: Replace f-string with % formatting
+
+ℹ Safe fix
+45 45 | # Test Various format specifiers
+46 46 | temperature = 23.7
+47 47 | items_count = 42
+48    |-logging.debug(f'Temperature: {temperature:.1f}°C')
+   48 |+logging.debug('Temperature: %.1f°C', temperature)
+49 49 | logging.warning(f'Items: {items_count:d}')
+50 50 | 
+51 51 | # Test Repr formatting
+
+G004.py:49:17: G004 [*] Logging statement uses f-string
+   |
+47 | items_count = 42
+48 | logging.debug(f'Temperature: {temperature:.1f}°C')
+49 | logging.warning(f'Items: {items_count:d}')
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^ G004
+50 |
+51 | # Test Repr formatting
+   |
+   = help: Replace f-string with % formatting
+
+ℹ Safe fix
+46 46 | temperature = 23.7
+47 47 | items_count = 42
+48 48 | logging.debug(f'Temperature: {temperature:.1f}°C')
+49    |-logging.warning(f'Items: {items_count:d}')
+   49 |+logging.warning('Items: %d', items_count)
+50 50 | 
+51 51 | # Test Repr formatting
+52 52 | obj = {"key": "value"}
+
+G004.py:53:14: G004 [*] Logging statement uses f-string
+   |
+51 | # Test Repr formatting
+52 | obj = {"key": "value"}
+53 | logging.info(f'Object: {obj!r}')
+   |              ^^^^^^^^^^^^^^^^^^ G004
+54 |
+55 | # Test Empty and text-only f-strings
+   |
+   = help: Replace f-string with % formatting
+
+ℹ Safe fix
+50 50 | 
+51 51 | # Test Repr formatting
+52 52 | obj = {"key": "value"}
+53    |-logging.info(f'Object: {obj!r}')
+   53 |+logging.info('Object: %r', obj)
+54 54 | 
+55 55 | # Test Empty and text-only f-strings
+56 56 | logging.debug(f'')
+
+G004.py:56:15: G004 [*] Logging statement uses f-string
+   |
+55 | # Test Empty and text-only f-strings
+56 | logging.debug(f'')
+   |               ^^^ G004
+57 | logging.info(f'Static message without variables')
+   |
+   = help: Replace f-string with % formatting
+
+ℹ Safe fix
+53 53 | logging.info(f'Object: {obj!r}')
+54 54 | 
+55 55 | # Test Empty and text-only f-strings
+56    |-logging.debug(f'')
+   56 |+logging.debug('')
+57 57 | logging.info(f'Static message without variables')
+58 58 | 
+59 59 | # Test Nested expressions
+
+G004.py:57:14: G004 [*] Logging statement uses f-string
+   |
+55 | # Test Empty and text-only f-strings
+56 | logging.debug(f'')
+57 | logging.info(f'Static message without variables')
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ G004
+58 |
+59 | # Test Nested expressions
+   |
+   = help: Replace f-string with % formatting
+
+ℹ Safe fix
+54 54 | 
+55 55 | # Test Empty and text-only f-strings
+56 56 | logging.debug(f'')
+57    |-logging.info(f'Static message without variables')
+   57 |+logging.info('Static message without variables')
+58 58 | 
+59 59 | # Test Nested expressions
+60 60 | result = user_id * 2
+
+G004.py:61:14: G004 [*] Logging statement uses f-string
+   |
+59 | # Test Nested expressions
+60 | result = user_id * 2
+61 | logging.info(f'Calculated result: {result + 100}')
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ G004
+   |
+   = help: Replace f-string with % formatting
+
+ℹ Safe fix
+58 58 | 
+59 59 | # Test Nested expressions
+60 60 | result = user_id * 2
+61    |-logging.info(f'Calculated result: {result + 100}')
+   61 |+logging.info('Calculated result: %s', result + 100)

--- a/crates/ruff_linter/src/rules/flake8_logging_format/violations.rs
+++ b/crates/ruff_linter/src/rules/flake8_logging_format/violations.rs
@@ -331,6 +331,10 @@ impl Violation for LoggingFString {
     fn message(&self) -> String {
         "Logging statement uses f-string".to_string()
     }
+    const FIX_AVAILABILITY: crate::FixAvailability = crate::FixAvailability::Sometimes;
+    fn fix_title(&self) -> Option<String> {
+        Some("Replace f-string with % formatting".to_string())
+    }
 }
 
 /// ## What it does


### PR DESCRIPTION
Closes #19302

<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary
This adds an auto-fix for `Logging statement uses f-string` Ruff G004, so users don't have to resolve it manually.
<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan
I ran the auto-fixes on a Python file locally and and it worked as expected.
<!-- How was it tested? -->