### PR TITLE
[ty] Synthesize precise `__getitem__` overloads for tuple subclasses

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/subscript/tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/subscript/tuple.md
@@ -73,6 +73,28 @@ def g(m: MixedSubclass, i: int):
     # but achieving that with only synthesized overloads wouldn't be possible
     reveal_type(m[-6])  # revealed: Exception | str | int | bytes | range
     reveal_type(m[-10])  # revealed: Exception | str | int | bytes | range
+
+class MixedSubclass2(tuple[int, str, *tuple[bytes, ...], range]): ...
+
+# revealed: Overload[(self, index: Literal[-2], /) -> bytes | str, (self, index: Literal[1], /) -> str, (self, index: Literal[2], /) -> bytes | range, (self, index: Literal[-1], /) -> range, (self, index: Literal[0], /) -> int, (self, index: Literal[-3], /) -> bytes | str | int, (self, index: SupportsIndex, /) -> int | str | bytes | range, (self, index: slice[Any, Any, Any], /) -> tuple[int | str | bytes | range, ...]]
+reveal_type(MixedSubclass2.__getitem__)
+
+def g(m: MixedSubclass2, i: int):
+    reveal_type(m[0])  # revealed: int
+    reveal_type(m[1])  # revealed: str
+    reveal_type(m[2])  # revealed: bytes | range
+
+    # Ideally this would just be `bytes | range`,
+    # but that's not possible to achieve with synthesized overloads
+    reveal_type(m[3])  # revealed: int | str | bytes | range
+
+    reveal_type(m[-1])  # revealed: range
+    reveal_type(m[-2])  # revealed: bytes | str
+    reveal_type(m[-3])  # revealed: bytes | str | int
+
+    # Ideally this would just be `int | str | bytes`,
+    # but that's not possible to achieve with synthesized overloads
+    reveal_type(m[-4])  # revealed: int | str | bytes | range
 ```
 
 ## Slices

--- a/crates/ty_python_semantic/resources/mdtest/subscript/tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/subscript/tuple.md
@@ -28,73 +28,102 @@ reveal_type(b)  # revealed: Unknown
 Precise types for index operations are also inferred for tuple subclasses:
 
 ```py
-class HeterogeneousSubclass(tuple[int, str, int, bytes]): ...
+class I0: ...
+class I1: ...
+class I2: ...
+class I3: ...
+class I5: ...
+class HeterogeneousSubclass0(tuple[()]): ...
 
-# revealed: Overload[(self, index: Literal[-1, 3], /) -> bytes, (self, index: Literal[-4, -2, 0, 2], /) -> int, (self, index: Literal[-3, 1], /) -> str, (self, index: SupportsIndex, /) -> int | str | bytes, (self, index: slice[Any, Any, Any], /) -> tuple[int | str | bytes, ...]]
-reveal_type(HeterogeneousSubclass.__getitem__)
+# revealed: Overload[(self, index: SupportsIndex, /) -> Never, (self, index: slice[Any, Any, Any], /) -> tuple[()]]
+reveal_type(HeterogeneousSubclass0.__getitem__)
 
-def f(h: HeterogeneousSubclass, i: int):
-    reveal_type(h[0])  # revealed: int
-    reveal_type(h[1])  # revealed: str
-    reveal_type(h[2])  # revealed: int
-    reveal_type(h[3])  # revealed: bytes
-    reveal_type(h[-1])  # revealed: bytes
-    reveal_type(h[-2])  # revealed: int
-    reveal_type(h[-3])  # revealed: str
-    reveal_type(h[-4])  # revealed: int
-    reveal_type(h[i])  # revealed: int | str | bytes
+def f0(h0: HeterogeneousSubclass0, i: int):
+    reveal_type(h0[0])  # revealed: Never
+    reveal_type(h0[1])  # revealed: Never
+    reveal_type(h0[-1])  # revealed: Never
+    reveal_type(h0[i])  # revealed: Never
 
-class MixedSubclass(tuple[Exception, *tuple[str, ...], int, bytes, int, range]): ...
+class HeterogeneousSubclass1(tuple[I0]): ...
 
