### PR TITLE
Run py-fuzzer using Python 3.14 in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ env:
   CARGO_TERM_COLOR: always
   RUSTUP_MAX_RETRIES: 10
   PACKAGE_NAME: ruff
-  PYTHON_VERSION: "3.13"
+  PYTHON_VERSION: "3.14"
   NEXTEST_PROFILE: ci
 
 jobs:
@@ -557,7 +557,8 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          # TODO: figure out why `ruff-ecosystem` crashes on Python 3.14
+          python-version: "3.13"
 
       - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         name: Download comparison Ruff binary
@@ -711,7 +712,7 @@ jobs:
             --baseline-executable="${PWD}/ty" \
             --only-new-bugs \
             --bin=ty \
-            0-500
+            0-1000
           )
 
   cargo-shear:

--- a/.github/workflows/daily_fuzz.yaml
+++ b/.github/workflows/daily_fuzz.yaml
@@ -49,7 +49,7 @@ jobs:
           # shellcheck disable=SC2046
           (
             uv run \
-            --python=3.13 \
+            --python=3.14 \
             --project=./python/py-fuzzer \
             --locked \
             fuzz \

--- a/python/py-fuzzer/fuzz.py
+++ b/python/py-fuzzer/fuzz.py
@@ -66,7 +66,7 @@ def ruff_contains_bug(code: str, *, ruff_executable: Path) -> bool:
             "lint.select=[]",
             "--no-cache",
             "--target-version",
-            "py313",
+            "py314",
             "--preview",
             "-",
         ],


### PR DESCRIPTION
## Summary

Note that this changes the contents of the file each seed corresponds to. For example, when running the fuzzer with Python 3.13, it identifies that ty panics on seed 289, but this isn't the case when running the fuzzer with Python 3.14, because the contents of the file generated by seed 289 are different when running with Python 3.14. When running the fuzzer with Python 3.14, in fact, ty no longer panics on any of seeds 0-500 -- so I bumped the range of seeds we fuzz ty with to 0-1000 range. This means that there is still one seed that ty panics on (692).

Possibly the Python version used here could also be bumped, but I'd rather not touch the release workflow unless it's absolutely necessary, given how many times I've broken it in the past 😆:

https://github.com/astral-sh/ruff/blob/68c1fa86c8d18801f3cfc943d6f16a78e745dda2/.github/workflows/build-binaries.yml#L31

## Test Plan

CI on this PR
