### PR TITLE
Update pre-commit's `ruff` id

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -109,7 +109,7 @@ Ruff can be used as a [pre-commit](https://pre-commit.com) hook via [`ruff-pre-c
   rev: v0.12.7
   hooks:
     # Run the linter.
-    - id: ruff
+    - id: ruff-check
     # Run the formatter.
     - id: ruff-format
 ```
@@ -122,7 +122,7 @@ To enable lint fixes, add the `--fix` argument to the lint hook:
   rev: v0.12.7
   hooks:
     # Run the linter.
-    - id: ruff
+    - id: ruff-check
       args: [ --fix ]
     # Run the formatter.
     - id: ruff-format
@@ -136,7 +136,7 @@ To avoid running on Jupyter Notebooks, remove `jupyter` from the list of allowed
   rev: v0.12.7
   hooks:
     # Run the linter.
-    - id: ruff
+    - id: ruff-check
       types_or: [ python, pyi ]
       args: [ --fix ]
     # Run the formatter.


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

Updates the usage of `ruff` in `pre-commit` according to https://github.com/astral-sh/ruff-pre-commit/commit/39f54b73c72a16ee873859353d1ef40552a22e4d. This was previously missed by https://github.com/astral-sh/ruff/pull/18718
