### PR TITLE
[`pyupgrade`]  Apply `UP008` only when the `__class__` cell exists

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP008.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP008.py
@@ -141,3 +141,91 @@ class ExampleWithKeywords:
     
     def method3(self):
         super(ExampleWithKeywords, self).some_method()  # Should be fixed - no keywords
+
+# See: https://github.com/astral-sh/ruff/issues/19357
+# Must be detected
+class ParentD1:
+    def f(self):
+        print("!")
+
+class ChildD1(ParentD1):
+    def f(self):
+        if False: __class__ # compiler injects __class__ into scope
+        builtins.super(ChildD1, self).f()
+
+ChildD1().f()
+
+class ParentD2:
+    def f(self):
+        print("!")
+
+class ChildD2(ParentD2):
+    def f(self):
+        if False: super # compiler injects __class__ into scope
+        builtins.super(ChildD2, self).f()
+
+ChildD2().f()
+
+class ParentD3:
+    def f(self):
+        print("!")
+
+class ChildD3(ParentD3):
+    def f(self):
+        builtins.super(ChildD3, self).f()
+        super # compiler injects __class__ into scope
+
+ChildD3().f()
+
+import builtins as builtins_alias
+
+class ParentD4:
+    def f(self):
+        print("!")
+
+class ChildD4(ParentD4):
+    def f(self):
+        builtins_alias.super(ChildD4, self).f()
+        super # compiler injects __class__ into scope
+
+ChildD4().f()
+
+# Must be ignored
+class ParentI1:
+    def f(self):
+        print("!")
+
+class ChildI1(ParentI1):
+    def f(self):
+        builtins.super(ChildI1, self).f() # no __class__ in the local scope
+
+ChildI1().f()
+
+class ParentI2:
+    def f(self):
+        print("!")
+
+class ChildI2(ParentI2):
+    def b(self):
+        x=__class__
+        if False: super
+
+    def f(self):
+        self.b()
+        builtins.super(ChildI2, self).f() # no __class__ in the local scope
+
+ChildI2().f()
+
+class ParentI3:
+    def f(self):
+        print("!")
+
+class ChildI3(ParentI3):
+    def f(self):
+        if False: super
+        def x(_):
+            builtins.super(ChildI3, self).f() # no __class__ in the local scope
+        x(None)
+
+ChildI3().f()
+

--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP008.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP008.py
@@ -150,7 +150,7 @@ class ParentD1:
 
 class ChildD1(ParentD1):
     def f(self):
-        if False: __class__ # compiler injects __class__ into scope
+        if False: __class__ # Python injects __class__ into scope
         builtins.super(ChildD1, self).f()
 
 ChildD1().f()
@@ -161,7 +161,7 @@ class ParentD2:
 
 class ChildD2(ParentD2):
     def f(self):
-        if False: super # compiler injects __class__ into scope
+        if False: super # Python injects __class__ into scope
         builtins.super(ChildD2, self).f()
 
 ChildD2().f()
@@ -173,7 +173,7 @@ class ParentD3:
 class ChildD3(ParentD3):
     def f(self):
         builtins.super(ChildD3, self).f()
-        super # compiler injects __class__ into scope
+        super # Python injects __class__ into scope
 
 ChildD3().f()
 
@@ -186,9 +186,84 @@ class ParentD4:
 class ChildD4(ParentD4):
     def f(self):
         builtins_alias.super(ChildD4, self).f()
-        super # compiler injects __class__ into scope
+        super # Python injects __class__ into scope
 
 ChildD4().f()
