### PR TITLE
Remove `release` CI job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -361,6 +361,37 @@ jobs:
           cargo nextest run --all-features --profile ci
           cargo test --all-features --doc
 
+  cargo-test-macos:
+    name: "cargo test (macos)"
+    runs-on: depot-windows-2022-16
+    needs: determine_changes
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-test') && (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+      - uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
+      - name: "Install Rust toolchain"
+        run: rustup show
+      - name: "Install mold"
+        uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
+      - name: "Install cargo nextest"
+        uses: taiki-e/install-action@522492a8c115f1b6d4d318581f09638e9442547b # v2.62.21
+        with:
+          tool: cargo-nextest
+      - name: "Install uv"
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        with:
+          enable-cache: "true"
+      - name: "Run tests"
+        shell: bash
+        env:
+          NEXTEST_PROFILE: "ci"
+        run: |
+          cargo nextest run --all-features --profile ci
+          cargo test --all-features --doc
+
   cargo-test-wasm:
     name: "cargo test (wasm)"
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

We added the release CI job to catch issues with conditionally compiled code (`debug`, `cfg(debug_assertions)` back in April 2024 (https://github.com/astral-sh/ruff/pull/11182). 

But, we've since then also added `cargo-test-linux-release` (https://github.com/astral-sh/ruff/pull/14604), which not only compiles with the release profile but also runs all tests

https://github.com/astral-sh/ruff/blob/3d2ece2f42f24b0c18968d3a624d37eeb37525ff/.github/workflows/ci.yaml#L300-L331

That's why I think we can safely remove the release CI Job, as it's covered by cargo-test-linux-release

## Test Plan

