### PR TITLE
[`refurb`] Fix false negative for underscores before sign in `Decimal` constructor (`FURB157`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/refurb/FURB157.py
+++ b/crates/ruff_linter/resources/test/fixtures/refurb/FURB157.py
@@ -85,3 +85,9 @@ Decimal("1234_5678")    # Safe fix: preserves non-thousands separators
 Decimal("0001_2345")
 Decimal("000_1_2345")
 Decimal("000_000")
+
+# Test cases for underscores before sign
+# https://github.com/astral-sh/ruff/issues/21186
+Decimal("_-1")      # Should flag as verbose
+Decimal("_+1")      # Should flag as verbose
+Decimal("_-1_000")  # Should flag as verbose

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB157_FURB157.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB157_FURB157.py.snap
@@ -669,6 +669,7 @@ help: Replace with `1_2345`
 85 + Decimal(1_2345)
 86 | Decimal("000_1_2345")
 87 | Decimal("000_000")
+88 | 
 
 FURB157 [*] Verbose expression in `Decimal` constructor
   --> FURB157.py:86:9
@@ -686,6 +687,8 @@ help: Replace with `1_2345`
    - Decimal("000_1_2345")
 86 + Decimal(1_2345)
 87 | Decimal("000_000")
+88 | 
+89 | # Test cases for underscores before sign
 
 FURB157 [*] Verbose expression in `Decimal` constructor
   --> FURB157.py:87:9
@@ -694,6 +697,8 @@ FURB157 [*] Verbose expression in `Decimal` constructor
 86 | Decimal("000_1_2345")
 87 | Decimal("000_000")
    |         ^^^^^^^^^
+88 |
+89 | # Test cases for underscores before sign
    |
 help: Replace with `0`
 84 | # Separators _and_ leading zeros
@@ -701,3 +706,57 @@ help: Replace with `0`
 86 | Decimal("000_1_2345")
    - Decimal("000_000")
 87 + Decimal(0)
+88 | 
+89 | # Test cases for underscores before sign
+90 | # https://github.com/astral-sh/ruff/issues/21186
+
+FURB157 [*] Verbose expression in `Decimal` constructor
+  --> FURB157.py:91:9
+   |
+89 | # Test cases for underscores before sign
+90 | # https://github.com/astral-sh/ruff/issues/21186
+91 | Decimal("_-1")      # Should flag as verbose
+   |         ^^^^^
+92 | Decimal("_+1")      # Should flag as verbose
+93 | Decimal("_-1_000")  # Should flag as verbose
+   |
+help: Replace with `-1`
+88 | 
+89 | # Test cases for underscores before sign
+90 | # https://github.com/astral-sh/ruff/issues/21186
+   - Decimal("_-1")      # Should flag as verbose
+91 + Decimal(-1)      # Should flag as verbose
+92 | Decimal("_+1")      # Should flag as verbose
+93 | Decimal("_-1_000")  # Should flag as verbose
+
+FURB157 [*] Verbose expression in `Decimal` constructor
+  --> FURB157.py:92:9
+   |
+90 | # https://github.com/astral-sh/ruff/issues/21186
+91 | Decimal("_-1")      # Should flag as verbose
+92 | Decimal("_+1")      # Should flag as verbose
+   |         ^^^^^
+93 | Decimal("_-1_000")  # Should flag as verbose
+   |
+help: Replace with `+1`
+89 | # Test cases for underscores before sign
+90 | # https://github.com/astral-sh/ruff/issues/21186
+91 | Decimal("_-1")      # Should flag as verbose
+   - Decimal("_+1")      # Should flag as verbose
+92 + Decimal(+1)      # Should flag as verbose
+93 | Decimal("_-1_000")  # Should flag as verbose
+
+FURB157 [*] Verbose expression in `Decimal` constructor
+  --> FURB157.py:93:9
+   |
+91 | Decimal("_-1")      # Should flag as verbose
+92 | Decimal("_+1")      # Should flag as verbose
+93 | Decimal("_-1_000")  # Should flag as verbose
+   |         ^^^^^^^^^
+   |
+help: Replace with `-1_000`
+90 | # https://github.com/astral-sh/ruff/issues/21186
+91 | Decimal("_-1")      # Should flag as verbose
+92 | Decimal("_+1")      # Should flag as verbose
+   - Decimal("_-1_000")  # Should flag as verbose
+93 + Decimal(-1_000)  # Should flag as verbose


### PR DESCRIPTION
## Summary

Fixes FURB157 false negative where `Decimal("_-1")` was not flagged as verbose when underscores precede the sign character. This fixes #21186.

## Problem Analysis

The `verbose-decimal-constructor` (FURB157) rule failed to detect verbose `Decimal` constructors when the sign character (`+` or `-`) was preceded by underscores. For example, `Decimal("_-1")` was not flagged, even though it can be simplified to `Decimal(-1)`.

The bug occurred because the rule checked for the sign character at the start of the string before stripping leading underscores. According to Python's `Decimal` parser behavior (as documented in CPython's `_pydecimal.py`), underscores are removed before parsing the sign. The rule's logic didn't match this behavior, causing a false negative for cases like `"_-1"` where the underscore came before the sign.

This was a regression introduced in version 0.14.3, as these cases were correctly flagged in version 0.14.2.

## Approach

The fix updates the sign extraction logic to:
1. Strip leading underscores first (matching Python's Decimal parser behavior)
2. Extract the sign from the underscore-stripped string
3. Preserve the string after the sign for normalization purposes

This ensures that cases like `Decimal("_-1")`, `Decimal("_+1")`, and `Decimal("_-1_000")` are correctly detected and flagged. The normalization logic was also updated to use the string after the sign (without underscores) to avoid double signs in the replacement output.
