### PR TITLE
Bump LibCST to 1.8.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1770,9 +1770,9 @@ checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libcst"
-version = "1.8.2"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae28ddc5b90c3e3146a21d051ca095cbc8d932ad8714cf65ddf71a9abb35684c"
+checksum = "052ef5d9fc958a51aeebdf3713573b36c6fd6eed0bf0e60e204d2c0f8cf19b9f"
 dependencies = [
  "annotate-snippets",
  "libcst_derive",
@@ -1785,9 +1785,9 @@ dependencies = [
 
 [[package]]
 name = "libcst_derive"
-version = "1.8.2"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc2de5c2f62bcf8a4f7290b1854388b262c4b68f1db1a3ee3ef6d4c1319b00a3"
+checksum = "a91a751afee92cbdd59d4bc6754c7672712eec2d30a308f23de4e3287b2929cb"
 dependencies = [
  "quote",
  "syn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,7 @@ jiff = { version = "0.2.0" }
 js-sys = { version = "0.3.69" }
 jod-thread = { version = "1.0.0" }
 libc = { version = "0.2.153" }
-libcst = { version = "1.1.0", default-features = false }
+libcst = { version = "1.8.4", default-features = false }
 log = { version = "0.4.17" }
 lsp-server = { version = "0.7.6" }
 lsp-types = { git = "https://github.com/astral-sh/lsp-types.git", rev = "3512a9f", features = [

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/format_literals.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/format_literals.rs
@@ -164,7 +164,7 @@ fn remove_specifiers<'a>(value: &mut Expression<'a>, arena: &'a typed_arena::Are
                         stack.push(&mut string.left);
                         stack.push(&mut string.right);
                     }
-                    libcst_native::String::Formatted(_) => {}
+                    libcst_native::String::Formatted(_) | libcst_native::String::Templated(_) => {}
                 }
             }
         }


### PR DESCRIPTION
This should fix the fuzz build on `main`. They added support for t-strings, which made one of our matches non-exhaustive.

https://github.com/Instagram/LibCST/releases/tag/v1.8.4
