### PR TITLE
[ty] Minor: test isolation

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/function/return_type.md
+++ b/crates/ty_python_semantic/resources/mdtest/function/return_type.md
@@ -433,6 +433,8 @@ def f(cond: bool) -> str:
 
 <!-- snapshot-diagnostics -->
 
+### Synchronous
+
 A function with a `yield` or `yield from` expression anywhere in its body is a
 [generator function](https://docs.python.org/3/glossary.html#term-generator). A generator function
 implicitly returns an instance of `types.GeneratorType` even if it does not contain any `return`
@@ -460,6 +462,8 @@ def i2() -> typing.Generator:
 def j() -> str:  # error: [invalid-return-type]
     yield 42
 ```
+
+### Asynchronous
 
 If it is an `async` function with a `yield` statement in its body, it is an
 [asynchronous generator function](https://docs.python.org/3/glossary.html#term-asynchronous-generator).

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Generator_functions_-_Asynchronous_(408134055c24a538).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Generator_functions_-_Asynchronous_(408134055c24a538).snap
@@ -1,0 +1,50 @@
+---
+source: crates/ty_test/src/lib.rs
+expression: snapshot
+---
+---
+mdtest name: return_type.md - Function return type - Generator functions - Asynchronous
+mdtest path: crates/ty_python_semantic/resources/mdtest/function/return_type.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+ 1 | import types
+ 2 | import typing
+ 3 | 
+ 4 | async def f() -> types.AsyncGeneratorType:
+ 5 |     yield 42
+ 6 | 
+ 7 | async def g() -> typing.AsyncGenerator:
+ 8 |     yield 42
+ 9 | 
+10 | async def h() -> typing.AsyncIterator:
+11 |     yield 42
+12 | 
+13 | async def i() -> typing.AsyncIterable:
+14 |     yield 42
+15 | 
+16 | async def j() -> str:  # error: [invalid-return-type]
+17 |     yield 42
+```
+
+# Diagnostics
+
+```
+error[invalid-return-type]: Return type does not match returned value
+  --> src/mdtest_snippet.py:16:18
+   |
+14 |     yield 42
+15 |
+16 | async def j() -> str:  # error: [invalid-return-type]
+   |                  ^^^ expected `str`, found `types.AsyncGeneratorType`
+17 |     yield 42
+   |
+info: Function is inferred as returning `types.AsyncGeneratorType` because it is an async generator function
+info: See https://docs.python.org/3/glossary.html#term-asynchronous-generator for more details
+info: rule `invalid-return-type` is enabled by default
+
+```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Generator_functions_-_Synchronous_(6a32ec69d15117b8).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Generator_functions_-_Synchronous_(6a32ec69d15117b8).snap
@@ -3,7 +3,7 @@ source: crates/ty_test/src/lib.rs
 expression: snapshot
 ---
 ---
-mdtest name: return_type.md - Function return type - Generator functions
+mdtest name: return_type.md - Function return type - Generator functions - Synchronous
 mdtest path: crates/ty_python_semantic/resources/mdtest/function/return_type.md
 ---
 
@@ -32,23 +32,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/function/return_type.md
 18 | 
 19 | def j() -> str:  # error: [invalid-return-type]
 20 |     yield 42
-21 | import types
-22 | import typing
-23 | 
-24 | async def f() -> types.AsyncGeneratorType:
-25 |     yield 42
-26 | 
-27 | async def g() -> typing.AsyncGenerator:
-28 |     yield 42
-29 | 
-30 | async def h() -> typing.AsyncIterator:
-31 |     yield 42
-32 | 
-33 | async def i() -> typing.AsyncIterable:
-34 |     yield 42
-35 | 
-36 | async def j() -> str:  # error: [invalid-return-type]
-37 |     yield 42
 ```
 
 # Diagnostics
@@ -62,26 +45,9 @@ error[invalid-return-type]: Return type does not match returned value
 19 | def j() -> str:  # error: [invalid-return-type]
    |            ^^^ expected `str`, found `types.GeneratorType`
 20 |     yield 42
-21 | import types
    |
 info: Function is inferred as returning `types.GeneratorType` because it is a generator function
 info: See https://docs.python.org/3/glossary.html#term-generator for more details
-info: rule `invalid-return-type` is enabled by default
-
-```
-
-```
-error[invalid-return-type]: Return type does not match returned value
-  --> src/mdtest_snippet.py:36:18
-   |
-34 |     yield 42
-35 |
-36 | async def j() -> str:  # error: [invalid-return-type]
-   |                  ^^^ expected `str`, found `types.AsyncGeneratorType`
-37 |     yield 42
-   |
-info: Function is inferred as returning `types.AsyncGeneratorType` because it is an async generator function
-info: See https://docs.python.org/3/glossary.html#term-asynchronous-generator for more details
 info: rule `invalid-return-type` is enabled by default
 
 ```


### PR DESCRIPTION
## Summary

Split the "Generator functions" tests into two parts. The first part (synchronous) refers to a function called `i` from a function `i2`. But `i` is later redeclared in the asynchronous part, which was probably not intended.