### PR TITLE
[ty] Make auto-import work in the playground

### DIFF
--- a/crates/ty_wasm/src/lib.rs
+++ b/crates/ty_wasm/src/lib.rs
@@ -439,7 +439,7 @@ impl Workspace {
                     name: comp.name.into(),
                     kind,
                     detail: type_display,
-                    description: comp.module_name.map(ToString::to_string),
+                    module_name: comp.module_name.map(ToString::to_string),
                     insert_text: comp.insert.map(String::from),
                     additional_text_edits: import_edit.map(|edit| vec![edit]),
                     documentation: comp
@@ -942,7 +942,7 @@ pub struct Completion {
     #[wasm_bindgen(getter_with_clone)]
     pub detail: Option<String>,
     #[wasm_bindgen(getter_with_clone)]
-    pub description: Option<String>,
+    pub module_name: Option<String>,
 }
 
 #[wasm_bindgen]
@@ -1010,9 +1010,9 @@ impl From<ty_ide::CompletionKind> for CompletionKind {
 #[wasm_bindgen]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TextEdit {
-    range: Range,
+    pub range: Range,
     #[wasm_bindgen(getter_with_clone)]
-    new_text: String,
+    pub new_text: String,
 }
 
 #[wasm_bindgen]

--- a/playground/ty/src/Editor/Editor.tsx
+++ b/playground/ty/src/Editor/Editor.tsx
@@ -28,6 +28,7 @@ import {
   DocumentHighlight,
   DocumentHighlightKind,
   InlayHintKind,
+  TextEdit,
 } from "ty_wasm";
 import { FileId, ReadonlyFiles } from "../Playground";
 import { isPythonFile } from "./Files";
@@ -313,13 +314,26 @@ class PlaygroundServer
 
     return {
       suggestions: completions.map((completion, i) => ({
-        label: completion.name,
+        label: {
+          label: completion.name,
+          detail:
+            completion.module_name == null
+              ? undefined
+              : ` (import ${completion.module_name})`,
+          description: completion.detail ?? undefined,
+        },
         sortText: String(i).padStart(digitsLength, "0"),
         kind:
           completion.kind == null
             ? CompletionItemKind.Variable
             : mapCompletionKind(completion.kind),
-        insertText: completion.name,
+        insertText: completion.insert_text ?? completion.name,
+        additionalTextEdits: completion.additional_text_edits?.map(
+          (edit: TextEdit) => ({
+            range: tyRangeToMonacoRange(edit.range),
+            text: edit.new_text,
+          }),
+        ),
         documentation: completion.documentation,
         detail: completion.detail,
         // TODO(micha): It's unclear why this field is required for monaco but not VS Code.


### PR DESCRIPTION
It turned out that we weren't quite funneling the new completion data
all the way through.

I followed the docs for [`CompletionItem`] for the Monaco editor. It's
similar, but not identical, to the LSP protocol specification.

[`CompletionItem`]: https://microsoft.github.io/monaco-editor/typedoc/interfaces/languages.CompletionItem.html
