### PR TITLE
[ty] Infer more precise types for collection literals 

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/assignment/annotations.md
+++ b/crates/ty_python_semantic/resources/mdtest/assignment/annotations.md
@@ -79,6 +79,49 @@ b: tuple[int] = ("foo",)
 c: tuple[str | int, str] = ([], "foo")
 ```
 
+## Collection literal annotations are understood
+
+`module.py`:
+
+```py
+import typing
+
+a: list[int] = [1, 2, 3]
+b: list[int | str] = [1, 2, 3]
+c: typing.List[int] = [1, 2, 3]
+d: list[typing.Any] = []
+
+e: set[int] = {1, 2, 3}
+f: set[int | str] = {1, 2, 3}
+g: typing.Set[int] = {1, 2, 3}
+```
+
+`script.py`:
+
+```py
+import typing
+from module import a, b, c, d, e, f, g
+
+reveal_type(a)  # revealed: list[int]
+reveal_type(b)  # revealed: list[int | str]
+reveal_type(c)  # revealed: list[int]
+reveal_type(d)  # revealed: list[Any]
+
+reveal_type(e)  # revealed: set[int]
+reveal_type(f)  # revealed: set[int | str]
+reveal_type(g)  # revealed: set[int]
+```
+
+## Incorrect collection literal assignments are complained aobut
+
+```py
+# error: [invalid-assignment] "Object of type `list[str | Literal[1, 2, 3]]` is not assignable to `list[str]`"
+a: list[str] = [1, 2, 3]
+
+# error: [invalid-assignment] "Object of type `set[int | Literal["3"]]` is not assignable to `set[int]`"
+b: set[int] = {1, 2, "3"}
+```
+
 ## PEP-604 annotations are supported
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/assignment/annotations.md
+++ b/crates/ty_python_semantic/resources/mdtest/assignment/annotations.md
@@ -129,6 +129,16 @@ type IntList = list[int]
 
 m: IntList = [1, 2, 3]
 reveal_type(m)  # revealed: list[int]
+
+# TODO: this should type-check and avoid literal promotion
+# error: [invalid-assignment] "Object of type `list[int]` is not assignable to `list[Literal[1, 2, 3]]`"
+n: list[typing.Literal[1, 2, 3]] = [1, 2, 3]
+reveal_type(n)  # revealed: list[Literal[1, 2, 3]]
+
+# TODO: this should type-check and avoid literal promotion
+# error: [invalid-assignment] "Object of type `list[str]` is not assignable to `list[LiteralString]`"
+o: list[typing.LiteralString] = ["a", "b", "c"]
+reveal_type(o)  # revealed: list[LiteralString]
 ```
 
 ## Incorrect collection literal assignments are complained aobut

--- a/crates/ty_python_semantic/resources/mdtest/assignment/annotations.md
+++ b/crates/ty_python_semantic/resources/mdtest/assignment/annotations.md
@@ -81,35 +81,41 @@ c: tuple[str | int, str] = ([], "foo")
 
 ## Collection literal annotations are understood
 
-`module.py`:
-
 ```py
 import typing
 
 a: list[int] = [1, 2, 3]
-b: list[int | str] = [1, 2, 3]
-c: typing.List[int] = [1, 2, 3]
-d: list[typing.Any] = []
-
-e: set[int] = {1, 2, 3}
-f: set[int | str] = {1, 2, 3}
-g: typing.Set[int] = {1, 2, 3}
-```
-
-`script.py`:
-
-```py
-import typing
-from module import a, b, c, d, e, f, g
-
 reveal_type(a)  # revealed: list[int]
+
+b: list[int | str] = [1, 2, 3]
 reveal_type(b)  # revealed: list[int | str]
+
+c: typing.List[int] = [1, 2, 3]
 reveal_type(c)  # revealed: list[int]
+
+d: list[typing.Any] = []
 reveal_type(d)  # revealed: list[Any]
 
+e: set[int] = {1, 2, 3}
 reveal_type(e)  # revealed: set[int]
+
+f: set[int | str] = {1, 2, 3}
 reveal_type(f)  # revealed: set[int | str]
+
+g: typing.Set[int] = {1, 2, 3}
 reveal_type(g)  # revealed: set[int]
+
+h: list[list[int]] = [[], [42]]
+# TODO: revealed: list[list[int]]
+reveal_type(h)  # revealed: list[list[int] | list[@Todo(list literal element type)]]
+
+i: list[tuple[str | int, ...]] = [(1, 2), ("foo", "bar"), ()]
+reveal_type(i)  # revealed: list[tuple[str | int, ...]]
+
+j: list[tuple[list[typing.Any], ...]] = [([],), ([1, 2], [3, 4]), (["foo"], ["bar"])]
+# TODO: revealed: list[tuple[list[typing.Any], ...]]
+# revealed: list[tuple[list[Any], ...] | tuple[list[@Todo(list literal element type)]] | tuple[list[@Todo(list literal element type)], list[@Todo(list literal element type)]]]
+reveal_type(j)
 ```
 
 ## Incorrect collection literal assignments are complained aobut

