### PR TITLE
[ty] Cover full range of annotated assignments

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/snapshots/named_tuple.md_-_`NamedTuple`_-_`typing.NamedTuple`_-_Definition_(bbf79630502e65e9).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/named_tuple.md_-_`NamedTuple`_-_`typing.NamedTuple`_-_Definition_(bbf79630502e65e9).snap
@@ -47,7 +47,7 @@ error[invalid-named-tuple]: NamedTuple field without default value cannot follow
   |     --------------------- Earlier field `altitude` defined here with a default value
 5 |     # error: [invalid-named-tuple] "NamedTuple field without default value cannot follow field(s) with default value(s): Field `latitud…
 6 |     latitude: float
-  |     ^^^^^^^^ Field `latitude` defined here without a default value
+  |     ^^^^^^^^^^^^^^^ Field `latitude` defined here without a default value
 7 |     # error: [invalid-named-tuple] "NamedTuple field without default value cannot follow field(s) with default value(s): Field `longitu…
 8 |     longitude: float
   |
@@ -66,7 +66,7 @@ error[invalid-named-tuple]: NamedTuple field without default value cannot follow
  6 |     latitude: float
  7 |     # error: [invalid-named-tuple] "NamedTuple field without default value cannot follow field(s) with default value(s): Field `longit…
  8 |     longitude: float
-   |     ^^^^^^^^^ Field `longitude` defined here without a default value
+   |     ^^^^^^^^^^^^^^^^ Field `longitude` defined here without a default value
  9 |
 10 | class StrangeLocation(NamedTuple):
    |
@@ -83,7 +83,7 @@ error[invalid-named-tuple]: NamedTuple field without default value cannot follow
 14 |     altitude: float = 0.0
    |     --------------------- Earlier field `altitude` defined here with a default value
 15 |     latitude: float  # error: [invalid-named-tuple]
-   |     ^^^^^^^^ Field `latitude` defined here without a default value
+   |     ^^^^^^^^^^^^^^^ Field `latitude` defined here without a default value
 16 |     longitude: float  # error: [invalid-named-tuple]
    |
 info: rule `invalid-named-tuple` is enabled by default
@@ -100,7 +100,7 @@ error[invalid-named-tuple]: NamedTuple field without default value cannot follow
    |     --------------------- Earlier field `altitude` defined here with a default value
 15 |     latitude: float  # error: [invalid-named-tuple]
 16 |     longitude: float  # error: [invalid-named-tuple]
-   |     ^^^^^^^^^ Field `longitude` defined here without a default value
+   |     ^^^^^^^^^^^^^^^^ Field `longitude` defined here without a default value
 17 |
 18 | class VeryStrangeLocation(NamedTuple):
    |
@@ -115,7 +115,7 @@ error[invalid-named-tuple]: NamedTuple field without default value cannot follow
 18 | class VeryStrangeLocation(NamedTuple):
 19 |     altitude: float = 0.0
 20 |     latitude: float  # error: [invalid-named-tuple]
-   |     ^^^^^^^^ Field `latitude` defined here without a default value
+   |     ^^^^^^^^^^^^^^^ Field `latitude` defined here without a default value
 21 |     longitude: float  # error: [invalid-named-tuple]
 22 |     altitude: float = 0.0
    |
@@ -131,7 +131,7 @@ error[invalid-named-tuple]: NamedTuple field without default value cannot follow
 19 |     altitude: float = 0.0
 20 |     latitude: float  # error: [invalid-named-tuple]
 21 |     longitude: float  # error: [invalid-named-tuple]
-   |     ^^^^^^^^^ Field `longitude` defined here without a default value
+   |     ^^^^^^^^^^^^^^^^ Field `longitude` defined here without a default value
 22 |     altitude: float = 0.0
    |
 info: Earlier field `altitude` was defined with a default value

--- a/crates/ty_python_semantic/src/semantic_index/definition.rs
+++ b/crates/ty_python_semantic/src/semantic_index/definition.rs
@@ -769,13 +769,14 @@ impl DefinitionKind<'_> {
                 target_range.cover(value_range)
             }
             DefinitionKind::AnnotatedAssignment(assign) => {
-                let target_range = assign.target.node(module).range();
+                let mut full_range = assign.target.node(module).range();
+                full_range = full_range.cover(assign.annotation.node(module).range());
+
                 if let Some(ref value) = assign.value {
-                    let value_range = value.node(module).range();
-                    target_range.cover(value_range)
-                } else {
-                    target_range
+                    full_range = full_range.cover(value.node(module).range());
                 }
+
+                full_range
             }
             DefinitionKind::AugmentedAssignment(aug_assign) => aug_assign.node(module).range(),
             DefinitionKind::For(for_stmt) => for_stmt.target.node(module).range(),


### PR DESCRIPTION
## Summary

An annotated assignment `name: annotation` without a right-hand side was previously not covered by the range returned from `DefinitionKind::full_range`, because we did expand the range to include the right-hand side (if there was one), but failed to include the annotation.

## Test Plan

Updated snapshot tests
