### PR TITLE
[ty] Use separate Rust types for bound and unbound type variables

### DIFF
--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -1358,7 +1358,7 @@ C.<CURSOR>
         __sizeof__ :: def __sizeof__(self) -> int
         __str__ :: def __str__(self) -> str
         __subclasscheck__ :: bound method <class 'C'>.__subclasscheck__(subclass: type, /) -> bool
-        __subclasses__ :: bound method <class 'C'>.__subclasses__[Self]() -> list[Self]
+        __subclasses__ :: bound method <class 'C'>.__subclasses__[Self]() -> list[Self@__subclasses__]
         __subclasshook__ :: bound method <class 'C'>.__subclasshook__(subclass: type, /) -> bool
         __text_signature__ :: str | None
         __type_params__ :: tuple[TypeVar | ParamSpec | TypeVarTuple, ...]
@@ -1426,7 +1426,7 @@ Meta.<CURSOR>
                 __sizeof__ :: def __sizeof__(self) -> int
                 __str__ :: def __str__(self) -> str
                 __subclasscheck__ :: def __subclasscheck__(self, subclass: type, /) -> bool
-                __subclasses__ :: def __subclasses__[Self](self: Self) -> list[Self]
+                __subclasses__ :: def __subclasses__[Self](self: Self@__subclasses__) -> list[Self@__subclasses__]
                 __subclasshook__ :: bound method <class 'Meta'>.__subclasshook__(subclass: type, /) -> bool
                 __text_signature__ :: str | None
                 __type_params__ :: tuple[TypeVar | ParamSpec | TypeVarTuple, ...]
@@ -1534,7 +1534,7 @@ Quux.<CURSOR>
         __sizeof__ :: def __sizeof__(self) -> int
         __str__ :: def __str__(self) -> str
         __subclasscheck__ :: bound method <class 'Quux'>.__subclasscheck__(subclass: type, /) -> bool
-        __subclasses__ :: bound method <class 'Quux'>.__subclasses__[Self]() -> list[Self]
+        __subclasses__ :: bound method <class 'Quux'>.__subclasses__[Self]() -> list[Self@__subclasses__]
         __subclasshook__ :: bound method <class 'Quux'>.__subclasshook__(subclass: type, /) -> bool
         __text_signature__ :: str | None
         __type_params__ :: tuple[TypeVar | ParamSpec | TypeVarTuple, ...]
@@ -1613,7 +1613,7 @@ Answer.<CURSOR>
                 __sizeof__ :: def __sizeof__(self) -> int
                 __str__ :: def __str__(self) -> str
                 __subclasscheck__ :: bound method <class 'Answer'>.__subclasscheck__(subclass: type, /) -> bool
-                __subclasses__ :: bound method <class 'Answer'>.__subclasses__[Self]() -> list[Self]
+                __subclasses__ :: bound method <class 'Answer'>.__subclasses__[Self]() -> list[Self@__subclasses__]
                 __subclasshook__ :: bound method <class 'Answer'>.__subclasshook__(subclass: type, /) -> bool
                 __text_signature__ :: str | None
                 __type_params__ :: tuple[TypeVar | ParamSpec | TypeVarTuple, ...]

