### PR TITLE
[ty] Reduce number of inline stored definitions per place

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,7 +150,7 @@ serde_with = { version = "3.6.0", default-features = false, features = [
 ] }
 shellexpand = { version = "3.0.0" }
 similar = { version = "2.4.0", features = ["inline"] }
-smallvec = { version = "1.13.2" }
+smallvec = { version = "1.13.2", features = ["union", "const_generics", "const_new"] }
 snapbox = { version = "0.6.0", features = [
     "diff",
     "term-svg",

--- a/crates/ty_ide/src/lib.rs
+++ b/crates/ty_ide/src/lib.rs
@@ -105,11 +105,11 @@ pub struct NavigationTargets(smallvec::SmallVec<[NavigationTarget; 1]>);
 
 impl NavigationTargets {
     fn single(target: NavigationTarget) -> Self {
-        Self(smallvec::smallvec![target])
+        Self(smallvec::smallvec_inline![target])
     }
 
     fn empty() -> Self {
-        Self(smallvec::SmallVec::new())
+        Self(smallvec::SmallVec::new_const())
     }
 
     fn unique(targets: impl IntoIterator<Item = NavigationTarget>) -> Self {

--- a/crates/ty_python_semantic/src/semantic_index/definition.rs
+++ b/crates/ty_python_semantic/src/semantic_index/definition.rs
@@ -107,7 +107,7 @@ pub struct Definitions<'db> {
 impl<'db> Definitions<'db> {
     pub(crate) fn single(definition: Definition<'db>) -> Self {
         Self {
-            definitions: smallvec::smallvec![definition],
+            definitions: smallvec::smallvec_inline![definition],
         }
     }
 

--- a/crates/ty_python_semantic/src/semantic_index/place.rs
+++ b/crates/ty_python_semantic/src/semantic_index/place.rs
@@ -10,7 +10,7 @@ use ruff_index::{IndexVec, newtype_index};
 use ruff_python_ast as ast;
 use ruff_python_ast::name::Name;
 use rustc_hash::FxHasher;
-use smallvec::{SmallVec, smallvec};
+use smallvec::SmallVec;
 
 use crate::Db;
 use crate::ast_node_ref::AstNodeRef;
@@ -162,10 +162,10 @@ impl TryFrom<ast::ExprRef<'_>> for PlaceExpr {
 }
 
 impl PlaceExpr {
-    pub(crate) fn name(name: Name) -> Self {
+    pub(crate) const fn name(name: Name) -> Self {
         Self {
             root_name: name,
-            sub_segments: smallvec![],
+            sub_segments: SmallVec::new_const(),
         }
     }
 

--- a/crates/ty_python_semantic/src/semantic_index/use_def/place_state.rs
+++ b/crates/ty_python_semantic/src/semantic_index/use_def/place_state.rs
@@ -76,7 +76,7 @@ impl ScopedDefinitionId {
 #[derive(Clone, Debug, Default, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
 pub(super) struct Declarations {
     /// A list of live declarations for this place, sorted by their `ScopedDefinitionId`
-    live_declarations: SmallVec<[LiveDeclaration; 3]>,
+    live_declarations: SmallVec<[LiveDeclaration; 2]>,
 }
 
 /// One of the live declarations for a single place at some point in control flow.

--- a/crates/ty_python_semantic/src/semantic_index/use_def/place_state.rs
+++ b/crates/ty_python_semantic/src/semantic_index/use_def/place_state.rs
@@ -71,16 +71,12 @@ impl ScopedDefinitionId {
     }
 }
 
-/// Can keep inline this many live bindings or declarations per place at a given time; more will
-/// go to heap.
-const INLINE_DEFINITIONS_PER_PLACE: usize = 4;
-
 /// Live declarations for a single place at some point in control flow, with their
 /// corresponding reachability constraints.
 #[derive(Clone, Debug, Default, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
 pub(super) struct Declarations {
     /// A list of live declarations for this place, sorted by their `ScopedDefinitionId`
-    live_declarations: SmallVec<[LiveDeclaration; INLINE_DEFINITIONS_PER_PLACE]>,
+    live_declarations: SmallVec<[LiveDeclaration; 3]>,
 }
 
 /// One of the live declarations for a single place at some point in control flow.
@@ -199,7 +195,7 @@ pub(super) struct Bindings {
     /// "unbound" binding.
     unbound_narrowing_constraint: Option<ScopedNarrowingConstraint>,
     /// A list of live bindings for this place, sorted by their `ScopedDefinitionId`
-    live_bindings: SmallVec<[LiveBinding; INLINE_DEFINITIONS_PER_PLACE]>,
+    live_bindings: SmallVec<[LiveBinding; 2]>,
 }
 
 impl Bindings {

--- a/crates/ty_python_semantic/src/suppression.rs
+++ b/crates/ty_python_semantic/src/suppression.rs
@@ -508,7 +508,7 @@ impl<'a> SuppressionsBuilder<'a> {
             lint_registry,
             seen_non_trivia_token: false,
             line: Vec::new(),
-            file: SmallVec::new(),
+            file: SmallVec::new_const(),
             unknown: Vec::new(),
             invalid: Vec::new(),
         }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -5007,9 +5007,9 @@ impl<'db> Type<'db> {
             | Type::ProtocolInstance(_)
             | Type::PropertyInstance(_)
             | Type::TypeIs(_) => Err(InvalidTypeExpressionError {
-                invalid_expressions: smallvec::smallvec![InvalidTypeExpression::InvalidType(
-                    *self, scope_id
-                )],
+                invalid_expressions: smallvec::smallvec_inline![
+                    InvalidTypeExpression::InvalidType(*self, scope_id)
+                ],
                 fallback_type: Type::unknown(),
             }),
 
@@ -5017,11 +5017,13 @@ impl<'db> Type<'db> {
                 KnownInstanceType::TypeAliasType(alias) => Ok(alias.value_type(db)),
                 KnownInstanceType::TypeVar(typevar) => Ok(Type::TypeVar(*typevar)),
                 KnownInstanceType::SubscriptedProtocol(_) => Err(InvalidTypeExpressionError {
-                    invalid_expressions: smallvec::smallvec![InvalidTypeExpression::Protocol],
+                    invalid_expressions: smallvec::smallvec_inline![
+                        InvalidTypeExpression::Protocol
+                    ],
                     fallback_type: Type::unknown(),
                 }),
                 KnownInstanceType::SubscriptedGeneric(_) => Err(InvalidTypeExpressionError {
-                    invalid_expressions: smallvec::smallvec![InvalidTypeExpression::Generic],
+                    invalid_expressions: smallvec::smallvec_inline![InvalidTypeExpression::Generic],
                     fallback_type: Type::unknown(),
                 }),
             },
@@ -5057,7 +5059,7 @@ impl<'db> Type<'db> {
                     let Some(class) = nearest_enclosing_class(db, index, scope_id, &module) else {
                         return Err(InvalidTypeExpressionError {
                             fallback_type: Type::unknown(),
-                            invalid_expressions: smallvec::smallvec![
+                            invalid_expressions: smallvec::smallvec_inline![
                                 InvalidTypeExpression::InvalidType(*self, scope_id)
                             ],
                         });
@@ -5081,18 +5083,20 @@ impl<'db> Type<'db> {
                 SpecialFormType::Literal
                 | SpecialFormType::Union
                 | SpecialFormType::Intersection => Err(InvalidTypeExpressionError {
-                    invalid_expressions: smallvec::smallvec![
+                    invalid_expressions: smallvec::smallvec_inline![
                         InvalidTypeExpression::RequiresArguments(*self)
                     ],
                     fallback_type: Type::unknown(),
                 }),
 
                 SpecialFormType::Protocol => Err(InvalidTypeExpressionError {
-                    invalid_expressions: smallvec::smallvec![InvalidTypeExpression::Protocol],
+                    invalid_expressions: smallvec::smallvec_inline![
+                        InvalidTypeExpression::Protocol
+                    ],
                     fallback_type: Type::unknown(),
                 }),
                 SpecialFormType::Generic => Err(InvalidTypeExpressionError {
-                    invalid_expressions: smallvec::smallvec![InvalidTypeExpression::Generic],
+                    invalid_expressions: smallvec::smallvec_inline![InvalidTypeExpression::Generic],
                     fallback_type: Type::unknown(),
                 }),
 
@@ -5103,7 +5107,7 @@ impl<'db> Type<'db> {
                 | SpecialFormType::TypeGuard
                 | SpecialFormType::Unpack
                 | SpecialFormType::CallableTypeOf => Err(InvalidTypeExpressionError {
-                    invalid_expressions: smallvec::smallvec![
+                    invalid_expressions: smallvec::smallvec_inline![
                         InvalidTypeExpression::RequiresOneArgument(*self)
                     ],
                     fallback_type: Type::unknown(),
@@ -5111,7 +5115,7 @@ impl<'db> Type<'db> {
 
                 SpecialFormType::Annotated | SpecialFormType::Concatenate => {
                     Err(InvalidTypeExpressionError {
-                        invalid_expressions: smallvec::smallvec![
+                        invalid_expressions: smallvec::smallvec_inline![
                             InvalidTypeExpression::RequiresTwoArguments(*self)
                         ],
                         fallback_type: Type::unknown(),
@@ -5120,7 +5124,7 @@ impl<'db> Type<'db> {
 
                 SpecialFormType::ClassVar | SpecialFormType::Final => {
                     Err(InvalidTypeExpressionError {
-                        invalid_expressions: smallvec::smallvec![
+                        invalid_expressions: smallvec::smallvec_inline![
                             InvalidTypeExpression::TypeQualifier(*special_form)
                         ],
                         fallback_type: Type::unknown(),
@@ -5130,7 +5134,7 @@ impl<'db> Type<'db> {
                 SpecialFormType::ReadOnly
                 | SpecialFormType::NotRequired
                 | SpecialFormType::Required => Err(InvalidTypeExpressionError {
-                    invalid_expressions: smallvec::smallvec![
+                    invalid_expressions: smallvec::smallvec_inline![
                         InvalidTypeExpression::TypeQualifierRequiresOneArgument(*special_form)
                     ],
                     fallback_type: Type::unknown(),
@@ -5184,9 +5188,9 @@ impl<'db> Type<'db> {
                     "Support for `types.UnionType` instances in type expressions"
                 )),
                 _ => Err(InvalidTypeExpressionError {
-                    invalid_expressions: smallvec::smallvec![InvalidTypeExpression::InvalidType(
-                        *self, scope_id
-                    )],
+                    invalid_expressions: smallvec::smallvec_inline![
+                        InvalidTypeExpression::InvalidType(*self, scope_id)
+                    ],
                     fallback_type: Type::unknown(),
                 }),
             },

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -8,7 +8,7 @@ use std::fmt;
 
 use itertools::Itertools;
 use ruff_db::parsed::parsed_module;
-use smallvec::{SmallVec, smallvec};
+use smallvec::{SmallVec, smallvec, smallvec_inline};
 
 use super::{Argument, CallArguments, CallError, CallErrorKind, InferContext, Signature, Type};
 use crate::db::Db;
@@ -1019,7 +1019,7 @@ impl<'db> From<CallableBinding<'db>> for Bindings<'db> {
     fn from(from: CallableBinding<'db>) -> Bindings<'db> {
         Bindings {
             callable_type: from.callable_type,
-            elements: smallvec![from],
+            elements: smallvec_inline![from],
             argument_forms: Box::from([]),
             conflicting_forms: Box::from([]),
         }
@@ -1037,11 +1037,11 @@ impl<'db> From<Binding<'db>> for Bindings<'db> {
             bound_type: None,
             overload_call_return_type: None,
             matching_overload_index: None,
-            overloads: smallvec![from],
+            overloads: smallvec_inline![from],
         };
         Bindings {
             callable_type,
-            elements: smallvec![callable_binding],
+            elements: smallvec_inline![callable_binding],
             argument_forms: Box::from([]),
             conflicting_forms: Box::from([]),
         }

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -13,7 +13,7 @@
 use std::{collections::HashMap, slice::Iter};
 
 use itertools::EitherOrBoth;
-use smallvec::{SmallVec, smallvec};
+use smallvec::{SmallVec, smallvec_inline};
 
 use super::{DynamicType, Type, TypeTransformer, TypeVarVariance, definition_expression_type};
 use crate::semantic_index::definition::Definition;
@@ -34,7 +34,7 @@ pub struct CallableSignature<'db> {
 impl<'db> CallableSignature<'db> {
     pub(crate) fn single(signature: Signature<'db>) -> Self {
         Self {
-            overloads: smallvec![signature],
+            overloads: smallvec_inline![signature],
         }
     }
 


### PR DESCRIPTION
## Summary

The `UseDefMap` are the main driver of ty's memory usage. This PR reduces the size of the `use_def_maps` on a large project by 1.5GB (~10%).

This is accomplished by updating how many items we store in the `SmallVec`'s stored in the `PlaceTable`.


* `LiveBinding`: Has a size of 12 bytes
* `LiveDeclaration`: Has a size of 8 bytes


 Ideally we'd pick numbers that ensure that the `SmallVec` isn't larger than a regular `Vec`. However, that would mean that we can only store 2 live declarations and only one live binding inline. I picked:

* `LiveBinding`: 2, that means each SmallVec has a size of 32 bytes, leaving 7 bytes unused. I considered going down to 1, so that the `SmallVec` has the same size as a `Vec` but that only reduces `Bindings` from 40 bytes to 32 bytes (saving only 8 bytes).
* `LiveDeclaration`: 2, that means each SmallVec has a size of 24 bytes, the same as a `Vec`. This leaves 7 bytes unuused


Not only does this improve memory usage but it also shows that this change improves performance by a few percent.


The remaining main driver of the `UseDefMap` size is `reachability_constraints` (about 30%). Reducing `Bindings` further would also still be valuable because we create a lot of them.


## How did you find this?

I used the following patch. Be aware, this is hacky and it seems to double count each value but it still gives the right proportional numbers. But this wouldn't have been possible without @ibraheemdev's work on adding the `heap_size` feature to salsa

<details>
	<summary>Patch</summary>

```patch
Subject: [PATCH] Reduce inline size of live declarations
---
Index: crates/ty_python_semantic/src/semantic_index/use_def.rs
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/crates/ty_python_semantic/src/semantic_index/use_def.rs b/crates/ty_python_semantic/src/semantic_index/use_def.rs
--- a/crates/ty_python_semantic/src/semantic_index/use_def.rs	(revision b8d2037373ee1aafe0574e4a6d202c609a7de6ad)
+++ b/crates/ty_python_semantic/src/semantic_index/use_def.rs	(date 1752778903756)
@@ -270,7 +270,7 @@
 mod place_state;
 
 /// Applicable definitions and constraints for every use of a name.
-#[derive(Debug, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
+#[derive(Debug, PartialEq, Eq, salsa::Update)]
 pub(crate) struct UseDefMap<'db> {
     /// Array of [`Definition`] in this scope. Only the first entry should be [`DefinitionState::Undefined`];
     /// this represents the implicit "unbound"/"undeclared" definition of every place.
@@ -341,6 +341,50 @@
     end_of_scope_reachability: ScopedReachabilityConstraintId,
 }
 
+pub(crate) fn use_def_map_size(map: &UseDefMap<'_>) -> usize {
+    use ruff_db::increment_memory_usage;
+
+    let all_definitions = ::get_size2::GetSize::get_heap_size(&map.all_definitions);
+    increment_memory_usage("all_definitions", all_definitions);
+    let predicates = ::get_size2::GetSize::get_heap_size(&map.predicates);
+    increment_memory_usage("predicates", predicates);
+    let narrowing_constraints = ::get_size2::GetSize::get_heap_size(&map.narrowing_constraints);
+    increment_memory_usage("narrowing_constraints", narrowing_constraints);
+    let reachability_constraints =
+        ::get_size2::GetSize::get_heap_size(&map.reachability_constraints);
+    increment_memory_usage("reachability_constraints", reachability_constraints);
+    let bindings_by_use = ::get_size2::GetSize::get_heap_size(&map.bindings_by_use);
+    increment_memory_usage("bindings_by_use", bindings_by_use);
+    let node_reachability = ::get_size2::GetSize::get_heap_size(&map.node_reachability);
+    increment_memory_usage("node_reachability", node_reachability);
+    let declarations_by_binding = ::get_size2::GetSize::get_heap_size(&map.declarations_by_binding);
+    increment_memory_usage("declarations_by_binding", declarations_by_binding);
+    let bindings_by_definition = ::get_size2::GetSize::get_heap_size(&map.bindings_by_definition);
+    increment_memory_usage("bindings_by_definition", bindings_by_definition);
+    let end_of_scope_places = ::get_size2::GetSize::get_heap_size(&map.end_of_scope_places);
+    increment_memory_usage("end_of_scope_places", end_of_scope_places);
+    let reachable_definitions = ::get_size2::GetSize::get_heap_size(&map.reachable_definitions);
+    increment_memory_usage("reachable_definitions", reachable_definitions);
+    let eager_snapshots = ::get_size2::GetSize::get_heap_size(&map.eager_snapshots);
+    increment_memory_usage("eager_snapshots", eager_snapshots);
+    let end_of_scope_reachability =
+        ::get_size2::GetSize::get_heap_size(&map.end_of_scope_reachability);
+    increment_memory_usage("end_of_scope_reachability", end_of_scope_reachability);
+
+    0 + all_definitions
+        + predicates
+        + narrowing_constraints
+        + reachability_constraints
+        + bindings_by_use
+        + node_reachability
+        + declarations_by_binding
+        + bindings_by_definition
+        + end_of_scope_places
+        + reachable_definitions
+        + eager_snapshots
+        + end_of_scope_reachability
+}
+
 pub(crate) enum ApplicableConstraints<'map, 'db> {
     UnboundBinding(ConstraintsIterator<'map, 'db>),
     ConstrainedBindings(BindingWithConstraintsIterator<'map, 'db>),
Index: crates/ty_python_semantic/src/semantic_index.rs
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/crates/ty_python_semantic/src/semantic_index.rs b/crates/ty_python_semantic/src/semantic_index.rs
--- a/crates/ty_python_semantic/src/semantic_index.rs	(revision b8d2037373ee1aafe0574e4a6d202c609a7de6ad)
+++ b/crates/ty_python_semantic/src/semantic_index.rs	(date 1752778603598)
@@ -5,12 +5,6 @@
 use ruff_db::parsed::parsed_module;
 use ruff_index::{IndexSlice, IndexVec};
 
-use ruff_python_ast::NodeIndex;
-use ruff_python_parser::semantic_errors::SemanticSyntaxError;
-use rustc_hash::{FxHashMap, FxHashSet};
-use salsa::Update;
-use salsa::plumbing::AsId;
-
 use crate::Db;
 use crate::module_name::ModuleName;
 use crate::node_key::NodeKey;
@@ -26,7 +20,12 @@
 };
 use crate::semantic_index::use_def::{EagerSnapshotKey, ScopedEagerSnapshotId, UseDefMap};
 use crate::semantic_model::HasTrackedScope;
-use crate::util::get_size::untracked_arc_size;
+use ruff_db::increment_memory_usage;
+use ruff_python_ast::NodeIndex;
+use ruff_python_parser::semantic_errors::SemanticSyntaxError;
+use rustc_hash::{FxHashMap, FxHashSet};
+use salsa::Update;
+use salsa::plumbing::AsId;
 
 pub mod ast_ids;
 mod builder;
@@ -49,7 +48,7 @@
 /// Returns the semantic index for `file`.
 ///
 /// Prefer using [`symbol_table`] when working with symbols from a single scope.
-#[salsa::tracked(returns(ref), no_eq, heap_size=get_size2::GetSize::get_heap_size)]
+#[salsa::tracked(returns(ref), no_eq, heap_size=semantic_index_size)]
 pub(crate) fn semantic_index(db: &dyn Db, file: File) -> SemanticIndex<'_> {
     let _span = tracing::trace_span!("semantic_index", ?file).entered();
 
@@ -93,7 +92,7 @@
 /// Using [`use_def_map`] over [`semantic_index`] has the advantage that
 /// Salsa can avoid invalidating dependent queries if this scope's use-def map
 /// is unchanged.
-#[salsa::tracked(returns(deref), heap_size=get_size2::GetSize::get_heap_size)]
+#[salsa::tracked(returns(deref), heap_size=use_def_map_heap_size)]
 pub(crate) fn use_def_map<'db>(db: &'db dyn Db, scope: ScopeId<'db>) -> ArcUseDefMap<'db> {
     let file = scope.file(db);
     let _span = tracing::trace_span!("use_def_map", scope=?scope.as_id(), ?file).entered();
@@ -196,7 +195,7 @@
 }
 
 /// The place tables and use-def maps for all scopes in a file.
-#[derive(Debug, Update, get_size2::GetSize)]
+#[derive(Debug, Update)]
 pub(crate) struct SemanticIndex<'db> {
     /// List of all place tables in this file, indexed by scope.
     place_tables: IndexVec<FileScopeId, Arc<PlaceTable>>,
@@ -244,6 +243,60 @@
     generator_functions: FxHashSet<FileScopeId>,
 }
 
+pub(crate) fn semantic_index_size(index: &SemanticIndex<'_>) -> usize {
+    let place_tables = ::get_size2::GetSize::get_heap_size(&index.place_tables);
+    increment_memory_usage("places_tables", place_tables);
+    let scopes = ::get_size2::GetSize::get_heap_size(&index.scopes);
+    increment_memory_usage("scopes", scopes);
+    let scopes_by_expression = ::get_size2::GetSize::get_heap_size(&index.scopes_by_expression);
+    increment_memory_usage("scopes_by_expression", scopes_by_expression);
+    let definitions_by_node = ::get_size2::GetSize::get_heap_size(&index.definitions_by_node);
+    increment_memory_usage("definitions_by_node", definitions_by_node);
+    let expressions_by_node = ::get_size2::GetSize::get_heap_size(&index.expressions_by_node);
+    increment_memory_usage("expressions_by_node", expressions_by_node);
+    let scopes_by_node = ::get_size2::GetSize::get_heap_size(&index.scopes_by_node);
+    increment_memory_usage("scopes_by_node", scopes_by_node);
+    let scope_ids_by_scope = ::get_size2::GetSize::get_heap_size(&index.scope_ids_by_scope);
+    increment_memory_usage("scope_ids_by_scope", scope_ids_by_scope);
+    let use_def_maps = ::get_size2::GetSize::get_heap_size(&index.use_def_maps);
+    increment_memory_usage("use_def_maps", use_def_maps);
+    let ast_ids = ::get_size2::GetSize::get_heap_size(&index.ast_ids);
+    increment_memory_usage("ast_ids", ast_ids);
+    let imported_modules = ::get_size2::GetSize::get_heap_size(&index.imported_modules);
+    increment_memory_usage("imported_modules", imported_modules);
+    let has_future_annotations = ::get_size2::GetSize::get_heap_size(&index.has_future_annotations);
+    increment_memory_usage("has_future_annotations", has_future_annotations);
+    let eager_snapshots = ::get_size2::GetSize::get_heap_size(&index.eager_snapshots);
+    increment_memory_usage("eager_snapshots", eager_snapshots);
+    let semantic_syntax_errors = ::get_size2::GetSize::get_heap_size(&index.semantic_syntax_errors);
+    increment_memory_usage("semantic_syntax_errors", semantic_syntax_errors);
+    let generator_functions = ::get_size2::GetSize::get_heap_size(&index.generator_functions);
+    increment_memory_usage("generator_functions", generator_functions);
+
+    let total = 0
+        + place_tables
+        + scopes
+        + scopes_by_expression
+        + definitions_by_node
+        + expressions_by_node
+        + use_def_maps
+        + ast_ids
+        + scopes_by_node
+        + scope_ids_by_scope
+        + imported_modules
+        + has_future_annotations
+        + eager_snapshots
+        + semantic_syntax_errors
+        + generator_functions;
+
+    increment_memory_usage("semantic_index", total);
+    total
+}
+
+pub(crate) fn use_def_map_heap_size(map: &ArcUseDefMap<'_>) -> usize {
+    crate::semantic_index::use_def::use_def_map_size(&map.inner)
+}
+
 impl<'db> SemanticIndex<'db> {
     /// Returns the place table for a specific scope.
     ///
@@ -521,9 +574,8 @@
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, salsa::Update, get_size2::GetSize)]
+#[derive(Debug, PartialEq, Eq, Clone, salsa::Update)]
 pub(crate) struct ArcUseDefMap<'db> {
-    #[get_size(size_fn = untracked_arc_size)]
     inner: Arc<UseDefMap<'db>>,
 }
 
@@ -543,6 +595,12 @@
     }
 }
 
+impl<'db> get_size2::GetSize for ArcUseDefMap<'db> {
+    fn get_heap_size(&self) -> usize {
+        crate::semantic_index::use_def::use_def_map_size(&self.inner)
+    }
+}
+
 pub struct AncestorsIter<'a> {
     scopes: &'a IndexSlice<FileScopeId, Scope>,
     next_id: Option<FileScopeId>,
Index: crates/ty/src/lib.rs
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/crates/ty/src/lib.rs b/crates/ty/src/lib.rs
--- a/crates/ty/src/lib.rs	(revision b8d2037373ee1aafe0574e4a6d202c609a7de6ad)
+++ b/crates/ty/src/lib.rs	(date 1752778603581)
@@ -22,8 +22,8 @@
 use crossbeam::channel as crossbeam_channel;
 use rayon::ThreadPoolBuilder;
 use ruff_db::diagnostic::{Diagnostic, DisplayDiagnosticConfig, Severity};
-use ruff_db::max_parallelism;
 use ruff_db::system::{OsSystem, SystemPath, SystemPathBuf};
+use ruff_db::{max_parallelism, take_memory_usage};
 use salsa::plumbing::ZalsaDatabase;
 use ty_project::metadata::options::ProjectOptionsOverrides;
 use ty_project::watch::ProjectWatcher;
@@ -155,7 +155,10 @@
     match std::env::var(EnvVars::TY_MEMORY_REPORT).as_deref() {
         Ok("short") => write!(stdout, "{}", db.salsa_memory_dump().display_short())?,
         Ok("mypy_primer") => write!(stdout, "{}", db.salsa_memory_dump().display_mypy_primer())?,
-        Ok("full") => write!(stdout, "{}", db.salsa_memory_dump().display_full())?,
+        Ok("full") => {
+            write!(stdout, "{}", db.salsa_memory_dump().display_full())?;
+            write!(stdout, "{:#?}", take_memory_usage())?;
+        }
         _ => {}
     }
 
Index: crates/ruff_db/src/lib.rs
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/crates/ruff_db/src/lib.rs b/crates/ruff_db/src/lib.rs
--- a/crates/ruff_db/src/lib.rs	(revision b8d2037373ee1aafe0574e4a6d202c609a7de6ad)
+++ b/crates/ruff_db/src/lib.rs	(date 1752778603574)
@@ -43,6 +43,25 @@
     VERSION.set(version)
 }
 
+thread_local! {
+    static MEMORY_USAGE_MAP: std::cell::RefCell<FxDashMap<String, usize>> = std::cell::RefCell::new(FxDashMap::default());
+}
+
+pub fn take_memory_usage() -> FxDashMap<String, usize> {
+    MEMORY_USAGE_MAP.with(|map| {
+        let mut map = map.borrow_mut();
+        std::mem::take(&mut *map)
+    })
+}
+
+pub fn increment_memory_usage(ty: &str, amount: usize) {
+    MEMORY_USAGE_MAP.with(|map| {
+        let map = map.borrow_mut();
+        let mut entry = map.entry(ty.to_string()).or_default();
+        *entry += amount;
+    });
+}
+
 /// Most basic database that gives access to files, the host system, source code, and parsed AST.
 #[salsa::db]
 pub trait Db: salsa::Database {

```

</details>
