### PR TITLE
[`flake8-logging-format`] Fix G004 preview mode breaking on f-strings with control characters (`G004`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_logging_format/G004.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_logging_format/G004.py
@@ -64,3 +64,12 @@ import logging
 
 x = 1
 logging.error(f"{x} -> %s", x)
+
+# Test cases for control characters in f-strings
+bar = "bar"
+logging.getLogger().error(f"Lorem ipsum \n {bar}")
+
+value = "test"
+logging.info(f"Tab\t{value}")
+
+logging.info(f"CR\r{value}")

--- a/crates/ruff_linter/src/rules/flake8_logging_format/snapshots/ruff_linter__rules__flake8_logging_format__tests__G004.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_logging_format/snapshots/ruff_linter__rules__flake8_logging_format__tests__G004.py.snap
@@ -217,5 +217,40 @@ G004 Logging statement uses f-string
 65 | x = 1
 66 | logging.error(f"{x} -> %s", x)
    |               ^^^^^^^^^^^^
+67 |
+68 | # Test cases for control characters in f-strings
+   |
+help: Convert to lazy `%` formatting
+
+G004 Logging statement uses f-string
+  --> G004.py:70:27
+   |
+68 | # Test cases for control characters in f-strings
+69 | bar = "bar"
+70 | logging.getLogger().error(f"Lorem ipsum \n {bar}")
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^
+71 |
+72 | value = "test"
+   |
+help: Convert to lazy `%` formatting
+
+G004 Logging statement uses f-string
+  --> G004.py:73:14
+   |
+72 | value = "test"
+73 | logging.info(f"Tab\t{value}")
+   |              ^^^^^^^^^^^^^^^
+74 |
+75 | logging.info(f"CR\r{value}")
+   |
+help: Convert to lazy `%` formatting
+
+G004 Logging statement uses f-string
+  --> G004.py:75:14
+   |
+73 | logging.info(f"Tab\t{value}")
+74 |
+75 | logging.info(f"CR\r{value}")
+   |              ^^^^^^^^^^^^^^
    |
 help: Convert to lazy `%` formatting

--- a/crates/ruff_linter/src/rules/flake8_logging_format/snapshots/ruff_linter__rules__flake8_logging_format__tests__preview__G004_G004.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_logging_format/snapshots/ruff_linter__rules__flake8_logging_format__tests__preview__G004_G004.py.snap
@@ -273,5 +273,60 @@ G004 Logging statement uses f-string
 65 | x = 1
 66 | logging.error(f"{x} -> %s", x)
    |               ^^^^^^^^^^^^
+67 |
+68 | # Test cases for control characters in f-strings
    |
 help: Convert to lazy `%` formatting
+
+G004 [*] Logging statement uses f-string
+  --> G004.py:70:27
+   |
+68 | # Test cases for control characters in f-strings
+69 | bar = "bar"
+70 | logging.getLogger().error(f"Lorem ipsum \n {bar}")
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^
+71 |
+72 | value = "test"
+   |
+help: Convert to lazy `%` formatting
+67 | 
+68 | # Test cases for control characters in f-strings
+69 | bar = "bar"
+   - logging.getLogger().error(f"Lorem ipsum \n {bar}")
+70 + logging.getLogger().error("Lorem ipsum \n %s", bar)
+71 | 
+72 | value = "test"
+73 | logging.info(f"Tab\t{value}")
+
+G004 [*] Logging statement uses f-string
+  --> G004.py:73:14
+   |
+72 | value = "test"
+73 | logging.info(f"Tab\t{value}")
+   |              ^^^^^^^^^^^^^^^
+74 |
+75 | logging.info(f"CR\r{value}")
+   |
+help: Convert to lazy `%` formatting
+70 | logging.getLogger().error(f"Lorem ipsum \n {bar}")
+71 | 
+72 | value = "test"
+   - logging.info(f"Tab\t{value}")
+73 + logging.info("Tab\t%s", value)
+74 | 
+75 | logging.info(f"CR\r{value}")
+
+G004 [*] Logging statement uses f-string
+  --> G004.py:75:14
+   |
+73 | logging.info(f"Tab\t{value}")
+74 |
+75 | logging.info(f"CR\r{value}")
+   |              ^^^^^^^^^^^^^^
+   |
+help: Convert to lazy `%` formatting
+72 | value = "test"
+73 | logging.info(f"Tab\t{value}")
+74 | 
+   - logging.info(f"CR\r{value}")
+75 + logging.info("CR\r%s", value)


### PR DESCRIPTION
## Summary

Fixes #21295. The G004 rule's preview mode fix was generating invalid Python syntax when converting f-strings containing control characters (newlines, tabs, carriage returns) to `%` formatting in logging calls. This fix adds proper escaping of control characters and quotes when building the replacement string literal.

## Problem Analysis

When G004's preview mode converts f-strings to `%` formatting, it directly appends literal text from the f-string parts to the format string without escaping control characters. This causes syntax errors when the generated code contains unescaped newlines, tabs, or other control characters in string literals.

The root cause was in the `logging_f_string` function in `crates/ruff_linter/src/rules/flake8_logging_format/rules/logging_call.rs`, where literal text from f-string parts was appended directly to the format string without escaping control characters (lines 60 and 72 in the original code).

## Approach

1. **Added escape helper function**: Created `escape_string_for_literal()` that properly escapes control characters (`\n`, `\t`, `\r`), backslashes (`\`), and quotes matching the quote style for use in Python string literals.

2. **Updated literal handling**: Modified the `logging_f_string` function to use the escape function when appending literal text from both:
   - `FStringPart::Literal` parts (line 83)
   - `InterpolatedStringElement::Literal` elements (lines 95-98)

3. **Added test cases**: Added test cases covering newlines, tabs, and carriage returns to ensure the fix works correctly and prevents regressions.

The fix ensures that all control characters are properly escaped in the generated Python code, making it syntactically valid while preserving the intended behavior of the original f-string.
