### PR TITLE
[ty] Disallow std::env and io methods in most ty crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,6 +215,8 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 
 [workspace.lints.clippy]
 pedantic = { level = "warn", priority = -2 }
+# Enabled at the crate level
+disallowed_methods = "allow"
 # Allowed pedantic lints
 char_lit_as_u8 = "allow"
 collapsible_else_if = "allow"
@@ -252,6 +254,7 @@ unused_peekable = "warn"
 
 # Diagnostics are not actionable: Enable once https://github.com/rust-lang/rust-clippy/issues/13774 is resolved.
 large_stack_arrays = "allow"
+
 
 [profile.release]
 # Note that we set these explicitly, and these values

--- a/clippy.toml
+++ b/clippy.toml
@@ -24,3 +24,20 @@ ignore-interior-mutability = [
     # The expression is read-only.
     "ruff_python_ast::hashable::HashableExpr",
 ]
+
+disallowed-methods = [
+    { path = "std::env::var", reason = "Use System::env_var instead in ty crates" },
+    { path = "std::env::current_dir", reason = "Use System::current_directory instead in ty crates" },
+    { path = "std::fs::read_to_string", reason = "Use System::read_to_string instead in ty crates" },
+    { path = "std::fs::metadata", reason = "Use System::path_metadata instead in ty crates" },
+    { path = "std::fs::canonicalize", reason = "Use System::canonicalize_path instead in ty crates" },
+    { path = "dunce::canonicalize", reason = "Use System::canonicalize_path instead in ty crates" },
+    { path = "std::fs::read_dir", reason = "Use System::read_directory instead in ty crates" },
+    { path = "std::fs::write", reason = "Use WritableSystem::write_file instead in ty crates" },
+    { path = "std::fs::create_dir_all", reason = "Use WritableSystem::create_directory_all instead in ty crates" },
+    { path = "std::fs::File::create_new", reason = "Use WritableSystem::create_new_file instead in ty crates" },
+    # Path methods that have System trait equivalents
+    { path = "std::path::Path::exists", reason = "Use System::path_exists instead in ty crates" },
+    { path = "std::path::Path::is_dir", reason = "Use System::is_directory instead in ty crates" },
+    { path = "std::path::Path::is_file", reason = "Use System::is_file instead in ty crates" },
+]

--- a/crates/ruff_db/src/lib.rs
+++ b/crates/ruff_db/src/lib.rs
@@ -1,3 +1,8 @@
+#![warn(
+    clippy::disallowed_methods,
+    reason = "Prefer System trait methods over std methods"
+)]
+
 use crate::files::Files;
 use crate::system::System;
 use crate::vendored::VendoredFileSystem;
@@ -65,6 +70,10 @@ pub trait Db: salsa::Database {
 /// to process work in parallel. For example, to index a directory or checking the files of a project.
 /// ty can still spawn more threads for other tasks, e.g. to wait for a Ctrl+C signal or
 /// watching the files for changes.
+#[expect(
+    clippy::disallowed_methods,
+    reason = "We don't have access to System here, but this is also only used by the CLI and the server which always run on a real system."
+)]
 pub fn max_parallelism() -> NonZeroUsize {
     std::env::var(EnvVars::TY_MAX_PARALLELISM)
         .or_else(|_| std::env::var(EnvVars::RAYON_NUM_THREADS))

--- a/crates/ruff_db/src/system.rs
+++ b/crates/ruff_db/src/system.rs
@@ -46,7 +46,7 @@ pub type Result<T> = std::io::Result<T>;
 ///    * File watching isn't supported.
 ///
 /// Abstracting the system also enables tests to use a more efficient in-memory file system.
-pub trait System: Debug {
+pub trait System: Debug + Sync + Send {
     /// Reads the metadata of the file or directory at `path`.
     ///
     /// This function will traverse symbolic links to query information about the destination file.
@@ -197,6 +197,8 @@ pub trait System: Debug {
     fn as_any(&self) -> &dyn std::any::Any;
 
     fn as_any_mut(&mut self) -> &mut dyn std::any::Any;
+
+    fn dyn_clone(&self) -> Box<dyn System>;
 }
 
 #[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]

--- a/crates/ruff_db/src/system/os.rs
+++ b/crates/ruff_db/src/system/os.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::disallowed_methods)]
+
 use super::walk_directory::{
     self, DirectoryWalker, WalkDirectoryBuilder, WalkDirectoryConfiguration,
     WalkDirectoryVisitorBuilder, WalkState,
@@ -254,6 +256,10 @@ impl System for OsSystem {
 
     fn env_var(&self, name: &str) -> std::result::Result<String, std::env::VarError> {
         std::env::var(name)
+    }
+
+    fn dyn_clone(&self) -> Box<dyn System> {
+        Box::new(self.clone())
     }
 }
 

--- a/crates/ruff_db/src/system/test.rs
+++ b/crates/ruff_db/src/system/test.rs
@@ -146,6 +146,10 @@ impl System for TestSystem {
     fn case_sensitivity(&self) -> CaseSensitivity {
         self.system().case_sensitivity()
     }
+
+    fn dyn_clone(&self) -> Box<dyn System> {
+        Box::new(self.clone())
+    }
 }
 
 impl Default for TestSystem {
@@ -393,6 +397,13 @@ impl System for InMemorySystem {
 
     fn case_sensitivity(&self) -> CaseSensitivity {
         CaseSensitivity::CaseSensitive
+    }
+
+    fn dyn_clone(&self) -> Box<dyn System> {
+        Box::new(Self {
+            user_config_directory: Mutex::new(self.user_config_directory.lock().unwrap().clone()),
+            memory_fs: self.memory_fs.clone(),
+        })
     }
 }
 

--- a/crates/ty_combine/src/lib.rs
+++ b/crates/ty_combine/src/lib.rs
@@ -1,3 +1,8 @@
+#![warn(
+    clippy::disallowed_methods,
+    reason = "Prefer System trait methods over std methods in ty crates"
+)]
+
 use std::{collections::HashMap, hash::BuildHasher};
 
 use ordermap::OrderMap;

--- a/crates/ty_ide/src/lib.rs
+++ b/crates/ty_ide/src/lib.rs
@@ -1,3 +1,7 @@
+#![warn(
+    clippy::disallowed_methods,
+    reason = "Prefer System trait methods over std methods in ty crates"
+)]
 mod completion;
 mod doc_highlights;
 mod docstring;

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -1,3 +1,7 @@
+#![warn(
+    clippy::disallowed_methods,
+    reason = "Prefer System trait methods over std methods in ty crates"
+)]
 use crate::glob::{GlobFilterCheckMode, IncludeResult};
 use crate::metadata::options::{OptionDiagnostic, ToSettingsError};
 use crate::walk::{ProjectFilesFilter, ProjectFilesWalker};

