### PR TITLE
[`pyflakes`] Add secondary annotation showing previous definition (`F811`)

### DIFF
--- a/crates/ruff/tests/lint.rs
+++ b/crates/ruff/tests/lint.rs
@@ -5588,15 +5588,15 @@ fn cookiecutter_globbing() -> Result<()> {
                 .args(STDIN_BASE_OPTIONS)
                 .arg("--select=F811")
                 .current_dir(tempdir.path()), @r"
-			success: false
-			exit_code: 1
-			----- stdout -----
-			{{cookiecutter.repo_name}}/tests/maintest.py:3:8: F811 [*] Redefinition of unused `foo` from line 1
-			Found 1 error.
-			[*] 1 fixable with the `--fix` option.
+        success: false
+        exit_code: 1
+        ----- stdout -----
+        {{cookiecutter.repo_name}}/tests/maintest.py:3:8: F811 [*] Redefinition of unused `foo` from line 1: `foo` redefined here
+        Found 1 error.
+        [*] 1 fixable with the `--fix` option.
 
-			----- stderr -----
-		");
+        ----- stderr -----
+        ");
     });
 
     Ok(())

--- a/crates/ruff_db/src/diagnostic/mod.rs
+++ b/crates/ruff_db/src/diagnostic/mod.rs
@@ -497,6 +497,16 @@ impl Diagnostic {
             other.expect_range().start(),
         ))
     }
+
+    /// Sort this diagnostic's sub-diagnostics by descending severity.
+    ///
+    /// This is particularly helpful to move `help`-level sub-diagnostics to the end, after any
+    /// longer, `info`-level diagnostics.
+    pub fn sort_sub_diagnostics(&mut self) {
+        Arc::make_mut(&mut self.inner)
+            .subs
+            .sort_by_key(|sub| std::cmp::Reverse(sub.inner.severity));
+    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, get_size2::GetSize)]

--- a/crates/ruff_db/src/diagnostic/mod.rs
+++ b/crates/ruff_db/src/diagnostic/mod.rs
@@ -254,6 +254,11 @@ impl Diagnostic {
             .find(|ann| ann.is_primary)
     }
 
+    /// Returns a mutable borrow of all annotations of this diagnostic.
+    pub fn annotations_mut(&mut self) -> impl Iterator<Item = &mut Annotation> {
+        Arc::make_mut(&mut self.inner).annotations.iter_mut()
+    }
+
     /// Returns the "primary" span of this diagnostic if one exists.
     ///
     /// When there are multiple primary spans, then the first one that was
@@ -308,6 +313,11 @@ impl Diagnostic {
 
     pub fn sub_diagnostics(&self) -> &[SubDiagnostic] {
         &self.inner.subs
+    }
+
+    /// Returns a mutable borrow of the sub-diagnostics of this diagnostic.
+    pub fn sub_diagnostics_mut(&mut self) -> impl Iterator<Item = &mut SubDiagnostic> {
+        Arc::make_mut(&mut self.inner).subs.iter_mut()
     }
 
     /// Returns the fix for this diagnostic if it exists.
@@ -619,6 +629,11 @@ impl SubDiagnostic {
 
     pub fn annotations(&self) -> &[Annotation] {
         &self.inner.annotations
+    }
+
+    /// Returns a mutable borrow of the annotations of this sub-diagnostic.
+    pub fn annotations_mut(&mut self) -> impl Iterator<Item = &mut Annotation> {
+        self.inner.annotations.iter_mut()
     }
 
     /// Returns a shared borrow of the "primary" annotation of this diagnostic

--- a/crates/ruff_db/src/diagnostic/mod.rs
+++ b/crates/ruff_db/src/diagnostic/mod.rs
@@ -497,16 +497,6 @@ impl Diagnostic {
             other.expect_range().start(),
         ))
     }
-
-    /// Sort this diagnostic's sub-diagnostics by descending severity.
-    ///
-    /// This is particularly helpful to move `help`-level sub-diagnostics to the end, after any
-    /// longer, `info`-level diagnostics.
-    pub fn sort_sub_diagnostics(&mut self) {
-        Arc::make_mut(&mut self.inner)
-            .subs
-            .sort_by_key(|sub| std::cmp::Reverse(sub.inner.severity));
-    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, get_size2::GetSize)]

--- a/crates/ruff_db/src/diagnostic/render.rs
+++ b/crates/ruff_db/src/diagnostic/render.rs
@@ -264,7 +264,12 @@ impl<'a> ResolvedDiagnostic<'a> {
             .annotations
             .iter()
             .filter_map(|ann| {
-                let path = ann.span.file.path(resolver);
+                let path = ann
+                    .span
+                    .file
+                    .relative_path(resolver)
+                    .to_str()
+                    .unwrap_or_else(|| ann.span.file.path(resolver));
                 let diagnostic_source = ann.span.file.diagnostic_source(resolver);
                 ResolvedAnnotation::new(path, &diagnostic_source, ann, resolver)
             })

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -3349,7 +3349,8 @@ impl Drop for DiagnosticGuard<'_, '_> {
             return;
         }
 
-        if let Some(diagnostic) = self.diagnostic.take() {
+        if let Some(mut diagnostic) = self.diagnostic.take() {
+            diagnostic.sort_sub_diagnostics();
             self.context.diagnostics.borrow_mut().push(diagnostic);
         }
     }

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -28,7 +28,9 @@ use itertools::Itertools;
 use log::debug;
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use ruff_db::diagnostic::Diagnostic;
+use ruff_db::diagnostic::{
+    Annotation, Diagnostic, IntoDiagnosticMessage, Span, SubDiagnostic, SubDiagnosticSeverity,
+};
 use ruff_diagnostics::{Applicability, Fix, IsolationLevel};
 use ruff_notebook::{CellOffsets, NotebookIndex};
 use ruff_python_ast::helpers::{collect_import_from_member, is_docstring_stmt, to_module_path};
@@ -3304,6 +3306,22 @@ impl DiagnosticGuard<'_, '_> {
             Ok(Some(fix)) => self.set_fix(fix),
             Err(err) => log::debug!("Failed to create fix for {}: {}", self.name(), err),
         }
+    }
+
+    /// Add an "info" sub-diagnostic with the given message and range.
+    ///
+    /// Note that this shadows `Diagnostic::info` from the `Deref` implementation because we'll
+    /// usually want to attach a range here.
+    pub(crate) fn info<'a>(
+        &mut self,
+        message: impl IntoDiagnosticMessage + 'a,
+        range: impl Ranged,
+    ) {
+        let mut sub = SubDiagnostic::new(SubDiagnosticSeverity::Info, message);
+        let span = Span::from(self.context.source_file.clone()).with_range(range.range());
+        let ann = Annotation::primary(span);
+        sub.annotate(ann);
+        self.diagnostic.as_mut().unwrap().sub(sub);
     }
 }
 

