### PR TITLE
[`playground`] Enable inline noqa for multiline strings in playground

### DIFF
--- a/crates/ruff_wasm/src/lib.rs
+++ b/crates/ruff_wasm/src/lib.rs
@@ -203,7 +203,7 @@ impl Workspace {
         // Extract the `# noqa` and `# isort: skip` directives from the source.
         let directives = directives::extract_directives(
             parsed.tokens(),
-            directives::Flags::empty(),
+            directives::Flags::from_settings(&self.settings.linter),
             &locator,
             &indexer,
         );


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Fixes #19015

Switch ruff_wasm to pass `Flags::from_settings`, matching CLI/server behavior. This enables NOQA flag.

https://github.com/astral-sh/ruff/blob/e363c4e48e8982f40b228366b8e0aec9d4525bad/crates/ruff_linter/src/directives.rs#L20

## Test Plan

<!-- How was it tested? -->

I've confirmed that it works in my local environemt. If it's necessary to add other test, please let me know.

<img width="1458" height="982" alt="スクリーンショット 2025-09-17 045233" src="https://github.com/user-attachments/assets/051bf16a-54df-4fdc-8b42-512dab5cc292" />