### PR TITLE
[ty] Increase default receive timeout in tests to 10s

### DIFF
--- a/crates/ty_server/tests/e2e/main.rs
+++ b/crates/ty_server/tests/e2e/main.rs
@@ -502,9 +502,9 @@ impl TestServer {
     /// It will wait for `timeout` duration for a message to arrive. If no message is received
     /// within that time, it will return an error.
     ///
-    /// If `timeout` is `None`, it will use a default timeout of 1 second.
+    /// If `timeout` is `None`, it will use a default timeout of 10 second.
     fn receive(&mut self, timeout: Option<Duration>) -> Result<(), TestServerError> {
-        static DEFAULT_TIMEOUT: Duration = Duration::from_secs(1);
+        static DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
 
         let receiver = self.client_connection.as_ref().unwrap().receiver.clone();
         let message = receiver


### PR DESCRIPTION
## Summary

Increase the default timeout for `receive` to 10s because tests on CI can sometimes take a bit longer. 

A longer timeout shouldn't "hurt" as we only use receive in places where we expect a response, notification, or request. 
That means, we should only hit this timeout when the test is likely to error anyway. 

The main downside of this is that it now takes 10s for a test to fail when the message is missing indeed.