--- a/crates/ruff_linter/src/rules/pyflakes/rules/redefined_while_unused.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/redefined_while_unused.rs
@@ -197,6 +197,10 @@ pub(crate) fn redefined_while_unused(checker: &Checker, scope_id: ScopeId, scope
                 shadowed,
             );
 
+            if let Some(ann) = diagnostic.primary_annotation_mut() {
+                ann.set_message(format_args!("`{name}` redefined here"));
+            }
+
             if let Some(range) = binding.parent_range(checker.semantic()) {
                 diagnostic.set_parent(range.start());
             }

--- a/crates/ruff_linter/src/rules/pyflakes/rules/redefined_while_unused.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/redefined_while_unused.rs
@@ -192,7 +192,7 @@ pub(crate) fn redefined_while_unused(checker: &Checker, scope_id: ScopeId, scope
                 binding.range(),
             );
 
-            diagnostic.info(
+            diagnostic.secondary_annotation(
                 format_args!("previous definition of `{name}` here"),
                 shadowed,
             );

--- a/crates/ruff_linter/src/rules/pyflakes/rules/redefined_while_unused.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/redefined_while_unused.rs
@@ -183,12 +183,18 @@ pub(crate) fn redefined_while_unused(checker: &Checker, scope_id: ScopeId, scope
     // Create diagnostics for each statement.
     for (source, entries) in &redefinitions {
         for (shadowed, binding) in entries {
+            let name = binding.name(checker.source());
             let mut diagnostic = checker.report_diagnostic(
                 RedefinedWhileUnused {
-                    name: binding.name(checker.source()).to_string(),
+                    name: name.to_string(),
                     row: checker.compute_source_row(shadowed.start()),
                 },
                 binding.range(),
+            );
+
+            diagnostic.info(
+                format_args!("previous definition of `{name}` here"),
+                shadowed,
             );
 
             if let Some(range) = binding.parent_range(checker.semantic()) {

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_0.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_0.py.snap
@@ -5,7 +5,7 @@ F811 Redefinition of unused `bar` from line 6
   --> F811_0.py:10:5
    |
 10 | def bar():
-   |     ^^^
+   |     ^^^ `bar` redefined here
 11 |     pass
    |
   ::: F811_0.py:6:5

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_0.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_0.py.snap
@@ -8,12 +8,11 @@ F811 Redefinition of unused `bar` from line 6
    |     ^^^
 11 |     pass
    |
-info: previous definition of `bar` here
- --> F811_0.py:6:5
-  |
-5 | @foo
-6 | def bar():
-  |     ^^^
-7 |     pass
-  |
+  ::: F811_0.py:6:5
+   |
+ 5 | @foo
+ 6 | def bar():
+   |     --- previous definition of `bar` here
+ 7 |     pass
+   |
 help: Remove definition: `bar`

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_0.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_0.py.snap
@@ -8,4 +8,12 @@ F811 Redefinition of unused `bar` from line 6
    |     ^^^
 11 |     pass
    |
+info: previous definition of `bar` here
+ --> F811_0.py:6:5
+  |
+5 | @foo
+6 | def bar():
+  |     ^^^
+7 |     pass
+  |
 help: Remove definition: `bar`

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_1.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_1.py.snap
@@ -5,7 +5,7 @@ F811 Redefinition of unused `FU` from line 1
  --> F811_1.py:1:14
   |
 1 | import fu as FU, bar as FU
-  |              --         ^^
+  |              --         ^^ `FU` redefined here
   |              |
   |              previous definition of `FU` here
   |

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_1.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_1.py.snap
@@ -7,4 +7,10 @@ F811 Redefinition of unused `FU` from line 1
 1 | import fu as FU, bar as FU
   |                         ^^
   |
+info: previous definition of `FU` here
+ --> F811_1.py:1:14
+  |
+1 | import fu as FU, bar as FU
+  |              ^^
+  |
 help: Remove definition: `FU`

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_1.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_1.py.snap
@@ -2,15 +2,11 @@
 source: crates/ruff_linter/src/rules/pyflakes/mod.rs
 ---
 F811 Redefinition of unused `FU` from line 1
- --> F811_1.py:1:25
-  |
-1 | import fu as FU, bar as FU
-  |                         ^^
-  |
-info: previous definition of `FU` here
  --> F811_1.py:1:14
   |
 1 | import fu as FU, bar as FU
-  |              ^^
+  |              --         ^^
+  |              |
+  |              previous definition of `FU` here
   |
 help: Remove definition: `FU`

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_12.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_12.py.snap
@@ -10,4 +10,13 @@ F811 Redefinition of unused `mixer` from line 2
   |                    ^^^^^
 7 | mixer(123)
   |
+info: previous definition of `mixer` here
+ --> F811_12.py:2:20
+  |
+1 | try:
+2 |     from aa import mixer
+  |                    ^^^^^
+3 | except ImportError:
+4 |     pass
+  |
 help: Remove definition: `mixer`

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_12.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_12.py.snap
@@ -2,21 +2,16 @@
 source: crates/ruff_linter/src/rules/pyflakes/mod.rs
 ---
 F811 Redefinition of unused `mixer` from line 2
- --> F811_12.py:6:20
+ --> F811_12.py:2:20
   |
+1 | try:
+2 |     from aa import mixer
+  |                    ----- previous definition of `mixer` here
+3 | except ImportError:
 4 |     pass
 5 | else:
 6 |     from bb import mixer
   |                    ^^^^^
 7 | mixer(123)
-  |
-info: previous definition of `mixer` here
- --> F811_12.py:2:20
-  |
-1 | try:
-2 |     from aa import mixer
-  |                    ^^^^^
-3 | except ImportError:
-4 |     pass
   |
 help: Remove definition: `mixer`

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_12.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_12.py.snap
@@ -11,7 +11,7 @@ F811 Redefinition of unused `mixer` from line 2
 4 |     pass
 5 | else:
 6 |     from bb import mixer
-  |                    ^^^^^
+  |                    ^^^^^ `mixer` redefined here
 7 | mixer(123)
   |
 help: Remove definition: `mixer`

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_15.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_15.py.snap
@@ -5,7 +5,7 @@ F811 Redefinition of unused `fu` from line 1
  --> F811_15.py:4:5
   |
 4 | def fu():
-  |     ^^
+  |     ^^ `fu` redefined here
 5 |     pass
   |
  ::: F811_15.py:1:8

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_15.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_15.py.snap
@@ -8,4 +8,10 @@ F811 Redefinition of unused `fu` from line 1
   |     ^^
 5 |     pass
   |
+info: previous definition of `fu` here
+ --> F811_15.py:1:8
+  |
+1 | import fu
+  |        ^^
+  |
 help: Remove definition: `fu`

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_15.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_15.py.snap
@@ -8,10 +8,9 @@ F811 Redefinition of unused `fu` from line 1
   |     ^^
 5 |     pass
   |
-info: previous definition of `fu` here
- --> F811_15.py:1:8
+ ::: F811_15.py:1:8
   |
 1 | import fu
-  |        ^^
+  |        -- previous definition of `fu` here
   |
 help: Remove definition: `fu`

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_16.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_16.py.snap
@@ -7,7 +7,7 @@ F811 Redefinition of unused `fu` from line 3
 6 | def bar():
 7 |     def baz():
 8 |         def fu():
-  |             ^^
+  |             ^^ `fu` redefined here
 9 |             pass
   |
  ::: F811_16.py:3:8

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_16.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_16.py.snap
@@ -10,12 +10,11 @@ F811 Redefinition of unused `fu` from line 3
   |             ^^
 9 |             pass
   |
-info: previous definition of `fu` here
- --> F811_16.py:3:8
+ ::: F811_16.py:3:8
   |
 1 | """Test that shadowing a global with a nested function generates a warning."""
 2 |
 3 | import fu
-  |        ^^
+  |        -- previous definition of `fu` here
   |
 help: Remove definition: `fu`

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_16.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_16.py.snap
@@ -10,4 +10,12 @@ F811 Redefinition of unused `fu` from line 3
   |             ^^
 9 |             pass
   |
+info: previous definition of `fu` here
+ --> F811_16.py:3:8
+  |
+1 | """Test that shadowing a global with a nested function generates a warning."""
+2 |
+3 | import fu
+  |        ^^
+  |
 help: Remove definition: `fu`

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_17.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_17.py.snap
@@ -10,6 +10,13 @@ F811 [*] Redefinition of unused `fu` from line 2
 7 |
 8 |     def baz():
   |
+info: previous definition of `fu` here
+ --> F811_17.py:2:8
+  |
+1 | """Test that shadowing a global name with a nested function generates a warning."""
+2 | import fu
+  |        ^^
+  |
 help: Remove definition: `fu`
 
 ℹ Safe fix
@@ -29,4 +36,13 @@ F811 Redefinition of unused `fu` from line 6
    |             ^^
 10 |             pass
    |
+info: previous definition of `fu` here
+ --> F811_17.py:6:12
+  |
+5 | def bar():
+6 |     import fu
+  |            ^^
+7 |
+8 |     def baz():
+  |
 help: Remove definition: `fu`

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_17.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_17.py.snap
@@ -10,12 +10,11 @@ F811 [*] Redefinition of unused `fu` from line 2
 7 |
 8 |     def baz():
   |
-info: previous definition of `fu` here
- --> F811_17.py:2:8
+ ::: F811_17.py:2:8
   |
 1 | """Test that shadowing a global name with a nested function generates a warning."""
 2 | import fu
-  |        ^^
+  |        -- previous definition of `fu` here
   |
 help: Remove definition: `fu`
 
@@ -29,20 +28,15 @@ help: Remove definition: `fu`
 9 8 |         def fu():
 
 F811 Redefinition of unused `fu` from line 6
-  --> F811_17.py:9:13
+  --> F811_17.py:6:12
    |
+ 5 | def bar():
+ 6 |     import fu
+   |            -- previous definition of `fu` here
+ 7 |
  8 |     def baz():
  9 |         def fu():
    |             ^^
 10 |             pass
    |
-info: previous definition of `fu` here
- --> F811_17.py:6:12
-  |
-5 | def bar():
-6 |     import fu
-  |            ^^
-7 |
-8 |     def baz():
-  |
 help: Remove definition: `fu`

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_17.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_17.py.snap
@@ -6,7 +6,7 @@ F811 [*] Redefinition of unused `fu` from line 2
   |
 5 | def bar():
 6 |     import fu
-  |            ^^
+  |            ^^ `fu` redefined here
 7 |
 8 |     def baz():
   |
@@ -36,7 +36,7 @@ F811 Redefinition of unused `fu` from line 6
  7 |
  8 |     def baz():
  9 |         def fu():
-   |             ^^
+   |             ^^ `fu` redefined here
 10 |             pass
    |
 help: Remove definition: `fu`

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_2.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_2.py.snap
@@ -2,15 +2,11 @@
 source: crates/ruff_linter/src/rules/pyflakes/mod.rs
 ---
 F811 Redefinition of unused `FU` from line 1
- --> F811_2.py:1:34
-  |
-1 | from moo import fu as FU, bar as FU
-  |                                  ^^
-  |
-info: previous definition of `FU` here
  --> F811_2.py:1:23
   |
 1 | from moo import fu as FU, bar as FU
-  |                       ^^
+  |                       --         ^^
+  |                       |
+  |                       previous definition of `FU` here
   |
 help: Remove definition: `FU`

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_2.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_2.py.snap
@@ -7,4 +7,10 @@ F811 Redefinition of unused `FU` from line 1
 1 | from moo import fu as FU, bar as FU
   |                                  ^^
   |
+info: previous definition of `FU` here
+ --> F811_2.py:1:23
+  |
+1 | from moo import fu as FU, bar as FU
+  |                       ^^
+  |
 help: Remove definition: `FU`

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_2.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_2.py.snap
@@ -5,7 +5,7 @@ F811 Redefinition of unused `FU` from line 1
  --> F811_2.py:1:23
   |
 1 | from moo import fu as FU, bar as FU
-  |                       --         ^^
+  |                       --         ^^ `FU` redefined here
   |                       |
   |                       previous definition of `FU` here
   |

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_21.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_21.py.snap
@@ -7,7 +7,7 @@ F811 [*] Redefinition of unused `Sequence` from line 26
 30 | from typing import (
 31 |     List,  # noqa: F811
 32 |     Sequence,
-   |     ^^^^^^^^
+   |     ^^^^^^^^ `Sequence` redefined here
 33 | )
    |
   ::: F811_21.py:26:5

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_21.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_21.py.snap
@@ -10,13 +10,12 @@ F811 [*] Redefinition of unused `Sequence` from line 26
    |     ^^^^^^^^
 33 | )
    |
-info: previous definition of `Sequence` here
-  --> F811_21.py:26:5
+  ::: F811_21.py:26:5
    |
 24 | from typing import (
 25 |     List,  # noqa
 26 |     Sequence,  # noqa
-   |     ^^^^^^^^
+   |     -------- previous definition of `Sequence` here
 27 | )
    |
 help: Remove definition: `Sequence`

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_21.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_21.py.snap
@@ -10,6 +10,15 @@ F811 [*] Redefinition of unused `Sequence` from line 26
    |     ^^^^^^^^
 33 | )
    |
+info: previous definition of `Sequence` here
+  --> F811_21.py:26:5
+   |
+24 | from typing import (
+25 |     List,  # noqa
+26 |     Sequence,  # noqa
+   |     ^^^^^^^^
+27 | )
+   |
 help: Remove definition: `Sequence`
 
 ℹ Safe fix

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_23.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_23.py.snap
@@ -9,6 +9,6 @@ F811 Redefinition of unused `foo` from line 3
 3 | import foo as foo
   |               --- previous definition of `foo` here
 4 | import bar as foo
-  |               ^^^
+  |               ^^^ `foo` redefined here
   |
 help: Remove definition: `foo`

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_23.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_23.py.snap
@@ -8,4 +8,13 @@ F811 Redefinition of unused `foo` from line 3
 4 | import bar as foo
   |               ^^^
   |
+info: previous definition of `foo` here
+ --> F811_23.py:3:15
+  |
+1 | """Test that shadowing an explicit re-export produces a warning."""
+2 |
+3 | import foo as foo
+  |               ^^^
+4 | import bar as foo
+  |
 help: Remove definition: `foo`

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_23.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_23.py.snap
@@ -2,19 +2,13 @@
 source: crates/ruff_linter/src/rules/pyflakes/mod.rs
 ---
 F811 Redefinition of unused `foo` from line 3
- --> F811_23.py:4:15
-  |
-3 | import foo as foo
-4 | import bar as foo
-  |               ^^^
-  |
-info: previous definition of `foo` here
  --> F811_23.py:3:15
   |
 1 | """Test that shadowing an explicit re-export produces a warning."""
 2 |
 3 | import foo as foo
-  |               ^^^
+  |               --- previous definition of `foo` here
 4 | import bar as foo
+  |               ^^^
   |
 help: Remove definition: `foo`

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_26.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_26.py.snap
@@ -10,4 +10,12 @@ F811 Redefinition of unused `func` from line 2
   |         ^^^^
 6 |         pass
   |
+info: previous definition of `func` here
+ --> F811_26.py:2:9
+  |
+1 | class Class:
+2 |     def func(self):
+  |         ^^^^
+3 |         pass
+  |
 help: Remove definition: `func`

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_26.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_26.py.snap
@@ -10,7 +10,7 @@ F811 Redefinition of unused `func` from line 2
 3 |         pass
 4 |
 5 |     def func(self):
-  |         ^^^^
+  |         ^^^^ `func` redefined here
 6 |         pass
   |
 help: Remove definition: `func`

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_26.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_26.py.snap
@@ -2,20 +2,15 @@
 source: crates/ruff_linter/src/rules/pyflakes/mod.rs
 ---
 F811 Redefinition of unused `func` from line 2
- --> F811_26.py:5:9
+ --> F811_26.py:2:9
   |
+1 | class Class:
+2 |     def func(self):
+  |         ---- previous definition of `func` here
 3 |         pass
 4 |
 5 |     def func(self):
   |         ^^^^
 6 |         pass
-  |
-info: previous definition of `func` here
- --> F811_26.py:2:9
-  |
-1 | class Class:
-2 |     def func(self):
-  |         ^^^^
-3 |         pass
   |
 help: Remove definition: `func`

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_28.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_28.py.snap
@@ -2,21 +2,15 @@
 source: crates/ruff_linter/src/rules/pyflakes/mod.rs
 ---
 F811 Redefinition of unused `datetime` from line 3
- --> F811_28.py:4:22
-  |
-3 | import datetime
-4 | from datetime import datetime
-  |                      ^^^^^^^^
-5 |
-6 | datetime(1, 2, 3)
-  |
-info: previous definition of `datetime` here
  --> F811_28.py:3:8
   |
 1 | """Regression test for: https://github.com/astral-sh/ruff/issues/10384"""
 2 |
 3 | import datetime
-  |        ^^^^^^^^
+  |        -------- previous definition of `datetime` here
 4 | from datetime import datetime
+  |                      ^^^^^^^^
+5 |
+6 | datetime(1, 2, 3)
   |
 help: Remove definition: `datetime`

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_28.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_28.py.snap
@@ -9,7 +9,7 @@ F811 Redefinition of unused `datetime` from line 3
 3 | import datetime
   |        -------- previous definition of `datetime` here
 4 | from datetime import datetime
-  |                      ^^^^^^^^
+  |                      ^^^^^^^^ `datetime` redefined here
 5 |
 6 | datetime(1, 2, 3)
   |

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_28.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_28.py.snap
@@ -10,4 +10,13 @@ F811 Redefinition of unused `datetime` from line 3
 5 |
 6 | datetime(1, 2, 3)
   |
+info: previous definition of `datetime` here
+ --> F811_28.py:3:8
+  |
+1 | """Regression test for: https://github.com/astral-sh/ruff/issues/10384"""
+2 |
+3 | import datetime
+  |        ^^^^^^^^
+4 | from datetime import datetime
+  |
 help: Remove definition: `datetime`

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_29.pyi.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_29.pyi.snap
@@ -2,21 +2,17 @@
 source: crates/ruff_linter/src/rules/pyflakes/mod.rs
 ---
 F811 Redefinition of unused `Bar` from line 3
- --> F811_29.pyi:8:1
-  |
-6 |     Bar: int  # OK
-7 |
-8 | Bar = 1  # F811
-  | ^^^
-  |
-info: previous definition of `Bar` here
  --> F811_29.pyi:3:24
   |
 1 | """Regression test for: https://github.com/astral-sh/ruff/issues/10509"""
 2 |
 3 | from foo import Bar as Bar
-  |                        ^^^
+  |                        --- previous definition of `Bar` here
 4 |
 5 | class Eggs:
+6 |     Bar: int  # OK
+7 |
+8 | Bar = 1  # F811
+  | ^^^
   |
 help: Remove definition: `Bar`

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_29.pyi.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_29.pyi.snap
@@ -13,6 +13,6 @@ F811 Redefinition of unused `Bar` from line 3
 6 |     Bar: int  # OK
 7 |
 8 | Bar = 1  # F811
-  | ^^^
+  | ^^^ `Bar` redefined here
   |
 help: Remove definition: `Bar`

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_29.pyi.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_29.pyi.snap
@@ -9,4 +9,14 @@ F811 Redefinition of unused `Bar` from line 3
 8 | Bar = 1  # F811
   | ^^^
   |
+info: previous definition of `Bar` here
+ --> F811_29.pyi:3:24
+  |
+1 | """Regression test for: https://github.com/astral-sh/ruff/issues/10509"""
+2 |
+3 | from foo import Bar as Bar
+  |                        ^^^
+4 |
+5 | class Eggs:
+  |
 help: Remove definition: `Bar`

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_3.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_3.py.snap
@@ -2,15 +2,11 @@
 source: crates/ruff_linter/src/rules/pyflakes/mod.rs
 ---
 F811 Redefinition of unused `fu` from line 1
- --> F811_3.py:1:12
-  |
-1 | import fu; fu = 3
-  |            ^^
-  |
-info: previous definition of `fu` here
  --> F811_3.py:1:8
   |
 1 | import fu; fu = 3
-  |        ^^
+  |        --  ^^
+  |        |
+  |        previous definition of `fu` here
   |
 help: Remove definition: `fu`

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_3.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_3.py.snap
@@ -5,7 +5,7 @@ F811 Redefinition of unused `fu` from line 1
  --> F811_3.py:1:8
   |
 1 | import fu; fu = 3
-  |        --  ^^
+  |        --  ^^ `fu` redefined here
   |        |
   |        previous definition of `fu` here
   |

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_3.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_3.py.snap
@@ -7,4 +7,10 @@ F811 Redefinition of unused `fu` from line 1
 1 | import fu; fu = 3
   |            ^^
   |
+info: previous definition of `fu` here
+ --> F811_3.py:1:8
+  |
+1 | import fu; fu = 3
+  |        ^^
+  |
 help: Remove definition: `fu`

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_30.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_30.py.snap
@@ -10,7 +10,7 @@ F811 Redefinition of unused `bar` from line 10
    |     --- previous definition of `bar` here
 11 |
 12 |     def bar(self) -> None:
-   |         ^^^
+   |         ^^^ `bar` redefined here
 13 |         """Bar."""
    |
 help: Remove definition: `bar`
@@ -25,7 +25,7 @@ F811 Redefinition of unused `baz` from line 18
 19 |         """Baz."""
 20 |
 21 |     baz = 1
-   |     ^^^
+   |     ^^^ `baz` redefined here
    |
 help: Remove definition: `baz`
 
@@ -39,6 +39,6 @@ F811 Redefinition of unused `foo` from line 26
 27 |         """Foo."""
 28 |
 29 |     bar = (foo := 1)
-   |            ^^^
+   |            ^^^ `foo` redefined here
    |
 help: Remove definition: `foo`

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_30.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_30.py.snap
@@ -10,6 +10,16 @@ F811 Redefinition of unused `bar` from line 10
    |         ^^^
 13 |         """Bar."""
    |
+info: previous definition of `bar` here
+  --> F811_30.py:10:5
+   |
+ 8 |         """Foo."""
+ 9 |
+10 |     bar = foo
+   |     ^^^
+11 |
+12 |     def bar(self) -> None:
+   |
 help: Remove definition: `bar`
 
 F811 Redefinition of unused `baz` from line 18
@@ -20,6 +30,15 @@ F811 Redefinition of unused `baz` from line 18
 21 |     baz = 1
    |     ^^^
    |
+info: previous definition of `baz` here
+  --> F811_30.py:18:9
+   |
+16 | class B:
+17 |     """B."""
+18 |     def baz(self) -> None:
+   |         ^^^
+19 |         """Baz."""
+   |
 help: Remove definition: `baz`
 
 F811 Redefinition of unused `foo` from line 26
@@ -29,5 +48,14 @@ F811 Redefinition of unused `foo` from line 26
 28 |
 29 |     bar = (foo := 1)
    |            ^^^
+   |
+info: previous definition of `foo` here
+  --> F811_30.py:26:9
+   |
+24 | class C:
+25 |     """C."""
+26 |     def foo(self) -> None:
+   |         ^^^
+27 |         """Foo."""
    |
 help: Remove definition: `foo`

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_30.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_30.py.snap
@@ -2,60 +2,43 @@
 source: crates/ruff_linter/src/rules/pyflakes/mod.rs
 ---
 F811 Redefinition of unused `bar` from line 10
-  --> F811_30.py:12:9
-   |
-10 |     bar = foo
-11 |
-12 |     def bar(self) -> None:
-   |         ^^^
-13 |         """Bar."""
-   |
-info: previous definition of `bar` here
   --> F811_30.py:10:5
    |
  8 |         """Foo."""
  9 |
 10 |     bar = foo
-   |     ^^^
+   |     --- previous definition of `bar` here
 11 |
 12 |     def bar(self) -> None:
+   |         ^^^
+13 |         """Bar."""
    |
 help: Remove definition: `bar`
 
 F811 Redefinition of unused `baz` from line 18
-  --> F811_30.py:21:5
-   |
-19 |         """Baz."""
-20 |
-21 |     baz = 1
-   |     ^^^
-   |
-info: previous definition of `baz` here
   --> F811_30.py:18:9
    |
 16 | class B:
 17 |     """B."""
 18 |     def baz(self) -> None:
-   |         ^^^
+   |         --- previous definition of `baz` here
 19 |         """Baz."""
+20 |
+21 |     baz = 1
+   |     ^^^
    |
 help: Remove definition: `baz`
 
 F811 Redefinition of unused `foo` from line 26
-  --> F811_30.py:29:12
-   |
-27 |         """Foo."""
-28 |
-29 |     bar = (foo := 1)
-   |            ^^^
-   |
-info: previous definition of `foo` here
   --> F811_30.py:26:9
    |
 24 | class C:
 25 |     """C."""
 26 |     def foo(self) -> None:
-   |         ^^^
+   |         --- previous definition of `foo` here
 27 |         """Foo."""
+28 |
+29 |     bar = (foo := 1)
+   |            ^^^
    |
 help: Remove definition: `foo`

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_31.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_31.py.snap
@@ -11,4 +11,13 @@ F811 Redefinition of unused `baz` from line 17
 20 | except ImportError:
 21 |     pass
    |
+info: previous definition of `baz` here
+  --> F811_31.py:17:5
+   |
+16 | try:
+17 |     baz = None
+   |     ^^^
+18 |
+19 |     from some_module import baz
+   |
 help: Remove definition: `baz`

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_31.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_31.py.snap
@@ -2,22 +2,15 @@
 source: crates/ruff_linter/src/rules/pyflakes/mod.rs
 ---
 F811 Redefinition of unused `baz` from line 17
-  --> F811_31.py:19:29
+  --> F811_31.py:17:5
    |
+16 | try:
 17 |     baz = None
+   |     --- previous definition of `baz` here
 18 |
 19 |     from some_module import baz
    |                             ^^^
 20 | except ImportError:
 21 |     pass
-   |
-info: previous definition of `baz` here
-  --> F811_31.py:17:5
-   |
-16 | try:
-17 |     baz = None
-   |     ^^^
-18 |
-19 |     from some_module import baz
    |
 help: Remove definition: `baz`

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_31.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_31.py.snap
@@ -9,7 +9,7 @@ F811 Redefinition of unused `baz` from line 17
    |     --- previous definition of `baz` here
 18 |
 19 |     from some_module import baz
-   |                             ^^^
+   |                             ^^^ `baz` redefined here
 20 | except ImportError:
 21 |     pass
    |

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_32.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_32.py.snap
@@ -8,7 +8,7 @@ F811 [*] Redefinition of unused `List` from line 4
 4 |     List,
   |     ---- previous definition of `List` here
 5 |     List,
-  |     ^^^^
+  |     ^^^^ `List` redefined here
 6 | )
   |
 help: Remove definition: `List`

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_32.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_32.py.snap
@@ -10,6 +10,15 @@ F811 [*] Redefinition of unused `List` from line 4
   |     ^^^^
 6 | )
   |
+info: previous definition of `List` here
+ --> F811_32.py:4:5
+  |
+3 | from typing import (
+4 |     List,
+  |     ^^^^
+5 |     List,
+6 | )
+  |
 help: Remove definition: `List`
 
 ℹ Safe fix

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_32.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_32.py.snap
@@ -2,21 +2,13 @@
 source: crates/ruff_linter/src/rules/pyflakes/mod.rs
 ---
 F811 [*] Redefinition of unused `List` from line 4
- --> F811_32.py:5:5
-  |
-3 | from typing import (
-4 |     List,
-5 |     List,
-  |     ^^^^
-6 | )
-  |
-info: previous definition of `List` here
  --> F811_32.py:4:5
   |
 3 | from typing import (
 4 |     List,
-  |     ^^^^
+  |     ---- previous definition of `List` here
 5 |     List,
+  |     ^^^^
 6 | )
   |
 help: Remove definition: `List`

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_4.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_4.py.snap
@@ -5,7 +5,7 @@ F811 Redefinition of unused `fu` from line 1
  --> F811_4.py:1:8
   |
 1 | import fu; fu, bar = 3
-  |        --  ^^
+  |        --  ^^ `fu` redefined here
   |        |
   |        previous definition of `fu` here
   |

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_4.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_4.py.snap
@@ -2,15 +2,11 @@
 source: crates/ruff_linter/src/rules/pyflakes/mod.rs
 ---
 F811 Redefinition of unused `fu` from line 1
- --> F811_4.py:1:12
-  |
-1 | import fu; fu, bar = 3
-  |            ^^
-  |
-info: previous definition of `fu` here
  --> F811_4.py:1:8
   |
 1 | import fu; fu, bar = 3
-  |        ^^
+  |        --  ^^
+  |        |
+  |        previous definition of `fu` here
   |
 help: Remove definition: `fu`

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_4.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_4.py.snap
@@ -7,4 +7,10 @@ F811 Redefinition of unused `fu` from line 1
 1 | import fu; fu, bar = 3
   |            ^^
   |
+info: previous definition of `fu` here
+ --> F811_4.py:1:8
+  |
+1 | import fu; fu, bar = 3
+  |        ^^
+  |
 help: Remove definition: `fu`

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_5.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_5.py.snap
@@ -5,7 +5,7 @@ F811 Redefinition of unused `fu` from line 1
  --> F811_5.py:1:8
   |
 1 | import fu; [fu, bar] = 3
-  |        --   ^^
+  |        --   ^^ `fu` redefined here
   |        |
   |        previous definition of `fu` here
   |

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_5.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_5.py.snap
@@ -2,15 +2,11 @@
 source: crates/ruff_linter/src/rules/pyflakes/mod.rs
 ---
 F811 Redefinition of unused `fu` from line 1
- --> F811_5.py:1:13
-  |
-1 | import fu; [fu, bar] = 3
-  |             ^^
-  |
-info: previous definition of `fu` here
  --> F811_5.py:1:8
   |
 1 | import fu; [fu, bar] = 3
-  |        ^^
+  |        --   ^^
+  |        |
+  |        previous definition of `fu` here
   |
 help: Remove definition: `fu`

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_5.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_5.py.snap
@@ -7,4 +7,10 @@ F811 Redefinition of unused `fu` from line 1
 1 | import fu; [fu, bar] = 3
   |             ^^
   |
+info: previous definition of `fu` here
+ --> F811_5.py:1:8
+  |
+1 | import fu; [fu, bar] = 3
+  |        ^^
+  |
 help: Remove definition: `fu`

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_6.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_6.py.snap
@@ -10,6 +10,16 @@ F811 [*] Redefinition of unused `os` from line 5
   |            ^^
 7 | os.path
   |
+info: previous definition of `os` here
+ --> F811_6.py:5:12
+  |
+3 | i = 2
+4 | if i == 1:
+5 |     import os
+  |            ^^
+6 |     import os
+7 | os.path
+  |
 help: Remove definition: `os`
 
 ℹ Safe fix

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_6.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_6.py.snap
@@ -2,22 +2,14 @@
 source: crates/ruff_linter/src/rules/pyflakes/mod.rs
 ---
 F811 [*] Redefinition of unused `os` from line 5
- --> F811_6.py:6:12
-  |
-4 | if i == 1:
-5 |     import os
-6 |     import os
-  |            ^^
-7 | os.path
-  |
-info: previous definition of `os` here
  --> F811_6.py:5:12
   |
 3 | i = 2
 4 | if i == 1:
 5 |     import os
-  |            ^^
+  |            -- previous definition of `os` here
 6 |     import os
+  |            ^^
 7 | os.path
   |
 help: Remove definition: `os`

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_6.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_6.py.snap
@@ -9,7 +9,7 @@ F811 [*] Redefinition of unused `os` from line 5
 5 |     import os
   |            -- previous definition of `os` here
 6 |     import os
-  |            ^^
+  |            ^^ `os` redefined here
 7 | os.path
   |
 help: Remove definition: `os`

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_8.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_8.py.snap
@@ -11,6 +11,15 @@ F811 [*] Redefinition of unused `os` from line 4
 6 | except:
 7 |     pass
   |
+info: previous definition of `os` here
+ --> F811_8.py:4:12
+  |
+3 | try:
+4 |     import os
+  |            ^^
+5 |     import os
+6 | except:
+  |
 help: Remove definition: `os`
 
 ℹ Safe fix

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_8.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_8.py.snap
@@ -2,23 +2,15 @@
 source: crates/ruff_linter/src/rules/pyflakes/mod.rs
 ---
 F811 [*] Redefinition of unused `os` from line 4
- --> F811_8.py:5:12
-  |
-3 | try:
-4 |     import os
-5 |     import os
-  |            ^^
-6 | except:
-7 |     pass
-  |
-info: previous definition of `os` here
  --> F811_8.py:4:12
   |
 3 | try:
 4 |     import os
-  |            ^^
+  |            -- previous definition of `os` here
 5 |     import os
+  |            ^^
 6 | except:
+7 |     pass
   |
 help: Remove definition: `os`
 

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_8.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_8.py.snap
@@ -8,7 +8,7 @@ F811 [*] Redefinition of unused `os` from line 4
 4 |     import os
   |            -- previous definition of `os` here
 5 |     import os
-  |            ^^
+  |            ^^ `os` redefined here
 6 | except:
 7 |     pass
   |

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__del_shadowed_global_import_in_local_scope.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__del_shadowed_global_import_in_local_scope.snap
@@ -26,7 +26,7 @@ F811 [*] Redefinition of unused `os` from line 2
 3 |
 4 | def f():
 5 |     import os
-  |            ^^
+  |            ^^ `os` redefined here
 6 |
 7 |     # Despite this `del`, `import os` in `f` should still be flagged as shadowing an unused
   |

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__del_shadowed_global_import_in_local_scope.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__del_shadowed_global_import_in_local_scope.snap
@@ -19,21 +19,16 @@ help: Remove unused import: `os`
 5 4 |     import os
 
 F811 [*] Redefinition of unused `os` from line 2
- --> <filename>:5:12
+ --> <filename>:2:8
   |
+2 | import os
+  |        -- previous definition of `os` here
+3 |
 4 | def f():
 5 |     import os
   |            ^^
 6 |
 7 |     # Despite this `del`, `import os` in `f` should still be flagged as shadowing an unused
-  |
-info: previous definition of `os` here
- --> <filename>:2:8
-  |
-2 | import os
-  |        ^^
-3 |
-4 | def f():
   |
 help: Remove definition: `os`
 

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__del_shadowed_global_import_in_local_scope.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__del_shadowed_global_import_in_local_scope.snap
@@ -27,6 +27,14 @@ F811 [*] Redefinition of unused `os` from line 2
 6 |
 7 |     # Despite this `del`, `import os` in `f` should still be flagged as shadowing an unused
   |
+info: previous definition of `os` here
+ --> <filename>:2:8
+  |
+2 | import os
+  |        ^^
+3 |
+4 | def f():
+  |
 help: Remove definition: `os`
 
 ℹ Safe fix

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__del_shadowed_import_shadow_in_local_scope.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__del_shadowed_import_shadow_in_local_scope.snap
@@ -26,7 +26,7 @@ F811 Redefinition of unused `os` from line 2
 3 |
 4 | def f():
 5 |     os = 1
-  |     ^^
+  |     ^^ `os` redefined here
 6 |     print(os)
   |
 help: Remove definition: `os`

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__del_shadowed_import_shadow_in_local_scope.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__del_shadowed_import_shadow_in_local_scope.snap
@@ -26,4 +26,12 @@ F811 Redefinition of unused `os` from line 2
   |     ^^
 6 |     print(os)
   |
+info: previous definition of `os` here
+ --> <filename>:2:8
+  |
+2 | import os
+  |        ^^
+3 |
+4 | def f():
+  |
 help: Remove definition: `os`

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__del_shadowed_import_shadow_in_local_scope.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__del_shadowed_import_shadow_in_local_scope.snap
@@ -19,19 +19,14 @@ help: Remove unused import: `os`
 5 4 |     os = 1
 
 F811 Redefinition of unused `os` from line 2
- --> <filename>:5:5
+ --> <filename>:2:8
   |
+2 | import os
+  |        -- previous definition of `os` here
+3 |
 4 | def f():
 5 |     os = 1
   |     ^^
 6 |     print(os)
-  |
-info: previous definition of `os` here
- --> <filename>:2:8
-  |
-2 | import os
-  |        ^^
-3 |
-4 | def f():
   |
 help: Remove definition: `os`

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__del_shadowed_local_import_in_local_scope.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__del_shadowed_local_import_in_local_scope.snap
@@ -2,22 +2,15 @@
 source: crates/ruff_linter/src/rules/pyflakes/mod.rs
 ---
 F811 [*] Redefinition of unused `os` from line 3
- --> <filename>:4:12
-  |
-2 | def f():
-3 |     import os
-4 |     import os
-  |            ^^
-5 |
-6 |     # Despite this `del`, `import os` should still be flagged as shadowing an unused
-  |
-info: previous definition of `os` here
  --> <filename>:3:12
   |
 2 | def f():
 3 |     import os
-  |            ^^
+  |            -- previous definition of `os` here
 4 |     import os
+  |            ^^
+5 |
+6 |     # Despite this `del`, `import os` should still be flagged as shadowing an unused
   |
 help: Remove definition: `os`
 

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__del_shadowed_local_import_in_local_scope.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__del_shadowed_local_import_in_local_scope.snap
@@ -8,7 +8,7 @@ F811 [*] Redefinition of unused `os` from line 3
 3 |     import os
   |            -- previous definition of `os` here
 4 |     import os
-  |            ^^
+  |            ^^ `os` redefined here
 5 |
 6 |     # Despite this `del`, `import os` should still be flagged as shadowing an unused
   |

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__del_shadowed_local_import_in_local_scope.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__del_shadowed_local_import_in_local_scope.snap
@@ -11,6 +11,14 @@ F811 [*] Redefinition of unused `os` from line 3
 5 |
 6 |     # Despite this `del`, `import os` should still be flagged as shadowing an unused
   |
+info: previous definition of `os` here
+ --> <filename>:3:12
+  |
+2 | def f():
+3 |     import os
+  |            ^^
+4 |     import os
+  |
 help: Remove definition: `os`
 
 ℹ Safe fix


### PR DESCRIPTION
## Summary

This is a second attempt at a first use of a new diagnostic feature after #19886. I'll blame rustc for this one because it also has a similar diagnostic:

<img width="735" height="335" alt="image" src="https://github.com/user-attachments/assets/572fe1c3-1742-4ce4-b575-1d9196ff0932" />

We end up with a very similar diagnostic:

<img width="764" height="401" alt="image" src="https://github.com/user-attachments/assets/01eaf0c7-2567-467b-a5d8-a27206b2c74c" />

## Test Plan

New snapshots and manual tests above
