### PR TITLE
[ty] WIP: handle recursive type inference properly

### DIFF
--- a/crates/ruff_benchmark/benches/ty_walltime.rs
+++ b/crates/ruff_benchmark/benches/ty_walltime.rs
@@ -164,7 +164,7 @@ static PANDAS: std::sync::LazyLock<Benchmark<'static>> = std::sync::LazyLock::ne
             max_dep_date: "2025-06-17",
             python_version: PythonVersion::PY312,
         },
-        3000,
+        3300,
     )
 });
 
@@ -199,7 +199,8 @@ static SYMPY: std::sync::LazyLock<Benchmark<'static>> = std::sync::LazyLock::new
             max_dep_date: "2025-06-17",
             python_version: PythonVersion::PY312,
         },
-        13000,
+        // TODO: With better decorator support, `__slots__` support, etc., it should be possible to reduce the number of errors considerably.
+        70000,
     )
 });
 

--- a/crates/ty_python_semantic/resources/corpus/cycle_into_callable.py
+++ b/crates/ty_python_semantic/resources/corpus/cycle_into_callable.py
@@ -1,0 +1,17 @@
+# Regression test for https://github.com/astral-sh/ruff/issues/17371
+# panicked in commit d1088545a08aeb57b67ec1e3a7f5141159efefa5
+# error message:
+# dependency graph cycle when querying ClassType < 'db >::into_callable_(Id(1c00))
+
+try:
+    class foo[T: bar](object):
+        pass
+    bar = foo
+except Exception:
+    bar = lambda: 0
+def bar():
+    pass
+
+@bar()
+class bar:
+    pass

--- a/crates/ty_python_semantic/resources/corpus/divergent.py
+++ b/crates/ty_python_semantic/resources/corpus/divergent.py
@@ -1,0 +1,69 @@
+def f(cond: bool):
+    if cond:
+        result = ()
+        result += (f(cond),)
+        return result
+
+    return None
+
+reveal_type(f(True))
+
+def f(cond: bool):
+    if cond:
+        result = ()
+        result += (f(cond),)
+        return result
+
+    return None
+
+def f(cond: bool):
+    result = None
+    if cond:
+        result = ()
+        result += (f(cond),)
+
+    return result
+
+reveal_type(f(True))
+
+def f(cond: bool):
+    result = None
+    if cond:
+        result = [f(cond) for _ in range(1)]
+
+    return result
+
+reveal_type(f(True))
+
+class Foo:
+    def value(self):
+        return 1
+
+def unwrap(value):
+    if isinstance(value, Foo):
+        foo = value
+        return foo.value()
+    elif type(value) is tuple:
+        length = len(value)
+        if length == 0:
+            return ()
+        elif length == 1:
+            return (unwrap(value[0]),)
+        else:
+            result = []
+            for item in value:
+                result.append(unwrap(item))
+            return tuple(result)
+    else:
+        raise TypeError()
+
+def descent(x: int, y: int):
+    if x > y:
+        y, x = descent(y, x)
+        return x, y
+    if x == 1:
+        return (1, 0)
+    if y == 1:
+        return (0, 1)
+    else:
+        return descent(x-1, y-1)

--- a/crates/ty_python_semantic/resources/mdtest/annotations/invalid.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/invalid.md
@@ -79,7 +79,9 @@ def outer_sync():  # `yield` from is only valid syntax inside a synchronous func
         a: (yield from [1]),  # error: [invalid-type-form] "`yield from` expressions are not allowed in type expressions"
     ): ...
 
