### PR TITLE
Stabilize `single-item-membership-test` (`FURB171`)

### DIFF
--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -1160,7 +1160,7 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         (Refurb, "167") => (RuleGroup::Stable, rules::refurb::rules::RegexFlagAlias),
         (Refurb, "168") => (RuleGroup::Stable, rules::refurb::rules::IsinstanceTypeNone),
         (Refurb, "169") => (RuleGroup::Stable, rules::refurb::rules::TypeNoneComparison),
-        (Refurb, "171") => (RuleGroup::Preview, rules::refurb::rules::SingleItemMembershipTest),
+        (Refurb, "171") => (RuleGroup::Stable, rules::refurb::rules::SingleItemMembershipTest),
         (Refurb, "177") => (RuleGroup::Stable, rules::refurb::rules::ImplicitCwd),
         (Refurb, "180") => (RuleGroup::Preview, rules::refurb::rules::MetaClassABCMeta),
         (Refurb, "181") => (RuleGroup::Stable, rules::refurb::rules::HashlibDigestHex),


### PR DESCRIPTION
This rule has been a stabilization candidate at least as far back as 0.6, but it
had a few issues that blocked stabilization each time. The last issue was before
the 0.12 release, so I think it's worth trying this one again.

The docs and tests looked good.
