### PR TITLE
[ty] Exhaustiveness checking & reachability for `match` statements

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/conditional/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/conditional/match.md
@@ -201,8 +201,7 @@ def _(target: Literal[True, False]):
         case None:
             y = 4
 
-    # TODO: with exhaustiveness checking, this should be Literal[2, 3]
-    reveal_type(y)  # revealed: Literal[1, 2, 3]
+    reveal_type(y)  # revealed: Literal[2, 3]
 
 def _(target: bool):
     y = 1
@@ -215,8 +214,7 @@ def _(target: bool):
         case None:
             y = 4
 
-    # TODO: with exhaustiveness checking, this should be Literal[2, 3]
-    reveal_type(y)  # revealed: Literal[1, 2, 3]
+    reveal_type(y)  # revealed: Literal[2, 3]
 
 def _(target: None):
     y = 1
@@ -242,8 +240,7 @@ def _(target: None | Literal[True]):
         case None:
             y = 4
 
-    # TODO: with exhaustiveness checking, this should be Literal[2, 4]
-    reveal_type(y)  # revealed: Literal[1, 2, 4]
+    reveal_type(y)  # revealed: Literal[2, 4]
 
 # bool is an int subclass
 def _(target: int):
@@ -292,7 +289,7 @@ def _(answer: Answer):
             reveal_type(answer)  # revealed: Literal[Answer.NO]
             y = 2
 
-    reveal_type(y)  # revealed: Literal[0, 1, 2]
+    reveal_type(y)  # revealed: Literal[1, 2]
 ```
 
 ## Or match
@@ -311,8 +308,7 @@ def _(target: Literal["foo", "baz"]):
         case "baz":
             y = 3
 
-    # TODO: with exhaustiveness, this should be Literal[2, 3]
-    reveal_type(y)  # revealed: Literal[1, 2, 3]
+    reveal_type(y)  # revealed: Literal[2, 3]
 
 def _(target: None):
     y = 1

--- a/crates/ty_python_semantic/resources/mdtest/directives/assert_never.md
+++ b/crates/ty_python_semantic/resources/mdtest/directives/assert_never.md
@@ -119,8 +119,6 @@ def match_singletons_success(obj: Literal[1, "a"] | None):
         case None:
             pass
         case _ as obj:
-            # TODO: Ideally, we would not emit an error here
-            # error: [type-assertion-failure] "Argument does not have asserted type `Never`"
             assert_never(obj)
 
 def match_singletons_error(obj: Literal[1, "a"] | None):

--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -720,8 +720,6 @@ def color_name(color: Color) -> str:
         case _:
             assert_never(color)
 
-# TODO: this should not be an error, see https://github.com/astral-sh/ty/issues/99#issuecomment-2983054488
-# error: [invalid-return-type] "Function can implicitly return `None`, which is not assignable to return type `str`"
 def color_name_without_assertion(color: Color) -> str:
     match color:
         case Color.RED:

--- a/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
+++ b/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
@@ -50,13 +50,10 @@ def match_exhaustive(x: Literal[0, 1, "a"]):
         case "a":
             pass
         case _:
-            # TODO: this should not be an error
-            no_diagnostic_here  # error: [unresolved-reference]
+            no_diagnostic_here
 
             assert_never(x)
 
-# TODO: there should be no error here
-# error: [invalid-return-type] "Function can implicitly return `None`, which is not assignable to return type `int`"
 def match_exhaustive_no_assertion(x: Literal[0, 1, "a"]) -> int:
     match x:
         case 0:
@@ -130,13 +127,21 @@ def match_exhaustive(x: Color):
         case Color.BLUE:
             pass
         case _:
-            # TODO: this should not be an error
-            no_diagnostic_here  # error: [unresolved-reference]
+            no_diagnostic_here
 
             assert_never(x)
 
-# TODO: there should be no error here
-# error: [invalid-return-type] "Function can implicitly return `None`, which is not assignable to return type `int`"
+def match_exhaustive_2(x: Color):
+    match x:
+        case Color.RED:
+            pass
+        case Color.GREEN | Color.BLUE:
+            pass
+        case _:
+            no_diagnostic_here
+
+            assert_never(x)
+
 def match_exhaustive_no_assertion(x: Color) -> int:
     match x:
         case Color.RED:
@@ -208,13 +213,10 @@ def match_exhaustive(x: A | B | C):
         case C():
             pass
         case _:
-            # TODO: this should not be an error
-            no_diagnostic_here  # error: [unresolved-reference]
+            no_diagnostic_here
 
             assert_never(x)
 
-# TODO: there should be no error here
-# error: [invalid-return-type] "Function can implicitly return `None`, which is not assignable to return type `int`"
 def match_exhaustive_no_assertion(x: A | B | C) -> int:
     match x:
         case A():

--- a/crates/ty_python_semantic/src/semantic_index/predicate.rs
+++ b/crates/ty_python_semantic/src/semantic_index/predicate.rs
@@ -150,6 +150,9 @@ pub(crate) struct PatternPredicate<'db> {
     pub(crate) kind: PatternPredicateKind<'db>,
 
     pub(crate) guard: Option<Expression<'db>>,
+
+    /// A reference to the pattern of the previous match case
+    pub(crate) previous_predicate: Option<Box<PatternPredicate<'db>>>,
 }
 
 // The Salsa heap is tracked separately.


### PR DESCRIPTION
## Summary

Implements proper reachability analysis and — in effect — exhaustiveness checking for `match` statements. This allows us to check the following code without any errors (leads to *"can implicitly return `None`"* on `main`):

```py
from enum import Enum, auto

class Color(Enum):
    RED = auto()
    GREEN = auto()
    BLUE = auto()

def hex(color: Color) -> str:
    match color:
        case Color.RED:
            return "#ff0000"
        case Color.GREEN:
            return "#00ff00"
        case Color.BLUE:
            return "#0000ff"
```

Note that code like this already worked fine if there was a `assert_never(color)` statement in a catch-all case, because we would then consider that `assert_never` call terminal. But now this also works without the wildcard case. Adding a member to the enum would still lead to an error here, if that case would not be handled in `hex`.

What needed to happen to support this is a new way of evaluating match pattern constraints. Previously, we would simply compare the type of the subject expression against the patterns. For the last case here, the subject type would still be `Color` and the value type would be `Literal[Color.BLUE]`, so we would infer an ambiguous truthiness.

Now, before we compare the subject type against the pattern, we first generate a union type that corresponds to the set of all values that would have *definitely been matched* by previous patterns. Then, we build a "narrowed" subject type by computing `subject_type & ~already_matched_type`, and compare *that* against the pattern type. For the example here, `already_matched_type = Literal[Color.RED] | Literal[Color.GREEN]`, and so we have a narrowed subject type of `Color & ~(Literal[Color.RED] | Literal[Color.GREEN]) = Literal[Color.BLUE]`, which allows us to infer a reachability of `AlwaysTrue`.

<details>

<summary>A note on negated reachability constraints</summary>

It might seem that we now perform duplicate work, because we also record *negated* reachability constraints. But that is still important for cases like the following (and possibly also for more realistic scenarios):

```py
from typing import Literal

def _(x: int | str):
    match x:
        case None:
            pass # never reachable
        case _:
            y = 1

    y
```

</details>

closes https://github.com/astral-sh/ty/issues/99

## Test Plan

* I verified that this solves all examples from the linked ticket (the first example needs a PEP 695 type alias, because we don't support legacy type aliases yet)
* Verified that the ecosystem changes are all because of removed false positives
* Updated tests