-async def baz(): ...
+async def baz():
+    yield
+
 async def outer_async():  # avoid unrelated syntax errors on `yield` and `await`
     def _(
         a: 1,  # error: [invalid-type-form] "Int literals are not allowed in this context in a type expression"

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -2281,6 +2281,24 @@ class B:
 
 reveal_type(B().x)  # revealed: Unknown | Literal[1]
 reveal_type(A().x)  # revealed: Unknown | Literal[1]
+
+class Base:
+    def flip(self) -> "Sub":
+        return Sub()
+
+class Sub(Base):
+    # TODO invalid override error
+    def flip(self) -> "Base":
+        return Base()
+
+class C2:
+    def __init__(self, x: Sub):
+        self.x = x
+
+    def replace_with(self, other: "C2"):
+        self.x = other.x.flip()
+
+reveal_type(C2(Sub()).x)  # revealed: Unknown | Base
 ```
 
 This case additionally tests our union/intersection simplification logic:

--- a/crates/ty_python_semantic/resources/mdtest/call/union.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/union.md
@@ -111,7 +111,7 @@ def _(flag: bool):
 
     # error: [call-non-callable] "Object of type `Literal["This is a string literal"]` is not callable"
     x = f(3)
-    reveal_type(x)  # revealed: Unknown
+    reveal_type(x)  # revealed: None | Unknown
 ```
 
 ## Union of binding errors
@@ -128,7 +128,7 @@ def _(flag: bool):
     # error: [too-many-positional-arguments] "Too many positional arguments to function `f1`: expected 0, got 1"
     # error: [too-many-positional-arguments] "Too many positional arguments to function `f2`: expected 0, got 1"
     x = f(3)
-    reveal_type(x)  # revealed: Unknown
+    reveal_type(x)  # revealed: None
 ```
 
 ## One not-callable, one wrong argument
@@ -146,7 +146,7 @@ def _(flag: bool):
     # error: [too-many-positional-arguments] "Too many positional arguments to function `f1`: expected 0, got 1"
     # error: [call-non-callable] "Object of type `C` is not callable"
     x = f(3)
-    reveal_type(x)  # revealed: Unknown
+    reveal_type(x)  # revealed: None | Unknown
 ```
 
 ## Union including a special-cased function

--- a/crates/ty_python_semantic/resources/mdtest/cycle.md
+++ b/crates/ty_python_semantic/resources/mdtest/cycle.md
@@ -31,3 +31,28 @@ p = Point()
 reveal_type(p.x)  # revealed: Unknown | int
 reveal_type(p.y)  # revealed: Unknown | int
 ```
+
+## Self-referential bare type alias
+
+```py
+A = list["A" | None]
+
+def f(x: A):
+    # TODO: should be `list[A | None]`?
+    reveal_type(x)  # revealed: list[Divergent]
+    # TODO: should be `A | None`?
+    reveal_type(x[0])  # revealed: Divergent
+```
+
+## Self-referential type variables
+
+```py
+from typing import Generic, TypeVar
+
+B = TypeVar("B", bound="Base")
+
+# TODO: no error
+# error: [invalid-argument-type] "`typing.TypeVar | typing.TypeVar` is not a valid argument to `Generic`"
+class Base(Generic[B]):
+    pass
+```

--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/semantic_syntax_errors.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/semantic_syntax_errors.md
@@ -125,7 +125,8 @@ match obj:
 
 ```py
 class C:
-    def __await__(self): ...
+    def __await__(self):
+        yield
 
 # error: [invalid-syntax] "`return` statement outside of a function"
 return

--- a/crates/ty_python_semantic/resources/mdtest/function/return_type.md
+++ b/crates/ty_python_semantic/resources/mdtest/function/return_type.md
@@ -256,6 +256,331 @@ def f(cond: bool) -> int:
         return 2
 ```
 
+## Inferred return type
+
+### Free function
+
+If a function's return type is not annotated, it is inferred. The inferred type is the union of all
+possible return types.
+
+```py
+def f():
+    return 1
+
+reveal_type(f())  # revealed: Literal[1]
+# TODO: should be `def f() -> Literal[1]`
+reveal_type(f)  # revealed: def f() -> Unknown
+
+def g(cond: bool):
+    if cond:
+        return 1
+    else:
+        return "a"
+
+reveal_type(g(True))  # revealed: Literal[1, "a"]
+
+# This function implicitly returns `None`.
+def h(x: int, y: str):
+    if x > 10:
+        return x
+    elif x > 5:
+        return y
+
+reveal_type(h(1, "a"))  # revealed: int | str | None
+
+lambda_func = lambda: 1
+# TODO: lambda function type inference
+# Should be `Literal[1]`
+reveal_type(lambda_func())  # revealed: Unknown
+
+def generator():
+    yield 1
+    yield 2
+    return None
+
+# TODO: Should be `Generator[Literal[1, 2], Any, None]`
+reveal_type(generator())  # revealed: Unknown
+
+async def async_generator():
+    yield
+
+# TODO: Should be `AsyncGenerator[None, Any]`
+reveal_type(async_generator())  # revealed: Unknown
+
+async def coroutine():
+    return
+
+# TODO: Should be `CoroutineType[Any, Any, None]`
+reveal_type(coroutine())  # revealed: Unknown
+```
+
+The return type of a recursive function is also inferred. When the return type inference would
+diverge, it is truncated and replaced with the special dynamic type `Divergent`.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+def fibonacci(n: int):
+    if n == 0:
+        return 0
+    elif n == 1:
+        return 1
+    else:
+        return fibonacci(n - 1) + fibonacci(n - 2)
+
+reveal_type(fibonacci(5))  # revealed: int
+
+def even(n: int):
+    if n == 0:
+        return True
+    else:
+        return odd(n - 1)
+
+def odd(n: int):
+    if n == 0:
+        return False
+    else:
+        return even(n - 1)
+
+reveal_type(even(1))  # revealed: bool
+reveal_type(odd(1))  # revealed: bool
+
+def repeat_a(n: int):
+    if n <= 0:
+        return ""
+    else:
+        return repeat_a(n - 1) + "a"
+
+reveal_type(repeat_a(3))  # revealed: str
+
+def divergent(value):
+    if type(value) is tuple:
+        return (divergent(value[0]),)
+    else:
+        return None
+
+# tuple[tuple[tuple[...] | None] | None] | None => tuple[Divergent] | None
+reveal_type(divergent((1,)))  # revealed: tuple[Divergent] | None
+
+def call_divergent(x: int):
+    return (divergent((1, 2, 3)), x)
+
+reveal_type(call_divergent(1))  # revealed: tuple[tuple[Divergent] | None, int]
+
+def list1[T](x: T) -> list[T]:
+    return [x]
+
+def divergent2(value):
+    if type(value) is tuple:
+        return (divergent2(value[0]),)
+    elif type(value) is list:
+        return list1(divergent2(value[0]))
+    else:
+        return None
+
+reveal_type(divergent2((1,)))  # revealed: tuple[Divergent] | list[Divergent] | None
+
+def list_int(x: int):
+    if x > 0:
+        return list1(list_int(x - 1))
+    else:
+        return list1(x)
+
+# TODO: should be `list[int]`
+reveal_type(list_int(1))  # revealed: list[Divergent] | list[int]
+
+def tuple_obj(cond: bool):
+    if cond:
+        x = object()
+    else:
+        x = tuple_obj(cond)
+    return (x,)
+
+reveal_type(tuple_obj(True))  # revealed: tuple[object]
+
+def get_non_empty(node):
+    for child in node.children:
+        node = get_non_empty(child)
+        if node is not None:
+            return node
+    return None
+
+reveal_type(get_non_empty(None))  # revealed: (Divergent & ~None) | None
+
+def nested_scope():
+    def inner():
+        return nested_scope()
+    return inner()
+
+reveal_type(nested_scope())  # revealed: Never
+
+def eager_nested_scope():
+    class A:
+        x = eager_nested_scope()
+
+    return A.x
+
+reveal_type(eager_nested_scope())  # revealed: Unknown
+
+class C:
+    def flip(self) -> "D":
+        return D()
+
+class D(C):
+    # TODO invalid override error
+    def flip(self) -> "C":
+        return C()
+
+def c_or_d(n: int):
+    if n == 0:
+        return D()
+    else:
+        return c_or_d(n - 1).flip()
+
+# In fixed-point iteration of the return type inference, the return type is monotonically widened.
+# For example, once the return type of `c_or_d` is determined to be `C`,
+# it will never be determined to be a subtype `D` in the subsequent iterations.
+reveal_type(c_or_d(1))  # revealed: C
+```
+
+### Class method
+
+If a method's return type is not annotated, it is also inferred, but the inferred type is a union of
+all possible return types and `Unknown`. This is because a method of a class may be overridden by
+its subtypes. For example, if the return type of a method is inferred to be `int`, the type the
+coder really intended might be `int | None`, in which case it would be impossible for the overridden
+method to return `None`.
+
+```py
+class C:
+    def f(self):
+        return 1
+
+class D(C):
+    def f(self):
+        return None
+
+reveal_type(C().f())  # revealed: Literal[1] | Unknown
+reveal_type(D().f())  # revealed: None | Literal[1] | Unknown
+```
+
+However, in the following cases, `Unknown` is not included in the inferred return type because there
+is no ambiguity in the subclass.
+
+- The class or the method is marked as `final`.
+
+```py
+from typing import final
+
+@final
+class C:
+    def f(self):
+        return 1
+
+class D:
+    @final
+    def f(self):
+        return "a"
+
+reveal_type(C().f())  # revealed: Literal[1]
+reveal_type(D().f())  # revealed: Literal["a"]
+```
+
+- The method overrides the methods of the base classes, and the return types of the base class
+    methods are known (In this case, the return type of the method is the intersection of the return
+    types of the methods in the base classes).
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Literal
+
+class C:
+    def f(self) -> int:
+        return 1
+
+    def g[T](self, x: T) -> T:
+        return x
+
+    def h[T: int](self, x: T) -> T:
+        return x
+
+    def i[T: int](self, x: T) -> list[T]:
+        return [x]
+
+class D(C):
+    def f(self):
+        return 2
+    # TODO: This should be an invalid-override error.
+    def g(self, x: int):
+        return 2
+    # A strict application of the Liskov Substitution Principle would consider
+    # this an invalid override because it violates the guarantee that the method returns
+    # the same type as its input type (any type smaller than int),
+    # but neither mypy nor pyright will throw an error for this.
+    def h(self, x: int):
+        return 2
+
+    def i(self, x: int):
+        return [2]
+
+class E(D):
+    def f(self):
+        return 3
+
+reveal_type(C().f())  # revealed: int
+reveal_type(D().f())  # revealed: int
+reveal_type(E().f())  # revealed: int
+reveal_type(C().g(1))  # revealed: Literal[1]
+reveal_type(D().g(1))  # revealed: Literal[2] | Unknown
+reveal_type(C().h(1))  # revealed: Literal[1]
+reveal_type(D().h(1))  # revealed: Literal[2] | Unknown
+reveal_type(C().h(True))  # revealed: Literal[True]
+reveal_type(D().h(True))  # revealed: Literal[2] | Unknown
+reveal_type(C().i(1))  # revealed: list[Literal[1]]
+# TODO: better type for list elements
+reveal_type(D().i(1))  # revealed: list[Unknown | int] | list[Unknown]
+
+class F:
+    def f(self) -> Literal[1, 2]:
+        return 2
+
+class G:
+    def f(self) -> Literal[2, 3]:
+        return 2
+
+class H(F, G):
+    # TODO: should be an invalid-override error
+    def f(self):
+        raise NotImplementedError
+
+class I(F, G):
+    # TODO: should be an invalid-override error
+    @final
+    def f(self):
+        raise NotImplementedError
+
+# We use a return type of `F.f` according to the MRO.
+reveal_type(H().f())  # revealed: Literal[1, 2]
+reveal_type(I().f())  # revealed: Never
+
+class C2[T]:
+    def f(self, x: T) -> T:
+        return x
+
+class D2(C2[int]):
+    def f(self, x: int):
+        return x
+
+reveal_type(D2().f(1))  # revealed: int
+```
+
 ## Invalid return type
 
 <!-- snapshot-diagnostics -->

--- a/crates/ty_python_semantic/resources/mdtest/narrow/type.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/type.md
@@ -144,20 +144,25 @@ def _(x: A | B):
         reveal_type(x)  # revealed: A | B
 ```
 
-## No narrowing for custom `type` callable
+## No special narrowing for custom `type` callable
 
 ```py
+def type(x: object):
+    return int
+
 class A: ...
 class B: ...
 
-def type(x):
-    return int
-
 def _(x: A | B):
+    # The custom `type` function always returns `int`,
+    # so any branch other than `type(...) is int` is unreachable.
     if type(x) is A:
+        reveal_type(x)  # revealed: Never
+    # And the condition here is always `True` and has no effect on the narrowing of `x`.
+    elif type(x) is int:
         reveal_type(x)  # revealed: A | B
     else:
-        reveal_type(x)  # revealed: A | B
+        reveal_type(x)  # revealed: Never
 ```
 
 ## No narrowing for multiple arguments

--- a/crates/ty_python_semantic/src/dunder_all.rs
+++ b/crates/ty_python_semantic/src/dunder_all.rs
@@ -6,8 +6,8 @@ use ruff_python_ast::name::Name;
 use ruff_python_ast::statement_visitor::{StatementVisitor, walk_stmt};
 use ruff_python_ast::{self as ast};
 
-use crate::semantic_index::{SemanticIndex, semantic_index};
-use crate::types::{Truthiness, Type, TypeContext, infer_expression_types};
+use crate::semantic_index::global_scope;
+use crate::types::{Truthiness, Type, infer_scope_expression_type};
 use crate::{Db, ModuleName, resolve_module};
 
 #[allow(clippy::ref_option)]
@@ -31,8 +31,7 @@ pub(crate) fn dunder_all_names(db: &dyn Db, file: File) -> Option<FxHashSet<Name
     let _span = tracing::trace_span!("dunder_all_names", file=?file.path(db)).entered();
 
     let module = parsed_module(db, file).load(db);
-    let index = semantic_index(db, file);
-    let mut collector = DunderAllNamesCollector::new(db, file, index);
+    let mut collector = DunderAllNamesCollector::new(db, file);
     collector.visit_body(module.suite());
     collector.into_names()
 }
