### PR TITLE
Add rule code to GitLab description

### DIFF
--- a/crates/ruff/tests/snapshots/lint__output_format_gitlab.snap
+++ b/crates/ruff/tests/snapshots/lint__output_format_gitlab.snap
@@ -19,7 +19,7 @@ exit_code: 1
 [
   {
     "check_name": "F401",
-    "description": "`os` imported but unused",
+    "description": "F401: `os` imported but unused",
     "fingerprint": "4dbad37161e65c72",
     "location": {
       "path": "input.py",
@@ -38,7 +38,7 @@ exit_code: 1
   },
   {
     "check_name": "F821",
-    "description": "Undefined name `y`",
+    "description": "F821: Undefined name `y`",
     "fingerprint": "7af59862a085230",
     "location": {
       "path": "input.py",
@@ -56,8 +56,8 @@ exit_code: 1
     "severity": "major"
   },
   {
-    "check_name": "syntax-error",
-    "description": "Cannot use `match` statement on Python 3.9 (syntax was added in Python 3.10)",
+    "check_name": "invalid-syntax",
+    "description": "invalid-syntax: Cannot use `match` statement on Python 3.9 (syntax was added in Python 3.10)",
     "fingerprint": "e558cec859bb66e8",
     "location": {
       "path": "input.py",

--- a/crates/ruff_linter/src/message/gitlab.rs
+++ b/crates/ruff_linter/src/message/gitlab.rs
@@ -88,16 +88,14 @@ impl Serialize for SerializedMessages<'_> {
             }
             fingerprints.insert(message_fingerprint);
 
-            let (description, check_name) = if let Some(code) = diagnostic.secondary_code() {
-                (diagnostic.body().to_string(), code.as_str())
-            } else {
-                let description = diagnostic.body();
-                (description.to_string(), "syntax-error")
-            };
+            let description = diagnostic.body();
+            let check_name = diagnostic.secondary_code_or_id();
 
             let value = json!({
                 "check_name": check_name,
-                "description": description,
+                // GitLab doesn't display the separate `check_name` field in a Code Quality report,
+                // so prepend it to the description too.
+                "description": format!("{check_name}: {description}"),
                 "severity": "major",
                 "fingerprint": format!("{:x}", message_fingerprint),
                 "location": {

--- a/crates/ruff_linter/src/message/gitlab.rs
+++ b/crates/ruff_linter/src/message/gitlab.rs
@@ -92,11 +92,7 @@ impl Serialize for SerializedMessages<'_> {
                 (diagnostic.body().to_string(), code.as_str())
             } else {
                 let description = diagnostic.body();
-                let description_without_prefix = description
-                    .strip_prefix("SyntaxError: ")
-                    .unwrap_or(description);
-
-                (description_without_prefix.to_string(), "syntax-error")
+                (description.to_string(), "syntax-error")
             };
 
             let value = json!({

--- a/crates/ruff_linter/src/message/snapshots/ruff_linter__message__gitlab__tests__output.snap
+++ b/crates/ruff_linter/src/message/snapshots/ruff_linter__message__gitlab__tests__output.snap
@@ -5,7 +5,7 @@ expression: redact_fingerprint(&content)
 [
   {
     "check_name": "F401",
-    "description": "`os` imported but unused",
+    "description": "F401: `os` imported but unused",
     "fingerprint": "<redacted>",
     "location": {
       "path": "fib.py",
@@ -24,7 +24,7 @@ expression: redact_fingerprint(&content)
   },
   {
     "check_name": "F841",
-    "description": "Local variable `x` is assigned to but never used",
+    "description": "F841: Local variable `x` is assigned to but never used",
     "fingerprint": "<redacted>",
     "location": {
       "path": "fib.py",
@@ -43,7 +43,7 @@ expression: redact_fingerprint(&content)
   },
   {
     "check_name": "F821",
-    "description": "Undefined name `a`",
+    "description": "F821: Undefined name `a`",
     "fingerprint": "<redacted>",
     "location": {
       "path": "undef.py",

--- a/crates/ruff_linter/src/message/snapshots/ruff_linter__message__gitlab__tests__syntax_errors.snap
+++ b/crates/ruff_linter/src/message/snapshots/ruff_linter__message__gitlab__tests__syntax_errors.snap
@@ -4,8 +4,8 @@ expression: redact_fingerprint(&content)
 ---
 [
   {
-    "check_name": "syntax-error",
-    "description": "Expected one or more symbol names after import",
+    "check_name": "invalid-syntax",
+    "description": "invalid-syntax: Expected one or more symbol names after import",
     "fingerprint": "<redacted>",
     "location": {
       "path": "syntax_errors.py",
@@ -23,8 +23,8 @@ expression: redact_fingerprint(&content)
     "severity": "major"
   },
   {
-    "check_name": "syntax-error",
-    "description": "Expected ')', found newline",
+    "check_name": "invalid-syntax",
+    "description": "invalid-syntax: Expected ')', found newline",
     "fingerprint": "<redacted>",
     "location": {
       "path": "syntax_errors.py",


### PR DESCRIPTION
## Summary

Fixes #19881. While I was here, I also made a couple of related tweaks to the output format. First, we don't need to strip the `SyntaxError: ` prefix anymore since that's not added directly to the diagnostic message after #19644. Second, we can use `secondary_code_or_id` to fall back on the lint ID for syntax errors, which changes the `check_name` from `syntax-error` to `invalid-syntax`. And then the main change requested in the issue, prepending the `check_name` to the description.

## Test Plan

Existing tests and a new screenshot from GitLab:

<img width="362" height="113" alt="image" src="https://github.com/user-attachments/assets/97654ad4-a639-4489-8c90-8661c7355097" />
