### PR TITLE
[ty] apply `KW_ONLY` sentinel only to local fields

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
@@ -988,6 +988,28 @@ class D:  # error: [duplicate-kw-only]
         z: float
 ```
 
+`KW_ONLY` should only affect fields declared after it within the same class, not fields in
+subclasses:
+
+```py
+from dataclasses import dataclass, KW_ONLY
+
+@dataclass
+class D:
+    x: int
+    _: KW_ONLY
+    y: str
+
+@dataclass
+class E(D):
+    z: bytes
+
+# This should work: x=1 (positional), z=b"foo" (positional), y="foo" (keyword-only)
+E(1, b"foo", y="foo")
+
+reveal_type(E.__init__)  # revealed: (self: E, x: int, z: bytes, *, y: str) -> None
+```
+
 ## Other special cases
 
 ### `dataclasses.dataclass`

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/dataclasses.md_-_Dataclasses_-_`dataclasses.KW_ONLY…_(dd1b8f2f71487f16).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/dataclasses.md_-_Dataclasses_-_`dataclasses.KW_ONLY…_(dd1b8f2f71487f16).snap
@@ -49,6 +49,22 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.
 35 |         y: str
 36 |         _2: KW_ONLY
 37 |         z: float
+38 | from dataclasses import dataclass, KW_ONLY
+39 | 
+40 | @dataclass
+41 | class D:
+42 |     x: int
+43 |     _: KW_ONLY
+44 |     y: str
+45 | 
+46 | @dataclass
+47 | class E(D):
+48 |     z: bytes
+49 | 
+50 | # This should work: x=1 (positional), z=b"foo" (positional), y="foo" (keyword-only)
+51 | E(1, b"foo", y="foo")
+52 | 
+53 | reveal_type(E.__init__)  # revealed: (self: E, x: int, z: bytes, *, y: str) -> None
 ```
 
 # Diagnostics
@@ -139,5 +155,17 @@ error[duplicate-kw-only]: Dataclass has more than one field annotated with `KW_O
    |
 info: `KW_ONLY` fields: `_1`, `_2`
 info: rule `duplicate-kw-only` is enabled by default
+
+```
+
+```
+info[revealed-type]: Revealed type
+  --> src/mdtest_snippet.py:53:13
+   |
+51 | E(1, b"foo", y="foo")
+52 |
+53 | reveal_type(E.__init__)  # revealed: (self: E, x: int, z: bytes, *, y: str) -> None
+   |             ^^^^^^^^^^ `(self: E, x: int, z: bytes, *, y: str) -> None`
+   |
 
 ```

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -90,7 +90,7 @@ use crate::semantic_index::{
     ApplicableConstraints, EnclosingSnapshotResult, SemanticIndex, place_table, semantic_index,
 };
 use crate::types::call::{Binding, Bindings, CallArguments, CallError, CallErrorKind};
-use crate::types::class::{CodeGeneratorKind, Field, MetaclassErrorKind};
+use crate::types::class::{CodeGeneratorKind, MetaclassErrorKind};
 use crate::types::diagnostic::{
     self, CALL_NON_CALLABLE, CONFLICTING_DECLARATIONS, CONFLICTING_METACLASS,
     CYCLIC_CLASS_DEFINITION, DIVISION_BY_ZERO, DUPLICATE_KW_ONLY, INCONSISTENT_MRO,
@@ -1381,31 +1381,16 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 CodeGeneratorKind::from_class(self.db(), class)
             {
                 let specialization = None;
-                let mut kw_only_field_names = vec![];
 
-                for (
-                    name,
-                    Field {
-                        declared_ty: field_ty,
-                        ..
-                    },
-                ) in class.fields(self.db(), specialization, field_policy)
-                {
-                    let Some(instance) = field_ty.into_nominal_instance() else {
-                        continue;
-                    };
+                let kw_only_sentinel_fields: Vec<_> = class
+                    .fields(self.db(), specialization, field_policy)
+                    .into_iter()
+                    .filter_map(|(name, field)| {
+                        field.is_kw_only_sentinel(self.db()).then_some(name)
+                    })
+                    .collect();
 
-                    if !instance
-                        .class(self.db())
-                        .is_known(self.db(), KnownClass::KwOnly)
-                    {
-                        continue;
-                    }
-
-                    kw_only_field_names.push(name);
-                }
-
-                if kw_only_field_names.len() > 1 {
+                if kw_only_sentinel_fields.len() > 1 {
                     // TODO: The fields should be displayed in a subdiagnostic.
                     if let Some(builder) = self
                         .context
@@ -1417,7 +1402,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
                         diagnostic.info(format_args!(
                             "`KW_ONLY` fields: {}",
-                            kw_only_field_names
+                            kw_only_sentinel_fields
                                 .iter()
                                 .map(|name| format!("`{name}`"))
                                 .join(", ")


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR fixes how `KW_ONLY` is applied in dataclasses. Previously, the sentinel leaked into subclasses and incorrectly marked their fields as keyword-only; now it only affects fields declared in the same class.

```py
from dataclasses import dataclass, KW_ONLY

@dataclass
class D:
    x: int
    _: KW_ONLY
    y: str

@dataclass
class E(D):
    z: bytes

# This should work: x=1 (positional), z=b"foo" (positional), y="foo" (keyword-only)
E(1, b"foo", y="foo")

reveal_type(E.__init__)  # revealed: (self: E, x: int, z: bytes, *, y: str) -> None
```

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
mdtests