### PR TITLE
[ty] Annotations are deferred by default for 3.14+

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/assignment/annotations.md
+++ b/crates/ty_python_semantic/resources/mdtest/assignment/annotations.md
@@ -308,6 +308,22 @@ x = Foo()
 reveal_type(x)  # revealed: Foo
 ```
 
+## Annotations are deferred by default in Python 3.14 and later
+
+```toml
+[environment]
+python-version = "3.14"
+```
+
+```py
+x: Foo
+
+class Foo: ...
+
+x = Foo()
+reveal_type(x)  # revealed: Foo
+```
+
 ## Annotated assignments in stub files are inferred correctly
 
 ```pyi

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -374,9 +374,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     }
 
     /// Are we currently inferring types in file with deferred types?
-    /// This is true for stub files and files with `__future__.annotations`
+    /// This is true for stub files, for files with `__future__.annotations`, and
+    /// by default for all source files in Python 3.14 and later.
     fn defer_annotations(&self) -> bool {
-        self.index.has_future_annotations() || self.in_stub()
+        self.index.has_future_annotations()
+            || self.in_stub()
+            || Program::get(self.db()).python_version(self.db()) >= PythonVersion::PY314
     }
 
     /// Are we currently in a context where name resolution should be deferred


### PR DESCRIPTION
## Summary

Type annotations are deferred by default starting with Python 3.14. No `from __future__ import annotations` import is necessary.

## Test Plan

New Markdown test
