### PR TITLE
[`flake8-pyi`] Fix operator precedence by adding parentheses when needed (`PYI061`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI061.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI061.py
@@ -78,3 +78,10 @@ b: None | Literal[None] | None
 c: (None | Literal[None]) | None
 d: None | (Literal[None] | None)
 e: None | ((None | Literal[None]) | None) | None
+
+# Test cases for operator precedence issue (https://github.com/astral-sh/ruff/issues/20265)
+print(Literal[1, None].__dict__)  # Should become (Literal[1] | None).__dict__
+print(Literal[1, None].method())  # Should become (Literal[1] | None).method()
+print(Literal[1, None][0])  # Should become (Literal[1] | None)[0]
+print(Literal[1, None] + 1)  # Should become (Literal[1] | None) + 1
+print(Literal[1, None] * 2)  # Should become (Literal[1] | None) * 2

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/redundant_none_literal.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/redundant_none_literal.rs
@@ -4,6 +4,7 @@ use ruff_python_ast::{
     self as ast, Expr, ExprBinOp, ExprContext, ExprNoneLiteral, Operator, PythonVersion,
     helpers::{pep_604_union, typing_optional},
     name::Name,
+    operator_precedence::OperatorPrecedence,
 };
 use ruff_python_semantic::analyze::typing::{traverse_literal, traverse_union};
 use ruff_text_size::{Ranged, TextRange};
@@ -238,7 +239,14 @@ fn create_fix(
                 node_index: ruff_python_ast::AtomicNodeIndex::NONE,
             });
             let union_expr = pep_604_union(&[new_literal_expr, none_expr]);
-            let content = checker.generator().expr(&union_expr);
+
+            // Check if we need parentheses to preserve operator precedence
+            let content = if needs_parentheses_for_precedence(semantic, &union_expr) {
+                format!("({})", checker.generator().expr(&union_expr))
+            } else {
+                checker.generator().expr(&union_expr)
+            };
+
             let union_edit = Edit::range_replacement(content, literal_expr.range());
             Fix::applicable_edit(union_edit, applicability)
         }
@@ -255,4 +263,36 @@ enum UnionKind {
     NoUnion,
     TypingOptional,
     BitOr,
+}
+
+/// Check if the union expression needs parentheses to preserve operator precedence.
+/// This is needed when the union is part of a larger expression where the `|` operator
+/// has lower precedence than the surrounding operations (like attribute access).
+fn needs_parentheses_for_precedence(
+    semantic: &ruff_python_semantic::SemanticModel,
+    _union_expr: &Expr,
+) -> bool {
+    // Get the parent expression to check if we're in a context that needs parentheses
+    let Some(parent_expr) = semantic.current_expression_parent() else {
+        return false;
+    };
+
+    // Check if the parent expression is an attribute access, call, or subscript
+    // These operations have higher precedence than the `|` operator
+    match parent_expr {
+        Expr::Attribute(_) | Expr::Call(_) | Expr::Subscript(_) => {
+            // The union expression needs parentheses to ensure correct precedence
+            true
+        }
+        Expr::BinOp(bin_op) => {
+            // Check if we're in a binary operation where the union is not the leftmost operand
+            // and the operator has higher precedence than `|`
+            let union_precedence = OperatorPrecedence::BitOr;
+            let bin_op_precedence = OperatorPrecedence::from(bin_op.op);
+
+            // If the binary operation has higher precedence than `|`, we need parentheses
+            bin_op_precedence > union_precedence
+        }
+        _ => false,
+    }
 }

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI061_PYI061.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI061_PYI061.py.snap
@@ -423,5 +423,97 @@ PYI061 Use `None` rather than `Literal[None]`
 79 | d: None | (Literal[None] | None)
 80 | e: None | ((None | Literal[None]) | None) | None
    |                            ^^^^
+81 |
+82 | # Test cases for operator precedence issue (https://github.com/astral-sh/ruff/issues/20265)
    |
 help: Replace with `None`
