### PR TITLE
[ty] Fix missing newline before first diagnostic

### DIFF
--- a/crates/ty/src/lib.rs
+++ b/crates/ty/src/lib.rs
@@ -280,7 +280,7 @@ impl MainLoop {
 
                         match salsa::Cancelled::catch(|| {
                             db.check_with_reporter(&mut reporter);
-                            reporter.bar.finish();
+                            reporter.bar.finish_and_clear();
                             reporter.collector.into_sorted(&db)
                         }) {
                             Ok(result) => {


### PR DESCRIPTION
## Summary

Copy pasting ty's output from the CLI into GitHub resulted in a missing newline after `Checked 9/9 files` and the first diagnostic
when they are rendered. This is a known issue in indicatif (https://github.com/console-rs/indicatif/issues/695).

The easiest fix is to clear the progress bar on completion, which I prefer anyways because it reduces the output produced by ty. 

Fixes https://github.com/astral-sh/ty/issues/1424


## Test Plan


```
cargo run --manifest-path ../ruff/Cargo.toml --bin ty -- check 444/
   Compiling ty v0.0.0 (/Users/micha/astral/ruff/crates/ty)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 6.54s
     Running `/Users/micha/astral/ruff/target/debug/ty check 444/`
error[unresolved-import]: Cannot resolve imported module `binary`
 --> 444/lib.py:1:6
  |
1 | from binary import *
  |      ^^^^^^
2 | from py3compat import *
  |
info: Searched in the following paths during module resolution:
info:   1. /Users/micha/astral/test (first-party code)
info:   2. vendored://stdlib (stdlib typeshed stubs vendored by ty)
info:   3. /Users/micha/astral/test/.venv/lib/python3.10/site-packages (site-packages)
info: make sure your Python environment is properly configured: https://docs.astral.sh/ty/modules/#python-environment
info: rule `unresolved-import` is enabled by default

error[unresolved-import]: Cannot resolve imported module `py3compat`
 --> 444/lib.py:2:6
  |
1 | from binary import *
2 | from py3compat import *
  |      ^^^^^^^^^
  |
info: Searched in the following paths during module resolution:
info:   1. /Users/micha/astral/test (first-party code)
info:   2. vendored://stdlib (stdlib typeshed stubs vendored by ty)
info:   3. /Users/micha/astral/test/.venv/lib/python3.10/site-packages (site-packages)
info: make sure your Python environment is properly configured: https://docs.astral.sh/ty/modules/#python-environment
info: rule `unresolved-import` is enabled by default

error[unresolved-import]: Cannot resolve imported module `construct`
 --> 444/mre.py:3:6
  |
1 | from io import BytesIO
2 |
3 | from construct import Float32l
  |      ^^^^^^^^^
  |
info: Searched in the following paths during module resolution:
info:   1. /Users/micha/astral/test (first-party code)
info:   2. vendored://stdlib (stdlib typeshed stubs vendored by ty)
info:   3. /Users/micha/astral/test/.venv/lib/python3.10/site-packages (site-packages)
info: make sure your Python environment is properly configured: https://docs.astral.sh/ty/modules/#python-environment
info: rule `unresolved-import` is enabled by default

Found 3 diagnostics
```
