### PR TITLE
[ty] Faster iteration on mdtests

### DIFF
--- a/crates/ty_python_semantic/mdtest.py
+++ b/crates/ty_python_semantic/mdtest.py
@@ -46,6 +46,7 @@ class MDTestRunner:
                 CRATE_NAME,
                 "--no-run",
                 "--color=always",
+                "--test=mdtest",
                 "--message-format",
                 message_format,
             ],


### PR DESCRIPTION
## Summary

This change reduces MD test compilation time from 6s to 3s on my laptop. We don't need to build the unit tests and the corpus tests when we're only interested in Markdown-based tests.

## Test Plan

local benchmarks
