### PR TITLE
[ty] Ecosystem analyzer: relax timeout thresholds

### DIFF
--- a/.github/workflows/ty-ecosystem-analyzer.yaml
+++ b/.github/workflows/ty-ecosystem-analyzer.yaml
@@ -64,7 +64,7 @@ jobs:
 
           cd ..
 
-          uv tool install "git+https://github.com/astral-sh/ecosystem-analyzer@fc0f612798710b0dd69bb7528bc9b361dc60bd43"
+          uv tool install "git+https://github.com/astral-sh/ecosystem-analyzer@6ce3a609575bc84eaf5d247739529c60b6c2ae5b"
 
           ecosystem-analyzer \
             --repository ruff \

--- a/.github/workflows/ty-ecosystem-report.yaml
+++ b/.github/workflows/ty-ecosystem-report.yaml
@@ -49,7 +49,7 @@ jobs:
 
           cd ..
 
-          uv tool install "git+https://github.com/astral-sh/ecosystem-analyzer@fc0f612798710b0dd69bb7528bc9b361dc60bd43"
+          uv tool install "git+https://github.com/astral-sh/ecosystem-analyzer@6ce3a609575bc84eaf5d247739529c60b6c2ae5b"
 
           ecosystem-analyzer \
             --verbose \


### PR DESCRIPTION
## Summary

Pull in a small upstream change (https://github.com/astral-sh/ecosystem-analyzer/commit/6ce3a609575bc84eaf5d247739529c60b6c2ae5b), because some type check times were close to the previous limits, which prevents us from seeing diagnostics diffs (in case they run into a timeout).
