### PR TITLE
[ty] Remove false positives when subscripting `Generic` or `Protocol` with a `ParamSpec` or `TypeVarTuple`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
@@ -1052,8 +1052,7 @@ class FooLegacy(Generic[T]):
 class Bar[T, **P]:
     def __call__(self): ...
 
-# TODO: should not error
-class BarLegacy(Generic[T, P]):  # error: [invalid-argument-type] "`ParamSpec` is not a valid argument to `Generic`"
+class BarLegacy(Generic[T, P]):
     def __call__(self): ...
 
 static_assert(is_assignable_to(Foo, Callable[..., Any]))
@@ -1064,9 +1063,7 @@ static_assert(is_assignable_to(BarLegacy, Callable[..., Any]))
 class Spam[T]: ...
 class SpamLegacy(Generic[T]): ...
 class Eggs[T, **P]: ...
-
-# TODO: should not error
-class EggsLegacy(Generic[T, P]): ...  # error: [invalid-argument-type] "`ParamSpec` is not a valid argument to `Generic`"
+class EggsLegacy(Generic[T, P]): ...
 
 static_assert(not is_assignable_to(Spam, Callable[..., Any]))
 static_assert(not is_assignable_to(SpamLegacy, Callable[..., Any]))


### PR DESCRIPTION
## Summary

Diagnostics from `Generic[P]` and `Protocol[P]` are changing from one error code to another in https://github.com/astral-sh/ruff/pull/19669. That's distracting in the mypy_primer diff -- but these diagnostics are false positives anyway, and it's fairly easy to get rid of them. So this PR gets rid of them. This gets rid of a bunch of false positives on ecosystem code, and on the typing conformance test suite.

## Test Plan

Mdtests updated.
