### PR TITLE
[ty] Fix out-of-order semantic token for function with regular argument after kwargs

### DIFF
--- a/crates/ty_ide/src/semantic_tokens.rs
+++ b/crates/ty_ide/src/semantic_tokens.rs
@@ -2274,7 +2274,7 @@ class C:
         "#);
     }
 
-    /// Regression test for https://github.com/astral-sh/ty/issues/1406
+    /// Regression test for <https://github.com/astral-sh/ty/issues/1406>
     #[test]
     fn test_invalid_kwargs() {
         let test = cursor_test(


### PR DESCRIPTION
## Summary

Fixes a bug where the semantic token provider returned out-of-order tokens for
function definitions with a regular parameter coming after a kwargs parameter:


```py
def foo(self, **key, value):
    return
```

The LSP specification isn't explicit whether out-of-order tokens are allowed, but
the way it reads suggests that providers are expected to return tokens in-order. 

The root cause for this issue is that `Parameters::iter()` only guarantees to
return the parameters in source order if there are no syntax errors because of how
parameters are represented internally (different vectors for the different parameter kinds). 

The ideal fix would be to change our `Parameters` definition but that's a bit more work,
which is why I decided to sort the parameters in place instead.

Fixes https://github.com/astral-sh/ty/issues/1406


## Test Plan

Added test
