### PR TITLE
:bug: Fix SIM109 to preserve expression order in boolean operations

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM109.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM109.py
@@ -14,6 +14,19 @@ if a == b or a == c or None:
 if a == b or None or a == c:
     d
 
+
+# SIM109
+if a or b == c or b == d:
+    e
+
+# SIM109
+if a or b == d or b == c:
+    e
+
+# OK
+if a or b == e or b == c or b == d or None:
+    f
+
 # OK
 if a in (b, c):
     d

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM109_SIM109.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM109_SIM109.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_simplify/mod.rs
-snapshot_kind: text
 ---
 SIM109.py:2:4: SIM109 [*] Use `a in (b, c)` instead of multiple equality comparisons
   |
@@ -74,4 +73,61 @@ SIM109.py:14:4: SIM109 [*] Use `a in (b, c)` instead of multiple equality compar
    14 |+if a in (b, c) or None:
 15 15 |     d
 16 16 | 
-17 17 | # OK
+17 17 | 
+
+SIM109.py:19:4: SIM109 [*] Use `b in (c, d)` instead of multiple equality comparisons
+   |
+18 | # SIM109
+19 | if a or b == c or b == d:
+   |    ^^^^^^^^^^^^^^^^^^^^^ SIM109
+20 |     e
+   |
+   = help: Replace with `b in (c, d)`
+
+ℹ Unsafe fix
+16 16 | 
+17 17 | 
+18 18 | # SIM109
+19    |-if a or b == c or b == d:
+   19 |+if a or b in (c, d):
+20 20 |     e
+21 21 | 
+22 22 | # SIM109
+
+SIM109.py:23:4: SIM109 [*] Use `b in (d, c)` instead of multiple equality comparisons
+   |
+22 | # SIM109
+23 | if a or b == d or b == c:
+   |    ^^^^^^^^^^^^^^^^^^^^^ SIM109
+24 |     e
+   |
+   = help: Replace with `b in (d, c)`
+
+ℹ Unsafe fix
+20 20 |     e
+21 21 | 
+22 22 | # SIM109
+23    |-if a or b == d or b == c:
+   23 |+if a or b in (d, c):
+24 24 |     e
+25 25 | 
+26 26 | # OK
+
+SIM109.py:27:4: SIM109 [*] Use `b in (e, c, d)` instead of multiple equality comparisons
+   |
+26 | # OK
+27 | if a or b == e or b == c or b == d or None:
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM109
+28 |     f
+   |
+   = help: Replace with `b in (e, c, d)`
+
+ℹ Unsafe fix
+24 24 |     e
+25 25 | 
+26 26 | # OK
+27    |-if a or b == e or b == c or b == d or None:
+   27 |+if a or b in (e, c, d) or None:
+28 28 |     f
+29 29 | 
+30 30 | # OK


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

### Problem
* The `compare_with_tuple` rule [(SIM109)](https://docs.astral.sh/ruff/rules/compare-with-tuple/#compare-with-tuple-sim109) was incorrectly reordering expressions when transforming multiple equality comparisons, which could change the semantic meaning due to Python's short-circuit evaluation. For example:
```python
# Before (incorrect transformation)
x or y == z or y == w  →  y in (z, w) or x  # Wrong order!

# After (correct transformation) 
x or y == z or y == w  →  x or y in (z, w)  # Preserves order
```

### Solution
* Fixed expression ordering: The replacement logic now preserves the original order by inserting the optimized expression at the position of the first matching equality comparison


### Changes
* Modified the replacement expression building logic in `compare_with_tuple()`
* Added order-preserving iteration that maintains the original boolean expression structure

## Test Plan

Enhanced snapshot tests by adding three more cases.
