### PR TITLE
More CI improvements

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+defaults:
+  run:
+    shell: bash
+
 env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
@@ -19,6 +23,7 @@ env:
   RUSTUP_MAX_RETRIES: 10
   PACKAGE_NAME: ruff
   PYTHON_VERSION: "3.13"
+  NEXTEST_PROFILE: ci
 
 jobs:
   determine_changes:
@@ -271,9 +276,6 @@ jobs:
         # This step is just to get nice GitHub annotations on the PR diff in the files-changed tab.
         run: cargo test -p ty_python_semantic --test mdtest || true
       - name: "Run tests"
-        shell: bash
-        env:
-          NEXTEST_PROFILE: "ci"
         run: cargo insta test --all-features --unreferenced reject --test-runner nextest
 
       # Check for broken links in the documentation.
@@ -299,9 +301,13 @@ jobs:
 
   cargo-test-linux-release:
     name: "cargo test (linux, release)"
-    runs-on: ${{ github.repository == 'astral-sh/ruff' && 'depot-ubuntu-22.04-16' || 'ubuntu-latest' }}
+    # release builds timeout on GitHub runners, so this job is just skipped on forks in the `if` check
+    runs-on: depot-ubuntu-22.04-16
     needs: determine_changes
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-test') && (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}
+    if: |
+      github.repository == 'astral-sh/ruff' &&
+      !contains(github.event.pull_request.labels.*.name, 'no-test') &&
+      (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main')
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -325,9 +331,6 @@ jobs:
         with:
           enable-cache: "true"
       - name: "Run tests"
-        shell: bash
-        env:
-          NEXTEST_PROFILE: "ci"
         run: cargo insta test --release --all-features --unreferenced reject --test-runner nextest
 
   cargo-test-windows:
@@ -352,9 +355,7 @@ jobs:
         with:
           enable-cache: "true"
       - name: "Run tests"
-        shell: bash
         env:
-          NEXTEST_PROFILE: "ci"
           # Workaround for <https://github.com/nextest-rs/nextest/issues/1493>.
           RUSTUP_WINDOWS_PATH_ADD_BIN: 1
         run: |
@@ -385,9 +386,6 @@ jobs:
         with:
           enable-cache: "true"
       - name: "Run tests"
-        shell: bash
-        env:
-          NEXTEST_PROFILE: "ci"
         run: |
           cargo nextest run --all-features --profile ci
           cargo test --all-features --doc
@@ -445,7 +443,6 @@ jobs:
       - name: "Install mold"
         uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
       - name: "Build tests"
-        shell: bash
         env:
           MSRV: ${{ steps.msrv.outputs.value }}
         run: cargo "+${MSRV}" test --no-run --all-features

--- a/.github/workflows/mypy_primer.yaml
+++ b/.github/workflows/mypy_primer.yaml
@@ -19,6 +19,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+defaults:
+  run:
+    shell: bash
+
 env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
@@ -49,7 +53,6 @@ jobs:
         run: rustup show
 
       - name: Run mypy_primer
-        shell: bash
         env:
           PRIMER_SELECTOR: crates/ty_python_semantic/resources/primer/good.txt
           DIFF_FILE: mypy_primer.diff
@@ -92,7 +95,6 @@ jobs:
         run: rustup show
 
       - name: Run mypy_primer
-        shell: bash
         env:
           TY_MAX_PARALLELISM: 1 # for deterministic memory numbers
           TY_MEMORY_REPORT: mypy_primer

--- a/.github/workflows/sync_typeshed.yaml
+++ b/.github/workflows/sync_typeshed.yaml
@@ -28,6 +28,10 @@ on:
     # Run on the 1st and the 15th of every month:
     - cron: "0 0 1,15 * *"
 
+defaults:
+  run:
+    shell: bash
+
 env:
   # Don't set this flag globally for the workflow: it does strange things
   # to the snapshots in the `cargo insta test --accept` step in the MacOS job.
@@ -35,6 +39,7 @@ env:
   # FORCE_COLOR: 1
 
   CARGO_TERM_COLOR: always
+  NEXTEST_PROFILE: "ci"
   GH_TOKEN: ${{ github.token }}
 
   # The name of the upstream branch that the first worker creates,
@@ -133,7 +138,6 @@ jobs:
           git config --global user.email '<>'
       - name: Sync Windows docstrings
         id: docstrings
-        shell: bash
         env:
           FORCE_COLOR: 1
         run: ./scripts/codemod_docstrings.sh


### PR DESCRIPTION
## Summary

- Just skip the `--release` job entirely on forks. It times out on GitHub's Linux runner...
- Move `shell: bash` and the `NEXTEST_PROFILE` environment variables to workflow-level defaults, to make the workflows less repetitive

## Test Plan

CI on this PR
