### PR TITLE
[ty] Use `Type::string_literal()` more

### DIFF
--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3134,9 +3134,7 @@ impl<'db> Type<'db> {
                     self.try_call_dunder(
                         db,
                         "__getattr__",
-                        CallArgumentTypes::positional([Type::StringLiteral(
-                            StringLiteralType::new(db, name.as_str()),
-                        )]),
+                        CallArgumentTypes::positional([Type::string_literal(db, &name)]),
                     )
                     .map(|outcome| Place::bound(outcome.return_type(db)))
                     // TODO: Handle call errors here.
@@ -3155,9 +3153,7 @@ impl<'db> Type<'db> {
                     self.try_call_dunder_with_policy(
                         db,
                         "__getattribute__",
-                        &mut CallArgumentTypes::positional([Type::StringLiteral(
-                            StringLiteralType::new(db, name.as_str()),
-                        )]),
+                        &mut CallArgumentTypes::positional([Type::string_literal(db, &name)]),
                         MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
                     )
                     .map(|outcome| Place::bound(outcome.return_type(db)))

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -1009,28 +1009,22 @@ mod tests {
     use crate::Db;
     use crate::db::tests::setup_db;
     use crate::place::typing_extensions_symbol;
-    use crate::types::{KnownClass, Parameter, Parameters, Signature, StringLiteralType, Type};
+    use crate::types::{KnownClass, Parameter, Parameters, Signature, Type};
 
     #[test]
     fn string_literal_display() {
         let db = setup_db();
 
         assert_eq!(
-            Type::StringLiteral(StringLiteralType::new(&db, r"\n"))
-                .display(&db)
-                .to_string(),
+            Type::string_literal(&db, r"\n").display(&db).to_string(),
             r#"Literal["\\n"]"#
         );
         assert_eq!(
-            Type::StringLiteral(StringLiteralType::new(&db, "'"))
-                .display(&db)
-                .to_string(),
+            Type::string_literal(&db, "'").display(&db).to_string(),
             r#"Literal["'"]"#
         );
         assert_eq!(
-            Type::StringLiteral(StringLiteralType::new(&db, r#"""#))
-                .display(&db)
-                .to_string(),
+            Type::string_literal(&db, r#"""#).display(&db).to_string(),
             r#"Literal["\""]"#
         );
     }

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -113,10 +113,9 @@ use crate::types::{
     CallDunderError, CallableType, ClassLiteral, ClassType, DataclassParams, DynamicType,
     IntersectionBuilder, IntersectionType, KnownClass, KnownInstanceType, LintDiagnosticGuard,
     MemberLookupPolicy, MetaclassCandidate, PEP695TypeAliasType, Parameter, ParameterForm,
-    Parameters, SpecialFormType, StringLiteralType, SubclassOfType, Truthiness, Type,
-    TypeAliasType, TypeAndQualifiers, TypeIsType, TypeQualifiers, TypeVarBoundOrConstraints,
-    TypeVarInstance, TypeVarKind, TypeVarVariance, UnionBuilder, UnionType, binding_type,
-    todo_type,
+    Parameters, SpecialFormType, SubclassOfType, Truthiness, Type, TypeAliasType,
+    TypeAndQualifiers, TypeIsType, TypeQualifiers, TypeVarBoundOrConstraints, TypeVarInstance,
+    TypeVarKind, TypeVarVariance, UnionBuilder, UnionType, binding_type, todo_type,
 };
 use crate::unpack::{Unpack, UnpackPosition};
 use crate::util::diagnostics::format_enumeration;
@@ -3462,7 +3461,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     db,
                     "__setattr__",
                     &mut CallArgumentTypes::positional([
-                        Type::StringLiteral(StringLiteralType::new(db, attribute)),
+                        Type::string_literal(db, attribute),
                         value_ty,
                     ]),
                     MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,


### PR DESCRIPTION
Minor followup to #19347