### PR TITLE
[ty] Don't include already-bound legacy typevars in function generic context

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -457,6 +457,10 @@ reveal_type(generic_context(C[int].generic_method))  # revealed: tuple[T, U]
 
 c: C[int] = C[int]()
 reveal_type(c.generic_method(1, "string"))  # revealed: Literal["string"]
+reveal_type(generic_context(c))  # revealed: None
+reveal_type(generic_context(c.method))  # revealed: None
+# TODO: revealed: tuple[U]
+reveal_type(generic_context(c.generic_method))  # revealed: tuple[T, U]
 ```
 
 ## Specializations propagate

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -433,17 +433,30 @@ the typevars of the enclosing generic class, and introduce new (distinct) typeva
 scope for the method.
 
 ```py
+from ty_extensions import generic_context
 from typing import Generic, TypeVar
 
 T = TypeVar("T")
 U = TypeVar("U")
 
 class C(Generic[T]):
-    def method(self, u: U) -> U:
+    def method(self, u: int) -> int:
         return u
 
+    def generic_method(self, t: T, u: U) -> U:
+        return u
+
+reveal_type(generic_context(C))  # revealed: tuple[T]
+reveal_type(generic_context(C.method))  # revealed: None
+# TODO: revealed: tuple[U]
+reveal_type(generic_context(C.generic_method))  # revealed: tuple[T, U]
+reveal_type(generic_context(C[int]))  # revealed: None
+reveal_type(generic_context(C[int].method))  # revealed: None
+# TODO: revealed: tuple[U]
+reveal_type(generic_context(C[int].generic_method))  # revealed: tuple[T, U]
+
 c: C[int] = C[int]()
-reveal_type(c.method("string"))  # revealed: Literal["string"]
+reveal_type(c.generic_method(1, "string"))  # revealed: Literal["string"]
 ```
 
 ## Specializations propagate

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -448,19 +448,16 @@ class C(Generic[T]):
 
 reveal_type(generic_context(C))  # revealed: tuple[T]
 reveal_type(generic_context(C.method))  # revealed: None
-# TODO: revealed: tuple[U]
-reveal_type(generic_context(C.generic_method))  # revealed: tuple[T, U]
+reveal_type(generic_context(C.generic_method))  # revealed: tuple[U]
 reveal_type(generic_context(C[int]))  # revealed: None
 reveal_type(generic_context(C[int].method))  # revealed: None
-# TODO: revealed: tuple[U]
-reveal_type(generic_context(C[int].generic_method))  # revealed: tuple[T, U]
+reveal_type(generic_context(C[int].generic_method))  # revealed: tuple[U]
 
 c: C[int] = C[int]()
 reveal_type(c.generic_method(1, "string"))  # revealed: Literal["string"]
 reveal_type(generic_context(c))  # revealed: None
 reveal_type(generic_context(c.method))  # revealed: None
-# TODO: revealed: tuple[U]
-reveal_type(generic_context(c.generic_method))  # revealed: tuple[T, U]
+reveal_type(generic_context(c.generic_method))  # revealed: tuple[U]
 ```
 
 ## Specializations propagate

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
@@ -415,6 +415,9 @@ reveal_type(generic_context(C[int].generic_method))  # revealed: tuple[U]
 
 c: C[int] = C[int]()
 reveal_type(c.generic_method(1, "string"))  # revealed: Literal["string"]
+reveal_type(generic_context(c))  # revealed: None
+reveal_type(generic_context(c.method))  # revealed: None
+reveal_type(generic_context(c.generic_method))  # revealed: tuple[U]
 ```
 
 ## Specializations propagate

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
@@ -392,8 +392,13 @@ the typevars of the enclosing generic class, and introduce new (distinct) typeva
 scope for the method.
 
 ```py
+from ty_extensions import generic_context
+
 class C[T]:
-    def method[U](self, u: U) -> U:
+    def method(self, u: int) -> int:
+        return u
+
+    def generic_method[U](self, t: T, u: U) -> U:
         return u
     # error: [unresolved-reference]
     def cannot_use_outside_of_method(self, u: U): ...
@@ -401,8 +406,15 @@ class C[T]:
     # TODO: error
     def cannot_shadow_class_typevar[T](self, t: T): ...
 
+reveal_type(generic_context(C))  # revealed: tuple[T]
+reveal_type(generic_context(C.method))  # revealed: None
+reveal_type(generic_context(C.generic_method))  # revealed: tuple[U]
+reveal_type(generic_context(C[int]))  # revealed: None
+reveal_type(generic_context(C[int].method))  # revealed: None
+reveal_type(generic_context(C[int].generic_method))  # revealed: tuple[U]
+
 c: C[int] = C[int]()
