### PR TITLE
[ty] TypedDict: Add support for `typing.ReadOnly`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/snapshots/typed_dict.md_-_`TypedDict`_-_Diagnostics_(e5289abf5c570c29).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/typed_dict.md_-_`TypedDict`_-_Diagnostics_(e5289abf5c570c29).snap
@@ -37,6 +37,14 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/typed_dict.md
 23 | 
 24 | def write_to_non_literal_string_key(person: Person, str_key: str):
 25 |     person[str_key] = "Alice"  # error: [invalid-key]
+26 | from typing_extensions import ReadOnly
+27 | 
+28 | class Employee(TypedDict):
+29 |     id: ReadOnly[int]
+30 |     name: str
+31 | 
+32 | def write_to_readonly_key(employee: Employee):
+33 |     employee["id"] = 42  # error: [invalid-assignment]
 ```
 
 # Diagnostics
@@ -127,7 +135,22 @@ error[invalid-key]: Cannot access `Person` with a key of type `str`. Only string
 24 | def write_to_non_literal_string_key(person: Person, str_key: str):
 25 |     person[str_key] = "Alice"  # error: [invalid-key]
    |            ^^^^^^^
+26 | from typing_extensions import ReadOnly
    |
 info: rule `invalid-key` is enabled by default
+
+```
+
+```
+error[invalid-assignment]: Can not assign to key "id" on TypedDict `Employee`
+  --> src/mdtest_snippet.py:33:5
+   |
+32 | def write_to_readonly_key(employee: Employee):
+33 |     employee["id"] = 42  # error: [invalid-assignment]
+   |     -------- ^^^^ key is marked read-only
+   |     |
+   |     TypedDict `Employee`
+   |
+info: rule `invalid-assignment` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -588,6 +588,11 @@ impl<'db> PlaceAndQualifiers<'db> {
         self.qualifiers.contains(TypeQualifiers::NOT_REQUIRED)
     }
 
+    /// Returns `true` if the place has a `ReadOnly` type qualifier.
+    pub(crate) fn is_read_only(&self) -> bool {
+        self.qualifiers.contains(TypeQualifiers::READ_ONLY)
+    }
+
     /// Returns `Some(…)` if the place is qualified with `typing.Final` without a specified type.
     pub(crate) fn is_bare_final(&self) -> Option<TypeQualifiers> {
         match self {

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -121,6 +121,10 @@ impl TypedDictAssignmentKind {
             Self::Constructor => &INVALID_ARGUMENT_TYPE,
         }
     }
+
+    const fn is_subscript(self) -> bool {
+        matches!(self, Self::Subscript)
+    }
 }
 
 /// Validates assignment of a value to a specific key on a `TypedDict`.
@@ -151,6 +155,29 @@ pub(super) fn validate_typed_dict_key_assignment<'db, 'ast>(
         );
         return false;
     };
+
+    if assignment_kind.is_subscript() && item.is_read_only() {
+        if let Some(builder) =
+            context.report_lint(assignment_kind.diagnostic_type(), key_node.into())
+        {
+            let typed_dict_ty = Type::TypedDict(typed_dict);
+            let typed_dict_d = typed_dict_ty.display(db);
+
+            let mut diagnostic = builder.into_diagnostic(format_args!(
+                "Can not assign to key \"{key}\" on TypedDict `{typed_dict_d}`",
+            ));
+
+            diagnostic.set_primary_message(format_args!("key is marked read-only"));
+
+            diagnostic.annotate(
+                context
+                    .secondary(typed_dict_node.into())
+                    .message(format_args!("TypedDict `{typed_dict_d}`")),
+            );
+        }
+
+        return false;
+    }
 
     // Key exists, check if value type is assignable to declared type
     if value_ty.is_assignable_to(db, item.declared_ty) {


### PR DESCRIPTION
## Summary

Add support for `typing.ReadOnly` as a type qualifier to mark `TypedDict` fields as being read-only. If you try to mutate them, you get a new diagnostic:

<img width="787" height="234" alt="image" src="https://github.com/user-attachments/assets/f62fddf9-4961-4bcd-ad1c-747043ebe5ff" />


## Test Plan

* New Markdown tests
* The typing conformance changes are all correct. There are some false negatives, but those are related to the missing support for the functional form of `TypedDict`, or to overriding of fields via inheritance. Both of these topics are tracked in https://github.com/astral-sh/ty/issues/154