### PR TITLE
[ty] support PEP 613 type aliases

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/unsupported_special_forms.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/unsupported_special_forms.md
@@ -16,7 +16,7 @@ Alias: TypeAlias = int
 
 def f(*args: Unpack[Ts]) -> tuple[Unpack[Ts]]:
     reveal_type(args)  # revealed: tuple[@Todo(`Unpack[]` special form), ...]
-    reveal_type(Alias)  # revealed: @Todo(Support for `typing.TypeAlias`)
+    reveal_type(Alias)  # revealed: Alias
     return args
 
 def g() -> TypeGuard[int]: ...

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -2187,9 +2187,9 @@ reveal_type(False.real)  # revealed: Literal[0]
 All attribute access on literal `bytes` types is currently delegated to `builtins.bytes`:
 
 ```py
-# revealed: bound method Literal[b"foo"].join(iterable_of_bytes: Iterable[@Todo(Support for `typing.TypeAlias`)], /) -> bytes
+# revealed: bound method Literal[b"foo"].join(iterable_of_bytes: Iterable[Buffer], /) -> bytes
 reveal_type(b"foo".join)
-# revealed: bound method Literal[b"foo"].endswith(suffix: @Todo(Support for `typing.TypeAlias`) | tuple[@Todo(Support for `typing.TypeAlias`), ...], start: SupportsIndex | None = None, end: SupportsIndex | None = None, /) -> bool
+# revealed: bound method Literal[b"foo"].endswith(suffix: Buffer | tuple[Buffer, ...], start: SupportsIndex | None = None, end: SupportsIndex | None = None, /) -> bool
 reveal_type(b"foo".endswith)
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/binary/instances.md
+++ b/crates/ty_python_semantic/resources/mdtest/binary/instances.md
@@ -313,8 +313,7 @@ reveal_type(A() + "foo")  # revealed: A
 reveal_type("foo" + A())  # revealed: A
 
 reveal_type(A() + b"foo")  # revealed: A
-# TODO should be `A` since `bytes.__add__` doesn't support `A` instances
-reveal_type(b"foo" + A())  # revealed: bytes
+reveal_type(b"foo" + A())  # revealed: A
 
 reveal_type(A() + ())  # revealed: A
 reveal_type(() + A())  # revealed: A

--- a/crates/ty_python_semantic/resources/mdtest/binary/integers.md
+++ b/crates/ty_python_semantic/resources/mdtest/binary/integers.md
@@ -54,10 +54,8 @@ reveal_type(2**largest_u32)  # revealed: int
 
 def variable(x: int):
     reveal_type(x**2)  # revealed: int
-    # TODO: should be `Any` (overload 5 on `__pow__`), requires correct overload matching
-    reveal_type(2**x)  # revealed: int
-    # TODO: should be `Any` (overload 5 on `__pow__`), requires correct overload matching
-    reveal_type(x**x)  # revealed: int
+    reveal_type(2**x)  # revealed: Any
+    reveal_type(x**x)  # revealed: Any
 ```
 
 If the second argument is \<0, a `float` is returned at runtime. If the first argument is \<0 but

--- a/crates/ty_python_semantic/resources/mdtest/expression/lambda.md
+++ b/crates/ty_python_semantic/resources/mdtest/expression/lambda.md
@@ -127,7 +127,7 @@ x = lambda y: y
 reveal_type(x.__code__)  # revealed: CodeType
 reveal_type(x.__name__)  # revealed: str
 reveal_type(x.__defaults__)  # revealed: tuple[Any, ...] | None
-reveal_type(x.__annotations__)  # revealed: dict[str, @Todo(Support for `typing.TypeAlias`)]
+reveal_type(x.__annotations__)  # revealed: dict[str, AnnotationForm]
 reveal_type(x.__dict__)  # revealed: dict[str, Any]
 reveal_type(x.__doc__)  # revealed: str | None
 reveal_type(x.__kwdefaults__)  # revealed: dict[str, Any] | None

--- a/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -146,13 +146,11 @@ def _(flag: bool):
 def _(flag: bool):
     x = 1 if flag else "a"
 
