### PR TITLE
[ty] perform type narrowing for places marked `global` too

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/scopes/global.md
+++ b/crates/ty_python_semantic/resources/mdtest/scopes/global.md
@@ -71,6 +71,19 @@ def f():
     reveal_type(x)  # revealed: Literal[1]
 ```
 
+Same for an `if` statement:
+
+```py
+x: int | None
+
+def f():
+    # The `global` keyword isn't necessary here, but this is testing that it doesn't get in the way
+    # of narrowing.
+    global x
+    if x == 1:
+        y: int = x  # allowed, because x cannot be None in this branch
+```
+
 ## `nonlocal` and `global`
 
 A binding cannot be both `nonlocal` and `global`. This should emit a semantic syntax error. CPython

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -6377,7 +6377,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             if let Some(name) = expr.as_name() {
                 if let Some(symbol_id) = place_table.place_id_by_name(name) {
                     if self.skip_non_global_scopes(file_scope_id, symbol_id) {
-                        return global_symbol(self.db(), self.file(), name);
+                        return global_symbol(self.db(), self.file(), name).map_type(|ty| {
+                            self.narrow_place_with_applicable_constraints(
+                                expr,
+                                ty,
+                                &constraint_keys,
+                            )
+                        });
                     }
                     is_nonlocal_binding = self
                         .index

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -6377,7 +6377,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             if let Some(name) = expr.as_name() {
                 if let Some(symbol_id) = place_table.place_id_by_name(name) {
                     if self.skip_non_global_scopes(file_scope_id, symbol_id) {
-                        return global_symbol(self.db(), self.file(), name);
+                        return global_symbol(self.db(), self.file(), name).map_type(|ty| {
+                            self.narrow_place_with_applicable_constraints(
+                                expr,
+                                ty,
+                                &constraint_keys,
+                            )
+                        });
                     }
                     is_nonlocal_binding = self
                         .index
@@ -6462,7 +6468,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             {
                                 continue;
                             }
-                            let place = place_from_bindings(db, bindings);
+                            let place = place_from_bindings(db, bindings).map_type(|ty| {
+                                self.narrow_place_with_applicable_constraints(
+                                    expr,
+                                    ty,
+                                    &constraint_keys,
+                                )
+                            });
                             constraint_keys.push((
                                 enclosing_scope_file_id,
                                 ConstraintKey::EagerNestedScope(file_scope_id),
@@ -6526,7 +6538,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         enclosing_scope_id,
                         expr,
                         ConsideredDefinitions::AllReachable,
-                    );
+                    )
+                    .map_type(|ty| {
+                        self.narrow_place_with_applicable_constraints(expr, ty, &constraint_keys)
+                    });
                     // We could have Place::Unbound here, despite the checks above, for example if
                     // this scope contains a `del` statement but no binding or declaration.
                     if let Place::Type(type_, boundness) = local_place_and_qualifiers.place {
@@ -6569,7 +6584,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 ));
                             }
                             EagerSnapshotResult::FoundBindings(bindings) => {
-                                let place = place_from_bindings(db, bindings);
+                                let place = place_from_bindings(db, bindings).map_type(|ty| {
+                                    self.narrow_place_with_applicable_constraints(
+                                        expr,
+                                        ty,
+                                        &constraint_keys,
+                                    )
+                                });
                                 constraint_keys.push((
                                     FileScopeId::global(),
                                     ConstraintKey::EagerNestedScope(file_scope_id),
@@ -6588,7 +6609,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         return Place::Unbound.into();
                     };
 
-                    explicit_global_symbol(db, self.file(), name)
+                    explicit_global_symbol(db, self.file(), name).map_type(|ty| {
+                        self.narrow_place_with_applicable_constraints(expr, ty, &constraint_keys)
+                    })
                 })
         });
 
@@ -6596,11 +6619,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             self.check_deprecated(expr_ref, ty);
         }
 
-        let narrowed_place = place.map_type(|ty| {
-            self.narrow_place_with_applicable_constraints(expr, ty, &constraint_keys)
-        });
-
-        (narrowed_place, constraint_keys)
+        (place, constraint_keys)
     }
 
     pub(super) fn report_unresolved_reference(&self, expr_name_node: &ast::ExprName) {


### PR DESCRIPTION
This fixes a bug reported at:
https://github.com/astral-sh/ty/issues/311#issuecomment-3070834132

---

I don't understand the narrowing machinery very well yet, so I don't have much intuition for whether this is a Good Change, other than that it doesn't seem to break anything. We call `narrow_place_with_applicable_constraints` five separate times (previously four) in this one function, and that seems a little fishy. When would we _not_ want to do it?