### PR TITLE
[ty] Add support for functional `TypedDict` syntax

### DIFF
--- a/crates/ruff_memory_usage/src/lib.rs
+++ b/crates/ruff_memory_usage/src/lib.rs
@@ -16,13 +16,16 @@ pub fn heap_size<T: GetSize>(value: &T) -> usize {
 
 /// An implementation of [`GetSize::get_heap_size`] for [`OrderSet`].
 pub fn order_set_heap_size<T: GetSize, S>(set: &OrderSet<T, S>) -> usize {
-    (set.capacity() * T::get_stack_size()) + set.iter().map(heap_size).sum::<usize>()
+    let size = set.iter().map(heap_size::<T>).sum::<usize>();
+    size + (set.capacity() * T::get_stack_size())
 }
 
-/// An implementation of [`GetSize::get_heap_size`] for [`OrderMap`].
-pub fn order_map_heap_size<K: GetSize, V: GetSize, S>(map: &OrderMap<K, V, S>) -> usize {
-    (map.capacity() * (K::get_stack_size() + V::get_stack_size()))
-        + (map.iter())
-            .map(|(k, v)| heap_size(k) + heap_size(v))
-            .sum::<usize>()
+/// An implementation of [`GetSize::get_heap_size`] for [`OrderSet`].
+pub fn order_map_heap_size<K: GetSize, V: GetSize, S>(set: &OrderMap<K, V, S>) -> usize {
+    let size = set
+        .iter()
+        .map(|(key, val)| heap_size::<K>(key) + heap_size::<V>(val))
+        .sum::<usize>();
+
+    size + (set.capacity() * <(K, V)>::get_stack_size())
 }

--- a/crates/ty_python_semantic/resources/mdtest/annotations/unsupported_special_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/unsupported_special_types.md
@@ -1,6 +1,6 @@
 # Unsupported special types
 
-We do not understand the functional syntax for creating `NamedTuple`s, `TypedDict`s or `Enum`s yet.
+We do not understand the functional syntax for creating `NamedTuple`s or `Enum`s yet.
 But we also do not emit false positives when these are used in type expressions.
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/annotations/unsupported_special_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/unsupported_special_types.md
@@ -1,7 +1,7 @@
 # Unsupported special types
 
-We do not understand the functional syntax for creating `NamedTuple`s or `Enum`s yet.
-But we also do not emit false positives when these are used in type expressions.
+We do not understand the functional syntax for creating `NamedTuple`s or `Enum`s yet. But we also do
+not emit false positives when these are used in type expressions.
 
 ```py
 import collections

--- a/crates/ty_python_semantic/resources/mdtest/annotations/unsupported_special_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/unsupported_special_types.md
@@ -10,9 +10,8 @@ import typing
 
 MyEnum = enum.Enum("MyEnum", ["foo", "bar", "baz"])
 MyIntEnum = enum.IntEnum("MyIntEnum", ["foo", "bar", "baz"])
-MyTypedDict = typing.TypedDict("MyTypedDict", {"foo": int})
 MyNamedTuple1 = typing.NamedTuple("MyNamedTuple1", [("foo", int)])
 MyNamedTuple2 = collections.namedtuple("MyNamedTuple2", ["foo"])
 
-def f(a: MyEnum, b: MyTypedDict, c: MyNamedTuple1, d: MyNamedTuple2): ...
+def f(a: MyEnum, c: MyNamedTuple1, d: MyNamedTuple2): ...
 ```

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -97,8 +97,16 @@ from typing import TypedDict
 from typing_extensions import Required, NotRequired
 
 Person = TypedDict("Person", {"name": Required[str], "age": int | None})
-
 reveal_type(Person)  # revealed: typing.TypedDict
+```
+
+The `TypedDict` schema must be passed directly as the second argument:
+
+```py
+fields = {"name": str}
+
+# error: [invalid-argument-type] "Argument is incorrect: Expected `_TypedDictSchema`, found `dict[Unknown | str, Unknown | <class 'str'>]`"
+Other = TypedDict("Other", fields)
 ```
 
 New inhabitants can be created from dict literals. When accessing keys, the correct types should be

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -1100,6 +1100,20 @@ emp_invalid1 = Employee(department="HR")
 emp_invalid2 = Employee(id=3)
 ```
 
+Fields from functional `TypedDict`s are not currently inherited:
+
+```py
+from typing import TypedDict
+
+class X(TypedDict("Y", {"y": int})):
+    x: int
+
+x: X = {"x": 0}
+
+# error: [invalid-key] "Invalid key access on TypedDict `X`: Unknown key "y""
+x: X = {"y": 0, "x": 0}
+```
+
 ## Generic `TypedDict`
 
 `TypedDict`s can also be generic.

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -315,12 +315,34 @@ Person(name="Alice", age=30, extra=True)  # type: ignore
 The positional dictionary constructor pattern (used by libraries like strawberry) should work
 correctly:
 
+`class.py`:
+
 ```py
 from typing import TypedDict
 
 class User(TypedDict):
     name: str
     age: int
+
+# Valid usage - all required fields provided
+user1 = User({"name": "Alice", "age": 30})
+
+# error: [missing-typed-dict-key] "Missing required key 'age' in TypedDict `User` constructor"
+user2 = User({"name": "Bob"})
+
+# error: [invalid-argument-type] "Invalid argument to key "name" with declared type `str` on TypedDict `User`: value of type `None`"
+user3 = User({"name": None, "age": 25})
+
+# error: [invalid-key] "Invalid key access on TypedDict `User`: Unknown key "extra""
+user4 = User({"name": "Charlie", "age": 30, "extra": True})
+```
+
+`functional.py`:
+
+```py
+from typing import TypedDict
+
+User = TypedDict("User", {"name": str, "age": int})
 
 # Valid usage - all required fields provided
 user1 = User({"name": "Alice", "age": 30})

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -172,7 +172,6 @@ alice["extra"] = True
 bob["extra"] = True
 ```
 
-
 ## Nested `TypedDict`
 
 Nested `TypedDict` fields are also supported.

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -4865,16 +4865,21 @@ impl<'db> Type<'db> {
 
             Type::EnumLiteral(enum_literal) => enum_literal.enum_class_instance(db).bindings(db),
 
-            Type::KnownInstance(KnownInstanceType::TypedDictType(typed_dict)) => Binding::single(
-                self,
-                Signature::new(
-                    // TODO: List more specific parameter types here for better code completion.
-                    Parameters::new([Parameter::keyword_variadic(Name::new_static("kwargs"))
-                        .with_annotated_type(Type::any())]),
-                    Some(Type::TypedDict(TypedDictType::Synthesized(typed_dict))),
-                ),
-            )
-            .into(),
+            Type::KnownInstance(KnownInstanceType::TypedDictType(typed_dict)) => {
+                CallableBinding::from_overloads(
+                    self,
+                    [Signature::new(
+                        // TODO: List more specific parameter types here for better code completion.
+                        Parameters::new([
+                            Parameter::variadic(Name::new_static("args")),
+                            Parameter::keyword_variadic(Name::new_static("kwargs"))
+                                .with_annotated_type(Type::any()),
+                        ]),
+                        Some(Type::TypedDict(TypedDictType::Synthesized(typed_dict))),
+                    )],
+                )
+                .into()
+            }
 
             Type::KnownInstance(known_instance) => {
                 known_instance.instance_fallback(db).bindings(db)

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -4764,6 +4764,9 @@ impl<'db> Type<'db> {
                             Parameter::positional_only(Some(Name::new_static("typename")))
                                 .with_annotated_type(KnownClass::Str.to_instance(db)),
                             Parameter::positional_only(Some(Name::new_static("fields")))
+                                // We infer this type as an anonymous `TypedDict` instance, such that the
+                                // complete `TypeDict` instance can be constructed from it after. Note that
+                                // `typing.TypedDict` is not otherwise allowed in type-form expressions.
                                 .with_annotated_type(Type::SpecialForm(SpecialFormType::TypedDict))
                                 .with_default_type(Type::any()),
                             Parameter::keyword_only(Name::new_static("total"))
@@ -4858,6 +4861,7 @@ impl<'db> Type<'db> {
             Type::KnownInstance(KnownInstanceType::TypedDictType(typed_dict)) => Binding::single(
                 self,
                 Signature::new(
+                    // TODO: List more specific parameter types here for better code completion.
                     Parameters::new([Parameter::keyword_variadic(Name::new_static("kwargs"))
                         .with_annotated_type(Type::any())]),
                     Some(Type::TypedDict(typed_dict)),

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1009,6 +1009,17 @@ impl<'db> Type<'db> {
         }
     }
 
+    /// Turn a typed dict class literal or synthesized type dict type into a `TypedDictType`.
+    pub(crate) fn to_typed_dict_type(self, db: &'db dyn Db) -> Option<TypedDictType<'db>> {
+        match self {
+            Type::ClassLiteral(class_literal) if class_literal.is_typed_dict(db) => Some(
+                TypedDictType::from_class(ClassType::NonGeneric(class_literal)),
+            ),
+            Type::KnownInstance(KnownInstanceType::TypedDictType(typed_dict)) => Some(typed_dict),
+            _ => None,
+        }
+    }
+
     /// Turn a class literal (`Type::ClassLiteral` or `Type::GenericAlias`) into a `ClassType`.
     /// Since a `ClassType` must be specialized, apply the default specialization to any
     /// unspecialized generic class literal.
@@ -1127,7 +1138,7 @@ impl<'db> Type<'db> {
     }
 
     pub(crate) fn typed_dict(defining_class: impl Into<ClassType<'db>>) -> Self {
-        Self::TypedDict(TypedDictType::new(defining_class.into()))
+        Self::TypedDict(TypedDictType::from_class(defining_class.into()))
     }
 
     #[must_use]
@@ -1253,10 +1264,9 @@ impl<'db> Type<'db> {
                 // Always normalize single-member enums to their class instance (`Literal[Single.VALUE]` => `Single`)
                 enum_literal.enum_class_instance(db)
             }
-            Type::TypedDict(_) => {
-                // TODO: Normalize TypedDicts
-                self
-            }
+            Type::TypedDict(typed_dict) => visitor.visit(self, || {
+                Type::TypedDict(typed_dict.normalized_impl(db, visitor))
+            }),
             Type::TypeAlias(alias) => alias.value_type(db).normalized_impl(db, visitor),
             Type::LiteralString
             | Type::AlwaysFalsy
@@ -2974,6 +2984,14 @@ impl<'db> Type<'db> {
         policy: MemberLookupPolicy,
     ) -> PlaceAndQualifiers<'db> {
         tracing::trace!("class_member: {}.{}", self.display(db), name);
+
+        if let Type::TypedDict(TypedDictType::Synthesized(typed_dict)) = self
+            && let Some(member) =
+                TypedDictType::synthesized_member(db, self, typed_dict.items(db), &name)
+        {
+            return Place::bound(member).into();
+        }
+
         match self {
             Type::Union(union) => union.map_with_boundness_and_qualifiers(db, |elem| {
                 elem.class_member_with_policy(db, name.clone(), policy)
@@ -3728,7 +3746,7 @@ impl<'db> Type<'db> {
             }
 
             Type::ClassLiteral(..) | Type::GenericAlias(..) | Type::SubclassOf(..) => {
-                let class_attr_plain = self.find_name_in_mro_with_policy(db, name_str,policy).expect(
+                let class_attr_plain = self.find_name_in_mro_with_policy(db, name_str, policy).expect(
                     "Calling `find_name_in_mro` on class literals and subclass-of types should always return `Some`",
                 );
 
@@ -4746,7 +4764,7 @@ impl<'db> Type<'db> {
                             Parameter::positional_only(Some(Name::new_static("typename")))
                                 .with_annotated_type(KnownClass::Str.to_instance(db)),
                             Parameter::positional_only(Some(Name::new_static("fields")))
-                                .with_annotated_type(KnownClass::Dict.to_instance(db))
+                                .with_annotated_type(Type::SpecialForm(SpecialFormType::TypedDict))
                                 .with_default_type(Type::any()),
                             Parameter::keyword_only(Name::new_static("total"))
                                 .with_annotated_type(KnownClass::Bool.to_instance(db))
@@ -4764,6 +4782,8 @@ impl<'db> Type<'db> {
             Type::SpecialForm(SpecialFormType::NamedTuple) => {
                 Binding::single(self, Signature::todo("functional `NamedTuple` syntax")).into()
             }
+
+            Type::SpecialForm(_) => CallableBinding::not_callable(self).into(),
 
             Type::GenericAlias(_) => {
                 // TODO annotated return type on `__new__` or metaclass `__call__`
@@ -4833,10 +4853,17 @@ impl<'db> Type<'db> {
             // TODO: this is actually callable
             Type::DataclassDecorator(_) => CallableBinding::not_callable(self).into(),
 
-            // TODO: some `SpecialForm`s are callable (e.g. TypedDicts)
-            Type::SpecialForm(_) => CallableBinding::not_callable(self).into(),
-
             Type::EnumLiteral(enum_literal) => enum_literal.enum_class_instance(db).bindings(db),
+
+            Type::KnownInstance(KnownInstanceType::TypedDictType(typed_dict)) => Binding::single(
+                self,
+                Signature::new(
+                    Parameters::new([Parameter::keyword_variadic(Name::new_static("kwargs"))
+                        .with_annotated_type(Type::any())]),
+                    Some(Type::TypedDict(typed_dict)),
+                ),
+            )
+            .into(),
 
             Type::KnownInstance(known_instance) => {
                 known_instance.instance_fallback(db).bindings(db)
@@ -5641,6 +5668,7 @@ impl<'db> Type<'db> {
                     .map(Type::NonInferableTypeVar)
                     .unwrap_or(*self))
                 }
+                KnownInstanceType::TypedDictType(typed_dict) => Ok(Type::TypedDict(*typed_dict)),
                 KnownInstanceType::Deprecated(_) => Err(InvalidTypeExpressionError {
                     invalid_expressions: smallvec::smallvec![InvalidTypeExpression::Deprecated],
                     fallback_type: Type::unknown(),
@@ -5927,9 +5955,7 @@ impl<'db> Type<'db> {
             Type::AlwaysTruthy | Type::AlwaysFalsy => KnownClass::Type.to_instance(db),
             Type::BoundSuper(_) => KnownClass::Super.to_class_literal(db),
             Type::ProtocolInstance(protocol) => protocol.to_meta_type(db),
-            // `TypedDict` instances are instances of `dict` at runtime, but its important that we
-            // understand a more specific meta type in order to correctly handle `__getitem__`.
-            Type::TypedDict(typed_dict) => SubclassOfType::from(db, typed_dict.defining_class()),
+            Type::TypedDict(typed_dict) => typed_dict.to_meta_type(db),
             Type::TypeAlias(alias) => alias.value_type(db).to_meta_type(db),
         }
     }
@@ -6486,8 +6512,9 @@ impl<'db> Type<'db> {
                 Protocol::Synthesized(_) => None,
             },
 
-            Type::TypedDict(typed_dict) => {
-                Some(TypeDefinition::Class(typed_dict.defining_class().definition(db)))
+            Type::TypedDict(typed_dict) => match typed_dict {
+                TypedDictType::FromClass(class) => Some(TypeDefinition::Class(class.definition(db))),
+                TypedDictType::Synthesized(_) => None,
             }
 
             Self::Union(_) | Self::Intersection(_) => None,
@@ -6836,6 +6863,9 @@ pub enum KnownInstanceType<'db> {
     /// A single instance of `typing.TypeAliasType` (PEP 695 type alias)
     TypeAliasType(TypeAliasType<'db>),
 
+    /// A single instance of `typing.TypedDict`.
+    TypedDictType(TypedDictType<'db>),
+
     /// A single instance of `warnings.deprecated` or `typing_extensions.deprecated`
     Deprecated(DeprecatedInstance<'db>),
 
@@ -6863,6 +6893,9 @@ fn walk_known_instance_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
         KnownInstanceType::TypeAliasType(type_alias) => {
             visitor.visit_type_alias_type(db, type_alias);
         }
+        KnownInstanceType::TypedDictType(typed_dict) => {
+            visitor.visit_typed_dict_type(db, typed_dict);
+        }
         KnownInstanceType::Deprecated(_) | KnownInstanceType::ConstraintSet(_) => {
             // Nothing to visit
         }
@@ -6885,6 +6918,9 @@ impl<'db> KnownInstanceType<'db> {
             Self::TypeAliasType(type_alias) => {
                 Self::TypeAliasType(type_alias.normalized_impl(db, visitor))
             }
+            Self::TypedDictType(typed_dict) => {
+                Self::TypedDictType(typed_dict.normalized_impl(db, visitor))
+            }
             Self::Deprecated(deprecated) => {
                 // Nothing to normalize
                 Self::Deprecated(deprecated)
@@ -6905,6 +6941,7 @@ impl<'db> KnownInstanceType<'db> {
                 KnownClass::GenericAlias
             }
             Self::TypeAliasType(_) => KnownClass::TypeAliasType,
+            Self::TypedDictType(_) => KnownClass::TypedDictFallback,
             Self::Deprecated(_) => KnownClass::Deprecated,
             Self::Field(_) => KnownClass::Field,
             Self::ConstraintSet(_) => KnownClass::ConstraintSet,
@@ -6961,6 +6998,7 @@ impl<'db> KnownInstanceType<'db> {
                             f.write_str("typing.TypeAliasType")
                         }
                     }
+                    KnownInstanceType::TypedDictType(_) => f.write_str("typing.TypedDict"),
                     // This is a legacy `TypeVar` _outside_ of any generic class or function, so we render
                     // it as an instance of `typing.TypeVar`. Inside of a generic class or function, we'll
                     // have a `Type::TypeVar(_)`, which is rendered as the typevar's name.
@@ -9119,7 +9157,7 @@ impl TypeRelation {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, get_size2::GetSize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, get_size2::GetSize)]
 pub enum Truthiness {
     /// For an object `x`, `bool(x)` will always return `True`
     AlwaysTrue,
@@ -9163,6 +9201,14 @@ impl Truthiness {
             (Truthiness::AlwaysFalse, Truthiness::AlwaysFalse) => Truthiness::AlwaysFalse,
             (Truthiness::AlwaysTrue, _) | (_, Truthiness::AlwaysTrue) => Truthiness::AlwaysTrue,
             _ => Truthiness::Ambiguous,
+        }
+    }
+
+    pub(crate) fn unwrap_or(self, value: bool) -> bool {
+        match self {
+            Truthiness::AlwaysTrue => true,
+            Truthiness::AlwaysFalse => false,
+            Truthiness::Ambiguous => value,
         }
     }
 

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -33,8 +33,8 @@ use crate::types::typed_dict::SynthesizedTypedDictType;
 use crate::types::{
     BoundMethodType, ClassLiteral, DataclassParams, FieldInstance, KnownBoundMethodType,
     KnownClass, KnownInstanceType, MemberLookupPolicy, PropertyInstanceType, SpecialFormType,
-    TrackedConstraintSet, TypeAliasType, TypeContext, TypedDictParams, TypedDictType, UnionBuilder,
-    UnionType, WrapperDescriptorKind, enums, ide_support, infer_isolated_expression,
+    TrackedConstraintSet, TypeAliasType, TypeContext, TypedDictParams, UnionBuilder, UnionType,
+    WrapperDescriptorKind, enums, ide_support, infer_isolated_expression,
 };
 use crate::{FxOrderMap, Program};
 use ruff_db::diagnostic::{Annotation, Diagnostic, SubDiagnostic, SubDiagnosticSeverity};
@@ -1140,13 +1140,11 @@ impl<'db> Bindings<'db> {
                             .collect::<FxOrderMap<_, _>>();
 
                         overload.set_return_type(Type::KnownInstance(
-                            KnownInstanceType::TypedDictType(TypedDictType::Synthesized(
-                                SynthesizedTypedDictType::new(
-                                    db,
-                                    Some(Name::new(name.value(db))),
-                                    params,
-                                    items,
-                                ),
+                            KnownInstanceType::TypedDictType(SynthesizedTypedDictType::new(
+                                db,
+                                Some(Name::new(name.value(db))),
+                                params,
+                                items,
                             )),
                         ));
                     }

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -29,7 +29,7 @@ use crate::types::function::{
 use crate::types::generics::{Specialization, SpecializationBuilder, SpecializationError};
 use crate::types::signatures::{Parameter, ParameterForm, ParameterKind, Parameters};
 use crate::types::tuple::{TupleLength, TupleType};
-use crate::types::typed_dict::SynthesizedTypedDictType;
+use crate::types::typed_dict::FunctionalTypedDictType;
 use crate::types::{
     BoundMethodType, ClassLiteral, DataclassParams, FieldInstance, KnownBoundMethodType,
     KnownClass, KnownInstanceType, MemberLookupPolicy, PropertyInstanceType, SpecialFormType,
@@ -1137,7 +1137,7 @@ impl<'db> Bindings<'db> {
                             .collect::<FxOrderMap<_, _>>();
 
                         overload.set_return_type(Type::KnownInstance(
-                            KnownInstanceType::TypedDictType(SynthesizedTypedDictType::new(
+                            KnownInstanceType::TypedDictType(FunctionalTypedDictType::new(
                                 db,
                                 Name::new(name.value(db)),
                                 params,

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -1286,7 +1286,7 @@ pub(crate) enum FieldKind<'db> {
     /// `TypedDict` field metadata
     TypedDict {
         /// Whether this field is required
-        is_required: Truthiness,
+        is_required: bool,
         /// Whether this field is marked read-only
         is_read_only: bool,
     },
@@ -1313,7 +1313,7 @@ impl<'db> Field<'db> {
             FieldKind::Dataclass {
                 init, default_ty, ..
             } => default_ty.is_none() && *init,
-            FieldKind::TypedDict { is_required, .. } => is_required.is_always_true(),
+            FieldKind::TypedDict { is_required, .. } => *is_required,
         }
     }
 
@@ -2566,7 +2566,7 @@ impl<'db> ClassLiteral<'db> {
                         };
 
                         FieldKind::TypedDict {
-                            is_required: Truthiness::from(is_required),
+                            is_required,
                             is_read_only: attr.is_read_only(),
                         }
                     }

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -170,6 +170,7 @@ impl<'db> ClassBase<'db> {
                 KnownInstanceType::TypeAliasType(_)
                 | KnownInstanceType::TypeVar(_)
                 | KnownInstanceType::TypedDictType(_)
+                | KnownInstanceType::TypedDictSchema(_)
                 | KnownInstanceType::Deprecated(_)
                 | KnownInstanceType::Field(_)
                 | KnownInstanceType::ConstraintSet(_) => None,
@@ -201,7 +202,8 @@ impl<'db> ClassBase<'db> {
                 | SpecialFormType::TypeOf
                 | SpecialFormType::CallableTypeOf
                 | SpecialFormType::AlwaysTruthy
-                | SpecialFormType::AlwaysFalsy => None,
+                | SpecialFormType::AlwaysFalsy
+                | SpecialFormType::TypedDictSchema => None,
 
                 SpecialFormType::Any => Some(Self::Dynamic(DynamicType::Any)),
                 SpecialFormType::Unknown => Some(Self::unknown()),

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -169,6 +169,7 @@ impl<'db> ClassBase<'db> {
                 KnownInstanceType::SubscriptedProtocol(_) => Some(Self::Protocol),
                 KnownInstanceType::TypeAliasType(_)
                 | KnownInstanceType::TypeVar(_)
+                | KnownInstanceType::TypedDictType(_)
                 | KnownInstanceType::Deprecated(_)
                 | KnownInstanceType::Field(_)
                 | KnownInstanceType::ConstraintSet(_) => None,

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -169,11 +169,12 @@ impl<'db> ClassBase<'db> {
                 KnownInstanceType::SubscriptedProtocol(_) => Some(Self::Protocol),
                 KnownInstanceType::TypeAliasType(_)
                 | KnownInstanceType::TypeVar(_)
-                | KnownInstanceType::TypedDictType(_)
                 | KnownInstanceType::TypedDictSchema(_)
                 | KnownInstanceType::Deprecated(_)
                 | KnownInstanceType::Field(_)
                 | KnownInstanceType::ConstraintSet(_) => None,
+                // TODO: Inherit the fields of synthesized `TypedDict`s.
+                KnownInstanceType::TypedDictType(_) => Some(Self::TypedDict),
             },
 
             Type::SpecialForm(special_form) => match special_form {

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -173,7 +173,7 @@ impl<'db> ClassBase<'db> {
                 | KnownInstanceType::Deprecated(_)
                 | KnownInstanceType::Field(_)
                 | KnownInstanceType::ConstraintSet(_) => None,
-                // TODO: Inherit the fields of synthesized `TypedDict`s.
+                // TODO: Inherit the fields of functional `TypedDict`s.
                 KnownInstanceType::TypedDictType(_) => Some(Self::TypedDict),
             },
 

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -517,13 +517,7 @@ impl Display for DisplayRepresentation<'_> {
                     .0
                     .display_with(self.db, self.settings.clone())
                     .fmt(f),
-                TypedDictType::Synthesized(synthesized) => {
-                    let name = synthesized
-                        .name(self.db)
-                        .expect("cannot have incomplete `TypedDict` in type expression");
-
-                    write!(f, "{name}")
-                }
+                TypedDictType::Synthesized(synthesized) => synthesized.name(self.db).fmt(f),
             },
 
             Type::TypeAlias(alias) => f.write_str(alias.name(self.db)),

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -512,12 +512,12 @@ impl Display for DisplayRepresentation<'_> {
             }
 
             Type::TypedDict(typed_dict) => match typed_dict {
-                TypedDictType::FromClass(class) => class
+                TypedDictType::ClassBased(class) => class
                     .class_literal(self.db)
                     .0
                     .display_with(self.db, self.settings.clone())
                     .fmt(f),
-                TypedDictType::Synthesized(synthesized) => synthesized.name(self.db).fmt(f),
+                TypedDictType::Functional(synthesized) => synthesized.name(self.db).fmt(f),
             },
 
             Type::TypeAlias(alias) => f.write_str(alias.name(self.db)),

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -769,6 +769,15 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     }
                     Type::unknown()
                 }
+                KnownInstanceType::TypedDictSchema(_) => {
+                    self.infer_type_expression(slice);
+                    if let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, subscript) {
+                        builder.into_diagnostic(format_args!(
+                            "`_TypedDictSchema` is not allowed in type expressions",
+                        ));
+                    }
+                    Type::unknown()
+                }
                 KnownInstanceType::TypeVar(_) => {
                     self.infer_type_expression(slice);
                     todo_type!("TypeVar annotations")
@@ -1383,7 +1392,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             SpecialFormType::Tuple => {
                 Type::tuple(self.infer_tuple_type_expression(arguments_slice))
             }
-            SpecialFormType::Generic | SpecialFormType::Protocol => {
+            SpecialFormType::Generic
+            | SpecialFormType::Protocol
+            | SpecialFormType::TypedDictSchema => {
                 self.infer_expression(arguments_slice, TypeContext::default());
                 if let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, subscript) {
                     builder.into_diagnostic(format_args!(

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -807,6 +807,15 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         }
                     }
                 }
+                KnownInstanceType::TypedDictType(_) => {
+                    self.infer_type_expression(slice);
+
+                    if let Some(builder) = self.context.report_lint(&NON_SUBSCRIPTABLE, subscript) {
+                        builder.into_diagnostic(format_args!("Cannot subscript typed dict"));
+                    }
+
+                    Type::unknown()
+                }
                 KnownInstanceType::TypeAliasType(TypeAliasType::ManualPEP695(_)) => {
                     self.infer_type_expression(slice);
                     todo_type!("Generic manual PEP-695 type alias")

--- a/crates/ty_python_semantic/src/types/special_form.rs
+++ b/crates/ty_python_semantic/src/types/special_form.rs
@@ -127,6 +127,10 @@ pub enum SpecialFormType {
     /// Typeshed defines this symbol as a class, but this isn't accurate: it's actually a factory function
     /// at runtime. We therefore represent it as a special form internally.
     NamedTuple,
+
+    /// An internal type representing the dictionary literal argument to the functional `TypedDict`
+    /// constructor.
+    TypedDictSchema,
 }
 
 impl SpecialFormType {
@@ -179,7 +183,9 @@ impl SpecialFormType {
             | Self::ChainMap
             | Self::OrderedDict => KnownClass::StdlibAlias,
 
-            Self::Unknown | Self::AlwaysTruthy | Self::AlwaysFalsy => KnownClass::Object,
+            Self::Unknown | Self::AlwaysTruthy | Self::AlwaysFalsy | Self::TypedDictSchema => {
+                KnownClass::Object
+            }
 
             Self::NamedTuple => KnownClass::FunctionType,
         }
@@ -264,6 +270,8 @@ impl SpecialFormType {
             | Self::Intersection
             | Self::TypeOf
             | Self::CallableTypeOf => module.is_ty_extensions(),
+
+            Self::TypedDictSchema => false,
         }
     }
 
@@ -324,7 +332,8 @@ impl SpecialFormType {
             | Self::ReadOnly
             | Self::Protocol
             | Self::Any
-            | Self::Generic => false,
+            | Self::Generic
+            | Self::TypedDictSchema => false,
         }
     }
 
@@ -375,6 +384,7 @@ impl SpecialFormType {
             SpecialFormType::Protocol => "typing.Protocol",
             SpecialFormType::Generic => "typing.Generic",
             SpecialFormType::NamedTuple => "typing.NamedTuple",
+            SpecialFormType::TypedDictSchema => "_TypedDictSchema",
         }
     }
 }

--- a/crates/ty_python_semantic/src/types/special_form.rs
+++ b/crates/ty_python_semantic/src/types/special_form.rs
@@ -130,7 +130,7 @@ pub enum SpecialFormType {
 }
 
 impl SpecialFormType {
-    /// Return the [`KnownClass`] which this symbol is an instance of
+    /// Return the [`KnownClass`] which this symbol is an instance of.
     pub(crate) const fn class(self) -> KnownClass {
         match self {
             Self::Annotated

--- a/crates/ty_python_semantic/src/types/type_ordering.rs
+++ b/crates/ty_python_semantic/src/types/type_ordering.rs
@@ -212,9 +212,7 @@ pub(super) fn union_or_intersection_elements_ordering<'db>(
         (Type::TypeAlias(_), _) => Ordering::Less,
         (_, Type::TypeAlias(_)) => Ordering::Greater,
 
-        (Type::TypedDict(left), Type::TypedDict(right)) => {
-            left.defining_class().cmp(&right.defining_class())
-        }
+        (Type::TypedDict(left), Type::TypedDict(right)) => left.cmp(right),
         (Type::TypedDict(_), _) => Ordering::Less,
         (_, Type::TypedDict(_)) => Ordering::Greater,
 

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -431,6 +431,15 @@ impl<'db> SynthesizedTypedDictType<'db> {
         SynthesizedTypedDictType::new(db, self.name(db), self.params(db), items)
     }
 
+    pub(crate) fn normalized_impl(
+        self,
+        _db: &'db dyn Db,
+        _visitor: &NormalizedVisitor<'db>,
+    ) -> Self {
+        // TODO: Normalize typed dicts.
+        self
+    }
+
     fn heap_size(
         (name, params, items): &(Option<Name>, TypedDictParams, FxOrderMap<Name, Field<'db>>),
     ) -> usize {

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -62,10 +62,10 @@ impl<'db> TypedDictType<'db> {
         TypedDictType::FromClass(class)
     }
 
-    /// Returns an incomplete `TypedDictType` from its items.
+    /// Returns an anonymous (incomplete) `TypedDictType` from its items.
     ///
     /// This is used to instantiate a `TypedDictType` from the dictionary literal passed to a
-    /// `TypedDict` constructor.
+    /// `typing.TypedDict` constructor (functional form for creating `TypedDict`s).
     pub(crate) fn from_items(db: &'db dyn Db, items: FxOrderMap<Name, Field<'db>>) -> Self {
         TypedDictType::Synthesized(SynthesizedTypedDictType::new(
             db,
@@ -397,7 +397,7 @@ impl<'db> TypedDictType<'db> {
 #[derive(PartialOrd, Ord)]
 pub struct SynthesizedTypedDictType<'db> {
     // The dictionary literal passed to the `TypedDict` constructor is inferred as
-    // a nameless `SynthesizedTypedDictType`.
+    // an anonymous (incomplete) `SynthesizedTypedDictType`.
     pub(crate) name: Option<Name>,
 
     pub(crate) params: TypedDictParams,


### PR DESCRIPTION
## Summary

Adds support for the functional `TypedDict` syntax, e.g.
```py
Person = TypedDict("Person", { "name": str })

person: Person = { "name": "..." }
```

Part of https://github.com/astral-sh/ty/issues/154.