### PR TITLE
[ty] Find legacy typevars using a `TypeVisitor`

### DIFF
--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -20,6 +20,7 @@ use crate::types::generics::{GenericContext, Specialization, walk_specialization
 use crate::types::infer::nearest_enclosing_class;
 use crate::types::signatures::{CallableSignature, Parameter, Parameters, Signature};
 use crate::types::tuple::TupleType;
+use crate::types::visitor::{TypeVisitor, TypeVisitorResult};
 use crate::types::{
     BareTypeAliasType, Binding, BoundSuperError, BoundSuperType, CallableType, DataclassParams,
     DeprecatedInstance, DynamicType, KnownInstanceType, TypeAliasType, TypeMapping, TypeRelation,
@@ -180,12 +181,13 @@ pub struct GenericAlias<'db> {
     pub(crate) specialization: Specialization<'db>,
 }
 
-pub(super) fn walk_generic_alias<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
+pub(super) fn walk_generic_alias<'db, V: TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
     alias: GenericAlias<'db>,
     visitor: &mut V,
-) {
-    walk_specialization(db, alias.specialization(db), visitor);
+) -> TypeVisitorResult {
+    walk_specialization(db, alias.specialization(db), visitor)?;
+    Ok(())
 }
 
 // The Salsa heap is tracked separately.

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -28,7 +28,7 @@ use crate::types::{
     infer_definition_types,
 };
 use crate::{
-    Db, FxOrderSet, KnownModule, Program,
+    Db, KnownModule, Program,
     module_resolver::file_to_module,
     place::{
         Boundness, LookupError, LookupResult, Place, PlaceAndQualifiers, class_symbol,
@@ -229,16 +229,6 @@ impl<'db> GenericAlias<'db> {
             self.specialization(db).apply_type_mapping(db, type_mapping),
         )
     }
-
-    pub(super) fn find_legacy_typevars(
-        self,
-        db: &'db dyn Db,
-        typevars: &mut FxOrderSet<TypeVarInstance<'db>>,
-    ) {
-        // A tuple's specialization will include all of its element types, so we don't need to also
-        // look in `self.tuple`.
-        self.specialization(db).find_legacy_typevars(db, typevars);
-    }
 }
 
 impl<'db> From<GenericAlias<'db>> for Type<'db> {
@@ -364,17 +354,6 @@ impl<'db> ClassType<'db> {
         match self {
             Self::NonGeneric(_) => self,
             Self::Generic(generic) => Self::Generic(generic.apply_type_mapping(db, type_mapping)),
-        }
-    }
-
-    pub(super) fn find_legacy_typevars(
-        self,
-        db: &'db dyn Db,
-        typevars: &mut FxOrderSet<TypeVarInstance<'db>>,
-    ) {
-        match self {
-            Self::NonGeneric(_) => {}
-            Self::Generic(generic) => generic.find_legacy_typevars(db, typevars),
         }
     }
 

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -77,10 +77,10 @@ use crate::types::signatures::{CallableSignature, Signature};
 use crate::types::visitor::{TypeVisitor, TypeVisitorResult, any_over_type};
 use crate::types::{
     BoundMethodType, CallableType, ClassLiteral, ClassType, DeprecatedInstance, DynamicType,
-    KnownClass, Truthiness, Type, TypeMapping, TypeRelation, TypeTransformer, TypeVarInstance,
-    UnionBuilder, walk_type_mapping,
+    KnownClass, Truthiness, Type, TypeMapping, TypeRelation, TypeTransformer, UnionBuilder,
+    walk_type_mapping,
 };
-use crate::{Db, FxOrderSet, ModuleName, resolve_module};
+use crate::{Db, ModuleName, resolve_module};
 
 /// A collection of useful spans for annotating functions.
 ///
