### PR TITLE
Use `profiling` profile for `cargo test(linux, release)`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -322,16 +322,14 @@ jobs:
         uses: taiki-e/install-action@44c6d64aa62cd779e873306675c7a58e86d6d532 # v2.62.49
         with:
           tool: cargo-nextest
-      - name: "Install cargo insta"
-        uses: taiki-e/install-action@44c6d64aa62cd779e873306675c7a58e86d6d532 # v2.62.49
-        with:
-          tool: cargo-insta
       - name: "Install uv"
         uses: astral-sh/setup-uv@85856786d1ce8acfbcc2f13a5f3fbd6b938f9f41 # v7.1.2
         with:
           enable-cache: "true"
       - name: "Run tests"
-        run: cargo insta test --release --all-features --unreferenced reject --test-runner nextest
+        run: cargo nextest run --cargo-profile profiling --all-features
+      - name: "Run doctests"
+        run: cargo test --doc --profile profiling --all-features
 
   cargo-test-other:
     strategy:


### PR DESCRIPTION
## Summary

Use the `profiling` profile over the `release` profile for `cargo test(linux, release)`. 

The idea of the `release` CI job is to catch bugs related to when `debug_assertions` is disabled. 
Since testing ruff/ty with `debug_assertions` doesn't require the `releaes` profile and because the `release` profile takes very long to build,  this PR switches to `profiling` to accomplish the same in less time.

I had to switch to use `nextest` directly because `cargo insta` doesn't remap the `--profile profiling` argument  to `--cargo-profile profiling` as required by insta. The only consequence this has is that we need to run the doctests ourselves and that we don't get unused snapshot detection. I don't think the latter is important as we already enforce this in all our other test CI jobs and is only really important to find stale snapshots.


## Test Plan

The release job now completes in 4min 30s (with a cold cache) compared to 9min before.
