### PR TITLE
Add warning for using R and S as selectors

### DIFF
--- a/crates/ruff_linter/src/rule_redirects.rs
+++ b/crates/ruff_linter/src/rule_redirects.rs
@@ -1,14 +1,30 @@
 use std::collections::HashMap;
 use std::sync::LazyLock;
 
+use crate::warn_user_once;
+
+const DEPRECATED_SELECTORS: [&str; 3] = ["R", "U", "IC"];
+
+fn check_for_deprecation(code: &str) {
+    if DEPRECATED_SELECTORS.contains(&code) {
+        warn_user_once!(
+            "Using `{code}` as a selector is deprecated and will be removed in a future version."
+        );
+    }
+}
+
 /// Returns the redirect target for the given code.
 pub(crate) fn get_redirect_target(code: &str) -> Option<&'static str> {
+    check_for_deprecation(code);
+
     REDIRECTS.get(code).copied()
 }
 
 /// Returns the code and the redirect target if the given code is a redirect.
 /// (The same code is returned to obtain it with a static lifetime).
 pub(crate) fn get_redirect(code: &str) -> Option<(&'static str, &'static str)> {
+    check_for_deprecation(code);
+
     REDIRECTS.get_key_value(code).map(|(k, v)| (*k, *v))
 }
 

--- a/crates/ruff_linter/src/rule_selector.rs
+++ b/crates/ruff_linter/src/rule_selector.rs
@@ -10,9 +10,6 @@ use crate::codes::{RuleCodePrefix, RuleGroup};
 use crate::registry::{Linter, Rule, RuleNamespace};
 use crate::rule_redirects::get_redirect;
 use crate::settings::types::PreviewMode;
-use crate::warn_user_once;
-
-const DEPRECATED_SELECTORS: [&str; 2] = ["R", "U"];
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum RuleSelector {
@@ -68,12 +65,6 @@ impl FromStr for RuleSelector {
             "C" => Ok(Self::C),
             "T" => Ok(Self::T),
             _ => {
-                if DEPRECATED_SELECTORS.contains(&s) {
-                    warn_user_once!(
-                        "Using `{s}` as a selector is deprecated and will be removed in a future version."
-                    );
-                }
-
                 let (s, redirected_from) = match get_redirect(s) {
                     Some((from, target)) => (target, Some(from)),
                     None => (s, None),


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

Following on from discussion in https://github.com/astral-sh/ruff/pull/17896, this change adds a user deprecation warning for selectors that currently work, but are not included in the schema. I believe R and S are the only ones.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

I have tested this locally with 

```
ruff check --select R
```

However it does not display the warning. If I change to `println!` it does. Is there something I am not understanding about the `warn_user*` macros?

<!-- How was it tested? -->
