### PR TITLE
Show fixes by default

### DIFF
--- a/crates/ruff/src/printer.rs
+++ b/crates/ruff/src/printer.rs
@@ -30,8 +30,6 @@ bitflags! {
         const SHOW_VIOLATIONS = 1 << 0;
         /// Whether to show a summary of the fixed violations when emitting diagnostics.
         const SHOW_FIX_SUMMARY = 1 << 1;
-        /// Whether to show a diff of each fixed violation when emitting diagnostics.
-        const SHOW_FIX_DIFF = 1 << 2;
     }
 }
 
@@ -260,7 +258,7 @@ impl Printer {
             OutputFormat::Concise | OutputFormat::Full => {
                 TextEmitter::default()
                     .with_show_fix_status(show_fix_status(self.fix_mode, fixables.as_ref()))
-                    .with_show_fix_diff(self.flags.intersects(Flags::SHOW_FIX_DIFF))
+                    .with_show_fix_diff(self.format == OutputFormat::Full && preview)
                     .with_show_source(self.format == OutputFormat::Full)
                     .with_fix_applicability(self.unsafe_fixes.required_applicability())
                     .with_preview(preview)

--- a/crates/ruff/src/printer.rs
+++ b/crates/ruff/src/printer.rs
@@ -262,7 +262,7 @@ impl Printer {
                     .with_show_fix_status(show_fix_status(self.fix_mode, fixables.as_ref()))
                     .with_show_fix_diff(self.flags.intersects(Flags::SHOW_FIX_DIFF))
                     .with_show_source(self.format == OutputFormat::Full)
-                    .with_unsafe_fixes(self.unsafe_fixes)
+                    .with_fix_applicability(self.unsafe_fixes.required_applicability())
                     .with_preview(preview)
                     .emit(writer, &diagnostics.inner, &context)?;
 
@@ -464,7 +464,7 @@ impl Printer {
             TextEmitter::default()
                 .with_show_fix_status(show_fix_status(self.fix_mode, fixables.as_ref()))
                 .with_show_source(preview)
-                .with_unsafe_fixes(self.unsafe_fixes)
+                .with_fix_applicability(self.unsafe_fixes.required_applicability())
                 .emit(writer, &diagnostics.inner, &context)?;
         }
         writer.flush()?;

--- a/crates/ruff/tests/lint.rs
+++ b/crates/ruff/tests/lint.rs
@@ -5830,3 +5830,33 @@ nested_optional: Optional[Optional[Optional[str]]] = None
     ",
     );
 }
+
+#[test]
+fn show_fixes_in_full_output_with_preview_enabled() {
+    assert_cmd_snapshot!(
+        Command::new(get_cargo_bin(BIN_NAME))
+            .args(["check", "--no-cache", "--output-format", "full"])
+            .args(["--select", "F401"])
+            .arg("--preview")
+            .arg("-")
+            .pass_stdin("import math"),
+        @r"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    F401 [*] `math` imported but unused
+     --> -:1:8
+      |
+    1 | import math
+      |        ^^^^
+      |
+    help: Remove unused import: `math`
+      - import math
+
+    Found 1 error.
+    [*] 1 fixable with the `--fix` option.
+
+    ----- stderr -----
+    ",
+    );
+}

--- a/crates/ruff_db/src/diagnostic/mod.rs
+++ b/crates/ruff_db/src/diagnostic/mod.rs
@@ -349,6 +349,13 @@ impl Diagnostic {
         self.fix().is_some()
     }
 
+    /// Returns `true` if the diagnostic is [`fixable`](Diagnostic::fixable) and applies at the
+    /// configured applicability level.
+    pub fn fix_applies(&self, config: &DisplayDiagnosticConfig) -> bool {
+        self.fix()
+            .is_some_and(|fix| fix.applies(config.fix_applicability))
+    }
+
     /// Returns the offset of the parent statement for this diagnostic if it exists.
     ///
     /// This is primarily used for checking noqa/secondary code suppressions.

--- a/crates/ruff_db/src/diagnostic/mod.rs
+++ b/crates/ruff_db/src/diagnostic/mod.rs
@@ -351,7 +351,7 @@ impl Diagnostic {
 
     /// Returns `true` if the diagnostic is [`fixable`](Diagnostic::fixable) and applies at the
     /// configured applicability level.
-    pub fn fix_applies(&self, config: &DisplayDiagnosticConfig) -> bool {
+    pub fn is_fix_applicable(&self, config: &DisplayDiagnosticConfig) -> bool {
         self.fix()
             .is_some_and(|fix| fix.applies(config.fix_applicability))
     }

--- a/crates/ruff_db/src/diagnostic/mod.rs
+++ b/crates/ruff_db/src/diagnostic/mod.rs
@@ -351,7 +351,7 @@ impl Diagnostic {
 
     /// Returns `true` if the diagnostic is [`fixable`](Diagnostic::fixable) and applies at the
     /// configured applicability level.
-    pub fn is_fix_applicable(&self, config: &DisplayDiagnosticConfig) -> bool {
+    pub fn has_applicable_fix(&self, config: &DisplayDiagnosticConfig) -> bool {
         self.fix()
             .is_some_and(|fix| fix.applies(config.fix_applicability))
     }

--- a/crates/ruff_db/src/diagnostic/render.rs
+++ b/crates/ruff_db/src/diagnostic/render.rs
@@ -254,7 +254,7 @@ impl<'a> ResolvedDiagnostic<'a> {
             id,
             message: diag.inner.message.as_str().to_string(),
             annotations,
-            is_fixable: diag.is_fix_applicable(config),
+            is_fixable: diag.has_applicable_fix(config),
         }
     }
 

--- a/crates/ruff_db/src/diagnostic/render.rs
+++ b/crates/ruff_db/src/diagnostic/render.rs
@@ -254,9 +254,7 @@ impl<'a> ResolvedDiagnostic<'a> {
             id,
             message: diag.inner.message.as_str().to_string(),
             annotations,
-            is_fixable: diag
-                .fix()
-                .is_some_and(|fix| fix.applies(config.fix_applicability)),
+            is_fixable: diag.fix_applies(config),
         }
     }
 

--- a/crates/ruff_db/src/diagnostic/render.rs
+++ b/crates/ruff_db/src/diagnostic/render.rs
@@ -254,7 +254,7 @@ impl<'a> ResolvedDiagnostic<'a> {
             id,
             message: diag.inner.message.as_str().to_string(),
             annotations,
-            is_fixable: diag.fix_applies(config),
+            is_fixable: diag.is_fix_applicable(config),
         }
     }
 

--- a/crates/ruff_db/src/diagnostic/render/concise.rs
+++ b/crates/ruff_db/src/diagnostic/render/concise.rs
@@ -77,11 +77,9 @@ impl<'a> ConciseRenderer<'a> {
                     )?;
                 }
                 if self.config.show_fix_status {
-                    if let Some(fix) = diag.fix() {
-                        // Do not display an indicator for inapplicable fixes
-                        if fix.applies(self.config.fix_applicability) {
-                            write!(f, "[{fix}] ", fix = fmt_styled("*", stylesheet.separator))?;
-                        }
+                    // Do not display an indicator for inapplicable fixes
+                    if diag.fix_applies(self.config) {
+                        write!(f, "[{fix}] ", fix = fmt_styled("*", stylesheet.separator))?;
                     }
                 }
             } else {

--- a/crates/ruff_db/src/diagnostic/render/concise.rs
+++ b/crates/ruff_db/src/diagnostic/render/concise.rs
@@ -78,7 +78,7 @@ impl<'a> ConciseRenderer<'a> {
                 }
                 if self.config.show_fix_status {
                     // Do not display an indicator for inapplicable fixes
-                    if diag.is_fix_applicable(self.config) {
+                    if diag.has_applicable_fix(self.config) {
                         write!(f, "[{fix}] ", fix = fmt_styled("*", stylesheet.separator))?;
                     }
                 }

--- a/crates/ruff_db/src/diagnostic/render/concise.rs
+++ b/crates/ruff_db/src/diagnostic/render/concise.rs
@@ -78,7 +78,7 @@ impl<'a> ConciseRenderer<'a> {
                 }
                 if self.config.show_fix_status {
                     // Do not display an indicator for inapplicable fixes
-                    if diag.fix_applies(self.config) {
+                    if diag.is_fix_applicable(self.config) {
                         write!(f, "[{fix}] ", fix = fmt_styled("*", stylesheet.separator))?;
                     }
                 }

--- a/crates/ruff_db/src/diagnostic/render/full.rs
+++ b/crates/ruff_db/src/diagnostic/render/full.rs
@@ -58,7 +58,7 @@ impl<'a> FullRenderer<'a> {
                 writeln!(f, "{}", renderer.render(diag.to_annotate()))?;
             }
 
-            if self.config.show_fix_diff && diag.fix_applies(self.config) {
+            if self.config.show_fix_diff && diag.is_fix_applicable(self.config) {
                 if let Some(diff) = Diff::from_diagnostic(diag, &stylesheet, self.resolver) {
                     write!(f, "{diff}")?;
                 }

--- a/crates/ruff_db/src/diagnostic/render/full.rs
+++ b/crates/ruff_db/src/diagnostic/render/full.rs
@@ -58,7 +58,7 @@ impl<'a> FullRenderer<'a> {
                 writeln!(f, "{}", renderer.render(diag.to_annotate()))?;
             }
 
-            if self.config.show_fix_diff && diag.is_fix_applicable(self.config) {
+            if self.config.show_fix_diff && diag.has_applicable_fix(self.config) {
                 if let Some(diff) = Diff::from_diagnostic(diag, &stylesheet, self.resolver) {
                     write!(f, "{diff}")?;
                 }

--- a/crates/ruff_db/src/diagnostic/render/full.rs
+++ b/crates/ruff_db/src/diagnostic/render/full.rs
@@ -58,7 +58,7 @@ impl<'a> FullRenderer<'a> {
                 writeln!(f, "{}", renderer.render(diag.to_annotate()))?;
             }
 
-            if self.config.show_fix_diff {
+            if self.config.show_fix_diff && diag.fix_applies(self.config) {
                 if let Some(diff) = Diff::from_diagnostic(diag, &stylesheet, self.resolver) {
                     write!(f, "{diff}")?;
                 }

--- a/crates/ruff_db/src/diagnostic/render/full.rs
+++ b/crates/ruff_db/src/diagnostic/render/full.rs
@@ -697,6 +697,8 @@ print()
     fn notebook_output_with_diff() {
         let (mut env, diagnostics) = create_notebook_diagnostics(DiagnosticFormat::Full);
         env.show_fix_diff(true);
+        env.fix_applicability(Applicability::DisplayOnly);
+
         insta::assert_snapshot!(env.render_diagnostics(&diagnostics), @r"
         error[unused-import][*]: `os` imported but unused
          --> notebook.ipynb:cell 1:2:8
@@ -726,7 +728,7 @@ print()
         2 | 
         3 | print('hello world')
 
-        error[unused-variable]: Local variable `x` is assigned to but never used
+        error[unused-variable][*]: Local variable `x` is assigned to but never used
          --> notebook.ipynb:cell 3:4:5
           |
         2 | def foo():
@@ -749,6 +751,7 @@ print()
     fn notebook_output_with_diff_spanning_cells() {
         let (mut env, mut diagnostics) = create_notebook_diagnostics(DiagnosticFormat::Full);
         env.show_fix_diff(true);
+        env.fix_applicability(Applicability::DisplayOnly);
 
         // Move all of the edits from the later diagnostics to the first diagnostic to simulate a
         // single diagnostic with edits in different cells.
@@ -761,7 +764,7 @@ print()
         *fix = Fix::unsafe_edits(edits.remove(0), edits);
 
         insta::assert_snapshot!(env.render(&diagnostic), @r"
-        error[unused-import]: `os` imported but unused
+        error[unused-import][*]: `os` imported but unused
          --> notebook.ipynb:cell 1:2:8
           |
         1 | # cell 1
@@ -924,6 +927,7 @@ line 10
         env.add("example.py", contents);
         env.format(DiagnosticFormat::Full);
         env.show_fix_diff(true);
+        env.fix_applicability(Applicability::DisplayOnly);
 
         let mut diagnostic = env.err().primary("example.py", "3", "3", "label").build();
         diagnostic.help("Start of diff:");
@@ -936,7 +940,7 @@ line 10
         )));
 
         insta::assert_snapshot!(env.render(&diagnostic), @r"
-        error[test-diagnostic]: main diagnostic message
+        error[test-diagnostic][*]: main diagnostic message
          --> example.py:3:1
           |
         1 | line 1

--- a/crates/ruff_linter/src/message/text.rs
+++ b/crates/ruff_linter/src/message/text.rs
@@ -3,9 +3,9 @@ use std::io::Write;
 use ruff_db::diagnostic::{
     Diagnostic, DiagnosticFormat, DisplayDiagnosticConfig, DisplayDiagnostics,
 };
+use ruff_diagnostics::Applicability;
 
 use crate::message::{Emitter, EmitterContext};
-use crate::settings::types::UnsafeFixes;
 
 pub struct TextEmitter {
     config: DisplayDiagnosticConfig,
@@ -46,10 +46,8 @@ impl TextEmitter {
     }
 
     #[must_use]
-    pub fn with_unsafe_fixes(mut self, unsafe_fixes: UnsafeFixes) -> Self {
-        self.config = self
-            .config
-            .fix_applicability(unsafe_fixes.required_applicability());
+    pub fn with_fix_applicability(mut self, applicability: Applicability) -> Self {
+        self.config = self.config.fix_applicability(applicability);
         self
     }
 
@@ -86,13 +84,13 @@ impl Emitter for TextEmitter {
 #[cfg(test)]
 mod tests {
     use insta::assert_snapshot;
+    use ruff_diagnostics::Applicability;
 
     use crate::message::TextEmitter;
     use crate::message::tests::{
         capture_emitter_notebook_output, capture_emitter_output, create_diagnostics,
         create_notebook_diagnostics, create_syntax_error_diagnostics,
     };
-    use crate::settings::types::UnsafeFixes;
 
     #[test]
     fn default() {
@@ -117,7 +115,7 @@ mod tests {
         let mut emitter = TextEmitter::default()
             .with_show_fix_status(true)
             .with_show_source(true)
-            .with_unsafe_fixes(UnsafeFixes::Enabled);
+            .with_fix_applicability(Applicability::Unsafe);
         let content = capture_emitter_output(&mut emitter, &create_diagnostics());
 
         assert_snapshot!(content);
@@ -128,7 +126,7 @@ mod tests {
         let mut emitter = TextEmitter::default()
             .with_show_fix_status(true)
             .with_show_source(true)
-            .with_unsafe_fixes(UnsafeFixes::Enabled);
+            .with_fix_applicability(Applicability::Unsafe);
         let (messages, notebook_indexes) = create_notebook_diagnostics();
         let content = capture_emitter_notebook_output(&mut emitter, &messages, &notebook_indexes);
 

--- a/crates/ruff_linter/src/rules/eradicate/snapshots/ruff_linter__rules__eradicate__tests__ERA001_ERA001.py.snap
+++ b/crates/ruff_linter/src/rules/eradicate/snapshots/ruff_linter__rules__eradicate__tests__ERA001_ERA001.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/eradicate/mod.rs
 ---
-ERA001 Found commented-out code
+ERA001 [*] Found commented-out code
  --> ERA001.py:1:1
   |
 1 | #import os
@@ -16,7 +16,7 @@ help: Remove commented-out code
 3 | a = 4
 note: This is a display-only fix and is likely to be incorrect
 
-ERA001 Found commented-out code
+ERA001 [*] Found commented-out code
  --> ERA001.py:2:1
   |
 1 | #import os
@@ -33,7 +33,7 @@ help: Remove commented-out code
 4 | #foo(1, 2, 3)
 note: This is a display-only fix and is likely to be incorrect
 
-ERA001 Found commented-out code
+ERA001 [*] Found commented-out code
  --> ERA001.py:3:1
   |
 1 | #import os
@@ -52,7 +52,7 @@ help: Remove commented-out code
 5 | 
 note: This is a display-only fix and is likely to be incorrect
 
-ERA001 Found commented-out code
+ERA001 [*] Found commented-out code
  --> ERA001.py:5:1
   |
 3 | #a = 3
@@ -72,7 +72,7 @@ help: Remove commented-out code
 7 |     content = 1 # print('hello')
 note: This is a display-only fix and is likely to be incorrect
 
-ERA001 Found commented-out code
+ERA001 [*] Found commented-out code
   --> ERA001.py:13:5
    |
 11 |     # This is a real comment.
@@ -91,7 +91,7 @@ help: Remove commented-out code
 15 | #import os  # noqa: ERA001
 note: This is a display-only fix and is likely to be incorrect
 
-ERA001 Found commented-out code
+ERA001 [*] Found commented-out code
   --> ERA001.py:21:5
    |
 19 | class A():
@@ -109,7 +109,7 @@ help: Remove commented-out code
 23 | dictionary = {
 note: This is a display-only fix and is likely to be incorrect
 
-ERA001 Found commented-out code
+ERA001 [*] Found commented-out code
   --> ERA001.py:26:5
    |
 24 | dictionary = {
@@ -129,7 +129,7 @@ help: Remove commented-out code
 28 | 
 note: This is a display-only fix and is likely to be incorrect
 
-ERA001 Found commented-out code
+ERA001 [*] Found commented-out code
   --> ERA001.py:27:5
    |
 25 |     # "key1": 123,  # noqa: ERA001
@@ -148,7 +148,7 @@ help: Remove commented-out code
 29 | #import os  # noqa
 note: This is a display-only fix and is likely to be incorrect
 
-ERA001 Found commented-out code
+ERA001 [*] Found commented-out code
   --> ERA001.py:32:1
    |
 30 | #import os  # noqa
@@ -168,7 +168,7 @@ help: Remove commented-out code
 34 | # try: print()
 note: This is a display-only fix and is likely to be incorrect
 
-ERA001 Found commented-out code
+ERA001 [*] Found commented-out code
   --> ERA001.py:33:1
    |
 32 | # case 1:
@@ -187,7 +187,7 @@ help: Remove commented-out code
 35 | # except:
 note: This is a display-only fix and is likely to be incorrect
 
-ERA001 Found commented-out code
+ERA001 [*] Found commented-out code
   --> ERA001.py:34:1
    |
 32 | # case 1:
@@ -207,7 +207,7 @@ help: Remove commented-out code
 36 | # except Foo:
 note: This is a display-only fix and is likely to be incorrect
 
-ERA001 Found commented-out code
+ERA001 [*] Found commented-out code
   --> ERA001.py:35:1
    |
 33 | # try:
@@ -227,7 +227,7 @@ help: Remove commented-out code
 37 | # except Exception as e: print(e)
 note: This is a display-only fix and is likely to be incorrect
 
-ERA001 Found commented-out code
+ERA001 [*] Found commented-out code
   --> ERA001.py:36:1
    |
 34 | # try:  # with comment
@@ -247,7 +247,7 @@ help: Remove commented-out code
 38 | 
 note: This is a display-only fix and is likely to be incorrect
 
-ERA001 Found commented-out code
+ERA001 [*] Found commented-out code
   --> ERA001.py:37:1
    |
 35 | # try: print()
@@ -266,7 +266,7 @@ help: Remove commented-out code
 39 | 
 note: This is a display-only fix and is likely to be incorrect
 
-ERA001 Found commented-out code
+ERA001 [*] Found commented-out code
   --> ERA001.py:38:1
    |
 36 | # except:
@@ -284,7 +284,7 @@ help: Remove commented-out code
 40 | # Script tag without an opening tag (Error)
 note: This is a display-only fix and is likely to be incorrect
 
-ERA001 Found commented-out code
+ERA001 [*] Found commented-out code
   --> ERA001.py:44:1
    |
 43 | # requires-python = ">=3.11"
@@ -303,7 +303,7 @@ help: Remove commented-out code
 46 | # ]
 note: This is a display-only fix and is likely to be incorrect
 
-ERA001 Found commented-out code
+ERA001 [*] Found commented-out code
   --> ERA001.py:47:1
    |
 45 | #   "requests<3",
@@ -322,7 +322,7 @@ help: Remove commented-out code
 49 | # Script tag (OK)
 note: This is a display-only fix and is likely to be incorrect
 
-ERA001 Found commented-out code
+ERA001 [*] Found commented-out code
   --> ERA001.py:75:1
    |
 73 | # /// script
@@ -342,7 +342,7 @@ help: Remove commented-out code
 77 | # ]
 note: This is a display-only fix and is likely to be incorrect
 
-ERA001 Found commented-out code
+ERA001 [*] Found commented-out code
   --> ERA001.py:78:1
    |
 76 | #   "requests<3",

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI034_PYI034.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI034_PYI034.py.snap
@@ -277,7 +277,7 @@ help: Use `Self` as return type
 334 |     def __new__(cls: type[Generic1]) -> Generic1: ...
 note: This is an unsafe fix and may change runtime behavior
 
-PYI034 `__new__` methods in classes like `Generic1` usually return `self` at runtime
+PYI034 [*] `__new__` methods in classes like `Generic1` usually return `self` at runtime
    --> PYI034.py:334:9
     |
 333 | class Generic1[T](list):
@@ -296,7 +296,7 @@ help: Use `Self` as return type
 337 | 
 note: This is a display-only fix and is likely to be incorrect
 
-PYI034 `__enter__` methods in classes like `Generic1` usually return `self` at runtime
+PYI034 [*] `__enter__` methods in classes like `Generic1` usually return `self` at runtime
    --> PYI034.py:335:9
     |
 333 | class Generic1[T](list):
@@ -315,7 +315,7 @@ help: Use `Self` as return type
 338 | ### Correctness of typevar-likes are not verified.
 note: This is a display-only fix and is likely to be incorrect
 
-PYI034 `__new__` methods in classes like `Generic2` usually return `self` at runtime
+PYI034 [*] `__new__` methods in classes like `Generic2` usually return `self` at runtime
    --> PYI034.py:345:9
     |
 344 | class Generic2(Generic[T]):
@@ -334,7 +334,7 @@ help: Use `Self` as return type
 348 | class Generic3(tuple[*Ts]):
 note: This is a display-only fix and is likely to be incorrect
 
-PYI034 `__enter__` methods in classes like `Generic2` usually return `self` at runtime
+PYI034 [*] `__enter__` methods in classes like `Generic2` usually return `self` at runtime
    --> PYI034.py:346:9
     |
 344 | class Generic2(Generic[T]):
@@ -355,7 +355,7 @@ help: Use `Self` as return type
 349 |     def __new__(cls: type[Generic3]) -> Generic3: ...
 note: This is a display-only fix and is likely to be incorrect
 
-PYI034 `__new__` methods in classes like `Generic3` usually return `self` at runtime
+PYI034 [*] `__new__` methods in classes like `Generic3` usually return `self` at runtime
    --> PYI034.py:349:9
     |
 348 | class Generic3(tuple[*Ts]):
@@ -374,7 +374,7 @@ help: Use `Self` as return type
 352 | class Generic4(collections.abc.Callable[P, ...]):
 note: This is a display-only fix and is likely to be incorrect
 
-PYI034 `__enter__` methods in classes like `Generic3` usually return `self` at runtime
+PYI034 [*] `__enter__` methods in classes like `Generic3` usually return `self` at runtime
    --> PYI034.py:350:9
     |
 348 | class Generic3(tuple[*Ts]):
@@ -395,7 +395,7 @@ help: Use `Self` as return type
 353 |     def __new__(cls: type[Generic4]) -> Generic4: ...
 note: This is a display-only fix and is likely to be incorrect
 
-PYI034 `__new__` methods in classes like `Generic4` usually return `self` at runtime
+PYI034 [*] `__new__` methods in classes like `Generic4` usually return `self` at runtime
    --> PYI034.py:353:9
     |
 352 | class Generic4(collections.abc.Callable[P, ...]):
@@ -414,7 +414,7 @@ help: Use `Self` as return type
 356 | from some_module import PotentialTypeVar
 note: This is a display-only fix and is likely to be incorrect
 
-PYI034 `__enter__` methods in classes like `Generic4` usually return `self` at runtime
+PYI034 [*] `__enter__` methods in classes like `Generic4` usually return `self` at runtime
    --> PYI034.py:354:9
     |
 352 | class Generic4(collections.abc.Callable[P, ...]):

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI034_PYI034.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI034_PYI034.pyi.snap
@@ -258,7 +258,7 @@ help: Use `Self` as return type
 228 |     def __new__(cls: type[Generic1]) -> Generic1: ...
 note: This is an unsafe fix and may change runtime behavior
 
-PYI034 `__new__` methods in classes like `Generic1` usually return `self` at runtime
+PYI034 [*] `__new__` methods in classes like `Generic1` usually return `self` at runtime
    --> PYI034.pyi:228:9
     |
 227 | class Generic1[T](list):
@@ -277,7 +277,7 @@ help: Use `Self` as return type
 231 | 
 note: This is a display-only fix and is likely to be incorrect
 
-PYI034 `__enter__` methods in classes like `Generic1` usually return `self` at runtime
+PYI034 [*] `__enter__` methods in classes like `Generic1` usually return `self` at runtime
    --> PYI034.pyi:229:9
     |
 227 | class Generic1[T](list):
@@ -296,7 +296,7 @@ help: Use `Self` as return type
 232 | ### Correctness of typevar-likes are not verified.
 note: This is a display-only fix and is likely to be incorrect
 
-PYI034 `__new__` methods in classes like `Generic2` usually return `self` at runtime
+PYI034 [*] `__new__` methods in classes like `Generic2` usually return `self` at runtime
    --> PYI034.pyi:239:9
     |
 238 | class Generic2(Generic[T]):
@@ -315,7 +315,7 @@ help: Use `Self` as return type
 242 | class Generic3(tuple[*Ts]):
 note: This is a display-only fix and is likely to be incorrect
 
-PYI034 `__enter__` methods in classes like `Generic2` usually return `self` at runtime
+PYI034 [*] `__enter__` methods in classes like `Generic2` usually return `self` at runtime
    --> PYI034.pyi:240:9
     |
 238 | class Generic2(Generic[T]):
@@ -336,7 +336,7 @@ help: Use `Self` as return type
 243 |     def __new__(cls: type[Generic3]) -> Generic3: ...
 note: This is a display-only fix and is likely to be incorrect
 
-PYI034 `__new__` methods in classes like `Generic3` usually return `self` at runtime
+PYI034 [*] `__new__` methods in classes like `Generic3` usually return `self` at runtime
    --> PYI034.pyi:243:9
     |
 242 | class Generic3(tuple[*Ts]):
@@ -355,7 +355,7 @@ help: Use `Self` as return type
 246 | class Generic4(collections.abc.Callable[P, ...]):
 note: This is a display-only fix and is likely to be incorrect
 
-PYI034 `__enter__` methods in classes like `Generic3` usually return `self` at runtime
+PYI034 [*] `__enter__` methods in classes like `Generic3` usually return `self` at runtime
    --> PYI034.pyi:244:9
     |
 242 | class Generic3(tuple[*Ts]):
@@ -376,7 +376,7 @@ help: Use `Self` as return type
 247 |     def __new__(cls: type[Generic4]) -> Generic4: ...
 note: This is a display-only fix and is likely to be incorrect
 
-PYI034 `__new__` methods in classes like `Generic4` usually return `self` at runtime
+PYI034 [*] `__new__` methods in classes like `Generic4` usually return `self` at runtime
    --> PYI034.pyi:247:9
     |
 246 | class Generic4(collections.abc.Callable[P, ...]):
@@ -395,7 +395,7 @@ help: Use `Self` as return type
 250 | from some_module import PotentialTypeVar
 note: This is a display-only fix and is likely to be incorrect
 
-PYI034 `__enter__` methods in classes like `Generic4` usually return `self` at runtime
+PYI034 [*] `__enter__` methods in classes like `Generic4` usually return `self` at runtime
    --> PYI034.pyi:248:9
     |
 246 | class Generic4(collections.abc.Callable[P, ...]):
@@ -416,7 +416,7 @@ help: Use `Self` as return type
 251 | 
 note: This is a display-only fix and is likely to be incorrect
 
-PYI034 `__new__` methods in classes like `Generic5` usually return `self` at runtime
+PYI034 [*] `__new__` methods in classes like `Generic5` usually return `self` at runtime
    --> PYI034.pyi:253:9
     |
 252 | class Generic5(list[PotentialTypeVar]):
@@ -433,7 +433,7 @@ help: Use `Self` as return type
 254 |     def __enter__(self: Generic5) -> Generic5: ...
 note: This is a display-only fix and is likely to be incorrect
 
-PYI034 `__enter__` methods in classes like `Generic5` usually return `self` at runtime
+PYI034 [*] `__enter__` methods in classes like `Generic5` usually return `self` at runtime
    --> PYI034.pyi:254:9
     |
 252 | class Generic5(list[PotentialTypeVar]):

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT028.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT028.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_pytest_style/mod.rs
 ---
-PT028 Test function parameter `a` has default argument
+PT028 [*] Test function parameter `a` has default argument
  --> PT028.py:3:16
   |
 1 | # Errors
@@ -21,7 +21,7 @@ help: Remove default argument
 6 | def test_foo(a: int=1): ...
 note: This is a display-only fix and is likely to be incorrect
 
-PT028 Test function parameter `a` has default argument
+PT028 [*] Test function parameter `a` has default argument
  --> PT028.py:4:18
   |
 3 | def test_foo(a=1): ...
@@ -41,7 +41,7 @@ help: Remove default argument
 7 | def test_foo(a: int = 1): ...
 note: This is a display-only fix and is likely to be incorrect
 
-PT028 Test function parameter `a` has default argument
+PT028 [*] Test function parameter `a` has default argument
  --> PT028.py:5:19
   |
 3 | def test_foo(a=1): ...
@@ -62,7 +62,7 @@ help: Remove default argument
 8 | def test_foo(a: (int) = 1): ...
 note: This is a display-only fix and is likely to be incorrect
 
-PT028 Test function parameter `a` has default argument
+PT028 [*] Test function parameter `a` has default argument
  --> PT028.py:6:21
   |
 4 | def test_foo(a = 1): ...
@@ -83,7 +83,7 @@ help: Remove default argument
 9 | def test_foo(a: int = (1)): ...
 note: This is a display-only fix and is likely to be incorrect
 
-PT028 Test function parameter `a` has default argument
+PT028 [*] Test function parameter `a` has default argument
  --> PT028.py:7:23
   |
 5 | def test_foo(a = (1)): ...
@@ -104,7 +104,7 @@ help: Remove default argument
 10 | def test_foo(a: (int) = (1)): ...
 note: This is a display-only fix and is likely to be incorrect
 
-PT028 Test function parameter `a` has default argument
+PT028 [*] Test function parameter `a` has default argument
   --> PT028.py:8:25
    |
  6 | def test_foo(a: int=1): ...
@@ -125,7 +125,7 @@ help: Remove default argument
 11 | def test_foo(a=1, /, b=2, *, c=3): ...
 note: This is a display-only fix and is likely to be incorrect
 
-PT028 Test function parameter `a` has default argument
+PT028 [*] Test function parameter `a` has default argument
   --> PT028.py:9:24
    |
  7 | def test_foo(a: int = 1): ...
@@ -146,7 +146,7 @@ help: Remove default argument
 12 | 
 note: This is a display-only fix and is likely to be incorrect
 
-PT028 Test function parameter `a` has default argument
+PT028 [*] Test function parameter `a` has default argument
   --> PT028.py:10:26
    |
  8 | def test_foo(a: (int) = 1): ...
@@ -166,7 +166,7 @@ help: Remove default argument
 13 | 
 note: This is a display-only fix and is likely to be incorrect
 
-PT028 Test function parameter `a` has default argument
+PT028 [*] Test function parameter `a` has default argument
   --> PT028.py:11:16
    |
  9 | def test_foo(a: int = (1)): ...
@@ -185,7 +185,7 @@ help: Remove default argument
 14 | # No errors
 note: This is a display-only fix and is likely to be incorrect
 
-PT028 Test function parameter `b` has default argument
+PT028 [*] Test function parameter `b` has default argument
   --> PT028.py:11:24
    |
  9 | def test_foo(a: int = (1)): ...
@@ -204,7 +204,7 @@ help: Remove default argument
 14 | # No errors
 note: This is a display-only fix and is likely to be incorrect
 
-PT028 Test function parameter `c` has default argument
+PT028 [*] Test function parameter `c` has default argument
   --> PT028.py:11:32
    |
  9 | def test_foo(a: int = (1)): ...

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__is_pytest_test.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__is_pytest_test.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_pytest_style/mod.rs
 ---
-PT028 Test function parameter `a` has default argument
+PT028 [*] Test function parameter `a` has default argument
  --> is_pytest_test.py:3:27
   |
 1 | # Errors
@@ -20,7 +20,7 @@ help: Remove default argument
 6 | class TestClass:
 note: This is a display-only fix and is likely to be incorrect
 
-PT028 Test function parameter `a` has default argument
+PT028 [*] Test function parameter `a` has default argument
  --> is_pytest_test.py:4:27
   |
 3 | def test_this_is_a_test(a=1): ...
@@ -40,7 +40,7 @@ help: Remove default argument
 7 |     def test_this_too_is_a_test(self, a=1): ...
 note: This is a display-only fix and is likely to be incorrect
 
-PT028 Test function parameter `a` has default argument
+PT028 [*] Test function parameter `a` has default argument
  --> is_pytest_test.py:7:41
   |
 6 | class TestClass:
@@ -59,7 +59,7 @@ help: Remove default argument
 10 | 
 note: This is a display-only fix and is likely to be incorrect
 
-PT028 Test function parameter `a` has default argument
+PT028 [*] Test function parameter `a` has default argument
  --> is_pytest_test.py:8:37
   |
 6 | class TestClass:

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E731_E731.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E731_E731.py.snap
@@ -120,7 +120,7 @@ help: Rewrite `f` as a `def`
 61 | class Scope:
 note: This is an unsafe fix and may change runtime behavior
 
-E731 Do not assign a `lambda` expression, use a `def`
+E731 [*] Do not assign a `lambda` expression, use a `def`
   --> E731.py:73:9
    |
 71 |     x: Callable[[int], int]
@@ -142,7 +142,7 @@ help: Rewrite `x` as a `def`
 77 |     return x
 note: This is a display-only fix and is likely to be incorrect
 
-E731 Do not assign a `lambda` expression, use a `def`
+E731 [*] Do not assign a `lambda` expression, use a `def`
   --> E731.py:75:9
    |
 73 |         x = lambda: 1

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP049_1.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP049_1.py.snap
@@ -262,7 +262,7 @@ UP049 Generic class uses private type parameters
    |
 help: Rename type parameter to remove leading underscores
 
-UP049 Generic class uses private type parameters
+UP049 [*] Generic class uses private type parameters
   --> UP049_1.py:71:9
    |
 71 | class C[_T]:
@@ -295,7 +295,7 @@ help: Rename type parameter to remove leading underscores
 82 | class C[_T]:
 note: This is a display-only fix and is likely to be incorrect
 
-UP049 Generic class uses private type parameters
+UP049 [*] Generic class uses private type parameters
   --> UP049_1.py:82:9
    |
 82 | class C[_T]:

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB116_FURB116.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB116_FURB116.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/refurb/mod.rs
 ---
-FURB116 Replace `oct` call with `f"{num:o}"`
+FURB116 [*] Replace `oct` call with `f"{num:o}"`
   --> FURB116.py:9:7
    |
  7 |     return num
@@ -22,7 +22,7 @@ help: Replace with `f"{num:o}"`
 12 | 
 note: This is a display-only fix and is likely to be incorrect
 
-FURB116 Replace `hex` call with `f"{num:x}"`
+FURB116 [*] Replace `hex` call with `f"{num:x}"`
   --> FURB116.py:10:7
    |
  9 | print(oct(num)[2:])  # FURB116
@@ -41,7 +41,7 @@ help: Replace with `f"{num:x}"`
 13 | print(oct(1337)[2:])  # FURB116
 note: This is a display-only fix and is likely to be incorrect
 
-FURB116 Replace `bin` call with `f"{num:b}"`
+FURB116 [*] Replace `bin` call with `f"{num:b}"`
   --> FURB116.py:11:7
    |
  9 | print(oct(num)[2:])  # FURB116
@@ -162,7 +162,7 @@ FURB116 Replace `bin` call with f-string
    |
 help: Replace with f-string
 
-FURB116 Replace `bin` call with `f"{d:b}"`
+FURB116 [*] Replace `bin` call with `f"{d:b}"`
   --> FURB116.py:32:7
    |
 30 | d = datetime.datetime.now(tz=datetime.UTC)
@@ -183,7 +183,7 @@ help: Replace with `f"{d:b}"`
 35 | 
 note: This is a display-only fix and is likely to be incorrect
 
-FURB116 Replace `bin` call with `f"{len("xyz").numerator:b}"`
+FURB116 [*] Replace `bin` call with `f"{len("xyz").numerator:b}"`
   --> FURB116.py:34:7
    |
 32 | print(bin(d)[2:])
@@ -204,7 +204,7 @@ help: Replace with `f"{len("xyz").numerator:b}"`
 37 | print(bin({0: 1}[0].numerator)[2:])
 note: This is a display-only fix and is likely to be incorrect
 
-FURB116 Replace `bin` call with `f"{ {0: 1}[0].numerator:b}"`
+FURB116 [*] Replace `bin` call with `f"{ {0: 1}[0].numerator:b}"`
   --> FURB116.py:37:7
    |
 36 | # autofix is display-only
@@ -224,7 +224,7 @@ help: Replace with `f"{ {0: 1}[0].numerator:b}"`
 40 | print(hex(sys
 note: This is a display-only fix and is likely to be incorrect
 
-FURB116 Replace `bin` call with `f"{ord("\\").numerator:b}"`
+FURB116 [*] Replace `bin` call with `f"{ord("\\").numerator:b}"`
   --> FURB116.py:39:7
    |
 37 | print(bin({0: 1}[0].numerator)[2:])
@@ -245,7 +245,7 @@ help: Replace with `f"{ord("\\").numerator:b}"`
 42 | 
 note: This is a display-only fix and is likely to be incorrect
 
-FURB116 Replace `hex` call with f-string
+FURB116 [*] Replace `hex` call with f-string
   --> FURB116.py:40:7
    |
 38 |   # no autofix for Python 3.11 and earlier, as it introduces a syntax error
@@ -270,7 +270,7 @@ help: Replace with f-string
 44 | print(bin(-1)[2:])
 note: This is a display-only fix and is likely to be incorrect
 
-FURB116 Replace `bin` call with `f"{-1:b}"`
+FURB116 [*] Replace `bin` call with `f"{-1:b}"`
   --> FURB116.py:44:7
    |
 43 | # for negatives numbers autofix is display-only

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__fstring_number_format_python_311.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__fstring_number_format_python_311.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/refurb/mod.rs
 ---
-FURB116 Replace `oct` call with `f"{num:o}"`
+FURB116 [*] Replace `oct` call with `f"{num:o}"`
   --> FURB116.py:9:7
    |
  7 |     return num
@@ -22,7 +22,7 @@ help: Replace with `f"{num:o}"`
 12 | 
 note: This is a display-only fix and is likely to be incorrect
 
-FURB116 Replace `hex` call with `f"{num:x}"`
+FURB116 [*] Replace `hex` call with `f"{num:x}"`
   --> FURB116.py:10:7
    |
  9 | print(oct(num)[2:])  # FURB116
@@ -41,7 +41,7 @@ help: Replace with `f"{num:x}"`
 13 | print(oct(1337)[2:])  # FURB116
 note: This is a display-only fix and is likely to be incorrect
 
-FURB116 Replace `bin` call with `f"{num:b}"`
+FURB116 [*] Replace `bin` call with `f"{num:b}"`
   --> FURB116.py:11:7
    |
  9 | print(oct(num)[2:])  # FURB116
@@ -162,7 +162,7 @@ FURB116 Replace `bin` call with f-string
    |
 help: Replace with f-string
 
-FURB116 Replace `bin` call with `f"{d:b}"`
+FURB116 [*] Replace `bin` call with `f"{d:b}"`
   --> FURB116.py:32:7
    |
 30 | d = datetime.datetime.now(tz=datetime.UTC)
@@ -195,7 +195,7 @@ FURB116 Replace `bin` call with f-string
    |
 help: Replace with f-string
 
-FURB116 Replace `bin` call with `f"{ {0: 1}[0].numerator:b}"`
+FURB116 [*] Replace `bin` call with `f"{ {0: 1}[0].numerator:b}"`
   --> FURB116.py:37:7
    |
 36 | # autofix is display-only
@@ -241,7 +241,7 @@ FURB116 Replace `hex` call with f-string
    |
 help: Replace with f-string
 
-FURB116 Replace `bin` call with `f"{-1:b}"`
+FURB116 [*] Replace `bin` call with `f"{-1:b}"`
   --> FURB116.py:44:7
    |
 43 | # for negatives numbers autofix is display-only

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_5.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_5.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/ruff/mod.rs
 ---
-ERA001 Found commented-out code
+ERA001 [*] Found commented-out code
  --> RUF100_5.py:7:5
   |
 5 |     # "key1": 123,  # noqa: ERA001
@@ -20,7 +20,7 @@ help: Remove commented-out code
 9 | 
 note: This is a display-only fix and is likely to be incorrect
 
-ERA001 Found commented-out code
+ERA001 [*] Found commented-out code
   --> RUF100_5.py:11:1
    |
 11 | #import os  # noqa: E501

--- a/crates/ruff_linter/src/test.rs
+++ b/crates/ruff_linter/src/test.rs
@@ -447,7 +447,7 @@ pub(crate) fn print_jupyter_messages(
         .with_show_fix_status(true)
         .with_show_fix_diff(true)
         .with_show_source(true)
-        .with_fix_applicability(Applicability::Unsafe)
+        .with_fix_applicability(Applicability::DisplayOnly)
         .emit(
             &mut output,
             diagnostics,
@@ -468,7 +468,7 @@ pub(crate) fn print_messages(diagnostics: &[Diagnostic]) -> String {
         .with_show_fix_status(true)
         .with_show_fix_diff(true)
         .with_show_source(true)
-        .with_fix_applicability(Applicability::Unsafe)
+        .with_fix_applicability(Applicability::DisplayOnly)
         .emit(
             &mut output,
             diagnostics,

--- a/crates/ruff_linter/src/test.rs
+++ b/crates/ruff_linter/src/test.rs
@@ -447,7 +447,7 @@ pub(crate) fn print_jupyter_messages(
         .with_show_fix_status(true)
         .with_show_fix_diff(true)
         .with_show_source(true)
-        .with_unsafe_fixes(UnsafeFixes::Enabled)
+        .with_fix_applicability(Applicability::Unsafe)
         .emit(
             &mut output,
             diagnostics,
@@ -468,7 +468,7 @@ pub(crate) fn print_messages(diagnostics: &[Diagnostic]) -> String {
         .with_show_fix_status(true)
         .with_show_fix_diff(true)
         .with_show_source(true)
-        .with_unsafe_fixes(UnsafeFixes::Enabled)
+        .with_fix_applicability(Applicability::Unsafe)
         .emit(
             &mut output,
             diagnostics,


### PR DESCRIPTION
## Summary

This PR fixes #7352 by exposing the `show_fix_diff` option used in our snapshot tests in the CLI. As the issue suggests, we plan to make this the default output format in the future, so this is added to the `full` output format in preview for now.

This turned out to be pretty straightforward. I just used our existing `Applicability` settings to determine whether or not to print the diff. 

The snapshot differences are because we now set `Applicability::DisplayOnly` for our snapshot tests. This `Applicability` is also used to determine whether or not the fix icon (`[*]`) is rendered, so this is now shown for display-only fixes in our snapshots. This was already the case previously, but we were only setting `Applicability::Unsafe` in these tests and ignoring the `Applicability` when rendering fix diffs. CLI users can't enable display-only fixes, so this is only a test change for now, but this should work smoothly if we decide to expose a `--display-only-fixes` flag or similar in the future.

I also deleted the `PrinterFlags::SHOW_FIX_DIFF` flag. This was completely unused before, and it seemed less confusing just to delete it than to enable it in the right place and check it along with the `OutputFormat` and `preview`.

## Test Plan

I only added one CLI test for now. I'm kind of assuming that we have decent coverage of the cases where this shouldn't be firing, especially the `output_format` CLI test, which shows that this definitely doesn't affect non-preview `full` output. I'm happy to add more tests with different combinations of options, if we're worried about any in particular. I did try `--diff` and `--preview` and a few other combinations manually.

And here's a screenshot using our trusty UP049 example from the design discussion confirming that all the colors and other formatting still look as expected:

<img width="786" height="629" alt="image" src="https://github.com/user-attachments/assets/94e408bc-af7b-4573-b546-a5ceac2620f2" />

And one with an unsafe fix to see the footer:

<img width="782" height="367" alt="image" src="https://github.com/user-attachments/assets/bbb29e47-310b-4293-b2c2-cc7aee3baff4" />


## Related issues and PR
- https://github.com/astral-sh/ruff/issues/7352
- https://github.com/astral-sh/ruff/pull/12595
- https://github.com/astral-sh/ruff/issues/12598
- https://github.com/astral-sh/ruff/issues/12599
- https://github.com/astral-sh/ruff/issues/12600

I think we could probably close all of these issues now. I think we've either resolved or avoided most of them, and if we encounter them again with the new output format, it would probably make sense to open new ones anyway.