+
+class ParentD5:
+    def f(self):
+        print("!")
+
+class ChildD5(ParentD5):
+    def f(self):
+        super = 1
+        super # Python injects __class__ into scope
+        builtins.super(ChildD5, self).f()
+
+ChildD5().f()
+
+class ParentD6:
+    def f(self):
+        print("!")
+
+class ChildD6(ParentD6):
+    def f(self):
+        super: "Any"
+        __class__ # Python injects __class__ into scope
+        builtins.super(ChildD6, self).f()
+
+ChildD6().f()
+
+class ParentD7:
+    def f(self):
+        print("!")
+
+class ChildD7(ParentD7):
+    def f(self):
+        def x():
+            __class__ # Python injects __class__ into scope
+        builtins.super(ChildD7, self).f()
+
+ChildD7().f()
+
+class ParentD8:
+    def f(self):
+        print("!")
+
+class ChildD8(ParentD8):
+    def f(self):
+        def x():
+            super = 1
+        super # Python injects __class__ into scope
+        builtins.super(ChildD8, self).f()
+
+ChildD8().f()
+
+class ParentD9:
+    def f(self):
+        print("!")
+
+class ChildD9(ParentD9):
+    def f(self):
+        def x():
+            __class__ = 1
+        __class__ # Python injects __class__ into scope
+        builtins.super(ChildD9, self).f()
+
+ChildD9().f()
+
+class ParentD10:
+    def f(self):
+        print("!")
+
+class ChildD10(ParentD10):
+    def f(self):
+        def x():
+            __class__ = 1
+        super # Python injects __class__ into scope
+        builtins.super(ChildD10, self).f()
+
+ChildD10().f()
 
 # Must be ignored
 class ParentI1:
@@ -207,7 +282,7 @@ class ParentI2:
 
 class ChildI2(ParentI2):
     def b(self):
-        x=__class__
+        x = __class__
         if False: super
 
     def f(self):
@@ -229,3 +304,75 @@ class ChildI3(ParentI3):
 
 ChildI3().f()
 
+class ParentI4:
+    def f(self):
+        print("!")
+
+class ChildI4(ParentI4):
+    def f(self):
+        super: "str"
+        builtins.super(ChildI4, self).f() # no __class__ in the local scope
+
+ChildI4().f()
+
+class ParentI5:
+    def f(self):
+        print("!")
+
+class ChildI5(ParentI5):
+    def f(self):
+        super = 1
+        __class__ = 3
+        builtins.super(ChildI5, self).f() # no __class__ in the local scope
+
+ChildI5().f()
+
+class ParentI6:
+    def f(self):
+        print("!")
+
+class ChildI6(ParentI6):
+    def f(self):
+        __class__ = None
+        __class__
+        builtins.super(ChildI6, self).f() # no __class__ in the local scope
+
+ChildI6().f()
+
+class ParentI7:
+    def f(self):
+        print("!")
+
+class ChildI7(ParentI7):
+    def f(self):
+        __class__ = None
+        super
+        builtins.super(ChildI7, self).f()
+
+ChildI7().f()
+
+class ParentI8:
+    def f(self):
+        print("!")
+
+class ChildI8(ParentI8):
+    def f(self):
+        __class__: "Any"
+        super
+        builtins.super(ChildI8, self).f()
+
+ChildI8().f()
+
+class ParentI9:
+    def f(self):
+        print("!")
+
+class ChildI9(ParentI9):
+    def f(self):
+        class A:
+            def foo(self):
+                if False: super
+                if False: __class__
+        builtins.super(ChildI9, self).f()
+
+ChildI9().f()

--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP008.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP008.py
@@ -144,143 +144,82 @@ class ExampleWithKeywords:
 
 # See: https://github.com/astral-sh/ruff/issues/19357
 # Must be detected
-class ParentD1:
+class ParentD:
     def f(self):
-        print("!")
+        print("D")
 
-class ChildD1(ParentD1):
+class ChildD1(ParentD):
     def f(self):
         if False: __class__ # Python injects __class__ into scope
         builtins.super(ChildD1, self).f()
 
-ChildD1().f()
-
-class ParentD2:
-    def f(self):
-        print("!")
-
-class ChildD2(ParentD2):
+class ChildD2(ParentD):
     def f(self):
         if False: super # Python injects __class__ into scope
         builtins.super(ChildD2, self).f()
 
-ChildD2().f()
-
-class ParentD3:
-    def f(self):
-        print("!")
-
-class ChildD3(ParentD3):
+class ChildD3(ParentD):
     def f(self):
         builtins.super(ChildD3, self).f()
         super # Python injects __class__ into scope
 
-ChildD3().f()
-
 import builtins as builtins_alias
-
-class ParentD4:
-    def f(self):
-        print("!")
-
-class ChildD4(ParentD4):
+class ChildD4(ParentD):
     def f(self):
         builtins_alias.super(ChildD4, self).f()
         super # Python injects __class__ into scope
 
