### PR TITLE
[ty] Use `ThinVec` for sub segments in `PlaceExpr`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4275,6 +4275,7 @@ dependencies = [
  "strum_macros",
  "tempfile",
  "test-case",
+ "thin-vec",
  "thiserror 2.0.12",
  "tracing",
  "ty_python_semantic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,6 +163,7 @@ strum_macros = { version = "0.27.0" }
 syn = { version = "2.0.55" }
 tempfile = { version = "3.9.0" }
 test-case = { version = "3.3.1" }
+thin-vec = { version = "0.2.14" }
 thiserror = { version = "2.0.0" }
 tikv-jemallocator = { version = "0.6.0" }
 toml = { version = "0.9.0" }

--- a/crates/ty_python_semantic/Cargo.toml
+++ b/crates/ty_python_semantic/Cargo.toml
@@ -35,6 +35,7 @@ indexmap = { workspace = true }
 itertools = { workspace = true }
 ordermap = { workspace = true }
 salsa = { workspace = true, features = ["compact_str"] }
+thin-vec = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 rustc-hash = { workspace = true }


### PR DESCRIPTION
## Summary

This replaces the `SmallVec` on `PlaceExpr` with a `ThinVec`. The main motivation is that many places (all symbols) have no sub segments and paying the extra cost of an empty vec (32 bytes) for each of those adds quiet a bit to overall memory usage

This reduces the `place_table` size by roughly 25%