### PR TITLE
Shard instrumented benchmark

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -906,21 +906,14 @@ jobs:
         run: npm run fmt:check
         working-directory: playground
 
-  benchmarks-instrumented:
+  benchmarks-instrumented-ruff:
+    name: "benchmarks instrumented (ruff)"
     runs-on: ubuntu-24.04
     needs: determine_changes
     if: |
       github.ref == 'refs/heads/main' || 
-      (matrix.name == 'ruff' && (needs.determine_changes.outputs.formatter == 'true' || needs.determine_changes.outputs.linter == 'true')) ||
-      (matrix.name == 'ty' && needs.determine_changes.outputs.ty == 'true')
+      (needs.determine_changes.outputs.formatter == 'true' || needs.determine_changes.outputs.linter == 'true')
     timeout-minutes: 20
-    strategy:
-      matrix:
-        include:
-          - name: ruff
-            benchmarks: "formatter lexer linter parser"
-          - name: ty
-            benchmarks: "ty"
     steps:
       - name: "Checkout Branch"
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -939,7 +932,42 @@ jobs:
           tool: cargo-codspeed
 
       - name: "Build benchmarks"
-        run: cargo codspeed build --features "codspeed,instrumented" --no-default-features -p ruff_benchmark ${{matrix.benchmarks}}
+        run: cargo codspeed build --features "codspeed,instrumented" --no-default-features -p ruff_benchmark formatter lexer linter parser
+
+      - name: "Run benchmarks"
+        uses: CodSpeedHQ/action@653fdc30e6c40ffd9739e40c8a0576f4f4523ca1 # v4.0.1
+        with:
+          mode: instrumentation
+          run: cargo codspeed run
+          token: ${{ secrets.CODSPEED_TOKEN }}
+
+  benchmarks-instrumented-ty:
+    name: "benchmarks instrumented (ty)"
+    runs-on: ubuntu-24.04
+    needs: determine_changes
+    if: |
+      github.ref == 'refs/heads/main' || 
+      needs.determine_changes.outputs.ty == 'true'
+    timeout-minutes: 20
+    steps:
+      - name: "Checkout Branch"
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
+      - uses: astral-sh/setup-uv@b75a909f75acd358c2196fb9a5f1299a9a8868a4 # v6.7.0
+
+      - name: "Install Rust toolchain"
+        run: rustup show
+
+      - name: "Install codspeed"
+        uses: taiki-e/install-action@67cc679904bee382389bf22082124fa963c6f6bd # v2.61.3
+        with:
+          tool: cargo-codspeed
+
+      - name: "Build benchmarks"
+        run: cargo codspeed build --features "codspeed,instrumented" --no-default-features -p ruff_benchmark ty
 
       - name: "Run benchmarks"
         uses: CodSpeedHQ/action@653fdc30e6c40ffd9739e40c8a0576f4f4523ca1 # v4.0.1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -909,6 +909,10 @@ jobs:
   benchmarks-instrumented:
     runs-on: ubuntu-24.04
     needs: determine_changes
+    if: |
+      github.ref == 'refs/heads/main' || 
+      (matrix.name == 'ruff' && (needs.determine_changes.outputs.formatter == 'true' || needs.determine_changes.outputs.linter == 'true')) ||
+      (matrix.name == 'ty' && needs.determine_changes.outputs.ty == 'true')
     timeout-minutes: 20
     strategy:
       matrix:
@@ -934,31 +938,10 @@ jobs:
         with:
           tool: cargo-codspeed
 
-      - name: "Determine if benchmarks should run"
-        id: should_run
-        env:
-          GITHUB_REF: ${{ github.ref }}
-          MATRIX_NAME: ${{ matrix.name }}
-          FORMATTER_CHANGED: ${{ needs.determine_changes.outputs.formatter }}
-          LINTER_CHANGED: ${{ needs.determine_changes.outputs.linter }}
-          TY_CHANGED: ${{ needs.determine_changes.outputs.ty }}
-        run: |
-          if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-          elif [[ "${MATRIX_NAME}" == "ruff" && ("${FORMATTER_CHANGED}" == "true" || "${LINTER_CHANGED}" == "true") ]]; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-          elif [[ "${MATRIX_NAME}" == "ty" && "${TY_CHANGED}" == "true" ]]; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "run=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: "Build benchmarks"
-        if: ${{ steps.should_run.outputs.run == 'true' }}
         run: cargo codspeed build --features "codspeed,instrumented" --no-default-features -p ruff_benchmark ${{matrix.benchmarks}}
 
       - name: "Run benchmarks"
