### PR TITLE
[docs] Update README.md with Albumentations new repository URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ Ruff is used by a number of major open-source projects and companies, including:
 
 - [Albumentations](https://github.com/albumentations-team/AlbumentationsX)
 - Amazon ([AWS SAM](https://github.com/aws/serverless-application-model))
-- [Anki](https://github.com/ankitects/anki)
+- [Anki](https://apps.ankiweb.net/)
 - Anthropic ([Python SDK](https://github.com/anthropics/anthropic-sdk-python))
 - [Apache Airflow](https://github.com/apache/airflow)
 - AstraZeneca ([Magnus](https://github.com/AstraZeneca/magnus-core))


### PR DESCRIPTION
## Summary

This PR updates Albumentations URL in `README.md -> Who's Using Ruff?`, as current URL points to an archived repository. This can downgrade ruff image as the URL appears as a first listing.
