### PR TITLE
[ty] Fall back to `object` for attribute access on synthesized protocols

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/callable.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/callable.md
@@ -395,8 +395,12 @@ def f_okay(c: Callable[[], None]):
         reveal_type(c.__qualname__)  # revealed: object
 
         # TODO: should be `property`
+        # (or complain that we don't know that `type(c)` has the attribute at all!)
         reveal_type(type(c).__qualname__)  # revealed: @Todo(Intersection meta-type)
-        # TODO: we should emit an error here (`hasattr` only guarantees that an attribute is readable.)
+
+        # `hasattr` only guarantees that an attribute is readable.
+        #
+        # error: [invalid-assignment] "Object of type `Literal["my_callable"]` is not assignable to attribute `__qualname__` on type `(() -> None) & <Protocol with members '__qualname__'>`"
         c.__qualname__ = "my_callable"
 
         result = getattr_static(c, "__qualname__")

--- a/crates/ty_python_semantic/resources/mdtest/annotations/callable.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/callable.md
@@ -392,9 +392,11 @@ from inspect import getattr_static
 
 def f_okay(c: Callable[[], None]):
     if hasattr(c, "__qualname__"):
-        c.__qualname__  # okay
-        # `hasattr` only guarantees that an attribute is readable.
-        # error: [invalid-assignment] "Object of type `Literal["my_callable"]` is not assignable to attribute `__qualname__` on type `(() -> None) & <Protocol with members '__qualname__'>`"
+        reveal_type(c.__qualname__)  # revealed: object
+
+        # TODO: should be `property`
+        reveal_type(type(c).__qualname__)  # revealed: @Todo(Intersection meta-type)
+        # TODO: we should emit an error here (`hasattr` only guarantees that an attribute is readable.)
         c.__qualname__ = "my_callable"
 
         result = getattr_static(c, "__qualname__")

--- a/crates/ty_python_semantic/resources/mdtest/narrow/hasattr.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/hasattr.md
@@ -85,11 +85,16 @@ def _(obj: MaybeWithSpam):
         reveal_type(obj.spam)  # revealed: int
 ```
 
-All attribute available on `object` are still available on these synthesized protocols:
+All attribute available on `object` are still available on these synthesized protocols, but
+attributes that are not present on `object` are not available:
 
 ```py
 def f(x: object):
     if hasattr(x, "__qualname__"):
         reveal_type(x.__repr__)  # revealed: bound method object.__repr__() -> str
         reveal_type(x.__str__)  # revealed: bound method object.__str__() -> str
+        reveal_type(x.__dict__)  # revealed: dict[str, Any]
+
+        # error: [unresolved-attribute] "Type `<Protocol with members '__qualname__'>` has no attribute `foo`"
+        reveal_type(x.foo)  # revealed: Unknown
 ```

--- a/crates/ty_python_semantic/resources/mdtest/narrow/hasattr.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/hasattr.md
@@ -84,3 +84,12 @@ def _(obj: MaybeWithSpam):
         # error: [possibly-unbound-attribute]
         reveal_type(obj.spam)  # revealed: int
 ```
+
+All attribute available on `object` are still available on these synthesized protocols:
+
+```py
+def f(x: object):
+    if hasattr(x, "__qualname__"):
+        reveal_type(x.__repr__)  # revealed: bound method object.__repr__() -> str
+        reveal_type(x.__str__)  # revealed: bound method object.__str__() -> str
+```

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3420,7 +3420,7 @@ impl<'db> Type<'db> {
             Type::ProtocolInstance(ProtocolInstanceType {
                 inner: Protocol::Synthesized(protocol),
                 ..
-            }) if policy.contains(MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK)
+            }) if policy.mro_no_object_fallback()
                 && !protocol.interface().includes_member(db, name_str) =>
             {
                 Place::Unbound.into()

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3409,6 +3409,23 @@ impl<'db> Type<'db> {
 
             Type::ModuleLiteral(module) => module.static_member(db, name_str),
 
+            // If a protocol does not include a member and the policy disables falling back to
+            // `object`, we return `Place::Unbound` here. This short-circuits attribute lookup
+            // before we find the "fallback to attribute access on `object`" logic later on
+            // (otherwise we would infer that all synthesized protocols have `__getattribute__`
+            // methods, and therefore that all synthesized protocols have all possible attributes.)
+            //
+            // Note that we could do this for *all* protocols, but it's only *necessary* for synthesized
+            // ones, and the standard logic is *probably* more performant for class-based protocols?
+            Type::ProtocolInstance(ProtocolInstanceType {
+                inner: Protocol::Synthesized(protocol),
+                ..
+            }) if policy.contains(MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK)
+                && !protocol.interface().includes_member(db, name_str) =>
+            {
+                Place::Unbound.into()
+            }
+
             _ if policy.no_instance_fallback() => self.invoke_descriptor_protocol(
                 db,
                 name_str,

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -227,7 +227,7 @@ impl<'db> ProtocolInterface<'db> {
                 place: Place::bound(member.ty()),
                 qualifiers: member.qualifiers(),
             })
-            .unwrap_or_else(|| Type::object(db).instance_member(db, name))
+            .unwrap_or_else(|| Type::object(db).member(db, name))
     }
 
     /// Return `true` if if all members on `self` are also members of `other`.


### PR DESCRIPTION
## Summary

Currently we have false positives for things like this:

```py
def f(x: object):
    if hasattr(x, "__qualname__"):
        reveal_type(x.__dict__)
        reveal_type(x.__repr__)
        reveal_type(x.__reduce__)
```

We complain that none of these attributes exist on an object of type `<Protocol with members '__qualname__'>`. But these attributes all exist on typeshed's stub for `object`, so these complaints don't make much sense.

It looks like the issue is that `ClassLiteral::own_instance_member()` returns `Place::Unbound` for attributes that are declared in the class body but are not bound in any instance methods:

https://github.com/astral-sh/ruff/blob/2467c4352e0f456e16a068ab5b7d09da009df8e2/crates/ty_python_semantic/src/types/class.rs#L3176-L3204

So this PR switches the attribute-fallback logic to use `Type::object(db).member(...)` rather than `Type::object(db).instance_member(db)`.

~~I'm not totally sure if this is the correct fix or not, to be honest! It seems like it also leads to some regressions: we no longer understand that these attributes are read-only, and I'm not totally sure why.~~ With @sharkdp's help, I fixed the regressions.

## Test Plan

Mdtests added
