### PR TITLE
[ty] Combine CallArguments and CallArgumentTypes

### DIFF
--- a/crates/ty_python_semantic/src/types/call.rs
+++ b/crates/ty_python_semantic/src/types/call.rs
@@ -4,7 +4,7 @@ use crate::Db;
 
 mod arguments;
 pub(crate) mod bind;
-pub(super) use arguments::{Argument, CallArgumentTypes, CallArguments};
+pub(super) use arguments::{Argument, CallArguments};
 pub(super) use bind::{Binding, Bindings, CallableBinding};
 
 /// Wraps a [`Bindings`] for an unsuccessful call with information about why the call was

--- a/crates/ty_python_semantic/src/types/call/arguments.rs
+++ b/crates/ty_python_semantic/src/types/call/arguments.rs
@@ -1,5 +1,4 @@
 use std::borrow::Cow;
-use std::ops::{Deref, DerefMut};
 
 use itertools::{Either, Itertools};
 use ruff_python_ast as ast;
@@ -9,60 +8,6 @@ use crate::types::KnownClass;
 use crate::types::tuple::{TupleSpec, TupleType};
 
 use super::Type;
-
-/// Arguments for a single call, in source order.
-#[derive(Clone, Debug, Default)]
-pub(crate) struct CallArguments<'a>(Vec<Argument<'a>>);
-
-impl<'a> CallArguments<'a> {
-    /// Create `CallArguments` from AST arguments
-    pub(crate) fn from_arguments(arguments: &'a ast::Arguments) -> Self {
-        arguments
-            .arguments_source_order()
-            .map(|arg_or_keyword| match arg_or_keyword {
-                ast::ArgOrKeyword::Arg(arg) => match arg {
-                    ast::Expr::Starred(ast::ExprStarred { .. }) => Argument::Variadic,
-                    _ => Argument::Positional,
-                },
-                ast::ArgOrKeyword::Keyword(ast::Keyword { arg, .. }) => {
-                    if let Some(arg) = arg {
-                        Argument::Keyword(&arg.id)
-                    } else {
-                        Argument::Keywords
-                    }
-                }
-            })
-            .collect()
-    }
-
-    /// Prepend an optional extra synthetic argument (for a `self` or `cls` parameter) to the front
-    /// of this argument list. (If `bound_self` is none, we return the argument list
-    /// unmodified.)
-    pub(crate) fn with_self(&self, bound_self: Option<Type<'_>>) -> Cow<Self> {
-        if bound_self.is_some() {
-            let arguments = std::iter::once(Argument::Synthetic)
-                .chain(self.0.iter().copied())
-                .collect();
-            Cow::Owned(CallArguments(arguments))
-        } else {
-            Cow::Borrowed(self)
-        }
-    }
-
-    pub(crate) fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    pub(crate) fn iter(&self) -> impl Iterator<Item = Argument<'a>> + '_ {
-        self.0.iter().copied()
-    }
-}
-
-impl<'a> FromIterator<Argument<'a>> for CallArguments<'a> {
-    fn from_iter<T: IntoIterator<Item = Argument<'a>>>(iter: T) -> Self {
-        Self(iter.into_iter().collect())
-    }
-}
 
 #[derive(Clone, Copy, Debug)]
 pub(crate) enum Argument<'a> {
@@ -80,12 +25,39 @@ pub(crate) enum Argument<'a> {
 
 /// Arguments for a single call, in source order, along with inferred types for each argument.
 #[derive(Clone, Debug, Default)]
