### PR TITLE
[ty] Treat `Hashable`, and similar protocols, equivalently to `object` for subtyping/assignability

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/mro.md
+++ b/crates/ty_python_semantic/resources/mdtest/mro.md
@@ -165,7 +165,9 @@ from does_not_exist import DoesNotExist  # error: [unresolved-import]
 reveal_type(DoesNotExist)  # revealed: Unknown
 
 if hasattr(DoesNotExist, "__mro__"):
-    reveal_type(DoesNotExist)  # revealed: Unknown & <Protocol with members '__mro__'>
+    # TODO: this should be `Unknown & <Protocol with members '__mro__'>` or similar
+    # (The second part of the intersection is incorrectly simplified to `object` due to https://github.com/astral-sh/ty/issues/986)
+    reveal_type(DoesNotExist)  # revealed: Unknown
 
     class Foo(DoesNotExist): ...  # no error!
     reveal_type(Foo.__mro__)  # revealed: tuple[<class 'Foo'>, Unknown, <class 'object'>]

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1349,6 +1349,9 @@ impl<'db> Type<'db> {
             (_, Type::NominalInstance(instance)) if instance.is_object(db) => {
                 C::always_satisfiable(db)
             }
+            (_, Type::ProtocolInstance(_)) if target.normalized(db).is_object(db) => {
+                C::always_satisfiable(db)
+            }
 
             // `Never` is the bottom type, the empty set.
             // It is a subtype of all other types.


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
