### PR TITLE
[formatter] blank lines around controls

### DIFF
--- a/crates/ruff/tests/lint.rs
+++ b/crates/ruff/tests/lint.rs
@@ -2462,6 +2462,7 @@ requires-python = ">= 3.11"
         formatter.magic_trailing_comma = respect
         formatter.docstring_code_format = disabled
         formatter.docstring_code_line_width = dynamic
+        formatter.blank_lines_around_controls = disabled
 
         # Analyze Settings
         analyze.exclude = []
@@ -2776,6 +2777,7 @@ requires-python = ">= 3.11"
         formatter.magic_trailing_comma = respect
         formatter.docstring_code_format = disabled
         formatter.docstring_code_line_width = dynamic
+        formatter.blank_lines_around_controls = disabled
 
         # Analyze Settings
         analyze.exclude = []
@@ -3089,6 +3091,7 @@ requires-python = ">= 3.11"
         formatter.magic_trailing_comma = respect
         formatter.docstring_code_format = disabled
         formatter.docstring_code_line_width = dynamic
+        formatter.blank_lines_around_controls = disabled
 
         # Analyze Settings
         analyze.exclude = []
@@ -3454,6 +3457,7 @@ from typing import Union;foo: Union[int, str] = 1
         formatter.magic_trailing_comma = respect
         formatter.docstring_code_format = disabled
         formatter.docstring_code_line_width = dynamic
+        formatter.blank_lines_around_controls = disabled
 
         # Analyze Settings
         analyze.exclude = []
@@ -3835,6 +3839,7 @@ from typing import Union;foo: Union[int, str] = 1
         formatter.magic_trailing_comma = respect
         formatter.docstring_code_format = disabled
         formatter.docstring_code_line_width = dynamic
+        formatter.blank_lines_around_controls = disabled
 
         # Analyze Settings
         analyze.exclude = []
@@ -4164,6 +4169,7 @@ from typing import Union;foo: Union[int, str] = 1
         formatter.magic_trailing_comma = respect
         formatter.docstring_code_format = disabled
         formatter.docstring_code_line_width = dynamic
+        formatter.blank_lines_around_controls = disabled
 
         # Analyze Settings
         analyze.exclude = []
@@ -4493,6 +4499,7 @@ from typing import Union;foo: Union[int, str] = 1
         formatter.magic_trailing_comma = respect
         formatter.docstring_code_format = disabled
         formatter.docstring_code_line_width = dynamic
+        formatter.blank_lines_around_controls = disabled
 
         # Analyze Settings
         analyze.exclude = []
@@ -4779,6 +4786,7 @@ from typing import Union;foo: Union[int, str] = 1
         formatter.magic_trailing_comma = respect
         formatter.docstring_code_format = disabled
         formatter.docstring_code_line_width = dynamic
+        formatter.blank_lines_around_controls = disabled
 
         # Analyze Settings
         analyze.exclude = []
@@ -5118,6 +5126,7 @@ from typing import Union;foo: Union[int, str] = 1
         formatter.magic_trailing_comma = respect
         formatter.docstring_code_format = disabled
         formatter.docstring_code_line_width = dynamic
+        formatter.blank_lines_around_controls = disabled
 
         # Analyze Settings
         analyze.exclude = []

--- a/crates/ruff/tests/snapshots/show_settings__display_default_settings.snap
+++ b/crates/ruff/tests/snapshots/show_settings__display_default_settings.snap
@@ -388,6 +388,7 @@ formatter.quote_style = double
 formatter.magic_trailing_comma = respect
 formatter.docstring_code_format = disabled
 formatter.docstring_code_line_width = dynamic
+formatter.blank_lines_around_controls = disabled
 
 # Analyze Settings
 analyze.exclude = []

--- a/crates/ruff_python_formatter/src/cli.rs
+++ b/crates/ruff_python_formatter/src/cli.rs
@@ -12,7 +12,9 @@ use ruff_python_trivia::CommentRanges;
 use ruff_text_size::Ranged;
 
 use crate::comments::collect_comments;
-use crate::{MagicTrailingComma, PreviewMode, PyFormatOptions, format_module_ast};
+use crate::{
+    BlankLinesAroundControls, MagicTrailingComma, PreviewMode, PyFormatOptions, format_module_ast,
+};
 
 #[derive(ValueEnum, Clone, Debug)]
 pub enum Emit {
@@ -60,7 +62,9 @@ pub fn format_and_debug_print(source: &str, cli: &Cli, source_path: &Path) -> Re
             MagicTrailingComma::Ignore
         } else {
             MagicTrailingComma::Respect
-        });
+        })
+        // Dev CLI uses default for new option; expose via workspace CLI if needed
+        .with_blank_lines_around_controls(BlankLinesAroundControls::Disabled);
 
     let source_code = SourceCode::new(source);
     let comment_ranges = CommentRanges::from(parsed.tokens());

