### PR TITLE
[ty] Don't provide completions when in class or function definition

### DIFF
--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -859,12 +859,17 @@ fn is_in_definition_place(db: &dyn Db, tokens: &[Token], file: File) -> bool {
         .checked_sub(2)
         .and_then(|i| tokens.get(i))
         .is_some_and(|t| {
-            matches!(
+            if matches!(
                 t.kind(),
                 TokenKind::Def | TokenKind::Class | TokenKind::Type
-            ) || file.read_to_string(db).is_ok_and(|source| {
-                source[t.range().start().to_usize()..t.range().end().to_usize()] == *"type"
-            })
+            ) {
+                true
+            } else if t.kind() == TokenKind::Name {
+                let source = source_text(db, file);
+                &source[t.range()] == "type"
+            } else {
+                false
+            }
         })
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

Resolves https://github.com/astral-sh/ty/issues/1457

We now check if we are in a situation where we are in the name of class or function definition like `def f` or `class f`. We check if the second last token is `def` or `class`.

## Test Plan

Added test shown in that issue.

Also add test for situation where we have not started typing the name like `def ` and `class `. My changes do not change any behavior there, but i think it is good to show we still dont provide completions there