--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -371,10 +371,10 @@ mod tests {
         );
 
         assert_snapshot!(test.hover(), @r"
-        T@Alias
+        typing.TypeVar[T: int = bool]
         ---------------------------------------------
         ```python
-        T@Alias
+        typing.TypeVar[T: int = bool]
         ```
         ---------------------------------------------
         info[hover]: Hovered content is

--- a/crates/ty_python_semantic/resources/mdtest/exception/basic.md
+++ b/crates/ty_python_semantic/resources/mdtest/exception/basic.md
@@ -102,7 +102,7 @@ def silence[T: type[BaseException]](
     try:
         func()
     except exception_type as e:
-        reveal_type(e)  # revealed: T'instance
+        reveal_type(e)  # revealed: T'instance@silence
 
 def silence2[T: (
     type[ValueError],
@@ -111,7 +111,7 @@ def silence2[T: (
     try:
         func()
     except exception_type as e:
-        reveal_type(e)  # revealed: T'instance
+        reveal_type(e)  # revealed: T'instance@silence2
 ```
 
 ## Invalid exception handlers

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/variables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/variables.md
@@ -20,7 +20,7 @@ from typing import TypeVar
 
 T = TypeVar("T")
 reveal_type(type(T))  # revealed: <class 'TypeVar'>
-reveal_type(T)  # revealed: typing.TypeVar
+reveal_type(T)  # revealed: typing.TypeVar[T]
 reveal_type(T.__name__)  # revealed: Literal["T"]
 ```
 
@@ -79,6 +79,8 @@ python-version = "3.13"
 from typing import TypeVar
 
 T = TypeVar("T", default=int)
+reveal_type(type(T))  # revealed: <class 'TypeVar'>
+reveal_type(T)  # revealed: typing.TypeVar[T = int]
 reveal_type(T.__default__)  # revealed: int
 reveal_type(T.__bound__)  # revealed: None
 reveal_type(T.__constraints__)  # revealed: tuple[()]
@@ -113,6 +115,8 @@ class Invalid(Generic[U]): ...
 from typing import TypeVar
 
 T = TypeVar("T", bound=int)
+reveal_type(type(T))  # revealed: <class 'TypeVar'>
+reveal_type(T)  # revealed: typing.TypeVar[T: int]
 reveal_type(T.__bound__)  # revealed: int
 reveal_type(T.__constraints__)  # revealed: tuple[()]
 
@@ -126,6 +130,8 @@ reveal_type(S.__bound__)  # revealed: None
 from typing import TypeVar
 
 T = TypeVar("T", int, str)
+reveal_type(type(T))  # revealed: <class 'TypeVar'>
+reveal_type(T)  # revealed: typing.TypeVar[T: (int, str)]
 reveal_type(T.__constraints__)  # revealed: tuple[int, str]
 
 S = TypeVar("S")

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
@@ -17,7 +17,7 @@ instances of `typing.TypeVar`, just like legacy type variables.
 ```py
 def f[T]():
     reveal_type(type(T))  # revealed: <class 'TypeVar'>
-    reveal_type(T)  # revealed: typing.TypeVar
+    reveal_type(T)  # revealed: typing.TypeVar[T]
     reveal_type(T.__name__)  # revealed: Literal["T"]
 ```
 
@@ -32,6 +32,8 @@ python-version = "3.13"
 
 ```py
 def f[T = int]():
+    reveal_type(type(T))  # revealed: <class 'TypeVar'>
+    reveal_type(T)  # revealed: typing.TypeVar[T = int]
     reveal_type(T.__default__)  # revealed: int
     reveal_type(T.__bound__)  # revealed: None
     reveal_type(T.__constraints__)  # revealed: tuple[()]
@@ -63,6 +65,8 @@ class Invalid[S = T]: ...
 
 ```py
 def f[T: int]():
+    reveal_type(type(T))  # revealed: <class 'TypeVar'>
+    reveal_type(T)  # revealed: typing.TypeVar[T: int]
     reveal_type(T.__bound__)  # revealed: int
     reveal_type(T.__constraints__)  # revealed: tuple[()]
 
@@ -74,6 +78,8 @@ def g[S]():
 
 ```py
 def f[T: (int, str)]():
+    reveal_type(type(T))  # revealed: <class 'TypeVar'>
+    reveal_type(T)  # revealed: typing.TypeVar[T: (int, str)]
     reveal_type(T.__constraints__)  # revealed: tuple[int, str]
     reveal_type(T.__bound__)  # revealed: None
 

--- a/crates/ty_python_semantic/resources/mdtest/type_compendium/never.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_compendium/never.md
@@ -21,6 +21,7 @@ static_assert(is_subtype_of(Never, Never))
 static_assert(not is_subtype_of(int, Never))
 
 T = TypeVar("T", bound=Never)
+
 def _(t: T):
     static_assert(is_subtype_of(T, Never))
 ```

--- a/crates/ty_python_semantic/resources/mdtest/type_compendium/never.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_compendium/never.md
@@ -21,7 +21,8 @@ static_assert(is_subtype_of(Never, Never))
 static_assert(not is_subtype_of(int, Never))
 
 T = TypeVar("T", bound=Never)
-static_assert(is_subtype_of(T, Never))
+def _(t: T):
+    static_assert(is_subtype_of(T, Never))
 ```
 
 ## `Never` is assignable to every type

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
@@ -44,7 +44,7 @@ reveal_type(top_materialization(Callable[[Any], None]))  # revealed: (Never, /) 
 The invariant position is replaced with an unresolved type variable.
 
 ```py
-reveal_type(top_materialization(list[Any]))  # revealed: list[T_all]
+reveal_type(top_materialization(list[Any]))  # revealed: list[typing.TypeVar[T_all]]
 ```
 
 ### Bottom materialization
@@ -70,7 +70,7 @@ The invariant position is replaced in the same way as the top materialization, w
 type variable.
 
 ```py
-reveal_type(bottom_materialization(list[Any]))  # revealed: list[T_all]
+reveal_type(bottom_materialization(list[Any]))  # revealed: list[typing.TypeVar[T_all]]
 ```
 
 ## Fully static types
@@ -198,14 +198,16 @@ def _(callable: Callable[[tuple[Any, int], tuple[str, Unknown]], None]) -> None:
 And, similarly for an invariant position.
 
 ```py
-reveal_type(top_materialization(list[tuple[Any, int]]))  # revealed: list[tuple[T_all, int]]
-reveal_type(bottom_materialization(list[tuple[Any, int]]))  # revealed: list[tuple[T_all, int]]
+reveal_type(top_materialization(list[tuple[Any, int]]))  # revealed: list[tuple[typing.TypeVar[T_all], int]]
+reveal_type(bottom_materialization(list[tuple[Any, int]]))  # revealed: list[tuple[typing.TypeVar[T_all], int]]
 
-reveal_type(top_materialization(list[tuple[str, Unknown]]))  # revealed: list[tuple[str, T_all]]
-reveal_type(bottom_materialization(list[tuple[str, Unknown]]))  # revealed: list[tuple[str, T_all]]
+reveal_type(top_materialization(list[tuple[str, Unknown]]))  # revealed: list[tuple[str, typing.TypeVar[T_all]]]
+reveal_type(bottom_materialization(list[tuple[str, Unknown]]))  # revealed: list[tuple[str, typing.TypeVar[T_all]]]
 
-reveal_type(top_materialization(list[tuple[Any, int, Unknown]]))  # revealed: list[tuple[T_all, int, T_all]]
-reveal_type(bottom_materialization(list[tuple[Any, int, Unknown]]))  # revealed: list[tuple[T_all, int, T_all]]
+# revealed: list[tuple[typing.TypeVar[T_all], int, typing.TypeVar[T_all]]]
+reveal_type(top_materialization(list[tuple[Any, int, Unknown]]))
+# revealed: list[tuple[typing.TypeVar[T_all], int, typing.TypeVar[T_all]]]
+reveal_type(bottom_materialization(list[tuple[Any, int, Unknown]]))
 ```
 
 ## Union
@@ -244,14 +246,14 @@ def _(callable: Callable[[Any | int, str | Unknown], None]) -> None:
 And, similarly for an invariant position.
 
 ```py
-reveal_type(top_materialization(list[Any | int]))  # revealed: list[T_all | int]
-reveal_type(bottom_materialization(list[Any | int]))  # revealed: list[T_all | int]
+reveal_type(top_materialization(list[Any | int]))  # revealed: list[typing.TypeVar[T_all] | int]
+reveal_type(bottom_materialization(list[Any | int]))  # revealed: list[typing.TypeVar[T_all] | int]
 
-reveal_type(top_materialization(list[str | Unknown]))  # revealed: list[str | T_all]
-reveal_type(bottom_materialization(list[str | Unknown]))  # revealed: list[str | T_all]
+reveal_type(top_materialization(list[str | Unknown]))  # revealed: list[str | typing.TypeVar[T_all]]
+reveal_type(bottom_materialization(list[str | Unknown]))  # revealed: list[str | typing.TypeVar[T_all]]
 
-reveal_type(top_materialization(list[Any | int | Unknown]))  # revealed: list[T_all | int]
-reveal_type(bottom_materialization(list[Any | int | Unknown]))  # revealed: list[T_all | int]
+reveal_type(top_materialization(list[Any | int | Unknown]))  # revealed: list[typing.TypeVar[T_all] | int]
+reveal_type(bottom_materialization(list[Any | int | Unknown]))  # revealed: list[typing.TypeVar[T_all] | int]
 ```
 
 ## Intersection
@@ -276,8 +278,8 @@ class Foo: ...
 # revealed: Foo & tuple[str]
 reveal_type(bottom_materialization(Intersection[Any | Foo, tuple[str]]))
 
-reveal_type(top_materialization(Intersection[list[Any], list[int]]))  # revealed: list[T_all] & list[int]
-reveal_type(bottom_materialization(Intersection[list[Any], list[int]]))  # revealed: list[T_all] & list[int]
+reveal_type(top_materialization(Intersection[list[Any], list[int]]))  # revealed: list[typing.TypeVar[T_all]] & list[int]
+reveal_type(bottom_materialization(Intersection[list[Any], list[int]]))  # revealed: list[typing.TypeVar[T_all]] & list[int]
 ```
 
 ## Negation (via `Not`)
@@ -315,9 +317,8 @@ reveal_type(bottom_materialization(type[Unknown]))  # revealed: Never
 reveal_type(top_materialization(type[int | Any]))  # revealed: type
 reveal_type(bottom_materialization(type[int | Any]))  # revealed: type[int]
 
-# Here, `T` has an upper bound of `type`
-reveal_type(top_materialization(list[type[Any]]))  # revealed: list[T_all]
-reveal_type(bottom_materialization(list[type[Any]]))  # revealed: list[T_all]
+reveal_type(top_materialization(list[type[Any]]))  # revealed: list[typing.TypeVar[T_all: type]]
+reveal_type(bottom_materialization(list[type[Any]]))  # revealed: list[typing.TypeVar[T_all: type]]
 ```
 
 ## Type variables
@@ -378,8 +379,8 @@ class GenericCovariant(Generic[T_co]):
 class GenericContravariant(Generic[T_contra]):
     pass
 
-reveal_type(top_materialization(GenericInvariant[Any]))  # revealed: GenericInvariant[T_all]
-reveal_type(bottom_materialization(GenericInvariant[Any]))  # revealed: GenericInvariant[T_all]
+reveal_type(top_materialization(GenericInvariant[Any]))  # revealed: GenericInvariant[typing.TypeVar[T_all]]
+reveal_type(bottom_materialization(GenericInvariant[Any]))  # revealed: GenericInvariant[typing.TypeVar[T_all]]
 
 reveal_type(top_materialization(GenericCovariant[Any]))  # revealed: GenericCovariant[object]
 reveal_type(bottom_materialization(GenericCovariant[Any]))  # revealed: GenericCovariant[Never]
@@ -395,10 +396,10 @@ from typing import Callable
 from ty_extensions import TypeOf
 
 def invariant(callable: Callable[[GenericInvariant[Any]], None]) -> None:
-    # revealed: (GenericInvariant[T_all], /) -> None
+    # revealed: (GenericInvariant[typing.TypeVar[T_all]], /) -> None
     reveal_type(top_materialization(TypeOf[callable]))
 
-    # revealed: (GenericInvariant[T_all], /) -> None
+    # revealed: (GenericInvariant[typing.TypeVar[T_all]], /) -> None
     reveal_type(bottom_materialization(TypeOf[callable]))
 
 def covariant(callable: Callable[[GenericCovariant[Any]], None]) -> None:

--- a/crates/ty_python_semantic/src/semantic_index/definition.rs
+++ b/crates/ty_python_semantic/src/semantic_index/definition.rs
@@ -23,6 +23,7 @@ use crate::unpack::{Unpack, UnpackPosition};
 /// before this `Definition`. However, the ID can be considered stable and it is okay to use
 /// `Definition` in cross-module` salsa queries or as a field on other salsa tracked structs.
 #[salsa::tracked(debug)]
+#[derive(Ord, PartialOrd)]
 pub struct Definition<'db> {
     /// The file in which the definition occurs.
     pub file: File,

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -431,7 +431,7 @@ impl<'db> PropertyInstanceType<'db> {
         self,
         db: &'db dyn Db,
         binding_context: Option<Definition<'db>>,
-        typevars: &mut FxOrderSet<TypeVarInstance<'db>>,
+        typevars: &mut FxOrderSet<BoundTypeVarInstance<'db>>,
     ) {
         if let Some(ty) = self.getter(db) {
             ty.find_legacy_typevars(db, binding_context, typevars);
@@ -601,7 +601,7 @@ pub enum Type<'db> {
     Tuple(TupleType<'db>),
     /// An instance of a typevar in a generic class or function. When the generic class or function
     /// is specialized, we will replace this typevar with its specialization.
-    TypeVar(TypeVarInstance<'db>),
+    TypeVar(BoundTypeVarInstance<'db>),
     /// A bound super object like `super()` or `super(A, A())`
     /// This type doesn't handle an unbound super object like `super(A)`; for that we just use
     /// a `Type::NominalInstance` of `builtins.super`.
@@ -700,16 +700,17 @@ impl<'db> Type<'db> {
                 // existential type representing "all lists, containing any type." We currently
                 // represent this by replacing `Any` in invariant position with an unresolved type
                 // variable.
-                TypeVarVariance::Invariant => Type::TypeVar(TypeVarInstance::new(
-                    db,
-                    Name::new_static("T_all"),
-                    None,
-                    None,
-                    None,
-                    variance,
-                    None,
-                    TypeVarKind::Pep695,
-                )),
+                TypeVarVariance::Invariant => {
+                    Type::KnownInstance(KnownInstanceType::TypeVar(TypeVarInstance::new(
+                        db,
+                        Name::new_static("T_all"),
+                        None,
+                        None,
+                        variance,
+                        None,
+                        TypeVarKind::Pep695,
+                    )))
+                }
                 TypeVarVariance::Covariant => Type::object(db),
                 TypeVarVariance::Contravariant => Type::Never,
                 TypeVarVariance::Bivariant => unreachable!(),
@@ -780,7 +781,7 @@ impl<'db> Type<'db> {
                 )
                 .build(),
             Type::Tuple(tuple_type) => Type::tuple(tuple_type.materialize(db, variance)),
-            Type::TypeVar(type_var) => Type::TypeVar(type_var.materialize(db, variance)),
+            Type::TypeVar(bound_typevar) => Type::TypeVar(bound_typevar.materialize(db, variance)),
             Type::TypeIs(type_is) => {
                 type_is.with_type(db, type_is.return_type(db).materialize(db, variance))
             }
@@ -1083,9 +1084,9 @@ impl<'db> Type<'db> {
             Type::SubclassOf(subclass_of) => visitor.visit(self, |v| {
                 Type::SubclassOf(subclass_of.normalized_impl(db, v))
             }),
-            Type::TypeVar(typevar) => {
-                visitor.visit(self, |v| Type::TypeVar(typevar.normalized_impl(db, v)))
-            }
+            Type::TypeVar(bound_typevar) => visitor.visit(self, |v| {
+                Type::TypeVar(bound_typevar.normalized_impl(db, v))
+            }),
             Type::KnownInstance(known_instance) => visitor.visit(self, |v| {
                 Type::KnownInstance(known_instance.normalized_impl(db, v))
             }),
@@ -1355,8 +1356,8 @@ impl<'db> Type<'db> {
             //
             // Note that this is not handled by the early return at the beginning of this method,
             // since subtyping between a TypeVar and an arbitrary other type cannot be guaranteed to be reflexive.
-            (Type::TypeVar(lhs_typevar), Type::TypeVar(rhs_typevar))
-                if lhs_typevar == rhs_typevar =>
+            (Type::TypeVar(lhs_bound_typevar), Type::TypeVar(rhs_bound_typevar))
+                if lhs_bound_typevar == rhs_bound_typevar =>
             {
                 true
             }
@@ -1364,7 +1365,9 @@ impl<'db> Type<'db> {
             // A fully static typevar is a subtype of its upper bound, and to something similar to
             // the union of its constraints. An unbound, unconstrained, fully static typevar has an
             // implicit upper bound of `object` (which is handled above).
-            (Type::TypeVar(typevar), _) if typevar.bound_or_constraints(db).is_some() => {
+            (Type::TypeVar(BoundTypeVarInstance { typevar, .. }), _)
+                if typevar.bound_or_constraints(db).is_some() =>
+            {
                 match typevar.bound_or_constraints(db) {
                     None => unreachable!(),
                     Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
@@ -1380,7 +1383,7 @@ impl<'db> Type<'db> {
             // If the typevar is constrained, there must be multiple constraints, and the typevar
             // might be specialized to any one of them. However, the constraints do not have to be
             // disjoint, which means an lhs type might be a subtype of all of the constraints.
-            (_, Type::TypeVar(typevar))
+            (_, Type::TypeVar(BoundTypeVarInstance { typevar, .. }))
                 if typevar.constraints(db).is_some_and(|constraints| {
                     constraints
                         .iter()
@@ -1803,8 +1806,8 @@ impl<'db> Type<'db> {
             // be specialized to the same type. (This is an important difference between typevars
             // and `Any`!) Different typevars might be disjoint, depending on their bounds and
             // constraints, which are handled below.
-            (Type::TypeVar(self_typevar), Type::TypeVar(other_typevar))
-                if self_typevar == other_typevar =>
+            (Type::TypeVar(self_bound_typevar), Type::TypeVar(other_bound_typevar))
+                if self_bound_typevar == other_bound_typevar =>
             {
                 false
             }
@@ -1820,7 +1823,8 @@ impl<'db> Type<'db> {
             // specialized to any type. A bounded typevar is not disjoint from its bound, and is
             // only disjoint from other types if its bound is. A constrained typevar is disjoint
             // from a type if all of its constraints are.
-            (Type::TypeVar(typevar), other) | (other, Type::TypeVar(typevar)) => {
+            (Type::TypeVar(BoundTypeVarInstance{ typevar, .. }), other) |
+                (other, Type::TypeVar(BoundTypeVarInstance{ typevar, .. })) => {
                 match typevar.bound_or_constraints(db) {
                     None => false,
                     Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
@@ -2332,14 +2336,16 @@ impl<'db> Type<'db> {
             // the bound is a final singleton class, since it can still be specialized to `Never`.
             // A constrained typevar is a singleton if all of its constraints are singletons. (Note
             // that you cannot specialize a constrained typevar to a subtype of a constraint.)
-            Type::TypeVar(typevar) => match typevar.bound_or_constraints(db) {
-                None => false,
-                Some(TypeVarBoundOrConstraints::UpperBound(_)) => false,
-                Some(TypeVarBoundOrConstraints::Constraints(constraints)) => constraints
-                    .elements(db)
-                    .iter()
-                    .all(|constraint| constraint.is_singleton(db)),
-            },
+            Type::TypeVar(BoundTypeVarInstance { typevar, .. }) => {
+                match typevar.bound_or_constraints(db) {
+                    None => false,
+                    Some(TypeVarBoundOrConstraints::UpperBound(_)) => false,
+                    Some(TypeVarBoundOrConstraints::Constraints(constraints)) => constraints
+                        .elements(db)
+                        .iter()
+                        .all(|constraint| constraint.is_singleton(db)),
+                }
+            }
 
             // We eagerly transform `SubclassOf` to `ClassLiteral` for final types, so `SubclassOf` is never a singleton.
             Type::SubclassOf(..) => false,
@@ -2467,14 +2473,16 @@ impl<'db> Type<'db> {
             // `Never`. A constrained typevar is single-valued if all of its constraints are
             // single-valued. (Note that you cannot specialize a constrained typevar to a subtype
             // of a constraint.)
-            Type::TypeVar(typevar) => match typevar.bound_or_constraints(db) {
-                None => false,
-                Some(TypeVarBoundOrConstraints::UpperBound(_)) => false,
-                Some(TypeVarBoundOrConstraints::Constraints(constraints)) => constraints
-                    .elements(db)
-                    .iter()
-                    .all(|constraint| constraint.is_single_valued(db)),
-            },
+            Type::TypeVar(BoundTypeVarInstance { typevar, .. }) => {
+                match typevar.bound_or_constraints(db) {
+                    None => false,
+                    Some(TypeVarBoundOrConstraints::UpperBound(_)) => false,
+                    Some(TypeVarBoundOrConstraints::Constraints(constraints)) => constraints
+                        .elements(db)
+                        .iter()
+                        .all(|constraint| constraint.is_single_valued(db)),
+                }
+            }
 
             Type::SubclassOf(..) => {
                 // TODO: Same comment as above for `is_singleton`
@@ -2736,16 +2744,18 @@ impl<'db> Type<'db> {
                 KnownClass::Object.to_instance(db).instance_member(db, name)
             }
 
-            Type::TypeVar(typevar) => match typevar.bound_or_constraints(db) {
-                None => KnownClass::Object.to_instance(db).instance_member(db, name),
-                Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
-                    bound.instance_member(db, name)
+            Type::TypeVar(BoundTypeVarInstance { typevar, .. }) => {
+                match typevar.bound_or_constraints(db) {
+                    None => KnownClass::Object.to_instance(db).instance_member(db, name),
+                    Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
+                        bound.instance_member(db, name)
+                    }
+                    Some(TypeVarBoundOrConstraints::Constraints(constraints)) => constraints
+                        .map_with_boundness_and_qualifiers(db, |constraint| {
+                            constraint.instance_member(db, name)
+                        }),
                 }
-                Some(TypeVarBoundOrConstraints::Constraints(constraints)) => constraints
-                    .map_with_boundness_and_qualifiers(db, |constraint| {
-                        constraint.instance_member(db, name)
-                    }),
-            },
+            }
 
             Type::IntLiteral(_) => KnownClass::Int.to_instance(db).instance_member(db, name),
             Type::BooleanLiteral(_) | Type::TypeIs(_) => {
@@ -3607,15 +3617,17 @@ impl<'db> Type<'db> {
                 }
             },
 
-            Type::TypeVar(typevar) => match typevar.bound_or_constraints(db) {
-                None => Truthiness::Ambiguous,
-                Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
-                    bound.try_bool_impl(db, allow_short_circuit)?
+            Type::TypeVar(BoundTypeVarInstance { typevar, .. }) => {
+                match typevar.bound_or_constraints(db) {
+                    None => Truthiness::Ambiguous,
+                    Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
+                        bound.try_bool_impl(db, allow_short_circuit)?
+                    }
+                    Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
+                        try_union(constraints)?
+                    }
                 }
-                Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
-                    try_union(constraints)?
-                }
-            },
+            }
 
             Type::NominalInstance(instance) => match instance.class.known(db) {
                 Some(known_class) => known_class.bool(),
@@ -3711,7 +3723,9 @@ impl<'db> Type<'db> {
                     .into()
             }
 
-            Type::TypeVar(typevar) => match typevar.bound_or_constraints(db) {
+            Type::TypeVar(BoundTypeVarInstance { typevar, .. }) => match typevar
+                .bound_or_constraints(db)
+            {
                 None => CallableBinding::not_callable(self).into(),
                 Some(TypeVarBoundOrConstraints::UpperBound(bound)) => bound.bindings(db),
                 Some(TypeVarBoundOrConstraints::Constraints(constraints)) => Bindings::from_union(
@@ -5211,7 +5225,8 @@ impl<'db> Type<'db> {
             // If there is no bound or constraints on a typevar `T`, `T: object` implicitly, which
             // has no instance type. Otherwise, synthesize a typevar with bound or constraints
             // mapped through `to_instance`.
-            Type::TypeVar(typevar) => {
+            Type::TypeVar(bound_typevar) => {
+                let typevar = bound_typevar.typevar;
                 let bound_or_constraints = match typevar.bound_or_constraints(db)? {
                     TypeVarBoundOrConstraints::UpperBound(upper_bound) => {
                         TypeVarBoundOrConstraints::UpperBound(upper_bound.to_instance(db)?)
@@ -5222,16 +5237,18 @@ impl<'db> Type<'db> {
                         )
                     }
                 };
-                Some(Type::TypeVar(TypeVarInstance::new(
-                    db,
-                    Name::new(format!("{}'instance", typevar.name(db))),
-                    None,
-                    None,
-                    Some(bound_or_constraints),
-                    typevar.variance(db),
-                    None,
-                    typevar.kind(db),
-                )))
+                Some(Type::TypeVar(
+                    TypeVarInstance::new(
+                        db,
+                        Name::new(format!("{}'instance", typevar.name(db))),
+                        None,
+                        Some(bound_or_constraints),
+                        typevar.variance(db),
+                        None,
+                        typevar.kind(db),
+                    )
+                    .with_binding_context(bound_typevar.binding_context),
+                ))
             }
             Type::Intersection(_) => Some(todo_type!("Type::Intersection.to_instance")),
             Type::BooleanLiteral(_)
@@ -5421,7 +5438,6 @@ impl<'db> Type<'db> {
                         db,
                         ast::name::Name::new_static("Self"),
                         Some(class_definition),
-                        None,
                         Some(TypeVarBoundOrConstraints::UpperBound(instance)),
                         TypeVarVariance::Invariant,
                         None,
@@ -5635,15 +5651,17 @@ impl<'db> Type<'db> {
             Type::Tuple(tuple) => tuple
                 .to_subclass_of(db)
                 .unwrap_or_else(SubclassOfType::subclass_of_unknown),
-            Type::TypeVar(typevar) => match typevar.bound_or_constraints(db) {
-                None => KnownClass::Type.to_instance(db),
-                Some(TypeVarBoundOrConstraints::UpperBound(bound)) => bound.to_meta_type(db),
-                Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
-                    // TODO: If we add a proper `OneOf` connector, we should use that here instead
-                    // of union. (Using a union here doesn't break anything, but it is imprecise.)
-                    constraints.map(db, |constraint| constraint.to_meta_type(db))
+            Type::TypeVar(BoundTypeVarInstance { typevar, .. }) => {
+                match typevar.bound_or_constraints(db) {
+                    None => KnownClass::Type.to_instance(db),
+                    Some(TypeVarBoundOrConstraints::UpperBound(bound)) => bound.to_meta_type(db),
+                    Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
+                        // TODO: If we add a proper `OneOf` connector, we should use that here instead
+                        // of union. (Using a union here doesn't break anything, but it is imprecise.)
+                        constraints.map(db, |constraint| constraint.to_meta_type(db))
+                    }
                 }
-            },
+            }
 
             Type::ClassLiteral(class) => class.metaclass(db),
             Type::GenericAlias(alias) => ClassType::from(*alias).metaclass(db),
@@ -5723,12 +5741,12 @@ impl<'db> Type<'db> {
         type_mapping: &TypeMapping<'a, 'db>,
     ) -> Type<'db> {
         match self {
-            Type::TypeVar(typevar) => match type_mapping {
+            Type::TypeVar(bound_typevar) => match type_mapping {
                 TypeMapping::Specialization(specialization) => {
-                    specialization.get(db, typevar).unwrap_or(self)
+                    specialization.get(db, bound_typevar).unwrap_or(self)
                 }
                 TypeMapping::PartialSpecialization(partial) => {
-                    partial.get(db, typevar).unwrap_or(self)
+                    partial.get(db, bound_typevar).unwrap_or(self)
                 }
                 TypeMapping::PromoteLiterals | TypeMapping::BindLegacyTypevars(_) => self,
             }
@@ -5738,7 +5756,7 @@ impl<'db> Type<'db> {
                 TypeMapping::PartialSpecialization(_) |
                 TypeMapping::PromoteLiterals => self,
                 TypeMapping::BindLegacyTypevars(binding_context) => {
-                    Type::TypeVar(typevar.with_binding_context(db, *binding_context))
+                    Type::TypeVar(bound_typevar.with_binding_context(db, *binding_context))
                 }
             }
 
@@ -5862,16 +5880,16 @@ impl<'db> Type<'db> {
         self,
         db: &'db dyn Db,
         binding_context: Option<Definition<'db>>,
-        typevars: &mut FxOrderSet<TypeVarInstance<'db>>,
+        typevars: &mut FxOrderSet<BoundTypeVarInstance<'db>>,
     ) {
         match self {
-            Type::TypeVar(typevar) => {
-                if (typevar.is_legacy(db) || typevar.is_implicit(db))
+            Type::TypeVar(bound_typevar) => {
+                if (bound_typevar.is_legacy(db) || bound_typevar.is_implicit(db))
                     && binding_context.is_none_or(|binding_context| {
-                        typevar.binding_context(db) == Some(binding_context)
+                        bound_typevar.binding_context(db) == Some(binding_context)
                     })
                 {
-                    typevars.insert(typevar);
+                    typevars.insert(bound_typevar);
                 }
             }
 
@@ -6771,13 +6789,39 @@ pub enum TypeVarKind {
     Implicit,
 }
 
-/// Data regarding a single type variable.
+/// A type variable that has not been bound to a generic context yet.
 ///
-/// This is referenced by `KnownInstanceType::TypeVar` (to represent the singleton type of the
-/// runtime `typing.TypeVar` object itself), and by `Type::TypeVar` to represent the type that this
-/// typevar represents as an annotation: that is, an unknown set of objects, constrained by the
-/// upper-bound/constraints on this type var, defaulting to the default type of this type var when
-/// not otherwise bound to a type.
+/// This is usually not the type that you want; if you are working with a typevar, in a generic
+/// context, which might be specialized to a concrete type, you want [`BoundTypeVarInstance`]. This
+/// type holds information that does not depend on which generic context the typevar is used in,
+/// which reduces the amount of data that is salsa-interned.
+///
+/// For a legacy typevar:
+///
+/// ```py
+/// T = TypeVar("T")                       # [1]
+/// def generic_function(t: T) -> T: ...   # [2]
+/// ```
+///
+/// we will create and intern a `TypeVarInstance` for the typevar `T` when it is instantiated.
+/// The type of `T` at `[1]` will be a `KnownInstanceType::TypeVar` wrapping this
+/// `TypeVarInstance`. The typevar is not yet bound to any generic context at this point.
+///
+/// The typevar is used in `generic_function`, which binds it to a new generic context. We will
+/// create a [`BoundTypeVarInstance`] for this new binding of the typevar. The type of `T` at `[2]`
+/// will be a `Type::TypeVar` wrapping this `BoundTypeVarInstance`.
+///
+/// For a PEP 695 typevar:
+///
+/// ```py
+/// def generic_function[T](t: T) -> T: ...
+/// #                          ╰─────╰─────────── [2]
+/// #                    ╰─────────────────────── [1]
+/// ```
+///
+/// the typevar is defined and immediately bound to a single generic context. Just like in the
+/// legacy case, we will create a `TypeVarInstance` and [`BoundTypeVarInstance`], and the type of
+/// `T` at `[1]` and `[2]` will be that `TypeVarInstance` and `BoundTypeVarInstance`, respectively.
 ///
 /// # Ordering
 /// Ordering is based on the type var instance's salsa-assigned id and not on its values.
@@ -6791,35 +6835,6 @@ pub struct TypeVarInstance<'db> {
 
     /// The type var's definition (None if synthesized)
     pub definition: Option<Definition<'db>>,
-
-    /// The definition of the generic class, function, or type alias that binds this typevar. This
-    /// is `None` for a legacy typevar outside of a context that can bind it.
-    ///
-    /// For a legacy typevar, the binding context might be missing:
-    ///
-    /// ```py
-    /// T = TypeVar("T")                       # [1]
-    /// def generic_function(t: T) -> T: ...   # [2]
-    /// ```
-    ///
-    /// Here, we will create two `TypeVarInstance`s for the typevar `T`. Both will have `[1]` as
-    /// their [`definition`][Self::definition]. The first represents the variable when it is first
-    /// created, and not yet used, so it's `binding_context` will be `None`. The second represents
-    /// when the typevar is used in `generic_function`, and its `binding_context` will be `[2]`
-    /// (that is, the definition of `generic_function`).
-    ///
-    /// For a PEP 695 typevar, there will always be a binding context, since you can only define
-    /// one as part of creating the generic context that uses it:
-    ///
-    /// ```py
-    /// def generic_function[T](t: T) -> T: ...
-    /// ```
-    ///
-    /// Here, we will create a single `TypeVarInstance`. Its [`definition`][Self::definition] will
-    /// be the `T` in `[T]` (i.e., the definition of the typevar in the syntactic construct that
-    /// creates the generic context that uses it). Its `binding_context` will be the definition of
-    /// `generic_function`.
-    binding_context: Option<Definition<'db>>,
 
     /// The upper bound or constraint on the type of this TypeVar
     bound_or_constraints: Option<TypeVarBoundOrConstraints<'db>>,
@@ -6838,13 +6853,13 @@ impl get_size2::GetSize for TypeVarInstance<'_> {}
 
 fn walk_type_var_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
-    type_var: TypeVarInstance<'db>,
+    typevar: TypeVarInstance<'db>,
     visitor: &mut V,
 ) {
-    if let Some(bounds) = type_var.bound_or_constraints(db) {
+    if let Some(bounds) = typevar.bound_or_constraints(db) {
         walk_type_var_bounds(db, bounds, visitor);
     }
-    if let Some(default_type) = type_var.default_ty(db) {
+    if let Some(default_type) = typevar.default_ty(db) {
         visitor.visit_type(db, default_type);
     }
 }
@@ -6852,21 +6867,12 @@ fn walk_type_var_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
 impl<'db> TypeVarInstance<'db> {
     pub(crate) fn with_binding_context(
         self,
-        db: &'db dyn Db,
         binding_context: Definition<'db>,
-    ) -> Self {
-        Self::new(
-            db,
-            self.name(db),
-            self.definition(db),
-            Some(binding_context),
-            self.bound_or_constraints(db),
-            self.variance(db),
-            self.default_ty(db).map(|ty| {
-                ty.apply_type_mapping(db, &TypeMapping::BindLegacyTypevars(binding_context))
-            }),
-            self.kind(db),
-        )
+    ) -> BoundTypeVarInstance<'db> {
+        BoundTypeVarInstance {
+            typevar: self,
+            binding_context,
+        }
     }
 
     pub(crate) fn is_legacy(self, db: &'db dyn Db) -> bool {
@@ -6902,7 +6908,6 @@ impl<'db> TypeVarInstance<'db> {
             db,
             self.name(db),
             self.definition(db),
-            self.binding_context(db),
             self.bound_or_constraints(db)
                 .map(|b| b.normalized_impl(db, visitor)),
             self.variance(db),
@@ -6916,13 +6921,58 @@ impl<'db> TypeVarInstance<'db> {
             db,
             self.name(db),
             self.definition(db),
-            self.binding_context(db),
             self.bound_or_constraints(db)
                 .map(|b| b.materialize(db, variance)),
             self.variance(db),
             self.default_ty(db),
             self.kind(db),
         )
+    }
+}
+
+/// A type variable that has been bound to a generic context, and which can be specialized to a
+/// concrete type.
+#[derive(
+    Clone, Copy, Debug, Hash, Eq, Ord, PartialEq, PartialOrd, salsa::Update, get_size2::GetSize,
+)]
+pub struct BoundTypeVarInstance<'db> {
+    pub typevar: TypeVarInstance<'db>,
+
+    /// The definition of the generic class, function, or type alias that binds this typevar.
+    binding_context: Definition<'db>,
+}
+
+fn walk_bound_type_var_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
+    db: &'db dyn Db,
+    bound_typevar: BoundTypeVarInstance<'db>,
+    visitor: &mut V,
+) {
+    visitor.visit_type_var_type(db, bound_typevar.typevar, visitor);
+}
+
+impl<'db> BoundTypeVarInstance<'db> {
+    pub(crate) fn default_ty(&self, db: &'db dyn Db) -> Option<Type<'db>> {
+        self.typevar.default_ty(db).map(|ty| {
+            ty.apply_type_mapping(db, &TypeMapping::BindLegacyTypevars(self.binding_context))
+        })
+    }
+
+    pub(crate) fn normalized_impl(
+        self,
+        db: &'db dyn Db,
+        visitor: &mut TypeTransformer<'db>,
+    ) -> Self {
+        Self {
+            typevar: self.typevar.normalized_impl(db, visitor),
+            binding_context: self.binding_context,
+        }
+    }
+
+    fn materialize(self, db: &'db dyn Db, variance: TypeVarVariance) -> Self {
+        Self {
+            typevar: self.typevar.materialize(db, variance),
+            binding_context: self.binding_context,
+        }
     }
 }
 
@@ -8143,7 +8193,7 @@ impl<'db> CallableType<'db> {
         self,
         db: &'db dyn Db,
         binding_context: Option<Definition<'db>>,
-        typevars: &mut FxOrderSet<TypeVarInstance<'db>>,
+        typevars: &mut FxOrderSet<BoundTypeVarInstance<'db>>,
     ) {
         self.signatures(db)
             .find_legacy_typevars(db, binding_context, typevars);

--- a/crates/ty_python_semantic/src/types/builder.rs
+++ b/crates/ty_python_semantic/src/types/builder.rs
@@ -39,7 +39,7 @@
 
 use crate::types::enums::{enum_member_literals, enum_metadata};
 use crate::types::{
-    BytesLiteralType, IntersectionType, KnownClass, StringLiteralType, Type,
+    BoundTypeVarInstance, BytesLiteralType, IntersectionType, KnownClass, StringLiteralType, Type,
     TypeVarBoundOrConstraints, UnionType,
 };
 use crate::{Db, FxOrderSet};
@@ -973,7 +973,7 @@ impl<'db> InnerIntersectionBuilder<'db> {
         let mut positive_to_remove = SmallVec::<[usize; 1]>::new();
 
         for (typevar_index, ty) in self.positive.iter().enumerate() {
-            let Type::TypeVar(typevar) = ty else {
+            let Type::TypeVar(BoundTypeVarInstance { typevar, .. }) = ty else {
                 continue;
             };
             let Some(TypeVarBoundOrConstraints::Constraints(constraints)) =

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -2857,7 +2857,7 @@ impl<'db> BindingError<'db> {
                     return;
                 };
 
-                let typevar = error.typevar();
+                let bound_typevar = error.bound_typevar();
                 let argument_type = error.argument_type();
                 let argument_ty_display = argument_type.display(context.db());
 
@@ -2875,10 +2875,10 @@ impl<'db> BindingError<'db> {
                         SpecializationError::MismatchedBound {..} => "upper bound",
                         SpecializationError::MismatchedConstraint {..} => "constraints",
                     },
-                    typevar.name(context.db()),
+                    bound_typevar.typevar.name(context.db()),
                 ));
 
-                if let Some(typevar_definition) = typevar.definition(context.db()) {
+                if let Some(typevar_definition) = bound_typevar.typevar.definition(context.db()) {
                     let module = parsed_module(context.db(), typevar_definition.file(context.db()))
                         .load(context.db());
                     let typevar_range = typevar_definition.full_range(context.db(), &module);

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -250,11 +250,13 @@ impl<'db> GenericAlias<'db> {
     pub(super) fn find_legacy_typevars(
         self,
         db: &'db dyn Db,
+        binding_context: Option<Definition<'db>>,
         typevars: &mut FxOrderSet<TypeVarInstance<'db>>,
     ) {
         // A tuple's specialization will include all of its element types, so we don't need to also
         // look in `self.tuple`.
-        self.specialization(db).find_legacy_typevars(db, typevars);
+        self.specialization(db)
+            .find_legacy_typevars(db, binding_context, typevars);
     }
 
     pub(super) fn is_typed_dict(self, db: &'db dyn Db) -> bool {
@@ -395,11 +397,12 @@ impl<'db> ClassType<'db> {
     pub(super) fn find_legacy_typevars(
         self,
         db: &'db dyn Db,
+        binding_context: Option<Definition<'db>>,
         typevars: &mut FxOrderSet<TypeVarInstance<'db>>,
     ) {
         match self {
             Self::NonGeneric(_) => {}
-            Self::Generic(generic) => generic.find_legacy_typevars(db, typevars),
+            Self::Generic(generic) => generic.find_legacy_typevars(db, binding_context, typevars),
         }
     }
 

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -1319,21 +1319,7 @@ impl<'db> ClassLiteral<'db> {
         class_stmt
             .bases()
             .iter()
-            .map(
-                |base_node| match definition_expression_type(db, class_definition, base_node) {
-                    Type::KnownInstance(KnownInstanceType::SubscriptedGeneric(generic_context)) => {
-                        Type::KnownInstance(KnownInstanceType::SubscriptedGeneric(
-                            generic_context.with_binding_context(db, class_definition),
-                        ))
-                    }
-                    Type::KnownInstance(KnownInstanceType::SubscriptedProtocol(
-                        generic_context,
-                    )) => Type::KnownInstance(KnownInstanceType::SubscriptedProtocol(
-                        generic_context.with_binding_context(db, class_definition),
-                    )),
-                    ty => ty,
-                },
-            )
+            .map(|base_node| definition_expression_type(db, class_definition, base_node))
             .collect()
     }
 

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -76,9 +76,9 @@ use crate::types::narrow::ClassInfoConstraintFunction;
 use crate::types::signatures::{CallableSignature, Signature};
 use crate::types::visitor::any_over_type;
 use crate::types::{
-    BoundMethodType, CallableType, ClassBase, ClassLiteral, ClassType, DeprecatedInstance,
-    DynamicType, KnownClass, Truthiness, Type, TypeMapping, TypeRelation, TypeTransformer,
-    TypeVarInstance, UnionBuilder, all_members, walk_type_mapping,
+    BoundMethodType, BoundTypeVarInstance, CallableType, ClassBase, ClassLiteral, ClassType,
+    DeprecatedInstance, DynamicType, KnownClass, Truthiness, Type, TypeMapping, TypeRelation,
+    TypeTransformer, UnionBuilder, all_members, walk_type_mapping,
 };
 use crate::{Db, FxOrderSet, ModuleName, resolve_module};
 
@@ -862,7 +862,7 @@ impl<'db> FunctionType<'db> {
         self,
         db: &'db dyn Db,
         binding_context: Option<Definition<'db>>,
-        typevars: &mut FxOrderSet<TypeVarInstance<'db>>,
+        typevars: &mut FxOrderSet<BoundTypeVarInstance<'db>>,
     ) {
         let signatures = self.signature(db);
         for signature in &signatures.overloads {

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -861,11 +861,12 @@ impl<'db> FunctionType<'db> {
     pub(crate) fn find_legacy_typevars(
         self,
         db: &'db dyn Db,
+        binding_context: Option<Definition<'db>>,
         typevars: &mut FxOrderSet<TypeVarInstance<'db>>,
     ) {
         let signatures = self.signature(db);
         for signature in &signatures.overloads {
-            signature.find_legacy_typevars(db, typevars);
+            signature.find_legacy_typevars(db, binding_context, typevars);
         }
     }
 

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -338,7 +338,7 @@ impl<'db> OverloadLiteral<'db> {
         let definition = self.definition(db);
         let generic_context = function_stmt_node.type_params.as_ref().map(|type_params| {
             let index = semantic_index(db, scope.file(db));
-            GenericContext::from_type_params(db, index, type_params)
+            GenericContext::from_type_params(db, index, definition, type_params)
         });
 
         let index = semantic_index(db, scope.file(db));

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -194,19 +194,6 @@ impl<'db> GenericContext<'db> {
         Some(Self::new(db, variables))
     }
 
-    pub(crate) fn with_binding_context(
-        self,
-        db: &'db dyn Db,
-        binding_context: Definition<'db>,
-    ) -> Self {
-        let variables: FxOrderSet<_> = self
-            .variables(db)
-            .iter()
-            .map(|typevar| typevar.with_binding_context(db, binding_context))
-            .collect();
-        Self::new(db, variables)
-    }
-
     pub(crate) fn len(self, db: &'db dyn Db) -> usize {
         self.variables(db).len()
     }

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -114,11 +114,14 @@ impl<'db> GenericContext<'db> {
     pub(crate) fn from_type_params(
         db: &'db dyn Db,
         index: &'db SemanticIndex<'db>,
+        binding_context: Definition<'db>,
         type_params_node: &ast::TypeParams,
     ) -> Self {
         let variables: FxOrderSet<_> = type_params_node
             .iter()
-            .filter_map(|type_param| Self::variable_from_type_param(db, index, type_param))
+            .filter_map(|type_param| {
+                Self::variable_from_type_param(db, index, binding_context, type_param)
+            })
             .collect();
         Self::new(db, variables)
     }
@@ -126,6 +129,7 @@ impl<'db> GenericContext<'db> {
     fn variable_from_type_param(
         db: &'db dyn Db,
         index: &'db SemanticIndex<'db>,
+        binding_context: Definition<'db>,
         type_param_node: &ast::TypeParam,
     ) -> Option<TypeVarInstance<'db>> {
         match type_param_node {
@@ -136,7 +140,7 @@ impl<'db> GenericContext<'db> {
                 else {
                     return None;
                 };
-                Some(typevar)
+                Some(typevar.with_binding_context(db, binding_context))
             }
             // TODO: Support these!
             ast::TypeParam::ParamSpec(_) => None,

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -31,12 +31,14 @@ fn enclosing_generic_contexts<'db>(
         .ancestor_scopes(scope)
         .filter_map(|(_, ancestor_scope)| match ancestor_scope.node() {
             NodeWithScopeKind::Class(class) => {
-                binding_type(db, index.expect_single_definition(class.node(module)))
+                let definition = index.expect_single_definition(class.node(module));
+                binding_type(db, definition)
                     .into_class_literal()?
                     .generic_context(db)
             }
             NodeWithScopeKind::Function(function) => {
-                infer_definition_types(db, index.expect_single_definition(function.node(module)))
+                let definition = index.expect_single_definition(function.node(module));
+                infer_definition_types(db, definition)
                     .undecorated_type()
                     .expect("function should have undecorated type")
                     .into_function_literal()?
@@ -50,33 +52,33 @@ fn enclosing_generic_contexts<'db>(
         })
 }
 
-/// Binds an unbound legacy typevar.
+/// Binds an unbound typevar.
 ///
-/// When a legacy typevar is first created, we will have a [`TypeVarInstance`] which does not have
-/// an associated binding context. When the typevar is used in a generic class or function, we
-/// "bind" it, adding the [`Definition`] of the generic class or function as its "binding context".
+/// When a typevar is first created, we will have a [`TypeVarInstance`] which does not have an
+/// associated binding context. When the typevar is used in a generic class or function, we "bind"
+/// it, adding the [`Definition`] of the generic class or function as its "binding context".
 ///
-/// When an expression resolves to a legacy typevar, our inferred type will refer to the unbound
+/// When an expression resolves to a typevar, our inferred type will refer to the unbound
 /// [`TypeVarInstance`] from when the typevar was first created. This function walks the scopes
 /// that enclosing the expression, looking for the innermost binding context that binds the
 /// typevar.
 ///
 /// If no enclosing scope has already bound the typevar, we might be in a syntactic position that
-/// is about to bind it (indicated by a non-`None` `legacy_typevar_binding_context`), in which case
-/// we bind the typevar with that new binding context.
-pub(crate) fn bind_legacy_typevar<'db>(
+/// is about to bind it (indicated by a non-`None` `typevar_binding_context`), in which case we
+/// bind the typevar with that new binding context.
+pub(crate) fn bind_typevar<'db>(
     db: &'db dyn Db,
     module: &ParsedModuleRef,
     index: &SemanticIndex<'db>,
     containing_scope: FileScopeId,
-    legacy_typevar_binding_context: Option<Definition<'db>>,
+    typevar_binding_context: Option<Definition<'db>>,
     typevar: TypeVarInstance<'db>,
 ) -> Option<TypeVarInstance<'db>> {
     enclosing_generic_contexts(db, module, index, containing_scope)
-        .find_map(|enclosing_context| enclosing_context.binds_legacy_typevar(db, typevar))
+        .find_map(|enclosing_context| enclosing_context.binds_typevar(db, typevar))
         .or_else(|| {
-            legacy_typevar_binding_context.map(|legacy_typevar_binding_context| {
-                typevar.with_binding_context(db, legacy_typevar_binding_context)
+            typevar_binding_context.map(|typevar_binding_context| {
+                typevar.with_binding_context(db, typevar_binding_context)
             })
         })
 }
@@ -271,19 +273,15 @@ impl<'db> GenericContext<'db> {
         self.variables(db).is_subset(other.variables(db))
     }
 
-    pub(crate) fn binds_legacy_typevar(
+    pub(crate) fn binds_typevar(
         self,
         db: &'db dyn Db,
         typevar: TypeVarInstance<'db>,
     ) -> Option<TypeVarInstance<'db>> {
-        assert!(typevar.is_legacy(db) || typevar.is_implicit(db));
         let typevar_def = typevar.definition(db);
         self.variables(db)
             .iter()
-            .find(|self_typevar| {
-                (self_typevar.is_legacy(db) || self_typevar.is_implicit(db))
-                    && self_typevar.definition(db) == typevar_def
-            })
+            .find(|self_typevar| self_typevar.definition(db) == typevar_def)
             .copied()
     }
 

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -110,7 +110,7 @@ use crate::types::enums::is_enum_class;
 use crate::types::function::{
     FunctionDecorators, FunctionLiteral, FunctionType, KnownFunction, OverloadLiteral,
 };
-use crate::types::generics::{GenericContext, bind_legacy_typevar};
+use crate::types::generics::GenericContext;
 use crate::types::mro::MroErrorKind;
 use crate::types::signatures::{CallableSignature, Signature};
 use crate::types::tuple::{TupleSpec, TupleType};
@@ -816,8 +816,8 @@ pub(super) struct TypeInferenceBuilder<'db, 'ast> {
     /// [`check_overloaded_functions`]: TypeInferenceBuilder::check_overloaded_functions
     called_functions: FxHashSet<FunctionType<'db>>,
 
-    /// Whether we are in a context that binds unbound legacy typevars.
-    legacy_typevar_binding_context: Option<Definition<'db>>,
+    /// Whether we are in a context that binds unbound typevars.
+    typevar_binding_context: Option<Definition<'db>>,
 
     /// The deferred state of inferring types of certain expressions within the region.
     ///
@@ -866,7 +866,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             expressions: FxHashMap::default(),
             bindings: VecMap::default(),
             declarations: VecMap::default(),
-            legacy_typevar_binding_context: None,
+            typevar_binding_context: None,
             deferred: VecSet::default(),
             undecorated_type: None,
             cycle_fallback: false,
@@ -1024,13 +1024,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             NodeWithScopeKind::Lambda(lambda) => self.infer_lambda_body(lambda.node(self.module())),
             NodeWithScopeKind::Class(class) => self.infer_class_body(class.node(self.module())),
             NodeWithScopeKind::ClassTypeParameters(class) => {
-                self.infer_class_type_params(class.node(self.module()));
+                self.infer_class_type_params(class.node(self.module()), scope);
             }
             NodeWithScopeKind::FunctionTypeParameters(function) => {
-                self.infer_function_type_params(function.node(self.module()));
+                self.infer_function_type_params(function.node(self.module()), scope);
             }
             NodeWithScopeKind::TypeAliasTypeParameters(type_alias) => {
-                self.infer_type_alias_type_params(type_alias.node(self.module()));
+                self.infer_type_alias_type_params(type_alias.node(self.module()), scope);
             }
             NodeWithScopeKind::TypeAlias(type_alias) => {
                 self.infer_type_alias(type_alias.node(self.module()));
@@ -2236,18 +2236,32 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         self.infer_body(&module.body);
     }
 
-    fn infer_class_type_params(&mut self, class: &ast::StmtClassDef) {
+    fn infer_class_type_params(&mut self, class: &ast::StmtClassDef, scope: ScopeId) {
         let type_params = class
             .type_params
             .as_deref()
             .expect("class type params scope without type params");
 
+        // Find the binding context for the PEP 695 typevars defined in this scope. The typevar
+        // scope should have a child containing the appropriate definition. Find that scope and use
+        // its definition as the binding context.
+        let child_scopes = self.index.child_scopes(scope.file_scope_id(self.db()));
+        let binding_context = child_scopes
+            .filter_map(|(_, binding_scope)| match binding_scope.node() {
+                NodeWithScopeKind::Class(class) => {
+                    Some(DefinitionNodeKey::from(class.node(self.context.module())))
+                }
+                _ => None,
+            })
+            .map(|key| self.index.expect_single_definition(key))
+            .next();
+
+        let previous_typevar_binding_context =
+            std::mem::replace(&mut self.typevar_binding_context, binding_context);
+
         self.infer_type_parameters(type_params);
 
         if let Some(arguments) = class.arguments.as_deref() {
-            // Note: We do not install a new `legacy_typevar_binding_context`; since this class has
-            // PEP 695 typevars, it should not also bind any legacy typevars via inheriting from
-            // `typing.Generic` or `typing.Protocol`.
             let mut call_arguments =
                 CallArguments::from_arguments(self.db(), arguments, |argument, splatted_value| {
                     let ty = self.infer_expression(splatted_value);
@@ -2257,36 +2271,69 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             let argument_forms = vec![Some(ParameterForm::Value); call_arguments.len()];
             self.infer_argument_types(arguments, &mut call_arguments, &argument_forms);
         }
+
+        self.typevar_binding_context = previous_typevar_binding_context;
     }
 
     fn infer_class_body(&mut self, class: &ast::StmtClassDef) {
         self.infer_body(&class.body);
     }
 
-    fn infer_function_type_params(&mut self, function: &ast::StmtFunctionDef) {
+    fn infer_function_type_params(&mut self, function: &ast::StmtFunctionDef, scope: ScopeId) {
         let type_params = function
             .type_params
             .as_deref()
             .expect("function type params scope without type params");
 
-        // Note: We do not install a new `legacy_typevar_binding_context`; since this function has
-        // PEP 695 typevars, it should not also bind any legacy typevars by referencing them in its
-        // parameter or return type annotations.
+        // Find the binding context for the PEP 695 typevars defined in this scope. The typevar
+        // scope should have a child containing the appropriate definition. Find that scope and use
+        // its definition as the binding context.
+        let child_scopes = self.index.child_scopes(scope.file_scope_id(self.db()));
+        let binding_context = child_scopes
+            .filter_map(|(_, binding_scope)| match binding_scope.node() {
+                NodeWithScopeKind::Function(function) => Some(DefinitionNodeKey::from(
+                    function.node(self.context.module()),
+                )),
+                _ => None,
+            })
+            .map(|key| self.index.expect_single_definition(key))
+            .next();
+
+        let previous_typevar_binding_context =
+            std::mem::replace(&mut self.typevar_binding_context, binding_context);
         self.infer_return_type_annotation(
             function.returns.as_deref(),
             DeferredExpressionState::None,
         );
         self.infer_type_parameters(type_params);
         self.infer_parameters(&function.parameters);
+        self.typevar_binding_context = previous_typevar_binding_context;
     }
 
-    fn infer_type_alias_type_params(&mut self, type_alias: &ast::StmtTypeAlias) {
+    fn infer_type_alias_type_params(&mut self, type_alias: &ast::StmtTypeAlias, scope: ScopeId) {
         let type_params = type_alias
             .type_params
             .as_ref()
             .expect("type alias type params scope without type params");
 
+        // Find the binding context for the PEP 695 typevars defined in this scope. The typevar
+        // scope should have a child containing the appropriate definition. Find that scope and use
+        // its definition as the binding context.
+        let child_scopes = self.index.child_scopes(scope.file_scope_id(self.db()));
+        let binding_context = child_scopes
+            .filter_map(|(_, binding_scope)| match binding_scope.node() {
+                NodeWithScopeKind::TypeAlias(alias) => {
+                    Some(DefinitionNodeKey::from(alias.node(self.context.module())))
+                }
+                _ => None,
+            })
+            .map(|key| self.index.expect_single_definition(key))
+            .next();
+
+        let previous_typevar_binding_context =
+            std::mem::replace(&mut self.typevar_binding_context, binding_context);
         self.infer_type_parameters(type_params);
+        self.typevar_binding_context = previous_typevar_binding_context;
     }
 
     fn infer_type_alias(&mut self, type_alias: &ast::StmtTypeAlias) {
@@ -2634,14 +2681,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             if self.defer_annotations() {
                 self.deferred.insert(definition);
             } else {
-                let previous_legacy_typevar_binding_context =
-                    self.legacy_typevar_binding_context.replace(definition);
+                let previous_typevar_binding_context =
+                    self.typevar_binding_context.replace(definition);
                 self.infer_return_type_annotation(
                     returns.as_deref(),
                     DeferredExpressionState::None,
                 );
                 self.infer_parameters(parameters);
-                self.legacy_typevar_binding_context = previous_legacy_typevar_binding_context;
+                self.typevar_binding_context = previous_typevar_binding_context;
             }
         }
 
@@ -3054,12 +3101,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             if self.in_stub() || class_node.bases().iter().any(contains_string_literal) {
                 self.deferred.insert(definition);
             } else {
-                let previous_legacy_typevar_binding_context =
-                    self.legacy_typevar_binding_context.replace(definition);
+                let previous_typevar_binding_context =
+                    self.typevar_binding_context.replace(definition);
                 for base in class_node.bases() {
                     self.infer_expression(base);
                 }
-                self.legacy_typevar_binding_context = previous_legacy_typevar_binding_context;
+                self.typevar_binding_context = previous_typevar_binding_context;
             }
         }
     }
@@ -3069,23 +3116,21 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         definition: Definition<'db>,
         function: &ast::StmtFunctionDef,
     ) {
-        let previous_legacy_typevar_binding_context =
-            self.legacy_typevar_binding_context.replace(definition);
+        let previous_typevar_binding_context = self.typevar_binding_context.replace(definition);
         self.infer_return_type_annotation(
             function.returns.as_deref(),
             DeferredExpressionState::Deferred,
         );
         self.infer_parameters(function.parameters.as_ref());
-        self.legacy_typevar_binding_context = previous_legacy_typevar_binding_context;
+        self.typevar_binding_context = previous_typevar_binding_context;
     }
 
     fn infer_class_deferred(&mut self, definition: Definition<'db>, class: &ast::StmtClassDef) {
-        let previous_legacy_typevar_binding_context =
-            self.legacy_typevar_binding_context.replace(definition);
+        let previous_typevar_binding_context = self.typevar_binding_context.replace(definition);
         for base in class.bases() {
             self.infer_expression(base);
         }
-        self.legacy_typevar_binding_context = previous_legacy_typevar_binding_context;
+        self.typevar_binding_context = previous_typevar_binding_context;
     }
 
     fn infer_type_alias_definition(
@@ -3394,27 +3439,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             default,
         } = node;
 
-        // Find the binding context for the PEP 695 typevars defined in this scope. The typevar
-        // scope should have a child containing the class, function, or type alias definition. Find
-        // that scope and use its definition as the binding context.
-        let typevar_scope = definition.file_scope(self.db());
-        let child_scopes = self.index.child_scopes(typevar_scope);
-        let binding_context = child_scopes
-            .filter_map(|(_, binding_scope)| match binding_scope.node() {
-                NodeWithScopeKind::Class(class) => {
-                    Some(DefinitionNodeKey::from(class.node(self.context.module())))
-                }
-                NodeWithScopeKind::Function(function) => Some(DefinitionNodeKey::from(
-                    function.node(self.context.module()),
-                )),
-                NodeWithScopeKind::TypeAlias(alias) => {
-                    Some(DefinitionNodeKey::from(alias.node(self.context.module())))
-                }
-                _ => None,
-            })
-            .map(|key| self.index.expect_single_definition(key))
-            .next();
-
         let bound_or_constraint = match bound.as_deref() {
             Some(expr @ ast::Expr::Tuple(ast::ExprTuple { elts, .. })) => {
                 if elts.len() < 2 {
@@ -3459,7 +3483,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             self.db(),
             &name.id,
             Some(definition),
-            binding_context,
+            None,
             bound_or_constraint,
             TypeVarVariance::Invariant, // TODO: infer this
             default_ty,
@@ -6439,43 +6463,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             self.infer_place_load(PlaceExprRef::from(&expr), ast::ExprRef::Name(name_node));
 
         resolved
-            .map_type(|ty| match ty {
-                // If the expression resolves to a legacy typevar, we will have the TypeVarInstance
-                // that was created when the typevar was created, which will not have an associated
-                // binding context. If this expression appears inside of a generic context that
-                // binds that typevar, we need to update the TypeVarInstance to include that
-                // binding context. To do that, we walk the enclosing scopes, looking for the
-                // nearest generic context that binds the typevar.
-                //
-                // If the legacy typevar is still unbound after that search, and we are in a
-                // context that binds unbound legacy typevars (i.e., the signature of a generic
-                // function), bind it with that context.
-                Type::TypeVar(typevar) if typevar.is_legacy(self.db()) => bind_legacy_typevar(
-                    self.db(),
-                    self.context.module(),
-                    self.index,
-                    self.scope().file_scope_id(self.db()),
-                    self.legacy_typevar_binding_context,
-                    typevar,
-                )
-                .map(Type::TypeVar)
-                .unwrap_or(ty),
-                Type::KnownInstance(KnownInstanceType::TypeVar(typevar))
-                    if typevar.is_legacy(self.db()) =>
-                {
-                    bind_legacy_typevar(
-                        self.db(),
-                        self.context.module(),
-                        self.index,
-                        self.scope().file_scope_id(self.db()),
-                        self.legacy_typevar_binding_context,
-                        typevar,
-                    )
-                    .map(|typevar| Type::KnownInstance(KnownInstanceType::TypeVar(typevar)))
-                    .unwrap_or(ty)
-                }
-                _ => ty,
-            })
             // Not found in the module's explicitly declared global symbols?
             // Check the "implicit globals" such as `__doc__`, `__file__`, `__name__`, etc.
             // These are looked up as attributes on `types.ModuleType`.
@@ -9137,7 +9124,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             undecorated_type: _,
 
             // builder only state
-            legacy_typevar_binding_context: _,
+            typevar_binding_context: _,
             deferred_state: _,
             called_functions: _,
             index: _,
@@ -9198,7 +9185,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             undecorated_type,
 
             // builder only state
-            legacy_typevar_binding_context: _,
+            typevar_binding_context: _,
             deferred_state: _,
             called_functions: _,
             index: _,
@@ -9268,7 +9255,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             undecorated_type: _,
 
             // Builder only state
-            legacy_typevar_binding_context: _,
+            typevar_binding_context: _,
             deferred_state: _,
             called_functions: _,
             index: _,
@@ -9377,7 +9364,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             .in_type_expression(
                                 self.db(),
                                 self.scope(),
-                                self.legacy_typevar_binding_context,
+                                self.typevar_binding_context,
                             )
                             .unwrap_or_else(|error| {
                                 error.into_fallback_type(
@@ -9597,11 +9584,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             ast::Expr::Name(name) => match name.ctx {
                 ast::ExprContext::Load => self
                     .infer_name_expression(name)
-                    .in_type_expression(
-                        self.db(),
-                        self.scope(),
-                        self.legacy_typevar_binding_context,
-                    )
+                    .in_type_expression(self.db(), self.scope(), self.typevar_binding_context)
                     .unwrap_or_else(|error| {
                         error.into_fallback_type(
                             &self.context,
@@ -9618,11 +9601,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             ast::Expr::Attribute(attribute_expression) => match attribute_expression.ctx {
                 ast::ExprContext::Load => self
                     .infer_attribute_expression(attribute_expression)
-                    .in_type_expression(
-                        self.db(),
-                        self.scope(),
-                        self.legacy_typevar_binding_context,
-                    )
+                    .in_type_expression(self.db(), self.scope(), self.typevar_binding_context)
                     .unwrap_or_else(|error| {
                         error.into_fallback_type(
                             &self.context,
@@ -10311,7 +10290,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             .in_type_expression(
                                 self.db(),
                                 self.scope(),
-                                self.legacy_typevar_binding_context,
+                                self.typevar_binding_context,
                             )
                             .unwrap_or(Type::unknown())
                     }

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -9026,18 +9026,15 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let typevars: Result<FxOrderSet<_>, GenericContextError> = typevars
             .iter()
             .map(|typevar| match typevar {
-                Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) => {
-                    let typevar = bind_typevar(
-                        self.db(),
-                        self.module(),
-                        self.index,
-                        self.scope().file_scope_id(self.db()),
-                        self.typevar_binding_context,
-                        *typevar,
-                    )
-                    .unwrap_or(*typevar);
-                    Ok(typevar)
-                }
+                Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) => bind_typevar(
+                    self.db(),
+                    self.module(),
+                    self.index,
+                    self.scope().file_scope_id(self.db()),
+                    self.typevar_binding_context,
+                    *typevar,
+                )
+                .ok_or(GenericContextError::InvalidArgument),
                 Type::Dynamic(DynamicType::TodoUnpack) => Err(GenericContextError::NotYetSupported),
                 Type::NominalInstance(NominalInstanceType { class, .. })
                     if matches!(

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -3483,7 +3483,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             self.db(),
             &name.id,
             Some(definition),
-            None,
             bound_or_constraint,
             TypeVarVariance::Invariant, // TODO: infer this
             default_ty,

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -3,16 +3,14 @@
 use std::marker::PhantomData;
 
 use super::protocol_class::ProtocolInterface;
-use super::{ClassType, KnownClass, SubclassOfType, Type, TypeVarVariance};
+use super::{BoundTypeVarInstance, ClassType, KnownClass, SubclassOfType, Type, TypeVarVariance};
 use crate::place::PlaceAndQualifiers;
 use crate::semantic_index::definition::Definition;
 use crate::types::cyclic::PairVisitor;
 use crate::types::enums::is_single_member_enum;
 use crate::types::protocol_class::walk_protocol_interface;
 use crate::types::tuple::TupleType;
-use crate::types::{
-    DynamicType, TypeMapping, TypeRelation, TypeTransformer, TypeVarInstance, TypedDictType,
-};
+use crate::types::{DynamicType, TypeMapping, TypeRelation, TypeTransformer, TypedDictType};
 use crate::{Db, FxOrderSet};
 
 pub(super) use synthesized_protocol::SynthesizedProtocolType;
@@ -163,7 +161,7 @@ impl<'db> NominalInstanceType<'db> {
         self,
         db: &'db dyn Db,
         binding_context: Option<Definition<'db>>,
-        typevars: &mut FxOrderSet<TypeVarInstance<'db>>,
+        typevars: &mut FxOrderSet<BoundTypeVarInstance<'db>>,
     ) {
         self.class
             .find_legacy_typevars(db, binding_context, typevars);
@@ -346,7 +344,7 @@ impl<'db> ProtocolInstanceType<'db> {
         self,
         db: &'db dyn Db,
         binding_context: Option<Definition<'db>>,
-        typevars: &mut FxOrderSet<TypeVarInstance<'db>>,
+        typevars: &mut FxOrderSet<BoundTypeVarInstance<'db>>,
     ) {
         match self.inner {
             Protocol::FromClass(class) => {
@@ -391,7 +389,7 @@ impl<'db> Protocol<'db> {
 mod synthesized_protocol {
     use crate::semantic_index::definition::Definition;
     use crate::types::protocol_class::ProtocolInterface;
-    use crate::types::{TypeMapping, TypeTransformer, TypeVarInstance, TypeVarVariance};
+    use crate::types::{BoundTypeVarInstance, TypeMapping, TypeTransformer, TypeVarVariance};
     use crate::{Db, FxOrderSet};
 
     /// A "synthesized" protocol type that is dissociated from a class definition in source code.
@@ -433,7 +431,7 @@ mod synthesized_protocol {
             self,
             db: &'db dyn Db,
             binding_context: Option<Definition<'db>>,
-            typevars: &mut FxOrderSet<TypeVarInstance<'db>>,
+            typevars: &mut FxOrderSet<BoundTypeVarInstance<'db>>,
         ) {
             self.0.find_legacy_typevars(db, binding_context, typevars);
         }

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -222,7 +222,7 @@ impl ClassInfoConstraintFunction {
             Type::Union(union) => {
                 union.try_map(db, |element| self.generate_constraint(db, *element))
             }
-            Type::TypeVar(type_var) => match type_var.bound_or_constraints(db)? {
+            Type::TypeVar(bound_typevar) => match bound_typevar.typevar.bound_or_constraints(db)? {
                 TypeVarBoundOrConstraints::UpperBound(bound) => self.generate_constraint(db, bound),
                 TypeVarBoundOrConstraints::Constraints(constraints) => {
                     self.generate_constraint(db, Type::Union(constraints))

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -12,8 +12,9 @@ use crate::{
     place::{Boundness, Place, PlaceAndQualifiers, place_from_bindings, place_from_declarations},
     semantic_index::{definition::Definition, use_def_map},
     types::{
-        CallableType, ClassBase, ClassLiteral, KnownFunction, PropertyInstanceType, Signature,
-        Type, TypeMapping, TypeQualifiers, TypeRelation, TypeTransformer, TypeVarInstance,
+        BoundTypeVarInstance, CallableType, ClassBase, ClassLiteral, KnownFunction,
+        PropertyInstanceType, Signature, Type, TypeMapping, TypeQualifiers, TypeRelation,
+        TypeTransformer,
         cyclic::PairVisitor,
         signatures::{Parameter, Parameters},
     },
@@ -211,7 +212,7 @@ impl<'db> ProtocolInterface<'db> {
         self,
         db: &'db dyn Db,
         binding_context: Option<Definition<'db>>,
-        typevars: &mut FxOrderSet<TypeVarInstance<'db>>,
+        typevars: &mut FxOrderSet<BoundTypeVarInstance<'db>>,
     ) {
         for data in self.inner(db).values() {
             data.find_legacy_typevars(db, binding_context, typevars);
@@ -273,7 +274,7 @@ impl<'db> ProtocolMemberData<'db> {
         &self,
         db: &'db dyn Db,
         binding_context: Option<Definition<'db>>,
-        typevars: &mut FxOrderSet<TypeVarInstance<'db>>,
+        typevars: &mut FxOrderSet<BoundTypeVarInstance<'db>>,
     ) {
         self.kind
             .find_legacy_typevars(db, binding_context, typevars);
@@ -362,7 +363,7 @@ impl<'db> ProtocolMemberKind<'db> {
         &self,
         db: &'db dyn Db,
         binding_context: Option<Definition<'db>>,
-        typevars: &mut FxOrderSet<TypeVarInstance<'db>>,
+        typevars: &mut FxOrderSet<BoundTypeVarInstance<'db>>,
     ) {
         match self {
             ProtocolMemberKind::Method(callable) => {

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -88,10 +88,11 @@ impl<'db> CallableSignature<'db> {
     pub(crate) fn find_legacy_typevars(
         &self,
         db: &'db dyn Db,
+        binding_context: Option<Definition<'db>>,
         typevars: &mut FxOrderSet<TypeVarInstance<'db>>,
     ) {
         for signature in &self.overloads {
-            signature.find_legacy_typevars(db, typevars);
+            signature.find_legacy_typevars(db, binding_context, typevars);
         }
     }
 
@@ -428,18 +429,19 @@ impl<'db> Signature<'db> {
     pub(crate) fn find_legacy_typevars(
         &self,
         db: &'db dyn Db,
+        binding_context: Option<Definition<'db>>,
         typevars: &mut FxOrderSet<TypeVarInstance<'db>>,
     ) {
         for param in &self.parameters {
             if let Some(ty) = param.annotated_type() {
-                ty.find_legacy_typevars(db, typevars);
+                ty.find_legacy_typevars(db, binding_context, typevars);
             }
             if let Some(ty) = param.default_type() {
-                ty.find_legacy_typevars(db, typevars);
+                ty.find_legacy_typevars(db, binding_context, typevars);
             }
         }
         if let Some(ty) = self.return_ty {
-            ty.find_legacy_typevars(db, typevars);
+            ty.find_legacy_typevars(db, binding_context, typevars);
         }
     }
 

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -18,7 +18,7 @@ use smallvec::{SmallVec, smallvec_inline};
 use super::{DynamicType, Type, TypeTransformer, TypeVarVariance, definition_expression_type};
 use crate::semantic_index::definition::Definition;
 use crate::types::generics::{GenericContext, walk_generic_context};
-use crate::types::{KnownClass, TypeMapping, TypeRelation, TypeVarInstance, todo_type};
+use crate::types::{BoundTypeVarInstance, KnownClass, TypeMapping, TypeRelation, todo_type};
 use crate::{Db, FxOrderSet};
 use ruff_python_ast::{self as ast, name::Name};
 
@@ -89,7 +89,7 @@ impl<'db> CallableSignature<'db> {
         &self,
         db: &'db dyn Db,
         binding_context: Option<Definition<'db>>,
-        typevars: &mut FxOrderSet<TypeVarInstance<'db>>,
+        typevars: &mut FxOrderSet<BoundTypeVarInstance<'db>>,
     ) {
         for signature in &self.overloads {
             signature.find_legacy_typevars(db, binding_context, typevars);
@@ -430,7 +430,7 @@ impl<'db> Signature<'db> {
         &self,
         db: &'db dyn Db,
         binding_context: Option<Definition<'db>>,
-        typevars: &mut FxOrderSet<TypeVarInstance<'db>>,
+        typevars: &mut FxOrderSet<BoundTypeVarInstance<'db>>,
     ) {
         for param in &self.parameters {
             if let Some(ty) = param.annotated_type() {

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -1,6 +1,7 @@
 use ruff_python_ast::name::Name;
 
 use crate::place::PlaceAndQualifiers;
+use crate::semantic_index::definition::Definition;
 use crate::types::{
     ClassType, DynamicType, KnownClass, MemberLookupPolicy, Type, TypeMapping, TypeRelation,
     TypeTransformer, TypeVarInstance,
@@ -124,11 +125,12 @@ impl<'db> SubclassOfType<'db> {
     pub(super) fn find_legacy_typevars(
         self,
         db: &'db dyn Db,
+        binding_context: Option<Definition<'db>>,
         typevars: &mut FxOrderSet<TypeVarInstance<'db>>,
     ) {
         match self.subclass_of {
             SubclassOfInner::Class(class) => {
-                class.find_legacy_typevars(db, typevars);
+                class.find_legacy_typevars(db, binding_context, typevars);
             }
             SubclassOfInner::Dynamic(_) => {}
         }

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -22,6 +22,7 @@ use std::hash::Hash;
 
 use itertools::{Either, EitherOrBoth, Itertools};
 
+use crate::semantic_index::definition::Definition;
 use crate::types::class::{ClassType, KnownClass};
 use crate::types::{SubclassOfType, Truthiness};
 use crate::types::{
@@ -270,9 +271,11 @@ impl<'db> TupleType<'db> {
     pub(crate) fn find_legacy_typevars(
         self,
         db: &'db dyn Db,
+        binding_context: Option<Definition<'db>>,
         typevars: &mut FxOrderSet<TypeVarInstance<'db>>,
     ) {
-        self.tuple(db).find_legacy_typevars(db, typevars);
+        self.tuple(db)
+            .find_legacy_typevars(db, binding_context, typevars);
     }
 
     pub(crate) fn has_relation_to(
@@ -433,10 +436,11 @@ impl<'db> FixedLengthTuple<Type<'db>> {
     fn find_legacy_typevars(
         &self,
         db: &'db dyn Db,
+        binding_context: Option<Definition<'db>>,
         typevars: &mut FxOrderSet<TypeVarInstance<'db>>,
     ) {
         for ty in &self.0 {
-            ty.find_legacy_typevars(db, typevars);
+            ty.find_legacy_typevars(db, binding_context, typevars);
         }
     }
 
@@ -771,14 +775,16 @@ impl<'db> VariableLengthTuple<Type<'db>> {
     fn find_legacy_typevars(
         &self,
         db: &'db dyn Db,
+        binding_context: Option<Definition<'db>>,
         typevars: &mut FxOrderSet<TypeVarInstance<'db>>,
     ) {
         for ty in &self.prefix {
-            ty.find_legacy_typevars(db, typevars);
+            ty.find_legacy_typevars(db, binding_context, typevars);
         }
-        self.variable.find_legacy_typevars(db, typevars);
+        self.variable
+            .find_legacy_typevars(db, binding_context, typevars);
         for ty in &self.suffix {
-            ty.find_legacy_typevars(db, typevars);
+            ty.find_legacy_typevars(db, binding_context, typevars);
         }
     }
 
@@ -1118,11 +1124,12 @@ impl<'db> Tuple<Type<'db>> {
     fn find_legacy_typevars(
         &self,
         db: &'db dyn Db,
+        binding_context: Option<Definition<'db>>,
         typevars: &mut FxOrderSet<TypeVarInstance<'db>>,
     ) {
         match self {
-            Tuple::Fixed(tuple) => tuple.find_legacy_typevars(db, typevars),
-            Tuple::Variable(tuple) => tuple.find_legacy_typevars(db, typevars),
+            Tuple::Fixed(tuple) => tuple.find_legacy_typevars(db, binding_context, typevars),
+            Tuple::Variable(tuple) => tuple.find_legacy_typevars(db, binding_context, typevars),
         }
     }
 

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -24,11 +24,11 @@ use itertools::{Either, EitherOrBoth, Itertools};
 
 use crate::semantic_index::definition::Definition;
 use crate::types::class::{ClassType, KnownClass};
-use crate::types::{SubclassOfType, Truthiness};
 use crate::types::{
-    Type, TypeMapping, TypeRelation, TypeTransformer, TypeVarInstance, TypeVarVariance,
+    BoundTypeVarInstance, Type, TypeMapping, TypeRelation, TypeTransformer, TypeVarVariance,
     UnionBuilder, UnionType, cyclic::PairVisitor,
 };
+use crate::types::{SubclassOfType, Truthiness};
 use crate::util::subscript::{Nth, OutOfBoundsError, PyIndex, PySlice, StepSizeZeroError};
 use crate::{Db, FxOrderSet};
 
@@ -272,7 +272,7 @@ impl<'db> TupleType<'db> {
         self,
         db: &'db dyn Db,
         binding_context: Option<Definition<'db>>,
-        typevars: &mut FxOrderSet<TypeVarInstance<'db>>,
+        typevars: &mut FxOrderSet<BoundTypeVarInstance<'db>>,
     ) {
         self.tuple(db)
             .find_legacy_typevars(db, binding_context, typevars);
@@ -437,7 +437,7 @@ impl<'db> FixedLengthTuple<Type<'db>> {
         &self,
         db: &'db dyn Db,
         binding_context: Option<Definition<'db>>,
-        typevars: &mut FxOrderSet<TypeVarInstance<'db>>,
+        typevars: &mut FxOrderSet<BoundTypeVarInstance<'db>>,
     ) {
         for ty in &self.0 {
             ty.find_legacy_typevars(db, binding_context, typevars);
@@ -776,7 +776,7 @@ impl<'db> VariableLengthTuple<Type<'db>> {
         &self,
         db: &'db dyn Db,
         binding_context: Option<Definition<'db>>,
-        typevars: &mut FxOrderSet<TypeVarInstance<'db>>,
+        typevars: &mut FxOrderSet<BoundTypeVarInstance<'db>>,
     ) {
         for ty in &self.prefix {
             ty.find_legacy_typevars(db, binding_context, typevars);
@@ -1125,7 +1125,7 @@ impl<'db> Tuple<Type<'db>> {
         &self,
         db: &'db dyn Db,
         binding_context: Option<Definition<'db>>,
-        typevars: &mut FxOrderSet<TypeVarInstance<'db>>,
+        typevars: &mut FxOrderSet<BoundTypeVarInstance<'db>>,
     ) {
         match self {
             Tuple::Fixed(tuple) => tuple.find_legacy_typevars(db, binding_context, typevars),

--- a/crates/ty_python_semantic/src/types/visitor.rs
+++ b/crates/ty_python_semantic/src/types/visitor.rs
@@ -242,7 +242,7 @@ fn walk_non_atomic_type<'db, V: TypeVisitor<'db> + ?Sized>(
         }
         NonAtomicType::TypeIs(type_is) => visitor.visit_typeis_type(db, type_is),
         NonAtomicType::TypeVar(bound_typevar) => {
-            visitor.visit_bound_type_var_type(db, bound_typevar)
+            visitor.visit_bound_type_var_type(db, bound_typevar);
         }
         NonAtomicType::ProtocolInstance(protocol) => {
             visitor.visit_protocol_instance_type(db, protocol);

--- a/crates/ty_python_semantic/src/types/visitor.rs
+++ b/crates/ty_python_semantic/src/types/visitor.rs
@@ -1,19 +1,19 @@
 use crate::{
     Db, FxIndexSet,
     types::{
-        BoundMethodType, BoundSuperType, CallableType, GenericAlias, IntersectionType,
-        KnownInstanceType, MethodWrapperKind, NominalInstanceType, PropertyInstanceType,
-        ProtocolInstanceType, SubclassOfType, Type, TypeAliasType, TypeIsType, TypeVarInstance,
-        TypedDictType, UnionType,
+        BoundMethodType, BoundSuperType, BoundTypeVarInstance, CallableType, GenericAlias,
+        IntersectionType, KnownInstanceType, MethodWrapperKind, NominalInstanceType,
+        PropertyInstanceType, ProtocolInstanceType, SubclassOfType, Type, TypeAliasType,
+        TypeIsType, TypeVarInstance, TypedDictType, UnionType,
         class::walk_generic_alias,
         function::{FunctionType, walk_function_type},
         instance::{walk_nominal_instance_type, walk_protocol_instance_type},
         subclass_of::walk_subclass_of_type,
         tuple::{TupleType, walk_tuple_type},
-        walk_bound_method_type, walk_bound_super_type, walk_callable_type, walk_intersection_type,
-        walk_known_instance_type, walk_method_wrapper_type, walk_property_instance_type,
-        walk_type_alias_type, walk_type_var_type, walk_typed_dict_type, walk_typeis_type,
-        walk_union,
+        walk_bound_method_type, walk_bound_super_type, walk_bound_type_var_type,
+        walk_callable_type, walk_intersection_type, walk_known_instance_type,
+        walk_method_wrapper_type, walk_property_instance_type, walk_type_alias_type,
+        walk_type_var_type, walk_typed_dict_type, walk_typeis_type, walk_union,
     },
 };
 
@@ -77,8 +77,16 @@ pub(crate) trait TypeVisitor<'db> {
         walk_nominal_instance_type(db, nominal, self);
     }
 
-    fn visit_type_var_type(&mut self, db: &'db dyn Db, type_var: TypeVarInstance<'db>) {
-        walk_type_var_type(db, type_var, self);
+    fn visit_bound_type_var_type(
+        &mut self,
+        db: &'db dyn Db,
+        bound_typevar: BoundTypeVarInstance<'db>,
+    ) {
+        walk_bound_type_var_type(db, bound_typevar, self);
+    }
+
+    fn visit_type_var_type(&mut self, db: &'db dyn Db, typevar: TypeVarInstance<'db>) {
+        walk_type_var_type(db, typevar, self);
     }
 
     fn visit_protocol_instance_type(
@@ -131,7 +139,7 @@ enum NonAtomicType<'db> {
     NominalInstance(NominalInstanceType<'db>),
     PropertyInstance(PropertyInstanceType<'db>),
     TypeIs(TypeIsType<'db>),
-    TypeVar(TypeVarInstance<'db>),
+    TypeVar(BoundTypeVarInstance<'db>),
     ProtocolInstance(ProtocolInstanceType<'db>),
     TypedDict(TypedDictType<'db>),
 }
@@ -194,7 +202,9 @@ impl<'db> From<Type<'db>> for TypeKind<'db> {
             Type::PropertyInstance(property) => {
                 TypeKind::NonAtomic(NonAtomicType::PropertyInstance(property))
             }
-            Type::TypeVar(type_var) => TypeKind::NonAtomic(NonAtomicType::TypeVar(type_var)),
+            Type::TypeVar(bound_typevar) => {
+                TypeKind::NonAtomic(NonAtomicType::TypeVar(bound_typevar))
+            }
             Type::TypeIs(type_is) => TypeKind::NonAtomic(NonAtomicType::TypeIs(type_is)),
             Type::TypedDict(typed_dict) => {
                 TypeKind::NonAtomic(NonAtomicType::TypedDict(typed_dict))
@@ -231,7 +241,9 @@ fn walk_non_atomic_type<'db, V: TypeVisitor<'db> + ?Sized>(
             visitor.visit_property_instance_type(db, property);
         }
         NonAtomicType::TypeIs(type_is) => visitor.visit_typeis_type(db, type_is),
-        NonAtomicType::TypeVar(type_var) => visitor.visit_type_var_type(db, type_var),
+        NonAtomicType::TypeVar(bound_typevar) => {
+            visitor.visit_bound_type_var_type(db, bound_typevar)
+        }
         NonAtomicType::ProtocolInstance(protocol) => {
             visitor.visit_protocol_instance_type(db, protocol);
         }


### PR DESCRIPTION
This PR creates separate Rust types for bound and unbound type variables, as proposed in https://github.com/astral-sh/ty/issues/926.

Closes https://github.com/astral-sh/ty/issues/926