### PR TITLE
fix(docs): Fix typo in `RUF015` description

### DIFF
--- a/crates/ruff_linter/src/rules/ruff/rules/unnecessary_iterable_allocation_for_first_element.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unnecessary_iterable_allocation_for_first_element.rs
@@ -48,7 +48,7 @@ use crate::{AlwaysFixableViolation, Edit, Fix};
 ///    element. As such, any side effects that occur during iteration will be
 ///    delayed.
 /// 2. Second, accessing members of a collection via square bracket notation
-///    `[0]` of the `pop()` function will raise `IndexError` if the collection
+///    `[0]` or the `pop()` function will raise `IndexError` if the collection
 ///    is empty, while `next(iter(...))` will raise `StopIteration`.
 ///
 /// ## References


### PR DESCRIPTION
## Summary
Fixed a typo. It should be "or", not "of". Both `.pop()` and `next()` on an empty collection will raise `IndexError`, not "`[0]` of the `pop()` function"

## Test Plan

n/a
