### PR TITLE
[ty] Add ecosystem-report workflow

### DIFF
--- a/.github/workflows/ty-ecosystem-report.yaml
+++ b/.github/workflows/ty-ecosystem-report.yaml
@@ -1,0 +1,76 @@
+name: ty ecosystem-report
+
+permissions: {}
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Run every Wednesday at 5:00 UTC:
+    - cron: 0 5 * * 3
+
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  CARGO_TERM_COLOR: always
+  RUSTUP_MAX_RETRIES: 10
+  RUST_BACKTRACE: 1
+  CF_API_TOKEN_EXISTS: ${{ secrets.CF_API_TOKEN != '' }}
+
+jobs:
+  ty-ecosystem-report:
+    name: Create ecosystem report
+    runs-on: depot-ubuntu-22.04-32
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          path: ruff
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6.3.1
+
+      - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
+        with:
+          workspaces: "ruff"
+
+      - name: Install Rust toolchain
+        run: rustup show
+
+      - name: Create report
+        shell: bash
+        run: |
+          cd ruff
+
+          echo "Enabling configuration overloads (see .github/mypy-primer-ty.toml)"
+          mkdir -p ~/.config/ty
+          cp .github/mypy-primer-ty.toml ~/.config/ty/ty.toml
+
+          cd ..
+
+          uv tool install "git+https://github.com/astral-sh/ecosystem-analyzer@f0eec0e549684d8e1d7b8bc3e351202124b63bda"
+
+          ecosystem-analyzer \
+            --verbose \
+            --repository ruff \
+            analyze \
+            --projects ruff/crates/ty_python_semantic/resources/primer/good.txt \
+            --output ecosystem-diagnostics.json
+
+          mkdir dist
+
+          ecosystem-analyzer \
+            generate-report \
+            --max-diagnostics-per-project=1200 \
+            ecosystem-diagnostics.json \
+            --output dist/index.html
+
+      - name: "Deploy to Cloudflare Pages"
+        if: ${{ env.CF_API_TOKEN_EXISTS == 'true' }}
+        id: deploy
+        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3.14.1
+        with:
+          apiToken: ${{ secrets.CF_API_TOKEN }}
+          accountId: ${{ secrets.CF_ACCOUNT_ID }}
+          command: pages deploy dist --project-name=ty-ecosystem --branch main --commit-hash ${GITHUB_SHA}

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -11,6 +11,7 @@ rules:
       - build-docker.yml
       - publish-playground.yml
       - ty-ecosystem-analyzer.yaml
+      - ty-ecosystem-report.yaml
   excessive-permissions:
     # it's hard to test what the impact of removing these ignores would be
     # without actually running the release workflow...


### PR DESCRIPTION
## Summary

Adds a new workflow that generates an ecosystem report like [this](https://shark.fish/ecosystem-report.html) and publishes it to Cloudflare pages.

## Test Plan

Not yet tested.