### PR TITLE
Fix default test executable in py-fuzzer

### DIFF
--- a/python/py-fuzzer/fuzz.py
+++ b/python/py-fuzzer/fuzz.py
@@ -414,7 +414,7 @@ def parse_args() -> ResolvedCliArgs:
         except subprocess.CalledProcessError as e:
             print(e.stderr)
             raise
-        args.test_executable = Path("target", "release", executable)
+        args.test_executable = Path("target", "profiling", executable)
         assert args.test_executable.is_file()
 
     seed_arguments: list[range | int] = args.seeds


### PR DESCRIPTION
Summary
--

I was firing up the fuzzer tonight and hit an assertion error here. We now build with the `profiling` profile, so we need to use that executable too.

This hasn't affected CI because we always set the `--test-executable`.

Test Plan
--

Ran the script again with the same arguments on this branch