### PR TITLE
`UP035`: Consistently set the deprecated tag

### DIFF
--- a/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_import.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_import.rs
@@ -766,11 +766,12 @@ pub(crate) fn deprecated_import(checker: &Checker, import_from_stmt: &StmtImport
     }
 
     for operation in fixer.with_renames() {
-        checker.report_diagnostic(
+        let mut diagnostic = checker.report_diagnostic(
             DeprecatedImport {
                 deprecation: Deprecation::WithRename(operation),
             },
             import_from_stmt.range(),
         );
+        diagnostic.add_primary_tag(ruff_db::diagnostic::DiagnosticTag::Deprecated);
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
This PR fixes #21333 

## Test Plan

<!-- How was it tested? -->
Before:
<img width="613" height="194" alt="Screenshot from 2025-11-12 11-23-41" src="https://github.com/user-attachments/assets/45e68870-229d-48c3-ae68-dbd3998c1fd1" />
After:
<img width="613" height="194" alt="Screenshot from 2025-11-12 11-24-16" src="https://github.com/user-attachments/assets/0808405b-9ac1-4c43-a44d-3edd79ac6f7b" />

Settings.json configured with local release binary:
<img width="613" height="194" alt="image" src="https://github.com/user-attachments/assets/aaca00a1-0ed3-4a6a-a017-2602ac913acc" />

