### PR TITLE
[ty] Track difference uses of legacy typevars, including context when rendering typevars

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -16,7 +16,7 @@ from typing import Self
 
 class Shape:
     def set_scale(self: Self, scale: float) -> Self:
-        reveal_type(self)  # revealed: Self
+        reveal_type(self)  # revealed: Self@Shape
         return self
 
     def nested_type(self: Self) -> list[Self]:
@@ -24,7 +24,7 @@ class Shape:
 
     def nested_func(self: Self) -> Self:
         def inner() -> Self:
-            reveal_type(self)  # revealed: Self
+            reveal_type(self)  # revealed: Self@Shape
             return self
         return inner()
 
@@ -38,13 +38,13 @@ reveal_type(Shape().nested_func())  # revealed: Shape
 
 class Circle(Shape):
     def set_scale(self: Self, scale: float) -> Self:
-        reveal_type(self)  # revealed: Self
+        reveal_type(self)  # revealed: Self@Circle
         return self
 
 class Outer:
     class Inner:
         def foo(self: Self) -> Self:
-            reveal_type(self)  # revealed: Self
+            reveal_type(self)  # revealed: Self@Inner
             return self
 ```
 
@@ -151,7 +151,7 @@ from typing import Self
 
 class Shape:
     def union(self: Self, other: Self | None):
-        reveal_type(other)  # revealed: Self | None
+        reveal_type(other)  # revealed: Self@Shape | None
         return self
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/annotations/unsupported_special_forms.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/unsupported_special_forms.md
@@ -26,7 +26,7 @@ def i(callback: Callable[Concatenate[int, P], R_co], *args: P.args, **kwargs: P.
 
 class Foo:
     def method(self, x: Self):
-        reveal_type(x)  # revealed: Self
+        reveal_type(x)  # revealed: Self@Foo
 ```
 
 ## Type expressions

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -15,8 +15,10 @@ S = TypeVar("S")
 class SingleTypevar(Generic[T]): ...
 class MultipleTypevars(Generic[T, S]): ...
 
-reveal_type(generic_context(SingleTypevar))  # revealed: tuple[T]
-reveal_type(generic_context(MultipleTypevars))  # revealed: tuple[T, S]
+# revealed: tuple[T@SingleTypevar]
+reveal_type(generic_context(SingleTypevar))
+# revealed: tuple[T@MultipleTypevars, S@MultipleTypevars]
+reveal_type(generic_context(MultipleTypevars))
 ```
 
 Inheriting from `Generic` multiple times yields a `duplicate-base` diagnostic, just like any other
@@ -49,9 +51,12 @@ class InheritedGeneric(MultipleTypevars[T, S]): ...
 class InheritedGenericPartiallySpecialized(MultipleTypevars[T, int]): ...
 class InheritedGenericFullySpecialized(MultipleTypevars[str, int]): ...
 
-reveal_type(generic_context(InheritedGeneric))  # revealed: tuple[T, S]
-reveal_type(generic_context(InheritedGenericPartiallySpecialized))  # revealed: tuple[T]
-reveal_type(generic_context(InheritedGenericFullySpecialized))  # revealed: None
+# revealed: tuple[T@InheritedGeneric, S@InheritedGeneric]
+reveal_type(generic_context(InheritedGeneric))
+# revealed: tuple[T@InheritedGenericPartiallySpecialized]
+reveal_type(generic_context(InheritedGenericPartiallySpecialized))
+# revealed: None
+reveal_type(generic_context(InheritedGenericFullySpecialized))
 ```
 
 If you don't specialize a generic base class, we use the default specialization, which maps each
