### PR TITLE
[`ruff`] Autogenerate TypeParam nodes

### DIFF
--- a/crates/ruff_python_ast/ast.toml
+++ b/crates/ruff_python_ast/ast.toml
@@ -605,10 +605,27 @@ fields = [{ name = "patterns", type = "Pattern*" }]
 [TypeParam]
 doc = "See also [type_param](https://docs.python.org/3/library/ast.html#ast.type_param)"
 
-[TypeParam.nodes]
-TypeParamTypeVar = {}
-TypeParamTypeVarTuple = {}
-TypeParamParamSpec = {}
+[TypeParam.nodes.TypeParamTypeVar]
+doc = "See also [TypeVar](https://docs.python.org/3/library/ast.html#ast.TypeVar)"
+fields = [
+  { name = "name", type = "Identifier" },
+  { name = "bound", type = "Box<Expr>?" },
+  { name = "default", type = "Box<Expr>?" },
+]
+
+[TypeParam.nodes.TypeParamTypeVarTuple]
+doc = "See also [TypeVarTuple](https://docs.python.org/3/library/ast.html#ast.TypeVarTuple)"
+fields = [
+  { name = "name", type = "Identifier" },
+  { name = "default", type = "Box<Expr>?" },
+]
+
+[TypeParam.nodes.TypeParamParamSpec]
+doc = "See also [ParamSpec](https://docs.python.org/3/library/ast.html#ast.ParamSpec)"
+fields = [
+  { name = "name", type = "Identifier" },
+  { name = "default", type = "Box<Expr>?" },
+]
 
 [ungrouped.nodes]
 InterpolatedStringFormatSpec = {}

--- a/crates/ruff_python_ast/src/generated.rs
+++ b/crates/ruff_python_ast/src/generated.rs
@@ -9713,6 +9713,37 @@ pub struct PatternMatchOr {
     pub patterns: Vec<Pattern>,
 }
 
+/// See also [TypeVar](https://docs.python.org/3/library/ast.html#ast.TypeVar)
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "get-size", derive(get_size2::GetSize))]
+pub struct TypeParamTypeVar {
+    pub node_index: crate::AtomicNodeIndex,
+    pub range: ruff_text_size::TextRange,
+    pub name: crate::Identifier,
+    pub bound: Option<Box<Expr>>,
+    pub default: Option<Box<Expr>>,
+}
+
+/// See also [TypeVarTuple](https://docs.python.org/3/library/ast.html#ast.TypeVarTuple)
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "get-size", derive(get_size2::GetSize))]
+pub struct TypeParamTypeVarTuple {
+    pub node_index: crate::AtomicNodeIndex,
+    pub range: ruff_text_size::TextRange,
+    pub name: crate::Identifier,
+    pub default: Option<Box<Expr>>,
+}
+
+/// See also [ParamSpec](https://docs.python.org/3/library/ast.html#ast.ParamSpec)
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "get-size", derive(get_size2::GetSize))]
+pub struct TypeParamParamSpec {
+    pub node_index: crate::AtomicNodeIndex,
+    pub range: ruff_text_size::TextRange,
+    pub name: crate::Identifier,
+    pub default: Option<Box<Expr>>,
+}
+
 impl ModModule {
     pub(crate) fn visit_source_order<'a, V>(&'a self, visitor: &mut V)
     where
@@ -10775,6 +10806,68 @@ impl PatternMatchOr {
 
         for elm in patterns {
             visitor.visit_pattern(elm);
+        }
+    }
+}
+
+impl TypeParamTypeVar {
+    pub(crate) fn visit_source_order<'a, V>(&'a self, visitor: &mut V)
+    where
+        V: SourceOrderVisitor<'a> + ?Sized,
+    {
+        let TypeParamTypeVar {
+            name,
+            bound,
+            default,
+            range: _,
+            node_index: _,
+        } = self;
+        visitor.visit_identifier(name);
+
+        if let Some(bound) = bound {
+            visitor.visit_expr(bound);
+        }
+
+        if let Some(default) = default {
+            visitor.visit_expr(default);
+        }
+    }
+}
+
+impl TypeParamTypeVarTuple {
+    pub(crate) fn visit_source_order<'a, V>(&'a self, visitor: &mut V)
+    where
+        V: SourceOrderVisitor<'a> + ?Sized,
+    {
+        let TypeParamTypeVarTuple {
+            name,
+            default,
+            range: _,
+            node_index: _,
+        } = self;
+        visitor.visit_identifier(name);
+
+        if let Some(default) = default {
+            visitor.visit_expr(default);
+        }
+    }
+}
+
+impl TypeParamParamSpec {
+    pub(crate) fn visit_source_order<'a, V>(&'a self, visitor: &mut V)
+    where
+        V: SourceOrderVisitor<'a> + ?Sized,
+    {
+        let TypeParamParamSpec {
+            name,
+            default,
+            range: _,
+            node_index: _,
+        } = self;
+        visitor.visit_identifier(name);
+
+        if let Some(default) = default {
+            visitor.visit_expr(default);
         }
     }
 }

--- a/crates/ruff_python_ast/src/node.rs
+++ b/crates/ruff_python_ast/src/node.rs
@@ -506,67 +506,6 @@ impl ast::TypeParams {
     }
 }
 
-impl ast::TypeParamTypeVar {
-    pub(crate) fn visit_source_order<'a, V>(&'a self, visitor: &mut V)
-    where
-        V: SourceOrderVisitor<'a> + ?Sized,
-    {
-        let ast::TypeParamTypeVar {
-            bound,
-            default,
-            name,
-            range: _,
-            node_index: _,
-        } = self;
-
-        visitor.visit_identifier(name);
-        if let Some(expr) = bound {
-            visitor.visit_expr(expr);
-        }
-        if let Some(expr) = default {
-            visitor.visit_expr(expr);
-        }
-    }
-}
-
-impl ast::TypeParamTypeVarTuple {
-    #[inline]
-    pub(crate) fn visit_source_order<'a, V>(&'a self, visitor: &mut V)
-    where
-        V: SourceOrderVisitor<'a> + ?Sized,
-    {
-        let ast::TypeParamTypeVarTuple {
-            range: _,
-            node_index: _,
-            name,
-            default,
-        } = self;
-        visitor.visit_identifier(name);
-        if let Some(expr) = default {
-            visitor.visit_expr(expr);
-        }
-    }
-}
-
-impl ast::TypeParamParamSpec {
-    #[inline]
-    pub(crate) fn visit_source_order<'a, V>(&'a self, visitor: &mut V)
-    where
-        V: SourceOrderVisitor<'a> + ?Sized,
-    {
-        let ast::TypeParamParamSpec {
-            range: _,
-            node_index: _,
-            name,
-            default,
-        } = self;
-        visitor.visit_identifier(name);
-        if let Some(expr) = default {
-            visitor.visit_expr(expr);
-        }
-    }
-}
-
 impl ast::FString {
     pub(crate) fn visit_source_order<'a, V>(&'a self, visitor: &mut V)
     where

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -2892,37 +2892,6 @@ impl TypeParam {
     }
 }
 
