### PR TITLE
[`flake8-simplify`] Implement fix for `maxsplit` without separator (`SIM905`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM905.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM905.py
@@ -166,3 +166,7 @@ r"""first
 print("S\x1cP\x1dL\x1eI\x1fT".split())
 print("\x1c\x1d\x1e\x1f>".split(maxsplit=0))
 print("<\x1c\x1d\x1e\x1f".rsplit(maxsplit=0))
+
+# leading/trailing whitespace should not count towards maxsplit
+" a b c d ".split(maxsplit=2)  # ["a", "b", "c d "]
+" a b c d ".rsplit(maxsplit=2)  # [" a b", "c", "d"]

--- a/crates/ruff_linter/src/preview.rs
+++ b/crates/ruff_linter/src/preview.rs
@@ -230,3 +230,8 @@ pub(crate) const fn is_add_future_annotations_imports_enabled(settings: &LinterS
 pub(crate) const fn is_trailing_comma_type_params_enabled(settings: &LinterSettings) -> bool {
     settings.preview.is_enabled()
 }
+
+// https://github.com/astral-sh/ruff/pull/19851
+pub(crate) const fn is_maxsplit_without_separator_fix_enabled(settings: &LinterSettings) -> bool {
+    settings.preview.is_enabled()
+}

--- a/crates/ruff_linter/src/rules/flake8_simplify/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/mod.rs
@@ -60,6 +60,7 @@ mod tests {
     }
 
     #[test_case(Rule::MultipleWithStatements, Path::new("SIM117.py"))]
+    #[test_case(Rule::SplitStaticString, Path::new("SIM905.py"))]
     fn preview_rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!(
             "preview__{}_{}",

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/split_static_string.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/split_static_string.rs
@@ -9,6 +9,8 @@ use ruff_python_ast::{
 use ruff_text_size::{Ranged, TextRange};
 
 use crate::checkers::ast::Checker;
+use crate::preview::is_maxsplit_without_separator_fix_enabled;
+use crate::settings::LinterSettings;
 use crate::{Applicability, Edit, Fix, FixAvailability, Violation};
 
 /// ## What it does
@@ -84,7 +86,9 @@ pub(crate) fn split_static_string(
     let sep_arg = arguments.find_argument_value("sep", 0);
     let split_replacement = if let Some(sep) = sep_arg {
         match sep {
-            Expr::NoneLiteral(_) => split_default(str_value, maxsplit_value, direction),
+            Expr::NoneLiteral(_) => {
+                split_default(str_value, maxsplit_value, direction, checker.settings())
+            }
             Expr::StringLiteral(sep_value) => {
                 let sep_value_str = sep_value.value.to_str();
                 Some(split_sep(
@@ -100,7 +104,7 @@ pub(crate) fn split_static_string(
             }
         }
     } else {
-        split_default(str_value, maxsplit_value, direction)
+        split_default(str_value, maxsplit_value, direction, checker.settings())
     };
 
     let mut diagnostic = checker.report_diagnostic(SplitStaticString, call.range());
@@ -174,6 +178,7 @@ fn split_default(
     str_value: &StringLiteralValue,
     max_split: i32,
     direction: Direction,
+    settings: &LinterSettings,
 ) -> Option<Expr> {
     // From the Python documentation:
     // > If sep is not specified or is None, a different splitting algorithm is applied: runs of
@@ -185,6 +190,9 @@ fn split_default(
     let string_val = str_value.to_str();
     match max_split.cmp(&0) {
         Ordering::Greater => {
+            if !is_maxsplit_without_separator_fix_enabled(settings) {
+                return None;
+            }
             let Ok(max_split) = usize::try_from(max_split) else {
                 return None;
             };

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM905_SIM905.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM905_SIM905.py.snap
@@ -95,7 +95,7 @@ help: Replace with list literal
 16 16 | "a,b,c,d".split(sep=",")
 17 17 | "a,b,c,d".split(sep=None)
 
-SIM905 Consider using a list literal instead of `str.split`
+SIM905 [*] Consider using a list literal instead of `str.split`
   --> SIM905.py:15:1
    |
 13 | "a,b,c,d".split(None)
@@ -106,6 +106,16 @@ SIM905 Consider using a list literal instead of `str.split`
 17 | "a,b,c,d".split(sep=None)
    |
 help: Replace with list literal
+
+ℹ Safe fix
+12 12 | "a,b,c,d".split(",")
+13 13 | "a,b,c,d".split(None)
+14 14 | "a,b,c,d".split(",", 1)
+15    |-"a,b,c,d".split(None, 1)
+   15 |+["a,b,c,d"]
+16 16 | "a,b,c,d".split(sep=",")
+17 17 | "a,b,c,d".split(sep=None)
+18 18 | "a,b,c,d".split(sep=",", maxsplit=1)
 
 SIM905 [*] Consider using a list literal instead of `str.split`
   --> SIM905.py:16:1
@@ -173,7 +183,7 @@ help: Replace with list literal
 20 20 | "a,b,c,d".split(maxsplit=1, sep=",")
 21 21 | "a,b,c,d".split(maxsplit=1, sep=None)
 
-SIM905 Consider using a list literal instead of `str.split`
+SIM905 [*] Consider using a list literal instead of `str.split`
   --> SIM905.py:19:1
    |
 17 | "a,b,c,d".split(sep=None)
@@ -184,6 +194,16 @@ SIM905 Consider using a list literal instead of `str.split`
 21 | "a,b,c,d".split(maxsplit=1, sep=None)
    |
 help: Replace with list literal
+
+ℹ Safe fix
+16 16 | "a,b,c,d".split(sep=",")
+17 17 | "a,b,c,d".split(sep=None)
+18 18 | "a,b,c,d".split(sep=",", maxsplit=1)
+19    |-"a,b,c,d".split(sep=None, maxsplit=1)
+   19 |+["a,b,c,d"]
+20 20 | "a,b,c,d".split(maxsplit=1, sep=",")
+21 21 | "a,b,c,d".split(maxsplit=1, sep=None)
+22 22 | "a,b,c,d".split(",", maxsplit=1)
 
 SIM905 [*] Consider using a list literal instead of `str.split`
   --> SIM905.py:20:1
@@ -207,7 +227,7 @@ help: Replace with list literal
 22 22 | "a,b,c,d".split(",", maxsplit=1)
 23 23 | "a,b,c,d".split(None, maxsplit=1)
 
-SIM905 Consider using a list literal instead of `str.split`
+SIM905 [*] Consider using a list literal instead of `str.split`
   --> SIM905.py:21:1
    |
 19 | "a,b,c,d".split(sep=None, maxsplit=1)
@@ -218,6 +238,16 @@ SIM905 Consider using a list literal instead of `str.split`
 23 | "a,b,c,d".split(None, maxsplit=1)
    |
 help: Replace with list literal
+
+ℹ Safe fix
+18 18 | "a,b,c,d".split(sep=",", maxsplit=1)
+19 19 | "a,b,c,d".split(sep=None, maxsplit=1)
+20 20 | "a,b,c,d".split(maxsplit=1, sep=",")
+21    |-"a,b,c,d".split(maxsplit=1, sep=None)
+   21 |+["a,b,c,d"]
+22 22 | "a,b,c,d".split(",", maxsplit=1)
+23 23 | "a,b,c,d".split(None, maxsplit=1)
+24 24 | "a,b,c,d".split(maxsplit=1)
 
 SIM905 [*] Consider using a list literal instead of `str.split`
   --> SIM905.py:22:1
@@ -241,7 +271,7 @@ help: Replace with list literal
 24 24 | "a,b,c,d".split(maxsplit=1)
 25 25 | "a,b,c,d".split(maxsplit=1.0)
 
-SIM905 Consider using a list literal instead of `str.split`
+SIM905 [*] Consider using a list literal instead of `str.split`
   --> SIM905.py:23:1
    |
 21 | "a,b,c,d".split(maxsplit=1, sep=None)
@@ -253,7 +283,17 @@ SIM905 Consider using a list literal instead of `str.split`
    |
 help: Replace with list literal
 
-SIM905 Consider using a list literal instead of `str.split`
+ℹ Safe fix
+20 20 | "a,b,c,d".split(maxsplit=1, sep=",")
+21 21 | "a,b,c,d".split(maxsplit=1, sep=None)
+22 22 | "a,b,c,d".split(",", maxsplit=1)
+23    |-"a,b,c,d".split(None, maxsplit=1)
+   23 |+["a,b,c,d"]
+24 24 | "a,b,c,d".split(maxsplit=1)
+25 25 | "a,b,c,d".split(maxsplit=1.0)
+26 26 | "a,b,c,d".split(maxsplit=1)
+
+SIM905 [*] Consider using a list literal instead of `str.split`
   --> SIM905.py:24:1
    |
 22 | "a,b,c,d".split(",", maxsplit=1)
@@ -265,7 +305,17 @@ SIM905 Consider using a list literal instead of `str.split`
    |
 help: Replace with list literal
 
-SIM905 Consider using a list literal instead of `str.split`
+ℹ Safe fix
+21 21 | "a,b,c,d".split(maxsplit=1, sep=None)
+22 22 | "a,b,c,d".split(",", maxsplit=1)
+23 23 | "a,b,c,d".split(None, maxsplit=1)
+24    |-"a,b,c,d".split(maxsplit=1)
+   24 |+["a,b,c,d"]
+25 25 | "a,b,c,d".split(maxsplit=1.0)
+26 26 | "a,b,c,d".split(maxsplit=1)
+27 27 | "a,b,c,d".split(maxsplit=0)
+
+SIM905 [*] Consider using a list literal instead of `str.split`
   --> SIM905.py:26:1
    |
 24 | "a,b,c,d".split(maxsplit=1)
@@ -276,6 +326,16 @@ SIM905 Consider using a list literal instead of `str.split`
 28 | "VERB AUX PRON ADP DET".split(" ")
    |
 help: Replace with list literal
+
+ℹ Safe fix
+23 23 | "a,b,c,d".split(None, maxsplit=1)
+24 24 | "a,b,c,d".split(maxsplit=1)
+25 25 | "a,b,c,d".split(maxsplit=1.0)
+26    |-"a,b,c,d".split(maxsplit=1)
+   26 |+["a,b,c,d"]
+27 27 | "a,b,c,d".split(maxsplit=0)
+28 28 | "VERB AUX PRON ADP DET".split(" ")
+29 29 | '   1   2   3   '.split()
 
 SIM905 [*] Consider using a list literal instead of `str.split`
   --> SIM905.py:27:1
@@ -1439,6 +1499,7 @@ help: Replace with list literal
     166 |+print(["S", "P", "L", "I", "T"])
 167 167 | print("\x1c\x1d\x1e\x1f>".split(maxsplit=0))
 168 168 | print("<\x1c\x1d\x1e\x1f".rsplit(maxsplit=0))
+169 169 | 
 
 SIM905 [*] Consider using a list literal instead of `str.split`
    --> SIM905.py:167:7
@@ -1458,6 +1519,8 @@ help: Replace with list literal
 167     |-print("\x1c\x1d\x1e\x1f>".split(maxsplit=0))
     167 |+print([">"])
 168 168 | print("<\x1c\x1d\x1e\x1f".rsplit(maxsplit=0))
+169 169 | 
+170 170 | # leading/trailing whitespace should not count towards maxsplit
 
 SIM905 [*] Consider using a list literal instead of `str.split`
    --> SIM905.py:168:7
@@ -1466,6 +1529,8 @@ SIM905 [*] Consider using a list literal instead of `str.split`
 167 | print("\x1c\x1d\x1e\x1f>".split(maxsplit=0))
 168 | print("<\x1c\x1d\x1e\x1f".rsplit(maxsplit=0))
     |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+169 |
+170 | # leading/trailing whitespace should not count towards maxsplit
     |
 help: Replace with list literal
 
@@ -1475,3 +1540,41 @@ help: Replace with list literal
 167 167 | print("\x1c\x1d\x1e\x1f>".split(maxsplit=0))
 168     |-print("<\x1c\x1d\x1e\x1f".rsplit(maxsplit=0))
     168 |+print(["<"])
+169 169 | 
+170 170 | # leading/trailing whitespace should not count towards maxsplit
+171 171 | " a b c d ".split(maxsplit=2)  # ["a", "b", "c d "]
+
+SIM905 [*] Consider using a list literal instead of `str.split`
+   --> SIM905.py:171:1
+    |
+170 | # leading/trailing whitespace should not count towards maxsplit
+171 | " a b c d ".split(maxsplit=2)  # ["a", "b", "c d "]
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+172 | " a b c d ".rsplit(maxsplit=2)  # [" a b", "c", "d"]
+    |
+help: Replace with list literal
+
+ℹ Safe fix
+168 168 | print("<\x1c\x1d\x1e\x1f".rsplit(maxsplit=0))
+169 169 | 
+170 170 | # leading/trailing whitespace should not count towards maxsplit
+171     |-" a b c d ".split(maxsplit=2)  # ["a", "b", "c d "]
+    171 |+["a", "b", "c d "]  # ["a", "b", "c d "]
+172 172 | " a b c d ".rsplit(maxsplit=2)  # [" a b", "c", "d"]
+
+SIM905 [*] Consider using a list literal instead of `str.split`
+   --> SIM905.py:172:1
+    |
+170 | # leading/trailing whitespace should not count towards maxsplit
+171 | " a b c d ".split(maxsplit=2)  # ["a", "b", "c d "]
+172 | " a b c d ".rsplit(maxsplit=2)  # [" a b", "c", "d"]
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+help: Replace with list literal
+
+ℹ Safe fix
+169 169 | 
+170 170 | # leading/trailing whitespace should not count towards maxsplit
+171 171 | " a b c d ".split(maxsplit=2)  # ["a", "b", "c d "]
+172     |-" a b c d ".rsplit(maxsplit=2)  # [" a b", "c", "d"]
+    172 |+[" a b", "c", "d"]  # [" a b", "c", "d"]

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__preview__SIM905_SIM905.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__preview__SIM905_SIM905.py.snap
@@ -95,7 +95,7 @@ help: Replace with list literal
 16 16 | "a,b,c,d".split(sep=",")
 17 17 | "a,b,c,d".split(sep=None)
 
-SIM905 Consider using a list literal instead of `str.split`
+SIM905 [*] Consider using a list literal instead of `str.split`
   --> SIM905.py:15:1
    |
 13 | "a,b,c,d".split(None)
@@ -106,6 +106,16 @@ SIM905 Consider using a list literal instead of `str.split`
 17 | "a,b,c,d".split(sep=None)
    |
 help: Replace with list literal
+
+ℹ Safe fix
+12 12 | "a,b,c,d".split(",")
+13 13 | "a,b,c,d".split(None)
+14 14 | "a,b,c,d".split(",", 1)
+15    |-"a,b,c,d".split(None, 1)
+   15 |+["a,b,c,d"]
+16 16 | "a,b,c,d".split(sep=",")
+17 17 | "a,b,c,d".split(sep=None)
+18 18 | "a,b,c,d".split(sep=",", maxsplit=1)
 
 SIM905 [*] Consider using a list literal instead of `str.split`
   --> SIM905.py:16:1
@@ -173,7 +183,7 @@ help: Replace with list literal
 20 20 | "a,b,c,d".split(maxsplit=1, sep=",")
 21 21 | "a,b,c,d".split(maxsplit=1, sep=None)
 
-SIM905 Consider using a list literal instead of `str.split`
+SIM905 [*] Consider using a list literal instead of `str.split`
   --> SIM905.py:19:1
    |
 17 | "a,b,c,d".split(sep=None)
@@ -184,6 +194,16 @@ SIM905 Consider using a list literal instead of `str.split`
 21 | "a,b,c,d".split(maxsplit=1, sep=None)
    |
 help: Replace with list literal
+
+ℹ Safe fix
+16 16 | "a,b,c,d".split(sep=",")
+17 17 | "a,b,c,d".split(sep=None)
+18 18 | "a,b,c,d".split(sep=",", maxsplit=1)
+19    |-"a,b,c,d".split(sep=None, maxsplit=1)
+   19 |+["a,b,c,d"]
+20 20 | "a,b,c,d".split(maxsplit=1, sep=",")
+21 21 | "a,b,c,d".split(maxsplit=1, sep=None)
+22 22 | "a,b,c,d".split(",", maxsplit=1)
 
 SIM905 [*] Consider using a list literal instead of `str.split`
   --> SIM905.py:20:1
@@ -207,7 +227,7 @@ help: Replace with list literal
 22 22 | "a,b,c,d".split(",", maxsplit=1)
 23 23 | "a,b,c,d".split(None, maxsplit=1)
 
-SIM905 Consider using a list literal instead of `str.split`
+SIM905 [*] Consider using a list literal instead of `str.split`
   --> SIM905.py:21:1
    |
 19 | "a,b,c,d".split(sep=None, maxsplit=1)
@@ -218,6 +238,16 @@ SIM905 Consider using a list literal instead of `str.split`
 23 | "a,b,c,d".split(None, maxsplit=1)
    |
 help: Replace with list literal
+
+ℹ Safe fix
+18 18 | "a,b,c,d".split(sep=",", maxsplit=1)
+19 19 | "a,b,c,d".split(sep=None, maxsplit=1)
+20 20 | "a,b,c,d".split(maxsplit=1, sep=",")
+21    |-"a,b,c,d".split(maxsplit=1, sep=None)
+   21 |+["a,b,c,d"]
+22 22 | "a,b,c,d".split(",", maxsplit=1)
+23 23 | "a,b,c,d".split(None, maxsplit=1)
+24 24 | "a,b,c,d".split(maxsplit=1)
 
 SIM905 [*] Consider using a list literal instead of `str.split`
   --> SIM905.py:22:1
@@ -241,7 +271,7 @@ help: Replace with list literal
 24 24 | "a,b,c,d".split(maxsplit=1)
 25 25 | "a,b,c,d".split(maxsplit=1.0)
 
-SIM905 Consider using a list literal instead of `str.split`
+SIM905 [*] Consider using a list literal instead of `str.split`
   --> SIM905.py:23:1
    |
 21 | "a,b,c,d".split(maxsplit=1, sep=None)
@@ -253,7 +283,17 @@ SIM905 Consider using a list literal instead of `str.split`
    |
 help: Replace with list literal
 
-SIM905 Consider using a list literal instead of `str.split`
+ℹ Safe fix
+20 20 | "a,b,c,d".split(maxsplit=1, sep=",")
+21 21 | "a,b,c,d".split(maxsplit=1, sep=None)
+22 22 | "a,b,c,d".split(",", maxsplit=1)
+23    |-"a,b,c,d".split(None, maxsplit=1)
+   23 |+["a,b,c,d"]
+24 24 | "a,b,c,d".split(maxsplit=1)
+25 25 | "a,b,c,d".split(maxsplit=1.0)
+26 26 | "a,b,c,d".split(maxsplit=1)
+
+SIM905 [*] Consider using a list literal instead of `str.split`
   --> SIM905.py:24:1
    |
 22 | "a,b,c,d".split(",", maxsplit=1)
@@ -265,7 +305,17 @@ SIM905 Consider using a list literal instead of `str.split`
    |
 help: Replace with list literal
 
-SIM905 Consider using a list literal instead of `str.split`
+ℹ Safe fix
+21 21 | "a,b,c,d".split(maxsplit=1, sep=None)
+22 22 | "a,b,c,d".split(",", maxsplit=1)
+23 23 | "a,b,c,d".split(None, maxsplit=1)
+24    |-"a,b,c,d".split(maxsplit=1)
+   24 |+["a,b,c,d"]
+25 25 | "a,b,c,d".split(maxsplit=1.0)
+26 26 | "a,b,c,d".split(maxsplit=1)
+27 27 | "a,b,c,d".split(maxsplit=0)
+
+SIM905 [*] Consider using a list literal instead of `str.split`
   --> SIM905.py:26:1
    |
 24 | "a,b,c,d".split(maxsplit=1)
@@ -276,6 +326,16 @@ SIM905 Consider using a list literal instead of `str.split`
 28 | "VERB AUX PRON ADP DET".split(" ")
    |
 help: Replace with list literal
+
+ℹ Safe fix
+23 23 | "a,b,c,d".split(None, maxsplit=1)
+24 24 | "a,b,c,d".split(maxsplit=1)
+25 25 | "a,b,c,d".split(maxsplit=1.0)
+26    |-"a,b,c,d".split(maxsplit=1)
+   26 |+["a,b,c,d"]
+27 27 | "a,b,c,d".split(maxsplit=0)
+28 28 | "VERB AUX PRON ADP DET".split(" ")
+29 29 | '   1   2   3   '.split()
 
 SIM905 [*] Consider using a list literal instead of `str.split`
   --> SIM905.py:27:1
@@ -1484,7 +1544,7 @@ help: Replace with list literal
 170 170 | # leading/trailing whitespace should not count towards maxsplit
 171 171 | " a b c d ".split(maxsplit=2)  # ["a", "b", "c d "]
 
-SIM905 Consider using a list literal instead of `str.split`
+SIM905 [*] Consider using a list literal instead of `str.split`
    --> SIM905.py:171:1
     |
 170 | # leading/trailing whitespace should not count towards maxsplit
@@ -1494,7 +1554,15 @@ SIM905 Consider using a list literal instead of `str.split`
     |
 help: Replace with list literal
 
-SIM905 Consider using a list literal instead of `str.split`
+ℹ Safe fix
+168 168 | print("<\x1c\x1d\x1e\x1f".rsplit(maxsplit=0))
+169 169 | 
+170 170 | # leading/trailing whitespace should not count towards maxsplit
+171     |-" a b c d ".split(maxsplit=2)  # ["a", "b", "c d "]
+    171 |+["a", "b", "c d "]  # ["a", "b", "c d "]
+172 172 | " a b c d ".rsplit(maxsplit=2)  # [" a b", "c", "d"]
+
+SIM905 [*] Consider using a list literal instead of `str.split`
    --> SIM905.py:172:1
     |
 170 | # leading/trailing whitespace should not count towards maxsplit
@@ -1503,3 +1571,10 @@ SIM905 Consider using a list literal instead of `str.split`
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
 help: Replace with list literal
+
+ℹ Safe fix
+169 169 | 
+170 170 | # leading/trailing whitespace should not count towards maxsplit
+171 171 | " a b c d ".split(maxsplit=2)  # ["a", "b", "c d "]
+172     |-" a b c d ".rsplit(maxsplit=2)  # [" a b", "c", "d"]
+    172 |+[" a b", "c", "d"]  # [" a b", "c", "d"]


### PR DESCRIPTION
**Stacked on top of #19849; diff will include that PR until it is merged.**

---

<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

As part of #19849, I noticed this fix could be implemented.

## Test Plan

Tests added based on CPython behaviour.
