### PR TITLE
Simplify `Program` configuration for GitHub output

### DIFF
--- a/crates/ruff/src/printer.rs
+++ b/crates/ruff/src/printer.rs
@@ -10,8 +10,8 @@ use ruff_linter::linter::FixTable;
 use serde::Serialize;
 
 use ruff_db::diagnostic::{
-    Diagnostic, DiagnosticFormat, DisplayDiagnosticConfig, DisplayDiagnostics, GithubRenderer,
-    SecondaryCode,
+    Diagnostic, DiagnosticFormat, DisplayDiagnosticConfig, DisplayDiagnostics,
+    DisplayGithubDiagnostics, GithubRenderer, SecondaryCode,
 };
 use ruff_linter::fs::relativize_path;
 use ruff_linter::logging::LogLevel;
@@ -283,7 +283,8 @@ impl Printer {
                 self.write_summary_text(writer, diagnostics)?;
             }
             OutputFormat::Github => {
-                let value = GithubRenderer::new(&context, "Ruff", &diagnostics.inner);
+                let renderer = GithubRenderer::new(&context, "Ruff");
+                let value = DisplayGithubDiagnostics::new(&renderer, &diagnostics.inner);
                 write!(writer, "{value}")?;
             }
             OutputFormat::Gitlab => {

--- a/crates/ruff/src/printer.rs
+++ b/crates/ruff/src/printer.rs
@@ -10,8 +10,8 @@ use ruff_linter::linter::FixTable;
 use serde::Serialize;
 
 use ruff_db::diagnostic::{
-    Diagnostic, DiagnosticFormat, DisplayDiagnosticConfig, DisplayDiagnostics, Program,
-    SecondaryCode,
+    Diagnostic, DiagnosticFormat, DisplayDiagnosticConfig, DisplayDiagnostics, GithubRenderer,
+    Program, SecondaryCode,
 };
 use ruff_linter::fs::relativize_path;
 use ruff_linter::logging::LogLevel;
@@ -286,7 +286,7 @@ impl Printer {
             }
             OutputFormat::Github => {
                 let config = config.format(DiagnosticFormat::Github);
-                let value = DisplayDiagnostics::new(&context, &config, &diagnostics.inner);
+                let value = GithubRenderer::new(&context, &config, &diagnostics.inner);
                 write!(writer, "{value}")?;
             }
             OutputFormat::Gitlab => {

--- a/crates/ruff/src/printer.rs
+++ b/crates/ruff/src/printer.rs
@@ -11,7 +11,7 @@ use serde::Serialize;
 
 use ruff_db::diagnostic::{
     Diagnostic, DiagnosticFormat, DisplayDiagnosticConfig, DisplayDiagnostics, GithubRenderer,
-    Program, SecondaryCode,
+    SecondaryCode,
 };
 use ruff_linter::fs::relativize_path;
 use ruff_linter::logging::LogLevel;
@@ -225,9 +225,7 @@ impl Printer {
         let context = EmitterContext::new(&diagnostics.notebook_indexes);
         let fixables = FixableStatistics::try_from(diagnostics, self.unsafe_fixes);
 
-        let config = DisplayDiagnosticConfig::default()
-            .preview(preview)
-            .program(Program::Ruff);
+        let config = DisplayDiagnosticConfig::default().preview(preview);
 
         match self.format {
             OutputFormat::Json => {
@@ -285,8 +283,7 @@ impl Printer {
                 self.write_summary_text(writer, diagnostics)?;
             }
             OutputFormat::Github => {
-                let config = config.format(DiagnosticFormat::Github);
-                let value = GithubRenderer::new(&context, &config, &diagnostics.inner);
+                let value = GithubRenderer::new(&context, "Ruff", &diagnostics.inner);
                 write!(writer, "{value}")?;
             }
             OutputFormat::Gitlab => {

--- a/crates/ruff_db/src/diagnostic/mod.rs
+++ b/crates/ruff_db/src/diagnostic/mod.rs
@@ -8,7 +8,7 @@ use ruff_text_size::{Ranged, TextRange, TextSize};
 
 pub use self::render::{
     DisplayDiagnostic, DisplayDiagnostics, FileResolver, Input, ceil_char_boundary,
-    github::GithubRenderer,
+    github::{DisplayGithubDiagnostics, GithubRenderer},
 };
 use crate::{Db, files::File};
 

--- a/crates/ruff_db/src/diagnostic/mod.rs
+++ b/crates/ruff_db/src/diagnostic/mod.rs
@@ -8,6 +8,7 @@ use ruff_text_size::{Ranged, TextRange, TextSize};
 
 pub use self::render::{
     DisplayDiagnostic, DisplayDiagnostics, FileResolver, Input, ceil_char_boundary,
+    github::GithubRenderer,
 };
 use crate::{Db, files::File};
 

--- a/crates/ruff_db/src/diagnostic/mod.rs
+++ b/crates/ruff_db/src/diagnostic/mod.rs
@@ -1313,10 +1313,6 @@ pub struct DisplayDiagnosticConfig {
     show_fix_diff: bool,
     /// The lowest applicability that should be shown when reporting diagnostics.
     fix_applicability: Applicability,
-    /// The program for which diagnostics are being rendered (Ruff or ty).
-    ///
-    /// This is currently only used by the GitHub output format and defaults to `Program::Ty`.
-    program: Program,
 }
 
 impl DisplayDiagnosticConfig {
@@ -1382,13 +1378,6 @@ impl DisplayDiagnosticConfig {
             ..self
         }
     }
-
-    /// Set the [`Program`] for which diagnostics are being displayed.
-    ///
-    /// This is currently only used by [`DiagnosticFormat::Github`].
-    pub fn program(self, program: Program) -> DisplayDiagnosticConfig {
-        DisplayDiagnosticConfig { program, ..self }
-    }
 }
 
 impl Default for DisplayDiagnosticConfig {
@@ -1402,7 +1391,6 @@ impl Default for DisplayDiagnosticConfig {
             show_fix_status: false,
             show_fix_diff: false,
             fix_applicability: Applicability::Safe,
-            program: Program::Ty,
         }
     }
 }
@@ -1465,21 +1453,6 @@ pub enum DiagnosticFormat {
     ///
     /// [GitHub Actions]: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#setting-an-error-message
     Github,
-}
-
-#[derive(Clone, Debug)]
-pub enum Program {
-    Ruff,
-    Ty,
-}
-
-impl std::fmt::Display for Program {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Program::Ruff => f.write_str("Ruff"),
-            Program::Ty => f.write_str("ty"),
-        }
-    }
 }
 
 /// A representation of the kinds of messages inside a diagnostic.

--- a/crates/ruff_db/src/diagnostic/render.rs
+++ b/crates/ruff_db/src/diagnostic/render.rs
@@ -145,7 +145,7 @@ impl std::fmt::Display for DisplayDiagnostics<'_> {
                 gitlab::GitlabRenderer::new(self.resolver).render(f, self.diagnostics)?;
             }
             DiagnosticFormat::Github => {
-                GithubRenderer::new(self.resolver, "ty", self.diagnostics).fmt(f)?;
+                GithubRenderer::new(self.resolver, "ty").render(f, self.diagnostics)?;
             }
         }
 

