### PR TITLE
[ty] Improve performance of subtyping and assignability checks for protocols

### DIFF
--- a/crates/ty_python_semantic/src/types/cyclic.rs
+++ b/crates/ty_python_semantic/src/types/cyclic.rs
@@ -47,16 +47,19 @@ impl<T: Hash + Eq + Copy, R: Copy> CycleDetector<T, R> {
     }
 
     pub(crate) fn visit(&mut self, item: T, func: impl FnOnce(&mut Self) -> R) -> R {
+        if let Some(ty) = self.cache.get(&item) {
+            return *ty;
+        }
+
+        // We hit a cycle
         if !self.seen.insert(item) {
             return self.fallback;
         }
-        if let Some(ty) = self.cache.get(&item) {
-            self.seen.pop();
-            return *ty;
-        }
+
         let ret = func(self);
-        self.cache.insert(item, ret);
         self.seen.pop();
+        self.cache.insert(item, ret);
+
         ret
     }
 }


### PR DESCRIPTION
## Summary

It seems unnecessary to write to `seen` if we have a cache entry (in which case we pop the seen immediately).

I doubt this has any meaningful performance impact but it makes it clearer that `cache` is a superset of `seen`.

## Test Plan

`cargo test`
