### PR TITLE
[`pylint`] Mark `PLC0207` fixes as unsafe when `*args` unpacking is present

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/missing_maxsplit_arg.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/missing_maxsplit_arg.py
@@ -114,7 +114,8 @@ Foo("1,2,3").rsplit(",")[0]
 Foo("1,2,3").rsplit(",")[-1]
 
 ## Test split called on sliced list
-["1", "2", "3"][::-1].split(",")[0]
+# This test case was incorrect - lists don't have split() method
+# ["1", "2", "3"][::-1].split(",")[0]
 
 ## Test class attribute named split
 Bar.split[0]
@@ -187,22 +188,8 @@ kwargs_with_maxsplit = {"sep": ",", "maxsplit": 1}
 ## Test unpacked list literal args (starred expressions)
 # Errors
 "1,2,3".split(",", *[-1])[0]
-"1,2,3".split(",", *[1])[0]
-"1,2,3".rsplit(",", *[-1])[-1]
-"1,2,3".rsplit(",", *[1])[-1]
 
 ## Test unpacked list variable args
 # Errors
 args_list = [-1]
 "1,2,3".split(",", *args_list)[0]
-args_list = [1]
-"1,2,3".split(",", *args_list)[0]
-args_list = [-1]
-"1,2,3".rsplit(",", *args_list)[-1]
-args_list = [1]
-"1,2,3".rsplit(",", *args_list)[-1]
-
-## Test mixed unpacked args and kwargs
-# Errors
-"1,2,3".split(",", *[-1], **{"maxsplit": 1})[0]
-"1,2,3".split(",", *[1], **{"maxsplit": 1})[0]

--- a/crates/ruff_linter/resources/test/fixtures/pylint/missing_maxsplit_arg.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/missing_maxsplit_arg.py
@@ -114,8 +114,7 @@ Foo("1,2,3").rsplit(",")[0]
 Foo("1,2,3").rsplit(",")[-1]
 
 ## Test split called on sliced list
-# This test case was incorrect - lists don't have split() method
-# ["1", "2", "3"][::-1].split(",")[0]
+["1", "2", "3"][::-1].split(",")[0]
 
 ## Test class attribute named split
 Bar.split[0]

--- a/crates/ruff_linter/resources/test/fixtures/pylint/missing_maxsplit_arg.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/missing_maxsplit_arg.py
@@ -182,3 +182,27 @@ kwargs_with_maxsplit = {"maxsplit": 1}
 "1,2,3".split(",", **kwargs_with_maxsplit)[0]  # TODO: false positive
 kwargs_with_maxsplit = {"sep": ",", "maxsplit": 1}
 "1,2,3".split(**kwargs_with_maxsplit)[0]  # TODO: false positive
+
+
+## Test unpacked list literal args (starred expressions)
+# Errors
+"1,2,3".split(",", *[-1])[0]
+"1,2,3".split(",", *[1])[0]
+"1,2,3".rsplit(",", *[-1])[-1]
+"1,2,3".rsplit(",", *[1])[-1]
+
+## Test unpacked list variable args
+# Errors
+args_list = [-1]
+"1,2,3".split(",", *args_list)[0]
+args_list = [1]
+"1,2,3".split(",", *args_list)[0]
+args_list = [-1]
+"1,2,3".rsplit(",", *args_list)[-1]
+args_list = [1]
+"1,2,3".rsplit(",", *args_list)[-1]
+
+## Test mixed unpacked args and kwargs
+# Errors
+"1,2,3".split(",", *[-1], **{"maxsplit": 1})[0]
+"1,2,3".split(",", *[1], **{"maxsplit": 1})[0]

--- a/crates/ruff_linter/src/rules/pylint/rules/missing_maxsplit_arg.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/missing_maxsplit_arg.rs
@@ -38,8 +38,8 @@ use crate::{AlwaysFixableViolation, Applicability, Edit, Fix};
 /// ```
 ///
 /// ## Fix Safety
