### PR TITLE
[ty] move graphql-core to good.txt

### DIFF
--- a/crates/ty_python_semantic/resources/primer/bad.txt
+++ b/crates/ty_python_semantic/resources/primer/bad.txt
@@ -1,3 +1,2 @@
-graphql-core  # stack overflow
 spark  # too many iterations (in `exported_names` query)
 steam.py  # hangs (single threaded)

--- a/crates/ty_python_semantic/resources/primer/good.txt
+++ b/crates/ty_python_semantic/resources/primer/good.txt
@@ -48,6 +48,7 @@ flake8
 flake8-pyi
 freqtrade
 git-revise
+graphql-core
 httpx-caching
 hydpy
 hydra-zen


### PR DESCRIPTION
## Summary

With https://github.com/astral-sh/ruff/pull/20446, graphql-core now checks without error; we can move it to `good.txt`.

## Test Plan

CI
