### PR TITLE
[ty] Allow `-qq` for silent output mode

### DIFF
--- a/crates/ty/docs/cli.md
+++ b/crates/ty/docs/cli.md
@@ -84,7 +84,7 @@ over all configuration files.</p>
 <li><code>3.11</code></li>
 <li><code>3.12</code></li>
 <li><code>3.13</code></li>
-</ul></dd><dt id="ty-check--quiet"><a href="#ty-check--quiet"><code>--quiet</code></a>, <code>-q</code></dt><dd><p>Use quiet output</p>
+</ul></dd><dt id="ty-check--quiet"><a href="#ty-check--quiet"><code>--quiet</code></a>, <code>-q</code></dt><dd><p>Use quiet output (or <code>-qq</code> for silent output)</p>
 </dd><dt id="ty-check--respect-ignore-files"><a href="#ty-check--respect-ignore-files"><code>--respect-ignore-files</code></a></dt><dd><p>Respect file exclusions via <code>.gitignore</code> and other standard ignore files. Use <code>--no-respect-gitignore</code> to disable</p>
 </dd><dt id="ty-check--typeshed"><a href="#ty-check--typeshed"><code>--typeshed</code></a>, <code>--custom-typeshed-dir</code> <i>path</i></dt><dd><p>Custom directory to use for stdlib typeshed stubs</p>
 </dd><dt id="ty-check--verbose"><a href="#ty-check--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output (or <code>-vv</code> and <code>-vvv</code> for more verbose output)</p>

--- a/crates/ty/src/logging.rs
+++ b/crates/ty/src/logging.rs
@@ -31,7 +31,7 @@ pub(crate) struct Verbosity {
     #[arg(
         long,
         short,
-        help = "Use quiet output",
+        help = "Use quiet output (or `-qq` for silent output)",
         action = clap::ArgAction::Count,
         global = true,
         overrides_with = "verbose",
@@ -47,8 +47,8 @@ impl Verbosity {
         // `--quiet` and `--verbose` are mutually exclusive in Clap, so we can just check one first.
         match self.quiet {
             0 => {}
-            _ => return VerbosityLevel::Quiet,
-            // TODO(zanieb): Add support for `-qq` with a "silent" mode
+            1 => return VerbosityLevel::Quiet,
+            _ => return VerbosityLevel::Silent,
         }
 
         match self.verbose {
@@ -62,6 +62,9 @@ impl Verbosity {
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Default)]
 pub(crate) enum VerbosityLevel {
+    /// Silent output. Does not show any logging output or summary information.
+    Silent,
+
     /// Quiet output.  Only shows Ruff and ty events up to the [`ERROR`](tracing::Level::ERROR).
     /// Silences output except for summary information.
     Quiet,
@@ -85,6 +88,7 @@ pub(crate) enum VerbosityLevel {
 impl VerbosityLevel {
     const fn level_filter(self) -> LevelFilter {
         match self {
+            VerbosityLevel::Silent => LevelFilter::OFF,
             VerbosityLevel::Quiet => LevelFilter::ERROR,
             VerbosityLevel::Default => LevelFilter::WARN,
             VerbosityLevel::Verbose => LevelFilter::INFO,

--- a/crates/ty/src/printer.rs
+++ b/crates/ty/src/printer.rs
@@ -34,6 +34,7 @@ impl Printer {
         }
 
         match self.verbosity {
+            VerbosityLevel::Silent => ProgressDrawTarget::hidden(),
             VerbosityLevel::Quiet => ProgressDrawTarget::hidden(),
             VerbosityLevel::Default => ProgressDrawTarget::stderr(),
             // Hide the progress bar when in verbose mode.
@@ -50,6 +51,7 @@ impl Printer {
     /// [`VerbosityLevel::Quiet`] is used.
     fn stdout_important(self) -> Stdout {
         match self.verbosity {
+            VerbosityLevel::Silent => Stdout::disabled(),
             VerbosityLevel::Quiet => Stdout::enabled(),
             VerbosityLevel::Default => Stdout::enabled(),
             VerbosityLevel::Verbose => Stdout::enabled(),
@@ -63,6 +65,7 @@ impl Printer {
     /// The returned stream will be disabled when [`VerbosityLevel::Quiet`] is used.
     fn stdout_general(self) -> Stdout {
         match self.verbosity {
+            VerbosityLevel::Silent => Stdout::disabled(),
             VerbosityLevel::Quiet => Stdout::disabled(),
             VerbosityLevel::Default => Stdout::enabled(),
             VerbosityLevel::Verbose => Stdout::enabled(),

--- a/crates/ty/tests/cli/main.rs
+++ b/crates/ty/tests/cli/main.rs
@@ -84,7 +84,6 @@ fn test_quiet_output() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    Found 1 diagnostic
 
     ----- stderr -----
     ");


### PR DESCRIPTION
This matches uv's behavior.

Briefly discussed at https://github.com/astral-sh/ruff/pull/19233#discussion_r2197930360

I think the most useful case is to avoid piping to `/dev/null` which hard to do properly in a cross-platform script.