### PR TITLE
Add `TextEmitter::with_color` and disable colors in `unreadable_files` test

### DIFF
--- a/crates/ruff/src/commands/check.rs
+++ b/crates/ruff/src/commands/check.rs
@@ -279,6 +279,7 @@ mod test {
 
         TextEmitter::default()
             .with_show_fix_status(true)
+            .with_color(false)
             .emit(
                 &mut output,
                 &diagnostics.inner,

--- a/crates/ruff_linter/src/message/text.rs
+++ b/crates/ruff_linter/src/message/text.rs
@@ -76,6 +76,12 @@ impl TextEmitter {
         self.config = self.config.preview(preview);
         self
     }
+
+    #[must_use]
+    pub fn with_color(mut self, color: bool) -> Self {
+        self.config = self.config.color(color);
+        self
+    }
 }
 
 impl Emitter for TextEmitter {


### PR DESCRIPTION
Summary
--

I looked at other uses of `TextEmitter`, and I think this should be the only one affected by this. The other integration tests must work properly since they're run with `assert_cmd_snapshot!`, which I assume triggers the `SHOULD_COLORIZE` case, and the `cfg!(test)` check will work for uses in `ruff_linter`.

https://github.com/astral-sh/ruff/blob/4a4dc38b5b5055601dcb8da4ad07720e47d451fa/crates/ruff_linter/src/message/text.rs#L36-L44

Alternatively, we could probably move this to a CLI test instead.

Test Plan
--

`cargo test -p ruff`, which was failing on `main` with color codes in the output before this