### PR TITLE
[ty] Remove 'materialize' from the ecosystem projects

### DIFF
--- a/.github/workflows/ty-ecosystem-analyzer.yaml
+++ b/.github/workflows/ty-ecosystem-analyzer.yaml
@@ -64,7 +64,7 @@ jobs:
 
           cd ..
 
-          uv tool install "git+https://github.com/astral-sh/ecosystem-analyzer@1f560d07d672effae250e3d271da53d96c5260ff"
+          uv tool install "git+https://github.com/astral-sh/ecosystem-analyzer@fc0f612798710b0dd69bb7528bc9b361dc60bd43"
 
           ecosystem-analyzer \
             --repository ruff \

--- a/crates/ty_python_semantic/resources/primer/good.txt
+++ b/crates/ty_python_semantic/resources/primer/good.txt
@@ -56,7 +56,6 @@ koda-validate
 kopf
 kornia
 manticore
-materialize
 meson
 mitmproxy
 mkdocs


### PR DESCRIPTION
## Summary

This project was [recently removed from mypy_primer](https://github.com/astral-sh/ruff/pull/20378), so we need to remove it from `good.txt` in order for ecosystem-analyzer to work correctly.

## Test Plan

Run mypy_primer and ecosystem-analyzer on this branch.
