### PR TITLE
[Formatter] Add `function-arg-extra-indent` option

### DIFF
--- a/crates/ruff/src/args.rs
+++ b/crates/ruff/src/args.rs
@@ -502,6 +502,16 @@ pub struct FormatCommand {
     /// Set the line-length.
     #[arg(long, help_heading = "Format configuration")]
     pub line_length: Option<LineLength>,
+    /// Enable extra indentation (8 spaces instead of 4) for function arguments (default: disabled).
+    /// Use `--no-function-arg-extra-indent` to disable (overrides configuration files).
+    #[arg(
+        long,
+        overrides_with("no_function_arg_extra_indent"),
+        help_heading = "Format configuration"
+    )]
+    function_arg_extra_indent: bool,
+    #[clap(long, overrides_with("function_arg_extra_indent"), hide = true)]
+    no_function_arg_extra_indent: bool,
     /// The name of the file when passing it through stdin.
     #[arg(long, help_heading = "Miscellaneous")]
     pub stdin_filename: Option<PathBuf>,
@@ -784,6 +794,10 @@ impl FormatCommand {
             target_version: self.target_version.map(ast::PythonVersion::from),
             cache_dir: self.cache_dir,
             extension: self.extension,
+            function_arg_extra_indent: resolve_bool_arg(
+                self.function_arg_extra_indent,
+                self.no_function_arg_extra_indent,
+            ),
             ..ExplicitConfigOverrides::default()
         };
 
