### PR TITLE
[`airflow`] warning `airflow....DAG.create_dagrun` has been removed (`AIR301`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR301_class_attribute.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR301_class_attribute.py
@@ -103,6 +103,12 @@ base_secret_backend.get_connections()
 lfb = LocalFilesystemBackend()
 lfb.get_connections()
 
+from airflow.models import DAG
+
+# airflow.DAG
+test_dag = DAG(dag_id="test_dag")
+test_dag.create_dagrun()
+
 from airflow import DAG
 
 # airflow.DAG

--- a/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
@@ -492,10 +492,12 @@ fn check_method(checker: &Checker, call_expr: &ExprCall) {
             "collected_datasets" => Replacement::AttrName("collected_assets"),
             _ => return,
         },
-        ["airflow", .., "DAG"] => match attr.as_str() {
-            "create_dagrun" => Replacement::None,
-            _ => return,
-        },
+        ["airflow", "models", "dag", "DAG"] | ["airflow", "models", "DAG"] | ["airflow", "DAG"] => {
+            match attr.as_str() {
+                "create_dagrun" => Replacement::None,
+                _ => return,
+            }
+        }
         ["airflow", "providers_manager", "ProvidersManager"] => match attr.as_str() {
             "initialize_providers_dataset_uri_resources" => {
                 Replacement::AttrName("initialize_providers_asset_uri_resources")

--- a/crates/ruff_linter/src/rules/airflow/rules/suggested_to_update_3_0.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/suggested_to_update_3_0.rs
@@ -288,10 +288,12 @@ fn check_name(checker: &Checker, expr: &Expr, range: TextRange) {
         },
 
         // airflow.model..DAG
-        ["airflow", "models", .., "DAG"] => Replacement::SourceModuleMoved {
-            module: "airflow.sdk",
-            name: "DAG".to_string(),
-        },
+        ["airflow", "models", "dag", "DAG"] | ["airflow", "models", "DAG"] | ["airflow", "DAG"] => {
+            Replacement::SourceModuleMoved {
+                module: "airflow.sdk",
+                name: "DAG".to_string(),
+            }
+        }
 
         // airflow.sensors.base
         [

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR301_AIR301_class_attribute.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR301_AIR301_class_attribute.py.snap
@@ -641,7 +641,7 @@ AIR301 [*] `get_connections` is removed in Airflow 3.0
 104 | lfb.get_connections()
     |     ^^^^^^^^^^^^^^^
 105 |
-106 | from airflow import DAG
+106 | from airflow.models import DAG
     |
 help: Use `get_connection` instead
 101 | 
@@ -650,7 +650,7 @@ help: Use `get_connection` instead
     - lfb.get_connections()
 104 + lfb.get_connection()
 105 | 
-106 | from airflow import DAG
+106 | from airflow.models import DAG
 107 | 
 
 AIR301 `create_dagrun` is removed in Airflow 3.0
@@ -659,5 +659,16 @@ AIR301 `create_dagrun` is removed in Airflow 3.0
 108 | # airflow.DAG
 109 | test_dag = DAG(dag_id="test_dag")
 110 | test_dag.create_dagrun()
+    |          ^^^^^^^^^^^^^
+111 |
+112 | from airflow import DAG
+    |
+
+AIR301 `create_dagrun` is removed in Airflow 3.0
+   --> AIR301_class_attribute.py:116:10
+    |
+114 | # airflow.DAG
+115 | test_dag = DAG(dag_id="test_dag")
+116 | test_dag.create_dagrun()
     |          ^^^^^^^^^^^^^
     |

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR311_AIR311_args.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR311_AIR311_args.py.snap
@@ -1,6 +1,25 @@
 ---
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 ---
+AIR311 [*] `airflow.DAG` is removed in Airflow 3.0; It still works in Airflow 3.0 but is expected to be removed in a future version.
+  --> AIR311_args.py:13:1
+   |
+13 | DAG(dag_id="class_sla_callback", sla_miss_callback=sla_callback)
+   | ^^^
+   |
+help: Use `DAG` from `airflow.sdk` instead.
+2  | 
+3  | from datetime import timedelta
+4  | 
+   - from airflow import DAG, dag
+5  + from airflow import dag
+6  | from airflow.operators.datetime import BranchDateTimeOperator
+7  + from airflow.sdk import DAG
+8  | 
+9  | 
+10 | def sla_callback(*arg, **kwargs):
+note: This is an unsafe fix and may change runtime behavior
+
 AIR311 `sla_miss_callback` is removed in Airflow 3.0; It still works in Airflow 3.0 but is expected to be removed in a future version.
   --> AIR311_args.py:13:34
    |


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
* Warn that `airflow....DAG.create_dagrun` has been removed

## Test Plan

<!-- How was it tested? -->
update accordingly and reorganize test cases