### PR TITLE
[ty] Add filtering option for mdtest runner

### DIFF
--- a/crates/ty_python_semantic/mdtest.py
+++ b/crates/ty_python_semantic/mdtest.py
@@ -131,13 +131,6 @@ class MDTestRunner:
             .removesuffix(".md")
         )
 
-    def _matches_filter(self, markdown_file: Path) -> bool:
-        if not self.filters:
-            return True
-
-        path_mangled = self._mangle_path(markdown_file)
-        return any(filter in path_mangled for filter in self.filters)
-
     def _run_mdtests_for_file(self, markdown_file: Path) -> None:
         path_mangled = self._mangle_path(markdown_file)
         test_name = f"mdtest__{path_mangled}"
@@ -243,8 +236,7 @@ class MDTestRunner:
                 )
 
             for path in new_md_files | changed_md_files:
-                if self._matches_filter(path):
-                    self._run_mdtests_for_file(path)
+                self._run_mdtests_for_file(path)
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary

This change to the mdtest runner makes it easy to run on a subset of tests/files. For example:

```
▶ uv run crates/ty_python_semantic/mdtest.py implicit
running 1 test
test mdtest__implicit_type_aliases ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 281 filtered out; finished in 0.83s

Ready to watch for changes...
```

Subsequent changes to either that test file or the Rust source code will also only rerun the `implicit_type_aliases` test.

Multiple arguments can be provided, and filters can either be partial file paths (`loops/for.md`, `loops/for`, `for`) or mangled test names (`loops_for`):
```
▶ uv run crates/ty_python_semantic/mdtest.py implicit binary/union

running 2 tests
test mdtest__binary_unions ... ok
test mdtest__implicit_type_aliases ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 280 filtered out; finished in 0.85s

Ready to watch for changes...
```

## Test Plan

Tested it interactively for a while