@@ -1310,6 +1324,7 @@ struct ExplicitConfigOverrides {
     extension: Option<Vec<ExtensionPair>>,
     detect_string_imports: Option<bool>,
     string_imports_min_dots: Option<usize>,
+    function_arg_extra_indent: Option<bool>,
 }
 
 impl ConfigurationTransformer for ExplicitConfigOverrides {
@@ -1399,6 +1414,9 @@ impl ConfigurationTransformer for ExplicitConfigOverrides {
         }
         if let Some(string_imports_min_dots) = &self.string_imports_min_dots {
             config.analyze.string_imports_min_dots = Some(*string_imports_min_dots);
+        }
+        if let Some(function_arg_extra_indent) = &self.function_arg_extra_indent {
+            config.format.function_arg_extra_indent = Some(*function_arg_extra_indent);
         }
 
         config

--- a/crates/ruff/tests/lint.rs
+++ b/crates/ruff/tests/lint.rs
@@ -2417,6 +2417,7 @@ requires-python = ">= 3.11"
         formatter.magic_trailing_comma = respect
         formatter.docstring_code_format = disabled
         formatter.docstring_code_line_width = dynamic
+        formatter.function_arg_extra_indent = disabled
 
         # Analyze Settings
         analyze.exclude = []
@@ -2729,6 +2730,7 @@ requires-python = ">= 3.11"
         formatter.magic_trailing_comma = respect
         formatter.docstring_code_format = disabled
         formatter.docstring_code_line_width = dynamic
+        formatter.function_arg_extra_indent = disabled
 
         # Analyze Settings
         analyze.exclude = []
@@ -3093,6 +3095,7 @@ from typing import Union;foo: Union[int, str] = 1
         formatter.magic_trailing_comma = respect
         formatter.docstring_code_format = disabled
         formatter.docstring_code_line_width = dynamic
+        formatter.function_arg_extra_indent = disabled
 
         # Analyze Settings
         analyze.exclude = []
@@ -3473,6 +3476,7 @@ from typing import Union;foo: Union[int, str] = 1
         formatter.magic_trailing_comma = respect
         formatter.docstring_code_format = disabled
         formatter.docstring_code_line_width = dynamic
+        formatter.function_arg_extra_indent = disabled
 
         # Analyze Settings
         analyze.exclude = []
@@ -3801,6 +3805,7 @@ from typing import Union;foo: Union[int, str] = 1
         formatter.magic_trailing_comma = respect
         formatter.docstring_code_format = disabled
         formatter.docstring_code_line_width = dynamic
+        formatter.function_arg_extra_indent = disabled
 
         # Analyze Settings
         analyze.exclude = []
@@ -4129,6 +4134,7 @@ from typing import Union;foo: Union[int, str] = 1
         formatter.magic_trailing_comma = respect
         formatter.docstring_code_format = disabled
         formatter.docstring_code_line_width = dynamic
+        formatter.function_arg_extra_indent = disabled
 
         # Analyze Settings
         analyze.exclude = []
@@ -4414,6 +4420,7 @@ from typing import Union;foo: Union[int, str] = 1
         formatter.magic_trailing_comma = respect
         formatter.docstring_code_format = disabled
         formatter.docstring_code_line_width = dynamic
+        formatter.function_arg_extra_indent = disabled
 
         # Analyze Settings
         analyze.exclude = []
@@ -4752,6 +4759,7 @@ from typing import Union;foo: Union[int, str] = 1
         formatter.magic_trailing_comma = respect
         formatter.docstring_code_format = disabled
         formatter.docstring_code_line_width = dynamic
+        formatter.function_arg_extra_indent = disabled
 
         # Analyze Settings
         analyze.exclude = []

--- a/crates/ruff/tests/snapshots/show_settings__display_default_settings.snap
+++ b/crates/ruff/tests/snapshots/show_settings__display_default_settings.snap
@@ -387,6 +387,7 @@ formatter.quote_style = double
 formatter.magic_trailing_comma = respect
 formatter.docstring_code_format = disabled
 formatter.docstring_code_line_width = dynamic
+formatter.function_arg_extra_indent = disabled
 
 # Analyze Settings
 analyze.exclude = []

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/function_arg_extra_indent.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/function_arg_extra_indent.options.json
@@ -1,0 +1,8 @@
+[
+    {
+        "function_arg_extra_indent": "disabled"
+    },
+    {
+        "function_arg_extra_indent": "enabled"
+    }
+]

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/function_arg_extra_indent.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/function_arg_extra_indent.py
@@ -1,0 +1,87 @@
+def simple_function(arg1, arg2, arg3):
+    pass
+
+def single_argument(
+    arg1,
+):
+    pass
+
+def multiple_arguments(
+    arg1,
+    arg2,
+    arg3,
+    arg4,
+):
+    pass
+
+def function_with_defaults(
+    arg1="default",
+    arg2=None,
+    arg3=[1, 2, 3],
+):
+    pass
+
+def function_with_long_names(
+    very_long_argument_name_that_might_cause_wrapping,
+    another_very_long_argument_name,
+    yet_another_extremely_long_argument_name,
+):
+    pass
+
+def mixed_argument_types(
+    arg1,
+    arg2="default",
+    *args,
+    kwarg1=None,
+    kwarg2="another_default",
+    **kwargs,
+):
+    pass
+
+def positional_only_args(
+    arg1,
+    arg2,
+    /,
+    arg3,
+    arg4,
+):
+    pass
+
+def keyword_only_args(
+    arg1,
+    arg2,
+    *,
+    kwarg1,
+    kwarg2,
+):
+    pass
+
+def all_argument_types(
+    pos1,
+    pos2,
+    /,
+    normal1,
+    normal2,
+    *args,
+    kw1,
+    kw2="default",
+    **kwargs,
+):
+    pass
+
+# Test lambdas (these should not be affected)
+lambda_func = lambda arg1, arg2, arg3: arg1 + arg2 + arg3
+
+# Nested function
+def outer_function(
+    outer_arg1,
+    outer_arg2,
+):
+    def inner_function(
+        inner_arg1,
+        inner_arg2,
+        inner_arg3,
+    ):
+        return inner_arg1 + inner_arg2 + inner_arg3
+    
+    return inner_function(outer_arg1, outer_arg2, 0)

--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -18,8 +18,8 @@ use crate::comments::{
 pub use crate::context::PyFormatContext;
 pub use crate::db::Db;
 pub use crate::options::{
-    DocstringCode, DocstringCodeLineWidth, MagicTrailingComma, PreviewMode, PyFormatOptions,
-    QuoteStyle,
+    DocstringCode, DocstringCodeLineWidth, FunctionArgExtraIndent, MagicTrailingComma, PreviewMode,
+    PyFormatOptions, QuoteStyle,
 };
 use crate::range::is_logical_line;
 pub use crate::shared_traits::{AsFormat, FormattedIter, FormattedIterExt, IntoFormat};

--- a/crates/ruff_python_formatter/src/other/parameters.rs
+++ b/crates/ruff_python_formatter/src/other/parameters.rs
@@ -3,6 +3,7 @@ use ruff_python_ast::{AnyNodeRef, Parameters};
 use ruff_python_trivia::{CommentLinePosition, SimpleToken, SimpleTokenKind, SimpleTokenizer};
 use ruff_text_size::{Ranged, TextRange, TextSize};
 
+use crate::builders::soft_two_level_block_indent;
 use crate::comments::{
     SourceComment, dangling_comments, dangling_open_parenthesis_comments, leading_comments,
     leading_node_comments, trailing_comments,
@@ -250,29 +251,55 @@ impl FormatNodeRule<Parameters> for FormatParameters {
             // If we have a single argument, avoid the inner group, to ensure that we insert a
             // trailing comma if the outer group breaks.
             let mut f = WithNodeLevel::new(NodeLevel::ParenthesizedExpression, f);
-            write!(
-                f,
-                [
-                    token("("),
-                    dangling_open_parenthesis_comments(parenthesis_dangling),
-                    soft_block_indent(&format_inner),
-                    token(")")
-                ]
-            )
+
+            if f.options().function_arg_extra_indent().is_enabled() {
+                write!(
+                    f,
+                    [
+                        token("("),
+                        dangling_open_parenthesis_comments(parenthesis_dangling),
+                        soft_two_level_block_indent(&format_inner),
+                        token(")")
+                    ]
+                )
+            } else {
+                write!(
+                    f,
+                    [
+                        token("("),
+                        dangling_open_parenthesis_comments(parenthesis_dangling),
+                        soft_block_indent(&format_inner),
+                        token(")")
+                    ]
+                )
+            }
         } else {
             // Intentionally avoid `parenthesized`, which groups the entire formatted contents.
             // We want parameters to be grouped alongside return types, one level up, so we
             // format them "inline" here.
             let mut f = WithNodeLevel::new(NodeLevel::ParenthesizedExpression, f);
-            write!(
-                f,
-                [
-                    token("("),
-                    dangling_open_parenthesis_comments(parenthesis_dangling),
-                    soft_block_indent(&group(&format_inner)),
-                    token(")")
-                ]
-            )
+
+            if f.options().function_arg_extra_indent().is_enabled() {
+                write!(
+                    f,
+                    [
+                        token("("),
+                        dangling_open_parenthesis_comments(parenthesis_dangling),
+                        soft_two_level_block_indent(&group(&format_inner)),
+                        token(")")
+                    ]
+                )
+            } else {
+                write!(
+                    f,
+                    [
+                        token("("),
+                        dangling_open_parenthesis_comments(parenthesis_dangling),
+                        soft_block_indent(&group(&format_inner)),
+                        token(")")
+                    ]
+                )
+            }
         }
     }
 }

--- a/crates/ruff_python_formatter/tests/fixtures.rs
+++ b/crates/ruff_python_formatter/tests/fixtures.rs
@@ -520,6 +520,7 @@ magic-trailing-comma       = {magic_trailing_comma:?}
 docstring-code             = {docstring_code:?}
 docstring-code-line-width  = {docstring_code_line_width:?}
 preview                    = {preview:?}
+function-arg-extra-indent  = {function_arg_extra_indent:?}
 target_version             = {target_version}
 source_type                = {source_type:?}"#,
             indent_style = self.0.indent_style(),
@@ -531,6 +532,7 @@ source_type                = {source_type:?}"#,
             docstring_code = self.0.docstring_code(),
             docstring_code_line_width = self.0.docstring_code_line_width(),
             preview = self.0.preview(),
+            function_arg_extra_indent = self.0.function_arg_extra_indent(),
             target_version = self.0.target_version(),
             source_type = self.0.source_type()
         )

