### PR TITLE
Expose `Indentation` in `ruff_python_codegen`

### DIFF
--- a/crates/ruff_python_codegen/src/lib.rs
+++ b/crates/ruff_python_codegen/src/lib.rs
@@ -1,6 +1,6 @@
 pub use generator::Generator;
 use ruff_python_parser::{ParseError, parse_module};
-pub use stylist::Stylist;
+pub use stylist::{Indentation, Stylist};
 
 mod generator;
 mod stylist;


### PR DESCRIPTION
## Summary

I'm trying to reduce code complexity for [RustPython](https://github.com/RustPython/RustPython), we have this file: https://github.com/RustPython/RustPython/blob/056795eed4dc0b09de00c2fabe45493ea1de7194/compiler/codegen/src/unparse.rs which can be replaced entirely by `ruff_python_codegen::Generator`. Unfortunately we can not create an instance of `Generator` easily, because `Indentation` is not exported at https://github.com/astral-sh/ruff/blob/cda376afe079b54b6779704bdd740c9e81423e39/crates/ruff_python_codegen/src/lib.rs#L3

I have managed to bypass this restriction by doing:
```rust
let contents = r"x = 1";
let module = ruff_python_parser::parse_module(contents).unwrap();
let stylist = ruff_python_codegen::Stylist::from_tokens(module.tokens(), contents);
stylist.indentation()
```

But ideally I'd rather use:
```rust
ruff_python_codegen::Indentation::default()
```