### PR TITLE
[ty] Remove 'pre-release software' warning

### DIFF
--- a/crates/ty/src/lib.rs
+++ b/crates/ty/src/lib.rs
@@ -73,11 +73,6 @@ fn run_check(args: CheckCommand) -> anyhow::Result<ExitStatus> {
 
     let printer = Printer::default().with_verbosity(verbosity);
 
-    tracing::warn!(
-        "ty is pre-release software and not ready for production use. \
-            Expect to encounter bugs, missing features, and fatal errors.",
-    );
-
     tracing::debug!("Version: {}", version::version());
 
     // The base path to which all CLI arguments are relative to.

--- a/crates/ty/tests/cli/config_option.rs
+++ b/crates/ty/tests/cli/config_option.rs
@@ -7,7 +7,7 @@ fn cli_config_args_toml_string_basic() -> anyhow::Result<()> {
     let case = CliTest::with_file("test.py", r"print(x)  # [unresolved-reference]")?;
 
     // Long flag
-    assert_cmd_snapshot!(case.command().arg("--warn").arg("unresolved-reference").arg("--config").arg("terminal.error-on-warning=true"), @r"
+    assert_cmd_snapshot!(case.command().arg("--warn").arg("unresolved-reference").arg("--config").arg("terminal.error-on-warning=true"), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -22,11 +22,10 @@ fn cli_config_args_toml_string_basic() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     // Short flag
-    assert_cmd_snapshot!(case.command().arg("-c").arg("terminal.error-on-warning=true"), @r"
+    assert_cmd_snapshot!(case.command().arg("-c").arg("terminal.error-on-warning=true"), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -41,8 +40,7 @@ fn cli_config_args_toml_string_basic() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     Ok(())
 }
@@ -61,7 +59,7 @@ fn cli_config_args_overrides_ty_toml() -> anyhow::Result<()> {
     ])?;
 
     // Exit code of 1 due to the setting in `ty.toml`
-    assert_cmd_snapshot!(case.command().arg("--warn").arg("unresolved-reference"), @r"
+    assert_cmd_snapshot!(case.command().arg("--warn").arg("unresolved-reference"), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -76,11 +74,10 @@ fn cli_config_args_overrides_ty_toml() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     // Exit code of 0 because the `ty.toml` setting is overwritten by `--config`
-    assert_cmd_snapshot!(case.command().arg("--warn").arg("unresolved-reference").arg("--config").arg("terminal.error-on-warning=false"), @r"
+    assert_cmd_snapshot!(case.command().arg("--warn").arg("unresolved-reference").arg("--config").arg("terminal.error-on-warning=false"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -95,8 +92,7 @@ fn cli_config_args_overrides_ty_toml() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     Ok(())
 }
@@ -104,7 +100,7 @@ fn cli_config_args_overrides_ty_toml() -> anyhow::Result<()> {
 #[test]
 fn cli_config_args_later_overrides_earlier() -> anyhow::Result<()> {
     let case = CliTest::with_file("test.py", r"print(x)  # [unresolved-reference]")?;
-    assert_cmd_snapshot!(case.command().arg("--warn").arg("unresolved-reference").arg("--config").arg("terminal.error-on-warning=true").arg("--config").arg("terminal.error-on-warning=false"), @r"
+    assert_cmd_snapshot!(case.command().arg("--warn").arg("unresolved-reference").arg("--config").arg("terminal.error-on-warning=true").arg("--config").arg("terminal.error-on-warning=false"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -119,8 +115,7 @@ fn cli_config_args_later_overrides_earlier() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     Ok(())
 }
@@ -165,7 +160,7 @@ fn config_file_override() -> anyhow::Result<()> {
     ])?;
 
     // Ensure flag works via CLI arg
-    assert_cmd_snapshot!(case.command().arg("--warn").arg("unresolved-reference").arg("--config-file").arg("ty-override.toml"), @r"
+    assert_cmd_snapshot!(case.command().arg("--warn").arg("unresolved-reference").arg("--config-file").arg("ty-override.toml"), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -180,11 +175,10 @@ fn config_file_override() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     // Ensure the flag works via an environment variable
-    assert_cmd_snapshot!(case.command().arg("--warn").arg("unresolved-reference").env("TY_CONFIG_FILE", "ty-override.toml"), @r"
+    assert_cmd_snapshot!(case.command().arg("--warn").arg("unresolved-reference").env("TY_CONFIG_FILE", "ty-override.toml"), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -199,8 +193,7 @@ fn config_file_override() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     Ok(())
 }

--- a/crates/ty/tests/cli/exit_code.rs
+++ b/crates/ty/tests/cli/exit_code.rs
@@ -6,7 +6,7 @@ use crate::CliTest;
 fn only_warnings() -> anyhow::Result<()> {
     let case = CliTest::with_file("test.py", r"print(x)  # [unresolved-reference]")?;
 
-    assert_cmd_snapshot!(case.command().arg("--warn").arg("unresolved-reference"), @r"
+    assert_cmd_snapshot!(case.command().arg("--warn").arg("unresolved-reference"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -21,8 +21,7 @@ fn only_warnings() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     Ok(())
 }
@@ -37,7 +36,7 @@ fn only_info() -> anyhow::Result<()> {
         "#,
     )?;
 
-    assert_cmd_snapshot!(case.command(), @r"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -52,8 +51,7 @@ fn only_info() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     Ok(())
 }
@@ -68,7 +66,7 @@ fn only_info_and_error_on_warning_is_true() -> anyhow::Result<()> {
         "#,
     )?;
 
-    assert_cmd_snapshot!(case.command().arg("--error-on-warning"), @r"
+    assert_cmd_snapshot!(case.command().arg("--error-on-warning"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -83,8 +81,7 @@ fn only_info_and_error_on_warning_is_true() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     Ok(())
 }
@@ -93,7 +90,7 @@ fn only_info_and_error_on_warning_is_true() -> anyhow::Result<()> {
 fn no_errors_but_error_on_warning_is_true() -> anyhow::Result<()> {
     let case = CliTest::with_file("test.py", r"print(x)  # [unresolved-reference]")?;
 
-    assert_cmd_snapshot!(case.command().arg("--error-on-warning").arg("--warn").arg("unresolved-reference"), @r"
+    assert_cmd_snapshot!(case.command().arg("--error-on-warning").arg("--warn").arg("unresolved-reference"), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -108,8 +105,7 @@ fn no_errors_but_error_on_warning_is_true() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     Ok(())
 }
@@ -127,7 +123,7 @@ fn no_errors_but_error_on_warning_is_enabled_in_configuration() -> anyhow::Resul
         ),
     ])?;
 
-    assert_cmd_snapshot!(case.command().arg("--warn").arg("unresolved-reference"), @r"
+    assert_cmd_snapshot!(case.command().arg("--warn").arg("unresolved-reference"), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -142,8 +138,7 @@ fn no_errors_but_error_on_warning_is_enabled_in_configuration() -> anyhow::Resul
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     Ok(())
 }
@@ -158,7 +153,7 @@ fn both_warnings_and_errors() -> anyhow::Result<()> {
         "#,
     )?;
 
-    assert_cmd_snapshot!(case.command().arg("--warn").arg("unresolved-reference"), @r"
+    assert_cmd_snapshot!(case.command().arg("--warn").arg("unresolved-reference"), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -183,8 +178,7 @@ fn both_warnings_and_errors() -> anyhow::Result<()> {
     Found 2 diagnostics
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     Ok(())
 }
@@ -199,7 +193,7 @@ fn both_warnings_and_errors_and_error_on_warning_is_true() -> anyhow::Result<()>
         "###,
     )?;
 
-    assert_cmd_snapshot!(case.command().arg("--warn").arg("unresolved-reference").arg("--error-on-warning"), @r"
+    assert_cmd_snapshot!(case.command().arg("--warn").arg("unresolved-reference").arg("--error-on-warning"), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -224,8 +218,7 @@ fn both_warnings_and_errors_and_error_on_warning_is_true() -> anyhow::Result<()>
     Found 2 diagnostics
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     Ok(())
 }
@@ -240,7 +233,7 @@ fn exit_zero_is_true() -> anyhow::Result<()> {
         "#,
     )?;
 
-    assert_cmd_snapshot!(case.command().arg("--exit-zero").arg("--warn").arg("unresolved-reference"), @r"
+    assert_cmd_snapshot!(case.command().arg("--exit-zero").arg("--warn").arg("unresolved-reference"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -265,8 +258,7 @@ fn exit_zero_is_true() -> anyhow::Result<()> {
     Found 2 diagnostics
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     Ok(())
 }

--- a/crates/ty/tests/cli/file_selection.rs
+++ b/crates/ty/tests/cli/file_selection.rs
@@ -27,7 +27,7 @@ fn exclude_argument() -> anyhow::Result<()> {
     ])?;
 
     // Test that exclude argument is recognized and works
-    assert_cmd_snapshot!(case.command().arg("--exclude").arg("tests/"), @r"
+    assert_cmd_snapshot!(case.command().arg("--exclude").arg("tests/"), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -50,11 +50,10 @@ fn exclude_argument() -> anyhow::Result<()> {
     Found 2 diagnostics
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     // Test multiple exclude patterns
-    assert_cmd_snapshot!(case.command().arg("--exclude").arg("tests/").arg("--exclude").arg("temp_*.py"), @r"
+    assert_cmd_snapshot!(case.command().arg("--exclude").arg("tests/").arg("--exclude").arg("temp_*.py"), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -69,8 +68,7 @@ fn exclude_argument() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     Ok(())
 }
@@ -108,7 +106,7 @@ fn configuration_include() -> anyhow::Result<()> {
         "#,
     )?;
 
-    assert_cmd_snapshot!(case.command(), @r"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -123,8 +121,7 @@ fn configuration_include() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     // Test multiple include patterns via configuration
     case.write_file(
@@ -135,7 +132,7 @@ fn configuration_include() -> anyhow::Result<()> {
         "#,
     )?;
 
-    assert_cmd_snapshot!(case.command(), @r"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -158,8 +155,7 @@ fn configuration_include() -> anyhow::Result<()> {
     Found 2 diagnostics
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     Ok(())
 }
@@ -197,7 +193,7 @@ fn configuration_exclude() -> anyhow::Result<()> {
         "#,
     )?;
 
-    assert_cmd_snapshot!(case.command(), @r"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -220,8 +216,7 @@ fn configuration_exclude() -> anyhow::Result<()> {
     Found 2 diagnostics
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     // Test multiple exclude patterns via configuration
     case.write_file(
@@ -232,7 +227,7 @@ fn configuration_exclude() -> anyhow::Result<()> {
         "#,
     )?;
 
-    assert_cmd_snapshot!(case.command(), @r"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -247,8 +242,7 @@ fn configuration_exclude() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     Ok(())
 }
@@ -287,7 +281,7 @@ fn exclude_precedence_over_include() -> anyhow::Result<()> {
         "#,
     )?;
 
-    assert_cmd_snapshot!(case.command(), @r"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -302,8 +296,7 @@ fn exclude_precedence_over_include() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     Ok(())
 }
@@ -356,7 +349,6 @@ fn exclude_argument_precedence_include_argument() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
     "###);
 
     Ok(())
@@ -381,7 +373,7 @@ fn remove_default_exclude() -> anyhow::Result<()> {
     ])?;
 
     // By default, 'dist' directory should be excluded (see default excludes)
-    assert_cmd_snapshot!(case.command(), @r"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -396,8 +388,7 @@ fn remove_default_exclude() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     // Now override the default exclude by using a negated pattern to re-include 'dist'
     case.write_file(
@@ -408,7 +399,7 @@ fn remove_default_exclude() -> anyhow::Result<()> {
         "#,
     )?;
 
-    assert_cmd_snapshot!(case.command(), @r"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -431,8 +422,7 @@ fn remove_default_exclude() -> anyhow::Result<()> {
     Found 2 diagnostics
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     Ok(())
 }
@@ -465,7 +455,7 @@ fn cli_removes_config_exclude() -> anyhow::Result<()> {
     )?;
 
     // Verify that build/ is excluded by configuration
-    assert_cmd_snapshot!(case.command(), @r"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -480,11 +470,10 @@ fn cli_removes_config_exclude() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     // Now remove the configuration exclude via CLI negation
-    assert_cmd_snapshot!(case.command().arg("--exclude").arg("!build/"), @r"
+    assert_cmd_snapshot!(case.command().arg("--exclude").arg("!build/"), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -507,8 +496,7 @@ fn cli_removes_config_exclude() -> anyhow::Result<()> {
     Found 2 diagnostics
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     Ok(())
 }
@@ -545,7 +533,7 @@ fn explicit_path_overrides_exclude() -> anyhow::Result<()> {
     ])?;
 
     // dist is excluded by default and `tests/generated` is excluded in the project, so only src/main.py should be checked
-    assert_cmd_snapshot!(case.command(), @r"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -560,11 +548,10 @@ fn explicit_path_overrides_exclude() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     // Explicitly checking a file in an excluded directory should still check that file
-    assert_cmd_snapshot!(case.command().arg("tests/generated.py"), @r"
+    assert_cmd_snapshot!(case.command().arg("tests/generated.py"), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -579,11 +566,10 @@ fn explicit_path_overrides_exclude() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     // Explicitly checking the entire excluded directory should check all files in it
-    assert_cmd_snapshot!(case.command().arg("dist/"), @r"
+    assert_cmd_snapshot!(case.command().arg("dist/"), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -598,8 +584,7 @@ fn explicit_path_overrides_exclude() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     Ok(())
 }
@@ -625,13 +610,12 @@ fn invalid_include_pattern() -> anyhow::Result<()> {
     ])?;
 
     // By default, dist/ is excluded, so only src/main.py should be checked
-    assert_cmd_snapshot!(case.command(), @r#"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: false
     exit_code: 2
     ----- stdout -----
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
     ty failed
       Cause: error[invalid-glob]: Invalid include pattern
      --> ty.toml:4:5
@@ -642,7 +626,7 @@ fn invalid_include_pattern() -> anyhow::Result<()> {
       |     ^^^^^^^^^^^^^ Too many stars at position 5
     5 | ]
       |
-    "#);
+    "###);
 
     Ok(())
 }
@@ -668,16 +652,15 @@ fn invalid_include_pattern_concise_output() -> anyhow::Result<()> {
     ])?;
 
     // By default, dist/ is excluded, so only src/main.py should be checked
-    assert_cmd_snapshot!(case.command().arg("--output-format").arg("concise"), @r"
+    assert_cmd_snapshot!(case.command().arg("--output-format").arg("concise"), @r###"
     success: false
     exit_code: 2
     ----- stdout -----
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
     ty failed
       Cause: ty.toml:4:5: error[invalid-glob] Invalid include pattern: Too many stars at position 5
-    ");
+    "###);
 
     Ok(())
 }
@@ -703,13 +686,12 @@ fn invalid_exclude_pattern() -> anyhow::Result<()> {
     ])?;
 
     // By default, dist/ is excluded, so only src/main.py should be checked
-    assert_cmd_snapshot!(case.command(), @r#"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: false
     exit_code: 2
     ----- stdout -----
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
     ty failed
       Cause: error[invalid-glob]: Invalid exclude pattern
      --> ty.toml:4:5
@@ -720,7 +702,7 @@ fn invalid_exclude_pattern() -> anyhow::Result<()> {
       |     ^^^^^^^^ The parent directory operator (`..`) at position 1 is not allowed
     5 | ]
       |
-    "#);
+    "###);
 
     Ok(())
 }
@@ -772,7 +754,7 @@ print(other_undefined)  # error: unresolved-reference
 
     // Change to the bazel-out directory and run ty from there
     // The symlinks should be followed and errors should be found
-    assert_cmd_snapshot!(case.command().current_dir(case.project_dir.join("bazel-out/k8-fastbuild/bin")), @r"
+    assert_cmd_snapshot!(case.command().current_dir(case.project_dir.join("bazel-out/k8-fastbuild/bin")), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -797,11 +779,10 @@ print(other_undefined)  # error: unresolved-reference
     Found 2 diagnostics
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     // Test that when checking a specific symlinked file from the bazel-out directory, it works correctly
-    assert_cmd_snapshot!(case.command().current_dir(case.project_dir.join("bazel-out/k8-fastbuild/bin")).arg("main.py"), @r"
+    assert_cmd_snapshot!(case.command().current_dir(case.project_dir.join("bazel-out/k8-fastbuild/bin")).arg("main.py"), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -817,8 +798,7 @@ print(other_undefined)  # error: unresolved-reference
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     Ok(())
 }
@@ -857,7 +837,7 @@ print(regular_undefined)  # error: unresolved-reference
     case.write_symlink("src/utils.py", "generated_utils.py")?;
 
     // Exclude pattern should match on the symlink name (generated_*), not the target name
-    assert_cmd_snapshot!(case.command().arg("--exclude").arg("generated_*.py"), @r"
+    assert_cmd_snapshot!(case.command().arg("--exclude").arg("generated_*.py"), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -890,11 +870,10 @@ print(regular_undefined)  # error: unresolved-reference
     Found 3 diagnostics
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     // Exclude pattern on target path should not affect symlinks with different names
-    assert_cmd_snapshot!(case.command().arg("--exclude").arg("src/*.py"), @r"
+    assert_cmd_snapshot!(case.command().arg("--exclude").arg("src/*.py"), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -927,11 +906,10 @@ print(regular_undefined)  # error: unresolved-reference
     Found 3 diagnostics
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     // Test that explicitly passing a symlink always checks it, even if excluded
-    assert_cmd_snapshot!(case.command().arg("--exclude").arg("generated_*.py").arg("generated_module.py"), @r"
+    assert_cmd_snapshot!(case.command().arg("--exclude").arg("generated_*.py").arg("generated_module.py"), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -947,8 +925,7 @@ print(regular_undefined)  # error: unresolved-reference
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     Ok(())
 }

--- a/crates/ty/tests/cli/main.rs
+++ b/crates/ty/tests/cli/main.rs
@@ -19,15 +19,14 @@ fn test_quiet_output() -> anyhow::Result<()> {
     let case = CliTest::with_file("test.py", "x: int = 1")?;
 
     // By default, we emit an "all checks passed" message
-    assert_cmd_snapshot!(case.command(), @r"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
     All checks passed!
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     // With `quiet`, the message is not displayed
     assert_cmd_snapshot!(case.command().arg("--quiet"), @r"
@@ -41,7 +40,7 @@ fn test_quiet_output() -> anyhow::Result<()> {
     let case = CliTest::with_file("test.py", "x: int = 'foo'")?;
 
     // By default, we emit a diagnostic
-    assert_cmd_snapshot!(case.command(), @r#"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -56,8 +55,7 @@ fn test_quiet_output() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    "#);
+    "###);
 
     // With `quiet`, the diagnostic is not displayed, just the summary message
     assert_cmd_snapshot!(case.command().arg("--quiet"), @r"
@@ -94,7 +92,7 @@ fn test_quiet_output() -> anyhow::Result<()> {
 #[test]
 fn test_run_in_sub_directory() -> anyhow::Result<()> {
     let case = CliTest::with_files([("test.py", "~"), ("subdir/nothing", "")])?;
-    assert_cmd_snapshot!(case.command().current_dir(case.root().join("subdir")).arg(".."), @r"
+    assert_cmd_snapshot!(case.command().current_dir(case.root().join("subdir")).arg(".."), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -108,15 +106,14 @@ fn test_run_in_sub_directory() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
     Ok(())
 }
 
 #[test]
 fn test_include_hidden_files_by_default() -> anyhow::Result<()> {
     let case = CliTest::with_files([(".test.py", "~")])?;
-    assert_cmd_snapshot!(case.command(), @r"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -130,8 +127,7 @@ fn test_include_hidden_files_by_default() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
     Ok(())
 }
 
@@ -139,19 +135,18 @@ fn test_include_hidden_files_by_default() -> anyhow::Result<()> {
 fn test_respect_ignore_files() -> anyhow::Result<()> {
     // First test that the default option works correctly (the file is skipped)
     let case = CliTest::with_files([(".ignore", "test.py"), ("test.py", "~")])?;
-    assert_cmd_snapshot!(case.command(), @r"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
     All checks passed!
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
     WARN No python files found under the given path(s)
-    ");
+    "###);
 
     // Test that we can set to false via CLI
-    assert_cmd_snapshot!(case.command().arg("--no-respect-ignore-files"), @r"
+    assert_cmd_snapshot!(case.command().arg("--no-respect-ignore-files"), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -165,12 +160,11 @@ fn test_respect_ignore_files() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     // Test that we can set to false via config file
     case.write_file("ty.toml", "src.respect-ignore-files = false")?;
-    assert_cmd_snapshot!(case.command(), @r"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -184,12 +178,11 @@ fn test_respect_ignore_files() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     // Ensure CLI takes precedence
     case.write_file("ty.toml", "src.respect-ignore-files = true")?;
-    assert_cmd_snapshot!(case.command().arg("--no-respect-ignore-files"), @r"
+    assert_cmd_snapshot!(case.command().arg("--no-respect-ignore-files"), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -203,8 +196,7 @@ fn test_respect_ignore_files() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
     Ok(())
 }
 
@@ -251,7 +243,7 @@ fn cli_arguments_are_relative_to_the_current_directory() -> anyhow::Result<()> {
     ])?;
 
     // Make sure that the CLI fails when the `libs` directory is not in the search path.
-    assert_cmd_snapshot!(case.command().current_dir(case.root().join("child")), @r"
+    assert_cmd_snapshot!(case.command().current_dir(case.root().join("child")), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -272,18 +264,16 @@ fn cli_arguments_are_relative_to_the_current_directory() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
-    assert_cmd_snapshot!(case.command().current_dir(case.root().join("child")).arg("--extra-search-path").arg("../libs"), @r"
+    assert_cmd_snapshot!(case.command().current_dir(case.root().join("child")).arg("--extra-search-path").arg("../libs"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
     All checks passed!
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     Ok(())
 }
@@ -329,15 +319,14 @@ fn paths_in_configuration_files_are_relative_to_the_project_root() -> anyhow::Re
         ),
     ])?;
 
-    assert_cmd_snapshot!(case.command().current_dir(case.root().join("child")), @r"
+    assert_cmd_snapshot!(case.command().current_dir(case.root().join("child")), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
     All checks passed!
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     Ok(())
 }
@@ -374,7 +363,7 @@ fn user_configuration() -> anyhow::Result<()> {
 
     assert_cmd_snapshot!(
         case.command().current_dir(case.root().join("project")).env(config_env_var, config_directory.as_os_str()),
-        @r"
+        @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -401,8 +390,7 @@ fn user_configuration() -> anyhow::Result<()> {
     Found 2 diagnostics
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    "
+    "###
     );
 
     // The user-level configuration sets the severity for `unresolved-reference` to warn.
@@ -419,7 +407,7 @@ fn user_configuration() -> anyhow::Result<()> {
 
     assert_cmd_snapshot!(
         case.command().current_dir(case.root().join("project")).env(config_env_var, config_directory.as_os_str()),
-        @r"
+        @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -446,8 +434,7 @@ fn user_configuration() -> anyhow::Result<()> {
     Found 2 diagnostics
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    "
+    "###
     );
 
     Ok(())
@@ -480,7 +467,7 @@ fn check_specific_paths() -> anyhow::Result<()> {
 
     assert_cmd_snapshot!(
         case.command(),
-        @r"
+        @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -513,15 +500,14 @@ fn check_specific_paths() -> anyhow::Result<()> {
     Found 2 diagnostics
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    "
+    "###
     );
 
     // Now check only the `tests` and `other.py` files.
     // We should no longer see any diagnostics related to `main.py`.
     assert_cmd_snapshot!(
         case.command().arg("project/tests").arg("project/other.py"),
-        @r"
+        @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -554,8 +540,7 @@ fn check_specific_paths() -> anyhow::Result<()> {
     Found 2 diagnostics
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    "
+    "###
     );
 
     Ok(())
@@ -574,7 +559,7 @@ fn check_non_existing_path() -> anyhow::Result<()> {
 
     assert_cmd_snapshot!(
         case.command().arg("project/main.py").arg("project/tests"),
-        @r"
+        @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -585,9 +570,8 @@ fn check_non_existing_path() -> anyhow::Result<()> {
     Found 2 diagnostics
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
     WARN No python files found under the given path(s)
-    "
+    "###
     );
 
     Ok(())
@@ -603,7 +587,7 @@ fn concise_diagnostics() -> anyhow::Result<()> {
         "#,
     )?;
 
-    assert_cmd_snapshot!(case.command().arg("--output-format=concise").arg("--warn").arg("unresolved-reference"), @r"
+    assert_cmd_snapshot!(case.command().arg("--output-format=concise").arg("--warn").arg("unresolved-reference"), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -612,8 +596,7 @@ fn concise_diagnostics() -> anyhow::Result<()> {
     Found 2 diagnostics
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     Ok(())
 }
@@ -633,7 +616,7 @@ fn gitlab_diagnostics() -> anyhow::Result<()> {
     let _s = settings.bind_to_scope();
 
     assert_cmd_snapshot!(case.command().arg("--output-format=gitlab").arg("--warn").arg("unresolved-reference")
-        .env("CI_PROJECT_DIR", case.project_dir), @r#"
+        .env("CI_PROJECT_DIR", case.project_dir), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -678,8 +661,7 @@ fn gitlab_diagnostics() -> anyhow::Result<()> {
       }
     ]
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    "#);
+    "###);
 
     Ok(())
 }
@@ -694,7 +676,7 @@ fn github_diagnostics() -> anyhow::Result<()> {
         "#,
     )?;
 
-    assert_cmd_snapshot!(case.command().arg("--output-format=github").arg("--warn").arg("unresolved-reference"), @r"
+    assert_cmd_snapshot!(case.command().arg("--output-format=github").arg("--warn").arg("unresolved-reference"), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -702,8 +684,7 @@ fn github_diagnostics() -> anyhow::Result<()> {
     ::error title=ty (non-subscriptable),file=<temp_dir>/test.py,line=3,col=7,endLine=3,endColumn=8::test.py:3:7: non-subscriptable: Cannot subscript object of type `Literal[4]` with no `__getitem__` method
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     Ok(())
 }
@@ -728,7 +709,7 @@ fn concise_revealed_type() -> anyhow::Result<()> {
         "#,
     )?;
 
-    assert_cmd_snapshot!(case.command().arg("--output-format=concise"), @r#"
+    assert_cmd_snapshot!(case.command().arg("--output-format=concise"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -736,8 +717,7 @@ fn concise_revealed_type() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    "#);
+    "###);
 
     Ok(())
 }
@@ -757,7 +737,7 @@ fn can_handle_large_binop_expressions() -> anyhow::Result<()> {
 
     let case = CliTest::with_file("test.py", &ruff_python_trivia::textwrap::dedent(&content))?;
 
-    assert_cmd_snapshot!(case.command(), @r"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -773,8 +753,7 @@ fn can_handle_large_binop_expressions() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     Ok(())
 }

--- a/crates/ty/tests/cli/python_environment.rs
+++ b/crates/ty/tests/cli/python_environment.rs
@@ -26,7 +26,7 @@ fn config_override_python_version() -> anyhow::Result<()> {
         ),
     ])?;
 
-    assert_cmd_snapshot!(case.command(), @r"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -42,18 +42,16 @@ fn config_override_python_version() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
-    assert_cmd_snapshot!(case.command().arg("--python-version").arg("3.12"), @r"
+    assert_cmd_snapshot!(case.command().arg("--python-version").arg("3.12"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
     All checks passed!
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     Ok(())
 }
@@ -80,7 +78,7 @@ fn config_override_python_platform() -> anyhow::Result<()> {
         ),
     ])?;
 
-    assert_cmd_snapshot!(case.command(), @r#"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -96,10 +94,9 @@ fn config_override_python_platform() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    "#);
+    "###);
 
-    assert_cmd_snapshot!(case.command().arg("--python-platform").arg("all"), @r"
+    assert_cmd_snapshot!(case.command().arg("--python-platform").arg("all"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -115,8 +112,7 @@ fn config_override_python_platform() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     Ok(())
 }
@@ -139,7 +135,7 @@ fn config_file_annotation_showing_where_python_version_set_typing_error() -> any
         ),
     ])?;
 
-    assert_cmd_snapshot!(case.command(), @r#"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -162,10 +158,9 @@ fn config_file_annotation_showing_where_python_version_set_typing_error() -> any
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    "#);
+    "###);
 
-    assert_cmd_snapshot!(case.command().arg("--python-version=3.9"), @r"
+    assert_cmd_snapshot!(case.command().arg("--python-version=3.9"), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -182,8 +177,7 @@ fn config_file_annotation_showing_where_python_version_set_typing_error() -> any
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     Ok(())
 }
@@ -201,7 +195,7 @@ fn src_subdirectory_takes_precedence_over_repo_root() -> anyhow::Result<()> {
     // If `./src` didn't take priority over `.` here, we would report
     // "Module `src.package` has no member `nonexistent_submodule`"
     // instead of "Module `package` has no member `nonexistent_submodule`".
-    assert_cmd_snapshot!(case.command(), @r"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -216,8 +210,7 @@ fn src_subdirectory_takes_precedence_over_repo_root() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     Ok(())
 }
@@ -242,7 +235,7 @@ fn python_version_inferred_from_system_installation() -> anyhow::Result<()> {
         ("test.py", "aiter"),
     ])?;
 
-    assert_cmd_snapshot!(cpython_case.command().arg("--python").arg("pythons/Python3.8/bin/python"), @r"
+    assert_cmd_snapshot!(cpython_case.command().arg("--python").arg("pythons/Python3.8/bin/python"), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -261,8 +254,7 @@ fn python_version_inferred_from_system_installation() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     let pypy_case = CliTest::with_files([
         ("pythons/pypy3.8/bin/python", ""),
@@ -270,7 +262,7 @@ fn python_version_inferred_from_system_installation() -> anyhow::Result<()> {
         ("test.py", "aiter"),
     ])?;
 
-    assert_cmd_snapshot!(pypy_case.command().arg("--python").arg("pythons/pypy3.8/bin/python"), @r"
+    assert_cmd_snapshot!(pypy_case.command().arg("--python").arg("pythons/pypy3.8/bin/python"), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -289,8 +281,7 @@ fn python_version_inferred_from_system_installation() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     let free_threaded_case = CliTest::with_files([
         ("pythons/Python3.13t/bin/python", ""),
@@ -301,7 +292,7 @@ fn python_version_inferred_from_system_installation() -> anyhow::Result<()> {
         ("test.py", "import string.templatelib"),
     ])?;
 
-    assert_cmd_snapshot!(free_threaded_case.command().arg("--python").arg("pythons/Python3.13t/bin/python"), @r"
+    assert_cmd_snapshot!(free_threaded_case.command().arg("--python").arg("pythons/Python3.13t/bin/python"), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -320,8 +311,7 @@ fn python_version_inferred_from_system_installation() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     Ok(())
 }
@@ -356,7 +346,7 @@ import bar",
         "strange-venv-location/bin/python",
     )?;
 
-    assert_cmd_snapshot!(case.command().arg("--python").arg("strange-venv-location/bin/python"), @r"
+    assert_cmd_snapshot!(case.command().arg("--python").arg("strange-venv-location/bin/python"), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -377,8 +367,7 @@ import bar",
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     Ok(())
 }
@@ -406,7 +395,7 @@ fn lib64_site_packages_directory_on_unix() -> anyhow::Result<()> {
         ("test.py", "import foo, bar, baz"),
     ])?;
 
-    assert_cmd_snapshot!(case.command().arg("--python").arg(".venv"), @r"
+    assert_cmd_snapshot!(case.command().arg("--python").arg(".venv"), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -427,8 +416,7 @@ fn lib64_site_packages_directory_on_unix() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     Ok(())
 }
@@ -463,7 +451,7 @@ fn pyvenv_cfg_file_annotation_showing_where_python_version_set() -> anyhow::Resu
         ("test.py", "aiter"),
     ])?;
 
-    assert_cmd_snapshot!(case.command(), @r"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -487,8 +475,7 @@ fn pyvenv_cfg_file_annotation_showing_where_python_version_set() -> anyhow::Resu
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     Ok(())
 }
@@ -523,7 +510,7 @@ fn pyvenv_cfg_file_annotation_no_trailing_newline() -> anyhow::Result<()> {
         ("test.py", "aiter"),
     ])?;
 
-    assert_cmd_snapshot!(case.command(), @r"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -546,8 +533,7 @@ fn pyvenv_cfg_file_annotation_no_trailing_newline() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     Ok(())
 }
@@ -574,7 +560,7 @@ fn config_file_annotation_showing_where_python_version_set_syntax_error() -> any
         ),
     ])?;
 
-    assert_cmd_snapshot!(case.command(), @r#"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -597,10 +583,9 @@ fn config_file_annotation_showing_where_python_version_set_syntax_error() -> any
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    "#);
+    "###);
 
-    assert_cmd_snapshot!(case.command().arg("--python-version=3.9"), @r"
+    assert_cmd_snapshot!(case.command().arg("--python-version=3.9"), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -617,8 +602,7 @@ fn config_file_annotation_showing_where_python_version_set_syntax_error() -> any
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     Ok(())
 }
@@ -648,51 +632,47 @@ fn python_cli_argument_virtual_environment() -> anyhow::Result<()> {
     ])?;
 
     // Passing a path to the installation works
-    assert_cmd_snapshot!(case.command().arg("--python").arg("my-venv"), @r"
+    assert_cmd_snapshot!(case.command().arg("--python").arg("my-venv"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
     All checks passed!
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     // And so does passing a path to the executable inside the installation
-    assert_cmd_snapshot!(case.command().arg("--python").arg(path_to_executable), @r"
+    assert_cmd_snapshot!(case.command().arg("--python").arg(path_to_executable), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
     All checks passed!
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     // But random other paths inside the installation are rejected
-    assert_cmd_snapshot!(case.command().arg("--python").arg(other_venv_path), @r"
+    assert_cmd_snapshot!(case.command().arg("--python").arg(other_venv_path), @r###"
     success: false
     exit_code: 2
     ----- stdout -----
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
     ty failed
       Cause: Invalid `--python` argument `<temp_dir>/my-venv/foo/some_other_file.txt`: does not point to a Python executable or a directory on disk
-    ");
+    "###);
 
     // And so are paths that do not exist on disk
-    assert_cmd_snapshot!(case.command().arg("--python").arg("not-a-directory-or-executable"), @r"
+    assert_cmd_snapshot!(case.command().arg("--python").arg("not-a-directory-or-executable"), @r###"
     success: false
     exit_code: 2
     ----- stdout -----
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
     ty failed
       Cause: Invalid `--python` argument `<temp_dir>/not-a-directory-or-executable`: does not point to a Python executable or a directory on disk
       Cause: No such file or directory (os error 2)
-    ");
+    "###);
 
     Ok(())
 }
@@ -719,26 +699,24 @@ fn python_cli_argument_system_installation() -> anyhow::Result<()> {
     ])?;
 
     // Passing a path to the installation works
-    assert_cmd_snapshot!(case.command().arg("--python").arg("Python3.11"), @r"
+    assert_cmd_snapshot!(case.command().arg("--python").arg("Python3.11"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
     All checks passed!
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     // And so does passing a path to the executable inside the installation
-    assert_cmd_snapshot!(case.command().arg("--python").arg(path_to_executable), @r"
+    assert_cmd_snapshot!(case.command().arg("--python").arg(path_to_executable), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
     All checks passed!
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     Ok(())
 }
@@ -764,13 +742,12 @@ fn config_file_broken_python_setting() -> anyhow::Result<()> {
         ("test.py", ""),
     ])?;
 
-    assert_cmd_snapshot!(case.command(), @r#"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: false
     exit_code: 2
     ----- stdout -----
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
     ty failed
       Cause: Invalid `environment.python` setting
 
@@ -783,7 +760,7 @@ fn config_file_broken_python_setting() -> anyhow::Result<()> {
        |
 
       Cause: No such file or directory (os error 2)
-    "#);
+    "###);
 
     Ok(())
 }
@@ -802,13 +779,12 @@ fn config_file_python_setting_directory_with_no_site_packages() -> anyhow::Resul
         ("test.py", ""),
     ])?;
 
-    assert_cmd_snapshot!(case.command(), @r#"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: false
     exit_code: 2
     ----- stdout -----
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
     ty failed
       Cause: Failed to discover the site-packages directory
       Cause: Invalid `environment.python` setting
@@ -820,7 +796,7 @@ fn config_file_python_setting_directory_with_no_site_packages() -> anyhow::Resul
     3 | python = "directory-but-no-site-packages"
       |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Could not find a `site-packages` directory for this Python installation/executable
       |
-    "#);
+    "###);
 
     Ok(())
 }
@@ -841,13 +817,12 @@ fn unix_system_installation_with_no_lib_directory() -> anyhow::Result<()> {
         ("test.py", ""),
     ])?;
 
-    assert_cmd_snapshot!(case.command(), @r#"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: false
     exit_code: 2
     ----- stdout -----
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
     ty failed
       Cause: Failed to discover the site-packages directory
       Cause: Failed to iterate over the contents of the `lib`/`lib64` directories of the Python installation
@@ -859,7 +834,7 @@ fn unix_system_installation_with_no_lib_directory() -> anyhow::Result<()> {
     3 | python = "directory-but-no-site-packages"
       |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       |
-    "#);
+    "###);
 
     Ok(())
 }
@@ -888,7 +863,7 @@ fn defaults_to_a_new_python_version() -> anyhow::Result<()> {
         ),
     ])?;
 
-    assert_cmd_snapshot!(case.command(), @r"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -905,8 +880,7 @@ fn defaults_to_a_new_python_version() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     // Use default (which should be latest supported)
     let case = CliTest::with_files([
@@ -927,15 +901,14 @@ fn defaults_to_a_new_python_version() -> anyhow::Result<()> {
         ),
     ])?;
 
-    assert_cmd_snapshot!(case.command(), @r"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
     All checks passed!
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     Ok(())
 }
@@ -1089,7 +1062,7 @@ home = ./
 
     // Run with nothing set, should find the working venv
     assert_cmd_snapshot!(case.command()
-        .current_dir(case.root().join("project")), @r"
+        .current_dir(case.root().join("project")), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -1107,13 +1080,12 @@ home = ./
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     // Run with VIRTUAL_ENV set, should find the active venv
     assert_cmd_snapshot!(case.command()
         .current_dir(case.root().join("project"))
-        .env("VIRTUAL_ENV", case.root().join("myvenv")), @r"
+        .env("VIRTUAL_ENV", case.root().join("myvenv")), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -1130,13 +1102,12 @@ home = ./
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     // run with CONDA_PREFIX set, should find the child conda
     assert_cmd_snapshot!(case.command()
         .current_dir(case.root().join("project"))
-        .env("CONDA_PREFIX", case.root().join("conda/envs/conda-env")), @r"
+        .env("CONDA_PREFIX", case.root().join("conda/envs/conda-env")), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -1154,14 +1125,13 @@ home = ./
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     // run with CONDA_PREFIX and CONDA_DEFAULT_ENV set (unequal), should find working venv
     assert_cmd_snapshot!(case.command()
         .current_dir(case.root().join("project"))
         .env("CONDA_PREFIX", case.root().join("conda"))
-        .env("CONDA_DEFAULT_ENV", "base"), @r"
+        .env("CONDA_DEFAULT_ENV", "base"), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -1179,8 +1149,7 @@ home = ./
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     // run with CONDA_PREFIX and CONDA_DEFAULT_ENV (unequal) and VIRTUAL_ENV set,
     // should find child active venv
@@ -1188,7 +1157,7 @@ home = ./
         .current_dir(case.root().join("project"))
         .env("CONDA_PREFIX", case.root().join("conda"))
         .env("CONDA_DEFAULT_ENV", "base")
-        .env("VIRTUAL_ENV", case.root().join("myvenv")), @r"
+        .env("VIRTUAL_ENV", case.root().join("myvenv")), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -1205,14 +1174,13 @@ home = ./
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     // run with CONDA_PREFIX and CONDA_DEFAULT_ENV (equal!) set, should find ChildConda
     assert_cmd_snapshot!(case.command()
         .current_dir(case.root().join("project"))
         .env("CONDA_PREFIX", case.root().join("conda/envs/conda-env"))
-        .env("CONDA_DEFAULT_ENV", "conda-env"), @r"
+        .env("CONDA_DEFAULT_ENV", "conda-env"), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -1230,14 +1198,13 @@ home = ./
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     // run with _CONDA_ROOT and CONDA_PREFIX (unequal!) set, should find ChildConda
     assert_cmd_snapshot!(case.command()
         .current_dir(case.root().join("project"))
         .env("CONDA_PREFIX", case.root().join("conda/envs/conda-env"))
-        .env("_CONDA_ROOT", "conda"), @r"
+        .env("_CONDA_ROOT", "conda"), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -1255,14 +1222,13 @@ home = ./
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     // run with _CONDA_ROOT and CONDA_PREFIX (equal!) set, should find BaseConda
     assert_cmd_snapshot!(case.command()
         .current_dir(case.root().join("project"))
         .env("CONDA_PREFIX", case.root().join("conda"))
-        .env("_CONDA_ROOT", "conda"), @r"
+        .env("_CONDA_ROOT", "conda"), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -1279,8 +1245,7 @@ home = ./
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     Ok(())
 }
@@ -1353,7 +1318,7 @@ home = ./
 
     // Run with nothing set, should fail to find anything
     assert_cmd_snapshot!(case.command()
-        .current_dir(case.root().join("project")), @r"
+        .current_dir(case.root().join("project")), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -1418,13 +1383,12 @@ home = ./
     Found 4 diagnostics
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     // Run with VIRTUAL_ENV set, should find the active venv
     assert_cmd_snapshot!(case.command()
         .current_dir(case.root().join("project"))
-        .env("VIRTUAL_ENV", case.root().join("myvenv")), @r"
+        .env("VIRTUAL_ENV", case.root().join("myvenv")), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -1441,13 +1405,12 @@ home = ./
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     // run with CONDA_PREFIX set, should find the child conda
     assert_cmd_snapshot!(case.command()
         .current_dir(case.root().join("project"))
-        .env("CONDA_PREFIX", case.root().join("conda/envs/conda-env")), @r"
+        .env("CONDA_PREFIX", case.root().join("conda/envs/conda-env")), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -1465,14 +1428,13 @@ home = ./
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     // run with CONDA_PREFIX and CONDA_DEFAULT_ENV set (unequal), should find base conda
     assert_cmd_snapshot!(case.command()
         .current_dir(case.root().join("project"))
         .env("CONDA_PREFIX", case.root().join("conda"))
-        .env("CONDA_DEFAULT_ENV", "base"), @r"
+        .env("CONDA_DEFAULT_ENV", "base"), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -1489,8 +1451,7 @@ home = ./
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     // run with CONDA_PREFIX and CONDA_DEFAULT_ENV (unequal) and VIRTUAL_ENV set,
     // should find child active venv
@@ -1498,7 +1459,7 @@ home = ./
         .current_dir(case.root().join("project"))
         .env("CONDA_PREFIX", case.root().join("conda"))
         .env("CONDA_DEFAULT_ENV", "base")
-        .env("VIRTUAL_ENV", case.root().join("myvenv")), @r"
+        .env("VIRTUAL_ENV", case.root().join("myvenv")), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -1515,14 +1476,13 @@ home = ./
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     // run with CONDA_PREFIX and CONDA_DEFAULT_ENV (unequal!) set, should find base conda
     assert_cmd_snapshot!(case.command()
         .current_dir(case.root().join("project"))
         .env("CONDA_PREFIX", case.root().join("conda"))
-        .env("CONDA_DEFAULT_ENV", "base"), @r"
+        .env("CONDA_DEFAULT_ENV", "base"), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -1539,14 +1499,13 @@ home = ./
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     // run with _CONDA_ROOT and CONDA_PREFIX (unequal!) set, should find ChildConda
     assert_cmd_snapshot!(case.command()
         .current_dir(case.root().join("project"))
         .env("CONDA_PREFIX", case.root().join("conda/envs/conda-env"))
-        .env("_CONDA_ROOT", "conda"), @r"
+        .env("_CONDA_ROOT", "conda"), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -1564,14 +1523,13 @@ home = ./
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     // run with _CONDA_ROOT and CONDA_PREFIX (equal!) set, should find BaseConda
     assert_cmd_snapshot!(case.command()
         .current_dir(case.root().join("project"))
         .env("CONDA_PREFIX", case.root().join("conda"))
-        .env("_CONDA_ROOT", "conda"), @r"
+        .env("_CONDA_ROOT", "conda"), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -1588,8 +1546,7 @@ home = ./
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     Ok(())
 }
@@ -1607,7 +1564,7 @@ fn src_root_deprecation_warning() -> anyhow::Result<()> {
         ("src/test.py", ""),
     ])?;
 
-    assert_cmd_snapshot!(case.command(), @r#"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -1622,8 +1579,7 @@ fn src_root_deprecation_warning() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    "#);
+    "###);
 
     Ok(())
 }
@@ -1644,7 +1600,7 @@ fn src_root_deprecation_warning_with_environment_root() -> anyhow::Result<()> {
         ("app/test.py", ""),
     ])?;
 
-    assert_cmd_snapshot!(case.command(), @r#"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -1662,8 +1618,7 @@ fn src_root_deprecation_warning_with_environment_root() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    "#);
+    "###);
 
     Ok(())
 }
@@ -1690,7 +1645,7 @@ fn environment_root_takes_precedence_over_src_root() -> anyhow::Result<()> {
 
     // The test should pass because environment.root points to ./app where my_module.py exists
     // If src.root took precedence, it would fail because my_module.py doesn't exist in ./src
-    assert_cmd_snapshot!(case.command(), @r#"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -1708,8 +1663,7 @@ fn environment_root_takes_precedence_over_src_root() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    "#);
+    "###);
 
     Ok(())
 }
@@ -1730,15 +1684,14 @@ fn default_root_src_layout() -> anyhow::Result<()> {
         ),
     ])?;
 
-    assert_cmd_snapshot!(case.command(), @r"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
     All checks passed!
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     Ok(())
 }
@@ -1766,15 +1719,14 @@ fn default_root_project_name_folder() -> anyhow::Result<()> {
         ),
     ])?;
 
-    assert_cmd_snapshot!(case.command(), @r"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
     All checks passed!
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     Ok(())
 }
@@ -1795,15 +1747,14 @@ fn default_root_flat_layout() -> anyhow::Result<()> {
         ),
     ])?;
 
-    assert_cmd_snapshot!(case.command(), @r"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
     All checks passed!
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     Ok(())
 }
@@ -1824,15 +1775,14 @@ fn default_root_tests_folder() -> anyhow::Result<()> {
         ),
     ])?;
 
-    assert_cmd_snapshot!(case.command(), @r"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
     All checks passed!
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     Ok(())
 }
@@ -1855,7 +1805,7 @@ fn default_root_tests_package() -> anyhow::Result<()> {
         ),
     ])?;
 
-    assert_cmd_snapshot!(case.command(), @r#"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -1878,8 +1828,7 @@ fn default_root_tests_package() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    "#);
+    "###);
 
     Ok(())
 }
@@ -1900,15 +1849,14 @@ fn default_root_python_folder() -> anyhow::Result<()> {
         ),
     ])?;
 
-    assert_cmd_snapshot!(case.command(), @r"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
     All checks passed!
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     Ok(())
 }
@@ -1931,7 +1879,7 @@ fn default_root_python_package() -> anyhow::Result<()> {
         ),
     ])?;
 
-    assert_cmd_snapshot!(case.command(), @r#"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -1954,8 +1902,7 @@ fn default_root_python_package() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    "#);
+    "###);
 
     Ok(())
 }
@@ -1978,7 +1925,7 @@ fn default_root_python_package_pyi() -> anyhow::Result<()> {
         ),
     ])?;
 
-    assert_cmd_snapshot!(case.command(), @r#"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -2001,8 +1948,7 @@ fn default_root_python_package_pyi() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    "#);
+    "###);
 
     Ok(())
 }
@@ -2021,7 +1967,7 @@ fn pythonpath_is_respected() -> anyhow::Result<()> {
     ])?;
 
     assert_cmd_snapshot!(case.command(),
-        @r#"
+        @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -2042,20 +1988,18 @@ fn pythonpath_is_respected() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    "#);
+    "###);
 
     assert_cmd_snapshot!(case.command()
         .env("PYTHONPATH", case.root().join("baz-dir")),
-        @r#"
+        @r###"
     success: true
     exit_code: 0
     ----- stdout -----
     All checks passed!
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    "#);
+    "###);
 
     Ok(())
 }
@@ -2078,7 +2022,7 @@ fn pythonpath_multiple_dirs_is_respected() -> anyhow::Result<()> {
     ])?;
 
     assert_cmd_snapshot!(case.command(),
-        @r#"
+        @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -2115,22 +2059,20 @@ fn pythonpath_multiple_dirs_is_respected() -> anyhow::Result<()> {
     Found 2 diagnostics
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    "#);
+    "###);
 
     let pythonpath =
         std::env::join_paths([case.root().join("baz-dir"), case.root().join("foo-dir")])?;
     assert_cmd_snapshot!(case.command()
         .env("PYTHONPATH", pythonpath),
-        @r#"
+        @r###"
     success: true
     exit_code: 0
     ----- stdout -----
     All checks passed!
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    "#);
+    "###);
 
     Ok(())
 }

--- a/crates/ty/tests/cli/rule_selection.rs
+++ b/crates/ty/tests/cli/rule_selection.rs
@@ -35,7 +35,6 @@ fn configuration_rule_severity() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
     "###);
 
     case.write_file(
@@ -47,7 +46,7 @@ fn configuration_rule_severity() -> anyhow::Result<()> {
     "#,
     )?;
 
-    assert_cmd_snapshot!(case.command(), @r"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -64,8 +63,7 @@ fn configuration_rule_severity() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     Ok(())
 }
@@ -89,7 +87,7 @@ fn cli_rule_severity() -> anyhow::Result<()> {
 
     // Assert that there's an `unresolved-reference` diagnostic (error)
     // and an unresolved-import (error) diagnostic by default.
-    assert_cmd_snapshot!(case.command(), @r"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -120,8 +118,7 @@ fn cli_rule_severity() -> anyhow::Result<()> {
     Found 2 diagnostics
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     assert_cmd_snapshot!(
         case
@@ -132,7 +129,7 @@ fn cli_rule_severity() -> anyhow::Result<()> {
             .arg("division-by-zero")
             .arg("--warn")
             .arg("unresolved-import"),
-        @r"
+        @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -165,8 +162,7 @@ fn cli_rule_severity() -> anyhow::Result<()> {
     Found 2 diagnostics
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    "
+    "###
     );
 
     Ok(())
@@ -206,7 +202,6 @@ fn cli_rule_severity_precedence() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
     "###);
 
     assert_cmd_snapshot!(
@@ -218,7 +213,7 @@ fn cli_rule_severity_precedence() -> anyhow::Result<()> {
             .arg("division-by-zero")
             .arg("--ignore")
             .arg("unresolved-reference"),
-        @r"
+        @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -235,8 +230,7 @@ fn cli_rule_severity_precedence() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    "
+    "###
     );
 
     Ok(())
@@ -256,7 +250,7 @@ fn configuration_unknown_rules() -> anyhow::Result<()> {
         ("test.py", "print(10)"),
     ])?;
 
-    assert_cmd_snapshot!(case.command(), @r#"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -271,8 +265,7 @@ fn configuration_unknown_rules() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    "#);
+    "###);
 
     Ok(())
 }
@@ -282,7 +275,7 @@ fn configuration_unknown_rules() -> anyhow::Result<()> {
 fn cli_unknown_rules() -> anyhow::Result<()> {
     let case = CliTest::with_file("test.py", "print(10)")?;
 
-    assert_cmd_snapshot!(case.command().arg("--ignore").arg("division-by-zer"), @r"
+    assert_cmd_snapshot!(case.command().arg("--ignore").arg("division-by-zer"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -291,8 +284,7 @@ fn cli_unknown_rules() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     Ok(())
 }
@@ -371,7 +363,6 @@ fn overrides_basic() -> anyhow::Result<()> {
     Found 3 diagnostics
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
     "###);
 
     Ok(())
@@ -414,7 +405,7 @@ fn overrides_precedence() -> anyhow::Result<()> {
         ),
     ])?;
 
-    assert_cmd_snapshot!(case.command(), @r"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -429,8 +420,7 @@ fn overrides_precedence() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     Ok(())
 }
@@ -466,7 +456,7 @@ fn overrides_exclude() -> anyhow::Result<()> {
         ),
     ])?;
 
-    assert_cmd_snapshot!(case.command(), @r"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -489,8 +479,7 @@ fn overrides_exclude() -> anyhow::Result<()> {
     Found 2 diagnostics
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    ");
+    "###);
 
     Ok(())
 }
@@ -530,7 +519,7 @@ fn overrides_inherit_global() -> anyhow::Result<()> {
         ),
     ])?;
 
-    assert_cmd_snapshot!(case.command(), @r#"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -564,8 +553,7 @@ fn overrides_inherit_global() -> anyhow::Result<()> {
     Found 3 diagnostics
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    "#);
+    "###);
 
     Ok(())
 }
@@ -594,13 +582,12 @@ fn overrides_invalid_include_glob() -> anyhow::Result<()> {
         ),
     ])?;
 
-    assert_cmd_snapshot!(case.command(), @r#"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: false
     exit_code: 2
     ----- stdout -----
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
     ty failed
       Cause: error[invalid-glob]: Invalid include pattern
      --> pyproject.toml:6:12
@@ -611,7 +598,7 @@ fn overrides_invalid_include_glob() -> anyhow::Result<()> {
     7 | [tool.ty.overrides.rules]
     8 | division-by-zero = "warn"
       |
-    "#);
+    "###);
 
     Ok(())
 }
@@ -641,13 +628,12 @@ fn overrides_invalid_exclude_glob() -> anyhow::Result<()> {
         ),
     ])?;
 
-    assert_cmd_snapshot!(case.command(), @r#"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: false
     exit_code: 2
     ----- stdout -----
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
     ty failed
       Cause: error[invalid-glob]: Invalid exclude pattern
      --> pyproject.toml:7:12
@@ -659,7 +645,7 @@ fn overrides_invalid_exclude_glob() -> anyhow::Result<()> {
     8 | [tool.ty.overrides.rules]
     9 | division-by-zero = "warn"
       |
-    "#);
+    "###);
 
     Ok(())
 }
@@ -688,7 +674,7 @@ fn overrides_missing_include_exclude() -> anyhow::Result<()> {
         ),
     ])?;
 
-    assert_cmd_snapshot!(case.command(), @r#"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -717,8 +703,7 @@ fn overrides_missing_include_exclude() -> anyhow::Result<()> {
     Found 2 diagnostics
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    "#);
+    "###);
 
     Ok(())
 }
@@ -747,7 +732,7 @@ fn overrides_empty_include() -> anyhow::Result<()> {
         ),
     ])?;
 
-    assert_cmd_snapshot!(case.command(), @r#"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -773,8 +758,7 @@ fn overrides_empty_include() -> anyhow::Result<()> {
     Found 2 diagnostics
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    "#);
+    "###);
 
     Ok(())
 }
@@ -802,7 +786,7 @@ fn overrides_no_actual_overrides() -> anyhow::Result<()> {
         ),
     ])?;
 
-    assert_cmd_snapshot!(case.command(), @r#"
+    assert_cmd_snapshot!(case.command(), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -831,8 +815,7 @@ fn overrides_no_actual_overrides() -> anyhow::Result<()> {
     Found 2 diagnostics
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
-    "#);
+    "###);
 
     Ok(())
 }
@@ -901,7 +884,6 @@ fn overrides_unknown_rules() -> anyhow::Result<()> {
     Found 3 diagnostics
 
     ----- stderr -----
-    WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
     "###);
 
     Ok(())


### PR DESCRIPTION
## Summary

This PR removes the "ty is pre-release software..." warning from the CLI. 
I think it's dramatically underselling where ty is today (compared to when we released the alpha earlier this year).
While there are still a few crashes and some missing language features, I think that's
covered sufficiently by the fact that ty is released as an alpha version.
