### PR TITLE
[ty] Use `dedent` in cursor tests

### DIFF
--- a/crates/ty_ide/src/document_symbols.rs
+++ b/crates/ty_ide/src/document_symbols.rs
@@ -198,7 +198,7 @@ def standalone_function():
         12 |     typed_class_var: str = 'class_typed'
         13 |     annotated_class_var: float
            |     ^^^^^^^^^^^^^^^^^^^
-        14 |     
+        14 |
         15 |     def __init__(self):
            |
         info: Field annotated_class_var
@@ -207,7 +207,7 @@ def standalone_function():
           --> main.py:15:9
            |
         13 |     annotated_class_var: float
-        14 |     
+        14 |
         15 |     def __init__(self):
            |         ^^^^^^^^
         16 |         self.instance_var = 0
@@ -218,7 +218,7 @@ def standalone_function():
           --> main.py:18:9
            |
         16 |         self.instance_var = 0
-        17 |     
+        17 |
         18 |     def public_method(self):
            |         ^^^^^^^^^^^^^
         19 |         return self.instance_var
@@ -229,7 +229,7 @@ def standalone_function():
           --> main.py:21:9
            |
         19 |         return self.instance_var
-        20 |     
+        20 |
         21 |     def _private_method(self):
            |         ^^^^^^^^^^^^^^^
         22 |         pass
@@ -282,7 +282,7 @@ class OuterClass:
         2 | class OuterClass:
         3 |     OUTER_CONSTANT = 100
           |     ^^^^^^^^^^^^^^
-        4 |     
+        4 |
         5 |     def outer_method(self):
           |
         info: Constant OUTER_CONSTANT
@@ -291,7 +291,7 @@ class OuterClass:
          --> main.py:5:9
           |
         3 |     OUTER_CONSTANT = 100
-        4 |     
+        4 |
         5 |     def outer_method(self):
           |         ^^^^^^^^^^^^
         6 |         return self.OUTER_CONSTANT
@@ -302,7 +302,7 @@ class OuterClass:
           --> main.py:8:11
            |
          6 |         return self.OUTER_CONSTANT
-         7 |     
+         7 |
          8 |     class InnerClass:
            |           ^^^^^^^^^^
          9 |         def inner_method(self):

