### PR TITLE
Feat/ignore deprecated rules by unless selected by exact code

### DIFF
--- a/crates/ruff/tests/integration_test.rs
+++ b/crates/ruff/tests/integration_test.rs
@@ -1469,8 +1469,8 @@ fn redirect_prefix() {
 }
 
 #[test]
-fn deprecated_direct() {
-    // Selection of a deprecated rule without preview enabled should still work
+fn deprecated_selected_exact() {
+    // A deprecated rule should be included if selected by exact code
     // but a warning should be displayed
     let mut cmd = RuffCheck::default().args(["--select", "RUF920"]).build();
     assert_cmd_snapshot!(cmd, @r"
@@ -1488,7 +1488,7 @@ fn deprecated_direct() {
 }
 
 #[test]
-fn deprecated_multiple_direct() {
+fn deprecated_selected_exact_multiple() {
     let mut cmd = RuffCheck::default()
         .args(["--select", "RUF920", "--select", "RUF921"])
         .build();
@@ -1511,28 +1511,21 @@ fn deprecated_multiple_direct() {
 }
 
 #[test]
-fn deprecated_indirect() {
-    // `RUF92` includes deprecated rules but should not warn
-    // since it is not a "direct" selection
+fn deprecated_selected_prefix() {
+    // A deprecated rule should not be included if selected by rule prefix
     let mut cmd = RuffCheck::default().args(["--select", "RUF92"]).build();
     assert_cmd_snapshot!(cmd, @r"
-    success: false
-    exit_code: 1
+    success: true
+    exit_code: 0
     ----- stdout -----
-    RUF920 Hey this is a deprecated test rule.
-    --> -:1:1
-
-    RUF921 Hey this is another deprecated test rule.
-    --> -:1:1
-
-    Found 2 errors.
+    All checks passed!
 
     ----- stderr -----
     ");
 }
 
 #[test]
-fn deprecated_direct_preview_enabled() {
+fn deprecated_selected_exact_preview_enabled() {
     // Direct selection of a deprecated rule in preview should fail
     let mut cmd = RuffCheck::default()
         .args(["--select", "RUF920", "--preview"])
@@ -1549,23 +1542,7 @@ fn deprecated_direct_preview_enabled() {
 }
 
 #[test]
-fn deprecated_indirect_preview_enabled() {
-    // `RUF920` is deprecated and should be off by default in preview.
-    let mut cmd = RuffCheck::default()
-        .args(["--select", "RUF92", "--preview"])
-        .build();
-    assert_cmd_snapshot!(cmd, @r"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-    All checks passed!
-
-    ----- stderr -----
-    ");
-}
-
-#[test]
-fn deprecated_multiple_direct_preview_enabled() {
+fn deprecated_selected_exact_multiple_preview_enabled() {
     // Direct selection of the deprecated rules in preview should fail with
     // a message listing all of the rule codes
     let mut cmd = RuffCheck::default()
@@ -1581,6 +1558,22 @@ fn deprecated_multiple_direct_preview_enabled() {
       Cause: Selection of deprecated rules is not allowed when preview is enabled. Remove selection of:
     	- RUF920
     	- RUF921
+    ");
+}
+
+#[test]
+fn deprecated_selected_prefix_preview_enabled() {
+    // `RUF920` is deprecated and should be off by default in preview.
+    let mut cmd = RuffCheck::default()
+        .args(["--select", "RUF92", "--preview"])
+        .build();
+    assert_cmd_snapshot!(cmd, @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    All checks passed!
+
+    ----- stderr -----
     ");
 }
 
@@ -2155,16 +2148,10 @@ extend-safe-fixes = ["RUF9"]
     RUF903 Hey this is a stable test rule with a display only fix.
     --> -:1:1
 
-    RUF920 Hey this is a deprecated test rule.
-    --> -:1:1
-
-    RUF921 Hey this is another deprecated test rule.
-    --> -:1:1
-
     RUF950 Hey this is a test rule that was redirected from another.
     --> -:1:1
 
-    Found 7 errors.
+    Found 5 errors.
     [*] 1 fixable with the `--fix` option (1 hidden fix can be enabled with the `--unsafe-fixes` option).
 
     ----- stderr -----

--- a/crates/ruff_linter/src/rule_selector.rs
+++ b/crates/ruff_linter/src/rule_selector.rs
@@ -214,10 +214,8 @@ impl RuleSelector {
                 RuleGroup::Preview => {
                     preview_enabled && (self.is_exact() || !preview_require_explicit)
                 }
-                // Deprecated rules are excluded in preview mode and with 'All' option unless explicitly selected
-                RuleGroup::Deprecated => {
-                    (!preview_enabled || self.is_exact()) && !matches!(self, RuleSelector::All)
-                }
+                // Deprecated rules are excluded by default unless explicitly selected
+                RuleGroup::Deprecated => !preview_enabled && self.is_exact(),
                 // Removed rules are included if explicitly selected but will error downstream
                 RuleGroup::Removed => self.is_exact(),
             }

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -20,6 +20,7 @@ Ruff uses a custom versioning scheme that uses the **minor** version number for 
     - Stable rules are added to the default set
     - Stable rules are removed from the default set
     - A safe fix for a rule is promoted to stable
+    - A rule is deprecated
 - Formatter:
      - The stable style changed
 - Language server:


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

Closes #18349

After this change:
- All deprecated rules are deselected by default
- They are only selected if the user specifically selects them by code, e.g. `--select UP038`
- Thus, `--select ALL --select UP --select UP0` won't select the deprecated rule UP038
- Documented the change in version policy. From now on, deprecating a rule should increase the minor version

## Test Plan

Integration tests in "integration_tests.rs"

Also tested with a temporary test package:
```
~> ../../ruff/target/debug/ruff.exe check --select UP038
warning: Rule `UP038` is deprecated and will be removed in a future release.
warning: Detected debug build without --no-cache.
UP038 Use `X | Y` in `isinstance` call instead of `(X, Y)`
 --> main.py:2:11
  |
1 | def main():
2 |     print(isinstance(25, (str, int)))
  |           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
help: Convert to `X | Y`

Found 1 error.
No fixes available (1 hidden fix can be enabled with the `--unsafe-fixes` option).

~> ../../ruff/target/debug/ruff.exe check --select UP03
warning: Detected debug build without --no-cache.
All checks passed!

~> ../../ruff/target/debug/ruff.exe check --select UP0
warning: Detected debug build without --no-cache.
All checks passed!

~> ../../ruff/target/debug/ruff.exe check --select UP
warning: Detected debug build without --no-cache.
All checks passed!

~> ../../ruff/target/debug/ruff.exe check --select ALL
# warnings and errors, but because of other errors, UP038 was deselected
```