### PR TITLE
[ty] Enum narrowing eq ne

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -107,6 +107,30 @@ def _(answer: AmbiguousEnum):
         reveal_type(answer)  # revealed: AmbiguousEnum
 ```
 
+If the enum only has a custom `__ne__` without a modified `__eq__`, it is safe to narrow on eq/in
+checks.
+
+```py
+from enum import Enum
+from typing import cast
+
+class Foo(Enum):
+    A = 1
+    B = 2
+
+    def __ne__(self,other): return False
+
+reveal_type(Foo.A == Foo.A) # revealed: Literal[True]
+
+foo = cast(Foo, Foo.A)
+
+if foo == Foo.A:
+    reveal_type(foo) # revealed: Literal[Foo.A]
+
+if foo != Foo.B:
+    reveal_type(foo) #revealed: Foo
+```
+
 ## `x != y` where `y` is of literal type
 
 ```py

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2713,7 +2713,7 @@ impl<'db> Type<'db> {
             | Type::SpecialForm(..)
             | Type::KnownInstance(..) => true,
 
-            Type::EnumLiteral(_) => false,
+            Type::EnumLiteral(_) => !self.overrides_equality(db, None),
 
             Type::ProtocolInstance(..) => {
                 // See comment in the `Type::ProtocolInstance` branch for `Type::is_singleton`.


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

In response to https://github.com/astral-sh/ty/issues/1177. This is my attempt at trying to modify the narrow mechanism of enum.

I implemented it this way because I didn't want to alter `fn is_single_valued` signature as it is used in 103 different places. Instead, I created a `fn is_single_valued_enum` and an optional parameter to modify if necessary the dunder methods checked by `fn overrides_equality`.

## Test Plan
I added a test with the case exposed in the issue mentioned above.
