### PR TITLE
[`playground`]: Fix non‑BMP code point handling in quick‑fixes and markers

### DIFF
--- a/crates/ruff_wasm/README.md
+++ b/crates/ruff_wasm/README.md
@@ -19,7 +19,7 @@ There are multiple versions for the different wasm-pack targets. See [here](http
 This example uses the wasm-pack web target and is known to work with Vite.
 
 ```ts
-import init, { Workspace, type Diagnostic } from '@astral-sh/ruff-wasm-web';
+import init, { Workspace, type Diagnostic, PositionEncoding } from '@astral-sh/ruff-wasm-web';
 
 const exampleDocument = `print('hello'); print("world")`
 
@@ -42,7 +42,7 @@ const workspace = new Workspace({
       'F'
     ],
   },
-});
+}, PositionEncoding.UTF16);
 
 // Will contain 1 diagnostic code for E702: Multiple statements on one line
 const diagnostics: Diagnostic[] = workspace.check(exampleDocument);

--- a/crates/ruff_wasm/src/lib.rs
+++ b/crates/ruff_wasm/src/lib.rs
@@ -127,7 +127,7 @@ impl Workspace {
     }
 
     #[wasm_bindgen(constructor)]
-    pub fn new(position_encoding: PositionEncoding, options: JsValue) -> Result<Workspace, Error> {
+    pub fn new(options: JsValue, position_encoding: Option<PositionEncoding>) -> Result<Workspace, Error> {
         let options: Options = serde_wasm_bindgen::from_value(options).map_err(into_error)?;
         let configuration =
             Configuration::from_options(options, Some(Path::new(".")), Path::new("."))
@@ -138,7 +138,7 @@ impl Workspace {
 
         Ok(Workspace {
             settings,
-            position_encoding: position_encoding.into(),
+            position_encoding: position_encoding.unwrap_or_default().into(),
         })
     }
 

--- a/crates/ruff_wasm/src/lib.rs
+++ b/crates/ruff_wasm/src/lib.rs
@@ -127,7 +127,10 @@ impl Workspace {
     }
 
     #[wasm_bindgen(constructor)]
-    pub fn new(options: JsValue, position_encoding: Option<PositionEncoding>) -> Result<Workspace, Error> {
+    pub fn new(
+        options: JsValue,
+        position_encoding: Option<PositionEncoding>,
+    ) -> Result<Workspace, Error> {
         let options: Options = serde_wasm_bindgen::from_value(options).map_err(into_error)?;
         let configuration =
             Configuration::from_options(options, Some(Path::new(".")), Path::new("."))

--- a/crates/ruff_wasm/tests/api.rs
+++ b/crates/ruff_wasm/tests/api.rs
@@ -9,7 +9,7 @@ use ruff_wasm::{ExpandedMessage, Location, PositionEncoding, Workspace};
 macro_rules! check {
     ($source:expr, $config:expr, $expected:expr) => {{
         let config = js_sys::JSON::parse($config).unwrap();
-        match Workspace::new(config, Some(PositionEncoding::Utf8))
+        match Workspace::new(config, PositionEncoding::Utf8)
             .unwrap()
             .check($source)
         {

--- a/crates/ruff_wasm/tests/api.rs
+++ b/crates/ruff_wasm/tests/api.rs
@@ -9,7 +9,7 @@ use ruff_wasm::{ExpandedMessage, Location, PositionEncoding, Workspace};
 macro_rules! check {
     ($source:expr, $config:expr, $expected:expr) => {{
         let config = js_sys::JSON::parse($config).unwrap();
-        match Workspace::new(config, PositionEncoding::Utf8)
+        match Workspace::new(config, Some(PositionEncoding::Utf8))
             .unwrap()
             .check($source)
         {

--- a/crates/ruff_wasm/tests/api.rs
+++ b/crates/ruff_wasm/tests/api.rs
@@ -9,7 +9,7 @@ use ruff_wasm::{ExpandedMessage, Location, PositionEncoding, Workspace};
 macro_rules! check {
     ($source:expr, $config:expr, $expected:expr) => {{
         let config = js_sys::JSON::parse($config).unwrap();
-        match Workspace::new(PositionEncoding::Utf8, config)
+        match Workspace::new(config, PositionEncoding::Utf8)
             .unwrap()
             .check($source)
         {

--- a/crates/ruff_wasm/tests/api.rs
+++ b/crates/ruff_wasm/tests/api.rs
@@ -4,12 +4,15 @@ use wasm_bindgen_test::wasm_bindgen_test;
 
 use ruff_linter::registry::Rule;
 use ruff_source_file::OneIndexed;
-use ruff_wasm::{ExpandedMessage, Location, Workspace};
+use ruff_wasm::{ExpandedMessage, Location, PositionEncoding, Workspace};
 
 macro_rules! check {
     ($source:expr, $config:expr, $expected:expr) => {{
         let config = js_sys::JSON::parse($config).unwrap();
-        match Workspace::new(config).unwrap().check($source) {
+        match Workspace::new(PositionEncoding::Utf8, config)
+            .unwrap()
+            .check($source)
+        {
             Ok(output) => {
                 let result: Vec<ExpandedMessage> = serde_wasm_bindgen::from_value(output).unwrap();
                 assert_eq!(result, $expected);

--- a/playground/ruff/src/Editor/Editor.tsx
+++ b/playground/ruff/src/Editor/Editor.tsx
@@ -6,7 +6,7 @@ import {
   useState,
 } from "react";
 import { Panel, PanelGroup } from "react-resizable-panels";
-import { Diagnostic, Workspace } from "ruff_wasm";
+import { Diagnostic, Workspace, PositionEncoding } from "ruff_wasm";
 import {
   ErrorMessage,
   Theme,
@@ -173,7 +173,7 @@ export default function Editor({
 
     try {
       const config = JSON.parse(settingsSource);
-      const workspace = new Workspace(config);
+      const workspace = new Workspace(PositionEncoding.Utf16, config);
       const diagnostics = workspace.check(pythonSource);
 
       let secondary: SecondaryPanelResult = null;

--- a/playground/ruff/src/Editor/Editor.tsx
+++ b/playground/ruff/src/Editor/Editor.tsx
@@ -6,7 +6,7 @@ import {
   useState,
 } from "react";
 import { Panel, PanelGroup } from "react-resizable-panels";
-import { Diagnostic, Workspace, PositionEncoding } from "ruff_wasm";
+import { Diagnostic, Workspace } from "ruff_wasm";
 import {
   ErrorMessage,
   Theme,
@@ -173,7 +173,7 @@ export default function Editor({
 
     try {
       const config = JSON.parse(settingsSource);
-      const workspace = new Workspace(PositionEncoding.Utf16, config);
+      const workspace = new Workspace(config);
       const diagnostics = workspace.check(pythonSource);
 
       let secondary: SecondaryPanelResult = null;

--- a/playground/ruff/src/Editor/Editor.tsx
+++ b/playground/ruff/src/Editor/Editor.tsx
@@ -6,7 +6,7 @@ import {
   useState,
 } from "react";
 import { Panel, PanelGroup } from "react-resizable-panels";
-import { Diagnostic, Workspace } from "ruff_wasm";
+import { Diagnostic, Workspace, PositionEncoding } from "ruff_wasm";
 import {
   ErrorMessage,
   Theme,
@@ -24,7 +24,6 @@ import SourceEditor from "./SourceEditor";
 import Diagnostics from "./Diagnostics";
 import { editor } from "monaco-editor";
 import IStandaloneCodeEditor = editor.IStandaloneCodeEditor;
-import { PositionEncoding } from "ty_wasm";
 
 type Tab = "Source" | "Settings";
 

--- a/playground/ruff/src/Editor/Editor.tsx
+++ b/playground/ruff/src/Editor/Editor.tsx
@@ -24,6 +24,7 @@ import SourceEditor from "./SourceEditor";
 import Diagnostics from "./Diagnostics";
 import { editor } from "monaco-editor";
 import IStandaloneCodeEditor = editor.IStandaloneCodeEditor;
+import { PositionEncoding } from "ty_wasm";
 
 type Tab = "Source" | "Settings";
 
@@ -173,7 +174,7 @@ export default function Editor({
 
     try {
       const config = JSON.parse(settingsSource);
-      const workspace = new Workspace(config);
+      const workspace = new Workspace(config, PositionEncoding.Utf16);
       const diagnostics = workspace.check(pythonSource);
 
       let secondary: SecondaryPanelResult = null;

--- a/playground/ruff/src/Editor/SourceEditor.tsx
+++ b/playground/ruff/src/Editor/SourceEditor.tsx
@@ -123,13 +123,6 @@ class RuffCodeActionProvider implements CodeActionProvider {
     model: editor.ITextModel,
     range: Range,
   ): languages.ProviderResult<languages.CodeActionList> {
-    // Convert UTF-32 (code points) columns from WASM to Monaco's UTF-16 columns
-    const utf32ToUtf16 = (lineText: string, utf32Column: number): number => {
-      // Monaco columns are 1-based. utf32Column is also 1-based (OneIndexed).
-      if (utf32Column <= 1) return 1;
-      const prefix = [...lineText].slice(0, utf32Column - 1).join("");
-      return prefix.length + 1; // length in UTF-16 code units, then make 1-based
-    };
     const actions = this.diagnostics
       // Show fixes for any diagnostic whose range intersects the requested range
       .filter((check) =>
@@ -161,15 +154,9 @@ class RuffCodeActionProvider implements CodeActionProvider {
                 textEdit: {
                   range: {
                     startLineNumber: edit.location.row,
-                    startColumn: utf32ToUtf16(
-                      model.getLineContent(edit.location.row),
-                      edit.location.column,
-                    ),
+                    startColumn: edit.location.column,
                     endLineNumber: edit.end_location.row,
-                    endColumn: utf32ToUtf16(
-                      model.getLineContent(edit.end_location.row),
-                      edit.end_location.column,
-                    ),
+                    endColumn: edit.end_location.column,
                   },
                   text: edit.content || "",
                 },
@@ -193,28 +180,15 @@ function updateMarkers(monaco: Monaco, diagnostics: Array<Diagnostic>) {
     return;
   }
 
-  // Helper to convert UTF-32 (code points) columns from WASM to Monaco's UTF-16 columns
-  const utf32ToUtf16 = (lineText: string, utf32Column: number): number => {
-    if (utf32Column <= 1) return 1;
-    const prefix = [...lineText].slice(0, utf32Column - 1).join("");
-    return prefix.length + 1;
-  };
-
   editor.setModelMarkers(
     model,
     "owner",
     diagnostics.map((diagnostic) => ({
       code: diagnostic.code ?? undefined,
       startLineNumber: diagnostic.start_location.row,
-      startColumn: utf32ToUtf16(
-        model.getLineContent(diagnostic.start_location.row),
-        diagnostic.start_location.column,
-      ),
+      startColumn: diagnostic.start_location.column,
       endLineNumber: diagnostic.end_location.row,
-      endColumn: utf32ToUtf16(
-        model.getLineContent(diagnostic.end_location.row),
-        diagnostic.end_location.column,
-      ),
+      endColumn: diagnostic.end_location.column,
       message: diagnostic.code
         ? `${diagnostic.code}: ${diagnostic.message}`
         : diagnostic.message,


### PR DESCRIPTION
## Summary

Fixes #16266

Updated the playground to convert UTF‑32 (code point) columns from the WASM diagnostics/fixes into Monaco’s UTF‑16 columns when constructing both quick‑fix edit ranges and diagnostic markers in `playground/ruff/src/Editor/SourceEditor.tsx`.

With this change, applying the `C408` quick fix on `dict(𠤪=1)` now correctly yields `{"𠤪": 1}` without leaving a stray `)`.