### PR TITLE
[ty] support recursive type aliases

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
@@ -167,6 +167,7 @@ def f(x: OptNestedInt) -> None:
 ### Invalid self-referential
 
 ```py
+# TODO emit a diagnostic here
 type IntOr = int | IntOr
 
 def f(x: IntOr):

--- a/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
@@ -187,4 +187,12 @@ def f(x: A):
         y = x[0]
         if y is not None:
             reveal_type(y)  # revealed: tuple[A]
+
+def g(x: A | B):
+    reveal_type(x)  # revealed: tuple[B] | None
+
+from ty_extensions import Intersection
+
+def h(x: Intersection[A, B]):
+    reveal_type(x)  # revealed: tuple[B] | None
 ```

--- a/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
@@ -20,7 +20,7 @@ x: IntOrStr = 1
 reveal_type(x)  # revealed: Literal[1]
 
 def f() -> None:
-    reveal_type(x)  # revealed: int | str
+    reveal_type(x)  # revealed: IntOrStr
 ```
 
 ## `__value__` attribute
@@ -49,7 +49,7 @@ type IntOrStrOrBytes = IntOrStr | bytes
 x: IntOrStrOrBytes = 1
 
 def f() -> None:
-    reveal_type(x)  # revealed: int | str | bytes
+    reveal_type(x)  # revealed: IntOrStrOrBytes
 ```
 
 ## Aliased type aliases
@@ -109,7 +109,7 @@ reveal_type(IntOrStr)  # revealed: typing.TypeAliasType
 reveal_type(IntOrStr.__name__)  # revealed: Literal["IntOrStr"]
 
 def f(x: IntOrStr) -> None:
-    reveal_type(x)  # revealed: int | str
+    reveal_type(x)  # revealed: IntOrStr
 ```
 
 ### Generic example
@@ -139,9 +139,9 @@ def get_name() -> str:
 IntOrStr = TypeAliasType(get_name(), int | str)
 ```
 
-### Cyclic aliases
+## Cyclic aliases
 
-#### Self-referential
+### Self-referential
 
 ```py
 type OptNestedInt = int | tuple[OptNestedInt, ...] | None
@@ -152,7 +152,7 @@ def f(x: OptNestedInt) -> None:
         reveal_type(x)  # revealed: int | tuple[OptNestedInt, ...]
 ```
 
-#### Invalid self-referential
+### Invalid self-referential
 
 ```py
 type IntOr = int | IntOr
@@ -160,10 +160,10 @@ type IntOr = int | IntOr
 def f(x: IntOr):
     reveal_type(x)  # revealed: IntOr
     if not isinstance(x, int):
-        reveal_type(x)  # revealed: Unknown
+        reveal_type(x)  # revealed: Never
 ```
 
-#### Mutually recursive
+### Mutually recursive
 
 ```py
 type A = tuple[B] | None

--- a/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
@@ -20,7 +20,7 @@ x: IntOrStr = 1
 reveal_type(x)  # revealed: Literal[1]
 
 def f() -> None:
-    reveal_type(x)  # revealed: IntOrStr
+    reveal_type(x)  # revealed: int | str
 ```
 
 ## `__value__` attribute
@@ -49,7 +49,7 @@ type IntOrStrOrBytes = IntOrStr | bytes
 x: IntOrStrOrBytes = 1
 
 def f() -> None:
-    reveal_type(x)  # revealed: IntOrStrOrBytes
+    reveal_type(x)  # revealed: int | str | bytes
 ```
 
 ## Aliased type aliases
@@ -69,6 +69,18 @@ y: MyIntOrStr = None
 ```py
 type ListOrSet[T] = list[T] | set[T]
 reveal_type(ListOrSet.__type_params__)  # revealed: tuple[TypeVar | ParamSpec | TypeVarTuple, ...]
+```
+
+## In unions and intersections
+
+We can "break apart" a type alias by e.g. adding it to a union:
+
+```py
+type IntOrStr = int | str
+
+def f(x: IntOrStr, y: str | bytes):
+    z = x or y
+    reveal_type(z)  # revealed: (int & ~AlwaysFalsy) | str | bytes
 ```
 
 ## `TypeAliasType` properties
@@ -109,7 +121,7 @@ reveal_type(IntOrStr)  # revealed: typing.TypeAliasType
 reveal_type(IntOrStr.__name__)  # revealed: Literal["IntOrStr"]
 
 def f(x: IntOrStr) -> None:
-    reveal_type(x)  # revealed: IntOrStr
+    reveal_type(x)  # revealed: int | str
 ```
 
 ### Generic example
@@ -147,7 +159,7 @@ IntOrStr = TypeAliasType(get_name(), int | str)
 type OptNestedInt = int | tuple[OptNestedInt, ...] | None
 
 def f(x: OptNestedInt) -> None:
-    reveal_type(x)  # revealed: OptNestedInt
+    reveal_type(x)  # revealed: int | tuple[OptNestedInt, ...] | None
     if x is not None:
         reveal_type(x)  # revealed: int | tuple[OptNestedInt, ...]
 ```
@@ -158,7 +170,7 @@ def f(x: OptNestedInt) -> None:
 type IntOr = int | IntOr
 
 def f(x: IntOr):
-    reveal_type(x)  # revealed: IntOr
+    reveal_type(x)  # revealed: int
     if not isinstance(x, int):
         reveal_type(x)  # revealed: Never
 ```

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -243,6 +243,7 @@ impl<'db> Completion<'db> {
                 | Type::KnownInstance(_)
                 | Type::AlwaysTruthy
                 | Type::AlwaysFalsy => return None,
+                Type::TypeAlias(alias) => imp(db, alias.value_type(db))?,
             })
         }
         imp(db, self.ty)

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -19,7 +19,7 @@ use ruff_python_ast::{self as ast, AnyNodeRef};
 use ruff_text_size::{Ranged, TextRange};
 use type_ordering::union_or_intersection_elements_ordering;
 
-pub(crate) use self::builder::{IntersectionBuilder, UnionBuilder, UnionStrategy};
+pub(crate) use self::builder::{IntersectionBuilder, UnionBuilder};
 pub(crate) use self::cyclic::{PairVisitor, TypeTransformer};
 pub use self::diagnostic::TypeCheckDiagnostics;
 pub(crate) use self::diagnostic::register_lints;
