### PR TITLE
[ty] Improve `sys.version_info` special casing

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/subscript/tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/subscript/tuple.md
@@ -142,6 +142,15 @@ reveal_type(os.stat_result.__mro__)
 reveal_type(os.stat_result.__getitem__)
 ```
 
+But perhaps the most commonly used tuple subclass instance is the singleton `sys.version_info`:
+
+```py
+import sys
+
+# revealed: Overload[(self, index: Literal[-5, 0], /) -> Literal[3], (self, index: Literal[-4, 1], /) -> Literal[11], (self, index: Literal[-3, -1, 2, 4], /) -> int, (self, index: Literal[-2, 3], /) -> Literal["alpha", "beta", "candidate", "final"], (self, index: SupportsIndex, /) -> int | Literal["alpha", "beta", "candidate", "final"], (self, index: slice[Any, Any, Any], /) -> tuple[int | Literal["alpha", "beta", "candidate", "final"], ...]]
+reveal_type(type(sys.version_info).__getitem__)
+```
+
 Because of the synthesized `__getitem__` overloads we synthesize for tuples and tuple subclasses,
 tuples are naturally understood as being subtypes of protocols that have precise return types from
 `__getitem__` method members:

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -11,8 +11,8 @@ use crate::types::cyclic::PairVisitor;
 use crate::types::enums::is_single_member_enum;
 use crate::types::protocol_class::walk_protocol_interface;
 use crate::types::tuple::{TupleSpec, TupleType};
-use crate::types::{ClassBase, DynamicType, TypeMapping, TypeRelation, TypeTransformer, UnionType};
-use crate::{Db, FxOrderSet, Program};
+use crate::types::{ClassBase, DynamicType, TypeMapping, TypeRelation, TypeTransformer};
+use crate::{Db, FxOrderSet};
 
 pub(super) use synthesized_protocol::SynthesizedProtocolType;
 
@@ -115,47 +115,6 @@ impl<'db> NominalInstanceType<'db> {
     /// I.e., for the type `tuple[int, str]`, this will return the tuple spec `[int, str]`.
     /// For a subclass of `tuple[int, str]`, it will return the same tuple spec.
     pub(super) fn tuple_spec(&self, db: &'db dyn Db) -> Option<Cow<'db, TupleSpec<'db>>> {
-        fn own_tuple_spec_of_class<'db>(
-            db: &'db dyn Db,
-            class: ClassType<'db>,
-        ) -> Option<Cow<'db, TupleSpec<'db>>> {
-            let (class_literal, specialization) = class.class_literal(db);
-            match class_literal.known(db)? {
-                KnownClass::Tuple => Some(
-                    specialization
-                        .and_then(|spec| Some(Cow::Borrowed(spec.tuple(db)?)))
-                        .unwrap_or_else(|| Cow::Owned(TupleSpec::homogeneous(Type::unknown()))),
-                ),
-                KnownClass::VersionInfo => {
-                    let python_version = Program::get(db).python_version(db);
-                    let int_instance_ty = KnownClass::Int.to_instance(db);
-
-                    // TODO: just grab this type from typeshed (it's a `sys._ReleaseLevel` type alias there)
-                    let release_level_ty = {
-                        let elements: Box<[Type<'db>]> = ["alpha", "beta", "candidate", "final"]
-                            .iter()
-                            .map(|level| Type::string_literal(db, level))
-                            .collect();
-
-                        // For most unions, it's better to go via `UnionType::from_elements` or use `UnionBuilder`;
-                        // those techniques ensure that union elements are deduplicated and unions are eagerly simplified
-                        // into other types where necessary. Here, however, we know that there are no duplicates
-                        // in this union, so it's probably more efficient to use `UnionType::new()` directly.
-                        Type::Union(UnionType::new(db, elements))
-                    };
-
-                    Some(Cow::Owned(TupleSpec::from_elements([
-                        Type::IntLiteral(python_version.major.into()),
-                        Type::IntLiteral(python_version.minor.into()),
-                        int_instance_ty,
-                        release_level_ty,
-                        int_instance_ty,
-                    ])))
-                }
-                _ => None,
-            }
-        }
-
         match self.0 {
             NominalInstanceInner::ExactTuple(tuple) => Some(Cow::Borrowed(tuple.tuple(db))),
             NominalInstanceInner::NonTuple(class) => {
@@ -169,7 +128,26 @@ impl<'db> NominalInstanceType<'db> {
                 class
                     .iter_mro(db)
                     .filter_map(ClassBase::into_class)
-                    .find_map(|class| own_tuple_spec_of_class(db, class))
+                    .find_map(|class| match class.known(db)? {
+                        // N.B. this is a pure optimisation: iterating through the MRO would give us
+                        // the correct tuple spec for `sys._version_info`, since we special-case the class
+                        // in `ClassLiteral::explicit_bases()` so that it is inferred as inheriting from
+                        // a tuple type with the correct spec for the user's configured Python version and platform.
+                        KnownClass::VersionInfo => {
+                            Some(Cow::Owned(TupleSpec::version_info_spec(db)))
+                        }
+                        KnownClass::Tuple => Some(
+                            class
+                                .into_generic_alias()
+                                .and_then(|alias| {
+                                    Some(Cow::Borrowed(alias.specialization(db).tuple(db)?))
+                                })
+                                .unwrap_or_else(|| {
+                                    Cow::Owned(TupleSpec::homogeneous(Type::unknown()))
+                                }),
+                        ),
+                        _ => None,
+                    })
             }
         }
     }


### PR DESCRIPTION
## Summary

Currently the `__getitem__` method we infer for `sys.version_info` is inconsistent with the types we infer for indexing/slicing/unpacking `sys.version_info`. This isn't really a big deal, but... it would be nice to be consistent :-)

The reason for the inconsistency is that we infer `sys.version_info` as inheriting from `tuple[int, int, int, @Todo(Type Alias), int]` due to [typeshed's definition](https://github.com/python/typeshed/blob/1e537d6216d4aef76a8c96ffac9da014ccfe7fc3/stdlib/sys/__init__.pyi#L328), but our special casing elsewhere treats it as a subtype of `tuple[Literal[3], Literal[<minor Python version>], int, Literal["alpha", "beta", ""candidate", "final"], int]`. We can resolve the inconsistency by adding some special-casing for `sys.version_info` to `ClassLiteral::explicit_bases()`.

In theory adding the special casing to `ClassLiteral::explicit_bases()` would let us remove any special casing for `sys.version_info` from `instance.rs`: we could just iterate through the MRO of `sys._version_info` until we find the tuple type in its MRO, and return the tuple spec of that tuple type. In practice, that (unsurpringly) leads to a big performance regression, however. 

I'm adding the "internal" label since I doubt this really changes any behaviour that users would realistically care about.

## Test Plan

Mdtests added
