### PR TITLE
[`flake8-annotations`] Fix return type annotations to handle shadowed builtin symbols (`ANN201`, `ANN202`, `ANN204`, `ANN205`, `ANN206`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_annotations/shadowed_builtins.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_annotations/shadowed_builtins.py
@@ -1,0 +1,21 @@
+from collections import UserString as str
+from typing import override
+
+def foo():
+    return "!"
+
+def _foo():
+    return "!"
+
+class C:
+    @override
+    def __str__(self):
+        return "!"
+    
+    @staticmethod
+    def foo():
+        return "!"
+    
+    @classmethod
+    def bar(cls):
+        return "!"

--- a/crates/ruff_linter/src/rules/flake8_annotations/helpers.rs
+++ b/crates/ruff_linter/src/rules/flake8_annotations/helpers.rs
@@ -266,17 +266,13 @@ fn type_expr(
             Some((expr, edit.map_or_else(Vec::new, |edit| vec![edit])))
         }
         PythonType::None => {
-            let (edit, binding) = checker
-                .importer()
-                .get_or_import_builtin_symbol("None", at, checker.semantic())
-                .ok()?;
             let expr = Expr::Name(ast::ExprName {
-                id: binding.into(),
+                id: "None".into(),
                 range: TextRange::default(),
                 node_index: ruff_python_ast::AtomicNodeIndex::NONE,
                 ctx: ExprContext::Load,
             });
-            Some((expr, edit.map_or_else(Vec::new, |edit| vec![edit])))
+            Some((expr, vec![]))
         }
         PythonType::Ellipsis => None,
         PythonType::Dict => None,

--- a/crates/ruff_linter/src/rules/flake8_annotations/helpers.rs
+++ b/crates/ruff_linter/src/rules/flake8_annotations/helpers.rs
@@ -143,22 +143,27 @@ impl AutoPythonType {
                 Some((expr, vec![no_return_edit]))
             }
             AutoPythonType::Atom(python_type) => {
-                let expr = type_expr(python_type)?;
-                Some((expr, vec![]))
+                let (expr, edits) = type_expr(python_type, checker, at)?;
+                Some((expr, edits))
             }
             AutoPythonType::Union(python_types) => {
                 if target_version >= PythonVersion::PY310 {
                     // Aggregate all the individual types (e.g., `int`, `float`).
+                    let mut all_edits = Vec::new();
                     let names = python_types
                         .iter()
                         .sorted_unstable()
-                        .map(|python_type| type_expr(*python_type))
+                        .map(|python_type| {
+                            let (expr, mut edits) = type_expr(*python_type, checker, at)?;
+                            all_edits.append(&mut edits);
+                            Some(expr)
+                        })
                         .collect::<Option<Vec<_>>>()?;
 
                     // Wrap in a bitwise union (e.g., `int | float`).
                     let expr = pep_604_union(&names);
 
-                    Some((expr, vec![]))
+                    Some((expr, all_edits))
                 } else {
                     let python_types = python_types
                         .into_iter()
@@ -167,7 +172,7 @@ impl AutoPythonType {
 
                     match python_types.as_slice() {
                         [python_type, PythonType::None] | [PythonType::None, python_type] => {
-                            let element = type_expr(*python_type)?;
+                            let (element, mut edits) = type_expr(*python_type, checker, at)?;
 
                             // Ex) `Optional[int]`
                             let (optional_edit, binding) = checker
@@ -175,12 +180,18 @@ impl AutoPythonType {
                                 .import(at)
                                 .ok()?;
                             let expr = typing_optional(element, Name::from(binding));
-                            Some((expr, vec![optional_edit]))
+                            edits.push(optional_edit);
+                            Some((expr, edits))
                         }
                         _ => {
+                            let mut all_edits = Vec::new();
                             let elements = python_types
                                 .into_iter()
-                                .map(type_expr)
+                                .map(|python_type| {
+                                    let (expr, mut edits) = type_expr(python_type, checker, at)?;
+                                    all_edits.append(&mut edits);
+                                    Some(expr)
+                                })
                                 .collect::<Option<Vec<_>>>()?;
 
                             // Ex) `Union[int, str]`
@@ -189,7 +200,8 @@ impl AutoPythonType {
                                 .import(at)
                                 .ok()?;
                             let expr = typing_union(&elements, Name::from(binding));
-                            Some((expr, vec![union_edit]))
+                            all_edits.push(union_edit);
+                            Some((expr, all_edits))
                         }
                     }
                 }
@@ -199,26 +211,73 @@ impl AutoPythonType {
 }
 
 /// Given a [`PythonType`], return an [`Expr`] that resolves to that type.
-fn type_expr(python_type: PythonType) -> Option<Expr> {
-    fn name(name: &str) -> Expr {
-        Expr::Name(ast::ExprName {
-            id: name.into(),
-            range: TextRange::default(),
-            node_index: ruff_python_ast::AtomicNodeIndex::NONE,
-            ctx: ExprContext::Load,
-        })
-    }
-
+///
+/// If the [`Expr`] relies on importing any external symbols, those imports will be returned as
+/// additional edits.
+fn type_expr(
+    python_type: PythonType,
+    checker: &Checker,
+    at: TextSize,
+) -> Option<(Expr, Vec<Edit>)> {
     match python_type {
-        PythonType::String => Some(name("str")),
-        PythonType::Bytes => Some(name("bytes")),
-        PythonType::Number(number) => match number {
-            NumberLike::Integer => Some(name("int")),
-            NumberLike::Float => Some(name("float")),
-            NumberLike::Complex => Some(name("complex")),
-            NumberLike::Bool => Some(name("bool")),
-        },
-        PythonType::None => Some(name("None")),
+        PythonType::String => {
+            let (edit, binding) = checker
+                .importer()
+                .get_or_import_builtin_symbol("str", at, checker.semantic())
+                .ok()?;
+            let expr = Expr::Name(ast::ExprName {
+                id: binding.into(),
+                range: TextRange::default(),
+                node_index: ruff_python_ast::AtomicNodeIndex::NONE,
+                ctx: ExprContext::Load,
+            });
+            Some((expr, edit.map_or_else(Vec::new, |edit| vec![edit])))
+        }
+        PythonType::Bytes => {
+            let (edit, binding) = checker
+                .importer()
+                .get_or_import_builtin_symbol("bytes", at, checker.semantic())
+                .ok()?;
+            let expr = Expr::Name(ast::ExprName {
+                id: binding.into(),
+                range: TextRange::default(),
+                node_index: ruff_python_ast::AtomicNodeIndex::NONE,
+                ctx: ExprContext::Load,
+            });
+            Some((expr, edit.map_or_else(Vec::new, |edit| vec![edit])))
+        }
+        PythonType::Number(number) => {
+            let symbol = match number {
+                NumberLike::Integer => "int",
+                NumberLike::Float => "float",
+                NumberLike::Complex => "complex",
+                NumberLike::Bool => "bool",
+            };
+            let (edit, binding) = checker
+                .importer()
+                .get_or_import_builtin_symbol(symbol, at, checker.semantic())
+                .ok()?;
+            let expr = Expr::Name(ast::ExprName {
+                id: binding.into(),
+                range: TextRange::default(),
+                node_index: ruff_python_ast::AtomicNodeIndex::NONE,
+                ctx: ExprContext::Load,
+            });
+            Some((expr, edit.map_or_else(Vec::new, |edit| vec![edit])))
+        }
+        PythonType::None => {
+            let (edit, binding) = checker
+                .importer()
+                .get_or_import_builtin_symbol("None", at, checker.semantic())
+                .ok()?;
+            let expr = Expr::Name(ast::ExprName {
+                id: binding.into(),
+                range: TextRange::default(),
+                node_index: ruff_python_ast::AtomicNodeIndex::NONE,
+                ctx: ExprContext::Load,
+            });
+            Some((expr, edit.map_or_else(Vec::new, |edit| vec![edit])))
+        }
         PythonType::Ellipsis => None,
         PythonType::Dict => None,
         PythonType::List => None,

--- a/crates/ruff_linter/src/rules/flake8_annotations/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_annotations/mod.rs
@@ -229,4 +229,20 @@ mod tests {
         assert_diagnostics!(diagnostics);
         Ok(())
     }
+
+    #[test]
+    fn shadowed_builtins() -> Result<()> {
+        let diagnostics = test_path(
+            Path::new("flake8_annotations/shadowed_builtins.py"),
+            &LinterSettings::for_rules(vec![
+                Rule::MissingReturnTypeUndocumentedPublicFunction,
+                Rule::MissingReturnTypePrivateFunction,
+                Rule::MissingReturnTypeSpecialMethod,
+                Rule::MissingReturnTypeStaticMethod,
+                Rule::MissingReturnTypeClassMethod,
+            ]),
+        )?;
+        assert_diagnostics!(diagnostics);
+        Ok(())
+    }
 }

--- a/crates/ruff_linter/src/rules/flake8_annotations/snapshots/ruff_linter__rules__flake8_annotations__tests__shadowed_builtins.snap
+++ b/crates/ruff_linter/src/rules/flake8_annotations/snapshots/ruff_linter__rules__flake8_annotations__tests__shadowed_builtins.snap
@@ -56,14 +56,21 @@ ANN204 [*] Missing return type annotation for special method `__str__`
 13 |         return "!"
    |
 help: Add return type annotation: `str`
-9  | 
-10 | class C:
-11 |     @override
+1  | from collections import UserString as str
+2  | from typing import override
+3  + import builtins
+4  | 
+5  | def foo():
+6  |     return "!"
+--------------------------------------------------------------------------------
+10 | 
+11 | class C:
+12 |     @override
    -     def __str__(self):
-12 +     def __str__(self) -> str:
-13 |         return "!"
-14 |     
-15 |     @staticmethod
+13 +     def __str__(self) -> builtins.str:
+14 |         return "!"
+15 |     
+16 |     @staticmethod
 note: This is an unsafe fix and may change runtime behavior
 
 ANN205 [*] Missing return type annotation for staticmethod `foo`

--- a/crates/ruff_linter/src/rules/flake8_annotations/snapshots/ruff_linter__rules__flake8_annotations__tests__shadowed_builtins.snap
+++ b/crates/ruff_linter/src/rules/flake8_annotations/snapshots/ruff_linter__rules__flake8_annotations__tests__shadowed_builtins.snap
@@ -1,0 +1,117 @@
+---
+source: crates/ruff_linter/src/rules/flake8_annotations/mod.rs
+---
+ANN201 [*] Missing return type annotation for public function `foo`
+ --> shadowed_builtins.py:4:5
+  |
+2 | from typing import override
+3 |
+4 | def foo():
+  |     ^^^
+5 |     return "!"
+  |
+help: Add return type annotation: `builtins.str`
+1 | from collections import UserString as str
+2 | from typing import override
+3 + import builtins
+4 | 
+  - def foo():
+5 + def foo() -> builtins.str:
+6 |     return "!"
+7 | 
+8 | def _foo():
+note: This is an unsafe fix and may change runtime behavior
+
+ANN202 [*] Missing return type annotation for private function `_foo`
+ --> shadowed_builtins.py:7:5
+  |
+5 |     return "!"
+6 |
+7 | def _foo():
+  |     ^^^^
+8 |     return "!"
+  |
+help: Add return type annotation: `builtins.str`
+1  | from collections import UserString as str
+2  | from typing import override
+3  + import builtins
+4  | 
+5  | def foo():
+6  |     return "!"
+7  | 
+   - def _foo():
+8  + def _foo() -> builtins.str:
+9  |     return "!"
+10 | 
+11 | class C:
+note: This is an unsafe fix and may change runtime behavior
+
+ANN204 [*] Missing return type annotation for special method `__str__`
+  --> shadowed_builtins.py:12:9
+   |
+10 | class C:
+11 |     @override
+12 |     def __str__(self):
+   |         ^^^^^^^
+13 |         return "!"
+   |
+help: Add return type annotation: `str`
+9  | 
+10 | class C:
+11 |     @override
+   -     def __str__(self):
+12 +     def __str__(self) -> str:
+13 |         return "!"
+14 |     
+15 |     @staticmethod
+note: This is an unsafe fix and may change runtime behavior
+
+ANN205 [*] Missing return type annotation for staticmethod `foo`
+  --> shadowed_builtins.py:16:9
+   |
+15 |     @staticmethod
+16 |     def foo():
+   |         ^^^
+17 |         return "!"
+   |
+help: Add return type annotation: `builtins.str`
+1  | from collections import UserString as str
+2  | from typing import override
+3  + import builtins
+4  | 
+5  | def foo():
+6  |     return "!"
+--------------------------------------------------------------------------------
+14 |         return "!"
+15 |     
+16 |     @staticmethod
+   -     def foo():
+17 +     def foo() -> builtins.str:
+18 |         return "!"
+19 |     
+20 |     @classmethod
+note: This is an unsafe fix and may change runtime behavior
+
+ANN206 [*] Missing return type annotation for classmethod `bar`
+  --> shadowed_builtins.py:20:9
+   |
+19 |     @classmethod
+20 |     def bar(cls):
+   |         ^^^
+21 |         return "!"
+   |
+help: Add return type annotation: `builtins.str`
+1  | from collections import UserString as str
+2  | from typing import override
+3  + import builtins
+4  | 
+5  | def foo():
+6  |     return "!"
+--------------------------------------------------------------------------------
+18 |         return "!"
+19 |     
+20 |     @classmethod
+   -     def bar(cls):
+21 +     def bar(cls) -> builtins.str:
+22 |         return "!"
+note: This is an unsafe fix and may change runtime behavior


### PR DESCRIPTION
## Summary

Fixes #20610
