### PR TITLE
Fix mdtest ignore python code blocks

### DIFF
--- a/crates/ty_test/src/lib.rs
+++ b/crates/ty_test/src/lib.rs
@@ -241,7 +241,9 @@ fn run_test(
 
             db.write_file(&full_path, &embedded.code).unwrap();
 
-            if !(full_path.starts_with(&src_path) && matches!(embedded.lang, "py" | "pyi")) {
+            if !(full_path.starts_with(&src_path)
+                && matches!(embedded.lang, "py" | "python" | "pyi"))
+            {
                 // These files need to be written to the file system (above), but we don't run any checks on them.
                 return None;
             }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

Resolves https://github.com/astral-sh/ty/issues/1103

## Test Plan

Edited `crates/ty_python_semantic/resources/mdtest/literal/boolean.md` with:

```
# Boolean literals

```python
reveal_type(True)  # revealed: Literal[False]
reveal_type(False)  # revealed: Literal[False]
```

Ran `cargo test -p ty_python_semantic --test mdtest -- mdtest__literal_boolean`

And we get a test failure:

```
running 1 test
test mdtest__literal_boolean ... FAILED

failures:

---- mdtest__literal_boolean stdout ----

boolean.md - Boolean literals (c336e1af3d538acd)

  crates/ty_python_semantic/resources/mdtest/literal/boolean.md:4 unmatched assertion: revealed: Literal[False]
  crates/ty_python_semantic/resources/mdtest/literal/boolean.md:4 unexpected error: 13 [revealed-type] "Revealed type: `Literal[True]`"

To rerun this specific test, set the environment variable: MDTEST_TEST_FILTER='boolean.md - Boolean literals (c336e1af3d538acd)'
MDTEST_TEST_FILTER='boolean.md - Boolean literals (c336e1af3d538acd)' cargo test -p ty_python_semantic --test mdtest -- mdtest__literal_boolean

--------------------------------------------------


thread 'mdtest__literal_boolean' panicked at crates/ty_test/src/lib.rs:138:5:
Some tests failed.
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    mdtest__literal_boolean

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 263 filtered out; finished in 0.18s

error: test failed, to rerun pass `-p ty_python_semantic --test mdtest`
```

As expected.

And when i checkout main and keep the same mdtest file all tests pass (as the repro).