### PR TITLE
[ty] Reduce size of empty `TypeCheckDiagnostics` to one word

### DIFF
--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -115,7 +115,7 @@ pub fn check_types(db: &dyn Db, file: File) -> Vec<Diagnostic> {
 
     check_suppressions(db, file, &mut diagnostics);
 
-    diagnostics.into_vec()
+    diagnostics.into_diagnostics()
 }
 
 /// Infer the type of a binding.


### PR DESCRIPTION
## Summary

`TypeCheckDiagnostics` are stored in every `TypeInference` and ty creates a lot of them (see below for some numbers from a large project). 
But most of those inference contexts don't have any diagnostics or suppressions.

This PR changes `TypeCheckDiagnostics` to use a `Option<Box<Inner>>` instead. This reduces the size of `TypeInference` from 224 bytes to 176 bytes (48 bytes). 
The downside of this is that it requires an extra allocation for files that use suppressions or diagnostics. But these should be rare.

```
`infer_definition_types -> ty_python_semantic::types::infer::TypeInference`
    metadata=850.32MB fields=2307.24MB count=5089303
`infer_expression_types -> ty_python_semantic::types::infer::TypeInference`
    metadata=1701.13MB fields=2014.07MB count=4971063
`infer_scope_types -> ty_python_semantic::types::infer::TypeInference`
    metadata=400.87MB fields=1738.46MB count=868855
```

I considered using a `ThinVec` for `diagnostics` over boxing the entire `TypeCheckDiagnostics` but that only reduces the size by 16 bytes because
it doesn't help with the much larger `HashSet`.

If the above project would have zero suppressions and diagnostics, this PR saves ~500MB even though ty emits a ton of diagnostics!

```
`infer_definition_types -> ty_python_semantic::types::infer::TypeInference`
    metadata=850.28MB fields=2065.54MB count=5089306
`infer_expression_types -> ty_python_semantic::types::infer::TypeInference`
    metadata=1701.02MB fields=1779.32MB count=4971063
`infer_scope_types -> ty_python_semantic::types::infer::TypeInference`
    metadata=400.87MB fields=1699.84MB count=868855
```

## Test Plan

`cargo test`
