### PR TITLE
[PLE2513] Make hex characters lowercase

### DIFF
--- a/crates/ruff_db/src/diagnostic/render/full.rs
+++ b/crates/ruff_db/src/diagnostic/render/full.rs
@@ -186,7 +186,7 @@ print()
     /// For example, without the fix, we get diagnostics like this:
     ///
     /// ```
-    /// error[invalid-character-sub]: Invalid unescaped character SUB, use "\x1A" instead
+    /// error[invalid-character-sub]: Invalid unescaped character SUB, use "\x1a" instead
     ///  --> example.py:1:25
     ///   |
     /// 1 | nested_fstrings = f'␈{f'{f'␛'}'}'
@@ -206,13 +206,13 @@ print()
             .builder(
                 "invalid-character-sub",
                 Severity::Error,
-                r#"Invalid unescaped character SUB, use "\x1A" instead"#,
+                r#"Invalid unescaped character SUB, use "\x1a" instead"#,
             )
             .primary("example.py", "1:24", "1:24", "")
             .build();
 
         insta::assert_snapshot!(env.render(&diagnostic), @r#"
-        error[invalid-character-sub]: Invalid unescaped character SUB, use "\x1A" instead
+        error[invalid-character-sub]: Invalid unescaped character SUB, use "\x1a" instead
          --> example.py:1:25
           |
         1 | nested_fstrings = f'␈{f'{f'␛'}'}'
@@ -231,13 +231,13 @@ print()
             .builder(
                 "invalid-character-sub",
                 Severity::Error,
-                r#"Invalid unescaped character SUB, use "\x1A" instead"#,
+                r#"Invalid unescaped character SUB, use "\x1a" instead"#,
             )
             .primary("example.py", "1:1", "1:1", "")
             .build();
 
         insta::assert_snapshot!(env.render(&diagnostic), @r#"
-        error[invalid-character-sub]: Invalid unescaped character SUB, use "\x1A" instead
+        error[invalid-character-sub]: Invalid unescaped character SUB, use "\x1a" instead
          --> example.py:1:2
           |
         1 | ␈␛

--- a/crates/ruff_linter/src/rules/pylint/rules/invalid_string_characters.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/invalid_string_characters.rs
@@ -48,7 +48,7 @@ impl Violation for InvalidCharacterBackspace {
 /// Control characters are displayed differently by different text editors and
 /// terminals.
 ///
-/// By using the `\x1A` sequence in lieu of the `SUB` control character, the
+/// By using the `\x1a` sequence in lieu of the `SUB` control character, the
 /// string will contain the same value, but will render visibly in all editors.
 ///
 /// ## Example
@@ -68,7 +68,7 @@ impl Violation for InvalidCharacterSub {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        "Invalid unescaped character SUB, use \"\\x1A\" instead".to_string()
+        "Invalid unescaped character SUB, use \"\\x1a\" instead".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {
@@ -83,7 +83,7 @@ impl Violation for InvalidCharacterSub {
 /// Control characters are displayed differently by different text editors and
 /// terminals.
 ///
-/// By using the `\x1B` sequence in lieu of the `SUB` control character, the
+/// By using the `\x1b` sequence in lieu of the `ESC` control character, the
 /// string will contain the same value, but will render visibly in all editors.
 ///
 /// ## Example
@@ -103,7 +103,7 @@ impl Violation for InvalidCharacterEsc {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        "Invalid unescaped character ESC, use \"\\x1B\" instead".to_string()
+        "Invalid unescaped character ESC, use \"\\x1b\" instead".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {
@@ -191,7 +191,7 @@ pub(crate) fn invalid_string_characters(context: &LintContext, token: &Token, lo
         _ => return,
     };
 
-    for (column, match_) in text.match_indices(&['\x08', '\x1A', '\x1B', '\0', '\u{200b}']) {
+    for (column, match_) in text.match_indices(&['\x08', '\x1a', '\x1b', '\0', '\u{200b}']) {
         let location = token.start() + TextSize::try_from(column).unwrap();
         let c = match_.chars().next().unwrap();
         let range = TextRange::at(location, c.text_len());
@@ -209,12 +209,12 @@ pub(crate) fn invalid_string_characters(context: &LintContext, token: &Token, lo
                 "\\b",
                 context.report_diagnostic_if_enabled(InvalidCharacterBackspace, range),
             ),
-            '\x1A' => (
-                "\\x1A",
+            '\x1a' => (
+                "\\x1a",
                 context.report_diagnostic_if_enabled(InvalidCharacterSub, range),
             ),
-            '\x1B' => (
-                "\\x1B",
+            '\x1b' => (
+                "\\x1b",
                 context.report_diagnostic_if_enabled(InvalidCharacterEsc, range),
             ),
             '\0' => (


### PR DESCRIPTION
PLE2513 --fix changes ESC and SUB to uppercase hexadecimal values such as \x1B while the formatter changes them to lowercase \x1b

<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
