### PR TITLE
[ty] Use full project names in `good.txt`

### DIFF
--- a/.github/workflows/ty-ecosystem-report.yaml
+++ b/.github/workflows/ty-ecosystem-report.yaml
@@ -49,7 +49,7 @@ jobs:
 
           cd ..
 
-          uv tool install "git+https://github.com/astral-sh/ecosystem-analyzer@27dd66d9e397d986ef9c631119ee09556eab8af9"
+          uv tool install "git+https://github.com/astral-sh/ecosystem-analyzer@fc0f612798710b0dd69bb7528bc9b361dc60bd43"
 
           ecosystem-analyzer \
             --verbose \

--- a/crates/ty/docs/mypy_primer.md
+++ b/crates/ty/docs/mypy_primer.md
@@ -31,7 +31,13 @@ mypy_primer \
 ```
 
 This will show the diagnostics diff for the `black` project between the `main` branch and your `my/feature` branch. To run the
-diff for all projects we currently enable in CI, use `--project-selector "/($(paste -s -d'|' crates/ty_python_semantic/resources/primer/good.txt))\$"`.
+diff for all projects we currently enable in CI, run
+
+```sh
+SELECTOR="$(paste -s -d'|' "crates/ty_python_semantic/resources/primer/good.txt" | sed -e 's@(@\\(@g' -e 's@)@\\)@g')"
+```
+
+and then use `--project-selector "$SELECTOR"`.
 
 You can also take a look at the [full list of ecosystem projects]. Note that some of them might still need a `ty_paths` configuration
 option to work correctly.

--- a/crates/ty_python_semantic/resources/primer/good.txt
+++ b/crates/ty_python_semantic/resources/primer/good.txt
@@ -33,7 +33,9 @@ colour
 com2ann
 comtypes
 core
-cpython
+CPython (Argument Clinic)
+CPython (cases_generator)
+CPython (peg_generator)
 cwltool
 dacite
 dd-trace-py

--- a/scripts/mypy_primer.sh
+++ b/scripts/mypy_primer.sh
@@ -5,7 +5,9 @@ echo "Enabling mypy primer specific configuration overloads (see .github/mypy-pr
 mkdir -p ~/.config/ty
 cp .github/mypy-primer-ty.toml ~/.config/ty/ty.toml
 
-PRIMER_SELECTOR="$(paste -s -d'|' "${PRIMER_SELECTOR}")"
+# Join the lines (project names) of the file into a large regex
+# using `|` and escape parentheses.
+PRIMER_SELECTOR="$(paste -s -d'|' "${PRIMER_SELECTOR}" | sed -e 's@(@\\(@g' -e 's@)@\\)@g')"
 
 echo "new commit"
 git rev-list --format=%s --max-count=1 "${GITHUB_SHA}"


### PR DESCRIPTION
## Summary

This allows `ecosystem-analyzer` to pick up these projects as well (uses full names instead of regex patterns).

## Test Plan

- [ ] Successful run of mypy_primer
- [ ] Made sure that mypy_primer still runs all three CPython projects
- [ ] Successful run of ecosystem-analyzer
- [ ] Made sure that ecossystem-analyzer now picks up the CPython projects