### PR TITLE
[ty] Provide docstrings for stdlib APIs when hovering over them in an IDE

### DIFF
--- a/.github/workflows/sync_typeshed.yaml
+++ b/.github/workflows/sync_typeshed.yaml
@@ -42,15 +42,32 @@ jobs:
         run: |
           # Run with the full matrix of Python versions supported by typeshed,
           # so that we codemod in docstrings that only exist on certain versions.
-          # TODO: what about platform-specific APIs?
-          uvx --python=3.14 --from=git+https://github.com/AlexWaygood/docstring-adder.git add-docstrings --stdlib-path ./typeshed/stdlib
-          uvx --python=3.13 --from=git+https://github.com/AlexWaygood/docstring-adder.git add-docstrings --stdlib-path ./typeshed/stdlib
-          uvx --python=3.12 --from=git+https://github.com/AlexWaygood/docstring-adder.git add-docstrings --stdlib-path ./typeshed/stdlib
-          uvx --python=3.11 --from=git+https://github.com/AlexWaygood/docstring-adder.git add-docstrings --stdlib-path ./typeshed/stdlib
-          uvx --python=3.10 --from=git+https://github.com/AlexWaygood/docstring-adder.git add-docstrings --stdlib-path ./typeshed/stdlib
-          uvx --python=3.9 --from=git+https://github.com/AlexWaygood/docstring-adder.git add-docstrings --stdlib-path ./typeshed/stdlib
+          #
+          # The codemod will only add docstrings to functions/classes that do not
+          # already have docstrings. We run with Python 3.14 before running with
+          # any other Python version so that we get the Python 3.14 version of the
+          # docstring for a definition that exists on all Python versions: if we
+          # ran with Python 3.9 first, then the later runs with Python 3.10+ would
+          # not modify the docstring that had already been added using the old version of Python.
+          #
+          # TODO: In order to add docstrings for platform-specific APIs, we would also
+          # need to run the codemod on Windows. We get the runtime docstrings by inspecting
+          # the docstrings at runtime, so if an API doesn't exist at runtime (because e.g.
+          # it's Windows-specific and we're running on Linux), then we won't add a docstring to it.
+          #
+          uvx --python=3.14 --force-reinstall --from=git+https://github.com/AlexWaygood/docstring-adder.git add-docstrings --stdlib-path ./typeshed/stdlib
+          uvx --python=3.13 --force-reinstall --from=git+https://github.com/AlexWaygood/docstring-adder.git add-docstrings --stdlib-path ./typeshed/stdlib
+          uvx --python=3.12 --force-reinstall --from=git+https://github.com/AlexWaygood/docstring-adder.git add-docstrings --stdlib-path ./typeshed/stdlib
+          uvx --python=3.11 --force-reinstall --from=git+https://github.com/AlexWaygood/docstring-adder.git add-docstrings --stdlib-path ./typeshed/stdlib
+          uvx --python=3.10 --force-reinstall --from=git+https://github.com/AlexWaygood/docstring-adder.git add-docstrings --stdlib-path ./typeshed/stdlib
+          uvx --python=3.9 --force-reinstall --from=git+https://github.com/AlexWaygood/docstring-adder.git add-docstrings --stdlib-path ./typeshed/stdlib
 
+          # Here we just reformat the codemodded stubs so that they are
+          # consistent with the other typeshed stubs around them.
+          # Typeshed formats code using black in their CI, so we just invoke
+          # black on the stubs the same way that typeshed does.
           uvx --directory=typeshed pre-commit run -a black
+
           rm -rf ruff/crates/ty_vendored/vendor/typeshed
           mkdir ruff/crates/ty_vendored/vendor/typeshed
           cp typeshed/README.md ruff/crates/ty_vendored/vendor/typeshed

--- a/.github/workflows/sync_typeshed.yaml
+++ b/.github/workflows/sync_typeshed.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Sync typeshed
         id: sync
         run: |
-          docstring_adder="git+https://github.com/astral-sh/docstring-adder.git@01701466882341843a3c1787e5c78b6076dbe96b"
+          docstring_adder="git+https://github.com/astral-sh/docstring-adder.git@6de51c5f44aea11fe8c8f2d30f9ee0683682c3d2"
 
           # Run with the full matrix of Python versions supported by typeshed,
           # so that we codemod in docstrings that only exist on certain versions.

--- a/.github/workflows/sync_typeshed.yaml
+++ b/.github/workflows/sync_typeshed.yaml
@@ -40,6 +40,8 @@ jobs:
       - name: Sync typeshed
         id: sync
         run: |
+          docstring_adder="git+https://github.com/astral-sh/docstring-adder.git@01701466882341843a3c1787e5c78b6076dbe96b"
+
           # Run with the full matrix of Python versions supported by typeshed,
           # so that we codemod in docstrings that only exist on certain versions.
           #
@@ -55,12 +57,12 @@ jobs:
           # the docstrings at runtime, so if an API doesn't exist at runtime (because e.g.
           # it's Windows-specific and we're running on Linux), then we won't add a docstring to it.
           #
