### PR TITLE
[ty] Implement module-level `__getattr__` support

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/import/module_getattr.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/module_getattr.md
@@ -36,3 +36,49 @@ explicit_attr = "explicit"
 def __getattr__(name: str) -> str:
     return "dynamic"
 ```
+
+## Precedence: submodules vs `__getattr__` - Case 1
+
+```py
+# if `mod/__init__.py` has a `__getattr__`, and there also exists a `mod/sub.py`
+# if we have `import mod;` `reveal_type(mod.sub)` returns the type of `__getattr__`.
+import mod
+
+reveal_type(mod.sub)  # revealed: str
+```
+
+`mod/__init__.py`:
+
+```py
+def __getattr__(name: str) -> str:
+    return "from_getattr"
+```
+
+`mod/sub.py`:
+
+```py
+value = 42
+```
+
+## Precedence: submodules vs `__getattr__` - Case 2
+
+```py
+# if `mod/__init__.py` has a `__getattr__`, and there also exists a `mod/sub.py`
+# if we have `import mod.sub;` `reveal_type(mod.sub)` returns the type of the submodule.
+import mod.sub
+
+reveal_type(mod.sub)  # revealed: <module 'mod.sub'>
+```
+
+`mod/__init__.py`:
+
+```py
+def __getattr__(name: str) -> str:
+    return "from_getattr"
+```
+
+`mod/sub.py`:
+
+```py
+value = 42
+```

--- a/crates/ty_python_semantic/resources/mdtest/import/module_getattr.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/module_getattr.md
@@ -37,48 +37,41 @@ def __getattr__(name: str) -> str:
     return "dynamic"
 ```
 
-## Precedence: submodules vs `__getattr__` - Case 1
+## Precedence: submodules vs `__getattr__`
+
+If a package's `__init__.py` (e.g. `mod/__init__.py`) defines a `__getattr__` function, and there is
+also a submodule file present (e.g. `mod/sub.py`), then:
+
+- If you do `import mod` (without importing the submodule directly), accessing `mod.sub` will call
+    `mod.__getattr__('sub')`, so `reveal_type(mod.sub)` will show the return type of `__getattr__`.
+- If you do `import mod.sub` (importing the submodule directly), then `mod.sub` refers to the actual
+    submodule, so `reveal_type(mod.sub)` will show the type of the submodule itself.
+
+`mod/__init__.py`:
 
 ```py
-# if `mod/__init__.py` has a `__getattr__`, and there also exists a `mod/sub.py`
-# if we have `import mod;` `reveal_type(mod.sub)` returns the type of `__getattr__`.
+def __getattr__(name: str) -> str:
+    return "from_getattr"
+```
+
+`mod/sub.py`:
+
+```py
+value = 42
+```
+
+`test_import_mod.py`:
+
+```py
 import mod
 
 reveal_type(mod.sub)  # revealed: str
 ```
 
-`mod/__init__.py`:
+`test_import_mod_sub.py`:
 
 ```py
-def __getattr__(name: str) -> str:
-    return "from_getattr"
-```
-
-`mod/sub.py`:
-
-```py
-value = 42
-```
-
-## Precedence: submodules vs `__getattr__` - Case 2
-
-```py
-# if `mod/__init__.py` has a `__getattr__`, and there also exists a `mod/sub.py`
-# if we have `import mod.sub;` `reveal_type(mod.sub)` returns the type of the submodule.
 import mod.sub
 
 reveal_type(mod.sub)  # revealed: <module 'mod.sub'>
-```
-
-`mod/__init__.py`:
-
-```py
-def __getattr__(name: str) -> str:
-    return "from_getattr"
-```
-
-`mod/sub.py`:
-
-```py
-value = 42
 ```

--- a/crates/ty_python_semantic/resources/mdtest/import/module_getattr.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/module_getattr.md
@@ -16,6 +16,24 @@ def __getattr__(name: str) -> str:
     return "hi"
 ```
 
+## `from import` with `__getattr__`
+
+At runtime, if `module` has a `__getattr__` implementation, you can do `from module import whatever`
+and it will exercise the `__getattr__` when `whatever` is not found as a normal attribute.
+
+```py
+from module_with_getattr import nonexistent_attr
+
+reveal_type(nonexistent_attr)  # revealed: int
+```
+
+`module_with_getattr.py`:
+
+```py
+def __getattr__(name: str) -> int:
+    return 42
+```
+
 ## Precedence: explicit attributes take priority over `__getattr__`
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/import/module_getattr.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/module_getattr.md
@@ -5,7 +5,7 @@
 ```py
 import module_with_getattr
 
