### PR TITLE
Add support for using uv as an alternative formatter backend

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -247,6 +247,10 @@ jobs:
         uses: taiki-e/install-action@c99cc51b309eee71a866715cfa08c922f11cf898 # v2.56.19
         with:
           tool: cargo-insta
+      - name: "Install uv"
+        uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc # v6.4.3
+        with:
+          enable-cache: "true"
       - name: ty mdtests (GitHub annotations)
         if: ${{ needs.determine_changes.outputs.ty == 'true' }}
         env:
@@ -305,6 +309,10 @@ jobs:
         uses: taiki-e/install-action@c99cc51b309eee71a866715cfa08c922f11cf898 # v2.56.19
         with:
           tool: cargo-insta
+      - name: "Install uv"
+        uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc # v6.4.3
+        with:
+          enable-cache: "true"
       - name: "Run tests"
         shell: bash
         env:
@@ -328,6 +336,10 @@ jobs:
         uses: taiki-e/install-action@c99cc51b309eee71a866715cfa08c922f11cf898 # v2.56.19
         with:
           tool: cargo-nextest
+      - name: "Install uv"
+        uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc # v6.4.3
+        with:
+          enable-cache: "true"
       - name: "Run tests"
         shell: bash
         env:

--- a/crates/ruff_formatter/src/lib.rs
+++ b/crates/ruff_formatter/src/lib.rs
@@ -81,14 +81,19 @@ impl IndentStyle {
     pub const fn is_space(&self) -> bool {
         matches!(self, IndentStyle::Space)
     }
+
+    /// Returns the string representation of the indent style.
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            IndentStyle::Tab => "tab",
+            IndentStyle::Space => "space",
+        }
+    }
 }
 
 impl std::fmt::Display for IndentStyle {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            IndentStyle::Tab => std::write!(f, "tab"),
-            IndentStyle::Space => std::write!(f, "space"),
-        }
+        f.write_str(self.as_str())
     }
 }
 

--- a/crates/ruff_formatter/src/printer/printer_options/mod.rs
+++ b/crates/ruff_formatter/src/printer/printer_options/mod.rs
@@ -139,4 +139,16 @@ impl LineEnding {
             LineEnding::CarriageReturn => "\r",
         }
     }
+
+    /// Returns the string used to configure this line ending.
+    ///
+    /// See [`LineEnding::as_str`] for the actual string representation of the line ending.
+    #[inline]
+    pub const fn as_setting_str(&self) -> &'static str {
+        match self {
+            LineEnding::LineFeed => "lf",
+            LineEnding::CarriageReturnLineFeed => "crlf",
+            LineEnding::CarriageReturn => "cr",
+        }
+    }
 }

--- a/crates/ruff_python_formatter/src/options.rs
+++ b/crates/ruff_python_formatter/src/options.rs
@@ -252,15 +252,20 @@ impl QuoteStyle {
     pub const fn is_preserve(self) -> bool {
         matches!(self, QuoteStyle::Preserve)
     }
+
+    /// Returns the string representation of the quote style.
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            QuoteStyle::Single => "single",
+            QuoteStyle::Double => "double",
+            QuoteStyle::Preserve => "preserve",
+        }
+    }
 }
 
 impl fmt::Display for QuoteStyle {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Single => write!(f, "single"),
-            Self::Double => write!(f, "double"),
-            Self::Preserve => write!(f, "preserve"),
-        }
+        f.write_str(self.as_str())
     }
 }
 
@@ -302,10 +307,10 @@ impl MagicTrailingComma {
 
 impl fmt::Display for MagicTrailingComma {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Respect => write!(f, "respect"),
-            Self::Ignore => write!(f, "ignore"),
-        }
+        f.write_str(match self {
+            MagicTrailingComma::Respect => "respect",
+            MagicTrailingComma::Ignore => "ignore",
+        })
     }
 }
 

