### PR TITLE
[ty] Remove unnecessary `parsed_module()` calls

### DIFF
--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -5632,11 +5632,9 @@ impl<'db> Type<'db> {
             Type::KnownInstance(known_instance) => match known_instance {
                 KnownInstanceType::TypeAliasType(alias) => Ok(Type::TypeAlias(*alias)),
                 KnownInstanceType::TypeVar(typevar) => {
-                    let module = parsed_module(db, scope_id.file(db)).load(db);
                     let index = semantic_index(db, scope_id.file(db));
                     Ok(bind_typevar(
                         db,
-                        &module,
                         index,
                         scope_id.file_scope_id(db),
                         typevar_binding_context,
@@ -5709,7 +5707,6 @@ impl<'db> Type<'db> {
                     .build()),
 
                 SpecialFormType::TypingSelf => {
-                    let module = parsed_module(db, scope_id.file(db)).load(db);
                     let index = semantic_index(db, scope_id.file(db));
                     let Some(class) = nearest_enclosing_class(db, index, scope_id) else {
                         return Err(InvalidTypeExpressionError {
@@ -5747,7 +5744,6 @@ impl<'db> Type<'db> {
                     );
                     Ok(bind_typevar(
                         db,
-                        &module,
                         index,
                         scope_id.file_scope_id(db),
                         typevar_binding_context,

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -8978,7 +8978,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 if let Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) = typevar {
                     bind_typevar(
                         self.db(),
-                        self.module(),
                         self.index,
                         self.scope().file_scope_id(self.db()),
                         self.typevar_binding_context,


### PR DESCRIPTION
## Summary

I noticed this while reviewing #20517. It's unnecessary for `bind_typevar` and `enclosing_generic_context` to depend directly on a module's AST.

## Test Plan

Existing tests
