### PR TITLE
[ty] Clean up inherited generic contexts

### DIFF
--- a/crates/ruff_memory_usage/src/lib.rs
+++ b/crates/ruff_memory_usage/src/lib.rs
@@ -1,7 +1,7 @@
 use std::sync::{LazyLock, Mutex};
 
 use get_size2::{GetSize, StandardTracker};
-use ordermap::OrderSet;
+use ordermap::{OrderMap, OrderSet};
 
 /// Returns the memory usage of the provided object, using a global tracker to avoid
 /// double-counting shared objects.
@@ -17,4 +17,12 @@ pub fn heap_size<T: GetSize>(value: &T) -> usize {
 /// An implementation of [`GetSize::get_heap_size`] for [`OrderSet`].
 pub fn order_set_heap_size<T: GetSize, S>(set: &OrderSet<T, S>) -> usize {
     (set.capacity() * T::get_stack_size()) + set.iter().map(heap_size).sum::<usize>()
+}
+
+/// An implementation of [`GetSize::get_heap_size`] for [`OrderMap`].
+pub fn order_map_heap_size<K: GetSize, V: GetSize, S>(map: &OrderMap<K, V, S>) -> usize {
+    (map.capacity() * (K::get_stack_size() + V::get_stack_size()))
+        + (map.iter())
+            .map(|(k, v)| heap_size(k) + heap_size(v))
+            .sum::<usize>()
 }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -6772,13 +6772,11 @@ impl<'db> TypeMapping<'_, 'db> {
                 db,
                 context
                     .variables(db)
-                    .iter()
-                    .filter(|var| !var.typevar(db).is_self(db))
-                    .copied(),
+                    .filter(|var| !var.typevar(db).is_self(db)),
             ),
             TypeMapping::ReplaceSelf { new_upper_bound } => GenericContext::from_typevar_instances(
                 db,
-                context.variables(db).iter().map(|typevar| {
+                context.variables(db).map(|typevar| {
                     if typevar.typevar(db).is_self(db) {
                         BoundTypeVarInstance::synthetic_self(
                             db,
@@ -6786,7 +6784,7 @@ impl<'db> TypeMapping<'_, 'db> {
                             typevar.binding_context(db),
                         )
                     } else {
-                        *typevar
+                        typevar
                     }
                 }),
             ),

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -5481,11 +5481,6 @@ impl<'db> Type<'db> {
                     combine_specializations(db, new_specialization, init_specialization);
                 let specialized = specialization
                     .map(|specialization| {
-                        // Promote any typevars that are inferred as a literal to the corresponding
-                        // instance type.
-                        specialization.apply_type_mapping(db, &TypeMapping::PromoteLiterals)
-                    })
-                    .map(|specialization| {
                         Type::instance(
                             db,
                             generic_origin.apply_specialization(db, |_| specialization),

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -324,7 +324,6 @@ impl<'db> VarianceInferable<'db> for GenericAlias<'db> {
                 specialization
                     .generic_context(db)
                     .variables(db)
-                    .iter()
                     .zip(specialization.types(db))
                     .map(|(generic_typevar, ty)| {
                         if let Some(explicit_variance) =
@@ -346,7 +345,7 @@ impl<'db> VarianceInferable<'db> for GenericAlias<'db> {
                             let typevar_variance_in_substituted_type = ty.variance_of(db, typevar);
                             origin
                                 .with_polarity(typevar_variance_in_substituted_type)
-                                .variance_of(db, *generic_typevar)
+                                .variance_of(db, generic_typevar)
                         }
                     }),
             )

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -1011,8 +1011,7 @@ impl<'db> ClassType<'db> {
 
                 let synthesized_dunder = CallableType::function_like(
                     db,
-                    Signature::new(parameters, None)
-                        .with_inherited_generic_context(inherited_generic_context),
+                    Signature::new_generic(inherited_generic_context, parameters, None),
                 );
 
                 Place::bound(synthesized_dunder).into()
@@ -2244,8 +2243,14 @@ impl<'db> ClassLiteral<'db> {
             // so that the keyword-only parameters appear after positional parameters.
             parameters.sort_by_key(Parameter::is_keyword_only);
 
-            let mut signature = Signature::new(Parameters::new(parameters), return_ty);
-            signature.inherited_generic_context = self.generic_context(db);
+            let signature = match name {
+                "__new__" | "__init__" => Signature::new_generic(
+                    self.generic_context(db),
+                    Parameters::new(parameters),
+                    return_ty,
+                ),
+                _ => Signature::new(Parameters::new(parameters), return_ty),
+            };
             Some(CallableType::function_like(db, signature))
         };
 

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -832,7 +832,6 @@ impl Display for DisplayGenericContext<'_> {
         let variables = self.generic_context.variables(self.db);
 
         let non_implicit_variables: Vec<_> = variables
-            .iter()
             .filter(|bound_typevar| !bound_typevar.typevar(self.db).is_self(self.db))
             .collect();
 

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -654,7 +654,7 @@ pub(crate) struct DisplayOverloadLiteral<'db> {
 
 impl Display for DisplayOverloadLiteral<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let signature = self.literal.signature(self.db, None);
+        let signature = self.literal.signature(self.db);
         let type_parameters = DisplayOptionalGenericContext {
             generic_context: signature.generic_context.as_ref(),
             db: self.db,
@@ -852,6 +852,10 @@ impl Display for DisplayGenericContext<'_> {
 }
 
 impl<'db> Specialization<'db> {
+    pub fn display(&'db self, db: &'db dyn Db) -> DisplaySpecialization<'db> {
+        self.display_short(db, TupleSpecialization::No, DisplaySettings::default())
+    }
+
     /// Renders the specialization as it would appear in a subscript expression, e.g. `[int, str]`.
     pub fn display_short(
         &'db self,

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -139,9 +139,6 @@ pub(crate) fn typing_self<'db>(
 
 /// A list of formal type variables for a generic function, class, or type alias.
 ///
-/// TODO: Handle nested generic contexts better, with actual parent links to the lexically
-/// containing context.
-///
 /// # Ordering
 /// Ordering is based on the context's salsa-assigned id and not on its values.
 /// The id may change between runs, or when the context was garbage collected and recreated.

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -138,7 +138,16 @@ pub(crate) fn typing_self<'db>(
 }
 
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, PartialEq, get_size2::GetSize)]
-pub struct GenericContextTypeVarOptions {}
+pub struct GenericContextTypeVarOptions {
+    should_promote_literals: bool,
+}
+
+impl GenericContextTypeVarOptions {
+    fn promote_literals(mut self) -> Self {
+        self.should_promote_literals = true;
+        self
+    }
+}
 
 /// A list of formal type variables for a generic function, class, or type alias.
 ///
@@ -197,6 +206,17 @@ impl<'db> GenericContext<'db> {
             type_params
                 .into_iter()
                 .map(|bound_typevar| (bound_typevar, GenericContextTypeVarOptions::default())),
+        )
+    }
+
+    /// Returns a copy of this generic context where we will promote literal types in any inferred
+    /// specializations.
+    pub(crate) fn promote_literals(self, db: &'db dyn Db) -> Self {
+        Self::from_variables(
+            db,
+            self.variables_inner(db)
+                .iter()
+                .map(|(bound_typevar, options)| (*bound_typevar, options.promote_literals())),
         )
     }
 

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -236,9 +236,7 @@ impl<'db> GenericContext<'db> {
         self,
         db: &'db dyn Db,
     ) -> impl ExactSizeIterator<Item = BoundTypeVarInstance<'db>> + Clone {
-        self.variables_inner(db)
-            .iter()
-            .map(|(bound_typevar, _)| *bound_typevar)
+        self.variables_inner(db).keys().copied()
     }
 
     fn variable_from_type_param(

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -2141,10 +2141,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             deprecated,
             dataclass_transformer_params,
         );
-
-        let inherited_generic_context = None;
-        let function_literal =
-            FunctionLiteral::new(self.db(), overload_literal, inherited_generic_context);
+        let function_literal = FunctionLiteral::new(self.db(), overload_literal);
 
         let mut inferred_ty =
             Type::FunctionLiteral(FunctionType::new(self.db(), function_literal, None, None));

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -88,13 +88,12 @@ use crate::types::typed_dict::{
 };
 use crate::types::visitor::any_over_type;
 use crate::types::{
-    BoundTypeVarInstance, CallDunderError, CallableType, ClassLiteral, ClassType, DataclassParams,
-    DynamicType, IntersectionBuilder, IntersectionType, KnownClass, KnownInstanceType,
-    MemberLookupPolicy, MetaclassCandidate, PEP695TypeAliasType, Parameter, ParameterForm,
-    Parameters, SpecialFormType, SubclassOfType, TrackedConstraintSet, Truthiness, Type,
-    TypeAliasType, TypeAndQualifiers, TypeContext, TypeQualifiers,
-    TypeVarBoundOrConstraintsEvaluation, TypeVarDefaultEvaluation, TypeVarInstance, TypeVarKind,
-    UnionBuilder, UnionType, binding_type, todo_type,
+    CallDunderError, CallableType, ClassLiteral, ClassType, DataclassParams, DynamicType,
+    IntersectionBuilder, IntersectionType, KnownClass, KnownInstanceType, MemberLookupPolicy,
+    MetaclassCandidate, PEP695TypeAliasType, Parameter, ParameterForm, Parameters, SpecialFormType,
+    SubclassOfType, TrackedConstraintSet, Truthiness, Type, TypeAliasType, TypeAndQualifiers,
+    TypeContext, TypeQualifiers, TypeVarBoundOrConstraintsEvaluation, TypeVarDefaultEvaluation,
+    TypeVarInstance, TypeVarKind, UnionBuilder, UnionType, binding_type, todo_type,
 };
 use crate::types::{ClassBase, add_inferred_python_version_hint_to_diagnostic};
 use crate::unpack::{EvaluationMode, UnpackPosition};
@@ -5351,19 +5350,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         collection_class: KnownClass,
     ) -> Option<Type<'db>> {
         // Extract the type variable `T` from `list[T]` in typeshed.
