### PR TITLE
[`pyflakes`/`pylint`] Skip `__class__` checks in method definitions (…

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyflakes/F841_0.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyflakes/F841_0.py
@@ -151,3 +151,26 @@ def f():
         pass
     except Exception as _:
         pass
+
+# OK
+class A:
+    def set_class(self, cls):
+        __class__ = cls
+
+# OK
+class A:
+    class B:
+        def set_class(self, cls):
+            __class__ = cls
+# OK
+class A:
+    __class__ = 1
+
+
+# OK
+class A:
+    def foo():
+        class B:
+            print(__class__)
+            def set_class(self, cls):
+                __class__ = cls

--- a/crates/ruff_linter/resources/test/fixtures/pylint/nonlocal_without_binding.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/nonlocal_without_binding.py
@@ -44,3 +44,8 @@ def f():
     def g():
         nonlocal x
         x = 2
+
+# OK
+class A:
+    def method(self):
+        nonlocal __class__

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__f841_dummy_variable_rgx.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__f841_dummy_variable_rgx.snap
@@ -273,3 +273,5 @@ F841_0.py:152:25: F841 [*] Local variable `_` is assigned to but never used
 152     |-    except Exception as _:
     152 |+    except Exception:
 153 153 |         pass
+154 154 | 
+155 155 | # OK


### PR DESCRIPTION
## Summary

### Problem
Rules [F841](https://docs.astral.sh/ruff/rules/unused-variable/) (`unused-variable`) and [PLE0117](https://docs.astral.sh/ruff/rules/nonlocal-without-binding/) (`nonlocal-without-binding`) incorrectly flagged usage within method definitions, causing false positives.
Root Cause: Both rules failed to recognize that it is a special variable automatically available in Python method definitions. In methods, it is implicitly bound by the Python runtime, making assignments to it legitimate and declarations valid. `__class__``__class__``nonlocal __class__`

### Solution
- Added special handling for when detected within method definitions: `__class__`
- **F841**: Skip unused variable warnings for assignments in methods `__class__`
- **PLE0117**: Allow statements in methods without requiring explicit outer bindings `nonlocal __class__`

```python
class C:
    def set_class(self, cls):
        __class__ = cls  # No longer warns about unused variable
        
    def get_class(self):
        nonlocal __class__  # No longer warns about missing binding
        return __class__
```


## Test Plan

```bash
cargo test
```