@@ -78,9 +83,12 @@ class ExplicitInheritedGenericPartiallySpecializedExtraTypevar(MultipleTypevars[
 # error: [invalid-generic-class] "`Generic` base class must include all type variables used in other base classes"
 class ExplicitInheritedGenericPartiallySpecializedMissingTypevar(MultipleTypevars[T, int], Generic[S]): ...
 
-reveal_type(generic_context(ExplicitInheritedGeneric))  # revealed: tuple[T, S]
-reveal_type(generic_context(ExplicitInheritedGenericPartiallySpecialized))  # revealed: tuple[T]
-reveal_type(generic_context(ExplicitInheritedGenericPartiallySpecializedExtraTypevar))  # revealed: tuple[T, S]
+# revealed: tuple[T@ExplicitInheritedGeneric, S@ExplicitInheritedGeneric]
+reveal_type(generic_context(ExplicitInheritedGeneric))
+# revealed: tuple[T@ExplicitInheritedGenericPartiallySpecialized]
+reveal_type(generic_context(ExplicitInheritedGenericPartiallySpecialized))
+# revealed: tuple[T@ExplicitInheritedGenericPartiallySpecializedExtraTypevar, S@ExplicitInheritedGenericPartiallySpecializedExtraTypevar]
+reveal_type(generic_context(ExplicitInheritedGenericPartiallySpecializedExtraTypevar))
 ```
 
 ## Specializing generic classes explicitly
@@ -446,18 +454,18 @@ class C(Generic[T]):
     def generic_method(self, t: T, u: U) -> U:
         return u
 
-reveal_type(generic_context(C))  # revealed: tuple[T]
+reveal_type(generic_context(C))  # revealed: tuple[T@C]
 reveal_type(generic_context(C.method))  # revealed: None
-reveal_type(generic_context(C.generic_method))  # revealed: tuple[U]
+reveal_type(generic_context(C.generic_method))  # revealed: tuple[U@generic_method]
 reveal_type(generic_context(C[int]))  # revealed: None
 reveal_type(generic_context(C[int].method))  # revealed: None
-reveal_type(generic_context(C[int].generic_method))  # revealed: tuple[U]
+reveal_type(generic_context(C[int].generic_method))  # revealed: tuple[U@generic_method]
 
 c: C[int] = C[int]()
 reveal_type(c.generic_method(1, "string"))  # revealed: Literal["string"]
 reveal_type(generic_context(c))  # revealed: None
 reveal_type(generic_context(c.method))  # revealed: None
-reveal_type(generic_context(c.generic_method))  # revealed: tuple[U]
+reveal_type(generic_context(c.generic_method))  # revealed: tuple[U@generic_method]
 ```
 
 ## Specializations propagate
@@ -540,7 +548,8 @@ class WithOverloadedMethod(Generic[T]):
     def method(self, x: S | T) -> S | T:
         return x
 
-reveal_type(WithOverloadedMethod[int].method)  # revealed: Overload[(self, x: int) -> int, (self, x: S) -> S | int]
+# revealed: Overload[(self, x: int) -> int, (self, x: S@method) -> S@method | int]
+reveal_type(WithOverloadedMethod[int].method)
 ```
 
 ## Cyclic class definitions

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -219,7 +219,7 @@ from typing import TypeVar
 T = TypeVar("T", bound=int)
 
 def good_param(x: T) -> None:
-    reveal_type(x)  # revealed: T
+    reveal_type(x)  # revealed: T@good_param
 ```
 
 If the function is annotated as returning the typevar, this means that the upper bound is _not_
@@ -232,7 +232,7 @@ def good_return(x: T) -> T:
     return x
 
 def bad_return(x: T) -> T:
-    # error: [invalid-return-type] "Return type does not match returned value: expected `T`, found `int`"
+    # error: [invalid-return-type] "Return type does not match returned value: expected `T@bad_return`, found `int`"
     return x + 1
 ```
 
@@ -250,7 +250,7 @@ def different_types(cond: bool, t: T, s: S) -> T:
     if cond:
         return t
     else:
-        # error: [invalid-return-type] "Return type does not match returned value: expected `T`, found `S`"
+        # error: [invalid-return-type] "Return type does not match returned value: expected `T@different_types`, found `S@different_types`"
         return s
 
 def same_types(cond: bool, t1: T, t2: T) -> T:
@@ -272,7 +272,7 @@ T = TypeVar("T", int, str)
 
 def same_constrained_types(t1: T, t2: T) -> T:
     # TODO: no error
-    # error: [unsupported-operator] "Operator `+` is unsupported between objects of type `T` and `T`"
+    # error: [unsupported-operator] "Operator `+` is unsupported between objects of type `T@same_constrained_types` and `T@same_constrained_types`"
     return t1 + t2
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/variables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/variables.md
@@ -182,7 +182,7 @@ from typing import Callable, TypeVar
 T = TypeVar("T", bound=Callable[[], int])
 
 def bound(f: T):
-    reveal_type(f)  # revealed: T
+    reveal_type(f)  # revealed: T@bound
     reveal_type(f())  # revealed: int
 ```
 
@@ -192,7 +192,7 @@ Same with a constrained typevar, as long as all constraints are callable:
 T = TypeVar("T", Callable[[], int], Callable[[], str])
 
 def constrained(f: T):
-    reveal_type(f)  # revealed: T
+    reveal_type(f)  # revealed: T@constrained
     reveal_type(f())  # revealed: int | str
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
@@ -16,8 +16,10 @@ from ty_extensions import generic_context
 class SingleTypevar[T]: ...
 class MultipleTypevars[T, S]: ...
 
-reveal_type(generic_context(SingleTypevar))  # revealed: tuple[T]
-reveal_type(generic_context(MultipleTypevars))  # revealed: tuple[T, S]
+# revealed: tuple[T@SingleTypevar]
+reveal_type(generic_context(SingleTypevar))
+# revealed: tuple[T@MultipleTypevars, S@MultipleTypevars]
+reveal_type(generic_context(MultipleTypevars))
 ```
 
 You cannot use the same typevar more than once.
@@ -43,9 +45,12 @@ class InheritedGeneric[U, V](MultipleTypevars[U, V]): ...
 class InheritedGenericPartiallySpecialized[U](MultipleTypevars[U, int]): ...
 class InheritedGenericFullySpecialized(MultipleTypevars[str, int]): ...
 
-reveal_type(generic_context(InheritedGeneric))  # revealed: tuple[U, V]
-reveal_type(generic_context(InheritedGenericPartiallySpecialized))  # revealed: tuple[U]
-reveal_type(generic_context(InheritedGenericFullySpecialized))  # revealed: None
+# revealed: tuple[U@InheritedGeneric, V@InheritedGeneric]
+reveal_type(generic_context(InheritedGeneric))
+# revealed: tuple[U@InheritedGenericPartiallySpecialized]
+reveal_type(generic_context(InheritedGenericPartiallySpecialized))
+# revealed: None
+reveal_type(generic_context(InheritedGenericFullySpecialized))
 ```
 
 If you don't specialize a generic base class, we use the default specialization, which maps each
@@ -406,18 +411,18 @@ class C[T]:
     # TODO: error
     def cannot_shadow_class_typevar[T](self, t: T): ...
 
-reveal_type(generic_context(C))  # revealed: tuple[T]
+reveal_type(generic_context(C))  # revealed: tuple[T@C]
 reveal_type(generic_context(C.method))  # revealed: None
-reveal_type(generic_context(C.generic_method))  # revealed: tuple[U]
+reveal_type(generic_context(C.generic_method))  # revealed: tuple[U@generic_method]
 reveal_type(generic_context(C[int]))  # revealed: None
 reveal_type(generic_context(C[int].method))  # revealed: None
-reveal_type(generic_context(C[int].generic_method))  # revealed: tuple[U]
+reveal_type(generic_context(C[int].generic_method))  # revealed: tuple[U@generic_method]
 
 c: C[int] = C[int]()
 reveal_type(c.generic_method(1, "string"))  # revealed: Literal["string"]
 reveal_type(generic_context(c))  # revealed: None
 reveal_type(generic_context(c.method))  # revealed: None
-reveal_type(generic_context(c.generic_method))  # revealed: tuple[U]
+reveal_type(generic_context(c.generic_method))  # revealed: tuple[U@generic_method]
 ```
 
 ## Specializations propagate
@@ -466,7 +471,8 @@ class WithOverloadedMethod[T]:
     def method[S](self, x: S | T) -> S | T:
         return x
 
-reveal_type(WithOverloadedMethod[int].method)  # revealed: Overload[(self, x: int) -> int, (self, x: S) -> S | int]
+# revealed: Overload[(self, x: int) -> int, (self, x: S@method) -> S@method | int]
+reveal_type(WithOverloadedMethod[int].method)
 ```
 
 ## Cyclic class definitions

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -195,7 +195,7 @@ in the function.
 
 ```py
 def good_param[T: int](x: T) -> None:
-    reveal_type(x)  # revealed: T
+    reveal_type(x)  # revealed: T@good_param
 ```
 
 If the function is annotated as returning the typevar, this means that the upper bound is _not_
@@ -208,7 +208,7 @@ def good_return[T: int](x: T) -> T:
     return x
 
 def bad_return[T: int](x: T) -> T:
-    # error: [invalid-return-type] "Return type does not match returned value: expected `T`, found `int`"
+    # error: [invalid-return-type] "Return type does not match returned value: expected `T@bad_return`, found `int`"
     return x + 1
 ```
 
@@ -221,7 +221,7 @@ def different_types[T, S](cond: bool, t: T, s: S) -> T:
     if cond:
         return t
     else:
-        # error: [invalid-return-type] "Return type does not match returned value: expected `T`, found `S`"
+        # error: [invalid-return-type] "Return type does not match returned value: expected `T@different_types`, found `S@different_types`"
         return s
 
 def same_types[T](cond: bool, t1: T, t2: T) -> T:
@@ -239,7 +239,7 @@ methods that are compatible with the return type, so the `return` expression is 
 ```py
 def same_constrained_types[T: (int, str)](t1: T, t2: T) -> T:
     # TODO: no error
-    # error: [unsupported-operator] "Operator `+` is unsupported between objects of type `T` and `T`"
+    # error: [unsupported-operator] "Operator `+` is unsupported between objects of type `T@same_constrained_types` and `T@same_constrained_types`"
     return t1 + t2
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/scoping.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/scoping.md
@@ -152,9 +152,9 @@ already solved and specialized when the class was specialized:
 from ty_extensions import generic_context
 
 legacy.m("string", None)  # error: [invalid-argument-type]
-reveal_type(legacy.m)  # revealed: bound method Legacy[int].m(x: int, y: S) -> S
-reveal_type(generic_context(Legacy))  # revealed: tuple[T]
-reveal_type(generic_context(legacy.m))  # revealed: tuple[S]
+reveal_type(legacy.m)  # revealed: bound method Legacy[int].m(x: int, y: S@m) -> S@m
+reveal_type(generic_context(Legacy))  # revealed: tuple[T@Legacy]
+reveal_type(generic_context(legacy.m))  # revealed: tuple[S@m]
 ```
 
 With PEP 695 syntax, it is clearer that the method uses a separate typevar:

--- a/crates/ty_python_semantic/resources/mdtest/mro.md
+++ b/crates/ty_python_semantic/resources/mdtest/mro.md
@@ -536,19 +536,19 @@ T = TypeVar("T")
 
 class peekable(Generic[T], Iterator[T]): ...
 
-# revealed: tuple[<class 'peekable[Unknown]'>, <class 'Iterator[T]'>, <class 'Iterable[T]'>, typing.Protocol, typing.Generic, <class 'object'>]
+# revealed: tuple[<class 'peekable[Unknown]'>, <class 'Iterator[T@peekable]'>, <class 'Iterable[T@peekable]'>, typing.Protocol, typing.Generic, <class 'object'>]
 reveal_type(peekable.__mro__)
 
 class peekable2(Iterator[T], Generic[T]): ...
 
-# revealed: tuple[<class 'peekable2[Unknown]'>, <class 'Iterator[T]'>, <class 'Iterable[T]'>, typing.Protocol, typing.Generic, <class 'object'>]
+# revealed: tuple[<class 'peekable2[Unknown]'>, <class 'Iterator[T@peekable2]'>, <class 'Iterable[T@peekable2]'>, typing.Protocol, typing.Generic, <class 'object'>]
 reveal_type(peekable2.__mro__)
 
 class Base: ...
 class Intermediate(Base, Generic[T]): ...
 class Sub(Intermediate[T], Base): ...
 
-# revealed: tuple[<class 'Sub[Unknown]'>, <class 'Intermediate[T]'>, <class 'Base'>, typing.Generic, <class 'object'>]
+# revealed: tuple[<class 'Sub[Unknown]'>, <class 'Intermediate[T@Sub]'>, <class 'Base'>, typing.Generic, <class 'object'>]
 reveal_type(Sub.__mro__)
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/named_tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/named_tuple.md
@@ -155,13 +155,13 @@ reveal_type(Person._asdict)  # revealed: def _asdict(self) -> dict[str, Any]
 reveal_type(Person._replace)  # revealed: def _replace(self, **kwargs: Any) -> Self@NamedTupleFallback
 
 # TODO: should be `Person` once we support `Self`
-reveal_type(Person._make(("Alice", 42)))  # revealed: Self@NamedTupleFallback
+reveal_type(Person._make(("Alice", 42)))  # revealed: Unknown
 
 person = Person("Alice", 42)
 
 reveal_type(person._asdict())  # revealed: dict[str, Any]
 # TODO: should be `Person` once we support `Self`
-reveal_type(person._replace(name="Bob"))  # revealed: Self@NamedTupleFallback
+reveal_type(person._replace(name="Bob"))  # revealed: Unknown
 ```
 
 ## `collections.namedtuple`

--- a/crates/ty_python_semantic/resources/mdtest/named_tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/named_tuple.md
@@ -150,9 +150,9 @@ class Person(NamedTuple):
 
 reveal_type(Person._field_defaults)  # revealed: dict[str, Any]
 reveal_type(Person._fields)  # revealed: tuple[str, ...]
-reveal_type(Person._make)  # revealed: bound method <class 'Person'>._make(iterable: Iterable[Any]) -> Self
+reveal_type(Person._make)  # revealed: bound method <class 'Person'>._make(iterable: Iterable[Any]) -> Self@NamedTupleFallback
 reveal_type(Person._asdict)  # revealed: def _asdict(self) -> dict[str, Any]
-reveal_type(Person._replace)  # revealed: def _replace(self, **kwargs: Any) -> Self
+reveal_type(Person._replace)  # revealed: def _replace(self, **kwargs: Any) -> Self@NamedTupleFallback
 
 # TODO: should be `Person` once we support `Self`
 reveal_type(Person._make(("Alice", 42)))  # revealed: Unknown

--- a/crates/ty_python_semantic/resources/mdtest/named_tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/named_tuple.md
@@ -155,13 +155,13 @@ reveal_type(Person._asdict)  # revealed: def _asdict(self) -> dict[str, Any]
 reveal_type(Person._replace)  # revealed: def _replace(self, **kwargs: Any) -> Self@NamedTupleFallback
 
 # TODO: should be `Person` once we support `Self`
-reveal_type(Person._make(("Alice", 42)))  # revealed: Unknown
+reveal_type(Person._make(("Alice", 42)))  # revealed: Self@NamedTupleFallback
 
 person = Person("Alice", 42)
 
 reveal_type(person._asdict())  # revealed: dict[str, Any]
 # TODO: should be `Person` once we support `Self`
-reveal_type(person._replace(name="Bob"))  # revealed: Unknown
+reveal_type(person._replace(name="Bob"))  # revealed: Self@NamedTupleFallback
 ```
 
 ## `collections.namedtuple`

--- a/crates/ty_python_semantic/resources/mdtest/narrow/complex_target.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/complex_target.md
@@ -136,19 +136,19 @@ def f(a: int | None):
         reveal_type(c.y)  # revealed: int | None
 
 def g[T](c: C[T]):
-    reveal_type(c.x)  # revealed: T
-    reveal_type(c.y)  # revealed: T
-    reveal_type(c)  # revealed: C[T]
+    reveal_type(c.x)  # revealed: T@g
+    reveal_type(c.y)  # revealed: T@g
+    reveal_type(c)  # revealed: C[T@g]
 
     if isinstance(c.x, int):
-        reveal_type(c.x)  # revealed: T & int
-        reveal_type(c.y)  # revealed: T
-        reveal_type(c)  # revealed: C[T]
+        reveal_type(c.x)  # revealed: T@g & int
+        reveal_type(c.y)  # revealed: T@g
+        reveal_type(c)  # revealed: C[T@g]
     if isinstance(c.x, int) and isinstance(c.y, int):
-        reveal_type(c.x)  # revealed: T & int
-        reveal_type(c.y)  # revealed: T & int
+        reveal_type(c.x)  # revealed: T@g & int
+        reveal_type(c.y)  # revealed: T@g & int
         # TODO: Probably better if inferred as `C[T & int]` (mypy and pyright don't support this)
-        reveal_type(c)  # revealed: C[T]
+        reveal_type(c)  # revealed: C[T@g]
 ```
 
 ### With intermediate scopes

--- a/crates/ty_python_semantic/resources/mdtest/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/overloads.md
@@ -299,7 +299,7 @@ def func[T](x: T) -> T: ...
 def func[T](x: T | None = None) -> T | None:
     return x
 
-reveal_type(func)  # revealed: Overload[() -> None, (x: T) -> T]
+reveal_type(func)  # revealed: Overload[() -> None, (x: T@func) -> T@func]
 reveal_type(func())  # revealed: None
 reveal_type(func(1))  # revealed: Literal[1]
 reveal_type(func(""))  # revealed: Literal[""]

--- a/crates/ty_python_semantic/resources/mdtest/scopes/builtin.md
+++ b/crates/ty_python_semantic/resources/mdtest/scopes/builtin.md
@@ -11,7 +11,7 @@ def _(flag: bool) -> None:
         abs = 1
         chr: int = 1
 
-    reveal_type(abs)  # revealed: Literal[1] | (def abs(x: SupportsAbs[_T], /) -> _T)
+    reveal_type(abs)  # revealed: Literal[1] | (def abs(x: SupportsAbs[_T@abs], /) -> _T@abs)
     reveal_type(chr)  # revealed: Literal[1] | (def chr(i: SupportsIndex, /) -> str)
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/mro.md_-_Method_Resolution_Or…_-_Unresolvable_MROs_in…_(e2b355c09a967862).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/mro.md_-_Method_Resolution_Or…_-_Unresolvable_MROs_in…_(e2b355c09a967862).snap
@@ -24,7 +24,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/mro.md
 # Diagnostics
 
 ```
-error[inconsistent-mro]: Cannot create a consistent method resolution order (MRO) for class `Baz` with bases list `[typing.Protocol[T], <class 'Foo'>, <class 'Bar[T]'>]`
+error[inconsistent-mro]: Cannot create a consistent method resolution order (MRO) for class `Baz` with bases list `[typing.Protocol[T], <class 'Foo'>, <class 'Bar[T@Baz]'>]`
  --> src/mdtest_snippet.py:7:1
   |
 5 | class Foo(Protocol): ...

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type_(a91e0c67519cd77f).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type_(a91e0c67519cd77f).snap
@@ -85,7 +85,7 @@ info: rule `invalid-return-type` is enabled by default
 ```
 
 ```
-error[invalid-return-type]: Function always implicitly returns `None`, which is not assignable to return type `T`
+error[invalid-return-type]: Function always implicitly returns `None`, which is not assignable to return type `T@m`
   --> src/mdtest_snippet.py:18:16
    |
 17 | # error: [invalid-return-type]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/union_call.md_-_Calling_a_union_of_f…_-_Try_to_cover_all_pos…_-_Cover_non-keyword_re…_(707b284610419a54).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/union_call.md_-_Calling_a_union_of_f…_-_Try_to_cover_all_pos…_-_Cover_non-keyword_re…_(707b284610419a54).snap
@@ -86,7 +86,7 @@ error[call-non-callable]: Object of type `Literal[5]` is not callable
    |         ^^^^
    |
 info: Union variant `Literal[5]` is incompatible with this call site
-info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> int) | (def f3(a: int, b: int) -> int) | (def f4(x: T) -> int) | Literal[5] | (Overload[() -> None, (x: str) -> str]) | (Overload[() -> None, (x: str, y: str) -> str]) | PossiblyNotCallable`
+info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> int) | (def f3(a: int, b: int) -> int) | (def f4(x: T@f4) -> int) | Literal[5] | (Overload[() -> None, (x: str) -> str]) | (Overload[() -> None, (x: str, y: str) -> str]) | PossiblyNotCallable`
 info: rule `call-non-callable` is enabled by default
 
 ```
@@ -101,7 +101,7 @@ error[call-non-callable]: Object of type `PossiblyNotCallable` is not callable (
    |         ^^^^
    |
 info: Union variant `PossiblyNotCallable` is incompatible with this call site
-info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> int) | (def f3(a: int, b: int) -> int) | (def f4(x: T) -> int) | Literal[5] | (Overload[() -> None, (x: str) -> str]) | (Overload[() -> None, (x: str, y: str) -> str]) | PossiblyNotCallable`
+info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> int) | (def f3(a: int, b: int) -> int) | (def f4(x: T@f4) -> int) | Literal[5] | (Overload[() -> None, (x: str) -> str]) | (Overload[() -> None, (x: str, y: str) -> str]) | PossiblyNotCallable`
 info: rule `call-non-callable` is enabled by default
 
 ```
@@ -116,7 +116,7 @@ error[missing-argument]: No argument provided for required parameter `b` of func
    |         ^^^^
    |
 info: Union variant `def f3(a: int, b: int) -> int` is incompatible with this call site
-info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> int) | (def f3(a: int, b: int) -> int) | (def f4(x: T) -> int) | Literal[5] | (Overload[() -> None, (x: str) -> str]) | (Overload[() -> None, (x: str, y: str) -> str]) | PossiblyNotCallable`
+info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> int) | (def f3(a: int, b: int) -> int) | (def f4(x: T@f4) -> int) | Literal[5] | (Overload[() -> None, (x: str) -> str]) | (Overload[() -> None, (x: str, y: str) -> str]) | PossiblyNotCallable`
 info: rule `missing-argument` is enabled by default
 
 ```
