### PR TITLE
Canonicalize path before filtering

### DIFF
--- a/crates/ruff/tests/lint.rs
+++ b/crates/ruff/tests/lint.rs
@@ -5718,9 +5718,11 @@ match 42:  # invalid-syntax
 
     let snapshot = format!("output_format_{output_format}");
 
+    let project_dir = dunce::canonicalize(tempdir.path())?;
+
     insta::with_settings!({
         filters => vec![
-            (tempdir_filter(&tempdir).as_str(), "[TMP]/"),
+            (tempdir_filter(&project_dir).as_str(), "[TMP]/"),
             (r#""[^"]+\\?/?input.py"#, r#""[TMP]/input.py"#),
             (ruff_linter::VERSION, "[VERSION]"),
         ]

--- a/crates/ruff/tests/lint.rs
+++ b/crates/ruff/tests/lint.rs
@@ -5723,6 +5723,7 @@ match 42:  # invalid-syntax
     insta::with_settings!({
         filters => vec![
             (tempdir_filter(&project_dir).as_str(), "[TMP]/"),
+            (tempdir_filter(&tempdir).as_str(), "[TMP]/"),
             (r#""[^"]+\\?/?input.py"#, r#""[TMP]/input.py"#),
             (ruff_linter::VERSION, "[VERSION]"),
         ]


### PR DESCRIPTION
## Summary

This came up on [Discord](https://discord.com/channels/1039017663004942429/1343692072921731082/1395447082520678440) and also in #19387, but on macOS the tmp directory is a symlink to `/private/tmp`, which breaks this filter. I'm still not quite sure why only these tests are affected when we use the `tempdir_filter` elsewhere, but hopefully this fixes the immediate issue. Just `tempdir.path().canonicalize()` also worked, but I used `dunce` since that's what I saw in other tests (I guess it's not _just_ these tests).

Some related links from uv:
- https://github.com/astral-sh/uv/blob/1b2f212e8b2f91069b858cb7f5905589c9d15add/crates/uv/tests/it/common/mod.rs#L1161-L1178
- https://github.com/astral-sh/uv/blob/1b2f212e8b2f91069b858cb7f5905589c9d15add/crates/uv/tests/it/common/mod.rs#L424-L438
- https://github.com/astral-sh/uv/pull/14290

Thanks to @zanieb for those!

## Test Plan

I tested the `main` branch on my MacBook and reproduced the test failure, then confirmed that the tests pass after the change. Now to make sure it passes on Windows, which caused most of the trouble in the first PR!
