### PR TITLE
[ty] Use 3.14 in the ty playground

### DIFF
--- a/playground/ty/src/Playground.tsx
+++ b/playground/ty/src/Playground.tsx
@@ -214,7 +214,7 @@ export default function Playground() {
 export const DEFAULT_SETTINGS = JSON.stringify(
   {
     environment: {
-      "python-version": "3.13",
+      "python-version": "3.14",
     },
     rules: {
       "undefined-reveal": "ignore",


### PR DESCRIPTION
## Summary

Use 3.14 by default in the ty playground

## Test Plan

Opened the playground locally and made sure that the default configuration uses 3.14.
