### PR TITLE
Update Rust toolchain to 1.89

### DIFF
--- a/crates/ruff_annotate_snippets/src/lib.rs
+++ b/crates/ruff_annotate_snippets/src/lib.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::needless_doctest_main)]
+
 //! A library for formatting of text or programming code snippets.
 //!
 //! It's primary purpose is to build an ASCII-graphical representation of the snippet

--- a/crates/ruff_db/src/diagnostic/mod.rs
+++ b/crates/ruff_db/src/diagnostic/mod.rs
@@ -212,7 +212,7 @@ impl Diagnostic {
     /// The type returned implements the `std::fmt::Display` trait. In most
     /// cases, just converting it to a string (or printing it) will do what
     /// you want.
-    pub fn concise_message(&self) -> ConciseMessage {
+    pub fn concise_message(&self) -> ConciseMessage<'_> {
         let main = self.inner.message.as_str();
         let annotation = self
             .primary_annotation()
@@ -654,7 +654,7 @@ impl SubDiagnostic {
     /// The type returned implements the `std::fmt::Display` trait. In most
     /// cases, just converting it to a string (or printing it) will do what
     /// you want.
-    pub fn concise_message(&self) -> ConciseMessage {
+    pub fn concise_message(&self) -> ConciseMessage<'_> {
         let main = self.inner.message.as_str();
         let annotation = self
             .primary_annotation()
@@ -1099,7 +1099,7 @@ enum DiagnosticSource {
 
 impl DiagnosticSource {
     /// Returns this input as a `SourceCode` for convenient querying.
-    fn as_source_code(&self) -> SourceCode {
+    fn as_source_code(&self) -> SourceCode<'_, '_> {
         match self {
             DiagnosticSource::Ty(input) => SourceCode::new(input.text.as_str(), &input.line_index),
             DiagnosticSource::Ruff(source) => SourceCode::new(source.source_text(), source.index()),

--- a/crates/ruff_db/src/system/path.rs
+++ b/crates/ruff_db/src/system/path.rs
@@ -236,7 +236,7 @@ impl SystemPath {
     ///
     /// [`CurDir`]: camino::Utf8Component::CurDir
     #[inline]
-    pub fn components(&self) -> camino::Utf8Components {
+    pub fn components(&self) -> camino::Utf8Components<'_> {
         self.0.components()
     }
 

--- a/crates/ruff_db/src/vendored.rs
+++ b/crates/ruff_db/src/vendored.rs
@@ -195,7 +195,7 @@ impl VendoredFileSystem {
     ///
     /// ## Panics:
     /// If the current thread already holds the lock.
-    fn lock_archive(&self) -> LockedZipArchive {
+    fn lock_archive(&self) -> LockedZipArchive<'_> {
         self.inner.lock().unwrap()
     }
 }
@@ -360,7 +360,7 @@ impl VendoredZipArchive {
         Ok(Self(ZipArchive::new(io::Cursor::new(data))?))
     }
 
-    fn lookup_path(&mut self, path: &NormalizedVendoredPath) -> Result<ZipFile> {
+    fn lookup_path(&mut self, path: &NormalizedVendoredPath) -> Result<ZipFile<'_>> {
         Ok(self.0.by_name(path.as_str())?)
     }
 

--- a/crates/ruff_db/src/vendored/path.rs
+++ b/crates/ruff_db/src/vendored/path.rs
@@ -37,7 +37,7 @@ impl VendoredPath {
         self.0.as_std_path()
     }
 
-    pub fn components(&self) -> Utf8Components {
+    pub fn components(&self) -> Utf8Components<'_> {
         self.0.components()
     }
 

--- a/crates/ruff_dev/src/format_dev.rs
+++ b/crates/ruff_dev/src/format_dev.rs
@@ -348,7 +348,7 @@ fn format_dev_multi_project(
         debug!(parent: None, "Starting {}", project_path.display());
 
         match format_dev_project(
-            &[project_path.clone()],
+            std::slice::from_ref(&project_path),
             args.stability_check,
             args.write,
             args.preview,
@@ -628,7 +628,7 @@ struct CheckRepoResult {
 }
 
 impl CheckRepoResult {
-    fn display(&self, format: Format) -> DisplayCheckRepoResult {
+    fn display(&self, format: Format) -> DisplayCheckRepoResult<'_> {
         DisplayCheckRepoResult {
             result: self,
             format,
@@ -665,7 +665,7 @@ struct Diagnostic {
 }
 
 impl Diagnostic {
-    fn display(&self, format: Format) -> DisplayDiagnostic {
+    fn display(&self, format: Format) -> DisplayDiagnostic<'_> {
         DisplayDiagnostic {
             diagnostic: self,
             format,

--- a/crates/ruff_formatter/src/buffer.rs
+++ b/crates/ruff_formatter/src/buffer.rs
@@ -562,7 +562,7 @@ struct RemoveSoftLinebreaksSnapshot {
 pub trait BufferExtensions: Buffer + Sized {
     /// Returns a new buffer that calls the passed inspector for every element that gets written to the output
     #[must_use]
-    fn inspect<F>(&mut self, inspector: F) -> Inspect<Self::Context, F>
+    fn inspect<F>(&mut self, inspector: F) -> Inspect<'_, Self::Context, F>
     where
         F: FnMut(&FormatElement),
     {
@@ -607,7 +607,7 @@ pub trait BufferExtensions: Buffer + Sized {
     /// # }
     /// ```
     #[must_use]
-    fn start_recording(&mut self) -> Recording<Self> {
+    fn start_recording(&mut self) -> Recording<'_, Self> {
         Recording::new(self)
     }
 

--- a/crates/ruff_formatter/src/builders.rs
+++ b/crates/ruff_formatter/src/builders.rs
@@ -340,7 +340,7 @@ impl<Context> Format<Context> for SourcePosition {
 /// Creates a text from a dynamic string.
 ///
 /// This is done by allocating a new string internally.
-pub fn text(text: &str) -> Text {
+pub fn text(text: &str) -> Text<'_> {
     debug_assert_no_newlines(text);
 
     Text { text }
@@ -459,7 +459,10 @@ fn debug_assert_no_newlines(text: &str) {
 /// # }
 /// ```
 #[inline]
-pub fn line_suffix<Content, Context>(inner: &Content, reserved_width: u32) -> LineSuffix<Context>
+pub fn line_suffix<Content, Context>(
+    inner: &Content,
+    reserved_width: u32,
+) -> LineSuffix<'_, Context>
 where
     Content: Format<Context>,
 {
@@ -597,7 +600,10 @@ impl<Context> Format<Context> for LineSuffixBoundary {
 /// Use `Memoized.inspect(f)?.has_label(LabelId::of::<SomeLabelId>()` if you need to know if some content breaks that should
 /// only be written later.
 #[inline]
-pub fn labelled<Content, Context>(label_id: LabelId, content: &Content) -> FormatLabelled<Context>
+pub fn labelled<Content, Context>(
+    label_id: LabelId,
+    content: &Content,
+) -> FormatLabelled<'_, Context>
 where
     Content: Format<Context>,
 {
@@ -700,7 +706,7 @@ impl<Context> Format<Context> for Space {
 /// # }
 /// ```
 #[inline]
-pub fn indent<Content, Context>(content: &Content) -> Indent<Context>
+pub fn indent<Content, Context>(content: &Content) -> Indent<'_, Context>
 where
     Content: Format<Context>,
 {
@@ -771,7 +777,7 @@ impl<Context> std::fmt::Debug for Indent<'_, Context> {
 /// # }
 /// ```
 #[inline]
-pub fn dedent<Content, Context>(content: &Content) -> Dedent<Context>
+pub fn dedent<Content, Context>(content: &Content) -> Dedent<'_, Context>
 where
     Content: Format<Context>,
 {
@@ -846,7 +852,7 @@ impl<Context> std::fmt::Debug for Dedent<'_, Context> {
 ///
 /// This resembles the behaviour of Prettier's `align(Number.NEGATIVE_INFINITY, content)` IR element.
 #[inline]
-pub fn dedent_to_root<Content, Context>(content: &Content) -> Dedent<Context>
+pub fn dedent_to_root<Content, Context>(content: &Content) -> Dedent<'_, Context>
 where
     Content: Format<Context>,
 {
@@ -960,7 +966,7 @@ where
 ///
 /// - tab indentation: Printer indents the expression with two tabs because the `align` increases the indentation level.
 /// - space indentation: Printer indents the expression by 4 spaces (one indentation level) **and** 2 spaces for the align.
-pub fn align<Content, Context>(count: u8, content: &Content) -> Align<Context>
+pub fn align<Content, Context>(count: u8, content: &Content) -> Align<'_, Context>
 where
     Content: Format<Context>,
 {
@@ -1030,7 +1036,7 @@ impl<Context> std::fmt::Debug for Align<'_, Context> {
 /// # }
 /// ```
 #[inline]
-pub fn block_indent<Context>(content: &impl Format<Context>) -> BlockIndent<Context> {
+pub fn block_indent<Context>(content: &impl Format<Context>) -> BlockIndent<'_, Context> {
     BlockIndent {
         content: Argument::new(content),
         mode: IndentMode::Block,
@@ -1101,7 +1107,7 @@ pub fn block_indent<Context>(content: &impl Format<Context>) -> BlockIndent<Cont
 /// # }
 /// ```
 #[inline]
-pub fn soft_block_indent<Context>(content: &impl Format<Context>) -> BlockIndent<Context> {
+pub fn soft_block_indent<Context>(content: &impl Format<Context>) -> BlockIndent<'_, Context> {
     BlockIndent {
         content: Argument::new(content),
         mode: IndentMode::Soft,
@@ -1175,7 +1181,9 @@ pub fn soft_block_indent<Context>(content: &impl Format<Context>) -> BlockIndent
 /// # }
 /// ```
 #[inline]
-pub fn soft_line_indent_or_space<Context>(content: &impl Format<Context>) -> BlockIndent<Context> {
+pub fn soft_line_indent_or_space<Context>(
+    content: &impl Format<Context>,
+) -> BlockIndent<'_, Context> {
     BlockIndent {
         content: Argument::new(content),
         mode: IndentMode::SoftLineOrSpace,
@@ -1308,7 +1316,9 @@ impl<Context> std::fmt::Debug for BlockIndent<'_, Context> {
 /// # Ok(())
 /// # }
 /// ```
-pub fn soft_space_or_block_indent<Context>(content: &impl Format<Context>) -> BlockIndent<Context> {
+pub fn soft_space_or_block_indent<Context>(
+    content: &impl Format<Context>,
+) -> BlockIndent<'_, Context> {
     BlockIndent {
         content: Argument::new(content),
         mode: IndentMode::SoftSpace,
@@ -1388,7 +1398,7 @@ pub fn soft_space_or_block_indent<Context>(content: &impl Format<Context>) -> Bl
 /// # }
 /// ```
 #[inline]
-pub fn group<Context>(content: &impl Format<Context>) -> Group<Context> {
+pub fn group<Context>(content: &impl Format<Context>) -> Group<'_, Context> {
     Group {
         content: Argument::new(content),
         id: None,
@@ -1551,7 +1561,7 @@ impl<Context> std::fmt::Debug for Group<'_, Context> {
 #[inline]
 pub fn best_fit_parenthesize<Context>(
     content: &impl Format<Context>,
-) -> BestFitParenthesize<Context> {
+) -> BestFitParenthesize<'_, Context> {
     BestFitParenthesize {
         content: Argument::new(content),
         group_id: None,
@@ -1691,7 +1701,7 @@ impl<Context> std::fmt::Debug for BestFitParenthesize<'_, Context> {
 pub fn conditional_group<Content, Context>(
     content: &Content,
     condition: Condition,
-) -> ConditionalGroup<Context>
+) -> ConditionalGroup<'_, Context>
 where
     Content: Format<Context>,
 {
@@ -1852,7 +1862,7 @@ impl<Context> Format<Context> for ExpandParent {
 /// # }
 /// ```
 #[inline]
-pub fn if_group_breaks<Content, Context>(content: &Content) -> IfGroupBreaks<Context>
+pub fn if_group_breaks<Content, Context>(content: &Content) -> IfGroupBreaks<'_, Context>
 where
     Content: Format<Context>,
 {
@@ -1933,7 +1943,7 @@ where
 /// # }
 /// ```
 #[inline]
-pub fn if_group_fits_on_line<Content, Context>(flat_content: &Content) -> IfGroupBreaks<Context>
+pub fn if_group_fits_on_line<Content, Context>(flat_content: &Content) -> IfGroupBreaks<'_, Context>
 where
     Content: Format<Context>,
 {
@@ -2122,7 +2132,7 @@ impl<Context> std::fmt::Debug for IfGroupBreaks<'_, Context> {
 pub fn indent_if_group_breaks<Content, Context>(
     content: &Content,
     group_id: GroupId,
-) -> IndentIfGroupBreaks<Context>
+) -> IndentIfGroupBreaks<'_, Context>
 where
     Content: Format<Context>,
 {
@@ -2205,7 +2215,7 @@ impl<Context> std::fmt::Debug for IndentIfGroupBreaks<'_, Context> {
 /// # Ok(())
 /// # }
 /// ```
-pub fn fits_expanded<Content, Context>(content: &Content) -> FitsExpanded<Context>
+pub fn fits_expanded<Content, Context>(content: &Content) -> FitsExpanded<'_, Context>
 where
     Content: Format<Context>,
 {

--- a/crates/ruff_formatter/src/format_element.rs
+++ b/crates/ruff_formatter/src/format_element.rs
@@ -197,7 +197,7 @@ pub const LINE_TERMINATORS: [char; 3] = ['\r', LINE_SEPARATOR, PARAGRAPH_SEPARAT
 
 /// Replace the line terminators matching the provided list with "\n"
 /// since its the only line break type supported by the printer
-pub fn normalize_newlines<const N: usize>(text: &str, terminators: [char; N]) -> Cow<str> {
+pub fn normalize_newlines<const N: usize>(text: &str, terminators: [char; N]) -> Cow<'_, str> {
     let mut result = String::new();
     let mut last_end = 0;
 

--- a/crates/ruff_formatter/src/format_element/document.rs
+++ b/crates/ruff_formatter/src/format_element/document.rs
@@ -222,7 +222,7 @@ impl FormatContext for IrFormatContext<'_> {
         &IrFormatOptions
     }
 
-    fn source_code(&self) -> SourceCode {
+    fn source_code(&self) -> SourceCode<'_> {
         self.source_code
     }
 }

--- a/crates/ruff_formatter/src/lib.rs
+++ b/crates/ruff_formatter/src/lib.rs
@@ -193,7 +193,7 @@ pub trait FormatContext {
     fn options(&self) -> &Self::Options;
 
     /// Returns the source code from the document that gets formatted.
-    fn source_code(&self) -> SourceCode;
+    fn source_code(&self) -> SourceCode<'_>;
 }
 
 /// Options customizing how the source code should be formatted.
@@ -239,7 +239,7 @@ impl FormatContext for SimpleFormatContext {
         &self.options
     }
 
-    fn source_code(&self) -> SourceCode {
+    fn source_code(&self) -> SourceCode<'_> {
         SourceCode::new(&self.source_code)
     }
 }
@@ -326,7 +326,7 @@ where
         printer.print_with_indent(&self.document, indent)
     }
 
-    fn create_printer(&self) -> Printer {
+    fn create_printer(&self) -> Printer<'_> {
         let source_code = self.context.source_code();
         let print_options = self.context.options().as_print_options();
 

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -315,7 +315,7 @@ impl<'a> Checker<'a> {
     }
 
     /// Create a [`Generator`] to generate source code based on the current AST state.
-    pub(crate) fn generator(&self) -> Generator {
+    pub(crate) fn generator(&self) -> Generator<'_> {
         Generator::new(self.stylist.indentation(), self.stylist.line_ending())
     }
 

--- a/crates/ruff_linter/src/cst/matchers.rs
+++ b/crates/ruff_linter/src/cst/matchers.rs
@@ -8,14 +8,14 @@ use libcst_native::{
 };
 use ruff_python_codegen::Stylist;
 
-pub(crate) fn match_module(module_text: &str) -> Result<Module> {
+pub(crate) fn match_module(module_text: &str) -> Result<Module<'_>> {
     match libcst_native::parse_module(module_text, None) {
         Ok(module) => Ok(module),
         Err(_) => bail!("Failed to extract CST from source"),
     }
 }
 
-pub(crate) fn match_statement(statement_text: &str) -> Result<Statement> {
+pub(crate) fn match_statement(statement_text: &str) -> Result<Statement<'_>> {
     match libcst_native::parse_statement(statement_text) {
         Ok(statement) => Ok(statement),
         Err(_) => bail!("Failed to extract statement from source"),
@@ -220,7 +220,7 @@ pub(crate) fn match_if<'a, 'b>(statement: &'a mut Statement<'b>) -> Result<&'a m
 ///
 /// If the expression is not guaranteed to be valid as a standalone expression (e.g., if it may
 /// span multiple lines and/or require parentheses), use [`transform_expression`] instead.
-pub(crate) fn match_expression(expression_text: &str) -> Result<Expression> {
+pub(crate) fn match_expression(expression_text: &str) -> Result<Expression<'_>> {
     match libcst_native::parse_expression(expression_text) {
         Ok(expression) => Ok(expression),
         Err(_) => bail!("Failed to extract expression from source"),

--- a/crates/ruff_linter/src/doc_lines.rs
+++ b/crates/ruff_linter/src/doc_lines.rs
@@ -13,7 +13,7 @@ use ruff_text_size::{Ranged, TextSize};
 use crate::Locator;
 
 /// Extract doc lines (standalone comments) from a token sequence.
-pub(crate) fn doc_lines_from_tokens(tokens: &Tokens) -> DocLines {
+pub(crate) fn doc_lines_from_tokens(tokens: &Tokens) -> DocLines<'_> {
     DocLines::new(tokens)
 }
 

--- a/crates/ruff_linter/src/docstrings/mod.rs
+++ b/crates/ruff_linter/src/docstrings/mod.rs
@@ -32,7 +32,7 @@ impl<'a> Docstring<'a> {
     }
 
     /// The contents of the docstring, excluding the opening and closing quotes.
-    pub(crate) fn body(&self) -> DocstringBody {
+    pub(crate) fn body(&self) -> DocstringBody<'_> {
         DocstringBody { docstring: self }
     }
 

--- a/crates/ruff_linter/src/docstrings/sections.rs
+++ b/crates/ruff_linter/src/docstrings/sections.rs
@@ -208,7 +208,7 @@ impl<'a> SectionContexts<'a> {
         self.contexts.len()
     }
 
-    pub(crate) fn iter(&self) -> SectionContextsIter {
+    pub(crate) fn iter(&self) -> SectionContextsIter<'_> {
         SectionContextsIter {
             docstring_body: self.docstring.body(),
             inner: self.contexts.iter(),

--- a/crates/ruff_linter/src/locator.rs
+++ b/crates/ruff_linter/src/locator.rs
@@ -49,7 +49,7 @@ impl<'a> Locator<'a> {
         self.index.get()
     }
 
-    pub fn to_source_code(&self) -> SourceCode {
+    pub fn to_source_code(&self) -> SourceCode<'_, '_> {
         SourceCode::new(self.contents, self.to_index())
     }
 

--- a/crates/ruff_linter/src/message/mod.rs
+++ b/crates/ruff_linter/src/message/mod.rs
@@ -149,7 +149,7 @@ impl Deref for MessageWithLocation<'_> {
 
 fn group_diagnostics_by_filename(
     diagnostics: &[Diagnostic],
-) -> BTreeMap<String, Vec<MessageWithLocation>> {
+) -> BTreeMap<String, Vec<MessageWithLocation<'_>>> {
     let mut grouped_messages = BTreeMap::default();
     for diagnostic in diagnostics {
         grouped_messages

--- a/crates/ruff_linter/src/message/text.rs
+++ b/crates/ruff_linter/src/message/text.rs
@@ -286,7 +286,7 @@ impl Display for MessageCodeFrame<'_> {
 /// modify the annotation ranges by inserting 3-byte Unicode replacements
 /// because `annotate-snippets` will account for their actual width when
 /// rendering and displaying the column to the user.
-fn replace_unprintable(source: &str, annotation_range: TextRange) -> SourceCode {
+fn replace_unprintable(source: &str, annotation_range: TextRange) -> SourceCode<'_> {
     let mut result = String::new();
     let mut last_end = 0;
     let mut range = annotation_range;

--- a/crates/ruff_linter/src/noqa.rs
+++ b/crates/ruff_linter/src/noqa.rs
@@ -99,7 +99,7 @@ pub(crate) struct Codes<'a> {
 
 impl Codes<'_> {
     /// Returns an iterator over the [`Code`]s in the `noqa` directive.
-    pub(crate) fn iter(&self) -> std::slice::Iter<Code> {
+    pub(crate) fn iter(&self) -> std::slice::Iter<'_, Code<'_>> {
         self.codes.iter()
     }
 
@@ -306,7 +306,7 @@ impl<'a> FileNoqaDirectives<'a> {
         Self(lines)
     }
 
-    pub(crate) fn lines(&self) -> &[FileNoqaDirectiveLine] {
+    pub(crate) fn lines(&self) -> &[FileNoqaDirectiveLine<'_>] {
         &self.0
     }
 
@@ -1106,7 +1106,10 @@ impl<'a> NoqaDirectives<'a> {
         Self { inner: directives }
     }
 
-    pub(crate) fn find_line_with_directive(&self, offset: TextSize) -> Option<&NoqaDirectiveLine> {
+    pub(crate) fn find_line_with_directive(
+        &self,
+        offset: TextSize,
+    ) -> Option<&NoqaDirectiveLine<'_>> {
         self.find_line_index(offset).map(|index| &self.inner[index])
     }
 
@@ -1139,7 +1142,7 @@ impl<'a> NoqaDirectives<'a> {
             .ok()
     }
 
-    pub(crate) fn lines(&self) -> &[NoqaDirectiveLine] {
+    pub(crate) fn lines(&self) -> &[NoqaDirectiveLine<'_>] {
         &self.inner
     }
 

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/collapsible_if.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/collapsible_if.rs
@@ -178,7 +178,7 @@ impl<'a> From<&NestedIf<'a>> for AnyNodeRef<'a> {
 }
 
 /// Returns the body, the range of the `if` or `elif` and whether the range is for an `if` or `elif`
-fn nested_if_body(stmt_if: &ast::StmtIf) -> Option<NestedIf> {
+fn nested_if_body(stmt_if: &ast::StmtIf) -> Option<NestedIf<'_>> {
     let ast::StmtIf {
         test,
         body,

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
@@ -267,7 +267,7 @@ struct Terminal<'a> {
     stmt: &'a Stmt,
 }
 
-fn match_loop(stmt: &Stmt) -> Option<Loop> {
+fn match_loop(stmt: &Stmt) -> Option<Loop<'_>> {
     let Stmt::For(ast::StmtFor {
         body, target, iter, ..
     }) = stmt
@@ -324,7 +324,7 @@ fn match_loop(stmt: &Stmt) -> Option<Loop> {
 ///         return True
 /// return False
 /// ```
-fn match_else_return(stmt: &Stmt) -> Option<Terminal> {
+fn match_else_return(stmt: &Stmt) -> Option<Terminal<'_>> {
     let Stmt::For(ast::StmtFor { orelse, .. }) = stmt else {
         return None;
     };

--- a/crates/ruff_linter/src/rules/isort/categorize.rs
+++ b/crates/ruff_linter/src/rules/isort/categorize.rs
@@ -388,7 +388,7 @@ impl KnownModules {
 
     /// Return the [`ImportSection`] for a given module, if it's been categorized as a known module
     /// by the user.
-    fn categorize(&self, module_name: &str) -> Option<(&ImportSection, Reason)> {
+    fn categorize(&self, module_name: &str) -> Option<(&ImportSection, Reason<'_>)> {
         if self.has_submodules {
             // Check all module prefixes from the longest to the shortest (e.g., given
             // `foo.bar.baz`, check `foo.bar.baz`, then `foo.bar`, then `foo`, taking the first,
@@ -412,7 +412,7 @@ impl KnownModules {
         }
     }
 
-    fn categorize_submodule(&self, submodule: &str) -> Option<(&ImportSection, Reason)> {
+    fn categorize_submodule(&self, submodule: &str) -> Option<(&ImportSection, Reason<'_>)> {
         let section = self.known.iter().find_map(|(pattern, section)| {
             if pattern.matches(submodule) {
                 Some(section)

--- a/crates/ruff_linter/src/rules/pydoclint/rules/check_docstring.rs
+++ b/crates/ruff_linter/src/rules/pydoclint/rules/check_docstring.rs
@@ -452,7 +452,7 @@ impl<'a> DocstringSections<'a> {
 ///
 /// Attempts to parse using the specified [`SectionStyle`], falling back to the other style if no
 /// entries are found.
-fn parse_entries(content: &str, style: Option<SectionStyle>) -> Vec<QualifiedName> {
+fn parse_entries(content: &str, style: Option<SectionStyle>) -> Vec<QualifiedName<'_>> {
     match style {
         Some(SectionStyle::Google) => parse_entries_google(content),
         Some(SectionStyle::Numpy) => parse_entries_numpy(content),
@@ -474,7 +474,7 @@ fn parse_entries(content: &str, style: Option<SectionStyle>) -> Vec<QualifiedNam
 ///     FasterThanLightError: If speed is greater than the speed of light.
 ///     DivisionByZero: If attempting to divide by zero.
 /// ```
-fn parse_entries_google(content: &str) -> Vec<QualifiedName> {
+fn parse_entries_google(content: &str) -> Vec<QualifiedName<'_>> {
     let mut entries: Vec<QualifiedName> = Vec::new();
     for potential in content.lines() {
         let Some(colon_idx) = potential.find(':') else {
@@ -496,7 +496,7 @@ fn parse_entries_google(content: &str) -> Vec<QualifiedName> {
 /// DivisionByZero
 ///     If attempting to divide by zero.
 /// ```
-fn parse_entries_numpy(content: &str) -> Vec<QualifiedName> {
+fn parse_entries_numpy(content: &str) -> Vec<QualifiedName<'_>> {
     let mut entries: Vec<QualifiedName> = Vec::new();
     let mut lines = content.lines();
     let Some(dashes) = lines.next() else {

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/multi_line_summary_start.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/multi_line_summary_start.rs
@@ -177,7 +177,6 @@ pub(crate) fn multi_line_summary_start(checker: &Checker, docstring: &Docstring)
         // "\
         // "
         // ```
-        return;
     } else {
         if checker.is_rule_enabled(Rule::MultiLineSummarySecondLine) {
             let mut diagnostic =

--- a/crates/ruff_linter/src/rules/pydocstyle/settings.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/settings.rs
@@ -98,11 +98,11 @@ impl Settings {
         self.convention
     }
 
-    pub fn ignore_decorators(&self) -> DecoratorIterator {
+    pub fn ignore_decorators(&self) -> DecoratorIterator<'_> {
         DecoratorIterator::new(&self.ignore_decorators)
     }
 
-    pub fn property_decorators(&self) -> DecoratorIterator {
+    pub fn property_decorators(&self) -> DecoratorIterator<'_> {
         DecoratorIterator::new(&self.property_decorators)
     }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/non_slot_assignment.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/non_slot_assignment.rs
@@ -100,7 +100,7 @@ impl Ranged for AttributeAssignment<'_> {
 /// Return a list of attributes that are assigned to but not included in `__slots__`.
 ///
 /// If the `__slots__` attribute cannot be statically determined, returns an empty vector.
-fn is_attributes_not_in_slots(body: &[Stmt]) -> Vec<AttributeAssignment> {
+fn is_attributes_not_in_slots(body: &[Stmt]) -> Vec<AttributeAssignment<'_>> {
     // First, collect all the attributes that are assigned to `__slots__`.
     let mut slots = FxHashSet::default();
     for statement in body {

--- a/crates/ruff_linter/src/rules/pylint/rules/redefined_slots_in_subclass.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/redefined_slots_in_subclass.rs
@@ -115,7 +115,7 @@ fn check_super_slots(checker: &Checker, class_def: &ast::StmtClassDef, slot: &Sl
     }
 }
 
-fn slots_members(body: &[Stmt]) -> FxHashSet<Slot> {
+fn slots_members(body: &[Stmt]) -> FxHashSet<Slot<'_>> {
     let mut members = FxHashSet::default();
     for stmt in body {
         match stmt {
@@ -161,7 +161,7 @@ fn slots_members(body: &[Stmt]) -> FxHashSet<Slot> {
     members
 }
 
-fn slots_attributes(expr: &Expr) -> impl Iterator<Item = Slot> {
+fn slots_attributes(expr: &Expr) -> impl Iterator<Item = Slot<'_>> {
     // Ex) `__slots__ = ("name",)`
     let elts_iter = match expr {
         Expr::Tuple(ast::ExprTuple { elts, .. })

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_encode_utf8.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_encode_utf8.rs
@@ -96,7 +96,7 @@ enum EncodingArg<'a> {
 
 /// Return the encoding argument to an `encode` call, if it can be determined to be a
 /// UTF-8-equivalent encoding.
-fn match_encoding_arg(arguments: &Arguments) -> Option<EncodingArg> {
+fn match_encoding_arg(arguments: &Arguments) -> Option<EncodingArg<'_>> {
     match (&*arguments.args, &*arguments.keywords) {
         // Ex `"".encode()`
         ([], []) => return Some(EncodingArg::Empty),

--- a/crates/ruff_linter/src/rules/refurb/rules/reimplemented_starmap.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/reimplemented_starmap.rs
@@ -343,7 +343,9 @@ enum ComprehensionTarget<'a> {
 }
 
 /// Extract the target from the comprehension (e.g., `(x, y, z)` in `(x, y, z, ...) in iter`).
-fn match_comprehension_target(comprehension: &ast::Comprehension) -> Option<ComprehensionTarget> {
+fn match_comprehension_target(
+    comprehension: &ast::Comprehension,
+) -> Option<ComprehensionTarget<'_>> {
     if comprehension.is_async || !comprehension.ifs.is_empty() {
         return None;
     }

--- a/crates/ruff_linter/src/rules/refurb/rules/single_item_membership_test.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/single_item_membership_test.rs
@@ -89,7 +89,7 @@ pub(crate) fn single_item_membership_test(
             generate_comparison(
                 left,
                 &[membership_test.replacement_op()],
-                &[item.clone()],
+                std::slice::from_ref(item),
                 expr.into(),
                 checker.comment_ranges(),
                 checker.source(),

--- a/crates/ruff_linter/src/rules/refurb/rules/slice_to_remove_prefix_or_suffix.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/slice_to_remove_prefix_or_suffix.rs
@@ -139,7 +139,7 @@ pub(crate) fn slice_to_remove_affix_stmt(checker: &Checker, if_stmt: &ast::StmtI
 /// where `func` is either `startswith` or `endswith`,
 /// this function collects `text`,`func`, `affix`, and the non-null
 /// bound of the slice. Otherwise, returns `None`.
-fn affix_removal_data_expr(if_expr: &ast::ExprIf) -> Option<RemoveAffixData> {
+fn affix_removal_data_expr(if_expr: &ast::ExprIf) -> Option<RemoveAffixData<'_>> {
     let ast::ExprIf {
         test,
         body,
@@ -166,7 +166,7 @@ fn affix_removal_data_expr(if_expr: &ast::ExprIf) -> Option<RemoveAffixData> {
 /// where `func` is either `startswith` or `endswith`,
 /// this function collects `text`,`func`, `affix`, and the non-null
 /// bound of the slice. Otherwise, returns `None`.
-fn affix_removal_data_stmt(if_stmt: &ast::StmtIf) -> Option<RemoveAffixData> {
+fn affix_removal_data_stmt(if_stmt: &ast::StmtIf) -> Option<RemoveAffixData<'_>> {
     let ast::StmtIf {
         test,
         body,

--- a/crates/ruff_options_metadata/src/lib.rs
+++ b/crates/ruff_options_metadata/src/lib.rs
@@ -39,7 +39,7 @@ where
 }
 
 /// Metadata of an option that can either be a [`OptionField`] or [`OptionSet`].
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(::serde::Serialize), serde(untagged))]
 pub enum OptionEntry {
     /// A single option.
@@ -62,7 +62,7 @@ impl Display for OptionEntry {
 ///
 /// It extracts the options by calling the [`OptionsMetadata::record`] of a type implementing
 /// [`OptionsMetadata`].
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct OptionSet {
     record: fn(&mut dyn Visit),
     doc: fn() -> Option<&'static str>,

--- a/crates/ruff_python_ast/src/comparable.rs
+++ b/crates/ruff_python_ast/src/comparable.rs
@@ -1900,7 +1900,7 @@ impl<'a> From<&'a Expr> for HashableExpr<'a> {
     fn from(expr: &'a Expr) -> Self {
         /// Returns a version of the given expression that can be hashed and compared according to
         /// Python  semantics.
-        fn as_hashable(expr: &Expr) -> ComparableExpr {
+        fn as_hashable(expr: &Expr) -> ComparableExpr<'_> {
             match expr {
                 Expr::Named(named) => ComparableExpr::NamedExpr(ExprNamed {
                     target: Box::new(ComparableExpr::from(&named.target)),

--- a/crates/ruff_python_ast/src/helpers.rs
+++ b/crates/ruff_python_ast/src/helpers.rs
@@ -789,7 +789,7 @@ where
 /// assert_eq!(format_import_from(1, None), ".".to_string());
 /// assert_eq!(format_import_from(1, Some("foo")), ".foo".to_string());
 /// ```
-pub fn format_import_from(level: u32, module: Option<&str>) -> Cow<str> {
+pub fn format_import_from(level: u32, module: Option<&str>) -> Cow<'_, str> {
     match (level, module) {
         (0, Some(module)) => Cow::Borrowed(module),
         (level, module) => {
@@ -1509,7 +1509,7 @@ pub fn pep_604_union(elts: &[Expr]) -> Expr {
         [rest @ .., elt] => Expr::BinOp(ast::ExprBinOp {
             left: Box::new(pep_604_union(rest)),
             op: Operator::BitOr,
-            right: Box::new(pep_604_union(&[elt.clone()])),
+            right: Box::new(pep_604_union(std::slice::from_ref(elt))),
             range: TextRange::default(),
             node_index: AtomicNodeIndex::dummy(),
         }),

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -162,13 +162,13 @@ impl Ranged for DictItem {
 impl ExprDict {
     /// Returns an `Iterator` over the AST nodes representing the
     /// dictionary's keys.
-    pub fn iter_keys(&self) -> DictKeyIterator {
+    pub fn iter_keys(&self) -> DictKeyIterator<'_> {
         DictKeyIterator::new(&self.items)
     }
 
     /// Returns an `Iterator` over the AST nodes representing the
     /// dictionary's values.
-    pub fn iter_values(&self) -> DictValueIterator {
+    pub fn iter_values(&self) -> DictValueIterator<'_> {
         DictValueIterator::new(&self.items)
     }
 
@@ -462,13 +462,13 @@ impl FStringValue {
     }
 
     /// Returns an iterator over all the [`FStringPart`]s contained in this value.
-    pub fn iter(&self) -> Iter<FStringPart> {
+    pub fn iter(&self) -> Iter<'_, FStringPart> {
         self.as_slice().iter()
     }
 
     /// Returns an iterator over all the [`FStringPart`]s contained in this value
     /// that allows modification.
-    pub fn iter_mut(&mut self) -> IterMut<FStringPart> {
+    pub fn iter_mut(&mut self) -> IterMut<'_, FStringPart> {
         self.as_mut_slice().iter_mut()
     }
 
@@ -657,13 +657,13 @@ impl TStringValue {
     }
 
     /// Returns an iterator over all the [`TString`]s contained in this value.
-    pub fn iter(&self) -> Iter<TString> {
+    pub fn iter(&self) -> Iter<'_, TString> {
         self.as_slice().iter()
     }
 
     /// Returns an iterator over all the [`TString`]s contained in this value
     /// that allows modification.
-    pub fn iter_mut(&mut self) -> IterMut<TString> {
+    pub fn iter_mut(&mut self) -> IterMut<'_, TString> {
         self.as_mut_slice().iter_mut()
     }
 
@@ -765,7 +765,7 @@ pub trait StringFlags: Copy {
         AnyStringFlags::new(self.prefix(), self.quote_style(), self.triple_quotes())
     }
 
-    fn display_contents(self, contents: &str) -> DisplayFlags {
+    fn display_contents(self, contents: &str) -> DisplayFlags<'_> {
         DisplayFlags {
             flags: self.as_any_string_flags(),
             contents,
@@ -1289,13 +1289,13 @@ impl StringLiteralValue {
     }
 
     /// Returns an iterator over all the [`StringLiteral`] parts contained in this value.
-    pub fn iter(&self) -> Iter<StringLiteral> {
+    pub fn iter(&self) -> Iter<'_, StringLiteral> {
         self.as_slice().iter()
     }
 
     /// Returns an iterator over all the [`StringLiteral`] parts contained in this value
     /// that allows modification.
-    pub fn iter_mut(&mut self) -> IterMut<StringLiteral> {
+    pub fn iter_mut(&mut self) -> IterMut<'_, StringLiteral> {
         self.as_mut_slice().iter_mut()
     }
 
@@ -1717,13 +1717,13 @@ impl BytesLiteralValue {
     }
 
     /// Returns an iterator over all the [`BytesLiteral`] parts contained in this value.
-    pub fn iter(&self) -> Iter<BytesLiteral> {
+    pub fn iter(&self) -> Iter<'_, BytesLiteral> {
         self.as_slice().iter()
     }
 
     /// Returns an iterator over all the [`BytesLiteral`] parts contained in this value
     /// that allows modification.
-    pub fn iter_mut(&mut self) -> IterMut<BytesLiteral> {
+    pub fn iter_mut(&mut self) -> IterMut<'_, BytesLiteral> {
         self.as_mut_slice().iter_mut()
     }
 
@@ -3011,7 +3011,7 @@ impl Parameters {
     }
 
     /// Returns an iterator over all parameters included in this [`Parameters`] node.
-    pub fn iter(&self) -> ParametersIterator {
+    pub fn iter(&self) -> ParametersIterator<'_> {
         ParametersIterator::new(self)
     }
 
@@ -3328,7 +3328,7 @@ impl Arguments {
     /// Return the argument with the given name or at the given position, or `None` if no such
     /// argument exists. Used to retrieve arguments that can be provided _either_ as keyword or
     /// positional arguments.
-    pub fn find_argument(&self, name: &str, position: usize) -> Option<ArgOrKeyword> {
+    pub fn find_argument(&self, name: &str, position: usize) -> Option<ArgOrKeyword<'_>> {
         self.find_keyword(name)
             .map(ArgOrKeyword::from)
             .or_else(|| self.find_positional(position).map(ArgOrKeyword::from))

--- a/crates/ruff_python_ast/src/stmt_if.rs
+++ b/crates/ruff_python_ast/src/stmt_if.rs
@@ -33,7 +33,7 @@ impl Ranged for IfElifBranch<'_> {
     }
 }
 
-pub fn if_elif_branches(stmt_if: &StmtIf) -> impl Iterator<Item = IfElifBranch> {
+pub fn if_elif_branches(stmt_if: &StmtIf) -> impl Iterator<Item = IfElifBranch<'_>> {
     iter::once(IfElifBranch {
         kind: BranchKind::If,
         test: stmt_if.test.as_ref(),

--- a/crates/ruff_python_formatter/src/comments/format.rs
+++ b/crates/ruff_python_formatter/src/comments/format.rs
@@ -21,7 +21,7 @@ where
 }
 
 /// Formats the passed comments as leading comments
-pub(crate) const fn leading_comments(comments: &[SourceComment]) -> FormatLeadingComments {
+pub(crate) const fn leading_comments(comments: &[SourceComment]) -> FormatLeadingComments<'_> {
     FormatLeadingComments::Comments(comments)
 }
 
@@ -135,7 +135,7 @@ impl Format<PyFormatContext<'_>> for FormatLeadingAlternateBranchComments<'_> {
 }
 
 /// Formats the passed comments as trailing comments
-pub(crate) fn trailing_comments(comments: &[SourceComment]) -> FormatTrailingComments {
+pub(crate) fn trailing_comments(comments: &[SourceComment]) -> FormatTrailingComments<'_> {
     FormatTrailingComments(comments)
 }
 
@@ -199,7 +199,7 @@ where
     FormatDanglingComments::Node(node.into())
 }
 
-pub(crate) fn dangling_comments(comments: &[SourceComment]) -> FormatDanglingComments {
+pub(crate) fn dangling_comments(comments: &[SourceComment]) -> FormatDanglingComments<'_> {
     FormatDanglingComments::Comments(comments)
 }
 
@@ -260,7 +260,7 @@ impl Format<PyFormatContext<'_>> for FormatDanglingComments<'_> {
 /// ```
 pub(crate) fn dangling_open_parenthesis_comments(
     comments: &[SourceComment],
-) -> FormatDanglingOpenParenthesisComments {
+) -> FormatDanglingOpenParenthesisComments<'_> {
     FormatDanglingOpenParenthesisComments { comments }
 }
 
@@ -292,7 +292,7 @@ impl Format<PyFormatContext<'_>> for FormatDanglingOpenParenthesisComments<'_> {
 ///
 /// * Adds a whitespace between `#` and the comment text except if the first character is a `#`, `:`, `'`, or `!`
 /// * Replaces non breaking whitespaces with regular whitespaces except if in front of a `types:` comment
-pub(crate) const fn format_comment(comment: &SourceComment) -> FormatComment {
+pub(crate) const fn format_comment(comment: &SourceComment) -> FormatComment<'_> {
     FormatComment { comment }
 }
 
@@ -361,7 +361,7 @@ impl Format<PyFormatContext<'_>> for FormatEmptyLines {
 /// * Expands parent node.
 pub(crate) const fn trailing_end_of_line_comment(
     comment: &SourceComment,
-) -> FormatTrailingEndOfLineComment {
+) -> FormatTrailingEndOfLineComment<'_> {
     FormatTrailingEndOfLineComment { comment }
 }
 
@@ -537,7 +537,7 @@ fn strip_comment_prefix(comment_text: &str) -> FormatResult<&str> {
 pub(crate) fn empty_lines_before_trailing_comments(
     comments: &[SourceComment],
     node_kind: NodeKind,
-) -> FormatEmptyLinesBeforeTrailingComments {
+) -> FormatEmptyLinesBeforeTrailingComments<'_> {
     FormatEmptyLinesBeforeTrailingComments {
         comments,
         node_kind,
@@ -589,7 +589,7 @@ impl Format<PyFormatContext<'_>> for FormatEmptyLinesBeforeTrailingComments<'_> 
 /// additional empty line before the comment.
 pub(crate) fn empty_lines_after_leading_comments(
     comments: &[SourceComment],
-) -> FormatEmptyLinesAfterLeadingComments {
+) -> FormatEmptyLinesAfterLeadingComments<'_> {
     FormatEmptyLinesAfterLeadingComments { comments }
 }
 

--- a/crates/ruff_python_formatter/src/comments/map.rs
+++ b/crates/ruff_python_formatter/src/comments/map.rs
@@ -249,7 +249,7 @@ impl<K: std::hash::Hash + Eq, V> MultiMap<K, V> {
     }
 
     /// Returns the *leading*, *dangling*, and *trailing* parts of `key`.
-    pub(super) fn leading_dangling_trailing(&self, key: &K) -> LeadingDanglingTrailing<V> {
+    pub(super) fn leading_dangling_trailing(&self, key: &K) -> LeadingDanglingTrailing<'_, V> {
         match self.index.get(key) {
             None => LeadingDanglingTrailing {
                 leading: &[],

--- a/crates/ruff_python_formatter/src/comments/mod.rs
+++ b/crates/ruff_python_formatter/src/comments/mod.rs
@@ -358,7 +358,10 @@ impl<'a> Comments<'a> {
     }
 
     /// Returns an iterator over the [leading](self#leading-comments), [dangling](self#dangling-comments), and [trailing](self#trailing) comments of `node`.
-    pub(crate) fn leading_dangling_trailing<T>(&self, node: T) -> LeadingDanglingTrailingComments
+    pub(crate) fn leading_dangling_trailing<T>(
+        &self,
+        node: T,
+    ) -> LeadingDanglingTrailingComments<'_>
     where
         T: Into<AnyNodeRef<'a>>,
     {

--- a/crates/ruff_python_formatter/src/comments/node_key.rs
+++ b/crates/ruff_python_formatter/src/comments/node_key.rs
@@ -18,7 +18,7 @@ impl<'a> NodeRefEqualityKey<'a> {
     }
 
     /// Returns the underlying node.
-    pub(super) fn node(&self) -> AnyNodeRef {
+    pub(super) fn node(&self) -> AnyNodeRef<'_> {
         self.node
     }
 }

--- a/crates/ruff_python_formatter/src/context.rs
+++ b/crates/ruff_python_formatter/src/context.rs
@@ -121,7 +121,7 @@ impl FormatContext for PyFormatContext<'_> {
         &self.options
     }
 
-    fn source_code(&self) -> SourceCode {
+    fn source_code(&self) -> SourceCode<'_> {
         SourceCode::new(self.contents)
     }
 }

--- a/crates/ruff_python_formatter/src/expression/expr_number_literal.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_number_literal.rs
@@ -62,7 +62,7 @@ impl NeedsParentheses for ExprNumberLiteral {
 }
 
 /// Returns the normalized integer string.
-fn normalize_integer(input: &str) -> Cow<str> {
+fn normalize_integer(input: &str) -> Cow<'_, str> {
     // The normalized string if `input` is not yet normalized.
     // `output` must remain empty if `input` is already normalized.
     let mut output = String::new();
@@ -107,7 +107,7 @@ fn normalize_integer(input: &str) -> Cow<str> {
 }
 
 /// Returns the normalized floating number string.
-fn normalize_floating_number(input: &str) -> Cow<str> {
+fn normalize_floating_number(input: &str) -> Cow<'_, str> {
     // The normalized string if `input` is not yet normalized.
     // `output` must remain empty if `input` is already normalized.
     let mut output = String::new();

--- a/crates/ruff_python_formatter/src/string/normalize.rs
+++ b/crates/ruff_python_formatter/src/string/normalize.rs
@@ -645,7 +645,7 @@ pub(crate) fn normalize_string(
     start_offset: usize,
     new_flags: AnyStringFlags,
     escape_braces: bool,
-) -> Cow<str> {
+) -> Cow<'_, str> {
     // The normalized string if `input` is not yet normalized.
     // `output` must remain empty if `input` is already normalized.
     let mut output = String::new();
@@ -798,7 +798,7 @@ impl UnicodeEscape {
     ///
     /// * `\u`, `\U'` and `\x`: To use lower case for the characters `a-f`.
     /// * `\N`: To use uppercase letters
-    fn normalize(self, input: &str) -> Option<Cow<str>> {
+    fn normalize(self, input: &str) -> Option<Cow<'_, str>> {
         let mut normalised = String::new();
 
         let len = match self {

--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -1687,7 +1687,7 @@ impl<'a> LexedText<'a> {
 }
 
 /// Create a new [`Lexer`] for the given source code and [`Mode`].
-pub fn lex(source: &str, mode: Mode) -> Lexer {
+pub fn lex(source: &str, mode: Mode) -> Lexer<'_> {
     Lexer::new(source, mode, TextSize::default())
 }
 

--- a/crates/ruff_python_parser/src/lib.rs
+++ b/crates/ruff_python_parser/src/lib.rs
@@ -485,7 +485,7 @@ impl Tokens {
     }
 
     /// Returns an iterator over all the tokens that provides context.
-    pub fn iter_with_context(&self) -> TokenIterWithContext {
+    pub fn iter_with_context(&self) -> TokenIterWithContext<'_> {
         TokenIterWithContext::new(&self.raw)
     }
 

--- a/crates/ruff_python_parser/src/parser/helpers.rs
+++ b/crates/ruff_python_parser/src/parser/helpers.rs
@@ -21,8 +21,9 @@ pub(super) fn set_expr_ctx(expr: &mut Expr, new_ctx: ExprContext) {
         Expr::List(ast::ExprList { elts, ctx, .. })
         | Expr::Tuple(ast::ExprTuple { elts, ctx, .. }) => {
             *ctx = new_ctx;
-            elts.iter_mut()
-                .for_each(|element| set_expr_ctx(element, new_ctx));
+            for element in elts.iter_mut() {
+                set_expr_ctx(element, new_ctx);
+            }
         }
         _ => {}
     }

--- a/crates/ruff_python_semantic/src/imports.rs
+++ b/crates/ruff_python_semantic/src/imports.rs
@@ -57,7 +57,7 @@ impl NameImport {
     }
 
     /// Returns the [`QualifiedName`] of the imported name (e.g., given `from foo import bar as baz`, returns `["foo", "bar"]`).
-    pub fn qualified_name(&self) -> QualifiedName {
+    pub fn qualified_name(&self) -> QualifiedName<'_> {
         match self {
             NameImport::Import(import) => QualifiedName::user_defined(&import.name.name),
             NameImport::ImportFrom(import_from) => collect_import_from_member(

--- a/crates/ruff_python_semantic/src/model.rs
+++ b/crates/ruff_python_semantic/src/model.rs
@@ -2100,7 +2100,7 @@ impl<'a> SemanticModel<'a> {
     /// This method searches all scopes created by a function definition, comparing the
     /// [`TextRange`] of the provided `function_def` with the the range of the function
     /// associated with the scope.
-    pub fn function_scope(&self, function_def: &ast::StmtFunctionDef) -> Option<&Scope> {
+    pub fn function_scope(&self, function_def: &ast::StmtFunctionDef) -> Option<&Scope<'_>> {
         self.scopes.iter().find(|scope| {
             let Some(function) = scope.kind.as_function() else {
                 return false;

--- a/crates/ruff_server/src/server/api.rs
+++ b/crates/ruff_server/src/server/api.rs
@@ -33,7 +33,7 @@ use super::{Result, schedule::BackgroundSchedule};
 /// that is of type [`lsp_types::Url`].
 macro_rules! define_document_url {
     ($params:ident: &$p:ty) => {
-        fn document_url($params: &$p) -> std::borrow::Cow<lsp_types::Url> {
+        fn document_url($params: &$p) -> std::borrow::Cow<'_, lsp_types::Url> {
             std::borrow::Cow::Borrowed(&$params.text_document.uri)
         }
     };

--- a/crates/ruff_server/src/server/api/requests/code_action_resolve.rs
+++ b/crates/ruff_server/src/server/api/requests/code_action_resolve.rs
@@ -21,7 +21,7 @@ impl super::RequestHandler for CodeActionResolve {
 }
 
 impl super::BackgroundDocumentRequestHandler for CodeActionResolve {
-    fn document_url(params: &types::CodeAction) -> Cow<types::Url> {
+    fn document_url(params: &types::CodeAction) -> Cow<'_, types::Url> {
         let uri: lsp_types::Url = serde_json::from_value(params.data.clone().unwrap_or_default())
             .expect("code actions should have a URI in their data fields");
         Cow::Owned(uri)

--- a/crates/ruff_server/src/server/api/requests/hover.rs
+++ b/crates/ruff_server/src/server/api/requests/hover.rs
@@ -15,7 +15,7 @@ impl super::RequestHandler for Hover {
 }
 
 impl super::BackgroundDocumentRequestHandler for Hover {
-    fn document_url(params: &types::HoverParams) -> std::borrow::Cow<lsp_types::Url> {
+    fn document_url(params: &types::HoverParams) -> std::borrow::Cow<'_, lsp_types::Url> {
         std::borrow::Cow::Borrowed(&params.text_document_position_params.text_document.uri)
     }
     fn run_with_snapshot(

--- a/crates/ruff_server/src/server/api/traits.rs
+++ b/crates/ruff_server/src/server/api/traits.rs
@@ -62,7 +62,7 @@ pub(super) trait BackgroundDocumentRequestHandler: RequestHandler {
     /// [`define_document_url`]: super::define_document_url
     fn document_url(
         params: &<<Self as RequestHandler>::RequestType as Request>::Params,
-    ) -> std::borrow::Cow<lsp_types::Url>;
+    ) -> std::borrow::Cow<'_, lsp_types::Url>;
 
     fn run_with_snapshot(
         snapshot: DocumentSnapshot,
@@ -100,7 +100,7 @@ pub(super) trait BackgroundDocumentNotificationHandler: NotificationHandler {
     /// [`define_document_url`]: super::define_document_url
     fn document_url(
         params: &<<Self as NotificationHandler>::NotificationType as LSPNotification>::Params,
-    ) -> std::borrow::Cow<lsp_types::Url>;
+    ) -> std::borrow::Cow<'_, lsp_types::Url>;
 
     fn run_with_snapshot(
         snapshot: DocumentSnapshot,

--- a/crates/ruff_server/src/session/index.rs
+++ b/crates/ruff_server/src/session/index.rs
@@ -619,7 +619,7 @@ impl DocumentQuery {
     /// Get the path for the document selected by this query, ignoring whether the file exists on disk.
     ///
     /// Returns the URL's path if this is an unsaved (untitled) document.
-    pub(crate) fn virtual_file_path(&self) -> Cow<Path> {
+    pub(crate) fn virtual_file_path(&self) -> Cow<'_, Path> {
         self.file_path()
             .map(Cow::Owned)
             .unwrap_or_else(|| Cow::Borrowed(Path::new(self.file_url().path())))

--- a/crates/ruff_source_file/src/lib.rs
+++ b/crates/ruff_source_file/src/lib.rs
@@ -190,7 +190,7 @@ impl SourceFile {
         &self.source_text()[range]
     }
 
-    pub fn to_source_code(&self) -> SourceCode {
+    pub fn to_source_code(&self) -> SourceCode<'_, '_> {
         SourceCode {
             text: self.source_text(),
             index: self.index(),

--- a/crates/ruff_wasm/src/lib.rs
+++ b/crates/ruff_wasm/src/lib.rs
@@ -308,7 +308,7 @@ impl<'a> ParsedModule<'a> {
         })
     }
 
-    fn format(&self, settings: &Settings) -> FormatResult<Formatted<PyFormatContext>> {
+    fn format(&self, settings: &Settings) -> FormatResult<Formatted<PyFormatContext<'_>>> {
         // TODO(konstin): Add an options for py/pyi to the UI (2/2)
         let options = settings
             .formatter

--- a/crates/ty_ide/src/goto.rs
+++ b/crates/ty_ide/src/goto.rs
@@ -331,7 +331,7 @@ impl GotoTarget<'_> {
     /// Returns `None` if no meaningful string representation can be provided.
     /// This is used by the "references" feature, which looks for references
     /// to this goto target.
-    pub(crate) fn to_string(&self) -> Option<Cow<str>> {
+    pub(crate) fn to_string(&self) -> Option<Cow<'_, str>> {
         match self {
             GotoTarget::Expression(expression) => match expression {
                 ast::ExprRef::Name(name) => Some(Cow::Borrowed(name.id.as_str())),

--- a/crates/ty_ide/src/markup.rs
+++ b/crates/ty_ide/src/markup.rs
@@ -8,7 +8,11 @@ pub enum MarkupKind {
 }
 
 impl MarkupKind {
-    pub(crate) const fn fenced_code_block<T>(self, code: T, language: &str) -> FencedCodeBlock<T>
+    pub(crate) const fn fenced_code_block<T>(
+        self,
+        code: T,
+        language: &str,
+    ) -> FencedCodeBlock<'_, T>
     where
         T: fmt::Display,
     {

--- a/crates/ty_project/src/files.rs
+++ b/crates/ty_project/src/files.rs
@@ -38,7 +38,7 @@ impl IndexedFiles {
         }
     }
 
-    pub(super) fn get(&self) -> Index {
+    pub(super) fn get(&self) -> Index<'_> {
         let state = self.state.lock().unwrap();
 
         match &*state {
@@ -57,7 +57,7 @@ impl IndexedFiles {
     /// Returns a mutable view on the index that allows cheap in-place mutations.
     ///
     /// The changes are automatically written back to the database once the view is dropped.
-    pub(super) fn indexed_mut(db: &mut dyn Db, project: Project) -> Option<IndexedMut> {
+    pub(super) fn indexed_mut(db: &mut dyn Db, project: Project) -> Option<IndexedMut<'_>> {
         // Calling `trigger_cancellation` cancels all pending salsa queries. This ensures that there are no pending
         // reads to the file set (this `db` is the only alive db).
         db.trigger_cancellation();

--- a/crates/ty_python_semantic/src/list.rs
+++ b/crates/ty_python_semantic/src/list.rs
@@ -196,7 +196,7 @@ impl<K, V> ListBuilder<K, V> {
     /// entries to duplicate for each insertion. If you construct the list in reverse order, we
     /// will have to duplicate O(n) entries for each insertion, making it _quadratic_ to construct
     /// the entire list.
-    pub(crate) fn entry(&mut self, list: List<K, V>, key: K) -> ListEntry<K, V>
+    pub(crate) fn entry(&mut self, list: List<K, V>, key: K) -> ListEntry<'_, K, V>
     where
         K: Clone + Ord,
         V: Clone,
@@ -373,7 +373,7 @@ impl<K, V> ListBuilder<K, V> {
 impl<K> ListStorage<K, ()> {
     /// Iterates through the elements in a set _in reverse order_.
     #[expect(clippy::needless_pass_by_value)]
-    pub(crate) fn iter_set_reverse(&self, set: List<K, ()>) -> ListSetReverseIterator<K> {
+    pub(crate) fn iter_set_reverse(&self, set: List<K, ()>) -> ListSetReverseIterator<'_, K> {
         ListSetReverseIterator {
             storage: self,
             curr: set.last,

--- a/crates/ty_python_semantic/src/module_resolver/mod.rs
+++ b/crates/ty_python_semantic/src/module_resolver/mod.rs
@@ -21,7 +21,7 @@ mod typeshed;
 mod testing;
 
 /// Returns an iterator over all search paths pointing to a system path
-pub fn system_module_search_paths(db: &dyn Db) -> SystemModuleSearchPathsIter {
+pub fn system_module_search_paths(db: &dyn Db) -> SystemModuleSearchPathsIter<'_> {
     SystemModuleSearchPathsIter {
         inner: search_paths(db),
     }

--- a/crates/ty_python_semantic/src/module_resolver/resolver.rs
+++ b/crates/ty_python_semantic/src/module_resolver/resolver.rs
@@ -153,7 +153,7 @@ pub(crate) fn file_to_module(db: &dyn Db, file: File) -> Option<Module<'_>> {
     }
 }
 
-pub(crate) fn search_paths(db: &dyn Db) -> SearchPathIterator {
+pub(crate) fn search_paths(db: &dyn Db) -> SearchPathIterator<'_> {
     Program::get(db).search_paths(db).iter(db)
 }
 

--- a/crates/ty_python_semantic/src/semantic_index.rs
+++ b/crates/ty_python_semantic/src/semantic_index.rs
@@ -301,7 +301,7 @@ impl<'db> SemanticIndex<'db> {
         &self.scopes[id]
     }
 
-    pub(crate) fn scope_ids(&self) -> impl Iterator<Item = ScopeId> {
+    pub(crate) fn scope_ids(&self) -> impl Iterator<Item = ScopeId<'db>> + '_ {
         self.scope_ids_by_scope.iter().copied()
     }
 
@@ -371,18 +371,18 @@ impl<'db> SemanticIndex<'db> {
 
     /// Returns an iterator over the descendent scopes of `scope`.
     #[allow(unused)]
-    pub(crate) fn descendent_scopes(&self, scope: FileScopeId) -> DescendantsIter {
+    pub(crate) fn descendent_scopes(&self, scope: FileScopeId) -> DescendantsIter<'_> {
         DescendantsIter::new(self, scope)
     }
 
     /// Returns an iterator over the direct child scopes of `scope`.
     #[allow(unused)]
-    pub(crate) fn child_scopes(&self, scope: FileScopeId) -> ChildrenIter {
+    pub(crate) fn child_scopes(&self, scope: FileScopeId) -> ChildrenIter<'_> {
         ChildrenIter::new(self, scope)
     }
 
     /// Returns an iterator over all ancestors of `scope`, starting with `scope` itself.
-    pub(crate) fn ancestor_scopes(&self, scope: FileScopeId) -> AncestorsIter {
+    pub(crate) fn ancestor_scopes(&self, scope: FileScopeId) -> AncestorsIter<'_> {
         AncestorsIter::new(self, scope)
     }
 
@@ -400,7 +400,7 @@ impl<'db> SemanticIndex<'db> {
     ///         print(x)  # Refers to global x=1, not class x=2
     /// ```
     /// The `method` function can see the global scope but not the class scope.
-    pub(crate) fn visible_ancestor_scopes(&self, scope: FileScopeId) -> VisibleAncestorsIter {
+    pub(crate) fn visible_ancestor_scopes(&self, scope: FileScopeId) -> VisibleAncestorsIter<'_> {
         VisibleAncestorsIter::new(self, scope)
     }
 

--- a/crates/ty_python_semantic/src/semantic_index/member.rs
+++ b/crates/ty_python_semantic/src/semantic_index/member.rs
@@ -243,7 +243,7 @@ impl MemberExpr {
         self.segments.len()
     }
 
-    pub(crate) fn as_ref(&self) -> MemberExprRef {
+    pub(crate) fn as_ref(&self) -> MemberExprRef<'_> {
         MemberExprRef {
             path: self.path.as_str(),
             segments: SegmentsRef::from(&self.segments),
@@ -381,7 +381,7 @@ impl MemberTable {
     }
 
     /// Returns an iterator over all members in the table.
-    pub(crate) fn iter(&self) -> std::slice::Iter<Member> {
+    pub(crate) fn iter(&self) -> std::slice::Iter<'_, Member> {
         self.members.iter()
     }
 

--- a/crates/ty_python_semantic/src/semantic_index/place.rs
+++ b/crates/ty_python_semantic/src/semantic_index/place.rs
@@ -162,12 +162,12 @@ impl PlaceTable {
     }
 
     /// Iterator over all symbols in this scope.
-    pub(crate) fn symbols(&self) -> std::slice::Iter<Symbol> {
+    pub(crate) fn symbols(&self) -> std::slice::Iter<'_, Symbol> {
         self.symbols.iter()
     }
 
     /// Iterator over all members in this scope.
-    pub(crate) fn members(&self) -> std::slice::Iter<Member> {
+    pub(crate) fn members(&self) -> std::slice::Iter<'_, Member> {
         self.members.iter()
     }
 
@@ -220,7 +220,7 @@ impl PlaceTable {
     /// ## Panics
     /// If the place ID is not found in the table.
     #[track_caller]
-    pub(crate) fn place(&self, place_id: impl Into<ScopedPlaceId>) -> PlaceExprRef {
+    pub(crate) fn place(&self, place_id: impl Into<ScopedPlaceId>) -> PlaceExprRef<'_> {
         match place_id.into() {
             ScopedPlaceId::Symbol(symbol) => self.symbol(symbol).into(),
             ScopedPlaceId::Member(member) => self.member(member).into(),
@@ -275,7 +275,7 @@ impl PlaceTableBuilder {
     }
 
     #[track_caller]
-    pub(crate) fn place(&self, place_id: impl Into<ScopedPlaceId>) -> PlaceExprRef {
+    pub(crate) fn place(&self, place_id: impl Into<ScopedPlaceId>) -> PlaceExprRef<'_> {
         match place_id.into() {
             ScopedPlaceId::Symbol(id) => PlaceExprRef::Symbol(self.symbols.symbol(id)),
             ScopedPlaceId::Member(id) => PlaceExprRef::Member(self.member.member(id)),
@@ -289,7 +289,7 @@ impl PlaceTableBuilder {
         }
     }
 
-    pub(crate) fn iter(&self) -> impl Iterator<Item = PlaceExprRef> {
+    pub(crate) fn iter(&self) -> impl Iterator<Item = PlaceExprRef<'_>> {
         self.symbols
             .iter()
             .map(Into::into)

--- a/crates/ty_python_semantic/src/semantic_index/symbol.rs
+++ b/crates/ty_python_semantic/src/semantic_index/symbol.rs
@@ -153,7 +153,7 @@ impl SymbolTable {
     }
 
     /// Iterate over the symbols in this symbol table.
-    pub(crate) fn iter(&self) -> std::slice::Iter<Symbol> {
+    pub(crate) fn iter(&self) -> std::slice::Iter<'_, Symbol> {
         self.symbols.iter()
     }
 

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -36,7 +36,7 @@ impl<'db> SemanticModel<'db> {
         line_index(self.db, self.file)
     }
 
-    pub fn resolve_module(&self, module_name: &ModuleName) -> Option<Module> {
+    pub fn resolve_module(&self, module_name: &ModuleName) -> Option<Module<'_>> {
         resolve_module(self.db, module_name)
     }
 

--- a/crates/ty_python_semantic/src/suppression.rs
+++ b/crates/ty_python_semantic/src/suppression.rs
@@ -402,7 +402,7 @@ impl Suppressions {
             })
     }
 
-    fn iter(&self) -> SuppressionsIter {
+    fn iter(&self) -> SuppressionsIter<'_> {
         self.file.iter().chain(&self.line)
     }
 }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2507,7 +2507,7 @@ impl<'db> Type<'db> {
 
     /// This function is roughly equivalent to `find_name_in_mro` as defined in the [descriptor guide] or
     /// [`_PyType_Lookup`] in CPython's `Objects/typeobject.c`. It should typically be called through
-    /// [Type::class_member], unless it is known that `self` is a class-like type. This function returns
+    /// [`Type::class_member`], unless it is known that `self` is a class-like type. This function returns
     /// `None` if called on an instance-like type.
     ///
     /// [descriptor guide]: https://docs.python.org/3/howto/descriptor.html#invocation-from-an-instance
@@ -5009,7 +5009,7 @@ impl<'db> Type<'db> {
         }
     }
 
-    /// Given a class literal or non-dynamic SubclassOf type, try calling it (creating an instance)
+    /// Given a class literal or non-dynamic `SubclassOf` type, try calling it (creating an instance)
     /// and return the resulting instance type.
     ///
     /// Models `type.__call__` behavior.
@@ -6328,7 +6328,7 @@ impl<'db> KnownInstanceType<'db> {
     /// For example, an alias created using the `type` statement is an instance of
     /// `typing.TypeAliasType`, so `KnownInstanceType::TypeAliasType(_).instance_fallback(db)`
     /// returns `Type::NominalInstance(NominalInstanceType { class: <typing.TypeAliasType> })`.
-    fn instance_fallback(self, db: &dyn Db) -> Type {
+    fn instance_fallback(self, db: &dyn Db) -> Type<'_> {
         self.class().to_instance(db)
     }
 
@@ -7908,7 +7908,7 @@ impl Truthiness {
         }
     }
 
-    fn into_type(self, db: &dyn Db) -> Type {
+    fn into_type(self, db: &dyn Db) -> Type<'_> {
         match self {
             Self::AlwaysTrue => Type::BooleanLiteral(true),
             Self::AlwaysFalse => Type::BooleanLiteral(false),
@@ -8606,7 +8606,7 @@ impl<'db> UnionType<'db> {
         Self::from_elements(db, self.elements(db).iter().filter(filter_fn))
     }
 
-    pub fn iter(&self, db: &'db dyn Db) -> Iter<Type<'db>> {
+    pub fn iter(&self, db: &'db dyn Db) -> Iter<'_, Type<'db>> {
         self.elements(db).iter()
     }
 

--- a/crates/ty_python_semantic/src/types/call/arguments.rs
+++ b/crates/ty_python_semantic/src/types/call/arguments.rs
@@ -97,7 +97,7 @@ impl<'a, 'db> CallArguments<'a, 'db> {
     /// Prepend an optional extra synthetic argument (for a `self` or `cls` parameter) to the front
     /// of this argument list. (If `bound_self` is none, we return the argument list
     /// unmodified.)
-    pub(crate) fn with_self(&self, bound_self: Option<Type<'db>>) -> Cow<Self> {
+    pub(crate) fn with_self(&self, bound_self: Option<Type<'db>>) -> Cow<'_, Self> {
         if bound_self.is_some() {
             let arguments = std::iter::once(Argument::Synthetic)
                 .chain(self.arguments.iter().copied())

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -591,7 +591,7 @@ impl<'db> ClassType<'db> {
     }
 
     /// Returns the inferred type of the class member named `name`. Only bound members
-    /// or those marked as ClassVars are considered.
+    /// or those marked as `ClassVars` are considered.
     ///
     /// You must provide the `inherited_generic_context` that we should use for the `__new__` or
     /// `__init__` member. This is inherited from the containing class -­but importantly, from the
@@ -1778,7 +1778,7 @@ impl<'db> ClassLiteral<'db> {
     }
 
     /// Returns the inferred type of the class member named `name`. Only bound members
-    /// or those marked as ClassVars are considered.
+    /// or those marked as `ClassVars` are considered.
     ///
     /// Returns [`Place::Unbound`] if `name` cannot be found in this class's scope
     /// directly. Use [`ClassLiteral::class_member`] if you require a method that will
@@ -3614,7 +3614,7 @@ impl KnownClass {
     /// representing all possible instances of the class.
     ///
     /// If the class cannot be found in typeshed, a debug-level log message will be emitted stating this.
-    pub(crate) fn to_instance(self, db: &dyn Db) -> Type {
+    pub(crate) fn to_instance(self, db: &dyn Db) -> Type<'_> {
         self.to_class_literal(db)
             .to_class_type(db)
             .map(|class| Type::instance(db, class))
@@ -3676,7 +3676,7 @@ impl KnownClass {
     fn try_to_class_literal_without_logging(
         self,
         db: &dyn Db,
-    ) -> Result<ClassLiteral, KnownClassLookupError> {
+    ) -> Result<ClassLiteral<'_>, KnownClassLookupError<'_>> {
         let symbol = known_module_symbol(db, self.canonical_module(db), self.name(db)).place;
         match symbol {
             Place::Type(Type::ClassLiteral(class_literal), Boundness::Bound) => Ok(class_literal),
@@ -3693,7 +3693,7 @@ impl KnownClass {
     /// Lookup a [`KnownClass`] in typeshed and return a [`Type`] representing that class-literal.
     ///
     /// If the class cannot be found in typeshed, a debug-level log message will be emitted stating this.
-    pub(crate) fn try_to_class_literal(self, db: &dyn Db) -> Option<ClassLiteral> {
+    pub(crate) fn try_to_class_literal(self, db: &dyn Db) -> Option<ClassLiteral<'_>> {
         // a cache of the `KnownClass`es that we have already failed to lookup in typeshed
         // (and therefore that we've already logged a warning for)
         static MESSAGES: LazyLock<Mutex<FxHashSet<KnownClass>>> = LazyLock::new(Mutex::default);
@@ -3728,7 +3728,7 @@ impl KnownClass {
     /// Lookup a [`KnownClass`] in typeshed and return a [`Type`] representing that class-literal.
     ///
     /// If the class cannot be found in typeshed, a debug-level log message will be emitted stating this.
-    pub(crate) fn to_class_literal(self, db: &dyn Db) -> Type {
+    pub(crate) fn to_class_literal(self, db: &dyn Db) -> Type<'_> {
         self.try_to_class_literal(db)
             .map(Type::ClassLiteral)
             .unwrap_or_else(Type::unknown)
@@ -3738,7 +3738,7 @@ impl KnownClass {
     /// representing that class and all possible subclasses of the class.
     ///
     /// If the class cannot be found in typeshed, a debug-level log message will be emitted stating this.
-    pub(crate) fn to_subclass_of(self, db: &dyn Db) -> Type {
+    pub(crate) fn to_subclass_of(self, db: &dyn Db) -> Type<'_> {
         self.to_class_literal(db)
             .to_class_type(db)
             .map(|class| SubclassOfType::from(db, class))

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -678,7 +678,7 @@ declare_lint! {
     /// Checks for exception handlers that catch non-exception classes.
     ///
     /// ## Why is this bad?
-    /// Catching classes that do not inherit from `BaseException` will raise a TypeError at runtime.
+    /// Catching classes that do not inherit from `BaseException` will raise a `TypeError` at runtime.
     ///
     /// ## Example
     /// ```python

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -20,7 +20,7 @@ use crate::types::{
 use crate::{Db, FxOrderSet};
 
 impl<'db> Type<'db> {
-    pub fn display(&self, db: &'db dyn Db) -> DisplayType {
+    pub fn display(&self, db: &'db dyn Db) -> DisplayType<'_> {
         DisplayType { ty: self, db }
     }
     fn representation(self, db: &'db dyn Db) -> DisplayRepresentation<'db> {
@@ -980,23 +980,23 @@ impl Display for DisplayMaybeParenthesizedType<'_> {
 }
 
 pub(crate) trait TypeArrayDisplay<'db> {
-    fn display(&self, db: &'db dyn Db) -> DisplayTypeArray;
+    fn display(&self, db: &'db dyn Db) -> DisplayTypeArray<'_, 'db>;
 }
 
 impl<'db> TypeArrayDisplay<'db> for Box<[Type<'db>]> {
-    fn display(&self, db: &'db dyn Db) -> DisplayTypeArray {
+    fn display(&self, db: &'db dyn Db) -> DisplayTypeArray<'_, 'db> {
         DisplayTypeArray { types: self, db }
     }
 }
 
 impl<'db> TypeArrayDisplay<'db> for Vec<Type<'db>> {
-    fn display(&self, db: &'db dyn Db) -> DisplayTypeArray {
+    fn display(&self, db: &'db dyn Db) -> DisplayTypeArray<'_, 'db> {
         DisplayTypeArray { types: self, db }
     }
 }
 
 impl<'db> TypeArrayDisplay<'db> for [Type<'db>] {
-    fn display(&self, db: &'db dyn Db) -> DisplayTypeArray {
+    fn display(&self, db: &'db dyn Db) -> DisplayTypeArray<'_, 'db> {
         DisplayTypeArray { types: self, db }
     }
 }

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -9631,7 +9631,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         &self,
         expression: &ast::Expr,
         message: std::fmt::Arguments,
-    ) -> Option<LintDiagnosticGuard> {
+    ) -> Option<LintDiagnosticGuard<'_, '_>> {
         self.context
             .report_lint(&INVALID_TYPE_FORM, expression)
             .map(|builder| {
@@ -11231,7 +11231,7 @@ impl StringPartsCollector {
         self.expression = true;
     }
 
-    fn string_type(self, db: &dyn Db) -> Type {
+    fn string_type(self, db: &dyn Db) -> Type<'_> {
         if self.expression {
             KnownClass::Str.to_instance(db)
         } else if let Some(concatenated) = self.concatenated {

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1183,7 +1183,7 @@ impl<'db> Parameters<'db> {
         self.value.len()
     }
 
-    pub(crate) fn iter(&self) -> std::slice::Iter<Parameter<'db>> {
+    pub(crate) fn iter(&self) -> std::slice::Iter<'_, Parameter<'db>> {
         self.value.iter()
     }
 

--- a/crates/ty_python_semantic/src/types/special_form.rs
+++ b/crates/ty_python_semantic/src/types/special_form.rs
@@ -171,7 +171,7 @@ impl SpecialFormType {
     /// For example, the symbol `typing.Literal` is an instance of `typing._SpecialForm`,
     /// so `SpecialFormType::Literal.instance_fallback(db)`
     /// returns `Type::NominalInstance(NominalInstanceType { class: <typing._SpecialForm> })`.
-    pub(super) fn instance_fallback(self, db: &dyn Db) -> Type {
+    pub(super) fn instance_fallback(self, db: &dyn Db) -> Type<'_> {
         self.class().to_instance(db)
     }
 
@@ -244,7 +244,7 @@ impl SpecialFormType {
         }
     }
 
-    pub(super) fn to_meta_type(self, db: &dyn Db) -> Type {
+    pub(super) fn to_meta_type(self, db: &dyn Db) -> Type<'_> {
         self.class().to_class_literal(db)
     }
 

--- a/crates/ty_server/src/server/api/requests/completion.rs
+++ b/crates/ty_server/src/server/api/requests/completion.rs
@@ -22,7 +22,7 @@ impl RequestHandler for CompletionRequestHandler {
 }
 
 impl BackgroundDocumentRequestHandler for CompletionRequestHandler {
-    fn document_url(params: &CompletionParams) -> Cow<Url> {
+    fn document_url(params: &CompletionParams) -> Cow<'_, Url> {
         Cow::Borrowed(&params.text_document_position.text_document.uri)
     }
 

--- a/crates/ty_server/src/server/api/requests/diagnostic.rs
+++ b/crates/ty_server/src/server/api/requests/diagnostic.rs
@@ -23,7 +23,7 @@ impl RequestHandler for DocumentDiagnosticRequestHandler {
 }
 
 impl BackgroundDocumentRequestHandler for DocumentDiagnosticRequestHandler {
-    fn document_url(params: &DocumentDiagnosticParams) -> Cow<Url> {
+    fn document_url(params: &DocumentDiagnosticParams) -> Cow<'_, Url> {
         Cow::Borrowed(&params.text_document.uri)
     }
 

--- a/crates/ty_server/src/server/api/requests/doc_highlights.rs
+++ b/crates/ty_server/src/server/api/requests/doc_highlights.rs
@@ -20,7 +20,7 @@ impl RequestHandler for DocumentHighlightRequestHandler {
 }
 
 impl BackgroundDocumentRequestHandler for DocumentHighlightRequestHandler {
-    fn document_url(params: &DocumentHighlightParams) -> Cow<Url> {
+    fn document_url(params: &DocumentHighlightParams) -> Cow<'_, Url> {
         Cow::Borrowed(&params.text_document_position_params.text_document.uri)
     }
 

--- a/crates/ty_server/src/server/api/requests/document_symbols.rs
+++ b/crates/ty_server/src/server/api/requests/document_symbols.rs
@@ -22,7 +22,7 @@ impl RequestHandler for DocumentSymbolRequestHandler {
 }
 
 impl BackgroundDocumentRequestHandler for DocumentSymbolRequestHandler {
-    fn document_url(params: &DocumentSymbolParams) -> Cow<Url> {
+    fn document_url(params: &DocumentSymbolParams) -> Cow<'_, Url> {
         Cow::Borrowed(&params.text_document.uri)
     }
 

--- a/crates/ty_server/src/server/api/requests/goto_declaration.rs
+++ b/crates/ty_server/src/server/api/requests/goto_declaration.rs
@@ -20,7 +20,7 @@ impl RequestHandler for GotoDeclarationRequestHandler {
 }
 
 impl BackgroundDocumentRequestHandler for GotoDeclarationRequestHandler {
-    fn document_url(params: &GotoDeclarationParams) -> Cow<Url> {
+    fn document_url(params: &GotoDeclarationParams) -> Cow<'_, Url> {
         Cow::Borrowed(&params.text_document_position_params.text_document.uri)
     }
 

--- a/crates/ty_server/src/server/api/requests/goto_definition.rs
+++ b/crates/ty_server/src/server/api/requests/goto_definition.rs
@@ -20,7 +20,7 @@ impl RequestHandler for GotoDefinitionRequestHandler {
 }
 
 impl BackgroundDocumentRequestHandler for GotoDefinitionRequestHandler {
-    fn document_url(params: &GotoDefinitionParams) -> Cow<Url> {
+    fn document_url(params: &GotoDefinitionParams) -> Cow<'_, Url> {
         Cow::Borrowed(&params.text_document_position_params.text_document.uri)
     }
 

--- a/crates/ty_server/src/server/api/requests/goto_references.rs
+++ b/crates/ty_server/src/server/api/requests/goto_references.rs
@@ -20,7 +20,7 @@ impl RequestHandler for ReferencesRequestHandler {
 }
 
 impl BackgroundDocumentRequestHandler for ReferencesRequestHandler {
-    fn document_url(params: &ReferenceParams) -> Cow<Url> {
+    fn document_url(params: &ReferenceParams) -> Cow<'_, Url> {
         Cow::Borrowed(&params.text_document_position.text_document.uri)
     }
 

--- a/crates/ty_server/src/server/api/requests/goto_type_definition.rs
+++ b/crates/ty_server/src/server/api/requests/goto_type_definition.rs
@@ -20,7 +20,7 @@ impl RequestHandler for GotoTypeDefinitionRequestHandler {
 }
 
 impl BackgroundDocumentRequestHandler for GotoTypeDefinitionRequestHandler {
-    fn document_url(params: &GotoTypeDefinitionParams) -> Cow<Url> {
+    fn document_url(params: &GotoTypeDefinitionParams) -> Cow<'_, Url> {
         Cow::Borrowed(&params.text_document_position_params.text_document.uri)
     }
 

--- a/crates/ty_server/src/server/api/requests/hover.rs
+++ b/crates/ty_server/src/server/api/requests/hover.rs
@@ -20,7 +20,7 @@ impl RequestHandler for HoverRequestHandler {
 }
 
 impl BackgroundDocumentRequestHandler for HoverRequestHandler {
-    fn document_url(params: &HoverParams) -> Cow<Url> {
+    fn document_url(params: &HoverParams) -> Cow<'_, Url> {
         Cow::Borrowed(&params.text_document_position_params.text_document.uri)
     }
 

--- a/crates/ty_server/src/server/api/requests/inlay_hints.rs
+++ b/crates/ty_server/src/server/api/requests/inlay_hints.rs
@@ -19,7 +19,7 @@ impl RequestHandler for InlayHintRequestHandler {
 }
 
 impl BackgroundDocumentRequestHandler for InlayHintRequestHandler {
-    fn document_url(params: &InlayHintParams) -> Cow<Url> {
+    fn document_url(params: &InlayHintParams) -> Cow<'_, Url> {
         Cow::Borrowed(&params.text_document.uri)
     }
 

--- a/crates/ty_server/src/server/api/requests/prepare_rename.rs
+++ b/crates/ty_server/src/server/api/requests/prepare_rename.rs
@@ -20,7 +20,7 @@ impl RequestHandler for PrepareRenameRequestHandler {
 }
 
 impl BackgroundDocumentRequestHandler for PrepareRenameRequestHandler {
-    fn document_url(params: &TextDocumentPositionParams) -> Cow<Url> {
+    fn document_url(params: &TextDocumentPositionParams) -> Cow<'_, Url> {
         Cow::Borrowed(&params.text_document.uri)
     }
 

--- a/crates/ty_server/src/server/api/requests/rename.rs
+++ b/crates/ty_server/src/server/api/requests/rename.rs
@@ -21,7 +21,7 @@ impl RequestHandler for RenameRequestHandler {
 }
 
 impl BackgroundDocumentRequestHandler for RenameRequestHandler {
-    fn document_url(params: &RenameParams) -> Cow<Url> {
+    fn document_url(params: &RenameParams) -> Cow<'_, Url> {
         Cow::Borrowed(&params.text_document_position.text_document.uri)
     }
 

--- a/crates/ty_server/src/server/api/requests/selection_range.rs
+++ b/crates/ty_server/src/server/api/requests/selection_range.rs
@@ -20,7 +20,7 @@ impl RequestHandler for SelectionRangeRequestHandler {
 }
 
 impl BackgroundDocumentRequestHandler for SelectionRangeRequestHandler {
-    fn document_url(params: &SelectionRangeParams) -> Cow<Url> {
+    fn document_url(params: &SelectionRangeParams) -> Cow<'_, Url> {
         Cow::Borrowed(&params.text_document.uri)
     }
 

--- a/crates/ty_server/src/server/api/requests/semantic_tokens.rs
+++ b/crates/ty_server/src/server/api/requests/semantic_tokens.rs
@@ -16,7 +16,7 @@ impl RequestHandler for SemanticTokensRequestHandler {
 }
 
 impl BackgroundDocumentRequestHandler for SemanticTokensRequestHandler {
-    fn document_url(params: &SemanticTokensParams) -> Cow<Url> {
+    fn document_url(params: &SemanticTokensParams) -> Cow<'_, Url> {
         Cow::Borrowed(&params.text_document.uri)
     }
 

--- a/crates/ty_server/src/server/api/requests/semantic_tokens_range.rs
+++ b/crates/ty_server/src/server/api/requests/semantic_tokens_range.rs
@@ -18,7 +18,7 @@ impl RequestHandler for SemanticTokensRangeRequestHandler {
 }
 
 impl BackgroundDocumentRequestHandler for SemanticTokensRangeRequestHandler {
-    fn document_url(params: &SemanticTokensRangeParams) -> Cow<Url> {
+    fn document_url(params: &SemanticTokensRangeParams) -> Cow<'_, Url> {
         Cow::Borrowed(&params.text_document.uri)
     }
 

--- a/crates/ty_server/src/server/api/requests/signature_help.rs
+++ b/crates/ty_server/src/server/api/requests/signature_help.rs
@@ -22,7 +22,7 @@ impl RequestHandler for SignatureHelpRequestHandler {
 }
 
 impl BackgroundDocumentRequestHandler for SignatureHelpRequestHandler {
-    fn document_url(params: &SignatureHelpParams) -> Cow<Url> {
+    fn document_url(params: &SignatureHelpParams) -> Cow<'_, Url> {
         Cow::Borrowed(&params.text_document_position_params.text_document.uri)
     }
 

--- a/crates/ty_server/src/server/api/traits.rs
+++ b/crates/ty_server/src/server/api/traits.rs
@@ -89,7 +89,7 @@ pub(super) trait BackgroundDocumentRequestHandler: RetriableRequestHandler {
     /// Returns the URL of the document that this request handler operates on.
     fn document_url(
         params: &<<Self as RequestHandler>::RequestType as Request>::Params,
-    ) -> Cow<Url>;
+    ) -> Cow<'_, Url>;
 
     /// Processes the request parameters and returns the LSP request result.
     ///
@@ -184,7 +184,7 @@ pub(super) trait BackgroundDocumentNotificationHandler: NotificationHandler {
     /// Returns the URL of the document that this notification handler operates on.
     fn document_url(
         params: &<<Self as NotificationHandler>::NotificationType as Notification>::Params,
-    ) -> Cow<Url>;
+    ) -> Cow<'_, Url>;
 
     fn run_with_snapshot(
         snapshot: DocumentSnapshot,

--- a/crates/ty_server/src/session.rs
+++ b/crates/ty_server/src/session.rs
@@ -750,7 +750,7 @@ impl Session {
     /// This method drops all references to the index and returns a guard that will restore the
     /// references when dropped. This guard holds the only reference to the index and allows
     /// modifying it.
-    fn index_mut(&mut self) -> MutIndexGuard {
+    fn index_mut(&mut self) -> MutIndexGuard<'_> {
         let index = self.index.take().unwrap();
 
         for db in self.projects_mut() {

--- a/crates/ty_static/src/env_vars.rs
+++ b/crates/ty_static/src/env_vars.rs
@@ -27,7 +27,7 @@ impl EnvVars {
     /// Accepted values:
     ///
     /// * `short` - Display short memory report
-    /// * `mypy_primer` - Display mypy_primer format and suppress workspace diagnostics
+    /// * `mypy_primer` - Display `mypy_primer` format and suppress workspace diagnostics
     /// * `full` - Display full memory report
     #[attr_hidden]
     pub const TY_MEMORY_REPORT: &'static str = "TY_MEMORY_REPORT";

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.88"
+channel = "1.89"


### PR DESCRIPTION
## Summary

This PR updates our Rust toolchain to 1.89. 

It doesn't bump the MSRV. We should do that but I might not have the time today (because it also requires updating conda forge).

## Test Plan

`cargo clippy && cargo fmt`
