### PR TITLE
Expose some methods of `ruff_python_parser::Lexer`

### DIFF
--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -82,7 +82,7 @@ impl<'src> Lexer<'src> {
     /// If the start offset is greater than 0, the cursor is moved ahead that many bytes.
     /// This means that the input source should be the complete source code and not the
     /// sliced version.
-    pub fn new(source: &'src str, mode: Mode, start_offset: TextSize) -> Self {
+    pub(crate) fn new(source: &'src str, mode: Mode, start_offset: TextSize) -> Self {
         assert!(
             u32::try_from(source.len()).is_ok(),
             "Lexer only supports files with a size up to 4GB"
@@ -131,7 +131,7 @@ impl<'src> Lexer<'src> {
     }
 
     /// Returns the flags for the current token.
-    pub(crate) fn current_flags(&self) -> TokenFlags {
+    pub fn current_flags(&self) -> TokenFlags {
         self.current_flags
     }
 

--- a/crates/ruff_python_parser/src/lib.rs
+++ b/crates/ruff_python_parser/src/lib.rs
@@ -71,7 +71,7 @@ pub use crate::error::{
     UnsupportedSyntaxError, UnsupportedSyntaxErrorKind,
 };
 pub use crate::parser::ParseOptions;
-pub use crate::token::{Token, TokenKind};
+pub use crate::token::{Token, TokenFlags, TokenKind};
 
 use crate::parser::Parser;
 

--- a/crates/ruff_python_parser/src/token.rs
+++ b/crates/ruff_python_parser/src/token.rs
@@ -729,7 +729,7 @@ impl fmt::Display for TokenKind {
 
 bitflags! {
     #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-    pub(crate) struct TokenFlags: u16 {
+    pub struct TokenFlags: u16 {
         /// The token is a string with double quotes (`"`).
         const DOUBLE_QUOTES = 1 << 0;
         /// The token is a triple-quoted string i.e., it starts and ends with three consecutive


### PR DESCRIPTION
While trying to lex an incomplete source code that comes from a lazy iterator or a [`BufRead`](https://doc.rust-lang.org/std/io/trait.BufRead.html), I had trouble with:
- knowing what is the offset of the last good token
- Configure the Lexer to start from the offset of the last good token

Unfortunately
https://github.com/astral-sh/ruff/blob/64ab79e5721ec6fdd2182fbf9d39a26534ccca43/crates/ruff_python_parser/src/lexer.rs#L1823-L1824

doesn't let you do that.

---

Feel free to close this PR if this is an unwanted change