-ChildD4().f()
-
-class ParentD5:
-    def f(self):
-        print("!")
-
-class ChildD5(ParentD5):
+class ChildD5(ParentD):
     def f(self):
         super = 1
         super # Python injects __class__ into scope
         builtins.super(ChildD5, self).f()
 
-ChildD5().f()
-
-class ParentD6:
-    def f(self):
-        print("!")
-
-class ChildD6(ParentD6):
+class ChildD6(ParentD):
     def f(self):
         super: "Any"
         __class__ # Python injects __class__ into scope
         builtins.super(ChildD6, self).f()
 
-ChildD6().f()
-
-class ParentD7:
-    def f(self):
-        print("!")
-
-class ChildD7(ParentD7):
+class ChildD7(ParentD):
     def f(self):
         def x():
             __class__ # Python injects __class__ into scope
         builtins.super(ChildD7, self).f()
 
-ChildD7().f()
-
-class ParentD8:
-    def f(self):
-        print("!")
-
-class ChildD8(ParentD8):
+class ChildD8(ParentD):
     def f(self):
         def x():
             super = 1
         super # Python injects __class__ into scope
         builtins.super(ChildD8, self).f()
 
-ChildD8().f()
-
-class ParentD9:
-    def f(self):
-        print("!")
-
-class ChildD9(ParentD9):
+class ChildD9(ParentD):
     def f(self):
         def x():
             __class__ = 1
         __class__ # Python injects __class__ into scope
         builtins.super(ChildD9, self).f()
 
-ChildD9().f()
-
-class ParentD10:
-    def f(self):
-        print("!")
-
-class ChildD10(ParentD10):
+class ChildD10(ParentD):
     def f(self):
         def x():
             __class__ = 1
         super # Python injects __class__ into scope
         builtins.super(ChildD10, self).f()
 
-ChildD10().f()
 
 # Must be ignored
-class ParentI1:
+class ParentI:
     def f(self):
-        print("!")
+        print("I")
 
-class ChildI1(ParentI1):
+class ChildI1(ParentI):
     def f(self):
         builtins.super(ChildI1, self).f() # no __class__ in the local scope
 
-ChildI1().f()
 
-class ParentI2:
-    def f(self):
-        print("!")
-
-class ChildI2(ParentI2):
+class ChildI2(ParentI):
     def b(self):
         x = __class__
         if False: super
@@ -289,90 +228,46 @@ class ChildI2(ParentI2):
         self.b()
         builtins.super(ChildI2, self).f() # no __class__ in the local scope
 
-ChildI2().f()
-
-class ParentI3:
-    def f(self):
-        print("!")
-
-class ChildI3(ParentI3):
+class ChildI3(ParentI):
     def f(self):
         if False: super
         def x(_):
             builtins.super(ChildI3, self).f() # no __class__ in the local scope
         x(None)
 
-ChildI3().f()
-
-class ParentI4:
-    def f(self):
-        print("!")
-
-class ChildI4(ParentI4):
+class ChildI4(ParentI):
     def f(self):
         super: "str"
         builtins.super(ChildI4, self).f() # no __class__ in the local scope
 
-ChildI4().f()
-
-class ParentI5:
-    def f(self):
-        print("!")
-
-class ChildI5(ParentI5):
+class ChildI5(ParentI):
     def f(self):
         super = 1
         __class__ = 3
         builtins.super(ChildI5, self).f() # no __class__ in the local scope
 
-ChildI5().f()
-
-class ParentI6:
-    def f(self):
-        print("!")
-
-class ChildI6(ParentI6):
+class ChildI6(ParentI):
     def f(self):
         __class__ = None
         __class__
         builtins.super(ChildI6, self).f() # no __class__ in the local scope
 
-ChildI6().f()
-
-class ParentI7:
-    def f(self):
-        print("!")
-
-class ChildI7(ParentI7):
+class ChildI7(ParentI):
     def f(self):
         __class__ = None
         super
         builtins.super(ChildI7, self).f()
 
