### PR TITLE
[ty] Skip overload filtering if there are no participating parameters

### DIFF
--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -1547,54 +1547,60 @@ impl<'db> CallableBinding<'db> {
             }
         }
 
-        let top_materialized_argument_type =
-            Type::heterogeneous_tuple(db, top_materialized_argument_types);
+        if !top_materialized_argument_types.is_empty() {
+            let top_materialized_argument_type =
+                Type::heterogeneous_tuple(db, top_materialized_argument_types);
 
-        // A flag to indicate whether we've found the overload that makes the remaining overloads
-        // unmatched for the given argument types.
-        let mut filter_remaining_overloads = false;
+            // A flag to indicate whether we've found the overload that makes the remaining overloads
+            // unmatched for the given argument types.
+            let mut filter_remaining_overloads = false;
 
-        for (upto, current_index) in matching_overload_indexes.iter().enumerate() {
-            if filter_remaining_overloads {
-                self.overloads[*current_index].mark_as_unmatched_overload();
-                continue;
-            }
-            let mut parameter_types = Vec::with_capacity(arguments.len());
-            for argument_index in 0..arguments.len() {
-                // The parameter types at the current argument index.
-                let mut current_parameter_types = vec![];
-                for overload_index in &matching_overload_indexes[..=upto] {
-                    let overload = &self.overloads[*overload_index];
-                    for parameter_index in &overload.argument_matches[argument_index].parameters {
-                        if !participating_parameter_indexes.contains(parameter_index) {
-                            // This parameter doesn't participate in the filtering process.
-                            continue;
-                        }
-                        // TODO: For an unannotated `self` / `cls` parameter, the type should be
-                        // `typing.Self` / `type[typing.Self]`
-                        let mut parameter_type = overload.signature.parameters()[*parameter_index]
-                            .annotated_type()
-                            .unwrap_or(Type::unknown());
-                        if let Some(specialization) = overload.specialization {
-                            parameter_type =
-                                parameter_type.apply_specialization(db, specialization);
-                        }
-                        if let Some(inherited_specialization) = overload.inherited_specialization {
-                            parameter_type =
-                                parameter_type.apply_specialization(db, inherited_specialization);
-                        }
-                        current_parameter_types.push(parameter_type);
-                    }
-                }
-                if current_parameter_types.is_empty() {
+            for (upto, current_index) in matching_overload_indexes.iter().enumerate() {
+                if filter_remaining_overloads {
+                    self.overloads[*current_index].mark_as_unmatched_overload();
                     continue;
                 }
-                parameter_types.push(UnionType::from_elements(db, current_parameter_types));
-            }
-            if top_materialized_argument_type
-                .is_assignable_to(db, Type::heterogeneous_tuple(db, parameter_types))
-            {
-                filter_remaining_overloads = true;
+                let mut parameter_types = Vec::with_capacity(arguments.len());
+                for argument_index in 0..arguments.len() {
+                    // The parameter types at the current argument index.
+                    let mut current_parameter_types = vec![];
+                    for overload_index in &matching_overload_indexes[..=upto] {
+                        let overload = &self.overloads[*overload_index];
+                        for parameter_index in &overload.argument_matches[argument_index].parameters
+                        {
+                            if !participating_parameter_indexes.contains(parameter_index) {
+                                // This parameter doesn't participate in the filtering process.
+                                continue;
+                            }
+                            // TODO: For an unannotated `self` / `cls` parameter, the type should be
+                            // `typing.Self` / `type[typing.Self]`
+                            let mut parameter_type = overload.signature.parameters()
+                                [*parameter_index]
+                                .annotated_type()
+                                .unwrap_or(Type::unknown());
+                            if let Some(specialization) = overload.specialization {
+                                parameter_type =
+                                    parameter_type.apply_specialization(db, specialization);
+                            }
+                            if let Some(inherited_specialization) =
+                                overload.inherited_specialization
+                            {
+                                parameter_type = parameter_type
+                                    .apply_specialization(db, inherited_specialization);
+                            }
+                            current_parameter_types.push(parameter_type);
+                        }
+                    }
+                    if current_parameter_types.is_empty() {
+                        continue;
+                    }
+                    parameter_types.push(UnionType::from_elements(db, current_parameter_types));
+                }
+                if top_materialized_argument_type
+                    .is_assignable_to(db, Type::heterogeneous_tuple(db, parameter_types))
+                {
+                    filter_remaining_overloads = true;
+                }
             }
         }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
