### PR TITLE
[ty] Remove incorrect type narrowing for `if type(x) is C[int]`

### DIFF
--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -756,12 +756,8 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                             node_index: _,
                         },
                 }) if keywords.is_empty() => {
-                    let rhs_class = match rhs_ty {
-                        Type::ClassLiteral(class) => class,
-                        Type::GenericAlias(alias) => alias.origin(self.db),
-                        _ => {
-                            continue;
-                        }
+                    let Type::ClassLiteral(rhs_class) = rhs_ty else {
+                        continue;
                     };
 
                     let target = match &**args {


### PR DESCRIPTION
## Summary

For this code, we currently apply incorrect type narrowing:

```py
class A[T]: ...
class B: ...

def f(x: A[int] | B):
    if type(x) is A[int]:
        reveal_type(x)  # revealed: (A[int] & A[Unknown]) | (B & A[Unknown])
    else:
        reveal_type(x)  # revealed: A[int] | B
```

`type(x)` will either be a subclass of `A` or a subclass of `B` at runtime, but `A[int]` isn't either of those things (it's not a class at all, it's a generic alias), so we shouldn't be doing any type narrowing at all if we see a pattern such as `if type(x) is A[int]`. (Well, we _could_ narrow the type to `Never`, since the condition will always resolve to `False`!)

Note that there is another pre-existing bug here that is not fixed by this PR:

```py
class A[T]: ...
class B: ...

def f(x: A[int] | B):
    if type(x) is A:
        reveal_type(x)  # revealed: Never
    else:
        reveal_type(x)  # revealed: A[int] | B
```

I'm not totally sure why we reveal `Never` for the first branch there. I tried quickly to fix it, but couldn't immediately figure it out, and it's a pre-existing issue so for now I just left it; it doesn't seem high-priority.

## Test Plan

Mdtests
