### PR TITLE
[`flake8-blind-except`] Change `BLE001` to permit `logging.critical(..., exc_info=True)`.

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_blind_except/BLE.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_blind_except/BLE.py
@@ -94,7 +94,7 @@ except Exception:
     logging.error("...", exc_info=True)
 
 
-from logging import error, exception
+from logging import critical, error, exception
 
 try:
     pass
@@ -117,6 +117,23 @@ except Exception:
 try:
     pass
 except Exception:
+    critical("...")
+
+
+try:
+    pass
+except Exception:
+    critical("...", exc_info=False)
+
+
+try:
+    pass
+except Exception:
+    critical("...", exc_info=None)
+
+try:
+    pass
+except Exception:
     exception("...")
 
 
@@ -124,6 +141,13 @@ try:
     pass
 except Exception:
     error("...", exc_info=True)
+
+
+try:
+    pass
+except Exception:
+    critical("...", exc_info=True)
+
 
 try:
     ...

--- a/crates/ruff_linter/src/rules/flake8_blind_except/rules/blind_except.rs
+++ b/crates/ruff_linter/src/rules/flake8_blind_except/rules/blind_except.rs
@@ -47,9 +47,10 @@ use crate::checkers::ast::Checker;
 ///     raise
 /// ```
 ///
-/// Exceptions that are logged via `logging.exception()` or `logging.error()`
-/// with `exc_info` enabled will _not_ be flagged, as this is a common pattern
-/// for propagating exception traces:
+/// Exceptions that are logged via `logging.exception()` or are logged via
+/// `logging.error()` or `logging.critical()` with `exc_info` enabled will
+/// _not_ be flagged, as this is a common pattern for propagating exception
+/// traces:
 /// ```python
 /// try:
 ///     foo()
@@ -201,7 +202,7 @@ impl<'a> StatementVisitor<'a> for LogExceptionVisitor<'a> {
                             ) {
                                 if match attr.as_str() {
                                     "exception" => true,
-                                    "error" => arguments
+                                    "error" | "critical" => arguments
                                         .find_keyword("exc_info")
                                         .is_some_and(|keyword| is_const_true(&keyword.value)),
                                     _ => false,
@@ -214,7 +215,7 @@ impl<'a> StatementVisitor<'a> for LogExceptionVisitor<'a> {
                             if self.semantic.resolve_qualified_name(func).is_some_and(
                                 |qualified_name| match qualified_name.segments() {
                                     ["logging", "exception"] => true,
-                                    ["logging", "error"] => arguments
+                                    ["logging", "error" | "critical"] => arguments
                                         .find_keyword("exc_info")
                                         .is_some_and(|keyword| is_const_true(&keyword.value)),
                                     _ => false,

--- a/crates/ruff_linter/src/rules/flake8_blind_except/snapshots/ruff_linter__rules__flake8_blind_except__tests__BLE001_BLE.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_blind_except/snapshots/ruff_linter__rules__flake8_blind_except__tests__BLE001_BLE.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_blind_except/mod.rs
-snapshot_kind: text
 ---
 BLE.py:25:8: BLE001 Do not catch blind exception: `BaseException`
    |
@@ -120,4 +119,31 @@ BLE.py:113:8: BLE001 Do not catch blind exception: `Exception`
 113 | except Exception:
     |        ^^^^^^^^^ BLE001
 114 |     error("...", exc_info=None)
+    |
+
+BLE.py:119:8: BLE001 Do not catch blind exception: `Exception`
+    |
+117 | try:
+118 |     pass
+119 | except Exception:
+    |        ^^^^^^^^^ BLE001
+120 |     critical("...")
+    |
+
+BLE.py:125:8: BLE001 Do not catch blind exception: `Exception`
+    |
+123 | try:
+124 |     pass
+125 | except Exception:
+    |        ^^^^^^^^^ BLE001
+126 |     critical("...", exc_info=False)
+    |
+
+BLE.py:131:8: BLE001 Do not catch blind exception: `Exception`
+    |
+129 | try:
+130 |     pass
+131 | except Exception:
+    |        ^^^^^^^^^ BLE001
+132 |     critical("...", exc_info=None)
     |


### PR DESCRIPTION
## Summary

Changing `BLE001` (blind-except) so that it does not flag `except` clauses which include `logging.critical(..., exc_info=True)`.

## Test Plan

It passes the following (whereas the `main` branch does not):
```sh
$ cargo run -p ruff -- check somefile.py --no-cache --select=BLE001
```
```python
# somefile.py

import logging


try:
    print("Hello world!")
except Exception:
    logging.critical("Did not run.", exc_info=True)
```
Related: https://github.com/astral-sh/ruff/issues/19519