### PR TITLE
[ty] Fix attribute access on `TypedDict`s

### DIFF
--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -1233,28 +1233,28 @@ quux.<CURSOR>
         baz :: Unknown | Literal[3]
         foo :: Unknown | Literal[1]
         __annotations__ :: dict[str, Any]
-        __class__ :: type
-        __delattr__ :: bound method object.__delattr__(name: str, /) -> None
+        __class__ :: type[Quux]
+        __delattr__ :: bound method Quux.__delattr__(name: str, /) -> None
         __dict__ :: dict[str, Any]
-        __dir__ :: bound method object.__dir__() -> Iterable[str]
+        __dir__ :: bound method Quux.__dir__() -> Iterable[str]
         __doc__ :: str | None
-        __eq__ :: bound method object.__eq__(value: object, /) -> bool
-        __format__ :: bound method object.__format__(format_spec: str, /) -> str
-        __getattribute__ :: bound method object.__getattribute__(name: str, /) -> Any
-        __getstate__ :: bound method object.__getstate__() -> object
-        __hash__ :: bound method object.__hash__() -> int
+        __eq__ :: bound method Quux.__eq__(value: object, /) -> bool
+        __format__ :: bound method Quux.__format__(format_spec: str, /) -> str
+        __getattribute__ :: bound method Quux.__getattribute__(name: str, /) -> Any
+        __getstate__ :: bound method Quux.__getstate__() -> object
+        __hash__ :: bound method Quux.__hash__() -> int
         __init__ :: bound method Quux.__init__() -> Unknown
-        __init_subclass__ :: bound method object.__init_subclass__() -> None
+        __init_subclass__ :: bound method Quux.__init_subclass__() -> None
         __module__ :: str
-        __ne__ :: bound method object.__ne__(value: object, /) -> bool
-        __new__ :: bound method object.__new__() -> Self@object
-        __reduce__ :: bound method object.__reduce__() -> str | tuple[Any, ...]
-        __reduce_ex__ :: bound method object.__reduce_ex__(protocol: SupportsIndex, /) -> str | tuple[Any, ...]
-        __repr__ :: bound method object.__repr__() -> str
-        __setattr__ :: bound method object.__setattr__(name: str, value: Any, /) -> None
-        __sizeof__ :: bound method object.__sizeof__() -> int
-        __str__ :: bound method object.__str__() -> str
-        __subclasshook__ :: bound method type.__subclasshook__(subclass: type, /) -> bool
+        __ne__ :: bound method Quux.__ne__(value: object, /) -> bool
+        __new__ :: bound method Quux.__new__() -> Self@object
+        __reduce__ :: bound method Quux.__reduce__() -> str | tuple[Any, ...]
+        __reduce_ex__ :: bound method Quux.__reduce_ex__(protocol: SupportsIndex, /) -> str | tuple[Any, ...]
+        __repr__ :: bound method Quux.__repr__() -> str
+        __setattr__ :: bound method Quux.__setattr__(name: str, value: Any, /) -> None
+        __sizeof__ :: bound method Quux.__sizeof__() -> int
+        __str__ :: bound method Quux.__str__() -> str
+        __subclasshook__ :: bound method type[Quux].__subclasshook__(subclass: type, /) -> bool
         ");
     }
 
@@ -1278,28 +1278,28 @@ quux.b<CURSOR>
         baz :: Unknown | Literal[3]
         foo :: Unknown | Literal[1]
         __annotations__ :: dict[str, Any]
-        __class__ :: type
-        __delattr__ :: bound method object.__delattr__(name: str, /) -> None
+        __class__ :: type[Quux]
+        __delattr__ :: bound method Quux.__delattr__(name: str, /) -> None
         __dict__ :: dict[str, Any]
-        __dir__ :: bound method object.__dir__() -> Iterable[str]
+        __dir__ :: bound method Quux.__dir__() -> Iterable[str]
         __doc__ :: str | None
