### PR TITLE
[`refurb`] Auto-fix annotated assignments (`FURB101`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/refurb/FURB101.py
+++ b/crates/ruff_linter/resources/test/fixtures/refurb/FURB101.py
@@ -129,3 +129,14 @@ with open(*filename, file="file.txt", mode="r") as f:
 # FURB101
 with open("file.txt", encoding="utf-8") as f:
     contents: str = f.read()
+
+# FURB101 but no fix because it would remove the assignment to `x`
+with open("file.txt", encoding="utf-8") as f:
+    contents, x = f.read(), 2
+
+# FURB101 but no fix because it would remove the `process_contents` call
+with open("file.txt", encoding="utf-8") as f:
+    contents = process_contents(f.read())
+
+with open("file.txt", encoding="utf-8") as f:
+    contents: str = process_contents(f.read())

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB101_FURB101.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB101_FURB101.py.snap
@@ -210,3 +210,37 @@ help: Replace with `Path("file.txt").read_text(encoding="utf-8")`
     - with open("file.txt", encoding="utf-8") as f:
     -     contents: str = f.read()
 131 + contents: str = pathlib.Path("file.txt").read_text(encoding="utf-8")
+132 | 
+133 | # FURB101 but no fix because it would remove the assignment to `x`
+134 | with open("file.txt", encoding="utf-8") as f:
+
+FURB101 `open` and `read` should be replaced by `Path("file.txt").read_text(encoding="utf-8")`
+   --> FURB101.py:134:6
+    |
+133 | # FURB101 but no fix because it would remove the assignment to `x`
+134 | with open("file.txt", encoding="utf-8") as f:
+    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+135 |     contents, x = f.read(), 2
+    |
+help: Replace with `Path("file.txt").read_text(encoding="utf-8")`
+
+FURB101 `open` and `read` should be replaced by `Path("file.txt").read_text(encoding="utf-8")`
+   --> FURB101.py:138:6
+    |
+137 | # FURB101 but no fix because it would remove the `process_contents` call
+138 | with open("file.txt", encoding="utf-8") as f:
+    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+139 |     contents = process_contents(f.read())
+    |
+help: Replace with `Path("file.txt").read_text(encoding="utf-8")`
+
+FURB101 `open` and `read` should be replaced by `Path("file.txt").read_text(encoding="utf-8")`
+   --> FURB101.py:141:6
+    |
+139 |     contents = process_contents(f.read())
+140 |
+141 | with open("file.txt", encoding="utf-8") as f:
+    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+142 |     contents: str = process_contents(f.read())
+    |
+help: Replace with `Path("file.txt").read_text(encoding="utf-8")`


### PR DESCRIPTION
## Summary

Fixed FURB101 (`read-whole-file`) to handle annotated assignments. Previously, the rule would detect violations in code like `contents: str = f.read()` but fail to generate a fix. Now it correctly generates fixes that preserve type annotations (e.g., `contents: str = Path("file.txt").read_text(encoding="utf-8")`).

Fixes #21274

## Problem Analysis

The FURB101 rule was only checking for `Stmt::Assign` statements when determining whether a fix could be applied. When encountering annotated assignments (`Stmt::AnnAssign`) like `contents: str = f.read()`, the rule would:

1. Correctly detect the violation (the diagnostic was reported)
2. Fail to generate a fix because:
   - The `visit_expr` method only matched `Stmt::Assign`, not `Stmt::AnnAssign`
   - The `generate_fix` function only accepted `Stmt::Assign` in its body validation
   - The replacement code generation didn't account for type annotations

This occurred because Python's AST represents annotated assignments as a different node type (`StmtAnnAssign`) with separate fields for the target, annotation, and value, unlike regular assignments which use a list of targets.

## Approach

The fix extends the rule to handle both assignment types:

1. **Updated `visit_expr` method**: Now matches both `Stmt::Assign` and `Stmt::AnnAssign`, extracting:
   - Variable name from the target expression
   - Type annotation code (when present) using the code generator

2. **Updated `generate_fix` function**:
   - Added `annotation: Option<String>` parameter to accept annotation code
   - Updated body validation to accept both `Stmt::Assign` and `Stmt::AnnAssign`
   - Modified replacement code generation to preserve annotations: `{var}: {annotation} = {binding}({filename_code}).{suggestion}`

3. **Added test case**: Added an annotated assignment test case to verify the fix works correctly.

The implementation maintains backward compatibility with regular assignments while adding support for annotated assignments, ensuring type annotations are preserved in the generated fixes.