### PR TITLE
[ty] Add type as detail to completion items

### DIFF
--- a/crates/ty_server/src/server/api/requests/completion.rs
+++ b/crates/ty_server/src/server/api/requests/completion.rs
@@ -71,6 +71,7 @@ impl BackgroundDocumentRequestHandler for CompletionRequestHandler {
                     label: comp.inner.name.into(),
                     kind,
                     sort_text: Some(format!("{i:-max_index_len$}")),
+                    detail: comp.inner.ty.display(db).to_string().into(),
                     documentation: comp
                         .documentation
                         .map(|docstring| Documentation::String(docstring.render_plaintext())),

--- a/crates/ty_wasm/src/lib.rs
+++ b/crates/ty_wasm/src/lib.rs
@@ -425,6 +425,7 @@ impl Workspace {
                 documentation: completion
                     .documentation
                     .map(|documentation| documentation.render_plaintext()),
+                detail: completion.inner.ty.display(&self.db).to_string().into(),
             })
             .collect())
     }
@@ -914,6 +915,8 @@ pub struct Completion {
     pub kind: Option<CompletionKind>,
     #[wasm_bindgen(getter_with_clone)]
     pub documentation: Option<String>,
+    #[wasm_bindgen(getter_with_clone)]
+    pub detail: Option<String>,
 }
 
 #[wasm_bindgen]

--- a/playground/ty/src/Editor/Editor.tsx
+++ b/playground/ty/src/Editor/Editor.tsx
@@ -321,6 +321,7 @@ class PlaygroundServer
             : mapCompletionKind(completion.kind),
         insertText: completion.name,
         documentation: completion.documentation,
+        detail: completion.detail,
         // TODO(micha): It's unclear why this field is required for monaco but not VS Code.
         //  and omitting it works just fine? The LSP doesn't expose this information right now
         //  which is why we go with undefined for now.


### PR DESCRIPTION
## Summary

@BurntSushi was so kind as to find me an easy task to do some coding before I'm off to PTO. 

This PR adds the type to completion items (see the gray little text at the end of a completion item). 


https://github.com/user-attachments/assets/c0a86061-fa12-47b4-b43c-3c646771a69d