-    # TODO: this should cause us to emit a diagnostic during
-    # type checking
+    # error: [invalid-argument-type]
     if isinstance(x, "a"):
         reveal_type(x)  # revealed: Literal[1, "a"]
 
-    # TODO: this should cause us to emit a diagnostic during
-    # type checking
+    # error: [invalid-argument-type]
     if isinstance(x, "int"):
         reveal_type(x)  # revealed: Literal[1, "a"]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/narrow/issubclass.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/issubclass.md
@@ -214,19 +214,12 @@ def flag() -> bool:
 
 t = int if flag() else str
 
-# TODO: this should cause us to emit a diagnostic during
-# type checking
+# error: [invalid-argument-type]
 if issubclass(t, "str"):
     reveal_type(t)  # revealed: <class 'int'> | <class 'str'>
 
-# TODO: this should cause us to emit a diagnostic during
-# type checking
+# TODO error: [invalid-argument-type]
 if issubclass(t, (bytes, "str")):
-    reveal_type(t)  # revealed: <class 'int'> | <class 'str'>
-
-# TODO: this should cause us to emit a diagnostic during
-# type checking
-if issubclass(t, Any):
     reveal_type(t)  # revealed: <class 'int'> | <class 'str'>
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/pep613_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep613_type_aliases.md
@@ -1,0 +1,272 @@
+# PEP 613 explicit type aliases
+
+```toml
+[environment]
+python-version = "3.10"
+```
+
+Explicit type aliases were introduced in PEP 613. They are defined using an annotated-assignment
+statement, annotated with `typing.TypeAlias`:
+
+## Basic
+
+```py
+from typing import TypeAlias
+
+MyInt: TypeAlias = int
+
+def f(x: MyInt):
+    reveal_type(x)  # revealed: int
+
+f(1)
+```
+
+## Union
+
+For more complex type aliases, such as those involving unions or generics, the inferred value type
+of the right-hand side is not a valid type for use in a type expression, and we need to infer it as
+a type expression.
+
+### Old syntax
+
+```py
+from typing import TypeAlias, Union
+
+IntOrStr: TypeAlias = Union[int, str]
+
+def f(x: IntOrStr):
+    reveal_type(x)  # revealed: int | str
+    if isinstance(x, int):
+        reveal_type(x)  # revealed: int
+    else:
+        reveal_type(x)  # revealed: str
+
+f(1)
+f("foo")
+```
+
+### New syntax
+
+```py
+from typing import TypeAlias
+
+IntOrStr: TypeAlias = int | str
+
+def f(x: IntOrStr):
+    reveal_type(x)  # revealed: int | str
+    if isinstance(x, int):
+        reveal_type(x)  # revealed: int
+    else:
+        reveal_type(x)  # revealed: str
+
+f(1)
+f("foo")
+```
+
+### Name resolution is not deferred
+
+Unlike with a PEP 695 type alias, the right-hand side of a PEP 613 type alias is evaluated
+immediately, name resolution is not deferred.
+
+```py
+from typing import TypeAlias
+
+A: TypeAlias = B | None  # error: [unresolved-reference]
+B: TypeAlias = int
+
+def _(a: A):
+    reveal_type(a)  # revealed: Unknown | None
+```
+
+## Multiple layers of union aliases
+
+```py
+from typing import TypeAlias
+
+class A: ...
+class B: ...
+class C: ...
+class D: ...
+
+W: TypeAlias = A | B
+X: TypeAlias = C | D
+Y: TypeAlias = W | X
+
+from ty_extensions import is_equivalent_to, static_assert
+
+static_assert(is_equivalent_to(Y, A | B | C | D))
+```
+
+## Cycles
+
+We also support cyclic type aliases:
+
+### Old syntax
+
+```py
+from typing import Union, TypeAlias
+
+MiniJSON: TypeAlias = Union[int, str, list["MiniJSON"]]
+
+def f(x: MiniJSON):
+    reveal_type(x)  # revealed: int | str | list[MiniJSON]
+    if isinstance(x, int):
+        reveal_type(x)  # revealed: int
+    elif isinstance(x, str):
+        reveal_type(x)  # revealed: str
+    else:
+        reveal_type(x)  # revealed: list[MiniJSON]
+
+f(1)
+f("foo")
+f([1, "foo"])
+```
+
+### New syntax
+
+```py
+from typing import TypeAlias
+
+MiniJSON: TypeAlias = int | str | list["MiniJSON"]
+
+def f(x: MiniJSON):
+    reveal_type(x)  # revealed: int | str | list[MiniJSON]
+    if isinstance(x, int):
+        reveal_type(x)  # revealed: int
+    elif isinstance(x, str):
+        reveal_type(x)  # revealed: str
+    else:
+        reveal_type(x)  # revealed: list[MiniJSON]
+
+f(1)
+f("foo")
+f([1, "foo"])
+```
+
+### Generic
+
+```py
+from typing import TypeAlias, Generic, TypeVar, Union
+
+T = TypeVar("T")
+
+Alias: TypeAlias = Union[list["Alias"], int]
+
+class A(Generic[T]):
+    pass
+
+class B(A[Alias]):
+    pass
+```
+
+### Mutually recursive
+
+```py
+from typing import TypeAlias
+
+A: TypeAlias = tuple["B"] | None
+B: TypeAlias = tuple[A] | None
+
+def f(x: A):
+    if x is not None:
+        reveal_type(x)  # revealed: tuple[B]
+        y = x[0]
+        if y is not None:
+            reveal_type(y)  # revealed: tuple[A]
+
+def g(x: A | B):
+    reveal_type(x)  # revealed: tuple[B] | None
+
+from ty_extensions import Intersection
+
+def h(x: Intersection[A, B]):
+    reveal_type(x)  # revealed: tuple[B] | None
+```
+
+### Self-recursive callable type
+
+```py
+from typing import Callable, TypeAlias
+
+C: TypeAlias = Callable[[], "C" | None]
+
+def _(x: C):
+    reveal_type(x)  # revealed: () -> C | None
+```
+
+### Union inside generic
+
+#### With old-style union
+
+```py
+from typing import Union, TypeAlias
+
+A: TypeAlias = list[Union["A", str]]
+
+def f(x: A):
+    reveal_type(x)  # revealed: list[A | str]
+    for item in x:
+        reveal_type(item)  # revealed: list[A | str] | str
+```
+
+#### With new-style union
+
+```py
+from typing import TypeAlias
+
+A: TypeAlias = list["A" | str]
+
+def f(x: A):
+    reveal_type(x)  # revealed: list[A | str]
+    for item in x:
+        reveal_type(item)  # revealed: list[A | str] | str
+```
+
+#### With Optional
+
+```py
+from typing import Optional, Union, TypeAlias
+
+A: TypeAlias = list[Optional[Union["A", str]]]
+
+def f(x: A):
+    reveal_type(x)  # revealed: list[A | str | None]
+    for item in x:
+        reveal_type(item)  # revealed: list[A | str | None] | str | None
+```
+
+### Invalid examples
+
+#### No value
+
+```py
+from typing import TypeAlias
+
+# TODO: error
+Bad: TypeAlias
+
+# Nested function so we don't emit unresolved-reference for `Bad`:
+def _():
+    def f(x: Bad):
+        reveal_type(x)  # revealed: Unknown
+```
+
+#### No value, in stub
+
+`stub.pyi`:
+
+```pyi
+from typing import TypeAlias
+
+# TODO: error
+Bad: TypeAlias
+```
+
+`main.py`:
+
+```py
+from stub import Bad
+
+def f(x: Bad):
+    reveal_type(x)  # revealed: Unknown
+```

