### PR TITLE
[`pyupgrade`] Fix UP030 to avoid modifying double curly braces in format strings

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP030_0.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP030_0.py
@@ -59,3 +59,5 @@ kwargs = {x: x for x in range(10)}
 "{1}_{0}".format(1, 2, *args)
 
 "{1}_{0}".format(1, 2)
+
+r"\d{{1,2}} {0}".format(42)

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP030_0.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP030_0.py.snap
@@ -481,6 +481,7 @@ UP030_0.py:59:1: UP030 [*] Use implicit references for positional format fields
    59 |+"{}_{}".format(2, 1, )
 60 60 | 
 61 61 | "{1}_{0}".format(1, 2)
+62 62 | 
 
 UP030_0.py:61:1: UP030 [*] Use implicit references for positional format fields
    |
@@ -488,6 +489,8 @@ UP030_0.py:61:1: UP030 [*] Use implicit references for positional format fields
 60 |
 61 | "{1}_{0}".format(1, 2)
    | ^^^^^^^^^^^^^^^^^^^^^^ UP030
+62 |
+63 | r"\d{{1,2}} {0}".format(42)
    |
    = help: Remove explicit positional indices
 
@@ -497,3 +500,21 @@ UP030_0.py:61:1: UP030 [*] Use implicit references for positional format fields
 60 60 | 
 61    |-"{1}_{0}".format(1, 2)
    61 |+"{}_{}".format(2, 1)
+62 62 | 
+63 63 | r"\d{{1,2}} {0}".format(42)
+
+UP030_0.py:63:1: UP030 [*] Use implicit references for positional format fields
+   |
+61 | "{1}_{0}".format(1, 2)
+62 |
+63 | r"\d{{1,2}} {0}".format(42)
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP030
+   |
+   = help: Remove explicit positional indices
+
+ℹ Unsafe fix
+60 60 | 
+61 61 | "{1}_{0}".format(1, 2)
+62 62 | 
+63    |-r"\d{{1,2}} {0}".format(42)
+   63 |+r"\d{{1,2}} {}".format(42)


### PR DESCRIPTION
## Summary

Fixes #19348