### PR TITLE
Add option to provide a reason to `--add-noqa`

### DIFF
--- a/crates/ruff/src/args.rs
+++ b/crates/ruff/src/args.rs
@@ -405,8 +405,13 @@ pub struct CheckCommand {
     )]
     pub statistics: bool,
     /// Enable automatic additions of `noqa` directives to failing lines.
+    /// Optionally provide a reason to append after the codes.
     #[arg(
         long,
+        value_name = "REASON",
+        default_missing_value = "",
+        num_args = 0..=1,
+        require_equals = true,
         // conflicts_with = "add_noqa",
         conflicts_with = "show_files",
         conflicts_with = "show_settings",
@@ -418,7 +423,7 @@ pub struct CheckCommand {
         conflicts_with = "fix",
         conflicts_with = "diff",
     )]
-    pub add_noqa: bool,
+    pub add_noqa: Option<String>,
     /// See the files Ruff will be run against with the current settings.
     #[arg(
         long,
@@ -1047,7 +1052,7 @@ Possible choices:
 /// etc.).
 #[expect(clippy::struct_excessive_bools)]
 pub struct CheckArguments {
-    pub add_noqa: bool,
+    pub add_noqa: Option<String>,
     pub diff: bool,
     pub exit_non_zero_on_fix: bool,
     pub exit_zero: bool,

--- a/crates/ruff/src/commands/add_noqa.rs
+++ b/crates/ruff/src/commands/add_noqa.rs
@@ -21,6 +21,7 @@ pub(crate) fn add_noqa(
     files: &[PathBuf],
     pyproject_config: &PyprojectConfig,
     config_arguments: &ConfigArguments,
+    reason: Option<&str>,
 ) -> Result<usize> {
     // Collect all the files to check.
     let start = Instant::now();
@@ -76,7 +77,14 @@ pub(crate) fn add_noqa(
                     return None;
                 }
             };
-            match add_noqa_to_path(path, package, &source_kind, source_type, &settings.linter) {
+            match add_noqa_to_path(
+                path,
+                package,
+                &source_kind,
+                source_type,
+                &settings.linter,
+                reason,
+            ) {
                 Ok(count) => Some(count),
                 Err(e) => {
                     error!("Failed to add noqa to {}: {e}", path.display());

--- a/crates/ruff_linter/src/linter.rs
+++ b/crates/ruff_linter/src/linter.rs
@@ -377,6 +377,7 @@ pub fn add_noqa_to_path(
     source_kind: &SourceKind,
     source_type: PySourceType,
     settings: &LinterSettings,
+    reason: Option<&str>,
 ) -> Result<usize> {
     // Parse once.
     let target_version = settings.resolve_target_version(path);
@@ -425,6 +426,7 @@ pub fn add_noqa_to_path(
         &settings.external,
         &directives.noqa_line_for,
         stylist.line_ending(),
+        reason,
     )
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -618,8 +618,9 @@ Options:
           notebooks, use `--extension ipy:ipynb`
       --statistics
           Show counts for every rule with at least one violation
-      --add-noqa
-          Enable automatic additions of `noqa` directives to failing lines
+      --add-noqa[=<REASON>]
+          Enable automatic additions of `noqa` directives to failing lines.
+          Optionally provide a reason to append after the codes
       --show-files
           See the files Ruff will be run against with the current settings
       --show-settings


### PR DESCRIPTION
## Summary

This PR adds an optional reason to `--add-noqa` that will be added to every inserted `noqa` comment. 

How to use:

```
ruff check --add-noqa "Disallow usage of method"
```

Fixes https://github.com/astral-sh/ruff/issues/10070


## Test Plan

Added CLI tests
