### PR TITLE
[ty] Fix accidental Liskov violation in protocol tests

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -630,7 +630,7 @@ static_assert(is_assignable_to(FooSub, HasX))
 static_assert(not is_subtype_of(FooSub, HasXY))
 static_assert(not is_assignable_to(FooSub, HasXY))
 
-class FooBool(Foo):
+class FooBool:
     x: bool
 
 static_assert(not is_subtype_of(FooBool, HasX))


### PR DESCRIPTION
## Summary

We have the following test in `protocols.md`:
```py
class HasX(Protocol):
    x: int

# […]

class Foo:
    x: int

# […]

class FooBool(Foo):
    x: bool

static_assert(not is_subtype_of(FooBool, HasX))
static_assert(not is_assignable_to(FooBool, HasX))
```

If `Foo` was indeed intended to be a base class of `FooBool`, then `x: bool` should be reported as a Liskov violation. And then it's a matter of definition whether or not these assertions should hold true or not (should the incorrect override take precedence or not?). So it looks to me like this is just an oversight, probably a copy-paste error from another test right before it, where `FooSub` is indeed intended to be a subclass of `Foo`.