### PR TITLE
Reword preview warning for `target-version` Python 3.14

### DIFF
--- a/crates/ruff_linter/src/linter.rs
+++ b/crates/ruff_linter/src/linter.rs
@@ -473,7 +473,7 @@ pub fn lint_only(
         && !is_py314_support_enabled(settings)
     {
         warn_user_once!(
-            "Support for Python 3.14 is under development and may be unstable. Enable `preview` to remove this warning."
+            "Support for Python 3.14 is in preview and may undergo breaking changes. Enable `preview` to remove this warning."
         );
     }
 
@@ -584,7 +584,7 @@ pub fn lint_fix<'a>(
         && !is_py314_support_enabled(settings)
     {
         warn_user_once!(
-            "Support for Python 3.14 is under development and may be unstable. Enable `preview` to remove this warning."
+            "Support for Python 3.14 is in preview and may undergo breaking changes. Enable `preview` to remove this warning."
         );
     }
 


### PR DESCRIPTION
Small rewording to indicate that core development is done but that we may add breaking changes.

Feel free to bikeshed!

Test:

```console
❯ echo "t''" | cargo run -p ruff -- check --no-cache --isolated --target-version py314 -
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.13s
     Running `target/debug/ruff check --no-cache --isolated --target-version py314 -`
warning: Support for Python 3.14 is in preview and may undergo breaking changes. Enable `preview` to remove this warning.
All checks passed!
```