--- a/crates/ruff_db/src/diagnostic/render.rs
+++ b/crates/ruff_db/src/diagnostic/render.rs
@@ -31,7 +31,7 @@ use pylint::PylintRenderer;
 mod azure;
 mod concise;
 mod full;
-mod github;
+pub mod github;
 #[cfg(feature = "serde")]
 mod gitlab;
 #[cfg(feature = "serde")]

--- a/crates/ruff_db/src/diagnostic/render.rs
+++ b/crates/ruff_db/src/diagnostic/render.rs
@@ -145,7 +145,7 @@ impl std::fmt::Display for DisplayDiagnostics<'_> {
                 gitlab::GitlabRenderer::new(self.resolver).render(f, self.diagnostics)?;
             }
             DiagnosticFormat::Github => {
-                GithubRenderer::new(self.resolver, self.config, self.diagnostics).fmt(f)?;
+                GithubRenderer::new(self.resolver, "ty", self.diagnostics).fmt(f)?;
             }
         }
 

--- a/crates/ruff_db/src/diagnostic/render.rs
+++ b/crates/ruff_db/src/diagnostic/render.rs
@@ -145,7 +145,7 @@ impl std::fmt::Display for DisplayDiagnostics<'_> {
                 gitlab::GitlabRenderer::new(self.resolver).render(f, self.diagnostics)?;
             }
             DiagnosticFormat::Github => {
-                GithubRenderer::new(self.resolver, self.config).render(f, self.diagnostics)?;
+                GithubRenderer::new(self.resolver, self.config, self.diagnostics).fmt(f)?;
             }
         }
 

