### PR TITLE
[ty] Move Salsa caching "down a layer" in `tuple.rs`

### DIFF
--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -12,7 +12,7 @@ use crate::types::class::{ClassLiteral, ClassType, GenericAlias};
 use crate::types::function::{FunctionType, OverloadLiteral};
 use crate::types::generics::{GenericContext, Specialization};
 use crate::types::signatures::{CallableSignature, Parameter, Parameters, Signature};
-use crate::types::tuple::TupleSpec;
+use crate::types::tuple::{Tuple, TupleSpec};
 use crate::types::{
     BoundTypeVarInstance, CallableType, IntersectionType, KnownClass, MethodWrapperKind, Protocol,
     StringLiteralType, SubclassOfInner, Type, TypeVarBoundOrConstraints, TypeVarInstance,
@@ -262,8 +262,8 @@ pub(crate) struct DisplayTuple<'db> {
 impl Display for DisplayTuple<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.write_str("tuple[")?;
-        match self.tuple {
-            TupleSpec::Fixed(tuple) => {
+        match self.tuple.inner(self.db) {
+            Tuple::Fixed(tuple) => {
                 let elements = tuple.elements_slice();
                 if elements.is_empty() {
                     f.write_str("()")?;
@@ -286,7 +286,7 @@ impl Display for DisplayTuple<'_> {
             // above only an S is included only if there's a suffix; anything about both a P and an
             // S is included if there is either a prefix or a suffix. The initial `tuple[` and
             // trailing `]` are printed elsewhere. The `yyy, ...` is printed no matter what.)
-            TupleSpec::Variable(tuple) => {
+            Tuple::Variable(tuple) => {
                 if !tuple.prefix.is_empty() {
                     tuple.prefix.display(self.db).fmt(f)?;
                     f.write_str(", ")?;

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -241,7 +241,7 @@ impl<'db> GenericContext<'db> {
                 db,
                 self,
                 partial.types(db),
-                TupleType::homogeneous(db, Type::unknown()),
+                Some(TupleType::homogeneous(db, Type::unknown())),
             )
         } else {
             partial
@@ -424,8 +424,8 @@ pub(super) fn walk_specialization<'db, V: super::visitor::TypeVisitor<'db> + ?Si
 
 impl<'db> Specialization<'db> {
     /// Returns the tuple spec for a specialization of the `tuple` class.
-    pub(crate) fn tuple(self, db: &'db dyn Db) -> Option<&'db TupleSpec<'db>> {
-        self.tuple_inner(db).map(|tuple_type| tuple_type.tuple(db))
+    pub(crate) fn tuple(self, db: &'db dyn Db) -> Option<TupleSpec<'db>> {
+        self.tuple_inner(db).map(|tuple_type| tuple_type.spec)
     }
 
     /// Returns the type that a typevar is mapped to, or None if the typevar isn't part of this
@@ -867,6 +867,8 @@ impl<'db> SpecializationBuilder<'db> {
                     formal.tuple_instance_spec(self.db),
                     actual_nominal.tuple_spec(self.db),
                 ) {
+                    let formal_tuple = formal_tuple.inner(self.db);
+                    let actual_tuple = actual_tuple.inner(self.db);
                     let Some(most_precise_length) =
                         formal_tuple.len().most_precise(actual_tuple.len())
                     else {

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -233,8 +233,8 @@ impl ClassInfoConstraintFunction {
                 UnionType::try_from_elements(
                     db,
                     tuple
-                        .all_elements()
-                        .map(|element| self.generate_constraint(db, *element)),
+                        .all_elements(db)
+                        .map(|element| self.generate_constraint(db, element)),
                 )
             }),
 
@@ -636,7 +636,10 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                 // but we'd still apply the narrowing here. This seems unlikely, however, and narrowing is
                 // generally unsound in numerous ways anyway (attribute narrowing, subscript, narrowing,
                 // narrowing of globals, etc.). So this doesn't seem worth worrying about too much.
-                Some(UnionType::from_elements(self.db, tuple_spec.all_elements()))
+                Some(UnionType::from_elements(
+                    self.db,
+                    tuple_spec.all_elements(self.db),
+                ))
             } else {
                 None
             }


### PR DESCRIPTION
## Summary

This PR moves the Salsa caching "down a layer" in `tuple.rs`:
- `TupleType` is no longer a Salsa-tracked struct; instead, it's just a thin wrapper around a Salsa-tracked struct, similar to `NominalInstanceType`, `ProtocolInstanceType` and others.
- `TupleSpec` (the type wrapped by `TupleType`) is no longer a type alias; instead, it's now a Salsa-tracked struct.

The benefits of this are that we need to use many fewer `Cow`s across the ty codebase (which were previously required due to `TupleSpec` not being `Copy`), and we can avoid some very complicated trait bounds that we currently have in the signature of `TupleType::new()` on `main`.

## Test Plan

Existing tests
