### PR TITLE
Remove `strip` from release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -268,7 +268,6 @@ large_stack_arrays = "allow"
 
 
 [profile.release]
-strip = true
 lto = "fat"
 codegen-units = 16
 


### PR DESCRIPTION
## Summary

I added `strip="symbols"` in https://github.com/astral-sh/ruff/pull/20863 for consistency with our released binaries (we always set strip=true when building with maturin).

Unfortunately, this breaks the WASM build (https://github.com/rust-lang/rust/issues/93294). I don't think it's worth having a separate release target for WASM only and 
`strip=symbols` isn't needed to fix the binary regression. 

## Test Plan

`npm run build --workspace ty-playground` compiles without error

