### PR TITLE
[`RUF051`] Ignore if `else`/`elif` block is present

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF051.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF051.py
@@ -128,3 +128,15 @@ if f"0" in d:                       # f-string
 
 if k in a.d:                        # Attribute dict
     del a.d[k]
+
+if k in d:                          # else statement
+    del d[k]
+else:
+    pass
+
+if k in d:                          # elif and else statements
+    del d[k]
+elif 0 in d:
+    del d[0]
+else:
+    pass

--- a/crates/ruff_linter/src/rules/ruff/rules/if_key_in_dict_del.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/if_key_in_dict_del.rs
@@ -45,6 +45,10 @@ impl AlwaysFixableViolation for IfKeyInDictDel {
 
 /// RUF051
 pub(crate) fn if_key_in_dict_del(checker: &Checker, stmt: &StmtIf) {
+    if !stmt.elif_else_clauses.is_empty() {
+        return;
+    }
+
     let [Stmt::Delete(delete)] = &stmt.body[..] else {
         return;
     };


### PR DESCRIPTION
## Summary

Fixes #20700

`else` and `elif` blocks could previously be deleted when applying a fix for this rule. If an `else` or `elif` branch is detected the rule will not trigger. So now the rule will only flag if it is safe.