### PR TITLE
[syntax-errors]: import from * only allowed at module scope (F406)

### DIFF
--- a/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
@@ -809,17 +809,6 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                         pyflakes::rules::future_feature_not_defined(checker, alias);
                     }
                 } else if &alias.name == "*" {
-                    // F406
-                    if checker.is_rule_enabled(Rule::UndefinedLocalWithNestedImportStarUsage) {
-                        if !matches!(checker.semantic.current_scope().kind, ScopeKind::Module) {
-                            checker.report_diagnostic(
-                                pyflakes::rules::UndefinedLocalWithNestedImportStarUsage {
-                                    name: helpers::format_import_from(level, module).to_string(),
-                                },
-                                stmt.range(),
-                            );
-                        }
-                    }
                     // F403
                     checker.report_diagnostic_if_enabled(
                         pyflakes::rules::UndefinedLocalWithImportStar {

--- a/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
@@ -1,7 +1,6 @@
 use ruff_python_ast::helpers;
 use ruff_python_ast::types::Node;
 use ruff_python_ast::{self as ast, Expr, Stmt};
-use ruff_python_semantic::ScopeKind;
 use ruff_text_size::Ranged;
 
 use crate::checkers::ast::Checker;

--- a/crates/ruff_linter/src/checkers/ast/analyze/unresolved_references.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/unresolved_references.rs
@@ -13,7 +13,7 @@ pub(crate) fn unresolved_references(checker: &Checker) {
 
     for reference in checker.semantic.unresolved_references() {
         if reference.is_wildcard_import() {
-            // F406
+            // F405
             checker.report_diagnostic_if_enabled(
                 pyflakes::rules::UndefinedLocalWithImportStarUsage {
                     name: reference.name(checker.source()).to_string(),

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -25,7 +25,6 @@ use std::cell::RefCell;
 use std::path::Path;
 
 use itertools::Itertools;
-use libcst_native::Name;
 use log::debug;
 use rustc_hash::{FxHashMap, FxHashSet};
 

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -25,6 +25,7 @@ use std::cell::RefCell;
 use std::path::Path;
 
 use itertools::Itertools;
+use libcst_native::Name;
 use log::debug;
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -69,7 +70,8 @@ use crate::package::PackageRoot;
 use crate::preview::is_undefined_export_in_dunder_init_enabled;
 use crate::registry::Rule;
 use crate::rules::pyflakes::rules::{
-    LateFutureImport, ReturnOutsideFunction, YieldOutsideFunction,
+    LateFutureImport, ReturnOutsideFunction, UndefinedLocalWithNestedImportStarUsage,
+    YieldOutsideFunction,
 };
 use crate::rules::pylint::rules::{
     AwaitOutsideAsync, LoadBeforeGlobalDeclaration, YieldFromInAsyncFunction,
@@ -657,6 +659,14 @@ impl SemanticSyntaxContext for Checker<'_> {
             SemanticSyntaxErrorKind::YieldOutsideFunction(kind) => {
                 if self.is_rule_enabled(Rule::YieldOutsideFunction) {
                     self.report_diagnostic(YieldOutsideFunction::new(kind), error.range);
+                }
+            }
+            SemanticSyntaxErrorKind::UndefinedLocalWithNestedImportStarUsage(name) => {
+                if self.is_rule_enabled(Rule::UndefinedLocalWithNestedImportStarUsage) {
+                    self.report_diagnostic(
+                        UndefinedLocalWithNestedImportStarUsage { name },
+                        error.range,
+                    );
                 }
             }
             SemanticSyntaxErrorKind::ReturnOutsideFunction => {

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -660,7 +660,7 @@ impl SemanticSyntaxContext for Checker<'_> {
                     self.report_diagnostic(YieldOutsideFunction::new(kind), error.range);
                 }
             }
-            SemanticSyntaxErrorKind::UndefinedLocalWithNestedImportStarUsage(name) => {
+            SemanticSyntaxErrorKind::NonModuleImportStar(name) => {
                 if self.is_rule_enabled(Rule::UndefinedLocalWithNestedImportStarUsage) {
                     self.report_diagnostic(
                         UndefinedLocalWithNestedImportStarUsage { name },

--- a/crates/ruff_python_parser/resources/inline/err/import_from_star.py
+++ b/crates/ruff_python_parser/resources/inline/err/import_from_star.py
@@ -1,2 +1,6 @@
-def f():
+def f1():
     from module import *
+class C:
+    from module import *
+def f2():
+    from ..module import *

--- a/crates/ruff_python_parser/resources/inline/err/import_from_star.py
+++ b/crates/ruff_python_parser/resources/inline/err/import_from_star.py
@@ -1,0 +1,2 @@
+def f():
+    from module import *

--- a/crates/ruff_python_parser/resources/inline/err/import_from_star.py
+++ b/crates/ruff_python_parser/resources/inline/err/import_from_star.py
@@ -4,3 +4,5 @@ class C:
     from module import *
 def f2():
     from ..module import *
+def f3():
+    from module import *, *

--- a/crates/ruff_python_parser/resources/inline/ok/import_from_star.py
+++ b/crates/ruff_python_parser/resources/inline/ok/import_from_star.py
@@ -1,0 +1,1 @@
+from module import *

--- a/crates/ruff_python_parser/src/semantic_errors.rs
+++ b/crates/ruff_python_parser/src/semantic_errors.rs
@@ -77,6 +77,8 @@ impl SemanticSyntaxChecker {
                         //     from module import *
                         // def f2():
                         //     from ..module import *
+                        // def f3():
+                        //     from module import *, *
 
                         // test_ok import_from_star
                         // from module import *

--- a/crates/ruff_python_parser/src/semantic_errors.rs
+++ b/crates/ruff_python_parser/src/semantic_errors.rs
@@ -71,6 +71,8 @@ impl SemanticSyntaxChecker {
                         // test_err import_from_star
                         // def f():
                         //     from module import *
+                        // test_ok import_from_star
+                        // from module import *
                         Self::add_error(
                             ctx,
                             SemanticSyntaxErrorKind::UndefinedLocalWithNestedImportStarUsage(

--- a/crates/ruff_python_parser/src/semantic_errors.rs
+++ b/crates/ruff_python_parser/src/semantic_errors.rs
@@ -3,17 +3,15 @@
 //! This checker is not responsible for traversing the AST itself. Instead, its
 //! [`SemanticSyntaxChecker::visit_stmt`] and [`SemanticSyntaxChecker::visit_expr`] methods should
 //! be called in a parent `Visitor`'s `visit_stmt` and `visit_expr` methods, respectively.
-use std::{default, fmt::Display, ops::Deref};
-
 use ruff_python_ast::{
     self as ast, Expr, ExprContext, IrrefutablePatternKind, Pattern, PythonVersion, Stmt, StmtExpr,
     StmtImportFrom,
     comparable::ComparableExpr,
-    name,
     visitor::{Visitor, walk_expr},
 };
 use ruff_text_size::{Ranged, TextRange, TextSize};
 use rustc_hash::{FxBuildHasher, FxHashSet};
+use std::fmt::Display;
 
 #[derive(Debug, Default)]
 pub struct SemanticSyntaxChecker {
@@ -84,7 +82,6 @@ impl SemanticSyntaxChecker {
                     }
                 }
             }
-            Stmt::Import(_) => {}
             Stmt::Match(match_stmt) => {
                 Self::irrefutable_match_case(match_stmt, ctx);
                 for case in &match_stmt.cases {

--- a/crates/ruff_python_parser/src/semantic_errors.rs
+++ b/crates/ruff_python_parser/src/semantic_errors.rs
@@ -71,6 +71,7 @@ impl SemanticSyntaxChecker {
                         // test_err import_from_star
                         // def f():
                         //     from module import *
+                        //
                         // test_ok import_from_star
                         // from module import *
                         Self::add_error(

--- a/crates/ruff_python_parser/src/semantic_errors.rs
+++ b/crates/ruff_python_parser/src/semantic_errors.rs
@@ -71,7 +71,7 @@ impl SemanticSyntaxChecker {
                         // test_err import_from_star
                         // def f():
                         //     from module import *
-                        //
+
                         // test_ok import_from_star
                         // from module import *
                         Self::add_error(

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@import_from_star.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@import_from_star.py.snap
@@ -8,7 +8,7 @@ input_file: crates/ruff_python_parser/resources/inline/err/import_from_star.py
 Module(
     ModModule {
         node_index: NodeIndex(None),
-        range: 0..106,
+        range: 0..144,
         body: [
             FunctionDef(
                 StmtFunctionDef {
@@ -156,10 +156,82 @@ Module(
                     ],
                 },
             ),
+            FunctionDef(
+                StmtFunctionDef {
+                    node_index: NodeIndex(None),
+                    range: 106..143,
+                    is_async: false,
+                    decorator_list: [],
+                    name: Identifier {
+                        id: Name("f3"),
+                        range: 110..112,
+                        node_index: NodeIndex(None),
+                    },
+                    type_params: None,
+                    parameters: Parameters {
+                        range: 112..114,
+                        node_index: NodeIndex(None),
+                        posonlyargs: [],
+                        args: [],
+                        vararg: None,
+                        kwonlyargs: [],
+                        kwarg: None,
+                    },
+                    returns: None,
+                    body: [
+                        ImportFrom(
+                            StmtImportFrom {
+                                node_index: NodeIndex(None),
+                                range: 120..143,
+                                module: Some(
+                                    Identifier {
+                                        id: Name("module"),
+                                        range: 125..131,
+                                        node_index: NodeIndex(None),
+                                    },
+                                ),
+                                names: [
+                                    Alias {
+                                        range: 139..140,
+                                        node_index: NodeIndex(None),
+                                        name: Identifier {
+                                            id: Name("*"),
+                                            range: 139..140,
+                                            node_index: NodeIndex(None),
+                                        },
+                                        asname: None,
+                                    },
+                                    Alias {
+                                        range: 142..143,
+                                        node_index: NodeIndex(None),
+                                        name: Identifier {
+                                            id: Name("*"),
+                                            range: 142..143,
+                                            node_index: NodeIndex(None),
+                                        },
+                                        asname: None,
+                                    },
+                                ],
+                                level: 0,
+                            },
+                        ),
+                    ],
+                },
+            ),
         ],
     },
 )
 ```
+## Errors
+
+  |
+6 |     from ..module import *
+7 | def f3():
+8 |     from module import *, *
+  |                        ^^^^ Syntax Error: Star import must be the only import
+  |
+
+
 ## Semantic Syntax Errors
 
   |
@@ -186,4 +258,14 @@ Module(
 5 | def f2():
 6 |     from ..module import *
   |     ^^^^^^^^^^^^^^^^^^^^^^ Syntax Error: `from ..module import *` only allowed at module level
+7 | def f3():
+8 |     from module import *, *
+  |
+
+
+  |
+6 |     from ..module import *
+7 | def f3():
+8 |     from module import *, *
+  |     ^^^^^^^^^^^^^^^^^^^^^^^ Syntax Error: `from module import *` only allowed at module level
   |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@import_from_star.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@import_from_star.py.snap
@@ -1,0 +1,75 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/inline/err/import_from_star.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        node_index: NodeIndex(None),
+        range: 0..34,
+        body: [
+            FunctionDef(
+                StmtFunctionDef {
+                    node_index: NodeIndex(None),
+                    range: 0..33,
+                    is_async: false,
+                    decorator_list: [],
+                    name: Identifier {
+                        id: Name("f"),
+                        range: 4..5,
+                        node_index: NodeIndex(None),
+                    },
+                    type_params: None,
+                    parameters: Parameters {
+                        range: 5..7,
+                        node_index: NodeIndex(None),
+                        posonlyargs: [],
+                        args: [],
+                        vararg: None,
+                        kwonlyargs: [],
+                        kwarg: None,
+                    },
+                    returns: None,
+                    body: [
+                        ImportFrom(
+                            StmtImportFrom {
+                                node_index: NodeIndex(None),
+                                range: 13..33,
+                                module: Some(
+                                    Identifier {
+                                        id: Name("module"),
+                                        range: 18..24,
+                                        node_index: NodeIndex(None),
+                                    },
+                                ),
+                                names: [
+                                    Alias {
+                                        range: 32..33,
+                                        node_index: NodeIndex(None),
+                                        name: Identifier {
+                                            id: Name("*"),
+                                            range: 32..33,
+                                            node_index: NodeIndex(None),
+                                        },
+                                        asname: None,
+                                    },
+                                ],
+                                level: 0,
+                            },
+                        ),
+                    ],
+                },
+            ),
+        ],
+    },
+)
+```
+## Semantic Syntax Errors
+
+  |
+1 | def f():
+2 |     from module import *
+  |     ^^^^^^^^^^^^^^^^^^^^ Syntax Error: `from module import *` only allowed at module level
+  |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@import_from_star.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@import_from_star.py.snap
@@ -8,22 +8,22 @@ input_file: crates/ruff_python_parser/resources/inline/err/import_from_star.py
 Module(
     ModModule {
         node_index: NodeIndex(None),
-        range: 0..34,
+        range: 0..106,
         body: [
             FunctionDef(
                 StmtFunctionDef {
                     node_index: NodeIndex(None),
-                    range: 0..33,
+                    range: 0..34,
                     is_async: false,
                     decorator_list: [],
                     name: Identifier {
-                        id: Name("f"),
-                        range: 4..5,
+                        id: Name("f1"),
+                        range: 4..6,
                         node_index: NodeIndex(None),
                     },
                     type_params: None,
                     parameters: Parameters {
-                        range: 5..7,
+                        range: 6..8,
                         node_index: NodeIndex(None),
                         posonlyargs: [],
                         args: [],
@@ -36,27 +36,121 @@ Module(
                         ImportFrom(
                             StmtImportFrom {
                                 node_index: NodeIndex(None),
-                                range: 13..33,
+                                range: 14..34,
                                 module: Some(
                                     Identifier {
                                         id: Name("module"),
-                                        range: 18..24,
+                                        range: 19..25,
                                         node_index: NodeIndex(None),
                                     },
                                 ),
                                 names: [
                                     Alias {
-                                        range: 32..33,
+                                        range: 33..34,
                                         node_index: NodeIndex(None),
                                         name: Identifier {
                                             id: Name("*"),
-                                            range: 32..33,
+                                            range: 33..34,
                                             node_index: NodeIndex(None),
                                         },
                                         asname: None,
                                     },
                                 ],
                                 level: 0,
+                            },
+                        ),
+                    ],
+                },
+            ),
+            ClassDef(
+                StmtClassDef {
+                    node_index: NodeIndex(None),
+                    range: 35..68,
+                    decorator_list: [],
+                    name: Identifier {
+                        id: Name("C"),
+                        range: 41..42,
+                        node_index: NodeIndex(None),
+                    },
+                    type_params: None,
+                    arguments: None,
+                    body: [
+                        ImportFrom(
+                            StmtImportFrom {
+                                node_index: NodeIndex(None),
+                                range: 48..68,
+                                module: Some(
+                                    Identifier {
+                                        id: Name("module"),
+                                        range: 53..59,
+                                        node_index: NodeIndex(None),
+                                    },
+                                ),
+                                names: [
+                                    Alias {
+                                        range: 67..68,
+                                        node_index: NodeIndex(None),
+                                        name: Identifier {
+                                            id: Name("*"),
+                                            range: 67..68,
+                                            node_index: NodeIndex(None),
+                                        },
+                                        asname: None,
+                                    },
+                                ],
+                                level: 0,
+                            },
+                        ),
+                    ],
+                },
+            ),
+            FunctionDef(
+                StmtFunctionDef {
+                    node_index: NodeIndex(None),
+                    range: 69..105,
+                    is_async: false,
+                    decorator_list: [],
+                    name: Identifier {
+                        id: Name("f2"),
+                        range: 73..75,
+                        node_index: NodeIndex(None),
+                    },
+                    type_params: None,
+                    parameters: Parameters {
+                        range: 75..77,
+                        node_index: NodeIndex(None),
+                        posonlyargs: [],
+                        args: [],
+                        vararg: None,
+                        kwonlyargs: [],
+                        kwarg: None,
+                    },
+                    returns: None,
+                    body: [
+                        ImportFrom(
+                            StmtImportFrom {
+                                node_index: NodeIndex(None),
+                                range: 83..105,
+                                module: Some(
+                                    Identifier {
+                                        id: Name("module"),
+                                        range: 90..96,
+                                        node_index: NodeIndex(None),
+                                    },
+                                ),
+                                names: [
+                                    Alias {
+                                        range: 104..105,
+                                        node_index: NodeIndex(None),
+                                        name: Identifier {
+                                            id: Name("*"),
+                                            range: 104..105,
+                                            node_index: NodeIndex(None),
+                                        },
+                                        asname: None,
+                                    },
+                                ],
+                                level: 2,
                             },
                         ),
                     ],
@@ -69,7 +163,27 @@ Module(
 ## Semantic Syntax Errors
 
   |
-1 | def f():
+1 | def f1():
 2 |     from module import *
   |     ^^^^^^^^^^^^^^^^^^^^ Syntax Error: `from module import *` only allowed at module level
+3 | class C:
+4 |     from module import *
+  |
+
+
+  |
+2 |     from module import *
+3 | class C:
+4 |     from module import *
+  |     ^^^^^^^^^^^^^^^^^^^^ Syntax Error: `from module import *` only allowed at module level
+5 | def f2():
+6 |     from ..module import *
+  |
+
+
+  |
+4 |     from module import *
+5 | def f2():
+6 |     from ..module import *
+  |     ^^^^^^^^^^^^^^^^^^^^^^ Syntax Error: `from ..module import *` only allowed at module level
   |

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@import_from_star.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@import_from_star.py.snap
@@ -1,0 +1,42 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/inline/ok/import_from_star.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        node_index: NodeIndex(None),
+        range: 0..21,
+        body: [
+            ImportFrom(
+                StmtImportFrom {
+                    node_index: NodeIndex(None),
+                    range: 0..20,
+                    module: Some(
+                        Identifier {
+                            id: Name("module"),
+                            range: 5..11,
+                            node_index: NodeIndex(None),
+                        },
+                    ),
+                    names: [
+                        Alias {
+                            range: 19..20,
+                            node_index: NodeIndex(None),
+                            name: Identifier {
+                                id: Name("*"),
+                                range: 19..20,
+                                node_index: NodeIndex(None),
+                            },
+                            asname: None,
+                        },
+                    ],
+                    level: 0,
+                },
+            ),
+        ],
+    },
+)
+```

--- a/crates/ty_python_semantic/resources/mdtest/import/star.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/star.md
@@ -1399,7 +1399,7 @@ X: bool = True
 
 ```py
 def f():
-    # TODO: we should emit a syntax error here (tracked by https://github.com/astral-sh/ruff/issues/17412)
+    # error: [invalid-syntax]
     from exporter import *
 
     # error: [unresolved-reference]


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR implements F406 https://docs.astral.sh/ruff/rules/undefined-local-with-nested-import-star-usage/ as a semantic syntax error

## Test Plan

I have written inline tests as directed in #17412 