-# revealed: Overload[(self, index: Literal[-3], /) -> bytes, (self, index: Literal[4], /) -> str | int | bytes | range, (self, index: Literal[2, 3], /) -> str | int | bytes, (self, index: Literal[-1], /) -> range, (self, index: Literal[1], /) -> str | int, (self, index: Literal[-5], /) -> str | Exception, (self, index: Literal[-4, -2], /) -> int, (self, index: Literal[0], /) -> Exception, (self, index: SupportsIndex, /) -> Exception | str | int | bytes | range, (self, index: slice[Any, Any, Any], /) -> tuple[Exception | str | int | bytes | range, ...]]
+# revealed: Overload[(self, index: SupportsIndex, /) -> I0, (self, index: slice[Any, Any, Any], /) -> tuple[I0, ...]]
+reveal_type(HeterogeneousSubclass1.__getitem__)
+
+def f0(h1: HeterogeneousSubclass1, i: int):
+    reveal_type(h1[0])  # revealed: I0
+    reveal_type(h1[1])  # revealed: I0
+    reveal_type(h1[-1])  # revealed: I0
+    reveal_type(h1[i])  # revealed: I0
+
+# Element at index 2 is deliberately the same as the element at index 1,
+# to illustrate that the `__getitem__` overloads for these two indices are combined
+class HeterogeneousSubclass4(tuple[I0, I1, I0, I3]): ...
+
+# revealed: Overload[(self, index: Literal[-4, -2, 0, 2], /) -> I0, (self, index: Literal[-3, 1], /) -> I1, (self, index: Literal[-1, 3], /) -> I3, (self, index: SupportsIndex, /) -> I0 | I1 | I3, (self, index: slice[Any, Any, Any], /) -> tuple[I0 | I1 | I3, ...]]
+reveal_type(HeterogeneousSubclass4.__getitem__)
+
+def f(h4: HeterogeneousSubclass4, i: int):
+    reveal_type(h4[0])  # revealed: I0
+    reveal_type(h4[1])  # revealed: I1
+    reveal_type(h4[2])  # revealed: I0
+    reveal_type(h4[3])  # revealed: I3
+    reveal_type(h4[-1])  # revealed: I3
+    reveal_type(h4[-2])  # revealed: I0
+    reveal_type(h4[-3])  # revealed: I1
+    reveal_type(h4[-4])  # revealed: I0
+    reveal_type(h4[i])  # revealed: I0 | I1 | I3
+
+class MixedSubclass(tuple[I0, *tuple[I1, ...], I2, I3, I2, I5]): ...
+
+# revealed: Overload[(self, index: Literal[0], /) -> I0, (self, index: Literal[2, 3], /) -> I1 | I2 | I3, (self, index: Literal[-1], /) -> I5, (self, index: Literal[1], /) -> I1 | I2, (self, index: Literal[-3], /) -> I3, (self, index: Literal[-5], /) -> I1 | I0, (self, index: Literal[-4, -2], /) -> I2, (self, index: Literal[4], /) -> I1 | I2 | I3 | I5, (self, index: SupportsIndex, /) -> I0 | I1 | I2 | I3 | I5, (self, index: slice[Any, Any, Any], /) -> tuple[I0 | I1 | I2 | I3 | I5, ...]]
 reveal_type(MixedSubclass.__getitem__)
 
 def g(m: MixedSubclass, i: int):
-    reveal_type(m[0])  # revealed: Exception
-    reveal_type(m[1])  # revealed: str | int
-    reveal_type(m[2])  # revealed: str | int | bytes
-    reveal_type(m[3])  # revealed: str | int | bytes
-    reveal_type(m[4])  # revealed: str | int | bytes | range
+    reveal_type(m[0])  # revealed: I0
+    reveal_type(m[1])  # revealed: I1 | I2
+    reveal_type(m[2])  # revealed: I1 | I2 | I3
+    reveal_type(m[3])  # revealed: I1 | I2 | I3
+    reveal_type(m[4])  # revealed: I1 | I2 | I3 | I5
 
-    reveal_type(m[-1])  # revealed: range
-    reveal_type(m[-2])  # revealed: int
-    reveal_type(m[-3])  # revealed: bytes
-    reveal_type(m[-4])  # revealed: int
-    reveal_type(m[-5])  # revealed: str | Exception
+    reveal_type(m[-1])  # revealed: I5
+    reveal_type(m[-2])  # revealed: I2
+    reveal_type(m[-3])  # revealed: I3
+    reveal_type(m[-4])  # revealed: I2
+    reveal_type(m[-5])  # revealed: I1 | I0
 
-    reveal_type(m[i])  # revealed: Exception | str | int | bytes | range
+    reveal_type(m[i])  # revealed: I0 | I1 | I2 | I3 | I5
 
-    # Ideally we would not include `Exception` in the unions for these,
+    # Ideally we would not include `I0` in the unions for these,
     # but it's not possible to do this using only synthesized overloads.
