### PR TITLE
[`ruff`] Skip autofix for keyword and `__debug__` path params

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/fastapi/FAST003.py
+++ b/crates/ruff_linter/resources/test/fixtures/fastapi/FAST003.py
@@ -256,3 +256,12 @@ async def f4():
 @app.get("/f5/{param: int}")
 async def f5():
     return locals()
+
+# https://github.com/astral-sh/ruff/issues/20941
+@app.get("/imports/{import}")
+async def get_import():
+    ...
+
+@app.get("/debug/{__debug__}")
+async def get_debug():
+    ...

--- a/crates/ruff_linter/src/rules/fastapi/rules/fastapi_unused_path_parameter.rs
+++ b/crates/ruff_linter/src/rules/fastapi/rules/fastapi_unused_path_parameter.rs
@@ -7,6 +7,7 @@ use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_python_ast as ast;
 use ruff_python_ast::{Arguments, Expr, ExprCall, ExprSubscript, Parameter, ParameterWithDefault};
 use ruff_python_semantic::{BindingKind, Modules, ScopeKind, SemanticModel};
+use ruff_python_stdlib::identifiers::is_identifier;
 use ruff_text_size::{Ranged, TextSize};
 
 use crate::Fix;
@@ -191,7 +192,7 @@ pub(crate) fn fastapi_unused_path_parameter(
                 .add_start(TextSize::from(range.start as u32 + 1))
                 .sub_end(TextSize::from((path.len() - range.end + 1) as u32)),
         );
-        if !is_positional {
+        if !is_positional && is_identifier(path_param) && path_param != "__debug__" {
             diagnostic.set_fix(Fix::unsafe_edit(add_parameter(
                 path_param,
                 &function_def.parameters,

--- a/crates/ruff_linter/src/rules/fastapi/snapshots/ruff_linter__rules__fastapi__tests__fast-api-unused-path-parameter_FAST003.py.snap
+++ b/crates/ruff_linter/src/rules/fastapi/snapshots/ruff_linter__rules__fastapi__tests__fast-api-unused-path-parameter_FAST003.py.snap
@@ -363,3 +363,26 @@ help: Add `id` to function signature
 206 | 
 207 | # No errors
 note: This is an unsafe fix and may change runtime behavior
+
+FAST003 Parameter `import` appears in route path, but not in `get_import` signature
+   --> FAST003.py:261:20
+    |
+260 | # https://github.com/astral-sh/ruff/issues/20941
+261 | @app.get("/imports/{import}")
+    |                    ^^^^^^^^
+262 | async def get_import():
+263 |     ...
+    |
+help: Add `import` to function signature
+
+FAST003 Parameter `__debug__` appears in route path, but not in `get_debug` signature
+   --> FAST003.py:265:18
+    |
+263 |     ...
+264 |
+265 | @app.get("/debug/{__debug__}")
+    |                  ^^^^^^^^^^^
+266 | async def get_debug():
+267 |     ...
+    |
+help: Add `__debug__` to function signature


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Fixes #20941

Skip autofix for keyword and __debug__ path params

## Test Plan

<!-- How was it tested? -->

I added two test cases to crates/ruff_linter/resources/test/fixtures/fastapi/FAST003.py.
