### PR TITLE
[ty] Improve LSP test server logging

### DIFF
--- a/crates/ty_server/src/capabilities.rs
+++ b/crates/ty_server/src/capabilities.rs
@@ -40,6 +40,16 @@ bitflags::bitflags! {
     }
 }
 
+impl std::fmt::Display for ResolvedClientCapabilities {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut f = f.debug_list();
+        for (name, _) in self.iter_names() {
+            f.entry(&name);
+        }
+        f.finish()
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(crate) enum SupportedCommand {
     Debug,

--- a/crates/ty_server/src/server.rs
+++ b/crates/ty_server/src/server.rs
@@ -65,9 +65,12 @@ impl Server {
             tracing::error!("Failed to deserialize initialization options: {error}");
         }
 
-        tracing::debug!("Initialization options: {initialization_options:?}");
+        tracing::debug!("Initialization options: {initialization_options:#?}");
 
         let resolved_client_capabilities = ResolvedClientCapabilities::new(&client_capabilities);
+
+        tracing::debug!("Resolved client capabilities: {resolved_client_capabilities}");
+
         let position_encoding = Self::find_best_position_encoding(&client_capabilities);
         let server_capabilities = server_capabilities(
             position_encoding,

--- a/crates/ty_server/src/server/api/diagnostics.rs
+++ b/crates/ty_server/src/server/api/diagnostics.rs
@@ -5,7 +5,6 @@ use lsp_types::{
     CodeDescription, Diagnostic, DiagnosticRelatedInformation, DiagnosticSeverity, DiagnosticTag,
     NumberOrString, PublishDiagnosticsParams, Url,
 };
-use ruff_db::source::source_text;
 use rustc_hash::FxHashMap;
 
 use ruff_db::diagnostic::{Annotation, Severity, SubDiagnostic};
@@ -274,7 +273,6 @@ pub(super) fn compute_diagnostics(
         return None;
     };
 
-    tracing::debug!("source text: {}", source_text(db, file).as_str());
     let diagnostics = db.check_file(file);
 
     Some(Diagnostics {

--- a/crates/ty_server/tests/e2e/main.rs
+++ b/crates/ty_server/tests/e2e/main.rs
@@ -167,6 +167,8 @@ impl TestServer {
     ) -> Result<Self> {
         setup_tracing();
 
+        tracing::debug!("Starting test client with capabilities {:#?}", capabilities);
+
         let (server_connection, client_connection) = Connection::memory();
 
         // Create OS system with the test directory as cwd
@@ -346,6 +348,7 @@ impl TestServer {
         }
 
         let id = self.next_request_id();
+        tracing::debug!("Client sends request `{}` with ID {}", R::METHOD, id);
         let request = lsp_server::Request::new(id.clone(), R::METHOD.to_string(), params);
         self.send(Message::Request(request));
         id
@@ -357,6 +360,7 @@ impl TestServer {
         N: Notification,
     {
         let notification = lsp_server::Notification::new(N::METHOD.to_string(), params);
+        tracing::debug!("Client sends notification `{}`", N::METHOD);
         self.send(Message::Notification(notification));
     }
 
@@ -540,7 +544,7 @@ impl TestServer {
     fn handle_message(&mut self, message: Message) -> Result<(), TestServerError> {
         match message {
             Message::Request(request) => {
-                tracing::debug!("Received server request {}", &request.method);
+                tracing::debug!("Received server request `{}`", &request.method);
                 self.requests.push_back(request);
             }
             Message::Response(response) => {
@@ -558,7 +562,7 @@ impl TestServer {
                 }
             }
             Message::Notification(notification) => {
-                tracing::debug!("Received notification {}", &notification.method);
+                tracing::debug!("Received notification `{}`", &notification.method);
                 self.notifications.push_back(notification);
             }
         }


### PR DESCRIPTION
## Summary

Improve the test server logging to get to the root cause of why `ty_server::e2e pull_diagnostics::on_did_open` flakes (it seems to take the dynamic registration path but it's unclear to me WHY?).

## Test Plan

```
2025-11-13 18:09:51.614252000 DEBUG Starting test client with capabilities ClientCapabilities {
    workspace: Some(
        WorkspaceClientCapabilities {
            apply_edit: None,
            workspace_edit: None,
            did_change_configuration: None,
            did_change_watched_files: None,
            symbol: None,
            execute_command: None,
            workspace_folders: None,
            configuration: Some(
                true,
            ),
            semantic_tokens: None,
            code_lens: None,
            file_operations: None,
            inline_value: None,
            inlay_hint: None,
            diagnostics: None,
        },
    ),
    text_document: Some(
        TextDocumentClientCapabilities {
            synchronization: None,
            completion: None,
            hover: None,
            signature_help: None,
            references: None,
            document_highlight: None,
            document_symbol: None,
            formatting: None,
            range_formatting: None,
            on_type_formatting: None,
            declaration: None,
            definition: None,
            type_definition: None,
            implementation: None,
            code_action: None,
            code_lens: None,
            document_link: None,
            color_provider: None,
            rename: None,
            publish_diagnostics: Some(
                PublishDiagnosticsClientCapabilities {
                    related_information: None,
                    tag_support: None,
                    version_support: None,
                    code_description_support: None,
                    data_support: None,
                },
            ),
            folding_range: None,
            selection_range: None,
            linked_editing_range: None,
            call_hierarchy: None,
            semantic_tokens: None,
            moniker: None,
            type_hierarchy: None,
            inline_value: None,
            inlay_hint: None,
            diagnostic: Some(
                DiagnosticClientCapabilities {
                    dynamic_registration: None,
                    related_document_support: None,
                },
            ),
            inline_completion: None,
        },
    ),
    notebook_document: None,
    window: None,
    general: None,
    offset_encoding: None,
    experimental: None,
}
2025-11-13 18:09:51.614536000 DEBUG Architecture: aarch64, OS: macos, case-sensitive: case-insensitive
2025-11-13 18:09:51.614655000 DEBUG Client sends request `initialize` with ID 1
2025-11-13 18:09:51.614964000 DEBUG Initialization options: InitializationOptions {
    log_level: None,
    log_file: None,
    options: ClientOptions {
        global: GlobalOptions {
            diagnostic_mode: None,
            experimental: None,
        },
        workspace: WorkspaceOptions {
            disable_language_services: None,
            inlay_hints: None,
            python_extension: None,
        },
        unknown: {},
    },
}
2025-11-13 18:09:51.615064000 DEBUG Resolved client capabilities: ["PULL_DIAGNOSTICS", "WORKSPACE_CONFIGURATION"]
2025-11-13 18:09:51.615123000  INFO Version: Unknown
2025-11-13 18:09:51.615214000 DEBUG Received server response for request 1
2025-11-13 18:09:51.615424000 DEBUG Client sends notification `initialized`
2025-11-13 18:09:51.615536000 DEBUG Requesting workspace configuration for workspaces
2025-11-13 18:09:51.615608000 DEBUG Received server request `workspace/configuration`
2025-11-13 18:09:51.615618000  INFO Retrying to receive `workspace/configuration` request
2025-11-13 18:09:51.615640000 DEBUG No workspace configuration provided for file:///private/var/folders/7s/n00zmc2d0qgchs1ns43xq47h0000gn/T/.tmpdi61VF/src
2025-11-13 18:09:51.615674000 DEBUG Client sends notification `textDocument/didOpen`
2025-11-13 18:09:51.615685000 DEBUG Client sends request `textDocument/diagnostic` with ID 2
2025-11-13 18:09:51.615762000 DEBUG client_response{id=0 method="workspace/configuration"}: Received workspace configurations, initializing workspaces
2025-11-13 18:09:51.615778000 DEBUG client_response{id=0 method="workspace/configuration"}: No workspace options provided for file:///private/var/folders/7s/n00zmc2d0qgchs1ns43xq47h0000gn/T/.tmpdi61VF/src, using default options
2025-11-13 18:09:51.615800000 DEBUG Deferring `textDocument/didOpen` notification until all workspaces are initialized
2025-11-13 18:09:51.615809000 DEBUG Initializing workspace `file:///private/var/folders/7s/n00zmc2d0qgchs1ns43xq47h0000gn/T/.tmpdi61VF/src`
2025-11-13 18:09:51.615857000 DEBUG Searching for a project in '/private/var/folders/7s/n00zmc2d0qgchs1ns43xq47h0000gn/T/.tmpdi61VF/src'
2025-11-13 18:09:51.615927000 DEBUG The ancestor directories contain no `pyproject.toml`. Falling back to a virtual project.
2025-11-13 18:09:51.615947000 DEBUG Searching for a user-level configuration at `/Users/micha/.config/ty/ty.toml`
2025-11-13 18:09:51.618682000  INFO Defaulting to python-platform `darwin`
2025-11-13 18:09:51.618712000 DEBUG Discovering virtual environment in `/private/var/folders/7s/n00zmc2d0qgchs1ns43xq47h0000gn/T/.tmpdi61VF/src`
2025-11-13 18:09:51.618799000 DEBUG Failed to discover ty's environment: Invalid ty environment `/Users/micha/astral/ruff/target/debug/deps/e2e-99930d2b8b0885b2`: does not point to a Python executable or a directory on disk
2025-11-13 18:09:51.618829000 DEBUG No virtual environment found
2025-11-13 18:09:51.618867000 DEBUG Including `.` in `environment.root`
2025-11-13 18:09:51.618914000 DEBUG Adding first-party search path `/private/var/folders/7s/n00zmc2d0qgchs1ns43xq47h0000gn/T/.tmpdi61VF/src`
2025-11-13 18:09:51.618933000 DEBUG Using vendored stdlib
2025-11-13 18:09:51.619642000  INFO Python version: Python 3.14, platform: darwin
2025-11-13 18:09:51.620239000 DEBUG Adding new file root '/private/var/folders/7s/n00zmc2d0qgchs1ns43xq47h0000gn/T/.tmpdi61VF/src' of kind Project
2025-11-13 18:09:51.620319000  WARN Your LSP client doesn't support file watching: You may see stale results when files change outside the editor
2025-11-13 18:09:51.620328000 DEBUG Processing deferred notification `textDocument/didOpen`
2025-11-13 18:09:51.628174000 DEBUG notification{method="textDocument/didOpen"}:apply_changes: Adding file `/private/var/folders/7s/n00zmc2d0qgchs1ns43xq47h0000gn/T/.tmpdi61VF/src/foo.py` to project `src`
2025-11-13 18:09:51.628209000 DEBUG notification{method="textDocument/didOpen"}: Opening file `/private/var/folders/7s/n00zmc2d0qgchs1ns43xq47h0000gn/T/.tmpdi61VF/src/foo.py`
2025-11-13 18:09:51.628219000 DEBUG notification{method="textDocument/didOpen"}: Take open project files
2025-11-13 18:09:51.628255000 DEBUG notification{method="textDocument/didOpen"}:set_open_files{open_files={file(Id(c00))}}: Set open project files (count: 1)
2025-11-13 18:09:51.628411000 DEBUG request{id=2 method="textDocument/diagnostic"}: source text: def foo() -> str:
    return 42

2025-11-13 18:09:51.631450000  INFO request{id=2 method="textDocument/diagnostic"}:check_file{file=file(Id(c00))}:Project::index_files{project=src}: Indexed 1 file(s) in 0.003s
2025-11-13 18:09:51.631640000 DEBUG request{id=2 method="textDocument/diagnostic"}:check_file{file=file(Id(c00))}: Checking file '/private/var/folders/7s/n00zmc2d0qgchs1ns43xq47h0000gn/T/.tmpdi61VF/src/foo.py'
2025-11-13 18:09:51.716922000 DEBUG Received server response for request 2
2025-11-13 18:09:51.754282000 DEBUG Client sends request `shutdown` with ID 3
2025-11-13 18:09:51.754405000 DEBUG request{id=3 method="shutdown"}: Received shutdown request, waiting for exit notification
2025-11-13 18:09:51.754460000 DEBUG Received server response for request 3
2025-11-13 18:09:51.754474000 DEBUG Client sends notification `exit`
2025-11-13 18:09:51.754491000 DEBUG Received exit notification, exiting
test pull_diagnostics::on_did_open ... ok
```