+
+PYI061 [*] Use `Literal[...] | None` rather than `Literal[None, ...]` 
+  --> PYI061.py:83:18
+   |
+82 | # Test cases for operator precedence issue (https://github.com/astral-sh/ruff/issues/20265)
+83 | print(Literal[1, None].__dict__)  # Should become (Literal[1] | None).__dict__
+   |                  ^^^^
+84 | print(Literal[1, None].method())  # Should become (Literal[1] | None).method()
+85 | print(Literal[1, None][0])  # Should become (Literal[1] | None)[0]
+   |
+help: Replace with `Literal[...] | None`
+80 | e: None | ((None | Literal[None]) | None) | None
+81 | 
+82 | # Test cases for operator precedence issue (https://github.com/astral-sh/ruff/issues/20265)
+   - print(Literal[1, None].__dict__)  # Should become (Literal[1] | None).__dict__
+83 + print((Literal[1] | None).__dict__)  # Should become (Literal[1] | None).__dict__
+84 | print(Literal[1, None].method())  # Should become (Literal[1] | None).method()
+85 | print(Literal[1, None][0])  # Should become (Literal[1] | None)[0]
+86 | print(Literal[1, None] + 1)  # Should become (Literal[1] | None) + 1
+
+PYI061 [*] Use `Literal[...] | None` rather than `Literal[None, ...]` 
+  --> PYI061.py:84:18
+   |
+82 | # Test cases for operator precedence issue (https://github.com/astral-sh/ruff/issues/20265)
+83 | print(Literal[1, None].__dict__)  # Should become (Literal[1] | None).__dict__
+84 | print(Literal[1, None].method())  # Should become (Literal[1] | None).method()
+   |                  ^^^^
+85 | print(Literal[1, None][0])  # Should become (Literal[1] | None)[0]
+86 | print(Literal[1, None] + 1)  # Should become (Literal[1] | None) + 1
+   |
+help: Replace with `Literal[...] | None`
+81 | 
+82 | # Test cases for operator precedence issue (https://github.com/astral-sh/ruff/issues/20265)
+83 | print(Literal[1, None].__dict__)  # Should become (Literal[1] | None).__dict__
+   - print(Literal[1, None].method())  # Should become (Literal[1] | None).method()
+84 + print((Literal[1] | None).method())  # Should become (Literal[1] | None).method()
+85 | print(Literal[1, None][0])  # Should become (Literal[1] | None)[0]
+86 | print(Literal[1, None] + 1)  # Should become (Literal[1] | None) + 1
+87 | print(Literal[1, None] * 2)  # Should become (Literal[1] | None) * 2
+
+PYI061 [*] Use `Literal[...] | None` rather than `Literal[None, ...]` 
+  --> PYI061.py:85:18
+   |
+83 | print(Literal[1, None].__dict__)  # Should become (Literal[1] | None).__dict__
+84 | print(Literal[1, None].method())  # Should become (Literal[1] | None).method()
+85 | print(Literal[1, None][0])  # Should become (Literal[1] | None)[0]
+   |                  ^^^^
+86 | print(Literal[1, None] + 1)  # Should become (Literal[1] | None) + 1
+87 | print(Literal[1, None] * 2)  # Should become (Literal[1] | None) * 2
+   |
+help: Replace with `Literal[...] | None`
+82 | # Test cases for operator precedence issue (https://github.com/astral-sh/ruff/issues/20265)
+83 | print(Literal[1, None].__dict__)  # Should become (Literal[1] | None).__dict__
+84 | print(Literal[1, None].method())  # Should become (Literal[1] | None).method()
+   - print(Literal[1, None][0])  # Should become (Literal[1] | None)[0]
+85 + print((Literal[1] | None)[0])  # Should become (Literal[1] | None)[0]
+86 | print(Literal[1, None] + 1)  # Should become (Literal[1] | None) + 1
+87 | print(Literal[1, None] * 2)  # Should become (Literal[1] | None) * 2
+
+PYI061 [*] Use `Literal[...] | None` rather than `Literal[None, ...]` 
+  --> PYI061.py:86:18
+   |
+84 | print(Literal[1, None].method())  # Should become (Literal[1] | None).method()
+85 | print(Literal[1, None][0])  # Should become (Literal[1] | None)[0]
+86 | print(Literal[1, None] + 1)  # Should become (Literal[1] | None) + 1
+   |                  ^^^^
+87 | print(Literal[1, None] * 2)  # Should become (Literal[1] | None) * 2
+   |
+help: Replace with `Literal[...] | None`
+83 | print(Literal[1, None].__dict__)  # Should become (Literal[1] | None).__dict__
+84 | print(Literal[1, None].method())  # Should become (Literal[1] | None).method()
+85 | print(Literal[1, None][0])  # Should become (Literal[1] | None)[0]
+   - print(Literal[1, None] + 1)  # Should become (Literal[1] | None) + 1
+86 + print((Literal[1] | None) + 1)  # Should become (Literal[1] | None) + 1
+87 | print(Literal[1, None] * 2)  # Should become (Literal[1] | None) * 2
+
+PYI061 [*] Use `Literal[...] | None` rather than `Literal[None, ...]` 
+  --> PYI061.py:87:18
+   |
+85 | print(Literal[1, None][0])  # Should become (Literal[1] | None)[0]
+86 | print(Literal[1, None] + 1)  # Should become (Literal[1] | None) + 1
+87 | print(Literal[1, None] * 2)  # Should become (Literal[1] | None) * 2
+   |                  ^^^^
+   |
+help: Replace with `Literal[...] | None`
+84 | print(Literal[1, None].method())  # Should become (Literal[1] | None).method()
+85 | print(Literal[1, None][0])  # Should become (Literal[1] | None)[0]
+86 | print(Literal[1, None] + 1)  # Should become (Literal[1] | None) + 1
+   - print(Literal[1, None] * 2)  # Should become (Literal[1] | None) * 2
+87 + print((Literal[1] | None) * 2)  # Should become (Literal[1] | None) * 2

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__py38_PYI061_PYI061.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__py38_PYI061_PYI061.py.snap
@@ -465,5 +465,127 @@ PYI061 Use `None` rather than `Literal[None]`
 79 | d: None | (Literal[None] | None)
 80 | e: None | ((None | Literal[None]) | None) | None
    |                            ^^^^