-        __eq__ :: bound method object.__eq__(value: object, /) -> bool
-        __format__ :: bound method object.__format__(format_spec: str, /) -> str
-        __getattribute__ :: bound method object.__getattribute__(name: str, /) -> Any
-        __getstate__ :: bound method object.__getstate__() -> object
-        __hash__ :: bound method object.__hash__() -> int
+        __eq__ :: bound method Quux.__eq__(value: object, /) -> bool
+        __format__ :: bound method Quux.__format__(format_spec: str, /) -> str
+        __getattribute__ :: bound method Quux.__getattribute__(name: str, /) -> Any
+        __getstate__ :: bound method Quux.__getstate__() -> object
+        __hash__ :: bound method Quux.__hash__() -> int
         __init__ :: bound method Quux.__init__() -> Unknown
-        __init_subclass__ :: bound method object.__init_subclass__() -> None
+        __init_subclass__ :: bound method Quux.__init_subclass__() -> None
         __module__ :: str
-        __ne__ :: bound method object.__ne__(value: object, /) -> bool
-        __new__ :: bound method object.__new__() -> Self@object
-        __reduce__ :: bound method object.__reduce__() -> str | tuple[Any, ...]
-        __reduce_ex__ :: bound method object.__reduce_ex__(protocol: SupportsIndex, /) -> str | tuple[Any, ...]
-        __repr__ :: bound method object.__repr__() -> str
-        __setattr__ :: bound method object.__setattr__(name: str, value: Any, /) -> None
-        __sizeof__ :: bound method object.__sizeof__() -> int
-        __str__ :: bound method object.__str__() -> str
-        __subclasshook__ :: bound method type.__subclasshook__(subclass: type, /) -> bool
+        __ne__ :: bound method Quux.__ne__(value: object, /) -> bool
+        __new__ :: bound method Quux.__new__() -> Self@object
+        __reduce__ :: bound method Quux.__reduce__() -> str | tuple[Any, ...]
+        __reduce_ex__ :: bound method Quux.__reduce_ex__(protocol: SupportsIndex, /) -> str | tuple[Any, ...]
+        __repr__ :: bound method Quux.__repr__() -> str
+        __setattr__ :: bound method Quux.__setattr__(name: str, value: Any, /) -> None
+        __sizeof__ :: bound method Quux.__sizeof__() -> int
+        __str__ :: bound method Quux.__str__() -> str
+        __subclasshook__ :: bound method type[Quux].__subclasshook__(subclass: type, /) -> bool
         ");
     }
 

--- a/crates/ty_python_semantic/resources/mdtest/ide_support/all_members.md
+++ b/crates/ty_python_semantic/resources/mdtest/ide_support/all_members.md
@@ -219,17 +219,26 @@ class Person(TypedDict):
     age: int | None
 
 static_assert(not has_member(Person, "name"))
-static_assert(not has_member(Person, "age"))
-
+static_assert(has_member(Person, "keys"))
 static_assert(has_member(Person, "__total__"))
-static_assert(has_member(Person, "__required_keys__"))
 
 def _(person: Person):
     static_assert(not has_member(person, "name"))
-    static_assert(not has_member(person, "age"))
-
+    static_assert(not has_member(person, "__total__"))
     static_assert(has_member(person, "keys"))
