### PR TITLE
[ty] add docstrings to completions based on type

### DIFF
--- a/crates/ty_ide/src/goto.rs
+++ b/crates/ty_ide/src/goto.rs
@@ -159,6 +159,28 @@ pub(crate) enum DefinitionsOrTargets<'db> {
 }
 
 impl<'db> DefinitionsOrTargets<'db> {
+    pub(crate) fn from_ty(db: &'db dyn crate::Db, ty: Type<'db>) -> Option<Self> {
+        let ty_def = ty.definition(db)?;
+        let resolved = match ty_def {
+            ty_python_semantic::types::TypeDefinition::Module(module) => {
+                ResolvedDefinition::Module(module.file(db)?)
+            }
+            ty_python_semantic::types::TypeDefinition::Class(definition) => {
+                ResolvedDefinition::Definition(definition)
+            }
+            ty_python_semantic::types::TypeDefinition::Function(definition) => {
+                ResolvedDefinition::Definition(definition)
+            }
+            ty_python_semantic::types::TypeDefinition::TypeVar(definition) => {
+                ResolvedDefinition::Definition(definition)
+            }
+            ty_python_semantic::types::TypeDefinition::TypeAlias(definition) => {
+                ResolvedDefinition::Definition(definition)
+            }
+        };
+        Some(DefinitionsOrTargets::Definitions(vec![resolved]))
+    }
+
     /// Get the "goto-declaration" interpretation of this definition
     ///
     /// In this case it basically returns exactly what was found.

--- a/crates/ty_server/src/server/api/requests/completion.rs
+++ b/crates/ty_server/src/server/api/requests/completion.rs
@@ -2,7 +2,9 @@ use std::borrow::Cow;
 use std::time::Instant;
 
 use lsp_types::request::Completion;
-use lsp_types::{CompletionItem, CompletionItemKind, CompletionParams, CompletionResponse, Url};
+use lsp_types::{
+    CompletionItem, CompletionItemKind, CompletionParams, CompletionResponse, Documentation, Url,
+};
 use ruff_db::source::{line_index, source_text};
 use ty_ide::completion;
 use ty_project::ProjectDatabase;
@@ -64,9 +66,12 @@ impl BackgroundDocumentRequestHandler for CompletionRequestHandler {
             .map(|(i, comp)| {
                 let kind = comp.kind(db).map(ty_kind_to_lsp_kind);
                 CompletionItem {
-                    label: comp.name.into(),
+                    label: comp.inner.name.into(),
                     kind,
                     sort_text: Some(format!("{i:-max_index_len$}")),
+                    documentation: comp
+                        .documentation
+                        .map(|docstring| Documentation::String(docstring.render_plaintext())),
                     ..Default::default()
                 }
             })

--- a/crates/ty_wasm/src/lib.rs
+++ b/crates/ty_wasm/src/lib.rs
@@ -421,7 +421,7 @@ impl Workspace {
             .into_iter()
             .map(|completion| Completion {
                 kind: completion.kind(&self.db).map(CompletionKind::from),
-                name: completion.name.into(),
+                name: completion.inner.name.into(),
             })
             .collect())
     }


### PR DESCRIPTION
This is a fairly simple but effective way to add docstrings to like 95% of completions from initial experimentation.

Fixes https://github.com/astral-sh/ty/issues/1036

Although ironically this approach *does not* work specifically for `print` and I haven't looked into why.