### PR TITLE
[ty] Update mypy_primer, add egglog-python project

### DIFF
--- a/crates/ty_python_semantic/resources/primer/good.txt
+++ b/crates/ty_python_semantic/resources/primer/good.txt
@@ -39,6 +39,7 @@ django-stubs
 downforeveryone
 dragonchain
 dulwich
+egglog-python
 flake8
 flake8-pyi
 freqtrade

--- a/scripts/mypy_primer.sh
+++ b/scripts/mypy_primer.sh
@@ -20,7 +20,7 @@ cd ..
 echo "Project selector: ${PRIMER_SELECTOR}"
 # Allow the exit code to be 0 or 1, only fail for actual mypy_primer crashes/bugs
 uvx \
-  --from="git+https://github.com/hauntsaninja/mypy_primer@a3798a3d7b8470603e650179b0f82deb2154364d" \
+  --from="git+https://github.com/hauntsaninja/mypy_primer@830b80cb00dc8ffee20a7ddcad8d6a13b09c18ed" \
   mypy_primer \
   --repo ruff \
   --type-checker ty \


### PR DESCRIPTION
Now that https://github.com/astral-sh/ruff/pull/20263 is merged, we can update mypy_primer and add the new `egglog-python` project to `good.txt`. The ecosystem-analyzer run shows that we now add 1,356 diagnostics (where we had over 5,000 previously, due to the unsupported project layout).