--- a/crates/ty_python_semantic/resources/mdtest/assignment/annotations.md
+++ b/crates/ty_python_semantic/resources/mdtest/assignment/annotations.md
@@ -111,21 +111,24 @@ g: typing.Set[int] = {1, 2, 3}
 reveal_type(g)  # revealed: set[int]
 
 h: list[list[int]] = [[], [42]]
-# TODO: revealed: list[list[int]]
-reveal_type(h)  # revealed: list[list[int] | list[Unknown] | list[Unknown | int]]
+reveal_type(h)  # revealed: list[list[int]]
 
-i: list[tuple[str | int, ...]] = [(1, 2), ("foo", "bar"), ()]
-reveal_type(i)  # revealed: list[tuple[str | int, ...]]
+i: list[typing.Any] = [1, 2, "3", ([4],)]
+reveal_type(i)  # revealed: list[Any | int | str | tuple[list[Unknown | int]]]
 
-j: list[tuple[list[typing.Any], ...]] = [([],), ([1, 2], [3, 4]), (["foo"], ["bar"])]
-# TODO: revealed: list[tuple[list[typing.Any], ...]]
-# revealed: list[tuple[list[Any], ...] | tuple[list[Unknown]] | tuple[list[Unknown | int], list[Unknown | int]] | tuple[list[Unknown | str], list[Unknown | str]]]
-reveal_type(j)
+j: list[tuple[str | int, ...]] = [(1, 2), ("foo", "bar"), ()]
+reveal_type(j)  # revealed: list[tuple[str | int, ...]]
+
+k: list[tuple[list[int], ...]] = [([],), ([1, 2], [3, 4]), ([5], [6], [7])]
+reveal_type(k)  # revealed: list[tuple[list[int], ...]]
+
+l: tuple[list[int], *tuple[list[typing.Any], ...], list[str]] = ([1, 2, 3], [4, 5, 6], [7, 8, 9], ["10", "11", "12"])
+reveal_type(l)  # revealed: tuple[list[int], list[Any | int], list[Any | int], list[str]]
 
 type IntList = list[int]
 
-k: IntList = [1, 2, 3]
-reveal_type(a)  # revealed: list[int]
+m: IntList = [1, 2, 3]
+reveal_type(m)  # revealed: list[int]
 ```
 
 ## Incorrect collection literal assignments are complained aobut

--- a/crates/ty_python_semantic/resources/mdtest/assignment/annotations.md
+++ b/crates/ty_python_semantic/resources/mdtest/assignment/annotations.md
@@ -81,6 +81,11 @@ c: tuple[str | int, str] = ([], "foo")
 
 ## Collection literal annotations are understood
 
+```toml
+[environment]
+python-version = "3.12"
+```
+
 ```py
 import typing
 
