### PR TITLE
[`pyupgrade`] Mark `printf-string-formatting` fixes as safe (`UP031`)

### DIFF
--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP031_0.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP031_0.py.snap
@@ -19,7 +19,6 @@ help: Replace with format specifiers
 5 | 
 6 | print('%s%s' % (a, b))
 7 | 
-note: This is an unsafe fix and may change runtime behavior
 
 UP031 [*] Use format specifiers instead of percent format
  --> UP031_0.py:6:7
@@ -40,7 +39,6 @@ help: Replace with format specifiers
 7 | 
 8 | print("trivial" % ())
 9 | 
-note: This is an unsafe fix and may change runtime behavior
 
 UP031 [*] Use format specifiers instead of percent format
   --> UP031_0.py:8:7
@@ -61,7 +59,6 @@ help: Replace with format specifiers
 9  | 
 10 | print("%s" % ("simple",))
 11 | 
-note: This is an unsafe fix and may change runtime behavior
 
 UP031 [*] Use format specifiers instead of percent format
   --> UP031_0.py:10:7
@@ -82,7 +79,6 @@ help: Replace with format specifiers
 11 | 
 12 | print("%s" % ("%s" % ("nested",),))
 13 | 
-note: This is an unsafe fix and may change runtime behavior
 
 UP031 [*] Use format specifiers instead of percent format
   --> UP031_0.py:12:7
@@ -103,7 +99,6 @@ help: Replace with format specifiers
 13 | 
 14 | print("%s%% percent" % (15,))
 15 | 
-note: This is an unsafe fix and may change runtime behavior
 
 UP031 [*] Use format specifiers instead of percent format
   --> UP031_0.py:12:15
@@ -124,7 +119,6 @@ help: Replace with format specifiers
 13 | 
 14 | print("%s%% percent" % (15,))
 15 | 
-note: This is an unsafe fix and may change runtime behavior
 
 UP031 [*] Use format specifiers instead of percent format
   --> UP031_0.py:14:7
@@ -145,7 +139,6 @@ help: Replace with format specifiers
 15 | 
 16 | print("%f" % (15,))
 17 | 
-note: This is an unsafe fix and may change runtime behavior
 
 UP031 [*] Use format specifiers instead of percent format
   --> UP031_0.py:16:7
@@ -166,7 +159,6 @@ help: Replace with format specifiers
 17 | 
 18 | print("%.f" % (15,))
 19 | 
-note: This is an unsafe fix and may change runtime behavior
 
 UP031 [*] Use format specifiers instead of percent format
   --> UP031_0.py:18:7
@@ -187,7 +179,6 @@ help: Replace with format specifiers
 19 | 
 20 | print("%.3f" % (15,))
 21 | 
-note: This is an unsafe fix and may change runtime behavior
 
 UP031 [*] Use format specifiers instead of percent format
   --> UP031_0.py:20:7
@@ -208,7 +199,6 @@ help: Replace with format specifiers
 21 | 
 22 | print("%3f" % (15,))
 23 | 
-note: This is an unsafe fix and may change runtime behavior
 
 UP031 [*] Use format specifiers instead of percent format
   --> UP031_0.py:22:7
@@ -229,7 +219,6 @@ help: Replace with format specifiers
 23 | 
 24 | print("%-5f" % (5,))
 25 | 
-note: This is an unsafe fix and may change runtime behavior
 
 UP031 [*] Use format specifiers instead of percent format
   --> UP031_0.py:24:7
@@ -250,7 +239,6 @@ help: Replace with format specifiers
 25 | 
 26 | print("%9f" % (5,))
 27 | 
-note: This is an unsafe fix and may change runtime behavior
 
 UP031 [*] Use format specifiers instead of percent format
   --> UP031_0.py:26:7
@@ -271,7 +259,6 @@ help: Replace with format specifiers
 27 | 
 28 | print("%#o" % (123,))
 29 | 
-note: This is an unsafe fix and may change runtime behavior
 
 UP031 [*] Use format specifiers instead of percent format
   --> UP031_0.py:28:7
@@ -292,7 +279,6 @@ help: Replace with format specifiers
 29 | 
 30 | print("brace {} %s" % (1,))
 31 | 
