### PR TITLE
[`RUF060`] Use helper function for empty f-string detection

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF060.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF060.py
@@ -16,6 +16,7 @@ _ not in ()
 "a" in ""
 b'c' in b""
 "b" in f""
+"b" in f"" ""
 b"a" in bytearray()
 b"a" in bytes()
 1 in frozenset()
@@ -35,6 +36,7 @@ _ not in ('a')
 "a" in "x"
 b'c' in b"x"
 "b" in f"x"
+"b" in f"" "x"
 b"a" in bytearray([2])
 b"a" in bytes("a", "utf-8")
 1 in frozenset("c")

--- a/crates/ruff_linter/src/rules/ruff/rules/in_empty_collection.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/in_empty_collection.rs
@@ -1,5 +1,5 @@
 use ruff_macros::{ViolationMetadata, derive_message_formats};
-use ruff_python_ast::{self as ast, CmpOp, Expr};
+use ruff_python_ast::{self as ast, CmpOp, Expr, helpers::is_empty_f_string};
 use ruff_python_semantic::SemanticModel;
 use ruff_text_size::Ranged;
 
@@ -75,10 +75,7 @@ fn is_empty(expr: &Expr, semantic: &SemanticModel) -> bool {
         Expr::Dict(ast::ExprDict { items, .. }) => items.is_empty(),
         Expr::BytesLiteral(ast::ExprBytesLiteral { value, .. }) => value.is_empty(),
         Expr::StringLiteral(ast::ExprStringLiteral { value, .. }) => value.is_empty(),
-        Expr::FString(s) => s
-            .value
-            .elements()
-            .all(|elt| elt.as_literal().is_some_and(|elt| elt.is_empty())),
+        Expr::FString(s) => is_empty_f_string(s),
         Expr::Call(ast::ExprCall {
             func,
             arguments,

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF060_RUF060.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF060_RUF060.py.snap
@@ -173,7 +173,7 @@ RUF060 Unnecessary membership test on empty collection
 17 | b'c' in b""
    | ^^^^^^^^^^^
 18 | "b" in f""
-19 | b"a" in bytearray()
+19 | "b" in f"" ""
    |
 
 RUF060 Unnecessary membership test on empty collection
@@ -183,8 +183,8 @@ RUF060 Unnecessary membership test on empty collection
 17 | b'c' in b""
 18 | "b" in f""
    | ^^^^^^^^^^
-19 | b"a" in bytearray()
-20 | b"a" in bytes()
+19 | "b" in f"" ""
+20 | b"a" in bytearray()
    |
 
 RUF060 Unnecessary membership test on empty collection
@@ -192,62 +192,73 @@ RUF060 Unnecessary membership test on empty collection
    |
 17 | b'c' in b""
 18 | "b" in f""
-19 | b"a" in bytearray()
-   | ^^^^^^^^^^^^^^^^^^^
-20 | b"a" in bytes()
-21 | 1 in frozenset()
+19 | "b" in f"" ""
+   | ^^^^^^^^^^^^^
+20 | b"a" in bytearray()
+21 | b"a" in bytes()
    |
 
 RUF060 Unnecessary membership test on empty collection
   --> RUF060.py:20:1
    |
 18 | "b" in f""
-19 | b"a" in bytearray()
-20 | b"a" in bytes()
-   | ^^^^^^^^^^^^^^^
-21 | 1 in frozenset()
-22 | 1 in set(set())
+19 | "b" in f"" ""
+20 | b"a" in bytearray()
+   | ^^^^^^^^^^^^^^^^^^^
+21 | b"a" in bytes()
+22 | 1 in frozenset()
    |
 
 RUF060 Unnecessary membership test on empty collection
   --> RUF060.py:21:1
    |
-19 | b"a" in bytearray()
-20 | b"a" in bytes()
-21 | 1 in frozenset()
-   | ^^^^^^^^^^^^^^^^
-22 | 1 in set(set())
-23 | 2 in frozenset([])
+19 | "b" in f"" ""
+20 | b"a" in bytearray()
+21 | b"a" in bytes()
+   | ^^^^^^^^^^^^^^^
+22 | 1 in frozenset()
+23 | 1 in set(set())
    |
 
 RUF060 Unnecessary membership test on empty collection
   --> RUF060.py:22:1
    |
-20 | b"a" in bytes()
-21 | 1 in frozenset()
-22 | 1 in set(set())
-   | ^^^^^^^^^^^^^^^
-23 | 2 in frozenset([])
-24 | '' in set("")
+20 | b"a" in bytearray()
+21 | b"a" in bytes()
+22 | 1 in frozenset()
+   | ^^^^^^^^^^^^^^^^
+23 | 1 in set(set())
+24 | 2 in frozenset([])
    |
 
 RUF060 Unnecessary membership test on empty collection
   --> RUF060.py:23:1
    |
-21 | 1 in frozenset()
-22 | 1 in set(set())
-23 | 2 in frozenset([])
-   | ^^^^^^^^^^^^^^^^^^
-24 | '' in set("")
+21 | b"a" in bytes()
+22 | 1 in frozenset()
+23 | 1 in set(set())
+   | ^^^^^^^^^^^^^^^
+24 | 2 in frozenset([])
+25 | '' in set("")
    |
 
 RUF060 Unnecessary membership test on empty collection
   --> RUF060.py:24:1
    |
-22 | 1 in set(set())
-23 | 2 in frozenset([])
-24 | '' in set("")
+22 | 1 in frozenset()
+23 | 1 in set(set())
+24 | 2 in frozenset([])
+   | ^^^^^^^^^^^^^^^^^^
+25 | '' in set("")
+   |
+
+RUF060 Unnecessary membership test on empty collection
+  --> RUF060.py:25:1
+   |
+23 | 1 in set(set())
+24 | 2 in frozenset([])
+25 | '' in set("")
    | ^^^^^^^^^^^^^
-25 |
-26 | # OK
+26 |
+27 | # OK
    |


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Fixes #20238

Replace inline f-string emptiness check with `is_empty_f_string` helper function

## Test Plan

<!-- How was it tested? -->

I have added test cases to `crates/ruff_linter/resources/test/fixtures/ruff/RUF060.py`