### PR TITLE
[`flake8_comprehensions`] Fix false positive for `C420` with attribute, subscript, or slice assignment targets

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_comprehensions/C420_3.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_comprehensions/C420_3.py
@@ -1,0 +1,19 @@
+class C: a = None
+dict.fromkeys("abc")  # OK
+print(C.a)
+
+x = [None]
+dict.fromkeys("abc")  # OK
+print(x)
+
+class C(list):
+    def __getitem__(self, index, /):
+        item = super().__getitem__(index)
+        if isinstance(index, slice): item = tuple(item)
+        return item
+x = C()
+dict.fromkeys("abc")  # OK
+print(x) 
+
+# C420: side-effecting assignment targets
+# See https://github.com/astral-sh/ruff/issues/19511

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/mod.rs
@@ -25,6 +25,7 @@ mod tests {
     #[test_case(Rule::UnnecessaryDictComprehensionForIterable, Path::new("C420.py"))]
     #[test_case(Rule::UnnecessaryDictComprehensionForIterable, Path::new("C420_1.py"))]
     #[test_case(Rule::UnnecessaryDictComprehensionForIterable, Path::new("C420_2.py"))]
+    #[test_case(Rule::UnnecessaryDictComprehensionForIterable, Path::new("C420_3.py"))]
     #[test_case(Rule::UnnecessaryDoubleCastOrProcess, Path::new("C414.py"))]
     #[test_case(Rule::UnnecessaryGeneratorDict, Path::new("C402.py"))]
     #[test_case(Rule::UnnecessaryGeneratorList, Path::new("C400.py"))]

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_dict_comprehension_for_iterable.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_dict_comprehension_for_iterable.rs
@@ -96,6 +96,14 @@ pub(crate) fn unnecessary_dict_comprehension_for_iterable(
         return;
     }
 
+    // Don't suggest `dict.fromkeys` if the target is an attribute, subscript, or slice (side-effecting assignment).
+    match &generator.target {
+        Expr::Attribute(_) | Expr::Subscript(_) | Expr::Slice(_) => {
+            return;
+        }
+        _ => {}
+    }
+
     // Don't suggest `dict.fromkeys` if the value is not a constant or constant-like.
     if !is_constant_like(dict_comp.value.as_ref()) {
         return;

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C420_C420_3.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C420_C420_3.py.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff_linter/src/rules/flake8_comprehensions/mod.rs
+---
+


### PR DESCRIPTION
## Summary

Fixes #19511
