### PR TITLE
[ty] Introduce `TypeRelation::Redundancy`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_equivalent_to.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_equivalent_to.md
@@ -138,6 +138,11 @@ static_assert(is_equivalent_to(Any, Any | Intersection[Any, str]))
 static_assert(is_equivalent_to(Any, Intersection[str, Any] | Any))
 static_assert(is_equivalent_to(Any, Any | Intersection[Any, Not[None]]))
 static_assert(is_equivalent_to(Any, Intersection[Not[None], Any] | Any))
+
+static_assert(is_equivalent_to(Any, Unknown | Intersection[Unknown, str]))
+static_assert(is_equivalent_to(Any, Intersection[str, Unknown] | Unknown))
+static_assert(is_equivalent_to(Any, Unknown | Intersection[Unknown, Not[None]]))
+static_assert(is_equivalent_to(Any, Intersection[Not[None], Unknown] | Unknown))
 ```
 
 ## Tuples

--- a/crates/ty_python_semantic/resources/mdtest/union_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/union_types.md
@@ -323,6 +323,8 @@ def f(
     d: tuple[str, ...] | tuple[int],
     e: tuple[()] | tuple[Any, ...],
     f: tuple[Any, ...] | tuple[()],
+    g: tuple[Any, ...] | tuple[Any | str, ...],
+    h: tuple[Any | str, ...] | tuple[Any, ...],
 ):
     reveal_type(a)  # revealed: tuple[int, ...]
     reveal_type(b)  # revealed: tuple[int, ...]
@@ -330,4 +332,48 @@ def f(
     reveal_type(d)  # revealed: tuple[str, ...] | tuple[int]
     reveal_type(e)  # revealed: tuple[Any, ...]
     reveal_type(f)  # revealed: tuple[Any, ...]
+    reveal_type(g)  # revealed: tuple[Any | str, ...]
+    reveal_type(h)  # revealed: tuple[Any | str, ...]
+```
+
+## Unions of other generic containers
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Any
+
+class Bivariant[T]: ...
+
+class Covariant[T]:
+    def get(self) -> T:
+        raise NotImplementedError
+
+class Contravariant[T]:
+    def receive(self, input: T) -> None: ...
+
+class Invariant[T]:
+    mutable_attribute: T
+
+def _(
+    a: Bivariant[Any] | Bivariant[Any | str],
+    b: Bivariant[Any | str] | Bivariant[Any],
+    c: Covariant[Any] | Covariant[Any | str],
+    d: Covariant[Any | str] | Covariant[Any],
+    e: Contravariant[Any | str] | Contravariant[Any],
+    f: Contravariant[Any] | Contravariant[Any | str],
+    g: Invariant[Any] | Invariant[Any | str],
+    h: Invariant[Any | str] | Invariant[Any],
+):
+    reveal_type(a)  # revealed: Bivariant[Any]
+    reveal_type(b)  # revealed: Bivariant[Any | str]
+    reveal_type(c)  # revealed: Covariant[Any | str]
+    reveal_type(d)  # revealed: Covariant[Any | str]
+    reveal_type(e)  # revealed: Contravariant[Any]
+    reveal_type(f)  # revealed: Contravariant[Any]
+    reveal_type(g)  # revealed: Invariant[Any] | Invariant[Any | str]
+    reveal_type(h)  # revealed: Invariant[Any | str] | Invariant[Any]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/union_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/union_types.md
@@ -306,3 +306,28 @@ def _(c: BC, d: BD):
     reveal_type(c)  # revealed: Literal[b""]
     reveal_type(d)  # revealed: Literal[b""]
 ```
+
+## Unions of tuples
+
+A union of a fixed-length tuple and a variable-length tuple must be collapsed to the variable-length
+element, never to the fixed-length element (`tuple[()] | tuple[Any, ...]` -> `tuple[Any, ...]`, not
+`tuple[()]`).
+
+```py
+from typing import Any
+
+def f(
+    a: tuple[()] | tuple[int, ...],
+    b: tuple[int, ...] | tuple[()],
+    c: tuple[int] | tuple[str, ...],
+    d: tuple[str, ...] | tuple[int],
+    e: tuple[()] | tuple[Any, ...],
+    f: tuple[Any, ...] | tuple[()],
+):
+    reveal_type(a)  # revealed: tuple[int, ...]
+    reveal_type(b)  # revealed: tuple[int, ...]
+    reveal_type(c)  # revealed: tuple[int] | tuple[str, ...]
+    reveal_type(d)  # revealed: tuple[str, ...] | tuple[int]
+    reveal_type(e)  # revealed: tuple[Any, ...]
+    reveal_type(f)  # revealed: tuple[Any, ...]
+```

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -9006,7 +9006,7 @@ pub(crate) enum TypeRelation {
     /// subtype of `C` if and only if the union of all possible sets of values
     /// represented by `D` (the "top materialization" of `D`) is a subtype of the
     /// intersection of all possible sets of values represented by `C` (the "bottom
-    /// materialization" of `C`).
+    /// materialization" of `C`). More concisely: `D <: C` iff `Top[D] <: Bottom[C]`.
     ///
     /// For example, `list[Any]` can be said to be a subtype of `Sequence[object]`,
     /// because every possible fully static materialization of `list[Any]` (`list[int]`,
@@ -9034,8 +9034,13 @@ pub(crate) enum TypeRelation {
     ///
     /// Between a pair of `C` and `D` where either `C` or `D` is not fully static, the
     /// assignability relation may be more permissive than the subtyping relation. `D`
-    /// can be said to be assignable to `C` if *any* possibly fully static [materialization]
-    /// of `D` is a subtype of *any* possible fully static materialization of `C`.
+    /// can be said to be assignable to `C` if *some* possible fully static [materialization]
+    /// of `D` is a subtype of *some* possible fully static materialization of `C`.
+    /// Another way of saying this is that `D` will be assignable to `C` if and only if the
+    /// intersection of all possible sets of values represented by `D` (the "bottom
+    /// materialization" of `D`) is a subtype of the union of all possible sets of values
+    /// represented by `C` (the "top materialization" of `C`).
+    /// More concisely: `D <: C` iff `Bottom[D] <: Top[C]`.
     ///
     /// For example, `Any` is not a subtype of `int`, because there are possible
     /// materializations of `Any` (e.g., `str`) that are not subtypes of `int`.
@@ -9062,17 +9067,16 @@ pub(crate) enum TypeRelation {
     /// pragmatically simplified to the type `A` without downstream consequences on ty's
     /// inference of types elsewhere.
     ///
-    /// For a pair of [fully static] types `A` and `B`, the assignability relation
+    /// For a pair of [fully static] types `A` and `B`, the union simplification relation
     /// between `A` and `B` is the same as the subtyping relation.
     ///
     /// Between a pair of `C` and `D` where either `C` or `D` is not fully static, the
     /// union simplification relation sits in between the subtyping relation and the
-    /// assignability relation. `D` can be said to be redundant in a union with `C` if either:
-    ///
-    /// 1. `D` is a subtype of `C`; or,
-    /// 2. The top materialization of the type `C | D` is equivalent to the top
-    ///    materialization of `C`, *and* the bottom materialization of `C | D` is equivalent
-    ///    to the bottom materialization of `C`.
+    /// assignability relation. `D` can be said to be redundant in a union with `C` if the
+    /// top materialization of the type `C | D` is equivalent to the top materialization of
+    /// `C`, *and* the bottom materialization of `C | D` is equivalent to the bottom
+    /// materialization of `C`.
+    /// More concisely: `D <: C` iff `Top[C | D] == Top[C]` AND `Bottom[C | D] == Bottom[C]`.
     ///
     /// Practically speaking, in most respects the union simplification relation is the
     /// same as the subtyping relation. It is redundant to add `bool` to a union that

--- a/crates/ty_python_semantic/src/types/builder.rs
+++ b/crates/ty_python_semantic/src/types/builder.rs
@@ -502,18 +502,9 @@ impl<'db> UnionBuilder<'db> {
             }
 
             if should_simplify_full && !matches!(element_type, Type::TypeAlias(_)) {
-                if ty.is_equivalent_to(self.db, element_type)
-                    || ty.is_subtype_of(self.db, element_type)
-                    || ty.into_intersection().is_some_and(|intersection| {
-                        intersection.positive(self.db).contains(&element_type)
-                    })
-                {
+                if ty.is_redundant_in_union_with(self.db, element_type) {
                     return;
-                } else if element_type.is_subtype_of(self.db, ty)
-                    || element_type
-                        .into_intersection()
-                        .is_some_and(|intersection| intersection.positive(self.db).contains(&ty))
-                {
+                } else if element_type.is_redundant_in_union_with(self.db, ty) {
                     to_remove.push(index);
                 } else if ty_negated.is_subtype_of(self.db, element_type) {
                     // We add `ty` to the union. We just checked that `~ty` is a subtype of an
@@ -930,13 +921,11 @@ impl<'db> InnerIntersectionBuilder<'db> {
                 let mut to_remove = SmallVec::<[usize; 1]>::new();
                 for (index, existing_positive) in self.positive.iter().enumerate() {
                     // S & T = S    if S <: T
-                    if existing_positive.is_subtype_of(db, new_positive)
-                        || existing_positive.is_equivalent_to(db, new_positive)
-                    {
+                    if existing_positive.is_redundant_in_union_with(db, new_positive) {
                         return;
                     }
                     // same rule, reverse order
-                    if new_positive.is_subtype_of(db, *existing_positive) {
+                    if new_positive.is_redundant_in_union_with(db, *existing_positive) {
                         to_remove.push(index);
                     }
                     // A & B = Never    if A and B are disjoint
@@ -953,7 +942,7 @@ impl<'db> InnerIntersectionBuilder<'db> {
                 let mut to_remove = SmallVec::<[usize; 1]>::new();
                 for (index, existing_negative) in self.negative.iter().enumerate() {
                     // S & ~T = Never    if S <: T
-                    if new_positive.is_subtype_of(db, *existing_negative) {
+                    if new_positive.is_redundant_in_union_with(db, *existing_negative) {
                         *self = Self::default();
                         self.positive.insert(Type::Never);
                         return;
@@ -1027,9 +1016,7 @@ impl<'db> InnerIntersectionBuilder<'db> {
                 let mut to_remove = SmallVec::<[usize; 1]>::new();
                 for (index, existing_negative) in self.negative.iter().enumerate() {
                     // ~S & ~T = ~T    if S <: T
-                    if existing_negative.is_subtype_of(db, new_negative)
-                        || existing_negative.is_equivalent_to(db, new_negative)
-                    {
+                    if existing_negative.is_redundant_in_union_with(db, new_negative) {
                         to_remove.push(index);
                     }
                     // same rule, reverse order
@@ -1043,7 +1030,7 @@ impl<'db> InnerIntersectionBuilder<'db> {
 
                 for existing_positive in &self.positive {
                     // S & ~T = Never    if S <: T
-                    if existing_positive.is_subtype_of(db, new_negative) {
+                    if existing_positive.is_redundant_in_union_with(db, new_negative) {
                         *self = Self::default();
                         self.positive.insert(Type::Never);
                         return;

--- a/crates/ty_python_semantic/src/types/builder.rs
+++ b/crates/ty_python_semantic/src/types/builder.rs
@@ -502,9 +502,9 @@ impl<'db> UnionBuilder<'db> {
             }
 
             if should_simplify_full && !matches!(element_type, Type::TypeAlias(_)) {
-                if ty.is_redundant_in_union_with(self.db, element_type) {
+                if ty.is_redundant_with(self.db, element_type) {
                     return;
-                } else if element_type.is_redundant_in_union_with(self.db, ty) {
+                } else if element_type.is_redundant_with(self.db, ty) {
                     to_remove.push(index);
                 } else if ty_negated.is_subtype_of(self.db, element_type) {
                     // We add `ty` to the union. We just checked that `~ty` is a subtype of an
@@ -921,11 +921,11 @@ impl<'db> InnerIntersectionBuilder<'db> {
                 let mut to_remove = SmallVec::<[usize; 1]>::new();
                 for (index, existing_positive) in self.positive.iter().enumerate() {
                     // S & T = S    if S <: T
-                    if existing_positive.is_redundant_in_union_with(db, new_positive) {
+                    if existing_positive.is_redundant_with(db, new_positive) {
                         return;
                     }
                     // same rule, reverse order
-                    if new_positive.is_redundant_in_union_with(db, *existing_positive) {
+                    if new_positive.is_redundant_with(db, *existing_positive) {
                         to_remove.push(index);
                     }
                     // A & B = Never    if A and B are disjoint
@@ -1016,7 +1016,7 @@ impl<'db> InnerIntersectionBuilder<'db> {
                 let mut to_remove = SmallVec::<[usize; 1]>::new();
                 for (index, existing_negative) in self.negative.iter().enumerate() {
                     // ~S & ~T = ~T    if S <: T
-                    if existing_negative.is_redundant_in_union_with(db, new_negative) {
+                    if existing_negative.is_redundant_with(db, new_negative) {
                         to_remove.push(index);
                     }
                     // same rule, reverse order

--- a/crates/ty_python_semantic/src/types/builder.rs
+++ b/crates/ty_python_semantic/src/types/builder.rs
@@ -942,7 +942,7 @@ impl<'db> InnerIntersectionBuilder<'db> {
                 let mut to_remove = SmallVec::<[usize; 1]>::new();
                 for (index, existing_negative) in self.negative.iter().enumerate() {
                     // S & ~T = Never    if S <: T
-                    if new_positive.is_redundant_in_union_with(db, *existing_negative) {
+                    if new_positive.is_subtype_of(db, *existing_negative) {
                         *self = Self::default();
                         self.positive.insert(Type::Never);
                         return;
@@ -1030,7 +1030,7 @@ impl<'db> InnerIntersectionBuilder<'db> {
 
                 for existing_positive in &self.positive {
                     // S & ~T = Never    if S <: T
-                    if existing_positive.is_redundant_in_union_with(db, new_negative) {
+                    if existing_positive.is_subtype_of(db, new_negative) {
                         *self = Self::default();
                         self.positive.insert(Type::Never);
                         return;

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -551,7 +551,7 @@ impl<'db> ClassType<'db> {
         self.iter_mro(db).when_any(db, |base| {
             match base {
                 ClassBase::Dynamic(_) => match relation {
-                    TypeRelation::Subtyping | TypeRelation::UnionSimplification => {
+                    TypeRelation::Subtyping | TypeRelation::Redundancy => {
                         ConstraintSet::from(other.is_object(db))
                     }
                     TypeRelation::Assignability => ConstraintSet::from(!other.is_final(db)),

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -551,7 +551,9 @@ impl<'db> ClassType<'db> {
         self.iter_mro(db).when_any(db, |base| {
             match base {
                 ClassBase::Dynamic(_) => match relation {
-                    TypeRelation::Subtyping => ConstraintSet::from(other.is_object(db)),
+                    TypeRelation::Subtyping | TypeRelation::UnionSimplification => {
+                        ConstraintSet::from(other.is_object(db))
+                    }
                     TypeRelation::Assignability => ConstraintSet::from(!other.is_final(db)),
                 },
 

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -969,7 +969,7 @@ impl<'db> FunctionType<'db> {
         _visitor: &HasRelationToVisitor<'db>,
     ) -> ConstraintSet<'db> {
         match relation {
-            TypeRelation::Subtyping | TypeRelation::UnionSimplification => {
+            TypeRelation::Subtyping | TypeRelation::Redundancy => {
                 ConstraintSet::from(self.is_subtype_of(db, other))
             }
             TypeRelation::Assignability => ConstraintSet::from(self.is_assignable_to(db, other)),

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -969,7 +969,9 @@ impl<'db> FunctionType<'db> {
         _visitor: &HasRelationToVisitor<'db>,
     ) -> ConstraintSet<'db> {
         match relation {
-            TypeRelation::Subtyping => ConstraintSet::from(self.is_subtype_of(db, other)),
+            TypeRelation::Subtyping | TypeRelation::UnionSimplification => {
+                ConstraintSet::from(self.is_subtype_of(db, other))
+            }
             TypeRelation::Assignability => ConstraintSet::from(self.is_assignable_to(db, other)),
         }
     }

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -620,22 +620,26 @@ fn has_relation_in_invariant_position<'db>(
                 base_type.has_relation_to_impl(db, *derived_type, relation, visitor)
             }),
         // For gradual types, A <: B (subtyping) is defined as Top[A] <: Bottom[B]
-        (None, Some(base_mat), TypeRelation::Subtyping) => is_subtype_in_invariant_position(
-            db,
-            derived_type,
-            MaterializationKind::Top,
-            base_type,
-            base_mat,
-            visitor,
-        ),
-        (Some(derived_mat), None, TypeRelation::Subtyping) => is_subtype_in_invariant_position(
-            db,
-            derived_type,
-            derived_mat,
-            base_type,
-            MaterializationKind::Bottom,
-            visitor,
-        ),
+        (None, Some(base_mat), TypeRelation::Subtyping | TypeRelation::UnionSimplification) => {
+            is_subtype_in_invariant_position(
+                db,
+                derived_type,
+                MaterializationKind::Top,
+                base_type,
+                base_mat,
+                visitor,
+            )
+        }
+        (Some(derived_mat), None, TypeRelation::Subtyping | TypeRelation::UnionSimplification) => {
+            is_subtype_in_invariant_position(
+                db,
+                derived_type,
+                derived_mat,
+                base_type,
+                MaterializationKind::Bottom,
+                visitor,
+            )
+        }
         // And A <~ B (assignability) is Bottom[A] <: Top[B]
         (None, Some(base_mat), TypeRelation::Assignability) => is_subtype_in_invariant_position(
             db,

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -620,7 +620,7 @@ fn has_relation_in_invariant_position<'db>(
                 base_type.has_relation_to_impl(db, *derived_type, relation, visitor)
             }),
         // For gradual types, A <: B (subtyping) is defined as Top[A] <: Bottom[B]
-        (None, Some(base_mat), TypeRelation::Subtyping | TypeRelation::UnionSimplification) => {
+        (None, Some(base_mat), TypeRelation::Subtyping | TypeRelation::Redundancy) => {
             is_subtype_in_invariant_position(
                 db,
                 derived_type,
@@ -630,7 +630,7 @@ fn has_relation_in_invariant_position<'db>(
                 visitor,
             )
         }
-        (Some(derived_mat), None, TypeRelation::Subtyping | TypeRelation::UnionSimplification) => {
+        (Some(derived_mat), None, TypeRelation::Subtyping | TypeRelation::Redundancy) => {
             is_subtype_in_invariant_position(
                 db,
                 derived_type,

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -138,7 +138,7 @@ impl<'db> SubclassOfType<'db> {
     ) -> ConstraintSet<'db> {
         match (self.subclass_of, other.subclass_of) {
             (SubclassOfInner::Dynamic(_), SubclassOfInner::Dynamic(_)) => {
-                ConstraintSet::from(relation.is_assignability())
+                ConstraintSet::from(!relation.is_subtyping())
             }
             (SubclassOfInner::Dynamic(_), SubclassOfInner::Class(other_class)) => {
                 ConstraintSet::from(other_class.is_object(db) || relation.is_assignability())

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -757,7 +757,7 @@ impl<'db> VariableLengthTuple<Type<'db>> {
                 // (or any other dynamic type), then the `...` is the _gradual choice_ of all
                 // possible lengths. This means that `tuple[Any, ...]` can match any tuple of any
                 // length.
-                if !relation.is_assignability() || !matches!(self.variable, Type::Dynamic(_)) {
+                if !relation.is_assignability() || !self.variable.is_dynamic() {
                     return ConstraintSet::from(false);
                 }
 

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -757,8 +757,7 @@ impl<'db> VariableLengthTuple<Type<'db>> {
                 // (or any other dynamic type), then the `...` is the _gradual choice_ of all
                 // possible lengths. This means that `tuple[Any, ...]` can match any tuple of any
                 // length.
-                if relation == TypeRelation::Subtyping || !matches!(self.variable, Type::Dynamic(_))
-                {
+                if !relation.is_assignability() || !matches!(self.variable, Type::Dynamic(_)) {
                     return ConstraintSet::from(false);
                 }
 


### PR DESCRIPTION
## Summary

The union `T | U` can be validly simplified to `U` iff:
1. `T` is a subtype of `U` OR
2. `T` is equivalent to `U` OR
3. `U` is a union and contains a type that is equivalent to `T` OR
4. `T` is an intersection and contains a type that is equivalent to `U`

(In practice, the only situation in which 2, 3 or 4 would be true when (1) was not true would be if `T` or `U` is a dynamic type.)

Currently we achieve these simplifications in the union builder by doing something along the lines of `t.is_subtype_of(db, u) || t.is_equivalent_to_(db, u) || t.into_intersection().is_some_and(|intersection| intersection.positive(db).contains(&u)) || u.into_union().is_some_and(|union| union.elements(db).contains(&t))`. But this is both slow and misses some cases (it doesn't simplify the union `Any | (Unknown & ~None)` to `Any`, for example). We can improve the consistency and performance of our union simplifications by adding a third type relation that sits in between `TypeRelation::Subtyping` and `TypeRelation::Assignability`: `TypeRelation::UnionSimplification`.

This change leads to simpler, more user-friendly types due to the more consistent simplification. It also lead to a pretty huge performance improvement!

## Test Plan

Existing tests, plus some new ones.
