### PR TITLE
Use fixed hash width for `ty_server` diagnostics

### DIFF
--- a/crates/ty_server/src/server/api/diagnostics.rs
+++ b/crates/ty_server/src/server/api/diagnostics.rs
@@ -42,7 +42,7 @@ impl Diagnostics<'_> {
         // Hash the length first to ensure different numbers of diagnostics produce different hashes
         diagnostics.hash(&mut hasher);
 
-        Some(format!("{:x}", hasher.finish()))
+        Some(format!("{:016x}", hasher.finish()))
     }
 
     /// Computes the result ID for the diagnostics.


### PR DESCRIPTION
Summary
--

Fixes a snapshot test failure I saw in #19653 locally and in Windows CI by
padding the hex ID to 16 digits to match the regex in `filter_result_id`.

https://github.com/astral-sh/ruff/blob/78e5fe0a51fcbb1456d54c65b4632f60c268e389/crates/ty_server/tests/e2e/pull_diagnostics.rs#L380-L384

Test Plan
--

I applied this to the branch from #19653 locally and saw that the tests now
pass. I couldn't reproduce this failure directly on `main` or this branch,
though.
