### PR TITLE
[ty] Extend `Final` test suite

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
@@ -311,7 +311,7 @@ Using `Final` in a loop is not allowed.
 ```py
 from typing import Final
 
-for i in range(10):
+for _ in range(10):
     # TODO: This should be an error
     i: Final[int] = 1
 ```


### PR DESCRIPTION
## Summary

Restructures and cleans up the `typing.Final` test suite. Also adds a few more tests with TODOs based on the [typing spec for `typing.Final`](https://typing.python.org/en/latest/spec/qualifiers.html#uppercase-final).


