### PR TITLE
highlight the relevant argument in type assert error messages

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/directives/cast.md
+++ b/crates/ty_python_semantic/resources/mdtest/directives/cast.md
@@ -1,5 +1,7 @@
 # `cast`
 
+## Behavior
+
 `cast()` takes two arguments, one type and one value, and returns a value of the given type.
 
 The (inferred) type of the value and the given type do not need to have any correlation.
@@ -77,4 +79,16 @@ def f(x: Any, y: Unknown, z: Any | str | int):
     reveal_type(d)  # revealed: Unknown
 
     e = cast(str | int | Any, z)  # error: [redundant-cast]
+```
+
+## The redundant `cast` diagnostic
+
+<!-- snapshot-diagnostics -->
+
+```py
+import secrets
+from typing import cast
+
+# error: [redundant-cast] "Value is already of type `int`"
+cast(int, secrets.randbelow(10))
 ```

--- a/crates/ty_python_semantic/resources/mdtest/directives/static_assert.md
+++ b/crates/ty_python_semantic/resources/mdtest/directives/static_assert.md
@@ -1,0 +1,29 @@
+# `static_assert`
+
+## Diagnostics
+
+<!-- snapshot-diagnostics -->
+
+```py
+from ty_extensions import static_assert
+import secrets
+
+# a passing assert
+static_assert(1 < 2)
+
+# evaluates to False
+# error: [static-assert-error]
+static_assert(1 > 2)
+
+# evaluates to False, with a message as the second argument
+# error: [static-assert-error]
+static_assert(1 > 2, "with a message")
+
+# evaluates to something falsey
+# error: [static-assert-error]
+static_assert("")
+
+# evaluates to something ambiguous
+# error: [static-assert-error]
+static_assert(secrets.randbelow(2))
+```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/assert_never.md_-_`assert_never`_-_Basic_functionality_-_Diagnostics_(be8f5d8b0718ee54).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/assert_never.md_-_`assert_never`_-_Basic_functionality_-_Diagnostics_(be8f5d8b0718ee54).snap
@@ -47,13 +47,11 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/directives/assert_never.
 
 ```
 error[type-assertion-failure]: Argument does not have asserted type `Never`
- --> src/mdtest_snippet.py:5:5
+ --> src/mdtest_snippet.py:5:18
   |
 4 | def _():
 5 |     assert_never(0)  # error: [type-assertion-failure]
-  |     ^^^^^^^^^^^^^-^
-  |                  |
-  |                  Inferred type of argument is `Literal[0]`
+  |                  ^ Inferred type is `Literal[0]`
 6 |
 7 | def _():
   |
@@ -64,13 +62,11 @@ info: rule `type-assertion-failure` is enabled by default
 
 ```
 error[type-assertion-failure]: Argument does not have asserted type `Never`
-  --> src/mdtest_snippet.py:8:5
+  --> src/mdtest_snippet.py:8:18
    |
  7 | def _():
  8 |     assert_never("")  # error: [type-assertion-failure]
-   |     ^^^^^^^^^^^^^--^
-   |                  |
-   |                  Inferred type of argument is `Literal[""]`
+   |                  ^^ Inferred type is `Literal[""]`
  9 |
 10 | def _():
    |
@@ -81,13 +77,11 @@ info: rule `type-assertion-failure` is enabled by default
 
 ```
 error[type-assertion-failure]: Argument does not have asserted type `Never`
-  --> src/mdtest_snippet.py:11:5
+  --> src/mdtest_snippet.py:11:18
    |
 10 | def _():
 11 |     assert_never(None)  # error: [type-assertion-failure]
-   |     ^^^^^^^^^^^^^----^
-   |                  |
-   |                  Inferred type of argument is `None`
+   |                  ^^^^ Inferred type is `None`
 12 |
 13 | def _():
    |
