### PR TITLE
[ty] Remove Salsa interning for `TypedDictType`

### DIFF
--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -2922,6 +2922,12 @@ impl<'db> From<ClassLiteral<'db>> for Type<'db> {
     }
 }
 
+impl<'db> From<ClassLiteral<'db>> for ClassType<'db> {
+    fn from(class: ClassLiteral<'db>) -> ClassType<'db> {
+        ClassType::NonGeneric(class)
+    }
+}
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, get_size2::GetSize)]
 pub(super) enum InheritanceCycle {
     /// The class is cyclically defined and is a participant in the cycle.

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -242,9 +242,7 @@ impl Display for DisplayRepresentation<'_> {
                 }
                 f.write_str("]")
             }
-            Type::TypedDict(typed_dict) => {
-                f.write_str(typed_dict.defining_class(self.db).name(self.db))
-            }
+            Type::TypedDict(typed_dict) => f.write_str(typed_dict.defining_class.name(self.db)),
         }
     }
 }

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -11,9 +11,7 @@ use crate::types::cyclic::PairVisitor;
 use crate::types::enums::is_single_member_enum;
 use crate::types::protocol_class::walk_protocol_interface;
 use crate::types::tuple::{TupleSpec, TupleType};
-use crate::types::{
-    ClassBase, DynamicType, TypeMapping, TypeRelation, TypeTransformer, TypedDictType, UnionType,
-};
+use crate::types::{ClassBase, DynamicType, TypeMapping, TypeRelation, TypeTransformer, UnionType};
 use crate::{Db, FxOrderSet, Program};
 
 pub(super) use synthesized_protocol::SynthesizedProtocolType;
@@ -34,7 +32,7 @@ impl<'db> Type<'db> {
             _ if class_literal.is_protocol(db) => {
                 Self::ProtocolInstance(ProtocolInstanceType::from_class(class))
             }
-            _ if class_literal.is_typed_dict(db) => TypedDictType::from(db, class),
+            _ if class_literal.is_typed_dict(db) => Type::typed_dict(class),
             _ => Type::non_tuple_instance(class),
         }
     }

--- a/crates/ty_python_semantic/src/types/type_ordering.rs
+++ b/crates/ty_python_semantic/src/types/type_ordering.rs
@@ -236,7 +236,9 @@ pub(super) fn union_or_intersection_elements_ordering<'db>(
             unreachable!("Two equal, normalized intersections should share the same Salsa ID")
         }
 
-        (Type::TypedDict(left), Type::TypedDict(right)) => left.cmp(right),
+        (Type::TypedDict(left), Type::TypedDict(right)) => {
+            left.defining_class.cmp(&right.defining_class)
+        }
         (Type::TypedDict(_), _) => Ordering::Less,
         (_, Type::TypedDict(_)) => Ordering::Greater,
     }


### PR DESCRIPTION
## Summary

It doesn't seem like Salsa interning is buying us much here: `TypedDictType` is just a thin wrapper around `ClassType`, which is already `Copy`.

## Test Plan

Existing tests
