### PR TITLE
[`flake8-logging-format`] fix handles grouping parens and preserves r-prefix/quotes

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_logging_format/G004.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_logging_format/G004.py
@@ -64,3 +64,8 @@ import logging
 
 x = 1
 logging.error(f"{x} -> %s", x)
+
+# https://github.com/astral-sh/ruff/issues/20151
+logging.warning(fr"\'{x}")
+logging.warning(f"{x}" "!")
+logging.warning((f"{x}"))

--- a/crates/ruff_linter/src/rules/flake8_logging_format/snapshots/ruff_linter__rules__flake8_logging_format__tests__G004.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_logging_format/snapshots/ruff_linter__rules__flake8_logging_format__tests__G004.py.snap
@@ -217,5 +217,39 @@ G004 Logging statement uses f-string
 65 | x = 1
 66 | logging.error(f"{x} -> %s", x)
    |               ^^^^^^^^^^^^
+67 |
+68 | # https://github.com/astral-sh/ruff/issues/20151
+   |
+help: Convert to lazy `%` formatting
+
+G004 Logging statement uses f-string
+  --> G004.py:69:17
+   |
+68 | # https://github.com/astral-sh/ruff/issues/20151
+69 | logging.warning(fr"\'{x}")
+   |                 ^^^^^^^^^
+70 | logging.warning(f"{x}" "!")
+71 | logging.warning((f"{x}"))
+   |
+help: Convert to lazy `%` formatting
+
+G004 Logging statement uses f-string
+  --> G004.py:70:17
+   |
+68 | # https://github.com/astral-sh/ruff/issues/20151
+69 | logging.warning(fr"\'{x}")
+70 | logging.warning(f"{x}" "!")
+   |                 ^^^^^^^^^^
+71 | logging.warning((f"{x}"))
+   |
+help: Convert to lazy `%` formatting
+
+G004 Logging statement uses f-string
+  --> G004.py:71:18
+   |
+69 | logging.warning(fr"\'{x}")
+70 | logging.warning(f"{x}" "!")
+71 | logging.warning((f"{x}"))
+   |                  ^^^^^^
    |
 help: Convert to lazy `%` formatting

--- a/crates/ruff_linter/src/rules/flake8_logging_format/snapshots/ruff_linter__rules__flake8_logging_format__tests__preview__G004_G004.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_logging_format/snapshots/ruff_linter__rules__flake8_logging_format__tests__preview__G004_G004.py.snap
@@ -273,5 +273,57 @@ G004 Logging statement uses f-string
 65 | x = 1
 66 | logging.error(f"{x} -> %s", x)
    |               ^^^^^^^^^^^^
+67 |
+68 | # https://github.com/astral-sh/ruff/issues/20151
    |
 help: Convert to lazy `%` formatting
+
+G004 [*] Logging statement uses f-string
+  --> G004.py:69:17
+   |
+68 | # https://github.com/astral-sh/ruff/issues/20151
+69 | logging.warning(fr"\'{x}")
+   |                 ^^^^^^^^^
+70 | logging.warning(f"{x}" "!")
+71 | logging.warning((f"{x}"))
+   |
+help: Convert to lazy `%` formatting
+66 | logging.error(f"{x} -> %s", x)
+67 | 
+68 | # https://github.com/astral-sh/ruff/issues/20151
+   - logging.warning(fr"\'{x}")
+69 + logging.warning(r"\'%s", x)
+70 | logging.warning(f"{x}" "!")
+71 | logging.warning((f"{x}"))
+
+G004 [*] Logging statement uses f-string
+  --> G004.py:70:17
+   |
+68 | # https://github.com/astral-sh/ruff/issues/20151
+69 | logging.warning(fr"\'{x}")
+70 | logging.warning(f"{x}" "!")
+   |                 ^^^^^^^^^^
+71 | logging.warning((f"{x}"))
+   |
+help: Convert to lazy `%` formatting
+67 | 
+68 | # https://github.com/astral-sh/ruff/issues/20151
+69 | logging.warning(fr"\'{x}")
+   - logging.warning(f"{x}" "!")
+70 + logging.warning("%s!", x)
+71 | logging.warning((f"{x}"))
+
+G004 [*] Logging statement uses f-string
+  --> G004.py:71:18
+   |
+69 | logging.warning(fr"\'{x}")
+70 | logging.warning(f"{x}" "!")
+71 | logging.warning((f"{x}"))
+   |                  ^^^^^^
+   |
+help: Convert to lazy `%` formatting
+68 | # https://github.com/astral-sh/ruff/issues/20151
+69 | logging.warning(fr"\'{x}")
+70 | logging.warning(f"{x}" "!")
+   - logging.warning((f"{x}"))
+71 + logging.warning("%s", x)


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Fixes some parts of #20151

Handles grouping parens and preserves r-prefix/quotes

- Iterate over `FStringPart` to build the format string, handling implicit string literal concatenation.
- Preserve the original quote style and `r` prefix in the generated message string.
- Replace over the expression’s parenthesized range to avoid tuple args, e.g. `logging.warning((f"{Ellipsis}"))` -> `logging.warning("%s", Ellipsis)`.
- Update tests and snapshots for nested parentheses and backslash escape case.

## Test Plan

<!-- How was it tested? -->

I have updated `crates/ruff_linter/resources/test/fixtures/flake8_logging_format/G004.py`.
