### PR TITLE
[`pyupgrade`] Fix false positive when class name is shadowed by local variable (`UP008`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP008.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP008.py
@@ -271,3 +271,19 @@ class ChildI9(ParentI):
                 if False: super
                 if False: __class__
         builtins.super(ChildI9, self).f()
+
+
+# See: https://github.com/astral-sh/ruff/issues/20422
+# UP008 should not apply when the class variable is shadowed
+class A:
+    def f(self):
+        return 1
+
+class B(A):
+    def f(self):
+        return 2
+
+class C(B):
+    def f(self):
+        C = B  # Local variable C shadows the class name
+        return super(C, self).f()  # Should NOT trigger UP008

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/super_call_with_parameters.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/super_call_with_parameters.rs
@@ -139,19 +139,12 @@ pub(crate) fn super_call_with_parameters(checker: &Checker, call: &ast::ExprCall
         return;
     };
 
-    if !((first_arg_id == "__class__" || first_arg_id == parent_name.as_str())
+    if !((first_arg_id == "__class__"
+        || (first_arg_id == parent_name.as_str()
+            && !checker.semantic().current_scope().has(first_arg_id)))
         && second_arg_id == parent_arg.name().as_str())
     {
         return;
-    }
-
-    // If the first argument matches the class name, check if it's a local variable
-    // that shadows the class name. If so, don't apply UP008.
-    if first_arg_id == parent_name.as_str() {
-        let scope = checker.semantic().current_scope();
-        if scope.has(first_arg_id) {
-            return;
-        }
     }
 
     drop(parents);

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/super_call_with_parameters.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/super_call_with_parameters.rs
@@ -141,6 +141,8 @@ pub(crate) fn super_call_with_parameters(checker: &Checker, call: &ast::ExprCall
 
     if !((first_arg_id == "__class__"
         || (first_arg_id == parent_name.as_str()
+            // If the first argument matches the class name, check if it's a local variable
+            // that shadows the class name. If so, don't apply UP008.
             && !checker.semantic().current_scope().has(first_arg_id)))
         && second_arg_id == parent_arg.name().as_str())
     {

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/super_call_with_parameters.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/super_call_with_parameters.rs
@@ -145,6 +145,15 @@ pub(crate) fn super_call_with_parameters(checker: &Checker, call: &ast::ExprCall
         return;
     }
 
+    // If the first argument matches the class name, check if it's a local variable
+    // that shadows the class name. If so, don't apply UP008.
+    if first_arg_id == parent_name.as_str() {
+        let scope = checker.semantic().current_scope();
+        if scope.has(first_arg_id) {
+            return;
+        }
+    }
+
     drop(parents);
 
     // If the class is an `@dataclass` with `slots=True`, calling `super()` without arguments raises


### PR DESCRIPTION
## Summary

Fixes #20422
