### PR TITLE
[ty] Fix error message for invalidly providing type arguments to `NamedTuple` when it occurs in a type expression

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/named_tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/named_tuple.md
@@ -312,6 +312,9 @@ def expects_named_tuple(x: typing.NamedTuple):
 
 def _(y: type[typing.NamedTuple]):
     reveal_type(y)  # revealed: @Todo(unsupported type[X] special form)
+
+# error: [invalid-type-form] "Special form `typing.NamedTuple` expected no type parameter"
+def _(z: typing.NamedTuple[int]): ...
 ```
 
 Any instance of a `NamedTuple` class can therefore be passed for a function parameter that is

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -10783,7 +10783,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             SpecialFormType::TypingSelf
             | SpecialFormType::TypeAlias
             | SpecialFormType::TypedDict
-            | SpecialFormType::Unknown => {
+            | SpecialFormType::Unknown
+            | SpecialFormType::NamedTuple => {
                 self.infer_type_expression(arguments_slice);
 
                 if let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, subscript) {
@@ -10808,7 +10809,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             SpecialFormType::Tuple => {
                 Type::tuple(self.infer_tuple_type_expression(arguments_slice))
             }
-            SpecialFormType::Generic | SpecialFormType::Protocol | SpecialFormType::NamedTuple => {
+            SpecialFormType::Generic | SpecialFormType::Protocol => {
                 self.infer_expression(arguments_slice);
                 if let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, subscript) {
                     builder.into_diagnostic(format_args!(


### PR DESCRIPTION
## Summary

This fixes a minor oversight in https://github.com/astral-sh/ruff/pull/19915 (which hasn't appeared in a release yet, so I'm adding the `internal` label to this PR)

## Test Plan

mdtest
