### PR TITLE
[ty] Set `INSTA_FORCE_PASS` and `INSTA_OUTPUT` environment variables from mdtest.py

### DIFF
--- a/crates/ty_python_semantic/mdtest.py
+++ b/crates/ty_python_semantic/mdtest.py
@@ -106,7 +106,12 @@ class MDTestRunner:
         return subprocess.run(
             [self.mdtest_executable, *arguments],
             cwd=CRATE_ROOT,
-            env=dict(os.environ, CLICOLOR_FORCE="1"),
+            env=dict(
+                os.environ,
+                CLICOLOR_FORCE="1",
+                INSTA_FORCE_PASS="1",
+                INSTA_OUTPUT="none",
+            ),
             capture_output=capture_output,
             text=True,
             check=False,


### PR DESCRIPTION
## Summary

Setting these environment variables makes it much less painful to iterate on an mdtest that has snapshots enabled.

Currently if any snapshots change, you can't see which mdtest assertions are failing until you accept the snapshots (which requires terminating mdtest.py). So you accept the snapshots, then start mdtest.py running again, then you find some mdtest assertions are failing, so then you update them... and now the snapshots are failing again.

By setting these environment variables, `.snap.new` files will still be created for any snapshots that change, but mdtest.py will continue as normal anyway so that you can see which assertions are failing.

Reviewing the snapshot changes still has to be done in a separate process to the mdtest.py script. I experimented with having mdtest.py auto-accept all snapshot changes, but invoking `cargo insta accept` every time an mdtest failed made the script much slower.

## Test Plan

I manually tested it by making this change:

```diff
diff --git a/crates/ty_python_semantic/src/types.rs b/crates/ty_python_semantic/src/types.rs
index 465df24583..37b2f890a4 100644
--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -9180,7 +9180,7 @@ impl<'db> IterationError<'db> {
             #[expect(clippy::wrong_self_convention)]
             fn is_not(self, because: impl std::fmt::Display) -> LintDiagnosticGuard<'a, 'a> {
                 let mut diag = self.builder.into_diagnostic(format_args!(
-                    "Object of type `{iterable_type}` is not {maybe_async}iterable",
+                    "Object of type `{iterable_type}` is nott {maybe_async}iterable",
                     iterable_type = self.iterable_type.display(self.db),
                     maybe_async = if self.mode.is_async() { "async-" } else { "" }
                 ));
```

and then incrementally updated failing assertions that were presented to me by mdtest, observing that snapshot failures no longer blocked the script from continuing.