### PR TITLE
[`pycodestyle`] Fix `E301` to only trigger for functions immediately within a class

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pycodestyle/E30.py
+++ b/crates/ruff_linter/resources/test/fixtures/pycodestyle/E30.py
@@ -974,3 +974,13 @@ BANANA = 100
 APPLE = 200
 
 # end
+
+
+# https://github.com/astral-sh/ruff/issues/19752
+class foo:
+    async def recv(self, *, length=65536):
+        loop = asyncio.get_event_loop()
+        def callback():
+            loop.remove_reader(self._fd)
+        loop.add_reader(self._fd, callback)
+# end

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/blank_lines.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/blank_lines.rs
@@ -836,7 +836,12 @@ impl<'a, 'b> BlankLinesChecker<'a, 'b> {
             // Allow groups of one-liners.
             && !(state.follows.is_any_def() && line.last_token != TokenKind::Colon)
             && !state.follows.follows_def_with_dummy_body()
-            && matches!(state.class_status, Status::Inside(_))
+            // Only apply to functions that are "immediately within" a class (not nested within other functions/blocks)
+            && if let Status::Inside(class_indent) = state.class_status {
+                line.indent_length == class_indent + self.context.settings().tab_size.as_usize()
+            } else {
+                false
+            }
             // The class/parent method's docstring can directly precede the def.
             // Allow following a decorator (if there is an error it will be triggered on the first decorator).
             && !matches!(state.follows, Follows::Docstring | Follows::Decorator)

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E306_E30.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E306_E30.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
-snapshot_kind: text
 ---
 E30.py:854:5: E306 [*] Expected 1 blank line before a nested definition, found 0
     |
@@ -220,3 +219,23 @@ E30.py:925:5: E306 [*] Expected 1 blank line before a nested definition, found 0
 925 926 |     async def b():
 926 927 |         pass
 927 928 | # end
+
+E30.py:983:9: E306 [*] Expected 1 blank line before a nested definition, found 0
+    |
+981 |     async def recv(self, *, length=65536):
+982 |         loop = asyncio.get_event_loop()
+983 |         def callback():
+    |         ^^^ E306
+984 |             loop.remove_reader(self._fd)
+985 |         loop.add_reader(self._fd, callback)
+    |
+    = help: Add missing blank line
+
+ℹ Safe fix
+980 980 | class foo:
+981 981 |     async def recv(self, *, length=65536):
+982 982 |         loop = asyncio.get_event_loop()
+    983 |+
+983 984 |         def callback():
+984 985 |             loop.remove_reader(self._fd)
+985 986 |         loop.add_reader(self._fd, callback)


### PR DESCRIPTION
## Summary

Fixes #19752
