### PR TITLE
Add `pyproject.toml` to rooster config `version_files` and bump to 0.13.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,7 @@ ignore_labels = ["internal", "ci", "testing", "ty"]
 
 version_files = [
     "README.md",
+    "pyproject.toml",
     "docs/integrations.md",
     "docs/tutorial.md",
     "crates/ruff/Cargo.toml",


### PR DESCRIPTION
It looks like the new `rooster` does not automatically bump `pyproject.toml`.

This should fix the following failure for the release action:

https://github.com/astral-sh/ruff/actions/runs/17839256763/job/50724254795