### PR TITLE
[ty] clear the terminal screen in watch mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4187,6 +4187,7 @@ dependencies = [
  "argfile",
  "clap",
  "clap_complete_command",
+ "clearscreen",
  "colored 3.0.0",
  "crossbeam",
  "ctrlc",

--- a/crates/ty/Cargo.toml
+++ b/crates/ty/Cargo.toml
@@ -25,6 +25,7 @@ anyhow = { workspace = true }
 argfile = { workspace = true }
 clap = { workspace = true, features = ["wrap_help", "string", "env"] }
 clap_complete_command = { workspace = true }
+clearscreen = { workspace = true }
 colored = { workspace = true }
 crossbeam = { workspace = true }
 ctrlc = { version = "3.4.4" }

--- a/crates/ty/src/lib.rs
+++ b/crates/ty/src/lib.rs
@@ -265,6 +265,9 @@ impl MainLoop {
         let mut revision = 0u64;
 
         while let Ok(message) = self.receiver.recv() {
+            if self.watcher.is_some() {
+                Printer::clear_screen()?;
+            }
             match message {
                 MainLoopMessage::CheckWorkspace => {
                     let db = db.clone();

--- a/crates/ty/src/printer.rs
+++ b/crates/ty/src/printer.rs
@@ -1,5 +1,6 @@
 use std::io::StdoutLock;
 
+use anyhow::Result;
 use indicatif::ProgressDrawTarget;
 
 use crate::logging::VerbosityLevel;
@@ -108,6 +109,12 @@ impl Printer {
     /// For example, in `ty check`, this would be used for the diagnostic output.
     pub(crate) fn stream_for_details(self) -> Stdout {
         self.stdout_general()
+    }
+
+    pub(crate) fn clear_screen() -> Result<()> {
+        #[cfg(not(target_family = "wasm"))]
+        clearscreen::clear()?;
+        Ok(())
     }
 }
 

--- a/crates/ty/src/printer.rs
+++ b/crates/ty/src/printer.rs
@@ -112,7 +112,6 @@ impl Printer {
     }
 
     pub(crate) fn clear_screen() -> Result<()> {
-        #[cfg(not(target_family = "wasm"))]
         clearscreen::clear()?;
         Ok(())
     }


### PR DESCRIPTION
The intended behavior is achieved by entering the terminal alternate screen and clearing the screen before printing the diagnostics.

Fixes [#827](https://github.com/astral-sh/ty/issues/827)
