### PR TITLE
Add `B012` and `PYI057` as default rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,9 +314,7 @@ Rust as a first-party feature.
 By default, Ruff enables Flake8's `F` rules, along with a subset of the `E`
 rules, omitting any stylistic rules that overlap with the use of a formatter,
 like `ruff format` or [Black](https://github.com/psf/black). Ruff also enables
-[`B012`](https://docs.astral.sh/ruff/rules/jump-statement-in-finally/), which
-corresponds to a `SyntaxWarning`, and
-[`PYI057`](https://docs.astral.sh/ruff/rules/byte-string-usage/), which flags
+`B012`, which corresponds to a `SyntaxWarning`, and `PYI057`, which flags
 usage of some long-deprecated APIs in the standard library.
 
 If you're just getting started with Ruff, **the default rule set is a great place to start**: it

--- a/README.md
+++ b/README.md
@@ -311,9 +311,13 @@ for more on the linting and formatting commands, respectively.
 isort, pyupgrade, and others. Regardless of the rule's origin, Ruff re-implements every rule in
 Rust as a first-party feature.
 
-By default, Ruff enables Flake8's `F` rules, along with a subset of the `E` rules, omitting any
-stylistic rules that overlap with the use of a formatter, like `ruff format` or
-[Black](https://github.com/psf/black).
+By default, Ruff enables Flake8's `F` rules, along with a subset of the `E`
+rules, omitting any stylistic rules that overlap with the use of a formatter,
+like `ruff format` or [Black](https://github.com/psf/black). Ruff also enables
+[`B012`](https://docs.astral.sh/ruff/rules/jump-statement-in-finally/), which
+corresponds to a `SyntaxWarning`, and
+[`PYI057`](https://docs.astral.sh/ruff/rules/byte-string-usage/), which flags
+usage of some long-deprecated APIs in the standard library.
 
 If you're just getting started with Ruff, **the default rule set is a great place to start**: it
 catches a wide variety of common errors (like unused imports) with zero configuration.

--- a/crates/ruff/tests/config.rs
+++ b/crates/ruff/tests/config.rs
@@ -21,12 +21,13 @@ fn lint_select() {
     specific prefixes. `ignore` takes precedence over `select` if the
     same prefix appears in both.
 
-    Default value: ["E4", "E7", "E9", "F"]
+    Default value: ["E4", "E7", "E9", "F", "B012", "PYI057"]
     Type: list[RuleSelector]
     Example usage:
     ```toml
-    # On top of the defaults (`E4`, E7`, `E9`, and `F`), enable flake8-bugbear (`B`) and flake8-quotes (`Q`).
-    select = ["E4", "E7", "E9", "F", "B", "Q"]
+    # On top of the defaults (`E4`, E7`, `E9`, `F`, `B012`, and `PYI057`),
+    # enable flake8-bugbear (`B`) and flake8-quotes (`Q`).
+    select = ["E4", "E7", "E9", "F", "PYI057", "B", "Q"]
     ```
 
     ----- stderr -----
@@ -43,10 +44,10 @@ fn lint_select_json() {
     ----- stdout -----
     {
       "doc": "A list of rule codes or prefixes to enable. Prefixes can specify exact\nrules (like `F841`), entire categories (like `F`), or anything in\nbetween.\n\nWhen breaking ties between enabled and disabled rules (via `select` and\n`ignore`, respectively), more specific prefixes override less\nspecific prefixes. `ignore` takes precedence over `select` if the\nsame prefix appears in both.",
-      "default": "[\"E4\", \"E7\", \"E9\", \"F\"]",
+      "default": "[\"E4\", \"E7\", \"E9\", \"F\", \"B012\", \"PYI057\"]",
       "value_type": "list[RuleSelector]",
       "scope": null,
-      "example": "# On top of the defaults (`E4`, E7`, `E9`, and `F`), enable flake8-bugbear (`B`) and flake8-quotes (`Q`).\nselect = [\"E4\", \"E7\", \"E9\", \"F\", \"B\", \"Q\"]",
+      "example": "# On top of the defaults (`E4`, E7`, `E9`, `F`, `B012`, and `PYI057`),\n# enable flake8-bugbear (`B`) and flake8-quotes (`Q`).\nselect = [\"E4\", \"E7\", \"E9\", \"F\", \"PYI057\", \"B\", \"Q\"]",
       "deprecated": null
     }
 

--- a/crates/ruff/tests/snapshots/show_settings__display_default_settings.snap
+++ b/crates/ruff/tests/snapshots/show_settings__display_default_settings.snap
@@ -65,6 +65,8 @@ file_resolver.project_root = "<temp_dir>/"
 linter.exclude = []
 linter.project_root = "<temp_dir>/"
 linter.rules.enabled = [
+	jump-statement-in-finally (B012),
+	byte-string-usage (PYI057),
 	multiple-imports-on-one-line (E401),
 	module-import-not-at-top-of-file (E402),
 	multiple-statements-on-one-line-colon (E701),
@@ -126,6 +128,8 @@ linter.rules.enabled = [
 	raise-not-implemented (F901),
 ]
 linter.rules.should_fix = [
+	jump-statement-in-finally (B012),
+	byte-string-usage (PYI057),
 	multiple-imports-on-one-line (E401),
 	module-import-not-at-top-of-file (E402),
 	multiple-statements-on-one-line-colon (E701),

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/jump_statement_in_finally.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/jump_statement_in_finally.rs
@@ -18,6 +18,9 @@ use crate::checkers::ast::Checker;
 /// `break`, `continue`, or `return` statement is reached in a `finally` block,
 /// any exception raised in the `try` or `except` blocks will be silenced.
 ///
+/// [PEP 765](https://peps.python.org/pep-0765/) additionally made this a `SyntaxWarning` starting
+/// in Python 3.14. It may become a `SyntaxError` in the future.
+///
 /// ## Example
 /// ```python
 /// def speed(distance, time):

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/bytestring_usage.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/bytestring_usage.rs
@@ -20,9 +20,21 @@ use crate::{FixAvailability, Violation};
 /// from typing import ByteString
 /// ```
 ///
-/// Use instead:
+/// On Python versions after 3.12, use the `Buffer` type from the standard library instead:
 /// ```python
 /// from collections.abc import Buffer
+/// ```
+///
+/// For earlier Python versions, you can use `typing_extensions`:
+/// ```python
+/// from typing_extensions import Buffer
+/// ```
+///
+/// or a union:
+/// ```python
+/// from typing import Union
+///
+/// x: Union[bytes, bytearray, memoryview]
 /// ```
 ///
 /// ## References

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/bytestring_usage.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/bytestring_usage.rs
@@ -11,9 +11,9 @@ use crate::{FixAvailability, Violation};
 ///
 /// ## Why is this bad?
 /// `ByteString` has been deprecated since Python 3.9 and will be removed in
-/// Python 3.14. The Python documentation recommends using either
+/// Python 3.17. The Python documentation recommends using either
 /// `collections.abc.Buffer` (or the `typing_extensions` backport
-/// on Python <3.12) or a union like `bytes | bytearray | memoryview` instead.
+/// on Python versions before 3.12) or a union like `bytes | bytearray | memoryview` instead.
 ///
 /// ## Example
 /// ```python

--- a/crates/ruff_linter/src/settings/mod.rs
+++ b/crates/ruff_linter/src/settings/mod.rs
@@ -369,6 +369,17 @@ pub const DEFAULT_SELECTORS: &[RuleSelector] = &[
         prefix: RuleCodePrefix::Pycodestyle(codes::Pycodestyle::E9),
         redirected_from: None,
     },
+    // Additionally include rules that will correspond to CPython errors in the future:
+    // - B012 is a syntax warning in 3.14 and will become an error in the future
+    // - PYI057 reports deprecated members of the standard library
+    RuleSelector::Rule {
+        prefix: RuleCodePrefix::Flake8Bugbear(codes::Flake8Bugbear::_012),
+        redirected_from: None,
+    },
+    RuleSelector::Rule {
+        prefix: RuleCodePrefix::Flake8Pyi(codes::Flake8Pyi::_057),
+        redirected_from: None,
+    },
 ];
 
 pub const TASK_TAGS: &[&str] = &["TODO", "FIXME", "XXX"];

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -804,11 +804,12 @@ pub struct LintCommonOptions {
     /// specific prefixes. `ignore` takes precedence over `select` if the
     /// same prefix appears in both.
     #[option(
-        default = r#"["E4", "E7", "E9", "F"]"#,
+        default = r#"["E4", "E7", "E9", "F", "B012", "PYI057"]"#,
         value_type = "list[RuleSelector]",
         example = r#"
-            # On top of the defaults (`E4`, E7`, `E9`, and `F`), enable flake8-bugbear (`B`) and flake8-quotes (`Q`).
-            select = ["E4", "E7", "E9", "F", "B", "Q"]
+            # On top of the defaults (`E4`, E7`, `E9`, `F`, `B012`, and `PYI057`),
+            # enable flake8-bugbear (`B`) and flake8-quotes (`Q`).
+            select = ["E4", "E7", "E9", "F", "PYI057", "B", "Q"]
         "#
     )]
     pub select: Option<Vec<RuleSelector>>,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -51,10 +51,12 @@ If left unspecified, Ruff's default configuration is equivalent to:
     target-version = "py39"
 
     [tool.ruff.lint]
-    # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`) codes by default.
+    # Enable Pyflakes (`F`), a subset of the pycodestyle (`E`) codes,
+	# and a couple of other codes corresponding to CPython deprecations
+	# and syntax warnings by default.
     # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
     # McCabe complexity (`C901`) by default.
-    select = ["E4", "E7", "E9", "F"]
+    select = ["E4", "E7", "E9", "F", "PYI057", "B012"]
     ignore = []
 
     # Allow fix for all enabled rules (when `--fix`) is provided.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,8 +52,8 @@ If left unspecified, Ruff's default configuration is equivalent to:
 
     [tool.ruff.lint]
     # Enable Pyflakes (`F`), a subset of the pycodestyle (`E`) codes,
-	# and a couple of other codes corresponding to CPython deprecations
-	# and syntax warnings by default.
+    # and a couple of other codes corresponding to CPython deprecations
+    # and syntax warnings by default.
     # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
     # McCabe complexity (`C901`) by default.
     select = ["E4", "E7", "E9", "F", "PYI057", "B012"]


### PR DESCRIPTION
## Summary

@AlexWaygood and I discussed this a bit on [Discord](https://discord.com/channels/1039017663004942429/1343691651243315312/1422892554868756552), and it seemed relevant for the Python 3.14 release next week, so I figured I'd put up a PR.

This adds [jump-statement-in-finally (B012)](https://docs.astral.sh/ruff/rules/jump-statement-in-finally/#jump-statement-in-finally-b012) and [byte-string-usage (PYI057)](https://docs.astral.sh/ruff/rules/byte-string-usage/#byte-string-usage-pyi057) to the default rule set. `B012` is especially relevant for Python 3.14 because it will become a `SyntaxWarning` and may be upgraded to a `SyntaxError` in the future. `PYI057`, on the other hand, covers APIs that now won't be removed until 3.17, but Ruff could help to make this more visible to avoid it being pushed back again.

I'm realizing now that I didn't attempt to gate the new defaults based on the target Python version as Alex suggested, but I can look into that if we want. It doesn't immediately seem straightforward to do, based on our current usage of `DEFAULT_SELECTORS`, though. `B012` seems serious enough to me always to be enabled, but the nice stdlib replacement for `PYI057` was only added in Python 3.12.

## Test Plan

Existing tests, plus a new CLI test with the new rules
