### PR TITLE
[`ruff`] Recognize t-strings, generators, and lambdas in RUF016

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF016.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF016.py
@@ -4,6 +4,7 @@ var = f"abc"[0]
 var = [1, 2, 3][0]
 var = (1, 2, 3)[0]
 var = b"abc"[0]
+var = [1, 2, 3][False]
 
 # Should not emit for valid access with slice
 var = "abc"[0:2]
@@ -15,6 +16,7 @@ var = [1, 2, 3][None:2]
 var = [1, 2, 3][0:None]
 var = [1, 2, 3][:2]
 var = [1, 2, 3][0:]
+var = [1, 2, 3][False:True:True]
 
 # Should emit for invalid access on strings
 var = "abc"["x"]
@@ -35,6 +37,7 @@ var = "abc"[1, 2]
 
 # Should emit for invalid access using string
 var = [1, 2]["x"]
+var = [1, 2][t"x"]
 
 # Should emit for invalid access using float
 var = [1, 2][0.25]
@@ -92,6 +95,12 @@ var = [1, 2, 3]["x":"y"]
 
 # Should emit once for repeated invalid access
 var = [1, 2, 3]["x"]["y"]["z"]
+
+# Should emit for invalid access using lambda
+var = [1, 2, 3][lambda: 0]
+
+# Should emit for invalid access using generator
+var = [1, 2, 3][(x for x in ())]
 
 # Cannot emit on invalid access using variable in index
 x = "x"

