### PR TITLE
[ty] Reorganize walltime benchmarks

### DIFF
--- a/crates/ruff_benchmark/benches/ty_walltime.rs
+++ b/crates/ruff_benchmark/benches/ty_walltime.rs
@@ -238,7 +238,7 @@ fn run_single_threaded(bencher: Bencher, benchmark: &Benchmark) {
         });
 }
 
-#[bench(args=[&ALTAIR, &FREQTRADE, &PYDANTIC, &TANJUN], sample_size=2, sample_count=3)]
+#[bench(args=[&ALTAIR, &FREQTRADE, &TANJUN], sample_size=2, sample_count=3)]
 fn small(bencher: Bencher, benchmark: &Benchmark) {
     run_single_threaded(bencher, benchmark);
 }
@@ -248,12 +248,12 @@ fn medium(bencher: Bencher, benchmark: &Benchmark) {
     run_single_threaded(bencher, benchmark);
 }
 
-#[bench(args=[&SYMPY], sample_size=1, sample_count=2)]
+#[bench(args=[&SYMPY, &PYDANTIC], sample_size=1, sample_count=2)]
 fn large(bencher: Bencher, benchmark: &Benchmark) {
     run_single_threaded(bencher, benchmark);
 }
 
-#[bench(args=[&PYDANTIC], sample_size=3, sample_count=8)]
+#[bench(args=[&ALTAIR], sample_size=3, sample_count=8)]
 fn multithreaded(bencher: Bencher, benchmark: &Benchmark) {
     let thread_pool = ThreadPoolBuilder::new().build().unwrap();
 


### PR DESCRIPTION
## Summary

I would like to merge this before https://github.com/astral-sh/ruff/pull/21363 to establish a new baseline.

* Move `pydantic` to the "large" section, as ty will soon be much slower when type-checking that project
* Use `altair` instead of `pydantic` for the multithreaded benchmark

## Test Plan

Both benchmark shards still take roughly the same amount of time (10% difference):

`medium|multithreaded`:

<img width="411" height="74" alt="image" src="https://github.com/user-attachments/assets/4c191c44-5e68-4765-a851-6f06ac8d0c93" />


`small|large`:

<img width="305" height="62" alt="image" src="https://github.com/user-attachments/assets/57a99b7c-0c98-4420-a097-4e0dc04f4d2b" />
