### PR TITLE
[ty] Add comment explaining why `HasTrackedScope` is implemented for `Identifier` and why it works

### DIFF
--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -505,8 +505,10 @@ impl HasTrackedScope for ast::Expr {}
 impl HasTrackedScope for ast::ExprRef<'_> {}
 impl HasTrackedScope for &ast::ExprRef<'_> {}
 
-// See https://github.com/astral-sh/ty/issues/572 why this implementation exists
-// even when we never register identifiers during semantic index building.
+// We never explicitly register the scope of an `Identifier`.
+// However, `ExpressionsScopeMap` stores the text ranges of each scope.
+// That allows us to look up the identifier's scope for as long as it's
+// inside an expression (because the ranges overlap).
 impl HasTrackedScope for ast::Identifier {}
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

I always assumed that the lookup by identifier is just a no-op and doesn't work. But it does! 

This was the last clean-up that I wanted to do for https://github.com/astral-sh/ty/issues/572, which I think we can close now

## Test Plan

Alex
