### PR TITLE
[ty] Add `static-frame` as a walltime benchmark

### DIFF
--- a/crates/ruff_benchmark/benches/ty_walltime.rs
+++ b/crates/ruff_benchmark/benches/ty_walltime.rs
@@ -218,6 +218,24 @@ static TANJUN: std::sync::LazyLock<Benchmark<'static>> = std::sync::LazyLock::ne
     )
 });
 
+static STATIC_FRAME: std::sync::LazyLock<Benchmark<'static>> = std::sync::LazyLock::new(|| {
+    Benchmark::new(
+        RealWorldProject {
+            name: "static-frame",
+            repository: "https://github.com/static-frame/static-frame",
+            commit: "34962b41baca5e7f98f5a758d530bff02748a421",
+            paths: vec![SystemPath::new("static_frame")],
+            // N.B. `arraykit` is installed as a dependency during mypy_primer runs,
+            // but it takes much longer to be installed in a Codspeed run than it does in a mypy_primer run
+            // (seems to be built from source on the Codspeed CI runners for some reason).
+            dependencies: vec!["numpy"],
+            max_dep_date: "2025-08-09",
+            python_version: PythonVersion::PY311,
+        },
+        500,
+    )
+});
+
 #[track_caller]
 fn run_single_threaded(bencher: Bencher, benchmark: &Benchmark) {
     bencher
@@ -232,7 +250,7 @@ fn small(bencher: Bencher, benchmark: &Benchmark) {
     run_single_threaded(bencher, benchmark);
 }
 
-#[bench(args=[&*COLOUR_SCIENCE, &*PANDAS], sample_size=1, sample_count=3)]
+#[bench(args=[&*COLOUR_SCIENCE, &*PANDAS, &*STATIC_FRAME], sample_size=1, sample_count=3)]
 fn medium(bencher: Bencher, benchmark: &Benchmark) {
     run_single_threaded(bencher, benchmark);
 }


### PR DESCRIPTION
## Summary

An early version of https://github.com/astral-sh/ruff/pull/19811 dramatically increased the time it took ty to type-check the [static-frame](https://github.com/static-frame/static-frame) codebase: in mypy_primer runs, the execution time went from around 1 minute to around 10 minutes. However, on that early version of #19811, most benchmarks showed big improvements, with only a few benchmarks showing regressions of 1-2%.

The latest version of #19811 no longer exhibits a large increase in execution time when type-checking static-frame, but I find it somewhat concerning that none of our benchmarks flagged the early version; I only accidentally noticed the regression due to the fact that mypy_primer runs were taking much longer to complete! This PR therefore adds static-frame as a walltime benchmark, since it obviously contains Python code patterns that don't currently have good coverage in our ty benchmark suite. The benchmark setup is basically copied from [the project's mypy_primer setup](https://github.com/hauntsaninja/mypy_primer/blob/3cc3235fb80746b03d197fbbce485e7407858c81/mypy_primer/projects.py#L1530-L1537).

## Test Plan

`cargo bench -p ruff_benchmark --bench=ty_walltime`
