### PR TITLE
[ty] Make use of salsa `Lookup` when interning values

### DIFF
--- a/crates/ty_python_semantic/src/semantic_index/builder.rs
+++ b/crates/ty_python_semantic/src/semantic_index/builder.rs
@@ -2692,7 +2692,7 @@ impl ExpressionsScopeMapBuilder {
         let mut interval_map = Vec::new();
 
         let mut current_scope = first.1;
-        let mut range = first.0..=NodeIndex::from(first.0.as_u32() + 1);
+        let mut range = first.0..=first.0;
 
         for (index, scope) in iter {
             if scope == current_scope {

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3135,7 +3135,7 @@ impl<'db> Type<'db> {
                         db,
                         "__getattr__",
                         CallArgumentTypes::positional([Type::StringLiteral(
-                            StringLiteralType::new(db, Box::from(name.as_str())),
+                            StringLiteralType::new(db, name.as_str()),
                         )]),
                     )
                     .map(|outcome| Place::bound(outcome.return_type(db)))
@@ -3156,7 +3156,7 @@ impl<'db> Type<'db> {
                         db,
                         "__getattribute__",
                         &mut CallArgumentTypes::positional([Type::StringLiteral(
-                            StringLiteralType::new(db, Box::from(name.as_str())),
+                            StringLiteralType::new(db, name.as_str()),
                         )]),
                         MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
                     )
@@ -4988,7 +4988,7 @@ impl<'db> Type<'db> {
                     );
                     Ok(Type::TypeVar(TypeVarInstance::new(
                         db,
-                        ast::name::Name::new("Self"),
+                        ast::name::Name::new_static("Self"),
                         Some(class.definition(db)),
                         Some(TypeVarBoundOrConstraints::UpperBound(instance)),
                         TypeVarVariance::Invariant,
@@ -8195,7 +8195,7 @@ impl<'db> StringLiteralType<'db> {
     pub(crate) fn iter_each_char(self, db: &'db dyn Db) -> impl Iterator<Item = Self> {
         self.value(db)
             .chars()
-            .map(|c| StringLiteralType::new(db, c.to_string().as_str()))
+            .map(|c| StringLiteralType::new(db, c.to_string().into_boxed_str()))
     }
 }
 

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -3502,7 +3502,7 @@ impl KnownClass {
                 Some(Type::KnownInstance(KnownInstanceType::TypeVar(
                     TypeVarInstance::new(
                         db,
-                        target.id.clone(),
+                        &target.id,
                         Some(containing_assignment),
                         bound_or_constraint,
                         variance,

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -2366,7 +2366,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let function_literal =
             FunctionLiteral::new(self.db(), overload_literal, inherited_generic_context);
 
-        let type_mappings = Box::from([]);
+        let type_mappings = Box::default();
         let mut inferred_ty = Type::FunctionLiteral(FunctionType::new(
             self.db(),
             function_literal,
@@ -3070,7 +3070,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let default_ty = self.infer_optional_type_expression(default.as_deref());
         let ty = Type::KnownInstance(KnownInstanceType::TypeVar(TypeVarInstance::new(
             self.db(),
-            name.id.clone(),
+            &name.id,
             Some(definition),
             bound_or_constraint,
             TypeVarVariance::Invariant, // TODO: infer this
@@ -3462,7 +3462,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     db,
                     "__setattr__",
                     &mut CallArgumentTypes::positional([
-                        Type::StringLiteral(StringLiteralType::new(db, Box::from(attribute))),
+                        Type::StringLiteral(StringLiteralType::new(db, attribute)),
                         value_ty,
                     ]),
                     MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,


### PR DESCRIPTION
## Summary

Interning a value doesn't require an owned value in Salsa. Instead, a value can implement the `Lookup` trait
so that the owned value is only allocated if the value-to-intern doesn't exist yet.

## Test Plan

`cargo test`