-    reveal_type(m[5])  # revealed: Exception | str | int | bytes | range
-    reveal_type(m[10])  # revealed: Exception | str | int | bytes | range
+    reveal_type(m[5])  # revealed: I0 | I1 | I2 | I3 | I5
+    reveal_type(m[10])  # revealed: I0 | I1 | I2 | I3 | I5
 
-    # Similarly, ideally these would just be `str` | Exception`,
+    # Similarly, ideally these would just be `I0` | I1`,
     # but achieving that with only synthesized overloads wouldn't be possible
-    reveal_type(m[-6])  # revealed: Exception | str | int | bytes | range
-    reveal_type(m[-10])  # revealed: Exception | str | int | bytes | range
+    reveal_type(m[-6])  # revealed: I0 | I1 | I2 | I3 | I5
+    reveal_type(m[-10])  # revealed: I0 | I1 | I2 | I3 | I5
 
-class MixedSubclass2(tuple[int, str, *tuple[bytes, ...], range]): ...
+class MixedSubclass2(tuple[I0, I1, *tuple[I2, ...], I3]): ...
 
-# revealed: Overload[(self, index: Literal[-2], /) -> bytes | str, (self, index: Literal[1], /) -> str, (self, index: Literal[2], /) -> bytes | range, (self, index: Literal[-1], /) -> range, (self, index: Literal[0], /) -> int, (self, index: Literal[-3], /) -> bytes | str | int, (self, index: SupportsIndex, /) -> int | str | bytes | range, (self, index: slice[Any, Any, Any], /) -> tuple[int | str | bytes | range, ...]]
+# revealed: Overload[(self, index: Literal[-1], /) -> I3, (self, index: Literal[0], /) -> I0, (self, index: Literal[-2], /) -> I2 | I1, (self, index: Literal[2], /) -> I2 | I3, (self, index: Literal[1], /) -> I1, (self, index: Literal[-3], /) -> I2 | I1 | I0, (self, index: SupportsIndex, /) -> I0 | I1 | I2 | I3, (self, index: slice[Any, Any, Any], /) -> tuple[I0 | I1 | I2 | I3, ...]]
 reveal_type(MixedSubclass2.__getitem__)
 
 def g(m: MixedSubclass2, i: int):
-    reveal_type(m[0])  # revealed: int
-    reveal_type(m[1])  # revealed: str
-    reveal_type(m[2])  # revealed: bytes | range
+    reveal_type(m[0])  # revealed: I0
+    reveal_type(m[1])  # revealed: I1
+    reveal_type(m[2])  # revealed: I2 | I3
 
-    # Ideally this would just be `bytes | range`,
+    # Ideally this would just be `I2 | I3`,
     # but that's not possible to achieve with synthesized overloads
-    reveal_type(m[3])  # revealed: int | str | bytes | range
+    reveal_type(m[3])  # revealed: I0 | I1 | I2 | I3
 
-    reveal_type(m[-1])  # revealed: range
-    reveal_type(m[-2])  # revealed: bytes | str
-    reveal_type(m[-3])  # revealed: bytes | str | int
+    reveal_type(m[-1])  # revealed: I3
+    reveal_type(m[-2])  # revealed: I2 | I1
+    reveal_type(m[-3])  # revealed: I2 | I1 | I0
 
-    # Ideally this would just be `int | str | bytes`,
+    # Ideally this would just be `I2 | I1 | I0`,
     # but that's not possible to achieve with synthesized overloads
