### PR TITLE
[ty] avoid standalone expressions for simple subscript targets

### DIFF
--- a/crates/ty_python_semantic/src/semantic_index/builder.rs
+++ b/crates/ty_python_semantic/src/semantic_index/builder.rs
@@ -1626,10 +1626,11 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
                 self.visit_expr(&node.value);
 
                 // Optimization for the common case: if there's just one target, and it's not an
-                // unpacking, and the target is a simple name, we don't need the RHS to be a
-                // standalone expression at all.
+                // unpacking, and the target is a simple name or subscript, we don't need the RHS
+                // to be a standalone expression at all. (We do still need standalone expressions
+                // for attribute targets, for implicit-attribute handling.)
                 if let [target] = &node.targets[..]
-                    && target.is_name_expr()
+                    && (target.is_name_expr() || target.is_subscript_expr())
                 {
                     self.push_assignment(CurrentAssignment::Assign { node, unpack: None });
                     self.visit_expr(target);

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -3215,7 +3215,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         for target in targets {
             self.infer_target(target, value, |builder, value_expr| {
-                builder.infer_standalone_expression(value_expr, TypeContext::default())
+                builder.infer_maybe_standalone_expression(value_expr, TypeContext::default())
             });
         }
     }


### PR DESCRIPTION
## Summary

We don't need the RHS of a simple assignment statement of the form `x[0] = ...` to be a standalone expression, if there is just one target and no unpacking. Eliminate these standalone expressions to reduce Salsa memory usage.

## Test Plan

Existing tests.