### PR TITLE
Better handling for panics and error messages

### DIFF
--- a/crates/ruff/src/commands/check.rs
+++ b/crates/ruff/src/commands/check.rs
@@ -6,7 +6,7 @@ use std::time::Instant;
 use anyhow::Result;
 use colored::Colorize;
 use ignore::Error;
-use log::{debug, error, warn};
+use log::{debug, warn};
 #[cfg(not(target_family = "wasm"))]
 use rayon::prelude::*;
 use rustc_hash::FxHashMap;
@@ -192,23 +192,15 @@ fn lint_path(
 
     match result {
         Ok(inner) => inner,
-        Err(error) => {
-            let message = r"This indicates a bug in Ruff. If you could open an issue at:
-
-    https://github.com/astral-sh/ruff/issues/new?title=%5BLinter%20panic%5D
-
-...with the relevant file contents, the `pyproject.toml` settings, and the following stack trace, we'd be very appreciative!
-";
-
-            error!(
-                "{}{}{} {message}\n{error}",
+        Err(error) => Ok(Diagnostics {
+            panics: vec![format!(
+                "{}{}{}\n{error}",
                 "Panicked while linting ".bold(),
                 fs::relativize_path(path).bold(),
                 ":".bold()
-            );
-
-            Ok(Diagnostics::default())
-        }
+            )],
+            ..Diagnostics::default()
+        }),
     }
 }
 

--- a/crates/ruff/src/diagnostics.rs
+++ b/crates/ruff/src/diagnostics.rs
@@ -40,6 +40,7 @@ pub(crate) struct Diagnostics {
     pub(crate) inner: Vec<Diagnostic>,
     pub(crate) fixed: FixMap,
     pub(crate) notebook_indexes: FxHashMap<String, NotebookIndex>,
+    pub(crate) panics: Vec<String>,
 }
 
 impl Diagnostics {
@@ -51,6 +52,7 @@ impl Diagnostics {
             inner: diagnostics,
             fixed: FixMap::default(),
             notebook_indexes,
+            panics: Vec::default(),
         }
     }
 
@@ -129,6 +131,7 @@ impl AddAssign for Diagnostics {
         self.inner.extend(other.inner);
         self.fixed += other.fixed;
         self.notebook_indexes.extend(other.notebook_indexes);
+        self.panics.extend(other.panics);
     }
 }
 
@@ -345,6 +348,7 @@ pub(crate) fn lint_path(
         inner: diagnostics,
         fixed: FixMap::from_iter([(fs::relativize_path(path), fixed)]),
         notebook_indexes,
+        ..Diagnostics::default()
     })
 }
 
@@ -384,6 +388,7 @@ pub(crate) fn lint_stdin(
                     inner: lint_pyproject_toml(&source_file, &settings.linter),
                     fixed: FixMap::from_iter([(fs::relativize_path(path), FixTable::default())]),
                     notebook_indexes: FxHashMap::default(),
+                    ..Diagnostics::default()
                 });
             }
 
@@ -492,5 +497,6 @@ pub(crate) fn lint_stdin(
             fixed,
         )]),
         notebook_indexes,
+        ..Diagnostics::default()
     })
 }

--- a/crates/ruff/src/lib.rs
+++ b/crates/ruff/src/lib.rs
@@ -444,7 +444,9 @@ pub fn check(args: CheckCommand, global_options: GlobalConfigArgs) -> Result<Exi
         }
 
         if !cli.exit_zero {
-            if cli.diff {
+            if !diagnostics.panics.is_empty() {
+                return Ok(ExitStatus::Error);
+            } else if cli.diff {
                 // If we're printing a diff, we always want to exit non-zero if there are
                 // any fixable violations (since we've printed the diff, but not applied the
                 // fixes).

--- a/crates/ruff/src/printer.rs
+++ b/crates/ruff/src/printer.rs
@@ -6,6 +6,7 @@ use anyhow::Result;
 use bitflags::bitflags;
 use colored::Colorize;
 use itertools::{Itertools, iterate};
+use log::error;
 use ruff_linter::linter::FixTable;
 use serde::Serialize;
 
@@ -198,6 +199,25 @@ impl Printer {
         Ok(())
     }
 
+    pub(crate) fn write_panics(diagnostics: &Diagnostics) {
+        if diagnostics.panics.is_empty() {
+            return;
+        }
+
+        for message in &diagnostics.panics {
+            error!("{message}");
+        }
+
+        let message = r"This indicates a bug in Ruff. If you could open an issue at:
+
+https://github.com/astral-sh/ruff/issues/new?title=%5BLinter%20panic%5D
+
+...with the relevant file contents, the `pyproject.toml` settings, and the stack trace above, we'd be very appreciative!
+";
+
+        error!("{message}");
+    }
+
     pub(crate) fn write_once(
         &self,
         diagnostics: &Diagnostics,
@@ -321,6 +341,7 @@ impl Printer {
         }
 
         writer.flush()?;
+        Self::write_panics(diagnostics);
 
         Ok(())
     }
@@ -427,6 +448,7 @@ impl Printer {
         }
 
         writer.flush()?;
+        Self::write_panics(diagnostics);
 
         Ok(())
     }
@@ -468,6 +490,7 @@ impl Printer {
                 .emit(writer, &diagnostics.inner, &context)?;
         }
         writer.flush()?;
+        Self::write_panics(diagnostics);
 
         Ok(())
     }


### PR DESCRIPTION

## Summary

Improve handling of panics during linting, and increase visibility
of error messages and the call-to-action to report issues to the repo.

- Adds a new `panics` vector to the `Diagnostics` object
- Updates the `check::lint_path` function to format and record panics
  on the diagnostics result rather than immediately logging the error
- Adds a new `printer::write_panics` function that logs any panics
  followed by the message requesting the user submit a bug report
- Call `write_panics` from the other `write_*` functions, but after
  normal output is logged, so that the request is at the bottom of
  output for user visibility
- Check for panics and exit with code 2 (error)

## Test Plan

Manually added a `panic!` and ran ruff on a file:

```
$ cargo run -p ruff -- check crates/ruff_linter/resources/test/fixtures/flake8_async/ASYNC250.py --no-cache --preview --select ASYNC250
...

     Running `target/debug/ruff check crates/ruff_linter/resources/test/fixtures/flake8_async/ASYNC250.py --no-cache --preview --select ASYNC250`
All checks passed!
error: Panicked while linting crates/ruff_linter/resources/test/fixtures/flake8_async/ASYNC250.py:
panicked at crates/ruff/src/diagnostics.rs:196:5:
thing happened
run with `RUST_BACKTRACE=1` environment variable to display a backtrace

error: This indicates a bug in Ruff. If you could open an issue at:

https://github.com/astral-sh/ruff/issues/new?title=%5BLinter%20panic%5D

...with the relevant file contents, the `pyproject.toml` settings, and the stack trace above, we'd be very appreciative!

> [2]
```
