### PR TITLE
[ty] Remove `AssertUnwindSafe` from `BackgroundRequestHandler` api

### DIFF
--- a/crates/ty_server/src/server/api.rs
+++ b/crates/ty_server/src/server/api.rs
@@ -218,7 +218,10 @@ where
                 return;
             }
 
-            let result = ruff_db::panic::catch_unwind(|| R::run(snapshot, client, params));
+            let result = ruff_db::panic::catch_unwind(|| {
+                let snapshot = snapshot;
+                R::run(snapshot.0, client, params)
+            });
 
             if let Some(response) = request_result_to_response::<R>(&id, client, result, retry) {
                 respond::<R>(&id, response, client);

--- a/crates/ty_server/src/server/api/requests/workspace_diagnostic.rs
+++ b/crates/ty_server/src/server/api/requests/workspace_diagnostic.rs
@@ -1,5 +1,3 @@
-use std::panic::AssertUnwindSafe;
-
 use lsp_types::request::WorkspaceDiagnosticRequest;
 use lsp_types::{
     FullDocumentDiagnosticReport, Url, WorkspaceDiagnosticParams, WorkspaceDiagnosticReport,
@@ -25,7 +23,7 @@ impl RequestHandler for WorkspaceDiagnosticRequestHandler {
 
 impl BackgroundRequestHandler for WorkspaceDiagnosticRequestHandler {
     fn run(
-        snapshot: AssertUnwindSafe<SessionSnapshot>,
+        snapshot: SessionSnapshot,
         _client: &Client,
         _params: WorkspaceDiagnosticParams,
     ) -> Result<WorkspaceDiagnosticReportResult> {

--- a/crates/ty_server/src/server/api/requests/workspace_symbols.rs
+++ b/crates/ty_server/src/server/api/requests/workspace_symbols.rs
@@ -1,5 +1,3 @@
-use std::panic::AssertUnwindSafe;
-
 use lsp_types::request::WorkspaceSymbolRequest;
 use lsp_types::{WorkspaceSymbolParams, WorkspaceSymbolResponse};
 use ty_ide::{WorkspaceSymbolInfo, workspace_symbols};
@@ -21,7 +19,7 @@ impl RequestHandler for WorkspaceSymbolRequestHandler {
 
 impl BackgroundRequestHandler for WorkspaceSymbolRequestHandler {
     fn run(
-        snapshot: AssertUnwindSafe<SessionSnapshot>,
+        snapshot: SessionSnapshot,
         _client: &Client,
         params: WorkspaceSymbolParams,
     ) -> crate::server::Result<Option<WorkspaceSymbolResponse>> {

--- a/crates/ty_server/src/server/api/traits.rs
+++ b/crates/ty_server/src/server/api/traits.rs
@@ -35,8 +35,6 @@
 
 use std::borrow::Cow;
 
-use std::panic::AssertUnwindSafe;
-
 use crate::session::client::Client;
 use crate::session::{DocumentSnapshot, Session, SessionSnapshot};
 
@@ -109,7 +107,7 @@ pub(super) trait BackgroundDocumentRequestHandler: RetriableRequestHandler {
 /// diagnostics.
 pub(super) trait BackgroundRequestHandler: RetriableRequestHandler {
     fn run(
-        snapshot: AssertUnwindSafe<SessionSnapshot>,
+        snapshot: SessionSnapshot,
         client: &Client,
         params: <<Self as RequestHandler>::RequestType as Request>::Params,
     ) -> super::Result<<<Self as RequestHandler>::RequestType as Request>::Result>;


### PR DESCRIPTION
## Summary

The use of `AssertUnwindSafe` is an implementation detail (as is that we use `std::panic::catch_unwind`). 

## Test Plan

`cargo build`
