### PR TITLE
[`pep8-naming`] Fix formatting of `__all__` (`N816`)

### DIFF
--- a/crates/ruff_linter/src/rules/pep8_naming/rules/mixed_case_variable_in_global_scope.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/rules/mixed_case_variable_in_global_scope.rs
@@ -19,7 +19,7 @@ use crate::rules::pep8_naming::helpers;
 /// > only.) The conventions are about the same as those for functions.
 /// >
 /// > Modules that are designed for use via from M import * should use the
-/// > __all__ mechanism to prevent exporting globals, or use the older
+/// > `__all__` mechanism to prevent exporting globals, or use the older
 /// > convention of prefixing such globals with an underscore (which you might
 /// > want to do to indicate these globals are “module non-public”).
 /// >

--- a/crates/ruff_linter/src/rules/pep8_naming/rules/mixed_case_variable_in_global_scope.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/rules/mixed_case_variable_in_global_scope.rs
@@ -18,7 +18,7 @@ use crate::rules::pep8_naming::helpers;
 /// > (Let’s hope that these variables are meant for use inside one module
 /// > only.) The conventions are about the same as those for functions.
 /// >
-/// > Modules that are designed for use via from M import * should use the
+/// > Modules that are designed for use via `from M import *` should use the
 /// > `__all__` mechanism to prevent exporting globals, or use the older
 /// > convention of prefixing such globals with an underscore (which you might
 /// > want to do to indicate these globals are “module non-public”).


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

Noticed this was not escaped when writing a project that parses the result of `ruff rule --outputformat json`. This is visible here: <https://docs.astral.sh/ruff/rules/mixed-case-variable-in-global-scope/#why-is-this-bad>

## Test Plan

documentation only
