### PR TITLE
[ty] use type context more aggressively to infer values ​​when constructing a `TypedDict`

### DIFF
--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5855,11 +5855,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let typed_dict_items = typed_dict.items(self.db());
 
         for item in items {
-            self.infer_optional_expression(item.key.as_ref(), TypeContext::default());
+            let key_ty = self.infer_optional_expression(item.key.as_ref(), TypeContext::default());
 
-            if let Some(ast::Expr::StringLiteral(ref key)) = item.key
-                && let Some(key) = key.as_single_part_string()
-                && let Some(field) = typed_dict_items.get(key.as_str())
+            if let Some(Type::StringLiteral(key)) = key_ty
+                && let Some(field) = typed_dict_items.get(key.value(self.db()))
             {
                 self.infer_expression(&item.value, TypeContext::new(Some(field.declared_ty)));
             } else {


### PR DESCRIPTION
## Summary

Based on @ibraheemdev's comment on #20792:

> I think we can also update our bidirectional inference code, [which makes the same assumption](https://github.com/astral-sh/ruff/blob/main/crates/ty_python_semantic/src/types/infer/builder.rs?rgh-link-date=2025-10-09T21%3A30%3A31Z#L5860).

This PR also adds more test cases for how `TypedDict` annotations affect generic call inference.

## Test Plan

New tests in `typed_dict.md`
