### PR TITLE
[ty] Experiment: make `infer_{expression,definition}_types` non-queries

### DIFF
--- a/crates/ty_python_semantic/resources/primer/good.txt
+++ b/crates/ty_python_semantic/resources/primer/good.txt
@@ -16,6 +16,7 @@ apprise
 artigraph
 async-utils
 asynq
+attrs
 bandersnatch
 beartype
 bidict
@@ -50,6 +51,7 @@ isort
 itsdangerous
 janus
 jinja
+koda-validate
 kopf
 kornia
 manticore
@@ -66,6 +68,7 @@ nionutils
 openlibrary
 operator
 optuna
+paasta
 pandas
 pandas-stubs
 paroxython
@@ -74,6 +77,7 @@ pegen
 poetry
 porcupine
 ppb-vector
+prefect
 psycopg
 pwndbg
 pybind11

--- a/crates/ty_python_semantic/resources/primer/good.txt
+++ b/crates/ty_python_semantic/resources/primer/good.txt
@@ -16,7 +16,6 @@ apprise
 artigraph
 async-utils
 asynq
-attrs
 bandersnatch
 beartype
 bidict
@@ -51,7 +50,6 @@ isort
 itsdangerous
 janus
 jinja
-koda-validate
 kopf
 kornia
 manticore
@@ -68,7 +66,6 @@ nionutils
 openlibrary
 operator
 optuna
-paasta
 pandas
 pandas-stubs
 paroxython
@@ -77,7 +74,6 @@ pegen
 poetry
 porcupine
 ppb-vector
-prefect
 psycopg
 pwndbg
 pybind11

--- a/crates/ty_python_semantic/src/semantic_index/ast_ids.rs
+++ b/crates/ty_python_semantic/src/semantic_index/ast_ids.rs
@@ -42,7 +42,7 @@ fn ast_ids<'db>(db: &'db dyn Db, scope: ScopeId) -> &'db AstIds {
 
 /// Uniquely identifies a use of a name in a [`crate::semantic_index::FileScopeId`].
 #[newtype_index]
-#[derive(get_size2::GetSize)]
+#[derive(get_size2::GetSize, salsa::Update)]
 pub struct ScopedUseId;
 
 pub trait HasScopedUseId {

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3337,7 +3337,7 @@ impl<'db> Type<'db> {
         name: Name,
         policy: MemberLookupPolicy,
     ) -> PlaceAndQualifiers<'db> {
-        tracing::trace!("member_lookup_with_policy: {}.{}", self.display(db), name);
+        let _span = tracing::trace_span!("member_lookup_with_policy: {}", ?name).entered();
         if name == "__class__" {
             return Place::bound(self.dunder_class(db)).into();
         }

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -2816,6 +2816,8 @@ impl<'db> ClassLiteral<'db> {
         name: String,
         target_method_decorator: MethodDecorator,
     ) -> PlaceAndQualifiers<'db> {
+        let _span =
+            tracing::trace_span!("implicit_attribute_inner", ?class_body_scope, ?name).entered();
         // If we do not see any declarations of an attribute, neither in the class body nor in
         // any method, we build a union of `Unknown` with the inferred types of all bindings of
         // that attribute. We include `Unknown` in that union to account for the fact that the


### PR DESCRIPTION
## Summary

For the [snippet in this comment](https://github.com/astral-sh/ty/issues/1111#issuecomment-3241694867), I observe the following execution times (release mode):

| Version   | `member_look…` | `infer_{expr,def}…_types` | `infer_local_place_load` | Execution time [s] |
|-----------|-------------------|---------------------------------------|--------------------------|-------------------:|
| main      | x                 | x                                     |                          |               27.0 |
| `fee980a` | x                 |                                       | x                        |                2.7 |
| `c6b661f` | x                 |                                       |                          |               0.34 |

The version without any cycle handling except for `member_lookup_…` (last row) is almost two orders of magnitude faster, but it leads to stack overflows on snippets like `a: a` with deferred name lookups. Adding cycle handling to `infer_local_place_load` fixes that, but is only 10x faster than `main`. Unfortunately, it also leads to regressions in all kinds of benchmarks, so this is not the solution that we're looking for.

see https://github.com/astral-sh/ty/issues/1111

## Test Plan

<!-- How was it tested? -->