-          uvx --python=3.14 --force-reinstall --from=git+https://github.com/AlexWaygood/docstring-adder.git add-docstrings --stdlib-path ./typeshed/stdlib
-          uvx --python=3.13 --force-reinstall --from=git+https://github.com/AlexWaygood/docstring-adder.git add-docstrings --stdlib-path ./typeshed/stdlib
-          uvx --python=3.12 --force-reinstall --from=git+https://github.com/AlexWaygood/docstring-adder.git add-docstrings --stdlib-path ./typeshed/stdlib
-          uvx --python=3.11 --force-reinstall --from=git+https://github.com/AlexWaygood/docstring-adder.git add-docstrings --stdlib-path ./typeshed/stdlib
-          uvx --python=3.10 --force-reinstall --from=git+https://github.com/AlexWaygood/docstring-adder.git add-docstrings --stdlib-path ./typeshed/stdlib
-          uvx --python=3.9 --force-reinstall --from=git+https://github.com/AlexWaygood/docstring-adder.git add-docstrings --stdlib-path ./typeshed/stdlib
+          uvx --python=3.14 --force-reinstall --from="${docstring_adder}" add-docstrings --stdlib-path ./typeshed/stdlib
+          uvx --python=3.13 --force-reinstall --from="${docstring_adder}" add-docstrings --stdlib-path ./typeshed/stdlib
+          uvx --python=3.12 --force-reinstall --from="${docstring_adder}" add-docstrings --stdlib-path ./typeshed/stdlib
+          uvx --python=3.11 --force-reinstall --from="${docstring_adder}" add-docstrings --stdlib-path ./typeshed/stdlib
+          uvx --python=3.10 --force-reinstall --from="${docstring_adder}" add-docstrings --stdlib-path ./typeshed/stdlib
+          uvx --python=3.9 --force-reinstall --from="${docstring_adder}" add-docstrings --stdlib-path ./typeshed/stdlib
 
           # Here we just reformat the codemodded stubs so that they are
           # consistent with the other typeshed stubs around them.

--- a/.github/workflows/sync_typeshed.yaml
+++ b/.github/workflows/sync_typeshed.yaml
@@ -36,9 +36,21 @@ jobs:
         run: |
           git config --global user.name typeshedbot
           git config --global user.email '<>'
+      - uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6.3.1
       - name: Sync typeshed
         id: sync
         run: |
+          # Run with the full matrix of Python versions supported by typeshed,
+          # so that we codemod in docstrings that only exist on certain versions.
+          # TODO: what about platform-specific APIs?
+          uvx --python=3.14 --from=git+https://github.com/AlexWaygood/docstring-adder.git add-docstrings --stdlib-path ./typeshed/stdlib
+          uvx --python=3.13 --from=git+https://github.com/AlexWaygood/docstring-adder.git add-docstrings --stdlib-path ./typeshed/stdlib
+          uvx --python=3.12 --from=git+https://github.com/AlexWaygood/docstring-adder.git add-docstrings --stdlib-path ./typeshed/stdlib
+          uvx --python=3.11 --from=git+https://github.com/AlexWaygood/docstring-adder.git add-docstrings --stdlib-path ./typeshed/stdlib
+          uvx --python=3.10 --from=git+https://github.com/AlexWaygood/docstring-adder.git add-docstrings --stdlib-path ./typeshed/stdlib
+          uvx --python=3.9 --from=git+https://github.com/AlexWaygood/docstring-adder.git add-docstrings --stdlib-path ./typeshed/stdlib
+
+          uvx --directory=typeshed pre-commit run -a black
           rm -rf ruff/crates/ty_vendored/vendor/typeshed
           mkdir ruff/crates/ty_vendored/vendor/typeshed
           cp typeshed/README.md ruff/crates/ty_vendored/vendor/typeshed


### PR DESCRIPTION
## Summary

I made a codemod that will auto-add docstrings to stub files by dynamically inspecting the value of the docstrings at runtime. This PR adds a step to our typeshed-sync workflow that applies the codemod, so that we always have docstrings for the stdlib checked into our vendored stubs for the standard library. This will allow us to display the docstrings when users hover over stdlib symbols in their IDE.

The source code for the codemod is [here](https://github.com/AlexWaygood/docstring-adder). The changes the codemod makes can be viewed [here](https://github.com/python/typeshed/compare/main...AlexWaygood:typeshed:docstrings?expand=1).

~~The only issue I _know_ of is that if you have version-dependent method definitions, e.g.~~

```py
class Foo:
    if sys.version_info >= (3, 13):
        def method(self): ...
    else:
        def method(self, arg): ...
```

~~then the codemod will only add a docstring to the definition in the first `sys.version_info` branch, not the second. This issue only exists for nested scopes, however; version-dependent class or function definitions in the global scope should have docstrings added to all definitions without issue.~~

^EDIT: I fixed this issue.

Codemodding docstrings into the stubs increases the size of the vendored-typeshed zipfile that we include as part of the ty binary. Locally, a release build of the ty binary increases in size from 38.7MB to 39.9MB. I think that's probably worth it, given that there's no other way to provide docstrings for C-extension modules in the stdlib. Even modules that are nominally written in Python, such as the `typing` module, often have several classes in them that are actually written in C (`typing.TypeVar`, for example); it would be impossible for ty to obtain docstrings for these classes by inspecting the runtime source code of the stdlib, so codemodding the docstrings into the stub seems to be a more resilient strategy here.

Codemodding docstrings into the stubs at typeshed-sync time is preferable to attempting to maintain these docstrings upstream in typeshed, because docstrings are constantly changing upstream in CPython, and it would be extremely difficult to keep the copies of these docstrings in typeshed up to date. An automated codemod solves this issue.

## Test Plan

- This has been mostly tested by eyeballing the [output](https://github.com/python/typeshed/compare/main...AlexWaygood:typeshed:docstrings?expand=1) of the codemod, and checking that there wasn't anything unexpectedly present or unexpectedly missing from the output.
- The script also has an assertion built into it which checks that every function name and class name in the AST appears the same number of times before and after the codemod
- Mypy is run on the script in CI over at https://github.com/AlexWaygood/docstring-adder/blob/main/.github/workflows/check.yaml
- There's a CI check in https://github.com/AlexWaygood/docstring-adder/blob/main/.github/workflows/check.yaml that ensures that the script never adds a docstring to a class or function that already has a docstring