### PR TITLE
[ty] `~T` should never be assignable to `T`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -522,3 +522,17 @@ age, name = team.employees[0]
 reveal_type(age)  # revealed: Age
 reveal_type(name)  # revealed: Name
 ```
+
+## `~T` is never assignable to `T`
+
+```py
+from typing import TypeVar
+from ty_extensions import Not
+
+T = TypeVar("T")
+
+def f(x: T, y: Not[T]) -> T:
+    x = y  # error: [invalid-assignment]
+    y = x  # error: [invalid-assignment]
+    return x
+```

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -537,3 +537,14 @@ def _(x: int):
     # TODO: this should be `tuple[C, int]` as well, once we support implicit `self`
     reveal_type(C().implicit_self(x))  # revealed: tuple[Unknown, int]
 ```
+
+## `~T` is never assignable to `T`
+
+```py
+from ty_extensions import Not
+
+def f[T](x: T, y: Not[T]) -> T:
+    x = y  # error: [invalid-assignment]
+    y = x  # error: [invalid-assignment]
+    return x
+```

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1562,7 +1562,7 @@ impl<'db> Type<'db> {
             (Type::Intersection(intersection), Type::NonInferableTypeVar(_))
                 if intersection.negative(db).contains(&target) =>
             {
-                ConstraintSet::from(true)
+                ConstraintSet::from(false)
             }
 
             // Two identical typevars must always solve to the same type, so they are always


### PR DESCRIPTION
## Summary

Currently we do not emit an error on this code:

```py
from ty_extensions import Not

def f[T](x: T, y: Not[T]) -> T:
    x = y
    return x
```

But we should do! `~T` should never be assignable to `T`.

This fixes a small regression introduced in https://github.com/astral-sh/ruff/commit/14fe1228e72dca90db6b3dbb7e07f973d175ea0e#diff-8049ab5af787dba29daa389bbe2b691560c15461ef536f122b1beab112a4b48aR1443-R1446, where a branch that previously returned `false` was replaced with a branch that returns `C::always_satisfiable` -- the opposite of what it used to be! The regression occurred because we didn't have any tests for this -- so I added some tests in this PR that fail on `main`. I only spotted the problem because I was going through the code of `has_relation_to_impl` with a fine toothcomb for https://github.com/astral-sh/ruff/pull/20602 😄