-ChildI7().f()
-
-class ParentI8:
-    def f(self):
-        print("!")
-
-class ChildI8(ParentI8):
+class ChildI8(ParentI):
     def f(self):
         __class__: "Any"
         super
         builtins.super(ChildI8, self).f()
 
-ChildI8().f()
-
-class ParentI9:
-    def f(self):
-        print("!")
-
-class ChildI9(ParentI9):
+class ChildI9(ParentI):
     def f(self):
         class A:
             def foo(self):
                 if False: super
                 if False: __class__
         builtins.super(ChildI9, self).f()
-
-ChildI9().f()

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP008.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP008.py.snap
@@ -147,25 +147,6 @@ help: Remove `super()` parameters
 note: This is an unsafe fix and may change runtime behavior
 
 UP008 [*] Use `super()` instead of `super(__class__, self)`
-   --> UP008.py:107:23
-    |
-105 | class C:
-106 |     def f(self):
-107 |         builtins.super(C, self)
-    |                       ^^^^^^^^^
-    |
-help: Remove `super()` parameters
-104 | 
-105 | class C:
-106 |     def f(self):
-    -         builtins.super(C, self)
-107 +         builtins.super()
-108 | 
-109 | 
-110 | # see: https://github.com/astral-sh/ruff/issues/18533
-note: This is an unsafe fix and may change runtime behavior
-
-UP008 [*] Use `super()` instead of `super(__class__, self)`
    --> UP008.py:113:14
     |
 111 |   class ClassForCommentEnthusiasts(BaseClass):
@@ -294,6 +275,8 @@ UP008 [*] Use `super()` instead of `super(__class__, self)`
 142 |     def method3(self):
 143 |         super(ExampleWithKeywords, self).some_method()  # Should be fixed - no keywords
     |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+144 |
+145 | # See: https://github.com/astral-sh/ruff/issues/19357
     |
 help: Remove `super()` parameters
 140 |         super(ExampleWithKeywords, self, **{"kwarg": "value"}).some_method()  # Should emit diagnostic but NOT be fixed
@@ -301,4 +284,213 @@ help: Remove `super()` parameters
 142 |     def method3(self):
     -         super(ExampleWithKeywords, self).some_method()  # Should be fixed - no keywords
 143 +         super().some_method()  # Should be fixed - no keywords
