### PR TITLE
[ty] Allow annotation expressions to be `ast::Attribute` nodes

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_qualifiers/classvar.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_qualifiers/classvar.md
@@ -9,6 +9,7 @@ For more details on the semantics of pure class variables, see [this test](../at
 ## Basic
 
 ```py
+import typing
 from typing import ClassVar, Annotated
 
 class C:
@@ -17,12 +18,14 @@ class C:
     c: ClassVar[Annotated[int, "the annotation for c"]] = 1
     d: ClassVar = 1
     e: "ClassVar[int]" = 1
+    f: typing.ClassVar = 1
 
 reveal_type(C.a)  # revealed: int
 reveal_type(C.b)  # revealed: int
 reveal_type(C.c)  # revealed: int
 reveal_type(C.d)  # revealed: Unknown | Literal[1]
 reveal_type(C.e)  # revealed: int
+reveal_type(C.f)  # revealed: Unknown | Literal[1]
 
 c = C()
 
@@ -36,6 +39,8 @@ c.c = 2
 c.d = 2
 # error: [invalid-attribute-access]
 c.e = 2
+# error: [invalid-attribute-access]
+c.f = 3
 ```
 
 ## From stubs


### PR DESCRIPTION
Fixes https://github.com/astral-sh/ty/issues/1187