### PR TITLE
[ty] Rename `inner` query for better debugging experience

### DIFF
--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -649,7 +649,11 @@ impl<'db> ProtocolInstanceType<'db> {
     /// normalised to `object`.
     pub(super) fn is_equivalent_to_object(self, db: &'db dyn Db) -> bool {
         #[salsa::tracked(cycle_initial=initial, heap_size=ruff_memory_usage::heap_size)]
-        fn inner<'db>(db: &'db dyn Db, protocol: ProtocolInstanceType<'db>, _: ()) -> bool {
+        fn is_equivalent_to_object_inner<'db>(
+            db: &'db dyn Db,
+            protocol: ProtocolInstanceType<'db>,
+            _: (),
+        ) -> bool {
             Type::object()
                 .satisfies_protocol(
                     db,
@@ -666,7 +670,7 @@ impl<'db> ProtocolInstanceType<'db> {
             true
         }
 
-        inner(db, self, ())
+        is_equivalent_to_object_inner(db, self, ())
     }
 
     /// Return a "normalized" version of this `Protocol` type.


### PR DESCRIPTION
## Summary

Using an unspecific name like `inner` makes it difficult to find the problematic query if Salsa panics because the cycle head iterated too many times, or if any other invariant isn't true. 

This specific instance came up on https://github.com/astral-sh/ruff/pull/20566 where the Salsa panic only referred to `inner`.


This PR renames the `inner` function to use a longer name so that the query's debug name is more self explanatory ;)

## Test Plan

The panic message now renders as `Cycle recovery function for infer_definition_types(Id(a42f)) introduced a cycle, depending on is_equivalent_to_object_inner(Id(8007)). This is not allowed.` which
is more actionable.