--- a/crates/ruff_python_formatter/tests/snapshots/format@blank_line_before_class_docstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@blank_line_before_class_docstring.py.snap
@@ -56,6 +56,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Enabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```

--- a/crates/ruff_python_formatter/tests/snapshots/format@docstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@docstring.py.snap
@@ -175,6 +175,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```
@@ -351,6 +352,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```
@@ -527,6 +529,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```
@@ -703,6 +706,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```
@@ -879,6 +883,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```

--- a/crates/ruff_python_formatter/tests/snapshots/format@docstring_code_examples.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@docstring_code_examples.py.snap
@@ -1368,6 +1368,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```
@@ -2740,6 +2741,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```
@@ -4112,6 +4114,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```
@@ -5484,6 +5487,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```
@@ -6856,6 +6860,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Enabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```
@@ -8221,6 +8226,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Enabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```
@@ -9586,6 +9592,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Enabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```
@@ -10960,6 +10967,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Enabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```
@@ -12325,6 +12333,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Enabled
 docstring-code-line-width  = 60
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```
@@ -13699,6 +13708,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Enabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```

--- a/crates/ruff_python_formatter/tests/snapshots/format@docstring_code_examples_crlf.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@docstring_code_examples_crlf.py.snap
@@ -27,6 +27,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Enabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```

--- a/crates/ruff_python_formatter/tests/snapshots/format@docstring_code_examples_dynamic_line_width.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@docstring_code_examples_dynamic_line_width.py.snap
@@ -308,6 +308,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Enabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```
@@ -879,6 +880,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Enabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```
@@ -1425,6 +1427,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Enabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```
@@ -1996,6 +1999,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Enabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```

--- a/crates/ruff_python_formatter/tests/snapshots/format@docstring_tab_indentation.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@docstring_tab_indentation.py.snap
@@ -90,6 +90,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```
@@ -184,6 +185,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__bytes.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__bytes.py.snap
@@ -140,6 +140,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```
@@ -296,6 +297,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
@@ -768,6 +768,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Enabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```
@@ -1595,6 +1596,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring_preview.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring_preview.py.snap
@@ -38,6 +38,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Enabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__join_implicit_concatenated_string_preserve.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__join_implicit_concatenated_string_preserve.py.snap
@@ -40,6 +40,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```
@@ -81,6 +82,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.12
 source_type                = Python
 ```

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__string.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__string.py.snap
@@ -232,6 +232,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```
@@ -482,6 +483,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__tstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__tstring.py.snap
@@ -749,6 +749,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.14
 source_type                = Python
 ```

