### PR TITLE
[ty] Require that implementors of `Constraints` also implement `Debug`

### DIFF
--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -111,7 +111,7 @@ fn incomparable<'db>(db: &'db dyn Db, left: Type<'db>, right: Type<'db>) -> bool
 }
 
 /// Encodes the constraints under which a type property (e.g. assignability) holds.
-pub(crate) trait Constraints<'db>: Clone + Sized + Debug {
+pub(crate) trait Constraints<'db>: Clone + Sized + std::fmt::Debug {
     /// Returns a constraint set that never holds
     fn unsatisfiable(db: &'db dyn Db) -> Self;
 


### PR DESCRIPTION
The debug representation isn't as useful as calling `.display(db)`, but it's still kind-of annoying when `dbg!()` calls don't compile locally due to the compiler not being able to guarantee that an object of type `impl Constraints` implements `Debug`