### PR TITLE
[ty] Favor in scope completions

### DIFF
--- a/crates/ty_completion_eval/completion-evaluation-tasks.csv
+++ b/crates/ty_completion_eval/completion-evaluation-tasks.csv
@@ -10,7 +10,7 @@ import-deprioritizes-type_check_only,main.py,1,1
 import-deprioritizes-type_check_only,main.py,2,1
 import-deprioritizes-type_check_only,main.py,3,2
 import-deprioritizes-type_check_only,main.py,4,3
-internal-typeshed-hidden,main.py,0,8
+internal-typeshed-hidden,main.py,0,5
 none-completion,main.py,0,11
 numpy-array,main.py,0,
 numpy-array,main.py,1,1
@@ -22,5 +22,5 @@ scope-prioritize-closer,main.py,0,2
 scope-simple-long-identifier,main.py,0,1
 tstring-completions,main.py,0,1
 ty-extensions-lower-stdlib,main.py,0,8
-type-var-typing-over-ast,main.py,0,4
-type-var-typing-over-ast,main.py,1,429
+type-var-typing-over-ast,main.py,0,3
+type-var-typing-over-ast,main.py,1,277

--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -260,7 +260,6 @@ pub fn completion<'db>(
     if scoped.is_some() {
         add_keyword_value_completions(db, &typed_query, &mut completions);
     }
-
     if settings.auto_import {
         if let Some(scoped) = scoped {
             add_unimported_completions(
@@ -273,10 +272,8 @@ pub fn completion<'db>(
             );
         }
     }
-
     completions.sort_by(compare_suggestions);
     completions.dedup_by(|c1, c2| (&c1.name, c1.module_name) == (&c2.name, c2.module_name));
-
     completions
 }
 
@@ -890,9 +887,9 @@ fn is_in_definition_place(db: &dyn Db, tokens: &[Token], file: File) -> bool {
 /// This has the effect of putting all dunder attributes after "normal"
 /// attributes, and all single-underscore attributes after dunder attributes.
 fn compare_suggestions(c1: &Completion, c2: &Completion) -> Ordering {
-    fn key<'a>(completion: &'a Completion) -> (Option<&'a ModuleName>, NameKind, bool, &'a Name) {
+    fn key<'a>(completion: &'a Completion) -> (bool, NameKind, bool, &'a Name) {
         (
-            completion.module_name,
+            completion.module_name.is_some(),
             NameKind::classify(&completion.name),
             completion.is_type_check_only,
             &completion.name,


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

Resolves https://github.com/astral-sh/ty/issues/1464

We sort the completions before we add the unimported ones, meaning that imported completions show up before unimported ones.

This is also spoken about in https://github.com/astral-sh/ty/issues/1274, and this is probably a duplicate of that.

@AlexWaygood mentions this [here](https://github.com/astral-sh/ty/issues/1274#issuecomment-3345942698) too.

## Test Plan

Add a test showing even if an unimported completion "should" (alphabetically before) come first, we favor the imported one.
