### PR TITLE
[`refurb`] Make example error out-of-the-box (`FURB180`)

### DIFF
--- a/crates/ruff_linter/src/rules/refurb/rules/metaclass_abcmeta.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/metaclass_abcmeta.rs
@@ -24,6 +24,7 @@ use crate::{AlwaysFixableViolation, Edit, Fix};
 /// ```python
 /// import abc
 ///
+///
 /// class C(metaclass=abc.ABCMeta):
 ///     pass
 /// ```
@@ -31,6 +32,7 @@ use crate::{AlwaysFixableViolation, Edit, Fix};
 /// Use instead:
 /// ```python
 /// import abc
+///
 ///
 /// class C(abc.ABC):
 ///     pass


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Part of #18972

This PR makes [meta-class-abc-meta (FURB180)](https://docs.astral.sh/ruff/rules/meta-class-abc-meta/#meta-class-abc-meta-furb180)'s example error out-of-the-box.

[Old example](https://play.ruff.rs/6beca1be-45cd-4e5a-aafa-6a0584c10d64)
```py
class C(metaclass=ABCMeta):
    pass
```

[New example](https://play.ruff.rs/bbad34da-bf07-44e6-9f34-53337e8f57d4)
```py
import abc


class C(metaclass=abc.ABCMeta):
    pass
```

The "Use instead" section as also modified similarly.

## Test Plan

<!-- How was it tested? -->

N/A, no functionality/tests affected