### PR TITLE
chore(deps): upgrade mkdocs-github-admonitions-plugin to v0.1.1

### DIFF
--- a/docs/requirements-insiders.txt
+++ b/docs/requirements-insiders.txt
@@ -1,6 +1,7 @@
 PyYAML==6.0.2
 ruff==0.12.3
 mkdocs==1.6.1
+# Renovate does not update non-Pypy dependencies, so the mkdocs-material sha needs to be manually updated
 mkdocs-material @ git+ssh://git@github.com/astral-sh/mkdocs-material-insiders.git@39da7a5e761410349e9a1b8abf593b0cdd5453ff
 mkdocs-redirects==1.2.2
 mdformat==0.7.22


### PR DESCRIPTION
## Summary

Renovate doesn't upgrade sha-pinned dependencies.

A sha pin on `└mkdocs-github-admonitions-plugin` was introduced due to a bug fix not being available in a released version in PR #18163

Now the bug fix has been released so the pin can be removed.

In the future, in such cases, it might be a good idea to add a comment
and/or set a reminder to look back and consider removing the pin
as renovate will not handle sha pins.

As renovate handles almost all dep upgrades, this provides a false sense
of "security" that deps are always kept up to date automatically.

Related to issue #19369

Thanks @ntBre for the pointer!

## Test Plan

Docs previews should be visually inspected for correct rendering of admonitions.

As I'm not an Astral insider, I unfortunately can't actually faithfully reproduce the docs (due to Material for MkDocs being closed source). I don't know if there are automatic preview builds in CI that I can inspect instead.

## Other

I also add a comment to remind the reader that renovate does not automatically update git/sha pinned dependencies. This was touched on in #19369 as well - I think this comment might be worth it but happy to remove of course if reviewers differ. It's not a big change, hence adding as piggyback commit to the PR that edits the same file.