--- a/crates/ruff_python_formatter/tests/snapshots/format@fmt_on_off__fmt_off_docstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@fmt_on_off__fmt_off_docstring.py.snap
@@ -37,6 +37,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```
@@ -75,6 +76,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```

--- a/crates/ruff_python_formatter/tests/snapshots/format@fmt_on_off__indent.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@fmt_on_off__indent.py.snap
@@ -18,6 +18,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```
@@ -37,6 +38,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```
@@ -56,6 +58,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```

--- a/crates/ruff_python_formatter/tests/snapshots/format@fmt_on_off__mixed_space_and_tab.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@fmt_on_off__mixed_space_and_tab.py.snap
@@ -33,6 +33,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```
@@ -68,6 +69,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```
@@ -103,6 +105,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```

--- a/crates/ruff_python_formatter/tests/snapshots/format@function_arg_extra_indent.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@function_arg_extra_indent.py.snap
@@ -1,0 +1,327 @@
+---
+source: crates/ruff_python_formatter/tests/fixtures.rs
+input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/function_arg_extra_indent.py
+---
+## Input
+```python
+def simple_function(arg1, arg2, arg3):
+    pass
+
+def single_argument(
+    arg1,
+):
+    pass
+
+def multiple_arguments(
+    arg1,
+    arg2,
+    arg3,
+    arg4,
+):
+    pass
+
+def function_with_defaults(
+    arg1="default",
+    arg2=None,
+    arg3=[1, 2, 3],
+):
+    pass
+
+def function_with_long_names(
+    very_long_argument_name_that_might_cause_wrapping,
+    another_very_long_argument_name,
+    yet_another_extremely_long_argument_name,
+):
+    pass
+
+def mixed_argument_types(
+    arg1,
+    arg2="default",
+    *args,
+    kwarg1=None,
+    kwarg2="another_default",
+    **kwargs,
+):
+    pass
+
+def positional_only_args(
+    arg1,
+    arg2,
+    /,
+    arg3,
+    arg4,
+):
+    pass
+
+def keyword_only_args(
+    arg1,
+    arg2,
+    *,
+    kwarg1,
+    kwarg2,
+):
+    pass
+
+def all_argument_types(
+    pos1,
+    pos2,
+    /,
+    normal1,
+    normal2,
+    *args,
+    kw1,
+    kw2="default",
+    **kwargs,
+):
+    pass
+
+# Test lambdas (these should not be affected)
+lambda_func = lambda arg1, arg2, arg3: arg1 + arg2 + arg3
+
+# Nested function
+def outer_function(
+    outer_arg1,
+    outer_arg2,
+):
+    def inner_function(
+        inner_arg1,
+        inner_arg2,
+        inner_arg3,
+    ):
+        return inner_arg1 + inner_arg2 + inner_arg3
+    
+    return inner_function(outer_arg1, outer_arg2, 0)```
+
+## Outputs
+### Output 1
+```
+indent-style               = space
+line-width                 = 88
+indent-width               = 4
+quote-style                = Double
+line-ending                = LineFeed
+magic-trailing-comma       = Respect
+docstring-code             = Disabled
+docstring-code-line-width  = "dynamic"
+preview                    = Disabled
+function-arg-extra-indent  = Disabled
+target_version             = 3.9
+source_type                = Python
+```
+
+```python
+def simple_function(arg1, arg2, arg3):
+    pass
+
+
+def single_argument(
+    arg1,
+):
+    pass
+
+
+def multiple_arguments(
+    arg1,
+    arg2,
+    arg3,
+    arg4,
+):
+    pass
+
+
+def function_with_defaults(
+    arg1="default",
+    arg2=None,
+    arg3=[1, 2, 3],
+):
+    pass
+
+
+def function_with_long_names(
+    very_long_argument_name_that_might_cause_wrapping,
+    another_very_long_argument_name,
+    yet_another_extremely_long_argument_name,
+):
+    pass
+
+
+def mixed_argument_types(
+    arg1,
+    arg2="default",
+    *args,
+    kwarg1=None,
+    kwarg2="another_default",
+    **kwargs,
+):
+    pass
+
+
+def positional_only_args(
+    arg1,
+    arg2,
+    /,
+    arg3,
+    arg4,
+):
+    pass
+
+
+def keyword_only_args(
+    arg1,
+    arg2,
+    *,
+    kwarg1,
+    kwarg2,
+):
+    pass
+
+
+def all_argument_types(
+    pos1,
+    pos2,
+    /,
+    normal1,
+    normal2,
+    *args,
+    kw1,
+    kw2="default",
+    **kwargs,
+):
+    pass
+
+
+# Test lambdas (these should not be affected)
+lambda_func = lambda arg1, arg2, arg3: arg1 + arg2 + arg3
+
+
+# Nested function
+def outer_function(
+    outer_arg1,
+    outer_arg2,
+):
+    def inner_function(
+        inner_arg1,
+        inner_arg2,
+        inner_arg3,
+    ):
+        return inner_arg1 + inner_arg2 + inner_arg3
+
+    return inner_function(outer_arg1, outer_arg2, 0)
+```
+
+
+### Output 2
+```
+indent-style               = space
+line-width                 = 88
+indent-width               = 4
+quote-style                = Double
+line-ending                = LineFeed
+magic-trailing-comma       = Respect
+docstring-code             = Disabled
+docstring-code-line-width  = "dynamic"
+preview                    = Disabled
+function-arg-extra-indent  = Enabled
+target_version             = 3.9
+source_type                = Python
+```
+
+```python
+def simple_function(arg1, arg2, arg3):
+    pass
+
+
+def single_argument(
+        arg1,
+):
+    pass
+
+
+def multiple_arguments(
+        arg1,
+        arg2,
+        arg3,
+        arg4,
+):
+    pass
+
+
+def function_with_defaults(
+        arg1="default",
+        arg2=None,
+        arg3=[1, 2, 3],
+):
+    pass
+
+
+def function_with_long_names(
+        very_long_argument_name_that_might_cause_wrapping,
+        another_very_long_argument_name,
+        yet_another_extremely_long_argument_name,
+):
+    pass
+
+
+def mixed_argument_types(
+        arg1,
+        arg2="default",
+        *args,
+        kwarg1=None,
+        kwarg2="another_default",
+        **kwargs,
+):
+    pass
+
+
+def positional_only_args(
+        arg1,
+        arg2,
+        /,
+        arg3,
+        arg4,
+):
+    pass
+
+
+def keyword_only_args(
+        arg1,
+        arg2,
+        *,
+        kwarg1,
+        kwarg2,
+):
+    pass
+
+
+def all_argument_types(
+        pos1,
+        pos2,
+        /,
+        normal1,
+        normal2,
+        *args,
+        kw1,
+        kw2="default",
+        **kwargs,
+):
+    pass
+
+
+# Test lambdas (these should not be affected)
+lambda_func = lambda arg1, arg2, arg3: arg1 + arg2 + arg3
+
+
+# Nested function
+def outer_function(
+        outer_arg1,
+        outer_arg2,
+):
+    def inner_function(
+            inner_arg1,
+            inner_arg2,
+            inner_arg3,
+    ):
+        return inner_arg1 + inner_arg2 + inner_arg3
+
+    return inner_function(outer_arg1, outer_arg2, 0)
+```

