### PR TITLE
[`ty`] Reject renaming files to start with slash in Playground

### DIFF
--- a/playground/ty/src/Playground.tsx
+++ b/playground/ty/src/Playground.tsx
@@ -96,6 +96,11 @@ export default function Playground() {
     file: FileId,
     newName: string,
   ) => {
+    if (newName.startsWith("/")) {
+      setError("File names cannot start with '/'.");
+      return;
+    }
+
     const handle = files.handles[file];
     let newHandle: FileHandle | null = null;
     if (handle == null) {


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Fixes https://github.com/astral-sh/ty/issues/1282

Block renaming to names starting with `/`, surfacing a clear error instead of crashing the playground.

## Test Plan

<!-- How was it tested? -->

https://github.com/user-attachments/assets/94848f31-9fcf-46b7-895e-f468e5030104