### PR TITLE
[ty] fix deferred name loading in PEP695 generic classes/functions

### DIFF
--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -728,11 +728,11 @@ mod tests {
         );
 
         // TODO: This should render T@Alias once we create GenericContexts for type alias scopes.
-        assert_snapshot!(test.hover(), @r#"
-        typing.TypeVar("T", bound=int, default=bool)
+        assert_snapshot!(test.hover(), @r###"
+        typing.TypeVar
         ---------------------------------------------
         ```python
-        typing.TypeVar("T", bound=int, default=bool)
+        typing.TypeVar
         ```
         ---------------------------------------------
         info[hover]: Hovered content is
@@ -743,7 +743,7 @@ mod tests {
           |                                              |
           |                                              source
           |
-        "#);
+        "###);
     }
 
     #[test]

--- a/crates/ty_ide/src/inlay_hints.rs
+++ b/crates/ty_ide/src/inlay_hints.rs
@@ -793,17 +793,17 @@ mod tests {
             identity('hello')",
         );
 
-        assert_snapshot!(test.inlay_hints(), @r#"
+        assert_snapshot!(test.inlay_hints(), @r###"
         from typing import TypeVar, Generic
 
-        T[: typing.TypeVar("T")] = TypeVar([name=]'T')
+        T[: typing.TypeVar] = TypeVar([name=]'T')
 
         def identity(x: T) -> T:
             return x
 
         identity([x=]42)
         identity([x=]'hello')
-        "#);
+        "###);
     }
 
     #[test]

--- a/crates/ty_python_semantic/resources/corpus/cyclic_pep695_typevars.py
+++ b/crates/ty_python_semantic/resources/corpus/cyclic_pep695_typevars.py
@@ -1,0 +1,5 @@
+def name_1[name_0: name_0](name_2: name_0):
+    try:
+        pass
+    except name_2:
+        pass

--- a/crates/ty_python_semantic/resources/corpus/except_handler_with_Any_bound_typevar.py
+++ b/crates/ty_python_semantic/resources/corpus/except_handler_with_Any_bound_typevar.py
@@ -1,9 +1,3 @@
-def name_1[name_0: name_0](name_2: name_0):
-    try:
-        pass
-    except name_2:
-        pass
-
 from typing import Any
 
 def name_2[T: Any](x: T):

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/variables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/variables.md
@@ -20,7 +20,7 @@ from typing import TypeVar
 
 T = TypeVar("T")
 reveal_type(type(T))  # revealed: <class 'TypeVar'>
-reveal_type(T)  # revealed: typing.TypeVar("T")
+reveal_type(T)  # revealed: typing.TypeVar
 reveal_type(T.__name__)  # revealed: Literal["T"]
 ```
 
@@ -80,7 +80,7 @@ from typing import TypeVar
 
 T = TypeVar("T", default=int)
 reveal_type(type(T))  # revealed: <class 'TypeVar'>
-reveal_type(T)  # revealed: typing.TypeVar("T", default=int)
+reveal_type(T)  # revealed: typing.TypeVar
 reveal_type(T.__default__)  # revealed: int
 reveal_type(T.__bound__)  # revealed: None
 reveal_type(T.__constraints__)  # revealed: tuple[()]
@@ -116,7 +116,7 @@ from typing import TypeVar
 
 T = TypeVar("T", bound=int)
 reveal_type(type(T))  # revealed: <class 'TypeVar'>
-reveal_type(T)  # revealed: typing.TypeVar("T", bound=int)
+reveal_type(T)  # revealed: typing.TypeVar
 reveal_type(T.__bound__)  # revealed: int
 reveal_type(T.__constraints__)  # revealed: tuple[()]
 
@@ -131,7 +131,7 @@ from typing import TypeVar
 
 T = TypeVar("T", int, str)
 reveal_type(type(T))  # revealed: <class 'TypeVar'>
-reveal_type(T)  # revealed: typing.TypeVar("T", int, str)
+reveal_type(T)  # revealed: typing.TypeVar
 reveal_type(T.__constraints__)  # revealed: tuple[int, str]
 
 S = TypeVar("S")

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
@@ -549,7 +549,7 @@ reveal_type(WithOverloadedMethod[int].method)
 Typevar bounds/constraints/defaults are lazy, but cannot refer to later typevars:
 
 ```py
-# error: [unresolved-reference]
+# TODO error
 class C[S: T, T]:
     pass
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
@@ -391,6 +391,7 @@ wrong_innards: C[int] = C("five", 1)
 ### Some `__init__` overloads only apply to certain specializations
 
 ```py
+from __future__ import annotations
 from typing import overload
 
 class C[T]:
@@ -541,6 +542,23 @@ class WithOverloadedMethod[T]:
 reveal_type(WithOverloadedMethod[int].method)
 ```
 
+## Scoping of typevars
+
+### No back-references
+
+Typevar bounds/constraints/defaults are lazy, but cannot refer to later typevars:
+
+```py
+# error: [unresolved-reference]
+class C[S: T, T]:
+    pass
+
+class D[S: X]:
+    pass
+
+X = int
+```
+
 ## Cyclic class definitions
 
 ### F-bounded quantification
@@ -591,7 +609,7 @@ class Derived[T](list[Derived[T]]): ...
 
 Inheritance that would result in a cyclic MRO is detected as an error.
 
-```py
+```pyi
 # error: [cyclic-class-definition]
 class C[T](C): ...
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
@@ -2,7 +2,7 @@
 
 ```toml
 [environment]
-python-version = "3.12"
+python-version = "3.13"
 ```
 
 [PEP 695] and Python 3.12 introduced new, more ergonomic syntax for type variables.
@@ -752,6 +752,8 @@ def constrained[T: (int, str)](x: T):
 A typevar's bounds and constraints cannot be generic, cyclic or otherwise:
 
 ```py
+from typing import Any
+
 # TODO: error
 def f[S, T: list[S]](x: S, y: T) -> S | T:
     return x or y
@@ -761,8 +763,8 @@ class C[S, T: list[S]]:
     x: S
     y: T
 
-reveal_type(C[int, str]().x)  # revealed: int
-reveal_type(C[int, str]().y)  # revealed: str
+reveal_type(C[int, list[Any]]().x)  # revealed: int
+reveal_type(C[int, list[Any]]().y)  # revealed: list[Any]
 
 # TODO: error
 def g[T: list[T]](x: T) -> T:
@@ -772,7 +774,7 @@ def g[T: list[T]](x: T) -> T:
 class D[T: list[T]]:
     x: T
 
-reveal_type(D[int]().x)  # revealed: int
+reveal_type(D[list[Any]]().x)  # revealed: list[Any]
 
 # TODO: error
 def h[S, T: (list[S], str)](x: S, y: T) -> S | T:
@@ -794,7 +796,7 @@ def i[T: (list[T], str)](x: T) -> T:
 class F[T: (list[T], str)]:
     x: T
 
-reveal_type(F[int]().x)  # revealed: int
+reveal_type(F[list[Any]]().x)  # revealed: list[Any]
 ```
 
 However, they are lazily evaluated and can cyclically refer to their own type:
@@ -803,7 +805,7 @@ However, they are lazily evaluated and can cyclically refer to their own type:
 class G[T: list[G]]:
     x: T
 
-reveal_type(G[list[G]]().x)  # revealed: list[G[list[G[Unknown]]]
+reveal_type(G[list[G]]().x)  # revealed: list[G[Unknown]]
 ```
 
 ### Defaults
@@ -824,7 +826,7 @@ reveal_type(C[int]().y)  # revealed: int
 class D[T = T]:
     x: T
 
-reveal_type(D().x)  # revealed: Unknown
+reveal_type(D().x)  # revealed: T@D
 ```
 
 [pep 695]: https://peps.python.org/pep-0695/

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
@@ -17,7 +17,7 @@ instances of `typing.TypeVar`, just like legacy type variables.
 ```py
 def f[T]():
     reveal_type(type(T))  # revealed: <class 'TypeVar'>
-    reveal_type(T)  # revealed: typing.TypeVar("T")
+    reveal_type(T)  # revealed: typing.TypeVar
     reveal_type(T.__name__)  # revealed: Literal["T"]
 ```
 
@@ -33,7 +33,7 @@ python-version = "3.13"
 ```py
 def f[T = int]():
     reveal_type(type(T))  # revealed: <class 'TypeVar'>
-    reveal_type(T)  # revealed: typing.TypeVar("T", default=int)
+    reveal_type(T)  # revealed: typing.TypeVar
     reveal_type(T.__default__)  # revealed: int
     reveal_type(T.__bound__)  # revealed: None
     reveal_type(T.__constraints__)  # revealed: tuple[()]
@@ -66,7 +66,7 @@ class Invalid[S = T]: ...
 ```py
 def f[T: int]():
     reveal_type(type(T))  # revealed: <class 'TypeVar'>
-    reveal_type(T)  # revealed: typing.TypeVar("T", bound=int)
+    reveal_type(T)  # revealed: typing.TypeVar
     reveal_type(T.__bound__)  # revealed: int
     reveal_type(T.__constraints__)  # revealed: tuple[()]
 
@@ -79,7 +79,7 @@ def g[S]():
 ```py
 def f[T: (int, str)]():
     reveal_type(type(T))  # revealed: <class 'TypeVar'>
-    reveal_type(T)  # revealed: typing.TypeVar("T", int, str)
+    reveal_type(T)  # revealed: typing.TypeVar
     reveal_type(T.__constraints__)  # revealed: tuple[int, str]
     reveal_type(T.__bound__)  # revealed: None
 

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2051,6 +2051,7 @@ python-version = "3.12"
 ```
 
 ```py
+from __future__ import annotations
 from typing import cast, Protocol
 
 class Iterator[T](Protocol):

--- a/crates/ty_python_semantic/resources/mdtest/scopes/eager.md
+++ b/crates/ty_python_semantic/resources/mdtest/scopes/eager.md
@@ -410,4 +410,47 @@ reveal_type(C.var)  # revealed: int | str
 x = str
 ```
 
+### Annotation scopes
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+#### Type alias annotation scopes are lazy
+
+```py
+type Foo = Bar
+
+class Bar:
+    pass
+
+def _(x: Foo):
+    if isinstance(x, Bar):
+        reveal_type(x)  # revealed: Bar
+    else:
+        reveal_type(x)  # revealed: Never
+```
+
+#### Type-param scopes are eager, but bounds/constraints are deferred
+
+```py
+# error: [unresolved-reference]
+class D[T](Bar):
+    pass
+
+class E[T: Bar]:
+    pass
+
+# error: [unresolved-reference]
+def g[T](x: Bar):
+    pass
+
+def h[T: Bar](x: T):
+    pass
+
+class Bar:
+    pass
+```
+
 [generators]: https://docs.python.org/3/reference/expressions.html#generator-expressions

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/union_call.md_-_Calling_a_union_of_f…_-_Try_to_cover_all_pos…_-_Cover_non-keyword_re…_(707b284610419a54).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/union_call.md_-_Calling_a_union_of_f…_-_Try_to_cover_all_pos…_-_Cover_non-keyword_re…_(707b284610419a54).snap
@@ -86,7 +86,7 @@ error[call-non-callable]: Object of type `Literal[5]` is not callable
    |         ^^^^
    |
 info: Union variant `Literal[5]` is incompatible with this call site
-info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> int) | (def f3(a: int, b: int) -> int) | (def f4[T: str](x: T@f4) -> int) | Literal[5] | (Overload[() -> None, (x: str) -> str]) | (Overload[() -> None, (x: str, y: str) -> str]) | PossiblyNotCallable`
+info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> int) | (def f3(a: int, b: int) -> int) | (def f4[T](x: T@f4) -> int) | Literal[5] | (Overload[() -> None, (x: str) -> str]) | (Overload[() -> None, (x: str, y: str) -> str]) | PossiblyNotCallable`
 info: rule `call-non-callable` is enabled by default
 
 ```
@@ -101,7 +101,7 @@ error[call-non-callable]: Object of type `PossiblyNotCallable` is not callable (
    |         ^^^^
    |
 info: Union variant `PossiblyNotCallable` is incompatible with this call site
-info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> int) | (def f3(a: int, b: int) -> int) | (def f4[T: str](x: T@f4) -> int) | Literal[5] | (Overload[() -> None, (x: str) -> str]) | (Overload[() -> None, (x: str, y: str) -> str]) | PossiblyNotCallable`
+info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> int) | (def f3(a: int, b: int) -> int) | (def f4[T](x: T@f4) -> int) | Literal[5] | (Overload[() -> None, (x: str) -> str]) | (Overload[() -> None, (x: str, y: str) -> str]) | PossiblyNotCallable`
 info: rule `call-non-callable` is enabled by default
 
 ```
@@ -116,7 +116,7 @@ error[missing-argument]: No argument provided for required parameter `b` of func
    |         ^^^^
    |
 info: Union variant `def f3(a: int, b: int) -> int` is incompatible with this call site
-info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> int) | (def f3(a: int, b: int) -> int) | (def f4[T: str](x: T@f4) -> int) | Literal[5] | (Overload[() -> None, (x: str) -> str]) | (Overload[() -> None, (x: str, y: str) -> str]) | PossiblyNotCallable`
+info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> int) | (def f3(a: int, b: int) -> int) | (def f4[T](x: T@f4) -> int) | Literal[5] | (Overload[() -> None, (x: str) -> str]) | (Overload[() -> None, (x: str, y: str) -> str]) | PossiblyNotCallable`
 info: rule `missing-argument` is enabled by default
 
 ```
@@ -152,7 +152,7 @@ info: Overload implementation defined here
 28 |     return x + y if x and y else None
    |
 info: Union variant `Overload[() -> None, (x: str, y: str) -> str]` is incompatible with this call site
-info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> int) | (def f3(a: int, b: int) -> int) | (def f4[T: str](x: T@f4) -> int) | Literal[5] | (Overload[() -> None, (x: str) -> str]) | (Overload[() -> None, (x: str, y: str) -> str]) | PossiblyNotCallable`
+info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> int) | (def f3(a: int, b: int) -> int) | (def f4[T](x: T@f4) -> int) | Literal[5] | (Overload[() -> None, (x: str) -> str]) | (Overload[() -> None, (x: str, y: str) -> str]) | PossiblyNotCallable`
 info: rule `no-matching-overload` is enabled by default
 
 ```
