### PR TITLE
[ty] Refactor inlay hints structure to use separate parts

### DIFF
--- a/crates/ty_ide/src/inlay_hints.rs
+++ b/crates/ty_ide/src/inlay_hints.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{fmt, vec};
 
 use crate::Db;
 use ruff_db::files::File;
@@ -18,11 +18,10 @@ pub struct InlayHint {
 
 impl InlayHint {
     fn type_hint(position: TextSize, ty: Type, db: &dyn Db) -> Self {
-        let mut label_parts = Vec::new();
-
-        label_parts.push(": ".into());
-
-        label_parts.push(InlayHintLabelPart::new(ty.display(db).to_string()));
+        let label_parts = vec![
+            InlayHintLabelPart::new(": ".into()),
+            InlayHintLabelPart::new(ty.display(db).to_string()),
+        ];
 
         Self {
             position,
@@ -32,11 +31,10 @@ impl InlayHint {
     }
 
     fn call_argument_name(position: TextSize, name: &str) -> Self {
-        let mut label_parts = Vec::new();
-
-        label_parts.push(InlayHintLabelPart::new(name.into()));
-
-        label_parts.push("=".into());
+        let label_parts = vec![
+            InlayHintLabelPart::new(name.into()),
+            InlayHintLabelPart::new("=".into()),
+        ];
 
         Self {
             position,

--- a/crates/ty_ide/src/inlay_hints.rs
+++ b/crates/ty_ide/src/inlay_hints.rs
@@ -15,7 +15,7 @@ pub struct InlayHint {
 }
 
 impl InlayHint {
-    pub fn type_hint<'db>(position: TextSize, ty: Type, db: &'db dyn Db) -> Self {
+    pub fn type_hint(position: TextSize, ty: Type, db: &dyn Db) -> Self {
         Self {
             position,
             kind: InlayHintKind::Type,
@@ -58,8 +58,8 @@ impl From<String> for InlayHintLabel {
     }
 }
 
-pub fn inlay_hints<'db>(
-    db: &'db dyn Db,
+pub fn inlay_hints(
+    db: &dyn Db,
     file: File,
     range: TextRange,
     settings: &InlayHintSettings,
@@ -138,7 +138,7 @@ impl<'a, 'db> InlayHintVisitor<'a, 'db> {
         self.hints.push(InlayHint::type_hint(position, ty, self.db));
     }
 
-    fn add_call_argument_name(&mut self, position: TextSize, name: String) {
+    fn add_call_argument_name(&mut self, position: TextSize, name: &str) {
         if !self.settings.call_argument_names {
             return;
         }
@@ -148,7 +148,7 @@ impl<'a, 'db> InlayHintVisitor<'a, 'db> {
         }
 
         self.hints
-            .push(InlayHint::call_argument_name(position, &name));
+            .push(InlayHint::call_argument_name(position, name));
     }
 }
 
@@ -214,10 +214,7 @@ impl SourceOrderVisitor<'_> for InlayHintVisitor<'_, '_> {
 
                 for (index, arg_or_keyword) in call.arguments.arguments_source_order().enumerate() {
                     if let Some(name) = argument_names.get(&index) {
-                        self.add_call_argument_name(
-                            arg_or_keyword.range().start(),
-                            name.to_string(),
-                        );
+                        self.add_call_argument_name(arg_or_keyword.range().start(), name);
                     }
                     self.visit_expr(arg_or_keyword.value());
                 }

--- a/crates/ty_ide/src/inlay_hints.rs
+++ b/crates/ty_ide/src/inlay_hints.rs
@@ -55,7 +55,7 @@ pub enum InlayHintKind {
 
 #[derive(Debug, Clone)]
 pub struct InlayHintLabel {
-    pub parts: SmallVec<[InlayHintLabelPart; 1]>,
+    pub parts: SmallVec<[InlayHintLabelPart; 2]>,
 }
 
 impl InlayHintLabel {

--- a/crates/ty_ide/src/inlay_hints.rs
+++ b/crates/ty_ide/src/inlay_hints.rs
@@ -19,7 +19,7 @@ pub struct InlayHint {
 impl InlayHint {
     fn variable_type(position: TextSize, ty: Type, db: &dyn Db) -> Self {
         let label_parts = vec![
-            InlayHintLabelPart::new(": "),
+            ": ".into(),
             InlayHintLabelPart::new(ty.display(db).to_string()),
         ];
 
@@ -31,7 +31,7 @@ impl InlayHint {
     }
 
     fn call_argument_name(position: TextSize, name: &str) -> Self {
-        let label_parts = vec![InlayHintLabelPart::new(name), InlayHintLabelPart::new("=")];
+        let label_parts = vec![InlayHintLabelPart::new(name), "=".into()];
 
         Self {
             position,

--- a/crates/ty_ide/src/inlay_hints.rs
+++ b/crates/ty_ide/src/inlay_hints.rs
@@ -6,7 +6,6 @@ use ruff_db::parsed::parsed_module;
 use ruff_python_ast::visitor::source_order::{self, SourceOrderVisitor, TraversalSignal};
 use ruff_python_ast::{AnyNodeRef, Expr, Stmt};
 use ruff_text_size::{Ranged, TextRange, TextSize};
-use smallvec::{SmallVec, smallvec};
 use ty_python_semantic::types::{Type, inlay_hint_function_argument_details};
 use ty_python_semantic::{HasType, SemanticModel};
 
@@ -55,13 +54,13 @@ pub enum InlayHintKind {
 
 #[derive(Debug, Clone)]
 pub struct InlayHintLabel {
-    pub parts: SmallVec<[InlayHintLabelPart; 2]>,
+    pub parts: Vec<InlayHintLabelPart>,
 }
 
 impl InlayHintLabel {
     pub fn simple(s: impl Into<String>, target: Option<crate::NavigationTarget>) -> InlayHintLabel {
         InlayHintLabel {
-            parts: smallvec![InlayHintLabelPart {
+            parts: vec![InlayHintLabelPart {
                 text: s.into(),
                 target,
             }],
@@ -95,7 +94,7 @@ impl InlayHintLabel {
 impl From<String> for InlayHintLabel {
     fn from(s: String) -> Self {
         Self {
-            parts: smallvec![InlayHintLabelPart {
+            parts: vec![InlayHintLabelPart {
                 text: s,
                 target: None,
             }],

--- a/crates/ty_ide/src/inlay_hints.rs
+++ b/crates/ty_ide/src/inlay_hints.rs
@@ -17,9 +17,9 @@ pub struct InlayHint {
 }
 
 impl InlayHint {
-    fn type_hint(position: TextSize, ty: Type, db: &dyn Db) -> Self {
+    fn variable_type(position: TextSize, ty: Type, db: &dyn Db) -> Self {
         let label_parts = vec![
-            InlayHintLabelPart::new(": ".into()),
+            InlayHintLabelPart::new(": "),
             InlayHintLabelPart::new(ty.display(db).to_string()),
         ];
 
@@ -31,10 +31,7 @@ impl InlayHint {
     }
 
     fn call_argument_name(position: TextSize, name: &str) -> Self {
-        let label_parts = vec![
-            InlayHintLabelPart::new(name.into()),
-            InlayHintLabelPart::new("=".into()),
-        ];
+        let label_parts = vec![InlayHintLabelPart::new(name), InlayHintLabelPart::new("=")];
 
         Self {
             position,
@@ -86,8 +83,11 @@ pub struct InlayHintLabelPart {
 }
 
 impl InlayHintLabelPart {
-    pub fn new(text: String) -> Self {
-        Self { text, target: None }
+    pub fn new(text: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            target: None,
+        }
     }
 
     pub fn text(&self) -> &str {
@@ -194,7 +194,8 @@ impl<'a, 'db> InlayHintVisitor<'a, 'db> {
         if !self.settings.variable_types {
             return;
         }
-        self.hints.push(InlayHint::type_hint(position, ty, self.db));
+        self.hints
+            .push(InlayHint::variable_type(position, ty, self.db));
     }
 
     fn add_call_argument_name(&mut self, position: TextSize, name: &str) {

--- a/crates/ty_ide/src/lib.rs
+++ b/crates/ty_ide/src/lib.rs
@@ -26,7 +26,7 @@ pub use document_symbols::{document_symbols, document_symbols_with_options};
 pub use goto::{goto_declaration, goto_definition, goto_type_definition};
 pub use goto_references::goto_references;
 pub use hover::hover;
-pub use inlay_hints::{InlayHintContent, InlayHintSettings, inlay_hints};
+pub use inlay_hints::{InlayHintKind, InlayHintLabel, InlayHintSettings, inlay_hints};
 pub use markup::MarkupKind;
 pub use references::ReferencesMode;
 pub use rename::{can_rename, rename};

--- a/crates/ty_server/src/server/api/requests/inlay_hints.rs
+++ b/crates/ty_server/src/server/api/requests/inlay_hints.rs
@@ -9,7 +9,7 @@ use crate::session::client::Client;
 use lsp_types::request::InlayHintRequest;
 use lsp_types::{InlayHintParams, Url};
 use ruff_db::source::{line_index, source_text};
-use ty_ide::{InlayHintContent, inlay_hints};
+use ty_ide::{InlayHintKind, InlayHintLabel, inlay_hints};
 use ty_project::ProjectDatabase;
 
 pub(crate) struct InlayHintRequestHandler;
@@ -55,8 +55,8 @@ impl BackgroundDocumentRequestHandler for InlayHintRequestHandler {
                 position: hint
                     .position
                     .to_position(&source, &index, snapshot.encoding()),
-                label: lsp_types::InlayHintLabel::String(hint.display(db).to_string()),
-                kind: Some(inlay_hint_kind(&hint.content)),
+                label: inlay_hint_label(&hint.label),
+                kind: Some(inlay_hint_kind(&hint.kind)),
                 tooltip: None,
                 padding_left: None,
                 padding_right: None,
@@ -71,9 +71,18 @@ impl BackgroundDocumentRequestHandler for InlayHintRequestHandler {
 
 impl RetriableRequestHandler for InlayHintRequestHandler {}
 
-fn inlay_hint_kind(inlay_hint_content: &InlayHintContent) -> lsp_types::InlayHintKind {
-    match inlay_hint_content {
-        InlayHintContent::Type(_) => lsp_types::InlayHintKind::TYPE,
-        InlayHintContent::CallArgumentName(_) => lsp_types::InlayHintKind::PARAMETER,
+fn inlay_hint_kind(inlay_hint_kind: &InlayHintKind) -> lsp_types::InlayHintKind {
+    match inlay_hint_kind {
+        InlayHintKind::Type => lsp_types::InlayHintKind::TYPE,
+        InlayHintKind::CallArgumentName => lsp_types::InlayHintKind::PARAMETER,
     }
+}
+
+fn inlay_hint_label(inlay_hint_label: &InlayHintLabel) -> lsp_types::InlayHintLabel {
+    lsp_types::InlayHintLabel::LabelParts(vec![lsp_types::InlayHintLabelPart {
+        value: inlay_hint_label.text.clone(),
+        location: None,
+        tooltip: None,
+        command: None,
+    }])
 }

--- a/crates/ty_server/src/server/api/requests/inlay_hints.rs
+++ b/crates/ty_server/src/server/api/requests/inlay_hints.rs
@@ -79,10 +79,14 @@ fn inlay_hint_kind(inlay_hint_kind: &InlayHintKind) -> lsp_types::InlayHintKind 
 }
 
 fn inlay_hint_label(inlay_hint_label: &InlayHintLabel) -> lsp_types::InlayHintLabel {
-    lsp_types::InlayHintLabel::LabelParts(vec![lsp_types::InlayHintLabelPart {
-        value: inlay_hint_label.text.clone(),
-        location: None,
-        tooltip: None,
-        command: None,
-    }])
+    let mut label_parts = Vec::new();
+    for part in &inlay_hint_label.parts {
+        label_parts.push(lsp_types::InlayHintLabelPart {
+            value: part.text.clone(),
+            location: None,
+            tooltip: None,
+            command: None,
+        });
+    }
+    lsp_types::InlayHintLabel::LabelParts(label_parts)
 }

--- a/crates/ty_server/src/server/api/requests/inlay_hints.rs
+++ b/crates/ty_server/src/server/api/requests/inlay_hints.rs
@@ -80,9 +80,9 @@ fn inlay_hint_kind(inlay_hint_kind: &InlayHintKind) -> lsp_types::InlayHintKind 
 
 fn inlay_hint_label(inlay_hint_label: &InlayHintLabel) -> lsp_types::InlayHintLabel {
     let mut label_parts = Vec::new();
-    for part in &inlay_hint_label.parts {
+    for part in inlay_hint_label.parts() {
         label_parts.push(lsp_types::InlayHintLabelPart {
-            value: part.text.clone(),
+            value: part.text().into(),
             location: None,
             tooltip: None,
             command: None,

--- a/crates/ty_server/tests/e2e/inlay_hints.rs
+++ b/crates/ty_server/tests/e2e/inlay_hints.rs
@@ -42,7 +42,11 @@ foo(1)
           "line": 0,
           "character": 1
         },
-        "label": ": Literal[1]",
+        "label": [
+          {
+            "value": ": Literal[1]"
+          }
+        ],
         "kind": 1
       },
       {
@@ -50,7 +54,11 @@ foo(1)
           "line": 5,
           "character": 4
         },
-        "label": "a=",
+        "label": [
+          {
+            "value": "a="
+          }
+        ],
         "kind": 2
       }
     ]

--- a/crates/ty_server/tests/e2e/inlay_hints.rs
+++ b/crates/ty_server/tests/e2e/inlay_hints.rs
@@ -44,7 +44,10 @@ foo(1)
         },
         "label": [
           {
-            "value": ": Literal[1]"
+            "value": ": "
+          },
+          {
+            "value": "Literal[1]"
           }
         ],
         "kind": 1
@@ -56,7 +59,10 @@ foo(1)
         },
         "label": [
           {
-            "value": "a="
+            "value": "a"
+          },
+          {
+            "value": "="
           }
         ],
         "kind": 2

--- a/crates/ty_wasm/src/lib.rs
+++ b/crates/ty_wasm/src/lib.rs
@@ -448,7 +448,7 @@ impl Workspace {
         Ok(result
             .into_iter()
             .map(|hint| InlayHint {
-                markdown: hint.display().to_string(),
+                markdown: hint.display(),
                 position: Position::from_text_size(
                     hint.position,
                     &index,

--- a/crates/ty_wasm/src/lib.rs
+++ b/crates/ty_wasm/src/lib.rs
@@ -448,14 +448,14 @@ impl Workspace {
         Ok(result
             .into_iter()
             .map(|hint| InlayHint {
-                markdown: hint.display(&self.db).to_string(),
+                markdown: hint.display().to_string(),
                 position: Position::from_text_size(
                     hint.position,
                     &index,
                     &source,
                     self.position_encoding,
                 ),
-                kind: hint.content.into(),
+                kind: hint.kind.into(),
             })
             .collect())
     }
@@ -985,11 +985,11 @@ pub enum InlayHintKind {
     Parameter,
 }
 
-impl From<ty_ide::InlayHintContent<'_>> for InlayHintKind {
-    fn from(kind: ty_ide::InlayHintContent) -> Self {
+impl From<ty_ide::InlayHintKind> for InlayHintKind {
+    fn from(kind: ty_ide::InlayHintKind) -> Self {
         match kind {
-            ty_ide::InlayHintContent::Type(_) => Self::Type,
-            ty_ide::InlayHintContent::CallArgumentName(_) => Self::Parameter,
+            ty_ide::InlayHintKind::Type => Self::Type,
+            ty_ide::InlayHintKind::CallArgumentName => Self::Parameter,
         }
     }
 }

--- a/crates/ty_wasm/src/lib.rs
+++ b/crates/ty_wasm/src/lib.rs
@@ -448,7 +448,7 @@ impl Workspace {
         Ok(result
             .into_iter()
             .map(|hint| InlayHint {
-                markdown: hint.display(),
+                markdown: hint.display().to_string(),
                 position: Position::from_text_size(
                     hint.position,
                     &index,


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

Our internal inlay hints structure (`ty_ide::InlayHint`) now more closely resembles `lsp_types::InlayHint`.

This mainly allows us to convert to `lsp_types::InlayHint` with less hassle, but it also allows us to manage the different parts of the inlay hint better, which in the future will allow us to implement features like goto on the type part of the type inlay hint.

It also really isn't important to store a specific `Type` instance in the `InlayHintContent`. So we remove this and use `InlayHintLabel` instead which just shows the representation of the type (along with other information). 

We see a similar structure used in rust-analyzer too. 
