### PR TITLE
[ty] Add narrowing for `isinstance()` and `issubclass()` checks that use PEP-604 unions

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -87,11 +87,22 @@ def _(x: int | str | bytes | memoryview | range):
         reveal_type(x)  # revealed: range
 ```
 
+Although `isinstance()` usually only works if all elements in the `UnionType` are class objects, at
+runtime a special exception is made for `None` so that `isinstance(x, int | None)` can work:
+
+```py
+def _(x: int | str | bytes | range | None):
+    if isinstance(x, int | str | None):
+        reveal_type(x)  # revealed: int | str | None
+    else:
+        reveal_type(x)  # revealed: bytes | range
+```
+
 ## `classinfo` is an invalid PEP-604 union of types
 
-Narrowing can only take place if all elements in the PEP-604 union are class literals. If any
-elements are generic aliases or other types, the `isinstance()` call will fail at runtime, so no
-narrowing can take place:
+Except for the `None` special case mentioned above, narrowing can only take place if all elements in
+the PEP-604 union are class literals. If any elements are generic aliases or other types, the
+`isinstance()` call may fail at runtime, so no narrowing can take place:
 
 ```toml
 [environment]

--- a/crates/ty_python_semantic/resources/mdtest/narrow/issubclass.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/issubclass.md
@@ -148,11 +148,22 @@ def f(x: type[int | str | bytes | range]):
         reveal_type(x)  # revealed: <class 'range'>
 ```
 
+Although `issubclass()` usually only works if all elements in the `UnionType` are class objects, at
+runtime a special exception is made for `None` so that `issubclass(x, int | None)` can work:
+
+```py
+def _(x: type):
+    if issubclass(x, int | str | None):
+        reveal_type(x)  # revealed: type[int] | type[str] | <class 'NoneType'>
+    else:
+        reveal_type(x)  # revealed: type & ~type[int] & ~type[str] & ~<class 'NoneType'>
+```
+
 ## `classinfo` is an invalid PEP-604 union of types
 
-Narrowing can only take place if all elements in the PEP-604 union are class literals. If any
-elements are generic aliases or other types, the `issubclass()` call will fail at runtime, so no
-narrowing can take place:
+Except for the `None` special case mentioned above, narrowing can only take place if all elements in
+the PEP-604 union are class literals. If any elements are generic aliases or other types, the
+`issubclass()` call may fail at runtime, so no narrowing can take place:
 
 ```toml
 [environment]

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -215,10 +215,17 @@ impl ClassInfoConstraintFunction {
             Type::KnownInstance(KnownInstanceType::UnionType(elements)) => {
                 UnionType::try_from_elements(
                     db,
-                    elements
-                        .elements(db)
-                        .iter()
-                        .map(|element| self.generate_constraint(db, *element)),
+                    elements.elements(db).iter().map(|element| {
+                        // A special case is made for `None` at runtime
+                        // (it's implicitly converted to `NoneType` in `int | None`)
+                        // which means that `isinstance(x, int | None)` works even though
+                        // `None` is not a class literal.
+                        if element.is_none(db) {
+                            self.generate_constraint(db, KnownClass::NoneType.to_class_literal(db))
+                        } else {
+                            self.generate_constraint(db, *element)
+                        }
+                    }),
                 )
             }
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ty/issues/122. Following @sharkdp's recent changes, this is now trivial!

## Test Plan

Added mdtests
