### PR TITLE
[`pyupgrade`] Enable rule triggering for stub files  (`UP043`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP043.pyi
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP043.pyi
@@ -1,0 +1,27 @@
+# https://github.com/python/typeshed/blob/main/stubs/networkx/networkx/algorithms/community/louvain.pyi
+from _typeshed import Incomplete
+from collections.abc import Generator
+
+from networkx.classes.graph import Graph, _Node
+from networkx.utils.backends import _dispatchable
+from numpy.random import RandomState
+
+__all__ = ["louvain_communities", "louvain_partitions"]
+
+@_dispatchable
+def louvain_communities(
+        G: Graph[_Node],
+        weight: str | None = "weight",
+        resolution: float | None = 1,
+        threshold: float | None = 1e-07,
+        max_level: int | None = None,
+        seed: int | RandomState | None = None,
+) -> list[set[Incomplete]]: ...
+@_dispatchable
+def louvain_partitions(
+        G: Graph[_Node],
+        weight: str | None = "weight",
+        resolution: float | None = 1,
+        threshold: float | None = 1e-07,
+        seed: int | RandomState | None = None,
+) -> Generator[list[set[Incomplete]], None, None]: ...

--- a/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
@@ -142,7 +142,9 @@ pub(crate) fn expression(expr: &Expr, checker: &Checker) {
             }
 
             if checker.is_rule_enabled(Rule::UnnecessaryDefaultTypeArgs) {
-                if checker.target_version() >= PythonVersion::PY313 {
+                if checker.target_version() >= PythonVersion::PY313
+                    || checker.semantic().in_stub_file()
+                {
                     pyupgrade::rules::unnecessary_default_type_args(checker, expr);
                 }
             }

--- a/crates/ruff_linter/src/rules/pyupgrade/mod.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/mod.rs
@@ -100,6 +100,7 @@ mod tests {
     #[test_case(Rule::UnnecessaryBuiltinImport, Path::new("UP029.py"))]
     #[test_case(Rule::UnnecessaryClassParentheses, Path::new("UP039.py"))]
     #[test_case(Rule::UnnecessaryDefaultTypeArgs, Path::new("UP043.py"))]
+    #[test_case(Rule::UnnecessaryDefaultTypeArgs, Path::new("UP043.pyi"))]
     #[test_case(Rule::UnnecessaryEncodeUTF8, Path::new("UP012.py"))]
     #[test_case(Rule::UnnecessaryFutureImport, Path::new("UP010_0.py"))]
     #[test_case(Rule::UnnecessaryFutureImport, Path::new("UP010_1.py"))]

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_default_type_args.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_default_type_args.rs
@@ -7,7 +7,7 @@ use crate::{AlwaysFixableViolation, Applicability, Edit, Fix};
 
 /// ## What it does
 /// Checks for unnecessary default type arguments for `Generator` and
-/// `AsyncGenerator` on Python 3.13+.
+/// `AsyncGenerator` on Python 3.13+ or stubs.
 ///
 /// ## Why is this bad?
 /// Python 3.13 introduced the ability for type parameters to specify default

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP043.pyi.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP043.pyi.snap
@@ -1,0 +1,19 @@
+---
+source: crates/ruff_linter/src/rules/pyupgrade/mod.rs
+---
+UP043 [*] Unnecessary default type arguments
+  --> UP043.pyi:27:6
+   |
+25 |         threshold: float | None = 1e-07,
+26 |         seed: int | RandomState | None = None,
+27 | ) -> Generator[list[set[Incomplete]], None, None]: ...
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: Remove default type arguments
+
+ℹ Safe fix
+24 24 |         resolution: float | None = 1,
+25 25 |         threshold: float | None = 1e-07,
+26 26 |         seed: int | RandomState | None = None,
+27    |-) -> Generator[list[set[Incomplete]], None, None]: ...
+   27 |+) -> Generator[list[set[Incomplete]]]: ...


### PR DESCRIPTION
## Summary
Resolves #20011

Implemented alternative triggering condition for rule [`UP043`](https://docs.astral.sh/ruff/rules/unnecessary-default-type-args/) based on requirements outlined in [issue #20011](https://github.com/astral-sh/ruff/issues/20011)
## Test Plan
Created .pyi file to ensure triggering the rule
