### PR TITLE
[ty] Implement the legacy PEP-484 convention for indicating positional-only parameters

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -1588,7 +1588,7 @@ from typing import Any
 class Foo(Any): ...
 
 reveal_type(Foo.bar)  # revealed: Any
-reveal_type(Foo.__repr__)  # revealed: (def __repr__(self) -> str) & Any
+reveal_type(Foo.__repr__)  # revealed: (def __repr__(self, /) -> str) & Any
 ```
 
 Similar principles apply if `Any` appears in the middle of an inheritance hierarchy:

--- a/crates/ty_python_semantic/resources/mdtest/call/function.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/function.md
@@ -68,6 +68,78 @@ def _(flag: bool):
     reveal_type(foo())  # revealed: int
 ```
 
+## PEP-484 convention for positional-only parameters
+
+PEP 570, introduced in Python 3.8, added dedicated Python syntax for denoting positional-only
+parameters (the `/` in a function signature). However, functions implemented in C were able to
+have positional-only parameters prior to Python 3.8 (there was just no syntax for expressing this
+at the Python level).
+
+Stub files describing functions implemented in C nonetheless needed a way of expressing that
+certain parameters were positional-only. In the absence of dedicated Python syntax, PEP 484
+described a convention that type checkers were expected to understand:
+
+> Some functions are designed to take their arguments only positionally, and expect their callers
+never to use the argument’s name to provide that argument by keyword. All arguments with names
+beginning with `__` are assumed to be positional-only, except if their names also end with `__`.
+
+While this convention is now redundant (following the implementation of PEP 570), many projects
+still continue to use the old convention, so it is supported by ty as well.
+
+```py
+def f(__x: int): ...
+
+f(1)
+# error: [missing-argument]
+# error: [unknown-argument]
+f(__x=1)
+```
+
+But not if they follow a non-positional-only parameter:
+
+```py
+def g(x: int, __y: str): ...
+
+g(x=1, __y="foo")
+```
+
+And also not if they both start and end with `__`:
+
+```py
+def h(__x__: str): ...
+
+h(__x__="foo")
+```
+
+And if *any* parameters use the new PEP-570 convention, the old convention does not apply:
+
+```py
+def i(x: str, /, __y: int): ...
+
+i("foo", __y=42)  # fine
+```
+
+And `self`/`cls` are implicitly positional-only:
+
+```py
+class C:
+    def method(self, __x: int): ...
+    @classmethod
+    def class_method(cls, __x: str): ...
+    # (the name of the first parameter is irrelevant;
+    # a staticmethod works the same as a free function in the global scope)
+    @staticmethod
+    def static_method(self, __x: int): ...
+
+# error: [missing-argument]
+# error: [unknown-argument]
+C().method(__x=1)
+# error: [missing-argument]
+# error: [unknown-argument]
+C.class_method(__x="1")
+C.static_method("x", __x=42)  # fine
+```
+
 ## Splatted arguments
 
 ### Unknown argument length

--- a/crates/ty_python_semantic/resources/mdtest/call/function.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/function.md
@@ -71,17 +71,17 @@ def _(flag: bool):
 ## PEP-484 convention for positional-only parameters
 
 PEP 570, introduced in Python 3.8, added dedicated Python syntax for denoting positional-only
-parameters (the `/` in a function signature). However, functions implemented in C were able to
-have positional-only parameters prior to Python 3.8 (there was just no syntax for expressing this
-at the Python level).
+parameters (the `/` in a function signature). However, functions implemented in C were able to have
+positional-only parameters prior to Python 3.8 (there was just no syntax for expressing this at the
+Python level).
 
-Stub files describing functions implemented in C nonetheless needed a way of expressing that
-certain parameters were positional-only. In the absence of dedicated Python syntax, PEP 484
-described a convention that type checkers were expected to understand:
+Stub files describing functions implemented in C nonetheless needed a way of expressing that certain
+parameters were positional-only. In the absence of dedicated Python syntax, PEP 484 described a
+convention that type checkers were expected to understand:
 
 > Some functions are designed to take their arguments only positionally, and expect their callers
