### PR TITLE
Add the *The Basics* title back to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,8 @@ exploration of new features, we will often close these pull requests immediately
 new feature to ruff creates a long-term maintenance burden and requires strong consensus from the ruff
 team before it is appropriate to begin work on an implementation.
 
+## The Basics
+
 ### Prerequisites
 
 Ruff is written in Rust. You'll need to install the


### PR DESCRIPTION
## Summary

I removed the *The Basics* header in https://github.com/astral-sh/ruff/pull/20567
but I didn't notice that the section had sub-section.

Re-adding the section because the sub-sections are separate from *Finding ways to help*

