### PR TITLE
Require ignore 0.4.24 in `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,7 @@ hashbrown = { version = "0.16.0", default-features = false, features = [
     "inline-more",
 ] }
 heck = "0.5.0"
-ignore = { version = "0.4.22" }
+ignore = { version = "0.4.24" }
 imara-diff = { version = "0.1.5" }
 imperative = { version = "1.0.4" }
 indexmap = { version = "2.6.0" }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
Since 4c4ddc8c29e, ruff uses the `WalkBuilder::current_dir` API [introduced in `ignore` version 0.4.24](https://diff.rs/ignore/0.4.23/0.4.24/src%2Fwalk.rs), so it should explicitly depend on this minimum version.

See also https://github.com/astral-sh/ruff/pull/20979.

## Test Plan

<!-- How was it tested? -->
Source inspection verifies this version is necessary; no additional testing is required since `Cargo.lock` already has (at least) this version.