### PR TITLE
[`ruff`] Fix comment placement between as and alias name in from import

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/import_from.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/import_from.py
@@ -37,3 +37,7 @@ from a import \
 )
 
 from tqdm .  auto import tqdm
+
+# Regression test for https://github.com/astral-sh/ruff/issues/19138
+from y import(e as#
+r)

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__import_from.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__import_from.py.snap
@@ -44,6 +44,10 @@ from a import \
 )
 
 from tqdm .  auto import tqdm
+
+# Regression test for https://github.com/astral-sh/ruff/issues/19138
+from y import(e as#
+r)
 ```
 
 ## Output
@@ -120,4 +124,9 @@ from a import (  # comment
 )
 
 from tqdm.auto import tqdm
+
+# Regression test for https://github.com/astral-sh/ruff/issues/19138
+from y import (
+    e as r,  #
+)
 ```


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Fixes #19138

- Treat comments located between the as token and the alias name as trailing comments on the alias.
- Add regression test to cover the case.

## Test Plan

<!-- How was it tested? -->

I have added a test case to import_from.py.