@@ -176,7 +176,7 @@ info: Function defined here
 8 |     return 0
   |
 info: Union variant `def f2(name: str) -> int` is incompatible with this call site
-info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> int) | (def f3(a: int, b: int) -> int) | (def f4[T: str](x: T@f4) -> int) | Literal[5] | (Overload[() -> None, (x: str) -> str]) | (Overload[() -> None, (x: str, y: str) -> str]) | PossiblyNotCallable`
+info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> int) | (def f3(a: int, b: int) -> int) | (def f4[T](x: T@f4) -> int) | Literal[5] | (Overload[() -> None, (x: str) -> str]) | (Overload[() -> None, (x: str, y: str) -> str]) | PossiblyNotCallable`
 info: rule `invalid-argument-type` is enabled by default
 
 ```
@@ -199,8 +199,8 @@ info: Type variable defined here
    |        ^^^^^^
 14 |     return 0
    |
-info: Union variant `def f4[T: str](x: T@f4) -> int` is incompatible with this call site
-info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> int) | (def f3(a: int, b: int) -> int) | (def f4[T: str](x: T@f4) -> int) | Literal[5] | (Overload[() -> None, (x: str) -> str]) | (Overload[() -> None, (x: str, y: str) -> str]) | PossiblyNotCallable`
+info: Union variant `def f4[T](x: T@f4) -> int` is incompatible with this call site
+info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> int) | (def f3(a: int, b: int) -> int) | (def f4[T](x: T@f4) -> int) | Literal[5] | (Overload[() -> None, (x: str) -> str]) | (Overload[() -> None, (x: str, y: str) -> str]) | PossiblyNotCallable`
 info: rule `invalid-argument-type` is enabled by default
 
 ```
