### PR TITLE
[ty] don't union in default type for annotated parameters

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/function/parameters.md
+++ b/crates/ty_python_semantic/resources/mdtest/function/parameters.md
@@ -1,12 +1,9 @@
 # Function parameter types
 
 Within a function scope, the declared type of each parameter is its annotated type (or Unknown if
-not annotated). The initial inferred type is the union of the declared type with the type of the
-default value expression (if any). If both are fully static types, this union should simplify to the
-annotated type (since the default value type must be assignable to the annotated type, and for fully
-static types this means subtype-of, which simplifies in unions). But if the annotated type is
-Unknown or another non-fully-static type, the default value type may still be relevant as lower
-bound.
+not annotated). The initial inferred type is the annotated type of the parameter, if any. If there
+is no annotation, it is the union of `Unknown` with the type of the default value expression (if
+any).
 
 The variadic parameter is a variadic tuple of its annotated type; the variadic-keywords parameter is
 a dictionary from strings to its annotated type.
@@ -41,13 +38,13 @@ def g(*args, **kwargs):
 
 ## Annotation is present but not a fully static type
 
-The default value type should be a lower bound on the inferred type.
+If there is an annotation, we respect it fully and don't union in the default value type.
 
 ```py
 from typing import Any
 
 def f(x: Any = 1):
-    reveal_type(x)  # revealed: Any | Literal[1]
+    reveal_type(x)  # revealed: Any
 ```
 
 ## Default value type must be assignable to annotated type
@@ -64,7 +61,7 @@ def f(x: int = "foo"):
 from typing import Any
 
 def g(x: Any = "foo"):
-    reveal_type(x)  # revealed: Any | Literal["foo"]
+    reveal_type(x)  # revealed: Any
 ```
 
 ## Stub functions

--- a/crates/ty_python_semantic/resources/mdtest/ty_extensions.md
+++ b/crates/ty_python_semantic/resources/mdtest/ty_extensions.md
@@ -99,7 +99,7 @@ static_assert(is_assignable_to(int, Unknown))
 def explicit_unknown(x: Unknown, y: tuple[str, Unknown], z: Unknown = 1) -> None:
     reveal_type(x)  # revealed: Unknown
     reveal_type(y)  # revealed: tuple[str, Unknown]
-    reveal_type(z)  # revealed: Unknown | Literal[1]
+    reveal_type(z)  # revealed: Unknown
 ```
 
 `Unknown` can be subclassed, just like `Any`:


### PR DESCRIPTION
Fixes https://github.com/astral-sh/ty/issues/1013

## Summary

When a function parameter has both an annotation and a default value, we shouldn't union in the type of the default value to the inferred type of the parameter.

If the default value type is not assignable to the annotated type (e.g. `x: int = "foo"`), we emit a diagnostic about that, and ignore the default value type. This matches what we (and other type checkers) do for invalid assignments. The annotation is the explicit declaration of intent and we respect it. (This PR doesn't change anything here.)

If the default is assignable to the annotated type, and both are fully static types (e.g. `x: int = 1`), unioning in the default has no effect, so this PR again changes nothing.

If the annotated type is a static type and the default is not (e.g. `x: int = returns_any()`), it's definitely more useful to have `int` rather than `int | Any` as the inferred type for `x`. Fixing this case is the main point of this PR.

If the annotated type is not fully static (e.g. `x: Any = 1`), this is perhaps the most debatable scenario. A case could be made for continuing to infer `Any | Literal[1]` here, since `Literal[1]` is a definitely-known lower bound. But it's difficult to distinguish all the variants of this case from the previous two cases in a principled way, and a case can also be made that even here, the `Any` annotation is opting out of type checking, and we shouldn't necessarily try to be too smart. All other type checkers infer just `Any` here. So this PR chooses to do that also.

Of course, if there is no annotated type (e.g. `x = 1`) we continue to infer `Unknown | Literal[1]`.

## Test Plan

Adjusted mdtests.
