### PR TITLE
[ty] Ban protocols from inheriting from non-protocol generic classes

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -150,6 +150,14 @@ class AlsoInvalid(MyProtocol, OtherProtocol, NotAProtocol, Protocol): ...
 
 # revealed: tuple[<class 'AlsoInvalid'>, <class 'MyProtocol'>, <class 'OtherProtocol'>, <class 'NotAProtocol'>, typing.Protocol, typing.Generic, <class 'object'>]
 reveal_type(AlsoInvalid.__mro__)
+
+class NotAGenericProtocol[T]: ...
+
+# error: [invalid-protocol] "Protocol class `StillInvalid` cannot inherit from non-protocol class `NotAGenericProtocol`"
+class StillInvalid(NotAGenericProtocol[int], Protocol): ...
+
+# revealed: tuple[<class 'StillInvalid'>, <class 'NotAGenericProtocol[int]'>, typing.Protocol, typing.Generic, <class 'object'>]
+reveal_type(StillInvalid.__mro__)
 ```
 
 But two exceptions to this rule are `object` and `Generic`:


### PR DESCRIPTION
## Summary

This is extracted from #19866, since I need to do some debugging on that PR but this makes sense as a standalone fix.

Currently we correctly emit a diagnostic on this class, which will fail at runtime (a protocol class cannot inherit from a non-protocol class, and `int` is not a protocol class):

```py
from typing import Protocol

class Foo(int, Protocol): ...
```

but we don't emit a diagnostic on this class (even though it also fails at runtime):

```py
from typing import Protocol

class Foo(list[int], Protocol): ...
```

The reason for this is that `list[int]` is represented in our model as a `Type::GenericAlias` rather than a `Type::ClassLiteral`. This PR fixes that oversight.

## Test Plan

mdtest added
