### PR TITLE
[ty] Use declared variable types as bidirectional type context

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/assignment/annotations.md
+++ b/crates/ty_python_semantic/resources/mdtest/assignment/annotations.md
@@ -144,6 +144,12 @@ reveal_type(q)  # revealed: dict[int | str, int]
 
 r: dict[int | str, int | str] = {1: 1, 2: 2, 3: 3}
 reveal_type(r)  # revealed: dict[int | str, int | str]
+
+s: dict[int | str, int | str]
+s = {1: 1, 2: 2, 3: 3}
+reveal_type(s)  # revealed: dict[int | str, int | str]
+(s := {1: 1, 2: 2, 3: 3})
+reveal_type(s)  # revealed: dict[int | str, int | str]
 ```
 
 ## Optional collection literal annotations are understood
@@ -296,6 +302,12 @@ reveal_type(q)  # revealed: list[int]
 
 r: list[Literal[1, 2, 3, 4]] = [1, 2]
 reveal_type(r)  # revealed: list[Literal[1, 2, 3, 4]]
+
+s: list[Literal[1]]
+s = [1]
+reveal_type(s)  # revealed: list[Literal[1]]
+(s := [1])
+reveal_type(s)  # revealed: list[Literal[1]]
 ```
 
 ## PEP-604 annotations are supported

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/nested.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/nested.md
@@ -310,13 +310,13 @@ no longer valid in the inner lazy scope.
 def f(l: list[str | None]):
     if l[0] is not None:
         def _():
-            reveal_type(l[0])  # revealed: str | None | Unknown
+            reveal_type(l[0])  # revealed: str | None
         l = [None]
 
 def f(l: list[str | None]):
     l[0] = "a"
     def _():
-        reveal_type(l[0])  # revealed: str | None | Unknown
+        reveal_type(l[0])  # revealed: str | None
     l = [None]
 
 def f(l: list[str | None]):

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -233,10 +233,12 @@ Person({"name": "Alice"})
 
 # error: [missing-typed-dict-key] "Missing required key 'age' in TypedDict `Person` constructor"
 accepts_person({"name": "Alice"})
+
 # TODO: this should be an error, similar to the above
 house.owner = {"name": "Alice"}
+
 a_person: Person
-# TODO: this should be an error, similar to the above
+# error: [missing-typed-dict-key] "Missing required key 'age' in TypedDict `Person` constructor"
 a_person = {"name": "Alice"}
 ```
 
@@ -254,9 +256,12 @@ Person({"name": None, "age": 30})
 accepts_person({"name": None, "age": 30})
 # TODO: this should be an error, similar to the above
 house.owner = {"name": None, "age": 30}
+
 a_person: Person
-# TODO: this should be an error, similar to the above
+# error: [invalid-argument-type] "Invalid argument to key "name" with declared type `str` on TypedDict `Person`: value of type `None`"
 a_person = {"name": None, "age": 30}
+# error: [invalid-argument-type] "Invalid argument to key "name" with declared type `str` on TypedDict `Person`: value of type `None`"
+(a_person := {"name": None, "age": 30})
 ```
 
 All of these have an extra field that is not defined in the `TypedDict`:
@@ -273,9 +278,12 @@ Person({"name": "Alice", "age": 30, "extra": True})
 accepts_person({"name": "Alice", "age": 30, "extra": True})
 # TODO: this should be an error
 house.owner = {"name": "Alice", "age": 30, "extra": True}
-# TODO: this should be an error
+
 a_person: Person
+# error: [invalid-key] "Invalid key access on TypedDict `Person`: Unknown key "extra""
 a_person = {"name": "Alice", "age": 30, "extra": True}
+# error: [invalid-key] "Invalid key access on TypedDict `Person`: Unknown key "extra""
+(a_person := {"name": "Alice", "age": 30, "extra": True})
 ```
 
 ## Type ignore compatibility issues


### PR DESCRIPTION
## Summary

Use the declared type of variables as type context for the RHS of assignment expressions, e.g.,
```py
x: list[int | str]
x = [1]
reveal_type(x)  # revealed: list[int | str]
```