### PR TITLE
[ty] Fix caching of imported modules in playground

### DIFF
--- a/playground/ty/src/Editor/SecondaryPanel.tsx
+++ b/playground/ty/src/Editor/SecondaryPanel.tsx
@@ -2,7 +2,7 @@ import MonacoEditor from "@monaco-editor/react";
 import { AstralButton, Theme } from "shared";
 import { ReadonlyFiles } from "../Playground";
 import { Suspense, use, useState } from "react";
-import { loadPyodide, PyodideInterface } from "pyodide";
+import { loadPyodide } from "pyodide";
 import classNames from "classnames";
 
 export enum SecondaryTool {


### PR DESCRIPTION
## Summary

Force a new Pyodide instance whenever a file changes. 

This ensures that imported modules aren't cached by Pyodide. 

## Test Plan

https://github.com/user-attachments/assets/ef1c7e32-2d8f-42f4-b85d-3424f5ac51d9