--- a/crates/ruff_python_formatter/tests/snapshots/format@notebook_docstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@notebook_docstring.py.snap
@@ -24,6 +24,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Ipynb
 ```
@@ -48,6 +49,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```

--- a/crates/ruff_python_formatter/tests/snapshots/format@preview.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@preview.py.snap
@@ -84,6 +84,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```
@@ -167,6 +168,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Enabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```

--- a/crates/ruff_python_formatter/tests/snapshots/format@quote_style.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@quote_style.py.snap
@@ -68,6 +68,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```
@@ -142,6 +143,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```
@@ -216,6 +218,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```

--- a/crates/ruff_python_formatter/tests/snapshots/format@range_formatting__docstring_code_examples.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@range_formatting__docstring_code_examples.py.snap
@@ -121,6 +121,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Enabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```
@@ -273,6 +274,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Enabled
 docstring-code-line-width  = 88
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```

--- a/crates/ruff_python_formatter/tests/snapshots/format@range_formatting__indent.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@range_formatting__indent.py.snap
@@ -81,6 +81,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```
@@ -160,6 +161,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```
@@ -239,6 +241,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```

--- a/crates/ruff_python_formatter/tests/snapshots/format@range_formatting__stub.pyi.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@range_formatting__stub.pyi.snap
@@ -34,6 +34,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Stub
 ```

--- a/crates/ruff_python_formatter/tests/snapshots/format@skip_magic_trailing_comma.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@skip_magic_trailing_comma.py.snap
@@ -51,6 +51,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```
@@ -109,6 +110,7 @@ magic-trailing-comma       = Ignore
 docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__with.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__with.py.snap
