### PR TITLE
[ty] Fix range filtering for tokens starting at the end of the requested range

### DIFF
--- a/crates/ty_ide/src/semantic_tokens.rs
+++ b/crates/ty_ide/src/semantic_tokens.rs
@@ -226,7 +226,7 @@ impl<'db> SemanticTokenVisitor<'db> {
         let range = ranged.range();
         // Only emit tokens that intersect with the range filter, if one is specified
         if let Some(range_filter) = self.range_filter {
-            // Only include ranges that intersect. Ranges that only touch (are empty)
+            // Only include ranges that have a non-empty overlap. Adjacent ranges
             // should be excluded.
             if range
                 .intersect(range_filter)
@@ -1294,8 +1294,8 @@ z = 3<CURSOR>
         );
 
         // Range [6..13) starts where "1" ends and ends where "z" starts.
-        // Expected: only "y" @ 7..8 and "2" @ 11..12 (non-empty intersections).
-        // Not included: "1" @ 5..6 and "z" @ 13..14 (touch at single points 6 and 13).
+        // Expected: only "y" @ 7..8 and "2" @ 11..12 (non-empty overlap with target range).
+        // Not included: "1" @ 5..6 and "z" @ 13..14 (adjacent, but not overlapping at offsets 6 and 13).
         let range = TextRange::new(TextSize::from(6), TextSize::from(13));
 
         let range_tokens = semantic_tokens(&test.db, test.cursor.file, Some(range));


### PR DESCRIPTION
## Summary

This PR fixes an issue where the semantic token provider returned tokens that
started at the end offset of the selected range. That is, the 
token and requested range intersect, but the intersecting range is empty. 

This isn't an issue for most documents because the only outcome is tha the server
sends one additional token to the client. However, this is an issue for notebooks
where the response can only contain tokens that all belong to the same cell. Sending one extra token can then have the effect of sending the first token of the next cell, 
which isn't allowed.

## Test Plan

Added test. My in draft notebook PR no longer panics during semantic syntax highlighting
