### PR TITLE
[`flake8-blind-except`] Change `BLE001` to correctly parse exception tuples

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_blind_except/BLE.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_blind_except/BLE.py
@@ -162,3 +162,86 @@ except Exception:
         exception("An error occurred")
     else:
         exception("An error occurred")
+
+# Test tuple exceptions
+try:
+    pass
+except (Exception,):
+    pass
+
+try:
+    pass
+except (Exception, ValueError):
+    pass
+
+try:
+    pass
+except (ValueError, Exception):
+    pass
+
+try:
+    pass
+except (ValueError, Exception) as e:
+    print(e)
+
+try:
+    pass
+except (BaseException, TypeError):
+    pass
+
+try:
+    pass
+except (TypeError, BaseException):
+    pass
+
+try:
+    pass
+except (Exception, BaseException):
+    pass
+
+try:
+    pass
+except (BaseException, Exception):
+    pass
+
+# Test nested tuples
+try:
+    pass
+except ((Exception, ValueError), TypeError):
+    pass
+
+try:
+    pass
+except (ValueError, (BaseException, TypeError)):
+    pass
+
+# Test valid tuple exceptions (should not trigger)
+try:
+    pass
+except (ValueError, TypeError):
+    pass
+
+try:
+    pass
+except (OSError, FileNotFoundError):
+    pass
+
+try:
+    pass
+except (OSError, FileNotFoundError) as e:
+    print(e)
+
+try:
+    pass
+except (Exception, ValueError):
+    critical("...", exc_info=True)
+
+try:
+    pass
+except (Exception, ValueError):
+    raise
+
+try:
+    pass
+except (Exception, ValueError) as e:
+    raise e

--- a/crates/ruff_linter/src/rules/flake8_blind_except/snapshots/ruff_linter__rules__flake8_blind_except__tests__BLE001_BLE.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_blind_except/snapshots/ruff_linter__rules__flake8_blind_except__tests__BLE001_BLE.py.snap
@@ -147,3 +147,93 @@ BLE.py:131:8: BLE001 Do not catch blind exception: `Exception`
     |        ^^^^^^^^^ BLE001
 132 |     critical("...", exc_info=None)
     |
+
+BLE.py:169:9: BLE001 Do not catch blind exception: `Exception`
+    |
+167 | try:
+168 |     pass
+169 | except (Exception,):
+    |         ^^^^^^^^^ BLE001
+170 |     pass
+    |
+
+BLE.py:174:9: BLE001 Do not catch blind exception: `Exception`
+    |
+172 | try:
+173 |     pass
+174 | except (Exception, ValueError):
+    |         ^^^^^^^^^ BLE001
+175 |     pass
+    |
+
+BLE.py:179:21: BLE001 Do not catch blind exception: `Exception`
+    |
+177 | try:
+178 |     pass
+179 | except (ValueError, Exception):
+    |                     ^^^^^^^^^ BLE001
+180 |     pass
+    |
+
+BLE.py:184:21: BLE001 Do not catch blind exception: `Exception`
+    |
+182 | try:
+183 |     pass
+184 | except (ValueError, Exception) as e:
+    |                     ^^^^^^^^^ BLE001
+185 |     print(e)
+    |
+
+BLE.py:189:9: BLE001 Do not catch blind exception: `BaseException`
+    |
+187 | try:
+188 |     pass
+189 | except (BaseException, TypeError):
+    |         ^^^^^^^^^^^^^ BLE001
+190 |     pass
+    |
+
+BLE.py:194:20: BLE001 Do not catch blind exception: `BaseException`
+    |
+192 | try:
+193 |     pass
+194 | except (TypeError, BaseException):
+    |                    ^^^^^^^^^^^^^ BLE001
+195 |     pass
+    |
+
+BLE.py:199:9: BLE001 Do not catch blind exception: `Exception`
+    |
+197 | try:
+198 |     pass
+199 | except (Exception, BaseException):
+    |         ^^^^^^^^^ BLE001
+200 |     pass
+    |
+
+BLE.py:204:9: BLE001 Do not catch blind exception: `BaseException`
+    |
+202 | try:
+203 |     pass
+204 | except (BaseException, Exception):
+    |         ^^^^^^^^^^^^^ BLE001
+205 |     pass
+    |
+
+BLE.py:210:10: BLE001 Do not catch blind exception: `Exception`
+    |
+208 | try:
+209 |     pass
+210 | except ((Exception, ValueError), TypeError):
+    |          ^^^^^^^^^ BLE001
+211 |     pass
+    |
+
+BLE.py:215:22: BLE001 Do not catch blind exception: `BaseException`
+    |
+213 | try:
+214 |     pass
+215 | except (ValueError, (BaseException, TypeError)):
+    |                      ^^^^^^^^^^^^^ BLE001
+216 |     pass
+    |


### PR DESCRIPTION
## Summary

This PR enhances the `BLE001` rule to correctly detect blind exception handling in tuple exceptions. Previously, the rule only checked single exception types, but Python allows catching multiple exceptions using tuples like `except (Exception, ValueError):`. 

## Test Plan

It fails the following (whereas the main branch does not):

```bash
cargo run -p ruff -- check somefile.py --no-cache --select=BLE001
```

```python
# somefile.py

try:
    1/0
except (ValueError, Exception) as e:
    print(e)
```

```
somefile.py:3:21: BLE001 Do not catch blind exception: `Exception`
  |
1 | try:
2 |     1/0
3 | except (ValueError, Exception) as e:
  |                     ^^^^^^^^^ BLE001
4 |     print(e)
  |

Found 1 error.
```