@@ -98,13 +92,11 @@ info: rule `type-assertion-failure` is enabled by default
 
 ```
 error[type-assertion-failure]: Argument does not have asserted type `Never`
-  --> src/mdtest_snippet.py:14:5
+  --> src/mdtest_snippet.py:14:18
    |
 13 | def _():
 14 |     assert_never([])  # error: [type-assertion-failure]
-   |     ^^^^^^^^^^^^^--^
-   |                  |
-   |                  Inferred type of argument is `list[Unknown]`
+   |                  ^^ Inferred type is `list[Unknown]`
 15 |
 16 | def _():
    |
@@ -115,13 +107,11 @@ info: rule `type-assertion-failure` is enabled by default
 
 ```
 error[type-assertion-failure]: Argument does not have asserted type `Never`
-  --> src/mdtest_snippet.py:17:5
+  --> src/mdtest_snippet.py:17:18
    |
 16 | def _():
 17 |     assert_never({})  # error: [type-assertion-failure]
-   |     ^^^^^^^^^^^^^--^
-   |                  |
-   |                  Inferred type of argument is `dict[Unknown, Unknown]`
+   |                  ^^ Inferred type is `dict[Unknown, Unknown]`
 18 |
 19 | def _():
    |
@@ -132,13 +122,11 @@ info: rule `type-assertion-failure` is enabled by default
 
 ```
 error[type-assertion-failure]: Argument does not have asserted type `Never`
-  --> src/mdtest_snippet.py:20:5
+  --> src/mdtest_snippet.py:20:18
    |
 19 | def _():
 20 |     assert_never(())  # error: [type-assertion-failure]
-   |     ^^^^^^^^^^^^^--^
-   |                  |
-   |                  Inferred type of argument is `tuple[()]`
+   |                  ^^ Inferred type is `tuple[()]`
 21 |
 22 | def _(flag: bool, never: Never):
    |
@@ -149,13 +137,11 @@ info: rule `type-assertion-failure` is enabled by default
 
 ```
 error[type-assertion-failure]: Argument does not have asserted type `Never`
-  --> src/mdtest_snippet.py:23:5
+  --> src/mdtest_snippet.py:23:18
    |
 22 | def _(flag: bool, never: Never):
 23 |     assert_never(1 if flag else never)  # error: [type-assertion-failure]
-   |     ^^^^^^^^^^^^^--------------------^
-   |                  |
-   |                  Inferred type of argument is `Literal[1]`
+   |                  ^^^^^^^^^^^^^^^^^^^^ Inferred type is `Literal[1]`
 24 |
 25 | def _(any_: Any):
    |
@@ -166,13 +152,11 @@ info: rule `type-assertion-failure` is enabled by default
 
 ```
 error[type-assertion-failure]: Argument does not have asserted type `Never`
-  --> src/mdtest_snippet.py:26:5
+  --> src/mdtest_snippet.py:26:18
    |
 25 | def _(any_: Any):
 26 |     assert_never(any_)  # error: [type-assertion-failure]
-   |     ^^^^^^^^^^^^^----^
-   |                  |
-   |                  Inferred type of argument is `Any`
+   |                  ^^^^ Inferred type is `Any`
 27 |
 28 | def _(unknown: Unknown):
    |
@@ -183,13 +167,11 @@ info: rule `type-assertion-failure` is enabled by default
 
 ```
 error[type-assertion-failure]: Argument does not have asserted type `Never`
-  --> src/mdtest_snippet.py:29:5
+  --> src/mdtest_snippet.py:29:18
    |
 28 | def _(unknown: Unknown):
 29 |     assert_never(unknown)  # error: [type-assertion-failure]