-# Should work: module `__getattr__` returns 'hi'
+# Should work: module `__getattr__` returns `str`
 reveal_type(module_with_getattr.whatever)  # revealed: str
 ```
 
@@ -13,26 +13,7 @@ reveal_type(module_with_getattr.whatever)  # revealed: str
 
 ```py
 def __getattr__(name: str) -> str:
-    if name == "whatever":
-        return "hi"
-    raise AttributeError(f"module has no attribute '{name}'")
-```
-
-## Type annotations on `__getattr__` return type
-
-```py
-import typed_getattr_module
-
-reveal_type(typed_getattr_module.dynamic_int)  # revealed: int
-```
-
-`typed_getattr_module.py`:
-
-```py
-def __getattr__(name: str) -> int:
-    if name == "dynamic_int":
-        return 42
-    raise AttributeError(f"module has no attribute '{name}'")
+    return "hi"
 ```
 
 ## Precedence: explicit attributes take priority over `__getattr__`
@@ -53,27 +34,5 @@ reveal_type(mixed_module.dynamic_attr)  # revealed: str
 explicit_attr = "explicit"
 
 def __getattr__(name: str) -> str:
-    if name == "dynamic_attr":
-        return "dynamic"
-    raise AttributeError(f"module has no attribute '{name}'")
-```
-
-## `__getattr__` should not be called for existing attributes
-
-```py
-import module_no_fallback
-
-# This should not trigger `__getattr__` since the attribute exists
-reveal_type(module_no_fallback.real_function)  # revealed: def real_function() -> str
-```
-
-`module_no_fallback.py`:
-
-```py
-def real_function() -> str:
-    return "real"
-
-def __getattr__(name: str) -> str:
-    # This should never be called for real_function
-    return "fallback"
+    return "dynamic"
 ```

