### PR TITLE
[ty] Add warning for unknown `TY_MEMORY_REPORT` value

### DIFF
--- a/crates/ty/src/lib.rs
+++ b/crates/ty/src/lib.rs
@@ -156,7 +156,12 @@ fn run_check(args: CheckCommand) -> anyhow::Result<ExitStatus> {
         Ok("short") => write!(stdout, "{}", db.salsa_memory_dump().display_short())?,
         Ok("mypy_primer") => write!(stdout, "{}", db.salsa_memory_dump().display_mypy_primer())?,
         Ok("full") => write!(stdout, "{}", db.salsa_memory_dump().display_full())?,
-        _ => {}
+        Ok(other) => {
+            tracing::warn!(
+                "Unknown value for `TY_MEMORY_REPORT`: `{other}`. Valid values are `short`, `mypy_primer`, and `full`."
+            );
+        }
+        Err(_) => {}
     }
 
     std::mem::forget(db);


### PR DESCRIPTION
## Summary

So that I don't have to question the env variable name next time I use `FULL` instead of `full`. 


