### PR TITLE
[relative-imports] Add setting to require relative imports

### DIFF
--- a/crates/ruff/tests/lint.rs
+++ b/crates/ruff/tests/lint.rs
@@ -2322,7 +2322,7 @@ requires-python = ">= 3.11"
         	_name_,
         	_value_,
         ]
-        linter.flake8_tidy_imports.ban_relative_imports = "parents"
+        linter.flake8_tidy_imports.relative_import_style = "parents-absolute"
         linter.flake8_tidy_imports.banned_api = {}
         linter.flake8_tidy_imports.banned_module_level_imports = []
         linter.flake8_type_checking.strict = false
@@ -2634,7 +2634,7 @@ requires-python = ">= 3.11"
         	_name_,
         	_value_,
         ]
-        linter.flake8_tidy_imports.ban_relative_imports = "parents"
+        linter.flake8_tidy_imports.relative_import_style = "parents-absolute"
         linter.flake8_tidy_imports.banned_api = {}
         linter.flake8_tidy_imports.banned_module_level_imports = []
         linter.flake8_type_checking.strict = false
@@ -2998,7 +2998,7 @@ from typing import Union;foo: Union[int, str] = 1
         	_name_,
         	_value_,
         ]
-        linter.flake8_tidy_imports.ban_relative_imports = "parents"
+        linter.flake8_tidy_imports.relative_import_style = "parents-absolute"
         linter.flake8_tidy_imports.banned_api = {}
         linter.flake8_tidy_imports.banned_module_level_imports = []
         linter.flake8_type_checking.strict = false
@@ -3378,7 +3378,7 @@ from typing import Union;foo: Union[int, str] = 1
         	_name_,
         	_value_,
         ]
-        linter.flake8_tidy_imports.ban_relative_imports = "parents"
+        linter.flake8_tidy_imports.relative_import_style = "parents-absolute"
         linter.flake8_tidy_imports.banned_api = {}
         linter.flake8_tidy_imports.banned_module_level_imports = []
         linter.flake8_type_checking.strict = false
@@ -3706,7 +3706,7 @@ from typing import Union;foo: Union[int, str] = 1
         	_name_,
         	_value_,
         ]
-        linter.flake8_tidy_imports.ban_relative_imports = "parents"
+        linter.flake8_tidy_imports.relative_import_style = "parents-absolute"
         linter.flake8_tidy_imports.banned_api = {}
         linter.flake8_tidy_imports.banned_module_level_imports = []
         linter.flake8_type_checking.strict = false
@@ -4034,7 +4034,7 @@ from typing import Union;foo: Union[int, str] = 1
         	_name_,
         	_value_,
         ]
-        linter.flake8_tidy_imports.ban_relative_imports = "parents"
+        linter.flake8_tidy_imports.relative_import_style = "parents-absolute"
         linter.flake8_tidy_imports.banned_api = {}
         linter.flake8_tidy_imports.banned_module_level_imports = []
         linter.flake8_type_checking.strict = false
@@ -4319,7 +4319,7 @@ from typing import Union;foo: Union[int, str] = 1
         	_name_,
         	_value_,
         ]
-        linter.flake8_tidy_imports.ban_relative_imports = "parents"
+        linter.flake8_tidy_imports.relative_import_style = "parents-absolute"
         linter.flake8_tidy_imports.banned_api = {}
         linter.flake8_tidy_imports.banned_module_level_imports = []
         linter.flake8_type_checking.strict = false
@@ -4657,7 +4657,7 @@ from typing import Union;foo: Union[int, str] = 1
         	_name_,
         	_value_,
         ]
-        linter.flake8_tidy_imports.ban_relative_imports = "parents"
+        linter.flake8_tidy_imports.relative_import_style = "parents-absolute"
         linter.flake8_tidy_imports.banned_api = {}
         linter.flake8_tidy_imports.banned_module_level_imports = []
         linter.flake8_type_checking.strict = false

--- a/crates/ruff/tests/snapshots/show_settings__display_default_settings.snap
+++ b/crates/ruff/tests/snapshots/show_settings__display_default_settings.snap
@@ -292,7 +292,7 @@ linter.flake8_self.ignore_names = [
 	_name_,
 	_value_,
 ]
-linter.flake8_tidy_imports.ban_relative_imports = "parents"
+linter.flake8_tidy_imports.relative_import_style = "parents-absolute"
 linter.flake8_tidy_imports.banned_api = {}
 linter.flake8_tidy_imports.banned_module_level_imports = []
 linter.flake8_type_checking.strict = false

