### PR TITLE
Fix incorrect lsp inlay hint type

### DIFF
--- a/crates/ty_ide/src/lib.rs
+++ b/crates/ty_ide/src/lib.rs
@@ -26,7 +26,7 @@ pub use document_symbols::{document_symbols, document_symbols_with_options};
 pub use goto::{goto_declaration, goto_definition, goto_type_definition};
 pub use goto_references::goto_references;
 pub use hover::hover;
-pub use inlay_hints::{InlayHintSettings, inlay_hints};
+pub use inlay_hints::{InlayHintContent, InlayHintSettings, inlay_hints};
 pub use markup::MarkupKind;
 pub use references::ReferencesMode;
 pub use rename::{can_rename, rename};

--- a/crates/ty_server/src/server/api/requests/inlay_hints.rs
+++ b/crates/ty_server/src/server/api/requests/inlay_hints.rs
@@ -9,7 +9,7 @@ use crate::session::client::Client;
 use lsp_types::request::InlayHintRequest;
 use lsp_types::{InlayHintParams, Url};
 use ruff_db::source::{line_index, source_text};
-use ty_ide::inlay_hints;
+use ty_ide::{InlayHintContent, inlay_hints};
 use ty_project::ProjectDatabase;
 
 pub(crate) struct InlayHintRequestHandler;
@@ -56,7 +56,7 @@ impl BackgroundDocumentRequestHandler for InlayHintRequestHandler {
                     .position
                     .to_position(&source, &index, snapshot.encoding()),
                 label: lsp_types::InlayHintLabel::String(hint.display(db).to_string()),
-                kind: Some(lsp_types::InlayHintKind::TYPE),
+                kind: Some(inlay_hint_type(&hint.content)),
                 tooltip: None,
                 padding_left: None,
                 padding_right: None,
@@ -70,3 +70,10 @@ impl BackgroundDocumentRequestHandler for InlayHintRequestHandler {
 }
 
 impl RetriableRequestHandler for InlayHintRequestHandler {}
+
+fn inlay_hint_type(inlay_hint_content: &InlayHintContent) -> lsp_types::InlayHintKind {
+    match inlay_hint_content {
+        InlayHintContent::Type(_) => lsp_types::InlayHintKind::TYPE,
+        InlayHintContent::CallArgumentName(_) => lsp_types::InlayHintKind::PARAMETER,
+    }
+}

--- a/crates/ty_server/src/server/api/requests/inlay_hints.rs
+++ b/crates/ty_server/src/server/api/requests/inlay_hints.rs
@@ -56,7 +56,7 @@ impl BackgroundDocumentRequestHandler for InlayHintRequestHandler {
                     .position
                     .to_position(&source, &index, snapshot.encoding()),
                 label: lsp_types::InlayHintLabel::String(hint.display(db).to_string()),
-                kind: Some(inlay_hint_type(&hint.content)),
+                kind: Some(inlay_hint_kind(&hint.content)),
                 tooltip: None,
                 padding_left: None,
                 padding_right: None,
@@ -71,7 +71,7 @@ impl BackgroundDocumentRequestHandler for InlayHintRequestHandler {
 
 impl RetriableRequestHandler for InlayHintRequestHandler {}
 
-fn inlay_hint_type(inlay_hint_content: &InlayHintContent) -> lsp_types::InlayHintKind {
+fn inlay_hint_kind(inlay_hint_content: &InlayHintContent) -> lsp_types::InlayHintKind {
     match inlay_hint_content {
         InlayHintContent::Type(_) => lsp_types::InlayHintKind::TYPE,
         InlayHintContent::CallArgumentName(_) => lsp_types::InlayHintKind::PARAMETER,

--- a/crates/ty_server/tests/e2e/inlay_hints.rs
+++ b/crates/ty_server/tests/e2e/inlay_hints.rs
@@ -51,7 +51,7 @@ foo(1)
           "character": 4
         },
         "label": "a=",
-        "kind": 1
+        "kind": 2
       }
     ]
     "#);

--- a/crates/ty_wasm/src/lib.rs
+++ b/crates/ty_wasm/src/lib.rs
@@ -452,6 +452,7 @@ impl Workspace {
                     &source,
                     self.position_encoding,
                 ),
+                kind: hint.content.into(),
             })
             .collect())
     }
@@ -973,12 +974,30 @@ impl From<ty_python_semantic::CompletionKind> for CompletionKind {
 }
 
 #[wasm_bindgen]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
+pub enum InlayHintKind {
+    Type,
+    Parameter,
+}
+
+impl From<ty_ide::InlayHintContent<'_>> for InlayHintKind {
+    fn from(kind: ty_ide::InlayHintContent) -> Self {
+        match kind {
+            ty_ide::InlayHintContent::Type(_) => Self::Type,
+            ty_ide::InlayHintContent::CallArgumentName(_) => Self::Parameter,
+        }
+    }
+}
+
+#[wasm_bindgen]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InlayHint {
     #[wasm_bindgen(getter_with_clone)]
     pub markdown: String,
 
     pub position: Position,
+
+    pub kind: InlayHintKind,
 }
 
 #[wasm_bindgen]

--- a/playground/ty/src/Editor/Editor.tsx
+++ b/playground/ty/src/Editor/Editor.tsx
@@ -27,6 +27,7 @@ import {
   type FileHandle,
   DocumentHighlight,
   DocumentHighlightKind,
+  InlayHintKind,
 } from "ty_wasm";
 import { FileId, ReadonlyFiles } from "../Playground";
 import { isPythonFile } from "./Files";
@@ -404,6 +405,15 @@ class PlaygroundServer
       return undefined;
     }
 
+    function mapInlayHintKind(kind: InlayHintKind): languages.InlayHintKind {
+      switch (kind) {
+        case InlayHintKind.Type:
+          return languages.InlayHintKind.Type;
+        case InlayHintKind.Parameter:
+          return languages.InlayHintKind.Parameter;
+      }
+    }
+
     return {
       dispose: () => {},
       hints: inlayHints.map((hint) => ({
@@ -412,6 +422,7 @@ class PlaygroundServer
           lineNumber: hint.position.line,
           column: hint.position.column,
         },
+        kind: mapInlayHintKind(hint.kind),
       })),
     };
   }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

Previously we just communicated that the inlay hint type was "TYPE", so now we give the correct type

