### PR TITLE
[ty] Discard `Definition`s when normalizing `Signature`s

### DIFF
--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -383,7 +383,9 @@ impl<'db> Signature<'db> {
             inherited_generic_context: self
                 .inherited_generic_context
                 .map(|ctx| ctx.normalized_impl(db, visitor)),
-            definition: self.definition,
+            // Discard the definition when normalizing, so that two equivalent signatures
+            // with different `Definition`s share the same Salsa ID when normalized
+            definition: None,
             parameters: self
                 .parameters
                 .iter()


### PR DESCRIPTION
## Summary

I noticed while looking at some debug prints that we appear to be holding onto the original `Definition` associated with a `Signature` when we normalize the `Signature`. This defeats the point of normalization of types: it means that two equivalent `Signature`s (and therefore two equivalent `CallableType`s) might not share the same Salsa ID even after being normalized if they originated from different `StmtFunctionDef`s in the source code.

I'm not sure whether or not this would lead to a user-facing bug right now, but it feels like a latent bug waiting to pounce, so this PR fixes it. Fixing the latent bug also has the advantage that it makes the debug representation of normalized `CallableType`s more concise, and probably reduces memory a little bit (because we need to intern fewer `Signature`s when normalizing `CallableType`s). I think there are no downsides to this change: normalized types should usually only be created transitively, so this shouldn't have any impact on goto-definition or go-to type definition.

## Test Plan

`cargo test -p ty_python_semantic`
