### PR TITLE
Revert "Update CodSpeedHQ/action action to v4"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -933,9 +933,8 @@ jobs:
         run: cargo codspeed build --features "codspeed,instrumented" --no-default-features -p ruff_benchmark
 
       - name: "Run benchmarks"
-        uses: CodSpeedHQ/action@653fdc30e6c40ffd9739e40c8a0576f4f4523ca1 # v4.0.1
+        uses: CodSpeedHQ/action@76578c2a7ddd928664caa737f0e962e3085d4e7c # v3.8.1
         with:
-          mode: instrumentation
           run: cargo codspeed run
           token: ${{ secrets.CODSPEED_TOKEN }}
 
@@ -967,8 +966,7 @@ jobs:
         run: cargo codspeed build --features "codspeed,walltime" --no-default-features -p ruff_benchmark
 
       - name: "Run benchmarks"
-        uses: CodSpeedHQ/action@653fdc30e6c40ffd9739e40c8a0576f4f4523ca1 # v4.0.1
+        uses: CodSpeedHQ/action@76578c2a7ddd928664caa737f0e962e3085d4e7c # v3.8.1
         with:
-          mode: walltime
           run: cargo codspeed run
           token: ${{ secrets.CODSPEED_TOKEN }}


### PR DESCRIPTION
Reverts astral-sh/ruff#20409

Prior to https://github.com/astral-sh/ruff/commit/25c13ea91c7535f14bda2d23595fa3ba311752fe, the walltime benchmarks CI job took around 10-11 minutes. It now seems to be taking around 17-18 minutes to complete, which is a pretty major slowdown and somewhat annoying if you're waiting for benchmark results on a PR! See e.g. https://github.com/astral-sh/ruff/actions/runs/17738649543/job/50411336184