### PR TITLE
[`pyflakes`] Fix `allowed-unused-imports` matching for top-level modules (`F401`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyflakes/F401_35.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyflakes/F401_35.py
@@ -4,7 +4,9 @@ Test: allowed-unused-imports-top-level-module
 
 # No errors
 
-import hvplot.pandas
-import hvplot.pandas.plots
-from hvplot.pandas import scatter_matrix
-from hvplot.pandas.plots import scatter_matrix
+def f():
+    import hvplot
+    import hvplot.pandas
+    import hvplot.pandas.plots
+    from hvplot.pandas import scatter_matrix
+    from hvplot.pandas.plots import scatter_matrix

--- a/crates/ruff_linter/resources/test/fixtures/pyflakes/F401_35.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyflakes/F401_35.py
@@ -1,0 +1,10 @@
+"""
+Test: allowed-unused-imports-top-level-module
+"""
+
+# No errors
+
+import hvplot.pandas
+import hvplot.pandas.plots
+from hvplot.pandas import scatter_matrix
+from hvplot.pandas.plots import scatter_matrix

--- a/crates/ruff_linter/resources/test/fixtures/pyflakes/F401_35.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyflakes/F401_35.py
@@ -6,7 +6,11 @@ Test: allowed-unused-imports-top-level-module
 
 def f():
     import hvplot
+def f():
     import hvplot.pandas
+def f():
     import hvplot.pandas.plots
+def f():
     from hvplot.pandas import scatter_matrix
+def f():
     from hvplot.pandas.plots import scatter_matrix

--- a/crates/ruff_linter/src/rules/pyflakes/mod.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/mod.rs
@@ -376,6 +376,22 @@ mod tests {
         Ok(())
     }
 
+    #[test_case(Rule::UnusedImport, Path::new("F401_35.py"))]
+    fn f401_allowed_unused_imports_top_level_module(rule_code: Rule, path: &Path) -> Result<()> {
+        let diagnostics = test_path(
+            Path::new("pyflakes").join(path).as_path(),
+            &LinterSettings {
+                pyflakes: pyflakes::settings::Settings {
+                    allowed_unused_imports: vec!["hvplot".to_string()],
+                    ..pyflakes::settings::Settings::default()
+                },
+                ..LinterSettings::for_rule(rule_code)
+            },
+        )?;
+        assert_diagnostics!(diagnostics);
+        Ok(())
+    }
+
     #[test]
     fn f841_dummy_variable_rgx() -> Result<()> {
         let diagnostics = test_path(

--- a/crates/ruff_linter/src/rules/pyflakes/rules/unused_import.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/unused_import.rs
@@ -334,7 +334,7 @@ pub(crate) fn unused_import(checker: &Checker, scope: &Scope) {
             .allowed_unused_imports
             .iter()
             .any(|allowed_unused_import| {
-                let allowed_unused_import = QualifiedName::from_dotted_name(allowed_unused_import);
+                let allowed_unused_import = QualifiedName::user_defined(allowed_unused_import);
                 import.qualified_name().starts_with(&allowed_unused_import)
             })
         {

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__f401_allowed_unused_imports_top_level_module.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__f401_allowed_unused_imports_top_level_module.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff_linter/src/rules/pyflakes/mod.rs
+---
+


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Fixes #19664

Fix allowed unused imports matching for top-level modules.

I've simply replaced `from_dotted_name` with `user_defined`. Since QualifiedName for imports is created in crates/ruff_python_semantic/src/imports.rs, I guess it's acceptable to use `user_defined` here. Please tell me if there is better way.

https://github.com/astral-sh/ruff/blob/0c5089ed9e180da7bc76733ffe1a1d132e9142b0/crates/ruff_python_semantic/src/imports.rs#L62

## Test Plan

<!-- How was it tested? -->

I've added a snapshot test `f401_allowed_unused_imports_top_level_module`.
