### PR TITLE
Add `full` output format changes to the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Add rule code to error description in GitLab output ([#19896](https://github.com/astral-sh/ruff/pull/19896))
 
 - Improve rendering of the `full` output format ([#19415](https://github.com/astral-sh/ruff/pull/19415))
+
     Below is an example diff for [`F401`](https://docs.astral.sh/ruff/rules/unused-import/):
 
     ```diff


### PR DESCRIPTION
Summary
--

I thought this might warrant a small blog-style writeup, especially since we already got a question about it (#19966), but I'm happy to switch back to a one-liner under `### Other changes` if preferred.

I'll copy whatever we add here to the release notes too.

Do we need a note at the top about the late addition?