--- a/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
@@ -28,7 +28,7 @@ def f() -> None:
 ```py
 type IntOrStr = int | str
 
-reveal_type(IntOrStr.__value__)  # revealed: @Todo(Support for `typing.TypeAlias`)
+reveal_type(IntOrStr.__value__)  # revealed: Any
 ```
 
 ## Invalid assignment

--- a/crates/ty_python_semantic/resources/mdtest/subscript/tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/subscript/tuple.md
@@ -147,8 +147,8 @@ But perhaps the most commonly used tuple subclass instance is the singleton `sys
 ```py
 import sys
 
-# revealed: Overload[(self, index: Literal[-5, 0], /) -> Literal[3], (self, index: Literal[-4, 1], /) -> Literal[11], (self, index: Literal[-3, -1, 2, 4], /) -> int, (self, index: Literal[-2, 3], /) -> Literal["alpha", "beta", "candidate", "final"], (self, index: SupportsIndex, /) -> int | Literal["alpha", "beta", "candidate", "final"], (self, index: slice[Any, Any, Any], /) -> tuple[int | Literal["alpha", "beta", "candidate", "final"], ...]]
-reveal_type(type(sys.version_info).__getitem__)
+# TODO revealed: Overload[(self, index: Literal[-5, 0], /) -> Literal[3], (self, index: Literal[-4, 1], /) -> Literal[11], (self, index: Literal[-3, -1, 2, 4], /) -> int, (self, index: Literal[-2, 3], /) -> Literal["alpha", "beta", "candidate", "final"], (self, index: SupportsIndex, /) -> int | Literal["alpha", "beta", "candidate", "final"], (self, index: slice[Any, Any, Any], /) -> tuple[int | Literal["alpha", "beta", "candidate", "final"], ...]]
+reveal_type(type(sys.version_info).__getitem__)  # revealed: Unknown
 ```
 
 Because of the synthesized `__getitem__` overloads we synthesize for tuples and tuple subclasses,

--- a/crates/ty_python_semantic/resources/mdtest/sys_version_info.md
+++ b/crates/ty_python_semantic/resources/mdtest/sys_version_info.md
@@ -122,7 +122,7 @@ properties on instance types:
 
 ```py
 reveal_type(sys.version_info.micro)  # revealed: int
