### PR TITLE
[ty] Use `invalid-assignment` error code for invalid assignments to `ClassVar`s

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -699,7 +699,7 @@ reveal_type(c_instance.pure_class_variable1)  # revealed: str
 
 reveal_type(c_instance.pure_class_variable2)  # revealed: Unknown | Literal[1]
 
-# error: [invalid-attribute-access] "Cannot assign to ClassVar `pure_class_variable1` from an instance of type `C`"
+# error: [invalid-assignment] "Cannot assign to ClassVar `pure_class_variable1` from an instance of type `C`"
 c_instance.pure_class_variable1 = "value set on instance"
 
 C.pure_class_variable1 = "overwritten on class"

--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/attribute_assignment.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/attribute_assignment.md
@@ -53,7 +53,7 @@ C.attr = 1  # fine
 C.attr = "wrong"  # error: [invalid-assignment]
 
 instance = C()
-instance.attr = 1  # error: [invalid-attribute-access]
+instance.attr = 1  # error: [invalid-assignment]
 ```
 
 ## Unknown attributes

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -1387,7 +1387,7 @@ class ClassVarXProto(Protocol):
 def f(obj: ClassVarXProto):
     reveal_type(obj.x)  # revealed: int
     reveal_type(type(obj).x)  # revealed: int
-    obj.x = 42  # error: [invalid-attribute-access] "Cannot assign to ClassVar `x` from an instance of type `ClassVarXProto`"
+    obj.x = 42  # error: [invalid-assignment] "Cannot assign to ClassVar `x` from an instance of type `ClassVarXProto`"
 
 class InstanceAttrX:
     x: int

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment…_-_Attribute_assignment_-_`ClassVar`s_(8d7cca27987b099d).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment…_-_Attribute_assignment_-_`ClassVar`s_(8d7cca27987b099d).snap
@@ -21,7 +21,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/attribute_as
  7 | C.attr = "wrong"  # error: [invalid-assignment]
  8 | 
  9 | instance = C()
-10 | instance.attr = 1  # error: [invalid-attribute-access]
+10 | instance.attr = 1  # error: [invalid-assignment]
 ```
 
 # Diagnostics
@@ -41,13 +41,13 @@ info: rule `invalid-assignment` is enabled by default
 ```
 
 ```
-error[invalid-attribute-access]: Cannot assign to ClassVar `attr` from an instance of type `C`
+error[invalid-assignment]: Cannot assign to ClassVar `attr` from an instance of type `C`
   --> src/mdtest_snippet.py:10:1
    |
  9 | instance = C()
-10 | instance.attr = 1  # error: [invalid-attribute-access]
+10 | instance.attr = 1  # error: [invalid-assignment]
    | ^^^^^^^^^^^^^
    |
-info: rule `invalid-attribute-access` is enabled by default
+info: rule `invalid-assignment` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/type_qualifiers/classvar.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_qualifiers/classvar.md
@@ -26,15 +26,15 @@ reveal_type(C.e)  # revealed: int
 
 c = C()
 
-# error: [invalid-attribute-access]
+# error: [invalid-assignment]
 c.a = 2
-# error: [invalid-attribute-access]
+# error: [invalid-assignment]
 c.b = 2
-# error: [invalid-attribute-access]
+# error: [invalid-assignment]
 c.c = 2
-# error: [invalid-attribute-access]
+# error: [invalid-assignment]
 c.d = 2
-# error: [invalid-attribute-access]
+# error: [invalid-assignment]
 c.e = 2
 ```
 
@@ -58,7 +58,7 @@ class C:
 from module import C
 
 c = C()
-c.a = 2  # error: [invalid-attribute-access]
+c.a = 2  # error: [invalid-assignment]
 ```
 
 ## Conflicting type qualifiers
@@ -82,7 +82,7 @@ reveal_type(C.a)  # revealed: int | str
 
 c = C()
 
-# error: [invalid-attribute-access]
+# error: [invalid-assignment]
 c.a = 2
 ```
 

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -4195,7 +4195,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             meta_attr @ PlaceAndQualifiers { .. } if meta_attr.is_class_var() => {
                                 if emit_diagnostics {
                                     if let Some(builder) =
-                                        self.context.report_lint(&INVALID_ATTRIBUTE_ACCESS, target)
+                                        self.context.report_lint(&INVALID_ASSIGNMENT, target)
                                     {
                                         builder.into_diagnostic(format_args!(
                                             "Cannot assign to ClassVar `{attribute}` \


### PR DESCRIPTION
## Summary

This error is about assigning to attributes rather than reading attributes, so I think `invalid-assignment` makes more sense than `invalid-attribute-access`

## Test Plan

existing mdtests updated
