### PR TITLE
Fix(19552)/watch does not show output format warning message

### DIFF
--- a/crates/ruff/src/lib.rs
+++ b/crates/ruff/src/lib.rs
@@ -15,7 +15,6 @@ use notify::{RecursiveMode, Watcher, recommended_watcher};
 use args::{GlobalConfigArgs, ServerCommand};
 use ruff_linter::logging::{LogLevel, set_up_logging};
 use ruff_linter::settings::flags::FixMode;
-use ruff_linter::settings::types::OutputFormat;
 use ruff_linter::{fs, warn_user, warn_user_once};
 use ruff_workspace::Settings;
 
@@ -343,13 +342,6 @@ pub fn check(args: CheckCommand, global_options: GlobalConfigArgs) -> Result<Exi
     let preview = pyproject_config.settings.linter.preview.is_enabled();
 
     if cli.watch {
-        if output_format != OutputFormat::default() {
-            warn_user!(
-                "`--output-format {}` is always used in watch mode.",
-                OutputFormat::default()
-            );
-        }
-
         // Configure the file watcher.
         let (tx, rx) = channel();
         let mut watcher = recommended_watcher(tx)?;
@@ -362,7 +354,9 @@ pub fn check(args: CheckCommand, global_options: GlobalConfigArgs) -> Result<Exi
 
         // Perform an initial run instantly.
         Printer::clear_screen()?;
-        printer.write_to_user("Starting linter in watch mode...\n");
+        printer.write_to_user(&format!(
+            "Starting linter in watch mode using {output_format} formatting...\n"
+        ));
 
         let diagnostics = commands::check::check(
             &files,

--- a/crates/ruff/tests/integration_test.rs
+++ b/crates/ruff/tests/integration_test.rs
@@ -2485,9 +2485,6 @@ fn should_output_correct_text_in_watch_mode_with_full_output_format() -> Result<
         for line in reader.lines().map_while(Result::ok) {
             // Filter out ANSI escape codes
             let clean_line = strip_ansi_codes(&line);
-            //let clean_line = line;
-
-            // Skip empty lines and watch mode status messages
 
             output.push_str(&clean_line);
             output.push('\n');
@@ -2593,9 +2590,6 @@ fn should_output_correct_text_in_watch_mode_with_concise_output_format() -> Resu
         for line in reader.lines().map_while(Result::ok) {
             // Filter out ANSI escape codes
             let clean_line = strip_ansi_codes(&line);
-            //let clean_line = line;
-
-            // Skip empty lines and watch mode status messages
 
             output.push_str(&clean_line);
             output.push('\n');
@@ -2695,9 +2689,6 @@ fn should_output_correct_text_in_watch_mode_with_full_output_format_and_no_error
         for line in reader.lines().map_while(Result::ok) {
             // Filter out ANSI escape codes
             let clean_line = strip_ansi_codes(&line);
-            //let clean_line = line;
-
-            // Skip empty lines and watch mode status messages
 
             output.push_str(&clean_line);
             output.push('\n');


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

Added and fixed how output formatting works in watch mode

### Changes Made


* Created `format_diagnostics()` method to support different write modes `WriteMode::Once` vs `WriteMode::Continuous`
* Added proper handling of `OutputFormat::Full` and `OutputFormat::Concise` in `watch` mode through the new `WriteMode::Continuous` branch
* Ensured that full diagnostic formatting (including source code snippets and detailed error context) is preserved when using --watch with --output-format full


* Introduced `WriteMode` enum to distinguish between single-run and continuous watch mode operations
* Updated `TextEmitter` configuration in continuous mode to respect the `OutputFormat::Full` setting via .with_show_source(self.format == OutputFormat::Full)
* Maintained backward compatibility by preserving existing behavior for non-watch mode operations

Note: with these changes, selecting `--preview` mode does not have any effect on output formatting. `full` mode is still the default mode. 



## Test Plan

* Added three integration tests to verify that watch mode properly outputs full diagnostic formatting
* Tests cover scenarios with both errors present and no errors found
* Ensured cross-platform compatibility for file path handling in test snapshots