-pub(crate) struct CallArgumentTypes<'a, 'db> {
-    arguments: CallArguments<'a>,
+pub(crate) struct CallArguments<'a, 'db> {
+    arguments: Vec<Argument<'a>>,
     types: Vec<Type<'db>>,
 }
 
-impl<'a, 'db> CallArgumentTypes<'a, 'db> {
+impl<'a, 'db> CallArguments<'a, 'db> {
+    fn new(iter: impl IntoIterator<Item = (Argument<'a>, Type<'db>)>) -> Self {
+        let (arguments, types) = iter.into_iter().unzip();
+        Self { arguments, types }
+    }
+
+    /// Create `CallArguments` from AST arguments
+    pub(crate) fn from_arguments(arguments: &'a ast::Arguments) -> Self {
+        Self::new(
+            arguments
+                .arguments_source_order()
+                .map(|arg_or_keyword| match arg_or_keyword {
+                    ast::ArgOrKeyword::Arg(arg) => match arg {
+                        ast::Expr::Starred(ast::ExprStarred { .. }) => Argument::Variadic,
+                        _ => Argument::Positional,
+                    },
+                    ast::ArgOrKeyword::Keyword(ast::Keyword { arg, .. }) => {
+                        if let Some(arg) = arg {
+                            Argument::Keyword(&arg.id)
+                        } else {
+                            Argument::Keywords
+                        }
+                    }
+                })
+                .map(|argument| (argument, Type::unknown())),
+        )
+    }
+
     /// Create a [`CallArgumentTypes`] with no arguments.
     pub(crate) fn none() -> Self {
         Self::default()
@@ -95,22 +67,12 @@ impl<'a, 'db> CallArgumentTypes<'a, 'db> {
     /// types.
     pub(crate) fn positional(positional_tys: impl IntoIterator<Item = Type<'db>>) -> Self {
         let types: Vec<_> = positional_tys.into_iter().collect();
-        let arguments = CallArguments(vec![Argument::Positional; types.len()]);
+        let arguments = vec![Argument::Positional; types.len()];
         Self { arguments, types }
     }
 
-    /// Create a new [`CallArgumentTypes`] to store the inferred types of the arguments in a
-    /// [`CallArguments`]. Uses the provided callback to infer each argument type.
-    pub(crate) fn new<F>(arguments: CallArguments<'a>, mut f: F) -> Self
-    where
-        F: FnMut(usize, Argument<'a>) -> Type<'db>,
-    {
-        let types = arguments
-            .iter()
-            .enumerate()
-            .map(|(idx, argument)| f(idx, argument))
-            .collect();
-        Self { arguments, types }
+    pub(crate) fn len(&self) -> usize {
+        self.arguments.len()
     }
 
     pub(crate) fn types(&self) -> &[Type<'db>] {
@@ -122,22 +84,24 @@ impl<'a, 'db> CallArgumentTypes<'a, 'db> {
     /// unmodified.)
     pub(crate) fn with_self(&self, bound_self: Option<Type<'db>>) -> Cow<Self> {
         if let Some(bound_self) = bound_self {
-            let arguments = CallArguments(
-                std::iter::once(Argument::Synthetic)
-                    .chain(self.arguments.0.iter().copied())
-                    .collect(),
-            );
+            let arguments = std::iter::once(Argument::Synthetic)
+                .chain(self.arguments.iter().copied())
+                .collect();
             let types = std::iter::once(bound_self)
                 .chain(self.types.iter().copied())
                 .collect();
-            Cow::Owned(CallArgumentTypes { arguments, types })
+            Cow::Owned(CallArguments { arguments, types })
         } else {
             Cow::Borrowed(self)
         }
     }
 
     pub(crate) fn iter(&self) -> impl Iterator<Item = (Argument<'a>, Type<'db>)> + '_ {
-        self.arguments.iter().zip(self.types.iter().copied())
+        (self.arguments.iter().copied()).zip(self.types.iter().copied())
+    }
+
+    pub(crate) fn iter_mut(&mut self) -> impl Iterator<Item = (Argument<'a>, &mut Type<'db>)> + '_ {
+        (self.arguments.iter().copied()).zip(self.types.iter_mut())
     }
 
     /// Returns an iterator on performing [argument type expansion].
@@ -146,17 +110,20 @@ impl<'a, 'db> CallArgumentTypes<'a, 'db> {
     /// contains the same arguments, but with one or more of the argument types expanded.
     ///
     /// [argument type expansion]: https://typing.python.org/en/latest/spec/overload.html#argument-type-expansion
-    pub(crate) fn expand(&self, db: &'db dyn Db) -> impl Iterator<Item = Vec<Vec<Type<'db>>>> + '_ {
+    pub(crate) fn expand(
+        &self,
+        db: &'db dyn Db,
+    ) -> impl Iterator<Item = Vec<CallArguments<'a, 'db>>> + '_ {
         /// Represents the state of the expansion process.
         ///
         /// This is useful to avoid cloning the initial types vector if none of the types can be
         /// expanded.
-        enum State<'a, 'db> {
-            Initial(&'a Vec<Type<'db>>),
-            Expanded(Vec<Vec<Type<'db>>>),
+        enum State<'a, 'b, 'db> {
+            Initial(&'b Vec<Type<'db>>),
+            Expanded(Vec<CallArguments<'a, 'db>>),
         }
 
-        impl<'db> State<'_, 'db> {
+        impl<'db> State<'_, '_, 'db> {
             fn len(&self) -> usize {
                 match self {
                     State::Initial(_) => 1,
@@ -164,10 +131,12 @@ impl<'a, 'db> CallArgumentTypes<'a, 'db> {
                 }
             }
 
-            fn iter(&self) -> impl Iterator<Item = &Vec<Type<'db>>> + '_ {
+            fn iter(&self) -> impl Iterator<Item = &[Type<'db>]> + '_ {
                 match self {
-                    State::Initial(types) => std::slice::from_ref(*types).iter(),
-                    State::Expanded(expanded) => expanded.iter(),
+                    State::Initial(types) => Either::Left(std::iter::once(types.as_slice())),
+                    State::Expanded(expanded) => {
+                        Either::Right(expanded.iter().map(CallArguments::types))
+                    }
                 }
             }
         }
@@ -184,20 +153,23 @@ impl<'a, 'db> CallArgumentTypes<'a, 'db> {
                 index += 1;
             };
 
-            let mut expanded_arg_types = Vec::with_capacity(expanded_types.len() * previous.len());
+            let mut expanded_arguments = Vec::with_capacity(expanded_types.len() * previous.len());
 
             for pre_expanded_types in previous.iter() {
                 for subtype in &expanded_types {
-                    let mut new_expanded_types = pre_expanded_types.clone();
+                    let mut new_expanded_types = pre_expanded_types.to_vec();
                     new_expanded_types[index] = *subtype;
-                    expanded_arg_types.push(new_expanded_types);
+                    expanded_arguments.push(CallArguments {
+                        arguments: self.arguments.clone(),
+                        types: new_expanded_types,
+                    });
                 }
             }
 
             // Increment the index to move to the next argument type for the next iteration.
             index += 1;
 
-            Some(State::Expanded(expanded_arg_types))
+            Some(State::Expanded(expanded_arguments))
         })
         .skip(1) // Skip the initial state, which has no expanded types.
         .map(|state| match state {
@@ -207,16 +179,10 @@ impl<'a, 'db> CallArgumentTypes<'a, 'db> {
     }
 }
 
-impl<'a> Deref for CallArgumentTypes<'a, '_> {
-    type Target = CallArguments<'a>;
-    fn deref(&self) -> &CallArguments<'a> {
-        &self.arguments
-    }
-}
-
-impl<'a> DerefMut for CallArgumentTypes<'a, '_> {
-    fn deref_mut(&mut self) -> &mut CallArguments<'a> {
-        &mut self.arguments
+impl<'a> From<Vec<Argument<'a>>> for CallArguments<'a, '_> {
+    fn from(arguments: Vec<Argument<'a>>) -> Self {
+        let types = vec![Type::unknown(); arguments.len()];
+        Self { arguments, types }
     }
 }
 

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -10,10 +10,7 @@ use itertools::Itertools;
 use ruff_db::parsed::parsed_module;
 use smallvec::{SmallVec, smallvec};
 
-use super::{
-    Argument, CallArgumentTypes, CallArguments, CallError, CallErrorKind, InferContext, Signature,
-    Type,
-};
+use super::{Argument, CallArguments, CallError, CallErrorKind, InferContext, Signature, Type};
 use crate::db::Db;
 use crate::dunder_all::dunder_all_names;
 use crate::place::{Boundness, Place};
@@ -95,12 +92,11 @@ impl<'db> Bindings<'db> {
     ///
     /// The returned bindings tell you which parameter (in each signature) each argument was
     /// matched against. You can then perform type inference on each argument with extra context
-    /// about the expected parameter types. (You do this by creating a [`CallArgumentTypes`] object
-    /// from the `arguments` that you match against.)
+    /// about the expected parameter types.
     ///
     /// Once you have argument types available, you can call [`check_types`][Self::check_types] to
     /// verify that each argument type is assignable to the corresponding parameter type.
-    pub(crate) fn match_parameters(mut self, arguments: &CallArguments<'_>) -> Self {
+    pub(crate) fn match_parameters(mut self, arguments: &CallArguments<'_, 'db>) -> Self {
         let mut argument_forms = vec![None; arguments.len()];
         let mut conflicting_forms = vec![false; arguments.len()];
         for binding in &mut self.elements {
@@ -123,7 +119,7 @@ impl<'db> Bindings<'db> {
     pub(crate) fn check_types(
         mut self,
         db: &'db dyn Db,
-        argument_types: &CallArgumentTypes<'_, 'db>,
+        argument_types: &CallArguments<'_, 'db>,
     ) -> Result<Self, CallError<'db>> {
         for element in &mut self.elements {
             element.check_types(db, argument_types);
@@ -410,7 +406,7 @@ impl<'db> Bindings<'db> {
                             [Some(Type::PropertyInstance(property)), Some(instance), ..] => {
                                 if let Some(getter) = property.getter(db) {
                                     if let Ok(return_ty) = getter
-                                        .try_call(db, &CallArgumentTypes::positional([*instance]))
+                                        .try_call(db, &CallArguments::positional([*instance]))
                                         .map(|binding| binding.return_type(db))
                                     {
                                         overload.set_return_type(return_ty);
@@ -439,7 +435,7 @@ impl<'db> Bindings<'db> {
                             [Some(instance), ..] => {
                                 if let Some(getter) = property.getter(db) {
                                     if let Ok(return_ty) = getter
-                                        .try_call(db, &CallArgumentTypes::positional([*instance]))
+                                        .try_call(db, &CallArguments::positional([*instance]))
                                         .map(|binding| binding.return_type(db))
                                     {
                                         overload.set_return_type(return_ty);
@@ -469,10 +465,9 @@ impl<'db> Bindings<'db> {
                         ] = overload.parameter_types()
                         {
                             if let Some(setter) = property.setter(db) {
-                                if let Err(_call_error) = setter.try_call(
-                                    db,
-                                    &CallArgumentTypes::positional([*instance, *value]),
-                                ) {
+                                if let Err(_call_error) = setter
+                                    .try_call(db, &CallArguments::positional([*instance, *value]))
+                                {
                                     overload.errors.push(BindingError::InternalCallError(
                                         "calling the setter failed",
                                     ));
@@ -488,10 +483,9 @@ impl<'db> Bindings<'db> {
                     Type::MethodWrapper(MethodWrapperKind::PropertyDunderSet(property)) => {
                         if let [Some(instance), Some(value), ..] = overload.parameter_types() {
                             if let Some(setter) = property.setter(db) {
-                                if let Err(_call_error) = setter.try_call(
-                                    db,
-                                    &CallArgumentTypes::positional([*instance, *value]),
-                                ) {
+                                if let Err(_call_error) = setter
+                                    .try_call(db, &CallArguments::positional([*instance, *value]))
+                                {
                                     overload.errors.push(BindingError::InternalCallError(
                                         "calling the setter failed",
                                     ));
@@ -1161,7 +1155,7 @@ impl<'db> CallableBinding<'db> {
 
     fn match_parameters(
         &mut self,
-        arguments: &CallArguments<'_>,
+        arguments: &CallArguments<'_, 'db>,
         argument_forms: &mut [Option<ParameterForm>],
         conflicting_forms: &mut [bool],
     ) {
@@ -1174,7 +1168,7 @@ impl<'db> CallableBinding<'db> {
         }
     }
 
-    fn check_types(&mut self, db: &'db dyn Db, argument_types: &CallArgumentTypes<'_, 'db>) {
+    fn check_types(&mut self, db: &'db dyn Db, argument_types: &CallArguments<'_, 'db>) {
         // If this callable is a bound method, prepend the self instance onto the arguments list
         // before checking.
         let argument_types = argument_types.with_self(self.bound_type);
@@ -1186,7 +1180,7 @@ impl<'db> CallableBinding<'db> {
                 // still perform type checking for non-overloaded function to provide better user
                 // experience.
                 if let [overload] = self.overloads.as_mut_slice() {
-                    overload.check_types(db, argument_types.as_ref(), argument_types.types());
+                    overload.check_types(db, argument_types.as_ref());
                 }
                 return;
             }
@@ -1194,11 +1188,7 @@ impl<'db> CallableBinding<'db> {
                 // If only one candidate overload remains, it is the winning match. Evaluate it as
                 // a regular (non-overloaded) call.
                 self.matching_overload_index = Some(index);
-                self.overloads[index].check_types(
-                    db,
-                    argument_types.as_ref(),
-                    argument_types.types(),
-                );
+                self.overloads[index].check_types(db, argument_types.as_ref());
                 return;
             }
             MatchingOverloadIndex::Multiple(indexes) => {
@@ -1216,7 +1206,7 @@ impl<'db> CallableBinding<'db> {
         // Step 2: Evaluate each remaining overload as a regular (non-overloaded) call to determine
         // whether it is compatible with the supplied argument list.
         for (_, overload) in self.matching_overloads_mut() {
-            overload.check_types(db, argument_types.as_ref(), argument_types.types());
+            overload.check_types(db, argument_types.as_ref());
         }
 
         match self.matching_overload_index() {
@@ -1232,7 +1222,7 @@ impl<'db> CallableBinding<'db> {
                 // TODO: Step 4
 
                 // Step 5
-                self.filter_overloads_using_any_or_unknown(db, argument_types.types(), &indexes);
+                self.filter_overloads_using_any_or_unknown(db, argument_types.as_ref(), &indexes);
 
                 // We're returning here because this shouldn't lead to argument type expansion.
                 return;
@@ -1268,7 +1258,7 @@ impl<'db> CallableBinding<'db> {
                 let pre_evaluation_snapshot = snapshotter.take(self);
 
                 for (_, overload) in self.matching_overloads_mut() {
-                    overload.check_types(db, argument_types.as_ref(), expanded_argument_types);
+                    overload.check_types(db, expanded_argument_types);
                 }
 
                 let return_type = match self.matching_overload_index() {
@@ -1358,7 +1348,7 @@ impl<'db> CallableBinding<'db> {
     fn filter_overloads_using_any_or_unknown(
         &mut self,
         db: &'db dyn Db,
-        argument_types: &[Type<'db>],
+        arguments: &CallArguments<'_, 'db>,
         matching_overload_indexes: &[usize],
     ) {
         // These are the parameter indexes that matches the arguments that participate in the
@@ -1372,7 +1362,7 @@ impl<'db> CallableBinding<'db> {
         // participating parameter indexes.
         let mut top_materialized_argument_types = vec![];
 
-        for (argument_index, argument_type) in argument_types.iter().enumerate() {
+        for (argument_index, (_, argument_type)) in arguments.iter().enumerate() {
             let mut first_parameter_type: Option<Type<'db>> = None;
             let mut participating_parameter_index = None;
 
@@ -1415,8 +1405,8 @@ impl<'db> CallableBinding<'db> {
                 self.overloads[*current_index].mark_as_unmatched_overload();
                 continue;
             }
-            let mut parameter_types = Vec::with_capacity(argument_types.len());
-            for argument_index in 0..argument_types.len() {
+            let mut parameter_types = Vec::with_capacity(arguments.len());
+            for argument_index in 0..arguments.len() {
                 // The parameter types at the current argument index.
                 let mut current_parameter_types = vec![];
                 for overload_index in &matching_overload_indexes[..=upto] {
@@ -1904,8 +1894,7 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
 struct ArgumentTypeChecker<'a, 'db> {
     db: &'db dyn Db,
     signature: &'a Signature<'db>,
-    arguments: &'a CallArguments<'a>,
-    argument_types: &'a [Type<'db>],
+    arguments: &'a CallArguments<'a, 'db>,
     argument_parameters: &'a [Option<usize>],
     parameter_tys: &'a mut [Option<Type<'db>>],
     errors: &'a mut Vec<BindingError<'db>>,
@@ -1918,8 +1907,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
     fn new(
         db: &'db dyn Db,
         signature: &'a Signature<'db>,
-        arguments: &'a CallArguments<'a>,
-        argument_types: &'a [Type<'db>],
+        arguments: &'a CallArguments<'a, 'db>,
         argument_parameters: &'a [Option<usize>],
         parameter_tys: &'a mut [Option<Type<'db>>],
         errors: &'a mut Vec<BindingError<'db>>,
@@ -1928,7 +1916,6 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             db,
             signature,
             arguments,
-            argument_types,
             argument_parameters,
             parameter_tys,
             errors,
@@ -1940,9 +1927,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
     fn enumerate_argument_types(
         &self,
     ) -> impl Iterator<Item = (usize, Option<usize>, Argument<'a>, Type<'db>)> + 'a {
-        let mut iter = (self.arguments.iter())
-            .zip(self.argument_types.iter().copied())
-            .enumerate();
+        let mut iter = self.arguments.iter().enumerate();
         let mut num_synthetic_args = 0;
         std::iter::from_fn(move || {
             let (argument_index, (argument, argument_type)) = iter.next()?;
@@ -2127,7 +2112,7 @@ impl<'db> Binding<'db> {
 
     pub(crate) fn match_parameters(
         &mut self,
-        arguments: &CallArguments<'_>,
+        arguments: &CallArguments<'_, 'db>,
         argument_forms: &mut [Option<ParameterForm>],
         conflicting_forms: &mut [bool],
     ) {
@@ -2139,7 +2124,7 @@ impl<'db> Binding<'db> {
             conflicting_forms,
             &mut self.errors,
         );
-        for (argument_index, argument) in arguments.iter().enumerate() {
+        for (argument_index, (argument, _)) in arguments.iter().enumerate() {
             match argument {
                 Argument::Positional | Argument::Synthetic => {
                     let _ = matcher.match_positional(argument_index, argument);
@@ -2158,17 +2143,11 @@ impl<'db> Binding<'db> {
         self.argument_parameters = matcher.finish();
     }
 
-    fn check_types(
-        &mut self,
-        db: &'db dyn Db,
-        arguments: &CallArguments<'_>,
-        argument_types: &[Type<'db>],
-    ) {
+    fn check_types(&mut self, db: &'db dyn Db, arguments: &CallArguments<'_, 'db>) {
         let mut checker = ArgumentTypeChecker::new(
             db,
             &self.signature,
             arguments,
-            argument_types,
             &self.argument_parameters,
             &mut self.parameter_tys,
             &mut self.errors,
@@ -2210,7 +2189,7 @@ impl<'db> Binding<'db> {
 
     pub(crate) fn arguments_for_parameter<'a>(
         &'a self,
-        argument_types: &'a CallArgumentTypes<'a, 'db>,
+        argument_types: &'a CallArguments<'a, 'db>,
         parameter_index: usize,
     ) -> impl Iterator<Item = (Argument<'a>, Type<'db>)> + 'a {
         argument_types

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -38,7 +38,7 @@ use crate::{
         place_table, semantic_index, use_def_map,
     },
     types::{
-        CallArgumentTypes, CallError, CallErrorKind, MetaclassCandidate, UnionBuilder, UnionType,
+        CallArguments, CallError, CallErrorKind, MetaclassCandidate, UnionBuilder, UnionType,
         definition_expression_type,
     },
 };
@@ -1201,7 +1201,7 @@ impl<'db> ClassLiteral<'db> {
                 .to_specialized_instance(db, [KnownClass::Str.to_instance(db), Type::any()]);
 
             // TODO: Other keyword arguments?
-            let arguments = CallArgumentTypes::positional([name, bases, namespace]);
+            let arguments = CallArguments::positional([name, bases, namespace]);
 
             let return_ty_result = match metaclass.try_call(db, &arguments) {
                 Ok(bindings) => Ok(bindings.return_type(db)),
@@ -3303,7 +3303,7 @@ impl KnownClass {
         context: &InferContext<'db, '_>,
         index: &SemanticIndex<'db>,
         overload_binding: &Binding<'db>,
-        call_argument_types: &CallArgumentTypes<'_, 'db>,
+        call_argument_types: &CallArguments<'_, 'db>,
         call_expression: &ast::ExprCall,
     ) -> Option<Type<'db>> {
         let db = context.db();

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -2,7 +2,7 @@ use super::call::CallErrorKind;
 use super::context::InferContext;
 use super::mro::DuplicateBaseError;
 use super::{
-    CallArgumentTypes, CallDunderError, ClassBase, ClassLiteral, KnownClass,
+    CallArguments, CallDunderError, ClassBase, ClassLiteral, KnownClass,
     add_inferred_python_version_hint_to_diagnostic,
 };
 use crate::lint::{Level, LintRegistryBuilder, LintStatus};
@@ -2325,7 +2325,7 @@ pub(crate) fn report_invalid_or_unsupported_base(
     match base_type.try_call_dunder(
         db,
         "__mro_entries__",
-        CallArgumentTypes::positional([tuple_of_types]),
+        CallArguments::positional([tuple_of_types]),
     ) {
         Ok(ret) => {
             if ret.return_type(db).is_assignable_to(db, tuple_of_types) {


### PR DESCRIPTION
We previously had separate `CallArguments` and `CallArgumentTypes` types in support of our two-phase call binding logic. `CallArguments` would store only the arity/kind of each argument (positional, keyword, variadic, etc). We then performed parameter matching using only this arity/kind information, and then infered the type of each argument, placing the result of this second phase into a new `CallArgumentTypes`.

In #18996, we will need to infer the types of splatted arguments _before_ performing parameter matching, since we need to know the argument type to accurately infer its length, which informs how many parameters the splatted argument is matched against.

That makes this separation of Rust types no longer useful. This PR merges everything back into a single `CallArguments`. In the case where we are performing two-phase call binding, the types will be initialized to `Unknown`, and updated to the actual argument type during the second `check_types` phase.

_[This is a refactoring in support of fixing the merge conflicts on #18996. I've pulled this out into a separate PR to make it easier to review in isolation.]_