### PR TITLE
[`ruff`] Use DiagnosticTag for more flake8 and numpy rules

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/suspicious_function_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/suspicious_function_call.rs
@@ -1091,9 +1091,12 @@ fn suspicious_function(
         ] => checker.report_diagnostic_if_enabled(SuspiciousInsecureCipherModeUsage, range),
 
         // Mktemp
-        ["tempfile", "mktemp"] => {
-            checker.report_diagnostic_if_enabled(SuspiciousMktempUsage, range)
-        }
+        ["tempfile", "mktemp"] => checker
+            .report_diagnostic_if_enabled(SuspiciousMktempUsage, range)
+            .map(|mut diagnostic| {
+                diagnostic.add_primary_tag(ruff_db::diagnostic::DiagnosticTag::Deprecated);
+                diagnostic
+            }),
 
         // Eval
         ["" | "builtins", "eval"] => {

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/bytestring_usage.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/bytestring_usage.rs
@@ -74,7 +74,8 @@ pub(crate) fn bytestring_attribute(checker: &Checker, attribute: &Expr) {
         ["collections", "abc", "ByteString"] => ByteStringOrigin::CollectionsAbc,
         _ => return,
     };
-    checker.report_diagnostic(ByteStringUsage { origin }, attribute.range());
+    let mut diagnostic = checker.report_diagnostic(ByteStringUsage { origin }, attribute.range());
+    diagnostic.add_primary_tag(ruff_db::diagnostic::DiagnosticTag::Deprecated);
 }
 
 /// PYI057
@@ -94,7 +95,9 @@ pub(crate) fn bytestring_import(checker: &Checker, import_from: &ast::StmtImport
 
     for name in names {
         if name.name.as_str() == "ByteString" {
-            checker.report_diagnostic(ByteStringUsage { origin }, name.range());
+            let mut diagnostic =
+                checker.report_diagnostic(ByteStringUsage { origin }, name.range());
+            diagnostic.add_primary_tag(ruff_db::diagnostic::DiagnosticTag::Deprecated);
         }
     }
 }

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/fixture.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/fixture.rs
@@ -898,7 +898,9 @@ fn check_test_function_args(checker: &Checker, parameters: &Parameters, decorato
 /// PT020
 fn check_fixture_decorator_name(checker: &Checker, decorator: &Decorator) {
     if is_pytest_yield_fixture(decorator, checker.semantic()) {
-        checker.report_diagnostic(PytestDeprecatedYieldFixture, decorator.range());
+        let mut diagnostic =
+            checker.report_diagnostic(PytestDeprecatedYieldFixture, decorator.range());
+        diagnostic.add_primary_tag(ruff_db::diagnostic::DiagnosticTag::Deprecated);
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_unused_arguments/rules/unused_arguments.rs
+++ b/crates/ruff_linter/src/rules/flake8_unused_arguments/rules/unused_arguments.rs
@@ -223,7 +223,7 @@ enum Argumentable {
 
 impl Argumentable {
     fn check_for(self, checker: &Checker, name: String, range: TextRange) {
-        match self {
+        let mut diagnostic = match self {
             Self::Function => checker.report_diagnostic(UnusedFunctionArgument { name }, range),
             Self::Method => checker.report_diagnostic(UnusedMethodArgument { name }, range),
             Self::ClassMethod => {
@@ -234,6 +234,7 @@ impl Argumentable {
             }
             Self::Lambda => checker.report_diagnostic(UnusedLambdaArgument { name }, range),
         };
+        diagnostic.add_primary_tag(ruff_db::diagnostic::DiagnosticTag::Unnecessary);
     }
 
     const fn rule_code(self) -> Rule {

--- a/crates/ruff_linter/src/rules/numpy/rules/deprecated_function.rs
+++ b/crates/ruff_linter/src/rules/numpy/rules/deprecated_function.rs
@@ -80,6 +80,7 @@ pub(crate) fn deprecated_function(checker: &Checker, expr: &Expr) {
             },
             expr.range(),
         );
+        diagnostic.add_primary_tag(ruff_db::diagnostic::DiagnosticTag::Deprecated);
         diagnostic.try_set_fix(|| {
             let (import_edit, binding) = checker.importer().get_or_import_symbol(
                 &ImportRequest::import_from("numpy", replacement),

--- a/crates/ruff_linter/src/rules/numpy/rules/deprecated_type_alias.rs
+++ b/crates/ruff_linter/src/rules/numpy/rules/deprecated_type_alias.rs
@@ -80,6 +80,7 @@ pub(crate) fn deprecated_type_alias(checker: &Checker, expr: &Expr) {
             },
             expr.range(),
         );
+        diagnostic.add_primary_tag(ruff_db::diagnostic::DiagnosticTag::Deprecated);
         let type_name = match type_name {
             "unicode" => "str",
             _ => type_name,


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Fixes a part of #20590 and follow up to #20734

Rolling out `DiagnosticTag` to every existing rule in one go would complicate the review, so in this pull request I’ve limited the changes to flake8 and numpy. (NPY001, NPY003, ARG001, ARG002, ARG003, ARG004, ARG005, PT020, PYI057, S306)

## Test Plan

<!-- How was it tested? -->