--- a/crates/ty_ide/src/goto_declaration.rs
+++ b/crates/ty_ide/src/goto_declaration.rs
@@ -53,19 +53,19 @@ mod tests {
 
         assert_snapshot!(test.goto_declaration(), @r"
         info[goto-declaration]: Declaration
-         --> main.py:2:17
+         --> main.py:2:5
           |
-        2 |             def my_function(x, y):
-          |                 ^^^^^^^^^^^
-        3 |                 return x + y
+        2 | def my_function(x, y):
+          |     ^^^^^^^^^^^
+        3 |     return x + y
           |
         info: Source
-         --> main.py:5:22
+         --> main.py:5:10
           |
-        3 |                 return x + y
+        3 |     return x + y
         4 |
-        5 |             result = my_function(1, 2)
-          |                      ^^^^^^^^^^^
+        5 | result = my_function(1, 2)
+          |          ^^^^^^^^^^^
           |
         ");
     }
@@ -81,18 +81,18 @@ mod tests {
 
         assert_snapshot!(test.goto_declaration(), @r"
         info[goto-declaration]: Declaration
-         --> main.py:2:13
+         --> main.py:2:1
           |
-        2 |             x = 42
-          |             ^
-        3 |             y = x
+        2 | x = 42
+          | ^
+        3 | y = x
           |
         info: Source
-         --> main.py:3:17
+         --> main.py:3:5
           |
-        2 |             x = 42
-        3 |             y = x
-          |                 ^
+        2 | x = 42
+        3 | y = x
+          |     ^
           |
         ");
     }
@@ -111,20 +111,20 @@ mod tests {
 
         assert_snapshot!(test.goto_declaration(), @r"
         info[goto-declaration]: Declaration
-         --> main.py:2:19
+         --> main.py:2:7
           |
-        2 |             class MyClass:
-          |                   ^^^^^^^
-        3 |                 def __init__(self):
-        4 |                     pass
+        2 | class MyClass:
+          |       ^^^^^^^
+        3 |     def __init__(self):
+        4 |         pass
           |
         info: Source
-         --> main.py:6:24
+         --> main.py:6:12
           |
-        4 |                     pass
+        4 |         pass
         5 |
-        6 |             instance = MyClass()
-          |                        ^^^^^^^
+        6 | instance = MyClass()
+          |            ^^^^^^^
           |
         ");
     }
@@ -140,18 +140,18 @@ mod tests {
 
         assert_snapshot!(test.goto_declaration(), @r"
         info[goto-declaration]: Declaration
-         --> main.py:2:21
+         --> main.py:2:9
           |
-        2 |             def foo(param):
-          |                     ^^^^^
-        3 |                 return param * 2
+        2 | def foo(param):
+          |         ^^^^^
+        3 |     return param * 2
           |
         info: Source
-         --> main.py:3:24
+         --> main.py:3:12
           |
-        2 |             def foo(param):
-        3 |                 return param * 2
-          |                        ^^^^^
+        2 | def foo(param):
+        3 |     return param * 2
+          |            ^^^^^
           |
         ");
     }
@@ -168,20 +168,20 @@ mod tests {
 
         assert_snapshot!(test.goto_declaration(), @r"
         info[goto-declaration]: Declaration
-         --> main.py:2:30
+         --> main.py:2:18
           |
-        2 |             def generic_func[T](value: T) -> T:
-          |                              ^
-        3 |                 v: T = value
-        4 |                 return v
+        2 | def generic_func[T](value: T) -> T:
+          |                  ^
+        3 |     v: T = value
+        4 |     return v
           |
         info: Source
-         --> main.py:3:20
+         --> main.py:3:8
           |
-        2 |             def generic_func[T](value: T) -> T:
-        3 |                 v: T = value
-          |                    ^
-        4 |                 return v
+        2 | def generic_func[T](value: T) -> T:
+        3 |     v: T = value
+          |        ^
+        4 |     return v
           |
         ");
     }
@@ -198,20 +198,20 @@ mod tests {
 
         assert_snapshot!(test.goto_declaration(), @r"
         info[goto-declaration]: Declaration
-         --> main.py:2:32
+         --> main.py:2:20
           |
-        2 |             class GenericClass[T]:
-          |                                ^
-        3 |                 def __init__(self, value: T):
-        4 |                     self.value = value
+        2 | class GenericClass[T]:
+          |                    ^
+        3 |     def __init__(self, value: T):
+        4 |         self.value = value
           |
         info: Source
-         --> main.py:3:43
+         --> main.py:3:31
           |
-        2 |             class GenericClass[T]:
-        3 |                 def __init__(self, value: T):
-          |                                           ^
-        4 |                     self.value = value
+        2 | class GenericClass[T]:
+        3 |     def __init__(self, value: T):
+          |                               ^
+        4 |         self.value = value
           |
         ");
     }
@@ -230,21 +230,21 @@ mod tests {
 
         assert_snapshot!(test.goto_declaration(), @r#"
         info[goto-declaration]: Declaration
-         --> main.py:2:13
+         --> main.py:2:1
           |
-        2 |             x = "outer"
-          |             ^
-        3 |             def outer_func():
-        4 |                 def inner_func():
+        2 | x = "outer"
+          | ^
+        3 | def outer_func():
+        4 |     def inner_func():
           |
         info: Source
-         --> main.py:5:28
+         --> main.py:5:16
           |
-        3 |             def outer_func():
-        4 |                 def inner_func():
-        5 |                     return x  # Should find outer x
-          |                            ^
-        6 |                 return inner_func
+        3 | def outer_func():
+        4 |     def inner_func():
+        5 |         return x  # Should find outer x
+          |                ^
+        6 |     return inner_func
           |
         "#);
     }
@@ -852,21 +852,21 @@ def another_helper(path):
 
         assert_snapshot!(test.goto_declaration(), @r"
         info[goto-declaration]: Declaration
-         --> main.py:4:21
+         --> main.py:4:9
           |
-        2 |             class C:
-        3 |                 def __init__(self):
-        4 |                     self.x: int = 1
-          |                     ^^^^^^
+        2 | class C:
+        3 |     def __init__(self):
+        4 |         self.x: int = 1
+          |         ^^^^^^
         5 |
-        6 |             c = C()
+        6 | c = C()
           |
         info: Source
-         --> main.py:7:19
+         --> main.py:7:7
           |
-        6 |             c = C()
-        7 |             y = c.x
-          |                   ^
+        6 | c = C()
+        7 | y = c.x
+          |       ^
           |
         ");
     }
@@ -890,21 +890,21 @@ def another_helper(path):
 
         assert_snapshot!(test.goto_declaration(), @r"
         info[goto-declaration]: Declaration
-         --> main.py:4:21
+         --> main.py:4:9
           |
-        2 |             class C:
-        3 |                 def __init__(self):
-        4 |                     self.x: int = 1
-          |                     ^^^^^^
+        2 | class C:
+        3 |     def __init__(self):
+        4 |         self.x: int = 1
+          |         ^^^^^^
         5 |
-        6 |             class D:
+        6 | class D:
           |
         info: Source
-          --> main.py:11:21
+          --> main.py:11:9
            |
-        10 |             d = D()
-        11 |             y = d.y.x
-           |                     ^
+        10 | d = D()
+        11 | y = d.y.x
+           |         ^
            |
         ");
     }
@@ -924,21 +924,21 @@ def another_helper(path):
 
         assert_snapshot!(test.goto_declaration(), @r"
         info[goto-declaration]: Declaration
-         --> main.py:4:21
+         --> main.py:4:9
           |
-        2 |             class C:
-        3 |                 def __init__(self):
-        4 |                     self.x = 1
-          |                     ^^^^^^
+        2 | class C:
+        3 |     def __init__(self):
+        4 |         self.x = 1
+          |         ^^^^^^
         5 |
-        6 |             c = C()
+        6 | c = C()
           |
         info: Source
-         --> main.py:7:19
+         --> main.py:7:7
           |
-        6 |             c = C()
-        7 |             y = c.x
-          |                   ^
+        6 | c = C()
+        7 | y = c.x
+          |       ^
           |
         ");
     }
@@ -958,19 +958,19 @@ def another_helper(path):
 
         assert_snapshot!(test.goto_declaration(), @r"
         info[goto-declaration]: Declaration
-         --> main.py:3:21
+         --> main.py:3:9
           |
-        2 |             class C:
-        3 |                 def foo(self):
-          |                     ^^^
-        4 |                     return 42
+        2 | class C:
+        3 |     def foo(self):
+          |         ^^^
+        4 |         return 42
           |
         info: Source
-         --> main.py:7:21
+         --> main.py:7:9
           |
-        6 |             c = C()
-        7 |             res = c.foo()
-          |                     ^^^
+        6 | c = C()
+        7 | res = c.foo()
+          |         ^^^
           |
         ");
     }
@@ -1036,7 +1036,7 @@ def outer():
         2 | def outer():
         3 |     x = "outer_value"
           |     ^
-        4 |     
+        4 |
         5 |     def inner():
           |
         info: Source
@@ -1046,7 +1046,7 @@ def outer():
          7 |         x = "modified"
          8 |         return x  # Should find the nonlocal x declaration in outer scope
            |                ^
-         9 |     
+         9 |
         10 |     return inner
            |
         "#);
@@ -1103,20 +1103,20 @@ def function():
 
         assert_snapshot!(test.goto_declaration(), @r"
         info[goto-declaration]: Declaration
-         --> main.py:3:17
+         --> main.py:3:5
           |
-        2 |             class A:
-        3 |                 x = 10
-          |                 ^
+        2 | class A:
+        3 |     x = 10
+          |     ^
         4 |
-        5 |             class B(A):
+        5 | class B(A):
           |
         info: Source
-         --> main.py:9:19
+         --> main.py:9:7
           |
-        8 |             b = B()
-        9 |             y = b.x
-          |                   ^
+        8 | b = B()
+        9 | y = b.x
+          |       ^
           |
         ");
     }
@@ -1140,19 +1140,19 @@ def function():
 
         assert_snapshot!(test.goto_declaration(), @r"
         info[goto-declaration]: Declaration
-         --> main.py:7:21
+         --> main.py:7:9
           |
-        6 |                 @property
-        7 |                 def value(self):
-          |                     ^^^^^
-        8 |                     return self._value
+        6 |     @property
+        7 |     def value(self):
+          |         ^^^^^
+        8 |         return self._value
           |
         info: Source
-          --> main.py:11:15
+          --> main.py:11:3
            |
-        10 |             c = C()
-        11 |             c.value = 42
-           |               ^^^^^
+        10 | c = C()
+        11 | c.value = 42
+           |   ^^^^^
            |
         ");
     }
@@ -1213,21 +1213,21 @@ def function():
 
         assert_snapshot!(test.goto_declaration(), @r"
         info[goto-declaration]: Declaration
-         --> main.py:6:17
+         --> main.py:6:5
           |
-        4 |             class Drawable(Protocol):
-        5 |                 def draw(self) -> None: ...
-        6 |                 name: str
-          |                 ^^^^
+        4 | class Drawable(Protocol):
+        5 |     def draw(self) -> None: ...
+        6 |     name: str
+          |     ^^^^
         7 |
-        8 |             def use_drawable(obj: Drawable):
+        8 | def use_drawable(obj: Drawable):
           |
         info: Source
-         --> main.py:9:21
+         --> main.py:9:9
           |
-        8 |             def use_drawable(obj: Drawable):
-        9 |                 obj.name
-          |                     ^^^^
+        8 | def use_drawable(obj: Drawable):
+        9 |     obj.name
+          |         ^^^^
           |
         ");
     }
@@ -1252,14 +1252,14 @@ class MyClass:
         2 | class MyClass:
         3 |     ClassType = int
           |     ^^^^^^^^^
-        4 |     
+        4 |
         5 |     def generic_method[T](self, value: ClassType) -> T:
           |
         info: Source
          --> main.py:5:40
           |
         3 |     ClassType = int
-        4 |     
+        4 |
         5 |     def generic_method[T](self, value: ClassType) -> T:
           |                                        ^^^^^^^^^
         6 |         return value
@@ -1280,19 +1280,19 @@ class MyClass:
 
         assert_snapshot!(test.goto_declaration(), @r"
         info[goto-declaration]: Declaration
-         --> main.py:2:32
+         --> main.py:2:20
           |
-        2 |             def my_function(x, y, z=10):
-          |                                ^
-        3 |                 return x + y + z
+        2 | def my_function(x, y, z=10):
+          |                    ^
+        3 |     return x + y + z
           |
         info: Source
-         --> main.py:5:37
+         --> main.py:5:25
           |
-        3 |                 return x + y + z
+        3 |     return x + y + z
         4 |
-        5 |             result = my_function(1, y=2, z=3)
-          |                                     ^
+        5 | result = my_function(1, y=2, z=3)
+          |                         ^
           |
         ");
     }
@@ -1320,37 +1320,37 @@ class MyClass:
         // Should navigate to the parameter in both matching overloads
         assert_snapshot!(test.goto_declaration(), @r#"
         info[goto-declaration]: Declaration
-         --> main.py:5:36
+         --> main.py:5:24
           |
-        4 |             @overload
-        5 |             def process(data: str, format: str) -> str: ...
-          |                                    ^^^^^^
+        4 | @overload
+        5 | def process(data: str, format: str) -> str: ...
+          |                        ^^^^^^
         6 |
-        7 |             @overload
+        7 | @overload
           |
         info: Source
-          --> main.py:14:39
+          --> main.py:14:27
            |
-        13 |             # Call the overloaded function
-        14 |             result = process("hello", format="json")
-           |                                       ^^^^^^
+        13 | # Call the overloaded function
+        14 | result = process("hello", format="json")
+           |                           ^^^^^^
            |
 
         info[goto-declaration]: Declaration
-          --> main.py:8:36
+          --> main.py:8:24
            |
-         7 |             @overload
-         8 |             def process(data: int, format: int) -> int: ...
-           |                                    ^^^^^^
+         7 | @overload
+         8 | def process(data: int, format: int) -> int: ...
+           |                        ^^^^^^
          9 |
-        10 |             def process(data, format):
+        10 | def process(data, format):
            |
         info: Source
-          --> main.py:14:39
+          --> main.py:14:27
            |
-        13 |             # Call the overloaded function
-        14 |             result = process("hello", format="json")
-           |                                       ^^^^^^
+        13 | # Call the overloaded function
+        14 | result = process("hello", format="json")
+           |                           ^^^^^^
            |
         "#);
     }

--- a/crates/ty_ide/src/goto_references.rs
+++ b/crates/ty_ide/src/goto_references.rs
@@ -786,7 +786,7 @@ class DataProcessor:
         5 |     def __init__(self):
         6 |         self.multiplier = func
           |                           ^^^^
-        7 |     
+        7 |
         8 |     def process(self, value):
           |
 
@@ -834,7 +834,7 @@ def process_model():
         2 | class MyModel:
         3 |     attr = 42
           |     ^^^^
-        4 |         
+        4 |
         5 |     def get_attribute(self):
           |
 

--- a/crates/ty_ide/src/goto_type_definition.rs
+++ b/crates/ty_ide/src/goto_type_definition.rs
@@ -50,20 +50,20 @@ mod tests {
 
         assert_snapshot!(test.goto_type_definition(), @r"
         info[goto-type-definition]: Type definition
-         --> main.py:2:19
+         --> main.py:2:7
           |
-        2 |             class Test: ...
-          |                   ^^^^
+        2 | class Test: ...
+          |       ^^^^
         3 |
-        4 |             ab = Test()
+        4 | ab = Test()
           |
         info: Source
-         --> main.py:4:13
+         --> main.py:4:1
           |
-        2 |             class Test: ...
+        2 | class Test: ...
         3 |
-        4 |             ab = Test()
-          |             ^^
+        4 | ab = Test()
+          | ^^
           |
         ");
     }
@@ -82,20 +82,20 @@ mod tests {
 
         assert_snapshot!(test.goto_type_definition(), @r"
         info[goto-type-definition]: Type definition
-         --> main.py:2:17
+         --> main.py:2:5
           |
-        2 |             def foo(a, b): ...
-          |                 ^^^
+        2 | def foo(a, b): ...
+          |     ^^^
         3 |
-        4 |             ab = foo
+        4 | ab = foo
           |
         info: Source
-         --> main.py:6:13
+         --> main.py:6:1
           |
-        4 |             ab = foo
+        4 | ab = foo
         5 |
-        6 |             ab
-          |             ^^
+        6 | ab
+          | ^^
           |
         ");
     }
@@ -120,39 +120,39 @@ mod tests {
 
         assert_snapshot!(test.goto_type_definition(), @r"
         info[goto-type-definition]: Type definition
-         --> main.py:3:17
+         --> main.py:3:5
           |
-        3 |             def foo(a, b): ...
-          |                 ^^^
+        3 | def foo(a, b): ...
+          |     ^^^
         4 |
-        5 |             def bar(a, b): ...
+        5 | def bar(a, b): ...
           |
         info: Source
-          --> main.py:12:13
+          --> main.py:12:1
            |
-        10 |                 a = bar
+        10 |     a = bar
         11 |
-        12 |             a
-           |             ^
+        12 | a
+           | ^
            |
 
         info[goto-type-definition]: Type definition
-         --> main.py:5:17
+         --> main.py:5:5
           |
-        3 |             def foo(a, b): ...
+        3 | def foo(a, b): ...
         4 |
-        5 |             def bar(a, b): ...
-          |                 ^^^
+        5 | def bar(a, b): ...
+          |     ^^^
         6 |
-        7 |             if random.choice():
+        7 | if random.choice():
           |
         info: Source
-          --> main.py:12:13
+          --> main.py:12:1
            |
-        10 |                 a = bar
+        10 |     a = bar
         11 |
-        12 |             a
-           |             ^
+        12 | a
+           | ^
            |
         ");
     }
@@ -177,12 +177,12 @@ mod tests {
           | ^^^^^^
           |
         info: Source
-         --> main.py:4:13
+         --> main.py:4:1
           |
-        2 |             import lib
+        2 | import lib
         3 |
-        4 |             lib
-          |             ^^^
+        4 | lib
+          | ^^^
           |
         ");
     }
@@ -197,7 +197,7 @@ mod tests {
             "#,
         );
 
-        assert_snapshot!(test.goto_type_definition(), @r###"
+        assert_snapshot!(test.goto_type_definition(), @r#"
         info[goto-type-definition]: Type definition
            --> stdlib/builtins.pyi:901:7
             |
@@ -209,14 +209,14 @@ mod tests {
         903 |     str(bytes_or_buffer[, encoding[, errors]]) -> str
             |
         info: Source
-         --> main.py:4:13
+         --> main.py:4:1
           |
-        2 |             a: str = "test"
+        2 | a: str = "test"
         3 |
-        4 |             a
-          |             ^
+        4 | a
+          | ^
           |
-        "###);
+        "#);
     }
     #[test]
     fn goto_type_of_expression_with_literal_node() {
@@ -226,7 +226,7 @@ mod tests {
             "#,
         );
 
-        assert_snapshot!(test.goto_type_definition(), @r###"
+        assert_snapshot!(test.goto_type_definition(), @r#"
         info[goto-type-definition]: Type definition
            --> stdlib/builtins.pyi:901:7
             |
@@ -238,12 +238,12 @@ mod tests {
         903 |     str(bytes_or_buffer[, encoding[, errors]]) -> str
             |
         info: Source
-         --> main.py:2:22
+         --> main.py:2:10
           |
-        2 |             a: str = "test"
-          |                      ^^^^^^
+        2 | a: str = "test"
+          |          ^^^^^^
           |
-        "###);
+        "#);
     }
 
     #[test]
@@ -256,16 +256,16 @@ mod tests {
 
         assert_snapshot!(test.goto_type_definition(), @r"
         info[goto-type-definition]: Type definition
-         --> main.py:2:24
+         --> main.py:2:12
           |
-        2 |             type Alias[T: int = bool] = list[T]
-          |                        ^
+        2 | type Alias[T: int = bool] = list[T]
+          |            ^
           |
         info: Source
-         --> main.py:2:46
+         --> main.py:2:34
           |
-        2 |             type Alias[T: int = bool] = list[T]
-          |                                              ^
+        2 | type Alias[T: int = bool] = list[T]
+          |                                  ^
           |
         ");
     }
@@ -312,22 +312,22 @@ mod tests {
 
         assert_snapshot!(test.goto_type_definition(), @r#"
         info[goto-type-definition]: Type definition
-         --> main.py:4:13
+         --> main.py:4:1
           |
-        2 |             from typing_extensions import TypeAliasType
+        2 | from typing_extensions import TypeAliasType
         3 |
-        4 |             Alias = TypeAliasType("Alias", tuple[int, int])
-          |             ^^^^^
+        4 | Alias = TypeAliasType("Alias", tuple[int, int])
+          | ^^^^^
         5 |
-        6 |             Alias
+        6 | Alias
           |
         info: Source
-         --> main.py:6:13
+         --> main.py:6:1
           |
-        4 |             Alias = TypeAliasType("Alias", tuple[int, int])
+        4 | Alias = TypeAliasType("Alias", tuple[int, int])
         5 |
-        6 |             Alias
-          |             ^^^^^
+        6 | Alias
+          | ^^^^^
           |
         "#);
     }
@@ -342,7 +342,7 @@ mod tests {
             "#,
         );
 
-        assert_snapshot!(test.goto_type_definition(), @r###"
+        assert_snapshot!(test.goto_type_definition(), @r#"
         info[goto-type-definition]: Type definition
            --> stdlib/builtins.pyi:901:7
             |
@@ -354,14 +354,14 @@ mod tests {
         903 |     str(bytes_or_buffer[, encoding[, errors]]) -> str
             |
         info: Source
-         --> main.py:4:18
+         --> main.py:4:6
           |
-        2 |             def test(a: str): ...
+        2 | def test(a: str): ...
         3 |
-        4 |             test(a= "123")
-          |                  ^
+        4 | test(a= "123")
+          |      ^
           |
-        "###);
+        "#);
     }
 
     #[test]
@@ -389,12 +389,12 @@ mod tests {
         339 |     int(x, base=10) -> integer
             |
         info: Source
-         --> main.py:4:18
+         --> main.py:4:6
           |
-        2 |             def test(a: str): ...
+        2 | def test(a: str): ...
         3 |
-        4 |             test(a= 123)
-          |                  ^
+        4 | test(a= 123)
+          |      ^
           |
         "#);
     }
@@ -442,7 +442,7 @@ f(**kwargs<CURSOR>)
             "#,
         );
 
-        assert_snapshot!(test.goto_type_definition(), @r###"
+        assert_snapshot!(test.goto_type_definition(), @r#"
         info[goto-type-definition]: Type definition
            --> stdlib/builtins.pyi:901:7
             |
@@ -454,13 +454,13 @@ f(**kwargs<CURSOR>)
         903 |     str(bytes_or_buffer[, encoding[, errors]]) -> str
             |
         info: Source
-         --> main.py:3:17
+         --> main.py:3:5
           |
-        2 |             def foo(a: str):
-        3 |                 a
-          |                 ^
+        2 | def foo(a: str):
+        3 |     a
+          |     ^
           |
-        "###);
+        "#);
     }
 
     #[test]
@@ -478,19 +478,19 @@ f(**kwargs<CURSOR>)
 
         assert_snapshot!(test.goto_type_definition(), @r"
         info[goto-type-definition]: Type definition
-         --> main.py:2:19
+         --> main.py:2:7
           |
-        2 |             class X:
-          |                   ^
-        3 |                 def foo(a, b): ...
+        2 | class X:
+          |       ^
+        3 |     def foo(a, b): ...
           |
         info: Source
-         --> main.py:7:13
+         --> main.py:7:1
           |
-        5 |             x = X()
+        5 | x = X()
         6 |
-        7 |             x.foo()
-          |             ^
+        7 | x.foo()
+          | ^
           |
         ");
     }
@@ -507,20 +507,20 @@ f(**kwargs<CURSOR>)
 
         assert_snapshot!(test.goto_type_definition(), @r"
         info[goto-type-definition]: Type definition
-         --> main.py:2:17
+         --> main.py:2:5
           |
-        2 |             def foo(a, b): ...
-          |                 ^^^
+        2 | def foo(a, b): ...
+          |     ^^^
         3 |
-        4 |             foo()
+        4 | foo()
           |
         info: Source
-         --> main.py:4:13
+         --> main.py:4:1
           |
-        2 |             def foo(a, b): ...
+        2 | def foo(a, b): ...
         3 |
-        4 |             foo()
-          |             ^^^
+        4 | foo()
+          | ^^^
           |
         ");
     }
@@ -535,7 +535,7 @@ f(**kwargs<CURSOR>)
             "#,
         );
 
-        assert_snapshot!(test.goto_type_definition(), @r###"
+        assert_snapshot!(test.goto_type_definition(), @r#"
         info[goto-type-definition]: Type definition
            --> stdlib/builtins.pyi:901:7
             |
@@ -547,14 +547,14 @@ f(**kwargs<CURSOR>)
         903 |     str(bytes_or_buffer[, encoding[, errors]]) -> str
             |
         info: Source
-         --> main.py:4:27
+         --> main.py:4:15
           |
-        2 |             def foo(a: str | None, b):
-        3 |                 if a is not None:
-        4 |                     print(a)
-          |                           ^
+        2 | def foo(a: str | None, b):
+        3 |     if a is not None:
+        4 |         print(a)
+          |               ^
           |
-        "###);
+        "#);
     }
 
     #[test]
@@ -566,7 +566,7 @@ f(**kwargs<CURSOR>)
             "#,
         );
 
-        assert_snapshot!(test.goto_type_definition(), @r###"
+        assert_snapshot!(test.goto_type_definition(), @r#"
         info[goto-type-definition]: Type definition
            --> stdlib/types.pyi:922:11
             |
@@ -577,11 +577,11 @@ f(**kwargs<CURSOR>)
         923 |         """The type of the None singleton."""
             |
         info: Source
-         --> main.py:3:17
+         --> main.py:3:5
           |
-        2 |             def foo(a: str | None, b):
-        3 |                 a
-          |                 ^
+        2 | def foo(a: str | None, b):
+        3 |     a
+          |     ^
           |
 
         info[goto-type-definition]: Type definition
@@ -595,13 +595,13 @@ f(**kwargs<CURSOR>)
         903 |     str(bytes_or_buffer[, encoding[, errors]]) -> str
             |
         info: Source
-         --> main.py:3:17
+         --> main.py:3:5
           |
-        2 |             def foo(a: str | None, b):
-        3 |                 a
-          |                 ^
+        2 | def foo(a: str | None, b):
+        3 |     a
+          |     ^
           |
-        "###);
+        "#);
     }
 
     impl CursorTest {

--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -174,14 +174,14 @@ mod tests {
         ```
         ---------------------------------------------
         info[hover]: Hovered content is
-         --> main.py:4:9
+         --> main.py:4:1
           |
-        2 |         a = 10
+        2 | a = 10
         3 |
-        4 |         a
-          |         ^- Cursor offset
-          |         |
-          |         source
+        4 | a
+          | ^- Cursor offset
+          | |
+          | source
           |
         ");
     }
@@ -233,15 +233,15 @@ mod tests {
         ```
         ---------------------------------------------
         info[hover]: Hovered content is
-          --> main.py:11:9
+          --> main.py:11:1
            |
-         9 |             return 0
+         9 |     return 0
         10 |
-        11 |         my_func(1, 2)
-           |         ^^^^^-^
-           |         |    |
-           |         |    Cursor offset
-           |         source
+        11 | my_func(1, 2)
+           | ^^^^^-^
+           | |    |
+           | |    Cursor offset
+           | source
            |
         ");
     }
@@ -291,14 +291,14 @@ mod tests {
         ```
         ---------------------------------------------
         info[hover]: Hovered content is
-         --> main.py:2:13
+         --> main.py:2:5
           |
-        2 |         def my_func(a, b):
-          |             ^^^^^-^
-          |             |    |
-          |             |    Cursor offset
-          |             source
-        3 |             '''This is such a great func!!
+        2 | def my_func(a, b):
+          |     ^^^^^-^
+          |     |    |
+          |     |    Cursor offset
+          |     source
+        3 |     '''This is such a great func!!
           |
         ");
     }
@@ -357,15 +357,15 @@ mod tests {
         ```
         ---------------------------------------------
         info[hover]: Hovered content is
-          --> main.py:24:9
+          --> main.py:24:1
            |
-        22 |                 return 0
+        22 |         return 0
         23 |
-        24 |         MyClass
-           |         ^^^^^-^
-           |         |    |
-           |         |    Cursor offset
-           |         source
+        24 | MyClass
+           | ^^^^^-^
+           | |    |
+           | |    Cursor offset
+           | source
            |
         ");
     }
@@ -422,15 +422,15 @@ mod tests {
         ```
         ---------------------------------------------
         info[hover]: Hovered content is
-         --> main.py:2:15
+         --> main.py:2:7
           |
-        2 |         class MyClass:
-          |               ^^^^^-^
-          |               |    |
-          |               |    Cursor offset
-          |               source
-        3 |             '''
-        4 |                 This is such a great class!!
+        2 | class MyClass:
+          |       ^^^^^-^
+          |       |    |
+          |       |    Cursor offset
+          |       source
+        3 |     '''
+        4 |         This is such a great class!!
           |
         ");
     }
@@ -489,15 +489,15 @@ mod tests {
         ```
         ---------------------------------------------
         info[hover]: Hovered content is
-          --> main.py:24:13
+          --> main.py:24:5
            |
-        22 |                 return 0
+        22 |         return 0
         23 |
-        24 |         x = MyClass(0)
-           |             ^^^^^-^
-           |             |    |
-           |             |    Cursor offset
-           |             source
+        24 | x = MyClass(0)
+           |     ^^^^^-^
+           |     |    |
+           |     |    Cursor offset
+           |     source
            |
         ");
     }
@@ -563,14 +563,14 @@ mod tests {
         ```
         ---------------------------------------------
         info[hover]: Hovered content is
-          --> main.py:25:11
+          --> main.py:25:3
            |
-        24 |         x = MyClass(0)
-        25 |         x.my_method(2, 3)
-           |           ^^^^^-^^^
-           |           |    |
-           |           |    Cursor offset
-           |           source
+        24 | x = MyClass(0)
+        25 | x.my_method(2, 3)
+           |   ^^^^^-^^^
+           |   |    |
+           |   |    Cursor offset
+           |   source
            |
         ");
     }
@@ -599,14 +599,14 @@ mod tests {
         ```
         ---------------------------------------------
         info[hover]: Hovered content is
-          --> main.py:10:13
+          --> main.py:10:5
            |
-         9 |         foo = Foo()
-        10 |         foo.a
-           |             -
-           |             |
-           |             source
-           |             Cursor offset
+         9 | foo = Foo()
+        10 | foo.a
+           |     -
+           |     |
+           |     source
+           |     Cursor offset
            |
         ");
     }
@@ -635,14 +635,14 @@ mod tests {
         ```
         ---------------------------------------------
         info[hover]: Hovered content is
-         --> main.py:4:13
+         --> main.py:4:1
           |
-        2 |             def foo(a, b): ...
+        2 | def foo(a, b): ...
         3 |
-        4 |             foo
-          |             ^^^- Cursor offset
-          |             |
-          |             source
+        4 | foo
+          | ^^^- Cursor offset
+          | |
+          | source
           |
         ");
     }
@@ -664,14 +664,14 @@ mod tests {
         ```
         ---------------------------------------------
         info[hover]: Hovered content is
-         --> main.py:3:17
+         --> main.py:3:5
           |
-        2 |             def foo(a: int, b: int, c: int):
-        3 |                 a + b == c
-          |                 ^^^^^^^^-^
-          |                 |       |
-          |                 |       Cursor offset
-          |                 source
+        2 | def foo(a: int, b: int, c: int):
+        3 |     a + b == c
+          |     ^^^^^^^^-^
+          |     |       |
+          |     |       Cursor offset
+          |     source
           |
         ");
     }
@@ -701,15 +701,15 @@ mod tests {
         ```
         ---------------------------------------------
         info[hover]: Hovered content is
-          --> main.py:10:18
+          --> main.py:10:6
            |
-         8 |                 return 0
+         8 |     return 0
          9 |
-        10 |             test(ab= 123)
-           |                  ^-
-           |                  ||
-           |                  |Cursor offset
-           |                  source
+        10 | test(ab= 123)
+           |      ^-
+           |      ||
+           |      |Cursor offset
+           |      source
            |
         ");
     }
@@ -736,14 +736,14 @@ mod tests {
         ```
         ---------------------------------------------
         info[hover]: Hovered content is
-         --> main.py:2:22
+         --> main.py:2:10
           |
-        2 |             def test(ab: int):
-          |                      ^-
-          |                      ||
-          |                      |Cursor offset
-          |                      source
-        3 |                 """my cool test
+        2 | def test(ab: int):
+          |          ^-
+          |          ||
+          |          |Cursor offset
+          |          source
+        3 |     """my cool test
           |
         "#);
     }
@@ -778,14 +778,14 @@ mod tests {
         ```
         ---------------------------------------------
         info[hover]: Hovered content is
-          --> main.py:16:13
+          --> main.py:16:1
            |
-        14 |                 a = bar
+        14 |     a = bar
         15 |
-        16 |             a
-           |             ^- Cursor offset
-           |             |
-           |             source
+        16 | a
+           | ^- Cursor offset
+           | |
+           | source
            |
         ");
     }
@@ -845,14 +845,14 @@ mod tests {
         ```
         ---------------------------------------------
         info[hover]: Hovered content is
-          --> main.py:19:13
+          --> main.py:19:1
            |
-        17 |                 a = "hello"
+        17 |     a = "hello"
         18 |
-        19 |             foo(a, 2)
-           |             ^^^- Cursor offset
-           |             |
-           |             source
+        19 | foo(a, 2)
+           | ^^^- Cursor offset
+           | |
+           | source
            |
         "#);
     }
@@ -900,14 +900,14 @@ mod tests {
         ```
         ---------------------------------------------
         info[hover]: Hovered content is
-          --> main.py:19:13
+          --> main.py:19:1
            |
-        17 |                 a = "hello"
+        17 |     a = "hello"
         18 |
-        19 |             foo(a)
-           |             ^^^- Cursor offset
-           |             |
-           |             source
+        19 | foo(a)
+           | ^^^- Cursor offset
+           | |
+           | source
            |
         "#);
     }
@@ -955,15 +955,15 @@ mod tests {
         ```
         ---------------------------------------------
         info[hover]: Hovered content is
-         --> main.py:4:13
+         --> main.py:4:1
           |
-        2 |             import lib
+        2 | import lib
         3 |
-        4 |             lib
-          |             ^^-
-          |             | |
-          |             | Cursor offset
-          |             source
+        4 | lib
+          | ^^-
+          | | |
+          | | Cursor offset
+          | source
           |
         ");
     }
@@ -1005,15 +1005,15 @@ mod tests {
         ```
         ---------------------------------------------
         info[hover]: Hovered content is
-         --> main.py:2:20
+         --> main.py:2:8
           |
-        2 |             import lib
-          |                    ^^-
-          |                    | |
-          |                    | Cursor offset
-          |                    source
+        2 | import lib
+          |        ^^-
+          |        | |
+          |        | Cursor offset
+          |        source
         3 |
-        4 |             lib
+        4 | lib
           |
         ");
     }
@@ -1027,7 +1027,7 @@ mod tests {
         );
 
         // TODO: This should render T@Alias once we create GenericContexts for type alias scopes.
-        assert_snapshot!(test.hover(), @r###"
+        assert_snapshot!(test.hover(), @r"
         typing.TypeVar
         ---------------------------------------------
         ```python
@@ -1035,14 +1035,14 @@ mod tests {
         ```
         ---------------------------------------------
         info[hover]: Hovered content is
-         --> main.py:2:46
+         --> main.py:2:34
           |
-        2 |             type Alias[T: int = bool] = list[T]
-          |                                              ^- Cursor offset
-          |                                              |
-          |                                              source
+        2 | type Alias[T: int = bool] = list[T]
+          |                                  ^- Cursor offset
+          |                                  |
+          |                                  source
           |
-        "###);
+        ");
     }
 
     #[test]
@@ -1061,12 +1061,12 @@ mod tests {
         ```
         ---------------------------------------------
         info[hover]: Hovered content is
-         --> main.py:2:53
+         --> main.py:2:41
           |
-        2 |             type Alias[**P = [int, str]] = Callable[P, int]
-          |                                                     ^- Cursor offset
-          |                                                     |
-          |                                                     source
+        2 | type Alias[**P = [int, str]] = Callable[P, int]
+          |                                         ^- Cursor offset
+          |                                         |
+          |                                         source
           |
         ");
     }
@@ -1087,12 +1087,12 @@ mod tests {
         ```
         ---------------------------------------------
         info[hover]: Hovered content is
-         --> main.py:2:43
+         --> main.py:2:31
           |
-        2 |             type Alias[*Ts = ()] = tuple[*Ts]
-          |                                           ^^- Cursor offset
-          |                                           |
-          |                                           source
+        2 | type Alias[*Ts = ()] = tuple[*Ts]
+          |                               ^^- Cursor offset
+          |                               |
+          |                               source
           |
         ");
     }
@@ -1113,12 +1113,12 @@ mod tests {
         ```
         ---------------------------------------------
         info[hover]: Hovered content is
-         --> main.py:2:13
+         --> main.py:2:1
           |
-        2 |             value = 1
-          |             ^^^^^- Cursor offset
-          |             |
-          |             source
+        2 | value = 1
+          | ^^^^^- Cursor offset
+          | |
+          | source
           |
         ");
     }
@@ -1144,13 +1144,13 @@ mod tests {
         ```
         ---------------------------------------------
         info[hover]: Hovered content is
-         --> main.py:3:13
+         --> main.py:3:1
           |
-        2 |             value = 1
-        3 |             value += 2
-          |             ^^^^^- Cursor offset
-          |             |
-          |             source
+        2 | value = 1
+        3 | value += 2
+          | ^^^^^- Cursor offset
+          | |
+          | source
           |
         ");
     }
@@ -1174,14 +1174,14 @@ mod tests {
         ```
         ---------------------------------------------
         info[hover]: Hovered content is
-         --> main.py:5:15
+         --> main.py:5:3
           |
-        3 |                 attr: int = 1
+        3 |     attr: int = 1
         4 |
-        5 |             C.attr = 2
-          |               ^^^^- Cursor offset
-          |               |
-          |               source
+        5 | C.attr = 2
+          |   ^^^^- Cursor offset
+          |   |
+          |   source
           |
         ");
     }
@@ -1207,14 +1207,14 @@ mod tests {
         ```
         ---------------------------------------------
         info[hover]: Hovered content is
-         --> main.py:5:15
+         --> main.py:5:3
           |
-        3 |                 attr = 1
+        3 |     attr = 1
         4 |
-        5 |             C.attr += 2
-          |               ^^^^- Cursor offset
-          |               |
-          |               source
+        5 | C.attr += 2
+          |   ^^^^- Cursor offset
+          |   |
+          |   source
           |
         ");
     }
@@ -1236,13 +1236,13 @@ mod tests {
         ```
         ---------------------------------------------
         info[hover]: Hovered content is
-         --> main.py:3:13
+         --> main.py:3:5
           |
-        2 |         class Foo:
-        3 |             a: int
-          |             ^- Cursor offset
-          |             |
-          |             source
+        2 | class Foo:
+        3 |     a: int
+          |     ^- Cursor offset
+          |     |
+          |     source
           |
         ");
     }
@@ -1264,13 +1264,13 @@ mod tests {
         ```
         ---------------------------------------------
         info[hover]: Hovered content is
-         --> main.py:3:13
+         --> main.py:3:5
           |
-        2 |         class Foo:
-        3 |             a: int = 1
-          |             ^- Cursor offset
-          |             |
-          |             source
+        2 | class Foo:
+        3 |     a: int = 1
+          |     ^- Cursor offset
+          |     |
+          |     source
           |
         ");
     }
@@ -1293,14 +1293,14 @@ mod tests {
         ```
         ---------------------------------------------
         info[hover]: Hovered content is
-         --> main.py:4:22
+         --> main.py:4:14
           |
-        2 |         class Foo:
-        3 |             def __init__(self, a: int):
-        4 |                 self.a: int = a
-          |                      ^- Cursor offset
-          |                      |
-          |                      source
+        2 | class Foo:
+        3 |     def __init__(self, a: int):
+        4 |         self.a: int = a
+          |              ^- Cursor offset
+          |              |
+          |              source
           |
         ");
     }
@@ -1329,14 +1329,14 @@ mod tests {
         ```
         ---------------------------------------------
         info[hover]: Hovered content is
-          --> main.py:10:27
+          --> main.py:10:15
            |
-         8 |                 '''
-         9 |                 if a is not None:
-        10 |                     print(a)
-           |                           ^- Cursor offset
-           |                           |
-           |                           source
+         8 |     '''
+         9 |     if a is not None:
+        10 |         print(a)
+           |               ^- Cursor offset
+           |               |
+           |               source
            |
         ");
     }
@@ -1407,15 +1407,15 @@ mod tests {
         ```
         ---------------------------------------------
         info[hover]: Hovered content is
-         --> main.py:5:9
+         --> main.py:5:1
           |
-        3 |         def ab(x: int, y: Callable[[int, int], Any], z: List[int]) -> int: ...
+        3 | def ab(x: int, y: Callable[[int, int], Any], z: List[int]) -> int: ...
         4 |
-        5 |         ab
-          |         ^-
-          |         ||
-          |         |Cursor offset
-          |         source
+        5 | ab
+          | ^-
+          | ||
+          | |Cursor offset
+          | source
           |
         ");
     }
@@ -1439,15 +1439,15 @@ mod tests {
         ```
         ---------------------------------------------
         info[hover]: Hovered content is
-         --> main.py:5:9
+         --> main.py:5:1
           |
-        3 |         ab: Tuple[Any, int, Callable[[int, int], Any]] = ...
+        3 | ab: Tuple[Any, int, Callable[[int, int], Any]] = ...
         4 |
-        5 |         ab
-          |         ^-
-          |         ||
-          |         |Cursor offset
-          |         source
+        5 | ab
+          | ^-
+          | ||
+          | |Cursor offset
+          | source
           |
         ");
     }
@@ -1471,15 +1471,15 @@ mod tests {
         ```
         ---------------------------------------------
         info[hover]: Hovered content is
-         --> main.py:5:9
+         --> main.py:5:1
           |
-        3 |         ab:  Callable[[int, int], Any] | None  = ...
+        3 | ab:  Callable[[int, int], Any] | None  = ...
         4 |
-        5 |         ab
-          |         ^-
-          |         ||
-          |         |Cursor offset
-          |         source
+        5 | ab
+          | ^-
+          | ||
+          | |Cursor offset
+          | source
           |
         ");
     }

--- a/crates/ty_ide/src/lib.rs
+++ b/crates/ty_ide/src/lib.rs
@@ -287,6 +287,7 @@ mod tests {
     use ruff_db::diagnostic::{Diagnostic, DiagnosticFormat, DisplayDiagnosticConfig};
     use ruff_db::files::{File, system_path_to_file};
     use ruff_db::system::{DbWithWritableSystem, SystemPath, SystemPathBuf};
+    use ruff_python_trivia::textwrap::dedent;
     use ruff_text_size::TextSize;
     use ty_project::ProjectMetadata;
     use ty_python_semantic::{
@@ -417,12 +418,12 @@ mod tests {
         pub(super) fn source(
             &mut self,
             path: impl Into<SystemPathBuf>,
-            contents: impl Into<String>,
+            contents: impl AsRef<str>,
         ) -> &mut CursorTestBuilder {
             const MARKER: &str = "<CURSOR>";
 
             let path = path.into();
-            let contents = contents.into();
+            let contents = dedent(contents.as_ref()).into_owned();
             let Some(cursor_offset) = contents.find(MARKER) else {
                 self.sources.push(Source {
                     path,

--- a/crates/ty_ide/src/semantic_tokens.rs
+++ b/crates/ty_ide/src/semantic_tokens.rs
@@ -1405,34 +1405,34 @@ u = List.__name__        # __name__ should be variable<CURSOR>
         "MyClass" @ 89..96: Class [definition]
         "CONSTANT" @ 102..110: Variable [readonly]
         "42" @ 113..115: Number
-        "method" @ 129..135: Method [definition]
-        "self" @ 136..140: SelfParameter
-        "/"hello/"" @ 158..165: String
-        "property" @ 176..184: Decorator
-        "prop" @ 193..197: Method [definition]
-        "self" @ 198..202: SelfParameter
-        "self" @ 220..224: Variable
-        "CONSTANT" @ 225..233: Variable [readonly]
-        "obj" @ 235..238: Variable
-        "MyClass" @ 241..248: Class
-        "x" @ 286..287: Namespace
-        "os" @ 290..292: Namespace
-        "path" @ 293..297: Namespace
-        "y" @ 347..348: Method
-        "obj" @ 351..354: Variable
-        "method" @ 355..361: Method
-        "z" @ 413..414: Variable
-        "obj" @ 417..420: Variable
-        "CONSTANT" @ 421..429: Variable [readonly]
-        "w" @ 491..492: Variable
-        "obj" @ 495..498: Variable
-        "prop" @ 499..503: Variable
-        "v" @ 542..543: Function
-        "MyClass" @ 546..553: Class
-        "method" @ 554..560: Method
-        "u" @ 604..605: Variable
-        "List" @ 608..612: Variable
-        "__name__" @ 613..621: Variable
+        "method" @ 125..131: Method [definition]
+        "self" @ 132..136: SelfParameter
+        "/"hello/"" @ 154..161: String
+        "property" @ 168..176: Decorator
+        "prop" @ 185..189: Method [definition]
+        "self" @ 190..194: SelfParameter
+        "self" @ 212..216: Variable
+        "CONSTANT" @ 217..225: Variable [readonly]
+        "obj" @ 227..230: Variable
+        "MyClass" @ 233..240: Class
+        "x" @ 278..279: Namespace
+        "os" @ 282..284: Namespace
+        "path" @ 285..289: Namespace
+        "y" @ 339..340: Method
+        "obj" @ 343..346: Variable
+        "method" @ 347..353: Method
+        "z" @ 405..406: Variable
+        "obj" @ 409..412: Variable
+        "CONSTANT" @ 413..421: Variable [readonly]
+        "w" @ 483..484: Variable
+        "obj" @ 487..490: Variable
+        "prop" @ 491..495: Variable
+        "v" @ 534..535: Function
+        "MyClass" @ 538..545: Class
+        "method" @ 546..552: Method
+        "u" @ 596..597: Variable
+        "List" @ 600..604: Variable
+        "__name__" @ 605..613: Variable
         "#);
     }
 
@@ -1456,14 +1456,14 @@ y = obj.unknown_attr     # Should fall back to variable<CURSOR>
         "MyClass" @ 7..14: Class [definition]
         "some_attr" @ 20..29: Variable
         "/"value/"" @ 32..39: String
-        "obj" @ 45..48: Variable
-        "MyClass" @ 51..58: Class
-        "x" @ 121..122: Variable
-        "obj" @ 125..128: Variable
-        "some_attr" @ 129..138: Variable
-        "y" @ 191..192: Variable
-        "obj" @ 195..198: Variable
-        "unknown_attr" @ 199..211: Variable
+        "obj" @ 41..44: Variable
+        "MyClass" @ 47..54: Class
+        "x" @ 117..118: Variable
+        "obj" @ 121..124: Variable
+        "some_attr" @ 125..134: Variable
+        "y" @ 187..188: Variable
+        "obj" @ 191..194: Variable
+        "unknown_attr" @ 195..207: Variable
         "#);
     }
 
@@ -1497,20 +1497,20 @@ w = obj.A             # Should not have readonly modifier (length == 1)<CURSOR>
         "12" @ 72..74: Number
         "A" @ 79..80: Variable
         "1" @ 83..84: Number
-        "obj" @ 90..93: Variable
-        "MyClass" @ 96..103: Class
-        "x" @ 106..107: Variable
-        "obj" @ 110..113: Variable
-        "UPPER_CASE" @ 114..124: Variable [readonly]
-        "y" @ 160..161: Variable
-        "obj" @ 164..167: Variable
-        "lower_case" @ 168..178: Variable
-        "z" @ 220..221: Variable
-        "obj" @ 224..227: Variable
-        "MixedCase" @ 228..237: Variable
-        "w" @ 278..279: Variable
-        "obj" @ 282..285: Variable
-        "A" @ 286..287: Variable
+        "obj" @ 86..89: Variable
+        "MyClass" @ 92..99: Class
+        "x" @ 102..103: Variable
+        "obj" @ 106..109: Variable
+        "UPPER_CASE" @ 110..120: Variable [readonly]
+        "y" @ 156..157: Variable
+        "obj" @ 160..163: Variable
+        "lower_case" @ 164..174: Variable
+        "z" @ 216..217: Variable
+        "obj" @ 220..223: Variable
+        "MixedCase" @ 224..233: Variable
+        "w" @ 274..275: Variable
+        "obj" @ 278..281: Variable
+        "A" @ 282..283: Variable
         "#);
     }
 
@@ -1636,7 +1636,7 @@ def test_function(param: int, other: MyClass) -> Optional[List[str]]:
         "List" @ 236..240: Variable
         "str" @ 241..244: Class
         "/"hello/"" @ 249..256: String
-        "None" @ 361..365: BuiltinConstant
+        "None" @ 357..361: BuiltinConstant
         "#);
     }
 
@@ -1800,32 +1800,32 @@ class BoundedContainer[T: int, U = str]:
         "value1" @ 594..600: Parameter
         "U" @ 622..623: TypeParameter
         "value2" @ 626..632: Parameter
-        "get_first" @ 646..655: Method [definition]
-        "self" @ 656..660: SelfParameter
-        "T" @ 665..666: TypeParameter
-        "self" @ 683..687: Variable
-        "value1" @ 688..694: Variable
-        "get_second" @ 708..718: Method [definition]
-        "self" @ 719..723: SelfParameter
-        "U" @ 728..729: TypeParameter
-        "self" @ 746..750: Variable
-        "value2" @ 751..757: Variable
-        "BoundedContainer" @ 806..822: Class [definition]
-        "T" @ 823..824: TypeParameter [definition]
-        "int" @ 826..829: Class
-        "U" @ 831..832: TypeParameter [definition]
-        "str" @ 835..838: Class
-        "process" @ 849..856: Method [definition]
-        "self" @ 857..861: SelfParameter
-        "x" @ 863..864: Parameter
-        "T" @ 866..867: TypeParameter
-        "y" @ 869..870: Parameter
-        "U" @ 872..873: TypeParameter
-        "tuple" @ 878..883: Class
-        "T" @ 884..885: TypeParameter
-        "U" @ 887..888: TypeParameter
-        "x" @ 907..908: Parameter
-        "y" @ 910..911: Parameter
+        "get_first" @ 642..651: Method [definition]
+        "self" @ 652..656: SelfParameter
+        "T" @ 661..662: TypeParameter
+        "self" @ 679..683: Variable
+        "value1" @ 684..690: Variable
+        "get_second" @ 700..710: Method [definition]
+        "self" @ 711..715: SelfParameter
+        "U" @ 720..721: TypeParameter
+        "self" @ 738..742: Variable
+        "value2" @ 743..749: Variable
+        "BoundedContainer" @ 798..814: Class [definition]
+        "T" @ 815..816: TypeParameter [definition]
+        "int" @ 818..821: Class
+        "U" @ 823..824: TypeParameter [definition]
+        "str" @ 827..830: Class
+        "process" @ 841..848: Method [definition]
+        "self" @ 849..853: SelfParameter
+        "x" @ 855..856: Parameter
+        "T" @ 858..859: TypeParameter
+        "y" @ 861..862: Parameter
+        "U" @ 864..865: TypeParameter
+        "tuple" @ 870..875: Class
+        "T" @ 876..877: TypeParameter
+        "U" @ 879..880: TypeParameter
+        "x" @ 899..900: Parameter
+        "y" @ 902..903: Parameter
         "#);
     }
 
@@ -2071,24 +2071,24 @@ def outer():
         "/"outer_value/"" @ 63..76: String
         "z" @ 81..82: Variable
         "/"outer_local/"" @ 85..98: String
-        "inner" @ 112..117: Function [definition]
-        "x" @ 138..139: Variable
-        "z" @ 141..142: Variable
-        "y" @ 193..194: Variable
-        "x" @ 243..244: Variable
-        "/"modified/"" @ 247..257: String
-        "y" @ 266..267: Variable
-        "/"modified_global/"" @ 270..287: String
-        "z" @ 296..297: Variable
-        "/"modified_local/"" @ 300..316: String
-        "deeper" @ 338..344: Function [definition]
-        "x" @ 369..370: Variable
-        "y" @ 410..411: Variable
-        "x" @ 413..414: Variable
-        "x" @ 469..470: Variable
-        "y" @ 473..474: Variable
-        "deeper" @ 499..505: Function
-        "inner" @ 522..527: Function
+        "inner" @ 108..113: Function [definition]
+        "x" @ 134..135: Variable
+        "z" @ 137..138: Variable
+        "y" @ 189..190: Variable
+        "x" @ 239..240: Variable
+        "/"modified/"" @ 243..253: String
+        "y" @ 262..263: Variable
+        "/"modified_global/"" @ 266..283: String
+        "z" @ 292..293: Variable
+        "/"modified_local/"" @ 296..312: String
+        "deeper" @ 326..332: Function [definition]
+        "x" @ 357..358: Variable
+        "y" @ 398..399: Variable
+        "x" @ 401..402: Variable
+        "x" @ 457..458: Variable
+        "y" @ 461..462: Variable
+        "deeper" @ 479..485: Function
+        "inner" @ 498..503: Function
         "#);
     }
 
@@ -2115,20 +2115,20 @@ def test():
         "test" @ 34..38: Function [definition]
         "x" @ 53..54: Variable
         "y" @ 68..69: Variable
-        "a" @ 128..129: Variable
-        "b" @ 131..132: Variable
-        "c" @ 134..135: Variable
-        "d" @ 149..150: Variable
-        "e" @ 152..153: Variable
-        "f" @ 155..156: Variable
-        "x" @ 173..174: Variable
-        "y" @ 177..178: Variable
-        "a" @ 181..182: Variable
-        "b" @ 185..186: Variable
-        "c" @ 189..190: Variable
-        "d" @ 193..194: Variable
-        "e" @ 197..198: Variable
-        "f" @ 201..202: Variable
+        "a" @ 124..125: Variable
+        "b" @ 127..128: Variable
+        "c" @ 130..131: Variable
+        "d" @ 145..146: Variable
+        "e" @ 148..149: Variable
+        "f" @ 151..152: Variable
+        "x" @ 165..166: Variable
+        "y" @ 169..170: Variable
+        "a" @ 173..174: Variable
+        "b" @ 177..178: Variable
+        "c" @ 181..182: Variable
+        "d" @ 185..186: Variable
+        "e" @ 189..190: Variable
+        "f" @ 193..194: Variable
         "#);
     }
 


### PR DESCRIPTION
## Summary

We need to dedent the source snippets in cursor tests to avoid unexpected indentations during parsing.
