### PR TITLE
Update end-of-file ranges to point to the actual last line

### DIFF
--- a/crates/ruff/tests/snapshots/integration_test__stdin_json.snap
+++ b/crates/ruff/tests/snapshots/integration_test__stdin_json.snap
@@ -3,11 +3,12 @@ source: crates/ruff/tests/integration_test.rs
 info:
   program: ruff
   args:
-    - "-"
-    - "--isolated"
-    - "--no-cache"
+    - check
     - "--output-format"
     - json
+    - "--no-cache"
+    - "--isolated"
+    - "-"
     - "--stdin-filename"
     - F401.py
   stdin: "import os\n"
@@ -30,8 +31,8 @@ exit_code: 1
         {
           "content": "",
           "end_location": {
-            "column": 1,
-            "row": 2
+            "column": 10,
+            "row": 1
           },
           "location": {
             "column": 1,
@@ -51,4 +52,3 @@ exit_code: 1
   }
 ]
 ----- stderr -----
-

--- a/crates/ruff/tests/snapshots/lint__output_format_eof_azure.snap
+++ b/crates/ruff/tests/snapshots/lint__output_format_eof_azure.snap
@@ -1,0 +1,22 @@
+---
+source: crates/ruff/tests/lint.rs
+info:
+  program: ruff
+  args:
+    - check
+    - "--no-cache"
+    - "--output-format"
+    - azure
+    - "--select"
+    - "F401,F821"
+    - "--target-version"
+    - py39
+    - input.py
+---
+success: false
+exit_code: 1
+----- stdout -----
+##vso[task.logissue type=error;sourcepath=[TMP]/input.py;linenumber=2;columnnumber=1;code=invalid-syntax;]missing closing quote in string literal
+##vso[task.logissue type=error;sourcepath=[TMP]/input.py;linenumber=5;columnnumber=1;code=invalid-syntax;]unexpected EOF while parsing
+
+----- stderr -----

--- a/crates/ruff/tests/snapshots/lint__output_format_eof_azure.snap
+++ b/crates/ruff/tests/snapshots/lint__output_format_eof_azure.snap
@@ -17,6 +17,6 @@ success: false
 exit_code: 1
 ----- stdout -----
 ##vso[task.logissue type=error;sourcepath=[TMP]/input.py;linenumber=2;columnnumber=1;code=invalid-syntax;]missing closing quote in string literal
-##vso[task.logissue type=error;sourcepath=[TMP]/input.py;linenumber=5;columnnumber=1;code=invalid-syntax;]unexpected EOF while parsing
+##vso[task.logissue type=error;sourcepath=[TMP]/input.py;linenumber=4;columnnumber=2;code=invalid-syntax;]unexpected EOF while parsing
 
 ----- stderr -----

--- a/crates/ruff/tests/snapshots/lint__output_format_eof_concise.snap
+++ b/crates/ruff/tests/snapshots/lint__output_format_eof_concise.snap
@@ -17,7 +17,7 @@ success: false
 exit_code: 1
 ----- stdout -----
 input.py:2:1: invalid-syntax: missing closing quote in string literal
-input.py:5:1: invalid-syntax: unexpected EOF while parsing
+input.py:4:2: invalid-syntax: unexpected EOF while parsing
 Found 2 errors.
 
 ----- stderr -----

--- a/crates/ruff/tests/snapshots/lint__output_format_eof_concise.snap
+++ b/crates/ruff/tests/snapshots/lint__output_format_eof_concise.snap
@@ -1,0 +1,23 @@
+---
+source: crates/ruff/tests/lint.rs
+info:
+  program: ruff
+  args:
+    - check
+    - "--no-cache"
+    - "--output-format"
+    - concise
+    - "--select"
+    - "F401,F821"
+    - "--target-version"
+    - py39
+    - input.py
+---
+success: false
+exit_code: 1
+----- stdout -----
+input.py:2:1: invalid-syntax: missing closing quote in string literal
+input.py:5:1: invalid-syntax: unexpected EOF while parsing
+Found 2 errors.
+
+----- stderr -----

