### PR TITLE
[`pylint`] Improve `unnecessary-direct-lambda-call` (`PLC3002`) to ha…

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/unnecessary_direct_lambda_call.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/unnecessary_direct_lambda_call.py
@@ -3,3 +3,54 @@
 
 y = (lambda x: x**2 + 2*x + 1)(a)  # [unnecessary-direct-lambda-call]
 y = max((lambda x: x**2)(a), (lambda x: x+1)(a))  # [unnecessary-direct-lambda-call,unnecessary-direct-lambda-call]
+
+def function():
+    # Safe - no comprehensions, no class scope issues
+    area = (lambda r: 3.14 * r ** 2)(radius)  # PLC3002
+
+    # Safe - simple expression
+    result = (lambda x, y: x + y)(1, 2)  # PLC3002
+
+def function():
+    numbers = [1, 2, 3]
+    # Safe - comprehension but in function scope, not class scope
+    result = (lambda lst: [x * 2 for x in lst])(numbers)  # PLC3002
+
+
+class A:
+    # Safe - comprehension doesn't reference class variables
+    y = (lambda: [i for i in range(3)])()  # PLC3002
+
+    # Safe - uses lambda parameter, not class variable
+    z = (lambda data: [x for x in data])([1, 2, 3])  # PLC3002
+
+class A:
+    x = 1
+    # Unsafe - would cause F821 if inlined
+    # (lambda test: [_ for _ in [1] if test])(x) → [_ for _ in [1] if x]
+    y = (lambda test: [_ for _ in [1] if test])(x)  # No PLC3002
+
+    # Unsafe - comprehension references class variable
+    data = [1, 2, 3]
+    filtered = (lambda items: [x for x in items if x > 1])(data)  # No PLC3002 if A.threshold exists
+
+
+class Config:
+    default_value = 42
+    # Unsafe - dict comprehension would lose access to class variable
+    mapping = (lambda val: {k: val for k in ['a', 'b']})(default_value)  # No PLC3002
+
+class DataProcessor:
+    multiplier = 5
+    # Unsafe - set comprehension references class variable
+    processed = (lambda m: {x * m for x in range(3)})(multiplier)  # No PLC3002
+
+class StreamProcessor:
+    factor = 2
+    # Unsafe - generator expression would cause undefined name
+    generator = (lambda f: (x * f for x in range(5)))(factor)  # No PLC3002
+
+class Matrix:
+    size = 3
+    # Unsafe - nested comprehensions with class variable reference
+    matrix = (lambda s: [[i * j * s for i in range(3)] for j in range(3)])(size)  # No PLC3002

--- a/crates/ruff_linter/src/rules/pylint/rules/unnecessary_direct_lambda_call.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/unnecessary_direct_lambda_call.rs
@@ -1,4 +1,7 @@
-use ruff_python_ast::Expr;
+use ruff_python_ast::{
+    Expr,
+    visitor::{self, Visitor},
+};
 
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_text_size::Ranged;
@@ -35,9 +38,177 @@ impl Violation for UnnecessaryDirectLambdaCall {
     }
 }
 