@@ -41,9 +40,6 @@ pub(crate) fn dunder_all_names(db: &dyn Db, file: File) -> Option<FxHashSet<Name
 struct DunderAllNamesCollector<'db> {
     db: &'db dyn Db,
     file: File,
-
-    /// The semantic index for the module.
-    index: &'db SemanticIndex<'db>,
 
     /// The origin of the `__all__` variable in the current module, [`None`] if it is not defined.
     origin: Option<DunderAllOrigin>,
@@ -57,11 +53,10 @@ struct DunderAllNamesCollector<'db> {
 }
 
 impl<'db> DunderAllNamesCollector<'db> {
-    fn new(db: &'db dyn Db, file: File, index: &'db SemanticIndex<'db>) -> Self {
+    fn new(db: &'db dyn Db, file: File) -> Self {
         Self {
             db,
             file,
-            index,
             origin: None,
             invalid: false,
             names: FxHashSet::default(),
@@ -182,8 +177,7 @@ impl<'db> DunderAllNamesCollector<'db> {
     ///
     /// This function panics if `expr` was not marked as a standalone expression during semantic indexing.
     fn standalone_expression_type(&self, expr: &ast::Expr) -> Type<'db> {
-        infer_expression_types(self.db, self.index.expression(expr), TypeContext::default())
-            .expression_type(expr)
+        infer_scope_expression_type(self.db, global_scope(self.db, self.file), expr)
     }
 
     /// Evaluate the given expression and return its truthiness.

--- a/crates/ty_python_semantic/src/semantic_index/scope.rs
+++ b/crates/ty_python_semantic/src/semantic_index/scope.rs
@@ -1,6 +1,9 @@
 use std::ops::Range;
 
-use ruff_db::{files::File, parsed::ParsedModuleRef};
+use ruff_db::{
+    files::File,
+    parsed::{ParsedModuleRef, parsed_module},
+};
 use ruff_index::newtype_index;
 use ruff_python_ast as ast;
 
@@ -26,6 +29,10 @@ pub struct ScopeId<'db> {
 impl get_size2::GetSize for ScopeId<'_> {}
 
 impl<'db> ScopeId<'db> {
+    pub(crate) fn is_non_lambda_function(self, db: &'db dyn Db) -> bool {
+        self.node(db).scope_kind().is_non_lambda_function()
+    }
+
     pub(crate) fn is_annotation(self, db: &'db dyn Db) -> bool {
         self.node(db).scope_kind().is_annotation()
     }
@@ -62,6 +69,18 @@ impl<'db> ScopeId<'db> {
             NodeWithScopeKind::DictComprehension(_) => "<dictcomp>",
             NodeWithScopeKind::GeneratorExpression(_) => "<generator>",
         }
+    }
+
+    pub(crate) fn is_coroutine_function(self, db: &'db dyn Db) -> bool {
+        let module = parsed_module(db, self.file(db)).load(db);
+        self.node(db)
+            .as_function()
+            .is_some_and(|func| func.node(&module).is_async && !self.is_generator_function(db))
+    }
+
+    pub(crate) fn is_generator_function(self, db: &'db dyn Db) -> bool {
+        let index = semantic_index(db, self.file(db));
+        self.file_scope_id(db).is_generator_function(index)
     }
 }
 

--- a/crates/ty_python_semantic/src/semantic_index/use_def.rs
+++ b/crates/ty_python_semantic/src/semantic_index/use_def.rs
@@ -590,7 +590,6 @@ impl<'db> UseDefMap<'db> {
             .map(|symbol_id| (symbol_id, self.end_of_scope_symbol_bindings(symbol_id)))
     }
 
-    /// This function is intended to be called only once inside `TypeInferenceBuilder::infer_function_body`.
     pub(crate) fn can_implicitly_return_none(&self, db: &dyn crate::Db) -> bool {
         !self
             .reachability_constraints

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -12,7 +12,7 @@ use crate::semantic_index::definition::Definition;
 use crate::semantic_index::scope::FileScopeId;
 use crate::semantic_index::semantic_index;
 use crate::types::ide_support::all_declarations_and_bindings;
-use crate::types::{Type, binding_type, infer_scope_types};
+use crate::types::{Type, binding_type, infer_scope_expression_type};
 
 pub struct SemanticModel<'db> {
     db: &'db dyn Db,
@@ -363,7 +363,7 @@ impl HasType for ast::ExprRef<'_> {
         let file_scope = index.expression_scope_id(self);
         let scope = file_scope.to_scope_id(model.db, model.file);
 
-        infer_scope_types(model.db, scope).expression_type(*self)
+        infer_scope_expression_type(model.db, scope, *self)
     }
 }
 

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -2720,10 +2720,15 @@ impl<'db> Binding<'db> {
                 }
             }
         }
