### PR TITLE
[`pyupgrade`] Add sub-diagnostics showing type variable definitions (`UP046`)

### DIFF
--- a/crates/ruff_db/src/diagnostic/mod.rs
+++ b/crates/ruff_db/src/diagnostic/mod.rs
@@ -497,6 +497,16 @@ impl Diagnostic {
             other.expect_range().start(),
         ))
     }
+
+    /// Sort this diagnostic's sub-diagnostics by descending severity.
+    ///
+    /// This is particularly helpful to move `help`-level sub-diagnostics to the end, after any
+    /// longer, `info`-level diagnostics.
+    pub fn sort_sub_diagnostics(&mut self) {
+        Arc::make_mut(&mut self.inner)
+            .subs
+            .sort_by_key(|sub| std::cmp::Reverse(sub.inner.severity));
+    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, get_size2::GetSize)]

--- a/crates/ruff_db/src/diagnostic/mod.rs
+++ b/crates/ruff_db/src/diagnostic/mod.rs
@@ -254,6 +254,11 @@ impl Diagnostic {
             .find(|ann| ann.is_primary)
     }
 
+    /// Returns a mutable borrow of all annotations of this diagnostic.
+    pub fn annotations_mut(&mut self) -> impl Iterator<Item = &mut Annotation> {
+        Arc::make_mut(&mut self.inner).annotations.iter_mut()
+    }
+
     /// Returns the "primary" span of this diagnostic if one exists.
     ///
     /// When there are multiple primary spans, then the first one that was
@@ -308,6 +313,11 @@ impl Diagnostic {
 
     pub fn sub_diagnostics(&self) -> &[SubDiagnostic] {
         &self.inner.subs
+    }
+
+    /// Returns a shared borrow of the sub-diagnostics of this diagnostic.
+    pub fn sub_diagnostics_mut(&mut self) -> impl Iterator<Item = &mut SubDiagnostic> {
+        Arc::make_mut(&mut self.inner).subs.iter_mut()
     }
 
     /// Returns the fix for this diagnostic if it exists.
@@ -619,6 +629,11 @@ impl SubDiagnostic {
 
     pub fn annotations(&self) -> &[Annotation] {
         &self.inner.annotations
+    }
+
+    /// Returns a shared borrow of the annotations of this diagnostic.
+    pub fn annotations_mut(&mut self) -> impl Iterator<Item = &mut Annotation> {
+        self.inner.annotations.iter_mut()
     }
 
     /// Returns a shared borrow of the "primary" annotation of this diagnostic

--- a/crates/ruff_db/src/diagnostic/render.rs
+++ b/crates/ruff_db/src/diagnostic/render.rs
@@ -264,7 +264,12 @@ impl<'a> ResolvedDiagnostic<'a> {
             .annotations
             .iter()
             .filter_map(|ann| {
-                let path = ann.span.file.path(resolver);
+                let path = ann
+                    .span
+                    .file
+                    .relative_path(resolver)
+                    .to_str()
+                    .unwrap_or_else(|| ann.span.file.path(resolver));
                 let diagnostic_source = ann.span.file.diagnostic_source(resolver);
                 ResolvedAnnotation::new(path, &diagnostic_source, ann, resolver)
             })

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -3349,7 +3349,8 @@ impl Drop for DiagnosticGuard<'_, '_> {
             return;
         }
 
-        if let Some(diagnostic) = self.diagnostic.take() {
+        if let Some(mut diagnostic) = self.diagnostic.take() {
+            diagnostic.sort_sub_diagnostics();
             self.context.diagnostics.borrow_mut().push(diagnostic);
         }
     }

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -28,7 +28,9 @@ use itertools::Itertools;
 use log::debug;
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use ruff_db::diagnostic::Diagnostic;
+use ruff_db::diagnostic::{
+    Annotation, Diagnostic, IntoDiagnosticMessage, Span, SubDiagnostic, SubDiagnosticSeverity,
+};
 use ruff_diagnostics::{Applicability, Fix, IsolationLevel};
 use ruff_notebook::{CellOffsets, NotebookIndex};
 use ruff_python_ast::helpers::{collect_import_from_member, is_docstring_stmt, to_module_path};
@@ -3304,6 +3306,22 @@ impl DiagnosticGuard<'_, '_> {
             Ok(Some(fix)) => self.set_fix(fix),
             Err(err) => log::debug!("Failed to create fix for {}: {}", self.name(), err),
         }
+    }
+
+    /// Add an "info" sub-diagnostic with the given message and range.
+    ///
+    /// Note that this shadows `Diagnostic::info` from the `Deref` implementation because we'll
+    /// usually want to attach a range here.
+    pub(crate) fn info<'a>(
+        &mut self,
+        message: impl IntoDiagnosticMessage + 'a,
+        range: impl Ranged,
+    ) {
+        let mut sub = SubDiagnostic::new(SubDiagnosticSeverity::Info, message);
+        let span = Span::from(self.context.source_file.clone()).with_range(range.range());
+        let ann = Annotation::primary(span);
+        sub.annotate(ann);
+        self.diagnostic.as_mut().unwrap().sub(sub);
     }
 }
 

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_generic_class.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_generic_class.rs
@@ -191,6 +191,15 @@ pub(crate) fn non_pep695_generic_class(checker: &Checker, class_def: &StmtClassD
             return;
         };
 
