### PR TITLE
Use system jemalloc

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -8,3 +8,7 @@ benchmark = "bench -p ruff_benchmark --bench linter --bench formatter --"
 # See: https://github.com/astral-sh/ruff/issues/11503
 [target.'cfg(all(target_env="msvc", target_os = "windows"))']
 rustflags = ["-C", "target-feature=+crt-static"]
+
+# Use system jemalloc (which may or may not be compiled for 64K pages).
+[target.'cfg(all(target_env = "musl", target_os = "linux"))'.jemalloc]
+rustc-link-lib = ["jemalloc"]


### PR DESCRIPTION
The version compiled by tikv_jemallocator by default assumes 16K pages, and doesn't work on systems which have 64K pages.

Link the system jemalloc to ensure we ruff always uses a compatible jemalloc which aligns with local system conventions.

We're currently shipping this patch downstream as otherwise builds simply don't work on systems with 64K pages.