@@ -387,6 +387,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.8
 source_type                = Python
 ```
@@ -818,6 +819,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Enabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__with_39.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__with_39.py.snap
@@ -110,6 +110,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Enabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```

--- a/crates/ruff_python_formatter/tests/snapshots/format@stub_files__blank_line_after_nested_stub_class.pyi.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@stub_files__blank_line_after_nested_stub_class.pyi.snap
@@ -201,6 +201,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Enabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Stub
 ```

--- a/crates/ruff_python_formatter/tests/snapshots/format@stub_files__blank_line_after_nested_stub_class_eof.pyi.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@stub_files__blank_line_after_nested_stub_class_eof.pyi.snap
@@ -35,6 +35,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Enabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Stub
 ```

--- a/crates/ruff_python_formatter/tests/snapshots/format@tab_width.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@tab_width.py.snap
@@ -26,6 +26,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```
@@ -53,6 +54,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```
@@ -83,6 +85,7 @@ magic-trailing-comma       = Respect
 docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
+function-arg-extra-indent  = Disabled
 target_version             = 3.9
 source_type                = Python
 ```

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -41,7 +41,7 @@ use ruff_linter::{
 };
 use ruff_python_ast as ast;
 use ruff_python_formatter::{
-    DocstringCode, DocstringCodeLineWidth, MagicTrailingComma, QuoteStyle,
+    DocstringCode, DocstringCodeLineWidth, FunctionArgExtraIndent, MagicTrailingComma, QuoteStyle,
 };
 
 use crate::options::{
@@ -211,6 +211,11 @@ impl Configuration {
             docstring_code_line_width: format
                 .docstring_code_line_width
                 .unwrap_or(format_defaults.docstring_code_line_width),
+            function_arg_extra_indent: if format.function_arg_extra_indent.unwrap_or(false) {
+                FunctionArgExtraIndent::Enabled
+            } else {
+                FunctionArgExtraIndent::Disabled
+            },
         };
 
         let analyze = self.analyze;
@@ -1213,6 +1218,7 @@ pub struct FormatConfiguration {
     pub line_ending: Option<LineEnding>,
     pub docstring_code_format: Option<DocstringCode>,
     pub docstring_code_line_width: Option<DocstringCodeLineWidth>,
+    pub function_arg_extra_indent: Option<bool>,
 }
 
 impl FormatConfiguration {
@@ -1249,6 +1255,7 @@ impl FormatConfiguration {
                 }
             }),
             docstring_code_line_width: options.docstring_code_line_length,
+            function_arg_extra_indent: options.function_arg_extra_indent,
         })
     }
 
@@ -1266,6 +1273,9 @@ impl FormatConfiguration {
             docstring_code_line_width: self
                 .docstring_code_line_width
                 .or(config.docstring_code_line_width),
+            function_arg_extra_indent: self
+                .function_arg_extra_indent
+                .or(config.function_arg_extra_indent),
         }
     }
 }

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -3795,6 +3795,41 @@ pub struct FormatOptions {
         "#
     )]
     pub docstring_code_line_length: Option<DocstringCodeLineWidth>,
+
+    /// Whether to add extra indentation for function arguments when they are wrapped.
+    ///
+    /// When enabled, function arguments will be indented with 8 spaces instead of the usual 4 spaces.
+    ///
+    /// `function-arg-extra-indent = false` (default):
+    ///
+    /// ```python
+    /// def my_function(
+    ///     arg1,
+    ///     arg2,
+    ///     arg3,
+    /// ):
+    ///     pass
+    /// ```
+    ///
+    /// `function-arg-extra-indent = true`:
+    ///
+    /// ```python
+    /// def my_function(
+    ///         arg1,
+    ///         arg2,
+    ///         arg3,
+    /// ):
+    ///     pass
+    /// ```
+    #[option(
+        default = r#"false"#,
+        value_type = r#"bool"#,
+        example = r#"
+            # Enable extra indentation for function arguments.
+            function-arg-extra-indent = true
+        "#
+    )]
+    pub function_arg_extra_indent: Option<bool>,
 }
 
 /// Configures Ruff's `analyze` command.

