### PR TITLE
Add `language: python` to several pre-commit hook entries

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,7 @@ repos:
     rev: 0.7.22
     hooks:
       - id: mdformat
+        language: python # means renovate will also update `additional_dependencies`
         additional_dependencies:
           - mdformat-mkdocs==4.0.0
           - mdformat-footnote==0.1.1
@@ -58,6 +59,7 @@ repos:
     rev: 1.19.1
     hooks:
       - id: blacken-docs
+        language: python # means renovate will also update `additional_dependencies`
         args: ["--pyi", "--line-length", "130"]
         files: '^crates/.*/resources/mdtest/.*\.md'
         exclude: |


### PR DESCRIPTION
This means renovate will also update the `additional_dependencies` entries for these hooks