+        for type_var in &type_vars {
+            if let Some(range) = type_var.range {
+                diagnostic.info(
+                    format_args!("Type variable `{}` defined here", type_var.name),
+                    range,
+                );
+            }
+        }
+
         // build the fix as a String to avoid removing comments from the entire function body
         let type_params = DisplayTypeVars {
             type_vars: &type_vars,

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_type_alias.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_type_alias.rs
@@ -170,6 +170,7 @@ pub(crate) fn non_pep695_type_alias_type(checker: &Checker, stmt: &StmtAssign) {
                     restriction: None,
                     kind: TypeParamKind::TypeVar,
                     default: None,
+                    range: Some(name.range),
                 })
             })
         })

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP046_0.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP046_0.py.snap
@@ -11,7 +11,7 @@ UP046 [*] Generic class `A` uses `Generic` subclass instead of type parameters
    |
 help: Use type parameters
 info: Type variable `T` defined here
- --> ./resources/test/fixtures/pyupgrade/UP046_0.py:6:1
+ --> UP046_0.py:6:1
   |
 5 | S = TypeVar("S", str, bytes)  # constrained type variable
 6 | T = TypeVar("T", bound=float)
@@ -39,7 +39,7 @@ UP046 [*] Generic class `B` uses `Generic` subclass instead of type parameters
    |
 help: Use type parameters
 info: Type variable `Ts` defined here
- --> ./resources/test/fixtures/pyupgrade/UP046_0.py:7:1
+ --> UP046_0.py:7:1
   |
 5 | S = TypeVar("S", str, bytes)  # constrained type variable
 6 | T = TypeVar("T", bound=float)
@@ -67,7 +67,7 @@ UP046 [*] Generic class `C` uses `Generic` subclass instead of type parameters
    |
 help: Use type parameters
 info: Type variable `P` defined here
- --> ./resources/test/fixtures/pyupgrade/UP046_0.py:8:1
+ --> UP046_0.py:8:1
   |
 6 | T = TypeVar("T", bound=float)
 7 | Ts = TypeVarTuple("Ts")
@@ -94,7 +94,7 @@ UP046 [*] Generic class `Constrained` uses `Generic` subclass instead of type pa
    |
 help: Use type parameters
 info: Type variable `S` defined here
- --> ./resources/test/fixtures/pyupgrade/UP046_0.py:5:1
+ --> UP046_0.py:5:1
   |
 3 | from somewhere import SupportsRichComparisonT
 4 |
@@ -157,7 +157,7 @@ UP046 [*] Generic class `MultipleGenerics` uses `Generic` subclass instead of ty
    |
 help: Use type parameters
 info: Type variable `S` defined here
- --> ./resources/test/fixtures/pyupgrade/UP046_0.py:5:1
+ --> UP046_0.py:5:1
   |
 3 | from somewhere import SupportsRichComparisonT
 4 |
@@ -167,7 +167,7 @@ info: Type variable `S` defined here
 7 | Ts = TypeVarTuple("Ts")
   |
 info: Type variable `T` defined here
