### PR TITLE
Refactor diagnostic start|end location helpers

### DIFF
--- a/crates/ruff_db/src/diagnostic/mod.rs
+++ b/crates/ruff_db/src/diagnostic/mod.rs
@@ -454,24 +454,26 @@ impl Diagnostic {
 
     /// Computes the start source location for the message.
     ///
-    /// Panics if the diagnostic has no primary span, if its file is not a `SourceFile`, or if the
-    /// span has no range.
-    pub fn expect_ruff_start_location(&self) -> LineColumn {
-        self.expect_primary_span()
-            .expect_ruff_file()
-            .to_source_code()
-            .line_column(self.expect_range().start())
+    /// Returns None if the diagnostic has no primary span, if its file is not a `SourceFile`,
+    /// or if the span has no range.
+    pub fn ruff_start_location(&self) -> Option<LineColumn> {
+        Some(
+            self.ruff_source_file()?
+                .to_source_code()
+                .line_column(self.range()?.start()),
+        )
     }
 
     /// Computes the end source location for the message.
     ///
-    /// Panics if the diagnostic has no primary span, if its file is not a `SourceFile`, or if the
-    /// span has no range.
-    pub fn expect_ruff_end_location(&self) -> LineColumn {
-        self.expect_primary_span()
-            .expect_ruff_file()
-            .to_source_code()
-            .line_column(self.expect_range().end())
+    /// Returns None if the diagnostic has no primary span, if its file is not a `SourceFile`,
+    /// or if the span has no range.
+    pub fn ruff_end_location(&self) -> Option<LineColumn> {
+        Some(
+            self.ruff_source_file()?
+                .to_source_code()
+                .line_column(self.range()?.end()),
+        )
     }
 
     /// Returns the [`SourceFile`] which the message belongs to.

--- a/crates/ruff_linter/src/message/github.rs
+++ b/crates/ruff_linter/src/message/github.rs
@@ -19,7 +19,7 @@ impl Emitter for GithubEmitter {
         context: &EmitterContext,
     ) -> anyhow::Result<()> {
         for diagnostic in diagnostics {
-            let source_location = diagnostic.expect_ruff_start_location();
+            let source_location = diagnostic.ruff_start_location().unwrap_or_default();
             let filename = diagnostic.expect_ruff_filename();
             let location = if context.is_notebook(&filename) {
                 // We can't give a reasonable location for the structured formats,
@@ -29,7 +29,7 @@ impl Emitter for GithubEmitter {
                 source_location
             };
 
-            let end_location = diagnostic.expect_ruff_end_location();
+            let end_location = diagnostic.ruff_end_location().unwrap_or_default();
 
             write!(
                 writer,

--- a/crates/ruff_linter/src/message/grouped.rs
+++ b/crates/ruff_linter/src/message/grouped.rs
@@ -105,7 +105,7 @@ fn group_diagnostics_by_filename(
             .or_insert_with(Vec::new)
             .push(MessageWithLocation {
                 message: diagnostic,
-                start_location: diagnostic.expect_ruff_start_location(),
+                start_location: diagnostic.ruff_start_location().unwrap_or_default(),
             });
     }
     grouped_messages

--- a/crates/ruff_linter/src/message/sarif.rs
+++ b/crates/ruff_linter/src/message/sarif.rs
@@ -158,8 +158,8 @@ struct SarifResult<'a> {
 impl<'a> SarifResult<'a> {
     #[cfg(not(target_arch = "wasm32"))]
     fn from_message(message: &'a Diagnostic) -> Result<Self> {
-        let start_location = message.expect_ruff_start_location();
-        let end_location = message.expect_ruff_end_location();
+        let start_location = message.ruff_start_location().unwrap_or_default();
+        let end_location = message.ruff_end_location().unwrap_or_default();
         let path = normalize_path(&*message.expect_ruff_filename());
         Ok(Self {
             code: RuleCode::from(message),
@@ -178,8 +178,8 @@ impl<'a> SarifResult<'a> {
     #[cfg(target_arch = "wasm32")]
     #[expect(clippy::unnecessary_wraps)]
     fn from_message(message: &'a Diagnostic) -> Result<Self> {
-        let start_location = message.expect_ruff_start_location();
-        let end_location = message.expect_ruff_end_location();
+        let start_location = message.ruff_start_location().unwrap_or_default();
+        let end_location = message.ruff_end_location().unwrap_or_default();
         let path = normalize_path(&*message.expect_ruff_filename());
         Ok(Self {
             code: RuleCode::from(message),


### PR DESCRIPTION
- Renames functions to drop `expect_` from names.
- Make functions return `Option<LineColumn>` to appropriately signal
  when range is not available.
- Update existing consumers to use `unwrap_or_default()`. Uncertain if
  there are better fallback behaviors for individual consumers.