+/// Check if the lambda body contains comprehensions
+fn has_comprehensions(expr: &Expr) -> bool {
+    let mut finder = ComprehensionFinder { found: false };
+    finder.visit_expr(expr);
+    finder.found
+}
+
+/// Check if a name is used within comprehensions in the expression
+fn name_used_in_comprehension(expr: &Expr, target_name: &str) -> bool {
+    let mut checker = ComprehensionNameChecker {
+        target_name,
+        found: false,
+        in_comprehension: false,
+    };
+    checker.visit_expr(expr);
+    checker.found
+}
+
+/// Check if inlining the lambda would cause undefined name issues in comprehensions within class scopes
+fn would_cause_undefined_name_in_comprehension(
+    lambda_body: &Expr,
+    lambda_params: &[String],
+    call_args: &[&Expr],
+    checker: &Checker,
+) -> bool {
+    // Check if we're in a class scope
+    if !checker.semantic().current_scope().kind.is_class() {
+        return false;
+    }
+
+    // Check if the lambda body contains comprehensions
+    if !has_comprehensions(lambda_body) {
+        return false;
+    }
+
+    // Check each lambda parameter to see if inlining would cause issues
+    for (param_idx, param_name) in lambda_params.iter().enumerate() {
+        // Check if this parameter is used in a comprehension
+        if name_used_in_comprehension(lambda_body, param_name) {
+            // Get the corresponding call argument
+            if let Some(call_arg) = call_args.get(param_idx) {
+                // Check if the call argument would cause issues after inlining
+                match call_arg {
+                    // Simple name that refers to a class variable
+                    Expr::Name(arg_name) => {
+                        if checker
+                            .semantic()
+                            .current_scope()
+                            .get(arg_name.id.as_str())
+                            .is_some()
+                        {
+                            return true;
+                        }
+                    }
+                    // Attribute access on class variables (like A.threshold)
+                    Expr::Attribute(attr_expr) => {
+                        if let Expr::Name(base_name) = attr_expr.value.as_ref() {
+                            if checker
+                                .semantic()
+                                .current_scope()
+                                .get(base_name.id.as_str())
+                                .is_some()
+                            {
+                                return true;
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    false
+}
+
+/// Extracts lambda parameters and call arguments from a lambda call expression.
+///
+/// This function validates that the expression is a lambda call and extracts the necessary
+/// components for further analysis. It returns the lambda parameter names and the call
+/// arguments, which can be used to check for potential issues with lambda inlining.
+fn extract_lambda_call_components<'a>(
+    expr: &'a ruff_python_ast::Expr,
+    lambda_expr: &ruff_python_ast::ExprLambda,
+) -> Option<(Vec<String>, Vec<&'a Expr>)> {
+    if let Expr::Call(call_expr) = expr {
+        // Get the lambda parameter names
+        let lambda_params: Vec<String> = lambda_expr
+            .parameters
+            .as_ref()
+            .map(|params| {
+                params
+                    .args
+                    .iter()
+                    .map(|param| param.parameter.name.to_string())
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        // Get the call arguments
+        let call_args: Vec<&Expr> = call_expr.arguments.args.iter().collect();
+
+        Some((lambda_params, call_args))
+    } else {
+        None
+    }
+}
+
+/// Visitor to find comprehensions in an expression
+struct ComprehensionFinder {
+    found: bool,
+}
+
+impl Visitor<'_> for ComprehensionFinder {
+    fn visit_expr(&mut self, expr: &Expr) {
+        match expr {
+            Expr::ListComp(_) | Expr::SetComp(_) | Expr::DictComp(_) | Expr::Generator(_) => {
+                self.found = true;
+            }
+            _ => {}
+        }
+        visitor::walk_expr(self, expr);
+    }
+}
+
+/// Visitor to check if a specific name is referenced within a comprehension
+struct ComprehensionNameChecker<'a> {
+    target_name: &'a str,
+    found: bool,
+    in_comprehension: bool,
+}
+
+impl Visitor<'_> for ComprehensionNameChecker<'_> {
+    fn visit_expr(&mut self, expr: &Expr) {
+        match expr {
+            Expr::ListComp(_) | Expr::SetComp(_) | Expr::DictComp(_) | Expr::Generator(_) => {
+                let was_in_comprehension = self.in_comprehension;
+                self.in_comprehension = true;
+                visitor::walk_expr(self, expr);
+                self.in_comprehension = was_in_comprehension;
+            }
+            Expr::Name(name_expr) if self.in_comprehension => {
+                if name_expr.id.as_str() == self.target_name {
+                    self.found = true;
+                }
+                visitor::walk_expr(self, expr);
+            }
+            _ => {
+                visitor::walk_expr(self, expr);
+            }
+        }
+    }
+}
+
 /// PLC3002
 pub(crate) fn unnecessary_direct_lambda_call(checker: &Checker, expr: &Expr, func: &Expr) {
-    if let Expr::Lambda(_) = func {
+    if let Expr::Lambda(lambda_expr) = func {
+        // Extract lambda parameters and call arguments
+        if let Some((lambda_params, call_args)) = extract_lambda_call_components(expr, lambda_expr)
+        {
+            // Check if inlining would cause undefined name issues in comprehensions
+            if would_cause_undefined_name_in_comprehension(
+                &lambda_expr.body,
+                &lambda_params,
+                &call_args,
+                checker,
+            ) {
+                return;
+            }
+        }
+
         checker.report_diagnostic(UnnecessaryDirectLambdaCall, expr.range());
     }
 }

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLC3002_unnecessary_direct_lambda_call.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLC3002_unnecessary_direct_lambda_call.py.snap
@@ -15,6 +15,8 @@ unnecessary_direct_lambda_call.py:5:9: PLC3002 Lambda expression called directly
 4 | y = (lambda x: x**2 + 2*x + 1)(a)  # [unnecessary-direct-lambda-call]
 5 | y = max((lambda x: x**2)(a), (lambda x: x+1)(a))  # [unnecessary-direct-lambda-call,unnecessary-direct-lambda-call]
   |         ^^^^^^^^^^^^^^^^^^^ PLC3002
+6 |
+7 | def function():
   |
 
 unnecessary_direct_lambda_call.py:5:30: PLC3002 Lambda expression called directly. Execute the expression inline instead.
@@ -22,4 +24,52 @@ unnecessary_direct_lambda_call.py:5:30: PLC3002 Lambda expression called directl
 4 | y = (lambda x: x**2 + 2*x + 1)(a)  # [unnecessary-direct-lambda-call]
 5 | y = max((lambda x: x**2)(a), (lambda x: x+1)(a))  # [unnecessary-direct-lambda-call,unnecessary-direct-lambda-call]
   |                              ^^^^^^^^^^^^^^^^^^ PLC3002
+6 |
+7 | def function():
   |
+
+unnecessary_direct_lambda_call.py:9:12: PLC3002 Lambda expression called directly. Execute the expression inline instead.
+   |
+ 7 | def function():
+ 8 |     # Safe - no comprehensions, no class scope issues
+ 9 |     area = (lambda r: 3.14 * r ** 2)(radius)  # PLC3002
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PLC3002
+10 |
+11 |     # Safe - simple expression
+   |
+
+unnecessary_direct_lambda_call.py:12:14: PLC3002 Lambda expression called directly. Execute the expression inline instead.
+   |
+11 |     # Safe - simple expression
+12 |     result = (lambda x, y: x + y)(1, 2)  # PLC3002
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ PLC3002
+13 |
+14 | def function():
+   |
+
+unnecessary_direct_lambda_call.py:17:14: PLC3002 Lambda expression called directly. Execute the expression inline instead.
+   |
+15 |     numbers = [1, 2, 3]
+16 |     # Safe - comprehension but in function scope, not class scope
+17 |     result = (lambda lst: [x * 2 for x in lst])(numbers)  # PLC3002
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PLC3002
+   |
+
+unnecessary_direct_lambda_call.py:22:9: PLC3002 Lambda expression called directly. Execute the expression inline instead.
+   |
+20 | class A:
+21 |     # Safe - comprehension doesn't reference class variables
+22 |     y = (lambda: [i for i in range(3)])()  # PLC3002
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PLC3002
+23 |
+24 |     # Safe - uses lambda parameter, not class variable
+   |
+
+unnecessary_direct_lambda_call.py:25:9: PLC3002 Lambda expression called directly. Execute the expression inline instead.
+   |
+24 |     # Safe - uses lambda parameter, not class variable
+25 |     z = (lambda data: [x for x in data])([1, 2, 3])  # PLC3002
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PLC3002
+26 |
+27 | class A:
+   |


### PR DESCRIPTION
## Summary

Improved `unnecessary-direct-lambda-call` ([PLC3002](https://docs.astral.sh/ruff/rules/unnecessary-direct-lambda-call/)) to handle comprehension-related edge cases in class scopes.
The rule now avoids false positives when lambda expressions contain comprehensions that reference class-scoped variables, as inlining these lambdas would cause [F821](https://docs.astral.sh/ruff/rules/undefined-name/) (undefined name) errors. The enhancement adds sophisticated analysis to detect:
- Lambda bodies containing list/set/dict comprehensions or generator expressions
- Class scope contexts where variable access semantics differ after inlining
- Parameter usage within comprehensions that would become undefined after transformation

This prevents unsafe refactoring suggestions while maintaining the rule's effectiveness for genuinely unnecessary lambda calls. 

**Safe cases that now correctly trigger the rule:**
```python
def function():
    # Safe - no comprehensions, triggers PLC3002
    area = (lambda r: 3.14 * r ** 2)(radius)
    
    # Safe - comprehension in function scope, triggers PLC3002
    numbers = [1, 2, 3]
    result = (lambda lst: [x * 2 for x in lst])(numbers)

class A:
    # Safe - comprehension doesn't reference class variables, triggers PLC3002
    y = (lambda: [i for i in range(3)])()
```

**Problematic cases that are now correctly ignored:**
```python
class A:
    x = 1
    # Would cause F821 if inlined: [_ for _ in [1] if x]
    y = (lambda test: [_ for _ in [1] if test])(x)

class Config:
    default_value = 42
    # Would cause F821 if inlined: {k: default_value for k in ['a', 'b']}
    mapping = (lambda val: {k: val for k in ['a', 'b']})(default_value)
```

### PEP709 and Its Impact

**[PEP 709](https://peps.python.org/pep-0709/) (Comprehension inlining)** fundamentally changes Python's scoping semantics for comprehensions, which has direct implications for this fix:

### Current Behavior vs. PEP 709
**Before PEP 709 (Python ≤3.11):**
```python
class A:
    x = 1
    # This would fail with NameError if inlined
    y = (lambda test: [_ for _ in [1] if test])(x)
```
**After PEP 709 (Python 3.12+):**
```python
class A:
    x = 1
    # This now works because comprehensions can access class scope
    y = [_ for _ in [1] if x]  # No longer causes NameError
```

Hopefully, this is a proper approach to add a specialization to the rule to handle problematic related classes and PEP709. In addition, I have taken a conservative approach and will not propose any warnings related to this specific case. 

[ISSUE](https://github.com/astral-sh/ruff/issues/19135)

## Test Plan

```bash
cargo test
```
