### PR TITLE
Add a new "Opening a PR" section to the contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -318,10 +318,6 @@ additional comment help us to review your PR more efficiently. It's also a great
 way to find new test cases to incorporate into your PR if you identify any
 issues.
 
-These steps will help us to review your PR quickly and effectively. Of course,
-if you run into any problems or have questions, feel free to ask them on the
-issue, in a draft PR, or on Discord!
-
 #### PR status
 
 To help us know when your PR is ready for review again, please either move your


### PR DESCRIPTION
Summary
--

This PR adds a new section to CONTRIBUTING.md describing the expected contents of the PR summary and test plan, using the ecosystem report, and communicating the status of a PR.

This seemed like a pretty good place to insert this in the document, at the end of the advice on preparing actual code changes, but I'm certainly open to other suggestions about both the content and placement.

Test Plan
--

Future PRs :)
