### PR TITLE
[ty] Detect illegal non-enum attribute accesses in Literal annotation

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/literal.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/literal.md
@@ -25,6 +25,9 @@ class Color(Enum):
 
 b1: Literal[Color.RED]
 
+MissingT = Enum("MissingT", {"MISSING": "MISSING"})
+b2: Literal[MissingT.MISSING]
+
 def f():
     reveal_type(mode)  # revealed: Literal["w", "r"]
     reveal_type(a1)  # revealed: Literal[26]
@@ -51,6 +54,12 @@ invalid4: Literal[
     hello,  # error: [invalid-type-form]
     (1, 2, 3),  # error: [invalid-type-form]
 ]
+
+class NotAnEnum:
+    x: int = 1
+
+# error: [invalid-type-form]
+invalid5: Literal[NotAnEnum.x]
 ```
 
 ## Shortening unions of literals

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -240,3 +240,10 @@ pub(crate) fn enum_member_literals<'a, 'db: 'a>(
 pub(crate) fn is_single_member_enum<'db>(db: &'db dyn Db, class: ClassLiteral<'db>) -> bool {
     enum_metadata(db, class).is_some_and(|metadata| metadata.members.len() == 1)
 }
+
+pub(crate) fn is_enum_class<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
+    match ty {
+        Type::ClassLiteral(class_literal) => enum_metadata(db, class_literal).is_some(),
+        _ => false,
+    }
+}


### PR DESCRIPTION
## Summary

Detect illegal attribute accesses in `Literal[X.Y]` annotations if `X` is not an enum class.

## Test Plan

New Markdown test