-    reveal_type(m[-4])  # revealed: int | str | bytes | range
+    reveal_type(m[-4])  # revealed: I0 | I1 | I2 | I3
 ```
 
 The stdlib API `os.stat` is a commonly used API that returns an instance of a tuple subclass
@@ -104,10 +133,38 @@ The stdlib API `os.stat` is a commonly used API that returns an instance of a tu
 import os
 import stat
 
+reveal_type(os.stat("my_file.txt"))  # revealed: stat_result
 reveal_type(os.stat("my_file.txt")[stat.ST_MODE])  # revealed: int
 reveal_type(os.stat("my_file.txt")[stat.ST_ATIME])  # revealed: int | float
+
+# revealed: tuple[<class 'stat_result'>, <class 'structseq[int | float]'>, <class 'tuple[int, int, int, int, int, int, int, int | float, int | float, int | float]'>, <class 'Sequence[int | float]'>, <class 'Reversible[int | float]'>, <class 'Collection[int | float]'>, <class 'Iterable[int | float]'>, <class 'Container[int | float]'>, typing.Protocol, typing.Generic, <class 'object'>]
+reveal_type(os.stat_result.__mro__)
+
+# There are no specific overloads for the `float` elements in `os.stat_result`,
+# because the fallback `(self, index: SupportsIndex, /) -> int | float` overload
+# gives the right result for those elements in the tuple, and we aim to synthesize
+# the minimum number of overloads for any given tuple
+#
 # revealed: Overload[(self, index: Literal[-10, -9, -8, -7, -6, -5, -4, 0, 1, 2, 3, 4, 5, 6], /) -> int, (self, index: SupportsIndex, /) -> int | float, (self, index: slice[Any, Any, Any], /) -> tuple[int | float, ...]]
 reveal_type(os.stat_result.__getitem__)
+```
+
+Because of the synthesized `__getitem__` overloads we synthesize for tuples and tuple subclasses,
+tuples are naturally understood as being subtypes of protocols that have precise return types from
+`__getitem__` method members:
+
+```py
+from typing import Protocol, Literal
+from ty_extensions import static_assert, is_subtype_of
+
+class IntFromZeroSubscript(Protocol):
+    def __getitem__(self, index: Literal[0], /) -> int: ...
+
+static_assert(is_subtype_of(tuple[int, str], IntFromZeroSubscript))
+
+class TupleSubclass(tuple[int, str]): ...
+
+static_assert(is_subtype_of(TupleSubclass, IntFromZeroSubscript))
 ```
 
 ## Slices

--- a/crates/ty_python_semantic/resources/mdtest/subscript/tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/subscript/tuple.md
@@ -46,7 +46,7 @@ def f(h: HeterogeneousSubclass, i: int):
 
 class MixedSubclass(tuple[Exception, *tuple[str, ...], int, bytes, int, range]): ...
 
-# revealed: Overload[(self, index: Literal[-3], /) -> bytes, (self, index: Literal[-5], /) -> str | Exception, (self, index: Literal[4], /) -> str | int | bytes | range, (self, index: Literal[2, 3], /) -> str | int | bytes, (self, index: Literal[-1], /) -> range, (self, index: Literal[1], /) -> str | int, (self, index: Literal[-4, -2], /) -> int, (self, index: Literal[0], /) -> Exception, (self, index: SupportsIndex, /) -> Exception | str | int | bytes | range, (self, index: slice[Any, Any, Any], /) -> tuple[Exception | str | int | bytes | range, ...]]
+# revealed: Overload[(self, index: Literal[-3], /) -> bytes, (self, index: Literal[4], /) -> str | int | bytes | range, (self, index: Literal[2, 3], /) -> str | int | bytes, (self, index: Literal[-1], /) -> range, (self, index: Literal[1], /) -> str | int, (self, index: Literal[-5], /) -> str | Exception, (self, index: Literal[-4, -2], /) -> int, (self, index: Literal[0], /) -> Exception, (self, index: SupportsIndex, /) -> Exception | str | int | bytes | range, (self, index: slice[Any, Any, Any], /) -> tuple[Exception | str | int | bytes | range, ...]]
 reveal_type(MixedSubclass.__getitem__)
 
 def g(m: MixedSubclass, i: int):

--- a/crates/ty_python_semantic/resources/mdtest/subscript/tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/subscript/tuple.md
@@ -97,6 +97,18 @@ def g(m: MixedSubclass2, i: int):
     reveal_type(m[-4])  # revealed: int | str | bytes | range
 ```
 
+The stdlib API `os.stat` is a commonly used API that returns an instance of a tuple subclass
+(`os.stat_result`), and therefore provides a good integration test for tuple subclasses.
+
+```py
+import os
+import stat
+
+reveal_type(os.stat("my_file.txt")[stat.ST_MODE])  # revealed: int
+# revealed: Overload[(self, index: Literal[-10, -9, -8, -7, -6, -5, -4, 0, 1, 2, 3, 4, 5, 6], /) -> int, (self, index: SupportsIndex, /) -> int | float, (self, index: slice[Any, Any, Any], /) -> tuple[int | float, ...]]
+reveal_type(os.stat_result.__getitem__)
+```
+
 ## Slices
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/subscript/tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/subscript/tuple.md
@@ -4,7 +4,7 @@
 
 ```toml
 [environment]
-python-version = "3.12"
+python-version = "3.11"
 ```
 
 ```py
@@ -105,6 +105,7 @@ import os
 import stat
 
 reveal_type(os.stat("my_file.txt")[stat.ST_MODE])  # revealed: int
