### PR TITLE
[ty] simplify CycleDetector::visit signature

### DIFF
--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1062,49 +1062,49 @@ impl<'db> Type<'db> {
     pub(crate) fn normalized_impl(self, db: &'db dyn Db, visitor: &TypeTransformer<'db>) -> Self {
         match self {
             Type::Union(union) => {
-                visitor.visit(self, |v| Type::Union(union.normalized_impl(db, v)))
+                visitor.visit(self, || Type::Union(union.normalized_impl(db, visitor)))
             }
-            Type::Intersection(intersection) => visitor.visit(self, |v| {
-                Type::Intersection(intersection.normalized_impl(db, v))
+            Type::Intersection(intersection) => visitor.visit(self, || {
+                Type::Intersection(intersection.normalized_impl(db, visitor))
             }),
-            Type::Callable(callable) => {
-                visitor.visit(self, |v| Type::Callable(callable.normalized_impl(db, v)))
-            }
+            Type::Callable(callable) => visitor.visit(self, || {
+                Type::Callable(callable.normalized_impl(db, visitor))
+            }),
             Type::ProtocolInstance(protocol) => {
-                visitor.visit(self, |v| protocol.normalized_impl(db, v))
+                visitor.visit(self, || protocol.normalized_impl(db, visitor))
             }
             Type::NominalInstance(instance) => {
-                visitor.visit(self, |v| instance.normalized_impl(db, v))
+                visitor.visit(self, || instance.normalized_impl(db, visitor))
             }
-            Type::FunctionLiteral(function) => visitor.visit(self, |v| {
-                Type::FunctionLiteral(function.normalized_impl(db, v))
+            Type::FunctionLiteral(function) => visitor.visit(self, || {
+                Type::FunctionLiteral(function.normalized_impl(db, visitor))
             }),
-            Type::PropertyInstance(property) => visitor.visit(self, |v| {
-                Type::PropertyInstance(property.normalized_impl(db, v))
+            Type::PropertyInstance(property) => visitor.visit(self, || {
+                Type::PropertyInstance(property.normalized_impl(db, visitor))
             }),
-            Type::MethodWrapper(method_kind) => visitor.visit(self, |v| {
-                Type::MethodWrapper(method_kind.normalized_impl(db, v))
+            Type::MethodWrapper(method_kind) => visitor.visit(self, || {
+                Type::MethodWrapper(method_kind.normalized_impl(db, visitor))
             }),
-            Type::BoundMethod(method) => {
-                visitor.visit(self, |v| Type::BoundMethod(method.normalized_impl(db, v)))
-            }
-            Type::BoundSuper(bound_super) => visitor.visit(self, |v| {
-                Type::BoundSuper(bound_super.normalized_impl(db, v))
+            Type::BoundMethod(method) => visitor.visit(self, || {
+                Type::BoundMethod(method.normalized_impl(db, visitor))
             }),
-            Type::GenericAlias(generic) => {
-                visitor.visit(self, |v| Type::GenericAlias(generic.normalized_impl(db, v)))
-            }
-            Type::SubclassOf(subclass_of) => visitor.visit(self, |v| {
-                Type::SubclassOf(subclass_of.normalized_impl(db, v))
+            Type::BoundSuper(bound_super) => visitor.visit(self, || {
+                Type::BoundSuper(bound_super.normalized_impl(db, visitor))
             }),
-            Type::TypeVar(bound_typevar) => visitor.visit(self, |v| {
-                Type::TypeVar(bound_typevar.normalized_impl(db, v))
+            Type::GenericAlias(generic) => visitor.visit(self, || {
+                Type::GenericAlias(generic.normalized_impl(db, visitor))
             }),
-            Type::KnownInstance(known_instance) => visitor.visit(self, |v| {
-                Type::KnownInstance(known_instance.normalized_impl(db, v))
+            Type::SubclassOf(subclass_of) => visitor.visit(self, || {
+                Type::SubclassOf(subclass_of.normalized_impl(db, visitor))
             }),
-            Type::TypeIs(type_is) => visitor.visit(self, |v| {
-                type_is.with_type(db, type_is.return_type(db).normalized_impl(db, v))
+            Type::TypeVar(bound_typevar) => visitor.visit(self, || {
+                Type::TypeVar(bound_typevar.normalized_impl(db, visitor))
+            }),
+            Type::KnownInstance(known_instance) => visitor.visit(self, || {
+                Type::KnownInstance(known_instance.normalized_impl(db, visitor))
+            }),
+            Type::TypeIs(type_is) => visitor.visit(self, || {
+                type_is.with_type(db, type_is.return_type(db).normalized_impl(db, visitor))
             }),
             Type::Dynamic(dynamic) => Type::Dynamic(dynamic.normalized()),
             Type::EnumLiteral(enum_literal)

--- a/crates/ty_python_semantic/src/types/cyclic.rs
+++ b/crates/ty_python_semantic/src/types/cyclic.rs
@@ -47,7 +47,7 @@ impl<T: Hash + Eq + Copy, R: Copy> CycleDetector<T, R> {
         }
     }
 
-    pub(crate) fn visit(&self, item: T, func: impl FnOnce(&Self) -> R) -> R {
+    pub(crate) fn visit(&self, item: T, func: impl FnOnce() -> R) -> R {
         if let Some(ty) = self.cache.borrow().get(&item) {
             return *ty;
         }
@@ -57,7 +57,7 @@ impl<T: Hash + Eq + Copy, R: Copy> CycleDetector<T, R> {
             return self.fallback;
         }
 
-        let ret = func(self);
+        let ret = func();
         self.seen.borrow_mut().pop();
         self.cache.borrow_mut().insert(item, ret);
 

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -437,9 +437,9 @@ impl<'a, 'db> ProtocolMember<'a, 'db> {
         match &self.kind {
             // TODO: implement disjointness for property/method members as well as attribute members
             ProtocolMemberKind::Property(_) | ProtocolMemberKind::Method(_) => false,
-            ProtocolMemberKind::Other(ty) => {
-                visitor.visit((*ty, other), |v| ty.is_disjoint_from_impl(db, other, v))
-            }
+            ProtocolMemberKind::Other(ty) => visitor.visit((*ty, other), || {
+                ty.is_disjoint_from_impl(db, other, visitor)
+            }),
         }
     }
 


### PR DESCRIPTION
## Summary

After https://github.com/astral-sh/ruff/pull/19871, I realized that now that we are passing around shared references to `CycleDetector` visitors, we can now also simplify the `visit` callback signature; we don't need to smuggle a single visitor reference through it anymore. This is a pretty minor simplification, and it doesn't really make anything shorter since I typically used a very short name (`v`) for the smuggled reference, but I think it reduces cognitive overhead in reading these `visit` usages; the extra variable would likely be confusing otherwise for a reader.

## Test Plan

Existing CI.