- --> ./resources/test/fixtures/pyupgrade/UP046_0.py:6:1
+ --> UP046_0.py:6:1
   |
 5 | S = TypeVar("S", str, bytes)  # constrained type variable
 6 | T = TypeVar("T", bound=float)
@@ -176,7 +176,7 @@ info: Type variable `T` defined here
 8 | P = ParamSpec("P")
   |
 info: Type variable `Ts` defined here
- --> ./resources/test/fixtures/pyupgrade/UP046_0.py:7:1
+ --> UP046_0.py:7:1
   |
 5 | S = TypeVar("S", str, bytes)  # constrained type variable
 6 | T = TypeVar("T", bound=float)
@@ -185,7 +185,7 @@ info: Type variable `Ts` defined here
 8 | P = ParamSpec("P")
   |
 info: Type variable `P` defined here
- --> ./resources/test/fixtures/pyupgrade/UP046_0.py:8:1
+ --> UP046_0.py:8:1
   |
 6 | T = TypeVar("T", bound=float)
 7 | Ts = TypeVarTuple("Ts")
@@ -212,7 +212,7 @@ UP046 [*] Generic class `MultipleBaseClasses` uses `Generic` subclass instead of
    |
 help: Use type parameters
 info: Type variable `T` defined here
- --> ./resources/test/fixtures/pyupgrade/UP046_0.py:6:1
+ --> UP046_0.py:6:1
   |
 5 | S = TypeVar("S", str, bytes)  # constrained type variable
 6 | T = TypeVar("T", bound=float)
@@ -240,7 +240,7 @@ UP046 [*] Generic class `MoreBaseClasses` uses `Generic` subclass instead of typ
    |
 help: Use type parameters
 info: Type variable `T` defined here
- --> ./resources/test/fixtures/pyupgrade/UP046_0.py:6:1
+ --> UP046_0.py:6:1
   |
 5 | S = TypeVar("S", str, bytes)  # constrained type variable
 6 | T = TypeVar("T", bound=float)
@@ -269,7 +269,7 @@ UP046 [*] Generic class `MultipleBaseAndGenerics` uses `Generic` subclass instea
    |
 help: Use type parameters
 info: Type variable `S` defined here
- --> ./resources/test/fixtures/pyupgrade/UP046_0.py:5:1
+ --> UP046_0.py:5:1
   |
 3 | from somewhere import SupportsRichComparisonT
 4 |
@@ -279,7 +279,7 @@ info: Type variable `S` defined here
 7 | Ts = TypeVarTuple("Ts")
   |
 info: Type variable `T` defined here
- --> ./resources/test/fixtures/pyupgrade/UP046_0.py:6:1
+ --> UP046_0.py:6:1
   |
 5 | S = TypeVar("S", str, bytes)  # constrained type variable
 6 | T = TypeVar("T", bound=float)
@@ -288,7 +288,7 @@ info: Type variable `T` defined here
 8 | P = ParamSpec("P")
   |
 info: Type variable `Ts` defined here
- --> ./resources/test/fixtures/pyupgrade/UP046_0.py:7:1
+ --> UP046_0.py:7:1
   |
 5 | S = TypeVar("S", str, bytes)  # constrained type variable
 6 | T = TypeVar("T", bound=float)
@@ -297,7 +297,7 @@ info: Type variable `Ts` defined here
 8 | P = ParamSpec("P")
   |
 info: Type variable `P` defined here
- --> ./resources/test/fixtures/pyupgrade/UP046_0.py:8:1
+ --> UP046_0.py:8:1
   |
 6 | T = TypeVar("T", bound=float)
 7 | Ts = TypeVarTuple("Ts")
@@ -323,7 +323,7 @@ UP046 [*] Generic class `A` uses `Generic` subclass instead of type parameters
    |
 help: Use type parameters
 info: Type variable `T` defined here
- --> ./resources/test/fixtures/pyupgrade/UP046_0.py:6:1
+ --> UP046_0.py:6:1
   |
 5 | S = TypeVar("S", str, bytes)  # constrained type variable
 6 | T = TypeVar("T", bound=float)
