### PR TITLE
[ty] Bump docstring-adder pin

### DIFF
--- a/scripts/codemod_docstrings.sh
+++ b/scripts/codemod_docstrings.sh
@@ -18,7 +18,7 @@
 
 set -eu
 
-docstring_adder="git+https://github.com/astral-sh/docstring-adder.git@6e91640a011248f5d9f85ce98218e16d1c4277c4"
+docstring_adder="git+https://github.com/astral-sh/docstring-adder.git@93e8fdf5f65410c2aa88bc8523e3fc2a598e3917"
 stdlib_path="./crates/ty_vendored/vendor/typeshed/stdlib"
 
 for python_version in 3.14 3.13 3.12 3.11 3.10 3.9


### PR DESCRIPTION
## Summary

Bumps docstring-adder to https://github.com/astral-sh/docstring-adder/commit/93e8fdf5f65410c2aa88bc8523e3fc2a598e3917

## Test Plan

I'll set off a sync-typeshed workflow using this branch
