### PR TITLE
[ty] fix non-deterministic overload function inference

### DIFF
--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -257,6 +257,8 @@ pub(super) struct TypeInferenceBuilder<'db, 'ast> {
     ///     return x
     /// ```
     ///
+    /// To keep the calculation deterministic, we use an `FxIndexSet` whose order is determined by the sequence of insertion calls.
+    ///
     /// [`check_overloaded_functions`]: TypeInferenceBuilder::check_overloaded_functions
     called_functions: FxIndexSet<FunctionType<'db>>,
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ty/issues/1389.

I'm not yet convinced that the bug has been fixed completely, but assuming that the cause of the non-determinism is `FxHash{Set, Map}`, I think this part is the most suspicious. As far as I can see, this is the only place where a non-deterministic operation is performed on `FxHash{Set, Map}`, i.e., where it is used as an iterator.

## Test Plan

I'll run the tests multiple times and check the results.