+reveal_type(os.stat("my_file.txt")[stat.ST_ATIME])  # revealed: int | float
 # revealed: Overload[(self, index: Literal[-10, -9, -8, -7, -6, -5, -4, 0, 1, 2, 3, 4, 5, 6], /) -> int, (self, index: SupportsIndex, /) -> int | float, (self, index: slice[Any, Any, Any], /) -> tuple[int | float, ...]]
 reveal_type(os.stat_result.__getitem__)
 ```

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -651,54 +651,23 @@ impl<'db> ClassType<'db> {
                                 }
                             }
 
-                            // E.g. for `tuple[str, *tuple[float, ...], bytes]`, we will generate the following overloads:
+                            // E.g. for `tuple[str, *tuple[float, ...], bytes, range]`, we will generate the following overloads:
                             //
                             //    __getitem__(self, index: Literal[0], /) -> str
-                            //    __getitem__(self, index: Literal[-1], /) -> bytes
+                            //    __getitem__(self, index: Literal[1], /) -> float | bytes
+                            //    __getitem__(self, index: Literal[2], /) -> float | bytes | range
+                            //    __getitem__(self, index: Literal[-1], /) -> range
+                            //    __getitem__(self, index: Literal[-2], /) -> bytes
+                            //    __getitem__(self, index: Literal[-3], /) -> float | str
                             //
                             TupleSpec::Variable(variable_length_tuple) => {
                                 for (index, ty) in variable_length_tuple.prefix.iter().enumerate() {
                                     if let Ok(index) = i64::try_from(index) {
                                         element_type_to_indices.entry(*ty).or_default().push(index);
                                     }
-                                }
 
-                                for index in 0..variable_length_tuple.suffix.len() {
-                                    if let Ok(i) =
-                                        i64::try_from(variable_length_tuple.prefix.len() + index)
-                                    {
-                                        let overload_return = UnionType::from_elements(
-                                            db,
-                                            std::iter::once(variable_length_tuple.variable).chain(
-                                                variable_length_tuple
-                                                    .suffix
-                                                    .iter()
-                                                    .take(index + 1)
-                                                    .copied(),
-                                            ),
-                                        );
-                                        element_type_to_indices
-                                            .entry(overload_return)
-                                            .or_default()
-                                            .push(i);
-                                    }
-                                }
-
-                                for (index, ty) in
-                                    variable_length_tuple.suffix.iter().rev().enumerate()
-                                {
-                                    if let Some(index) =
-                                        index.checked_add(1).and_then(|i| i64::try_from(i).ok())
-                                    {
-                                        element_type_to_indices
-                                            .entry(*ty)
-                                            .or_default()
-                                            .push(0 - index);
-                                    }
-                                }
-
-                                for index in 0..variable_length_tuple.prefix.len() {
                                     let one_based_index = index + 1;
+
                                     if let Ok(i) = i64::try_from(
                                         variable_length_tuple.suffix.len() + one_based_index,
                                     ) {
@@ -717,6 +686,38 @@ impl<'db> ClassType<'db> {
                                             .entry(overload_return)
                                             .or_default()
                                             .push(0 - i);
+                                    }
+                                }
+
+                                for (index, ty) in
+                                    variable_length_tuple.suffix.iter().rev().enumerate()
+                                {
+                                    if let Some(index) =
+                                        index.checked_add(1).and_then(|i| i64::try_from(i).ok())
+                                    {
+                                        element_type_to_indices
+                                            .entry(*ty)
+                                            .or_default()
+                                            .push(0 - index);
+                                    }
+
+                                    if let Ok(i) =
+                                        i64::try_from(variable_length_tuple.prefix.len() + index)
+                                    {
+                                        let overload_return = UnionType::from_elements(
+                                            db,
+                                            std::iter::once(variable_length_tuple.variable).chain(
+                                                variable_length_tuple
+                                                    .suffix
+                                                    .iter()
+                                                    .take(index + 1)
+                                                    .copied(),
+                                            ),
+                                        );
+                                        element_type_to_indices
+                                            .entry(overload_return)
+                                            .or_default()
+                                            .push(i);
                                     }
                                 }
                             }

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -19,7 +19,7 @@ use crate::types::function::{DataclassTransformerParams, KnownFunction};
 use crate::types::generics::{GenericContext, Specialization, walk_specialization};
 use crate::types::infer::nearest_enclosing_class;
 use crate::types::signatures::{CallableSignature, Parameter, Parameters, Signature};
-use crate::types::tuple::TupleType;
+use crate::types::tuple::{TupleSpec, TupleType};
 use crate::types::{
     BareTypeAliasType, Binding, BoundSuperError, BoundSuperType, CallableType, DataclassParams,
     DeprecatedInstance, DynamicType, KnownInstanceType, TypeAliasType, TypeMapping, TypeRelation,
@@ -53,7 +53,7 @@ use ruff_db::parsed::{ParsedModuleRef, parsed_module};
 use ruff_python_ast::name::Name;
 use ruff_python_ast::{self as ast, PythonVersion};
 use ruff_text_size::{Ranged, TextRange};
-use rustc_hash::{FxHashSet, FxHasher};
+use rustc_hash::{FxHashMap, FxHashSet, FxHasher};
 
 type FxOrderMap<K, V> = ordermap::map::OrderMap<K, V, BuildHasherDefault<FxHasher>>;
 
@@ -574,7 +574,24 @@ impl<'db> ClassType<'db> {
     /// directly. Use [`ClassType::class_member`] if you require a method that will
     /// traverse through the MRO until it finds the member.
     pub(super) fn own_class_member(self, db: &'db dyn Db, name: &str) -> PlaceAndQualifiers<'db> {
+        fn synthesize_getitem_overload_signature<'db>(
+            index_annotation: Type<'db>,
+            return_annotation: Type<'db>,
+        ) -> Signature<'db> {
+            let self_parameter = Parameter::positional_only(Some(Name::new_static("self")));
+            let index_parameter = Parameter::positional_only(Some(Name::new_static("index")))
+                .with_annotated_type(index_annotation);
+            let parameters = Parameters::new([self_parameter, index_parameter]);
+            Signature::new(parameters, Some(return_annotation))
+        }
+
         let (class_literal, specialization) = self.class_literal(db);
+
+        let fallback_member_lookup = || {
+            class_literal
+                .own_class_member(db, specialization, name)
+                .map_type(|ty| ty.apply_optional_specialization(db, specialization))
+        };
 
         let synthesize_simple_tuple_method = |return_type| {
             let parameters =
@@ -604,6 +621,116 @@ impl<'db> ClassType<'db> {
                     .unwrap_or_else(|| KnownClass::Bool.to_instance(db));
 
                 synthesize_simple_tuple_method(return_type)
+            }
+
+            "__getitem__" if class_literal.is_tuple(db) => {
+                specialization
+                    .map(|spec| {
+                        let tuple = spec.tuple(db);
+
+                        let mut element_type_to_indices: FxHashMap<Type<'db>, Vec<i64>> =
+                            FxHashMap::default();
+
+                        match tuple {
+                            // E.g. for `tuple[int, str]`, we will generate the following overloads:
+                            //
+                            //    __getitem__(self, index: Literal[0, -2], /) -> int
+                            //    __getitem__(self, index: Literal[1, -1], /) -> str
+                            //
+                            TupleSpec::Fixed(fixed_length_tuple) => {
+                                let tuple_length = fixed_length_tuple.len();
+
+                                for (index, ty) in fixed_length_tuple.elements().enumerate() {
+                                    let entry = element_type_to_indices.entry(*ty).or_default();
+                                    if let Ok(index) = i64::try_from(index) {
+                                        entry.push(index);
+                                    }
+                                    if let Ok(index) = i64::try_from(tuple_length - index) {
+                                        entry.push(0 - index);
+                                    }
+                                }
+                            }
+
+                            TupleSpec::Variable(variable_length_tuple) => {
+                                // E.g. for `tuple[str, *tuple[float, ...], bytes]`, we will generate the following overloads:
+                                //
+                                //    __getitem__(self, index: Literal[0], /) -> str
+                                //    __getitem__(self, index: Literal[-1], /) -> bytes
+                                //
+                                for (index, ty) in variable_length_tuple.prefix.iter().enumerate() {
+                                    if let Ok(index) = i64::try_from(index) {
+                                        element_type_to_indices.entry(*ty).or_default().push(index);
+                                    }
+                                }
+                                for (index, ty) in
+                                    variable_length_tuple.suffix.iter().rev().enumerate()
+                                {
+                                    if let Some(index) =
+                                        index.checked_add(1).and_then(|i| i64::try_from(i).ok())
+                                    {
+                                        element_type_to_indices
+                                            .entry(*ty)
+                                            .or_default()
+                                            .push(0 - index);
+                                    }
+                                }
+                            }
+                        }
+
+                        let all_elements_unioned =
+                            UnionType::from_elements(db, tuple.all_elements());
+
+                        let mut overload_signatures =
+                            Vec::with_capacity(element_type_to_indices.len().saturating_add(2));
+
+                        overload_signatures.extend(element_type_to_indices.into_iter().filter_map(
+                            |(return_type, mut indices)| {
+                                if return_type.is_equivalent_to(db, all_elements_unioned) {
+                                    return None;
+                                }
+
+                                // Sorting isn't strictly required, but leads to nicer `reveal_type` output
+                                indices.sort_unstable();
+
+                                let index_annotation = UnionType::from_elements(
+                                    db,
+                                    indices.into_iter().map(Type::IntLiteral),
+                                );
+
+                                Some(synthesize_getitem_overload_signature(
+                                    index_annotation,
+                                    return_type,
+                                ))
+                            },
+                        ));
+
+                        // Fallback overloads: for `tuple[int, str]`, we will generate the following overloads:
+                        //
+                        //    __getitem__(self, index: int, /) -> int | str
+                        //    __getitem__(self, index: slice[Any, Any, Any], /) -> tuple[int | str, ...]
+                        //
+                        // and for `tuple[str, *tuple[float, ...], bytes]`, we will generate the following overloads:
+                        //
+                        //    __getitem__(self, index: int, /) -> str | float | bytes
+                        //    __getitem__(self, index: slice[Any, Any, Any], /) -> tuple[str | float | bytes, ...]
+                        //
+                        overload_signatures.push(synthesize_getitem_overload_signature(
+                            KnownClass::SupportsIndex.to_instance(db),
+                            all_elements_unioned,
+                        ));
+
+                        overload_signatures.push(synthesize_getitem_overload_signature(
+                            KnownClass::Slice.to_instance(db),
+                            TupleType::homogeneous(db, all_elements_unioned),
+                        ));
+
+                        let getitem_signature =
+                            CallableSignature::from_overloads(overload_signatures);
+                        let getitem_type =
+                            Type::Callable(CallableType::new(db, getitem_signature, true));
+                        Place::bound(getitem_type).into()
+                    })
+                    .unwrap_or_else(fallback_member_lookup)
             }
 
             // ```py