@@ -152,7 +152,7 @@ info: Overload implementation defined here
 28 |     return x + y if x and y else None
    |
 info: Union variant `Overload[() -> None, (x: str, y: str) -> str]` is incompatible with this call site
-info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> int) | (def f3(a: int, b: int) -> int) | (def f4(x: T) -> int) | Literal[5] | (Overload[() -> None, (x: str) -> str]) | (Overload[() -> None, (x: str, y: str) -> str]) | PossiblyNotCallable`
+info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> int) | (def f3(a: int, b: int) -> int) | (def f4(x: T@f4) -> int) | Literal[5] | (Overload[() -> None, (x: str) -> str]) | (Overload[() -> None, (x: str, y: str) -> str]) | PossiblyNotCallable`
 info: rule `no-matching-overload` is enabled by default
 
 ```
@@ -176,7 +176,7 @@ info: Function defined here
 8 |     return 0
   |
 info: Union variant `def f2(name: str) -> int` is incompatible with this call site
-info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> int) | (def f3(a: int, b: int) -> int) | (def f4(x: T) -> int) | Literal[5] | (Overload[() -> None, (x: str) -> str]) | (Overload[() -> None, (x: str, y: str) -> str]) | PossiblyNotCallable`
+info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> int) | (def f3(a: int, b: int) -> int) | (def f4(x: T@f4) -> int) | Literal[5] | (Overload[() -> None, (x: str) -> str]) | (Overload[() -> None, (x: str, y: str) -> str]) | PossiblyNotCallable`
 info: rule `invalid-argument-type` is enabled by default
 
 ```
