### PR TITLE
[ty] Narrow specialized generics using isinstance()

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
+++ b/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
@@ -281,12 +281,10 @@ def if_else_exhaustive(x: A[D] | B[E] | C[F]):
     elif isinstance(x, C):
         pass
     else:
-        # TODO: both of these are false positives (https://github.com/astral-sh/ty/issues/456)
-        no_diagnostic_here  # error: [unresolved-reference]
-        assert_never(x)  # error: [type-assertion-failure]
+        no_diagnostic_here
+        assert_never(x)
 
-# TODO: false-positive diagnostic (https://github.com/astral-sh/ty/issues/456)
-def if_else_exhaustive_no_assertion(x: A[D] | B[E] | C[F]) -> int:  # error: [invalid-return-type]
+def if_else_exhaustive_no_assertion(x: A[D] | B[E] | C[F]) -> int:
     if isinstance(x, A):
         return 0
     elif isinstance(x, B):

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -174,10 +174,10 @@ impl ClassInfoConstraintFunction {
     fn generate_constraint<'db>(self, db: &'db dyn Db, classinfo: Type<'db>) -> Option<Type<'db>> {
         let constraint_fn = |class: ClassLiteral<'db>| match self {
             ClassInfoConstraintFunction::IsInstance => {
-                Type::instance(db, class.default_specialization(db))
+                Type::instance(db, class.top_materialization(db))
             }
             ClassInfoConstraintFunction::IsSubclass => {
-                SubclassOfType::from(db, class.default_specialization(db))
+                SubclassOfType::from(db, class.top_materialization(db))
             }
         };
 


### PR DESCRIPTION
Closes astral-sh/ty#456. Part of astral-sh/ty#994.

After all the foundational work, this is only a small change, but let's see if it exposes any unresolved issues.