### PR TITLE
[`pycodestyle`] Fix handling of format specs for `invalid-escape-sequence (W605`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pycodestyle/W605_1.py
+++ b/crates/ruff_linter/resources/test/fixtures/pycodestyle/W605_1.py
@@ -135,3 +135,12 @@ s = t"TOTAL: {total}\nOK: {ok}\INCOMPLETE: {incomplete}\n"
 
 # Debug text (should trigger)
 t = t"{'\InHere'=}"
+
+# https://github.com/astral-sh/ruff/issues/11491
+f"\n{a:\XFF}"
+f"\XFF{a:\XFF}"
+t"\n{a:\XFF}"
+t"\XFF{a:\XFF}"
+
+f"{a:\{1}\}"
+t"{a:\{1}\}"

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__W605_W605_1.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__W605_W605_1.py.snap
@@ -654,6 +654,8 @@ W605_1.py:137:9: W605 [*] Invalid escape sequence: `\I`
 136 | # Debug text (should trigger)
 137 | t = t"{'\InHere'=}"
     |         ^^ W605
+138 |
+139 | # https://github.com/astral-sh/ruff/issues/11491
     |
     = help: Use a raw string literal
 
@@ -663,3 +665,196 @@ W605_1.py:137:9: W605 [*] Invalid escape sequence: `\I`
 136 136 | # Debug text (should trigger)
 137     |-t = t"{'\InHere'=}"
     137 |+t = t"{r'\InHere'=}"
