### PR TITLE
[ty] Avoid warning for old settings schema too aggresively

### DIFF
--- a/crates/ty_server/src/server.rs
+++ b/crates/ty_server/src/server.rs
@@ -118,7 +118,7 @@ impl Server {
                     Refer to the logs for more details",
                     unknown_options
                         .keys()
-                        .map(|key| key.as_str())
+                        .map(String::as_str)
                         .collect::<Vec<_>>()
                         .join("', '")
                 ));

--- a/crates/ty_server/src/server.rs
+++ b/crates/ty_server/src/server.rs
@@ -98,13 +98,31 @@ impl Server {
         let (main_loop_sender, main_loop_receiver) = crossbeam::channel::bounded(32);
         let client = Client::new(main_loop_sender.clone(), connection.sender.clone());
 
-        if !initialization_options.options.unknown.is_empty() {
-            let options = serde_json::to_string_pretty(&initialization_options.options.unknown)
-                .unwrap_or_else(|_| "<invalid JSON>".to_string());
-            tracing::warn!("Received unknown options during initialization: {options}");
-            client.show_warning_message(format_args!(
-                "Received unknown options during initialization: {options}"
-            ));
+        let unknown_options = &initialization_options.options.unknown;
+        if !unknown_options.is_empty() {
+            // HACK: Old versions of the ty VS Code extension used a custom schema for settings
+            // which was changed in version 2025.35.0. This is to ensure that users don't receive
+            // unnecessary warnings when using an older version of the extension. This should be
+            // removed after a few releases.
+            if !unknown_options.contains_key("settings")
+                || !unknown_options.contains_key("globalSettings")
+            {
+                tracing::warn!(
+                    "Received unknown options during initialization: {}",
+                    serde_json::to_string_pretty(unknown_options)
+                        .unwrap_or_else(|_| format!("{unknown_options:?}"))
+                );
+
+                client.show_warning_message(format_args!(
+                    "Received unknown options during initialization: '{}'. \
+                    Refer to the logs for more details",
+                    unknown_options
+                        .keys()
+                        .map(|key| key.as_str())
+                        .collect::<Vec<_>>()
+                        .join("', '")
+                ));
+            }
         }
 
         // Get workspace URLs without settings - settings will come from workspace/configuration

--- a/crates/ty_server/src/session.rs
+++ b/crates/ty_server/src/session.rs
@@ -477,7 +477,7 @@ impl Session {
                         Refer to the logs for more details.",
                         unknown_options
                             .keys()
-                            .map(|key| key.to_string())
+                            .map(String::as_str)
                             .collect::<Vec<_>>()
                             .join("', '")
                     ));

--- a/crates/ty_server/src/session.rs
+++ b/crates/ty_server/src/session.rs
@@ -458,13 +458,30 @@ impl Session {
                 .clone()
                 .combine(options.clone());
 
-            if !options.unknown.is_empty() {
-                let options = serde_json::to_string_pretty(&options.unknown)
-                    .unwrap_or_else(|_| "<invalid JSON>".to_string());
-                tracing::warn!("Received unknown options for workspace `{url}`: {options}");
-                client.show_warning_message(format!(
-                    "Received unknown options for workspace `{url}`: {options}",
-                ));
+            let unknown_options = &options.unknown;
+            if !unknown_options.is_empty() {
+                // HACK: This is to ensure that users with an older version of the ty VS Code
+                // extension don't get warnings about unknown options when they are using a newer
+                // version of the language server. This should be removed after a few releases.
+                if !unknown_options.contains_key("importStrategy")
+                    && !unknown_options.contains_key("interpreter")
+                {
+                    tracing::warn!(
+                        "Received unknown options for workspace `{url}`: {}",
+                        serde_json::to_string_pretty(unknown_options)
+                            .unwrap_or_else(|_| format!("{unknown_options:?}"))
+                    );
+
+                    client.show_warning_message(format!(
+                        "Received unknown options for workspace `{url}`: '{}'. \
+                        Refer to the logs for more details.",
+                        unknown_options
+                            .keys()
+                            .map(|key| key.to_string())
+                            .collect::<Vec<_>>()
+                            .join("', '")
+                    ));
+                }
             }
 
             combined_global_options.combine_with(Some(global));

--- a/crates/ty_server/tests/e2e/initialize.rs
+++ b/crates/ty_server/tests/e2e/initialize.rs
@@ -392,13 +392,7 @@ fn unknown_initialization_options() -> Result<()> {
     let mut server = TestServerBuilder::new()?
         .with_workspace(workspace_root, None)?
         .with_initialization_options(
-            ClientOptions::default().with_unknown(
-                [
-                    ("foo".to_string(), Value::Null),
-                    ("bar".to_string(), Value::Null),
-                ]
-                .into(),
-            ),
+            ClientOptions::default().with_unknown([("bar".to_string(), Value::Null)].into()),
         )
         .build()?
         .wait_until_workspaces_are_initialized()?;
@@ -408,7 +402,7 @@ fn unknown_initialization_options() -> Result<()> {
     insta::assert_json_snapshot!(show_message_params, @r#"
     {
       "type": 2,
-      "message": "Received unknown options during initialization: 'bar', 'foo'. Refer to the logs for more details"
+      "message": "Received unknown options during initialization: 'bar'. Refer to the logs for more details"
     }
     "#);
 
@@ -423,15 +417,7 @@ fn unknown_options_in_workspace_configuration() -> Result<()> {
     let mut server = TestServerBuilder::new()?
         .with_workspace(
             workspace_root,
-            Some(
-                ClientOptions::default().with_unknown(
-                    [
-                        ("foo".to_string(), Value::Null),
-                        ("bar".to_string(), Value::Null),
-                    ]
-                    .into(),
-                ),
-            ),
+            Some(ClientOptions::default().with_unknown([("bar".to_string(), Value::Null)].into())),
         )?
         .build()?
         .wait_until_workspaces_are_initialized()?;
@@ -441,7 +427,7 @@ fn unknown_options_in_workspace_configuration() -> Result<()> {
     insta::assert_json_snapshot!(show_message_params, @r#"
     {
       "type": 2,
-      "message": "Received unknown options for workspace `file://<temp_dir>/foo`: 'bar', 'foo'. Refer to the logs for more details."
+      "message": "Received unknown options for workspace `file://<temp_dir>/foo`: 'bar'. Refer to the logs for more details."
     }
     "#);
 

--- a/crates/ty_server/tests/e2e/initialize.rs
+++ b/crates/ty_server/tests/e2e/initialize.rs
@@ -392,8 +392,13 @@ fn unknown_initialization_options() -> Result<()> {
     let mut server = TestServerBuilder::new()?
         .with_workspace(workspace_root, None)?
         .with_initialization_options(
-            ClientOptions::default()
-                .with_unknown([("foo".to_string(), Value::String("bar".to_string()))].into()),
+            ClientOptions::default().with_unknown(
+                [
+                    ("foo".to_string(), Value::Null),
+                    ("bar".to_string(), Value::Null),
+                ]
+                .into(),
+            ),
         )
         .build()?
         .wait_until_workspaces_are_initialized()?;
@@ -403,7 +408,7 @@ fn unknown_initialization_options() -> Result<()> {
     insta::assert_json_snapshot!(show_message_params, @r#"
     {
       "type": 2,
-      "message": "Received unknown options during initialization: {\n  /"foo/": /"bar/"\n}"
+      "message": "Received unknown options during initialization: 'bar', 'foo'. Refer to the logs for more details"
     }
     "#);
 
@@ -419,8 +424,13 @@ fn unknown_options_in_workspace_configuration() -> Result<()> {
         .with_workspace(
             workspace_root,
             Some(
-                ClientOptions::default()
-                    .with_unknown([("foo".to_string(), Value::String("bar".to_string()))].into()),
+                ClientOptions::default().with_unknown(
+                    [
+                        ("foo".to_string(), Value::Null),
+                        ("bar".to_string(), Value::Null),
+                    ]
+                    .into(),
+                ),
             ),
         )?
         .build()?
@@ -431,7 +441,7 @@ fn unknown_options_in_workspace_configuration() -> Result<()> {
     insta::assert_json_snapshot!(show_message_params, @r#"
     {
       "type": 2,
-      "message": "Received unknown options for workspace `file://<temp_dir>/foo`: {\n  /"foo/": /"bar/"\n}"
+      "message": "Received unknown options for workspace `file://<temp_dir>/foo`: 'bar', 'foo'. Refer to the logs for more details."
     }
     "#);
 


### PR DESCRIPTION
## Summary

This PR avoids warning the users too aggressively by checking the structure of the initialization and workspace options and avoids the warning if they conform to the old schema.

## Test Plan


https://github.com/user-attachments/assets/9ade9dc4-90cb-4fd4-abd0-4bc4177df3db