+144 | 
+145 | # See: https://github.com/astral-sh/ruff/issues/19357
+146 | # Must be detected
+note: This is an unsafe fix and may change runtime behavior
+
+UP008 [*] Use `super()` instead of `super(__class__, self)`
+   --> UP008.py:154:23
+    |
+152 |     def f(self):
+153 |         if False: __class__ # Python injects __class__ into scope
+154 |         builtins.super(ChildD1, self).f()
+    |                       ^^^^^^^^^^^^^^^
+155 |
+156 | class ChildD2(ParentD):
+    |
+help: Remove `super()` parameters
+151 | class ChildD1(ParentD):
+152 |     def f(self):
+153 |         if False: __class__ # Python injects __class__ into scope
+    -         builtins.super(ChildD1, self).f()
+154 +         builtins.super().f()
+155 | 
+156 | class ChildD2(ParentD):
+157 |     def f(self):
+note: This is an unsafe fix and may change runtime behavior
+
+UP008 [*] Use `super()` instead of `super(__class__, self)`
+   --> UP008.py:159:23
+    |
+157 |     def f(self):
+158 |         if False: super # Python injects __class__ into scope
+159 |         builtins.super(ChildD2, self).f()
+    |                       ^^^^^^^^^^^^^^^
+160 |
+161 | class ChildD3(ParentD):
+    |
+help: Remove `super()` parameters
+156 | class ChildD2(ParentD):
+157 |     def f(self):
+158 |         if False: super # Python injects __class__ into scope
+    -         builtins.super(ChildD2, self).f()
+159 +         builtins.super().f()
+160 | 
+161 | class ChildD3(ParentD):
+162 |     def f(self):
+note: This is an unsafe fix and may change runtime behavior
+
+UP008 [*] Use `super()` instead of `super(__class__, self)`
+   --> UP008.py:163:23
+    |
+161 | class ChildD3(ParentD):
+162 |     def f(self):
+163 |         builtins.super(ChildD3, self).f()
+    |                       ^^^^^^^^^^^^^^^
+164 |         super # Python injects __class__ into scope
+    |
+help: Remove `super()` parameters
+160 | 
+161 | class ChildD3(ParentD):
+162 |     def f(self):
+    -         builtins.super(ChildD3, self).f()
+163 +         builtins.super().f()
+164 |         super # Python injects __class__ into scope
+165 | 
+166 | import builtins as builtins_alias
+note: This is an unsafe fix and may change runtime behavior
+
+UP008 [*] Use `super()` instead of `super(__class__, self)`
+   --> UP008.py:169:29
+    |
+167 | class ChildD4(ParentD):
+168 |     def f(self):
+169 |         builtins_alias.super(ChildD4, self).f()
+    |                             ^^^^^^^^^^^^^^^
+170 |         super # Python injects __class__ into scope
+    |
+help: Remove `super()` parameters
+166 | import builtins as builtins_alias
+167 | class ChildD4(ParentD):
+168 |     def f(self):
+    -         builtins_alias.super(ChildD4, self).f()
+169 +         builtins_alias.super().f()
+170 |         super # Python injects __class__ into scope
+171 | 
+172 | class ChildD5(ParentD):
+note: This is an unsafe fix and may change runtime behavior
+
+UP008 [*] Use `super()` instead of `super(__class__, self)`
+   --> UP008.py:176:23
+    |
+174 |         super = 1
+175 |         super # Python injects __class__ into scope
+176 |         builtins.super(ChildD5, self).f()
+    |                       ^^^^^^^^^^^^^^^
+177 |
+178 | class ChildD6(ParentD):
+    |
+help: Remove `super()` parameters
+173 |     def f(self):
+174 |         super = 1
+175 |         super # Python injects __class__ into scope
+    -         builtins.super(ChildD5, self).f()
+176 +         builtins.super().f()
+177 | 
+178 | class ChildD6(ParentD):
+179 |     def f(self):
+note: This is an unsafe fix and may change runtime behavior
+
+UP008 [*] Use `super()` instead of `super(__class__, self)`
+   --> UP008.py:182:23
+    |
+180 |         super: "Any"
+181 |         __class__ # Python injects __class__ into scope
+182 |         builtins.super(ChildD6, self).f()
+    |                       ^^^^^^^^^^^^^^^
+183 |
+184 | class ChildD7(ParentD):
+    |
+help: Remove `super()` parameters
+179 |     def f(self):
+180 |         super: "Any"
+181 |         __class__ # Python injects __class__ into scope
+    -         builtins.super(ChildD6, self).f()
+182 +         builtins.super().f()
+183 | 
+184 | class ChildD7(ParentD):
+185 |     def f(self):
+note: This is an unsafe fix and may change runtime behavior
+
+UP008 [*] Use `super()` instead of `super(__class__, self)`
+   --> UP008.py:188:23
+    |
+186 |         def x():
+187 |             __class__ # Python injects __class__ into scope
+188 |         builtins.super(ChildD7, self).f()
+    |                       ^^^^^^^^^^^^^^^
+189 |
+190 | class ChildD8(ParentD):
+    |
+help: Remove `super()` parameters
+185 |     def f(self):
+186 |         def x():
+187 |             __class__ # Python injects __class__ into scope
+    -         builtins.super(ChildD7, self).f()
+188 +         builtins.super().f()
+189 | 
+190 | class ChildD8(ParentD):
+191 |     def f(self):
+note: This is an unsafe fix and may change runtime behavior
+
+UP008 [*] Use `super()` instead of `super(__class__, self)`
+   --> UP008.py:195:23
+    |
+193 |             super = 1
+194 |         super # Python injects __class__ into scope
+195 |         builtins.super(ChildD8, self).f()
+    |                       ^^^^^^^^^^^^^^^
+196 |
+197 | class ChildD9(ParentD):
+    |
+help: Remove `super()` parameters
+192 |         def x():
+193 |             super = 1
+194 |         super # Python injects __class__ into scope
+    -         builtins.super(ChildD8, self).f()
+195 +         builtins.super().f()
+196 | 
+197 | class ChildD9(ParentD):
+198 |     def f(self):
+note: This is an unsafe fix and may change runtime behavior
+
+UP008 [*] Use `super()` instead of `super(__class__, self)`
+   --> UP008.py:202:23
+    |
+200 |             __class__ = 1
+201 |         __class__ # Python injects __class__ into scope
+202 |         builtins.super(ChildD9, self).f()
+    |                       ^^^^^^^^^^^^^^^
+203 |
+204 | class ChildD10(ParentD):
+    |
+help: Remove `super()` parameters
+199 |         def x():
+200 |             __class__ = 1
+201 |         __class__ # Python injects __class__ into scope
+    -         builtins.super(ChildD9, self).f()
+202 +         builtins.super().f()
+203 | 
+204 | class ChildD10(ParentD):
+205 |     def f(self):
+note: This is an unsafe fix and may change runtime behavior
+
+UP008 [*] Use `super()` instead of `super(__class__, self)`
+   --> UP008.py:209:23
+    |
+207 |             __class__ = 1
+208 |         super # Python injects __class__ into scope
+209 |         builtins.super(ChildD10, self).f()
+    |                       ^^^^^^^^^^^^^^^^
+    |
+help: Remove `super()` parameters
+206 |         def x():
+207 |             __class__ = 1
+208 |         super # Python injects __class__ into scope
+    -         builtins.super(ChildD10, self).f()
+209 +         builtins.super().f()
+210 | 
+211 | 
+212 | # Must be ignored
 note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP008.py__preview.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP008.py__preview.snap
