### PR TITLE
[ty] Ensure various special-cased builtin functions are understood as assignable to `Callable`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/methods.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/methods.md
@@ -610,9 +610,6 @@ static_assert(is_assignable_to(types.FunctionType, Callable))
 
 # revealed: <wrapper-descriptor `__get__` of `function` objects>
 reveal_type(types.FunctionType.__get__)
-
-# TODO: should pass
-# error: [static-assert-error]
 static_assert(is_assignable_to(TypeOf[types.FunctionType.__get__], Callable))
 
 # revealed: def f(obj: type) -> None
@@ -633,9 +630,6 @@ static_assert(is_assignable_to(TypeOf[f.__call__], Callable))
 
 # revealed: <wrapper-descriptor `__get__` of `property` objects>
 reveal_type(property.__get__)
-
-# TODO: should pass
-# error: [static-assert-error]
 static_assert(is_assignable_to(TypeOf[property.__get__], Callable))
 
 # revealed: property
@@ -649,9 +643,6 @@ static_assert(is_assignable_to(TypeOf[MyClass.my_property.__get__], Callable))
 
 # revealed: <wrapper-descriptor `__set__` of `property` objects>
 reveal_type(property.__set__)
-
-# TODO: should pass
-# error: [static-assert-error]
 static_assert(is_assignable_to(TypeOf[property.__set__], Callable))
 
 # revealed: <method-wrapper `__set__` of `property` object>


### PR DESCRIPTION
## Summary

(Stacked on top of #20329 and #20330; review those two first.)

This PR improves the implementation of `Type::bindings()` and `Type::into_callable()` for our `Type::WrapperDescriptor` variant so that all subvariants of `Type::WrapperDescriptor` are understood as assignable to `Callable`. The question "is this variant assignable to `Callable`?" is currently answered by our `Type::into_callable()` method, which currently always returns `None` for this variant. This PR ensures that it always returns `Some()` by creating a new `WrapperDescriptorKind::signatures()` method that can be used from both `Type::bindings()` and `Type::into_callable()`. This both fixes the bug and increases our internal consistency for these types.

## Test Plan

mdtests updated