-        fn elt_tys(
-            collection_class: KnownClass,
-            db: &dyn Db,
-        ) -> Option<(
-            ClassLiteral<'_>,
-            impl Iterator<Item = BoundTypeVarInstance<'_>> + Clone,
-        )> {
-            let class_literal = collection_class.try_to_class_literal(db)?;
-            let generic_context = class_literal.generic_context(db)?;
-            Some((class_literal, generic_context.variables(db)))
-        }
+        let elt_tys = |collection_class: KnownClass| {
+            let class_literal = collection_class.try_to_class_literal(self.db())?;
+            let generic_context = class_literal.generic_context(self.db())?;
+            Some((class_literal, generic_context.variables(self.db())))
+        };
 
-        let (class_literal, elt_tys) = elt_tys(collection_class, self.db()).unwrap_or_else(|| {
+        let (class_literal, elt_tys) = elt_tys(collection_class).unwrap_or_else(|| {
             let name = collection_class.name(self.db());
             panic!("Typeshed should always have a `{name}` class in `builtins.pyi`")
         });

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -422,7 +422,6 @@ impl<'db> Signature<'db> {
             (Some(legacy_ctx), Some(ctx)) => {
                 if legacy_ctx
                     .variables(db)
-                    .iter()
                     .exactly_one()
                     .is_ok_and(|bound_typevar| bound_typevar.typevar(db).is_self(db))
                 {
@@ -1226,10 +1225,7 @@ impl<'db> Parameters<'db> {
                 let method_has_self_in_generic_context =
                     method.signature(db).overloads.iter().any(|s| {
                         s.generic_context.is_some_and(|context| {
-                            context
-                                .variables(db)
-                                .iter()
-                                .any(|v| v.typevar(db).is_self(db))
+                            context.variables(db).any(|v| v.typevar(db).is_self(db))
                         })
                     });
 

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -102,12 +102,13 @@ impl<'db> CallableSignature<'db> {
 
     pub(crate) fn with_inherited_generic_context(
         &self,
-        inherited_generic_context: Option<GenericContext<'db>>,
+        db: &'db dyn Db,
+        inherited_generic_context: GenericContext<'db>,
     ) -> Self {
         Self::from_overloads(self.overloads.iter().map(|signature| {
             signature
                 .clone()
-                .with_inherited_generic_context(inherited_generic_context)
+                .with_inherited_generic_context(db, inherited_generic_context)
         }))
     }
 
@@ -301,11 +302,6 @@ pub struct Signature<'db> {
     /// The generic context for this overload, if it is generic.
     pub(crate) generic_context: Option<GenericContext<'db>>,
 
-    /// The inherited generic context, if this function is a class method being used to infer the
-    /// specialization of its generic class. If the method is itself generic, this is in addition
-    /// to its own generic context.
-    pub(crate) inherited_generic_context: Option<GenericContext<'db>>,
-
     /// The original definition associated with this function, if available.
     /// This is useful for locating and extracting docstring information for the signature.
     pub(crate) definition: Option<Definition<'db>>,
@@ -332,9 +328,6 @@ pub(super) fn walk_signature<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
     if let Some(generic_context) = &signature.generic_context {
         walk_generic_context(db, *generic_context, visitor);
     }
-    if let Some(inherited_generic_context) = &signature.inherited_generic_context {
-        walk_generic_context(db, *inherited_generic_context, visitor);
-    }
     // By default we usually don't visit the type of the default value,
     // as it isn't relevant to most things
     for parameter in &signature.parameters {
@@ -351,7 +344,6 @@ impl<'db> Signature<'db> {
     pub(crate) fn new(parameters: Parameters<'db>, return_ty: Option<Type<'db>>) -> Self {
         Self {
             generic_context: None,
-            inherited_generic_context: None,
             definition: None,
             parameters,
             return_ty,
@@ -365,7 +357,6 @@ impl<'db> Signature<'db> {
     ) -> Self {
         Self {
             generic_context,
-            inherited_generic_context: None,
             definition: None,
             parameters,
             return_ty,
@@ -376,7 +367,6 @@ impl<'db> Signature<'db> {
     pub(crate) fn dynamic(signature_type: Type<'db>) -> Self {
         Signature {
             generic_context: None,
-            inherited_generic_context: None,
             definition: None,
             parameters: Parameters::gradual_form(),
             return_ty: Some(signature_type),
@@ -389,7 +379,6 @@ impl<'db> Signature<'db> {
         let signature_type = todo_type!(reason);
         Signature {
             generic_context: None,
-            inherited_generic_context: None,
             definition: None,
             parameters: Parameters::todo(),
             return_ty: Some(signature_type),
@@ -400,7 +389,6 @@ impl<'db> Signature<'db> {
     pub(super) fn from_function(
         db: &'db dyn Db,
         generic_context: Option<GenericContext<'db>>,
-        inherited_generic_context: Option<GenericContext<'db>>,
         definition: Definition<'db>,
         function_node: &ast::StmtFunctionDef,
         is_generator: bool,
@@ -449,7 +437,6 @@ impl<'db> Signature<'db> {
 
         Self {
             generic_context: full_generic_context,
-            inherited_generic_context,
             definition: Some(definition),
             parameters,
             return_ty,
@@ -468,9 +455,17 @@ impl<'db> Signature<'db> {
 
     pub(crate) fn with_inherited_generic_context(
         mut self,
-        inherited_generic_context: Option<GenericContext<'db>>,
+        db: &'db dyn Db,
+        inherited_generic_context: GenericContext<'db>,
     ) -> Self {
-        self.inherited_generic_context = inherited_generic_context;
+        match self.generic_context.as_mut() {
+            Some(generic_context) => {
+                *generic_context = generic_context.merge(db, inherited_generic_context);
+            }
+            None => {
+                self.generic_context = Some(inherited_generic_context);
+            }
+        }
         self
     }
 
@@ -482,9 +477,6 @@ impl<'db> Signature<'db> {
         Self {
             generic_context: self
                 .generic_context
-                .map(|ctx| ctx.normalized_impl(db, visitor)),
-            inherited_generic_context: self
-                .inherited_generic_context
                 .map(|ctx| ctx.normalized_impl(db, visitor)),
             // Discard the definition when normalizing, so that two equivalent signatures
             // with different `Definition`s share the same Salsa ID when normalized
@@ -516,7 +508,6 @@ impl<'db> Signature<'db> {
             generic_context: self
                 .generic_context
                 .map(|context| type_mapping.update_signature_generic_context(db, context)),
-            inherited_generic_context: self.inherited_generic_context,
             definition: self.definition,
             parameters: self
                 .parameters
@@ -571,7 +562,6 @@ impl<'db> Signature<'db> {
         }
         Self {
             generic_context: self.generic_context,
-            inherited_generic_context: self.inherited_generic_context,
             definition: self.definition,
             parameters,
             return_ty,
@@ -1882,7 +1872,7 @@ mod tests {
             .literal(&db)
             .last_definition(&db);
 
-        let sig = func.signature(&db, None);
+        let sig = func.signature(&db);
 
         assert!(sig.return_ty.is_none());
         assert_params(&sig, &[]);
@@ -1907,7 +1897,7 @@ mod tests {
             .literal(&db)
             .last_definition(&db);
 
-        let sig = func.signature(&db, None);
+        let sig = func.signature(&db);
 
         assert_eq!(sig.return_ty.unwrap().display(&db).to_string(), "bytes");
         assert_params(
@@ -1959,7 +1949,7 @@ mod tests {
             .literal(&db)
             .last_definition(&db);
 
-        let sig = func.signature(&db, None);
+        let sig = func.signature(&db);
 
         let [
             Parameter {
@@ -1997,7 +1987,7 @@ mod tests {
             .literal(&db)
             .last_definition(&db);
 
-        let sig = func.signature(&db, None);
+        let sig = func.signature(&db);
 
         let [
             Parameter {
@@ -2035,7 +2025,7 @@ mod tests {
             .literal(&db)
             .last_definition(&db);
 
-        let sig = func.signature(&db, None);
+        let sig = func.signature(&db);
 
         let [
             Parameter {
@@ -2079,7 +2069,7 @@ mod tests {
             .literal(&db)
             .last_definition(&db);
 
-        let sig = func.signature(&db, None);
+        let sig = func.signature(&db);
 
         let [
             Parameter {
@@ -2116,7 +2106,7 @@ mod tests {
         let func = get_function_f(&db, "/src/a.py");
 
         let overload = func.literal(&db).last_definition(&db);
-        let expected_sig = overload.signature(&db, None);
+        let expected_sig = overload.signature(&db);
 
         // With no decorators, internal and external signature are the same
         assert_eq!(


### PR DESCRIPTION
We add an `inherited_generic_context` to the constructors of a generic class. That lets us infer specializations of the class when invoking the constructor. The constructor might itself be generic, in which case we have to merge the list of typevars that we are willing to infer in the constructor call.

Before we did that by tracking the two (and their specializations) separately, with distinct `Option` fields/parameters. This PR updates our call binding logic such that any given function call has _one_ optional generic context that we're willing to infer a specialization for. If needed, we use the existing `GenericContext::merge` method to create a new combined generic context for when the class and constructor are both generic. This simplifies the call binding code considerably, and is no more complex in the constructor call logic.

We also have a heuristic that we will promote any literals in the specialized types of a generic class, but we don't promote literals in the specialized types of the function itself. To handle this, we now track this `should_promote_literals` property within `GenericContext`. And moreover, we track this separately for each typevar, instead of a single property for the generic context as a whole, so that we can correctly merge the generic context of a constructor method (where the option should be `false`) with the inherited generic context of its containing class (where the option should be `true`).