### PR TITLE
[`refurb`] Make example error out-of-the-box (`FURB164`)

### DIFF
--- a/crates/ruff_linter/src/rules/refurb/rules/unnecessary_from_float.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/unnecessary_from_float.rs
@@ -26,6 +26,9 @@ use crate::{Applicability, Edit, Fix, FixAvailability, Violation};
 ///
 /// ## Example
 /// ```python
+/// from decimal import Decimal
+/// from fractions import Fraction
+///
 /// Decimal.from_float(4.2)
 /// Decimal.from_float(float("inf"))
 /// Fraction.from_float(4.2)
@@ -34,10 +37,13 @@ use crate::{Applicability, Edit, Fix, FixAvailability, Violation};
 ///
 /// Use instead:
 /// ```python
+/// from decimal import Decimal
+/// from fractions import Fraction
+///
 /// Decimal(4.2)
 /// Decimal("inf")
 /// Fraction(4.2)
-/// Fraction(Decimal(4.2))
+/// Fraction(Decimal("4.2"))
 /// ```
 ///
 /// ## Fix safety


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Part of #18972

This PR makes [unnecessary-from-float (FURB164)](https://docs.astral.sh/ruff/rules/unnecessary-from-float/#unnecessary-from-float-furb164)'s example error out-of-the-box.

[Old example](https://play.ruff.rs/807ef72f-9671-408d-87ab-8b8bad65b33f)
```py
Decimal.from_float(4.2)
Decimal.from_float(float("inf"))
Fraction.from_float(4.2)
Fraction.from_decimal(Decimal("4.2"))
```

[New example](https://play.ruff.rs/303680d1-8a68-4b6c-a5fd-d79c56eb0f88)
```py
from decimal import Decimal
from fractions import Fraction

Decimal.from_float(4.2)
Decimal.from_float(float("inf"))
Fraction.from_float(4.2)
Fraction.from_decimal(Decimal("4.2"))
```

The "Use instead" section also had imports added, and one of the fixed examples was slightly wrong and needed modification.

## Test Plan

<!-- How was it tested? -->

N/A, no functionality/tests affected