### PR TITLE
[ty] Remap Jupyter notebook cell indices in `ruff_db`

### DIFF
--- a/crates/ruff_annotate_snippets/src/renderer/display_list.rs
+++ b/crates/ruff_annotate_snippets/src/renderer/display_list.rs
@@ -298,11 +298,22 @@ impl DisplaySet<'_> {
                 let lineno_color = stylesheet.line_no();
                 buffer.puts(line_offset, lineno_width, header_sigil, *lineno_color);
                 buffer.puts(line_offset, lineno_width + 4, path, stylesheet.none);
-                if let Some((col, row)) = pos {
-                    buffer.append(line_offset, ":", stylesheet.none);
-                    buffer.append(line_offset, col.to_string().as_str(), stylesheet.none);
-                    buffer.append(line_offset, ":", stylesheet.none);
-                    buffer.append(line_offset, row.to_string().as_str(), stylesheet.none);
+                match pos {
+                    Some(Position::RowCol(row, col)) => {
+                        buffer.append(line_offset, ":", stylesheet.none);
+                        buffer.append(line_offset, row.to_string().as_str(), stylesheet.none);
+                        buffer.append(line_offset, ":", stylesheet.none);
+                        buffer.append(line_offset, col.to_string().as_str(), stylesheet.none);
+                    }
+                    Some(Position::Cell(cell, row, col)) => {
+                        buffer.append(line_offset, ":", stylesheet.none);
+                        buffer.append(line_offset, &format!("cell {cell}"), stylesheet.none);
+                        buffer.append(line_offset, ":", stylesheet.none);
+                        buffer.append(line_offset, row.to_string().as_str(), stylesheet.none);
+                        buffer.append(line_offset, ":", stylesheet.none);
+                        buffer.append(line_offset, col.to_string().as_str(), stylesheet.none);
+                    }
+                    None => {}
                 }
                 Ok(())
             }
@@ -883,6 +894,12 @@ impl DisplaySourceAnnotation<'_> {
     }
 }
 
+#[derive(Debug, PartialEq)]
+pub(crate) enum Position {
+    RowCol(usize, usize),
+    Cell(usize, usize, usize),
+}
+
 /// Raw line - a line which does not have the `lineno` part and is not considered
 /// a part of the snippet.
 #[derive(Debug, PartialEq)]
@@ -891,7 +908,7 @@ pub(crate) enum DisplayRawLine<'a> {
     /// slice in the project structure.
     Origin {
         path: &'a str,
-        pos: Option<(usize, usize)>,
+        pos: Option<Position>,
         header_type: DisplayHeaderType,
     },
 
@@ -1191,12 +1208,14 @@ fn format_snippet<'m>(
             "Non-empty file-level snippet that won't be rendered: {:?}",
             snippet.source
         );
-        let header = format_header(origin, main_range, &[], is_first);
+        let header = format_header(origin, main_range, &[], is_first, snippet.cell_index);
         return DisplaySet {
             display_lines: header.map_or_else(Vec::new, |header| vec![header]),
             margin: Margin::new(0, 0, 0, 0, term_width, 0),
         };
     }
+
+    let cell_index = snippet.cell_index;
 
     let mut body = format_body(
         snippet,
@@ -1206,7 +1225,13 @@ fn format_snippet<'m>(
         anonymized_line_numbers,
         cut_indicator,
     );
-    let header = format_header(origin, main_range, &body.display_lines, is_first);
+    let header = format_header(
+        origin,
+        main_range,
+        &body.display_lines,
+        is_first,
+        cell_index,
+    );
 
     if let Some(header) = header {
         body.display_lines.insert(0, header);
@@ -1226,6 +1251,7 @@ fn format_header<'a>(
     main_range: Option<usize>,
     body: &[DisplayLine<'_>],
     is_first: bool,
+    cell_index: Option<usize>,
 ) -> Option<DisplayLine<'a>> {
     let display_header = if is_first {
         DisplayHeaderType::Initial
@@ -1260,9 +1286,15 @@ fn format_header<'a>(
             }
         }
 
+        let pos = if let Some(cell) = cell_index {
+            Position::Cell(cell, line_offset, col)
+        } else {
+            Position::RowCol(line_offset, col)
+        };
+
         return Some(DisplayLine::Raw(DisplayRawLine::Origin {
             path,
-            pos: Some((line_offset, col)),
+            pos: Some(pos),
             header_type: display_header,
         }));
     }

