### PR TITLE
[ty] `continue` and `break` statements outside loops are syntax errors

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/semantic_syntax_errors.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/semantic_syntax_errors.md
@@ -354,3 +354,25 @@ def f():
     x = 1
     global x  # error: [invalid-syntax] "name `x` is used prior to global declaration"
 ```
+
+## `break` and `continue` outside a loop
+
+<!-- snapshot-diagnostics -->
+
+```py
+break  # error: [invalid-syntax]
+continue  # error: [invalid-syntax]
+
+for x in range(42):
+    break  # fine
+    continue  # fine
+
+    def _():
+        break  # error: [invalid-syntax]
+        continue  # error: [invalid-syntax]
+
+    class Fine:
+        # this is invalid syntax despite it being in an eager-nested scope!
+        break  # error: [invalid-syntax]
+        continue  # error: [invalid-syntax]
+```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/semantic_syntax_erro…_-_Semantic_syntax_erro…_-_`break`_and_`continu…_(3143ba0a999d644).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/semantic_syntax_erro…_-_Semantic_syntax_erro…_-_`break`_and_`continu…_(3143ba0a999d644).snap
@@ -1,0 +1,107 @@
+---
+source: crates/ty_test/src/lib.rs
+expression: snapshot
+---
+---
+mdtest name: semantic_syntax_errors.md - Semantic syntax error diagnostics - `break` and `continue` outside a loop
+mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/semantic_syntax_errors.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+ 1 | break  # error: [invalid-syntax]
+ 2 | continue  # error: [invalid-syntax]
+ 3 | 
+ 4 | for x in range(42):
+ 5 |     break  # fine
+ 6 |     continue  # fine
+ 7 | 
+ 8 |     def _():
+ 9 |         break  # error: [invalid-syntax]
+10 |         continue  # error: [invalid-syntax]
+11 | 
+12 |     class Fine:
+13 |         # this is invalid syntax despite it being in an eager-nested scope!
+14 |         break  # error: [invalid-syntax]
+15 |         continue  # error: [invalid-syntax]
+```
+
+# Diagnostics
+
+```
+error[invalid-syntax]: `break` outside loop
+ --> src/mdtest_snippet.py:1:1
+  |
+1 | break  # error: [invalid-syntax]
+  | ^^^^^
+2 | continue  # error: [invalid-syntax]
+  |
+
+```
+
+```
+error[invalid-syntax]: `continue` outside loop
+ --> src/mdtest_snippet.py:2:1
+  |
+1 | break  # error: [invalid-syntax]
+2 | continue  # error: [invalid-syntax]
+  | ^^^^^^^^
+3 |
+4 | for x in range(42):
+  |
+
+```
+
+```
+error[invalid-syntax]: `break` outside loop
+  --> src/mdtest_snippet.py:9:9
+   |
+ 8 |     def _():
+ 9 |         break  # error: [invalid-syntax]
+   |         ^^^^^
+10 |         continue  # error: [invalid-syntax]
+   |
+
+```
+
+```
+error[invalid-syntax]: `continue` outside loop
+  --> src/mdtest_snippet.py:10:9
+   |
+ 8 |     def _():
+ 9 |         break  # error: [invalid-syntax]
+10 |         continue  # error: [invalid-syntax]
+   |         ^^^^^^^^
+11 |
+12 |     class Fine:
+   |
+
+```
+
+```
+error[invalid-syntax]: `break` outside loop
+  --> src/mdtest_snippet.py:14:9
+   |
+12 |     class Fine:
+13 |         # this is invalid syntax despite it being in an eager-nested scope!
+14 |         break  # error: [invalid-syntax]
+   |         ^^^^^
+15 |         continue  # error: [invalid-syntax]
+   |
+
+```
+
+```
+error[invalid-syntax]: `continue` outside loop
+  --> src/mdtest_snippet.py:15:9
+   |
+13 |         # this is invalid syntax despite it being in an eager-nested scope!
+14 |         break  # error: [invalid-syntax]
+15 |         continue  # error: [invalid-syntax]
+   |         ^^^^^^^^
+   |
+
+```

--- a/crates/ty_python_semantic/src/semantic_index/builder.rs
+++ b/crates/ty_python_semantic/src/semantic_index/builder.rs
@@ -2787,7 +2787,7 @@ impl SemanticSyntaxContext for SemanticIndexBuilder<'_, '_> {
     }
 
     fn in_loop_context(&self) -> bool {
-        true
+        self.current_scope_info().current_loop.is_some()
     }
 }
 


### PR DESCRIPTION
## Summary

Co-authored-by: Brent Westbrook <brentrwestbrook@gmail.com>

## Test Plan

Mdtest and snapshots
