### PR TITLE
[ty] Add support for workspace/didChangeConfiguration notification

### DIFF
--- a/crates/ty_server/src/capabilities.rs
+++ b/crates/ty_server/src/capabilities.rs
@@ -36,6 +36,7 @@ bitflags::bitflags! {
         const DIAGNOSTIC_DYNAMIC_REGISTRATION = 1 << 14;
         const WORKSPACE_CONFIGURATION = 1 << 15;
         const RENAME_DYNAMIC_REGISTRATION = 1 << 16;
+        const DID_CHANGE_CONFIGURATION = 1 << 17;
     }
 }
 
@@ -70,6 +71,10 @@ impl FromStr for SupportedCommand {
 }
 
 impl ResolvedClientCapabilities {
+    /// Returns `true` if the client supports change configuration notifications.
+    pub(crate) const fn supports_change_conf_notifications(self) -> bool {
+        self.contains(Self::DID_CHANGE_CONFIGURATION)
+    }
     /// Returns `true` if the client supports workspace diagnostic refresh.
     pub(crate) const fn supports_workspace_diagnostic_refresh(self) -> bool {
         self.contains(Self::WORKSPACE_DIAGNOSTIC_REFRESH)
@@ -163,6 +168,10 @@ impl ResolvedClientCapabilities {
 
         let workspace = client_capabilities.workspace.as_ref();
         let text_document = client_capabilities.text_document.as_ref();
+
+        if workspace.is_some_and(|workspace| workspace.did_change_configuration.is_some()) {
+            flags |= Self::DID_CHANGE_CONFIGURATION;
+        }
 
         if workspace
             .and_then(|workspace| workspace.diagnostics.as_ref()?.refresh_support)

--- a/crates/ty_server/src/server/api.rs
+++ b/crates/ty_server/src/server/api.rs
@@ -136,6 +136,9 @@ pub(super) fn request(req: server::Request) -> Task {
 
 pub(super) fn notification(notif: server::Notification) -> Task {
     match notif.method.as_str() {
+        notifications::DidChangeConfiguration::METHOD => {
+            sync_notification_task::<notifications::DidChangeConfiguration>(notif)
+        }
         notifications::DidCloseTextDocumentHandler::METHOD => {
             sync_notification_task::<notifications::DidCloseTextDocumentHandler>(notif)
         }

--- a/crates/ty_server/src/server/api/notifications.rs
+++ b/crates/ty_server/src/server/api/notifications.rs
@@ -1,5 +1,6 @@
 mod cancel;
 mod did_change;
+mod did_change_configuration;
 mod did_change_watched_files;
 mod did_close;
 mod did_close_notebook;
@@ -8,6 +9,7 @@ mod did_open_notebook;
 
 pub(super) use cancel::CancelNotificationHandler;
 pub(super) use did_change::DidChangeTextDocumentHandler;
+pub(super) use did_change_configuration::DidChangeConfiguration;
 pub(super) use did_change_watched_files::DidChangeWatchedFiles;
 pub(super) use did_close::DidCloseTextDocumentHandler;
 pub(super) use did_close_notebook::DidCloseNotebookHandler;

--- a/crates/ty_server/src/server/api/notifications/did_change_configuration.rs
+++ b/crates/ty_server/src/server/api/notifications/did_change_configuration.rs
@@ -1,37 +1,83 @@
 use crate::server::Result;
 use crate::server::api::traits::{NotificationHandler, SyncNotificationHandler};
-use crate::session::Session;
 use crate::session::client::Client;
-use lsp_types as types;
+use crate::session::{ClientOptions, Session};
 use lsp_types::notification as notif;
-
+use lsp_types::{self as types, ConfigurationParams};
+use serde_json::Value;
 pub(crate) struct DidChangeConfiguration;
 
 impl NotificationHandler for DidChangeConfiguration {
     type NotificationType = notif::DidChangeConfiguration;
 }
 
+//server receives a didChangeConfiguration notification from the client. He should pull the
+//current client settings and refresh all workspace settings with the new values.
 impl SyncNotificationHandler for DidChangeConfiguration {
     fn run(
         session: &mut Session,
-        _client: &Client,
+        client: &Client,
         params: types::DidChangeConfigurationParams,
     ) -> Result<()> {
-        //the client send a didChangeConfiguration with an empty change event. The server should
-        //pulls for settings.
+        //the client send a didChangeConfiguration with an empty change event.
         //see https://github.com/microsoft/vscode-languageserver-node/issues/380#issuecomment-414691493
         //see https://github.com/microsoft/language-server-protocol/issues/676
         assert!(params.settings.is_null());
 
-        let _urls = session.workspaces().urls().cloned().collect::<Vec<_>>();
+        //The server should pull for settings. We send a workspace/configuration request to the
+        //client.
+        let urls = session.workspaces().urls().cloned().collect::<Vec<_>>();
 
-        let w_settings = session.workspaces().into_iter().map(|item| {
-            let (_, workspaces) = item;
-            workspaces.settings()
-        });
+        let items = urls
+            .iter()
+            .map(|root| lsp_types::ConfigurationItem {
+                scope_uri: Some(root.clone()),
+                section: Some("ty".to_string()),
+            })
+            .collect();
+
+        client.send_request::<lsp_types::request::WorkspaceConfiguration>(
+            session,
+            ConfigurationParams { items },
+            |_, result: Vec<Value>| {
+                tracing::debug!("Received workspace configurations, initializing workspaces");
+
+                // This shouldn't fail because, as per the spec, the client needs to provide a
+                // `null` value even if it cannot provide a configuration for a workspace.
+                assert_eq!(
+                    result.len(),
+                    urls.len(),
+                    "Mismatch in number of workspace URLs ({}) and configuration results ({})",
+                    urls.len(),
+                    result.len()
+                );
+
+                let workspaces_with_options: Vec<_> = urls
+                    .into_iter()
+                    .zip(result)
+                    .map(|(url, value)| {
+                        if value.is_null() {
+                            tracing::debug!(
+                                "No workspace options provided for {url}, using default options"
+                            );
+                            return (url, ClientOptions::default());
+                        }
+                        let options: ClientOptions =
+                            serde_json::from_value(value).unwrap_or_else(|err| {
+                                tracing::error!(
+                                    "Failed to deserialize workspace options for {url}: {err}. \
+                                        Using default options"
+                                );
+                                ClientOptions::default()
+                            });
+                        (url, options)
+                    })
+                    .collect();
+                tracing::info!("WORKSPACES: {:?}", workspaces_with_options);
+            },
+        );
         tracing::info!("GLOBAL: {:?}", session.global_settings());
         tracing::info!("INIT: {:?}", session.initialization_options());
-        tracing::info!("WORKSPACES: {:?}", w_settings);
         Ok(())
     }
 }

--- a/crates/ty_server/src/server/api/notifications/did_change_configuration.rs
+++ b/crates/ty_server/src/server/api/notifications/did_change_configuration.rs
@@ -23,11 +23,15 @@ impl SyncNotificationHandler for DidChangeConfiguration {
         //see https://github.com/microsoft/language-server-protocol/issues/676
         assert!(params.settings.is_null());
 
-        let urls = session.workspaces().urls().cloned().collect::<Vec<_>>();
+        let _urls = session.workspaces().urls().cloned().collect::<Vec<_>>();
 
+        let w_settings = session.workspaces().into_iter().map(|item| {
+            let (_, workspaces) = item;
+            workspaces.settings()
+        });
         tracing::info!("GLOBAL: {:?}", session.global_settings());
         tracing::info!("INIT: {:?}", session.initialization_options());
-        tracing::info!("WORKSPACES: {:?}", urls);
+        tracing::info!("WORKSPACES: {:?}", w_settings);
         Ok(())
-    } 
+    }
 }

--- a/crates/ty_server/src/server/api/notifications/did_change_configuration.rs
+++ b/crates/ty_server/src/server/api/notifications/did_change_configuration.rs
@@ -1,8 +1,10 @@
 use crate::server::Result;
 use crate::server::api::traits::{NotificationHandler, SyncNotificationHandler};
-use crate::session::{Session, client::Client};
+use crate::session::Session;
+use crate::session::client::Client;
 use lsp_types as types;
 use lsp_types::notification as notif;
+
 pub(crate) struct DidChangeConfiguration;
 
 impl NotificationHandler for DidChangeConfiguration {
@@ -11,11 +13,21 @@ impl NotificationHandler for DidChangeConfiguration {
 
 impl SyncNotificationHandler for DidChangeConfiguration {
     fn run(
-        _session: &mut Session,
+        session: &mut Session,
         _client: &Client,
-        _params: types::DidChangeConfigurationParams,
+        params: types::DidChangeConfigurationParams,
     ) -> Result<()> {
-        tracing::info!("fn triggered");
+        //the client send a didChangeConfiguration with an empty change event. The server should
+        //pulls for settings.
+        //see https://github.com/microsoft/vscode-languageserver-node/issues/380#issuecomment-414691493
+        //see https://github.com/microsoft/language-server-protocol/issues/676
+        assert!(params.settings.is_null());
+
+        let urls = session.workspaces().urls().cloned().collect::<Vec<_>>();
+
+        tracing::info!("GLOBAL: {:?}", session.global_settings());
+        tracing::info!("INIT: {:?}", session.initialization_options());
+        tracing::info!("WORKSPACES: {:?}", urls);
         Ok(())
-    }
+    } 
 }

--- a/crates/ty_server/src/server/api/notifications/did_change_configuration.rs
+++ b/crates/ty_server/src/server/api/notifications/did_change_configuration.rs
@@ -1,0 +1,21 @@
+use crate::server::Result;
+use crate::server::api::traits::{NotificationHandler, SyncNotificationHandler};
+use crate::session::{Session, client::Client};
+use lsp_types as types;
+use lsp_types::notification as notif;
+pub(crate) struct DidChangeConfiguration;
+
+impl NotificationHandler for DidChangeConfiguration {
+    type NotificationType = notif::DidChangeConfiguration;
+}
+
+impl SyncNotificationHandler for DidChangeConfiguration {
+    fn run(
+        _session: &mut Session,
+        _client: &Client,
+        _params: types::DidChangeConfigurationParams,
+    ) -> Result<()> {
+        tracing::info!("fn triggered");
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary

Hi, I started working on implementing didChangeConfiguration in response to https://github.com/astral-sh/ty/issues/953 but I need help.

The current status of my PR (draft):
* I see the capability I added in Client capabilities: ResolvedClientCapabilities(
    WORKSPACE_DIAGNOSTIC_REFRESH | ... | **DID_CHANGE_CONFIGURATION**
* `didChangeConfiguration` notifications sent by VSCode to the server are catched. But here is my first question: VSCode only send this notification when I change 

> Ty › Trace: Server Traces the communication between VSCode and the ty language server.

```
[Trace - 9:35:32 AM] Sending notification '$/setTrace'.
[Trace - 9:35:32 AM] Sending notification 'workspace/didChangeConfiguration'.
[Trace - 9:35:32 AM] Received request 'workspace/configuration - (3)'.
[Trace - 9:35:32 AM] Sending response 'workspace/configuration - (3)'. Processing request took 1ms
```

 For all the other settings (12 in total for ty), VSCode send a `request shutdown` instead. 

```
[Trace - 7:58:21 AM] Sending request 'shutdown - (16)'.
[Trace - 7:58:21 AM] Received response 'shutdown - (16)' in 2ms.
[Trace - 7:58:21 AM] Sending notification 'exit'.
[Trace - 7:58:21 AM] Sending request 'initialize - (0)'.
[Trace - 7:58:21 AM] Received response 'initialize - (0)' in 20ms.
[Trace - 7:58:21 AM] Sending notification 'initialized'.
[Trace - 7:58:21 AM] Sending notification 'textDocument/didOpen'.
[Trace - 7:58:21 AM] Received request 'workspace/configuration - (0)'.
[Trace - 7:58:21 AM] Sending response 'workspace/configuration - (0)'. Processing request took 1ms
[Trace - 7:58:21 AM] Received request 'client/registerCapability - (1)'.
[Trace - 7:58:21 AM] Sending response 'client/registerCapability - (1)'. Processing request took 1ms
[Trace - 7:58:21 AM] Sending request 'textDocument/diagnostic - (1)'.
[Trace - 7:58:21 AM] Received response 'textDocument/diagnostic - (1)' in 379ms.
[Trace - 7:58:21 AM] Sending request 'textDocument/diagnostic - (2)'.
[Trace - 7:58:21 AM] Received response 'textDocument/diagnostic - (2)' in 1ms.
```
If I change a settings outside of ty, I get the `didChangeConfiguration` notification. For example, for `Editor: format on save`.
Is it a normal behavior? In my understanding, we don't control what the client send to us but maybe I missed something...

* when the server receive the notification, the `DidChangeConfigurationParams` is empty. It is normal according to [lsp specs](https://github.com/astral-sh/ty/issues/82#issuecomment-3045358677) and some github issues I found ([1]( https://github.com/microsoft/vscode-languageserver-node/issues/380#issuecomment-414691493) - [2]( https://github.com/microsoft/language-server-protocol/issues/676)). So in my understanding, we have to pull the settings from the client and apply them to all managed workspaces in the session.  I began to implement something and I get this for the moment (one python file open):

```
2025-09-24 09:36:33.201403900  INFO GLOBAL: GlobalSettings { diagnostic_mode: OpenFilesOnly, experimental: ExperimentalSettings { rename: true, auto_import: true } }

2025-09-24 09:36:33.201471700  INFO INIT: InitializationOptions { log_level: Some(Info), log_file: None, options: ClientOptions { global: GlobalOptions { diagnostic_mode: None, experimental: None }, workspace: WorkspaceOptions { disable_language_services: None, inlay_hints: None, python_extension: None }, unknown: {} } }

2025-09-24 09:36:33.207605400  INFO WORKSPACES: [(Url { scheme: "file", cannot_be_a_base: false, username: "", password: None, host: None, port: None, path: "/c%3A/Users/guill/Documents/Python/Advent_Of_Code", query: None, fragment: None }, ClientOptions { global: GlobalOptions { diagnostic_mode: Some(OpenFilesOnly), experimental: Some(Experimental { rename: Some(true), auto_import: Some(true) }) }, workspace: WorkspaceOptions { disable_language_services: Some(true), inlay_hints: Some(InlayHintOptions { variable_types: Some(false), call_argument_names: Some(false) }), python_extension: Some(PythonExtension { active_environment: Some(ActiveEnvironment { executable: PythonExecutable { uri: Url { scheme: "file", cannot_be_a_base: false, username: "", password: None, host: None, port: None, path: "/c%3A/Users/guill/Documents/Python/Advent_Of_Code/.venv/Scripts/python.exe", query: None, fragment: None }, sys_prefix: "C:\\Users\\guill\\Documents\\Python\\Advent_Of_Code\\.venv" }, environment: Some(PythonEnvironment { folder_uri: Url { scheme: "file", cannot_be_a_base: false, username: "", password: None, host: None, port: None, path: "/c%3A/Users/guill/Documents/Python/Advent_Of_Code/.venv/Scripts/python.exe", query: None, fragment: None }, kind: "VirtualEnvironment", name: None }), version: Some(EnvironmentVersion { major: 3, minor: 12, patch: 2, sys_version: "3.12.2.final.0" }) }) }) }, unknown: {"importStrategy": String("fromEnvironment"), "logFile": Null, "logLevel": String("info"), "interpreter": Array [], "path": Array [String("C:\\Users\\guill\\Documents\\Rust\\others\\ruff\\target\\debug\\ty.exe")], "trace": Object {"server": String("messages")}} })]
```

But I am not sure I used the correct way to retrieve the settings and which one to choose. For example, I see there is a `request_workspace_configurations` in `main_loop.rs` but don't know how I can access it. So I duplicated some code to retrieve the settings for INFO WORKSPACES. And after, we will have to apply them to the session. I imagine with `session.apply_changes()`

TLDR: 
My goals by opening this draft PR:
- Is my implementation of didChangeConfiguration notification is correct?
- help to handle the server response and discuss the best strategy (gather client settings, change session settings).

I hope I am helping you by opening this draft PR, not complicating your work. You can tell me, no offense taken.
## Test Plan

Not relevant for the moment.
