### PR TITLE
[ty] Make auto import completions include global imports from other modules in suggestions

### DIFF
--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -4058,6 +4058,85 @@ def f[T](x: T):
         test.build().contains("__repr__");
     }
 
+    #[test]
+    fn reexport_simple_import_noauto() {
+        let snapshot = CursorTest::builder()
+            .source(
+                "main.py",
+                r#"
+import foo
+foo.ZQ<CURSOR>
+"#,
+            )
+            .source("foo.py", r#"from bar import ZQZQ"#)
+            .source("bar.py", r#"ZQZQ = 1"#)
+            .completion_test_builder()
+            .module_names()
+            .build()
+            .snapshot();
+        assert_snapshot!(snapshot, @"ZQZQ :: Current module");
+    }
+
+    #[test]
+    fn reexport_simple_import_auto() {
+        let snapshot = CursorTest::builder()
+            .source(
+                "main.py",
+                r#"
+ZQ<CURSOR>
+"#,
+            )
+            .source("foo.py", r#"from bar import ZQZQ"#)
+            .source("bar.py", r#"ZQZQ = 1"#)
+            .completion_test_builder()
+            .auto_import()
+            .module_names()
+            .build()
+            .snapshot();
+        assert_snapshot!(snapshot, @"ZQZQ :: bar");
+    }
+
+    #[test]
+    fn reexport_redundant_convention_import_noauto() {
+        let snapshot = CursorTest::builder()
+            .source(
+                "main.py",
+                r#"
+import foo
+foo.ZQ<CURSOR>
+"#,
+            )
+            .source("foo.py", r#"from bar import ZQZQ as ZQZQ"#)
+            .source("bar.py", r#"ZQZQ = 1"#)
+            .completion_test_builder()
+            .module_names()
+            .build()
+            .snapshot();
+        assert_snapshot!(snapshot, @"ZQZQ :: Current module");
+    }
+
+    #[test]
+    fn reexport_redundant_convention_import_auto() {
+        let snapshot = CursorTest::builder()
+            .source(
+                "main.py",
+                r#"
+ZQ<CURSOR>
+"#,
+            )
+            .source("foo.py", r#"from bar import ZQZQ as ZQZQ"#)
+            .source("bar.py", r#"ZQZQ = 1"#)
+            .completion_test_builder()
+            .auto_import()
+            .module_names()
+            .build()
+            .snapshot();
+        assert_snapshot!(snapshot, @r"
+        ZQZQ :: bar
+        ZQZQ :: foo
+        ");
+    }
+
     /// A way to create a simple single-file (named `main.py`) completion test
     /// builder.
     ///


### PR DESCRIPTION
Previously, our special auto-import code for discovering symbols in
other files quickly (without running ty on them) didn't take imports
into account. This PR makes a small change to do exactly that.

This in particular helps with libraries that build their public API
from submodules. In particular, numpy. This consequently improves our
numpy evaluation tasks (which includes sub-optimal ranking because of
precisely this bug). The ranking still isn't perfect, but at least the
correct result appears in the suggestions. It previously did not.

Unfortunately, this does regress some other tasks. For example, invoking
auto-import on `TypeVa<CURSOR>` now brings up `TypeVar` from a whole
bunch of modules. Presumably because it's imported in those modules.

So I guess that means this heuristic is probably wrong. How does one
differentiate imports that are meant to build out an API and just a
regular old import meant for internal use?

One idea is to perhaps down-rank symbols derived from imports, but above
symbols from private modules (beginning with `_`). This would work for
the numpy case I believe without (hopefully) regressing other tasks.
