### PR TITLE
[`flake8_comprehensions`] Fix `C409` to preserve trailing commas in tuple calls

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_comprehensions/C409.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_comprehensions/C409.py
@@ -42,3 +42,6 @@ tuple(
         x for x in [1,2,3]
     }
 )
+
+t9 = tuple([1],)
+t10 = tuple([1, 2],)

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C409_C409.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C409_C409.py.snap
@@ -203,7 +203,7 @@ C409.py:24:6: C409 [*] Unnecessary list literal passed to `tuple()` (rewrite as 
 22 22 | ))
 23 23 | 
 24    |-t6 = tuple([1])
-   24 |+t6 = (1,)
+   24 |+t6 = (1)
 25 25 | t7 = tuple((1,))
 26 26 | t8 = tuple([1,])
 27 27 | 
@@ -247,3 +247,36 @@ C409.py:26:6: C409 [*] Unnecessary list literal passed to `tuple()` (rewrite as 
 27 27 | 
 28 28 | tuple([x for x in range(5)])
 29 29 | tuple({x for x in range(10)})
+
+C409.py:46:6: C409 [*] Unnecessary list literal passed to `tuple()` (rewrite as a tuple literal)
+   |
+44 | )
+45 |
+46 | t9 = tuple([1],)
+   |      ^^^^^^^^^^^ C409
+47 | t10 = tuple([1, 2],)
+   |
+   = help: Rewrite as a tuple literal
+
+ℹ Unsafe fix
+43 43 |     }
+44 44 | )
+45 45 | 
+46    |-t9 = tuple([1],)
+   46 |+t9 = (1,)
+47 47 | t10 = tuple([1, 2],)
+
+C409.py:47:7: C409 [*] Unnecessary list literal passed to `tuple()` (rewrite as a tuple literal)
+   |
+46 | t9 = tuple([1],)
+47 | t10 = tuple([1, 2],)
+   |       ^^^^^^^^^^^^^^ C409
+   |
+   = help: Rewrite as a tuple literal
+
+ℹ Unsafe fix
+44 44 | )
+45 45 | 
+46 46 | t9 = tuple([1],)
+47    |-t10 = tuple([1, 2],)
+   47 |+t10 = (1, 2,)

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__preview__C409_C409.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__preview__C409_C409.py.snap
@@ -203,7 +203,7 @@ C409.py:24:6: C409 [*] Unnecessary list literal passed to `tuple()` (rewrite as 
 22 22 | ))
 23 23 | 
 24    |-t6 = tuple([1])
-   24 |+t6 = (1,)
+   24 |+t6 = (1)
 25 25 | t7 = tuple((1,))
 26 26 | t8 = tuple([1,])
 27 27 | 
@@ -344,3 +344,36 @@ C409.py:37:1: C409 [*] Unnecessary list comprehension passed to `tuple()` (rewri
 41 41 |     {
 42 42 |         x for x in [1,2,3]
 43 43 |     }
+
+C409.py:46:6: C409 [*] Unnecessary list literal passed to `tuple()` (rewrite as a tuple literal)
+   |
+44 | )
+45 |
+46 | t9 = tuple([1],)
+   |      ^^^^^^^^^^^ C409
+47 | t10 = tuple([1, 2],)
+   |
+   = help: Rewrite as a tuple literal
+
+ℹ Unsafe fix
+43 43 |     }
+44 44 | )
+45 45 | 
+46    |-t9 = tuple([1],)
+   46 |+t9 = (1,)
+47 47 | t10 = tuple([1, 2],)
+
+C409.py:47:7: C409 [*] Unnecessary list literal passed to `tuple()` (rewrite as a tuple literal)
+   |
+46 | t9 = tuple([1],)
+47 | t10 = tuple([1, 2],)
+   |       ^^^^^^^^^^^^^^ C409
+   |
+   = help: Rewrite as a tuple literal
+
+ℹ Unsafe fix
+44 44 | )
+45 45 | 
+46 46 | t9 = tuple([1],)
+47    |-t10 = tuple([1, 2],)
+   47 |+t10 = (1, 2,)


### PR DESCRIPTION
## Summary

Fixes #19568
