### PR TITLE
[`isort`] Fix inserting required imports before future imports (`I002`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/isort/required_imports/future_import.py
+++ b/crates/ruff_linter/resources/test/fixtures/isort/required_imports/future_import.py
@@ -1,0 +1,2 @@
+from __future__ import annotations
+# EOF

--- a/crates/ruff_linter/src/rules/isort/mod.rs
+++ b/crates/ruff_linter/src/rules/isort/mod.rs
@@ -1014,6 +1014,29 @@ mod tests {
         Ok(())
     }
 
+    #[test_case(Path::new("future_import.py"))]
+    fn required_import_with_future_import(path: &Path) -> Result<()> {
+        let snapshot = format!(
+            "required_import_with_future_import_{}",
+            path.to_string_lossy()
+        );
+        let diagnostics = test_path(
+            Path::new("isort/required_imports").join(path).as_path(),
+            &LinterSettings {
+                src: vec![test_resource_path("fixtures/isort")],
+                isort: super::settings::Settings {
+                    required_imports: BTreeSet::from_iter([NameImport::Import(
+                        ModuleNameImport::module("this".to_string()),
+                    )]),
+                    ..super::settings::Settings::default()
+                },
+                ..LinterSettings::for_rule(Rule::MissingRequiredImport)
+            },
+        )?;
+        assert_diagnostics!(snapshot, diagnostics);
+        Ok(())
+    }
+
     #[test_case(Path::new("from_first.py"))]
     fn from_first(path: &Path) -> Result<()> {
         let snapshot = format!("from_first_{}", path.to_string_lossy());

--- a/crates/ruff_linter/src/rules/isort/snapshots/ruff_linter__rules__isort__tests__required_import_existing_import.py.snap
+++ b/crates/ruff_linter/src/rules/isort/snapshots/ruff_linter__rules__isort__tests__required_import_existing_import.py.snap
@@ -4,6 +4,6 @@ source: crates/ruff_linter/src/rules/isort/mod.rs
 I002 [*] Missing required import: `from __future__ import annotations`
 --> existing_import.py:1:1
 help: Insert required import: `from __future__ import annotations`
-1 + from __future__ import annotations
-2 | from __future__ import generator_stop
+1 | from __future__ import generator_stop
+2 + from __future__ import annotations
 3 | import os

--- a/crates/ruff_linter/src/rules/isort/snapshots/ruff_linter__rules__isort__tests__required_import_with_alias_existing_import.py.snap
+++ b/crates/ruff_linter/src/rules/isort/snapshots/ruff_linter__rules__isort__tests__required_import_with_alias_existing_import.py.snap
@@ -4,6 +4,6 @@ source: crates/ruff_linter/src/rules/isort/mod.rs
 I002 [*] Missing required import: `from __future__ import annotations as _annotations`
 --> existing_import.py:1:1
 help: Insert required import: `from __future__ import annotations as _annotations`
-1 + from __future__ import annotations as _annotations
-2 | from __future__ import generator_stop
+1 | from __future__ import generator_stop
+2 + from __future__ import annotations as _annotations
 3 | import os

--- a/crates/ruff_linter/src/rules/isort/snapshots/ruff_linter__rules__isort__tests__required_import_with_future_import_future_import.py.snap
+++ b/crates/ruff_linter/src/rules/isort/snapshots/ruff_linter__rules__isort__tests__required_import_with_future_import_future_import.py.snap
@@ -1,0 +1,9 @@
+---
+source: crates/ruff_linter/src/rules/isort/mod.rs
+---
+I002 [*] Missing required import: `import this`
+--> future_import.py:1:1
+help: Insert required import: `import this`
+1 | from __future__ import annotations
+2 + import this
+3 | # EOF


### PR DESCRIPTION
## Summary

Fixes #20674
