### PR TITLE
[ty] Fix tool name is None when no ty path is given in ty_benchmark

### DIFF
--- a/scripts/ty_benchmark/src/benchmark/cases.py
+++ b/scripts/ty_benchmark/src/benchmark/cases.py
@@ -58,7 +58,7 @@ class Ty(Tool):
     name: str
 
     def __init__(self, *, path: Path | None = None):
-        self.name = str(path) or "ty"
+        self.name = str(path) if path else "ty"
         self.path = (
             path or (Path(__file__) / "../../../../../target/release/ty")
         ).resolve()


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
When running the ty_benchmark, I found out that the Ty Tool name is None when no ty_path is given as str(None)='None'
<img width="1011" height="168" alt="image" src="https://github.com/user-attachments/assets/cf3e6d98-2329-48e9-b180-c72e4f01ccb6" />

## Test Plan
Minor fix, tested local
<img width="1105" height="218" alt="image" src="https://github.com/user-attachments/assets/173128c9-dcfa-49f1-a58d-1b39a6c6b53b" />

<!-- How was it tested? -->