--- a/crates/ruff_server/Cargo.toml
+++ b/crates/ruff_server/Cargo.toml
@@ -50,5 +50,8 @@ insta = { workspace = true }
 [target.'cfg(target_vendor = "apple")'.dependencies]
 libc = { workspace = true }
 
+[features]
+test-uv = []
+
 [lints]
 workspace = true

--- a/crates/ruff_server/src/format.rs
+++ b/crates/ruff_server/src/format.rs
@@ -1,14 +1,48 @@
+use std::io::Write;
 use std::path::Path;
+use std::process::{Command, Stdio};
 
-use ruff_formatter::PrintedRange;
+use anyhow::Context;
+
+use ruff_formatter::{FormatOptions, PrintedRange};
 use ruff_python_ast::PySourceType;
-use ruff_python_formatter::{FormatModuleError, format_module_source};
+use ruff_python_formatter::{FormatModuleError, PyFormatOptions, format_module_source};
+use ruff_source_file::LineIndex;
 use ruff_text_size::TextRange;
 use ruff_workspace::FormatterSettings;
 
 use crate::edit::TextDocument;
 
+/// The backend to use for formatting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum FormatBackend {
+    /// Use the built-in Ruff formatter.
+    ///
+    /// The formatter version will match the LSP version.
+    #[default]
+    Internal,
+    /// Use uv for formatting.
+    ///
+    /// The formatter version may differ from the LSP version.
+    Uv,
+}
+
 pub(crate) fn format(
+    document: &TextDocument,
+    source_type: PySourceType,
+    formatter_settings: &FormatterSettings,
+    path: &Path,
+    backend: FormatBackend,
+) -> crate::Result<Option<String>> {
+    match backend {
+        FormatBackend::Uv => format_external(document, source_type, formatter_settings, path),
+        FormatBackend::Internal => format_internal(document, source_type, formatter_settings, path),
+    }
+}
+
+/// Format using the built-in Ruff formatter.
+fn format_internal(
     document: &TextDocument,
     source_type: PySourceType,
     formatter_settings: &FormatterSettings,
@@ -35,7 +69,39 @@ pub(crate) fn format(
     }
 }
 
+/// Format using an external uv command.
+fn format_external(
+    document: &TextDocument,
+    source_type: PySourceType,
+    formatter_settings: &FormatterSettings,
+    path: &Path,
+) -> crate::Result<Option<String>> {
+    let format_options =
+        formatter_settings.to_format_options(source_type, document.contents(), Some(path));
+    let uv_command = UvFormatCommand::from(format_options);
+    uv_command.format_document(document.contents(), path)
+}
+
 pub(crate) fn format_range(
+    document: &TextDocument,
+    source_type: PySourceType,
+    formatter_settings: &FormatterSettings,
+    range: TextRange,
+    path: &Path,
+    backend: FormatBackend,
+) -> crate::Result<Option<PrintedRange>> {
+    match backend {
+        FormatBackend::Uv => {
+            format_range_external(document, source_type, formatter_settings, range, path)
+        }
+        FormatBackend::Internal => {
+            format_range_internal(document, source_type, formatter_settings, range, path)
+        }
+    }
+}
+
+/// Format range using the built-in Ruff formatter
+fn format_range_internal(
     document: &TextDocument,
     source_type: PySourceType,
     formatter_settings: &FormatterSettings,
@@ -63,6 +129,185 @@ pub(crate) fn format_range(
     }
 }
 
