### PR TITLE
[ty] Add basic `__slots__` type inference support

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/slots.md
+++ b/crates/ty_python_semantic/resources/mdtest/slots.md
@@ -1,0 +1,62 @@
+# `__slots__`
+
+## Basic slot access
+
+```py
+class A:
+    __slots__ = ("foo", "bar")
+
+    def __init__(self, foo: int, bar: str):
+        self.foo = foo
+        self.bar = bar
+
+a = A(1, "zip")
+a.foo = 2
+a.bar = "woo"
+a.baz = 3  # error: [unresolved-attribute]
+```
+
+## Accessing undefined attributes
+
+```py
+class A:
+    __slots__ = ("x",)
+
+a = A()
+a.y = 1  # error: [unresolved-attribute]
+```
+
+## Empty slots
+
+```py
+class A:
+    __slots__ = ()
+
+a = A()
+a.x = 1  # error: [unresolved-attribute]
+```
+
+## Single character string
+
+```py
+class A:
+    __slots__ = "x"
+
+a = A()
+a.x = 1  # error: [possibly-missing-attribute]
+a.y = 2  # error: [unresolved-attribute]
+```
+
+## Multi-character string
+
+```py
+class A:
+    __slots__ = "xyz"
+
+a = A()
+a.x = 1  # error: [possibly-missing-attribute]
+a.y = 2  # error: [possibly-missing-attribute]
+a.z = 3  # error: [possibly-missing-attribute]
+a.xyz = 4  # error: [unresolved-attribute]
+a.q = 5  # error: [unresolved-attribute]
+```

--- a/crates/ty_python_semantic/resources/mdtest/slots.md
+++ b/crates/ty_python_semantic/resources/mdtest/slots.md
@@ -49,14 +49,17 @@ a.y = 2  # error: [unresolved-attribute]
 
 ## Multi-character string
 
+Python treats `__slots__ = "xyz"` as a single slot named `"xyz"`, not three individual character
+slots.
+
 ```py
 class A:
     __slots__ = "xyz"
 
 a = A()
-a.x = 1  # error: [possibly-missing-attribute]
-a.y = 2  # error: [possibly-missing-attribute]
-a.z = 3  # error: [possibly-missing-attribute]
-a.xyz = 4  # error: [unresolved-attribute]
+a.xyz = 1  # error: [possibly-missing-attribute]
+a.x = 2  # error: [unresolved-attribute]
+a.y = 3  # error: [unresolved-attribute]
+a.z = 4  # error: [unresolved-attribute]
 a.q = 5  # error: [unresolved-attribute]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/slots.md
+++ b/crates/ty_python_semantic/resources/mdtest/slots.md
@@ -16,6 +16,20 @@ a.bar = "woo"
 a.baz = 3  # error: [unresolved-attribute]
 ```
 
+## Accessing slot-declared but uninitialized attributes
+
+A slot declaration is analogous to a bare annotation like `x: int` in a class body: the attribute is
+considered declared and accessible on instances, even if it was never explicitly initialized.
+
+```py
+class A:
+    __slots__ = ("x",)
+
+a = A()
+reveal_type(a.x)  # revealed: Unknown
+a.x = 1
+```
+
 ## Accessing undefined attributes
 
 ```py
@@ -43,7 +57,7 @@ class A:
     __slots__ = "x"
 
 a = A()
-a.x = 1  # error: [possibly-missing-attribute]
+a.x = 1
 a.y = 2  # error: [unresolved-attribute]
 ```
 
@@ -57,7 +71,7 @@ class A:
     __slots__ = "xyz"
 
 a = A()
