### PR TITLE
[ty] Add `ty.experimental.rename` server setting

### DIFF
--- a/crates/ty_server/src/server.rs
+++ b/crates/ty_server/src/server.rs
@@ -69,8 +69,15 @@ impl Server {
 
         let resolved_client_capabilities = ResolvedClientCapabilities::new(&client_capabilities);
         let position_encoding = Self::find_best_position_encoding(&client_capabilities);
-        let server_capabilities =
-            server_capabilities(position_encoding, resolved_client_capabilities);
+        let server_capabilities = server_capabilities(
+            position_encoding,
+            resolved_client_capabilities,
+            &initialization_options
+                .options
+                .global
+                .clone()
+                .into_settings(),
+        );
 
         let version = ruff_db::program_version().unwrap_or("Unknown");
         tracing::debug!("Version: {version}");
@@ -102,7 +109,7 @@ impl Server {
             {
                 tracing::warn!(
                     "Received unknown options during initialization: {}",
-                    serde_json::to_string_pretty(unknown_options)
+                    serde_json::to_string_pretty(&unknown_options)
                         .unwrap_or_else(|_| format!("{unknown_options:?}"))
                 );
 

--- a/crates/ty_server/src/session.rs
+++ b/crates/ty_server/src/session.rs
@@ -5,19 +5,20 @@ use index::DocumentQueryError;
 use lsp_server::{Message, RequestId};
 use lsp_types::notification::{Exit, Notification};
 use lsp_types::request::{
-    DocumentDiagnosticRequest, RegisterCapability, Request, Shutdown, UnregisterCapability,
+    DocumentDiagnosticRequest, RegisterCapability, Rename, Request, Shutdown, UnregisterCapability,
     WorkspaceDiagnosticRequest,
 };
 use lsp_types::{
     DiagnosticRegistrationOptions, DiagnosticServerCapabilities, Registration, RegistrationParams,
-    TextDocumentContentChangeEvent, Unregistration, UnregistrationParams, Url,
+    RenameOptions, TextDocumentContentChangeEvent, Unregistration, UnregistrationParams, Url,
+    WorkDoneProgressOptions,
 };
 use options::GlobalOptions;
 use ruff_db::Db;
 use ruff_db::files::File;
 use ruff_db::system::{System, SystemPath, SystemPathBuf};
 use settings::GlobalSettings;
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::{BTreeMap, HashSet, VecDeque};
 use std::ops::{Deref, DerefMut};
 use std::panic::RefUnwindSafe;
 use std::sync::Arc;
@@ -91,8 +92,6 @@ pub(crate) struct Session {
     shutdown_requested: bool,
 
     /// Whether the server has dynamically registered the diagnostic capability with the client.
-    diagnostic_capability_registered: bool,
-
     /// Is the connected client a `TestServer` instance.
     in_test: bool,
 
@@ -107,6 +106,10 @@ pub(crate) struct Session {
     /// We'll re-run the request after every change to `Session` (see `revision`)
     /// to see if there are now changes and, if so, respond to the client.
     suspended_workspace_diagnostics_request: Option<SuspendedWorkspaceDiagnosticRequest>,
+
+    /// Registrations is a set of LSP methods that have been dynamically registered with the
+    /// client.
+    registrations: HashSet<String>,
 }
 
 /// LSP State for a Project
@@ -166,10 +169,10 @@ impl Session {
             resolved_client_capabilities,
             request_queue: RequestQueue::new(),
             shutdown_requested: false,
-            diagnostic_capability_registered: false,
             in_test,
             suspended_workspace_diagnostics_request: None,
             revision: 0,
+            registrations: HashSet::new(),
         })
     }
 
@@ -568,6 +571,7 @@ impl Session {
         }
 
         self.register_diagnostic_capability(client);
+        self.register_rename_capability(client);
 
         assert!(
             self.workspaces.all_initialized(),
@@ -584,10 +588,10 @@ impl Session {
     }
 
     /// Sends a registration notification to the client to enable / disable workspace diagnostics
-    /// as per the `diagnostic_mode`.
+    /// as per the `ty.diagnosticMode` global setting.
     ///
     /// This method is a no-op if the client doesn't support dynamic registration of diagnostic
-    /// capabilities.
+    /// capability.
     fn register_diagnostic_capability(&mut self, client: &Client) {
         static DIAGNOSTIC_REGISTRATION_ID: &str = "ty/textDocument/diagnostic";
 
@@ -598,9 +602,11 @@ impl Session {
             return;
         }
 
-        let diagnostic_mode = self.global_settings.diagnostic_mode;
+        let registered = self
+            .registrations
+            .contains(DocumentDiagnosticRequest::METHOD);
 
-        if self.diagnostic_capability_registered {
+        if registered {
             client.send_request::<UnregisterCapability>(
                 self,
                 UnregistrationParams {
@@ -614,6 +620,8 @@ impl Session {
                 },
             );
         }
+
+        let diagnostic_mode = self.global_settings.diagnostic_mode;
 
         let registration = Registration {
             id: DIAGNOSTIC_REGISTRATION_ID.into(),
@@ -643,7 +651,74 @@ impl Session {
             },
         );
 
-        self.diagnostic_capability_registered = true;
+        if !registered {
+            self.registrations
+                .insert(DocumentDiagnosticRequest::METHOD.to_string());
+        }
+    }
+
+    /// Sends a registration notification to the client to enable / disable rename capability as
+    /// per the `ty.experimental.rename` global setting.
+    ///
+    /// This method is a no-op if the client doesn't support dynamic registration of rename
+    /// capability.
+    fn register_rename_capability(&mut self, client: &Client) {
+        static RENAME_REGISTRATION_ID: &str = "ty/textDocument/rename";
+
+        if !self
+            .resolved_client_capabilities
+            .supports_rename_dynamic_registration()
+        {
+            return;
+        }
+
+        let registered = self.registrations.contains(Rename::METHOD);
+
+        if registered {
+            client.send_request::<UnregisterCapability>(
+                self,
+                UnregistrationParams {
+                    unregisterations: vec![Unregistration {
+                        id: RENAME_REGISTRATION_ID.into(),
+                        method: Rename::METHOD.into(),
+                    }],
+                },
+                move |_: &Client, ()| {
+                    tracing::debug!("Unregistered rename capability");
+                },
+            );
+        }
+
+        if !self.global_settings.experimental.rename {
+            tracing::debug!("Rename capability is disabled in the client settings");
+            return;
+        }
+
+        let registration = Registration {
+            id: RENAME_REGISTRATION_ID.into(),
+            method: Rename::METHOD.into(),
+            register_options: Some(
+                serde_json::to_value(RenameOptions {
+                    prepare_provider: Some(true),
+                    work_done_progress_options: WorkDoneProgressOptions::default(),
+                })
+                .unwrap(),
+            ),
+        };
+
+        client.send_request::<RegisterCapability>(
+            self,
+            RegistrationParams {
+                registrations: vec![registration],
+            },
+            move |_: &Client, ()| {
+                tracing::debug!("Registered rename capability");
+            },
+        );
+
+        if !registered {
+            self.registrations.insert(Rename::METHOD.to_string());
+        }
     }
 
     /// Creates a document snapshot with the URL referencing the document to snapshot.

--- a/crates/ty_server/src/session/options.rs
+++ b/crates/ty_server/src/session/options.rs
@@ -130,7 +130,7 @@ pub(crate) struct GlobalOptions {
     diagnostic_mode: Option<DiagnosticMode>,
 
     /// Experimental features that the server provides on an opt-in basis.
-    experimental: Option<Experimental>,
+    pub(crate) experimental: Option<Experimental>,
 }
 
 impl GlobalOptions {
@@ -259,7 +259,7 @@ impl Combine for DiagnosticMode {
 #[serde(rename_all = "camelCase")]
 pub(crate) struct Experimental {
     /// Whether to enable the experimental symbol rename feature.
-    rename: Option<bool>,
+    pub(crate) rename: Option<bool>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]

--- a/crates/ty_server/src/session/settings.rs
+++ b/crates/ty_server/src/session/settings.rs
@@ -10,6 +10,12 @@ pub(crate) struct GlobalSettings {
 }
 
 impl GlobalSettings {
+    pub(crate) fn is_rename_enabled(&self) -> bool {
+        self.experimental.rename
+    }
+}
+
+impl GlobalSettings {
     pub(crate) fn diagnostic_mode(&self) -> DiagnosticMode {
         self.diagnostic_mode
     }

--- a/crates/ty_server/src/session/settings.rs
+++ b/crates/ty_server/src/session/settings.rs
@@ -6,12 +6,18 @@ use ty_project::metadata::options::ProjectOptionsOverrides;
 #[derive(Clone, Default, Debug, PartialEq)]
 pub(crate) struct GlobalSettings {
     pub(super) diagnostic_mode: DiagnosticMode,
+    pub(super) experimental: ExperimentalSettings,
 }
 
 impl GlobalSettings {
     pub(crate) fn diagnostic_mode(&self) -> DiagnosticMode {
         self.diagnostic_mode
     }
+}
+
+#[derive(Clone, Default, Debug, PartialEq)]
+pub(crate) struct ExperimentalSettings {
+    pub(super) rename: bool,
 }
 
 /// Resolved client settings for a specific workspace.

--- a/crates/ty_server/tests/e2e/initialize.rs
+++ b/crates/ty_server/tests/e2e/initialize.rs
@@ -437,7 +437,7 @@ fn unknown_options_in_workspace_configuration() -> Result<()> {
 /// Tests that the server sends a registration request for the rename capability if the client
 /// setting is set to true and dynamic registration is enabled.
 #[test]
-fn register_rename_capability_when_true() -> Result<()> {
+fn register_rename_capability_when_enabled() -> Result<()> {
     let workspace_root = SystemPath::new("foo");
     let mut server = TestServerBuilder::new()?
         .with_workspace(workspace_root, None)?
@@ -467,10 +467,33 @@ fn register_rename_capability_when_true() -> Result<()> {
     Ok(())
 }
 
+/// Tests that rename capability is statically registered during initialization if the client
+/// doesn't support dynamic registration, but the server is configured to support it.
+#[test]
+fn rename_available_without_dynamic_registration() -> Result<()> {
+    let workspace_root = SystemPath::new("foo");
+
+    let server = TestServerBuilder::new()?
+        .with_workspace(workspace_root, None)?
+        .with_initialization_options(ClientOptions::default().with_experimental_rename(true))
+        .enable_rename_dynamic_registration(false)
+        .build()?
+        .wait_until_workspaces_are_initialized()?;
+
+    let initialization_result = server.initialization_result().unwrap();
+    insta::assert_json_snapshot!(initialization_result.capabilities.rename_provider, @r#"
+    {
+      "prepareProvider": true
+    }
+    "#);
+
+    Ok(())
+}
+
 /// Tests that the server does not send a registration request for the rename capability if the
 /// client setting is set to false and dynamic registration is enabled.
 #[test]
-fn not_register_rename_capability_when_false() -> Result<()> {
+fn not_register_rename_capability_when_disabled() -> Result<()> {
     let workspace_root = SystemPath::new("foo");
 
     TestServerBuilder::new()?

--- a/crates/ty_server/tests/e2e/initialize.rs
+++ b/crates/ty_server/tests/e2e/initialize.rs
@@ -433,3 +433,55 @@ fn unknown_options_in_workspace_configuration() -> Result<()> {
 
     Ok(())
 }
+
+/// Tests that the server sends a registration request for the rename capability if the client
+/// setting is set to true and dynamic registration is enabled.
+#[test]
+fn register_rename_capability_when_true() -> Result<()> {
+    let workspace_root = SystemPath::new("foo");
+    let mut server = TestServerBuilder::new()?
+        .with_workspace(workspace_root, None)?
+        .with_initialization_options(ClientOptions::default().with_experimental_rename(true))
+        .enable_rename_dynamic_registration(true)
+        .build()?
+        .wait_until_workspaces_are_initialized()?;
+
+    let (_, params) = server.await_request::<RegisterCapability>()?;
+    let [registration] = params.registrations.as_slice() else {
+        panic!(
+            "Expected a single registration, got: {:#?}",
+            params.registrations
+        );
+    };
+
+    insta::assert_json_snapshot!(registration, @r#"
+    {
+      "id": "ty/textDocument/rename",
+      "method": "textDocument/rename",
+      "registerOptions": {
+        "prepareProvider": true
+      }
+    }
+    "#);
+
+    Ok(())
+}
+
+/// Tests that the server does not send a registration request for the rename capability if the
+/// client setting is set to false and dynamic registration is enabled.
+#[test]
+fn not_register_rename_capability_when_false() -> Result<()> {
+    let workspace_root = SystemPath::new("foo");
+
+    TestServerBuilder::new()?
+        .with_workspace(workspace_root, None)?
+        .with_initialization_options(ClientOptions::default().with_experimental_rename(false))
+        .enable_rename_dynamic_registration(true)
+        .build()?
+        .wait_until_workspaces_are_initialized()?;
+
+    // The `Drop` implementation will make sure that the client did not receive any registration
+    // request.
+
+    Ok(())
+}

--- a/crates/ty_server/tests/e2e/main.rs
+++ b/crates/ty_server/tests/e2e/main.rs
@@ -868,7 +868,7 @@ impl TestServerBuilder {
     pub(crate) fn enable_pull_diagnostics(mut self, enabled: bool) -> Self {
         self.client_capabilities
             .text_document
-            .get_or_insert_with(Default::default)
+            .get_or_insert_default()
             .diagnostic = if enabled {
             Some(DiagnosticClientCapabilities::default())
         } else {
@@ -881,9 +881,20 @@ impl TestServerBuilder {
     pub(crate) fn enable_diagnostic_dynamic_registration(mut self, enabled: bool) -> Self {
         self.client_capabilities
             .text_document
-            .get_or_insert_with(Default::default)
+            .get_or_insert_default()
             .diagnostic
-            .get_or_insert_with(Default::default)
+            .get_or_insert_default()
+            .dynamic_registration = Some(enabled);
+        self
+    }
+
+    /// Enable or disable dynamic registration of rename capability
+    pub(crate) fn enable_rename_dynamic_registration(mut self, enabled: bool) -> Self {
+        self.client_capabilities
+            .text_document
+            .get_or_insert_default()
+            .rename
+            .get_or_insert_default()
             .dynamic_registration = Some(enabled);
         self
     }
@@ -892,7 +903,7 @@ impl TestServerBuilder {
     pub(crate) fn enable_workspace_configuration(mut self, enabled: bool) -> Self {
         self.client_capabilities
             .workspace
-            .get_or_insert_with(Default::default)
+            .get_or_insert_default()
             .configuration = Some(enabled);
         self
     }
@@ -902,7 +913,7 @@ impl TestServerBuilder {
     pub(crate) fn enable_did_change_watched_files(mut self, enabled: bool) -> Self {
         self.client_capabilities
             .workspace
-            .get_or_insert_with(Default::default)
+            .get_or_insert_default()
             .did_change_watched_files = if enabled {
             Some(DidChangeWatchedFilesClientCapabilities::default())
         } else {

--- a/crates/ty_server/tests/e2e/snapshots/e2e__initialize__initialization.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__initialize__initialization.snap
@@ -31,9 +31,6 @@ expression: initialization_result
     "documentHighlightProvider": true,
     "documentSymbolProvider": true,
     "workspaceSymbolProvider": true,
-    "renameProvider": {
-      "prepareProvider": true
-    },
     "declarationProvider": true,
     "semanticTokensProvider": {
       "legend": {

--- a/crates/ty_server/tests/e2e/snapshots/e2e__initialize__initialization_with_workspace.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__initialize__initialization_with_workspace.snap
@@ -31,9 +31,6 @@ expression: initialization_result
     "documentHighlightProvider": true,
     "documentSymbolProvider": true,
     "workspaceSymbolProvider": true,
-    "renameProvider": {
-      "prepareProvider": true
-    },
     "declarationProvider": true,
     "semanticTokensProvider": {
       "legend": {


### PR DESCRIPTION
## Summary

This PR is a follow-up from https://github.com/astral-sh/ruff/pull/19551 and adds a new `ty.experimental.rename` setting to conditionally register for the rename capability. The complementary PR in ty VS Code extension is https://github.com/astral-sh/ty-vscode/pull/111.

This is done using dynamic registration after the settings have been resolved. The experimental group is part of the global settings because they're applied for all workspaces that are managed by the client.

## Test Plan

Add E2E tests.

In VS Code, with the following setting:
```json
{
	"ty.experimental.rename": "true",
	"python.languageServer": "None"
}
```

I get the relevant log entry:
```
2025-08-07 16:05:40.598709000 DEBUG client_response{id=3 method="client/registerCapability"}: Registered rename capability
```

And, I'm able to rename a symbol. Once I set it to `false`, then I can see this log entry:

```
2025-08-07 16:08:39.027876000 DEBUG Rename capability is disabled in the client settings
```

And, I don't see the "Rename Symbol" open in the VS Code dropdown.

https://github.com/user-attachments/assets/501659df-ba96-4252-bf51-6f22acb4920b

