### PR TITLE
[ty] Fix panic for cyclic star imports

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -331,9 +331,7 @@ jobs:
         with:
           enable-cache: "true"
       - name: "Run tests"
-        run: cargo nextest run --cargo-profile profiling --all-features
-      - name: "Run doctests"
-        run: cargo test --doc --profile profiling --all-features
+        run: cargo insta test --release --all-features --unreferenced reject --test-runner nextest
 
   cargo-test-other:
     strategy:


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ty/issues/444

This PR fixes a panic where the `export_names` query never converged for a cyclic star import. 

This is a rather silly bug. The cycle never converged because the symbol ordering changed between iterations (forever).... 


Here's a diff between the exported symbols before the fix for the last two iterations

https://www.diffchecker.com/tk3ihAdo/


This PR fixes the bug by simply sorting the names before returning.

I considered using a `BTreeMap` but found the sort slightly simpler (and both roughly have the same complexity)

## Test Plan

I recreated the MRE from the linked issue and verified that it panics without my changes.