-/// See also [TypeVar](https://docs.python.org/3/library/ast.html#ast.TypeVar)
-#[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "get-size", derive(get_size2::GetSize))]
-pub struct TypeParamTypeVar {
-    pub range: TextRange,
-    pub node_index: AtomicNodeIndex,
-    pub name: Identifier,
-    pub bound: Option<Box<Expr>>,
-    pub default: Option<Box<Expr>>,
-}
-
-/// See also [ParamSpec](https://docs.python.org/3/library/ast.html#ast.ParamSpec)
-#[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "get-size", derive(get_size2::GetSize))]
-pub struct TypeParamParamSpec {
-    pub range: TextRange,
-    pub node_index: AtomicNodeIndex,
-    pub name: Identifier,
-    pub default: Option<Box<Expr>>,
-}
-
-/// See also [TypeVarTuple](https://docs.python.org/3/library/ast.html#ast.TypeVarTuple)
-#[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "get-size", derive(get_size2::GetSize))]
-pub struct TypeParamTypeVarTuple {
-    pub range: TextRange,
-    pub node_index: AtomicNodeIndex,
-    pub name: Identifier,
-    pub default: Option<Box<Expr>>,
-}
-
 /// See also [decorator](https://docs.python.org/3/library/ast.html#ast.decorator)
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "get-size", derive(get_size2::GetSize))]

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@class_def_unclosed_type_param_list.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@class_def_unclosed_type_param_list.py.snap
@@ -27,8 +27,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 10..12,
                                         node_index: NodeIndex(None),
