### PR TITLE
[ty] Add (unused) `inferable` parameter to type property methods

### DIFF
--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -26,7 +26,9 @@ use crate::types::enums::is_enum_class;
 use crate::types::function::{
     DataclassTransformerParams, FunctionDecorators, FunctionType, KnownFunction, OverloadLiteral,
 };
-use crate::types::generics::{Specialization, SpecializationBuilder, SpecializationError};
+use crate::types::generics::{
+    InferableTypeVars, Specialization, SpecializationBuilder, SpecializationError,
+};
 use crate::types::signatures::{Parameter, ParameterForm, ParameterKind, Parameters};
 use crate::types::tuple::{TupleLength, TupleType};
 use crate::types::{
@@ -597,7 +599,8 @@ impl<'db> Bindings<'db> {
                     Type::FunctionLiteral(function_type) => match function_type.known(db) {
                         Some(KnownFunction::IsEquivalentTo) => {
                             if let [Some(ty_a), Some(ty_b)] = overload.parameter_types() {
-                                let constraints = ty_a.when_equivalent_to(db, *ty_b);
+                                let constraints =
+                                    ty_a.when_equivalent_to(db, *ty_b, InferableTypeVars::None);
                                 let tracked = TrackedConstraintSet::new(db, constraints);
                                 overload.set_return_type(Type::KnownInstance(
                                     KnownInstanceType::ConstraintSet(tracked),
@@ -607,7 +610,8 @@ impl<'db> Bindings<'db> {
 
                         Some(KnownFunction::IsSubtypeOf) => {
                             if let [Some(ty_a), Some(ty_b)] = overload.parameter_types() {
-                                let constraints = ty_a.when_subtype_of(db, *ty_b);
+                                let constraints =
+                                    ty_a.when_subtype_of(db, *ty_b, InferableTypeVars::None);
                                 let tracked = TrackedConstraintSet::new(db, constraints);
                                 overload.set_return_type(Type::KnownInstance(
                                     KnownInstanceType::ConstraintSet(tracked),
@@ -617,7 +621,8 @@ impl<'db> Bindings<'db> {
 
                         Some(KnownFunction::IsAssignableTo) => {
                             if let [Some(ty_a), Some(ty_b)] = overload.parameter_types() {
-                                let constraints = ty_a.when_assignable_to(db, *ty_b);
+                                let constraints =
+                                    ty_a.when_assignable_to(db, *ty_b, InferableTypeVars::None);
                                 let tracked = TrackedConstraintSet::new(db, constraints);
                                 overload.set_return_type(Type::KnownInstance(
                                     KnownInstanceType::ConstraintSet(tracked),
@@ -627,7 +632,8 @@ impl<'db> Bindings<'db> {
 
                         Some(KnownFunction::IsDisjointFrom) => {
                             if let [Some(ty_a), Some(ty_b)] = overload.parameter_types() {
-                                let constraints = ty_a.when_disjoint_from(db, *ty_b);
+                                let constraints =
+                                    ty_a.when_disjoint_from(db, *ty_b, InferableTypeVars::None);
                                 let tracked = TrackedConstraintSet::new(db, constraints);
                                 overload.set_return_type(Type::KnownInstance(
                                     KnownInstanceType::ConstraintSet(tracked),
@@ -1407,7 +1413,10 @@ impl<'db> CallableBinding<'db> {
                     let parameter_type = overload.signature.parameters()[*parameter_index]
                         .annotated_type()
                         .unwrap_or(Type::unknown());
-                    if argument_type.is_assignable_to(db, parameter_type) {
+                    if argument_type
+                        .when_assignable_to(db, parameter_type, overload.inferable_typevars)
+                        .is_always_satisfied()
+                    {
                         is_argument_assignable_to_any_overload = true;
                         break 'overload;
                     }
@@ -1633,7 +1642,14 @@ impl<'db> CallableBinding<'db> {
                         .unwrap_or(Type::unknown());
                     let first_parameter_type = &mut first_parameter_types[parameter_index];
                     if let Some(first_parameter_type) = first_parameter_type {
-                        if !first_parameter_type.is_equivalent_to(db, current_parameter_type) {
+                        if !first_parameter_type
+                            .when_equivalent_to(
+                                db,
+                                current_parameter_type,
+                                overload.inferable_typevars,
+                            )
+                            .is_always_satisfied()
+                        {
                             participating_parameter_indexes.insert(parameter_index);
                         }
                     } else {
@@ -1750,7 +1766,12 @@ impl<'db> CallableBinding<'db> {
                 matching_overloads.all(|(_, overload)| {
                     overload
                         .return_type()
-                        .is_equivalent_to(db, first_overload_return_type)
+                        .when_equivalent_to(
+                            db,
+                            first_overload_return_type,
+                            overload.inferable_typevars,
+                        )
+                        .is_always_satisfied()
                 })
             } else {
                 // No matching overload
@@ -2461,6 +2482,7 @@ struct ArgumentTypeChecker<'a, 'db> {
     call_expression_tcx: &'a TypeContext<'db>,
     errors: &'a mut Vec<BindingError<'db>>,
 
+    inferable_typevars: InferableTypeVars<'db, 'db>,
     specialization: Option<Specialization<'db>>,
 }
 
@@ -2482,6 +2504,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             parameter_tys,
             call_expression_tcx,
             errors,
+            inferable_typevars: InferableTypeVars::None,
             specialization: None,
         }
     }
@@ -2514,11 +2537,12 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
     }
 
     fn infer_specialization(&mut self) {
-        if self.signature.generic_context.is_none() {
+        let Some(generic_context) = self.signature.generic_context else {
             return;
-        }
+        };
 
-        let mut builder = SpecializationBuilder::new(self.db);
+        // TODO: Use the list of inferable typevars from the generic context of the callable.
+        let mut builder = SpecializationBuilder::new(self.db, self.inferable_typevars);
 
         // Note that we infer the annotated type _before_ the arguments if this call is part of
         // an annotated assignment, to closer match the order of any unions written in the type
@@ -2563,10 +2587,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             }
         }
 
-        self.specialization = self
-            .signature
-            .generic_context
-            .map(|gc| builder.build(gc, *self.call_expression_tcx));
+        self.specialization = Some(builder.build(generic_context, *self.call_expression_tcx));
     }
 
     fn check_argument_type(
@@ -2590,7 +2611,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             // constraint set that we get from this assignability check, instead of inferring and
             // building them in an earlier separate step.
             if argument_type
-                .when_assignable_to(self.db, expected_ty)
+                .when_assignable_to(self.db, expected_ty, self.inferable_typevars)
                 .is_never_satisfied()
             {
                 let positional = matches!(argument, Argument::Positional | Argument::Synthetic)
@@ -2719,7 +2740,14 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                 return;
             };
 
-            if !key_type.is_assignable_to(self.db, KnownClass::Str.to_instance(self.db)) {
+            if !key_type
+                .when_assignable_to(
+                    self.db,
+                    KnownClass::Str.to_instance(self.db),
+                    self.inferable_typevars,
+                )
+                .is_always_satisfied()
+            {
                 self.errors.push(BindingError::InvalidKeyType {
                     argument_index: adjusted_argument_index,
                     provided_ty: key_type,
@@ -2754,8 +2782,8 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         }
     }
 
-    fn finish(self) -> Option<Specialization<'db>> {
-        self.specialization
+    fn finish(self) -> (InferableTypeVars<'db, 'db>, Option<Specialization<'db>>) {
+        (self.inferable_typevars, self.specialization)
     }
 }
 
@@ -2819,6 +2847,9 @@ pub(crate) struct Binding<'db> {
     /// Return type of the call.
     return_ty: Type<'db>,
 
+    /// The inferable typevars in this signature.
+    inferable_typevars: InferableTypeVars<'db, 'db>,
+
     /// The specialization that was inferred from the argument types, if the callable is generic.
     specialization: Option<Specialization<'db>>,
 
@@ -2845,6 +2876,7 @@ impl<'db> Binding<'db> {
             callable_type: signature_type,
             signature_type,
             return_ty: Type::unknown(),
+            inferable_typevars: InferableTypeVars::None,
             specialization: None,
             argument_matches: Box::from([]),
             variadic_argument_matched_to_variadic_parameter: false,
@@ -2916,7 +2948,7 @@ impl<'db> Binding<'db> {
         checker.infer_specialization();
 
         checker.check_argument_types();
-        self.specialization = checker.finish();
+        (self.inferable_typevars, self.specialization) = checker.finish();
         if let Some(specialization) = self.specialization {
             self.return_ty = self.return_ty.apply_specialization(db, specialization);
         }
@@ -3010,6 +3042,7 @@ impl<'db> Binding<'db> {
     fn snapshot(&self) -> BindingSnapshot<'db> {
         BindingSnapshot {
             return_ty: self.return_ty,
+            inferable_typevars: self.inferable_typevars,
             specialization: self.specialization,
             argument_matches: self.argument_matches.clone(),
             parameter_tys: self.parameter_tys.clone(),
@@ -3020,6 +3053,7 @@ impl<'db> Binding<'db> {
     fn restore(&mut self, snapshot: BindingSnapshot<'db>) {
         let BindingSnapshot {
             return_ty,
+            inferable_typevars,
             specialization,
             argument_matches,
             parameter_tys,
@@ -3027,6 +3061,7 @@ impl<'db> Binding<'db> {
         } = snapshot;
 
         self.return_ty = return_ty;
+        self.inferable_typevars = inferable_typevars;
         self.specialization = specialization;
         self.argument_matches = argument_matches;
         self.parameter_tys = parameter_tys;
@@ -3046,6 +3081,7 @@ impl<'db> Binding<'db> {
     /// Resets the state of this binding to its initial state.
     fn reset(&mut self) {
         self.return_ty = Type::unknown();
+        self.inferable_typevars = InferableTypeVars::None;
         self.specialization = None;
         self.argument_matches = Box::from([]);
         self.parameter_tys = Box::from([]);
@@ -3056,6 +3092,7 @@ impl<'db> Binding<'db> {
 #[derive(Clone, Debug)]
 struct BindingSnapshot<'db> {
     return_ty: Type<'db>,
+    inferable_typevars: InferableTypeVars<'db, 'db>,
     specialization: Option<Specialization<'db>>,
     argument_matches: Box<[MatchedArgument<'db>]>,
     parameter_tys: Box<[Option<Type<'db>>]>,
@@ -3095,6 +3132,7 @@ impl<'db> CallableBindingSnapshot<'db> {
 
                 // ... and update the snapshot with the current state of the binding.
                 snapshot.return_ty = binding.return_ty;
+                snapshot.inferable_typevars = binding.inferable_typevars;
                 snapshot.specialization = binding.specialization;
                 snapshot
                     .argument_matches

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -1,6 +1,7 @@
 use crate::place::PlaceAndQualifiers;
 use crate::semantic_index::definition::Definition;
 use crate::types::constraints::ConstraintSet;
+use crate::types::generics::InferableTypeVars;
 use crate::types::variance::VarianceInferable;
 use crate::types::{
     ApplyTypeMappingVisitor, BoundTypeVarInstance, ClassType, DynamicType,
@@ -135,6 +136,7 @@ impl<'db> SubclassOfType<'db> {
         self,
         db: &'db dyn Db,
         other: SubclassOfType<'db>,
+        inferable: InferableTypeVars<'_, 'db>,
         relation: TypeRelation,
         relation_visitor: &HasRelationToVisitor<'db>,
         disjointness_visitor: &IsDisjointVisitor<'db>,
@@ -157,6 +159,7 @@ impl<'db> SubclassOfType<'db> {
                 .has_relation_to_impl(
                     db,
                     other_class,
+                    inferable,
                     relation,
                     relation_visitor,
                     disjointness_visitor,
@@ -171,6 +174,7 @@ impl<'db> SubclassOfType<'db> {
         self,
         db: &'db dyn Db,
         other: Self,
+        _inferable: InferableTypeVars<'_, 'db>,
         _visitor: &IsDisjointVisitor<'db>,
     ) -> ConstraintSet<'db> {
         match (self.subclass_of, other.subclass_of) {

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -24,6 +24,7 @@ use itertools::{Either, EitherOrBoth, Itertools};
 use crate::semantic_index::definition::Definition;
 use crate::types::class::{ClassType, KnownClass};
 use crate::types::constraints::{ConstraintSet, IteratorConstraintsExtension};
+use crate::types::generics::InferableTypeVars;
 use crate::types::{
     ApplyTypeMappingVisitor, BoundTypeVarInstance, FindLegacyTypeVarsVisitor, HasRelationToVisitor,
     IsDisjointVisitor, IsEquivalentVisitor, NormalizedVisitor, Type, TypeMapping, TypeRelation,
@@ -258,6 +259,7 @@ impl<'db> TupleType<'db> {
         self,
         db: &'db dyn Db,
         other: Self,
+        inferable: InferableTypeVars<'_, 'db>,
         relation: TypeRelation,
         relation_visitor: &HasRelationToVisitor<'db>,
         disjointness_visitor: &IsDisjointVisitor<'db>,
@@ -265,6 +267,7 @@ impl<'db> TupleType<'db> {
         self.tuple(db).has_relation_to_impl(
             db,
             other.tuple(db),
+            inferable,
             relation,
             relation_visitor,
             disjointness_visitor,
@@ -275,10 +278,11 @@ impl<'db> TupleType<'db> {
         self,
         db: &'db dyn Db,
         other: Self,
+        inferable: InferableTypeVars<'_, 'db>,
         visitor: &IsEquivalentVisitor<'db>,
     ) -> ConstraintSet<'db> {
         self.tuple(db)
-            .is_equivalent_to_impl(db, other.tuple(db), visitor)
+            .is_equivalent_to_impl(db, other.tuple(db), inferable, visitor)
     }
 
     pub(crate) fn is_single_valued(self, db: &'db dyn Db) -> bool {
@@ -442,6 +446,7 @@ impl<'db> FixedLengthTuple<Type<'db>> {
         &self,
         db: &'db dyn Db,
         other: &Tuple<Type<'db>>,
+        inferable: InferableTypeVars<'_, 'db>,
         relation: TypeRelation,
         relation_visitor: &HasRelationToVisitor<'db>,
         disjointness_visitor: &IsDisjointVisitor<'db>,
@@ -453,6 +458,7 @@ impl<'db> FixedLengthTuple<Type<'db>> {
                         self_ty.has_relation_to_impl(
                             db,
                             *other_ty,
+                            inferable,
                             relation,
                             relation_visitor,
                             disjointness_visitor,
@@ -473,6 +479,7 @@ impl<'db> FixedLengthTuple<Type<'db>> {
                     let element_constraints = self_ty.has_relation_to_impl(
                         db,
                         *other_ty,
+                        inferable,
                         relation,
                         relation_visitor,
                         disjointness_visitor,
@@ -491,6 +498,7 @@ impl<'db> FixedLengthTuple<Type<'db>> {
                     let element_constraints = self_ty.has_relation_to_impl(
                         db,
                         *other_ty,
+                        inferable,
                         relation,
                         relation_visitor,
                         disjointness_visitor,
@@ -510,6 +518,7 @@ impl<'db> FixedLengthTuple<Type<'db>> {
                         self_ty.has_relation_to_impl(
                             db,
                             other.variable,
+                            inferable,
                             relation,
                             relation_visitor,
                             disjointness_visitor,
@@ -524,13 +533,14 @@ impl<'db> FixedLengthTuple<Type<'db>> {
         &self,
         db: &'db dyn Db,
         other: &Self,
+        inferable: InferableTypeVars<'_, 'db>,
         visitor: &IsEquivalentVisitor<'db>,
     ) -> ConstraintSet<'db> {
         ConstraintSet::from(self.0.len() == other.0.len()).and(db, || {
             (self.0.iter())
                 .zip(&other.0)
                 .when_all(db, |(self_ty, other_ty)| {
-                    self_ty.is_equivalent_to_impl(db, *other_ty, visitor)
+                    self_ty.is_equivalent_to_impl(db, *other_ty, inferable, visitor)
                 })
         })
     }
@@ -793,6 +803,7 @@ impl<'db> VariableLengthTuple<Type<'db>> {
         &self,
         db: &'db dyn Db,
         other: &Tuple<Type<'db>>,
+        inferable: InferableTypeVars<'_, 'db>,
         relation: TypeRelation,
         relation_visitor: &HasRelationToVisitor<'db>,
         disjointness_visitor: &IsDisjointVisitor<'db>,
@@ -825,6 +836,7 @@ impl<'db> VariableLengthTuple<Type<'db>> {
                     let element_constraints = self_ty.has_relation_to_impl(
                         db,
                         other_ty,
+                        inferable,
                         relation,
                         relation_visitor,
                         disjointness_visitor,
@@ -844,6 +856,7 @@ impl<'db> VariableLengthTuple<Type<'db>> {
                     let element_constraints = self_ty.has_relation_to_impl(
                         db,
                         other_ty,
+                        inferable,
                         relation,
                         relation_visitor,
                         disjointness_visitor,
@@ -884,6 +897,7 @@ impl<'db> VariableLengthTuple<Type<'db>> {
                         EitherOrBoth::Both(self_ty, other_ty) => self_ty.has_relation_to_impl(
                             db,
                             other_ty,
+                            inferable,
                             relation,
                             relation_visitor,
                             disjointness_visitor,
@@ -891,6 +905,7 @@ impl<'db> VariableLengthTuple<Type<'db>> {
                         EitherOrBoth::Left(self_ty) => self_ty.has_relation_to_impl(
                             db,
                             other.variable,
+                            inferable,
                             relation,
                             relation_visitor,
                             disjointness_visitor,
@@ -918,6 +933,7 @@ impl<'db> VariableLengthTuple<Type<'db>> {
                         EitherOrBoth::Both(self_ty, other_ty) => self_ty.has_relation_to_impl(
                             db,
                             *other_ty,
+                            inferable,
                             relation,
                             relation_visitor,
                             disjointness_visitor,
@@ -925,6 +941,7 @@ impl<'db> VariableLengthTuple<Type<'db>> {
                         EitherOrBoth::Left(self_ty) => self_ty.has_relation_to_impl(
                             db,
                             other.variable,
+                            inferable,
                             relation,
                             relation_visitor,
                             disjointness_visitor,
@@ -945,6 +962,7 @@ impl<'db> VariableLengthTuple<Type<'db>> {
                     self.variable.has_relation_to_impl(
                         db,
                         other.variable,
+                        inferable,
                         relation,
                         relation_visitor,
                         disjointness_visitor,
@@ -958,16 +976,17 @@ impl<'db> VariableLengthTuple<Type<'db>> {
         &self,
         db: &'db dyn Db,
         other: &Self,
+        inferable: InferableTypeVars<'_, 'db>,
         visitor: &IsEquivalentVisitor<'db>,
     ) -> ConstraintSet<'db> {
         self.variable
-            .is_equivalent_to_impl(db, other.variable, visitor)
+            .is_equivalent_to_impl(db, other.variable, inferable, visitor)
             .and(db, || {
                 (self.prenormalized_prefix_elements(db, None))
                     .zip_longest(other.prenormalized_prefix_elements(db, None))
                     .when_all(db, |pair| match pair {
                         EitherOrBoth::Both(self_ty, other_ty) => {
-                            self_ty.is_equivalent_to_impl(db, other_ty, visitor)
+                            self_ty.is_equivalent_to_impl(db, other_ty, inferable, visitor)
                         }
                         EitherOrBoth::Left(_) | EitherOrBoth::Right(_) => {
                             ConstraintSet::from(false)
@@ -979,7 +998,7 @@ impl<'db> VariableLengthTuple<Type<'db>> {
                     .zip_longest(other.prenormalized_suffix_elements(db, None))
                     .when_all(db, |pair| match pair {
                         EitherOrBoth::Both(self_ty, other_ty) => {
-                            self_ty.is_equivalent_to_impl(db, other_ty, visitor)
+                            self_ty.is_equivalent_to_impl(db, other_ty, inferable, visitor)
                         }
                         EitherOrBoth::Left(_) | EitherOrBoth::Right(_) => {
                             ConstraintSet::from(false)
@@ -1170,6 +1189,7 @@ impl<'db> Tuple<Type<'db>> {
         &self,
         db: &'db dyn Db,
         other: &Self,
+        inferable: InferableTypeVars<'_, 'db>,
         relation: TypeRelation,
         relation_visitor: &HasRelationToVisitor<'db>,
         disjointness_visitor: &IsDisjointVisitor<'db>,
@@ -1178,6 +1198,7 @@ impl<'db> Tuple<Type<'db>> {
             Tuple::Fixed(self_tuple) => self_tuple.has_relation_to_impl(
                 db,
                 other,
+                inferable,
                 relation,
                 relation_visitor,
                 disjointness_visitor,
@@ -1185,6 +1206,7 @@ impl<'db> Tuple<Type<'db>> {
             Tuple::Variable(self_tuple) => self_tuple.has_relation_to_impl(
                 db,
                 other,
+                inferable,
                 relation,
                 relation_visitor,
                 disjointness_visitor,
@@ -1196,14 +1218,15 @@ impl<'db> Tuple<Type<'db>> {
         &self,
         db: &'db dyn Db,
         other: &Self,
+        inferable: InferableTypeVars<'_, 'db>,
         visitor: &IsEquivalentVisitor<'db>,
     ) -> ConstraintSet<'db> {
         match (self, other) {
             (Tuple::Fixed(self_tuple), Tuple::Fixed(other_tuple)) => {
-                self_tuple.is_equivalent_to_impl(db, other_tuple, visitor)
+                self_tuple.is_equivalent_to_impl(db, other_tuple, inferable, visitor)
             }
             (Tuple::Variable(self_tuple), Tuple::Variable(other_tuple)) => {
-                self_tuple.is_equivalent_to_impl(db, other_tuple, visitor)
+                self_tuple.is_equivalent_to_impl(db, other_tuple, inferable, visitor)
             }
             (Tuple::Fixed(_), Tuple::Variable(_)) | (Tuple::Variable(_), Tuple::Fixed(_)) => {
                 ConstraintSet::from(false)
@@ -1215,6 +1238,7 @@ impl<'db> Tuple<Type<'db>> {
         &self,
         db: &'db dyn Db,
         other: &Self,
+        inferable: InferableTypeVars<'_, 'db>,
         disjointness_visitor: &IsDisjointVisitor<'db>,
         relation_visitor: &HasRelationToVisitor<'db>,
     ) -> ConstraintSet<'db> {
@@ -1234,6 +1258,7 @@ impl<'db> Tuple<Type<'db>> {
             db: &'db dyn Db,
             a: impl IntoIterator<Item = &'s Type<'db>>,
             b: impl IntoIterator<Item = &'s Type<'db>>,
+            inferable: InferableTypeVars<'_, 'db>,
             disjointness_visitor: &IsDisjointVisitor<'db>,
             relation_visitor: &HasRelationToVisitor<'db>,
         ) -> ConstraintSet<'db>
@@ -1244,6 +1269,7 @@ impl<'db> Tuple<Type<'db>> {
                 self_element.is_disjoint_from_impl(
                     db,
                     *other_element,
+                    inferable,
                     disjointness_visitor,
                     relation_visitor,
                 )
@@ -1255,6 +1281,7 @@ impl<'db> Tuple<Type<'db>> {
                 db,
                 self_tuple.elements(),
                 other_tuple.elements(),
+                inferable,
                 disjointness_visitor,
                 relation_visitor,
             ),
@@ -1266,6 +1293,7 @@ impl<'db> Tuple<Type<'db>> {
                 db,
                 self_tuple.prefix_elements(),
                 other_tuple.prefix_elements(),
+                inferable,
                 disjointness_visitor,
                 relation_visitor,
             )
@@ -1274,6 +1302,7 @@ impl<'db> Tuple<Type<'db>> {
                     db,
                     self_tuple.suffix_elements().rev(),
                     other_tuple.suffix_elements().rev(),
+                    inferable,
                     disjointness_visitor,
                     relation_visitor,
                 )
@@ -1284,6 +1313,7 @@ impl<'db> Tuple<Type<'db>> {
                 db,
                 fixed.elements(),
                 variable.prefix_elements(),
+                inferable,
                 disjointness_visitor,
                 relation_visitor,
             )
@@ -1292,6 +1322,7 @@ impl<'db> Tuple<Type<'db>> {
                     db,
                     fixed.elements().rev(),
                     variable.suffix_elements().rev(),
+                    inferable,
                     disjointness_visitor,
                     relation_visitor,
                 )


### PR DESCRIPTION
A large part of the diff on #20677 just involves threading a new `inferable` parameter through all of the type property methods. In the interests of making that PR easier to review, I've pulled that bit out into here, so that it can be reviewed in isolation. This should be a pure refactoring, with no logic changes or behavioral changes.