### PR TITLE
[ty] improve base conda distinction from child conda

### DIFF
--- a/crates/ty/docs/environment.md
+++ b/crates/ty/docs/environment.md
@@ -35,12 +35,16 @@ ty also reads the following externally defined environment variables:
 
 ### `CONDA_DEFAULT_ENV`
 
-Used to determine if an active Conda environment is the base environment or not.
+Used to determine the name of the active Conda environment.
 
 ### `CONDA_PREFIX`
 
-Used to detect an activated Conda environment location.
+Used to detect the path of an active Conda environment.
 If both `VIRTUAL_ENV` and `CONDA_PREFIX` are present, `VIRTUAL_ENV` will be preferred.
+
+### `_CONDA_ROOT`
+
+Used to determine the root install path of Conda.
 
 ### `PYTHONPATH`
 

--- a/crates/ty/tests/cli/python_environment.rs
+++ b/crates/ty/tests/cli/python_environment.rs
@@ -946,6 +946,7 @@ fn defaults_to_a_new_python_version() -> anyhow::Result<()> {
 /// 2) If `CONDA_PREFIX` environment variable is set (and .filename == `CONDA_DEFAULT_ENV`)
 /// 3) If a `.venv` directory exists at the project root
 /// 4) If `CONDA_PREFIX` environment variable is set (and .filename != `CONDA_DEFAULT_ENV`)
+///    or if `_CONDA_ROOT` is set (and `_CONDA_ROOT` == `CONDA_PREFIX`)
 ///
 /// This test (and the next one) is aiming at validating the logic around these cases.
 ///
@@ -1232,6 +1233,55 @@ home = ./
     WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
     ");
 
+    // run with _CONDA_ROOT and CONDA_PREFIX (unequal!) set, should find ChildConda
+    assert_cmd_snapshot!(case.command()
+        .current_dir(case.root().join("project"))
+        .env("CONDA_PREFIX", case.root().join("conda/envs/conda-env"))
+        .env("_CONDA_ROOT", "conda"), @r"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    error[unresolved-import]: Module `package1` has no member `ChildConda`
+     --> test.py:3:22
+      |
+    2 | from package1 import ActiveVenv
+    3 | from package1 import ChildConda
+      |                      ^^^^^^^^^^
+    4 | from package1 import WorkingVenv
+    5 | from package1 import BaseConda
+      |
+    info: rule `unresolved-import` is enabled by default
+
+    Found 1 diagnostic
+
+    ----- stderr -----
+    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
+    ");
+
+    // run with _CONDA_ROOT and CONDA_PREFIX (equal!) set, should find BaseConda
+    assert_cmd_snapshot!(case.command()
+        .current_dir(case.root().join("project"))
+        .env("CONDA_PREFIX", case.root().join("conda"))
+        .env("_CONDA_ROOT", "conda"), @r"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    error[unresolved-import]: Module `package1` has no member `BaseConda`
+     --> test.py:5:22
+      |
+    3 | from package1 import ChildConda
+    4 | from package1 import WorkingVenv
+    5 | from package1 import BaseConda
+      |                      ^^^^^^^^^
+      |
+    info: rule `unresolved-import` is enabled by default
+
+    Found 1 diagnostic
+
+    ----- stderr -----
+    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
+    ");
+
     Ok(())
 }
 
@@ -1473,6 +1523,55 @@ home = ./
         .current_dir(case.root().join("project"))
         .env("CONDA_PREFIX", case.root().join("conda"))
         .env("CONDA_DEFAULT_ENV", "base"), @r"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    error[unresolved-import]: Module `package1` has no member `BaseConda`
+     --> test.py:5:22
+      |
+    3 | from package1 import ChildConda
+    4 | from package1 import WorkingVenv
+    5 | from package1 import BaseConda
+      |                      ^^^^^^^^^
+      |
+    info: rule `unresolved-import` is enabled by default
+
+    Found 1 diagnostic
+
+    ----- stderr -----
+    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
+    ");
+
+    // run with _CONDA_ROOT and CONDA_PREFIX (unequal!) set, should find ChildConda
+    assert_cmd_snapshot!(case.command()
+        .current_dir(case.root().join("project"))
+        .env("CONDA_PREFIX", case.root().join("conda/envs/conda-env"))
+        .env("_CONDA_ROOT", "conda"), @r"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    error[unresolved-import]: Module `package1` has no member `ChildConda`
+     --> test.py:3:22
+      |
+    2 | from package1 import ActiveVenv
+    3 | from package1 import ChildConda
+      |                      ^^^^^^^^^^
+    4 | from package1 import WorkingVenv
+    5 | from package1 import BaseConda
+      |
+    info: rule `unresolved-import` is enabled by default
+
+    Found 1 diagnostic
+
+    ----- stderr -----
+    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
+    ");
+
+    // run with _CONDA_ROOT and CONDA_PREFIX (equal!) set, should find BaseConda
+    assert_cmd_snapshot!(case.command()
+        .current_dir(case.root().join("project"))
+        .env("CONDA_PREFIX", case.root().join("conda"))
+        .env("_CONDA_ROOT", "conda"), @r"
     success: false
     exit_code: 1
     ----- stdout -----

--- a/crates/ty_python_semantic/src/site_packages.rs
+++ b/crates/ty_python_semantic/src/site_packages.rs
@@ -623,7 +623,7 @@ impl CondaEnvironmentKind {
     fn from_prefix_path(system: &dyn System, path: &SystemPath) -> Self {
         // If `_CONDA_ROOT` is set and matches `CONDA_PREFIX`, it's the base environment.
         if let Ok(conda_root) = system.env_var(EnvVars::CONDA_ROOT) {
-            if path.as_str() == &conda_root {
+            if path.as_str() == conda_root {
                 return Self::Base;
             }
         }

--- a/crates/ty_python_semantic/src/site_packages.rs
+++ b/crates/ty_python_semantic/src/site_packages.rs
@@ -614,28 +614,44 @@ pub(crate) enum CondaEnvironmentKind {
 impl CondaEnvironmentKind {
     /// Compute the kind of `CONDA_PREFIX` we have.
     ///
-    /// When the base environment is used, `CONDA_DEFAULT_ENV` will be set to a name, i.e., `base` or
-    /// `root` which does not match the prefix, e.g. `/usr/local` instead of
-    /// `/usr/local/conda/envs/<name>`.
+    /// The base environment is typically stored in a location matching the `_CONDA_ROOT` path.
+    ///
+    /// Additionally, when the base environment is active, `CONDA_DEFAULT_ENV` will be set to a
+    /// name, e.g., `base`, which does not match the `CONDA_PREFIX`, e.g., `/usr/local` instead of
+    /// `/usr/local/conda/envs/<name>`. Note that the name `CONDA_DEFAULT_ENV` is misleading, it's
+    /// the active environment name, not a constant base environment name.
     fn from_prefix_path(system: &dyn System, path: &SystemPath) -> Self {
-        // If we cannot read `CONDA_DEFAULT_ENV`, there's no way to know if the base environment
-        let Ok(default_env) = system.env_var(EnvVars::CONDA_DEFAULT_ENV) else {
-            return CondaEnvironmentKind::Child;
-        };
-
-        // These are the expected names for the base environment
-        if default_env != "base" && default_env != "root" {
-            return CondaEnvironmentKind::Child;
+        // If `_CONDA_ROOT` is set and matches `CONDA_PREFIX`, it's the base environment.
+        if let Ok(conda_root) = system.env_var(EnvVars::CONDA_ROOT) {
+            if path.as_str() == &conda_root {
+                return Self::Base;
+            }
         }
 
-        let Some(name) = path.file_name() else {
-            return CondaEnvironmentKind::Child;
+        // Next, we'll use a heuristic based on `CONDA_DEFAULT_ENV`
+        let Ok(current_env) = system.env_var(EnvVars::CONDA_DEFAULT_ENV) else {
+            return Self::Child;
         };
 
-        if name == default_env {
-            CondaEnvironmentKind::Child
+        // If the environment name is "base" or "root", treat it as a base environment
+        //
+        // These are the expected names for the base environment; and is retained for backwards
+        // compatibility, but in a future breaking release we should remove this special-casing.
+        if current_env == "base" || current_env == "root" {
+            return Self::Base;
+        }
+
+        // For other environment names, use the path-based logic
+        let Some(name) = path.file_name() else {
+            return Self::Child;
+        };
+
+        // If the environment is in a directory matching the name of the environment, it's not
+        // usually a base environment.
+        if name == current_env {
+            Self::Child
         } else {
-            CondaEnvironmentKind::Base
+            Self::Base
         }
     }
 }

--- a/crates/ty_python_semantic/src/site_packages.rs
+++ b/crates/ty_python_semantic/src/site_packages.rs
@@ -633,9 +633,9 @@ impl CondaEnvironmentKind {
         };
 
         if name == default_env {
-            CondaEnvironmentKind::Base
-        } else {
             CondaEnvironmentKind::Child
+        } else {
+            CondaEnvironmentKind::Base
         }
     }
 }

--- a/crates/ty_static/src/env_vars.rs
+++ b/crates/ty_static/src/env_vars.rs
@@ -48,12 +48,15 @@ impl EnvVars {
     /// (e.g. colons on Unix or semicolons on Windows).
     pub const PYTHONPATH: &'static str = "PYTHONPATH";
 
-    /// Used to determine if an active Conda environment is the base environment or not.
+    /// Used to determine the name of the active Conda environment.
     pub const CONDA_DEFAULT_ENV: &'static str = "CONDA_DEFAULT_ENV";
 
-    /// Used to detect an activated Conda environment location.
+    /// Used to detect the path of an active Conda environment.
     /// If both `VIRTUAL_ENV` and `CONDA_PREFIX` are present, `VIRTUAL_ENV` will be preferred.
     pub const CONDA_PREFIX: &'static str = "CONDA_PREFIX";
+
+    /// Used to determine the root install path of Conda.
+    pub const CONDA_ROOT: &'static str = "_CONDA_ROOT";
 
     /// Filter which tests to run in mdtest.
     ///


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

#19990 didn't completely fix the base vs. child conda environment distinction, since it detected slightly different behavior than what I usually see in conda. E.g., I see something like the following:
```
(didn't yet activate conda, but base is active)
➜ printenv | grep CONDA
CONDA_PYTHON_EXE=/opt/anaconda3/bin/python
CONDA_PREFIX=/opt/anaconda3
CONDA_DEFAULT_ENV=base
CONDA_EXE=/opt/anaconda3/bin/conda
CONDA_SHLVL=1
CONDA_PROMPT_MODIFIER=(base)

(activating conda)
➜ conda activate test

(test is an active conda environment)
❯ printenv | grep CONDA
CONDA_PREFIX=/opt/anaconda3/envs/test
CONDA_PYTHON_EXE=/opt/anaconda3/bin/python
CONDA_SHLVL=2
CONDA_PREFIX_1=/opt/anaconda3
CONDA_DEFAULT_ENV=test
CONDA_PROMPT_MODIFIER=(test)
CONDA_EXE=/opt/anaconda3/bin/conda
```

But the current behavior looks for `CONDA_DEFAULT_ENV = basename(CONDA_PREFIX)` for the base environment instead of the child environment, where we actually see this equality. 

This pull request fixes that and updates the tests correspondingly.

## Test Plan

I updated the existing tests with the new behavior. Let me know if you want more tests. Note: It shouldn't be necessary to test for the case where we have `conda/envs/base`, since one should not be able to create such an environment (one with the name of `CONDA_DEFAULT_ENV`). 
