### PR TITLE
[ty] Teach the resolver that vendored copies of typeshed in the ty cache are in fact typeshed

### DIFF
--- a/crates/ty_python_semantic/Cargo.toml
+++ b/crates/ty_python_semantic/Cargo.toml
@@ -24,6 +24,7 @@ ruff_text_size = { workspace = true }
 ruff_python_literal = { workspace = true }
 ruff_python_trivia = { workspace = true }
 ty_static = { workspace = true }
+ty_vendored = { workspace = true }
 
 anyhow = { workspace = true }
 bitflags = { workspace = true }
@@ -58,7 +59,6 @@ ruff_python_parser = { workspace = true }
 ty_python_semantic = { workspace = true, features = ["testing"] }
 ty_static = { workspace = true }
 ty_test = { workspace = true }
-ty_vendored = { workspace = true }
 
 anyhow = { workspace = true }
 dir-test = { workspace = true }

--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -13,7 +13,7 @@ pub use diagnostic::add_inferred_python_version_hint_to_diagnostic;
 pub use module_name::{ModuleName, ModuleNameResolutionError};
 pub use module_resolver::{
     Module, SearchPath, SearchPathValidationError, SearchPaths, all_modules, list_modules,
-    resolve_module, resolve_real_module, system_module_search_paths,
+    resolve_module, resolve_real_module, system_module_search_paths, vendored_path_for_cache,
 };
 pub use program::{
     Program, ProgramSettings, PythonVersionFileSource, PythonVersionSource,

--- a/crates/ty_python_semantic/src/module_resolver/mod.rs
+++ b/crates/ty_python_semantic/src/module_resolver/mod.rs
@@ -3,7 +3,7 @@ use std::iter::FusedIterator;
 pub use list::{all_modules, list_modules};
 pub(crate) use module::KnownModule;
 pub use module::Module;
-pub use path::{SearchPath, SearchPathValidationError};
+pub use path::{SearchPath, SearchPathValidationError, vendored_path_for_cache};
 pub use resolver::SearchPaths;
 pub(crate) use resolver::file_to_module;
 pub use resolver::{resolve_module, resolve_real_module};


### PR DESCRIPTION
Fixes https://github.com/astral-sh/ty/issues/1054

I've confirmed it works on my machine in vscode, but it's not clear to me if there's a good way to test this in our test suite.