### PR TITLE
[`refurb`] Ignore decorated functions for FURB118

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/refurb/FURB118.py
+++ b/crates/ruff_linter/resources/test/fixtures/refurb/FURB118.py
@@ -143,3 +143,23 @@ class NotAMethodButHardToDetect:
     # without risking false positives elsewhere or introducing complex heuristics
     # that users would find surprising and confusing
     FOO = sorted([x for x in BAR], key=lambda x: x.baz)
+
+# https://github.com/astral-sh/ruff/issues/19305
+import pytest
+
+@pytest.fixture
+def my_fixture_with_param(request):
+    return request.param
+
+@pytest.fixture()
+def my_fixture_with_param2(request):
+    return request.param
+
+
+# Decorated function (should be ignored)
+def custom_decorator(func):
+    return func
+
+@custom_decorator
+def add(x, y):
+    return x + y

--- a/crates/ruff_linter/src/rules/refurb/rules/reimplemented_operator.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/reimplemented_operator.rs
@@ -104,6 +104,13 @@ pub(crate) fn reimplemented_operator(checker: &Checker, target: &FunctionLike) {
         return;
     }
 
+    // Skip decorated functions
+    if let FunctionLike::Function(func) = target {
+        if !func.decorator_list.is_empty() {
+            return;
+        }
+    }
+
     let Some(params) = target.parameters() else {
         return;
     };


### PR DESCRIPTION
## Summary

Fixes #19305