### PR TITLE
[ty] bump docstring-adder pin

### DIFF
--- a/.github/workflows/sync_typeshed.yaml
+++ b/.github/workflows/sync_typeshed.yaml
@@ -34,6 +34,10 @@ env:
   # and which all three workers push to.
   UPSTREAM_BRANCH: typeshedbot/sync-typeshed
 
+  # The path to the directory that contains the vendored typeshed stubs,
+  # relative to the root of the Ruff repository.
+  VENDORED_TYPESHED: crates/ty_vendored/vendor/typeshed
+
 jobs:
   # Sync typeshed stubs, and sync all docstrings available on Linux.
   # Push the changes to a new branch on the upstream repository.
@@ -64,20 +68,20 @@ jobs:
       - uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6.3.1
       - name: Sync typeshed stubs
         run: |
-          rm -rf ruff/crates/ty_vendored/vendor/typeshed
-          mkdir ruff/crates/ty_vendored/vendor/typeshed
-          cp typeshed/README.md ruff/crates/ty_vendored/vendor/typeshed
-          cp typeshed/LICENSE ruff/crates/ty_vendored/vendor/typeshed
+          rm -rf "ruff/${VENDORED_TYPESHED}"
+          mkdir "ruff/${VENDORED_TYPESHED}"
+          cp typeshed/README.md "ruff/${VENDORED_TYPESHED}"
+          cp typeshed/LICENSE "ruff/${VENDORED_TYPESHED}"
 
           # The pyproject.toml file is needed by a later job for the black configuration.
           # It's deleted before creating the PR.
-          cp typeshed/pyproject.toml ruff/crates/ty_vendored/vendor/typeshed
+          cp typeshed/pyproject.toml "ruff/${VENDORED_TYPESHED}"
 
-          cp -r typeshed/stdlib ruff/crates/ty_vendored/vendor/typeshed/stdlib
-          rm -rf ruff/crates/ty_vendored/vendor/typeshed/stdlib/@tests
-          git -C typeshed rev-parse HEAD > ruff/crates/ty_vendored/vendor/typeshed/source_commit.txt
+          cp -r typeshed/stdlib "ruff/${VENDORED_TYPESHED}/stdlib"
+          rm -rf "ruff/${VENDORED_TYPESHED}/stdlib/@tests"
+          git -C typeshed rev-parse HEAD > "ruff/${VENDORED_TYPESHED}/source_commit.txt"
           cd ruff
-          git checkout -b typeshedbot/sync-typeshed
+          git checkout -b "${UPSTREAM_BRANCH}"
           git add .
           git commit -m "Sync typeshed. Source commit: https://github.com/python/typeshed/commit/$(git -C ../typeshed rev-parse HEAD)" --allow-empty
       - name: Sync Linux docstrings
@@ -167,17 +171,17 @@ jobs:
           # consistent with the other typeshed stubs around them.
           # Typeshed formats code using black in their CI, so we just invoke
           # black on the stubs the same way that typeshed does.
-          uvx black crates/ty_vendored/vendor/typeshed/stdlib --config crates/ty_vendored/vendor/typeshed/pyproject.toml || true
+          uvx black "${VENDORED_TYPESHED}/stdlib" --config "${VENDORED_TYPESHED}/pyproject.toml" || true
           git commit -am "Format codemodded docstrings" --allow-empty
 
-          rm crates/ty_vendored/vendor/typeshed/pyproject.toml
+          rm "${VENDORED_TYPESHED}/pyproject.toml"
           git commit -am "Remove pyproject.toml file"
 
           git push
       - name: Create a PR
         if: ${{ success() }}
         run: |
-          gh pr list --repo "$GITHUB_REPOSITORY" --head typeshedbot/sync-typeshed --json id --jq length | grep 1 && exit 0 # exit if there is existing pr
+          gh pr list --repo "${GITHUB_REPOSITORY}" --head "${UPSTREAM_BRANCH}" --json id --jq length | grep 1 && exit 0 # exit if there is existing pr
           gh pr create --title "[ty] Sync vendored typeshed stubs" --body "Close and reopen this PR to trigger CI" --label "ty"
 
   create-issue-on-failure:

--- a/scripts/codemod_docstrings.sh
+++ b/scripts/codemod_docstrings.sh
@@ -18,7 +18,7 @@
 
 set -eu
 
-docstring_adder="git+https://github.com/astral-sh/docstring-adder.git@513b650c8c6b0f1bb6f12d8f79da9294614214e4"
+docstring_adder="git+https://github.com/astral-sh/docstring-adder.git@6e91640a011248f5d9f85ce98218e16d1c4277c4"
 stdlib_path="./crates/ty_vendored/vendor/typeshed/stdlib"
 
 for python_version in 3.14 3.13 3.12 3.11 3.10 3.9


### PR DESCRIPTION
## Summary

Bumps docstring-adder to https://github.com/astral-sh/docstring-adder/commit/6e91640a011248f5d9f85ce98218e16d1c4277c4, and uses some environment variables to reduce the number of hardcoded strings that are repeated many times across the workflow

## Test Plan

I'll kick off a typeshed-sync workflow run on this branch