+
         for (keywords_index, keywords_type) in keywords_arguments {
             matcher.match_keyword_variadic(db, keywords_index, keywords_type);
         }
-        self.return_ty = self.signature.return_ty.unwrap_or(Type::unknown());
+        self.return_ty = self.signature.return_ty.unwrap_or_else(|| {
+            self.callable_type
+                .infer_return_type(db)
+                .unwrap_or(Type::unknown())
+        });
         self.parameter_tys = vec![None; parameters.len()].into_boxed_slice();
         self.argument_matches = matcher.finish();
     }

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -4,8 +4,8 @@ use crate::types::generics::Specialization;
 use crate::types::tuple::TupleType;
 use crate::types::{
     ApplyTypeMappingVisitor, ClassLiteral, ClassType, DynamicType, KnownClass, KnownInstanceType,
-    MaterializationKind, MroError, MroIterator, NormalizedVisitor, SpecialFormType, Type,
-    TypeMapping, todo_type,
+    MaterializationKind, MroError, MroIterator, NormalizedVisitor, RecursiveTypeNormalizedVisitor,
+    SpecialFormType, Type, TypeMapping, todo_type,
 };
 
 /// Enumeration of the possible kinds of types we allow in class bases.
@@ -39,6 +39,18 @@ impl<'db> ClassBase<'db> {
         match self {
             Self::Dynamic(dynamic) => Self::Dynamic(dynamic.normalized()),
             Self::Class(class) => Self::Class(class.normalized_impl(db, visitor)),
+            Self::Protocol | Self::Generic | Self::TypedDict => self,
+        }
+    }
+
+    pub(super) fn recursive_type_normalized(
+        self,
+        db: &'db dyn Db,
+        visitor: &RecursiveTypeNormalizedVisitor<'db>,
+    ) -> Self {
+        match self {
+            Self::Dynamic(dynamic) => Self::Dynamic(dynamic.recursive_type_normalized()),
+            Self::Class(class) => Self::Class(class.recursive_type_normalized(db, visitor)),
             Self::Protocol | Self::Generic | Self::TypedDict => self,
         }
     }

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -7,25 +7,21 @@ use crate::types::diagnostic::{
     report_invalid_arguments_to_annotated, report_invalid_arguments_to_callable,
 };
 use crate::types::enums::is_enum_class;
