### PR TITLE
[ty] Limit hack in protocol satisfiability to only apply to subtyping (not assignability)

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2016,16 +2016,21 @@ class NominalReturningSelfNotGeneric:
 # TODO: should pass
 static_assert(is_equivalent_to(LegacyFunctionScoped, NewStyleFunctionScoped))  # error: [static-assert-error]
 
+static_assert(is_assignable_to(NominalNewStyle, NewStyleFunctionScoped))
+static_assert(is_assignable_to(NominalNewStyle, LegacyFunctionScoped))
 static_assert(is_subtype_of(NominalNewStyle, NewStyleFunctionScoped))
 static_assert(is_subtype_of(NominalNewStyle, LegacyFunctionScoped))
 static_assert(not is_assignable_to(NominalNewStyle, UsesSelf))
 
+static_assert(is_assignable_to(NominalLegacy, NewStyleFunctionScoped))
+static_assert(is_assignable_to(NominalLegacy, LegacyFunctionScoped))
 static_assert(is_subtype_of(NominalLegacy, NewStyleFunctionScoped))
 static_assert(is_subtype_of(NominalLegacy, LegacyFunctionScoped))
 static_assert(not is_assignable_to(NominalLegacy, UsesSelf))
 
 static_assert(not is_assignable_to(NominalWithSelf, NewStyleFunctionScoped))
 static_assert(not is_assignable_to(NominalWithSelf, LegacyFunctionScoped))
+static_assert(is_assignable_to(NominalWithSelf, UsesSelf))
 static_assert(is_subtype_of(NominalWithSelf, UsesSelf))
 
 # TODO: these should pass
@@ -2035,8 +2040,23 @@ static_assert(not is_assignable_to(NominalNotGeneric, UsesSelf))
 
 static_assert(not is_assignable_to(NominalReturningSelfNotGeneric, NewStyleFunctionScoped))
 static_assert(not is_assignable_to(NominalReturningSelfNotGeneric, LegacyFunctionScoped))
+
 # TODO: should pass
 static_assert(not is_assignable_to(NominalReturningSelfNotGeneric, UsesSelf))  # error: [static-assert-error]
+
+# These test cases are taken from the typing conformance suite:
+class ShapeProtocolImplicitSelf(Protocol):
+    def set_scale(self, scale: float) -> Self: ...
+
+class ShapeProtocolExplicitSelf(Protocol):
+    def set_scale(self: Self, scale: float) -> Self: ...
+
+class BadReturnType:
+    def set_scale(self, scale: float) -> int:
+        return 42
+
+static_assert(not is_assignable_to(BadReturnType, ShapeProtocolImplicitSelf))
+static_assert(not is_assignable_to(BadReturnType, ShapeProtocolExplicitSelf))
 ```
 
 ## Subtyping of protocols with `@classmethod` or `@staticmethod` members

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -573,15 +573,17 @@ impl<'a, 'db> ProtocolMember<'a, 'db> {
 
                 let proto_member_as_bound_method = method.bind_self(db);
 
-                if any_over_type(
+                let relation = if any_over_type(
                     db,
                     proto_member_as_bound_method,
                     &|t| matches!(t, Type::TypeVar(_)),
                     true,
                 ) {
-                    // TODO: proper validation for generic methods on protocols
-                    return ConstraintSet::from(true);
-                }
+                    // TODO: proper subtyping validation for generic methods on protocols
+                    TypeRelation::Assignability
+                } else {
+                    relation
+                };
 
                 attribute_type.has_relation_to_impl(
                     db,


### PR DESCRIPTION
## Summary

Following https://github.com/astral-sh/ruff/commit/742f8a4ee6d0730c7eaec081c80babdabc62a8c6, we now do sometimes consider `Type::TypeVar`s to be assignable to other types, and other types to be assignable to `Type::TypeVar`s. That means that this hack in our protocol satisfiability logic is needed _less_ than it used to be: all tests (including some new ones) continue to pass if we apply the hack _only_ when the `relation` passed is `TypeRelation::Subtyping`

## Test Plan

`cargo test -p ty_python_semantic`
