### PR TITLE
non-building draft PR for early feedback

### DIFF
--- a/crates/ty_ide/src/semantic_tokens.rs
+++ b/crates/ty_ide/src/semantic_tokens.rs
@@ -336,7 +336,7 @@ impl<'db> SemanticTokenVisitor<'db> {
         }
 
         match ty {
-            Type::ClassLiteral(_) => (SemanticTokenType::Class, modifiers),
+            Type::ClassSingleton(_) => (SemanticTokenType::Class, modifiers),
             Type::NonInferableTypeVar(_) | Type::TypeVar(_) => {
                 (SemanticTokenType::TypeParameter, modifiers)
             }
@@ -370,7 +370,7 @@ impl<'db> SemanticTokenVisitor<'db> {
 
         // Classify based on the inferred type of the attribute
         match ty {
-            Type::ClassLiteral(_) => (SemanticTokenType::Class, modifiers),
+            Type::ClassSingleton(_) => (SemanticTokenType::Class, modifiers),
             Type::FunctionLiteral(_) => {
                 // This is a function accessed as an attribute, likely a method
                 (SemanticTokenType::Method, modifiers)
@@ -1373,10 +1373,10 @@ from typing import List
 
 class MyClass:
     CONSTANT = 42
-    
+
     def method(self):
         return \"hello\"
-    
+
     @property
     def prop(self):
         return self.CONSTANT
@@ -1442,7 +1442,7 @@ u = List.__name__        # __name__ should be variable<CURSOR>
             "
 class MyClass:
     some_attr = \"value\"
-    
+
 obj = MyClass()
 # Test attribute that might not have detailed semantic info
 x = obj.some_attr        # Should fall back to variable, not property
@@ -1476,10 +1476,10 @@ class MyClass:
     lower_case = 24
     MixedCase = 12
     A = 1
-    
+
 obj = MyClass()
 x = obj.UPPER_CASE    # Should have readonly modifier
-y = obj.lower_case    # Should not have readonly modifier  
+y = obj.lower_case    # Should not have readonly modifier
 z = obj.MixedCase     # Should not have readonly modifier
 w = obj.A             # Should not have readonly modifier (length == 1)<CURSOR>
 ",
@@ -1604,7 +1604,7 @@ def test_function(param: int, other: MyClass) -> Optional[List[str]]:
     x: int = 42
     y: MyClass = MyClass()
     z: List[str] = [\"hello\"]
-    
+
     # Type annotations should be Class tokens:
     # int, MyClass, Optional, List, str
     return None<CURSOR>
@@ -1683,7 +1683,7 @@ class MyProtocol(Protocol):
 # Value context - MyProtocol is still a class literal, so should be Class
 my_protocol_var = MyProtocol
 
-# Type annotation context - should be Class  
+# Type annotation context - should be Class
 def test_function(param: MyProtocol) -> MyProtocol:
     return param
 <CURSOR>",
@@ -1719,7 +1719,7 @@ def test_function(param: MyProtocol) -> MyProtocol:
 def func[T](x: T) -> T:
     return x
 
-# Generic function with TypeVarTuple  
+# Generic function with TypeVarTuple
 def func_tuple[*Ts](args: tuple[*Ts]) -> tuple[*Ts]:
     return args
 
@@ -1734,10 +1734,10 @@ class Container[T, U]:
     def __init__(self, value1: T, value2: U):
         self.value1: T = value1
         self.value2: U = value2
-    
+
     def get_first(self) -> T:
         return self.value1
-    
+
     def get_second(self) -> U:
         return self.value2
 
@@ -1892,8 +1892,8 @@ class MyClass:
     fn test_implicitly_concatenated_strings() {
         let test = cursor_test(
             r#"x = "hello" "world"
-y = ("multi" 
-     "line" 
+y = ("multi"
+     "line"
      "string")
 z = 'single' "mixed" 'quotes'<CURSOR>"#,
         );
@@ -1919,8 +1919,8 @@ z = 'single' "mixed" 'quotes'<CURSOR>"#,
     fn test_bytes_literals() {
         let test = cursor_test(
             r#"x = b"hello" b"world"
-y = (b"multi" 
-     b"line" 
+y = (b"multi"
+     b"line"
      b"bytes")
 z = b'single' b"mixed" b'quotes'<CURSOR>"#,
         );
@@ -2040,21 +2040,21 @@ y = "another_global"
 def outer():
     x = "outer_value"
     z = "outer_local"
-    
+
     def inner():
         nonlocal x, z  # These should be variable tokens
         global y       # This should be a variable token
         x = "modified"
         y = "modified_global"
         z = "modified_local"
-        
+
         def deeper():
             nonlocal x    # Variable token
             global y, x   # Both should be variable tokens
             return x + y
-        
+
         return deeper
-    
+
     return inner<CURSOR>
 "#,
         );
@@ -2100,11 +2100,11 @@ def outer():
 def test():
     global x
     nonlocal y
-    
+
     # Multiple variables in one statement
     global a, b, c
     nonlocal d, e, f
-    
+
     return x + y + a + b + c + d + e + f<CURSOR>
 "#,
         );

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -1323,7 +1323,7 @@ mod implicit_globals {
         {
             return Place::Unbound.into();
         }
-        let Type::ClassSingleton(module_type_class) = KnownClass::ModuleType.to_class_literal(db)
+        let Type::ClassSingleton(module_type_class) = KnownClass::ModuleType.to_class_singleton(db)
         else {
             return Place::Unbound.into();
         };
@@ -1402,7 +1402,7 @@ mod implicit_globals {
     #[salsa::tracked(returns(deref), heap_size=ruff_memory_usage::heap_size)]
     fn module_type_symbols<'db>(db: &'db dyn Db) -> smallvec::SmallVec<[ast::name::Name; 8]> {
         let Some(module_type) = KnownClass::ModuleType
-            .to_class_literal(db)
+            .to_class_singleton(db)
             .into_class_literal()
         else {
             // The most likely way we get here is if a user specified a `--custom-typeshed-dir`

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -1403,7 +1403,7 @@ mod implicit_globals {
     fn module_type_symbols<'db>(db: &'db dyn Db) -> smallvec::SmallVec<[ast::name::Name; 8]> {
         let Some(module_type) = KnownClass::ModuleType
             .to_class_singleton(db)
-            .into_class_literal()
+            .into_class_singleton()
         else {
             // The most likely way we get here is if a user specified a `--custom-typeshed-dir`
             // without a `types.pyi` stub in the `stdlib/` directory

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -1323,7 +1323,7 @@ mod implicit_globals {
         {
             return Place::Unbound.into();
         }
-        let Type::ClassLiteral(module_type_class) = KnownClass::ModuleType.to_class_literal(db)
+        let Type::ClassSingleton(module_type_class) = KnownClass::ModuleType.to_class_literal(db)
         else {
             return Place::Unbound.into();
         };

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -215,7 +215,7 @@ impl<'db> Completion<'db> {
                 | Type::Callable(_) => CompletionKind::Function,
                 Type::BoundMethod(_) | Type::MethodWrapper(_) => CompletionKind::Method,
                 Type::ModuleLiteral(_) => CompletionKind::Module,
-                Type::ClassLiteral(_) | Type::GenericAlias(_) | Type::SubclassOf(_) => {
+                Type::ClassSingleton(_) | Type::GenericAlias(_) | Type::SubclassOf(_) => {
                     CompletionKind::Class
                 }
                 // This is a little weird for "struct." I'm mostly interpreting

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -474,7 +474,7 @@ mod tests {
         let model = SemanticModel::new(&db, foo);
         let ty = class.inferred_type(&model);
 
-        assert!(ty.is_class_literal());
+        assert!(ty.is_class_singleton());
 
         Ok(())
     }
@@ -495,7 +495,7 @@ mod tests {
         let model = SemanticModel::new(&db, bar);
         let ty = alias.inferred_type(&model);
 
-        assert!(ty.is_class_literal());
+        assert!(ty.is_class_singleton());
 
         Ok(())
     }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -4257,6 +4257,20 @@ impl<'db> Type<'db> {
                     .into()
                 }
 
+                Some(KnownClass::NewType) => Binding::single(
+                    self,
+                    Signature::new(
+                        Parameters::new([
+                            Parameter::positional_or_keyword(Name::new_static("name"))
+                                .with_annotated_type(Type::LiteralString),
+                            Parameter::positional_or_keyword(Name::new_static("tp")),
+                        ]),
+                        // TODO: What should this return type be?
+                        Some(KnownClass::NewType.to_instance(db)),
+                    ),
+                )
+                .into(),
+
                 Some(KnownClass::Object) => {
                     // ```py
                     // class object:

--- a/crates/ty_python_semantic/src/types/builder.rs
+++ b/crates/ty_python_semantic/src/types/builder.rs
@@ -577,7 +577,7 @@ impl<'db> IntersectionBuilder<'db> {
                 self
             }
             Type::NominalInstance(instance)
-                if enum_metadata(self.db, instance.class(self.db).class_literal(self.db).0)
+                if enum_metadata(self.db, instance.class(self.db).class_singleton(self.db).0)
                     .is_some() =>
             {
                 let mut contains_enum_literal_as_negative_element = false;
@@ -602,7 +602,7 @@ impl<'db> IntersectionBuilder<'db> {
                     let db = self.db;
                     self.add_positive(Type::Union(UnionType::new(
                         db,
-                        enum_member_literals(db, instance.class(db).class_literal(db).0, None)
+                        enum_member_literals(db, instance.class(db).class_singleton(db).0, None)
                             .expect("Calling `enum_member_literals` on an enum class")
                             .collect::<Box<[_]>>(),
                     )))

--- a/crates/ty_python_semantic/src/types/builder.rs
+++ b/crates/ty_python_semantic/src/types/builder.rs
@@ -1175,7 +1175,7 @@ mod tests {
             .ignore_possibly_unbound()
             .unwrap();
 
-        let literals = enum_member_literals(&db, safe_uuid_class.expect_class_literal(), None)
+        let literals = enum_member_literals(&db, safe_uuid_class.expect_class_singleton(), None)
             .unwrap()
             .collect::<Vec<_>>();
         assert_eq!(literals.len(), 3);

--- a/crates/ty_python_semantic/src/types/call/arguments.rs
+++ b/crates/ty_python_semantic/src/types/call/arguments.rs
@@ -251,7 +251,8 @@ fn expand_type<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Vec<Type<'db>>> {
                 };
             }
 
-            if let Some(enum_members) = enum_member_literals(db, class.class_literal(db).0, None) {
+            if let Some(enum_members) = enum_member_literals(db, class.class_singleton(db).0, None)
+            {
                 return Some(enum_members.collect());
             }
 

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -644,7 +644,7 @@ impl<'db> Bindings<'db> {
                                 // TODO: Handle generic functions, and unions/intersections of
                                 // generic types
                                 overload.set_return_type(match ty {
-                                    Type::ClassLiteral(class) => class
+                                    Type::ClassSingleton(class) => class
                                         .generic_context(db)
                                         .map(|generic_context| generic_context.as_tuple(db))
                                         .unwrap_or_else(|| Type::none(db)),
@@ -693,7 +693,7 @@ impl<'db> Bindings<'db> {
                         Some(KnownFunction::EnumMembers) => {
                             if let [Some(ty)] = overload.parameter_types() {
                                 let return_ty = match ty {
-                                    Type::ClassLiteral(class) => {
+                                    Type::ClassSingleton(class) => {
                                         if let Some(metadata) = enums::enum_metadata(db, *class) {
                                             Type::heterogeneous_tuple(
                                                 db,
@@ -767,7 +767,8 @@ impl<'db> Bindings<'db> {
                         }
 
                         Some(KnownFunction::GetProtocolMembers) => {
-                            if let [Some(Type::ClassLiteral(class))] = overload.parameter_types() {
+                            if let [Some(Type::ClassSingleton(class))] = overload.parameter_types()
+                            {
                                 if let Some(protocol_class) = class.into_protocol_class(db) {
                                     let member_names = protocol_class
                                         .interface(db)
@@ -878,7 +879,7 @@ impl<'db> Bindings<'db> {
                             }
 
                             // `dataclass` being used as a non-decorator
-                            if let [Some(Type::ClassLiteral(class_literal))] =
+                            if let [Some(Type::ClassSingleton(class_literal))] =
                                 overload.parameter_types()
                             {
                                 let params = DataclassParams::default();
@@ -1008,7 +1009,7 @@ impl<'db> Bindings<'db> {
                         }
                     },
 
-                    Type::ClassLiteral(class) => match class.known(db) {
+                    Type::ClassSingleton(class) => match class.known(db) {
                         Some(KnownClass::Bool) => match overload.parameter_types() {
                             [Some(arg)] => overload.set_return_type(arg.bool(db).into_type(db)),
                             [None] => overload.set_return_type(Type::BooleanLiteral(false)),
@@ -2576,7 +2577,7 @@ impl<'db> CallableDescription<'db> {
                 kind: "function",
                 name: function.name(db),
             }),
-            Type::ClassLiteral(class_type) => Some(CallableDescription {
+            Type::ClassSingleton(class_type) => Some(CallableDescription {
                 kind: "class",
                 name: class_type.name(db),
             }),

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -760,7 +760,7 @@ impl<'db> Bindings<'db> {
                         Some(KnownFunction::IsProtocol) => {
                             if let [Some(ty)] = overload.parameter_types() {
                                 overload.set_return_type(Type::BooleanLiteral(
-                                    ty.into_class_literal()
+                                    ty.into_class_singleton()
                                         .is_some_and(|class| class.is_protocol(db)),
                                 ));
                             }

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -1056,6 +1056,22 @@ impl<'db> Bindings<'db> {
                             }
                         }
 
+                        Some(KnownClass::NewType) => match overload.parameter_types() {
+                            [Some(Type::StringLiteral(name)), Some(supertype)] => {
+                                let params = DataclassParams::default();
+                                overload.set_return_type(Type::from(ClassLiteral::new(
+                                    db,
+                                    ast::name::Name::new(name.value(db)),
+                                    what_goes_here,
+                                    None,
+                                    None,
+                                    None,
+                                    None,
+                                )));
+                            }
+                            _ => {}
+                        },
+
                         _ => {}
                     },
 

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -327,7 +327,7 @@ impl<'db> From<GenericAlias<'db>> for Type<'db> {
     get_size2::GetSize,
 )]
 pub enum ClassType<'db> {
-    NonGeneric(ClassLiteral<'db>),
+    NonGeneric(ClassSingletonType<'db>),
     Generic(GenericAlias<'db>),
 }
 
@@ -2917,7 +2917,7 @@ impl<'db> ClassLiteral<'db> {
     }
 
     pub(super) fn to_non_generic_instance(self, db: &'db dyn Db) -> Type<'db> {
-        Type::instance(db, ClassType::NonGeneric(self))
+        Type::instance(db, ClassType::NonGeneric(self.into()))
     }
 
     /// Return this class' involvement in an inheritance cycle, if any.
@@ -3016,7 +3016,7 @@ impl<'db> From<ClassLiteral<'db>> for ClassSingletonType<'db> {
 
 impl<'db> From<ClassLiteral<'db>> for ClassType<'db> {
     fn from(class: ClassLiteral<'db>) -> ClassType<'db> {
-        ClassType::NonGeneric(class)
+        ClassType::NonGeneric(class.into())
     }
 }
 

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -1144,6 +1144,11 @@ impl<'db> ClassType<'db> {
         }
     }
 
+    pub(crate) fn dataclass_params(&self, db: &'db dyn Db) -> Option<DataclassParams> {
+        let (singleton, _) = self.class_singleton(db);
+        singleton.dataclass_params(db)
+    }
+
     pub(crate) fn dataclass_transformer_params(
         &self,
         db: &'db dyn Db,
@@ -1381,6 +1386,13 @@ impl<'db> ClassSingletonType<'db> {
         match self {
             Self::Literal(literal) => literal.own_instance_member(db, name),
             Self::NewType(new_type) => new_type.own_instance_member(db, name),
+        }
+    }
+
+    pub(crate) fn dataclass_params(&self, db: &'db dyn Db) -> Option<DataclassParams> {
+        match self {
+            Self::Literal(literal) => literal.dataclass_params(db),
+            Self::NewType(new_type) => new_type.dataclass_params(db),
         }
     }
 
@@ -3308,6 +3320,10 @@ impl<'db> NewTypeClass<'db> {
 
     fn own_instance_member(self, db: &'db dyn Db, name: &str) -> PlaceAndQualifiers<'db> {
         self.parent(db).own_instance_member(db, name)
+    }
+
+    pub(crate) fn dataclass_params(&self, db: &'db dyn Db) -> Option<DataclassParams> {
+        self.parent(db).dataclass_params(db)
     }
 
     pub(crate) fn dataclass_transformer_params(

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -1343,6 +1343,13 @@ impl<'db> ClassSingletonType<'db> {
             }
         }
     }
+
+    fn own_instance_member(self, db: &'db dyn Db, name: &str) -> PlaceAndQualifiers<'db> {
+        match self {
+            Self::Literal(literal) => literal.own_instance_member(db, name),
+            Self::NewType(new_type) => new_type.own_instance_member(db, name),
+        }
+    }
 }
 
 impl<'db> From<ClassSingletonType<'db>> for Type<'db> {
@@ -3243,6 +3250,10 @@ impl<'db> NewTypeClass<'db> {
 
     pub(super) fn instance_member(self, db: &'db dyn Db, name: &str) -> PlaceAndQualifiers<'db> {
         self.parent(db).instance_member(db, name)
+    }
+
+    fn own_instance_member(self, db: &'db dyn Db, name: &str) -> PlaceAndQualifiers<'db> {
+        self.parent(db).own_instance_member(db, name)
     }
 }
 

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -1194,6 +1194,15 @@ enum ClassSingletonType<'db> {
     NewType(NewTypeClass<'db>),
 }
 
+impl<'db> ClassSingletonType<'db> {
+    pub(crate) fn has_pep_695_type_params(self, db: &'db dyn Db) -> bool {
+        match self {
+            Self::ClassLiteral(literal) => literal.has_pep_695_type_params(db),
+            Self::NewType(new_type) => false,
+        }
+    }
+}
+
 /// Representation of a class definition statement in the AST: either a non-generic class, or a
 /// generic class that has not been specialized.
 ///

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -1328,6 +1328,21 @@ impl<'db> ClassSingletonType<'db> {
             }
         }
     }
+
+    pub(super) fn instance_member(
+        self,
+        db: &'db dyn Db,
+        specialization: Option<Specialization<'db>>,
+        name: &str,
+    ) -> PlaceAndQualifiers<'db> {
+        match self {
+            Self::Literal(literal) => literal.instance_member(db, specialization, name),
+            Self::NewType(new_type) => {
+                // A NewType can't be specialized.
+                new_type.instance_member(db, name)
+            }
+        }
+    }
 }
 
 impl<'db> From<ClassSingletonType<'db>> for Type<'db> {
@@ -3224,6 +3239,10 @@ impl<'db> NewTypeClass<'db> {
     ) -> PlaceAndQualifiers<'db> {
         self.parent(db)
             .own_class_member(db, inherited_generic_context, name)
+    }
+
+    pub(super) fn instance_member(self, db: &'db dyn Db, name: &str) -> PlaceAndQualifiers<'db> {
+        self.parent(db).instance_member(db, name)
     }
 }
 

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -1231,6 +1231,14 @@ impl<'db> ClassSingletonType<'db> {
         }
     }
 
+    pub(crate) fn is_known(self, db: &'db dyn Db, known_class: KnownClass) -> bool {
+        self.known(db) == Some(known_class)
+    }
+
+    pub(crate) fn is_tuple(self, db: &'db dyn Db) -> bool {
+        self.is_known(db, KnownClass::Tuple)
+    }
+
     pub(crate) fn definition(self, db: &'db dyn Db) -> Definition<'db> {
         match self {
             Self::Literal(literal) => literal.definition(db),

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -657,6 +657,18 @@ impl<'db> ClassType<'db> {
         singleton.class_member_inner(db, specialization, name, policy)
     }
 
+    pub(super) fn class_member_from_mro(
+        self,
+        db: &'db dyn Db,
+        name: &str,
+        policy: MemberLookupPolicy,
+        mro_iter: impl Iterator<Item = ClassBase<'db>>,
+    ) -> PlaceAndQualifiers<'db> {
+        // TODO: Is this correct?
+        let (singleton, _) = self.class_singleton(db);
+        singleton.class_member_from_mro(db, name, policy, mro_iter)
+    }
+
     /// Returns the inferred type of the class member named `name`. Only bound members
     /// or those marked as `ClassVars` are considered.
     ///
@@ -1309,6 +1321,19 @@ impl<'db> ClassSingletonType<'db> {
         }
 
         self.class_member_from_mro(db, name, policy, self.iter_mro(db, specialization))
+    }
+
+    pub(super) fn class_member_from_mro(
+        self,
+        db: &'db dyn Db,
+        name: &str,
+        policy: MemberLookupPolicy,
+        mro_iter: impl Iterator<Item = ClassBase<'db>>,
+    ) -> PlaceAndQualifiers<'db> {
+        match self {
+            Self::Literal(literal) => literal.class_member_from_mro(db, name, policy, mro_iter),
+            Self::NewType(new_type) => new_type.class_member_from_mro(db, name, policy, mro_iter),
+        }
     }
 
     pub(super) fn own_class_member(
@@ -3236,6 +3261,17 @@ impl<'db> NewTypeClass<'db> {
     ) -> PlaceAndQualifiers<'db> {
         self.parent(db)
             .class_member_inner(db, specialization, name, policy)
+    }
+
+    pub(super) fn class_member_from_mro(
+        self,
+        db: &'db dyn Db,
+        name: &str,
+        policy: MemberLookupPolicy,
+        mro_iter: impl Iterator<Item = ClassBase<'db>>,
+    ) -> PlaceAndQualifiers<'db> {
+        self.parent(db)
+            .class_member_from_mro(db, name, policy, mro_iter)
     }
 
     pub(super) fn own_class_member(

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -77,7 +77,7 @@ impl<'db> ClassBase<'db> {
     ) -> Option<Self> {
         match ty {
             Type::Dynamic(dynamic) => Some(Self::Dynamic(dynamic)),
-            Type::ClassLiteral(literal) => {
+            Type::ClassSingleton(literal) => {
                 if literal.is_known(db, KnownClass::Any) {
                     Some(Self::Dynamic(DynamicType::Any))
                 } else {

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -62,7 +62,7 @@ impl<'db> ClassBase<'db> {
     /// Return a `ClassBase` representing the class `builtins.object`
     pub(super) fn object(db: &'db dyn Db) -> Self {
         KnownClass::Object
-            .to_class_literal(db)
+            .to_class_singleton(db)
             .to_class_type(db)
             .map_or(Self::unknown(), Self::Class)
     }
@@ -220,38 +220,42 @@ impl<'db> ClassBase<'db> {
 
                 // TODO: Classes inheriting from `typing.Type` et al. also have `Generic` in their MRO
                 SpecialFormType::Dict => {
-                    Self::try_from_type(db, KnownClass::Dict.to_class_literal(db), subclass)
+                    Self::try_from_type(db, KnownClass::Dict.to_class_singleton(db), subclass)
                 }
                 SpecialFormType::List => {
-                    Self::try_from_type(db, KnownClass::List.to_class_literal(db), subclass)
+                    Self::try_from_type(db, KnownClass::List.to_class_singleton(db), subclass)
                 }
                 SpecialFormType::Type => {
-                    Self::try_from_type(db, KnownClass::Type.to_class_literal(db), subclass)
+                    Self::try_from_type(db, KnownClass::Type.to_class_singleton(db), subclass)
                 }
                 SpecialFormType::Tuple => {
-                    Self::try_from_type(db, KnownClass::Tuple.to_class_literal(db), subclass)
+                    Self::try_from_type(db, KnownClass::Tuple.to_class_singleton(db), subclass)
                 }
                 SpecialFormType::Set => {
-                    Self::try_from_type(db, KnownClass::Set.to_class_literal(db), subclass)
+                    Self::try_from_type(db, KnownClass::Set.to_class_singleton(db), subclass)
                 }
                 SpecialFormType::FrozenSet => {
-                    Self::try_from_type(db, KnownClass::FrozenSet.to_class_literal(db), subclass)
+                    Self::try_from_type(db, KnownClass::FrozenSet.to_class_singleton(db), subclass)
                 }
                 SpecialFormType::ChainMap => {
-                    Self::try_from_type(db, KnownClass::ChainMap.to_class_literal(db), subclass)
+                    Self::try_from_type(db, KnownClass::ChainMap.to_class_singleton(db), subclass)
                 }
                 SpecialFormType::Counter => {
-                    Self::try_from_type(db, KnownClass::Counter.to_class_literal(db), subclass)
+                    Self::try_from_type(db, KnownClass::Counter.to_class_singleton(db), subclass)
                 }
-                SpecialFormType::DefaultDict => {
-                    Self::try_from_type(db, KnownClass::DefaultDict.to_class_literal(db), subclass)
-                }
+                SpecialFormType::DefaultDict => Self::try_from_type(
+                    db,
+                    KnownClass::DefaultDict.to_class_singleton(db),
+                    subclass,
+                ),
                 SpecialFormType::Deque => {
-                    Self::try_from_type(db, KnownClass::Deque.to_class_literal(db), subclass)
+                    Self::try_from_type(db, KnownClass::Deque.to_class_singleton(db), subclass)
                 }
-                SpecialFormType::OrderedDict => {
-                    Self::try_from_type(db, KnownClass::OrderedDict.to_class_literal(db), subclass)
-                }
+                SpecialFormType::OrderedDict => Self::try_from_type(
+                    db,
+                    KnownClass::OrderedDict.to_class_singleton(db),
+                    subclass,
+                ),
                 SpecialFormType::TypedDict => Some(Self::TypedDict),
                 SpecialFormType::Callable => Self::try_from_type(
                     db,
@@ -302,7 +306,7 @@ impl<'db> ClassBase<'db> {
     pub(super) fn has_cyclic_mro(self, db: &'db dyn Db) -> bool {
         match self {
             ClassBase::Class(class) => {
-                let (class_literal, specialization) = class.class_literal(db);
+                let (class_literal, specialization) = class.class_singleton(db);
                 class_literal
                     .try_mro(db, specialization)
                     .is_err_and(MroError::is_cycle)

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -2357,7 +2357,7 @@ pub(crate) fn report_bad_argument_to_protocol_interface(
             ),
         );
         class_def_diagnostic.annotate(Annotation::primary(
-            class.class_literal(db).0.header_span(db),
+            class.class_singleton(db).0.header_span(db),
         ));
         diagnostic.sub(class_def_diagnostic);
     }

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -1848,7 +1848,7 @@ fn report_invalid_assignment_with_message(
         return;
     };
     match target_ty {
-        Type::ClassLiteral(class) => {
+        Type::ClassSingleton(class) => {
             let mut diag = builder.into_diagnostic(format_args!(
                 "Implicit shadowing of class `{}`",
                 class.name(context.db()),

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -37,7 +37,7 @@ impl Display for DisplayType<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let representation = self.ty.representation(self.db);
         match self.ty {
-            Type::ClassLiteral(literal) if literal.is_known(self.db, KnownClass::Any) => {
+            Type::ClassSingleton(literal) if literal.is_known(self.db, KnownClass::Any) => {
                 write!(f, "typing.Any")
             }
             Type::IntLiteral(_)
@@ -111,7 +111,7 @@ impl Display for DisplayRepresentation<'_> {
             Type::ModuleLiteral(module) => {
                 write!(f, "<module '{}'>", module.module(self.db).name(self.db))
             }
-            Type::ClassLiteral(class) => {
+            Type::ClassSingleton(class) => {
                 write!(f, "<class '{}'>", class.name(self.db))
             }
             Type::GenericAlias(generic) => write!(f, "<class '{}'>", generic.display(self.db)),

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -66,7 +66,7 @@ pub(crate) fn enum_metadata<'db>(
         return None;
     }
 
-    if !Type::ClassLiteral(class).is_subtype_of(db, KnownClass::Enum.to_subclass_of(db))
+    if !Type::ClassSingleton(class).is_subtype_of(db, KnownClass::Enum.to_subclass_of(db))
         && !class
             .metaclass(db)
             .is_subtype_of(db, KnownClass::EnumType.to_subclass_of(db))
@@ -249,7 +249,7 @@ pub(crate) fn is_single_member_enum<'db>(db: &'db dyn Db, class: ClassLiteral<'d
 
 pub(crate) fn is_enum_class<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
     match ty {
-        Type::ClassLiteral(class_literal) => enum_metadata(db, class_literal).is_some(),
+        Type::ClassSingleton(class_literal) => enum_metadata(db, class_literal).is_some(),
         _ => false,
     }
 }

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -132,7 +132,7 @@ impl FunctionDecorators {
                 Some(KnownFunction::Override) => FunctionDecorators::OVERRIDE,
                 _ => FunctionDecorators::empty(),
             },
-            Type::ClassLiteral(class) => match class.known(db) {
+            Type::ClassSingleton(class) => match class.known(db) {
                 Some(KnownClass::Classmethod) => FunctionDecorators::CLASSMETHOD,
                 Some(KnownClass::Staticmethod) => FunctionDecorators::STATICMETHOD,
                 _ => FunctionDecorators::empty(),
@@ -997,7 +997,7 @@ fn is_instance_truthiness<'db>(
             always_true_if(is_instance(&KnownClass::FunctionType.to_instance(db)))
         }
 
-        Type::ClassLiteral(..) => always_true_if(is_instance(&KnownClass::Type.to_instance(db))),
+        Type::ClassSingleton(..) => always_true_if(is_instance(&KnownClass::Type.to_instance(db))),
 
         Type::TypeAlias(alias) => is_instance_truthiness(db, alias.value_type(db), class),
 
@@ -1414,7 +1414,7 @@ impl KnownFunction {
             }
 
             KnownFunction::GetProtocolMembers => {
-                let [Some(Type::ClassLiteral(class))] = parameter_types else {
+                let [Some(Type::ClassSingleton(class))] = parameter_types else {
                     return;
                 };
                 if class.is_protocol(db) {
@@ -1451,7 +1451,7 @@ impl KnownFunction {
             }
 
             KnownFunction::IsInstance | KnownFunction::IsSubclass => {
-                let [Some(first_arg), Some(Type::ClassLiteral(class))] = parameter_types else {
+                let [Some(first_arg), Some(Type::ClassSingleton(class))] = parameter_types else {
                     return;
                 };
 

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -1428,7 +1428,7 @@ impl KnownFunction {
                     return;
                 };
                 let Some(protocol_class) = param_type
-                    .into_class_literal()
+                    .into_class_singleton()
                     .and_then(|class| class.into_protocol_class(db))
                 else {
                     report_bad_argument_to_protocol_interface(

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -35,7 +35,7 @@ fn enclosing_generic_contexts<'db>(
             NodeWithScopeKind::Class(class) => {
                 let definition = index.expect_single_definition(class.node(module));
                 binding_type(db, definition)
-                    .into_class_literal()?
+                    .into_class_singleton()?
                     .generic_context(db)
             }
             NodeWithScopeKind::Function(function) => {

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -95,20 +95,20 @@ impl<'db> AllMembers<'db> {
             ),
 
             Type::NominalInstance(instance) => {
-                let (class_literal, _specialization) = instance.class(db).class_literal(db);
+                let (class_literal, _specialization) = instance.class(db).class_singleton(db);
                 self.extend_with_instance_members(db, ty, class_literal);
             }
 
             Type::ClassSingleton(class_literal) if class_literal.is_typed_dict(db) => {
-                self.extend_with_type(db, KnownClass::TypedDictFallback.to_class_literal(db));
+                self.extend_with_type(db, KnownClass::TypedDictFallback.to_class_singleton(db));
             }
 
             Type::GenericAlias(generic_alias) if generic_alias.is_typed_dict(db) => {
-                self.extend_with_type(db, KnownClass::TypedDictFallback.to_class_literal(db));
+                self.extend_with_type(db, KnownClass::TypedDictFallback.to_class_singleton(db));
             }
 
             Type::SubclassOf(subclass_of_type) if subclass_of_type.is_typed_dict(db) => {
-                self.extend_with_type(db, KnownClass::TypedDictFallback.to_class_literal(db));
+                self.extend_with_type(db, KnownClass::TypedDictFallback.to_class_singleton(db));
             }
 
             Type::ClassSingleton(class_literal) => {
@@ -126,7 +126,7 @@ impl<'db> AllMembers<'db> {
 
             Type::SubclassOf(subclass_of_type) => {
                 if let Some(class_literal) = subclass_of_type.subclass_of().into_class() {
-                    self.extend_with_class_members(db, ty, class_literal.class_literal(db).0);
+                    self.extend_with_class_members(db, ty, class_literal.class_singleton(db).0);
                 }
             }
 
@@ -160,7 +160,7 @@ impl<'db> AllMembers<'db> {
                 }
                 Type::SubclassOf(subclass_of) => {
                     if let Some(class) = subclass_of.subclass_of().into_class() {
-                        self.extend_with_class_members(db, ty, class.class_literal(db).0);
+                        self.extend_with_class_members(db, ty, class.class_singleton(db).0);
                     }
                 }
                 Type::GenericAlias(generic_alias) => {
@@ -176,7 +176,7 @@ impl<'db> AllMembers<'db> {
                 }
 
                 if let Type::ClassSingleton(class) =
-                    KnownClass::TypedDictFallback.to_class_literal(db)
+                    KnownClass::TypedDictFallback.to_class_singleton(db)
                 {
                     self.extend_with_instance_members(db, ty, class);
                 }
@@ -279,7 +279,7 @@ impl<'db> AllMembers<'db> {
         for parent in class_literal
             .iter_mro(db, None)
             .filter_map(ClassBase::into_class)
-            .map(|class| class.class_literal(db).0)
+            .map(|class| class.class_singleton(db).0)
         {
             let parent_scope = parent.body_scope(db);
             for Member { name, .. } in all_declarations_and_bindings(db, parent_scope) {
@@ -301,7 +301,7 @@ impl<'db> AllMembers<'db> {
         for parent in class_literal
             .iter_mro(db, None)
             .filter_map(ClassBase::into_class)
-            .map(|class| class.class_literal(db).0)
+            .map(|class| class.class_singleton(db).0)
         {
             let class_body_scope = parent.body_scope(db);
             let file = class_body_scope.file(db);
@@ -611,7 +611,7 @@ pub fn definitions_for_attribute<'db>(
         let class_literal = match meta_type {
             Type::ClassSingleton(class_literal) => class_literal,
             Type::SubclassOf(subclass) => match subclass.subclass_of().into_class() {
-                Some(cls) => cls.class_literal(db).0,
+                Some(cls) => cls.class_singleton(db).0,
                 None => continue,
             },
             _ => continue,
@@ -621,7 +621,7 @@ pub fn definitions_for_attribute<'db>(
         'scopes: for ancestor in class_literal
             .iter_mro(db, None)
             .filter_map(ClassBase::into_class)
-            .map(|cls| cls.class_literal(db).0)
+            .map(|cls| cls.class_singleton(db).0)
         {
             let class_scope = ancestor.body_scope(db);
             let class_place_table = crate::semantic_index::place_table(db, class_scope);

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -384,7 +384,7 @@ pub(crate) fn nearest_enclosing_class<'db>(
             infer_definition_types(db, definition)
                 .declaration_type(definition)
                 .inner_type()
-                .into_class_literal()
+                .into_class_singleton()
         })
 }
 
@@ -1083,7 +1083,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             // Filter out class literals that result from imports
             if let DefinitionKind::Class(class) = definition.kind(self.db()) {
                 ty.inner_type()
-                    .into_class_literal()
+                    .into_class_singleton()
                     .map(|class_literal| (class_literal, class.node(self.module())))
             } else {
                 None
@@ -1524,7 +1524,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         self.index
                             .expect_single_definition(class_node_ref.node(self.module())),
                     )
-                    .expect_class_literal();
+                    .expect_class_singleton();
 
                     if class.is_protocol(self.db())
                         || (class.is_abstract(self.db())
@@ -2361,7 +2361,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let class_stmt = class_scope.node().as_class(self.module())?;
         let class_definition = self.index.expect_single_definition(class_stmt);
-        binding_type(self.db(), class_definition).into_class_literal()
+        binding_type(self.db(), class_definition).into_class_singleton()
     }
 
     /// If the current scope is a (non-lambda) function, return that function's AST node.
@@ -9055,7 +9055,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // TODO: properly handle old-style generics; get rid of this temporary hack
             if !value_ty
-                .into_class_literal()
+                .into_class_singleton()
                 .is_some_and(|class| class.iter_mro(db, None).contains(&ClassBase::Generic))
             {
                 report_non_subscriptable(context, value_node.into(), value_ty, "__class_getitem__");

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -6231,6 +6231,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         | KnownClass::TypeVar
                         | KnownClass::TypeAliasType
                         | KnownClass::Deprecated
+                        | KnownClass::NewType
                 )
             ) || (
                 // Constructor calls to `tuple` and subclasses of `tuple` are handled in `Type::Bindings`,

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -1175,11 +1175,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 };
 
                 if let Some(solid_base) = base_class.nearest_solid_base(self.db()) {
-                    solid_bases.insert(solid_base, i, base_class.class_literal(self.db()).0);
+                    solid_bases.insert(solid_base, i, base_class.class_singleton(self.db()).0);
                 }
 
                 if is_protocol
-                    && !(base_class.class_literal(self.db()).0.is_protocol(self.db())
+                    && !(base_class
+                        .class_singleton(self.db())
+                        .0
+                        .is_protocol(self.db())
                         || base_class.is_known(self.db(), KnownClass::Object))
                 {
                     if let Some(builder) = self
@@ -6202,7 +6205,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             // <https://typing.python.org/en/latest/spec/protocol.html#type-and-class-objects-vs-protocols>.
             if !callable_type.is_subclass_of() {
                 if let Some(protocol) = class
-                    .class_literal(self.db())
+                    .class_singleton(self.db())
                     .0
                     .into_protocol_class(self.db())
                 {
@@ -6245,7 +6248,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             // until we support the functional syntax for creating enum classes
             if !has_special_cased_constructor
                 && KnownClass::Enum
-                    .to_class_literal(self.db())
+                    .to_class_singleton(self.db())
                     .to_class_type(self.db())
                     .is_none_or(|enum_class| !class.is_subclass_of(self.db(), enum_class))
             {

--- a/crates/ty_python_semantic/src/types/mro.rs
+++ b/crates/ty_python_semantic/src/types/mro.rs
@@ -151,7 +151,7 @@ impl<'db> Mro<'db> {
                             )
                     ) =>
             {
-                ClassBase::try_from_type(db, *single_base, class.class_literal(db).0).map_or_else(
+                ClassBase::try_from_type(db, *single_base, class.class_singleton(db).0).map_or_else(
                     || Err(MroErrorKind::InvalidBases(Box::from([(0, *single_base)]))),
                     |single_base| {
                         if single_base.has_cyclic_mro(db) {
@@ -186,7 +186,7 @@ impl<'db> Mro<'db> {
                             &original_bases[i + 1..],
                         );
                     } else {
-                        match ClassBase::try_from_type(db, *base, class.class_literal(db).0) {
+                        match ClassBase::try_from_type(db, *base, class.class_singleton(db).0) {
                             Some(valid_base) => resolved_bases.push(valid_base),
                             None => invalid_bases.push((i, *base)),
                         }
@@ -254,7 +254,7 @@ impl<'db> Mro<'db> {
                     // precise!).
                     for (index, base) in original_bases.iter().enumerate() {
                         let Some(base) =
-                            ClassBase::try_from_type(db, *base, class.class_literal(db).0)
+                            ClassBase::try_from_type(db, *base, class.class_singleton(db).0)
                         else {
                             continue;
                         };

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -573,13 +573,18 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                     }
                     // Treat enums as a union of their members.
                     Type::NominalInstance(instance)
-                        if enum_metadata(db, instance.class(db).class_literal(db).0).is_some() =>
+                        if enum_metadata(db, instance.class(db).class_singleton(db).0)
+                            .is_some() =>
                     {
                         UnionType::from_elements(
                             db,
-                            enum_member_literals(db, instance.class(db).class_literal(db).0, None)
-                                .expect("Calling `enum_member_literals` on an enum class")
-                                .map(|ty| filter_to_cannot_be_equal(db, ty, rhs_ty)),
+                            enum_member_literals(
+                                db,
+                                instance.class(db).class_singleton(db).0,
+                                None,
+                            )
+                            .expect("Calling `enum_member_literals` on an enum class")
+                            .map(|ty| filter_to_cannot_be_equal(db, ty, rhs_ty)),
                         )
                     }
                     _ => {

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -789,7 +789,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                     let callable_type = inference.expression_type(&**callable);
 
                     if callable_type
-                        .into_class_literal()
+                        .into_class_singleton()
                         .is_some_and(|c| c.is_known(self.db, KnownClass::Type))
                     {
                         let place = self.expect_place(&target);

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -183,7 +183,7 @@ impl ClassInfoConstraintFunction {
 
         match classinfo {
             Type::TypeAlias(alias) => self.generate_constraint(db, alias.value_type(db)),
-            Type::ClassLiteral(class_literal) => {
+            Type::ClassSingleton(class_literal) => {
                 // At runtime (on Python 3.11+), this will return `True` for classes that actually
                 // do inherit `typing.Any` and `False` otherwise. We could accurately model that?
                 if class_literal.is_known(db, KnownClass::Any) {
@@ -757,7 +757,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                             node_index: _,
                         },
                 }) if keywords.is_empty() => {
-                    let Type::ClassLiteral(rhs_class) = rhs_ty else {
+                    let Type::ClassSingleton(rhs_class) = rhs_ty else {
                         continue;
                     };
 
@@ -881,7 +881,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                     })
             }
             // for the expression `bool(E)`, we further narrow the type based on `E`
-            Type::ClassLiteral(class_type)
+            Type::ClassSingleton(class_type)
                 if expr_call.arguments.args.len() == 1
                     && expr_call.arguments.keywords.is_empty()
                     && class_type.is_known(self.db, KnownClass::Bool) =>

--- a/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
+++ b/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
@@ -145,7 +145,7 @@ impl Ty {
                 known_module_symbol(db, KnownModule::Uuid, "SafeUUID")
                     .place
                     .expect_type()
-                    .expect_class_literal(),
+                    .expect_class_singleton(),
                 Name::new(name),
             )),
             Ty::SingleMemberEnumLiteral => {
@@ -209,7 +209,7 @@ impl Ty {
                 builtins_symbol(db, s)
                     .place
                     .expect_type()
-                    .expect_class_literal()
+                    .expect_class_singleton()
                     .default_specialization(db),
             ),
             Ty::SubclassOfAbcClass(s) => SubclassOfType::from(
@@ -217,7 +217,7 @@ impl Ty {
                 known_module_symbol(db, KnownModule::Abc, s)
                     .place
                     .expect_type()
-                    .expect_class_literal()
+                    .expect_class_singleton()
                     .default_specialization(db),
             ),
             Ty::AlwaysTruthy => Type::AlwaysTruthy,

--- a/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
+++ b/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
@@ -153,7 +153,7 @@ impl Ty {
                     .place
                     .expect_type();
                 debug_assert!(
-                    matches!(ty, Type::NominalInstance(instance) if is_single_member_enum(db, instance.class(db).class_literal(db).0))
+                    matches!(ty, Type::NominalInstance(instance) if is_single_member_enum(db, instance.class(db).class_singleton(db).0))
                 );
                 ty
             }

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -528,7 +528,7 @@ fn cached_protocol_interface<'db>(
     for parent_protocol in class
         .iter_mro(db, None)
         .filter_map(ClassBase::into_class)
-        .filter_map(|class| class.class_literal(db).0.into_protocol_class(db))
+        .filter_map(|class| class.class_singleton(db).0.into_protocol_class(db))
     {
         let parent_scope = parent_protocol.body_scope(db);
         let use_def_map = use_def_map(db, parent_scope);

--- a/crates/ty_python_semantic/src/types/special_form.rs
+++ b/crates/ty_python_semantic/src/types/special_form.rs
@@ -253,7 +253,7 @@ impl SpecialFormType {
     }
 
     pub(super) fn to_meta_type(self, db: &dyn Db) -> Type<'_> {
-        self.class().to_class_literal(db)
+        self.class().to_class_singleton(db)
     }
 
     /// Return true if this special form is callable at runtime.

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -268,7 +268,7 @@ impl<'db> SubclassOfInner<'db> {
     pub(crate) fn try_from_type(db: &'db dyn Db, ty: Type<'db>) -> Option<Self> {
         match ty {
             Type::Dynamic(dynamic) => Some(Self::Dynamic(dynamic)),
-            Type::ClassLiteral(literal) => Some(if literal.is_known(db, KnownClass::Any) {
+            Type::ClassSingleton(literal) => Some(if literal.is_known(db, KnownClass::Any) {
                 Self::Dynamic(DynamicType::Any)
             } else {
                 Self::Class(literal.default_specialization(db))

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -211,7 +211,7 @@ impl<'db> SubclassOfType<'db> {
     pub(crate) fn is_typed_dict(self, db: &'db dyn Db) -> bool {
         self.subclass_of
             .into_class()
-            .is_some_and(|class| class.class_literal(db).0.is_typed_dict(db))
+            .is_some_and(|class| class.class_singleton(db).0.is_typed_dict(db))
     }
 }
 

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -201,7 +201,7 @@ impl<'db> TupleType<'db> {
     #[salsa::tracked(cycle_fn=to_class_type_cycle_recover, cycle_initial=to_class_type_cycle_initial, heap_size=ruff_memory_usage::heap_size)]
     pub(crate) fn to_class_type(self, db: &'db dyn Db) -> ClassType<'db> {
         let tuple_class = KnownClass::Tuple
-            .try_to_class_literal(db)
+            .try_to_class_singleton(db)
             .expect("Typeshed should always have a `tuple` class in `builtins.pyi`");
 
         tuple_class.apply_specialization(db, |generic_context| {
@@ -285,7 +285,7 @@ fn to_class_type_cycle_recover<'db>(
 
 fn to_class_type_cycle_initial<'db>(db: &'db dyn Db, self_: TupleType<'db>) -> ClassType<'db> {
     let tuple_class = KnownClass::Tuple
-        .try_to_class_literal(db)
+        .try_to_class_singleton(db)
         .expect("Typeshed should always have a `tuple` class in `builtins.pyi`");
 
     tuple_class.apply_specialization(db, |generic_context| {

--- a/crates/ty_python_semantic/src/types/type_ordering.rs
+++ b/crates/ty_python_semantic/src/types/type_ordering.rs
@@ -104,9 +104,9 @@ pub(super) fn union_or_intersection_elements_ordering<'db>(
         (Type::ModuleLiteral(_), _) => Ordering::Less,
         (_, Type::ModuleLiteral(_)) => Ordering::Greater,
 
-        (Type::ClassLiteral(left), Type::ClassLiteral(right)) => left.cmp(right),
-        (Type::ClassLiteral(_), _) => Ordering::Less,
-        (_, Type::ClassLiteral(_)) => Ordering::Greater,
+        (Type::ClassSingleton(left), Type::ClassSingleton(right)) => left.cmp(right),
+        (Type::ClassSingleton(_), _) => Ordering::Less,
+        (_, Type::ClassSingleton(_)) => Ordering::Greater,
 
         (Type::GenericAlias(left), Type::GenericAlias(right)) => left.cmp(right),
         (Type::GenericAlias(_), _) => Ordering::Less,

--- a/crates/ty_python_semantic/src/types/visitor.rs
+++ b/crates/ty_python_semantic/src/types/visitor.rs
@@ -142,7 +142,7 @@ impl<'db> From<Type<'db>> for TypeKind<'db> {
             | Type::DataclassTransformer(_)
             | Type::WrapperDescriptor(_)
             | Type::ModuleLiteral(_)
-            | Type::ClassLiteral(_)
+            | Type::ClassSingleton(_)
             | Type::SpecialForm(_)
             | Type::Dynamic(_) => TypeKind::Atomic,
 


### PR DESCRIPTION
This is my trial-and-error attempt to introduce a `ClassSingletonType` enum to `crates/ty_python_semantic/src/types/class.rs`, as @carljm and @AlexWaygood and I discussed. This fixes all the immediate type errors in that file, but there are still many in other files. I wanted to check in with you guys to see if I can get some early feedback about whether I'm moving in the right direction. In particular, a lot of `ClassLiteral` methods end up getting wrapped by `ClassSingletonType` and `NewTypeClass` _and_ `ClassType`, which doesn't seem ideal.