+138 138 | 
+139 139 | # https://github.com/astral-sh/ruff/issues/11491
+140 140 | f"\n{a:\XFF}"
+
+W605_1.py:140:8: W605 [*] Invalid escape sequence: `\X`
+    |
+139 | # https://github.com/astral-sh/ruff/issues/11491
+140 | f"\n{a:\XFF}"
+    |        ^^ W605
+141 | f"\XFF{a:\XFF}"
+142 | t"\n{a:\XFF}"
+    |
+    = help: Add backslash to escape sequence
+
+ℹ Safe fix
+137 137 | t = t"{'\InHere'=}"
+138 138 | 
+139 139 | # https://github.com/astral-sh/ruff/issues/11491
+140     |-f"\n{a:\XFF}"
+    140 |+f"\n{a:\\XFF}"
+141 141 | f"\XFF{a:\XFF}"
+142 142 | t"\n{a:\XFF}"
+143 143 | t"\XFF{a:\XFF}"
+
+W605_1.py:141:3: W605 [*] Invalid escape sequence: `\X`
+    |
+139 | # https://github.com/astral-sh/ruff/issues/11491
+140 | f"\n{a:\XFF}"
+141 | f"\XFF{a:\XFF}"
+    |   ^^ W605
+142 | t"\n{a:\XFF}"
+143 | t"\XFF{a:\XFF}"
+    |
+    = help: Use a raw string literal
+
+ℹ Safe fix
+138 138 | 
+139 139 | # https://github.com/astral-sh/ruff/issues/11491
+140 140 | f"\n{a:\XFF}"
+141     |-f"\XFF{a:\XFF}"
+    141 |+rf"\XFF{a:\XFF}"
+142 142 | t"\n{a:\XFF}"
+143 143 | t"\XFF{a:\XFF}"
+144 144 | 
+
+W605_1.py:141:10: W605 [*] Invalid escape sequence: `\X`
+    |
+139 | # https://github.com/astral-sh/ruff/issues/11491
+140 | f"\n{a:\XFF}"
+141 | f"\XFF{a:\XFF}"
+    |          ^^ W605
+142 | t"\n{a:\XFF}"
+143 | t"\XFF{a:\XFF}"
+    |
+    = help: Add backslash to escape sequence
+
+ℹ Safe fix
+138 138 | 
+139 139 | # https://github.com/astral-sh/ruff/issues/11491
+140 140 | f"\n{a:\XFF}"
+141     |-f"\XFF{a:\XFF}"
+    141 |+f"\XFF{a:\\XFF}"
+142 142 | t"\n{a:\XFF}"
+143 143 | t"\XFF{a:\XFF}"
+144 144 | 
+
+W605_1.py:142:8: W605 [*] Invalid escape sequence: `\X`
+    |
+140 | f"\n{a:\XFF}"
+141 | f"\XFF{a:\XFF}"
+142 | t"\n{a:\XFF}"
+    |        ^^ W605
+143 | t"\XFF{a:\XFF}"
+    |
+    = help: Add backslash to escape sequence
+
+ℹ Safe fix
+139 139 | # https://github.com/astral-sh/ruff/issues/11491
+140 140 | f"\n{a:\XFF}"
+141 141 | f"\XFF{a:\XFF}"
+142     |-t"\n{a:\XFF}"
+    142 |+t"\n{a:\\XFF}"
+143 143 | t"\XFF{a:\XFF}"
+144 144 | 
+145 145 | f"{a:\{1}\}"
+
+W605_1.py:143:3: W605 [*] Invalid escape sequence: `\X`
+    |
+141 | f"\XFF{a:\XFF}"
+142 | t"\n{a:\XFF}"
+143 | t"\XFF{a:\XFF}"
+    |   ^^ W605
+144 |
+145 | f"{a:\{1}\}"
+    |
+    = help: Use a raw string literal
+
+ℹ Safe fix
+140 140 | f"\n{a:\XFF}"
+141 141 | f"\XFF{a:\XFF}"
+142 142 | t"\n{a:\XFF}"
+143     |-t"\XFF{a:\XFF}"
+    143 |+rt"\XFF{a:\XFF}"
+144 144 | 
+145 145 | f"{a:\{1}\}"
+146 146 | t"{a:\{1}\}"
+
+W605_1.py:143:10: W605 [*] Invalid escape sequence: `\X`
+    |
+141 | f"\XFF{a:\XFF}"
+142 | t"\n{a:\XFF}"
+143 | t"\XFF{a:\XFF}"
+    |          ^^ W605
+144 |
+145 | f"{a:\{1}\}"
+    |
+    = help: Add backslash to escape sequence
+
+ℹ Safe fix
+140 140 | f"\n{a:\XFF}"
+141 141 | f"\XFF{a:\XFF}"
+142 142 | t"\n{a:\XFF}"
+143     |-t"\XFF{a:\XFF}"
+    143 |+t"\XFF{a:\\XFF}"
+144 144 | 
+145 145 | f"{a:\{1}\}"
+146 146 | t"{a:\{1}\}"
+
+W605_1.py:145:6: W605 [*] Invalid escape sequence: `\{`
+    |
+143 | t"\XFF{a:\XFF}"
+144 |
+145 | f"{a:\{1}\}"
+    |      ^^ W605
+146 | t"{a:\{1}\}"
+    |
+    = help: Use a raw string literal
+
+ℹ Safe fix
+142 142 | t"\n{a:\XFF}"
+143 143 | t"\XFF{a:\XFF}"
+144 144 | 
+145     |-f"{a:\{1}\}"
+    145 |+rf"{a:\{1}\}"
+146 146 | t"{a:\{1}\}"
+
+W605_1.py:145:10: W605 [*] Invalid escape sequence: `\}`
+    |
+143 | t"\XFF{a:\XFF}"
+144 |
+145 | f"{a:\{1}\}"
+    |          ^^ W605
+146 | t"{a:\{1}\}"
+    |
+    = help: Use a raw string literal
+
+ℹ Safe fix
+142 142 | t"\n{a:\XFF}"
+143 143 | t"\XFF{a:\XFF}"
+144 144 | 
+145     |-f"{a:\{1}\}"
+    145 |+rf"{a:\{1}\}"
+146 146 | t"{a:\{1}\}"
+
+W605_1.py:146:6: W605 [*] Invalid escape sequence: `\{`
+    |
+145 | f"{a:\{1}\}"
+146 | t"{a:\{1}\}"
+    |      ^^ W605
+    |
+    = help: Use a raw string literal
+
+ℹ Safe fix
+143 143 | t"\XFF{a:\XFF}"
+144 144 | 
+145 145 | f"{a:\{1}\}"
+146     |-t"{a:\{1}\}"
+    146 |+rt"{a:\{1}\}"
+
+W605_1.py:146:10: W605 [*] Invalid escape sequence: `\}`
+    |
+145 | f"{a:\{1}\}"
+146 | t"{a:\{1}\}"
+    |          ^^ W605
+    |
+    = help: Use a raw string literal
+
+ℹ Safe fix
+143 143 | t"\XFF{a:\XFF}"
+144 144 | 
+145 145 | f"{a:\{1}\}"
+146     |-t"{a:\{1}\}"
+    146 |+rt"{a:\{1}\}"


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

This PR fixes #11491, cleaning up the last of the interpolated string related issues with [invalid-escape-sequence (W605)](https://docs.astral.sh/ruff/rules/invalid-escape-sequence/#invalid-escape-sequence-w605). Interpolated string format specs behave very strangely, in that their contents are not affected by the raw-ness of their containing string, unless they are adjacent to a `{` or `}`, in which case they are affected.

The fix functions by separating out all of the non-raw-affected escapes into their own vec, since the only option for them is to be escaped via adding another `\`. The edge cases of `{` and `}` adjacent `\`s are left with the rest of the invalid escapes.

Passing the inside-format-spec-ness via a bool is a bit ugly, but I could not think of a better solution. Ideas welcome.

## Test Plan

<!-- How was it tested? -->

Added 4 new test cases for the non-`{`-`}` edge cases, and 2 other new test cases for those edge cases.