-use crate::types::signatures::{CallableSignature, Signature};
+use crate::types::signatures::{CallableSignature, Parameter, Parameters, Signature};
 use crate::types::string_annotation::parse_string_annotation;
 use crate::types::tuple::{TupleSpecBuilder, TupleType};
 use crate::types::visitor::any_over_type;
 use crate::types::{
     CallableType, DynamicType, IntersectionBuilder, KnownClass, KnownInstanceType,
-    LintDiagnosticGuard, Parameter, Parameters, SpecialFormType, SubclassOfType, Type,
-    TypeAliasType, TypeContext, TypeIsType, UnionBuilder, UnionType, todo_type,
+    LintDiagnosticGuard, SpecialFormType, SubclassOfType, Type, TypeAliasType, TypeContext,
+    TypeIsType, UnionBuilder, UnionType, todo_type,
 };
 
 /// Type expressions
 impl<'db> TypeInferenceBuilder<'db, '_> {
     /// Infer the type of a type expression.
     pub(super) fn infer_type_expression(&mut self, expression: &ast::Expr) -> Type<'db> {
-        let mut ty = self.infer_type_expression_no_store(expression);
-        let divergent = Type::divergent(self.scope());
-        if ty.has_divergent_type(self.db(), divergent) {
-            ty = divergent;
-        }
+        let ty = self.infer_type_expression_no_store(expression);
         self.store_expression_type(expression, ty);
         ty
     }
