### PR TITLE
[ty] Cancel background tasks when shutdown is requested

### DIFF
--- a/crates/ty_server/src/session.rs
+++ b/crates/ty_server/src/session.rs
@@ -427,7 +427,7 @@ impl Session {
     /// Returns a mutable iterator over all project databases that have been initialized to this point.
     ///
     /// This iterator will only yield the default project database if it has been used.
-    fn projects_mut(&mut self) -> impl Iterator<Item = &'_ mut ProjectDatabase> + '_ {
+    pub(crate) fn projects_mut(&mut self) -> impl Iterator<Item = &'_ mut ProjectDatabase> + '_ {
         self.project_states_mut().map(|project| &mut project.db)
     }
 


### PR DESCRIPTION
## Summary

Cancel any background tasks when the client requests the server to shut down. 

This ensures that long running tasks like workspace diagnostics or workspace symbols don't run to completion before shutting down the server.

## Test Plan

Restarted the server while workspace diagnostics was running. The server exited immediately.