-never to use the argument’s name to provide that argument by keyword. All arguments with names
-beginning with `__` are assumed to be positional-only, except if their names also end with `__`.
+> never to use the argument’s name to provide that argument by keyword. All arguments with names
+> beginning with `__` are assumed to be positional-only, except if their names also end with `__`.
 
 While this convention is now redundant (following the implementation of PEP 570), many projects
 still continue to use the old convention, so it is supported by ty as well.
@@ -617,7 +617,7 @@ def _(args: str) -> None:
 
 This is a regression that was highlighted by the ecosystem check, which shows that we might need to
 rethink how we perform argument expansion during overload resolution. In particular, we might need
-to retry both `match_parameters` _and_ `check_types` for each expansion. Currently we only retry
+to retry both `match_parameters` *and* `check_types` for each expansion. Currently we only retry
 `check_types`.
 
 The issue is that argument expansion might produce a splatted value with a different arity than what

--- a/crates/ty_python_semantic/resources/mdtest/call/methods.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/methods.md
@@ -32,11 +32,11 @@ the latter case, it returns a *bound method* object:
 ```py
 from inspect import getattr_static
 
-reveal_type(getattr_static(C, "f"))  # revealed: def f(self, x: int) -> str
+reveal_type(getattr_static(C, "f"))  # revealed: def f(self, /, x: int) -> str
 
 reveal_type(getattr_static(C, "f").__get__)  # revealed: <method-wrapper `__get__` of `f`>
 
-reveal_type(getattr_static(C, "f").__get__(None, C))  # revealed: def f(self, x: int) -> str
+reveal_type(getattr_static(C, "f").__get__(None, C))  # revealed: def f(self, /, x: int) -> str
 reveal_type(getattr_static(C, "f").__get__(C(), C))  # revealed: bound method C.f(x: int) -> str
 ```
 
@@ -44,7 +44,7 @@ In conclusion, this is why we see the following two types when accessing the `f`
 class object `C` and on an instance `C()`:
 
 ```py
-reveal_type(C.f)  # revealed: def f(self, x: int) -> str
+reveal_type(C.f)  # revealed: def f(self, /, x: int) -> str
 reveal_type(C().f)  # revealed: bound method C.f(x: int) -> str
 ```
 
@@ -56,7 +56,7 @@ via `__func__`):
 bound_method = C().f
 
 reveal_type(bound_method.__self__)  # revealed: C
-reveal_type(bound_method.__func__)  # revealed: def f(self, x: int) -> str
+reveal_type(bound_method.__func__)  # revealed: def f(self, /, x: int) -> str
 ```
 
 When we call the bound method, the `instance` is implicitly passed as the first argument (`self`):
@@ -411,7 +411,7 @@ class C:
     @classmethod
     def f(cls): ...
 
-reveal_type(getattr_static(C, "f"))  # revealed: def f(cls) -> Unknown
+reveal_type(getattr_static(C, "f"))  # revealed: def f(cls, /) -> Unknown
 reveal_type(getattr_static(C, "f").__get__)  # revealed: <method-wrapper `__get__` of `f`>
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/class/super.md
+++ b/crates/ty_python_semantic/resources/mdtest/class/super.md
@@ -193,7 +193,7 @@ reveal_type(super(B, B()).a1)  # revealed: bound method B.a1() -> Unknown
 reveal_type(super(B, B()).a2)  # revealed: bound method type[B].a2() -> Unknown
 
 # A.__dict__["a1"].__get__(None, B)
-reveal_type(super(B, B).a1)  # revealed: def a1(self) -> Unknown
+reveal_type(super(B, B).a1)  # revealed: def a1(self, /) -> Unknown
 # A.__dict__["a2"].__get__(None, B)
 reveal_type(super(B, B).a2)  # revealed: bound method <class 'B'>.a2() -> Unknown
 ```

--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
@@ -1116,7 +1116,7 @@ The generated methods have the following signatures:
 ```py
 reveal_type(Person.__init__)  # revealed: (self: Person, name: str, age: int | None = None) -> None
 
-reveal_type(Person.__repr__)  # revealed: def __repr__(self) -> str
+reveal_type(Person.__repr__)  # revealed: def __repr__(self, /) -> str
 
 reveal_type(Person.__eq__)  # revealed: def __eq__(self, value: object, /) -> bool
 ```

