### PR TITLE
[ty] Warn incompatible type annotation for self

### DIFF
--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -3030,6 +3030,12 @@ impl Parameters {
             .find(|arg| arg.parameter.name.as_str() == name)
     }
 
+    /// Returns the index of the parameter with the given name
+    pub fn index(&self, name: &str) -> Option<usize> {
+        self.iter_non_variadic_params()
+            .position(|arg| arg.parameter.name.as_str() == name)
+    }
+
     /// Returns an iterator over all parameters included in this [`Parameters`] node.
     pub fn iter(&self) -> ParametersIterator<'_> {
         ParametersIterator::new(self)

--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -180,6 +180,7 @@ b: Self
 # TODO: "Self" cannot be used in a function with a `self` or `cls` parameter that has a type annotation other than "Self"
 class Foo:
     # TODO: rejected Self because self has a different type
+    # error: [invalid-self-parameter-type]
     def has_existing_self_annotation(self: T) -> Self:
         return self  # error: [invalid-return-type]
 
@@ -267,6 +268,25 @@ class C:
         reveal_type(generic_context(b))  # revealed: None
 
 reveal_type(generic_context(C.f))  # revealed: None
+```
+
+## Valid Self Annotations
+
+The first argument in methods(that are not decorated with `classmethod` and `staticmethod`) is
+called `self` and it's type should accept any subclass of the class.
+
+```py
+import typing
+
+class A:
+    # error: [invalid-self-parameter-type]
+    def bad(self: int) -> None: ...
+    def good1(self: "A") -> None: ...
+    def good2(self: typing.Self) -> None: ...
+
+class B(A):
+    # TODO: Should warn the user if self is overriden with a type that is not supertype of the class
+    def good(self: "A") -> None: ...
 ```
 
 [self attribute]: https://typing.python.org/en/latest/spec/generics.html#use-in-attribute-annotations

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -65,6 +65,7 @@ pub(crate) fn register_lints(registry: &mut LintRegistryBuilder) {
     registry.register_lint(&INVALID_METACLASS);
     registry.register_lint(&INVALID_OVERLOAD);
     registry.register_lint(&INVALID_PARAMETER_DEFAULT);
+    registry.register_lint(&INVALID_SELF_PARAMETER_TYPE);
     registry.register_lint(&INVALID_PROTOCOL);
     registry.register_lint(&INVALID_NAMED_TUPLE);
     registry.register_lint(&INVALID_RAISE);
@@ -974,6 +975,30 @@ declare_lint! {
         summary: "detects default values that can't be assigned to the parameter's annotated type",
         status: LintStatus::preview("1.0.0"),
         default_level: Level::Error,
+    }
+}
+
+declare_lint! {
+    /// ## What it does
+    /// Checks for explicit `self` parameter type annotations that are not
+    /// supertypes of the containing class.
+    ///
+    /// ## Why is this bad?
+    /// This violates type system invariants and breaks method call safety.
+    /// The `self` parameter must be typed as a supertype of its class to ensure
+    /// that instances of the class can be safely passed as the `self` argument.
+    /// When a subtype is used instead of a supertype, it creates unsound type
+    /// relationships that can lead to runtime errors.
+    ///
+    /// ## Examples
+    /// ```
+    /// class Parent:
+    ///     def method(self: str): pass
+    /// ```
+    pub(crate) static INVALID_SELF_PARAMETER_TYPE = {
+        summary: "detects self parameter annotations that are not supertypes of the containing class",
+        status: LintStatus::stable("1.0.0"),
+        default_level: Level::Warn,
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

Part of: https://github.com/astral-sh/ty/issues/159

Report incompatible type annotations for `self` argument.
The type that is used should be either `typing.Self` or super type of the class.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