+                                        range: 10..12,
                                         name: Identifier {
                                             id: Name("T1"),
                                             range: 10..12,
@@ -40,8 +40,8 @@ Module(
                                 ),
                                 TypeVarTuple(
                                     TypeParamTypeVarTuple {
-                                        range: 14..17,
                                         node_index: NodeIndex(None),
+                                        range: 14..17,
                                         name: Identifier {
                                             id: Name("T2"),
                                             range: 15..17,

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@class_type_params_py311.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@class_type_params_py311.py.snap
@@ -27,8 +27,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 54..69,
                                         node_index: NodeIndex(None),
+                                        range: 54..69,
                                         name: Identifier {
                                             id: Name("S"),
                                             range: 54..55,
@@ -67,8 +67,8 @@ Module(
                                 ),
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 71..79,
                                         node_index: NodeIndex(None),
+                                        range: 71..79,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 71..72,
@@ -89,8 +89,8 @@ Module(
                                 ),
                                 TypeVarTuple(
                                     TypeParamTypeVarTuple {
-                                        range: 81..84,
                                         node_index: NodeIndex(None),
+                                        range: 81..84,
                                         name: Identifier {
                                             id: Name("Ts"),
                                             range: 82..84,
@@ -101,8 +101,8 @@ Module(
                                 ),
                                 ParamSpec(
                                     TypeParamParamSpec {
-                                        range: 86..89,
                                         node_index: NodeIndex(None),
+                                        range: 86..89,
                                         name: Identifier {
                                             id: Name("P"),
                                             range: 88..89,

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@debug_shadow_class.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@debug_shadow_class.py.snap
@@ -55,8 +55,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 43..52,
                                         node_index: NodeIndex(None),
+                                        range: 43..52,
                                         name: Identifier {
                                             id: Name("__debug__"),
                                             range: 43..52,

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@debug_shadow_function.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@debug_shadow_function.py.snap
@@ -66,8 +66,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 44..53,
                                         node_index: NodeIndex(None),
+                                        range: 44..53,
                                         name: Identifier {
                                             id: Name("__debug__"),
                                             range: 44..53,

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@debug_shadow_type_alias.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@debug_shadow_type_alias.py.snap
@@ -67,8 +67,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 78..87,
                                         node_index: NodeIndex(None),
+                                        range: 78..87,
                                         name: Identifier {
                                             id: Name("__debug__"),
                                             range: 78..87,

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@duplicate_type_parameter_names.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@duplicate_type_parameter_names.py.snap
@@ -29,8 +29,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 11..12,
                                         node_index: NodeIndex(None),
+                                        range: 11..12,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 11..12,
@@ -42,8 +42,8 @@ Module(
                                 ),
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 14..15,
                                         node_index: NodeIndex(None),
+                                        range: 14..15,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 14..15,
@@ -82,8 +82,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 29..30,
                                         node_index: NodeIndex(None),
+                                        range: 29..30,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 29..30,
@@ -95,8 +95,8 @@ Module(
                                 ),
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 32..33,
                                         node_index: NodeIndex(None),
+                                        range: 32..33,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 32..33,
@@ -177,8 +177,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 54..55,
                                         node_index: NodeIndex(None),
+                                        range: 54..55,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 54..55,
@@ -190,8 +190,8 @@ Module(
                                 ),
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 57..58,
                                         node_index: NodeIndex(None),
+                                        range: 57..58,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 57..58,
@@ -240,8 +240,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 76..77,
                                         node_index: NodeIndex(None),
+                                        range: 76..77,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 76..77,
@@ -253,8 +253,8 @@ Module(
                                 ),
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 79..85,
                                         node_index: NodeIndex(None),
+                                        range: 79..85,
                                         name: Identifier {
                                             id: Name("U"),
                                             range: 79..80,
@@ -275,8 +275,8 @@ Module(
                                 ),
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 87..102,
                                         node_index: NodeIndex(None),
+                                        range: 87..102,
                                         name: Identifier {
                                             id: Name("V"),
                                             range: 87..88,
@@ -315,8 +315,8 @@ Module(
                                 ),
                                 TypeVarTuple(
                                     TypeParamTypeVarTuple {
-                                        range: 104..107,
                                         node_index: NodeIndex(None),
+                                        range: 104..107,
                                         name: Identifier {
                                             id: Name("Ts"),
                                             range: 105..107,
@@ -327,8 +327,8 @@ Module(
                                 ),
                                 ParamSpec(
                                     TypeParamParamSpec {
-                                        range: 109..112,
                                         node_index: NodeIndex(None),
+                                        range: 109..112,
                                         name: Identifier {
                                             id: Name("P"),
                                             range: 111..112,
@@ -339,8 +339,8 @@ Module(
                                 ),
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 114..125,
                                         node_index: NodeIndex(None),
+                                        range: 114..125,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 114..115,
@@ -388,8 +388,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 139..140,
                                         node_index: NodeIndex(None),
+                                        range: 139..140,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 139..140,
@@ -401,8 +401,8 @@ Module(
                                 ),
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 142..143,
                                         node_index: NodeIndex(None),
+                                        range: 142..143,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 142..143,
@@ -414,8 +414,8 @@ Module(
                                 ),
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 145..146,
                                         node_index: NodeIndex(None),
+                                        range: 145..146,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 145..146,
@@ -472,8 +472,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 175..176,
                                         node_index: NodeIndex(None),
+                                        range: 175..176,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 175..176,
@@ -485,8 +485,8 @@ Module(
                                 ),
                                 TypeVarTuple(
                                     TypeParamTypeVarTuple {
-                                        range: 178..180,
                                         node_index: NodeIndex(None),
+                                        range: 178..180,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 179..180,
@@ -542,8 +542,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 224..225,
                                         node_index: NodeIndex(None),
+                                        range: 224..225,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 224..225,
@@ -555,8 +555,8 @@ Module(
                                 ),
                                 ParamSpec(
                                     TypeParamParamSpec {
-                                        range: 227..230,
                                         node_index: NodeIndex(None),
+                                        range: 227..230,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 229..230,

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@function_def_unclosed_type_param_list.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@function_def_unclosed_type_param_list.py.snap
@@ -28,8 +28,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 8..10,
                                         node_index: NodeIndex(None),
+                                        range: 8..10,
                                         name: Identifier {
                                             id: Name("T1"),
                                             range: 8..10,
@@ -41,8 +41,8 @@ Module(
                                 ),
                                 TypeVarTuple(
                                     TypeParamTypeVarTuple {
-                                        range: 12..15,
                                         node_index: NodeIndex(None),
+                                        range: 12..15,
                                         name: Identifier {
                                             id: Name("T2"),
                                             range: 13..15,

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@function_type_params_py311.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@function_type_params_py311.py.snap
@@ -28,8 +28,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 52..53,
                                         node_index: NodeIndex(None),
+                                        range: 52..53,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 52..53,

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@invalid_annotation_class.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@invalid_annotation_class.py.snap
@@ -27,8 +27,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 8..9,
                                         node_index: NodeIndex(None),
+                                        range: 8..9,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 8..9,
@@ -105,8 +105,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 35..36,
                                         node_index: NodeIndex(None),
+                                        range: 35..36,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 35..36,
@@ -178,8 +178,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 62..63,
                                         node_index: NodeIndex(None),
+                                        range: 62..63,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 62..63,
@@ -249,8 +249,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 94..106,
                                         node_index: NodeIndex(None),
+                                        range: 94..106,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 94..95,
@@ -315,8 +315,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 145..156,
                                         node_index: NodeIndex(None),
+                                        range: 145..156,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 145..146,
@@ -387,8 +387,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 201..202,
                                         node_index: NodeIndex(None),
+                                        range: 201..202,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 201..202,
@@ -458,8 +458,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 228..240,
                                         node_index: NodeIndex(None),
+                                        range: 228..240,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 228..229,

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@invalid_annotation_function.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@invalid_annotation_function.py.snap
@@ -28,8 +28,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 6..7,
                                         node_index: NodeIndex(None),
+                                        range: 6..7,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 6..7,
@@ -102,8 +102,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 35..36,
                                         node_index: NodeIndex(None),
+                                        range: 35..36,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 35..36,
@@ -192,8 +192,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 65..66,
                                         node_index: NodeIndex(None),
+                                        range: 65..66,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 65..66,
@@ -274,8 +274,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 93..94,
                                         node_index: NodeIndex(None),
+                                        range: 93..94,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 93..94,
@@ -372,8 +372,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 122..123,
                                         node_index: NodeIndex(None),
+                                        range: 122..123,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 122..123,
@@ -464,8 +464,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 150..151,
                                         node_index: NodeIndex(None),
+                                        range: 150..151,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 150..151,
@@ -540,8 +540,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 179..180,
                                         node_index: NodeIndex(None),
+                                        range: 179..180,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 179..180,
@@ -630,8 +630,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 212..213,
                                         node_index: NodeIndex(None),
+                                        range: 212..213,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 212..213,
@@ -704,8 +704,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 246..258,
                                         node_index: NodeIndex(None),
+                                        range: 246..258,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 246..247,
@@ -780,8 +780,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 303..316,
                                         node_index: NodeIndex(None),
+                                        range: 303..316,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 303..304,
@@ -856,8 +856,8 @@ Module(
                             type_params: [
                                 TypeVarTuple(
                                     TypeParamTypeVarTuple {
-                                        range: 362..377,
                                         node_index: NodeIndex(None),
+                                        range: 362..377,
                                         name: Identifier {
                                             id: Name("Ts"),
                                             range: 363..365,
@@ -931,8 +931,8 @@ Module(
                             type_params: [
                                 ParamSpec(
                                     TypeParamParamSpec {
-                                        range: 426..442,
                                         node_index: NodeIndex(None),
+                                        range: 426..442,
                                         name: Identifier {
                                             id: Name("Ts"),
                                             range: 428..430,
@@ -1006,8 +1006,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 487..498,
                                         node_index: NodeIndex(None),
+                                        range: 487..498,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 487..488,
@@ -1088,8 +1088,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 549..561,
                                         node_index: NodeIndex(None),
+                                        range: 549..561,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 549..550,
@@ -1170,8 +1170,8 @@ Module(
                             type_params: [
                                 TypeVarTuple(
                                     TypeParamTypeVarTuple {
-                                        range: 613..627,
                                         node_index: NodeIndex(None),
+                                        range: 613..627,
                                         name: Identifier {
                                             id: Name("Ts"),
                                             range: 614..616,
@@ -1251,8 +1251,8 @@ Module(
                             type_params: [
                                 ParamSpec(
                                     TypeParamParamSpec {
-                                        range: 682..697,
                                         node_index: NodeIndex(None),
+                                        range: 682..697,
                                         name: Identifier {
                                             id: Name("Ts"),
                                             range: 684..686,
@@ -1332,8 +1332,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 748..760,
                                         node_index: NodeIndex(None),
+                                        range: 748..760,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 748..749,
@@ -1406,8 +1406,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 806..819,
                                         node_index: NodeIndex(None),
+                                        range: 806..819,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 806..807,
@@ -1480,8 +1480,8 @@ Module(
                             type_params: [
                                 TypeVarTuple(
                                     TypeParamTypeVarTuple {
-                                        range: 866..881,
                                         node_index: NodeIndex(None),
+                                        range: 866..881,
                                         name: Identifier {
                                             id: Name("Ts"),
                                             range: 867..869,
@@ -1553,8 +1553,8 @@ Module(
                             type_params: [
                                 ParamSpec(
                                     TypeParamParamSpec {
-                                        range: 931..947,
                                         node_index: NodeIndex(None),
+                                        range: 931..947,
                                         name: Identifier {
                                             id: Name("Ts"),
                                             range: 933..935,

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@invalid_annotation_type_alias.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@invalid_annotation_type_alias.py.snap
@@ -29,8 +29,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 7..19,
                                         node_index: NodeIndex(None),
+                                        range: 7..19,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 7..8,
@@ -90,8 +90,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 55..68,
                                         node_index: NodeIndex(None),
+                                        range: 55..68,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 55..56,
@@ -151,8 +151,8 @@ Module(
                             type_params: [
                                 TypeVarTuple(
                                     TypeParamTypeVarTuple {
-                                        range: 105..120,
                                         node_index: NodeIndex(None),
+                                        range: 105..120,
                                         name: Identifier {
                                             id: Name("Ts"),
                                             range: 106..108,
@@ -211,8 +211,8 @@ Module(
                             type_params: [
                                 ParamSpec(
                                     TypeParamParamSpec {
-                                        range: 160..176,
                                         node_index: NodeIndex(None),
+                                        range: 160..176,
                                         name: Identifier {
                                             id: Name("Ts"),
                                             range: 162..164,
@@ -341,8 +341,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 315..327,
                                         node_index: NodeIndex(None),
+                                        range: 315..327,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 315..316,

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@statements__function_type_parameters.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@statements__function_type_parameters.py.snap
@@ -28,8 +28,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 808..809,
                                         node_index: NodeIndex(None),
+                                        range: 808..809,
                                         name: Identifier {
                                             id: Name("A"),
                                             range: 808..809,
@@ -41,8 +41,8 @@ Module(
                                 ),
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 811..816,
                                         node_index: NodeIndex(None),
+                                        range: 811..816,
                                         name: Identifier {
                                             id: Name("await"),
                                             range: 811..816,
@@ -99,8 +99,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 847..848,
                                         node_index: NodeIndex(None),
+                                        range: 847..848,
                                         name: Identifier {
                                             id: Name("A"),
                                             range: 847..848,
@@ -112,8 +112,8 @@ Module(
                                 ),
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 853..854,
                                         node_index: NodeIndex(None),
+                                        range: 853..854,
                                         name: Identifier {
                                             id: Name("B"),
                                             range: 853..854,
@@ -170,8 +170,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 884..885,
                                         node_index: NodeIndex(None),
+                                        range: 884..885,
                                         name: Identifier {
                                             id: Name("A"),
                                             range: 884..885,
@@ -183,8 +183,8 @@ Module(
                                 ),
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 887..888,
                                         node_index: NodeIndex(None),
+                                        range: 887..888,
                                         name: Identifier {
                                             id: Name("B"),
                                             range: 887..888,
@@ -241,8 +241,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 927..928,
                                         node_index: NodeIndex(None),
+                                        range: 927..928,
                                         name: Identifier {
                                             id: Name("A"),
                                             range: 927..928,
@@ -299,8 +299,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 973..974,
                                         node_index: NodeIndex(None),
+                                        range: 973..974,
                                         name: Identifier {
                                             id: Name("A"),
                                             range: 973..974,

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@type_param_default_py312.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@type_param_default_py312.py.snap
@@ -29,8 +29,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 51..58,
                                         node_index: NodeIndex(None),
+                                        range: 51..58,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 51..52,
@@ -80,8 +80,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 72..79,
                                         node_index: NodeIndex(None),
+                                        range: 72..79,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 72..73,
@@ -146,8 +146,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 96..103,
                                         node_index: NodeIndex(None),
+                                        range: 96..103,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 96..97,
@@ -210,8 +210,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 120..121,
                                         node_index: NodeIndex(None),
+                                        range: 120..121,
                                         name: Identifier {
                                             id: Name("S"),
                                             range: 120..121,
@@ -223,8 +223,8 @@ Module(
                                 ),
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 123..130,
                                         node_index: NodeIndex(None),
+                                        range: 123..130,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 123..124,
@@ -245,8 +245,8 @@ Module(
                                 ),
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 132..140,
                                         node_index: NodeIndex(None),
+                                        range: 132..140,
                                         name: Identifier {
                                             id: Name("U"),
                                             range: 132..133,

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@type_param_invalid_bound_expr.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@type_param_invalid_bound_expr.py.snap
@@ -29,8 +29,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 7..14,
                                         node_index: NodeIndex(None),
+                                        range: 7..14,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 7..8,
@@ -88,8 +88,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 29..39,
                                         node_index: NodeIndex(None),
+                                        range: 29..39,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 29..30,
@@ -148,8 +148,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 54..69,
                                         node_index: NodeIndex(None),
+                                        range: 54..69,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 54..55,
@@ -206,8 +206,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 84..88,
                                         node_index: NodeIndex(None),
+                                        range: 84..88,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 84..85,
@@ -228,8 +228,8 @@ Module(
                                 ),
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 92..95,
                                         node_index: NodeIndex(None),
+                                        range: 92..95,
                                         name: Identifier {
                                             id: Name("int"),
                                             range: 92..95,

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@type_param_missing_bound.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@type_param_missing_bound.py.snap
@@ -29,8 +29,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 7..9,
                                         node_index: NodeIndex(None),
+                                        range: 7..9,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 7..8,
@@ -72,8 +72,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 25..28,
                                         node_index: NodeIndex(None),
+                                        range: 25..28,
                                         name: Identifier {
                                             id: Name("T1"),
                                             range: 25..27,
@@ -85,8 +85,8 @@ Module(
                                 ),
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 31..33,
                                         node_index: NodeIndex(None),
+                                        range: 31..33,
                                         name: Identifier {
                                             id: Name("T2"),
                                             range: 31..33,

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@type_param_param_spec_bound.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@type_param_param_spec_bound.py.snap
@@ -29,8 +29,8 @@ Module(
                             type_params: [
                                 ParamSpec(
                                     TypeParamParamSpec {
-                                        range: 7..10,
                                         node_index: NodeIndex(None),
+                                        range: 7..10,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 9..10,

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@type_param_param_spec_invalid_default_expr.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@type_param_param_spec_invalid_default_expr.py.snap
@@ -29,8 +29,8 @@ Module(
                             type_params: [
                                 ParamSpec(
                                     TypeParamParamSpec {
-                                        range: 7..17,
                                         node_index: NodeIndex(None),
+                                        range: 7..17,
                                         name: Identifier {
                                             id: Name("P"),
                                             range: 9..10,
@@ -87,8 +87,8 @@ Module(
                             type_params: [
                                 ParamSpec(
                                     TypeParamParamSpec {
-                                        range: 32..45,
                                         node_index: NodeIndex(None),
+                                        range: 32..45,
                                         name: Identifier {
                                             id: Name("P"),
                                             range: 34..35,
@@ -146,8 +146,8 @@ Module(
                             type_params: [
                                 ParamSpec(
                                     TypeParamParamSpec {
-                                        range: 60..78,
                                         node_index: NodeIndex(None),
+                                        range: 60..78,
                                         name: Identifier {
                                             id: Name("P"),
                                             range: 62..63,
@@ -203,8 +203,8 @@ Module(
                             type_params: [
                                 ParamSpec(
                                     TypeParamParamSpec {
-                                        range: 93..100,
                                         node_index: NodeIndex(None),
+                                        range: 93..100,
                                         name: Identifier {
                                             id: Name("P"),
                                             range: 95..96,
@@ -224,8 +224,8 @@ Module(
                                 ),
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 104..107,
                                         node_index: NodeIndex(None),
+                                        range: 104..107,
                                         name: Identifier {
                                             id: Name("int"),
                                             range: 104..107,
@@ -267,8 +267,8 @@ Module(
                             type_params: [
                                 ParamSpec(
                                     TypeParamParamSpec {
-                                        range: 122..132,
                                         node_index: NodeIndex(None),
+                                        range: 122..132,
                                         name: Identifier {
                                             id: Name("P"),
                                             range: 124..125,

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@type_param_param_spec_missing_default.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@type_param_param_spec_missing_default.py.snap
@@ -29,8 +29,8 @@ Module(
                             type_params: [
                                 ParamSpec(
                                     TypeParamParamSpec {
-                                        range: 7..12,
                                         node_index: NodeIndex(None),
+                                        range: 7..12,
                                         name: Identifier {
                                             id: Name("P"),
                                             range: 9..10,
@@ -71,8 +71,8 @@ Module(
                             type_params: [
                                 ParamSpec(
                                     TypeParamParamSpec {
-                                        range: 27..32,
                                         node_index: NodeIndex(None),
+                                        range: 27..32,
                                         name: Identifier {
                                             id: Name("P"),
                                             range: 29..30,
@@ -83,8 +83,8 @@ Module(
                                 ),
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 34..36,
                                         node_index: NodeIndex(None),
+                                        range: 34..36,
                                         name: Identifier {
                                             id: Name("T2"),
                                             range: 34..36,

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@type_param_type_var_invalid_default_expr.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@type_param_type_var_invalid_default_expr.py.snap
@@ -29,8 +29,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 7..15,
                                         node_index: NodeIndex(None),
+                                        range: 7..15,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 7..8,
@@ -88,8 +88,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 30..41,
                                         node_index: NodeIndex(None),
+                                        range: 30..41,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 30..31,
@@ -148,8 +148,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 56..69,
                                         node_index: NodeIndex(None),
+                                        range: 56..69,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 56..57,
@@ -208,8 +208,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 84..100,
                                         node_index: NodeIndex(None),
+                                        range: 84..100,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 84..85,
@@ -266,8 +266,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 115..120,
                                         node_index: NodeIndex(None),
+                                        range: 115..120,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 115..116,
@@ -288,8 +288,8 @@ Module(
                                 ),
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 124..127,
                                         node_index: NodeIndex(None),
+                                        range: 124..127,
                                         name: Identifier {
                                             id: Name("int"),
                                             range: 124..127,
@@ -331,8 +331,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 142..155,
                                         node_index: NodeIndex(None),
+                                        range: 142..155,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 142..143,

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@type_param_type_var_missing_default.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@type_param_type_var_missing_default.py.snap
@@ -29,8 +29,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 7..10,
                                         node_index: NodeIndex(None),
+                                        range: 7..10,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 7..8,
@@ -72,8 +72,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 25..33,
                                         node_index: NodeIndex(None),
+                                        range: 25..33,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 25..26,
@@ -124,8 +124,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 48..52,
                                         node_index: NodeIndex(None),
+                                        range: 48..52,
                                         name: Identifier {
                                             id: Name("T1"),
                                             range: 48..50,
@@ -137,8 +137,8 @@ Module(
                                 ),
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 54..56,
                                         node_index: NodeIndex(None),
+                                        range: 54..56,
                                         name: Identifier {
                                             id: Name("T2"),
                                             range: 54..56,

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@type_param_type_var_tuple_bound.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@type_param_type_var_tuple_bound.py.snap
@@ -29,8 +29,8 @@ Module(
                             type_params: [
                                 TypeVarTuple(
                                     TypeParamTypeVarTuple {
-                                        range: 7..9,
                                         node_index: NodeIndex(None),
+                                        range: 7..9,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 8..9,

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@type_param_type_var_tuple_invalid_default_expr.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@type_param_type_var_tuple_invalid_default_expr.py.snap
@@ -29,8 +29,8 @@ Module(
                             type_params: [
                                 TypeVarTuple(
                                     TypeParamTypeVarTuple {
-                                        range: 7..17,
                                         node_index: NodeIndex(None),
+                                        range: 7..17,
                                         name: Identifier {
                                             id: Name("Ts"),
                                             range: 8..10,
@@ -87,8 +87,8 @@ Module(
                             type_params: [
                                 TypeVarTuple(
                                     TypeParamTypeVarTuple {
-                                        range: 32..49,
                                         node_index: NodeIndex(None),
+                                        range: 32..49,
                                         name: Identifier {
                                             id: Name("Ts"),
                                             range: 33..35,
@@ -162,8 +162,8 @@ Module(
                             type_params: [
                                 TypeVarTuple(
                                     TypeParamTypeVarTuple {
-                                        range: 64..77,
                                         node_index: NodeIndex(None),
+                                        range: 64..77,
                                         name: Identifier {
                                             id: Name("Ts"),
                                             range: 65..67,
@@ -221,8 +221,8 @@ Module(
                             type_params: [
                                 TypeVarTuple(
                                     TypeParamTypeVarTuple {
-                                        range: 92..110,
                                         node_index: NodeIndex(None),
+                                        range: 92..110,
                                         name: Identifier {
                                             id: Name("Ts"),
                                             range: 93..95,
@@ -278,8 +278,8 @@ Module(
                             type_params: [
                                 TypeVarTuple(
                                     TypeParamTypeVarTuple {
-                                        range: 125..132,
                                         node_index: NodeIndex(None),
+                                        range: 125..132,
                                         name: Identifier {
                                             id: Name("Ts"),
                                             range: 126..128,
@@ -299,8 +299,8 @@ Module(
                                 ),
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 136..139,
                                         node_index: NodeIndex(None),
+                                        range: 136..139,
                                         name: Identifier {
                                             id: Name("int"),
                                             range: 136..139,

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@type_param_type_var_tuple_missing_default.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@type_param_type_var_tuple_missing_default.py.snap
@@ -29,8 +29,8 @@ Module(
                             type_params: [
                                 TypeVarTuple(
                                     TypeParamTypeVarTuple {
-                                        range: 7..12,
                                         node_index: NodeIndex(None),
+                                        range: 7..12,
                                         name: Identifier {
                                             id: Name("Ts"),
                                             range: 8..10,
@@ -71,8 +71,8 @@ Module(
                             type_params: [
                                 TypeVarTuple(
                                     TypeParamTypeVarTuple {
-                                        range: 27..32,
                                         node_index: NodeIndex(None),
+                                        range: 27..32,
                                         name: Identifier {
                                             id: Name("Ts"),
                                             range: 28..30,
@@ -83,8 +83,8 @@ Module(
                                 ),
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 34..36,
                                         node_index: NodeIndex(None),
+                                        range: 34..36,
                                         name: Identifier {
                                             id: Name("T2"),
                                             range: 34..36,

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@class_type_params_py312.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@class_type_params_py312.py.snap
@@ -27,8 +27,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 54..69,
                                         node_index: NodeIndex(None),
+                                        range: 54..69,
                                         name: Identifier {
                                             id: Name("S"),
                                             range: 54..55,
@@ -67,8 +67,8 @@ Module(
                                 ),
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 71..79,
                                         node_index: NodeIndex(None),
+                                        range: 71..79,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 71..72,
@@ -89,8 +89,8 @@ Module(
                                 ),
                                 TypeVarTuple(
                                     TypeParamTypeVarTuple {
-                                        range: 81..84,
                                         node_index: NodeIndex(None),
+                                        range: 81..84,
                                         name: Identifier {
                                             id: Name("Ts"),
                                             range: 82..84,
@@ -101,8 +101,8 @@ Module(
                                 ),
                                 ParamSpec(
                                     TypeParamParamSpec {
-                                        range: 86..89,
                                         node_index: NodeIndex(None),
+                                        range: 86..89,
                                         name: Identifier {
                                             id: Name("P"),
                                             range: 88..89,

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@function_type_params_py312.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@function_type_params_py312.py.snap
@@ -28,8 +28,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 52..53,
                                         node_index: NodeIndex(None),
+                                        range: 52..53,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 52..53,

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@non_duplicate_type_parameter_names.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@non_duplicate_type_parameter_names.py.snap
@@ -29,8 +29,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 11..12,
                                         node_index: NodeIndex(None),
+                                        range: 11..12,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 11..12,
@@ -86,8 +86,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 30..31,
                                         node_index: NodeIndex(None),
+                                        range: 30..31,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 30..31,
@@ -168,8 +168,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 52..53,
                                         node_index: NodeIndex(None),
+                                        range: 52..53,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 52..53,
@@ -216,8 +216,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 68..69,
                                         node_index: NodeIndex(None),
+                                        range: 68..69,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 68..69,
@@ -229,8 +229,8 @@ Module(
                                 ),
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 71..72,
                                         node_index: NodeIndex(None),
+                                        range: 71..72,
                                         name: Identifier {
                                             id: Name("U"),
                                             range: 71..72,
@@ -242,8 +242,8 @@ Module(
                                 ),
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 74..75,
                                         node_index: NodeIndex(None),
+                                        range: 74..75,
                                         name: Identifier {
                                             id: Name("V"),
                                             range: 74..75,
@@ -292,8 +292,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 93..94,
                                         node_index: NodeIndex(None),
+                                        range: 93..94,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 93..94,
@@ -305,8 +305,8 @@ Module(
                                 ),
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 96..102,
                                         node_index: NodeIndex(None),
+                                        range: 96..102,
                                         name: Identifier {
                                             id: Name("U"),
                                             range: 96..97,
@@ -327,8 +327,8 @@ Module(
                                 ),
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 104..119,
                                         node_index: NodeIndex(None),
+                                        range: 104..119,
                                         name: Identifier {
                                             id: Name("V"),
                                             range: 104..105,
@@ -367,8 +367,8 @@ Module(
                                 ),
                                 TypeVarTuple(
                                     TypeParamTypeVarTuple {
-                                        range: 121..124,
                                         node_index: NodeIndex(None),
+                                        range: 121..124,
                                         name: Identifier {
                                             id: Name("Ts"),
                                             range: 122..124,
@@ -379,8 +379,8 @@ Module(
                                 ),
                                 ParamSpec(
                                     TypeParamParamSpec {
-                                        range: 126..129,
                                         node_index: NodeIndex(None),
+                                        range: 126..129,
                                         name: Identifier {
                                             id: Name("P"),
                                             range: 128..129,
@@ -391,8 +391,8 @@ Module(
                                 ),
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 131..142,
                                         node_index: NodeIndex(None),
+                                        range: 131..142,
                                         name: Identifier {
                                             id: Name("D"),
                                             range: 131..132,

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__class.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__class.py.snap
@@ -468,8 +468,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 342..343,
                                         node_index: NodeIndex(None),
+                                        range: 342..343,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 342..343,
@@ -523,8 +523,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 387..394,
                                         node_index: NodeIndex(None),
+                                        range: 387..394,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 387..388,
@@ -587,8 +587,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 436..442,
                                         node_index: NodeIndex(None),
+                                        range: 436..442,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 436..437,
@@ -651,8 +651,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 496..514,
                                         node_index: NodeIndex(None),
+                                        range: 496..514,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 496..497,
@@ -739,8 +739,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 562..577,
                                         node_index: NodeIndex(None),
+                                        range: 562..577,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 562..563,
@@ -821,8 +821,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 617..618,
                                         node_index: NodeIndex(None),
+                                        range: 617..618,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 617..618,
@@ -834,8 +834,8 @@ Module(
                                 ),
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 620..621,
                                         node_index: NodeIndex(None),
+                                        range: 620..621,
                                         name: Identifier {
                                             id: Name("U"),
                                             range: 620..621,
@@ -889,8 +889,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 659..660,
                                         node_index: NodeIndex(None),
+                                        range: 659..660,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 659..660,
@@ -902,8 +902,8 @@ Module(
                                 ),
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 662..663,
                                         node_index: NodeIndex(None),
+                                        range: 662..663,
                                         name: Identifier {
                                             id: Name("U"),
                                             range: 662..663,
@@ -957,8 +957,8 @@ Module(
                             type_params: [
                                 TypeVarTuple(
                                     TypeParamTypeVarTuple {
-                                        range: 700..703,
                                         node_index: NodeIndex(None),
+                                        range: 700..703,
                                         name: Identifier {
                                             id: Name("Ts"),
                                             range: 701..703,
@@ -1011,8 +1011,8 @@ Module(
                             type_params: [
                                 TypeVarTuple(
                                     TypeParamTypeVarTuple {
-                                        range: 752..781,
                                         node_index: NodeIndex(None),
+                                        range: 752..781,
                                         name: Identifier {
                                             id: Name("Ts"),
                                             range: 753..755,
@@ -1122,8 +1122,8 @@ Module(
                             type_params: [
                                 TypeVarTuple(
                                     TypeParamTypeVarTuple {
-                                        range: 838..860,
                                         node_index: NodeIndex(None),
+                                        range: 838..860,
                                         name: Identifier {
                                             id: Name("Ts"),
                                             range: 839..841,
@@ -1225,8 +1225,8 @@ Module(
                             type_params: [
                                 ParamSpec(
                                     TypeParamParamSpec {
-                                        range: 893..896,
                                         node_index: NodeIndex(None),
+                                        range: 893..896,
                                         name: Identifier {
                                             id: Name("P"),
                                             range: 895..896,
@@ -1279,8 +1279,8 @@ Module(
                             type_params: [
                                 ParamSpec(
                                     TypeParamParamSpec {
-                                        range: 942..958,
                                         node_index: NodeIndex(None),
+                                        range: 942..958,
                                         name: Identifier {
                                             id: Name("P"),
                                             range: 944..945,
@@ -1359,8 +1359,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 993..994,
                                         node_index: NodeIndex(None),
+                                        range: 993..994,
                                         name: Identifier {
                                             id: Name("X"),
                                             range: 993..994,
@@ -1372,8 +1372,8 @@ Module(
                                 ),
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 996..1002,
                                         node_index: NodeIndex(None),
+                                        range: 996..1002,
                                         name: Identifier {
                                             id: Name("Y"),
                                             range: 996..997,
@@ -1394,8 +1394,8 @@ Module(
                                 ),
                                 TypeVarTuple(
                                     TypeParamTypeVarTuple {
-                                        range: 1004..1006,
                                         node_index: NodeIndex(None),
+                                        range: 1004..1006,
                                         name: Identifier {
                                             id: Name("U"),
                                             range: 1005..1006,
@@ -1406,8 +1406,8 @@ Module(
                                 ),
                                 ParamSpec(
                                     TypeParamParamSpec {
-                                        range: 1008..1011,
                                         node_index: NodeIndex(None),
+                                        range: 1008..1011,
                                         name: Identifier {
                                             id: Name("P"),
                                             range: 1010..1011,

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__function.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__function.py.snap
@@ -2387,8 +2387,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 1712..1713,
                                         node_index: NodeIndex(None),
+                                        range: 1712..1713,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 1712..1713,
@@ -2473,8 +2473,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 1747..1753,
                                         node_index: NodeIndex(None),
+                                        range: 1747..1753,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 1747..1748,
@@ -2568,8 +2568,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 1787..1802,
                                         node_index: NodeIndex(None),
+                                        range: 1787..1802,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 1787..1788,
@@ -2681,8 +2681,8 @@ Module(
                             type_params: [
                                 TypeVarTuple(
                                     TypeParamTypeVarTuple {
-                                        range: 1836..1839,
                                         node_index: NodeIndex(None),
+                                        range: 1836..1839,
                                         name: Identifier {
                                             id: Name("Ts"),
                                             range: 1837..1839,
@@ -2800,8 +2800,8 @@ Module(
                             type_params: [
                                 ParamSpec(
                                     TypeParamParamSpec {
-                                        range: 1885..1888,
                                         node_index: NodeIndex(None),
+                                        range: 1885..1888,
                                         name: Identifier {
                                             id: Name("P"),
                                             range: 1887..1888,
@@ -2915,8 +2915,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 1946..1947,
                                         node_index: NodeIndex(None),
+                                        range: 1946..1947,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 1946..1947,
@@ -2928,8 +2928,8 @@ Module(
                                 ),
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 1949..1955,
                                         node_index: NodeIndex(None),
+                                        range: 1949..1955,
                                         name: Identifier {
                                             id: Name("U"),
                                             range: 1949..1950,
@@ -2950,8 +2950,8 @@ Module(
                                 ),
                                 TypeVarTuple(
                                     TypeParamTypeVarTuple {
-                                        range: 1957..1960,
                                         node_index: NodeIndex(None),
+                                        range: 1957..1960,
                                         name: Identifier {
                                             id: Name("Ts"),
                                             range: 1958..1960,
@@ -2962,8 +2962,8 @@ Module(
                                 ),
                                 ParamSpec(
                                     TypeParamParamSpec {
-                                        range: 1962..1965,
                                         node_index: NodeIndex(None),
+                                        range: 1962..1965,
                                         name: Identifier {
                                             id: Name("P"),
                                             range: 1964..1965,

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__type.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__type.py.snap
@@ -141,8 +141,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 68..69,
                                         node_index: NodeIndex(None),
+                                        range: 68..69,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 68..69,
@@ -229,8 +229,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 108..109,
                                         node_index: NodeIndex(None),
+                                        range: 108..109,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 108..109,
@@ -272,8 +272,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 124..125,
                                         node_index: NodeIndex(None),
+                                        range: 124..125,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 124..125,
@@ -360,8 +360,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 153..154,
                                         node_index: NodeIndex(None),
+                                        range: 153..154,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 153..154,
@@ -373,8 +373,8 @@ Module(
                                 ),
                                 TypeVarTuple(
                                     TypeParamTypeVarTuple {
-                                        range: 156..159,
                                         node_index: NodeIndex(None),
+                                        range: 156..159,
                                         name: Identifier {
                                             id: Name("Ts"),
                                             range: 157..159,
@@ -385,8 +385,8 @@ Module(
                                 ),
                                 ParamSpec(
                                     TypeParamParamSpec {
-                                        range: 161..164,
                                         node_index: NodeIndex(None),
+                                        range: 161..164,
                                         name: Identifier {
                                             id: Name("P"),
                                             range: 163..164,
@@ -453,8 +453,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 186..192,
                                         node_index: NodeIndex(None),
+                                        range: 186..192,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 186..187,
@@ -475,8 +475,8 @@ Module(
                                 ),
                                 TypeVarTuple(
                                     TypeParamTypeVarTuple {
-                                        range: 194..197,
                                         node_index: NodeIndex(None),
+                                        range: 194..197,
                                         name: Identifier {
                                             id: Name("Ts"),
                                             range: 195..197,
@@ -487,8 +487,8 @@ Module(
                                 ),
                                 ParamSpec(
                                     TypeParamParamSpec {
-                                        range: 199..202,
                                         node_index: NodeIndex(None),
+                                        range: 199..202,
                                         name: Identifier {
                                             id: Name("P"),
                                             range: 201..202,
@@ -555,8 +555,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 224..237,
                                         node_index: NodeIndex(None),
+                                        range: 224..237,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 224..225,
@@ -595,8 +595,8 @@ Module(
                                 ),
                                 TypeVarTuple(
                                     TypeParamTypeVarTuple {
-                                        range: 239..242,
                                         node_index: NodeIndex(None),
+                                        range: 239..242,
                                         name: Identifier {
                                             id: Name("Ts"),
                                             range: 240..242,
@@ -607,8 +607,8 @@ Module(
                                 ),
                                 ParamSpec(
                                     TypeParamParamSpec {
-                                        range: 244..247,
                                         node_index: NodeIndex(None),
+                                        range: 244..247,
                                         name: Identifier {
                                             id: Name("P"),
                                             range: 246..247,
@@ -675,8 +675,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 269..276,
                                         node_index: NodeIndex(None),
+                                        range: 269..276,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 269..270,
@@ -742,8 +742,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 295..313,
                                         node_index: NodeIndex(None),
+                                        range: 295..313,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 295..296,
@@ -848,8 +848,8 @@ Module(
                             type_params: [
                                 TypeVarTuple(
                                     TypeParamTypeVarTuple {
-                                        range: 338..360,
                                         node_index: NodeIndex(None),
+                                        range: 338..360,
                                         name: Identifier {
                                             id: Name("Ts"),
                                             range: 339..341,
@@ -987,8 +987,8 @@ Module(
                             type_params: [
                                 ParamSpec(
                                     TypeParamParamSpec {
-                                        range: 392..408,
                                         node_index: NodeIndex(None),
+                                        range: 392..408,
                                         name: Identifier {
                                             id: Name("P"),
                                             range: 394..395,
@@ -1318,8 +1318,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 687..688,
                                         node_index: NodeIndex(None),
+                                        range: 687..688,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 687..688,
@@ -1361,8 +1361,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 708..709,
                                         node_index: NodeIndex(None),
+                                        range: 708..709,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 708..709,
@@ -1404,8 +1404,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 722..723,
                                         node_index: NodeIndex(None),
+                                        range: 722..723,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 722..723,
@@ -1611,8 +1611,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 865..866,
                                         node_index: NodeIndex(None),
+                                        range: 865..866,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 865..866,
@@ -1687,8 +1687,8 @@ Module(
                             type_params: [
                                 ParamSpec(
                                     TypeParamParamSpec {
-                                        range: 895..898,
                                         node_index: NodeIndex(None),
+                                        range: 895..898,
                                         name: Identifier {
                                             id: Name("P"),
                                             range: 897..898,
@@ -1762,8 +1762,8 @@ Module(
                             type_params: [
                                 TypeVarTuple(
                                     TypeParamTypeVarTuple {
-                                        range: 950..953,
                                         node_index: NodeIndex(None),
+                                        range: 950..953,
                                         name: Identifier {
                                             id: Name("Ts"),
                                             range: 951..953,
@@ -1844,8 +1844,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 1011..1022,
                                         node_index: NodeIndex(None),
+                                        range: 1011..1022,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 1011..1012,
@@ -1911,8 +1911,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 1082..1095,
                                         node_index: NodeIndex(None),
+                                        range: 1082..1095,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 1082..1083,

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@type_param_default_py313.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@type_param_default_py313.py.snap
@@ -29,8 +29,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 51..58,
                                         node_index: NodeIndex(None),
+                                        range: 51..58,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 51..52,
@@ -80,8 +80,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 72..79,
                                         node_index: NodeIndex(None),
+                                        range: 72..79,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 72..73,
@@ -146,8 +146,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 96..103,
                                         node_index: NodeIndex(None),
+                                        range: 96..103,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 96..97,

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@type_param_param_spec.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@type_param_param_spec.py.snap
@@ -29,8 +29,8 @@ Module(
                             type_params: [
                                 ParamSpec(
                                     TypeParamParamSpec {
-                                        range: 7..10,
                                         node_index: NodeIndex(None),
+                                        range: 7..10,
                                         name: Identifier {
                                             id: Name("P"),
                                             range: 9..10,
@@ -71,8 +71,8 @@ Module(
                             type_params: [
                                 ParamSpec(
                                     TypeParamParamSpec {
-                                        range: 25..34,
                                         node_index: NodeIndex(None),
+                                        range: 25..34,
                                         name: Identifier {
                                             id: Name("P"),
                                             range: 27..28,
@@ -122,8 +122,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 49..50,
                                         node_index: NodeIndex(None),
+                                        range: 49..50,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 49..50,
@@ -135,8 +135,8 @@ Module(
                                 ),
                                 ParamSpec(
                                     TypeParamParamSpec {
-                                        range: 52..55,
                                         node_index: NodeIndex(None),
+                                        range: 52..55,
                                         name: Identifier {
                                             id: Name("P"),
                                             range: 54..55,
@@ -177,8 +177,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 70..71,
                                         node_index: NodeIndex(None),
+                                        range: 70..71,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 70..71,
@@ -190,8 +190,8 @@ Module(
                                 ),
                                 ParamSpec(
                                     TypeParamParamSpec {
-                                        range: 73..82,
                                         node_index: NodeIndex(None),
+                                        range: 73..82,
                                         name: Identifier {
                                             id: Name("P"),
                                             range: 75..76,

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@type_param_type_var.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@type_param_type_var.py.snap
@@ -29,8 +29,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 7..8,
                                         node_index: NodeIndex(None),
+                                        range: 7..8,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 7..8,
@@ -72,8 +72,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 23..30,
                                         node_index: NodeIndex(None),
+                                        range: 23..30,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 23..24,
@@ -124,8 +124,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 45..57,
                                         node_index: NodeIndex(None),
+                                        range: 45..57,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 45..46,
@@ -185,8 +185,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 72..91,
                                         node_index: NodeIndex(None),
+                                        range: 72..91,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 72..73,
@@ -264,8 +264,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 106..118,
                                         node_index: NodeIndex(None),
+                                        range: 106..118,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 106..107,
@@ -295,8 +295,8 @@ Module(
                                 ),
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 120..139,
                                         node_index: NodeIndex(None),
+                                        range: 120..139,
                                         name: Identifier {
                                             id: Name("U"),
                                             range: 120..121,

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@type_param_type_var_tuple.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@type_param_type_var_tuple.py.snap
@@ -29,8 +29,8 @@ Module(
                             type_params: [
                                 TypeVarTuple(
                                     TypeParamTypeVarTuple {
-                                        range: 7..10,
                                         node_index: NodeIndex(None),
+                                        range: 7..10,
                                         name: Identifier {
                                             id: Name("Ts"),
                                             range: 8..10,
@@ -71,8 +71,8 @@ Module(
                             type_params: [
                                 TypeVarTuple(
                                     TypeParamTypeVarTuple {
-                                        range: 25..34,
                                         node_index: NodeIndex(None),
+                                        range: 25..34,
                                         name: Identifier {
                                             id: Name("Ts"),
                                             range: 26..28,
@@ -122,8 +122,8 @@ Module(
                             type_params: [
                                 TypeVarTuple(
                                     TypeParamTypeVarTuple {
-                                        range: 49..59,
                                         node_index: NodeIndex(None),
+                                        range: 49..59,
                                         name: Identifier {
                                             id: Name("Ts"),
                                             range: 50..52,
@@ -180,8 +180,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 74..75,
                                         node_index: NodeIndex(None),
+                                        range: 74..75,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 74..75,
@@ -193,8 +193,8 @@ Module(
                                 ),
                                 TypeVarTuple(
                                     TypeParamTypeVarTuple {
-                                        range: 77..80,
                                         node_index: NodeIndex(None),
+                                        range: 77..80,
                                         name: Identifier {
                                             id: Name("Ts"),
                                             range: 78..80,
@@ -235,8 +235,8 @@ Module(
                             type_params: [
                                 TypeVar(
                                     TypeParamTypeVar {
-                                        range: 95..96,
                                         node_index: NodeIndex(None),
+                                        range: 95..96,
                                         name: Identifier {
                                             id: Name("T"),
                                             range: 95..96,
@@ -248,8 +248,8 @@ Module(
                                 ),
                                 TypeVarTuple(
                                     TypeParamTypeVarTuple {
-                                        range: 98..107,
                                         node_index: NodeIndex(None),
+                                        range: 98..107,
                                         name: Identifier {
                                             id: Name("Ts"),
                                             range: 99..101,


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Fixes a part of #15655

Auto generate ast TypeParam nodes

## Test Plan

<!-- How was it tested? -->

I have fixed some syntax tests. All other tests should pass without any changes. I have confirmed the generated code to make sure it's the same as old code.