### PR TITLE
[`RUF`] Fix indentation to preserve relative whitespace in multi-line expressions (`RUF033`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF033.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF033.py
@@ -124,3 +124,12 @@ def fun_with_python_syntax():
             ...
 
     return Foo
+
+
+@dataclass
+class C:
+    def __post_init__(self, x: tuple[int, ...] = (
+        1,
+        2,
+    )) -> None:
+        self.x = x

--- a/crates/ruff_linter/src/rules/ruff/rules/post_init_default.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/post_init_default.rs
@@ -186,7 +186,7 @@ fn use_initvar(
 
     let indentation = indentation_at_offset(post_init_def.start(), checker.source())
         .context("Failed to calculate leading indentation of `__post_init__` method")?;
-    let content = textwrap::indent(&content, indentation);
+    let content = textwrap::indent_first_line(&content, indentation);
 
     let initvar_edit = Edit::insertion(
         content.into_owned(),

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF033_RUF033.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF033_RUF033.py.snap
@@ -434,3 +434,30 @@ RUF033.py:121:27: RUF033 [*] `__post_init__` method with argument defaults
 122 123 |             ,
 123 124 |         ) -> None:
 124 125 |             ...
+
+RUF033.py:131:50: RUF033 [*] `__post_init__` method with argument defaults
+    |
+129 |   @dataclass
+130 |   class C:
+131 |       def __post_init__(self, x: tuple[int, ...] = (
+    |  __________________________________________________^
+132 | |         1,
+133 | |         2,
+134 | |     )) -> None:
+    | |_____^ RUF033
+135 |           self.x = x
+    |
+    = help: Use `dataclasses.InitVar` instead
+
+ℹ Unsafe fix
+128 128 | 
+129 129 | @dataclass
+130 130 | class C:
+131     |-    def __post_init__(self, x: tuple[int, ...] = (
+    131 |+    x: InitVar[tuple[int, ...]] = (
+132 132 |         1,
+133 133 |         2,
+134     |-    )) -> None:
+    134 |+    )
+    135 |+    def __post_init__(self, x: tuple[int, ...]) -> None:
+135 136 |         self.x = x


### PR DESCRIPTION
## Summary

Fixes #19581

I decided to add in a `indent_first_line` function into [`textwrap.rs`](https://github.com/astral-sh/ruff/blob/main/crates/ruff_python_trivia/src/textwrap.rs), as this it solely focuses on text manipulation utilities. It follows the same design as `indent()`, and there may be situations in the future where it can be reused as well.