### PR TITLE
[`ruff`] Fix panic when comments appear between unary operators and operands

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/unary.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/unary.py
@@ -193,3 +193,20 @@ def foo():
         not (aaaaaaaaaaaaaaaaaaaaa[bbbbbbbb, ccccccc]) and dddddddddd < eeeeeeeeeeeeeee
     ):
         pass
+
+# Regression tests for https://github.com/astral-sh/ruff/issues/19226
+if '' and (not #
+0):
+    pass
+
+if '' and (
+    # unary comment
+    not
+    # operand comment
+    (
+        # comment
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    )
+):
+    pass

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__unary.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__unary.py.snap
@@ -200,6 +200,23 @@ def foo():
         not (aaaaaaaaaaaaaaaaaaaaa[bbbbbbbb, ccccccc]) and dddddddddd < eeeeeeeeeeeeeee
     ):
         pass
+
+# Regression tests for https://github.com/astral-sh/ruff/issues/19226
+if '' and (not #
+0):
+    pass
+
+if '' and (
+    # unary comment
+    not
+    # operand comment
+    (
+        # comment
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    )
+):
+    pass
 ```
 
 ## Output
@@ -415,4 +432,26 @@ def foo():
         not (aaaaaaaaaaaaaaaaaaaaa[bbbbbbbb, ccccccc]) and dddddddddd < eeeeeeeeeeeeeee
     ):
         pass
+
+
+# Regression tests for https://github.com/astral-sh/ruff/issues/19226
+if "" and (  #
+    not 0
+):
+    pass
+
+if (
+    ""
+    and
+    # unary comment
+    # operand comment
+    (
+        not (
+            # comment
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+        )
+    )
+):
+    pass
 ```


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Fixes #19226

Fixes a panic in binary expression formatting caused by TextRange assertion failures when comments are positioned between unary operators (like `not`) and their operands.

The issue occurred because `expression.start()` points to the unary operator while `comment.end()` can be positioned after it, creating invalid TextRange where start > end. The fix uses `operand.start()` for unary operations to ensure proper ordering.

## Test Plan

<!-- How was it tested? -->

I have added new test cases to  `crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/unary.py`.
