### PR TITLE
[ty] Fix class literal subtyping with object fallback

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
@@ -1753,12 +1753,6 @@ static_assert(is_subtype_of(TypeOf[B], ReturnsWithArgument[int, B]))
 static_assert(is_subtype_of(TypeOf[B], Callable[[], B]))
 static_assert(is_subtype_of(TypeOf[B], Returns[B]))
 
-class C: ...
-
-# TODO: These assertions should be true once we understand `Self`
-static_assert(is_subtype_of(TypeOf[C], Callable[[], C]))  # error: [static-assert-error]
-static_assert(is_subtype_of(TypeOf[C], Returns[C]))  # error: [static-assert-error]
-
 class D[T]:
     def __init__(self, x: T) -> None: ...
 
@@ -1873,6 +1867,21 @@ static_assert(not is_subtype_of(TypeOf[F], Callable[[], str]))
 static_assert(not is_subtype_of(TypeOf[F], Returns[str]))
 static_assert(not is_subtype_of(TypeOf[F], Callable[[int], F]))
 static_assert(not is_subtype_of(TypeOf[F], ReturnsWithArgument[int, F]))
+```
+
+### Classes with no constructor methods
+
+```py
+from typing import Callable, Protocol
+from ty_extensions import TypeOf, static_assert, is_subtype_of
+
+class Returns[T](Protocol):
+    def __call__(self) -> T: ...
+
+class A: ...
+
+static_assert(is_subtype_of(TypeOf[A], Callable[[], A]))
+static_assert(is_subtype_of(TypeOf[A], Returns[A]))
 ```
 
 ### Subclass of

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -1185,7 +1185,7 @@ impl<'db> ClassType<'db> {
                 if let Place::Type(Type::FunctionLiteral(new_function), _) = new_function_symbol {
                     Type::Callable(
                         new_function
-                            .into_bound_method_type(db, self_ty)
+                            .into_bound_method_type(db, correct_return_type)
                             .into_callable_type(db),
                     )
                 } else {


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

@ibraheemdev notes this example failed

```py
from typing import Callable

class X:
    ...

def f(callable: Callable[[], X]) -> X:
    return callable()

x = f(X)
```

Resolves https://github.com/astral-sh/ty/issues/1210

The issue was that we set the `Self` to the class type instead of the instance type of the class.

## Test Plan

Fix tests in `is_subtype_of.md`
