### PR TITLE
[ty] Add workflow to comment diagnostic diff for conformance tests

### DIFF
--- a/.github/workflows/typing_conformance_comment.yaml
+++ b/.github/workflows/typing_conformance_comment.yaml
@@ -1,0 +1,97 @@
+name: PR comment (typing_conformance)
+
+on: # zizmor: ignore[dangerous-triggers]
+  workflow_run:
+    workflows: [Run typing conformance]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      workflow_run_id:
+        description: The typing_conformance workflow that triggers the workflow run
+        required: true
+
+jobs:
+  comment:
+    runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: dawidd6/action-download-artifact@20319c5641d495c8a52e688b7dc5fada6c3a9fbc # v8
+        name: Download PR number
+        with:
+          name: pr-number
+          run_id: ${{ github.event.workflow_run.id ||  github.event.inputs.workflow_run_id }}
+          if_no_artifact_found: ignore
+          allow_forks: true
+
+      - name: Parse pull request number
+        id: pr-number
+        run: |
+          if [[ -f pr-number ]]
+          then
+            echo "pr-number=$(<pr-number)" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: dawidd6/action-download-artifact@20319c5641d495c8a52e688b7dc5fada6c3a9fbc # v8
+        name: "Download typing_conformance results"
+        id: download-typing_conformance_diff
+        if: steps.pr-number.outputs.pr-number
+        with:
+          name: typing_conformance_diagnostics_diff
+          workflow: typing_conformance.yaml
+          pr: ${{ steps.pr-number.outputs.pr-number }}
+          path: pr/typing_conformance_diagnostics_diff
+          workflow_conclusion: completed
+          if_no_artifact_found: ignore
+          allow_forks: true
+
+      - name: Generate comment content
+        id: generate-comment
+        if: ${{ steps.download-typing_conformance_diff.outputs.found_artifact == 'true' }}
+        run: |
+          # Guard against malicious typing_conformance results that symlink to a secret
+          # file on this runner
+          if [[ -L pr/typing_conformance_diagnostics_diff/typing_conformance_diagnostics.diff ]]
+          then
+              echo "Error: typing_conformance_diagnostics.diff cannot be a symlink"
+              exit 1
+          fi
+
+          # Note this identifier is used to find the comment to update on
+          # subsequent runs
+          echo '<!-- generated-comment typing_conformance_diagnostics_diff -->' >> comment.txt
+
+          echo '## Diagnostic diff on typing conformance tests' >> comment.txt
+          if [ -s "pr/typing_conformance_diagnostics_diff/typing_conformance_diagnostics.diff" ]; then
+            echo '<details>' >> comment.txt
+            echo '<summary>Changes were detected when running ty on typing conformance tests</summary>' >> comment.txt
+            echo '' >> comment.txt
+            echo '```diff' >> comment.txt
+            cat pr/typing_conformance_diagnostics_diff/typing_conformance_diagnostics.diff >> comment.txt
+            echo '```' >> comment.txt
+            echo '</details>' >> comment.txt
+          else
+            echo 'No changes detected when running ty on typing conformance tests ✅' >> comment.txt
+          fi
+
+          echo 'comment<<EOF' >> "$GITHUB_OUTPUT"
+          cat comment.txt >> "$GITHUB_OUTPUT"
+          echo 'EOF' >> "$GITHUB_OUTPUT"
+
+      - name: Find existing comment
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
+        if: steps.generate-comment.outcome == 'success'
+        id: find-comment
+        with:
+          issue-number: ${{ steps.pr-number.outputs.pr-number }}
+          comment-author: "github-actions[bot]"
+          body-includes: "<!-- generated-comment typing_conformance_diagnostics_diff -->"
+
+      - name: Create or update comment
+        if: steps.find-comment.outcome == 'success'
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ steps.pr-number.outputs.pr-number }}
+          body-path: comment.txt
+          edit-mode: replace


### PR DESCRIPTION
## Summary

This PR adds a workflow to comment the diff of diagnostics when running ty between `main` and a pull request on the [typing conformance test suite](https://github.com/python/typing/tree/main/conformance/tests).

The main workflow is introduced in https://github.com/astral-sh/ruff/pull/19555 which this workflow depends on. This workflow is similar to the [mypy primer comment](https://github.com/astral-sh/ruff/blob/d781a6ab3f44afe5dd1afe1d06fb58fd3739fab5/.github/workflows/mypy_primer_comment.yaml) workflow.

## Test Plan

I cannot test this workflow without merging it on `main` unless anyone knows a way to do this.
