### PR TITLE
[ty] Simplify unions of enum literals and subtypes thereof

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/union_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/union_types.md
@@ -118,7 +118,8 @@ def _(
 
 ```py
 from enum import Enum
-from typing import Literal
+from typing import Literal, Any
+from ty_extensions import Intersection
 
 class Color(Enum):
     RED = "red"
@@ -139,6 +140,13 @@ def _(
     reveal_type(u4)  # revealed: Literal[Color.RED, Color.GREEN]
     reveal_type(u5)  # revealed: Color
     reveal_type(u6)  # revealed: Color
+
+def _(
+    u1: Intersection[Literal[Color.RED], Any] | Literal[Color.RED],
+    u2: Literal[Color.RED] | Intersection[Literal[Color.RED], Any],
+):
+    reveal_type(u1)  # revealed: Literal[Color.RED]
+    reveal_type(u2)  # revealed: Literal[Color.RED]
 ```
 
 ## Do not erase `Unknown`


### PR DESCRIPTION
## Summary

When adding an enum literal `E = Literal[Color.RED]` to a union which already contained a subtype of that enum literal(!), we were previously not simplifying the union correctly. My assumption is that our property tests didn't catch that earlier, because the only possible non-trivial subytpe of an enum literal that I can think of is `Any & E`. And in order for that to be detected by the property tests, it would have to randomly generate `Any & E | E` and then also compare that with `E` on the other side (in an equivalence test, or the subtyping-antisymmetry test).

closes https://github.com/astral-sh/ty/issues/1155

## Test Plan

* Added a regression test.
* I also ran the property tests for a while, but probably not for two months worth of daily CI runs.
