### PR TITLE
[`ruff`] Allow dataclass attribute value instantiation from nested frozen dataclass (`RUF009`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF009.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF009.py
@@ -126,3 +126,12 @@ class D:
 @dataclass
 class E:
     c: C = C()
+
+# https://github.com/astral-sh/ruff/issues/20266
+@dataclass(frozen=True)
+class C:
+    @dataclass(frozen=True)
+    class D:
+        foo: int = 1
+
+    d: D = D() # OK

--- a/crates/ruff_linter/src/checkers/ast/analyze/deferred_scopes.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/deferred_scopes.rs
@@ -134,7 +134,7 @@ pub(crate) fn deferred_scopes(checker: &Checker) {
                 );
             }
             if checker.is_rule_enabled(Rule::FunctionCallInDataclassDefaultArgument) {
-                ruff::rules::function_call_in_dataclass_default(checker, class_def);
+                ruff::rules::function_call_in_dataclass_default(checker, class_def, scope_id);
             }
             if checker.is_rule_enabled(Rule::MutableClassDefault) {
                 ruff::rules::mutable_class_default(checker, class_def);

--- a/crates/ruff_python_semantic/src/model.rs
+++ b/crates/ruff_python_semantic/src/model.rs
@@ -859,11 +859,17 @@ impl<'a> SemanticModel<'a> {
     /// associated with `Class`, then the `BindingKind::FunctionDefinition` associated with
     /// `Class.method`.
     pub fn lookup_attribute(&self, value: &Expr) -> Option<BindingId> {
+        self.lookup_attribute_in_scope(value, self.scope_id)
+    }
+
+    /// Lookup a qualified attribute in the certain scope.
+    pub fn lookup_attribute_in_scope(&self, value: &Expr, scope_id: ScopeId) -> Option<BindingId> {
         let unqualified_name = UnqualifiedName::from_expr(value)?;
 
         // Find the symbol in the current scope.
         let (symbol, attribute) = unqualified_name.segments().split_first()?;
-        let mut binding_id = self.lookup_symbol(symbol)?;
+        let mut binding_id =
+            self.lookup_symbol_in_scope(symbol, scope_id, self.in_forward_reference())?;
 
         // Recursively resolve class attributes, e.g., `foo.bar.baz` in.
         let mut tail = attribute;


### PR DESCRIPTION
## Summary
Resolves #20266

Definition of the frozen dataclass attribute can be instantiation of a nested frozen dataclass as well as a non-nested one.

### Problem explanation
The `function_call_in_dataclass_default` function is invoked during the "defined scope" stage, after all scopes have been processed. At this point, the semantic references the top-level scope. When `SemanticModel::lookup_attribute` executes, it searches for bindings in the top-level module scope rather than the class scope, resulting in an error.

To solve this issue, the lookup should be evaluated through the class scope.

## Test Plan
- Added test case from issue 
