### PR TITLE
[`flake8-simplify`] Mark guaranteed-bool fixes as safe `SIM103`

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM103_SIM103.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM103_SIM103.py.snap
@@ -23,7 +23,6 @@ help: Replace with `return bool(a)`
 4 | 
 5 | 
 6 | def f():
-note: This is an unsafe fix and may change runtime behavior
 
 SIM103 [*] Return the condition `a == b` directly
   --> SIM103.py:11:5
@@ -73,7 +72,6 @@ help: Replace with `return bool(b)`
 22 | 
 23 | 
 24 | def f():
-note: This is an unsafe fix and may change runtime behavior
 
 SIM103 [*] Return the condition `bool(b)` directly
   --> SIM103.py:32:9
@@ -98,7 +96,6 @@ help: Replace with `return bool(b)`
 33 | 
 34 | 
 35 | def f():
-note: This is an unsafe fix and may change runtime behavior
 
 SIM103 [*] Return the condition `not a` directly
   --> SIM103.py:57:5
@@ -123,7 +120,6 @@ help: Replace with `return not a`
 58 | 
 59 | 
 60 | def f():
-note: This is an unsafe fix and may change runtime behavior
 
 SIM103 Return the condition directly
   --> SIM103.py:83:5
@@ -161,7 +157,6 @@ help: Replace with `return not (keys is not None and notice.key not in keys)`
 92 | 
 93 | 
 94 | ###
-note: This is an unsafe fix and may change runtime behavior
 
 SIM103 [*] Return the condition `bool(a)` directly
    --> SIM103.py:104:5
@@ -184,7 +179,6 @@ help: Replace with `return bool(a)`
 105 | 
 106 | 
 107 | def f():
-note: This is an unsafe fix and may change runtime behavior
 
 SIM103 [*] Return the condition `not a` directly
    --> SIM103.py:111:5
@@ -207,7 +201,6 @@ help: Replace with `return not a`
 112 | 
 113 | 
 114 | def f():
-note: This is an unsafe fix and may change runtime behavior
 
 SIM103 [*] Return the condition `10 < a` directly
    --> SIM103.py:117:5
@@ -251,7 +244,6 @@ help: Replace with `return not 10 < a`
 124 | 
 125 | 
 126 | def f():
-note: This is an unsafe fix and may change runtime behavior
 
 SIM103 [*] Return the condition `10 not in a` directly
    --> SIM103.py:129:5
@@ -273,7 +265,6 @@ help: Replace with `return 10 not in a`
 130 | 
 131 | 
 132 | def f():
-note: This is an unsafe fix and may change runtime behavior
 
 SIM103 [*] Return the condition `10 in a` directly
    --> SIM103.py:135:5
@@ -295,7 +286,6 @@ help: Replace with `return 10 in a`
 136 | 
 137 | 
 138 | def f():
-note: This is an unsafe fix and may change runtime behavior
 
 SIM103 [*] Return the condition `a is not 10` directly
    --> SIM103.py:141:5
@@ -317,7 +307,6 @@ help: Replace with `return a is not 10`
 142 | 
 143 | 
 144 | def f():
-note: This is an unsafe fix and may change runtime behavior
 
 SIM103 [*] Return the condition `a is 10` directly
    --> SIM103.py:147:5
@@ -339,7 +328,6 @@ help: Replace with `return a is 10`
 148 | 
 149 | 
 150 | def f():
-note: This is an unsafe fix and may change runtime behavior
 
 SIM103 [*] Return the condition `a != 10` directly
    --> SIM103.py:153:5


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Fixes #20287

Mark guaranteed-bool fixes as safe.

- Mark fixes as `Applicability::Safe` when the replacement is guaranteed boolean
    - not <expr>, identity/membership compares (is/is not/in/not in), builtin bool(...)
- Keep `Applicability::Unsafe` for equality/inequality (==/!=) and other non‑guaranteed cases
- Avoid offering a fix when bool is shadowed and expression isn’t guaranteed boolean

## Test Plan

<!-- How was it tested? -->

Update the snapshot of `SIM103.py`
