### PR TITLE
[ty] rename BareTypeAliasType to ManualPEP695TypeAliasType

### DIFF
--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -28,11 +28,12 @@ use crate::types::infer::nearest_enclosing_class;
 use crate::types::signatures::{CallableSignature, Parameter, Parameters, Signature};
 use crate::types::tuple::{TupleSpec, TupleType};
 use crate::types::{
-    ApplyTypeMappingVisitor, BareTypeAliasType, Binding, BoundSuperError, BoundSuperType,
-    CallableType, DataclassParams, DeprecatedInstance, HasRelationToVisitor, IsEquivalentVisitor,
-    KnownInstanceType, NormalizedVisitor, PropertyInstanceType, StringLiteralType, TypeAliasType,
-    TypeMapping, TypeRelation, TypeVarBoundOrConstraints, TypeVarInstance, TypeVarKind,
-    VarianceInferable, declaration_type, infer_definition_types, todo_type,
+    ApplyTypeMappingVisitor, Binding, BoundSuperError, BoundSuperType, CallableType,
+    DataclassParams, DeprecatedInstance, HasRelationToVisitor, IsEquivalentVisitor,
+    KnownInstanceType, ManualPEP695TypeAliasType, NormalizedVisitor, PropertyInstanceType,
+    StringLiteralType, TypeAliasType, TypeMapping, TypeRelation, TypeVarBoundOrConstraints,
+    TypeVarInstance, TypeVarKind, VarianceInferable, declaration_type, infer_definition_types,
+    todo_type,
 };
 use crate::{
     Db, FxIndexMap, FxOrderSet, Program,
@@ -4935,7 +4936,7 @@ impl KnownClass {
                     return;
                 };
                 overload.set_return_type(Type::KnownInstance(KnownInstanceType::TypeAliasType(
-                    TypeAliasType::Bare(BareTypeAliasType::new(
+                    TypeAliasType::ManualPEP695(ManualPEP695TypeAliasType::new(
                         db,
                         ast::name::Name::new(name.value(db)),
                         containing_assignment,


### PR DESCRIPTION
## Summary

Rename `TypeAliasType::Bare` to `TypeAliasType::ManualPEP695`, and `BareTypeAliasType` to `ManualPEP695TypeAliasType`.

Why?

Both existing variants of `TypeAliasType` are specific to features added in PEP 695 (which introduced both the `type` statement and `types.TypeAliasType`), so it doesn't make sense to name one with the name `PEP695` and not the other.

A "bare" type alias, in my mind, is a legacy type alias like `IntOrStr = int | str`, which is "bare" in that there is nothing at all distinguishing it as a type alias. I will want to use the "bare" name for this variant, in a future PR.

The renamed variant here describes a type alias created with `IntOrStr = types.TypeAliasType("IntOrStr", int | str)`, which is not "bare", it's just "manually" instantiated instead of using the `type` statement syntax sugar. (This is useful when using the `typing_extensions` backport of `TypeAliasType` on older Python versions.)

## Test Plan

Pure rename, existing tests pass.
