### PR TITLE
feat: 'ruff rule' provides more easily parsable JSON ouput

### DIFF
--- a/crates/ruff/src/commands/rule.rs
+++ b/crates/ruff/src/commands/rule.rs
@@ -7,6 +7,7 @@ use serde::{Serialize, Serializer};
 use strum::IntoEnumIterator;
 
 use ruff_linter::FixAvailability;
+use ruff_linter::codes::RuleGroup;
 use ruff_linter::registry::{Linter, Rule, RuleNamespace};
 
 use crate::args::HelpFormat;
@@ -18,26 +19,25 @@ struct Explanation<'a> {
     linter: &'a str,
     summary: &'a str,
     message_formats: &'a [&'a str],
-    fix: String,
     #[expect(clippy::struct_field_names)]
     explanation: Option<&'a str>,
-    preview: bool,
+    fix: FixAvailability,
+    group: RuleGroup,
 }
 
 impl<'a> Explanation<'a> {
     fn from_rule(rule: &'a Rule) -> Self {
         let code = rule.noqa_code().to_string();
         let (linter, _) = Linter::parse_code(&code).unwrap();
-        let fix = rule.fixable().to_string();
         Self {
             name: rule.name().as_str(),
             code,
             linter: linter.name(),
             summary: rule.message_formats()[0],
             message_formats: rule.message_formats(),
-            fix,
             explanation: rule.explanation(),
-            preview: rule.is_preview(),
+            fix: rule.fixable(),
+            group: rule.group(),
         }
     }
 }

--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -4,12 +4,13 @@
 /// `--select`. For pylint this is e.g. C0414 and E0118 but also C and E01.
 use std::fmt::Formatter;
 
-use ruff_db::diagnostic::SecondaryCode;
-use strum_macros::EnumIter;
+use serde::Serialize;
 
 use crate::registry::Linter;
 use crate::rule_selector::is_single_rule_selector;
 use crate::rules;
+use ruff_db::diagnostic::SecondaryCode;
+use strum_macros::EnumIter;
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct NoqaCode(&'static str, &'static str);
@@ -74,7 +75,7 @@ impl serde::Serialize for NoqaCode {
     }
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Serialize)]
 pub enum RuleGroup {
     /// The rule is stable.
     Stable,

--- a/crates/ruff_linter/src/violation.rs
+++ b/crates/ruff_linter/src/violation.rs
@@ -1,12 +1,14 @@
 use std::fmt::{Debug, Display};
 
+use serde::Serialize;
+
 use ruff_db::diagnostic::Diagnostic;
 use ruff_source_file::SourceFile;
 use ruff_text_size::TextRange;
 
 use crate::{codes::Rule, message::create_lint_diagnostic};
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Serialize)]
 pub enum FixAvailability {
     Sometimes,
     Always,


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

Not sure if it entirely closes #9891, but it's at least a step in the right direction

This change improves the JSON output of the "ruff rule" command.
- the "fix" field is more easily parsable: possible values are now the values from the `FixAvailability` enum
- replaced the "preview" field with a "group" field with the possible values of the `RuleGroup` enum (stable, preview, deprecated, removed). It's more accurate and parsable that way
- everything else is the same

## Test Plan

I saw no tests for the "ruff rule" command (maybe I missed them?)

So I tested manually:
```
# BEFORE
~> uvx ruff rule I001 --output-format json
{
  "name": "unsorted-imports",
  "code": "I001",
  "linter": "isort",
  "summary": "Import block is un-sorted or un-formatted",
  "message_formats": [
    "Import block is un-sorted or un-formatted"
  ],
  "fix": "Fix is sometimes available.",
  "explanation": "## What it does\nDe-duplicates, groups, and sorts imports based on the provided `isort` settings.\n\n## Why is this bad?\nConsistency is good. Use a common convention for imports to make your code\nmore readable and idiomatic.\n\n## Example\n```python\nimport pandas\nimport numpy as np\n```\n\nUse instead:\n```python\nimport numpy as np\nimport pandas\n```\n\n## Preview\nWhen [`preview`](https://docs.astral.sh/ruff/preview/) mode is enabled, Ruff applies a stricter criterion\nfor determining whether an import should be classified as first-party.\nSpecifically, for an import of the form `import foo.bar.baz`, Ruff will\ncheck that `foo/bar`, relative to a [user-specified `src`](https://docs.astral.sh/ruff/settings/#src) directory, contains either\nthe directory `baz` or else a file with the name `baz.py` or `baz.pyi`.\n",
  "preview": false
}

# AFTER
~> target\debug\ruff.exe rule I001 --output-format json
{
  "name": "unsorted-imports",
  "code": "I001",
  "linter": "isort",
  "summary": "Import block is un-sorted or un-formatted",
  "message_formats": [
    "Import block is un-sorted or un-formatted"
  ],
  "explanation": "## What it does\nDe-duplicates, groups, and sorts imports based on the provided `isort` settings.\n\n## Why is this bad?\nConsistency is good. Use a common convention for imports to make your code\nmore readable and idiomatic.\n\n## Example\n```python\nimport pandas\nimport numpy as np\n```\n\nUse instead:\n```python\nimport numpy as np\nimport pandas\n```\n\n## Preview\nWhen [`preview`](https://docs.astral.sh/ruff/preview/) mode is enabled, Ruff applies a stricter criterion\nfor determining whether an import should be classified as first-party.\nSpecifically, for an import of the form `import foo.bar.baz`, Ruff will\ncheck that `foo/bar`, relative to a [user-specified `src`](https://docs.astral.sh/ruff/settings/#src) directory, contains either\nthe directory `baz` or else a file with the name `baz.py` or `baz.pyi`.\n",
  "fix": "Sometimes",
  "group": "Stable"
}
```
