### PR TITLE
Exclude snapshots from vscode search results

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,4 +3,7 @@
         "--all-features"
     ],
     "rust-analyzer.check.command": "clippy",
+    "search.exclude": {
+        "**/*.snap": true
+    }
 }


### PR DESCRIPTION
Makes ⌘-T file search ignore snapshot files, so you can actually fuzzy
match "ruff cache" to "ruff/src/cache.rs" without looking/scrolling past
dozens of snapshot files in the search results.