--- a/crates/ruff_workspace/src/settings.rs
+++ b/crates/ruff_workspace/src/settings.rs
@@ -11,8 +11,8 @@ use ruff_linter::settings::types::{
 use ruff_macros::CacheKey;
 use ruff_python_ast::{PySourceType, PythonVersion};
 use ruff_python_formatter::{
-    DocstringCode, DocstringCodeLineWidth, MagicTrailingComma, PreviewMode, PyFormatOptions,
-    QuoteStyle,
+    DocstringCode, DocstringCodeLineWidth, FunctionArgExtraIndent, MagicTrailingComma, PreviewMode,
+    PyFormatOptions, QuoteStyle,
 };
 use ruff_source_file::find_newline;
 use std::fmt;
@@ -189,6 +189,7 @@ pub struct FormatterSettings {
 
     pub docstring_code_format: DocstringCode,
     pub docstring_code_line_width: DocstringCodeLineWidth,
+    pub function_arg_extra_indent: FunctionArgExtraIndent,
 }
 
 impl FormatterSettings {
@@ -234,6 +235,7 @@ impl FormatterSettings {
             .with_line_width(self.line_width)
             .with_docstring_code(self.docstring_code_format)
             .with_docstring_code_line_width(self.docstring_code_line_width)
+            .with_function_arg_extra_indent(self.function_arg_extra_indent)
     }
 
     /// Resolve the [`PythonVersion`] to use for formatting.
@@ -266,6 +268,7 @@ impl Default for FormatterSettings {
             magic_trailing_comma: default_options.magic_trailing_comma(),
             docstring_code_format: default_options.docstring_code(),
             docstring_code_line_width: default_options.docstring_code_line_width(),
+            function_arg_extra_indent: default_options.function_arg_extra_indent(),
         }
     }
 }
@@ -289,6 +292,7 @@ impl fmt::Display for FormatterSettings {
                 self.magic_trailing_comma,
                 self.docstring_code_format,
                 self.docstring_code_line_width,
+                self.function_arg_extra_indent,
             ]
         }
         Ok(())

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -90,6 +90,10 @@ If left unspecified, Ruff's default configuration is equivalent to:
     # This only has an effect when the `docstring-code-format` setting is
     # enabled.
     docstring-code-line-length = "dynamic"
+
+    # Enable extra indentation for function arguments when they span multiple lines.
+    # When enabled, arguments are indented with 8 spaces instead of the default 4.
+    function-arg-extra-indent = false
     ```
 
 === "ruff.toml"
@@ -172,6 +176,10 @@ If left unspecified, Ruff's default configuration is equivalent to:
     # This only has an effect when the `docstring-code-format` setting is
     # enabled.
     docstring-code-line-length = "dynamic"
+
+    # Enable extra indentation for function arguments when they span multiple lines.
+    # When enabled, arguments are indented with 8 spaces instead of the default 4.
+    function-arg-extra-indent = false
     ```
 
 As an example, the following would configure Ruff to:
@@ -752,7 +760,12 @@ File selection:
           command-line. Use `--no-force-exclude` to disable
 
 Format configuration:
-      --line-length <LINE_LENGTH>  Set the line-length
+      --line-length <LINE_LENGTH>
+          Set the line-length
+      --function-arg-extra-indent
+          Enable extra indentation (8 spaces instead of 4) for function
+          arguments (default: disabled). Use `--no-function-arg-extra-indent`
+          to disable (overrides configuration files)
 
 Editor options:
       --range <RANGE>  When specified, Ruff will try to only format the code in

--- a/docs/formatter.md
+++ b/docs/formatter.md
@@ -114,6 +114,7 @@ following to your configuration file:
     quote-style = "single"
     indent-style = "tab"
     docstring-code-format = true
+    function-arg-extra-indent = true
     ```
 
 === "ruff.toml"
@@ -125,6 +126,7 @@ following to your configuration file:
     quote-style = "single"
     indent-style = "tab"
     docstring-code-format = true
+    function-arg-extra-indent = true
     ```
 
 
