### PR TITLE
[ty] fix stack overflow when comparing recursive `NamedTuple` types with `is_disjoint_from`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
@@ -616,6 +616,31 @@ class BarNone(Protocol):
 static_assert(is_disjoint_from(type[Foo], BarNone))
 ```
 
+### `NamedTuple`
+
+```py
+from __future__ import annotations
+
+from typing import NamedTuple, final
+from ty_extensions import is_disjoint_from, static_assert
+
+@final
+class Path(NamedTuple):
+    prev: Path | None
+    key: str
+
+@final
+class Path2(NamedTuple):
+    prev: Path2 | None
+    key: str
+
+static_assert(not is_disjoint_from(Path, Path))
+static_assert(not is_disjoint_from(Path, tuple[Path | None, str]))
+static_assert(is_disjoint_from(Path, tuple[Path | None]))
+static_assert(is_disjoint_from(Path, tuple[Path | None, str, int]))
+static_assert(is_disjoint_from(Path, Path2))
+```
+
 ## Callables
 
 No two callable types are disjoint because there exists a non-empty callable type

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2553,9 +2553,10 @@ impl<'db> Type<'db> {
                 other.is_disjoint_from_impl(db, KnownClass::ModuleType.to_instance(db), visitor)
             }
 
-            (Type::NominalInstance(left), Type::NominalInstance(right)) => {
-                left.is_disjoint_from_impl(db, right, visitor)
-            }
+            (Type::NominalInstance(left), Type::NominalInstance(right)) => visitor
+                .visit((self, other), || {
+                    left.is_disjoint_from_impl(db, right, visitor)
+                }),
 
             (Type::PropertyInstance(_), other) | (other, Type::PropertyInstance(_)) => {
                 KnownClass::Property


### PR DESCRIPTION
## Summary

I found this bug while working on #20528.
The minimum reproducible code is:

```python
from __future__ import annotations

from typing import NamedTuple
from ty_extensions import is_disjoint_from, static_assert

class Path(NamedTuple):
    prev: Path | None
    key: str

static_assert(not is_disjoint_from(Path, Path))
```

A stack overflow occurs when a nominal instance type inherits from `NamedTuple` and is defined recursively.
This PR fixes this bug.

## Test Plan

mdtest updated
