### PR TITLE
[`pyupgrade`] Fix Unicode escape sequence handling in format string parsing

### DIFF
--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F521_F521.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F521_F521.py.snap
@@ -9,7 +9,7 @@ F521.py:1:1: F521 `.format` call has invalid format string: Single '{' encounter
 3 | "{foo[}".format(foo=1)
   |
 
-F521.py:2:1: F521 `.format` call has invalid format string: Single '}' encountered in format string
+F521.py:2:1: F521 `.format` call has invalid format string: Unexpected error parsing format string
   |
 1 | "{".format(1)
 2 | "}".format(1)

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP032_0.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP032_0.py.snap
@@ -944,6 +944,26 @@ UP032_0.py:129:1: UP032 [*] Use f-string instead of `format` call
 131 131 | ###
 132 132 | # Non-errors
 
+UP032_0.py:136:1: UP032 [*] Use f-string instead of `format` call
+    |
+135 | # False-negative: RustPython doesn't parse the `\N{snowman}`.
+136 | "\N{snowman} {}".format(a)
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ UP032
+137 |
+138 | "{".format(a)
+    |
+    = help: Convert to f-string
+
+ℹ Safe fix
+133 133 | ###
+134 134 | 
+135 135 | # False-negative: RustPython doesn't parse the `\N{snowman}`.
+136     |-"\N{snowman} {}".format(a)
+    136 |+f"\N{snowman} {a}"
+137 137 | 
+138 138 | "{".format(a)
+139 139 | 
+
 UP032_0.py:160:1: UP032 [*] Use f-string instead of `format` call
     |
 158 |   r'"\N{snowman} {}".format(a)'

--- a/crates/ruff_python_literal/src/format.rs
+++ b/crates/ruff_python_literal/src/format.rs
@@ -598,14 +598,9 @@ impl FormatString {
                 result_string.push_str("\\N");
                 let rest = &cur_text[2..];
                 let mut chars = rest.chars();
-                if let Some('{') = chars.next() {
-                    result_string.push('{');
-                } else {
-                    result_string.truncate(result_string.len() - 2);
-                    result_string.push_str(cur_text);
-                    cur_text = "";
-                    continue;
-                }
+                let next = chars.next();
+                debug_assert!(next == Some('{'));
+                result_string.push('{');
 
                 loop {
                     match chars.next() {
@@ -622,7 +617,6 @@ impl FormatString {
                             result_string.push(ch);
                         }
                         None => {
-                            result_string.push_str(chars.as_str());
                             cur_text = "";
                             break;
                         }


### PR DESCRIPTION
## Summary

Fixes #19771
