### PR TITLE
[ty] Support "legacy" `typing.Self` in combination with PEP 695 generic contexts

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -494,3 +494,25 @@ age, name = team.employees[0]
 reveal_type(age)  # revealed: Age
 reveal_type(name)  # revealed: Name
 ```
+
+## `self` in PEP 695 generic methods
+
+When a generic method uses a PEP 695 generic context, an implict or explicit annotation of
+`self: Self` is still part of the full generic context:
+
+```py
+from typing import Self
+
+class C:
+    def explicit_self[T](self: Self, x: T) -> tuple[Self, T]:
+        return self, x
+
+    def implicit_self[T](self, x: T) -> tuple[Self, T]:
+        return self, x
+
+def _(x: int):
+    reveal_type(C().explicit_self(x))  # revealed: tuple[C, int]
+
+    # TODO: this should be `tuple[C, int]` as well, once we support implicit `self`
+    reveal_type(C().implicit_self(x))  # revealed: tuple[Unknown, int]
+```

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -134,6 +134,18 @@ impl<'db> GenericContext<'db> {
         Self::new(db, type_params.into_iter().collect::<FxOrderSet<_>>())
     }
 
+    /// Merge this generic context with another, returning a new generic context that
+    /// contains type variables from both contexts.
+    pub(crate) fn merge(self, db: &'db dyn Db, other: Self) -> Self {
+        Self::from_typevar_instances(
+            db,
+            self.variables(db)
+                .iter()
+                .chain(other.variables(db).iter())
+                .copied(),
+        )
+    }
+
     fn variable_from_type_param(
         db: &'db dyn Db,
         index: &'db SemanticIndex<'db>,

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -376,12 +376,25 @@ impl<'db> Signature<'db> {
         let legacy_generic_context =
             GenericContext::from_function_params(db, definition, &parameters, return_ty);
 
-        if generic_context.is_some() && legacy_generic_context.is_some() {
-            // TODO: Raise a diagnostic!
-        }
+        let full_generic_context = match (legacy_generic_context, generic_context) {
+            (Some(legacy_ctx), Some(ctx)) => {
+                if legacy_ctx
+                    .variables(db)
+                    .iter()
+                    .exactly_one()
+                    .is_ok_and(|bound_typevar| bound_typevar.typevar(db).is_self(db))
+                {
+                    Some(legacy_ctx.merge(db, ctx))
+                } else {
+                    // TODO: Raise a diagnostic — mixing PEP 695 and legacy typevars is not allowed
+                    Some(ctx)
+                }
+            }
+            (left, right) => left.or(right),
+        };
 
         Self {
-            generic_context: generic_context.or(legacy_generic_context),
+            generic_context: full_generic_context,
             inherited_generic_context,
             definition: Some(definition),
             parameters,


### PR DESCRIPTION
## Summary

Support cases like the following, where we need the generic context to include both `Self` and `T` (not just `T`):

```py
from typing import Self

class C:
    def method[T](self: Self, arg: T): ...

C().method(1)
```

closes https://github.com/astral-sh/ty/issues/1131

## Test Plan

Added regression test
