### PR TITLE
Bump Rust MSRV to 1.87

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 # Please update rustfmt.toml when bumping the Rust edition
 edition = "2024"
-rust-version = "1.86"
+rust-version = "1.87"
 homepage = "https://docs.astral.sh/ruff"
 documentation = "https://docs.astral.sh/ruff"
 repository = "https://github.com/astral-sh/ruff"


### PR DESCRIPTION
## Summary
Bumps the minimum supported Rust version from 1.86 to 1.87. This is in accordance with our MSRV policy N-2 where N is 1.89.

Related conda feedstock PR: https://github.com/conda-forge/ruff-feedstock/pull/290

## Test plan
- `cargo clippy` passes
- `cargo fmt` passes
- `cargo test` passes