@@ -854,17 +854,6 @@ impl<'db> FunctionType<'db> {
         let self_signature = self.signature(db);
         let other_signature = other.signature(db);
         self_signature.is_equivalent_to(db, other_signature)
-    }
-
-    pub(crate) fn find_legacy_typevars(
-        self,
-        db: &'db dyn Db,
-        typevars: &mut FxOrderSet<TypeVarInstance<'db>>,
-    ) {
-        let signatures = self.signature(db);
-        for signature in &signatures.overloads {
-            signature.find_legacy_typevars(db, typevars);
-        }
     }
 
     pub(crate) fn normalized(self, db: &'db dyn Db) -> Self {

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -9,6 +9,7 @@ use crate::types::cyclic::PairVisitor;
 use crate::types::enums::is_single_member_enum;
 use crate::types::protocol_class::walk_protocol_interface;
 use crate::types::tuple::TupleType;
+use crate::types::visitor::{TypeVisitor, TypeVisitorResult};
 use crate::types::{DynamicType, TypeMapping, TypeRelation, TypeTransformer, TypeVarInstance};
 use crate::{Db, FxOrderSet};
 
@@ -77,12 +78,13 @@ pub struct NominalInstanceType<'db> {
     _phantom: PhantomData<()>,
 }
 
-pub(super) fn walk_nominal_instance_type<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
+pub(super) fn walk_nominal_instance_type<'db, V: TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
     nominal: NominalInstanceType<'db>,
     visitor: &mut V,
-) {
-    visitor.visit_type(db, nominal.class.into());
+) -> TypeVisitorResult {
+    visitor.visit_type(db, nominal.class.into())?;
+    Ok(())
 }
 
 impl<'db> NominalInstanceType<'db> {
@@ -177,12 +179,13 @@ pub struct ProtocolInstanceType<'db> {
     _phantom: PhantomData<()>,
 }
 
-pub(super) fn walk_protocol_instance_type<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
+pub(super) fn walk_protocol_instance_type<'db, V: TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
     protocol: ProtocolInstanceType<'db>,
     visitor: &mut V,
-) {
-    walk_protocol_interface(db, protocol.inner.interface(db), visitor);
+) -> TypeVisitorResult {
+    walk_protocol_interface(db, protocol.inner.interface(db), visitor)?;
+    Ok(())
 }
 
 impl<'db> ProtocolInstanceType<'db> {

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -7,12 +7,12 @@ use ruff_python_ast::name::Name;
 use super::TypeVarVariance;
 use crate::semantic_index::place_table;
 use crate::{
-    Db, FxOrderSet,
+    Db,
     place::{Boundness, Place, PlaceAndQualifiers, place_from_bindings, place_from_declarations},
     semantic_index::use_def_map,
     types::{
         CallableType, ClassBase, ClassLiteral, KnownFunction, PropertyInstanceType, Signature,
-        Type, TypeMapping, TypeQualifiers, TypeRelation, TypeTransformer, TypeVarInstance,
+        Type, TypeMapping, TypeQualifiers, TypeRelation, TypeTransformer,
         cyclic::PairVisitor,
         signatures::{Parameter, Parameters},
         visitor::{TypeVisitor, TypeVisitorResult},
@@ -207,16 +207,6 @@ impl<'db> ProtocolInterface<'db> {
                 .collect::<BTreeMap<_, _>>(),
         )
     }
-
-    pub(super) fn find_legacy_typevars(
-        self,
-        db: &'db dyn Db,
-        typevars: &mut FxOrderSet<TypeVarInstance<'db>>,
-    ) {
-        for data in self.inner(db).values() {
-            data.find_legacy_typevars(db, typevars);
-        }
-    }
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, salsa::Update)]
@@ -242,14 +232,6 @@ impl<'db> ProtocolMemberData<'db> {
             kind: self.kind.apply_type_mapping(db, type_mapping),
             qualifiers: self.qualifiers,
         }
-    }
-
-    fn find_legacy_typevars(
-        &self,
-        db: &'db dyn Db,
-        typevars: &mut FxOrderSet<TypeVarInstance<'db>>,
-    ) {
-        self.kind.find_legacy_typevars(db, typevars);
     }
 
     fn materialize(&self, db: &'db dyn Db, variance: TypeVarVariance) -> Self {
@@ -293,18 +275,6 @@ impl<'db> ProtocolMemberKind<'db> {
             ProtocolMemberKind::Other(ty) => {
                 ProtocolMemberKind::Other(ty.apply_type_mapping(db, type_mapping))
             }
-        }
-    }
-
-    fn find_legacy_typevars(
-        &self,
-        db: &'db dyn Db,
-        typevars: &mut FxOrderSet<TypeVarInstance<'db>>,
-    ) {
-        match self {
-            ProtocolMemberKind::Method(callable) => callable.find_legacy_typevars(db, typevars),
-            ProtocolMemberKind::Property(property) => property.find_legacy_typevars(db, typevars),
-            ProtocolMemberKind::Other(ty) => ty.find_legacy_typevars(db, typevars),
         }
     }
 

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -1,6 +1,7 @@
 use ruff_python_ast::name::Name;
 
 use crate::place::PlaceAndQualifiers;
