### PR TITLE
[ty] Signature help for playground

### DIFF
--- a/playground/ty/src/Editor/Editor.tsx
+++ b/playground/ty/src/Editor/Editor.tsx
@@ -323,8 +323,6 @@ class PlaygroundServer
       return;
     }
 
-    debugger;
-
     return {
       value: {
         signatures: info.signatures.map((sig) => ({


### PR DESCRIPTION
This PR adds support for "signature help" in the ty playground.

<img width="332" height="120" alt="screenshot" src="https://github.com/user-attachments/assets/29e715dd-f1c2-49f3-8f8b-7421337ec8b6" />
