### PR TITLE
[ty] Enable auto-import for completions in WASM builds by default

### DIFF
--- a/crates/ty_wasm/src/lib.rs
+++ b/crates/ty_wasm/src/lib.rs
@@ -415,10 +415,7 @@ impl Workspace {
 
         let offset = position.to_text_size(&source, &index, self.position_encoding)?;
 
-        // NOTE: At time of writing, 2025-08-29, auto-import isn't
-        // ready to be enabled by default yet. Once it is, we should
-        // either just enable it or provide a way to configure it.
-        let settings = ty_ide::CompletionSettings { auto_import: false };
+        let settings = ty_ide::CompletionSettings { auto_import: true };
         let completions = ty_ide::completion(&self.db, &settings, file_id.file, offset);
 
         Ok(completions


### PR DESCRIPTION
Now that imports are actually inserted, this should give us some
valuable dog-fooding experience.

Note that we don't currently do any ranking on completions, so until
that is improved, even in-scope completions could suffer. With that
said, this shouldn't have any impact at all in several scenarios (like
completions for attributes on objects).