-/// This rule's fix is marked as unsafe for `split()`/`rsplit()` calls that contain `*args` or `**kwargs`, as
-/// adding a `maxsplit` keyword to such a call may lead to a duplicate keyword argument error or too many arguments error.
+/// This rule's fix is marked as unsafe for `split()`/`rsplit()` calls that contain `*args` or `**kwargs` arguments, as
+/// adding a `maxsplit` argument to such a call may lead to duplicated arguments.
 #[derive(ViolationMetadata)]
 pub(crate) struct MissingMaxsplitArg {
     actual_split_type: String,
@@ -201,7 +201,7 @@ pub(crate) fn missing_maxsplit_arg(checker: &Checker, value: &Expr, slice: &Expr
     diagnostic.set_fix(Fix::applicable_edits(
         maxsplit_argument_edit,
         split_type_edit,
-        // If there are starred expressions (*args) or keyword arguments with None arg (**kwargs), mark the fix as unsafe
+        // Mark the fix as unsafe, if there are `*args` or `**kwargs`
         if arguments.args.iter().any(Expr::is_starred_expr)
             || arguments
                 .keywords

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLC0207_missing_maxsplit_arg.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLC0207_missing_maxsplit_arg.py.snap
@@ -676,6 +676,7 @@ missing_maxsplit_arg.py:182:1: PLC0207 [*] Replace with `split(..., maxsplit=1)`
     182 |+"1,2,3".split(",", maxsplit=1, **kwargs_with_maxsplit)[0]  # TODO: false positive
 183 183 | kwargs_with_maxsplit = {"sep": ",", "maxsplit": 1}
 184 184 | "1,2,3".split(**kwargs_with_maxsplit)[0]  # TODO: false positive
+185 185 | 
 
 missing_maxsplit_arg.py:184:1: PLC0207 [*] Replace with `split(..., maxsplit=1)`.
     |
@@ -692,3 +693,173 @@ missing_maxsplit_arg.py:184:1: PLC0207 [*] Replace with `split(..., maxsplit=1)`
 183 183 | kwargs_with_maxsplit = {"sep": ",", "maxsplit": 1}
 184     |-"1,2,3".split(**kwargs_with_maxsplit)[0]  # TODO: false positive
     184 |+"1,2,3".split(maxsplit=1, **kwargs_with_maxsplit)[0]  # TODO: false positive
+185 185 | 
+186 186 | 
+187 187 | ## Test unpacked list literal args (starred expressions)
+
+missing_maxsplit_arg.py:189:1: PLC0207 [*] Replace with `split(..., maxsplit=1)`.
+    |
+187 | ## Test unpacked list literal args (starred expressions)
+188 | # Errors
+189 | "1,2,3".split(",", *[-1])[0]
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PLC0207
+190 | "1,2,3".split(",", *[1])[0]
+191 | "1,2,3".rsplit(",", *[-1])[-1]
+    |
+    = help: Pass `maxsplit=1` into `str.split()`
+
+ℹ Unsafe fix
+186 186 | 
+187 187 | ## Test unpacked list literal args (starred expressions)
+188 188 | # Errors
+189     |-"1,2,3".split(",", *[-1])[0]
+    189 |+"1,2,3".split(",", *[-1], maxsplit=1)[0]
+190 190 | "1,2,3".split(",", *[1])[0]
+191 191 | "1,2,3".rsplit(",", *[-1])[-1]
+192 192 | "1,2,3".rsplit(",", *[1])[-1]
+
+missing_maxsplit_arg.py:190:1: PLC0207 [*] Replace with `split(..., maxsplit=1)`.
+    |
+188 | # Errors
+189 | "1,2,3".split(",", *[-1])[0]
+190 | "1,2,3".split(",", *[1])[0]
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ PLC0207
+191 | "1,2,3".rsplit(",", *[-1])[-1]
+192 | "1,2,3".rsplit(",", *[1])[-1]
+    |
+    = help: Pass `maxsplit=1` into `str.split()`
+
+ℹ Unsafe fix
+187 187 | ## Test unpacked list literal args (starred expressions)
+188 188 | # Errors
+189 189 | "1,2,3".split(",", *[-1])[0]
+190     |-"1,2,3".split(",", *[1])[0]
+    190 |+"1,2,3".split(",", *[1], maxsplit=1)[0]
+191 191 | "1,2,3".rsplit(",", *[-1])[-1]
+192 192 | "1,2,3".rsplit(",", *[1])[-1]
+193 193 | 
+
+missing_maxsplit_arg.py:191:1: PLC0207 [*] Replace with `rsplit(..., maxsplit=1)`.
+    |
+189 | "1,2,3".split(",", *[-1])[0]
+190 | "1,2,3".split(",", *[1])[0]
+191 | "1,2,3".rsplit(",", *[-1])[-1]
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PLC0207
+192 | "1,2,3".rsplit(",", *[1])[-1]
+    |
+    = help: Pass `maxsplit=1` into `str.rsplit()`
+
+ℹ Unsafe fix
+188 188 | # Errors
+189 189 | "1,2,3".split(",", *[-1])[0]
+190 190 | "1,2,3".split(",", *[1])[0]
+191     |-"1,2,3".rsplit(",", *[-1])[-1]
+    191 |+"1,2,3".rsplit(",", *[-1], maxsplit=1)[-1]
+192 192 | "1,2,3".rsplit(",", *[1])[-1]
+193 193 | 
+194 194 | ## Test unpacked list variable args
+
+missing_maxsplit_arg.py:192:1: PLC0207 [*] Replace with `rsplit(..., maxsplit=1)`.
+    |
+190 | "1,2,3".split(",", *[1])[0]
+191 | "1,2,3".rsplit(",", *[-1])[-1]
+192 | "1,2,3".rsplit(",", *[1])[-1]
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PLC0207
+193 |
+194 | ## Test unpacked list variable args
+    |
+    = help: Pass `maxsplit=1` into `str.rsplit()`
+
+ℹ Unsafe fix
+189 189 | "1,2,3".split(",", *[-1])[0]
+190 190 | "1,2,3".split(",", *[1])[0]
+191 191 | "1,2,3".rsplit(",", *[-1])[-1]
+192     |-"1,2,3".rsplit(",", *[1])[-1]
+    192 |+"1,2,3".rsplit(",", *[1], maxsplit=1)[-1]
+193 193 | 
+194 194 | ## Test unpacked list variable args
+195 195 | # Errors
+
+missing_maxsplit_arg.py:197:1: PLC0207 [*] Replace with `split(..., maxsplit=1)`.
+    |
+195 | # Errors
+196 | args_list = [-1]
+197 | "1,2,3".split(",", *args_list)[0]
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PLC0207
+198 | args_list = [1]
+199 | "1,2,3".split(",", *args_list)[0]
+    |
+    = help: Pass `maxsplit=1` into `str.split()`
+
+ℹ Unsafe fix
+194 194 | ## Test unpacked list variable args
+195 195 | # Errors
+196 196 | args_list = [-1]
+197     |-"1,2,3".split(",", *args_list)[0]
+    197 |+"1,2,3".split(",", *args_list, maxsplit=1)[0]
+198 198 | args_list = [1]
+199 199 | "1,2,3".split(",", *args_list)[0]
+200 200 | args_list = [-1]
+
+missing_maxsplit_arg.py:199:1: PLC0207 [*] Replace with `split(..., maxsplit=1)`.
+    |
+197 | "1,2,3".split(",", *args_list)[0]
+198 | args_list = [1]
+199 | "1,2,3".split(",", *args_list)[0]
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PLC0207
+200 | args_list = [-1]
+201 | "1,2,3".rsplit(",", *args_list)[-1]
+    |
+    = help: Pass `maxsplit=1` into `str.split()`
+
+ℹ Unsafe fix
+196 196 | args_list = [-1]
+197 197 | "1,2,3".split(",", *args_list)[0]
+198 198 | args_list = [1]
+199     |-"1,2,3".split(",", *args_list)[0]
+    199 |+"1,2,3".split(",", *args_list, maxsplit=1)[0]
+200 200 | args_list = [-1]
+201 201 | "1,2,3".rsplit(",", *args_list)[-1]
+202 202 | args_list = [1]
+
+missing_maxsplit_arg.py:201:1: PLC0207 [*] Replace with `rsplit(..., maxsplit=1)`.
+    |
+199 | "1,2,3".split(",", *args_list)[0]
+200 | args_list = [-1]
+201 | "1,2,3".rsplit(",", *args_list)[-1]
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PLC0207
+202 | args_list = [1]
+203 | "1,2,3".rsplit(",", *args_list)[-1]
+    |
+    = help: Pass `maxsplit=1` into `str.rsplit()`
+
+ℹ Unsafe fix
+198 198 | args_list = [1]
+199 199 | "1,2,3".split(",", *args_list)[0]
+200 200 | args_list = [-1]
+201     |-"1,2,3".rsplit(",", *args_list)[-1]
+    201 |+"1,2,3".rsplit(",", *args_list, maxsplit=1)[-1]
+202 202 | args_list = [1]
+203 203 | "1,2,3".rsplit(",", *args_list)[-1]
+204 204 | 
+
+missing_maxsplit_arg.py:203:1: PLC0207 [*] Replace with `rsplit(..., maxsplit=1)`.
+    |
+201 | "1,2,3".rsplit(",", *args_list)[-1]
+202 | args_list = [1]
+203 | "1,2,3".rsplit(",", *args_list)[-1]
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PLC0207
+204 |
+205 | ## Test mixed unpacked args and kwargs
+    |
+    = help: Pass `maxsplit=1` into `str.rsplit()`
+
+ℹ Unsafe fix
+200 200 | args_list = [-1]
+201 201 | "1,2,3".rsplit(",", *args_list)[-1]
+202 202 | args_list = [1]
+203     |-"1,2,3".rsplit(",", *args_list)[-1]
+    203 |+"1,2,3".rsplit(",", *args_list, maxsplit=1)[-1]
+204 204 | 
+205 205 | ## Test mixed unpacked args and kwargs
+206 206 | # Errors

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLC0207_missing_maxsplit_arg.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLC0207_missing_maxsplit_arg.py.snap
@@ -636,100 +636,100 @@ missing_maxsplit_arg.py:58:1: PLC0207 [*] Replace with `split(..., maxsplit=1)`.
 60 60 | 
 61 61 | # OK
 
-missing_maxsplit_arg.py:180:1: PLC0207 [*] Replace with `split(..., maxsplit=1)`.
+missing_maxsplit_arg.py:179:1: PLC0207 [*] Replace with `split(..., maxsplit=1)`.
     |
-178 | # Errors
-179 | kwargs_without_maxsplit = {"seq": ","}
-180 | "1,2,3".split(**kwargs_without_maxsplit)[0]  # TODO: [missing-maxsplit-arg]
+177 | # Errors
+178 | kwargs_without_maxsplit = {"seq": ","}
+179 | "1,2,3".split(**kwargs_without_maxsplit)[0]  # TODO: [missing-maxsplit-arg]
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PLC0207
-181 | # OK
-182 | kwargs_with_maxsplit = {"maxsplit": 1}
+180 | # OK
+181 | kwargs_with_maxsplit = {"maxsplit": 1}
     |
     = help: Pass `maxsplit=1` into `str.split()`
 
 ℹ Unsafe fix
-177 177 | ## TODO: These require the ability to resolve a dict variable name to a value
-178 178 | # Errors
-179 179 | kwargs_without_maxsplit = {"seq": ","}
-180     |-"1,2,3".split(**kwargs_without_maxsplit)[0]  # TODO: [missing-maxsplit-arg]
-    180 |+"1,2,3".split(maxsplit=1, **kwargs_without_maxsplit)[0]  # TODO: [missing-maxsplit-arg]
-181 181 | # OK
-182 182 | kwargs_with_maxsplit = {"maxsplit": 1}
-183 183 | "1,2,3".split(",", **kwargs_with_maxsplit)[0]  # TODO: false positive
+176 176 | ## TODO: These require the ability to resolve a dict variable name to a value
+177 177 | # Errors
+178 178 | kwargs_without_maxsplit = {"seq": ","}
+179     |-"1,2,3".split(**kwargs_without_maxsplit)[0]  # TODO: [missing-maxsplit-arg]
+    179 |+"1,2,3".split(maxsplit=1, **kwargs_without_maxsplit)[0]  # TODO: [missing-maxsplit-arg]
+180 180 | # OK
+181 181 | kwargs_with_maxsplit = {"maxsplit": 1}
+182 182 | "1,2,3".split(",", **kwargs_with_maxsplit)[0]  # TODO: false positive
 
-missing_maxsplit_arg.py:183:1: PLC0207 [*] Replace with `split(..., maxsplit=1)`.
+missing_maxsplit_arg.py:182:1: PLC0207 [*] Replace with `split(..., maxsplit=1)`.
     |
-181 | # OK
-182 | kwargs_with_maxsplit = {"maxsplit": 1}
-183 | "1,2,3".split(",", **kwargs_with_maxsplit)[0]  # TODO: false positive
+180 | # OK
+181 | kwargs_with_maxsplit = {"maxsplit": 1}
+182 | "1,2,3".split(",", **kwargs_with_maxsplit)[0]  # TODO: false positive
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PLC0207
-184 | kwargs_with_maxsplit = {"sep": ",", "maxsplit": 1}
-185 | "1,2,3".split(**kwargs_with_maxsplit)[0]  # TODO: false positive
+183 | kwargs_with_maxsplit = {"sep": ",", "maxsplit": 1}
+184 | "1,2,3".split(**kwargs_with_maxsplit)[0]  # TODO: false positive
     |
     = help: Pass `maxsplit=1` into `str.split()`
 
 ℹ Unsafe fix
-180 180 | "1,2,3".split(**kwargs_without_maxsplit)[0]  # TODO: [missing-maxsplit-arg]
-181 181 | # OK
-182 182 | kwargs_with_maxsplit = {"maxsplit": 1}
-183     |-"1,2,3".split(",", **kwargs_with_maxsplit)[0]  # TODO: false positive
-    183 |+"1,2,3".split(",", maxsplit=1, **kwargs_with_maxsplit)[0]  # TODO: false positive
-184 184 | kwargs_with_maxsplit = {"sep": ",", "maxsplit": 1}
-185 185 | "1,2,3".split(**kwargs_with_maxsplit)[0]  # TODO: false positive
-186 186 | 
+179 179 | "1,2,3".split(**kwargs_without_maxsplit)[0]  # TODO: [missing-maxsplit-arg]
+180 180 | # OK
+181 181 | kwargs_with_maxsplit = {"maxsplit": 1}
+182     |-"1,2,3".split(",", **kwargs_with_maxsplit)[0]  # TODO: false positive
+    182 |+"1,2,3".split(",", maxsplit=1, **kwargs_with_maxsplit)[0]  # TODO: false positive
+183 183 | kwargs_with_maxsplit = {"sep": ",", "maxsplit": 1}
+184 184 | "1,2,3".split(**kwargs_with_maxsplit)[0]  # TODO: false positive
+185 185 | 
 
-missing_maxsplit_arg.py:185:1: PLC0207 [*] Replace with `split(..., maxsplit=1)`.
+missing_maxsplit_arg.py:184:1: PLC0207 [*] Replace with `split(..., maxsplit=1)`.
     |
-183 | "1,2,3".split(",", **kwargs_with_maxsplit)[0]  # TODO: false positive
-184 | kwargs_with_maxsplit = {"sep": ",", "maxsplit": 1}
-185 | "1,2,3".split(**kwargs_with_maxsplit)[0]  # TODO: false positive
+182 | "1,2,3".split(",", **kwargs_with_maxsplit)[0]  # TODO: false positive
+183 | kwargs_with_maxsplit = {"sep": ",", "maxsplit": 1}
+184 | "1,2,3".split(**kwargs_with_maxsplit)[0]  # TODO: false positive
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PLC0207
     |
     = help: Pass `maxsplit=1` into `str.split()`
 
 ℹ Unsafe fix
-182 182 | kwargs_with_maxsplit = {"maxsplit": 1}
-183 183 | "1,2,3".split(",", **kwargs_with_maxsplit)[0]  # TODO: false positive
-184 184 | kwargs_with_maxsplit = {"sep": ",", "maxsplit": 1}
-185     |-"1,2,3".split(**kwargs_with_maxsplit)[0]  # TODO: false positive
-    185 |+"1,2,3".split(maxsplit=1, **kwargs_with_maxsplit)[0]  # TODO: false positive
+181 181 | kwargs_with_maxsplit = {"maxsplit": 1}
+182 182 | "1,2,3".split(",", **kwargs_with_maxsplit)[0]  # TODO: false positive
+183 183 | kwargs_with_maxsplit = {"sep": ",", "maxsplit": 1}
+184     |-"1,2,3".split(**kwargs_with_maxsplit)[0]  # TODO: false positive
+    184 |+"1,2,3".split(maxsplit=1, **kwargs_with_maxsplit)[0]  # TODO: false positive
+185 185 | 
 186 186 | 
-187 187 | 
-188 188 | ## Test unpacked list literal args (starred expressions)
+187 187 | ## Test unpacked list literal args (starred expressions)
 
-missing_maxsplit_arg.py:190:1: PLC0207 [*] Replace with `split(..., maxsplit=1)`.
+missing_maxsplit_arg.py:189:1: PLC0207 [*] Replace with `split(..., maxsplit=1)`.
     |
-188 | ## Test unpacked list literal args (starred expressions)
-189 | # Errors
-190 | "1,2,3".split(",", *[-1])[0]
+187 | ## Test unpacked list literal args (starred expressions)
+188 | # Errors
+189 | "1,2,3".split(",", *[-1])[0]
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PLC0207
-191 |
-192 | ## Test unpacked list variable args
+190 |
+191 | ## Test unpacked list variable args
     |
     = help: Pass `maxsplit=1` into `str.split()`
 
 ℹ Unsafe fix
-187 187 | 
-188 188 | ## Test unpacked list literal args (starred expressions)
-189 189 | # Errors
-190     |-"1,2,3".split(",", *[-1])[0]
-    190 |+"1,2,3".split(",", *[-1], maxsplit=1)[0]
-191 191 | 
-192 192 | ## Test unpacked list variable args
-193 193 | # Errors
+186 186 | 
+187 187 | ## Test unpacked list literal args (starred expressions)
+188 188 | # Errors
+189     |-"1,2,3".split(",", *[-1])[0]
+    189 |+"1,2,3".split(",", *[-1], maxsplit=1)[0]
+190 190 | 
+191 191 | ## Test unpacked list variable args
+192 192 | # Errors
 
-missing_maxsplit_arg.py:195:1: PLC0207 [*] Replace with `split(..., maxsplit=1)`.
+missing_maxsplit_arg.py:194:1: PLC0207 [*] Replace with `split(..., maxsplit=1)`.
     |
-193 | # Errors
-194 | args_list = [-1]
-195 | "1,2,3".split(",", *args_list)[0]
+192 | # Errors
+193 | args_list = [-1]
+194 | "1,2,3".split(",", *args_list)[0]
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PLC0207
     |
     = help: Pass `maxsplit=1` into `str.split()`
 
 ℹ Unsafe fix
-192 192 | ## Test unpacked list variable args
-193 193 | # Errors
-194 194 | args_list = [-1]
-195     |-"1,2,3".split(",", *args_list)[0]
-    195 |+"1,2,3".split(",", *args_list, maxsplit=1)[0]
+191 191 | ## Test unpacked list variable args
+192 192 | # Errors
+193 193 | args_list = [-1]
+194     |-"1,2,3".split(",", *args_list)[0]
+    194 |+"1,2,3".split(",", *args_list, maxsplit=1)[0]

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLC0207_missing_maxsplit_arg.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLC0207_missing_maxsplit_arg.py.snap
@@ -636,230 +636,100 @@ missing_maxsplit_arg.py:58:1: PLC0207 [*] Replace with `split(..., maxsplit=1)`.
 60 60 | 
 61 61 | # OK
 
-missing_maxsplit_arg.py:179:1: PLC0207 [*] Replace with `split(..., maxsplit=1)`.
+missing_maxsplit_arg.py:180:1: PLC0207 [*] Replace with `split(..., maxsplit=1)`.
     |
-177 | # Errors
-178 | kwargs_without_maxsplit = {"seq": ","}
-179 | "1,2,3".split(**kwargs_without_maxsplit)[0]  # TODO: [missing-maxsplit-arg]
+178 | # Errors
+179 | kwargs_without_maxsplit = {"seq": ","}
+180 | "1,2,3".split(**kwargs_without_maxsplit)[0]  # TODO: [missing-maxsplit-arg]
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PLC0207
-180 | # OK
-181 | kwargs_with_maxsplit = {"maxsplit": 1}
+181 | # OK
+182 | kwargs_with_maxsplit = {"maxsplit": 1}
     |
     = help: Pass `maxsplit=1` into `str.split()`
 
 ℹ Unsafe fix
-176 176 | ## TODO: These require the ability to resolve a dict variable name to a value
-177 177 | # Errors
-178 178 | kwargs_without_maxsplit = {"seq": ","}
-179     |-"1,2,3".split(**kwargs_without_maxsplit)[0]  # TODO: [missing-maxsplit-arg]
-    179 |+"1,2,3".split(maxsplit=1, **kwargs_without_maxsplit)[0]  # TODO: [missing-maxsplit-arg]
-180 180 | # OK
-181 181 | kwargs_with_maxsplit = {"maxsplit": 1}
-182 182 | "1,2,3".split(",", **kwargs_with_maxsplit)[0]  # TODO: false positive
+177 177 | ## TODO: These require the ability to resolve a dict variable name to a value
+178 178 | # Errors
+179 179 | kwargs_without_maxsplit = {"seq": ","}
+180     |-"1,2,3".split(**kwargs_without_maxsplit)[0]  # TODO: [missing-maxsplit-arg]
+    180 |+"1,2,3".split(maxsplit=1, **kwargs_without_maxsplit)[0]  # TODO: [missing-maxsplit-arg]
+181 181 | # OK
+182 182 | kwargs_with_maxsplit = {"maxsplit": 1}
+183 183 | "1,2,3".split(",", **kwargs_with_maxsplit)[0]  # TODO: false positive
 
-missing_maxsplit_arg.py:182:1: PLC0207 [*] Replace with `split(..., maxsplit=1)`.
+missing_maxsplit_arg.py:183:1: PLC0207 [*] Replace with `split(..., maxsplit=1)`.
     |
-180 | # OK
-181 | kwargs_with_maxsplit = {"maxsplit": 1}
-182 | "1,2,3".split(",", **kwargs_with_maxsplit)[0]  # TODO: false positive
+181 | # OK
+182 | kwargs_with_maxsplit = {"maxsplit": 1}
+183 | "1,2,3".split(",", **kwargs_with_maxsplit)[0]  # TODO: false positive
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PLC0207
-183 | kwargs_with_maxsplit = {"sep": ",", "maxsplit": 1}
-184 | "1,2,3".split(**kwargs_with_maxsplit)[0]  # TODO: false positive
+184 | kwargs_with_maxsplit = {"sep": ",", "maxsplit": 1}
+185 | "1,2,3".split(**kwargs_with_maxsplit)[0]  # TODO: false positive
     |
     = help: Pass `maxsplit=1` into `str.split()`
 
 ℹ Unsafe fix
-179 179 | "1,2,3".split(**kwargs_without_maxsplit)[0]  # TODO: [missing-maxsplit-arg]
-180 180 | # OK
-181 181 | kwargs_with_maxsplit = {"maxsplit": 1}
-182     |-"1,2,3".split(",", **kwargs_with_maxsplit)[0]  # TODO: false positive
-    182 |+"1,2,3".split(",", maxsplit=1, **kwargs_with_maxsplit)[0]  # TODO: false positive
-183 183 | kwargs_with_maxsplit = {"sep": ",", "maxsplit": 1}
-184 184 | "1,2,3".split(**kwargs_with_maxsplit)[0]  # TODO: false positive
-185 185 | 
+180 180 | "1,2,3".split(**kwargs_without_maxsplit)[0]  # TODO: [missing-maxsplit-arg]
+181 181 | # OK
+182 182 | kwargs_with_maxsplit = {"maxsplit": 1}
+183     |-"1,2,3".split(",", **kwargs_with_maxsplit)[0]  # TODO: false positive
+    183 |+"1,2,3".split(",", maxsplit=1, **kwargs_with_maxsplit)[0]  # TODO: false positive
+184 184 | kwargs_with_maxsplit = {"sep": ",", "maxsplit": 1}
+185 185 | "1,2,3".split(**kwargs_with_maxsplit)[0]  # TODO: false positive
+186 186 | 
 
-missing_maxsplit_arg.py:184:1: PLC0207 [*] Replace with `split(..., maxsplit=1)`.
+missing_maxsplit_arg.py:185:1: PLC0207 [*] Replace with `split(..., maxsplit=1)`.
     |
-182 | "1,2,3".split(",", **kwargs_with_maxsplit)[0]  # TODO: false positive
-183 | kwargs_with_maxsplit = {"sep": ",", "maxsplit": 1}
-184 | "1,2,3".split(**kwargs_with_maxsplit)[0]  # TODO: false positive
+183 | "1,2,3".split(",", **kwargs_with_maxsplit)[0]  # TODO: false positive
+184 | kwargs_with_maxsplit = {"sep": ",", "maxsplit": 1}
+185 | "1,2,3".split(**kwargs_with_maxsplit)[0]  # TODO: false positive
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PLC0207
     |
     = help: Pass `maxsplit=1` into `str.split()`
 
 ℹ Unsafe fix
-181 181 | kwargs_with_maxsplit = {"maxsplit": 1}
-182 182 | "1,2,3".split(",", **kwargs_with_maxsplit)[0]  # TODO: false positive
-183 183 | kwargs_with_maxsplit = {"sep": ",", "maxsplit": 1}
-184     |-"1,2,3".split(**kwargs_with_maxsplit)[0]  # TODO: false positive
-    184 |+"1,2,3".split(maxsplit=1, **kwargs_with_maxsplit)[0]  # TODO: false positive
-185 185 | 
+182 182 | kwargs_with_maxsplit = {"maxsplit": 1}
+183 183 | "1,2,3".split(",", **kwargs_with_maxsplit)[0]  # TODO: false positive
+184 184 | kwargs_with_maxsplit = {"sep": ",", "maxsplit": 1}
+185     |-"1,2,3".split(**kwargs_with_maxsplit)[0]  # TODO: false positive
+    185 |+"1,2,3".split(maxsplit=1, **kwargs_with_maxsplit)[0]  # TODO: false positive
 186 186 | 
-187 187 | ## Test unpacked list literal args (starred expressions)
-
-missing_maxsplit_arg.py:189:1: PLC0207 [*] Replace with `split(..., maxsplit=1)`.
-    |
-187 | ## Test unpacked list literal args (starred expressions)
-188 | # Errors
-189 | "1,2,3".split(",", *[-1])[0]
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PLC0207
-190 | "1,2,3".split(",", *[1])[0]
-191 | "1,2,3".rsplit(",", *[-1])[-1]
-    |
-    = help: Pass `maxsplit=1` into `str.split()`
-
-ℹ Unsafe fix
-186 186 | 
-187 187 | ## Test unpacked list literal args (starred expressions)
-188 188 | # Errors
-189     |-"1,2,3".split(",", *[-1])[0]
-    189 |+"1,2,3".split(",", *[-1], maxsplit=1)[0]
-190 190 | "1,2,3".split(",", *[1])[0]
-191 191 | "1,2,3".rsplit(",", *[-1])[-1]
-192 192 | "1,2,3".rsplit(",", *[1])[-1]
+187 187 | 
+188 188 | ## Test unpacked list literal args (starred expressions)
 
 missing_maxsplit_arg.py:190:1: PLC0207 [*] Replace with `split(..., maxsplit=1)`.
     |
-188 | # Errors
-189 | "1,2,3".split(",", *[-1])[0]
-190 | "1,2,3".split(",", *[1])[0]
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ PLC0207
-191 | "1,2,3".rsplit(",", *[-1])[-1]
-192 | "1,2,3".rsplit(",", *[1])[-1]
+188 | ## Test unpacked list literal args (starred expressions)
+189 | # Errors
+190 | "1,2,3".split(",", *[-1])[0]
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PLC0207
+191 |
+192 | ## Test unpacked list variable args
     |
     = help: Pass `maxsplit=1` into `str.split()`
 
 ℹ Unsafe fix
-187 187 | ## Test unpacked list literal args (starred expressions)
-188 188 | # Errors
-189 189 | "1,2,3".split(",", *[-1])[0]
-190     |-"1,2,3".split(",", *[1])[0]
-    190 |+"1,2,3".split(",", *[1], maxsplit=1)[0]
-191 191 | "1,2,3".rsplit(",", *[-1])[-1]
-192 192 | "1,2,3".rsplit(",", *[1])[-1]
-193 193 | 
+187 187 | 
+188 188 | ## Test unpacked list literal args (starred expressions)
+189 189 | # Errors
+190     |-"1,2,3".split(",", *[-1])[0]
+    190 |+"1,2,3".split(",", *[-1], maxsplit=1)[0]
+191 191 | 
+192 192 | ## Test unpacked list variable args
+193 193 | # Errors
 
-missing_maxsplit_arg.py:191:1: PLC0207 [*] Replace with `rsplit(..., maxsplit=1)`.
+missing_maxsplit_arg.py:195:1: PLC0207 [*] Replace with `split(..., maxsplit=1)`.
     |
-189 | "1,2,3".split(",", *[-1])[0]
-190 | "1,2,3".split(",", *[1])[0]
-191 | "1,2,3".rsplit(",", *[-1])[-1]
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PLC0207
-192 | "1,2,3".rsplit(",", *[1])[-1]
-    |
-    = help: Pass `maxsplit=1` into `str.rsplit()`
-
-ℹ Unsafe fix
-188 188 | # Errors
-189 189 | "1,2,3".split(",", *[-1])[0]
-190 190 | "1,2,3".split(",", *[1])[0]
-191     |-"1,2,3".rsplit(",", *[-1])[-1]
-    191 |+"1,2,3".rsplit(",", *[-1], maxsplit=1)[-1]
-192 192 | "1,2,3".rsplit(",", *[1])[-1]
-193 193 | 
-194 194 | ## Test unpacked list variable args
-
-missing_maxsplit_arg.py:192:1: PLC0207 [*] Replace with `rsplit(..., maxsplit=1)`.
-    |
-190 | "1,2,3".split(",", *[1])[0]
-191 | "1,2,3".rsplit(",", *[-1])[-1]
-192 | "1,2,3".rsplit(",", *[1])[-1]
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PLC0207
-193 |
-194 | ## Test unpacked list variable args
-    |
-    = help: Pass `maxsplit=1` into `str.rsplit()`
-
-ℹ Unsafe fix
-189 189 | "1,2,3".split(",", *[-1])[0]
-190 190 | "1,2,3".split(",", *[1])[0]
-191 191 | "1,2,3".rsplit(",", *[-1])[-1]
-192     |-"1,2,3".rsplit(",", *[1])[-1]
-    192 |+"1,2,3".rsplit(",", *[1], maxsplit=1)[-1]
-193 193 | 
-194 194 | ## Test unpacked list variable args
-195 195 | # Errors
-
-missing_maxsplit_arg.py:197:1: PLC0207 [*] Replace with `split(..., maxsplit=1)`.
-    |
-195 | # Errors
-196 | args_list = [-1]
-197 | "1,2,3".split(",", *args_list)[0]
+193 | # Errors
+194 | args_list = [-1]
+195 | "1,2,3".split(",", *args_list)[0]
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PLC0207
-198 | args_list = [1]
-199 | "1,2,3".split(",", *args_list)[0]
     |
     = help: Pass `maxsplit=1` into `str.split()`
 
 ℹ Unsafe fix
-194 194 | ## Test unpacked list variable args
-195 195 | # Errors
-196 196 | args_list = [-1]
-197     |-"1,2,3".split(",", *args_list)[0]
-    197 |+"1,2,3".split(",", *args_list, maxsplit=1)[0]
-198 198 | args_list = [1]
-199 199 | "1,2,3".split(",", *args_list)[0]
-200 200 | args_list = [-1]
-
-missing_maxsplit_arg.py:199:1: PLC0207 [*] Replace with `split(..., maxsplit=1)`.
-    |
-197 | "1,2,3".split(",", *args_list)[0]
-198 | args_list = [1]
-199 | "1,2,3".split(",", *args_list)[0]
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PLC0207
-200 | args_list = [-1]
-201 | "1,2,3".rsplit(",", *args_list)[-1]
-    |
-    = help: Pass `maxsplit=1` into `str.split()`
-
-ℹ Unsafe fix
-196 196 | args_list = [-1]
-197 197 | "1,2,3".split(",", *args_list)[0]
-198 198 | args_list = [1]
-199     |-"1,2,3".split(",", *args_list)[0]
-    199 |+"1,2,3".split(",", *args_list, maxsplit=1)[0]
-200 200 | args_list = [-1]
-201 201 | "1,2,3".rsplit(",", *args_list)[-1]
-202 202 | args_list = [1]
-
-missing_maxsplit_arg.py:201:1: PLC0207 [*] Replace with `rsplit(..., maxsplit=1)`.
-    |
-199 | "1,2,3".split(",", *args_list)[0]
-200 | args_list = [-1]
-201 | "1,2,3".rsplit(",", *args_list)[-1]
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PLC0207
-202 | args_list = [1]
-203 | "1,2,3".rsplit(",", *args_list)[-1]
-    |
-    = help: Pass `maxsplit=1` into `str.rsplit()`
-
-ℹ Unsafe fix
-198 198 | args_list = [1]
-199 199 | "1,2,3".split(",", *args_list)[0]
-200 200 | args_list = [-1]
-201     |-"1,2,3".rsplit(",", *args_list)[-1]
-    201 |+"1,2,3".rsplit(",", *args_list, maxsplit=1)[-1]
-202 202 | args_list = [1]
-203 203 | "1,2,3".rsplit(",", *args_list)[-1]
-204 204 | 
-
-missing_maxsplit_arg.py:203:1: PLC0207 [*] Replace with `rsplit(..., maxsplit=1)`.
-    |
-201 | "1,2,3".rsplit(",", *args_list)[-1]
-202 | args_list = [1]
-203 | "1,2,3".rsplit(",", *args_list)[-1]
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PLC0207
-204 |
-205 | ## Test mixed unpacked args and kwargs
-    |
-    = help: Pass `maxsplit=1` into `str.rsplit()`
-
-ℹ Unsafe fix
-200 200 | args_list = [-1]
-201 201 | "1,2,3".rsplit(",", *args_list)[-1]
-202 202 | args_list = [1]
-203     |-"1,2,3".rsplit(",", *args_list)[-1]
-    203 |+"1,2,3".rsplit(",", *args_list, maxsplit=1)[-1]
-204 204 | 
-205 205 | ## Test mixed unpacked args and kwargs
-206 206 | # Errors
+192 192 | ## Test unpacked list variable args
+193 193 | # Errors
+194 194 | args_list = [-1]
+195     |-"1,2,3".split(",", *args_list)[0]
+    195 |+"1,2,3".split(",", *args_list, maxsplit=1)[0]


### PR DESCRIPTION
## Summary

Fixes #19660
