### PR TITLE
Add license classifier back to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
+    "License :: OSI Approved :: MIT License",  # for compatibility with tooling such as pip-licenses
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
Reverts astral-sh/ruff#19499

@AlexWaygood brought to light that the same change caused a lot of churn for `typing_extensions` users: 

> Just as an FYI, we received a lot of confused bug reports at typing_extensions after we made a similar change, due to some tooling not yet supporting PEP 639
> 
> * https://github.com/python/typing_extensions/issues/576
> * https://github.com/python/typing_extensions/issues/563
> * https://github.com/python/typing_extensions/issues/562
> * https://github.com/python/typing_extensions/issues/559
> * https://github.com/python/typing_extensions/pull/584


Given that this causes significant churn without a very clear benefit for users, we decided to wait with this change until the ecosystem is further along.
