### PR TITLE
[ty] Speedup project file discovery 

### DIFF
--- a/crates/ruff_db/src/files.rs
+++ b/crates/ruff_db/src/files.rs
@@ -87,31 +87,68 @@ impl Files {
             .system_by_path
             .entry(absolute.clone())
             .or_insert_with(|| {
-                tracing::trace!("Adding file '{path}'");
-
                 let metadata = db.system().path_metadata(path);
-                let durability = self
-                    .root(db, path)
-                    .map_or(Durability::default(), |root| root.durability(db));
 
-                let builder = File::builder(FilePath::System(absolute))
-                    .durability(durability)
-                    .path_durability(Durability::HIGH);
-
-                let builder = match metadata {
-                    Ok(metadata) if metadata.file_type().is_file() => builder
-                        .permissions(metadata.permissions())
-                        .revision(metadata.revision()),
-                    Ok(metadata) if metadata.file_type().is_directory() => {
-                        builder.status(FileStatus::IsADirectory)
-                    }
-                    _ => builder
-                        .status(FileStatus::NotFound)
-                        .status_durability(Durability::MEDIUM.max(durability)),
-                };
-
-                builder.new(db)
+                self.create_system_entry(db, absolute, metadata)
             })
+    }
+
+    /// Looks up or inserts a [`File`] at the given path using the provided metadata.
+    ///
+    ///
+    /// Prefer using [`system_path_to_file`] unless its `stats` call when inserting a new file is a performance
+    /// concern because the metadata is already available or when computing the metadata on different threads.
+    ///
+    /// The metadata is only used when inserting a new file. It doesn't
+    /// update the metadata if a [`File`] for `path` already exists.
+    ///
+    /// This function differs from [`system_path_to_file`] in that it doesn't add a dependency
+    /// on `File.status` and always returns a `File`, even
+    /// if `path` doesn't point to a file (e.g. if `path` is a directory).
+    pub fn system_from_metadata(
+        &self,
+        db: &dyn Db,
+        path: &SystemPath,
+        metadata: crate::system::Metadata,
+    ) -> File {
+        let absolute = SystemPath::absolute(path, db.system().current_directory());
+
+        *self
+            .inner
+            .system_by_path
+            .entry(absolute.clone())
+            .or_insert_with(|| self.create_system_entry(db, absolute, Ok(metadata)))
+    }
+
+    fn create_system_entry(
+        &self,
+        db: &dyn Db,
+        absolute_path: SystemPathBuf,
+        metadata: crate::system::Result<crate::system::Metadata>,
+    ) -> File {
+        tracing::trace!("Adding file '{absolute_path}'");
+
+        let durability = self
+            .root(db, &absolute_path)
+            .map_or(Durability::default(), |root| root.durability(db));
+
+        let builder = File::builder(FilePath::System(absolute_path))
+            .durability(durability)
+            .path_durability(Durability::HIGH);
+
+        let builder = match metadata {
+            Ok(metadata) if metadata.file_type().is_file() => builder
+                .permissions(metadata.permissions())
+                .revision(metadata.revision()),
+            Ok(metadata) if metadata.file_type().is_directory() => {
+                builder.status(FileStatus::IsADirectory)
+            }
+            _ => builder
+                .status(FileStatus::NotFound)
+                .status_durability(Durability::MEDIUM.max(durability)),
+        };
+
+        builder.new(db)
     }
 
     /// Tries to look up the file for the given system path, returns `None` if no such file exists yet

--- a/crates/ruff_db/src/system.rs
+++ b/crates/ruff_db/src/system.rs
@@ -46,7 +46,7 @@ pub type Result<T> = std::io::Result<T>;
 ///    * File watching isn't supported.
 ///
 /// Abstracting the system also enables tests to use a more efficient in-memory file system.
-pub trait System: Debug + Sync {
+pub trait System: Debug {
     /// Reads the metadata of the file or directory at `path`.
     ///
     /// This function will traverse symbolic links to query information about the destination file.

--- a/crates/ruff_db/src/system.rs
+++ b/crates/ruff_db/src/system.rs
@@ -46,7 +46,7 @@ pub type Result<T> = std::io::Result<T>;
 ///    * File watching isn't supported.
 ///
 /// Abstracting the system also enables tests to use a more efficient in-memory file system.
-pub trait System: Debug {
+pub trait System: Debug + Sync {
     /// Reads the metadata of the file or directory at `path`.
     ///
     /// This function will traverse symbolic links to query information about the destination file.

--- a/crates/ty_project/src/db.rs
+++ b/crates/ty_project/src/db.rs
@@ -21,6 +21,8 @@ mod changes;
 #[salsa::db]
 pub trait Db: SemanticDb {
     fn project(&self) -> Project;
+
+    fn dyn_clone(&self) -> Box<dyn Db>;
 }
 
 #[salsa::db]
@@ -484,6 +486,10 @@ impl Db for ProjectDatabase {
     fn project(&self) -> Project {
         self.project.unwrap()
     }
+
+    fn dyn_clone(&self) -> Box<dyn Db> {
+        Box::new(self.clone())
+    }
 }
 
 #[cfg(feature = "format")]
@@ -610,6 +616,10 @@ pub(crate) mod tests {
     impl Db for TestDb {
         fn project(&self) -> Project {
             self.project.unwrap()
+        }
+
+        fn dyn_clone(&self) -> Box<dyn Db> {
+            Box::new(self.clone())
         }
     }
 


### PR DESCRIPTION
## Summary

The `ProjectFilesWalker` discovers all the files to check in a ty project by spawning multiple threads that walk the directory tree.
The walker's output is a `Vec` or `Set` of all the `File`s. The way this works today is that we first collect all file paths (multi threaded)
into a single `Vec`, and the main thread then interns the paths to their `File`'s. 

The problem with this approach is that `system_path_to_file` is fairly expensive when called for many files because it does a `stat` call internally. 

The ideal solution would move the `system_path_to_file` call to the walker threads. That would also eliminate the shared `Vec` that collects all paths. Unfortunately, this isn't possible because `&dyn Db` isn't `Send` nor does `&dyn Db` implement `Clone` (Salsa does have a `fork_db` feature but this isn't publicly exposed as of today). We also can't add a `fork` method to `ty_project::Db` that returns a cloned `Self` because the `Db` trait must be dyn compatible. 

~~The solution I've taken here is to move the stat files into the walker threads, which fixes most of the waterfall effect and is much simpler than exposing `fork_db` properly in salsa.~~

I implemented the ideal solution thanks to @ibraheemdev's suggestion to add a `dyn_clone`!

Fixes https://github.com/astral-sh/ty/issues/970


## Test Plan

Before 
<img width="689" height="960" alt="Screenshot 2025-08-14 at 14 04 46" src="https://github.com/user-attachments/assets/67908e8c-0881-4a98-9446-9d03a984706d" />


After

<img width="689" height="960" alt="Screenshot 2025-08-14 at 14 04 59" src="https://github.com/user-attachments/assets/3501d3da-912d-46b0-9ead-daa937b31f73" />

