### PR TITLE
[`isort`] Fix infinite loop when checking equivalent imports (`I002`, `PLR0402`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/isort/required_imports/equivalent_imports.py
+++ b/crates/ruff_linter/resources/test/fixtures/isort/required_imports/equivalent_imports.py
@@ -1,0 +1,3 @@
+from concurrent import futures
+
+1

--- a/crates/ruff_linter/src/rules/isort/mod.rs
+++ b/crates/ruff_linter/src/rules/isort/mod.rs
@@ -991,6 +991,29 @@ mod tests {
         Ok(())
     }
 
+    #[test_case(Path::new("equivalent_imports.py"))]
+    fn required_import_equivalent_imports(path: &Path) -> Result<()> {
+        let snapshot = format!("required_import_equivalent_imports_{}", path.to_string_lossy());
+        let diagnostics = test_path(
+            Path::new("isort/required_imports").join(path).as_path(),
+            &LinterSettings {
+                src: vec![test_resource_path("fixtures/isort")],
+                isort: super::settings::Settings {
+                    required_imports: BTreeSet::from_iter([NameImport::Import(
+                        ModuleNameImport::alias(
+                            "concurrent.futures".to_string(),
+                            "futures".to_string(),
+                        ),
+                    )]),
+                    ..super::settings::Settings::default()
+                },
+                ..LinterSettings::for_rules([Rule::MissingRequiredImport, Rule::ManualFromImport])
+            },
+        )?;
+        assert_diagnostics!(snapshot, diagnostics);
+        Ok(())
+    }
+
     #[test_case(Path::new("from_first.py"))]
     fn from_first(path: &Path) -> Result<()> {
         let snapshot = format!("from_first_{}", path.to_string_lossy());

--- a/crates/ruff_linter/src/rules/isort/snapshots/ruff_linter__rules__isort__tests__required_import_equivalent_imports_equivalent_imports.py.snap
+++ b/crates/ruff_linter/src/rules/isort/snapshots/ruff_linter__rules__isort__tests__required_import_equivalent_imports_equivalent_imports.py.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff_linter/src/rules/isort/mod.rs
+---
+


### PR DESCRIPTION
## Summary

Fixes #20380

The fix changes the `includes_import` function in `I002` to recognize equivalent imports based on bound name and qualified name rather than exact syntax matching.

This allows the function to correctly identify that `from concurrent import futures` satisfies the requirement for `import concurrent.futures as futures`.