### PR TITLE
Remove myself as a codeowner from some ty crates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,7 +18,10 @@
 /python/py-fuzzer/ @AlexWaygood
 
 # ty
-/crates/ty* @carljm @MichaReiser @AlexWaygood @sharkdp @dcreager
-/crates/ruff_db/ @carljm @MichaReiser @AlexWaygood @sharkdp @dcreager
+/crates/ty* @carljm @MichaReiser @sharkdp @dcreager
+/crates/ruff_db/ @carljm @MichaReiser @sharkdp @dcreager
 /scripts/ty_benchmark/ @carljm @MichaReiser @AlexWaygood @sharkdp @dcreager
 /crates/ty_python_semantic @carljm @AlexWaygood @sharkdp @dcreager
+/crates/ty_ide @carljm @AlexWaygood @MichaReiser @sharkdp @dcreager
+/crates/ty_vendored @carljm @AlexWaygood @MichaReiser @sharkdp @dcreager
+/crates/ty_test @carljm @AlexWaygood @MichaReiser @sharkdp @dcreager

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,10 +18,11 @@
 /python/py-fuzzer/ @AlexWaygood
 
 # ty
-/crates/ty* @carljm @MichaReiser @sharkdp @dcreager
+/crates/ty* @carljm @MichaReiser @AlexWaygood @sharkdp @dcreager
 /crates/ruff_db/ @carljm @MichaReiser @sharkdp @dcreager
+/crates/ty_project/ @carljm @MichaReiser @sharkdp @dcreager
+/crates/ty_server/ @carljm @MichaReiser @sharkdp @dcreager
+/crates/ty/ @carljm @MichaReiser @sharkdp @dcreager
+/crates/ty_wasm/ @carljm @MichaReiser @sharkdp @dcreager
 /scripts/ty_benchmark/ @carljm @MichaReiser @AlexWaygood @sharkdp @dcreager
 /crates/ty_python_semantic @carljm @AlexWaygood @sharkdp @dcreager
-/crates/ty_ide @carljm @AlexWaygood @MichaReiser @sharkdp @dcreager
-/crates/ty_vendored @carljm @AlexWaygood @MichaReiser @sharkdp @dcreager
-/crates/ty_test @carljm @AlexWaygood @MichaReiser @sharkdp @dcreager


### PR DESCRIPTION
## Summary

This removes me as a CODEOWNER for several ty crates:
- ty
- ty_server
- ty_project
- ty_wasm
- ruff_db

I don't know the code in these crates particularly well and don't have a strong sense of ownership over most of it, so there are other people on the team better placed to review PRs touching these crates. This will reduce the number of notifications in my inbox, allowing me to focus on the important ones.

## Test Plan

GitHub says the CODE0WNERS file is valid, and I think it confoms with the syntax described in https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax
