### PR TITLE
[ty] Do not treat tuple types as ever being single-valued

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
@@ -431,7 +431,7 @@ def constrained_non_singletons[T: (int, str)](t: T) -> None:
 def constrained_singletons[T: (Literal[True], Literal[False])](t: T) -> None:
     static_assert(is_singleton(T))
 
-def constrained_single_valued[T: (Literal[True], tuple[()])](t: T) -> None:
+def constrained_single_valued[T: (Literal[True], Literal[42])](t: T) -> None:
     static_assert(is_single_valued(T))
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_single_valued.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_single_valued.md
@@ -13,9 +13,6 @@ static_assert(is_single_valued(Literal[1]))
 static_assert(is_single_valued(Literal["abc"]))
 static_assert(is_single_valued(Literal[b"abc"]))
 
-static_assert(is_single_valued(tuple[()]))
-static_assert(is_single_valued(tuple[Literal[True], Literal[1]]))
-
 static_assert(not is_single_valued(str))
 static_assert(not is_single_valued(Never))
 static_assert(not is_single_valued(Any))
@@ -33,6 +30,43 @@ class A:
 static_assert(is_single_valued(TypeOf[A().method]))
 static_assert(is_single_valued(TypeOf[types.FunctionType.__get__]))
 static_assert(is_single_valued(TypeOf[A.method.__get__]))
+```
+
+Tuple types are not single-valued, because the type `tuple[int, str]` means "any two-element
+instance of `tuple` where the first element is `int` and the second is `str`, *or* any instance of a
+subclass of `tuple[int, str]`". It's easy to create a subclass of `tuple[int, str]` that is
+Liskov-compliant but not single-valued, which therefore means that `tuple[int, str]` cannot be
+single-valued, as it is a supertype of its subclass, so can only be single-valued if all its
+subtypes are single-valued:
+
+```py
+from ty_extensions import is_single_valued, static_assert
+
+class EmptyTupleSubclass(tuple[()]):
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, EmptyTupleSubclass) and len(other) == 0
+
+static_assert(not is_single_valued(tuple[()]))
+static_assert(not is_single_valued(EmptyTupleSubclass))
+
+class SingleElementTupleSubclass(tuple[int]):
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, SingleElementTupleSubclass) and len(other) == 1 and isinstance(other[0], int)
+
+static_assert(not is_single_valued(tuple[int]))
+static_assert(not is_single_valued(SingleElementTupleSubclass))
+
+class TwoElementTupleSubclass(tuple[str, bytes]):
+    def __eq__(self, other: object) -> bool:
+        return (
+            isinstance(other, TwoElementTupleSubclass)
+            and len(other) == 2
+            and isinstance(other[0], str)
+            and isinstance(other[1], bytes)
+        )
+
+static_assert(not is_single_valued(tuple[str, bytes]))
+static_assert(not is_single_valued(TwoElementTupleSubclass))
 ```
 
 An enum literal is only considered single-valued if it has no custom `__eq__`/`__ne__` method, or if

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2442,7 +2442,6 @@ impl<'db> Type<'db> {
                 false
             }
 
-            Type::Tuple(tuple) => tuple.is_single_valued(db),
             Type::NominalInstance(instance) => instance.is_single_valued(db),
 
             Type::BoundSuper(_) => {
@@ -2453,6 +2452,7 @@ impl<'db> Type<'db> {
             Type::TypeIs(type_is) => type_is.is_bound(db),
 
             Type::Dynamic(_)
+            | Type::Tuple(..)
             | Type::Never
             | Type::Union(..)
             | Type::Intersection(..)

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -299,10 +299,6 @@ impl<'db> TupleType<'db> {
             .is_disjoint_from_impl(db, other.tuple(db), visitor)
     }
 
-    pub(crate) fn is_single_valued(self, db: &'db dyn Db) -> bool {
-        self.tuple(db).is_single_valued(db)
-    }
-
     pub(crate) fn truthiness(self, db: &'db dyn Db) -> Truthiness {
         self.tuple(db).truthiness()
     }
@@ -487,10 +483,6 @@ impl<'db> FixedLengthTuple<Type<'db>> {
             && (self.0.iter())
                 .zip(&other.0)
                 .all(|(self_ty, other_ty)| self_ty.is_equivalent_to(db, *other_ty))
-    }
-
-    fn is_single_valued(&self, db: &'db dyn Db) -> bool {
-        self.0.iter().all(|ty| ty.is_single_valued(db))
     }
 }
 
@@ -1220,13 +1212,6 @@ impl<'db> Tuple<Type<'db>> {
         // disjoint even if A and B are disjoint, because `tuple[()]` would be assignable to
         // both.
         false
-    }
-
-    fn is_single_valued(&self, db: &'db dyn Db) -> bool {
-        match self {
-            Tuple::Fixed(tuple) => tuple.is_single_valued(db),
-            Tuple::Variable(_) => false,
-        }
     }
 }
 


### PR DESCRIPTION
## Summary

This PR updates our handling of tuples so that we no longer consider tuple types as ever being "single-valued" types. As a reminder, a type is only single-valued if all possible inhabitants of the type compare equal. For example, `Literal[42]` is a single-valued type (even though it is not a singleton type), because the definition of the type is such that the only possible inhabitants of the type are instances of _exactly_ `int` (cannot be an `int` subclass!) that compare equal to the runtime value `42`.

On `main` we consider a tuple type as being single-valued if it is a fixed-length tuple and all its element types are single-valued types. This makes sense if you assume that inhabitants of `tuple[int, str]` must be instances of _exactly_ `tuple`. But that's not what we assume, and it's not what we should assume: all other type checkers consider tuple subclasses as being subtypes of the tuple type defined by their tuple superclass. It would be a huge compatibility break with the ecosystem if we tried to assume otherwise:

```py
from ty_extensions import static_assert, is_subtype_of

