### PR TITLE
[ty] Fix static assertion size check

### DIFF
--- a/crates/ty_python_semantic/src/semantic_index/member.rs
+++ b/crates/ty_python_semantic/src/semantic_index/member.rs
@@ -507,6 +507,7 @@ enum Segments {
 }
 
 static_assertions::assert_eq_size!(SmallSegments, u64);
+#[cfg(target_pointer_width = "64")]
 static_assertions::assert_eq_size!(Segments, [u64; 2]);
 
 impl Segments {


### PR DESCRIPTION
A `Segment` has a `Box` in it, which has a platform dependent size.
Restrict the check to only 64-bit targets.
