### PR TITLE
[ty] Log server version at info level

### DIFF
--- a/crates/ty_server/src/server.rs
+++ b/crates/ty_server/src/server.rs
@@ -80,7 +80,7 @@ impl Server {
         );
 
         let version = ruff_db::program_version().unwrap_or("Unknown");
-        tracing::debug!("Version: {version}");
+        tracing::info!("Version: {version}");
 
         connection.initialize_finish(
             id,


### PR DESCRIPTION
## Summary

Log the server version at level "info".

It's not always clear for users what ty version the extension uses. 
That's why it's useful to log that information without the need to change the log level.


