### PR TITLE
[ty] Enforce that `typing_extensions` must come from a stdlib search path

### DIFF
--- a/crates/ty_python_semantic/src/module_resolver/resolver.rs
+++ b/crates/ty_python_semantic/src/module_resolver/resolver.rs
@@ -666,11 +666,15 @@ struct ModuleNameIngredient<'db> {
 /// Returns `true` if the module name refers to a standard library module which can't be shadowed
 /// by a first-party module.
 ///
-/// This includes "builtin" modules, which can never be shadowed at runtime either, as well as the
-/// `types` module, which tends to be imported early in Python startup, so can't be consistently
-/// shadowed, and is important to type checking.
+/// This includes "builtin" modules, which can never be shadowed at runtime either, as well as
+/// certain other modules that are involved in an import cycle with `builtins` (`types`,
+/// `typing_extensions`, etc.). This latter set of modules cannot be allowed to be shadowed by
+/// first-party or "extra-path" modules, or we risk panics in unexpected places due to being
+/// unable to resolve builtin symbols. This is similar behaviour other other type checkers such
+/// as mypy: <https://github.com/python/mypy/blob/3807423e9d98e678bf16b13ec8b4f909fe181908/mypy/build.py#L104-L117>
 pub(super) fn is_non_shadowable(minor_version: u8, module_name: &str) -> bool {
-    module_name == "types" || ruff_python_stdlib::sys::is_builtin_module(minor_version, module_name)
+    matches!(module_name, "types" | "typing_extensions")
+        || ruff_python_stdlib::sys::is_builtin_module(minor_version, module_name)
 }
 
 /// Given a module name and a list of search paths in which to lookup modules,


### PR DESCRIPTION
## Summary

I _believe_ this fixes the panic in https://github.com/astral-sh/ty/issues/1289. It's what mypy does, anyway, and it seems like reasonable behaviour. (I don't want to close that issue, though, because I think we should do other things as well, such as improve our documentation around these options.)

## Test Plan

The following steps reproduce the panic on `main`:

1. `git clone https://github.com/copdips/ty-issues-1289`
2. `uv venv -p3.12`
3. `uv sync`
4. `cd backend`
5. `cargo run --manifest-path path/to/ruff/clone -p ty check`

If I then checkout this branch on my Ruff clone, the panic then no longer manifests when executing the final command.