### PR TITLE
[pycodestyle] Allow gi.require_version[s]() interspersed with imports, for PyGObject (E402) (fixes #20288)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pycodestyle/E402_6.py
+++ b/crates/ruff_linter/resources/test/fixtures/pycodestyle/E402_6.py
@@ -1,0 +1,7 @@
+# Issue: https://github.com/astral-sh/ruff/issues/20288
+import gi
+
+gi.require_version('Gtk', '4.0')
+gi.require_versions({'GObject': '2.0', 'Gio': '2.0'})
+
+from gi.repository import GObject, Gio, Gtk

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -842,7 +842,8 @@ impl<'a> Visitor<'a> for Checker<'a> {
                     || imports::is_sys_path_modification(stmt, self.semantic())
                     || imports::is_os_environ_modification(stmt, self.semantic())
                     || imports::is_pytest_importorskip(stmt, self.semantic())
-                    || imports::is_site_sys_path_modification(stmt, self.semantic()))
+                    || imports::is_site_sys_path_modification(stmt, self.semantic())
+                    || imports::is_gi_version_selection(stmt, self.semantic()))
                 {
                     self.semantic.flags |= SemanticModelFlags::IMPORT_BOUNDARY;
                 }

--- a/crates/ruff_linter/src/rules/pycodestyle/mod.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/mod.rs
@@ -46,6 +46,7 @@ mod tests {
     #[test_case(Rule::ModuleImportNotAtTopOfFile, Path::new("E402_3.py"))]
     #[test_case(Rule::ModuleImportNotAtTopOfFile, Path::new("E402_4.py"))]
     #[test_case(Rule::ModuleImportNotAtTopOfFile, Path::new("E402_5.py"))]
+    #[test_case(Rule::ModuleImportNotAtTopOfFile, Path::new("E402_6.py"))]
     #[test_case(Rule::ModuleImportNotAtTopOfFile, Path::new("E402.ipynb"))]
     #[test_case(Rule::MultipleImportsOnOneLine, Path::new("E40.py"))]
     #[test_case(Rule::MultipleStatementsOnOneLineColon, Path::new("E70.py"))]

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E402_E402_6.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E402_E402_6.py.snap
@@ -1,0 +1,3 @@
+---
+source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
+---


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->


<!-- What's the purpose of the change? What does it do, and why? -->

## Summary

Exempt `gi.require_version()` and `gi.require_versions()` calls from triggering E402 if they appear interspersed with imports, because they are necessary version-selection calls required before importing from `gi.repository`, when working with PyGObject / GIRepository code.

This places `gi.require_version[s]()` calls in the same category as:

* `sys.path` modifications
* `os.environ` modifications
* `site.addsitedir()` calls

And, most similar in both nature and niche-ness:

* `pytest.importorskip()` calls
* `matplotlib.use()` calls
 
All of which are exempted from E402 in Ruff.

Fixes #20288 

## Test Plan

<!-- How was it tested? -->

The PR contains a new test fixture `crates/ruff_linter/resources/test/fixtures/pycodestyle/E402_6.py`.

The sample code contained within triggers E402 without the changes in this PR.

With the PR changes in place, the corresponding test case (added to `crates/ruff_linter/src/rules/pycodestyle/mod.rs`) and `.snap` file result in a passing test.