--- a/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
@@ -836,13 +836,13 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                     );
                 }
                 if checker.is_rule_enabled(Rule::RelativeImports) {
-                    flake8_tidy_imports::rules::banned_relative_import(
+                    flake8_tidy_imports::rules::enforce_import_strictness(
                         checker,
                         stmt,
                         level,
                         module,
                         checker.module.qualified_name(),
-                        checker.settings().flake8_tidy_imports.ban_relative_imports,
+                        checker.settings().flake8_tidy_imports.relative_import_style,
                     );
                 }
                 if checker.is_rule_enabled(Rule::Debugger) {

--- a/crates/ruff_linter/src/rules/flake8_tidy_imports/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_tidy_imports/mod.rs
@@ -13,7 +13,7 @@ mod tests {
     use crate::assert_diagnostics;
     use crate::registry::Rule;
     use crate::rules::flake8_tidy_imports;
-    use crate::rules::flake8_tidy_imports::settings::{ApiBan, Strictness};
+    use crate::rules::flake8_tidy_imports::settings::{ApiBan, ImportStyle};
     use crate::settings::LinterSettings;
     use crate::test::test_path;
 
@@ -82,7 +82,7 @@ mod tests {
             Path::new("flake8_tidy_imports/TID252.py"),
             &LinterSettings {
                 flake8_tidy_imports: flake8_tidy_imports::settings::Settings {
-                    ban_relative_imports: Strictness::Parents,
+                    relative_import_style: ImportStyle::ParentsAbsolute,
                     ..Default::default()
                 },
                 ..LinterSettings::for_rules(vec![Rule::RelativeImports])
@@ -98,7 +98,7 @@ mod tests {
             Path::new("flake8_tidy_imports/TID252.py"),
             &LinterSettings {
                 flake8_tidy_imports: flake8_tidy_imports::settings::Settings {
-                    ban_relative_imports: Strictness::All,
+                    relative_import_style: ImportStyle::AlwaysAbsolute,
                     ..Default::default()
                 },
                 ..LinterSettings::for_rules(vec![Rule::RelativeImports])
@@ -114,7 +114,7 @@ mod tests {
             Path::new("flake8_tidy_imports/TID/my_package/sublib/api/application.py"),
             &LinterSettings {
                 flake8_tidy_imports: flake8_tidy_imports::settings::Settings {
-                    ban_relative_imports: Strictness::Parents,
+                    relative_import_style: ImportStyle::ParentsAbsolute,
                     ..Default::default()
                 },
                 namespace_packages: vec![Path::new("my_package").to_path_buf()],

--- a/crates/ruff_linter/src/rules/flake8_tidy_imports/settings.rs
+++ b/crates/ruff_linter/src/rules/flake8_tidy_imports/settings.rs
@@ -22,26 +22,29 @@ impl Display for ApiBan {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, CacheKey, Default)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
-pub enum Strictness {
+pub enum ImportStyle {
+    /// Force imports to be relative.
+    AlwaysRelative,
     /// Ban imports that extend into the parent module or beyond.
     #[default]
-    Parents,
+    ParentsAbsolute,
     /// Ban all relative imports.
-    All,
+    AlwaysAbsolute,
 }
 
-impl Display for Strictness {
+impl Display for ImportStyle {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Parents => write!(f, "\"parents\""),
-            Self::All => write!(f, "\"all\""),
+            Self::AlwaysRelative => write!(f, "\"always-relative\""),
+            Self::ParentsAbsolute => write!(f, "\"parents-absolute\""),
+            Self::AlwaysAbsolute => write!(f, "\"always-absolute\""),
         }
     }
 }
 
 #[derive(Debug, Clone, CacheKey, Default)]
 pub struct Settings {
-    pub ban_relative_imports: Strictness,
+    pub relative_import_style: ImportStyle,
     pub banned_api: FxHashMap<String, ApiBan>,
     pub banned_module_level_imports: Vec<String>,
 }
@@ -58,7 +61,7 @@ impl Display for Settings {
             formatter = f,
             namespace = "linter.flake8_tidy_imports",
             fields = [
-                self.ban_relative_imports,
+                self.relative_import_style,
                 self.banned_api | map,
                 self.banned_module_level_imports | array,
             ]

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -15,7 +15,7 @@ use ruff_linter::rules::flake8_import_conventions::settings::BannedAliases;
 use ruff_linter::rules::flake8_pytest_style::settings::SettingsError;
 use ruff_linter::rules::flake8_pytest_style::types;
 use ruff_linter::rules::flake8_quotes::settings::Quote;
-use ruff_linter::rules::flake8_tidy_imports::settings::{ApiBan, Strictness};
+use ruff_linter::rules::flake8_tidy_imports::settings::{ApiBan, ImportStyle};
 use ruff_linter::rules::isort::settings::RelativeImportsOrder;
 use ruff_linter::rules::isort::{ImportSection, ImportType};
 use ruff_linter::rules::pep8_naming::settings::IgnoreNames;
@@ -2007,10 +2007,10 @@ pub struct Flake8TidyImportsOptions {
         value_type = r#""parents" | "all""#,
         example = r#"
             # Disallow all relative imports.
-            ban-relative-imports = "all"
+            relative-import-style = "all"
         "#
     )]
-    pub ban_relative_imports: Option<Strictness>,
+    pub relative_import_style: Option<ImportStyle>,
 
     /// Specific modules or module members that may not be imported or accessed.
     /// Note that this rule is only meant to flag accidental uses,
@@ -2045,7 +2045,9 @@ pub struct Flake8TidyImportsOptions {
 impl Flake8TidyImportsOptions {
     pub fn into_settings(self) -> flake8_tidy_imports::settings::Settings {
         flake8_tidy_imports::settings::Settings {
-            ban_relative_imports: self.ban_relative_imports.unwrap_or(Strictness::Parents),
+            relative_import_style: self
+                .relative_import_style
+                .unwrap_or(ImportStyle::ParentsAbsolute),
             banned_api: self.banned_api.unwrap_or_default(),
             banned_module_level_imports: self.banned_module_level_imports.unwrap_or_default(),
         }

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -1425,17 +1425,6 @@
       "description": "Options for the `flake8-tidy-imports` plugin",
       "type": "object",
       "properties": {
-        "ban-relative-imports": {
-          "description": "Whether to ban all relative imports (`\"all\"`), or only those imports that extend into the parent module or beyond (`\"parents\"`).",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Strictness"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
         "banned-api": {
           "description": "Specific modules or module members that may not be imported or accessed. Note that this rule is only meant to flag accidental uses, and can be circumvented via `eval` or `importlib`.",
           "type": [
@@ -1455,6 +1444,17 @@
           "items": {
             "type": "string"
           }
+        },
+        "relative-import-style": {
+          "description": "Whether to ban all relative imports (`\"all\"`), or only those imports that extend into the parent module or beyond (`\"parents\"`).",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ImportStyle"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "additionalProperties": false
@@ -1613,6 +1613,31 @@
         },
         {
           "type": "string"
+        }
+      ]
+    },
+    "ImportStyle": {
+      "oneOf": [
+        {
+          "description": "Force imports to be relative.",
+          "type": "string",
+          "enum": [
+            "always-relative"
+          ]
+        },
+        {
+          "description": "Ban imports that extend into the parent module or beyond.",
+          "type": "string",
+          "enum": [
+            "parents-absolute"
+          ]
+        },
+        {
+          "description": "Ban all relative imports.",
+          "type": "string",
+          "enum": [
+            "always-absolute"
+          ]
         }
       ]
     },
@@ -4356,24 +4381,6 @@
         "YTT301",
         "YTT302",
         "YTT303"
-      ]
-    },
-    "Strictness": {
-      "oneOf": [
-        {
-          "description": "Ban imports that extend into the parent module or beyond.",
-          "type": "string",
-          "enum": [
-            "parents"
-          ]
-        },
-        {
-          "description": "Ban all relative imports.",
-          "type": "string",
-          "enum": [
-            "all"
-          ]
-        }
       ]
     }
   }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

Adds an 'always relative' import style setting to flake8-tidy-imports, closing #4188 .
    
The PR changes the flake8-tidy-imports TID252 rule and its ban-relative-imports setting to allow forcing imports to be always absolute, relative, or absolute for parents.
    
Since the rule used to just configure the maximum level of relative import (either never allowing relative or allowing at the same level), I renamed the rule from `ban-relative-imports` to `relative-import-style`. I also made some internal name changes, e.g., relative import `Strictness` became relative import `ImportStyle` (perhaps a slightly redundant name), and diagnostics were updated.
    
The implementation relies on the categorize function used for the isort rule to determine if absolute imports are first party and therefore could be relative.
    
NOTE: I realize now that this implementation is wrong, which is why this PR is marked as draft.
First party doesn't mean 'can be relative,'  as users can configure separate packages to be first party with `isort.known-first-party` but they can't be imported relatively. I'll have to take a closer look at the ImportType options and see which one applies to same-package imports that could become `from .bar import baz` instead of `from foo.bar import baz`.

### Settings

I also presume that the way this PR naively renames the setting is a big no-no for breaking configs, especially since TID252 is not in preview. I actually couldn't find any examples of renaming settings in the changelogs: presumably there should be some sort of deprecation period.

**Getting feedback on the settings is the main reason I'm opening the PR** even in its incomplete state. The renaming seems necessary, because:

* The initial feedback on the feature request said "We could probably add support for this as a configurable setting in TID252"
* The existing setting can cleanly cover all three cases, so adding a second one and having two overlapping settings for this rule would seem odd
* However, setting `ban-relative-imports` to force relative imports would be confusing. Even something like `ban-relative-imports = 'none'`, while in keeping with the current rules, doesn't make it clear that absolute imports are actually being banned.

## Test Plan

Right now, I updated the existing tests, but I still need to add new tests where absolute imports trigger diagnostics if appropriate (they are in the same package namespace and could be relative).

I also want to look into the performance. It feels redundant to re-categorize all imports when they're already being categorized elsewhere for the isort rule, but we can't assume that the isort rule is enabled and we can get the information from there. Maybe we could categorize them all at a higher level and pass that information to the relevant places, but that could also add unnecessary complexity?