@@ -351,7 +351,7 @@ UP046 [*] Generic class `B` uses `Generic` subclass instead of type parameters
    |
 help: Use type parameters
 info: Type variable `S` defined here
- --> ./resources/test/fixtures/pyupgrade/UP046_0.py:5:1
+ --> UP046_0.py:5:1
   |
 3 | from somewhere import SupportsRichComparisonT
 4 |
@@ -380,7 +380,7 @@ UP046 [*] Generic class `C` uses `Generic` subclass instead of type parameters
    |
 help: Use type parameters
 info: Type variable `S` defined here
- --> ./resources/test/fixtures/pyupgrade/UP046_0.py:5:1
+ --> UP046_0.py:5:1
   |
 3 | from somewhere import SupportsRichComparisonT
 4 |
@@ -390,7 +390,7 @@ info: Type variable `S` defined here
 7 | Ts = TypeVarTuple("Ts")
   |
 info: Type variable `T` defined here
- --> ./resources/test/fixtures/pyupgrade/UP046_0.py:6:1
+ --> UP046_0.py:6:1
   |
 5 | S = TypeVar("S", str, bytes)  # constrained type variable
 6 | T = TypeVar("T", bound=float)
@@ -418,7 +418,7 @@ UP046 [*] Generic class `D` uses `Generic` subclass instead of type parameters
    |
 help: Use type parameters
 info: Type variable `T` defined here
- --> ./resources/test/fixtures/pyupgrade/UP046_0.py:6:1
+ --> UP046_0.py:6:1
   |
 5 | S = TypeVar("S", str, bytes)  # constrained type variable
 6 | T = TypeVar("T", bound=float)

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP046_0.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP046_0.py.snap
@@ -9,7 +9,6 @@ UP046 [*] Generic class `A` uses `Generic` subclass instead of type parameters
 12 |     # Comments in a class body are preserved
 13 |     var: T
    |
-help: Use type parameters
 info: Type variable `T` defined here
  --> UP046_0.py:6:1
   |
@@ -19,6 +18,7 @@ info: Type variable `T` defined here
 7 | Ts = TypeVarTuple("Ts")
 8 | P = ParamSpec("P")
   |
+help: Use type parameters
 
 ℹ Unsafe fix
 8  8  | P = ParamSpec("P")
@@ -37,7 +37,6 @@ UP046 [*] Generic class `B` uses `Generic` subclass instead of type parameters
    |         ^^^^^^^^^^^^
 17 |     var: tuple[*Ts]
    |
-help: Use type parameters
 info: Type variable `Ts` defined here
  --> UP046_0.py:7:1
   |
@@ -47,6 +46,7 @@ info: Type variable `Ts` defined here
   | ^^^^^^^^^^^^^^^^^^^^^^^
 8 | P = ParamSpec("P")
   |
+help: Use type parameters
 
 ℹ Unsafe fix
 13 13 |     var: T
@@ -65,7 +65,6 @@ UP046 [*] Generic class `C` uses `Generic` subclass instead of type parameters
    |         ^^^^^^^^^^
 21 |     var: P
    |
-help: Use type parameters
 info: Type variable `P` defined here
  --> UP046_0.py:8:1
   |
@@ -74,6 +73,7 @@ info: Type variable `P` defined here
 8 | P = ParamSpec("P")
   | ^^^^^^^^^^^^^^^^^^
   |
+help: Use type parameters
 
 ℹ Unsafe fix
 17 17 |     var: tuple[*Ts]
@@ -92,7 +92,6 @@ UP046 [*] Generic class `Constrained` uses `Generic` subclass instead of type pa
    |                   ^^^^^^^^^^
 25 |     var: S
    |
-help: Use type parameters
 info: Type variable `S` defined here
  --> UP046_0.py:5:1
   |
@@ -103,6 +102,7 @@ info: Type variable `S` defined here
 6 | T = TypeVar("T", bound=float)
 7 | Ts = TypeVarTuple("Ts")
   |
+help: Use type parameters
 
 ℹ Unsafe fix
 21 21 |     var: P
@@ -155,7 +155,6 @@ UP046 [*] Generic class `MultipleGenerics` uses `Generic` subclass instead of ty
 42 |     var: S
 43 |     typ: T
    |
