### PR TITLE
[ty] Run ecosystem-analyzer in release mode

### DIFF
--- a/.github/workflows/ty-ecosystem-analyzer.yaml
+++ b/.github/workflows/ty-ecosystem-analyzer.yaml
@@ -69,6 +69,7 @@ jobs:
           ecosystem-analyzer \
             --repository ruff \
             diff \
+            --profile=release \
             --projects-old ruff/projects_old.txt \
             --projects-new ruff/projects_new.txt \
             --old old_commit \


### PR DESCRIPTION
## Summary

We already have `mypy_primer` running in debug mode, so this should provide some additional coverage, and allows us produce reasonable timing results.

## Test Plan

CI run on this PR