+81 |
+82 | # Test cases for operator precedence issue (https://github.com/astral-sh/ruff/issues/20265)
    |
 help: Replace with `None`
+
+PYI061 [*] Use `Optional[Literal[...]]` rather than `Literal[None, ...]` 
+  --> PYI061.py:83:18
+   |
+82 | # Test cases for operator precedence issue (https://github.com/astral-sh/ruff/issues/20265)
+83 | print(Literal[1, None].__dict__)  # Should become (Literal[1] | None).__dict__
+   |                  ^^^^
+84 | print(Literal[1, None].method())  # Should become (Literal[1] | None).method()
+85 | print(Literal[1, None][0])  # Should become (Literal[1] | None)[0]
+   |
+help: Replace with `Optional[Literal[...]]`
+   - from typing import Literal, Union
+1  + from typing import Literal, Union, Optional
+2  | 
+3  | 
+4  | def func1(arg1: Literal[None]):
+--------------------------------------------------------------------------------
+80 | e: None | ((None | Literal[None]) | None) | None
+81 | 
+82 | # Test cases for operator precedence issue (https://github.com/astral-sh/ruff/issues/20265)
+   - print(Literal[1, None].__dict__)  # Should become (Literal[1] | None).__dict__
+83 + print(Optional[Literal[1]].__dict__)  # Should become (Literal[1] | None).__dict__
+84 | print(Literal[1, None].method())  # Should become (Literal[1] | None).method()
+85 | print(Literal[1, None][0])  # Should become (Literal[1] | None)[0]
+86 | print(Literal[1, None] + 1)  # Should become (Literal[1] | None) + 1
+
+PYI061 [*] Use `Optional[Literal[...]]` rather than `Literal[None, ...]` 
+  --> PYI061.py:84:18
+   |
+82 | # Test cases for operator precedence issue (https://github.com/astral-sh/ruff/issues/20265)
+83 | print(Literal[1, None].__dict__)  # Should become (Literal[1] | None).__dict__
+84 | print(Literal[1, None].method())  # Should become (Literal[1] | None).method()
+   |                  ^^^^
+85 | print(Literal[1, None][0])  # Should become (Literal[1] | None)[0]
+86 | print(Literal[1, None] + 1)  # Should become (Literal[1] | None) + 1
+   |
+help: Replace with `Optional[Literal[...]]`
+   - from typing import Literal, Union
+1  + from typing import Literal, Union, Optional
+2  | 
+3  | 
+4  | def func1(arg1: Literal[None]):
+--------------------------------------------------------------------------------
+81 | 
+82 | # Test cases for operator precedence issue (https://github.com/astral-sh/ruff/issues/20265)
+83 | print(Literal[1, None].__dict__)  # Should become (Literal[1] | None).__dict__
+   - print(Literal[1, None].method())  # Should become (Literal[1] | None).method()
+84 + print(Optional[Literal[1]].method())  # Should become (Literal[1] | None).method()
+85 | print(Literal[1, None][0])  # Should become (Literal[1] | None)[0]
+86 | print(Literal[1, None] + 1)  # Should become (Literal[1] | None) + 1
+87 | print(Literal[1, None] * 2)  # Should become (Literal[1] | None) * 2
+
+PYI061 [*] Use `Optional[Literal[...]]` rather than `Literal[None, ...]` 
+  --> PYI061.py:85:18
+   |
+83 | print(Literal[1, None].__dict__)  # Should become (Literal[1] | None).__dict__
+84 | print(Literal[1, None].method())  # Should become (Literal[1] | None).method()
+85 | print(Literal[1, None][0])  # Should become (Literal[1] | None)[0]
+   |                  ^^^^
+86 | print(Literal[1, None] + 1)  # Should become (Literal[1] | None) + 1
+87 | print(Literal[1, None] * 2)  # Should become (Literal[1] | None) * 2
+   |
+help: Replace with `Optional[Literal[...]]`
+   - from typing import Literal, Union
+1  + from typing import Literal, Union, Optional
+2  | 
+3  | 
+4  | def func1(arg1: Literal[None]):
+--------------------------------------------------------------------------------
+82 | # Test cases for operator precedence issue (https://github.com/astral-sh/ruff/issues/20265)
+83 | print(Literal[1, None].__dict__)  # Should become (Literal[1] | None).__dict__
+84 | print(Literal[1, None].method())  # Should become (Literal[1] | None).method()
+   - print(Literal[1, None][0])  # Should become (Literal[1] | None)[0]
+85 + print(Optional[Literal[1]][0])  # Should become (Literal[1] | None)[0]
+86 | print(Literal[1, None] + 1)  # Should become (Literal[1] | None) + 1
+87 | print(Literal[1, None] * 2)  # Should become (Literal[1] | None) * 2
+
+PYI061 [*] Use `Optional[Literal[...]]` rather than `Literal[None, ...]` 
+  --> PYI061.py:86:18
+   |
+84 | print(Literal[1, None].method())  # Should become (Literal[1] | None).method()
+85 | print(Literal[1, None][0])  # Should become (Literal[1] | None)[0]
+86 | print(Literal[1, None] + 1)  # Should become (Literal[1] | None) + 1
+   |                  ^^^^
+87 | print(Literal[1, None] * 2)  # Should become (Literal[1] | None) * 2
+   |
+help: Replace with `Optional[Literal[...]]`
+   - from typing import Literal, Union
+1  + from typing import Literal, Union, Optional
+2  | 
+3  | 
+4  | def func1(arg1: Literal[None]):
+--------------------------------------------------------------------------------
+83 | print(Literal[1, None].__dict__)  # Should become (Literal[1] | None).__dict__
+84 | print(Literal[1, None].method())  # Should become (Literal[1] | None).method()
+85 | print(Literal[1, None][0])  # Should become (Literal[1] | None)[0]
+   - print(Literal[1, None] + 1)  # Should become (Literal[1] | None) + 1
+86 + print(Optional[Literal[1]] + 1)  # Should become (Literal[1] | None) + 1
+87 | print(Literal[1, None] * 2)  # Should become (Literal[1] | None) * 2
+
+PYI061 [*] Use `Optional[Literal[...]]` rather than `Literal[None, ...]` 
+  --> PYI061.py:87:18
+   |
+85 | print(Literal[1, None][0])  # Should become (Literal[1] | None)[0]
+86 | print(Literal[1, None] + 1)  # Should become (Literal[1] | None) + 1
+87 | print(Literal[1, None] * 2)  # Should become (Literal[1] | None) * 2
+   |                  ^^^^
+   |
+help: Replace with `Optional[Literal[...]]`
+   - from typing import Literal, Union
+1  + from typing import Literal, Union, Optional
+2  | 
+3  | 
+4  | def func1(arg1: Literal[None]):
+--------------------------------------------------------------------------------
+84 | print(Literal[1, None].method())  # Should become (Literal[1] | None).method()
+85 | print(Literal[1, None][0])  # Should become (Literal[1] | None)[0]
+86 | print(Literal[1, None] + 1)  # Should become (Literal[1] | None) + 1
+   - print(Literal[1, None] * 2)  # Should become (Literal[1] | None) * 2
+87 + print(Optional[Literal[1]] * 2)  # Should become (Literal[1] | None) * 2


### PR DESCRIPTION
## Summary

Fixes #20265
