### PR TITLE
Remove `KnownModule::is_enum`

### DIFF
--- a/crates/ruff_graph/src/resolver.rs
+++ b/crates/ruff_graph/src/resolver.rs
@@ -69,7 +69,7 @@ impl<'a> Resolver<'a> {
     }
 
     /// Resolves a module name to a module.
-    fn resolve_module(&self, module_name: &ModuleName) -> Option<&'a FilePath> {
+    pub(crate) fn resolve_module(&self, module_name: &ModuleName) -> Option<&'a FilePath> {
         let module = resolve_module(self.db, module_name)?;
         Some(module.file(self.db)?.path(self.db))
     }

--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -7,8 +7,8 @@ use crate::suppression::{INVALID_IGNORE_COMMENT, UNKNOWN_RULE, UNUSED_IGNORE_COM
 pub use db::Db;
 pub use module_name::ModuleName;
 pub use module_resolver::{
-    KnownModule, Module, SearchPathValidationError, SearchPaths, resolve_module,
-    resolve_real_module, system_module_search_paths,
+    Module, SearchPathValidationError, SearchPaths, resolve_module, resolve_real_module,
+    system_module_search_paths,
 };
 pub use program::{
     Program, ProgramSettings, PythonVersionFileSource, PythonVersionSource,

--- a/crates/ty_python_semantic/src/module_resolver/mod.rs
+++ b/crates/ty_python_semantic/src/module_resolver/mod.rs
@@ -1,6 +1,7 @@
 use std::iter::FusedIterator;
 
-pub use module::{KnownModule, Module};
+pub(crate) use module::KnownModule;
+pub use module::Module;
 pub use path::SearchPathValidationError;
 pub use resolver::SearchPaths;
 pub(crate) use resolver::file_to_module;

--- a/crates/ty_python_semantic/src/module_resolver/module.rs
+++ b/crates/ty_python_semantic/src/module_resolver/module.rs
@@ -59,7 +59,7 @@ impl<'db> Module<'db> {
     }
 
     /// Is this a module that we special-case somehow? If so, which one?
-    pub fn known(self, db: &'db dyn Database) -> Option<KnownModule> {
+    pub(crate) fn known(self, db: &'db dyn Database) -> Option<KnownModule> {
         match self {
             Module::File(module) => module.known(db),
             Module::Namespace(_) => None,
@@ -67,7 +67,7 @@ impl<'db> Module<'db> {
     }
 
     /// Does this module represent the given known module?
-    pub fn is_known(self, db: &'db dyn Database, known_module: KnownModule) -> bool {
+    pub(crate) fn is_known(self, db: &'db dyn Database, known_module: KnownModule) -> bool {
         self.known(db) == Some(known_module)
     }
 
@@ -281,7 +281,7 @@ pub enum KnownModule {
 }
 
 impl KnownModule {
-    pub const fn as_str(self) -> &'static str {
+    pub(crate) const fn as_str(self) -> &'static str {
         match self {
             Self::Builtins => "builtins",
             Self::Enum => "enum",
@@ -305,7 +305,7 @@ impl KnownModule {
         }
     }
 
-    pub fn name(self) -> ModuleName {
+    pub(crate) fn name(self) -> ModuleName {
         ModuleName::new_static(self.as_str())
             .unwrap_or_else(|| panic!("{self} should be a valid module name!"))
     }
@@ -321,27 +321,23 @@ impl KnownModule {
         }
     }
 
-    pub const fn is_builtins(self) -> bool {
+    pub(crate) const fn is_builtins(self) -> bool {
         matches!(self, Self::Builtins)
     }
 
-    pub const fn is_typing(self) -> bool {
+    pub(crate) const fn is_typing(self) -> bool {
         matches!(self, Self::Typing)
     }
 
-    pub const fn is_ty_extensions(self) -> bool {
+    pub(crate) const fn is_ty_extensions(self) -> bool {
         matches!(self, Self::TyExtensions)
     }
 
-    pub const fn is_inspect(self) -> bool {
+    pub(crate) const fn is_inspect(self) -> bool {
         matches!(self, Self::Inspect)
     }
 
-    pub const fn is_enum(self) -> bool {
-        matches!(self, Self::Enum)
-    }
-
-    pub const fn is_importlib(self) -> bool {
+    pub(crate) const fn is_importlib(self) -> bool {
         matches!(self, Self::ImportLib)
     }
 }

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -1,7 +1,7 @@
 use ruff_db::files::File;
 
 use crate::dunder_all::dunder_all_names;
-use crate::module_resolver::file_to_module;
+use crate::module_resolver::{KnownModule, file_to_module};
 use crate::semantic_index::definition::{Definition, DefinitionState};
 use crate::semantic_index::place::{PlaceExprRef, ScopedPlaceId};
 use crate::semantic_index::scope::ScopeId;
@@ -13,7 +13,7 @@ use crate::types::{
     DynamicType, KnownClass, Truthiness, Type, TypeAndQualifiers, TypeQualifiers, UnionBuilder,
     UnionType, binding_type, declaration_type, todo_type,
 };
-use crate::{Db, FxOrderSet, KnownModule, Program, resolve_module};
+use crate::{Db, FxOrderSet, Program, resolve_module};
 
 pub(crate) use implicit_globals::{
     module_type_implicit_global_declaration, module_type_implicit_global_symbol,

--- a/crates/ty_python_semantic/src/types/builder.rs
+++ b/crates/ty_python_semantic/src/types/builder.rs
@@ -1068,8 +1068,8 @@ impl<'db> InnerIntersectionBuilder<'db> {
 mod tests {
     use super::{IntersectionBuilder, Type, UnionBuilder, UnionType};
 
-    use crate::KnownModule;
     use crate::db::tests::setup_db;
+    use crate::module_resolver::KnownModule;
     use crate::place::known_module_symbol;
     use crate::types::enums::enum_member_literals;
     use crate::types::{KnownClass, Truthiness};

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -9,6 +9,7 @@ use super::{
     function::{FunctionDecorators, FunctionType},
     infer_expression_type, infer_unpack_types,
 };
+use crate::module_resolver::KnownModule;
 use crate::semantic_index::definition::{Definition, DefinitionState};
 use crate::semantic_index::scope::NodeWithScopeKind;
 use crate::semantic_index::{DeclarationWithConstraint, SemanticIndex, attribute_declarations};
@@ -27,7 +28,7 @@ use crate::types::{
     infer_definition_types,
 };
 use crate::{
-    Db, FxIndexMap, FxOrderSet, KnownModule, Program,
+    Db, FxIndexMap, FxOrderSet, Program,
     module_resolver::file_to_module,
     place::{
         Boundness, LookupError, LookupResult, Place, PlaceAndQualifiers, class_symbol,

--- a/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
+++ b/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
@@ -6,7 +6,7 @@ use crate::types::{
     BoundMethodType, CallableType, EnumLiteralType, IntersectionBuilder, KnownClass, Parameter,
     Parameters, Signature, SpecialFormType, SubclassOfType, Type, UnionType,
 };
-use crate::{Db, KnownModule};
+use crate::{Db, module_resolver::KnownModule};
 use hashbrown::HashSet;
 use quickcheck::{Arbitrary, Gen};
 use ruff_python_ast::name::Name;


### PR DESCRIPTION
## Summary

Changes the visibility of `KnownModule` and removes an unneeded function.
