### PR TITLE
[ty] Rename `functionArgumentNames` to `callArgumentNames` inlay hint setting

### DIFF
--- a/crates/ty_ide/src/inlay_hints.rs
+++ b/crates/ty_ide/src/inlay_hints.rs
@@ -24,7 +24,7 @@ impl<'db> InlayHint<'db> {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum InlayHintContent<'db> {
     Type(Type<'db>),
-    FunctionArgumentName(String),
+    CallArgumentName(String),
 }
 
 impl<'db> InlayHintContent<'db> {
@@ -44,7 +44,7 @@ impl fmt::Display for DisplayInlayHint<'_, '_> {
             InlayHintContent::Type(ty) => {
                 write!(f, ": {}", ty.display(self.db))
             }
-            InlayHintContent::FunctionArgumentName(name) => {
+            InlayHintContent::CallArgumentName(name) => {
                 write!(f, "{name}=")
             }
         }
@@ -77,21 +77,21 @@ pub struct InlayHintSettings {
     /// ```
     pub variable_types: bool,
 
-    /// Whether to show function argument names.
+    /// Whether to show call argument names.
     ///
     /// For example, this would enable / disable hints like the ones quoted below:
     /// ```python
     /// def foo(x: int): pass
     /// foo("x="1)
     /// ```
-    pub function_argument_names: bool,
+    pub call_argument_names: bool,
 }
 
 impl Default for InlayHintSettings {
     fn default() -> Self {
         Self {
             variable_types: true,
-            function_argument_names: true,
+            call_argument_names: true,
         }
     }
 }
@@ -127,8 +127,8 @@ impl<'a, 'db> InlayHintVisitor<'a, 'db> {
         });
     }
 
-    fn add_function_argument_name(&mut self, position: TextSize, name: String) {
-        if !self.settings.function_argument_names {
+    fn add_call_argument_name(&mut self, position: TextSize, name: String) {
+        if !self.settings.call_argument_names {
             return;
         }
 
@@ -138,7 +138,7 @@ impl<'a, 'db> InlayHintVisitor<'a, 'db> {
 
         self.hints.push(InlayHint {
             position,
-            content: InlayHintContent::FunctionArgumentName(name),
+            content: InlayHintContent::CallArgumentName(name),
         });
     }
 }
@@ -205,7 +205,7 @@ impl SourceOrderVisitor<'_> for InlayHintVisitor<'_, '_> {
 
                 for (index, arg_or_keyword) in call.arguments.arguments_source_order().enumerate() {
                     if let Some(name) = argument_names.get(&index) {
-                        self.add_function_argument_name(
+                        self.add_call_argument_name(
                             arg_or_keyword.range().start(),
                             name.to_string(),
                         );
@@ -301,7 +301,7 @@ mod tests {
         fn inlay_hints(&self) -> String {
             self.inlay_hints_with_settings(&InlayHintSettings {
                 variable_types: true,
-                function_argument_names: true,
+                call_argument_names: true,
             })
         }
 
@@ -857,7 +857,7 @@ mod tests {
         );
 
         assert_snapshot!(test.inlay_hints_with_settings(&InlayHintSettings {
-            function_argument_names: false,
+            call_argument_names: false,
             ..Default::default()
         }), @r"
         def foo(x: int): pass

--- a/crates/ty_server/src/session/options.rs
+++ b/crates/ty_server/src/session/options.rs
@@ -237,14 +237,14 @@ impl WorkspaceOptions {
 #[serde(rename_all = "camelCase")]
 struct InlayHintOptions {
     variable_types: Option<bool>,
-    function_argument_names: Option<bool>,
+    call_argument_names: Option<bool>,
 }
 
 impl InlayHintOptions {
     fn into_settings(self) -> InlayHintSettings {
         InlayHintSettings {
             variable_types: self.variable_types.unwrap_or(true),
-            function_argument_names: self.function_argument_names.unwrap_or(true),
+            call_argument_names: self.call_argument_names.unwrap_or(true),
         }
     }
 }

--- a/crates/ty_wasm/src/lib.rs
+++ b/crates/ty_wasm/src/lib.rs
@@ -438,7 +438,7 @@ impl Workspace {
             // TODO: Provide a way to configure this
             &InlayHintSettings {
                 variable_types: true,
-                function_argument_names: true,
+                call_argument_names: true,
             },
         );
 


### PR DESCRIPTION
## Summary

This PR renames `ty.inlayHints.functionArgumentNames` to `ty.inlayHints.callArgumentNames` which would contain both function calls and class initialization calls i.e., it represents a generic call expression.
