### PR TITLE
[ty] Include `python` folder in `environment.root` if it exists

### DIFF
--- a/crates/ty/docs/configuration.md
+++ b/crates/ty/docs/configuration.md
@@ -144,7 +144,7 @@ If left unspecified, ty will try to detect common project layouts and initialize
 * if a `./<project-name>/<project-name>` directory exists, include `.` and `./<project-name>` in the first party search path
 * otherwise, default to `.` (flat layout)
 
-Besides, if a `./tests` directory exists and is not a package (i.e. it does not contain an `__init__.py` file),
+Besides, if a `./python` or `./tests` directory exists and is not a package (i.e. it does not contain an `__init__.py` or `__init__.pyi` file),
 it will also be included in the first party search path.
 
 **Default value**: `null`

--- a/crates/ty_project/src/metadata/options.rs
+++ b/crates/ty_project/src/metadata/options.rs
@@ -259,6 +259,19 @@ impl Options {
                 vec![project_root.to_path_buf()]
             };
 
+            let python = project_root.join("python");
+            if system.is_directory(&python) {
+                // If a `./python` directory exists, include it as a source root. This is the recommended layout
+                // maturin-based rust/python projects [1].
+                //
+                // https://github.com/PyO3/maturin/blob/979fe1db42bb9e58bc150fa6fc45360b377288bf/README.md?plain=1#L88-L99
+                tracing::debug!(
+                    "Including `./python` in `environment.root` because a `./python` directory exists"
+                );
+
+                roots.push(python);
+            }
+
             // Considering pytest test discovery conventions,
             // we also include the `tests` directory if it exists and is not a package.
             let tests_dir = project_root.join("tests");

--- a/crates/ty_project/src/metadata/options.rs
+++ b/crates/ty_project/src/metadata/options.rs
@@ -260,9 +260,13 @@ impl Options {
             };
 
             let python = project_root.join("python");
-            if system.is_directory(&python) {
+            if system.is_directory(&python)
+                && !system.is_file(&python.join("__init__.py"))
+                && !system.is_file(&python.join("__init__.pyi"))
+                && !roots.contains(&python)
+            {
                 // If a `./python` directory exists, include it as a source root. This is the recommended layout
-                // maturin-based rust/python projects [1].
+                // for maturin-based rust/python projects [1].
                 //
                 // https://github.com/PyO3/maturin/blob/979fe1db42bb9e58bc150fa6fc45360b377288bf/README.md?plain=1#L88-L99
                 tracing::debug!(
@@ -277,6 +281,7 @@ impl Options {
             let tests_dir = project_root.join("tests");
             if system.is_directory(&tests_dir)
                 && !system.is_file(&tests_dir.join("__init__.py"))
+                && !system.is_file(&tests_dir.join("__init__.pyi"))
                 && !roots.contains(&tests_dir)
             {
                 // If the `tests` directory exists and is not a package, include it as a source root.
@@ -441,7 +446,7 @@ pub struct EnvironmentOptions {
     /// * if a `./<project-name>/<project-name>` directory exists, include `.` and `./<project-name>` in the first party search path
     /// * otherwise, default to `.` (flat layout)
     ///
-    /// Besides, if a `./tests` directory exists and is not a package (i.e. it does not contain an `__init__.py` file),
+    /// Besides, if a `./python` or `./tests` directory exists and is not a package (i.e. it does not contain an `__init__.py` or `__init__.pyi` file),
     /// it will also be included in the first party search path.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[option(

--- a/ty.schema.json
+++ b/ty.schema.json
@@ -101,7 +101,7 @@
           ]
         },
         "root": {
-          "description": "The root paths of the project, used for finding first-party modules.\n\nAccepts a list of directory paths searched in priority order (first has highest priority).\n\nIf left unspecified, ty will try to detect common project layouts and initialize `root` accordingly:\n\n* if a `./src` directory exists, include `.` and `./src` in the first party search path (src layout or flat) * if a `./<project-name>/<project-name>` directory exists, include `.` and `./<project-name>` in the first party search path * otherwise, default to `.` (flat layout)\n\nBesides, if a `./tests` directory exists and is not a package (i.e. it does not contain an `__init__.py` file), it will also be included in the first party search path.",
+          "description": "The root paths of the project, used for finding first-party modules.\n\nAccepts a list of directory paths searched in priority order (first has highest priority).\n\nIf left unspecified, ty will try to detect common project layouts and initialize `root` accordingly:\n\n* if a `./src` directory exists, include `.` and `./src` in the first party search path (src layout or flat) * if a `./<project-name>/<project-name>` directory exists, include `.` and `./<project-name>` in the first party search path * otherwise, default to `.` (flat layout)\n\nBesides, if a `./python` or `./tests` directory exists and is not a package (i.e. it does not contain an `__init__.py` or `__init__.pyi` file), it will also be included in the first party search path.",
           "type": [
             "array",
             "null"


### PR DESCRIPTION
## Summary

I felt it was safer to add the `python` folder *in addition* to a possibly-existing `src` folder, even though the `src` folder only contains Rust code for `maturin`-based projects. There might be non-maturin projects where a `python` folder exists for other reasons, next to a normal `src` layout.

closes https://github.com/astral-sh/ty/issues/1120

## Test Plan

Tested locally on the egglog-python project.
