### PR TITLE
ignore errors when reformatting codemodded typeshed

### DIFF
--- a/.github/workflows/sync_typeshed.yaml
+++ b/.github/workflows/sync_typeshed.yaml
@@ -68,7 +68,7 @@ jobs:
           # consistent with the other typeshed stubs around them.
           # Typeshed formats code using black in their CI, so we just invoke
           # black on the stubs the same way that typeshed does.
-          uvx --directory=typeshed pre-commit run -a black
+          uvx --directory=typeshed pre-commit run -a black || true
 
           rm -rf ruff/crates/ty_vendored/vendor/typeshed
           mkdir ruff/crates/ty_vendored/vendor/typeshed


### PR DESCRIPTION
## Summary

Followup to https://github.com/astral-sh/ruff/pull/19311. Pre-commit exits with code 1 when any files are reformatted by black. But it's expected that some files will need to be reformatted here; this shouldn't cause the whole typeshed-sync job to fail.

## Test Plan

I'll re-run the workflow manually after merging this...
