### PR TITLE
[ty] Support goto-definition on vendored typeshed stubs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4376,6 +4376,7 @@ dependencies = [
  "tracing",
  "ty_project",
  "ty_python_semantic",
+ "ty_vendored",
 ]
 
 [[package]]
@@ -4504,7 +4505,6 @@ dependencies = [
  "ty_ide",
  "ty_project",
  "ty_python_semantic",
- "ty_vendored",
 ]
 
 [[package]]

--- a/crates/ty_ide/Cargo.toml
+++ b/crates/ty_ide/Cargo.toml
@@ -25,6 +25,7 @@ ruff_source_file = { workspace = true }
 ruff_text_size = { workspace = true }
 ty_python_semantic = { workspace = true }
 ty_project = { workspace = true, features = ["testing"] }
+ty_vendored = { workspace = true }
 
 get-size2 = { workspace = true }
 itertools = { workspace = true }

--- a/crates/ty_ide/src/lib.rs
+++ b/crates/ty_ide/src/lib.rs
@@ -45,7 +45,11 @@ pub use signature_help::{ParameterDetails, SignatureDetails, SignatureHelpInfo, 
 pub use symbols::{FlatSymbols, HierarchicalSymbols, SymbolId, SymbolInfo, SymbolKind};
 pub use workspace_symbols::{WorkspaceSymbolInfo, workspace_symbols};
 
-use ruff_db::files::{File, FileRange};
+use ruff_db::{
+    files::{File, FileRange},
+    system::SystemPathBuf,
+    vendored::VendoredPath,
+};
 use ruff_text_size::{Ranged, TextRange};
 use rustc_hash::FxHashSet;
 use std::ops::{Deref, DerefMut};
@@ -285,6 +289,38 @@ impl HasNavigationTargets for TypeDefinition<'_> {
             full_range: full_range.range(),
         })
     }
+}
+
+/// Get the cache-relative path where vendored paths should be written to.
+pub fn relative_cached_vendored_root() -> SystemPathBuf {
+    // The vendored files are uniquely identified by the source commit.
+    SystemPathBuf::from(format!("vendored/typeshed/{}", ty_vendored::SOURCE_COMMIT))
+}
+
+/// Get the cached version of a vendored path in the cache, ensuring the file is written to disk.
+pub fn cached_vendored_path(
+    db: &dyn ty_python_semantic::Db,
+    path: &VendoredPath,
+) -> Option<SystemPathBuf> {
+    let writable = db.system().as_writable()?;
+    let mut relative_path = relative_cached_vendored_root();
+    relative_path.push(path.as_str());
+
+    // Extract the vendored file onto the system.
+    writable
+        .get_or_cache(&relative_path, &|| db.vendored().read_to_string(path))
+        .ok()
+        .flatten()
+}
+
+/// Get the absolute root path of all cached vendored paths.
+///
+/// This does not ensure that this path exists (this is only used for mapping cached paths
+/// back to vendored ones, so this only matters if we've already been handed a path inside here).
+pub fn cached_vendored_root(db: &dyn ty_python_semantic::Db) -> Option<SystemPathBuf> {
+    let writable = db.system().as_writable()?;
+    let relative_root = relative_cached_vendored_root();
+    Some(writable.cache_dir()?.join(relative_root))
 }
 
 #[cfg(test)]

--- a/crates/ty_server/Cargo.toml
+++ b/crates/ty_server/Cargo.toml
@@ -22,7 +22,6 @@ ty_combine = { workspace = true }
 ty_ide = { workspace = true }
 ty_project = { workspace = true }
 ty_python_semantic = { workspace = true }
-ty_vendored = { workspace = true }
 
 anyhow = { workspace = true }
 bitflags = { workspace = true }


### PR DESCRIPTION
This is an alternative to #21012 that more narrowly handles this logic in the stub-mapping machinery rather than pervasively allowing us to identify cached files as typeshed stubs. Much of the logic is the same (pulling the logic out of ty_server so it can be reused).

I don't have a good sense for if one approach is "better" or "worse" in terms of like, semantics and Weird Bugs that this can cause. This one is just "less spooky in its broad consequences" and "less muddying of separation of concerns" and puts the extra logic on a much colder path. I won't be surprised if one day the previous implementation needs to be revisited for its more sweeping effects but for now this is good.

Fixes https://github.com/astral-sh/ty/issues/1054