### PR TITLE
[ty] Add more tests for subtyping/assignability between two protocol types

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/loops/for.md
+++ b/crates/ty_python_semantic/resources/mdtest/loops/for.md
@@ -228,6 +228,48 @@ def _(flag: bool):
         reveal_type(x)  # revealed: Result1A | Result1B | Result2A | Result2B | Result3 | Result4
 ```
 
+## Union type as iterable where `Iterator[]` is used as the return type of `__iter__`
+
+This test differs from the above tests in that `Iterator` (an abstract type) is used as the return
+annotation of the `__iter__` methods, rather than a concrete type being used as the return
+annotation.
+
+```py
+from typing import Iterator, Literal
+
+class IntIterator:
+    def __iter__(self) -> Iterator[int]:
+        return iter(range(42))
+
+class StrIterator:
+    def __iter__(self) -> Iterator[str]:
+        return iter("foo")
+
+def f(x: IntIterator | StrIterator):
+    for a in x:
+        # TODO: this should be `int | str` (https://github.com/astral-sh/ty/issues/1089)
+        reveal_type(a)  # revealed: int
+```
+
+Most real-world iterable types use `Iterator` as the return annotation of their `__iter__` methods:
+
+```py
+def g(
+    a: tuple[int, ...] | tuple[str, ...],
+    b: list[str] | list[int],
+    c: Literal["foo", b"bar"],
+):
+    for x in a:
+        # TODO: should be `int | str` (https://github.com/astral-sh/ty/issues/1089)
+        reveal_type(x)  # revealed: int
+    for y in b:
+        # TODO: should be `str | int` (https://github.com/astral-sh/ty/issues/1089)
+        reveal_type(y)  # revealed: str
+    for z in c:
+        # TODO: should be `LiteralString | int` (https://github.com/astral-sh/ty/issues/1089)
+        reveal_type(z)  # revealed: LiteralString
+```
+
 ## Union type as iterable where one union element has no `__iter__` method
 
 <!-- snapshot-diagnostics -->


### PR DESCRIPTION
## Summary

Currently we have lots of tests for subtyping and assignability where one type is nominal and the other type is a protocol type. However, we have few tests for subtyping/assignability between two types where both types are protocols, which is a different code path. This PR adds that missing test coverage.

Specifically, this PR:
- Adds missing tests for subtyping/assignability between two protocols with attribute members
- Adds missing tests for subtyping/assignability between two protocols with `@property` members
- Adds missing tests for subtyping/assignability between two protocols with method members
- Adds missing tests for subtyping/assignability (in both directions) between two protocols where one has a method member and the other has a `@property` member
- Adds missing tests for subtyping/assignability (in both directions) between two protocols where one has a method member and the other has an attribute member
- Adds missing tests for subtyping/assignability (in both directions) between two protocols where one has an attribute member and the other has a `@property` member
- Fixes some pre-existing bugs in our tests for protocols with `@property` members
- Adds regression tests for https://github.com/astral-sh/ty/issues/1089
