### PR TITLE
[`pyupgrade`] Fix false positive on relative imports from local `.builtins` module (`UP029`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP029_2.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP029_2.py
@@ -1,0 +1,5 @@
+from .builtins import next
+from ..builtins import str
+from ...builtins import int
+from .builtins import next as _next
+

--- a/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
@@ -717,7 +717,9 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
             }
             if checker.is_rule_enabled(Rule::UnnecessaryBuiltinImport) {
                 if let Some(module) = module {
-                    pyupgrade::rules::unnecessary_builtin_import(checker, stmt, module, names);
+                    pyupgrade::rules::unnecessary_builtin_import(
+                        checker, stmt, module, names, level,
+                    );
                 }
             }
             if checker.any_rule_enabled(&[

--- a/crates/ruff_linter/src/rules/pyupgrade/mod.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/mod.rs
@@ -99,6 +99,7 @@ mod tests {
     #[test_case(Rule::UTF8EncodingDeclaration, Path::new("UP009_many_empty_lines.py"))]
     #[test_case(Rule::UnicodeKindPrefix, Path::new("UP025.py"))]
     #[test_case(Rule::UnnecessaryBuiltinImport, Path::new("UP029_0.py"))]
+    #[test_case(Rule::UnnecessaryBuiltinImport, Path::new("UP029_2.py"))]
     #[test_case(Rule::UnnecessaryClassParentheses, Path::new("UP039.py"))]
     #[test_case(Rule::UnnecessaryDefaultTypeArgs, Path::new("UP043.py"))]
     #[test_case(Rule::UnnecessaryEncodeUTF8, Path::new("UP012.py"))]

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_builtin_import.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_builtin_import.rs
@@ -75,7 +75,13 @@ pub(crate) fn unnecessary_builtin_import(
     stmt: &Stmt,
     module: &str,
     names: &[Alias],
+    level: u32,
 ) {
+    // Ignore relative imports (they're importing from local modules, not Python's builtins).
+    if level > 0 {
+        return;
+    }
+
     // Ignore irrelevant modules.
     if !matches!(
         module,

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP029_2.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP029_2.py.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff_linter/src/rules/pyupgrade/mod.rs
+---
+


### PR DESCRIPTION
## Summary

Fixes false positive where `UP029` incorrectly flagged relative imports from local modules named `builtins` (e.g., `from .builtins import next`) as unnecessary builtin imports. The rule should only flag imports from Python's standard `builtins` module, not from local modules.

Fixes #21307

## Problem Analysis

The `UP029` rule checks for unnecessary imports from Python's `builtins` module. However, it was incorrectly flagging relative imports like `from .builtins import next` as unnecessary, even though these are importing from a local module named `builtins`, not Python's builtins module.

The bug occurred because the rule only checked if the module name matched `"builtins"` without distinguishing between:
- Absolute imports: `from builtins import next` (should be flagged)
- Relative imports: `from .builtins import next` (should NOT be flagged)

This caused issues in projects like `aioitertools` that reimplement builtins as async-compatible variants in a local `.builtins` module.

## Approach

The fix adds a check for relative imports by:
1. Adding a `level: u32` parameter to the `unnecessary_builtin_import` function to detect import level
2. Adding an early return when `level > 0` (indicating a relative import) before checking the module name
3. Updating the call site to pass the `level` parameter from the AST node

This ensures that relative imports are skipped entirely, as they're importing from local modules, not Python's builtins. Absolute imports continue to work correctly and are still flagged as expected.

The fix is minimal and surgical - it only adds the relative import check without modifying any existing logic for absolute imports.