### PR TITLE
[ty] Added support for "go to definition" for attribute accesses and keyword arguments

### DIFF
--- a/crates/ty_ide/src/goto.rs
+++ b/crates/ty_ide/src/goto.rs
@@ -151,21 +151,17 @@ impl GotoTarget<'_> {
         use ruff_python_ast as ast;
 
         match self {
-            // For names, find the definitions of the symbol
             GotoTarget::Expression(expression) => match expression {
-                ast::ExprRef::Name(name) => {
-                    // Delegate to shared helper
-                    let definitions = definitions_for_name(db, file, name);
-                    definitions_to_navigation_targets(db, stub_mapper, definitions)
-                }
-                ast::ExprRef::Attribute(attribute) => {
-                    // Navigate to declarations for attribute accesses (`x.y`)
-                    definitions_to_navigation_targets(
-                        db,
-                        stub_mapper,
-                        ty_python_semantic::definitions_for_attribute(db, file, attribute),
-                    )
-                }
+                ast::ExprRef::Name(name) => definitions_to_navigation_targets(
+                    db,
+                    stub_mapper,
+                    definitions_for_name(db, file, name),
+                ),
+                ast::ExprRef::Attribute(attribute) => definitions_to_navigation_targets(
+                    db,
+                    stub_mapper,
+                    ty_python_semantic::definitions_for_attribute(db, file, attribute),
+                ),
                 _ => None,
             },
 
@@ -278,12 +274,12 @@ fn convert_resolved_definitions_to_targets(
                     full_range: full_range.range(),
                 }
             }
-            ty_python_semantic::ResolvedDefinition::FileWithRange(target_file, range) => {
+            ty_python_semantic::ResolvedDefinition::FileWithRange(file_range) => {
                 // For file ranges, navigate to the specific range within the file
                 crate::NavigationTarget {
-                    file: target_file,
-                    focus_range: range,
-                    full_range: range,
+                    file: file_range.file(),
+                    focus_range: file_range.range(),
+                    full_range: file_range.range(),
                 }
             }
         })

--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -17,8 +17,8 @@ pub use program::{
 pub use python_platform::PythonPlatform;
 pub use semantic_model::{Completion, CompletionKind, HasType, NameKind, SemanticModel};
 pub use site_packages::{PythonEnvironment, SitePackagesPaths, SysPrefixPathOrigin};
-pub use types::definitions_for_name;
 pub use types::ide_support::ResolvedDefinition;
+pub use types::{definitions_for_attribute, definitions_for_name};
 pub use util::diagnostics::add_inferred_python_version_hint_to_diagnostic;
 
 pub mod ast_node_ref;

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -49,7 +49,7 @@ use crate::types::generics::{
 };
 pub use crate::types::ide_support::{
     CallSignatureDetails, Member, all_members, call_signature_details, definition_kind_for_name,
-    definitions_for_name,
+    definitions_for_attribute, definitions_for_keyword_argument, definitions_for_name,
 };
 use crate::types::infer::infer_unpack_types;
 use crate::types::mro::{Mro, MroError, MroIterator};


### PR DESCRIPTION
This PR builds upon #19371. It addresses a few additional code review suggestions and adds support for attribute accesses (expressions of the form `x.y`) and keyword arguments within call expressions.