### PR TITLE
[ty] now that inference sees nested bindings, allow unresolved globals

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/import/star.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/star.md
@@ -1299,15 +1299,12 @@ reveal_type(Nope)  # revealed: Unknown
 ## `global` statements in non-global scopes
 
 Python allows `global` statements in function bodies to add new variables to the global scope, but
-we require a matching global binding or declaration. We lint on unresolved `global` statements, and
 we don't include the symbols they might define in `*` imports:
 
 `a.py`:
 
 ```py
 def f():
-    # error: [unresolved-global] "Invalid global declaration of `g`: `g` has no declarations or bindings in the global scope"
-    # error: [unresolved-global] "Invalid global declaration of `h`: `h` has no declarations or bindings in the global scope"
     global g, h
 
     g = True

--- a/crates/ty_python_semantic/resources/mdtest/scopes/global.md
+++ b/crates/ty_python_semantic/resources/mdtest/scopes/global.md
@@ -241,26 +241,32 @@ def f():
 # TODO: reveal_type(x)  # revealed: Unknown | Literal["1"]
 ```
 
-## Global variables need an explicit definition in the global scope
+## Global variables don't need an explicit definition in the global scope
 
 You're allowed to use the `global` keyword to define new global variables that don't have any
-explicit definition in the global scope, but we consider that fishy and prefer to lint on it:
+explicit definition in the global scope:
 
 ```py
-x = 1
-y: int
-# z is neither bound nor declared in the global scope
-
 def f():
-    global x, y, z  # error: [unresolved-global] "Invalid global declaration of `z`: `z` has no declarations or bindings in the global scope"
+    global x
+    x = 42
+
+def g():
+    print(x)  # allowed, resolves to the global `x` defined by `f`
+
+def h():
+    print(y)  # error: [unresolved-reference]
 ```
 
-You don't need a definition for implicit globals, but you do for built-ins:
+However, this only affects the "public" type of the global. It's still considered unbound when
+module-scope code refers to it locally.
 
 ```py
 def f():
-    global __file__  # allowed, implicit global
-    global int  # error: [unresolved-global] "Invalid global declaration of `int`: `int` has no declarations or bindings in the global scope"
+    global x
+    x = 42
+
+print(x)  # error: [unresolved-reference]
 ```
 
 ## References to variables before they are defined within a class scope are considered global


### PR DESCRIPTION
This is an optional follow-up PR on top of https://github.com/astral-sh/ruff/pull/19820. Now that we track all bindings from nested scopes, it could be practical to allow `global` variables without an explicit definition in the module scope. For example:

```py
def f():
    global x
    x = 1

def g():
    print(x)
```

Before:

```
warning[unresolved-global]: Invalid global declaration of `x`
 --> test.py:2:12
  |
1 | def f():
2 |     global x
  |            ^ `x` has no declarations or bindings in the global scope
3 |     x = 1
  |
info: This limits ty's ability to make accurate inferences about the boundness and types of global-scope symbols
info: Consider adding a declaration to the global scope, e.g. `x: int`
info: rule `unresolved-global` is enabled by default

error[unresolved-reference]: Name `x` used when not defined
 --> test.py:6:11
  |
5 | def g():
6 |     print(x)
  |           ^
  |
info: rule `unresolved-reference` is enabled by default
```

After:

```
All checks passed!
```