### PR TITLE
Auto-accept snapshot changes as part of typeshed-sync PRs

### DIFF
--- a/.github/workflows/sync_typeshed.yaml
+++ b/.github/workflows/sync_typeshed.yaml
@@ -29,7 +29,12 @@ on:
     - cron: "0 0 1,15 * *"
 
 env:
-  FORCE_COLOR: 1
+  # Don't set this flag globally for the workflow: it does strange things
+  # to the snapshots in the `cargo insta test --accept` step in the MacOS job.
+  #
+  # FORCE_COLOR: 1
+
+  CARGO_TERM_COLOR: always
   GH_TOKEN: ${{ github.token }}
 
   # The name of the upstream branch that the first worker creates,
@@ -88,6 +93,8 @@ jobs:
           git commit -m "Sync typeshed. Source commit: https://github.com/python/typeshed/commit/$(git -C ../typeshed rev-parse HEAD)" --allow-empty
       - name: Sync Linux docstrings
         if: ${{ success() }}
+        env:
+          FORCE_COLOR: 1
         run: |
           cd ruff
           ./scripts/codemod_docstrings.sh
@@ -127,6 +134,8 @@ jobs:
       - name: Sync Windows docstrings
         id: docstrings
         shell: bash
+        env:
+          FORCE_COLOR: 1
         run: ./scripts/codemod_docstrings.sh
       - name: Commit the changes
         if: ${{ steps.docstrings.outcome == 'success' }}
@@ -164,11 +173,15 @@ jobs:
           git config --global user.email '<>'
       - name: Sync macOS docstrings
         if: ${{ success() }}
+        env:
+          FORCE_COLOR: 1
         run: |
           ./scripts/codemod_docstrings.sh
           git commit -am "Sync macOS docstrings" --allow-empty
       - name: Format the changes
         if: ${{ success() }}
+        env:
+          FORCE_COLOR: 1
         run: |
           # Here we just reformat the codemodded stubs so that they are
           # consistent with the other typeshed stubs around them.
@@ -188,6 +201,11 @@ jobs:
       - name: "Install mold"
         if: ${{ success() }}
         uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
+      - name: "Install cargo nextest"
+        if: ${{ success() }}
+        uses: taiki-e/install-action@522492a8c115f1b6d4d318581f09638e9442547b # v2.62.21
+        with:
+          tool: cargo-nextest
       - name: "Install cargo insta"
         if: ${{ success() }}
         uses: taiki-e/install-action@522492a8c115f1b6d4d318581f09638e9442547b # v2.62.21
@@ -203,8 +221,10 @@ jobs:
           # but if there were also other mdtest failures (for example), it will return a nonzero exit code.
           # We don't care about other tests failing here, we just want snapshots updated where possible,
           # so we use `|| true` here to ignore the exit code.
-          cargo insta test --accept || true
-          git commit -am "Update snapshots" || echo "No snapshot changes to commit"
+          cargo insta test --accept --color=always --all-features --test-runner=nextest || true
+      - name: Commit snapshot changes
+        if: ${{ success() }}
+        run: git commit -am "Update snapshots" || echo "No snapshot changes to commit"
       - name: Push changes upstream and create a PR
         if: ${{ success() }}
         run: |


### PR DESCRIPTION
## Summary

Some of our ty snapshots (in particular, several in the `ty_ide` crate that relate to autocompletions) are very sensitive to changes in typeshed. If typeshed changes the line number a class or function is defined on, that often leads to the snapshots in `ty_ide` needing to be updated manually before a typeshed-sync PR can be merged, which is a bit of a pain.

This PR adds a step to the `sync_typeshed.yaml` workflow that checks for changes to snapshots and automatically accepts them all before the PR is made. This should hopefully reduce the number of changes we need to make manually to sync-typeshed PRs. (We'll still need to review these PRs carefully to check that all the changes to the snapshots are _desirable_, but I still think that this will probably save us time overall.) The step is allowed to fail; if checking for changes to snapshots produces a nonzero exit code, the sync-typeshed PR should still be filed.

The `cargo insta` docs are here: https://insta.rs/docs/cli/

## Test Plan

I:
1. Ran `git checkout dc64c086336148c57db14060c86f448351710b2e -- crates/ty_python_semantic/resources/mdtest/snapshots`. This reverted all the snapshot changes from https://github.com/astral-sh/ruff/pull/20820, a PR which resulted in lots of snapshot changes -- multiple snapshot changes per mdtest file, in some cases.
2. Ran `cargo insta test --accept`. I observed that this command reverted all changes from step (1).