### PR TITLE
[ty] Add assertions to ensure that we never call `KnownClass::Tuple.to_instance()` or similar

### DIFF
--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5950,7 +5950,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 .unwrap_or(InferableTypeVars::None);
             annotation.filter_disjoint_elements(
                 self.db(),
-                KnownClass::Tuple.to_instance(self.db()),
+                Type::homogeneous_tuple(self.db(), Type::unknown()),
                 inferable,
             )
         });


### PR DESCRIPTION
## Summary

This came up in https://github.com/astral-sh/ruff/pull/20988. It's usually a mistake to call `KnownClass::Tuple.to_instance()`; it will usually be more efficient and more correct to call `Type::homogeneous_tuple()` or `Type::heterogeneous_tuple()` instead. Add some debug assertions to ensure that we don't make this mistake.

I considered making these non-debug assertions, as the equality check _should_ be pretty cheap, but `KnownClass::to_instance()` is a pretty hot method, and I think it's exceedingly likely that debug assertions will catch this bug cropping up in the future.

I also removed the private helper method `Type::non_tuple_instance()` from `instance.rs`. It wasn't a zero-cost abstraction, it didn't save that much code, and it had to have a big warning doc-comment above it telling us never to make it public to code outside the module. All things considered, it was no longer worth it to keep it around.

## Test Plan

`cargo test -p ty_python_semantic`
