### PR TITLE
[ty] fix panic with direct recursive type alias

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
@@ -244,6 +244,16 @@ def f(x: IntOr, y: OrInt):
         reveal_type(x)  # revealed: Never
     if not isinstance(y, int):
         reveal_type(y)  # revealed: Never
+
+# TODO emit a diagnostic on this line
+type Itself = Itself
+
+def foo(Itself: Itself):
+    x: Itself
+
+# A type alias defined with invalid recursion behaves as a dynamic type.
+foo(42)
+foo("hello")
 ```
 
 ### With legacy generic


### PR DESCRIPTION
## Summary

I found that trying to use a directly recursive type alias like this would result in a stack overflow:

```python
type Itself = Itself

def foo(Itself: Itself):
    x: Itself
```

This should be reported as an invalid type alias, but a stack overflow should be fixed immediately anyway. We now consider the value type to be `Unknown` in such cases.

## Test Plan

New test case in `mdtest\pep695_type_aliases.md`