### PR TITLE
[ty] Use `Top` materializations for `TypeIs` special form

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/narrow/type_guards.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/type_guards.md
@@ -173,6 +173,11 @@ def _(d: Any):
 
 ## Narrowing
 
+```toml
+[environment]
+python-version = "3.12"
+```
+
 ```py
 from typing import Any
 from typing_extensions import TypeGuard, TypeIs
@@ -293,6 +298,38 @@ def _(a: Foo):
 
     if g(f(a)):
         reveal_type(a)  # revealed: Foo & Bar
+```
+
+For generics, we transform the argument passed into `TypeIs[]` from `X` to `Top[X]`. This helps
+especially when using various functions from typeshed that are annotated as returning
+`TypeIs[SomeCovariantGeneric[Any]]` to avoid false positives in other type checkers. For ty's
+purposes, it would usually lead to more intuitive results if `object` was used as the specialization
+for a covariant generic inside the `TypeIs` special form, but this is mitigated by our implicit
+transformation from `TypeIs[SomeCovariantGeneric[Any]]` to `TypeIs[Top[SomeCovariantGeneric[Any]]]`
+(which just simplifies to `TypeIs[SomeCovariantGeneric[object]]`).
+
+```py
+class Unrelated: ...
+
+class Covariant[T]:
+    def get(self) -> T:
+        raise NotImplementedError
+
+def is_instance_of_covariant(arg: object) -> TypeIs[Covariant[Any]]:
+    return isinstance(arg, Covariant)
+
+def needs_instance_of_unrelated(arg: Unrelated):
+    pass
+
+def _(x: Unrelated | Covariant[int]):
+    if is_instance_of_covariant(x):
+        raise RuntimeError("oh no")
+
+    reveal_type(x)  # revealed: Unrelated & ~Covariant[object]
+
+    # We would emit a false-positive diagnostic here if we didn't implicitly transform
+    # `TypeIs[Covariant[Any]]` to `TypeIs[Covariant[object]]`
+    needs_instance_of_unrelated(x)
 ```
 
 ## `TypeGuard` special cases

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -1286,7 +1286,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
                     Type::unknown()
                 }
-                _ => TypeIsType::unbound(self.db(), self.infer_type_expression(arguments_slice)),
+                _ => TypeIsType::unbound(
+                    self.db(),
+                    self.infer_type_expression(arguments_slice)
+                        .top_materialization(self.db()),
+                ),
             },
             SpecialFormType::TypeGuard => {
                 self.infer_type_expression(arguments_slice);

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -1288,6 +1288,12 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 }
                 _ => TypeIsType::unbound(
                     self.db(),
+                    // N.B. Using the top materialization here is a pragmatic decision
+                    // that makes us produce more intuitive results given how
+                    // `TypeIs` is used in the real world (in particular, in typeshed).
+                    // However, there's some debate about whether this is really
+                    // fully correct. See <https://github.com/astral-sh/ruff/pull/20591>
+                    // for more discussion.
                     self.infer_type_expression(arguments_slice)
                         .top_materialization(self.db()),
                 ),


### PR DESCRIPTION
## Summary

Typeshed has many functions that return `TypeIs[SomeCovariantGeneric[Any]]`. This is somewhat unfortunate for ty, because for our purposes it's almost always better to intersect with `CovariantGeneric[object]` for the purposes of type narrowing, but it's [somewhat hard](https://github.com/python/typeshed/pull/14784) to change these in typeshed without creating false-positive diagnostics for users of other type checkers. This PR therefore introduces a workaround for the typeshed issue: under the hood, we convert the type argument passed to `TypeIs` to its top materialization before intersecting with that type.

## Test Plan

I added an mdtest that fails on `main` without this change. It's similar to the false-positive diagnostics relating to the use of [`asyncio.iscoroutine`](https://github.com/python/typeshed/blob/6af8f287bb3eae6c6d8839c69c39f07ee7057517/stdlib/asyncio/coroutines.pyi#L28) that we see going away on `homeassistant/core` in the mypy_primer report.

Some more ecosystem analysis is found in https://github.com/astral-sh/ruff/pull/20591#issuecomment-3338847554.