### PR TITLE
[ty] Resolve overloads for hovers

### DIFF
--- a/crates/ty_ide/src/goto.rs
+++ b/crates/ty_ide/src/goto.rs
@@ -15,8 +15,7 @@ use ruff_text_size::{Ranged, TextRange, TextSize};
 use ty_python_semantic::ResolvedDefinition;
 use ty_python_semantic::types::Type;
 use ty_python_semantic::types::ide_support::{
-    CallSignatureDetails, call_signature_details, call_signature_details_typed,
-    definitions_for_keyword_argument,
+    call_signature_details, call_type_simplified_by_overloads, definitions_for_keyword_argument,
 };
 use ty_python_semantic::{
     HasDefinition, HasType, ImportAliasResolution, SemanticModel, definitions_for_imported_symbol,
@@ -327,20 +326,16 @@ impl GotoTarget<'_> {
         Some(ty)
     }
 
-    pub(crate) fn signature<'db>(
+    /// Try to get a simplified display of this callable type by resolving overloads
+    pub(crate) fn call_type_simplified_by_overloads(
         &self,
-        model: &SemanticModel<'db>,
-    ) -> Option<Vec<CallSignatureDetails<'db>>> {
+        model: &SemanticModel,
+    ) -> Option<String> {
         if let GotoTarget::Call { call, .. } = self {
-            let signature_details = call_signature_details(model.db(), model, call);
-            if signature_details.len() > 1 {
-                let signature_details = call_signature_details_typed(model.db(), model, call);
-                if !signature_details.is_empty() {
-                    return Some(signature_details);
-                }
-            }
+            call_type_simplified_by_overloads(model.db(), model, call)
+        } else {
+            None
         }
-        None
     }
 
     /// Gets the definitions for this goto target.

--- a/crates/ty_python_semantic/src/types/call/arguments.rs
+++ b/crates/ty_python_semantic/src/types/call/arguments.rs
@@ -67,6 +67,9 @@ impl<'a, 'db> CallArguments<'a, 'db> {
     }
 
     /// Like [`Self::from_arguments`] but fills as much typing info in as possible.
+    ///
+    /// This currently only exists for the LSP usecase, and shouldn't be used in normal
+    /// typechecking.
     pub(crate) fn from_arguments_typed(
         arguments: &'a ast::Arguments,
         mut infer_argument_type: impl FnMut(Option<&ast::Expr>, &ast::Expr) -> Type<'db>,

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -17,7 +17,7 @@ use crate::types::{
     ClassBase, ClassLiteral, DynamicType, KnownClass, KnownInstanceType, Type, TypeContext,
     TypeVarBoundOrConstraints, class::CodeGeneratorKind,
 };
-use crate::{Db, HasType, NameKind, SemanticModel};
+use crate::{Db, DisplaySettings, HasType, NameKind, SemanticModel};
 use ruff_db::files::{File, FileRange};
 use ruff_db::parsed::parsed_module;
 use ruff_python_ast::name::Name;
@@ -973,55 +973,63 @@ pub fn call_signature_details<'db>(
     }
 }
 
-/// Extract signature details from a function call expression using type info.
+/// Given a call expression that has overloads, and whose overload is resolved to a
+/// single option by its arguments, return the type of the Signature.
 ///
-/// Unlike [`call_signature_details`][] we reduce down to the exact match if possible.
-pub fn call_signature_details_typed<'db>(
+/// This is only used for simplifying complex call types, so if we ever detect that
+/// the given callable type *is* simple, or that our answer *won't* be simple, we
+/// bail at out and return None, so that the original type can be used.
+///
+/// We do this because `Type::Signature` intentionally loses a lot of context, and
+/// so it has a "worse" display than say `Type::FunctionLiteral` or `Type::BoundMethod`,
+/// which this analysis would naturally wipe away. The contexts this function
+/// succeeds in are those where we would print a complicated/ugly type anyway.
+pub fn call_type_simplified_by_overloads<'db>(
     db: &'db dyn Db,
     model: &SemanticModel<'db>,
     call_expr: &ast::ExprCall,
-) -> Vec<CallSignatureDetails<'db>> {
+) -> Option<String> {
     let func_type = call_expr.func.inferred_type(model);
 
     // Use into_callable to handle all the complex type conversions
-    if let Some(callable_type) = func_type.try_upcast_to_callable(db) {
-        // Really shove as much type info in as we can
-        let call_arguments =
-            CallArguments::from_arguments_typed(&call_expr.arguments, |_, splatted_value| {
-                splatted_value.inferred_type(model)
-            });
+    let callable_type = func_type.try_upcast_to_callable(db)?;
+    let bindings = callable_type.bindings(db);
 
-        // Extract signature details from all callable bindings
-        callable_type
-            .bindings(db)
-            .match_parameters(db, &call_arguments)
-            .check_types(db, &call_arguments, TypeContext::default(), &[])
-            // Only use the Ok
-            .iter()
-            .flatten()
-            // The first matching overload is the one to use
-            .filter_map(|binding| binding.matching_overloads().next())
-            .map(|(_, binding)| {
-                let argument_to_parameter_mapping = binding.argument_matches().to_vec();
-                let signature = binding.signature.clone();
-                let display_details = signature.display(db).to_string_parts();
-                let parameter_label_offsets = display_details.parameter_ranges;
-                let parameter_names = display_details.parameter_names;
-
-                CallSignatureDetails {
-                    definition: signature.definition(),
-                    signature,
-                    label: display_details.label,
-                    parameter_label_offsets,
-                    parameter_names,
-                    argument_to_parameter_mapping,
-                }
-            })
-            .collect()
-    } else {
-        // Type is not callable, return empty signatures
-        vec![]
+    // If the callable is trivial this analysis is useless, bail out
+    if let Some(binding) = bindings.single_element()
+        && binding.overloads().len() < 2
+    {
+        return None;
     }
+
+    // Hand the overload resolution system as much type info as we have
+    let args = CallArguments::from_arguments_typed(&call_expr.arguments, |_, splatted_value| {
+        splatted_value.inferred_type(model)
+    });
+
+    // Try to resolve overloads with the arguments/types we have
+    let mut resolved = bindings
+        .match_parameters(db, &args)
+        .check_types(db, &args, TypeContext::default(), &[])
+        // Only use the Ok
+        .iter()
+        .flatten()
+        .flat_map(|binding| {
+            binding.matching_overloads().map(|(_, overload)| {
+                overload
+                    .signature
+                    .display_with(db, DisplaySettings::default().multiline())
+                    .to_string()
+            })
+        })
+        .collect::<Vec<_>>();
+
+    // If at the end of this we still got multiple signatures (or no signatures), give up
+    if resolved.len() != 1 {
+        return None;
+    }
+
+    resolved.pop()
 }
 
 /// Returns the definitions of the binary operation along with its callable type.


### PR DESCRIPTION
This is a very conservative minimal implementation of applying overloads to resolve a callable-type-being-called down to a single function signature on hover. If we ever encounter a situation where the answer doesn't simplify down to a single function call, we bail out to preserve prettier printing of non-raw-Signatures.

The resulting Signatures are still a bit bare, I'm going to try to improve that in a followup to improve our Signature printing in general.

Fixes https://github.com/astral-sh/ty/issues/73