--- a/crates/ruff_annotate_snippets/src/renderer/display_list.rs
+++ b/crates/ruff_annotate_snippets/src/renderer/display_list.rs
@@ -263,7 +263,11 @@ impl DisplaySet<'_> {
             if annotation.is_fixable {
                 buffer.append(line_offset, "[", stylesheet.none);
                 buffer.append(line_offset, "*", stylesheet.help);
-                buffer.append(line_offset, "] ", stylesheet.none);
+                buffer.append(line_offset, "]", stylesheet.none);
+                // In the hide-severity case, we need a space instead of the colon and space below.
+                if hide_severity {
+                    buffer.append(line_offset, " ", stylesheet.none);
+                }
             }
 
             if !is_annotation_empty(annotation) {

--- a/crates/ruff_annotate_snippets/src/snippet.rs
+++ b/crates/ruff_annotate_snippets/src/snippet.rs
@@ -75,6 +75,10 @@ pub struct Snippet<'a> {
     pub(crate) annotations: Vec<Annotation<'a>>,
 
     pub(crate) fold: bool,
+
+    /// The optional cell index in a Jupyter notebook, used for reporting source locations along
+    /// with the ranges on `annotations`.
+    pub(crate) cell_index: Option<usize>,
 }
 
 impl<'a> Snippet<'a> {
@@ -85,6 +89,7 @@ impl<'a> Snippet<'a> {
             source,
             annotations: vec![],
             fold: false,
+            cell_index: None,
         }
     }
 
@@ -111,6 +116,12 @@ impl<'a> Snippet<'a> {
     /// Hide lines without [`Annotation`]s
     pub fn fold(mut self, fold: bool) -> Self {
         self.fold = fold;
+        self
+    }
+
+    /// Attach a Jupyter notebook cell index.
+    pub fn cell_index(mut self, index: Option<usize>) -> Self {
+        self.cell_index = index;
         self
     }
 }

--- a/crates/ruff_db/src/diagnostic/render.rs
+++ b/crates/ruff_db/src/diagnostic/render.rs
@@ -2739,7 +2739,7 @@ watermelon
         ///
         /// See the docs on `TestEnvironment::span` for the meaning of
         /// `path`, `line_offset_start` and `line_offset_end`.
-        fn secondary(
+        pub(super) fn secondary(
             mut self,
             path: &str,
             line_offset_start: &str,
@@ -2775,7 +2775,7 @@ watermelon
         }
 
         /// Adds a "help" sub-diagnostic with the given message.
-        fn help(mut self, message: impl IntoDiagnosticMessage) -> DiagnosticBuilder<'e> {
+        pub(super) fn help(mut self, message: impl IntoDiagnosticMessage) -> DiagnosticBuilder<'e> {
             self.diag.help(message);
             self
         }
@@ -2946,7 +2946,8 @@ if call(foo
         (env, diagnostics)
     }
 
-    /// Create Ruff-style diagnostics for testing the various output formats for a notebook.
+    /// A Jupyter notebook for testing diagnostics.
+    ///
     ///
     /// The concatenated cells look like this:
     ///
