### PR TITLE
[ty] Enforce that an attribute on a class `X` must be callable in order to satisfy a member on a protocol `P`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -1704,7 +1704,11 @@ class NotSubtype:
     def m(self, x: int) -> int:
         return 42
 
+class DefinitelyNotSubtype:
+    m = None
+
 static_assert(is_subtype_of(NominalSubtype, P))
+static_assert(not is_subtype_of(DefinitelyNotSubtype, P))
 
 # TODO: should pass
 static_assert(not is_subtype_of(NotSubtype, P))  # error: [static-assert-error]

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -560,7 +560,8 @@ impl<'a, 'db> ProtocolMember<'a, 'db> {
                 db,
                 matches!(
                     other.to_meta_type(db).member(db, self.name).place,
-                    Place::Type(_, Boundness::Bound)
+                    Place::Type(ty, Boundness::Bound)
+                    if ty.is_assignable_to(db, CallableType::single(db, Signature::dynamic(Type::any())))
                 ),
             ),
             // TODO: consider the types of the attribute on `other` for property members


### PR DESCRIPTION
## Summary

Small, incremental progress towards checking the types of method members.

## Test Plan

Added an mdtest