@@ -132,7 +134,7 @@ For the full list of supported settings, see [_Settings_](settings.md#format). F
 configuring Ruff via `pyproject.toml`, see [_Configuring Ruff_](configuration.md).
 
 Given the focus on Black compatibility (and unlike formatters like [YAPF](https://github.com/google/yapf)),
-Ruff does not currently expose any other configuration options.
+Ruff does not currently expose many configuration options.
 
 ## Docstring formatting
 
@@ -224,6 +226,55 @@ def f(x):
 [fenced code blocks]: https://spec.commonmark.org/0.30/#fenced-code-blocks
 [literal blocks]: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#literal-blocks
 [`code-block` and `sourcecode` directives]: https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-code-block
+
+## Function argument indentation
+
+The Ruff formatter supports an optional feature for using extra indentation when formatting
+function arguments that span multiple lines. When enabled via the `function-arg-extra-indent` 
+setting, function arguments will be indented with 8 spaces instead of the default 4 spaces,
+making it easier to visually distinguish between function arguments and the function body.
+This style of extra indentation is suggested in [PEP-008](https://peps.python.org/pep-0008/#indentation).
+
+By default, this feature is disabled and Ruff uses standard 4-space indentation:
+
+```python
+def my_function(
+    arg1,
+    arg2,
+    arg3,
+):
+    pass
+```
+
+When `function-arg-extra-indent` is enabled, function arguments use 8-space indentation:
+
+```python
+def my_function(
+        arg1,
+        arg2,
+        arg3,
+):
+    pass
+```
+
+This feature applies to all types of function arguments, including positional arguments,
+keyword arguments, `*args`, `**kwargs`, and positional-only or keyword-only arguments.
+
+To enable this feature, add the following to your configuration:
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.ruff.format]
+    function-arg-extra-indent = true
+    ```
+
+=== "ruff.toml"
+
+    ```toml
+    [format]
+    function-arg-extra-indent = true
+    ```
 
 ## Format suppression
 

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -1556,6 +1556,13 @@
             "type": "string"
           }
         },
+        "function-arg-extra-indent": {
+          "description": "Whether to add extra indentation for function arguments when they are wrapped.\n\nWhen enabled, function arguments will be indented with 8 spaces instead of the usual 4 spaces.\n\n`function-arg-extra-indent = false` (default):\n\n```python def my_function( arg1, arg2, arg3, ): pass ```\n\n`function-arg-extra-indent = true`:\n\n```python def my_function( arg1, arg2, arg3, ): pass ```",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "indent-style": {
           "description": "Whether to use spaces or tabs for indentation.\n\n`indent-style = \"space\"` (default):\n\n```python def f(): print(\"Hello\") #  Spaces indent the `print` statement. ```\n\n`indent-style = \"tab\"`:\n\n```python def f(): print(\"Hello\") #  A tab `\\t` indents the `print` statement. ```\n\nPEP 8 recommends using spaces for [indentation](https://peps.python.org/pep-0008/#indentation). We care about accessibility; if you do not need tabs for accessibility, we do not recommend you use them.\n\nSee [`indent-width`](#indent-width) to configure the number of spaces per indentation and the tab width.",
           "anyOf": [


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

(Implements https://github.com/astral-sh/ruff/issues/8360)

This PR introduces a new formatter option, `function-arg-extra-indent`, which enables extra indentation (8 spaces instead of 4) for function arguments that span multiple lines.

This option can be configured via the CLI or configuration files, and is intended to improve readability in accordance with PEP-8 recommendations.  This option defaults to "disabled", **which means guarantees backward compatibility**.

The implementation includes updates to the formatter internals, configuration schema, CLI, documentation, and adds relevant tests and fixtures to verify the new behavior.

### _Additional context:_

This feature is probably one of the most controversial topics in `Black`'s issue board.  Many people are frustrated that `Black` doesn't add such a feature.  Discussions on both sides are filled with emotions, most notably this one: 
- https://github.com/psf/black/issues/1178

Here are some additional feature requests:

- https://github.com/grantjenks/blue/issues/89
- https://github.com/grantjenks/blue/issues/90
- https://github.com/psf/black/issues/1127
- https://github.com/psf/black/issues/2117

A similar feature request was posted on Ruff's issue board: https://github.com/astral-sh/ruff/issues/8360.

## Test Plan

<!-- How was it tested? -->

- Added and updated unit and integration tests to cover both enabled and disabled states of the `function-arg-extra-indent` option.
- Verified output via new and existing test fixtures.
- Confirmed correct CLI and config file parsing, and checked documentation updates for accuracy.