### PR TITLE
[ty] Add tests for nested generic functions

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -464,6 +464,7 @@ def f(x: str):
 from typing import TypeVar, overload
 
 T = TypeVar("T")
+S = TypeVar("S")
 
 def outer(t: T) -> None:
     def inner(t: T) -> None: ...
@@ -479,6 +480,13 @@ def overloaded_outer(t: T | None = None) -> None:
 
     if t is not None:
         inner(t)
+
+def outer(t: T) -> None:
+    def inner(inner_t: T, s: S) -> tuple[T, S]:
+        return inner_t, s
+    reveal_type(inner(t, 1))  # revealed: tuple[T@outer, Literal[1]]
+
+    inner("wrong", 1)  # error: [invalid-argument-type]
 ```
 
 ## Unpacking a TypeVar

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -474,6 +474,13 @@ def overloaded_outer[T](t: T | None = None) -> None:
 
     if t is not None:
         inner(t)
+
+def outer[T](t: T) -> None:
+    def inner[S](inner_t: T, s: S) -> tuple[T, S]:
+        return inner_t, s
+    reveal_type(inner(t, 1))  # revealed: tuple[T@outer, Literal[1]]
+
+    inner("wrong", 1)  # error: [invalid-argument-type]
 ```
 
 ## Unpacking a TypeVar


### PR DESCRIPTION
## Summary

Add two simple tests that we recently discussed with @dcreager. They demonstrate that the `TypeMapping::MarkTypeVarsInferable` operation really does need to keep track of the binding context.

## Test Plan

Made sure that those tests fail if we create `TypeMapping::MarkTypeVarsInferable(None)`s everywhere.