### PR TITLE
[ty] Update `get-size2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1168,9 +1168,9 @@ dependencies = [
 
 [[package]]
 name = "get-size-derive2"
-version = "0.6.3"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a443e77201a230c25f0c11574e9b20e5705f749520e0f30ab0d0974fb1a794"
+checksum = "e3814abc7da8ab18d2fd820f5b540b5e39b6af0a32de1bdd7c47576693074843"
 dependencies = [
  "attribute-derive",
  "quote",
@@ -1179,9 +1179,9 @@ dependencies = [
 
 [[package]]
 name = "get-size2"
-version = "0.6.3"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0594e2a78d082f2f8b1615c728391c6a5277f6c017474a7249934fc735945d55"
+checksum = "5dfe2cec5b5ce8fb94dcdb16a1708baa4d0609cc3ce305ca5d3f6f2ffb59baed"
 dependencies = [
  "compact_str",
  "get-size-derive2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ etcetera = { version = "0.10.0" }
 fern = { version = "0.7.0" }
 filetime = { version = "0.2.23" }
 getrandom = { version = "0.3.1" }
-get-size2 = { version = "0.6.3", features = [
+get-size2 = { version = "0.7.0", features = [
     "derive",
     "smallvec",
     "hashbrown",

--- a/crates/ruff_db/src/system/path.rs
+++ b/crates/ruff_db/src/system/path.rs
@@ -504,8 +504,8 @@ impl ToOwned for SystemPath {
 pub struct SystemPathBuf(#[cfg_attr(feature = "schemars", schemars(with = "String"))] Utf8PathBuf);
 
 impl get_size2::GetSize for SystemPathBuf {
-    fn get_heap_size(&self) -> usize {
-        self.0.capacity()
+    fn get_heap_size_with_tracker<T: get_size2::GetSizeTracker>(&self, tracker: T) -> (usize, T) {
+        (self.0.capacity(), tracker)
     }
 }
 

--- a/crates/ruff_db/src/vendored/path.rs
+++ b/crates/ruff_db/src/vendored/path.rs
@@ -92,8 +92,8 @@ impl ToOwned for VendoredPath {
 pub struct VendoredPathBuf(Utf8PathBuf);
 
 impl get_size2::GetSize for VendoredPathBuf {
-    fn get_heap_size(&self) -> usize {
-        self.0.capacity()
+    fn get_heap_size_with_tracker<T: get_size2::GetSizeTracker>(&self, tracker: T) -> (usize, T) {
+        (self.0.capacity(), tracker)
     }
 }
 


### PR DESCRIPTION
## Summary

Let's see if https://github.com/bircni/get-size2/pull/34 gives us more accurate memory usage numbers.