### PR TITLE
[`flake8-logging-format`] Avoid dropping implicitly concatenated pieces in the `G004` fix

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_logging_format/G004_implicit_concat.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_logging_format/G004_implicit_concat.py
@@ -1,0 +1,8 @@
+import logging
+
+variablename = "value"
+
+log = logging.getLogger(__name__)
+log.info(f"a" f"b {variablename}")
+log.info("a " f"b {variablename}")
+log.info("prefix " f"middle {variablename}" f" suffix")

--- a/crates/ruff_linter/src/rules/flake8_logging_format/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_logging_format/mod.rs
@@ -23,6 +23,7 @@ mod tests {
     #[test_case(Path::new("G003.py"))]
     #[test_case(Path::new("G004.py"))]
     #[test_case(Path::new("G004_arg_order.py"))]
+    #[test_case(Path::new("G004_implicit_concat.py"))]
     #[test_case(Path::new("G010.py"))]
     #[test_case(Path::new("G101_1.py"))]
     #[test_case(Path::new("G101_2.py"))]
@@ -52,6 +53,7 @@ mod tests {
 
     #[test_case(Rule::LoggingFString, Path::new("G004.py"))]
     #[test_case(Rule::LoggingFString, Path::new("G004_arg_order.py"))]
+    #[test_case(Rule::LoggingFString, Path::new("G004_implicit_concat.py"))]
     fn preview_rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!(
             "preview__{}_{}",

--- a/crates/ruff_linter/src/rules/flake8_logging_format/snapshots/ruff_linter__rules__flake8_logging_format__tests__G004_implicit_concat.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_logging_format/snapshots/ruff_linter__rules__flake8_logging_format__tests__G004_implicit_concat.py.snap
@@ -1,0 +1,35 @@
+---
+source: crates/ruff_linter/src/rules/flake8_logging_format/mod.rs
+assertion_line: 50
+---
+G004 Logging statement uses f-string
+ --> G004_implicit_concat.py:6:10
+  |
+5 | log = logging.getLogger(__name__)
+6 | log.info(f"a" f"b {variablename}")
+  |          ^^^^^^^^^^^^^^^^^^^^^^^^
+7 | log.info("a " f"b {variablename}")
+8 | log.info("prefix " f"middle {variablename}" f" suffix")
+  |
+help: Convert to lazy `%` formatting
+
+G004 Logging statement uses f-string
+ --> G004_implicit_concat.py:7:10
+  |
+5 | log = logging.getLogger(__name__)
+6 | log.info(f"a" f"b {variablename}")
+7 | log.info("a " f"b {variablename}")
+  |          ^^^^^^^^^^^^^^^^^^^^^^^^
+8 | log.info("prefix " f"middle {variablename}" f" suffix")
+  |
+help: Convert to lazy `%` formatting
+
+G004 Logging statement uses f-string
+ --> G004_implicit_concat.py:8:10
+  |
+6 | log.info(f"a" f"b {variablename}")
+7 | log.info("a " f"b {variablename}")
+8 | log.info("prefix " f"middle {variablename}" f" suffix")
+  |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+help: Convert to lazy `%` formatting

--- a/crates/ruff_linter/src/rules/flake8_logging_format/snapshots/ruff_linter__rules__flake8_logging_format__tests__preview__G004_G004_implicit_concat.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_logging_format/snapshots/ruff_linter__rules__flake8_logging_format__tests__preview__G004_G004_implicit_concat.py.snap
@@ -1,0 +1,53 @@
+---
+source: crates/ruff_linter/src/rules/flake8_logging_format/mod.rs
+assertion_line: 71
+---
+G004 [*] Logging statement uses f-string
+ --> G004_implicit_concat.py:6:10
+  |
+5 | log = logging.getLogger(__name__)
+6 | log.info(f"a" f"b {variablename}")
+  |          ^^^^^^^^^^^^^^^^^^^^^^^^
+7 | log.info("a " f"b {variablename}")
+8 | log.info("prefix " f"middle {variablename}" f" suffix")
+  |
+help: Convert to lazy `%` formatting
+3 | variablename = "value"
+4 | 
+5 | log = logging.getLogger(__name__)
+  - log.info(f"a" f"b {variablename}")
+6 + log.info("ab %s", variablename)
+7 | log.info("a " f"b {variablename}")
+8 | log.info("prefix " f"middle {variablename}" f" suffix")
+
+G004 [*] Logging statement uses f-string
+ --> G004_implicit_concat.py:7:10
+  |
+5 | log = logging.getLogger(__name__)
+6 | log.info(f"a" f"b {variablename}")
+7 | log.info("a " f"b {variablename}")
+  |          ^^^^^^^^^^^^^^^^^^^^^^^^
+8 | log.info("prefix " f"middle {variablename}" f" suffix")
+  |
+help: Convert to lazy `%` formatting
+4 | 
+5 | log = logging.getLogger(__name__)
+6 | log.info(f"a" f"b {variablename}")
+  - log.info("a " f"b {variablename}")
+7 + log.info("a b %s", variablename)
+8 | log.info("prefix " f"middle {variablename}" f" suffix")
+
+G004 [*] Logging statement uses f-string
+ --> G004_implicit_concat.py:8:10
+  |
+6 | log.info(f"a" f"b {variablename}")
+7 | log.info("a " f"b {variablename}")
+8 | log.info("prefix " f"middle {variablename}" f" suffix")
+  |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+help: Convert to lazy `%` formatting
+5 | log = logging.getLogger(__name__)
+6 | log.info(f"a" f"b {variablename}")
+7 | log.info("a " f"b {variablename}")
+  - log.info("prefix " f"middle {variablename}" f" suffix")
+8 + log.info("prefix middle %s suffix", variablename)


### PR DESCRIPTION
## Summary

The original autofix for G004 was quietly dropping everything but the f-string components of any implicit concatenation sequence; this addresses that.

Side note: It looks like `f_strings` is a bit risky to use (since it implicitly skips non-f-string parts); use iter and include implicitly concatenated pieces. We should consider if it's worth having (convenience vs. bit risky). 

## Test Plan

```
cargo test -p ruff_linter
```

Backtest (run new testcases against previous implementation):
```
git checkout HEAD^ crates/ruff_linter/src/rules/flake8_logging_format/rules/logging_call.rs
cargo test -p ruff_linter

```