@@ -140,24 +140,6 @@ help: Remove `super()` parameters
 95 | # see: https://github.com/astral-sh/ruff/issues/18684
 
 UP008 [*] Use `super()` instead of `super(__class__, self)`
-   --> UP008.py:107:23
-    |
-105 | class C:
-106 |     def f(self):
-107 |         builtins.super(C, self)
-    |                       ^^^^^^^^^
-    |
-help: Remove `super()` parameters
-104 | 
-105 | class C:
-106 |     def f(self):
-    -         builtins.super(C, self)
-107 +         builtins.super()
-108 | 
-109 | 
-110 | # see: https://github.com/astral-sh/ruff/issues/18533
-
-UP008 [*] Use `super()` instead of `super(__class__, self)`
    --> UP008.py:113:14
     |
 111 |   class ClassForCommentEnthusiasts(BaseClass):
@@ -286,6 +268,8 @@ UP008 [*] Use `super()` instead of `super(__class__, self)`
 142 |     def method3(self):
 143 |         super(ExampleWithKeywords, self).some_method()  # Should be fixed - no keywords
     |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+144 |
+145 | # See: https://github.com/astral-sh/ruff/issues/19357
     |
 help: Remove `super()` parameters
 140 |         super(ExampleWithKeywords, self, **{"kwarg": "value"}).some_method()  # Should emit diagnostic but NOT be fixed
@@ -293,3 +277,202 @@ help: Remove `super()` parameters
 142 |     def method3(self):
     -         super(ExampleWithKeywords, self).some_method()  # Should be fixed - no keywords
 143 +         super().some_method()  # Should be fixed - no keywords