class Foo(tuple[int, str]): ...

static_assert(is_subtype_of(Foo, tuple[int, str]))  # passes
```

It's easy to create a subclass of `tuple[int, str]` that is Liskov-compliant but not single-valued, which therefore means that `tuple[int, str]` cannot be single-valued, as it is a supertype of its subclass, so can only be single-valued if all its subtypes are single-valued:

```py
from ty_extensions import is_single_valued, static_assert

class EmptyTupleSubclass(tuple[()]):
    def __eq__(self, other: object) -> bool:
        return isinstance(other, EmptyTupleSubclass) and len(other) == 0

static_assert(not is_single_valued(tuple[()]))
static_assert(not is_single_valued(EmptyTupleSubclass))

class SingleElementTupleSubclass(tuple[int]):
    def __eq__(self, other: object) -> bool:
        return (
            isinstance(other, SingleElementTupleSubclass)
            and len(other) == 1
            and isinstance(other[0], int)
        )

static_assert(not is_single_valued(tuple[int]))
static_assert(not is_single_valued(SingleElementTupleSubclass))

class TwoElementTupleSubclass(tuple[str, bytes]):
    def __eq__(self, other: object) -> bool:
        return (
            isinstance(other, TwoElementTupleSubclass)
            and len(other) == 2
            and isinstance(other[0], str)
            and isinstance(other[1], bytes)
        )

static_assert(not is_single_valued(tuple[str, bytes]))
static_assert(not is_single_valued(TwoElementTupleSubclass))
```

This might seem needlessly nitpicky and academic -- who creates tuple subclasses in the real world? But the answer to that question is "Quite a few people, actually!", since all `NamedTuple` classes are tuple subclasses, and `NamedTuple`s are a very popular feature.

## Test Plan

Updated and extended mdtests

## Ecosystem analysis

There is a single new diagnostic being emitted on `zope.interface` [here](https://github.com/zopefoundation/zope.interface/blob/f418c310af667c619314cdc635aeaca2b1c7a4c3/src/zope/interface/ro.py#L483-L497). This is because they're using `()` as a sentinel value, and then trying to narrow that type out of a union of types by using `== ()`. But we no longer see that as a valid way of narrowing a type, because we infer the type of `()` as `tuple[()]`, and we must account for the possibility of `tuple[()]` subclasses that define custom equality methods.

This does feel a _bit_ unfortunate, because while tuple subclasses are common and defining custom `__eq__` methods on them seems pretty plausible, defining a custom `__eq__` method on a subclass of `tuple[()]` specifically seems somewhat implausible. However, it's only a single new diagnostic, and I think that's worth it to make our behaviour sound and consistent.