### PR TITLE
Fix typeshed-sync workflow

### DIFF
--- a/.github/workflows/sync_typeshed.yaml
+++ b/.github/workflows/sync_typeshed.yaml
@@ -89,7 +89,7 @@ jobs:
       - name: Push the changes
         id: commit
         if: ${{ success() }}
-        run: git push --force --set-upstream origin "${UPSTREAM_BRANCH}"
+        run: git -C ruff push --force --set-upstream origin "${UPSTREAM_BRANCH}"
 
   # Checkout the branch created by the sync job,
   # and sync all docstrings available on Windows that are not available on Linux.

--- a/scripts/codemod_docstrings.sh
+++ b/scripts/codemod_docstrings.sh
@@ -18,10 +18,10 @@
 
 set -eu
 
-docstring_adder="git+https://github.com/astral-sh/docstring-adder.git@7f350b03ee83dd44ebd8010228ad3dfca34a7887"
+docstring_adder="git+https://github.com/astral-sh/docstring-adder.git@513b650c8c6b0f1bb6f12d8f79da9294614214e4"
 stdlib_path="./crates/ty_vendored/vendor/typeshed/stdlib"
 
 for python_version in 3.14 3.13 3.12 3.11 3.10 3.9
 do
-  uvx --python="$python_version" --force-reinstall --from="${docstring_adder}" add-docstrings --stdlib-path="${stdlib_path}"
+  PYTHONUTF8=1 uvx --python="$python_version" --force-reinstall --from="${docstring_adder}" add-docstrings --stdlib-path="${stdlib_path}"
 done


### PR DESCRIPTION
we need to either cd into the Ruff repo or use `-C` here to push to the upstream branch. An oversight in https://github.com/astral-sh/ruff/commit/8d7d02193e9baa094595ec8571478241cd5bc77d