### PR TITLE
[`ty`] Include `NamedTupleFallback` members in `NamedTuple` instance completions

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/ide_support/all_members.md
+++ b/crates/ty_python_semantic/resources/mdtest/ide_support/all_members.md
@@ -250,15 +250,26 @@ class Person(NamedTuple):
 
 static_assert(has_member(Person, "id"))
 static_assert(has_member(Person, "name"))
-static_assert(has_member(Person(1, "Name"), "id"))
-static_assert(has_member(Person(1, "Name"), "name"))
 
 static_assert(has_member(Person, "_make"))
 static_assert(has_member(Person, "_asdict"))
 static_assert(has_member(Person, "_replace"))
-static_assert(has_member(Person(1, "Name"), "_make"))
-static_assert(has_member(Person(1, "Name"), "_asdict"))
-static_assert(has_member(Person(1, "Name"), "_replace"))
+
+def _(person: Person):
+    static_assert(has_member(person, "id"))
+    static_assert(has_member(person, "name"))
+
+    static_assert(has_member(person, "_make"))
+    static_assert(has_member(person, "_asdict"))
+    static_assert(has_member(person, "_replace"))
+
+def _(t_person: type[Person]):
+    static_assert(has_member(t_person, "id"))
+    static_assert(has_member(t_person, "name"))
+
+    static_assert(has_member(t_person, "_make"))
+    static_assert(has_member(t_person, "_asdict"))
+    static_assert(has_member(t_person, "_replace"))
 
 T = TypeVar("T")
 
@@ -266,15 +277,17 @@ class Box(NamedTuple, Generic[T]):
     item: T
 
 static_assert(has_member(Box, "item"))
-static_assert(has_member(Box[int], "item"))
-static_assert(has_member(Box[int](1), "item"))
 
 static_assert(has_member(Box, "_make"))
 static_assert(has_member(Box, "_asdict"))
 static_assert(has_member(Box, "_replace"))
-static_assert(has_member(Box[int](1), "_make"))
-static_assert(has_member(Box[int](1), "_asdict"))
-static_assert(has_member(Box[int](1), "_replace"))
+
+def _(box: Box[int]):
+    static_assert(has_member(box, "item"))
+
+    static_assert(has_member(box, "_make"))
+    static_assert(has_member(box, "_asdict"))
+    static_assert(has_member(box, "_replace"))
 ```
 
 ### Unions

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -120,11 +120,11 @@ impl<'db> AllMembers<'db> {
             }
 
             Type::ClassLiteral(class_literal) => {
+                self.extend_with_class_members(db, ty, class_literal);
+
                 if CodeGeneratorKind::NamedTuple.matches(db, class_literal) {
                     self.extend_with_type(db, KnownClass::NamedTupleFallback.to_class_literal(db));
                 }
-
-                self.extend_with_class_members(db, ty, class_literal);
 
                 if let Type::ClassLiteral(meta_class_literal) = ty.to_meta_type(db) {
                     self.extend_with_class_members(db, ty, meta_class_literal);
@@ -140,8 +140,16 @@ impl<'db> AllMembers<'db> {
             }
 
             Type::SubclassOf(subclass_of_type) => {
-                if let Some(class_literal) = subclass_of_type.subclass_of().into_class() {
-                    self.extend_with_class_members(db, ty, class_literal.class_literal(db).0);
+                if let Some(class_type) = subclass_of_type.subclass_of().into_class() {
+                    let class_literal = class_type.class_literal(db).0;
+                    self.extend_with_class_members(db, ty, class_literal);
+
+                    if CodeGeneratorKind::NamedTuple.matches(db, class_literal) {
+                        self.extend_with_type(
+                            db,
+                            KnownClass::NamedTupleFallback.to_class_literal(db),
+                        );
+                    }
                 }
             }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Fixes https://github.com/astral-sh/ty/issues/1161

Include `NamedTupleFallback` members in `NamedTuple` instance completions.

- Augment instance attribute completions when completing on NamedTuple instances by merging members from `_typeshed._type_checker_internals.NamedTupleFallback`

## Test Plan

<!-- How was it tested? -->

Adds a minimal completion test `namedtuple_fallback_instance_methods`