@@ -550,7 +546,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         // we do not store types for sub-expressions. Re-infer the type here.
                         builder.infer_expression(value, TypeContext::default())
                     } else {
-                        builder.expression_type(value)
+                        builder.expression_type(value.as_ref())
                     };
 
                     value_ty == Type::SpecialForm(SpecialFormType::Unpack)

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -5,13 +5,43 @@ use crate::place::{ConsideredDefinitions, Place, global_symbol};
 use crate::semantic_index::definition::Definition;
 use crate::semantic_index::scope::FileScopeId;
 use crate::semantic_index::{global_scope, place_table, semantic_index, use_def_map};
-use crate::types::{KnownClass, KnownInstanceType, UnionType, check_types};
+use crate::types::function::FunctionType;
+use crate::types::{BoundMethodType, KnownClass, KnownInstanceType, UnionType, check_types};
 use ruff_db::diagnostic::Diagnostic;
 use ruff_db::files::{File, system_path_to_file};
 use ruff_db::system::DbWithWritableSystem as _;
 use ruff_db::testing::{assert_function_query_was_not_run, assert_function_query_was_run};
+use salsa::Database;
 
 use super::*;
+
+fn __() {
+    let _ = &Type::member_lookup_with_policy;
+    let _ = &Type::class_member_with_policy;
+    let _ = &FunctionType::infer_return_type;
+    let _ = &BoundMethodType::infer_return_type;
+    let _ = &ClassLiteral::implicit_attribute_inner;
+    let _ = &infer_expression_type_impl;
+    let _ = &infer_expression_types_impl;
+    let _ = &infer_definition_types;
+    let _ = &infer_scope_types;
+    let _ = &infer_unpack_types;
+}
+/// These queries refer to a value ​​from the previous cycle to ensure convergence.
+/// Therefore, even when convergence is apparent, they will cycle at least once.
+/// TODO: Is it possible to use the salsa API to get the value from the previous cycle (without doing anything if called for the first time)?
+const QUERIES_USE_PREVIOUS_CYCLE_VALUE: [&str; 10] = [
+    "Type < 'db >::member_lookup_with_policy_",
+    "Type < 'db >::class_member_with_policy_",
+    "FunctionType < 'db >::infer_return_type_",
+    "BoundMethodType < 'db >::infer_return_type_",
+    "ClassLiteral < 'db >::implicit_attribute_inner_",
+    "infer_expression_type_impl",
+    "infer_expression_types_impl",
+    "infer_definition_types",
+    "infer_scope_types",
+    "infer_unpack_types",
+];
 
 #[track_caller]
 fn get_symbol<'db>(
