### PR TITLE
[ty] Improve `isinstance()` truthiness analysis for generic types

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/builtins.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/builtins.md
@@ -152,7 +152,8 @@ s = SubclassOfA()
 reveal_type(isinstance(s, SubclassOfA))  # revealed: Literal[True]
 reveal_type(isinstance(s, A))  # revealed: Literal[True]
 
-def _(x: A | B):
+def _(x: A | B, y: list[int]):
+    reveal_type(isinstance(y, list))  # revealed: Literal[True]
     reveal_type(isinstance(x, A))  # revealed: bool
 
     if isinstance(x, A):

--- a/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
+++ b/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
@@ -238,3 +238,103 @@ def match_non_exhaustive(x: A | B | C):
             # this diagnostic is correct: the inferred type of `x` is `B & ~A & ~C`
             assert_never(x)  # error: [type-assertion-failure]
 ```
+
+## `isinstance` checks with generics
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import assert_never
+
+class A[T]: ...
+class ASub[T](A[T]): ...
+class B[T]: ...
+class C[T]: ...
+class D: ...
+class E: ...
+class F: ...
+
+def if_else_exhaustive(x: A[D] | B[E] | C[F]):
+    if isinstance(x, A):
+        pass
+    elif isinstance(x, B):
+        pass
+    elif isinstance(x, C):
+        pass
+    else:
+        # TODO: both of these are false positives (https://github.com/astral-sh/ty/issues/456)
+        no_diagnostic_here  # error: [unresolved-reference]
+        assert_never(x)  # error: [type-assertion-failure]
+
+# TODO: false-positive diagnostic (https://github.com/astral-sh/ty/issues/456)
+def if_else_exhaustive_no_assertion(x: A[D] | B[E] | C[F]) -> int:  # error: [invalid-return-type]
+    if isinstance(x, A):
+        return 0
+    elif isinstance(x, B):
+        return 1
+    elif isinstance(x, C):
+        return 2
+
+def if_else_non_exhaustive(x: A[D] | B[E] | C[F]):
+    if isinstance(x, A):
+        pass
+    elif isinstance(x, C):
+        pass
+    else:
+        this_should_be_an_error  # error: [unresolved-reference]
+
+        # this diagnostic is correct: the inferred type of `x` is `B[E] & ~A[D] & ~C[F]`
+        assert_never(x)  # error: [type-assertion-failure]
+
+def match_exhaustive(x: A[D] | B[E] | C[F]):
+    match x:
+        case A():
+            pass
+        case B():
+            pass
+        case C():
+            pass
+        case _:
+            # TODO: both of these are false positives (https://github.com/astral-sh/ty/issues/456)
+            no_diagnostic_here  # error: [unresolved-reference]
+            assert_never(x)  # error: [type-assertion-failure]
+
+# TODO: false-positive diagnostic (https://github.com/astral-sh/ty/issues/456)
+def match_exhaustive_no_assertion(x: A[D] | B[E] | C[F]) -> int:  # error: [invalid-return-type]
+    match x:
+        case A():
+            return 0
+        case B():
+            return 1
+        case C():
+            return 2
+
+def match_non_exhaustive(x: A[D] | B[E] | C[F]):
+    match x:
+        case A():
+            pass
+        case C():
+            pass
+        case _:
+            this_should_be_an_error  # error: [unresolved-reference]
+
+            # this diagnostic is correct: the inferred type of `x` is `B[E] & ~A[D] & ~C[F]`
+            assert_never(x)  # error: [type-assertion-failure]
+
+# This function might seem a bit silly, but it's a pattern that exists in real-world code!
+# see https://github.com/bokeh/bokeh/blob/adef0157284696ce86961b2089c75fddda53c15c/src/bokeh/core/property/container.py#L130-L140
+def no_invalid_return_diagnostic_here_either[T](x: A[T]) -> ASub[T]:
+    if isinstance(x, A):
+        if isinstance(x, ASub):
+            return x
+        else:
+            return ASub()
+    else:
+        # We *would* emit a diagnostic here complaining that it's an invalid `return` statement
+        # ...except that we (correctly) infer that this branch is unreachable, so the complaint
+        # is null and void (and therefore we don't emit a diagnostic)
+        return x
+```


### PR DESCRIPTION
## Summary

This PR extends the `isinstance()` truthiness inference (added in #19503) so that it works better for instances of generic types. Specifically, we now infer `Literal[True]` here, whereas on `main` we infer `bool`:

```py
def f(x: list[int]):
    reveal_type(isinstance(x, list))
```

The motivation for improving our logic here is that the logic on `main` breaks for tuples if we remove the `Type::Tuple` variant and treat them simply as instances of a (very special) generic class. I.e., we have tests asserting that we infer `isinstance((1, 2), tuple)` as `Literal[True]`; those break on the branch for #19669 without this change.

I've split this out into a separate PR from #19669 as it seems like a useful change on its own merits, however. We can see from the ecosystem report that it gets rid of two false positives from `bokeh`: we now correctly infer two branches of code as unreachable, and therefore do not emit any `invalid-return-type` diagnostics on those branches anymore. (See https://github.com/bokeh/bokeh/blob/adef0157284696ce86961b2089c75fddda53c15c/src/bokeh/core/property/container.py#L130-L140.)

I can't quite figure out what's going on in the sympy ecosystem hit (https://github.com/sympy/sympy/blob/3c817ed8ab551d71e36907ce869afe5e4ca789ff/sympy/polys/polyclasses.py#L308-L317) -- it seems like we used to infer the type of `g` as `DMP[Es] & DMP[Unknown]` at the point of the `return` statement, whereas we now infer the type of `g` as `DMP[Es]`. I don't quite understand why we now get to that answer; but still, our new inference seems better here -- intersecting with `DMP[Unknown]` as a result of the `isinstance()` check in that function is incorrect (https://github.com/astral-sh/ty/issues/456).

## Test Plan

I added mdtests for the direct functionality being added, and for the false positives that this PR removes from `bokeh`. I also extended the reachability tests added in #19503 to include some examples of generic types. Most of these tests currently fail, so there are many TODO comments added -- they require https://github.com/astral-sh/ty/issues/456 for them to be fixed. If this is merged, I'll add a comment to that issue saying that we now have some failing tests on `main` that should naturally be fixed if and when that issue is fixed.
