### PR TITLE
[ty] propagate visitors and constraints through has_relation_in_invariant_position

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
@@ -287,18 +287,18 @@ def _(x: C):
     reveal_type(x)  # revealed: () -> C | None
 ```
 
-### Recursive relation in invariant position
+### Subtyping of materializations of cyclic aliases
 
 ```py
-from typing import Any, Callable
+from ty_extensions import static_assert, is_subtype_of, Bottom, Top
 
 type JsonValue = None | JsonDict
 type JsonDict = dict[str, JsonValue]
-type JsonSchemaExtraCallable = Callable[[JsonDict], None] | Callable[[JsonDict, type[Any]], None]
 
-def _update_class_schema(json_schema: dict[str, Any], json_schema_extra: JsonSchemaExtraCallable) -> None:
-    if isinstance(json_schema_extra, dict):
-        json_schema.update(json_schema_extra)
+static_assert(is_subtype_of(Top[JsonDict], Top[JsonDict]))
+static_assert(is_subtype_of(Top[JsonDict], Bottom[JsonDict]))
+static_assert(is_subtype_of(Bottom[JsonDict], Bottom[JsonDict]))
+static_assert(is_subtype_of(Bottom[JsonDict], Top[JsonDict]))
 ```
 
 ### Union inside generic

--- a/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
@@ -287,6 +287,20 @@ def _(x: C):
     reveal_type(x)  # revealed: () -> C | None
 ```
 