@@ -672,9 +799,7 @@ impl<'db> ClassType<'db> {
                 Place::bound(synthesized_dunder).into()
             }
 
-            _ => class_literal
-                .own_class_member(db, specialization, name)
-                .map_type(|ty| ty.apply_optional_specialization(db, specialization)),
+            _ => fallback_member_lookup(),
         }
     }
 

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -651,17 +651,39 @@ impl<'db> ClassType<'db> {
                                 }
                             }
 
+                            // E.g. for `tuple[str, *tuple[float, ...], bytes]`, we will generate the following overloads:
+                            //
+                            //    __getitem__(self, index: Literal[0], /) -> str
+                            //    __getitem__(self, index: Literal[-1], /) -> bytes
+                            //
                             TupleSpec::Variable(variable_length_tuple) => {
-                                // E.g. for `tuple[str, *tuple[float, ...], bytes]`, we will generate the following overloads:
-                                //
-                                //    __getitem__(self, index: Literal[0], /) -> str
-                                //    __getitem__(self, index: Literal[-1], /) -> bytes
-                                //
                                 for (index, ty) in variable_length_tuple.prefix.iter().enumerate() {
                                     if let Ok(index) = i64::try_from(index) {
                                         element_type_to_indices.entry(*ty).or_default().push(index);
                                     }
                                 }
+
+                                for index in 0..variable_length_tuple.suffix.len() {
+                                    if let Ok(i) =
+                                        i64::try_from(variable_length_tuple.prefix.len() + index)
+                                    {
+                                        let overload_return = UnionType::from_elements(
+                                            db,
+                                            std::iter::once(variable_length_tuple.variable).chain(
+                                                variable_length_tuple
+                                                    .suffix
+                                                    .iter()
+                                                    .take(index + 1)
+                                                    .copied(),
+                                            ),
+                                        );
+                                        element_type_to_indices
+                                            .entry(overload_return)
+                                            .or_default()
+                                            .push(i);
+                                    }
+                                }
+
                                 for (index, ty) in
                                     variable_length_tuple.suffix.iter().rev().enumerate()
                                 {
@@ -672,6 +694,29 @@ impl<'db> ClassType<'db> {
                                             .entry(*ty)
                                             .or_default()
                                             .push(0 - index);
+                                    }
+                                }
+
+                                for index in 0..variable_length_tuple.prefix.len() {
+                                    let one_based_index = index + 1;
+                                    if let Ok(i) = i64::try_from(
+                                        variable_length_tuple.suffix.len() + one_based_index,
+                                    ) {
+                                        let overload_return = UnionType::from_elements(
+                                            db,
+                                            std::iter::once(variable_length_tuple.variable).chain(
+                                                variable_length_tuple
+                                                    .prefix
+                                                    .iter()
+                                                    .rev()
+                                                    .take(one_based_index)
+                                                    .copied(),
+                                            ),
+                                        );
+                                        element_type_to_indices
+                                            .entry(overload_return)
+                                            .or_default()
+                                            .push(0 - i);
                                     }
                                 }
                             }

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -528,7 +528,7 @@ impl<T> VariableLengthTuple<T> {
         self.prefix_elements().chain(self.suffix_elements())
     }
 
