### PR TITLE
RUF026: Fix false positive for t strings

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF026.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF026.py
@@ -118,3 +118,10 @@ def func():
         return lambda: value
 
     defaultdict(constant_factory("<missing>"))
+
+def func():
+    defaultdict(default_factory=t"")  # OK
+
+
+def func():
+    defaultdict(default_factory=t"hello")  # OK

--- a/crates/ruff_linter/src/rules/ruff/rules/default_factory_kwarg.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/default_factory_kwarg.rs
@@ -123,7 +123,8 @@ fn is_non_callable_value(value: &Expr) -> bool {
             | Expr::SetComp(_)
             | Expr::DictComp(_)
             | Expr::Generator(_)
-            | Expr::FString(_))
+            | Expr::FString(_)
+            | Expr::TString(_))
 }
 
 /// Generate an [`Expr`] to replace `defaultdict(default_factory=callable)` with


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

Closes #19993

## Summary
Recognize t strings as never being callable to avoid false positives on RUF026.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan
Added two test cases covering t strings. 
<!-- How was it tested? -->
