### PR TITLE
Remove `FunctionType.into_bound_method_type`

### DIFF
--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1191,14 +1191,14 @@ impl<'db> Type<'db> {
                 }
             }
             Type::ClassLiteral(class_literal) => {
-                Some(ClassType::NonGeneric(class_literal).into_callable(db))
+                ClassType::NonGeneric(class_literal).into_callable(db)
             }
 
-            Type::GenericAlias(alias) => Some(ClassType::Generic(alias).into_callable(db)),
+            Type::GenericAlias(alias) => ClassType::Generic(alias).into_callable(db),
 
             // TODO: This is unsound so in future we can consider an opt-in option to disable it.
             Type::SubclassOf(subclass_of_ty) => match subclass_of_ty.subclass_of() {
-                SubclassOfInner::Class(class) => Some(class.into_callable(db)),
+                SubclassOfInner::Class(class) => class.into_callable(db),
                 SubclassOfInner::Dynamic(dynamic) => Some(CallableType::single(
                     db,
                     Signature::new(Parameters::unknown(), Some(Type::Dynamic(dynamic))),

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1191,14 +1191,14 @@ impl<'db> Type<'db> {
                 }
             }
             Type::ClassLiteral(class_literal) => {
-                ClassType::NonGeneric(class_literal).into_callable(db)
+                Some(ClassType::NonGeneric(class_literal).into_callable(db))
             }
 
-            Type::GenericAlias(alias) => ClassType::Generic(alias).into_callable(db),
+            Type::GenericAlias(alias) => Some(ClassType::Generic(alias).into_callable(db)),
 
             // TODO: This is unsound so in future we can consider an opt-in option to disable it.
             Type::SubclassOf(subclass_of_ty) => match subclass_of_ty.subclass_of() {
-                SubclassOfInner::Class(class) => class.into_callable(db),
+                SubclassOfInner::Class(class) => Some(class.into_callable(db)),
                 SubclassOfInner::Dynamic(dynamic) => Some(CallableType::single(
                     db,
                     Signature::new(Parameters::unknown(), Some(Type::Dynamic(dynamic))),

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -914,7 +914,7 @@ impl<'db> ClassType<'db> {
 
     /// Return a callable type (or union of callable types) that represents the callable
     /// constructor signature of this class.
-    pub(super) fn into_callable(self, db: &'db dyn Db) -> Option<Type<'db>> {
+    pub(super) fn into_callable(self, db: &'db dyn Db) -> Type<'db> {
         let self_ty = Type::from(self);
         let metaclass_dunder_call_function_symbol = self_ty
             .member_lookup_with_policy(
@@ -932,9 +932,7 @@ impl<'db> ClassType<'db> {
             // https://typing.python.org/en/latest/spec/constructors.html#converting-a-constructor-to-callable
             // by always respecting the signature of the metaclass `__call__`, rather than
             // using a heuristic which makes unwarranted assumptions to sometimes ignore it.
-            return Some(Type::Callable(
-                metaclass_dunder_call_function.into_callable_type(db),
-            ));
+            return Type::Callable(metaclass_dunder_call_function.into_callable_type(db));
         }
 
         let dunder_new_function_symbol = self_ty
@@ -974,7 +972,7 @@ impl<'db> ClassType<'db> {
             ));
 
             if returns_non_subclass {
-                return Some(dunder_new_bound_method);
+                return dunder_new_bound_method;
             }
             Some(dunder_new_bound_method)
         } else {
@@ -1033,12 +1031,12 @@ impl<'db> ClassType<'db> {
             synthesized_dunder_init_callable.and_then(|ty| ty.into_callable(db)),
         ) {
             (Some(dunder_new_function), Some(synthesized_dunder_init_callable)) => {
-                Some(UnionType::from_elements(
+                UnionType::from_elements(
                     db,
                     vec![dunder_new_function, synthesized_dunder_init_callable],
-                ))
+                )
             }
-            (Some(constructor), None) | (None, Some(constructor)) => Some(constructor),
+            (Some(constructor), None) | (None, Some(constructor)) => constructor,
             (None, None) => {
                 // If no `__new__` or `__init__` method is found, then we fall back to looking for
                 // an `object.__new__` method.
@@ -1051,15 +1049,13 @@ impl<'db> ClassType<'db> {
                     .place;
 
                 if let Place::Type(Type::FunctionLiteral(new_function), _) = new_function_symbol {
-                    new_function
-                        .into_bound_method_type(db, self_ty)
-                        .into_callable(db)
+                    Type::Callable(new_function.into_callable_type(db))
                 } else {
                     // Fallback if no `object.__new__` is found.
-                    Some(CallableType::single(
+                    CallableType::single(
                         db,
                         Signature::new(Parameters::empty(), Some(correct_return_type)),
-                    ))
+                    )
                 }
             }
         }

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -1026,10 +1026,7 @@ impl<'db> ClassType<'db> {
                 None
             };
 
-        match (
-            dunder_new_function.and_then(|ty| ty.into_callable(db)),
-            synthesized_dunder_init_callable.and_then(|ty| ty.into_callable(db)),
-        ) {
+        match (dunder_new_function, synthesized_dunder_init_callable) {
             (Some(dunder_new_function), Some(synthesized_dunder_init_callable)) => {
                 UnionType::from_elements(
                     db,

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -76,9 +76,9 @@ use crate::types::narrow::ClassInfoConstraintFunction;
 use crate::types::signatures::{CallableSignature, Signature};
 use crate::types::visitor::any_over_type;
 use crate::types::{
-    BoundMethodType, CallableType, ClassBase, ClassLiteral, ClassType, DeprecatedInstance,
-    DynamicType, KnownClass, Truthiness, Type, TypeMapping, TypeRelation, TypeTransformer,
-    TypeVarInstance, UnionBuilder, all_members, walk_type_mapping,
+    CallableType, ClassBase, ClassLiteral, ClassType, DeprecatedInstance, DynamicType, KnownClass,
+    Truthiness, Type, TypeMapping, TypeRelation, TypeTransformer, TypeVarInstance, UnionBuilder,
+    all_members, walk_type_mapping,
 };
 use crate::{Db, FxOrderSet, ModuleName, resolve_module};
 
@@ -798,15 +798,6 @@ impl<'db> FunctionType<'db> {
     /// Convert the `FunctionType` into a [`CallableType`].
     pub(crate) fn into_callable_type(self, db: &'db dyn Db) -> CallableType<'db> {
         CallableType::new(db, self.signature(db), false)
-    }
-
-    /// Convert the `FunctionType` into a [`Type::BoundMethod`].
-    pub(crate) fn into_bound_method_type(
-        self,
-        db: &'db dyn Db,
-        self_instance: Type<'db>,
-    ) -> Type<'db> {
-        Type::BoundMethod(BoundMethodType::new(db, self, self_instance))
     }
 
     pub(crate) fn has_relation_to(


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

Was just trying to clean the `ClassType.into_callable` function a little, realised we don't need this function.

