### PR TITLE
[ty] Make `Module` a Salsa ingredient

### DIFF
--- a/crates/ruff_graph/src/resolver.rs
+++ b/crates/ruff_graph/src/resolver.rs
@@ -20,7 +20,7 @@ impl<'a> Resolver<'a> {
         match import {
             CollectedImport::Import(import) => {
                 let module = resolve_module(self.db, &import)?;
-                Some(module.file()?.path(self.db))
+                Some(module.file(self.db)?.path(self.db))
             }
             CollectedImport::ImportFrom(import) => {
                 // Attempt to resolve the member (e.g., given `from foo import bar`, look for `foo.bar`).
@@ -32,7 +32,7 @@ impl<'a> Resolver<'a> {
                     resolve_module(self.db, &parent?)
                 })?;
 
-                Some(module.file()?.path(self.db))
+                Some(module.file(self.db)?.path(self.db))
             }
         }
     }

--- a/crates/ruff_python_semantic/src/analyze/visibility.rs
+++ b/crates/ruff_python_semantic/src/analyze/visibility.rs
@@ -163,7 +163,7 @@ fn stem(path: &str) -> &str {
 }
 
 /// Infer the [`Visibility`] of a module from its path.
-pub(crate) fn module_visibility(module: &Module) -> Visibility {
+pub(crate) fn module_visibility(module: Module) -> Visibility {
     match &module.source {
         ModuleSource::Path(path) => {
             if path.iter().any(|m| is_private_module(m)) {

--- a/crates/ruff_python_semantic/src/definition.rs
+++ b/crates/ruff_python_semantic/src/definition.rs
@@ -223,7 +223,7 @@ impl<'a> Definitions<'a> {
             // visibility.
             let visibility = {
                 match &definition {
-                    Definition::Module(module) => module_visibility(module),
+                    Definition::Module(module) => module_visibility(*module),
                     Definition::Member(member) => match member.kind {
                         MemberKind::Class(class) => {
                             let parent = &definitions[member.parent];

--- a/crates/ty_ide/src/goto.rs
+++ b/crates/ty_ide/src/goto.rs
@@ -525,7 +525,7 @@ fn resolve_module_to_navigation_target(
 
     if let Some(module_name) = ModuleName::new(module_name_str) {
         if let Some(resolved_module) = resolve_module(db, &module_name) {
-            if let Some(module_file) = resolved_module.file() {
+            if let Some(module_file) = resolved_module.file(db) {
                 return Some(crate::NavigationTargets::single(crate::NavigationTarget {
                     file: module_file,
                     focus_range: TextRange::default(),

--- a/crates/ty_python_semantic/src/dunder_all.rs
+++ b/crates/ty_python_semantic/src/dunder_all.rs
@@ -103,7 +103,7 @@ impl<'db> DunderAllNamesCollector<'db> {
                 };
                 let Some(module_dunder_all_names) = module_literal
                     .module(self.db)
-                    .file()
+                    .file(self.db)
                     .and_then(|file| dunder_all_names(self.db, file))
                 else {
                     // The module either does not have a `__all__` variable or it is invalid.
@@ -173,7 +173,7 @@ impl<'db> DunderAllNamesCollector<'db> {
         let module_name =
             ModuleName::from_import_statement(self.db, self.file, import_from).ok()?;
         let module = resolve_module(self.db, &module_name)?;
-        dunder_all_names(self.db, module.file()?)
+        dunder_all_names(self.db, module.file(self.db)?)
     }
 
     /// Infer the type of a standalone expression.

--- a/crates/ty_python_semantic/src/module_name.rs
+++ b/crates/ty_python_semantic/src/module_name.rs
@@ -345,12 +345,12 @@ fn relative_module_name(
         .ok_or(ModuleNameResolutionError::UnknownCurrentModule)?;
     let mut level = level.get();
 
-    if module.kind().is_package() {
+    if module.kind(db).is_package() {
         level = level.saturating_sub(1);
     }
 
     let mut module_name = module
-        .name()
+        .name(db)
         .ancestors()
         .nth(level as usize)
         .ok_or(ModuleNameResolutionError::TooManyDots)?;

--- a/crates/ty_python_semantic/src/module_resolver/module.rs
+++ b/crates/ty_python_semantic/src/module_resolver/module.rs
@@ -1,10 +1,11 @@
 use std::fmt::Formatter;
 use std::str::FromStr;
-use std::sync::Arc;
 
 use ruff_db::files::File;
 use ruff_python_ast::name::Name;
 use ruff_python_stdlib::identifiers::is_identifier;
+use salsa::Database;
+use salsa::plumbing::AsId;
 
 use super::path::SearchPath;
 use crate::Db;
@@ -12,14 +13,19 @@ use crate::module_name::ModuleName;
 use crate::module_resolver::path::SystemOrVendoredPathRef;
 
 /// Representation of a Python module.
-#[derive(Clone, PartialEq, Eq, Hash, get_size2::GetSize)]
-pub struct Module {
-    inner: Arc<ModuleInner>,
+#[derive(Clone, Copy, Eq, Hash, PartialEq, salsa::Supertype, salsa::Update)]
+pub enum Module<'db> {
+    File(FileModule<'db>),
+    Namespace(NamespacePackage<'db>),
 }
 
+// The Salsa heap is tracked separately.
+impl get_size2::GetSize for Module<'_> {}
+
 #[salsa::tracked]
-impl Module {
+impl<'db> Module<'db> {
     pub(crate) fn file_module(
+        db: &'db dyn Db,
         name: ModuleName,
         kind: ModuleKind,
         search_path: SearchPath,
@@ -27,67 +33,57 @@ impl Module {
     ) -> Self {
         let known = KnownModule::try_from_search_path_and_name(&search_path, &name);
 
-        Self {
-            inner: Arc::new(ModuleInner::FileModule {
-                name,
-                kind,
-                search_path,
-                file,
-                known,
-            }),
-        }
+        Self::File(FileModule::new(db, name, kind, search_path, file, known))
     }
 
-    pub(crate) fn namespace_package(name: ModuleName) -> Self {
-        Self {
-            inner: Arc::new(ModuleInner::NamespacePackage { name }),
-        }
+    pub(crate) fn namespace_package(db: &'db dyn Db, name: ModuleName) -> Self {
+        Self::Namespace(NamespacePackage::new(db, name))
     }
 
     /// The absolute name of the module (e.g. `foo.bar`)
-    pub fn name(&self) -> &ModuleName {
-        match &*self.inner {
-            ModuleInner::FileModule { name, .. } => name,
-            ModuleInner::NamespacePackage { name, .. } => name,
+    pub fn name(self, db: &'db dyn Database) -> &'db ModuleName {
+        match self {
+            Module::File(module) => module.name(db),
+            Module::Namespace(ref package) => package.name(db),
         }
     }
 
     /// The file to the source code that defines this module
     ///
     /// This is `None` for namespace packages.
-    pub fn file(&self) -> Option<File> {
-        match &*self.inner {
-            ModuleInner::FileModule { file, .. } => Some(*file),
-            ModuleInner::NamespacePackage { .. } => None,
+    pub fn file(self, db: &'db dyn Database) -> Option<File> {
+        match self {
+            Module::File(module) => Some(module.file(db)),
+            Module::Namespace(_) => None,
         }
     }
 
     /// Is this a module that we special-case somehow? If so, which one?
-    pub fn known(&self) -> Option<KnownModule> {
-        match &*self.inner {
-            ModuleInner::FileModule { known, .. } => *known,
-            ModuleInner::NamespacePackage { .. } => None,
+    pub fn known(self, db: &'db dyn Database) -> Option<KnownModule> {
+        match self {
+            Module::File(module) => module.known(db),
+            Module::Namespace(_) => None,
         }
     }
 
     /// Does this module represent the given known module?
-    pub fn is_known(&self, known_module: KnownModule) -> bool {
-        self.known() == Some(known_module)
+    pub fn is_known(self, db: &'db dyn Database, known_module: KnownModule) -> bool {
+        self.known(db) == Some(known_module)
     }
 
     /// The search path from which the module was resolved.
-    pub(crate) fn search_path(&self) -> Option<&SearchPath> {
-        match &*self.inner {
-            ModuleInner::FileModule { search_path, .. } => Some(search_path),
-            ModuleInner::NamespacePackage { .. } => None,
+    pub(crate) fn search_path(self, db: &'db dyn Database) -> Option<&'db SearchPath> {
+        match self {
+            Module::File(module) => Some(module.search_path(db)),
+            Module::Namespace(_) => None,
         }
     }
 
     /// Determine whether this module is a single-file module or a package
-    pub fn kind(&self) -> ModuleKind {
-        match &*self.inner {
-            ModuleInner::FileModule { kind, .. } => *kind,
-            ModuleInner::NamespacePackage { .. } => ModuleKind::Package,
+    pub fn kind(self, db: &'db dyn Database) -> ModuleKind {
+        match self {
+            Module::File(module) => module.kind(db),
+            Module::Namespace(_) => ModuleKind::Package,
         }
     }
 
@@ -98,16 +94,13 @@ impl Module {
     ///
     /// The names returned correspond to the "base" name of the module.
     /// That is, `{self.name}.{basename}` should give the full module name.
-    pub fn all_submodules<'db>(&self, db: &'db dyn Db) -> &'db [Name] {
-        self.clone()
-            .all_submodules_inner(db, ())
-            .as_deref()
-            .unwrap_or_default()
+    pub fn all_submodules(self, db: &'db dyn Db) -> &'db [Name] {
+        self.all_submodules_inner(db).as_deref().unwrap_or_default()
     }
 
-    #[allow(clippy::ref_option, clippy::used_underscore_binding)]
+    #[allow(clippy::ref_option)]
     #[salsa::tracked(returns(ref))]
-    fn all_submodules_inner(self, db: &dyn Db, _dummy: ()) -> Option<Vec<Name>> {
+    fn all_submodules_inner(self, db: &'db dyn Db) -> Option<Vec<Name>> {
         fn is_submodule(
             is_dir: bool,
             is_file: bool,
@@ -125,16 +118,14 @@ impl Module {
         // to a single file; it can span multiple directories across multiple
         // search paths. For now, we only compute submodules for traditional
         // packages that exist in a single directory on a single search path.
-        let ModuleInner::FileModule {
-            kind: ModuleKind::Package,
-            file,
-            ..
-        } = &*self.inner
-        else {
+        let Module::File(module) = self else {
             return None;
         };
+        if !matches!(module.kind(db), ModuleKind::Package) {
+            return None;
+        }
 
-        let path = SystemOrVendoredPathRef::try_from_file(db, *file)?;
+        let path = SystemOrVendoredPathRef::try_from_file(db, module.file(db))?;
         debug_assert!(
             matches!(path.file_name(), Some("__init__.py" | "__init__.pyi")),
             "expected package file `{:?}` to be `__init__.py` or `__init__.pyi`",
@@ -201,33 +192,41 @@ impl Module {
     }
 }
 
-impl std::fmt::Debug for Module {
+impl std::fmt::Debug for Module<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Module")
-            .field("name", &self.name())
-            .field("kind", &self.kind())
-            .field("file", &self.file())
-            .field("search_path", &self.search_path())
-            .field("known", &self.known())
-            .finish()
+        salsa::with_attached_database(|db| {
+            f.debug_struct("Module")
+                .field("name", &self.name(db))
+                .field("kind", &self.kind(db))
+                .field("file", &self.file(db))
+                .field("search_path", &self.search_path(db))
+                .field("known", &self.known(db))
+                .finish()
+        })
+        .unwrap_or_else(|| f.debug_tuple("Module").field(&self.as_id()).finish())
     }
 }
 
-#[derive(PartialEq, Eq, Hash, get_size2::GetSize)]
-enum ModuleInner {
-    /// A module that resolves to a file (`lib.py` or `package/__init__.py`)
-    FileModule {
-        name: ModuleName,
-        kind: ModuleKind,
-        search_path: SearchPath,
-        file: File,
-        known: Option<KnownModule>,
-    },
+/// A module that resolves to a file (`lib.py` or `package/__init__.py`)
+#[salsa::tracked(debug)]
+pub struct FileModule<'db> {
+    #[returns(ref)]
+    name: ModuleName,
+    kind: ModuleKind,
+    #[returns(ref)]
+    search_path: SearchPath,
+    file: File,
+    known: Option<KnownModule>,
+}
 
-    /// A namespace package. Namespace packages are special because
-    /// there are multiple possible paths and they have no corresponding
-    /// code file.
-    NamespacePackage { name: ModuleName },
+/// A namespace package.
+///
+/// Namespace packages are special because there are
+/// multiple possible paths and they have no corresponding code file.
+#[salsa::tracked(debug)]
+pub struct NamespacePackage<'db> {
+    #[returns(ref)]
+    name: ModuleName,
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, get_size2::GetSize)]

--- a/crates/ty_python_semantic/src/module_resolver/path.rs
+++ b/crates/ty_python_semantic/src/module_resolver/path.rs
@@ -411,7 +411,7 @@ enum SearchPathInner {
 /// and "Standard-library" categories, however, there will always be exactly
 /// one search path from that category in any given list of search paths.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, get_size2::GetSize)]
-pub(crate) struct SearchPath(Arc<SearchPathInner>);
+pub struct SearchPath(Arc<SearchPathInner>);
 
 impl SearchPath {
     fn directory_path(system: &dyn System, root: SystemPathBuf) -> SearchPathResult<SystemPathBuf> {

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -374,7 +374,7 @@ pub(crate) fn imported_symbol<'db>(
 pub(crate) fn builtins_symbol<'db>(db: &'db dyn Db, symbol: &str) -> PlaceAndQualifiers<'db> {
     resolve_module(db, &KnownModule::Builtins.name())
         .and_then(|module| {
-            let file = module.file()?;
+            let file = module.file(db)?;
             Some(
                 symbol_impl(
                     db,
@@ -404,7 +404,7 @@ pub(crate) fn known_module_symbol<'db>(
 ) -> PlaceAndQualifiers<'db> {
     resolve_module(db, &known_module.name())
         .and_then(|module| {
-            let file = module.file()?;
+            let file = module.file(db)?;
             Some(imported_symbol(db, file, symbol, None))
         })
         .unwrap_or_default()
@@ -442,7 +442,7 @@ pub(crate) fn builtins_module_scope(db: &dyn Db) -> Option<ScopeId<'_>> {
 /// Can return `None` if a custom typeshed is used that is missing the core module in question.
 fn core_module_scope(db: &dyn Db, core_module: KnownModule) -> Option<ScopeId<'_>> {
     let module = resolve_module(db, &core_module.name())?;
-    Some(global_scope(db, module.file()?))
+    Some(global_scope(db, module.file(db)?))
 }
 
 /// Infer the combined type from an iterator of bindings, and return it
@@ -812,7 +812,7 @@ fn symbol_impl<'db>(
 
     if name == "platform"
         && file_to_module(db, scope.file(db))
-            .is_some_and(|module| module.is_known(KnownModule::Sys))
+            .is_some_and(|module| module.is_known(db, KnownModule::Sys))
     {
         match Program::get(db).python_platform(db) {
             crate::PythonPlatform::Identifier(platform) => {

--- a/crates/ty_python_semantic/src/semantic_index/builder.rs
+++ b/crates/ty_python_semantic/src/semantic_index/builder.rs
@@ -1278,7 +1278,7 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
                             continue;
                         };
 
-                        let Some(referenced_module) = module.file() else {
+                        let Some(referenced_module) = module.file(self.db) else {
                             continue;
                         };
 

--- a/crates/ty_python_semantic/src/semantic_index/re_exports.rs
+++ b/crates/ty_python_semantic/src/semantic_index/re_exports.rs
@@ -257,7 +257,7 @@ impl<'db> Visitor<'db> for ExportFinder<'db> {
                                     .iter()
                                     .flat_map(|module| {
                                         module
-                                            .file()
+                                            .file(self.db)
                                             .map(|file| exported_names(self.db, file))
                                             .unwrap_or_default()
                                     })

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -67,8 +67,8 @@ impl<'db> SemanticModel<'db> {
             tracing::debug!("Could not resolve module from `{module_name:?}`");
             return vec![];
         };
-        let ty = Type::module_literal(self.db, self.file, &module);
-        let builtin = module.is_known(KnownModule::Builtins);
+        let ty = Type::module_literal(self.db, self.file, module);
+        let builtin = module.is_known(self.db, KnownModule::Builtins);
 
         let mut completions = vec![];
         for crate::types::Member { name, ty } in crate::types::all_members(self.db, ty) {
@@ -84,7 +84,7 @@ impl<'db> SemanticModel<'db> {
             let Some(submodule) = resolve_module(self.db, &submodule_name) else {
                 continue;
             };
-            let ty = Type::module_literal(self.db, self.file, &submodule);
+            let ty = Type::module_literal(self.db, self.file, submodule);
             completions.push(Completion {
                 name: submodule_basename.clone(),
                 ty,

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -648,7 +648,7 @@ impl<'db> Bindings<'db> {
                                     Type::ModuleLiteral(module_literal) => {
                                         let all_names = module_literal
                                             .module(db)
-                                            .file()
+                                            .file(db)
                                             .map(|file| dunder_all_names(db, file))
                                             .unwrap_or_default();
                                         match all_names {

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -3498,7 +3498,7 @@ impl KnownClass {
         };
 
         candidate
-            .check_module(db, file_to_module(db, file)?.known()?)
+            .check_module(db, file_to_module(db, file)?.known(db)?)
             .then_some(candidate)
     }
 
@@ -4067,7 +4067,11 @@ mod tests {
             let class_module = resolve_module(&db, &class.canonical_module(&db).name()).unwrap();
 
             assert_eq!(
-                KnownClass::try_from_file_and_name(&db, class_module.file().unwrap(), class_name),
+                KnownClass::try_from_file_and_name(
+                    &db,
+                    class_module.file(&db).unwrap(),
+                    class_name
+                ),
                 Some(class),
                 "`KnownClass::candidate_from_str` appears to be missing a case for `{class_name}`"
             );

--- a/crates/ty_python_semantic/src/types/definition.rs
+++ b/crates/ty_python_semantic/src/types/definition.rs
@@ -7,7 +7,7 @@ use ruff_text_size::{TextLen, TextRange};
 
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub enum TypeDefinition<'db> {
-    Module(Module),
+    Module(Module<'db>),
     Class(Definition<'db>),
     Function(Definition<'db>),
     TypeVar(Definition<'db>),
@@ -31,7 +31,7 @@ impl TypeDefinition<'_> {
     pub fn full_range(&self, db: &dyn Db) -> Option<FileRange> {
         match self {
             Self::Module(module) => {
-                let file = module.file()?;
+                let file = module.file(db)?;
                 let source = source_text(db, file);
                 Some(FileRange::new(file, TextRange::up_to(source.text_len())))
             }

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -2522,9 +2522,9 @@ pub(super) fn hint_if_stdlib_submodule_exists_on_other_versions(
     db: &dyn Db,
     mut diagnostic: LintDiagnosticGuard,
     full_submodule_name: &ModuleName,
-    parent_module: &Module,
+    parent_module: Module,
 ) {
-    let Some(search_path) = parent_module.search_path() else {
+    let Some(search_path) = parent_module.search_path(db) else {
         return;
     };
 
@@ -2547,7 +2547,7 @@ pub(super) fn hint_if_stdlib_submodule_exists_on_other_versions(
     diagnostic.info(format_args!(
         "The stdlib module `{module_name}` only has a `{name}` \
             submodule on Python {version_range}",
-        module_name = parent_module.name(),
+        module_name = parent_module.name(db),
         name = full_submodule_name
             .components()
             .next_back()

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -102,7 +102,7 @@ impl Display for DisplayRepresentation<'_> {
             },
             Type::PropertyInstance(_) => f.write_str("property"),
             Type::ModuleLiteral(module) => {
-                write!(f, "<module '{}'>", module.module(self.db).name())
+                write!(f, "<module '{}'>", module.module(self.db).name(self.db))
             }
             Type::ClassLiteral(class) => {
                 write!(f, "<class '{}'>", class.name(self.db))

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -1097,7 +1097,7 @@ impl KnownFunction {
     ) -> Option<Self> {
         let candidate = Self::from_str(name).ok()?;
         candidate
-            .check_module(file_to_module(db, definition.file(db))?.known()?)
+            .check_module(file_to_module(db, definition.file(db))?.known(db)?)
             .then_some(candidate)
     }
 
@@ -1368,7 +1368,7 @@ impl KnownFunction {
                     return;
                 };
 
-                overload.set_return_type(Type::module_literal(db, file, &module));
+                overload.set_return_type(Type::module_literal(db, file, module));
             }
 
             _ => {}

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -156,7 +156,7 @@ impl<'db> AllMembers<'db> {
                 self.extend_with_type(db, KnownClass::ModuleType.to_instance(db));
                 let module = literal.module(db);
 
-                let Some(file) = module.file() else {
+                let Some(file) = module.file(db) else {
                     return;
                 };
 
@@ -544,7 +544,7 @@ pub fn definitions_for_attribute<'db>(
     for ty in expanded_tys {
         // Handle modules
         if let Type::ModuleLiteral(module_literal) = ty {
-            if let Some(module_file) = module_literal.module(db).file() {
+            if let Some(module_file) = module_literal.module(db).file(db) {
                 let module_scope = global_scope(db, module_file);
                 for def in find_symbol_in_scope(db, module_scope, name_str) {
                     resolved.extend(resolve_definition(db, def, Some(name_str)));
@@ -878,7 +878,7 @@ mod resolve_definition {
                     return Vec::new(); // Module not found, return empty list
                 };
 
-                let Some(module_file) = resolved_module.file() else {
+                let Some(module_file) = resolved_module.file(db) else {
                     return Vec::new(); // No file for module, return empty list
                 };
 
@@ -939,7 +939,7 @@ mod resolve_definition {
             let Some(resolved_module) = resolve_module(db, &module_name) else {
                 return Vec::new();
             };
-            resolved_module.file()
+            resolved_module.file(db)
         };
 
         let Some(module_file) = module_file else {
@@ -1013,10 +1013,10 @@ mod resolve_definition {
 
         // It's definitely a stub, so now rerun module resolution but with stubs disabled.
         let stub_module = file_to_module(db, stub_file)?;
-        trace!("Found stub module: {}", stub_module.name());
-        let real_module = resolve_real_module(db, stub_module.name())?;
-        trace!("Found real module: {}", real_module.name());
-        let real_file = real_module.file()?;
+        trace!("Found stub module: {}", stub_module.name(db));
+        let real_module = resolve_real_module(db, stub_module.name(db))?;
+        trace!("Found real module: {}", real_module.name(db));
+        let real_file = real_module.file(db)?;
         trace!("Found real file: {}", real_file.path(db));
 
         // A definition has a "Definition Path" in a file made of nested definitions (~scopes):

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -4866,7 +4866,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return;
         };
 
-        let module_ty = Type::module_literal(self.db(), self.file(), &module);
+        let module_ty = Type::module_literal(self.db(), self.file(), module);
 
         // The indirection of having `star_import_info` as a separate variable
         // is required in order to make the borrow checker happy.
@@ -4892,7 +4892,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // (e.g. `from parent import submodule` inside the `parent` module).
         let import_is_self_referential = module_ty
             .into_module_literal()
-            .is_some_and(|module| Some(self.file()) == module.module(self.db()).file());
+            .is_some_and(|module| Some(self.file()) == module.module(self.db()).file(self.db()));
 
         // First try loading the requested attribute from the module.
         if !import_is_self_referential {
@@ -4990,7 +4990,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 self.db(),
                 diagnostic,
                 &full_submodule_name,
-                &module,
+                module,
             );
         }
     }
@@ -5144,7 +5144,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
     fn module_type_from_name(&self, module_name: &ModuleName) -> Option<Type<'db>> {
         resolve_module(self.db(), module_name)
-            .map(|module| Type::module_literal(self.db(), self.file(), &module))
+            .map(|module| Type::module_literal(self.db(), self.file(), module))
     }
 
     fn infer_decorator(&mut self, decorator: &ast::Decorator) -> Type<'db> {

--- a/crates/ty_python_semantic/src/types/special_form.rs
+++ b/crates/ty_python_semantic/src/types/special_form.rs
@@ -187,7 +187,7 @@ impl SpecialFormType {
     ) -> Option<Self> {
         let candidate = Self::from_str(symbol_name).ok()?;
         candidate
-            .check_module(file_to_module(db, file)?.known()?)
+            .check_module(file_to_module(db, file)?.known(db)?)
             .then_some(candidate)
     }
 


### PR DESCRIPTION
We want to write queries that depend on `Module` for caching. While it
seems it can be done without making `Module` an ingredient, it seems it
is [best practice to do so].

[best practice to do so]: https://github.com/astral-sh/ruff/pull/19408#discussion_r2215867301
