### PR TITLE
[`ruff`] Flag fmt: off/on comments around class signatures as invalid (`RUF028`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF028.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF028.py
@@ -101,3 +101,24 @@ import pytest
 )  # fmt: skip
 def test_eval(test_input, expected):
     assert eval(test_input) == expected
+
+
+# Test cases for fmt: off/on around class signatures (RUF028)
+# fmt: off
+class TestClassSignature1:
+    pass
+# fmt: on
+
+class TestClassSignature2:
+    pass
+# fmt: off
+
+# fmt: off
+@decorator
+class TestClassSignature3:
+    pass
+# fmt: on
+
+class TestClassSignature4:
+    pass
+# fmt: on

--- a/crates/ruff_linter/src/rules/ruff/rules/invalid_formatter_suppression_comment.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/invalid_formatter_suppression_comment.rs
@@ -173,12 +173,14 @@ impl<'src, 'loc> UselessSuppressionComments<'src, 'loc> {
                     name: _,
                     decorator_list,
                     ..
-                })) = comment.following {
+                })) = comment.following
+                {
                     // The comment is before a class definition
                     if comment.line_position.is_own_line() {
                         // Check if the comment is after any decorators
-                        if let Some(last_decorator) = decorator_list.last() 
-                            && comment.range.start() > last_decorator.end() {
+                        if let Some(last_decorator) = decorator_list.last()
+                            && comment.range.start() > last_decorator.end()
+                        {
                             return Err(IgnoredReason::AroundClassSignature);
                         }
                         // No decorators, so any comment before the class is invalid
@@ -186,7 +188,7 @@ impl<'src, 'loc> UselessSuppressionComments<'src, 'loc> {
                     }
                 }
             }
-            
+
             // Check if the comment is after a class definition (as a trailing comment)
             if let Some(AnyNodeRef::StmtClassDef(_)) = comment.enclosing {
                 if comment.line_position.is_own_line() {

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF028_RUF028.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF028_RUF028.py.snap
@@ -215,3 +215,102 @@ help: Remove this comment
 65 | 
 66 | # all of these should be fine
 note: This is an unsafe fix and may change runtime behavior
+
+RUF028 [*] This suppression comment is invalid because it cannot be around a class signature
+   --> RUF028.py:107:1
+    |
+106 | # Test cases for fmt: off/on around class signatures (RUF028)
+107 | # fmt: off
+    | ^^^^^^^^^^
+108 | class TestClassSignature1:
+109 |     pass
+    |
+help: Remove this comment
+104 | 
+105 | 
+106 | # Test cases for fmt: off/on around class signatures (RUF028)
+    - # fmt: off
+107 | class TestClassSignature1:
+108 |     pass
+109 | # fmt: on
+note: This is an unsafe fix and may change runtime behavior
+
+RUF028 [*] This suppression comment is invalid because it cannot be around a class signature
+   --> RUF028.py:110:1
+    |
+108 | class TestClassSignature1:
+109 |     pass
+110 | # fmt: on
+    | ^^^^^^^^^
+111 |
+112 | class TestClassSignature2:
+    |
+help: Remove this comment
+107 | # fmt: off
+108 | class TestClassSignature1:
+109 |     pass
+    - # fmt: on
+110 | 
+111 | class TestClassSignature2:
+112 |     pass
+note: This is an unsafe fix and may change runtime behavior
+
+RUF028 [*] This suppression comment is invalid because it cannot be around a class signature
+   --> RUF028.py:114:1
+    |
+112 | class TestClassSignature2:
+113 |     pass
+114 | # fmt: off
+    | ^^^^^^^^^^
+115 |
+116 | # fmt: off
+    |
+help: Remove this comment
+111 | 
+112 | class TestClassSignature2:
+113 |     pass
+    - # fmt: off
+114 | 
+115 | # fmt: off
+116 | @decorator
+note: This is an unsafe fix and may change runtime behavior
+
+RUF028 [*] This suppression comment is invalid because it cannot be around a class signature
+   --> RUF028.py:116:1
+    |
+114 | # fmt: off
+115 |
+116 | # fmt: off
+    | ^^^^^^^^^^
+117 | @decorator
+118 | class TestClassSignature3:
+    |
+help: Remove this comment
+113 |     pass
+114 | # fmt: off
+115 | 
+    - # fmt: off
+116 | @decorator
+117 | class TestClassSignature3:
+118 |     pass
+note: This is an unsafe fix and may change runtime behavior
+
+RUF028 [*] This suppression comment is invalid because it cannot be around a class signature
+   --> RUF028.py:120:1
+    |
+118 | class TestClassSignature3:
+119 |     pass
+120 | # fmt: on
+    | ^^^^^^^^^
+121 |
+122 | class TestClassSignature4:
+    |
+help: Remove this comment
+117 | @decorator
+118 | class TestClassSignature3:
+119 |     pass
+    - # fmt: on
+120 | 
+121 | class TestClassSignature4:
+122 |     pass
+note: This is an unsafe fix and may change runtime behavior


### PR DESCRIPTION
## Summary

Fixes #20425
