### PR TITLE
Avoid printing out entire search path if long

### DIFF
--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -4811,15 +4811,15 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // Add search paths information to the diagnostic
             // Use the same search paths function that is used in actual module resolution
-            let mut search_paths =
-                search_paths(self.db(), ModuleResolveMode::StubsAllowed).peekable();
+            let search_paths: Vec<_> =
+                search_paths(self.db(), ModuleResolveMode::StubsAllowed).collect();
 
-            if search_paths.peek().is_some() {
+            if !search_paths.is_empty() && search_paths.len() < 25 {
                 diagnostic.info(format_args!(
                     "Searched in the following paths during module resolution:"
                 ));
 
-                for (index, path) in search_paths.enumerate() {
+                for (index, path) in search_paths.into_iter().enumerate() {
                     diagnostic.info(format_args!(
                         "  {}. {} ({})",
                         index + 1,


### PR DESCRIPTION
We have environments with a thousand entries in our search path.
This overwhelms ty output