### PR TITLE
Allow the `if_not_else` Clippy lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -251,6 +251,14 @@ rest_pat_in_fully_bound_structs = "warn"
 redundant_clone = "warn"
 debug_assert_with_mut_call = "warn"
 unused_peekable = "warn"
+# This lint sometimes flags code whose `if` and `else`
+# bodies could be flipped when a `!` operator is removed.
+# While perhaps sometimes a good idea, it is also often
+# not a good idea due to other factors impacting
+# readability. For example, if flipping the bodies results
+# in the `if` being an order of magnitude bigger than the
+# `else`, then some might consider that harder to read.
+if_not_else = "allow"
 
 # Diagnostics are not actionable: Enable once https://github.com/rust-lang/rust-clippy/issues/13774 is resolved.
 large_stack_arrays = "allow"

--- a/crates/ruff_linter/src/rules/fastapi/rules/fastapi_unused_path_parameter.rs
+++ b/crates/ruff_linter/src/rules/fastapi/rules/fastapi_unused_path_parameter.rs
@@ -79,7 +79,6 @@ impl Violation for FastApiUnusedPathParameter {
             function_name,
             is_positional,
         } = self;
-        #[expect(clippy::if_not_else)]
         if !is_positional {
             format!(
                 "Parameter `{arg_name}` appears in route path, but not in `{function_name}` signature"

--- a/crates/ruff_linter/src/rules/pep8_naming/rules/invalid_first_argument_name.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/rules/invalid_first_argument_name.rs
@@ -141,7 +141,6 @@ impl Violation for InvalidFirstArgumentNameForClassMethod {
     #[derive_message_formats]
     // The first string below is what shows up in the documentation
     // in the rule table, and it is the more common case.
-    #[expect(clippy::if_not_else)]
     fn message(&self) -> String {
         if !self.is_new {
             "First argument of a class method should be named `cls`".to_string()

--- a/crates/ruff_linter/src/rules/pylint/rules/useless_import_alias.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/useless_import_alias.rs
@@ -47,7 +47,6 @@ impl Violation for UselessImportAlias {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        #[expect(clippy::if_not_else)]
         if !self.required_import_conflict {
             "Import alias does not rename original package".to_string()
         } else {

--- a/crates/ty_server/src/session.rs
+++ b/crates/ty_server/src/session.rs
@@ -790,7 +790,6 @@ impl Session {
         // But while this seemed to work for the project root, it
         // simply wouldn't result in any file notifications for changes
         // to files outside of the project root.
-        #[allow(clippy::if_not_else)] // no! it reads better this way ---AG
         let watchers = if !self.client_capabilities().supports_relative_file_watcher() {
             tracing::warn!(
                 "Your LSP client doesn't support file watching outside of project: \


### PR DESCRIPTION
Specifically, the [`if_not_else`] lint will sometimes flag
code to change the order of `if` and `else` bodies if this
would allow a `!` to be removed. While perhaps tasteful in
some cases, there are many cases in my experience where this
bows to other competing concerns that impact readability.
(Such as the relative sizes of the `if` and `else` bodies,
or perhaps an ordering that just makes the code flow in a
more natural way.)

[`if_not_else`]: https://rust-lang.github.io/rust-clippy/master/index.html#/if_not_else