+144 | 
+145 | # See: https://github.com/astral-sh/ruff/issues/19357
+146 | # Must be detected
+
+UP008 [*] Use `super()` instead of `super(__class__, self)`
+   --> UP008.py:154:23
+    |
+152 |     def f(self):
+153 |         if False: __class__ # Python injects __class__ into scope
+154 |         builtins.super(ChildD1, self).f()
+    |                       ^^^^^^^^^^^^^^^
+155 |
+156 | class ChildD2(ParentD):
+    |
+help: Remove `super()` parameters
+151 | class ChildD1(ParentD):
+152 |     def f(self):
+153 |         if False: __class__ # Python injects __class__ into scope
+    -         builtins.super(ChildD1, self).f()
+154 +         builtins.super().f()
+155 | 
+156 | class ChildD2(ParentD):
+157 |     def f(self):
+
+UP008 [*] Use `super()` instead of `super(__class__, self)`
+   --> UP008.py:159:23
+    |
+157 |     def f(self):
+158 |         if False: super # Python injects __class__ into scope
+159 |         builtins.super(ChildD2, self).f()
+    |                       ^^^^^^^^^^^^^^^
+160 |
+161 | class ChildD3(ParentD):
+    |
+help: Remove `super()` parameters
+156 | class ChildD2(ParentD):
+157 |     def f(self):
+158 |         if False: super # Python injects __class__ into scope
+    -         builtins.super(ChildD2, self).f()
+159 +         builtins.super().f()
+160 | 
+161 | class ChildD3(ParentD):
+162 |     def f(self):
+
+UP008 [*] Use `super()` instead of `super(__class__, self)`
+   --> UP008.py:163:23
+    |
+161 | class ChildD3(ParentD):
+162 |     def f(self):
+163 |         builtins.super(ChildD3, self).f()
+    |                       ^^^^^^^^^^^^^^^
+164 |         super # Python injects __class__ into scope
+    |
+help: Remove `super()` parameters
+160 | 
+161 | class ChildD3(ParentD):
+162 |     def f(self):
+    -         builtins.super(ChildD3, self).f()
+163 +         builtins.super().f()
+164 |         super # Python injects __class__ into scope
+165 | 
+166 | import builtins as builtins_alias
+
+UP008 [*] Use `super()` instead of `super(__class__, self)`
+   --> UP008.py:169:29
+    |
+167 | class ChildD4(ParentD):
+168 |     def f(self):
+169 |         builtins_alias.super(ChildD4, self).f()
+    |                             ^^^^^^^^^^^^^^^
+170 |         super # Python injects __class__ into scope
+    |
+help: Remove `super()` parameters
+166 | import builtins as builtins_alias
+167 | class ChildD4(ParentD):
+168 |     def f(self):
+    -         builtins_alias.super(ChildD4, self).f()
+169 +         builtins_alias.super().f()
+170 |         super # Python injects __class__ into scope
+171 | 
+172 | class ChildD5(ParentD):
+
+UP008 [*] Use `super()` instead of `super(__class__, self)`
+   --> UP008.py:176:23
+    |
+174 |         super = 1
+175 |         super # Python injects __class__ into scope
+176 |         builtins.super(ChildD5, self).f()
+    |                       ^^^^^^^^^^^^^^^
+177 |
+178 | class ChildD6(ParentD):
+    |
+help: Remove `super()` parameters
+173 |     def f(self):
+174 |         super = 1
+175 |         super # Python injects __class__ into scope
+    -         builtins.super(ChildD5, self).f()
+176 +         builtins.super().f()
+177 | 
+178 | class ChildD6(ParentD):
+179 |     def f(self):
+
+UP008 [*] Use `super()` instead of `super(__class__, self)`
+   --> UP008.py:182:23
+    |
+180 |         super: "Any"
+181 |         __class__ # Python injects __class__ into scope
+182 |         builtins.super(ChildD6, self).f()
+    |                       ^^^^^^^^^^^^^^^
+183 |
+184 | class ChildD7(ParentD):
+    |
+help: Remove `super()` parameters
+179 |     def f(self):
+180 |         super: "Any"
+181 |         __class__ # Python injects __class__ into scope
+    -         builtins.super(ChildD6, self).f()
+182 +         builtins.super().f()
+183 | 
+184 | class ChildD7(ParentD):
+185 |     def f(self):
+
+UP008 [*] Use `super()` instead of `super(__class__, self)`
+   --> UP008.py:188:23
+    |
+186 |         def x():
+187 |             __class__ # Python injects __class__ into scope
+188 |         builtins.super(ChildD7, self).f()
+    |                       ^^^^^^^^^^^^^^^
+189 |
+190 | class ChildD8(ParentD):
+    |
+help: Remove `super()` parameters
+185 |     def f(self):
+186 |         def x():
+187 |             __class__ # Python injects __class__ into scope
+    -         builtins.super(ChildD7, self).f()
+188 +         builtins.super().f()
+189 | 
+190 | class ChildD8(ParentD):
+191 |     def f(self):
+
+UP008 [*] Use `super()` instead of `super(__class__, self)`
+   --> UP008.py:195:23
+    |
+193 |             super = 1
+194 |         super # Python injects __class__ into scope
+195 |         builtins.super(ChildD8, self).f()
+    |                       ^^^^^^^^^^^^^^^
+196 |
+197 | class ChildD9(ParentD):
+    |
+help: Remove `super()` parameters
+192 |         def x():
+193 |             super = 1
+194 |         super # Python injects __class__ into scope
+    -         builtins.super(ChildD8, self).f()
+195 +         builtins.super().f()
+196 | 
+197 | class ChildD9(ParentD):
+198 |     def f(self):
+
+UP008 [*] Use `super()` instead of `super(__class__, self)`
+   --> UP008.py:202:23
+    |
+200 |             __class__ = 1
+201 |         __class__ # Python injects __class__ into scope
+202 |         builtins.super(ChildD9, self).f()
+    |                       ^^^^^^^^^^^^^^^
+203 |
+204 | class ChildD10(ParentD):
+    |
+help: Remove `super()` parameters
+199 |         def x():
+200 |             __class__ = 1
+201 |         __class__ # Python injects __class__ into scope
+    -         builtins.super(ChildD9, self).f()
+202 +         builtins.super().f()
+203 | 
+204 | class ChildD10(ParentD):
+205 |     def f(self):
+
+UP008 [*] Use `super()` instead of `super(__class__, self)`
+   --> UP008.py:209:23
+    |
+207 |             __class__ = 1
+208 |         super # Python injects __class__ into scope
+209 |         builtins.super(ChildD10, self).f()
+    |                       ^^^^^^^^^^^^^^^^
+    |
+help: Remove `super()` parameters
+206 |         def x():
+207 |             __class__ = 1
+208 |         super # Python injects __class__ into scope
+    -         builtins.super(ChildD10, self).f()
+209 +         builtins.super().f()
+210 | 
+211 | 
+212 | # Must be ignored

