### PR TITLE
[ty] Make `attributes.md` mdtests faster

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -2476,10 +2476,7 @@ class NestedMixed:
     def g(self: "NestedMixed"):
         self.x = {self.x}
 
-    def h(self: "NestedMixed"):
-        self.x = {"a": self.x}
-
-reveal_type(NestedMixed().x)  # revealed: Unknown | list[Divergent] | set[Divergent] | dict[Unknown | str, Divergent]
+reveal_type(NestedMixed().x)  # revealed: Unknown | list[Divergent] | set[Divergent]
 ```
 
 And cases where the types originate from annotations:


### PR DESCRIPTION
## Summary

That example was too extreme for debug mode.
