### PR TITLE
[ty] Shrink reachability constraints

### DIFF
--- a/crates/ty_python_semantic/src/semantic_index/reachability_constraints.rs
+++ b/crates/ty_python_semantic/src/semantic_index/reachability_constraints.rs
@@ -334,7 +334,9 @@ pub(crate) struct ReachabilityConstraintsBuilder {
 }
 
 impl ReachabilityConstraintsBuilder {
-    pub(crate) fn build(self) -> ReachabilityConstraints {
+    pub(crate) fn build(mut self) -> ReachabilityConstraints {
+        self.interiors.shrink_to_fit();
+
         ReachabilityConstraints {
             interiors: self.interiors,
         }


### PR DESCRIPTION
## Summary

Shrink the reachability constraints before storing them in the `UseDefMap`. 
This reduces memory usage on a large project for UseDefMaps by about 400mb or around 8%

## Test Plan

`cargo test`
