### PR TITLE
[ty] use the name span rather than the statement span for unresolved `global` lints

### DIFF
--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -4672,7 +4672,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // in the global scope.
         let ast::StmtGlobal {
             node_index: _,
-            range,
+            range: _,
             names,
         } = global;
         let global_place_table = self.index.place_table(FileScopeId::global());
@@ -4694,7 +4694,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
             // This variable isn't explicitly defined in the global scope, nor is it an
             // implicit global from `types.ModuleType`, so we consider this `global` statement invalid.
-            let Some(builder) = self.context.report_lint(&UNRESOLVED_GLOBAL, range) else {
+            let Some(builder) = self.context.report_lint(&UNRESOLVED_GLOBAL, name.range) else {
                 return;
             };
             let mut diag =

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -4694,7 +4694,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
             // This variable isn't explicitly defined in the global scope, nor is it an
             // implicit global from `types.ModuleType`, so we consider this `global` statement invalid.
-            let Some(builder) = self.context.report_lint(&UNRESOLVED_GLOBAL, name.range) else {
+            let Some(builder) = self.context.report_lint(&UNRESOLVED_GLOBAL, name) else {
                 return;
             };
             let mut diag =


### PR DESCRIPTION
This is a follow-up to https://github.com/astral-sh/ruff/pull/19344 that improves the error formatting slightly. For example with this program:

```py
def f():
    global foo, bar
```

Before we printed:

```
1 | def f():
2 |     global foo, bar
  |     ^^^^^^^^^^^^^^^ `foo` has no declarations or bindings in the global scope
...
1 | def f():
2 |     global foo, bar
  |     ^^^^^^^^^^^^^^^ `bar` has no declarations or bindings in the global scope
```

Now we print:

```
1 | def f():
2 |     global foo, bar
  |            ^^^ `foo` has no declarations or bindings in the global scope
...
1 | def f():
2 |     global foo, bar
  |                 ^^^ `bar` has no declarations or bindings in the global scope
```