### PR TITLE
[ruff]: Build loongarch64 binaries in CI

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -294,6 +294,11 @@ jobs:
             arch: arm
           - target: riscv64gc-unknown-linux-gnu
             arch: riscv64
+          - target: loongarch64-unknown-linux-gnu
+            arch: loong64
+            # There's currently no loong64 support for Ubuntu so we are using Debian
+            base_image: --platform=linux/loong64 ghcr.io/loong64/debian:trixie
+            maturin_docker_options: -e JEMALLOC_SYS_WITH_LG_PAGE=16
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -318,12 +323,15 @@ jobs:
         with:
           arch: ${{ matrix.platform.arch == 'arm' && 'armv6' || matrix.platform.arch }}
           distro: ${{ matrix.platform.arch == 'arm' && 'bullseye' || 'ubuntu20.04' }}
+          base_image: ${{ matrix.platform.base_image }}
           githubToken: ${{ github.token }}
           install: |
             apt-get update
-            apt-get install -y --no-install-recommends python3 python3-pip libatomic1
-            pip3 install -U pip
+            apt-get install -y --no-install-recommends python3 python3-pip python3-venv libatomic1
           run: |
+            python3 -m venv .venv
+            source .venv/bin/activate
+            pip3 install -U pip
             pip3 install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
             ruff --help
       - name: "Upload wheels"

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -28,5 +28,7 @@ jobs:
           pattern: wheels-*
           path: wheels
           merge-multiple: true
+      - name: Remove wheels unsupported by PyPI
+        run: rm wheels/*loong*
       - name: Publish to PyPi
         run: uv publish -v wheels/*

--- a/crates/ruff/Cargo.toml
+++ b/crates/ruff/Cargo.toml
@@ -85,7 +85,7 @@ dist = true
 [target.'cfg(target_os = "windows")'.dependencies]
 mimalloc = { workspace = true }
 
-[target.'cfg(all(not(target_os = "windows"), not(target_os = "openbsd"), not(target_os = "aix"), not(target_os = "android"), any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "powerpc64", target_arch = "riscv64")))'.dependencies]
+[target.'cfg(all(not(target_os = "windows"), not(target_os = "openbsd"), not(target_os = "aix"), not(target_os = "android"), any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "powerpc64", target_arch = "riscv64", target_arch = "loongarch64")))'.dependencies]
 tikv-jemallocator = { workspace = true }
 
 [lints]

--- a/crates/ruff/src/main.rs
+++ b/crates/ruff/src/main.rs
@@ -20,7 +20,8 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
         target_arch = "x86_64",
         target_arch = "aarch64",
         target_arch = "powerpc64",
-        target_arch = "riscv64"
+        target_arch = "riscv64",
+        target_arch = "loongarch64",
     )
 ))]
 #[global_allocator]

--- a/crates/ruff_benchmark/Cargo.toml
+++ b/crates/ruff_benchmark/Cargo.toml
@@ -86,5 +86,5 @@ walltime = ["ruff_db/os", "ty_project", "divan"]
 [target.'cfg(target_os = "windows")'.dev-dependencies]
 mimalloc = { workspace = true }
 
-[target.'cfg(all(not(target_os = "windows"), not(target_os = "openbsd"), any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "powerpc64", target_arch = "riscv64")))'.dev-dependencies]
+[target.'cfg(all(not(target_os = "windows"), not(target_os = "openbsd"), any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "powerpc64", target_arch = "riscv64", target_arch = "loongarch64")))'.dev-dependencies]
 tikv-jemallocator = { workspace = true }

--- a/crates/ruff_benchmark/benches/formatter.rs
+++ b/crates/ruff_benchmark/benches/formatter.rs
@@ -22,7 +22,8 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
         target_arch = "x86_64",
         target_arch = "aarch64",
         target_arch = "powerpc64",
-        target_arch = "riscv64"
+        target_arch = "riscv64",
+        target_arch = "loongarch64"
     )
 ))]
 #[global_allocator]

--- a/crates/ruff_benchmark/benches/lexer.rs
+++ b/crates/ruff_benchmark/benches/lexer.rs
@@ -19,7 +19,8 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
         target_arch = "x86_64",
         target_arch = "aarch64",
         target_arch = "powerpc64",
-        target_arch = "riscv64"
+        target_arch = "riscv64",
+        target_arch = "loongarch64"
     )
 ))]
 #[global_allocator]

--- a/crates/ruff_benchmark/benches/linter.rs
+++ b/crates/ruff_benchmark/benches/linter.rs
@@ -27,7 +27,8 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
         target_arch = "x86_64",
         target_arch = "aarch64",
         target_arch = "powerpc64",
-        target_arch = "riscv64"
+        target_arch = "riscv64",
+        target_arch = "loongarch64"
     )
 ))]
 #[global_allocator]
@@ -44,7 +45,8 @@ static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
         target_arch = "x86_64",
         target_arch = "aarch64",
         target_arch = "powerpc64",
-        target_arch = "riscv64"
+        target_arch = "riscv64",
+        target_arch = "loongarch64"
     )
 ))]
 #[unsafe(export_name = "_rjem_malloc_conf")]

--- a/crates/ruff_benchmark/benches/parser.rs
+++ b/crates/ruff_benchmark/benches/parser.rs
@@ -21,7 +21,8 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
         target_arch = "x86_64",
         target_arch = "aarch64",
         target_arch = "powerpc64",
-        target_arch = "riscv64"
+        target_arch = "riscv64",
+        target_arch = "loongarch64"
     )
 ))]
 #[global_allocator]

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -30,6 +30,7 @@ targets = [
     "powerpc64le-unknown-linux-gnu",
     "riscv64gc-unknown-linux-gnu",
     "s390x-unknown-linux-gnu",
+    "loongarch64-unknown-linux-gnu",
     "x86_64-unknown-linux-gnu",
     "x86_64-unknown-linux-musl",
     "x86_64-pc-windows-msvc",


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

This PR adds support for building loongarch64 binaries in CI. As such support has been merged in uv (astral-sh/uv#15387) it's time to consider adding it to ruff.

Please note that as Ubuntu is not yet available for loongarch64, I have elected to use a Debian Trixie container maintained by community members. In addition, as Debian's pip does not allow installing modules system-wide, I have modified the workflow to install additional modules in a virtual environment.

Since the workflow is shared between all targets, the only way to handle this difference (between Debian and Ubuntu) is just to install pip in a venv for all targets. If there is a better (and less intrusive) way to work around this, please let me know.

## Test Plan

Tests are included in CI and the loongarch64 artifacts built in [this workflow](https://github.com/SkyBird233/ruff/actions/runs/17640270032/job/50125471548) has been smoke tested.