@@ -8707,24 +8707,11 @@ impl<'db> UnionType<'db> {
         I: IntoIterator<Item = T>,
         T: Into<Type<'db>>,
     {
-        Self::from_elements_impl(db, elements, UnionStrategy::EliminateSubtypes)
-    }
-
-    pub(crate) fn from_elements_impl<I, T>(
-        db: &'db dyn Db,
-        elements: I,
-        strategy: UnionStrategy,
-    ) -> Type<'db>
-    where
-        I: IntoIterator<Item = T>,
-        T: Into<Type<'db>>,
-    {
         elements
             .into_iter()
-            .fold(
-                UnionBuilder::new(db).strategy(strategy),
-                |builder, element| builder.add(element.into()),
-            )
+            .fold(UnionBuilder::new(db), |builder, element| {
+                builder.add(element.into())
+            })
             .build()
     }
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -5969,7 +5969,7 @@ impl<'db> Type<'db> {
             Type::TypeAlias(alias) => {
                 alias
                     .value_type(db)
-                    .find_legacy_typevars(db, binding_context, typevars)
+                    .find_legacy_typevars(db, binding_context, typevars);
             }
 
             Type::Dynamic(_)

--- a/crates/ty_python_semantic/src/types/builder.rs
+++ b/crates/ty_python_semantic/src/types/builder.rs
@@ -205,7 +205,13 @@ enum ReduceResult<'db> {
 const MAX_UNION_LITERALS: usize = 200;
 
 pub(crate) enum UnionStrategy {
+    /// Only eliminate equivalent types from the union; allow subtypes to remain.
+    /// Currently we only use this in limited cases to avoid cycles where subtype-checking itself
+    /// needs to construct a union (e.g. for tuples). We may switch to this strategy in more cases
+    /// in future, in order to leave more user-authored unions in their original form.
     EliminateEquivalentTypes,
+    /// Eliminate any type from the union that is a subtype of another union element. This aims for
+    /// the "most simplified" form of the union.
     EliminateSubtypes,
 }
 

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -222,7 +222,7 @@ pub struct GenericAlias<'db> {
 pub(super) fn walk_generic_alias<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
     alias: GenericAlias<'db>,
-    visitor: &V,
+    visitor: &mut V,
 ) {
     walk_specialization(db, alias.specialization(db), visitor);
 }
@@ -231,7 +231,11 @@ pub(super) fn walk_generic_alias<'db, V: super::visitor::TypeVisitor<'db> + ?Siz
 impl get_size2::GetSize for GenericAlias<'_> {}
 
 impl<'db> GenericAlias<'db> {
-    pub(super) fn normalized_impl(self, db: &'db dyn Db, visitor: &TypeTransformer<'db>) -> Self {
+    pub(super) fn normalized_impl(
+        self,
+        db: &'db dyn Db,
+        visitor: &mut TypeTransformer<'db>,
+    ) -> Self {
         Self::new(
             db,
             self.origin(db),
@@ -255,7 +259,7 @@ impl<'db> GenericAlias<'db> {
         self,
         db: &'db dyn Db,
         type_mapping: &TypeMapping<'a, 'db>,
-        visitor: &TypeTransformer<'db>,
+        visitor: &mut TypeTransformer<'db>,
     ) -> Self {
         Self::new(
             db,
@@ -319,7 +323,11 @@ impl<'db> ClassType<'db> {
         }
     }
 
-    pub(super) fn normalized_impl(self, db: &'db dyn Db, visitor: &TypeTransformer<'db>) -> Self {
+    pub(super) fn normalized_impl(
+        self,
+        db: &'db dyn Db,
+        visitor: &mut TypeTransformer<'db>,
+    ) -> Self {
         match self {
             Self::NonGeneric(_) => self,
             Self::Generic(generic) => Self::Generic(generic.normalized_impl(db, visitor)),
@@ -406,7 +414,7 @@ impl<'db> ClassType<'db> {
         self,
         db: &'db dyn Db,
         type_mapping: &TypeMapping<'a, 'db>,
-        visitor: &TypeTransformer<'db>,
+        visitor: &mut TypeTransformer<'db>,
     ) -> Self {
         match self {
             Self::NonGeneric(_) => self,
@@ -461,7 +469,12 @@ impl<'db> ClassType<'db> {
 
     /// Return `true` if `other` is present in this class's MRO.
     pub(super) fn is_subclass_of(self, db: &'db dyn Db, other: ClassType<'db>) -> bool {
-        self.has_relation_to_impl(db, other, TypeRelation::Subtyping, &PairVisitor::new(true))
+        self.has_relation_to_impl(
+            db,
+            other,
+            TypeRelation::Subtyping,
+            &mut PairVisitor::new(true),
+        )
     }
 
     pub(super) fn has_relation_to_impl(
@@ -469,7 +482,7 @@ impl<'db> ClassType<'db> {
         db: &'db dyn Db,
         other: Self,
         relation: TypeRelation,
-        visitor: &PairVisitor<'db>,
+        visitor: &mut PairVisitor<'db>,
     ) -> bool {
         self.iter_mro(db).any(|base| {
             match base {

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -251,15 +251,17 @@ impl<'db> GenericAlias<'db> {
         self.origin(db).definition(db)
     }
 
-    pub(super) fn apply_type_mapping<'a>(
+    pub(super) fn apply_type_mapping_impl<'a>(
         self,
         db: &'db dyn Db,
         type_mapping: &TypeMapping<'a, 'db>,
+        visitor: &mut TypeTransformer<'db>,
     ) -> Self {
         Self::new(
             db,
             self.origin(db),
-            self.specialization(db).apply_type_mapping(db, type_mapping),
+            self.specialization(db)
+                .apply_type_mapping_impl(db, type_mapping, visitor),
         )
     }
 
@@ -400,14 +402,17 @@ impl<'db> ClassType<'db> {
         self.is_known(db, KnownClass::Object)
     }
 
-    pub(super) fn apply_type_mapping<'a>(
+    pub(super) fn apply_type_mapping_impl<'a>(
         self,
         db: &'db dyn Db,
         type_mapping: &TypeMapping<'a, 'db>,
+        visitor: &mut TypeTransformer<'db>,
     ) -> Self {
         match self {
             Self::NonGeneric(_) => self,
-            Self::Generic(generic) => Self::Generic(generic.apply_type_mapping(db, type_mapping)),
+            Self::Generic(generic) => {
+                Self::Generic(generic.apply_type_mapping_impl(db, type_mapping, visitor))
+            }
         }
     }
 

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -255,7 +255,7 @@ impl<'db> GenericAlias<'db> {
         self,
         db: &'db dyn Db,
         type_mapping: &TypeMapping<'a, 'db>,
-        visitor: &mut TypeTransformer<'db>,
+        visitor: &TypeTransformer<'db>,
     ) -> Self {
         Self::new(
             db,
@@ -406,7 +406,7 @@ impl<'db> ClassType<'db> {
         self,
         db: &'db dyn Db,
         type_mapping: &TypeMapping<'a, 'db>,
-        visitor: &mut TypeTransformer<'db>,
+        visitor: &TypeTransformer<'db>,
     ) -> Self {
         match self {
             Self::NonGeneric(_) => self,
@@ -461,12 +461,7 @@ impl<'db> ClassType<'db> {
 
     /// Return `true` if `other` is present in this class's MRO.
     pub(super) fn is_subclass_of(self, db: &'db dyn Db, other: ClassType<'db>) -> bool {
-        self.has_relation_to_impl(
-            db,
-            other,
-            TypeRelation::Subtyping,
-            &mut PairVisitor::new(true),
-        )
+        self.has_relation_to_impl(db, other, TypeRelation::Subtyping, &PairVisitor::new(true))
     }
 
     pub(super) fn has_relation_to_impl(
@@ -474,7 +469,7 @@ impl<'db> ClassType<'db> {
         db: &'db dyn Db,
         other: Self,
         relation: TypeRelation,
-        visitor: &mut PairVisitor<'db>,
+        visitor: &PairVisitor<'db>,
     ) -> bool {
         self.iter_mro(db).any(|base| {
             match base {

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -222,7 +222,7 @@ pub struct GenericAlias<'db> {
 pub(super) fn walk_generic_alias<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
     alias: GenericAlias<'db>,
-    visitor: &mut V,
+    visitor: &V,
 ) {
     walk_specialization(db, alias.specialization(db), visitor);
 }
@@ -231,11 +231,7 @@ pub(super) fn walk_generic_alias<'db, V: super::visitor::TypeVisitor<'db> + ?Siz
 impl get_size2::GetSize for GenericAlias<'_> {}
 
 impl<'db> GenericAlias<'db> {
-    pub(super) fn normalized_impl(
-        self,
-        db: &'db dyn Db,
-        visitor: &mut TypeTransformer<'db>,
-    ) -> Self {
+    pub(super) fn normalized_impl(self, db: &'db dyn Db, visitor: &TypeTransformer<'db>) -> Self {
         Self::new(
             db,
             self.origin(db),
@@ -259,7 +255,7 @@ impl<'db> GenericAlias<'db> {
         self,
         db: &'db dyn Db,
         type_mapping: &TypeMapping<'a, 'db>,
-        visitor: &mut TypeTransformer<'db>,
+        visitor: &TypeTransformer<'db>,
     ) -> Self {
         Self::new(
             db,
@@ -323,11 +319,7 @@ impl<'db> ClassType<'db> {
         }
     }
 
-    pub(super) fn normalized_impl(
-        self,
-        db: &'db dyn Db,
-        visitor: &mut TypeTransformer<'db>,
-    ) -> Self {
+    pub(super) fn normalized_impl(self, db: &'db dyn Db, visitor: &TypeTransformer<'db>) -> Self {
         match self {
             Self::NonGeneric(_) => self,
             Self::Generic(generic) => Self::Generic(generic.normalized_impl(db, visitor)),
@@ -414,7 +406,7 @@ impl<'db> ClassType<'db> {
         self,
         db: &'db dyn Db,
         type_mapping: &TypeMapping<'a, 'db>,
-        visitor: &mut TypeTransformer<'db>,
+        visitor: &TypeTransformer<'db>,
     ) -> Self {
         match self {
             Self::NonGeneric(_) => self,
@@ -469,12 +461,7 @@ impl<'db> ClassType<'db> {
 
     /// Return `true` if `other` is present in this class's MRO.
     pub(super) fn is_subclass_of(self, db: &'db dyn Db, other: ClassType<'db>) -> bool {
-        self.has_relation_to_impl(
-            db,
-            other,
-            TypeRelation::Subtyping,
-            &mut PairVisitor::new(true),
-        )
+        self.has_relation_to_impl(db, other, TypeRelation::Subtyping, &PairVisitor::new(true))
     }
 
     pub(super) fn has_relation_to_impl(
@@ -482,7 +469,7 @@ impl<'db> ClassType<'db> {
         db: &'db dyn Db,
         other: Self,
         relation: TypeRelation,
-        visitor: &mut PairVisitor<'db>,
+        visitor: &PairVisitor<'db>,
     ) -> bool {
         self.iter_mro(db).any(|base| {
             match base {

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -253,7 +253,7 @@ impl<'db> ClassBase<'db> {
         self,
         db: &'db dyn Db,
         type_mapping: &TypeMapping<'a, 'db>,
-        visitor: &mut TypeTransformer<'db>,
+        visitor: &TypeTransformer<'db>,
     ) -> Self {
         match self {
             Self::Class(class) => {
@@ -272,7 +272,7 @@ impl<'db> ClassBase<'db> {
             self.apply_type_mapping_impl(
                 db,
                 &TypeMapping::Specialization(specialization),
-                &mut TypeTransformer::default(),
+                &TypeTransformer::default(),
             )
         } else {
             self

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -135,6 +135,8 @@ impl<'db> ClassBase<'db> {
             // in which case we want to treat `Never` in a forgiving way and silence diagnostics
             Type::Never => Some(ClassBase::unknown()),
 
+            Type::TypeAlias(alias) => Self::try_from_type(db, alias.value_type(db)),
+
             Type::PropertyInstance(_)
             | Type::BooleanLiteral(_)
             | Type::FunctionLiteral(_)

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -32,7 +32,11 @@ impl<'db> ClassBase<'db> {
         Self::Dynamic(DynamicType::Unknown)
     }
 
-    pub(crate) fn normalized_impl(self, db: &'db dyn Db, visitor: &TypeTransformer<'db>) -> Self {
+    pub(crate) fn normalized_impl(
+        self,
+        db: &'db dyn Db,
+        visitor: &mut TypeTransformer<'db>,
+    ) -> Self {
         match self {
             Self::Dynamic(dynamic) => Self::Dynamic(dynamic.normalized()),
             Self::Class(class) => Self::Class(class.normalized_impl(db, visitor)),
@@ -253,7 +257,7 @@ impl<'db> ClassBase<'db> {
         self,
         db: &'db dyn Db,
         type_mapping: &TypeMapping<'a, 'db>,
-        visitor: &TypeTransformer<'db>,
+        visitor: &mut TypeTransformer<'db>,
     ) -> Self {
         match self {
             Self::Class(class) => {
@@ -272,7 +276,7 @@ impl<'db> ClassBase<'db> {
             self.apply_type_mapping_impl(
                 db,
                 &TypeMapping::Specialization(specialization),
-                &TypeTransformer::default(),
+                &mut TypeTransformer::default(),
             )
         } else {
             self

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -32,11 +32,7 @@ impl<'db> ClassBase<'db> {
         Self::Dynamic(DynamicType::Unknown)
     }
 
-    pub(crate) fn normalized_impl(
-        self,
-        db: &'db dyn Db,
-        visitor: &mut TypeTransformer<'db>,
-    ) -> Self {
+    pub(crate) fn normalized_impl(self, db: &'db dyn Db, visitor: &TypeTransformer<'db>) -> Self {
         match self {
             Self::Dynamic(dynamic) => Self::Dynamic(dynamic.normalized()),
             Self::Class(class) => Self::Class(class.normalized_impl(db, visitor)),
@@ -257,7 +253,7 @@ impl<'db> ClassBase<'db> {
         self,
         db: &'db dyn Db,
         type_mapping: &TypeMapping<'a, 'db>,
-        visitor: &mut TypeTransformer<'db>,
+        visitor: &TypeTransformer<'db>,
     ) -> Self {
         match self {
             Self::Class(class) => {
@@ -276,7 +272,7 @@ impl<'db> ClassBase<'db> {
             self.apply_type_mapping_impl(
                 db,
                 &TypeMapping::Specialization(specialization),
-                &mut TypeTransformer::default(),
+                &TypeTransformer::default(),
             )
         } else {
             self

--- a/crates/ty_python_semantic/src/types/cyclic.rs
+++ b/crates/ty_python_semantic/src/types/cyclic.rs
@@ -22,7 +22,6 @@ use rustc_hash::FxHashMap;
 
 use crate::FxIndexSet;
 use crate::types::Type;
-use std::cell::RefCell;
 use std::cmp::Eq;
 use std::hash::Hash;
 
@@ -45,7 +44,7 @@ pub(crate) struct CycleDetector<T, R> {
     /// If the type we're visiting is present in `seen`, it indicates that we've hit a cycle (due
     /// to a recursive type); we need to immediately short circuit the whole operation and return
     /// the fallback value. That's why we pop items off the end of `seen` after we've visited them.
-    seen: RefCell<FxIndexSet<T>>,
+    seen: FxIndexSet<T>,
 
     /// Unlike `seen`, this field is a pure performance optimisation (and an essential one). If the
     /// type we're trying to normalize is present in `cache`, it doesn't necessarily mean we've hit
@@ -53,7 +52,7 @@ pub(crate) struct CycleDetector<T, R> {
     /// chain we're currently in. Since this cache is just a performance optimisation, it doesn't
     /// make sense to pop items off the end of the cache after they've been visited (it would
     /// sort-of defeat the point of a cache if we did!)
-    cache: RefCell<FxHashMap<T, R>>,
+    cache: FxHashMap<T, R>,
 
     fallback: R,
 }
@@ -61,25 +60,25 @@ pub(crate) struct CycleDetector<T, R> {
 impl<T: Hash + Eq + Copy, R: Copy> CycleDetector<T, R> {
     pub(crate) fn new(fallback: R) -> Self {
         CycleDetector {
-            seen: RefCell::new(FxIndexSet::default()),
-            cache: RefCell::new(FxHashMap::default()),
+            seen: FxIndexSet::default(),
+            cache: FxHashMap::default(),
             fallback,
         }
     }
 
-    pub(crate) fn visit(&self, item: T, func: impl FnOnce() -> R) -> R {
-        if let Some(val) = self.cache.borrow().get(&item) {
+    pub(crate) fn visit(&mut self, item: T, func: impl FnOnce(&mut Self) -> R) -> R {
+        if let Some(val) = self.cache.get(&item) {
             return *val;
         }
 
         // We hit a cycle
-        if !self.seen.borrow_mut().insert(item) {
+        if !self.seen.insert(item) {
             return self.fallback;
         }
 
-        let ret = func();
-        self.seen.borrow_mut().pop();
-        self.cache.borrow_mut().insert(item, ret);
+        let ret = func(self);
+        self.seen.pop();
+        self.cache.insert(item, ret);
 
         ret
     }

--- a/crates/ty_python_semantic/src/types/cyclic.rs
+++ b/crates/ty_python_semantic/src/types/cyclic.rs
@@ -1,3 +1,23 @@
+//! Cycle detection for recursive types.
+//!
+//! The visitors here (`TypeTransformer` and `PairVisitor`) are used in methods that recursively
+//! visit types to transform them (e.g. `Type::normalize`) or to decide a relation between a pair
+//! of types (e.g. `Type::has_relation_to`).
+//!
+//! The typical pattern is that the "entry" method (e.g. `Type::has_relation_to`) will create a
+//! visitor and pass it to the recursive method (e.g. `Type::has_relation_to_impl`). Rust types
+//! that form part of a complex type (e.g. tuples, protocols, nominal instances, etc) should
+//! usually just implement the recursive method, and all recursive calls should call the recursive
+//! method and pass along the visitor.
+//!
+//! Not all recursive calls need to actually call `.visit` on the visitor; only when visiting types
+//! that can create a recursive relationship (this includes, for example, type aliases and
+//! protocols).
+//!
+//! There is a risk of double-visiting, for example if `Type::has_relation_to_impl` calls
+//! `visitor.visit` when visiting a protocol type, and then internal `has_relation_to_impl` methods
+//! of the Rust types implementing protocols also call `visitor.visit`. The best way to avoid this
+//! is to prefer always calling `visitor.visit` only in the main recursive method on `Type`.
 use rustc_hash::FxHashMap;
 
 use crate::FxIndexSet;

--- a/crates/ty_python_semantic/src/types/cyclic.rs
+++ b/crates/ty_python_semantic/src/types/cyclic.rs
@@ -42,17 +42,17 @@ pub(crate) type PairVisitor<'db> = CycleDetector<(Type<'db>, Type<'db>), bool>;
 
 #[derive(Debug)]
 pub(crate) struct CycleDetector<T, R> {
-    /// If the type we're visiting is present in `seen`,
-    /// it indicates that we've hit a cycle (due to a recursive type);
-    /// we need to immediately short circuit the whole operation and return the fallback value.
-    /// That's why we pop items off the end of `seen` after we've visited them.
+    /// If the type we're visiting is present in `seen`, it indicates that we've hit a cycle (due
+    /// to a recursive type); we need to immediately short circuit the whole operation and return
+    /// the fallback value. That's why we pop items off the end of `seen` after we've visited them.
     seen: RefCell<FxIndexSet<T>>,
 
-    /// Unlike `seen`, this field is a pure performance optimisation (and an essential one).
-    /// If the type we're trying to normalize is present in `cache`, it doesn't necessarily mean we've hit a cycle:
-    /// it just means that we've already visited this inner type as part of a bigger call chain we're currently in.
-    /// Since this cache is just a performance optimisation, it doesn't make sense to pop items off the end of the
-    /// cache after they've been visited (it would sort-of defeat the point of a cache if we did!)
+    /// Unlike `seen`, this field is a pure performance optimisation (and an essential one). If the
+    /// type we're trying to normalize is present in `cache`, it doesn't necessarily mean we've hit
+    /// a cycle: it just means that we've already visited this inner type as part of a bigger call
+    /// chain we're currently in. Since this cache is just a performance optimisation, it doesn't
+    /// make sense to pop items off the end of the cache after they've been visited (it would
+    /// sort-of defeat the point of a cache if we did!)
     cache: RefCell<FxHashMap<T, R>>,
 
     fallback: R,
@@ -68,8 +68,8 @@ impl<T: Hash + Eq + Copy, R: Copy> CycleDetector<T, R> {
     }
 
     pub(crate) fn visit(&self, item: T, func: impl FnOnce() -> R) -> R {
-        if let Some(ty) = self.cache.borrow().get(&item) {
-            return *ty;
+        if let Some(val) = self.cache.borrow().get(&item) {
+            return *val;
         }
 
         // We hit a cycle

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -243,6 +243,9 @@ impl Display for DisplayRepresentation<'_> {
                 f.write_str("]")
             }
             Type::TypedDict(typed_dict) => f.write_str(typed_dict.defining_class.name(self.db)),
+            Type::TypeAlias(alias) => {
+                write!(f, "{name}", name = alias.name(self.db),)
+            }
         }
     }
 }

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -243,9 +243,7 @@ impl Display for DisplayRepresentation<'_> {
                 f.write_str("]")
             }
             Type::TypedDict(typed_dict) => f.write_str(typed_dict.defining_class.name(self.db)),
-            Type::TypeAlias(alias) => {
-                write!(f, "{name}", name = alias.name(self.db),)
-            }
+            Type::TypeAlias(alias) => f.write_str(alias.name(self.db)),
         }
     }
 }

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -441,7 +441,7 @@ impl get_size2::GetSize for FunctionLiteral<'_> {}
 fn walk_function_literal<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
     function: FunctionLiteral<'db>,
-    visitor: &V,
+    visitor: &mut V,
 ) {
     if let Some(context) = function.inherited_generic_context(db) {
         walk_generic_context(db, context, visitor);
@@ -604,7 +604,7 @@ impl<'db> FunctionLiteral<'db> {
         )
     }
 
-    fn normalized_impl(self, db: &'db dyn Db, visitor: &TypeTransformer<'db>) -> Self {
+    fn normalized_impl(self, db: &'db dyn Db, visitor: &mut TypeTransformer<'db>) -> Self {
         let context = self
             .inherited_generic_context(db)
             .map(|ctx| ctx.normalized_impl(db, visitor));
@@ -632,7 +632,7 @@ impl get_size2::GetSize for FunctionType<'_> {}
 pub(super) fn walk_function_type<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
     function: FunctionType<'db>,
-    visitor: &V,
+    visitor: &mut V,
 ) {
     walk_function_literal(db, function.literal(db), visitor);
     for mapping in function.type_mappings(db) {
@@ -920,10 +920,14 @@ impl<'db> FunctionType<'db> {
     }
 
     pub(crate) fn normalized(self, db: &'db dyn Db) -> Self {
-        self.normalized_impl(db, &TypeTransformer::default())
+        self.normalized_impl(db, &mut TypeTransformer::default())
     }
 
-    pub(crate) fn normalized_impl(self, db: &'db dyn Db, visitor: &TypeTransformer<'db>) -> Self {
+    pub(crate) fn normalized_impl(
+        self,
+        db: &'db dyn Db,
+        visitor: &mut TypeTransformer<'db>,
+    ) -> Self {
         let mappings: Box<_> = self
             .type_mappings(db)
             .iter()

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -1000,6 +1000,8 @@ fn is_instance_truthiness<'db>(
 
         Type::ClassLiteral(..) => always_true_if(is_instance(&KnownClass::Type.to_instance(db))),
 
+        Type::TypeAlias(alias) => is_instance_truthiness(db, alias.value_type(db), class),
+
         Type::BoundMethod(..)
         | Type::MethodWrapper(..)
         | Type::WrapperDescriptor(..)

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -441,7 +441,7 @@ impl get_size2::GetSize for FunctionLiteral<'_> {}
 fn walk_function_literal<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
     function: FunctionLiteral<'db>,
-    visitor: &mut V,
+    visitor: &V,
 ) {
     if let Some(context) = function.inherited_generic_context(db) {
         walk_generic_context(db, context, visitor);
@@ -604,7 +604,7 @@ impl<'db> FunctionLiteral<'db> {
         )
     }
 
-    fn normalized_impl(self, db: &'db dyn Db, visitor: &mut TypeTransformer<'db>) -> Self {
+    fn normalized_impl(self, db: &'db dyn Db, visitor: &TypeTransformer<'db>) -> Self {
         let context = self
             .inherited_generic_context(db)
             .map(|ctx| ctx.normalized_impl(db, visitor));
@@ -632,7 +632,7 @@ impl get_size2::GetSize for FunctionType<'_> {}
 pub(super) fn walk_function_type<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
     function: FunctionType<'db>,
-    visitor: &mut V,
+    visitor: &V,
 ) {
     walk_function_literal(db, function.literal(db), visitor);
     for mapping in function.type_mappings(db) {
@@ -920,14 +920,10 @@ impl<'db> FunctionType<'db> {
     }
 
     pub(crate) fn normalized(self, db: &'db dyn Db) -> Self {
-        self.normalized_impl(db, &mut TypeTransformer::default())
+        self.normalized_impl(db, &TypeTransformer::default())
     }
 
-    pub(crate) fn normalized_impl(
-        self,
-        db: &'db dyn Db,
-        visitor: &mut TypeTransformer<'db>,
-    ) -> Self {
+    pub(crate) fn normalized_impl(self, db: &'db dyn Db, visitor: &TypeTransformer<'db>) -> Self {
         let mappings: Box<_> = self
             .type_mappings(db)
             .iter()

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -464,15 +464,14 @@ impl<'db> Specialization<'db> {
         db: &'db dyn Db,
         type_mapping: &TypeMapping<'a, 'db>,
     ) -> Self {
-        let mut visitor = TypeTransformer::default();
-        self.apply_type_mapping_impl(db, type_mapping, &mut visitor)
+        self.apply_type_mapping_impl(db, type_mapping, &TypeTransformer::default())
     }
 
     pub(crate) fn apply_type_mapping_impl<'a>(
         self,
         db: &'db dyn Db,
         type_mapping: &TypeMapping<'a, 'db>,
-        visitor: &mut TypeTransformer<'db>,
+        visitor: &TypeTransformer<'db>,
     ) -> Self {
         let types: Box<[_]> = self
             .types(db)
@@ -564,7 +563,7 @@ impl<'db> Specialization<'db> {
         db: &'db dyn Db,
         other: Self,
         relation: TypeRelation,
-        visitor: &mut PairVisitor<'db>,
+        visitor: &PairVisitor<'db>,
     ) -> bool {
         let generic_context = self.generic_context(db);
         if generic_context != other.generic_context(db) {

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -304,9 +304,9 @@ impl<'db> GenericContext<'db> {
     pub(crate) fn specialize_tuple(
         self,
         db: &'db dyn Db,
+        element_type: Type<'db>,
         tuple: TupleType<'db>,
     ) -> Specialization<'db> {
-        let element_type = tuple.tuple(db).homogeneous_element_type(db);
         Specialization::new(db, self, Box::from([element_type]), Some(tuple))
     }
 

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -99,7 +99,7 @@ pub struct GenericContext<'db> {
 pub(super) fn walk_generic_context<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
     context: GenericContext<'db>,
-    visitor: &mut V,
+    visitor: &V,
 ) {
     for bound_typevar in context.variables(db) {
         visitor.visit_bound_type_var_type(db, *bound_typevar);
@@ -355,11 +355,7 @@ impl<'db> GenericContext<'db> {
         Specialization::new(db, self, expanded.into_boxed_slice(), None)
     }
 
-    pub(crate) fn normalized_impl(
-        self,
-        db: &'db dyn Db,
-        visitor: &mut TypeTransformer<'db>,
-    ) -> Self {
+    pub(crate) fn normalized_impl(self, db: &'db dyn Db, visitor: &TypeTransformer<'db>) -> Self {
         let variables: FxOrderSet<_> = self
             .variables(db)
             .iter()
@@ -415,7 +411,7 @@ impl get_size2::GetSize for Specialization<'_> {}
 pub(super) fn walk_specialization<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
     specialization: Specialization<'db>,
-    visitor: &mut V,
+    visitor: &V,
 ) {
     walk_generic_context(db, specialization.generic_context(db), visitor);
     for ty in specialization.types(db) {
@@ -468,14 +464,14 @@ impl<'db> Specialization<'db> {
         db: &'db dyn Db,
         type_mapping: &TypeMapping<'a, 'db>,
     ) -> Self {
-        self.apply_type_mapping_impl(db, type_mapping, &mut TypeTransformer::default())
+        self.apply_type_mapping_impl(db, type_mapping, &TypeTransformer::default())
     }
 
     pub(crate) fn apply_type_mapping_impl<'a>(
         self,
         db: &'db dyn Db,
         type_mapping: &TypeMapping<'a, 'db>,
-        visitor: &mut TypeTransformer<'db>,
+        visitor: &TypeTransformer<'db>,
     ) -> Self {
         let types: Box<[_]> = self
             .types(db)
@@ -526,11 +522,7 @@ impl<'db> Specialization<'db> {
         Specialization::new(db, self.generic_context(db), types, None)
     }
 
-    pub(crate) fn normalized_impl(
-        self,
-        db: &'db dyn Db,
-        visitor: &mut TypeTransformer<'db>,
-    ) -> Self {
+    pub(crate) fn normalized_impl(self, db: &'db dyn Db, visitor: &TypeTransformer<'db>) -> Self {
         let types: Box<[_]> = self
             .types(db)
             .iter()
@@ -571,7 +563,7 @@ impl<'db> Specialization<'db> {
         db: &'db dyn Db,
         other: Self,
         relation: TypeRelation,
-        visitor: &mut PairVisitor<'db>,
+        visitor: &PairVisitor<'db>,
     ) -> bool {
         let generic_context = self.generic_context(db);
         if generic_context != other.generic_context(db) {
@@ -691,7 +683,7 @@ pub struct PartialSpecialization<'a, 'db> {
 pub(super) fn walk_partial_specialization<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
     specialization: &PartialSpecialization<'_, 'db>,
-    visitor: &mut V,
+    visitor: &V,
 ) {
     walk_generic_context(db, specialization.generic_context, visitor);
     for ty in &*specialization.types {
@@ -724,7 +716,7 @@ impl<'db> PartialSpecialization<'_, 'db> {
     pub(crate) fn normalized_impl(
         &self,
         db: &'db dyn Db,
-        visitor: &mut TypeTransformer<'db>,
+        visitor: &TypeTransformer<'db>,
     ) -> PartialSpecialization<'db, 'db> {
         let generic_context = self.generic_context.normalized_impl(db, visitor);
         let types: Cow<_> = self

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -464,14 +464,24 @@ impl<'db> Specialization<'db> {
         db: &'db dyn Db,
         type_mapping: &TypeMapping<'a, 'db>,
     ) -> Self {
+        let mut visitor = TypeTransformer::default();
+        self.apply_type_mapping_impl(db, type_mapping, &mut visitor)
+    }
+
+    pub(crate) fn apply_type_mapping_impl<'a>(
+        self,
+        db: &'db dyn Db,
+        type_mapping: &TypeMapping<'a, 'db>,
+        visitor: &mut TypeTransformer<'db>,
+    ) -> Self {
         let types: Box<[_]> = self
             .types(db)
             .iter()
-            .map(|ty| ty.apply_type_mapping(db, type_mapping))
+            .map(|ty| ty.apply_type_mapping_impl(db, type_mapping, visitor))
             .collect();
         let tuple_inner = self
             .tuple_inner(db)
-            .and_then(|tuple| tuple.apply_type_mapping(db, type_mapping));
+            .and_then(|tuple| tuple.apply_type_mapping_impl(db, type_mapping, visitor));
         Specialization::new(db, self.generic_context(db), types, tuple_inner)
     }
 

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -132,6 +132,8 @@ impl<'db> AllMembers<'db> {
 
             Type::Dynamic(_) | Type::Never | Type::AlwaysTruthy | Type::AlwaysFalsy => {}
 
+            Type::TypeAlias(alias) => self.extend_with_type(db, alias.value_type(db)),
+
             Type::IntLiteral(_)
             | Type::BooleanLiteral(_)
             | Type::StringLiteral(_)

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -7151,10 +7151,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let operand_type = self.infer_expression(operand);
 
-        self.infer_unary_expression_impl(*op, operand_type, unary)
+        self.infer_unary_expression_type(*op, operand_type, unary)
     }
 
-    fn infer_unary_expression_impl(
+    fn infer_unary_expression_type(
         &mut self,
         op: ast::UnaryOp,
         operand_type: Type<'db>,
@@ -7165,7 +7165,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             (_, Type::Never) => Type::Never,
 
             (_, Type::TypeAlias(alias)) => {
-                self.infer_unary_expression_impl(op, alias.value_type(self.db()), unary)
+                self.infer_unary_expression_type(op, alias.value_type(self.db()), unary)
             }
 
             (ast::UnaryOp::UAdd, Type::IntLiteral(value)) => Type::IntLiteral(value),

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -3956,6 +3956,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
             }
 
+            Type::TypeAlias(alias) => self.validate_attribute_assignment(
+                target,
+                alias.value_type(self.db()),
+                attribute,
+                value_ty,
+                emit_diagnostics,
+            ),
+
             // Super instances do not allow attribute assignment
             Type::NominalInstance(instance)
                 if instance.class(db).is_known(db, KnownClass::Super) =>
@@ -7143,9 +7151,22 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let operand_type = self.infer_expression(operand);
 
+        self.infer_unary_expression_impl(*op, operand_type, unary)
+    }
+
+    fn infer_unary_expression_impl(
+        &mut self,
+        op: ast::UnaryOp,
+        operand_type: Type<'db>,
+        unary: &ast::ExprUnaryOp,
+    ) -> Type<'db> {
         match (op, operand_type) {
             (_, Type::Dynamic(_)) => operand_type,
             (_, Type::Never) => Type::Never,
+
+            (_, Type::TypeAlias(alias)) => {
+                self.infer_unary_expression_impl(op, alias.value_type(self.db()), unary)
+            }
 
             (ast::UnaryOp::UAdd, Type::IntLiteral(value)) => Type::IntLiteral(value),
             (ast::UnaryOp::USub, Type::IntLiteral(value)) => Type::IntLiteral(-value),
@@ -7306,6 +7327,22 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     op,
                 )
             }),
+
+            (Type::TypeAlias(alias), rhs, _) => self.infer_binary_expression_type(
+                node,
+                emitted_division_by_zero_diagnostic,
+                alias.value_type(self.db()),
+                rhs,
+                op,
+            ),
+
+            (lhs, Type::TypeAlias(alias), _) => self.infer_binary_expression_type(
+                node,
+                emitted_division_by_zero_diagnostic,
+                lhs,
+                alias.value_type(self.db()),
+                op,
+            ),
 
             // Non-todo Anys take precedence over Todos (as if we fix this `Todo` in the future,
             // the result would then become Any or Unknown, respectively).

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -260,20 +260,21 @@ impl<'db> NominalInstanceType<'db> {
         }
     }
 
-    pub(super) fn has_relation_to(
+    pub(super) fn has_relation_to_impl(
         self,
         db: &'db dyn Db,
         other: Self,
         relation: TypeRelation,
+        visitor: &mut PairVisitor<'db>,
     ) -> bool {
         match (self.0, other.0) {
             (
                 NominalInstanceInner::ExactTuple(tuple1),
                 NominalInstanceInner::ExactTuple(tuple2),
-            ) => tuple1.has_relation_to(db, tuple2, relation),
+            ) => tuple1.has_relation_to_impl(db, tuple2, relation, visitor),
             _ => self
                 .class(db)
-                .has_relation_to(db, other.class(db), relation),
+                .has_relation_to_impl(db, other.class(db), relation, visitor),
         }
     }
 

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -66,7 +66,7 @@ impl<'db> Type<'db> {
             SynthesizedProtocolType::new(
                 db,
                 ProtocolInterface::with_property_members(db, members),
-                &mut TypeTransformer::default(),
+                &TypeTransformer::default(),
             ),
         ))
     }
@@ -97,7 +97,7 @@ pub struct NominalInstanceType<'db>(
 pub(super) fn walk_nominal_instance_type<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
     nominal: NominalInstanceType<'db>,
-    visitor: &mut V,
+    visitor: &V,
 ) {
     visitor.visit_type(db, nominal.class(db).into());
 }
@@ -239,7 +239,7 @@ impl<'db> NominalInstanceType<'db> {
     pub(super) fn normalized_impl(
         self,
         db: &'db dyn Db,
-        visitor: &mut TypeTransformer<'db>,
+        visitor: &TypeTransformer<'db>,
     ) -> Type<'db> {
         match self.0 {
             NominalInstanceInner::ExactTuple(tuple) => {
@@ -265,7 +265,7 @@ impl<'db> NominalInstanceType<'db> {
         db: &'db dyn Db,
         other: Self,
         relation: TypeRelation,
-        visitor: &mut PairVisitor<'db>,
+        visitor: &PairVisitor<'db>,
     ) -> bool {
         match (self.0, other.0) {
             (
@@ -295,7 +295,7 @@ impl<'db> NominalInstanceType<'db> {
         self,
         db: &'db dyn Db,
         other: Self,
-        visitor: &mut PairVisitor<'db>,
+        visitor: &PairVisitor<'db>,
     ) -> bool {
         let self_spec = self.tuple_spec(db);
         if let Some(self_spec) = self_spec.as_deref() {
@@ -345,7 +345,7 @@ impl<'db> NominalInstanceType<'db> {
         self,
         db: &'db dyn Db,
         type_mapping: &TypeMapping<'a, 'db>,
-        visitor: &mut TypeTransformer<'db>,
+        visitor: &TypeTransformer<'db>,
     ) -> Type<'db> {
         match self.0 {
             NominalInstanceInner::ExactTuple(tuple) => {
@@ -421,7 +421,7 @@ pub struct ProtocolInstanceType<'db> {
 pub(super) fn walk_protocol_instance_type<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
     protocol: ProtocolInstanceType<'db>,
-    visitor: &mut V,
+    visitor: &V,
 ) {
     walk_protocol_interface(db, protocol.inner.interface(db), visitor);
 }
@@ -471,7 +471,7 @@ impl<'db> ProtocolInstanceType<'db> {
     ///
     /// See [`Type::normalized`] for more details.
     pub(super) fn normalized(self, db: &'db dyn Db) -> Type<'db> {
-        self.normalized_impl(db, &mut TypeTransformer::default())
+        self.normalized_impl(db, &TypeTransformer::default())
     }
 
     /// Return a "normalized" version of this `Protocol` type.
@@ -480,7 +480,7 @@ impl<'db> ProtocolInstanceType<'db> {
     pub(super) fn normalized_impl(
         self,
         db: &'db dyn Db,
-        visitor: &mut TypeTransformer<'db>,
+        visitor: &TypeTransformer<'db>,
     ) -> Type<'db> {
         let object = Type::object(db);
         if object.satisfies_protocol(db, self, TypeRelation::Subtyping) {
@@ -532,7 +532,7 @@ impl<'db> ProtocolInstanceType<'db> {
         self,
         _db: &'db dyn Db,
         _other: Self,
-        _visitor: &mut PairVisitor<'db>,
+        _visitor: &PairVisitor<'db>,
     ) -> bool {
         false
     }
@@ -558,7 +558,7 @@ impl<'db> ProtocolInstanceType<'db> {
         self,
         db: &'db dyn Db,
         type_mapping: &TypeMapping<'a, 'db>,
-        visitor: &mut TypeTransformer<'db>,
+        visitor: &TypeTransformer<'db>,
     ) -> Self {
         match self.inner {
             Protocol::FromClass(class) => {
@@ -640,7 +640,7 @@ mod synthesized_protocol {
         pub(super) fn new(
             db: &'db dyn Db,
             interface: ProtocolInterface<'db>,
-            visitor: &mut TypeTransformer<'db>,
+            visitor: &TypeTransformer<'db>,
         ) -> Self {
             Self(interface.normalized_impl(db, visitor))
         }
@@ -653,7 +653,7 @@ mod synthesized_protocol {
             self,
             db: &'db dyn Db,
             type_mapping: &TypeMapping<'a, 'db>,
-            _visitor: &mut TypeTransformer<'db>,
+            _visitor: &TypeTransformer<'db>,
         ) -> Self {
             Self(self.0.specialized_and_normalized(db, type_mapping))
         }

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -66,7 +66,7 @@ impl<'db> Type<'db> {
             SynthesizedProtocolType::new(
                 db,
                 ProtocolInterface::with_property_members(db, members),
-                &TypeTransformer::default(),
+                &mut TypeTransformer::default(),
             ),
         ))
     }
@@ -97,7 +97,7 @@ pub struct NominalInstanceType<'db>(
 pub(super) fn walk_nominal_instance_type<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
     nominal: NominalInstanceType<'db>,
-    visitor: &V,
+    visitor: &mut V,
 ) {
     visitor.visit_type(db, nominal.class(db).into());
 }
@@ -239,7 +239,7 @@ impl<'db> NominalInstanceType<'db> {
     pub(super) fn normalized_impl(
         self,
         db: &'db dyn Db,
-        visitor: &TypeTransformer<'db>,
+        visitor: &mut TypeTransformer<'db>,
     ) -> Type<'db> {
         match self.0 {
             NominalInstanceInner::ExactTuple(tuple) => {
@@ -265,7 +265,7 @@ impl<'db> NominalInstanceType<'db> {
         db: &'db dyn Db,
         other: Self,
         relation: TypeRelation,
-        visitor: &PairVisitor<'db>,
+        visitor: &mut PairVisitor<'db>,
     ) -> bool {
         match (self.0, other.0) {
             (
@@ -295,7 +295,7 @@ impl<'db> NominalInstanceType<'db> {
         self,
         db: &'db dyn Db,
         other: Self,
-        visitor: &PairVisitor<'db>,
+        visitor: &mut PairVisitor<'db>,
     ) -> bool {
         let self_spec = self.tuple_spec(db);
         if let Some(self_spec) = self_spec.as_deref() {
@@ -345,7 +345,7 @@ impl<'db> NominalInstanceType<'db> {
         self,
         db: &'db dyn Db,
         type_mapping: &TypeMapping<'a, 'db>,
-        visitor: &TypeTransformer<'db>,
+        visitor: &mut TypeTransformer<'db>,
     ) -> Type<'db> {
         match self.0 {
             NominalInstanceInner::ExactTuple(tuple) => {
@@ -421,7 +421,7 @@ pub struct ProtocolInstanceType<'db> {
 pub(super) fn walk_protocol_instance_type<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
     protocol: ProtocolInstanceType<'db>,
-    visitor: &V,
+    visitor: &mut V,
 ) {
     walk_protocol_interface(db, protocol.inner.interface(db), visitor);
 }
@@ -471,7 +471,7 @@ impl<'db> ProtocolInstanceType<'db> {
     ///
     /// See [`Type::normalized`] for more details.
     pub(super) fn normalized(self, db: &'db dyn Db) -> Type<'db> {
-        self.normalized_impl(db, &TypeTransformer::default())
+        self.normalized_impl(db, &mut TypeTransformer::default())
     }
 
     /// Return a "normalized" version of this `Protocol` type.
@@ -480,7 +480,7 @@ impl<'db> ProtocolInstanceType<'db> {
     pub(super) fn normalized_impl(
         self,
         db: &'db dyn Db,
-        visitor: &TypeTransformer<'db>,
+        visitor: &mut TypeTransformer<'db>,
     ) -> Type<'db> {
         let object = Type::object(db);
         if object.satisfies_protocol(db, self, TypeRelation::Subtyping) {
@@ -532,7 +532,7 @@ impl<'db> ProtocolInstanceType<'db> {
         self,
         _db: &'db dyn Db,
         _other: Self,
-        _visitor: &PairVisitor<'db>,
+        _visitor: &mut PairVisitor<'db>,
     ) -> bool {
         false
     }
@@ -558,7 +558,7 @@ impl<'db> ProtocolInstanceType<'db> {
         self,
         db: &'db dyn Db,
         type_mapping: &TypeMapping<'a, 'db>,
-        visitor: &TypeTransformer<'db>,
+        visitor: &mut TypeTransformer<'db>,
     ) -> Self {
         match self.inner {
             Protocol::FromClass(class) => {
@@ -640,7 +640,7 @@ mod synthesized_protocol {
         pub(super) fn new(
             db: &'db dyn Db,
             interface: ProtocolInterface<'db>,
-            visitor: &TypeTransformer<'db>,
+            visitor: &mut TypeTransformer<'db>,
         ) -> Self {
             Self(interface.normalized_impl(db, visitor))
         }
@@ -653,7 +653,7 @@ mod synthesized_protocol {
             self,
             db: &'db dyn Db,
             type_mapping: &TypeMapping<'a, 'db>,
-            _visitor: &TypeTransformer<'db>,
+            _visitor: &mut TypeTransformer<'db>,
         ) -> Self {
             Self(self.0.specialized_and_normalized(db, type_mapping))
         }

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -265,7 +265,7 @@ impl<'db> NominalInstanceType<'db> {
         db: &'db dyn Db,
         other: Self,
         relation: TypeRelation,
-        visitor: &mut PairVisitor<'db>,
+        visitor: &PairVisitor<'db>,
     ) -> bool {
         match (self.0, other.0) {
             (
@@ -345,7 +345,7 @@ impl<'db> NominalInstanceType<'db> {
         self,
         db: &'db dyn Db,
         type_mapping: &TypeMapping<'a, 'db>,
-        visitor: &mut TypeTransformer<'db>,
+        visitor: &TypeTransformer<'db>,
     ) -> Type<'db> {
         match self.0 {
             NominalInstanceInner::ExactTuple(tuple) => {
@@ -558,7 +558,7 @@ impl<'db> ProtocolInstanceType<'db> {
         self,
         db: &'db dyn Db,
         type_mapping: &TypeMapping<'a, 'db>,
-        visitor: &mut TypeTransformer<'db>,
+        visitor: &TypeTransformer<'db>,
     ) -> Self {
         match self.inner {
             Protocol::FromClass(class) => {
@@ -653,7 +653,7 @@ mod synthesized_protocol {
             self,
             db: &'db dyn Db,
             type_mapping: &TypeMapping<'a, 'db>,
-            _visitor: &mut TypeTransformer<'db>,
+            _visitor: &TypeTransformer<'db>,
         ) -> Self {
             Self(self.0.specialized_and_normalized(db, type_mapping))
         }

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -182,6 +182,7 @@ impl ClassInfoConstraintFunction {
         };
 
         match classinfo {
+            Type::TypeAlias(alias) => self.generate_constraint(db, alias.value_type(db)),
             Type::ClassLiteral(class_literal) => {
                 // At runtime (on Python 3.11+), this will return `True` for classes that actually
                 // do inherit `typing.Any` and `False` otherwise. We could accurately model that?

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -82,7 +82,7 @@ impl get_size2::GetSize for ProtocolInterface<'_> {}
 pub(super) fn walk_protocol_interface<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
     interface: ProtocolInterface<'db>,
-    visitor: &mut V,
+    visitor: &V,
 ) {
     for member in interface.members(db) {
         walk_protocol_member(db, &member, visitor);
@@ -165,11 +165,7 @@ impl<'db> ProtocolInterface<'db> {
             .all(|member_name| other.inner(db).contains_key(member_name))
     }
 
-    pub(super) fn normalized_impl(
-        self,
-        db: &'db dyn Db,
-        visitor: &mut TypeTransformer<'db>,
-    ) -> Self {
+    pub(super) fn normalized_impl(self, db: &'db dyn Db, visitor: &TypeTransformer<'db>) -> Self {
         Self::new(
             db,
             self.inner(db)
@@ -253,10 +249,10 @@ pub(super) struct ProtocolMemberData<'db> {
 
 impl<'db> ProtocolMemberData<'db> {
     fn normalized(&self, db: &'db dyn Db) -> Self {
-        self.normalized_impl(db, &mut TypeTransformer::default())
+        self.normalized_impl(db, &TypeTransformer::default())
     }
 
-    fn normalized_impl(&self, db: &'db dyn Db, visitor: &mut TypeTransformer<'db>) -> Self {
+    fn normalized_impl(&self, db: &'db dyn Db, visitor: &TypeTransformer<'db>) -> Self {
         Self {
             kind: self.kind.normalized_impl(db, visitor),
             qualifiers: self.qualifiers,
@@ -331,7 +327,7 @@ enum ProtocolMemberKind<'db> {
 }
 
 impl<'db> ProtocolMemberKind<'db> {
-    fn normalized_impl(&self, db: &'db dyn Db, visitor: &mut TypeTransformer<'db>) -> Self {
+    fn normalized_impl(&self, db: &'db dyn Db, visitor: &TypeTransformer<'db>) -> Self {
         match self {
             ProtocolMemberKind::Method(callable) => {
                 ProtocolMemberKind::Method(callable.normalized_impl(db, visitor))
@@ -404,7 +400,7 @@ pub(super) struct ProtocolMember<'a, 'db> {
 fn walk_protocol_member<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
     member: &ProtocolMember<'_, 'db>,
-    visitor: &mut V,
+    visitor: &V,
 ) {
     match member.kind {
         ProtocolMemberKind::Method(method) => visitor.visit_callable_type(db, method),
@@ -436,7 +432,7 @@ impl<'a, 'db> ProtocolMember<'a, 'db> {
         &self,
         db: &'db dyn Db,
         other: Type<'db>,
-        visitor: &mut PairVisitor<'db>,
+        visitor: &PairVisitor<'db>,
     ) -> bool {
         match &self.kind {
             // TODO: implement disjointness for property/method members as well as attribute members

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -82,7 +82,7 @@ impl get_size2::GetSize for ProtocolInterface<'_> {}
 pub(super) fn walk_protocol_interface<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
     interface: ProtocolInterface<'db>,
-    visitor: &V,
+    visitor: &mut V,
 ) {
     for member in interface.members(db) {
         walk_protocol_member(db, &member, visitor);
@@ -165,7 +165,11 @@ impl<'db> ProtocolInterface<'db> {
             .all(|member_name| other.inner(db).contains_key(member_name))
     }
 
-    pub(super) fn normalized_impl(self, db: &'db dyn Db, visitor: &TypeTransformer<'db>) -> Self {
+    pub(super) fn normalized_impl(
+        self,
+        db: &'db dyn Db,
+        visitor: &mut TypeTransformer<'db>,
+    ) -> Self {
         Self::new(
             db,
             self.inner(db)
@@ -249,10 +253,10 @@ pub(super) struct ProtocolMemberData<'db> {
 
 impl<'db> ProtocolMemberData<'db> {
     fn normalized(&self, db: &'db dyn Db) -> Self {
-        self.normalized_impl(db, &TypeTransformer::default())
+        self.normalized_impl(db, &mut TypeTransformer::default())
     }
 
-    fn normalized_impl(&self, db: &'db dyn Db, visitor: &TypeTransformer<'db>) -> Self {
+    fn normalized_impl(&self, db: &'db dyn Db, visitor: &mut TypeTransformer<'db>) -> Self {
         Self {
             kind: self.kind.normalized_impl(db, visitor),
             qualifiers: self.qualifiers,
@@ -327,7 +331,7 @@ enum ProtocolMemberKind<'db> {
 }
 
 impl<'db> ProtocolMemberKind<'db> {
-    fn normalized_impl(&self, db: &'db dyn Db, visitor: &TypeTransformer<'db>) -> Self {
+    fn normalized_impl(&self, db: &'db dyn Db, visitor: &mut TypeTransformer<'db>) -> Self {
         match self {
             ProtocolMemberKind::Method(callable) => {
                 ProtocolMemberKind::Method(callable.normalized_impl(db, visitor))
@@ -400,7 +404,7 @@ pub(super) struct ProtocolMember<'a, 'db> {
 fn walk_protocol_member<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
     member: &ProtocolMember<'_, 'db>,
-    visitor: &V,
+    visitor: &mut V,
 ) {
     match member.kind {
         ProtocolMemberKind::Method(method) => visitor.visit_callable_type(db, method),
@@ -432,7 +436,7 @@ impl<'a, 'db> ProtocolMember<'a, 'db> {
         &self,
         db: &'db dyn Db,
         other: Type<'db>,
-        visitor: &PairVisitor<'db>,
+        visitor: &mut PairVisitor<'db>,
     ) -> bool {
         match &self.kind {
             // TODO: implement disjointness for property/method members as well as attribute members

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -437,9 +437,7 @@ impl<'a, 'db> ProtocolMember<'a, 'db> {
         match &self.kind {
             // TODO: implement disjointness for property/method members as well as attribute members
             ProtocolMemberKind::Property(_) | ProtocolMemberKind::Method(_) => false,
-            ProtocolMemberKind::Other(ty) => visitor.visit((*ty, other), || {
-                ty.is_disjoint_from_impl(db, other, visitor)
-            }),
+            ProtocolMemberKind::Other(ty) => ty.is_disjoint_from_impl(db, other, visitor),
         }
     }
 

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -61,7 +61,11 @@ impl<'db> CallableSignature<'db> {
         )
     }
 
-    pub(crate) fn normalized_impl(&self, db: &'db dyn Db, visitor: &TypeTransformer<'db>) -> Self {
+    pub(crate) fn normalized_impl(
+        &self,
+        db: &'db dyn Db,
+        visitor: &mut TypeTransformer<'db>,
+    ) -> Self {
         Self::from_overloads(
             self.overloads
                 .iter()
@@ -241,7 +245,7 @@ pub struct Signature<'db> {
 pub(super) fn walk_signature<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
     signature: &Signature<'db>,
-    visitor: &V,
+    visitor: &mut V,
 ) {
     if let Some(generic_context) = &signature.generic_context {
         walk_generic_context(db, *generic_context, visitor);
@@ -380,7 +384,11 @@ impl<'db> Signature<'db> {
         }
     }
 
-    pub(crate) fn normalized_impl(&self, db: &'db dyn Db, visitor: &TypeTransformer<'db>) -> Self {
+    pub(crate) fn normalized_impl(
+        &self,
+        db: &'db dyn Db,
+        visitor: &mut TypeTransformer<'db>,
+    ) -> Self {
         Self {
             generic_context: self
                 .generic_context
@@ -1360,7 +1368,11 @@ impl<'db> Parameter<'db> {
     /// Normalize nested unions and intersections in the annotated type, if any.
     ///
     /// See [`Type::normalized`] for more details.
-    pub(crate) fn normalized_impl(&self, db: &'db dyn Db, visitor: &TypeTransformer<'db>) -> Self {
+    pub(crate) fn normalized_impl(
+        &self,
+        db: &'db dyn Db,
+        visitor: &mut TypeTransformer<'db>,
+    ) -> Self {
         let Parameter {
             annotated_type,
             kind,

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -61,11 +61,7 @@ impl<'db> CallableSignature<'db> {
         )
     }
 
-    pub(crate) fn normalized_impl(
-        &self,
-        db: &'db dyn Db,
-        visitor: &mut TypeTransformer<'db>,
-    ) -> Self {
+    pub(crate) fn normalized_impl(&self, db: &'db dyn Db, visitor: &TypeTransformer<'db>) -> Self {
         Self::from_overloads(
             self.overloads
                 .iter()
@@ -245,7 +241,7 @@ pub struct Signature<'db> {
 pub(super) fn walk_signature<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
     signature: &Signature<'db>,
-    visitor: &mut V,
+    visitor: &V,
 ) {
     if let Some(generic_context) = &signature.generic_context {
         walk_generic_context(db, *generic_context, visitor);
@@ -384,11 +380,7 @@ impl<'db> Signature<'db> {
         }
     }
 
-    pub(crate) fn normalized_impl(
-        &self,
-        db: &'db dyn Db,
-        visitor: &mut TypeTransformer<'db>,
-    ) -> Self {
+    pub(crate) fn normalized_impl(&self, db: &'db dyn Db, visitor: &TypeTransformer<'db>) -> Self {
         Self {
             generic_context: self
                 .generic_context
@@ -1368,11 +1360,7 @@ impl<'db> Parameter<'db> {
     /// Normalize nested unions and intersections in the annotated type, if any.
     ///
     /// See [`Type::normalized`] for more details.
-    pub(crate) fn normalized_impl(
-        &self,
-        db: &'db dyn Db,
-        visitor: &mut TypeTransformer<'db>,
-    ) -> Self {
+    pub(crate) fn normalized_impl(&self, db: &'db dyn Db, visitor: &TypeTransformer<'db>) -> Self {
         let Parameter {
             annotated_type,
             kind,

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -116,7 +116,7 @@ impl<'db> SubclassOfType<'db> {
         self,
         db: &'db dyn Db,
         type_mapping: &TypeMapping<'a, 'db>,
-        visitor: &mut TypeTransformer<'db>,
+        visitor: &TypeTransformer<'db>,
     ) -> Self {
         match self.subclass_of {
             SubclassOfInner::Class(class) => Self {
@@ -159,7 +159,7 @@ impl<'db> SubclassOfType<'db> {
         db: &'db dyn Db,
         other: SubclassOfType<'db>,
         relation: TypeRelation,
-        visitor: &mut PairVisitor<'db>,
+        visitor: &PairVisitor<'db>,
     ) -> bool {
         match (self.subclass_of, other.subclass_of) {
             (SubclassOfInner::Dynamic(_), SubclassOfInner::Dynamic(_)) => {

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -4,7 +4,7 @@ use crate::place::PlaceAndQualifiers;
 use crate::semantic_index::definition::Definition;
 use crate::types::{
     BindingContext, BoundTypeVarInstance, ClassType, DynamicType, KnownClass, MemberLookupPolicy,
-    Type, TypeMapping, TypeRelation, TypeTransformer, TypeVarInstance,
+    Type, TypeMapping, TypeRelation, TypeTransformer, TypeVarInstance, cyclic::PairVisitor,
 };
 use crate::{Db, FxOrderSet};
 
@@ -154,11 +154,12 @@ impl<'db> SubclassOfType<'db> {
     }
 
     /// Return `true` if `self` has a certain relation to `other`.
-    pub(crate) fn has_relation_to(
+    pub(crate) fn has_relation_to_impl(
         self,
         db: &'db dyn Db,
         other: SubclassOfType<'db>,
         relation: TypeRelation,
+        visitor: &mut PairVisitor<'db>,
     ) -> bool {
         match (self.subclass_of, other.subclass_of) {
             (SubclassOfInner::Dynamic(_), SubclassOfInner::Dynamic(_)) => {
@@ -173,7 +174,7 @@ impl<'db> SubclassOfType<'db> {
             // and `type[int]` describes all possible runtime subclasses of the class `int`.
             // The first set is a subset of the second set, because `bool` is itself a subclass of `int`.
             (SubclassOfInner::Class(self_class), SubclassOfInner::Class(other_class)) => {
-                self_class.has_relation_to(db, other_class, relation)
+                self_class.has_relation_to_impl(db, other_class, relation, visitor)
             }
         }
     }

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -20,7 +20,7 @@ pub struct SubclassOfType<'db> {
 pub(super) fn walk_subclass_of_type<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
     subclass_of: SubclassOfType<'db>,
-    visitor: &mut V,
+    visitor: &V,
 ) {
     visitor.visit_type(db, Type::from(subclass_of.subclass_of));
 }
@@ -116,7 +116,7 @@ impl<'db> SubclassOfType<'db> {
         self,
         db: &'db dyn Db,
         type_mapping: &TypeMapping<'a, 'db>,
-        visitor: &mut TypeTransformer<'db>,
+        visitor: &TypeTransformer<'db>,
     ) -> Self {
         match self.subclass_of {
             SubclassOfInner::Class(class) => Self {
@@ -159,7 +159,7 @@ impl<'db> SubclassOfType<'db> {
         db: &'db dyn Db,
         other: SubclassOfType<'db>,
         relation: TypeRelation,
-        visitor: &mut PairVisitor<'db>,
+        visitor: &PairVisitor<'db>,
     ) -> bool {
         match (self.subclass_of, other.subclass_of) {
             (SubclassOfInner::Dynamic(_), SubclassOfInner::Dynamic(_)) => {
@@ -191,11 +191,7 @@ impl<'db> SubclassOfType<'db> {
         }
     }
 
-    pub(crate) fn normalized_impl(
-        self,
-        db: &'db dyn Db,
-        visitor: &mut TypeTransformer<'db>,
-    ) -> Self {
+    pub(crate) fn normalized_impl(self, db: &'db dyn Db, visitor: &TypeTransformer<'db>) -> Self {
         Self {
             subclass_of: self.subclass_of.normalized_impl(db, visitor),
         }
@@ -258,11 +254,7 @@ impl<'db> SubclassOfInner<'db> {
         }
     }
 
-    pub(crate) fn normalized_impl(
-        self,
-        db: &'db dyn Db,
-        visitor: &mut TypeTransformer<'db>,
-    ) -> Self {
+    pub(crate) fn normalized_impl(self, db: &'db dyn Db, visitor: &TypeTransformer<'db>) -> Self {
         match self {
             Self::Class(class) => Self::Class(class.normalized_impl(db, visitor)),
             Self::Dynamic(dynamic) => Self::Dynamic(dynamic.normalized()),

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -112,14 +112,19 @@ impl<'db> SubclassOfType<'db> {
         }
     }
 
-    pub(super) fn apply_type_mapping<'a>(
+    pub(super) fn apply_type_mapping_impl<'a>(
         self,
         db: &'db dyn Db,
         type_mapping: &TypeMapping<'a, 'db>,
+        visitor: &mut TypeTransformer<'db>,
     ) -> Self {
         match self.subclass_of {
             SubclassOfInner::Class(class) => Self {
-                subclass_of: SubclassOfInner::Class(class.apply_type_mapping(db, type_mapping)),
+                subclass_of: SubclassOfInner::Class(class.apply_type_mapping_impl(
+                    db,
+                    type_mapping,
+                    visitor,
+                )),
             },
             SubclassOfInner::Dynamic(_) => self,
         }

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -20,7 +20,7 @@ pub struct SubclassOfType<'db> {
 pub(super) fn walk_subclass_of_type<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
     subclass_of: SubclassOfType<'db>,
-    visitor: &V,
+    visitor: &mut V,
 ) {
     visitor.visit_type(db, Type::from(subclass_of.subclass_of));
 }
@@ -116,7 +116,7 @@ impl<'db> SubclassOfType<'db> {
         self,
         db: &'db dyn Db,
         type_mapping: &TypeMapping<'a, 'db>,
-        visitor: &TypeTransformer<'db>,
+        visitor: &mut TypeTransformer<'db>,
     ) -> Self {
         match self.subclass_of {
             SubclassOfInner::Class(class) => Self {
@@ -159,7 +159,7 @@ impl<'db> SubclassOfType<'db> {
         db: &'db dyn Db,
         other: SubclassOfType<'db>,
         relation: TypeRelation,
-        visitor: &PairVisitor<'db>,
+        visitor: &mut PairVisitor<'db>,
     ) -> bool {
         match (self.subclass_of, other.subclass_of) {
             (SubclassOfInner::Dynamic(_), SubclassOfInner::Dynamic(_)) => {
@@ -191,7 +191,11 @@ impl<'db> SubclassOfType<'db> {
         }
     }
 
-    pub(crate) fn normalized_impl(self, db: &'db dyn Db, visitor: &TypeTransformer<'db>) -> Self {
+    pub(crate) fn normalized_impl(
+        self,
+        db: &'db dyn Db,
+        visitor: &mut TypeTransformer<'db>,
+    ) -> Self {
         Self {
             subclass_of: self.subclass_of.normalized_impl(db, visitor),
         }
@@ -254,7 +258,11 @@ impl<'db> SubclassOfInner<'db> {
         }
     }
 
-    pub(crate) fn normalized_impl(self, db: &'db dyn Db, visitor: &TypeTransformer<'db>) -> Self {
+    pub(crate) fn normalized_impl(
+        self,
+        db: &'db dyn Db,
+        visitor: &mut TypeTransformer<'db>,
+    ) -> Self {
         match self {
             Self::Class(class) => Self::Class(class.normalized_impl(db, visitor)),
             Self::Dynamic(dynamic) => Self::Dynamic(dynamic.normalized()),

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -456,9 +456,7 @@ impl<'db> FixedLengthTuple<Type<'db>> {
                     let Some(self_ty) = self_iter.next() else {
                         return false;
                     };
-                    if !visitor.visit((*self_ty, *other_ty), |v| {
-                        self_ty.has_relation_to_impl(db, *other_ty, relation, v)
-                    }) {
+                    if !self_ty.has_relation_to_impl(db, *other_ty, relation, visitor) {
                         return false;
                     }
                 }
@@ -466,9 +464,7 @@ impl<'db> FixedLengthTuple<Type<'db>> {
                     let Some(self_ty) = self_iter.next_back() else {
                         return false;
                     };
-                    if !visitor.visit((*self_ty, *other_ty), |v| {
-                        self_ty.has_relation_to_impl(db, *other_ty, relation, v)
-                    }) {
+                    if !self_ty.has_relation_to_impl(db, *other_ty, relation, visitor) {
                         return false;
                     }
                 }
@@ -476,9 +472,7 @@ impl<'db> FixedLengthTuple<Type<'db>> {
                 // In addition, any remaining elements in this tuple must satisfy the
                 // variable-length portion of the other tuple.
                 self_iter.all(|self_ty| {
-                    visitor.visit((*self_ty, other.variable), |v| {
-                        self_ty.has_relation_to_impl(db, other.variable, relation, v)
-                    })
+                    self_ty.has_relation_to_impl(db, other.variable, relation, visitor)
                 })
             }
         }
@@ -797,9 +791,7 @@ impl<'db> VariableLengthTuple<Type<'db>> {
                     let Some(other_ty) = other_iter.next() else {
                         return false;
                     };
-                    if !visitor.visit((self_ty, other_ty), |v| {
-                        self_ty.has_relation_to_impl(db, other_ty, relation, v)
-                    }) {
+                    if !self_ty.has_relation_to_impl(db, other_ty, relation, visitor) {
                         return false;
                     }
                 }
@@ -808,9 +800,7 @@ impl<'db> VariableLengthTuple<Type<'db>> {
                     let Some(other_ty) = other_iter.next_back() else {
                         return false;
                     };
-                    if !visitor.visit((*self_ty, other_ty), |v| {
-                        self_ty.has_relation_to_impl(db, other_ty, relation, v)
-                    }) {
+                    if !self_ty.has_relation_to_impl(db, other_ty, relation, visitor) {
                         return false;
                     }
                 }
@@ -885,10 +875,8 @@ impl<'db> VariableLengthTuple<Type<'db>> {
                 }
 
                 // And lastly, the variable-length portions must satisfy the relation.
-                visitor.visit((self.variable, other.variable), |v| {
-                    self.variable
-                        .has_relation_to_impl(db, other.variable, relation, v)
-                })
+                self.variable
+                    .has_relation_to_impl(db, other.variable, relation, visitor)
             }
         }
     }

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -24,7 +24,6 @@ use itertools::{Either, EitherOrBoth, Itertools};
 
 use crate::semantic_index::definition::Definition;
 use crate::types::Truthiness;
-use crate::types::builder::UnionStrategy;
 use crate::types::class::{ClassType, KnownClass};
 use crate::types::{
     BoundTypeVarInstance, Type, TypeMapping, TypeRelation, TypeTransformer, TypeVarVariance,
@@ -1035,15 +1034,7 @@ impl<T> Tuple<T> {
 
 impl<'db> Tuple<Type<'db>> {
     pub(crate) fn homogeneous_element_type(&self, db: &'db dyn Db) -> Type<'db> {
-        self.homogeneous_element_type_impl(db, UnionStrategy::EliminateSubtypes)
-    }
-
-    pub(crate) fn homogeneous_element_type_impl(
-        &self,
-        db: &'db dyn Db,
-        union_strategy: UnionStrategy,
-    ) -> Type<'db> {
-        UnionType::from_elements_impl(db, self.all_elements(), union_strategy)
+        UnionType::from_elements(db, self.all_elements())
     }
 
     /// Concatenates another tuple to the end of this tuple, returning a new tuple.

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -224,7 +224,7 @@ impl<'db> TupleType<'db> {
     // N.B. If this method is not Salsa-tracked, we take 10 minutes to check
     // `static-frame` as part of a mypy_primer run! This is because it's called
     // from `NominalInstanceType::class()`, which is a very hot method.
-    #[salsa::tracked(heap_size=ruff_memory_usage::heap_size)]
+    #[salsa::tracked(cycle_fn=to_class_type_cycle_recover, cycle_initial=to_class_type_cycle_initial, heap_size=ruff_memory_usage::heap_size)]
     pub(crate) fn to_class_type(self, db: &'db dyn Db) -> ClassType<'db> {
         let tuple_class = KnownClass::Tuple
             .try_to_class_literal(db)
@@ -279,15 +279,6 @@ impl<'db> TupleType<'db> {
             .find_legacy_typevars(db, binding_context, typevars);
     }
 
-    pub(crate) fn has_relation_to(
-        self,
-        db: &'db dyn Db,
-        other: Self,
-        relation: TypeRelation,
-    ) -> bool {
-        self.has_relation_to_impl(db, other, relation, &mut PairVisitor::new(true))
-    }
-
     pub(crate) fn has_relation_to_impl(
         self,
         db: &'db dyn Db,
@@ -306,6 +297,29 @@ impl<'db> TupleType<'db> {
     pub(crate) fn is_single_valued(self, db: &'db dyn Db) -> bool {
         self.tuple(db).is_single_valued(db)
     }
+}
+
+fn to_class_type_cycle_recover<'db>(
+    _db: &'db dyn Db,
+    _value: &ClassType<'db>,
+    _count: u32,
+    _self: TupleType<'db>,
+) -> salsa::CycleRecoveryAction<ClassType<'db>> {
+    salsa::CycleRecoveryAction::Iterate
+}
+
+fn to_class_type_cycle_initial<'db>(db: &'db dyn Db, self_: TupleType<'db>) -> ClassType<'db> {
+    let tuple_class = KnownClass::Tuple
+        .try_to_class_literal(db)
+        .expect("Typeshed should always have a `tuple` class in `builtins.pyi`");
+
+    tuple_class.apply_specialization(db, |generic_context| {
+        if generic_context.variables(db).len() == 1 {
+            generic_context.specialize_tuple(db, Type::Never, self_)
+        } else {
+            generic_context.default_specialization(db, Some(KnownClass::Tuple))
+        }
+    })
 }
 
 /// A tuple spec describes the contents of a tuple type, which might be fixed- or variable-length.

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -135,7 +135,7 @@ pub struct TupleType<'db> {
 pub(super) fn walk_tuple_type<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
     tuple: TupleType<'db>,
-    visitor: &mut V,
+    visitor: &V,
 ) {
     for element in tuple.tuple(db).all_elements() {
         visitor.visit_type(db, *element);
@@ -246,7 +246,7 @@ impl<'db> TupleType<'db> {
     pub(crate) fn normalized_impl(
         self,
         db: &'db dyn Db,
-        visitor: &mut TypeTransformer<'db>,
+        visitor: &TypeTransformer<'db>,
     ) -> Option<Self> {
         TupleType::new(db, self.tuple(db).normalized_impl(db, visitor))
     }
@@ -259,7 +259,7 @@ impl<'db> TupleType<'db> {
         self,
         db: &'db dyn Db,
         type_mapping: &TypeMapping<'a, 'db>,
-        visitor: &mut TypeTransformer<'db>,
+        visitor: &TypeTransformer<'db>,
     ) -> Option<Self> {
         TupleType::new(
             db,
@@ -283,7 +283,7 @@ impl<'db> TupleType<'db> {
         db: &'db dyn Db,
         other: Self,
         relation: TypeRelation,
-        visitor: &mut PairVisitor<'db>,
+        visitor: &PairVisitor<'db>,
     ) -> bool {
         self.tuple(db)
             .has_relation_to_impl(db, other.tuple(db), relation, visitor)
@@ -401,7 +401,7 @@ impl<'db> FixedLengthTuple<Type<'db>> {
     }
 
     #[must_use]
-    fn normalized_impl(&self, db: &'db dyn Db, visitor: &mut TypeTransformer<'db>) -> Self {
+    fn normalized_impl(&self, db: &'db dyn Db, visitor: &TypeTransformer<'db>) -> Self {
         Self::from_elements(self.0.iter().map(|ty| ty.normalized_impl(db, visitor)))
     }
 
@@ -413,7 +413,7 @@ impl<'db> FixedLengthTuple<Type<'db>> {
         &self,
         db: &'db dyn Db,
         type_mapping: &TypeMapping<'a, 'db>,
-        visitor: &mut TypeTransformer<'db>,
+        visitor: &TypeTransformer<'db>,
     ) -> Self {
         Self::from_elements(
             self.0
@@ -438,7 +438,7 @@ impl<'db> FixedLengthTuple<Type<'db>> {
         db: &'db dyn Db,
         other: &Tuple<Type<'db>>,
         relation: TypeRelation,
-        visitor: &mut PairVisitor<'db>,
+        visitor: &PairVisitor<'db>,
     ) -> bool {
         match other {
             Tuple::Fixed(other) => {
@@ -695,11 +695,7 @@ impl<'db> VariableLengthTuple<Type<'db>> {
     }
 
     #[must_use]
-    fn normalized_impl(
-        &self,
-        db: &'db dyn Db,
-        visitor: &mut TypeTransformer<'db>,
-    ) -> TupleSpec<'db> {
+    fn normalized_impl(&self, db: &'db dyn Db, visitor: &TypeTransformer<'db>) -> TupleSpec<'db> {
         let prefix = self
             .prenormalized_prefix_elements(db, None)
             .map(|ty| ty.normalized_impl(db, visitor))
@@ -728,13 +724,12 @@ impl<'db> VariableLengthTuple<Type<'db>> {
         &self,
         db: &'db dyn Db,
         type_mapping: &TypeMapping<'a, 'db>,
-        visitor: &mut TypeTransformer<'db>,
+        visitor: &TypeTransformer<'db>,
     ) -> TupleSpec<'db> {
         Self::mixed(
             self.prefix
                 .iter()
-                .map(|ty| ty.apply_type_mapping_impl(db, type_mapping, visitor))
-                .collect::<Vec<_>>(),
+                .map(|ty| ty.apply_type_mapping_impl(db, type_mapping, visitor)),
             self.variable
                 .apply_type_mapping_impl(db, type_mapping, visitor),
             self.suffix
@@ -764,7 +759,7 @@ impl<'db> VariableLengthTuple<Type<'db>> {
         db: &'db dyn Db,
         other: &Tuple<Type<'db>>,
         relation: TypeRelation,
-        visitor: &mut PairVisitor<'db>,
+        visitor: &PairVisitor<'db>,
     ) -> bool {
         match other {
             Tuple::Fixed(other) => {
@@ -1040,11 +1035,7 @@ impl<'db> Tuple<Type<'db>> {
         }
     }
 
-    pub(crate) fn normalized_impl(
-        &self,
-        db: &'db dyn Db,
-        visitor: &mut TypeTransformer<'db>,
-    ) -> Self {
+    pub(crate) fn normalized_impl(&self, db: &'db dyn Db, visitor: &TypeTransformer<'db>) -> Self {
         match self {
             Tuple::Fixed(tuple) => Tuple::Fixed(tuple.normalized_impl(db, visitor)),
             Tuple::Variable(tuple) => tuple.normalized_impl(db, visitor),
@@ -1062,7 +1053,7 @@ impl<'db> Tuple<Type<'db>> {
         &self,
         db: &'db dyn Db,
         type_mapping: &TypeMapping<'a, 'db>,
-        visitor: &mut TypeTransformer<'db>,
+        visitor: &TypeTransformer<'db>,
     ) -> Self {
         match self {
             Tuple::Fixed(tuple) => {
@@ -1089,7 +1080,7 @@ impl<'db> Tuple<Type<'db>> {
         db: &'db dyn Db,
         other: &Self,
         relation: TypeRelation,
-        visitor: &mut PairVisitor<'db>,
+        visitor: &PairVisitor<'db>,
     ) -> bool {
         match self {
             Tuple::Fixed(self_tuple) => {
@@ -1117,7 +1108,7 @@ impl<'db> Tuple<Type<'db>> {
         &self,
         db: &'db dyn Db,
         other: &Self,
-        visitor: &mut PairVisitor<'db>,
+        visitor: &PairVisitor<'db>,
     ) -> bool {
         // Two tuples with an incompatible number of required elements must always be disjoint.
         let (self_min, self_max) = self.len().size_hint();
@@ -1135,7 +1126,7 @@ impl<'db> Tuple<Type<'db>> {
             db: &'db dyn Db,
             a: impl IntoIterator<Item = &'s Type<'db>>,
             b: impl IntoIterator<Item = &'s Type<'db>>,
-            visitor: &mut PairVisitor<'db>,
+            visitor: &PairVisitor<'db>,
         ) -> bool
         where
             'db: 's,

--- a/crates/ty_python_semantic/src/types/type_ordering.rs
+++ b/crates/ty_python_semantic/src/types/type_ordering.rs
@@ -204,6 +204,10 @@ pub(super) fn union_or_intersection_elements_ordering<'db>(
         (Type::Dynamic(_), _) => Ordering::Less,
         (_, Type::Dynamic(_)) => Ordering::Greater,
 
+        (Type::TypeAlias(left), Type::TypeAlias(right)) => left.cmp(right),
+        (Type::TypeAlias(_), _) => Ordering::Less,
+        (_, Type::TypeAlias(_)) => Ordering::Greater,
+
         (Type::Union(_), _) | (_, Type::Union(_)) => {
             unreachable!("our type representation does not permit nested unions");
         }

--- a/crates/ty_python_semantic/src/types/visitor.rs
+++ b/crates/ty_python_semantic/src/types/visitor.rs
@@ -117,6 +117,7 @@ enum NonAtomicType<'db> {
     TypeVar(BoundTypeVarInstance<'db>),
     ProtocolInstance(ProtocolInstanceType<'db>),
     TypedDict(TypedDictType<'db>),
+    TypeAlias(TypeAliasType<'db>),
 }
 
 enum TypeKind<'db> {
@@ -183,6 +184,7 @@ impl<'db> From<Type<'db>> for TypeKind<'db> {
             Type::TypedDict(typed_dict) => {
                 TypeKind::NonAtomic(NonAtomicType::TypedDict(typed_dict))
             }
+            Type::TypeAlias(alias) => TypeKind::NonAtomic(NonAtomicType::TypeAlias(alias)),
         }
     }
 }
@@ -221,6 +223,9 @@ fn walk_non_atomic_type<'db, V: TypeVisitor<'db> + ?Sized>(
             visitor.visit_protocol_instance_type(db, protocol);
         }
         NonAtomicType::TypedDict(typed_dict) => visitor.visit_typed_dict_type(db, typed_dict),
+        NonAtomicType::TypeAlias(alias) => {
+            visitor.visit_type(db, alias.value_type(db));
+        }
     }
 }
 

--- a/crates/ty_python_semantic/src/types/visitor.rs
+++ b/crates/ty_python_semantic/src/types/visitor.rs
@@ -224,7 +224,7 @@ fn walk_non_atomic_type<'db, V: TypeVisitor<'db> + ?Sized>(
         }
         NonAtomicType::TypedDict(typed_dict) => visitor.visit_typed_dict_type(db, typed_dict),
         NonAtomicType::TypeAlias(alias) => {
-            visitor.visit_type(db, alias.value_type(db));
+            visitor.visit_type_alias_type(db, alias);
         }
     }
 }

--- a/crates/ty_python_semantic/src/types/visitor.rs
+++ b/crates/ty_python_semantic/src/types/visitor.rs
@@ -15,7 +15,6 @@ use crate::{
         walk_type_var_type, walk_typed_dict_type, walk_typeis_type, walk_union,
     },
 };
-use std::cell::{Cell, RefCell};
 
 /// A visitor trait that recurses into nested types.
 ///
@@ -23,77 +22,97 @@ use std::cell::{Cell, RefCell};
 /// but it makes it easy for implementors of the trait to do so.
 /// See [`any_over_type`] for an example of how to do this.
 pub(crate) trait TypeVisitor<'db> {
-    fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>);
+    fn visit_type(&mut self, db: &'db dyn Db, ty: Type<'db>);
 
-    fn visit_union_type(&self, db: &'db dyn Db, union: UnionType<'db>) {
+    fn visit_union_type(&mut self, db: &'db dyn Db, union: UnionType<'db>) {
         walk_union(db, union, self);
     }
 
-    fn visit_intersection_type(&self, db: &'db dyn Db, intersection: IntersectionType<'db>) {
+    fn visit_intersection_type(&mut self, db: &'db dyn Db, intersection: IntersectionType<'db>) {
         walk_intersection_type(db, intersection, self);
     }
 
-    fn visit_callable_type(&self, db: &'db dyn Db, callable: CallableType<'db>) {
+    fn visit_callable_type(&mut self, db: &'db dyn Db, callable: CallableType<'db>) {
         walk_callable_type(db, callable, self);
     }
 
-    fn visit_property_instance_type(&self, db: &'db dyn Db, property: PropertyInstanceType<'db>) {
+    fn visit_property_instance_type(
+        &mut self,
+        db: &'db dyn Db,
+        property: PropertyInstanceType<'db>,
+    ) {
         walk_property_instance_type(db, property, self);
     }
 
-    fn visit_typeis_type(&self, db: &'db dyn Db, type_is: TypeIsType<'db>) {
+    fn visit_typeis_type(&mut self, db: &'db dyn Db, type_is: TypeIsType<'db>) {
         walk_typeis_type(db, type_is, self);
     }
 
-    fn visit_subclass_of_type(&self, db: &'db dyn Db, subclass_of: SubclassOfType<'db>) {
+    fn visit_subclass_of_type(&mut self, db: &'db dyn Db, subclass_of: SubclassOfType<'db>) {
         walk_subclass_of_type(db, subclass_of, self);
     }
 
-    fn visit_generic_alias_type(&self, db: &'db dyn Db, alias: GenericAlias<'db>) {
+    fn visit_generic_alias_type(&mut self, db: &'db dyn Db, alias: GenericAlias<'db>) {
         walk_generic_alias(db, alias, self);
     }
 
-    fn visit_function_type(&self, db: &'db dyn Db, function: FunctionType<'db>) {
+    fn visit_function_type(&mut self, db: &'db dyn Db, function: FunctionType<'db>) {
         walk_function_type(db, function, self);
     }
 
-    fn visit_bound_method_type(&self, db: &'db dyn Db, method: BoundMethodType<'db>) {
+    fn visit_bound_method_type(&mut self, db: &'db dyn Db, method: BoundMethodType<'db>) {
         walk_bound_method_type(db, method, self);
     }
 
-    fn visit_bound_super_type(&self, db: &'db dyn Db, bound_super: BoundSuperType<'db>) {
+    fn visit_bound_super_type(&mut self, db: &'db dyn Db, bound_super: BoundSuperType<'db>) {
         walk_bound_super_type(db, bound_super, self);
     }
 
-    fn visit_nominal_instance_type(&self, db: &'db dyn Db, nominal: NominalInstanceType<'db>) {
+    fn visit_nominal_instance_type(&mut self, db: &'db dyn Db, nominal: NominalInstanceType<'db>) {
         walk_nominal_instance_type(db, nominal, self);
     }
 
-    fn visit_bound_type_var_type(&self, db: &'db dyn Db, bound_typevar: BoundTypeVarInstance<'db>) {
+    fn visit_bound_type_var_type(
+        &mut self,
+        db: &'db dyn Db,
+        bound_typevar: BoundTypeVarInstance<'db>,
+    ) {
         walk_bound_type_var_type(db, bound_typevar, self);
     }
 
-    fn visit_type_var_type(&self, db: &'db dyn Db, typevar: TypeVarInstance<'db>) {
+    fn visit_type_var_type(&mut self, db: &'db dyn Db, typevar: TypeVarInstance<'db>) {
         walk_type_var_type(db, typevar, self);
     }
 
-    fn visit_protocol_instance_type(&self, db: &'db dyn Db, protocol: ProtocolInstanceType<'db>) {
+    fn visit_protocol_instance_type(
+        &mut self,
+        db: &'db dyn Db,
+        protocol: ProtocolInstanceType<'db>,
+    ) {
         walk_protocol_instance_type(db, protocol, self);
     }
 
-    fn visit_method_wrapper_type(&self, db: &'db dyn Db, method_wrapper: MethodWrapperKind<'db>) {
+    fn visit_method_wrapper_type(
+        &mut self,
+        db: &'db dyn Db,
+        method_wrapper: MethodWrapperKind<'db>,
+    ) {
         walk_method_wrapper_type(db, method_wrapper, self);
     }
 
-    fn visit_known_instance_type(&self, db: &'db dyn Db, known_instance: KnownInstanceType<'db>) {
+    fn visit_known_instance_type(
+        &mut self,
+        db: &'db dyn Db,
+        known_instance: KnownInstanceType<'db>,
+    ) {
         walk_known_instance_type(db, known_instance, self);
     }
 
-    fn visit_type_alias_type(&self, db: &'db dyn Db, type_alias: TypeAliasType<'db>) {
+    fn visit_type_alias_type(&mut self, db: &'db dyn Db, type_alias: TypeAliasType<'db>) {
         walk_type_alias_type(db, type_alias, self);
     }
 
-    fn visit_typed_dict_type(&self, db: &'db dyn Db, typed_dict: TypedDictType<'db>) {
+    fn visit_typed_dict_type(&mut self, db: &'db dyn Db, typed_dict: TypedDictType<'db>) {
         walk_typed_dict_type(db, typed_dict, self);
     }
 }
@@ -192,7 +211,7 @@ impl<'db> From<Type<'db>> for TypeKind<'db> {
 fn walk_non_atomic_type<'db, V: TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
     non_atomic_type: NonAtomicType<'db>,
-    visitor: &V,
+    visitor: &mut V,
 ) {
     match non_atomic_type {
         NonAtomicType::FunctionLiteral(function) => visitor.visit_function_type(db, function),
@@ -240,25 +259,25 @@ pub(super) fn any_over_type<'db>(
 ) -> bool {
     struct AnyOverTypeVisitor<'db, 'a> {
         query: &'a dyn Fn(Type<'db>) -> bool,
-        seen_types: RefCell<FxIndexSet<NonAtomicType<'db>>>,
-        found_matching_type: Cell<bool>,
+        seen_types: FxIndexSet<NonAtomicType<'db>>,
+        found_matching_type: bool,
     }
 
     impl<'db> TypeVisitor<'db> for AnyOverTypeVisitor<'db, '_> {
-        fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {
-            let already_found = self.found_matching_type.get();
+        fn visit_type(&mut self, db: &'db dyn Db, ty: Type<'db>) {
+            let already_found = self.found_matching_type;
             if already_found {
                 return;
             }
             let found = already_found | (self.query)(ty);
-            self.found_matching_type.set(found);
+            self.found_matching_type = found;
             if found {
                 return;
             }
             match TypeKind::from(ty) {
                 TypeKind::Atomic => {}
                 TypeKind::NonAtomic(non_atomic_type) => {
-                    if !self.seen_types.borrow_mut().insert(non_atomic_type) {
+                    if !self.seen_types.insert(non_atomic_type) {
                         // If we have already seen this type, we can skip it.
                         return;
                     }
@@ -268,11 +287,11 @@ pub(super) fn any_over_type<'db>(
         }
     }
 
-    let visitor = AnyOverTypeVisitor {
+    let mut visitor = AnyOverTypeVisitor {
         query,
-        seen_types: RefCell::new(FxIndexSet::default()),
-        found_matching_type: Cell::new(false),
+        seen_types: FxIndexSet::default(),
+        found_matching_type: false,
     };
     visitor.visit_type(db, ty);
-    visitor.found_matching_type.get()
+    visitor.found_matching_type
 }

--- a/crates/ty_python_semantic/src/types/visitor.rs
+++ b/crates/ty_python_semantic/src/types/visitor.rs
@@ -15,6 +15,7 @@ use crate::{
         walk_type_var_type, walk_typed_dict_type, walk_typeis_type, walk_union,
     },
 };
+use std::cell::{Cell, RefCell};
 
 /// A visitor trait that recurses into nested types.
 ///
@@ -22,97 +23,77 @@ use crate::{
 /// but it makes it easy for implementors of the trait to do so.
 /// See [`any_over_type`] for an example of how to do this.
 pub(crate) trait TypeVisitor<'db> {
-    fn visit_type(&mut self, db: &'db dyn Db, ty: Type<'db>);
+    fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>);
 
-    fn visit_union_type(&mut self, db: &'db dyn Db, union: UnionType<'db>) {
+    fn visit_union_type(&self, db: &'db dyn Db, union: UnionType<'db>) {
         walk_union(db, union, self);
     }
 
-    fn visit_intersection_type(&mut self, db: &'db dyn Db, intersection: IntersectionType<'db>) {
+    fn visit_intersection_type(&self, db: &'db dyn Db, intersection: IntersectionType<'db>) {
         walk_intersection_type(db, intersection, self);
     }
 
-    fn visit_callable_type(&mut self, db: &'db dyn Db, callable: CallableType<'db>) {
+    fn visit_callable_type(&self, db: &'db dyn Db, callable: CallableType<'db>) {
         walk_callable_type(db, callable, self);
     }
 
-    fn visit_property_instance_type(
-        &mut self,
-        db: &'db dyn Db,
-        property: PropertyInstanceType<'db>,
-    ) {
+    fn visit_property_instance_type(&self, db: &'db dyn Db, property: PropertyInstanceType<'db>) {
         walk_property_instance_type(db, property, self);
     }
 
-    fn visit_typeis_type(&mut self, db: &'db dyn Db, type_is: TypeIsType<'db>) {
+    fn visit_typeis_type(&self, db: &'db dyn Db, type_is: TypeIsType<'db>) {
         walk_typeis_type(db, type_is, self);
     }
 
-    fn visit_subclass_of_type(&mut self, db: &'db dyn Db, subclass_of: SubclassOfType<'db>) {
+    fn visit_subclass_of_type(&self, db: &'db dyn Db, subclass_of: SubclassOfType<'db>) {
         walk_subclass_of_type(db, subclass_of, self);
     }
 
-    fn visit_generic_alias_type(&mut self, db: &'db dyn Db, alias: GenericAlias<'db>) {
+    fn visit_generic_alias_type(&self, db: &'db dyn Db, alias: GenericAlias<'db>) {
         walk_generic_alias(db, alias, self);
     }
 
-    fn visit_function_type(&mut self, db: &'db dyn Db, function: FunctionType<'db>) {
+    fn visit_function_type(&self, db: &'db dyn Db, function: FunctionType<'db>) {
         walk_function_type(db, function, self);
     }
 
-    fn visit_bound_method_type(&mut self, db: &'db dyn Db, method: BoundMethodType<'db>) {
+    fn visit_bound_method_type(&self, db: &'db dyn Db, method: BoundMethodType<'db>) {
         walk_bound_method_type(db, method, self);
     }
 
-    fn visit_bound_super_type(&mut self, db: &'db dyn Db, bound_super: BoundSuperType<'db>) {
+    fn visit_bound_super_type(&self, db: &'db dyn Db, bound_super: BoundSuperType<'db>) {
         walk_bound_super_type(db, bound_super, self);
     }
 
-    fn visit_nominal_instance_type(&mut self, db: &'db dyn Db, nominal: NominalInstanceType<'db>) {
+    fn visit_nominal_instance_type(&self, db: &'db dyn Db, nominal: NominalInstanceType<'db>) {
         walk_nominal_instance_type(db, nominal, self);
     }
 
-    fn visit_bound_type_var_type(
-        &mut self,
-        db: &'db dyn Db,
-        bound_typevar: BoundTypeVarInstance<'db>,
-    ) {
+    fn visit_bound_type_var_type(&self, db: &'db dyn Db, bound_typevar: BoundTypeVarInstance<'db>) {
         walk_bound_type_var_type(db, bound_typevar, self);
     }
 
-    fn visit_type_var_type(&mut self, db: &'db dyn Db, typevar: TypeVarInstance<'db>) {
+    fn visit_type_var_type(&self, db: &'db dyn Db, typevar: TypeVarInstance<'db>) {
         walk_type_var_type(db, typevar, self);
     }
 
-    fn visit_protocol_instance_type(
-        &mut self,
-        db: &'db dyn Db,
-        protocol: ProtocolInstanceType<'db>,
-    ) {
+    fn visit_protocol_instance_type(&self, db: &'db dyn Db, protocol: ProtocolInstanceType<'db>) {
         walk_protocol_instance_type(db, protocol, self);
     }
 
-    fn visit_method_wrapper_type(
-        &mut self,
-        db: &'db dyn Db,
-        method_wrapper: MethodWrapperKind<'db>,
-    ) {
+    fn visit_method_wrapper_type(&self, db: &'db dyn Db, method_wrapper: MethodWrapperKind<'db>) {
         walk_method_wrapper_type(db, method_wrapper, self);
     }
 
-    fn visit_known_instance_type(
-        &mut self,
-        db: &'db dyn Db,
-        known_instance: KnownInstanceType<'db>,
-    ) {
+    fn visit_known_instance_type(&self, db: &'db dyn Db, known_instance: KnownInstanceType<'db>) {
         walk_known_instance_type(db, known_instance, self);
     }
 
-    fn visit_type_alias_type(&mut self, db: &'db dyn Db, type_alias: TypeAliasType<'db>) {
+    fn visit_type_alias_type(&self, db: &'db dyn Db, type_alias: TypeAliasType<'db>) {
         walk_type_alias_type(db, type_alias, self);
     }
 
-    fn visit_typed_dict_type(&mut self, db: &'db dyn Db, typed_dict: TypedDictType<'db>) {
+    fn visit_typed_dict_type(&self, db: &'db dyn Db, typed_dict: TypedDictType<'db>) {
         walk_typed_dict_type(db, typed_dict, self);
     }
 }
@@ -211,7 +192,7 @@ impl<'db> From<Type<'db>> for TypeKind<'db> {
 fn walk_non_atomic_type<'db, V: TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
     non_atomic_type: NonAtomicType<'db>,
-    visitor: &mut V,
+    visitor: &V,
 ) {
     match non_atomic_type {
         NonAtomicType::FunctionLiteral(function) => visitor.visit_function_type(db, function),
@@ -259,25 +240,25 @@ pub(super) fn any_over_type<'db>(
 ) -> bool {
     struct AnyOverTypeVisitor<'db, 'a> {
         query: &'a dyn Fn(Type<'db>) -> bool,
-        seen_types: FxIndexSet<NonAtomicType<'db>>,
-        found_matching_type: bool,
+        seen_types: RefCell<FxIndexSet<NonAtomicType<'db>>>,
+        found_matching_type: Cell<bool>,
     }
 
     impl<'db> TypeVisitor<'db> for AnyOverTypeVisitor<'db, '_> {
-        fn visit_type(&mut self, db: &'db dyn Db, ty: Type<'db>) {
-            let already_found = self.found_matching_type;
+        fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {
+            let already_found = self.found_matching_type.get();
             if already_found {
                 return;
             }
             let found = already_found | (self.query)(ty);
-            self.found_matching_type = found;
+            self.found_matching_type.set(found);
             if found {
                 return;
             }
             match TypeKind::from(ty) {
                 TypeKind::Atomic => {}
                 TypeKind::NonAtomic(non_atomic_type) => {
-                    if !self.seen_types.insert(non_atomic_type) {
+                    if !self.seen_types.borrow_mut().insert(non_atomic_type) {
                         // If we have already seen this type, we can skip it.
                         return;
                     }
@@ -287,11 +268,11 @@ pub(super) fn any_over_type<'db>(
         }
     }
 
-    let mut visitor = AnyOverTypeVisitor {
+    let visitor = AnyOverTypeVisitor {
         query,
-        seen_types: FxIndexSet::default(),
-        found_matching_type: false,
+        seen_types: RefCell::new(FxIndexSet::default()),
+        found_matching_type: Cell::new(false),
     };
     visitor.visit_type(db, ty);
-    visitor.found_matching_type
+    visitor.found_matching_type.get()
 }


### PR DESCRIPTION
## Summary

Support recursive type aliases by adding a `Type::TypeAlias` type variant, which allows referring to a type alias directly as a type without eagerly unpacking it to its value.

We still unpack type aliases when they are added to intersections and unions, so that we can simplify the intersection/union appropriately based on the unpacked value of the type alias.

This introduces new possible recursive types, and so also requires expanding our usage of recursion-detecting visitors in Type methods. The use of these visitors is still not fully comprehensive in this PR, and will require further expansion to support recursion in more kinds of types (I already have further work on this locally), but I think it may be better to do this incrementally in multiple PRs.

## Test Plan

Added some recursive type-alias tests and made them pass.
