### PR TITLE
Extended `SarifEmitter` to include `fixes` in the SARIF ouput

### DIFF
--- a/crates/ruff/tests/snapshots/lint__output_format_sarif.snap
+++ b/crates/ruff/tests/snapshots/lint__output_format_sarif.snap
@@ -22,6 +22,33 @@ exit_code: 1
     {
       "results": [
         {
+          "fixes": [
+            {
+              "artifactChanges": [
+                {
+                  "artifactLocation": {
+                    "uri": "[TMP]/input.py"
+                  },
+                  "replacements": [
+                    {
+                      "deletedRegion": {
+                        "endColumn": 10,
+                        "endLine": 1,
+                        "startColumn": 8,
+                        "startLine": 1
+                      },
+                      "insertedContent": {
+                        "text": ""
+                      }
+                    }
+                  ]
+                }
+              ],
+              "description": {
+                "text": "Remove unused import: `os`"
+              }
+            }
+          ],
           "level": "error",
           "locations": [
             {

--- a/crates/ruff_linter/src/message/sarif.rs
+++ b/crates/ruff_linter/src/message/sarif.rs
@@ -153,6 +153,58 @@ struct SarifResult<'a> {
     start_column: OneIndexed,
     end_line: OneIndexed,
     end_column: OneIndexed,
+    fixes: Vec<SarifFix>,
+}
+
+#[derive(Debug, Serialize)]
+struct SarifFix {
+    description: RuleDescription,
+    #[serde(rename = "artifactChanges")]
+    artifact_changes: Vec<SarifArtifactChange>,
+}
+
+#[derive(Debug, Serialize)]
+
+struct RuleDescription {
+    text: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct SarifArtifactChange {
+    #[serde(rename = "artifactLocation")]
+    uri: SarifArtifactLocation,
+    replacements: Vec<SarifReplacement>,
+}
+
+#[derive(Debug, Serialize)]
+struct SarifArtifactLocation {
+    uri: String,
+}
+
+#[derive(Debug, Serialize)]
+struct SarifReplacement {
+    #[serde(rename = "deletedRegion")]
+    deleted_region: SarifRegion,
+    #[serde(rename = "insertedContent")]
+    inserted_content: InsertedContent,
+}
+
+#[derive(Debug, Serialize)]
+struct InsertedContent {
+    #[serde(rename = "text")]
+    inserted_content: String,
+}
+
+#[derive(Debug, Serialize)]
+struct SarifRegion {
+    #[serde(rename = "startLine")]
+    start_line: OneIndexed,
+    #[serde(rename = "startColumn")]
+    start_column: OneIndexed,
+    #[serde(rename = "endLine")]
+    end_line: OneIndexed,
+    #[serde(rename = "endColumn")]
+    end_column: OneIndexed,
 }
 
 impl<'a> SarifResult<'a> {
@@ -161,17 +213,60 @@ impl<'a> SarifResult<'a> {
         let start_location = message.expect_ruff_start_location();
         let end_location = message.expect_ruff_end_location();
         let path = normalize_path(&*message.expect_ruff_filename());
+        let uri = url::Url::from_file_path(&path)
+            .map_err(|()| anyhow::anyhow!("Failed to convert path to URL: {}", path.display()))?
+            .to_string();
+        let fixes = message
+            .fix()
+            .map(|fix| {
+                let fix_description = message
+                    .first_help_text()
+                    .map(std::string::ToString::to_string);
+
+                let replacements: Vec<SarifReplacement> = fix
+                    .edits()
+                    .iter()
+                    .map(|edit| SarifReplacement {
+                        deleted_region: SarifRegion {
+                            start_line: start_location.line,
+                            start_column: start_location.column,
+                            end_line: end_location.line,
+                            end_column: end_location.column,
+                        },
+                        inserted_content: InsertedContent {
+                            inserted_content: edit.content().unwrap_or("").to_string(),
+                        },
+                    })
+                    .collect();
+
+                let mut artifact_changes = Vec::new();
+                if !replacements.is_empty() {
+                    artifact_changes.push(SarifArtifactChange {
+                        uri: SarifArtifactLocation { uri: uri.clone() },
+                        replacements,
+                    });
+                }
+
+                SarifFix {
+                    description: RuleDescription {
+                        text: fix_description,
+                    },
+                    artifact_changes,
+                }
+            })
+            .into_iter()
+            .collect();
+
         Ok(Self {
             code: RuleCode::from(message),
             level: "error".to_string(),
             message: message.body().to_string(),
-            uri: url::Url::from_file_path(&path)
-                .map_err(|()| anyhow::anyhow!("Failed to convert path to URL: {}", path.display()))?
-                .to_string(),
+            uri,
             start_line: start_location.line,
             start_column: start_location.column,
             end_line: end_location.line,
             end_column: end_location.column,
+            fixes,
         })
     }
 
@@ -199,7 +294,7 @@ impl Serialize for SarifResult<'_> {
     where
         S: Serializer,
     {
-        json!({
+        let mut value = json!({
             "level": self.level,
             "message": {
                 "text": self.message,
@@ -218,10 +313,43 @@ impl Serialize for SarifResult<'_> {
                 }
             }],
             "ruleId": self.code.as_str(),
-        })
-        .serialize(serializer)
+        });
+        if !self.fixes.is_empty() {
+            value["fixes"] = serde_json::to_value(&self.fixes).unwrap();
+        }
+        value.serialize(serializer)
     }
 }
+
+// impl Serialize for SarifFix {
+//     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+//     where
+//         S: Serializer,
+//     {
+//         json!({
+//             "description": self.description.as_ref().map(|d| { "text": d }),
+//             "artifactChanges": self.artifact_changes.iter().map(|change| {
+//                 json!({
+//                     "artifactLocation": { "uri": change.uri },
+//                     "replacements": change.replacements.iter().map(|r| {
+//                         json!({
+//                             "deletedRegion": {
+//                                 "startLine": r.deleted_region.start_line,
+//                                 "startColumn": r.deleted_region.start_column,
+//                                 "endLine": r.deleted_region.end_line,
+//                                 "endColumn": r.deleted_region.end_column,
+//                             },
+//                             "insertedContent": r.inserted_content.as_ref().map(|c| {
+//                                 json!({ "text": c })
+//                             }),
+//                         })
+//                     }).collect::<Vec<_>>()
+//                 })
+//             }).collect::<Vec<_>>(),
+//         })
+//         .serialize(serializer)
+//     }
+// }
 
 #[cfg(test)]
 mod tests {

--- a/crates/ruff_linter/src/message/snapshots/ruff_linter__message__sarif__tests__results.snap
+++ b/crates/ruff_linter/src/message/snapshots/ruff_linter__message__sarif__tests__results.snap
@@ -8,6 +8,33 @@ expression: value
     {
       "results": [
         {
+          "fixes": [
+            {
+              "artifactChanges": [
+                {
+                  "artifactLocation": {
+                    "uri": "file:///Users/nik/projects/ruff/crates/ruff_linter/fib.py"
+                  },
+                  "replacements": [
+                    {
+                      "deletedRegion": {
+                        "endColumn": 10,
+                        "endLine": 1,
+                        "startColumn": 8,
+                        "startLine": 1
+                      },
+                      "insertedContent": {
+                        "text": ""
+                      }
+                    }
+                  ]
+                }
+              ],
+              "description": {
+                "text": "Remove unused import: `os`"
+              }
+            }
+          ],
           "level": "error",
           "locations": [
             {
@@ -30,6 +57,33 @@ expression: value
           "ruleId": "F401"
         },
         {
+          "fixes": [
+            {
+              "artifactChanges": [
+                {
+                  "artifactLocation": {
+                    "uri": "file:///Users/nik/projects/ruff/crates/ruff_linter/fib.py"
+                  },
+                  "replacements": [
+                    {
+                      "deletedRegion": {
+                        "endColumn": 6,
+                        "endLine": 6,
+                        "startColumn": 5,
+                        "startLine": 6
+                      },
+                      "insertedContent": {
+                        "text": ""
+                      }
+                    }
+                  ]
+                }
+              ],
+              "description": {
+                "text": "Remove assignment to unused variable `x`"
+              }
+            }
+          ],
           "level": "error",
           "locations": [
             {


### PR DESCRIPTION
## Summary

Addresses #19962

This PR extends `SarifEmitter` to include `fixes` in the SARIF ouput, if an auto fix is available. Before SARIF output did not include the `fixes` field. This makes Ruff's SARIF output more compliant with the spec.

Key changes:
- `SarifFix`, `SarifArtifactChange`, and related structs to represent fixes in SARIF.
- `fixes` is outputted only if an auto fix is available.

## Test Plan

Check for SARIF spec compliance and regressions.