+/// Format range using an external command, i.e., `uv`.
+fn format_range_external(
+    document: &TextDocument,
+    source_type: PySourceType,
+    formatter_settings: &FormatterSettings,
+    range: TextRange,
+    path: &Path,
+) -> crate::Result<Option<PrintedRange>> {
+    let format_options =
+        formatter_settings.to_format_options(source_type, document.contents(), Some(path));
+    let uv_command = UvFormatCommand::from(format_options);
+
+    // Format the range using uv and convert the result to `PrintedRange`
+    match uv_command.format_range(document.contents(), range, path, document.index())? {
+        Some(formatted) => Ok(Some(PrintedRange::new(formatted, range))),
+        None => Ok(None),
+    }
+}
+
+/// Builder for uv format commands
+#[derive(Debug)]
+pub(crate) struct UvFormatCommand {
+    options: PyFormatOptions,
+}
+
+impl From<PyFormatOptions> for UvFormatCommand {
+    fn from(options: PyFormatOptions) -> Self {
+        Self { options }
+    }
+}
+
+impl UvFormatCommand {
+    /// Build the command with all necessary arguments
+    fn build_command(
+        &self,
+        path: &Path,
+        range_with_index: Option<(TextRange, &LineIndex, &str)>,
+    ) -> Command {
+        // TODO(zanieb): We actually want to invoke `uv format` here, but that needs to be released
+        // first! So for now, we're using this as a placeholder to test the experience.
+        let mut command = Command::new("uvx");
+        command.arg("ruff");
+        command.arg("format");
+
+        let target_version = format!(
+            "py{}{}",
+            self.options.target_version().major,
+            self.options.target_version().minor
+        );
+        let line_width = FormatOptions::line_width(&self.options).value().to_string();
+        let indent_width = FormatOptions::indent_width(&self.options)
+            .value()
+            .to_string();
+
+        // Add only the formatting options that the CLI supports
+        command.arg("--target-version");
+        command.arg(&target_version);
+
+        command.arg("--line-length");
+        command.arg(&line_width);
+
+        if self.options.preview().is_enabled() {
+            command.arg("--preview");
+        }
+
+        // Pass other formatting options via --config
+        command.arg("--config");
+        command.arg(format!(
+            "format.indent-style = '{}'",
+            FormatOptions::indent_style(&self.options).as_str()
+        ));
+
+        command.arg("--config");
+        command.arg(format!("indent-width = {indent_width}"));
+
+        command.arg("--config");
+        command.arg(format!(
+            "format.quote-style = '{}'",
+            self.options.quote_style().as_str()
+        ));
+
+        command.arg("--config");
+        command.arg(format!(
+            "format.line-ending = '{}'",
+            self.options.line_ending().as_setting_str()
+        ));
+
+        command.arg("--config");
+        command.arg(format!(
+            "format.skip-magic-trailing-comma = {}",
+            match self.options.magic_trailing_comma() {
+                ruff_python_formatter::MagicTrailingComma::Respect => "false",
+                ruff_python_formatter::MagicTrailingComma::Ignore => "true",
+            }
+        ));
+
+        if let Some((range, line_index, source)) = range_with_index {
+            // The CLI expects line:column format
+            let start_pos = line_index.line_column(range.start(), source);
+            let end_pos = line_index.line_column(range.end(), source);
+            let range_str = format!(
+                "{}:{}-{}:{}",
+                start_pos.line.get(),
+                start_pos.column.get(),
+                end_pos.line.get(),
+                end_pos.column.get()
+            );
+            command.arg("--range");
+            command.arg(&range_str);
+        }
+
+        command.arg("--stdin-filename");
+        command.arg(path.to_string_lossy().as_ref());
+
+        command.stdin(Stdio::piped());
+        command.stdout(Stdio::piped());
+
+        command
+    }
+
+    /// Execute the format command on the given source.
+    pub(crate) fn format(
+        &self,
+        source: &str,
+        path: &Path,
+        range_with_index: Option<(TextRange, &LineIndex)>,
+    ) -> crate::Result<Option<String>> {
+        let mut command =
+            self.build_command(path, range_with_index.map(|(r, idx)| (r, idx, source)));
+        let mut child = command.spawn().context("Failed to spawn uv")?;
+
+        let mut stdin = child.stdin.take().context("Failed to get stdin")?;
+        stdin
+            .write_all(source.as_bytes())
+            .context("Failed to write to stdin")?;
+        drop(stdin);
+
+        let output = child.wait_with_output().context("Failed to get output")?;
+
+        // TODO(zanieb): We should find a way to special case syntax/parse errors as we do with the
+        // internal implementation.
+
+        // TODO(zanieb): We should consider returning this case to the caller somehow
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            tracing::warn!("uvx ruff format failed: {}", stderr);
+            return Ok(None);
+        }
+
+        let formatted = String::from_utf8(output.stdout).context("Invalid UTF-8 in output")?;
+
+        if formatted == source {
+            Ok(None)
+        } else {
+            Ok(Some(formatted))
+        }
+    }
+
+    /// Format the entire document.
+    pub(crate) fn format_document(
+        &self,
+        source: &str,
+        path: &Path,
+    ) -> crate::Result<Option<String>> {
+        self.format(source, path, None)
+    }
+
+    /// Format a specific range.
+    pub(crate) fn format_range(
+        &self,
+        source: &str,
+        range: TextRange,
+        path: &Path,
+        line_index: &LineIndex,
+    ) -> crate::Result<Option<String>> {
+        self.format(source, path, Some((range, line_index)))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::path::Path;
@@ -74,7 +319,7 @@ mod tests {
     use ruff_workspace::FormatterSettings;
 
     use crate::TextDocument;
-    use crate::format::{format, format_range};
+    use crate::format::{FormatBackend, format, format_range};
 
     #[test]
     fn format_per_file_version() {
@@ -98,6 +343,7 @@ with open("a_really_long_foo") as foo, open("a_really_long_bar") as bar, open("a
                 ..Default::default()
             },
             Path::new("test.py"),
+            FormatBackend::Internal,
         )
         .expect("Expected no errors when formatting")
         .expect("Expected formatting changes");
@@ -120,6 +366,7 @@ with open("a_really_long_foo") as foo, open("a_really_long_bar") as bar, open("a
                 ..Default::default()
             },
             Path::new("test.py"),
+            FormatBackend::Internal,
         )
         .expect("Expected no errors when formatting")
         .expect("Expected formatting changes");
@@ -168,6 +415,7 @@ sys.exit(
             },
             range,
             Path::new("test.py"),
+            FormatBackend::Internal,
         )
         .expect("Expected no errors when formatting")
         .expect("Expected formatting changes");
