### PR TITLE
[ty] infer `Self` return type annotation for class methods

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/cls.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/cls.md
@@ -1,0 +1,20 @@
+# `cls`
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+## Methods
+
+```py
+from typing import Type, Self
+
+class C:
+    @classmethod
+    def make_instance(cls: Type[Self]) -> Self:
+        return cls()
+
+reveal_type(C.make_instance())  # revealed: C
+reveal_type(C.make_instance)  # revealed: bound method <class 'C'>.make_instance() -> C
+```


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

Infer annotated `Self` return type correctly for class methods.

Example:

```py
from typing import Type, Self

class C:
    @classmethod
    def make_instance(cls: Type[Self]) -> Self:
        return cls()

reveal_type(C.make_instance())  # Should be C but is Unknown
reveal_type(C.make_instance)  # revealed: bound method <class 'C'>.make_instance() -> C
```

## Test Plan

<!-- How was it tested? -->
