### PR TITLE
Disable npm caching for playground

### DIFF
--- a/.github/workflows/publish-playground.yml
+++ b/.github/workflows/publish-playground.yml
@@ -34,8 +34,7 @@ jobs:
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 22
-          cache: "npm" # zizmor: ignore[cache-poisoning] acceptable risk for CloudFlare pages artifact
-          cache-dependency-path: playground/package-lock.json
+          package-manager-cache: false
       - uses: jetli/wasm-bindgen-action@20b33e20595891ab1a0ed73145d8a21fc96e7c29 # v0.2.0
       - name: "Install Node dependencies"
         run: npm ci

--- a/.github/workflows/publish-ty-playground.yml
+++ b/.github/workflows/publish-ty-playground.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 22
-          cache: "npm" # zizmor: ignore[cache-poisoning] acceptable risk for CloudFlare pages artifact
+          package-manager-cache: false
       - uses: jetli/wasm-bindgen-action@20b33e20595891ab1a0ed73145d8a21fc96e7c29 # v0.2.0
       - name: "Install Node dependencies"
         run: npm ci


### PR DESCRIPTION
## Summary

https://github.com/astral-sh/ruff/pull/20999 broke the ty playground deployment because it 
added npm caching without specifying the path to the package.json

I don't think the NPM caching gives us that much (this isn't a workflow that runs for every PR),
especially not if it also introduces us to cache poisoning (while the playground isn't critical, 
it's still something that many Astral employees and users access eveyr day). 

## Test Plan

Test in prod ;)
