### PR TITLE
[ty] Fix `--exclude` and `src.exclude` merging

### DIFF
--- a/crates/ty_project/src/metadata/options.rs
+++ b/crates/ty_project/src/metadata/options.rs
@@ -1186,6 +1186,16 @@ impl From<OutputFormat> for DiagnosticFormat {
     }
 }
 
+impl Combine for OutputFormat {
+    #[inline(always)]
+    fn combine_with(&mut self, _other: Self) {}
+
+    #[inline]
+    fn combine(self, _other: Self) -> Self {
+        self
+    }
+}
+
 #[derive(
     Debug,
     Default,

--- a/crates/ty_project/src/metadata/value.rs
+++ b/crates/ty_project/src/metadata/value.rs
@@ -179,14 +179,13 @@ impl<T> RangedValue<T> {
     }
 }
 
-impl<T> Combine for RangedValue<T> {
-    fn combine(self, _other: Self) -> Self
-    where
-        Self: Sized,
-    {
-        self
+impl<T> Combine for RangedValue<T>
+where
+    T: Combine,
+{
+    fn combine_with(&mut self, other: Self) {
+        self.value.combine_with(other.value);
     }
-    fn combine_with(&mut self, _other: Self) {}
 }
 
 impl<T> IntoIterator for RangedValue<T>

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -7488,7 +7488,7 @@ impl<'db> VarianceInferable<'db> for Type<'db> {
             | Type::TypeAlias(_) => TypeVarVariance::Bivariant,
         };
 
-        tracing::debug!(
+        tracing::trace!(
             "Result of variance of '{tvar}' in `{ty:?}` is `{v:?}`",
             tvar = typevar.typevar(db).name(db),
             ty = self.display(db),


### PR DESCRIPTION
## Summary

The `RangedValue` `Combine` implementation always returned `self` 
instead of using `T::combine` to merge the value. 

This results in incorrect merging for lists (and maps) where the values should be
merged and not replaced because we use the `!pattern` syntax to override the inherited `pattern`.


## Test Plan

Added test