+### Recursive relation in invariant position
+
+```py
+from typing import Any, Callable
+
+type JsonValue = None | JsonDict
+type JsonDict = dict[str, JsonValue]
+type JsonSchemaExtraCallable = Callable[[JsonDict], None] | Callable[[JsonDict, type[Any]], None]
+
+def _update_class_schema(json_schema: dict[str, Any], json_schema_extra: JsonSchemaExtraCallable) -> None:
+    if isinstance(json_schema_extra, dict):
+        json_schema.update(json_schema_extra)
+```
+
 ### Union inside generic
 
 #### With old-style union

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -451,6 +451,7 @@ fn is_subtype_in_invariant_position<'db, C: Constraints<'db>>(
     derived_materialization: MaterializationKind,
     base_type: &Type<'db>,
     base_materialization: MaterializationKind,
+    visitor: &HasRelationToVisitor<'db, C>,
 ) -> C {
     let derived_top = derived_type.top_materialization(db);
     let derived_bottom = derived_type.bottom_materialization(db);
@@ -459,37 +460,52 @@ fn is_subtype_in_invariant_position<'db, C: Constraints<'db>>(
     match (derived_materialization, base_materialization) {
         // `Derived` is a subtype of `Base` if the range of materializations covered by `Derived`
         // is a subset of the range covered by `Base`.
-        (MaterializationKind::Top, MaterializationKind::Top) => C::from_bool(
-            db,
-            base_bottom.is_subtype_of(db, derived_bottom)
-                && derived_top.is_subtype_of(db, base_top),
-        ),
+        (MaterializationKind::Top, MaterializationKind::Top) => base_bottom
+            .has_relation_to_impl(db, derived_bottom, TypeRelation::Subtyping, visitor)
+            .and(db, || {
+                derived_top.has_relation_to_impl(db, base_top, TypeRelation::Subtyping, visitor)
+            }),
         // One bottom is a subtype of another if it covers a strictly larger set of materializations.
-        (MaterializationKind::Bottom, MaterializationKind::Bottom) => C::from_bool(
-            db,
-            derived_bottom.is_subtype_of(db, base_bottom)
-                && base_top.is_subtype_of(db, derived_top),
-        ),
+        (MaterializationKind::Bottom, MaterializationKind::Bottom) => derived_bottom
+            .has_relation_to_impl(db, base_bottom, TypeRelation::Subtyping, visitor)
+            .and(db, || {
+                base_top.has_relation_to_impl(db, derived_top, TypeRelation::Subtyping, visitor)
+            }),
         // The bottom materialization of `Derived` is a subtype of the top materialization
         // of `Base` if there is some type that is both within the
         // range of types covered by derived and within the range covered by base, because if such a type
         // exists, it's a subtype of `Top[base]` and a supertype of `Bottom[derived]`.
-        (MaterializationKind::Bottom, MaterializationKind::Top) => C::from_bool(
-            db,
-            (base_bottom.is_subtype_of(db, derived_bottom)
-                && derived_bottom.is_subtype_of(db, base_top))
-                || (base_bottom.is_subtype_of(db, derived_top)
-                    && derived_top.is_subtype_of(db, base_top)
-                    || (base_top.is_subtype_of(db, derived_top)
-                        && derived_bottom.is_subtype_of(db, base_top))),
-        ),
+        (MaterializationKind::Bottom, MaterializationKind::Top) => (base_bottom
+            .has_relation_to_impl(db, derived_bottom, TypeRelation::Subtyping, visitor)
+            .and(db, || {
+                derived_bottom.has_relation_to_impl(db, base_top, TypeRelation::Subtyping, visitor)
+            }))
+        .or(db, || {
+            base_bottom
+                .has_relation_to_impl(db, derived_top, TypeRelation::Subtyping, visitor)
+                .and(db, || {
+                    derived_top.has_relation_to_impl(db, base_top, TypeRelation::Subtyping, visitor)
+                })
+                .or(db, || {
+                    base_top
+                        .has_relation_to_impl(db, derived_top, TypeRelation::Subtyping, visitor)
+                        .and(db, || {
+                            derived_bottom.has_relation_to_impl(
+                                db,
+                                base_top,
+                                TypeRelation::Subtyping,
+                                visitor,
+                            )
+                        })
+                })
+        }),
         // A top materialization is a subtype of a bottom materialization only if both original
         // un-materialized types are the same fully static type.
-        (MaterializationKind::Top, MaterializationKind::Bottom) => C::from_bool(
-            db,
-            derived_top.is_subtype_of(db, base_bottom)
-                && base_top.is_subtype_of(db, derived_bottom),
-        ),
+        (MaterializationKind::Top, MaterializationKind::Bottom) => derived_top
+            .has_relation_to_impl(db, base_bottom, TypeRelation::Subtyping, visitor)
+            .and(db, || {
+                base_top.has_relation_to_impl(db, derived_bottom, TypeRelation::Subtyping, visitor)
+            }),
     }
 }
 
@@ -503,23 +519,32 @@ fn has_relation_in_invariant_position<'db, C: Constraints<'db>>(
     base_type: &Type<'db>,
     base_materialization: Option<MaterializationKind>,
     relation: TypeRelation,
+    visitor: &HasRelationToVisitor<'db, C>,
 ) -> C {
     match (derived_materialization, base_materialization, relation) {
         // Top and bottom materializations are fully static types, so subtyping
         // is the same as assignability.
-        (Some(derived_mat), Some(base_mat), _) => {
-            is_subtype_in_invariant_position(db, derived_type, derived_mat, base_type, base_mat)
-        }
+        (Some(derived_mat), Some(base_mat), _) => is_subtype_in_invariant_position(
+            db,
+            derived_type,
+            derived_mat,
+            base_type,
+            base_mat,
+            visitor,
+        ),
         // Subtyping between invariant type parameters without a top/bottom materialization involved
         // is equivalence
-        (None, None, TypeRelation::Subtyping) => {
-            C::from_bool(db, derived_type.is_equivalent_to(db, *base_type))
-        }
-        (None, None, TypeRelation::Assignability) => C::from_bool(
-            db,
-            derived_type.is_assignable_to(db, *base_type)
-                && base_type.is_assignable_to(db, *derived_type),
-        ),
+        (None, None, TypeRelation::Subtyping) => derived_type.when_equivalent_to(db, *base_type),
+        (None, None, TypeRelation::Assignability) => derived_type
+            .has_relation_to_impl(db, *base_type, TypeRelation::Assignability, visitor)
+            .and(db, || {
+                base_type.has_relation_to_impl(
+                    db,
+                    *derived_type,
+                    TypeRelation::Assignability,
+                    visitor,
+                )
+            }),
         // For gradual types, A <: B (subtyping) is defined as Top[A] <: Bottom[B]
         (None, Some(base_mat), TypeRelation::Subtyping) => is_subtype_in_invariant_position(
             db,
@@ -527,6 +552,7 @@ fn has_relation_in_invariant_position<'db, C: Constraints<'db>>(
             MaterializationKind::Top,
             base_type,
             base_mat,
+            visitor,
         ),
         (Some(derived_mat), None, TypeRelation::Subtyping) => is_subtype_in_invariant_position(
             db,
@@ -534,6 +560,7 @@ fn has_relation_in_invariant_position<'db, C: Constraints<'db>>(
             derived_mat,
             base_type,
             MaterializationKind::Bottom,
+            visitor,
         ),
         // And A <~ B (assignability) is Bottom[A] <: Top[B]
         (None, Some(base_mat), TypeRelation::Assignability) => is_subtype_in_invariant_position(
@@ -542,6 +569,7 @@ fn has_relation_in_invariant_position<'db, C: Constraints<'db>>(
             MaterializationKind::Bottom,
             base_type,
             base_mat,
+            visitor,
         ),
         (Some(derived_mat), None, TypeRelation::Assignability) => is_subtype_in_invariant_position(
             db,
@@ -549,6 +577,7 @@ fn has_relation_in_invariant_position<'db, C: Constraints<'db>>(
             derived_mat,
             base_type,
             MaterializationKind::Top,
+            visitor,
         ),
     }
 }
@@ -805,6 +834,7 @@ impl<'db> Specialization<'db> {
                     other_type,
                     other_materialization_kind,
                     relation,
+                    visitor,
                 ),
                 TypeVarVariance::Covariant => {
                     self_type.has_relation_to_impl(db, *other_type, relation, visitor)

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -483,10 +483,10 @@ fn is_subtype_in_invariant_position<'db, C: Constraints<'db>>(
             .or(db, || {
                 is_subtype_of(base_bottom, derived_top)
                     .and(db, || is_subtype_of(derived_top, base_top))
-                    .or(db, || {
-                        is_subtype_of(base_top, derived_top)
-                            .and(db, || is_subtype_of(derived_bottom, base_top))
-                    })
+            })
+            .or(db, || {
+                is_subtype_of(base_top, derived_top)
+                    .and(db, || is_subtype_of(derived_bottom, base_top))
             })
         }
         // A top materialization is a subtype of a bottom materialization only if both original


### PR DESCRIPTION
## Summary

The sub-checks for assignability and subtyping of materializations performed in `has_relation_in_invariant_position` and `is_subtype_in_invariant_position` need to propagate the `HasRelationToVisitor`, or we can stack overflow.

A side effect of this change is that we also propagate the `ConstraintSet` through, rather than using `C::from_bool`, which I think may also become important for correctness in cases involving type variables (though it isn't testable yet, since we aren't yet actually creating constraints other than always-true and always-false.)

## Test Plan

Added mdtest (derived from code found in pydantic) which stack-overflowed before this PR.

With this change incorporated, pydantic now checks successfully on my draft PR for PEP 613 TypeAlias support.
