### PR TITLE
Make TC010 docs example more realistic

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_type_checking/rules/runtime_string_union.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/rules/runtime_string_union.rs
@@ -23,17 +23,25 @@ use crate::checkers::ast::Checker;
 ///
 /// ## Example
 /// ```python
-/// var: str | "int"
+/// var: "Foo" | None
+///
+/// class Foo: ...
 /// ```
 ///
 /// Use instead:
 /// ```python
-/// var: str | int
+/// from __future__ import annotations
+///
+/// var: Foo | None
+///
+/// class Foo: ...
 /// ```
 ///
 /// Or, extend the quotes to include the entire union:
 /// ```python
-/// var: "str | int"
+/// var: "Foo | None"
+///
+/// class Foo: ...
 /// ```
 ///
 /// ## References


### PR DESCRIPTION
## Summary

I noticed this while reviewing https://github.com/astral-sh/ruff/pull/19100. The current example here is pretty confusing IMO: you'd never need to quote `int` in a type annotation, because it's always defined (it's a builtin!). Usually you quote annotations if they represent a forward reference to something defined later on. Also, the first "use instead" suggestion will only be valid if you also add `from __future__ import annotations` to the top of the file; this makes that explicit
