### PR TITLE
[ty] Make `__getattr__` available for `ModuleType` instances

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/dunder_import.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/dunder_import.md
@@ -49,12 +49,9 @@ def _(flag: bool):
 a = reveal_type(__import__("a.b.c"))  # revealed: ModuleType
 
 # TODO: Should be `int`, `str`, `bytes`
-# error: [unresolved-attribute]
-reveal_type(a.a)  # revealed: Unknown
-# error: [unresolved-attribute]
-reveal_type(a.b.b)  # revealed: Unknown
-# error: [unresolved-attribute]
-reveal_type(a.b.c.c)  # revealed: Unknown
+reveal_type(a.a)  # revealed: Any
+reveal_type(a.b.b)  # revealed: Any
+reveal_type(a.b.c.c)  # revealed: Any
 ```
 
 `a/__init__.py`:

--- a/crates/ty_python_semantic/resources/mdtest/scopes/moduletype_attrs.md
+++ b/crates/ty_python_semantic/resources/mdtest/scopes/moduletype_attrs.md
@@ -120,6 +120,21 @@ we're dealing with:
 reveal_type(typing.__getattr__)  # revealed: Unknown
 ```
 
+However, if we have a `ModuleType` instance, we make `__getattr__` available. This means that
+arbitrary attribute accesses are allowed (with a result type of `Any`):
+
+```py
+import types
+
+reveal_type(types.ModuleType.__getattr__)  # revealed: def __getattr__(self, name: str) -> Any
+
+def f(module: types.ModuleType):
+    reveal_type(module.__getattr__)  # revealed: bound method ModuleType.__getattr__(name: str) -> Any
+
+    reveal_type(module.__all__)  # revealed: Any
+    reveal_type(module.whatever)  # revealed: Any
+```
+
 ## `types.ModuleType.__dict__` takes precedence over global variable `__dict__`
 
 It's impossible to override the `__dict__` attribute of `types.ModuleType` instances from inside the


### PR DESCRIPTION
## Summary

Typeshed has a (fake) `__getattr__` method on `types.ModuleType` with a return type of `Any`. We ignore this method when accessing attributes on module *literals*, but with this PR, we respect this method when dealing with `ModuleType` itself. That is, we allow arbitrary attribute accesses on instances of `types.ModuleType`. This is useful because dynamic import mechanisms such as `importlib.import_module` use `ModuleType` as a return type.

closes https://github.com/astral-sh/ty/issues/1346

## Ecosystem

Massive reduction in diagnostics. The few new diagnostics are true positives. 

## Test Plan

Added regression test.
