### PR TITLE
[ty] Remove use of `ClassBase::try_from_type` from `super()` machinery

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/class/super.md
+++ b/crates/ty_python_semantic/resources/mdtest/class/super.md
@@ -380,6 +380,9 @@ reveal_type(super(typing.ChainMap, collections.ChainMap()))  # revealed: Unknown
 # Meanwhile, it's not valid to inherit from unsubscripted `typing.Generic`,
 # but it *is* valid as the first argument to `super()`.
 reveal_type(super(typing.Generic, typing.SupportsInt))  # revealed: <super: typing.Generic, <class 'SupportsInt'>>
+
+def _(x: type[typing.Any], y: typing.Any):
+    reveal_type(super(x, y))  # revealed: <super: Any, Any>
 ```
 
 ### Instance Member Access via `super`

--- a/crates/ty_python_semantic/resources/mdtest/class/super.md
+++ b/crates/ty_python_semantic/resources/mdtest/class/super.md
@@ -331,6 +331,9 @@ instance or a subclass of the first. If either condition is violated, a `TypeErr
 runtime.
 
 ```py
+import typing
+import collections
+
 def f(x: int):
     # error: [invalid-super-argument] "`int` is not a valid class"
     super(x, x)
@@ -367,6 +370,16 @@ reveal_type(super(B, A))
 reveal_type(super(B, object))
 
 super(object, object()).__class__
+
+# Not all objects valid in a class's bases list are valid as the first argument to `super()`.
+# For example, it's valid to inherit from `typing.ChainMap`, but it's not valid as the first argument to `super()`.
+#
+# error: [invalid-super-argument] "`typing.ChainMap` is not a valid class"
+reveal_type(super(typing.ChainMap, collections.ChainMap()))  # revealed: Unknown
+
+# Meanwhile, it's not valid to inherit from unsubscripted `typing.Generic`,
+# but it *is* valid as the first argument to `super()`.
+reveal_type(super(typing.Generic, typing.SupportsInt))  # revealed: <super: typing.Generic, <class 'SupportsInt'>>
 ```
 
 ### Instance Member Access via `super`

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -9397,6 +9397,14 @@ impl<'db> BoundSuperType<'db> {
         let pivot_class = match pivot_class_type {
             Type::ClassLiteral(class) => ClassBase::Class(ClassType::NonGeneric(class)),
             Type::GenericAlias(class) => ClassBase::Class(ClassType::Generic(class)),
+            Type::SubclassOf(subclass_of) if subclass_of.subclass_of().is_dynamic() => {
+                ClassBase::Dynamic(
+                    subclass_of
+                        .subclass_of()
+                        .into_dynamic()
+                        .expect("Checked in branch arm"),
+                )
+            }
             Type::SpecialForm(SpecialFormType::Protocol) => ClassBase::Protocol,
             Type::SpecialForm(SpecialFormType::Generic) => ClassBase::Generic,
             Type::SpecialForm(SpecialFormType::TypedDict) => ClassBase::TypedDict,


### PR DESCRIPTION
Followup to conversation in https://github.com/astral-sh/ruff/pull/19560#discussion_r2271570071. `ClassBase::try_from_type` doesn't implement the right semantics here.