-   |     ^^^^^^^^^^^^^-------^
-   |                  |
-   |                  Inferred type of argument is `Unknown`
+   |                  ^^^^^^^ Inferred type is `Unknown`
    |
 info: `Never` and `Unknown` are not equivalent types
 info: rule `type-assertion-failure` is enabled by default

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/assert_type.md_-_`assert_type`_-_Basic_(c507788da2659ec9).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/assert_type.md_-_`assert_type`_-_Basic_(c507788da2659ec9).snap
@@ -23,14 +23,12 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/directives/assert_type.m
 
 ```
 error[type-assertion-failure]: Argument does not have asserted type `str`
- --> src/mdtest_snippet.py:5:5
+ --> src/mdtest_snippet.py:5:17
   |
 3 | def _(x: int):
 4 |     assert_type(x, int)  # fine
 5 |     assert_type(x, str)  # error: [type-assertion-failure]
-  |     ^^^^^^^^^^^^-^^^^^^
-  |                 |
-  |                 Inferred type of argument is `int`
+  |                 ^ Inferred type is `int`
   |
 info: `str` and `int` are not equivalent types
 info: rule `type-assertion-failure` is enabled by default

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/cast.md_-_`cast`_-_The_redundant_`cast`…_(7746465d25c4280a).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/cast.md_-_`cast`_-_The_redundant_`cast`…_(7746465d25c4280a).snap
@@ -1,0 +1,34 @@
+---
+source: crates/ty_test/src/lib.rs
+expression: snapshot
+---
+---
+mdtest name: cast.md - `cast` - The redundant `cast` diagnostic
+mdtest path: crates/ty_python_semantic/resources/mdtest/directives/cast.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+1 | import secrets
+2 | from typing import cast
+3 | 
+4 | # error: [redundant-cast] "Value is already of type `int`"
+5 | cast(int, secrets.randbelow(10))
+```
+
+# Diagnostics
+
+```
+warning[redundant-cast]: Value is already of type `int`
+ --> src/mdtest_snippet.py:5:11
+  |
+4 | # error: [redundant-cast] "Value is already of type `int`"
+5 | cast(int, secrets.randbelow(10))
+  |           ^^^^^^^^^^^^^^^^^^^^^ Inferred type is already `int`
+  |
+info: rule `redundant-cast` is enabled by default
+
+```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/static_assert.md_-_`static_assert`_-_Diagnostics_(b195c06ae1c68ef3).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/static_assert.md_-_`static_assert`_-_Diagnostics_(b195c06ae1c68ef3).snap
@@ -1,0 +1,96 @@
+---
+source: crates/ty_test/src/lib.rs
+expression: snapshot
+---
+---
+mdtest name: static_assert.md - `static_assert` - Diagnostics
+mdtest path: crates/ty_python_semantic/resources/mdtest/directives/static_assert.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+ 1 | from ty_extensions import static_assert
+ 2 | import secrets
+ 3 | 
+ 4 | # a passing assert
+ 5 | static_assert(1 < 2)
+ 6 | 
+ 7 | # evaluates to False
+ 8 | # error: [static-assert-error]
+ 9 | static_assert(1 > 2)
+10 | 
+11 | # evaluates to False, with a message as the second argument
+12 | # error: [static-assert-error]
+13 | static_assert(1 > 2, "with a message")
+14 | 
+15 | # evaluates to something falsey
+16 | # error: [static-assert-error]
+17 | static_assert("")
+18 | 
+19 | # evaluates to something ambiguous
+20 | # error: [static-assert-error]
+21 | static_assert(secrets.randbelow(2))
+```
+
+# Diagnostics
+
+```
+error[static-assert-error]: Static assertion error: argument evaluates to `False`
+  --> src/mdtest_snippet.py:9:15
+   |
+ 7 | # evaluates to False
+ 8 | # error: [static-assert-error]
+ 9 | static_assert(1 > 2)
+   |               ^^^^^ Inferred type is `Literal[False]`
+10 |
+11 | # evaluates to False, with a message as the second argument
+   |
+info: rule `static-assert-error` is enabled by default
+
+```
+
+```
+error[static-assert-error]: Static assertion error: with a message
+  --> src/mdtest_snippet.py:13:15
+   |
+11 | # evaluates to False, with a message as the second argument
+12 | # error: [static-assert-error]
+13 | static_assert(1 > 2, "with a message")
+   |               ^^^^^ Inferred type is `Literal[False]`
+14 |
+15 | # evaluates to something falsey
+   |
+info: rule `static-assert-error` is enabled by default
+
+```
+
+```
+error[static-assert-error]: Static assertion error: argument of type `Literal[""]` is statically known to be falsy
+  --> src/mdtest_snippet.py:17:15
+   |
+15 | # evaluates to something falsey
+16 | # error: [static-assert-error]
+17 | static_assert("")
+   |               ^^ Inferred type is `Literal[""]`
+18 |
+19 | # evaluates to something ambiguous
+   |
+info: rule `static-assert-error` is enabled by default
+
+```
+
+```
+error[static-assert-error]: Static assertion error: argument of type `int` has an ambiguous static truthiness
+  --> src/mdtest_snippet.py:21:15
+   |
+19 | # evaluates to something ambiguous
+20 | # error: [static-assert-error]
+21 | static_assert(secrets.randbelow(2))
+   |               ^^^^^^^^^^^^^^^^^^^^ Inferred type is `int`
+   |
+info: rule `static-assert-error` is enabled by default
+
+```


### PR DESCRIPTION
Here's a quick before/after summary of the formatting changes:

```py
from ty_extensions import static_assert
from typing import assert_type, assert_never, cast
assert_type(1 + 2 + 3 + 4, str)
assert_never(["blarg"])
static_assert(3 > 4, "custom message")
_ = cast(int, int("100"))
```

Before:
```
error[type-assertion-failure]: Argument does not have asserted type `str`
 --> test.py:3:1
  |
