### PR TITLE
[ty] Avoid unnecessary argument type expansion

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/overloads.md
@@ -620,6 +620,81 @@ def _(ab: A | B, ac: A | C, cd: C | D):
     reveal_type(f(*(cd,)))  # revealed: Unknown
 ```
 
+### Performance
+
+Argument type expansion could lead to exponential growth of the number of argument lists that needs
+to be evaluated, so ty deploys some heuristics to prevent this from happening.
+
+#### Avoid argument type expansion
+
+Heuristic: If an argument type that cannot be expanded and cannot be assighned to any of the
+remaining overloads before argument type expansion, then even with argument type expansion, it won't
+lead to a successful evaluation of the call.
+
+`overloaded.pyi`:
+
+```pyi
+from typing import overload
+
+class A: ...
+class B: ...
+class C: ...
+
+@overload
+def f() -> None: ...
+@overload
+def f(**kwargs: int) -> C: ...
+@overload
+def f(x: A, /, **kwargs: int) -> A: ...
+@overload
+def f(x: B, /, **kwargs: int) -> B: ...
+```
+
+```py
+from overloaded import A, B, C, f
+
+def _(a=1):
+    reveal_type(f(a1=a, a2=a, a3=a))  # revealed: C
+    reveal_type(f(A(), a1=a, a2=a, a3=a))  # revealed: A
+    reveal_type(f(B(), a1=a, a2=a, a3=a))  # revealed: B
+
+    # error: [no-matching-overload]
+    # revealed: Unknown
+    reveal_type(f(
+        C(),
+        a1=a,
+        a2=a,
+        a3=a,
+        a4=a,
+        a5=a,
+        a6=a,
+        a7=a,
+        a8=a,
+        a9=a,
+        a10=a,
+        a11=a,
+        a12=a,
+        a13=a,
+        a14=a,
+        a15=a,
+        a16=a,
+        a17=a,
+        a18=a,
+        a19=a,
+        a20=a,
+        a21=a,
+        a22=a,
+        a23=a,
+        a24=a,
+        a25=a,
+        a26=a,
+        a27=a,
+        a28=a,
+        a29=a,
+        a30=a,
+    ))
+```
+
 ## Filtering based on `Any` / `Unknown`
 
 This is the step 5 of the overload call evaluation algorithm which specifies that:

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -16,6 +16,7 @@ use crate::Program;
 use crate::db::Db;
 use crate::dunder_all::dunder_all_names;
 use crate::place::{Boundness, Place};
+use crate::types::call::arguments::is_type_expandable;
 use crate::types::diagnostic::{
     CALL_NON_CALLABLE, CONFLICTING_ARGUMENT_FORMS, INVALID_ARGUMENT_TYPE, MISSING_ARGUMENT,
     NO_MATCHING_OVERLOAD, PARAMETER_ALREADY_ASSIGNED, TOO_MANY_POSITIONAL_ARGUMENTS,
@@ -1326,6 +1327,40 @@ impl<'db> CallableBinding<'db> {
         // Restore the bindings state to the one prior to the type checking step in preparation
         // for evaluating the expanded argument lists.
         snapshotter.restore(self, pre_evaluation_snapshot);
+
+        // At this point, there's at least one argument that can be expanded.
+        for (argument_index, (argument, argument_type)) in argument_types.iter().enumerate() {
+            if matches!(argument, Argument::Synthetic) {
+                continue;
+            }
+            let Some(argument_type) = argument_type else {
+                continue;
+            };
+            if is_type_expandable(db, argument_type) {
+                continue;
+            }
+            let mut is_argument_assignable_to_any_overload = false;
+            'overload: for (_, overload) in self.matching_overloads() {
+                for parameter_index in &overload.argument_matches[argument_index].parameters {
+                    let parameter_type = overload.signature.parameters()[*parameter_index]
+                        .annotated_type()
+                        .unwrap_or(Type::unknown());
+                    if argument_type.is_assignable_to(db, parameter_type) {
+                        is_argument_assignable_to_any_overload = true;
+                        break 'overload;
+                    }
+                }
+            }
+            if !is_argument_assignable_to_any_overload {
+                tracing::debug!(
+                    "Argument at {argument_index} (`{}`) is not assignable to any of the \
+                    remaining overloads, skipping argument type expansion",
+                    argument_type.display(db)
+                );
+                snapshotter.restore(self, post_evaluation_snapshot);
+                return;
+            }
+        }
 
         for expanded_argument_lists in expansions {
             // This is the merged state of the bindings after evaluating all of the expanded


### PR DESCRIPTION
## Summary

Part of: https://github.com/astral-sh/ty/issues/868

This PR adds a heuristic to avoid argument type expansion if it's going to eventually lead to no matching overload.

This is done by checking whether the non-expandable argument types are assignable to the corresponding annotated parameter type. If one of them is not assignable to all of the remaining overloads, then argument type expansion isn't going to help.

## Test Plan

<!-- How was it tested? -->
