### PR TITLE
[ty] Reduce allocations in `tuple.rs`

### DIFF
--- a/crates/ty_python_semantic/src/types/call/arguments.rs
+++ b/crates/ty_python_semantic/src/types/call/arguments.rs
@@ -358,9 +358,9 @@ mod tests {
         // Variable-length tuples are not expanded.
         let variable_length_tuple = Type::tuple(TupleType::mixed(
             &db,
-            [bool_ty],
+            std::iter::once(bool_ty),
             int_ty,
-            [UnionType::from_elements(&db, [str_ty, bytes_ty]), str_ty],
+            [UnionType::from_elements(&db, [str_ty, bytes_ty]), str_ty].into_iter(),
         ));
         let expanded = expand_type(&db, variable_length_tuple);
         assert!(expanded.is_none());

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -722,7 +722,8 @@ impl<'db> ClassType<'db> {
                             //    __getitem__(self, index: Literal[-3], /) -> float | str
                             //
                             TupleSpec::Variable(variable_length_tuple) => {
-                                for (index, ty) in variable_length_tuple.prefix.iter().enumerate() {
+                                for (index, ty) in variable_length_tuple.prefix().iter().enumerate()
+                                {
                                     if let Ok(index) = i64::try_from(index) {
                                         element_type_to_indices.entry(*ty).or_default().push(index);
                                     }
@@ -730,18 +731,18 @@ impl<'db> ClassType<'db> {
                                     let one_based_index = index + 1;
 
                                     if let Ok(i) = i64::try_from(
-                                        variable_length_tuple.suffix.len() + one_based_index,
+                                        variable_length_tuple.suffix().len() + one_based_index,
                                     ) {
                                         let overload_return = UnionType::from_elements(
                                             db,
-                                            std::iter::once(variable_length_tuple.variable).chain(
-                                                variable_length_tuple
-                                                    .prefix
-                                                    .iter()
-                                                    .rev()
-                                                    .take(one_based_index)
-                                                    .copied(),
-                                            ),
+                                            std::iter::once(variable_length_tuple.variable())
+                                                .chain(
+                                                    variable_length_tuple
+                                                        .prefix()
+                                                        .iter()
+                                                        .rev()
+                                                        .take(one_based_index),
+                                                ),
                                         );
                                         element_type_to_indices
                                             .entry(overload_return)
@@ -751,7 +752,7 @@ impl<'db> ClassType<'db> {
                                 }
 
                                 for (index, ty) in
-                                    variable_length_tuple.suffix.iter().rev().enumerate()
+                                    variable_length_tuple.suffix().iter().rev().enumerate()
                                 {
                                     if let Some(index) =
                                         index.checked_add(1).and_then(|i| i64::try_from(i).ok())
@@ -763,17 +764,17 @@ impl<'db> ClassType<'db> {
                                     }
 
                                     if let Ok(i) =
-                                        i64::try_from(variable_length_tuple.prefix.len() + index)
+                                        i64::try_from(variable_length_tuple.prefix().len() + index)
                                     {
                                         let overload_return = UnionType::from_elements(
                                             db,
-                                            std::iter::once(variable_length_tuple.variable).chain(
-                                                variable_length_tuple
-                                                    .suffix
-                                                    .iter()
-                                                    .take(index + 1)
-                                                    .copied(),
-                                            ),
+                                            std::iter::once(variable_length_tuple.variable())
+                                                .chain(
+                                                    variable_length_tuple
+                                                        .suffix()
+                                                        .iter()
+                                                        .take(index + 1),
+                                                ),
                                         );
                                         element_type_to_indices
                                             .entry(overload_return)

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -287,21 +287,21 @@ impl Display for DisplayTuple<'_> {
             // S is included if there is either a prefix or a suffix. The initial `tuple[` and
             // trailing `]` are printed elsewhere. The `yyy, ...` is printed no matter what.)
             TupleSpec::Variable(tuple) => {
-                if !tuple.prefix.is_empty() {
-                    tuple.prefix.display(self.db).fmt(f)?;
+                if !tuple.prefix().is_empty() {
+                    tuple.prefix().display(self.db).fmt(f)?;
                     f.write_str(", ")?;
                 }
-                if !tuple.prefix.is_empty() || !tuple.suffix.is_empty() {
+                if !tuple.prefix().is_empty() || !tuple.suffix().is_empty() {
                     f.write_str("*tuple[")?;
                 }
-                tuple.variable.display(self.db).fmt(f)?;
+                tuple.variable().display(self.db).fmt(f)?;
                 f.write_str(", ...")?;
-                if !tuple.prefix.is_empty() || !tuple.suffix.is_empty() {
+                if !tuple.prefix().is_empty() || !tuple.suffix().is_empty() {
                     f.write_str("]")?;
                 }
-                if !tuple.suffix.is_empty() {
+                if !tuple.suffix().is_empty() {
                     f.write_str(", ")?;
-                    tuple.suffix.display(self.db).fmt(f)?;
+                    tuple.suffix().display(self.db).fmt(f)?;
                 }
             }
         }


### PR DESCRIPTION
## Summary

The vast majority of real-world variable-length tuples are "pure homogeneous" tuples with no prefix and no suffix. We can optimize for the common case by using `Option<Box<[T]>>` for these fields rather than `Box<[T]>`, which in many cases allows us to avoid allocating.

An alternative approach here would be to use a different `Tuple` variant entirely for pure-homogeneous tuples that have no prefix and no suffix: rather than just `Tuple::FixedLength` and `Tuple::VariableLength`, we could have `Tuple::Heterogeneous`, `Tuple::Homogeneous` and `Tuple::Mixed`. I do like that the current design is quite expressive of the fact that a "pure homogeneous" tuple really has exactly the same semantics as a "mixed tuple" with a 0-length prefix and a 0-length suffix, however, so that's an argument for keeping homogeneous tuples and mixed tuples together in one `Tuple` variant.

## Test Plan

Existing tests pass. The mypy primer report is clean.
