### PR TITLE
[ty] Render `import <...>` in completions when "label details" isn't supported

### DIFF
--- a/crates/ty_server/src/capabilities.rs
+++ b/crates/ty_server/src/capabilities.rs
@@ -36,6 +36,7 @@ bitflags::bitflags! {
         const DIAGNOSTIC_DYNAMIC_REGISTRATION = 1 << 14;
         const WORKSPACE_CONFIGURATION = 1 << 15;
         const RENAME_DYNAMIC_REGISTRATION = 1 << 16;
+        const COMPLETION_ITEM_LABEL_DETAILS_SUPPORT = 1 << 17;
     }
 }
 
@@ -156,6 +157,11 @@ impl ResolvedClientCapabilities {
     /// Returns `true` if the client supports dynamic registration for rename capabilities.
     pub(crate) const fn supports_rename_dynamic_registration(self) -> bool {
         self.contains(Self::RENAME_DYNAMIC_REGISTRATION)
+    }
+
+    /// Returns `true` if the client supports "label details" in completion items.
+    pub(crate) const fn supports_completion_item_label_details(self) -> bool {
+        self.contains(Self::COMPLETION_ITEM_LABEL_DETAILS_SUPPORT)
     }
 
     pub(super) fn new(client_capabilities: &ClientCapabilities) -> Self {
@@ -312,6 +318,15 @@ impl ResolvedClientCapabilities {
             .unwrap_or_default()
         {
             flags |= Self::WORK_DONE_PROGRESS;
+        }
+
+        if text_document
+            .and_then(|text_document| text_document.completion.as_ref())
+            .and_then(|completion| completion.completion_item.as_ref())
+            .and_then(|completion_item| completion_item.label_details_support)
+            .unwrap_or_default()
+        {
+            flags |= Self::COMPLETION_ITEM_LABEL_DETAILS_SUPPORT;
         }
 
         flags


### PR DESCRIPTION
This fixes a bug where the `import module` part of a completion for
unimported candidates would be missing. This makes it especially
confusing because the user can't tell where the symbol is coming from,
and there is no hint that an `import` statement will be inserted.

Previously, we were using [`CompletionItemLabelDetails`] to render the
`import module` part of the suggestion. But this is only supported in
clients that support version 3.17 (or newer) of the LSP specification.
It turns out that this support isn't widespread yet. In particular,
Heliex doesn't seem to support "label details."

To fix this, we take a [cue from rust-analyzer][rust-analyzer-details].
We detect if the client supports "label details," and if so, use it.
Otherwise, we push the `import module` text into the completion label
itself.

Fixes https://github.com/astral-sh/ruff/pull/20439#issuecomment-3313689568

[`CompletionItemLabelDetails`]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#completionItemLabelDetails
[rust-analyzer-details]: https://github.com/rust-lang/rust-analyzer/blob/5d905576d49233ed843bb40df4ed57e5534558f5/crates/rust-analyzer/src/lsp/to_proto.rs#L391-L404