--- a/crates/ty_python_semantic/resources/mdtest/expression/boolean.md
+++ b/crates/ty_python_semantic/resources/mdtest/expression/boolean.md
@@ -108,7 +108,7 @@ class VariadicTupleSubclassWithDunderBoolOverride(tuple[int, ...]):
         return True
 
 reveal_type(bool(VariadicTupleSubclassWithDunderBoolOverride((1,))))  # revealed: Literal[True]
-reveal_type(VariadicTupleSubclassWithDunderBoolOverride.__bool__)  # revealed: def __bool__(self) -> Literal[True]
+reveal_type(VariadicTupleSubclassWithDunderBoolOverride.__bool__)  # revealed: def __bool__(self, /) -> Literal[True]
 
 # revealed: bound method VariadicTupleSubclassWithDunderBoolOverride.__bool__() -> Literal[True]
 reveal_type(VariadicTupleSubclassWithDunderBoolOverride().__bool__)
@@ -120,7 +120,7 @@ class EmptyTupleSubclassWithDunderBoolOverride(tuple[()]):
         return True
 
 reveal_type(bool(EmptyTupleSubclassWithDunderBoolOverride(())))  # revealed: Literal[True]
-reveal_type(EmptyTupleSubclassWithDunderBoolOverride.__bool__)  # revealed: def __bool__(self) -> Literal[True]
+reveal_type(EmptyTupleSubclassWithDunderBoolOverride.__bool__)  # revealed: def __bool__(self, /) -> Literal[True]
 
 # revealed: bound method EmptyTupleSubclassWithDunderBoolOverride.__bool__() -> Literal[True]
 reveal_type(EmptyTupleSubclassWithDunderBoolOverride().__bool__)

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -655,7 +655,7 @@ class WithOverloadedMethod(Generic[T]):
     def method(self, x: S | T) -> S | T:
         return x
 
-# revealed: Overload[(self, x: int) -> int, (self, x: S@method) -> S@method | int]
+# revealed: Overload[(self, /, x: int) -> int, (self, /, x: S@method) -> S@method | int]
 reveal_type(WithOverloadedMethod[int].method)
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
@@ -570,7 +570,7 @@ class WithOverloadedMethod[T]:
     def method[S](self, x: S | T) -> S | T:
         return x
 
-# revealed: Overload[(self, x: int) -> int, (self, x: S@method) -> S@method | int]
+# revealed: Overload[(self, /, x: int) -> int, (self, /, x: S@method) -> S@method | int]
 reveal_type(WithOverloadedMethod[int].method)
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/scoping.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/scoping.md
@@ -101,18 +101,18 @@ class C[T]:
     def f(self, x: T) -> str:
         return "a"
 
-reveal_type(getattr_static(C[int], "f"))  # revealed: def f(self, x: int) -> str
+reveal_type(getattr_static(C[int], "f"))  # revealed: def f(self, /, x: int) -> str
 reveal_type(getattr_static(C[int], "f").__get__)  # revealed: <method-wrapper `__get__` of `f`>
-reveal_type(getattr_static(C[int], "f").__get__(None, C[int]))  # revealed: def f(self, x: int) -> str
+reveal_type(getattr_static(C[int], "f").__get__(None, C[int]))  # revealed: def f(self, /, x: int) -> str
 # revealed: bound method C[int].f(x: int) -> str
 reveal_type(getattr_static(C[int], "f").__get__(C[int](), C[int]))
 
-reveal_type(C[int].f)  # revealed: def f(self, x: int) -> str
+reveal_type(C[int].f)  # revealed: def f(self, /, x: int) -> str
 reveal_type(C[int]().f)  # revealed: bound method C[int].f(x: int) -> str
 
 bound_method = C[int]().f
 reveal_type(bound_method.__self__)  # revealed: C[int]
-reveal_type(bound_method.__func__)  # revealed: def f(self, x: int) -> str
+reveal_type(bound_method.__func__)  # revealed: def f(self, /, x: int) -> str
 
 reveal_type(C[int]().f(1))  # revealed: str
 reveal_type(bound_method(1))  # revealed: str

--- a/crates/ty_python_semantic/resources/mdtest/named_tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/named_tuple.md
@@ -269,8 +269,8 @@ class Person(NamedTuple):
 reveal_type(Person._field_defaults)  # revealed: dict[str, Any]
 reveal_type(Person._fields)  # revealed: tuple[str, ...]
 reveal_type(Person._make)  # revealed: bound method <class 'Person'>._make(iterable: Iterable[Any]) -> Person
