### PR TITLE
[ty] Reduce size of `TypeInference`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,6 +680,11 @@ name = "countme"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
+dependencies = [
+ "dashmap 5.5.3",
+ "once_cell",
+ "rustc-hash 1.1.0",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -845,6 +850,19 @@ dependencies = [
  "darling_core",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -2243,7 +2261,7 @@ dependencies = [
  "once_cell",
  "pep440_rs",
  "regex",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde",
  "smallvec",
  "thiserror 1.0.69",
@@ -2753,7 +2771,7 @@ dependencies = [
  "ruff_source_file",
  "ruff_text_size",
  "ruff_workspace",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "shellexpand",
@@ -2799,7 +2817,7 @@ dependencies = [
  "ruff_python_formatter",
  "ruff_python_parser",
  "ruff_python_trivia",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "tikv-jemallocator",
@@ -2828,7 +2846,7 @@ dependencies = [
  "arc-swap",
  "camino",
  "countme",
- "dashmap",
+ "dashmap 6.1.0",
  "dunce",
  "etcetera",
  "filetime",
@@ -2848,7 +2866,7 @@ dependencies = [
  "ruff_python_trivia",
  "ruff_source_file",
  "ruff_text_size",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "salsa",
  "schemars",
  "serde",
@@ -2923,7 +2941,7 @@ dependencies = [
  "ruff_cache",
  "ruff_macros",
  "ruff_text_size",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "schemars",
  "serde",
  "static_assertions",
@@ -3004,7 +3022,7 @@ dependencies = [
  "ruff_python_trivia",
  "ruff_source_file",
  "ruff_text_size",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "schemars",
  "serde",
  "serde_json",
@@ -3076,7 +3094,7 @@ dependencies = [
  "ruff_python_trivia",
  "ruff_source_file",
  "ruff_text_size",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "salsa",
  "schemars",
  "serde",
@@ -3126,7 +3144,7 @@ dependencies = [
  "ruff_python_trivia",
  "ruff_source_file",
  "ruff_text_size",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "salsa",
  "schemars",
  "serde",
@@ -3175,7 +3193,7 @@ dependencies = [
  "ruff_python_trivia",
  "ruff_source_file",
  "ruff_text_size",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "static_assertions",
@@ -3199,7 +3217,7 @@ dependencies = [
  "ruff_python_parser",
  "ruff_python_stdlib",
  "ruff_text_size",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "schemars",
  "serde",
  "smallvec",
@@ -3260,7 +3278,7 @@ dependencies = [
  "ruff_source_file",
  "ruff_text_size",
  "ruff_workspace",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "shellexpand",
@@ -3349,7 +3367,7 @@ dependencies = [
  "ruff_python_semantic",
  "ruff_python_stdlib",
  "ruff_source_file",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "schemars",
  "serde",
  "shellexpand",
@@ -3367,6 +3385,12 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -3422,7 +3446,7 @@ dependencies = [
  "parking_lot",
  "portable-atomic",
  "rayon",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "salsa-macro-rules",
  "salsa-macros",
  "smallvec",
@@ -4151,6 +4175,7 @@ dependencies = [
  "clap",
  "clap_complete_command",
  "colored 3.0.0",
+ "countme",
  "crossbeam",
  "ctrlc",
  "dunce",
@@ -4190,7 +4215,7 @@ dependencies = [
  "ruff_python_trivia",
  "ruff_source_file",
  "ruff_text_size",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "salsa",
  "smallvec",
  "tracing",
@@ -4222,7 +4247,7 @@ dependencies = [
  "ruff_python_ast",
  "ruff_python_formatter",
  "ruff_text_size",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "salsa",
  "schemars",
  "serde",
@@ -4243,6 +4268,7 @@ dependencies = [
  "camino",
  "colored 3.0.0",
  "compact_str",
+ "countme",
  "dir-test",
  "drop_bomb",
  "get-size2",
@@ -4266,7 +4292,7 @@ dependencies = [
  "ruff_python_trivia",
  "ruff_source_file",
  "ruff_text_size",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "salsa",
  "schemars",
  "serde",
@@ -4300,7 +4326,7 @@ dependencies = [
  "ruff_python_ast",
  "ruff_source_file",
  "ruff_text_size",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "salsa",
  "serde",
  "serde_json",
@@ -4339,7 +4365,7 @@ dependencies = [
  "ruff_python_trivia",
  "ruff_source_file",
  "ruff_text_size",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustc-stable-hash",
  "salsa",
  "serde",

--- a/crates/ty/Cargo.toml
+++ b/crates/ty/Cargo.toml
@@ -26,6 +26,7 @@ argfile = { workspace = true }
 clap = { workspace = true, features = ["wrap_help", "string", "env"] }
 clap_complete_command = { workspace = true }
 colored = { workspace = true }
+countme = { workspace = true, features = ["enable", "print_at_exit"] }
 crossbeam = { workspace = true }
 ctrlc = { version = "3.4.4" }
 indicatif = { workspace = true }

--- a/crates/ty/src/lib.rs
+++ b/crates/ty/src/lib.rs
@@ -62,6 +62,7 @@ pub(crate) fn version() -> Result<()> {
 
 fn run_check(args: CheckCommand) -> anyhow::Result<ExitStatus> {
     set_colored_override(args.color);
+    countme::enable(true);
 
     let verbosity = args.verbosity.level();
     let _guard = setup_tracing(verbosity, args.color.unwrap_or_default())?;
@@ -158,6 +159,8 @@ fn run_check(args: CheckCommand) -> anyhow::Result<ExitStatus> {
         Ok("full") => write!(stdout, "{}", db.salsa_memory_dump().display_full())?,
         _ => {}
     }
+
+    tracing::info!("countme: {:?}", countme::get_all());
 
     std::mem::forget(db);
 

--- a/crates/ty_python_semantic/Cargo.toml
+++ b/crates/ty_python_semantic/Cargo.toml
@@ -28,6 +28,7 @@ anyhow = { workspace = true }
 bitflags = { workspace = true }
 camino = { workspace = true }
 colored = { workspace = true }
+countme = { workspace = true }
 compact_str = { workspace = true }
 drop_bomb = { workspace = true }
 get-size2 = { workspace = true }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -103,7 +103,10 @@ pub fn check_types(db: &dyn Db, file: File) -> Vec<Diagnostic> {
 
     for scope_id in index.scope_ids() {
         let result = infer_scope_types(db, scope_id);
+
+        // if let Some(extra) = result.extra() {
         diagnostics.extend(result.diagnostics());
+        // }
     }
 
     diagnostics.extend_diagnostics(

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -104,9 +104,9 @@ pub fn check_types(db: &dyn Db, file: File) -> Vec<Diagnostic> {
     for scope_id in index.scope_ids() {
         let result = infer_scope_types(db, scope_id);
 
-        // if let Some(extra) = result.extra() {
-        diagnostics.extend(result.diagnostics());
-        // }
+        if let Some(scope_diagnotics) = result.diagnostics() {
+            diagnostics.extend(scope_diagnotics);
+        }
     }
 
     diagnostics.extend_diagnostics(

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -115,7 +115,7 @@ pub fn check_types(db: &dyn Db, file: File) -> Vec<Diagnostic> {
 
     check_suppressions(db, file, &mut diagnostics);
 
-    diagnostics.into_vec()
+    diagnostics.into_diagnostics()
 }
 
 /// Infer the type of a binding.

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -1713,6 +1713,12 @@ impl TypeCheckDiagnostics {
             .unwrap_or_default()
     }
 
+    pub(crate) fn is_empty(&self) -> bool {
+        self.inner
+            .as_ref()
+            .is_none_or(|inner| inner.diagnostics.is_empty() && inner.used_suppressions.is_empty())
+    }
+
     pub fn iter(&self) -> std::slice::Iter<'_, Diagnostic> {
         self.diagnostics().iter()
     }


### PR DESCRIPTION
- **[ty] Reduce size of `TypeCheckDiagnostics` to one word**
- **Move most fields to extra**
- **Move `TypeInference` fields onto builder**
- **Split out `ExpressionInference**
- **Undo `Option<Box<Inner>>` for type check diagnostics**

<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
