### PR TITLE
Run MD tests for Markdown-only changes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -143,6 +143,9 @@ jobs:
         env:
           MERGE_BASE: ${{ steps.merge_base.outputs.sha }}
         run: |
+          # NOTE: Do not exclude all Markdown files here, but rather use
+          # specific exclude patterns like 'docs/**'), because tests for
+          # 'ty' are written in Markdown.
           if git diff --quiet "${MERGE_BASE}...HEAD" -- \
             ':!docs/**' \
             ':!assets/**' \


### PR DESCRIPTION
## Summary

Exclusions in Git pathspecs [are not order-sensitive](https://css-tricks.com/git-pathspecs-and-how-to-use-them/#aa-exclude):

> After all other pathspecs have been resolved, all pathspecs with an exclude signature are resolved and then removed from the returned paths.

This means that we can't write chains like we had here before to exclude Markdown file changes *unless* they are in `crates/ty_python_semantic/resources/mdtest`. This doesn't work. The exclude pattern will just overwrite the second pattern and all Markdown changes will be excluded:

```bash
':!**/*.md' \
':crates/ty_python_semantic/resources/mdtest/**/*.md' \
```

The configuration we had here before meant that tests wouldn't run on MD-test only PRs, see e.g. https://github.com/astral-sh/ruff/pull/19476.

So here, I'm proposing to remove the broad `:!**/*.md` pattern. We can always add more fine-grained exclusion patterns, if that's needed. The `docs` folder is already excluded.

## Test Plan

Tested with local `git diff` invocations.