### PR TITLE
[ty] Simplify `Self` for final types

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -508,4 +508,22 @@ def _(c: CallableTypeOf[C().method]):
     reveal_type(c)  # revealed: (...) -> None
 ```
 
+## Final classes
+
+For final classes, we simplify `Self` to an instance of the class:
+
+```py
+from typing import final, Self
+
+@final
+class FinalClass:
+    def implicit_self(self) -> Self:
+        reveal_type(self)  # revealed: FinalClass
+        return self
+
+    def explicit_self(self: Self) -> Self:
+        reveal_type(self)  # revealed: FinalClass
+        return self
+```
+
 [self attribute]: https://typing.python.org/en/latest/spec/generics.html#use-in-attribute-annotations

--- a/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
+++ b/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
@@ -379,3 +379,22 @@ def as_pattern_non_exhaustive(subject: int | str):
             # this diagnostic is correct: the inferred type of `subject` is `str`
             assert_never(subject)  # error: [type-assertion-failure]
 ```
+
+## Exhaustiveness checking for methods of enums
+
+```py
+from enum import Enum
+
+class Answer(Enum):
+    YES = "yes"
+    NO = "no"
+
+    def is_yes(self) -> bool:
+        reveal_type(self)  # revealed: Answer
+
+        match self:
+            case Answer.YES:
+                return True
+            case Answer.NO:
+                return False
+```

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -84,6 +84,10 @@ pub(crate) fn typing_self<'db>(
     typevar_binding_context: Option<Definition<'db>>,
     class: ClassLiteral<'db>,
 ) -> Option<Type<'db>> {
+    if class.is_final(db) {
+        return Some(Type::instance(db, class.identity_specialization(db)));
+    }
+
     let index = semantic_index(db, function_scope_id.file(db));
 
     let identity = TypeVarIdentity::new(


### PR DESCRIPTION
## Summary

For final classes, we simplify `Self` to an instance of the class.

Ideally, we would also do that for other type variables with a final bound, but those seem like a rare edge-case, because there's not really any benefit to using a type variable in the first place, if it's bound to a final type (thank you, @AlexWaygood).

closes https://github.com/astral-sh/ty/issues/1404

## Test Plan

Added regression test