-        if: ${{ steps.should_run.outputs.run == 'true' }}
         uses: CodSpeedHQ/action@653fdc30e6c40ffd9739e40c8a0576f4f4523ca1 # v4.0.1
         with:
           mode: instrumentation

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,10 +1,10 @@
 name: CI
 
-permissions: {}
+permissions: { }
 
 on:
   push:
-    branches: [main]
+    branches: [ main ]
   pull_request:
   workflow_dispatch:
 
@@ -912,6 +912,9 @@ jobs:
     needs: determine_changes
     if: ${{ github.repository == 'astral-sh/ruff' && !contains(github.event.pull_request.labels.*.name, 'no-test') && (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}
     timeout-minutes: 20
+    strategy:
+      matrix:
+        benchmark: [ "formatter lexer linter parser", "ty" ]
     steps:
       - name: "Checkout Branch"
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -930,7 +933,7 @@ jobs:
           tool: cargo-codspeed
 
       - name: "Build benchmarks"
-        run: cargo codspeed build --features "codspeed,instrumented" --no-default-features -p ruff_benchmark
+        run: cargo codspeed build --features "codspeed,instrumented" --no-default-features -p ruff_benchmark ${{matrix.benchmark}}
 
       - name: "Run benchmarks"
         uses: CodSpeedHQ/action@653fdc30e6c40ffd9739e40c8a0576f4f4523ca1 # v4.0.1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,10 +1,10 @@
 name: CI
 
-permissions: { }
+permissions: {}
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
   workflow_dispatch:
 
@@ -88,7 +88,6 @@ jobs:
             ':!crates/ruff_python_formatter/**' \
             ':!crates/ruff_formatter/**' \
             ':!crates/ruff_dev/**' \
-            ':!crates/ruff_db/**' \
             ':scripts/*' \
             ':python/**' \
             ':.github/workflows/ci.yaml' \
@@ -910,11 +909,14 @@ jobs:
   benchmarks-instrumented:
     runs-on: ubuntu-24.04
     needs: determine_changes
-    if: ${{ github.repository == 'astral-sh/ruff' && !contains(github.event.pull_request.labels.*.name, 'no-test') && (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}
     timeout-minutes: 20
     strategy:
       matrix:
-        benchmark: [ "formatter lexer linter parser", "ty" ]
+        include:
+          - name: ruff
+            benchmarks: "formatter lexer linter parser"
+          - name: ty
+            benchmarks: "ty"
     steps:
       - name: "Checkout Branch"
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -932,10 +934,31 @@ jobs:
         with:
           tool: cargo-codspeed
 
+      - name: "Determine if benchmarks should run"
+        id: should_run
+        env:
+          GITHUB_REF: ${{ github.ref }}
+          MATRIX_NAME: ${{ matrix.name }}
+          FORMATTER_CHANGED: ${{ needs.determine_changes.outputs.formatter }}
+          LINTER_CHANGED: ${{ needs.determine_changes.outputs.linter }}
+          TY_CHANGED: ${{ needs.determine_changes.outputs.ty }}
+        run: |
+          if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          elif [[ "${MATRIX_NAME}" == "ruff" && ("${FORMATTER_CHANGED}" == "true" || "${LINTER_CHANGED}" == "true") ]]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          elif [[ "${MATRIX_NAME}" == "ty" && "${TY_CHANGED}" == "true" ]]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: "Build benchmarks"
-        run: cargo codspeed build --features "codspeed,instrumented" --no-default-features -p ruff_benchmark ${{matrix.benchmark}}
+        if: ${{ steps.should_run.outputs.run == 'true' }}
+        run: cargo codspeed build --features "codspeed,instrumented" --no-default-features -p ruff_benchmark ${{matrix.benchmarks}}
 
       - name: "Run benchmarks"
+        if: ${{ steps.should_run.outputs.run == 'true' }}
         uses: CodSpeedHQ/action@653fdc30e6c40ffd9739e40c8a0576f4f4523ca1 # v4.0.1
         with:
           mode: instrumentation


### PR DESCRIPTION
Shard the instrumented benchmarks and only run the ruff/ty benchmarks when there were corresponding code changes.

I tested that the corresponding benchmarks run when making changes to ruff or ty

* https://github.com/astral-sh/ruff/pull/20450
* https://github.com/astral-sh/ruff/pull/20451

This PR increases the overall CI time when making changes that apply to both ruff and ty, as it now requires building the shared crates twice. However, it should reduce CI time when only changing code for one project because the benchmark jobs now only build the relevant benchmarks (e.g. ty doesn't need to build `ruff_linter` and `ruff`).

Sharding the walltime benchmarks is a bit more involved because codspeed doesn't support filtering the benchmarks by name but this is something they plan to add soon.