### PR TITLE
chore: Document Material for MkDocs Insiders limitations in CONTRIBUTING.md in more detail

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -271,7 +271,7 @@ Finally, regenerate the documentation and generated code with `cargo dev generat
 > The documentation uses Material for MkDocs Insiders, which is closed-source software.
 > This means only members of the Astral organization can preview the documentation exactly as it
 > will appear in production.
-> Outside contributors can still preview the documentation, but there will be some differences. Consult \[the Material for MkDocs documentation\]((<https://squidfunk.github.io/mkdocs-material/insiders/benefits/#features>) for which features are exlsuively available in the insiders version\].
+> Outside contributors can still preview the documentation, but there will be some differences. Consult [the Material for MkDocs documentation](https://squidfunk.github.io/mkdocs-material/insiders/benefits/#features) for which features are exclusively available in the insiders version.
 
 To preview any changes to the documentation locally:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -266,6 +266,14 @@ Finally, regenerate the documentation and generated code with `cargo dev generat
 
 ## MkDocs
 
+> [!NOTE]
+>
+> The production documentation uses Material for MkDocs Insiders, which is closed-source software.
+> This means only members of the Astral organization can preview the documentation exactly as it
+> will appear in production.
+> Outside contributors can still preview documentation, but there will be some differences.
+> MkDocs maintains a [list of features that are available solely to Insiders](https://squidfunk.github.io/mkdocs-material/insiders/benefits/#features).
+
 To preview any changes to the documentation locally:
 
 1. Install the [Rust toolchain](https://www.rust-lang.org/tools/install).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -268,11 +268,10 @@ Finally, regenerate the documentation and generated code with `cargo dev generat
 
 > [!NOTE]
 >
-> The production documentation uses Material for MkDocs Insiders, which is closed-source software.
+> The documentation uses Material for MkDocs Insiders, which is closed-source software.
 > This means only members of the Astral organization can preview the documentation exactly as it
 > will appear in production.
-> Outside contributors can still preview documentation, but there will be some differences.
-> MkDocs maintains a [list of features that are available solely to Insiders](https://squidfunk.github.io/mkdocs-material/insiders/benefits/#features).
+> Outside contributors can still preview the documentation, but there will be some differences. Consult \[the Material for MkDocs documentation\]((<https://squidfunk.github.io/mkdocs-material/insiders/benefits/#features>) for which features are exlsuively available in the insiders version\].
 
 To preview any changes to the documentation locally:
 


### PR DESCRIPTION
## Summary

It took me some time to figure out that as an outside contributor I can't reproduce the docs. This is because the Ruff docs use Material for MkDocs Insiders, which is closed source.

While CONTRIBUTING.md has terse comments to point outside contributors to a fallback, it does not go into much detail.

This PR adds a Note admonition to highlight to new contributors that they can't fully reproduce the docs locally, with a relevant link to the features that are missing from the OSS version.

I arrived here through a rabbit hole via https://github.com/astral-sh/ruff/issues/19362 and https://github.com/astral-sh/ruff/issues/19369