@@ -116,6 +121,11 @@ j: list[tuple[list[typing.Any], ...]] = [([],), ([1, 2], [3, 4]), (["foo"], ["ba
 # TODO: revealed: list[tuple[list[typing.Any], ...]]
 # revealed: list[tuple[list[Any], ...] | tuple[list[Unknown]] | tuple[list[Unknown | Literal[1, 2]], list[Unknown | Literal[3, 4]]] | tuple[list[Unknown | Literal["foo"]], list[Unknown | Literal["bar"]]]]
 reveal_type(j)
+
+type IntList = list[int]
+
+k: IntList = [1, 2, 3]
+reveal_type(a)  # revealed: list[int]
 ```
 
 ## Incorrect collection literal assignments are complained aobut

--- a/crates/ty_python_semantic/resources/mdtest/assignment/annotations.md
+++ b/crates/ty_python_semantic/resources/mdtest/assignment/annotations.md
@@ -112,14 +112,14 @@ reveal_type(g)  # revealed: set[int]
 
 h: list[list[int]] = [[], [42]]
 # TODO: revealed: list[list[int]]
-reveal_type(h)  # revealed: list[list[int] | list[Unknown] | list[Unknown | Literal[42]]]
+reveal_type(h)  # revealed: list[list[int] | list[Unknown] | list[Unknown | int]]
 
 i: list[tuple[str | int, ...]] = [(1, 2), ("foo", "bar"), ()]
 reveal_type(i)  # revealed: list[tuple[str | int, ...]]
 
 j: list[tuple[list[typing.Any], ...]] = [([],), ([1, 2], [3, 4]), (["foo"], ["bar"])]
 # TODO: revealed: list[tuple[list[typing.Any], ...]]
-# revealed: list[tuple[list[Any], ...] | tuple[list[Unknown]] | tuple[list[Unknown | Literal[1, 2]], list[Unknown | Literal[3, 4]]] | tuple[list[Unknown | Literal["foo"]], list[Unknown | Literal["bar"]]]]
+# revealed: list[tuple[list[Any], ...] | tuple[list[Unknown]] | tuple[list[Unknown | int], list[Unknown | int]] | tuple[list[Unknown | str], list[Unknown | str]]]
 reveal_type(j)
 
 type IntList = list[int]
@@ -131,10 +131,10 @@ reveal_type(a)  # revealed: list[int]
 ## Incorrect collection literal assignments are complained aobut
 
 ```py
-# error: [invalid-assignment] "Object of type `list[Literal[1, 2, 3]]` is not assignable to `list[str]`"
+# error: [invalid-assignment] "Object of type `list[int]` is not assignable to `list[str]`"
 a: list[str] = [1, 2, 3]
 
-# error: [invalid-assignment] "Object of type `set[Literal[1, 2, "3"]]` is not assignable to `set[int]`"
+# error: [invalid-assignment] "Object of type `set[int | str]` is not assignable to `set[int]`"
 b: set[int] = {1, 2, "3"}
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/assignment/annotations.md
+++ b/crates/ty_python_semantic/resources/mdtest/assignment/annotations.md
@@ -107,24 +107,24 @@ reveal_type(g)  # revealed: set[int]
 
 h: list[list[int]] = [[], [42]]
 # TODO: revealed: list[list[int]]
-reveal_type(h)  # revealed: list[list[int] | list[@Todo(list literal element type)]]
+reveal_type(h)  # revealed: list[list[int] | list[Unknown] | list[Unknown | Literal[42]]]
 
 i: list[tuple[str | int, ...]] = [(1, 2), ("foo", "bar"), ()]
 reveal_type(i)  # revealed: list[tuple[str | int, ...]]
 
 j: list[tuple[list[typing.Any], ...]] = [([],), ([1, 2], [3, 4]), (["foo"], ["bar"])]
 # TODO: revealed: list[tuple[list[typing.Any], ...]]
-# revealed: list[tuple[list[Any], ...] | tuple[list[@Todo(list literal element type)]] | tuple[list[@Todo(list literal element type)], list[@Todo(list literal element type)]]]
+# revealed: list[tuple[list[Any], ...] | tuple[list[Unknown]] | tuple[list[Unknown | Literal[1, 2]], list[Unknown | Literal[3, 4]]] | tuple[list[Unknown | Literal["foo"]], list[Unknown | Literal["bar"]]]]
 reveal_type(j)
 ```
 
 ## Incorrect collection literal assignments are complained aobut
 
 ```py
-# error: [invalid-assignment] "Object of type `list[str | Literal[1, 2, 3]]` is not assignable to `list[str]`"
+# error: [invalid-assignment] "Object of type `list[Literal[1, 2, 3]]` is not assignable to `list[str]`"
 a: list[str] = [1, 2, 3]
 
-# error: [invalid-assignment] "Object of type `set[int | Literal["3"]]` is not assignable to `set[int]`"
+# error: [invalid-assignment] "Object of type `set[Literal[1, 2, "3"]]` is not assignable to `set[int]`"
 b: set[int] = {1, 2, "3"}
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/del.md
+++ b/crates/ty_python_semantic/resources/mdtest/del.md
@@ -46,7 +46,7 @@ def delete():
     del d  # error: [unresolved-reference] "Name `d` used when not defined"
 
 delete()
-reveal_type(d)  # revealed: list[Unknown | Literal[1, 2, 3]]
+reveal_type(d)  # revealed: list[Unknown | int]
 
 def delete_element():
     # When the `del` target isn't a name, it doesn't force local resolution.
@@ -62,7 +62,7 @@ def delete_global():
 
 delete_global()
 # Again, the variable should have been removed, but we don't check it.
-reveal_type(d)  # revealed: list[Unknown | Literal[1, 2, 3]]
+reveal_type(d)  # revealed: list[Unknown | int]
 
 def delete_nonlocal():
     e = 2

--- a/crates/ty_python_semantic/resources/mdtest/del.md
+++ b/crates/ty_python_semantic/resources/mdtest/del.md
@@ -46,7 +46,7 @@ def delete():
     del d  # error: [unresolved-reference] "Name `d` used when not defined"
 
 delete()
-reveal_type(d)  # revealed: list[@Todo(list literal element type)]
+reveal_type(d)  # revealed: list[Unknown | Literal[1, 2, 3]]
 
 def delete_element():
     # When the `del` target isn't a name, it doesn't force local resolution.
@@ -62,7 +62,7 @@ def delete_global():
 
 delete_global()
 # Again, the variable should have been removed, but we don't check it.
-reveal_type(d)  # revealed: list[@Todo(list literal element type)]
+reveal_type(d)  # revealed: list[Unknown | Literal[1, 2, 3]]
 
 def delete_nonlocal():
     e = 2

--- a/crates/ty_python_semantic/resources/mdtest/import/dunder_all.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/dunder_all.md
@@ -783,9 +783,8 @@ class A: ...
 ```py
 from subexporter import *
 
-# TODO: Should be `list[str]`
 # TODO: Should we avoid including `Unknown` for this case?
-reveal_type(__all__)  # revealed: Unknown | list[@Todo(list literal element type)]
+reveal_type(__all__)  # revealed: Unknown | list[Unknown | Literal["A", "__all__"]]
 
 __all__.append("B")
 

--- a/crates/ty_python_semantic/resources/mdtest/import/dunder_all.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/dunder_all.md
@@ -784,7 +784,7 @@ class A: ...
 from subexporter import *
 
 # TODO: Should we avoid including `Unknown` for this case?
-reveal_type(__all__)  # revealed: Unknown | list[Unknown | Literal["A", "__all__"]]
+reveal_type(__all__)  # revealed: Unknown | list[Unknown | str]
 
 __all__.append("B")
 

--- a/crates/ty_python_semantic/resources/mdtest/literal/collections/list.md
+++ b/crates/ty_python_semantic/resources/mdtest/literal/collections/list.md
@@ -6,6 +6,19 @@
 reveal_type([])  # revealed: list[Unknown]
 ```
 
+## List of tuples
+
+```py
+reveal_type([(1, 2), (3, 4)])  # revealed: list[Unknown | tuple[int, int]]
+```
+
+## Mixed list
+
+```py
+# revealed: list[Unknown | int | tuple[int, int] | tuple[int, int, int]]
+reveal_type([1, (1, 2), (1, 2, 3)])
+```
+
 ## List comprehensions
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/literal/collections/list.md
+++ b/crates/ty_python_semantic/resources/mdtest/literal/collections/list.md
@@ -3,7 +3,7 @@
 ## Empty list
 
 ```py
-reveal_type([])  # revealed: list[@Todo(list literal element type)]
+reveal_type([])  # revealed: list[Unknown]
 ```
 
 ## List comprehensions

--- a/crates/ty_python_semantic/resources/mdtest/literal/collections/list.md
+++ b/crates/ty_python_semantic/resources/mdtest/literal/collections/list.md
@@ -12,6 +12,19 @@ reveal_type([])  # revealed: list[Unknown]
 reveal_type([(1, 2), (3, 4)])  # revealed: list[Unknown | tuple[int, int]]
 ```
 
+## List of functions
+
+```py
+def a(_: int) -> int:
+    return 0
+
+def b(_: int) -> int:
+    return 1
+
+x = [a, b]
+reveal_type(x)  # revealed: list[Unknown | ((_: int) -> int)]
+```
+
 ## Mixed list
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/literal/collections/set.md
+++ b/crates/ty_python_semantic/resources/mdtest/literal/collections/set.md
@@ -3,7 +3,7 @@
 ## Basic set
 
 ```py
-reveal_type({1, 2})  # revealed: set[@Todo(set literal element type)]
+reveal_type({1, 2})  # revealed: set[Unknown | Literal[1, 2]]
 ```
 
 ## Set comprehensions

--- a/crates/ty_python_semantic/resources/mdtest/literal/collections/set.md
+++ b/crates/ty_python_semantic/resources/mdtest/literal/collections/set.md
@@ -12,6 +12,19 @@ reveal_type({1, 2})  # revealed: set[Unknown | int]
 reveal_type({(1, 2), (3, 4)})  # revealed: set[Unknown | tuple[int, int]]
 ```
 
+## Set of functions
+
+```py
+def a(_: int) -> int:
+    return 0
+
+def b(_: int) -> int:
+    return 1
+
+x = {a, b}
+reveal_type(x)  # revealed: set[Unknown | ((_: int) -> int)]
+```
+
 ## Mixed set
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/literal/collections/set.md
+++ b/crates/ty_python_semantic/resources/mdtest/literal/collections/set.md
@@ -6,6 +6,19 @@
 reveal_type({1, 2})  # revealed: set[Unknown | int]
 ```
 
+## Set of tuples
+
+```py
+reveal_type({(1, 2), (3, 4)})  # revealed: set[Unknown | tuple[int, int]]
+```
+
+## Mixed set
+
+```py
+# revealed: set[Unknown | int | tuple[int, int] | tuple[int, int, int]]
+reveal_type({1, (1, 2), (1, 2, 3)})
+```
+
 ## Set comprehensions
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/literal/collections/set.md
+++ b/crates/ty_python_semantic/resources/mdtest/literal/collections/set.md
@@ -3,7 +3,7 @@
 ## Basic set
 
 ```py
-reveal_type({1, 2})  # revealed: set[Unknown | Literal[1, 2]]
+reveal_type({1, 2})  # revealed: set[Unknown | int]
 ```
 
 ## Set comprehensions

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/nested.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/nested.md
@@ -328,8 +328,7 @@ def f(l: list[str | None]):
     def _():
         l: list[str | None] = [None]
         def _():
-            # TODO: should be `str | None`
-            reveal_type(l[0])  # revealed: @Todo(list literal element type)
+            reveal_type(l[0])  # revealed: str | None
 
     def _():
         def _():

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/nested.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/nested.md
@@ -310,17 +310,13 @@ no longer valid in the inner lazy scope.
 def f(l: list[str | None]):
     if l[0] is not None:
         def _():
-            # TODO: should be `str | None`
             reveal_type(l[0])  # revealed: str | None | Unknown
-        # TODO: should be of type `list[None]`
         l = [None]
 
 def f(l: list[str | None]):
     l[0] = "a"
     def _():
-        # TODO: should be `str | None`
         reveal_type(l[0])  # revealed: str | None | Unknown
-    # TODO: should be of type `list[None]`
     l = [None]
 
 def f(l: list[str | None]):

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/nested.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/nested.md
@@ -311,7 +311,7 @@ def f(l: list[str | None]):
     if l[0] is not None:
         def _():
             # TODO: should be `str | None`
-            reveal_type(l[0])  # revealed: str | None | @Todo(list literal element type)
+            reveal_type(l[0])  # revealed: str | None | Unknown
         # TODO: should be of type `list[None]`
         l = [None]
 
@@ -319,7 +319,7 @@ def f(l: list[str | None]):
     l[0] = "a"
     def _():
         # TODO: should be `str | None`
-        reveal_type(l[0])  # revealed: str | None | @Todo(list literal element type)
+        reveal_type(l[0])  # revealed: str | None | Unknown
     # TODO: should be of type `list[None]`
     l = [None]
 

--- a/crates/ty_python_semantic/resources/mdtest/subscript/lists.md
+++ b/crates/ty_python_semantic/resources/mdtest/subscript/lists.md
@@ -9,11 +9,11 @@ A list can be indexed into with:
 
 ```py
 x = [1, 2, 3]
-reveal_type(x)  # revealed: list[Unknown | Literal[1, 2, 3]]
+reveal_type(x)  # revealed: list[Unknown | int]
 
-reveal_type(x[0])  # revealed: Unknown | Literal[1, 2, 3]
+reveal_type(x[0])  # revealed: Unknown | int
 
-reveal_type(x[0:1])  # revealed: list[Unknown | Literal[1, 2, 3]]
+reveal_type(x[0:1])  # revealed: list[Unknown | int]
 
 # error: [invalid-argument-type]
 reveal_type(x["a"])  # revealed: Unknown

--- a/crates/ty_python_semantic/resources/mdtest/subscript/lists.md
+++ b/crates/ty_python_semantic/resources/mdtest/subscript/lists.md
@@ -9,13 +9,11 @@ A list can be indexed into with:
 
 ```py
 x = [1, 2, 3]
-reveal_type(x)  # revealed: list[@Todo(list literal element type)]
+reveal_type(x)  # revealed: list[Unknown | Literal[1, 2, 3]]
 
-# TODO reveal int
-reveal_type(x[0])  # revealed: @Todo(list literal element type)
+reveal_type(x[0])  # revealed: Unknown | Literal[1, 2, 3]
 
-# TODO reveal list[int]
-reveal_type(x[0:1])  # revealed: list[@Todo(list literal element type)]
+reveal_type(x[0:1])  # revealed: list[Unknown | Literal[1, 2, 3]]
 
 # error: [invalid-argument-type]
 reveal_type(x["a"])  # revealed: Unknown

--- a/crates/ty_python_semantic/resources/mdtest/type_compendium/tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_compendium/tuple.md
@@ -55,8 +55,7 @@ def f(x: Iterable[int], y: list[str], z: Never, aa: list[Never], bb: LiskovUncom
 
 reveal_type(tuple((1, 2)))  # revealed: tuple[Literal[1], Literal[2]]
 
-# TODO: should be `tuple[Literal[1], ...]`
-reveal_type(tuple([1]))  # revealed: tuple[@Todo(list literal element type), ...]
+reveal_type(tuple([1]))  # revealed: tuple[Unknown | Literal[1], ...]
 
 # error: [invalid-argument-type]
 reveal_type(tuple[int]([1]))  # revealed: tuple[int]

--- a/crates/ty_python_semantic/resources/mdtest/type_compendium/tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_compendium/tuple.md
@@ -55,7 +55,7 @@ def f(x: Iterable[int], y: list[str], z: Never, aa: list[Never], bb: LiskovUncom
 
 reveal_type(tuple((1, 2)))  # revealed: tuple[Literal[1], Literal[2]]
 
-reveal_type(tuple([1]))  # revealed: tuple[Unknown | Literal[1], ...]
+reveal_type(tuple([1]))  # revealed: tuple[Unknown | int, ...]
 
 # error: [invalid-argument-type]
 reveal_type(tuple[int]([1]))  # revealed: tuple[int]

--- a/crates/ty_python_semantic/resources/mdtest/unpacking.md
+++ b/crates/ty_python_semantic/resources/mdtest/unpacking.md
@@ -213,8 +213,8 @@ reveal_type(d)  # revealed: Literal[2]
 
 ```py
 a, b = [1, 2]
-reveal_type(a)  # revealed: Unknown | Literal[1, 2]
-reveal_type(b)  # revealed: Unknown | Literal[1, 2]
+reveal_type(a)  # revealed: Unknown | int
+reveal_type(b)  # revealed: Unknown | int
 ```
 
 ### Simple unpacking

--- a/crates/ty_python_semantic/resources/mdtest/unpacking.md
+++ b/crates/ty_python_semantic/resources/mdtest/unpacking.md
@@ -213,9 +213,8 @@ reveal_type(d)  # revealed: Literal[2]
 
 ```py
 a, b = [1, 2]
-# TODO: should be `int` for both `a` and `b`
-reveal_type(a)  # revealed: @Todo(list literal element type)
-reveal_type(b)  # revealed: @Todo(list literal element type)
+reveal_type(a)  # revealed: Unknown | Literal[1, 2]
+reveal_type(b)  # revealed: Unknown | Literal[1, 2]
 ```
 
 ### Simple unpacking

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1137,7 +1137,7 @@ impl<'db> Type<'db> {
     /// If this type is a literal, promote it to a type that this literal is an instance of.
     ///
     /// Note that this function tries to promote literals to a more user-friendly form than their
-    /// fallback instance type. For example, `def _() -> int` is promoted to a `Callable[[], int]`
+    /// fallback instance type. For example, `def _() -> int` is promoted to `Callable[[], int]`,
     /// as opposed to `FunctionType`.
     pub(crate) fn literal_promotion_type(self, db: &'db dyn Db) -> Option<Type<'db>> {
         match self {

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -2277,7 +2277,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             // inferred as a literal to the corresponding instance type.
             builder
                 .build(gc)
-                .apply_type_mapping(self.db, &TypeMapping::LiteralToInstance)
+                .apply_type_mapping(self.db, &TypeMapping::PromoteLiterals)
         });
     }
 

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -2277,7 +2277,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             // inferred as a literal to the corresponding instance type.
             builder
                 .build(gc)
-                .apply_type_mapping(self.db, &TypeMapping::PromoteLiterals)
+                .apply_type_mapping(self.db, &TypeMapping::LiteralToInstance)
         });
     }
 

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -2626,7 +2626,7 @@ pub(crate) fn report_undeclared_protocol_member(
         let binding_type = binding_type(db, definition);
 
         let suggestion = binding_type
-            .literal_fallback_instance(db)
+            .literal_annotation_type(db)
             .unwrap_or(binding_type);
 
         if should_give_hint(db, suggestion) {

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -2626,7 +2626,7 @@ pub(crate) fn report_undeclared_protocol_member(
         let binding_type = binding_type(db, definition);
 
         let suggestion = binding_type
-            .literal_annotation_type(db)
+            .literal_promotion_type(db)
             .unwrap_or(binding_type);
 
         if should_give_hint(db, suggestion) {

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -1081,15 +1081,12 @@ fn is_instance_truthiness<'db>(
         | Type::StringLiteral(..)
         | Type::LiteralString
         | Type::ModuleLiteral(..)
-        | Type::EnumLiteral(..) => always_true_if(
+        | Type::EnumLiteral(..)
+        | Type::FunctionLiteral(..) => always_true_if(
             ty.literal_fallback_instance(db)
                 .as_ref()
                 .is_some_and(is_instance),
         ),
-
-        Type::FunctionLiteral(..) => {
-            always_true_if(is_instance(&KnownClass::FunctionType.to_instance(db)))
-        }
 
         Type::ClassLiteral(..) => always_true_if(is_instance(&KnownClass::Type.to_instance(db))),
 

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -49,8 +49,9 @@ use crate::semantic_index::expression::Expression;
 use crate::semantic_index::scope::ScopeId;
 use crate::semantic_index::{SemanticIndex, semantic_index};
 use crate::types::diagnostic::TypeCheckDiagnostics;
+use crate::types::generics::Specialization;
 use crate::types::unpacker::{UnpackResult, Unpacker};
-use crate::types::{ClassLiteral, Truthiness, Type, TypeAndQualifiers};
+use crate::types::{ClassLiteral, KnownClass, Truthiness, Type, TypeAndQualifiers};
 use crate::unpack::Unpack;
 use builder::TypeInferenceBuilder;
 
@@ -349,10 +350,31 @@ pub(crate) struct TypeContext<'db> {
 }
 
 impl<'db> TypeContext<'db> {
-    pub(crate) fn new(annotation: Type<'db>) -> Self {
-        Self {
-            annotation: Some(annotation),
+    pub(crate) fn new(annotation: Option<Type<'db>>) -> Self {
+        Self { annotation }
+    }
+
+    // If the type annotation is a specialized instance of the given `KnownClass`, returns the
+    // specialization.
+    fn known_specialization(
+        &self,
+        known_class: KnownClass,
+        db: &'db dyn Db,
+    ) -> Option<Specialization<'db>> {
+        let class_type = match self.annotation? {
+            Type::NominalInstance(instance) => instance,
+            Type::TypeAlias(alias) => alias.value_type(db).into_nominal_instance()?,
+            _ => return None,
         }
+        .class(db);
+
+        if !class_type.is_known(db, known_class) {
+            return None;
+        }
+
+        class_type
+            .into_generic_alias()
+            .map(|generic_alias| generic_alias.specialization(db))
     }
 }
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5377,10 +5377,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         // The inferred type of each element acts as an additional constraint on `T`.
         for inferred_elt_ty in inferred_elt_tys {
-            // Promote element literals to their type annotation form to avoid excessively large
+            // Convert any element literals to their promoted type form to avoid excessively large
             // unions for large nested list literals, which the constraint solver struggles with.
             let inferred_elt_ty =
-                inferred_elt_ty.apply_type_mapping(self.db(), &TypeMapping::LiteralToAnnotation);
+                inferred_elt_ty.apply_type_mapping(self.db(), &TypeMapping::PromoteLiterals);
             builder.infer(elts_ty, inferred_elt_ty).ok()?;
         }
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5366,6 +5366,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         // The inferred type of each element acts as an additional constraint on `T`.
         for inferred_elt_ty in inferred_elt_tys {
+            // Use the fallback instance type for element literals to avoid excessively large unions
+            // for large nested list literals, which the constraint solver struggles with.
+            let inferred_elt_ty = inferred_elt_ty
+                .literal_fallback_instance(self.db())
+                .unwrap_or(inferred_elt_ty);
+
             builder.infer(elts_ty, inferred_elt_ty).ok()?;
         }
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5293,7 +5293,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             collection_class: KnownClass,
             db: &'db dyn Db,
         ) -> Option<Type<'db>> {
-            let class_type = tcx.annotation?.into_nominal_instance()?.class(db);
+            let class_type = match tcx.annotation? {
+                Type::NominalInstance(instance) => instance,
+                Type::TypeAlias(alias) => alias.value_type(db).into_nominal_instance()?,
+                _ => return None,
+            }
+            .class(db);
+
             if !class_type.is_known(db, collection_class) {
                 return None;
             }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5366,12 +5366,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         // The inferred type of each element acts as an additional constraint on `T`.
         for inferred_elt_ty in inferred_elt_tys {
-            // Use the fallback instance type for element literals to avoid excessively large unions
+            // Promote element literals to their fallback instance type to avoid excessively large unions
             // for large nested list literals, which the constraint solver struggles with.
-            let inferred_elt_ty = inferred_elt_ty
-                .literal_fallback_instance(self.db())
-                .unwrap_or(inferred_elt_ty);
-
+            let inferred_elt_ty = inferred_elt_ty.promote_literals(self.db());
             builder.infer(elts_ty, inferred_elt_ty).ok()?;
         }
 

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -545,11 +545,15 @@ impl<T> VariableLengthTuple<T> {
         })
     }
 
-    fn prefix_elements(&self) -> impl DoubleEndedIterator<Item = &T> + ExactSizeIterator + '_ {
+    pub(crate) fn prefix_elements(
+        &self,
+    ) -> impl DoubleEndedIterator<Item = &T> + ExactSizeIterator + '_ {
         self.prefix.iter()
     }
 
-    fn suffix_elements(&self) -> impl DoubleEndedIterator<Item = &T> + ExactSizeIterator + '_ {
+    pub(crate) fn suffix_elements(
+        &self,
+    ) -> impl DoubleEndedIterator<Item = &T> + ExactSizeIterator + '_ {
         self.suffix.iter()
     }
 


### PR DESCRIPTION
## Summary

Part of https://github.com/astral-sh/ty/issues/168. Infer more precise types for collection literals (currently, only `list` and `set`). For example,

```py
x = [1, 2, 3] # revealed: list[Unknown | int]
y: list[int] = [1, 2, 3] # revealed: list[int]
```

This could easily be extended to `dict` literals, but I am intentionally limiting scope for now.