### PR TITLE
[ruff] Treat panics as fatal diagnostics, sort panics last

### DIFF
--- a/crates/ruff/src/lib.rs
+++ b/crates/ruff/src/lib.rs
@@ -9,10 +9,11 @@ use std::sync::mpsc::channel;
 use anyhow::Result;
 use clap::CommandFactory;
 use colored::Colorize;
-use log::warn;
+use log::{error, warn};
 use notify::{RecursiveMode, Watcher, recommended_watcher};
 
 use args::{GlobalConfigArgs, ServerCommand};
+use ruff_db::diagnostic::{Diagnostic, Severity};
 use ruff_linter::logging::{LogLevel, set_up_logging};
 use ruff_linter::settings::flags::FixMode;
 use ruff_linter::settings::types::OutputFormat;
@@ -444,6 +445,27 @@ pub fn check(args: CheckCommand, global_options: GlobalConfigArgs) -> Result<Exi
         }
 
         if !cli.exit_zero {
+            let max_severity = diagnostics
+                .inner
+                .iter()
+                .map(Diagnostic::severity)
+                .max()
+                .unwrap_or(Severity::Info);
+            if max_severity.is_fatal() {
+                // When a panic/fatal error is reported, prompt the user to open an issue on github.
+                // Diagnostics with severity `fatal` will be sorted to the bottom, and printing the
+                // message here instead of attaching it to the diagnostic ensures that we only print
+                // it once instead of repeating it for each diagnostic. Prints to stderr to prevent
+                // the message from being captured by tools parsing the normal output.
+                let message = "Panic during linting indicates a bug in Ruff. If you could open an issue at:
+
+https://github.com/astral-sh/ruff/issues/new?title=%5BLinter%20panic%5D
+
+...with the relevant file contents, the `pyproject.toml` settings, and the stack trace above, we'd be very appreciative!
+";
+                error!("{message}");
+                return Ok(ExitStatus::Error);
+            }
             if cli.diff {
                 // If we're printing a diff, we always want to exit non-zero if there are
                 // any fixable violations (since we've printed the diff, but not applied the

--- a/crates/ruff_db/src/diagnostic/mod.rs
+++ b/crates/ruff_db/src/diagnostic/mod.rs
@@ -499,10 +499,12 @@ impl Diagnostic {
     /// Panics if either diagnostic has no primary span, or if its file is not a `SourceFile`.
     pub fn ruff_start_ordering(&self, other: &Self) -> std::cmp::Ordering {
         let a = (
+            self.severity().is_fatal(),
             self.expect_ruff_source_file(),
             self.range().map(|r| r.start()),
         );
         let b = (
+            other.severity().is_fatal(),
             other.expect_ruff_source_file(),
             other.range().map(|r| r.start()),
         );

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -3266,6 +3266,11 @@ impl<'a> LintContext<'a> {
     pub(crate) const fn settings(&self) -> &LinterSettings {
         self.settings
     }
+
+    #[cfg(any(feature = "test-rules", test))]
+    pub(crate) const fn source_file(&self) -> &SourceFile {
+        &self.source_file
+    }
 }
 
 /// An abstraction for mutating a diagnostic.

--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -1080,6 +1080,8 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         (Ruff, "950") => (RuleGroup::Stable, rules::ruff::rules::RedirectedToTestRule),
         #[cfg(any(feature = "test-rules", test))]
         (Ruff, "960") => (RuleGroup::Removed, rules::ruff::rules::RedirectedFromPrefixTestRule),
+        #[cfg(any(feature = "test-rules", test))]
+        (Ruff, "990") => (RuleGroup::Preview, rules::ruff::rules::PanicyTestRule),
 
 
         // flake8-django

--- a/crates/ruff_linter/src/linter.rs
+++ b/crates/ruff_linter/src/linter.rs
@@ -319,6 +319,9 @@ pub fn check_path(
                         &context,
                     );
                 }
+                Rule::PanicyTestRule => {
+                    test_rules::PanicyTestRule::diagnostic(locator, comment_ranges, &context);
+                }
                 _ => unreachable!("All test rules must have an implementation"),
             }
         }

--- a/crates/ruff_linter/src/rules/ruff/rules/test_rules.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/test_rules.rs
@@ -46,6 +46,7 @@ pub(crate) const TEST_RULES: &[Rule] = &[
     Rule::RedirectedFromTestRule,
     Rule::RedirectedToTestRule,
     Rule::RedirectedFromPrefixTestRule,
+    Rule::PanicyTestRule,
 ];
 
 pub(crate) trait TestRule {
@@ -474,6 +475,42 @@ impl TestRule for RedirectedFromPrefixTestRule {
         context.report_diagnostic(
             RedirectedFromPrefixTestRule,
             ruff_text_size::TextRange::default(),
+        );
+    }
+}
+
+/// # What it does
+/// Fake rule for testing panics.
+///
+/// # Why is this bad?
+/// Panics are bad.
+///
+/// # Example
+/// ```python
+/// foo
+/// ```
+///
+/// Use instead:
+/// ```python
+/// bar
+/// ```
+#[derive(ViolationMetadata)]
+pub(crate) struct PanicyTestRule;
+
+impl Violation for PanicyTestRule {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::None;
+
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        "If you see this, maybe panic!".to_string()
+    }
+}
+
+impl TestRule for PanicyTestRule {
+    fn diagnostic(_locator: &Locator, _comment_ranges: &CommentRanges, context: &LintContext) {
+        assert!(
+            !context.source_file().name().ends_with("panic.py"),
+            "This is a fake panic for testing."
         );
     }
 }


### PR DESCRIPTION
- Convert panics to diagnostics with id `Panic`, severity `Fatal`, and the error as the diagnostic message, annotated with a `Span` with empty code block and no range.
- Updates the post-linting message diagnostic handling to track the maximum severity seen, and then prints the "report a bug in ruff" message only if the max severity was `Fatal`

This depends on the sorting changes since it creates diagnostics with no range specified.

