### PR TITLE
[ty] Fix panic when attempting to validate the members of a protocol that inherits from a protocol in another module

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -1150,6 +1150,7 @@ here too:
 ```py
 from typing import Protocol
 
+# Ensure the number of scopes in `b.py` is greater than the number of scopes in `c.py`:
 class SomethingUnrelated: ...
 
 class A(Protocol):

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Diagnostics_for_prot…_(585a3e9545d41b64).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Diagnostics_for_prot…_(585a3e9545d41b64).snap
@@ -42,10 +42,11 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/protocols.md
 ```
 1 | from typing import Protocol
 2 | 
-3 | class SomethingUnrelated: ...
-4 | 
-5 | class A(Protocol):
-6 |     x: int
+3 | # Ensure the number of scopes in `b.py` is greater than the number of scopes in `c.py`:
+4 | class SomethingUnrelated: ...
+5 | 
+6 | class A(Protocol):
+7 |     x: int
 ```
 
 ## c.py

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -932,7 +932,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
 
             if let Some(protocol) = class.into_protocol_class(self.db()) {
-                protocol.validate_members(&self.context, self.index);
+                protocol.validate_members(&self.context);
             }
         }
     }

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -10,9 +10,7 @@ use crate::types::TypeContext;
 use crate::{
     Db, FxOrderSet,
     place::{Definedness, Place, PlaceAndQualifiers, place_from_bindings, place_from_declarations},
-    semantic_index::{
-        SemanticIndex, definition::Definition, place::ScopedPlaceId, place_table, use_def_map,
-    },
+    semantic_index::{definition::Definition, place::ScopedPlaceId, place_table, use_def_map},
     types::{
         ApplyTypeMappingVisitor, BoundTypeVarInstance, CallableType, ClassBase, ClassLiteral,
         ClassType, FindLegacyTypeVarsVisitor, HasRelationToVisitor,
@@ -77,11 +75,11 @@ impl<'db> ProtocolClass<'db> {
     /// Iterate through the body of the protocol class. Check that all definitions
     /// in the protocol class body are either explicitly declared directly in the
     /// class body, or are declared in a superclass of the protocol class.
-    pub(super) fn validate_members(self, context: &InferContext, index: &SemanticIndex<'db>) {
+    pub(super) fn validate_members(self, context: &InferContext) {
         let db = context.db();
         let interface = self.interface(db);
         let body_scope = self.class_literal(db).0.body_scope(db);
-        let class_place_table = index.place_table(body_scope.file_scope_id(db));
+        let class_place_table = place_table(db, body_scope);
 
         for (symbol_id, mut bindings_iterator) in
             use_def_map(db, body_scope).all_end_of_scope_symbol_bindings()
@@ -104,8 +102,7 @@ impl<'db> ProtocolClass<'db> {
                         };
                         !place_from_declarations(
                             db,
-                            index
-                                .use_def_map(superclass_scope.file_scope_id(db))
+                            use_def_map(db, superclass_scope)
                                 .end_of_scope_declarations(ScopedPlaceId::Symbol(scoped_symbol_id)),
                         )
                         .into_place_and_conflicting_declarations()


### PR DESCRIPTION
## Summary

This fixes a panic that could occur when trying to validate a protocol's members, if the protocol had unannotated assignments in its class body and inherited from a protocol that was defined in another module. We were attempting to lookup the superclass protocol in the wrong file, which could lead to panics and incorrect behaviour.

## Test Plan

Added an mdtest that causes us to panic on `main`
