### PR TITLE
[ty] Remove duplicate global lint registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2935,6 +2935,7 @@ dependencies = [
  "tracing-subscriber",
  "ty",
  "ty_project",
+ "ty_python_semantic",
  "ty_static",
  "url",
 ]

--- a/crates/ruff_dev/Cargo.toml
+++ b/crates/ruff_dev/Cargo.toml
@@ -13,6 +13,7 @@ license = { workspace = true }
 [dependencies]
 ty = { workspace = true }
 ty_project = { workspace = true, features = ["schemars"] }
+ty_python_semantic = { workspace = true }
 ty_static = { workspace = true }
 ruff = { workspace = true }
 ruff_formatter = { workspace = true }

--- a/crates/ruff_dev/src/generate_ty_rules.rs
+++ b/crates/ruff_dev/src/generate_ty_rules.rs
@@ -52,7 +52,7 @@ pub(crate) fn main(args: &Args) -> Result<()> {
 }
 
 fn generate_markdown() -> String {
-    let registry = &*ty_project::DEFAULT_LINT_REGISTRY;
+    let registry = ty_python_semantic::default_lint_registry();
 
     let mut output = String::new();
 

--- a/crates/ty_project/src/db.rs
+++ b/crates/ty_project/src/db.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 use std::{cmp, fmt};
 
 pub use self::changes::ChangeResult;
+use crate::CollectReporter;
 use crate::metadata::settings::file_settings;
-use crate::{CollectReporter, DEFAULT_LINT_REGISTRY};
 use crate::{ProgressReporter, Project, ProjectMetadata};
 use ruff_db::Db as SourceDb;
 use ruff_db::diagnostic::Diagnostic;
@@ -455,7 +455,7 @@ impl SemanticDb for ProjectDatabase {
     }
 
     fn lint_registry(&self) -> &LintRegistry {
-        &DEFAULT_LINT_REGISTRY
+        ty_python_semantic::default_lint_registry()
     }
 }
 
@@ -518,7 +518,6 @@ pub(crate) mod tests {
     use ty_python_semantic::Program;
     use ty_python_semantic::lint::{LintRegistry, RuleSelection};
 
-    use crate::DEFAULT_LINT_REGISTRY;
     use crate::db::Db;
     use crate::{Project, ProjectMetadata};
 
@@ -608,7 +607,7 @@ pub(crate) mod tests {
         }
 
         fn lint_registry(&self) -> &LintRegistry {
-            &DEFAULT_LINT_REGISTRY
+            ty_python_semantic::default_lint_registry()
         }
     }
 

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -28,9 +28,9 @@ use std::panic::{AssertUnwindSafe, UnwindSafe};
 use std::sync::Arc;
 use thiserror::Error;
 use tracing::error;
-use ty_python_semantic::lint::{LintRegistry, LintRegistryBuilder, RuleSelection};
+use ty_python_semantic::add_inferred_python_version_hint_to_diagnostic;
+use ty_python_semantic::lint::RuleSelection;
 use ty_python_semantic::types::check_types;
-use ty_python_semantic::{add_inferred_python_version_hint_to_diagnostic, register_lints};
 
 mod db;
 mod files;
@@ -38,15 +38,6 @@ mod glob;
 pub mod metadata;
 mod walk;
 pub mod watch;
-
-pub static DEFAULT_LINT_REGISTRY: std::sync::LazyLock<LintRegistry> =
-    std::sync::LazyLock::new(default_lints_registry);
-
-pub fn default_lints_registry() -> LintRegistry {
-    let mut builder = LintRegistryBuilder::default();
-    register_lints(&mut builder);
-    builder.build()
-}
 
 /// The project as a Salsa ingredient.
 ///

--- a/crates/ty_project/src/metadata/options.rs
+++ b/crates/ty_project/src/metadata/options.rs
@@ -1457,7 +1457,6 @@ impl std::error::Error for ToSettingsError {}
 
 #[cfg(feature = "schemars")]
 mod schema {
-    use crate::DEFAULT_LINT_REGISTRY;
     use schemars::JsonSchema;
     use schemars::r#gen::SchemaGenerator;
     use schemars::schema::{
@@ -1473,7 +1472,7 @@ mod schema {
         }
 
         fn json_schema(generator: &mut SchemaGenerator) -> Schema {
-            let registry = &*DEFAULT_LINT_REGISTRY;
+            let registry = ty_python_semantic::default_lint_registry();
 
             let level_schema = generator.subschema_for::<Level>();
 


### PR DESCRIPTION
## Summary

Looks like an oversight at some point that led to two identical globals, the one in `ty_project` just calls `ty_python_semantic::register_lints`.