### PR TITLE
[ty] Improve subscript narrowing for "safe mutable classes"

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/narrow/assignment.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/assignment.md
@@ -213,23 +213,20 @@ reveal_type(l[0])  # revealed: Literal[0]
 reveal_type(d[0])  # revealed: Literal[0]
 reveal_type(b[0])  # revealed: Literal[0]
 reveal_type(dd[0])  # revealed: Literal[0]
-# TODO: should be Literal[0]
-reveal_type(cm[0])  # revealed: Unknown
+reveal_type(cm[0])  # revealed: Literal[0]
 
 class C:
     reveal_type(l[0])  # revealed: Literal[0]
     reveal_type(d[0])  # revealed: Literal[0]
     reveal_type(b[0])  # revealed: Literal[0]
     reveal_type(dd[0])  # revealed: Literal[0]
-    # TODO: should be Literal[0]
-    reveal_type(cm[0])  # revealed: Unknown
+    reveal_type(cm[0])  # revealed: Literal[0]
 
 [reveal_type(l[0]) for _ in range(1)]  # revealed: Literal[0]
 [reveal_type(d[0]) for _ in range(1)]  # revealed: Literal[0]
 [reveal_type(b[0]) for _ in range(1)]  # revealed: Literal[0]
 [reveal_type(dd[0]) for _ in range(1)]  # revealed: Literal[0]
-# TODO: should be Literal[0]
-[reveal_type(cm[0]) for _ in range(1)]  # revealed: Unknown
+[reveal_type(cm[0]) for _ in range(1)]  # revealed: Literal[0]
 
 def _():
     reveal_type(l[0])  # revealed: int | None


### PR DESCRIPTION
## Summary

This PR improves the `is_safe_mutable_class` function in `infer.rs` in several ways:
- It uses `KnownClass::to_instance()` for all "safe mutable classes". Previously, we were using `SpecialFormType::instance_fallback()` for some variants -- I'm not totally sure why. Switching to `KnownClass::to_instance()` for all "safe mutable classes" fixes a number of TODOs in the `assignment.md` mdtest suite
- Rather than eagerly calling `.to_instance(db)` on all "safe mutable classes" every time `is_safe_mutable_class` is called, we now only call it lazily on each element, allowing us to short-circuit more effectively.
- I removed the entry entirely for `TypedDict` from the list of "safe mutable classes", as it's not correct. `SpecialFormType::TypedDict.instance_fallback(db)` just returns an instance type representing "any instance of `typing._SpecialForm`", which I don't think was the intent of this code. No tests fail as a result of removing this entry, as we already check separately whether an object is an inhabitant of a `TypedDict` type (and consider that object safe-mutable if so!).

## Test Plan

mdtests updated