--- a/crates/ruff/tests/snapshots/lint__output_format_eof_full.snap
+++ b/crates/ruff/tests/snapshots/lint__output_format_eof_full.snap
@@ -1,0 +1,37 @@
+---
+source: crates/ruff/tests/lint.rs
+info:
+  program: ruff
+  args:
+    - check
+    - "--no-cache"
+    - "--output-format"
+    - full
+    - "--select"
+    - "F401,F821"
+    - "--target-version"
+    - py39
+    - input.py
+---
+success: false
+exit_code: 1
+----- stdout -----
+input.py:2:1: invalid-syntax: missing closing quote in string literal
+  |
+1 |   (
+2 | / '''unterminated string
+3 | | 'x'
+4 | | )
+  | |__^
+  |
+
+input.py:5:1: invalid-syntax: unexpected EOF while parsing
+  |
+3 | 'x'
+4 | )
+  |  ^
+  |
+
+Found 2 errors.
+
+----- stderr -----

--- a/crates/ruff/tests/snapshots/lint__output_format_eof_full.snap
+++ b/crates/ruff/tests/snapshots/lint__output_format_eof_full.snap
@@ -25,7 +25,7 @@ input.py:2:1: invalid-syntax: missing closing quote in string literal
   | |__^
   |
 
-input.py:5:1: invalid-syntax: unexpected EOF while parsing
+input.py:4:2: invalid-syntax: unexpected EOF while parsing
   |
 3 | 'x'
 4 | )

--- a/crates/ruff/tests/snapshots/lint__output_format_eof_github.snap
+++ b/crates/ruff/tests/snapshots/lint__output_format_eof_github.snap
@@ -1,0 +1,22 @@
+---
+source: crates/ruff/tests/lint.rs
+info:
+  program: ruff
+  args:
+    - check
+    - "--no-cache"
+    - "--output-format"
+    - github
+    - "--select"
+    - "F401,F821"
+    - "--target-version"
+    - py39
+    - input.py
+---
+success: false
+exit_code: 1
+----- stdout -----
+::error title=Ruff (invalid-syntax),file=[TMP]/input.py,line=2,col=1,endLine=5,endColumn=1::input.py:2:1: invalid-syntax: missing closing quote in string literal
+::error title=Ruff (invalid-syntax),file=[TMP]/input.py,line=5,col=1,endLine=5,endColumn=1::input.py:5:1: invalid-syntax: unexpected EOF while parsing
+
+----- stderr -----

--- a/crates/ruff/tests/snapshots/lint__output_format_eof_github.snap
+++ b/crates/ruff/tests/snapshots/lint__output_format_eof_github.snap
@@ -16,7 +16,7 @@ info:
 success: false
 exit_code: 1
 ----- stdout -----
-::error title=Ruff (invalid-syntax),file=[TMP]/input.py,line=2,col=1,endLine=5,endColumn=1::input.py:2:1: invalid-syntax: missing closing quote in string literal
-::error title=Ruff (invalid-syntax),file=[TMP]/input.py,line=5,col=1,endLine=5,endColumn=1::input.py:5:1: invalid-syntax: unexpected EOF while parsing
+::error title=Ruff (invalid-syntax),file=[TMP]/input.py,line=2,col=1,endLine=4,endColumn=2::input.py:2:1: invalid-syntax: missing closing quote in string literal
+::error title=Ruff (invalid-syntax),file=[TMP]/input.py,line=4,col=2,endLine=4,endColumn=2::input.py:4:2: invalid-syntax: unexpected EOF while parsing
 
 ----- stderr -----

--- a/crates/ruff/tests/snapshots/lint__output_format_eof_gitlab.snap
+++ b/crates/ruff/tests/snapshots/lint__output_format_eof_gitlab.snap
@@ -1,0 +1,59 @@
+---
+source: crates/ruff/tests/lint.rs
+info:
+  program: ruff
+  args:
+    - check
+    - "--no-cache"
+    - "--output-format"
+    - gitlab
+    - "--select"
+    - "F401,F821"
+    - "--target-version"
+    - py39
+    - input.py
+---
+success: false
+exit_code: 1
+----- stdout -----
+[
+  {
+    "check_name": "syntax-error",
+    "description": "missing closing quote in string literal",
+    "fingerprint": "e558cec859bb66e8",
+    "location": {
+      "path": "input.py",
+      "positions": {
+        "begin": {
+          "column": 1,
+          "line": 2
+        },
+        "end": {
+          "column": 1,
+          "line": 5
+        }
+      }
+    },
+    "severity": "major"
+  },
+  {
+    "check_name": "syntax-error",
+    "description": "unexpected EOF while parsing",
+    "fingerprint": "2aefec8d57710ec4",
+    "location": {
+      "path": "input.py",
+      "positions": {
+        "begin": {
+          "column": 1,
+          "line": 5
+        },
+        "end": {
+          "column": 1,
+          "line": 5
+        }
+      }
+    },
+    "severity": "major"
+  }
+]
+----- stderr -----

--- a/crates/ruff/tests/snapshots/lint__output_format_eof_gitlab.snap
+++ b/crates/ruff/tests/snapshots/lint__output_format_eof_gitlab.snap
@@ -29,8 +29,8 @@ exit_code: 1
           "line": 2
         },
         "end": {
-          "column": 1,
-          "line": 5
+          "column": 2,
+          "line": 4
         }
       }
     },
@@ -44,12 +44,12 @@ exit_code: 1
       "path": "input.py",
       "positions": {
         "begin": {
-          "column": 1,
-          "line": 5
+          "column": 2,
+          "line": 4
         },
         "end": {
-          "column": 1,
-          "line": 5
+          "column": 2,
+          "line": 4
         }
       }
     },

--- a/crates/ruff/tests/snapshots/lint__output_format_eof_grouped.snap
+++ b/crates/ruff/tests/snapshots/lint__output_format_eof_grouped.snap
@@ -18,7 +18,7 @@ exit_code: 1
 ----- stdout -----
 input.py:
   2:1 invalid-syntax: missing closing quote in string literal
-  5:1 invalid-syntax: unexpected EOF while parsing
+  4:2 invalid-syntax: unexpected EOF while parsing
 
 Found 2 errors.
 

--- a/crates/ruff/tests/snapshots/lint__output_format_eof_grouped.snap
+++ b/crates/ruff/tests/snapshots/lint__output_format_eof_grouped.snap
@@ -1,0 +1,25 @@
+---
+source: crates/ruff/tests/lint.rs
+info:
+  program: ruff
+  args:
+    - check
+    - "--no-cache"
+    - "--output-format"
+    - grouped
+    - "--select"
+    - "F401,F821"
+    - "--target-version"
+    - py39
+    - input.py
+---
+success: false
+exit_code: 1
+----- stdout -----
+input.py:
+  2:1 invalid-syntax: missing closing quote in string literal
+  5:1 invalid-syntax: unexpected EOF while parsing
+
+Found 2 errors.
+
+----- stderr -----

--- a/crates/ruff/tests/snapshots/lint__output_format_eof_json-lines.snap
+++ b/crates/ruff/tests/snapshots/lint__output_format_eof_json-lines.snap
@@ -1,0 +1,22 @@
+---
+source: crates/ruff/tests/lint.rs
+info:
+  program: ruff
+  args:
+    - check
+    - "--no-cache"
+    - "--output-format"
+    - json-lines
+    - "--select"
+    - "F401,F821"
+    - "--target-version"
+    - py39
+    - input.py
+---
+success: false
+exit_code: 1
+----- stdout -----
+{"cell":null,"code":"invalid-syntax","end_location":{"column":1,"row":5},"filename":"[TMP]/input.py","fix":null,"location":{"column":1,"row":2},"message":"missing closing quote in string literal","noqa_row":null,"url":null}
+{"cell":null,"code":"invalid-syntax","end_location":{"column":1,"row":5},"filename":"[TMP]/input.py","fix":null,"location":{"column":1,"row":5},"message":"unexpected EOF while parsing","noqa_row":null,"url":null}
+
+----- stderr -----

--- a/crates/ruff/tests/snapshots/lint__output_format_eof_json-lines.snap
+++ b/crates/ruff/tests/snapshots/lint__output_format_eof_json-lines.snap
@@ -16,7 +16,7 @@ info:
 success: false
 exit_code: 1
 ----- stdout -----
-{"cell":null,"code":"invalid-syntax","end_location":{"column":1,"row":5},"filename":"[TMP]/input.py","fix":null,"location":{"column":1,"row":2},"message":"missing closing quote in string literal","noqa_row":null,"url":null}
-{"cell":null,"code":"invalid-syntax","end_location":{"column":1,"row":5},"filename":"[TMP]/input.py","fix":null,"location":{"column":1,"row":5},"message":"unexpected EOF while parsing","noqa_row":null,"url":null}
+{"cell":null,"code":"invalid-syntax","end_location":{"column":2,"row":4},"filename":"[TMP]/input.py","fix":null,"location":{"column":1,"row":2},"message":"missing closing quote in string literal","noqa_row":null,"url":null}
+{"cell":null,"code":"invalid-syntax","end_location":{"column":2,"row":4},"filename":"[TMP]/input.py","fix":null,"location":{"column":2,"row":4},"message":"unexpected EOF while parsing","noqa_row":null,"url":null}
 
 ----- stderr -----

--- a/crates/ruff/tests/snapshots/lint__output_format_eof_json.snap
+++ b/crates/ruff/tests/snapshots/lint__output_format_eof_json.snap
@@ -21,8 +21,8 @@ exit_code: 1
     "cell": null,
     "code": "invalid-syntax",
     "end_location": {
-      "column": 1,
-      "row": 5
+      "column": 2,
+      "row": 4
     },
     "filename": "[TMP]/input.py",
     "fix": null,
@@ -38,14 +38,14 @@ exit_code: 1
     "cell": null,
     "code": "invalid-syntax",
     "end_location": {
-      "column": 1,
-      "row": 5
+      "column": 2,
+      "row": 4
     },
     "filename": "[TMP]/input.py",
     "fix": null,
     "location": {
-      "column": 1,
-      "row": 5
+      "column": 2,
+      "row": 4
     },
     "message": "unexpected EOF while parsing",
     "noqa_row": null,

--- a/crates/ruff/tests/snapshots/lint__output_format_eof_json.snap
+++ b/crates/ruff/tests/snapshots/lint__output_format_eof_json.snap
@@ -1,0 +1,55 @@
+---
+source: crates/ruff/tests/lint.rs
+info:
+  program: ruff
+  args:
+    - check
+    - "--no-cache"
+    - "--output-format"
+    - json
+    - "--select"
+    - "F401,F821"
+    - "--target-version"
+    - py39
+    - input.py
+---
+success: false
+exit_code: 1
+----- stdout -----
+[
+  {
+    "cell": null,
+    "code": "invalid-syntax",
+    "end_location": {
+      "column": 1,
+      "row": 5
+    },
+    "filename": "[TMP]/input.py",
+    "fix": null,
+    "location": {
+      "column": 1,
+      "row": 2
+    },
+    "message": "missing closing quote in string literal",
+    "noqa_row": null,
+    "url": null
+  },
+  {
+    "cell": null,
+    "code": "invalid-syntax",
+    "end_location": {
+      "column": 1,
+      "row": 5
+    },
+    "filename": "[TMP]/input.py",
+    "fix": null,
+    "location": {
+      "column": 1,
+      "row": 5
+    },
+    "message": "unexpected EOF while parsing",
+    "noqa_row": null,
+    "url": null
+  }
+]
+----- stderr -----

--- a/crates/ruff/tests/snapshots/lint__output_format_eof_junit.snap
+++ b/crates/ruff/tests/snapshots/lint__output_format_eof_junit.snap
@@ -22,8 +22,8 @@ exit_code: 1
         <testcase name="org.ruff.invalid-syntax" classname="[TMP]/input" line="2" column="1">
             <failure message="missing closing quote in string literal">line 2, col 1, missing closing quote in string literal</failure>
         </testcase>
-        <testcase name="org.ruff.invalid-syntax" classname="[TMP]/input" line="5" column="1">
-            <failure message="unexpected EOF while parsing">line 5, col 1, unexpected EOF while parsing</failure>
+        <testcase name="org.ruff.invalid-syntax" classname="[TMP]/input" line="4" column="2">
+            <failure message="unexpected EOF while parsing">line 4, col 2, unexpected EOF while parsing</failure>
         </testcase>
     </testsuite>
 </testsuites>

--- a/crates/ruff/tests/snapshots/lint__output_format_eof_junit.snap
+++ b/crates/ruff/tests/snapshots/lint__output_format_eof_junit.snap
@@ -1,0 +1,31 @@
+---
+source: crates/ruff/tests/lint.rs
+info:
+  program: ruff
+  args:
+    - check
+    - "--no-cache"
+    - "--output-format"
+    - junit
+    - "--select"
+    - "F401,F821"
+    - "--target-version"
+    - py39
+    - input.py
+---
+success: false
+exit_code: 1
+----- stdout -----
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="ruff" tests="2" failures="2" errors="0">
+    <testsuite name="[TMP]/input.py" tests="2" disabled="0" errors="0" failures="2" package="org.ruff">
+        <testcase name="org.ruff.invalid-syntax" classname="[TMP]/input" line="2" column="1">
+            <failure message="missing closing quote in string literal">line 2, col 1, missing closing quote in string literal</failure>
+        </testcase>
+        <testcase name="org.ruff.invalid-syntax" classname="[TMP]/input" line="5" column="1">
+            <failure message="unexpected EOF while parsing">line 5, col 1, unexpected EOF while parsing</failure>
+        </testcase>
+    </testsuite>
+</testsuites>
+
+----- stderr -----

--- a/crates/ruff/tests/snapshots/lint__output_format_eof_pylint.snap
+++ b/crates/ruff/tests/snapshots/lint__output_format_eof_pylint.snap
@@ -1,0 +1,22 @@
+---
+source: crates/ruff/tests/lint.rs
+info:
+  program: ruff
+  args:
+    - check
+    - "--no-cache"
+    - "--output-format"
+    - pylint
+    - "--select"
+    - "F401,F821"
+    - "--target-version"
+    - py39
+    - input.py
+---
+success: false
+exit_code: 1
+----- stdout -----
+input.py:2: [invalid-syntax] missing closing quote in string literal
+input.py:5: [invalid-syntax] unexpected EOF while parsing
+
+----- stderr -----

--- a/crates/ruff/tests/snapshots/lint__output_format_eof_pylint.snap
+++ b/crates/ruff/tests/snapshots/lint__output_format_eof_pylint.snap
@@ -17,6 +17,6 @@ success: false
 exit_code: 1
 ----- stdout -----
 input.py:2: [invalid-syntax] missing closing quote in string literal
-input.py:5: [invalid-syntax] unexpected EOF while parsing
+input.py:4: [invalid-syntax] unexpected EOF while parsing
 
 ----- stderr -----

--- a/crates/ruff/tests/snapshots/lint__output_format_eof_rdjson.snap
+++ b/crates/ruff/tests/snapshots/lint__output_format_eof_rdjson.snap
@@ -26,8 +26,8 @@ exit_code: 1
         "path": "[TMP]/input.py",
         "range": {
           "end": {
-            "column": 1,
-            "line": 5
+            "column": 2,
+            "line": 4
           },
           "start": {
             "column": 1,
@@ -45,12 +45,12 @@ exit_code: 1
         "path": "[TMP]/input.py",
         "range": {
           "end": {
-            "column": 1,
-            "line": 5
+            "column": 2,
+            "line": 4
           },
           "start": {
-            "column": 1,
-            "line": 5
+            "column": 2,
+            "line": 4
           }
         }
       },

--- a/crates/ruff/tests/snapshots/lint__output_format_eof_rdjson.snap
+++ b/crates/ruff/tests/snapshots/lint__output_format_eof_rdjson.snap
@@ -1,0 +1,66 @@
+---
+source: crates/ruff/tests/lint.rs
+info:
+  program: ruff
+  args:
+    - check
+    - "--no-cache"
+    - "--output-format"
+    - rdjson
+    - "--select"
+    - "F401,F821"
+    - "--target-version"
+    - py39
+    - input.py
+---
+success: false
+exit_code: 1
+----- stdout -----
+{
+  "diagnostics": [
+    {
+      "code": {
+        "value": "invalid-syntax"
+      },
+      "location": {
+        "path": "[TMP]/input.py",
+        "range": {
+          "end": {
+            "column": 1,
+            "line": 5
+          },
+          "start": {
+            "column": 1,
+            "line": 2
+          }
+        }
+      },
+      "message": "missing closing quote in string literal"
+    },
+    {
+      "code": {
+        "value": "invalid-syntax"
+      },
+      "location": {
+        "path": "[TMP]/input.py",
+        "range": {
+          "end": {
+            "column": 1,
+            "line": 5
+          },
+          "start": {
+            "column": 1,
+            "line": 5
+          }
+        }
+      },
+      "message": "unexpected EOF while parsing"
+    }
+  ],
+  "severity": "WARNING",
+  "source": {
+    "name": "ruff",
+    "url": "https://docs.astral.sh/ruff"
+  }
+}
+----- stderr -----

--- a/crates/ruff/tests/snapshots/lint__output_format_eof_sarif.snap
+++ b/crates/ruff/tests/snapshots/lint__output_format_eof_sarif.snap
@@ -30,8 +30,8 @@ exit_code: 1
                   "uri": "[TMP]/input.py"
                 },
                 "region": {
-                  "endColumn": 1,
-                  "endLine": 5,
+                  "endColumn": 2,
+                  "endLine": 4,
                   "startColumn": 1,
                   "startLine": 2
                 }
@@ -52,10 +52,10 @@ exit_code: 1
                   "uri": "[TMP]/input.py"
                 },
                 "region": {
-                  "endColumn": 1,
-                  "endLine": 5,
-                  "startColumn": 1,
-                  "startLine": 5
+                  "endColumn": 2,
+                  "endLine": 4,
+                  "startColumn": 2,
+                  "startLine": 4
                 }
               }
             }

--- a/crates/ruff/tests/snapshots/lint__output_format_eof_sarif.snap
+++ b/crates/ruff/tests/snapshots/lint__output_format_eof_sarif.snap
@@ -1,0 +1,81 @@
+---
+source: crates/ruff/tests/lint.rs
+info:
+  program: ruff
+  args:
+    - check
+    - "--no-cache"
+    - "--output-format"
+    - sarif
+    - "--select"
+    - "F401,F821"
+    - "--target-version"
+    - py39
+    - input.py
+---
+success: false
+exit_code: 1
+----- stdout -----
+{
+  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+  "runs": [
+    {
+      "results": [
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "[TMP]/input.py"
+                },
+                "region": {
+                  "endColumn": 1,
+                  "endLine": 5,
+                  "startColumn": 1,
+                  "startLine": 2
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "missing closing quote in string literal"
+          },
+          "ruleId": "invalid-syntax"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "[TMP]/input.py"
+                },
+                "region": {
+                  "endColumn": 1,
+                  "endLine": 5,
+                  "startColumn": 1,
+                  "startLine": 5
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "unexpected EOF while parsing"
+          },
+          "ruleId": "invalid-syntax"
+        }
+      ],
+      "tool": {
+        "driver": {
+          "informationUri": "https://github.com/astral-sh/ruff",
+          "name": "ruff",
+          "rules": [],
+          "version": "[VERSION]"
+        }
+      }
+    }
+  ],
+  "version": "2.1.0"
+}
+----- stderr -----

--- a/crates/ruff_linter/src/rules/flake8_implicit_str_concat/snapshots/ruff_linter__rules__flake8_implicit_str_concat__tests__ISC001_ISC_syntax_error.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_implicit_str_concat/snapshots/ruff_linter__rules__flake8_implicit_str_concat__tests__ISC001_ISC_syntax_error.py.snap
@@ -170,14 +170,14 @@ ISC_syntax_error.py:26:9: invalid-syntax: f-string: unterminated triple-quoted s
    | |__^
    |
 
-ISC_syntax_error.py:30:1: invalid-syntax: unexpected EOF while parsing
+ISC_syntax_error.py:29:2: invalid-syntax: unexpected EOF while parsing
    |
 28 |     "i" "j"
 29 | )
    |  ^
    |
 
-ISC_syntax_error.py:30:1: invalid-syntax: f-string: unterminated string
+ISC_syntax_error.py:29:2: invalid-syntax: f-string: unterminated string
    |
 28 |     "i" "j"
 29 | )

--- a/crates/ruff_linter/src/rules/flake8_implicit_str_concat/snapshots/ruff_linter__rules__flake8_implicit_str_concat__tests__ISC002_ISC_syntax_error.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_implicit_str_concat/snapshots/ruff_linter__rules__flake8_implicit_str_concat__tests__ISC002_ISC_syntax_error.py.snap
@@ -124,14 +124,14 @@ ISC_syntax_error.py:26:9: invalid-syntax: f-string: unterminated triple-quoted s
    | |__^
    |
 
-ISC_syntax_error.py:30:1: invalid-syntax: unexpected EOF while parsing
+ISC_syntax_error.py:29:2: invalid-syntax: unexpected EOF while parsing
    |
 28 |     "i" "j"
 29 | )
    |  ^
    |
 
-ISC_syntax_error.py:30:1: invalid-syntax: f-string: unterminated string
+ISC_syntax_error.py:29:2: invalid-syntax: f-string: unterminated string
    |
 28 |     "i" "j"
 29 | )

--- a/crates/ruff_source_file/src/line_index.rs
+++ b/crates/ruff_source_file/src/line_index.rs
@@ -72,13 +72,13 @@ impl LineIndex {
     /// The `column` number is the nth-character of the line, except for the first line
     /// where it doesn't include the UTF-8 BOM marker at the start of the file.
     ///
-    /// ### BOM handling
+    /// ## BOM handling
     ///
     /// For files starting with a UTF-8 BOM marker, the byte offsets
     /// in the range `0...3` are all mapped to line 0 and column 0.
     /// Because of this, the conversion isn't losless.
     ///
-    /// ## Examples
+    /// ### Examples
     ///
     /// ```
     /// # use ruff_text_size::TextSize;
@@ -105,6 +105,27 @@ impl LineIndex {
     /// assert_eq!(
     ///     index.line_column(TextSize::from(16), &source),
     ///     LineColumn { line: OneIndexed::from_zero_indexed(1), column: OneIndexed::from_zero_indexed(4) }
+    /// );
+    /// ```
+    ///
+    /// ## EOF handling
+    ///
+    /// For offsets exactly at the end of a file ending in a line terminator
+    /// (`\r` or `\n`), the offset is mapped to the last column of the preceding
+    /// line rather than the start of another line.
+    ///
+    /// ### Example
+    ///
+    /// ```
+    /// # use ruff_text_size::{TextLen, TextSize};
+    /// # use ruff_source_file::{LineIndex, OneIndexed, LineColumn};
+    /// let source = "eof\n";
+    /// let index = LineIndex::from_source_text(&source);
+    ///
+    /// // New line at EOF maps to the same line
+    /// assert_eq!(
+    ///     index.line_column(source.text_len(), &source),
+    ///     LineColumn { line: OneIndexed::from_zero_indexed(0), column: OneIndexed::from_zero_indexed(3) }
     /// );
     /// ```
     ///

--- a/crates/ruff_source_file/src/line_index.rs
+++ b/crates/ruff_source_file/src/line_index.rs
@@ -112,6 +112,13 @@ impl LineIndex {
     ///
     /// If the byte offset isn't within the bounds of `content`.
     pub fn line_column(&self, offset: TextSize, content: &str) -> LineColumn {
+        // Don't count the new line at the very end of a file as a separate line.
+        let offset = if offset == content.text_len() && content.ends_with(['\r', '\n']) {
+            offset.checked_sub(TextSize::ONE).unwrap_or(offset)
+        } else {
+            offset
+        };
+
         let location = self.source_location(offset, content, PositionEncoding::Utf32);
 
         // Don't count the BOM character as a column, but only on the first line.

--- a/crates/ruff_text_size/src/size.rs
+++ b/crates/ruff_text_size/src/size.rs
@@ -33,6 +33,9 @@ impl fmt::Debug for TextSize {
 }
 
 impl TextSize {
+    /// A `TextSize` of one.
+    pub const ONE: TextSize = TextSize::new(1);
+
     /// Creates a new `TextSize` at the given `offset`.
     ///
     /// # Examples


### PR DESCRIPTION
## Summary

See https://github.com/astral-sh/ruff/pull/19806#discussion_r2260365462. In short, we would previously report EOF ranges as being on a line that didn't actually exist:

```
try.py:5:1: SyntaxError: unexpected EOF while parsing
  |
3 | 'x'
4 | )
  |  ^
  |
```

Note the final line is 4 in the file and in the diagnostic, but the header reports 5:1 as the location.

I split off this PR because I think this is basically a bug fix in Ruff. I'll leave the ty diagnostic change in #19806.

## Test Plan

I was a bit worried that some of the output formats might differ in the way they calculate line locations, so I added a copy of the `output_format` CLI test that runs on a snippet minimized from the `ISC_syntax_error.py` case that also changed in this PR. I guess my fears have been allayed, so we don't necessarily have to keep the CLI test if we don't want to.
