### PR TITLE
[ty] Ignore 'apprise' for ecosystem checks

### DIFF
--- a/crates/ty_python_semantic/resources/primer/good.txt
+++ b/crates/ty_python_semantic/resources/primer/good.txt
@@ -12,7 +12,6 @@ alectryon
 alerta
 altair
 anyio
-apprise
 async-utils
 asynq
 attrs

--- a/crates/ty_python_semantic/resources/primer/ignored.txt
+++ b/crates/ty_python_semantic/resources/primer/ignored.txt
@@ -1,0 +1,11 @@
+This file lists mypy_primer projects that we do not to test on:
+
+apprise:
+
+  This project has outdated (and completely wrong) stub files that
+  frequently lead to very confusing errors (usually true positives).
+  Evaluating ecosystem impact on this project is therefore irritating
+  and usually not very helpful.
+
+  [1] https://github.com/caronc/apprise/issues/1211
+  [2] https://github.com/caronc/apprise/blob/91faed0c6d22b49e7f31bc9dec1c8742f52a0aa3/apprise/config/base.pyi


### PR DESCRIPTION
## Summary

The `apprise` project has outdated (and completely wrong) stub files that frequently lead to very confusing errors (usually true positives). Evaluating ecosystem impact on this project is therefore irritating and usually not very helpful. I've wasted a lot of time looking through ecosystem diffs on this project (until I remember — oh, it's "apprise"), and I don't think that it was ever helpful. I therefore suggest to skip evaluating on `apprise`. If there are no objections, we can also think about removing that project upstream (in `mypy_primer`).

[1] https://github.com/caronc/apprise/issues/1211
[2] https://github.com/caronc/apprise/blob/91faed0c6d22b49e7f31bc9dec1c8742f52a0aa3/apprise/config/base.pyi

