### PR TITLE
[ty] Improve disambiguation of class names in diagnostics

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/same_names.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/same_names.md
@@ -228,7 +228,7 @@ class Person(TypedDict):
     name: bytes
 ```
 
-## Generic specializations
+## Tuple specializations
 
 `module.py`:
 

--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/same_names.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/same_names.md
@@ -43,7 +43,7 @@ import b
 df: a.DataFrame = b.DataFrame()  # error: [invalid-assignment] "Object of type `b.DataFrame` is not assignable to `a.DataFrame`"
 
 def _(dfs: list[b.DataFrame]):
-    # error: [invalid-assignment] "Object of type `builtins.list[b.DataFrame]` is not assignable to `builtins.list[a.DataFrame]`"
+    # error: [invalid-assignment] "Object of type `list[b.DataFrame]` is not assignable to `list[a.DataFrame]`"
     dataframes: list[a.DataFrame] = dfs
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/same_names.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/same_names.md
@@ -43,8 +43,7 @@ import b
 df: a.DataFrame = b.DataFrame()  # error: [invalid-assignment] "Object of type `b.DataFrame` is not assignable to `a.DataFrame`"
 
 def _(dfs: list[b.DataFrame]):
-    # TODO should be"Object of type `list[b.DataFrame]` is not assignable to `list[a.DataFrame]`
-    # error: [invalid-assignment] "Object of type `list[DataFrame]` is not assignable to `list[DataFrame]`"
+    # error: [invalid-assignment] "Object of type `builtins.list[b.DataFrame]` is not assignable to `builtins.list[a.DataFrame]`"
     dataframes: list[a.DataFrame] = dfs
 ```
 
@@ -227,4 +226,22 @@ from typing import TypedDict
 
 class Person(TypedDict):
     name: bytes
