### PR TITLE
[ty] Make `variance_of` logging `trace` only

### DIFF
--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -7400,7 +7400,7 @@ impl<'db> From<&Type<'db>> for Type<'db> {
 
 impl<'db> VarianceInferable<'db> for Type<'db> {
     fn variance_of(self, db: &'db dyn Db, typevar: BoundTypeVarInstance<'db>) -> TypeVarVariance {
-        tracing::debug!(
+        tracing::trace!(
             "Checking variance of '{tvar}' in `{ty:?}`",
             tvar = typevar.typevar(db).name(db),
             ty = self.display(db),

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1111,7 +1111,7 @@ impl<'db> Signature<'db> {
 
 impl<'db> VarianceInferable<'db> for &Signature<'db> {
     fn variance_of(self, db: &'db dyn Db, typevar: BoundTypeVarInstance<'db>) -> TypeVarVariance {
-        tracing::debug!(
+        tracing::trace!(
             "Checking variance of `{tvar}` in `{self:?}`",
             tvar = typevar.typevar(db).name(db)
         );


### PR DESCRIPTION
## Summary

`debug` level logs are intended to be user facing and should fit on a single line. 

The `variance_of` logs can get extremelly long and aren't very useful to users. That's why I change
the verbosity to `trace` for both `variance_of` tracing calls


Here's an example of a `variance_of` log:

```
2025-11-08 15:01:35.276541000 DEBUG request{id=12 method="workspace/diagnostic"}:Project::check:check_file{file=file(Id(1407))}: Checking variance of `_PWrapper` in `Signature { generic_context: Some(GenericContext { variables_inner: {BoundTypeVarIdentity { identity: TypeVarIdentity { name: Name("Self"), definition: Some(Definition { [salsa id]: Id(3e6aa), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(41)), kind: Class(AstNodeRef { kind: StmtClassDef, range: 5860..6194 }), is_reexported: true }), kind: TypingSelf }, binding_context: Definition(Definition { [salsa id]: Id(3e6a7), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(15), place: Symbol(ScopedSymbolId(6)), kind: Function(AstNodeRef { kind: StmtFunctionDef, range: 5998..6085 }), is_reexported: true }) }: GenericContextTypeVar { bound_typevar: BoundTypeVarInstance { typevar: TypeVarInstance { identity: TypeVarIdentity { name: Name("Self"), definition: Some(Definition { [salsa id]: Id(3e6aa), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(41)), kind: Class(AstNodeRef { kind: StmtClassDef, range: 5860..6194 }), is_reexported: true }), kind: TypingSelf }, _bound_or_constraints: Some(Eager(UpperBound(NominalInstance(NominalInstanceType(NonTuple(Generic(GenericAlias { origin: ClassLiteral { name: Name("_Wrapped"), body_scope: ScopeId { [salsa id]: Id(3e096), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope_id: FileScopeId(15) }, known: None, deprecated: None, type_check_only: true, dataclass_params: None, dataclass_transformer_params: None }, specialization: Specialization { generic_context: GenericContext { variables_inner: {BoundTypeVarIdentity { identity: TypeVarIdentity { name: Name("_PWrapped"), definition: Some(Definition { [salsa id]: Id(3e671), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(27)), kind: Assignment(AssignmentDefinitionKind { target_kind: Single, value: AstNodeRef { kind: ExprCall, range: 826..848 }, target: AstNodeRef { kind: ExprName, range: 814..823 } }), is_reexported: true }), kind: ParamSpec }, binding_context: Definition(Definition { [salsa id]: Id(3e6aa), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(41)), kind: Class(AstNodeRef { kind: StmtClassDef, range: 5860..6194 }), is_reexported: true }) }: GenericContextTypeVar { bound_typevar: BoundTypeVarInstance { typevar: TypeVarInstance { identity: TypeVarIdentity { name: Name("_PWrapped"), definition: Some(Definition { [salsa id]: Id(3e671), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(27)), kind: Assignment(AssignmentDefinitionKind { target_kind: Single, value: AstNodeRef { kind: ExprCall, range: 826..848 }, target: AstNodeRef { kind: ExprName, range: 814..823 } }), is_reexported: true }), kind: ParamSpec }, _bound_or_constraints: None, explicit_variance: None, _default: None }, binding_context: Definition(Definition { [salsa id]: Id(3e6aa), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(41)), kind: Class(AstNodeRef { kind: StmtClassDef, range: 5860..6194 }), is_reexported: true }) }, should_promote_literals: false }, BoundTypeVarIdentity { identity: TypeVarIdentity { name: Name("_RWrapped"), definition: Some(Definition { [salsa id]: Id(3e672), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(28)), kind: Assignment(AssignmentDefinitionKind { target_kind: Single, value: AstNodeRef { kind: ExprCall, range: 861..881 }, target: AstNodeRef { kind: ExprName, range: 849..858 } }), is_reexported: true }), kind: Legacy }, binding_context: Definition(Definition { [salsa id]: Id(3e6aa), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(41)), kind: Class(AstNodeRef { kind: StmtClassDef, range: 5860..6194 }), is_reexported: true }) }: GenericContextTypeVar { bound_typevar: BoundTypeVarInstance { typevar: TypeVarInstance { identity: TypeVarIdentity { name: Name("_RWrapped"), definition: Some(Definition { [salsa id]: Id(3e672), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(28)), kind: Assignment(AssignmentDefinitionKind { target_kind: Single, value: AstNodeRef { kind: ExprCall, range: 861..881 }, target: AstNodeRef { kind: ExprName, range: 849..858 } }), is_reexported: true }), kind: Legacy }, _bound_or_constraints: None, explicit_variance: Some(Invariant), _default: None }, binding_context: Definition(Definition { [salsa id]: Id(3e6aa), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(41)), kind: Class(AstNodeRef { kind: StmtClassDef, range: 5860..6194 }), is_reexported: true }) }, should_promote_literals: false }, BoundTypeVarIdentity { identity: TypeVarIdentity { name: Name("_PWrapper"), definition: Some(Definition { [salsa id]: Id(3e673), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(29)), kind: Assignment(AssignmentDefinitionKind { target_kind: Single, value: AstNodeRef { kind: ExprCall, range: 894..916 }, target: AstNodeRef { kind: ExprName, range: 882..891 } }), is_reexported: true }), kind: ParamSpec }, binding_context: Definition(Definition { [salsa id]: Id(3e6aa), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(41)), kind: Class(AstNodeRef { kind: StmtClassDef, range: 5860..6194 }), is_reexported: true }) }: GenericContextTypeVar { bound_typevar: BoundTypeVarInstance { typevar: TypeVarInstance { identity: TypeVarIdentity { name: Name("_PWrapper"), definition: Some(Definition { [salsa id]: Id(3e673), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(29)), kind: Assignment(AssignmentDefinitionKind { target_kind: Single, value: AstNodeRef { kind: ExprCall, range: 894..916 }, target: AstNodeRef { kind: ExprName, range: 882..891 } }), is_reexported: true }), kind: ParamSpec }, _bound_or_constraints: None, explicit_variance: None, _default: None }, binding_context: Definition(Definition { [salsa id]: Id(3e6aa), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(41)), kind: Class(AstNodeRef { kind: StmtClassDef, range: 5860..6194 }), is_reexported: true }) }, should_promote_literals: false }, BoundTypeVarIdentity { identity: TypeVarIdentity { name: Name("_RWrapper"), definition: Some(Definition { [salsa id]: Id(3e674), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(30)), kind: Assignment(AssignmentDefinitionKind { target_kind: Single, value: AstNodeRef { kind: ExprCall, range: 929..949 }, target: AstNodeRef { kind: ExprName, range: 917..926 } }), is_reexported: true }), kind: Legacy }, binding_context: Definition(Definition { [salsa id]: Id(3e6aa), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(41)), kind: Class(AstNodeRef { kind: StmtClassDef, range: 5860..6194 }), is_reexported: true }) }: GenericContextTypeVar { bound_typevar: BoundTypeVarInstance { typevar: TypeVarInstance { identity: TypeVarIdentity { name: Name("_RWrapper"), definition: Some(Definition { [salsa id]: Id(3e674), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(30)), kind: Assignment(AssignmentDefinitionKind { target_kind: Single, value: AstNodeRef { kind: ExprCall, range: 929..949 }, target: AstNodeRef { kind: ExprName, range: 917..926 } }), is_reexported: true }), kind: Legacy }, _bound_or_constraints: None, explicit_variance: Some(Invariant), _default: None }, binding_context: Definition(Definition { [salsa id]: Id(3e6aa), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(41)), kind: Class(AstNodeRef { kind: StmtClassDef, range: 5860..6194 }), is_reexported: true }) }, should_promote_literals: false }} }, types: [TypeVar(BoundTypeVarInstance { typevar: TypeVarInstance { identity: TypeVarIdentity { name: Name("_PWrapped"), definition: Some(Definition { [salsa id]: Id(3e671), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(27)), kind: Assignment(AssignmentDefinitionKind { target_kind: Single, value: AstNodeRef { kind: ExprCall, range: 826..848 }, target: AstNodeRef { kind: ExprName, range: 814..823 } }), is_reexported: true }), kind: ParamSpec }, _bound_or_constraints: None, explicit_variance: None, _default: None }, binding_context: Definition(Definition { [salsa id]: Id(3e6aa), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(41)), kind: Class(AstNodeRef { kind: StmtClassDef, range: 5860..6194 }), is_reexported: true }) }), TypeVar(BoundTypeVarInstance { typevar: TypeVarInstance { identity: TypeVarIdentity { name: Name("_RWrapped"), definition: Some(Definition { [salsa id]: Id(3e672), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(28)), kind: Assignment(AssignmentDefinitionKind { target_kind: Single, value: AstNodeRef { kind: ExprCall, range: 861..881 }, target: AstNodeRef { kind: ExprName, range: 849..858 } }), is_reexported: true }), kind: Legacy }, _bound_or_constraints: None, explicit_variance: Some(Invariant), _default: None }, binding_context: Definition(Definition { [salsa id]: Id(3e6aa), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(41)), kind: Class(AstNodeRef { kind: StmtClassDef, range: 5860..6194 }), is_reexported: true }) }), TypeVar(BoundTypeVarInstance { typevar: TypeVarInstance { identity: TypeVarIdentity { name: Name("_PWrapper"), definition: Some(Definition { [salsa id]: Id(3e673), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(29)), kind: Assignment(AssignmentDefinitionKind { target_kind: Single, value: AstNodeRef { kind: ExprCall, range: 894..916 }, target: AstNodeRef { kind: ExprName, range: 882..891 } }), is_reexported: true }), kind: ParamSpec }, _bound_or_constraints: None, explicit_variance: None, _default: None }, binding_context: Definition(Definition { [salsa id]: Id(3e6aa), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(41)), kind: Class(AstNodeRef { kind: StmtClassDef, range: 5860..6194 }), is_reexported: true }) }), TypeVar(BoundTypeVarInstance { typevar: TypeVarInstance { identity: TypeVarIdentity { name: Name("_RWrapper"), definition: Some(Definition { [salsa id]: Id(3e674), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(30)), kind: Assignment(AssignmentDefinitionKind { target_kind: Single, value: AstNodeRef { kind: ExprCall, range: 929..949 }, target: AstNodeRef { kind: ExprName, range: 917..926 } }), is_reexported: true }), kind: Legacy }, _bound_or_constraints: None, explicit_variance: Some(Invariant), _default: None }, binding_context: Definition(Definition { [salsa id]: Id(3e6aa), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(41)), kind: Class(AstNodeRef { kind: StmtClassDef, range: 5860..6194 }), is_reexported: true }) })], materialization_kind: None, tuple_inner: None } }))))))), explicit_variance: Some(Invariant), _default: None }, binding_context: Definition(Definition { [salsa id]: Id(3e6a7), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(15), place: Symbol(ScopedSymbolId(6)), kind: Function(AstNodeRef { kind: StmtFunctionDef, range: 5998..6085 }), is_reexported: true }) }, should_promote_literals: false }} }), definition: Some(Definition { [salsa id]: Id(3e6a7), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(15), place: Symbol(ScopedSymbolId(6)), kind: Function(AstNodeRef { kind: StmtFunctionDef, range: 5998..6085 }), is_reexported: true }), parameters: Parameters { value: [Parameter { annotated_type: Some(TypeVar(BoundTypeVarInstance { typevar: TypeVarInstance { identity: TypeVarIdentity { name: Name("Self"), definition: Some(Definition { [salsa id]: Id(3e6aa), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(41)), kind: Class(AstNodeRef { kind: StmtClassDef, range: 5860..6194 }), is_reexported: true }), kind: TypingSelf }, _bound_or_constraints: Some(Eager(UpperBound(NominalInstance(NominalInstanceType(NonTuple(Generic(GenericAlias { origin: ClassLiteral { name: Name("_Wrapped"), body_scope: ScopeId { [salsa id]: Id(3e096), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope_id: FileScopeId(15) }, known: None, deprecated: None, type_check_only: true, dataclass_params: None, dataclass_transformer_params: None }, specialization: Specialization { generic_context: GenericContext { variables_inner: {BoundTypeVarIdentity { identity: TypeVarIdentity { name: Name("_PWrapped"), definition: Some(Definition { [salsa id]: Id(3e671), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(27)), kind: Assignment(AssignmentDefinitionKind { target_kind: Single, value: AstNodeRef { kind: ExprCall, range: 826..848 }, target: AstNodeRef { kind: ExprName, range: 814..823 } }), is_reexported: true }), kind: ParamSpec }, binding_context: Definition(Definition { [salsa id]: Id(3e6aa), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(41)), kind: Class(AstNodeRef { kind: StmtClassDef, range: 5860..6194 }), is_reexported: true }) }: GenericContextTypeVar { bound_typevar: BoundTypeVarInstance { typevar: TypeVarInstance { identity: TypeVarIdentity { name: Name("_PWrapped"), definition: Some(Definition { [salsa id]: Id(3e671), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(27)), kind: Assignment(AssignmentDefinitionKind { target_kind: Single, value: AstNodeRef { kind: ExprCall, range: 826..848 }, target: AstNodeRef { kind: ExprName, range: 814..823 } }), is_reexported: true }), kind: ParamSpec }, _bound_or_constraints: None, explicit_variance: None, _default: None }, binding_context: Definition(Definition { [salsa id]: Id(3e6aa), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(41)), kind: Class(AstNodeRef { kind: StmtClassDef, range: 5860..6194 }), is_reexported: true }) }, should_promote_literals: false }, BoundTypeVarIdentity { identity: TypeVarIdentity { name: Name("_RWrapped"), definition: Some(Definition { [salsa id]: Id(3e672), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(28)), kind: Assignment(AssignmentDefinitionKind { target_kind: Single, value: AstNodeRef { kind: ExprCall, range: 861..881 }, target: AstNodeRef { kind: ExprName, range: 849..858 } }), is_reexported: true }), kind: Legacy }, binding_context: Definition(Definition { [salsa id]: Id(3e6aa), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(41)), kind: Class(AstNodeRef { kind: StmtClassDef, range: 5860..6194 }), is_reexported: true }) }: GenericContextTypeVar { bound_typevar: BoundTypeVarInstance { typevar: TypeVarInstance { identity: TypeVarIdentity { name: Name("_RWrapped"), definition: Some(Definition { [salsa id]: Id(3e672), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(28)), kind: Assignment(AssignmentDefinitionKind { target_kind: Single, value: AstNodeRef { kind: ExprCall, range: 861..881 }, target: AstNodeRef { kind: ExprName, range: 849..858 } }), is_reexported: true }), kind: Legacy }, _bound_or_constraints: None, explicit_variance: Some(Invariant), _default: None }, binding_context: Definition(Definition { [salsa id]: Id(3e6aa), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(41)), kind: Class(AstNodeRef { kind: StmtClassDef, range: 5860..6194 }), is_reexported: true }) }, should_promote_literals: false }, BoundTypeVarIdentity { identity: TypeVarIdentity { name: Name("_PWrapper"), definition: Some(Definition { [salsa id]: Id(3e673), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(29)), kind: Assignment(AssignmentDefinitionKind { target_kind: Single, value: AstNodeRef { kind: ExprCall, range: 894..916 }, target: AstNodeRef { kind: ExprName, range: 882..891 } }), is_reexported: true }), kind: ParamSpec }, binding_context: Definition(Definition { [salsa id]: Id(3e6aa), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(41)), kind: Class(AstNodeRef { kind: StmtClassDef, range: 5860..6194 }), is_reexported: true }) }: GenericContextTypeVar { bound_typevar: BoundTypeVarInstance { typevar: TypeVarInstance { identity: TypeVarIdentity { name: Name("_PWrapper"), definition: Some(Definition { [salsa id]: Id(3e673), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(29)), kind: Assignment(AssignmentDefinitionKind { target_kind: Single, value: AstNodeRef { kind: ExprCall, range: 894..916 }, target: AstNodeRef { kind: ExprName, range: 882..891 } }), is_reexported: true }), kind: ParamSpec }, _bound_or_constraints: None, explicit_variance: None, _default: None }, binding_context: Definition(Definition { [salsa id]: Id(3e6aa), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(41)), kind: Class(AstNodeRef { kind: StmtClassDef, range: 5860..6194 }), is_reexported: true }) }, should_promote_literals: false }, BoundTypeVarIdentity { identity: TypeVarIdentity { name: Name("_RWrapper"), definition: Some(Definition { [salsa id]: Id(3e674), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(30)), kind: Assignment(AssignmentDefinitionKind { target_kind: Single, value: AstNodeRef { kind: ExprCall, range: 929..949 }, target: AstNodeRef { kind: ExprName, range: 917..926 } }), is_reexported: true }), kind: Legacy }, binding_context: Definition(Definition { [salsa id]: Id(3e6aa), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(41)), kind: Class(AstNodeRef { kind: StmtClassDef, range: 5860..6194 }), is_reexported: true }) }: GenericContextTypeVar { bound_typevar: BoundTypeVarInstance { typevar: TypeVarInstance { identity: TypeVarIdentity { name: Name("_RWrapper"), definition: Some(Definition { [salsa id]: Id(3e674), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(30)), kind: Assignment(AssignmentDefinitionKind { target_kind: Single, value: AstNodeRef { kind: ExprCall, range: 929..949 }, target: AstNodeRef { kind: ExprName, range: 917..926 } }), is_reexported: true }), kind: Legacy }, _bound_or_constraints: None, explicit_variance: Some(Invariant), _default: None }, binding_context: Definition(Definition { [salsa id]: Id(3e6aa), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(41)), kind: Class(AstNodeRef { kind: StmtClassDef, range: 5860..6194 }), is_reexported: true }) }, should_promote_literals: false }} }, types: [TypeVar(BoundTypeVarInstance { typevar: TypeVarInstance { identity: TypeVarIdentity { name: Name("_PWrapped"), definition: Some(Definition { [salsa id]: Id(3e671), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(27)), kind: Assignment(AssignmentDefinitionKind { target_kind: Single, value: AstNodeRef { kind: ExprCall, range: 826..848 }, target: AstNodeRef { kind: ExprName, range: 814..823 } }), is_reexported: true }), kind: ParamSpec }, _bound_or_constraints: None, explicit_variance: None, _default: None }, binding_context: Definition(Definition { [salsa id]: Id(3e6aa), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(41)), kind: Class(AstNodeRef { kind: StmtClassDef, range: 5860..6194 }), is_reexported: true }) }), TypeVar(BoundTypeVarInstance { typevar: TypeVarInstance { identity: TypeVarIdentity { name: Name("_RWrapped"), definition: Some(Definition { [salsa id]: Id(3e672), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(28)), kind: Assignment(AssignmentDefinitionKind { target_kind: Single, value: AstNodeRef { kind: ExprCall, range: 861..881 }, target: AstNodeRef { kind: ExprName, range: 849..858 } }), is_reexported: true }), kind: Legacy }, _bound_or_constraints: None, explicit_variance: Some(Invariant), _default: None }, binding_context: Definition(Definition { [salsa id]: Id(3e6aa), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(41)), kind: Class(AstNodeRef { kind: StmtClassDef, range: 5860..6194 }), is_reexported: true }) }), TypeVar(BoundTypeVarInstance { typevar: TypeVarInstance { identity: TypeVarIdentity { name: Name("_PWrapper"), definition: Some(Definition { [salsa id]: Id(3e673), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(29)), kind: Assignment(AssignmentDefinitionKind { target_kind: Single, value: AstNodeRef { kind: ExprCall, range: 894..916 }, target: AstNodeRef { kind: ExprName, range: 882..891 } }), is_reexported: true }), kind: ParamSpec }, _bound_or_constraints: None, explicit_variance: None, _default: None }, binding_context: Definition(Definition { [salsa id]: Id(3e6aa), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(41)), kind: Class(AstNodeRef { kind: StmtClassDef, range: 5860..6194 }), is_reexported: true }) }), TypeVar(BoundTypeVarInstance { typevar: TypeVarInstance { identity: TypeVarIdentity { name: Name("_RWrapper"), definition: Some(Definition { [salsa id]: Id(3e674), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(30)), kind: Assignment(AssignmentDefinitionKind { target_kind: Single, value: AstNodeRef { kind: ExprCall, range: 929..949 }, target: AstNodeRef { kind: ExprName, range: 917..926 } }), is_reexported: true }), kind: Legacy }, _bound_or_constraints: None, explicit_variance: Some(Invariant), _default: None }, binding_context: Definition(Definition { [salsa id]: Id(3e6aa), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(41)), kind: Class(AstNodeRef { kind: StmtClassDef, range: 5860..6194 }), is_reexported: true }) })], materialization_kind: None, tuple_inner: None } }))))))), explicit_variance: Some(Invariant), _default: None }, binding_context: Definition(Definition { [salsa id]: Id(3e6a7), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(15), place: Symbol(ScopedSymbolId(6)), kind: Function(AstNodeRef { kind: StmtFunctionDef, range: 5998..6085 }), is_reexported: true }) })), inferred_annotation: true, kind: PositionalOrKeyword { name: Name("self"), default_type: None }, form: Value }, Parameter { annotated_type: Some(Dynamic(Todo(TodoType("ParamSpecArgs / ParamSpecKwargs")))), inferred_annotation: false, kind: Variadic { name: Name("args") }, form: Value }, Parameter { annotated_type: Some(Dynamic(Todo(TodoType("ParamSpecArgs / ParamSpecKwargs")))), inferred_annotation: false, kind: KeywordVariadic { name: Name("kwargs") }, form: Value }], is_gradual: false }, return_ty: Some(TypeVar(BoundTypeVarInstance { typevar: TypeVarInstance { identity: TypeVarIdentity { name: Name("_RWrapper"), definition: Some(Definition { [salsa id]: Id(3e674), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(30)), kind: Assignment(AssignmentDefinitionKind { target_kind: Single, value: AstNodeRef { kind: ExprCall, range: 929..949 }, target: AstNodeRef { kind: ExprName, range: 917..926 } }), is_reexported: true }), kind: Legacy }, _bound_or_constraints: None, explicit_variance: Some(Invariant), _default: None }, binding_context: Definition(Definition { [salsa id]: Id(3e6aa), file: File(Vendored(VendoredPathBuf("stdlib/functools.pyi"))), file_scope: FileScopeId(0), place: Symbol(ScopedSymbolId(41)), kind: Class(AstNodeRef { kind: StmtClassDef, range: 5860..6194 }), is_reexported: true }) })) }`
```