@@ -227,7 +227,7 @@ info: Matching overload defined here
 info: Non-matching overloads for function `f5`:
 info:   () -> None
 info: Union variant `Overload[() -> None, (x: str) -> str]` is incompatible with this call site
-info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> int) | (def f3(a: int, b: int) -> int) | (def f4[T: str](x: T@f4) -> int) | Literal[5] | (Overload[() -> None, (x: str) -> str]) | (Overload[() -> None, (x: str, y: str) -> str]) | PossiblyNotCallable`
+info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> int) | (def f3(a: int, b: int) -> int) | (def f4[T](x: T@f4) -> int) | Literal[5] | (Overload[() -> None, (x: str) -> str]) | (Overload[() -> None, (x: str, y: str) -> str]) | PossiblyNotCallable`
 info: rule `invalid-argument-type` is enabled by default
 
 ```
@@ -242,7 +242,7 @@ error[too-many-positional-arguments]: Too many positional arguments to function 
    |           ^
    |
 info: Union variant `def f1() -> int` is incompatible with this call site
-info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> int) | (def f3(a: int, b: int) -> int) | (def f4[T: str](x: T@f4) -> int) | Literal[5] | (Overload[() -> None, (x: str) -> str]) | (Overload[() -> None, (x: str, y: str) -> str]) | PossiblyNotCallable`
+info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> int) | (def f3(a: int, b: int) -> int) | (def f4[T](x: T@f4) -> int) | Literal[5] | (Overload[() -> None, (x: str) -> str]) | (Overload[() -> None, (x: str, y: str) -> str]) | PossiblyNotCallable`
 info: rule `too-many-positional-arguments` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/src/semantic_index.rs
+++ b/crates/ty_python_semantic/src/semantic_index.rs
@@ -167,7 +167,7 @@ pub(crate) fn attribute_scopes<'db, 's>(
 
     ChildrenIter::new(index, class_scope_id).filter_map(move |(child_scope_id, scope)| {
         let (function_scope_id, function_scope) =
-            if scope.node().scope_kind() == ScopeKind::Annotation {
+            if scope.node().scope_kind() == ScopeKind::TypeParams {
                 // This could be a generic method with a type-params scope.
                 // Go one level deeper to find the function scope. The first
                 // descendant is the (potential) function scope.
@@ -597,8 +597,8 @@ impl<'a> Iterator for VisibleAncestorsIter<'a> {
             // Skip class scopes for subsequent scopes (following Python's lexical scoping rules)
             // Exception: type parameter scopes can see names defined in an immediately-enclosing class scope
             if scope.kind() == ScopeKind::Class {
-                // Allow type parameter scopes to see their immediately-enclosing class scope exactly once
-                if self.starting_scope_kind.is_type_parameter() && self.yielded_count == 2 {
+                // Allow annotation scopes to see their immediately-enclosing class scope exactly once
+                if self.starting_scope_kind.is_annotation() && self.yielded_count == 2 {
                     return Some((scope_id, scope));
                 }
                 continue;
@@ -1317,7 +1317,7 @@ def func[T]():
             panic!("expected one child scope");
         };
 
-        assert_eq!(ann_scope.kind(), ScopeKind::Annotation);
+        assert_eq!(ann_scope.kind(), ScopeKind::TypeParams);
         assert_eq!(
             ann_scope_id.to_scope_id(&db, file).name(&db, &module),
             "func"
@@ -1361,7 +1361,7 @@ class C[T]:
             panic!("expected one child scope");
         };
 
-        assert_eq!(ann_scope.kind(), ScopeKind::Annotation);
+        assert_eq!(ann_scope.kind(), ScopeKind::TypeParams);
         assert_eq!(ann_scope_id.to_scope_id(&db, file).name(&db, &module), "C");
         let ann_table = index.place_table(ann_scope_id);
         assert_eq!(names(&ann_table), vec!["T"]);

--- a/crates/ty_python_semantic/src/semantic_index/builder.rs
+++ b/crates/ty_python_semantic/src/semantic_index/builder.rs
@@ -199,7 +199,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
         match self.scopes[parent.file_scope_id].kind() {
             ScopeKind::Class => Some(parent.file_scope_id),
-            ScopeKind::Annotation => {
+            ScopeKind::TypeParams => {
                 // If the function is generic, the parent scope is an annotation scope.
                 // In this case, we need to go up one level higher to find the class scope.
                 let grandparent = scopes_rev.next()?;
@@ -2637,7 +2637,7 @@ impl SemanticSyntaxContext for SemanticIndexBuilder<'_, '_> {
                 ScopeKind::Comprehension
                 | ScopeKind::Module
                 | ScopeKind::TypeAlias
-                | ScopeKind::Annotation => {}
+                | ScopeKind::TypeParams => {}
             }
         }
         false
@@ -2652,7 +2652,7 @@ impl SemanticSyntaxContext for SemanticIndexBuilder<'_, '_> {
                 ScopeKind::Comprehension
                 | ScopeKind::Module
                 | ScopeKind::TypeAlias
-                | ScopeKind::Annotation => {}
+                | ScopeKind::TypeParams => {}
             }
         }
         false
@@ -2664,7 +2664,7 @@ impl SemanticSyntaxContext for SemanticIndexBuilder<'_, '_> {
             match scope.kind() {
                 ScopeKind::Class | ScopeKind::Comprehension => return false,
                 ScopeKind::Function | ScopeKind::Lambda => return true,
-                ScopeKind::Module | ScopeKind::TypeAlias | ScopeKind::Annotation => {}
+                ScopeKind::Module | ScopeKind::TypeAlias | ScopeKind::TypeParams => {}
             }
         }
         false

--- a/crates/ty_python_semantic/src/semantic_index/definition.rs
+++ b/crates/ty_python_semantic/src/semantic_index/definition.rs
@@ -702,7 +702,7 @@ impl DefinitionKind<'_> {
         )
     }
 
-    pub(crate) fn into_typevar(&self) -> Option<&AstNodeRef<ast::TypeParamTypeVar>> {
+    pub(crate) fn as_typevar(&self) -> Option<&AstNodeRef<ast::TypeParamTypeVar>> {
         match self {
             DefinitionKind::TypeVar(type_var) => Some(type_var),
             _ => None,

--- a/crates/ty_python_semantic/src/semantic_index/definition.rs
+++ b/crates/ty_python_semantic/src/semantic_index/definition.rs
@@ -702,6 +702,13 @@ impl DefinitionKind<'_> {
         )
     }
 
+    pub(crate) fn into_typevar(&self) -> Option<&AstNodeRef<ast::TypeParamTypeVar>> {
+        match self {
+            DefinitionKind::TypeVar(type_var) => Some(type_var),
+            _ => None,
+        }
+    }
+
     /// Returns the [`TextRange`] of the definition target.
     ///
     /// A definition target would mainly be the node representing the place being defined i.e.,

--- a/crates/ty_python_semantic/src/semantic_index/scope.rs
+++ b/crates/ty_python_semantic/src/semantic_index/scope.rs
@@ -33,10 +33,6 @@ impl<'db> ScopeId<'db> {
         self.node(db).scope_kind().is_annotation()
     }
 
-    pub(crate) fn is_type_parameter(self, db: &'db dyn Db) -> bool {
-        self.node(db).scope_kind().is_type_parameter()
-    }
-
     pub(crate) fn node(self, db: &dyn Db) -> &NodeWithScopeKind {
         self.scope(db).node()
     }
@@ -261,10 +257,6 @@ impl ScopeKind {
 
     pub(crate) const fn is_annotation(self) -> bool {
         matches!(self, ScopeKind::TypeParams | ScopeKind::TypeAlias)
-    }
-
-    pub(crate) const fn is_type_parameter(self) -> bool {
-        matches!(self, ScopeKind::TypeParams)
     }
 
     pub(crate) const fn is_non_lambda_function(self) -> bool {

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -7004,7 +7004,7 @@ impl<'db> TypeVarInstance<'db> {
     fn lazy_bound(self, db: &'db dyn Db) -> Option<TypeVarBoundOrConstraints<'db>> {
         let definition = self.definition(db)?;
         let module = parsed_module(db, definition.file(db)).load(db);
-        let typevar_node = definition.kind(db).into_typevar()?.node(&module);
+        let typevar_node = definition.kind(db).as_typevar()?.node(&module);
         let ty = definition_expression_type(db, definition, typevar_node.bound.as_ref()?);
         Some(TypeVarBoundOrConstraints::UpperBound(ty))
     }
@@ -7013,7 +7013,7 @@ impl<'db> TypeVarInstance<'db> {
     fn lazy_constraints(self, db: &'db dyn Db) -> Option<TypeVarBoundOrConstraints<'db>> {
         let definition = self.definition(db)?;
         let module = parsed_module(db, definition.file(db)).load(db);
-        let typevar_node = definition.kind(db).into_typevar()?.node(&module);
+        let typevar_node = definition.kind(db).as_typevar()?.node(&module);
         let ty = definition_expression_type(db, definition, typevar_node.bound.as_ref()?)
             .into_union()?;
         Some(TypeVarBoundOrConstraints::Constraints(ty))
@@ -7023,7 +7023,7 @@ impl<'db> TypeVarInstance<'db> {
     fn lazy_default(self, db: &'db dyn Db) -> Option<Type<'db>> {
         let definition = self.definition(db)?;
         let module = parsed_module(db, definition.file(db)).load(db);
-        let typevar_node = definition.kind(db).into_typevar()?.node(&module);
+        let typevar_node = definition.kind(db).as_typevar()?.node(&module);
         Some(definition_expression_type(
             db,
             definition,

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -6949,24 +6949,14 @@ impl<'db> TypeVarInstance<'db> {
             self._bound_or_constraints(db)
                 .and_then(|bound_or_constraints| match bound_or_constraints {
                     TypeVarBoundOrConstraintsEvaluation::Eager(bound_or_constraints) => {
-                        Some(TypeVarBoundOrConstraintsEvaluation::Eager(
-                            bound_or_constraints.normalized_impl(db, visitor),
-                        ))
+                        Some(bound_or_constraints.normalized_impl(db, visitor).into())
                     }
-                    TypeVarBoundOrConstraintsEvaluation::LazyUpperBound => {
-                        self.lazy_bound(db).map(|bound| {
-                            TypeVarBoundOrConstraintsEvaluation::Eager(
-                                bound.normalized_impl(db, visitor),
-                            )
-                        })
-                    }
-                    TypeVarBoundOrConstraintsEvaluation::LazyConstraints => {
-                        self.lazy_constraints(db).map(|constraints| {
-                            TypeVarBoundOrConstraintsEvaluation::Eager(
-                                constraints.normalized_impl(db, visitor),
-                            )
-                        })
-                    }
+                    TypeVarBoundOrConstraintsEvaluation::LazyUpperBound => self
+                        .lazy_bound(db)
+                        .map(|bound| bound.normalized_impl(db, visitor).into()),
+                    TypeVarBoundOrConstraintsEvaluation::LazyConstraints => self
+                        .lazy_constraints(db)
+                        .map(|constraints| constraints.normalized_impl(db, visitor).into()),
                 }),
             self.variance(db),
             self._default(db).and_then(|default| match default {
@@ -6987,24 +6977,14 @@ impl<'db> TypeVarInstance<'db> {
             self._bound_or_constraints(db)
                 .and_then(|bound_or_constraints| match bound_or_constraints {
                     TypeVarBoundOrConstraintsEvaluation::Eager(bound_or_constraints) => {
-                        Some(TypeVarBoundOrConstraintsEvaluation::Eager(
-                            bound_or_constraints.materialize(db, variance),
-                        ))
+                        Some(bound_or_constraints.materialize(db, variance).into())
                     }
-                    TypeVarBoundOrConstraintsEvaluation::LazyUpperBound => {
-                        self.lazy_bound(db).map(|bound| {
-                            TypeVarBoundOrConstraintsEvaluation::Eager(
-                                bound.materialize(db, variance),
-                            )
-                        })
-                    }
-                    TypeVarBoundOrConstraintsEvaluation::LazyConstraints => {
-                        self.lazy_constraints(db).map(|constraints| {
-                            TypeVarBoundOrConstraintsEvaluation::Eager(
-                                constraints.materialize(db, variance),
-                            )
-                        })
-                    }
+                    TypeVarBoundOrConstraintsEvaluation::LazyUpperBound => self
+                        .lazy_bound(db)
+                        .map(|bound| bound.materialize(db, variance).into()),
+                    TypeVarBoundOrConstraintsEvaluation::LazyConstraints => self
+                        .lazy_constraints(db)
+                        .map(|constraints| constraints.materialize(db, variance).into()),
                 }),
             self.variance(db),
             self._default(db).and_then(|default| match default {

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -6423,9 +6423,7 @@ impl<'db> KnownInstanceType<'db> {
                     // This is a legacy `TypeVar` _outside_ of any generic class or function, so we render
                     // it as an instance of `typing.TypeVar`. Inside of a generic class or function, we'll
                     // have a `Type::TypeVar(_)`, which is rendered as the typevar's name.
-                    KnownInstanceType::TypeVar(typevar) => {
-                        write!(f, "typing.TypeVar({})", typevar.display(self.db))
-                    }
+                    KnownInstanceType::TypeVar(_) => f.write_str("typing.TypeVar"),
                     KnownInstanceType::Deprecated(_) => f.write_str("warnings.deprecated"),
                     KnownInstanceType::Field(field) => {
                         f.write_str("dataclasses.Field[")?;

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -397,7 +397,7 @@ impl<'db> Bindings<'db> {
                                     }
                                     Some("__default__") => {
                                         overload.set_return_type(
-                                            typevar.default_ty(db).unwrap_or_else(|| {
+                                            typevar.default_type(db).unwrap_or_else(|| {
                                                 KnownClass::NoDefaultType.to_instance(db)
                                             }),
                                         );

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -4558,7 +4558,7 @@ impl KnownClass {
                         Some(containing_assignment),
                         bound_or_constraint,
                         variance,
-                        default.map(|ty| TypeVarDefault::Eager(ty)),
+                        default.map(TypeVarDefault::Eager),
                         TypeVarKind::Legacy,
                     ),
                 )));

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -24,9 +24,9 @@ use crate::types::tuple::{TupleSpec, TupleType};
 use crate::types::{
     ApplyTypeMappingVisitor, BareTypeAliasType, Binding, BoundSuperError, BoundSuperType,
     CallableType, DataclassParams, DeprecatedInstance, HasRelationToVisitor, KnownInstanceType,
-    LazyTypeVarBoundOrConstraints, NormalizedVisitor, StringLiteralType, TypeAliasType,
-    TypeMapping, TypeRelation, TypeVarBoundOrConstraints, TypeVarDefault, TypeVarInstance,
-    TypeVarKind, declaration_type, infer_definition_types, todo_type,
+    NormalizedVisitor, StringLiteralType, TypeAliasType, TypeMapping, TypeRelation,
+    TypeVarBoundOrConstraints, TypeVarInstance, TypeVarKind, declaration_type,
+    infer_definition_types, todo_type,
 };
 use crate::{
     Db, FxIndexMap, FxOrderSet, Program,
@@ -4520,9 +4520,9 @@ impl KnownClass {
                 }
 
                 let bound_or_constraint = match (bound, constraints) {
-                    (Some(bound), None) => Some(LazyTypeVarBoundOrConstraints::Eager(
-                        TypeVarBoundOrConstraints::UpperBound(*bound),
-                    )),
+                    (Some(bound), None) => {
+                        Some(TypeVarBoundOrConstraints::UpperBound(*bound).into())
+                    }
 
                     (None, Some(_constraints)) => {
                         // We don't use UnionType::from_elements or UnionBuilder here,
@@ -4538,9 +4538,7 @@ impl KnownClass {
                                 .map(|(_, ty)| ty)
                                 .collect::<Box<_>>(),
                         );
-                        Some(LazyTypeVarBoundOrConstraints::Eager(
-                            TypeVarBoundOrConstraints::Constraints(elements),
-                        ))
+                        Some(TypeVarBoundOrConstraints::Constraints(elements).into())
                     }
 
                     // TODO: Emit a diagnostic that TypeVar cannot be both bounded and
@@ -4558,7 +4556,7 @@ impl KnownClass {
                         Some(containing_assignment),
                         bound_or_constraint,
                         variance,
-                        default.map(TypeVarDefault::Eager),
+                        default.map(Into::into),
                         TypeVarKind::Legacy,
                     ),
                 )));

--- a/crates/ty_python_semantic/src/types/cyclic.rs
+++ b/crates/ty_python_semantic/src/types/cyclic.rs
@@ -38,6 +38,7 @@ impl Default for TypeTransformer<'_> {
     }
 }
 
+pub(crate) type TypeVisitor<'db> = CycleDetector<Type<'db>, bool>;
 pub(crate) type PairVisitor<'db> = CycleDetector<(Type<'db>, Type<'db>), bool>;
 
 #[derive(Debug)]

--- a/crates/ty_python_semantic/src/types/cyclic.rs
+++ b/crates/ty_python_semantic/src/types/cyclic.rs
@@ -38,7 +38,6 @@ impl Default for TypeTransformer<'_> {
     }
 }
 
-pub(crate) type TypeVisitor<'db> = CycleDetector<Type<'db>, bool>;
 pub(crate) type PairVisitor<'db> = CycleDetector<(Type<'db>, Type<'db>), bool>;
 
 #[derive(Debug)]

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -442,7 +442,7 @@ impl Display for DisplayTypeVarInstance<'_> {
             }
             None => {}
         }
-        if let Some(default_type) = self.typevar.default_ty(self.db) {
+        if let Some(default_type) = self.typevar.default_type(self.db) {
             write!(f, ", default={}", default_type.display(self.db))?;
         }
         Ok(())
@@ -487,7 +487,7 @@ impl Display for DisplayBoundTypeVarInstance<'_> {
             }
             None => {}
         }
-        if let Some(default_type) = self.bound_typevar.default_ty(self.db) {
+        if let Some(default_type) = self.bound_typevar.default_type(self.db) {
             write!(f, " = {}", default_type.display(self.db))?;
         }
         Ok(())

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -14,9 +14,8 @@ use crate::types::generics::{GenericContext, Specialization};
 use crate::types::signatures::{CallableSignature, Parameter, Parameters, Signature};
 use crate::types::tuple::TupleSpec;
 use crate::types::{
-    BoundTypeVarInstance, CallableType, IntersectionType, KnownClass, MethodWrapperKind, Protocol,
-    StringLiteralType, SubclassOfInner, Type, TypeVarBoundOrConstraints, TypeVarInstance,
-    UnionType, WrapperDescriptorKind,
+    CallableType, IntersectionType, KnownClass, MethodWrapperKind, Protocol, StringLiteralType,
+    SubclassOfInner, Type, UnionType, WrapperDescriptorKind,
 };
 
 impl<'db> Type<'db> {
@@ -417,83 +416,6 @@ impl Display for DisplayGenericAlias<'_> {
     }
 }
 
-impl<'db> TypeVarInstance<'db> {
-    pub(crate) fn display(self, db: &'db dyn Db) -> DisplayTypeVarInstance<'db> {
-        DisplayTypeVarInstance { typevar: self, db }
-    }
-}
-
-pub(crate) struct DisplayTypeVarInstance<'db> {
-    typevar: TypeVarInstance<'db>,
-    db: &'db dyn Db,
-}
-
-impl Display for DisplayTypeVarInstance<'_> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        display_quoted_string(self.typevar.name(self.db)).fmt(f)?;
-        match self.typevar.bound_or_constraints(self.db) {
-            Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
-                write!(f, ", bound={}", bound.display(self.db))?;
-            }
-            Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
-                for constraint in constraints.iter(self.db) {
-                    write!(f, ", {}", constraint.display(self.db))?;
-                }
-            }
-            None => {}
-        }
-        if let Some(default_type) = self.typevar.default_type(self.db) {
-            write!(f, ", default={}", default_type.display(self.db))?;
-        }
-        Ok(())
-    }
-}
-
-impl<'db> BoundTypeVarInstance<'db> {
-    pub(crate) fn display(self, db: &'db dyn Db) -> DisplayBoundTypeVarInstance<'db> {
-        DisplayBoundTypeVarInstance {
-            bound_typevar: self,
-            db,
-        }
-    }
-}
-
-pub(crate) struct DisplayBoundTypeVarInstance<'db> {
-    bound_typevar: BoundTypeVarInstance<'db>,
-    db: &'db dyn Db,
-}
-
-impl Display for DisplayBoundTypeVarInstance<'_> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        // This looks very much like DisplayTypeVarInstance::fmt, but note that we have typevar
-        // default values in a subtly different way: if the default value contains other typevars,
-        // here those must be bound as well, whereas in DisplayTypeVarInstance they should not. See
-        // BoundTypeVarInstance::default_ty for more details.
-        let typevar = self.bound_typevar.typevar(self.db);
-        f.write_str(typevar.name(self.db))?;
-        match typevar.bound_or_constraints(self.db) {
-            Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
-                write!(f, ": {}", bound.display(self.db))?;
-            }
-            Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
-                f.write_str(": (")?;
-                for (idx, constraint) in constraints.iter(self.db).enumerate() {
-                    if idx > 0 {
-                        f.write_str(", ")?;
-                    }
-                    constraint.display(self.db).fmt(f)?;
-                }
-                f.write_char(')')?;
-            }
-            None => {}
-        }
-        if let Some(default_type) = self.bound_typevar.default_type(self.db) {
-            write!(f, " = {}", default_type.display(self.db))?;
-        }
-        Ok(())
-    }
-}
-
 impl<'db> GenericContext<'db> {
     pub fn display(&'db self, db: &'db dyn Db) -> DisplayGenericContext<'db> {
         DisplayGenericContext {
@@ -545,7 +467,7 @@ impl Display for DisplayGenericContext<'_> {
             if idx > 0 {
                 f.write_str(", ")?;
             }
-            bound_typevar.display(self.db).fmt(f)?;
+            f.write_str(bound_typevar.typevar(self.db).name(self.db))?;
         }
         f.write_char(']')
     }

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -224,7 +224,7 @@ impl<'db> GenericContext<'db> {
             }
             None => {}
         }
-        if let Some(default_ty) = bound_typevar.default_ty(db) {
+        if let Some(default_ty) = bound_typevar.default_type(db) {
             parameter = parameter.with_default_type(default_ty);
         }
         parameter
@@ -336,7 +336,7 @@ impl<'db> GenericContext<'db> {
                 continue;
             }
 
-            let Some(default) = typevar.default_ty(db) else {
+            let Some(default) = typevar.default_type(db) else {
                 continue;
             };
 
@@ -755,7 +755,7 @@ impl<'db> SpecializationBuilder<'db> {
                 self.types
                     .get(variable)
                     .copied()
-                    .unwrap_or(variable.default_ty(self.db).unwrap_or(Type::unknown()))
+                    .unwrap_or(variable.default_type(self.db).unwrap_or(Type::unknown()))
             })
             .collect();
         // TODO Infer the tuple spec for a tuple type

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -3464,7 +3464,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 self.infer_type_expression(expr);
             }
             None => {}
-        };
+        }
         self.infer_optional_type_expression(default.as_deref());
     }
 

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -11565,32 +11565,14 @@ mod tests {
             );
         };
 
-        check_typevar("T", "typing.TypeVar(\"T\")", None, None, None);
-        check_typevar("U", "typing.TypeVar(\"U\", bound=A)", Some("A"), None, None);
-        check_typevar(
-            "V",
-            "typing.TypeVar(\"V\", A, B)",
-            None,
-            Some(&["A", "B"]),
-            None,
-        );
-        check_typevar(
-            "W",
-            "typing.TypeVar(\"W\", default=A)",
-            None,
-            None,
-            Some("A"),
-        );
-        check_typevar(
-            "X",
-            "typing.TypeVar(\"X\", bound=A, default=A1)",
-            Some("A"),
-            None,
-            Some("A1"),
-        );
+        check_typevar("T", "typing.TypeVar", None, None, None);
+        check_typevar("U", "typing.TypeVar", Some("A"), None, None);
+        check_typevar("V", "typing.TypeVar", None, Some(&["A", "B"]), None);
+        check_typevar("W", "typing.TypeVar", None, None, Some("A"));
+        check_typevar("X", "typing.TypeVar", Some("A"), None, Some("A1"));
 
         // a typevar with less than two constraints is treated as unconstrained
-        check_typevar("Y", "typing.TypeVar(\"Y\")", None, None, None);
+        check_typevar("Y", "typing.TypeVar", None, None, None);
     }
 
     /// Test that a symbol known to be unbound in a scope does not still trigger cycle-causing

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -118,12 +118,12 @@ use crate::types::tuple::{Tuple, TupleSpec, TupleSpecBuilder, TupleType};
 use crate::types::unpacker::{UnpackResult, Unpacker};
 use crate::types::{
     CallDunderError, CallableType, ClassLiteral, ClassType, DataclassParams, DynamicType,
-    IntersectionBuilder, IntersectionType, KnownClass, KnownInstanceType,
-    LazyTypeVarBoundOrConstraints, LintDiagnosticGuard, MemberLookupPolicy, MetaclassCandidate,
-    PEP695TypeAliasType, Parameter, ParameterForm, Parameters, SpecialFormType, SubclassOfType,
-    Truthiness, Type, TypeAliasType, TypeAndQualifiers, TypeIsType, TypeQualifiers, TypeVarDefault,
-    TypeVarInstance, TypeVarKind, TypeVarVariance, UnionBuilder, UnionType, binding_type,
-    todo_type,
+    IntersectionBuilder, IntersectionType, KnownClass, KnownInstanceType, LintDiagnosticGuard,
+    MemberLookupPolicy, MetaclassCandidate, PEP695TypeAliasType, Parameter, ParameterForm,
+    Parameters, SpecialFormType, SubclassOfType, Truthiness, Type, TypeAliasType,
+    TypeAndQualifiers, TypeIsType, TypeQualifiers, TypeVarBoundOrConstraintsEvaluation,
+    TypeVarDefaultEvaluation, TypeVarInstance, TypeVarKind, TypeVarVariance, UnionBuilder,
+    UnionType, binding_type, todo_type,
 };
 use crate::unpack::{EvaluationMode, Unpack, UnpackPosition};
 use crate::util::diagnostics::format_enumeration;
@@ -3412,10 +3412,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     }
                     None
                 } else {
-                    Some(LazyTypeVarBoundOrConstraints::LazyConstraints)
+                    Some(TypeVarBoundOrConstraintsEvaluation::LazyConstraints)
                 }
             }
-            Some(_) => Some(LazyTypeVarBoundOrConstraints::LazyUpperBound),
+            Some(_) => Some(TypeVarBoundOrConstraintsEvaluation::LazyUpperBound),
             None => None,
         };
         if bound_or_constraint.is_some() || default.is_some() {
@@ -3427,7 +3427,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             Some(definition),
             bound_or_constraint,
             TypeVarVariance::Invariant, // TODO: infer this
-            default.as_deref().map(|_| TypeVarDefault::Lazy),
+            default.as_deref().map(|_| TypeVarDefaultEvaluation::Lazy),
             TypeVarKind::Pep695,
         )));
         self.add_declaration_with_binding(

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1783,11 +1783,7 @@ mod tests {
         };
         assert_eq!(a_name, "a");
         assert_eq!(b_name, "b");
-        // TODO resolution should not be deferred; we should see A, not A | B
-        assert_eq!(
-            a_annotated_ty.unwrap().display(&db).to_string(),
-            "Unknown | A | B"
-        );
+        assert_eq!(a_annotated_ty.unwrap().display(&db).to_string(), "A");
         assert_eq!(b_annotated_ty.unwrap().display(&db).to_string(), "T@f");
     }
 

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -3,8 +3,9 @@ use ruff_python_ast::name::Name;
 use crate::place::PlaceAndQualifiers;
 use crate::semantic_index::definition::Definition;
 use crate::types::{
-    BindingContext, BoundTypeVarInstance, ClassType, DynamicType, KnownClass, MemberLookupPolicy,
-    Type, TypeMapping, TypeRelation, TypeTransformer, TypeVarInstance, cyclic::PairVisitor,
+    BindingContext, BoundTypeVarInstance, ClassType, DynamicType, KnownClass,
+    LazyTypeVarBoundOrConstraints, MemberLookupPolicy, Type, TypeMapping, TypeRelation,
+    TypeTransformer, TypeVarInstance, cyclic::PairVisitor,
 };
 use crate::{Db, FxOrderSet};
 
@@ -96,8 +97,10 @@ impl<'db> SubclassOfType<'db> {
                             db,
                             Name::new_static("T_all"),
                             None,
-                            Some(TypeVarBoundOrConstraints::UpperBound(
-                                KnownClass::Type.to_instance(db),
+                            Some(LazyTypeVarBoundOrConstraints::Eager(
+                                TypeVarBoundOrConstraints::UpperBound(
+                                    KnownClass::Type.to_instance(db),
+                                ),
                             )),
                             variance,
                             None,

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -4,8 +4,8 @@ use crate::place::PlaceAndQualifiers;
 use crate::semantic_index::definition::Definition;
 use crate::types::{
     ApplyTypeMappingVisitor, BindingContext, BoundTypeVarInstance, ClassType, DynamicType,
-    HasRelationToVisitor, KnownClass, LazyTypeVarBoundOrConstraints, MemberLookupPolicy,
-    NormalizedVisitor, Type, TypeMapping, TypeRelation, TypeVarInstance,
+    HasRelationToVisitor, KnownClass, MemberLookupPolicy, NormalizedVisitor, Type, TypeMapping,
+    TypeRelation, TypeVarInstance,
 };
 use crate::{Db, FxOrderSet};
 
@@ -97,11 +97,12 @@ impl<'db> SubclassOfType<'db> {
                             db,
                             Name::new_static("T_all"),
                             None,
-                            Some(LazyTypeVarBoundOrConstraints::Eager(
+                            Some(
                                 TypeVarBoundOrConstraints::UpperBound(
                                     KnownClass::Type.to_instance(db),
-                                ),
-                            )),
+                                )
+                                .into(),
+                            ),
                             variance,
                             None,
                             TypeVarKind::Pep695,


### PR DESCRIPTION
## Summary

For PEP 695 generic functions and classes, there is an extra "type params scope" (a child of the outer scope, and wrapping the body scope) in which the type parameters are defined; class bases and function parameter/return annotations are resolved in that type-params scope.

This PR fixes some longstanding bugs in how we resolve name loads from inside these PEP 695 type parameter scopes, and also defers type inference of PEP 695 typevar bounds/constraints/default, so we can handle cycles without panicking.

We were previously treating these type-param scopes as lazy nested scopes, which is wrong. In fact they are eager nested scopes; the class `C` here inherits `int`, not `str`, and previously we got that wrong:

```py
Base = int

