### PR TITLE
[`ruff`] Suppress diagnostic for f-string interpolations with debug text (`RUF010`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF010.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF010.py
@@ -56,3 +56,11 @@ f"{str(object=3)}"
 f"{str(x for x in [])}"
 
 f"{str((x for x in []))}"
+
+# Debug text cases - should not trigger RUF010
+f"{str(1)=}"
+f"{ascii(1)=}"
+f"{repr(1)=}"
+f"{str('hello')=}"
+f"{ascii('hello')=}"
+f"{repr('hello')=}"

--- a/crates/ruff_linter/src/rules/ruff/rules/explicit_f_string_type_conversion.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/explicit_f_string_type_conversion.rs
@@ -110,16 +110,16 @@ pub(crate) fn explicit_f_string_type_conversion(checker: &Checker, f_string: &as
             return;
         }
 
-        let mut diagnostic =
-            checker.report_diagnostic(ExplicitFStringTypeConversion, expression.range());
-
-        // Don't support fixing f-string with debug text.
+        // Don't report diagnostic for f-string with debug text.
         if element
             .as_interpolation()
             .is_some_and(|interpolation| interpolation.debug_text.is_some())
         {
             return;
         }
+
+        let mut diagnostic =
+            checker.report_diagnostic(ExplicitFStringTypeConversion, expression.range());
 
         diagnostic.try_set_fix(|| {
             convert_call_to_conversion_flag(checker, conversion, f_string, index, arg)

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF010_RUF010.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF010_RUF010.py.snap
@@ -293,18 +293,6 @@ help: Replace with conversion flag
 48 | f"{repr(1)=}"
 49 | 
 
-RUF010 Use explicit conversion flag
-  --> RUF010.py:48:4
-   |
-46 | f"{builtins.repr(1)}"
-47 |
-48 | f"{repr(1)=}"
-   |    ^^^^^^^
-49 |
-50 | f"{repr(lambda: 1)}"
-   |
-help: Replace with conversion flag
-
 RUF010 [*] Use explicit conversion flag
   --> RUF010.py:50:4
    |
@@ -383,6 +371,7 @@ help: Replace with conversion flag
 56 + f"{(x for x in [])!s}"
 57 | 
 58 | f"{str((x for x in []))}"
+59 | 
 
 RUF010 [*] Use explicit conversion flag
   --> RUF010.py:58:4
@@ -391,6 +380,8 @@ RUF010 [*] Use explicit conversion flag
 57 |
 58 | f"{str((x for x in []))}"
    |    ^^^^^^^^^^^^^^^^^^^^
+59 |
+60 | # Debug text cases - should not trigger RUF010
    |
 help: Replace with conversion flag
 55 | 
@@ -398,3 +389,6 @@ help: Replace with conversion flag
 57 | 
    - f"{str((x for x in []))}"
 58 + f"{(x for x in [])!s}"
+59 | 
+60 | # Debug text cases - should not trigger RUF010
+61 | f"{str(1)=}"


### PR DESCRIPTION
## Summary

Fixes #20519