-reveal_type(c.method("string"))  # revealed: Literal["string"]
+reveal_type(c.generic_method(1, "string"))  # revealed: Literal["string"]
 ```
 
 ## Specializations propagate

--- a/crates/ty_python_semantic/resources/mdtest/generics/scoping.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/scoping.md
@@ -141,8 +141,16 @@ class Legacy(Generic[T]):
     def m(self, x: T, y: S) -> S:
         return y
 
-legacy: Legacy[int] = Legacy()
+legacy: Legacy[int] = Legacy[int]()
 reveal_type(legacy.m(1, "string"))  # revealed: Literal["string"]
+```
+
+The class typevar in the method signature does not bind a _new_ instance of the typevar; it was
+already solved and specialized when the class was specialized:
+
+```py
+legacy.m("string", None)  # error: [invalid-argument-type]
+reveal_type(legacy.m)  # revealed: bound method Legacy[int].m(x: int, y: S) -> S
 ```
 
 With PEP 695 syntax, it is clearer that the method uses a separate typevar:

--- a/crates/ty_python_semantic/resources/mdtest/generics/scoping.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/scoping.md
@@ -149,8 +149,13 @@ The class typevar in the method signature does not bind a _new_ instance of the 
 already solved and specialized when the class was specialized:
 
 ```py
+from ty_extensions import generic_context
+
 legacy.m("string", None)  # error: [invalid-argument-type]
 reveal_type(legacy.m)  # revealed: bound method Legacy[int].m(x: int, y: S) -> S
+reveal_type(generic_context(Legacy))  # revealed: tuple[T]
+# TODO: revealed: tuple[S]
+reveal_type(generic_context(legacy.m))  # revealed: tuple[T, S]
 ```
 
 With PEP 695 syntax, it is clearer that the method uses a separate typevar:

--- a/crates/ty_python_semantic/resources/mdtest/generics/scoping.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/scoping.md
@@ -154,8 +154,7 @@ from ty_extensions import generic_context
 legacy.m("string", None)  # error: [invalid-argument-type]
 reveal_type(legacy.m)  # revealed: bound method Legacy[int].m(x: int, y: S) -> S
 reveal_type(generic_context(Legacy))  # revealed: tuple[T]
