### PR TITLE
[`flake8-comprehensions`] Fix typo in `C416` documentation

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_comprehension.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_comprehension.rs
@@ -43,7 +43,7 @@ use crate::rules::flake8_comprehensions::fixes;
 /// >>> {x: y for x, y in d1}  # Iterates over the keys of a mapping
 /// {1: 2, 4: 5}
 /// >>> dict(d1)               # Ruff's incorrect suggested fix
-/// (1, 2): 3, (4, 5): 6}
+/// {(1, 2): 3, (4, 5): 6}
 /// >>> dict(d1.keys())        # Correct fix
 /// {1: 2, 4: 5}
 /// ```


### PR DESCRIPTION
## Summary

Adds missing curly brace to the C416 documentation.

## Test Plan

Build the docs