--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -18,8 +18,8 @@ use crate::comments::{
 pub use crate::context::PyFormatContext;
 pub use crate::db::Db;
 pub use crate::options::{
-    DocstringCode, DocstringCodeLineWidth, MagicTrailingComma, PreviewMode, PyFormatOptions,
-    QuoteStyle,
+    BlankLinesAroundControls, DocstringCode, DocstringCodeLineWidth, MagicTrailingComma,
+    PreviewMode, PyFormatOptions, QuoteStyle,
 };
 use crate::range::is_logical_line;
 pub use crate::shared_traits::{AsFormat, FormattedIter, FormattedIterExt, IntoFormat};

--- a/crates/ruff_python_formatter/src/options.rs
+++ b/crates/ruff_python_formatter/src/options.rs
@@ -62,6 +62,10 @@ pub struct PyFormatOptions {
 
     /// Whether preview style formatting is enabled or not
     preview: PreviewMode,
+
+    /// Whether to enforce a blank line before and after control blocks
+    /// (if/for/while/with/try) inside suites.
+    blank_lines_around_controls: BlankLinesAroundControls,
 }
 
 fn default_line_width() -> LineWidth {
@@ -91,6 +95,7 @@ impl Default for PyFormatOptions {
             docstring_code: DocstringCode::default(),
             docstring_code_line_width: DocstringCodeLineWidth::default(),
             preview: PreviewMode::default(),
+            blank_lines_around_controls: BlankLinesAroundControls::Disabled,
         }
     }
 }
@@ -142,6 +147,10 @@ impl PyFormatOptions {
 
     pub const fn preview(&self) -> PreviewMode {
         self.preview
+    }
+
+    pub const fn blank_lines_around_controls(&self) -> BlankLinesAroundControls {
+        self.blank_lines_around_controls
     }
 
     #[must_use]
@@ -207,6 +216,12 @@ impl PyFormatOptions {
     #[must_use]
     pub fn with_source_map_generation(mut self, source_map: SourceMapGeneration) -> Self {
         self.source_map_generation = source_map;
+        self
+    }
+
+    #[must_use]
+    pub fn with_blank_lines_around_controls(mut self, value: BlankLinesAroundControls) -> Self {
+        self.blank_lines_around_controls = value;
         self
     }
 }
@@ -344,6 +359,32 @@ impl PreviewMode {
 }
 
 impl fmt::Display for PreviewMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Disabled => write!(f, "disabled"),
+            Self::Enabled => write!(f, "enabled"),
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Default, CacheKey)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub enum BlankLinesAroundControls {
+    #[default]
+    Disabled,
+
+    Enabled,
+}
+
+impl BlankLinesAroundControls {
+    pub const fn is_enabled(self) -> bool {
+        matches!(self, BlankLinesAroundControls::Enabled)
+    }
+}
+
+impl fmt::Display for BlankLinesAroundControls {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Disabled => write!(f, "disabled"),

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -41,7 +41,7 @@ use ruff_linter::{
 };
 use ruff_python_ast as ast;
 use ruff_python_formatter::{
-    DocstringCode, DocstringCodeLineWidth, MagicTrailingComma, QuoteStyle,
+    BlankLinesAroundControls, DocstringCode, DocstringCodeLineWidth, MagicTrailingComma, QuoteStyle,
 };
 
 use crate::options::{
@@ -210,6 +210,9 @@ impl Configuration {
             docstring_code_line_width: format
                 .docstring_code_line_width
                 .unwrap_or(format_defaults.docstring_code_line_width),
+            blank_lines_around_controls: format
+                .blank_lines_around_controls
+                .unwrap_or(format_defaults.blank_lines_around_controls),
         };
 
         let analyze = self.analyze;
@@ -1211,6 +1214,7 @@ pub struct FormatConfiguration {
     pub line_ending: Option<LineEnding>,
     pub docstring_code_format: Option<DocstringCode>,
     pub docstring_code_line_width: Option<DocstringCodeLineWidth>,
+    pub blank_lines_around_controls: Option<BlankLinesAroundControls>,
 }
 
 impl FormatConfiguration {
@@ -1247,6 +1251,13 @@ impl FormatConfiguration {
                 }
             }),
             docstring_code_line_width: options.docstring_code_line_length,
+            blank_lines_around_controls: options.blank_lines_around_controls.map(|yes| {
+                if yes {
+                    BlankLinesAroundControls::Enabled
+                } else {
+                    BlankLinesAroundControls::Disabled
+                }
+            }),
         })
     }
 
@@ -1264,6 +1275,9 @@ impl FormatConfiguration {
             docstring_code_line_width: self
                 .docstring_code_line_width
                 .or(config.docstring_code_line_width),
+            blank_lines_around_controls: self
+                .blank_lines_around_controls
+                .or(config.blank_lines_around_controls),
         }
     }
 }

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -3799,6 +3799,17 @@ pub struct FormatOptions {
         "#
     )]
     pub docstring_code_line_length: Option<DocstringCodeLineWidth>,
+
+    /// Whether to insert blank lines around control blocks (if/for/while/with/try)
+    #[option(
+        default = r#"false"#,
+        value_type = r#"bool"#,
+        example = r#"
+            # Insert blank lines around control blocks
+            blank-lines-around-controls = true
+        "#
+    )]
+    pub blank_lines_around_controls: Option<bool>,
 }
 
 /// Configures Ruff's `analyze` command.

