### PR TITLE
[`flake8-comprehensions`] Skip `C417` when lambda contains `yield`/`yield from` (`C417`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_comprehensions/C417.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_comprehensions/C417.py
@@ -75,3 +75,11 @@ list(map(lambda x, y: x, [(1, 2), (3, 4)]))
 _ = t"{set(map(lambda x: x % 2 == 0, nums))}"
 _ = t"{dict(map(lambda v: (v, v**2), nums))}"
 
+
+# See https://github.com/astral-sh/ruff/issues/20198
+# No error: lambda contains `yield`, so map() should not be rewritten
+base = 0
+gens = map(lambda x: (yield base + x), [1, 2, 3])
+for gen in gens:
+    _ = [*gen]
+    base += 20

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_map.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_map.rs
@@ -122,6 +122,13 @@ pub(crate) fn unnecessary_map(checker: &Checker, call: &ast::ExprCall) {
         }
     };
 
+    // If the lambda body contains a `yield` or `yield from`, rewriting `map(lambda ...)` to a
+    // generator or comprehension changes the semantics or is outright invalid syntax
+    // (e.g., `yield` is not allowed inside a generator expression). In such cases, skip.
+    if lambda_contains_yield(&lambda.body) {
+        return;
+    }
+
     for iterable in iterables {
         // For example, (x+1 for x in (c:=a)) is invalid syntax
         // so we can't suggest it.
@@ -181,6 +188,13 @@ fn map_lambda_and_iterables<'a>(
     };
 
     Some((lambda, iterables))
+}
+
+/// Returns true if the expression tree contains a `yield` or `yield from` expression.
+fn lambda_contains_yield(expr: &Expr) -> bool {
+    any_over_expr(expr, &|expr| {
+        matches!(expr, Expr::Yield(_) | Expr::YieldFrom(_))
+    })
 }
 
 /// A lambda as the first argument to `map()` has the "expected" arity when:

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C417_C417.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C417_C417.py.snap
@@ -342,6 +342,7 @@ help: Replace `map()` with a set comprehension
 75 + _ = t"{ {x % 2 == 0 for x in nums} }"
 76 | _ = t"{dict(map(lambda v: (v, v**2), nums))}"
 77 | 
+78 | 
 note: This is an unsafe fix and may change runtime behavior
 
 C417 [*] Unnecessary `map()` usage (rewrite using a dict comprehension)
@@ -359,4 +360,6 @@ help: Replace `map()` with a dict comprehension
    - _ = t"{dict(map(lambda v: (v, v**2), nums))}"
 76 + _ = t"{ {v: v**2 for v in nums} }"
 77 | 
+78 | 
+79 | # See https://github.com/astral-sh/ruff/issues/20198
 note: This is an unsafe fix and may change runtime behavior


### PR DESCRIPTION
## Summary

Fixes #20198
