### PR TITLE
[ty] Remove `Self` from generic context when binding `Self`

### DIFF
--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -6777,8 +6777,15 @@ impl<'db> TypeMapping<'_, 'db> {
             | TypeMapping::PromoteLiterals
             | TypeMapping::BindLegacyTypevars(_)
             | TypeMapping::MarkTypeVarsInferable(_)
-            | TypeMapping::Materialize(_)
-            | TypeMapping::BindSelf(_) => context,
+            | TypeMapping::Materialize(_) => context,
+            TypeMapping::BindSelf(_) => GenericContext::from_typevar_instances(
+                db,
+                context
+                    .variables(db)
+                    .iter()
+                    .filter(|var| !var.typevar(db).is_self(db))
+                    .copied(),
+            ),
             TypeMapping::ReplaceSelf { new_upper_bound } => GenericContext::from_typevar_instances(
                 db,
                 context.variables(db).iter().map(|typevar| {


### PR DESCRIPTION
## Summary

This mainly removes an internal inconsistency, where we didn't remove the `Self` type variable when eagerly binding `Self` to an instance type. It has no observable effect, apparently.

builds on top of https://github.com/astral-sh/ruff/pull/20328

## Test Plan

None