-reveal_type(sys.version_info.releaselevel)  # revealed: @Todo(Support for `typing.TypeAlias`)
+reveal_type(sys.version_info.releaselevel)  # revealed: Literal["alpha", "beta", "candidate", "final"]
 reveal_type(sys.version_info.serial)  # revealed: int
 ```
 

--- a/crates/ty_python_semantic/src/semantic_index/definition.rs
+++ b/crates/ty_python_semantic/src/semantic_index/definition.rs
@@ -693,6 +693,15 @@ impl DefinitionKind<'_> {
         }
     }
 
+    pub(crate) const fn as_annotated_assignment(
+        &self,
+    ) -> Option<&AnnotatedAssignmentDefinitionKind> {
+        match self {
+            DefinitionKind::AnnotatedAssignment(annotated_assignment) => Some(annotated_assignment),
+            _ => None,
+        }
+    }
+
     pub(crate) fn is_import(&self) -> bool {
         matches!(
             self,

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -11785,7 +11785,7 @@ pub(super) fn determine_upper_bound<'db>(
 // Make sure that the `Type` enum does not grow unexpectedly.
 #[cfg(not(debug_assertions))]
 #[cfg(target_pointer_width = "64")]
-static_assertions::assert_eq_size!(Type, [u8; 16]);
+static_assertions::assert_eq_size!(Type, [u8; 24]);
 
 #[cfg(test)]
 pub(crate) mod tests {

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -34,7 +34,7 @@ use crate::types::visitor::{NonAtomicType, TypeKind, TypeVisitor, walk_non_atomi
 use crate::types::{
     ApplyTypeMappingVisitor, Binding, BoundSuperType, CallableType, DataclassParams,
     DeprecatedInstance, FindLegacyTypeVarsVisitor, HasRelationToVisitor, IsDisjointVisitor,
-    IsEquivalentVisitor, KnownInstanceType, ManualPEP695TypeAliasType, MaterializationKind,
+    IsEquivalentVisitor, KnownInstanceType, ManualPEP695TypeAlias, MaterializationKind,
     NormalizedVisitor, PropertyInstanceType, StringLiteralType, TypeAliasType, TypeContext,
     TypeMapping, TypeRelation, TypedDictParams, UnionBuilder, VarianceInferable, declaration_type,
     determine_upper_bound, infer_definition_types,
@@ -5328,7 +5328,7 @@ impl KnownClass {
                     return;
                 };
                 overload.set_return_type(Type::KnownInstance(KnownInstanceType::TypeAliasType(
-                    TypeAliasType::ManualPEP695(ManualPEP695TypeAliasType::new(
+                    TypeAliasType::ManualPEP695(ManualPEP695TypeAlias::new(
                         db,
                         ast::name::Name::new(name.value(db)),
                         containing_assignment,

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -49,10 +49,7 @@ impl<'db> ClassBase<'db> {
             ClassBase::Dynamic(DynamicType::Any) => "Any",
             ClassBase::Dynamic(DynamicType::Unknown) => "Unknown",
             ClassBase::Dynamic(
-                DynamicType::Todo(_)
-                | DynamicType::TodoPEP695ParamSpec
-                | DynamicType::TodoTypeAlias
-                | DynamicType::TodoUnpack,
+                DynamicType::Todo(_) | DynamicType::TodoPEP695ParamSpec | DynamicType::TodoUnpack,
             ) => "@Todo",
             ClassBase::Dynamic(DynamicType::Divergent(_)) => "Divergent",
             ClassBase::Protocol => "Protocol",
@@ -168,6 +165,7 @@ impl<'db> ClassBase<'db> {
                 KnownInstanceType::SubscriptedGeneric(_) => Some(Self::Generic),
                 KnownInstanceType::SubscriptedProtocol(_) => Some(Self::Protocol),
                 KnownInstanceType::TypeAliasType(_)
+                | KnownInstanceType::TypeAlias(_)
                 | KnownInstanceType::TypeVar(_)
                 | KnownInstanceType::Deprecated(_)
                 | KnownInstanceType::Field(_)

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -13,8 +13,7 @@ use crate::semantic_index::{
 use crate::types::call::{CallArguments, MatchedArgument};
 use crate::types::signatures::Signature;
 use crate::types::{
-    ClassBase, ClassLiteral, DynamicType, KnownClass, KnownInstanceType, Type,
-    class::CodeGeneratorKind,
+    ClassBase, ClassLiteral, KnownClass, KnownInstanceType, Type, class::CodeGeneratorKind,
 };
 use crate::{Db, HasType, NameKind, SemanticModel};
 use ruff_db::files::{File, FileRange};
@@ -268,9 +267,10 @@ impl<'db> AllMembers<'db> {
                             }
                             Type::ClassLiteral(class) if class.is_protocol(db) => continue,
                             Type::KnownInstance(
-                                KnownInstanceType::TypeVar(_) | KnownInstanceType::TypeAliasType(_),
+                                KnownInstanceType::TypeVar(_)
+                                | KnownInstanceType::TypeAliasType(_)
+                                | KnownInstanceType::TypeAlias(_),
                             ) => continue,
-                            Type::Dynamic(DynamicType::TodoTypeAlias) => continue,
                             _ => {}
                         }
                     }

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -811,6 +811,13 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     self.infer_type_expression(slice);
                     todo_type!("Generic manual PEP-695 type alias")
                 }
+                KnownInstanceType::TypeAliasType(TypeAliasType::PEP613(_)) => {
+                    unreachable!("PEP 613 type aliases are not KnownInstance::TypeAliasType");
+                }
+                KnownInstanceType::TypeAlias(_) => {
+                    self.infer_type_expression(&subscript.slice);
+                    todo_type!("Generic PEP-613 type alias")
+                }
             },
             Type::Dynamic(DynamicType::Todo(_)) => {
                 self.infer_type_expression(slice);

--- a/crates/ty_python_semantic/src/types/type_ordering.rs
+++ b/crates/ty_python_semantic/src/types/type_ordering.rs
@@ -272,9 +272,6 @@ fn dynamic_elements_ordering(left: DynamicType, right: DynamicType) -> Ordering 
         (DynamicType::TodoUnpack, _) => Ordering::Less,
         (_, DynamicType::TodoUnpack) => Ordering::Greater,
 
-        (DynamicType::TodoTypeAlias, _) => Ordering::Less,
-        (_, DynamicType::TodoTypeAlias) => Ordering::Greater,
-
         (DynamicType::Divergent(left), DynamicType::Divergent(right)) => {
             left.scope.cmp(&right.scope)
         }


### PR DESCRIPTION
## Summary

Add support for PEP 613 type aliases (defined by annotating with `typing.TypeAlias`), including recursive ones.

## Test Plan

Added mdtests and updated existing tests.
