### PR TITLE
[ty] Add `--venv` as an alias to `--python`

### DIFF
--- a/crates/ty/docs/cli.md
+++ b/crates/ty/docs/cli.md
@@ -67,7 +67,7 @@ over all configuration files.</p>
 </ul></dd><dt id="ty-check--project"><a href="#ty-check--project"><code>--project</code></a> <i>project</i></dt><dd><p>Run the command within the given project directory.</p>
 <p>All <code>pyproject.toml</code> files will be discovered by walking up the directory tree from the given project directory, as will the project's virtual environment (<code>.venv</code>) unless the <code>venv-path</code> option is set.</p>
 <p>Other command-line arguments (such as relative paths) will be resolved relative to the current working directory.</p>
-</dd><dt id="ty-check--python"><a href="#ty-check--python"><code>--python</code></a> <i>path</i></dt><dd><p>Path to the Python environment.</p>
+</dd><dt id="ty-check--python"><a href="#ty-check--python"><code>--python</code></a>, <code>--venv</code> <i>path</i></dt><dd><p>Path to the Python environment.</p>
 <p>ty uses the Python environment to resolve type information and third-party dependencies.</p>
 <p>If not specified, ty will attempt to infer it from the <code>VIRTUAL_ENV</code> or <code>CONDA_PREFIX</code> environment variables, or discover a <code>.venv</code> directory in the project root or working directory.</p>
 <p>If a path to a Python interpreter is provided, e.g., <code>.venv/bin/python3</code>, ty will attempt to find an environment two directories up from the interpreter's path, e.g., <code>.venv</code>. At this time, ty does not invoke the interpreter to determine the location of the environment. This means that ty will not resolve dynamic executables such as a shim.</p>

--- a/crates/ty/docs/environment.md
+++ b/crates/ty/docs/environment.md
@@ -42,10 +42,6 @@ Used to determine the name of the active Conda environment.
 Used to detect the path of an active Conda environment.
 If both `VIRTUAL_ENV` and `CONDA_PREFIX` are present, `VIRTUAL_ENV` will be preferred.
 
-### `_CONDA_ROOT`
-
-Used to determine the root install path of Conda.
-
 ### `PYTHONPATH`
 
 Adds additional directories to ty's search paths.
@@ -67,4 +63,8 @@ Used to detect an activated virtual environment.
 ### `XDG_CONFIG_HOME`
 
 Path to user-level configuration directory on Unix systems.
+
+### `_CONDA_ROOT`
+
+Used to determine the root install path of Conda.
 

--- a/crates/ty/src/args.rs
+++ b/crates/ty/src/args.rs
@@ -66,7 +66,7 @@ pub(crate) struct CheckCommand {
     ///
     /// ty will search in the resolved environment's `site-packages` directories for type
     /// information and third-party imports.
-    #[arg(long, value_name = "PATH")]
+    #[arg(long, value_name = "PATH", alias = "venv")]
     pub(crate) python: Option<SystemPathBuf>,
 
     /// Custom directory to use for stdlib typeshed stubs.


### PR DESCRIPTION
## Summary

This PR adds `--venv` as an alias to `--python` on the ty CLI. The motivation is that if you're just skimming the online docs for the CLI interface, this may make it easier to spot at a glance that this option should be used to specify the location of your virtual environment. (See the changes to the generated `cli.md` file in this PR.)

We shouldn't rename the option to `--venv` because it can also be used to point to a system environment. It's tempting to add a `--venv-path` alias, which would match the name of one of pyright's options, but pyright's `--venv-path` option has different semantics, so that would probably cause more confusion rather than clarifying anything.

Helps with https://github.com/astral-sh/ty/issues/1289