### PR TITLE
Don't cache files with diagnostics

### DIFF
--- a/crates/ruff/src/cache.rs
+++ b/crates/ruff/src/cache.rs
@@ -525,7 +525,7 @@ mod tests {
         assert_eq!(cache.changes.lock().unwrap().len(), 0);
 
         let mut paths = Vec::new();
-        let mut errors = Vec::new();
+        let mut paths_with_diagnostics = Vec::new();
         let mut expected_diagnostics = Diagnostics::default();
         for entry in fs::read_dir(&package_root).unwrap() {
             let entry = entry.unwrap();
@@ -560,7 +560,7 @@ mod tests {
                 )
                 .unwrap();
                 if !diagnostics.inner.is_empty() {
-                    errors.push(path.clone());
+                    paths_with_diagnostics.push(path.clone());
                 }
                 paths.push(path);
                 expected_diagnostics += diagnostics;
@@ -573,10 +573,10 @@ mod tests {
         let cache = Cache::open(package_root.clone(), &settings);
         assert_ne!(cache.package.files.len(), 0);
 
-        errors.sort();
+        paths_with_diagnostics.sort();
 
         for path in &paths {
-            if errors.binary_search(path).is_ok() {
+            if paths_with_diagnostics.binary_search(path).is_ok() {
                 continue; // We don't cache files with diagnostics.
             }
 

--- a/crates/ruff/src/cache.rs
+++ b/crates/ruff/src/cache.rs
@@ -547,7 +547,7 @@ mod tests {
                     continue;
                 }
 
-                let diagnostics = lint_path(
+                let mut diagnostics = lint_path(
                     &path,
                     Some(PackageRoot::root(&package_root)),
                     &settings.linter,
@@ -557,7 +557,14 @@ mod tests {
                     UnsafeFixes::Enabled,
                 )
                 .unwrap();
-                if !diagnostics.inner.is_empty() {
+                if diagnostics.inner.is_empty() {
+                    // We won't load a notebook index from the cache for files without diagnostics,
+                    // so remove them from `expected_diagnostics` too. This allows us to keep the
+                    // full equality assertion below.
+                    diagnostics
+                        .notebook_indexes
+                        .remove(&path.to_string_lossy().to_string());
+                } else {
                     paths_with_diagnostics.push(path.clone());
                 }
                 paths.push(path);

--- a/crates/ruff/src/cache.rs
+++ b/crates/ruff/src/cache.rs
@@ -23,8 +23,6 @@ use ruff_macros::CacheKey;
 use ruff_workspace::Settings;
 use ruff_workspace::resolver::Resolver;
 
-use crate::diagnostics::Diagnostics;
-
 /// [`Path`] that is relative to the package root in [`PackageCache`].
 pub(crate) type RelativePath = Path;
 /// [`PathBuf`] that is relative to the package root in [`PackageCache`].
@@ -327,9 +325,9 @@ pub(crate) struct FileCache {
 }
 
 impl FileCache {
-    /// Convert the file cache into an empty `Diagnostics`, if it has been linted.
-    pub(crate) fn to_diagnostics(&self) -> Option<Diagnostics> {
-        self.data.linted.then(Diagnostics::default)
+    /// Return whether or not the file in the cache was linted and found to have no diagnostics.
+    pub(crate) fn linted(&self) -> bool {
+        self.data.linted
     }
 }
 

--- a/crates/ruff/src/diagnostics.rs
+++ b/crates/ruff/src/diagnostics.rs
@@ -490,13 +490,19 @@ pub(crate) fn lint_stdin(
             (result, transformed, fixed)
         };
 
-    let notebook_indexes = if let SourceKind::IpyNotebook(notebook) = transformed {
-        FxHashMap::from_iter([(
-            path.map_or_else(|| "-".into(), |path| path.to_string_lossy().to_string()),
-            notebook.into_index(),
-        )])
-    } else {
+    // Avoid constructing a map when there are no diagnostics. The index is only used for rendering
+    // diagnostics anyway.
+    let notebook_indexes = if diagnostics.is_empty() {
         FxHashMap::default()
+    } else {
+        if let SourceKind::IpyNotebook(notebook) = transformed {
+            FxHashMap::from_iter([(
+                path.map_or_else(|| "-".into(), |path| path.to_string_lossy().to_string()),
+                notebook.into_index(),
+            )])
+        } else {
+            FxHashMap::default()
+        }
     };
 
     Ok(Diagnostics {

--- a/crates/ruff/src/diagnostics.rs
+++ b/crates/ruff/src/diagnostics.rs
@@ -342,10 +342,17 @@ pub(crate) fn lint_path(
         }
     }
 
-    let notebook_indexes = if let SourceKind::IpyNotebook(notebook) = transformed {
-        FxHashMap::from_iter([(path.to_string_lossy().to_string(), notebook.into_index())])
-    } else {
+    // Avoid constructing a map when there are no diagnostics. The index is only used for rendering
+    // diagnostics anyway. This mirrors our caching behavior, which does not preserve an empty index
+    // either.
+    let notebook_indexes = if diagnostics.is_empty() {
         FxHashMap::default()
+    } else {
+        if let SourceKind::IpyNotebook(notebook) = transformed {
+            FxHashMap::from_iter([(path.to_string_lossy().to_string(), notebook.into_index())])
+        } else {
+            FxHashMap::default()
+        }
     };
 
     Ok(Diagnostics {

--- a/crates/ruff/src/diagnostics.rs
+++ b/crates/ruff/src/diagnostics.rs
@@ -29,6 +29,12 @@ use rustc_hash::FxHashMap;
 
 use crate::cache::{Cache, FileCache, FileCacheKey};
 
+/// A collection of [`Diagnostic`]s and additional information needed to render them.
+///
+/// Note that `notebook_indexes` may be empty if there are no diagnostics because the
+/// `NotebookIndex` isn't cached in this case. This isn't a problem for any current uses as of
+/// 2025-08-12, which are all related to diagnostic rendering, but could be surprising if used
+/// differently in the future.
 #[derive(Debug, Default, PartialEq)]
 pub(crate) struct Diagnostics {
     pub(crate) inner: Vec<Diagnostic>,

--- a/crates/ruff/src/diagnostics.rs
+++ b/crates/ruff/src/diagnostics.rs
@@ -329,17 +329,10 @@ pub(crate) fn lint_path(
         cache.set_linted(relative_path.to_owned(), &key, linted);
     }
 
-    // Avoid constructing a map when there are no diagnostics. The index is only used for rendering
-    // diagnostics anyway. This mirrors our caching behavior, which does not preserve an empty index
-    // either.
-    let notebook_indexes = if diagnostics.is_empty() {
-        FxHashMap::default()
+    let notebook_indexes = if let SourceKind::IpyNotebook(notebook) = transformed {
+        FxHashMap::from_iter([(path.to_string_lossy().to_string(), notebook.into_index())])
     } else {
-        if let SourceKind::IpyNotebook(notebook) = transformed {
-            FxHashMap::from_iter([(path.to_string_lossy().to_string(), notebook.into_index())])
-        } else {
-            FxHashMap::default()
-        }
+        FxHashMap::default()
     };
 
     Ok(Diagnostics {
@@ -477,19 +470,13 @@ pub(crate) fn lint_stdin(
             (result, transformed, fixed)
         };
 
-    // Avoid constructing a map when there are no diagnostics. The index is only used for rendering
-    // diagnostics anyway.
-    let notebook_indexes = if diagnostics.is_empty() {
-        FxHashMap::default()
+    let notebook_indexes = if let SourceKind::IpyNotebook(notebook) = transformed {
+        FxHashMap::from_iter([(
+            path.map_or_else(|| "-".into(), |path| path.to_string_lossy().to_string()),
+            notebook.into_index(),
+        )])
     } else {
-        if let SourceKind::IpyNotebook(notebook) = transformed {
-            FxHashMap::from_iter([(
-                path.map_or_else(|| "-".into(), |path| path.to_string_lossy().to_string()),
-                notebook.into_index(),
-            )])
-        } else {
-            FxHashMap::default()
-        }
+        FxHashMap::default()
     };
 
     Ok(Diagnostics {

--- a/crates/ruff/src/diagnostics.rs
+++ b/crates/ruff/src/diagnostics.rs
@@ -326,8 +326,8 @@ pub(crate) fn lint_path(
     let diagnostics = result.diagnostics;
 
     if let Some((cache, relative_path, key)) = caching {
-        // We don't cache parsing errors.
-        if !has_error {
+        // We don't cache errors.
+        if !has_error && diagnostics.is_empty() {
             // `FixMode::Apply` and `FixMode::Diff` rely on side-effects (writing to disk,
             // and writing the diff to stdout, respectively). If a file has diagnostics, we
             // need to avoid reading from and writing to the cache in these modes.
@@ -340,10 +340,7 @@ pub(crate) fn lint_path(
                 cache.update_lint(
                     relative_path.to_owned(),
                     &key,
-                    LintCacheData::from_diagnostics(
-                        &diagnostics,
-                        transformed.as_ipy_notebook().map(Notebook::index).cloned(),
-                    ),
+                    LintCacheData::new(transformed.as_ipy_notebook().map(Notebook::index).cloned()),
                 );
             }
         }

--- a/crates/ruff_benchmark/benches/linter.rs
+++ b/crates/ruff_benchmark/benches/linter.rs
@@ -77,8 +77,11 @@ fn benchmark_linter(mut group: BenchmarkGroup, settings: &LinterSettings) {
                 b.iter_batched(
                     || parsed.clone(),
                     |parsed| {
+                        // Assert that file contains no parse errors
+                        assert!(parsed.has_valid_syntax());
+
                         let path = case.path();
-                        let result = lint_only(
+                        lint_only(
                             &path,
                             None,
                             settings,
@@ -86,10 +89,7 @@ fn benchmark_linter(mut group: BenchmarkGroup, settings: &LinterSettings) {
                             &SourceKind::Python(case.code().to_string()),
                             PySourceType::from(path.as_path()),
                             ParseSource::Precomputed(parsed),
-                        );
-
-                        // Assert that file contains no parse errors
-                        assert!(!result.has_syntax_errors());
+                        )
                     },
                     criterion::BatchSize::SmallInput,
                 );

--- a/crates/ruff_linter/src/linter.rs
+++ b/crates/ruff_linter/src/linter.rs
@@ -44,44 +44,15 @@ pub struct LinterResult {
     /// Flag indicating that the parsed source code does not contain any
     /// [`ParseError`]s
     has_valid_syntax: bool,
-    /// Flag indicating that the parsed source code does not contain any [`ParseError`]s,
-    /// [`UnsupportedSyntaxError`]s, or [`SemanticSyntaxError`]s.
-    has_no_syntax_errors: bool,
 }
 
 impl LinterResult {
-    /// Returns `true` if the parsed source code contains any [`ParseError`]s *or*
-    /// [`UnsupportedSyntaxError`]s.
-    ///
-    /// See [`LinterResult::has_invalid_syntax`] for a version specific to [`ParseError`]s.
-    pub fn has_syntax_errors(&self) -> bool {
-        !self.has_no_syntax_errors()
-    }
-
-    /// Returns `true` if the parsed source code does not contain any [`ParseError`]s *or*
-    /// [`UnsupportedSyntaxError`]s.
-    ///
-    /// See [`LinterResult::has_valid_syntax`] for a version specific to [`ParseError`]s.
-    pub fn has_no_syntax_errors(&self) -> bool {
-        self.has_valid_syntax() && self.has_no_syntax_errors
-    }
-
-    /// Returns `true` if the parsed source code is valid i.e., it has no [`ParseError`]s.
-    ///
-    /// Note that this does not include version-related [`UnsupportedSyntaxError`]s.
-    ///
-    /// See [`LinterResult::has_no_syntax_errors`] for a version that takes these into account.
-    pub fn has_valid_syntax(&self) -> bool {
-        self.has_valid_syntax
-    }
-
     /// Returns `true` if the parsed source code is invalid i.e., it has [`ParseError`]s.
     ///
-    /// Note that this does not include version-related [`UnsupportedSyntaxError`]s.
-    ///
-    /// See [`LinterResult::has_no_syntax_errors`] for a version that takes these into account.
+    /// Note that this does not include version-related [`UnsupportedSyntaxError`]s or
+    /// [`SemanticSyntaxError`]s.
     pub fn has_invalid_syntax(&self) -> bool {
-        !self.has_valid_syntax()
+        !self.has_valid_syntax
     }
 }
 
@@ -513,7 +484,6 @@ pub fn lint_only(
 
     LinterResult {
         has_valid_syntax: parsed.has_valid_syntax(),
-        has_no_syntax_errors: !diagnostics.iter().any(Diagnostic::is_invalid_syntax),
         diagnostics,
     }
 }
@@ -670,7 +640,6 @@ pub fn lint_fix<'a>(
             result: LinterResult {
                 diagnostics,
                 has_valid_syntax,
-                has_no_syntax_errors,
             },
             transformed,
             fixed,

--- a/crates/ruff_macros/src/map_codes.rs
+++ b/crates/ruff_macros/src/map_codes.rs
@@ -433,13 +433,7 @@ fn register_rules<'a>(input: impl Iterator<Item = &'a Rule>) -> TokenStream {
             Copy,
             Clone,
             Hash,
-            PartialOrd,
-            Ord,
-            ::ruff_macros::CacheKey,
             ::strum_macros::IntoStaticStr,
-            ::strum_macros::EnumString,
-            ::serde::Serialize,
-            ::serde::Deserialize,
         )]
         #[repr(u16)]
         #[strum(serialize_all = "kebab-case")]

--- a/fuzz/fuzz_targets/ruff_formatter_validity.rs
+++ b/fuzz/fuzz_targets/ruff_formatter_validity.rs
@@ -37,7 +37,7 @@ fn do_fuzz(case: &[u8]) -> Corpus {
         ParseSource::None,
     );
 
-    if linter_result.has_syntax_errors() {
+    if linter_result.has_invalid_syntax() {
         return Corpus::Keep; // keep, but don't continue
     }
 
@@ -63,7 +63,7 @@ fn do_fuzz(case: &[u8]) -> Corpus {
         );
 
         assert!(
-            !linter_result.has_syntax_errors(),
+            linter_result.has_invalid_syntax(),
             "formatter introduced a parse error"
         );
 


### PR DESCRIPTION
Summary
--

To take advantage of the new diagnostics, we need to update our caching model to include all of the information supported by `ruff_db`'s diagnostic type. Instead of trying to serialize all of this information, Micha suggested simply not caching files with diagnostics, like we already do for files with syntax errors. This PR is an attempt at that approach.

This has the added benefit of trimming down our `Rule` derives since this was the last place the `FromStr`/`strum_macros::EnumString` implementation was used, as well as the (de)serialization macros and `CacheKey`.

Test Plan
--

Existing tests, with their input updated not to include a diagnostic, plus a new test showing that files with lint diagnostics are not cached.

Benchmarks
--

In addition to tests, we wanted to check that this doesn't degrade performance too much. I posted part of this new analysis in https://github.com/astral-sh/ruff/issues/18198#issuecomment-3175048672, but I'll duplicate it here. In short, there's not much difference between `main` and this branch for projects with few diagnostics (`home-assistant`, `airflow`), as expected. The difference for projects with many diagnostics (`cpython`) is quite a bit bigger (~300 ms vs ~220 ms), but most projects that run ruff regularly are likely to have very few diagnostics, so this may not be a problem practically. 

I guess GitHub isn't really rendering this as I intended, but the extra separator line is meant to separate the benchmarks on `main` (above the line) from this branch (below the line).

| Command                                                       | Mean [ms] | Min [ms] | Max [ms] |
|:--------------------------------------------------------------|----------:|---------:|---------:|
| `ruff check cpython --no-cache --isolated --exit-zero`        |     322.0 |    317.5 |    326.2 |
| `ruff check cpython --isolated --exit-zero`                   |     217.3 |    209.8 |    237.9 |
| `ruff check home-assistant --no-cache --isolated --exit-zero` |     279.5 |    277.0 |    283.6 |
| `ruff check home-assistant --isolated --exit-zero`            |      37.2 |     35.7 |     40.6 |
| `ruff check airflow --no-cache --isolated --exit-zero`        |     133.1 |    130.4 |    146.4 |
| `ruff check airflow --isolated --exit-zero`                   |      34.7 |     32.9 |     41.6 |
|:--------------------------------------------------------------|----------:|---------:|---------:|
| `ruff check cpython --no-cache --isolated --exit-zero`        |     330.1 |    324.5 |    333.6 |
| `ruff check cpython --isolated --exit-zero`                   |     309.2 |    306.1 |    314.7 |
| `ruff check home-assistant --no-cache --isolated --exit-zero` |     288.6 |    279.4 |    302.3 |
| `ruff check home-assistant --isolated --exit-zero`            |      39.8 |     36.9 |     42.4 |
| `ruff check airflow --no-cache --isolated --exit-zero`        |     134.5 |    131.3 |    140.6 |
| `ruff check airflow --isolated --exit-zero`                   |      39.1 |     37.2 |     44.3 |

I had Claude adapt one of the [scripts](https://github.com/sharkdp/hyperfine/blob/master/scripts/plot_whisker.py) from the hyperfine repo to make this plot, so it's not quite perfect, but maybe it's still useful. The table is probably more reliable for close comparisons. I'll put more details about the benchmarks below for the sake of future reproducibility.

<img width="4472" height="2368" alt="image" src="https://github.com/user-attachments/assets/1c42d13e-818a-44e7-b34c-247340a936d7" />

<details><summary>Benchmark details</summary>
<p>

The versions of each project:
- CPython: 6322edd260e8cad4b09636e05ddfb794a96a0451, the 3.10 branch from the contributing docs
- `home-assistant`: 5585376b406f099fb29a970b160877b57e5efcb0
- `airflow`: 29a1cb0cfde9d99b1774571688ed86cb60123896

The last two are just the main branches at the time I cloned the repos.

I don't think our Ruff config should be applied since I used `--isolated`, but these are cloned into my copy of Ruff at `crates/ruff_linter/resources/test`, and I trimmed the `./target/release/` prefix from each of the commands, but these are builds of Ruff in release mode.

And here's the script with the `hyperfine` invocation:

```shell
#!/bin/bash

cargo build --release --bin ruff

# git clone --depth 1 https://github.com/home-assistant/core crates/ruff_linter/resources/test/home-assistant
# git clone --depth 1 https://github.com/apache/airflow crates/ruff_linter/resources/test/airflow

bin=./target/release/ruff
resources=./crates/ruff_linter/resources/test
cpython=$resources/cpython
home_assistant=$resources/home-assistant
airflow=$resources/airflow

base=${1:-bench}

hyperfine --warmup 10 --export-json $base.json --export-markdown $base.md \
		  "$bin check $cpython --no-cache --isolated --exit-zero" \
		  "$bin check $cpython --isolated --exit-zero" \
		  "$bin check $home_assistant --no-cache --isolated --exit-zero" \
		  "$bin check $home_assistant --isolated --exit-zero" \
		  "$bin check $airflow --no-cache --isolated --exit-zero" \
		  "$bin check $airflow --isolated --exit-zero"
```

I ran this once on `main` (`baseline` in the graph, top half of the table) and once on this branch (`nocache` and bottom of the table).

</p>
</details> 
