### PR TITLE
[ty] more cases for the class body global fallback

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/narrow/assignment.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/assignment.md
@@ -75,7 +75,7 @@ class _:
 
     if cond():
         a = A()
-    reveal_type(a.x)  # revealed: int | None
+    reveal_type(a.x)  # revealed: int | None | Unknown
     reveal_type(a.y)  # revealed: Unknown | None
     reveal_type(a.z)  # revealed: Unknown | None
 

--- a/crates/ty_python_semantic/resources/mdtest/scopes/global.md
+++ b/crates/ty_python_semantic/resources/mdtest/scopes/global.md
@@ -269,6 +269,8 @@ If we try to access a variable in a class before it has been defined, the lookup
 global.
 
 ```py
+import secrets
+
 x: str = "a"
 
 def f(x: int, y: int):
@@ -286,4 +288,23 @@ def f(x: int, y: int):
         # error: [unresolved-reference]
         reveal_type(y)  # revealed: Unknown
         y = None
+
+    # Declarations count as definitions, even if there's no binding.
+    class F:
+        reveal_type(x)  # revealed: str
+        x: int
+        reveal_type(x)  # revealed: str
+
+    # Explicitly `nonlocal` variables don't count, even if they're bound.
+    class G:
+        nonlocal x
+        reveal_type(x)  # revealed: int
+        x = 42
+        reveal_type(x)  # revealed: Literal[42]
+
+    # Possibly-unbound variables get unioned with the fallback lookup.
+    class H:
+        if secrets.randbelow(2):
+            x = None
+        reveal_type(x)  # revealed: None | str
 ```

--- a/crates/ty_python_semantic/resources/mdtest/scopes/unbound.md
+++ b/crates/ty_python_semantic/resources/mdtest/scopes/unbound.md
@@ -34,7 +34,7 @@ class C:
     if coinflip():
         x = 1
 
-    # error: [possibly-unresolved-reference]
+    # Possibly unbound variables in enclosing scopes are considered bound.
     y = x
 
 reveal_type(C.y)  # revealed: Unknown | Literal[1, "abc"]

--- a/crates/ty_python_semantic/src/semantic_index/symbol.rs
+++ b/crates/ty_python_semantic/src/semantic_index/symbol.rs
@@ -80,6 +80,38 @@ impl Symbol {
         self.flags.contains(SymbolFlags::MARKED_NONLOCAL)
     }
 
+    /// Is the symbol defined in this scope, vs referring to some enclosing scope?
+    ///
+    /// There are three common cases where a name refers to an enclosing scope:
+    ///
+    /// 1. explicit `global` variables
+    /// 2. explicit `nonlocal` variables
+    /// 3. "free" variables, which are used in a scope where they're neither bound nor declared
+    ///
+    /// Note that even if `is_local` is false, that doesn't necessarily mean there's an enclosing
+    /// scope that resolves the reference. The symbol could be a built-in like `print`, or a name
+    /// error at runtime, or a global variable added dynamically with e.g. `globals()`.
+    ///
+    /// XXX: There's a fourth case that we don't (can't) handle here. A variable that's bound or
+    /// declared (anywhere) in a class body, but used before it's bound (at runtime), resolves
+    /// (unbelievably) to the global scope. For example:
+    /// ```py
+    /// x = 42
+    /// def f():
+    ///     x = 43
+    ///     class Foo:
+    ///         print(x)  # 42 (never 43)
+    ///         if secrets.randbelow(2):
+    ///             x = 44
+    ///         print(x)  # 42 or 44
+    /// ```
+    /// In cases like this, the resolution isn't known until runtime, and in fact it varies from
+    /// one use to the next. The semantic index alone can't resolve this, and instead it's a
+    /// special case in type inference (see `infer_place_load`).
+    pub(crate) fn is_local(&self) -> bool {
+        !self.is_global() && !self.is_nonlocal() && (self.is_bound() || self.is_declared())
+    }
+
     pub(crate) const fn is_reassigned(&self) -> bool {
         self.flags.contains(SymbolFlags::IS_REASSIGNED)
     }


### PR DESCRIPTION
I had been tracking https://github.com/astral-sh/ty/issues/875, and I took a look at @mtshiba's https://github.com/astral-sh/ruff/pull/19743 after it closed that bug. It looks like there are some obscure corner cases that don't match CPython's behavior, and some of the refactoring I've been doing for https://github.com/astral-sh/ruff/pull/19703 (particularly a `Symbol::is_local` method) might be helpful. I expect that all these cases are extremely rare, so this PR is more for my own understanding and to kick the tires on the refactorings I'm already considering. ~~I don't expect to get any ecosystem hits but we'll see.~~ (lol what is scipy doing :sweat_smile:)

This PR adds three new cases to the class body global fallback tests in `global.md`:

```py
x: str = "a"

def f(x: int, y: int):
    ...
    # Declarations count as definitions, even if there's no binding.
    class F:
        reveal_type(x)  # revealed: str
        x: int
        reveal_type(x)  # revealed: str

    # Explicitly `nonlocal` variables don't count, even if they're bound.
    class G:
        nonlocal x
        reveal_type(x)  # revealed: int
        x = 42
        reveal_type(x)  # revealed: Literal[42]

    # Possibly-unbound variables get unioned with the fallback lookup.
    class H:
        if secrets.randbelow(2):
            x = None
        reveal_type(x)  # revealed: None | str
```

These cases all fail in `main` and pass with this PR.