### PR TITLE
[ty] Fix namespace packages that behave like partial stubs

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/import/partial_stub_packages.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/partial_stub_packages.md
@@ -54,9 +54,9 @@ partial
 ```pyi
 ```
 
-`/packages/foo-stubs/both.py`:
+`/packages/foo-stubs/both.pyi`:
 
-```py
+```pyi
 class Both:
     both: str
     other: int
@@ -107,9 +107,9 @@ extra-paths = ["/packages"]
 ```pyi
 ```
 
-`/packages/foo-stubs/both.py`:
+`/packages/foo-stubs/both.pyi`:
 
-```py
+```pyi
 class Both:
     both: str
     other: int
@@ -165,9 +165,9 @@ extra-paths = ["/packages"]
 ```pyi
 ```
 
-`/packages/foo-stubs/both.py`:
+`/packages/foo-stubs/both.pyi`:
 
-```py
+```pyi
 class Both:
     both: str
     other: int
@@ -230,9 +230,9 @@ extra-paths = ["/packages"]
 ```pyi
 ```
 
-`/packages/foo-stubs/bar/both.py`:
+`/packages/foo-stubs/bar/both.pyi`:
 
-```py
+```pyi
 class Both:
     both: str
     other: int
@@ -305,9 +305,9 @@ partial/n
 ```pyi
 ```
 
-`/packages/foo-stubs/bar/both.py`:
+`/packages/foo-stubs/bar/both.pyi`:
 
-```py
+```pyi
 class Both:
     both: str
     other: int
@@ -380,9 +380,9 @@ pArTiAl\n
 ```pyi
 ```
 
-`/packages/foo-stubs/bar/both.py`:
+`/packages/foo-stubs/bar/both.pyi`:
 
-```py
+```pyi
 class Both:
     both: str
     other: int
@@ -418,6 +418,52 @@ class Impl:
 from foo.bar.both import Both
 from foo.bar.impl import Impl  # error: "Cannot resolve"
 from foo.bar.fake import Fake  # error: "Cannot resolve"
+
+reveal_type(Both().both)  # revealed: str
+reveal_type(Impl().impl)  # revealed: Unknown
+reveal_type(Fake().fake)  # revealed: Unknown
+```
+
+## Namespace stub with missing module
+
+Namespace stubs are always partial.
+
+Here "both" is found in the stub, while "impl" is found in the implementation. "fake" is found in
+neither.
+
+```toml
+[environment]
+extra-paths = ["/packages"]
+```
+
+`/packages/parent-stubs/foo/both.pyi`:
+
+```pyi
+class Both:
+    both: str
+    other: int
+```
+
+`/packages/parent/foo/both.py`:
+
+```py
+class Both: ...
+```
+
+`/packages/parent/foo/impl.py`:
+
+```py
+class Impl:
+    impl: str
+    other: int
+```
+
+`main.py`:
+
+```py
+from parent.foo.both import Both
+from parent.foo.impl import Impl  # error: "Cannot resolve"
+from parent.foo.fake import Fake  # error: "Cannot resolve"
 
 reveal_type(Both().both)  # revealed: str
 reveal_type(Impl().impl)  # revealed: Unknown

--- a/crates/ty_python_semantic/resources/mdtest/import/partial_stub_packages.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/partial_stub_packages.md
@@ -428,8 +428,7 @@ reveal_type(Fake().fake)  # revealed: Unknown
 
 Namespace stubs are always partial.
 
-Here "both" is found in the stub, while "impl" is found in the implementation. "fake" is found in
-neither.
+This is a regression test for <https://github.com/astral-sh/ty/issues/520>.
 
 ```toml
 [environment]
@@ -462,10 +461,10 @@ class Impl:
 
 ```py
 from parent.foo.both import Both
-from parent.foo.impl import Impl  # error: "Cannot resolve"
+from parent.foo.impl import Impl
 from parent.foo.fake import Fake  # error: "Cannot resolve"
 
 reveal_type(Both().both)  # revealed: str
-reveal_type(Impl().impl)  # revealed: Unknown
+reveal_type(Impl().impl)  # revealed: str
 reveal_type(Fake().fake)  # revealed: Unknown
 ```

--- a/crates/ty_python_semantic/src/module_resolver/resolver.rs
+++ b/crates/ty_python_semantic/src/module_resolver/resolver.rs
@@ -723,8 +723,7 @@ fn resolve_name(db: &dyn Db, name: &ModuleName, mode: ModuleResolveMode) -> Opti
                          `{name}` but it is a namespace package, keep going."
                     );
                     // stub exists, but the module doesn't. But this is a namespace package,
-                    // keep searching the next search path for a stub package with the same name.
-                    continue;
+                    // fall through to looking for a non-stub package
                 }
             }
         }


### PR DESCRIPTION
In implementing partial stubs I had observed that this continue in the namespace package code seemed erroneous since the same continue for partial stubs didn't work. Unfortunately I wasn't confident enough to push on that hunch. Fortunately I remembered that hunch to make this an easy fix.

The issue with the continue is that it bails out of the current search-path without testing any .py files. This breaks when for example `google` and `google-stubs`/`types-google` are both in the same site-packages dir -- failing to find a module in `types-google` has us completely skip over `google`!

Fixes https://github.com/astral-sh/ty/issues/520