### PR TITLE
[ty] distinguish base conda from child conda

### DIFF
--- a/crates/ty_static/src/env_vars.rs
+++ b/crates/ty_static/src/env_vars.rs
@@ -42,6 +42,9 @@ impl EnvVars {
     /// Used to detect an activated virtual environment.
     pub const VIRTUAL_ENV: &'static str = "VIRTUAL_ENV";
 
+    /// Used to determine if an active Conda environment is the base environment or not.
+    pub const CONDA_DEFAULT_ENV: &'static str = "CONDA_DEFAULT_ENV";
+
     /// Used to detect an activated Conda environment location.
     /// If both `VIRTUAL_ENV` and `CONDA_PREFIX` are present, `VIRTUAL_ENV` will be preferred.
     pub const CONDA_PREFIX: &'static str = "CONDA_PREFIX";


### PR DESCRIPTION
This is a port of the logic in https://github.com/astral-sh/uv/pull/7691

The basic idea is we use CONDA_DEFAULT_ENV as a signal for whether CONDA_PREFIX is just the ambient system conda install, or the user has explicitly activated a custom one. If the former, then the conda is treated like a system install (having lowest priority). If the latter, the conda is treated like an activated venv (having priority over everything but an Actual activated venv).

Fixes https://github.com/astral-sh/ty/issues/611