### PR TITLE
[ty] Add docstrings for `ty_extensions` functions

### DIFF
--- a/crates/ty_vendored/ty_extensions/ty_extensions.pyi
+++ b/crates/ty_vendored/ty_extensions/ty_extensions.pyi
@@ -86,7 +86,6 @@ def is_disjoint_from(type_a: Any, type_b: Any) -> ConstraintSet:
 
 def is_singleton(ty: Any) -> bool:
     """Returns `True` if `ty` is a singleton type with exactly one inhabitant."""
-    """
 
 def is_single_valued(ty: Any) -> bool:
     """Returns `True` if `ty` is non-empty and all inhabitants compare equal to each other."""


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

Add docstrings to some ty_extensions functions that test predicates on types.

Additionally update some keyword argument names in these functions to clarify which direction the relevant relations are being tested.

## Test Plan

Manually tested with a local ty language server that the new docstrings show up.

<!-- How was it tested? -->
