### PR TITLE
Add `LinterContext::settings` to avoid passing separate settings

### DIFF
--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -3216,6 +3216,11 @@ impl<'a> LintContext<'a> {
     pub(crate) fn iter(&mut self) -> impl Iterator<Item = &Diagnostic> {
         self.diagnostics.get_mut().iter()
     }
+
+    /// The [`LinterSettings`] for the current analysis, including the enabled rules.
+    pub(crate) const fn settings(&self) -> &LinterSettings {
+        self.settings
+    }
 }
 
 /// An abstraction for mutating a diagnostic.

--- a/crates/ruff_linter/src/checkers/tokens.rs
+++ b/crates/ruff_linter/src/checkers/tokens.rs
@@ -16,7 +16,6 @@ use crate::rules::{
     eradicate, flake8_commas, flake8_executable, flake8_fixme, flake8_implicit_str_concat,
     flake8_pyi, flake8_todos, pycodestyle, pygrep_hooks, pylint, pyupgrade, ruff,
 };
-use crate::settings::LinterSettings;
 
 use super::ast::LintContext;
 
@@ -27,7 +26,6 @@ pub(crate) fn check_tokens(
     locator: &Locator,
     indexer: &Indexer,
     stylist: &Stylist,
-    settings: &LinterSettings,
     source_type: PySourceType,
     cell_offsets: Option<&CellOffsets>,
     context: &mut LintContext,
@@ -42,15 +40,8 @@ pub(crate) fn check_tokens(
         Rule::BlankLinesAfterFunctionOrClass,
         Rule::BlankLinesBeforeNestedDefinition,
     ]) {
-        BlankLinesChecker::new(
-            locator,
-            stylist,
-            settings,
-            source_type,
-            cell_offsets,
-            context,
-        )
-        .check_lines(tokens);
+        BlankLinesChecker::new(locator, stylist, source_type, cell_offsets, context)
+            .check_lines(tokens);
     }
 
     if context.is_rule_enabled(Rule::BlanketTypeIgnore) {
@@ -63,12 +54,12 @@ pub(crate) fn check_tokens(
 
     if context.is_rule_enabled(Rule::AmbiguousUnicodeCharacterComment) {
         for range in comment_ranges {
-            ruff::rules::ambiguous_unicode_character_comment(context, locator, range, settings);
+            ruff::rules::ambiguous_unicode_character_comment(context, locator, range);
         }
     }
 
     if context.is_rule_enabled(Rule::CommentedOutCode) {
-        eradicate::rules::commented_out_code(context, locator, comment_ranges, settings);
+        eradicate::rules::commented_out_code(context, locator, comment_ranges);
     }
 
     if context.is_rule_enabled(Rule::UTF8EncodingDeclaration) {
@@ -110,7 +101,7 @@ pub(crate) fn check_tokens(
         Rule::SingleLineImplicitStringConcatenation,
         Rule::MultiLineImplicitStringConcatenation,
     ]) {
-        flake8_implicit_str_concat::rules::implicit(context, tokens, locator, indexer, settings);
+        flake8_implicit_str_concat::rules::implicit(context, tokens, locator, indexer);
     }
 
     if context.any_rule_enabled(&[
@@ -118,7 +109,7 @@ pub(crate) fn check_tokens(
         Rule::TrailingCommaOnBareTuple,
         Rule::ProhibitedTrailingComma,
     ]) {
-        flake8_commas::rules::trailing_commas(context, tokens, locator, indexer, settings);
+        flake8_commas::rules::trailing_commas(context, tokens, locator, indexer);
     }
 
     if context.is_rule_enabled(Rule::ExtraneousParentheses) {

--- a/crates/ruff_linter/src/linter.rs
+++ b/crates/ruff_linter/src/linter.rs
@@ -188,7 +188,6 @@ pub fn check_path(
             locator,
             indexer,
             stylist,
-            settings,
             source_type,
             source_kind.as_ipy_notebook().map(Notebook::cell_offsets),
             &mut context,

--- a/crates/ruff_linter/src/rules/eradicate/rules/commented_out_code.rs
+++ b/crates/ruff_linter/src/rules/eradicate/rules/commented_out_code.rs
@@ -5,7 +5,6 @@ use ruff_text_size::TextRange;
 
 use crate::Locator;
 use crate::checkers::ast::LintContext;
-use crate::settings::LinterSettings;
 use crate::{Edit, Fix, FixAvailability, Violation};
 
 use crate::rules::eradicate::detection::comment_contains_code;
@@ -51,7 +50,6 @@ pub(crate) fn commented_out_code(
     context: &LintContext,
     locator: &Locator,
     comment_ranges: &CommentRanges,
-    settings: &LinterSettings,
 ) {
     let mut comments = comment_ranges.into_iter().peekable();
     // Iterate over all comments in the document.
@@ -65,7 +63,9 @@ pub(crate) fn commented_out_code(
         }
 
         // Verify that the comment is on its own line, and that it contains code.
-        if is_own_line_comment(line) && comment_contains_code(line, &settings.task_tags[..]) {
+        if is_own_line_comment(line)
+            && comment_contains_code(line, &context.settings().task_tags[..])
+        {
             if let Some(mut diagnostic) =
                 context.report_diagnostic_if_enabled(CommentedOutCode, range)
             {

--- a/crates/ruff_linter/src/rules/flake8_commas/rules/trailing_commas.rs
+++ b/crates/ruff_linter/src/rules/flake8_commas/rules/trailing_commas.rs
@@ -251,7 +251,6 @@ pub(crate) fn trailing_commas(
     tokens: &Tokens,
     locator: &Locator,
     indexer: &Indexer,
-    settings: &LinterSettings,
 ) {
     let mut fstrings = 0u32;
     let simple_tokens = tokens.iter().filter_map(|token| {
@@ -299,7 +298,7 @@ pub(crate) fn trailing_commas(
         }
 
         // Update the comma context stack.
-        let context = update_context(token, prev, prev_prev, &mut stack, settings);
+        let context = update_context(token, prev, prev_prev, &mut stack, lint_context.settings());
 
         check_token(token, prev, prev_prev, context, locator, lint_context);
 

--- a/crates/ruff_linter/src/rules/flake8_implicit_str_concat/rules/implicit.rs
+++ b/crates/ruff_linter/src/rules/flake8_implicit_str_concat/rules/implicit.rs
@@ -11,7 +11,6 @@ use ruff_text_size::{Ranged, TextRange};
 
 use crate::Locator;
 use crate::checkers::ast::LintContext;
-use crate::settings::LinterSettings;
 use crate::{Edit, Fix, FixAvailability, Violation};
 
 /// ## What it does
@@ -108,13 +107,15 @@ pub(crate) fn implicit(
     tokens: &Tokens,
     locator: &Locator,
     indexer: &Indexer,
-    settings: &LinterSettings,
 ) {
     for (a_token, b_token) in tokens
         .iter()
         .filter(|token| {
             token.kind() != TokenKind::Comment
-                && (settings.flake8_implicit_str_concat.allow_multiline
+                && (context
+                    .settings()
+                    .flake8_implicit_str_concat
+                    .allow_multiline
                     || token.kind() != TokenKind::NonLogicalNewline)
         })
         .tuple_windows()

--- a/crates/ruff_linter/src/rules/ruff/rules/ambiguous_unicode_character.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/ambiguous_unicode_character.rs
@@ -178,11 +178,10 @@ pub(crate) fn ambiguous_unicode_character_comment(
     context: &LintContext,
     locator: &Locator,
     range: TextRange,
-    settings: &LinterSettings,
 ) {
     let text = locator.slice(range);
-    for candidate in ambiguous_unicode_character(text, range, settings) {
-        candidate.into_diagnostic(Context::Comment, settings, context);
+    for candidate in ambiguous_unicode_character(text, range, context.settings()) {
+        candidate.into_diagnostic(Context::Comment, context);
     }
 }
 
@@ -342,13 +341,12 @@ impl Candidate {
         }
     }
 
-    fn into_diagnostic(
-        self,
-        context: Context,
-        settings: &LinterSettings,
-        lint_context: &LintContext,
-    ) {
-        if !settings.allowed_confusables.contains(&self.confusable) {
+    fn into_diagnostic(self, context: Context, lint_context: &LintContext) {
+        if !lint_context
+            .settings()
+            .allowed_confusables
+            .contains(&self.confusable)
+        {
             let char_range = TextRange::at(self.offset, self.confusable.text_len());
             match context {
                 Context::String => lint_context.report_diagnostic_if_enabled(


### PR DESCRIPTION
Summary
--

I noticed while reviewing #19390 that in `check_tokens` we were still passing
around an extra `LinterSettings`, despite all of the same functions also
receiving a `LintContext` with its own settings.

This PR adds the `LintContext::settings` method and calls that instead of using
the separate `LinterSettings`.

Test Plan
--

Existing tests