@@ -199,8 +199,8 @@ info: Type variable defined here
    |        ^^^^^^
 14 |     return 0
    |
-info: Union variant `def f4(x: T) -> int` is incompatible with this call site
-info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> int) | (def f3(a: int, b: int) -> int) | (def f4(x: T) -> int) | Literal[5] | (Overload[() -> None, (x: str) -> str]) | (Overload[() -> None, (x: str, y: str) -> str]) | PossiblyNotCallable`
+info: Union variant `def f4(x: T@f4) -> int` is incompatible with this call site
+info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> int) | (def f3(a: int, b: int) -> int) | (def f4(x: T@f4) -> int) | Literal[5] | (Overload[() -> None, (x: str) -> str]) | (Overload[() -> None, (x: str, y: str) -> str]) | PossiblyNotCallable`
 info: rule `invalid-argument-type` is enabled by default
 
 ```
@@ -227,7 +227,7 @@ info: Matching overload defined here
 info: Non-matching overloads for function `f5`:
 info:   () -> None
 info: Union variant `Overload[() -> None, (x: str) -> str]` is incompatible with this call site
-info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> int) | (def f3(a: int, b: int) -> int) | (def f4(x: T) -> int) | Literal[5] | (Overload[() -> None, (x: str) -> str]) | (Overload[() -> None, (x: str, y: str) -> str]) | PossiblyNotCallable`
+info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> int) | (def f3(a: int, b: int) -> int) | (def f4(x: T@f4) -> int) | Literal[5] | (Overload[() -> None, (x: str) -> str]) | (Overload[() -> None, (x: str, y: str) -> str]) | PossiblyNotCallable`
 info: rule `invalid-argument-type` is enabled by default
 
 ```