-reveal_type(Person._asdict)  # revealed: def _asdict(self) -> dict[str, Any]
-reveal_type(Person._replace)  # revealed: def _replace(self, **kwargs: Any) -> Self@_replace
+reveal_type(Person._asdict)  # revealed: def _asdict(self, /) -> dict[str, Any]
+reveal_type(Person._replace)  # revealed: def _replace(self, /, **kwargs: Any) -> Self@_replace
 
 # TODO: should be `Person` once we support `Self`
 reveal_type(Person._make(("Alice", 42)))  # revealed: Unknown
@@ -354,8 +354,8 @@ class Point(NamedTuple):
     y: int
 
 reveal_type(Point._make)  # revealed: bound method <class 'Point'>._make(iterable: Iterable[Any]) -> Point
-reveal_type(Point._asdict)  # revealed: def _asdict(self) -> dict[str, Any]
-reveal_type(Point._replace)  # revealed: def _replace(self, **kwargs: Any) -> Self@_replace
+reveal_type(Point._asdict)  # revealed: def _asdict(self, /) -> dict[str, Any]
+reveal_type(Point._replace)  # revealed: def _replace(self, /, **kwargs: Any) -> Self@_replace
 
 static_assert(is_assignable_to(Point, NamedTuple))
 

--- a/crates/ty_python_semantic/resources/mdtest/properties.md
+++ b/crates/ty_python_semantic/resources/mdtest/properties.md
@@ -146,7 +146,7 @@ class C:
     @property
     def attr(self) -> int:
         return 1
-    # error: [invalid-argument-type] "Argument to bound method `setter` is incorrect: Expected `(Any, Any, /) -> None`, found `def attr(self) -> None`"
+    # error: [invalid-argument-type] "Argument to bound method `setter` is incorrect: Expected `(Any, Any, /) -> None`, found `def attr(self, /) -> None`"
     @attr.setter
     def attr(self) -> None:
         pass
@@ -156,7 +156,7 @@ class C:
 
 ```py
 class C:
-    # error: [invalid-argument-type] "Argument to class `property` is incorrect: Expected `((Any, /) -> Any) | None`, found `def attr(self, x: int) -> int`"
+    # error: [invalid-argument-type] "Argument to class `property` is incorrect: Expected `((Any, /) -> Any) | None`, found `def attr(self, /, x: int) -> int`"
     @property
     def attr(self, x: int) -> int:
         return 1
@@ -294,10 +294,10 @@ Properties also have `fget` and `fset` attributes that can be used to retrieve t
 and setter functions, respectively.
 
 ```py
-reveal_type(attr_property.fget)  # revealed: def attr(self) -> int
+reveal_type(attr_property.fget)  # revealed: def attr(self, /) -> int
 reveal_type(attr_property.fget(c))  # revealed: int
 
-reveal_type(attr_property.fset)  # revealed: def attr(self, value: str) -> None
+reveal_type(attr_property.fset)  # revealed: def attr(self, /, value: str) -> None
 reveal_type(attr_property.fset(c, "a"))  # revealed: None
 
 # error: [invalid-argument-type]

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -413,13 +413,13 @@ To see the kinds and types of the protocol members, you can use the debugging ai
 from ty_extensions import reveal_protocol_interface
 from typing import SupportsIndex, SupportsAbs, ClassVar, Iterator
 
-# revealed: {"method_member": MethodMember(`(self) -> bytes`), "x": AttributeMember(`int`), "y": PropertyMember { getter: `def y(self) -> str` }, "z": PropertyMember { getter: `def z(self) -> int`, setter: `def z(self, z: int) -> None` }}
+# revealed: {"method_member": MethodMember(`(self, /) -> bytes`), "x": AttributeMember(`int`), "y": PropertyMember { getter: `def y(self, /) -> str` }, "z": PropertyMember { getter: `def z(self, /) -> int`, setter: `def z(self, /, z: int) -> None` }}
 reveal_protocol_interface(Foo)
-# revealed: {"__index__": MethodMember(`(self) -> int`)}
+# revealed: {"__index__": MethodMember(`(self, /) -> int`)}
 reveal_protocol_interface(SupportsIndex)