+use crate::types::visitor::{TypeVisitor, TypeVisitorResult};
 use crate::types::{
     ClassType, DynamicType, KnownClass, MemberLookupPolicy, Type, TypeMapping, TypeRelation,
     TypeTransformer, TypeVarInstance,
@@ -16,12 +17,13 @@ pub struct SubclassOfType<'db> {
     subclass_of: SubclassOfInner<'db>,
 }
 
-pub(super) fn walk_subclass_of_type<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
+pub(super) fn walk_subclass_of_type<'db, V: TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
     subclass_of: SubclassOfType<'db>,
     visitor: &mut V,
-) {
-    visitor.visit_type(db, Type::from(subclass_of.subclass_of));
+) -> TypeVisitorResult {
+    visitor.visit_type(db, Type::from(subclass_of.subclass_of))?;
+    Ok(())
 }
 
 impl<'db> SubclassOfType<'db> {

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -1,12 +1,12 @@
 use ruff_python_ast::name::Name;
 
+use crate::Db;
 use crate::place::PlaceAndQualifiers;
 use crate::types::visitor::{TypeVisitor, TypeVisitorResult};
 use crate::types::{
     ClassType, DynamicType, KnownClass, MemberLookupPolicy, Type, TypeMapping, TypeRelation,
     TypeTransformer, TypeVarInstance,
 };
-use crate::{Db, FxOrderSet};
 
 use super::{TypeVarBoundOrConstraints, TypeVarKind, TypeVarVariance};
 
@@ -119,19 +119,6 @@ impl<'db> SubclassOfType<'db> {
                 subclass_of: SubclassOfInner::Class(class.apply_type_mapping(db, type_mapping)),
             },
             SubclassOfInner::Dynamic(_) => self,
-        }
-    }
-
-    pub(super) fn find_legacy_typevars(
-        self,
-        db: &'db dyn Db,
-        typevars: &mut FxOrderSet<TypeVarInstance<'db>>,
-    ) {
-        match self.subclass_of {
-            SubclassOfInner::Class(class) => {
-                class.find_legacy_typevars(db, typevars);
-            }
-            SubclassOfInner::Dynamic(_) => {}
         }
     }
 

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -24,6 +24,7 @@ use itertools::{Either, EitherOrBoth, Itertools};
 
 use crate::types::Truthiness;
 use crate::types::class::{ClassType, KnownClass};
+use crate::types::visitor::{TypeVisitor, TypeVisitorResult};
 use crate::types::{
     Type, TypeMapping, TypeRelation, TypeTransformer, TypeVarInstance, TypeVarVariance,
     UnionBuilder, UnionType, cyclic::PairVisitor,
@@ -104,14 +105,15 @@ pub struct TupleType<'db> {
     pub(crate) tuple: TupleSpec<'db>,
 }
 
-pub(super) fn walk_tuple_type<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
+pub(super) fn walk_tuple_type<'db, V: TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
     tuple: TupleType<'db>,
     visitor: &mut V,
-) {
+) -> TypeVisitorResult {
     for element in tuple.tuple(db).all_elements() {
-        visitor.visit_type(db, *element);
+        visitor.visit_type(db, *element)?;
     }
+    Ok(())
 }
 
 // The Salsa heap is tracked separately.

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -22,15 +22,15 @@ use std::hash::Hash;
 
 use itertools::{Either, EitherOrBoth, Itertools};
 
+use crate::Db;
 use crate::types::Truthiness;
 use crate::types::class::{ClassType, KnownClass};
 use crate::types::visitor::{TypeVisitor, TypeVisitorResult};
 use crate::types::{
-    Type, TypeMapping, TypeRelation, TypeTransformer, TypeVarInstance, TypeVarVariance,
-    UnionBuilder, UnionType, cyclic::PairVisitor,
+    Type, TypeMapping, TypeRelation, TypeTransformer, TypeVarVariance, UnionBuilder, UnionType,
+    cyclic::PairVisitor,
 };
 use crate::util::subscript::{Nth, OutOfBoundsError, PyIndex, PySlice, StepSizeZeroError};