@@ -242,7 +242,7 @@ error[too-many-positional-arguments]: Too many positional arguments to function 
    |           ^
    |
 info: Union variant `def f1() -> int` is incompatible with this call site
-info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> int) | (def f3(a: int, b: int) -> int) | (def f4(x: T) -> int) | Literal[5] | (Overload[() -> None, (x: str) -> str]) | (Overload[() -> None, (x: str, y: str) -> str]) | PossiblyNotCallable`
+info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> int) | (def f3(a: int, b: int) -> int) | (def f4(x: T@f4) -> int) | Literal[5] | (Overload[() -> None, (x: str) -> str]) | (Overload[() -> None, (x: str, y: str) -> str]) | PossiblyNotCallable`
 info: rule `too-many-positional-arguments` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/src/semantic_index/definition.rs
+++ b/crates/ty_python_semantic/src/semantic_index/definition.rs
@@ -60,6 +60,35 @@ impl<'db> Definition<'db> {
         FileRange::new(self.file(db), self.kind(db).target_range(module))
     }
 
+    /// Returns the name of the item being defined, if applicable.
+    pub fn name(self, db: &'db dyn Db) -> Option<String> {
+        let file = self.file(db);
+        let module = parsed_module(db, file).load(db);
+        let kind = self.kind(db);
+        match kind {
+            DefinitionKind::Function(def) => {
+                let node = def.node(&module);
+                Some(node.name.as_str().to_string())
+            }
+            DefinitionKind::Class(def) => {
+                let node = def.node(&module);
+                Some(node.name.as_str().to_string())
+            }
+            DefinitionKind::TypeAlias(def) => {
+                let node = def.node(&module);
+                Some(
+                    node.name
+                        .as_name_expr()
+                        .expect("type alias name should be a NameExpr")
+                        .id
+                        .as_str()
+                        .to_string(),
+                )
+            }
+            _ => None,
+        }
+    }
+
     /// Extract a docstring from this definition, if applicable.
     /// This method returns a docstring for function and class definitions.
     /// The docstring is extracted from the first statement in the body if it's a string literal.

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -703,7 +703,7 @@ impl<'db> Type<'db> {
                     None,
                     variance,
                     None,
-                    TypeVarKind::Pep695,
+                    TypeVarKind::Legacy,
                 )),
                 TypeVarVariance::Covariant => Type::object(db),
                 TypeVarVariance::Contravariant => Type::Never,
