### PR TITLE
[`RUF102`] Respect rule redirects in invalid rule code detection

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF102.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF102.py
@@ -16,3 +16,5 @@ from collections import defaultdict  # noqa: INVALID100, INVALID200, F401
 from itertools import chain  # noqa: E402, INVALID300, F401
 # Test for mixed code types
 import json  # noqa: E402, INVALID400, V100
+# Test for rule redirects
+import pandas as pd  # noqa: TCH002

--- a/crates/ruff_linter/src/rules/ruff/rules/invalid_rule_code.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/invalid_rule_code.rs
@@ -6,6 +6,7 @@ use crate::checkers::ast::LintContext;
 use crate::noqa::{Code, Directive};
 use crate::noqa::{Codes, NoqaDirectives};
 use crate::registry::Rule;
+use crate::rule_redirects::get_redirect_target;
 use crate::{AlwaysFixableViolation, Edit, Fix};
 
 /// ## What it does
@@ -81,7 +82,8 @@ pub(crate) fn invalid_noqa_code(
 
 fn code_is_valid(code: &Code, external: &[String]) -> bool {
     let code_str = code.as_str();
-    Rule::from_code(code_str).is_ok() || external.iter().any(|ext| code_str.starts_with(ext))
+    Rule::from_code(get_redirect_target(code.as_str()).unwrap_or(code.as_str())).is_ok()
+        || external.iter().any(|ext| code_str.starts_with(ext))
 }
 
 fn all_codes_invalid_diagnostic(

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF102_RUF102.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF102_RUF102.py.snap
@@ -176,6 +176,7 @@ help: Remove the rule code
 16 + from itertools import chain  # noqa: E402, F401
 17 | # Test for mixed code types
 18 | import json  # noqa: E402, INVALID400, V100
+19 | # Test for rule redirects
 
 RUF102 [*] Invalid rule code in `# noqa`: INVALID400
   --> RUF102.py:18:28
@@ -184,6 +185,8 @@ RUF102 [*] Invalid rule code in `# noqa`: INVALID400
 17 | # Test for mixed code types
 18 | import json  # noqa: E402, INVALID400, V100
    |                            ^^^^^^^^^^
+19 | # Test for rule redirects
+20 | import pandas as pd  # noqa: TCH002
    |
 help: Remove the rule code
 15 | # Test for preserving valid codes when fixing
@@ -191,6 +194,8 @@ help: Remove the rule code
 17 | # Test for mixed code types
    - import json  # noqa: E402, INVALID400, V100
 18 + import json  # noqa: E402, V100
+19 | # Test for rule redirects
+20 | import pandas as pd  # noqa: TCH002
 
 RUF102 [*] Invalid rule code in `# noqa`: V100
   --> RUF102.py:18:40
@@ -199,6 +204,8 @@ RUF102 [*] Invalid rule code in `# noqa`: V100
 17 | # Test for mixed code types
 18 | import json  # noqa: E402, INVALID400, V100
    |                                        ^^^^
+19 | # Test for rule redirects
+20 | import pandas as pd  # noqa: TCH002
    |
 help: Remove the rule code
 15 | # Test for preserving valid codes when fixing
@@ -206,3 +213,5 @@ help: Remove the rule code
 17 | # Test for mixed code types
    - import json  # noqa: E402, INVALID400, V100
 18 + import json  # noqa: E402, INVALID400
+19 | # Test for rule redirects
+20 | import pandas as pd  # noqa: TCH002

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__invalid_rule_code_external_rules.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__invalid_rule_code_external_rules.snap
@@ -156,6 +156,7 @@ help: Remove the rule code
 16 + from itertools import chain  # noqa: E402, F401
 17 | # Test for mixed code types
 18 | import json  # noqa: E402, INVALID400, V100
+19 | # Test for rule redirects
 
 RUF102 [*] Invalid rule code in `# noqa`: INVALID400
   --> RUF102.py:18:28
@@ -164,6 +165,8 @@ RUF102 [*] Invalid rule code in `# noqa`: INVALID400
 17 | # Test for mixed code types
 18 | import json  # noqa: E402, INVALID400, V100
    |                            ^^^^^^^^^^
+19 | # Test for rule redirects
+20 | import pandas as pd  # noqa: TCH002
    |
 help: Remove the rule code
 15 | # Test for preserving valid codes when fixing
@@ -171,3 +174,5 @@ help: Remove the rule code
 17 | # Test for mixed code types
    - import json  # noqa: E402, INVALID400, V100
 18 + import json  # noqa: E402, V100
+19 | # Test for rule redirects
+20 | import pandas as pd  # noqa: TCH002


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Fixes #20235

• Fix `RUF102` to properly handle rule redirects when validating noqa codes
• Update `code_is_valid` to check redirect targets before determining validity
• Add test case for rule redirects (TCH002 in this case)

## Test Plan

<!-- How was it tested? -->

I have added a test case for rule redirects to `crates/ruff_linter/resources/test/fixtures/ruff/RUF102.py`.