-note: This is an unsafe fix and may change runtime behavior
 
 UP031 [*] Use format specifiers instead of percent format
   --> UP031_0.py:30:7
@@ -313,7 +299,6 @@ help: Replace with format specifiers
 31 | 
 32 | print((
 33 |     "foo %s "
-note: This is an unsafe fix and may change runtime behavior
 
 UP031 [*] Use format specifiers instead of percent format
   --> UP031_0.py:33:5
@@ -335,7 +320,6 @@ help: Replace with format specifiers
 35 | ))
 36 | 
 37 | print(
-note: This is an unsafe fix and may change runtime behavior
 
 UP031 [*] Use format specifiers instead of percent format
   --> UP031_0.py:38:3
@@ -356,7 +340,6 @@ help: Replace with format specifiers
 39 |     "trailing comma",
 40 |         )
 41 | )
-note: This is an unsafe fix and may change runtime behavior
 
 UP031 [*] Use format specifiers instead of percent format
   --> UP031_0.py:43:7
@@ -377,7 +360,6 @@ help: Replace with format specifiers
 44 | 
 45 | print("%(k)s" % {"k": "v"})
 46 | 
-note: This is an unsafe fix and may change runtime behavior
 
 UP031 [*] Use format specifiers instead of percent format
   --> UP031_0.py:45:7
