### PR TITLE
Remove unnecessary f-string handling in comment placement

### DIFF
--- a/crates/ruff_python_formatter/src/comments/placement.rs
+++ b/crates/ruff_python_formatter/src/comments/placement.rs
@@ -73,20 +73,6 @@ fn handle_parenthesized_comment<'a>(
     comment: DecoratedComment<'a>,
     source: &str,
 ) -> CommentPlacement<'a> {
-    // As a special-case, ignore comments within f-strings, like:
-    // ```python
-    // (
-    //     f'{1}' # comment
-    //     f'{2}'
-    // )
-    // ```
-    // These can't be parenthesized, as they must fall between two string tokens in an implicit
-    // concatenation. But the expression ranges only include the `1` and `2` above, so we also
-    // can't lex the contents between them.
-    if comment.enclosing_node().is_expr_f_string() {
-        return CommentPlacement::Default(comment);
-    }
-
     let Some(preceding) = comment.preceding_node() else {
         return CommentPlacement::Default(comment);
     };


### PR DESCRIPTION
In #7047 some logic was added to comment placement in order to address a panic in #6898 . I believe that panic was caused by old behavior of `SimpleTokenizer` that is no longer present, because it does not occur if the new logic is simply removed.

This was discovered while trying to figure out the potential side-effects of #20578 - I originally was going to augment the logic to include t-strings here, but discovered that you could instead just remove it (unless I missed something?)