-    fn all_elements(&self) -> impl Iterator<Item = &T> + '_ {
+    pub(super) fn all_elements(&self) -> impl Iterator<Item = &T> + '_ {
         (self.prefix_elements())
             .chain(std::iter::once(&self.variable))
             .chain(self.suffix_elements())

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -528,7 +528,7 @@ impl<T> VariableLengthTuple<T> {
         self.prefix_elements().chain(self.suffix_elements())
     }
 
-    pub(super) fn all_elements(&self) -> impl Iterator<Item = &T> + '_ {
+    fn all_elements(&self) -> impl Iterator<Item = &T> + '_ {
         (self.prefix_elements())
             .chain(std::iter::once(&self.variable))
             .chain(self.suffix_elements())


### PR DESCRIPTION
## Summary

This PR adds synthesized `__getitem__` overloads for tuple subclasses, such that for `f` in the following example, we can infer that `f[0]` evaluates to `int` and `f[1]` evaluates to `str`:

```py
class Foo(tuple[int, str]): ...

f = Foo((42, "foo"))
reveal_type(f[0])
reveal_type(f[1])
```

It was initially my hope when embarking on this PR that we would be able to use these synthesized overloads to fully get rid of the special casing we have for tuples in `infer_subscript_expression_types`. Over the course of writing the PR, I realised that this would not be possible, for the following reasons:
1. The special casing for slice literals is too complicated to be reasonably implemented via synthesized overloads.

   The synthesized overloads being added for int literals in this PR are already (I believe) the most complicated synthesized functions we have anywhere in our codebase so far. The synthesized overloads required to support slice literals would be far more complicated. It might be theoretically possible to generate them, but I think the inherent complexity makes this realistically untenable. It could also cause performance problems to synthesize that many overloads.
