### PR TITLE
Fix rust feature activation

### DIFF
--- a/crates/ruff_diagnostics/Cargo.toml
+++ b/crates/ruff_diagnostics/Cargo.toml
@@ -14,8 +14,11 @@ license = { workspace = true }
 doctest = false
 
 [dependencies]
-ruff_text_size = { workspace = true }
+ruff_text_size = { workspace = true, features = ["get-size"] }
 
 get-size2 = { workspace = true }
 is-macro = { workspace = true }
 serde = { workspace = true, optional = true, features = [] }
+
+[features]
+serde = ["dep:serde", "ruff_text_size/serde"]

--- a/crates/ruff_source_file/Cargo.toml
+++ b/crates/ruff_source_file/Cargo.toml
@@ -22,7 +22,7 @@ serde = { workspace = true, optional = true }
 [dev-dependencies]
 
 [features]
-get-size = ["dep:get-size2"]
+get-size = ["dep:get-size2", "ruff_text_size/get-size"]
 serde = ["dep:serde", "ruff_text_size/serde"]
 
 [lints]

--- a/crates/ruff_workspace/Cargo.toml
+++ b/crates/ruff_workspace/Cargo.toml
@@ -64,6 +64,7 @@ default = []
 schemars = [
     "dep:schemars",
     "ruff_formatter/schemars",
+    "ruff_linter/schemars",
     "ruff_python_formatter/schemars",
     "ruff_python_semantic/schemars",
 ]

--- a/crates/ty_project/Cargo.toml
+++ b/crates/ty_project/Cargo.toml
@@ -51,7 +51,12 @@ insta = { workspace = true, features = ["redactions", "ron"] }
 [features]
 default = ["zstd"]
 deflate = ["ty_vendored/deflate"]
-schemars = ["dep:schemars", "ruff_db/schemars", "ty_python_semantic/schemars"]
+schemars = [
+    "dep:schemars",
+    "ruff_db/schemars",
+    "ruff_python_ast/schemars",
+    "ty_python_semantic/schemars",
+]
 zstd = ["ty_vendored/zstd"]
 format = ["ruff_python_formatter"]
 testing = []


### PR DESCRIPTION
Summary
--

I ran into a problem earlier when trying to run this command:

```shell
$ cargo test -p ruff_source_file --all-features
error[E0277]: the trait bound `TextSize: GetSize` is not satisfied
  --> crates/ruff_source_file/src/line_index.rs:23:41
```

It looks like we just needed to activate the `get-size` feature of `ruff_text_size` when `ruff_source_file` activates its feature of the same name.

While I was at it, I looked for other cases with the same problem:

```shell
for crate in crates/*; do
    if ! cargo test -p ${crate#*/} --all-features > /dev/null; then
        echo "$crate failed"
        break
    fi
done
```

and fixed those too. I also tried with no features enabled, since I know we've run into similar problems with that before, but that didn't find anything except for some unreachable `pub` warnings for `TestDb` in `ty_project`. But `TestDb` is conditionally re-exported, so I don't think we can get rid of those warnings easily, unless we just want to `allow` the warnings.

Should we consider throwing something like the script above into a daily/weekly cron job in CI? I don't think we necessarily need to run it on every PR.

Test Plan
--

Same commands above, which now succeed
