### PR TITLE
[ty] Use fully qualified names to distinguish ambiguous protocols in diagnostics

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/same_names.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/same_names.md
@@ -170,6 +170,36 @@ class Container(Generic[T]):
 
 ## Protocols
 
+### Differing members
+
+`bad.py`:
+
+```py
+from typing import Protocol, TypeVar
+
+T_co = TypeVar("T_co", covariant=True)
+
+class Iterator(Protocol[T_co]):
+    def __nexxt__(self) -> T_co: ...
+
+def bad() -> Iterator[str]:
+    raise NotImplementedError
+```
+
+`main.py`:
+
+```py
+from typing import Iterator
+
+def f() -> Iterator[str]:
+    import bad
+
+    # error: [invalid-return-type] "Return type does not match returned value: expected `typing.Iterator[str]`, found `bad.Iterator[str]"
+    return bad.bad()
+```
+
+### Same members but with different types
+
 ```py
 from typing import Protocol
 import proto_a


### PR DESCRIPTION
## Summary

A minor followup to https://github.com/astral-sh/ruff/pull/20603. I'm adding the `internal` label as I don't think it warrants an additional changelog entry

## Test Plan

Added an mdtest that fails on `main`
