### PR TITLE
[ty] Disallow `Final` in function parameter/return-type annotations

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
@@ -275,7 +275,7 @@ class C:
         self.LEGAL_I: Final[int]
         self.LEGAL_I = 1
 
-# TODO: This should be an error
+# error: [invalid-type-form] "`Final` is not allowed in function parameter annotations"
 def f(ILLEGAL: Final[int]) -> None:
     pass
 

--- a/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
@@ -255,6 +255,11 @@ class Derived(Base):
 Final may only be used in assignments or variable annotations. Using it in any other position is an
 error.
 
+```toml
+[environment]
+python-version = "3.12"
+```
+
 ```py
 from typing import Final, ClassVar, Annotated
 
@@ -279,8 +284,16 @@ class C:
 def f(ILLEGAL: Final[int]) -> None:
     pass
 
-# TODO: This should be an error
+# error: [invalid-type-form] "`Final` is not allowed in function parameter annotations"
+def f[T](ILLEGAL: Final[int]) -> None:
+    pass
+
+# error: [invalid-type-form] "`Final` is not allowed in function return type annotations"
 def f() -> Final[None]: ...
+
+# error: [invalid-type-form] "`Final` is not allowed in function return type annotations"
+def f[T](x: T) -> Final[T]:
+    return x
 
 # TODO: This should be an error
 class Foo(Final[tuple[int]]): ...

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -2668,10 +2668,16 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             default: _,
         } = parameter_with_default;
 
-        self.infer_optional_annotation_expression(
+        let annotated = self.infer_optional_annotation_expression(
             parameter.annotation.as_deref(),
             DeferredExpressionState::None,
         );
+
+        if annotated.is_some_and(|annotated| annotated.qualifiers.contains(TypeQualifiers::FINAL)) {
+            if let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, parameter) {
+                builder.into_diagnostic("`Final` is not allowed in function parameter annotations");
+            }
+        }
     }
 
     fn infer_parameter(&mut self, parameter: &ast::Parameter) {


### PR DESCRIPTION
## Summary

Disallow `Final` in function parameter- and return-type annotations.

[Typing spec](https://typing.python.org/en/latest/spec/qualifiers.html#uppercase-final):

> `Final` may only be used in assignments or variable annotations. Using it in any other position is an error. In particular, `Final` can’t be used in annotations for function arguments

## Test Plan

Updated MD test
