### PR TITLE
[`refurb`] Make example error out-of-the-box (`FURB157`)

### DIFF
--- a/crates/ruff_linter/src/rules/refurb/rules/verbose_decimal_constructor.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/verbose_decimal_constructor.rs
@@ -30,12 +30,16 @@ use crate::{Edit, Fix, FixAvailability, Violation};
 ///
 /// ## Example
 /// ```python
+/// from decimal import Decimal
+///
 /// Decimal("0")
 /// Decimal(float("Infinity"))
 /// ```
 ///
 /// Use instead:
 /// ```python
+/// from decimal import Decimal
+///
 /// Decimal(0)
 /// Decimal("Infinity")
 /// ```


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Part of #18972

This PR makes [verbose-decimal-constructor (FURB157)](https://docs.astral.sh/ruff/rules/verbose-decimal-constructor/#verbose-decimal-constructor-furb157)'s example error out-of-the-box.

[Old example](https://play.ruff.rs/0930015c-ad45-4490-800e-66ed057bfe34)
```py
Decimal("0")
Decimal(float("Infinity"))
```

[New example](https://play.ruff.rs/516e5992-322f-4203-afe7-46d8cad53368)
```py
from decimal import Decimal

Decimal("0")
Decimal(float("Infinity"))
```

Imports were also added to the "Use Instead" section.

## Test Plan

<!-- How was it tested? -->

N/A, no functionality/tests affected