### PR TITLE
[ty] minor TypedDict fixes

### DIFF
--- a/crates/ty_python_semantic/src/types/type_ordering.rs
+++ b/crates/ty_python_semantic/src/types/type_ordering.rs
@@ -212,6 +212,12 @@ pub(super) fn union_or_intersection_elements_ordering<'db>(
         (Type::TypeAlias(_), _) => Ordering::Less,
         (_, Type::TypeAlias(_)) => Ordering::Greater,
 
+        (Type::TypedDict(left), Type::TypedDict(right)) => {
+            left.defining_class().cmp(&right.defining_class())
+        }
+        (Type::TypedDict(_), _) => Ordering::Less,
+        (_, Type::TypedDict(_)) => Ordering::Greater,
+
         (Type::Union(_), _) | (_, Type::Union(_)) => {
             unreachable!("our type representation does not permit nested unions");
         }
@@ -243,12 +249,6 @@ pub(super) fn union_or_intersection_elements_ordering<'db>(
 
             unreachable!("Two equal, normalized intersections should share the same Salsa ID")
         }
-
-        (Type::TypedDict(left), Type::TypedDict(right)) => {
-            left.defining_class().cmp(&right.defining_class())
-        }
-        (Type::TypedDict(_), _) => Ordering::Less,
-        (_, Type::TypedDict(_)) => Ordering::Greater,
     }
 }
 


### PR DESCRIPTION
## Summary

In `is_disjoint_from_impl`, we should unpack type aliases before we check `TypedDict`. This change probably doesn't have any visible effect until we have a more discriminating implementation of disjointness for `TypedDict`, but making the change now can avoid some confusion/bugs in future.

In `type_ordering.rs`, we should order `TypedDict` near more similar types, and leave Union/Intersection together at the end of the list. This is not necessary for correctness, but it's more consistent and it could have saved me some confusion trying to figure out why I was only getting an unreachable panic when my code example included a `TypedDict` type.

## Test Plan

None besides existing tests.