### PR TITLE
Update import path to ruff-wasm-web

### DIFF
--- a/crates/ruff_wasm/README.md
+++ b/crates/ruff_wasm/README.md
@@ -19,7 +19,7 @@ There are multiple versions for the different wasm-pack targets. See [here](http
 This example uses the wasm-pack web target and is known to work with Vite.
 
 ```ts
-import init, { Workspace, type Diagnostic } from '@astral-sh/ruff-api';
+import init, { Workspace, type Diagnostic } from '@astral-sh/ruff-wasm-web';
 
 const exampleDocument = `print('hello'); print("world")`
 


### PR DESCRIPTION
## Summary

Update import statement to match the correct package name.

## Test Plan

Verified using a local unit test as follows:

ruff.ts:
```ts
import initRuff, { Workspace } from "@astral-sh/ruff-wasm-web";

function noConsoleLog<T>(fn: () => T): T {
  const originalConsoleLog = console.log;
  console.log = () => {
    /* no-op */
  };
  try {
    return fn();
  } finally {
    console.log = originalConsoleLog;
  }
}

let initPromise: Promise<Workspace> | null = null;

function getWorkspace(): Promise<Workspace> {
  if (initPromise === null) {
    initPromise = (async () => {
      await initRuff();
      const workspace = noConsoleLog(() => new Workspace({}));
      return workspace;
    })();
  }
  return initPromise;
}

export async function format(code: string): Promise<string> {
  const workspace = await getWorkspace();
  const result = noConsoleLog(() => workspace.format(code));
  return result;
}
```

ruff.test.ts:
```ts
import { expect, test } from "bun:test";
import { format } from "./ruff";

test("format ok", async () => {
  const code = 'print(1+2)'
  const formatted = await format(code);
  expect(formatted).toBe('print(1 + 2)\n');
});
```

### Notes

The `noConsoleLog()` wrapper is used to suppress verbose and unnecessary debug logs such as:
```
built glob set; 25 literals, 0 basenames, 0 extensions, 0 prefixes, 0 suffixes, 0 required extensions, 0 regexes
built glob set; 0 literals, 1 basenames, 3 extensions, 0 prefixes, 0 suffixes, 0 required extensions, 0 regexes
```

These logs also appear on the official Ruff playground (https://play.ruff.rs/), originating from the upstream Rust dependency [globset](https://github.com/BurntSushi/globset/blob/5001475e8230f6e79b43b1d1821b6fa75f1add04/src/lib.rs#L425-L435). 

Maybe we could consider disabling debug-level logging in future WASM builds?