### PR TITLE
[ty] Silence false-positive diagnostics when using `typing.Dict` or `typing.Callable` as the second argument to `isinstance()`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/builtins.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/builtins.md
@@ -163,7 +163,7 @@ def _(x: A | B, y: list[int]):
         reveal_type(isinstance(x, B))  # revealed: Literal[True]
 ```
 
-Certain special forms in the typing module are not instances of `type`, so are strictly-spekaing
+Certain special forms in the typing module are not instances of `type`, so are strictly-speaking
 disallowed as the second argument to `isinstance()` according to typeshed's annotations. However, at
 runtime they work fine as the second argument, and we implement that special case in ty:
 
@@ -182,6 +182,11 @@ isinstance("", t.Deque)
 isinstance("", t.OrderedDict)
 isinstance("", t.Callable)
 isinstance("", t.Type)
+isinstance("", t.Callable | t.Deque)
+
+# `Any` is valid in `issubclass()` calls but not `isinstance()` calls
+issubclass(list, t.Any)
+issubclass(list, t.Any | t.Dict)
 ```
 
 But for other special forms that are not permitted as the second argument, we still emit an error:
@@ -190,4 +195,5 @@ But for other special forms that are not permitted as the second argument, we st
 isinstance("", t.TypeGuard)  # error: [invalid-argument-type]
 isinstance("", t.ClassVar)  # error: [invalid-argument-type]
 isinstance("", t.Final)  # error: [invalid-argument-type]
+isinstance("", t.Any)  # error: [invalid-argument-type]
 ```

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1028,6 +1028,13 @@ impl<'db> Type<'db> {
         any_over_type(db, self, &|ty| matches!(ty, Type::TypeVar(_)), false)
     }
 
+    pub(crate) const fn as_special_form(self) -> Option<SpecialFormType> {
+        match self {
+            Type::SpecialForm(special_form) => Some(special_form),
+            _ => None,
+        }
+    }
+
     pub(crate) const fn as_class_literal(self) -> Option<ClassLiteral<'db>> {
         match self {
             Type::ClassLiteral(class_type) => Some(class_type),

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -3665,23 +3665,9 @@ impl<'db> BindingError<'db> {
                             .and_then(|function| function.known(context.db())),
                         Some(KnownFunction::IsInstance | KnownFunction::IsSubclass)
                     )
-                    && matches!(
-                        provided_ty,
-                        Type::SpecialForm(
-                            SpecialFormType::Callable
-                                | SpecialFormType::ChainMap
-                                | SpecialFormType::Counter
-                                | SpecialFormType::DefaultDict
-                                | SpecialFormType::Deque
-                                | SpecialFormType::FrozenSet
-                                | SpecialFormType::Dict
-                                | SpecialFormType::List
-                                | SpecialFormType::OrderedDict
-                                | SpecialFormType::Set
-                                | SpecialFormType::Tuple
-                                | SpecialFormType::Type
-                        )
-                    )
+                    && provided_ty
+                        .as_special_form()
+                        .is_some_and(SpecialFormType::is_valid_isinstance_target)
                 {
                     return;
                 }

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -1764,6 +1764,7 @@ impl KnownFunction {
                     Type::KnownInstance(KnownInstanceType::UnionType(_)) => {
                         fn find_invalid_elements<'db>(
                             db: &'db dyn Db,
+                            function: KnownFunction,
                             ty: Type<'db>,
                             invalid_elements: &mut Vec<Type<'db>>,
                         ) {
@@ -1771,9 +1772,19 @@ impl KnownFunction {
                                 Type::ClassLiteral(_) => {}
                                 Type::NominalInstance(instance)
                                     if instance.has_known_class(db, KnownClass::NoneType) => {}
+                                Type::SpecialForm(special_form)
+                                    if special_form.is_valid_isinstance_target() => {}
+                                // `Any` can be used in `issubclass()` calls but not `isinstance()` calls
+                                Type::SpecialForm(SpecialFormType::Any)
+                                    if function == KnownFunction::IsSubclass => {}
                                 Type::KnownInstance(KnownInstanceType::UnionType(union)) => {
                                     for element in union.elements(db) {
-                                        find_invalid_elements(db, *element, invalid_elements);
+                                        find_invalid_elements(
+                                            db,
+                                            function,
+                                            *element,
+                                            invalid_elements,
+                                        );
                                     }
                                 }
                                 _ => invalid_elements.push(ty),
@@ -1781,7 +1792,7 @@ impl KnownFunction {
                         }
 
                         let mut invalid_elements = vec![];
-                        find_invalid_elements(db, *second_argument, &mut invalid_elements);
+                        find_invalid_elements(db, self, *second_argument, &mut invalid_elements);
 
                         let Some((first_invalid_element, other_invalid_elements)) =
                             invalid_elements.split_first()

--- a/crates/ty_python_semantic/src/types/special_form.rs
+++ b/crates/ty_python_semantic/src/types/special_form.rs
@@ -328,6 +328,58 @@ impl SpecialFormType {
         }
     }
 
+    /// Return `true` if this special form is valid as the second argument
+    /// to `issubclass()` and `isinstance()` calls.
+    pub(super) const fn is_valid_isinstance_target(self) -> bool {
+        match self {
+            Self::Callable
+            | Self::ChainMap
+            | Self::Counter
+            | Self::DefaultDict
+            | Self::Deque
+            | Self::FrozenSet
+            | Self::Dict
+            | Self::List
+            | Self::OrderedDict
+            | Self::Set
+            | Self::Tuple
+            | Self::Type
+            | Self::Protocol
+            | Self::Generic => true,
+
+            Self::AlwaysFalsy
+            | Self::AlwaysTruthy
+            | Self::Annotated
+            | Self::Bottom
+            | Self::CallableTypeOf
+            | Self::ClassVar
+            | Self::Concatenate
+            | Self::Final
+            | Self::Intersection
+            | Self::Literal
+            | Self::LiteralString
+            | Self::Never
+            | Self::NoReturn
+            | Self::Not
+            | Self::ReadOnly
+            | Self::Required
+            | Self::TypeAlias
+            | Self::TypeGuard
+            | Self::NamedTuple
+            | Self::NotRequired
+            | Self::Optional
+            | Self::Top
+            | Self::TypeIs
+            | Self::TypedDict
+            | Self::TypingSelf
+            | Self::Union
+            | Self::Unknown
+            | Self::TypeOf
+            | Self::Any  // can be used in `issubclass()` but not `isinstance()`.
+            | Self::Unpack => false,
+        }
+    }
+
     /// Return the repr of the symbol at runtime
     pub(super) const fn repr(self) -> &'static str {
         match self {


### PR DESCRIPTION
## Summary

Typeshed annotates the builtin functions `isinstance()` and `issubclass()` like so:

https://github.com/astral-sh/ruff/blob/44b0c9ebac8b63d39632233959ff3ec2694c3ef6/crates/ty_vendored/vendor/typeshed/stdlib/builtins.pyi#L3741-L3760

That leads us to currently reject code such as `isinstance({}, typing.Dict)`, since `typing.Dict` isn't an instance of `type`, an instance of `types.UnionType`, or a tuple thereof:

```pycon
>>> import typing
>>> type(typing.Dict)
<class 'typing._SpecialGenericAlias'>
```

However, you _can_ still nonetheless use it in `isinstance()` checks at runtime, due to some magic the typing module does to make these special forms behave similarly to the stdlib clases that they're aliasing in some ways:

```pycon
>>> isinstance({}, typing.Dict)
True
```

This PR implements that special case.

## Test Plan

Mdtests added
