### PR TITLE
[ty] allow any string `Literal` type expression as a key when constructing a `TypedDict`

### DIFF
--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5565,14 +5565,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
         }
 
-        validate_typed_dict_dict_literal(
-            self.db(),
-            &self.context,
-            typed_dict,
-            dict,
-            dict.into(),
-            |expr| self.expression_type(expr),
-        )
+        validate_typed_dict_dict_literal(&self.context, typed_dict, dict, dict.into(), |expr| {
+            self.expression_type(expr)
+        })
         .ok()
         .map(|_| Type::TypedDict(typed_dict))
     }

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -387,12 +387,11 @@ fn validate_from_keywords<'db, 'ast>(
 
 /// Validates a `TypedDict` dictionary literal assignment,
 /// e.g. `person: Person = {"name": "Alice", "age": 30}`
-pub(super) fn validate_typed_dict_dict_literal<'db, 'ast>(
-    db: &'db dyn Db,
-    context: &InferContext<'db, 'ast>,
+pub(super) fn validate_typed_dict_dict_literal<'db>(
+    context: &InferContext<'db, '_>,
     typed_dict: TypedDictType<'db>,
-    dict_expr: &'ast ast::ExprDict,
-    error_node: AnyNodeRef<'ast>,
+    dict_expr: &ast::ExprDict,
+    error_node: AnyNodeRef,
     expression_type_fn: impl Fn(&ast::Expr) -> Type<'db>,
 ) -> Result<OrderSet<&'db str>, OrderSet<&'db str>> {
     let mut valid = true;
@@ -403,7 +402,7 @@ pub(super) fn validate_typed_dict_dict_literal<'db, 'ast>(
         if let Some(key_expr) = &item.key {
             let key_ty = expression_type_fn(key_expr);
             if let Type::StringLiteral(key_str) = key_ty {
-                let key_str = key_str.value(db);
+                let key_str = key_str.value(context.db());
                 provided_keys.insert(key_str);
 
                 let value_type = expression_type_fn(&item.value);


### PR DESCRIPTION
## Summary

This PR allows any string `Literal` type expression to be used as a key when constructing a `TypedDict`.

The pattern of reusing constant key strings when constructing a `TypedDict` seems to be common in several libraries (e.g., [home-assistant/core](https://github.com/home-assistant/core/blob/f6fb4c8d5a26d496ca0ebe790776bc208386e83d/homeassistant/components/environment_canada/weather.py#L227C1-L241C14)).
Currently, we only accept string literal keys when constructing a `TypedDict`, but any expression that can be inferred to be of type string `Literal` is also acceptable. In fact, [the spec](https://typing.python.org/en/latest/spec/typeddict.html#use-of-final-values-and-literal-types) explicitly states that `Literal` type expressions and `Final` names ​​should be allowed.

## Test Plan

New tests in `typed_dict.md`