--- a/crates/ty_python_semantic/resources/mdtest/import/module_getattr.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/module_getattr.md
@@ -1,0 +1,79 @@
+# Module-level `__getattr__`
+
+## Basic functionality
+
+```py
+import module_with_getattr
+
+# Should work: module `__getattr__` returns 'hi'
+reveal_type(module_with_getattr.whatever)  # revealed: str
+```
+
+`module_with_getattr.py`:
+
+```py
+def __getattr__(name: str) -> str:
+    if name == "whatever":
+        return "hi"
+    raise AttributeError(f"module has no attribute '{name}'")
+```
+
+## Type annotations on `__getattr__` return type
+
+```py
+import typed_getattr_module
+
+reveal_type(typed_getattr_module.dynamic_int)  # revealed: int
+```
+
+`typed_getattr_module.py`:
+
+```py
+def __getattr__(name: str) -> int:
+    if name == "dynamic_int":
+        return 42
+    raise AttributeError(f"module has no attribute '{name}'")
+```
+
+## Precedence: explicit attributes take priority over `__getattr__`
+
+```py
+import mixed_module
+
+# Explicit attribute should take precedence
+reveal_type(mixed_module.explicit_attr)  # revealed: Unknown | Literal["explicit"]
+
+# `__getattr__` should handle unknown attributes
+reveal_type(mixed_module.dynamic_attr)  # revealed: str
+```
+
+`mixed_module.py`:
+
+```py
+explicit_attr = "explicit"
+
+def __getattr__(name: str) -> str:
+    if name == "dynamic_attr":
+        return "dynamic"
+    raise AttributeError(f"module has no attribute '{name}'")
+```
+
+## `__getattr__` should not be called for existing attributes
+
+```py
+import module_no_fallback
+
+# This should not trigger `__getattr__` since the attribute exists
+reveal_type(module_no_fallback.real_function)  # revealed: def real_function() -> str
+```
+
+`module_no_fallback.py`:
+
+```py
+def real_function() -> str:
+    return "real"
+
+def __getattr__(name: str) -> str:
+    # This should never be called for real_function
+    return "fallback"
+```

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -8295,17 +8295,17 @@ impl<'db> ModuleLiteralType<'db> {
     }
 
     fn try_module_getattr(self, db: &'db dyn Db, name: &str) -> PlaceAndQualifiers<'db> {
-        // For module literals, we want to try calling the module's own __getattr__ function
-        // if it exists. First, we need to look up the __getattr__ function in the module's scope.
+        // For module literals, we want to try calling the module's own `__getattr__` function
+        // if it exists. First, we need to look up the `__getattr__` function in the module's scope.
         if let Some(file) = self.module(db).file(db) {
             let getattr_symbol = imported_symbol(db, file, "__getattr__", None);
-            if let Place::Type(getattr_type, _) = getattr_symbol.place {
+            if let Place::Type(getattr_type, boundness) = getattr_symbol.place {
                 // If we found a __getattr__ function, try to call it with the name argument
                 if let Ok(outcome) = getattr_type.try_call(
                     db,
                     &CallArguments::positional([Type::string_literal(db, name)]),
                 ) {
-                    return Place::bound(outcome.return_type(db)).into();
+                    return Place::Type(outcome.return_type(db), boundness).into();
                 }
             }
         }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3282,32 +3282,7 @@ impl<'db> Type<'db> {
                     policy,
                 );
 
-                let custom_getattr_result = || {
-                    // Typeshed has a fake `__getattr__` on `types.ModuleType` to help out with
-                    // dynamic imports. We explicitly hide it here to prevent arbitrary attributes
-                    // from being available on modules. Same for `types.GenericAlias` - its
-                    // `__getattr__` method will delegate to `__origin__` to allow looking up
-                    // attributes on the original type. But in typeshed its return type is `Any`.
-                    // It will need a special handling, so it remember the origin type to properly
-                    // resolve the attribute.
-                    if matches!(
-                        self.into_nominal_instance()
-                            .and_then(|instance| instance.class.known(db)),
-                        Some(KnownClass::ModuleType | KnownClass::GenericAlias)
-                    ) {
-                        return Place::Unbound.into();
-                    }
-
-                    self.try_call_dunder(
-                        db,
-                        "__getattr__",
-                        CallArguments::positional([Type::string_literal(db, &name)]),
-                    )
-                    .map(|outcome| Place::bound(outcome.return_type(db)))
-                    // TODO: Handle call errors here.
-                    .unwrap_or(Place::Unbound)
-                    .into()
-                };
+                let custom_getattr_result = || self.try_custom_getattr(db, &name, false);
 
                 let custom_getattribute_result = || {
                     // Avoid cycles when looking up `__getattribute__`
@@ -4682,6 +4657,47 @@ impl<'db> Type<'db> {
             }
             Place::Unbound => Err(CallDunderError::MethodNotAvailable),
         }
+    }
+
+    /// Try to call `__getattr__` on the given type, respecting restrictions for fake typeshed methods.
+    ///
+    /// This helper function encapsulates the logic for calling `__getattr__` while preventing
+    /// the fake `__getattr__` methods on `types.ModuleType` and `types.GenericAlias` from being used.
+    fn try_custom_getattr(
+        self,
+        db: &'db dyn Db,
+        name: &str,
+        allow_module_type_getattr: bool,
+    ) -> PlaceAndQualifiers<'db> {
+        // Typeshed has a fake `__getattr__` on `types.ModuleType` to help out with
+        // dynamic imports. We explicitly hide it here to prevent arbitrary attributes
+        // from being available on modules. Same for `types.GenericAlias` - its
+        // `__getattr__` method will delegate to `__origin__` to allow looking up
+        // attributes on the original type. But in typeshed its return type is `Any`.
+        // It will need a special handling, so it remember the origin type to properly
+        // resolve the attribute.
+        //
+        // However, for ModuleLiteral types with real module-level __getattr__, we should
+        // allow it to be called.
+        if !allow_module_type_getattr
+            && matches!(
+                self.into_nominal_instance()
+                    .and_then(|instance| instance.class.known(db)),
+                Some(KnownClass::ModuleType | KnownClass::GenericAlias)
+            )
+        {
+            return Place::Unbound.into();
+        }
+
+        self.try_call_dunder(
+            db,
+            "__getattr__",
+            CallArguments::positional([Type::string_literal(db, name)]),
+        )
+        .map(|outcome| Place::bound(outcome.return_type(db)))
+        // TODO: Handle call errors here.
+        .unwrap_or(Place::Unbound)
+        .into()
     }
 
     /// Returns a tuple spec describing the elements that are produced when iterating over `self`.

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -8310,6 +8310,25 @@ impl<'db> ModuleLiteralType<'db> {
         Some(Type::module_literal(db, importing_file, submodule))
     }
 
+    fn try_module_getattr(self, db: &'db dyn Db, name: &str) -> PlaceAndQualifiers<'db> {
+        // For module literals, we want to try calling the module's own __getattr__ function
+        // if it exists. First, we need to look up the __getattr__ function in the module's scope.
+        if let Some(file) = self.module(db).file(db) {
+            let getattr_symbol = imported_symbol(db, file, "__getattr__", None);
+            if let Place::Type(getattr_type, _) = getattr_symbol.place {
+                // If we found a __getattr__ function, try to call it with the name argument
+                if let Ok(outcome) = getattr_type.try_call(
+                    db,
+                    &CallArguments::positional([Type::string_literal(db, name)]),
+                ) {
+                    return Place::bound(outcome.return_type(db)).into();
+                }
+            }
+        }
+
+        Place::Unbound.into()
+    }
+
     fn static_member(self, db: &'db dyn Db, name: &str) -> PlaceAndQualifiers<'db> {
         // `__dict__` is a very special member that is never overridden by module globals;
         // we should always look it up directly as an attribute on `types.ModuleType`,
@@ -8335,10 +8354,21 @@ impl<'db> ModuleLiteralType<'db> {
             }
         }
 
-        self.module(db)
+        let result = self
+            .module(db)
             .file(db)
             .map(|file| imported_symbol(db, file, name, None))
-            .unwrap_or_default()
+            .unwrap_or_default();
+
+        // If the normal lookup failed, try to call the module's __getattr__ function
+        if result.place.is_unbound() {
+            let getattr_result = self.try_module_getattr(db, name);
+            if !getattr_result.place.is_unbound() {
+                return getattr_result;
+            }
+        }
+
+        result
     }
 }
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -8338,21 +8338,18 @@ impl<'db> ModuleLiteralType<'db> {
             }
         }
 
