### PR TITLE
[ty] Fix typing repository commit output in CI

### DIFF
--- a/.github/workflows/typing_conformance_comment.yaml
+++ b/.github/workflows/typing_conformance_comment.yaml
@@ -40,14 +40,6 @@ jobs:
           if_no_artifact_found: ignore
           allow_forks: true
 
-      - name: Parse conformance suite commit
-        id: conformance-suite-commit
-        run: |
-          if [[ -f conformance-suite-commit ]]
-          then
-            echo "value=$(<conformance-suite-commit)" >> "$GITHUB_OUTPUT"
-          fi
-
       - uses: dawidd6/action-download-artifact@20319c5641d495c8a52e688b7dc5fada6c3a9fbc # v8
         name: "Download typing_conformance results"
         id: download-typing_conformance_diff
@@ -77,7 +69,14 @@ jobs:
           # subsequent runs
           echo '<!-- generated-comment typing_conformance_diagnostics_diff -->' >> comment.txt
 
-          echo "## Diagnostic diff on [typing conformance tests](https://github.com/python/typing/tree/${{ steps.conformance-suite-commit.outputs.value }}/conformance)" >> comment.txt
+          if [[ -f conformance-suite-commit ]]
+          then
+            echo "## Diagnostic diff on [typing conformance tests](https://github.com/python/typing/tree/$(<conformance-suite-commit)/conformance)" >> comment.txt
+          else
+            echo "conformance-suite-commit file not found"
+            echo "## Diagnostic diff on typing conformance tests" >> comment.txt
+          fi
+
           if [ -s "pr/typing_conformance_diagnostics_diff/typing_conformance_diagnostics.diff" ]; then
             echo '<details>' >> comment.txt
             echo '<summary>Changes were detected when running ty on typing conformance tests</summary>' >> comment.txt


### PR DESCRIPTION
## Summary

This PR fixes the issue mentioned in https://github.com/astral-sh/ruff/pull/19736#issuecomment-3151903662 ~~but I can't test it without merging it on `main` because GitHub Actions still pickup the old version of the workflow file.~~ and is tested by manually triggering the workflow, refer to the comment on this PR (https://github.com/astral-sh/ruff/pull/19754#issuecomment-3153894179) which has the commit hash.