### PR TITLE
[ty] Remove unnecessary `FileScopeId` to `ScopeId` conversion

### DIFF
--- a/crates/ty_python_semantic/src/semantic_index/scope.rs
+++ b/crates/ty_python_semantic/src/semantic_index/scope.rs
@@ -26,11 +26,6 @@ pub struct ScopeId<'db> {
 impl get_size2::GetSize for ScopeId<'_> {}
 
 impl<'db> ScopeId<'db> {
-    #[expect(unused)]
-    pub(crate) fn is_function_like(self, db: &'db dyn Db) -> bool {
-        self.node(db).scope_kind().is_function_like()
-    }
-
     pub(crate) fn is_annotation(self, db: &'db dyn Db) -> bool {
         self.node(db).scope_kind().is_annotation()
     }

--- a/crates/ty_python_semantic/src/semantic_index/scope.rs
+++ b/crates/ty_python_semantic/src/semantic_index/scope.rs
@@ -26,6 +26,7 @@ pub struct ScopeId<'db> {
 impl get_size2::GetSize for ScopeId<'_> {}
 
 impl<'db> ScopeId<'db> {
+    #[expect(unused)]
     pub(crate) fn is_function_like(self, db: &'db dyn Db) -> bool {
         self.node(db).scope_kind().is_function_like()
     }

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -191,10 +191,8 @@ impl ClassDisplay<'_> {
         let mut name_parts = vec![];
 
         // Skips itself
-        for (ancestor_file_scope_id, ancestor_scope) in index.ancestor_scopes(file_scope_id).skip(1)
-        {
-            let ancestor_scope_id = ancestor_file_scope_id.to_scope_id(self.db, file);
-            let node = ancestor_scope_id.node(self.db);
+        for (_, ancestor_scope) in index.ancestor_scopes(file_scope_id).skip(1) {
+            let node = ancestor_scope.node();
 
             match ancestor_scope.kind() {
                 ScopeKind::Class => {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -4856,7 +4856,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let db = self.db();
         let scope = self.scope();
         let file_scope_id = scope.file_scope_id(db);
-        let current_file = self.file();
+
         'names: for name in names {
             // Walk up parent scopes looking for a possible enclosing scope that may have a
             // definition of this name visible to us. Note that we skip the scope containing the
@@ -4864,8 +4864,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             for (enclosing_scope_file_id, _) in self.index.ancestor_scopes(file_scope_id).skip(1) {
                 // Class scopes are not visible to nested scopes, and `nonlocal` cannot refer to
                 // globals, so check only function-like scopes.
-                let enclosing_scope_id = enclosing_scope_file_id.to_scope_id(db, current_file);
-                if !enclosing_scope_id.is_function_like(db) {
+                let enclosing_scope = self.index.scope(enclosing_scope_file_id);
+                if !enclosing_scope.kind().is_function_like() {
                     continue;
                 }
                 let enclosing_place_table = self.index.place_table(enclosing_scope_file_id);
@@ -6362,7 +6362,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         let place = PlaceAndQualifiers::from(local_scope_place).or_fall_back_to(db, || {
-            let current_file = self.file();
             let mut symbol_resolves_locally = false;
             if let Some(symbol) = place_expr.as_symbol() {
                 if let Some(symbol_id) = place_table.symbol_id(symbol.name()) {
@@ -6428,7 +6427,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 // check only function-like scopes.
                 // There is one exception to this rule: annotation scopes can see
                 // names defined in an immediately-enclosing class scope.
-                let enclosing_scope_id = enclosing_scope_file_id.to_scope_id(db, current_file);
+                let enclosing_scope = self.index.scope(enclosing_scope_file_id);
 
                 let is_immediately_enclosing_scope = scope.is_annotation(db)
                     && scope
@@ -6495,7 +6494,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     }
                 }
 
-                if !enclosing_scope_id.is_function_like(db) && !is_immediately_enclosing_scope {
+                if !enclosing_scope.kind().is_function_like() && !is_immediately_enclosing_scope {
                     continue;
                 }
 
@@ -6515,6 +6514,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 if enclosing_place.as_symbol().is_some_and(Symbol::is_global) {
                     break;
                 }
+
+                let enclosing_scope_id = enclosing_scope_file_id.to_scope_id(db, self.file());
 
                 // If the name is declared or bound in this scope, figure out its type. This might
                 // resolve the name and end the walk. But if the name is declared `nonlocal` in


### PR DESCRIPTION
I noticed this when debugging https://github.com/astral-sh/ty/issues/1111 because I saw many repeated `semantic_index` calls.

Going to `ScopeId` here is unnecessary (and only introduces more work). We can retrieve the `node` directly from `index.scope(id).node`