--- a/crates/ruff_workspace/src/settings.rs
+++ b/crates/ruff_workspace/src/settings.rs
@@ -11,8 +11,8 @@ use ruff_linter::settings::types::{
 use ruff_macros::CacheKey;
 use ruff_python_ast::{PySourceType, PythonVersion};
 use ruff_python_formatter::{
-    DocstringCode, DocstringCodeLineWidth, MagicTrailingComma, PreviewMode, PyFormatOptions,
-    QuoteStyle,
+    BlankLinesAroundControls, DocstringCode, DocstringCodeLineWidth, MagicTrailingComma,
+    PreviewMode, PyFormatOptions, QuoteStyle,
 };
 use ruff_source_file::find_newline;
 use std::fmt;
@@ -196,6 +196,10 @@ pub struct FormatterSettings {
 
     pub docstring_code_format: DocstringCode,
     pub docstring_code_line_width: DocstringCodeLineWidth,
+
+    /// Whether to enforce a blank line before and after control blocks
+    /// (if/for/while/with/try) inside suites.
+    pub blank_lines_around_controls: BlankLinesAroundControls,
 }
 
 impl FormatterSettings {
@@ -241,6 +245,7 @@ impl FormatterSettings {
             .with_line_width(self.line_width)
             .with_docstring_code(self.docstring_code_format)
             .with_docstring_code_line_width(self.docstring_code_line_width)
+            .with_blank_lines_around_controls(self.blank_lines_around_controls)
     }
 
     /// Resolve the [`PythonVersion`] to use for formatting.
@@ -273,6 +278,7 @@ impl Default for FormatterSettings {
             magic_trailing_comma: default_options.magic_trailing_comma(),
             docstring_code_format: default_options.docstring_code(),
             docstring_code_line_width: default_options.docstring_code_line_width(),
+            blank_lines_around_controls: default_options.blank_lines_around_controls(),
         }
     }
 }
@@ -295,7 +301,8 @@ impl fmt::Display for FormatterSettings {
                 self.quote_style,
                 self.magic_trailing_comma,
                 self.docstring_code_format,
-                self.docstring_code_line_width,
+                    self.docstring_code_line_width,
+                    self.blank_lines_around_controls,
             ]
         }
         Ok(())

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -172,6 +172,9 @@ If left unspecified, Ruff's default configuration is equivalent to:
     # This only has an effect when the `docstring-code-format` setting is
     # enabled.
     docstring-code-line-length = "dynamic"
+
+    # Enable inserting blank lines around controlis like if/for/while/with
+    blank-lines-around-controls = false
     ```
 
 As an example, the following would configure Ruff to:

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -1528,6 +1528,13 @@
       "description": "Configures the way Ruff formats your code.",
       "type": "object",
       "properties": {
+        "blank-lines-around-controls": {
+          "description": "Whether to insert blank lines around control blocks (if/for/while/with/try)",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "docstring-code-format": {
           "description": "Whether to format code snippets in docstrings.\n\nWhen this is enabled, Python code examples within docstrings are automatically reformatted.\n\nFor example, when this is enabled, the following code:\n\n```python def f(x): \"\"\" Something about `f`. And an example in doctest format:\n\n>>> f(  x  )\n\nMarkdown is also supported:\n\n```py f(  x  ) ```\n\nAs are reStructuredText literal blocks::\n\nf(  x  )\n\nAnd reStructuredText code blocks:\n\n.. code-block:: python\n\nf(  x  ) \"\"\" pass ```\n\n... will be reformatted (assuming the rest of the options are set to their defaults) as:\n\n```python def f(x): \"\"\" Something about `f`. And an example in doctest format:\n\n>>> f(x)\n\nMarkdown is also supported:\n\n```py f(x) ```\n\nAs are reStructuredText literal blocks::\n\nf(x)\n\nAnd reStructuredText code blocks:\n\n.. code-block:: python\n\nf(x) \"\"\" pass ```\n\nIf a code snippet in a docstring contains invalid Python code or if the formatter would otherwise write invalid Python code, then the code example is ignored by the formatter and kept as-is.\n\nCurrently, doctest, Markdown, reStructuredText literal blocks, and reStructuredText code blocks are all supported and automatically recognized. In the case of unlabeled fenced code blocks in Markdown and reStructuredText literal blocks, the contents are assumed to be Python and reformatted. As with any other format, if the contents aren't valid Python, then the block is left untouched automatically.",
           "type": [


### PR DESCRIPTION
## Summary

Adds new formatter option: format.blank-lines-around-controls (default: false)
Optional style to visually separate control-flow blocks(if/while/whith/for) without impacting default behavior
No change to stable formatting by default; feature is opt-in
Applies at both top-level and within suites, respecting existing comment/import spacing logic
Minimal perf impact; uses existing trivia counting helpers

## Test Plan

New unit test in ruff_python_formatter asserts extra blank lines around control statements
Also testedmanually
