### PR TITLE
[ty] support type aliases in binary compares

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
@@ -137,6 +137,18 @@ from ty_extensions import is_equivalent_to, static_assert
 static_assert(is_equivalent_to(Y, A | B | C | D))
 ```
 
+## In binary ops
+
+```py
+from typing import Literal
+
+type X = tuple[Literal[1], Literal[2]]
+
+def _(x: X, y: tuple[Literal[1], Literal[3]]):
+    reveal_type(x == y)  # revealed: Literal[False]
+    reveal_type(x < y)  # revealed: Literal[True]
+```
+
 ## `TypeAliasType` properties
 
 Two `TypeAliasType`s are distinct and disjoint, even if they refer to the same type

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -7721,6 +7721,20 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 ))
             }
 
+            (Type::TypeAlias(alias), right) => Some(self.infer_binary_type_comparison(
+                alias.value_type(self.db()),
+                op,
+                right,
+                range,
+            )),
+
+            (left, Type::TypeAlias(alias)) => Some(self.infer_binary_type_comparison(
+                left,
+                op,
+                alias.value_type(self.db()),
+                range,
+            )),
+
             (Type::IntLiteral(n), Type::IntLiteral(m)) => Some(match op {
                 ast::CmpOp::Eq => Ok(Type::BooleanLiteral(n == m)),
                 ast::CmpOp::NotEq => Ok(Type::BooleanLiteral(n != m)),


### PR DESCRIPTION
## Summary

Add missing `Type::TypeAlias` clauses to `infer_binary_type_comparison`.

## Test Plan

Added mdtests that failed before.