@@ -2966,17 +2967,7 @@ if call(foo
     /// The first diagnostic is on the unused `os` import with location cell 1, row 2, column 8
     /// (`cell 1:2:8`). The second diagnostic is the unused `math` import at `cell 2:2:8`, and the
     /// third diagnostic is an unfixable unused variable at `cell 3:4:5`.
-    #[allow(
-        dead_code,
-        reason = "This is currently only used for JSON but will be needed soon for other formats"
-    )]
-    pub(crate) fn create_notebook_diagnostics(
-        format: DiagnosticFormat,
-    ) -> (TestEnvironment, Vec<Diagnostic>) {
-        let mut env = TestEnvironment::new();
-        env.add(
-            "notebook.ipynb",
-            r##"
+    pub(super) static NOTEBOOK: &str = r##"
         {
  "cells": [
   {
@@ -3015,8 +3006,14 @@ if call(foo
  "nbformat": 4,
  "nbformat_minor": 5
 }
-"##,
-        );
+"##;
+
+    /// Create Ruff-style diagnostics for testing the various output formats for a notebook.
+    pub(crate) fn create_notebook_diagnostics(
+        format: DiagnosticFormat,
+    ) -> (TestEnvironment, Vec<Diagnostic>) {
+        let mut env = TestEnvironment::new();
+        env.add("notebook.ipynb", NOTEBOOK);
         env.format(format);
 
         let diagnostics = vec![

--- a/crates/ruff_db/src/diagnostic/render.rs
+++ b/crates/ruff_db/src/diagnostic/render.rs
@@ -608,12 +608,17 @@ struct RenderableSnippet<'r> {
 
 impl<'r> RenderableSnippet<'r> {
     /// Creates a new snippet with one or more annotations that is ready to be
-    /// renderer.
+    /// rendered.
     ///
     /// The first line of the snippet is the smallest line number on which one
     /// of the annotations begins, minus the context window size. The last line
     /// is the largest line number on which one of the annotations ends, plus
     /// the context window size.
+    ///
+    /// For Jupyter notebooks, the context window may also be truncated at cell
+    /// boundaries. If multiple annotations are present, and they point to
+    /// different cells, these will have already been split into separate
+    /// snippets by `ResolvedDiagnostic::to_renderable`.
     ///
     /// Callers should guarantee that the `input` on every `ResolvedAnnotation`
     /// given is identical.

--- a/crates/ruff_db/src/diagnostic/render.rs
+++ b/crates/ruff_db/src/diagnostic/render.rs
@@ -456,7 +456,6 @@ impl<'a> ResolvedAnnotation<'a> {
                 (range, line_start, line_end)
             }
         };
-
         Some(ResolvedAnnotation {
             path,
             diagnostic_source: diagnostic_source.clone(),

--- a/crates/ruff_db/src/diagnostic/render/full.rs
+++ b/crates/ruff_db/src/diagnostic/render/full.rs
@@ -345,6 +345,12 @@ print()
                 .secondary("notebook.ipynb", "10:4", "10:5", "second cell")
                 .help("Remove unused import: `os`")
                 .build(),
+            // adjacent context windows in the same cell
+            env.err()
+                .primary("notebook.ipynb", "4:7", "4:11", "second cell")
+                .secondary("notebook.ipynb", "6:0", "6:5", "print statement")
+                .help("Remove `print` statement")
+                .build(),
         ];
 
         insta::assert_snapshot!(env.render_diagnostics(&diagnostics), @r"
@@ -380,6 +386,18 @@ print()
           |     - second cell
           |
         help: Remove unused import: `os`
+
+        error[test-diagnostic]: main diagnostic message
+         --> notebook.ipynb:cell 2:2:8
+          |
+        1 | # cell 2
+        2 | import math
+          |        ^^^^ second cell
+        3 |
+        4 | print('hello world')
+          | ----- print statement
+          |
+        help: Remove `print` statement
         ");
     }
 }

--- a/crates/ruff_db/src/diagnostic/render/full.rs
+++ b/crates/ruff_db/src/diagnostic/render/full.rs
@@ -294,7 +294,7 @@ print()
     fn notebook_output() {
         let (env, diagnostics) = create_notebook_diagnostics(DiagnosticFormat::Full);
         insta::assert_snapshot!(env.render_diagnostics(&diagnostics), @r"
-        error[unused-import]: `os` imported but unused
+        error[unused-import][*]: `os` imported but unused
          --> notebook.ipynb:cell 1:2:8
           |
         1 | # cell 1
@@ -303,7 +303,7 @@ print()
           |
         help: Remove unused import: `os`
 
-        error[unused-import]: `math` imported but unused
+        error[unused-import][*]: `math` imported but unused
          --> notebook.ipynb:cell 2:2:8
           |
         1 | # cell 2

--- a/crates/ruff_db/src/diagnostic/render/full.rs
+++ b/crates/ruff_db/src/diagnostic/render/full.rs
@@ -300,31 +300,28 @@ print()
         1 | # cell 1
         2 | import os
           |        ^^
-        3 | # cell 2
-        4 | import math
           |
         help: Remove unused import: `os`
 
         error[unused-import]: `math` imported but unused
          --> notebook.ipynb:cell 2:2:8
           |
-        2 | import os
-        3 | # cell 2
-        4 | import math
+        1 | # cell 2
+        2 | import math
           |        ^^^^
-        5 |
-        6 | print('hello world')
+        3 |
+        4 | print('hello world')
           |
         help: Remove unused import: `math`
 
         error[unused-variable]: Local variable `x` is assigned to but never used
-          --> notebook.ipynb:cell 3:4:5
-           |
-         8 | def foo():
-         9 |     print()
-        10 |     x = 1
-           |     ^
-           |
+         --> notebook.ipynb:cell 3:4:5
+          |
+        2 | def foo():
+        3 |     print()
+        4 |     x = 1
+          |     ^
+          |
         help: Remove assignment to unused variable `x`
         ");
     }

--- a/crates/ruff_db/src/diagnostic/render/full.rs
+++ b/crates/ruff_db/src/diagnostic/render/full.rs
@@ -354,11 +354,14 @@ print()
         1 | # cell 1
         2 | import os
           |        ^^
-        3 | # cell 2
-        4 | import math
+          |
+         ::: notebook.ipynb:cell 2:2:8
+          |
+        1 | # cell 2
+        2 | import math
           |        ---- second cell
-        5 |
-        6 | print('hello world')
+        3 |
+        4 | print('hello world')
           |
         help: Remove unused import: `os`
 


### PR DESCRIPTION
## Summary

This PR remaps ranges in Jupyter notebooks from simple `row:column` indices in the concatenated source code to `cell:row:col` to match Ruff's output. This is probably not a likely change to land upstream in `annotate-snippets`, but I didn't see a good way around it.

The remapping logic is taken nearly verbatim from here:

https://github.com/astral-sh/ruff/blob/cd6bf1457d667dd17058e07fa4198dae4bfb75f6/crates/ruff_linter/src/message/text.rs#L212-L222


## Test Plan

New `full` rendering test for a notebook

I was mainly focused on Ruff, but in local tests this also works for ty:

```
error[invalid-assignment]: Object of type `Literal[1]` is not assignable to `str`
 --> Untitled.ipynb:cell 1:3:1
  |
1 | import math
2 |
3 | x: str = 1
  | ^
  |
info: rule `invalid-assignment` is enabled by default

error[invalid-assignment]: Object of type `Literal[1]` is not assignable to `str`
 --> Untitled.ipynb:cell 2:3:1
  |
1 | import math
2 |
3 | x: str = 1
  | ^
  |
info: rule `invalid-assignment` is enabled by default
```

This isn't a duplicate diagnostic, just an unimaginative example:

```py
# cell 1
import math

x: str = 1
# cell 2
import math

x: str = 1
```
