### PR TITLE
[ty] supress inlay hints for `+1` and `-1`

### DIFF
--- a/crates/ty_ide/src/inlay_hints.rs
+++ b/crates/ty_ide/src/inlay_hints.rs
@@ -346,7 +346,7 @@ fn type_hint_is_excessive_for_expr(expr: &Expr) -> bool {
         | Expr::TString(_)=> true,
 
         // You too `+1 and `-1`, get back here  
-        | Expr::UnaryOp(ExprUnaryOp { op: UnaryOp::UAdd | UnaryOp::USub, operand, .. }) => matches!(**operand, Expr::NumberLiteral(_)),
+        Expr::UnaryOp(ExprUnaryOp { op: UnaryOp::UAdd | UnaryOp::USub, operand, .. }) => matches!(**operand, Expr::NumberLiteral(_)),
 
         // Everything else is reasonable
         _ => false,


### PR DESCRIPTION
It's everyone's favourite language corner case!

Also having kicked the tires on it, I'm pretty happy to call this (in conjunction with #21367):

Fixes https://github.com/astral-sh/ty/issues/494

There's cases where you can make noisy Literal hints appear, so we can always iterate on it, but this handles like, 98% of the cases in the wild, which is great.