### PR TITLE
[ty] Make implicit submodule imports only occur in global scope

### DIFF
--- a/crates/ty_python_semantic/src/semantic_index/builder.rs
+++ b/crates/ty_python_semantic/src/semantic_index/builder.rs
@@ -1454,6 +1454,7 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
                 // * `from .x.y import z` (must be relative!)
                 // * And we are in an `__init__.py(i)` (hereafter `thispackage`)
                 // * And this is the first time we've seen `from .x` in this module
+                // * And we're in the global scope
                 //
                 // We introduce a local definition `x = <module 'thispackage.x'>` that occurs
                 // before the `z = ...` declaration the import introduces. This models the fact
@@ -1466,9 +1467,8 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
                 // in one function is visible in another function.
                 //
                 // TODO: Also support `from thispackage.x.y import z`?
-                // TODO: `seen_submodule_imports` should be per-scope and not per-file
-                // (if two functions import `.x`, they both should believe `x` is defined)
-                if node.level == 1
+                if self.current_scope() == FileScopeId::global()
+                    && node.level == 1
                     && let Some(submodule) = &node.module
                     && let Some(parsed_submodule) = ModuleName::new(submodule.as_str())
                     && let Some(direct_submodule) = parsed_submodule.components().next()

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5911,20 +5911,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         submodule: &Name,
         definition: Definition<'db>,
     ) {
-        // Although the *actual* runtime semantic of this kind of statement is to
-        // introduce a variable in the global scope of this module, we want to
-        // encourage users to write code that doesn't have dependence on execution-order.
-        //
-        // By introducing it as a local variable in the scope the import occurs in,
-        // we effectively require the developer to either do the import at the start of
-        // the file where it belongs, or to repeat the import in every function that
-        // wants to use it, which "definitely" works.
-        //
-        // (It doesn't actually "definitely" work because only the first import of `thispackage.x`
-        // will ever set `x`, and any subsequent overwrites of it will permanently clobber it.
-        // Also, a local variable `x` in a function should always shadow the submodule because
-        // the submodule is defined at file-scope. However, both of these issues are much more
-        // narrow, so this approach seems to work well in practice!)
+        // The runtime semantic of this kind of statement is to introduce a variable in the global
+        // scope of this module, so we do just that. (Actually we introduce a local variable, but
+        // this type of Definition is only created when a `from..import` is in global scope.)
 
         // Get this package's module by resolving `.`
         let Ok(module_name) = ModuleName::from_identifier_parts(self.db(), self.file(), None, 1)


### PR DESCRIPTION
This loses any ability to have "per-function" implicit submodule imports, to avoid the "ok but now we need per-scope imports" and "ok but this should actually introduce a global that only exists during this function" problems. A simple and clean implementation with no weird corners.

Fixes https://github.com/astral-sh/ty/issues/1482