### PR TITLE
[ty] Add more regression tests for `tuple`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
@@ -630,5 +630,34 @@ class C[T](C): ...
 class D[T](D[int]): ...
 ```
 
+## Tuple as a PEP-695 generic class
+
+Our special handling for `tuple` does not break if `tuple` is defined as a PEP-695 generic class in
+typeshed:
+
+```toml
+[environment]
+python-version = "3.12"
+typeshed = "/typeshed"
+```
+
+`/typeshed/stdlib/builtins.pyi`:
+
+```pyi
+class tuple[T]: ...
+```
+
+`/typeshed/stdlib/typing_extensions.pyi`:
+
+```pyi
+def reveal_type(obj, /): ...
+```
+
+`main.py`:
+
+```py
+reveal_type((1, 2, 3))  # revealed: tuple[Literal[1], Literal[2], Literal[3]]
+```
+
 [crtp]: https://en.wikipedia.org/wiki/Curiously_recurring_template_pattern
 [f-bound]: https://en.wikipedia.org/wiki/Bounded_quantification#F-bounded_quantification

--- a/crates/ty_python_semantic/resources/mdtest/narrow/type.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/type.md
@@ -223,6 +223,17 @@ def _[T](x: A | B):
         reveal_type(x)  # revealed: A[int] | B
 ```
 
+## Narrowing for tuple
+
+An early version of <https://github.com/astral-sh/ruff/pull/19920> caused us to crash on this:
+
+```py
+def _(val):
+    if type(val) is tuple:
+        # TODO: better would be `Unknown & tuple[object, ...]`
+        reveal_type(val)  # revealed: Unknown & tuple[Unknown, ...]
+```
+
 ## Limitations
 
 ```py


### PR DESCRIPTION
## Summary

Early versions of #19920 (which we decided not to merge, at least for now) caused incorrect behaviour or panics for both of the situations being tested here, without any tests failing. This indicates that we have missing coverage -- so this PR adds the tests from that branch.

## Test Plan

`cargo test -p ty_python_semantic`