--- a/crates/ruff_db/src/diagnostic/render/github.rs
+++ b/crates/ruff_db/src/diagnostic/render/github.rs
@@ -3,19 +3,26 @@ use crate::diagnostic::{Diagnostic, DisplayDiagnosticConfig, FileResolver, Sever
 pub(super) struct GithubRenderer<'a> {
     resolver: &'a dyn FileResolver,
     config: &'a DisplayDiagnosticConfig,
+    diagnostics: &'a [Diagnostic],
 }
 
 impl<'a> GithubRenderer<'a> {
-    pub(super) fn new(resolver: &'a dyn FileResolver, config: &'a DisplayDiagnosticConfig) -> Self {
-        Self { resolver, config }
+    pub(super) fn new(
+        resolver: &'a dyn FileResolver,
+        config: &'a DisplayDiagnosticConfig,
+        diagnostics: &'a [Diagnostic],
+    ) -> Self {
+        Self {
+            resolver,
+            config,
+            diagnostics,
+        }
     }
+}
 
-    pub(super) fn render(
-        &self,
-        f: &mut std::fmt::Formatter,
-        diagnostics: &[Diagnostic],
-    ) -> std::fmt::Result {
-        for diagnostic in diagnostics {
+impl std::fmt::Display for GithubRenderer<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        for diagnostic in self.diagnostics {
             let severity = match diagnostic.severity() {
                 Severity::Info => "notice",
                 Severity::Warning => "warning",

--- a/crates/ruff_db/src/diagnostic/render/github.rs
+++ b/crates/ruff_db/src/diagnostic/render/github.rs
@@ -3,26 +3,19 @@ use crate::diagnostic::{Diagnostic, FileResolver, Severity};
 pub struct GithubRenderer<'a> {
     resolver: &'a dyn FileResolver,
     program: &'a str,
-    diagnostics: &'a [Diagnostic],
 }
 
 impl<'a> GithubRenderer<'a> {
-    pub fn new(
-        resolver: &'a dyn FileResolver,
-        program: &'a str,
-        diagnostics: &'a [Diagnostic],
-    ) -> Self {
-        Self {
-            resolver,
-            program,
-            diagnostics,
-        }
+    pub fn new(resolver: &'a dyn FileResolver, program: &'a str) -> Self {
+        Self { resolver, program }
     }
-}
 
-impl std::fmt::Display for GithubRenderer<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        for diagnostic in self.diagnostics {
+    pub(super) fn render(
+        &self,
+        f: &mut std::fmt::Formatter,
+        diagnostics: &[Diagnostic],
+    ) -> std::fmt::Result {
+        for diagnostic in diagnostics {
             let severity = match diagnostic.severity() {
                 Severity::Info => "notice",
                 Severity::Warning => "warning",
@@ -86,6 +79,26 @@ impl std::fmt::Display for GithubRenderer<'_> {
         }
 
         Ok(())
+    }
+}
+
+pub struct DisplayGithubDiagnostics<'a> {
+    renderer: &'a GithubRenderer<'a>,
+    diagnostics: &'a [Diagnostic],
+}
+
+impl<'a> DisplayGithubDiagnostics<'a> {
+    pub fn new(renderer: &'a GithubRenderer<'a>, diagnostics: &'a [Diagnostic]) -> Self {
+        Self {
+            renderer,
+            diagnostics,
+        }
+    }
+}
+
+impl std::fmt::Display for DisplayGithubDiagnostics<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.renderer.render(f, self.diagnostics)
     }
 }
 

--- a/crates/ruff_db/src/diagnostic/render/github.rs
+++ b/crates/ruff_db/src/diagnostic/render/github.rs
@@ -1,13 +1,13 @@
 use crate::diagnostic::{Diagnostic, DisplayDiagnosticConfig, FileResolver, Severity};
 
-pub(super) struct GithubRenderer<'a> {
+pub struct GithubRenderer<'a> {
     resolver: &'a dyn FileResolver,
     config: &'a DisplayDiagnosticConfig,
     diagnostics: &'a [Diagnostic],
 }
 
 impl<'a> GithubRenderer<'a> {
-    pub(super) fn new(
+    pub fn new(
         resolver: &'a dyn FileResolver,
         config: &'a DisplayDiagnosticConfig,
         diagnostics: &'a [Diagnostic],

--- a/crates/ruff_db/src/diagnostic/render/github.rs
+++ b/crates/ruff_db/src/diagnostic/render/github.rs
@@ -1,20 +1,20 @@
-use crate::diagnostic::{Diagnostic, DisplayDiagnosticConfig, FileResolver, Severity};
+use crate::diagnostic::{Diagnostic, FileResolver, Severity};
 
 pub struct GithubRenderer<'a> {
     resolver: &'a dyn FileResolver,
-    config: &'a DisplayDiagnosticConfig,
+    program: &'a str,
     diagnostics: &'a [Diagnostic],
 }
 
 impl<'a> GithubRenderer<'a> {
     pub fn new(
         resolver: &'a dyn FileResolver,
-        config: &'a DisplayDiagnosticConfig,
+        program: &'a str,
         diagnostics: &'a [Diagnostic],
     ) -> Self {
         Self {
             resolver,
-            config,
+            program,
             diagnostics,
         }
     }
@@ -31,7 +31,7 @@ impl std::fmt::Display for GithubRenderer<'_> {
             write!(
                 f,
                 "::{severity} title={program} ({code})",
-                program = self.config.program,
+                program = self.program,
                 code = diagnostic.secondary_code_or_id()
             )?;
 

--- a/crates/ruff_linter/src/message/text.rs
+++ b/crates/ruff_linter/src/message/text.rs
@@ -1,7 +1,7 @@
 use std::io::Write;
 
 use ruff_db::diagnostic::{
-    Diagnostic, DiagnosticFormat, DisplayDiagnosticConfig, DisplayDiagnostics, Program,
+    Diagnostic, DiagnosticFormat, DisplayDiagnosticConfig, DisplayDiagnostics,
 };
 use ruff_diagnostics::Applicability;
 
@@ -17,8 +17,7 @@ impl Default for TextEmitter {
             config: DisplayDiagnosticConfig::default()
                 .format(DiagnosticFormat::Concise)
                 .hide_severity(true)
-                .color(!cfg!(test) && colored::control::SHOULD_COLORIZE.should_colorize())
-                .program(Program::Ruff),
+                .color(!cfg!(test) && colored::control::SHOULD_COLORIZE.should_colorize()),
         }
     }
 }


### PR DESCRIPTION
## Summary

This is a follow-up to https://github.com/astral-sh/ruff/pull/20358 to avoid adding a new `DisplayDiagnosticConfig` option (with a surprising default value) just to print the program name for GitHub diagnostics.

Initially I expected this to be a larger refactor including making the various `Renderer::render` methods take a `std::io::Write` instead of a `std::fmt::Formatter` to make them easier to call directly in Ruff. However, this was a bit more painful than expected because we use the `Display` implementation of `DisplayDiagnostics` for more than writing directly to stdout. Implementing `Display` on the individual renderers seemed like a smaller step in this direction.

At this point it might make sense just to merge this into https://github.com/astral-sh/ruff/pull/20358. Alternatively, I could apply the same transformation to the other affected renderers. For example, the JSON and JSON-lines formats only use their `config` fields for the `preview` setting. Or we could update all of the renderers and call them directly in Ruff instead of assembling a config at all. I just wanted to make sure this approach looked reasonable before applying it to everything.

## Test Plan

Existing tests
