### PR TITLE
Use uv more in CI workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -529,10 +529,11 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
-      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
         with:
           # TODO: figure out why `ruff-ecosystem` crashes on Python 3.14
           python-version: "3.13"
+          activate-environment: true
 
       - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         name: Download comparison Ruff binary
@@ -551,7 +552,7 @@ jobs:
 
       - name: Install ruff-ecosystem
         run: |
-          pip install ./python/ruff-ecosystem
+          uv pip install ./python/ruff-ecosystem
 
       - name: Run `ruff check` stable ecosystem check
         if: ${{ needs.determine_changes.outputs.linter == 'true' }}
@@ -787,9 +788,6 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
-      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
-        with:
-          python-version: "3.13"
       - uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
       - name: "Add SSH key"
         if: ${{ env.MKDOCS_INSIDERS_SSH_KEY_EXISTS == 'true' }}
@@ -800,12 +798,15 @@ jobs:
         run: rustup show
       - name: Install uv
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        with:
+          python-version: 3.13
+          activate-environment: true
       - name: "Install Insiders dependencies"
         if: ${{ env.MKDOCS_INSIDERS_SSH_KEY_EXISTS == 'true' }}
-        run: uv pip install -r docs/requirements-insiders.txt --system
+        run: uv pip install -r docs/requirements-insiders.txt
       - name: "Install dependencies"
         if: ${{ env.MKDOCS_INSIDERS_SSH_KEY_EXISTS != 'true' }}
-        run: uv pip install -r docs/requirements.txt --system
+        run: uv pip install -r docs/requirements.txt
       - name: "Update README File"
         run: python scripts/transform_readme.py --target mkdocs
       - name: "Generate docs"


### PR DESCRIPTION
## Summary

More dogfooding of our own tools.

I didn't touch the build-binaries workflow (it's scary) or the publish-docs workflow (which doesn't run on PRs) or the ruff-lsp job in the ci.yaml workflow (ruff-lsp is deprecated; it doesn't seem worth making changes there).

## Test Plan

CI on this PR