-help: Use type parameters
 info: Type variable `S` defined here
  --> UP046_0.py:5:1
   |
@@ -192,6 +191,7 @@ info: Type variable `P` defined here
 8 | P = ParamSpec("P")
   | ^^^^^^^^^^^^^^^^^^
   |
+help: Use type parameters
 
 ℹ Unsafe fix
 38 38 |     s: AnyStr
@@ -210,7 +210,6 @@ UP046 [*] Generic class `MultipleBaseClasses` uses `Generic` subclass instead of
    |                                 ^^^^^^^^^^
 49 |     var: T
    |
-help: Use type parameters
 info: Type variable `T` defined here
  --> UP046_0.py:6:1
   |
@@ -220,6 +219,7 @@ info: Type variable `T` defined here
 7 | Ts = TypeVarTuple("Ts")
 8 | P = ParamSpec("P")
   |
+help: Use type parameters
 
 ℹ Unsafe fix
 45 45 |     pep: P
@@ -238,7 +238,6 @@ UP046 [*] Generic class `MoreBaseClasses` uses `Generic` subclass instead of typ
    |                                            ^^^^^^^^^^
 63 |     var: T
    |
-help: Use type parameters
 info: Type variable `T` defined here
  --> UP046_0.py:6:1
   |
@@ -248,6 +247,7 @@ info: Type variable `T` defined here
 7 | Ts = TypeVarTuple("Ts")
 8 | P = ParamSpec("P")
   |
+help: Use type parameters
 
 ℹ Unsafe fix
 59 59 | class Base3: ...
@@ -267,7 +267,6 @@ UP046 [*] Generic class `MultipleBaseAndGenerics` uses `Generic` subclass instea
 67 |     var: S
 68 |     typ: T
    |
-help: Use type parameters
 info: Type variable `S` defined here
  --> UP046_0.py:5:1
   |
@@ -304,6 +303,7 @@ info: Type variable `P` defined here
 8 | P = ParamSpec("P")
   | ^^^^^^^^^^^^^^^^^^
   |
+help: Use type parameters
 
 ℹ Unsafe fix
 63 63 |     var: T
@@ -321,7 +321,6 @@ UP046 [*] Generic class `A` uses `Generic` subclass instead of type parameters
 73 | class A(Generic[T]): ...
    |         ^^^^^^^^^^
    |
-help: Use type parameters
 info: Type variable `T` defined here
  --> UP046_0.py:6:1
   |
@@ -331,6 +330,7 @@ info: Type variable `T` defined here
 7 | Ts = TypeVarTuple("Ts")
 8 | P = ParamSpec("P")
   |
+help: Use type parameters
 
 ℹ Unsafe fix
 70 70 |     pep: P
@@ -349,7 +349,6 @@ UP046 [*] Generic class `B` uses `Generic` subclass instead of type parameters
    |               ^^^^^^^^^^
 77 |     var: S
    |
-help: Use type parameters
 info: Type variable `S` defined here
  --> UP046_0.py:5:1
   |
@@ -360,6 +359,7 @@ info: Type variable `S` defined here
 6 | T = TypeVar("T", bound=float)
 7 | Ts = TypeVarTuple("Ts")
   |
+help: Use type parameters
 
 ℹ Unsafe fix
 73 73 | class A(Generic[T]): ...
@@ -378,7 +378,6 @@ UP046 [*] Generic class `C` uses `Generic` subclass instead of type parameters
    |               ^^^^^^^^^^^^^
 81 |     var: tuple[S, T]
    |
-help: Use type parameters
 info: Type variable `S` defined here
  --> UP046_0.py:5:1
   |
@@ -398,6 +397,7 @@ info: Type variable `T` defined here
 7 | Ts = TypeVarTuple("Ts")
 8 | P = ParamSpec("P")
   |
+help: Use type parameters
 
 ℹ Unsafe fix
 77 77 |     var: S
@@ -416,7 +416,6 @@ UP046 [*] Generic class `D` uses `Generic` subclass instead of type parameters
    |                 ^^^^^^^^^^
 85 |     var: T
    |
-help: Use type parameters
 info: Type variable `T` defined here
  --> UP046_0.py:6:1
   |
