### PR TITLE
[ty] Allow values of type `None` in type expressions

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/implicit_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/implicit_type_aliases.md
@@ -22,11 +22,8 @@ f(1)
 ```py
 MyNone = None
 
-# TODO: this should not be an error
-# error: [invalid-type-form] "Variable of type `None` is not allowed in a type expression"
 def g(x: MyNone):
-    # TODO: this should be `None`
-    reveal_type(x)  # revealed: Unknown
+    reveal_type(x)  # revealed: None
 
 g(None)
 ```

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -6597,6 +6597,7 @@ impl<'db> Type<'db> {
             Type::Dynamic(_) => Ok(*self),
 
             Type::NominalInstance(instance) => match instance.known_class(db) {
+                Some(KnownClass::NoneType) => Ok(Type::none(db)),
                 Some(KnownClass::TypeVar) => Ok(todo_type!(
                     "Support for `typing.TypeVar` instances in type expressions"
                 )),


### PR DESCRIPTION
## Summary

Allow values of type `None` in type expressions. The [typing spec](https://typing.python.org/en/latest/spec/annotations.html#type-and-annotation-expressions) could be more explicit on whether this is actually allowed or not, but it seems relatively harmless and does help in some use cases like:

```py
try:
    from module import MyClass
except ImportError:
    MyClass = None  # ty: ignore


def f(m: MyClass):
    pass
``` 

## Test Plan

Updated tests, ecosystem check.