+
+    # type(person) is `dict` at runtime, so `__total__` is not available:
+    static_assert(not has_member(type(person), "name"))
+    static_assert(not has_member(type(person), "__total__"))
+    static_assert(has_member(type(person), "keys"))
+
+def _(t_person: type[Person]):
+    static_assert(not has_member(t_person, "name"))
+    static_assert(has_member(t_person, "__total__"))
+    static_assert(has_member(t_person, "keys"))
 ```
+
+### Unions
 
 For unions, `ide_support::all_members` only returns members that are available on all elements of
 the union.

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -1010,7 +1010,7 @@ impl<'db> Bindings<'db> {
 
                         Some(KnownClass::Type) if overload_index == 0 => {
                             if let [Some(arg)] = overload.parameter_types() {
-                                overload.set_return_type(arg.to_meta_type(db));
+                                overload.set_return_type(arg.dunder_class(db));
                             }
                         }
 

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -95,7 +95,7 @@ impl<'db> AllMembers<'db> {
 
             Type::NominalInstance(instance) => {
                 let (class_literal, _specialization) = instance.class.class_literal(db);
-                self.extend_with_instance_members(db, class_literal);
+                self.extend_with_instance_members(db, ty, class_literal);
             }
 
             Type::ClassLiteral(class_literal) if class_literal.is_typed_dict(db) => {
@@ -103,6 +103,10 @@ impl<'db> AllMembers<'db> {
             }
 
             Type::GenericAlias(generic_alias) if generic_alias.is_typed_dict(db) => {
+                self.extend_with_type(db, KnownClass::TypedDictFallback.to_class_literal(db));
+            }
+
+            Type::SubclassOf(subclass_of_type) if subclass_of_type.is_typed_dict(db) => {
                 self.extend_with_type(db, KnownClass::TypedDictFallback.to_class_literal(db));
             }
 
@@ -168,7 +172,11 @@ impl<'db> AllMembers<'db> {
                     self.extend_with_class_members(db, ty, class_literal);
                 }
 
-                self.extend_with_type(db, KnownClass::TypedDictFallback.to_instance(db));
+                if let Type::ClassLiteral(class) =
+                    KnownClass::TypedDictFallback.to_class_literal(db)
+                {
+                    self.extend_with_instance_members(db, ty, class);
+                }
             }
 
             Type::ModuleLiteral(literal) => {
@@ -281,13 +289,17 @@ impl<'db> AllMembers<'db> {
         }
     }
 
-    fn extend_with_instance_members(&mut self, db: &'db dyn Db, class_literal: ClassLiteral<'db>) {
+    fn extend_with_instance_members(
+        &mut self,
+        db: &'db dyn Db,
+        ty: Type<'db>,
+        class_literal: ClassLiteral<'db>,
+    ) {
         for parent in class_literal
             .iter_mro(db, None)
             .filter_map(ClassBase::into_class)
             .map(|class| class.class_literal(db).0)
         {
-            let parent_instance = Type::instance(db, parent.default_specialization(db));
             let class_body_scope = parent.body_scope(db);
             let file = class_body_scope.file(db);
             let index = semantic_index(db, file);
@@ -297,7 +309,7 @@ impl<'db> AllMembers<'db> {
                     let Some(name) = place_expr.as_instance_attribute() else {
                         continue;
                     };
-                    let result = parent_instance.member(db, name.as_str());
+                    let result = ty.member(db, name.as_str());
                     let Some(ty) = result.place.ignore_possibly_unbound() else {
                         continue;
                     };
@@ -314,7 +326,7 @@ impl<'db> AllMembers<'db> {
             // member, e.g., `SomeClass.__delattr__` is not a bound
             // method, but `instance_of_SomeClass.__delattr__` is.
             for Member { name, .. } in all_declarations_and_bindings(db, class_body_scope) {
-                let result = parent_instance.member(db, name.as_str());
+                let result = ty.member(db, name.as_str());
                 let Some(ty) = result.place.ignore_possibly_unbound() else {
                     continue;
                 };

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -196,6 +196,12 @@ impl<'db> SubclassOfType<'db> {
             SubclassOfInner::Dynamic(dynamic_type) => Type::Dynamic(dynamic_type),
         }
     }
+
+    pub(crate) fn is_typed_dict(self, db: &'db dyn Db) -> bool {
+        self.subclass_of
+            .into_class()
+            .is_some_and(|class| class.class_literal(db).0.is_typed_dict(db))
+    }
 }
 
 /// An enumeration of the different kinds of `type[]` types that a [`SubclassOfType`] can represent:


### PR DESCRIPTION
## Summary

This PR fixes a few inaccuracies in attribute access on `TypedDict`s. It also changes the return type of `type(person)` to `type[dict[str, object]]` if `person: Person` is an inhabitant of a `TypedDict`  `Person`. We still use `type[Person]` as the *meta type* of Person, however (see reasoning [here](https://github.com/astral-sh/ruff/pull/19733#discussion_r2253297926)).

## Test Plan

Updated Markdown tests.