### PR TITLE
[ty] Stop running every mdtest twice

### DIFF
--- a/crates/ty_test/src/lib.rs
+++ b/crates/ty_test/src/lib.rs
@@ -78,7 +78,7 @@ pub fn run(
             println!("\n{}\n", test.name().bold().underline());
         }
 
-        if let Err(failures) = run_test(&mut db, relative_fixture_path, snapshot_path, &test) {
+        if let Err(failures) = failures {
             let md_index = LineIndex::from_source_text(&source);
 
             for test_failures in failures {
@@ -105,7 +105,7 @@ pub fn run(
                 }
             }
         }
-        if let Err(inconsistencies) = run_module_resolution_consistency_test(&db) {
+        if let Err(inconsistencies) = inconsistencies {
             any_failures = true;
             for inconsistency in inconsistencies {
                 match output_format {


### PR DESCRIPTION
This was an accidental oversight introduced in commit
468eb37d7572acaa354c0159875157ffceb9d447.
