### PR TITLE
[ty] fix a couple latent bugs uncovered during `nonlocal` work

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/scopes/nonlocal.md
+++ b/crates/ty_python_semantic/resources/mdtest/scopes/nonlocal.md
@@ -31,17 +31,17 @@ def f():
             reveal_type(x)  # revealed: Unknown | Literal[1]
 ```
 
-## Skips annotation-only assignment
+## Reads respect annotation-only declarations
 
 ```py
 def f():
-    x = 1
+    x: int = 1
     def g():
-        # it's pretty weird to have an annotated assignment in a function where the
-        # name is otherwise not defined; maybe should be an error?
-        x: int
+        # TODO: This example should actually be an unbound variable error. However to avoid false
+        # positives, we'd need to analyze `nonlocal x` statements in other inner functions.
+        x: str
         def h():
-            reveal_type(x)  # revealed: Unknown | Literal[1]
+            reveal_type(x)  # revealed: str
 ```
 
 ## The `nonlocal` keyword
@@ -229,7 +229,7 @@ def f():
             nonlocal x  # error: [invalid-syntax] "no binding for nonlocal `x` found"
 ```
 
-## `nonlocal` bindings respect declared types from the defining scope, even without a binding
+## Assigning to a `nonlocal` respects the declared type from its defining scope, even without a binding in that scope
 
 ```py
 def f():

--- a/crates/ty_python_semantic/resources/mdtest/scopes/nonlocal.md
+++ b/crates/ty_python_semantic/resources/mdtest/scopes/nonlocal.md
@@ -44,6 +44,24 @@ def f():
             reveal_type(x)  # revealed: str
 ```
 
+## Reads terminate at the `global` keyword in an enclosing scope, even if there's no binding in that scope
+
+_Unlike_ variables that are explicitly declared `nonlocal` (below), implicitly nonlocal ("free")
+reads can come from a variable that's declared `global` in an enclosing scope. It doesn't matter
+whether the variable is bound in that scope:
+
+```py
+x: int = 1
+
+def f():
+    x: str = "hello"
+    def g():
+        global x
+        def h():
+            # allowed: this loads the global `x` variable due to the `global` declaration in the immediate enclosing scope
+            y: int = x
+```
+
 ## The `nonlocal` keyword
 
 Without the `nonlocal` keyword, bindings in an inner scope shadow variables of the same name in
@@ -264,8 +282,8 @@ def f1():
 
             @staticmethod
             def f3():
-                # This scope declares `x` nonlocal and `y` as global, and it shadows `z` without
-                # giving it a type declaration.
+                # This scope declares `x` nonlocal, shadows `y` without a type declaration, and
+                # declares `z` global.
                 nonlocal x
                 x = 4
                 y = 5

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -6079,6 +6079,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 let Some(enclosing_place) = enclosing_place_table.place_by_expr(expr) else {
                     continue;
                 };
+                if enclosing_place.is_marked_global() {
+                    // Reads of "free" variables can terminate at an enclosing scope that marks the
+                    // variable `global` but doesn't actually bind it. In that case, stop walking
+                    // scopes and proceed to the global handling below. (But note that it's a
+                    // semantic syntax error for the `nonlocal` keyword to do this. See
+                    // `infer_nonlocal_statement`.)
+                    break;
+                }
                 if enclosing_place.is_bound() || enclosing_place.is_declared() {
                     // We can return early here, because the nearest function-like scope that
                     // defines a name must be the only source for the nonlocal reference (at

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -1618,8 +1618,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     // here and just bail out of this loop.
                     break;
                 }
-                // We found the closest definition. Note that (unlike in `infer_place_load`) this
-                // does *not* need to be a binding. It could be just `x: int`.
+                // We found the closest definition. Note that (as in `infer_place_load`) this does
+                // *not* need to be a binding. It could be just a declaration, e.g. `x: int`.
                 nonlocal_use_def_map = self.index.use_def_map(enclosing_scope_file_id);
                 declarations = nonlocal_use_def_map.end_of_scope_declarations(enclosing_place_id);
                 is_local = false;
@@ -6079,7 +6079,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 let Some(enclosing_place) = enclosing_place_table.place_by_expr(expr) else {
                     continue;
                 };
-                if enclosing_place.is_bound() {
+                if enclosing_place.is_bound() || enclosing_place.is_declared() {
                     // We can return early here, because the nearest function-like scope that
                     // defines a name must be the only source for the nonlocal reference (at
                     // runtime, it is the scope that creates the cell for our closure.) If the name


### PR DESCRIPTION
https://github.com/astral-sh/ty/issues/793

This PR includes two commits for two different bugs (I could separate them, but there would be a merge conflict, because they touch the same line):

- Free reads should terminate at an annotation-only declaration in an enclosing scope, even if that scope doesn't have a binding (in part because a sibling inner function could provide a binding).
- Free reads should terminate at a `global` declaration in an enclosing scope, even if that scope doesn't have a binding (a type annotation would be a syntax error). Usually the global scope will have a definition, and we currently require that it does, although CPython doesn't require that at runtime. (Also add a test case for that.)