@@ -191,6 +439,7 @@ sys.exit(
             },
             range,
             Path::new("test.py"),
+            FormatBackend::Internal,
         )
         .expect("Expected no errors when formatting")
         .expect("Expected formatting changes");
@@ -203,5 +452,280 @@ sys.exit(
         "#);
 
         Ok(())
+    }
+
+    #[cfg(feature = "test-uv")]
+    mod uv_tests {
+        use super::*;
+
+        #[test]
+        fn test_uv_format_document() {
+            let document = TextDocument::new(
+                r#"
+def hello(  x,y ,z  ):
+    return x+y  +z
+
+
+def world(  ):
+    pass
+"#
+                .to_string(),
+                0,
+            );
+
+            let result = format(
+                &document,
+                PySourceType::Python,
+                &FormatterSettings::default(),
+                Path::new("test.py"),
+                FormatBackend::Uv,
+            )
+            .expect("Expected no errors when formatting with uv")
+            .expect("Expected formatting changes");
+
+            // uv should format this to a consistent style
+            assert_snapshot!(result, @r#"
+            def hello(x, y, z):
+                return x + y + z
+
+
+            def world():
+                pass
+            "#);
+        }
+
+        #[test]
+        fn test_uv_format_range() -> anyhow::Result<()> {
+            let document = TextDocument::new(
+                r#"
+def messy_function(  a,  b,c   ):
+    return a+b+c
+
+def another_function(x,y,z):
+    result=x+y+z
+    return result
+"#
+                .to_string(),
+                0,
+            );
+
+            // Find the range of the second function
+            let start = document.contents().find("def another_function").unwrap();
+            let end = document.contents().find("return result").unwrap() + "return result".len();
+            let range = TextRange::new(TextSize::try_from(start)?, TextSize::try_from(end)?);
+
+            let result = format_range(
+                &document,
+                PySourceType::Python,
+                &FormatterSettings::default(),
+                range,
+                Path::new("test.py"),
+                FormatBackend::Uv,
+            )
+            .expect("Expected no errors when formatting range with uv")
+            .expect("Expected formatting changes");
+
+            assert_snapshot!(result.as_code(), @r#"
+            def messy_function(  a,  b,c   ):
+                return a+b+c
+            
+            def another_function(x, y, z):
+                result = x + y + z
+                return result
+            "#);
+
+            Ok(())
+        }
+
+        #[test]
+        fn test_uv_format_with_line_length() {
+            use ruff_formatter::LineWidth;
+
+            let document = TextDocument::new(
+                r#"
+def hello(very_long_parameter_name_1, very_long_parameter_name_2, very_long_parameter_name_3):
+    return very_long_parameter_name_1 + very_long_parameter_name_2 + very_long_parameter_name_3
+"#
+                .to_string(),
+                0,
+            );
+
+            // Test with shorter line length
+            let formatter_settings = FormatterSettings {
+                line_width: LineWidth::try_from(60).unwrap(),
+                ..Default::default()
+            };
+
+            let result = format(
+                &document,
+                PySourceType::Python,
+                &formatter_settings,
+                Path::new("test.py"),
+                FormatBackend::Uv,
+            )
+            .expect("Expected no errors when formatting with uv")
+            .expect("Expected formatting changes");
+
+            // With line length 60, the function should be wrapped
+            assert_snapshot!(result, @r#"
+            def hello(
+                very_long_parameter_name_1,
+                very_long_parameter_name_2,
+                very_long_parameter_name_3,
+            ):
+                return (
+                    very_long_parameter_name_1
+                    + very_long_parameter_name_2
+                    + very_long_parameter_name_3
+                )
+            "#);
+        }
+
+        #[test]
+        fn test_uv_format_with_indent_style() {
+            use ruff_formatter::IndentStyle;
+
+            let document = TextDocument::new(
+                r#"
+def hello():
+    if True:
+        print("Hello")
+        if False:
+            print("World")
+"#
+                .to_string(),
+                0,
+            );
+
+            // Test with tabs instead of spaces
+            let formatter_settings = FormatterSettings {
+                indent_style: IndentStyle::Tab,
+                ..Default::default()
+            };
+
+            let result = format(
+                &document,
+                PySourceType::Python,
+                &formatter_settings,
+                Path::new("test.py"),
+                FormatBackend::Uv,
+            )
+            .expect("Expected no errors when formatting with uv")
+            .expect("Expected formatting changes");
+
+            // Should have formatting changes (spaces to tabs)
+            assert_snapshot!(result, @r#"
+            def hello():
+            	if True:
+            		print("Hello")
+            		if False:
+            			print("World")
+            "#);
+        }
+
+        #[test]
+        fn test_uv_format_syntax_error() {
+            let document = TextDocument::new(
+                r#"
+def broken(:
+    pass
+"#
+                .to_string(),
+                0,
+            );
+
+            // uv should return None for syntax errors (as indicated by the TODO comment)
+            let result = format(
+                &document,
+                PySourceType::Python,
+                &FormatterSettings::default(),
+                Path::new("test.py"),
+                FormatBackend::Uv,
+            )
+            .expect("Expected no errors from format function");
+
+            // Should return None since the syntax is invalid
+            assert_eq!(result, None, "Expected None for syntax error");
+        }
+
+        #[test]
+        fn test_uv_format_with_quote_style() {
+            use ruff_python_formatter::QuoteStyle;
+
+            let document = TextDocument::new(
+                r#"
+x = "hello"
+y = 'world'
+z = '''multi
+line'''
+"#
+                .to_string(),
+                0,
+            );
+
+            // Test with single quotes
+            let formatter_settings = FormatterSettings {
+                quote_style: QuoteStyle::Single,
+                ..Default::default()
+            };
+
+            let result = format(
+                &document,
+                PySourceType::Python,
+                &formatter_settings,
+                Path::new("test.py"),
+                FormatBackend::Uv,
+            )
+            .expect("Expected no errors when formatting with uv")
+            .expect("Expected formatting changes");
+
+            assert_snapshot!(result, @r#"
+            x = 'hello'
+            y = 'world'
+            z = """multi
+            line"""
+            "#);
+        }
+
+        #[test]
+        fn test_uv_format_with_magic_trailing_comma() {
+            use ruff_python_formatter::MagicTrailingComma;
+
+            let document = TextDocument::new(
+                r#"
+foo = [
+    1,
+    2,
+    3,
+]
+
+bar = [1, 2, 3,]
+"#
+                .to_string(),
+                0,
+            );
+
+            // Test with ignore magic trailing comma
+            let formatter_settings = FormatterSettings {
+                magic_trailing_comma: MagicTrailingComma::Ignore,
+                ..Default::default()
+            };
+
+            let result = format(
+                &document,
+                PySourceType::Python,
+                &formatter_settings,
+                Path::new("test.py"),
+                FormatBackend::Uv,
+            )
+            .expect("Expected no errors when formatting with uv")
+            .expect("Expected formatting changes");
+
+            assert_snapshot!(result, @r#"
+            foo = [1, 2, 3]
+            
+            bar = [1, 2, 3]
+            "#);
+        }
     }
 }

--- a/crates/ruff_server/src/format.rs
+++ b/crates/ruff_server/src/format.rs
@@ -171,6 +171,7 @@ impl UvFormatCommand {
         // `uv format` or add a special error message when the subcommand doesn't exist
         let mut command = Command::new("uv");
         command.arg("format");
+        command.arg("--");
 
         let target_version = format!(
             "py{}{}",
@@ -534,7 +535,7 @@ def another_function(x,y,z):
             assert_snapshot!(result.as_code(), @r#"
             def messy_function(  a,  b,c   ):
                 return a+b+c
-            
+
             def another_function(x, y, z):
                 result = x + y + z
                 return result
@@ -729,7 +730,7 @@ bar = [1, 2, 3,]
 
             assert_snapshot!(result, @r#"
             foo = [1, 2, 3]
-            
+
             bar = [1, 2, 3]
             "#);
         }

--- a/crates/ruff_server/src/format.rs
+++ b/crates/ruff_server/src/format.rs
@@ -167,10 +167,9 @@ impl UvFormatCommand {
         path: &Path,
         range_with_index: Option<(TextRange, &LineIndex, &str)>,
     ) -> Command {
-        // TODO(zanieb): We actually want to invoke `uv format` here, but that needs to be released
-        // first! So for now, we're using this as a placeholder to test the experience.
-        let mut command = Command::new("uvx");
-        command.arg("ruff");
+        // TODO(zanieb): We should probably check the uv version to make sure it supports
+        // `uv format` or add a special error message when the subcommand doesn't exist
+        let mut command = Command::new("uv");
         command.arg("format");
 
         let target_version = format!(

--- a/crates/ruff_server/src/server/api/requests/format_range.rs
+++ b/crates/ruff_server/src/server/api/requests/format_range.rs
@@ -36,7 +36,11 @@ fn format_document_range(
         .context("Failed to get text document for the format range request")
         .unwrap();
     let query = snapshot.query();
-    format_text_document_range(text_document, range, query, snapshot.encoding())
+    let backend = snapshot
+        .client_settings()
+        .editor_settings()
+        .format_backend();
+    format_text_document_range(text_document, range, query, snapshot.encoding(), backend)
 }
 
 /// Formats the specified [`Range`] in the [`TextDocument`].
@@ -45,6 +49,7 @@ fn format_text_document_range(
     range: Range,
     query: &DocumentQuery,
     encoding: PositionEncoding,
+    backend: crate::format::FormatBackend,
 ) -> Result<super::FormatResponse> {
     let settings = query.settings();
     let file_path = query.virtual_file_path();
@@ -68,6 +73,7 @@ fn format_text_document_range(
         &settings.formatter,
         range,
         &file_path,
+        backend,
     )
     .with_failure_code(lsp_server::ErrorCode::InternalError)?;
 

--- a/crates/ruff_server/src/session/index/ruff_settings.rs
+++ b/crates/ruff_server/src/session/index/ruff_settings.rs
@@ -401,6 +401,7 @@ impl ConfigurationTransformer for EditorConfigurationTransformer<'_> {
             configuration,
             format_preview,
             lint_preview,
+            format_backend: _,
             select,
             extend_select,
             ignore,

--- a/crates/ruff_server/src/session/settings.rs
+++ b/crates/ruff_server/src/session/settings.rs
@@ -8,6 +8,7 @@ use ruff_workspace::options::Options;
 
 use crate::{
     ClientOptions,
+    format::FormatBackend,
     session::{
         Client,
         options::{ClientConfiguration, ConfigurationPreference},
@@ -84,6 +85,7 @@ pub(crate) struct EditorSettings {
     pub(super) configuration: Option<ResolvedConfiguration>,
     pub(super) lint_preview: Option<bool>,
     pub(super) format_preview: Option<bool>,
+    pub(super) format_backend: Option<FormatBackend>,
     pub(super) select: Option<Vec<RuleSelector>>,
     pub(super) extend_select: Option<Vec<RuleSelector>>,
     pub(super) ignore: Option<Vec<RuleSelector>>,
@@ -161,5 +163,11 @@ impl ClientSettings {
 
     pub(crate) fn editor_settings(&self) -> &EditorSettings {
         &self.editor_settings
+    }
+}
+
+impl EditorSettings {
+    pub(crate) fn format_backend(&self) -> FormatBackend {
+        self.format_backend.unwrap_or_default()
     }
 }

--- a/docs/editors/settings.md
+++ b/docs/editors/settings.md
@@ -971,6 +971,62 @@ Whether to enable Ruff's preview mode when formatting.
     }
     ```
 
+### `backend` {: #format_backend }
+
+The backend to use for formatting files. Following options are available:
+
+- `"internal"`: Use the built-in Ruff formatter
+- `"uv"`: Use uv for formatting (requires uv >= 0.8.13)
+
+For `internal`, the formatter version will match the selected Ruff version while for `uv`, the
+formatter version may differ.
+
+**Default value**: `"internal"`
+
+**Type**: `"internal" | "uv"`
+
+**Example usage**:
+
+=== "VS Code"
+
+    ```json
+    {
+        "ruff.format.backend": "uv"
+    }
+    ```
+
+=== "Neovim"
+
+    ```lua
+    require('lspconfig').ruff.setup {
+      init_options = {
+        settings = {
+          format = {
+            backend = "uv"
+          }
+        }
+      }
+    }
+    ```
+
+=== "Zed"
+
+    ```json
+    {
+      "lsp": {
+        "ruff": {
+          "initialization_options": {
+            "settings": {
+              "format": {
+                "backend": "uv"
+              }
+            }
+          }
+        }
+      }
+    }
+    ```
+
 ## VS Code specific
 
 Additionally, the Ruff extension provides the following settings specific to VS Code. These settings


### PR DESCRIPTION
This adds a new `backend: internal | uv` option to the LSP `FormatOptions` allowing users to perform document and range formatting operations though uv. The idea here is to prototype a solution for users to transition to a `uv format` command without encountering version mismatches (and consequently, formatting differences) between the LSP's version of `ruff` and uv's version of `ruff`.

The primarily alternative to this would be to use uv to discover the `ruff` version used to start the LSP in the first place. However, this would increase the scope of a minimal `uv format` command beyond "run a formatter", and raise larger questions about how uv should be used to coordinate toolchain discovery. I think those are good things to explore, but I'm hesitant to let them block a `uv format` implementation. Another downside of using uv to discover `ruff`, is that it needs to be implemented _outside_ the LSP; e.g., we'd need to change the instructions on how to run the LSP and implement it in each editor integration, like the VS Code plugin.