@@ -426,6 +425,7 @@ info: Type variable `T` defined here
 7 | Ts = TypeVarTuple("Ts")
 8 | P = ParamSpec("P")
   |
+help: Use type parameters
 
 ℹ Unsafe fix
 81 81 |     var: tuple[S, T]

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP046_0.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP046_0.py.snap
@@ -10,6 +10,15 @@ UP046 [*] Generic class `A` uses `Generic` subclass instead of type parameters
 13 |     var: T
    |
 help: Use type parameters
+info: Type variable `T` defined here
+ --> ./resources/test/fixtures/pyupgrade/UP046_0.py:6:1
+  |
+5 | S = TypeVar("S", str, bytes)  # constrained type variable
+6 | T = TypeVar("T", bound=float)
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+7 | Ts = TypeVarTuple("Ts")
+8 | P = ParamSpec("P")
+  |
 
 ℹ Unsafe fix
 8  8  | P = ParamSpec("P")
@@ -29,6 +38,15 @@ UP046 [*] Generic class `B` uses `Generic` subclass instead of type parameters
 17 |     var: tuple[*Ts]
    |
 help: Use type parameters
+info: Type variable `Ts` defined here
+ --> ./resources/test/fixtures/pyupgrade/UP046_0.py:7:1
+  |
+5 | S = TypeVar("S", str, bytes)  # constrained type variable
+6 | T = TypeVar("T", bound=float)
+7 | Ts = TypeVarTuple("Ts")
+  | ^^^^^^^^^^^^^^^^^^^^^^^
+8 | P = ParamSpec("P")
+  |
 
 ℹ Unsafe fix
 13 13 |     var: T
@@ -48,6 +66,14 @@ UP046 [*] Generic class `C` uses `Generic` subclass instead of type parameters
 21 |     var: P
    |
 help: Use type parameters
+info: Type variable `P` defined here
+ --> ./resources/test/fixtures/pyupgrade/UP046_0.py:8:1
+  |
+6 | T = TypeVar("T", bound=float)
+7 | Ts = TypeVarTuple("Ts")
+8 | P = ParamSpec("P")
+  | ^^^^^^^^^^^^^^^^^^
+  |
 
 ℹ Unsafe fix
 17 17 |     var: tuple[*Ts]
@@ -67,6 +93,16 @@ UP046 [*] Generic class `Constrained` uses `Generic` subclass instead of type pa
 25 |     var: S
    |
 help: Use type parameters
+info: Type variable `S` defined here
+ --> ./resources/test/fixtures/pyupgrade/UP046_0.py:5:1
+  |
+3 | from somewhere import SupportsRichComparisonT
+4 |
+5 | S = TypeVar("S", str, bytes)  # constrained type variable
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+6 | T = TypeVar("T", bound=float)
+7 | Ts = TypeVarTuple("Ts")
+  |
 
 ℹ Unsafe fix
 21 21 |     var: P
@@ -120,6 +156,42 @@ UP046 [*] Generic class `MultipleGenerics` uses `Generic` subclass instead of ty
 43 |     typ: T
    |
 help: Use type parameters
+info: Type variable `S` defined here
+ --> ./resources/test/fixtures/pyupgrade/UP046_0.py:5:1
+  |
+3 | from somewhere import SupportsRichComparisonT
+4 |
+5 | S = TypeVar("S", str, bytes)  # constrained type variable
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+6 | T = TypeVar("T", bound=float)
+7 | Ts = TypeVarTuple("Ts")
+  |
+info: Type variable `T` defined here
+ --> ./resources/test/fixtures/pyupgrade/UP046_0.py:6:1
+  |
+5 | S = TypeVar("S", str, bytes)  # constrained type variable
+6 | T = TypeVar("T", bound=float)
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+7 | Ts = TypeVarTuple("Ts")
+8 | P = ParamSpec("P")
+  |
+info: Type variable `Ts` defined here
+ --> ./resources/test/fixtures/pyupgrade/UP046_0.py:7:1
+  |
+5 | S = TypeVar("S", str, bytes)  # constrained type variable
+6 | T = TypeVar("T", bound=float)
+7 | Ts = TypeVarTuple("Ts")
+  | ^^^^^^^^^^^^^^^^^^^^^^^
+8 | P = ParamSpec("P")
+  |
+info: Type variable `P` defined here
+ --> ./resources/test/fixtures/pyupgrade/UP046_0.py:8:1
+  |
+6 | T = TypeVar("T", bound=float)
+7 | Ts = TypeVarTuple("Ts")
+8 | P = ParamSpec("P")
+  | ^^^^^^^^^^^^^^^^^^
+  |
 
 ℹ Unsafe fix
 38 38 |     s: AnyStr
