### PR TITLE
Update rust toolchain to 1.90

### DIFF
--- a/crates/ruff_linter/src/rules/fastapi/rules/fastapi_unused_path_parameter.rs
+++ b/crates/ruff_linter/src/rules/fastapi/rules/fastapi_unused_path_parameter.rs
@@ -487,7 +487,6 @@ impl<'a> Iterator for PathParamIterator<'a> {
                     let param_name_end = param_content.find(':').unwrap_or(param_content.len());
                     let param_name = &param_content[..param_name_end];
 
-                    #[expect(clippy::range_plus_one)]
                     return Some((param_name, start..end + 1));
                 }
             }

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/indentation.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/indentation.rs
@@ -269,7 +269,7 @@ pub(crate) fn indentation(
     range: TextRange,
     context: &LintContext,
 ) {
-    if indent_level % indent_size != 0 {
+    if !indent_level.is_multiple_of(indent_size) {
         if logical_line.is_comment_only() {
             context.report_diagnostic_if_enabled(
                 IndentationWithInvalidMultipleComment {

--- a/crates/ruff_python_formatter/src/string/docstring.rs
+++ b/crates/ruff_python_formatter/src/string/docstring.rs
@@ -1613,7 +1613,7 @@ pub(super) fn needs_chaperone_space(
     if is_no_chaperone_for_escaped_quote_in_triple_quoted_docstring_enabled(context) {
         if flags.is_triple_quoted() {
             if let Some(before_quote) = trim_end.strip_suffix(flags.quote_style().as_char()) {
-                if count_consecutive_chars_from_end(before_quote, '\\') % 2 == 0 {
+                if count_consecutive_chars_from_end(before_quote, '\\').is_multiple_of(2) {
                     // Even backslash count preceding quote;
                     // ```py
                     // """a "  """

--- a/crates/ty_server/src/server/api/requests/workspace_diagnostic.rs
+++ b/crates/ty_server/src/server/api/requests/workspace_diagnostic.rs
@@ -250,7 +250,7 @@ impl ProgressReporter for WorkspaceDiagnosticsProgressReporter<'_> {
     fn report_checked_file(&self, db: &dyn Db, file: File, diagnostics: &[Diagnostic]) {
         let checked = self.checked_files.fetch_add(1, Ordering::Relaxed) + 1;
 
-        if checked % 100 == 0 || checked == self.total_files {
+        if checked.is_multiple_of(100) || checked == self.total_files {
             // Report progress every 100 files or when all files are checked
             self.report_progress();
         }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.89"
+channel = "1.90"


### PR DESCRIPTION
## Summary

This PR bumps the development toolchain from Rust 1.89 to 1.90. 

This PR does not change the MSRV because that requires updating the conda forge recipe first.

## Test Plan

CI
