### PR TITLE
[`pylint`] Fix missing `max-nested-blocks` in settings display

### DIFF
--- a/crates/ruff/tests/lint.rs
+++ b/crates/ruff/tests/lint.rs
@@ -4762,6 +4762,7 @@ from typing import Union;foo: Union[int, str] = 1
         linter.pylint.max_statements = 50
         linter.pylint.max_public_methods = 20
         linter.pylint.max_locals = 15
+        linter.pylint.max_nested_blocks = 5
         linter.pyupgrade.keep_runtime_typing = false
         linter.ruff.parenthesize_tuple_in_subscript = false
 

--- a/crates/ruff/tests/lint.rs
+++ b/crates/ruff/tests/lint.rs
@@ -2445,6 +2445,7 @@ requires-python = ">= 3.11"
         linter.pylint.max_statements = 50
         linter.pylint.max_public_methods = 20
         linter.pylint.max_locals = 15
+        linter.pylint.max_nested_blocks = 5
         linter.pyupgrade.keep_runtime_typing = false
         linter.ruff.parenthesize_tuple_in_subscript = false
 
@@ -2758,6 +2759,7 @@ requires-python = ">= 3.11"
         linter.pylint.max_statements = 50
         linter.pylint.max_public_methods = 20
         linter.pylint.max_locals = 15
+        linter.pylint.max_nested_blocks = 5
         linter.pyupgrade.keep_runtime_typing = false
         linter.ruff.parenthesize_tuple_in_subscript = false
 
@@ -3070,6 +3072,7 @@ requires-python = ">= 3.11"
         linter.pylint.max_statements = 50
         linter.pylint.max_public_methods = 20
         linter.pylint.max_locals = 15
+        linter.pylint.max_nested_blocks = 5
         linter.pyupgrade.keep_runtime_typing = false
         linter.ruff.parenthesize_tuple_in_subscript = false
 
@@ -3434,6 +3437,7 @@ from typing import Union;foo: Union[int, str] = 1
         linter.pylint.max_statements = 50
         linter.pylint.max_public_methods = 20
         linter.pylint.max_locals = 15
+        linter.pylint.max_nested_blocks = 5
         linter.pyupgrade.keep_runtime_typing = false
         linter.ruff.parenthesize_tuple_in_subscript = false
 
@@ -3814,6 +3818,7 @@ from typing import Union;foo: Union[int, str] = 1
         linter.pylint.max_statements = 50
         linter.pylint.max_public_methods = 20
         linter.pylint.max_locals = 15
+        linter.pylint.max_nested_blocks = 5
         linter.pyupgrade.keep_runtime_typing = false
         linter.ruff.parenthesize_tuple_in_subscript = false
 
@@ -4142,6 +4147,7 @@ from typing import Union;foo: Union[int, str] = 1
         linter.pylint.max_statements = 50
         linter.pylint.max_public_methods = 20
         linter.pylint.max_locals = 15
+        linter.pylint.max_nested_blocks = 5
         linter.pyupgrade.keep_runtime_typing = false
         linter.ruff.parenthesize_tuple_in_subscript = false
 
@@ -4470,6 +4476,7 @@ from typing import Union;foo: Union[int, str] = 1
         linter.pylint.max_statements = 50
         linter.pylint.max_public_methods = 20
         linter.pylint.max_locals = 15
+        linter.pylint.max_nested_blocks = 5
         linter.pyupgrade.keep_runtime_typing = false
         linter.ruff.parenthesize_tuple_in_subscript = false
 
@@ -5093,6 +5100,7 @@ from typing import Union;foo: Union[int, str] = 1
         linter.pylint.max_statements = 50
         linter.pylint.max_public_methods = 20
         linter.pylint.max_locals = 15
+        linter.pylint.max_nested_blocks = 5
         linter.pyupgrade.keep_runtime_typing = false
         linter.ruff.parenthesize_tuple_in_subscript = false
 

--- a/crates/ruff/tests/snapshots/show_settings__display_default_settings.snap
+++ b/crates/ruff/tests/snapshots/show_settings__display_default_settings.snap
@@ -371,6 +371,7 @@ linter.pylint.max_branches = 12
 linter.pylint.max_statements = 50
 linter.pylint.max_public_methods = 20
 linter.pylint.max_locals = 15
+linter.pylint.max_nested_blocks = 5
 linter.pyupgrade.keep_runtime_typing = false
 linter.ruff.parenthesize_tuple_in_subscript = false
 

--- a/crates/ruff_linter/src/rules/pylint/settings.rs
+++ b/crates/ruff_linter/src/rules/pylint/settings.rs
@@ -96,7 +96,8 @@ impl fmt::Display for Settings {
                 self.max_branches,
                 self.max_statements,
                 self.max_public_methods,
-                self.max_locals
+                self.max_locals,
+                self.max_nested_blocks
             ]
         }
         Ok(())


### PR DESCRIPTION
Summary
--

This fixes a bug pointed out in #20560 where one of the `pylint` settings wasn't used in its `Display` implementation.

Test Plan
--

Existing tests with updated snapshots