### PR TITLE
Update goto range for attribute access to only target the attribute

### DIFF
--- a/crates/ty_ide/src/goto.rs
+++ b/crates/ty_ide/src/goto.rs
@@ -557,7 +557,10 @@ impl GotoTarget<'_> {
 impl Ranged for GotoTarget<'_> {
     fn range(&self) -> TextRange {
         match self {
-            GotoTarget::Expression(expression) => expression.range(),
+            GotoTarget::Expression(expression) => match expression {
+                ast::ExprRef::Attribute(attribute) => attribute.attr.range,
+                _ => expression.range(),
+            },
             GotoTarget::FunctionDef(function) => function.name.range,
             GotoTarget::ClassDef(class) => class.name.range,
             GotoTarget::Parameter(parameter) => parameter.name.range,

--- a/crates/ty_ide/src/goto_declaration.rs
+++ b/crates/ty_ide/src/goto_declaration.rs
@@ -865,11 +865,11 @@ def another_helper(path):
         6 |             c = C()
           |
         info: Source
-         --> main.py:7:17
+         --> main.py:7:19
           |
         6 |             c = C()
         7 |             y = c.x
-          |                 ^^^
+          |                   ^
           |
         ");
     }
@@ -899,11 +899,11 @@ def another_helper(path):
         6 |             c = C()
           |
         info: Source
-         --> main.py:7:17
+         --> main.py:7:19
           |
         6 |             c = C()
         7 |             y = c.x
-          |                 ^^^
+          |                   ^
           |
         ");
     }
@@ -931,11 +931,11 @@ def another_helper(path):
         4 |                     return 42
           |
         info: Source
-         --> main.py:7:19
+         --> main.py:7:21
           |
         6 |             c = C()
         7 |             res = c.foo()
-          |                   ^^^^^
+          |                     ^^^
           |
         ");
     }
@@ -1077,11 +1077,11 @@ def function():
         5 |             class B(A):
           |
         info: Source
-         --> main.py:9:17
+         --> main.py:9:19
           |
         8 |             b = B()
         9 |             y = b.x
-          |                 ^^^
+          |                   ^
           |
         ");
     }
@@ -1113,11 +1113,11 @@ def function():
         8 |                     return self._value
           |
         info: Source
-          --> main.py:11:13
+          --> main.py:11:15
            |
         10 |             c = C()
         11 |             c.value = 42
-           |             ^^^^^^^
+           |               ^^^^^
            |
         ");
     }
@@ -1188,11 +1188,11 @@ def function():
         8 |             def use_drawable(obj: Drawable):
           |
         info: Source
-         --> main.py:9:17
+         --> main.py:9:21
           |
         8 |             def use_drawable(obj: Drawable):
         9 |                 obj.name
-          |                 ^^^^^^^^
+          |                     ^^^^
           |
         ");
     }

--- a/crates/ty_ide/src/goto_definition.rs
+++ b/crates/ty_ide/src/goto_definition.rs
@@ -439,12 +439,12 @@ class MyOtherClass:
         6 |         print(self.val)
           |
         info: Source
-         --> main.py:4:1
+         --> main.py:4:3
           |
         2 | from mymodule import MyClass
         3 | x = MyClass(0)
         4 | x.action()
-          | ^^^^^^^^
+          |   ^^^^^^
           |
         ");
     }
@@ -498,11 +498,11 @@ class MyOtherClass:
         6 |         print("hi!")
           |
         info: Source
-         --> main.py:3:5
+         --> main.py:3:13
           |
         2 | from mymodule import MyClass
         3 | x = MyClass.action()
-          |     ^^^^^^^^^^^^^^
+          |             ^^^^^^
           |
         "#);
     }

--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -189,14 +189,14 @@ mod tests {
         ```
         ---------------------------------------------
         info[hover]: Hovered content is
-          --> main.py:10:9
+          --> main.py:10:13
            |
          9 |         foo = Foo()
         10 |         foo.a
-           |         ^^^^-
-           |         |   |
-           |         |   Cursor offset
-           |         source
+           |             -
+           |             |
+           |             source
+           |             Cursor offset
            |
         ");
     }
@@ -517,14 +517,14 @@ mod tests {
         ```
         ---------------------------------------------
         info[hover]: Hovered content is
-         --> main.py:5:13
+         --> main.py:5:15
           |
         3 |                 attr: int = 1
         4 |
         5 |             C.attr = 2
-          |             ^^^^^^- Cursor offset
-          |             |
-          |             source
+          |               ^^^^- Cursor offset
+          |               |
+          |               source
           |
         ");
     }
@@ -550,14 +550,14 @@ mod tests {
         ```
         ---------------------------------------------
         info[hover]: Hovered content is
-         --> main.py:5:13
+         --> main.py:5:15
           |
         3 |                 attr = 1
         4 |
         5 |             C.attr += 2
-          |             ^^^^^^- Cursor offset
-          |             |
-          |             source
+          |               ^^^^- Cursor offset
+          |               |
+          |               source
           |
         ");
     }
@@ -636,14 +636,14 @@ mod tests {
         ```
         ---------------------------------------------
         info[hover]: Hovered content is
-         --> main.py:4:17
+         --> main.py:4:22
           |
         2 |         class Foo:
         3 |             def __init__(self, a: int):
         4 |                 self.a: int = a
-          |                 ^^^^^^- Cursor offset
-          |                 |
-          |                 source
+          |                      ^- Cursor offset
+          |                      |
+          |                      source
           |
         ");
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

We previously highlighted the whole attribute access for goto definition. This does not align with other language servers (rust-analyzer, python, etc).

More related discussion has been had here https://github.com/astral-sh/ty/issues/169.

But I think for goto definition it seems unintuitive to highlight the whole expression

## Test Plan

Update ty_ide tests
