### PR TITLE
`Option::unwrap` is now const

### DIFF
--- a/crates/ruff_linter/src/rules/refurb/rules/hardcoded_string_charset.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/hardcoded_string_charset.rs
@@ -93,12 +93,7 @@ impl NamedCharset {
             name,
             bytes,
             // SAFETY: The named charset is guaranteed to have only ascii bytes.
-            // TODO: replace with `.unwrap()`, when `Option::unwrap` will be stable in `const fn`
-            //  https://github.com/rust-lang/rust/issues/67441
-            ascii_char_set: match AsciiCharSet::from_bytes(bytes) {
-                Some(ascii_char_set) => ascii_char_set,
-                None => unreachable!(),
-            },
+            ascii_char_set: AsciiCharSet::from_bytes(bytes).unwrap(),
         }
     }
 }

--- a/crates/ruff_source_file/src/line_index.rs
+++ b/crates/ruff_source_file/src/line_index.rs
@@ -562,11 +562,11 @@ pub struct OneIndexed(NonZeroUsize);
 
 impl OneIndexed {
     /// The largest value that can be represented by this integer type
-    pub const MAX: Self = unwrap(Self::new(usize::MAX));
+    pub const MAX: Self = Self::new(usize::MAX).unwrap();
     // SAFETY: These constants are being initialized with non-zero values
     /// The smallest value that can be represented by this integer type.
-    pub const MIN: Self = unwrap(Self::new(1));
-    pub const ONE: NonZeroUsize = unwrap(NonZeroUsize::new(1));
+    pub const MIN: Self = Self::new(1).unwrap();
+    pub const ONE: NonZeroUsize = NonZeroUsize::new(1).unwrap();
 
     /// Creates a non-zero if the given value is not zero.
     pub const fn new(value: usize) -> Option<Self> {
@@ -633,15 +633,6 @@ impl Default for OneIndexed {
 impl fmt::Display for OneIndexed {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         std::fmt::Debug::fmt(&self.0.get(), f)
-    }
-}
-
-/// A const `Option::unwrap` without nightly features:
-/// [Tracking issue](https://github.com/rust-lang/rust/issues/67441)
-const fn unwrap<T: Copy>(option: Option<T>) -> T {
-    match option {
-        Some(value) => value,
-        None => panic!("unwrapping None"),
     }
 }
 


### PR DESCRIPTION
Summary
--

I noticed while working on #20006 that we had a custom `unwrap` function for `Option`. This has been const on stable since 1.83 ([docs](https://doc.rust-lang.org/std/option/enum.Option.html#method.unwrap), [release notes](https://blog.rust-lang.org/2024/11/28/Rust-1.83.0/)), so I think it's safe to use now. I grepped a bit for related todos and found this one for `AsciiCharSet` but no others.

Test Plan
--

Existing tests