### PR TITLE
[ty] Implement non-stdlib stub mapping for classes and functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4183,6 +4183,7 @@ version = "0.0.0"
 dependencies = [
  "bitflags 2.9.1",
  "insta",
+ "itertools 0.14.0",
  "regex",
  "ruff_db",
  "ruff_python_ast",

--- a/crates/ty_ide/Cargo.toml
+++ b/crates/ty_ide/Cargo.toml
@@ -20,6 +20,7 @@ ruff_source_file = { workspace = true }
 ruff_text_size = { workspace = true }
 ty_python_semantic = { workspace = true }
 
+itertools = { workspace = true }
 regex = { workspace = true }
 rustc-hash = { workspace = true }
 salsa = { workspace = true }

--- a/crates/ty_ide/src/goto_definition.rs
+++ b/crates/ty_ide/src/goto_definition.rs
@@ -311,6 +311,40 @@ class MyOtherClass:
         "#);
     }
 
+    #[test]
+    fn goto_definition_stub_map_many_empty_mods() {
+        // According to AlexWaygood this test should goto mymodule/MyClass.py
+        // (but it currently doesn't!)
+        let test = CursorTest::builder()
+            .source(
+                "main.py",
+                "
+from mymodule import MyC<CURSOR>lass
+",
+            )
+            .source(
+                "mymodule/__init__.py",
+                r#"
+# empty file
+"#,
+            )
+            .source(
+                "mymodule/MyClass.py",
+                r#"
+# also empty file
+"#,
+            )
+            .source(
+                "mymodule.pyi",
+                r#"
+class MyClass: ...
+"#,
+            )
+            .build();
+
+        assert_snapshot!(test.goto_definition(), @"No goto target found");
+    }
+
     impl CursorTest {
         fn goto_definition(&self) -> String {
             let Some(targets) = goto_definition(&self.db, self.cursor.file, self.cursor.offset)

--- a/crates/ty_ide/src/goto_definition.rs
+++ b/crates/ty_ide/src/goto_definition.rs
@@ -42,7 +42,9 @@ mod test {
     use ruff_text_size::Ranged;
 
     /// goto-definition on a module should go to the .py not the .pyi
-    /// FIXME: this currently doesn't work right!
+    ///
+    /// TODO: this currently doesn't work right! This is especially surprising
+    /// because [`goto_definition_stub_map_module_ref`] works fine.
     #[test]
     fn goto_definition_stub_map_module_import() {
         let test = CursorTest::builder()
@@ -180,7 +182,9 @@ def other_function(): ...
 
     /// goto-definition on a function that's redefined many times in the impl .py
     ///
-    /// FIXME(?): Currently this yields all instances, presumably it should prefer the last one?
+    /// Currently this yields all instances. There's an argument for only yielding
+    /// the final one since that's the one "exported" but, this is consistent for
+    /// how we do file-local goto-definition.
     #[test]
     fn goto_definition_stub_map_function_redefine() {
         let test = CursorTest::builder()

--- a/crates/ty_ide/src/goto_definition.rs
+++ b/crates/ty_ide/src/goto_definition.rs
@@ -499,43 +499,9 @@ class MyOtherClass:
         "#);
     }
 
-    /// According to Alex Waygood this test should goto mymodule/MyClass.py
-    /// (but it currently doesn't!)
+    /// goto-definition on a class import should go to the .py not the .pyi
     #[test]
-    fn goto_definition_stub_map_many_empty_mods() {
-        let test = CursorTest::builder()
-            .source(
-                "main.py",
-                "
-from mymodule import MyC<CURSOR>lass
-",
-            )
-            .source(
-                "mymodule/__init__.py",
-                r#"
-from . import MyClass
-"#,
-            )
-            .source(
-                "mymodule/MyClass.py",
-                r#"
-# also empty file
-"#,
-            )
-            .source(
-                "mymodule.pyi",
-                r#"
-class MyClass: ...
-"#,
-            )
-            .build();
-
-        assert_snapshot!(test.goto_definition(), @"No goto target found");
-    }
-
-    /// If the .pyi and the .py both define the class with no body, still prefer the .py
-    #[test]
-    fn goto_definition_stub_map_both_stubbed() {
+    fn goto_definition_stub_map_class_import() {
         let test = CursorTest::builder()
             .source(
                 "main.py",

--- a/crates/ty_ide/src/goto_definition.rs
+++ b/crates/ty_ide/src/goto_definition.rs
@@ -71,14 +71,13 @@ def other_function(): ...
             )
             .build();
 
-        assert_snapshot!(test.goto_definition(), @r"
+        assert_snapshot!(test.goto_definition(), @r#"
         info[goto-definition]: Definition
-         --> mymodule.pyi:2:5
+         --> mymodule.py:2:5
           |
-        2 | def my_function(): ...
+        2 | def my_function():
           |     ^^^^^^^^^^^
-        3 |
-        4 | def other_function(): ...
+        3 |     return "hello"
           |
         info: Source
          --> main.py:3:7
@@ -87,7 +86,7 @@ def other_function(): ...
         3 | print(my_function())
           |       ^^^^^^^^^^^
           |
-        ");
+        "#);
     }
 
     #[test]
@@ -126,11 +125,12 @@ class MyOtherClass:
 
         assert_snapshot!(test.goto_definition(), @r"
         info[goto-definition]: Definition
-         --> mymodule.pyi:2:7
+         --> mymodule.py:2:7
           |
         2 | class MyClass:
           |       ^^^^^^^
-        3 |     def __init__(self, val: bool): ...
+        3 |     def __init__(self, val):
+        4 |         self.val = val
           |
         info: Source
          --> main.py:3:5
@@ -178,11 +178,12 @@ class MyOtherClass:
 
         assert_snapshot!(test.goto_definition(), @r"
         info[goto-definition]: Definition
-         --> mymodule.pyi:2:7
+         --> mymodule.py:2:7
           |
         2 | class MyClass:
           |       ^^^^^^^
-        3 |     def __init__(self, val: bool): ...
+        3 |     def __init__(self, val):
+        4 |         self.val = val
           |
         info: Source
          --> main.py:3:5
@@ -234,14 +235,13 @@ class MyOtherClass:
 
         assert_snapshot!(test.goto_definition(), @r"
         info[goto-definition]: Definition
-         --> mymodule.pyi:4:9
+         --> mymodule.py:5:9
           |
-        2 | class MyClass:
-        3 |     def __init__(self, val: bool): ...
-        4 |     def action(self): ...
+        3 |     def __init__(self, val):
+        4 |         self.val = val
+        5 |     def action(self):
           |         ^^^^^^
-        5 |
-        6 | class MyOtherClass:
+        6 |         print(self.val)
           |
         info: Source
          --> main.py:4:1
@@ -291,16 +291,15 @@ class MyOtherClass:
             )
             .build();
 
-        assert_snapshot!(test.goto_definition(), @r"
+        assert_snapshot!(test.goto_definition(), @r#"
         info[goto-definition]: Definition
-         --> mymodule.pyi:4:9
+         --> mymodule.py:5:9
           |
-        2 | class MyClass:
-        3 |     def __init__(self, val: bool): ...
-        4 |     def action(): ...
+        3 |     def __init__(self, val):
+        4 |         self.val = val
+        5 |     def action():
           |         ^^^^^^
-        5 |
-        6 | class MyOtherClass:
+        6 |         print("hi!")
           |
         info: Source
          --> main.py:3:5
@@ -309,7 +308,7 @@ class MyOtherClass:
         3 | x = MyClass.action()
           |     ^^^^^^^^^^^^^^
           |
-        ");
+        "#);
     }
 
     impl CursorTest {

--- a/crates/ty_ide/src/stub_mapping.rs
+++ b/crates/ty_ide/src/stub_mapping.rs
@@ -12,7 +12,6 @@ pub(crate) struct StubMapper<'db> {
 }
 
 impl<'db> StubMapper<'db> {
-    #[allow(dead_code)] // Will be used in the future
     pub(crate) fn new(db: &'db dyn crate::Db) -> Self {
         Self { db }
     }
@@ -21,8 +20,6 @@ impl<'db> StubMapper<'db> {
     ///
     /// If the definition is in a stub file and a corresponding source file definition exists,
     /// returns the source file definition(s). Otherwise, returns the original definition.
-    #[allow(dead_code)] // Will be used when implementation is added
-    #[allow(clippy::unused_self)] // Will use self when implementation is added
     pub(crate) fn map_definition(
         &self,
         def: ResolvedDefinition<'db>,

--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -8,7 +8,7 @@ pub use db::Db;
 pub use module_name::ModuleName;
 pub use module_resolver::{
     KnownModule, Module, SearchPathValidationError, SearchPaths, resolve_module,
-    system_module_search_paths,
+    resolve_real_module, system_module_search_paths,
 };
 pub use program::{
     Program, ProgramSettings, PythonVersionFileSource, PythonVersionSource,
@@ -19,7 +19,7 @@ pub use semantic_model::{Completion, CompletionKind, HasType, NameKind, Semantic
 pub use site_packages::{PythonEnvironment, SitePackagesPaths, SysPrefixPathOrigin};
 pub use types::ide_support::{
     ResolvedDefinition, definitions_for_attribute, definitions_for_imported_symbol,
-    definitions_for_name,
+    definitions_for_name, map_stub_definition,
 };
 pub use util::diagnostics::add_inferred_python_version_hint_to_diagnostic;
 

--- a/crates/ty_python_semantic/src/module_resolver/mod.rs
+++ b/crates/ty_python_semantic/src/module_resolver/mod.rs
@@ -4,7 +4,7 @@ pub use module::{KnownModule, Module};
 pub use path::SearchPathValidationError;
 pub use resolver::SearchPaths;
 pub(crate) use resolver::file_to_module;
-pub use resolver::resolve_module;
+pub use resolver::{resolve_module, resolve_real_module};
 use ruff_db::system::SystemPath;
 
 use crate::Db;

--- a/crates/ty_python_semantic/src/module_resolver/path.rs
+++ b/crates/ty_python_semantic/src/module_resolver/path.rs
@@ -314,7 +314,11 @@ fn query_stdlib_version(
     let Some(module_name) = stdlib_path_to_module_name(relative_path) else {
         return TypeshedVersionsQueryResult::DoesNotExist;
     };
-    let ResolverContext { db, python_version } = context;
+    let ResolverContext {
+        db,
+        python_version,
+        mode: _,
+    } = context;
 
     typeshed_versions(*db).query_module(&module_name, *python_version)
 }
@@ -701,6 +705,7 @@ mod tests {
     use ruff_python_ast::PythonVersion;
 
     use crate::db::tests::TestDb;
+    use crate::module_resolver::resolver::ModuleResolveMode;
     use crate::module_resolver::testing::{FileSpec, MockedTypeshed, TestCase, TestCaseBuilder};
 
     use super::*;
@@ -965,7 +970,8 @@ mod tests {
         };
 
         let (db, stdlib_path) = py38_typeshed_test_case(TYPESHED);
-        let resolver = ResolverContext::new(&db, PythonVersion::PY38);
+        let resolver =
+            ResolverContext::new(&db, PythonVersion::PY38, ModuleResolveMode::StubsAllowed);
 
         let asyncio_regular_package = stdlib_path.join("asyncio");
         assert!(asyncio_regular_package.is_directory(&resolver));
@@ -995,7 +1001,8 @@ mod tests {
         };
 
         let (db, stdlib_path) = py38_typeshed_test_case(TYPESHED);
-        let resolver = ResolverContext::new(&db, PythonVersion::PY38);
+        let resolver =
+            ResolverContext::new(&db, PythonVersion::PY38, ModuleResolveMode::StubsAllowed);
 
         let xml_namespace_package = stdlib_path.join("xml");
         assert!(xml_namespace_package.is_directory(&resolver));
@@ -1017,7 +1024,8 @@ mod tests {
         };
 
         let (db, stdlib_path) = py38_typeshed_test_case(TYPESHED);
-        let resolver = ResolverContext::new(&db, PythonVersion::PY38);
+        let resolver =
+            ResolverContext::new(&db, PythonVersion::PY38, ModuleResolveMode::StubsAllowed);
 
         let functools_module = stdlib_path.join("functools.pyi");
         assert!(functools_module.to_file(&resolver).is_some());
@@ -1033,7 +1041,8 @@ mod tests {
         };
 
         let (db, stdlib_path) = py38_typeshed_test_case(TYPESHED);
-        let resolver = ResolverContext::new(&db, PythonVersion::PY38);
+        let resolver =
+            ResolverContext::new(&db, PythonVersion::PY38, ModuleResolveMode::StubsAllowed);
 
         let collections_regular_package = stdlib_path.join("collections");
         assert_eq!(collections_regular_package.to_file(&resolver), None);
@@ -1049,7 +1058,8 @@ mod tests {
         };
 
         let (db, stdlib_path) = py38_typeshed_test_case(TYPESHED);
-        let resolver = ResolverContext::new(&db, PythonVersion::PY38);
+        let resolver =
+            ResolverContext::new(&db, PythonVersion::PY38, ModuleResolveMode::StubsAllowed);
 
         let importlib_namespace_package = stdlib_path.join("importlib");
         assert_eq!(importlib_namespace_package.to_file(&resolver), None);
@@ -1070,7 +1080,8 @@ mod tests {
         };
 
         let (db, stdlib_path) = py38_typeshed_test_case(TYPESHED);
-        let resolver = ResolverContext::new(&db, PythonVersion::PY38);
+        let resolver =
+            ResolverContext::new(&db, PythonVersion::PY38, ModuleResolveMode::StubsAllowed);
 
         let non_existent = stdlib_path.join("doesnt_even_exist");
         assert_eq!(non_existent.to_file(&resolver), None);
@@ -1098,7 +1109,8 @@ mod tests {
         };
 
         let (db, stdlib_path) = py39_typeshed_test_case(TYPESHED);
-        let resolver = ResolverContext::new(&db, PythonVersion::PY39);
+        let resolver =
+            ResolverContext::new(&db, PythonVersion::PY39, ModuleResolveMode::StubsAllowed);
 
         // Since we've set the target version to Py39,
         // `collections` should now exist as a directory, according to VERSIONS...
@@ -1129,7 +1141,8 @@ mod tests {
         };
 
         let (db, stdlib_path) = py39_typeshed_test_case(TYPESHED);
-        let resolver = ResolverContext::new(&db, PythonVersion::PY39);
+        let resolver =
+            ResolverContext::new(&db, PythonVersion::PY39, ModuleResolveMode::StubsAllowed);
 
         // The `importlib` directory now also exists
         let importlib_namespace_package = stdlib_path.join("importlib");
@@ -1153,7 +1166,8 @@ mod tests {
         };
 
         let (db, stdlib_path) = py39_typeshed_test_case(TYPESHED);
-        let resolver = ResolverContext::new(&db, PythonVersion::PY39);
+        let resolver =
+            ResolverContext::new(&db, PythonVersion::PY39, ModuleResolveMode::StubsAllowed);
 
         // The `xml` package no longer exists on py39:
         let xml_namespace_package = stdlib_path.join("xml");

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -20,7 +20,7 @@ use ruff_python_ast::name::Name;
 use ruff_text_size::{Ranged, TextRange};
 use rustc_hash::FxHashSet;
 
-pub use resolve_definition::ResolvedDefinition;
+pub use resolve_definition::{ResolvedDefinition, map_stub_definition};
 use resolve_definition::{find_symbol_in_scope, resolve_definition};
 
 pub(crate) fn all_declarations_and_bindings<'db>(
@@ -789,15 +789,17 @@ mod resolve_definition {
     //! definition targeted by the import.
 
     use ruff_db::files::{File, FileRange};
-    use ruff_db::parsed::parsed_module;
+    use ruff_db::parsed::{ParsedModuleRef, parsed_module};
     use ruff_python_ast as ast;
-    use ruff_text_size::TextRange;
+    use ruff_text_size::{Ranged, TextRange};
     use rustc_hash::FxHashSet;
+    use tracing::trace;
 
+    use crate::module_resolver::file_to_module;
     use crate::semantic_index::definition::{Definition, DefinitionKind};
-    use crate::semantic_index::place::ScopeId;
-    use crate::semantic_index::{global_scope, place_table, use_def_map};
-    use crate::{Db, ModuleName, resolve_module};
+    use crate::semantic_index::place::{NodeWithScopeKind, ScopeId};
+    use crate::semantic_index::{global_scope, place_table, semantic_index, use_def_map};
+    use crate::{Db, ModuleName, resolve_module, resolve_real_module};
 
     /// Represents the result of resolving an import to either a specific definition or
     /// a specific range within a file.
@@ -810,6 +812,15 @@ mod resolve_definition {
         Definition(Definition<'db>),
         /// The import resolved to a file with a specific range
         FileWithRange(FileRange),
+    }
+
+    impl<'db> ResolvedDefinition<'db> {
+        fn file(&self, db: &'db dyn Db) -> File {
+            match self {
+                ResolvedDefinition::Definition(definition) => definition.file(db),
+                ResolvedDefinition::FileWithRange(file_range) => file_range.file(),
+            }
+        }
     }
 
     /// Resolve import definitions to their targets.
@@ -980,5 +991,208 @@ mod resolve_definition {
         }
 
         definitions
+    }
+
+    #[tracing::instrument(skip_all)]
+    pub fn map_stub_definition<'db>(
+        db: &'db dyn Db,
+        def: &ResolvedDefinition<'db>,
+    ) -> Option<Vec<ResolvedDefinition<'db>>> {
+        trace!("Stub mapping definition...");
+        // If the file isn't a stub, this is presumably the real definition
+        let stub_file = def.file(db);
+        if !stub_file.is_stub(db) {
+            trace!("File isn't a stub, no stub mapping to do");
+            return None;
+        }
+
+        // It's definitely a stub, so now rerun module resolution but with stubs disabled.
+        let stub_module = file_to_module(db, stub_file)?;
+        trace!("Found stub module: {}", stub_module.name());
+        let real_module = resolve_real_module(db, stub_module.name())?;
+        trace!("Found real module: {}", real_module.name());
+        let real_file = real_module.file()?;
+        trace!("Found real file: {}", real_file.path(db));
+
+        // A definition has a "Definition Path" in a file made of nested definitions (~scopes):
+        //
+        // ```
+        // class myclass:  # ./myclass
+        //     def some_func(args: bool):  # ./myclass/some_func
+        //                 # ^~~~ ./myclass/other_func/args/
+        // ```
+        //
+        // So our heuristic goal here is to compute a Definition Path in the stub file
+        // and then resolve the same Definition Path in the real file.
+        let mut path = Vec::new();
+        let stub_parsed;
+        let stub_ref;
+        match *def {
+            ResolvedDefinition::Definition(definition) => {
+                stub_parsed = parsed_module(db, stub_file);
+                stub_ref = stub_parsed.load(db);
+
+                // Get the leaf of the path (the definition itself)
+                let leaf = definition_path_component_for_leaf(db, &stub_ref, definition)
+                    .map_err(|()| {
+                        trace!("Found unsupported DefinitionKind while stub mapping, giving up");
+                    })
+                    .ok()?;
+                path.push(leaf);
+
+                // Get the ancestors of the path (all the definitions we're nested under)
+                let index = semantic_index(db, stub_file);
+                for (_scope_id, scope) in index.ancestor_scopes(definition.file_scope(db)) {
+                    let node = scope.node();
+                    let component = definition_path_component_for_node(&stub_ref, node)
+                        .map_err(|()| {
+                            trace!("Found unsupported NodeScopeKind while stub mapping, giving up");
+                        })
+                        .ok()?;
+                    if let Some(component) = component {
+                        path.push(component);
+                    }
+                }
+                trace!("Built Definition Path: {path:?}");
+            }
+            ResolvedDefinition::FileWithRange(file_range) => {
+                return if file_range.range() == TextRange::default() {
+                    trace!(
+                        "Found module mapping: {} => {}",
+                        stub_file.path(db),
+                        real_file.path(db)
+                    );
+                    // This is just a reference to a module, no need to do paths
+                    Some(vec![ResolvedDefinition::FileWithRange(FileRange::new(
+                        real_file,
+                        TextRange::default(),
+                    ))])
+                } else {
+                    // Not yet implemented -- in this case we want to recover something like a Definition
+                    // and build a Definition Path, but this input is a bit too abstract for now.
+                    trace!("Found arbitrary FileWithRange by stub mapping, giving up");
+                    None
+                };
+            }
+        }
+
+        // Walk down the Definition Path in the real file
+        let mut definitions = Vec::new();
+        let index = semantic_index(db, real_file);
+        let real_parsed = parsed_module(db, real_file);
+        let real_ref = real_parsed.load(db);
+        // Start our search in the module (global) scope
+        let mut scopes = vec![global_scope(db, real_file)];
+        while let Some(component) = path.pop() {
+            trace!("Traversing definition path component: {}", component);
+            // We're doing essentially a breadth-first traversal of the definitions.
+            // If ever find_symbol_in_scope yields multiple results, we need to continue
+            // walking down each of them to try to resolve the path. Here we loop over
+            // all the scopes at the current level of search.
+            for scope in std::mem::take(&mut scopes) {
+                if path.is_empty() {
+                    // We're at the end of the path, everything we find here is the final result
+                    definitions.extend(find_symbol_in_scope(db, scope, component));
+                } else {
+                    // We're in the middle of the path, look for scopes that match the current component
+                    for (child_scope_id, child_scope) in index.child_scopes(scope.file_scope_id(db))
+                    {
+                        let scope_node = child_scope.node();
+                        if let Ok(Some(real_component)) =
+                            definition_path_component_for_node(&real_ref, scope_node)
+                        {
+                            if real_component == component {
+                                scopes.push(child_scope_id.to_scope_id(db, real_file));
+                            }
+                        }
+                        scope.node(db);
+                    }
+                }
+            }
+            trace!(
+                "Found {} scopes and {} definitions",
+                scopes.len(),
+                definitions.len()
+            );
+        }
+        if definitions.is_empty() {
+            trace!("No definitions found in real file, stub mapping failed");
+            None
+        } else {
+            trace!("Found {} definitions from stub mapping", definitions.len());
+            Some(
+                definitions
+                    .into_iter()
+                    .map(ResolvedDefinition::Definition)
+                    .collect::<Vec<_>>(),
+            )
+        }
+    }
+
+    /// Computes a "Definition Path" component for an internal node of the definition path.
+    ///
+    /// See [`map_stub_definition`][] for details.
+    fn definition_path_component_for_node<'parse>(
+        parsed: &'parse ParsedModuleRef,
+        node: &NodeWithScopeKind,
+    ) -> Result<Option<&'parse str>, ()> {
+        let component = match node {
+            NodeWithScopeKind::Module => {
+                // This is just implicit, so has no component
+                return Ok(None);
+            }
+            NodeWithScopeKind::Class(class) => class.node(parsed).name.as_str(),
+            NodeWithScopeKind::Function(func) => func.node(parsed).name.as_str(),
+            NodeWithScopeKind::TypeAlias(_)
+            | NodeWithScopeKind::ClassTypeParameters(_)
+            | NodeWithScopeKind::FunctionTypeParameters(_)
+            | NodeWithScopeKind::TypeAliasTypeParameters(_)
+            | NodeWithScopeKind::Lambda(_)
+            | NodeWithScopeKind::ListComprehension(_)
+            | NodeWithScopeKind::SetComprehension(_)
+            | NodeWithScopeKind::DictComprehension(_)
+            | NodeWithScopeKind::GeneratorExpression(_) => {
+                return Err(());
+            }
+        };
+        Ok(Some(component))
+    }
+
+    /// Computes a "Definition Path" component for a leaf node of the definition path.
+    ///
+    /// See [`map_stub_definition`][] for details.
+    fn definition_path_component_for_leaf<'parse>(
+        db: &dyn Db,
+        parsed: &'parse ParsedModuleRef,
+        definition: Definition,
+    ) -> Result<&'parse str, ()> {
+        let component = match definition.kind(db) {
+            DefinitionKind::Function(func) => func.node(parsed).name.as_str(),
+            DefinitionKind::Class(class) => class.node(parsed).name.as_str(),
+            DefinitionKind::TypeAlias(_)
+            | DefinitionKind::Import(_)
+            | DefinitionKind::ImportFrom(_)
+            | DefinitionKind::StarImport(_)
+            | DefinitionKind::NamedExpression(_)
+            | DefinitionKind::Assignment(_)
+            | DefinitionKind::AnnotatedAssignment(_)
+            | DefinitionKind::AugmentedAssignment(_)
+            | DefinitionKind::For(_)
+            | DefinitionKind::Comprehension(_)
+            | DefinitionKind::VariadicPositionalParameter(_)
+            | DefinitionKind::VariadicKeywordParameter(_)
+            | DefinitionKind::Parameter(_)
+            | DefinitionKind::WithItem(_)
+            | DefinitionKind::MatchPattern(_)
+            | DefinitionKind::ExceptHandler(_)
+            | DefinitionKind::TypeVar(_)
+            | DefinitionKind::ParamSpec(_)
+            | DefinitionKind::TypeVarTuple(_) => {
+                // Not yet implemented
+                return Err(());
+            }
+        };
+
+        Ok(component)
     }
 }

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -993,6 +993,7 @@ mod resolve_definition {
         definitions
     }
 
+    /// Given a definition that may be in a stub file, find the "real" definition in a non-stub.
     #[tracing::instrument(skip_all)]
     pub fn map_stub_definition<'db>(
         db: &'db dyn Db,
@@ -1024,6 +1025,9 @@ mod resolve_definition {
         //
         // So our heuristic goal here is to compute a Definition Path in the stub file
         // and then resolve the same Definition Path in the real file.
+        //
+        // NOTE: currently a path component is just a str, but in the future additional
+        // disambiguators (like "is a class def") could be added if needed.
         let mut path = Vec::new();
         let stub_parsed;
         let stub_ref;
@@ -1086,7 +1090,7 @@ mod resolve_definition {
         while let Some(component) = path.pop() {
             trace!("Traversing definition path component: {}", component);
             // We're doing essentially a breadth-first traversal of the definitions.
-            // If ever find_symbol_in_scope yields multiple results, we need to continue
+            // If ever we find multiple matching scopes for a component, we need to continue
             // walking down each of them to try to resolve the path. Here we loop over
             // all the scopes at the current level of search.
             for scope in std::mem::take(&mut scopes) {
@@ -1152,6 +1156,7 @@ mod resolve_definition {
             | NodeWithScopeKind::SetComprehension(_)
             | NodeWithScopeKind::DictComprehension(_)
             | NodeWithScopeKind::GeneratorExpression(_) => {
+                // Not yet implemented
                 return Err(());
             }
         };

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -788,6 +788,7 @@ mod resolve_definition {
     //! "resolved definitions". This is done recursively to find the original
     //! definition targeted by the import.
 
+    use indexmap::IndexSet;
     use ruff_db::files::{File, FileRange};
     use ruff_db::parsed::{ParsedModuleRef, parsed_module};
     use ruff_python_ast as ast;
@@ -1081,7 +1082,8 @@ mod resolve_definition {
         }
 
         // Walk down the Definition Path in the real file
-        let mut definitions = Vec::new();
+        // we use an IndexSet to try to preserve order but remove duplicates.
+        let mut definitions = IndexSet::new();
         let index = semantic_index(db, real_file);
         let real_parsed = parsed_module(db, real_file);
         let real_ref = real_parsed.load(db);


### PR DESCRIPTION
This implements mapping of definitions in stubs to definitions in the "real" implementation using the approach described in https://github.com/astral-sh/ty/issues/788#issuecomment-3097000287

I've tested this with goto-definition in vscode with code that uses `colorama` and `types-colorama` (will put up a screen recording and hopefully tests after lunch).

Notably this implementation does not add support for stub-mapping stdlib modules, which can be done as an essentially orthogonal followup in the implementation of `resolve_real_module`.

Partially fixes https://github.com/astral-sh/ty/issues/788