### PR TITLE
Fix copy and line separator colors in dark mode

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -27,6 +27,7 @@
   --md-primary-fg-color: var(--galaxy);
   --md-typeset-a-color: var(--flare);
   --md-accent-fg-color: var(--cosmic);
+  --md-default-fg-color--lightest: rgba(0, 0, 0, 0.14);
 }
 
 [data-md-color-scheme="astral-dark"] {
@@ -34,6 +35,7 @@
   --md-default-fg-color: var(--white);
   --md-default-fg-color--light: var(--white);
   --md-default-fg-color--lighter: var(--white);
+  --md-default-fg-color--lightest: rgba(255, 255, 255, 0.5);
   --md-primary-fg-color: var(--space);
   --md-primary-bg-color: var(--white);
   --md-accent-fg-color: var(--cosmic);
@@ -120,3 +122,4 @@
 .toclink:hover {
   color: var(--md-accent-fg-color) !important;
 }
+


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ruff/issues/19613

Note: We have the same issue in the ty and uv documentation.

## Test Plan

Before 
<img width="1210" height="677" alt="Screenshot 2025-07-30 at 09 22 39" src="https://github.com/user-attachments/assets/4a5864e9-6194-450a-b4ac-e45a205295c9" />

After


<img width="1671" height="923" alt="Screenshot 2025-07-30 at 09 36 05" src="https://github.com/user-attachments/assets/0eb8c43a-4075-4c72-81d9-3fdee1bfedc0" />


I also decided to change the color for light mode too because the visibility wasn't great either:

Before

<img width="1671" height="923" alt="Screenshot 2025-07-30 at 09 37 36" src="https://github.com/user-attachments/assets/a40f4754-c049-4c8b-b6fe-a56a0ae6fe71" />

After
<img width="1089" height="576" alt="Screenshot 2025-07-30 at 09 37 09" src="https://github.com/user-attachments/assets/a986a85b-9012-46d4-bdcb-7eb01fb7a005" />