@@ -139,6 +211,15 @@ UP046 [*] Generic class `MultipleBaseClasses` uses `Generic` subclass instead of
 49 |     var: T
    |
 help: Use type parameters
+info: Type variable `T` defined here
+ --> ./resources/test/fixtures/pyupgrade/UP046_0.py:6:1
+  |
+5 | S = TypeVar("S", str, bytes)  # constrained type variable
+6 | T = TypeVar("T", bound=float)
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+7 | Ts = TypeVarTuple("Ts")
+8 | P = ParamSpec("P")
+  |
 
 ℹ Unsafe fix
 45 45 |     pep: P
@@ -158,6 +239,15 @@ UP046 [*] Generic class `MoreBaseClasses` uses `Generic` subclass instead of typ
 63 |     var: T
    |
 help: Use type parameters
+info: Type variable `T` defined here
+ --> ./resources/test/fixtures/pyupgrade/UP046_0.py:6:1
+  |
+5 | S = TypeVar("S", str, bytes)  # constrained type variable
+6 | T = TypeVar("T", bound=float)
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+7 | Ts = TypeVarTuple("Ts")
+8 | P = ParamSpec("P")
+  |
 
 ℹ Unsafe fix
 59 59 | class Base3: ...
@@ -178,6 +268,42 @@ UP046 [*] Generic class `MultipleBaseAndGenerics` uses `Generic` subclass instea
 68 |     typ: T
    |
 help: Use type parameters
+info: Type variable `S` defined here
+ --> ./resources/test/fixtures/pyupgrade/UP046_0.py:5:1
+  |
+3 | from somewhere import SupportsRichComparisonT
+4 |
+5 | S = TypeVar("S", str, bytes)  # constrained type variable
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+6 | T = TypeVar("T", bound=float)
+7 | Ts = TypeVarTuple("Ts")
+  |
+info: Type variable `T` defined here
+ --> ./resources/test/fixtures/pyupgrade/UP046_0.py:6:1
+  |
+5 | S = TypeVar("S", str, bytes)  # constrained type variable
+6 | T = TypeVar("T", bound=float)
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+7 | Ts = TypeVarTuple("Ts")
+8 | P = ParamSpec("P")
+  |
+info: Type variable `Ts` defined here
+ --> ./resources/test/fixtures/pyupgrade/UP046_0.py:7:1
+  |
+5 | S = TypeVar("S", str, bytes)  # constrained type variable
+6 | T = TypeVar("T", bound=float)
+7 | Ts = TypeVarTuple("Ts")
+  | ^^^^^^^^^^^^^^^^^^^^^^^
+8 | P = ParamSpec("P")
+  |
+info: Type variable `P` defined here
+ --> ./resources/test/fixtures/pyupgrade/UP046_0.py:8:1
+  |
+6 | T = TypeVar("T", bound=float)
+7 | Ts = TypeVarTuple("Ts")
+8 | P = ParamSpec("P")
+  | ^^^^^^^^^^^^^^^^^^
+  |
 
 ℹ Unsafe fix
 63 63 |     var: T
@@ -196,6 +322,15 @@ UP046 [*] Generic class `A` uses `Generic` subclass instead of type parameters
    |         ^^^^^^^^^^
    |
 help: Use type parameters
+info: Type variable `T` defined here
+ --> ./resources/test/fixtures/pyupgrade/UP046_0.py:6:1
+  |
+5 | S = TypeVar("S", str, bytes)  # constrained type variable
+6 | T = TypeVar("T", bound=float)
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+7 | Ts = TypeVarTuple("Ts")
+8 | P = ParamSpec("P")
+  |
 
 ℹ Unsafe fix
 70 70 |     pep: P