--- a/crates/ruff_python_ast/src/helpers.rs
+++ b/crates/ruff_python_ast/src/helpers.rs
@@ -1092,30 +1092,6 @@ impl Visitor<'_> for AwaitVisitor {
     }
 }
 
-/// A [`Visitor`] that collects all [`Expr::Name`] nodes within function scope,
-/// excluding nested class definitions.
-#[derive(Debug, Default)]
-pub struct FunctionScopeNameFinder<'a> {
-    /// All name expressions found in the visited scope.
-    pub names: Vec<&'a ast::ExprName>,
-}
-
-impl<'a> Visitor<'a> for FunctionScopeNameFinder<'a> {
-    fn visit_stmt(&mut self, stmt: &'a Stmt) {
-        match stmt {
-            Stmt::ClassDef(_) => {}
-            _ => crate::visitor::walk_stmt(self, stmt),
-        }
-    }
-
-    fn visit_expr(&mut self, expr: &'a Expr) {
-        if let Expr::Name(name) = expr {
-            self.names.push(name);
-        }
-        crate::visitor::walk_expr(self, expr);
-    }
-}
-
 /// Return `true` if a `Stmt` is a docstring.
 pub fn is_docstring_stmt(stmt: &Stmt) -> bool {
     if let Stmt::Expr(ast::StmtExpr {


### PR DESCRIPTION
## Summary

Resolves #19357 

Skip UP008 diagnostic for `builtins.super(P, self)` calls when `__class__` is not referenced locally, preventing incorrect fixes.  

**Note:** I haven't found concrete information about which cases `__class__` will be loaded into the scope. Let me know if anyone has references, it would be useful to enhance the implementation. I did a lot of tests to determine when `__class__` is loaded. Considered sources:
1.  [Python doc super](https://docs.python.org/3/library/functions.html#super)
2.  [Python doc classes](https://docs.python.org/3/tutorial/classes.html)
3. [pep-3135](https://peps.python.org/pep-3135/#specification)

As I understand it, Python will inject at runtime into local scope a `__class__` variable if it detects references to `super` or `__class__`. This allows calling `super()` and passing appropriate parameters. However, the compiler doesn't do the same for `builtins.super`, so we need to somehow introduce `__class__` into the local scope.

I figured out `__class__` will be in scope with valid value when two conditions are met:
1. `super` or `__class__` names have been loaded within function scope
4. `__class__` is not overridden.

I think my solution isn't elegant, so I would be appreciate a detailed review.

## Test Plan

Added 19 test cases, updated snapshots.
