### PR TITLE
[ty] Implicit instance attributes declared `Final`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
@@ -87,6 +87,8 @@ class C:
     def __init__(self):
         self.FINAL_C: Final[int] = 1
         self.FINAL_D: Final = 1
+        self.FINAL_E: Final
+        self.FINAL_E = 1
 
 reveal_type(C.FINAL_A)  # revealed: int
 reveal_type(C.FINAL_B)  # revealed: Literal[1]
@@ -94,8 +96,8 @@ reveal_type(C.FINAL_B)  # revealed: Literal[1]
 reveal_type(C().FINAL_A)  # revealed: int
 reveal_type(C().FINAL_B)  # revealed: Literal[1]
 reveal_type(C().FINAL_C)  # revealed: int
-# TODO: this should be `Literal[1]`
-reveal_type(C().FINAL_D)  # revealed: Unknown
+reveal_type(C().FINAL_D)  # revealed: Literal[1]
+reveal_type(C().FINAL_E)  # revealed: Literal[1]
 ```
 
 ## Not modifiable
@@ -181,6 +183,8 @@ class C(metaclass=Meta):
     def __init__(self):
         self.INSTANCE_FINAL_A: Final[int] = 1
         self.INSTANCE_FINAL_B: Final = 1
+        self.INSTANCE_FINAL_C: Final[int]
+        self.INSTANCE_FINAL_C = 1
 
 # error: [invalid-assignment] "Cannot assign to final attribute `META_FINAL_A` on type `<class 'C'>`"
 C.META_FINAL_A = 2
@@ -197,10 +201,12 @@ c = C()
 c.CLASS_FINAL_A = 2
 # error: [invalid-assignment] "Cannot assign to final attribute `CLASS_FINAL_B` on type `C`"
 c.CLASS_FINAL_B = 2
-# TODO: this should be an error
+# error: [invalid-assignment] "Cannot assign to final attribute `INSTANCE_FINAL_A` on type `C`"
 c.INSTANCE_FINAL_A = 2
-# TODO: this should be an error
+# error: [invalid-assignment] "Cannot assign to final attribute `INSTANCE_FINAL_B` on type `C`"
 c.INSTANCE_FINAL_B = 2
+# error: [invalid-assignment] "Cannot assign to final attribute `INSTANCE_FINAL_C` on type `C`"
+c.INSTANCE_FINAL_C = 2
 ```
 
 ## Mutability

--- a/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
@@ -19,6 +19,10 @@ FINAL_A: Final[int] = 1
 FINAL_B: Annotated[Final[int], "the annotation for FINAL_B"] = 1
 FINAL_C: Final[Annotated[int, "the annotation for FINAL_C"]] = 1
 FINAL_D: "Final[int]" = 1
+# Note: Some type checkers do not support a separate declaration and
+# assignment for `Final` symbols, but it's possible to support this in
+# ty, and is useful for code that declares symbols `Final` inside
+# `if TYPE_CHECKING` blocks.
 FINAL_F: Final[int]
 FINAL_F = 1
 

--- a/crates/ty_python_semantic/src/semantic_index/builder.rs
+++ b/crates/ty_python_semantic/src/semantic_index/builder.rs
@@ -1421,6 +1421,7 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
                 self.visit_expr(&node.annotation);
                 if let Some(value) = &node.value {
                     self.visit_expr(value);
+                    self.add_standalone_expression(value);
                 }
 
                 if let ast::Expr::Name(name) = &*node.target {

--- a/crates/ty_python_semantic/src/semantic_index/builder.rs
+++ b/crates/ty_python_semantic/src/semantic_index/builder.rs
@@ -1421,7 +1421,13 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
                 self.visit_expr(&node.annotation);
                 if let Some(value) = &node.value {
                     self.visit_expr(value);
-                    self.add_standalone_expression(value);
+                    if self.is_method_of_class().is_some() {
+                        // Record the right-hand side of the assignment as a standalone expression
+                        // if we're inside a method. This allows type inference to infer the type
+                        // of the value for annotated assignments like `self.CONSTANT: Final = 1`,
+                        // where the type itself is not part of the annotation.
+                        self.add_standalone_expression(value);
+                    }
                 }
 
                 if let ast::Expr::Name(name) = &*node.target {

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -3980,7 +3980,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             let annotated =
                 self.infer_annotation_expression(annotation, DeferredExpressionState::None);
             if let Some(value) = value {
-                self.infer_standalone_expression(value);
+                self.infer_maybe_standalone_expression(value);
             }
 
             // If we have an annotated assignment like `self.attr: int = 1`, we still need to
@@ -4060,7 +4060,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         debug_assert!(PlaceExpr::try_from(target).is_ok());
 
         if let Some(value) = value {
-            let inferred_ty = self.infer_standalone_expression(value);
+            let inferred_ty = self.infer_maybe_standalone_expression(value);
             let inferred_ty = if target
                 .as_name_expr()
                 .is_some_and(|name| &name.id == "TYPE_CHECKING")


### PR DESCRIPTION
## Summary

Adds proper type inference for implicit instance attributes that are declared with a "bare" `Final` and adds `invalid-assignment` diagnostics for all implicit instance attributes that are declared `Final` or `Final[…]`.

## Test Plan

New and updated MD tests.

## Ecosystem analysis

```diff
pytest (https://github.com/pytest-dev/pytest)
+ error[invalid-return-type] src/_pytest/fixtures.py:1662:24: Return type does not match returned value: expected `Scope`, found `Scope | (Unknown & ~None & ~((...) -> object) & ~str) | (((str, Config, /) -> Unknown) & ~((...) -> object) & ~str) | (Unknown & ~str)
```

The definition of the `scope` attribute is [here](
https://github.com/pytest-dev/pytest/blob/5f993856350d1cff144e48810b1c0137c8ec45c5/src/_pytest/fixtures.py#L1020-L1028). Looks like this is a new false positive due to missing `TypeAlias` support that is surfaced here because we now infer a more precise type for `FixtureDef._scope`.