2. The index-out-of-bounds error can't be implemented via synthesized overloads.

   I'd like to explore generalising this diagnostic so that we don't just emit it for specific `Type` variants that we know to have fixed lengths, but for any type where `Type::len()` returns `Some()`. That's for another PR, however.
3. For a tuple type like `tuple[int, *tuple[str, ...], bytes]`, it's impossible to express "if it's subscripted with any literal integer higher than 1, you should infer `str | bytes` rather than `int | str | bytes` using synthesized overloads.

   This is currently implemented in our tuple special-casing, and it would be a shame to introduce a regression on this.

Because of these issues, I've come to the conclusion that we will not be able to get rid of the hardcoded special casing for tuples in `TypeInferenceBuilder::infer_suscript_expression_types`, and that we will probably have to extend it so that it also applies to tuple subclasses. Nonetheless, I'm opening this PR anyway, because inferring precise signatures for `__getitem__` attributes on specialised tuples has advantages even if we don't end up using these signatures directly when inferring the types of subscript expressions against tuples. A good example of why is protocol assignability: it would be ideal if `Bar` is understood by ty as a subtype of `Proto` in the following example:

```py
from typing import Protocol, Literal

class Proto(Protocol):
    def __getitem__(self, index: Literal[0], /) -> int: ...

class Bar(tuple[int, str]): ...
```

We [currently say](https://play.ty.dev/4f46d225-fc80-4fb5-b453-fd5e9c01aa49) that `Bar` is indeed a subtype of `Proto`, but (if we do not land something similar to this PR), that will no longer be the case after fixing https://github.com/astral-sh/ty/issues/889. After fixing that issue, we will strictly validate the signature of a class's method against the signature of a protocol it claims to be an instance of. Without this PR, we would look up the `__getitem__` signature on `tuple[int]` and fallback to the generic `__getitem__` signature in typeshed, which would lead us to incorrectly infer that `Bar` is not a subtype of `Proto`. With this PR, however, we should have the necessary pieces in place that we continue to consider `Bar` a subtype of `Proto` even after #889 has been fixed, because the lookup of `__getitem__` on the `Bar` class object would return the precise synthesized overloads being added here.

## Test Plan

Mdtests. The ecosystem hits also LGTM. They use `os.stat()` and `pwd.getpwuid()`, both of which return instances of tuple subclasses.
