### PR TITLE
[ty] Short circuit `ReachabilityConstraints::analyze_single` for dynamic types

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/function/return_type.md
+++ b/crates/ty_python_semantic/resources/mdtest/function/return_type.md
@@ -506,7 +506,6 @@ class Concrete(Abstract):
     def method(self) -> str: ...  # error: [invalid-return-type]
 ```
 
-
 ## Diagnostics for `invalid-return-type` on dynamic type
 
 ```toml

--- a/crates/ty_python_semantic/resources/mdtest/function/return_type.md
+++ b/crates/ty_python_semantic/resources/mdtest/function/return_type.md
@@ -505,3 +505,17 @@ class Abstract(Protocol):
 class Concrete(Abstract):
     def method(self) -> str: ...  # error: [invalid-return-type]
 ```
+
+
+## Diagnostics for `invalid-return-type` on dynamic type
+
+```toml
+environment.python-version = "3.12"
+```
+
+```py
+from typing import Never, Any
+
+def f(func: Any) -> Never:  # error: [invalid-return-type]
+    func()
+```

--- a/crates/ty_python_semantic/src/semantic_index/reachability_constraints.rs
+++ b/crates/ty_python_semantic/src/semantic_index/reachability_constraints.rs
@@ -823,7 +823,7 @@ impl ReachabilityConstraints {
                 // doesn't help much.
                 // See <https://github.com/astral-sh/ty/issues/968>.
                 if matches!(ty, Type::Dynamic(_)) {
-                    return Truthiness::AlwaysTrue.negate_if(!predicate.is_positive);
+                    return Truthiness::AlwaysFalse.negate_if(!predicate.is_positive);
                 }
 
                 let overloads_iterator =


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ty/issues/968

This reduces the wall time for a large project from ~24s to ~19s. I plan to do another perf recording to verify that the lock congestion is entirely gone but I first need to walk the dog :)

See inline comment for more details.

## Test Plan

`cargo nextest`
