### PR TITLE
Stabilize the remaining Airflow rules

### DIFF
--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -1109,7 +1109,7 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         (Airflow, "002") => (RuleGroup::Preview, rules::airflow::rules::AirflowDagNoScheduleArgument),
         (Airflow, "301") => (RuleGroup::Preview, rules::airflow::rules::Airflow3Removal),
         (Airflow, "302") => (RuleGroup::Preview, rules::airflow::rules::Airflow3MovedToProvider),
-        (Airflow, "311") => (RuleGroup::Preview, rules::airflow::rules::Airflow3SuggestedUpdate),
+        (Airflow, "311") => (RuleGroup::Stable, rules::airflow::rules::Airflow3SuggestedUpdate),
         (Airflow, "312") => (RuleGroup::Preview, rules::airflow::rules::Airflow3SuggestedToMoveToProvider),
 
         // perflint

--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -1107,7 +1107,7 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         // airflow
         (Airflow, "001") => (RuleGroup::Stable, rules::airflow::rules::AirflowVariableNameTaskIdMismatch),
         (Airflow, "002") => (RuleGroup::Preview, rules::airflow::rules::AirflowDagNoScheduleArgument),
-        (Airflow, "301") => (RuleGroup::Preview, rules::airflow::rules::Airflow3Removal),
+        (Airflow, "301") => (RuleGroup::Stable, rules::airflow::rules::Airflow3Removal),
         (Airflow, "302") => (RuleGroup::Preview, rules::airflow::rules::Airflow3MovedToProvider),
         (Airflow, "311") => (RuleGroup::Stable, rules::airflow::rules::Airflow3SuggestedUpdate),
         (Airflow, "312") => (RuleGroup::Stable, rules::airflow::rules::Airflow3SuggestedToMoveToProvider),

--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -1106,7 +1106,7 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
 
         // airflow
         (Airflow, "001") => (RuleGroup::Stable, rules::airflow::rules::AirflowVariableNameTaskIdMismatch),
-        (Airflow, "002") => (RuleGroup::Preview, rules::airflow::rules::AirflowDagNoScheduleArgument),
+        (Airflow, "002") => (RuleGroup::Stable, rules::airflow::rules::AirflowDagNoScheduleArgument),
         (Airflow, "301") => (RuleGroup::Stable, rules::airflow::rules::Airflow3Removal),
         (Airflow, "302") => (RuleGroup::Stable, rules::airflow::rules::Airflow3MovedToProvider),
         (Airflow, "311") => (RuleGroup::Stable, rules::airflow::rules::Airflow3SuggestedUpdate),

--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -1108,7 +1108,7 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         (Airflow, "001") => (RuleGroup::Stable, rules::airflow::rules::AirflowVariableNameTaskIdMismatch),
         (Airflow, "002") => (RuleGroup::Preview, rules::airflow::rules::AirflowDagNoScheduleArgument),
         (Airflow, "301") => (RuleGroup::Stable, rules::airflow::rules::Airflow3Removal),
-        (Airflow, "302") => (RuleGroup::Preview, rules::airflow::rules::Airflow3MovedToProvider),
+        (Airflow, "302") => (RuleGroup::Stable, rules::airflow::rules::Airflow3MovedToProvider),
         (Airflow, "311") => (RuleGroup::Stable, rules::airflow::rules::Airflow3SuggestedUpdate),
         (Airflow, "312") => (RuleGroup::Stable, rules::airflow::rules::Airflow3SuggestedToMoveToProvider),
 

--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -1110,7 +1110,7 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         (Airflow, "301") => (RuleGroup::Preview, rules::airflow::rules::Airflow3Removal),
         (Airflow, "302") => (RuleGroup::Preview, rules::airflow::rules::Airflow3MovedToProvider),
         (Airflow, "311") => (RuleGroup::Stable, rules::airflow::rules::Airflow3SuggestedUpdate),
-        (Airflow, "312") => (RuleGroup::Preview, rules::airflow::rules::Airflow3SuggestedToMoveToProvider),
+        (Airflow, "312") => (RuleGroup::Stable, rules::airflow::rules::Airflow3SuggestedToMoveToProvider),
 
         // perflint
         (Perflint, "101") => (RuleGroup::Stable, rules::perflint::rules::UnnecessaryListCast),

--- a/crates/ruff_linter/src/rules/airflow/rules/moved_to_provider_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/moved_to_provider_in_3.rs
@@ -13,13 +13,13 @@ use ruff_text_size::TextRange;
 use crate::{FixAvailability, Violation};
 
 /// ## What it does
-/// Checks for uses of Airflow functions and values that have been moved to it providers.
-/// (e.g., apache-airflow-providers-fab)
+/// Checks for uses of Airflow functions and values that have been moved to its providers
+/// (e.g., `apache-airflow-providers-fab`).
 ///
 /// ## Why is this bad?
 /// Airflow 3.0 moved various deprecated functions, members, and other
 /// values to its providers. The user needs to install the corresponding provider and replace
-/// the original usage with the one in the provider
+/// the original usage with the one in the provider.
 ///
 /// ## Example
 /// ```python

--- a/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
@@ -23,7 +23,7 @@ use ruff_text_size::TextRange;
 /// ## Why is this bad?
 /// Airflow 3.0 removed various deprecated functions, members, and other
 /// values. Some have more modern replacements. Others are considered too niche
-/// and not worth to be maintained in Airflow.
+/// and not worth continued maintenance in Airflow.
 ///
 /// ## Example
 /// ```python

--- a/crates/ruff_linter/src/rules/airflow/rules/suggested_to_update_3_0.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/suggested_to_update_3_0.rs
@@ -17,9 +17,9 @@ use ruff_text_size::TextRange;
 /// ## Why is this bad?
 /// Airflow 3.0 removed various deprecated functions, members, and other
 /// values. Some have more modern replacements. Others are considered too niche
-/// and not worth to be maintained in Airflow.
+/// and not worth continued maintenance in Airflow.
 /// Even though these symbols still work fine on Airflow 3.0, they are expected to be removed in a future version.
-/// The user is suggested to replace the original usage with the new ones.
+/// Where available, users should replace the removed functionality with the new alternatives.
 ///
 /// ## Example
 /// ```python


### PR DESCRIPTION
- **Stabilize `airflow3-suggested-update` (`AIR311`)**
- **Stabilize `airflow3-suggested-to-move-to-provider` (`AIR312`)**
- **Stabilize `airflow3-removal` (`AIR301`)**
- **Stabilize `airflow3-moved-to-provider` (`AIR302`)**
- **Stabilize `airflow-dag-no-schedule-argument` (`AIR002`)**

I put this all in one PR to make it easier to double check with @Lee-W before we merge this. I also made a few minor documentation changes and updated one error message that I want to make sure are okay. But for the most part this just moves the rules from `RuleGroup::Preview` to `RuleGroup::Stable`!

Fixes #17749 