### PR TITLE
Enable lto=fat

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -308,7 +308,7 @@ opt-level = 1
 # But compile times with `lto = fat` are completely untenable.
 #
 # This setup does risk that we are measuring something in benchmarks
-# that we are shipping, but in order to make those two the same, we'd
+# that we aren't shipping, but in order to make those two the same, we'd
 # either need to make compile times way worse for development, or take
 # a hit to binary size and a slight hit to runtime performance in our
 # release builds.


### PR DESCRIPTION
## Summary

This PR switches from thin to fat LTO optimization.

The main motivation is that using lto=fat fixes the binary size increase that we've seen after switching to inventory for [ingredient registration](https://github.com/astral-sh/ruff/issues/20845#issuecomment-3401604238). The regression is mainly due to symbols not being removed when using lto=thin, but they're successfully removed when using lto=fat (from 19MB to 17MB).

Using lto=fat also results in a significant performance improvement, which I think is worth it on its own.

Unfortunately, using lto=flat does have the downside that release builds take significantly longer. One of the main motivations for using `lto=thin` when we switched from `fat` to `thin` in https://github.com/astral-sh/ruff/pull/9031 was to improve performance. To mitigate this, I changed the `--profiling` profile to only use `lto=thin`, similar to what we do in uv (where we disable lto entirely). This PR is also likely to make the mypy primer and benchmark jobs slower (or when running mypy primer locally), because of a significant increase in compile time.

This setup now mirrors uv's (with the exception that `profiling` use `lto=fat`).

I do feel a bit bad about making this change while @BurntSushi is out, because I know he feels the most vocal about this.

Clean build timing:

* fat: 2m 02s
* thin: 1m 00s

Fixes https://github.com/astral-sh/ruff/issues/20845

Relevant discussions:

* https://github.com/astral-sh/uv/pull/5904
* https://github.com/astral-sh/ruff/pull/9031
* https://github.com/astral-sh/uv/pull/5955