### PR TITLE
Revert `license` and `license-files` changes in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,7 @@ description = "An extremely fast Python linter and code formatter, written in Ru
 authors = [{ name = "Astral Software Inc.", email = "hey@astral.sh" }]
 readme = "README.md"
 requires-python = ">=3.7"
-license = "MIT"
-license-files = ["LICENSE"]
+license = { file = "LICENSE" }
 keywords = [
     "automation",
     "flake8",


### PR DESCRIPTION
Summary
--

This partially reverts commit 13634ff433310fa4b718c57cb8ea43ab334e2637 after issues in the release today.

Test Plan
--

```shell
uv build --sdist
tar -tzf dist/ruff-0.12.6.tar.gz | grep ruff-0.12.6/LICENSE
```

which finds the license now.