-# revealed: {"__abs__": MethodMember(`(self) -> Unknown`)}
+# revealed: {"__abs__": MethodMember(`(self, /) -> Unknown`)}
 reveal_protocol_interface(SupportsAbs)
-# revealed: {"__iter__": MethodMember(`(self) -> Iterator[Unknown]`), "__next__": MethodMember(`(self) -> Unknown`)}
+# revealed: {"__iter__": MethodMember(`(self, /) -> Iterator[Unknown]`), "__next__": MethodMember(`(self, /) -> Unknown`)}
 reveal_protocol_interface(Iterator)
 
 # error: [invalid-argument-type] "Invalid argument to `reveal_protocol_interface`: Only protocol classes can be passed to `reveal_protocol_interface`"
@@ -439,9 +439,9 @@ do not implement any special handling for generic aliases passed to the function
 reveal_type(get_protocol_members(SupportsAbs[int]))  # revealed: frozenset[str]
 reveal_type(get_protocol_members(Iterator[int]))  # revealed: frozenset[str]
 
-# revealed: {"__abs__": MethodMember(`(self) -> int`)}
+# revealed: {"__abs__": MethodMember(`(self, /) -> int`)}
 reveal_protocol_interface(SupportsAbs[int])
-# revealed: {"__iter__": MethodMember(`(self) -> Iterator[int]`), "__next__": MethodMember(`(self) -> int`)}
+# revealed: {"__iter__": MethodMember(`(self, /) -> Iterator[int]`), "__next__": MethodMember(`(self, /) -> int`)}
 reveal_protocol_interface(Iterator[int])
 
 class BaseProto(Protocol):
@@ -450,10 +450,10 @@ class BaseProto(Protocol):
 class SubProto(BaseProto, Protocol):
     def member(self) -> bool: ...
 
-# revealed: {"member": MethodMember(`(self) -> int`)}
+# revealed: {"member": MethodMember(`(self, /) -> int`)}
 reveal_protocol_interface(BaseProto)
 
-# revealed: {"member": MethodMember(`(self) -> bool`)}
+# revealed: {"member": MethodMember(`(self, /) -> bool`)}
 reveal_protocol_interface(SubProto)
 
 class ProtoWithClassVar(Protocol):
@@ -1767,13 +1767,36 @@ class Foo(Protocol):
     def method(self) -> str: ...
 
 def f(x: Foo):
-    reveal_type(type(x).method)  # revealed: def method(self) -> str
+    reveal_type(type(x).method)  # revealed: def method(self, /) -> str
 
 class Bar:
     def __init__(self):
         self.method = lambda: "foo"
 
 f(Bar())  # error: [invalid-argument-type]