class C[T](Base): ...

Base = str
```

But certain syntactic positions within type param scopes (typevar bounds/constraints/defaults) are lazy at runtime, and we should use deferred name resolution for them. This also means they can have cycles; in order to handle that without panicking in type inference, we need to actually defer their type inference until after we have constructed the `TypeVarInstance`.

PEP 695 does specify that typevar bounds and constraints cannot be generic, and that typevar defaults can only reference prior typevars, not later ones. This reduces the scope of (valid from the type-system perspective) cycles somewhat, although cycles are still possible (e.g. `class C[T: list[C]]`). And this is a type-system-only restriction; from the runtime perspective an "invalid" case like `class C[T: T]` actually works fine.

I debated whether to implement the PEP 695 restrictions as a way to avoid some cycles up-front, but I ended up deciding against that; I'd rather model the runtime name-resolution semantics accurately, and implement the PEP 695 restrictions as a separate diagnostic on top. (This PR doesn't yet implement those diagnostics, thus some `# TODO: error` in the added tests.)

Introducing the possibility of cyclic typevars made typevar display potentially stack overflow. For now I've handled this by simply removing typevar details (bounds/constraints/default) from typevar display. This impacts display of two kinds of types. If you `reveal_type(T)` on an unbound `T` you now get just `typing.TypeVar` instead of `typing.TypeVar("T", ...)` where `...` is the bound/constraints/default. This matches pyright and mypy; pyrefly uses `type[TypeVar[T]]` which seems a bit confusing, but does include the name. (We could easily include the name without cycle issues, if there's a syntax we like for that.)

It also means that displaying a generic function type like `def f[T: int](x: T) -> T: ...` now displays as `f[T](x: T) -> T` instead of `f[T: int](x: T) -> T`. This matches pyright and pyrefly; mypy does include bound/constraints/defaults of typevars in function/callable type display. If we wanted to add this, we would either need to thread a visitor through all the type display code, or add a `decycle` type transformation that replaced recursive reoccurrence of a type with a marker.

## Test Plan

Added mdtests and modified existing tests to improve their correctness.

After this PR, there's only a single remaining py-fuzzer seed in the 0-500 range that panics! (Before this PR, there were 10; the fuzzer likes to generate cyclic PEP 695 syntax.)

## Ecosystem report

It's all just the changes to `TypeVar` display.