### PR TITLE
distinguish references from definitions in `infer_nonlocal`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/scopes/nonlocal.md
+++ b/crates/ty_python_semantic/resources/mdtest/scopes/nonlocal.md
@@ -141,6 +141,12 @@ def f():
     global x
     def g():
         nonlocal x  # error: [invalid-syntax] "no binding for nonlocal `x` found"
+
+def f():
+    # A *use* of `x` in an enclosing scope isn't good enough. There needs to be a binding.
+    print(x)
+    def g():
+        nonlocal x  # error: [invalid-syntax] "no binding for nonlocal `x` found"
 ```
 
 A class-scoped `x` also doesn't work:

--- a/crates/ty_python_semantic/src/semantic_index/place.rs
+++ b/crates/ty_python_semantic/src/semantic_index/place.rs
@@ -320,7 +320,7 @@ impl PlaceExprWithFlags {
         self.flags.contains(PlaceFlags::IS_USED)
     }
 
-    /// Is the place defined in its containing scope?
+    /// Is the place given a value in its containing scope?
     pub fn is_bound(&self) -> bool {
         self.flags.contains(PlaceFlags::IS_BOUND)
     }


### PR DESCRIPTION
The initial implementation of `infer_nonlocal` landed in https://github.com/astral-sh/ruff/pull/19112 fails to report an error for this example:

```py
x = 1
def f():
    # This is only a usage of `x`, not a definition. It shouldn't be
    # enough to make the `nonlocal` statement below allowed.
    print(x)
    def g():
        nonlocal x
```

Fix this by continuing to walk enclosing scopes when the place we've found isn't bound, declared, or `nonlocal`.