### PR TITLE
[`pyupgrade`] Fix `UP008` to not apply when `__class__` is a local variable (`UP008`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP008.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP008.py
@@ -287,3 +287,19 @@ class C(B):
     def f(self):
         C = B  # Local variable C shadows the class name
         return super(C, self).f()  # Should NOT trigger UP008
+
+
+# See: https://github.com/astral-sh/ruff/issues/20491
+# UP008 should not apply when __class__ is a local variable
+class A:
+    def f(self):
+        return 1
+
+class B(A):
+    def f(self):
+        return 2
+
+class C(B):
+    def f(self):
+        __class__ = B  # Local variable __class__ shadows the implicit __class__
+        return super(__class__, self).f()  # Should NOT trigger UP008

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/super_call_with_parameters.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/super_call_with_parameters.rs
@@ -140,6 +140,9 @@ pub(crate) fn super_call_with_parameters(checker: &Checker, call: &ast::ExprCall
     };
 
     if !((first_arg_id == "__class__"
+            // If the first argument is __class__, check if it's a local variable.
+            // If so, don't apply UP008.
+            && !checker.semantic().current_scope().has("__class__")
         || (first_arg_id == parent_name.as_str()
             // If the first argument matches the class name, check if it's a local variable
             // that shadows the class name. If so, don't apply UP008.


### PR DESCRIPTION
## Summary

Fixes #20491