+```
+
+Some protocols use the old convention (specified in PEP-484) for denoting positional-only
+parameters. This is supported by ty:
+
+```py
+class HasPosOnlyDunders:
+    def __invert__(self, /) -> "HasPosOnlyDunders":
+        return self
+
+    def __lt__(self, other, /) -> bool:
+        return True
+
+class SupportsLessThan(Protocol):
+    def __lt__(self, __other) -> bool: ...
+
+class Invertable(Protocol):
+    def __invert__(self) -> object: ...
+
+static_assert(is_assignable_to(HasPosOnlyDunders, SupportsLessThan))
+static_assert(is_assignable_to(HasPosOnlyDunders, Invertable))
+static_assert(is_assignable_to(str, SupportsLessThan))
+static_assert(is_assignable_to(int, Invertable))
 ```
 
 ## Equivalence of protocols with method or property members

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/no_matching_overload…_-_No_matching_overload…_-_A_method_call_with_u…_(31cb5f881221158e).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/no_matching_overload…_-_No_matching_overload…_-_A_method_call_with_u…_(31cb5f881221158e).snap
@@ -47,8 +47,8 @@ info: First overload defined here
 7 |     def bar(self, x: str) -> str: ...
   |
 info: Possible overloads for bound method `bar`:
-info:   (self, x: int) -> int
-info:   (self, x: str) -> str
+info:   (self, /, x: int) -> int
+info:   (self, /, x: str) -> str
 info: Overload implementation defined here
  --> src/mdtest_snippet.py:8:9
   |

--- a/crates/ty_python_semantic/src/ast_node_ref.rs
+++ b/crates/ty_python_semantic/src/ast_node_ref.rs
@@ -49,6 +49,12 @@ pub struct AstNodeRef<T> {
     _node: PhantomData<T>,
 }
 
+impl<T> AstNodeRef<T> {
+    pub(crate) fn index(&self) -> NodeIndex {
+        self.index
+    }
+}
+
 impl<T> AstNodeRef<T>
 where
     T: HasNodeIndex + Ranged + PartialEq + Debug,

--- a/crates/ty_python_semantic/src/node_key.rs
+++ b/crates/ty_python_semantic/src/node_key.rs
@@ -1,5 +1,7 @@
 use ruff_python_ast::{HasNodeIndex, NodeIndex};
 
+use crate::ast_node_ref::AstNodeRef;
+
 /// Compact key for a node for use in a hash map.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, get_size2::GetSize)]
 pub(super) struct NodeKey(NodeIndex);
@@ -10,5 +12,9 @@ impl NodeKey {
         N: HasNodeIndex,
     {
         NodeKey(node.node_index().load())
+    }
+
+    pub(super) fn from_node_ref<T>(node_ref: &AstNodeRef<T>) -> Self {
+        NodeKey(node_ref.index())
     }
 }

--- a/crates/ty_python_semantic/src/semantic_index/definition.rs
+++ b/crates/ty_python_semantic/src/semantic_index/definition.rs
@@ -1134,6 +1134,12 @@ impl From<&ast::StmtClassDef> for DefinitionNodeKey {
     }
 }
 
+impl From<&AstNodeRef<ast::StmtClassDef>> for DefinitionNodeKey {
+    fn from(node_ref: &AstNodeRef<ast::StmtClassDef>) -> Self {
+        Self(NodeKey::from_node_ref(node_ref))
+    }
+}
+
 impl From<&ast::StmtTypeAlias> for DefinitionNodeKey {
     fn from(node: &ast::StmtTypeAlias) -> Self {
         Self(NodeKey::from_node(node))

--- a/crates/ty_python_semantic/src/semantic_index/scope.rs
+++ b/crates/ty_python_semantic/src/semantic_index/scope.rs
@@ -401,18 +401,19 @@ impl NodeWithScopeKind {
         &self,
         module: &'ast ParsedModuleRef,
     ) -> &'ast ast::StmtClassDef {
-        match self {
-            Self::Class(class) => class.node(module),
-            _ => panic!("expected class"),
-        }
+        self.as_class(module).expect("expected class")
     }
 
     pub(crate) fn as_class<'ast>(
         &self,
         module: &'ast ParsedModuleRef,
     ) -> Option<&'ast ast::StmtClassDef> {
+        self.as_class_ref().map(|class| class.node(module))
+    }
+
+    pub(crate) fn as_class_ref(&self) -> Option<&AstNodeRef<ast::StmtClassDef>> {
         match self {
-            Self::Class(class) => Some(class.node(module)),
+            Self::Class(class) => Some(class),
             _ => None,
         }
     }

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -2417,29 +2417,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     /// behaviour to the [`nearest_enclosing_class`] function.
     fn class_context_of_current_method(&self) -> Option<ClassType<'db>> {
         let current_scope_id = self.scope().file_scope_id(self.db());
-        let current_scope = self.index.scope(current_scope_id);
-        if current_scope.kind() != ScopeKind::Function {
-            return None;
-        }
-        let parent_scope_id = current_scope.parent()?;
-        let parent_scope = self.index.scope(parent_scope_id);
-
-        let class_scope = match parent_scope.kind() {
-            ScopeKind::Class => parent_scope,
-            ScopeKind::TypeParams => {
-                let class_scope_id = parent_scope.parent()?;
-                let potentially_class_scope = self.index.scope(class_scope_id);
-
-                match potentially_class_scope.kind() {
-                    ScopeKind::Class => potentially_class_scope,
-                    _ => return None,
-                }
-            }
-            _ => return None,
-        };
-
-        let class_stmt = class_scope.node().as_class(self.module())?;
-        let class_definition = self.index.expect_single_definition(class_stmt);
+        let class_definition = self.index.class_definition_of_method(current_scope_id)?;
         binding_type(self.db(), class_definition).to_class_type(self.db())
     }
 


### PR DESCRIPTION
## Summary

## Test Plan

Mdtests added and updated

---

Co-authored-by: Carl Meyer <carl@astral.sh>