1 | from ty_extensions import static_assert
2 | from typing import assert_type, assert_never, cast
3 | assert_type(1 + 2 + 3 + 4, str)
  | ^^^^^^^^^^^^-------------^^^^^^
  |             |
  |             Inferred type of argument is `Literal[10]`
4 | assert_never(["blarg"])
5 | static_assert(3 > 4, "custom message")
  |
info: `str` and `Literal[10]` are not equivalent types
```

After:
```
error[type-assertion-failure]: Argument does not have asserted type `str`
 --> test.py:3:13
  |
1 | from ty_extensions import static_assert
2 | from typing import assert_type, assert_never, cast
3 | assert_type(1 + 2 + 3 + 4, str)
  |             ^^^^^^^^^^^^^ Inferred type is `Literal[10]`
4 | assert_never(["blarg"])
5 | static_assert(3 > 4, "custom message")
  |
info: `str` and `Literal[10]` are not equivalent types
```

Before:
```
error[type-assertion-failure]: Argument does not have asserted type `Never`
 --> test.py:4:1
  |
2 | from typing import assert_type, assert_never, cast
3 | assert_type(1 + 2 + 3 + 4, str)
4 | assert_never(["blarg"])
  | ^^^^^^^^^^^^^---------^
  |              |
  |              Inferred type of argument is `list[Unknown]`
5 | static_assert(3 > 4, "custom message")
6 | _ = cast(int, int("100"))
  |
info: `Never` and `list[Unknown]` are not equivalent types
```

After:
```
error[type-assertion-failure]: Argument does not have asserted type `Never`
 --> test.py:4:14
  |
2 | from typing import assert_type, assert_never, cast
3 | assert_type(1 + 2 + 3 + 4, str)
4 | assert_never(["blarg"])
  |              ^^^^^^^^^ Inferred type is `list[Unknown]`
5 | static_assert(3 > 4, "custom message")
6 | _ = cast(int, int("100"))
  |
info: `Never` and `list[Unknown]` are not equivalent types
```

Before:
```
error[static-assert-error]: Static assertion error: custom message
 --> test.py:5:1
  |
3 | assert_type(1 + 2 + 3 + 4, str)
4 | assert_never(["blarg"])
5 | static_assert(3 > 4, "custom message")
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
6 | _ = cast(int, int("100"))
  |
```

After:
```
error[static-assert-error]: Static assertion error: custom message
 --> test.py:5:15
  |
3 | assert_type(1 + 2 + 3 + 4, str)
4 | assert_never(["blarg"])
5 | static_assert(3 > 4, "custom message")
  |               ^^^^^ Inferred type is `Literal[False]`
6 | _ = cast(int, int("100"))
  |
```

Before:
```
warning[redundant-cast]: Value is already of type `int`
 --> test.py:6:5
  |
4 | assert_never(["blarg"])
5 | static_assert(3 > 4, "custom message")
6 | _ = cast(int, int("100"))
  |     ^^^^^^^^^^^^^^^^^^^^^
  |
```

After:
```
warning[redundant-cast]: Value is already of type `int`
 --> test.py:6:15
  |
4 | assert_never(["blarg"])
5 | static_assert(3 > 4, "custom message")
6 | _ = cast(int, int("100"))
  |               ^^^^^^^^^^ Inferred type is already `int`
  |
```