--- a/crates/ty_project/src/watch/watcher.rs
+++ b/crates/ty_project/src/watch/watcher.rs
@@ -1,3 +1,8 @@
+#![allow(
+    clippy::disallowed_methods,
+    reason = "This implementation is specific to real file systems."
+)]
+
 use notify::event::{CreateKind, MetadataKind, ModifyKind, RemoveKind, RenameMode};
 use notify::{EventKind, RecommendedWatcher, RecursiveMode, Watcher as _, recommended_watcher};
 

--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -1,3 +1,7 @@
+#![warn(
+    clippy::disallowed_methods,
+    reason = "Prefer System trait methods over std methods in ty crates"
+)]
 use std::hash::BuildHasherDefault;
 
 use rustc_hash::FxHasher;

--- a/crates/ty_server/src/system.rs
+++ b/crates/ty_server/src/system.rs
@@ -298,6 +298,10 @@ impl System for LSPSystem {
     fn env_var(&self, name: &str) -> std::result::Result<String, std::env::VarError> {
         self.native_system.env_var(name)
     }
+
+    fn dyn_clone(&self) -> Box<dyn System> {
+        Box::new(self.clone())
+    }
 }
 
 fn not_a_text_document(path: impl Display) -> std::io::Error {

--- a/crates/ty_static/src/lib.rs
+++ b/crates/ty_static/src/lib.rs
@@ -1,3 +1,7 @@
+#![warn(
+    clippy::disallowed_methods,
+    reason = "Prefer System trait methods over std methods in ty crates"
+)]
 pub use env_vars::*;
 
 mod env_vars;

--- a/crates/ty_test/src/db.rs
+++ b/crates/ty_test/src/db.rs
@@ -268,6 +268,10 @@ impl System for MdtestSystem {
     fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
         self
     }
+
+    fn dyn_clone(&self) -> Box<dyn System> {
+        Box::new(self.clone())
+    }
 }
 
 impl WritableSystem for MdtestSystem {

--- a/crates/ty_vendored/src/lib.rs
+++ b/crates/ty_vendored/src/lib.rs
@@ -1,3 +1,7 @@
+#![warn(
+    clippy::disallowed_methods,
+    reason = "Prefer System trait methods over std methods in ty crates"
+)]
 use ruff_db::vendored::VendoredFileSystem;
 use std::sync::LazyLock;
 

--- a/crates/ty_wasm/src/lib.rs
+++ b/crates/ty_wasm/src/lib.rs
@@ -1209,6 +1209,10 @@ impl System for WasmSystem {
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }
+
+    fn dyn_clone(&self) -> Box<dyn System> {
+        Box::new(self.clone())
+    }
 }
 
 fn not_found() -> std::io::Error {


### PR DESCRIPTION
## Summary

We use the `System` abstraction in ty to abstract away the host/system on which ty runs. 
This has a few benefits:

* Tests can run in full isolation using a memory system (that uses an in-memory file system)
* The LSP has a custom implementation where `read_to_string` returns the content as seen by the editor (e.g. unsaved changes) instead of always returning the content as it is stored on disk
* We don't require any file system polyfills for wasm in the browser


However, it does require extra care that we don't accidentially use `std::fs` or `std::env` (etc.) methods in ty's code base (which is very easy).

This PR sets up clippy and disallowes the most common methods and points users towards the corresponding `System` methods instead. 

The setup is a bit awkward because clippy doesn't support inheriting configurations. That means, a crate can only override the entire workspace conifguration or not at all. 
The approach taken in this PR is:

* Configure the disallowed methods at the workspace level
* Allow `disallowed_methods` at the workspace level
* Enable the lint at the crate level using the warn attribute (in code)


The obvious downside of this is that it won't work if we ever want to disallow other methods... but that's something we can figure out once we reach that point.

## Test Plan

Clippy found a place where we incorrectly used `std::fs::read_to_string`
