### PR TITLE
Update outdated links to https://typing.python.org/en/latest/source/stubs.html

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/future_annotations_in_stub.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/future_annotations_in_stub.rs
@@ -16,7 +16,7 @@ use crate::{checkers::ast::Checker, fix};
 /// statement has no effect and should be omitted.
 ///
 /// ## References
-/// - [Static Typing with Python: Type Stubs](https://typing.python.org/en/latest/source/stubs.html)
+/// - [Typing Style Guide](https://typing.python.org/en/latest/guides/writing_stubs.html#language-features)
 #[derive(ViolationMetadata)]
 pub(crate) struct FutureAnnotationsInStub;
 

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/blank_lines.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/blank_lines.rs
@@ -60,7 +60,7 @@ const BLANK_LINES_NESTED_LEVEL: u32 = 1;
 /// ## References
 /// - [PEP 8: Blank Lines](https://peps.python.org/pep-0008/#blank-lines)
 /// - [Flake 8 rule](https://www.flake8rules.com/rules/E301.html)
-/// - [Typing Style Guide](https://typing.python.org/en/latest/source/stubs.html#blank-lines)
+/// - [Typing Style Guide](https://typing.python.org/en/latest/guides/writing_stubs.html#blank-lines)
 #[derive(ViolationMetadata)]
 pub(crate) struct BlankLineBetweenMethods;
 
@@ -113,7 +113,7 @@ impl AlwaysFixableViolation for BlankLineBetweenMethods {
 /// ## References
 /// - [PEP 8: Blank Lines](https://peps.python.org/pep-0008/#blank-lines)
 /// - [Flake 8 rule](https://www.flake8rules.com/rules/E302.html)
-/// - [Typing Style Guide](https://typing.python.org/en/latest/source/stubs.html#blank-lines)
+/// - [Typing Style Guide](https://typing.python.org/en/latest/guides/writing_stubs.html#blank-lines)
 #[derive(ViolationMetadata)]
 pub(crate) struct BlankLinesTopLevel {
     actual_blank_lines: u32,
@@ -180,7 +180,7 @@ impl AlwaysFixableViolation for BlankLinesTopLevel {
 /// ## References
 /// - [PEP 8: Blank Lines](https://peps.python.org/pep-0008/#blank-lines)
 /// - [Flake 8 rule](https://www.flake8rules.com/rules/E303.html)
-/// - [Typing Style Guide](https://typing.python.org/en/latest/source/stubs.html#blank-lines)
+/// - [Typing Style Guide](https://typing.python.org/en/latest/guides/writing_stubs.html#blank-lines)
 #[derive(ViolationMetadata)]
 pub(crate) struct TooManyBlankLines {
     actual_blank_lines: u32,
@@ -277,7 +277,7 @@ impl AlwaysFixableViolation for BlankLineAfterDecorator {
 /// ## References
 /// - [PEP 8: Blank Lines](https://peps.python.org/pep-0008/#blank-lines)
 /// - [Flake 8 rule](https://www.flake8rules.com/rules/E305.html)
-/// - [Typing Style Guide](https://typing.python.org/en/latest/source/stubs.html#blank-lines)
+/// - [Typing Style Guide](https://typing.python.org/en/latest/guides/writing_stubs.html#blank-lines)
 #[derive(ViolationMetadata)]
 pub(crate) struct BlankLinesAfterFunctionOrClass {
     actual_blank_lines: u32,
@@ -331,7 +331,7 @@ impl AlwaysFixableViolation for BlankLinesAfterFunctionOrClass {
 /// ## References
 /// - [PEP 8: Blank Lines](https://peps.python.org/pep-0008/#blank-lines)
 /// - [Flake 8 rule](https://www.flake8rules.com/rules/E306.html)
-/// - [Typing Style Guide](https://typing.python.org/en/latest/source/stubs.html#blank-lines)
+/// - [Typing Style Guide](https://typing.python.org/en/latest/guides/writing_stubs.html#blank-lines)
 #[derive(ViolationMetadata)]
 pub(crate) struct BlankLinesBeforeNestedDefinition;
 


### PR DESCRIPTION

<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

> ### Type Stubs
> The contents of this document have been moved to [Stub files](https://typing.python.org/en/latest/spec/distributing.html#stub-files) and [Writing and Maintaining Stub Files](https://typing.python.org/en/latest/guides/writing_stubs.html#writing-stubs).

## Test Plan

Look at the docs