-# TODO: revealed: tuple[S]
-reveal_type(generic_context(legacy.m))  # revealed: tuple[T, S]
+reveal_type(generic_context(legacy.m))  # revealed: tuple[S]
 ```
 
 With PEP 695 syntax, it is clearer that the method uses a separate typevar:

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -643,9 +643,9 @@ impl<'db> Bindings<'db> {
                                 // TODO: Handle generic functions, and unions/intersections of
                                 // generic types
                                 overload.set_return_type(match ty {
-                                    Type::ClassLiteral(class) => (class.generic_context(db))
+                                    Type::ClassLiteral(class) => class.generic_context(db)
                                         .map(|generic_context| generic_context.as_tuple(db))
-                                        .unwrap_or(Type::none(db)),
+                                        .unwrap_or_else(|| Type::none(db)),
 
                                     Type::FunctionLiteral(function) => {
                                         function_generic_context(*function)

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -643,7 +643,8 @@ impl<'db> Bindings<'db> {
                                 // TODO: Handle generic functions, and unions/intersections of
                                 // generic types
                                 overload.set_return_type(match ty {
-                                    Type::ClassLiteral(class) => class.generic_context(db)
+                                    Type::ClassLiteral(class) => class
+                                        .generic_context(db)
                                         .map(|generic_context| generic_context.as_tuple(db))
                                         .unwrap_or_else(|| Type::none(db)),
 

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -332,18 +332,28 @@ impl<'db> OverloadLiteral<'db> {
         db: &'db dyn Db,
         inherited_generic_context: Option<GenericContext<'db>>,
     ) -> Signature<'db> {
-        let scope = self.body_scope(db);
-        let module = parsed_module(db, self.file(db)).load(db);
-        let function_stmt_node = scope.node(db).expect_function(&module);
-        let definition = self.definition(db);
-        let generic_context = function_stmt_node.type_params.as_ref().map(|type_params| {
-            let index = semantic_index(db, scope.file(db));
-            GenericContext::from_type_params(db, index, type_params)
-        });
+        let body_scope = self.body_scope(db);
+        let body_node = body_scope.node(db);
+        let file = body_scope.file(db);
+        let module = parsed_module(db, file).load(db);
+        let function_stmt_node = body_node.expect_function(&module);
+        let index = semantic_index(db, file);
+        let definition = index.expect_single_definition(function_stmt_node);
+        let containing_scope = index
+            .parent_scope_id(body_scope.file_scope_id(db))
+            .expect("function definition should not be top-most scope");
+
+        let generic_context = function_stmt_node
+            .type_params
+            .as_ref()
+            .map(|type_params| GenericContext::from_type_params(db, index, type_params));
         Signature::from_function(
             db,
             generic_context,
             inherited_generic_context,
+            &module,
+            index,
+            containing_scope,
             definition,
             function_stmt_node,
         )

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -171,6 +171,16 @@ impl<'db> GenericContext<'db> {
         self.specialize(db, types.into())
     }
 
+    /// Returns a tuple type of the typevars introduced by this generic context.
+    pub(crate) fn as_tuple(self, db: &'db dyn Db) -> Type<'db> {
+        TupleType::from_elements(
+            db,
+            self.variables(db)
+                .iter()
+                .map(|typevar| Type::TypeVar(*typevar)),
+        )
+    }
+
     pub(crate) fn is_subset_of(self, db: &'db dyn Db, other: GenericContext<'db>) -> bool {
         self.variables(db).is_subset(other.variables(db))
     }

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -387,9 +387,9 @@ pub(crate) fn nearest_enclosing_class<'db>(
 
 /// Returns in iterator of any generic context introduced by the given scope or any enclosing
 /// scope.
-pub(crate) fn enclosing_generic_contexts<'ast, 'db>(
+pub(crate) fn enclosing_generic_contexts<'db>(
     db: &'db dyn Db,
-    module: &'ast ParsedModuleRef,
+    module: &ParsedModuleRef,
     index: &SemanticIndex<'db>,
     scope: FileScopeId,
 ) -> impl Iterator<Item = GenericContext<'db>> {
@@ -415,9 +415,9 @@ pub(crate) fn enclosing_generic_contexts<'ast, 'db>(
 }
 
 /// Returns the legacy typevars that have been bound in the given scope or any enclosing scope.
-pub(crate) fn bound_legacy_typevars<'ast, 'db>(
+pub(crate) fn bound_legacy_typevars<'db>(
     db: &'db dyn Db,
-    module: &'ast ParsedModuleRef,
+    module: &ParsedModuleRef,
     index: &'db SemanticIndex<'db>,
     scope: FileScopeId,
 ) -> impl Iterator<Item = TypeVarInstance<'db>> {

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -385,7 +385,7 @@ pub(crate) fn nearest_enclosing_class<'db>(
         })
 }
 
-/// Returns in iterator of any generic context introduced by the given scope or any enclosing
+/// Returns an iterator of any generic context introduced by the given scope or any enclosing
 /// scope.
 pub(crate) fn enclosing_generic_contexts<'db>(
     db: &'db dyn Db,

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -385,47 +385,6 @@ pub(crate) fn nearest_enclosing_class<'db>(
         })
 }
 
-/// Returns an iterator of any generic context introduced by the given scope or any enclosing
-/// scope.
-pub(crate) fn enclosing_generic_contexts<'db>(
-    db: &'db dyn Db,
-    module: &ParsedModuleRef,
-    index: &SemanticIndex<'db>,
-    scope: FileScopeId,
-) -> impl Iterator<Item = GenericContext<'db>> {
-    index
-        .ancestor_scopes(scope)
-        .filter_map(|(_, ancestor_scope)| match ancestor_scope.node() {
-            NodeWithScopeKind::Class(class) => {
-                binding_type(db, index.expect_single_definition(class.node(module)))
-                    .into_class_literal()?
-                    .generic_context(db)
-            }
-            NodeWithScopeKind::Function(function) => {
-                binding_type(db, index.expect_single_definition(function.node(module)))
-                    .into_function_literal()?
-                    .signature(db)
-                    .iter()
-                    .last()
-                    .expect("function should have at least one overload")
-                    .generic_context
-            }
-            _ => None,
-        })
-}
-
-/// Returns the legacy typevars that have been bound in the given scope or any enclosing scope.
-pub(crate) fn bound_legacy_typevars<'db>(
-    db: &'db dyn Db,
-    module: &ParsedModuleRef,
-    index: &'db SemanticIndex<'db>,
-    scope: FileScopeId,
-) -> impl Iterator<Item = TypeVarInstance<'db>> {
-    enclosing_generic_contexts(db, module, index, scope)
-        .flat_map(|generic_context| generic_context.variables(db).iter().copied())
-        .filter(|typevar| typevar.is_legacy(db))
-}
-
 /// A region within which we can infer types.
 #[derive(Copy, Clone, Debug)]
 pub(crate) enum InferenceRegion<'db> {

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -317,6 +317,7 @@ impl<'db> Signature<'db> {
     }
 
     /// Return a typed signature from a function definition.
+    #[expect(clippy::too_many_arguments)]
     pub(super) fn from_function(
         db: &'db dyn Db,
         generic_context: Option<GenericContext<'db>>,


### PR DESCRIPTION
We now correctly exclude legacy typevars from enclosing scopes when constructing the generic context for a generic function.

more detail:

A function is generic if it refers to legacy typevars in its signature:

```py
from typing import TypeVar

T = TypeVar("T")

def f(t: T) -> T:
    return t
```

Generic functions are allowed to appear inside of other generic contexts. When they do, they can refer to the typevars of those enclosing generic contexts, and that should not rebind the typevar:

```py
from typing import TypeVar, Generic

T = TypeVar("T")
U = TypeVar("U")

class C(Generic[T]):
    @staticmethod
    def method(t: T, u: U) -> None: ...

# revealed: def method(t: int, u: U) -> None
reveal_type(C[int].method)
```

This substitution was already being performed correctly, but we were also still including the enclosing legacy typevars in the method's own generic context, which can be seen via `ty_extensions.generic_context` (which has been updated to work on generic functions and methods):

```py
from ty_extensions import generic_context

# before: tuple[T, U]
# after: tuple[U]
reveal_type(generic_context(C[int].method))
```

