### PR TITLE
[ty] Fix 'too many cycle iterations' for unions of literals

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -2309,6 +2309,20 @@ reveal_type(Toggle().x)  # revealed: Literal[True]
 reveal_type(Toggle().y)  # revealed:  Unknown | Literal[True]
 ```
 
+Make sure that the growing union of literals `Literal[0, 1, 2, ...]` collapses to `int` during
+fixpoint iteration. This is a regression test for <https://github.com/astral-sh/ty/issues/660>.
+
+```py
+class Counter:
+    def __init__(self: "Counter"):
+        self.count = 0
+
+    def increment(self: "Counter"):
+        self.count = self.count + 1
+
+reveal_type(Counter().count)  # revealed: Unknown | int
+```
+
 ### Builtin types attributes
 
 This test can probably be removed eventually, but we currently include it because we do not yet

--- a/crates/ty_python_semantic/src/types/builder.rs
+++ b/crates/ty_python_semantic/src/types/builder.rs
@@ -202,7 +202,10 @@ enum ReduceResult<'db> {
 
 // TODO increase this once we extend `UnionElement` throughout all union/intersection
 // representations, so that we can make large unions of literals fast in all operations.
-const MAX_UNION_LITERALS: usize = 200;
+//
+// For now (until we solve https://github.com/astral-sh/ty/issues/957), keep this number
+// below 200, which is the salsa fixpoint iteration limit.
+const MAX_UNION_LITERALS: usize = 199;
 
 pub(crate) struct UnionBuilder<'db> {
     elements: Vec<UnionElement<'db>>,


### PR DESCRIPTION
## Summary

Decrease the maximum number of literals in a union before we collapse to the supertype. The better fix for this will be https://github.com/astral-sh/ty/issues/957, but it is very tempting to solve this for now by simply decreasing the limit by one, to get below the salsa limit of 200.

closes https://github.com/astral-sh/ty/issues/660

## Test Plan

Added a regression test that would previously lead to a "too many cycle iterations" panic.
