### PR TITLE
[ty] Favour imported symbols over builtin symbols

### DIFF
--- a/crates/ty_completion_eval/completion-evaluation-tasks.csv
+++ b/crates/ty_completion_eval/completion-evaluation-tasks.csv
@@ -17,7 +17,7 @@ numpy-array,main.py,1,1
 object-attr-instance-methods,main.py,0,1
 object-attr-instance-methods,main.py,1,1
 raise-uses-base-exception,main.py,0,2
-scope-existing-over-new-import,main.py,0,13
+scope-existing-over-new-import,main.py,0,1
 scope-prioritize-closer,main.py,0,2
 scope-simple-long-identifier,main.py,0,1
 tstring-completions,main.py,0,1

--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -4201,7 +4201,6 @@ type <CURSOR>
     fn favour_imported_over_builtin() {
         let snapshot =
             completion_test_builder("from typing import Protocol\nclass Foo(P<CURSOR>: ...")
-                .type_signatures()
                 .filter(|c| c.name.starts_with('P'))
                 .build()
                 .snapshot();
@@ -4209,11 +4208,11 @@ type <CURSOR>
         // Here we favour `Protocol` over the other completions
         // because `Protocol` has been imported, and the other completions are builtin.
         assert_snapshot!(snapshot, @r"
-        Protocol :: typing.Protocol :: Current module
-        PendingDeprecationWarning :: <class 'PendingDeprecationWarning'> :: Current module
-        PermissionError :: <class 'PermissionError'> :: Current module
-        ProcessLookupError :: <class 'ProcessLookupError'> :: Current module
-        PythonFinalizationError :: <class 'PythonFinalizationError'> :: Current module
+        Protocol
+        PendingDeprecationWarning
+        PermissionError
+        ProcessLookupError
+        PythonFinalizationError
         ");
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

Raised by @AlexWaygood.

We previously did not favour imported symbols, when we probably should've 

## Test Plan

Add test showing that we favour imported symbol even if it is alphabetically after other symbols that are builtin.
