### PR TITLE
Fix panic for illegal `Literal[…]` annotations with inner subscript expressions

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/literal.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/literal.md
@@ -60,6 +60,10 @@ class NotAnEnum:
 
 # error: [invalid-type-form]
 invalid5: Literal[NotAnEnum.x]
+
+a_list: list[int] = [1, 2, 3]
+# error: [invalid-type-form]
+invalid6: Literal[a_list[0]]
 ```
 
 ## Shortening unions of literals

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -10438,6 +10438,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     self.store_expression_type(parameters, ty);
                     ty
                 } else {
+                    self.infer_expression(slice);
                     self.store_expression_type(parameters, Type::unknown());
 
                     return Err(vec![parameters]);


### PR DESCRIPTION
## Summary

Fixes pull-types panics for illegal annotations like `Literal[object[index]]`.

Originally reported by @AlexWaygood

## Test Plan

* Verified that this caused panics in the playground, when typing (and potentially hovering over) `x: Literal[obj[0]]`.
* Added a regression test