### PR TITLE
Fix a typo in the docs

### DIFF
--- a/crates/ruff_linter/src/rules/ruff/rules/none_not_at_end_of_union.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/none_not_at_end_of_union.rs
@@ -11,7 +11,7 @@ use crate::checkers::ast::Checker;
 /// Checks for type annotations where `None` is not at the end of an union.
 ///
 /// ## Why is this bad?
-/// Type annotation unions are associative, meaning that the order of the elements
+/// Type annotation unions are commutative, meaning that the order of the elements
 /// does not matter. The `None` literal represents the absence of a value. For
 /// readability, it's preferred to write the more informative type expressions first.
 ///


### PR DESCRIPTION
Thanks for the great tool!

I noticed a small typo [in the docs](https://docs.astral.sh/ruff/rules/none-not-at-end-of-union/): it's [commutativity](Commutative_property) that makes the order not matter in type unions, not [associativity](https://en.wikipedia.org/wiki/Associative_property) which is something different.

I make the change in this PR.