@@ -215,6 +350,16 @@ UP046 [*] Generic class `B` uses `Generic` subclass instead of type parameters
 77 |     var: S
    |
 help: Use type parameters
+info: Type variable `S` defined here
+ --> ./resources/test/fixtures/pyupgrade/UP046_0.py:5:1
+  |
+3 | from somewhere import SupportsRichComparisonT
+4 |
+5 | S = TypeVar("S", str, bytes)  # constrained type variable
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+6 | T = TypeVar("T", bound=float)
+7 | Ts = TypeVarTuple("Ts")
+  |
 
 ℹ Unsafe fix
 73 73 | class A(Generic[T]): ...
@@ -234,6 +379,25 @@ UP046 [*] Generic class `C` uses `Generic` subclass instead of type parameters
 81 |     var: tuple[S, T]
    |
 help: Use type parameters
+info: Type variable `S` defined here
+ --> ./resources/test/fixtures/pyupgrade/UP046_0.py:5:1
+  |
+3 | from somewhere import SupportsRichComparisonT
+4 |
+5 | S = TypeVar("S", str, bytes)  # constrained type variable
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+6 | T = TypeVar("T", bound=float)
+7 | Ts = TypeVarTuple("Ts")
+  |
+info: Type variable `T` defined here
+ --> ./resources/test/fixtures/pyupgrade/UP046_0.py:6:1
+  |
+5 | S = TypeVar("S", str, bytes)  # constrained type variable
+6 | T = TypeVar("T", bound=float)
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+7 | Ts = TypeVarTuple("Ts")
+8 | P = ParamSpec("P")
+  |
 
 ℹ Unsafe fix
 77 77 |     var: S
@@ -253,6 +417,15 @@ UP046 [*] Generic class `D` uses `Generic` subclass instead of type parameters
 85 |     var: T
    |
 help: Use type parameters
+info: Type variable `T` defined here
+ --> ./resources/test/fixtures/pyupgrade/UP046_0.py:6:1
+  |
+5 | S = TypeVar("S", str, bytes)  # constrained type variable
+6 | T = TypeVar("T", bound=float)
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+7 | Ts = TypeVarTuple("Ts")
+8 | P = ParamSpec("P")
+  |
 
 ℹ Unsafe fix
 81 81 |     var: tuple[S, T]


### PR DESCRIPTION
Summary
--

Now that we've handled caching for the new diagnostics, I went looking for diagnostics that could use additional annotations or sub-diagnostics that weren't already tracked in #17203. UP046 (and UP040 and UP047 if we like this one) seemed like a reasonable candidate because we check for separate type variable definitions in the same file before emitting a diagnostic. In this case, I added an info-level sub-diagnostic pointing to this type variable definition. I'm not actually sure if this is super helpful information, so I wouldn't mind closing this if others don't think it's useful.

I also added a helper `DiagnosticGuard::info` method that I think will be useful for adding this kind of sub-diagnostic in general.

I spent a while debugging why the snapshots were showing a longer path in the sub-diagnostics before remembering that we overwrite the source file for the main diagnostic here:

https://github.com/astral-sh/ruff/blob/79c949f0f75f6582782f3d5fddc65089789801d5/crates/ruff_linter/src/test.rs#L280-L288

As shown below, the sub-diagnostics look as expected in the CLI. I think we _could_ delete this part of the test code, but it results in using the longer test file names (like our new sub-diagnostics) in every snapshot. So alternatively, we may want to apply the same transformation to the sub-diagnostics (and secondary annotations) too.

Test Plan
--

Existing UP046 tests with newly expanded snapshots, as well as some manual testing in the CLI:

<img width="748" height="328" alt="image" src="https://github.com/user-attachments/assets/f48a0d1b-8f93-4403-84a8-3aabd660cf8e" />

Alternative Idea
--

I don't really love the `help:` and `info:` lines stacked so closely together, so I also tried this as a secondary annotation:

<img width="683" height="264" alt="image" src="https://github.com/user-attachments/assets/d51ea0b6-bd0c-4931-ba1f-05ed0bd16277" />

That's not implemented in the PR but could be a different route with a small change to `DiagnosticGuard::info` (and a rename of the method).