### PR TITLE
[ty] Disable panicking mdtest

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -2551,11 +2551,13 @@ reveal_type(Answer.__members__)  # revealed: MappingProxyType[str, Unknown]
 ## Divergent inferred implicit instance attribute types
 
 ```py
-class C:
-    def f(self, other: "C"):
-        self.x = (other.x, 1)
+# TODO: This test currently panics, see https://github.com/astral-sh/ty/issues/837
 
-reveal_type(C().x)  # revealed: Unknown | tuple[Divergent, Literal[1]]
+# class C:
+#    def f(self, other: "C"):
+#        self.x = (other.x, 1)
+#
+# reveal_type(C().x)  # revealed: Unknown | tuple[Divergent, Literal[1]]
 ```
 
 ## Attributes of standard library modules that aren't yet defined

--- a/crates/ty_test/src/lib.rs
+++ b/crates/ty_test/src/lib.rs
@@ -323,26 +323,6 @@ fn run_test(
     let mut failures: Failures = test_files
         .iter()
         .filter_map(|test_file| {
-            let pull_types_result = attempt_test(
-                db,
-                pull_types,
-                test_file,
-                "\"pull types\"",
-                Some(
-                    "Note: either fix the panic or add the `<!-- pull-types:skip -->` \
-                    directive to this test",
-                ),
-            );
-            match pull_types_result {
-                Ok(()) => {}
-                Err(failures) => {
-                    any_pull_types_failures = true;
-                    if !test.should_skip_pulling_types() {
-                        return Some(failures);
-                    }
-                }
-            }
-
             let parsed = parsed_module(db, test_file.file).load(db);
 
             let mut diagnostics: Vec<Diagnostic> = parsed
@@ -385,6 +365,26 @@ fn run_test(
                     diagnostic.id() != DiagnosticId::RevealedType
                         && !diagnostic.id().is_lint_named(&UNDEFINED_REVEAL.name())
                 }));
+            }
+
+            let pull_types_result = attempt_test(
+                db,
+                pull_types,
+                test_file,
+                "\"pull types\"",
+                Some(
+                    "Note: either fix the panic or add the `<!-- pull-types:skip -->` \
+                    directive to this test",
+                ),
+            );
+            match pull_types_result {
+                Ok(()) => {}
+                Err(failures) => {
+                    any_pull_types_failures = true;
+                    if !test.should_skip_pulling_types() {
+                        return Some(failures);
+                    }
+                }
             }
 
             failure


### PR DESCRIPTION
## Summary

Only run the "pull types" test after performing the "actual" mdtest. We observed that the order matters. There is currently one mdtest which panics when checked in the CLI or the playground. With this change, it also panics in the mdtest suite.

reopens https://github.com/astral-sh/ty/issues/837?