--- a/crates/ruff_linter/src/rules/ruff/rules/invalid_index_type.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/invalid_index_type.rs
@@ -89,7 +89,9 @@ pub(crate) fn invalid_index_type(checker: &Checker, expr: &ExprSubscript) {
 
     if index_type.is_literal() {
         // If the index is a literal, require an integer
-        if index_type != CheckableExprType::IntLiteral {
+        if index_type != CheckableExprType::IntLiteral
+            && index_type != CheckableExprType::BooleanLiteral
+        {
             checker.report_diagnostic(
                 InvalidIndexType {
                     value_type: value_type.to_string(),
@@ -111,7 +113,9 @@ pub(crate) fn invalid_index_type(checker: &Checker, expr: &ExprSubscript) {
                 // If the index is a slice, require integer or null bounds
                 if !matches!(
                     is_slice_type,
-                    CheckableExprType::IntLiteral | CheckableExprType::NoneLiteral
+                    CheckableExprType::IntLiteral
+                        | CheckableExprType::NoneLiteral
+                        | CheckableExprType::BooleanLiteral
                 ) {
                     checker.report_diagnostic(
                         InvalidIndexType {
@@ -154,6 +158,7 @@ pub(crate) fn invalid_index_type(checker: &Checker, expr: &ExprSubscript) {
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 enum CheckableExprType {
     FString,
+    TString,
     StringLiteral,
     BytesLiteral,
     IntLiteral,
@@ -170,12 +175,15 @@ enum CheckableExprType {
     Dict,
     Tuple,
     Slice,
+    Generator,
+    Lambda,
 }
 
 impl fmt::Display for CheckableExprType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Self::FString => f.write_str("str"),
+            Self::TString => f.write_str("str"),
             Self::StringLiteral => f.write_str("str"),
             Self::BytesLiteral => f.write_str("bytes"),
             Self::IntLiteral => f.write_str("int"),
@@ -192,6 +200,8 @@ impl fmt::Display for CheckableExprType {
             Self::Slice => f.write_str("slice"),
             Self::Dict => f.write_str("dict"),
             Self::Tuple => f.write_str("tuple"),
+            Self::Generator => f.write_str("generator"),
+            Self::Lambda => f.write_str("lambda"),
         }
     }
 }
@@ -209,6 +219,7 @@ impl CheckableExprType {
             Expr::BooleanLiteral(_) => Some(Self::BooleanLiteral),
             Expr::NoneLiteral(_) => Some(Self::NoneLiteral),
             Expr::EllipsisLiteral(_) => Some(Self::EllipsisLiteral),
+            Expr::TString(_) => Some(Self::TString),
             Expr::FString(_) => Some(Self::FString),
             Expr::List(_) => Some(Self::List),
             Expr::ListComp(_) => Some(Self::ListComp),
@@ -218,6 +229,8 @@ impl CheckableExprType {
             Expr::Dict(_) => Some(Self::Dict),
             Expr::Tuple(_) => Some(Self::Tuple),
             Expr::Slice(_) => Some(Self::Slice),
+            Expr::Generator(_) => Some(Self::Generator),
+            Expr::Lambda(_) => Some(Self::Lambda),
             _ => None,
         }
     }

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF016_RUF016.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF016_RUF016.py.snap
@@ -2,416 +2,446 @@
 source: crates/ruff_linter/src/rules/ruff/mod.rs
 ---
 RUF016 Indexed access to type `str` uses type `str` instead of an integer or slice
-  --> RUF016.py:20:13
+  --> RUF016.py:22:13
    |
-19 | # Should emit for invalid access on strings
-20 | var = "abc"["x"]
+21 | # Should emit for invalid access on strings
+22 | var = "abc"["x"]
    |             ^^^
-21 | var = f"abc"["x"]
+23 | var = f"abc"["x"]
    |
 
 RUF016 Indexed access to type `str` uses type `str` instead of an integer or slice
-  --> RUF016.py:21:14
+  --> RUF016.py:23:14
    |
-19 | # Should emit for invalid access on strings
-20 | var = "abc"["x"]
-21 | var = f"abc"["x"]
+21 | # Should emit for invalid access on strings
+22 | var = "abc"["x"]
+23 | var = f"abc"["x"]
    |              ^^^
-22 |
-23 | # Should emit for invalid access on bytes
+24 |
+25 | # Should emit for invalid access on bytes
    |
 
 RUF016 Indexed access to type `bytes` uses type `str` instead of an integer or slice
-  --> RUF016.py:24:14
+  --> RUF016.py:26:14
    |
-23 | # Should emit for invalid access on bytes
-24 | var = b"abc"["x"]
+25 | # Should emit for invalid access on bytes
+26 | var = b"abc"["x"]
    |              ^^^
-25 |
-26 | # Should emit for invalid access on lists and tuples
+27 |
+28 | # Should emit for invalid access on lists and tuples
    |
 
 RUF016 Indexed access to type `list` uses type `str` instead of an integer or slice
-  --> RUF016.py:27:17
+  --> RUF016.py:29:17
    |
-26 | # Should emit for invalid access on lists and tuples
-27 | var = [1, 2, 3]["x"]
+28 | # Should emit for invalid access on lists and tuples
+29 | var = [1, 2, 3]["x"]
    |                 ^^^
-28 | var = (1, 2, 3)["x"]
+30 | var = (1, 2, 3)["x"]
    |
 
 RUF016 Indexed access to type `tuple` uses type `str` instead of an integer or slice
-  --> RUF016.py:28:17
+  --> RUF016.py:30:17
    |
-26 | # Should emit for invalid access on lists and tuples
-27 | var = [1, 2, 3]["x"]
-28 | var = (1, 2, 3)["x"]
+28 | # Should emit for invalid access on lists and tuples
+29 | var = [1, 2, 3]["x"]
+30 | var = (1, 2, 3)["x"]
    |                 ^^^
-29 |
-30 | # Should emit for invalid access on list comprehensions
+31 |
+32 | # Should emit for invalid access on list comprehensions
    |
 
 RUF016 Indexed access to type `list comprehension` uses type `str` instead of an integer or slice
-  --> RUF016.py:31:30
+  --> RUF016.py:33:30
    |
-30 | # Should emit for invalid access on list comprehensions
-31 | var = [x for x in range(10)]["x"]
+32 | # Should emit for invalid access on list comprehensions
+33 | var = [x for x in range(10)]["x"]
    |                              ^^^
-32 |
-33 | # Should emit for invalid access using tuple
+34 |
+35 | # Should emit for invalid access using tuple
    |
 
 RUF016 Indexed access to type `str` uses type `tuple` instead of an integer or slice
-  --> RUF016.py:34:13
+  --> RUF016.py:36:13
    |
-33 | # Should emit for invalid access using tuple
-34 | var = "abc"[1, 2]
+35 | # Should emit for invalid access using tuple
+36 | var = "abc"[1, 2]
    |             ^^^^
-35 |
-36 | # Should emit for invalid access using string
+37 |
+38 | # Should emit for invalid access using string
    |
 
 RUF016 Indexed access to type `list` uses type `str` instead of an integer or slice
-  --> RUF016.py:37:14
+  --> RUF016.py:39:14
    |
-36 | # Should emit for invalid access using string
-37 | var = [1, 2]["x"]
+38 | # Should emit for invalid access using string
+39 | var = [1, 2]["x"]
    |              ^^^
-38 |
-39 | # Should emit for invalid access using float
+40 | var = [1, 2][t"x"]
+   |
+
+RUF016 Indexed access to type `list` uses type `str` instead of an integer or slice
+  --> RUF016.py:40:14
+   |
+38 | # Should emit for invalid access using string
+39 | var = [1, 2]["x"]
+40 | var = [1, 2][t"x"]
+   |              ^^^^
+41 |
+42 | # Should emit for invalid access using float
    |
 
 RUF016 Indexed access to type `list` uses type `float` instead of an integer or slice
-  --> RUF016.py:40:14
+  --> RUF016.py:43:14
    |
-39 | # Should emit for invalid access using float
-40 | var = [1, 2][0.25]
+42 | # Should emit for invalid access using float
+43 | var = [1, 2][0.25]
    |              ^^^^
-41 |
-42 | # Should emit for invalid access using dict
+44 |
+45 | # Should emit for invalid access using dict
    |
 
 RUF016 Indexed access to type `list` uses type `dict` instead of an integer or slice
-  --> RUF016.py:43:14
+  --> RUF016.py:46:14
    |
-42 | # Should emit for invalid access using dict
-43 | var = [1, 2][{"x": "y"}]
+45 | # Should emit for invalid access using dict
+46 | var = [1, 2][{"x": "y"}]
    |              ^^^^^^^^^^
-44 |
-45 | # Should emit for invalid access using dict comp
+47 |
+48 | # Should emit for invalid access using dict comp
    |
 
 RUF016 Indexed access to type `list` uses type `dict comprehension` instead of an integer or slice
-  --> RUF016.py:46:14
+  --> RUF016.py:49:14
    |
-45 | # Should emit for invalid access using dict comp
-46 | var = [1, 2][{x: "y" for x in range(2)}]
+48 | # Should emit for invalid access using dict comp
+49 | var = [1, 2][{x: "y" for x in range(2)}]
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^
-47 |
-48 | # Should emit for invalid access using list 
+50 |
+51 | # Should emit for invalid access using list 
    |
 
 RUF016 Indexed access to type `list` uses type `tuple` instead of an integer or slice
-  --> RUF016.py:49:14
+  --> RUF016.py:52:14
    |
-48 | # Should emit for invalid access using list 
-49 | var = [1, 2][2, 3]
+51 | # Should emit for invalid access using list 
+52 | var = [1, 2][2, 3]
    |              ^^^^
-50 |
-51 | # Should emit for invalid access using list comp
+53 |
+54 | # Should emit for invalid access using list comp
    |
 
 RUF016 Indexed access to type `list` uses type `list comprehension` instead of an integer or slice
-  --> RUF016.py:52:14
+  --> RUF016.py:55:14
    |
-51 | # Should emit for invalid access using list comp
-52 | var = [1, 2][[x for x in range(2)]]
+54 | # Should emit for invalid access using list comp
+55 | var = [1, 2][[x for x in range(2)]]
    |              ^^^^^^^^^^^^^^^^^^^^^
-53 |
-54 | # Should emit on invalid access using set
+56 |
+57 | # Should emit on invalid access using set
    |
 
 RUF016 Indexed access to type `list` uses type `set` instead of an integer or slice
-  --> RUF016.py:55:14
+  --> RUF016.py:58:14
    |
-54 | # Should emit on invalid access using set
-55 | var = [1, 2][{"x", "y"}]
+57 | # Should emit on invalid access using set
+58 | var = [1, 2][{"x", "y"}]
    |              ^^^^^^^^^^
-56 |
-57 | # Should emit on invalid access using set comp
+59 |
+60 | # Should emit on invalid access using set comp
    |
 
 RUF016 Indexed access to type `list` uses type `set comprehension` instead of an integer or slice
-  --> RUF016.py:58:14
+  --> RUF016.py:61:14
    |
-57 | # Should emit on invalid access using set comp
-58 | var = [1, 2][{x for x in range(2)}]
+60 | # Should emit on invalid access using set comp
+61 | var = [1, 2][{x for x in range(2)}]
    |              ^^^^^^^^^^^^^^^^^^^^^
-59 |
-60 | # Should emit on invalid access using bytes
+62 |
+63 | # Should emit on invalid access using bytes
    |
 
 RUF016 Indexed access to type `list` uses type `bytes` instead of an integer or slice
-  --> RUF016.py:61:14
+  --> RUF016.py:64:14
    |
-60 | # Should emit on invalid access using bytes
-61 | var = [1, 2][b"x"]
+63 | # Should emit on invalid access using bytes
+64 | var = [1, 2][b"x"]
    |              ^^^^
-62 |
-63 | # Should emit for non-integer slice start
+65 |
+66 | # Should emit for non-integer slice start
    |
 
 RUF016 Slice in indexed access to type `list` uses type `str` instead of an integer
-  --> RUF016.py:64:17
-   |
-63 | # Should emit for non-integer slice start
-64 | var = [1, 2, 3]["x":2]
-   |                 ^^^
-65 | var = [1, 2, 3][f"x":2]
-66 | var = [1, 2, 3][1.2:2]
-   |
-
-RUF016 Slice in indexed access to type `list` uses type `str` instead of an integer
-  --> RUF016.py:65:17
-   |
-63 | # Should emit for non-integer slice start
-64 | var = [1, 2, 3]["x":2]
-65 | var = [1, 2, 3][f"x":2]
-   |                 ^^^^
-66 | var = [1, 2, 3][1.2:2]
-67 | var = [1, 2, 3][{"x"}:2]
-   |
-
-RUF016 Slice in indexed access to type `list` uses type `float` instead of an integer
-  --> RUF016.py:66:17
-   |
-64 | var = [1, 2, 3]["x":2]
-65 | var = [1, 2, 3][f"x":2]
-66 | var = [1, 2, 3][1.2:2]
-   |                 ^^^
-67 | var = [1, 2, 3][{"x"}:2]
-68 | var = [1, 2, 3][{x for x in range(2)}:2]
-   |
-
-RUF016 Slice in indexed access to type `list` uses type `set` instead of an integer
   --> RUF016.py:67:17
    |
-65 | var = [1, 2, 3][f"x":2]
-66 | var = [1, 2, 3][1.2:2]
-67 | var = [1, 2, 3][{"x"}:2]
-   |                 ^^^^^
-68 | var = [1, 2, 3][{x for x in range(2)}:2]
-69 | var = [1, 2, 3][{"x": x for x in range(2)}:2]
+66 | # Should emit for non-integer slice start
+67 | var = [1, 2, 3]["x":2]
+   |                 ^^^
+68 | var = [1, 2, 3][f"x":2]
+69 | var = [1, 2, 3][1.2:2]
    |
 
-RUF016 Slice in indexed access to type `list` uses type `set comprehension` instead of an integer
+RUF016 Slice in indexed access to type `list` uses type `str` instead of an integer
   --> RUF016.py:68:17
    |
-66 | var = [1, 2, 3][1.2:2]
-67 | var = [1, 2, 3][{"x"}:2]
-68 | var = [1, 2, 3][{x for x in range(2)}:2]
-   |                 ^^^^^^^^^^^^^^^^^^^^^
-69 | var = [1, 2, 3][{"x": x for x in range(2)}:2]
-70 | var = [1, 2, 3][[x for x in range(2)]:2]
+66 | # Should emit for non-integer slice start
+67 | var = [1, 2, 3]["x":2]
+68 | var = [1, 2, 3][f"x":2]
+   |                 ^^^^
+69 | var = [1, 2, 3][1.2:2]
+70 | var = [1, 2, 3][{"x"}:2]
    |
 
-RUF016 Slice in indexed access to type `list` uses type `dict comprehension` instead of an integer
+RUF016 Slice in indexed access to type `list` uses type `float` instead of an integer
   --> RUF016.py:69:17
    |
-67 | var = [1, 2, 3][{"x"}:2]
-68 | var = [1, 2, 3][{x for x in range(2)}:2]
-69 | var = [1, 2, 3][{"x": x for x in range(2)}:2]
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
-70 | var = [1, 2, 3][[x for x in range(2)]:2]
+67 | var = [1, 2, 3]["x":2]
+68 | var = [1, 2, 3][f"x":2]
+69 | var = [1, 2, 3][1.2:2]
+   |                 ^^^
+70 | var = [1, 2, 3][{"x"}:2]
+71 | var = [1, 2, 3][{x for x in range(2)}:2]
    |
 
-RUF016 Slice in indexed access to type `list` uses type `list comprehension` instead of an integer
+RUF016 Slice in indexed access to type `list` uses type `set` instead of an integer
   --> RUF016.py:70:17
    |
-68 | var = [1, 2, 3][{x for x in range(2)}:2]
-69 | var = [1, 2, 3][{"x": x for x in range(2)}:2]
-70 | var = [1, 2, 3][[x for x in range(2)]:2]
+68 | var = [1, 2, 3][f"x":2]
+69 | var = [1, 2, 3][1.2:2]
+70 | var = [1, 2, 3][{"x"}:2]
+   |                 ^^^^^
+71 | var = [1, 2, 3][{x for x in range(2)}:2]
+72 | var = [1, 2, 3][{"x": x for x in range(2)}:2]
+   |
+
+RUF016 Slice in indexed access to type `list` uses type `set comprehension` instead of an integer
+  --> RUF016.py:71:17
+   |
+69 | var = [1, 2, 3][1.2:2]
+70 | var = [1, 2, 3][{"x"}:2]
+71 | var = [1, 2, 3][{x for x in range(2)}:2]
    |                 ^^^^^^^^^^^^^^^^^^^^^
-71 |
-72 | # Should emit for non-integer slice end
+72 | var = [1, 2, 3][{"x": x for x in range(2)}:2]
+73 | var = [1, 2, 3][[x for x in range(2)]:2]
+   |
+
+RUF016 Slice in indexed access to type `list` uses type `dict comprehension` instead of an integer
+  --> RUF016.py:72:17
+   |
+70 | var = [1, 2, 3][{"x"}:2]
+71 | var = [1, 2, 3][{x for x in range(2)}:2]
+72 | var = [1, 2, 3][{"x": x for x in range(2)}:2]
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
+73 | var = [1, 2, 3][[x for x in range(2)]:2]
+   |
+
+RUF016 Slice in indexed access to type `list` uses type `list comprehension` instead of an integer
+  --> RUF016.py:73:17
+   |
+71 | var = [1, 2, 3][{x for x in range(2)}:2]
+72 | var = [1, 2, 3][{"x": x for x in range(2)}:2]
+73 | var = [1, 2, 3][[x for x in range(2)]:2]
+   |                 ^^^^^^^^^^^^^^^^^^^^^
+74 |
+75 | # Should emit for non-integer slice end
    |
 
 RUF016 Slice in indexed access to type `list` uses type `str` instead of an integer
-  --> RUF016.py:73:19
-   |
-72 | # Should emit for non-integer slice end
-73 | var = [1, 2, 3][0:"x"]
-   |                   ^^^
-74 | var = [1, 2, 3][0:f"x"]
-75 | var = [1, 2, 3][0:1.2]
-   |
-
-RUF016 Slice in indexed access to type `list` uses type `str` instead of an integer
-  --> RUF016.py:74:19
-   |
-72 | # Should emit for non-integer slice end
-73 | var = [1, 2, 3][0:"x"]
-74 | var = [1, 2, 3][0:f"x"]
-   |                   ^^^^
-75 | var = [1, 2, 3][0:1.2]
-76 | var = [1, 2, 3][0:{"x"}]
-   |
-
-RUF016 Slice in indexed access to type `list` uses type `float` instead of an integer
-  --> RUF016.py:75:19
-   |
-73 | var = [1, 2, 3][0:"x"]
-74 | var = [1, 2, 3][0:f"x"]
-75 | var = [1, 2, 3][0:1.2]
-   |                   ^^^
-76 | var = [1, 2, 3][0:{"x"}]
-77 | var = [1, 2, 3][0:{x for x in range(2)}]
-   |
-
-RUF016 Slice in indexed access to type `list` uses type `set` instead of an integer
   --> RUF016.py:76:19
    |
-74 | var = [1, 2, 3][0:f"x"]
-75 | var = [1, 2, 3][0:1.2]
-76 | var = [1, 2, 3][0:{"x"}]
-   |                   ^^^^^
-77 | var = [1, 2, 3][0:{x for x in range(2)}]
-78 | var = [1, 2, 3][0:{"x": x for x in range(2)}]
+75 | # Should emit for non-integer slice end
+76 | var = [1, 2, 3][0:"x"]
+   |                   ^^^
+77 | var = [1, 2, 3][0:f"x"]
+78 | var = [1, 2, 3][0:1.2]
    |
 
-RUF016 Slice in indexed access to type `list` uses type `set comprehension` instead of an integer
+RUF016 Slice in indexed access to type `list` uses type `str` instead of an integer
   --> RUF016.py:77:19
    |
-75 | var = [1, 2, 3][0:1.2]
-76 | var = [1, 2, 3][0:{"x"}]
-77 | var = [1, 2, 3][0:{x for x in range(2)}]
-   |                   ^^^^^^^^^^^^^^^^^^^^^
-78 | var = [1, 2, 3][0:{"x": x for x in range(2)}]
-79 | var = [1, 2, 3][0:[x for x in range(2)]]
-   |
-
-RUF016 Slice in indexed access to type `list` uses type `dict comprehension` instead of an integer
-  --> RUF016.py:78:19
-   |
-76 | var = [1, 2, 3][0:{"x"}]
-77 | var = [1, 2, 3][0:{x for x in range(2)}]
-78 | var = [1, 2, 3][0:{"x": x for x in range(2)}]
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
-79 | var = [1, 2, 3][0:[x for x in range(2)]]
-   |
-
-RUF016 Slice in indexed access to type `list` uses type `list comprehension` instead of an integer
-  --> RUF016.py:79:19
-   |
-77 | var = [1, 2, 3][0:{x for x in range(2)}]
-78 | var = [1, 2, 3][0:{"x": x for x in range(2)}]
-79 | var = [1, 2, 3][0:[x for x in range(2)]]
-   |                   ^^^^^^^^^^^^^^^^^^^^^
-80 |
-81 | # Should emit for non-integer slice step
-   |
-
-RUF016 Slice in indexed access to type `list` uses type `str` instead of an integer
-  --> RUF016.py:82:21
-   |
-81 | # Should emit for non-integer slice step
-82 | var = [1, 2, 3][0:1:"x"]
-   |                     ^^^
-83 | var = [1, 2, 3][0:1:f"x"]
-84 | var = [1, 2, 3][0:1:1.2]
-   |
-
-RUF016 Slice in indexed access to type `list` uses type `str` instead of an integer
-  --> RUF016.py:83:21
-   |
-81 | # Should emit for non-integer slice step
-82 | var = [1, 2, 3][0:1:"x"]
-83 | var = [1, 2, 3][0:1:f"x"]
-   |                     ^^^^
-84 | var = [1, 2, 3][0:1:1.2]
-85 | var = [1, 2, 3][0:1:{"x"}]
+75 | # Should emit for non-integer slice end
+76 | var = [1, 2, 3][0:"x"]
+77 | var = [1, 2, 3][0:f"x"]
+   |                   ^^^^
+78 | var = [1, 2, 3][0:1.2]
+79 | var = [1, 2, 3][0:{"x"}]
    |
 
 RUF016 Slice in indexed access to type `list` uses type `float` instead of an integer
-  --> RUF016.py:84:21
+  --> RUF016.py:78:19
    |
-82 | var = [1, 2, 3][0:1:"x"]
-83 | var = [1, 2, 3][0:1:f"x"]
-84 | var = [1, 2, 3][0:1:1.2]
-   |                     ^^^
-85 | var = [1, 2, 3][0:1:{"x"}]
-86 | var = [1, 2, 3][0:1:{x for x in range(2)}]
+76 | var = [1, 2, 3][0:"x"]
+77 | var = [1, 2, 3][0:f"x"]
+78 | var = [1, 2, 3][0:1.2]
+   |                   ^^^
+79 | var = [1, 2, 3][0:{"x"}]
+80 | var = [1, 2, 3][0:{x for x in range(2)}]
    |
 
 RUF016 Slice in indexed access to type `list` uses type `set` instead of an integer
-  --> RUF016.py:85:21
+  --> RUF016.py:79:19
    |
-83 | var = [1, 2, 3][0:1:f"x"]
-84 | var = [1, 2, 3][0:1:1.2]
-85 | var = [1, 2, 3][0:1:{"x"}]
-   |                     ^^^^^
-86 | var = [1, 2, 3][0:1:{x for x in range(2)}]
-87 | var = [1, 2, 3][0:1:{"x": x for x in range(2)}]
+77 | var = [1, 2, 3][0:f"x"]
+78 | var = [1, 2, 3][0:1.2]
+79 | var = [1, 2, 3][0:{"x"}]
+   |                   ^^^^^
+80 | var = [1, 2, 3][0:{x for x in range(2)}]
+81 | var = [1, 2, 3][0:{"x": x for x in range(2)}]
    |
 
 RUF016 Slice in indexed access to type `list` uses type `set comprehension` instead of an integer
-  --> RUF016.py:86:21
+  --> RUF016.py:80:19
    |
-84 | var = [1, 2, 3][0:1:1.2]
-85 | var = [1, 2, 3][0:1:{"x"}]
-86 | var = [1, 2, 3][0:1:{x for x in range(2)}]
-   |                     ^^^^^^^^^^^^^^^^^^^^^
-87 | var = [1, 2, 3][0:1:{"x": x for x in range(2)}]
-88 | var = [1, 2, 3][0:1:[x for x in range(2)]]
+78 | var = [1, 2, 3][0:1.2]
+79 | var = [1, 2, 3][0:{"x"}]
+80 | var = [1, 2, 3][0:{x for x in range(2)}]
+   |                   ^^^^^^^^^^^^^^^^^^^^^
+81 | var = [1, 2, 3][0:{"x": x for x in range(2)}]
+82 | var = [1, 2, 3][0:[x for x in range(2)]]
    |
 
 RUF016 Slice in indexed access to type `list` uses type `dict comprehension` instead of an integer
-  --> RUF016.py:87:21
+  --> RUF016.py:81:19
    |
-85 | var = [1, 2, 3][0:1:{"x"}]
-86 | var = [1, 2, 3][0:1:{x for x in range(2)}]
-87 | var = [1, 2, 3][0:1:{"x": x for x in range(2)}]
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
-88 | var = [1, 2, 3][0:1:[x for x in range(2)]]
+79 | var = [1, 2, 3][0:{"x"}]
+80 | var = [1, 2, 3][0:{x for x in range(2)}]
+81 | var = [1, 2, 3][0:{"x": x for x in range(2)}]
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
+82 | var = [1, 2, 3][0:[x for x in range(2)]]
    |
 
 RUF016 Slice in indexed access to type `list` uses type `list comprehension` instead of an integer
+  --> RUF016.py:82:19
+   |
+80 | var = [1, 2, 3][0:{x for x in range(2)}]
+81 | var = [1, 2, 3][0:{"x": x for x in range(2)}]
+82 | var = [1, 2, 3][0:[x for x in range(2)]]
+   |                   ^^^^^^^^^^^^^^^^^^^^^
+83 |
+84 | # Should emit for non-integer slice step
+   |
+
+RUF016 Slice in indexed access to type `list` uses type `str` instead of an integer
+  --> RUF016.py:85:21
+   |
+84 | # Should emit for non-integer slice step
+85 | var = [1, 2, 3][0:1:"x"]
+   |                     ^^^
+86 | var = [1, 2, 3][0:1:f"x"]
+87 | var = [1, 2, 3][0:1:1.2]
+   |
+
+RUF016 Slice in indexed access to type `list` uses type `str` instead of an integer
+  --> RUF016.py:86:21
+   |
+84 | # Should emit for non-integer slice step
+85 | var = [1, 2, 3][0:1:"x"]
+86 | var = [1, 2, 3][0:1:f"x"]
+   |                     ^^^^
+87 | var = [1, 2, 3][0:1:1.2]
+88 | var = [1, 2, 3][0:1:{"x"}]
+   |
+
+RUF016 Slice in indexed access to type `list` uses type `float` instead of an integer
+  --> RUF016.py:87:21
+   |
+85 | var = [1, 2, 3][0:1:"x"]
+86 | var = [1, 2, 3][0:1:f"x"]
+87 | var = [1, 2, 3][0:1:1.2]
+   |                     ^^^
+88 | var = [1, 2, 3][0:1:{"x"}]
+89 | var = [1, 2, 3][0:1:{x for x in range(2)}]
+   |
+
+RUF016 Slice in indexed access to type `list` uses type `set` instead of an integer
   --> RUF016.py:88:21
    |
-86 | var = [1, 2, 3][0:1:{x for x in range(2)}]
-87 | var = [1, 2, 3][0:1:{"x": x for x in range(2)}]
-88 | var = [1, 2, 3][0:1:[x for x in range(2)]]
+86 | var = [1, 2, 3][0:1:f"x"]
+87 | var = [1, 2, 3][0:1:1.2]
+88 | var = [1, 2, 3][0:1:{"x"}]
+   |                     ^^^^^
+89 | var = [1, 2, 3][0:1:{x for x in range(2)}]
+90 | var = [1, 2, 3][0:1:{"x": x for x in range(2)}]
+   |
+
+RUF016 Slice in indexed access to type `list` uses type `set comprehension` instead of an integer
+  --> RUF016.py:89:21
+   |
+87 | var = [1, 2, 3][0:1:1.2]
+88 | var = [1, 2, 3][0:1:{"x"}]
+89 | var = [1, 2, 3][0:1:{x for x in range(2)}]
    |                     ^^^^^^^^^^^^^^^^^^^^^
-89 |
-90 | # Should emit for non-integer slice start and end; should emit twice with specific ranges
+90 | var = [1, 2, 3][0:1:{"x": x for x in range(2)}]
+91 | var = [1, 2, 3][0:1:[x for x in range(2)]]
    |
 
-RUF016 Slice in indexed access to type `list` uses type `str` instead of an integer
-  --> RUF016.py:91:17
+RUF016 Slice in indexed access to type `list` uses type `dict comprehension` instead of an integer
+  --> RUF016.py:90:21
    |
-90 | # Should emit for non-integer slice start and end; should emit twice with specific ranges
-91 | var = [1, 2, 3]["x":"y"]
-   |                 ^^^
-92 |
-93 | # Should emit once for repeated invalid access
+88 | var = [1, 2, 3][0:1:{"x"}]
+89 | var = [1, 2, 3][0:1:{x for x in range(2)}]
+90 | var = [1, 2, 3][0:1:{"x": x for x in range(2)}]
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+91 | var = [1, 2, 3][0:1:[x for x in range(2)]]
    |
 
-RUF016 Slice in indexed access to type `list` uses type `str` instead of an integer
+RUF016 Slice in indexed access to type `list` uses type `list comprehension` instead of an integer
   --> RUF016.py:91:21
    |
-90 | # Should emit for non-integer slice start and end; should emit twice with specific ranges
-91 | var = [1, 2, 3]["x":"y"]
-   |                     ^^^
+89 | var = [1, 2, 3][0:1:{x for x in range(2)}]
+90 | var = [1, 2, 3][0:1:{"x": x for x in range(2)}]
+91 | var = [1, 2, 3][0:1:[x for x in range(2)]]
+   |                     ^^^^^^^^^^^^^^^^^^^^^
 92 |
-93 | # Should emit once for repeated invalid access
+93 | # Should emit for non-integer slice start and end; should emit twice with specific ranges
+   |
+
+RUF016 Slice in indexed access to type `list` uses type `str` instead of an integer
+  --> RUF016.py:94:17
+   |
+93 | # Should emit for non-integer slice start and end; should emit twice with specific ranges
+94 | var = [1, 2, 3]["x":"y"]
+   |                 ^^^
+95 |
+96 | # Should emit once for repeated invalid access
+   |
+
+RUF016 Slice in indexed access to type `list` uses type `str` instead of an integer
+  --> RUF016.py:94:21
+   |
+93 | # Should emit for non-integer slice start and end; should emit twice with specific ranges
+94 | var = [1, 2, 3]["x":"y"]
+   |                     ^^^
+95 |
+96 | # Should emit once for repeated invalid access
    |
 
 RUF016 Indexed access to type `list` uses type `str` instead of an integer or slice
-  --> RUF016.py:94:17
+  --> RUF016.py:97:17
    |
-93 | # Should emit once for repeated invalid access
-94 | var = [1, 2, 3]["x"]["y"]["z"]
+96 | # Should emit once for repeated invalid access
+97 | var = [1, 2, 3]["x"]["y"]["z"]
    |                 ^^^
-95 |
-96 | # Cannot emit on invalid access using variable in index
+98 |
+99 | # Should emit for invalid access using lambda
    |
+
+RUF016 Indexed access to type `list` uses type `lambda` instead of an integer or slice
+   --> RUF016.py:100:17
+    |
+ 99 | # Should emit for invalid access using lambda
+100 | var = [1, 2, 3][lambda: 0]
+    |                 ^^^^^^^^^
+101 |
+102 | # Should emit for invalid access using generator
+    |
+
+RUF016 Indexed access to type `list` uses type `generator` instead of an integer or slice
+   --> RUF016.py:103:17
+    |
+102 | # Should emit for invalid access using generator
+103 | var = [1, 2, 3][(x for x in ())]
+    |                 ^^^^^^^^^^^^^^^
+104 |
+105 | # Cannot emit on invalid access using variable in index
+    |


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Fixes #20204

Recognize t-strings, generators, and lambdas in RUF016

- Accept boolean literals as valid index and slice bounds.
- Add TString, Generator, and Lambda to `CheckableExprType`.
- Expand RUF016.py fixture and update snapshots accordingly.

## Test Plan

<!-- How was it tested? -->

I've added test cases for t-string, generator and lambda to RUF016.py.