### PR TITLE
Fix some false positive for `is_non_empty_f_string`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_bandit/S604.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_bandit/S604.py
@@ -22,3 +22,15 @@ foo(shell=lambda: 0)
 foo(shell=f"{b''}")
 x = 1
 foo(shell=f"{x=}")
+print(bool(dict(shell=f"{f""!s}")["shell"]))
+
+# Unknown truthiness
+print(bool(dict(shell=f"{"x":.0}")["shell"]))
+
+
+class C:
+    def __gt__(self, other):
+        return ""
+
+
+print(bool(dict(shell=f"{C() > C()}")["shell"]))

--- a/crates/ruff_linter/src/rules/flake8_bandit/snapshots/ruff_linter__rules__flake8_bandit__tests__S604_S604.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bandit/snapshots/ruff_linter__rules__flake8_bandit__tests__S604_S604.py.snap
@@ -90,4 +90,5 @@ S604 Function call with truthy `shell` parameter identified, security issue
 23 | x = 1
 24 | foo(shell=f"{x=}")
    | ^^^
+25 | print(bool(dict(shell=f"{f""!s}")["shell"]))
    |


### PR DESCRIPTION
## Summary
Closes #21048

Fix some false positive edge cases when determining string truthiness. The following cases are now treated as unknown truthiness:

1. Comparison expressions can return any value, even empty strings.
2. F-strings with format specs can produce either empty or non-empty strings:
```python
bool(f"{'mystring':.0}") # Returns False
``` 

Additionally, fixed a bug that caused `f"{f""!s}"` to be treated as non-empty. Since `.iter().all()` returns true if the iterator is empty, f-strings with no elements (like nested `f"{f""!s}"`) were incorrectly treated as non-empty.

## Test Plan
- Added test cases to S604 since `Truthiness` has no tests of its own