### PR TITLE
[ty] Timeout based workspace diagnostic progress reports

### DIFF
--- a/crates/ty_server/src/server/api/requests/workspace_diagnostic.rs
+++ b/crates/ty_server/src/server/api/requests/workspace_diagnostic.rs
@@ -23,6 +23,7 @@ use ruff_db::files::File;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
+use std::sync::Mutex;
 use std::time::{Duration, Instant};
 use ty_project::{Db, ProgressReporter};
 
@@ -199,13 +200,13 @@ impl RetriableRequestHandler for WorkspaceDiagnosticRequestHandler {
 /// Diagnostics are only streamed if the client sends a partial result token.
 struct WorkspaceDiagnosticsProgressReporter<'a> {
     work_done: LazyWorkDoneProgress,
-    state: std::sync::Mutex<ProgressReporterState<'a>>,
+    state: Mutex<ProgressReporterState<'a>>,
 }
 
 impl<'a> WorkspaceDiagnosticsProgressReporter<'a> {
     fn new(work_done: LazyWorkDoneProgress, response: ResponseWriter<'a>) -> Self {
         Self {
-            state: std::sync::Mutex::new(ProgressReporterState {
+            state: Mutex::new(ProgressReporterState {
                 total_files: 0,
                 checked_files: 0,
                 last_response_sent: Instant::now(),


### PR DESCRIPTION
## Summary

This PR changes the workspace diagnostic's progress report (how many files were checked) from sending
a report for every 100th file to sending a report every 50ms. It makes ty feel snappier. 

The only motivation for having a timeout in the first place is to not overwhelm the client
(and not spend more time serializing messages than checking files ;) )

## Test Plan


https://github.com/user-attachments/assets/0c7513bb-8280-4196-9ca0-60fc6517a1b1

