### PR TITLE
Stabilize `in-empty-collection` (`RUF060`)

### DIFF
--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -1047,7 +1047,7 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         (Ruff, "057") => (RuleGroup::Stable, rules::ruff::rules::UnnecessaryRound),
         (Ruff, "058") => (RuleGroup::Stable, rules::ruff::rules::StarmapZip),
         (Ruff, "059") => (RuleGroup::Preview, rules::ruff::rules::UnusedUnpackedVariable),
-        (Ruff, "060") => (RuleGroup::Preview, rules::ruff::rules::InEmptyCollection),
+        (Ruff, "060") => (RuleGroup::Stable, rules::ruff::rules::InEmptyCollection),
         (Ruff, "061") => (RuleGroup::Preview, rules::ruff::rules::LegacyFormPytestRaises),
         (Ruff, "063") => (RuleGroup::Preview, rules::ruff::rules::AccessAnnotationsFromClassDict),
         (Ruff, "064") => (RuleGroup::Preview, rules::ruff::rules::NonOctalPermissions),

--- a/crates/ruff_linter/src/rules/ruff/rules/in_empty_collection.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/in_empty_collection.rs
@@ -7,10 +7,10 @@ use crate::Violation;
 use crate::checkers::ast::Checker;
 
 /// ## What it does
-/// Checks for membership tests on empty collections (such as `list`, `tuple`, `set` or `dict`).
+/// Checks for membership tests on empty collections (such as `list`, `tuple`, `set`, or `dict`).
 ///
 /// ## Why is this bad?
-/// If the collection is always empty, the check is unnecessary, and can be removed.
+/// If the collection is always empty, the check is unnecessary and can be removed.
 ///
 /// ## Example
 ///


### PR DESCRIPTION
Tests look good, just two very small comma changes to the docs