-        let result = self
+        let place_and_qualifiers = self
             .module(db)
             .file(db)
             .map(|file| imported_symbol(db, file, name, None))
             .unwrap_or_default();
 
-        // If the normal lookup failed, try to call the module's __getattr__ function
-        if result.place.is_unbound() {
-            let getattr_result = self.try_module_getattr(db, name);
-            if !getattr_result.place.is_unbound() {
-                return getattr_result;
-            }
+        // If the normal lookup failed, try to call the module's `__getattr__` function
+        if place_and_qualifiers.place.is_unbound() {
+            return self.try_module_getattr(db, name);
         }
 
-        result
+        place_and_qualifiers
     }
 }
 


### PR DESCRIPTION
fix https://github.com/astral-sh/ty/issues/943

## Summary

Add module-level `__getattr__` support for ty's type checker, fixing issue https://github.com/astral-sh/ty/issues/943. 
Module-level `__getattr__` functions ([PEP 562](https://peps.python.org/pep-0562/)) are now respected when resolving dynamic attributes, matching the behavior of mypy and pyright.

## Implementation

Thanks @sharkdp for the guidance in https://github.com/astral-sh/ty/issues/943#issuecomment-3157566579
  - Extracts existing `__getattr__` logic into a reusable helper function
  - Adds module-specific `__getattr__` resolution in `ModuleLiteral.static_member()`
  - Maintains proper attribute precedence: explicit attributes > submodules > `__getattr__`
  - Preserves restrictions on fake typeshed `__getattr__` methods

## Test Plan
  - New mdtest covering basic functionality, type annotations, attribute precedence, and edge cases
  (run ```cargo nextest run -p ty_python_semantic mdtest__import_module_getattr```)
  - All new tests pass, verifying `__getattr__` is called correctly and returns proper types
  - Existing test suite passes, ensuring no regressions introduced
