### PR TITLE
[ty] Move `pandas-stubs` to bad.txt

### DIFF
--- a/crates/ty_python_semantic/resources/primer/bad.txt
+++ b/crates/ty_python_semantic/resources/primer/bad.txt
@@ -10,6 +10,8 @@ jax  # too many iterations
 mypy # too many iterations (self-recursive type alias)
 packaging  # too many iterations
 pandas  # slow (9s)
+pandas-stubs  # panics on versions of pandas-stubs newer than https://github.com/pandas-dev/pandas-stubs/commit/bf1221eb7ea0e582c30fe233d1f4f5713fce376b
+              # Panicked at crates/ty_python_semantic/src/types/type_ordering.rs:207:13 when checking `/tmp/mypy_primer/projects/pandas-stubs/tests/test_indexes.py`: `internal error: entered unreachable code: our type representation does not permit nested unions`
 pandera  # too many iterations
 pip  # vendors packaging, see above
 pylint  # cycle panics (self-recursive type alias)

--- a/crates/ty_python_semantic/resources/primer/good.txt
+++ b/crates/ty_python_semantic/resources/primer/good.txt
@@ -69,7 +69,6 @@ openlibrary
 operator
 optuna
 paasta
-pandas-stubs
 paroxython
 parso
 pegen


### PR DESCRIPTION
## Summary

Following https://github.com/pandas-dev/pandas-stubs/commit/bf1221eb7ea0e582c30fe233d1f4f5713fce376b, we panic when trying to check the pandas-stubs `main` branch (we're entering code that's supposed to be unreachable, which is exciting!). This is causing every mypy_primer run to fail and meaning that we can't get diffs on PRs, so for now I'm just moving the project to bad.txt.

## Test Plan

Hopefully primer will not fail on this PR
