### PR TITLE
[ty] Make tuple subclass constructors sound

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/expression/boolean.md
+++ b/crates/ty_python_semantic/resources/mdtest/expression/boolean.md
@@ -93,14 +93,14 @@ class SingleElementTupleSubclass(tuple[int]): ...
 
 reveal_type(bool(SingleElementTupleSubclass((0,))))  # revealed: Literal[True]
 reveal_type(SingleElementTupleSubclass.__bool__)  # revealed: (self: tuple[int], /) -> Literal[True]
-reveal_type(SingleElementTupleSubclass().__bool__)  # revealed: () -> Literal[True]
+reveal_type(SingleElementTupleSubclass((1,)).__bool__)  # revealed: () -> Literal[True]
 
 # Unknown length, but we know the length is guaranteed to be >=2
 class MixedTupleSubclass(tuple[int, *tuple[str, ...], bytes]): ...
 
 reveal_type(bool(MixedTupleSubclass((1, b"foo"))))  # revealed: Literal[True]
 reveal_type(MixedTupleSubclass.__bool__)  # revealed: (self: tuple[int, *tuple[str, ...], bytes], /) -> Literal[True]
-reveal_type(MixedTupleSubclass().__bool__)  # revealed: () -> Literal[True]
+reveal_type(MixedTupleSubclass((1, b"foo")).__bool__)  # revealed: () -> Literal[True]
 
 # Unknown length with an overridden `__bool__`:
 class VariadicTupleSubclassWithDunderBoolOverride(tuple[int, ...]):

--- a/crates/ty_python_semantic/resources/mdtest/type_compendium/tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_compendium/tuple.md
@@ -19,8 +19,8 @@ def _(p: P, q: Q):
 ## Instantiating tuples
 
 Like all classes, tuples can be instantiated by invoking the `tuple` class. When instantiating a
-specialization of `tuple` we check that the values passed in match the element types
-defined in the specialization.
+specialization of `tuple` we check that the values passed in match the element types defined in the
+specialization.
 
 ```toml
 [environment]

--- a/crates/ty_python_semantic/resources/mdtest/type_compendium/tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_compendium/tuple.md
@@ -19,14 +19,20 @@ def _(p: P, q: Q):
 ## Instantiating tuples
 
 Like all classes, tuples can be instantiated by invoking the `tuple` class. When instantiating a
-specialization of `tuple` we (TODO: should) check that the values passed in match the element types
+specialization of `tuple` we check that the values passed in match the element types
 defined in the specialization.
+
+```toml
+[environment]
+python-version = "3.11"
+```
 
 ```py
 from typing_extensions import Iterable, Never
 
 reveal_type(tuple())  # revealed: tuple[()]
 reveal_type(tuple[int]((1,)))  # revealed: tuple[int]
+reveal_type(tuple[int, *tuple[str, ...]]((1,)))  # revealed: tuple[int, *tuple[str, ...]]
 reveal_type(().__class__())  # revealed: tuple[()]
 reveal_type((1, 2).__class__((1, 2)))  # revealed: tuple[Literal[1], Literal[2]]
 
@@ -54,6 +60,63 @@ reveal_type((1,).__class__())  # revealed: tuple[Literal[1]]
 
 # error: [missing-argument] "No argument provided for required parameter `iterable`"
 reveal_type((1, 2).__class__())  # revealed: tuple[Literal[1], Literal[2]]
