### PR TITLE
[ty] rollback preferring declared type on invalid TypedDict creation

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -99,7 +99,8 @@ eve1a: Person = {"name": b"Eve", "age": None}
 # error: [invalid-argument-type] "Invalid argument to key "name" with declared type `str` on TypedDict `Person`"
 eve1b = Person(name=b"Eve", age=None)
 
-reveal_type(eve1a)  # revealed: Person
+# TODO should reveal Person (should be fixed by implementing assignability for TypedDicts)
+reveal_type(eve1a)  # revealed: dict[Unknown | str, Unknown | bytes | None]
 reveal_type(eve1b)  # revealed: Person
 
 # error: [missing-typed-dict-key] "Missing required key 'name' in TypedDict `Person` constructor"
@@ -107,7 +108,8 @@ eve2a: Person = {"age": 22}
 # error: [missing-typed-dict-key] "Missing required key 'name' in TypedDict `Person` constructor"
 eve2b = Person(age=22)
 
-reveal_type(eve2a)  # revealed: Person
+# TODO should reveal Person (should be fixed by implementing assignability for TypedDicts)
+reveal_type(eve2a)  # revealed: dict[Unknown | str, Unknown | int]
 reveal_type(eve2b)  # revealed: Person
 
 # error: [invalid-key] "Invalid key for TypedDict `Person`: Unknown key "extra""
@@ -115,7 +117,8 @@ eve3a: Person = {"name": "Eve", "age": 25, "extra": True}
 # error: [invalid-key] "Invalid key for TypedDict `Person`: Unknown key "extra""
 eve3b = Person(name="Eve", age=25, extra=True)
 
-reveal_type(eve3a)  # revealed: Person
+# TODO should reveal Person (should be fixed by implementing assignability for TypedDicts)
+reveal_type(eve3a)  # revealed: dict[Unknown | str, Unknown | str | int]
 reveal_type(eve3b)  # revealed: Person
 ```
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -6103,9 +6103,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             && let Some(typed_dict) = tcx
                 .filter_union(self.db(), Type::is_typed_dict)
                 .as_typed_dict()
+            && let Some(ty) = self.infer_typed_dict_expression(dict, typed_dict)
         {
-            self.infer_typed_dict_expression(dict, typed_dict);
-            return Type::TypedDict(typed_dict);
+            return ty;
         }
 
         // Avoid false positives for the functional `TypedDict` form, which is currently
@@ -6130,7 +6130,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         &mut self,
         dict: &ast::ExprDict,
         typed_dict: TypedDictType<'db>,
-    ) {
+    ) -> Option<Type<'db>> {
         let ast::ExprDict {
             range: _,
             node_index: _,
@@ -6153,7 +6153,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         validate_typed_dict_dict_literal(&self.context, typed_dict, dict, dict.into(), |expr| {
             self.expression_type(expr)
-        });
+        })
+        .ok()
+        .map(|_| Type::TypedDict(typed_dict))
     }
 
     // Infer the type of a collection literal expression.


### PR DESCRIPTION
## Summary

Discussion with @ibraheemdev clarified that https://github.com/astral-sh/ruff/pull/21168 was incorrect. In a case of failed inference of a dict literal as a `TypedDict`, we should store the context-less inferred type of the dict literal as the type of the dict literal expression itself; the fallback to declared type should happen at the level of the overall assignment definition.

The reason the latter isn't working yet is because currently we (wrongly) consider a homogeneous dict type as assignable to a `TypedDict`, so we don't actually consider the assignment itself as failed. So the "bug" I observed (and tried to fix) will naturally be fixed by implementing TypedDict assignability rules.

Rollback https://github.com/astral-sh/ruff/pull/21168 except for the tests, and modify the tests to include TODOs as needed.

## Test Plan

Updated mdtests.
