### PR TITLE
[ty] Print `display` of types when a property test fails

### DIFF
--- a/crates/ty_python_semantic/src/types/property_tests.rs
+++ b/crates/ty_python_semantic/src/types/property_tests.rs
@@ -38,7 +38,6 @@ use type_generation::{intersection, union};
 ///
 /// where `t1`, `t2`, ..., `tn` are identifiers that represent arbitrary types, and `<property>`
 /// is an expression using these identifiers.
-///
 macro_rules! type_property_test {
     ($test_name:ident, $db:ident, forall types $($types:ident),+ . $property:expr) => {
         #[quickcheck_macros::quickcheck]
@@ -46,20 +45,34 @@ macro_rules! type_property_test {
         fn $test_name($($types: crate::types::property_tests::type_generation::Ty),+) -> bool {
             let $db = &crate::types::property_tests::setup::get_cached_db();
             $(let $types = $types.into_type($db);)+
+            let result = $property;
 
-            $property
+            if !result {
+                println!("\nFailing types were:");
+                $(println!("{}", $types.display($db));)+
+            }
+
+            result
         }
     };
+
     ($test_name:ident, $db:ident, forall fully_static_types $($types:ident),+ . $property:expr) => {
         #[quickcheck_macros::quickcheck]
         #[ignore]
         fn $test_name($($types: crate::types::property_tests::type_generation::FullyStaticTy),+) -> bool {
             let $db = &crate::types::property_tests::setup::get_cached_db();
             $(let $types = $types.into_type($db);)+
+            let result = $property;
 
-            $property
+            if !result {
+                println!("\nFailing types were:");
+                $(println!("{}", $types.display($db));)+
+            }
+
+            result
         }
     };
+
     // A property test with a logical implication.
     ($name:ident, $db:ident, forall $typekind:ident $($types:ident),+ . $premise:expr => $conclusion:expr) => {
         type_property_test!($name, $db, forall $typekind $($types),+ . !($premise) || ($conclusion));


### PR DESCRIPTION
## Summary

This PR attempts to make it easier to understand what a failing property test _means_, by showing you (something closer to) the type that ty internally simplified a type to, rather than just the schema that was used to generate a pair of types for a particular property test.

Demo:

```
~/dev/ruff (alex/property-test-debug)⚡ [101] % QUICKCHECK_TESTS=1000000 cargo test --release -p ty_python_semantic -- --ignored types::property_tests::flaky::double_negation_is_identity
    Finished `release` profile [optimized] target(s) in 0.09s
     Running unittests src/lib.rs (target/release/deps/ty_python_semantic-8dac72c754bdebcd)

running 1 test
test types::property_tests::flaky::double_negation_is_identity ... FAILED

failures:

---- types::property_tests::flaky::double_negation_is_identity stdout ----

Failing types were:
(~(bound method int.bit_length() -> int) & ~Mock) | (bound method int.bit_length() -> int) | ABCMeta | ((**n4: tuple[*tuple[type[str], ...], Unknown, bool]) -> Literal[SafeUUID.unknown])

Failing types were:
(~(bound method int.bit_length() -> int) & ~Mock) | (bound method int.bit_length() -> int) | ABCMeta

Failing types were:
(~(bound method int.bit_length() -> int) & ~Mock) | (bound method int.bit_length() -> int)

Failing types were:
(~(bound method int.bit_length() -> int) & ~Mock) | (bound method int.bit_length() -> int)

thread 'types::property_tests::flaky::double_negation_is_identity' panicked at /Users/alexw/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/quickcheck-1.0.3/src/tester.rs:165:28:
[quickcheck] TEST FAILED. Arguments: (Union([Intersection { pos: [], neg: [BuiltinsBoundMethod { class: "int", method: "bit_length" }, UnittestMockInstance] }, BuiltinsBoundMethod { class: "int", method: "bit_length" }]))
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    types::property_tests::flaky::double_negation_is_identity
```

## Test Plan

<!-- How was it tested? -->
