### PR TITLE
[ty] Fix failing test on windows

### DIFF
--- a/crates/ty_server/tests/e2e/pull_diagnostics.rs
+++ b/crates/ty_server/tests/e2e/pull_diagnostics.rs
@@ -324,6 +324,7 @@ def foo() -> str:
 }
 
 #[test]
+#[cfg(unix)]
 fn workspace_diagnostic_caching_unchanged_with_colon_in_path() -> Result<()> {
     let _filter = filter_result_id();
 


### PR DESCRIPTION
## Summary

Windows doesn't like colons in file names.

## Test Plan

