### PR TITLE
[ty] Improve exhaustiveness analysis for type variables with bounds or constraints

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
+++ b/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
@@ -417,3 +417,55 @@ class Answer(Enum):
             case Answer.NO:
                 return False
 ```
+
+## Exhaustiveness checking for type variables with bounds or constraints
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import assert_never, Literal
+
+def f[T: bool](x: T) -> T:
+    match x:
+        case True:
+            return x
+        case False:
+            return x
+        case _:
+            reveal_type(x)  # revealed: Never
+            assert_never(x)
+
+def g[T: Literal["foo", "bar"]](x: T) -> T:
+    match x:
+        case "foo":
+            return x
+        case "bar":
+            return x
+        case _:
+            reveal_type(x)  # revealed: Never
+            assert_never(x)
+
+def h[T: int | str](x: T) -> T:
+    if isinstance(x, int):
+        return x
+    elif isinstance(x, str):
+        return x
+    else:
+        reveal_type(x)  # revealed: Never
+        assert_never(x)
+
+def i[T: (int, str)](x: T) -> T:
+    match x:
+        case int():
+            pass
+        case str():
+            pass
+        case _:
+            reveal_type(x)  # revealed: Never
+            assert_never(x)
+
+    return x
+```


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ty/issues/1456.

This PR backs out the changes made in https://github.com/astral-sh/ruff/pull/21130 and replaces them with a more generalised implementation of exhaustiveness checking for `match`es over type variables with upper bounds or constraints. The approach in #21130 works for type variables with an enum upper bound, and could have been adapted to work for type variables with a `bool` upper bound. But it would _not_ work for a type variable with a union upper bound, because of the fact that we distribute over a union (to create a union of intersections) when adding a union type to an intersection.

Instead, the approach this PR takes is to speculatively solve all type variables in the positive part of an intersection to their upper bound/constraints when finally building the intersection. If that speculative intersection simplifies to `Never`, so must the original intersection.

## Test Plan

New mdtests added.