@@ -398,7 +380,6 @@ help: Replace with format specifiers
 46 | 
 47 | print("%(k)s" % {
 48 |     "k": "v",
-note: This is an unsafe fix and may change runtime behavior
 
 UP031 [*] Use format specifiers instead of percent format
   --> UP031_0.py:47:7
@@ -429,7 +410,6 @@ help: Replace with format specifiers
 51 | 
 52 | print("%(to_list)s" % {"to_list": []})
 53 | 
-note: This is an unsafe fix and may change runtime behavior
 
 UP031 [*] Use format specifiers instead of percent format
   --> UP031_0.py:52:7
@@ -450,7 +430,6 @@ help: Replace with format specifiers
 53 | 
 54 | print("%(k)s" % {"k": "v", "i": 1, "j": []})
 55 | 
-note: This is an unsafe fix and may change runtime behavior
 
 UP031 [*] Use format specifiers instead of percent format
   --> UP031_0.py:54:7
@@ -471,7 +450,6 @@ help: Replace with format specifiers
 55 | 
 56 | print("%(ab)s" % {"a" "b": 1})
 57 | 
-note: This is an unsafe fix and may change runtime behavior
 
 UP031 [*] Use format specifiers instead of percent format
   --> UP031_0.py:56:7
@@ -492,7 +470,6 @@ help: Replace with format specifiers
 57 | 
 58 | print("%(a)s" % {"a"  :  1})
 59 | 
-note: This is an unsafe fix and may change runtime behavior
 
 UP031 [*] Use format specifiers instead of percent format
   --> UP031_0.py:58:7
@@ -511,7 +488,6 @@ help: Replace with format specifiers
 59 | 
 60 | 
 61 | print(
-note: This is an unsafe fix and may change runtime behavior
 
 UP031 [*] Use format specifiers instead of percent format
   --> UP031_0.py:62:5
@@ -533,7 +509,6 @@ help: Replace with format specifiers
 64 | )
 65 | 
 66 | bar = {"bar": y}
-note: This is an unsafe fix and may change runtime behavior
 
 UP031 [*] Use format specifiers instead of percent format
   --> UP031_0.py:68:5
@@ -556,7 +531,6 @@ help: Replace with format specifiers
 70 | )
 71 | 
 72 | print("%s \N{snowman}" % (a,))
-note: This is an unsafe fix and may change runtime behavior
 
 UP031 [*] Use format specifiers instead of percent format
   --> UP031_0.py:72:7
@@ -577,7 +551,6 @@ help: Replace with format specifiers
 73 | 
 74 | print("%(foo)s \N{snowman}" % {"foo": 1})
 75 | 
-note: This is an unsafe fix and may change runtime behavior
 
 UP031 [*] Use format specifiers instead of percent format
   --> UP031_0.py:74:7
@@ -598,7 +571,6 @@ help: Replace with format specifiers
 75 | 
 76 | print(("foo %s " "bar %s") % (x, y))
 77 | 
-note: This is an unsafe fix and may change runtime behavior
 
 UP031 [*] Use format specifiers instead of percent format
   --> UP031_0.py:76:7
@@ -619,7 +591,6 @@ help: Replace with format specifiers
 77 | 
 78 | # Single-value expressions
 79 | print('Hello %s' % "World")
-note: This is an unsafe fix and may change runtime behavior
 
 UP031 [*] Use format specifiers instead of percent format
   --> UP031_0.py:79:7
@@ -639,7 +610,6 @@ help: Replace with format specifiers
 80 | print('Hello %s' % f"World")
 81 | print('Hello %s (%s)' % bar)
 82 | print('Hello %s (%s)' % bar.baz)
-note: This is an unsafe fix and may change runtime behavior
 
 UP031 [*] Use format specifiers instead of percent format
   --> UP031_0.py:80:7
@@ -660,7 +630,6 @@ help: Replace with format specifiers
 81 | print('Hello %s (%s)' % bar)
 82 | print('Hello %s (%s)' % bar.baz)
 83 | print('Hello %s (%s)' % bar['bop'])
-note: This is an unsafe fix and may change runtime behavior
 
 UP031 [*] Use format specifiers instead of percent format
   --> UP031_0.py:81:7
@@ -681,7 +650,6 @@ help: Replace with format specifiers
 82 | print('Hello %s (%s)' % bar.baz)
 83 | print('Hello %s (%s)' % bar['bop'])
 84 | print('Hello %(arg)s' % bar)
-note: This is an unsafe fix and may change runtime behavior
 
 UP031 [*] Use format specifiers instead of percent format
   --> UP031_0.py:82:7
@@ -702,7 +670,6 @@ help: Replace with format specifiers
 83 | print('Hello %s (%s)' % bar['bop'])
 84 | print('Hello %(arg)s' % bar)
 85 | print('Hello %(arg)s' % bar.baz)
-note: This is an unsafe fix and may change runtime behavior
 
 UP031 [*] Use format specifiers instead of percent format
   --> UP031_0.py:83:7
@@ -723,7 +690,6 @@ help: Replace with format specifiers
 84 | print('Hello %(arg)s' % bar)
 85 | print('Hello %(arg)s' % bar.baz)
 86 | print('Hello %(arg)s' % bar['bop'])
-note: This is an unsafe fix and may change runtime behavior
 
 UP031 [*] Use format specifiers instead of percent format
   --> UP031_0.py:84:7
@@ -744,7 +710,6 @@ help: Replace with format specifiers
 85 | print('Hello %(arg)s' % bar.baz)
 86 | print('Hello %(arg)s' % bar['bop'])
 87 | 
-note: This is an unsafe fix and may change runtime behavior
 
 UP031 [*] Use format specifiers instead of percent format
   --> UP031_0.py:85:7
@@ -764,7 +729,6 @@ help: Replace with format specifiers
 86 | print('Hello %(arg)s' % bar['bop'])
 87 | 
 88 | # Hanging modulos
-note: This is an unsafe fix and may change runtime behavior
 
 UP031 [*] Use format specifiers instead of percent format
   --> UP031_0.py:86:7
@@ -785,7 +749,6 @@ help: Replace with format specifiers
 87 | 
 88 | # Hanging modulos
 89 | (
-note: This is an unsafe fix and may change runtime behavior
 
 UP031 [*] Use format specifiers instead of percent format
   --> UP031_0.py:89:1
@@ -812,7 +775,6 @@ help: Replace with format specifiers
 93 | 
 94 | (
 95 |     "foo %(foo)s "
-note: This is an unsafe fix and may change runtime behavior
 
 UP031 [*] Use format specifiers instead of percent format
   --> UP031_0.py:94:1
@@ -840,7 +802,6 @@ help: Replace with format specifiers
 98  | 
 99  | (
 100 |     """foo %s"""
-note: This is an unsafe fix and may change runtime behavior
 
 UP031 [*] Use format specifiers instead of percent format
    --> UP031_0.py:100:5
@@ -861,7 +822,6 @@ help: Replace with format specifiers
 101 | )
 102 | 
 103 | (
-note: This is an unsafe fix and may change runtime behavior
 
 UP031 [*] Use format specifiers instead of percent format
    --> UP031_0.py:105:5
@@ -886,7 +846,6 @@ help: Replace with format specifiers
 108 | )
 109 | 
 110 | "%s" % (
-note: This is an unsafe fix and may change runtime behavior
 
 UP031 [*] Use format specifiers instead of percent format
    --> UP031_0.py:111:1
@@ -907,7 +866,6 @@ help: Replace with format specifiers
 112 |     x,  # comment
 113 | )
 114 | 
-note: This is an unsafe fix and may change runtime behavior
 
 UP031 [*] Use format specifiers instead of percent format
    --> UP031_0.py:116:8
@@ -931,7 +889,6 @@ help: Replace with format specifiers
 117 |     safe_domain_name(cn), # common name, which should be filename safe because it is IDNA-encoded, but in case of a malformed cert make sure it's ok to use as a filename
 118 |     cert.not_valid_after.date().isoformat().replace("-", ""), # expiration date
 119 |     hexlify(cert.fingerprint(hashes.SHA256())).decode("ascii")[0:8], # fingerprint prefix
-note: This is an unsafe fix and may change runtime behavior
 
 UP031 [*] Use format specifiers instead of percent format
    --> UP031_0.py:123:1
@@ -1014,7 +971,6 @@ help: Replace with format specifiers
 132 | 
 133 | # See: https://github.com/astral-sh/ruff/issues/12421
 134 | print("%.2X" % 1)
-note: This is an unsafe fix and may change runtime behavior
 
 UP031 [*] Use format specifiers instead of percent format
    --> UP031_0.py:134:7
@@ -1034,7 +990,6 @@ help: Replace with format specifiers
 135 | print("%.02X" % 1)
 136 | print("%02X" % 1)
 137 | print("%.00002X" % 1)
-note: This is an unsafe fix and may change runtime behavior
 
 UP031 [*] Use format specifiers instead of percent format
    --> UP031_0.py:135:7
@@ -1055,7 +1010,6 @@ help: Replace with format specifiers
 136 | print("%02X" % 1)
 137 | print("%.00002X" % 1)
 138 | print("%.20X" % 1)
-note: This is an unsafe fix and may change runtime behavior
 
 UP031 [*] Use format specifiers instead of percent format
    --> UP031_0.py:136:7
@@ -1076,7 +1030,6 @@ help: Replace with format specifiers
 137 | print("%.00002X" % 1)
 138 | print("%.20X" % 1)
 139 | 
-note: This is an unsafe fix and may change runtime behavior
 
 UP031 [*] Use format specifiers instead of percent format
    --> UP031_0.py:137:7
@@ -1096,7 +1049,6 @@ help: Replace with format specifiers
 138 | print("%.20X" % 1)
 139 | 
 140 | print("%2X" % 1)
-note: This is an unsafe fix and may change runtime behavior
 
 UP031 [*] Use format specifiers instead of percent format
    --> UP031_0.py:138:7
@@ -1117,7 +1069,6 @@ help: Replace with format specifiers
 139 | 
 140 | print("%2X" % 1)
 141 | print("%02X" % 1)
-note: This is an unsafe fix and may change runtime behavior
 
 UP031 [*] Use format specifiers instead of percent format
    --> UP031_0.py:140:7
@@ -1137,7 +1088,6 @@ help: Replace with format specifiers
 141 | print("%02X" % 1)
 142 | 
 143 | # UP031 (no longer false negatives, but offer no fix because of more complex syntax)
-note: This is an unsafe fix and may change runtime behavior
 
 UP031 [*] Use format specifiers instead of percent format
    --> UP031_0.py:141:7
@@ -1157,7 +1107,6 @@ help: Replace with format specifiers
 142 | 
 143 | # UP031 (no longer false negatives, but offer no fix because of more complex syntax)
 144 | 
-note: This is an unsafe fix and may change runtime behavior
 
 UP031 Use format specifiers instead of percent format
    --> UP031_0.py:145:1


### PR DESCRIPTION
## Summary

This marks the subset of fixes emitted by UP031, where the RHS operand is unambiguous (see https://docs.astral.sh/ruff/rules/printf-string-formatting/#fix-safety), as safe.

## Test Plan

`cargo test`, and inspect snapshot diff to see the new safe fixes