### PR TITLE
[ty] Rename `Type::into_nominal_instance`

### DIFF
--- a/crates/ty_python_semantic/src/types/bound_super.rs
+++ b/crates/ty_python_semantic/src/types/bound_super.rs
@@ -186,7 +186,7 @@ impl<'db> SuperOwnerKind<'db> {
             }
             SuperOwnerKind::Instance(instance) => instance
                 .normalized_impl(db, visitor)
-                .into_nominal_instance()
+                .as_nominal_instance()
                 .map(Self::Instance)
                 .unwrap_or(Self::Dynamic(DynamicType::Any)),
         }

--- a/crates/ty_python_semantic/src/types/builder.rs
+++ b/crates/ty_python_semantic/src/types/builder.rs
@@ -854,7 +854,7 @@ impl<'db> InnerIntersectionBuilder<'db> {
 
             _ => {
                 let known_instance = new_positive
-                    .into_nominal_instance()
+                    .as_nominal_instance()
                     .and_then(|instance| instance.known_class(db));
 
                 if known_instance == Some(KnownClass::Object) {
@@ -966,7 +966,7 @@ impl<'db> InnerIntersectionBuilder<'db> {
         let contains_bool = || {
             self.positive
                 .iter()
-                .filter_map(|ty| ty.into_nominal_instance())
+                .filter_map(|ty| ty.as_nominal_instance())
                 .filter_map(|instance| instance.known_class(db))
                 .any(KnownClass::is_bool)
         };

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -1295,7 +1295,7 @@ impl<'db> Field<'db> {
     /// <https://docs.python.org/3/library/dataclasses.html#dataclasses.KW_ONLY>
     pub(crate) fn is_kw_only_sentinel(&self, db: &'db dyn Db) -> bool {
         self.declared_ty
-            .into_nominal_instance()
+            .as_nominal_instance()
             .is_some_and(|instance| instance.has_known_class(db, KnownClass::KwOnly))
     }
 }

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -88,7 +88,7 @@ impl<'db> Type<'db> {
         Type::NominalInstance(NominalInstanceType(NominalInstanceInner::ExactTuple(tuple)))
     }
 
-    pub(crate) const fn into_nominal_instance(self) -> Option<NominalInstanceType<'db>> {
+    pub(crate) const fn as_nominal_instance(self) -> Option<NominalInstanceType<'db>> {
         match self {
             Type::NominalInstance(instance_type) => Some(instance_type),
             _ => None,


### PR DESCRIPTION
Looks like this was missed in https://github.com/astral-sh/ruff/pull/20857.

I also made some methods `const`, for consistency with what we do elsewhere