### PR TITLE
[`flake8-bandit`] Fix false negative with implicit string concatenation (`S608`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_bandit/S608.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_bandit/S608.py
@@ -179,3 +179,10 @@ query63 = t"""
 """
 query64 = f"update {t"{table}"} set var = {t"{var}"}"
 query65 = t"update {f"{table}"} set var = {f"{var}"}"
+
+# Implicit string concatenation with binary operation
+def query66():
+    return (
+        "select * "
+        "from \"" + schema + "\""
+    )

--- a/crates/ruff_linter/src/rules/flake8_bandit/snapshots/ruff_linter__rules__flake8_bandit__tests__S608_S608.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bandit/snapshots/ruff_linter__rules__flake8_bandit__tests__S608_S608.py.snap
@@ -672,3 +672,14 @@ S608 Possible SQL injection vector through string-based query construction
     |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 181 | query65 = t"update {f"{table}"} set var = {f"{var}"}"
     |
+
+S608 Possible SQL injection vector through string-based query construction
+   --> S608.py:186:9
+    |
+184 |   def query66():
+185 |       return (
+186 | /         "select * "
+187 | |         "from \"" + schema + "\""
+    | |_________________________________^
+188 |       )
+    |


### PR DESCRIPTION
# Disclaimer

This is my first PR to Ruff, and I’m still learning Rust. I’ve done my best to follow the contributing guide and the repository’s patterns, though I may have missed some details. I’d be grateful for your patience and feedback to help me improve.

# Summary

The S608 rule (flake8-bandit's hardcoded_sql_expression) was not detecting SQL injection vulnerabilities in expressions that combine implicit string concatenation with binary operations.

# Bug Description

The rule failed to catch SQL injection patterns like:
```
query("select * "
"from \"" + schema + "\"")
```

# Testing

- Added test case query66 that reproduces the vulnerability
-  Verified all existing tests pass