### PR TITLE
[ty] Show the raw argument type in `reveal_type` 

### DIFF
--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -3388,7 +3388,7 @@ impl KnownClass {
         context: &InferContext<'db, '_>,
         index: &SemanticIndex<'db>,
         overload: &mut Binding<'db>,
-        call_argument_types: &CallArguments<'_, 'db>,
+        call_arguments: &CallArguments<'_, 'db>,
         call_expression: &ast::ExprCall,
     ) {
         let db = context.db();
@@ -3581,7 +3581,7 @@ impl KnownClass {
                         let elements = UnionType::new(
                             db,
                             overload
-                                .arguments_for_parameter(call_argument_types, 1)
+                                .arguments_for_parameter(call_arguments, 1)
                                 .map(|(_, ty)| ty)
                                 .collect::<Box<_>>(),
                         );

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -64,6 +64,7 @@ use crate::semantic_index::ast_ids::HasScopedUseId;
 use crate::semantic_index::definition::Definition;
 use crate::semantic_index::place::ScopeId;
 use crate::semantic_index::semantic_index;
+use crate::types::call::Binding;
 use crate::types::context::InferContext;
 use crate::types::diagnostic::{
     REDUNDANT_CAST, STATIC_ASSERT_ERROR, TYPE_ASSERTION_FAILURE,
@@ -1039,86 +1040,88 @@ impl KnownFunction {
     pub(super) fn check_call<'db>(
         self,
         context: &InferContext<'db, '_>,
-        parameter_types: &[Option<Type<'db>>],
+        overload: &mut Binding<'db>,
         call_expression: &ast::ExprCall,
         file: File,
-    ) -> Option<Type<'db>> {
+    ) {
         let db = context.db();
+        let parameter_types = overload.parameter_types();
 
         match self {
             KnownFunction::RevealType => {
                 let [Some(revealed_type)] = parameter_types else {
-                    return None;
+                    return;
                 };
-                let builder =
-                    context.report_diagnostic(DiagnosticId::RevealedType, Severity::Info)?;
-                let mut diag = builder.into_diagnostic("Revealed type");
-                let span = context.span(&call_expression.arguments.args[0]);
-                diag.annotate(
-                    Annotation::primary(span)
-                        .message(format_args!("`{}`", revealed_type.display(db))),
-                );
-                None
+                if let Some(builder) =
+                    context.report_diagnostic(DiagnosticId::RevealedType, Severity::Info)
+                {
+                    let mut diag = builder.into_diagnostic("Revealed type");
+                    let span = context.span(&call_expression.arguments.args[0]);
+                    diag.annotate(
+                        Annotation::primary(span)
+                            .message(format_args!("`{}`", revealed_type.display(db))),
+                    );
+                }
             }
+
             KnownFunction::AssertType => {
                 let [Some(actual_ty), Some(asserted_ty)] = parameter_types else {
-                    return None;
+                    return;
                 };
-
                 if actual_ty.is_equivalent_to(db, *asserted_ty) {
-                    return None;
+                    return;
                 }
-                let builder = context.report_lint(&TYPE_ASSERTION_FAILURE, call_expression)?;
+                if let Some(builder) = context.report_lint(&TYPE_ASSERTION_FAILURE, call_expression)
+                {
+                    let mut diagnostic = builder.into_diagnostic(format_args!(
+                        "Argument does not have asserted type `{}`",
+                        asserted_ty.display(db),
+                    ));
 
-                let mut diagnostic = builder.into_diagnostic(format_args!(
-                    "Argument does not have asserted type `{}`",
-                    asserted_ty.display(db),
-                ));
+                    diagnostic.annotate(
+                        Annotation::secondary(context.span(&call_expression.arguments.args[0]))
+                            .message(format_args!(
+                                "Inferred type of argument is `{}`",
+                                actual_ty.display(db),
+                            )),
+                    );
 
-                diagnostic.annotate(
-                    Annotation::secondary(context.span(&call_expression.arguments.args[0]))
-                        .message(format_args!(
-                            "Inferred type of argument is `{}`",
-                            actual_ty.display(db),
-                        )),
-                );
-
-                diagnostic.info(format_args!(
-                    "`{asserted_type}` and `{inferred_type}` are not equivalent types",
-                    asserted_type = asserted_ty.display(db),
-                    inferred_type = actual_ty.display(db),
-                ));
-
-                None
+                    diagnostic.info(format_args!(
+                        "`{asserted_type}` and `{inferred_type}` are not equivalent types",
+                        asserted_type = asserted_ty.display(db),
+                        inferred_type = actual_ty.display(db),
+                    ));
+                }
             }
+
             KnownFunction::AssertNever => {
                 let [Some(actual_ty)] = parameter_types else {
-                    return None;
+                    return;
                 };
                 if actual_ty.is_equivalent_to(db, Type::Never) {
-                    return None;
+                    return;
                 }
-                let builder = context.report_lint(&TYPE_ASSERTION_FAILURE, call_expression)?;
-
-                let mut diagnostic =
-                    builder.into_diagnostic("Argument does not have asserted type `Never`");
-                diagnostic.annotate(
-                    Annotation::secondary(context.span(&call_expression.arguments.args[0]))
-                        .message(format_args!(
-                            "Inferred type of argument is `{}`",
-                            actual_ty.display(db)
-                        )),
-                );
-                diagnostic.info(format_args!(
-                    "`Never` and `{inferred_type}` are not equivalent types",
-                    inferred_type = actual_ty.display(db),
-                ));
-
-                None
+                if let Some(builder) = context.report_lint(&TYPE_ASSERTION_FAILURE, call_expression)
+                {
+                    let mut diagnostic =
+                        builder.into_diagnostic("Argument does not have asserted type `Never`");
+                    diagnostic.annotate(
+                        Annotation::secondary(context.span(&call_expression.arguments.args[0]))
+                            .message(format_args!(
+                                "Inferred type of argument is `{}`",
+                                actual_ty.display(db)
+                            )),
+                    );
+                    diagnostic.info(format_args!(
+                        "`Never` and `{inferred_type}` are not equivalent types",
+                        inferred_type = actual_ty.display(db),
+                    ));
+                }
             }
+
             KnownFunction::StaticAssert => {
                 let [Some(parameter_ty), message] = parameter_types else {
-                    return None;
+                    return;
                 };
                 let truthiness = match parameter_ty.try_bool(db) {
                     Ok(truthiness) => truthiness,
@@ -1138,41 +1141,42 @@ impl KnownFunction {
 
                         err.report_diagnostic(context, condition);
 
-                        return None;
+                        return;
                     }
                 };
 
-                let builder = context.report_lint(&STATIC_ASSERT_ERROR, call_expression)?;
-                if truthiness.is_always_true() {
-                    return None;
-                }
-                if let Some(message) = message
-                    .and_then(Type::into_string_literal)
-                    .map(|s| s.value(db))
-                {
-                    builder.into_diagnostic(format_args!("Static assertion error: {message}"));
-                } else if *parameter_ty == Type::BooleanLiteral(false) {
-                    builder
-                        .into_diagnostic("Static assertion error: argument evaluates to `False`");
-                } else if truthiness.is_always_false() {
-                    builder.into_diagnostic(format_args!(
-                        "Static assertion error: argument of type `{parameter_ty}` \
+                if let Some(builder) = context.report_lint(&STATIC_ASSERT_ERROR, call_expression) {
+                    if truthiness.is_always_true() {
+                        return;
+                    }
+                    if let Some(message) = message
+                        .and_then(Type::into_string_literal)
+                        .map(|s| s.value(db))
+                    {
+                        builder.into_diagnostic(format_args!("Static assertion error: {message}"));
+                    } else if *parameter_ty == Type::BooleanLiteral(false) {
+                        builder.into_diagnostic(
+                            "Static assertion error: argument evaluates to `False`",
+                        );
+                    } else if truthiness.is_always_false() {
+                        builder.into_diagnostic(format_args!(
+                            "Static assertion error: argument of type `{parameter_ty}` \
                             is statically known to be falsy",
-                        parameter_ty = parameter_ty.display(db)
-                    ));
-                } else {
-                    builder.into_diagnostic(format_args!(
-                        "Static assertion error: argument of type `{parameter_ty}` \
+                            parameter_ty = parameter_ty.display(db)
+                        ));
+                    } else {
+                        builder.into_diagnostic(format_args!(
+                            "Static assertion error: argument of type `{parameter_ty}` \
                             has an ambiguous static truthiness",
-                        parameter_ty = parameter_ty.display(db)
-                    ));
+                            parameter_ty = parameter_ty.display(db)
+                        ));
+                    }
                 }
-
-                None
             }
+
             KnownFunction::Cast => {
                 let [Some(casted_type), Some(source_type)] = parameter_types else {
-                    return None;
+                    return;
                 };
                 let contains_unknown_or_todo =
                     |ty| matches!(ty, Type::Dynamic(dynamic) if dynamic != DynamicType::Any);
@@ -1180,31 +1184,34 @@ impl KnownFunction {
                     && !any_over_type(db, *source_type, &contains_unknown_or_todo)
                     && !any_over_type(db, *casted_type, &contains_unknown_or_todo)
                 {
-                    let builder = context.report_lint(&REDUNDANT_CAST, call_expression)?;
-                    builder.into_diagnostic(format_args!(
-                        "Value is already of type `{}`",
-                        casted_type.display(db),
-                    ));
+                    if let Some(builder) = context.report_lint(&REDUNDANT_CAST, call_expression) {
+                        builder.into_diagnostic(format_args!(
+                            "Value is already of type `{}`",
+                            casted_type.display(db),
+                        ));
+                    }
                 }
-                None
             }
+
             KnownFunction::GetProtocolMembers => {
                 let [Some(Type::ClassLiteral(class))] = parameter_types else {
-                    return None;
+                    return;
                 };
                 if class.is_protocol(db) {
-                    return None;
+                    return;
                 }
                 report_bad_argument_to_get_protocol_members(context, call_expression, *class);
-                None
             }
+
             KnownFunction::IsInstance | KnownFunction::IsSubclass => {
                 let [_, Some(Type::ClassLiteral(class))] = parameter_types else {
-                    return None;
+                    return;
                 };
-                let protocol_class = class.into_protocol_class(db)?;
+                let Some(protocol_class) = class.into_protocol_class(db) else {
+                    return;
+                };
                 if protocol_class.is_runtime_checkable(db) {
-                    return None;
+                    return;
                 }
                 report_runtime_check_against_non_runtime_checkable_protocol(
                     context,
@@ -1212,16 +1219,16 @@ impl KnownFunction {
                     protocol_class,
                     self,
                 );
-                None
             }
+
             known @ (KnownFunction::DunderImport | KnownFunction::ImportModule) => {
                 let [Some(Type::StringLiteral(full_module_name)), rest @ ..] = parameter_types
                 else {
-                    return None;
+                    return;
                 };
 
                 if rest.iter().any(Option::is_some) {
-                    return None;
+                    return;
                 }
 
                 let module_name = full_module_name.value(db);
@@ -1231,16 +1238,20 @@ impl KnownFunction {
                     // `importlib.import_module("collections.abc")` returns the `collections.abc` module.
                     // ty doesn't have a way to represent the return type of the former yet.
                     // https://github.com/astral-sh/ruff/pull/19008#discussion_r2173481311
-                    return None;
+                    return;
                 }
 
-                let module_name = ModuleName::new(module_name)?;
-                let module = resolve_module(db, &module_name)?;
+                let Some(module_name) = ModuleName::new(module_name) else {
+                    return;
+                };
+                let Some(module) = resolve_module(db, &module_name) else {
+                    return;
+                };
 
-                Some(Type::module_literal(db, file, &module))
+                overload.set_return_type(Type::module_literal(db, file, &module));
             }
 
-            _ => None,
+            _ => {}
         }
     }
 }

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -5615,30 +5615,23 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 match binding_type {
                     Type::FunctionLiteral(function_literal) => {
                         if let Some(known_function) = function_literal.known(self.db()) {
-                            if let Some(return_type) = known_function.check_call(
+                            known_function.check_call(
                                 &self.context,
-                                overload.parameter_types(),
+                                overload,
                                 call_expression,
                                 self.file(),
-                            ) {
-                                overload.set_return_type(return_type);
-                            }
+                            );
                         }
                     }
-
                     Type::ClassLiteral(class) => {
-                        let Some(known_class) = class.known(self.db()) else {
-                            continue;
-                        };
-                        let overridden_return = known_class.check_call(
-                            &self.context,
-                            self.index,
-                            overload,
-                            &call_arguments,
-                            call_expression,
-                        );
-                        if let Some(overridden_return) = overridden_return {
-                            overload.set_return_type(overridden_return);
+                        if let Some(known_class) = class.known(self.db()) {
+                            known_class.check_call(
+                                &self.context,
+                                self.index,
+                                overload,
+                                &call_arguments,
+                                call_expression,
+                            );
                         }
                     }
                     _ => {}

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -5618,6 +5618,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             known_function.check_call(
                                 &self.context,
                                 overload,
+                                &call_arguments,
                                 call_expression,
                                 self.file(),
                             );


### PR DESCRIPTION
This PR is changes how `reveal_type` determines what type to reveal, in a way that should be a no-op to most callers.

Previously, we would reveal the type of the first parameter, _after_ all of the call binding machinery had done its work. This includes inferring the specialization of a generic function, and then applying that specialization to all parameter and argument types, which is relevant since the typeshed definition of `reveal_type` is generic:

```pyi
def reveal_type(obj: _T, /) -> _T: ...
```

Normally this does not matter, since we infer `_T = [arg type]` and apply that to the parameter type, yielding `[arg type]`. But applying that specialization also simplifies the argument type, which makes `reveal_type` less useful as a debugging aid when we want to see the actual, raw, unsimplified argument type.

With this patch, we now grab the original unmodified argument type and reveal that instead.

In addition to making the debugging aid example work, this also makes our `reveal_type` implementation more robust to custom typeshed definitions, such as

```py
def reveal_type(obj: Any) -> Any: ...
```

(That custom definition is probably not what anyone would want, since you wouldn't be able to depend on the return type being equivalent to the argument type, but still)