### PR TITLE
[ty] skip a slow seed in fuzzer

### DIFF
--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -191,7 +191,7 @@ pub(crate) struct IsDisjoint;
 pub(crate) type IsEquivalentVisitor<'db, C> = PairVisitor<'db, IsEquivalent, C>;
 pub(crate) struct IsEquivalent;
 
-/// A [`CycleDetector`] for `find_legacy_typevars` methods.
+/// A [`CycleDetector`] that is used in `find_legacy_typevars` methods.
 pub(crate) type FindLegacyTypeVarsVisitor<'db> = CycleDetector<FindLegacyTypeVars, Type<'db>, ()>;
 pub(crate) struct FindLegacyTypeVars;
 

--- a/python/py-fuzzer/fuzz.py
+++ b/python/py-fuzzer/fuzz.py
@@ -152,13 +152,16 @@ class FuzzResult:
 
 def fuzz_code(seed: Seed, args: ResolvedCliArgs) -> FuzzResult:
     """Return a `FuzzResult` instance describing the fuzzing result from this seed."""
+    # TODO(carljm) debug slowness of this seed
+    skip_check = seed in {-1}
+
     code = generate_random_code(seed)
     bug_found = False
     minimizer_callback: Callable[[str], bool] | None = None
 
     if args.baseline_executable_path is None:
         only_new_bugs = False
-        if contains_bug(
+        if not skip_check and contains_bug(
             code, executable=args.executable, executable_path=args.test_executable_path
         ):
             bug_found = True
@@ -169,7 +172,7 @@ def fuzz_code(seed: Seed, args: ResolvedCliArgs) -> FuzzResult:
             )
     else:
         only_new_bugs = True
-        if contains_new_bug(
+        if not skip_check and contains_new_bug(
             code,
             executable=args.executable,
             test_executable_path=args.test_executable_path,

--- a/python/py-fuzzer/fuzz.py
+++ b/python/py-fuzzer/fuzz.py
@@ -153,7 +153,7 @@ class FuzzResult:
 def fuzz_code(seed: Seed, args: ResolvedCliArgs) -> FuzzResult:
     """Return a `FuzzResult` instance describing the fuzzing result from this seed."""
     # TODO(carljm) debug slowness of this seed
-    skip_check = seed in {-1}
+    skip_check = seed in {208}
 
     code = generate_random_code(seed)
     bug_found = False


### PR DESCRIPTION
## Summary

Fuzzer seed 208 seems to be timing out all fuzzer runs on PRs today. This has happened on multiple unrelated PRs, as well as on an initial version of this PR that made a comment-only change in ty and didn't skip any seeds, so the timeout appears to be consistent in CI, on ty main branch, as of today, but it started happening due to some change in a factor outside ty; not sure what.

I checked the code generated for seed 208 locally, and it takes about 30s to check on current ty main branch. This is slow for a fuzzer seed, but shouldn't be slow enough to make it time out after 20min in CI (even accounting for GH runners being slower than my laptop.)

I tried to bisect the slowness of checking that code locally, but I didn't go back far enough to find the change that made it slow. In fact it seems like it became significantly faster in the last few days (on an older checkout I had to stop it after several minutes.) So whatever the cause of the slowness, it's not a recent change in ty.

I don't want to rabbit-hole on this right now (fuzzer-discovered issues are lower-priority than real-world-code issues), and need a working CI, so skip this seed for now until we can investigate it.

## Test Plan

CI. This PR contains a no-op (comment) change in ty, so that the fuzz test is triggered in CI and we can verify it now works (as well as verify, on the previous commit, that the fuzzer job is timing out on that seed, even with just a no-op change in ty.)