-use crate::{Db, FxOrderSet};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum TupleLength {
@@ -223,14 +223,6 @@ impl<'db> TupleType<'db> {
         TupleType::new(db, self.tuple(db).apply_type_mapping(db, type_mapping))
     }
 
-    pub(crate) fn find_legacy_typevars(
-        self,
-        db: &'db dyn Db,
-        typevars: &mut FxOrderSet<TypeVarInstance<'db>>,
-    ) {
-        self.tuple(db).find_legacy_typevars(db, typevars);
-    }
-
     pub(crate) fn has_relation_to(
         self,
         db: &'db dyn Db,
@@ -384,16 +376,6 @@ impl<'db> FixedLengthTuple<Type<'db>> {
                 .iter()
                 .map(|ty| ty.apply_type_mapping(db, type_mapping)),
         )
-    }
-
-    fn find_legacy_typevars(
-        &self,
-        db: &'db dyn Db,
-        typevars: &mut FxOrderSet<TypeVarInstance<'db>>,
-    ) {
-        for ty in &self.0 {
-            ty.find_legacy_typevars(db, typevars);
-        }
     }
 
     fn has_relation_to(
@@ -722,20 +704,6 @@ impl<'db> VariableLengthTuple<Type<'db>> {
                 .iter()
                 .map(|ty| ty.apply_type_mapping(db, type_mapping)),
         )
-    }
-
-    fn find_legacy_typevars(
-        &self,
-        db: &'db dyn Db,
-        typevars: &mut FxOrderSet<TypeVarInstance<'db>>,
-    ) {
-        for ty in &self.prefix {
-            ty.find_legacy_typevars(db, typevars);
-        }
-        self.variable.find_legacy_typevars(db, typevars);
-        for ty in &self.suffix {
-            ty.find_legacy_typevars(db, typevars);
-        }
     }
 
     fn has_relation_to(
@@ -1068,17 +1036,6 @@ impl<'db> Tuple<Type<'db>> {
         match self {
             Tuple::Fixed(tuple) => Tuple::Fixed(tuple.apply_type_mapping(db, type_mapping)),
             Tuple::Variable(tuple) => tuple.apply_type_mapping(db, type_mapping),
-        }
-    }
-
-    fn find_legacy_typevars(
-        &self,
-        db: &'db dyn Db,
-        typevars: &mut FxOrderSet<TypeVarInstance<'db>>,
-    ) {
-        match self {
-            Tuple::Fixed(tuple) => tuple.find_legacy_typevars(db, typevars),
-            Tuple::Variable(tuple) => tuple.find_legacy_typevars(db, typevars),
         }
     }
 

--- a/crates/ty_python_semantic/src/types/visitor.rs
+++ b/crates/ty_python_semantic/src/types/visitor.rs
@@ -16,96 +16,146 @@ use crate::{
     },
 };
 
+/// The result returned from the [`TypeVisitor`] trait methods. You can abort the visitor by
+/// returning `Err(AbortTypeVisitor)`.
+pub(crate) type TypeVisitorResult = Result<(), AbortTypeVisitor>;
+
+/// Indicates that you wish to abort visiting a type.
+pub(crate) struct AbortTypeVisitor;
+
 /// A visitor trait that recurses into nested types.
 ///
-/// The trait does not guard against infinite recursion out of the box,
-/// but it makes it easy for implementors of the trait to do so.
-/// See [`any_over_type`] for an example of how to do this.
+/// You will typically not call the methods of this trait directly; instead, call the
+/// [`visit_type`] function, which handles visiting infinitely recursive types correctly.
 pub(crate) trait TypeVisitor<'db> {
-    fn visit_type(&mut self, db: &'db dyn Db, ty: Type<'db>);
+    fn visit_type(&mut self, db: &'db dyn Db, ty: Type<'db>) -> TypeVisitorResult;
 
-    fn visit_union_type(&mut self, db: &'db dyn Db, union: UnionType<'db>) {
-        walk_union(db, union, self);
+    fn visit_union_type(&mut self, db: &'db dyn Db, union: UnionType<'db>) -> TypeVisitorResult {
+        walk_union(db, union, self)
     }
 
-    fn visit_intersection_type(&mut self, db: &'db dyn Db, intersection: IntersectionType<'db>) {
-        walk_intersection_type(db, intersection, self);
+    fn visit_intersection_type(
+        &mut self,
+        db: &'db dyn Db,
+        intersection: IntersectionType<'db>,
+    ) -> TypeVisitorResult {
+        walk_intersection_type(db, intersection, self)
     }
 
-    fn visit_tuple_type(&mut self, db: &'db dyn Db, tuple: TupleType<'db>) {
-        walk_tuple_type(db, tuple, self);
+    fn visit_tuple_type(&mut self, db: &'db dyn Db, tuple: TupleType<'db>) -> TypeVisitorResult {
+        walk_tuple_type(db, tuple, self)
     }
 
-    fn visit_callable_type(&mut self, db: &'db dyn Db, callable: CallableType<'db>) {
-        walk_callable_type(db, callable, self);
+    fn visit_callable_type(
+        &mut self,
+        db: &'db dyn Db,
+        callable: CallableType<'db>,
+    ) -> TypeVisitorResult {
+        walk_callable_type(db, callable, self)
     }
 
     fn visit_property_instance_type(
         &mut self,
         db: &'db dyn Db,
         property: PropertyInstanceType<'db>,
-    ) {
-        walk_property_instance_type(db, property, self);
+    ) -> TypeVisitorResult {
+        walk_property_instance_type(db, property, self)
     }
 
-    fn visit_typeis_type(&mut self, db: &'db dyn Db, type_is: TypeIsType<'db>) {
-        walk_typeis_type(db, type_is, self);
+    fn visit_typeis_type(
+        &mut self,
+        db: &'db dyn Db,
+        type_is: TypeIsType<'db>,
+    ) -> TypeVisitorResult {
+        walk_typeis_type(db, type_is, self)
     }
 
-    fn visit_subclass_of_type(&mut self, db: &'db dyn Db, subclass_of: SubclassOfType<'db>) {
-        walk_subclass_of_type(db, subclass_of, self);
+    fn visit_subclass_of_type(
+        &mut self,
+        db: &'db dyn Db,
+        subclass_of: SubclassOfType<'db>,
+    ) -> TypeVisitorResult {
+        walk_subclass_of_type(db, subclass_of, self)
     }
 
-    fn visit_generic_alias_type(&mut self, db: &'db dyn Db, alias: GenericAlias<'db>) {
-        walk_generic_alias(db, alias, self);
+    fn visit_generic_alias_type(
+        &mut self,
+        db: &'db dyn Db,
+        alias: GenericAlias<'db>,
+    ) -> TypeVisitorResult {
+        walk_generic_alias(db, alias, self)
     }
 
-    fn visit_function_type(&mut self, db: &'db dyn Db, function: FunctionType<'db>) {
-        walk_function_type(db, function, self);
+    fn visit_function_type(
+        &mut self,
+        db: &'db dyn Db,
+        function: FunctionType<'db>,
+    ) -> TypeVisitorResult {
+        walk_function_type(db, function, self)
     }
 
-    fn visit_bound_method_type(&mut self, db: &'db dyn Db, method: BoundMethodType<'db>) {
-        walk_bound_method_type(db, method, self);
+    fn visit_bound_method_type(
+        &mut self,
+        db: &'db dyn Db,
+        method: BoundMethodType<'db>,
+    ) -> TypeVisitorResult {
+        walk_bound_method_type(db, method, self)
     }
 
-    fn visit_bound_super_type(&mut self, db: &'db dyn Db, bound_super: BoundSuperType<'db>) {
-        walk_bound_super_type(db, bound_super, self);
+    fn visit_bound_super_type(
+        &mut self,
+        db: &'db dyn Db,
+        bound_super: BoundSuperType<'db>,
+    ) -> TypeVisitorResult {
+        walk_bound_super_type(db, bound_super, self)
     }
 
-    fn visit_nominal_instance_type(&mut self, db: &'db dyn Db, nominal: NominalInstanceType<'db>) {
-        walk_nominal_instance_type(db, nominal, self);
+    fn visit_nominal_instance_type(
+        &mut self,
+        db: &'db dyn Db,
+        nominal: NominalInstanceType<'db>,
+    ) -> TypeVisitorResult {
+        walk_nominal_instance_type(db, nominal, self)
     }
 
-    fn visit_type_var_type(&mut self, db: &'db dyn Db, type_var: TypeVarInstance<'db>) {
-        walk_type_var_type(db, type_var, self);
+    fn visit_type_var_type(
+        &mut self,
+        db: &'db dyn Db,
+        type_var: TypeVarInstance<'db>,
+    ) -> TypeVisitorResult {
+        walk_type_var_type(db, type_var, self)
     }
 
     fn visit_protocol_instance_type(
         &mut self,
         db: &'db dyn Db,
         protocol: ProtocolInstanceType<'db>,
-    ) {
-        walk_protocol_instance_type(db, protocol, self);
+    ) -> TypeVisitorResult {
+        walk_protocol_instance_type(db, protocol, self)
     }
 
     fn visit_method_wrapper_type(
         &mut self,
         db: &'db dyn Db,
         method_wrapper: MethodWrapperKind<'db>,
-    ) {
-        walk_method_wrapper_type(db, method_wrapper, self);
+    ) -> TypeVisitorResult {
+        walk_method_wrapper_type(db, method_wrapper, self)
     }
 
     fn visit_known_instance_type(
         &mut self,
         db: &'db dyn Db,
         known_instance: KnownInstanceType<'db>,
-    ) {
-        walk_known_instance_type(db, known_instance, self);
+    ) -> TypeVisitorResult {
+        walk_known_instance_type(db, known_instance, self)
     }
 
-    fn visit_type_alias_type(&mut self, db: &'db dyn Db, type_alias: TypeAliasType<'db>) {
-        walk_type_alias_type(db, type_alias, self);
+    fn visit_type_alias_type(
+        &mut self,
+        db: &'db dyn Db,
+        type_alias: TypeAliasType<'db>,
+    ) -> TypeVisitorResult {
+        walk_type_alias_type(db, type_alias, self)
     }
 }
 
@@ -198,79 +248,104 @@ fn walk_non_atomic_type<'db, V: TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
     non_atomic_type: NonAtomicType<'db>,
     visitor: &mut V,
-) {
+) -> TypeVisitorResult {
     match non_atomic_type {
         NonAtomicType::FunctionLiteral(function) => visitor.visit_function_type(db, function),
         NonAtomicType::Intersection(intersection) => {
-            visitor.visit_intersection_type(db, intersection);
+            visitor.visit_intersection_type(db, intersection)
         }
         NonAtomicType::Union(union) => visitor.visit_union_type(db, union),
         NonAtomicType::Tuple(tuple) => visitor.visit_tuple_type(db, tuple),
         NonAtomicType::BoundMethod(method) => visitor.visit_bound_method_type(db, method),
         NonAtomicType::BoundSuper(bound_super) => visitor.visit_bound_super_type(db, bound_super),
         NonAtomicType::MethodWrapper(method_wrapper) => {
-            visitor.visit_method_wrapper_type(db, method_wrapper);
+            visitor.visit_method_wrapper_type(db, method_wrapper)
         }
         NonAtomicType::Callable(callable) => visitor.visit_callable_type(db, callable),
         NonAtomicType::GenericAlias(alias) => visitor.visit_generic_alias_type(db, alias),
         NonAtomicType::KnownInstance(known_instance) => {
-            visitor.visit_known_instance_type(db, known_instance);
+            visitor.visit_known_instance_type(db, known_instance)
         }
         NonAtomicType::SubclassOf(subclass_of) => visitor.visit_subclass_of_type(db, subclass_of),
         NonAtomicType::NominalInstance(nominal) => visitor.visit_nominal_instance_type(db, nominal),
         NonAtomicType::PropertyInstance(property) => {
-            visitor.visit_property_instance_type(db, property);
+            visitor.visit_property_instance_type(db, property)
         }
         NonAtomicType::TypeIs(type_is) => visitor.visit_typeis_type(db, type_is),
         NonAtomicType::TypeVar(type_var) => visitor.visit_type_var_type(db, type_var),
         NonAtomicType::ProtocolInstance(protocol) => {
-            visitor.visit_protocol_instance_type(db, protocol);
+            visitor.visit_protocol_instance_type(db, protocol)
         }
     }
 }
 
+/// Visits a type while guarding against infinite recursion. This lets you write a [`TypeVisitor`]
+/// without having to track which types have already been seen. We guarantee that your
+/// [`visit_type`][TypeVisitor::visit_type] trait method will only be called once for each distinct
+/// non-atomic type that is encountered.
+pub(super) fn visit_type<'a, 'db, V>(db: &'db dyn Db, wrapped: &'a mut V, ty: Type<'db>)
+where
+    V: TypeVisitor<'db>,
+{
+    struct RecursionGuard<'a, 'db, V> {
+        wrapped: &'a mut V,
+        seen_types: FxIndexSet<NonAtomicType<'db>>,
+    }
+
+    impl<'db, V> TypeVisitor<'db> for RecursionGuard<'_, 'db, V>
+    where
+        V: TypeVisitor<'db>,
+    {
+        fn visit_type(&mut self, db: &'db dyn Db, ty: Type<'db>) -> TypeVisitorResult {
+            self.wrapped.visit_type(db, ty)?;
+            match TypeKind::from(ty) {
+                TypeKind::Atomic => {}
+                TypeKind::NonAtomic(non_atomic_type) => {
+                    if self.seen_types.insert(non_atomic_type) {
+                        // If we haven't already seen this type, we should recurse into it.
+                        walk_non_atomic_type(db, non_atomic_type, self)?;
+                    }
+                }
+            }
+            Ok(())
+        }
+    }
+
+    let mut visitor = RecursionGuard {
+        wrapped,
+        seen_types: FxIndexSet::default(),
+    };
+    let _ = visitor.visit_type(db, ty);
+}
+
 /// Return `true` if `ty`, or any of the types contained in `ty`, match the closure passed in.
-///
-/// The function guards against infinite recursion
-/// by keeping track of the non-atomic types it has already seen.
 pub(super) fn any_over_type<'db>(
     db: &'db dyn Db,
     ty: Type<'db>,
-    query: &dyn Fn(Type<'db>) -> bool,
+    query: &'db dyn Fn(Type<'db>) -> bool,
 ) -> bool {
     struct AnyOverTypeVisitor<'db, 'a> {
         query: &'a dyn Fn(Type<'db>) -> bool,
-        seen_types: FxIndexSet<NonAtomicType<'db>>,
         found_matching_type: bool,
     }
 
     impl<'db> TypeVisitor<'db> for AnyOverTypeVisitor<'db, '_> {
-        fn visit_type(&mut self, db: &'db dyn Db, ty: Type<'db>) {
+        fn visit_type(&mut self, _db: &'db dyn Db, ty: Type<'db>) -> TypeVisitorResult {
             if self.found_matching_type {
-                return;
+                return Err(AbortTypeVisitor);
             }
             self.found_matching_type |= (self.query)(ty);
             if self.found_matching_type {
-                return;
+                return Err(AbortTypeVisitor);
             }
-            match TypeKind::from(ty) {
-                TypeKind::Atomic => {}
-                TypeKind::NonAtomic(non_atomic_type) => {
-                    if !self.seen_types.insert(non_atomic_type) {
-                        // If we have already seen this type, we can skip it.
-                        return;
-                    }
-                    walk_non_atomic_type(db, non_atomic_type, self);
-                }
-            }
+            Ok(())
         }
     }
 
     let mut visitor = AnyOverTypeVisitor {
         query,
-        seen_types: FxIndexSet::default(),
         found_matching_type: false,
     };
-    visitor.visit_type(db, ty);
+    visit_type(db, &mut visitor, ty);
     visitor.found_matching_type
 }


### PR DESCRIPTION
Now that we have a nice mechanism for visiting a type, we can replace the `find_legacy_typevars` method with a `TypeVisitor`. To make this happen, this PR also adds the following:

- Type visitors can now return an `AbortTypeVisitor` result to end the visitor early.
- The logic for avoiding infinite recursion has been factored out into a more reusable helper method.
- We implement `TypeVisitor` for closures that have the right signature, meaning that we usually won't need to create a named type for the visitor.