@@ -6497,6 +6497,23 @@ fn walk_type_var_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
 }
 
 impl<'db> TypeVarInstance<'db> {
+    pub(crate) fn with_binding_context(
+        self,
+        db: &'db dyn Db,
+        binding_context: Definition<'db>,
+    ) -> Self {
+        Self::new(
+            db,
+            self.name(db),
+            self.definition(db),
+            Some(binding_context),
+            self.bound_or_constraints(db),
+            self.variance(db),
+            self.default_ty(db),
+            self.kind(db),
+        )
+    }
+
     pub(crate) fn is_legacy(self, db: &'db dyn Db) -> bool {
         matches!(self.kind(db), TypeVarKind::Legacy)
     }

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -3887,11 +3887,15 @@ impl KnownClass {
                 };
 
                 let containing_assignment = index.expect_single_definition(target);
+                // A freshly legacy TypeVar does not have a binding context until it is used in a
+                // base class list, function parameter list, or type alias.
+                let binding_context = None;
                 overload.set_return_type(Type::KnownInstance(KnownInstanceType::TypeVar(
                     TypeVarInstance::new(
                         db,
                         &target.id,
                         Some(containing_assignment),
+                        binding_context,
                         bound_or_constraint,
                         variance,
                         *default,

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -202,7 +202,16 @@ impl Display for DisplayRepresentation<'_> {
                 )
             }
             Type::Tuple(specialization) => specialization.tuple(self.db).display(self.db).fmt(f),
-            Type::TypeVar(typevar) => f.write_str(typevar.name(self.db)),
+            Type::TypeVar(typevar) => {
+                f.write_str(typevar.name(self.db))?;
+                if let Some(binding_context) = typevar
+                    .binding_context(self.db)
+                    .and_then(|def| def.name(self.db))
+                {
+                    write!(f, "@{binding_context}")?;
+                }
+                Ok(())
+            }
             Type::AlwaysTruthy => f.write_str("AlwaysTruthy"),
             Type::AlwaysFalsy => f.write_str("AlwaysFalsy"),
             Type::BoundSuper(bound_super) => {

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -14,13 +14,13 @@ use crate::types::signatures::{Parameter, Parameters, Signature};
 use crate::types::tuple::{TupleSpec, TupleType};
 use crate::types::{
     KnownInstanceType, Type, TypeMapping, TypeRelation, TypeTransformer, TypeVarBoundOrConstraints,
-    TypeVarInstance, TypeVarVariance, UnionType, binding_type, declaration_type,
+    TypeVarInstance, TypeVarKind, TypeVarVariance, UnionType, binding_type, declaration_type,
 };
 use crate::{Db, FxOrderSet};
 
 /// Returns an iterator of any generic context introduced by the given scope or any enclosing
 /// scope.
-fn enclosing_generic_contexts<'db>(
+pub(crate) fn enclosing_generic_contexts<'db>(
     db: &'db dyn Db,
     module: &ParsedModuleRef,
     index: &SemanticIndex<'db>,
@@ -175,6 +175,19 @@ impl<'db> GenericContext<'db> {
         Some(Self::new(db, variables))
     }
 
+    pub(crate) fn with_binding_context(
+        self,
+        db: &'db dyn Db,
+        binding_context: Definition<'db>,
+    ) -> Self {
+        let variables: FxOrderSet<_> = self
+            .variables(db)
+            .iter()
+            .map(|typevar| typevar.with_binding_context(db, binding_context))
+            .collect();
+        Self::new(db, variables)
+    }
+
     pub(crate) fn len(self, db: &'db dyn Db) -> usize {
         self.variables(db).len()
     }
@@ -239,6 +252,22 @@ impl<'db> GenericContext<'db> {
 
     pub(crate) fn is_subset_of(self, db: &'db dyn Db, other: GenericContext<'db>) -> bool {
         self.variables(db).is_subset(other.variables(db))
+    }
+
+    pub(crate) fn binds_legacy_typevar(
+        self,
+        db: &'db dyn Db,
+        typevar: TypeVarInstance<'db>,
+    ) -> Option<TypeVarInstance<'db>> {
+        assert!(typevar.kind(db) == TypeVarKind::Legacy);
+        let typevar_def = typevar.definition(db);
+        self.variables(db)
+            .iter()
+            .find(|self_typevar| {
+                self_typevar.kind(db) == TypeVarKind::Legacy
+                    && self_typevar.definition(db) == typevar_def
+            })
+            .copied()
     }
 
     /// Creates a specialization of this generic context. Panics if the length of `types` does not

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1784,7 +1784,7 @@ mod tests {
             a_annotated_ty.unwrap().display(&db).to_string(),
             "Unknown | A | B"
         );
-        assert_eq!(b_annotated_ty.unwrap().display(&db).to_string(), "T");
+        assert_eq!(b_annotated_ty.unwrap().display(&db).to_string(), "T@f");
     }
 
     #[test]
@@ -1829,7 +1829,7 @@ mod tests {
         assert_eq!(b_name, "b");
         // Parameter resolution deferred:
         assert_eq!(a_annotated_ty.unwrap().display(&db).to_string(), "A | B");
-        assert_eq!(b_annotated_ty.unwrap().display(&db).to_string(), "T");
+        assert_eq!(b_annotated_ty.unwrap().display(&db).to_string(), "T@f");
     }
 
     #[test]

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -99,7 +99,7 @@ impl<'db> SubclassOfType<'db> {
                         )),
                         variance,
                         None,
-                        TypeVarKind::Pep695,
+                        TypeVarKind::Legacy,
                     ))
                 }
                 TypeVarVariance::Bivariant => unreachable!(),

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -93,6 +93,7 @@ impl<'db> SubclassOfType<'db> {
                         db,
                         Name::new_static("T_all"),
                         None,
+                        None,
                         Some(TypeVarBoundOrConstraints::UpperBound(
                             KnownClass::Type.to_instance(db),
                         )),


### PR DESCRIPTION
This PR introduces a few related changes:

- We now keep track of each time a legacy typevar is bound in a different generic context (e.g. class, function), and internally create a new `TypeVarInstance` for each usage. This means the rest of the code can now assume that salsa-equivalent `TypeVarInstance`s refer to the same typevar, even taking into account that legacy typevars can be used more than once.

- We also go ahead and track the binding context of PEP 695 typevars. That's _much_ easier to track since we have the binding context right there during type inference.

- With that in place, we can now include the name of the binding context when rendering typevars (e.g. `T@f` instead of `T`)