### PR TITLE
[`ruff`] Use DiagnosticTag for more pyflakes and panda rules

### DIFF
--- a/crates/ruff_linter/src/checkers/noqa.rs
+++ b/crates/ruff_linter/src/checkers/noqa.rs
@@ -130,6 +130,7 @@ pub(crate) fn check_noqa(
                         let edit = delete_comment(directive.range(), locator);
                         let mut diagnostic = context
                             .report_diagnostic(UnusedNOQA { codes: None }, directive.range());
+                        diagnostic.add_primary_tag(ruff_db::diagnostic::DiagnosticTag::Unnecessary);
                         diagnostic.set_fix(Fix::safe_edit(edit));
                     }
                 }
@@ -226,6 +227,7 @@ pub(crate) fn check_noqa(
                             },
                             directive.range(),
                         );
+                        diagnostic.add_primary_tag(ruff_db::diagnostic::DiagnosticTag::Unnecessary);
                         diagnostic.set_fix(Fix::safe_edit(edit));
                     }
                 }

--- a/crates/ruff_linter/src/rules/pandas_vet/rules/subscript.rs
+++ b/crates/ruff_linter/src/rules/pandas_vet/rules/subscript.rs
@@ -165,16 +165,17 @@ pub(crate) fn subscript(checker: &Checker, value: &Expr, expr: &Expr) {
     match attr.as_str() {
         // PD007
         "ix" if checker.is_rule_enabled(Rule::PandasUseOfDotIx) => {
-            checker.report_diagnostic(PandasUseOfDotIx, range)
+            let mut diagnostic = checker.report_diagnostic(PandasUseOfDotIx, range);
+            diagnostic.add_primary_tag(ruff_db::diagnostic::DiagnosticTag::Deprecated);
         }
         // PD008
         "at" if checker.is_rule_enabled(Rule::PandasUseOfDotAt) => {
-            checker.report_diagnostic(PandasUseOfDotAt, range)
+            checker.report_diagnostic(PandasUseOfDotAt, range);
         }
         // PD009
         "iat" if checker.is_rule_enabled(Rule::PandasUseOfDotIat) => {
-            checker.report_diagnostic(PandasUseOfDotIat, range)
+            checker.report_diagnostic(PandasUseOfDotIat, range);
         }
-        _ => return,
-    };
+        _ => (),
+    }
 }

--- a/crates/ruff_linter/src/rules/pyflakes/rules/redefined_while_unused.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/redefined_while_unused.rs
@@ -191,6 +191,7 @@ pub(crate) fn redefined_while_unused(checker: &Checker, scope_id: ScopeId, scope
                 },
                 binding.range(),
             );
+            diagnostic.add_primary_tag(ruff_db::diagnostic::DiagnosticTag::Unnecessary);
 
             diagnostic.secondary_annotation(
                 format_args!("previous definition of `{name}` here"),


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Fixes a part of #20590 and follow up to #20734

Rolling out DiagnosticTag to every existing rule in one go would complicate the review, so in this pull request I’ve limited the changes to flake8 and numpy. (RUF100, PD011, F811, F842, RUF029)

## Test Plan

<!-- How was it tested? -->