-a.xyz = 1  # error: [possibly-missing-attribute]
+a.xyz = 1
 a.x = 2  # error: [unresolved-attribute]
 a.y = 3  # error: [unresolved-attribute]
 a.z = 4  # error: [unresolved-attribute]

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -4277,10 +4277,11 @@ impl<'db> StaticClassLiteral<'db> {
         }
 
         if result.place.is_undefined() {
-            return Place::Defined(
-                DefinedPlace::new(Type::unknown()).with_definedness(Definedness::PossiblyUndefined),
-            )
-            .into();
+            // The attribute is declared in `__slots__` but has no explicit binding
+            // or annotation in the class body or any method. This is analogous to a
+            // bare annotation like `x: int` in a class body: the attribute is
+            // considered declared and accessible on instances, just without a known type.
+            return Place::Defined(DefinedPlace::new(Type::unknown())).into();
         }
 
         result

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -4741,14 +4741,16 @@ impl<'db> StaticClassLiteral<'db> {
                     // The attribute is not *declared* in the class body. It could still be declared/bound
                     // in a method.
 
-                    Self::implicit_attribute(db, body_scope, name, MethodDecorator::None)
+                    let result = Self::implicit_attribute(db, body_scope, name, MethodDecorator::None);
+                    self.apply_slots_constraints(db, name, result)
                 }
             }
         } else {
             // This attribute is neither declared nor bound in the class body.
             // It could still be implicitly defined in a method.
 
-            Self::implicit_attribute(db, body_scope, name, MethodDecorator::None)
+            let result = Self::implicit_attribute(db, body_scope, name, MethodDecorator::None);
+            self.apply_slots_constraints(db, name, result)
         }
     }
 
@@ -8317,6 +8319,84 @@ impl SlotsKind {
 
             _ => Self::Dynamic,
         }
+    }
+}
+
+/// Helper functions for __slots__ support
+impl<'db> ClassLiteral<'db> {
+    /// Extract the names of attributes defined in __slots__ as a set of strings.
+    /// Returns None if __slots__ is not defined, empty, or dynamic.
+    pub(super) fn slots_members(self, db: &'db dyn Db) -> Option<FxHashSet<String>> {
+        let Place::Type(slots_ty, bound) = self
+            .own_class_member(db, self.generic_context(db), None, "__slots__")
+            .place
+        else {
+            return None;
+        };
+
+        if matches!(bound, Boundness::PossiblyUnbound) {
+            return None;
+        }
+
+        match slots_ty {
+            // __slots__ = ("a", "b")
+            Type::NominalInstance(nominal) => {
+                if let Some(tuple_spec) = nominal.tuple_spec(db) {
+                    let mut slots = FxHashSet::default();
+                    for element in tuple_spec.all_elements() {
+                        if let Type::StringLiteral(string_literal) = element {
+                            slots.insert(string_literal.value(db).to_string());
+                        } else {
+                            // Non-string element, consider it dynamic
+                            return None;
+                        }
+                    }
+                    Some(slots)
+                } else {
+                    None
+                }
+            }
+
+            // __slots__ = "abc"  # Expands to slots "a", "b", "c"
+            Type::StringLiteral(string_literal) => {
+                let mut slots = FxHashSet::default();
+                let slot_value = string_literal.value(db);
+
+                // Python treats a bare string as a sequence of slot names (one per character)
+                for ch in slot_value.chars() {
+                    slots.insert(ch.to_string());
+                }
+                Some(slots)
+            }
+
+            _ => None,
+        }
+    }
+
+    /// Apply __slots__ constraints to attribute access.
+    fn apply_slots_constraints(
+        self,
+        db: &'db dyn Db,
+        name: &str,
+        result: PlaceAndQualifiers<'db>,
+    ) -> PlaceAndQualifiers<'db> {
+        // TODO: This function will be extended to support:
+        // - Inheritance: Check slots across the MRO chain
+        // - `__dict__` special case: Allow dynamic attributes when `__dict__` is in slots
+        
+        if let Some(slots) = self.slots_members(db) {
+            if slots.contains(name) {
+                // Attribute is in __slots__, so it's allowed even if not found elsewhere
+                if result.place.is_unbound() {
+                    // Return as possibly unbound since it's declared but not necessarily initialized
+                    return Place::Type(Type::unknown(), Boundness::PossiblyUnbound).into();
+                }
+                return result;
+            }
+            // Attribute is not in __slots__
+            return Place::Unbound.into();
+        }
+        result
     }
 }
 


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Implements initial `__slots__` type checking as requested in astral-sh/ty#1268. This is the first PR which has come from PR #20636 which ballooned in size trying to solve all of the issues requests.

Now, when a class defines `__slots__`, we restricts instance attribute access to only the names listed in the slots:

- Accessing an attribute not in __slots__ produces `unresolved-attribute`.
- Accessing a valid slot name that was never assigned does not produce a diagnostic (but returns `Unknown` type).
- `__slots__` defined as a string literal (e.g., `__slots__ = "xyz"`) is treated as a single slot name, not individual
characters.

For example, like Pyright, the following no longer produces `unresolved-attribute`:

```python
class Foo:
    __slots__ = ("bar",)

foo = Foo()
reveal_type(foo.bar)
```