@@ -273,6 +303,12 @@ fn unbound_symbol_no_reachability_constraint_check() {
             .iter()
             .filter_map(|event| {
                 if let salsa::EventKind::WillIterateCycle { database_key, .. } = event.kind {
+                    if QUERIES_USE_PREVIOUS_CYCLE_VALUE.contains(
+                        &db.ingredient_debug_name(database_key.ingredient_index())
+                            .as_ref(),
+                    ) {
+                        return None;
+                    }
                     Some(format!("{database_key:?}"))
                 } else {
                     None
@@ -466,7 +502,6 @@ fn dependency_implicit_instance_attribute() -> anyhow::Result<()> {
         assert_eq!(attr_ty.display(&db).to_string(), "Unknown | str | None");
         db.take_salsa_events()
     };
-
     assert_function_query_was_not_run(
         &db,
         infer_expression_types_impl,
@@ -560,7 +595,6 @@ fn dependency_own_instance_member() -> anyhow::Result<()> {
         assert_eq!(attr_ty.display(&db).to_string(), "Unknown | str | None");
         db.take_salsa_events()
     };
-
     assert_function_query_was_not_run(
         &db,
         infer_expression_types_impl,
@@ -659,7 +693,6 @@ fn dependency_implicit_class_member() -> anyhow::Result<()> {
         assert_eq!(attr_ty.display(&db).to_string(), "Unknown | str");
         db.take_salsa_events()
     };
-
     assert_function_query_was_not_run(
         &db,
         infer_expression_types_impl,

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -507,7 +507,7 @@ impl<'a, 'db> ProtocolMember<'a, 'db> {
         self.qualifiers
     }
 
-    fn ty(&self) -> Type<'db> {
+    pub(super) fn ty(&self) -> Type<'db> {
         match &self.kind {
             ProtocolMemberKind::Method(callable) => Type::Callable(*callable),
             ProtocolMemberKind::Property(property) => Type::PropertyInstance(*property),

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -27,8 +27,8 @@ use crate::types::class::{ClassType, KnownClass};
 use crate::types::constraints::{ConstraintSet, IteratorConstraintsExtension};
 use crate::types::{
     ApplyTypeMappingVisitor, BoundTypeVarInstance, FindLegacyTypeVarsVisitor, HasRelationToVisitor,
-    IsDisjointVisitor, IsEquivalentVisitor, NormalizedVisitor, Type, TypeMapping, TypeRelation,
-    UnionBuilder, UnionType,
+    IsDisjointVisitor, IsEquivalentVisitor, NormalizedVisitor, RecursiveTypeNormalizedVisitor,
+    Type, TypeMapping, TypeRelation, UnionBuilder, UnionType,
 };
 use crate::util::subscript::{Nth, OutOfBoundsError, PyIndex, PySlice, StepSizeZeroError};
 use crate::{Db, FxOrderSet, Program};
@@ -228,6 +228,14 @@ impl<'db> TupleType<'db> {
         TupleType::new(db, &self.tuple(db).normalized_impl(db, visitor))
     }
 
+    pub(super) fn recursive_type_normalized(
+        self,
+        db: &'db dyn Db,
+        visitor: &RecursiveTypeNormalizedVisitor<'db>,
+    ) -> Self {
+        Self::new_internal(db, self.tuple(db).recursive_type_normalized(db, visitor))
+    }
+
     pub(crate) fn apply_type_mapping_impl<'a>(
         self,
         db: &'db dyn Db,
@@ -384,6 +392,18 @@ impl<'db> FixedLengthTuple<Type<'db>> {
     #[must_use]
     fn normalized_impl(&self, db: &'db dyn Db, visitor: &NormalizedVisitor<'db>) -> Self {
         Self::from_elements(self.0.iter().map(|ty| ty.normalized_impl(db, visitor)))
+    }
+
+    fn recursive_type_normalized(
+        &self,
+        db: &'db dyn Db,
+        visitor: &RecursiveTypeNormalizedVisitor<'db>,
+    ) -> Self {
+        Self::from_elements(
+            self.0
+                .iter()
+                .map(|ty| ty.recursive_type_normalized(db, visitor)),
+        )
     }
 
     fn apply_type_mapping_impl<'a>(
@@ -701,6 +721,29 @@ impl<'db> VariableLengthTuple<Type<'db>> {
             variable,
             suffix,
         })
+    }
+
+    fn recursive_type_normalized(
+        &self,
+        db: &'db dyn Db,
+        visitor: &RecursiveTypeNormalizedVisitor<'db>,
+    ) -> Self {
+        let prefix = self
+            .prefix
+            .iter()
+            .map(|ty| ty.recursive_type_normalized(db, visitor))
+            .collect::<Box<_>>();
+        let suffix = self
+            .suffix
+            .iter()
+            .map(|ty| ty.recursive_type_normalized(db, visitor))
+            .collect::<Box<_>>();
+        let variable = self.variable.recursive_type_normalized(db, visitor);
+        Self {
+            prefix,
+            variable,
+            suffix,
+        }
     }
 
     fn apply_type_mapping_impl<'a>(
@@ -1041,6 +1084,17 @@ impl<'db> Tuple<Type<'db>> {
         match self {
             Tuple::Fixed(tuple) => Tuple::Fixed(tuple.normalized_impl(db, visitor)),
             Tuple::Variable(tuple) => tuple.normalized_impl(db, visitor),
+        }
+    }
+
+    pub(super) fn recursive_type_normalized(
+        &self,
+        db: &'db dyn Db,
+        visitor: &RecursiveTypeNormalizedVisitor<'db>,
+    ) -> Self {
+        match self {
+            Tuple::Fixed(tuple) => Tuple::Fixed(tuple.recursive_type_normalized(db, visitor)),
+            Tuple::Variable(tuple) => Tuple::Variable(tuple.recursive_type_normalized(db, visitor)),
         }
     }
 

--- a/crates/ty_python_semantic/src/types/type_ordering.rs
+++ b/crates/ty_python_semantic/src/types/type_ordering.rs
@@ -253,7 +253,7 @@ pub(super) fn union_or_intersection_elements_ordering<'db>(
 }
 
 /// Determine a canonical order for two instances of [`DynamicType`].
-fn dynamic_elements_ordering(left: DynamicType, right: DynamicType) -> Ordering {
+fn dynamic_elements_ordering<'db>(left: DynamicType<'db>, right: DynamicType<'db>) -> Ordering {
     match (left, right) {
         (DynamicType::Any, _) => Ordering::Less,
         (_, DynamicType::Any) => Ordering::Greater,
@@ -276,9 +276,7 @@ fn dynamic_elements_ordering(left: DynamicType, right: DynamicType) -> Ordering 
         (DynamicType::TodoTypeAlias, _) => Ordering::Less,
         (_, DynamicType::TodoTypeAlias) => Ordering::Greater,
 
-        (DynamicType::Divergent(left), DynamicType::Divergent(right)) => {
-            left.scope.cmp(&right.scope)
-        }
+        (DynamicType::Divergent(left), DynamicType::Divergent(right)) => left.cmp(&right),
         (DynamicType::Divergent(_), _) => Ordering::Less,
         (_, DynamicType::Divergent(_)) => Ordering::Greater,
     }

--- a/crates/ty_python_semantic/src/unpack.rs
+++ b/crates/ty_python_semantic/src/unpack.rs
@@ -27,6 +27,7 @@ use crate::semantic_index::scope::{FileScopeId, ScopeId};
 /// * a field of a type that is a return type of a cross-module query
 /// * an argument of a cross-module query
 #[salsa::tracked(debug, heap_size=ruff_memory_usage::heap_size)]
+#[derive(PartialOrd, Ord)]
 pub(crate) struct Unpack<'db> {
     pub(crate) file: File,
 

--- a/crates/ty_python_semantic/tests/corpus.rs
+++ b/crates/ty_python_semantic/tests/corpus.rs
@@ -169,9 +169,6 @@ fn run_corpus_tests(pattern: &str) -> anyhow::Result<()> {
 /// Whether or not the .py/.pyi version of this file is expected to fail
 #[rustfmt::skip]
 const KNOWN_FAILURES: &[(&str, bool, bool)] = &[
-    // Fails with too-many-cycle-iterations due to a self-referential
-    // type alias, see https://github.com/astral-sh/ty/issues/256
-    ("crates/ruff_linter/resources/test/fixtures/pyflakes/F401_34.py", true, true),
 ];
 
 #[salsa::db]


### PR DESCRIPTION
## Summary

Derived from #17371

Fixes astral-sh/ty#256

Properly handles any kind of recursive inference and prevents panics.
The discussion in https://github.com/astral-sh/ruff/pull/17371#discussion_r2356324183 revealed that additional changes to the salsa API are required to complete this PR, and I will update this PR as soon as those changes are made.

The technique we used here to converge fixed-point iterations was roughly described in #17371, but will be properly documented in this PR.

## Test Plan
