### PR TITLE
[`airflow`]: rename `AutoImport` as `Rename` (internal)

### DIFF
--- a/crates/ruff_linter/src/rules/airflow/helpers.rs
+++ b/crates/ruff_linter/src/rules/airflow/helpers.rs
@@ -17,13 +17,13 @@ use ruff_text_size::TextRange;
 pub(crate) enum Replacement {
     // There's no replacement or suggestion other than removal
     None,
+    // Additional information. Used when there's no direct maaping replacement.
+    Message(&'static str),
     // The attribute name of a class has been changed.
     AttrName(&'static str),
-    // Additional information. Used when there's replacement but they're not direct mapping.
-    Message(&'static str),
     // Symbols updated in Airflow 3 with replacement
     // e.g., `airflow.datasets.Dataset` to `airflow.sdk.Asset`
-    AutoImport {
+    Rename {
         module: &'static str,
         name: &'static str,
     },
@@ -37,7 +37,7 @@ pub(crate) enum Replacement {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum ProviderReplacement {
-    AutoImport {
+    Rename {
         module: &'static str,
         name: &'static str,
         provider: &'static str,

--- a/crates/ruff_linter/src/rules/airflow/rules/moved_to_provider_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/moved_to_provider_in_3.rs
@@ -50,7 +50,7 @@ impl Violation for Airflow3MovedToProvider<'_> {
             replacement,
         } = self;
         match replacement {
-            ProviderReplacement::AutoImport {
+            ProviderReplacement::Rename {
                 name: _,
                 module: _,
                 provider,
@@ -70,7 +70,7 @@ impl Violation for Airflow3MovedToProvider<'_> {
     fn fix_title(&self) -> Option<String> {
         let Airflow3MovedToProvider { replacement, .. } = self;
         if let Some((module, name, provider, version)) = match &replacement {
-            ProviderReplacement::AutoImport {
+            ProviderReplacement::Rename {
                 module,
                 name,
                 provider,
@@ -125,20 +125,18 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             provider: "amazon",
             version: "1.0.0",
         },
-        ["airflow", "operators", "gcs_to_s3", "GCSToS3Operator"] => {
-            ProviderReplacement::AutoImport {
-                module: "airflow.providers.amazon.aws.transfers.gcs_to_s3",
-                name: "GCSToS3Operator",
-                provider: "amazon",
-                version: "1.0.0",
-            }
-        }
+        ["airflow", "operators", "gcs_to_s3", "GCSToS3Operator"] => ProviderReplacement::Rename {
+            module: "airflow.providers.amazon.aws.transfers.gcs_to_s3",
+            name: "GCSToS3Operator",
+            provider: "amazon",
+            version: "1.0.0",
+        },
         [
             "airflow",
             "operators",
             "google_api_to_s3_transfer",
             "GoogleApiToS3Operator" | "GoogleApiToS3Transfer",
-        ] => ProviderReplacement::AutoImport {
+        ] => ProviderReplacement::Rename {
             module: "airflow.providers.amazon.aws.transfers.google_api_to_s3",
             name: "GoogleApiToS3Operator",
             provider: "amazon",
@@ -149,7 +147,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             "operators",
             "redshift_to_s3_operator",
             "RedshiftToS3Operator" | "RedshiftToS3Transfer",
-        ] => ProviderReplacement::AutoImport {
+        ] => ProviderReplacement::Rename {
             module: "airflow.providers.amazon.aws.transfers.redshift_to_s3",
             name: "RedshiftToS3Operator",
             provider: "amazon",
@@ -160,7 +158,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             "operators",
             "s3_file_transform_operator",
             "S3FileTransformOperator",
-        ] => ProviderReplacement::AutoImport {
+        ] => ProviderReplacement::Rename {
             module: "airflow.providers.amazon.aws.operators.s3",
             name: "S3FileTransformOperator",
             provider: "amazon",
@@ -171,13 +169,13 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             "operators",
             "s3_to_redshift_operator",
             "S3ToRedshiftOperator" | "S3ToRedshiftTransfer",
-        ] => ProviderReplacement::AutoImport {
+        ] => ProviderReplacement::Rename {
             module: "airflow.providers.amazon.aws.transfers.s3_to_redshift",
             name: "S3ToRedshiftOperator",
             provider: "amazon",
             version: "1.0.0",
         },
-        ["airflow", "sensors", "s3_key_sensor", "S3KeySensor"] => ProviderReplacement::AutoImport {
+        ["airflow", "sensors", "s3_key_sensor", "S3KeySensor"] => ProviderReplacement::Rename {
             module: "airflow.providers.amazon.aws.sensors.s3",
             name: "S3KeySensor",
             provider: "amazon",
@@ -190,20 +188,20 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             "config_templates",
             "default_celery",
             "DEFAULT_CELERY_CONFIG",
-        ] => ProviderReplacement::AutoImport {
+        ] => ProviderReplacement::Rename {
             module: "airflow.providers.celery.executors.default_celery",
             name: "DEFAULT_CELERY_CONFIG",
             provider: "celery",
             version: "3.3.0",
         },
         ["airflow", "executors", "celery_executor", rest] => match *rest {
-            "app" => ProviderReplacement::AutoImport {
+            "app" => ProviderReplacement::Rename {
                 module: "airflow.providers.celery.executors.celery_executor_utils",
                 name: "app",
                 provider: "celery",
                 version: "3.3.0",
             },
-            "CeleryExecutor" => ProviderReplacement::AutoImport {
+            "CeleryExecutor" => ProviderReplacement::Rename {
                 module: "airflow.providers.celery.executors.celery_executor",
                 name: "CeleryExecutor",
                 provider: "celery",
@@ -216,7 +214,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             "executors",
             "celery_kubernetes_executor",
             "CeleryKubernetesExecutor",
-        ] => ProviderReplacement::AutoImport {
+        ] => ProviderReplacement::Rename {
             module: "airflow.providers.celery.executors.celery_kubernetes_executor",
             name: "CeleryKubernetesExecutor",
             provider: "celery",
@@ -235,7 +233,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             provider: "common-sql",
             version: "1.0.0",
         },
-        ["airflow", "hooks", "dbapi_hook", "DbApiHook"] => ProviderReplacement::AutoImport {
+        ["airflow", "hooks", "dbapi_hook", "DbApiHook"] => ProviderReplacement::Rename {
             module: "airflow.providers.common.sql.hooks.sql",
             name: "DbApiHook",
             provider: "common-sql",
@@ -252,7 +250,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             "operators",
             "check_operator" | "druid_check_operator" | "presto_check_operator",
             "CheckOperator",
-        ] => ProviderReplacement::AutoImport {
+        ] => ProviderReplacement::Rename {
             module: "airflow.providers.common.sql.operators.sql",
             name: "SQLCheckOperator",
             provider: "common-sql",
@@ -269,7 +267,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             "operators",
             "presto_check_operator",
             "PrestoCheckOperator",
-        ] => ProviderReplacement::AutoImport {
+        ] => ProviderReplacement::Rename {
             module: "airflow.providers.common.sql.operators.sql",
             name: "SQLCheckOperator",
             provider: "common-sql",
@@ -288,7 +286,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             "IntervalCheckOperator",
         ]
         | ["airflow", "operators", "sql", "SQLIntervalCheckOperator"] => {
-            ProviderReplacement::AutoImport {
+            ProviderReplacement::Rename {
                 module: "airflow.providers.common.sql.operators.sql",
                 name: "SQLIntervalCheckOperator",
                 provider: "common-sql",
@@ -300,7 +298,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             "operators",
             "presto_check_operator",
             "PrestoIntervalCheckOperator",
-        ] => ProviderReplacement::AutoImport {
+        ] => ProviderReplacement::Rename {
             module: "airflow.providers.common.sql.operators.sql",
             name: "SQLIntervalCheckOperator",
             provider: "common-sql",
@@ -313,7 +311,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             "SQLThresholdCheckOperator" | "ThresholdCheckOperator",
         ]
         | ["airflow", "operators", "sql", "SQLThresholdCheckOperator"] => {
-            ProviderReplacement::AutoImport {
+            ProviderReplacement::Rename {
                 module: "airflow.providers.common.sql.operators.sql",
                 name: "SQLThresholdCheckOperator",
                 provider: "common-sql",
@@ -332,20 +330,18 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             "presto_check_operator",
             "ValueCheckOperator",
         ]
-        | ["airflow", "operators", "sql", "SQLValueCheckOperator"] => {
-            ProviderReplacement::AutoImport {
-                module: "airflow.providers.common.sql.operators.sql",
-                name: "SQLValueCheckOperator",
-                provider: "common-sql",
-                version: "1.1.0",
-            }
-        }
+        | ["airflow", "operators", "sql", "SQLValueCheckOperator"] => ProviderReplacement::Rename {
+            module: "airflow.providers.common.sql.operators.sql",
+            name: "SQLValueCheckOperator",
+            provider: "common-sql",
+            version: "1.1.0",
+        },
         [
             "airflow",
             "operators",
             "presto_check_operator",
             "PrestoValueCheckOperator",
-        ] => ProviderReplacement::AutoImport {
+        ] => ProviderReplacement::Rename {
             module: "airflow.providers.common.sql.operators.sql",
             name: "SQLValueCheckOperator",
             provider: "common-sql",
@@ -370,14 +366,12 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             }
             _ => return,
         },
-        ["airflow", "sensors", "sql" | "sql_sensor", "SqlSensor"] => {
-            ProviderReplacement::AutoImport {
-                module: "airflow.providers.common.sql.sensors.sql",
-                name: "SqlSensor",
-                provider: "common-sql",
-                version: "1.0.0",
-            }
-        }
+        ["airflow", "sensors", "sql" | "sql_sensor", "SqlSensor"] => ProviderReplacement::Rename {
+            module: "airflow.providers.common.sql.sensors.sql",
+            name: "SqlSensor",
+            provider: "common-sql",
+            version: "1.0.0",
+        },
         ["airflow", "operators", "jdbc_operator", "JdbcOperator"]
         | ["airflow", "operators", "mssql_operator", "MsSqlOperator"]
         | ["airflow", "operators", "mysql_operator", "MySqlOperator"]
@@ -389,7 +383,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             "PostgresOperator",
         ]
         | ["airflow", "operators", "sqlite_operator", "SqliteOperator"] => {
-            ProviderReplacement::AutoImport {
+            ProviderReplacement::Rename {
                 module: "airflow.providers.common.sql.operators.sql",
                 name: "SQLExecuteQueryOperator",
                 provider: "common-sql",
@@ -398,24 +392,22 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
         }
 
         // apache-airflow-providers-daskexecutor
-        ["airflow", "executors", "dask_executor", "DaskExecutor"] => {
-            ProviderReplacement::AutoImport {
-                module: "airflow.providers.daskexecutor.executors.dask_executor",
-                name: "DaskExecutor",
-                provider: "daskexecutor",
-                version: "1.0.0",
-            }
-        }
+        ["airflow", "executors", "dask_executor", "DaskExecutor"] => ProviderReplacement::Rename {
+            module: "airflow.providers.daskexecutor.executors.dask_executor",
+            name: "DaskExecutor",
+            provider: "daskexecutor",
+            version: "1.0.0",
+        },
 
         // apache-airflow-providers-docker
-        ["airflow", "hooks", "docker_hook", "DockerHook"] => ProviderReplacement::AutoImport {
+        ["airflow", "hooks", "docker_hook", "DockerHook"] => ProviderReplacement::Rename {
             module: "airflow.providers.docker.hooks.docker",
             name: "DockerHook",
             provider: "docker",
             version: "1.0.0",
         },
         ["airflow", "operators", "docker_operator", "DockerOperator"] => {
-            ProviderReplacement::AutoImport {
+            ProviderReplacement::Rename {
                 module: "airflow.providers.docker.operators.docker",
                 name: "DockerOperator",
                 provider: "docker",
@@ -440,7 +432,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             "operators",
             "hive_to_druid",
             "HiveToDruidOperator" | "HiveToDruidTransfer",
-        ] => ProviderReplacement::AutoImport {
+        ] => ProviderReplacement::Rename {
             module: "airflow.providers.apache.druid.transfers.hive_to_druid",
             name: "HiveToDruidOperator",
             provider: "apache-druid",
@@ -497,7 +489,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             "fab",
             "fab_auth_manager",
             "FabAuthManager",
-        ] => ProviderReplacement::AutoImport {
+        ] => ProviderReplacement::Rename {
             module: "airflow.providers.fab.auth_manager.fab_auth_manager",
             name: "FabAuthManager",
             provider: "fab",
@@ -511,7 +503,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             "security_manager",
             "override",
             "MAX_NUM_DATABASE_USER_SESSIONS",
-        ] => ProviderReplacement::AutoImport {
+        ] => ProviderReplacement::Rename {
             module: "airflow.providers.fab.auth_manager.security_manager.override",
             name: "MAX_NUM_DATABASE_USER_SESSIONS",
             provider: "fab",
@@ -531,7 +523,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             "www",
             "security",
             "FabAirflowSecurityManagerOverride",
-        ] => ProviderReplacement::AutoImport {
+        ] => ProviderReplacement::Rename {
             module: "airflow.providers.fab.auth_manager.security_manager.override",
             name: "FabAirflowSecurityManagerOverride",
             provider: "fab",
@@ -539,20 +531,18 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
         },
 
         // apache-airflow-providers-apache-hdfs
-        ["airflow", "hooks", "webhdfs_hook", "WebHDFSHook"] => ProviderReplacement::AutoImport {
+        ["airflow", "hooks", "webhdfs_hook", "WebHDFSHook"] => ProviderReplacement::Rename {
             module: "airflow.providers.apache.hdfs.hooks.webhdfs",
             name: "WebHDFSHook",
             provider: "apache-hdfs",
             version: "1.0.0",
         },
-        ["airflow", "sensors", "web_hdfs_sensor", "WebHdfsSensor"] => {
-            ProviderReplacement::AutoImport {
-                module: "airflow.providers.apache.hdfs.sensors.web_hdfs",
-                name: "WebHdfsSensor",
-                provider: "apache-hdfs",
-                version: "1.0.0",
-            }
-        }
+        ["airflow", "sensors", "web_hdfs_sensor", "WebHdfsSensor"] => ProviderReplacement::Rename {
+            module: "airflow.providers.apache.hdfs.sensors.web_hdfs",
+            name: "WebHdfsSensor",
+            provider: "apache-hdfs",
+            version: "1.0.0",
+        },
 
         // apache-airflow-providers-apache-hive
         [
@@ -580,20 +570,18 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             provider: "apache-hive",
             version: "5.1.0",
         },
-        ["airflow", "operators", "hive_operator", "HiveOperator"] => {
-            ProviderReplacement::AutoImport {
-                module: "airflow.providers.apache.hive.operators.hive",
-                name: "HiveOperator",
-                provider: "apache-hive",
-                version: "1.0.0",
-            }
-        }
+        ["airflow", "operators", "hive_operator", "HiveOperator"] => ProviderReplacement::Rename {
+            module: "airflow.providers.apache.hive.operators.hive",
+            name: "HiveOperator",
+            provider: "apache-hive",
+            version: "1.0.0",
+        },
         [
             "airflow",
             "operators",
             "hive_stats_operator",
             "HiveStatsCollectionOperator",
-        ] => ProviderReplacement::AutoImport {
+        ] => ProviderReplacement::Rename {
             module: "airflow.providers.apache.hive.operators.hive_stats",
             name: "HiveStatsCollectionOperator",
             provider: "apache-hive",
@@ -604,7 +592,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             "operators",
             "hive_to_mysql",
             "HiveToMySqlOperator" | "HiveToMySqlTransfer",
-        ] => ProviderReplacement::AutoImport {
+        ] => ProviderReplacement::Rename {
             module: "airflow.providers.apache.hive.transfers.hive_to_mysql",
             name: "HiveToMySqlOperator",
             provider: "apache-hive",
@@ -615,7 +603,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             "operators",
             "hive_to_samba_operator",
             "HiveToSambaOperator",
-        ] => ProviderReplacement::AutoImport {
+        ] => ProviderReplacement::Rename {
             module: "airflow.providers.apache.hive.transfers.hive_to_samba",
             name: "HiveToSambaOperator",
             provider: "apache-hive",
@@ -626,7 +614,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             "operators",
             "mssql_to_hive",
             "MsSqlToHiveOperator" | "MsSqlToHiveTransfer",
-        ] => ProviderReplacement::AutoImport {
+        ] => ProviderReplacement::Rename {
             module: "airflow.providers.apache.hive.transfers.mssql_to_hive",
             name: "MsSqlToHiveOperator",
             provider: "apache-hive",
@@ -637,7 +625,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             "operators",
             "mysql_to_hive",
             "MySqlToHiveOperator" | "MySqlToHiveTransfer",
-        ] => ProviderReplacement::AutoImport {
+        ] => ProviderReplacement::Rename {
             module: "airflow.providers.apache.hive.transfers.mysql_to_hive",
             name: "MySqlToHiveOperator",
             provider: "apache-hive",
@@ -648,7 +636,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             "operators",
             "s3_to_hive_operator",
             "S3ToHiveOperator" | "S3ToHiveTransfer",
-        ] => ProviderReplacement::AutoImport {
+        ] => ProviderReplacement::Rename {
             module: "airflow.providers.apache.hive.transfers.s3_to_hive",
             name: "S3ToHiveOperator",
             provider: "apache-hive",
@@ -659,7 +647,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             "sensors",
             "hive_partition_sensor",
             "HivePartitionSensor",
-        ] => ProviderReplacement::AutoImport {
+        ] => ProviderReplacement::Rename {
             module: "airflow.providers.apache.hive.sensors.hive_partition",
             name: "HivePartitionSensor",
             provider: "apache-hive",
@@ -670,7 +658,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             "sensors",
             "metastore_partition_sensor",
             "MetastorePartitionSensor",
-        ] => ProviderReplacement::AutoImport {
+        ] => ProviderReplacement::Rename {
             module: "airflow.providers.apache.hive.sensors.metastore_partition",
             name: "MetastorePartitionSensor",
             provider: "apache-hive",
@@ -681,7 +669,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             "sensors",
             "named_hive_partition_sensor",
             "NamedHivePartitionSensor",
-        ] => ProviderReplacement::AutoImport {
+        ] => ProviderReplacement::Rename {
             module: "airflow.providers.apache.hive.sensors.named_hive_partition",
             name: "NamedHivePartitionSensor",
             provider: "apache-hive",
@@ -689,7 +677,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
         },
 
         // apache-airflow-providers-http
-        ["airflow", "hooks", "http_hook", "HttpHook"] => ProviderReplacement::AutoImport {
+        ["airflow", "hooks", "http_hook", "HttpHook"] => ProviderReplacement::Rename {
             module: "airflow.providers.http.hooks.http",
             name: "HttpHook",
             provider: "http",
@@ -700,13 +688,13 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             "operators",
             "http_operator",
             "SimpleHttpOperator",
-        ] => ProviderReplacement::AutoImport {
+        ] => ProviderReplacement::Rename {
             module: "airflow.providers.http.operators.http",
             name: "HttpOperator",
             provider: "http",
             version: "5.0.0",
         },
-        ["airflow", "sensors", "http_sensor", "HttpSensor"] => ProviderReplacement::AutoImport {
+        ["airflow", "sensors", "http_sensor", "HttpSensor"] => ProviderReplacement::Rename {
             module: "airflow.providers.http.sensors.http",
             name: "HttpSensor",
             provider: "http",
@@ -765,7 +753,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             "kubernetes",
             "kubernetes_helper_functions",
             "add_pod_suffix",
-        ] => ProviderReplacement::AutoImport {
+        ] => ProviderReplacement::Rename {
             module: "airflow.providers.cncf.kubernetes.kubernetes_helper_functions",
             name: "add_unique_suffix",
             provider: "cncf-kubernetes",
@@ -776,7 +764,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             "kubernetes",
             "kubernetes_helper_functions",
             "create_pod_id",
-        ] => ProviderReplacement::AutoImport {
+        ] => ProviderReplacement::Rename {
             module: "airflow.providers.cncf.kubernetes.kubernetes_helper_functions",
             name: "create_unique_id",
             provider: "cncf-kubernetes",
@@ -797,13 +785,13 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             version: "7.4.0",
         },
         ["airflow", "kubernetes", "pod", rest] => match *rest {
-            "Port" => ProviderReplacement::AutoImport {
+            "Port" => ProviderReplacement::Rename {
                 module: "kubernetes.client.models",
                 name: "V1ContainerPort",
                 provider: "cncf-kubernetes",
                 version: "7.4.0",
             },
-            "Resources" => ProviderReplacement::AutoImport {
+            "Resources" => ProviderReplacement::Rename {
                 module: "kubernetes.client.models",
                 name: "V1ResourceRequirements",
                 provider: "cncf-kubernetes",
@@ -823,19 +811,19 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
                 provider: "cncf-kubernetes",
                 version: "7.4.0",
             },
-            "PodDefaults" => ProviderReplacement::AutoImport {
+            "PodDefaults" => ProviderReplacement::Rename {
                 module: "airflow.providers.cncf.kubernetes.utils.xcom_sidecar",
                 name: "PodDefaults",
                 provider: "cncf-kubernetes",
                 version: "7.4.0",
             },
-            "PodGeneratorDeprecated" => ProviderReplacement::AutoImport {
+            "PodGeneratorDeprecated" => ProviderReplacement::Rename {
                 module: "airflow.providers.cncf.kubernetes.pod_generator",
                 name: "PodGenerator",
                 provider: "cncf-kubernetes",
                 version: "7.4.0",
             },
-            "add_pod_suffix" => ProviderReplacement::AutoImport {
+            "add_pod_suffix" => ProviderReplacement::Rename {
                 module: "airflow.providers.cncf.kubernetes.kubernetes_helper_functions",
                 name: "add_unique_suffix",
                 provider: "cncf-kubernetes",
@@ -865,7 +853,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             "kubernetes",
             "pod_generator_deprecated" | "pod_launcher_deprecated",
             "PodDefaults",
-        ] => ProviderReplacement::AutoImport {
+        ] => ProviderReplacement::Rename {
             module: "airflow.providers.cncf.kubernetes.utils.xcom_sidecar",
             name: "PodDefaults",
             provider: "cncf-kubernetes",
@@ -876,7 +864,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             "kubernetes",
             "pod_launcher_deprecated",
             "get_kube_client",
-        ] => ProviderReplacement::AutoImport {
+        ] => ProviderReplacement::Rename {
             module: "airflow.providers.cncf.kubernetes.kube_client",
             name: "get_kube_client",
             provider: "cncf-kubernetes",
@@ -887,7 +875,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             "kubernetes",
             "pod_launcher" | "pod_launcher_deprecated",
             "PodLauncher",
-        ] => ProviderReplacement::AutoImport {
+        ] => ProviderReplacement::Rename {
             module: "airflow.providers.cncf.kubernetes.utils.pod_manager",
             name: "PodManager",
             provider: "cncf-kubernetes",
@@ -898,7 +886,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             "kubernetes",
             "pod_launcher" | "pod_launcher_deprecated",
             "PodStatus",
-        ] => ProviderReplacement::AutoImport {
+        ] => ProviderReplacement::Rename {
             module: " airflow.providers.cncf.kubernetes.utils.pod_manager",
             name: "PodPhase",
             provider: "cncf-kubernetes",
@@ -909,20 +897,20 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             "kubernetes",
             "pod_runtime_info_env",
             "PodRuntimeInfoEnv",
-        ] => ProviderReplacement::AutoImport {
+        ] => ProviderReplacement::Rename {
             module: "kubernetes.client.models",
             name: "V1EnvVar",
             provider: "cncf-kubernetes",
             version: "7.4.0",
         },
         ["airflow", "kubernetes", "secret", rest] => match *rest {
-            "K8SModel" => ProviderReplacement::AutoImport {
+            "K8SModel" => ProviderReplacement::Rename {
                 module: "airflow.providers.cncf.kubernetes.k8s_model",
                 name: "K8SModel",
                 provider: "cncf-kubernetes",
                 version: "7.4.0",
             },
-            "Secret" => ProviderReplacement::AutoImport {
+            "Secret" => ProviderReplacement::Rename {
                 module: "airflow.providers.cncf.kubernetes.secret",
                 name: "Secret",
                 provider: "cncf-kubernetes",
@@ -930,23 +918,21 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             },
             _ => return,
         },
-        ["airflow", "kubernetes", "volume", "Volume"] => ProviderReplacement::AutoImport {
+        ["airflow", "kubernetes", "volume", "Volume"] => ProviderReplacement::Rename {
             module: "kubernetes.client.models",
             name: "V1Volume",
             provider: "cncf-kubernetes",
             version: "7.4.0",
         },
-        ["airflow", "kubernetes", "volume_mount", "VolumeMount"] => {
-            ProviderReplacement::AutoImport {
-                module: "kubernetes.client.models",
-                name: "V1VolumeMount",
-                provider: "cncf-kubernetes",
-                version: "7.4.0",
-            }
-        }
+        ["airflow", "kubernetes", "volume_mount", "VolumeMount"] => ProviderReplacement::Rename {
+            module: "kubernetes.client.models",
+            name: "V1VolumeMount",
+            provider: "cncf-kubernetes",
+            version: "7.4.0",
+        },
 
         // apache-airflow-providers-microsoft-mssql
-        ["airflow", "hooks", "mssql_hook", "MsSqlHook"] => ProviderReplacement::AutoImport {
+        ["airflow", "hooks", "mssql_hook", "MsSqlHook"] => ProviderReplacement::Rename {
             module: "airflow.providers.microsoft.mssql.hooks.mssql",
             name: "MsSqlHook",
             provider: "microsoft-mssql",
@@ -954,7 +940,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
         },
 
         // apache-airflow-providers-mysql
-        ["airflow", "hooks", "mysql_hook", "MySqlHook"] => ProviderReplacement::AutoImport {
+        ["airflow", "hooks", "mysql_hook", "MySqlHook"] => ProviderReplacement::Rename {
             module: "airflow.providers.mysql.hooks.mysql",
             name: "MySqlHook",
             provider: "mysql",
@@ -965,7 +951,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             "operators",
             "presto_to_mysql",
             "PrestoToMySqlOperator" | "PrestoToMySqlTransfer",
-        ] => ProviderReplacement::AutoImport {
+        ] => ProviderReplacement::Rename {
             module: "airflow.providers.mysql.transfers.presto_to_mysql",
             name: "PrestoToMySqlOperator",
             provider: "mysql",
@@ -973,7 +959,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
         },
 
         // apache-airflow-providers-oracle
-        ["airflow", "hooks", "oracle_hook", "OracleHook"] => ProviderReplacement::AutoImport {
+        ["airflow", "hooks", "oracle_hook", "OracleHook"] => ProviderReplacement::Rename {
             module: "airflow.providers.oracle.hooks.oracle",
             name: "OracleHook",
             provider: "oracle",
@@ -986,7 +972,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             "operators",
             "papermill_operator",
             "PapermillOperator",
-        ] => ProviderReplacement::AutoImport {
+        ] => ProviderReplacement::Rename {
             module: "airflow.providers.papermill.operators.papermill",
             name: "PapermillOperator",
             provider: "papermill",
@@ -994,23 +980,21 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
         },
 
         // apache-airflow-providers-apache-pig
-        ["airflow", "hooks", "pig_hook", "PigCliHook"] => ProviderReplacement::AutoImport {
+        ["airflow", "hooks", "pig_hook", "PigCliHook"] => ProviderReplacement::Rename {
             module: "airflow.providers.apache.pig.hooks.pig",
             name: "PigCliHook",
             provider: "apache-pig",
             version: "1.0.0",
         },
-        ["airflow", "operators", "pig_operator", "PigOperator"] => {
-            ProviderReplacement::AutoImport {
-                module: "airflow.providers.apache.pig.operators.pig",
-                name: "PigOperator",
-                provider: "apache-pig",
-                version: "1.0.0",
-            }
-        }
+        ["airflow", "operators", "pig_operator", "PigOperator"] => ProviderReplacement::Rename {
+            module: "airflow.providers.apache.pig.operators.pig",
+            name: "PigOperator",
+            provider: "apache-pig",
+            version: "1.0.0",
+        },
 
         // apache-airflow-providers-postgres
-        ["airflow", "hooks", "postgres_hook", "PostgresHook"] => ProviderReplacement::AutoImport {
+        ["airflow", "hooks", "postgres_hook", "PostgresHook"] => ProviderReplacement::Rename {
             module: "airflow.providers.postgres.hooks.postgres",
             name: "PostgresHook",
             provider: "postgres",
@@ -1018,7 +1002,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
         },
 
         // apache-airflow-providers-presto
-        ["airflow", "hooks", "presto_hook", "PrestoHook"] => ProviderReplacement::AutoImport {
+        ["airflow", "hooks", "presto_hook", "PrestoHook"] => ProviderReplacement::Rename {
             module: "airflow.providers.presto.hooks.presto",
             name: "PrestoHook",
             provider: "presto",
@@ -1026,7 +1010,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
         },
 
         // apache-airflow-providers-samba
-        ["airflow", "hooks", "samba_hook", "SambaHook"] => ProviderReplacement::AutoImport {
+        ["airflow", "hooks", "samba_hook", "SambaHook"] => ProviderReplacement::Rename {
             module: "airflow.providers.samba.hooks.samba",
             name: "SambaHook",
             provider: "samba",
@@ -1034,7 +1018,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
         },
 
         // apache-airflow-providers-slack
-        ["airflow", "hooks", "slack_hook", "SlackHook"] => ProviderReplacement::AutoImport {
+        ["airflow", "hooks", "slack_hook", "SlackHook"] => ProviderReplacement::Rename {
             module: "airflow.providers.slack.hooks.slack",
             name: "SlackHook",
             provider: "slack",
@@ -1058,7 +1042,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             "operators",
             "email_operator" | "email",
             "EmailOperator",
-        ] => ProviderReplacement::AutoImport {
+        ] => ProviderReplacement::Rename {
             module: "airflow.providers.smtp.operators.smtp",
             name: "EmailOperator",
             provider: "smtp",
@@ -1066,7 +1050,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
         },
 
         // apache-airflow-providers-sqlite
-        ["airflow", "hooks", "sqlite_hook", "SqliteHook"] => ProviderReplacement::AutoImport {
+        ["airflow", "hooks", "sqlite_hook", "SqliteHook"] => ProviderReplacement::Rename {
             module: "airflow.providers.sqlite.hooks.sqlite",
             name: "SqliteHook",
             provider: "sqlite",
@@ -1074,7 +1058,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
         },
 
         // apache-airflow-providers-zendesk
-        ["airflow", "hooks", "zendesk_hook", "ZendeskHook"] => ProviderReplacement::AutoImport {
+        ["airflow", "hooks", "zendesk_hook", "ZendeskHook"] => ProviderReplacement::Rename {
             module: "airflow.providers.zendesk.hooks.zendesk",
             name: "ZendeskHook",
             provider: "zendesk",
@@ -1093,14 +1077,12 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             provider: "standard",
             version: "0.0.3",
         },
-        ["airflow", "operators", "bash_operator", "BashOperator"] => {
-            ProviderReplacement::AutoImport {
-                module: "airflow.providers.standard.operators.bash",
-                name: "BashOperator",
-                provider: "standard",
-                version: "0.0.1",
-            }
-        }
+        ["airflow", "operators", "bash_operator", "BashOperator"] => ProviderReplacement::Rename {
+            module: "airflow.providers.standard.operators.bash",
+            name: "BashOperator",
+            provider: "standard",
+            version: "0.0.1",
+        },
         [
             "airflow",
             "operators",
@@ -1117,14 +1099,14 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             "operators",
             "trigger_dagrun",
             "TriggerDagRunLink",
-        ] => ProviderReplacement::AutoImport {
+        ] => ProviderReplacement::Rename {
             module: "airflow.providers.standard.operators.trigger_dagrun",
             name: "TriggerDagRunLink",
             provider: "standard",
             version: "0.0.2",
         },
         ["airflow", "operators", "datetime", "target_times_as_dates"] => {
-            ProviderReplacement::AutoImport {
+            ProviderReplacement::Rename {
                 module: "airflow.providers.standard.operators.datetime",
                 name: "target_times_as_dates",
                 provider: "standard",
@@ -1136,7 +1118,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             "operators",
             "dummy" | "dummy_operator",
             "EmptyOperator" | "DummyOperator",
-        ] => ProviderReplacement::AutoImport {
+        ] => ProviderReplacement::Rename {
             module: "airflow.providers.standard.operators.empty",
             name: "EmptyOperator",
             provider: "standard",
@@ -1147,7 +1129,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             "operators",
             "latest_only_operator",
             "LatestOnlyOperator",
-        ] => ProviderReplacement::AutoImport {
+        ] => ProviderReplacement::Rename {
             module: "airflow.providers.standard.operators.latest_only",
             name: "LatestOnlyOperator",
             provider: "standard",
@@ -1172,7 +1154,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             "sensors",
             "external_task" | "external_task_sensor",
             "ExternalTaskSensorLink",
-        ] => ProviderReplacement::AutoImport {
+        ] => ProviderReplacement::Rename {
             module: "airflow.providers.standard.sensors.external_task",
             name: "ExternalDagLink",
             provider: "standard",
@@ -1189,7 +1171,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             provider: "standard",
             version: "0.0.3",
         },
-        ["airflow", "sensors", "time_delta", "WaitSensor"] => ProviderReplacement::AutoImport {
+        ["airflow", "sensors", "time_delta", "WaitSensor"] => ProviderReplacement::Rename {
             module: "airflow.providers.standard.sensors.time_delta",
             name: "WaitSensor",
             provider: "standard",
@@ -1200,7 +1182,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
     };
 
     let (module, name) = match &replacement {
-        ProviderReplacement::AutoImport { module, name, .. } => (module, *name),
+        ProviderReplacement::Rename { module, name, .. } => (module, *name),
         ProviderReplacement::SourceModuleMovedToProvider { module, name, .. } => {
             (module, name.as_str())
         }

--- a/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
@@ -59,7 +59,7 @@ impl Violation for Airflow3Removal {
             Replacement::None
             | Replacement::AttrName(_)
             | Replacement::Message(_)
-            | Replacement::AutoImport { module: _, name: _ }
+            | Replacement::Rename { module: _, name: _ }
             | Replacement::SourceModuleMoved { module: _, name: _ } => {
                 format!("`{deprecated}` is removed in Airflow 3.0")
             }
@@ -72,7 +72,7 @@ impl Violation for Airflow3Removal {
             Replacement::None => None,
             Replacement::AttrName(name) => Some(format!("Use `{name}` instead")),
             Replacement::Message(message) => Some((*message).to_string()),
-            Replacement::AutoImport { module, name } => {
+            Replacement::Rename { module, name } => {
                 Some(format!("Use `{name}` from `{module}` instead."))
             }
             Replacement::SourceModuleMoved { module, name } => {
@@ -593,7 +593,7 @@ fn check_name(checker: &Checker, expr: &Expr, range: TextRange) {
             "api_connexion",
             "security",
             "requires_access_dataset",
-        ] => Replacement::AutoImport {
+        ] => Replacement::Rename {
             module: "airflow.api_fastapi.core_api.security",
             name: "requires_access_asset",
         },
@@ -605,7 +605,7 @@ fn check_name(checker: &Checker, expr: &Expr, range: TextRange) {
             "managers",
             "base_auth_manager",
             "BaseAuthManager",
-        ] => Replacement::AutoImport {
+        ] => Replacement::Rename {
             module: "airflow.api_fastapi.auth.managers.base_auth_manager",
             name: "BaseAuthManager",
         },
@@ -616,7 +616,7 @@ fn check_name(checker: &Checker, expr: &Expr, range: TextRange) {
             "models",
             "resource_details",
             "DatasetDetails",
-        ] => Replacement::AutoImport {
+        ] => Replacement::Rename {
             module: "airflow.api_fastapi.auth.managers.models.resource_details",
             name: "AssetDetails",
         },
@@ -639,15 +639,15 @@ fn check_name(checker: &Checker, expr: &Expr, range: TextRange) {
 
         // airflow.datasets.manager
         ["airflow", "datasets", "manager", rest] => match *rest {
-            "DatasetManager" => Replacement::AutoImport {
+            "DatasetManager" => Replacement::Rename {
                 module: "airflow.assets.manager",
                 name: "AssetManager",
             },
-            "dataset_manager" => Replacement::AutoImport {
+            "dataset_manager" => Replacement::Rename {
                 module: "airflow.assets.manager",
                 name: "asset_manager",
             },
-            "resolve_dataset_manager" => Replacement::AutoImport {
+            "resolve_dataset_manager" => Replacement::Rename {
                 module: "airflow.assets.manager",
                 name: "resolve_asset_manager",
             },
@@ -657,24 +657,24 @@ fn check_name(checker: &Checker, expr: &Expr, range: TextRange) {
         ["airflow", "datasets", "DatasetAliasEvent"] => Replacement::None,
 
         // airflow.hooks
-        ["airflow", "hooks", "base_hook", "BaseHook"] => Replacement::AutoImport {
+        ["airflow", "hooks", "base_hook", "BaseHook"] => Replacement::Rename {
             module: "airflow.hooks.base",
             name: "BaseHook",
         },
 
         // airflow.lineage.hook
-        ["airflow", "lineage", "hook", "DatasetLineageInfo"] => Replacement::AutoImport {
+        ["airflow", "lineage", "hook", "DatasetLineageInfo"] => Replacement::Rename {
             module: "airflow.lineage.hook",
             name: "AssetLineageInfo",
         },
 
         // airflow.listeners.spec
         ["airflow", "listeners", "spec", "dataset", rest] => match *rest {
-            "on_dataset_created" => Replacement::AutoImport {
+            "on_dataset_created" => Replacement::Rename {
                 module: "airflow.listeners.spec.asset",
                 name: "on_asset_created",
             },
-            "on_dataset_changed" => Replacement::AutoImport {
+            "on_dataset_changed" => Replacement::Rename {
                 module: "airflow.listeners.spec.asset",
                 name: "on_asset_changed",
             },
@@ -683,11 +683,11 @@ fn check_name(checker: &Checker, expr: &Expr, range: TextRange) {
 
         // airflow.metrics.validators
         ["airflow", "metrics", "validators", rest] => match *rest {
-            "AllowListValidator" => Replacement::AutoImport {
+            "AllowListValidator" => Replacement::Rename {
                 module: "airflow.metrics.validators",
                 name: "PatternAllowListValidator",
             },
-            "BlockListValidator" => Replacement::AutoImport {
+            "BlockListValidator" => Replacement::Rename {
                 module: "airflow.metrics.validators",
                 name: "PatternBlockListValidator",
             },
@@ -695,7 +695,7 @@ fn check_name(checker: &Checker, expr: &Expr, range: TextRange) {
         },
 
         // airflow.notifications
-        ["airflow", "notifications", "basenotifier", "BaseNotifier"] => Replacement::AutoImport {
+        ["airflow", "notifications", "basenotifier", "BaseNotifier"] => Replacement::Rename {
             module: "airflow.sdk.bases.notifier",
             name: "BaseNotifier",
         },
@@ -705,23 +705,23 @@ fn check_name(checker: &Checker, expr: &Expr, range: TextRange) {
             Replacement::Message("The whole `airflow.subdag` module has been removed.")
         }
         ["airflow", "operators", "postgres_operator", "Mapping"] => Replacement::None,
-        ["airflow", "operators", "python", "get_current_context"] => Replacement::AutoImport {
+        ["airflow", "operators", "python", "get_current_context"] => Replacement::Rename {
             module: "airflow.sdk",
             name: "get_current_context",
         },
 
         // airflow.secrets
-        ["airflow", "secrets", "cache", "SecretCache"] => Replacement::AutoImport {
+        ["airflow", "secrets", "cache", "SecretCache"] => Replacement::Rename {
             module: "airflow.sdk",
             name: "SecretCache",
         },
-        ["airflow", "secrets", "local_filesystem", "load_connections"] => Replacement::AutoImport {
+        ["airflow", "secrets", "local_filesystem", "load_connections"] => Replacement::Rename {
             module: "airflow.secrets.local_filesystem",
             name: "load_connections_dict",
         },
 
         // airflow.security
-        ["airflow", "security", "permissions", "RESOURCE_DATASET"] => Replacement::AutoImport {
+        ["airflow", "security", "permissions", "RESOURCE_DATASET"] => Replacement::Rename {
             module: "airflow.security.permissions",
             name: "RESOURCE_ASSET",
         },
@@ -732,7 +732,7 @@ fn check_name(checker: &Checker, expr: &Expr, range: TextRange) {
             "sensors",
             "base_sensor_operator",
             "BaseSensorOperator",
-        ] => Replacement::AutoImport {
+        ] => Replacement::Rename {
             module: "airflow.sdk.bases.sensor",
             name: "BaseSensorOperator",
         },
@@ -743,7 +743,7 @@ fn check_name(checker: &Checker, expr: &Expr, range: TextRange) {
             "timetables",
             "simple",
             "DatasetTriggeredTimetable",
-        ] => Replacement::AutoImport {
+        ] => Replacement::Rename {
             module: "airflow.timetables.simple",
             name: "AssetTriggeredTimetable",
         },
@@ -775,25 +775,25 @@ fn check_name(checker: &Checker, expr: &Expr, range: TextRange) {
             ] => Replacement::None,
 
             // airflow.utils.file
-            ["file", "TemporaryDirectory"] => Replacement::AutoImport {
+            ["file", "TemporaryDirectory"] => Replacement::Rename {
                 module: "tempfile",
                 name: "TemporaryDirectory",
             },
             ["file", "mkdirs"] => Replacement::Message("Use `pathlib.Path({path}).mkdir` instead"),
 
             // airflow.utils.helpers
-            ["helpers", "chain"] => Replacement::AutoImport {
+            ["helpers", "chain"] => Replacement::Rename {
                 module: "airflow.sdk",
                 name: "chain",
             },
-            ["helpers", "cross_downstream"] => Replacement::AutoImport {
+            ["helpers", "cross_downstream"] => Replacement::Rename {
                 module: "airflow.sdk",
                 name: "cross_downstream",
             },
 
             // TODO: update it as SourceModuleMoved
             // airflow.utils.log.secrets_masker
-            ["log", "secrets_masker"] => Replacement::AutoImport {
+            ["log", "secrets_masker"] => Replacement::Rename {
                 module: "airflow.sdk.execution_time",
                 name: "secrets_masker",
             },
@@ -834,15 +834,15 @@ fn check_name(checker: &Checker, expr: &Expr, range: TextRange) {
             "s3",
             rest,
         ] => match *rest {
-            "create_dataset" => Replacement::AutoImport {
+            "create_dataset" => Replacement::Rename {
                 module: "airflow.providers.amazon.aws.assets.s3",
                 name: "create_asset",
             },
-            "convert_dataset_to_openlineage" => Replacement::AutoImport {
+            "convert_dataset_to_openlineage" => Replacement::Rename {
                 module: "airflow.providers.amazon.aws.assets.s3",
                 name: "convert_asset_to_openlineage",
             },
-            "sanitize_uri" => Replacement::AutoImport {
+            "sanitize_uri" => Replacement::Rename {
                 module: "airflow.providers.amazon.aws.assets.s3",
                 name: "sanitize_uri",
             },
@@ -858,7 +858,7 @@ fn check_name(checker: &Checker, expr: &Expr, range: TextRange) {
             "entities",
             "AvpEntities",
             "DATASET",
-        ] => Replacement::AutoImport {
+        ] => Replacement::Rename {
             module: "airflow.providers.amazon.aws.auth_manager.avp.entities",
             name: "AvpEntities.ASSET",
         },
@@ -874,15 +874,15 @@ fn check_name(checker: &Checker, expr: &Expr, range: TextRange) {
             "file",
             rest,
         ] => match *rest {
-            "create_dataset" => Replacement::AutoImport {
+            "create_dataset" => Replacement::Rename {
                 module: "airflow.providers.common.io.assets.file",
                 name: "create_asset",
             },
-            "convert_dataset_to_openlineage" => Replacement::AutoImport {
+            "convert_dataset_to_openlineage" => Replacement::Rename {
                 module: "airflow.providers.common.io.assets.file",
                 name: "convert_asset_to_openlineage",
             },
-            "sanitize_uri" => Replacement::AutoImport {
+            "sanitize_uri" => Replacement::Rename {
                 module: "airflow.providers.common.io.assets.file",
                 name: "sanitize_uri",
             },
@@ -892,19 +892,19 @@ fn check_name(checker: &Checker, expr: &Expr, range: TextRange) {
         // airflow.providers.google
         // airflow.providers.google.datasets
         ["airflow", "providers", "google", "datasets", rest @ ..] => match &rest {
-            ["bigquery", "create_dataset"] => Replacement::AutoImport {
+            ["bigquery", "create_dataset"] => Replacement::Rename {
                 module: "airflow.providers.google.assets.bigquery",
                 name: "create_asset",
             },
-            ["gcs", "create_dataset"] => Replacement::AutoImport {
+            ["gcs", "create_dataset"] => Replacement::Rename {
                 module: "airflow.providers.google.assets.gcs",
                 name: "create_asset",
             },
-            ["gcs", "convert_dataset_to_openlineage"] => Replacement::AutoImport {
+            ["gcs", "convert_dataset_to_openlineage"] => Replacement::Rename {
                 module: "airflow.providers.google.assets.gcs",
                 name: "convert_asset_to_openlineage",
             },
-            ["gcs", "sanitize_uri"] => Replacement::AutoImport {
+            ["gcs", "sanitize_uri"] => Replacement::Rename {
                 module: "airflow.providers.google.assets.gcs",
                 name: "sanitize_uri",
             },
@@ -920,7 +920,7 @@ fn check_name(checker: &Checker, expr: &Expr, range: TextRange) {
             "datasets",
             "mysql",
             "sanitize_uri",
-        ] => Replacement::AutoImport {
+        ] => Replacement::Rename {
             module: "airflow.providers.mysql.assets.mysql",
             name: "sanitize_uri",
         },
@@ -933,7 +933,7 @@ fn check_name(checker: &Checker, expr: &Expr, range: TextRange) {
             "datasets",
             "postgres",
             "sanitize_uri",
-        ] => Replacement::AutoImport {
+        ] => Replacement::Rename {
             module: "airflow.providers.postgres.assets.postgres",
             name: "sanitize_uri",
         },
@@ -948,12 +948,12 @@ fn check_name(checker: &Checker, expr: &Expr, range: TextRange) {
             "utils",
             rest,
         ] => match *rest {
-            "DatasetInfo" => Replacement::AutoImport {
+            "DatasetInfo" => Replacement::Rename {
                 module: "airflow.providers.openlineage.utils.utils",
                 name: "AssetInfo",
             },
 
-            "translate_airflow_dataset" => Replacement::AutoImport {
+            "translate_airflow_dataset" => Replacement::Rename {
                 module: "airflow.providers.openlineage.utils.utils",
                 name: "translate_airflow_asset",
             },
@@ -968,7 +968,7 @@ fn check_name(checker: &Checker, expr: &Expr, range: TextRange) {
             "datasets",
             "trino",
             "sanitize_uri",
-        ] => Replacement::AutoImport {
+        ] => Replacement::Rename {
             module: "airflow.providers.trino.assets.trino",
             name: "sanitize_uri",
         },
@@ -977,7 +977,7 @@ fn check_name(checker: &Checker, expr: &Expr, range: TextRange) {
     };
 
     let (module, name) = match &replacement {
-        Replacement::AutoImport { module, name } => (module, *name),
+        Replacement::Rename { module, name } => (module, *name),
         Replacement::SourceModuleMoved { module, name } => (module, name.as_str()),
         _ => {
             checker.report_diagnostic(

--- a/crates/ruff_linter/src/rules/airflow/rules/suggested_to_move_to_provider_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/suggested_to_move_to_provider_in_3.rs
@@ -65,7 +65,7 @@ impl Violation for Airflow3SuggestedToMoveToProvider<'_> {
             replacement,
         } = self;
         match replacement {
-            ProviderReplacement::AutoImport {
+            ProviderReplacement::Rename {
                 name: _,
                 module: _,
                 provider,
@@ -88,7 +88,7 @@ impl Violation for Airflow3SuggestedToMoveToProvider<'_> {
     fn fix_title(&self) -> Option<String> {
         let Airflow3SuggestedToMoveToProvider { replacement, .. } = self;
         match replacement {
-            ProviderReplacement::AutoImport {
+            ProviderReplacement::Rename {
                 module,
                 name,
                 provider,
@@ -130,34 +130,32 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
 
     let replacement = match qualified_name.segments() {
         // apache-airflow-providers-standard
-        ["airflow", "hooks", "filesystem", "FSHook"] => ProviderReplacement::AutoImport {
+        ["airflow", "hooks", "filesystem", "FSHook"] => ProviderReplacement::Rename {
             module: "airflow.providers.standard.hooks.filesystem",
             name: "FSHook",
             provider: "standard",
             version: "0.0.1",
         },
-        ["airflow", "hooks", "package_index", "PackageIndexHook"] => {
-            ProviderReplacement::AutoImport {
-                module: "airflow.providers.standard.hooks.package_index",
-                name: "PackageIndexHook",
-                provider: "standard",
-                version: "0.0.1",
-            }
-        }
-        ["airflow", "hooks", "subprocess", "SubprocessHook"] => ProviderReplacement::AutoImport {
+        ["airflow", "hooks", "package_index", "PackageIndexHook"] => ProviderReplacement::Rename {
+            module: "airflow.providers.standard.hooks.package_index",
+            name: "PackageIndexHook",
+            provider: "standard",
+            version: "0.0.1",
+        },
+        ["airflow", "hooks", "subprocess", "SubprocessHook"] => ProviderReplacement::Rename {
             module: "airflow.providers.standard.hooks.subprocess",
             name: "SubprocessHook",
             provider: "standard",
             version: "0.0.3",
         },
-        ["airflow", "operators", "bash", "BashOperator"] => ProviderReplacement::AutoImport {
+        ["airflow", "operators", "bash", "BashOperator"] => ProviderReplacement::Rename {
             module: "airflow.providers.standard.operators.bash",
             name: "BashOperator",
             provider: "standard",
             version: "0.0.1",
         },
         ["airflow", "operators", "datetime", "BranchDateTimeOperator"] => {
-            ProviderReplacement::AutoImport {
+            ProviderReplacement::Rename {
                 module: "airflow.providers.standard.operators.datetime",
                 name: "BranchDateTimeOperator",
                 provider: "standard",
@@ -169,20 +167,20 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             "operators",
             "trigger_dagrun",
             "TriggerDagRunOperator",
-        ] => ProviderReplacement::AutoImport {
+        ] => ProviderReplacement::Rename {
             module: "airflow.providers.standard.operators.trigger_dagrun",
             name: "TriggerDagRunOperator",
             provider: "standard",
             version: "0.0.2",
         },
-        ["airflow", "operators", "empty", "EmptyOperator"] => ProviderReplacement::AutoImport {
+        ["airflow", "operators", "empty", "EmptyOperator"] => ProviderReplacement::Rename {
             module: "airflow.providers.standard.operators.empty",
             name: "EmptyOperator",
             provider: "standard",
             version: "0.0.2",
         },
         ["airflow", "operators", "latest_only", "LatestOnlyOperator"] => {
-            ProviderReplacement::AutoImport {
+            ProviderReplacement::Rename {
                 module: "airflow.providers.standard.operators.latest_only",
                 name: "LatestOnlyOperator",
                 provider: "standard",
@@ -204,14 +202,14 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             version: "0.0.1",
         },
         ["airflow", "operators", "weekday", "BranchDayOfWeekOperator"] => {
-            ProviderReplacement::AutoImport {
+            ProviderReplacement::Rename {
                 module: "airflow.providers.standard.operators.weekday",
                 name: "BranchDayOfWeekOperator",
                 provider: "standard",
                 version: "0.0.1",
             }
         }
-        ["airflow", "sensors", "bash", "BashSensor"] => ProviderReplacement::AutoImport {
+        ["airflow", "sensors", "bash", "BashSensor"] => ProviderReplacement::Rename {
             module: "airflow.providers.standard.sensor.bash",
             name: "BashSensor",
             provider: "standard",
@@ -239,13 +237,13 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             provider: "standard",
             version: "0.0.3",
         },
-        ["airflow", "sensors", "filesystem", "FileSensor"] => ProviderReplacement::AutoImport {
+        ["airflow", "sensors", "filesystem", "FileSensor"] => ProviderReplacement::Rename {
             module: "airflow.providers.standard.sensors.filesystem",
             name: "FileSensor",
             provider: "standard",
             version: "0.0.2",
         },
-        ["airflow", "sensors", "python", "PythonSensor"] => ProviderReplacement::AutoImport {
+        ["airflow", "sensors", "python", "PythonSensor"] => ProviderReplacement::Rename {
             module: "airflow.providers.standard.sensors.python",
             name: "PythonSensor",
             provider: "standard",
@@ -273,7 +271,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             provider: "standard",
             version: "0.0.1",
         },
-        ["airflow", "sensors", "weekday", "DayOfWeekSensor"] => ProviderReplacement::AutoImport {
+        ["airflow", "sensors", "weekday", "DayOfWeekSensor"] => ProviderReplacement::Rename {
             module: "airflow.providers.standard.sensors.weekday",
             name: "DayOfWeekSensor",
             provider: "standard",
@@ -290,7 +288,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
             provider: "standard",
             version: "0.0.3",
         },
-        ["airflow", "triggers", "file", "FileTrigger"] => ProviderReplacement::AutoImport {
+        ["airflow", "triggers", "file", "FileTrigger"] => ProviderReplacement::Rename {
             module: "airflow.providers.standard.triggers.file",
             name: "FileTrigger",
             provider: "standard",
@@ -311,7 +309,7 @@ fn check_names_moved_to_provider(checker: &Checker, expr: &Expr, ranged: TextRan
     };
 
     let (module, name) = match &replacement {
-        ProviderReplacement::AutoImport { module, name, .. } => (module, *name),
+        ProviderReplacement::Rename { module, name, .. } => (module, *name),
         ProviderReplacement::SourceModuleMovedToProvider { module, name, .. } => {
             (module, name.as_str())
         }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Since we are trying to import both `AutoImport` and `SourceModuleMoved`, the previous naming was not as descriptive. Renaming it to `Rename` better reflects the intention.

## Test Plan

<!-- How was it tested? -->

no functionality change
