### PR TITLE
[`ruff`] Add `analyze.string-imports-min-dots` to settings

### DIFF
--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -3860,6 +3860,13 @@ pub struct AnalyzeOptions {
     /// This setting is only relevant when [`detect-string-imports`](#detect-string-imports) is enabled.
     /// For example, if this is set to `2`, then only strings with at least two dots (e.g., `"path.to.module"`)
     /// would be considered valid imports.
+    #[option(
+        default = "2",
+        value_type = "usize",
+        example = r#"
+            string-imports-min-dots = 2
+        "#
+    )]
     pub string_imports_min_dots: Option<usize>,
     /// A map from file path to the list of Python or non-Python file paths or globs that should be
     /// considered dependencies of that file, regardless of whether relevant imports are detected.


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Fixes #20110

`string_imports_min_dots` was introduced in #19538, so the option has been available since then; this PR adds documentation and a config test.

## Test Plan

<!-- How was it tested? -->

Add integration test `string_detection_from_config` to verify the config setting works.
