### PR TITLE
[`pep8-naming`] Fix `N802` false positives for `CGIHTTPRequestHandler` and `SimpleHTTPRequestHandler`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pep8_naming/N802.py
+++ b/crates/ruff_linter/resources/test/fixtures/pep8_naming/N802.py
@@ -84,3 +84,25 @@ class MyRequestHandler(BaseHTTPRequestHandler):
     def dont_GET(self):
         pass
 
+
+from http.server import CGIHTTPRequestHandler
+
+
+class MyCGIRequestHandler(CGIHTTPRequestHandler):
+    def do_OPTIONS(self):
+        pass
+
+    def dont_OPTIONS(self):
+        pass
+
+
+from http.server import SimpleHTTPRequestHandler
+
+
+class MySimpleRequestHandler(SimpleHTTPRequestHandler):
+    def do_OPTIONS(self):
+        pass
+
+    def dont_OPTIONS(self):
+        pass
+

--- a/crates/ruff_linter/src/rules/pep8_naming/rules/invalid_function_name.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/rules/invalid_function_name.rs
@@ -100,16 +100,16 @@ pub(crate) fn invalid_function_name(
         return;
     }
 
-    // Ignore the do_* methods of the http.server.BaseHTTPRequestHandler class
+    // Ignore the do_* methods of the http.server.BaseHTTPRequestHandler class and its subclasses
     if name.starts_with("do_")
         && parent_class.is_some_and(|class| {
             any_base_class(class, semantic, &mut |superclass| {
                 let qualified = semantic.resolve_qualified_name(superclass);
                 qualified.is_some_and(|name| {
-                    matches!(
-                        name.segments(),
-                        ["http", "server", "BaseHTTPRequestHandler"]
-                    )
+                    let segments = name.segments();
+                    segments == ["http", "server", "BaseHTTPRequestHandler"]
+                        || segments == ["http", "server", "CGIHTTPRequestHandler"]
+                        || segments == ["http", "server", "SimpleHTTPRequestHandler"]
                 })
             })
         })

--- a/crates/ruff_linter/src/rules/pep8_naming/rules/invalid_function_name.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/rules/invalid_function_name.rs
@@ -106,10 +106,16 @@ pub(crate) fn invalid_function_name(
             any_base_class(class, semantic, &mut |superclass| {
                 let qualified = semantic.resolve_qualified_name(superclass);
                 qualified.is_some_and(|name| {
-                    let segments = name.segments();
-                    segments == ["http", "server", "BaseHTTPRequestHandler"]
-                        || segments == ["http", "server", "CGIHTTPRequestHandler"]
-                        || segments == ["http", "server", "SimpleHTTPRequestHandler"]
+                    matches!(
+                        name.segments(),
+                        [
+                            "http",
+                            "server",
+                            "BaseHTTPRequestHandler"
+                                | "CGIHTTPRequestHandler"
+                                | "SimpleHTTPRequestHandler"
+                        ]
+                    )
                 })
             })
         })

--- a/crates/ruff_linter/src/rules/pep8_naming/snapshots/ruff_linter__rules__pep8_naming__tests__N802_N802.py.snap
+++ b/crates/ruff_linter/src/rules/pep8_naming/snapshots/ruff_linter__rules__pep8_naming__tests__N802_N802.py.snap
@@ -55,3 +55,21 @@ N802.py:84:9: N802 Function name `dont_GET` should be lowercase
    |         ^^^^^^^^ N802
 85 |         pass
    |
+
+N802.py:95:9: N802 Function name `dont_OPTIONS` should be lowercase
+   |
+93 |         pass
+94 |
+95 |     def dont_OPTIONS(self):
+   |         ^^^^^^^^^^^^ N802
+96 |         pass
+   |
+
+N802.py:106:9: N802 Function name `dont_OPTIONS` should be lowercase
+    |
+104 |         pass
+105 |
+106 |     def dont_OPTIONS(self):
+    |         ^^^^^^^^^^^^ N802
+107 |         pass
+    |


### PR DESCRIPTION
## Summary

Fixes #19422
