### PR TITLE
[ty] Synthesize read-only properties for all declared members on `NamedTuple` classes

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/named_tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/named_tuple.md
@@ -163,7 +163,7 @@ class User(NamedTuple):
     nickname: str
 
 class SuperUser(User):
-    # this should be an error because it implies that the `id` attribute on
+    # TODO: this should be an error because it implies that the `id` attribute on
     # `SuperUser` is mutable, but the read-only `id` property from the superclass
     # has not been overridden in the class body
     id: int

--- a/crates/ty_python_semantic/resources/mdtest/named_tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/named_tuple.md
@@ -205,13 +205,29 @@ python-version = "3.12"
 ```
 
 ```py
-from typing import NamedTuple
+from typing import NamedTuple, Generic, TypeVar
 
 class Property[T](NamedTuple):
     name: str
     value: T
 
 reveal_type(Property("height", 3.4))  # revealed: Property[float]
+reveal_type(Property.value)  # revealed: property
+reveal_type(Property.value.fget)  # revealed: (self, /) -> Unknown
+reveal_type(Property[str].value.fget)  # revealed: (self, /) -> str
+reveal_type(Property("height", 3.4).value)  # revealed: float
+
+T = TypeVar("T")
+
+class LegacyProperty(NamedTuple, Generic[T]):
+    name: str
+    value: T
+
+reveal_type(LegacyProperty("height", 42))  # revealed: LegacyProperty[int]
+reveal_type(LegacyProperty.value)  # revealed: property
+reveal_type(LegacyProperty.value.fget)  # revealed: (self, /) -> Unknown
+reveal_type(LegacyProperty[str].value.fget)  # revealed: (self, /) -> str
+reveal_type(LegacyProperty("height", 3.4).value)  # revealed: float
 ```
 
 ## Attributes on `NamedTuple`


### PR DESCRIPTION
## Summary

Currently we treat declared attributes on `NamedTuple` classes just like declared attributes on any other class. But this is not correct! At runtime, the `NamedTuple` machinery synthesizes a read-only property for each attribute declared on a `NamedTuple` class. This PR implements that behaviour.

## Test Plan

Mdtests