+```
+
+## Generic specializations
+
+`module.py`:
+
+```py
+class Model: ...
+```
+
+```py
+class Model: ...
+
+def get_models_tuple() -> tuple[Model]:
+    from module import Model
+
+    # error: [invalid-return-type] "Return type does not match returned value: expected `tuple[mdtest_snippet.Model]`, found `tuple[module.Model]`"
+    return (Model(),)
 ```

--- a/crates/ty_python_semantic/resources/mdtest/public_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/public_types.md
@@ -339,7 +339,7 @@ class A: ...
 
 def f(x: A):
     # TODO: no error
-    # error: [invalid-assignment] "Object of type `A | A` is not assignable to `A`"
+    # error: [invalid-assignment] "Object of type `mdtest_snippet.A | mdtest_snippet.A` is not assignable to `mdtest_snippet.A`"
     x = A()
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type_(a91e0c67519cd77f).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type_(a91e0c67519cd77f).snap
@@ -119,10 +119,10 @@ error[invalid-return-type]: Return type does not match returned value
 20 | class A[T]: ...
 21 |
 22 | def f() -> A[int]:
-   |            ------ Expected `mdtest_snippet.A[int]` because of return type
+   |            ------ Expected `mdtest_snippet.A[builtins.int]` because of return type
 23 |     class A[T]: ...
 24 |     return A[int]()  # error: [invalid-return-type]
-   |            ^^^^^^^^ expected `mdtest_snippet.A[int]`, found `mdtest_snippet.<locals of function 'f'>.A[int]`
+   |            ^^^^^^^^ expected `mdtest_snippet.A[builtins.int]`, found `mdtest_snippet.<locals of function 'f'>.A[builtins.int]`
 25 |
 26 | class B: ...
    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type_(a91e0c67519cd77f).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type_(a91e0c67519cd77f).snap
@@ -119,10 +119,10 @@ error[invalid-return-type]: Return type does not match returned value
 20 | class A[T]: ...
 21 |
 22 | def f() -> A[int]:
-   |            ------ Expected `mdtest_snippet.A[builtins.int]` because of return type
+   |            ------ Expected `mdtest_snippet.A[int]` because of return type
 23 |     class A[T]: ...
 24 |     return A[int]()  # error: [invalid-return-type]
-   |            ^^^^^^^^ expected `mdtest_snippet.A[builtins.int]`, found `mdtest_snippet.<locals of function 'f'>.A[builtins.int]`
+   |            ^^^^^^^^ expected `mdtest_snippet.A[int]`, found `mdtest_snippet.<locals of function 'f'>.A[int]`
 25 |
 26 | class B: ...
    |

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -7065,7 +7065,11 @@ impl<'db> KnownInstanceType<'db> {
                         if let Some(specialization) = alias.specialization(self.db) {
                             f.write_str(alias.name(self.db))?;
                             specialization
-                                .display_short(self.db, TupleSpecialization::No)
+                                .display_short(
+                                    self.db,
+                                    TupleSpecialization::No,
+                                    DisplaySettings::default(),
+                                )
                                 .fmt(f)
                         } else {
                             f.write_str("typing.TypeAliasType")

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -1986,7 +1986,7 @@ pub(super) fn report_invalid_assignment<'db>(
         target_ty,
         format_args!(
             "Object of type `{}` is not assignable to `{}`",
-            source_ty.display_with(context.db(), settings),
+            source_ty.display_with(context.db(), settings.clone()),
             target_ty.display_with(context.db(), settings)
         ),
     );
@@ -2068,8 +2068,8 @@ pub(super) fn report_invalid_return_type(
     let mut diag = builder.into_diagnostic("Return type does not match returned value");
     diag.set_primary_message(format_args!(
         "expected `{expected_ty}`, found `{actual_ty}`",
-        expected_ty = expected_ty.display_with(context.db(), settings),
-        actual_ty = actual_ty.display_with(context.db(), settings),
+        expected_ty = expected_ty.display_with(context.db(), settings.clone()),
+        actual_ty = actual_ty.display_with(context.db(), settings.clone()),
     ));
     diag.annotate(
         Annotation::secondary(return_type_span).message(format_args!(

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -2,6 +2,7 @@
 
 use std::cell::RefCell;
 use std::fmt::{self, Display, Formatter, Write};
+use std::rc::Rc;
 
 use ruff_db::display::FormatterJoinExtension;
 use ruff_python_ast::str::{Quote, TripleQuotes};
@@ -31,7 +32,7 @@ pub struct DisplaySettings<'db> {
     /// Whether rendering can be multiline
     pub multiline: bool,
     /// Class names that should be displayed fully qualified
-    pub qualified: FxHashSet<&'db str>,
+    pub qualified: Rc<FxHashSet<&'db str>>,
 }
 
 impl<'db> DisplaySettings<'db> {
@@ -62,12 +63,14 @@ impl<'db> DisplaySettings<'db> {
         collector.visit_type(db, type_2);
 
         Self {
-            qualified: collector
-                .class_names
-                .borrow()
-                .iter()
-                .filter_map(|(name, classes)| (classes.len() > 1).then_some(*name))
-                .collect(),
+            qualified: Rc::new(
+                collector
+                    .class_names
+                    .borrow()
+                    .iter()
+                    .filter_map(|(name, classes)| (classes.len() > 1).then_some(*name))
+                    .collect(),
+            ),
             ..Self::default()
         }
     }

--- a/crates/ty_python_semantic/src/types/visitor.rs
+++ b/crates/ty_python_semantic/src/types/visitor.rs
@@ -107,7 +107,7 @@ pub(crate) trait TypeVisitor<'db> {
 
 /// Enumeration of types that may contain other types, such as unions, intersections, and generics.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
-enum NonAtomicType<'db> {
+pub(super) enum NonAtomicType<'db> {
     Union(UnionType<'db>),
     Intersection(IntersectionType<'db>),
     FunctionLiteral(FunctionType<'db>),
@@ -128,7 +128,7 @@ enum NonAtomicType<'db> {
     TypeAlias(TypeAliasType<'db>),
 }
 
-enum TypeKind<'db> {
+pub(super) enum TypeKind<'db> {
     Atomic,
     NonAtomic(NonAtomicType<'db>),
 }
@@ -200,7 +200,7 @@ impl<'db> From<Type<'db>> for TypeKind<'db> {
     }
 }
 
-fn walk_non_atomic_type<'db, V: TypeVisitor<'db> + ?Sized>(
+pub(super) fn walk_non_atomic_type<'db, V: TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
     non_atomic_type: NonAtomicType<'db>,
     visitor: &V,


### PR DESCRIPTION
## Summary

Currently we'll use the fully qualified name of a class in _some_ cases when reporting instances where one class was expected but another one was found and the two classes have the same name. But there are still many cases where we won't do that -- e.g. in https://github.com/astral-sh/ruff/pull/20368, this is one of the new diagnostics:

```
error[invalid-return-type] Return type does not match returned value: expected `Iterable[Model]`, found `Iterable[Model]`
```

This PR switches the `DisplaySettings::from_possibly_ambiguous_type_pair()` function to use a `TypeVisitor` implementation, so that we can be confident it will deeply recurse into a pair of types and identify possibly ambiguous type names wherever they might be hiding.

## Test Plan

Mdtests
