### PR TITLE
[ty] Reduce false positives for `ParamSpec`s and `TypeVarTuple`s

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/unsupported_special_forms.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/unsupported_special_forms.md
@@ -28,6 +28,23 @@ def i(callback: Callable[Concatenate[int, P], R_co], *args: P.args, **kwargs: P.
 class Foo:
     def method(self, x: Self):
         reveal_type(x)  # revealed: Self@method
+
+def ex2(msg: str):
+    def wrapper(fn: Callable[P, R_co]) -> Callable[P, R_co]:
+        def wrapped(*args: P.args, **kwargs: P.kwargs) -> R_co:
+            print(msg)
+            return fn(*args, **kwargs)
+        return wrapped
+    return wrapper
+
+def ex3(msg: str):
+    P = ParamSpec("P")
+    def wrapper(fn: Callable[P, R_co]) -> Callable[P, R_co]:
+        def wrapped(*args: P.args, **kwargs: P.kwargs) -> R_co:
+            print(msg)
+            return fn(*args, **kwargs)
+        return wrapped
+    return wrapper
 ```
 
 ## Type expressions


### PR DESCRIPTION
## Summary

Helps with https://github.com/astral-sh/ty/issues/157#issuecomment-3253068088. We have existing workarounds to avoid emitting false positives if the inferred type of a variable is `ParamSpec` or `TypeVarTuple`, but these don't work if a `ParamSpec` or a `TypeVarTuple` from the global scope is used in an inner function, since the type of these variables seen by the nested scope will be `ParamSpec | Unknown` (or `TypeVarTuple | Unknown`). This can be fixed fairly easily by using `any_over_type()` to search for types that we don't support yet.

## Test Plan

Added an mdtest that uses the examples from https://github.com/astral-sh/ty/issues/157#issuecomment-3253068088