### PR TITLE
[ty] Improve effectiveness of `KnownClass` fast paths in `instance.rs`

### DIFF
--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -125,15 +125,17 @@ impl<'db> NominalInstanceType<'db> {
     }
 
     pub(super) fn is_singleton(self, db: &'db dyn Db) -> bool {
-        self.class.known(db).is_some_and(KnownClass::is_singleton)
-            || is_single_member_enum(db, self.class.class_literal(db).0)
+        self.class
+            .known(db)
+            .map(KnownClass::is_singleton)
+            .unwrap_or_else(|| is_single_member_enum(db, self.class.class_literal(db).0))
     }
 
     pub(super) fn is_single_valued(self, db: &'db dyn Db) -> bool {
         self.class
             .known(db)
-            .is_some_and(KnownClass::is_single_valued)
-            || is_single_member_enum(db, self.class.class_literal(db).0)
+            .map(KnownClass::is_single_valued)
+            .unwrap_or_else(|| is_single_member_enum(db, self.class.class_literal(db).0))
     }
 
     pub(super) fn to_meta_type(self, db: &'db dyn Db) -> Type<'db> {


### PR DESCRIPTION
## Summary

This may not make much of a perf difference, but the intent of these fast paths is that if a class is a `KnownClass` then we already know if it's a singleton/single-valued. Currently for these methods, we're only taking the fast path if the class is a `KnownClass` _and_ the relevant `KnownClass` method returns `true` -- if the relevant `KnownClass` method returns `false`, we'll currently check the slow path as well even though it's unnecessary.

This PR fixes that so that we use the fast path even if the relevant methods on `KnownClass` return `false`. 

## Test Plan

Existing tests all pass.
