### PR TITLE
[`ruff`] Use `DiagnosticTag` for more pyupgrade rules

### DIFF
--- a/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_c_element_tree.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_c_element_tree.rs
@@ -43,6 +43,7 @@ where
     T: Ranged,
 {
     let mut diagnostic = checker.report_diagnostic(DeprecatedCElementTree, node.range());
+    diagnostic.add_primary_tag(ruff_db::diagnostic::DiagnosticTag::Deprecated);
     let contents = checker.locator().slice(node);
     diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
         contents.replacen("cElementTree", "ElementTree", 1),

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_mock_import.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_mock_import.rs
@@ -265,6 +265,7 @@ pub(crate) fn deprecated_mock_attribute(checker: &Checker, attribute: &ast::Expr
             },
             attribute.value.range(),
         );
+        diagnostic.add_primary_tag(ruff_db::diagnostic::DiagnosticTag::Deprecated);
         diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
             "mock".to_string(),
             attribute.value.range(),
@@ -313,6 +314,7 @@ pub(crate) fn deprecated_mock_import(checker: &Checker, stmt: &Stmt) {
                             },
                             name.range(),
                         );
+                        diagnostic.add_primary_tag(ruff_db::diagnostic::DiagnosticTag::Deprecated);
                         if let Some(content) = content.as_ref() {
                             diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                                 content.clone(),
@@ -351,6 +353,7 @@ pub(crate) fn deprecated_mock_import(checker: &Checker, stmt: &Stmt) {
                     },
                     stmt.range(),
                 );
+                diagnostic.add_primary_tag(ruff_db::diagnostic::DiagnosticTag::Deprecated);
                 if let Some(indent) = indentation(checker.source(), stmt) {
                     diagnostic.try_set_fix(|| {
                         format_import_from(stmt, indent, checker.locator(), checker.stylist())

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_unittest_alias.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_unittest_alias.rs
@@ -98,6 +98,7 @@ pub(crate) fn deprecated_unittest_alias(checker: &Checker, expr: &Expr) {
         },
         expr.range(),
     );
+    diagnostic.add_primary_tag(ruff_db::diagnostic::DiagnosticTag::Deprecated);
     diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
         format!("self.{target}"),
         expr.range(),

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/replace_universal_newlines.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/replace_universal_newlines.rs
@@ -68,6 +68,7 @@ pub(crate) fn replace_universal_newlines(checker: &Checker, call: &ast::ExprCall
         };
 
         let mut diagnostic = checker.report_diagnostic(ReplaceUniversalNewlines, arg.range());
+        diagnostic.add_primary_tag(ruff_db::diagnostic::DiagnosticTag::Deprecated);
 
         if call.arguments.find_keyword("text").is_some() {
             diagnostic.try_set_fix(|| {

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/typing_text_str_alias.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/typing_text_str_alias.rs
@@ -57,6 +57,7 @@ pub(crate) fn typing_text_str_alias(checker: &Checker, expr: &Expr) {
         .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["typing", "Text"]))
     {
         let mut diagnostic = checker.report_diagnostic(TypingTextStrAlias, expr.range());
+        diagnostic.add_primary_tag(ruff_db::diagnostic::DiagnosticTag::Deprecated);
         diagnostic.try_set_fix(|| {
             let (import_edit, binding) = checker.importer().get_or_import_builtin_symbol(
                 "str",


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Fixes a part of #20590

Rolling out DiagnosticTag to every existing rule in one go would complicate the review, so in this pull request I’ve limited the changes to **pyupgrade**. (UP019, UP021, UP005, UP026, UP023)

If you’d prefer I include more changes in one go, I can do that—please let me know.

## Test Plan

<!-- How was it tested? -->
