### PR TITLE
Limit `eglot-format` hook to eglot-managed Python buffers

### DIFF
--- a/docs/editors/setup.md
+++ b/docs/editors/setup.md
@@ -400,15 +400,13 @@ Ruff can be utilized as a language server via [`Eglot`](https://github.com/joaot
 To enable Ruff with automatic formatting on save, use the following configuration:
 
 ```elisp
-(add-hook 'python-mode-hook 'eglot-ensure)
 (with-eval-after-load 'eglot
   (add-to-list 'eglot-server-programs
-               '(python-mode . ("ruff" "server")))
-  (add-hook 'after-save-hook
-            (lambda ()
-              (when (and (derived-mode-p 'python-base-mode)
-                         (bound-and-true-p eglot--managed-mode))
-                (eglot-format-buffer)))))
+               '(python-base-mode . ("ruff" "server"))))
+(add-hook 'python-base-mode-hook
+          (lambda ()
+            (eglot-ensure)
+            (add-hook 'after-save-hook 'eglot-format nil t)))
 ```
 
 Ruff is available as [`flymake-ruff`](https://melpa.org/#/flymake-ruff) on MELPA:


### PR DESCRIPTION
Running `eglot-format` in buffers not managed by Eglot causes a `jsonrpc-error` in Emacs 30. It may also display a `documentFormattingProvider` warning when the server does not support formatting. Add checks for both.