+```
+
+## Instantiating tuple subclasses
+
+Tuple subclasses inherit the special-cased constructors from their tuple superclasses:
+
+```toml
+[environment]
+python-version = "3.11"
+```
+
+```py
+from typing_extensions import Iterable, Never
+
+class UnspecializedTupleSubclass(tuple): ...
+class EmptyTupleSubclass(tuple[()]): ...
+class SingleElementTupleSubclass(tuple[int]): ...
+class VariadicTupleSubclass(tuple[int, ...]): ...
+class MixedTupleSubclass(tuple[int, *tuple[str, ...]]): ...
+
+reveal_type(UnspecializedTupleSubclass())  # revealed: UnspecializedTupleSubclass
+reveal_type(UnspecializedTupleSubclass(()))  # revealed: UnspecializedTupleSubclass
+reveal_type(UnspecializedTupleSubclass((1, 2, "foo")))  # revealed: UnspecializedTupleSubclass
+reveal_type(UnspecializedTupleSubclass([1, 2, "foo", b"bar"]))  # revealed: UnspecializedTupleSubclass
+
+reveal_type(EmptyTupleSubclass())  # revealed: EmptyTupleSubclass
+reveal_type(EmptyTupleSubclass(()))  # revealed: EmptyTupleSubclass
+
+# error: [invalid-argument-type] "Argument is incorrect: Expected `tuple[()]`, found `tuple[Literal[1], Literal[2]]`"
+reveal_type(EmptyTupleSubclass((1, 2)))  # revealed: EmptyTupleSubclass
+
+reveal_type(SingleElementTupleSubclass((1,)))  # revealed: SingleElementTupleSubclass
+
+# error: [missing-argument] "No argument provided for required parameter `iterable`"
+reveal_type(SingleElementTupleSubclass())  # revealed: SingleElementTupleSubclass
+
+reveal_type(VariadicTupleSubclass())  # revealed: VariadicTupleSubclass
+reveal_type(VariadicTupleSubclass(()))  # revealed: VariadicTupleSubclass
+reveal_type(VariadicTupleSubclass([1, 2, 3]))  # revealed: VariadicTupleSubclass
+reveal_type(VariadicTupleSubclass((1, 2, 3, 4)))  # revealed: VariadicTupleSubclass
+
+reveal_type(MixedTupleSubclass((1,)))  # revealed: MixedTupleSubclass
+reveal_type(MixedTupleSubclass((1, "foo")))  # revealed: MixedTupleSubclass
+
+# error: [invalid-argument-type] "Argument is incorrect: Expected `tuple[int, *tuple[str, ...]]`, found `tuple[Literal[1], Literal[b"foo"]]`"
+reveal_type(MixedTupleSubclass((1, b"foo")))  # revealed: MixedTupleSubclass
+
+# error: [missing-argument] "No argument provided for required parameter `iterable`"
+reveal_type(MixedTupleSubclass())  # revealed: MixedTupleSubclass
+
+def _(empty: EmptyTupleSubclass, single_element: SingleElementTupleSubclass, mixed: MixedTupleSubclass, x: tuple[int, int]):
+    # error: [invalid-argument-type] "Argument is incorrect: Expected `tuple[()]`, found `tuple[Literal[1], Literal[2]]`"
+    empty.__class__((1, 2))
+    # error: [invalid-argument-type] "Argument is incorrect: Expected `tuple[int]`, found `tuple[Literal[1], Literal[2]]`"
+    single_element.__class__((1, 2))
+    # error: [missing-argument] "No argument provided for required parameter `iterable`"
+    mixed.__class__()
 ```
 
 ## Subtyping relationships

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -5623,10 +5623,16 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         | KnownClass::TypeVar
                         | KnownClass::NamedTuple
                         | KnownClass::TypeAliasType
-                        | KnownClass::Tuple
                         | KnownClass::Deprecated
                 )
             )
+
+            // Constructor calls to `tuple` and subclasses of `tuple` are handled in `Type::Bindings`,
+            // but constructor calls to `tuple[int]`, `tuple[int, ...]`, `tuple[int, *tuple[str, ...]]` (etc.)
+            // are handled by the default constructor-call logic (we synthesize a `__new__` method for them
+            // in `ClassType::own_class_member()`).
+            && (callable_type.is_generic_alias() || !class.is_known(self.db(), KnownClass::Tuple))
+
             // temporary special-casing for all subclasses of `enum.Enum`
             // until we support the functional syntax for creating enum classes
             && KnownClass::Enum


### PR DESCRIPTION
## Summary

https://github.com/astral-sh/ruff/pull/18987 only partly implemented the special-casing required to make tuple instantiations sound. While that PR made instantiations of `tuple` itself sound, it did not make instantiations of tuple subclasses sound, as the way in which that PR added the special casing did not mean that the synthesized constructor signatures would be automatically inherited by subclasses. This PR fixes that by moving the special casing to a lower level, inside `ClassType::own_class_member`.

## Test Plan

Mdtests added. Some existing mdtests also had to be slightly modified because they were unsoundly constructing instances of tuple subclasses.
